### PR TITLE
[windows] Support win_debug_x86 compilation target in engine

### DIFF
--- a/shell/gpu/gpu_surface_gl_delegate.cc
+++ b/shell/gpu/gpu_surface_gl_delegate.cc
@@ -40,7 +40,11 @@ static bool IsProcResolverOpenGLES(
 #define GPU_GL_VERSION 0x1F02
   constexpr char kGLESVersionPrefix[] = "OpenGL ES";
 
+#ifdef WIN32
+  using GLGetStringProc = const char*(__stdcall*)(uint32_t);
+#else
   using GLGetStringProc = const char* (*)(uint32_t);
+#endif
 
   GLGetStringProc gl_get_string =
       reinterpret_cast<GLGetStringProc>(proc_resolver("glGetString"));

--- a/shell/platform/windows/keyboard_win32_unittests.cc
+++ b/shell/platform/windows/keyboard_win32_unittests.cc
@@ -284,8 +284,8 @@ class MockKeyboardManagerWin32Delegate
           forged_message_expectations_.front();
       forged_message_expectations_.pop_front();
       EXPECT_EQ(expectation.message.message, Msg);
-      EXPECT_EQ(expectation.message.wParam, wParam & 0xffffffff);
-      EXPECT_EQ(expectation.message.lParam, lParam & 0xffffffff);
+      EXPECT_EQ(expectation.message.wParam, wParam);
+      EXPECT_EQ(expectation.message.lParam, lParam);
       if (expectation.message.expected_result != kWmResultDontCheck) {
         EXPECT_EQ(expectation.message.expected_result,
                   handled ? kWmResultZero : kWmResultDefault);

--- a/shell/platform/windows/testing/wm_builders.cc
+++ b/shell/platform/windows/testing/wm_builders.cc
@@ -8,8 +8,8 @@ namespace flutter {
 namespace testing {
 
 Win32Message WmKeyDownInfo::Build(LRESULT expected_result) {
-  uint32_t lParam = (repeat_count << 0) | (scan_code << 16) | (extended << 24) |
-                    (prev_state << 30);
+  LPARAM lParam = (repeat_count << 0) | (scan_code << 16) | (extended << 24) |
+                  (prev_state << 30);
   return Win32Message{
       .message = WM_KEYDOWN,
       .wParam = key,
@@ -19,9 +19,9 @@ Win32Message WmKeyDownInfo::Build(LRESULT expected_result) {
 }
 
 Win32Message WmKeyUpInfo::Build(LRESULT expected_result) {
-  uint32_t lParam = (1 /* repeat_count */ << 0) | (scan_code << 16) |
-                    (extended << 24) | (!overwrite_prev_state_0 << 30) |
-                    (1 /* transition */ << 31);
+  LPARAM lParam = (1 /* repeat_count */ << 0) | (scan_code << 16) |
+                  (extended << 24) | (!overwrite_prev_state_0 << 30) |
+                  (1 /* transition */ << 31);
   return Win32Message{
       .message = WM_KEYUP,
       .wParam = key,
@@ -31,9 +31,9 @@ Win32Message WmKeyUpInfo::Build(LRESULT expected_result) {
 }
 
 Win32Message WmCharInfo::Build(LRESULT expected_result) {
-  uint32_t lParam = (repeat_count << 0) | (scan_code << 16) | (extended << 24) |
-                    (bit25 << 25) | (context << 29) | (prev_state << 30) |
-                    (transition << 31);
+  LPARAM lParam = (repeat_count << 0) | (scan_code << 16) | (extended << 24) |
+                  (bit25 << 25) | (context << 29) | (prev_state << 30) |
+                  (transition << 31);
   return Win32Message{
       .message = WM_CHAR,
       .wParam = char_code,
@@ -43,9 +43,9 @@ Win32Message WmCharInfo::Build(LRESULT expected_result) {
 }
 
 Win32Message WmSysKeyDownInfo::Build(LRESULT expected_result) {
-  uint32_t lParam = (repeat_count << 0) | (scan_code << 16) | (extended << 24) |
-                    (context << 29) | (prev_state << 30) |
-                    (0 /* transition */ << 31);
+  LPARAM lParam = (repeat_count << 0) | (scan_code << 16) | (extended << 24) |
+                  (context << 29) | (prev_state << 30) |
+                  (0 /* transition */ << 31);
   return Win32Message{
       .message = WM_SYSKEYDOWN,
       .wParam = key,
@@ -55,9 +55,9 @@ Win32Message WmSysKeyDownInfo::Build(LRESULT expected_result) {
 }
 
 Win32Message WmSysKeyUpInfo::Build(LRESULT expected_result) {
-  uint32_t lParam = (1 /* repeat_count */ << 0) | (scan_code << 16) |
-                    (extended << 24) | (context << 29) |
-                    (1 /* prev_state */ << 30) | (1 /* transition */ << 31);
+  LPARAM lParam = (1 /* repeat_count */ << 0) | (scan_code << 16) |
+                  (extended << 24) | (context << 29) |
+                  (1 /* prev_state */ << 30) | (1 /* transition */ << 31);
   return Win32Message{
       .message = WM_SYSKEYUP,
       .wParam = key,
@@ -67,8 +67,8 @@ Win32Message WmSysKeyUpInfo::Build(LRESULT expected_result) {
 }
 
 Win32Message WmDeadCharInfo::Build(LRESULT expected_result) {
-  uint32_t lParam = (repeat_count << 0) | (scan_code << 16) | (extended << 24) |
-                    (context << 30) | (prev_state << 30) | (transition << 31);
+  LPARAM lParam = (repeat_count << 0) | (scan_code << 16) | (extended << 24) |
+                  (context << 30) | (prev_state << 30) | (transition << 31);
   return Win32Message{
       .message = WM_DEADCHAR,
       .wParam = char_code,

--- a/third_party/txt/src/utils/WindowsUtils.h
+++ b/third_party/txt/src/utils/WindowsUtils.h
@@ -42,7 +42,11 @@ inline unsigned int clz_win(unsigned int num) {
 
 inline unsigned int clzl_win(unsigned long num) {
   unsigned long r = 0;
+#if defined(_WIN64)
   _BitScanReverse64(&r, num);
+#else
+  _BitScanReverse(&r, num);
+#endif
   return r;
 }
 

--- a/tools/gn
+++ b/tools/gn
@@ -241,12 +241,8 @@ def to_gn_args(args):
     # DBC is not supported anymore.
     if args.interpreter:
       raise Exception('--interpreter is no longer needed on any supported platform.')
+    gn_args['dart_target_arch'] = gn_args['target_cpu']
 
-    if sys.platform == 'win32' and gn_args['target_cpu'] == 'x86':
-      # Dart recognizes "ia32" for x86 arch.
-      gn_args['dart_target_arch'] = 'ia32'
-    else:
-      gn_args['dart_target_arch'] = gn_args['target_cpu']
     if sys.platform.startswith(('cygwin', 'win')) and args.target_os != 'win':
       if 'target_cpu' in gn_args:
         gn_args['target_cpu'] = cpu_for_target_arch(gn_args['target_cpu'])

--- a/tools/gn
+++ b/tools/gn
@@ -75,7 +75,7 @@ def to_command_line(gn_args):
     return [merge(x, y) for x, y in gn_args.items()]
 
 def cpu_for_target_arch(arch):
-  if arch in ['ia32', 'arm', 'armv6', 'armv5te', 'mips',
+  if arch in ['ia32', 'x86', 'arm', 'armv6', 'armv5te', 'mips',
               'simarm', 'simarmv6', 'simarmv5te', 'simmips', 'simdbc',
               'armsimdbc']:
     return 'x86'
@@ -208,7 +208,7 @@ def to_gn_args(args):
     if runtime_mode == 'debug':
         gn_args['dart_runtime_mode'] = 'develop'
     elif runtime_mode == 'jit_release':
-        gn_args['dart_runtime_mode'] = 'release';
+        gn_args['dart_runtime_mode'] = 'release'
     else:
         gn_args['dart_runtime_mode'] = runtime_mode
 
@@ -241,8 +241,12 @@ def to_gn_args(args):
     # DBC is not supported anymore.
     if args.interpreter:
       raise Exception('--interpreter is no longer needed on any supported platform.')
-    gn_args['dart_target_arch'] = gn_args['target_cpu']
 
+    if sys.platform == 'win32' and gn_args['target_cpu'] == 'x86':
+      # Dart recognizes "ia32" for x86 arch.
+      gn_args['dart_target_arch'] = 'ia32'
+    else:
+      gn_args['dart_target_arch'] = gn_args['target_cpu']
     if sys.platform.startswith(('cygwin', 'win')) and args.target_os != 'win':
       if 'target_cpu' in gn_args:
         gn_args['target_cpu'] = cpu_for_target_arch(gn_args['target_cpu'])
@@ -446,11 +450,12 @@ def parse_args(args):
   parser.add_argument('--simulator', action='store_true', default=False)
   parser.add_argument('--linux', dest='target_os', action='store_const', const='linux')
   parser.add_argument('--fuchsia', dest='target_os', action='store_const', const='fuchsia')
+  parser.add_argument('--windows', dest='target_os', action='store_const', const='win')
   parser.add_argument('--winuwp', dest='target_os', action='store_const', const='winuwp')
 
   parser.add_argument('--linux-cpu', type=str, choices=['x64', 'x86', 'arm64', 'arm'])
   parser.add_argument('--fuchsia-cpu', type=str, choices=['x64', 'arm64'], default = 'x64')
-  parser.add_argument('--windows-cpu', type=str, choices=['x64', 'arm64'], default = 'x64')
+  parser.add_argument('--windows-cpu', type=str, choices=['x64', 'arm64', 'x86'], default = 'x64')
   parser.add_argument('--simulator-cpu', type=str, choices=['x64', 'arm64'], default = 'x64')
   parser.add_argument('--arm-float-abi', type=str, choices=['hard', 'soft', 'softfp'])
 

--- a/vulkan/vulkan_debug_report.cc
+++ b/vulkan/vulkan_debug_report.cc
@@ -108,14 +108,17 @@ static const char* VkDebugReportObjectTypeEXTToString(
 }
 
 static VKAPI_ATTR VkBool32
-OnVulkanDebugReportCallback(VkDebugReportFlagsEXT flags,
-                            VkDebugReportObjectTypeEXT object_type,
-                            uint64_t object,
-                            size_t location,
-                            int32_t message_code,
-                            const char* layer_prefix,
-                            const char* message,
-                            void* user_data) {
+#ifdef WIN32
+    __stdcall
+#endif
+    OnVulkanDebugReportCallback(VkDebugReportFlagsEXT flags,
+                                VkDebugReportObjectTypeEXT object_type,
+                                uint64_t object,
+                                size_t location,
+                                int32_t message_code,
+                                const char* layer_prefix,
+                                const char* message,
+                                void* user_data) {
   std::vector<std::pair<std::string, std::string>> items;
 
   items.emplace_back("Severity", VkDebugReportFlagsEXTToString(flags));


### PR DESCRIPTION
It added `--windows` param for gn, added `x86` target_arch, and fixed windows win_debug_x86 32-bit debug target compilation errors in Flutter engine. That is, using this command can do a successful compilation for x86 target on windows x64 host:
```shell
$ tools\gn --no-goma --no-prebuilt-dart-sdk --windows --windows-cpu x86 # "--windows" is a must to generate "win" not "host“
$ ninja -C ..\out\win_debug_x86
```

(And windows jit_release_x86 (`tools\gn --runtime-mode jit_release --windows --windows-cpu x86`) is a WIP.)

Design doc:
* https://docs.google.com/document/d/1gAGqtTAjO0GntR8bPonIO1aZJnTghPCI_PHJPdNzEmo/edit?resourcekey=0-l1tL7iai47yw3bMl9IcpHw#

Related issues:
* https://github.com/flutter/flutter/issues/37777
* https://github.com/flutter/flutter/issues/80105

In our Windows desktop scenarios and some customers like hospital, bank, embedded industrial control hardwares, the OS are not updated for years. So there are still many x86 users and devices. 
Many cross platform frameworks, such as QT and electron, support 32-bit. I think Flutter can also support this CPU architecture.

So we want to contribute this PR. 😄

Details:
1. About `LPARAM` change:

| OS                  | WPARAM        | LPARAM       |
|----------------|-----------------|---------------|
| 32-bit Windows | 32-bit unsigned | 32-bit signed |
| 64-bit Windows | 64-bit unsigned | 64-bit signed |

Which cause compile error on 32-bit target:
```c++
[974/1574] CXX obj/flutter/shell/platform/windows/testing/flutter_windows_unittests.wm_builders.obj
FAILED: obj/flutter/shell/platform/windows/testing/flutter_windows_unittests.wm_builders.obj
ninja -t msvc -e environment.x86 -- ../../buildtools/windows-x64/clang/bin/clang-cl.exe -m32 /nologo /showIncludes @obj/flutter/shell/platform/windows/testing/flutter_windows_unittests.wm_builders.obj.rsp /c ../../flutter/shell/platform/windows/testing/wm_builders.cc /Foobj/flutter/shell/platform/windows/testing/flutter_windows_unittests.wm_builders.obj /Fdobj/flutter/shell/platform/windows/flutter_windows_unittests_cc.pdb
../../flutter/shell/platform/windows/testing/wm_builders.cc(28,17): error: non-constant-expression cannot be narrowed from type 'uint32_t' (aka 'unsigned int') to 'LPARAM' (aka 'long') in initializer list [-Wc++11-narrowing]
      .lParam = lParam,
                ^~~~~~
../../flutter/shell/platform/windows/testing/wm_builders.cc(28,17): note: insert an explicit cast to silence this issue
      .lParam = lParam,
                ^~~~~~
                static_cast<LPARAM>( )
1 error generated.
[987/1574] ACTION //third_party/dart/utils/analysis_server:analysis_server_dill(//build/toolchain/win:clang_x86)
ninja: build stopped: subcommand failed.
```
I think we can direcly use `LPARAM` type instead of `uint32_t`, and do some mod in tests to avoid this test failure:

```
[ RUN      ] KeyboardTest.AltGrTwice
../../flutter/shell/platform/windows/keyboard_win32_unittests.cc(288): error: Expected equality of these values:
  expectation.message.lParam
    Which is: -1071841279
  lParam & 0xffffffff
    Which is: 3223126017
../../flutter/shell/platform/windows/keyboard_win32_unittests.cc(288): error: Expected equality of these values:
  expectation.message.lParam
    Which is: -1071841279
  lParam & 0xffffffff
    Which is: 3223126017
[  FAILED  ] KeyboardTest.AltGrTwice (9 ms)
```
@dkwingsmt may I have your double check about this?

2. The compilation error:
```log
ninja: Entering directory `..\out\host_debug_unopt_x86'
[1/19] CXX obj/flutter/vulkan/vulkan.vulkan_debug_report.obj
FAILED: obj/flutter/vulkan/vulkan.vulkan_debug_report.obj
ninja -t msvc -e environment.x86 -- ../../buildtools/windows-x64/clang/bin/clang-cl.exe -m32 /nologo /showIncludes @obj/flutter/vulkan/vulkan.vulkan_debug_report.obj.rsp /c ../../flutter/vulkan/vulkan_debug_report.cc /Foobj/flutter/vulkan/vulkan.vulkan_debug_report.obj /Fdobj/flutter/vulkan/vulkan_cc.pdb
../../flutter/vulkan/vulkan_debug_report.cc(205,22): error: cannot initialize a member subobject of type 'PFN_vkDebugReportCallbackEXT' (aka 'unsigned int (*)(unsigned int, VkDebugReportObjectTypeEXT, unsigned long long, unsigned int, int, const char *, const char *, void *) __attribute__((stdcall))') with an rvalue of type 'VkBool32 (*)(VkDebugReportFlagsEXT, VkDebugReportObjectTypeEXT, uint64_t, size_t, int32_t, const char *, const char *, void *)' (aka 'unsigned int (*)(unsigned int, VkDebugReportObjectTypeEXT, unsigned long long, unsigned int, int, const char *, const char *, void *)')
      .pfnCallback = &vulkan::OnVulkanDebugReportCallback,
                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
ninja: build stopped: subcommand failed.
```

The fixing:
* Adding a __stdcall when WIN32 is defined.
https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros says:
```text
_WIN32 Defined as 1 when the compilation target is 32-bit ARM, 64-bit ARM, x86, or x64. Otherwise, undefined.
_WIN64 Defined as 1 when the compilation target is 64-bit ARM or x64. Otherwise, undefined.
```



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

