### PR TITLE
VSyncWaiter on Fuchsia will defer firing until frame start time (#29287)

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1449,6 +1449,7 @@ FILE: ../../../flutter/shell/platform/fuchsia/flutter/thread.h
 FILE: ../../../flutter/shell/platform/fuchsia/flutter/unique_fdio_ns.h
 FILE: ../../../flutter/shell/platform/fuchsia/flutter/vsync_waiter.cc
 FILE: ../../../flutter/shell/platform/fuchsia/flutter/vsync_waiter.h
+FILE: ../../../flutter/shell/platform/fuchsia/flutter/vsync_waiter_unittest.cc
 FILE: ../../../flutter/shell/platform/fuchsia/flutter/vulkan_surface.cc
 FILE: ../../../flutter/shell/platform/fuchsia/flutter/vulkan_surface.h
 FILE: ../../../flutter/shell/platform/fuchsia/flutter/vulkan_surface_pool.cc

--- a/shell/platform/fuchsia/flutter/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/BUILD.gn
@@ -449,6 +449,7 @@ executable("flutter_runner_unittests") {
     "tests/engine_unittests.cc",
     "tests/flutter_runner_product_configuration_unittests.cc",
     "tests/gfx_session_connection_unittests.cc",
+    "vsync_waiter_unittest.cc",
   ]
 
   # This is needed for //third_party/googletest for linking zircon symbols.

--- a/shell/platform/fuchsia/flutter/vsync_waiter.h
+++ b/shell/platform/fuchsia/flutter/vsync_waiter.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_FUCHSIA_VSYNC_WAITER_H_
-#define FLUTTER_SHELL_PLATFORM_FUCHSIA_VSYNC_WAITER_H_
+#ifndef FLUTTER_SHELL_PLATFORM_FUCHSIA_FLUTTER_VSYNC_WAITER_H_
+#define FLUTTER_SHELL_PLATFORM_FUCHSIA_FLUTTER_VSYNC_WAITER_H_
 
 #include <lib/async/cpp/wait.h>
 
@@ -46,6 +46,7 @@ class VsyncWaiter final : public flutter::VsyncWaiter {
   AwaitVsyncForSecondaryCallbackCallback
       await_vsync_for_secondary_callback_callback_;
 
+  fml::WeakPtr<VsyncWaiter> weak_ui_;
   std::unique_ptr<fml::WeakPtrFactory<VsyncWaiter>> weak_factory_ui_;
   fml::WeakPtrFactory<VsyncWaiter> weak_factory_;
 
@@ -54,4 +55,4 @@ class VsyncWaiter final : public flutter::VsyncWaiter {
 
 }  // namespace flutter_runner
 
-#endif  // FLUTTER_SHELL_PLATFORM_FUCHSIA_VSYNC_WAITER_H_
+#endif  // FLUTTER_SHELL_PLATFORM_FUCHSIA_FLUTTER_VSYNC_WAITER_H_

--- a/shell/platform/fuchsia/flutter/vsync_waiter_unittest.cc
+++ b/shell/platform/fuchsia/flutter/vsync_waiter_unittest.cc
@@ -1,0 +1,62 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "flutter/fml/task_runner.h"
+#include "flutter/shell/common/thread_host.h"
+#include "fml/make_copyable.h"
+#include "fml/message_loop.h"
+#include "fml/synchronization/waitable_event.h"
+#include "fml/time/time_delta.h"
+#include "fml/time/time_point.h"
+#include "vsync_waiter.h"
+
+namespace flutter_runner {
+
+TEST(VSyncWaiterFuchsia, FrameScheduledForStartTime) {
+  using flutter::ThreadHost;
+  std::string prefix = "vsync_waiter_test";
+
+  fml::MessageLoop::EnsureInitializedForCurrentThread();
+
+  ThreadHost thread_host = ThreadHost(
+      prefix,
+      flutter::ThreadHost::Type::RASTER | flutter::ThreadHost::Type::UI |
+          flutter::ThreadHost::Type::IO | flutter::ThreadHost::Type::Platform);
+  const flutter::TaskRunners task_runners(
+      prefix,                                       // Dart thread labels
+      thread_host.raster_thread->GetTaskRunner(),   // raster
+      thread_host.ui_thread->GetTaskRunner(),       // ui
+      thread_host.io_thread->GetTaskRunner(),       // io
+      thread_host.platform_thread->GetTaskRunner()  // platform
+  );
+
+  // await vsync will invoke the callback right away, but vsync waiter will post
+  // the task for frame_start time.
+  VsyncWaiter vsync_waiter(
+      [](FireCallbackCallback callback) {
+        const auto now = fml::TimePoint::Now();
+        const auto frame_start = now + fml::TimeDelta::FromMilliseconds(20);
+        const auto frame_end = now + fml::TimeDelta::FromMilliseconds(36);
+        callback(frame_start, frame_end);
+      },
+      /*secondary callback*/ nullptr, task_runners);
+
+  fml::AutoResetWaitableEvent latch;
+  task_runners.GetUITaskRunner()->PostTask([&]() {
+    vsync_waiter.AsyncWaitForVsync(
+        [&](std::unique_ptr<flutter::FrameTimingsRecorder> recorder) {
+          const auto now = fml::TimePoint::Now();
+          EXPECT_GT(now, recorder->GetVsyncStartTime());
+          latch.Signal();
+        });
+  });
+
+  latch.Wait();
+}
+
+}  // namespace flutter_runner


### PR DESCRIPTION
* VSyncWaiter on Fuchsia will defer firing until frame start time

The common vsync waiter implementation expects this invariant to be
held.

* Add a test for vsync_waiter

Original bug: b/208443497
CP request: b/208711800