### PR TITLE
[fuchsia] Remove unused zx/cpp/fidl.h include.

### DIFF
--- a/shell/platform/fuchsia/flutter/software_surface.cc
+++ b/shell/platform/fuchsia/flutter/software_surface.cc
@@ -19,7 +19,6 @@
 #include "third_party/skia/include/core/SkImageInfo.h"
 
 #include "../runtime/dart/utils/inlines.h"
-#include "zx/cpp/fidl.h"
 
 namespace flutter_runner {
 

--- a/shell/platform/fuchsia/flutter/vulkan_surface_producer.cc
+++ b/shell/platform/fuchsia/flutter/vulkan_surface_producer.cc
@@ -131,10 +131,12 @@ bool VulkanSurfaceProducer::Initialize(scenic::Session* scenic_session) {
   const char* device_extensions[] = {
       VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME,
   };
+  const int device_extensions_count =
+      sizeof(device_extensions) / sizeof(device_extensions[0]);
   GrVkExtensions vk_extensions;
   vk_extensions.init(backend_context.fGetProc, backend_context.fInstance,
                      backend_context.fPhysicalDevice, 0, nullptr,
-                     countof(device_extensions), device_extensions);
+                     device_extensions_count, device_extensions);
   backend_context.fVkExtensions = &vk_extensions;
   GrContextOptions options;
   options.fReduceOpsTaskSplitting = GrContextOptions::Enable::kNo;


### PR DESCRIPTION
This include redefines several symbols that are now coming from
the SDK. See this SDK roll failure
https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8826397088488060737/+/u/build_fuchsia_debug_x64_flutter_shell_platform_fuchsia:fuchsia_fuchsia_tests/stdout.

This include does not appear to be used.
