### PR TITLE
Win32: Handle OnAccessibilityEvent

### DIFF
--- a/shell/platform/windows/accessibility_bridge_delegate_win32.cc
+++ b/shell/platform/windows/accessibility_bridge_delegate_win32.cc
@@ -18,7 +18,120 @@ AccessibilityBridgeDelegateWin32::AccessibilityBridgeDelegateWin32(
 
 void AccessibilityBridgeDelegateWin32::OnAccessibilityEvent(
     ui::AXEventGenerator::TargetedEvent targeted_event) {
-  // TODO(cbracken): https://github.com/flutter/flutter/issues/77838
+  ui::AXNode* ax_node = targeted_event.node;
+  ui::AXEventGenerator::Event event_type = targeted_event.event_params.event;
+
+  // Look up the flutter platform node delegate.
+  auto bridge = engine_->accessibility_bridge().lock();
+  assert(bridge);
+  auto node_delegate =
+      bridge->GetFlutterPlatformNodeDelegateFromID(ax_node->id()).lock();
+  assert(node_delegate);
+  std::shared_ptr<FlutterPlatformNodeDelegateWin32> win_delegate =
+      std::static_pointer_cast<FlutterPlatformNodeDelegateWin32>(node_delegate);
+
+  switch (event_type) {
+    case ui::AXEventGenerator::Event::ALERT:
+      DispatchWinAccessibilityEvent(win_delegate, EVENT_SYSTEM_ALERT);
+      break;
+    case ui::AXEventGenerator::Event::CHILDREN_CHANGED:
+      DispatchWinAccessibilityEvent(win_delegate, EVENT_OBJECT_REORDER);
+      break;
+    case ui::AXEventGenerator::Event::FOCUS_CHANGED:
+      DispatchWinAccessibilityEvent(win_delegate, EVENT_OBJECT_FOCUS);
+      break;
+    case ui::AXEventGenerator::Event::IGNORED_CHANGED:
+      if (ax_node->IsIgnored()) {
+        DispatchWinAccessibilityEvent(win_delegate, EVENT_OBJECT_HIDE);
+      }
+      break;
+    case ui::AXEventGenerator::Event::IMAGE_ANNOTATION_CHANGED:
+      DispatchWinAccessibilityEvent(win_delegate, EVENT_OBJECT_NAMECHANGE);
+      break;
+    case ui::AXEventGenerator::Event::LIVE_REGION_CHANGED:
+      DispatchWinAccessibilityEvent(win_delegate,
+                                    EVENT_OBJECT_LIVEREGIONCHANGED);
+      break;
+    case ui::AXEventGenerator::Event::NAME_CHANGED:
+      DispatchWinAccessibilityEvent(win_delegate, EVENT_OBJECT_NAMECHANGE);
+      break;
+    case ui::AXEventGenerator::Event::SCROLL_HORIZONTAL_POSITION_CHANGED:
+      DispatchWinAccessibilityEvent(win_delegate, EVENT_SYSTEM_SCROLLINGEND);
+      break;
+    case ui::AXEventGenerator::Event::SCROLL_VERTICAL_POSITION_CHANGED:
+      DispatchWinAccessibilityEvent(win_delegate, EVENT_SYSTEM_SCROLLINGEND);
+      break;
+    case ui::AXEventGenerator::Event::SELECTED_CHANGED:
+      DispatchWinAccessibilityEvent(win_delegate, EVENT_OBJECT_VALUECHANGE);
+      break;
+    case ui::AXEventGenerator::Event::SELECTED_CHILDREN_CHANGED:
+      DispatchWinAccessibilityEvent(win_delegate, EVENT_OBJECT_SELECTIONWITHIN);
+      break;
+    case ui::AXEventGenerator::Event::SUBTREE_CREATED:
+      DispatchWinAccessibilityEvent(win_delegate, EVENT_OBJECT_SHOW);
+      break;
+    case ui::AXEventGenerator::Event::VALUE_CHANGED:
+      DispatchWinAccessibilityEvent(win_delegate, EVENT_OBJECT_VALUECHANGE);
+      break;
+    case ui::AXEventGenerator::Event::WIN_IACCESSIBLE_STATE_CHANGED:
+      DispatchWinAccessibilityEvent(win_delegate, EVENT_OBJECT_STATECHANGE);
+      break;
+    case ui::AXEventGenerator::Event::ACCESS_KEY_CHANGED:
+    case ui::AXEventGenerator::Event::ACTIVE_DESCENDANT_CHANGED:
+    case ui::AXEventGenerator::Event::ATK_TEXT_OBJECT_ATTRIBUTE_CHANGED:
+    case ui::AXEventGenerator::Event::ATOMIC_CHANGED:
+    case ui::AXEventGenerator::Event::AUTO_COMPLETE_CHANGED:
+    case ui::AXEventGenerator::Event::BUSY_CHANGED:
+    case ui::AXEventGenerator::Event::CHECKED_STATE_CHANGED:
+    case ui::AXEventGenerator::Event::CLASS_NAME_CHANGED:
+    case ui::AXEventGenerator::Event::COLLAPSED:
+    case ui::AXEventGenerator::Event::CONTROLS_CHANGED:
+    case ui::AXEventGenerator::Event::DESCRIBED_BY_CHANGED:
+    case ui::AXEventGenerator::Event::DESCRIPTION_CHANGED:
+    case ui::AXEventGenerator::Event::DOCUMENT_SELECTION_CHANGED:
+    case ui::AXEventGenerator::Event::DOCUMENT_TITLE_CHANGED:
+    case ui::AXEventGenerator::Event::DROPEFFECT_CHANGED:
+    case ui::AXEventGenerator::Event::ENABLED_CHANGED:
+    case ui::AXEventGenerator::Event::EXPANDED:
+    case ui::AXEventGenerator::Event::FLOW_FROM_CHANGED:
+    case ui::AXEventGenerator::Event::FLOW_TO_CHANGED:
+    case ui::AXEventGenerator::Event::GRABBED_CHANGED:
+    case ui::AXEventGenerator::Event::HASPOPUP_CHANGED:
+    case ui::AXEventGenerator::Event::HIERARCHICAL_LEVEL_CHANGED:
+    case ui::AXEventGenerator::Event::INVALID_STATUS_CHANGED:
+    case ui::AXEventGenerator::Event::KEY_SHORTCUTS_CHANGED:
+    case ui::AXEventGenerator::Event::LABELED_BY_CHANGED:
+    case ui::AXEventGenerator::Event::LANGUAGE_CHANGED:
+    case ui::AXEventGenerator::Event::LAYOUT_INVALIDATED:
+    case ui::AXEventGenerator::Event::LIVE_REGION_CREATED:
+    case ui::AXEventGenerator::Event::LIVE_REGION_NODE_CHANGED:
+    case ui::AXEventGenerator::Event::LIVE_RELEVANT_CHANGED:
+    case ui::AXEventGenerator::Event::LIVE_STATUS_CHANGED:
+    case ui::AXEventGenerator::Event::LOAD_COMPLETE:
+    case ui::AXEventGenerator::Event::LOAD_START:
+    case ui::AXEventGenerator::Event::MENU_ITEM_SELECTED:
+    case ui::AXEventGenerator::Event::MULTILINE_STATE_CHANGED:
+    case ui::AXEventGenerator::Event::MULTISELECTABLE_STATE_CHANGED:
+    case ui::AXEventGenerator::Event::OBJECT_ATTRIBUTE_CHANGED:
+    case ui::AXEventGenerator::Event::OTHER_ATTRIBUTE_CHANGED:
+    case ui::AXEventGenerator::Event::PLACEHOLDER_CHANGED:
+    case ui::AXEventGenerator::Event::PORTAL_ACTIVATED:
+    case ui::AXEventGenerator::Event::POSITION_IN_SET_CHANGED:
+    case ui::AXEventGenerator::Event::READONLY_CHANGED:
+    case ui::AXEventGenerator::Event::RELATED_NODE_CHANGED:
+    case ui::AXEventGenerator::Event::REQUIRED_STATE_CHANGED:
+    case ui::AXEventGenerator::Event::ROLE_CHANGED:
+    case ui::AXEventGenerator::Event::ROW_COUNT_CHANGED:
+    case ui::AXEventGenerator::Event::SET_SIZE_CHANGED:
+    case ui::AXEventGenerator::Event::SORT_CHANGED:
+    case ui::AXEventGenerator::Event::STATE_CHANGED:
+    case ui::AXEventGenerator::Event::TEXT_ATTRIBUTE_CHANGED:
+    case ui::AXEventGenerator::Event::VALUE_MAX_CHANGED:
+    case ui::AXEventGenerator::Event::VALUE_MIN_CHANGED:
+    case ui::AXEventGenerator::Event::VALUE_STEP_CHANGED:
+      // Unhandled event type.
+      break;
+  }
 }
 
 void AccessibilityBridgeDelegateWin32::DispatchAccessibilityAction(
@@ -31,6 +144,12 @@ void AccessibilityBridgeDelegateWin32::DispatchAccessibilityAction(
 std::shared_ptr<FlutterPlatformNodeDelegate>
 AccessibilityBridgeDelegateWin32::CreateFlutterPlatformNodeDelegate() {
   return std::make_shared<FlutterPlatformNodeDelegateWin32>(engine_);
+}
+
+void AccessibilityBridgeDelegateWin32::DispatchWinAccessibilityEvent(
+    std::shared_ptr<FlutterPlatformNodeDelegateWin32> node_delegate,
+    DWORD event_type) {
+  node_delegate->DispatchWinAccessibilityEvent(event_type);
 }
 
 }  // namespace flutter

--- a/shell/platform/windows/accessibility_bridge_delegate_win32.h
+++ b/shell/platform/windows/accessibility_bridge_delegate_win32.h
@@ -6,6 +6,8 @@
 #define FLUTTER_SHELL_PLATFORM_WINDOWS_ACCESSIBILITY_BRIDGE_DELEGATE_H_
 
 #include "flutter/shell/platform/common/accessibility_bridge.h"
+
+#include "flutter/shell/platform/windows/flutter_platform_node_delegate_win32.h"
 #include "flutter/shell/platform/windows/flutter_windows_engine.h"
 
 namespace flutter {
@@ -37,6 +39,12 @@ class AccessibilityBridgeDelegateWin32
   // |AccessibilityBridge::AccessibilityBridgeDelegate|
   std::shared_ptr<FlutterPlatformNodeDelegate>
   CreateFlutterPlatformNodeDelegate() override;
+
+  // Dispatches a Windows accessibility event of the specified type, generated
+  // by the accessibility node associated with the specified semantics node.
+  virtual void DispatchWinAccessibilityEvent(
+      std::shared_ptr<FlutterPlatformNodeDelegateWin32> node_delegate,
+      DWORD event_type);
 
  private:
   FlutterWindowsEngine* engine_;

--- a/shell/platform/windows/flutter_platform_node_delegate_win32.cc
+++ b/shell/platform/windows/flutter_platform_node_delegate_win32.cc
@@ -77,4 +77,19 @@ gfx::Rect FlutterPlatformNodeDelegateWin32::GetBoundsRect(
                    extent.y - origin.y);
 }
 
+void FlutterPlatformNodeDelegateWin32::DispatchWinAccessibilityEvent(
+    DWORD event_type) {
+  FlutterWindowsView* view = engine_->view();
+  if (!view) {
+    return;
+  }
+  HWND hwnd = view->GetPlatformWindow();
+  if (!hwnd) {
+    return;
+  }
+  assert(ax_platform_node_);
+  ::NotifyWinEvent(event_type, hwnd, OBJID_CLIENT,
+                   -ax_platform_node_->GetUniqueId());
+}
+
 }  // namespace flutter

--- a/shell/platform/windows/flutter_platform_node_delegate_win32.h
+++ b/shell/platform/windows/flutter_platform_node_delegate_win32.h
@@ -40,6 +40,11 @@ class FlutterPlatformNodeDelegateWin32 : public FlutterPlatformNodeDelegate {
 
   const ui::AXUniqueId& GetUniqueId() const override { return unique_id_; }
 
+  // Dispatches a Windows accessibility event of the specified type, generated
+  // by the accessibility node associated with this object. This is a
+  // convenience wrapper around |NotifyWinEvent|.
+  virtual void DispatchWinAccessibilityEvent(DWORD event_type);
+
  private:
   ui::AXPlatformNode* ax_platform_node_;
   FlutterWindowsEngine* engine_;

--- a/shell/platform/windows/window_win32.cc
+++ b/shell/platform/windows/window_win32.cc
@@ -179,11 +179,8 @@ LRESULT WindowWin32::OnGetObject(UINT const message,
 
   gfx::NativeViewAccessible root_view = GetNativeViewAccessible();
   if (is_uia_request && root_view) {
-    Microsoft::WRL::ComPtr<IRawElementProviderSimple> root;
-    root_view->QueryInterface(IID_PPV_ARGS(&root));
-    LRESULT lresult =
-        UiaReturnRawElementProvider(window_handle_, wparam, lparam, root.Get());
-    return lresult;
+    // TODO(cbracken): https://github.com/flutter/flutter/issues/94782
+    // Implement when we adopt UIA support.
   } else if (is_msaa_request && root_view) {
     // Return the IAccessible for the root view.
     Microsoft::WRL::ComPtr<IAccessible> root(root_view);


### PR DESCRIPTION
Implements OnAccessibilityEvent, which translates events from the AXTree
into Windows MSAA event notifications.

This also eliminates the UIA root object lookup in response to
WM_GETOBJECT, since our initial implementation, like Chromium's default
implementation, is based on MSAA.

Issue: https://github.com/flutter/flutter/issues/77838

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
