### PR TITLE
Fix platform env variable not registering with sdk_manager

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -504,7 +504,7 @@ deps = {
      'packages': [
        {
         'package': 'flutter/android/sdk/all/${{platform}}',
-        'version': 'version:31v2'
+        'version': 'version:31v5'
        }
      ],
      'condition': 'download_android_deps',

--- a/tools/android_sdk/create_sdk_cipd_packages.sh
+++ b/tools/android_sdk/create_sdk_cipd_packages.sh
@@ -80,13 +80,15 @@ for platform in "${platforms[@]}"; do
   echo "Creating temporary working directory for $platform: $sdk_root"
   mkdir $sdk_root
   mkdir $upload_dir
+  export REPO_OS_OVERRIDE=$platform
 
   # Download all the packages with sdkmanager.
   for package in $(cat $package_file_name); do
     echo $package
     split=(${package//:/ })
     echo "Installing ${split[0]}"
-    REPO_OS_OVERRIDE=$platform yes "y" | $sdkmanager_path --sdk_root=$sdk_root ${split[0]}
+    yes "y" | $sdkmanager_path --sdk_root=$sdk_root ${split[0]}
+
     # We copy only the relevant directories to a temporary dir
     # for upload. sdkmanager creates extra files that we don't need.
     array_length=${#split[@]}


### PR DESCRIPTION
Fixes https://github.com/dart-lang/sdk/issues/47760

The REPO_OS_OVERRIDE was improperly configured and would not always download the platform distinguished package.