### PR TITLE
Revert "Removed the email warning about notifications entitlement"

### DIFF
--- a/shell/platform/darwin/ios/framework/Headers/FlutterPluginAppLifeCycleDelegate.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterPluginAppLifeCycleDelegate.h
@@ -53,28 +53,20 @@ FLUTTER_DARWIN_EXPORT
 
 /**
  * Calls all plugins registered for `UIApplicationDelegate` callbacks.
- *
- * At runtime this is also mapped to
- * `application:didRegisterForRemoteNotificationsWithDeviceToken:`.
  */
-- (void)performApplication:(UIApplication*)application
+- (void)application:(UIApplication*)application
     didRegisterForRemoteNotificationsWithDeviceToken:(NSData*)deviceToken;
 
 /**
  * Calls all plugins registered for `UIApplicationDelegate` callbacks.
- * At runtime this is also mapped to
- * `application:didFailToRegisterForRemoteNotificationsWithError:`.
  */
-- (void)performApplication:(UIApplication*)application
+- (void)application:(UIApplication*)application
     didFailToRegisterForRemoteNotificationsWithError:(NSError*)error;
 
 /**
  * Calls all plugins registered for `UIApplicationDelegate` callbacks.
- *
- * At runtime this is also mapped to
- * `application:didReceiveRemoteNotification:fetchCompletionHandler:`.
  */
-- (void)performApplication:(UIApplication*)application
+- (void)application:(UIApplication*)application
     didReceiveRemoteNotification:(NSDictionary*)userInfo
           fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler;
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -15,12 +15,6 @@ static NSString* const kUIBackgroundMode = @"UIBackgroundModes";
 static NSString* const kRemoteNotificationCapabitiliy = @"remote-notification";
 static NSString* const kBackgroundFetchCapatibility = @"fetch";
 static NSString* const kRestorationStateAppModificationKey = @"mod-date";
-static NSString* const kApplicationDidReceiveRemoteNotificationFetchCompletionHandler =
-    @"application:didReceiveRemoteNotification:fetchCompletionHandler:";
-
-static SEL ApplicationDidReceiveRemoteNotificationFetchCompletionHandlerSelector() {
-  return NSSelectorFromString(kApplicationDidReceiveRemoteNotificationFetchCompletionHandler);
-}
 
 @interface FlutterAppDelegate ()
 @property(nonatomic, copy) FlutterViewController* (^rootFlutterViewControllerGetter)(void);
@@ -95,6 +89,18 @@ static SEL ApplicationDidReceiveRemoteNotificationFetchCompletionHandlerSelector
       didRegisterUserNotificationSettings:notificationSettings];
 }
 #pragma GCC diagnostic pop
