### PR TITLE
Removed the email warning about notifications entitlement

### DIFF
--- a/shell/platform/darwin/ios/framework/Headers/FlutterPluginAppLifeCycleDelegate.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterPluginAppLifeCycleDelegate.h
@@ -53,6 +53,9 @@ FLUTTER_DARWIN_EXPORT
 
 /**
  * Calls all plugins registered for `UIApplicationDelegate` callbacks.
+ *
+ * At runtime this is also mapped to
+ * `application:didRegisterForRemoteNotificationsWithDeviceToken:`.
  */
 - (void)performApplication:(UIApplication*)application
     didRegisterForRemoteNotificationsWithDeviceToken:(NSData*)deviceToken;
@@ -65,6 +68,9 @@ FLUTTER_DARWIN_EXPORT
 
 /**
  * Calls all plugins registered for `UIApplicationDelegate` callbacks.
+ *
+ * At runtime this is also mapped to
+ * `application:didReceiveRemoteNotification:fetchCompletionHandler:`.
  */
 - (void)performApplication:(UIApplication*)application
     didReceiveRemoteNotification:(NSDictionary*)userInfo

--- a/shell/platform/darwin/ios/framework/Headers/FlutterPluginAppLifeCycleDelegate.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterPluginAppLifeCycleDelegate.h
@@ -62,8 +62,10 @@ FLUTTER_DARWIN_EXPORT
 
 /**
  * Calls all plugins registered for `UIApplicationDelegate` callbacks.
+ * At runtime this is also mapped to
+ * `application:didFailToRegisterForRemoteNotificationsWithError:`.
  */
-- (void)application:(UIApplication*)application
+- (void)performApplication:(UIApplication*)application
     didFailToRegisterForRemoteNotificationsWithError:(NSError*)error;
 
 /**

--- a/shell/platform/darwin/ios/framework/Headers/FlutterPluginAppLifeCycleDelegate.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterPluginAppLifeCycleDelegate.h
@@ -54,7 +54,7 @@ FLUTTER_DARWIN_EXPORT
 /**
  * Calls all plugins registered for `UIApplicationDelegate` callbacks.
  */
-- (void)application:(UIApplication*)application
+- (void)performApplication:(UIApplication*)application
     didRegisterForRemoteNotificationsWithDeviceToken:(NSData*)deviceToken;
 
 /**

--- a/shell/platform/darwin/ios/framework/Headers/FlutterPluginAppLifeCycleDelegate.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterPluginAppLifeCycleDelegate.h
@@ -66,7 +66,7 @@ FLUTTER_DARWIN_EXPORT
 /**
  * Calls all plugins registered for `UIApplicationDelegate` callbacks.
  */
-- (void)application:(UIApplication*)application
+- (void)performApplication:(UIApplication*)application
     didReceiveRemoteNotification:(NSDictionary*)userInfo
           fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler;
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -97,12 +97,6 @@ static SEL ApplicationDidReceiveRemoteNotificationFetchCompletionHandlerSelector
 #pragma GCC diagnostic pop
 
 - (void)application:(UIApplication*)application
