### PR TITLE
Use MallocMapping for DispatchSemanticsAction data

### DIFF
--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -471,9 +471,10 @@ bool FlutterWindowsEngine::MarkExternalTextureFrameAvailable(
 bool FlutterWindowsEngine::DispatchSemanticsAction(
     uint64_t target,
     FlutterSemanticsAction action,
-    const std::vector<uint8_t>& data) {
-  return (embedder_api_.DispatchSemanticsAction(
-              engine_, target, action, data.data(), data.size()) == kSuccess);
+    fml::MallocMapping data) {
+  return (embedder_api_.DispatchSemanticsAction(engine_, target, action,
+                                                data.GetMapping(),
+                                                data.GetSize()) == kSuccess);
 }
 
 void FlutterWindowsEngine::UpdateSemanticsEnabled(bool enabled) {

--- a/shell/platform/windows/flutter_windows_engine.h
+++ b/shell/platform/windows/flutter_windows_engine.h
@@ -152,7 +152,7 @@ class FlutterWindowsEngine {
   // Dispatches a semantics action to the specified semantics node.
   bool DispatchSemanticsAction(uint64_t id,
                                FlutterSemanticsAction action,
-                               const std::vector<uint8_t>& data);
+                               fml::MallocMapping data);
 
   // Informs the engine that the semantics enabled state has changed.
   void UpdateSemanticsEnabled(bool enabled);

--- a/shell/platform/windows/flutter_windows_engine_unittests.cc
+++ b/shell/platform/windows/flutter_windows_engine_unittests.cc
@@ -236,22 +236,22 @@ TEST(FlutterWindowsEngine, DispatchSemanticsAction) {
   EngineModifier modifier(engine.get());
 
   bool called = false;
-  std::string test_data = "Hello";
+  std::string message = "Hello";
   modifier.embedder_api().DispatchSemanticsAction = MOCK_ENGINE_PROC(
       DispatchSemanticsAction,
-      ([&called, &test_data](auto engine, auto target, auto action, auto data,
-                             auto data_length) {
+      ([&called, &message](auto engine, auto target, auto action, auto data,
+                           auto data_length) {
         called = true;
         EXPECT_EQ(target, 42);
         EXPECT_EQ(action, kFlutterSemanticsActionDismiss);
-        EXPECT_EQ(memcmp(data, test_data.c_str(), test_data.size()), 0);
-        EXPECT_EQ(data_length, test_data.size());
+        EXPECT_EQ(memcmp(data, message.c_str(), message.size()), 0);
+        EXPECT_EQ(data_length, message.size());
         return kSuccess;
       }));
 
-  engine->DispatchSemanticsAction(
-      42, kFlutterSemanticsActionDismiss,
-      std::vector<uint8_t>(test_data.begin(), test_data.end()));
+  auto data = fml::MallocMapping::Copy(message.c_str(), message.size());
+  engine->DispatchSemanticsAction(42, kFlutterSemanticsActionDismiss,
+                                  std::move(data));
   EXPECT_TRUE(called);
 }
 


### PR DESCRIPTION
In the Windows embedder, the data parameter of
FlutterWindowsEngine::DispatchSemanticsAction was a vector of bytes.
Here, we switch it to use MallocMapping since that is the type of the
data paramater on the DispatchAccessibilityAction method of
AccessibilityBridgeDelegate, which calls this method. This avoids an
extra type conversion.

This is a cleanup patch with no functional changes, but makes this
call very slightly more performant in the follow-up events patch.

Issue: https://github.com/flutter/flutter/issues/77838

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
