### PR TITLE
Make fragment leftover from an attach/detach race slightly safer

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
@@ -784,7 +784,9 @@ public class FlutterFragment extends Fragment
   // possible.
   @ActivityCallThrough
   public void onPostResume() {
-    delegate.onPostResume();
+    if (stillAttachedForEvent("onPostResume")) {
+      delegate.onPostResume();
+    }
   }
 
   @Override

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
@@ -121,9 +121,11 @@ public class FlutterFragmentTest {
     fragment.setDelegate(mockDelegate);
     fragment.onStart();
     fragment.onResume();
+    fragment.onPostResume();
 
     verify(mockDelegate, times(1)).onStart();
     verify(mockDelegate, times(1)).onResume();
+    verify(mockDelegate, times(1)).onPostResume();
 
     fragment.onPause();
     fragment.detachFromFlutterEngine();

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
@@ -136,9 +136,11 @@ public class FlutterFragmentTest {
 
     fragment.onStart();
     fragment.onResume();
+    fragment.onPostResume();
     // No more events through to the delegate.
     verify(mockDelegate, times(1)).onStart();
     verify(mockDelegate, times(1)).onResume();
+    verify(mockDelegate, times(1)).onPostResume();
 
     fragment.onDestroy();
     // 1 time same as before.


### PR DESCRIPTION
fix https://github.com/flutter/flutter/issues/87526

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

