### PR TITLE
[web] make new image decoder opt-in via experimental flag

### DIFF
--- a/lib/web_ui/dev/steps/compile_tests_step.dart
+++ b/lib/web_ui/dev/steps/compile_tests_step.dart
@@ -258,6 +258,14 @@ Future<bool> compileUnitTest(FilePath input, { required bool forCanvasKit }) asy
     '-DFLUTTER_WEB_AUTO_DETECT=false',
     '-DFLUTTER_WEB_USE_SKIA=$forCanvasKit',
 
+    // Enable the image decoder experiment in tests so we can test the new
+    // functionality. WASM decoders are still tested by forcing the value of
+    // `browserSupportsImageDecoder` to false in the test. See also:
+    //
+    // lib/web_ui/test/canvaskit/image_golden_test.dart
+    // TODO(yjbanov): https://github.com/flutter/flutter/issues/95277
+    '-DEXPERIMENTAL_IMAGE_DECODER=true',
+
     '-O2',
     '-o',
     targetFileName, // target path.

--- a/lib/web_ui/lib/src/engine/safe_browser_api.dart
+++ b/lib/web_ui/lib/src/engine/safe_browser_api.dart
@@ -218,9 +218,18 @@ html.CanvasElement? tryCreateCanvasElement(int width, int height) {
 @JS('window.ImageDecoder')
 external Object? get _imageDecoderConstructor;
 
+/// Hides `image_web_codecs.dart` behind a flag.
+// TODO(yjbanov): https://github.com/flutter/flutter/issues/95277
+const bool _imageDecoderExperimentEnabled = bool.fromEnvironment(
+  'EXPERIMENTAL_IMAGE_DECODER',
+  defaultValue: false,
+);
+
 /// Whether the current browser supports `ImageDecoder`.
 bool browserSupportsImageDecoder =
-    _imageDecoderConstructor != null && browserEngine == BrowserEngine.blink;
+  _imageDecoderExperimentEnabled &&
+  _imageDecoderConstructor != null &&
+  browserEngine == BrowserEngine.blink;
 
 /// Sets the value of [browserSupportsImageDecoder] to its default value.
 void debugResetBrowserSupportsImageDecoder() {


### PR DESCRIPTION
Due to https://github.com/flutter/flutter/issues/94318 and, to a lesser extent, https://github.com/flutter/flutter/issues/94500, I'm putting the new image decoder behind an experimental flag for now. In the upcoming the stable release developers can experiment with it, but let's delay the full launch until the next release.