### PR TITLE
Android accessibility bridge also fire selection change event when it predict selection change.

### DIFF
--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -1215,7 +1215,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
     if (previousTextSelectionBase != semanticsNode.textSelectionBase
         || previousTextSelectionExtent != semanticsNode.textSelectionExtent) {
       final String value = semanticsNode.value != null ? semanticsNode.value : "";
-      AccessibilityEvent selectionEvent =
+      final AccessibilityEvent selectionEvent =
           obtainAccessibilityEvent(
               semanticsNode.id, AccessibilityEvent.TYPE_VIEW_TEXT_SELECTION_CHANGED);
       selectionEvent.getText().add(value);

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -1208,7 +1208,23 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
         arguments.getBoolean(AccessibilityNodeInfo.ACTION_ARGUMENT_EXTEND_SELECTION_BOOLEAN);
     // The voice access expects the semantics node to update immediately. We update the semantics
     // node based on prediction. If the result is incorrect, it will be updated in the next frame.
+    final int previousTextSelectionBase = semanticsNode.textSelectionBase;
+    final int previousTextSelectionExtent = semanticsNode.textSelectionExtent;
     predictCursorMovement(semanticsNode, granularity, forward, extendSelection);
+
+    if (previousTextSelectionBase != semanticsNode.textSelectionBase
+        || previousTextSelectionExtent != semanticsNode.textSelectionExtent) {
+      final String value = semanticsNode.value != null ? semanticsNode.value : "";
+      AccessibilityEvent selectionEvent =
+          obtainAccessibilityEvent(
+              semanticsNode.id, AccessibilityEvent.TYPE_VIEW_TEXT_SELECTION_CHANGED);
+      selectionEvent.getText().add(value);
+      selectionEvent.setFromIndex(semanticsNode.textSelectionBase);
+      selectionEvent.setToIndex(semanticsNode.textSelectionExtent);
+      selectionEvent.setItemCount(value.length());
+      sendAccessibilityEvent(selectionEvent);
+    }
+
     switch (granularity) {
       case AccessibilityNodeInfo.MOVEMENT_GRANULARITY_CHARACTER:
         {

--- a/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -6,6 +6,7 @@ package io.flutter.view;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;
@@ -1156,6 +1157,55 @@ public class AccessibilityBridgeTest {
     assertEquals(event.getFromIndex(), 1);
     assertEquals(event.getToIndex(), 1);
     assertEquals(event.getItemCount(), node1.value.length());
+  }
+
+  @Test
+  public void itDoesNotFireSelectionEventWhenPredictCursorMovementsDoesNotChangeSelection() {
+    AccessibilityChannel mockChannel = mock(AccessibilityChannel.class);
+    AccessibilityViewEmbedder mockViewEmbedder = mock(AccessibilityViewEmbedder.class);
+    AccessibilityManager mockManager = mock(AccessibilityManager.class);
+    View mockRootView = mock(View.class);
+    Context context = mock(Context.class);
+    when(mockRootView.getContext()).thenReturn(context);
+    when(context.getPackageName()).thenReturn("test");
+    AccessibilityBridge accessibilityBridge =
+        setUpBridge(
+            /*rootAccessibilityView=*/ mockRootView,
+            /*accessibilityChannel=*/ mockChannel,
+            /*accessibilityManager=*/ mockManager,
+            /*contentResolver=*/ null,
+            /*accessibilityViewEmbedder=*/ mockViewEmbedder,
+            /*platformViewsAccessibilityDelegate=*/ null);
+
+    ViewParent mockParent = mock(ViewParent.class);
+    when(mockRootView.getParent()).thenReturn(mockParent);
+    when(mockManager.isEnabled()).thenReturn(true);
+
+    TestSemanticsNode root = new TestSemanticsNode();
+    root.id = 0;
+    TestSemanticsNode node1 = new TestSemanticsNode();
+    node1.id = 1;
+    node1.value = "some text";
+    node1.textSelectionBase = 0;
+    node1.textSelectionExtent = 0;
+    node1.addFlag(AccessibilityBridge.Flag.IS_TEXT_FIELD);
+    root.children.add(node1);
+    TestSemanticsUpdate testSemanticsUpdate = root.toUpdate();
+    testSemanticsUpdate.sendUpdateToBridge(accessibilityBridge);
+    Bundle bundle = new Bundle();
+    bundle.putInt(
+        AccessibilityNodeInfo.ACTION_ARGUMENT_MOVEMENT_GRANULARITY_INT,
+        AccessibilityNodeInfo.MOVEMENT_GRANULARITY_CHARACTER);
+    bundle.putBoolean(AccessibilityNodeInfo.ACTION_ARGUMENT_EXTEND_SELECTION_BOOLEAN, false);
+    accessibilityBridge.performAction(
+        1, AccessibilityNodeInfo.ACTION_PREVIOUS_AT_MOVEMENT_GRANULARITY, bundle);
+    ArgumentCaptor<AccessibilityEvent> eventCaptor =
+        ArgumentCaptor.forClass(AccessibilityEvent.class);
+    verify(mockParent, times(1))
+        .requestSendAccessibilityEvent(eq(mockRootView), eventCaptor.capture());
+    assertEquals(eventCaptor.getAllValues().size(), 1);
+    AccessibilityEvent event = eventCaptor.getAllValues().get(0);
+    assertNotEquals(event.getEventType(), AccessibilityEvent.TYPE_VIEW_TEXT_SELECTION_CHANGED);
   }
 
   @Test


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/84920

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
