### PR TITLE
[Android] Access FlutterFragmentActivity's content view ID

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
@@ -240,6 +240,7 @@ public class FlutterFragmentActivity extends FragmentActivity
   }
 
   @Nullable private FlutterFragment flutterFragment;
+  @NonNull private View rootFrameLayout;
 
   @Override
   protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -252,7 +253,8 @@ public class FlutterFragmentActivity extends FragmentActivity
     super.onCreate(savedInstanceState);
 
     configureWindowForTransparency();
-    setContentView(createFragmentContainer());
+    rootFrameLayout = createFragmentContainer();
+    setContentView(rootFrameLayout);
     configureStatusBarForFullscreenFlutterExperience();
     ensureFlutterFragmentCreated();
   }
@@ -782,5 +784,11 @@ public class FlutterFragmentActivity extends FragmentActivity
   @NonNull
   protected FrameLayout provideRootLayout(Context context) {
     return new FrameLayout(context);
+  }
+
+  /** Returns the {@code #FRAGMENT_CONTAINER_ID} of the activity's content view. */
+  @NonNull
+  public int getFragmentContainerId() {
+    return rootFrameLayout.getId();
   }
 }

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentActivityTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentActivityTest.java
@@ -17,6 +17,7 @@ import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
+import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
 import androidx.annotation.NonNull;
@@ -89,6 +90,15 @@ public class FlutterFragmentActivityTest {
           }
         };
     assertEquals(activity.createFlutterFragment().getRenderMode(), RenderMode.texture);
+  }
+
+  @Test
+  public void hasRootLayoutId() {
+    FlutterFragmentActivityWithRootLayout activity =
+        Robolectric.buildActivity(FlutterFragmentActivityWithRootLayout.class).get();
+    activity.onCreate(null);
+    assertNotNull(activity.getFragmentContainerId());
+    assertTrue(activity.getFragmentContainerId() != View.NO_ID);
   }
 
   @Test


### PR DESCRIPTION
Allowing access to FlutterFragmentActivity's content view ID.

Currently there is no way for user to access FRAGMENT_CONTAINER_ID when extending from FlutterFragmentActivity.

Activities extending from FlutterFragmentActivity can add views to root layout instead of creating a new layout.
This is especially useful when the user wants to create additional fragments and transact them to the root layout.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.