### PR TITLE
Implement GetUniqueId on Windows node delegates

### DIFF
--- a/shell/platform/windows/accessibility_bridge_delegate_win32_unittests.cc
+++ b/shell/platform/windows/accessibility_bridge_delegate_win32_unittests.cc
@@ -98,6 +98,21 @@ void PopulateAXTree(std::shared_ptr<AccessibilityBridge> bridge) {
 
 }  // namespace
 
+TEST(AccessibilityBridgeDelegateWin32, NodeDelegateHasUniqueId) {
+  auto window_binding_handler =
+      std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();
+  FlutterWindowsView view(std::move(window_binding_handler));
+  view.SetEngine(GetTestEngine());
+  view.OnUpdateSemanticsEnabled(true);
+
+  auto bridge = view.GetEngine()->accessibility_bridge().lock();
+  PopulateAXTree(bridge);
+
+  auto node0_delegate = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
+  auto node1_delegate = bridge->GetFlutterPlatformNodeDelegateFromID(1).lock();
+  EXPECT_TRUE(node0_delegate->GetUniqueId() != node1_delegate->GetUniqueId());
+}
+
 TEST(AccessibilityBridgeDelegateWin32, DispatchAccessibilityAction) {
   auto window_binding_handler =
       std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();

--- a/shell/platform/windows/flutter_platform_node_delegate_win32.h
+++ b/shell/platform/windows/flutter_platform_node_delegate_win32.h
@@ -8,6 +8,7 @@
 #include "flutter/shell/platform/common/flutter_platform_node_delegate.h"
 #include "flutter/shell/platform/windows/flutter_windows_engine.h"
 #include "flutter/third_party/accessibility/ax/platform/ax_platform_node.h"
+#include "flutter/third_party/accessibility/ax/platform/ax_unique_id.h"
 
 namespace flutter {
 
@@ -37,9 +38,12 @@ class FlutterPlatformNodeDelegateWin32 : public FlutterPlatformNodeDelegate {
       const ui::AXClippingBehavior clipping_behavior,
       ui::AXOffscreenResult* offscreen_result) const override;
 
+  const ui::AXUniqueId& GetUniqueId() const override { return unique_id_; }
+
  private:
   ui::AXPlatformNode* ax_platform_node_;
   FlutterWindowsEngine* engine_;
+  ui::AXUniqueId unique_id_;
 };
 
 }  // namespace flutter


### PR DESCRIPTION
`AXPlatformNodeDelegate` provides a default implementation of `GetUniqueId()` which returns the same value (1) for all nodes. `AXPlatformNodeWin` relies on a unique ID being returned from this method in its `GetTargetFromChildID` method.

In the world MSAA accessibility, each `HWND` may have a root `IAccessible` object associated with it. Events are fired by calling the `NotifyWinEvent` Win32 call and specifying:
1. The `HWND` (in our case, the one associated with our `WindowWin32`)
2. The target object (`OBJID_CLIENT` for the root `IAccessible` associated with that `HWND`)
3. A child identifier that uniquely identifies the target node in the tree

This child identifier can be one of:
* `CHILDID_SELF` for events targeting the root `IAccessible`.
* A positive integer that specifies the index of a direct child of the root.
* A negative integer which, when negated, specifies the unique ID of a child within the tree.

On receipt of an accessibility event, `AXPlatformWin` (our `IAccessible` implementation) looks up the target `IAccessible` from the child ID specified on the event using its `GetTargetFromChildID` method and delegates the appropriate method call to that object.

So, why is this implemented on our `AXPlatformNodeDelegate` subclass and not on `AXPlatformNodeWin` itself? Because the implementation of `AXPlatformNode::GetUniqueId()` delegates this lookup to the node delegate.

As background, `AXUniqueId` automatically assigns itself a globally-unique value in its constructor; it tracks all used values in an internal static pool.

Issue: https://github.com/flutter/flutter/issues/77838

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
