### PR TITLE
[canvaskit] Only dispose views to release overlays as long as there are overlays available

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
@@ -346,8 +346,7 @@ class HtmlViewEmbedder {
             final svg.ClipPathElement newClipPath = svg.ClipPathElement();
             newClipPath.id = clipId;
             newClipPath.append(
-                svg.PathElement()
-                  ..setAttribute('d', path.toSvgString()!));
+                svg.PathElement()..setAttribute('d', path.toSvgString()!));
 
             pathDefs.append(newClipPath);
             // Store the id of the node instead of [newClipPath] directly. For
@@ -365,8 +364,7 @@ class HtmlViewEmbedder {
             final svg.ClipPathElement newClipPath = svg.ClipPathElement();
             newClipPath.id = clipId;
             newClipPath.append(
-                svg.PathElement()
-                  ..setAttribute('d', path.toSvgString()!));
+                svg.PathElement()..setAttribute('d', path.toSvgString()!));
             pathDefs.append(newClipPath);
             // Store the id of the node instead of [newClipPath] directly. For
             // some reason, calling `newClipPath.remove()` doesn't remove it
@@ -651,7 +649,8 @@ class HtmlViewEmbedder {
         // them. Otherwise, we will need to release overlays from the unchanged
         // segment of view ids.
         if (diffResult.viewsToAdd.length > availableOverlays) {
-          int viewsToDispose = diffResult.viewsToAdd.length - availableOverlays;
+          int viewsToDispose = math.min(SurfaceFactory.instance.maximumOverlays,
+              diffResult.viewsToAdd.length - availableOverlays);
           // The first `maximumSurfaces` views in the previous composition order
           // had an overlay.
           int index = SurfaceFactory.instance.maximumOverlays -

--- a/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
@@ -346,7 +346,8 @@ class HtmlViewEmbedder {
             final svg.ClipPathElement newClipPath = svg.ClipPathElement();
             newClipPath.id = clipId;
             newClipPath.append(
-                svg.PathElement()..setAttribute('d', path.toSvgString()!));
+                svg.PathElement()
+                  ..setAttribute('d', path.toSvgString()!));
 
             pathDefs.append(newClipPath);
             // Store the id of the node instead of [newClipPath] directly. For
@@ -364,7 +365,8 @@ class HtmlViewEmbedder {
             final svg.ClipPathElement newClipPath = svg.ClipPathElement();
             newClipPath.id = clipId;
             newClipPath.append(
-                svg.PathElement()..setAttribute('d', path.toSvgString()!));
+                svg.PathElement()
+                  ..setAttribute('d', path.toSvgString()!));
             pathDefs.append(newClipPath);
             // Store the id of the node instead of [newClipPath] directly. For
             // some reason, calling `newClipPath.remove()` doesn't remove it

--- a/lib/web_ui/lib/src/engine/configuration.dart
+++ b/lib/web_ui/lib/src/engine/configuration.dart
@@ -35,8 +35,7 @@ import 'package:js/js.dart';
 const String _canvaskitVersion = '0.31.0';
 
 /// The Web Engine configuration for the current application.
-FlutterConfiguration get configuration =>
-    _configuration ??= FlutterConfiguration(_jsConfiguration);
+FlutterConfiguration get configuration => _configuration ??= FlutterConfiguration(_jsConfiguration);
 FlutterConfiguration? _configuration;
 
 /// Sets the given configuration as the current one.
@@ -78,6 +77,7 @@ class FlutterConfiguration {
   static const bool useSkia =
       bool.fromEnvironment('FLUTTER_WEB_USE_SKIA', defaultValue: false);
 
+
   // Runtime parameters.
   //
   // These parameters can be supplied either as environment variables, or at
@@ -107,8 +107,7 @@ class FlutterConfiguration {
   ///   --web-renderer=canvaskit \
   ///   --dart-define=FLUTTER_WEB_CANVASKIT_URL=https://example.com/custom-canvaskit-build/
   /// ```
-  String get canvasKitBaseUrl =>
-      _js?.canvasKitBaseUrl ?? _defaultCanvasKitBaseUrl;
+  String get canvasKitBaseUrl => _js?.canvasKitBaseUrl ?? _defaultCanvasKitBaseUrl;
   static const String _defaultCanvasKitBaseUrl = String.fromEnvironment(
     'FLUTTER_WEB_CANVASKIT_URL',
     defaultValue: 'https://unpkg.com/canvaskit-wasm@$_canvaskitVersion/bin/',
@@ -119,8 +118,7 @@ class FlutterConfiguration {
   ///
   /// This is mainly used for testing or for apps that want to ensure they
   /// run on devices which don't support WebGL.
-  bool get canvasKitForceCpuOnly =>
-      _js?.canvasKitForceCpuOnly ?? _defaultCanvasKitForceCpuOnly;
+  bool get canvasKitForceCpuOnly => _js?.canvasKitForceCpuOnly ?? _defaultCanvasKitForceCpuOnly;
   static const bool _defaultCanvasKitForceCpuOnly = bool.fromEnvironment(
     'FLUTTER_WEB_CANVASKIT_FORCE_CPU_ONLY',
     defaultValue: false,
@@ -135,8 +133,7 @@ class FlutterConfiguration {
   ///
   /// This value can be specified using either the `FLUTTER_WEB_MAXIMUM_SURFACES`
   /// environment variable, or using the runtime configuration.
-  int get canvasKitMaximumSurfaces =>
-      _js?.canvasKitMaximumSurfaces ?? _defaultCanvasKitMaximumSurfaces;
+  int get canvasKitMaximumSurfaces => _js?.canvasKitMaximumSurfaces ?? _defaultCanvasKitMaximumSurfaces;
   static const int _defaultCanvasKitMaximumSurfaces = int.fromEnvironment(
     'FLUTTER_WEB_MAXIMUM_SURFACES',
     defaultValue: 8,
@@ -153,8 +150,7 @@ class FlutterConfiguration {
   /// ```
   /// flutter run -d chrome --profile --dart-define=FLUTTER_WEB_DEBUG_SHOW_SEMANTICS=true
   /// ```
-  bool get debugShowSemanticsNodes =>
-      _js?.debugShowSemanticsNodes ?? _defaultDebugShowSemanticsNodes;
+  bool get debugShowSemanticsNodes => _js?.debugShowSemanticsNodes ?? _defaultDebugShowSemanticsNodes;
   static const bool _defaultDebugShowSemanticsNodes = bool.fromEnvironment(
     'FLUTTER_WEB_DEBUG_SHOW_SEMANTICS',
     defaultValue: false,

--- a/lib/web_ui/lib/src/engine/configuration.dart
+++ b/lib/web_ui/lib/src/engine/configuration.dart
@@ -35,7 +35,8 @@ import 'package:js/js.dart';
 const String _canvaskitVersion = '0.31.0';
 
 /// The Web Engine configuration for the current application.
-FlutterConfiguration get configuration => _configuration ??= FlutterConfiguration(_jsConfiguration);
+FlutterConfiguration get configuration =>
+    _configuration ??= FlutterConfiguration(_jsConfiguration);
 FlutterConfiguration? _configuration;
 
 /// Sets the given configuration as the current one.
@@ -77,7 +78,6 @@ class FlutterConfiguration {
   static const bool useSkia =
       bool.fromEnvironment('FLUTTER_WEB_USE_SKIA', defaultValue: false);
 
-
   // Runtime parameters.
   //
   // These parameters can be supplied either as environment variables, or at
@@ -107,7 +107,8 @@ class FlutterConfiguration {
   ///   --web-renderer=canvaskit \
   ///   --dart-define=FLUTTER_WEB_CANVASKIT_URL=https://example.com/custom-canvaskit-build/
   /// ```
-  String get canvasKitBaseUrl => _js?.canvasKitBaseUrl ?? _defaultCanvasKitBaseUrl;
+  String get canvasKitBaseUrl =>
+      _js?.canvasKitBaseUrl ?? _defaultCanvasKitBaseUrl;
   static const String _defaultCanvasKitBaseUrl = String.fromEnvironment(
     'FLUTTER_WEB_CANVASKIT_URL',
     defaultValue: 'https://unpkg.com/canvaskit-wasm@$_canvaskitVersion/bin/',
@@ -118,7 +119,8 @@ class FlutterConfiguration {
   ///
   /// This is mainly used for testing or for apps that want to ensure they
   /// run on devices which don't support WebGL.
-  bool get canvasKitForceCpuOnly => _js?.canvasKitForceCpuOnly ?? _defaultCanvasKitForceCpuOnly;
+  bool get canvasKitForceCpuOnly =>
+      _js?.canvasKitForceCpuOnly ?? _defaultCanvasKitForceCpuOnly;
   static const bool _defaultCanvasKitForceCpuOnly = bool.fromEnvironment(
     'FLUTTER_WEB_CANVASKIT_FORCE_CPU_ONLY',
     defaultValue: false,
@@ -133,7 +135,8 @@ class FlutterConfiguration {
   ///
   /// This value can be specified using either the `FLUTTER_WEB_MAXIMUM_SURFACES`
   /// environment variable, or using the runtime configuration.
-  int get canvasKitMaximumSurfaces => _js?.canvasKitMaximumSurfaces ?? _defaultCanvasKitMaximumSurfaces;
+  int get canvasKitMaximumSurfaces =>
+      _js?.canvasKitMaximumSurfaces ?? _defaultCanvasKitMaximumSurfaces;
   static const int _defaultCanvasKitMaximumSurfaces = int.fromEnvironment(
     'FLUTTER_WEB_MAXIMUM_SURFACES',
     defaultValue: 8,
@@ -150,7 +153,8 @@ class FlutterConfiguration {
   /// ```
   /// flutter run -d chrome --profile --dart-define=FLUTTER_WEB_DEBUG_SHOW_SEMANTICS=true
   /// ```
-  bool get debugShowSemanticsNodes => _js?.debugShowSemanticsNodes ?? _defaultDebugShowSemanticsNodes;
+  bool get debugShowSemanticsNodes =>
+      _js?.debugShowSemanticsNodes ?? _defaultDebugShowSemanticsNodes;
   static const bool _defaultDebugShowSemanticsNodes = bool.fromEnvironment(
     'FLUTTER_WEB_DEBUG_SHOW_SEMANTICS',
     defaultValue: false,
@@ -166,8 +170,10 @@ external JsFlutterConfiguration? get _jsConfiguration;
 class JsFlutterConfiguration {
   external String? get canvasKitBaseUrl;
   external bool? get canvasKitForceCpuOnly;
-  external int? get canvasKitMaximumSurfaces;
   external bool? get debugShowSemanticsNodes;
+
+  external int? get canvasKitMaximumSurfaces;
+  external set canvasKitMaximumSurfaces(int? maxSurfaces);
 }
 
 /// A JavaScript entrypoint that allows developer to set rendering backend

--- a/lib/web_ui/test/canvaskit/embedded_views_test.dart
+++ b/lib/web_ui/test/canvaskit/embedded_views_test.dart
@@ -77,9 +77,7 @@ void testMain() {
       dispatcher.rasterizer!.draw(sb.build().layerTree);
 
       expect(
-        flutterViewEmbedder.sceneElement!
-            .querySelectorAll('#sk_path_defs')
-            .single,
+        flutterViewEmbedder.sceneElement!.querySelectorAll('#sk_path_defs').single,
         isNotNull,
       );
       expect(
@@ -120,8 +118,8 @@ void testMain() {
       dispatcher.rasterizer!.draw(sb.build().layerTree);
 
       // Transformations happen on the slot element.
-      final html.Element slotHost = flutterViewEmbedder.sceneElement!
-          .querySelector('flt-platform-view-slot')!;
+      final html.Element slotHost =
+          flutterViewEmbedder.sceneElement!.querySelector('flt-platform-view-slot')!;
 
       expect(
         slotHost.style.transform,
@@ -162,8 +160,8 @@ void testMain() {
       dispatcher.rasterizer!.draw(sb.build().layerTree);
 
       // Transformations happen on the slot element.
-      final html.Element slotHost = flutterViewEmbedder.sceneElement!
-          .querySelector('flt-platform-view-slot')!;
+      final html.Element slotHost =
+          flutterViewEmbedder.sceneElement!.querySelector('flt-platform-view-slot')!;
 
       expect(
         getTransformChain(slotHost),
@@ -191,8 +189,8 @@ void testMain() {
       dispatcher.rasterizer!.draw(sb.build().layerTree);
 
       // Transformations happen on the slot element.
-      final html.Element slotHost = flutterViewEmbedder.sceneElement!
-          .querySelector('flt-platform-view-slot')!;
+      final html.Element slotHost =
+          flutterViewEmbedder.sceneElement!.querySelector('flt-platform-view-slot')!;
 
       expect(
         getTransformChain(slotHost),
@@ -236,9 +234,7 @@ void testMain() {
       }
 
       int countCanvases() {
-        return flutterViewEmbedder.sceneElement!
-            .querySelectorAll('canvas')
-            .length;
+        return flutterViewEmbedder.sceneElement!.querySelectorAll('canvas').length;
       }
 
       // Frame 1:
@@ -341,9 +337,7 @@ void testMain() {
       }
 
       int countCanvases() {
-        return flutterViewEmbedder.sceneElement!
-            .querySelectorAll('canvas')
-            .length;
+        return flutterViewEmbedder.sceneElement!.querySelectorAll('canvas').length;
       }
 
       // Frame 1:
@@ -385,13 +379,11 @@ void testMain() {
       dispatcher.rasterizer!.draw(sb.build().layerTree);
 
       expect(
-        flutterViewEmbedder.sceneElement!
-            .querySelector('flt-platform-view-slot'),
+        flutterViewEmbedder.sceneElement!.querySelector('flt-platform-view-slot'),
         isNotNull,
       );
       expect(
-        flutterViewEmbedder.glassPaneElement!
-            .querySelector('flt-platform-view'),
+        flutterViewEmbedder.glassPaneElement!.querySelector('flt-platform-view'),
         isNotNull,
       );
 
@@ -402,13 +394,11 @@ void testMain() {
       dispatcher.rasterizer!.draw(sb.build().layerTree);
 
       expect(
-        flutterViewEmbedder.sceneElement!
-            .querySelector('flt-platform-view-slot'),
+        flutterViewEmbedder.sceneElement!.querySelector('flt-platform-view-slot'),
         isNull,
       );
       expect(
-        flutterViewEmbedder.glassPaneElement!
-            .querySelector('flt-platform-view'),
+        flutterViewEmbedder.glassPaneElement!.querySelector('flt-platform-view'),
         isNull,
       );
     });
@@ -429,13 +419,11 @@ void testMain() {
       dispatcher.rasterizer!.draw(sb.build().layerTree);
 
       expect(
-        flutterViewEmbedder.sceneElement!
-            .querySelector('flt-platform-view-slot'),
+        flutterViewEmbedder.sceneElement!.querySelector('flt-platform-view-slot'),
         isNotNull,
       );
       expect(
-        flutterViewEmbedder.glassPaneElement!
-            .querySelector('flt-platform-view'),
+        flutterViewEmbedder.glassPaneElement!.querySelector('flt-platform-view'),
         isNotNull,
       );
 
@@ -447,12 +435,10 @@ void testMain() {
       dispatcher.rasterizer!.draw(sb.build().layerTree);
 
       expect(
-          flutterViewEmbedder.sceneElement!
-              .querySelectorAll('flt-platform-view-slot'),
+          flutterViewEmbedder.sceneElement!.querySelectorAll('flt-platform-view-slot'),
           hasLength(1));
       expect(
-          flutterViewEmbedder.glassPaneElement!
-              .querySelectorAll('flt-platform-view'),
+          flutterViewEmbedder.glassPaneElement!.querySelectorAll('flt-platform-view'),
           hasLength(2));
 
       // Render a frame without a platform view, but also without disposing of
@@ -462,15 +448,13 @@ void testMain() {
       dispatcher.rasterizer!.draw(sb.build().layerTree);
 
       expect(
-        flutterViewEmbedder.sceneElement!
-            .querySelector('flt-platform-view-slot'),
+        flutterViewEmbedder.sceneElement!.querySelector('flt-platform-view-slot'),
         isNull,
       );
       // The actual contents of the platform view are kept in the dom, until
       // it's actually disposed of!
       expect(
-        flutterViewEmbedder.glassPaneElement!
-            .querySelector('flt-platform-view'),
+        flutterViewEmbedder.glassPaneElement!.querySelector('flt-platform-view'),
         isNotNull,
       );
     });
@@ -728,9 +712,7 @@ void testMain() {
           ui.window.platformDispatcher as EnginePlatformDispatcher;
 
       int countCanvases() {
-        return flutterViewEmbedder.sceneElement!
-            .querySelectorAll('canvas')
-            .length;
+        return flutterViewEmbedder.sceneElement!.querySelectorAll('canvas').length;
       }
 
       expect(platformViewManager.isInvisible(0), isFalse);

--- a/lib/web_ui/test/canvaskit/embedded_views_test.dart
+++ b/lib/web_ui/test/canvaskit/embedded_views_test.dart
@@ -622,8 +622,8 @@ void testMain() {
           JsFlutterConfiguration()..canvasKitMaximumSurfaces = 2));
       SurfaceFactory.instance.debugClear();
 
-      expect(SurfaceFactory.instance.maximumOverlays, 2);
-      expect(SurfaceFactory.instance.maximumSurfaces, 0);
+      expect(SurfaceFactory.instance.maximumSurfaces, 2);
+      expect(SurfaceFactory.instance.maximumOverlays, 0);
 
       ui.platformViewRegistry.registerViewFactory(
         'test-platform-view',
@@ -659,6 +659,9 @@ void testMain() {
           flutterViewEmbedder.glassPaneShadow!
               .querySelectorAll('flt-platform-view-slot'),
           hasLength(2));
+
+      // Reset configuration
+      debugSetConfiguration(FlutterConfiguration(null));
     });
 
     test(

--- a/lib/web_ui/test/canvaskit/embedded_views_test.dart
+++ b/lib/web_ui/test/canvaskit/embedded_views_test.dart
@@ -77,7 +77,9 @@ void testMain() {
       dispatcher.rasterizer!.draw(sb.build().layerTree);
 
       expect(
-        flutterViewEmbedder.sceneElement!.querySelectorAll('#sk_path_defs').single,
+        flutterViewEmbedder.sceneElement!
+            .querySelectorAll('#sk_path_defs')
+            .single,
         isNotNull,
       );
       expect(
@@ -118,8 +120,8 @@ void testMain() {
       dispatcher.rasterizer!.draw(sb.build().layerTree);
 
       // Transformations happen on the slot element.
-      final html.Element slotHost =
-          flutterViewEmbedder.sceneElement!.querySelector('flt-platform-view-slot')!;
+      final html.Element slotHost = flutterViewEmbedder.sceneElement!
+          .querySelector('flt-platform-view-slot')!;
 
       expect(
         slotHost.style.transform,
@@ -160,8 +162,8 @@ void testMain() {
       dispatcher.rasterizer!.draw(sb.build().layerTree);
 
       // Transformations happen on the slot element.
-      final html.Element slotHost =
-          flutterViewEmbedder.sceneElement!.querySelector('flt-platform-view-slot')!;
+      final html.Element slotHost = flutterViewEmbedder.sceneElement!
+          .querySelector('flt-platform-view-slot')!;
 
       expect(
         getTransformChain(slotHost),
@@ -189,8 +191,8 @@ void testMain() {
       dispatcher.rasterizer!.draw(sb.build().layerTree);
 
       // Transformations happen on the slot element.
-      final html.Element slotHost =
-          flutterViewEmbedder.sceneElement!.querySelector('flt-platform-view-slot')!;
+      final html.Element slotHost = flutterViewEmbedder.sceneElement!
+          .querySelector('flt-platform-view-slot')!;
 
       expect(
         getTransformChain(slotHost),
@@ -234,7 +236,9 @@ void testMain() {
       }
 
       int countCanvases() {
-        return flutterViewEmbedder.sceneElement!.querySelectorAll('canvas').length;
+        return flutterViewEmbedder.sceneElement!
+            .querySelectorAll('canvas')
+            .length;
       }
 
       // Frame 1:
@@ -337,7 +341,9 @@ void testMain() {
       }
 
       int countCanvases() {
-        return flutterViewEmbedder.sceneElement!.querySelectorAll('canvas').length;
+        return flutterViewEmbedder.sceneElement!
+            .querySelectorAll('canvas')
+            .length;
       }
 
       // Frame 1:
@@ -379,11 +385,13 @@ void testMain() {
       dispatcher.rasterizer!.draw(sb.build().layerTree);
 
       expect(
-        flutterViewEmbedder.sceneElement!.querySelector('flt-platform-view-slot'),
+        flutterViewEmbedder.sceneElement!
+            .querySelector('flt-platform-view-slot'),
         isNotNull,
       );
       expect(
-        flutterViewEmbedder.glassPaneElement!.querySelector('flt-platform-view'),
+        flutterViewEmbedder.glassPaneElement!
+            .querySelector('flt-platform-view'),
         isNotNull,
       );
 
@@ -394,11 +402,13 @@ void testMain() {
       dispatcher.rasterizer!.draw(sb.build().layerTree);
 
       expect(
-        flutterViewEmbedder.sceneElement!.querySelector('flt-platform-view-slot'),
+        flutterViewEmbedder.sceneElement!
+            .querySelector('flt-platform-view-slot'),
         isNull,
       );
       expect(
-        flutterViewEmbedder.glassPaneElement!.querySelector('flt-platform-view'),
+        flutterViewEmbedder.glassPaneElement!
+            .querySelector('flt-platform-view'),
         isNull,
       );
     });
@@ -419,11 +429,13 @@ void testMain() {
       dispatcher.rasterizer!.draw(sb.build().layerTree);
 
       expect(
-        flutterViewEmbedder.sceneElement!.querySelector('flt-platform-view-slot'),
+        flutterViewEmbedder.sceneElement!
+            .querySelector('flt-platform-view-slot'),
         isNotNull,
       );
       expect(
-        flutterViewEmbedder.glassPaneElement!.querySelector('flt-platform-view'),
+        flutterViewEmbedder.glassPaneElement!
+            .querySelector('flt-platform-view'),
         isNotNull,
       );
 
@@ -435,10 +447,12 @@ void testMain() {
       dispatcher.rasterizer!.draw(sb.build().layerTree);
 
       expect(
-          flutterViewEmbedder.sceneElement!.querySelectorAll('flt-platform-view-slot'),
+          flutterViewEmbedder.sceneElement!
+              .querySelectorAll('flt-platform-view-slot'),
           hasLength(1));
       expect(
-          flutterViewEmbedder.glassPaneElement!.querySelectorAll('flt-platform-view'),
+          flutterViewEmbedder.glassPaneElement!
+              .querySelectorAll('flt-platform-view'),
           hasLength(2));
 
       // Render a frame without a platform view, but also without disposing of
@@ -448,13 +462,15 @@ void testMain() {
       dispatcher.rasterizer!.draw(sb.build().layerTree);
 
       expect(
-        flutterViewEmbedder.sceneElement!.querySelector('flt-platform-view-slot'),
+        flutterViewEmbedder.sceneElement!
+            .querySelector('flt-platform-view-slot'),
         isNull,
       );
       // The actual contents of the platform view are kept in the dom, until
       // it's actually disposed of!
       expect(
-        flutterViewEmbedder.glassPaneElement!.querySelector('flt-platform-view'),
+        flutterViewEmbedder.glassPaneElement!
+            .querySelector('flt-platform-view'),
         isNotNull,
       );
     });
@@ -601,6 +617,50 @@ void testMain() {
       HtmlViewEmbedder.debugDisableOverlays = false;
     });
 
+    test('works correctly with max overlays == 2', () async {
+      debugSetConfiguration(FlutterConfiguration(
+          JsFlutterConfiguration()..canvasKitMaximumSurfaces = 2));
+      SurfaceFactory.instance.debugClear();
+
+      expect(SurfaceFactory.instance.maximumOverlays, 2);
+      expect(SurfaceFactory.instance.maximumSurfaces, 0);
+
+      ui.platformViewRegistry.registerViewFactory(
+        'test-platform-view',
+        (int viewId) => html.DivElement()..id = 'view-0',
+      );
+      await createPlatformView(0, 'test-platform-view');
+      await createPlatformView(1, 'test-platform-view');
+
+      final EnginePlatformDispatcher dispatcher =
+          ui.window.platformDispatcher as EnginePlatformDispatcher;
+
+      LayerSceneBuilder sb = LayerSceneBuilder();
+      sb.pushOffset(0, 0);
+      sb.addPlatformView(0, width: 10, height: 10);
+      sb.pop();
+      // The below line should not throw an error.
+      dispatcher.rasterizer!.draw(sb.build().layerTree);
+
+      expect(
+          flutterViewEmbedder.glassPaneShadow!
+              .querySelectorAll('flt-platform-view-slot'),
+          hasLength(1));
+
+      sb = LayerSceneBuilder();
+      sb.pushOffset(0, 0);
+      sb.addPlatformView(1, width: 10, height: 10);
+      sb.addPlatformView(0, width: 10, height: 10);
+      sb.pop();
+      // The below line should not throw an error.
+      dispatcher.rasterizer!.draw(sb.build().layerTree);
+
+      expect(
+          flutterViewEmbedder.glassPaneShadow!
+              .querySelectorAll('flt-platform-view-slot'),
+          hasLength(2));
+    });
+
     test(
         'correctly renders when overlays are disabled and a subset '
         'of views is used', () async {
@@ -665,7 +725,9 @@ void testMain() {
           ui.window.platformDispatcher as EnginePlatformDispatcher;
 
       int countCanvases() {
-        return flutterViewEmbedder.sceneElement!.querySelectorAll('canvas').length;
+        return flutterViewEmbedder.sceneElement!
+            .querySelectorAll('canvas')
+            .length;
       }
 
       expect(platformViewManager.isInvisible(0), isFalse);


### PR DESCRIPTION
We had a bug where we would attempt to dispose views which were using overlays in order to use those overlays earlier in
the composition order, but we weren't first checking that doing so would actually cause an overlay to be released.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
