### PR TITLE
[fuchsia] Fix unset key and present key meaning

### DIFF
--- a/shell/platform/fuchsia/flutter/keyboard.h
+++ b/shell/platform/fuchsia/flutter/keyboard.h
@@ -57,6 +57,8 @@ class Keyboard final {
   bool IsKeys();
 
   // Returns the value of the last key as a uint32_t.
+  // If there isn't such a value (as in the case of on-screen keyboards), this
+  // will return a 0;
   uint32_t GetLastKey();
 
   // Set to false until any event is received.


### PR DESCRIPTION
The old code did not behave correctly when faced with a
`KeyEvent` with `key` unset, and would crash. This is
because `KeyEvent` with unset `key` became possible
only when `key_meaning` was introduced.

As for `key_meaning`, I also added it to the code point
determination. I originally thought that the two issues
could be handled separately, but that wasn't the case.

So, as result, fixed both and added tests.

Fixes: https://github.com/flutter/flutter/issues/93898, https://github.com/flutter/flutter/issues/93891

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
