### PR TITLE
[android] Fix unexpected behavior in |detachFromFlutterEngine|.

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -647,10 +647,12 @@ public class FlutterActivity extends Activity
    * <p>After calling, this activity should be disposed immediately and not be re-used.
    */
   private void release() {
-    delegate.onDestroyView();
-    delegate.onDetach();
-    delegate.release();
-    delegate = null;
+    if (delegate != null) {
+      delegate.onDestroyView();
+      delegate.onDetach();
+      delegate.release();
+      delegate = null;
+    }
   }
 
   @Override
@@ -662,8 +664,10 @@ public class FlutterActivity extends Activity
             + " connection to the engine "
             + getFlutterEngine()
             + " evicted by another attaching activity");
-    delegate.onDestroyView();
-    delegate.onDetach();
+    if (delegate != null) {
+      delegate.onDestroyView();
+      delegate.onDetach();
+    }
   }
 
   @Override
@@ -1130,14 +1134,15 @@ public class FlutterActivity extends Activity
 
   @Override
   public void updateSystemUiOverlays() {
-    if (delegate != null && delegate.isAttached()) {
+    if (delegate != null) {
       delegate.updateSystemUiOverlays();
     }
   }
 
   private boolean stillAttachedForEvent(String event) {
     if (delegate == null || !delegate.isAttached()) {
-      Log.w(TAG, "FlutterActivity " + hashCode() + " " + event + " called after detach.");
+      Log.w(
+          TAG, "FlutterActivity " + hashCode() + " " + event + " called after release or detach.");
       return false;
     }
     return true;

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -648,8 +648,6 @@ public class FlutterActivity extends Activity
    */
   private void release() {
     if (delegate != null) {
-      delegate.onDestroyView();
-      delegate.onDetach();
       delegate.release();
       delegate = null;
     }
@@ -674,8 +672,10 @@ public class FlutterActivity extends Activity
   protected void onDestroy() {
     super.onDestroy();
     if (stillAttachedForEvent("onDestroy")) {
-      release();
+      delegate.onDestroyView();
+      delegate.onDetach();
     }
+    release();
     lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY);
   }
 

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -662,7 +662,8 @@ public class FlutterActivity extends Activity
             + " connection to the engine "
             + getFlutterEngine()
             + " evicted by another attaching activity");
-    release();
+    delegate.onDestroyView();
+    delegate.onDetach();
   }
 
   @Override
