### PR TITLE
Use the Android NDK bin/gdb tool instead of gdb-orig in the Flutter GDB script

### DIFF
--- a/sky/tools/flutter_gdb
+++ b/sky/tools/flutter_gdb
@@ -71,7 +71,7 @@ class GdbClient(object):
     SYSTEM_LIBS_PATH = '/tmp/flutter_gdb_device_libs'
 
     def _gdb_local_path(self):
-        GDB_LOCAL_PATH = ('third_party/android_tools/ndk/prebuilt/%s-x86_64/bin/gdb-orig')
+        GDB_LOCAL_PATH = ('third_party/android_tools/ndk/prebuilt/%s-x86_64/bin/gdb')
         if sys.platform.startswith('darwin'):
             return GDB_LOCAL_PATH % 'darwin'
         else:


### PR DESCRIPTION
bin/gdb will set environment variables such as PYTHONPATH before
launching GDB