### PR TITLE
Migrate sk_cf_obj to sk_cfp

### DIFF
--- a/shell/platform/darwin/graphics/FlutterDarwinExternalTextureMetal.mm
+++ b/shell/platform/darwin/graphics/FlutterDarwinExternalTextureMetal.mm
@@ -230,7 +230,7 @@ FLUTTER_ASSERT_ARC
                             width:(size_t)width
                            height:(size_t)height {
   GrMtlTextureInfo ySkiaTextureInfo;
-  ySkiaTextureInfo.fTexture = sk_cf_obj<const void*>{(__bridge_retained const void*)yTex};
+  ySkiaTextureInfo.fTexture = sk_cfp<const void*>{(__bridge_retained const void*)yTex};
 
   GrBackendTexture skiaBackendTextures[2];
   skiaBackendTextures[0] = GrBackendTexture(/*width=*/width,
@@ -239,7 +239,7 @@ FLUTTER_ASSERT_ARC
                                             /*textureInfo=*/ySkiaTextureInfo);
 
   GrMtlTextureInfo uvSkiaTextureInfo;
-  uvSkiaTextureInfo.fTexture = sk_cf_obj<const void*>{(__bridge_retained const void*)uvTex};
+  uvSkiaTextureInfo.fTexture = sk_cfp<const void*>{(__bridge_retained const void*)uvTex};
 
   skiaBackendTextures[1] = GrBackendTexture(/*width=*/width,
                                             /*height=*/height,
@@ -259,7 +259,7 @@ FLUTTER_ASSERT_ARC
                             width:(size_t)width
                            height:(size_t)height {
   GrMtlTextureInfo skiaTextureInfo;
-  skiaTextureInfo.fTexture = sk_cf_obj<const void*>{(__bridge_retained const void*)rgbaTex};
+  skiaTextureInfo.fTexture = sk_cfp<const void*>{(__bridge_retained const void*)rgbaTex};
 
   GrBackendTexture skiaBackendTexture(/*width=*/width,
                                       /*height=*/height,

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -589,7 +589,7 @@ static sk_sp<SkSurface> MakeSkSurfaceFromBackingStore(
     FML_LOG(ERROR) << "Embedder supplied null Metal texture.";
     return nullptr;
   }
-  sk_cf_obj<FlutterMetalTextureHandle> mtl_texture;
+  sk_cfp<FlutterMetalTextureHandle> mtl_texture;
   mtl_texture.retain(metal->texture.texture);
   texture_info.fTexture = mtl_texture;
   GrBackendTexture backend_texture(config.size.width,   //

--- a/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
+++ b/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
@@ -197,7 +197,7 @@ bool EmbedderTestBackingStoreProducer::CreateMTLTexture(
   // own MTLTexture and wrapping it.
   auto surface_size = SkISize::Make(config->size.width, config->size.height);
   auto texture_info = test_metal_context_->CreateMetalTexture(surface_size);
-  sk_cf_obj<FlutterMetalTextureHandle> texture;
+  sk_cfp<FlutterMetalTextureHandle> texture;
   texture.retain(texture_info.texture);
 
   GrMtlTextureInfo skia_texture_info;

--- a/testing/test_metal_context.h
+++ b/testing/test_metal_context.h
@@ -42,8 +42,8 @@ class TestMetalContext {
   void* command_queue_;
   sk_sp<GrDirectContext> skia_context_;
   std::mutex textures_mutex;
-  int64_t texture_id_ctr_ = 1;                    // guarded by textures_mutex
-  std::map<int64_t, sk_cf_obj<void*>> textures_;  // guarded by textures_mutex
+  int64_t texture_id_ctr_ = 1;                 // guarded by textures_mutex
+  std::map<int64_t, sk_cfp<void*>> textures_;  // guarded by textures_mutex
 };
 
 }  // namespace flutter

--- a/testing/test_metal_context.mm
+++ b/testing/test_metal_context.mm
@@ -82,8 +82,8 @@ TestMetalContext::TextureInfo TestMetalContext::CreateMetalTexture(const SkISize
   }
 
   id<MTLDevice> device = (__bridge id<MTLDevice>)GetMetalDevice();
-  sk_cf_obj<void*> texture =
-      sk_cf_obj<void*>{[[device newTextureWithDescriptor:texture_descriptor.get()] retain]};
+  sk_cfp<void*> texture =
+      sk_cfp<void*>{[[device newTextureWithDescriptor:texture_descriptor.get()] retain]};
 
   if (!texture) {
     FML_CHECK(false) << "Could not create texture from texture descriptor.";


### PR DESCRIPTION
It seems that `sk_cf_obj` is deprecated. So I guess we neet to migrate `sk_cf_obj` to `sk_cfp`
detail: https://github.com/google/skia/blob/1f193df9b393d50da39570dab77a0bb5d28ec8ef/include/ports/SkCFObject.h#L176

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
