### PR TITLE
 UiKitView will be rendered with borders

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -120,7 +120,7 @@ typedef enum UIAccessibilityContrast : NSInteger {
   NSAssert(engine != nil, @"Engine is required");
   self = [super initWithNibName:nibName bundle:nibBundle];
   if (self) {
-    _viewOpaque = YES;
+    _viewOpaque = NO;
     if (engine.viewController) {
       FML_LOG(ERROR) << "The supplied FlutterEngine " << [[engine description] UTF8String]
                      << " is already used with FlutterViewController instance "
@@ -203,7 +203,7 @@ typedef enum UIAccessibilityContrast : NSInteger {
     return;
   }
 
-  _viewOpaque = YES;
+  _viewOpaque = NO;
   _weakFactory = std::make_unique<fml::WeakPtrFactory<FlutterViewController>>(self);
   _engine = std::move(engine);
   _flutterView.reset([[FlutterView alloc] initWithDelegate:_engine opaque:self.isViewOpaque]);

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -168,6 +168,16 @@ typedef enum UIAccessibilityContrast : NSInteger {
   self.messageSent = nil;
 }
 
+- (void)testFlutterViewControllerViewOpaue {
+  FlutterEngine* mockEngine = OCMPartialMock([[FlutterEngine alloc] init]);
+  [mockEngine createShell:@"" libraryURI:@"" initialRoute:nil];
+  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:mockEngine
+                                                                                nibName:nil
+                                                                                 bundle:nil];
+  // The FlutterViewController's FlutterViewLayer Opaque default is NO
+  XCTAssertFalse(viewController.isViewOpaque);
+}
+
 - (void)testkeyboardWillChangeFrameWillStartKeyboardAnimation {
   FlutterEngine* mockEngine = OCMPartialMock([[FlutterEngine alloc] init]);
   [mockEngine createShell:@"" libraryURI:@"" initialRoute:nil];


### PR DESCRIPTION
The UIView's `opaque` property will  inform the UIViews color blend, for example the parent is Red and subview is Green,
when the subview's alpha not equal 1.0, then iOS GPU will blend the color: `Result = Source + Destination * (1 - SourceAlpha)` 
> Result: is the blended color
> Source: is the top of texture color: green
> Destination: is the bottom of texture color: red
> SourceAlpha: is the subView alpa

If the FlutterView `opaque = YES` and when it subView has translucent pixel that rendering out may have jagged black edges.
So I change the FlutterView `opaque = NO` to make blend alpha correctly.
And you can use this project to check the effect: https://github.com/JsouLiang/platform_blend_test

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
