### PR TITLE
Remove implicit copy assignment operator for 'EmbeddedViewParams'

### DIFF
--- a/flow/embedded_views.h
+++ b/flow/embedded_views.h
@@ -210,14 +210,6 @@ class EmbeddedViewParams {
     final_bounding_rect_ = path.getBounds();
   }
 
-  EmbeddedViewParams(const EmbeddedViewParams& other) {
-    size_points_ = other.size_points_;
-    mutators_stack_ = other.mutators_stack_;
-    matrix_ = other.matrix_;
-    final_bounding_rect_ = other.final_bounding_rect_;
-  };
-  EmbeddedViewParams& operator=(const EmbeddedViewParams& e) = default;
-
   // The transformation Matrix corresponding to the sum of all the
   // transformations in the platform view's mutator stack.
   const SkMatrix& transformMatrix() const { return matrix_; };

--- a/flow/embedded_views.h
+++ b/flow/embedded_views.h
@@ -216,6 +216,7 @@ class EmbeddedViewParams {
     matrix_ = other.matrix_;
     final_bounding_rect_ = other.final_bounding_rect_;
   };
+  EmbeddedViewParams& operator=(const EmbeddedViewParams& e) = default;
 
   // The transformation Matrix corresponding to the sum of all the
   // transformations in the platform view's mutator stack.


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/94586

Tested this locally with clang 13, will be validated on the Xcode 13 migration with the ` -Wdeprecated-copy` warning.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
