### PR TITLE
Fix TestAccessibilityBridgeDelegate event caching

### DIFF
--- a/shell/platform/common/accessibility_bridge_unittests.cc
+++ b/shell/platform/common/accessibility_bridge_unittests.cc
@@ -4,12 +4,15 @@
 
 #include "accessibility_bridge.h"
 
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 #include "test_accessibility_bridge.h"
 
 namespace flutter {
 namespace testing {
+
+using ::testing::Contains;
 
 TEST(AccessibilityBridgeTest, basicTest) {
   std::shared_ptr<AccessibilityBridge> bridge =
@@ -115,7 +118,7 @@ TEST(AccessibilityBridgeTest, canFireChildrenChangedCorrectly) {
 
   EXPECT_EQ(child1_node->GetChildCount(), 0);
   EXPECT_EQ(child1_node->GetName(), "child 1");
-  delegate->accessibilitiy_events.clear();
+  delegate->accessibility_events.clear();
 
   // Add a child to root.
   root.child_count = 2;
@@ -145,14 +148,14 @@ TEST(AccessibilityBridgeTest, canFireChildrenChangedCorrectly) {
   EXPECT_EQ(root_node->GetChildCount(), 2);
   EXPECT_EQ(root_node->GetData().child_ids[0], 1);
   EXPECT_EQ(root_node->GetData().child_ids[1], 2);
-  EXPECT_EQ(delegate->accessibilitiy_events.size(), size_t{2});
-  std::set<ui::AXEventGenerator::Event> actual_event;
-  actual_event.insert(delegate->accessibilitiy_events[0].event_params.event);
-  actual_event.insert(delegate->accessibilitiy_events[1].event_params.event);
-  EXPECT_NE(actual_event.find(ui::AXEventGenerator::Event::CHILDREN_CHANGED),
-            actual_event.end());
-  EXPECT_NE(actual_event.find(ui::AXEventGenerator::Event::SUBTREE_CREATED),
-            actual_event.end());
+  EXPECT_EQ(delegate->accessibility_events.size(), size_t{2});
+  std::set<ui::AXEventGenerator::Event> actual_event{
+      delegate->accessibility_events.begin(),
+      delegate->accessibility_events.end()};
+  EXPECT_THAT(actual_event,
+              Contains(ui::AXEventGenerator::Event::CHILDREN_CHANGED));
+  EXPECT_THAT(actual_event,
+              Contains(ui::AXEventGenerator::Event::SUBTREE_CREATED));
 }
 
 TEST(AccessibilityBridgeTest, canUpdateDelegate) {
@@ -240,7 +243,7 @@ TEST(AccessibilityBridgeTest, canHandleSelectionChangeCorrectly) {
 
   const ui::AXTreeData& tree = bridge->GetAXTreeData();
   EXPECT_EQ(tree.sel_anchor_object_id, ui::AXNode::kInvalidAXID);
-  delegate->accessibilitiy_events.clear();
+  delegate->accessibility_events.clear();
 
   // Update the selection.
   root.text_selection_base = 0;
@@ -253,10 +256,10 @@ TEST(AccessibilityBridgeTest, canHandleSelectionChangeCorrectly) {
   EXPECT_EQ(tree.sel_anchor_offset, 0);
   EXPECT_EQ(tree.sel_focus_object_id, 0);
   EXPECT_EQ(tree.sel_focus_offset, 5);
-  EXPECT_EQ(delegate->accessibilitiy_events.size(), size_t{2});
-  EXPECT_EQ(delegate->accessibilitiy_events[0].event_params.event,
+  ASSERT_EQ(delegate->accessibility_events.size(), size_t{2});
+  EXPECT_EQ(delegate->accessibility_events[0],
             ui::AXEventGenerator::Event::DOCUMENT_SELECTION_CHANGED);
-  EXPECT_EQ(delegate->accessibilitiy_events[1].event_params.event,
+  EXPECT_EQ(delegate->accessibility_events[1],
             ui::AXEventGenerator::Event::OTHER_ATTRIBUTE_CHANGED);
 }
 

--- a/shell/platform/common/test_accessibility_bridge.cc
+++ b/shell/platform/common/test_accessibility_bridge.cc
@@ -13,7 +13,7 @@ TestAccessibilityBridgeDelegate::CreateFlutterPlatformNodeDelegate() {
 
 void TestAccessibilityBridgeDelegate::OnAccessibilityEvent(
     ui::AXEventGenerator::TargetedEvent targeted_event) {
-  accessibilitiy_events.push_back(targeted_event);
+  accessibility_events.push_back(targeted_event.event_params.event);
 }
 
 void TestAccessibilityBridgeDelegate::DispatchAccessibilityAction(

--- a/shell/platform/common/test_accessibility_bridge.h
+++ b/shell/platform/common/test_accessibility_bridge.h
@@ -22,7 +22,7 @@ class TestAccessibilityBridgeDelegate
   std::shared_ptr<FlutterPlatformNodeDelegate>
   CreateFlutterPlatformNodeDelegate() override;
 
-  std::vector<ui::AXEventGenerator::TargetedEvent> accessibilitiy_events;
+  std::vector<ui::AXEventGenerator::Event> accessibility_events;
   std::vector<FlutterSemanticsAction> performed_actions;
 };
 


### PR DESCRIPTION
`TestAccessibilityBridgeDelegate::accessibility_events` previously held values of type `ui::AXEventGenerator::TargetedEvent`. [TargetedEvent](https://github.com/flutter/engine/blob/df21689a2feab24d319aaa1b02bbdc2ff89b3c6c/third_party/accessibility/ax/ax_event_generator.h#L121-L126) contains an `AXNode` pointer and a const reference to a `ui::AXEventGenerator::EventParams` object, and as such it's unsafe to make or read copies of `TargetedEvent` values outside the scope of the [AccessibilityBridgeDelegate::OnAccessibilityEvent](https://github.com/flutter/engine/blob/df21689a2feab24d319aaa1b02bbdc2ff89b3c6c/shell/platform/common/accessibility_bridge.h#L66-L75) callback.

In this patch, we update the `accessibility_events` vector to simply hold `Event` values since this is the only part of the value we use in our existing tests. If in future we need the full `TargetedEvent`, we'll need to properly copy these values.

This patch also fixes a typo in the `accessibility_events` identifier.

Issue: https://github.com/flutter/flutter/issues/77838

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
