### PR TITLE
[fuchsia] Don't use sys.Environment in V2.

### DIFF
--- a/shell/platform/fuchsia/flutter/component_v1.cc
+++ b/shell/platform/fuchsia/flutter/component_v1.cc
@@ -548,7 +548,8 @@ void ComponentV1::CreateViewWithViewRef(
       },
       std::move(fdio_ns_),            // FDIO namespace
       std::move(directory_request_),  // outgoing request
-      product_config_                 // product configuration
+      product_config_,                // product configuration
+      true                            // v1 component
       ));
 }
 
@@ -571,7 +572,8 @@ void ComponentV1::CreateView2(fuchsia::ui::app::CreateView2Args view_args) {
       scenic::ViewRefPair::New(),                     // view ref pair
       std::move(fdio_ns_),                            // FDIO namespace
       std::move(directory_request_),                  // outgoing request
-      product_config_                                 // product configuration
+      product_config_,                                // product configuration
+      true                                            // v1 component
       ));
 }
 

--- a/shell/platform/fuchsia/flutter/component_v2.cc
+++ b/shell/platform/fuchsia/flutter/component_v2.cc
@@ -598,7 +598,8 @@ void ComponentV2::CreateViewWithViewRef(
       },
       std::move(fdio_ns_),            // FDIO namespace
       std::move(directory_request_),  // outgoing request
-      product_config_                 // product configuration
+      product_config_,                // product configuration
+      false                           // not a v1 component
       ));
 }
 
@@ -621,7 +622,8 @@ void ComponentV2::CreateView2(fuchsia::ui::app::CreateView2Args view_args) {
       scenic::ViewRefPair::New(),                     // view ref pair
       std::move(fdio_ns_),                            // FDIO namespace
       std::move(directory_request_),                  // outgoing request
-      product_config_                                 // product configuration
+      product_config_,                                // product configuration
+      false                                           // not a v1 component
       ));
 }
 

--- a/shell/platform/fuchsia/flutter/engine.cc
+++ b/shell/platform/fuchsia/flutter/engine.cc
@@ -70,7 +70,8 @@ Engine::Engine(Delegate& delegate,
                scenic::ViewRefPair view_ref_pair,
                UniqueFDIONS fdio_ns,
                fidl::InterfaceRequest<fuchsia::io::Directory> directory_request,
-               FlutterRunnerProductConfiguration product_config)
+               FlutterRunnerProductConfiguration product_config,
+               bool for_v1_component)
     : delegate_(delegate),
       thread_label_(std::move(thread_label)),
       thread_host_(CreateThreadHost(thread_label_)),
@@ -82,7 +83,7 @@ Engine::Engine(Delegate& delegate,
   Initialize(/*=use_flatland*/ false, std::move(view_ref_pair), std::move(svc),
              std::move(runner_services), std::move(settings),
              std::move(fdio_ns), std::move(directory_request),
-             std::move(product_config));
+             std::move(product_config), for_v1_component);
 }
 
 Engine::Engine(Delegate& delegate,
@@ -94,7 +95,8 @@ Engine::Engine(Delegate& delegate,
                scenic::ViewRefPair view_ref_pair,
                UniqueFDIONS fdio_ns,
                fidl::InterfaceRequest<fuchsia::io::Directory> directory_request,
-               FlutterRunnerProductConfiguration product_config)
+               FlutterRunnerProductConfiguration product_config,
+               bool for_v1_component)
     : delegate_(delegate),
       thread_label_(std::move(thread_label)),
       thread_host_(CreateThreadHost(thread_label_)),
@@ -106,7 +108,7 @@ Engine::Engine(Delegate& delegate,
   Initialize(/*=use_flatland*/ true, std::move(view_ref_pair), std::move(svc),
              std::move(runner_services), std::move(settings),
              std::move(fdio_ns), std::move(directory_request),
-             std::move(product_config));
+             std::move(product_config), for_v1_component);
 }
 
 void Engine::Initialize(
@@ -117,7 +119,8 @@ void Engine::Initialize(
     flutter::Settings settings,
     UniqueFDIONS fdio_ns,
     fidl::InterfaceRequest<fuchsia::io::Directory> directory_request,
-    FlutterRunnerProductConfiguration product_config) {
+    FlutterRunnerProductConfiguration product_config,
+    bool for_v1_component) {
   // Flatland uses |view_creation_token_| for linking. Gfx uses |view_token_|.
   FML_CHECK((use_flatland && view_creation_token_.value.is_valid()) ||
             (!use_flatland && view_token_.value.is_valid()));
@@ -529,14 +532,15 @@ void Engine::Initialize(
   // configurator.
   {
     fuchsia::sys::EnvironmentPtr environment;
-    svc->Connect(environment.NewRequest());
+    if (for_v1_component) {
+      svc->Connect(environment.NewRequest());
+    }
 
     isolate_configurator_ = std::make_unique<IsolateConfigurator>(
-        std::move(fdio_ns),                    //
-        std::move(environment),                //
-        directory_request.TakeChannel(),       //
-        std::move(isolate_view_ref.reference)  //
-    );
+        std::move(fdio_ns),
+        // v2 components do not use fuchsia.sys.Environment.
+        for_v1_component ? std::move(environment) : nullptr,
+        directory_request.TakeChannel(), std::move(isolate_view_ref.reference));
   }
 
   //  This platform does not get a separate surface platform view creation

--- a/shell/platform/fuchsia/flutter/engine.h
+++ b/shell/platform/fuchsia/flutter/engine.h
@@ -60,7 +60,8 @@ class Engine final : public fuchsia::memorypressure::Watcher {
          scenic::ViewRefPair view_ref_pair,
          UniqueFDIONS fdio_ns,
          fidl::InterfaceRequest<fuchsia::io::Directory> directory_request,
-         FlutterRunnerProductConfiguration product_config);
+         FlutterRunnerProductConfiguration product_config,
+         bool for_v1_component);
 
   // Flatland connection ctor.
   Engine(Delegate& delegate,
@@ -72,7 +73,8 @@ class Engine final : public fuchsia::memorypressure::Watcher {
          scenic::ViewRefPair view_ref_pair,
          UniqueFDIONS fdio_ns,
          fidl::InterfaceRequest<fuchsia::io::Directory> directory_request,
-         FlutterRunnerProductConfiguration product_config);
+         FlutterRunnerProductConfiguration product_config,
+         bool for_v1_component);
 
   ~Engine();
 
@@ -93,7 +95,8 @@ class Engine final : public fuchsia::memorypressure::Watcher {
       flutter::Settings settings,
       UniqueFDIONS fdio_ns,
       fidl::InterfaceRequest<fuchsia::io::Directory> directory_request,
-      FlutterRunnerProductConfiguration product_config);
+      FlutterRunnerProductConfiguration product_config,
+      bool for_v1_component);
 
   static void WarmupSkps(
       fml::BasicTaskRunner* concurrent_task_runner,


### PR DESCRIPTION
Bug: http://fxbug.dev/89048

The nullptr is handled here: https://github.com/flutter/engine/blob/main/shell/platform/fuchsia/dart-pkg/fuchsia/sdk_ext/fuchsia.cc#L121