### PR TITLE
Fix typo in jni registration

### DIFF
--- a/shell/platform/android/platform_view_android_jni_impl.cc
+++ b/shell/platform/android/platform_view_android_jni_impl.cc
@@ -1013,7 +1013,7 @@ bool PlatformViewAndroid::Register(JNIEnv* env) {
 
   g_mutators_stack_push_cliprrect_method = env->GetMethodID(
       g_mutators_stack_class->obj(), "pushClipRRect", "(IIII[F)V");
-  if (g_mutators_stack_push_cliprect_method == nullptr) {
+  if (g_mutators_stack_push_cliprrect_method == nullptr) {
     FML_LOG(ERROR)
         << "Could not locate FlutterMutatorsStack.pushClipRRect method";
     return false;


### PR DESCRIPTION
Fixes a typo inside the JNI registration method.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.