### PR TITLE
Optmize path volatility tracker

### DIFF
--- a/lib/ui/painting/path.cc
+++ b/lib/ui/painting/path.cc
@@ -81,14 +81,8 @@ void CanvasPath::resetVolatility() {
     mutable_path().setIsVolatile(true);
     tracked_path_->frame_count = 0;
     tracked_path_->tracking_volatility = true;
-    path_tracker_->Insert(tracked_path_);
+    path_tracker_->Track(tracked_path_);
   }
-}
-
-void CanvasPath::ReleaseDartWrappableReference() const {
-  FML_DCHECK(path_tracker_);
-  path_tracker_->Erase(tracked_path_);
-  RefCountedDartWrappable::ReleaseDartWrappableReference();
 }
 
 int CanvasPath::getFillType() {

--- a/lib/ui/painting/path.h
+++ b/lib/ui/painting/path.h
@@ -115,8 +115,6 @@ class CanvasPath : public RefCountedDartWrappable<CanvasPath> {
 
   static void RegisterNatives(tonic::DartLibraryNatives* natives);
 
-  virtual void ReleaseDartWrappableReference() const override;
-
  private:
   CanvasPath();
 

--- a/lib/ui/ui_benchmarks.cc
+++ b/lib/ui/ui_benchmarks.cc
@@ -91,7 +91,7 @@ static void BM_PathVolatilityTracker(benchmark::State& state) {
     fml::AutoResetWaitableEvent latch;
     task_runners.GetUITaskRunner()->PostTask([&]() {
       for (auto path : paths) {
-        tracker.Insert(path);
+        tracker.Track(path);
       }
       latch.Signal();
     });
@@ -101,7 +101,7 @@ static void BM_PathVolatilityTracker(benchmark::State& state) {
     task_runners.GetUITaskRunner()->PostTask([&]() { tracker.OnFrame(); });
 
     for (int i = 0; i < path_count - 10; ++i) {
-      tracker.Erase(paths[i]);
+      paths[i].reset();
     }
 
     task_runners.GetUITaskRunner()->PostTask([&]() { tracker.OnFrame(); });

--- a/lib/ui/volatile_path_tracker.h
+++ b/lib/ui/volatile_path_tracker.h
@@ -7,7 +7,7 @@
 
 #include <deque>
 #include <mutex>
-#include <set>
+#include <vector>
 
 #include "flutter/fml/macros.h"
 #include "flutter/fml/task_runner.h"
@@ -33,6 +33,7 @@ class VolatilePathTracker {
   /// The fields of this struct must only accessed on the UI task runner.
   struct TrackedPath {
     bool tracking_volatility = false;
+    bool erased = false;
     int frame_count = 0;
     SkPath path;
   };
@@ -66,13 +67,9 @@ class VolatilePathTracker {
 
  private:
   fml::RefPtr<fml::TaskRunner> ui_task_runner_;
-  std::atomic_bool needs_drain_ = false;
-  std::mutex paths_to_remove_mutex_;
-  std::deque<std::shared_ptr<TrackedPath>> paths_to_remove_;
-  std::set<std::shared_ptr<TrackedPath>> paths_;
+  std::mutex paths_mutex_;
+  std::vector<std::shared_ptr<TrackedPath>> paths_;
   bool enabled_ = true;
-
-  void Drain();
 
   FML_DISALLOW_COPY_AND_ASSIGN(VolatilePathTracker);
 };

--- a/shell/common/shell_test.cc
+++ b/shell/common/shell_test.cc
@@ -402,5 +402,19 @@ bool ShellTest::IsAnimatorRunning(Shell* shell) {
   return running;
 }
 
+size_t ShellTest::GetLiveTrackedPathCount(
+    std::shared_ptr<VolatilePathTracker> tracker) {
+  size_t count = 0;
+  for (const std::weak_ptr<VolatilePathTracker::TrackedPath>& weak_path :
+       tracker->paths_) {
+    auto path = weak_path.lock();
+    if (!path) {
+      continue;
+    }
+    count += 1;
+  }
+  return count;
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/shell/common/shell_test.cc
+++ b/shell/common/shell_test.cc
@@ -404,16 +404,11 @@ bool ShellTest::IsAnimatorRunning(Shell* shell) {
 
 size_t ShellTest::GetLiveTrackedPathCount(
     std::shared_ptr<VolatilePathTracker> tracker) {
-  size_t count = 0;
-  for (const std::weak_ptr<VolatilePathTracker::TrackedPath>& weak_path :
-       tracker->paths_) {
-    auto path = weak_path.lock();
-    if (!path) {
-      continue;
-    }
-    count += 1;
-  }
-  return count;
+  return std::count_if(
+      tracker->paths_.begin(), tracker->paths_.end(),
+      [](std::weak_ptr<VolatilePathTracker::TrackedPath> path) {
+        return path.lock();
+      });
 }
 
 }  // namespace testing

--- a/shell/common/shell_test.h
+++ b/shell/common/shell_test.h
@@ -15,6 +15,7 @@
 #include "flutter/fml/build_config.h"
 #include "flutter/fml/macros.h"
 #include "flutter/fml/time/time_point.h"
+#include "flutter/lib/ui/volatile_path_tracker.h"
 #include "flutter/lib/ui/window/platform_message.h"
 #include "flutter/shell/common/run_configuration.h"
 #include "flutter/shell/common/shell_test_external_view_embedder.h"
@@ -123,6 +124,9 @@ class ShellTest : public FixtureTest {
   // Otherwise those tests will be flaky as the clearing of unreported timings
   // is unpredictive.
   static int UnreportedTimingsCount(Shell* shell);
+
+  static size_t GetLiveTrackedPathCount(
+      std::shared_ptr<VolatilePathTracker> tracker);
 
  private:
   ThreadHost thread_host_;


### PR DESCRIPTION
Simplifies the logic of tracking/erasing paths quite a bit. 

Before 

```
2021-12-13T10:28:52-08:00
Running out/host_profile/ui_benchmarks
Run on (16 X 2400 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x8)
  L1 Instruction 32 KiB (x8)
  L2 Unified 256 KiB (x8)
  L3 Unified 16384 KiB (x1)
Load Average: 6.17, 7.32, 6.16
---------------------------------------------------------------------------------
Benchmark                                       Time             CPU   Iterations
---------------------------------------------------------------------------------
BM_PlatformMessageResponseDartComplete       1288 us         24.3 us        10000
BM_PathVolatilityTracker                    0.573 ms        0.329 ms         2108
```

After

```
2021-12-13T10:27:54-08:00
Running out/host_profile/ui_benchmarks
Run on (16 X 2400 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x8)
  L1 Instruction 32 KiB (x8)
  L2 Unified 256 KiB (x8)
  L3 Unified 16384 KiB (x1)
Load Average: 6.61, 7.70, 6.21
---------------------------------------------------------------------------------
Benchmark                                       Time             CPU   Iterations
---------------------------------------------------------------------------------
BM_PlatformMessageResponseDartComplete       1248 us         23.7 us        10000
BM_PathVolatilityTracker                    0.306 ms        0.219 ms         3198
```

Using weak_ptr:

```
2021-12-13T14:28:35-08:00
Running out/host_profile/ui_benchmarks
Run on (16 X 2400 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x8)
  L1 Instruction 32 KiB (x8)
  L2 Unified 256 KiB (x8)
  L3 Unified 16384 KiB (x1)
Load Average: 2.55, 2.59, 2.58
---------------------------------------------------------------------------------
Benchmark                                       Time             CPU   Iterations
---------------------------------------------------------------------------------
BM_PlatformMessageResponseDartComplete       1566 us         20.3 us        10000
BM_PathVolatilityTracker                    0.220 ms        0.133 ms         5295
```

/cc @jonahwilliams 
