### PR TITLE
Fix embedder_->EndFrame() not called in case of DrawLastLayerTree()

### DIFF
--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -483,6 +483,7 @@ class Rasterizer final : public SnapshotDelegate {
   void FireNextFrameCallbackIfPresent();
 
   static bool NoDiscard(const flutter::LayerTree& layer_tree) { return false; }
+  static bool ShouldResubmitFrame(const RasterStatus& raster_status);
 
   Delegate& delegate_;
   std::unique_ptr<Surface> surface_;

--- a/shell/common/rasterizer_unittests.cc
+++ b/shell/common/rasterizer_unittests.cc
@@ -300,6 +300,80 @@ TEST(
   rasterizer->Draw(CreateFinishedBuildRecorder(), pipeline, no_discard);
 }
 
+TEST(RasterizerTest,
+     drawLastLayerTreeWithThreadsMergedExternalViewEmbedderAndEndFrameCalled) {
+  std::string test_name =
+      ::testing::UnitTest::GetInstance()->current_test_info()->name();
+  ThreadHost thread_host("io.flutter.test." + test_name + ".",
+                         ThreadHost::Type::Platform | ThreadHost::Type::RASTER |
+                             ThreadHost::Type::IO | ThreadHost::Type::UI);
+  fml::MessageLoop::EnsureInitializedForCurrentThread();
+  TaskRunners task_runners("test",
+                           fml::MessageLoop::GetCurrent().GetTaskRunner(),
+                           fml::MessageLoop::GetCurrent().GetTaskRunner(),
+                           thread_host.ui_thread->GetTaskRunner(),
+                           thread_host.io_thread->GetTaskRunner());
+
+  MockDelegate delegate;
+  EXPECT_CALL(delegate, GetTaskRunners())
+      .WillRepeatedly(ReturnRef(task_runners));
+  EXPECT_CALL(delegate, OnFrameRasterized(_));
+
+  auto rasterizer = std::make_unique<Rasterizer>(delegate);
+  auto surface = std::make_unique<MockSurface>();
+
+  std::shared_ptr<MockExternalViewEmbedder> external_view_embedder =
+      std::make_shared<MockExternalViewEmbedder>();
+  rasterizer->SetExternalViewEmbedder(external_view_embedder);
+
+  SurfaceFrame::FramebufferInfo framebuffer_info;
+  framebuffer_info.supports_readback = true;
+
+  auto surface_frame1 = std::make_unique<SurfaceFrame>(
+      /*surface=*/nullptr, framebuffer_info,
+      /*submit_callback=*/[](const SurfaceFrame&, SkCanvas*) { return true; });
+  auto surface_frame2 = std::make_unique<SurfaceFrame>(
+      /*surface=*/nullptr, framebuffer_info,
+      /*submit_callback=*/[](const SurfaceFrame&, SkCanvas*) { return true; });
+  EXPECT_CALL(*surface, AllowsDrawingWhenGpuDisabled())
+      .WillRepeatedly(Return(true));
+  // Prepare two frames for Draw() and DrawLastLayerTree().
+  EXPECT_CALL(*surface, AcquireFrame(SkISize()))
+      .WillOnce(Return(ByMove(std::move(surface_frame1))))
+      .WillOnce(Return(ByMove(std::move(surface_frame2))));
+  EXPECT_CALL(*surface, MakeRenderContextCurrent())
+      .WillOnce(Return(ByMove(std::make_unique<GLContextDefaultResult>(true))));
+  EXPECT_CALL(*external_view_embedder, SupportsDynamicThreadMerging)
+      .WillRepeatedly(Return(true));
+
+  EXPECT_CALL(*external_view_embedder,
+              BeginFrame(/*frame_size=*/SkISize(), /*context=*/nullptr,
+                         /*device_pixel_ratio=*/2.0,
+                         /*raster_thread_merger=*/_))
+      .Times(2);
+  EXPECT_CALL(*external_view_embedder, SubmitFrame).Times(2);
+  EXPECT_CALL(*external_view_embedder, EndFrame(/*should_resubmit_frame=*/false,
+                                                /*raster_thread_merger=*/_))
+      .Times(2);
+
+  rasterizer->Setup(std::move(surface));
+
+  auto pipeline = std::make_shared<Pipeline<LayerTree>>(/*depth=*/10);
+  auto layer_tree = std::make_unique<LayerTree>(/*frame_size=*/SkISize(),
+                                                /*device_pixel_ratio=*/2.0f);
+  bool result = pipeline->Produce().Complete(std::move(layer_tree));
+  EXPECT_TRUE(result);
+  auto no_discard = [](LayerTree&) { return false; };
+
+  // The Draw() will respectively call BeginFrame(), SubmitFrame() and
+  // EndFrame() one time.
+  rasterizer->Draw(CreateFinishedBuildRecorder(), pipeline, no_discard);
+
+  // The DrawLastLayerTree() will respectively call BeginFrame(), SubmitFrame()
+  // and EndFrame() one more time, totally 2 times.
+  rasterizer->DrawLastLayerTree(CreateFinishedBuildRecorder());
+}
+
 TEST(RasterizerTest, externalViewEmbedderDoesntEndFrameWhenNoSurfaceIsSet) {
   std::string test_name =
       ::testing::UnitTest::GetInstance()->current_test_info()->name();

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -535,16 +535,6 @@ zip_bundle("flutter_jar_zip") {
   ]
 
   deps = [ ":android_jar" ]
-
-  if (current_cpu == "x86" || current_cpu == "x64") {
-    files += [
-      {
-        source = "$root_build_dir/lib.stripped/libflutter.so"
-        destination = "libflutter.so"
-      },
-    ]
-    deps += [ ":flutter_shell_native" ]
-  }
 }
 
 action("gen_android_javadoc") {


### PR DESCRIPTION
It fixes this video flicker bug:
* https://github.com/flutter/flutter/issues/94612

The root cause is EndFrame() is not called in case of `DrawLastLayerTree()` when reusing previous layer tree.
The detail context is in the issue 😁 https://github.com/flutter/flutter/issues/94612 


https://user-images.githubusercontent.com/922837/144641881-07f487ea-cb5c-4ffb-9b2d-7be870479548.mp4

And after this fix, the app works correctly: 

https://user-images.githubusercontent.com/922837/144642305-e62006a5-1698-41aa-8308-d4094dcb9568.mp4


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.


