### PR TITLE
[fuchsia] Use network-legacy-deprecated pkg in embedder test

### DIFF
--- a/shell/platform/fuchsia/flutter/integration_flutter_tests/embedder/flutter-embedder-test2.cc
+++ b/shell/platform/fuchsia/flutter/integration_flutter_tests/embedder/flutter-embedder-test2.cc
@@ -71,9 +71,9 @@ const std::vector<std::pair<const char*, const char*>> GetInjectedServices() {
        "fuchsia-pkg://fuchsia.com/intl_property_manager#meta/"
        "intl_property_manager.cmx"},
       {"fuchsia.netstack.Netstack",
-       "fuchsia-pkg://fuchsia.com/netstack#meta/netstack.cmx"},
+       "fuchsia-pkg://fuchsia.com/network-legacy-deprecated#meta/netstack.cmx"},
       {"fuchsia.posix.socket.Provider",
-       "fuchsia-pkg://fuchsia.com/netstack#meta/netstack.cmx"},
+       "fuchsia-pkg://fuchsia.com/network-legacy-deprecated#meta/netstack.cmx"},
       {"fuchsia.tracing.provider.Registry",
        "fuchsia-pkg://fuchsia.com/trace_manager#meta/trace_manager.cmx"},
       {"fuchsia.ui.input.ImeService",


### PR DESCRIPTION
The single-component netstack package corresponding to the package URL
fuchsia-pkg://fuchsia.com/netstack#netstack.cmx will soon be deleted
from the Fuchsia tree. In preparation for this removal, update
references to this package in the flutter embedder integration test to
use the replacement package: network-legacy-deprecated.

Issue: https://fxbug.dev/86968

