### PR TITLE
Add length guard to fix Windows build with VS2019 16.11.7 headers

### DIFF
--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -171,7 +171,8 @@ static bool IsAllowedDartVMFlag(const std::string& flag) {
     // Check that the prefix of the flag matches one of the allowed flags.
     // We don't need to worry about cases like "--safe --sneaky_dangerous" as
     // the VM will discard these as a single unrecognized flag.
-    if (std::equal(allowed.begin(), allowed.end(), flag.begin())) {
+    if (flag.length() >= allowed.length() &&
+        std::equal(allowed.begin(), allowed.end(), flag.begin())) {
       return true;
     }
   }


### PR DESCRIPTION
The shell tests are failing on Windows against the latest VS2019 headers due to a new safety assert.