### PR TITLE
Fix: support to set layout direction for hybrid composition platform view

### DIFF
--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -122,7 +122,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
   private final PlatformViewsChannel.PlatformViewsHandler channelHandler =
       new PlatformViewsChannel.PlatformViewsHandler() {
 
-        @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
+        @TargetApi(Build.VERSION_CODES.KITKAT)
         @Override
         public void createAndroidViewForPlatformView(
             @NonNull PlatformViewsChannel.PlatformViewCreationRequest request) {

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -149,6 +149,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
           }
 
           final PlatformView platformView = factory.create(context, request.viewId, createParams);
+          platformView.setLayoutDirection(request.direction);
           platformViews.put(request.viewId, platformView);
         }
 
@@ -331,10 +332,18 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
           }
 
           ensureValidAndroidVersion(Build.VERSION_CODES.KITKAT_WATCH);
+          final PlatformView platformView = platformViews.get(viewId);
+          if (platformView != null) {
+            platformView.setLayoutDirection(direction);
+            return;
+          }
           View view = vdControllers.get(viewId).getView();
           if (view == null) {
             throw new IllegalStateException(
-                "Sending touch to an unknown view with id: " + direction);
+                "Trying to set direction: "
+                    + direction
+                    + " to an unknown view with id: "
+                    + viewId);
           }
 
           view.setLayoutDirection(direction);

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -345,7 +345,6 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
                     + " to an unknown platform view with id: "
                     + viewId);
           }
-
           controller.getView().setLayoutDirection(direction);
         }
 

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -122,6 +122,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
   private final PlatformViewsChannel.PlatformViewsHandler channelHandler =
       new PlatformViewsChannel.PlatformViewsHandler() {
 
+        @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
         @Override
         public void createAndroidViewForPlatformView(
             @NonNull PlatformViewsChannel.PlatformViewCreationRequest request) {

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -149,7 +149,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
           }
 
           final PlatformView platformView = factory.create(context, request.viewId, createParams);
-          platformView.setLayoutDirection(request.direction);
+          platformView.getView().setLayoutDirection(request.direction);
           platformViews.put(request.viewId, platformView);
         }
 
@@ -334,7 +334,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
           ensureValidAndroidVersion(Build.VERSION_CODES.KITKAT_WATCH);
           final PlatformView platformView = platformViews.get(viewId);
           if (platformView != null) {
-            platformView.setLayoutDirection(direction);
+            platformView.getView().setLayoutDirection(direction);
             return;
           }
           View view = vdControllers.get(viewId).getView();

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -337,16 +337,16 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
             platformView.getView().setLayoutDirection(direction);
             return;
           }
