### PR TITLE
Call IAccessible::accFocus to move a11y focus

### DIFF
--- a/shell/platform/windows/accessibility_bridge_delegate_win32.cc
+++ b/shell/platform/windows/accessibility_bridge_delegate_win32.cc
@@ -39,6 +39,7 @@ void AccessibilityBridgeDelegateWin32::OnAccessibilityEvent(
       break;
     case ui::AXEventGenerator::Event::FOCUS_CHANGED:
       DispatchWinAccessibilityEvent(win_delegate, EVENT_OBJECT_FOCUS);
+      SetFocus(win_delegate);
       break;
     case ui::AXEventGenerator::Event::IGNORED_CHANGED:
       if (ax_node->IsIgnored()) {
@@ -150,6 +151,11 @@ void AccessibilityBridgeDelegateWin32::DispatchWinAccessibilityEvent(
     std::shared_ptr<FlutterPlatformNodeDelegateWin32> node_delegate,
     DWORD event_type) {
   node_delegate->DispatchWinAccessibilityEvent(event_type);
+}
+
+void AccessibilityBridgeDelegateWin32::SetFocus(
+    std::shared_ptr<FlutterPlatformNodeDelegateWin32> node_delegate) {
+  node_delegate->SetFocus();
 }
 
 }  // namespace flutter

--- a/shell/platform/windows/accessibility_bridge_delegate_win32.h
+++ b/shell/platform/windows/accessibility_bridge_delegate_win32.h
@@ -46,6 +46,11 @@ class AccessibilityBridgeDelegateWin32
       std::shared_ptr<FlutterPlatformNodeDelegateWin32> node_delegate,
       DWORD event_type);
 
+  // Sets the accessibility focus to the accessibility node associated with the
+  // specified semantics node.
+  virtual void SetFocus(
+      std::shared_ptr<FlutterPlatformNodeDelegateWin32> node_delegate);
+
  private:
   FlutterWindowsEngine* engine_;
 };

--- a/shell/platform/windows/flutter_platform_node_delegate_win32.cc
+++ b/shell/platform/windows/flutter_platform_node_delegate_win32.cc
@@ -92,4 +92,11 @@ void FlutterPlatformNodeDelegateWin32::DispatchWinAccessibilityEvent(
                    -ax_platform_node_->GetUniqueId());
 }
 
+void FlutterPlatformNodeDelegateWin32::SetFocus() {
+  VARIANT varchild{};
+  varchild.vt = VT_I4;
+  varchild.lVal = CHILDID_SELF;
+  GetNativeViewAccessible()->accSelect(SELFLAG_TAKEFOCUS, varchild);
+}
+
 }  // namespace flutter

--- a/shell/platform/windows/flutter_platform_node_delegate_win32.h
+++ b/shell/platform/windows/flutter_platform_node_delegate_win32.h
@@ -45,6 +45,10 @@ class FlutterPlatformNodeDelegateWin32 : public FlutterPlatformNodeDelegate {
   // convenience wrapper around |NotifyWinEvent|.
   virtual void DispatchWinAccessibilityEvent(DWORD event_type);
 
+  // Sets the accessibility focus to the accessibility node associated with
+  // this object.
+  void SetFocus();
+
  private:
   ui::AXPlatformNode* ax_platform_node_;
   FlutterWindowsEngine* engine_;


### PR DESCRIPTION
On receipt of a FOCUS_CHANGED event from the AX tree, call
IAccessible::accFocus to tell screen readers to move the accessibility
focus to that node. This is in addition to setting the keyboard focus
via the EVENT_OBJECT_FOCUS event.

Issue: https://github.com/flutter/flutter/issues/77838

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