-    didRegisterForRemoteNotificationsWithDeviceToken:(NSData*)deviceToken {
-  [_lifeCycleDelegate application:application
-      didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
-}
-
-- (void)application:(UIApplication*)application
     didFailToRegisterForRemoteNotificationsWithError:(NSError*)error {
   [_lifeCycleDelegate application:application
       didFailToRegisterForRemoteNotificationsWithError:error];

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -15,6 +15,12 @@ static NSString* const kUIBackgroundMode = @"UIBackgroundModes";
 static NSString* const kRemoteNotificationCapabitiliy = @"remote-notification";
 static NSString* const kBackgroundFetchCapatibility = @"fetch";
 static NSString* const kRestorationStateAppModificationKey = @"mod-date";
+static NSString* const kApplicationDidReceiveRemoteNotificationFetchCompletionHandler =
+    @"application:didReceiveRemoteNotification:fetchCompletionHandler:";
+
+static SEL ApplicationDidReceiveRemoteNotificationFetchCompletionHandlerSelector() {
+  return NSSelectorFromString(kApplicationDidReceiveRemoteNotificationFetchCompletionHandler);
+}
 
 @interface FlutterAppDelegate ()
 @property(nonatomic, copy) FlutterViewController* (^rootFlutterViewControllerGetter)(void);
@@ -296,7 +302,7 @@ static NSString* const kRestorationStateAppModificationKey = @"mod-date";
   NSArray* backgroundModesArray =
       [[NSBundle mainBundle] objectForInfoDictionaryKey:kUIBackgroundMode];
   NSSet* backgroundModesSet = [[[NSSet alloc] initWithArray:backgroundModesArray] autorelease];
-  if (selector == @selector(application:didReceiveRemoteNotification:fetchCompletionHandler:)) {
+  if (selector == ApplicationDidReceiveRemoteNotificationFetchCompletionHandlerSelector()) {
     if (![backgroundModesSet containsObject:kRemoteNotificationCapabitiliy]) {
       NSLog(
           @"You've implemented -[<UIApplicationDelegate> "

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -96,12 +96,6 @@ static SEL ApplicationDidReceiveRemoteNotificationFetchCompletionHandlerSelector
 }
 #pragma GCC diagnostic pop
 
-- (void)application:(UIApplication*)application
-    didFailToRegisterForRemoteNotificationsWithError:(NSError*)error {
-  [_lifeCycleDelegate application:application
-      didFailToRegisterForRemoteNotificationsWithError:error];
-}
-
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 - (void)application:(UIApplication*)application

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
@@ -13,6 +13,14 @@
 
 FLUTTER_ASSERT_ARC
 
+@interface FlutterAppDelegate ()
+- (void)application:(UIApplication*)application
+    didReceiveRemoteNotification:(NSDictionary*)userInfo
+          fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler;
+- (void)application:(UIApplication*)application
+    didRegisterForRemoteNotificationsWithDeviceToken:(NSData*)deviceToken;
+@end
+
 @interface FlutterAppDelegateTest : XCTestCase
 @property(strong) FlutterAppDelegate* appDelegate;
 
@@ -153,6 +161,48 @@ FLUTTER_ASSERT_ARC
   XCTAssertTrue(result);
   OCMVerify([self.mockNavigationChannel invokeMethod:@"pushRoute"
                                            arguments:@"/custom/route?query=test"]);
+}
+
+- (void)testDidReceiveRemoteNotificationTrue {
+  id delegate = OCMProtocolMock(@protocol(FlutterApplicationLifeCycleDelegate));
+  [self.appDelegate addApplicationLifeCycleDelegate:delegate];
+  XCTAssertTrue([self.appDelegate
+      respondsToSelector:@selector(application:
+                             didReceiveRemoteNotification:fetchCompletionHandler:)]);
+  NSDictionary* info = @{};
+  void (^handler)(UIBackgroundFetchResult) = ^(UIBackgroundFetchResult result) {
+  };
+  [self.appDelegate application:[UIApplication sharedApplication]
+      didReceiveRemoteNotification:info
+            fetchCompletionHandler:handler];
+  [(NSObject<FlutterApplicationLifeCycleDelegate>*)[delegate verify]
+                       application:[UIApplication sharedApplication]
+      didReceiveRemoteNotification:info
+            fetchCompletionHandler:handler];
+}
+
+- (void)testDidRegisterForRemoteNotificationsWithDeviceTokenTrue {
+  id delegate = OCMProtocolMock(@protocol(FlutterApplicationLifeCycleDelegate));
+  [self.appDelegate addApplicationLifeCycleDelegate:delegate];
+  XCTAssertTrue([self.appDelegate
+      respondsToSelector:@selector(application:didRegisterForRemoteNotificationsWithDeviceToken:)]);
+  NSData* token = [[NSData alloc] init];
+  [self.appDelegate application:[UIApplication sharedApplication]
+      didRegisterForRemoteNotificationsWithDeviceToken:token];
+  [(NSObject<FlutterApplicationLifeCycleDelegate>*)[delegate verify]
+                                           application:[UIApplication sharedApplication]
+      didRegisterForRemoteNotificationsWithDeviceToken:token];
+}
+
+- (void)testDidReceiveRemoteNotificationFalse {
+  XCTAssertFalse([self.appDelegate
+      respondsToSelector:@selector(application:
+                             didReceiveRemoteNotification:fetchCompletionHandler:)]);
+}
+
+- (void)testDidRegisterForRemoteNotificationsWithDeviceTokenFalse {
+  XCTAssertFalse([self.appDelegate
+      respondsToSelector:@selector(application:didRegisterForRemoteNotificationsWithDeviceToken:)]);
 }
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
@@ -19,6 +19,8 @@ FLUTTER_ASSERT_ARC
           fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler;
 - (void)application:(UIApplication*)application
     didRegisterForRemoteNotificationsWithDeviceToken:(NSData*)deviceToken;
+- (void)application:(UIApplication*)application
+    didFailToRegisterForRemoteNotificationsWithError:(NSError*)error;
 @end
 
 @interface FlutterAppDelegateTest : XCTestCase
@@ -203,6 +205,19 @@ FLUTTER_ASSERT_ARC
 - (void)testDidRegisterForRemoteNotificationsWithDeviceTokenFalse {
   XCTAssertFalse([self.appDelegate
       respondsToSelector:@selector(application:didRegisterForRemoteNotificationsWithDeviceToken:)]);
+}
+
+- (void)testDidFailToRegisterForRemoteNotificationsWithError {
+  id delegate = OCMProtocolMock(@protocol(FlutterApplicationLifeCycleDelegate));
+  [self.appDelegate addApplicationLifeCycleDelegate:delegate];
+  XCTAssertTrue([self.appDelegate
+      respondsToSelector:@selector(application:didFailToRegisterForRemoteNotificationsWithError:)]);
+  NSError* error = [[NSError alloc] init];
+  [self.appDelegate application:[UIApplication sharedApplication]
+      didFailToRegisterForRemoteNotificationsWithError:error];
+  [(NSObject<FlutterApplicationLifeCycleDelegate>*)[delegate verify]
+                                           application:[UIApplication sharedApplication]
+      didFailToRegisterForRemoteNotificationsWithError:error];
 }
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm
@@ -36,12 +36,14 @@ static const SEL selectorsHandledByPlugins[] = {
 }
 
 + (void)load {
-  // Swap out `performApplication:didReceiveRemoteNotification:fetchCompletionHandler:` for
-  // `application:didReceiveRemoteNotification:fetchCompletionHandler:`.  This has to be done
-  // to avoid a potential false positive email when uploading apps to the AppStore about
-  // entitlements.  Linked NSPlugin implementations that have
-  // `application:didReceiveRemoteNotification:fetchCompletionHandler:` defined will cause the
-  // email to happen if the entitlements are missing.
+  // Swap out
+  // `performApplication:didReceiveRemoteNotification:fetchCompletionHandler:`
+  // for `application:didReceiveRemoteNotification:fetchCompletionHandler:`.
+  // This has to be done to avoid a potential false positive "Missing Push
+  // Notification Entitlement" validation failure when uploading apps to the App
+  // Store.  Linked NSPlugin implementations that have
+  // `application:didReceiveRemoteNotification:fetchCompletionHandler:` defined
+  // will cause the failure to happen correctly if the entitlements are missing.
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
     Class thisClass = [self class];

--- a/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm
@@ -59,13 +59,12 @@ static void RemapMethod(Class thisClass, SEL originalSelector, SEL addedSelector
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
     RemapMethod(
-        [self class],
-        @selector(performApplication:didReceiveRemoteNotification:fetchCompletionHandler:),
+        self, @selector(performApplication:didReceiveRemoteNotification:fetchCompletionHandler:),
         NSSelectorFromString(kApplicationDidReceiveRemoteNotificationFetchCompletionHandler));
-    RemapMethod([self class],
+    RemapMethod(self,
                 @selector(performApplication:didRegisterForRemoteNotificationsWithDeviceToken:),
                 NSSelectorFromString(kApplicationDidRegisterForRemoteNotificationsWithDeviceToken));
-    RemapMethod([self class],
+    RemapMethod(self,
                 @selector(performApplication:didFailToRegisterForRemoteNotificationsWithError:),
                 NSSelectorFromString(kApplicationDidFailToRegisterForRemoteNotificationsWithError));
   });

--- a/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm
@@ -16,10 +16,13 @@ static NSString* const kApplicationDidReceiveRemoteNotificationFetchCompletionHa
     @"application:didReceiveRemoteNotification:fetchCompletionHandler:";
 static NSString* const kApplicationDidRegisterForRemoteNotificationsWithDeviceToken =
     @"application:didRegisterForRemoteNotificationsWithDeviceToken:";
+static NSString* const kApplicationDidFailToRegisterForRemoteNotificationsWithError =
+    @"application:didFailToRegisterForRemoteNotificationsWithError:";
 
 static const SEL selectorsHandledByPlugins[] = {
     NSSelectorFromString(kApplicationDidReceiveRemoteNotificationFetchCompletionHandler),
     NSSelectorFromString(kApplicationDidRegisterForRemoteNotificationsWithDeviceToken),
+    NSSelectorFromString(kApplicationDidFailToRegisterForRemoteNotificationsWithError),
     @selector(application:performFetchWithCompletionHandler:)};
 
 @interface FlutterPluginAppLifeCycleDelegate ()
@@ -62,6 +65,9 @@ static void RemapMethod(Class thisClass, SEL originalSelector, SEL addedSelector
     RemapMethod([self class],
                 @selector(performApplication:didRegisterForRemoteNotificationsWithDeviceToken:),
                 NSSelectorFromString(kApplicationDidRegisterForRemoteNotificationsWithDeviceToken));
+    RemapMethod([self class],
+                @selector(performApplication:didFailToRegisterForRemoteNotificationsWithError:),
+                NSSelectorFromString(kApplicationDidFailToRegisterForRemoteNotificationsWithError));
   });
 }
 
@@ -281,7 +287,7 @@ static BOOL IsPowerOfTwo(NSUInteger x) {
   }
 }
 
-- (void)application:(UIApplication*)application
+- (void)performApplication:(UIApplication*)application
     didFailToRegisterForRemoteNotificationsWithError:(NSError*)error {
   for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
     if (!delegate) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegateTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegateTest.mm
@@ -16,6 +16,8 @@ FLUTTER_ASSERT_ARC
           fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler;
 - (void)application:(UIApplication*)application
     didRegisterForRemoteNotificationsWithDeviceToken:(NSData*)deviceToken;
+- (void)application:(UIApplication*)application
+    didFailToRegisterForRemoteNotificationsWithError:(NSError*)error;
 @end
 
 @interface FlutterPluginAppLifeCycleDelegateSubclass : FlutterPluginAppLifeCycleDelegate
@@ -161,6 +163,19 @@ FLUTTER_ASSERT_ARC
       didRegisterForRemoteNotificationsWithDeviceToken:token];
   [(NSObject<FlutterPlugin>*)[plugin verify] application:[UIApplication sharedApplication]
         didRegisterForRemoteNotificationsWithDeviceToken:token];
+}
+
+- (void)testDidFailToRegisterForRemoteNotificationsWithError {
+  FlutterPluginAppLifeCycleDelegate* delegate = [[FlutterPluginAppLifeCycleDelegate alloc] init];
+  id plugin = OCMProtocolMock(@protocol(FlutterPlugin));
+  [delegate addDelegate:plugin];
+  NSError* error = [[NSError alloc] init];
+  XCTAssertTrue([delegate
+      respondsToSelector:@selector(application:didFailToRegisterForRemoteNotificationsWithError:)]);
+  [delegate application:[UIApplication sharedApplication]
+      didFailToRegisterForRemoteNotificationsWithError:error];
+  [(NSObject<FlutterPlugin>*)[plugin verify] application:[UIApplication sharedApplication]
+        didFailToRegisterForRemoteNotificationsWithError:error];
 }
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegateTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegateTest.mm
@@ -10,6 +10,12 @@
 
 FLUTTER_ASSERT_ARC
 
+@interface FlutterPluginAppLifeCycleDelegate ()
+- (void)application:(UIApplication*)application
+    didReceiveRemoteNotification:(NSDictionary*)userInfo
+          fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler;
+@end
+
 @interface FlutterPluginAppLifeCycleDelegateTest : XCTestCase
 @end
 
@@ -87,6 +93,23 @@ FLUTTER_ASSERT_ARC
                                                       object:nil];
   [self waitForExpectations:@[ expectation ] timeout:5.0];
   OCMVerify([plugin applicationWillTerminate:[UIApplication sharedApplication]]);
+}
+
+- (void)testDidReceiveRemoteNotification {
+  FlutterPluginAppLifeCycleDelegate* delegate = [[FlutterPluginAppLifeCycleDelegate alloc] init];
+  id plugin = OCMProtocolMock(@protocol(FlutterPlugin));
+  [delegate addDelegate:plugin];
+  NSDictionary* info = @{};
+  void (^handler)(UIBackgroundFetchResult) = ^(UIBackgroundFetchResult result) {
+  };
+  XCTAssertTrue([delegate respondsToSelector:@selector
+                          (application:didReceiveRemoteNotification:fetchCompletionHandler:)]);
+  [delegate application:[UIApplication sharedApplication]
+      didReceiveRemoteNotification:info
+            fetchCompletionHandler:handler];
+  [(NSObject<FlutterPlugin>*)[plugin verify] application:[UIApplication sharedApplication]
+                            didReceiveRemoteNotification:info
+                                  fetchCompletionHandler:handler];
 }
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegateTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegateTest.mm
@@ -14,6 +14,8 @@ FLUTTER_ASSERT_ARC
 - (void)application:(UIApplication*)application
     didReceiveRemoteNotification:(NSDictionary*)userInfo
           fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler;
