### PR TITLE
Support opacity layers for platform-views using hybrid-composition

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
+++ b/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
@@ -6,9 +6,8 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Matrix;
+import android.graphics.Paint;
 import android.graphics.Path;
-import android.graphics.Rect;
-import android.graphics.RectF;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
@@ -146,9 +145,9 @@ public class FlutterMutatorView extends FrameLayout {
     }
 
     // Apply the final opacity value on the parent canvas.
-    Rect clipBounds = canvas.getClipBounds();
-    RectF rect = new RectF(clipBounds);
-    canvas.saveLayerAlpha(rect, (int) (mutatorsStack.getFinalOpacity() * 255));
+    Paint transparency = new Paint();
+    transparency.setAlpha((int) (mutatorsStack.getFinalOpacity() * 255));
+    this.setLayerType(LAYER_TYPE_HARDWARE, transparency);
 
     super.draw(canvas);
     canvas.restore();

--- a/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
+++ b/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
@@ -29,6 +29,7 @@ public class FlutterMutatorView extends FrameLayout {
   private int top;
   private int prevLeft;
   private int prevTop;
+  private Paint paint;
 
   private final AndroidTouchProcessor androidTouchProcessor;
 
@@ -43,6 +44,7 @@ public class FlutterMutatorView extends FrameLayout {
     super(context, null);
     this.screenDensity = screenDensity;
     this.androidTouchProcessor = androidTouchProcessor;
+    paint = new Paint();
   }
 
   /** Initialize the FlutterMutatorView. */
@@ -145,9 +147,8 @@ public class FlutterMutatorView extends FrameLayout {
     }
 
     // Apply the final opacity value on the parent canvas.
-    Paint transparency = new Paint();
-    transparency.setAlpha((int) (mutatorsStack.getFinalOpacity() * 255));
-    this.setLayerType(LAYER_TYPE_HARDWARE, transparency);
+    paint.setAlpha((int) (mutatorsStack.getFinalOpacity() * 255));
+    this.setLayerType(LAYER_TYPE_HARDWARE, paint);
 
     super.draw(canvas);
     canvas.restore();

--- a/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
+++ b/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
@@ -44,7 +44,7 @@ public class FlutterMutatorView extends FrameLayout {
     super(context, null);
     this.screenDensity = screenDensity;
     this.androidTouchProcessor = androidTouchProcessor;
-    paint = new Paint();
+    this.paint = new Paint();
   }
 
   /** Initialize the FlutterMutatorView. */

--- a/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
+++ b/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
@@ -7,6 +7,8 @@ import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Matrix;
 import android.graphics.Path;
+import android.graphics.Rect;
+import android.graphics.RectF;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
@@ -142,6 +144,12 @@ public class FlutterMutatorView extends FrameLayout {
       pathCopy.offset(-left, -top);
       canvas.clipPath(pathCopy);
     }
+
+    // Apply the final opacity value on the parent canvas.
+    Rect clipBounds = canvas.getClipBounds();
+    RectF rect = new RectF(clipBounds);
+    canvas.saveLayerAlpha(rect, (int) (mutatorsStack.getFinalOpacity() * 255));
+
     super.draw(canvas);
     canvas.restore();
   }

--- a/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorsStack.java
+++ b/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorsStack.java
@@ -47,6 +47,7 @@ public class FlutterMutatorsStack {
     @Nullable private Rect rect;
     @Nullable private Path path;
     @Nullable private float[] radiis;
+    @Nullable private float opacity;
 
     private FlutterMutatorType type;
 
@@ -94,6 +95,16 @@ public class FlutterMutatorsStack {
     }
 
     /**
+     * Initialize an opacity mutator.
+     *
+     * @param opacity the opacity to apply.
+     */
+    public FlutterMutator(float opacity) {
+      this.type = FlutterMutatorType.OPACITY;
+      this.opacity = opacity;
+    }
+
+    /**
      * Get the mutator type.
      *
      * @return The type of the mutator.
@@ -128,18 +139,29 @@ public class FlutterMutatorsStack {
     public Matrix getMatrix() {
       return matrix;
     }
+
+    /**
+     * Get the opacity of the mutator if {@link #getType()} returns FlutterMutatorType.OPACITY.
+     *
+     * @return the opacity if the type is FlutterMutatorType.OPACITY; otherwise null.
+     */
+    public float getOpacity() {
+      return opacity;
+    }
   }
 
   private @NonNull List<FlutterMutator> mutators;
 
   private List<Path> finalClippingPaths;
   private Matrix finalMatrix;
