### PR TITLE
[Android] Access FlutterFragmentActivity's content view ID

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
@@ -783,4 +783,10 @@ public class FlutterFragmentActivity extends FragmentActivity
   protected FrameLayout provideRootLayout(Context context) {
     return new FrameLayout(context);
   }
+  
+  /** Returns the {@code #FRAGMENT_CONTAINER_ID} of the activity's content view. */
+  @NonNull
+  public int getFragmentContainerId() {
+    return FRAGMENT_CONTAINER_ID;
+  }
 }


### PR DESCRIPTION
Allowing access to FlutterFragmentActivity's content view ID.

Currently there is no way for user to access FRAGMENT_CONTAINER_ID when extending from FlutterFragmentActivity.

Activities extending from FlutterFragmentActivity can add views to root layout instead of creating a new layout.
This is especially useful when the user wants to create additional fragments and transact them to the root layout.