### PR TITLE
Test shell/platform/common a11y code on Windows

### DIFF
--- a/shell/platform/common/BUILD.gn
+++ b/shell/platform/common/BUILD.gn
@@ -187,7 +187,7 @@ if (enable_unittests) {
     ]
 
     # The accessibility bridge only supports MacOS for now.
-    if (is_mac) {
+    if (is_mac || is_win) {
       sources += [
         "accessibility_bridge_unittests.cc",
         "flutter_platform_node_delegate_unittests.cc",


### PR DESCRIPTION
This enables unittests for the accessibility bridge in
common_cpp_unittests, when running on Windows. Previously, we only
tested on macOS.

This is currently rebased on top of https://github.com/flutter/engine/pull/30260  which must land first.

Issue: https://github.com/flutter/flutter/issues/77838

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
