### PR TITLE
[macOS] MacOS Keyboard properly handles multi-char characters

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterEmbedderKeyResponder.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEmbedderKeyResponder.mm
@@ -109,7 +109,7 @@ static uint64_t toLower(uint64_t n) {
 //
 // See https://en.wikipedia.org/wiki/UTF-16#Description for the algorithm.
 //
-// The returned character array must be cleared with delete[]. The length of
+// The returned character array must be deallocated with delete[]. The length of
 // the result is stored in `out_length`.
 //
 // Although NSString has a dataUsingEncoding method, we implement our own

--- a/shell/platform/darwin/macos/framework/Source/FlutterEmbedderKeyResponder.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEmbedderKeyResponder.mm
@@ -125,10 +125,10 @@ static uint32_t* DecodeUtf16(NSString* target, size_t* out_length) {
     if (codeUnit <= 0xD7FF || codeUnit >= 0xE000) {
       result[result_pos] = codeUnit;
       result_pos += 1;
-    // High surrogates
+      // High surrogates
     } else if (codeUnit <= 0xDBFF) {
       high_surrogate = codeUnit - 0xD800;
-    // Low surrogates
+      // Low surrogates
     } else {
       uint16_t low_surrogate = codeUnit - 0xDC00;
       result[result_pos] = (high_surrogate << 10) + low_surrogate + 0x10000;

--- a/shell/platform/darwin/macos/framework/Source/FlutterEmbedderKeyResponder.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEmbedderKeyResponder.mm
@@ -107,9 +107,13 @@ static uint64_t toLower(uint64_t n) {
 
 // Decode a UTF-16 sequence to an array of char32 (UTF-32).
 //
-// The returned character array must be cleared using delete[].
+// See https://en.wikipedia.org/wiki/UTF-16#Description for the algorithm.
 //
-// See https://en.wikipedia.org/wiki/UTF-16#Description.
+// The returned character array must be cleared with delete[]. The length of
+// the result is stored in `out_length`.
+//
+// Although NSString has a dataUsingEncoding method, we implement our own
+// because dataUsingEncoding outputs redundant characters for unknown reasons.
 static uint32_t* DecodeUtf16(NSString* target, size_t* out_length) {
   // The result always has a length less or equal to target.
   size_t result_pos = 0;

--- a/shell/platform/darwin/macos/framework/Source/FlutterEmbedderKeyResponderUnittests.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEmbedderKeyResponderUnittests.mm
@@ -265,6 +265,49 @@ TEST(FlutterEmbedderKeyResponderUnittests, NonAsciiCharacters) {
   [events removeAllObjects];
 }
 
+TEST(FlutterEmbedderKeyResponderUnittests, MultipleCharacters) {
+  __block NSMutableArray<TestKeyEvent*>* events = [[NSMutableArray<TestKeyEvent*> alloc] init];
+  FlutterKeyEvent* event;
+
+  FlutterEmbedderKeyResponder* responder = [[FlutterEmbedderKeyResponder alloc]
+      initWithSendEvent:^(const FlutterKeyEvent& event, _Nullable FlutterKeyEventCallback callback,
+                          _Nullable _VoidPtr user_data) {
+        [events addObject:[[TestKeyEvent alloc] initWithEvent:&event
+                                                     callback:callback
+                                                     userData:user_data]];
+      }];
+
+  [responder
+      handleEvent:keyEvent(NSEventTypeKeyDown, 100, @"àn", @"àn", FALSE, kKeyCodeKeyA)
+         callback:^(BOOL handled){
+         }];
+
+  EXPECT_EQ([events count], 1u);
+  event = [events lastObject].data;
+  EXPECT_EQ(event->type, kFlutterKeyEventTypeDown);
+  EXPECT_EQ(event->physical, kPhysicalKeyA);
+  EXPECT_EQ(event->logical, kLogicalAltRight);
+  EXPECT_STREQ(event->character, "àn");
+  EXPECT_EQ(event->synthesized, false);
+
+  [events removeAllObjects];
+
+  [responder
+      handleEvent:keyEvent(NSEventTypeKeyUp, 100, @"a", @"a", FALSE, kKeyCodeKeyA)
+         callback:^(BOOL handled){
+         }];
+
+  EXPECT_EQ([events count], 1u);
+  event = [events lastObject].data;
+  EXPECT_EQ(event->type, kFlutterKeyEventTypeUp);
+  EXPECT_EQ(event->physical, kPhysicalKeyA);
+  EXPECT_EQ(event->logical, kLogicalKeyW);
+  EXPECT_STREQ(event->character, nullptr);
+  EXPECT_EQ(event->synthesized, false);
+
+  [events removeAllObjects];
+}
+
 TEST(FlutterEmbedderKeyResponderUnittests, IgnoreDuplicateDownEvent) {
   __block NSMutableArray<TestKeyEvent*>* events = [[NSMutableArray<TestKeyEvent*> alloc] init];
   __block BOOL last_handled = TRUE;

--- a/shell/platform/darwin/macos/framework/Source/FlutterEmbedderKeyResponderUnittests.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEmbedderKeyResponderUnittests.mm
@@ -277,10 +277,9 @@ TEST(FlutterEmbedderKeyResponderUnittests, MultipleCharacters) {
                                                      userData:user_data]];
       }];
 
-  [responder
-      handleEvent:keyEvent(NSEventTypeKeyDown, 0, @"àn", @"àn", FALSE, kKeyCodeKeyA)
-         callback:^(BOOL handled){
-         }];
+  [responder handleEvent:keyEvent(NSEventTypeKeyDown, 0, @"àn", @"àn", FALSE, kKeyCodeKeyA)
+                callback:^(BOOL handled){
+                }];
 
   EXPECT_EQ([events count], 1u);
   event = [events lastObject].data;
@@ -292,10 +291,9 @@ TEST(FlutterEmbedderKeyResponderUnittests, MultipleCharacters) {
 
   [events removeAllObjects];
 
-  [responder
-      handleEvent:keyEvent(NSEventTypeKeyUp, 0, @"a", @"a", FALSE, kKeyCodeKeyA)
-         callback:^(BOOL handled){
-         }];
+  [responder handleEvent:keyEvent(NSEventTypeKeyUp, 0, @"a", @"a", FALSE, kKeyCodeKeyA)
+                callback:^(BOOL handled){
+                }];
 
   EXPECT_EQ([events count], 1u);
   event = [events lastObject].data;

--- a/shell/platform/darwin/macos/framework/Source/FlutterEmbedderKeyResponderUnittests.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEmbedderKeyResponderUnittests.mm
@@ -278,7 +278,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, MultipleCharacters) {
       }];
 
   [responder
-      handleEvent:keyEvent(NSEventTypeKeyDown, 100, @"àn", @"àn", FALSE, kKeyCodeKeyA)
+      handleEvent:keyEvent(NSEventTypeKeyDown, 0, @"àn", @"àn", FALSE, kKeyCodeKeyA)
          callback:^(BOOL handled){
          }];
 
@@ -286,14 +286,14 @@ TEST(FlutterEmbedderKeyResponderUnittests, MultipleCharacters) {
   event = [events lastObject].data;
   EXPECT_EQ(event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(event->physical, kPhysicalKeyA);
-  EXPECT_EQ(event->logical, kLogicalAltRight);
+  EXPECT_EQ(event->logical, 0x1400000000ull);
   EXPECT_STREQ(event->character, "àn");
   EXPECT_EQ(event->synthesized, false);
 
   [events removeAllObjects];
 
   [responder
-      handleEvent:keyEvent(NSEventTypeKeyUp, 100, @"a", @"a", FALSE, kKeyCodeKeyA)
+      handleEvent:keyEvent(NSEventTypeKeyUp, 0, @"a", @"a", FALSE, kKeyCodeKeyA)
          callback:^(BOOL handled){
          }];
 
@@ -301,7 +301,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, MultipleCharacters) {
   event = [events lastObject].data;
   EXPECT_EQ(event->type, kFlutterKeyEventTypeUp);
   EXPECT_EQ(event->physical, kPhysicalKeyA);
-  EXPECT_EQ(event->logical, kLogicalKeyW);
+  EXPECT_EQ(event->logical, 0x1400000000ull);
   EXPECT_STREQ(event->character, nullptr);
   EXPECT_EQ(event->synthesized, false);
 


### PR DESCRIPTION
This PR changes the logicalKey value of a KeyEvent that has a multi-char character.

For detailed explanation, see https://github.com/flutter/flutter/pull/94432.

This fixes the macOS-embedder part of #82673.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