@@ -1129,14 +1130,14 @@ public class FlutterActivity extends Activity
 
   @Override
   public void updateSystemUiOverlays() {
-    if (delegate != null) {
+    if (delegate != null && delegate.isAttached()) {
       delegate.updateSystemUiOverlays();
     }
   }
 
   private boolean stillAttachedForEvent(String event) {
-    if (delegate == null) {
-      Log.w(TAG, "FlutterActivity " + hashCode() + " " + event + " called after release.");
+    if (delegate == null || !delegate.isAttached()) {
+      Log.w(TAG, "FlutterActivity " + hashCode() + " " + event + " called after detach.");
       return false;
     }
     return true;

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -1140,9 +1140,12 @@ public class FlutterActivity extends Activity
   }
 
   private boolean stillAttachedForEvent(String event) {
-    if (delegate == null || !delegate.isAttached()) {
-      Log.w(
-          TAG, "FlutterActivity " + hashCode() + " " + event + " called after release or detach.");
+    if (delegate == null) {
+      Log.w(TAG, "FlutterActivity " + hashCode() + " " + event + " called after release.");
+      return false;
+    }
+    if (!delegate.isAttached()) {
+      Log.w(TAG, "FlutterActivity " + hashCode() + " " + event + " called after detach.");
       return false;
     }
     return true;

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -80,6 +80,7 @@ import java.util.Arrays;
   private boolean isFlutterEngineFromHost;
   private boolean isFlutterUiDisplayed;
   private boolean isFirstFrameRendered;
+  private boolean isAttached;
 
   @NonNull
   private final FlutterUiDisplayListener flutterUiDisplayListener =
@@ -139,6 +140,14 @@ import java.util.Arrays;
   }
 
   /**
+   * Whether or not this {@code FlutterActivityAndFragmentDelegate} is attached to a {@code
+   * FlutterEngine}.
+   */
+  /* package */ boolean isAttached() {
+    return isAttached;
+  }
+
+  /**
    * Invoke this method from {@code Activity#onCreate(Bundle)} or {@code
    * Fragment#onAttach(Context)}.
    *
@@ -188,6 +197,7 @@ import java.util.Arrays;
     platformPlugin = host.providePlatformPlugin(host.getActivity(), flutterEngine);
 
     host.configureFlutterEngine(flutterEngine);
+    isAttached = true;
   }
 
   @Override
@@ -662,6 +672,8 @@ import java.util.Arrays;
 
       flutterEngine = null;
     }
+
+    isAttached = false;
   }
 
   /**

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
@@ -830,9 +830,11 @@ public class FlutterFragment extends Fragment
             + " connection to the engine "
             + getFlutterEngine()
             + " evicted by another attaching activity");
-    // Redundant calls are ok.
-    delegate.onDestroyView();
-    delegate.onDetach();
+    if (delegate != null) {
+      // Redundant calls are ok.
+      delegate.onDestroyView();
+      delegate.onDetach();
+    }
   }
 
   @Override
@@ -1277,7 +1279,7 @@ public class FlutterFragment extends Fragment
 
   @Override
   public void updateSystemUiOverlays() {
-    if (delegate != null && delegate.isAttached()) {
+    if (delegate != null) {
       delegate.updateSystemUiOverlays();
     }
   }
@@ -1316,7 +1318,8 @@ public class FlutterFragment extends Fragment
 
   private boolean stillAttachedForEvent(String event) {
     if (delegate == null || !delegate.isAttached()) {
-      Log.w(TAG, "FlutterFragment " + hashCode() + " " + event + " called after detach.");
+      Log.w(
+          TAG, "FlutterFragment " + hashCode() + " " + event + " called after release or detach.");
       return false;
     }
     return true;

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
@@ -833,8 +833,6 @@ public class FlutterFragment extends Fragment
     // Redundant calls are ok.
     delegate.onDestroyView();
     delegate.onDetach();
-    delegate.release();
-    delegate = null;
   }
 
   @Override
@@ -1279,7 +1277,7 @@ public class FlutterFragment extends Fragment
 
   @Override
   public void updateSystemUiOverlays() {
-    if (delegate != null) {
+    if (delegate != null && delegate.isAttached()) {
       delegate.updateSystemUiOverlays();
     }
   }
@@ -1317,8 +1315,8 @@ public class FlutterFragment extends Fragment
   }
 
   private boolean stillAttachedForEvent(String event) {
-    if (delegate == null) {
-      Log.w(TAG, "FlutterFragment " + hashCode() + " " + event + " called after release.");
+    if (delegate == null || !delegate.isAttached()) {
+      Log.w(TAG, "FlutterFragment " + hashCode() + " " + event + " called after detach.");
       return false;
     }
     return true;

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
@@ -1317,9 +1317,12 @@ public class FlutterFragment extends Fragment
   }
 
   private boolean stillAttachedForEvent(String event) {
-    if (delegate == null || !delegate.isAttached()) {
-      Log.w(
-          TAG, "FlutterFragment " + hashCode() + " " + event + " called after release or detach.");
+    if (delegate == null) {
+      Log.w(TAG, "FlutterFragment " + hashCode() + " " + event + " called after release.");
+      return false;
+    }
+    if (!delegate.isAttached()) {
+      Log.w(TAG, "FlutterFragment " + hashCode() + " " + event + " called after detach.");
       return false;
     }
     return true;

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -53,6 +54,8 @@ import org.robolectric.annotation.Config;
 @Config(manifest = Config.NONE)
 @RunWith(RobolectricTestRunner.class)
 public class FlutterActivityTest {
+  boolean isDelegateAttached;
+
   @Before
   public void setUp() {
     FlutterInjector.reset();
@@ -265,6 +268,11 @@ public class FlutterActivityTest {
     ActivityController<FlutterActivity> activityController =
         Robolectric.buildActivity(FlutterActivity.class, intent);
     FlutterActivity flutterActivity = activityController.get();
+
+    isDelegateAttached = true;
+    when(mockDelegate.isAttached()).thenAnswer(invocation -> isDelegateAttached);
+    doAnswer(invocation -> isDelegateAttached = false).when(mockDelegate).onDetach();
+
     flutterActivity.setDelegate(mockDelegate);
     flutterActivity.onStart();
     flutterActivity.onResume();

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
@@ -376,6 +376,31 @@ public class FlutterActivityTest {
   }
 
   @Test
+  public void itDoesNotReleaseEnginewhenDetachFromFlutterEngine() {
+    FlutterActivityAndFragmentDelegate mockDelegate =
+        mock(FlutterActivityAndFragmentDelegate.class);
+    isDelegateAttached = true;
+    when(mockDelegate.isAttached()).thenAnswer(invocation -> isDelegateAttached);
+    doAnswer(invocation -> isDelegateAttached = false).when(mockDelegate).onDetach();
+    FlutterEngine mockEngine = mock(FlutterEngine.class);
+    FlutterEngineCache.getInstance().put("my_cached_engine", mockEngine);
+
+    Intent intent =
+        FlutterActivity.withCachedEngine("my_cached_engine").build(RuntimeEnvironment.application);
+    ActivityController<FlutterActivity> activityController =
+        Robolectric.buildActivity(FlutterActivity.class, intent);
+    FlutterActivity flutterActivity = activityController.get();
+
+    flutterActivity.setDelegate(mockDelegate);
+    flutterActivity.onStart();
+    flutterActivity.onResume();
+    flutterActivity.onPause();
+    flutterActivity.detachFromFlutterEngine();
+    assertNotNull(mockDelegate);
+    assertFalse(mockDelegate.isAttached());
+  }
+
+  @Test
   @Config(shadows = {SplashShadowResources.class})
   public void itLoadsSplashScreenDrawable() throws PackageManager.NameNotFoundException {
     TestUtils.setApiVersion(19);

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
@@ -176,8 +176,37 @@ public class FlutterFragmentTest {
     fragment.onResume();
     fragment.onPostResume();
     fragment.onPause();
+
+    assertTrue(mockDelegate.isAttached());
     fragment.detachFromFlutterEngine();
-    assertNotNull(mockDelegate);
+    verify(mockDelegate, times(1)).onDetach();
+    verify(mockDelegate, never()).release();
+    assertFalse(mockDelegate.isAttached());
+  }
+
+  @Test
+  public void itReleaseEngineWhenOnDetach() {
+    FlutterActivityAndFragmentDelegate mockDelegate =
+        mock(FlutterActivityAndFragmentDelegate.class);
+    isDelegateAttached = true;
+    when(mockDelegate.isAttached()).thenAnswer(invocation -> isDelegateAttached);
+    doAnswer(invocation -> isDelegateAttached = false).when(mockDelegate).onDetach();
+
+    FlutterFragment fragment =
+        FlutterFragment.withCachedEngine("my_cached_engine")
+            .destroyEngineWithFragment(true)
+            .build();
+
+    fragment.setDelegate(mockDelegate);
+    fragment.onStart();
+    fragment.onResume();
+    fragment.onPostResume();
+    fragment.onPause();
+
+    assertTrue(mockDelegate.isAttached());
+    fragment.onDetach();
+    verify(mockDelegate, times(1)).onDetach();
+    verify(mockDelegate, times(1)).release();
     assertFalse(mockDelegate.isAttached());
   }
 

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
@@ -159,6 +159,29 @@ public class FlutterFragmentTest {
   }
 
   @Test
+  public void itDoesNotReleaseEnginewhenDetachFromFlutterEngine() {
+    FlutterActivityAndFragmentDelegate mockDelegate =
+        mock(FlutterActivityAndFragmentDelegate.class);
+    isDelegateAttached = true;
+    when(mockDelegate.isAttached()).thenAnswer(invocation -> isDelegateAttached);
+    doAnswer(invocation -> isDelegateAttached = false).when(mockDelegate).onDetach();
+
+    FlutterFragment fragment =
+        FlutterFragment.withCachedEngine("my_cached_engine")
+            .destroyEngineWithFragment(true)
+            .build();
+
+    fragment.setDelegate(mockDelegate);
+    fragment.onStart();
+    fragment.onResume();
+    fragment.onPostResume();
+    fragment.onPause();
+    fragment.detachFromFlutterEngine();
+    assertNotNull(mockDelegate);
+    assertFalse(mockDelegate.isAttached());
+  }
+
+  @Test
   public void itDelegatesOnBackPressedAutomaticallyWhenEnabled() {
     // We need to mock FlutterJNI to avoid triggering native code.
     FlutterJNI flutterJNI = mock(FlutterJNI.class);

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -29,6 +30,8 @@ import org.robolectric.annotation.Config;
 @Config(manifest = Config.NONE)
 @RunWith(RobolectricTestRunner.class)
 public class FlutterFragmentTest {
+  boolean isDelegateAttached;
+
   @Test
   public void itCreatesDefaultFragmentWithExpectedDefaults() {
     FlutterFragment fragment = FlutterFragment.createDefault();
@@ -118,6 +121,11 @@ public class FlutterFragmentTest {
         FlutterFragment.withCachedEngine("my_cached_engine")
             .destroyEngineWithFragment(true)
             .build();
+
+    isDelegateAttached = true;
+    when(mockDelegate.isAttached()).thenAnswer(invocation -> isDelegateAttached);
+    doAnswer(invocation -> isDelegateAttached = false).when(mockDelegate).onDetach();
+
     fragment.setDelegate(mockDelegate);
     fragment.onStart();
     fragment.onResume();
@@ -174,6 +182,9 @@ public class FlutterFragmentTest {
 
     FlutterActivityAndFragmentDelegate mockDelegate =
         mock(FlutterActivityAndFragmentDelegate.class);
+    isDelegateAttached = true;
+    when(mockDelegate.isAttached()).thenAnswer(invocation -> isDelegateAttached);
+    doAnswer(invocation -> isDelegateAttached = false).when(mockDelegate).onDetach();
     fragment.setDelegate(mockDelegate);
 
     activity.onBackPressed();


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/94802

Related issue: https://github.com/flutter/flutter/issues/49950#issuecomment-738745428

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
