### PR TITLE
[Win32] Use mock macro for UpdateSemanticsEnabled

### DIFF
--- a/shell/platform/windows/flutter_windows_view_unittests.cc
+++ b/shell/platform/windows/flutter_windows_view_unittests.cc
@@ -35,7 +35,6 @@ struct TestResponseHandle {
 };
 
 static bool test_response = false;
-static bool semantics_enabled = false;
 
 constexpr uint64_t kKeyEventFromChannel = 0x11;
 constexpr uint64_t kKeyEventFromEmbedder = 0x22;
@@ -130,11 +129,15 @@ TEST(FlutterWindowsViewTest, RestartClearsKeyboardState) {
 TEST(FlutterWindowsViewTest, EnableSemantics) {
   std::unique_ptr<FlutterWindowsEngine> engine = GetTestEngine();
   EngineModifier modifier(engine.get());
-  modifier.embedder_api().UpdateSemanticsEnabled =
-      [](FLUTTER_API_SYMBOL(FlutterEngine) engine, bool enabled) {
+
+  bool semantics_enabled = false;
+  modifier.embedder_api().UpdateSemanticsEnabled = MOCK_ENGINE_PROC(
+      UpdateSemanticsEnabled,
+      [&semantics_enabled](FLUTTER_API_SYMBOL(FlutterEngine) engine,
+                           bool enabled) {
         semantics_enabled = enabled;
         return kSuccess;
-      };
+      });
 
   auto window_binding_handler =
       std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();


### PR DESCRIPTION
Previously, we'd mocked out UpdateSemanticsEnabled using a simple
lambda. Due to the embedder API's C ABI, we were unable to make use of
lambda captures. This patch instead uses MOCK_ENGINE_PROC so we can make
the test variable a local and rely on lambda capture.

Issue: https://github.com/flutter/flutter/issues/77838

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
