### PR TITLE
Simplify win32 platform node delegate GetParent

### DIFF
--- a/shell/platform/windows/accessibility_bridge_delegate_win32_unittests.cc
+++ b/shell/platform/windows/accessibility_bridge_delegate_win32_unittests.cc
@@ -163,6 +163,36 @@ void ExpectWinEventFromAXEvent(int32_t node_id,
 
 }  // namespace
 
+TEST(AccessibilityBridgeDelegateWin32, GetParent) {
+  auto window_binding_handler =
+      std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();
+  FlutterWindowsView view(std::move(window_binding_handler));
+  view.SetEngine(GetTestEngine());
+  view.OnUpdateSemanticsEnabled(true);
+
+  auto bridge = view.GetEngine()->accessibility_bridge().lock();
+  PopulateAXTree(bridge);
+
+  auto node0_delegate = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
+  auto node1_delegate = bridge->GetFlutterPlatformNodeDelegateFromID(1).lock();
+  EXPECT_EQ(node0_delegate->GetNativeViewAccessible(),
+            node1_delegate->GetParent());
+}
+
+TEST(AccessibilityBridgeDelegateWin32, GetParentOnRootRetunsNullptr) {
+  auto window_binding_handler =
+      std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();
+  FlutterWindowsView view(std::move(window_binding_handler));
+  view.SetEngine(GetTestEngine());
+  view.OnUpdateSemanticsEnabled(true);
+
+  auto bridge = view.GetEngine()->accessibility_bridge().lock();
+  PopulateAXTree(bridge);
+
+  auto node0_delegate = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
+  ASSERT_TRUE(node0_delegate->GetParent() == nullptr);
+}
+
 TEST(AccessibilityBridgeDelegateWin32, NodeDelegateHasUniqueId) {
   auto window_binding_handler =
       std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();

--- a/shell/platform/windows/flutter_platform_node_delegate_win32.cc
+++ b/shell/platform/windows/flutter_platform_node_delegate_win32.cc
@@ -38,31 +38,6 @@ FlutterPlatformNodeDelegateWin32::GetNativeViewAccessible() {
 }
 
 // |FlutterPlatformNodeDelegate|
-gfx::NativeViewAccessible FlutterPlatformNodeDelegateWin32::GetParent() {
-  gfx::NativeViewAccessible parent = FlutterPlatformNodeDelegate::GetParent();
-  if (parent) {
-    return parent;
-  }
-  assert(engine_);
-  FlutterWindowsView* view = engine_->view();
-  if (!view) {
-    return nullptr;
-  }
-  HWND hwnd = view->GetPlatformWindow();
-  if (!hwnd) {
-    return nullptr;
-  }
-
-  IAccessible* iaccessible_parent;
-  if (SUCCEEDED(::AccessibleObjectFromWindow(
-          hwnd, OBJID_WINDOW, IID_IAccessible,
-          reinterpret_cast<void**>(&iaccessible_parent)))) {
-    return iaccessible_parent;
-  }
-  return nullptr;
-}
-
-// |FlutterPlatformNodeDelegate|
 gfx::Rect FlutterPlatformNodeDelegateWin32::GetBoundsRect(
     const ui::AXCoordinateSystem coordinate_system,
     const ui::AXClippingBehavior clipping_behavior,

--- a/shell/platform/windows/flutter_platform_node_delegate_win32.h
+++ b/shell/platform/windows/flutter_platform_node_delegate_win32.h
@@ -30,9 +30,6 @@ class FlutterPlatformNodeDelegateWin32 : public FlutterPlatformNodeDelegate {
   gfx::NativeViewAccessible GetNativeViewAccessible() override;
 
   // |FlutterPlatformNodeDelegate|
-  gfx::NativeViewAccessible GetParent() override;
-
-  // |FlutterPlatformNodeDelegate|
   gfx::Rect GetBoundsRect(
       const ui::AXCoordinateSystem coordinate_system,
       const ui::AXClippingBehavior clipping_behavior,


### PR DESCRIPTION
In the Win32 accessibility tree, each AXTree node has an associated
IAccessible object. In WindowWin32, our WM_GETOBJECT handler returns the
IAccessible associated with the root node of the tree (node 0). On other
platforms, we often add our root accessibility object as a subnode of
some existing accessibility object associated with the view. On Windows,
the root IAccessible _is_ the accessibility object associated with the
view (on Windows, and HWND).

In the previous implementation, AccessibleObjectFromWindow actually just
returns the root IAccessible object, which is equivalent to just
returning GetNativeViewAccessible. Instead, we just return null once we
hit the root of the tree.

Issue: https://github.com/flutter/flutter/issues/77838

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
