### PR TITLE
[ios platform view] fix overlay zPosition

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -457,8 +457,7 @@ SkRect FlutterPlatformViewsController::GetPlatformViewRect(int view_id) {
   return SkRect::MakeXYWH(platform_view_cgrect.origin.x * screen.scale,    //
                           platform_view_cgrect.origin.y * screen.scale,    //
                           platform_view_cgrect.size.width * screen.scale,  //
-                          platform_view_cgrect.size.height * screen.scale
-  );
+                          platform_view_cgrect.size.height * screen.scale);
 }
 
 bool FlutterPlatformViewsController::SubmitFrame(GrDirectContext* gr_context,
@@ -520,13 +519,11 @@ bool FlutterPlatformViewsController::SubmitFrame(GrDirectContext* gr_context,
       }
       for (SkRect& joined_rect : intersection_rects) {
         // Get the intersection rect between the current rect
-        // FML_DLOG(ERROR) << "top " << joined_rect.fTop;
         // and the platform view rect.
         joined_rect.intersect(platform_view_rect);
         // Subpixels in the platform may not align with the canvas subpixels.
         // To workaround it, round the floating point bounds and make the rect slightly larger.
         // For example, {0.3, 0.5, 3.1, 4.7} becomes {0, 0, 4, 5}.
-        // FML_DLOG(ERROR) << "joined_rect top " << std::floor(joined_rect.top());
         joined_rect.setLTRB(std::floor(joined_rect.left()), std::floor(joined_rect.top()),
                             std::ceil(joined_rect.right()), std::ceil(joined_rect.bottom()));
         // Clip the background canvas, so it doesn't contain any of the pixels drawn
@@ -567,11 +564,10 @@ bool FlutterPlatformViewsController::SubmitFrame(GrDirectContext* gr_context,
 void FlutterPlatformViewsController::BringLayersIntoView(LayersMap layer_map) {
   FML_DCHECK(flutter_view_);
   UIView* flutter_view = flutter_view_.get();
-  // The first platform view should be above the flutter view.
+  // The first platform view should be above the flutter view, so we start the zIndex with +1.
   auto zIndex = flutter_view.layer.zPosition + 1;
   // Clear the `active_composition_order_`, which will be populated down below.
   active_composition_order_.clear();
-  // FML_LOG(ERROR) << "223";
   for (size_t i = 0; i < composition_order_.size(); i++) {
     int64_t platform_view_id = composition_order_[i];
     std::vector<std::shared_ptr<FlutterPlatformViewLayer>> layers = layer_map[platform_view_id];
@@ -579,18 +575,16 @@ void FlutterPlatformViewsController::BringLayersIntoView(LayersMap layer_map) {
 
     if (platform_view_root.superview != flutter_view) {
       [flutter_view addSubview:platform_view_root];
-    } else {
-      platform_view_root.layer.zPosition = zIndex++;
     }
-    FML_DLOG(ERROR) << ">> platform view zindex   " << platform_view_root.layer.zPosition;
+    platform_view_root.layer.zPosition = zIndex++;
+
     for (const std::shared_ptr<FlutterPlatformViewLayer>& layer : layers) {
       if ([layer->overlay_view_wrapper superview] != flutter_view) {
         [flutter_view addSubview:layer->overlay_view_wrapper];
-      } else {
-        layer->overlay_view_wrapper.get().layer.zPosition = zIndex++;
       }
-      FML_DLOG(ERROR) << ">> overlay view zindex   " << layer->overlay_view_wrapper.get().layer.zPosition;
-      FML_DCHECK(layer->overlay_view_wrapper.get().layer.zPosition > platform_view_root.layer.zPosition);
+      layer->overlay_view_wrapper.get().layer.zPosition = zIndex++;
+      FML_DCHECK(layer->overlay_view_wrapper.get().layer.zPosition >
+                 platform_view_root.layer.zPosition);
     }
     active_composition_order_.push_back(platform_view_id);
   }
@@ -952,4 +946,3 @@ void FlutterPlatformViewsController::ResetFrameState() {
   return YES;
 }
 @end
-

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -565,9 +565,9 @@ bool FlutterPlatformViewsController::SubmitFrame(GrDirectContext* gr_context,
 void FlutterPlatformViewsController::BringLayersIntoView(LayersMap layer_map) {
   FML_DCHECK(flutter_view_);
   UIView* flutter_view = flutter_view_.get();
-  auto zIndex = 0
-                // Clear the `active_composition_order_`, which will be populated down below.
-                active_composition_order_.clear();
+  auto zIndex = 0;
+  // Clear the `active_composition_order_`, which will be populated down below.
+  active_composition_order_.clear();
   for (size_t i = 0; i < composition_order_.size(); i++) {
     int64_t platform_view_id = composition_order_[i];
     std::vector<std::shared_ptr<FlutterPlatformViewLayer>> layers = layer_map[platform_view_id];
@@ -576,12 +576,15 @@ void FlutterPlatformViewsController::BringLayersIntoView(LayersMap layer_map) {
     if (platform_view_root.superview != flutter_view) {
       [flutter_view addSubview:platform_view_root];
     }
+    // Make sure the platform_view_root is higher than the last platform_view_root in
+    // composition_order_.
     platform_view_root.layer.zPosition = zIndex++;
 
     for (const std::shared_ptr<FlutterPlatformViewLayer>& layer : layers) {
       if ([layer->overlay_view_wrapper.get() superview] != flutter_view) {
         [flutter_view addSubview:layer->overlay_view_wrapper];
       }
+      // Make sure all the overlays are higher than the platform view.
       layer->overlay_view_wrapper.get().layer.zPosition = zIndex++;
       FML_DCHECK(layer->overlay_view_wrapper.get().layer.zPosition >
                  platform_view_root.layer.zPosition);

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -565,10 +565,9 @@ bool FlutterPlatformViewsController::SubmitFrame(GrDirectContext* gr_context,
 void FlutterPlatformViewsController::BringLayersIntoView(LayersMap layer_map) {
   FML_DCHECK(flutter_view_);
   UIView* flutter_view = flutter_view_.get();
-  // The first platform view should be above the flutter view, so we start the zIndex with +1.
-  auto zIndex = flutter_view.layer.zPosition + 1;
-  // Clear the `active_composition_order_`, which will be populated down below.
-  active_composition_order_.clear();
+  auto zIndex = 0
+                // Clear the `active_composition_order_`, which will be populated down below.
+                active_composition_order_.clear();
   for (size_t i = 0; i < composition_order_.size(); i++) {
     int64_t platform_view_id = composition_order_[i];
     std::vector<std::shared_ptr<FlutterPlatformViewLayer>> layers = layer_map[platform_view_id];

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -457,7 +457,8 @@ SkRect FlutterPlatformViewsController::GetPlatformViewRect(int view_id) {
   return SkRect::MakeXYWH(platform_view_cgrect.origin.x * screen.scale,    //
                           platform_view_cgrect.origin.y * screen.scale,    //
                           platform_view_cgrect.size.width * screen.scale,  //
-                          platform_view_cgrect.size.height * screen.scale);
+                          platform_view_cgrect.size.height * screen.scale  //
+  );
 }
 
 bool FlutterPlatformViewsController::SubmitFrame(GrDirectContext* gr_context,
@@ -483,6 +484,7 @@ bool FlutterPlatformViewsController::SubmitFrame(GrDirectContext* gr_context,
 
   auto did_submit = true;
   auto num_platform_views = composition_order_.size();
+
   for (size_t i = 0; i < num_platform_views; i++) {
     int64_t platform_view_id = composition_order_[i];
     sk_sp<RTree> rtree = platform_view_rtrees_[platform_view_id];
@@ -490,7 +492,6 @@ bool FlutterPlatformViewsController::SubmitFrame(GrDirectContext* gr_context,
 
     // Check if the current picture contains overlays that intersect with the
     // current platform view or any of the previous platform views.
-
     for (size_t j = i + 1; j > 0; j--) {
       int64_t current_platform_view_id = composition_order_[j - 1];
       SkRect platform_view_rect = GetPlatformViewRect(current_platform_view_id);
@@ -611,8 +612,6 @@ std::shared_ptr<FlutterPlatformViewLayer> FlutterPlatformViewsController::GetLay
       [NSString stringWithFormat:@"platform_view[%lld].overlay[%lld]", view_id, overlay_id];
 
   UIView* overlay_view = layer->overlay_view.get();
-  // overlay_view_wrapper.backgroundColor = UIColor.blackColor;
-  // overlay_view.backgroundColor = UIColor.greenColor;
   // Set the size of the overlay view.
   // This size is equal to the device screen size.
   overlay_view.frame = flutter_view_.get().bounds;

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -580,7 +580,7 @@ void FlutterPlatformViewsController::BringLayersIntoView(LayersMap layer_map) {
     platform_view_root.layer.zPosition = zIndex++;
 
     for (const std::shared_ptr<FlutterPlatformViewLayer>& layer : layers) {
-      if ([layer->overlay_view_wrapper superview] != flutter_view) {
+      if ([layer->overlay_view_wrapper.get() superview] != flutter_view) {
         [flutter_view addSubview:layer->overlay_view_wrapper];
       }
       layer->overlay_view_wrapper.get().layer.zPosition = zIndex++;

--- a/testing/scenario_app/ios/Scenarios/Scenarios/AppDelegate.m
+++ b/testing/scenario_app/ios/Scenarios/Scenarios/AppDelegate.m
@@ -61,6 +61,7 @@
     @"--bogus-font-text" : @"bogus_font_text",
     @"--spawn-engine-works" : @"spawn_engine_works",
     @"--pointer-events" : @"pointer_events",
+    @"--platform-view-scrolling-under-widget" : @"platform_view_scrolling_under_widget"
   };
   __block NSString* flutterViewControllerTestName = nil;
   [launchArgsMap

--- a/testing/scenario_app/ios/Scenarios/ScenariosUITests/PlatformViewUITests.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosUITests/PlatformViewUITests.m
@@ -257,3 +257,35 @@ static const NSInteger kSecondsToWaitForPlatformView = 30;
 }
 
 @end
+
+@interface PlatformViewScrollingUnderWidget : XCTestCase
+
+@end
+
+@implementation PlatformViewScrollingUnderWidget
+
+- (void)setUp {
+  self.continueAfterFailure = NO;
+}
+
+- (void)testPlatformViewScrollingUnderWidget {
+  XCUIApplication* app = [[XCUIApplication alloc] init];
+  app.launchArguments =
+      @[ @"--platform-view-scrolling-under-widget", @"--with-continuous-texture" ];
+  [app launch];
+
+  XCUIElement* platformView = app.textViews.firstMatch;
+  BOOL exists = [platformView waitForExistenceWithTimeout:kSecondsToWaitForPlatformView];
+  if (!exists) {
+    XCTFail(@"It took longer than %@ second to find the platform view."
+            @"There might be issues with the platform view's construction,"
+            @"or with how the scenario is built.",
+            @(kSecondsToWaitForPlatformView));
+  }
+
+  // Wait and let the scenario app scroll a bit.
+  sleep(5);
+  XCTAssertNotNil(platformView);
+}
+
+@end

--- a/testing/scenario_app/ios/Scenarios/ScenariosUITests/PlatformViewUITests.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosUITests/PlatformViewUITests.m
@@ -265,6 +265,7 @@ static const NSInteger kSecondsToWaitForPlatformView = 30;
 @implementation PlatformViewScrollingUnderWidget
 
 - (void)setUp {
+  [super setUp];
   self.continueAfterFailure = NO;
 }
 
@@ -284,8 +285,12 @@ static const NSInteger kSecondsToWaitForPlatformView = 30;
   }
 
   // Wait and let the scenario app scroll a bit.
-  sleep(5);
-  XCTAssertNotNil(platformView);
+  XCTWaiterResult waitResult = [XCTWaiter
+      waitForExpectations:@[ [[XCTestExpectation alloc] initWithDescription:@"Wait for 5 seconds"] ]
+                  timeout:5];
+  // If the waiter is not interrupted, we know the app is in a valid state after timeout, thus the
+  // test passes.
+  XCTAssert(waitResult != XCTWaiterResultInterrupted);
 }
 
 @end

--- a/testing/scenario_app/lib/src/platform_view.dart
+++ b/testing/scenario_app/lib/src/platform_view.dart
@@ -28,11 +28,13 @@ List<int> _to64(num value) {
 }
 
 /// A simple platform view.
-class PlatformViewScenario extends Scenario with _BasePlatformViewScenarioMixin {
+class PlatformViewScenario extends Scenario
+    with _BasePlatformViewScenarioMixin {
   /// Creates the PlatformView scenario.
   ///
   /// The [dispatcher] parameter must not be null.
-  PlatformViewScenario(PlatformDispatcher dispatcher, String text, { required this.id })
+  PlatformViewScenario(PlatformDispatcher dispatcher, String text,
+      {required this.id})
       : assert(dispatcher != null),
         super(dispatcher) {
     createPlatformView(dispatcher, text, id);
@@ -75,11 +77,14 @@ class NonFullScreenFlutterViewPlatformViewScenario extends Scenario
 }
 
 /// A simple platform view with overlay that doesn't intersect with the platform view.
-class PlatformViewNoOverlayIntersectionScenario extends Scenario with _BasePlatformViewScenarioMixin {
+class PlatformViewNoOverlayIntersectionScenario extends Scenario
+    with _BasePlatformViewScenarioMixin {
   /// Creates the PlatformView scenario.
   ///
   /// The [dispatcher] parameter must not be null.
-  PlatformViewNoOverlayIntersectionScenario(PlatformDispatcher dispatcher, String text, { required this.id })
+  PlatformViewNoOverlayIntersectionScenario(
+      PlatformDispatcher dispatcher, String text,
+      {required this.id})
       : assert(dispatcher != null),
         super(dispatcher) {
     createPlatformView(dispatcher, text, id);
@@ -101,11 +106,14 @@ class PlatformViewNoOverlayIntersectionScenario extends Scenario with _BasePlatf
 }
 
 /// A simple platform view with an overlay that partially intersects with the platform view.
-class PlatformViewPartialIntersectionScenario extends Scenario with _BasePlatformViewScenarioMixin {
+class PlatformViewPartialIntersectionScenario extends Scenario
+    with _BasePlatformViewScenarioMixin {
   /// Creates the PlatformView scenario.
   ///
   /// The [dispatcher] parameter must not be null.
-  PlatformViewPartialIntersectionScenario(PlatformDispatcher dispatcher, String text, { required this.id })
+  PlatformViewPartialIntersectionScenario(
+      PlatformDispatcher dispatcher, String text,
+      {required this.id})
       : assert(dispatcher != null),
         super(dispatcher) {
     createPlatformView(dispatcher, text, id);
@@ -127,11 +135,14 @@ class PlatformViewPartialIntersectionScenario extends Scenario with _BasePlatfor
 }
 
 /// A simple platform view with two overlays that intersect with each other and the platform view.
-class PlatformViewTwoIntersectingOverlaysScenario extends Scenario with _BasePlatformViewScenarioMixin {
+class PlatformViewTwoIntersectingOverlaysScenario extends Scenario
+    with _BasePlatformViewScenarioMixin {
   /// Creates the PlatformView scenario.
   ///
   /// The [dispatcher] parameter must not be null.
-  PlatformViewTwoIntersectingOverlaysScenario(PlatformDispatcher dispatcher, String text, { required this.id })
+  PlatformViewTwoIntersectingOverlaysScenario(
+      PlatformDispatcher dispatcher, String text,
+      {required this.id})
       : assert(dispatcher != null),
         super(dispatcher) {
     createPlatformView(dispatcher, text, id);
@@ -166,11 +177,14 @@ class PlatformViewTwoIntersectingOverlaysScenario extends Scenario with _BasePla
 }
 
 /// A simple platform view with one overlay and two overlays that intersect with each other and the platform view.
-class PlatformViewOneOverlayTwoIntersectingOverlaysScenario extends Scenario with _BasePlatformViewScenarioMixin {
+class PlatformViewOneOverlayTwoIntersectingOverlaysScenario extends Scenario
+    with _BasePlatformViewScenarioMixin {
   /// Creates the PlatformView scenario.
   ///
   /// The [dispatcher] parameter must not be null.
-  PlatformViewOneOverlayTwoIntersectingOverlaysScenario(PlatformDispatcher dispatcher, String text, { required this.id })
+  PlatformViewOneOverlayTwoIntersectingOverlaysScenario(
+      PlatformDispatcher dispatcher, String text,
+      {required this.id})
       : assert(dispatcher != null),
         super(dispatcher) {
     createPlatformView(dispatcher, text, id);
@@ -210,11 +224,14 @@ class PlatformViewOneOverlayTwoIntersectingOverlaysScenario extends Scenario wit
 }
 
 /// Two platform views without an overlay intersecting either platform view.
-class MultiPlatformViewWithoutOverlaysScenario extends Scenario with _BasePlatformViewScenarioMixin {
+class MultiPlatformViewWithoutOverlaysScenario extends Scenario
+    with _BasePlatformViewScenarioMixin {
   /// Creates the PlatformView scenario.
   ///
   /// The [dispatcher] parameter must not be null.
-  MultiPlatformViewWithoutOverlaysScenario(PlatformDispatcher dispatcher, String text, { required this.firstId, required this.secondId })
+  MultiPlatformViewWithoutOverlaysScenario(
+      PlatformDispatcher dispatcher, String text,
+      {required this.firstId, required this.secondId})
       : assert(dispatcher != null),
         super(dispatcher) {
     createPlatformView(dispatcher, text, firstId);
@@ -254,11 +271,13 @@ class MultiPlatformViewWithoutOverlaysScenario extends Scenario with _BasePlatfo
 }
 
 /// A simple platform view with too many overlays result in a single native view.
-class PlatformViewMaxOverlaysScenario extends Scenario with _BasePlatformViewScenarioMixin {
+class PlatformViewMaxOverlaysScenario extends Scenario
+    with _BasePlatformViewScenarioMixin {
   /// Creates the PlatformView scenario.
   ///
   /// The [dispatcher] parameter must not be null.
-  PlatformViewMaxOverlaysScenario(PlatformDispatcher dispatcher, String text, { required this.id })
+  PlatformViewMaxOverlaysScenario(PlatformDispatcher dispatcher, String text,
+      {required this.id})
       : assert(dispatcher != null),
         super(dispatcher) {
     createPlatformView(dispatcher, text, id);
@@ -303,11 +322,13 @@ class PlatformViewMaxOverlaysScenario extends Scenario with _BasePlatformViewSce
 }
 
 /// Builds a scene with 2 platform views.
-class MultiPlatformViewScenario extends Scenario with _BasePlatformViewScenarioMixin {
+class MultiPlatformViewScenario extends Scenario
+    with _BasePlatformViewScenarioMixin {
   /// Creates the PlatformView scenario.
   ///
   /// The [dispatcher] parameter must not be null.
-  MultiPlatformViewScenario(PlatformDispatcher dispatcher, {required this.firstId, required this.secondId})
+  MultiPlatformViewScenario(PlatformDispatcher dispatcher,
+      {required this.firstId, required this.secondId})
       : assert(dispatcher != null),
         super(dispatcher) {
     createPlatformView(dispatcher, 'platform view 1', firstId);
@@ -337,11 +358,13 @@ class MultiPlatformViewScenario extends Scenario with _BasePlatformViewScenarioM
 /// Renders a frame with 2 platform views covered by a flutter drawn rectangle,
 /// when the app goes to the background and comes back to the foreground renders a new frame
 /// with the 2 platform views but without the flutter drawn rectangle.
-class MultiPlatformViewBackgroundForegroundScenario extends Scenario with _BasePlatformViewScenarioMixin {
+class MultiPlatformViewBackgroundForegroundScenario extends Scenario
+    with _BasePlatformViewScenarioMixin {
   /// Creates the PlatformView scenario.
   ///
   /// The [dispatcher] parameter must not be null.
-  MultiPlatformViewBackgroundForegroundScenario(PlatformDispatcher dispatcher, {required this.firstId, required this.secondId})
+  MultiPlatformViewBackgroundForegroundScenario(PlatformDispatcher dispatcher,
+      {required this.firstId, required this.secondId})
       : assert(dispatcher != null),
         super(dispatcher) {
     _nextFrame = _firstFrame;
@@ -405,15 +428,16 @@ class MultiPlatformViewBackgroundForegroundScenario extends Scenario with _BaseP
 
   @override
   void onPlatformMessage(
-      String name,
-      ByteData? data,
-      PlatformMessageResponseCallback? callback,
-      ) {
+    String name,
+    ByteData? data,
+    PlatformMessageResponseCallback? callback,
+  ) {
     if (name != 'flutter/lifecycle') {
       return;
     }
     final String message = utf8.decode(data!.buffer.asUint8List());
-    if (_lastLifecycleState == 'AppLifecycleState.inactive' && message == 'AppLifecycleState.resumed') {
+    if (_lastLifecycleState == 'AppLifecycleState.inactive' &&
+        message == 'AppLifecycleState.resumed') {
       _nextFrame = _secondFrame;
       window.scheduleFrame();
     }
@@ -423,9 +447,11 @@ class MultiPlatformViewBackgroundForegroundScenario extends Scenario with _BaseP
 }
 
 /// Platform view with clip rect.
-class PlatformViewClipRectScenario extends Scenario with _BasePlatformViewScenarioMixin {
+class PlatformViewClipRectScenario extends Scenario
+    with _BasePlatformViewScenarioMixin {
   /// Constructs a platform view with clip rect scenario.
-  PlatformViewClipRectScenario(PlatformDispatcher dispatcher, String text, { required this.id })
+  PlatformViewClipRectScenario(PlatformDispatcher dispatcher, String text,
+      {required this.id})
       : assert(dispatcher != null),
         super(dispatcher) {
     createPlatformView(dispatcher, text, id);
@@ -436,8 +462,7 @@ class PlatformViewClipRectScenario extends Scenario with _BasePlatformViewScenar
 
   @override
   void onBeginFrame(Duration duration) {
-    final SceneBuilder builder =
-      SceneBuilder()
+    final SceneBuilder builder = SceneBuilder()
       ..pushClipRect(const Rect.fromLTRB(100, 100, 400, 400));
 
     finishBuilderByAddingPlatformViewAndPicture(builder, id);
@@ -447,7 +472,8 @@ class PlatformViewClipRectScenario extends Scenario with _BasePlatformViewScenar
 /// Platform view with clip rrect.
 class PlatformViewClipRRectScenario extends PlatformViewScenario {
   /// Constructs a platform view with clip rrect scenario.
-  PlatformViewClipRRectScenario(PlatformDispatcher dispatcher, String text, { int id = 0 })
+  PlatformViewClipRRectScenario(PlatformDispatcher dispatcher, String text,
+      {int id = 0})
       : super(dispatcher, text, id: id);
 
   @override
@@ -471,7 +497,8 @@ class PlatformViewClipRRectScenario extends PlatformViewScenario {
 /// Platform view with clip path.
 class PlatformViewClipPathScenario extends PlatformViewScenario {
   /// Constructs a platform view with clip rrect scenario.
-  PlatformViewClipPathScenario(PlatformDispatcher dispatcher, String text, { int id = 0 })
+  PlatformViewClipPathScenario(PlatformDispatcher dispatcher, String text,
+      {int id = 0})
       : super(dispatcher, text, id: id);
 
   @override
@@ -491,7 +518,8 @@ class PlatformViewClipPathScenario extends PlatformViewScenario {
 /// Platform view with transform.
 class PlatformViewTransformScenario extends PlatformViewScenario {
   /// Constructs a platform view with transform scenario.
-  PlatformViewTransformScenario(PlatformDispatcher dispatcher, String text, { int id = 0 })
+  PlatformViewTransformScenario(PlatformDispatcher dispatcher, String text,
+      {int id = 0})
       : super(dispatcher, text, id: id);
 
   @override
@@ -510,7 +538,8 @@ class PlatformViewTransformScenario extends PlatformViewScenario {
 /// Platform view with opacity.
 class PlatformViewOpacityScenario extends PlatformViewScenario {
   /// Constructs a platform view with transform scenario.
-  PlatformViewOpacityScenario(PlatformDispatcher dispatcher, String text, { int id = 0 })
+  PlatformViewOpacityScenario(PlatformDispatcher dispatcher, String text,
+      {int id = 0})
       : super(dispatcher, text, id: id);
 
   @override
@@ -526,13 +555,15 @@ class PlatformViewForTouchIOSScenario extends Scenario
   /// Creates the PlatformView scenario.
   ///
   /// The [dispatcher] parameter must not be null.
-  PlatformViewForTouchIOSScenario(PlatformDispatcher dispatcher, String text, {int id = 0, required bool accept, bool rejectUntilTouchesEnded = false})
+  PlatformViewForTouchIOSScenario(PlatformDispatcher dispatcher, String text,
+      {int id = 0, required bool accept, bool rejectUntilTouchesEnded = false})
       : assert(dispatcher != null),
-       _accept = accept,
-      _viewId = id,
+        _accept = accept,
+        _viewId = id,
         super(dispatcher) {
     if (rejectUntilTouchesEnded) {
-      createPlatformView(dispatcher, text, id, viewType: 'scenarios/textPlatformView_blockPolicyUntilTouchesEnded');
+      createPlatformView(dispatcher, text, id,
+          viewType: 'scenarios/textPlatformView_blockPolicyUntilTouchesEnded');
     } else {
       createPlatformView(dispatcher, text, id);
     }
@@ -563,32 +594,31 @@ class PlatformViewForTouchIOSScenario extends Scenario
   @override
   void onPointerDataPacket(PointerDataPacket packet) {
     if (packet.data.first.change == PointerChange.add) {
-    String method = 'rejectGesture';
-    if (_accept) {
-      method = 'acceptGesture';
+      String method = 'rejectGesture';
+      if (_accept) {
+        method = 'acceptGesture';
+      }
+      const int _valueString = 7;
+      const int _valueInt32 = 3;
+      const int _valueMap = 13;
+      final Uint8List message = Uint8List.fromList(<int>[
+        _valueString,
+        method.length,
+        ...utf8.encode(method),
+        _valueMap,
+        1,
+        _valueString,
+        'id'.length,
+        ...utf8.encode('id'),
+        _valueInt32,
+        ..._to32(_viewId),
+      ]);
+      window.sendPlatformMessage(
+        'flutter/platform_views',
+        message.buffer.asByteData(),
+        (ByteData? response) {},
+      );
     }
-    const int _valueString = 7;
-    const int _valueInt32 = 3;
-    const int _valueMap = 13;
-    final Uint8List message = Uint8List.fromList(<int>[
-      _valueString,
-      method.length,
-      ...utf8.encode(method),
-      _valueMap,
-      1,
-      _valueString,
-      'id'.length,
-      ...utf8.encode('id'),
-      _valueInt32,
-      ..._to32(_viewId),
-    ]);
-    window.sendPlatformMessage(
-      'flutter/platform_views',
-      message.buffer.asByteData(),
-      (ByteData? response) {},
-    );
-    }
-
   }
 
   void _firstFrame() {
@@ -606,14 +636,16 @@ class PlatformViewForTouchIOSScenario extends Scenario
 /// For example, it simulates a video being played.
 class PlatformViewWithContinuousTexture extends PlatformViewScenario {
   /// Constructs a platform view with continuous texture layer.
-  PlatformViewWithContinuousTexture(PlatformDispatcher dispatcher, String text, { int id = 0 })
+  PlatformViewWithContinuousTexture(PlatformDispatcher dispatcher, String text,
+      {int id = 0})
       : super(dispatcher, text, id: id);
 
   @override
   void onBeginFrame(Duration duration) {
     final SceneBuilder builder = SceneBuilder();
 
-    builder.addTexture(0, width: 300, height: 300, offset: const Offset(200, 200));
+    builder.addTexture(0,
+        width: 300, height: 300, offset: const Offset(200, 200));
 
     finishBuilderByAddingPlatformViewAndPicture(builder, id);
   }
@@ -627,7 +659,9 @@ class PlatformViewWithContinuousTexture extends PlatformViewScenario {
 /// See: https://github.com/flutter/flutter/issues/80766
 class PlatformViewWithOtherBackDropFilter extends PlatformViewScenario {
   /// Constructs the scenario.
-  PlatformViewWithOtherBackDropFilter(PlatformDispatcher dispatcher, String text, { int id = 0 })
+  PlatformViewWithOtherBackDropFilter(
+      PlatformDispatcher dispatcher, String text,
+      {int id = 0})
       : super(dispatcher, text, id: id);
 
   @override
@@ -692,9 +726,11 @@ class PlatformViewWithOtherBackDropFilter extends PlatformViewScenario {
 /// The stack would look like: picture 1 -> pv1 -> picture 2 -> filter -> pv2 - > picture 3.
 /// Because backdrop filter on platform views has not been implemented(see: https://github.com/flutter/flutter/issues/43902),
 /// the result will not including a filtered pv1.
-class TwoPlatformViewsWithOtherBackDropFilter extends Scenario with _BasePlatformViewScenarioMixin {
+class TwoPlatformViewsWithOtherBackDropFilter extends Scenario
+    with _BasePlatformViewScenarioMixin {
   /// Constructs the scenario.
-  TwoPlatformViewsWithOtherBackDropFilter(PlatformDispatcher dispatcher, {required int firstId, required int secondId})
+  TwoPlatformViewsWithOtherBackDropFilter(PlatformDispatcher dispatcher,
+      {required int firstId, required int secondId})
       : _firstId = firstId,
         _secondId = secondId,
         super(dispatcher) {
@@ -765,61 +801,60 @@ class TwoPlatformViewsWithOtherBackDropFilter extends Scenario with _BasePlatfor
   }
 }
 
-/// Builds a scenario where many platform views are scrolling and pass under a widget
-class PlatformViewScrollingUnderWidget extends Scenario with _BasePlatformViewScenarioMixin {
+/// Builds a scenario where many platform views are scrolling and pass under a picture.
+class PlatformViewScrollingUnderWidget extends Scenario
+    with _BasePlatformViewScenarioMixin {
   /// Creates the PlatformView scenario.
   ///
   /// The [dispatcher] parameter must not be null.
-  PlatformViewScrollingUnderWidget(PlatformDispatcher dispatcher, {required this.minId, required this.maxId})
-      : assert(dispatcher != null),
+  PlatformViewScrollingUnderWidget(PlatformDispatcher dispatcher,
+      {required int firstPlatformViewId, required int lastPlatformViewId})
+      : _firstPlatformViewId = firstPlatformViewId,
+        _lastPlatformViewId = lastPlatformViewId,
+        assert(dispatcher != null),
         super(dispatcher) {
-    for (int i = minId; i < maxId+1; i ++) {
+    for (int i = _firstPlatformViewId; i <= _lastPlatformViewId; i++) {
       createPlatformView(dispatcher, 'platform view', i);
     }
   }
 
-  /// The platform view identifier to use for the first platform view.
-  final int minId;
+  final int _firstPlatformViewId;
 
-  /// The platform view identifier to use for the last platform view.
-  final int maxId;
+  final int _lastPlatformViewId;
 
-  double offset = 0;
+  double _offset = 0;
 
-  bool movingUp = true;
+  bool _movingUp = true;
 
   @override
   void onBeginFrame(Duration duration) {
-    _buildOneFrame(offset);
+    _buildOneFrame(_offset);
   }
 
   @override
   void onDrawFrame() {
-
     // Scroll up until -1000, then scroll down until -1.
-    if (offset < -1000) {
-      movingUp = false;
-    } else if (offset > -1) {
-      movingUp = true;
+    if (_offset < -1000) {
+      _movingUp = false;
+    } else if (_offset > -1) {
+      _movingUp = true;
     }
 
-    if (movingUp) {
-      offset -= 100;
+    if (_movingUp) {
+      _offset -= 100;
     } else {
-      offset += 100;
+      _offset += 100;
     }
     window.scheduleFrame();
     super.onDrawFrame();
   }
 
-
   void _buildOneFrame(double offset) {
     const double cellWidth = 1000;
-    print(offset);
     double localOffset = offset;
     final SceneBuilder builder = SceneBuilder();
     const double cellHeight = 300;
-    for (int i = minId; i < maxId+1; i ++) {
+    for (int i = _firstPlatformViewId; i <= _lastPlatformViewId; i++) {
       // Build a list view with platform views.
       builder.pushOffset(0, localOffset);
       _addPlatformViewToScene(builder, i, cellWidth, cellHeight);
@@ -855,7 +890,8 @@ mixin _BasePlatformViewScenarioMixin on Scenario {
   /// It prepare a TextPlatformView so it can be added to the SceneBuilder in `onBeginFrame`.
   /// Call this method in the constructor of the platform view related scenarios
   /// to perform necessary set up.
-  void createPlatformView(PlatformDispatcher dispatcher, String text, int id, {String viewType = 'scenarios/textPlatformView'}) {
+  void createPlatformView(PlatformDispatcher dispatcher, String text, int id,
+      {String viewType = 'scenarios/textPlatformView'}) {
     const int _valueTrue = 1;
     const int _valueInt32 = 3;
     const int _valueFloat64 = 6;
@@ -868,8 +904,7 @@ mixin _BasePlatformViewScenarioMixin on Scenario {
       'create'.length, // this won't work if we use multi-byte characters.
       ...utf8.encode('create'),
       _valueMap,
-      if (Platform.isIOS)
-        3, // 3 entries in map for iOS.
+      if (Platform.isIOS) 3, // 3 entries in map for iOS.
       if (Platform.isAndroid && !usesAndroidHybridComposition)
         6, // 6 entries in map for virtual displays on Android.
       if (Platform.isAndroid && usesAndroidHybridComposition)
@@ -925,7 +960,9 @@ mixin _BasePlatformViewScenarioMixin on Scenario {
       'flutter/platform_views',
       message.buffer.asByteData(),
       (ByteData? response) {
-        if (response != null && Platform.isAndroid && !usesAndroidHybridComposition) {
+        if (response != null &&
+            Platform.isAndroid &&
+            !usesAndroidHybridComposition) {
           // Envelope.
           _textureId = response.getUint8(0);
         }
@@ -948,7 +985,8 @@ mixin _BasePlatformViewScenarioMixin on Scenario {
         sceneBuilder.addTexture(_textureId!, width: width, height: height);
       }
     } else {
-      throw UnsupportedError('Platform ${Platform.operatingSystem} is not supported');
+      throw UnsupportedError(
+          'Platform ${Platform.operatingSystem} is not supported');
     }
   }
 

--- a/testing/scenario_app/lib/src/platform_view.dart
+++ b/testing/scenario_app/lib/src/platform_view.dart
@@ -28,13 +28,11 @@ List<int> _to64(num value) {
 }
 
 /// A simple platform view.
-class PlatformViewScenario extends Scenario
-    with _BasePlatformViewScenarioMixin {
+class PlatformViewScenario extends Scenario with _BasePlatformViewScenarioMixin {
   /// Creates the PlatformView scenario.
   ///
   /// The [dispatcher] parameter must not be null.
-  PlatformViewScenario(PlatformDispatcher dispatcher, String text,
-      {required this.id})
+  PlatformViewScenario(PlatformDispatcher dispatcher, String text, {required this.id})
       : assert(dispatcher != null),
         super(dispatcher) {
     createPlatformView(dispatcher, text, id);
@@ -52,14 +50,11 @@ class PlatformViewScenario extends Scenario
 }
 
 /// A simple platform view.
-class NonFullScreenFlutterViewPlatformViewScenario extends Scenario
-    with _BasePlatformViewScenarioMixin {
+class NonFullScreenFlutterViewPlatformViewScenario extends Scenario with _BasePlatformViewScenarioMixin {
   /// Creates the PlatformView scenario.
   ///
   /// The [dispatcher] parameter must not be null.
-  NonFullScreenFlutterViewPlatformViewScenario(
-      PlatformDispatcher dispatcher, String text,
-      {required this.id})
+  NonFullScreenFlutterViewPlatformViewScenario(PlatformDispatcher dispatcher, String text, {required this.id})
       : assert(dispatcher != null),
         super(dispatcher) {
     createPlatformView(dispatcher, text, id);
@@ -77,14 +72,11 @@ class NonFullScreenFlutterViewPlatformViewScenario extends Scenario
 }
 
 /// A simple platform view with overlay that doesn't intersect with the platform view.
-class PlatformViewNoOverlayIntersectionScenario extends Scenario
-    with _BasePlatformViewScenarioMixin {
+class PlatformViewNoOverlayIntersectionScenario extends Scenario with _BasePlatformViewScenarioMixin {
   /// Creates the PlatformView scenario.
   ///
   /// The [dispatcher] parameter must not be null.
-  PlatformViewNoOverlayIntersectionScenario(
-      PlatformDispatcher dispatcher, String text,
-      {required this.id})
+  PlatformViewNoOverlayIntersectionScenario(PlatformDispatcher dispatcher, String text, {required this.id})
       : assert(dispatcher != null),
         super(dispatcher) {
     createPlatformView(dispatcher, text, id);
@@ -106,14 +98,11 @@ class PlatformViewNoOverlayIntersectionScenario extends Scenario
 }
 
 /// A simple platform view with an overlay that partially intersects with the platform view.
-class PlatformViewPartialIntersectionScenario extends Scenario
-    with _BasePlatformViewScenarioMixin {
+class PlatformViewPartialIntersectionScenario extends Scenario with _BasePlatformViewScenarioMixin {
   /// Creates the PlatformView scenario.
   ///
   /// The [dispatcher] parameter must not be null.
-  PlatformViewPartialIntersectionScenario(
-      PlatformDispatcher dispatcher, String text,
-      {required this.id})
+  PlatformViewPartialIntersectionScenario(PlatformDispatcher dispatcher, String text, {required this.id})
       : assert(dispatcher != null),
         super(dispatcher) {
     createPlatformView(dispatcher, text, id);
@@ -135,14 +124,11 @@ class PlatformViewPartialIntersectionScenario extends Scenario
 }
 
 /// A simple platform view with two overlays that intersect with each other and the platform view.
-class PlatformViewTwoIntersectingOverlaysScenario extends Scenario
-    with _BasePlatformViewScenarioMixin {
+class PlatformViewTwoIntersectingOverlaysScenario extends Scenario with _BasePlatformViewScenarioMixin {
   /// Creates the PlatformView scenario.
   ///
   /// The [dispatcher] parameter must not be null.
-  PlatformViewTwoIntersectingOverlaysScenario(
-      PlatformDispatcher dispatcher, String text,
-      {required this.id})
+  PlatformViewTwoIntersectingOverlaysScenario(PlatformDispatcher dispatcher, String text, {required this.id})
       : assert(dispatcher != null),
         super(dispatcher) {
     createPlatformView(dispatcher, text, id);
@@ -177,14 +163,11 @@ class PlatformViewTwoIntersectingOverlaysScenario extends Scenario
 }
 
 /// A simple platform view with one overlay and two overlays that intersect with each other and the platform view.
-class PlatformViewOneOverlayTwoIntersectingOverlaysScenario extends Scenario
-    with _BasePlatformViewScenarioMixin {
+class PlatformViewOneOverlayTwoIntersectingOverlaysScenario extends Scenario with _BasePlatformViewScenarioMixin {
   /// Creates the PlatformView scenario.
   ///
   /// The [dispatcher] parameter must not be null.
-  PlatformViewOneOverlayTwoIntersectingOverlaysScenario(
-      PlatformDispatcher dispatcher, String text,
-      {required this.id})
+  PlatformViewOneOverlayTwoIntersectingOverlaysScenario(PlatformDispatcher dispatcher, String text, {required this.id})
       : assert(dispatcher != null),
         super(dispatcher) {
     createPlatformView(dispatcher, text, id);
@@ -224,13 +207,11 @@ class PlatformViewOneOverlayTwoIntersectingOverlaysScenario extends Scenario
 }
 
 /// Two platform views without an overlay intersecting either platform view.
-class MultiPlatformViewWithoutOverlaysScenario extends Scenario
-    with _BasePlatformViewScenarioMixin {
+class MultiPlatformViewWithoutOverlaysScenario extends Scenario with _BasePlatformViewScenarioMixin {
   /// Creates the PlatformView scenario.
   ///
   /// The [dispatcher] parameter must not be null.
-  MultiPlatformViewWithoutOverlaysScenario(
-      PlatformDispatcher dispatcher, String text,
+  MultiPlatformViewWithoutOverlaysScenario(PlatformDispatcher dispatcher, String text,
       {required this.firstId, required this.secondId})
       : assert(dispatcher != null),
         super(dispatcher) {
@@ -271,13 +252,11 @@ class MultiPlatformViewWithoutOverlaysScenario extends Scenario
 }
 
 /// A simple platform view with too many overlays result in a single native view.
-class PlatformViewMaxOverlaysScenario extends Scenario
-    with _BasePlatformViewScenarioMixin {
+class PlatformViewMaxOverlaysScenario extends Scenario with _BasePlatformViewScenarioMixin {
   /// Creates the PlatformView scenario.
   ///
   /// The [dispatcher] parameter must not be null.
-  PlatformViewMaxOverlaysScenario(PlatformDispatcher dispatcher, String text,
-      {required this.id})
+  PlatformViewMaxOverlaysScenario(PlatformDispatcher dispatcher, String text, {required this.id})
       : assert(dispatcher != null),
         super(dispatcher) {
     createPlatformView(dispatcher, text, id);
@@ -322,13 +301,11 @@ class PlatformViewMaxOverlaysScenario extends Scenario
 }
 
 /// Builds a scene with 2 platform views.
-class MultiPlatformViewScenario extends Scenario
-    with _BasePlatformViewScenarioMixin {
+class MultiPlatformViewScenario extends Scenario with _BasePlatformViewScenarioMixin {
   /// Creates the PlatformView scenario.
   ///
   /// The [dispatcher] parameter must not be null.
-  MultiPlatformViewScenario(PlatformDispatcher dispatcher,
-      {required this.firstId, required this.secondId})
+  MultiPlatformViewScenario(PlatformDispatcher dispatcher, {required this.firstId, required this.secondId})
       : assert(dispatcher != null),
         super(dispatcher) {
     createPlatformView(dispatcher, 'platform view 1', firstId);
@@ -358,8 +335,7 @@ class MultiPlatformViewScenario extends Scenario
 /// Renders a frame with 2 platform views covered by a flutter drawn rectangle,
 /// when the app goes to the background and comes back to the foreground renders a new frame
 /// with the 2 platform views but without the flutter drawn rectangle.
-class MultiPlatformViewBackgroundForegroundScenario extends Scenario
-    with _BasePlatformViewScenarioMixin {
+class MultiPlatformViewBackgroundForegroundScenario extends Scenario with _BasePlatformViewScenarioMixin {
   /// Creates the PlatformView scenario.
   ///
   /// The [dispatcher] parameter must not be null.
@@ -436,8 +412,7 @@ class MultiPlatformViewBackgroundForegroundScenario extends Scenario
       return;
     }
     final String message = utf8.decode(data!.buffer.asUint8List());
-    if (_lastLifecycleState == 'AppLifecycleState.inactive' &&
-        message == 'AppLifecycleState.resumed') {
+    if (_lastLifecycleState == 'AppLifecycleState.inactive' && message == 'AppLifecycleState.resumed') {
       _nextFrame = _secondFrame;
       window.scheduleFrame();
     }
@@ -447,11 +422,9 @@ class MultiPlatformViewBackgroundForegroundScenario extends Scenario
 }
 
 /// Platform view with clip rect.
-class PlatformViewClipRectScenario extends Scenario
-    with _BasePlatformViewScenarioMixin {
+class PlatformViewClipRectScenario extends Scenario with _BasePlatformViewScenarioMixin {
   /// Constructs a platform view with clip rect scenario.
-  PlatformViewClipRectScenario(PlatformDispatcher dispatcher, String text,
-      {required this.id})
+  PlatformViewClipRectScenario(PlatformDispatcher dispatcher, String text, {required this.id})
       : assert(dispatcher != null),
         super(dispatcher) {
     createPlatformView(dispatcher, text, id);
@@ -462,8 +435,7 @@ class PlatformViewClipRectScenario extends Scenario
 
   @override
   void onBeginFrame(Duration duration) {
-    final SceneBuilder builder = SceneBuilder()
-      ..pushClipRect(const Rect.fromLTRB(100, 100, 400, 400));
+    final SceneBuilder builder = SceneBuilder()..pushClipRect(const Rect.fromLTRB(100, 100, 400, 400));
 
     finishBuilderByAddingPlatformViewAndPicture(builder, id);
   }
@@ -472,8 +444,7 @@ class PlatformViewClipRectScenario extends Scenario
 /// Platform view with clip rrect.
 class PlatformViewClipRRectScenario extends PlatformViewScenario {
   /// Constructs a platform view with clip rrect scenario.
-  PlatformViewClipRRectScenario(PlatformDispatcher dispatcher, String text,
-      {int id = 0})
+  PlatformViewClipRRectScenario(PlatformDispatcher dispatcher, String text, {int id = 0})
       : super(dispatcher, text, id: id);
 
   @override
@@ -497,8 +468,7 @@ class PlatformViewClipRRectScenario extends PlatformViewScenario {
 /// Platform view with clip path.
 class PlatformViewClipPathScenario extends PlatformViewScenario {
   /// Constructs a platform view with clip rrect scenario.
-  PlatformViewClipPathScenario(PlatformDispatcher dispatcher, String text,
-      {int id = 0})
+  PlatformViewClipPathScenario(PlatformDispatcher dispatcher, String text, {int id = 0})
       : super(dispatcher, text, id: id);
 
   @override
@@ -518,8 +488,7 @@ class PlatformViewClipPathScenario extends PlatformViewScenario {
 /// Platform view with transform.
 class PlatformViewTransformScenario extends PlatformViewScenario {
   /// Constructs a platform view with transform scenario.
-  PlatformViewTransformScenario(PlatformDispatcher dispatcher, String text,
-      {int id = 0})
+  PlatformViewTransformScenario(PlatformDispatcher dispatcher, String text, {int id = 0})
       : super(dispatcher, text, id: id);
 
   @override
@@ -538,8 +507,7 @@ class PlatformViewTransformScenario extends PlatformViewScenario {
 /// Platform view with opacity.
 class PlatformViewOpacityScenario extends PlatformViewScenario {
   /// Constructs a platform view with transform scenario.
-  PlatformViewOpacityScenario(PlatformDispatcher dispatcher, String text,
-      {int id = 0})
+  PlatformViewOpacityScenario(PlatformDispatcher dispatcher, String text, {int id = 0})
       : super(dispatcher, text, id: id);
 
   @override
@@ -550,8 +518,7 @@ class PlatformViewOpacityScenario extends PlatformViewScenario {
 }
 
 /// A simple platform view for testing touch events from iOS.
-class PlatformViewForTouchIOSScenario extends Scenario
-    with _BasePlatformViewScenarioMixin {
+class PlatformViewForTouchIOSScenario extends Scenario with _BasePlatformViewScenarioMixin {
   /// Creates the PlatformView scenario.
   ///
   /// The [dispatcher] parameter must not be null.
@@ -562,8 +529,7 @@ class PlatformViewForTouchIOSScenario extends Scenario
         _viewId = id,
         super(dispatcher) {
     if (rejectUntilTouchesEnded) {
-      createPlatformView(dispatcher, text, id,
-          viewType: 'scenarios/textPlatformView_blockPolicyUntilTouchesEnded');
+      createPlatformView(dispatcher, text, id, viewType: 'scenarios/textPlatformView_blockPolicyUntilTouchesEnded');
     } else {
       createPlatformView(dispatcher, text, id);
     }
@@ -636,16 +602,14 @@ class PlatformViewForTouchIOSScenario extends Scenario
 /// For example, it simulates a video being played.
 class PlatformViewWithContinuousTexture extends PlatformViewScenario {
   /// Constructs a platform view with continuous texture layer.
-  PlatformViewWithContinuousTexture(PlatformDispatcher dispatcher, String text,
-      {int id = 0})
+  PlatformViewWithContinuousTexture(PlatformDispatcher dispatcher, String text, {int id = 0})
       : super(dispatcher, text, id: id);
 
   @override
   void onBeginFrame(Duration duration) {
     final SceneBuilder builder = SceneBuilder();
 
-    builder.addTexture(0,
-        width: 300, height: 300, offset: const Offset(200, 200));
+    builder.addTexture(0, width: 300, height: 300, offset: const Offset(200, 200));
 
     finishBuilderByAddingPlatformViewAndPicture(builder, id);
   }
@@ -659,9 +623,7 @@ class PlatformViewWithContinuousTexture extends PlatformViewScenario {
 /// See: https://github.com/flutter/flutter/issues/80766
 class PlatformViewWithOtherBackDropFilter extends PlatformViewScenario {
   /// Constructs the scenario.
-  PlatformViewWithOtherBackDropFilter(
-      PlatformDispatcher dispatcher, String text,
-      {int id = 0})
+  PlatformViewWithOtherBackDropFilter(PlatformDispatcher dispatcher, String text, {int id = 0})
       : super(dispatcher, text, id: id);
 
   @override
@@ -726,11 +688,9 @@ class PlatformViewWithOtherBackDropFilter extends PlatformViewScenario {
 /// The stack would look like: picture 1 -> pv1 -> picture 2 -> filter -> pv2 - > picture 3.
 /// Because backdrop filter on platform views has not been implemented(see: https://github.com/flutter/flutter/issues/43902),
 /// the result will not including a filtered pv1.
-class TwoPlatformViewsWithOtherBackDropFilter extends Scenario
-    with _BasePlatformViewScenarioMixin {
+class TwoPlatformViewsWithOtherBackDropFilter extends Scenario with _BasePlatformViewScenarioMixin {
   /// Constructs the scenario.
-  TwoPlatformViewsWithOtherBackDropFilter(PlatformDispatcher dispatcher,
-      {required int firstId, required int secondId})
+  TwoPlatformViewsWithOtherBackDropFilter(PlatformDispatcher dispatcher, {required int firstId, required int secondId})
       : _firstId = firstId,
         _secondId = secondId,
         super(dispatcher) {
@@ -802,8 +762,7 @@ class TwoPlatformViewsWithOtherBackDropFilter extends Scenario
 }
 
 /// Builds a scenario where many platform views are scrolling and pass under a picture.
-class PlatformViewScrollingUnderWidget extends Scenario
-    with _BasePlatformViewScenarioMixin {
+class PlatformViewScrollingUnderWidget extends Scenario with _BasePlatformViewScenarioMixin {
   /// Creates the PlatformView scenario.
   ///
   /// The [dispatcher] parameter must not be null.
@@ -905,10 +864,8 @@ mixin _BasePlatformViewScenarioMixin on Scenario {
       ...utf8.encode('create'),
       _valueMap,
       if (Platform.isIOS) 3, // 3 entries in map for iOS.
-      if (Platform.isAndroid && !usesAndroidHybridComposition)
-        6, // 6 entries in map for virtual displays on Android.
-      if (Platform.isAndroid && usesAndroidHybridComposition)
-        5, // 5 entries in map for Android views.
+      if (Platform.isAndroid && !usesAndroidHybridComposition) 6, // 6 entries in map for virtual displays on Android.
+      if (Platform.isAndroid && usesAndroidHybridComposition) 5, // 5 entries in map for Android views.
       _valueString,
       'id'.length,
       ...utf8.encode('id'),
@@ -960,9 +917,7 @@ mixin _BasePlatformViewScenarioMixin on Scenario {
       'flutter/platform_views',
       message.buffer.asByteData(),
       (ByteData? response) {
-        if (response != null &&
-            Platform.isAndroid &&
-            !usesAndroidHybridComposition) {
+        if (response != null && Platform.isAndroid && !usesAndroidHybridComposition) {
           // Envelope.
           _textureId = response.getUint8(0);
         }
@@ -985,8 +940,7 @@ mixin _BasePlatformViewScenarioMixin on Scenario {
         sceneBuilder.addTexture(_textureId!, width: width, height: height);
       }
     } else {
-      throw UnsupportedError(
-          'Platform ${Platform.operatingSystem} is not supported');
+      throw UnsupportedError('Platform ${Platform.operatingSystem} is not supported');
     }
   }
 

--- a/testing/scenario_app/lib/src/platform_view.dart
+++ b/testing/scenario_app/lib/src/platform_view.dart
@@ -28,11 +28,13 @@ List<int> _to64(num value) {
 }
 
 /// A simple platform view.
-class PlatformViewScenario extends Scenario with _BasePlatformViewScenarioMixin {
+class PlatformViewScenario extends Scenario
+    with _BasePlatformViewScenarioMixin {
   /// Creates the PlatformView scenario.
   ///
   /// The [dispatcher] parameter must not be null.
-  PlatformViewScenario(PlatformDispatcher dispatcher, String text, {required this.id})
+  PlatformViewScenario(PlatformDispatcher dispatcher, String text,
+      {required this.id})
       : assert(dispatcher != null),
         super(dispatcher) {
     createPlatformView(dispatcher, text, id);
@@ -50,11 +52,14 @@ class PlatformViewScenario extends Scenario with _BasePlatformViewScenarioMixin 
 }
 
 /// A simple platform view.
-class NonFullScreenFlutterViewPlatformViewScenario extends Scenario with _BasePlatformViewScenarioMixin {
+class NonFullScreenFlutterViewPlatformViewScenario extends Scenario
+    with _BasePlatformViewScenarioMixin {
   /// Creates the PlatformView scenario.
   ///
   /// The [dispatcher] parameter must not be null.
-  NonFullScreenFlutterViewPlatformViewScenario(PlatformDispatcher dispatcher, String text, {required this.id})
+  NonFullScreenFlutterViewPlatformViewScenario(
+      PlatformDispatcher dispatcher, String text,
+      {required this.id})
       : assert(dispatcher != null),
         super(dispatcher) {
     createPlatformView(dispatcher, text, id);
@@ -72,11 +77,14 @@ class NonFullScreenFlutterViewPlatformViewScenario extends Scenario with _BasePl
 }
 
 /// A simple platform view with overlay that doesn't intersect with the platform view.
-class PlatformViewNoOverlayIntersectionScenario extends Scenario with _BasePlatformViewScenarioMixin {
+class PlatformViewNoOverlayIntersectionScenario extends Scenario
+    with _BasePlatformViewScenarioMixin {
   /// Creates the PlatformView scenario.
   ///
   /// The [dispatcher] parameter must not be null.
-  PlatformViewNoOverlayIntersectionScenario(PlatformDispatcher dispatcher, String text, {required this.id})
+  PlatformViewNoOverlayIntersectionScenario(
+      PlatformDispatcher dispatcher, String text,
+      {required this.id})
       : assert(dispatcher != null),
         super(dispatcher) {
     createPlatformView(dispatcher, text, id);
@@ -98,11 +106,14 @@ class PlatformViewNoOverlayIntersectionScenario extends Scenario with _BasePlatf
 }
 
 /// A simple platform view with an overlay that partially intersects with the platform view.
-class PlatformViewPartialIntersectionScenario extends Scenario with _BasePlatformViewScenarioMixin {
+class PlatformViewPartialIntersectionScenario extends Scenario
+    with _BasePlatformViewScenarioMixin {
   /// Creates the PlatformView scenario.
   ///
   /// The [dispatcher] parameter must not be null.
-  PlatformViewPartialIntersectionScenario(PlatformDispatcher dispatcher, String text, {required this.id})
+  PlatformViewPartialIntersectionScenario(
+      PlatformDispatcher dispatcher, String text,
+      {required this.id})
       : assert(dispatcher != null),
         super(dispatcher) {
     createPlatformView(dispatcher, text, id);
@@ -124,11 +135,14 @@ class PlatformViewPartialIntersectionScenario extends Scenario with _BasePlatfor
 }
 
 /// A simple platform view with two overlays that intersect with each other and the platform view.
-class PlatformViewTwoIntersectingOverlaysScenario extends Scenario with _BasePlatformViewScenarioMixin {
+class PlatformViewTwoIntersectingOverlaysScenario extends Scenario
+    with _BasePlatformViewScenarioMixin {
   /// Creates the PlatformView scenario.
   ///
   /// The [dispatcher] parameter must not be null.
-  PlatformViewTwoIntersectingOverlaysScenario(PlatformDispatcher dispatcher, String text, {required this.id})
+  PlatformViewTwoIntersectingOverlaysScenario(
+      PlatformDispatcher dispatcher, String text,
+      {required this.id})
       : assert(dispatcher != null),
         super(dispatcher) {
     createPlatformView(dispatcher, text, id);
@@ -163,11 +177,14 @@ class PlatformViewTwoIntersectingOverlaysScenario extends Scenario with _BasePla
 }
 
 /// A simple platform view with one overlay and two overlays that intersect with each other and the platform view.
-class PlatformViewOneOverlayTwoIntersectingOverlaysScenario extends Scenario with _BasePlatformViewScenarioMixin {
+class PlatformViewOneOverlayTwoIntersectingOverlaysScenario extends Scenario
+    with _BasePlatformViewScenarioMixin {
   /// Creates the PlatformView scenario.
   ///
   /// The [dispatcher] parameter must not be null.
-  PlatformViewOneOverlayTwoIntersectingOverlaysScenario(PlatformDispatcher dispatcher, String text, {required this.id})
+  PlatformViewOneOverlayTwoIntersectingOverlaysScenario(
+      PlatformDispatcher dispatcher, String text,
+      {required this.id})
       : assert(dispatcher != null),
         super(dispatcher) {
     createPlatformView(dispatcher, text, id);
@@ -207,11 +224,13 @@ class PlatformViewOneOverlayTwoIntersectingOverlaysScenario extends Scenario wit
 }
 
 /// Two platform views without an overlay intersecting either platform view.
-class MultiPlatformViewWithoutOverlaysScenario extends Scenario with _BasePlatformViewScenarioMixin {
+class MultiPlatformViewWithoutOverlaysScenario extends Scenario
+    with _BasePlatformViewScenarioMixin {
   /// Creates the PlatformView scenario.
   ///
   /// The [dispatcher] parameter must not be null.
-  MultiPlatformViewWithoutOverlaysScenario(PlatformDispatcher dispatcher, String text,
+  MultiPlatformViewWithoutOverlaysScenario(
+      PlatformDispatcher dispatcher, String text,
       {required this.firstId, required this.secondId})
       : assert(dispatcher != null),
         super(dispatcher) {
@@ -252,11 +271,13 @@ class MultiPlatformViewWithoutOverlaysScenario extends Scenario with _BasePlatfo
 }
 
 /// A simple platform view with too many overlays result in a single native view.
-class PlatformViewMaxOverlaysScenario extends Scenario with _BasePlatformViewScenarioMixin {
+class PlatformViewMaxOverlaysScenario extends Scenario
+    with _BasePlatformViewScenarioMixin {
   /// Creates the PlatformView scenario.
   ///
   /// The [dispatcher] parameter must not be null.
-  PlatformViewMaxOverlaysScenario(PlatformDispatcher dispatcher, String text, {required this.id})
+  PlatformViewMaxOverlaysScenario(PlatformDispatcher dispatcher, String text,
+      {required this.id})
       : assert(dispatcher != null),
         super(dispatcher) {
     createPlatformView(dispatcher, text, id);
@@ -301,11 +322,13 @@ class PlatformViewMaxOverlaysScenario extends Scenario with _BasePlatformViewSce
 }
 
 /// Builds a scene with 2 platform views.
-class MultiPlatformViewScenario extends Scenario with _BasePlatformViewScenarioMixin {
+class MultiPlatformViewScenario extends Scenario
+    with _BasePlatformViewScenarioMixin {
   /// Creates the PlatformView scenario.
   ///
   /// The [dispatcher] parameter must not be null.
-  MultiPlatformViewScenario(PlatformDispatcher dispatcher, {required this.firstId, required this.secondId})
+  MultiPlatformViewScenario(PlatformDispatcher dispatcher,
+      {required this.firstId, required this.secondId})
       : assert(dispatcher != null),
         super(dispatcher) {
     createPlatformView(dispatcher, 'platform view 1', firstId);
@@ -335,7 +358,8 @@ class MultiPlatformViewScenario extends Scenario with _BasePlatformViewScenarioM
 /// Renders a frame with 2 platform views covered by a flutter drawn rectangle,
 /// when the app goes to the background and comes back to the foreground renders a new frame
 /// with the 2 platform views but without the flutter drawn rectangle.
-class MultiPlatformViewBackgroundForegroundScenario extends Scenario with _BasePlatformViewScenarioMixin {
+class MultiPlatformViewBackgroundForegroundScenario extends Scenario
+    with _BasePlatformViewScenarioMixin {
   /// Creates the PlatformView scenario.
   ///
   /// The [dispatcher] parameter must not be null.
@@ -412,7 +436,8 @@ class MultiPlatformViewBackgroundForegroundScenario extends Scenario with _BaseP
       return;
     }
     final String message = utf8.decode(data!.buffer.asUint8List());
-    if (_lastLifecycleState == 'AppLifecycleState.inactive' && message == 'AppLifecycleState.resumed') {
+    if (_lastLifecycleState == 'AppLifecycleState.inactive' &&
+        message == 'AppLifecycleState.resumed') {
       _nextFrame = _secondFrame;
       window.scheduleFrame();
     }
@@ -422,9 +447,11 @@ class MultiPlatformViewBackgroundForegroundScenario extends Scenario with _BaseP
 }
 
 /// Platform view with clip rect.
-class PlatformViewClipRectScenario extends Scenario with _BasePlatformViewScenarioMixin {
+class PlatformViewClipRectScenario extends Scenario
+    with _BasePlatformViewScenarioMixin {
   /// Constructs a platform view with clip rect scenario.
-  PlatformViewClipRectScenario(PlatformDispatcher dispatcher, String text, {required this.id})
+  PlatformViewClipRectScenario(PlatformDispatcher dispatcher, String text,
+      {required this.id})
       : assert(dispatcher != null),
         super(dispatcher) {
     createPlatformView(dispatcher, text, id);
@@ -435,7 +462,8 @@ class PlatformViewClipRectScenario extends Scenario with _BasePlatformViewScenar
 
   @override
   void onBeginFrame(Duration duration) {
-    final SceneBuilder builder = SceneBuilder()..pushClipRect(const Rect.fromLTRB(100, 100, 400, 400));
+    final SceneBuilder builder = SceneBuilder()
+      ..pushClipRect(const Rect.fromLTRB(100, 100, 400, 400));
 
     finishBuilderByAddingPlatformViewAndPicture(builder, id);
   }
@@ -444,7 +472,8 @@ class PlatformViewClipRectScenario extends Scenario with _BasePlatformViewScenar
 /// Platform view with clip rrect.
 class PlatformViewClipRRectScenario extends PlatformViewScenario {
   /// Constructs a platform view with clip rrect scenario.
-  PlatformViewClipRRectScenario(PlatformDispatcher dispatcher, String text, {int id = 0})
+  PlatformViewClipRRectScenario(PlatformDispatcher dispatcher, String text,
+      {int id = 0})
       : super(dispatcher, text, id: id);
 
   @override
@@ -468,7 +497,8 @@ class PlatformViewClipRRectScenario extends PlatformViewScenario {
 /// Platform view with clip path.
 class PlatformViewClipPathScenario extends PlatformViewScenario {
   /// Constructs a platform view with clip rrect scenario.
-  PlatformViewClipPathScenario(PlatformDispatcher dispatcher, String text, {int id = 0})
+  PlatformViewClipPathScenario(PlatformDispatcher dispatcher, String text,
+      {int id = 0})
       : super(dispatcher, text, id: id);
 
   @override
@@ -488,7 +518,8 @@ class PlatformViewClipPathScenario extends PlatformViewScenario {
 /// Platform view with transform.
 class PlatformViewTransformScenario extends PlatformViewScenario {
   /// Constructs a platform view with transform scenario.
-  PlatformViewTransformScenario(PlatformDispatcher dispatcher, String text, {int id = 0})
+  PlatformViewTransformScenario(PlatformDispatcher dispatcher, String text,
+      {int id = 0})
       : super(dispatcher, text, id: id);
 
   @override
@@ -507,7 +538,8 @@ class PlatformViewTransformScenario extends PlatformViewScenario {
 /// Platform view with opacity.
 class PlatformViewOpacityScenario extends PlatformViewScenario {
   /// Constructs a platform view with transform scenario.
-  PlatformViewOpacityScenario(PlatformDispatcher dispatcher, String text, {int id = 0})
+  PlatformViewOpacityScenario(PlatformDispatcher dispatcher, String text,
+      {int id = 0})
       : super(dispatcher, text, id: id);
 
   @override
@@ -518,7 +550,8 @@ class PlatformViewOpacityScenario extends PlatformViewScenario {
 }
 
 /// A simple platform view for testing touch events from iOS.
-class PlatformViewForTouchIOSScenario extends Scenario with _BasePlatformViewScenarioMixin {
+class PlatformViewForTouchIOSScenario extends Scenario
+    with _BasePlatformViewScenarioMixin {
   /// Creates the PlatformView scenario.
   ///
   /// The [dispatcher] parameter must not be null.
@@ -529,7 +562,8 @@ class PlatformViewForTouchIOSScenario extends Scenario with _BasePlatformViewSce
         _viewId = id,
         super(dispatcher) {
     if (rejectUntilTouchesEnded) {
-      createPlatformView(dispatcher, text, id, viewType: 'scenarios/textPlatformView_blockPolicyUntilTouchesEnded');
+      createPlatformView(dispatcher, text, id,
+          viewType: 'scenarios/textPlatformView_blockPolicyUntilTouchesEnded');
     } else {
       createPlatformView(dispatcher, text, id);
     }
@@ -602,14 +636,16 @@ class PlatformViewForTouchIOSScenario extends Scenario with _BasePlatformViewSce
 /// For example, it simulates a video being played.
 class PlatformViewWithContinuousTexture extends PlatformViewScenario {
   /// Constructs a platform view with continuous texture layer.
-  PlatformViewWithContinuousTexture(PlatformDispatcher dispatcher, String text, {int id = 0})
+  PlatformViewWithContinuousTexture(PlatformDispatcher dispatcher, String text,
+      {int id = 0})
       : super(dispatcher, text, id: id);
 
   @override
   void onBeginFrame(Duration duration) {
     final SceneBuilder builder = SceneBuilder();
 
-    builder.addTexture(0, width: 300, height: 300, offset: const Offset(200, 200));
+    builder.addTexture(0,
+        width: 300, height: 300, offset: const Offset(200, 200));
 
     finishBuilderByAddingPlatformViewAndPicture(builder, id);
   }
@@ -623,7 +659,9 @@ class PlatformViewWithContinuousTexture extends PlatformViewScenario {
 /// See: https://github.com/flutter/flutter/issues/80766
 class PlatformViewWithOtherBackDropFilter extends PlatformViewScenario {
   /// Constructs the scenario.
-  PlatformViewWithOtherBackDropFilter(PlatformDispatcher dispatcher, String text, {int id = 0})
+  PlatformViewWithOtherBackDropFilter(
+      PlatformDispatcher dispatcher, String text,
+      {int id = 0})
       : super(dispatcher, text, id: id);
 
   @override
@@ -688,9 +726,11 @@ class PlatformViewWithOtherBackDropFilter extends PlatformViewScenario {
 /// The stack would look like: picture 1 -> pv1 -> picture 2 -> filter -> pv2 - > picture 3.
 /// Because backdrop filter on platform views has not been implemented(see: https://github.com/flutter/flutter/issues/43902),
 /// the result will not including a filtered pv1.
-class TwoPlatformViewsWithOtherBackDropFilter extends Scenario with _BasePlatformViewScenarioMixin {
+class TwoPlatformViewsWithOtherBackDropFilter extends Scenario
+    with _BasePlatformViewScenarioMixin {
   /// Constructs the scenario.
-  TwoPlatformViewsWithOtherBackDropFilter(PlatformDispatcher dispatcher, {required int firstId, required int secondId})
+  TwoPlatformViewsWithOtherBackDropFilter(PlatformDispatcher dispatcher,
+      {required int firstId, required int secondId})
       : _firstId = firstId,
         _secondId = secondId,
         super(dispatcher) {
@@ -762,7 +802,8 @@ class TwoPlatformViewsWithOtherBackDropFilter extends Scenario with _BasePlatfor
 }
 
 /// Builds a scenario where many platform views are scrolling and pass under a picture.
-class PlatformViewScrollingUnderWidget extends Scenario with _BasePlatformViewScenarioMixin {
+class PlatformViewScrollingUnderWidget extends Scenario
+    with _BasePlatformViewScenarioMixin {
   /// Creates the PlatformView scenario.
   ///
   /// The [dispatcher] parameter must not be null.
@@ -864,8 +905,10 @@ mixin _BasePlatformViewScenarioMixin on Scenario {
       ...utf8.encode('create'),
       _valueMap,
       if (Platform.isIOS) 3, // 3 entries in map for iOS.
-      if (Platform.isAndroid && !usesAndroidHybridComposition) 6, // 6 entries in map for virtual displays on Android.
-      if (Platform.isAndroid && usesAndroidHybridComposition) 5, // 5 entries in map for Android views.
+      if (Platform.isAndroid && !usesAndroidHybridComposition)
+        6, // 6 entries in map for virtual displays on Android.
+      if (Platform.isAndroid && usesAndroidHybridComposition)
+        5, // 5 entries in map for Android views.
       _valueString,
       'id'.length,
       ...utf8.encode('id'),
@@ -917,7 +960,9 @@ mixin _BasePlatformViewScenarioMixin on Scenario {
       'flutter/platform_views',
       message.buffer.asByteData(),
       (ByteData? response) {
-        if (response != null && Platform.isAndroid && !usesAndroidHybridComposition) {
+        if (response != null &&
+            Platform.isAndroid &&
+            !usesAndroidHybridComposition) {
           // Envelope.
           _textureId = response.getUint8(0);
         }
@@ -940,7 +985,8 @@ mixin _BasePlatformViewScenarioMixin on Scenario {
         sceneBuilder.addTexture(_textureId!, width: width, height: height);
       }
     } else {
-      throw UnsupportedError('Platform ${Platform.operatingSystem} is not supported');
+      throw UnsupportedError(
+          'Platform ${Platform.operatingSystem} is not supported');
     }
   }
 

--- a/testing/scenario_app/lib/src/scenarios.dart
+++ b/testing/scenario_app/lib/src/scenarios.dart
@@ -43,6 +43,7 @@ Map<String, ScenarioFactory> _scenarios = <String, ScenarioFactory>{
   'platform_view_gesture_reject_eager': () => PlatformViewForTouchIOSScenario(PlatformDispatcher.instance, 'platform view touch', id: _viewId++, accept: false),
   'platform_view_gesture_accept': () => PlatformViewForTouchIOSScenario(PlatformDispatcher.instance, 'platform view touch', id: _viewId++, accept: true),
   'platform_view_gesture_reject_after_touches_ended': () => PlatformViewForTouchIOSScenario(PlatformDispatcher.instance, 'platform view touch', id: _viewId++, accept: false, rejectUntilTouchesEnded: true),
+  'platform_view_scrolling_under_widget':()=>PlatformViewScrollingUnderWidget(PlatformDispatcher.instance, minId: _viewId++, maxId: _viewId+=16),
   'tap_status_bar': () => TouchesScenario(PlatformDispatcher.instance),
   'text_semantics_focus': () => SendTextFocusSemantics(PlatformDispatcher.instance),
   'initial_route_reply': () => InitialRouteReply(PlatformDispatcher.instance),

--- a/testing/scenario_app/lib/src/scenarios.dart
+++ b/testing/scenario_app/lib/src/scenarios.dart
@@ -43,7 +43,7 @@ Map<String, ScenarioFactory> _scenarios = <String, ScenarioFactory>{
   'platform_view_gesture_reject_eager': () => PlatformViewForTouchIOSScenario(PlatformDispatcher.instance, 'platform view touch', id: _viewId++, accept: false),
   'platform_view_gesture_accept': () => PlatformViewForTouchIOSScenario(PlatformDispatcher.instance, 'platform view touch', id: _viewId++, accept: true),
   'platform_view_gesture_reject_after_touches_ended': () => PlatformViewForTouchIOSScenario(PlatformDispatcher.instance, 'platform view touch', id: _viewId++, accept: false, rejectUntilTouchesEnded: true),
-  'platform_view_scrolling_under_widget':()=>PlatformViewScrollingUnderWidget(PlatformDispatcher.instance, minId: _viewId++, maxId: _viewId+=16),
+  'platform_view_scrolling_under_widget':()=>PlatformViewScrollingUnderWidget(PlatformDispatcher.instance, firstPlatformViewId: _viewId++, lastPlatformViewId: _viewId+=16),
   'tap_status_bar': () => TouchesScenario(PlatformDispatcher.instance),
   'text_semantics_focus': () => SendTextFocusSemantics(PlatformDispatcher.instance),
   'initial_route_reply': () => InitialRouteReply(PlatformDispatcher.instance),


### PR DESCRIPTION
Explicitly set every platform view and overlay view's zPosition so we are sure the overlays are on top of the platform views.

Fixes: https://github.com/flutter/flutter/issues/86787

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
