### PR TITLE
Document rationale for Dart VM flag prefix match

### DIFF
--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -168,7 +168,10 @@ static std::vector<std::string> ParseCommaDelimited(const std::string& input) {
 static bool IsAllowedDartVMFlag(const std::string& flag) {
   for (uint32_t i = 0; i < fml::size(gAllowedDartFlags); ++i) {
     const std::string& allowed = gAllowedDartFlags[i];
-    // Check that the prefix of the flag matches one of the allowed flags.
+    // Check that the prefix of the flag matches one of the allowed flags. This
+    // is to handle cases where flags take arguments, such as in
+    // "--max_profile_depth 1".
+    //
     // We don't need to worry about cases like "--safe --sneaky_dangerous" as
     // the VM will discard these as a single unrecognized flag.
     if (flag.length() >= allowed.length() &&


### PR DESCRIPTION
Dart VM flags are passed to Flutter via an fml::CommandLine::Option that
looks something like:

    {"dart-flags, "--max_profile_depth 1,--trace_service"}

We perform a prefix match to handle cases where Dart VM options take
arguments.

Adding the comment since in a recent review I found myself wondering why
we're using a prefix match to begin with. While the original author had
forgotten, the good news is, he wrote a test that covers this exact
case. This comment just removes one level of indirection for future
readers.

No tests added since this is a comment-only change, and a test already
exists that covers this scenario.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
