### PR TITLE
Update IosUnitTests to use iPhone 11 simulator

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -357,9 +357,10 @@ typedef enum UIAccessibilityContrast : NSInteger {
                                                                                 nibName:nil
                                                                                  bundle:nil];
   mockEngine.viewController = viewController;
-  [viewController updateViewportMetrics];
   flutter::ViewportMetrics viewportMetrics;
-  OCMVerify([mockEngine updateViewportMetrics:viewportMetrics]);
+  OCMExpect([mockEngine updateViewportMetrics:viewportMetrics]).ignoringNonObjectArgs();
+  [viewController updateViewportMetrics];
+  OCMVerifyAll(mockEngine);
 }
 
 - (void)testViewDidLoadDoesntInvokeEngineWhenNotTheViewController {

--- a/testing/ios/IosUnitTests/README.md
+++ b/testing/ios/IosUnitTests/README.md
@@ -15,9 +15,9 @@ After the `ios_test_flutter` target is built you can also run the tests inside
 of Xcode with `testing/ios/IosUnitTests/IosUnitTests.xcodeproj`.
 
 When you load the test project [IosUnitTests.xcodeproj](IosUnitTests.xcodeproj)
-into XCode after running `run_tests.py`, only a few basic tests will appear
-initially. You have to run the test suite once in XCode for the rest to appear.
-Select "iPhone 8" as the device, and press `command-u` to start all the tests
+into Xcode after running `run_tests.py`, only a few basic tests will appear
+initially. You have to run the test suite once in Xcode for the rest to appear.
+Select "iPhone 11" as the device, and press `command-u` to start all the tests
 running. Once the tests are done running, the tests that ran will appear in the
 sidebar, and you can pick the specific one you want to debug/run.
 

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -387,7 +387,7 @@ def RunObjcTests(ios_variant='ios_debug_sim_unopt', test_filter=None):
     'xcodebuild '
     '-sdk iphonesimulator '
     '-scheme IosUnitTests '
-    "-destination platform='iOS Simulator,name=iPhone 8' "
+    "-destination platform='iOS Simulator,name=iPhone 11' "
     'test '
     'FLUTTER_ENGINE=' + ios_variant
   ]


### PR DESCRIPTION
To facilitate upgrading to Xcode 13, run the tests on an iPhone 11 simulator, which is available on both Xcode 12 and 13.

iPhone 8 is available in Xcode 12, but not Xcode 13.

```
xcodebuild: error: Unable to find a destination matching the provided destination specifier:
		{ platform:iOS Simulator, OS:latest, name:iPhone 8 }

	The requested device could not be found because no available devices matched the request.
```
https://logs.chromium.org/logs/flutter/led/magder_google.com/349337923817235f1787d85315977fa8fe0b5fac40129da0920833bccd53679b/+/u/test:_Host_Tests_for_ios_debug_sim__3_/stdout

Passes: https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8828912330933038337/+/u/test:_Host_Tests_for_ios_debug_sim/stdout

Part of https://github.com/flutter/flutter/issues/85555.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
