### PR TITLE
Add logging to scrollable semantics test

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
@@ -266,14 +266,27 @@ class MockAccessibilityBridgeNoWindow : public AccessibilityBridgeIos {
   [scrollable setSemanticsNode:&node];
   [scrollable accessibilityBridgeDidFinishUpdate];
   UIScrollView* scrollView = [scrollable nativeAccessibility];
-  XCTAssertTrue(
-      CGRectEqualToRect(scrollView.frame, CGRectMake(x * effectivelyScale, y * effectivelyScale,
-                                                     w * effectivelyScale, h * effectivelyScale)));
-  XCTAssertTrue(CGSizeEqualToSize(
-      scrollView.contentSize,
-      CGSizeMake(w * effectivelyScale, (h + scrollExtentMax) * effectivelyScale)));
-  XCTAssertTrue(CGPointEqualToPoint(scrollView.contentOffset,
-                                    CGPointMake(0, scrollPosition * effectivelyScale)));
+
+  CGRect actualFrame = scrollView.frame;
+  CGRect expectedFrame = CGRectMake(x * effectivelyScale, y * effectivelyScale,
+                                    w * effectivelyScale, h * effectivelyScale);
+  XCTAssertTrue(CGRectEqualToRect(actualFrame, expectedFrame),
+                @"Scroll view %@ frame is %@, expected %@", scrollView,
+                NSStringFromCGRect(actualFrame), NSStringFromCGRect(expectedFrame));
+
+  CGSize actualContentSize = scrollView.contentSize;
+  CGSize expectedContentSize =
+      CGSizeMake(w * effectivelyScale, (h + scrollExtentMax) * effectivelyScale);
+  XCTAssertTrue(CGSizeEqualToSize(actualContentSize, expectedContentSize),
+                @"Scroll view %@ size is %@, expected %@", scrollView,
+                NSStringFromCGSize(actualContentSize), NSStringFromCGSize(expectedContentSize));
+
+  CGPoint actualContentOffset = scrollView.contentOffset;
+  CGPoint expectedContentOffset = CGPointMake(0, scrollPosition * effectivelyScale);
+  XCTAssertTrue(CGPointEqualToPoint(actualContentOffset, expectedContentOffset),
+                @"Scroll view %@ offset is %@, expected %@", scrollView,
+                NSStringFromCGPoint(actualContentOffset),
+                NSStringFromCGPoint(expectedContentOffset));
 }
 
 - (void)testHorizontalFlutterScrollableSemanticsObject {


### PR DESCRIPTION
Add logging to diagnose https://github.com/flutter/flutter/issues/94979.

Passing: https://ci.chromium.org/p/flutter/builders/try/Mac%20Unopt/7092?

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
