### PR TITLE
Allow opting out of installation of Git hooks.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -83,6 +83,9 @@ vars = {
   # So by default we will not download prebuilts. This varible is needed in
   # the flutter engine to ensure that Dart gn has access to it as well.
   "checkout_llvm": False,
+
+  # Setup Git hooks by default.
+  "setup_githooks": True,
 }
 
 gclient_gn_args_file = 'src/third_party/dart/build/config/gclient_args.gni'
@@ -718,6 +721,7 @@ hooks = [
   {
     'name': 'Setup githooks',
     'pattern': '.',
+    'condition': 'setup_githooks',
     'action': [
       'python3',
       'src/flutter/tools/githooks/setup.py',


### PR DESCRIPTION
The hooks perform various useful tasks such as running linters and formatters.

However, some developers have already configured their editors and development
environments such that  these steps are run when a file is saved or a build
performed. In such a setup, the tree is guaranteed to be in a ready state at any
given time. Running the hooks is redundant this setup. The hooks don't take
particularly long. But, when the git invocation is initiated via a GUI tools
such as Tower or Sublime Merge, failures are extremely common. Adding the
`--no-verify` prefix to the global config doesn't seem to hold either. This
patch adds a condition that is `True` by default but which developers can use to
disable the installation of the hooks.

To disable installation of hooks, the following can be added to the solution in
the `.gclient` file outside the buildroot. The same technique is used to to skip
other Gclient hooks such as downloading Android artifacts.

```
  "custom_vars": {
    "setup_githooks": False,
  },
```

To remove a Git hook already installed by this Gclient hook, remove the custom
hooks directory specified in `.git/config`.

This does not change the default behavior.