### PR TITLE
Use ToT of release branch if the commit is from release branch.

### DIFF
--- a/tools/configure_framework_commit.sh
+++ b/tools/configure_framework_commit.sh
@@ -43,12 +43,9 @@ else
     COMMIT_NO=`git log --before="$LATEST_COMMIT_TIME_ENGINE" -n 1 | grep commit | cut -d ' ' -f2`
   else
     COMMIT_NO=`git rev-parse $RELEASE_BRANCH`
+    git checkout $RELEASE_BRANCH
   fi
 fi
-#else
-#  # If this is a release branch use the ToT commit of the same release branch as the engine.
-#  COMMIT_NO=`git rev-parse $RELEASE_BRANCH`
-#ifi
 
 echo "Using the flutter/flutter commit $COMMIT_NO";
 git reset --hard $COMMIT_NO

--- a/tools/configure_framework_commit.sh
+++ b/tools/configure_framework_commit.sh
@@ -15,14 +15,14 @@ cd $ENGINE_PATH/src/flutter
 ENGINE_COMMIT=`git rev-parse HEAD`
 echo "Using engine commit: $ENGINE_COMMIT"
 
-if [[ $GIT_BRANCH =~ ^flutter-.*-candidate.*$ ]]
-then
-  # $GIT_BRANCH exists this is comming from presubmit.
-  RELEASE_BRANCH="remotes/upstream/$GIT_BRANCH"
-else
-  # Try to get it from the checkout. 
-  RELEASE_BRANCH=`git branch -a --contains $ENGINE_COMMIT | grep 'flutter-.*-candidate.*' || true`
-fi
+#if [[ $GIT_BRANCH =~ ^flutter-.*-candidate.*$ ]]
+#then
+#  # $GIT_BRANCH exists this is comming from presubmit.
+#  RELEASE_BRANCH="remotes/upstream/$GIT_BRANCH"
+#else
+#  # Try to get it from the checkout. 
+#  RELEASE_BRANCH=`git branch -a --contains $ENGINE_COMMIT | grep 'flutter-.*-candidate.*' || true`
+#fi
 
 if [[ -z $FLUTTER_CLONE_REPO_PATH ]]
 then
@@ -32,8 +32,11 @@ else
   cd $FLUTTER_CLONE_REPO_PATH
 fi
 
-if [[ -z $RELEASE_BRANCH ]]
+if [[ $GIT_BRANCH =~ ^flutter-.*-candidate.*$ ]]
+#if [[ -z $RELEASE_BRANCH ]]
 then
+  COMMIT_NO==`git rev-parse HEAD`
+else
   # If this is not a release branch commit get latest commit's time for the engine repo.
   # Use date based on local time otherwise timezones might get mixed.
   LATEST_COMMIT_TIME_ENGINE=`git log -1 --date=local --format="%cd"`
@@ -43,10 +46,11 @@ then
   # Git log uses commit date not the author date.
   # Before makes the comparison considering the timezone as well.
   COMMIT_NO=`git log --before="$LATEST_COMMIT_TIME_ENGINE" -n 1 | grep commit | cut -d ' ' -f2`
-else
-  # If this is a release branch use the ToT commit of the same release branch as the engine.
-  COMMIT_NO=`git rev-parse $RELEASE_BRANCH`
 fi
+#else
+#  # If this is a release branch use the ToT commit of the same release branch as the engine.
+#  COMMIT_NO=`git rev-parse $RELEASE_BRANCH`
+#ifi
 
 echo "Using the flutter/flutter commit $COMMIT_NO";
 git reset --hard $COMMIT_NO

--- a/tools/configure_framework_commit.sh
+++ b/tools/configure_framework_commit.sh
@@ -26,7 +26,7 @@ fi
 if [[ $GIT_BRANCH =~ ^flutter-.*-candidate.*$ ]]
 then
   # Coming from presubmit and assuming the correct branch has been already checked out.
-  COMMIT_NO==`git rev-parse HEAD`
+  COMMIT_NO=`git rev-parse HEAD`
 else
   # Try to get release branch from the checkout. 
   RELEASE_BRANCH=`git branch -a --contains $ENGINE_COMMIT | grep 'flutter-.*-candidate.*' || true`

--- a/tools/configure_framework_commit.sh
+++ b/tools/configure_framework_commit.sh
@@ -8,12 +8,21 @@ then
   exit 1
 fi
 
+
 # Go to the engine git repo to get the date of the latest commit.
 cd $ENGINE_PATH/src/flutter
 
 ENGINE_COMMIT=`git rev-parse HEAD`
 echo "Using engine commit: $ENGINE_COMMIT"
