### PR TITLE
Update buildroot to pick up Xcode macOS SDK parsing

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -99,7 +99,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '42be4395efc85e455bbdd555ef2791615338dbea',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '97e127ae7ef2052f7a684d3f7fb688a75c9d11ab',
 
    # Fuchsia compatibility
    #

--- a/DEPS
+++ b/DEPS
@@ -99,7 +99,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '97e127ae7ef2052f7a684d3f7fb688a75c9d11ab',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '6b40830418375475f7ad8ede1b8a3a7a66928040',
 
    # Fuchsia compatibility
    #

--- a/DEPS
+++ b/DEPS
@@ -99,7 +99,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '6b40830418375475f7ad8ede1b8a3a7a66928040',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '36609df73b63e5ed0064240f302c445188ed902e',
 
    # Fuchsia compatibility
    #


### PR DESCRIPTION
Roll buildroot to https://github.com/flutter/buildroot/pull/528 and https://github.com/flutter/buildroot/pull/530 and https://github.com/flutter/buildroot/pull/531 so Xcode macOS SDKs are fetched from Xcode instead of path parsed.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
