### PR TITLE
Reland: Only provide frame damage to rasterizer if partial repaint is enabled

### DIFF
--- a/flow/surface_frame.h
+++ b/flow/surface_frame.h
@@ -28,6 +28,10 @@ class SurfaceFrame {
     // circumstances such as a BackdropFilter.
     bool supports_readback = false;
 
+    // Indicates that target device supports partial repaint. At very minimum
+    // this means that the surface will provide valid existing damage.
+    bool supports_partial_repaint = false;
+
     // This is the area of framebuffer that lags behind the front buffer.
     //
     // Correctly providing exiting_damage is necessary for supporting double and

--- a/shell/gpu/gpu_surface_metal.mm
+++ b/shell/gpu/gpu_surface_metal.mm
@@ -160,7 +160,7 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetal::AcquireFrameFromCAMetalLayer(
   if (i != damage_.end()) {
     framebuffer_info.existing_damage = i->second;
   }
-
+  framebuffer_info.supports_partial_repaint = true;
   return std::make_unique<SurfaceFrame>(std::move(surface), framebuffer_info, submit_callback);
 }
 


### PR DESCRIPTION
Fixes flutter/flutter#95681

The original PR had an issue where `FramebufferInfo::existing_damage != std::nullopt` was used to determine whether target supports partial repaint. This was wrong, because empty `existing_damage` is a valid state even if partial repaint is supported. It simply means that the target doesn't know anything about the state of the framebuffer and thus entire frame needs to be repainted. When partial repaint is supported, even with empty `existing_damage`, we still need to perform tree diffing, so that we have valid paint regions for layers in current frame (that will be used when diffing next frame).

Instead this PR introduces a specific flag to determine if target supports partial repaint (`supports_partial_repaint`). Setting this flag to `false` (default) will avoid executing any tree diffing code whatsoever.

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
