### PR TITLE
Only creates 'onscreen_surface_' when it's not available in 'AndroidSurfaceGL::CreateSnapshotSurface'

### DIFF
--- a/shell/platform/android/android_context_gl_unittests.cc
+++ b/shell/platform/android/android_context_gl_unittests.cc
@@ -4,12 +4,62 @@
 #include "flutter/shell/common/thread_host.h"
 #include "flutter/shell/platform/android/android_context_gl.h"
 #include "flutter/shell/platform/android/android_environment_gl.h"
+#include "flutter/shell/platform/android/android_surface_gl.h"
+#include "flutter/shell/platform/android/jni/platform_view_android_jni.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace flutter {
 namespace testing {
 namespace android {
 namespace {
+class MockPlatformViewAndroidJNI : public PlatformViewAndroidJNI {
+ public:
+  MOCK_METHOD2(FlutterViewHandlePlatformMessage,
+               void(std::unique_ptr<flutter::PlatformMessage> message,
+                    int responseId));
+  MOCK_METHOD2(FlutterViewHandlePlatformMessageResponse,
+               void(int responseId, std::unique_ptr<fml::Mapping> data));
+  MOCK_METHOD3(FlutterViewUpdateSemantics,
+               void(std::vector<uint8_t> buffer,
+                    std::vector<std::string> strings,
+                    std::vector<std::vector<uint8_t>> string_attribute_args));
+  MOCK_METHOD2(FlutterViewUpdateCustomAccessibilityActions,
+               void(std::vector<uint8_t> actions_buffer,
+                    std::vector<std::string> strings));
+  MOCK_METHOD0(FlutterViewOnFirstFrame, void());
+  MOCK_METHOD0(FlutterViewOnPreEngineRestart, void());
+  MOCK_METHOD2(SurfaceTextureAttachToGLContext,
+               void(JavaLocalRef surface_texture, int textureId));
+  MOCK_METHOD1(SurfaceTextureUpdateTexImage,
+               void(JavaLocalRef surface_texture));
+  MOCK_METHOD2(SurfaceTextureGetTransformMatrix,
+               void(JavaLocalRef surface_texture, SkMatrix& transform));
+  MOCK_METHOD1(SurfaceTextureDetachFromGLContext,
+               void(JavaLocalRef surface_texture));
+  MOCK_METHOD8(FlutterViewOnDisplayPlatformView,
+               void(int view_id,
+                    int x,
+                    int y,
+                    int width,
+                    int height,
+                    int viewWidth,
+                    int viewHeight,
+                    MutatorsStack mutators_stack));
+  MOCK_METHOD5(FlutterViewDisplayOverlaySurface,
+               void(int surface_id, int x, int y, int width, int height));
+  MOCK_METHOD0(FlutterViewBeginFrame, void());
+  MOCK_METHOD0(FlutterViewEndFrame, void());
+  MOCK_METHOD0(FlutterViewCreateOverlaySurface,
+               std::unique_ptr<PlatformViewAndroidJNI::OverlayMetadata>());
+  MOCK_METHOD0(FlutterViewDestroyOverlaySurfaces, void());
+  MOCK_METHOD1(FlutterViewComputePlatformResolvedLocale,
+               std::unique_ptr<std::vector<std::string>>(
+                   std::vector<std::string> supported_locales_data));
+  MOCK_METHOD0(GetDisplayRefreshRate, double());
+  MOCK_METHOD1(RequestDartDeferredLibrary, bool(int loading_unit_id));
+};
+
 TaskRunners MakeTaskRunners(const std::string& thread_label,
                             const ThreadHost& thread_host) {
   fml::MessageLoop::EnsureInitializedForCurrentThread();
@@ -61,6 +111,52 @@ TEST(AndroidContextGl, CreateSingleThread) {
   EXPECT_NE(context.get(), nullptr);
   context.reset();
   EXPECT_TRUE(main_context->abandoned());
+}
+
+TEST(AndroidSurfaceGL, CreateSnapshopSurfaceWhenOnscreenSurfaceIsNotNull) {
+  GrMockOptions main_context_options;
+  sk_sp<GrDirectContext> main_context =
+      GrDirectContext::MakeMock(&main_context_options);
+  auto environment = fml::MakeRefCounted<AndroidEnvironmentGL>();
+  std::string thread_label =
+      ::testing::UnitTest::GetInstance()->current_test_info()->name();
+  ThreadHost thread_host(thread_label, ThreadHost::Type::UI |
+                                           ThreadHost::Type::RASTER |
+                                           ThreadHost::Type::IO);
+  TaskRunners task_runners = MakeTaskRunners(thread_label, thread_host);
+  auto android_context = std::make_shared<AndroidContextGL>(
+      AndroidRenderingAPI::kOpenGLES, environment, task_runners);
+  auto jni = std::make_shared<MockPlatformViewAndroidJNI>();
+  auto android_surface =
+      std::make_unique<AndroidSurfaceGL>(android_context, jni);
+  auto window = fml::MakeRefCounted<AndroidNativeWindow>(
+      nullptr, /*is_fake_window=*/true);
+  android_surface->SetNativeWindow(window);
+  auto onscreen_surface = android_surface->GetOnscreenSurface();
+  EXPECT_NE(onscreen_surface, nullptr);
+  android_surface->CreateSnapshotSurface();
+  EXPECT_EQ(onscreen_surface, android_surface->GetOnscreenSurface());
+}
+
+TEST(AndroidSurfaceGL, CreateSnapshopSurfaceWhenOnscreenSurfaceIsNull) {
+  GrMockOptions main_context_options;
+  sk_sp<GrDirectContext> main_context =
+      GrDirectContext::MakeMock(&main_context_options);
+  auto environment = fml::MakeRefCounted<AndroidEnvironmentGL>();
+  std::string thread_label =
+      ::testing::UnitTest::GetInstance()->current_test_info()->name();
+  ThreadHost thread_host(thread_label, ThreadHost::Type::UI |
+                                           ThreadHost::Type::RASTER |
+                                           ThreadHost::Type::IO);
+  TaskRunners task_runners = MakeTaskRunners(thread_label, thread_host);
+  auto android_context = std::make_shared<AndroidContextGL>(
+      AndroidRenderingAPI::kOpenGLES, environment, task_runners);
+  auto jni = std::make_shared<MockPlatformViewAndroidJNI>();
+  auto android_surface =
+      std::make_unique<AndroidSurfaceGL>(android_context, jni);
+  EXPECT_EQ(android_surface->GetOnscreenSurface(), nullptr);
+  android_surface->CreateSnapshotSurface();
+  EXPECT_NE(android_surface->GetOnscreenSurface(), nullptr);
 }
 }  // namespace android
 }  // namespace testing

--- a/shell/platform/android/android_surface_gl.cc
+++ b/shell/platform/android/android_surface_gl.cc
@@ -176,7 +176,9 @@ AndroidContextGL* AndroidSurfaceGL::GLContextPtr() const {
 }
 
 std::unique_ptr<Surface> AndroidSurfaceGL::CreatePbufferSurface() {
-  onscreen_surface_ = GLContextPtr()->CreatePbufferSurface();
+  if (!onscreen_surface_ || !onscreen_surface_->IsValid()) {
+    onscreen_surface_ = GLContextPtr()->CreatePbufferSurface();
+  }
   sk_sp<GrDirectContext> main_skia_context =
       GLContextPtr()->GetMainSkiaContext();
   if (!main_skia_context) {

--- a/shell/platform/android/android_surface_gl.cc
+++ b/shell/platform/android/android_surface_gl.cc
@@ -175,7 +175,7 @@ AndroidContextGL* AndroidSurfaceGL::GLContextPtr() const {
   return reinterpret_cast<AndroidContextGL*>(android_context_.get());
 }
 
-std::unique_ptr<Surface> AndroidSurfaceGL::CreatePbufferSurface() {
+std::unique_ptr<Surface> AndroidSurfaceGL::CreateSnapshotSurface() {
   if (!onscreen_surface_ || !onscreen_surface_->IsValid()) {
     onscreen_surface_ = GLContextPtr()->CreatePbufferSurface();
   }

--- a/shell/platform/android/android_surface_gl.h
+++ b/shell/platform/android/android_surface_gl.h
@@ -66,6 +66,10 @@ class AndroidSurfaceGL final : public GPUSurfaceGLDelegate,
   // |GPUSurfaceGLDelegate|
   sk_sp<const GrGLInterface> GetGLInterface() const override;
 
+  // Obtain a raw pointer to the on-screen AndroidEGLSurface.
+  //
+  // This method is intended for use in tests. Callers must not
+  // delete the returned pointer.
   AndroidEGLSurface* GetOnscreenSurface() const {
     return onscreen_surface_.get();
   }

--- a/shell/platform/android/android_surface_gl.h
+++ b/shell/platform/android/android_surface_gl.h
@@ -49,7 +49,7 @@ class AndroidSurfaceGL final : public GPUSurfaceGLDelegate,
   bool SetNativeWindow(fml::RefPtr<AndroidNativeWindow> window) override;
 
   // |AndroidSurface|
-  virtual std::unique_ptr<Surface> CreatePbufferSurface() override;
+  virtual std::unique_ptr<Surface> CreateSnapshotSurface() override;
 
   // |GPUSurfaceGLDelegate|
   std::unique_ptr<GLContextResult> GLContextMakeCurrent() override;
@@ -65,6 +65,10 @@ class AndroidSurfaceGL final : public GPUSurfaceGLDelegate,
 
   // |GPUSurfaceGLDelegate|
   sk_sp<const GrGLInterface> GetGLInterface() const override;
+
+  AndroidEGLSurface* GetOnscreenSurface() const {
+    return onscreen_surface_.get();
+  }
 
  private:
   fml::RefPtr<AndroidNativeWindow> native_window_;

--- a/shell/platform/android/surface/android_surface.cc
+++ b/shell/platform/android/surface/android_surface.cc
@@ -15,7 +15,7 @@ AndroidSurface::AndroidSurface(
 
 AndroidSurface::~AndroidSurface() = default;
 
-std::unique_ptr<Surface> AndroidSurface::CreatePbufferSurface() {
+std::unique_ptr<Surface> AndroidSurface::CreateSnapshotSurface() {
   return nullptr;
 }
 

--- a/shell/platform/android/surface/android_surface.h
+++ b/shell/platform/android/surface/android_surface.h
@@ -37,7 +37,7 @@ class AndroidSurface {
 
   virtual bool SetNativeWindow(fml::RefPtr<AndroidNativeWindow> window) = 0;
 
-  virtual std::unique_ptr<Surface> CreatePbufferSurface();
+  virtual std::unique_ptr<Surface> CreateSnapshotSurface();
 
  protected:
   explicit AndroidSurface(

--- a/shell/platform/android/surface/snapshot_surface_producer.cc
+++ b/shell/platform/android/surface/snapshot_surface_producer.cc
@@ -12,7 +12,7 @@ AndroidSnapshotSurfaceProducer::AndroidSnapshotSurfaceProducer(
 
 std::unique_ptr<Surface>
 AndroidSnapshotSurfaceProducer::CreateSnapshotSurface() {
-  return android_surface_.CreatePbufferSurface();
+  return android_surface_.CreateSnapshotSurface();
 }
 
 }  // namespace flutter


### PR DESCRIPTION
fix issue: https://github.com/flutter/flutter/issues/95957

There will be a situation where `AndroidSurfaceGL::on_screen_surface_`  is set, but `Rasterizer::surface_` has not been set. So when'AndroidSurfaceGL::CreatePbufferSurface' is called, `AndroidSurfaceGL::on_screen_surface_` may already exist. At this time, we should not generate a new one, but should directly use the existing one.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
