### PR TITLE
[Windows keyboard] Remove redundant parameter FlutterWindowsView

### DIFF
--- a/shell/platform/windows/flutter_window_win32_unittests.cc
+++ b/shell/platform/windows/flutter_window_win32_unittests.cc
@@ -55,8 +55,7 @@ class SpyKeyboardKeyHandler : public KeyboardHandlerBase {
                     char32_t character,
                     bool extended,
                     bool was_down));
-  MOCK_METHOD1(TextHook,
-               void(const std::u16string& text));
+  MOCK_METHOD1(TextHook, void(const std::u16string& text));
   MOCK_METHOD0(ComposeBeginHook, void());
   MOCK_METHOD0(ComposeCommitHook, void());
   MOCK_METHOD0(ComposeEndHook, void());
@@ -89,8 +88,7 @@ class SpyTextInputPlugin : public KeyboardHandlerBase,
                     char32_t character,
                     bool extended,
                     bool was_down));
-  MOCK_METHOD1(TextHook,
-               void(const std::u16string& text));
+  MOCK_METHOD1(TextHook, void(const std::u16string& text));
   MOCK_METHOD0(ComposeBeginHook, void());
   MOCK_METHOD0(ComposeCommitHook, void());
   MOCK_METHOD0(ComposeEndHook, void());
@@ -361,10 +359,8 @@ TEST(FlutterWindowWin32Test, NonPrintableKeyDownPropagation) {
                 KeyboardHook(_, _, _, _, _, _))
         .Times(1)
         .RetiresOnSaturation();
-    EXPECT_CALL(*flutter_windows_view.key_event_handler, TextHook(_))
-        .Times(0);
-    EXPECT_CALL(*flutter_windows_view.text_input_plugin, TextHook(_))
-        .Times(0);
+    EXPECT_CALL(*flutter_windows_view.key_event_handler, TextHook(_)).Times(0);
+    EXPECT_CALL(*flutter_windows_view.text_input_plugin, TextHook(_)).Times(0);
     win32window.InjectMessages(1,
                                Win32Message{WM_KEYDOWN, virtual_key, lparam});
     flutter_windows_view.InjectPendingEvents(&win32window);
@@ -408,18 +404,16 @@ TEST(FlutterWindowWin32Test, SystemKeyDownPropagation) {
     test_response = false;
     flutter_windows_view.SetEngine(std::move(GetTestEngine()));
     EXPECT_CALL(*flutter_windows_view.key_event_handler,
-                KeyboardHook(virtual_key, scan_code, WM_SYSKEYDOWN,
-                             character, false /* extended */, _))
+                KeyboardHook(virtual_key, scan_code, WM_SYSKEYDOWN, character,
+                             false /* extended */, _))
         .Times(2)
         .RetiresOnSaturation();
     EXPECT_CALL(*flutter_windows_view.text_input_plugin,
                 KeyboardHook(_, _, _, _, _, _))
         .Times(1)
         .RetiresOnSaturation();
-    EXPECT_CALL(*flutter_windows_view.key_event_handler, TextHook(_))
-        .Times(0);
-    EXPECT_CALL(*flutter_windows_view.text_input_plugin, TextHook(_))
-        .Times(0);
+    EXPECT_CALL(*flutter_windows_view.key_event_handler, TextHook(_)).Times(0);
+    EXPECT_CALL(*flutter_windows_view.text_input_plugin, TextHook(_)).Times(0);
     win32window.InjectMessages(
         1, Win32Message{WM_SYSKEYDOWN, virtual_key, lparam, kWmResultDefault});
     flutter_windows_view.InjectPendingEvents(&win32window);
