### PR TITLE
Revert "Roll web_installers simulators package"

### DIFF
--- a/lib/web_ui/pubspec.yaml
+++ b/lib/web_ui/pubspec.yaml
@@ -27,4 +27,4 @@ dev_dependencies:
     git:
       url: https://github.com/flutter/web_installers.git
       path: packages/simulators/
-      ref: 9afed28b771da1c4e82a3382c4a2b31344c04522
+      ref: 4a7b0a2c84b8993bf4d19030218de38c18838c26


### PR DESCRIPTION
Reverts flutter/engine#30035

This looks like it might be causing a simulator error in the latest engine rolls, as seen in:
https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8828997122017962129/+/u/run_module_test_ios/test_stdout