-RELEASE_BRANCH=`git branch -a --contains $ENGINE_COMMIT | grep 'flutter-.*-candidate.*' || true`
+
+if [[ $GIT_BRANCH =~ ^flutter-.*-candidate.*$ ]]
+then
+  # $GIT_BRANCH exists this is comming from presubmit.
+  RELEASE_BRANCH="remotes/upstream/$GIT_BRANCH"
+else
+  # Try to get it from the checkout. 
+  RELEASE_BRANCH=`git branch -a --contains $ENGINE_COMMIT | grep 'flutter-.*-candidate.*' || true`
+fi
 
 if [[ -z $FLUTTER_CLONE_REPO_PATH ]]
 then

--- a/tools/configure_framework_commit.sh
+++ b/tools/configure_framework_commit.sh
@@ -28,7 +28,7 @@ then
   # Coming from presubmit and assuming the correct branch has been already checked out.
   COMMIT_NO=`git rev-parse HEAD`
 else
-  # Try to get release branch from the checkout. 
+  # Try to get release branch from the checkout.
   RELEASE_BRANCH=`git branch -a --contains $ENGINE_COMMIT | grep 'flutter-.*-candidate.*' || true`
   if [[ -z $RELEASE_BRANCH ]]
   then

--- a/tools/configure_framework_commit.sh
+++ b/tools/configure_framework_commit.sh
@@ -13,7 +13,7 @@ cd $ENGINE_PATH/src/flutter
 
 ENGINE_COMMIT=`git rev-parse HEAD`
 echo "Using engine commit: $ENGINE_COMMIT"
-RELEASE_BRANCH=`git branch -a --contains $ENGINE_COMMIT | grep 'flutter-.*-candidate.*'`
+RELEASE_BRANCH=`git branch -a --contains $ENGINE_COMMIT | grep 'flutter-.*-candidate.*' || true`
 
 if [[ -z $FLUTTER_CLONE_REPO_PATH ]]
 then
@@ -24,7 +24,7 @@ else
 fi
 
 if [[ -z $RELEASE_BRANCH ]]
-then	
+then
   # If this is not a release branch commit get latest commit's time for the engine repo.
   # Use date based on local time otherwise timezones might get mixed.
   LATEST_COMMIT_TIME_ENGINE=`git log -1 --date=local --format="%cd"`

--- a/tools/configure_framework_commit.sh
+++ b/tools/configure_framework_commit.sh
@@ -25,19 +25,20 @@ fi
 
 if [[ -z $RELEASE_BRANCH ]]
 then	
-# If this is not a release branch commit get latest commit's time for the engine repo.
-# Use date based on local time otherwise timezones might get mixed.
-LATEST_COMMIT_TIME_ENGINE=`git log -1 --date=local --format="%cd"`
-echo "Latest commit time on engine found as $LATEST_COMMIT_TIME_ENGINE"
+  # If this is not a release branch commit get latest commit's time for the engine repo.
+  # Use date based on local time otherwise timezones might get mixed.
+  LATEST_COMMIT_TIME_ENGINE=`git log -1 --date=local --format="%cd"`
+  echo "Latest commit time on engine found as $LATEST_COMMIT_TIME_ENGINE"
 
-# Get the time of the youngest commit older than engine commit.
-# Git log uses commit date not the author date.
-# Before makes the comparison considering the timezone as well.
-COMMIT_NO=`git log --before="$LATEST_COMMIT_TIME_ENGINE" -n 1 | grep commit | cut -d ' ' -f2`
+  # Get the time of the youngest commit older than engine commit.
+  # Git log uses commit date not the author date.
+  # Before makes the comparison considering the timezone as well.
+  COMMIT_NO=`git log --before="$LATEST_COMMIT_TIME_ENGINE" -n 1 | grep commit | cut -d ' ' -f2`
 else
-# If this is a release branch use the ToT commit of the same release branch as the engine.
-COMMIT_NO=`git rev-parse $RELEASE_BRANCH`
+  # If this is a release branch use the ToT commit of the same release branch as the engine.
+  COMMIT_NO=`git rev-parse $RELEASE_BRANCH`
 fi
+
 echo "Using the flutter/flutter commit $COMMIT_NO";
 git reset --hard $COMMIT_NO
 # Write the commit number to a file. This file will be read by the LUCI recipe.

--- a/tools/configure_framework_commit.sh
+++ b/tools/configure_framework_commit.sh
@@ -15,15 +15,6 @@ cd $ENGINE_PATH/src/flutter
 ENGINE_COMMIT=`git rev-parse HEAD`
 echo "Using engine commit: $ENGINE_COMMIT"
 
