### PR TITLE
Reset viewport_metrics when spawning new engine

### DIFF
--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -60,6 +60,7 @@ std::unique_ptr<RuntimeController> RuntimeController::Spawn(
                                           p_persistent_isolate_data,     //
                                           context_);                     //
   result->spawning_isolate_ = root_isolate_;
+  result->platform_data_.viewport_metrics = ViewportMetrics();
   return result;
 }
 


### PR DESCRIPTION
The `physical_width` and `physical_height` should be reset to 0 when spawn new Engine. Otherwise, flutter will use the wrong width and height for layout, and if the developer uses `SizeChangedLayoutNotifier`, the wrong width and height will be obtained before `onSizeChanged` is called.

* It fixes [94144](https://github.com/flutter/flutter/issues/94144)
* This is a continueation of this PR: https://github.com/flutter/engine/pull/28221


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

