### PR TITLE
[WIP] keep ui and raster thread on fast CPUs, keep io thread on slow CPUs

### DIFF
--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -79,6 +79,8 @@ source_set("flutter_shell_native_src") {
     "android_surface_software.h",
     "apk_asset_provider.cc",
     "apk_asset_provider.h",
+    "cpuinfo.cc",
+    "cpuinfo.h",
     "flutter_main.cc",
     "flutter_main.h",
     "library_loader.cc",

--- a/shell/platform/android/cpuinfo.cc
+++ b/shell/platform/android/cpuinfo.cc
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define LOG_TAG "felixlog"
+
+#include "cpuinfo.h"
+
+#include <bitset>
+#include <cstdlib>
+#include <cstring>
+#include <limits>
+
+namespace {
+
+bool startsWith(std::string& mainStr, const char* toMatch) {
+  // std::string::find returns 0 if toMatch is found at beginning
+  return mainStr.find(toMatch) == 0;
+}
+
+std::vector<std::string> split(const std::string& s, char c) {
+  std::vector<std::string> v;
+  std::string::size_type i = 0;
+  std::string::size_type j = s.find(c);
+
+  while (j != std::string::npos) {
+    v.push_back(s.substr(i, j - i));
+    i = ++j;
+    j = s.find(c, j);
+
+    if (j == std::string::npos) {
+      v.push_back(s.substr(i, s.length()));
+    }
+  }
+  return v;
+}
+
+std::string ReadFile(const std::string& path) {
+  char buf[10240];
+  FILE* fp = fopen(path.c_str(), "r");
+  if (fp == nullptr)
+    return std::string();
+
+  fgets(buf, 10240, fp);
+  fclose(fp);
+  return std::string(buf);
+}
+
+}  // anonymous namespace
+
+namespace flutter {
+
+std::string to_string(int n) {
+    constexpr int kBufSize = 12;  // strlen("−2147483648")+1
+    static char buf[kBufSize];
+    snprintf(buf, kBufSize, "%d", n);
+    return buf;
+}
+
+CpuInfo::CpuInfo() {
+    const auto BUFFER_LENGTH = 10240;
+
+    char buf[BUFFER_LENGTH];
+    FILE *fp = fopen("/proc/cpuinfo", "r");
+
+    if (!fp) {
+        return;
+    }
+
+    long mMaxFrequency = 0;
+    long mMinFrequency = std::numeric_limits<long>::max();
+
+    while (fgets(buf, BUFFER_LENGTH, fp) != NULL) {
+        buf[strlen(buf) - 1] = '\0';  // eat the newline fgets() stores
+        std::string line = buf;
+
+        if (startsWith(line, "processor")) {
+            Cpu core;
+            core.id = mCpus.size();
+
+            auto core_path =
+                std::string("/sys/devices/system/cpu/cpu") + to_string(core.id);
+
+            auto frequency = ReadFile(core_path + "/cpufreq/cpuinfo_max_freq");
+
+            core.package_id = 1;
+            core.frequency = atol(frequency.c_str());
+
+            mMinFrequency = std::min(mMinFrequency, core.frequency);
+            mMaxFrequency = std::max(mMaxFrequency, core.frequency);
+
+            mCpus.push_back(core);
+        } else if (startsWith(line, "Hardware")) {
+            mHardware = split(line, ':')[1];
+        }
+    }
+    fclose(fp);
+
+    CPU_ZERO(&mLittleCoresMask);
+    CPU_ZERO(&mBigCoresMask);
+
+    for (auto cpu : mCpus) {
+        if (cpu.frequency == mMinFrequency) {
+            ++mNumberOfLittleCores;
+            cpu.type = Cpu::Type::Little;
+            CPU_SET(cpu.id, &mLittleCoresMask);
+        } else {
+            ++mNumberOfBigCores;
+            cpu.type = Cpu::Type::Big;
+            CPU_SET(cpu.id, &mBigCoresMask);
+        }
+    }
+}
+
+unsigned int CpuInfo::getNumberOfCpus() const { return mCpus.size(); }
+
+const std::vector<CpuInfo::Cpu> &CpuInfo::getCpus() const { return mCpus; }
+
+const std::string CpuInfo::getHardware() const { return mHardware; }
+
+unsigned int CpuInfo::getNumberOfLittleCores() const {
+    return mNumberOfLittleCores;
+}
+
+unsigned int CpuInfo::getNumberOfBigCores() const { return mNumberOfBigCores; }
+
+cpu_set_t CpuInfo::getLittleCoresMask() const { return mLittleCoresMask; }
+
+cpu_set_t CpuInfo::getBigCoresMask() const { return mBigCoresMask; }
+
+unsigned int to_mask(cpu_set_t cpu_set) {
+    std::bitset<32> mask;
+
+    for (int i = 0; i < CPU_SETSIZE; ++i) {
+        if (CPU_ISSET(i, &cpu_set)) mask[i] = 1;
+    }
+    return (int)mask.to_ulong();
+}
+
+}  // namespace flutter

--- a/shell/platform/android/cpuinfo.cc
+++ b/shell/platform/android/cpuinfo.cc
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#define LOG_TAG "felixlog"
-
 #include "cpuinfo.h"
 
 #include <bitset>

--- a/shell/platform/android/cpuinfo.h
+++ b/shell/platform/android/cpuinfo.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <sched.h>
+
+#include <map>
+#include <string>
+#include <vector>
+
+namespace flutter {
+
+class CpuInfo {
+ public:
+  struct Cpu {
+    enum class Type { Little, Big };
+
+    int id;
+    int package_id;
+    long frequency;
+
+    Type type;
+  };
+
+  CpuInfo();
+
+  unsigned int getNumberOfCpus() const;
+
+  const std::vector<Cpu>& getCpus() const;
+  const std::string getHardware() const;
+
+  unsigned int getNumberOfLittleCores() const;
+  unsigned int getNumberOfBigCores() const;
+
+  cpu_set_t getLittleCoresMask() const;
+  cpu_set_t getBigCoresMask() const;
+
+ private:
+  std::vector<Cpu> mCpus;
+  std::string mHardware;
+
+  unsigned int mNumberOfLittleCores = 0;
+  unsigned int mNumberOfBigCores = 0;
+
+  cpu_set_t mLittleCoresMask;
+  cpu_set_t mBigCoresMask;
+};
+
+unsigned int to_mask(cpu_set_t cpu_set);
+
+}  // namespace flutter


### PR DESCRIPTION
On many mobile devices, the L1 caches reside on specific CPUs, and L2 caches reside on the set of CPUs that share a clock. 
Keeping ui and raster thread on fast CPUs will help to maximize L2 cache hits and operate at faster speed.
There is a trade off to this as we will incur more power usage when running on fast CPUs.

See also: 
https://developer.android.com/games/optimize?hl=zh-tw#keep-mem-heavy-threads-one-cpu
https://developer.android.com/games/optimize?hl=zh-tw#defer-work-to-slow-cpus


Here's the flutter_gallery__transitions_perf benchmark report on a HUAWEI ELS AN00 phone

Before
```json
 "average_frame_build_time_millis": 6.579668269230771,
  "90th_percentile_frame_build_time_millis": 10.818,
  "99th_percentile_frame_build_time_millis": 23.7,
  "worst_frame_build_time_millis": 140.948,
  "missed_frame_build_budget_count": 9,
  "average_frame_rasterizer_time_millis": 16.873414457831323,
  "90th_percentile_frame_rasterizer_time_millis": 20.421,
  "99th_percentile_frame_rasterizer_time_millis": 53.492,
  "worst_frame_rasterizer_time_millis": 104.351,
  "missed_frame_rasterizer_budget_count": 181,
  "frame_count": 416,
  "frame_rasterizer_count": 415,

  "average_frame_build_time_millis": 6.523223277909746,
  "90th_percentile_frame_build_time_millis": 10.393,
  "99th_percentile_frame_build_time_millis": 33.673,
  "worst_frame_build_time_millis": 124.373,
  "missed_frame_build_budget_count": 10,
  "average_frame_rasterizer_time_millis": 16.824433333333342,
  "90th_percentile_frame_rasterizer_time_millis": 19.946,
  "99th_percentile_frame_rasterizer_time_millis": 52.629,
  "worst_frame_rasterizer_time_millis": 101.326,
  "missed_frame_rasterizer_budget_count": 177,
  "frame_count": 421,
  "frame_rasterizer_count": 420,
```

After
```json
 "average_frame_build_time_millis": 4.494899521531101,
  "90th_percentile_frame_build_time_millis": 8.089,
  "99th_percentile_frame_build_time_millis": 14.804,
  "worst_frame_build_time_millis": 107.017,
  "missed_frame_build_budget_count": 4,
  "average_frame_rasterizer_time_millis": 17.21504086538461,
  "90th_percentile_frame_rasterizer_time_millis": 21.238,
  "99th_percentile_frame_rasterizer_time_millis": 56.181,
  "worst_frame_rasterizer_time_millis": 87.671,
  "missed_frame_rasterizer_budget_count": 186,
  "frame_count": 418,
  "frame_rasterizer_count": 416,

  "average_frame_build_time_millis": 4.61509478672986,
  "90th_percentile_frame_build_time_millis": 8.691,
  "99th_percentile_frame_build_time_millis": 15.92,
  "worst_frame_build_time_millis": 123.315,
  "missed_frame_build_budget_count": 4,
  "average_frame_rasterizer_time_millis": 16.785314285714286,
  "90th_percentile_frame_rasterizer_time_millis": 20.222,
  "99th_percentile_frame_rasterizer_time_millis": 52.744,
  "worst_frame_rasterizer_time_millis": 101.359,
  "missed_frame_rasterizer_budget_count": 181,
  "frame_count": 422,
  "frame_rasterizer_count": 420,
```
We can see the obvious optimization of frame_build_time, but no  effect of frame_rasterizer_time.
I use [perfetto](https://ui.perfetto.dev/) to see which cpu the thread runs on, before the ui thread runs on slow cpus, and after it runs on  fast cpus.



