### PR TITLE
Fix missing shcore.dll error on Windows 7

### DIFF
--- a/third_party/accessibility/ax/BUILD.gn
+++ b/third_party/accessibility/ax/BUILD.gn
@@ -99,7 +99,6 @@ source_set("ax") {
     ]
     libs = [
       "oleacc.lib",
-      "shcore.lib",
       "uiautomationcore.lib",
     ]
   }

--- a/third_party/accessibility/base/win/display.cc
+++ b/third_party/accessibility/base/win/display.cc
@@ -7,11 +7,75 @@
 namespace base {
 namespace win {
 
+namespace {
+
+template <typename T>
+bool AssignProcAddress(HMODULE comBaseModule, const char* name, T*& outProc) {
+  outProc = reinterpret_cast<T*>(GetProcAddress(comBaseModule, name));
+  return *outProc != nullptr;
+}
+
+// Helper class for supporting display scale factor lookup across Windows
+// versions, with fallbacks where these lookups are unavailable.
+class ScaleHelperWin32 {
+ public:
+  ScaleHelperWin32();
+  ~ScaleHelperWin32();
+
+  /// Returns the scale factor for the specified monitor. Sets |scale| to
+  /// SCALE_100_PERCENT if the API is not available.
+  HRESULT GetScaleFactorForMonitor(HMONITOR hmonitor,
+                                   DEVICE_SCALE_FACTOR* scale) const;
+
+ private:
+  using GetScaleFactorForMonitor_ =
+      HRESULT __stdcall(HMONITOR hmonitor, DEVICE_SCALE_FACTOR* scale);
+
+  GetScaleFactorForMonitor_* get_scale_factor_for_monitor_ = nullptr;
+
+  HMODULE shlib_module_ = nullptr;
+  bool scale_factor_for_monitor_supported_ = false;
+};
+
+ScaleHelperWin32::ScaleHelperWin32() {
+  if ((shlib_module_ = LoadLibraryA("Shcore.dll")) != nullptr) {
+    scale_factor_for_monitor_supported_ =
+        AssignProcAddress(shlib_module_, "GetScaleFactorForMonitor",
+                          get_scale_factor_for_monitor_);
+  }
+}
+
+ScaleHelperWin32::~ScaleHelperWin32() {
+  if (shlib_module_ != nullptr) {
+    FreeLibrary(shlib_module_);
+  }
+}
+
+HRESULT ScaleHelperWin32::GetScaleFactorForMonitor(
+    HMONITOR hmonitor,
+    DEVICE_SCALE_FACTOR* scale) const {
+  if (hmonitor == nullptr || scale == nullptr) {
+    return E_INVALIDARG;
+  }
+  if (!scale_factor_for_monitor_supported_) {
+    *scale = SCALE_100_PERCENT;
+    return S_OK;
+  }
+  return get_scale_factor_for_monitor_(hmonitor, scale);
+}
+
+ScaleHelperWin32* GetHelper() {
+  static ScaleHelperWin32* helper = new ScaleHelperWin32();
+  return helper;
+}
+
+}  // namespace
+
 float GetScaleFactorForHWND(HWND hwnd) {
   HMONITOR monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
-  DEVICE_SCALE_FACTOR scale_factor = DEVICE_SCALE_FACTOR_INVALID;
-  if (SUCCEEDED(GetScaleFactorForMonitor(monitor, &scale_factor))) {
-    return ScaleFactorToFloat(scale_factor);
+  DEVICE_SCALE_FACTOR scale = DEVICE_SCALE_FACTOR_INVALID;
+  if (SUCCEEDED(GetHelper()->GetScaleFactorForMonitor(monitor, &scale))) {
+    return ScaleFactorToFloat(scale);
   }
   return 1.0f;
 }


### PR DESCRIPTION
Since shcore.dll is not available on Windows 7, we can't directly link
against it. Instead, we perform a runtime lookup of the DLL and the
symbol we need and cache a pointer to it. On systems (such as Windows 7)
where the DLL is unavailable, we return a scale factor of 100%.

Expected behaviour is identical to before, except that since we no
longer directly link against shcore.dll, we no longer crash when running
on Windows 7. We do not currently have Windows 7 testing on the bots due
due to its status as [tested by the community](https://docs.flutter.dev/development/tools/sdk/release-notes/supported-platforms),
but if we do add Windows 7 bots, our launch test is sufficient to catch
this.

The issue this fixes was introduced in: https://github.com/flutter/engine/pull/30013

Issue: https://github.com/flutter/flutter/issues/95376

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
