### PR TITLE
[android]  Make ExclusiveAppComponent accessible to FlutterFragment's subclasses similar to FlutterActivity's

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
@@ -705,7 +705,7 @@ public class FlutterFragment extends Fragment
   // Delegate that runs all lifecycle and OS hook logic that is common between
   // FlutterActivity and FlutterFragment. See the FlutterActivityAndFragmentDelegate
   // implementation for details about why it exists.
-  @VisibleForTesting @Nullable /* package */ FlutterActivityAndFragmentDelegate delegate;
+  @VisibleForTesting @Nullable protected FlutterActivityAndFragmentDelegate delegate;
 
   private final OnBackPressedCallback onBackPressedCallback =
       new OnBackPressedCallback(true) {

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
@@ -499,8 +499,8 @@ public class FlutterActivityTest {
     }
   }
 
-  // It‘s a compile-time check to ensure that FlutterActivity subclasses can access
-  // FlutterActivityAndFragmentDelegate.
+  // It‘s a compile-time check to ensure that FlutterActivityAndFragmentDelegate is
+  // accessible to FlutterActivity subclasses.
   static class FlutterActivitySubclass extends FlutterActivity {
     public void performAttach() {
       getFlutterEngine().getActivityControlSurface().attachToActivity(delegate, getLifecycle());

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
@@ -499,6 +499,14 @@ public class FlutterActivityTest {
     }
   }
 
+  // It‘s a compile-time check to ensure that FlutterActivity subclasses can access
+  // FlutterActivityAndFragmentDelegate.
+  static class FlutterActivitySubclass extends FlutterActivity {
+    public void performAttach() {
+      getFlutterEngine().getActivityControlSurface().attachToActivity(delegate, getLifecycle());
+    }
+  }
+
   private static class FlutterActivityWithTextureRendering extends FlutterActivity {
     @Override
     public RenderMode getRenderMode() {

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
@@ -39,6 +39,8 @@ import io.flutter.embedding.engine.plugins.activity.ActivityAware;
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding.OnSaveInstanceStateListener;
 import io.flutter.plugins.GeneratedPluginRegistrant;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.List;
 import org.junit.After;
 import org.junit.Before;
@@ -466,6 +468,19 @@ public class FlutterActivityTest {
     }
   }
 
+  @Test
+  public void itCanBeAccessibleFromSubclass() {
+    // To ensure that FlutterActivityAndFragmentDelegate is
+    // accessible to FlutterActivity subclasses.
+    try {
+      Field field = FlutterActivity.class.getDeclaredField("delegate");
+      field.setAccessible(true);
+      assertTrue(Modifier.isProtected(field.getModifiers()));
+    } catch (Exception e) {
+      assertTrue(false);
+    }
+  }
+
   static class FlutterActivityWithProvidedEngine extends FlutterActivity {
     @Override
     @SuppressLint("MissingSuperCall")
@@ -496,14 +511,6 @@ public class FlutterActivityTest {
 
     public static CachedEngineIntentBuilder withCachedEngine(@NonNull String cachedEngineId) {
       return new CachedEngineIntentBuilder(FlutterActivityWithIntentBuilders.class, cachedEngineId);
-    }
-  }
-
-  // It‘s a compile-time check to ensure that FlutterActivityAndFragmentDelegate is
-  // accessible to FlutterActivity subclasses.
-  static class FlutterActivitySubclass extends FlutterActivity {
-    public void performAttach() {
-      getFlutterEngine().getActivityControlSurface().attachToActivity(delegate, getLifecycle());
     }
   }
 

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
@@ -222,3 +222,11 @@ public class FlutterFragmentTest {
     assertTrue(onBackPressedCalled.get());
   }
 }
+
+// It‘s a compile-time check to ensure that FlutterFragment subclasses can access
+// FlutterActivityAndFragmentDelegate.
+static class FlutterFragmentSubclass extends FlutterFragment {
+  public void performAttach() {
+    getFlutterEngine().getActivityControlSurface().attachToActivity(delegate, getLifecycle());
+  }
+}

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
@@ -18,6 +18,8 @@ import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.FlutterEngineCache;
 import io.flutter.embedding.engine.FlutterJNI;
 import io.flutter.embedding.engine.loader.FlutterLoader;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -221,12 +223,17 @@ public class FlutterFragmentTest {
     verify(mockDelegate, never()).onBackPressed();
     assertTrue(onBackPressedCalled.get());
   }
-}
 
-// It‘s a compile-time check to ensure that FlutterActivityAndFragmentDelegate is
-// accessible to FlutterFragment subclasses.
-static class FlutterFragmentSubclass extends FlutterFragment {
-  public void performAttach() {
-    getFlutterEngine().getActivityControlSurface().attachToActivity(delegate, getLifecycle());
+  @Test
+  public void itCanBeAccessibleFromSubclass() {
+    // To ensure that FlutterActivityAndFragmentDelegate is
+    // accessible to FlutterFragment subclasses.
+    try {
+      Field field = FlutterFragment.class.getDeclaredField("delegate");
+      field.setAccessible(true);
+      assertTrue(Modifier.isProtected(field.getModifiers()));
+    } catch (Exception e) {
+      assertTrue(false);
+    }
   }
 }

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
@@ -223,8 +223,8 @@ public class FlutterFragmentTest {
   }
 }
 
-// It‘s a compile-time check to ensure that FlutterFragment subclasses can access
-// FlutterActivityAndFragmentDelegate.
+// It‘s a compile-time check to ensure that FlutterActivityAndFragmentDelegate is
+// accessible to FlutterFragment subclasses.
 static class FlutterFragmentSubclass extends FlutterFragment {
   public void performAttach() {
     getFlutterEngine().getActivityControlSurface().attachToActivity(delegate, getLifecycle());


### PR DESCRIPTION
In the `FlutterActivity` subclass, we can access the instance of `FlutterActivityAndFragmentDelegate` which is `protected`, as below show. 

```java
public class FlutterActivityEx extends FlutterActivity {
    private void performAttach() {
          // Attach plugins to the activity.
          // getFlutterEngine().getActivityControlSurface().attachToActivity(getActivity(), getLifecycle());
          getFlutterEngine().getActivityControlSurface().attachToActivity(delegate, getLifecycle());
    }
}
```

But, in `FlutterFragment`, the instance of `FlutterActivityAndFragmentDelegate` is package-level access.  so we expect to modify the `delegate` member to `protected`, similar to `FlutterActivity`. Make sure FlutterActivity/FlutterFragment subclasses can call `flutterEngine.getActivityControlSurface().attachToActivity(delegate, getLifecycle())`.

Related issues: [#issues/93905](https://github.com/flutter/flutter/issues/93905)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
