### PR TITLE
Accessibility: emit FOCUS_CHANGED events

### DIFF
--- a/third_party/accessibility/ax/ax_event_generator.cc
+++ b/third_party/accessibility/ax/ax_event_generator.cc
@@ -570,6 +570,12 @@ void AXEventGenerator::OnTreeDataChanged(AXTree* tree,
   }
   if (new_tree_data.title != old_tree_data.title)
     AddEvent(tree->root(), Event::DOCUMENT_TITLE_CHANGED);
+  if (new_tree_data.focus_id != old_tree_data.focus_id) {
+    AXNode* focus_node = tree->GetFromId(new_tree_data.focus_id);
+    if (focus_node) {
+      AddEvent(focus_node, Event::FOCUS_CHANGED);
+    }
+  }
 }
 
 void AXEventGenerator::OnNodeWillBeDeleted(AXTree* tree, AXNode* node) {

--- a/third_party/accessibility/ax/ax_event_generator_unittest.cc
+++ b/third_party/accessibility/ax/ax_event_generator_unittest.cc
@@ -164,6 +164,48 @@ TEST(AXEventGeneratorTest, DocumentTitleChanged) {
                        AXEventGenerator::Event::DOCUMENT_TITLE_CHANGED, 1));
 }
 
+// Do not emit a FOCUS_CHANGED event if focus_id is unchanged.
+TEST(AXEventGeneratorTest, FocusIdUnchanged) {
+  AXTreeUpdate initial_state;
+  initial_state.root_id = 1;
+  initial_state.nodes.resize(2);
+  initial_state.nodes[0].id = 1;
+  initial_state.nodes[0].child_ids.push_back(2);
+  initial_state.nodes[1].id = 2;
+  initial_state.has_tree_data = true;
+  initial_state.tree_data.focus_id = 1;
+  AXTree tree(initial_state);
+
+  AXEventGenerator event_generator(&tree);
+  AXTreeUpdate update = initial_state;
+  update.tree_data.focus_id = 1;
+
+  ASSERT_TRUE(tree.Unserialize(update));
+  EXPECT_FALSE(
+      HasEvent(event_generator, AXEventGenerator::Event::FOCUS_CHANGED, 1));
+}
+
+// Emit a FOCUS_CHANGED event if focus_id changes.
+TEST(AXEventGeneratorTest, FocusIdChanged) {
+  AXTreeUpdate initial_state;
+  initial_state.root_id = 1;
+  initial_state.nodes.resize(2);
+  initial_state.nodes[0].id = 1;
+  initial_state.nodes[0].child_ids.push_back(2);
+  initial_state.nodes[1].id = 2;
+  initial_state.has_tree_data = true;
+  initial_state.tree_data.focus_id = 1;
+  AXTree tree(initial_state);
+
+  AXEventGenerator event_generator(&tree);
+  AXTreeUpdate update = initial_state;
+  update.tree_data.focus_id = 2;
+
+  ASSERT_TRUE(tree.Unserialize(update));
+  EXPECT_TRUE(
+      HasEvent(event_generator, AXEventGenerator::Event::FOCUS_CHANGED, 2));
+}
+
 TEST(AXEventGeneratorTest, ExpandedAndRowCount) {
   AXTreeUpdate initial_state;
   initial_state.root_id = 1;


### PR DESCRIPTION
When calling Unserialize on an AXTreeUpdate, check whether the focus_id
has changed. If so, emit a FOCUS_CHANGED event from the event generator.
This allows the platform-specific FlutterPlatformNodeDelegate
implementations to handle focus changes originating from the framework,
and trigger the appropriate operating system focus-changed
notifications.

Issue: https://github.com/flutter/flutter/issues/77838

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
