### PR TITLE
[fuchsia] Change Touch priority to YES

### DIFF
--- a/shell/platform/fuchsia/flutter/pointer_delegate.cc
+++ b/shell/platform/fuchsia/flutter/pointer_delegate.cc
@@ -356,7 +356,7 @@ void PointerDelegate::WatchLoop(
           InsertIntoBuffer(std::move(events), &to_client);
         }
         // For this simple client, always claim we want the gesture.
-        response.set_response_type(fup_TouchResponseType::YES_PRIORITIZE);
+        response.set_response_type(fup_TouchResponseType::YES);
       }
       if (event.has_interaction_result()) {
         const auto& result = event.interaction_result();

--- a/shell/platform/fuchsia/flutter/pointer_delegate_unittests.cc
+++ b/shell/platform/fuchsia/flutter/pointer_delegate_unittests.cc
@@ -343,14 +343,11 @@ TEST_F(PointerDelegateTest, Protocol_ResponseMatchesEarlierEvents) {
   EXPECT_FALSE(responses.value()[0].has_response_type());
   // Events 1-3 had a sample, must have a response.
   EXPECT_TRUE(responses.value()[1].has_response_type());
-  EXPECT_EQ(responses.value()[1].response_type(),
-            fup_TouchResponseType::YES_PRIORITIZE);
+  EXPECT_EQ(responses.value()[1].response_type(), fup_TouchResponseType::YES);
   EXPECT_TRUE(responses.value()[2].has_response_type());
-  EXPECT_EQ(responses.value()[2].response_type(),
-            fup_TouchResponseType::YES_PRIORITIZE);
+  EXPECT_EQ(responses.value()[2].response_type(), fup_TouchResponseType::YES);
   EXPECT_TRUE(responses.value()[3].has_response_type());
-  EXPECT_EQ(responses.value()[3].response_type(),
-            fup_TouchResponseType::YES_PRIORITIZE);
+  EXPECT_EQ(responses.value()[3].response_type(), fup_TouchResponseType::YES);
 }
 
 TEST_F(PointerDelegateTest, Protocol_LateGrant) {


### PR DESCRIPTION
This CL changes priority to YES so that the children can receive Touch events.

Bug: https://bugs.fuchsia.dev/p/fuchsia/issues/detail?id=89541