### PR TITLE
Deprecates `hashValues` and `hashList`

### DIFF
--- a/lib/ui/geometry.dart
+++ b/lib/ui/geometry.dart
@@ -91,7 +91,7 @@ abstract class OffsetBase {
   }
 
   @override
-  int get hashCode => hashValues(_dx, _dy);
+  int get hashCode => Object.hash(_dx, _dy);
 
   @override
   String toString() => 'OffsetBase(${_dx.toStringAsFixed(1)}, ${_dy.toStringAsFixed(1)})';
@@ -341,7 +341,7 @@ class Offset extends OffsetBase {
   }
 
   @override
-  int get hashCode => hashValues(dx, dy);
+  int get hashCode => Object.hash(dx, dy);
 
   @override
   String toString() => 'Offset(${dx.toStringAsFixed(1)}, ${dy.toStringAsFixed(1)})';
@@ -613,7 +613,7 @@ class Size extends OffsetBase {
   }
 
   @override
-  int get hashCode => hashValues(_dx, _dy);
+  int get hashCode => Object.hash(_dx, _dy);
 
   @override
   String toString() => 'Size(${width.toStringAsFixed(1)}, ${height.toStringAsFixed(1)})';
@@ -907,7 +907,7 @@ class Rect {
   }
 
   @override
-  int get hashCode => hashValues(left, top, right, bottom);
+  int get hashCode => Object.hash(left, top, right, bottom);
 
   @override
   String toString() => 'Rect.fromLTRB(${left.toStringAsFixed(1)}, ${top.toStringAsFixed(1)}, ${right.toStringAsFixed(1)}, ${bottom.toStringAsFixed(1)})';
@@ -1033,7 +1033,7 @@ class Radius {
   }
 
   @override
