### PR TITLE
Revert "Use WindowInfoTracker.Companion.getOrCreate instead of the short version"

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -455,7 +455,7 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
     try {
       return new WindowInfoRepositoryCallbackAdapterWrapper(
           new WindowInfoTrackerCallbackAdapter(
-              WindowInfoTracker.Companion.getOrCreate((Activity) getContext())));
+              WindowInfoTracker.getOrCreate((Activity) getContext())));
     } catch (NoClassDefFoundError noClassDefFoundError) {
       // Testing environment uses gn/javac, which does not work with aar files. This is why aar
       // are converted to jar files, losing resources and other android-specific files.


### PR DESCRIPTION
Reverts flutter/engine#30012