### PR TITLE
[web] Implement onTextScaleFactorChanged

### DIFF
--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -807,7 +807,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
 
     _fontSizeObserver = html.MutationObserver(
         (List<dynamic> mutations, html.MutationObserver _) {
-      for (final mutation in mutations) {
+      for (final dynamic mutation in mutations) {
         final html.MutationRecord record = mutation as html.MutationRecord;
         if (record.type == 'attributes' &&
             record.attributeName == styleAttribute) {

--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -44,7 +44,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
   /// these.
   EnginePlatformDispatcher._() {
     _addBrightnessMediaQueryListener();
-    _observeFontSize();
+    _addFontSizeObserver();
   }
 
   /// The [EnginePlatformDispatcher] singleton.
@@ -784,8 +784,8 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
   @override
   bool get alwaysUse24HourFormat => configuration.alwaysUse24HourFormat;
 
-  /// Updates [textScaleFactor] and invokes [onTextScaleFactorChanged]
-  /// callback if [textScaleFactor] changed.
+  /// Updates [textScaleFactor] and invokes [onTextScaleFactorChanged] and
+  /// [onPlatformConfigurationChanged] callbacks if [textScaleFactor] changed.
   void _updateTextScaleFactor(double value) {
     if (configuration.textScaleFactor != value) {
       _configuration = configuration.copyWith(textScaleFactor: value);
@@ -802,7 +802,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
 
   /// Set the callback function for updating [textScaleFactor] based on
   /// font-size changes in the browser's <html> element.
-  void _observeFontSize() {
+  void _addFontSizeObserver() {
     const String styleAttribute = 'style';
 
     _fontSizeObserver = html.MutationObserver(

--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -44,6 +44,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
   /// these.
   EnginePlatformDispatcher._() {
     _addBrightnessMediaQueryListener();
+    _observeFontSize();
   }
 
   /// The [EnginePlatformDispatcher] singleton.
@@ -782,6 +783,54 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
   /// This option is used by [showTimePicker].
   @override
   bool get alwaysUse24HourFormat => configuration.alwaysUse24HourFormat;
+
+  /// Updates [textScaleFactor] and invokes [onTextScaleFactorChanged]
+  /// callback if [textScaleFactor] changed.
+  void _updateTextScaleFactor(double value) {
+    if (configuration.textScaleFactor != value) {
+      _configuration = configuration.copyWith(textScaleFactor: value);
+      invokeOnPlatformConfigurationChanged();
+      invokeOnTextScaleFactorChanged();
+    }
+  }
+
+  /// Watches for font-size changes in the browser's <html> element to
+  /// recalculate [textScaleFactor].
+  ///
+  /// Updates [textScaleFactor] with the new value.
+  html.MutationObserver? _fontSizeObserver;
+
+  /// Set the callback function for updating [textScaleFactor] based on
+  /// font-size changes in the browser's <html> element.
+  void _observeFontSize() {
+    const String styleAttribute = 'style';
+
+    _fontSizeObserver = html.MutationObserver(
+        (List<dynamic> mutations, html.MutationObserver _) {
+      for (final html.MutationRecord record
+          in mutations.cast<html.MutationRecord>()) {
+        if (record.type == 'attributes' &&
+            record.attributeName == styleAttribute) {
+          final double newTextScaleFactor = findBrowserTextScaleFactor();
+          _updateTextScaleFactor(newTextScaleFactor);
+        }
+      }
+    });
+    _fontSizeObserver!.observe(
+      html.document.documentElement!,
+      attributes: true,
+      attributeFilter: <String>[styleAttribute],
+    );
+    registerHotRestartListener(() {
+      _disconnectFontSizeObserver();
+    });
+  }
+
+  /// Remove the observer for font-size changes in the browser's <html> element.
+  void _disconnectFontSizeObserver() {
+    _fontSizeObserver?.disconnect();
+    _fontSizeObserver = null;
+  }
 
   /// A callback that is invoked whenever [textScaleFactor] changes value.
   ///

--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -807,8 +807,8 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
 
     _fontSizeObserver = html.MutationObserver(
         (List<dynamic> mutations, html.MutationObserver _) {
-      for (final html.MutationRecord record
-          in mutations.cast<html.MutationRecord>()) {
+      for (final mutation in mutations) {
+        final html.MutationRecord record = mutation as html.MutationRecord;
         if (record.type == 'attributes' &&
             record.attributeName == styleAttribute) {
           final double newTextScaleFactor = findBrowserTextScaleFactor();

--- a/lib/web_ui/test/engine/platform_dispatcher_test.dart
+++ b/lib/web_ui/test/engine/platform_dispatcher_test.dart
@@ -132,22 +132,18 @@ void testMain() {
       };
 
       root.style.fontSize = '20px';
-      await Future<void>(() {
-        expect(isCalled, true);
-      }).then((_) {
-        expect(ui.PlatformDispatcher.instance.textScaleFactor,
-            findBrowserTextScaleFactor());
-      });
+      await Future<void>.delayed(Duration.zero);
+      expect(root.style.fontSize, '20px');
+      expect(isCalled, isTrue);
+      expect(ui.PlatformDispatcher.instance.textScaleFactor, findBrowserTextScaleFactor());
 
       isCalled = false;
 
       root.style.fontSize = '16px';
-      await Future<void>(() {
-        expect(isCalled, true);
-      }).then((_) {
-        expect(ui.PlatformDispatcher.instance.textScaleFactor,
-            findBrowserTextScaleFactor());
-      });
+      await Future<void>.delayed(Duration.zero);
+      expect(root.style.fontSize, '16px');
+      expect(isCalled, isTrue);
+      expect(ui.PlatformDispatcher.instance.textScaleFactor, findBrowserTextScaleFactor());
     });
   });
 }

--- a/lib/web_ui/test/engine/platform_dispatcher_test.dart
+++ b/lib/web_ui/test/engine/platform_dispatcher_test.dart
@@ -130,7 +130,7 @@ void testMain() {
       };
 
       Future<void> waitUntilCalled() {
-        final Completer completer = Completer();
+        final Completer<void> completer = Completer<void>();
 
         void check() {
           if (callsCallback == true) {

--- a/lib/web_ui/test/engine/platform_dispatcher_test.dart
+++ b/lib/web_ui/test/engine/platform_dispatcher_test.dart
@@ -131,34 +131,23 @@ void testMain() {
         isCalled = true;
       };
 
-      Future<void> waitUntilCalled() {
-        final Completer<void> completer = Completer<void>();
-
-        void check() {
-          if (isCalled == true) {
-            completer.complete();
-          } else {
-            Timer(Duration.zero, check);
-          }
-        }
-
-        check();
-        return completer.future;
-      }
-
       root.style.fontSize = '20px';
-      await waitUntilCalled();
-      expect(isCalled, true);
-      expect(ui.PlatformDispatcher.instance.textScaleFactor,
-          findBrowserTextScaleFactor());
+      await Future(() {
+        expect(isCalled, true);
+      }).then((_) {
+        expect(ui.PlatformDispatcher.instance.textScaleFactor,
+            findBrowserTextScaleFactor());
+      });
 
       isCalled = false;
 
       root.style.fontSize = '16px';
-      await waitUntilCalled();
-      expect(isCalled, true);
-      expect(ui.PlatformDispatcher.instance.textScaleFactor,
-          findBrowserTextScaleFactor());
+      await Future(() {
+        expect(isCalled, true);
+      }).then((_) {
+        expect(ui.PlatformDispatcher.instance.textScaleFactor,
+            findBrowserTextScaleFactor());
+      });
     });
   });
 }

--- a/lib/web_ui/test/engine/platform_dispatcher_test.dart
+++ b/lib/web_ui/test/engine/platform_dispatcher_test.dart
@@ -132,7 +132,7 @@ void testMain() {
       };
 
       root.style.fontSize = '20px';
-      await Future(() {
+      await Future<void>(() {
         expect(isCalled, true);
       }).then((_) {
         expect(ui.PlatformDispatcher.instance.textScaleFactor,
@@ -142,7 +142,7 @@ void testMain() {
       isCalled = false;
 
       root.style.fontSize = '16px';
-      await Future(() {
+      await Future<void>(() {
         expect(isCalled, true);
       }).then((_) {
         expect(ui.PlatformDispatcher.instance.textScaleFactor,

--- a/lib/web_ui/test/engine/platform_dispatcher_test.dart
+++ b/lib/web_ui/test/engine/platform_dispatcher_test.dart
@@ -117,23 +117,25 @@ void testMain() {
         () async {
       final html.Element root = html.document.documentElement!;
       final String oldFontSize = root.style.fontSize;
+      final ui.VoidCallback? oldCallback = ui.PlatformDispatcher.instance.onTextScaleFactorChanged;
 
       addTearDown(() {
         root.style.fontSize = oldFontSize;
+        ui.PlatformDispatcher.instance.onTextScaleFactorChanged = oldCallback;
       });
 
       root.style.fontSize = '16px';
 
-      bool callsCallback = false;
+      bool isCalled = false;
       ui.PlatformDispatcher.instance.onTextScaleFactorChanged = () {
-        callsCallback = true;
+        isCalled = true;
       };
 
       Future<void> waitUntilCalled() {
         final Completer<void> completer = Completer<void>();
 
         void check() {
-          if (callsCallback == true) {
+          if (isCalled == true) {
             completer.complete();
           } else {
             Timer(Duration.zero, check);
@@ -146,15 +148,15 @@ void testMain() {
 
       root.style.fontSize = '20px';
       await waitUntilCalled();
-      expect(callsCallback, true);
+      expect(isCalled, true);
       expect(ui.PlatformDispatcher.instance.textScaleFactor,
           findBrowserTextScaleFactor());
 
-      callsCallback = false;
+      isCalled = false;
 
       root.style.fontSize = '16px';
       await waitUntilCalled();
-      expect(callsCallback, true);
+      expect(isCalled, true);
       expect(ui.PlatformDispatcher.instance.textScaleFactor,
           findBrowserTextScaleFactor());
     });


### PR DESCRIPTION
Correctly call the `onTextScaleFactorChanged` callback on the web platform.

Currently `onTextScaleFactorChanged` can be set, but it is never called on web. Adds a `MutationObserver` to respond to text scale factor changes by observing the `<html>` element's style attribute.

Fixes [#91327](https://github.com/flutter/flutter/issues/91327)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.