### PR TITLE
Add a custom switch to clean up the leaked Dart VM

### DIFF
--- a/common/settings.h
+++ b/common/settings.h
@@ -207,6 +207,10 @@ struct Settings {
   // shells in the platform (via their embedding APIs) should cooperate to make
   // sure this flag is never set if they want the VM to shutdown and free all
   // associated resources.
+  // It can be customized by application, more detail:
+  // https://github.com/flutter/flutter/issues/95903
+  // TODO(eggfly): Should it be set to false by default?
+  // https://github.com/flutter/flutter/issues/96843
   bool leak_vm = true;
 
   // Engine settings

--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -384,6 +384,10 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line) {
   command_line.GetOptionValue(FlagForSwitch(Switch::CacheDirPath),
                               &settings.temp_directory_path);
 
+  bool leak_vm = "true" == command_line.GetOptionValueWithDefault(
+                               FlagForSwitch(Switch::LeakVM), "true");
+  settings.leak_vm = leak_vm;
+
   if (settings.icu_initialization_required) {
     command_line.GetOptionValue(FlagForSwitch(Switch::ICUDataFilePath),
                                 &settings.icu_data_path);

--- a/shell/common/switches.h
+++ b/shell/common/switches.h
@@ -215,6 +215,11 @@ DEF_SWITCH(EnableSkParagraph,
            "enable-skparagraph",
            "Selects the SkParagraph implementation of the text layout engine.")
 
+DEF_SWITCH(LeakVM,
+           "leak-vm",
+           "When the last shell shuts down, the shared VM is leaked by default "
+           "(the leak_vm in VM settings is true). To clean up the leak VM, set "
+           "this value to false.")
 DEF_SWITCHES_END
 
 void PrintUsage(const std::string& executable_name);

--- a/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
@@ -327,7 +327,7 @@ public class FlutterLoader {
     }
   }
 
-  private static boolean isLeakVM(Bundle metaData) {
+  private static boolean isLeakVM(@Nullable Bundle metaData) {
     final boolean leakVMDefaultValue = true;
     if (metaData == null) {
       return leakVMDefaultValue;

--- a/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
@@ -41,8 +41,15 @@ public class FlutterLoader {
       "io.flutter.embedding.android.EnableSkParagraph";
 
   /**
-   * Set whether leave or clean up the VM after the last shell shuts down. It's true by default, set
-   * it to false to destroy VM.
+   * Set whether leave or clean up the VM after the last shell shuts down. It can be set from app's
+   * meta-data in <application /> in AndroidManifest.xml. Set it to true in to leave the Dart VM,
+   * set it to false to destroy VM.
+   *
+   * <p>If your want to let your app destroy the last shell and re-create shells more quickly, set
+   * it to true, otherwise if you want to clean up the memory of the leak VM, set it to false.
+   *
+   * <p>TODO(eggfly): Should it be set to false by default?
+   * https://github.com/flutter/flutter/issues/96843
    */
   private static final String LEAK_VM_META_DATA_KEY = "io.flutter.embedding.android.LeakVM";
 

--- a/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
@@ -40,6 +40,12 @@ public class FlutterLoader {
   private static final String ENABLE_SKPARAGRAPH_META_DATA_KEY =
       "io.flutter.embedding.android.EnableSkParagraph";
 
+  /**
+   * Set whether leave or clean up the VM after the last shell shuts down. It's true by default, set
+   * it to false to destroy VM.
+   */
+  private static final String LEAK_VM_META_DATA_KEY = "io.flutter.embedding.android.LeakVM";
+
   // Must match values in flutter::switches
   static final String AOT_SHARED_LIBRARY_NAME = "aot-shared-library-name";
   static final String AOT_VMSERVICE_SHARED_LIBRARY_NAME = "aot-vmservice-shared-library-name";
@@ -299,6 +305,9 @@ public class FlutterLoader {
         shellArgs.add("--enable-skparagraph");
       }
 
+      final String leakVM = isLeakVM(metaData) ? "true" : "false";
+      shellArgs.add("--leak-vm=" + leakVM);
+
       long initTimeMillis = SystemClock.uptimeMillis() - initStartTimestampMillis;
 
       flutterJNI.init(
@@ -316,6 +325,14 @@ public class FlutterLoader {
     } finally {
       Trace.endSection();
     }
+  }
+
+  private static boolean isLeakVM(Bundle metaData) {
+    final boolean leakVMDefaultValue = true;
+    if (metaData == null) {
+      return leakVMDefaultValue;
+    }
+    return metaData.getBoolean(LEAK_VM_META_DATA_KEY, leakVMDefaultValue);
   }
 
   /**

--- a/shell/platform/darwin/ios/framework/Headers/FlutterDartProject.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterDartProject.h
@@ -28,13 +28,6 @@ FLUTTER_DARWIN_EXPORT
 - (instancetype)initFromDefaultSourceForConfiguration FLUTTER_UNAVAILABLE("Use -init instead.");
 
 /**
- * Sets whether leave or clean up the VM after the last shell shuts down. It's YES by default, set
- * to NO to destroy VM.
- * @param enabled Whether leak Dart VM or not.
- */
-- (void)setLeakDartVM:(BOOL)enabled;
-
-/**
  * Returns the file name for the given asset. If the bundle with the identifier
  * "io.flutter.flutter.app" exists, it will try use that bundle; otherwise, it
  * will use the main bundle.  To specify a different bundle, use

--- a/shell/platform/darwin/ios/framework/Headers/FlutterDartProject.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterDartProject.h
@@ -28,6 +28,13 @@ FLUTTER_DARWIN_EXPORT
 - (instancetype)initFromDefaultSourceForConfiguration FLUTTER_UNAVAILABLE("Use -init instead.");
 
 /**
+ * Sets whether leave or clean up the VM after the last shell shuts down. It's YES by default, set
+ * to NO to destroy VM.
+ * @param enabled Whether leak Dart VM or not.
+ */
+- (void)setLeakDartVM:(BOOL)enabled;
+
+/**
  * Returns the file name for the given asset. If the bundle with the identifier
  * "io.flutter.flutter.app" exists, it will try use that bundle; otherwise, it
  * will use the main bundle.  To specify a different bundle, use

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -337,4 +337,8 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle) {
   return @"io.flutter.flutter.app";
 }
 
+- (void)setLeakDartVM:(BOOL)enabled {
+  _settings.leak_vm = enabled;
+}
+
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -160,6 +160,13 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle) {
   NSNumber* enableSkParagraph = [mainBundle objectForInfoDictionaryKey:@"FLTEnableSkParagraph"];
   settings.enable_skparagraph = (enableSkParagraph != nil) ? enableSkParagraph.boolValue : false;
 
+  // Leak Dart VM settings, set whether leave or clean up the VM after the last shell shuts down.
+  NSNumber* leakDartVM = [mainBundle objectForInfoDictionaryKey:@"FLTLeakDartVM"];
+  // It will change the default leak_vm value in settings only if the key exists.
+  if (leakDartVM != nil) {
+    settings.leak_vm = leakDartVM.boolValue;
+  }
+
 #if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
   // There are no ownership concerns here as all mappings are owned by the
   // embedder and not the engine.
@@ -335,10 +342,6 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle) {
 
 + (NSString*)defaultBundleIdentifier {
   return @"io.flutter.flutter.app";
-}
-
-- (void)setLeakDartVM:(BOOL)enabled {
-  _settings.leak_vm = enabled;
 }
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProjectTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProjectTest.mm
@@ -29,6 +29,15 @@ FLUTTER_ASSERT_ARC
   XCTAssertEqual(project.settings.old_gen_heap_size, old_gen_heap_size);
 }
 
+- (void)testLeakDartVMSetting {
+  FlutterDartProject* project = [[FlutterDartProject alloc] init];
+  [project setLeakDartVM:YES];
+  XCTAssertEqual(project.settings.leak_vm, YES);
+
+  [project setLeakDartVM:NO];
+  XCTAssertEqual(project.settings.leak_vm, NO);
+}
+
 - (void)testMainBundleSettingsAreCorrectlyParsed {
   NSBundle* mainBundle = [NSBundle mainBundle];
   NSDictionary* appTransportSecurity =

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProjectTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProjectTest.mm
@@ -29,15 +29,6 @@ FLUTTER_ASSERT_ARC
   XCTAssertEqual(project.settings.old_gen_heap_size, old_gen_heap_size);
 }
 
-- (void)testLeakDartVMSetting {
-  FlutterDartProject* project = [[FlutterDartProject alloc] init];
-  [project setLeakDartVM:YES];
-  XCTAssertEqual(project.settings.leak_vm, YES);
-
-  [project setLeakDartVM:NO];
-  XCTAssertEqual(project.settings.leak_vm, NO);
-}
-
 - (void)testMainBundleSettingsAreCorrectlyParsed {
   NSBundle* mainBundle = [NSBundle mainBundle];
   NSDictionary* appTransportSecurity =
@@ -46,6 +37,17 @@ FLUTTER_ASSERT_ARC
   XCTAssertEqualObjects(
       @"[[\"invalid-site.com\",true,false],[\"sub.invalid-site.com\",false,false]]",
       [FlutterDartProject domainNetworkPolicy:appTransportSecurity]);
+}
+
+- (void)testLeakDartVMSettingsAreCorrectlyParsed {
+  // The FLTLeakDartVM's value is defined in Info.plist
+  NSBundle* mainBundle = [NSBundle mainBundle];
+  NSNumber* leakDartVM = [mainBundle objectForInfoDictionaryKey:@"FLTLeakDartVM"];
+  XCTAssertEqual(leakDartVM.boolValue, NO);
+
+  auto settings = FLTDefaultSettingsForBundle();
+  // Check settings.leak_vm value is same as the value defined in Info.plist.
+  XCTAssertEqual(settings.leak_vm, NO);
 }
 
 - (void)testEmptySettingsAreCorrect {

--- a/testing/ios/IosUnitTests/App/Info.plist
+++ b/testing/ios/IosUnitTests/App/Info.plist
@@ -44,6 +44,8 @@
                         </dict>
 		</dict>
 	</dict>
+	<key>FLTLeakDartVM</key>
+	<false/>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>


### PR DESCRIPTION
It's both Android and iOS part of:
* https://github.com/flutter/flutter/issues/95903

Considering the `leak_vm` setting is  an process global option, I put it into AndroidManifest.xml's app meta-data, like the `OldGenHeapSize` option. 

Demo app link:  https://github.com/eggfly/flutter_leak_vm_test

Code:

https://github.com/eggfly/flutter_leak_vm_test/blob/612b2271c90de68f9bbaf03696fcdb18bcd73745/android/app/src/main/AndroidManifest.xml#L51


```xml
 <!-- Force clean up the leak VM -->
        <meta-data
            android:name="io.flutter.embedding.android.LeakVM"
            android:value="false" />
```

Keep switching between native MainActivity and flutter activity, and observe the memory usage.

LeakVM is true (or not set): back to native Activity then native memory = 34.9MB
![image](https://user-images.githubusercontent.com/922837/147574719-1bcb4db8-f972-454b-8261-16b3af5a6807.png)


LeakVM is false: back to native Activity then native memory = 32.2MB
![image](https://user-images.githubusercontent.com/922837/147575594-ef70c343-3d15-4a97-a420-1fe1645a804d.png)

Some debug logs:

![image](https://user-images.githubusercontent.com/922837/147575929-7b5fcb42-3cf3-418c-8dd4-153577766070.png)


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
