### PR TITLE
Dont use TypedData.fromList if you dont have a list already

### DIFF
--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -383,7 +383,7 @@ class SceneBuilder extends NativeFieldWrapperClass1 {
     assert(clipBehavior != Clip.none);
     assert(_debugCheckCanBeUsedAsOldLayer(oldLayer, 'pushClipRRect'));
     final EngineLayer engineLayer = EngineLayer._();
-    _pushClipRRect(engineLayer, rrect._value32, clipBehavior.index, oldLayer?._nativeLayer);
+    _pushClipRRect(engineLayer, rrect._getValue32(), clipBehavior.index, oldLayer?._nativeLayer);
     final ClipRRectEngineLayer layer = ClipRRectEngineLayer._(engineLayer);
     assert(_debugPushLayer(layer));
     return layer;

--- a/lib/ui/geometry.dart
+++ b/lib/ui/geometry.dart
@@ -672,7 +672,14 @@ class Rect {
     math.max(a.dy, b.dy),
   );
 
-  Float32List get _value32 => Float32List.fromList(<double>[left, top, right, bottom]);
+  Float32List _getValue32() {
+    final Float32List result = Float32List(4);
+    result[0] = left;
+    result[1] = top;
+    result[2] = right;
+    result[3] = bottom;
+    return result;
+  }
 
   /// The offset of the left edge of this rectangle from the x axis.
   final double left;
@@ -1192,20 +1199,22 @@ class RRect {
        assert(blRadiusX != null),
        assert(blRadiusY != null);
 
-  Float32List get _value32 => Float32List.fromList(<double>[
-    left,
-    top,
-    right,
-    bottom,
-    tlRadiusX,
-    tlRadiusY,
-    trRadiusX,
-    trRadiusY,
-    brRadiusX,
-    brRadiusY,
-    blRadiusX,
-    blRadiusY,
-  ]);
+  Float32List _getValue32()  {
+    final Float32List result = Float32List(12);
+    result[0] = left;
+    result[1] = top;
+    result[2] = right;
+    result[3] = bottom;
+    result[4] = tlRadiusX;
+    result[5] = tlRadiusY;
+    result[6] = trRadiusX;
+    result[7] = trRadiusY;
+    result[8] = brRadiusX;
+    result[9] = brRadiusY;
+    result[10] = blRadiusX;
+    result[11] = blRadiusY;
+    return result;
+  }
 
   /// The offset of the left edge of this rectangle from the x axis.
   final double left;

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -2495,7 +2495,7 @@ class Path extends NativeFieldWrapperClass1 {
   /// argument.
   void addRRect(RRect rrect) {
     assert(_rrectIsValid(rrect));
-    _addRRect(rrect._value32);
+    _addRRect(rrect._getValue32());
   }
   void _addRRect(Float32List rrect) native 'Path_addRRect';
 
@@ -4333,7 +4333,7 @@ class Canvas extends NativeFieldWrapperClass1 {
   void clipRRect(RRect rrect, {bool doAntiAlias = true}) {
     assert(_rrectIsValid(rrect));
     assert(doAntiAlias != null);
-    _clipRRect(rrect._value32, doAntiAlias);
+    _clipRRect(rrect._getValue32(), doAntiAlias);
   }
   void _clipRRect(Float32List rrect, bool doAntiAlias) native 'Canvas_clipRRect';
 
@@ -4409,7 +4409,7 @@ class Canvas extends NativeFieldWrapperClass1 {
   void drawRRect(RRect rrect, Paint paint) {
     assert(_rrectIsValid(rrect));
     assert(paint != null);
-    _drawRRect(rrect._value32, paint._objects, paint._data);
+    _drawRRect(rrect._getValue32(), paint._objects, paint._data);
   }
   void _drawRRect(Float32List rrect,
                   List<dynamic>? paintObjects,
@@ -4424,7 +4424,7 @@ class Canvas extends NativeFieldWrapperClass1 {
     assert(_rrectIsValid(outer));
     assert(_rrectIsValid(inner));
     assert(paint != null);
-    _drawDRRect(outer._value32, inner._value32, paint._objects, paint._data);
+    _drawDRRect(outer._getValue32(), inner._getValue32(), paint._objects, paint._data);
   }
   void _drawDRRect(Float32List outer,
                    Float32List inner,
@@ -4863,7 +4863,7 @@ class Canvas extends NativeFieldWrapperClass1 {
     }
 
     final Int32List? colorBuffer = (colors == null || colors.isEmpty) ? null : _encodeColorList(colors);
-    final Float32List? cullRectBuffer = cullRect?._value32;
+    final Float32List? cullRectBuffer = cullRect?._getValue32();
     final int qualityIndex = paint.filterQuality.index;
 
     _drawAtlas(
@@ -5037,7 +5037,7 @@ class Canvas extends NativeFieldWrapperClass1 {
 
     _drawAtlas(
       paint._objects, paint._data, qualityIndex, atlas._image, rstTransforms, rects,
-      colors, (blendMode ?? BlendMode.src).index, cullRect?._value32
+      colors, (blendMode ?? BlendMode.src).index, cullRect?._getValue32()
     );
   }
 


### PR DESCRIPTION
Path.addRRect was showing up in the traces of https://github.com/flutter/flutter/issues/94585

see: 

![image](https://user-images.githubusercontent.com/8975114/145756531-a81258f9-ed19-4f83-bb1e-6cd037eb7a8b.png)

When I looked at the implementation I found this was using fromList, which is kind of slow and probably shouldn't be used unless you already have a list. I put together a fairly simple benchmark which measured how long it takes to add an RRect to a path N times. Before the patch it was ~8.6 seconds and after it is ~6.5 seconds - which I think is a reasonable improvement for a simple code change. Since this method is private there are no breaking change implications.

@dnfield 