+- (void)application:(UIApplication*)application
+    didRegisterForRemoteNotificationsWithDeviceToken:(NSData*)deviceToken;
 @end
 
 @interface FlutterPluginAppLifeCycleDelegateTest : XCTestCase
@@ -110,6 +112,19 @@ FLUTTER_ASSERT_ARC
   [(NSObject<FlutterPlugin>*)[plugin verify] application:[UIApplication sharedApplication]
                             didReceiveRemoteNotification:info
                                   fetchCompletionHandler:handler];
+}
+
+- (void)testDidRegisterForRemoteNotificationsWithDeviceToken {
+  FlutterPluginAppLifeCycleDelegate* delegate = [[FlutterPluginAppLifeCycleDelegate alloc] init];
+  id plugin = OCMProtocolMock(@protocol(FlutterPlugin));
+  [delegate addDelegate:plugin];
+  NSData* token = [[NSData alloc] init];
+  XCTAssertTrue([delegate
+      respondsToSelector:@selector(application:didRegisterForRemoteNotificationsWithDeviceToken:)]);
+  [delegate application:[UIApplication sharedApplication]
+      didRegisterForRemoteNotificationsWithDeviceToken:token];
+  [(NSObject<FlutterPlugin>*)[plugin verify] application:[UIApplication sharedApplication]
+        didRegisterForRemoteNotificationsWithDeviceToken:token];
 }
 
 @end


### PR DESCRIPTION
This removes explicit references to `application:didReceiveRemoteNotification:fetchCompletionHandler:` from the engine and adds it at runtime.  This will remove the false positive emails users receive about entitlements.  If the user is using a plugin that implements `-[NSPlugin application:didReceiveRemoteNotification:fetchCompletionHandler:]` that should trigger the warning email since that plugin will be linked in and that symbol will show up for the plugin.

This is based off of what firebase does: https://github.com/firebase/firebase-ios-sdk/blob/7eb1747e4b9be195ea9908b9da28b1d0f818afe3/GoogleUtilities/AppDelegateSwizzler/GULAppDelegateSwizzler.m#L98

fixes https://github.com/flutter/flutter/issues/9984

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