-          View view = vdControllers.get(viewId).getView();
-          if (view == null) {
+          VirtualDisplayController controller = vdControllers.get(viewId);
+          if (controller == null) {
             throw new IllegalStateException(
                 "Trying to set direction: "
                     + direction
-                    + " to an unknown view with id: "
+                    + " to an unknown platform view with id: "
                     + viewId);
           }
 
-          view.setLayoutDirection(direction);
+          controller.getView().setLayoutDirection(direction);
         }
 
         @Override

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
@@ -412,8 +412,9 @@ public class PlatformViewsControllerTest {
     
     // Simulate set direction call from the framework.
     setLayoutDirection(jni, platformViewsController, platformViewId, 1);
-    // This limit value will be equal to 2 if the layout direction is set successfully, 
-    // otherwise it will be much more than 2 due to an error message returned.
+    // The limit value of reply message will be equal to 2 if the layout direction is set
+    // successfully, otherwise it will be much more than 2 due to the reply message contains
+    // an error message wrapped with exception detail information.
     assertEquals(ShadowFlutterJNI.getResponses().get(0).limit(), 2);
   }
 

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
@@ -395,10 +395,7 @@ public class PlatformViewsControllerTest {
 
     PlatformViewFactory viewFactory = mock(PlatformViewFactory.class);
     PlatformView platformView = mock(PlatformView.class);
-
-    Context context = RuntimeEnvironment.application.getApplicationContext();
-    View androidView = new View(context);
-
+    final View androidView = mock(View.class);
     when(platformView.getView()).thenReturn(androidView);
     when(viewFactory.create(any(), eq(platformViewId), any())).thenReturn(platformView);
     platformViewsController.getRegistry().registerViewFactory("testType", viewFactory);
@@ -406,12 +403,16 @@ public class PlatformViewsControllerTest {
     FlutterJNI jni = new FlutterJNI();
     attach(jni, platformViewsController);
 
+    verify(androidView, never()).setLayoutDirection(anyInt());
+
     // Simulate create call from the framework.
     createPlatformView(jni, platformViewsController, platformViewId, "testType", /* hybrid=*/ true);
     assertEquals(ShadowFlutterJNI.getResponses().size(), 1);
 
     // Simulate set direction call from the framework.
     setLayoutDirection(jni, platformViewsController, platformViewId, 1);
+    verify(androidView, times(1)).setLayoutDirection(1);
+
     // The limit value of reply message will be equal to 2 if the layout direction is set
     // successfully, otherwise it will be much more than 2 due to the reply message contains
     // an error message wrapped with exception detail information.

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
@@ -409,7 +409,7 @@ public class PlatformViewsControllerTest {
     // Simulate create call from the framework.
     createPlatformView(jni, platformViewsController, platformViewId, "testType", /* hybrid=*/ true);
     assertEquals(ShadowFlutterJNI.getResponses().size(), 1);
-    
+
     // Simulate set direction call from the framework.
     setLayoutDirection(jni, platformViewsController, platformViewId, 1);
     // The limit value of reply message will be equal to 2 if the layout direction is set

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
@@ -387,6 +387,38 @@ public class PlatformViewsControllerTest {
 
   @Test
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
+  public void setPlatformViewDirection__throwIfPlatformViewNotFound() {
+    PlatformViewsController platformViewsController = new PlatformViewsController();
+
+    int platformViewId = 0;
+    assertNull(platformViewsController.getPlatformViewById(platformViewId));
+
+    PlatformViewFactory viewFactory = mock(PlatformViewFactory.class);
+    PlatformView platformView = mock(PlatformView.class);
+
+    Context context = RuntimeEnvironment.application.getApplicationContext();
+    View androidView = new View(context);
+
+    when(platformView.getView()).thenReturn(androidView);
+    when(viewFactory.create(any(), eq(platformViewId), any())).thenReturn(platformView);
+    platformViewsController.getRegistry().registerViewFactory("testType", viewFactory);
+
+    FlutterJNI jni = new FlutterJNI();
+    attach(jni, platformViewsController);
+
+    // Simulate create call from the framework.
+    createPlatformView(jni, platformViewsController, platformViewId, "testType", /* hybrid=*/ true);
+    assertEquals(ShadowFlutterJNI.getResponses().size(), 1);
+    
+    // Simulate set direction call from the framework.
+    setLayoutDirection(jni, platformViewsController, platformViewId, 1);
+    // This limit value will be equal to 2 if the layout direction is set successfully, 
+    // otherwise it will be much more than 2 due to an error message returned.
+    assertEquals(ShadowFlutterJNI.getResponses().get(0).limit(), 2);
+  }
+
+  @Test
+  @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
   public void disposeAndroidView__hybridComposition() {
     PlatformViewsController platformViewsController = new PlatformViewsController();
 
@@ -827,6 +859,25 @@ public class PlatformViewsControllerTest {
 
     final MethodCall platformCreateMethodCall =
         new MethodCall("create", platformViewCreateArguments);
+
+    jni.handlePlatformMessage(
+        "flutter/platform_views",
+        encodeMethodCall(platformCreateMethodCall),
+        /*replyId=*/ 0,
+        /*messageData=*/ 0);
+  }
+
+  private static void setLayoutDirection(
+      FlutterJNI jni,
+      PlatformViewsController platformViewsController,
+      int platformViewId,
+      int direction) {
+    final Map<String, Object> platformViewCreateArguments = new HashMap<>();
+    platformViewCreateArguments.put("id", platformViewId);
+    platformViewCreateArguments.put("direction", direction);
+
+    final MethodCall platformCreateMethodCall =
+        new MethodCall("setDirection", platformViewCreateArguments);
 
     jni.handlePlatformMessage(
         "flutter/platform_views",


### PR DESCRIPTION
On android platform, virtual display platform view can set direction layout correctly, but hybrid composition will fail and throw an NullPointerException as https://github.com/flutter/flutter/issues/96003 shown, this PR fixes it.

Besides, if a virtual display platform view is not found with specified viewId,  `vdControllers.get(viewId)` will be null, so an NPE will also occur, this PR also fixes it.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
