### PR TITLE
Support user defined font request URL

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/font_fallbacks.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/font_fallbacks.dart
@@ -20,22 +20,22 @@ import 'interval_tree.dart';
 
 // Runtime parameters.
 
-// The URL to use when downloading the font resources.
-// 
-// The base URL can be overridden using the `FONT_API_SERVER`
-// environment variable.
-//
-// When specifying using the environment variable set it in the Flutter tool
-// using the `--dart-define` option. The value must end with a `/`.
-//
-// Example:
-//
-// ```
-// flutter run \
-//   -d chrome \
-//   --web-renderer=canvaskit \
-//   --dart-define=FONT_API_SERVER=https://example.com/
-// ```
+/// The URL to use when downloading the font resources.
+/// 
+/// The base URL can be overridden using the `FONT_API_SERVER`
+/// environment variable.
+///
+/// When specifying using the environment variable set it in the Flutter tool
+/// using the `--dart-define` option. The value must end with a `/`.
+///
+/// Example:
+///
+/// ```
+/// flutter run \
+///   -d chrome \
+///   --web-renderer=canvaskit \
+///   --dart-define=FONT_API_SERVER=https://example.com/
+/// ```
 const String defaultFontServerUrl = String.fromEnvironment(
   'FONT_API_SERVER',
   defaultValue: 'https://fonts.googleapis.com/',

--- a/lib/web_ui/lib/src/engine/canvaskit/font_fallbacks.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/font_fallbacks.dart
@@ -18,14 +18,14 @@ import 'initialization.dart';
 import 'interval_tree.dart';
 
 
-// Runtime parameters.
+// Compile time parameters.
 
 /// The URL to use when downloading the font resources.
 /// 
 /// The base URL can be overridden using the `FONT_API_SERVER`
 /// environment variable.
 ///
-/// When specifying using the environment variable set it in the Flutter tool
+/// The environment variable can be set in the Flutter tool
 /// using the `--dart-define` option. The value must end with a `/`.
 ///
 /// Example:
@@ -36,7 +36,7 @@ import 'interval_tree.dart';
 ///   --web-renderer=canvaskit \
 ///   --dart-define=FONT_API_SERVER=https://example.com/
 /// ```
-const String defaultFontServerUrl = String.fromEnvironment(
+const String fontServerBaseUrl = String.fromEnvironment(
   'FONT_API_SERVER',
   defaultValue: 'https://fonts.googleapis.com/',
 );
@@ -452,9 +452,9 @@ Future<void> _registerSymbolsAndEmoji() async {
   }
   data.registeredSymbolsAndEmoji = true;
   const String emojiUrl =
-      '${defaultFontServerUrl}css2?family=Noto+Color+Emoji+Compat';
+      '${fontServerBaseUrl}css2?family=Noto+Color+Emoji+Compat';
   const String symbolsUrl =
-      '${defaultFontServerUrl}css2?family=Noto+Sans+Symbols';
+      '${fontServerBaseUrl}css2?family=Noto+Sans+Symbols';
 
   final String emojiCss =
       await notoDownloadQueue.downloader.downloadAsString(emojiUrl);
@@ -583,7 +583,7 @@ class NotoFont {
   NotoFont(this.name, this.approximateUnicodeRanges);
 
   String get googleFontsCssUrl =>
-      '${defaultFontServerUrl}css2?family=${name.replaceAll(' ', '+')}';
+      '${fontServerBaseUrl}css2?family=${Uri.encodeQueryComponent(name)}';
 
   Future<void> ensureResolved() async {
     if (resolvedFont == null) {

--- a/lib/web_ui/lib/src/engine/canvaskit/font_fallbacks.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/font_fallbacks.dart
@@ -17,6 +17,31 @@ import 'fonts.dart';
 import 'initialization.dart';
 import 'interval_tree.dart';
 
+
+// Runtime parameters.
+
+// The URL to use when downloading the font resources.
+// 
+// The base URL can be overridden using the `FONT_API_SERVER`
+// environment variable.
+//
+// When specifying using the environment variable set it in the Flutter tool
+// using the `--dart-define` option. The value must end with a `/`.
+//
+// Example:
+//
+// ```
+// flutter run \
+//   -d chrome \
+//   --web-renderer=canvaskit \
+//   --dart-define=FONT_API_SERVER=https://example.com/
+// ```
+const String defaultFontServerUrl = String.fromEnvironment(
+  'FONT_API_SERVER',
+  defaultValue: 'https://fonts.googleapis.com/',
+);
+
+
 /// Global static font fallback data.
 class FontFallbackData {
   static FontFallbackData get instance => _instance;
@@ -427,9 +452,9 @@ Future<void> _registerSymbolsAndEmoji() async {
   }
   data.registeredSymbolsAndEmoji = true;
   const String emojiUrl =
-      'https://fonts.googleapis.com/css2?family=Noto+Color+Emoji+Compat';
+      '${defaultFontServerUrl}css2?family=Noto+Color+Emoji+Compat';
   const String symbolsUrl =
-      'https://fonts.googleapis.com/css2?family=Noto+Sans+Symbols';
+      '${defaultFontServerUrl}css2?family=Noto+Sans+Symbols';
 
   final String emojiCss =
       await notoDownloadQueue.downloader.downloadAsString(emojiUrl);
@@ -558,7 +583,7 @@ class NotoFont {
   NotoFont(this.name, this.approximateUnicodeRanges);
 
   String get googleFontsCssUrl =>
-      'https://fonts.googleapis.com/css2?family=${name.replaceAll(' ', '+')}';
+      '${defaultFontServerUrl}css2?family=${name.replaceAll(' ', '+')}';
 
   Future<void> ensureResolved() async {
     if (resolvedFont == null) {

--- a/lib/web_ui/lib/src/engine/canvaskit/fonts.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/fonts.dart
@@ -13,26 +13,26 @@ import 'font_fallbacks.dart';
 
 // Runtime parameters.
 //
-// This URL was found by using the Google Fonts Developer API to find the URL
-// for Roboto. The API warns that this URL is not stable. In order to update
-// this, list out all of the fonts and find the URL for the regular
-// Roboto font. The API reference is here:
-// https://developers.google.com/fonts/docs/developer_api
-//
-// The base URL can be overridden using the `ROBOTO_FONT_URL`
-// environment variable.
-//
-// When specifying using the environment variable set it in the Flutter tool
-// using the `--dart-define` option.
-//
-// Example:
-//
-// ```
-// flutter run \
-//   -d chrome \
-//   --web-renderer=canvaskit \
-//   --dart-define=ROBOTO_FONT_URL=https://example.com/roboto.ttf
-// ```
+/// This URL was found by using the Google Fonts Developer API to find the URL
+/// for Roboto. The API warns that this URL is not stable. In order to update
+/// this, list out all of the fonts and find the URL for the regular
+/// Roboto font. The API reference is here:
+/// https://developers.google.com/fonts/docs/developer_api
+///
+/// The base URL can be overridden using the `ROBOTO_FONT_URL`
+/// environment variable.
+///
+/// When specifying using the environment variable set it in the Flutter tool
+/// using the `--dart-define` option.
+///
+/// Example:
+///
+/// ```
+/// flutter run \
+///   -d chrome \
+///   --web-renderer=canvaskit \
+///   --dart-define=ROBOTO_FONT_URL=https://example.com/roboto.ttf
+/// ```
 const String _robotoUrl = String.fromEnvironment(
   'ROBOTO_FONT_URL',
   defaultValue: 'https://fonts.gstatic.com/s/roboto/v20/KFOmCnqEu92Fr1Me5WZLCzYlKw.ttf',

--- a/lib/web_ui/lib/src/engine/canvaskit/fonts.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/fonts.dart
@@ -11,13 +11,32 @@ import '../util.dart';
 import 'canvaskit_api.dart';
 import 'font_fallbacks.dart';
 
+// Runtime parameters.
+//
 // This URL was found by using the Google Fonts Developer API to find the URL
 // for Roboto. The API warns that this URL is not stable. In order to update
 // this, list out all of the fonts and find the URL for the regular
 // Roboto font. The API reference is here:
 // https://developers.google.com/fonts/docs/developer_api
-const String _robotoUrl =
-    'https://fonts.gstatic.com/s/roboto/v20/KFOmCnqEu92Fr1Me5WZLCzYlKw.ttf';
+//
+// The base URL can be overridden using the `ROBOTO_FONT_URL`
+// environment variable.
+//
+// When specifying using the environment variable set it in the Flutter tool
+// using the `--dart-define` option.
+//
+// Example:
+//
+// ```
+// flutter run \
+//   -d chrome \
+//   --web-renderer=canvaskit \
+//   --dart-define=ROBOTO_FONT_URL=https://example.com/roboto.ttf
+// ```
+const String _robotoUrl = String.fromEnvironment(
+  'ROBOTO_FONT_URL',
+  defaultValue: 'https://fonts.gstatic.com/s/roboto/v20/KFOmCnqEu92Fr1Me5WZLCzYlKw.ttf',
+);
 
 // URL for the Ahem font, only used in tests.
 const String _ahemUrl = '/assets/fonts/ahem.ttf';

--- a/lib/web_ui/lib/src/engine/canvaskit/fonts.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/fonts.dart
@@ -12,17 +12,17 @@ import 'canvaskit_api.dart';
 import 'font_fallbacks.dart';
 
 // Runtime parameters.
-//
-/// This URL was found by using the Google Fonts Developer API to find the URL
-/// for Roboto. The API warns that this URL is not stable. In order to update
-/// this, list out all of the fonts and find the URL for the regular
-/// Roboto font. The API reference is here:
-/// https://developers.google.com/fonts/docs/developer_api
+// The API warns that this URL is not stable. In order to update
+// this, list out all of the fonts and find the URL for the regular
+// Roboto font. The API reference is here:
+// https://developers.google.com/fonts/docs/developer_api
+
+/// This URL was found by using the Google Fonts Developer API to find the URL for Roboto.
 ///
-/// The base URL can be overridden using the `ROBOTO_FONT_URL`
+/// The URL can be overridden using the `ROBOTO_FONT_URL`
 /// environment variable.
 ///
-/// When specifying using the environment variable set it in the Flutter tool
+/// The environment variable can be set in the Flutter tool
 /// using the `--dart-define` option.
 ///
 /// Example:
@@ -33,7 +33,7 @@ import 'font_fallbacks.dart';
 ///   --web-renderer=canvaskit \
 ///   --dart-define=ROBOTO_FONT_URL=https://example.com/roboto.ttf
 /// ```
-const String _robotoUrl = String.fromEnvironment(
+const String robotoUrl = String.fromEnvironment(
   'ROBOTO_FONT_URL',
   defaultValue: 'https://fonts.gstatic.com/s/roboto/v20/KFOmCnqEu92Fr1Me5WZLCzYlKw.ttf',
 );
@@ -158,7 +158,7 @@ class SkiaFontCollection {
     /// Roboto to match Android.
     if (!registeredRoboto) {
       // Download Roboto and add it to the font buffers.
-      _unloadedFonts.add(_registerFont(_robotoUrl, 'Roboto'));
+      _unloadedFonts.add(_registerFont(robotoUrl, 'Roboto'));
     }
   }
 


### PR DESCRIPTION
### issue
https://github.com/flutter/flutter/issues/94404

### Description
Because of [GWF](https://en.wikipedia.org/wiki/Great_Firewall), Chinese users cannot access Google services normally, Flutter needs to provide proxy configuration to access google font.

### Use examples
`
flutter build web --web-renderer=canvaskit --release --dart-define=FONT_API_SERVER="https://fonts.loli.net/" --dart-define=ROBOTO_FONT_URL="https://gstatic.loli.net/s/roboto/v20/KFOmCnqEu92Fr1Me5WZLCzYlKw.ttf"
`
- environment variable FONT_API_SERVER: Font api server, default value is `https://fonts.googleapis.com/`
- environment variable ROBOTO_FONT_URL: Roboto font url, default value is `https://fonts.gstatic.com/s/roboto/v20/KFOmCnqEu92Fr1Me5WZLCzYlKw.ttf`

### Result
- Font api: ![font api](https://user-images.githubusercontent.com/5383506/144019423-33d681fe-cc1f-46fe-8d20-ec101bc8c3e7.jpg)
- Get roboto font: ![get roboto font](https://user-images.githubusercontent.com/5383506/144019483-c11064ea-b920-40e3-be39-ce0c5f2f54ac.jpg)


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.