### PR TITLE
Only provide frame damage to rasterizer if partial repaint is enabled

### DIFF
--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -560,22 +560,24 @@ RasterStatus Rasterizer::DrawToSurfaceUnsafe(
         external_view_embedder_ &&
         (!raster_thread_merger_ || raster_thread_merger_->IsMerged());
 
-    FrameDamage damage;
+    std::unique_ptr<FrameDamage> damage;
     if (!disable_partial_repaint && frame->framebuffer_info().existing_damage) {
-      damage.SetPreviousLayerTree(last_layer_tree_.get());
-      damage.AddAdditonalDamage(*frame->framebuffer_info().existing_damage);
+      damage = std::make_unique<FrameDamage>();
+      damage->SetPreviousLayerTree(last_layer_tree_.get());
+      damage->AddAdditonalDamage(*frame->framebuffer_info().existing_damage);
     }
 
     RasterStatus raster_status =
-        compositor_frame->Raster(layer_tree, false, &damage);
+        compositor_frame->Raster(layer_tree, false, damage.get());
     if (raster_status == RasterStatus::kFailed ||
         raster_status == RasterStatus::kSkipAndRetry) {
       return raster_status;
     }
 
     SurfaceFrame::SubmitInfo submit_info;
-    submit_info.frame_damage = damage.GetFrameDamage();
-    submit_info.buffer_damage = damage.GetBufferDamage();
+    submit_info.frame_damage = damage ? damage->GetFrameDamage() : std::nullopt;
+    submit_info.buffer_damage =
+        damage ? damage->GetBufferDamage() : std::nullopt;
 
     frame->set_submit_info(submit_info);
 

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -575,9 +575,10 @@ RasterStatus Rasterizer::DrawToSurfaceUnsafe(
     }
 
     SurfaceFrame::SubmitInfo submit_info;
-    submit_info.frame_damage = damage ? damage->GetFrameDamage() : std::nullopt;
-    submit_info.buffer_damage =
-        damage ? damage->GetBufferDamage() : std::nullopt;
+    if (damage) {
+      submit_info.frame_damage = damage->GetFrameDamage();
+      submit_info.buffer_damage = damage->GetBufferDamage();
+    }
 
     frame->set_submit_info(submit_info);
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/95681

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