+
+- (void)application:(UIApplication*)application
+    didRegisterForRemoteNotificationsWithDeviceToken:(NSData*)deviceToken {
+  [_lifeCycleDelegate application:application
+      didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
+}
+
+- (void)application:(UIApplication*)application
+    didFailToRegisterForRemoteNotificationsWithError:(NSError*)error {
+  [_lifeCycleDelegate application:application
+      didFailToRegisterForRemoteNotificationsWithError:error];
+}
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
@@ -290,7 +296,7 @@ static SEL ApplicationDidReceiveRemoteNotificationFetchCompletionHandlerSelector
   NSArray* backgroundModesArray =
       [[NSBundle mainBundle] objectForInfoDictionaryKey:kUIBackgroundMode];
   NSSet* backgroundModesSet = [[[NSSet alloc] initWithArray:backgroundModesArray] autorelease];
-  if (selector == ApplicationDidReceiveRemoteNotificationFetchCompletionHandlerSelector()) {
+  if (selector == @selector(application:didReceiveRemoteNotification:fetchCompletionHandler:)) {
     if (![backgroundModesSet containsObject:kRemoteNotificationCapabitiliy]) {
       NSLog(
           @"You've implemented -[<UIApplicationDelegate> "

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
@@ -13,16 +13,6 @@
 
 FLUTTER_ASSERT_ARC
 
-@interface FlutterAppDelegate ()
-- (void)application:(UIApplication*)application
-    didReceiveRemoteNotification:(NSDictionary*)userInfo
-          fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler;
-- (void)application:(UIApplication*)application
-    didRegisterForRemoteNotificationsWithDeviceToken:(NSData*)deviceToken;
-- (void)application:(UIApplication*)application
-    didFailToRegisterForRemoteNotificationsWithError:(NSError*)error;
-@end
-
 @interface FlutterAppDelegateTest : XCTestCase
 @property(strong) FlutterAppDelegate* appDelegate;
 
@@ -163,61 +153,6 @@ FLUTTER_ASSERT_ARC
   XCTAssertTrue(result);
   OCMVerify([self.mockNavigationChannel invokeMethod:@"pushRoute"
                                            arguments:@"/custom/route?query=test"]);
-}
-
-- (void)testDidReceiveRemoteNotificationTrue {
-  id delegate = OCMProtocolMock(@protocol(FlutterApplicationLifeCycleDelegate));
-  [self.appDelegate addApplicationLifeCycleDelegate:delegate];
-  XCTAssertTrue([self.appDelegate
-      respondsToSelector:@selector(application:
-                             didReceiveRemoteNotification:fetchCompletionHandler:)]);
-  NSDictionary* info = @{};
-  void (^handler)(UIBackgroundFetchResult) = ^(UIBackgroundFetchResult result) {
-  };
-  [self.appDelegate application:[UIApplication sharedApplication]
-      didReceiveRemoteNotification:info
-            fetchCompletionHandler:handler];
-  [(NSObject<FlutterApplicationLifeCycleDelegate>*)[delegate verify]
-                       application:[UIApplication sharedApplication]
-      didReceiveRemoteNotification:info
-            fetchCompletionHandler:handler];
-}
-
-- (void)testDidRegisterForRemoteNotificationsWithDeviceTokenTrue {
-  id delegate = OCMProtocolMock(@protocol(FlutterApplicationLifeCycleDelegate));
-  [self.appDelegate addApplicationLifeCycleDelegate:delegate];
-  XCTAssertTrue([self.appDelegate
-      respondsToSelector:@selector(application:didRegisterForRemoteNotificationsWithDeviceToken:)]);
-  NSData* token = [[NSData alloc] init];
-  [self.appDelegate application:[UIApplication sharedApplication]
-      didRegisterForRemoteNotificationsWithDeviceToken:token];
-  [(NSObject<FlutterApplicationLifeCycleDelegate>*)[delegate verify]
-                                           application:[UIApplication sharedApplication]
-      didRegisterForRemoteNotificationsWithDeviceToken:token];
-}
-
-- (void)testDidReceiveRemoteNotificationFalse {
-  XCTAssertFalse([self.appDelegate
-      respondsToSelector:@selector(application:
-                             didReceiveRemoteNotification:fetchCompletionHandler:)]);
-}
-
-- (void)testDidRegisterForRemoteNotificationsWithDeviceTokenFalse {
-  XCTAssertFalse([self.appDelegate
-      respondsToSelector:@selector(application:didRegisterForRemoteNotificationsWithDeviceToken:)]);
-}
-
-- (void)testDidFailToRegisterForRemoteNotificationsWithError {
-  id delegate = OCMProtocolMock(@protocol(FlutterApplicationLifeCycleDelegate));
-  [self.appDelegate addApplicationLifeCycleDelegate:delegate];
-  XCTAssertTrue([self.appDelegate
-      respondsToSelector:@selector(application:didFailToRegisterForRemoteNotificationsWithError:)]);
-  NSError* error = [[NSError alloc] init];
-  [self.appDelegate application:[UIApplication sharedApplication]
-      didFailToRegisterForRemoteNotificationsWithError:error];
-  [(NSObject<FlutterApplicationLifeCycleDelegate>*)[delegate verify]
-                                           application:[UIApplication sharedApplication]
-      didFailToRegisterForRemoteNotificationsWithError:error];
 }
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm
@@ -4,7 +4,6 @@
 
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterPluginAppLifeCycleDelegate.h"
 
-#import <objc/runtime.h>
 #include "flutter/fml/logging.h"
 #include "flutter/fml/paths.h"
 #include "flutter/lib/ui/plugins/callback_cache.h"
@@ -12,17 +11,9 @@
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterCallbackCache_Internal.h"
 
 static const char* kCallbackCacheSubDir = "Library/Caches/";
-static NSString* const kApplicationDidReceiveRemoteNotificationFetchCompletionHandler =
-    @"application:didReceiveRemoteNotification:fetchCompletionHandler:";
-static NSString* const kApplicationDidRegisterForRemoteNotificationsWithDeviceToken =
-    @"application:didRegisterForRemoteNotificationsWithDeviceToken:";
-static NSString* const kApplicationDidFailToRegisterForRemoteNotificationsWithError =
-    @"application:didFailToRegisterForRemoteNotificationsWithError:";
 
 static const SEL selectorsHandledByPlugins[] = {
-    NSSelectorFromString(kApplicationDidReceiveRemoteNotificationFetchCompletionHandler),
-    NSSelectorFromString(kApplicationDidRegisterForRemoteNotificationsWithDeviceToken),
-    NSSelectorFromString(kApplicationDidFailToRegisterForRemoteNotificationsWithError),
+    @selector(application:didReceiveRemoteNotification:fetchCompletionHandler:),
     @selector(application:performFetchWithCompletionHandler:)};
 
 @interface FlutterPluginAppLifeCycleDelegate ()
@@ -39,35 +30,6 @@ static const SEL selectorsHandledByPlugins[] = {
 
   // Weak references to registered plugins.
   NSPointerArray* _delegates;
-}
-
-static void RemapMethod(Class thisClass, SEL originalSelector, SEL addedSelector) {
-  Method originalMethod = class_getInstanceMethod(thisClass, originalSelector);
-  IMP originalImp = method_getImplementation(originalMethod);
-  class_addMethod(thisClass, addedSelector, originalImp, method_getTypeEncoding(originalMethod));
-}
-
-+ (void)load {
-  // Swap out
-  // `performApplication:didReceiveRemoteNotification:fetchCompletionHandler:`
-  // for `application:didReceiveRemoteNotification:fetchCompletionHandler:`.
-  // This has to be done to avoid a potential false positive "Missing Push
-  // Notification Entitlement" validation failure when uploading apps to the App
-  // Store.  Linked NSPlugin implementations that have
-  // `application:didReceiveRemoteNotification:fetchCompletionHandler:` defined
-  // will cause the failure to happen correctly if the entitlements are missing.
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    RemapMethod(
-        self, @selector(performApplication:didReceiveRemoteNotification:fetchCompletionHandler:),
-        NSSelectorFromString(kApplicationDidReceiveRemoteNotificationFetchCompletionHandler));
-    RemapMethod(self,
-                @selector(performApplication:didRegisterForRemoteNotificationsWithDeviceToken:),
-                NSSelectorFromString(kApplicationDidRegisterForRemoteNotificationsWithDeviceToken));
-    RemapMethod(self,
-                @selector(performApplication:didFailToRegisterForRemoteNotificationsWithError:),
-                NSSelectorFromString(kApplicationDidFailToRegisterForRemoteNotificationsWithError));
-  });
 }
 
 - (void)addObserverFor:(NSString*)name selector:(SEL)selector {
@@ -273,7 +235,7 @@ static BOOL IsPowerOfTwo(NSUInteger x) {
 }
 #pragma GCC diagnostic pop
 
-- (void)performApplication:(UIApplication*)application
+- (void)application:(UIApplication*)application
     didRegisterForRemoteNotificationsWithDeviceToken:(NSData*)deviceToken {
   for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
     if (!delegate) {
@@ -286,7 +248,7 @@ static BOOL IsPowerOfTwo(NSUInteger x) {
   }
 }
 
-- (void)performApplication:(UIApplication*)application
+- (void)application:(UIApplication*)application
     didFailToRegisterForRemoteNotificationsWithError:(NSError*)error {
   for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
     if (!delegate) {
@@ -298,9 +260,7 @@ static BOOL IsPowerOfTwo(NSUInteger x) {
   }
 }
 
-// This will get swapped into `application:didReceiveRemoteNotification:fetchCompletionHandler:`
-// in +[FlutterPluginAppLifeCycleDelegate load].
-- (void)performApplication:(UIApplication*)application
+- (void)application:(UIApplication*)application
     didReceiveRemoteNotification:(NSDictionary*)userInfo
           fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler {
   for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegateTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegateTest.mm
@@ -10,31 +10,6 @@
 
 FLUTTER_ASSERT_ARC
 
-@interface FlutterPluginAppLifeCycleDelegate ()
-- (void)application:(UIApplication*)application
-    didReceiveRemoteNotification:(NSDictionary*)userInfo
-          fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler;
-- (void)application:(UIApplication*)application
-    didRegisterForRemoteNotificationsWithDeviceToken:(NSData*)deviceToken;
-- (void)application:(UIApplication*)application
-    didFailToRegisterForRemoteNotificationsWithError:(NSError*)error;
-@end
-
-@interface FlutterPluginAppLifeCycleDelegateSubclass : FlutterPluginAppLifeCycleDelegate
-@property(nonatomic, strong) XCTestExpectation* didReceiveRemoteNotificationExpectation;
-@end
-
-@implementation FlutterPluginAppLifeCycleDelegateSubclass
-- (void)performApplication:(UIApplication*)application
-    didReceiveRemoteNotification:(NSDictionary*)userInfo
-          fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler {
-  [self.didReceiveRemoteNotificationExpectation fulfill];
-  [super performApplication:application
-      didReceiveRemoteNotification:userInfo
-            fetchCompletionHandler:completionHandler];
-}
-@end
-
 @interface FlutterPluginAppLifeCycleDelegateTest : XCTestCase
 @end
 
@@ -112,70 +87,6 @@ FLUTTER_ASSERT_ARC
                                                       object:nil];
   [self waitForExpectations:@[ expectation ] timeout:5.0];
   OCMVerify([plugin applicationWillTerminate:[UIApplication sharedApplication]]);
-}
-
-- (void)testDidReceiveRemoteNotification {
-  FlutterPluginAppLifeCycleDelegate* delegate = [[FlutterPluginAppLifeCycleDelegate alloc] init];
-  id plugin = OCMProtocolMock(@protocol(FlutterPlugin));
-  [delegate addDelegate:plugin];
-  NSDictionary* info = @{};
-  void (^handler)(UIBackgroundFetchResult) = ^(UIBackgroundFetchResult result) {
-  };
-  XCTAssertTrue([delegate respondsToSelector:@selector
-                          (application:didReceiveRemoteNotification:fetchCompletionHandler:)]);
-  [delegate application:[UIApplication sharedApplication]
-      didReceiveRemoteNotification:info
-            fetchCompletionHandler:handler];
-  [(NSObject<FlutterPlugin>*)[plugin verify] application:[UIApplication sharedApplication]
-                            didReceiveRemoteNotification:info
-                                  fetchCompletionHandler:handler];
-}
-
-- (void)flutterPluginAppLifeCycleDelegateSubclass {
-  FlutterPluginAppLifeCycleDelegateSubclass* delegate =
-      [[FlutterPluginAppLifeCycleDelegateSubclass alloc] init];
-  XCTestExpectation* expecation = [self expectationWithDescription:@"subclass called"];
-  delegate.didReceiveRemoteNotificationExpectation = expecation;
-  id plugin = OCMProtocolMock(@protocol(FlutterPlugin));
-  [delegate addDelegate:plugin];
-  NSDictionary* info = @{};
-  void (^handler)(UIBackgroundFetchResult) = ^(UIBackgroundFetchResult result) {
-  };
-  XCTAssertTrue([delegate respondsToSelector:@selector
-                          (application:didReceiveRemoteNotification:fetchCompletionHandler:)]);
-  [delegate application:[UIApplication sharedApplication]
-      didReceiveRemoteNotification:info
-            fetchCompletionHandler:handler];
-  [(NSObject<FlutterPlugin>*)[plugin verify] application:[UIApplication sharedApplication]
-                            didReceiveRemoteNotification:info
-                                  fetchCompletionHandler:handler];
-  [self waitForExpectationsWithTimeout:1.0 handler:nil];
-}
-
-- (void)testDidRegisterForRemoteNotificationsWithDeviceToken {
-  FlutterPluginAppLifeCycleDelegate* delegate = [[FlutterPluginAppLifeCycleDelegate alloc] init];
-  id plugin = OCMProtocolMock(@protocol(FlutterPlugin));
-  [delegate addDelegate:plugin];
-  NSData* token = [[NSData alloc] init];
-  XCTAssertTrue([delegate
-      respondsToSelector:@selector(application:didRegisterForRemoteNotificationsWithDeviceToken:)]);
-  [delegate application:[UIApplication sharedApplication]
-      didRegisterForRemoteNotificationsWithDeviceToken:token];
-  [(NSObject<FlutterPlugin>*)[plugin verify] application:[UIApplication sharedApplication]
-        didRegisterForRemoteNotificationsWithDeviceToken:token];
-}
-
-- (void)testDidFailToRegisterForRemoteNotificationsWithError {
-  FlutterPluginAppLifeCycleDelegate* delegate = [[FlutterPluginAppLifeCycleDelegate alloc] init];
-  id plugin = OCMProtocolMock(@protocol(FlutterPlugin));
-  [delegate addDelegate:plugin];
-  NSError* error = [[NSError alloc] init];
-  XCTAssertTrue([delegate
-      respondsToSelector:@selector(application:didFailToRegisterForRemoteNotificationsWithError:)]);
-  [delegate application:[UIApplication sharedApplication]
-      didFailToRegisterForRemoteNotificationsWithError:error];
-  [(NSObject<FlutterPlugin>*)[plugin verify] application:[UIApplication sharedApplication]
-        didFailToRegisterForRemoteNotificationsWithError:error];
 }
 
 @end


### PR DESCRIPTION
Reverts flutter/engine#29996

This change broke APNS registration for apps that were using Flutter push notification plugins and also using Firebase, since both are swizzling the same methods: b/210427076

> Unfortunately it causes the [1P plugin] to not receive any APNS registration token and therefore not receive any push notifications. I'd guess it ends up breaking external push messaging plugins as well.

> Aha there is a bad interaction here between the flutter delegate swizzling and the firebase SDK swizzling (not the firebase plugin but the native SDK itself). If I comment out firebase's swizzling for didRegister then the chime plugin does receive the callback.