### PR TITLE
[web] roll CanvasKit 0.32.0; fix frame order in animated images

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ vars = {
 
   # WARNING: DO NOT EDIT canvaskit_cipd_instance MANUALLY
   # See `lib/web_ui/README.md` for how to roll CanvasKit to a new version.
-  'canvaskit_cipd_instance': 'NcwvqeeKK7urddCbEdDvHytdaCiCA_8-4oS_T_ouGfgC',
+  'canvaskit_cipd_instance': 'CQJGaIvKwSuYCIi4hxn3jdY-Pcrdkcnnu65ZVt18oW8C',
 
   # When updating the Dart revision, ensure that all entries that are
   # dependencies of Dart are also updated to match the entries in the

--- a/lib/web_ui/dev/canvaskit_lock.yaml
+++ b/lib/web_ui/dev/canvaskit_lock.yaml
@@ -1,4 +1,4 @@
 # Specifies the version of CanvasKit to use for Flutter Web apps.
 #
 # See `lib/web_ui/README.md` for how to update this file.
-canvaskit_version: "0.31.0"
+canvaskit_version: "0.32.0"

--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -758,9 +758,14 @@ class SkColorType {
 class SkAnimatedImage {
   external int getFrameCount();
 
-  /// Returns duration in milliseconds.
   external int getRepetitionCount();
+
+  /// Returns duration in milliseconds.
+  external int currentFrameDuration();
+
+  /// Advances to the next frame and returns its duration in milliseconds.
   external int decodeNextFrame();
+
   external SkImage makeImageAtCurrentFrame();
   external int width();
   external int height();

--- a/lib/web_ui/lib/src/engine/configuration.dart
+++ b/lib/web_ui/lib/src/engine/configuration.dart
@@ -32,7 +32,7 @@ import 'package:js/js.dart';
 /// The version of CanvasKit used by the web engine by default.
 // DO NOT EDIT THE NEXT LINE OF CODE MANUALLY
 // See `lib/web_ui/README.md` for how to roll CanvasKit to a new version.
-const String _canvaskitVersion = '0.31.0';
+const String _canvaskitVersion = '0.32.0';
 
 /// The Web Engine configuration for the current application.
 FlutterConfiguration get configuration => _configuration ??= FlutterConfiguration(_jsConfiguration);

--- a/lib/web_ui/test/canvaskit/image_golden_test.dart
+++ b/lib/web_ui/test/canvaskit/image_golden_test.dart
@@ -94,9 +94,9 @@ void _testForImageCodecs({required bool useBrowserImageDecoder}) {
       expect(image.repetitionCount, -1);
 
       final ui.FrameInfo frame1 = await image.getNextFrame();
-      await expectFrameData(frame1, <int>[0, 255, 0, 255]);
+      await expectFrameData(frame1, <int>[255, 0, 0, 255]);
       final ui.FrameInfo frame2 = await image.getNextFrame();
-      await expectFrameData(frame2, <int>[0, 0, 255, 255]);
+      await expectFrameData(frame2, <int>[0, 255, 0, 255]);
 
       // Pretend that the image is temporarily deleted.
       image.delete();
@@ -104,7 +104,7 @@ void _testForImageCodecs({required bool useBrowserImageDecoder}) {
 
       // Check that we got the 3rd frame after resurrection.
       final ui.FrameInfo frame3 = await image.getNextFrame();
-      await expectFrameData(frame3, <int>[255, 0, 0, 255]);
+      await expectFrameData(frame3, <int>[0, 0, 255, 255]);
 
       testCollector.collectNow();
     });
@@ -548,11 +548,10 @@ void _testCkAnimatedImage() {
 
   test('CkAnimatedImage toByteData(RGBA)', () async {
     final CkAnimatedImage image = CkAnimatedImage.decodeFromBytes(kAnimatedGif, 'test');
-    // TODO(yjbanov): frame sequence is wrong (https://github.com/flutter/flutter/issues/95281)
     const List<List<int>> expectedColors = <List<int>>[
+      <int>[255, 0, 0, 255],
       <int>[0, 255, 0, 255],
       <int>[0, 0, 255, 255],
-      <int>[255, 0, 0, 255],
     ];
     for (int i = 0; i < image.frameCount; i++) {
       final ui.FrameInfo frame = await image.getNextFrame();


### PR DESCRIPTION
- Roll CanvasKit to 0.32.0
- Fix frame order in animated images

Fixes https://github.com/flutter/flutter/issues/94318
Fixes https://github.com/flutter/flutter/issues/95281