### PR TITLE
Windows: Implement IAccessible hit testing

### DIFF
--- a/shell/platform/windows/flutter_platform_node_delegate_win32.h
+++ b/shell/platform/windows/flutter_platform_node_delegate_win32.h
@@ -29,6 +29,11 @@ class FlutterPlatformNodeDelegateWin32 : public FlutterPlatformNodeDelegate {
   // |ui::AXPlatformNodeDelegate|
   gfx::NativeViewAccessible GetNativeViewAccessible() override;
 
+  // |ui::AXPlatformNodeDelegate|
+  gfx::NativeViewAccessible HitTestSync(
+      int screen_physical_pixel_x,
+      int screen_physical_pixel_y) const override;
+
   // |FlutterPlatformNodeDelegate|
   gfx::Rect GetBoundsRect(
       const ui::AXCoordinateSystem coordinate_system,


### PR DESCRIPTION
IAccessible objects should implement accHitTest. Our implementation, in
AXPlatformNodeWin, delegates hit testing to
AXPlatformNodeDelegate::HitTestSync. Here, we do a quick recursive
depth-first walk of the accessibility tree to return the best match.

We define the best match as the deepest node in the tree that contains
the point under test whose children do not.

Issue: https://github.com/flutter/flutter/issues/77838

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
