### PR TITLE
Revert "Only provide frame damage to rasterizer if partial repaint is enabled (#30461)"

### DIFF
--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -560,25 +560,22 @@ RasterStatus Rasterizer::DrawToSurfaceUnsafe(
         external_view_embedder_ &&
         (!raster_thread_merger_ || raster_thread_merger_->IsMerged());
 
-    std::unique_ptr<FrameDamage> damage;
+    FrameDamage damage;
     if (!disable_partial_repaint && frame->framebuffer_info().existing_damage) {
-      damage = std::make_unique<FrameDamage>();
-      damage->SetPreviousLayerTree(last_layer_tree_.get());
-      damage->AddAdditonalDamage(*frame->framebuffer_info().existing_damage);
+      damage.SetPreviousLayerTree(last_layer_tree_.get());
+      damage.AddAdditonalDamage(*frame->framebuffer_info().existing_damage);
     }
 
     RasterStatus raster_status =
-        compositor_frame->Raster(layer_tree, false, damage.get());
+        compositor_frame->Raster(layer_tree, false, &damage);
     if (raster_status == RasterStatus::kFailed ||
         raster_status == RasterStatus::kSkipAndRetry) {
       return raster_status;
     }
 
     SurfaceFrame::SubmitInfo submit_info;
-    if (damage) {
-      submit_info.frame_damage = damage->GetFrameDamage();
-      submit_info.buffer_damage = damage->GetBufferDamage();
-    }
+    submit_info.frame_damage = damage.GetFrameDamage();
+    submit_info.buffer_damage = damage.GetBufferDamage();
 
     frame->set_submit_info(submit_info);
 


### PR DESCRIPTION
This reverts commit a6a856f3487731241846b5c3bebbe46c8320e0ae.

See: https://github.com/flutter/flutter/issues/96188