### PR TITLE
[web] bring libraries.yaml/libraries.json up to date

### DIFF
--- a/web_sdk/libraries.json
+++ b/web_sdk/libraries.json
@@ -25,6 +25,9 @@
       "_isolate_helper": {
         "uri": "../dart-sdk/lib/_internal/js_dev_runtime/private/isolate_helper.dart"
       },
+      "_js_annotations": {
+        "uri": "../dart-sdk/lib/js/_js_annotations.dart"
+      },
       "_js_helper": {
         "uri": "../dart-sdk/lib/_internal/js_dev_runtime/private/js_helper.dart"
       },
@@ -88,9 +91,6 @@
         "uri": "../dart-sdk/lib/js/js.dart",
         "patches": "../dart-sdk/lib/_internal/js_dev_runtime/patch/js_patch.dart"
       },
-      "_js_annotations": {
-        "uri": "../dart-sdk/lib/js/_js_annotations.dart"
-      },
       "js_util": {
         "uri": "../dart-sdk/lib/js_util/js_util.dart"
       },
@@ -102,9 +102,6 @@
       },
       "web_gl": {
         "uri": "../dart-sdk/lib/web_gl/dart2js/web_gl_dart2js.dart"
-      },
-      "web_sql": {
-        "uri": "../dart-sdk/lib/web_sql/dart2js/web_sql_dart2js.dart"
       },
       "ui": {
         "uri": "lib/ui/ui.dart"
@@ -156,7 +153,7 @@
       },
       "io": {
         "uri": "../dart-sdk/lib/io/io.dart",
-        "patches": "io_patch.dart",
+        "patches": "../dart-sdk/lib/_internal/js_runtime/lib/io_patch.dart",
         "supported": false
       },
       "isolate": {
@@ -166,7 +163,7 @@
       },
       "js": {
         "uri": "../dart-sdk/lib/js/js.dart",
-        "patches": "../dart-sdk/lib/_internal/js_dev_runtime/patch/js_patch.dart"
+        "patches": "../dart-sdk/lib/_internal/js_runtime/lib/js_patch.dart"
       },
       "_js": {
         "uri": "../dart-sdk/lib/js/_js.dart",
@@ -198,8 +195,8 @@
       "web_gl": {
         "uri": "../dart-sdk/lib/web_gl/dart2js/web_gl_dart2js.dart"
       },
-      "web_sql": {
-        "uri": "../dart-sdk/lib/web_sql/dart2js/web_sql_dart2js.dart"
+      "_dart2js_runtime_metrics": {
+        "uri": "../dart-sdk/lib/_internal/js_runtime/lib/dart2js_runtime_metrics.dart"
       },
       "_internal": {
         "uri": "../dart-sdk/lib/internal/internal.dart",
@@ -207,6 +204,12 @@
       },
       "_js_helper": {
         "uri": "../dart-sdk/lib/_internal/js_runtime/lib/js_helper.dart"
+      },
+      "_late_helper": {
+        "uri": "../dart-sdk/lib/_internal/js_runtime/lib/late_helper.dart"
+      },
+      "_rti": {
+        "uri": "../dart-sdk/lib/_internal/js_runtime/lib/rti.dart"
       },
       "_interceptors": {
         "uri": "../dart-sdk/lib/_internal/js_runtime/lib/interceptors.dart"
@@ -225,6 +228,9 @@
       },
       "_async_await_error_codes": {
         "uri": "../dart-sdk/lib/_internal/js_runtime/lib/shared/async_await_error_codes.dart"
+      },
+      "_recipe_syntax": {
+        "uri": "../dart-sdk/lib/_internal/js_runtime/lib/shared/recipe_syntax.dart"
       },
       "_metadata": {
         "uri": "../dart-sdk/lib/html/html_common/metadata.dart"

--- a/web_sdk/libraries.yaml
+++ b/web_sdk/libraries.yaml
@@ -37,6 +37,9 @@ dartdevc:
     _isolate_helper:
       uri: "../dart-sdk/lib/_internal/js_dev_runtime/private/isolate_helper.dart"
 
+    _js_annotations:
+      uri: "../dart-sdk/lib/js/_js_annotations.dart"
+
     _js_helper:
       uri: "../dart-sdk/lib/_internal/js_dev_runtime/private/js_helper.dart"
 
@@ -103,9 +106,6 @@ dartdevc:
     js_util:
       uri: "../dart-sdk/lib/js_util/js_util.dart"
 
-    _js_annotations:
-      uri: "../dart-sdk/lib/js/_js_annotations.dart"
-
     svg:
       uri: "../dart-sdk/lib/svg/dart2js/svg_dart2js.dart"
 
@@ -114,9 +114,6 @@ dartdevc:
 
     web_gl:
       uri: "../dart-sdk/lib/web_gl/dart2js/web_gl_dart2js.dart"
-
-    web_sql:
-      uri: "../dart-sdk/lib/web_sql/dart2js/web_sql_dart2js.dart"
 
     ui:
       uri: "lib/ui/ui.dart"
@@ -166,7 +163,7 @@ dart2js:
 
     io:
       uri: "../dart-sdk/lib/io/io.dart"
-      patches: "io_patch.dart"
+      patches: "../dart-sdk/lib/_internal/js_runtime/lib/io_patch.dart"
       supported: false
 
     isolate:
@@ -176,7 +173,7 @@ dart2js:
 
     js:
       uri: "../dart-sdk/lib/js/js.dart"
-      patches: "../dart-sdk/lib/_internal/js_dev_runtime/patch/js_patch.dart"
+      patches: "../dart-sdk/lib/_internal/js_runtime/lib/js_patch.dart"
 
     _js:
       uri: "../dart-sdk/lib/js/_js.dart"
@@ -208,8 +205,8 @@ dart2js:
     web_gl:
       uri: "../dart-sdk/lib/web_gl/dart2js/web_gl_dart2js.dart"
 
-    web_sql:
-      uri: "../dart-sdk/lib/web_sql/dart2js/web_sql_dart2js.dart"
+    _dart2js_runtime_metrics:
+      uri: "../dart-sdk/lib/_internal/js_runtime/lib/dart2js_runtime_metrics.dart"
 
     _internal:
       uri: "../dart-sdk/lib/internal/internal.dart"
@@ -217,6 +214,12 @@ dart2js:
 
     _js_helper:
       uri: "../dart-sdk/lib/_internal/js_runtime/lib/js_helper.dart"
+
+    _late_helper:
+      uri: "../dart-sdk/lib/_internal/js_runtime/lib/late_helper.dart"
+
+    _rti:
+      uri: "../dart-sdk/lib/_internal/js_runtime/lib/rti.dart"
 
     _interceptors:
       uri: "../dart-sdk/lib/_internal/js_runtime/lib/interceptors.dart"
@@ -235,6 +238,9 @@ dart2js:
 
     _async_await_error_codes:
       uri: "../dart-sdk/lib/_internal/js_runtime/lib/shared/async_await_error_codes.dart"
+
+    _recipe_syntax:
+      uri: "../dart-sdk/lib/_internal/js_runtime/lib/shared/recipe_syntax.dart"
 
     _metadata:
       uri: "../dart-sdk/lib/html/html_common/metadata.dart"


### PR DESCRIPTION
The libraries.yaml/json files are out of date in the flutter-web-sdk. These updates are needed to unify how we build flutter web platform files in the internal build system as well.

Eventually, we'd like to stop copying entries between libraries.json configuration files. Ideally we'd have a mechanism to extend/compose from existing files instead. Currently we are tracking that idea in https://github.com/dart-lang/sdk/issues/47998 