### PR TITLE
Add synchronization mechanism to avoid deadlock caused by thread merging

### DIFF
--- a/fml/raster_thread_merger.cc
+++ b/fml/raster_thread_merger.cc
@@ -79,7 +79,7 @@ void RasterThreadMerger::MergeWithLease(size_t lease_term) {
 
   // To avoid data races between the platform thread posting sync tasks to the
   // raster thread and the raster thread merging, we add a lock here.
-  std::scoped_lock lock{mutex_, gThreadMergingLock};
+  std::scoped_lock lock{mutex_, g_thread_merging_lock};
   bool success = shared_merger_->MergeWithLease(this, lease_term);
   if (success && merge_unmerge_callback_ != nullptr) {
     merge_unmerge_callback_();

--- a/fml/task_runner.cc
+++ b/fml/task_runner.cc
@@ -16,6 +16,8 @@
 
 namespace fml {
 
+std::mutex gThreadMergingLock;
+
 TaskRunner::TaskRunner(fml::RefPtr<MessageLoopImpl> loop)
     : loop_(std::move(loop)) {}
 
@@ -62,4 +64,9 @@ void TaskRunner::RunNowOrPostTask(fml::RefPtr<fml::TaskRunner> runner,
   }
 }
 
+void TaskRunner::RunNowOrPostSyncTask(fml::RefPtr<fml::TaskRunner> runner,
+                                      const fml::closure& task) {
+  std::scoped_lock lock(gThreadMergingLock);
+  RunNowOrPostTask(runner, task);
+}
 }  // namespace fml

--- a/fml/task_runner.cc
+++ b/fml/task_runner.cc
@@ -16,7 +16,7 @@
 
 namespace fml {
 
-std::mutex gThreadMergingLock;
+std::mutex g_thread_merging_lock;
 
 TaskRunner::TaskRunner(fml::RefPtr<MessageLoopImpl> loop)
     : loop_(std::move(loop)) {}
@@ -66,7 +66,7 @@ void TaskRunner::RunNowOrPostTask(fml::RefPtr<fml::TaskRunner> runner,
 
 void TaskRunner::RunNowOrPostSyncTask(fml::RefPtr<fml::TaskRunner> runner,
                                       const fml::closure& task) {
-  std::scoped_lock lock(gThreadMergingLock);
+  std::scoped_lock lock(g_thread_merging_lock);
   RunNowOrPostTask(runner, task);
 }
 }  // namespace fml

--- a/fml/task_runner.h
+++ b/fml/task_runner.h
@@ -16,6 +16,10 @@ namespace fml {
 
 class MessageLoopImpl;
 
+/// To avoid data races between the platform thread posting sync tasks to the
+/// raster thread and the raster thread merging.
+extern std::mutex gThreadMergingLock;
+
 /// An interface over the ability to schedule tasks on a \p TaskRunner.
 class BasicTaskRunner {
  public:
@@ -61,6 +65,11 @@ class TaskRunner : public fml::RefCountedThreadSafe<TaskRunner>,
   /// TaskRunner associated with the current executing thread.
   static void RunNowOrPostTask(fml::RefPtr<fml::TaskRunner> runner,
                                const fml::closure& task);
+
+  /// Similar to |RunNowOrPostTask|, but it needs to synchronize with thread
+  /// merging operation.
+  static void RunNowOrPostSyncTask(fml::RefPtr<fml::TaskRunner> runner,
+                                   const fml::closure& task);
 
  protected:
   explicit TaskRunner(fml::RefPtr<MessageLoopImpl> loop);

--- a/fml/task_runner.h
+++ b/fml/task_runner.h
@@ -66,9 +66,9 @@ class TaskRunner : public fml::RefCountedThreadSafe<TaskRunner>,
   static void RunNowOrPostTask(fml::RefPtr<fml::TaskRunner> runner,
                                const fml::closure& task);
 
-  /// Similar to |RunNowOrPostTask|, but it needs to synchronize with thread
-  /// merging operation.
-  static void RunNowOrPostSyncTask(fml::RefPtr<fml::TaskRunner> runner,
+  /// Similar to |RunNowOrPostTask|, but it needs to mutex with thread
+  /// merging operation and post the \p tast synchronously.
+  static void RunNowOrPostTaskSync(fml::RefPtr<fml::TaskRunner> runner,
                                    const fml::closure& task);
 
  protected:

--- a/fml/task_runner.h
+++ b/fml/task_runner.h
@@ -18,7 +18,7 @@ class MessageLoopImpl;
 
 /// To avoid data races between the platform thread posting sync tasks to the
 /// raster thread and the raster thread merging.
-extern std::mutex gThreadMergingLock;
+extern std::mutex g_thread_merging_lock;
 
 /// An interface over the ability to schedule tasks on a \p TaskRunner.
 class BasicTaskRunner {

--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -63,7 +63,7 @@ void PlatformView::NotifyCreated() {
   // so that the platform view is not collected till the surface is obtained.
   auto* platform_view = this;
   fml::ManualResetWaitableEvent latch;
-  fml::TaskRunner::RunNowOrPostTask(
+  fml::TaskRunner::RunNowOrPostSyncTask(
       task_runners_.GetRasterTaskRunner(), [platform_view, &surface, &latch]() {
         surface = platform_view->CreateRenderingSurface();
         if (surface && !surface->IsValid()) {

--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -62,16 +62,14 @@ void PlatformView::NotifyCreated() {
   // Using the weak pointer is illegal. But, we are going to introduce a latch
   // so that the platform view is not collected till the surface is obtained.
   auto* platform_view = this;
-  fml::ManualResetWaitableEvent latch;
-  fml::TaskRunner::RunNowOrPostSyncTask(
-      task_runners_.GetRasterTaskRunner(), [platform_view, &surface, &latch]() {
+  fml::TaskRunner::RunNowOrPostTaskSync(
+      task_runners_.GetRasterTaskRunner(), [platform_view, &surface]() {
         surface = platform_view->CreateRenderingSurface();
         if (surface && !surface->IsValid()) {
           surface.reset();
         }
-        latch.Signal();
       });
-  latch.Wait();
+
   if (!surface) {
     FML_LOG(ERROR) << "Failed to create platform view rendering surface";
     return;

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -98,7 +98,7 @@ void PlatformViewAndroid::NotifyCreated(
     InstallFirstFrameCallback();
 
     fml::AutoResetWaitableEvent latch;
-    fml::TaskRunner::RunNowOrPostTask(
+    fml::TaskRunner::RunNowOrPostSyncTask(
         task_runners_.GetRasterTaskRunner(),
         [&latch, surface = android_surface_.get(),
          native_window = std::move(native_window)]() {
@@ -115,7 +115,7 @@ void PlatformViewAndroid::NotifySurfaceWindowChanged(
     fml::RefPtr<AndroidNativeWindow> native_window) {
   if (android_surface_) {
     fml::AutoResetWaitableEvent latch;
-    fml::TaskRunner::RunNowOrPostTask(
+    fml::TaskRunner::RunNowOrPostSyncTask(
         task_runners_.GetRasterTaskRunner(),
         [&latch, surface = android_surface_.get(),
          native_window = std::move(native_window)]() {
@@ -132,7 +132,7 @@ void PlatformViewAndroid::NotifyDestroyed() {
 
   if (android_surface_) {
     fml::AutoResetWaitableEvent latch;
-    fml::TaskRunner::RunNowOrPostTask(
+    fml::TaskRunner::RunNowOrPostSyncTask(
         task_runners_.GetRasterTaskRunner(),
         [&latch, surface = android_surface_.get()]() {
           surface->TeardownOnScreenContext();
@@ -147,7 +147,7 @@ void PlatformViewAndroid::NotifyChanged(const SkISize& size) {
     return;
   }
   fml::AutoResetWaitableEvent latch;
-  fml::TaskRunner::RunNowOrPostTask(
+  fml::TaskRunner::RunNowOrPostSyncTask(
       task_runners_.GetRasterTaskRunner(),  //
       [&latch, surface = android_surface_.get(), size]() {
         surface->OnScreenSurfaceResize(size);


### PR DESCRIPTION
To avoid deadlock caused by thread merging:
1. Add  synchronization mechanism to ensure that during the platform thread posting synchronization messages to the raster thread, the raster thread will not perform the thread merging; 
2. Before the thread merging, flush the expired task to ensure that the synchronization message has been executed.

Fixes issue: [#94524](https://github.com/flutter/flutter/issues/94524)

/cc @dnfield 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
