### PR TITLE
Close image reader when the resource is unreachable

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
@@ -215,12 +215,20 @@ public class FlutterImageView extends View implements RenderSurface {
 
     // Close resources.
     closeCurrentImage();
-
-    // Close all the resources associated with the image reader,
-    // including the images.
-    imageReader.close();
+    // Close the current image reader, then create a new one with the new size.
     // Image readers cannot be resized once created.
+    closeImageReader();
     imageReader = createImageReader(width, height);
+  }
+
+  /**
+   * Closes the image reader associated with the current {@code FlutterImageView}.
+   *
+   * <p>Once the image reader is closed, calling {@code acquireLatestImage} will result in an {@code
+   * IllegalStateException}.
+   */
+  public void closeImageReader() {
+    imageReader.close();
   }
 
   @Override

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -1222,7 +1222,10 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
     }
     renderSurface.detachFromRenderer();
 
-    flutterImageView = null;
+    if (flutterImageView != null) {
+      flutterImageView.closeImageReader();
+      flutterImageView = null;
+    }
     previousRenderSurface = null;
     flutterEngine = null;
   }

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -973,6 +973,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
       int overlayId = overlayLayerViews.keyAt(i);
       FlutterImageView overlayView = overlayLayerViews.valueAt(i);
       overlayView.detachFromRenderer();
+      overlayView.closeImageReader();
       if (flutterView != null) {
         ((FlutterView) flutterView).removeView(overlayView);
       }

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
@@ -136,6 +136,32 @@ public class FlutterViewTest {
   }
 
   @Test
+  public void detachFromFlutterEngine_closesImageView() {
+    FlutterEngine flutterEngine =
+        spy(new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, mockFlutterJni));
+
+    FlutterRenderer flutterRenderer = spy(new FlutterRenderer(mockFlutterJni));
+    when(flutterEngine.getRenderer()).thenReturn(flutterRenderer);
+
+    FlutterImageView imageViewMock = mock(FlutterImageView.class);
+    when(imageViewMock.getAttachedRenderer()).thenReturn(flutterRenderer);
+
+    FlutterView flutterView = spy(new FlutterView(RuntimeEnvironment.application));
+    when(flutterView.createImageView()).thenReturn(imageViewMock);
+
+    flutterView.attachToFlutterEngine(flutterEngine);
+
+    assertFalse(flutterView.renderSurface == imageViewMock);
+
+    flutterView.convertToImageView();
+    assertTrue(flutterView.renderSurface == imageViewMock);
+
+    flutterView.detachFromFlutterEngine();
+    assertFalse(flutterView.renderSurface == imageViewMock);
+    verify(imageViewMock, times(1)).closeImageReader();
+  }
+
+  @Test
   public void onConfigurationChanged_fizzlesWhenNullEngine() {
     FlutterView flutterView = new FlutterView(Robolectric.setupActivity(Activity.class));
     FlutterEngine flutterEngine =
@@ -835,6 +861,22 @@ public class FlutterViewTest {
     imageView.resizeIfNeeded(incorrectWidth, incorrectHeight);
     assertEquals(1, imageView.getImageReader().getWidth());
     assertEquals(1, imageView.getImageReader().getHeight());
+  }
+
+  @Test
+  public void flutterImageView_closesReader() {
+    final ImageReader mockReader = mock(ImageReader.class);
+    when(mockReader.getMaxImages()).thenReturn(1);
+
+    final FlutterImageView imageView =
+        spy(
+            new FlutterImageView(
+                RuntimeEnvironment.application,
+                mockReader,
+                FlutterImageView.SurfaceKind.background));
+
+    imageView.closeImageReader();
+    verify(mockReader, times(1)).close();
   }
 
   @Test

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
@@ -699,7 +699,9 @@ public class PlatformViewsControllerTest {
         overlaySurface.getId(), /* x=*/ 0, /* y=*/ 0, /* width=*/ 10, /* height=*/ 10);
 
     platformViewsController.detachFromView();
+
     platformViewsController.destroyOverlaySurfaces();
+    verify(overlayImageView, times(1)).closeImageReader();
   }
 
   @Test


### PR DESCRIPTION
Fixes http://b/207173651

The image reader must be closed once the resource is unreachable. 
Otherwise, the resources associated with the image reader are leaked. This is particularly prohibited in StrictMode.

I'm thinking that it's a good idea to turn StrictMode by default. In this case, 
the e2e test should have been able to capture the issue.

