### PR TITLE
Support toggle buttons for desktop accessibility

### DIFF
--- a/shell/platform/common/accessibility_bridge.cc
+++ b/shell/platform/common/accessibility_bridge.cc
@@ -253,6 +253,10 @@ void AccessibilityBridge::SetRoleFromFlutterUpdate(ui::AXNodeData& node_data,
     node_data.role = ax::mojom::Role::kCheckBox;
     return;
   }
+  if (flags & kFlutterSemanticsFlagHasToggledState) {
+    node_data.role = ax::mojom::Role::kToggleButton;
+    return;
+  }
   // If the state cannot be derived from the flutter flags, we fallback to group
   // or static text.
   if (node.children_in_traversal_order.size() == 0) {

--- a/shell/platform/common/accessibility_bridge_unittests.cc
+++ b/shell/platform/common/accessibility_bridge_unittests.cc
@@ -292,5 +292,27 @@ TEST(AccessibilityBridgeTest, doesNotAssignEditableRootToSelectableText) {
       ax::mojom::BoolAttribute::kEditableRoot));
 }
 
+TEST(AccessibilityBridgeTest, ToggleHasToggleButtonRole) {
+  std::shared_ptr<AccessibilityBridge> bridge =
+      std::make_shared<AccessibilityBridge>(
+          std::make_unique<TestAccessibilityBridgeDelegate>());
+  FlutterSemanticsNode root{.id = 0};
+  root.flags = static_cast<FlutterSemanticsFlag>(
+      FlutterSemanticsFlag::kFlutterSemanticsFlagHasToggledState |
+      FlutterSemanticsFlag::kFlutterSemanticsFlagHasEnabledState |
+      FlutterSemanticsFlag::kFlutterSemanticsFlagIsEnabled);
+  root.actions = static_cast<FlutterSemanticsAction>(0);
+  root.text_selection_base = -1;
+  root.text_selection_extent = -1;
+  root.label = "root";
+  root.child_count = 0;
+  root.custom_accessibility_actions_count = 0;
+  bridge->AddFlutterSemanticsNodeUpdate(&root);
+  bridge->CommitUpdates();
+
+  auto root_node = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
+  EXPECT_EQ(root_node->GetData().role, ax::mojom::Role::kToggleButton);
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/shell/platform/windows/accessibility_bridge_delegate_win32.cc
+++ b/shell/platform/windows/accessibility_bridge_delegate_win32.cc
@@ -34,6 +34,9 @@ void AccessibilityBridgeDelegateWin32::OnAccessibilityEvent(
     case ui::AXEventGenerator::Event::ALERT:
       DispatchWinAccessibilityEvent(win_delegate, EVENT_SYSTEM_ALERT);
       break;
+    case ui::AXEventGenerator::Event::CHECKED_STATE_CHANGED:
+      DispatchWinAccessibilityEvent(win_delegate, EVENT_OBJECT_VALUECHANGE);
+      break;
     case ui::AXEventGenerator::Event::CHILDREN_CHANGED:
       DispatchWinAccessibilityEvent(win_delegate, EVENT_OBJECT_REORDER);
       break;
@@ -83,7 +86,6 @@ void AccessibilityBridgeDelegateWin32::OnAccessibilityEvent(
     case ui::AXEventGenerator::Event::ATOMIC_CHANGED:
     case ui::AXEventGenerator::Event::AUTO_COMPLETE_CHANGED:
     case ui::AXEventGenerator::Event::BUSY_CHANGED:
-    case ui::AXEventGenerator::Event::CHECKED_STATE_CHANGED:
     case ui::AXEventGenerator::Event::CLASS_NAME_CHANGED:
     case ui::AXEventGenerator::Event::COLLAPSED:
     case ui::AXEventGenerator::Event::CONTROLS_CHANGED:


### PR DESCRIPTION
This adds support for toggle switches such as the material Switch and
CupertinoSwitch widgets. Previously, we added support for checkboxes on
desktop platforms, but not for toggle switches.

Issue: https://github.com/flutter/flutter/issues/77838

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
