### PR TITLE
Override FlutterPlatformNodeDelegate::GetUniqueId

### DIFF
--- a/shell/platform/common/flutter_platform_node_delegate.h
+++ b/shell/platform/common/flutter_platform_node_delegate.h
@@ -99,6 +99,9 @@ class FlutterPlatformNodeDelegate : public ui::AXPlatformNodeDelegateBase {
   virtual ~FlutterPlatformNodeDelegate() override;
 
   // |ui::AXPlatformNodeDelegateBase|
+  const ui::AXUniqueId& GetUniqueId() const override { return unique_id_; }
+
+  // |ui::AXPlatformNodeDelegateBase|
   const ui::AXNodeData& GetData() const override;
 
   // |ui::AXPlatformNodeDelegateBase|
@@ -144,6 +147,7 @@ class FlutterPlatformNodeDelegate : public ui::AXPlatformNodeDelegateBase {
  private:
   ui::AXNode* ax_node_;
   std::weak_ptr<OwnerBridge> bridge_;
+  ui::AXUniqueId unique_id_;
 };
 
 }  // namespace flutter

--- a/shell/platform/common/flutter_platform_node_delegate_unittests.cc
+++ b/shell/platform/common/flutter_platform_node_delegate_unittests.cc
@@ -12,6 +12,34 @@
 namespace flutter {
 namespace testing {
 
+TEST(FlutterPlatformNodeDelegateTest, NodeDelegateHasUniqueId) {
+  TestAccessibilityBridgeDelegate* delegate =
+      new TestAccessibilityBridgeDelegate();
+  std::unique_ptr<TestAccessibilityBridgeDelegate> ptr(delegate);
+  std::shared_ptr<AccessibilityBridge> bridge =
+      std::make_shared<AccessibilityBridge>(std::move(ptr));
+
+  // Add node 0: root.
+  FlutterSemanticsNode node0{sizeof(FlutterSemanticsNode), 0};
+  std::vector<int32_t> node0_children{1};
+  node0.child_count = node0_children.size();
+  node0.children_in_traversal_order = node0_children.data();
+  node0.children_in_hit_test_order = node0_children.data();
+
+  // Add node 1: text child of node 0.
+  FlutterSemanticsNode node1{sizeof(FlutterSemanticsNode), 1};
+  node1.label = "prefecture";
+  node1.value = "Kyoto";
+
+  bridge->AddFlutterSemanticsNodeUpdate(&node0);
+  bridge->AddFlutterSemanticsNodeUpdate(&node1);
+  bridge->CommitUpdates();
+
+  auto node0_delegate = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
+  auto node1_delegate = bridge->GetFlutterPlatformNodeDelegateFromID(1).lock();
+  EXPECT_TRUE(node0_delegate->GetUniqueId() != node1_delegate->GetUniqueId());
+}
+
 TEST(FlutterPlatformNodeDelegateTest, canPerfomActions) {
   TestAccessibilityBridgeDelegate* delegate =
       new TestAccessibilityBridgeDelegate();

--- a/shell/platform/windows/accessibility_bridge_delegate_win32_unittests.cc
+++ b/shell/platform/windows/accessibility_bridge_delegate_win32_unittests.cc
@@ -193,21 +193,6 @@ TEST(AccessibilityBridgeDelegateWin32, GetParentOnRootRetunsNullptr) {
   ASSERT_TRUE(node0_delegate->GetParent() == nullptr);
 }
 
-TEST(AccessibilityBridgeDelegateWin32, NodeDelegateHasUniqueId) {
-  auto window_binding_handler =
-      std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();
-  FlutterWindowsView view(std::move(window_binding_handler));
-  view.SetEngine(GetTestEngine());
-  view.OnUpdateSemanticsEnabled(true);
-
-  auto bridge = view.GetEngine()->accessibility_bridge().lock();
-  PopulateAXTree(bridge);
-
-  auto node0_delegate = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
-  auto node1_delegate = bridge->GetFlutterPlatformNodeDelegateFromID(1).lock();
-  EXPECT_TRUE(node0_delegate->GetUniqueId() != node1_delegate->GetUniqueId());
-}
-
 TEST(AccessibilityBridgeDelegateWin32, DispatchAccessibilityAction) {
   auto window_binding_handler =
       std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();

--- a/shell/platform/windows/flutter_platform_node_delegate_win32.h
+++ b/shell/platform/windows/flutter_platform_node_delegate_win32.h
@@ -35,8 +35,6 @@ class FlutterPlatformNodeDelegateWin32 : public FlutterPlatformNodeDelegate {
       const ui::AXClippingBehavior clipping_behavior,
       ui::AXOffscreenResult* offscreen_result) const override;
 
-  const ui::AXUniqueId& GetUniqueId() const override { return unique_id_; }
-
   // Dispatches a Windows accessibility event of the specified type, generated
   // by the accessibility node associated with this object. This is a
   // convenience wrapper around |NotifyWinEvent|.
@@ -49,7 +47,6 @@ class FlutterPlatformNodeDelegateWin32 : public FlutterPlatformNodeDelegate {
  private:
   ui::AXPlatformNode* ax_platform_node_;
   FlutterWindowsEngine* engine_;
-  ui::AXUniqueId unique_id_;
 };
 
 }  // namespace flutter


### PR DESCRIPTION
The default implementation of GetUniqueId on ui::AXPlatformNodeDelegate
always returns ID 1. We had previously implemented this on the windows
platform node delegate, but for consistency's sake, and because the
default implementation is surprising, we're promoting this to the
FlutterPlatformNodeDelegate base class.

Issue: https://github.com/flutter/flutter/issues/77838

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