@@ -493,10 +487,8 @@ TEST(FlutterWindowWin32Test, CharKeyDownPropagation) {
     EXPECT_CALL(*flutter_windows_view.text_input_plugin,
                 KeyboardHook(_, _, _, _, _, _))
         .Times(0);
-    EXPECT_CALL(*flutter_windows_view.key_event_handler, TextHook(_))
-        .Times(0);
-    EXPECT_CALL(*flutter_windows_view.text_input_plugin, TextHook(_))
-        .Times(0);
+    EXPECT_CALL(*flutter_windows_view.key_event_handler, TextHook(_)).Times(0);
+    EXPECT_CALL(*flutter_windows_view.text_input_plugin, TextHook(_)).Times(0);
     win32window.InjectMessages(2, Win32Message{WM_KEYDOWN, virtual_key, lparam},
                                Win32Message{WM_CHAR, virtual_key, lparam});
     flutter_windows_view.InjectPendingEvents(&win32window);
@@ -531,10 +523,8 @@ TEST(FlutterWindowWin32Test, ModifierKeyDownPropagation) {
                 KeyboardHook(_, _, _, _, _, _))
         .Times(1)
         .RetiresOnSaturation();
-    EXPECT_CALL(*flutter_windows_view.key_event_handler, TextHook(_))
-        .Times(0);
-    EXPECT_CALL(*flutter_windows_view.text_input_plugin, TextHook(_))
-        .Times(0);
+    EXPECT_CALL(*flutter_windows_view.key_event_handler, TextHook(_)).Times(0);
+    EXPECT_CALL(*flutter_windows_view.text_input_plugin, TextHook(_)).Times(0);
     EXPECT_EQ(win32window.InjectWindowMessage(WM_KEYDOWN, virtual_key, lparam),
               0);
     flutter_windows_view.InjectPendingEvents(&win32window);

--- a/shell/platform/windows/flutter_window_win32_unittests.cc
+++ b/shell/platform/windows/flutter_window_win32_unittests.cc
@@ -40,24 +40,23 @@ class SpyKeyboardKeyHandler : public KeyboardHandlerBase {
         std::make_unique<KeyboardKeyHandler>(redispatch_event);
     real_implementation_->AddDelegate(
         std::make_unique<KeyboardKeyChannelHandler>(messenger));
-    ON_CALL(*this, KeyboardHook(_, _, _, _, _, _, _))
+    ON_CALL(*this, KeyboardHook(_, _, _, _, _, _))
         .WillByDefault(Invoke(real_implementation_.get(),
                               &KeyboardKeyHandler::KeyboardHook));
-    ON_CALL(*this, TextHook(_, _))
+    ON_CALL(*this, TextHook(_))
         .WillByDefault(
             Invoke(real_implementation_.get(), &KeyboardKeyHandler::TextHook));
   }
 
-  MOCK_METHOD7(KeyboardHook,
-               bool(FlutterWindowsView* window,
-                    int key,
+  MOCK_METHOD6(KeyboardHook,
+               bool(int key,
                     int scancode,
                     int action,
                     char32_t character,
                     bool extended,
                     bool was_down));
-  MOCK_METHOD2(TextHook,
-               void(FlutterWindowsView* window, const std::u16string& text));
+  MOCK_METHOD1(TextHook,
+               void(const std::u16string& text));
   MOCK_METHOD0(ComposeBeginHook, void());
   MOCK_METHOD0(ComposeCommitHook, void());
   MOCK_METHOD0(ComposeEndHook, void());
@@ -75,24 +74,23 @@ class SpyTextInputPlugin : public KeyboardHandlerBase,
  public:
   SpyTextInputPlugin(flutter::BinaryMessenger* messenger) {
     real_implementation_ = std::make_unique<TextInputPlugin>(messenger, this);
-    ON_CALL(*this, KeyboardHook(_, _, _, _, _, _, _))
+    ON_CALL(*this, KeyboardHook(_, _, _, _, _, _))
         .WillByDefault(
             Invoke(real_implementation_.get(), &TextInputPlugin::KeyboardHook));
-    ON_CALL(*this, TextHook(_, _))
+    ON_CALL(*this, TextHook(_))
         .WillByDefault(
             Invoke(real_implementation_.get(), &TextInputPlugin::TextHook));
   }
 
-  MOCK_METHOD7(KeyboardHook,
-               bool(FlutterWindowsView* window,
-                    int key,
+  MOCK_METHOD6(KeyboardHook,
+               bool(int key,
                     int scancode,
                     int action,
                     char32_t character,
                     bool extended,
                     bool was_down));
-  MOCK_METHOD2(TextHook,
-               void(FlutterWindowsView* window, const std::u16string& text));
+  MOCK_METHOD1(TextHook,
+               void(const std::u16string& text));
   MOCK_METHOD0(ComposeBeginHook, void());
   MOCK_METHOD0(ComposeCommitHook, void());
   MOCK_METHOD0(ComposeEndHook, void());
@@ -355,17 +353,17 @@ TEST(FlutterWindowWin32Test, NonPrintableKeyDownPropagation) {
     test_response = false;
     flutter_windows_view.SetEngine(std::move(GetTestEngine()));
     EXPECT_CALL(*flutter_windows_view.key_event_handler,
-                KeyboardHook(_, virtual_key, scan_code, WM_KEYDOWN, character,
+                KeyboardHook(virtual_key, scan_code, WM_KEYDOWN, character,
                              false /* extended */, _))
         .Times(2)
         .RetiresOnSaturation();
     EXPECT_CALL(*flutter_windows_view.text_input_plugin,
-                KeyboardHook(_, _, _, _, _, _, _))
+                KeyboardHook(_, _, _, _, _, _))
         .Times(1)
         .RetiresOnSaturation();
-    EXPECT_CALL(*flutter_windows_view.key_event_handler, TextHook(_, _))
+    EXPECT_CALL(*flutter_windows_view.key_event_handler, TextHook(_))
         .Times(0);
-    EXPECT_CALL(*flutter_windows_view.text_input_plugin, TextHook(_, _))
+    EXPECT_CALL(*flutter_windows_view.text_input_plugin, TextHook(_))
         .Times(0);
     win32window.InjectMessages(1,
                                Win32Message{WM_KEYDOWN, virtual_key, lparam});
@@ -376,12 +374,12 @@ TEST(FlutterWindowWin32Test, NonPrintableKeyDownPropagation) {
   {
     test_response = true;
     EXPECT_CALL(*flutter_windows_view.key_event_handler,
-                KeyboardHook(_, virtual_key, scan_code, WM_KEYDOWN, character,
+                KeyboardHook(virtual_key, scan_code, WM_KEYDOWN, character,
                              false /* extended */, false /* PrevState */))
         .Times(1)
         .RetiresOnSaturation();
     EXPECT_CALL(*flutter_windows_view.text_input_plugin,
-                KeyboardHook(_, _, _, _, _, _, _))
+                KeyboardHook(_, _, _, _, _, _))
         .Times(0);
     win32window.InjectMessages(1,
                                Win32Message{WM_KEYDOWN, virtual_key, lparam});
@@ -410,17 +408,17 @@ TEST(FlutterWindowWin32Test, SystemKeyDownPropagation) {
     test_response = false;
     flutter_windows_view.SetEngine(std::move(GetTestEngine()));
     EXPECT_CALL(*flutter_windows_view.key_event_handler,
-                KeyboardHook(_, virtual_key, scan_code, WM_SYSKEYDOWN,
+                KeyboardHook(virtual_key, scan_code, WM_SYSKEYDOWN,
                              character, false /* extended */, _))
         .Times(2)
         .RetiresOnSaturation();
     EXPECT_CALL(*flutter_windows_view.text_input_plugin,
-                KeyboardHook(_, _, _, _, _, _, _))
+                KeyboardHook(_, _, _, _, _, _))
         .Times(1)
         .RetiresOnSaturation();
-    EXPECT_CALL(*flutter_windows_view.key_event_handler, TextHook(_, _))
+    EXPECT_CALL(*flutter_windows_view.key_event_handler, TextHook(_))
         .Times(0);
-    EXPECT_CALL(*flutter_windows_view.text_input_plugin, TextHook(_, _))
+    EXPECT_CALL(*flutter_windows_view.text_input_plugin, TextHook(_))
         .Times(0);
     win32window.InjectMessages(
         1, Win32Message{WM_SYSKEYDOWN, virtual_key, lparam, kWmResultDefault});
@@ -431,10 +429,10 @@ TEST(FlutterWindowWin32Test, SystemKeyDownPropagation) {
   {
     test_response = true;
     EXPECT_CALL(*flutter_windows_view.key_event_handler,
-                KeyboardHook(_, _, _, _, _, _, _))
+                KeyboardHook(_, _, _, _, _, _))
         .Times(0);
     EXPECT_CALL(*flutter_windows_view.text_input_plugin,
-                KeyboardHook(_, _, _, _, _, _, _))
+                KeyboardHook(_, _, _, _, _, _))
         .Times(0);
     win32window.InjectMessages(
         1, Win32Message{WM_SYSKEYDOWN, virtual_key, lparam, kWmResultDefault});
@@ -465,18 +463,18 @@ TEST(FlutterWindowWin32Test, CharKeyDownPropagation) {
   {
     test_response = false;
     EXPECT_CALL(*flutter_windows_view.key_event_handler,
-                KeyboardHook(_, virtual_key, scan_code, WM_KEYDOWN, character,
+                KeyboardHook(virtual_key, scan_code, WM_KEYDOWN, character,
                              false, false))
         .Times(2)
         .RetiresOnSaturation();
     EXPECT_CALL(*flutter_windows_view.text_input_plugin,
-                KeyboardHook(_, _, _, _, _, _, _))
+                KeyboardHook(_, _, _, _, _, _))
         .Times(1)
         .RetiresOnSaturation();
-    EXPECT_CALL(*flutter_windows_view.key_event_handler, TextHook(_, _))
+    EXPECT_CALL(*flutter_windows_view.key_event_handler, TextHook(_))
         .Times(1)
         .RetiresOnSaturation();
-    EXPECT_CALL(*flutter_windows_view.text_input_plugin, TextHook(_, _))
+    EXPECT_CALL(*flutter_windows_view.text_input_plugin, TextHook(_))
         .Times(1)
         .RetiresOnSaturation();
     win32window.InjectMessages(2, Win32Message{WM_KEYDOWN, virtual_key, lparam},
@@ -488,16 +486,16 @@ TEST(FlutterWindowWin32Test, CharKeyDownPropagation) {
   {
     test_response = true;
     EXPECT_CALL(*flutter_windows_view.key_event_handler,
-                KeyboardHook(_, virtual_key, scan_code, WM_KEYDOWN, character,
+                KeyboardHook(virtual_key, scan_code, WM_KEYDOWN, character,
                              false, false))
         .Times(1)
         .RetiresOnSaturation();
     EXPECT_CALL(*flutter_windows_view.text_input_plugin,
-                KeyboardHook(_, _, _, _, _, _, _))
+                KeyboardHook(_, _, _, _, _, _))
         .Times(0);
-    EXPECT_CALL(*flutter_windows_view.key_event_handler, TextHook(_, _))
+    EXPECT_CALL(*flutter_windows_view.key_event_handler, TextHook(_))
         .Times(0);
-    EXPECT_CALL(*flutter_windows_view.text_input_plugin, TextHook(_, _))
+    EXPECT_CALL(*flutter_windows_view.text_input_plugin, TextHook(_))
         .Times(0);
     win32window.InjectMessages(2, Win32Message{WM_KEYDOWN, virtual_key, lparam},
                                Win32Message{WM_CHAR, virtual_key, lparam});
@@ -525,17 +523,17 @@ TEST(FlutterWindowWin32Test, ModifierKeyDownPropagation) {
     test_response = false;
     flutter_windows_view.SetEngine(std::move(GetTestEngine()));
     EXPECT_CALL(*flutter_windows_view.key_event_handler,
-                KeyboardHook(_, virtual_key, scan_code, WM_KEYDOWN, character,
+                KeyboardHook(virtual_key, scan_code, WM_KEYDOWN, character,
                              false /* extended */, false))
         .Times(2)
         .RetiresOnSaturation();
     EXPECT_CALL(*flutter_windows_view.text_input_plugin,
-                KeyboardHook(_, _, _, _, _, _, _))
+                KeyboardHook(_, _, _, _, _, _))
         .Times(1)
         .RetiresOnSaturation();
-    EXPECT_CALL(*flutter_windows_view.key_event_handler, TextHook(_, _))
+    EXPECT_CALL(*flutter_windows_view.key_event_handler, TextHook(_))
         .Times(0);
-    EXPECT_CALL(*flutter_windows_view.text_input_plugin, TextHook(_, _))
+    EXPECT_CALL(*flutter_windows_view.text_input_plugin, TextHook(_))
         .Times(0);
     EXPECT_EQ(win32window.InjectWindowMessage(WM_KEYDOWN, virtual_key, lparam),
               0);
@@ -546,12 +544,12 @@ TEST(FlutterWindowWin32Test, ModifierKeyDownPropagation) {
   {
     test_response = true;
     EXPECT_CALL(*flutter_windows_view.key_event_handler,
-                KeyboardHook(_, virtual_key, scan_code, WM_KEYDOWN, character,
+                KeyboardHook(virtual_key, scan_code, WM_KEYDOWN, character,
                              false /* extended */, false))
         .Times(1)
         .RetiresOnSaturation();
     EXPECT_CALL(*flutter_windows_view.text_input_plugin,
-                KeyboardHook(_, _, _, _, _, _, _))
+                KeyboardHook(_, _, _, _, _, _))
         .Times(0);
     EXPECT_EQ(win32window.InjectWindowMessage(WM_KEYDOWN, virtual_key, lparam),
               0);

--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -382,7 +382,7 @@ void FlutterWindowsView::SendPointerLeave(PointerState* state) {
 
 void FlutterWindowsView::SendText(const std::u16string& text) {
   for (const auto& handler : keyboard_handlers_) {
-    handler->TextHook(this, text);
+    handler->TextHook(text);
   }
 }
 
@@ -393,7 +393,7 @@ bool FlutterWindowsView::SendKey(int key,
                                  bool extended,
                                  bool was_down) {
   for (const auto& handler : keyboard_handlers_) {
-    if (handler->KeyboardHook(this, key, scancode, action, character, extended,
+    if (handler->KeyboardHook(key, scancode, action, character, extended,
                               was_down)) {
       // key event was handled, so don't send to other handlers.
       return true;

--- a/shell/platform/windows/keyboard_handler_base.h
+++ b/shell/platform/windows/keyboard_handler_base.h
@@ -5,13 +5,9 @@
 #ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_KEYBOARD_HOOK_HANDLER_H_
 #define FLUTTER_SHELL_PLATFORM_WINDOWS_KEYBOARD_HOOK_HANDLER_H_
 
-#include "flutter/shell/platform/windows/public/flutter_windows.h"
-
 #include <string>
 
 namespace flutter {
-
-class FlutterWindowsView;
 
 // Interface for classes that handles keyboard input events.
 //
@@ -27,8 +23,7 @@ class KeyboardHandlerBase {
   //
   // Returns true if the key event has been handled, to indicate that other
   // handlers should not be called for this event.
-  virtual bool KeyboardHook(FlutterWindowsView* view,
-                            int key,
+  virtual bool KeyboardHook(int key,
                             int scancode,
                             int action,
                             char32_t character,
@@ -36,8 +31,7 @@ class KeyboardHandlerBase {
                             bool was_down) = 0;
 
   // A function for hooking into Unicode text input.
-  virtual void TextHook(FlutterWindowsView* view,
-                        const std::u16string& text) = 0;
+  virtual void TextHook(const std::u16string& text) = 0;
 
   // Handler for IME compose begin events.
   //

--- a/shell/platform/windows/keyboard_key_handler.cc
+++ b/shell/platform/windows/keyboard_key_handler.cc
@@ -109,8 +109,7 @@ KeyboardKeyHandler::KeyboardKeyHandler(EventDispatcher dispatch_event)
 
 KeyboardKeyHandler::~KeyboardKeyHandler() = default;
 
-void KeyboardKeyHandler::TextHook(FlutterWindowsView* view,
-                                  const std::u16string& code_point) {}
+void KeyboardKeyHandler::TextHook(const std::u16string& code_point) {}
 
 void KeyboardKeyHandler::AddDelegate(
     std::unique_ptr<KeyboardKeyHandlerDelegate> delegate) {
@@ -169,8 +168,7 @@ void KeyboardKeyHandler::RedispatchEvent(std::unique_ptr<PendingEvent> event) {
 #endif
 }
 
-bool KeyboardKeyHandler::KeyboardHook(FlutterWindowsView* view,
-                                      int key,
+bool KeyboardKeyHandler::KeyboardHook(int key,
                                       int scancode,
                                       int action,
                                       char32_t character,

--- a/shell/platform/windows/keyboard_key_handler.h
+++ b/shell/platform/windows/keyboard_key_handler.h
@@ -5,10 +5,10 @@
 #ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_KEYBOARD_KEY_HANDLER_H_
 #define FLUTTER_SHELL_PLATFORM_WINDOWS_KEYBOARD_KEY_HANDLER_H_
 
+#include <windows.h>
 #include <deque>
 #include <memory>
 #include <string>
-#include <windows.h>
 
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/basic_message_channel.h"
 #include "flutter/shell/platform/windows/keyboard_handler_base.h"

--- a/shell/platform/windows/keyboard_key_handler.h
+++ b/shell/platform/windows/keyboard_key_handler.h
@@ -8,16 +8,13 @@
 #include <deque>
 #include <memory>
 #include <string>
+#include <windows.h>
 
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/basic_message_channel.h"
-#include "flutter/shell/platform/common/client_wrapper/include/flutter/binary_messenger.h"
 #include "flutter/shell/platform/windows/keyboard_handler_base.h"
-#include "flutter/shell/platform/windows/public/flutter_windows.h"
 #include "rapidjson/document.h"
 
 namespace flutter {
-
-class FlutterWindowsView;
 
 // Handles key events.
 //
@@ -92,8 +89,7 @@ class KeyboardKeyHandler : public KeyboardHandlerBase {
   // after which the channel delegate should be removed.
   //
   // Inherited from |KeyboardHandlerBase|.
-  bool KeyboardHook(FlutterWindowsView* window,
-                    int key,
+  bool KeyboardHook(int key,
                     int scancode,
                     int action,
                     char32_t character,
@@ -101,8 +97,7 @@ class KeyboardKeyHandler : public KeyboardHandlerBase {
                     bool was_down) override;
 
   // |KeyboardHandlerBase|
-  void TextHook(FlutterWindowsView* window,
-                const std::u16string& text) override;
+  void TextHook(const std::u16string& text) override;
 
   // |KeyboardHandlerBase|
   void ComposeBeginHook() override;

--- a/shell/platform/windows/keyboard_key_handler_unittests.cc
+++ b/shell/platform/windows/keyboard_key_handler_unittests.cc
@@ -122,8 +122,8 @@ TEST(KeyboardKeyHandlerTest, SingleDelegateWithAsyncResponds) {
   /// Test 1: One event that is handled by the framework
 
   // Dispatch a key event
-  delegate_handled = handler.KeyboardHook(64, kHandledScanCode,
-                                          WM_KEYDOWN, L'a', false, true);
+  delegate_handled =
+      handler.KeyboardHook(64, kHandledScanCode, WM_KEYDOWN, L'a', false, true);
   EXPECT_EQ(delegate_handled, true);
   EXPECT_EQ(redispatch_scancode, 0);
   EXPECT_EQ(hook_history.size(), 1);
@@ -140,8 +140,8 @@ TEST(KeyboardKeyHandlerTest, SingleDelegateWithAsyncResponds) {
 
   /// Test 2: Two events that are unhandled by the framework
 
-  delegate_handled = handler.KeyboardHook(64, kHandledScanCode,
-                                          WM_KEYDOWN, L'a', false, false);
+  delegate_handled = handler.KeyboardHook(64, kHandledScanCode, WM_KEYDOWN,
+                                          L'a', false, false);
   EXPECT_EQ(delegate_handled, true);
   EXPECT_EQ(redispatch_scancode, 0);
   EXPECT_EQ(hook_history.size(), 1);
@@ -150,8 +150,8 @@ TEST(KeyboardKeyHandlerTest, SingleDelegateWithAsyncResponds) {
   EXPECT_EQ(hook_history.back().was_down, false);
 
   // Dispatch another key event
-  delegate_handled = handler.KeyboardHook(65, kHandledScanCode2,
-                                          WM_KEYUP, L'b', false, true);
+  delegate_handled =
+      handler.KeyboardHook(65, kHandledScanCode2, WM_KEYUP, L'b', false, true);
   EXPECT_EQ(delegate_handled, true);
   EXPECT_EQ(redispatch_scancode, 0);
   EXPECT_EQ(hook_history.size(), 2);
@@ -167,12 +167,12 @@ TEST(KeyboardKeyHandlerTest, SingleDelegateWithAsyncResponds) {
   hook_history.front().callback(false);
   EXPECT_EQ(redispatch_scancode, kHandledScanCode);
 
-  EXPECT_EQ(handler.KeyboardHook(64, kHandledScanCode, WM_KEYDOWN,
-                                 L'a', false, false),
+  EXPECT_EQ(handler.KeyboardHook(64, kHandledScanCode, WM_KEYDOWN, L'a', false,
+                                 false),
             false);
-  EXPECT_EQ(handler.KeyboardHook(65, kHandledScanCode2, WM_KEYUP, L'b',
-                                 false, false),
-            false);
+  EXPECT_EQ(
+      handler.KeyboardHook(65, kHandledScanCode2, WM_KEYUP, L'b', false, false),
+      false);
 
   EXPECT_EQ(handler.HasRedispatched(), false);
   hook_history.clear();
@@ -201,8 +201,8 @@ TEST(KeyboardKeyHandlerTest, SingleDelegateWithSyncResponds) {
 
   // Dispatch a key event
   delegate_handler = respond_true;
-  delegate_handled = handler.KeyboardHook(64, kHandledScanCode,
-                                          WM_KEYDOWN, L'a', false, false);
+  delegate_handled = handler.KeyboardHook(64, kHandledScanCode, WM_KEYDOWN,
+                                          L'a', false, false);
   EXPECT_EQ(delegate_handled, true);
   EXPECT_EQ(redispatch_scancode, 0);
   EXPECT_EQ(hook_history.size(), 1);
@@ -216,8 +216,8 @@ TEST(KeyboardKeyHandlerTest, SingleDelegateWithSyncResponds) {
   /// Test 2: An event unhandled by the framework
 
   delegate_handler = respond_false;
-  delegate_handled = handler.KeyboardHook(64, kHandledScanCode,
-                                          WM_KEYDOWN, L'a', false, false);
+  delegate_handled = handler.KeyboardHook(64, kHandledScanCode, WM_KEYDOWN,
+                                          L'a', false, false);
   EXPECT_EQ(delegate_handled, true);
   EXPECT_EQ(redispatch_scancode, kHandledScanCode);
   EXPECT_EQ(hook_history.size(), 1);
@@ -228,8 +228,8 @@ TEST(KeyboardKeyHandlerTest, SingleDelegateWithSyncResponds) {
   EXPECT_EQ(handler.HasRedispatched(), true);
 
   // Resolve the event
-  EXPECT_EQ(handler.KeyboardHook(64, kHandledScanCode, WM_KEYDOWN,
-                                 L'a', false, false),
+  EXPECT_EQ(handler.KeyboardHook(64, kHandledScanCode, WM_KEYDOWN, L'a', false,
+                                 false),
             false);
 
   EXPECT_EQ(handler.HasRedispatched(), false);
@@ -261,8 +261,8 @@ TEST(KeyboardKeyHandlerTest, WithTwoAsyncDelegates) {
 
   /// Test 1: One delegate responds true, the other false
 
-  delegate_handled = handler.KeyboardHook(64, kHandledScanCode,
-                                          WM_KEYDOWN, L'a', false, false);
+  delegate_handled = handler.KeyboardHook(64, kHandledScanCode, WM_KEYDOWN,
+                                          L'a', false, false);
   EXPECT_EQ(delegate_handled, true);
   EXPECT_EQ(redispatch_scancode, 0);
   EXPECT_EQ(hook_history.size(), 2);
@@ -287,8 +287,8 @@ TEST(KeyboardKeyHandlerTest, WithTwoAsyncDelegates) {
 
   /// Test 2: All delegates respond false
 
-  delegate_handled = handler.KeyboardHook(64, kHandledScanCode,
-                                          WM_KEYDOWN, L'a', false, false);
+  delegate_handled = handler.KeyboardHook(64, kHandledScanCode, WM_KEYDOWN,
+                                          L'a', false, false);
   EXPECT_EQ(delegate_handled, true);
   EXPECT_EQ(redispatch_scancode, 0);
   EXPECT_EQ(hook_history.size(), 2);
@@ -308,8 +308,8 @@ TEST(KeyboardKeyHandlerTest, WithTwoAsyncDelegates) {
   EXPECT_EQ(redispatch_scancode, kHandledScanCode);
 
   EXPECT_EQ(handler.HasRedispatched(), true);
-  EXPECT_EQ(handler.KeyboardHook(64, kHandledScanCode, WM_KEYDOWN,
-                                 L'a', false, false),
+  EXPECT_EQ(handler.KeyboardHook(64, kHandledScanCode, WM_KEYDOWN, L'a', false,
+                                 false),
             false);
 
   EXPECT_EQ(handler.HasRedispatched(), false);
@@ -318,8 +318,8 @@ TEST(KeyboardKeyHandlerTest, WithTwoAsyncDelegates) {
 
   /// Test 3: All delegates responds true
 
-  delegate_handled = handler.KeyboardHook(64, kHandledScanCode,
-                                          WM_KEYDOWN, L'a', false, false);
+  delegate_handled = handler.KeyboardHook(64, kHandledScanCode, WM_KEYDOWN,
+                                          L'a', false, false);
   EXPECT_EQ(delegate_handled, true);
   EXPECT_EQ(redispatch_scancode, 0);
   EXPECT_EQ(hook_history.size(), 2);
@@ -370,15 +370,15 @@ TEST(KeyboardKeyHandlerTest, WithSlowFrameworkResponse) {
   handler.AddDelegate(std::move(delegate1));
 
   // The first native event.
-  EXPECT_EQ(handler.KeyboardHook(64, kHandledScanCode, WM_KEYDOWN,
-                                 L'a', false, true),
-            true);
+  EXPECT_EQ(
+      handler.KeyboardHook(64, kHandledScanCode, WM_KEYDOWN, L'a', false, true),
+      true);
 
   // The second identical native event, received between the first and its
   // framework response.
-  EXPECT_EQ(handler.KeyboardHook(64, kHandledScanCode, WM_KEYDOWN,
-                                 L'a', false, true),
-            true);
+  EXPECT_EQ(
+      handler.KeyboardHook(64, kHandledScanCode, WM_KEYDOWN, L'a', false, true),
+      true);
   EXPECT_EQ(redispatch_scancode, 0);
   EXPECT_EQ(hook_history.size(), 2);
 
@@ -390,8 +390,8 @@ TEST(KeyboardKeyHandlerTest, WithSlowFrameworkResponse) {
   EXPECT_EQ(handler.HasRedispatched(), true);
 
   // Redispatch the first event.
-  EXPECT_EQ(handler.KeyboardHook(64, kHandledScanCode, WM_KEYDOWN,
-                                 L'a', false, false),
+  EXPECT_EQ(handler.KeyboardHook(64, kHandledScanCode, WM_KEYDOWN, L'a', false,
+                                 false),
             false);
   EXPECT_EQ(handler.HasRedispatched(), false);
   redispatch_scancode = 0;
@@ -402,8 +402,8 @@ TEST(KeyboardKeyHandlerTest, WithSlowFrameworkResponse) {
   EXPECT_EQ(handler.HasRedispatched(), true);
 
   // Redispatch the second event.
-  EXPECT_EQ(handler.KeyboardHook(64, kHandledScanCode, WM_KEYDOWN,
-                                 L'a', false, false),
+  EXPECT_EQ(handler.KeyboardHook(64, kHandledScanCode, WM_KEYDOWN, L'a', false,
+                                 false),
             false);
 
   EXPECT_EQ(handler.HasRedispatched(), false);
@@ -435,8 +435,8 @@ TEST(KeyboardKeyHandlerTest, NeverRedispatchShiftRightKeyDown) {
 
   // Press ShiftRight and the delegate responds false.
 
-  delegate_handled = handler.KeyboardHook(
-      VK_RSHIFT, kScanCodeShiftRight, WM_KEYDOWN, 0, false, false);
+  delegate_handled = handler.KeyboardHook(VK_RSHIFT, kScanCodeShiftRight,
+                                          WM_KEYDOWN, 0, false, false);
   EXPECT_EQ(delegate_handled, true);
   EXPECT_EQ(redispatch_scancode, 0);
   EXPECT_EQ(hook_history.size(), 1);
@@ -467,11 +467,11 @@ TEST(KeyboardKeyHandlerTest, AltGr) {
 
   // The key down event causes a ControlLeft down and a AltRight (extended
   // AltLeft) down.
-  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft,
-                                 WM_KEYDOWN, 0, false, false),
+  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft, WM_KEYDOWN,
+                                 0, false, false),
             true);
-  EXPECT_EQ(handler.KeyboardHook(VK_RMENU, kScanCodeAltLeft,
-                                 WM_KEYDOWN, 0, true, false),
+  EXPECT_EQ(handler.KeyboardHook(VK_RMENU, kScanCodeAltLeft, WM_KEYDOWN, 0,
+                                 true, false),
             true);
   EXPECT_EQ(redispatch_scancode, 0);
   EXPECT_EQ(hook_history.size(), 2);
@@ -486,11 +486,11 @@ TEST(KeyboardKeyHandlerTest, AltGr) {
   EXPECT_EQ(redispatch_scancode, kScanCodeAltLeft);
 
   // Resolve redispatches.
-  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft,
-                                 WM_KEYDOWN, 0, false, false),
+  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft, WM_KEYDOWN,
+                                 0, false, false),
             false);
-  EXPECT_EQ(handler.KeyboardHook(VK_RMENU, kScanCodeAltLeft,
-                                 WM_KEYDOWN, 0, true, false),
+  EXPECT_EQ(handler.KeyboardHook(VK_RMENU, kScanCodeAltLeft, WM_KEYDOWN, 0,
+                                 true, false),
             false);
 
   EXPECT_EQ(handler.HasRedispatched(), false);
@@ -498,17 +498,17 @@ TEST(KeyboardKeyHandlerTest, AltGr) {
   hook_history.clear();
 
   // The key up event only causes a AltRight (extended AltLeft) up.
-  EXPECT_EQ(handler.KeyboardHook(VK_RMENU, kScanCodeAltLeft, WM_KEYUP,
-                                 0, true, true),
-            true);
+  EXPECT_EQ(
+      handler.KeyboardHook(VK_RMENU, kScanCodeAltLeft, WM_KEYUP, 0, true, true),
+      true);
   EXPECT_EQ(hook_history.size(), 1);
   EXPECT_EQ(hook_history.front().scancode, kScanCodeAltLeft);
   EXPECT_EQ(hook_history.front().was_down, true);
 
   // A ControlLeft key up is synthesized.
   EXPECT_EQ(redispatch_scancode, kScanCodeControlLeft);
-  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft,
-                                 WM_KEYUP, 0, false, true),
+  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft, WM_KEYUP, 0,
+                                 false, true),
             true);
 
   EXPECT_EQ(hook_history.back().scancode, kScanCodeControlLeft);
@@ -520,12 +520,12 @@ TEST(KeyboardKeyHandlerTest, AltGr) {
   EXPECT_EQ(redispatch_scancode, kScanCodeControlLeft);
 
   // Resolve redispatches.
-  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft,
-                                 WM_KEYUP, 0, false, true),
+  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft, WM_KEYUP, 0,
+                                 false, true),
             false);
-  EXPECT_EQ(handler.KeyboardHook(VK_RMENU, kScanCodeAltLeft, WM_KEYUP,
-                                 0, true, true),
-            false);
+  EXPECT_EQ(
+      handler.KeyboardHook(VK_RMENU, kScanCodeAltLeft, WM_KEYUP, 0, true, true),
+      false);
 
   EXPECT_EQ(handler.HasRedispatched(), false);
   redispatch_scancode = 0;
@@ -537,8 +537,8 @@ TEST(KeyboardKeyHandlerTest, AltGr) {
   // than "tapping AltGr".
 
   // Key down ControlLeft.
-  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft,
-                                 WM_KEYDOWN, 0, false, false),
+  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft, WM_KEYDOWN,
+                                 0, false, false),
             true);
   EXPECT_EQ(redispatch_scancode, 0);
   EXPECT_EQ(hook_history.size(), 1);
@@ -551,13 +551,13 @@ TEST(KeyboardKeyHandlerTest, AltGr) {
   redispatch_scancode = 0;
 
   // Resolve redispatches.
-  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft,
-                                 WM_KEYDOWN, 0, false, false),
+  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft, WM_KEYDOWN,
+                                 0, false, false),
             false);
 
   // Key down AltRight.
-  EXPECT_EQ(handler.KeyboardHook(VK_RMENU, kScanCodeAltLeft,
-                                 WM_KEYDOWN, 0, true, false),
+  EXPECT_EQ(handler.KeyboardHook(VK_RMENU, kScanCodeAltLeft, WM_KEYDOWN, 0,
+                                 true, false),
             true);
   EXPECT_EQ(redispatch_scancode, 0);
   EXPECT_EQ(hook_history.size(), 1);
@@ -569,24 +569,24 @@ TEST(KeyboardKeyHandlerTest, AltGr) {
   hook_history.clear();
 
   // Resolve redispatches.
-  EXPECT_EQ(handler.KeyboardHook(VK_RMENU, kScanCodeAltLeft,
-                                 WM_KEYDOWN, 0, true, false),
+  EXPECT_EQ(handler.KeyboardHook(VK_RMENU, kScanCodeAltLeft, WM_KEYDOWN, 0,
+                                 true, false),
             false);
 
   redispatch_scancode = 0;
 
   // Key up AltRight.
-  EXPECT_EQ(handler.KeyboardHook(VK_RMENU, kScanCodeAltLeft, WM_KEYUP,
-                                 0, true, true),
-            true);
+  EXPECT_EQ(
+      handler.KeyboardHook(VK_RMENU, kScanCodeAltLeft, WM_KEYUP, 0, true, true),
+      true);
   EXPECT_EQ(hook_history.size(), 1);
   EXPECT_EQ(hook_history.front().scancode, kScanCodeAltLeft);
   EXPECT_EQ(hook_history.front().was_down, true);
 
   // A ControlLeft key up is synthesized.
   EXPECT_EQ(redispatch_scancode, kScanCodeControlLeft);
-  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft,
-                                 WM_KEYUP, 0, false, true),
+  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft, WM_KEYUP, 0,
+                                 false, true),
             true);
 
   EXPECT_EQ(hook_history.back().scancode, kScanCodeControlLeft);
@@ -598,12 +598,12 @@ TEST(KeyboardKeyHandlerTest, AltGr) {
   EXPECT_EQ(redispatch_scancode, kScanCodeControlLeft);
 
   // Resolve redispatches.
-  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft,
-                                 WM_KEYUP, 0, false, true),
+  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft, WM_KEYUP, 0,
+                                 false, true),
             false);
-  EXPECT_EQ(handler.KeyboardHook(VK_RMENU, kScanCodeAltLeft, WM_KEYUP,
-                                 0, true, true),
-            false);
+  EXPECT_EQ(
+      handler.KeyboardHook(VK_RMENU, kScanCodeAltLeft, WM_KEYUP, 0, true, true),
+      false);
 
   hook_history.clear();
   redispatch_scancode = 0;
@@ -611,8 +611,8 @@ TEST(KeyboardKeyHandlerTest, AltGr) {
   // Key up ControlLeft should be dispatched to delegates, but will be properly
   // handled by delegates' logic.
 
-  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft,
-                                 WM_KEYUP, 0, false, true),
+  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft, WM_KEYUP, 0,
+                                 false, true),
             true);
   EXPECT_EQ(redispatch_scancode, 0);
   EXPECT_EQ(hook_history.size(), 1);
@@ -632,11 +632,11 @@ TEST(KeyboardKeyHandlerTest, AltGr) {
   // (repeat).
 
   // Key down AltRight.
-  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft,
-                                 WM_KEYDOWN, 0, false, false),
+  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft, WM_KEYDOWN,
+                                 0, false, false),
             true);
-  EXPECT_EQ(handler.KeyboardHook(VK_RMENU, kScanCodeAltLeft,
-                                 WM_KEYDOWN, 0, true, false),
+  EXPECT_EQ(handler.KeyboardHook(VK_RMENU, kScanCodeAltLeft, WM_KEYDOWN, 0,
+                                 true, false),
             true);
   EXPECT_EQ(redispatch_scancode, 0);
   EXPECT_EQ(hook_history.size(), 2);
@@ -651,11 +651,11 @@ TEST(KeyboardKeyHandlerTest, AltGr) {
   EXPECT_EQ(redispatch_scancode, kScanCodeAltLeft);
 
   // Resolve redispatches.
-  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft,
-                                 WM_KEYDOWN, 0, false, false),
+  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft, WM_KEYDOWN,
+                                 0, false, false),
             false);
-  EXPECT_EQ(handler.KeyboardHook(VK_RMENU, kScanCodeAltLeft,
-                                 WM_KEYDOWN, 0, true, false),
+  EXPECT_EQ(handler.KeyboardHook(VK_RMENU, kScanCodeAltLeft, WM_KEYDOWN, 0,
+                                 true, false),
             false);
 
   EXPECT_EQ(handler.HasRedispatched(), false);
@@ -663,11 +663,11 @@ TEST(KeyboardKeyHandlerTest, AltGr) {
   hook_history.clear();
 
   // Another key down AltRight.
-  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft,
-                                 WM_KEYDOWN, 0, false, true),
+  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft, WM_KEYDOWN,
+                                 0, false, true),
             true);
-  EXPECT_EQ(handler.KeyboardHook(VK_RMENU, kScanCodeAltLeft,
-                                 WM_KEYDOWN, 0, true, true),
+  EXPECT_EQ(handler.KeyboardHook(VK_RMENU, kScanCodeAltLeft, WM_KEYDOWN, 0,
+                                 true, true),
             true);
   EXPECT_EQ(redispatch_scancode, 0);
   EXPECT_EQ(hook_history.size(), 2);
@@ -682,11 +682,11 @@ TEST(KeyboardKeyHandlerTest, AltGr) {
   EXPECT_EQ(redispatch_scancode, kScanCodeAltLeft);
 
   // Resolve redispatches.
-  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft,
-                                 WM_KEYDOWN, 0, false, false),
+  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft, WM_KEYDOWN,
+                                 0, false, false),
             false);
-  EXPECT_EQ(handler.KeyboardHook(VK_RMENU, kScanCodeAltLeft,
-                                 WM_KEYDOWN, 0, true, false),
+  EXPECT_EQ(handler.KeyboardHook(VK_RMENU, kScanCodeAltLeft, WM_KEYDOWN, 0,
+                                 true, false),
             false);
 
   EXPECT_EQ(handler.HasRedispatched(), false);
@@ -694,17 +694,17 @@ TEST(KeyboardKeyHandlerTest, AltGr) {
   hook_history.clear();
 
   // Key up AltRight.
-  EXPECT_EQ(handler.KeyboardHook(VK_RMENU, kScanCodeAltLeft, WM_KEYUP,
-                                 0, true, true),
-            true);
+  EXPECT_EQ(
+      handler.KeyboardHook(VK_RMENU, kScanCodeAltLeft, WM_KEYUP, 0, true, true),
+      true);
   EXPECT_EQ(hook_history.size(), 1);
   EXPECT_EQ(hook_history.front().scancode, kScanCodeAltLeft);
   EXPECT_EQ(hook_history.front().was_down, true);
 
   // A ControlLeft key up is synthesized.
   EXPECT_EQ(redispatch_scancode, kScanCodeControlLeft);
-  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft,
-                                 WM_KEYUP, 0, false, true),
+  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft, WM_KEYUP, 0,
+                                 false, true),
             true);
 
   EXPECT_EQ(hook_history.back().scancode, kScanCodeControlLeft);
@@ -716,12 +716,12 @@ TEST(KeyboardKeyHandlerTest, AltGr) {
   EXPECT_EQ(redispatch_scancode, kScanCodeControlLeft);
 
   // Resolve redispatches.
-  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft,
-                                 WM_KEYUP, 0, false, true),
+  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft, WM_KEYUP, 0,
+                                 false, true),
             false);
-  EXPECT_EQ(handler.KeyboardHook(VK_RMENU, kScanCodeAltLeft, WM_KEYUP,
-                                 0, true, true),
-            false);
+  EXPECT_EQ(
+      handler.KeyboardHook(VK_RMENU, kScanCodeAltLeft, WM_KEYUP, 0, true, true),
+      false);
 
   EXPECT_EQ(handler.HasRedispatched(), false);
   redispatch_scancode = 0;

--- a/shell/platform/windows/keyboard_key_handler_unittests.cc
+++ b/shell/platform/windows/keyboard_key_handler_unittests.cc
@@ -122,7 +122,7 @@ TEST(KeyboardKeyHandlerTest, SingleDelegateWithAsyncResponds) {
   /// Test 1: One event that is handled by the framework
 
   // Dispatch a key event
-  delegate_handled = handler.KeyboardHook(nullptr, 64, kHandledScanCode,
+  delegate_handled = handler.KeyboardHook(64, kHandledScanCode,
                                           WM_KEYDOWN, L'a', false, true);
   EXPECT_EQ(delegate_handled, true);
   EXPECT_EQ(redispatch_scancode, 0);
@@ -140,7 +140,7 @@ TEST(KeyboardKeyHandlerTest, SingleDelegateWithAsyncResponds) {
 
   /// Test 2: Two events that are unhandled by the framework
 
-  delegate_handled = handler.KeyboardHook(nullptr, 64, kHandledScanCode,
+  delegate_handled = handler.KeyboardHook(64, kHandledScanCode,
                                           WM_KEYDOWN, L'a', false, false);
   EXPECT_EQ(delegate_handled, true);
   EXPECT_EQ(redispatch_scancode, 0);
@@ -150,7 +150,7 @@ TEST(KeyboardKeyHandlerTest, SingleDelegateWithAsyncResponds) {
   EXPECT_EQ(hook_history.back().was_down, false);
 
   // Dispatch another key event
-  delegate_handled = handler.KeyboardHook(nullptr, 65, kHandledScanCode2,
+  delegate_handled = handler.KeyboardHook(65, kHandledScanCode2,
                                           WM_KEYUP, L'b', false, true);
   EXPECT_EQ(delegate_handled, true);
   EXPECT_EQ(redispatch_scancode, 0);
@@ -167,10 +167,10 @@ TEST(KeyboardKeyHandlerTest, SingleDelegateWithAsyncResponds) {
   hook_history.front().callback(false);
   EXPECT_EQ(redispatch_scancode, kHandledScanCode);
 
-  EXPECT_EQ(handler.KeyboardHook(nullptr, 64, kHandledScanCode, WM_KEYDOWN,
+  EXPECT_EQ(handler.KeyboardHook(64, kHandledScanCode, WM_KEYDOWN,
                                  L'a', false, false),
             false);
-  EXPECT_EQ(handler.KeyboardHook(nullptr, 65, kHandledScanCode2, WM_KEYUP, L'b',
+  EXPECT_EQ(handler.KeyboardHook(65, kHandledScanCode2, WM_KEYUP, L'b',
                                  false, false),
             false);
 
@@ -201,7 +201,7 @@ TEST(KeyboardKeyHandlerTest, SingleDelegateWithSyncResponds) {
 
   // Dispatch a key event
   delegate_handler = respond_true;
-  delegate_handled = handler.KeyboardHook(nullptr, 64, kHandledScanCode,
+  delegate_handled = handler.KeyboardHook(64, kHandledScanCode,
                                           WM_KEYDOWN, L'a', false, false);
   EXPECT_EQ(delegate_handled, true);
   EXPECT_EQ(redispatch_scancode, 0);
@@ -216,7 +216,7 @@ TEST(KeyboardKeyHandlerTest, SingleDelegateWithSyncResponds) {
   /// Test 2: An event unhandled by the framework
 
   delegate_handler = respond_false;
-  delegate_handled = handler.KeyboardHook(nullptr, 64, kHandledScanCode,
+  delegate_handled = handler.KeyboardHook(64, kHandledScanCode,
                                           WM_KEYDOWN, L'a', false, false);
   EXPECT_EQ(delegate_handled, true);
   EXPECT_EQ(redispatch_scancode, kHandledScanCode);
@@ -228,7 +228,7 @@ TEST(KeyboardKeyHandlerTest, SingleDelegateWithSyncResponds) {
   EXPECT_EQ(handler.HasRedispatched(), true);
 
   // Resolve the event
-  EXPECT_EQ(handler.KeyboardHook(nullptr, 64, kHandledScanCode, WM_KEYDOWN,
+  EXPECT_EQ(handler.KeyboardHook(64, kHandledScanCode, WM_KEYDOWN,
                                  L'a', false, false),
             false);
 
@@ -261,7 +261,7 @@ TEST(KeyboardKeyHandlerTest, WithTwoAsyncDelegates) {
 
   /// Test 1: One delegate responds true, the other false
 
-  delegate_handled = handler.KeyboardHook(nullptr, 64, kHandledScanCode,
+  delegate_handled = handler.KeyboardHook(64, kHandledScanCode,
                                           WM_KEYDOWN, L'a', false, false);
   EXPECT_EQ(delegate_handled, true);
   EXPECT_EQ(redispatch_scancode, 0);
@@ -287,7 +287,7 @@ TEST(KeyboardKeyHandlerTest, WithTwoAsyncDelegates) {
 
   /// Test 2: All delegates respond false
 
-  delegate_handled = handler.KeyboardHook(nullptr, 64, kHandledScanCode,
+  delegate_handled = handler.KeyboardHook(64, kHandledScanCode,
                                           WM_KEYDOWN, L'a', false, false);
   EXPECT_EQ(delegate_handled, true);
   EXPECT_EQ(redispatch_scancode, 0);
@@ -308,7 +308,7 @@ TEST(KeyboardKeyHandlerTest, WithTwoAsyncDelegates) {
   EXPECT_EQ(redispatch_scancode, kHandledScanCode);
 
   EXPECT_EQ(handler.HasRedispatched(), true);
-  EXPECT_EQ(handler.KeyboardHook(nullptr, 64, kHandledScanCode, WM_KEYDOWN,
+  EXPECT_EQ(handler.KeyboardHook(64, kHandledScanCode, WM_KEYDOWN,
                                  L'a', false, false),
             false);
 
@@ -318,7 +318,7 @@ TEST(KeyboardKeyHandlerTest, WithTwoAsyncDelegates) {
 
   /// Test 3: All delegates responds true
 
-  delegate_handled = handler.KeyboardHook(nullptr, 64, kHandledScanCode,
+  delegate_handled = handler.KeyboardHook(64, kHandledScanCode,
                                           WM_KEYDOWN, L'a', false, false);
   EXPECT_EQ(delegate_handled, true);
   EXPECT_EQ(redispatch_scancode, 0);
@@ -370,13 +370,13 @@ TEST(KeyboardKeyHandlerTest, WithSlowFrameworkResponse) {
   handler.AddDelegate(std::move(delegate1));
 
   // The first native event.
-  EXPECT_EQ(handler.KeyboardHook(nullptr, 64, kHandledScanCode, WM_KEYDOWN,
+  EXPECT_EQ(handler.KeyboardHook(64, kHandledScanCode, WM_KEYDOWN,
                                  L'a', false, true),
             true);
 
   // The second identical native event, received between the first and its
   // framework response.
-  EXPECT_EQ(handler.KeyboardHook(nullptr, 64, kHandledScanCode, WM_KEYDOWN,
+  EXPECT_EQ(handler.KeyboardHook(64, kHandledScanCode, WM_KEYDOWN,
                                  L'a', false, true),
             true);
   EXPECT_EQ(redispatch_scancode, 0);
@@ -390,7 +390,7 @@ TEST(KeyboardKeyHandlerTest, WithSlowFrameworkResponse) {
   EXPECT_EQ(handler.HasRedispatched(), true);
 
   // Redispatch the first event.
-  EXPECT_EQ(handler.KeyboardHook(nullptr, 64, kHandledScanCode, WM_KEYDOWN,
+  EXPECT_EQ(handler.KeyboardHook(64, kHandledScanCode, WM_KEYDOWN,
                                  L'a', false, false),
             false);
   EXPECT_EQ(handler.HasRedispatched(), false);
@@ -402,7 +402,7 @@ TEST(KeyboardKeyHandlerTest, WithSlowFrameworkResponse) {
   EXPECT_EQ(handler.HasRedispatched(), true);
 
   // Redispatch the second event.
-  EXPECT_EQ(handler.KeyboardHook(nullptr, 64, kHandledScanCode, WM_KEYDOWN,
+  EXPECT_EQ(handler.KeyboardHook(64, kHandledScanCode, WM_KEYDOWN,
                                  L'a', false, false),
             false);
 
@@ -436,7 +436,7 @@ TEST(KeyboardKeyHandlerTest, NeverRedispatchShiftRightKeyDown) {
   // Press ShiftRight and the delegate responds false.
 
   delegate_handled = handler.KeyboardHook(
-      nullptr, VK_RSHIFT, kScanCodeShiftRight, WM_KEYDOWN, 0, false, false);
+      VK_RSHIFT, kScanCodeShiftRight, WM_KEYDOWN, 0, false, false);
   EXPECT_EQ(delegate_handled, true);
   EXPECT_EQ(redispatch_scancode, 0);
   EXPECT_EQ(hook_history.size(), 1);
@@ -467,10 +467,10 @@ TEST(KeyboardKeyHandlerTest, AltGr) {
 
   // The key down event causes a ControlLeft down and a AltRight (extended
   // AltLeft) down.
-  EXPECT_EQ(handler.KeyboardHook(nullptr, VK_LCONTROL, kScanCodeControlLeft,
+  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft,
                                  WM_KEYDOWN, 0, false, false),
             true);
-  EXPECT_EQ(handler.KeyboardHook(nullptr, VK_RMENU, kScanCodeAltLeft,
+  EXPECT_EQ(handler.KeyboardHook(VK_RMENU, kScanCodeAltLeft,
                                  WM_KEYDOWN, 0, true, false),
             true);
   EXPECT_EQ(redispatch_scancode, 0);
@@ -486,10 +486,10 @@ TEST(KeyboardKeyHandlerTest, AltGr) {
   EXPECT_EQ(redispatch_scancode, kScanCodeAltLeft);
 
   // Resolve redispatches.
-  EXPECT_EQ(handler.KeyboardHook(nullptr, VK_LCONTROL, kScanCodeControlLeft,
+  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft,
                                  WM_KEYDOWN, 0, false, false),
             false);
-  EXPECT_EQ(handler.KeyboardHook(nullptr, VK_RMENU, kScanCodeAltLeft,
+  EXPECT_EQ(handler.KeyboardHook(VK_RMENU, kScanCodeAltLeft,
                                  WM_KEYDOWN, 0, true, false),
             false);
 
@@ -498,7 +498,7 @@ TEST(KeyboardKeyHandlerTest, AltGr) {
   hook_history.clear();
 
   // The key up event only causes a AltRight (extended AltLeft) up.
-  EXPECT_EQ(handler.KeyboardHook(nullptr, VK_RMENU, kScanCodeAltLeft, WM_KEYUP,
+  EXPECT_EQ(handler.KeyboardHook(VK_RMENU, kScanCodeAltLeft, WM_KEYUP,
                                  0, true, true),
             true);
   EXPECT_EQ(hook_history.size(), 1);
@@ -507,7 +507,7 @@ TEST(KeyboardKeyHandlerTest, AltGr) {
 
   // A ControlLeft key up is synthesized.
   EXPECT_EQ(redispatch_scancode, kScanCodeControlLeft);
-  EXPECT_EQ(handler.KeyboardHook(nullptr, VK_LCONTROL, kScanCodeControlLeft,
+  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft,
                                  WM_KEYUP, 0, false, true),
             true);
 
@@ -520,10 +520,10 @@ TEST(KeyboardKeyHandlerTest, AltGr) {
   EXPECT_EQ(redispatch_scancode, kScanCodeControlLeft);
 
   // Resolve redispatches.
-  EXPECT_EQ(handler.KeyboardHook(nullptr, VK_LCONTROL, kScanCodeControlLeft,
+  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft,
                                  WM_KEYUP, 0, false, true),
             false);
-  EXPECT_EQ(handler.KeyboardHook(nullptr, VK_RMENU, kScanCodeAltLeft, WM_KEYUP,
+  EXPECT_EQ(handler.KeyboardHook(VK_RMENU, kScanCodeAltLeft, WM_KEYUP,
                                  0, true, true),
             false);
 
@@ -537,7 +537,7 @@ TEST(KeyboardKeyHandlerTest, AltGr) {
   // than "tapping AltGr".
 
   // Key down ControlLeft.
-  EXPECT_EQ(handler.KeyboardHook(nullptr, VK_LCONTROL, kScanCodeControlLeft,
+  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft,
                                  WM_KEYDOWN, 0, false, false),
             true);
   EXPECT_EQ(redispatch_scancode, 0);
@@ -551,12 +551,12 @@ TEST(KeyboardKeyHandlerTest, AltGr) {
   redispatch_scancode = 0;
 
   // Resolve redispatches.
-  EXPECT_EQ(handler.KeyboardHook(nullptr, VK_LCONTROL, kScanCodeControlLeft,
+  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft,
                                  WM_KEYDOWN, 0, false, false),
             false);
 
   // Key down AltRight.
-  EXPECT_EQ(handler.KeyboardHook(nullptr, VK_RMENU, kScanCodeAltLeft,
+  EXPECT_EQ(handler.KeyboardHook(VK_RMENU, kScanCodeAltLeft,
                                  WM_KEYDOWN, 0, true, false),
             true);
   EXPECT_EQ(redispatch_scancode, 0);
@@ -569,14 +569,14 @@ TEST(KeyboardKeyHandlerTest, AltGr) {
   hook_history.clear();
 
   // Resolve redispatches.
-  EXPECT_EQ(handler.KeyboardHook(nullptr, VK_RMENU, kScanCodeAltLeft,
+  EXPECT_EQ(handler.KeyboardHook(VK_RMENU, kScanCodeAltLeft,
                                  WM_KEYDOWN, 0, true, false),
             false);
 
   redispatch_scancode = 0;
 
   // Key up AltRight.
-  EXPECT_EQ(handler.KeyboardHook(nullptr, VK_RMENU, kScanCodeAltLeft, WM_KEYUP,
+  EXPECT_EQ(handler.KeyboardHook(VK_RMENU, kScanCodeAltLeft, WM_KEYUP,
                                  0, true, true),
             true);
   EXPECT_EQ(hook_history.size(), 1);
@@ -585,7 +585,7 @@ TEST(KeyboardKeyHandlerTest, AltGr) {
 
   // A ControlLeft key up is synthesized.
   EXPECT_EQ(redispatch_scancode, kScanCodeControlLeft);
-  EXPECT_EQ(handler.KeyboardHook(nullptr, VK_LCONTROL, kScanCodeControlLeft,
+  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft,
                                  WM_KEYUP, 0, false, true),
             true);
 
@@ -598,10 +598,10 @@ TEST(KeyboardKeyHandlerTest, AltGr) {
   EXPECT_EQ(redispatch_scancode, kScanCodeControlLeft);
 
   // Resolve redispatches.
-  EXPECT_EQ(handler.KeyboardHook(nullptr, VK_LCONTROL, kScanCodeControlLeft,
+  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft,
                                  WM_KEYUP, 0, false, true),
             false);
-  EXPECT_EQ(handler.KeyboardHook(nullptr, VK_RMENU, kScanCodeAltLeft, WM_KEYUP,
+  EXPECT_EQ(handler.KeyboardHook(VK_RMENU, kScanCodeAltLeft, WM_KEYUP,
                                  0, true, true),
             false);
 
@@ -611,7 +611,7 @@ TEST(KeyboardKeyHandlerTest, AltGr) {
   // Key up ControlLeft should be dispatched to delegates, but will be properly
   // handled by delegates' logic.
 
-  EXPECT_EQ(handler.KeyboardHook(nullptr, VK_LCONTROL, kScanCodeControlLeft,
+  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft,
                                  WM_KEYUP, 0, false, true),
             true);
   EXPECT_EQ(redispatch_scancode, 0);
@@ -632,10 +632,10 @@ TEST(KeyboardKeyHandlerTest, AltGr) {
   // (repeat).
 
   // Key down AltRight.
-  EXPECT_EQ(handler.KeyboardHook(nullptr, VK_LCONTROL, kScanCodeControlLeft,
+  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft,
                                  WM_KEYDOWN, 0, false, false),
             true);
-  EXPECT_EQ(handler.KeyboardHook(nullptr, VK_RMENU, kScanCodeAltLeft,
+  EXPECT_EQ(handler.KeyboardHook(VK_RMENU, kScanCodeAltLeft,
                                  WM_KEYDOWN, 0, true, false),
             true);
   EXPECT_EQ(redispatch_scancode, 0);
@@ -651,10 +651,10 @@ TEST(KeyboardKeyHandlerTest, AltGr) {
   EXPECT_EQ(redispatch_scancode, kScanCodeAltLeft);
 
   // Resolve redispatches.
-  EXPECT_EQ(handler.KeyboardHook(nullptr, VK_LCONTROL, kScanCodeControlLeft,
+  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft,
                                  WM_KEYDOWN, 0, false, false),
             false);
-  EXPECT_EQ(handler.KeyboardHook(nullptr, VK_RMENU, kScanCodeAltLeft,
+  EXPECT_EQ(handler.KeyboardHook(VK_RMENU, kScanCodeAltLeft,
                                  WM_KEYDOWN, 0, true, false),
             false);
 
@@ -663,10 +663,10 @@ TEST(KeyboardKeyHandlerTest, AltGr) {
   hook_history.clear();
 
   // Another key down AltRight.
-  EXPECT_EQ(handler.KeyboardHook(nullptr, VK_LCONTROL, kScanCodeControlLeft,
+  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft,
                                  WM_KEYDOWN, 0, false, true),
             true);
-  EXPECT_EQ(handler.KeyboardHook(nullptr, VK_RMENU, kScanCodeAltLeft,
+  EXPECT_EQ(handler.KeyboardHook(VK_RMENU, kScanCodeAltLeft,
                                  WM_KEYDOWN, 0, true, true),
             true);
   EXPECT_EQ(redispatch_scancode, 0);
@@ -682,10 +682,10 @@ TEST(KeyboardKeyHandlerTest, AltGr) {
   EXPECT_EQ(redispatch_scancode, kScanCodeAltLeft);
 
   // Resolve redispatches.
-  EXPECT_EQ(handler.KeyboardHook(nullptr, VK_LCONTROL, kScanCodeControlLeft,
+  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft,
                                  WM_KEYDOWN, 0, false, false),
             false);
-  EXPECT_EQ(handler.KeyboardHook(nullptr, VK_RMENU, kScanCodeAltLeft,
+  EXPECT_EQ(handler.KeyboardHook(VK_RMENU, kScanCodeAltLeft,
                                  WM_KEYDOWN, 0, true, false),
             false);
 
@@ -694,7 +694,7 @@ TEST(KeyboardKeyHandlerTest, AltGr) {
   hook_history.clear();
 
   // Key up AltRight.
-  EXPECT_EQ(handler.KeyboardHook(nullptr, VK_RMENU, kScanCodeAltLeft, WM_KEYUP,
+  EXPECT_EQ(handler.KeyboardHook(VK_RMENU, kScanCodeAltLeft, WM_KEYUP,
                                  0, true, true),
             true);
   EXPECT_EQ(hook_history.size(), 1);
@@ -703,7 +703,7 @@ TEST(KeyboardKeyHandlerTest, AltGr) {
 
   // A ControlLeft key up is synthesized.
   EXPECT_EQ(redispatch_scancode, kScanCodeControlLeft);
-  EXPECT_EQ(handler.KeyboardHook(nullptr, VK_LCONTROL, kScanCodeControlLeft,
+  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft,
                                  WM_KEYUP, 0, false, true),
             true);
 
@@ -716,10 +716,10 @@ TEST(KeyboardKeyHandlerTest, AltGr) {
   EXPECT_EQ(redispatch_scancode, kScanCodeControlLeft);
 
   // Resolve redispatches.
-  EXPECT_EQ(handler.KeyboardHook(nullptr, VK_LCONTROL, kScanCodeControlLeft,
+  EXPECT_EQ(handler.KeyboardHook(VK_LCONTROL, kScanCodeControlLeft,
                                  WM_KEYUP, 0, false, true),
             false);
-  EXPECT_EQ(handler.KeyboardHook(nullptr, VK_RMENU, kScanCodeAltLeft, WM_KEYUP,
+  EXPECT_EQ(handler.KeyboardHook(VK_RMENU, kScanCodeAltLeft, WM_KEYUP,
                                  0, true, true),
             false);
 

--- a/shell/platform/windows/text_input_plugin.cc
+++ b/shell/platform/windows/text_input_plugin.cc
@@ -9,7 +9,6 @@
 #include <cstdint>
 
 #include "flutter/shell/platform/common/json_method_codec.h"
-#include "flutter/shell/platform/windows/flutter_windows_view.h"
 
 static constexpr char kSetEditingStateMethod[] = "TextInput.setEditingState";
 static constexpr char kClearClientMethod[] = "TextInput.clearClient";
@@ -51,8 +50,7 @@ static constexpr char kInternalConsistencyError[] =
 
 namespace flutter {
 
-void TextInputPlugin::TextHook(FlutterWindowsView* view,
-                               const std::u16string& text) {
+void TextInputPlugin::TextHook(const std::u16string& text) {
   if (active_model_ == nullptr) {
     return;
   }
@@ -60,8 +58,7 @@ void TextInputPlugin::TextHook(FlutterWindowsView* view,
   SendStateUpdate(*active_model_);
 }
 
-bool TextInputPlugin::KeyboardHook(FlutterWindowsView* view,
-                                   int key,
+bool TextInputPlugin::KeyboardHook(int key,
                                    int scancode,
                                    int action,
                                    char32_t character,

--- a/shell/platform/windows/text_input_plugin.h
+++ b/shell/platform/windows/text_input_plugin.h
@@ -15,12 +15,9 @@
 #include "flutter/shell/platform/common/json_method_codec.h"
 #include "flutter/shell/platform/common/text_input_model.h"
 #include "flutter/shell/platform/windows/keyboard_handler_base.h"
-#include "flutter/shell/platform/windows/public/flutter_windows.h"
 #include "flutter/shell/platform/windows/text_input_plugin_delegate.h"
 
 namespace flutter {
-
-class FlutterWindowsView;
 
 // Implements a text input plugin.
 //
@@ -33,8 +30,7 @@ class TextInputPlugin : public KeyboardHandlerBase {
   virtual ~TextInputPlugin();
 
   // |KeyboardHandlerBase|
-  bool KeyboardHook(FlutterWindowsView* view,
-                    int key,
+  bool KeyboardHook(int key,
                     int scancode,
                     int action,
                     char32_t character,
@@ -42,7 +38,7 @@ class TextInputPlugin : public KeyboardHandlerBase {
                     bool was_down) override;
 
   // |KeyboardHandlerBase|
-  void TextHook(FlutterWindowsView* view, const std::u16string& text) override;
+  void TextHook(const std::u16string& text) override;
 
   // |KeyboardHandlerBase|
   void ComposeBeginHook() override;

--- a/shell/platform/windows/text_input_plugin_unittest.cc
+++ b/shell/platform/windows/text_input_plugin_unittest.cc
@@ -5,10 +5,10 @@
 
 #include <rapidjson/document.h>
 #include <memory>
+#include <windows.h>
 
 #include "flutter/shell/platform/common/json_message_codec.h"
 #include "flutter/shell/platform/common/json_method_codec.h"
-#include "flutter/shell/platform/windows/flutter_windows_view.h"
 #include "flutter/shell/platform/windows/testing/test_binary_messenger.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -55,7 +55,7 @@ TEST(TextInputPluginTest, TextMethodsWorksWithEmptyModel) {
   int redispatch_scancode = 0;
   TextInputPlugin handler(&messenger, &delegate);
 
-  handler.KeyboardHook(nullptr, VK_RETURN, 100, WM_KEYDOWN, '\n', false, false);
+  handler.KeyboardHook(VK_RETURN, 100, WM_KEYDOWN, '\n', false, false);
   handler.ComposeBeginHook();
   std::u16string text;
   text.push_back('\n');

--- a/shell/platform/windows/text_input_plugin_unittest.cc
+++ b/shell/platform/windows/text_input_plugin_unittest.cc
@@ -4,8 +4,8 @@
 #include "flutter/shell/platform/windows/text_input_plugin.h"
 
 #include <rapidjson/document.h>
-#include <memory>
 #include <windows.h>
+#include <memory>
 
 #include "flutter/shell/platform/common/json_message_codec.h"
 #include "flutter/shell/platform/common/json_method_codec.h"


### PR DESCRIPTION
This stub PR removes a redundant parameter `FlutterWindowsView* view` from all of the keyboard classes.

This PR is one of the many steps to refactor the Windows keyboard system, before we finally have to tackle the rework for https://github.com/flutter/flutter/issues/88021.

This PR doesn't need tests because it's just a refactor.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