-  int get hashCode => hashValues(x, y);
+  int get hashCode => Object.hash(x, y);
 
   @override
   String toString() {
@@ -1645,7 +1645,7 @@ class RRect {
   }
 
   @override
-  int get hashCode => hashValues(left, top, right, bottom,
+  int get hashCode => Object.hash(left, top, right, bottom,
     tlRadiusX, tlRadiusY, trRadiusX, trRadiusY,
     blRadiusX, blRadiusY, brRadiusX, brRadiusY);
 

--- a/lib/ui/hash_codes.dart
+++ b/lib/ui/hash_codes.dart
@@ -43,7 +43,7 @@ class _Jenkins {
 /// ```
 @Deprecated(
   'Use Object.hash() instead. '
-  'This feature was deprecated in v2.9.0-0.1.pre'
+  'This feature was deprecated in v3.1.0-0.0.pre.897'
 )
 int hashValues(
   Object? arg01,            Object? arg02,          [ Object? arg03 = _hashEnd,
@@ -119,7 +119,7 @@ int hashValues(
 /// given null as if given an empty list.
 @Deprecated(
   'Use Object.hashAll() or Object.hashAllUnordered() instead. '
-  'This feature was deprecated in v2.9.0-0.1.pre'
+  'This feature was deprecated in v3.1.0-0.0.pre.897'
 )
 int hashList(Iterable<Object?>? arguments) {
   int result = 0;

--- a/lib/ui/hash_codes.dart
+++ b/lib/ui/hash_codes.dart
@@ -41,7 +41,7 @@ class _Jenkins {
 /// int hashCode => hashValues(foo, bar, hashList(quux), baz);
 /// ```
 @Deprecated(
-  'Use Object.hash() instead '
+  'Use Object.hash() instead. '
   'This feature was deprecated in v2.9.0-0.1.pre'
 )
 int hashValues(
@@ -117,7 +117,7 @@ int hashValues(
 /// an [Iterable] into one value. This function will return the same value if
 /// given null as if given an empty list.
 @Deprecated(
-  'Use Object.hashAll() or Object.hashAllUnordered() instead '
+  'Use Object.hashAll() or Object.hashAllUnordered() instead. '
   'This feature was deprecated in v2.9.0-0.1.pre'
 )
 int hashList(Iterable<Object?>? arguments) {

--- a/lib/ui/hash_codes.dart
+++ b/lib/ui/hash_codes.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
 // @dart = 2.12
 part of dart.ui;
 
@@ -41,6 +40,10 @@ class _Jenkins {
 /// ```dart
 /// int hashCode => hashValues(foo, bar, hashList(quux), baz);
 /// ```
+@Deprecated(
+  'Use Object.hash() instead '
+  'This feature was deprecated in v2.9.0-0.1.pre'
+)
 int hashValues(
   Object? arg01,            Object? arg02,          [ Object? arg03 = _hashEnd,
   Object? arg04 = _hashEnd, Object? arg05 = _hashEnd, Object? arg06 = _hashEnd,
@@ -113,6 +116,10 @@ int hashValues(
 /// Combine the [Object.hashCode] values of an arbitrary number of objects from
 /// an [Iterable] into one value. This function will return the same value if
 /// given null as if given an empty list.
+@Deprecated(
+  'Use Object.hashAll() or Object.hashAllUnordered() instead '
+  'This feature was deprecated in v2.9.0-0.1.pre'
+)
 int hashList(Iterable<Object?>? arguments) {
   int result = 0;
   if (arguments != null) {

--- a/lib/ui/hash_codes.dart
+++ b/lib/ui/hash_codes.dart
@@ -8,6 +8,7 @@ part of dart.ui;
 class _HashEnd { const _HashEnd(); }
 const _HashEnd _hashEnd = _HashEnd();
 
+// ignore: avoid_classes_with_only_static_members
 /// Jenkins hash function, optimized for small integers.
 //
 // Borrowed from the dart sdk: sdk/lib/math/jenkins_smi_hash.dart.

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -3009,7 +3009,7 @@ class MaskFilter {
   }
 
   @override
-  int get hashCode => hashValues(_style, _sigma);
+  int get hashCode => Object.hash(_style, _sigma);
 
   @override
   String toString() => 'MaskFilter.blur($_style, ${_sigma.toStringAsFixed(1)})';
@@ -3168,7 +3168,7 @@ class ColorFilter implements ImageFilter {
   }
 
   @override
-  int get hashCode => hashValues(_color, _blendMode, hashList(_matrix), _type);
+  int get hashCode => Object.hash(_color, _blendMode, Object.hashAll(_matrix ?? const <Object?>[]), _type);
 
   @override
   String get _shortDescription {
@@ -3342,7 +3342,7 @@ class _MatrixImageFilter implements ImageFilter {
   }
 
   @override
-  int get hashCode => hashValues(filterQuality, hashList(data));
+  int get hashCode => Object.hash(filterQuality, Object.hashAll(data));
 }
 
 class _GaussianBlurImageFilter implements ImageFilter {
@@ -3383,7 +3383,7 @@ class _GaussianBlurImageFilter implements ImageFilter {
   }
 
   @override
-  int get hashCode => hashValues(sigmaX, sigmaY);
+  int get hashCode => Object.hash(sigmaX, sigmaY);
 }
 
 class _DilateImageFilter implements ImageFilter {
@@ -3471,7 +3471,7 @@ class _ComposeImageFilter implements ImageFilter {
   }
 
   @override
-  int get hashCode => hashValues(innerFilter, outerFilter);
+  int get hashCode => Object.hash(innerFilter, outerFilter);
 }
 
 /// An [ImageFilter] that is backed by a native SkImageFilter.
@@ -4048,7 +4048,7 @@ class _FragmentShader extends Shader {
   }
 
   @override
-  int get hashCode => hashValues(_builder, hashList(_floatUniforms), hashList(_samplerUniforms));
+  int get hashCode => Object.hash(_builder, Object.hashAll(_floatUniforms), Object.hashAll(_samplerUniforms));
 }
 
 /// Defines how a list of points is interpreted when drawing a set of triangles.
@@ -5508,7 +5508,7 @@ class Shadow {
   }
 
   @override
-  int get hashCode => hashValues(color, offset, blurRadius);
+  int get hashCode => Object.hash(color, offset, blurRadius);
 
   // Serialize [shadows] into ByteData. The format is a single uint_32_t at
   // the beginning indicating the number of shadows, followed by _kBytesPerShadow

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -3168,7 +3168,7 @@ class ColorFilter implements ImageFilter {
   }
 
   @override
-  int get hashCode => Object.hash(_color, _blendMode, Object.hashAll(_matrix ?? const <Object?>[]), _type);
+  int get hashCode => Object.hash(_color, _blendMode, _matrix == null ? null : Object.hashAll(_matrix!), _type);
 
   @override
   String get _shortDescription {

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -3412,7 +3412,7 @@ class _DilateImageFilter implements ImageFilter {
   }
 
   @override
-  int get hashCode => hashValues(radiusX, radiusY);
+  int get hashCode => Object.hash(radiusX, radiusY);
 }
 
 class _ErodeImageFilter implements ImageFilter {

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -1689,7 +1689,7 @@ class DisplayFeature {
   }
 
   @override
-  int get hashCode => hashValues(bounds, type, state);
+  int get hashCode => Object.hash(bounds, type, state);
 
   @override
   String toString() {
@@ -2016,13 +2016,7 @@ class Locale {
   }
 
   @override
-  int get hashCode => _hashCode[this] ??= hashValues(
-        languageCode,
-        scriptCode,
-        countryCode == '' ? null : countryCode,
-      );
-  // Memoize hashCode since languageCode and countryCode require lookups.
-  static final Expando<int> _hashCode = Expando<int>();
+  int get hashCode => Object.hash(languageCode, scriptCode, countryCode == '' ? null : countryCode);
 
   static Locale? _cachedLocale;
   static String? _cachedLocaleString;

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -1540,7 +1540,23 @@ class TextStyle {
   }
 
   @override
-  int get hashCode => Object.hash(Object.hashAll(_encoded), _leadingDistribution, _fontFamily, _fontFamilyFallback, _fontSize, _letterSpacing, _wordSpacing, _height, _locale, _background, _foreground, Object.hashAll(_shadows ?? const <Object?>[]), _decorationThickness, Object.hashAll(_fontFeatures ?? const <Object?>[]), Object.hashAll(_fontVariations ?? const <Object?>[]));
+  int get hashCode => Object.hash(
+    Object.hashAll(_encoded),
+    _leadingDistribution,
+    _fontFamily,
+    _fontFamilyFallback,
+    _fontSize,
+    _letterSpacing,
+    _wordSpacing,
+    _height,
+    _locale,
+    _background,
+    _foreground,
+    Object.hashAll(_shadows ?? const <Object?>[]),
+    _decorationThickness,
+    Object.hashAll(_fontFeatures ?? const <Object?>[]),
+    Object.hashAll(_fontVariations ?? const <Object?>[]),
+  );
 
   @override
   String toString() {

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -1552,10 +1552,10 @@ class TextStyle {
     _locale,
     _background,
     _foreground,
-    Object.hashAll(_shadows ?? const <Object?>[]),
+    _shadows == null ? null : Object.hashAll(_shadows!),
     _decorationThickness,
-    Object.hashAll(_fontFeatures ?? const <Object?>[]),
-    Object.hashAll(_fontVariations ?? const <Object?>[]),
+    _fontFeatures == null ? null : Object.hashAll(_fontFeatures!),
+    _fontVariations == null ? null : Object.hashAll(_fontVariations!),
   );
 
   @override

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -988,7 +988,7 @@ class FontVariation {
   }
 
   @override
-  int get hashCode => hashValues(axis, value);
+  int get hashCode => Object.hash(axis, value);
 
   @override
   String toString() => "FontVariation('$axis', $value)";

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -927,7 +927,7 @@ class FontFeature {
   }
 
   @override
-  int get hashCode => hashValues(feature, value);
+  int get hashCode => Object.hash(feature, value);
 
   @override
   String toString() => "FontFeature('$feature', $value)";
@@ -1236,7 +1236,7 @@ class TextHeightBehavior {
 
   @override
   int get hashCode {
-    return hashValues(
+    return Object.hash(
       applyHeightToFirstAscent,
       applyHeightToLastDescent,
       leadingDistribution.index,
@@ -1540,7 +1540,7 @@ class TextStyle {
   }
 
   @override
-  int get hashCode => hashValues(hashList(_encoded), _leadingDistribution, _fontFamily, _fontFamilyFallback, _fontSize, _letterSpacing, _wordSpacing, _height, _locale, _background, _foreground, hashList(_shadows), _decorationThickness, hashList(_fontFeatures), hashList(_fontVariations));
+  int get hashCode => Object.hash(Object.hashAll(_encoded), _leadingDistribution, _fontFamily, _fontFamilyFallback, _fontSize, _letterSpacing, _wordSpacing, _height, _locale, _background, _foreground, Object.hashAll(_shadows ?? const <Object?>[]), _decorationThickness, Object.hashAll(_fontFeatures ?? const <Object?>[]), Object.hashAll(_fontVariations ?? const <Object?>[]));
 
   @override
   String toString() {
@@ -1785,7 +1785,7 @@ class ParagraphStyle {
   }
 
   @override
-  int get hashCode => hashValues(hashList(_encoded), _fontFamily, _fontSize, _height, _ellipsis, _locale, _leadingDistribution);
+  int get hashCode => Object.hash(Object.hashAll(_encoded), _fontFamily, _fontSize, _height, _ellipsis, _locale, _leadingDistribution);
 
   @override
   String toString() {
@@ -1979,7 +1979,7 @@ class StrutStyle {
   }
 
   @override
-  int get hashCode => hashValues(hashList(_encoded.buffer.asInt8List()), _fontFamily, _leadingDistribution);
+  int get hashCode => Object.hash(Object.hashAll(_encoded.buffer.asInt8List()), _fontFamily, _leadingDistribution);
 
 }
 
@@ -2145,7 +2145,7 @@ class TextBox {
   }
 
   @override
-  int get hashCode => hashValues(left, top, right, bottom, direction);
+  int get hashCode => Object.hash(left, top, right, bottom, direction);
 
   @override
   String toString() => 'TextBox.fromLTRBD(${left.toStringAsFixed(1)}, ${top.toStringAsFixed(1)}, ${right.toStringAsFixed(1)}, ${bottom.toStringAsFixed(1)}, $direction)';
@@ -2252,7 +2252,7 @@ class TextPosition {
   }
 
   @override
-  int get hashCode => hashValues(offset, affinity);
+  int get hashCode => Object.hash(offset, affinity);
 
   @override
   String toString() {
@@ -2336,7 +2336,7 @@ class TextRange {
   }
 
   @override
-  int get hashCode => hashValues(
+  int get hashCode => Object.hash(
     start.hashCode,
     end.hashCode,
   );
@@ -2619,7 +2619,7 @@ class LineMetrics {
   }
 
   @override
-  int get hashCode => hashValues(hardBreak, ascent, descent, unscaledAscent, height, width, left, baseline, lineNumber);
+  int get hashCode => Object.hash(hardBreak, ascent, descent, unscaledAscent, height, width, left, baseline, lineNumber);
 
   @override
   String toString() {

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -983,7 +983,7 @@ class GestureSettings {
   }
 
   @override
-  int get hashCode => hashValues(physicalTouchSlop, physicalDoubleTapSlop);
+  int get hashCode => Object.hash(physicalTouchSlop, physicalDoubleTapSlop);
 
   @override
   String toString() => 'GestureSettings(physicalTouchSlop: $physicalTouchSlop, physicalDoubleTapSlop: $physicalDoubleTapSlop)';

--- a/lib/web_ui/lib/geometry.dart
+++ b/lib/web_ui/lib/geometry.dart
@@ -28,7 +28,7 @@ abstract class OffsetBase {
   }
 
   @override
-  int get hashCode => hashValues(_dx, _dy);
+  int get hashCode => Object.hash(_dx, _dy);
 
   @override
   String toString() => 'OffsetBase(${_dx.toStringAsFixed(1)}, ${_dy.toStringAsFixed(1)})';
@@ -82,7 +82,7 @@ class Offset extends OffsetBase {
   }
 
   @override
-  int get hashCode => hashValues(dx, dy);
+  int get hashCode => Object.hash(dx, dy);
 
   @override
   String toString() => 'Offset(${dx.toStringAsFixed(1)}, ${dy.toStringAsFixed(1)})';
@@ -169,7 +169,7 @@ class Size extends OffsetBase {
   }
 
   @override
-  int get hashCode => hashValues(_dx, _dy);
+  int get hashCode => Object.hash(_dx, _dy);
 
   @override
   String toString() => 'Size(${width.toStringAsFixed(1)}, ${height.toStringAsFixed(1)})';
@@ -321,7 +321,7 @@ class Rect {
   }
 
   @override
-  int get hashCode => hashValues(left, top, right, bottom);
+  int get hashCode => Object.hash(left, top, right, bottom);
 
   @override
   String toString() => 'Rect.fromLTRB(${left.toStringAsFixed(1)}, ${top.toStringAsFixed(1)}, ${right.toStringAsFixed(1)}, ${bottom.toStringAsFixed(1)})';
@@ -374,7 +374,7 @@ class Radius {
   }
 
   @override
-  int get hashCode => hashValues(x, y);
+  int get hashCode => Object.hash(x, y);
 
   @override
   String toString() {
@@ -870,7 +870,7 @@ class RRect {
   }
 
   @override
-  int get hashCode => hashValues(left, top, right, bottom,
+  int get hashCode => Object.hash(left, top, right, bottom,
     tlRadiusX, tlRadiusY, trRadiusX, trRadiusY,
     blRadiusX, blRadiusY, brRadiusX, brRadiusY);
 

--- a/lib/web_ui/lib/hash_codes.dart
+++ b/lib/web_ui/lib/hash_codes.dart
@@ -40,7 +40,7 @@ class _Jenkins {
 /// int hashCode => hashValues(foo, bar, hashList(quux), baz);
 /// ```
 @Deprecated(
-  'Use Object.hash() instead '
+  'Use Object.hash() instead. '
   'This feature was deprecated in v2.9.0-0.1.pre'
 )
 int hashValues(
@@ -116,7 +116,7 @@ int hashValues(
 /// an [Iterable] into one value. This function will return the same value if
 /// given null as if given an empty list.
 @Deprecated(
-  'Use Object.hashAll() or Object.hashAllUnordered() instead '
+  'Use Object.hashAll() or Object.hashAllUnordered() instead. '
   'This feature was deprecated in v2.9.0-0.1.pre'
 )
 int hashList(Iterable<Object?>? arguments) {

--- a/lib/web_ui/lib/hash_codes.dart
+++ b/lib/web_ui/lib/hash_codes.dart
@@ -7,6 +7,7 @@ part of ui;
 class _HashEnd { const _HashEnd(); }
 const _HashEnd _hashEnd = _HashEnd();
 
+// ignore: avoid_classes_with_only_static_members
 /// Jenkins hash function, optimized for small integers.
 //
 // Borrowed from the dart sdk: sdk/lib/math/jenkins_smi_hash.dart.

--- a/lib/web_ui/lib/hash_codes.dart
+++ b/lib/web_ui/lib/hash_codes.dart
@@ -4,96 +4,91 @@
 
 part of ui;
 
-class _HashEnd {
-  const _HashEnd();
-}
-
+class _HashEnd { const _HashEnd(); }
 const _HashEnd _hashEnd = _HashEnd();
 
-// Jenkins hash function, optimized for small integers.
+/// Jenkins hash function, optimized for small integers.
 //
 // Borrowed from the dart sdk: sdk/lib/math/jenkins_smi_hash.dart.
-abstract class _Jenkins {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  _Jenkins._();
-
+class _Jenkins {
   static int combine(int hash, Object? o) {
     assert(o is! Iterable);
     hash = 0x1fffffff & (hash + o.hashCode);
     hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
-    hash = hash ^ (hash >> 6);
-    return hash;
+    return hash ^ (hash >> 6);
   }
 
   static int finish(int hash) {
     hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
     hash = hash ^ (hash >> 11);
-    hash = 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
-    return hash;
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
   }
 }
 
+/// Combine up to twenty objects' hash codes into one value.
+///
+/// If you only need to handle one object's hash code, then just refer to its
+/// [Object.hashCode] getter directly.
+///
+/// If you need to combine an arbitrary number of objects from a [List] or other
+/// [Iterable], use [hashList]. The output of [hashList] can be used as one of
+/// the arguments to this function.
+///
+/// For example:
+///
+/// ```dart
+/// int hashCode => hashValues(foo, bar, hashList(quux), baz);
+/// ```
+@Deprecated(
+  'Use Object.hash() instead '
+  'This feature was deprecated in v2.9.0-0.1.pre'
+)
 int hashValues(
-  Object? arg01,
-  Object? arg02, [
-  Object? arg03 = _hashEnd,
-  Object? arg04 = _hashEnd,
-  Object? arg05 = _hashEnd,
-  Object? arg06 = _hashEnd,
-  Object? arg07 = _hashEnd,
-  Object? arg08 = _hashEnd,
-  Object? arg09 = _hashEnd,
-  Object? arg10 = _hashEnd,
-  Object? arg11 = _hashEnd,
-  Object? arg12 = _hashEnd,
-  Object? arg13 = _hashEnd,
-  Object? arg14 = _hashEnd,
-  Object? arg15 = _hashEnd,
-  Object? arg16 = _hashEnd,
-  Object? arg17 = _hashEnd,
-  Object? arg18 = _hashEnd,
-  Object? arg19 = _hashEnd,
-  Object? arg20 = _hashEnd,
-]) {
+  Object? arg01,            Object? arg02,          [ Object? arg03 = _hashEnd,
+  Object? arg04 = _hashEnd, Object? arg05 = _hashEnd, Object? arg06 = _hashEnd,
+  Object? arg07 = _hashEnd, Object? arg08 = _hashEnd, Object? arg09 = _hashEnd,
+  Object? arg10 = _hashEnd, Object? arg11 = _hashEnd, Object? arg12 = _hashEnd,
+  Object? arg13 = _hashEnd, Object? arg14 = _hashEnd, Object? arg15 = _hashEnd,
+  Object? arg16 = _hashEnd, Object? arg17 = _hashEnd, Object? arg18 = _hashEnd,
+  Object? arg19 = _hashEnd, Object? arg20 = _hashEnd ]) {
   int result = 0;
   result = _Jenkins.combine(result, arg01);
   result = _Jenkins.combine(result, arg02);
-  if (arg03 != _hashEnd) {
+  if (!identical(arg03, _hashEnd)) {
     result = _Jenkins.combine(result, arg03);
-    if (arg04 != _hashEnd) {
+    if (!identical(arg04, _hashEnd)) {
       result = _Jenkins.combine(result, arg04);
-      if (arg05 != _hashEnd) {
+      if (!identical(arg05, _hashEnd)) {
         result = _Jenkins.combine(result, arg05);
-        if (arg06 != _hashEnd) {
+        if (!identical(arg06, _hashEnd)) {
           result = _Jenkins.combine(result, arg06);
-          if (arg07 != _hashEnd) {
+          if (!identical(arg07, _hashEnd)) {
             result = _Jenkins.combine(result, arg07);
-            if (arg08 != _hashEnd) {
+            if (!identical(arg08, _hashEnd)) {
               result = _Jenkins.combine(result, arg08);
-              if (arg09 != _hashEnd) {
+              if (!identical(arg09, _hashEnd)) {
                 result = _Jenkins.combine(result, arg09);
-                if (arg10 != _hashEnd) {
+                if (!identical(arg10, _hashEnd)) {
                   result = _Jenkins.combine(result, arg10);
-                  if (arg11 != _hashEnd) {
+                  if (!identical(arg11, _hashEnd)) {
                     result = _Jenkins.combine(result, arg11);
-                    if (arg12 != _hashEnd) {
+                    if (!identical(arg12, _hashEnd)) {
                       result = _Jenkins.combine(result, arg12);
-                      if (arg13 != _hashEnd) {
+                      if (!identical(arg13, _hashEnd)) {
                         result = _Jenkins.combine(result, arg13);
-                        if (arg14 != _hashEnd) {
+                        if (!identical(arg14, _hashEnd)) {
                           result = _Jenkins.combine(result, arg14);
-                          if (arg15 != _hashEnd) {
+                          if (!identical(arg15, _hashEnd)) {
                             result = _Jenkins.combine(result, arg15);
-                            if (arg16 != _hashEnd) {
+                            if (!identical(arg16, _hashEnd)) {
                               result = _Jenkins.combine(result, arg16);
-                              if (arg17 != _hashEnd) {
+                              if (!identical(arg17, _hashEnd)) {
                                 result = _Jenkins.combine(result, arg17);
-                                if (arg18 != _hashEnd) {
+                                if (!identical(arg18, _hashEnd)) {
                                   result = _Jenkins.combine(result, arg18);
-                                  if (arg19 != _hashEnd) {
+                                  if (!identical(arg19, _hashEnd)) {
                                     result = _Jenkins.combine(result, arg19);
-                                    if (arg20 != _hashEnd) {
+                                    if (!identical(arg20, _hashEnd)) {
                                       result = _Jenkins.combine(result, arg20);
                                       // I can see my house from here!
                                     }
@@ -117,6 +112,13 @@ int hashValues(
   return _Jenkins.finish(result);
 }
 
+/// Combine the [Object.hashCode] values of an arbitrary number of objects from
+/// an [Iterable] into one value. This function will return the same value if
+/// given null as if given an empty list.
+@Deprecated(
+  'Use Object.hashAll() or Object.hashAllUnordered() instead '
+  'This feature was deprecated in v2.9.0-0.1.pre'
+)
 int hashList(Iterable<Object?>? arguments) {
   int result = 0;
   if (arguments != null) {

--- a/lib/web_ui/lib/hash_codes.dart
+++ b/lib/web_ui/lib/hash_codes.dart
@@ -42,7 +42,7 @@ class _Jenkins {
 /// ```
 @Deprecated(
   'Use Object.hash() instead. '
-  'This feature was deprecated in v2.9.0-0.1.pre'
+  'This feature was deprecated in v3.1.0-0.0.pre.897'
 )
 int hashValues(
   Object? arg01,            Object? arg02,          [ Object? arg03 = _hashEnd,
@@ -118,7 +118,7 @@ int hashValues(
 /// given null as if given an empty list.
 @Deprecated(
   'Use Object.hashAll() or Object.hashAllUnordered() instead. '
-  'This feature was deprecated in v2.9.0-0.1.pre'
+  'This feature was deprecated in v3.1.0-0.0.pre.897'
 )
 int hashList(Iterable<Object?>? arguments) {
   int result = 0;

--- a/lib/web_ui/lib/painting.dart
+++ b/lib/web_ui/lib/painting.dart
@@ -383,7 +383,7 @@ class MaskFilter {
   }
 
   @override
-  int get hashCode => hashValues(_style, _sigma);
+  int get hashCode => Object.hash(_style, _sigma);
 
   @override
   String toString() => 'MaskFilter.blur($_style, ${_sigma.toStringAsFixed(1)})';
@@ -734,7 +734,7 @@ class Shadow {
   }
 
   @override
-  int get hashCode => hashValues(color, offset, blurRadius);
+  int get hashCode => Object.hash(color, offset, blurRadius);
 
   @override
   String toString() => 'TextShadow($color, $offset, $blurRadius)';

--- a/lib/web_ui/lib/platform_dispatcher.dart
+++ b/lib/web_ui/lib/platform_dispatcher.dart
@@ -368,7 +368,7 @@ class DisplayFeature {
   }
 
   @override
-  int get hashCode => hashValues(bounds, type, state);
+  int get hashCode => Object.hash(bounds, type, state);
 
   @override
   String toString() {
@@ -523,7 +523,7 @@ class Locale {
   }
 
   @override
-  int get hashCode => hashValues(languageCode, scriptCode, countryCode);
+  int get hashCode => Object.hash(languageCode, scriptCode, countryCode);
 
   @override
   String toString() => _rawToString('_');

--- a/lib/web_ui/lib/src/engine/canvaskit/color_filter.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/color_filter.dart
@@ -94,7 +94,7 @@ class CkBlendModeColorFilter extends CkColorFilter {
   }
 
   @override
-  int get hashCode => ui.hashValues(color, blendMode);
+  int get hashCode => Object.hash(color, blendMode);
 
   @override
   bool operator ==(Object other) {
@@ -140,7 +140,7 @@ class CkMatrixColorFilter extends CkColorFilter {
   }
 
   @override
-  int get hashCode => ui.hashList(matrix);
+  int get hashCode => Object.hashAll(matrix);
 
   @override
   bool operator ==(Object other) {

--- a/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
@@ -807,7 +807,7 @@ class EmbeddedViewParams {
   }
 
   @override
-  int get hashCode => ui.hashValues(offset, size, mutators);
+  int get hashCode => Object.hash(offset, size, mutators);
 }
 
 enum MutatorType {
@@ -885,7 +885,7 @@ class Mutator {
   }
 
   @override
-  int get hashCode => ui.hashValues(type, rect, rrect, path, matrix, alpha);
+  int get hashCode => Object.hash(type, rect, rrect, path, matrix, alpha);
 }
 
 /// A stack of mutators that can be applied to an embedded view.
@@ -931,7 +931,7 @@ class MutatorsStack extends Iterable<Mutator> {
   }
 
   @override
-  int get hashCode => ui.hashList(_mutators);
+  int get hashCode => Object.hashAll(_mutators);
 
   @override
   Iterator<Mutator> get iterator => _mutators.reversed.iterator;

--- a/lib/web_ui/lib/src/engine/canvaskit/font_fallbacks.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/font_fallbacks.dart
@@ -6,8 +6,6 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:ui/ui.dart' as ui;
-
 import '../dom.dart';
 import '../font_change_util.dart';
 import '../platform_dispatcher.dart';
@@ -988,9 +986,8 @@ class NotoDownloader {
     if (assertionsEnabled) {
       _debugActiveDownloadCount += 1;
     }
-    final Future<String> result = httpFetch(url).then(
-        (DomResponse response) =>
-            response.text().then<String>((dynamic x) => x as String));
+    final Future<String> result = httpFetch(url).then((DomResponse response) =>
+        response.text().then<String>((dynamic x) => x as String));
     if (assertionsEnabled) {
       result.whenComplete(() {
         _debugActiveDownloadCount -= 1;

--- a/lib/web_ui/lib/src/engine/canvaskit/font_fallbacks.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/font_fallbacks.dart
@@ -602,7 +602,7 @@ class CodeunitRange {
   }
 
   @override
-  int get hashCode => ui.hashValues(start, end);
+  int get hashCode => Object.hash(start, end);
 
   @override
   String toString() => '[$start, $end]';

--- a/lib/web_ui/lib/src/engine/canvaskit/image_filter.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image_filter.dart
@@ -124,7 +124,7 @@ class _CkBlurImageFilter extends CkImageFilter {
   }
 
   @override
-  int get hashCode => ui.hashValues(sigmaX, sigmaY, tileMode);
+  int get hashCode => Object.hash(sigmaX, sigmaY, tileMode);
 
   @override
   String toString() {
@@ -161,7 +161,7 @@ class _CkMatrixImageFilter extends CkImageFilter {
   }
 
   @override
-  int get hashCode => ui.hashValues(filterQuality, ui.hashList(matrix));
+  int get hashCode => Object.hash(filterQuality, Object.hashAll(matrix));
 
   @override
   String toString() => 'ImageFilter.matrix($matrix, $filterQuality)';

--- a/lib/web_ui/lib/src/engine/canvaskit/text.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/text.dart
@@ -504,7 +504,7 @@ class CkStrutStyle implements ui.StrutStyle {
   }
 
   @override
-  int get hashCode => ui.hashValues(
+  int get hashCode => Object.hash(
         _fontFamily,
         _fontFamilyFallback,
         _fontSize,

--- a/lib/web_ui/lib/src/engine/html/path/path_ref.dart
+++ b/lib/web_ui/lib/src/engine/html/path/path_ref.dart
@@ -319,7 +319,7 @@ class PathRef {
   }
 
   @override
-  int get hashCode => ui.hashValues(fSegmentMask,
+  int get hashCode => Object.hash(fSegmentMask,
       fPoints, _conicWeights, _fVerbs);
 
   bool equals(PathRef ref) {

--- a/lib/web_ui/lib/src/engine/html/shaders/shader.dart
+++ b/lib/web_ui/lib/src/engine/html/shaders/shader.dart
@@ -726,7 +726,7 @@ class _BlurEngineImageFilter extends EngineImageFilter {
   }
 
   @override
-  int get hashCode => ui.hashValues(sigmaX, sigmaY, tileMode);
+  int get hashCode => Object.hash(sigmaX, sigmaY, tileMode);
 
   @override
   String toString() {
@@ -756,7 +756,7 @@ class _MatrixEngineImageFilter extends EngineImageFilter {
   }
 
   @override
-  int get hashCode => ui.hashValues(ui.hashList(webMatrix), filterQuality);
+  int get hashCode => Object.hash(Object.hashAll(webMatrix), filterQuality);
 
   @override
   String toString() {

--- a/lib/web_ui/lib/src/engine/safe_browser_api.dart
+++ b/lib/web_ui/lib/src/engine/safe_browser_api.dart
@@ -162,7 +162,7 @@ num? parseFontSize(html.Element element) {
   if (hasJsProperty(element, 'computedStyleMap')) {
     // Use the newer `computedStyleMap` API available on some browsers.
     final Object? computedStyleMap =
-        js_util.callMethod<Object?>(element, 'computedStyleMap', <Object?>[]);
+        js_util.callMethod<Object?>(element, 'computedStyleMap', const <Object?>[]);
     if (computedStyleMap is Object) {
       final Object? fontSizeObject =
           js_util.callMethod<Object?>(computedStyleMap, 'get', <Object?>['font-size']);

--- a/lib/web_ui/lib/src/engine/text/line_breaker.dart
+++ b/lib/web_ui/lib/src/engine/text/line_breaker.dart
@@ -4,8 +4,6 @@
 
 import 'dart:math' as math;
 
-import 'package:ui/ui.dart' as ui;
-
 import '../util.dart';
 import 'line_break_properties.dart';
 import 'unicode_range.dart';

--- a/lib/web_ui/lib/src/engine/text/line_breaker.dart
+++ b/lib/web_ui/lib/src/engine/text/line_breaker.dart
@@ -86,7 +86,7 @@ class LineBreakResult {
       type == LineBreakType.mandatory || type == LineBreakType.endOfText;
 
   @override
-  int get hashCode => ui.hashValues(
+  int get hashCode => Object.hash(
         index,
         indexWithoutTrailingNewlines,
         indexWithoutTrailingSpaces,

--- a/lib/web_ui/lib/src/engine/text/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/paragraph.dart
@@ -133,7 +133,7 @@ class EngineLineMetrics implements ui.LineMetrics {
   }
 
   @override
-  int get hashCode => ui.hashValues(
+  int get hashCode => Object.hash(
         displayText,
         startIndex,
         endIndex,
@@ -268,7 +268,7 @@ class EngineParagraphStyle implements ui.ParagraphStyle {
 
   @override
   int get hashCode {
-    return ui.hashValues(
+    return Object.hash(
         textAlign,
         textDirection,
         fontWeight,
@@ -476,7 +476,7 @@ class EngineTextStyle implements ui.TextStyle {
   }
 
   @override
-  int get hashCode => ui.hashValues(
+  int get hashCode => Object.hash(
         color,
         decoration,
         decorationColor,
@@ -584,7 +584,7 @@ class EngineStrutStyle implements ui.StrutStyle {
   }
 
   @override
-  int get hashCode => ui.hashValues(
+  int get hashCode => Object.hash(
         _fontFamily,
         _fontFamilyFallback,
         _fontSize,

--- a/lib/web_ui/lib/src/engine/text/ruler.dart
+++ b/lib/web_ui/lib/src/engine/text/ruler.dart
@@ -78,8 +78,8 @@ class TextHeightStyle {
     fontFamily,
     fontSize,
     height,
-    Object.hashAll(fontFeatures ?? const <Object?>[]),
-    Object.hashAll(fontVariations ?? const <Object?>[]),
+    fontFeatures == null ? null : Object.hashAll(fontFeatures!),
+    fontVariations == null ? null : Object.hashAll(fontVariations!),
   );
 }
 

--- a/lib/web_ui/lib/src/engine/text/ruler.dart
+++ b/lib/web_ui/lib/src/engine/text/ruler.dart
@@ -74,12 +74,12 @@ class TextHeightStyle {
   }
 
   @override
-  late final int hashCode = ui.hashValues(
+  late final int hashCode = Object.hash(
     fontFamily,
     fontSize,
     height,
-    ui.hashList(fontFeatures),
-    ui.hashList(fontVariations),
+    Object.hashAll(fontFeatures ?? const <Object?>[]),
+    Object.hashAll(fontVariations ?? const <Object?>[]),
   );
 }
 

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -730,7 +730,7 @@ class EditingState {
   bool get isValid => baseOffset! >= 0 && extentOffset! >= 0;
 
   @override
-  int get hashCode => ui.hashValues(text, baseOffset, extentOffset);
+  int get hashCode => Object.hash(text, baseOffset, extentOffset);
 
   @override
   bool operator ==(Object other) {

--- a/lib/web_ui/lib/text.dart
+++ b/lib/web_ui/lib/text.dart
@@ -173,7 +173,7 @@ class FontFeature {
   }
 
   @override
-  int get hashCode => hashValues(feature, value);
+  int get hashCode => Object.hash(feature, value);
 
   @override
   String toString() => "FontFeature('$feature', $value)";
@@ -301,7 +301,7 @@ class TextHeightBehavior {
 
   @override
   int get hashCode {
-    return hashValues(
+    return Object.hash(
       applyHeightToFirstAscent,
       applyHeightToLastDescent,
     );
@@ -561,7 +561,7 @@ class TextBox {
   }
 
   @override
-  int get hashCode => hashValues(left, top, right, bottom, direction);
+  int get hashCode => Object.hash(left, top, right, bottom, direction);
 
   @override
   String toString() {
@@ -594,7 +594,7 @@ class TextPosition {
   }
 
   @override
-  int get hashCode => hashValues(offset, affinity);
+  int get hashCode => Object.hash(offset, affinity);
 
   @override
   String toString() {
@@ -642,7 +642,7 @@ class TextRange {
   }
 
   @override
-  int get hashCode => hashValues(
+  int get hashCode => Object.hash(
         start.hashCode,
         end.hashCode,
       );

--- a/lib/web_ui/lib/text.dart
+++ b/lib/web_ui/lib/text.dart
@@ -200,7 +200,7 @@ class FontVariation {
   }
 
   @override
-  int get hashCode => hashValues(axis, value);
+  int get hashCode => Object.hash(axis, value);
 
   @override
   String toString() => "FontVariation('$axis', $value)";

--- a/lib/web_ui/lib/window.dart
+++ b/lib/web_ui/lib/window.dart
@@ -255,7 +255,7 @@ class GestureSettings {
   }
 
   @override
-  int get hashCode => hashValues(physicalTouchSlop, physicalDoubleTapSlop);
+  int get hashCode => Object.hash(physicalTouchSlop, physicalDoubleTapSlop);
 
   @override
   String toString() => 'GestureSettings(physicalTouchSlop: $physicalTouchSlop, physicalDoubleTapSlop: $physicalDoubleTapSlop)';

--- a/lib/web_ui/test/engine/profiler_test.dart
+++ b/lib/web_ui/test/engine/profiler_test.dart
@@ -9,7 +9,6 @@ import 'dart:js_util' as js_util;
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
-import 'package:ui/ui.dart';
 
 import '../spy.dart';
 
@@ -138,7 +137,7 @@ class BenchmarkDatapoint {
   final num value;
 
   @override
-  int get hashCode => hashValues(name, value);
+  int get hashCode => Object.hash(name, value);
 
   @override
   bool operator ==(Object other) {

--- a/lib/web_ui/test/hash_codes_test.dart
+++ b/lib/web_ui/test/hash_codes_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// ignore_for_file: deprecated_member_use_from_same_package
+
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/ui.dart';

--- a/lib/web_ui/test/text/line_breaker_test.dart
+++ b/lib/web_ui/test/text/line_breaker_test.dart
@@ -6,7 +6,6 @@ import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 
 import 'package:ui/src/engine.dart';
-import 'package:ui/ui.dart';
 
 import 'line_breaker_test_helper.dart';
 import 'line_breaker_test_raw_data.dart';
@@ -310,7 +309,7 @@ class Line {
   final LineBreakType breakType;
 
   @override
-  int get hashCode => hashValues(text, breakType);
+  int get hashCode => Object.hash(text, breakType);
 
   @override
   bool operator ==(Object other) {


### PR DESCRIPTION
Deprecates `hashValues` and `hashList` in favour of `Object.hash` and `Object.hashAll` respectively.

Fixes flutter/flutter#85431

Supposed to land after below listed PRs
- [x] https://github.com/flutter/flutter/pull/96109
- [x] https://github.com/flutter/flutter/pull/99505
- [x] https://github.com/flutter/plugins/pull/4994
- [x] https://github.com/flutter/packages/pull/1581
- [x] https://github.com/flutter/samples/pull/1133

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
