### PR TITLE
Remove the ios_tools Chromium-style dependency

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -62,9 +62,6 @@ vars = {
 
   'ocmock_tag': 'v3.7.1',
 
-  # Build bot tooling for iOS
-  'ios_tools_revision': '69b7c1b160e7107a6a98d948363772dc9caea46f',
-
   # Download a prebuilt Dart SDK by default
   'download_dart_sdk': True,
 
@@ -147,9 +144,6 @@ deps = {
    #
    # As part of integrating with Fuchsia, we should eventually remove all these
    # Chromium-style dependencies.
-
-  'src/ios_tools':
-   Var('chromium_git') + '/chromium/src/ios.git' + '@' + Var('ios_tools_revision'),
 
   'src/third_party/icu':
    Var('chromium_git') + '/chromium/deps/icu.git' + '@' + '2b50fa94b07b601293d7c1f791e853bba8ffbb84',


### PR DESCRIPTION
Reference this old issue: https://github.com/flutter/flutter/issues/10510
Maybe xcode 8 /  iOS SDK 10.3 is very old and `find_xcode.py` is also old? Not sure whether it is still used on internal repo:

https://chromium-review.googlesource.com/c/chromium/tools/build/+/525074/6/scripts/slave/recipes/flutter/flutter.py#112

Can we do some clean up work?

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