+  private float finalOpacity;
 
   /** Initialize the mutator stack. */
   public FlutterMutatorsStack() {
     this.mutators = new ArrayList<FlutterMutator>();
     finalMatrix = new Matrix();
     finalClippingPaths = new ArrayList<Path>();
+    finalOpacity = 1.f;
   }
 
   /**
@@ -188,6 +210,17 @@ public class FlutterMutatorsStack {
   }
 
   /**
+   * Push an opacity {@link FlutterMutatorsStack.FlutterMutator} to the stack.
+   *
+   * @param opacity the opacity value.
+   */
+  public void pushOpacity(float opacity) {
+    FlutterMutator mutator = new FlutterMutator(opacity);
+    mutators.add(mutator);
+    finalOpacity *= opacity;
+  }
+
+  /**
    * Get a list of all the raw mutators. The 0 index of the returned list is the top of the stack.
    */
   public List<FlutterMutator> getMutators() {
@@ -213,5 +246,10 @@ public class FlutterMutatorsStack {
    */
   public Matrix getFinalMatrix() {
     return finalMatrix;
+  }
+
+  /** Returns the final opacity value. Apply this value to the canvas of the view. */
+  public float getFinalOpacity() {
+    return finalOpacity;
   }
 }

--- a/shell/platform/android/test/io/flutter/FlutterTestSuite.java
+++ b/shell/platform/android/test/io/flutter/FlutterTestSuite.java
@@ -24,6 +24,7 @@ import io.flutter.embedding.engine.deferredcomponents.PlayStoreDeferredComponent
 import io.flutter.embedding.engine.loader.ApplicationInfoLoaderTest;
 import io.flutter.embedding.engine.loader.FlutterLoaderTest;
 import io.flutter.embedding.engine.mutatorsstack.FlutterMutatorViewTest;
+import io.flutter.embedding.engine.mutatorsstack.FlutterMutatorsStackTest;
 import io.flutter.embedding.engine.plugins.shim.ShimPluginRegistryTest;
 import io.flutter.embedding.engine.renderer.FlutterRendererTest;
 import io.flutter.embedding.engine.systemchannels.DeferredComponentChannelTest;
@@ -73,6 +74,7 @@ import test.io.flutter.embedding.engine.PluginComponentTest;
   FlutterJNITest.class,
   FlutterLaunchTests.class,
   FlutterLoaderTest.class,
+  FlutterMutatorsStackTest.class,
   FlutterMutatorViewTest.class,
   FlutterShellArgsTest.class,
   FlutterRendererTest.class,

--- a/shell/platform/android/test/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorViewTest.java
@@ -1,10 +1,13 @@
 package io.flutter.embedding.engine.mutatorsstack;
 
+import static android.view.View.LAYER_TYPE_HARDWARE;
 import static android.view.View.OnFocusChangeListener;
 import static junit.framework.TestCase.*;
 import static org.mockito.Mockito.*;
 
+import android.graphics.Canvas;
 import android.graphics.Matrix;
+import android.graphics.Paint;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
@@ -249,5 +252,21 @@ public class FlutterMutatorViewTest {
 
     view.unsetOnDescendantFocusChangeListener();
     verify(viewTreeObserver, times(1)).removeOnGlobalFocusChangeListener(activeFocusListener);
+  }
+
+  @Test
+  public void draw_opacityApplied() {
+    final FlutterMutatorView view = new FlutterMutatorView(RuntimeEnvironment.systemContext);
+    final FlutterMutatorView spy = spy(view);
+
+    final FlutterMutatorsStack mutatorsStack = new FlutterMutatorsStack();
+    mutatorsStack.pushOpacity(.3f);
+
+    spy.readyToDisplay(mutatorsStack, /*left=*/ 1, /*top=*/ 2, /*width=*/ 0, /*height=*/ 0);
+    spy.draw(new Canvas());
+    verify(spy)
+        .setLayerType(
+            intThat((Integer layerType) -> layerType == LAYER_TYPE_HARDWARE),
+            argThat((Paint paint) -> paint.getAlpha() == (int) (.3f * 255)));
   }
 }

--- a/shell/platform/android/test/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorsStackTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorsStackTest.java
@@ -1,0 +1,42 @@
+package io.flutter.embedding.engine.mutatorsstack;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@Config(manifest = Config.NONE)
+@RunWith(RobolectricTestRunner.class)
+public class FlutterMutatorsStackTest {
+
+  @Test
+  public void pushOpacity() {
+    final FlutterMutatorsStack mutatorsStack = new FlutterMutatorsStack();
+    mutatorsStack.pushOpacity(.5f);
+
+    assertEquals(mutatorsStack.getMutators().size(), 1);
+    assertEquals(
+        mutatorsStack.getMutators().get(0).getType(),
+        FlutterMutatorsStack.FlutterMutatorType.OPACITY);
+    assertEquals(mutatorsStack.getMutators().get(0).getOpacity(), .5f, 0f);
+  }
+
+  @Test
+  public void defaultOpacity() {
+    final FlutterMutatorsStack mutatorsStack = new FlutterMutatorsStack();
+
+    assertEquals(1f, mutatorsStack.getFinalOpacity(), 0f);
+  }
+
+  @Test
+  public void layeredOpacity() {
+    final FlutterMutatorsStack mutatorsStack = new FlutterMutatorsStack();
+    mutatorsStack.pushOpacity(.5f);
+    mutatorsStack.pushOpacity(.6f);
+    mutatorsStack.pushOpacity(1f);
+
+    assertEquals(.3f, mutatorsStack.getFinalOpacity(), 1 / 255);
+  }
+}


### PR DESCRIPTION
SceneBuilder opacity layers are not currently supported for Android platform-views using hybrid-composition.
This PR implements it. 

Note that even though #58426 mentions opacity being implemented, it does not seem to be the case.

Fixes [#93757](https://github.com/flutter/flutter/issues/93757)
Advances [#58426](https://github.com/flutter/flutter/issues/58426)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.