### PR TITLE
Don't run curl in verbose mode when --verbose set

### DIFF
--- a/tools/download_dart_sdk.py
+++ b/tools/download_dart_sdk.py
@@ -108,7 +108,6 @@ def DownloadDartSDK(channel, version, os_name, arch, verbose):
     url,
   ]
   if verbose:
-    curl_command.append('--verbose')
     print('Running: "%s"' % (' '.join(curl_command)))
   curl_result = subprocess.run(
     curl_command,


### PR DESCRIPTION
In download_dart_sdk.py, we previously ran curl with the --verbose flag
when the --verbose flag was passed to the script. This generates vast
quantities of output that is unlikely to be valuable except if we're
attempting to debug a curl download issue. In such a case we could
perhaps pass a separate --verbose-download flag as well.

Issue: https://github.com/flutter/flutter/issues/94492


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
