### PR TITLE
[Android] Access FlutterFragmentActivity's content view ID

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
@@ -46,6 +46,7 @@ import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.FlutterShellArgs;
 import io.flutter.embedding.engine.plugins.util.GeneratedPluginRegister;
 import io.flutter.plugin.platform.PlatformPlugin;
+import io.flutter.util.ViewUtils;
 
 /**
  * A Flutter {@code Activity} that is based upon {@link FragmentActivity}.
@@ -65,7 +66,8 @@ public class FlutterFragmentActivity extends FragmentActivity
   // FlutterFragment management.
   private static final String TAG_FLUTTER_FRAGMENT = "flutter_fragment";
   // TODO(mattcarroll): replace ID with R.id when build system supports R.java
-  private static final int FRAGMENT_CONTAINER_ID = 609893468; // random number
+  public static final int FRAGMENT_CONTAINER_ID =
+      ViewUtils.generateViewId(609893468); // random number
 
   /**
    * Creates an {@link Intent} that launches a {@code FlutterFragmentActivity}, which executes a

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentActivityTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentActivityTest.java
@@ -17,6 +17,7 @@ import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
+import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
 import androidx.annotation.NonNull;
@@ -102,6 +103,15 @@ public class FlutterFragmentActivityTest {
         };
     assertEquals(
         activity.createFlutterFragment().getDartEntrypointLibraryUri(), "package:foo/bar.dart");
+  }
+
+  @Test
+  public void hasRootLayoutId() {
+    FlutterFragmentActivityWithRootLayout activity =
+        Robolectric.buildActivity(FlutterFragmentActivityWithRootLayout.class).get();
+    activity.onCreate(null);
+    assertNotNull(activity.FRAGMENT_CONTAINER_ID);
+    assertTrue(activity.FRAGMENT_CONTAINER_ID != View.NO_ID);
   }
 
   @Test


### PR DESCRIPTION
Allowing access to FlutterFragmentActivity's content view ID.

Currently this is the way for user to access root layout ID (FRAGMENT_CONTAINER_ID) when extending from FlutterFragmentActivity, but what if there were breaking changes?

`private fun getRootViewId(): Int {`
       `    var rootView: ViewGroup? = (this.findViewById(android.R.id.content) as ViewGroup).getChildAt(0) as ViewGroup`
       `    return rootView?.getId() ?: NO_ROOT_VIEW`
   ` }`

Activities extending from FlutterFragmentActivity can add views to root layout instead of creating a new layout.
This is especially useful when the user wants to create additional fragments and transact them to the root layout.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.