### PR TITLE
Check string size before Win32 MultiByte <-> WideChar conversions

### DIFF
--- a/shell/platform/windows/string_conversion.cc
+++ b/shell/platform/windows/string_conversion.cc
@@ -20,6 +20,9 @@ std::string Utf8FromUtf16(const std::wstring_view utf16_string) {
   }
   std::string utf8_string;
   utf8_string.resize(target_length);
+  if (utf8_string.length() != target_length) {
+    return std::string();
+  }
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string.data(),
       static_cast<int>(utf16_string.length()), utf8_string.data(),
@@ -42,6 +45,9 @@ std::wstring Utf16FromUtf8(const std::string_view utf8_string) {
   }
   std::wstring utf16_string;
   utf16_string.resize(target_length);
+  if (utf16_string.length() != target_length) {
+    return std::wstring();
+  }
   int converted_length =
       ::MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, utf8_string.data(),
                             static_cast<int>(utf8_string.length()),

--- a/shell/platform/windows/string_conversion.cc
+++ b/shell/platform/windows/string_conversion.cc
@@ -19,8 +19,9 @@ std::string Utf8FromUtf16(const std::wstring_view utf16_string) {
     return std::string();
   }
   std::string utf8_string;
-  utf8_string.resize(target_length);
-  if (utf8_string.length() != target_length) {
+  try {
+    utf8_string.resize(target_length);
+  } catch (...) {
     return std::string();
   }
   int converted_length = ::WideCharToMultiByte(
@@ -44,8 +45,9 @@ std::wstring Utf16FromUtf8(const std::string_view utf8_string) {
     return std::wstring();
   }
   std::wstring utf16_string;
-  utf16_string.resize(target_length);
-  if (utf16_string.length() != target_length) {
+  try {
+    utf16_string.resize(target_length);
+  } catch (...) {
     return std::wstring();
   }
   int converted_length =

--- a/third_party/accessibility/base/win/string_conversion.cc
+++ b/third_party/accessibility/base/win/string_conversion.cc
@@ -24,6 +24,9 @@ std::string Utf8FromUtf16(const std::wstring& utf16_string) {
   }
   std::string utf8_string;
   utf8_string.resize(target_length);
+  if (utf8_string.length() != target_length) {
+    return std::string();
+  }
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string.data(),
       static_cast<int>(utf16_string.length()), utf8_string.data(),
@@ -46,6 +49,9 @@ std::wstring Utf16FromUtf8(const std::string& utf8_string) {
   }
   std::wstring utf16_string;
   utf16_string.resize(target_length);
+  if (utf16_string.length() != target_length) {
+    return std::wstring();
+  }
   int converted_length =
       ::MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, utf8_string.data(),
                             static_cast<int>(utf8_string.length()),

--- a/third_party/accessibility/base/win/string_conversion.cc
+++ b/third_party/accessibility/base/win/string_conversion.cc
@@ -23,8 +23,9 @@ std::string Utf8FromUtf16(const std::wstring& utf16_string) {
     return std::string();
   }
   std::string utf8_string;
-  utf8_string.resize(target_length);
-  if (utf8_string.length() != target_length) {
+  try {
+    utf8_string.resize(target_length);
+  } catch (...) {
     return std::string();
   }
   int converted_length = ::WideCharToMultiByte(
@@ -48,8 +49,9 @@ std::wstring Utf16FromUtf8(const std::string& utf8_string) {
     return std::wstring();
   }
   std::wstring utf16_string;
-  utf16_string.resize(target_length);
-  if (utf16_string.length() != target_length) {
+  try {
+    utf16_string.resize(target_length);
+  } catch (...) {
     return std::wstring();
   }
   int converted_length =


### PR DESCRIPTION
This PR adds string size checks after .resize() before calling WideCharToMultiByte / MultiByteToWideChar.

This is to avoid buffer overruns should resize() call fail (e.g. alloc error or too long a string length). As per C++ standard: "Strong guarantee: if an exception is thrown, there are no changes in the string".

According to Win32 API docs ([WideCharToMultiByte](https://docs.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-widechartomultibyte), [MultiByteToWideChar](https://docs.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-multibytetowidechar)) it's the caller responsibility to make sure the buffers are correctly allocated:

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
