### PR TITLE
[web] Implement onTextScaleFactorChanged

### DIFF
--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -44,6 +44,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
   /// these.
   EnginePlatformDispatcher._() {
     _addBrightnessMediaQueryListener();
+    _observeFontSize();
   }
 
   /// The [EnginePlatformDispatcher] singleton.
@@ -782,6 +783,54 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
   /// This option is used by [showTimePicker].
   @override
   bool get alwaysUse24HourFormat => configuration.alwaysUse24HourFormat;
+
+  /// Updates [textScaleFactor] and invokes [onTextScaleFactorChanged]
+  /// callback if [textScaleFactor] changed.
+  void _updateTextScaleFactor(double value) {
+    if (configuration.textScaleFactor != value) {
+      _configuration = configuration.copyWith(textScaleFactor: value);
+      invokeOnPlatformConfigurationChanged();
+      invokeOnTextScaleFactorChanged();
+    }
+  }
+
+  /// Watches for font-size changes in the browser's <html> element to
+  /// recalculate [textScaleFactor].
+  ///
+  /// Updates [textScaleFactor] with the new value.
+  html.MutationObserver? _fontSizeObserver;
+
+  /// Set the callback function for updating [textScaleFactor] based on
+  /// font-size changes in the browser's <html> element.
+  void _observeFontSize() {
+    const String styleAttribute = 'style';
+
+    _fontSizeObserver = html.MutationObserver(
+        (List<dynamic> mutations, html.MutationObserver _) {
+      for (final html.MutationRecord record
+          in mutations.cast<html.MutationRecord>()) {
+        if (record.type == 'attributes' &&
+            record.attributeName == styleAttribute) {
+          final double newTextScaleFactor = findBrowserTextScaleFactor();
+          _updateTextScaleFactor(newTextScaleFactor);
+        }
+      }
+    });
+    _fontSizeObserver!.observe(
+      html.document.documentElement!,
+      attributes: true,
+      attributeFilter: <String>[styleAttribute],
+    );
+    registerHotRestartListener(() {
+      _disconnectFontSizeObserver();
+    });
+  }
+
+  /// Remove the observer for font-size changes in the browser's <html> element.
+  void _disconnectFontSizeObserver() {
+    _fontSizeObserver?.disconnect();
+    _fontSizeObserver = null;
+  }
 
   /// A callback that is invoked whenever [textScaleFactor] changes value.
   ///

--- a/lib/web_ui/test/engine/platform_dispatcher_test.dart
+++ b/lib/web_ui/test/engine/platform_dispatcher_test.dart
@@ -117,18 +117,12 @@ void testMain() {
         () async {
       final html.Element root = html.document.documentElement!;
       final String oldFontSize = root.style.fontSize;
-      final String oldBackgroundColor = root.style.backgroundColor;
-      final String oldContentEditable = root.contentEditable;
 
       addTearDown(() {
         root.style.fontSize = oldFontSize;
-        root.style.backgroundColor = oldBackgroundColor;
-        root.contentEditable = oldContentEditable;
       });
 
       root.style.fontSize = '16px';
-      root.style.backgroundColor = 'white';
-      root.contentEditable = 'false';
 
       bool callsCallback = false;
       ui.PlatformDispatcher.instance.onTextScaleFactorChanged = () {


### PR DESCRIPTION
Correctly call the `onTextScaleFactorChanged` callback on the web platform.

Currently `onTextScaleFactorChanged` can be set, but it is never called on web. Adds a `MutationObserver` to respond to text scale factor changes by observing the `<html>` element's style attribute.

Fixes [#91327](https://github.com/flutter/flutter/issues/91327)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.