### PR TITLE
[fuchsia] Fix failing SDK roll, take 2.

### DIFF
--- a/shell/platform/fuchsia/flutter/software_surface.cc
+++ b/shell/platform/fuchsia/flutter/software_surface.cc
@@ -8,6 +8,7 @@
 #include <lib/ui/scenic/cpp/commands.h>
 #include <zircon/status.h>
 #include <zircon/types.h>
+#include <zx/cpp/fidl.h>
 
 #include <cmath>
 


### PR DESCRIPTION
The SDK roll was initially failing because zx_rights_t was added to the SDK and it conflicts with `zx::rights`. I removed the import for `zx::rights` in #30600 not realizing that it was used. I'm not sure why CQ didn't fail.

I don't see that `zx_rights_t` issue occurring anymore in some of the later SDK rolls so it might have been a temporary issue in the SDK that was fixed. Going to add back in this include and see what happens in the next SDK roll.