### PR TITLE
[web] flip browser image codec flag to opt-out

### DIFF
--- a/lib/web_ui/dev/steps/compile_tests_step.dart
+++ b/lib/web_ui/dev/steps/compile_tests_step.dart
@@ -258,14 +258,6 @@ Future<bool> compileUnitTest(FilePath input, { required bool forCanvasKit }) asy
     '-DFLUTTER_WEB_AUTO_DETECT=false',
     '-DFLUTTER_WEB_USE_SKIA=$forCanvasKit',
 
-    // Enable the image decoder experiment in tests so we can test the new
-    // functionality. WASM decoders are still tested by forcing the value of
-    // `browserSupportsImageDecoder` to false in the test. See also:
-    //
-    // lib/web_ui/test/canvaskit/image_golden_test.dart
-    // TODO(yjbanov): https://github.com/flutter/flutter/issues/95277
-    '-DEXPERIMENTAL_IMAGE_DECODER=true',
-
     '-O2',
     '-o',
     targetFileName, // target path.

--- a/lib/web_ui/lib/src/engine/safe_browser_api.dart
+++ b/lib/web_ui/lib/src/engine/safe_browser_api.dart
@@ -219,16 +219,22 @@ html.CanvasElement? tryCreateCanvasElement(int width, int height) {
 @JS('window.ImageDecoder')
 external Object? get _imageDecoderConstructor;
 
-/// Hides `image_web_codecs.dart` behind a flag.
-// TODO(yjbanov): https://github.com/flutter/flutter/issues/95277
-const bool _imageDecoderExperimentEnabled = bool.fromEnvironment(
-  'EXPERIMENTAL_IMAGE_DECODER',
-  defaultValue: false,
+/// Environment variable that allows the developer to opt out of using browser's
+/// `ImageDecoder` API, and use the WASM codecs bundled with CanvasKit.
+///
+/// While all reported severe issues with `ImageDecoder` have been fixed, this
+/// API remains relatively new. This option will allow developers to opt out of
+/// it, if they hit a severe bug that we did not anticipate.
+// TODO(yjbanov): remove this flag once we're fully confident in the new API.
+//                https://github.com/flutter/flutter/issues/95277
+const bool _browserImageDecodingEnabled = bool.fromEnvironment(
+  'BROWSER_IMAGE_DECODING_ENABLED',
+  defaultValue: true,
 );
 
 /// Whether the current browser supports `ImageDecoder`.
 bool browserSupportsImageDecoder =
-  _imageDecoderExperimentEnabled &&
+  _browserImageDecodingEnabled &&
   _imageDecoderConstructor != null &&
   browserEngine == BrowserEngine.blink;
 


### PR DESCRIPTION
Make the flag controlling our usage of the `ImageDecoder` API an opt-out rather than opt-in. The rationale is that all known serious issues have been fixed, namely:

- https://github.com/flutter/flutter/issues/94318
- https://github.com/flutter/flutter/issues/94500
- Missing `toByteData` implementation (https://github.com/flutter/engine/pull/30224)

One remaining known issue is memory efficiency, but that's less severe, so the performance benefits outweigh the cost in common situations (https://github.com/flutter/flutter/issues/96145). This opt-out should cover the remaining cases.