-#if [[ $GIT_BRANCH =~ ^flutter-.*-candidate.*$ ]]
-#then
-#  # $GIT_BRANCH exists this is comming from presubmit.
-#  RELEASE_BRANCH="remotes/upstream/$GIT_BRANCH"
-#else
-#  # Try to get it from the checkout. 
-#  RELEASE_BRANCH=`git branch -a --contains $ENGINE_COMMIT | grep 'flutter-.*-candidate.*' || true`
-#fi
-
 if [[ -z $FLUTTER_CLONE_REPO_PATH ]]
 then
   echo "Please set FLUTTER_CLONE_REPO_PATH environment variable."
@@ -33,19 +24,26 @@ else
 fi
 
 if [[ $GIT_BRANCH =~ ^flutter-.*-candidate.*$ ]]
-#if [[ -z $RELEASE_BRANCH ]]
 then
+  # Coming from presubmit and assuming the correct branch has been already checked out.
   COMMIT_NO==`git rev-parse HEAD`
 else
-  # If this is not a release branch commit get latest commit's time for the engine repo.
-  # Use date based on local time otherwise timezones might get mixed.
-  LATEST_COMMIT_TIME_ENGINE=`git log -1 --date=local --format="%cd"`
-  echo "Latest commit time on engine found as $LATEST_COMMIT_TIME_ENGINE"
+  # Try to get release branch from the checkout. 
+  RELEASE_BRANCH=`git branch -a --contains $ENGINE_COMMIT | grep 'flutter-.*-candidate.*' || true`
+  if [[ -z $RELEASE_BRANCH ]]
+  then
+    # If this is not a release branch commit get latest commit's time for the engine repo.
+    # Use date based on local time otherwise timezones might get mixed.
+    LATEST_COMMIT_TIME_ENGINE=`git log -1 --date=local --format="%cd"`
+    echo "Latest commit time on engine found as $LATEST_COMMIT_TIME_ENGINE"
 
-  # Get the time of the youngest commit older than engine commit.
-  # Git log uses commit date not the author date.
-  # Before makes the comparison considering the timezone as well.
-  COMMIT_NO=`git log --before="$LATEST_COMMIT_TIME_ENGINE" -n 1 | grep commit | cut -d ' ' -f2`
+    # Get the time of the youngest commit older than engine commit.
+    # Git log uses commit date not the author date.
+    # Before makes the comparison considering the timezone as well.
+    COMMIT_NO=`git log --before="$LATEST_COMMIT_TIME_ENGINE" -n 1 | grep commit | cut -d ' ' -f2`
+  else
+    COMMIT_NO=`git rev-parse $RELEASE_BRANCH`
+  fi
 fi
 #else
 #  # If this is a release branch use the ToT commit of the same release branch as the engine.

--- a/tools/configure_framework_commit.sh
+++ b/tools/configure_framework_commit.sh
@@ -11,10 +11,9 @@ fi
 # Go to the engine git repo to get the date of the latest commit.
 cd $ENGINE_PATH/src/flutter
 
-# Get latest commit's time for the engine repo.
-# Use date based on local time otherwise timezones might get mixed.
-LATEST_COMMIT_TIME_ENGINE=`git log -1 --date=local --format="%cd"`
-echo "Latest commit time on engine found as $LATEST_COMMIT_TIME_ENGINE"
+ENGINE_COMMIT=`git rev-parse HEAD`
+echo "Using engine commit: $ENGINE_COMMIT"
+RELEASE_BRANCH=`git branch -a --contains $ENGINE_COMMIT | grep 'flutter-.*-candidate.*'`
 
 if [[ -z $FLUTTER_CLONE_REPO_PATH ]]
 then
@@ -24,13 +23,23 @@ else
   cd $FLUTTER_CLONE_REPO_PATH
 fi
 
+if [[ -z $RELEASE_BRANCH ]]
+then	
+# If this is not a release branch commit get latest commit's time for the engine repo.
+# Use date based on local time otherwise timezones might get mixed.
+LATEST_COMMIT_TIME_ENGINE=`git log -1 --date=local --format="%cd"`
+echo "Latest commit time on engine found as $LATEST_COMMIT_TIME_ENGINE"
+
 # Get the time of the youngest commit older than engine commit.
 # Git log uses commit date not the author date.
 # Before makes the comparison considering the timezone as well.
 COMMIT_NO=`git log --before="$LATEST_COMMIT_TIME_ENGINE" -n 1 | grep commit | cut -d ' ' -f2`
+else
+# If this is a release branch use the ToT commit of the same release branch as the engine.
+COMMIT_NO=`git rev-parse $RELEASE_BRANCH`
+fi
 echo "Using the flutter/flutter commit $COMMIT_NO";
 git reset --hard $COMMIT_NO
-
 # Write the commit number to a file. This file will be read by the LUCI recipe.
 echo "$COMMIT_NO" >> flutter_ref.txt
 


### PR DESCRIPTION
Use the release branches consistently for web engine framework tests. With this change if a PR is coming from a release branch flutter-2.8-... branch it will checkout the same version of the framework to run the tests.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
