### PR TITLE
[web] check that picture is not disposed prior to drawing it

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/canvas.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvas.dart
@@ -218,6 +218,12 @@ class CkCanvas {
   }
 
   void drawPicture(CkPicture picture) {
+    assert(
+      !picture.debugIsDisposed,
+      'Unable to draw the specified picture because it has been disposed. '
+      'When the picture was disposed the stack trace was:\n'
+      '${picture.debugDisposalStackTrace}',
+    );
     skCanvas.drawPicture(picture.skiaObject);
   }
 

--- a/lib/web_ui/lib/src/engine/canvaskit/canvas.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvas.dart
@@ -218,12 +218,7 @@ class CkCanvas {
   }
 
   void drawPicture(CkPicture picture) {
-    assert(
-      !picture.debugIsDisposed,
-      'Unable to draw the specified picture because it has been disposed. '
-      'When the picture was disposed the stack trace was:\n'
-      '${picture.debugDisposalStackTrace}',
-    );
+    assert(picture.debugCheckNotDisposed('Failed to draw picture.'));
     skCanvas.drawPicture(picture.skiaObject);
   }
 

--- a/lib/web_ui/lib/src/engine/canvaskit/picture.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/picture.dart
@@ -47,12 +47,30 @@ class CkPicture extends ManagedSkiaObject<SkPicture> implements ui.Picture {
   ///
   /// Returns null if [dispose] has not been called. Returns null in non-debug
   /// modes.
-  StackTrace? get debugDisposalStackTrace => _debugDisposalStackTrace;
   StackTrace? _debugDisposalStackTrace;
+
+  /// Throws an [AssertionError] if this picture was disposed.
+  ///
+  /// The [mainErrorMessage] is used as the first line in the error message. It
+  /// is expected to end with a period, e.g. "Failed to draw picture." The full
+  /// message will also explain that the error is due to the fact that the
+  /// picture was disposed and include the stack trace taken when the picture
+  /// was disposed.
+  bool debugCheckNotDisposed(String mainErrorMessage) {
+    if (_isDisposed) {
+      throw AssertionError(
+        '$mainErrorMessage\n'
+        'The picture has been disposed. When the picture was disposed the '
+        'stack trace was:\n'
+        '$_debugDisposalStackTrace',
+      );
+    }
+    return true;
+  }
 
   @override
   void dispose() {
-    assert(!_isDisposed, 'Object has been disposed.');
+    assert(debugCheckNotDisposed('Cannot dispose picture.'));
     assert(() {
       _debugDisposalStackTrace = StackTrace.current;
       return true;
@@ -70,7 +88,7 @@ class CkPicture extends ManagedSkiaObject<SkPicture> implements ui.Picture {
 
   @override
   Future<ui.Image> toImage(int width, int height) async {
-    assert(!_isDisposed);
+    assert(debugCheckNotDisposed('Cannot convert picture to image.'));
     final SkSurface skSurface = canvasKit.MakeSurface(width, height);
     final SkCanvas skCanvas = skSurface.getCanvas();
     skCanvas.drawPicture(skiaObject);
@@ -93,7 +111,7 @@ class CkPicture extends ManagedSkiaObject<SkPicture> implements ui.Picture {
     // If a picture has been explicitly disposed of, it can no longer be
     // resurrected. An attempt to resurrect after the framework told the
     // engine to dispose of the picture likely indicates a bug in the engine.
-    assert(!_isDisposed);
+    assert(debugCheckNotDisposed('Cannot resurrect picture.'));
     return _snapshot!.toPicture();
   }
 

--- a/lib/web_ui/lib/src/engine/canvaskit/picture.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/picture.dart
@@ -43,9 +43,20 @@ class CkPicture extends ManagedSkiaObject<SkPicture> implements ui.Picture {
   /// similar flag [SkiaObjectBox.isDeletedPermanently].
   bool _isDisposed = false;
 
+  /// The stack trace taken when [dispose] was called.
+  ///
+  /// Returns null if [dispose] has not been called. Returns null in non-debug
+  /// modes.
+  StackTrace? get debugDisposalStackTrace => _debugDisposalStackTrace;
+  StackTrace? _debugDisposalStackTrace;
+
   @override
   void dispose() {
     assert(!_isDisposed, 'Object has been disposed.');
+    assert(() {
+      _debugDisposalStackTrace = StackTrace.current;
+      return true;
+    }());
     if (Instrumentation.enabled) {
       Instrumentation.instance.incrementCounter('Picture disposed');
     }

--- a/lib/web_ui/lib/src/engine/canvaskit/picture.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/picture.dart
@@ -58,7 +58,7 @@ class CkPicture extends ManagedSkiaObject<SkPicture> implements ui.Picture {
   /// was disposed.
   bool debugCheckNotDisposed(String mainErrorMessage) {
     if (_isDisposed) {
-      throw AssertionError(
+      throw StateError(
         '$mainErrorMessage\n'
         'The picture has been disposed. When the picture was disposed the '
         'stack trace was:\n'

--- a/lib/web_ui/test/canvaskit/picture_test.dart
+++ b/lib/web_ui/test/canvaskit/picture_test.dart
@@ -29,9 +29,11 @@ void testMain() {
         final CkPicture picture = recorder.endRecording() as CkPicture;
         expect(picture.rawSkiaObject, isNotNull);
         expect(picture.debugIsDisposed, isFalse);
+        expect(picture.debugDisposalStackTrace, isNull);
         picture.dispose();
         expect(picture.rawSkiaObject, isNull);
         expect(picture.debugIsDisposed, isTrue);
+        expect(picture.debugDisposalStackTrace, isNotNull);
 
         // Emulate SkiaObjectCache deleting the picture
         picture.delete();

--- a/lib/web_ui/test/canvaskit/picture_test.dart
+++ b/lib/web_ui/test/canvaskit/picture_test.dart
@@ -8,7 +8,6 @@ import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' as ui;
 
-import '../matchers.dart';
 import 'common.dart';
 
 void main() {
@@ -34,19 +33,19 @@ void testMain() {
         expect(picture.rawSkiaObject, isNull);
         expect(picture.debugIsDisposed, isTrue);
 
-        AssertionError? actualError;
+        StateError? actualError;
         try {
           picture.debugCheckNotDisposed('Test.');
-        } on AssertionError catch (error) {
+        } on StateError catch (error) {
           actualError = error;
         }
 
         expect(actualError, isNotNull);
         expect('$actualError', startsWith(
-          r'Assertion failed: "Test.\n'
+          'Bad state: Test.\n'
           'The picture has been disposed. '
-          r'When the picture was disposed the stack trace was:\n'
-          r'Error\n'
+          'When the picture was disposed the stack trace was:\n'
+          'Error\n'
           '    at Object.StackTrace_current'
         ));
 
@@ -56,9 +55,9 @@ void testMain() {
         expect(picture.rawSkiaObject, isNull);
 
         // A Picture that's been disposed of can no longer be resurrected
-        expect(() => picture.resurrect(), throwsAssertionError);
-        expect(() => picture.toImage(10, 10), throwsAssertionError);
-        expect(() => picture.dispose(), throwsAssertionError);
+        expect(() => picture.resurrect(), throwsStateError);
+        expect(() => picture.toImage(10, 10), throwsStateError);
+        expect(() => picture.dispose(), throwsStateError);
       });
 
       test('can be deleted by SkiaObjectCache', () {

--- a/lib/web_ui/test/canvaskit/picture_test.dart
+++ b/lib/web_ui/test/canvaskit/picture_test.dart
@@ -29,11 +29,26 @@ void testMain() {
         final CkPicture picture = recorder.endRecording() as CkPicture;
         expect(picture.rawSkiaObject, isNotNull);
         expect(picture.debugIsDisposed, isFalse);
-        expect(picture.debugDisposalStackTrace, isNull);
+        picture.debugCheckNotDisposed('Test.'); // must not throw
         picture.dispose();
         expect(picture.rawSkiaObject, isNull);
         expect(picture.debugIsDisposed, isTrue);
-        expect(picture.debugDisposalStackTrace, isNotNull);
+
+        AssertionError? actualError;
+        try {
+          picture.debugCheckNotDisposed('Test.');
+        } on AssertionError catch (error) {
+          actualError = error;
+        }
+
+        expect(actualError, isNotNull);
+        expect('$actualError', startsWith(
+          r'Assertion failed: "Test.\n'
+          'The picture has been disposed. '
+          r'When the picture was disposed the stack trace was:\n'
+          r'Error\n'
+          '    at Object.StackTrace_current'
+        ));
 
         // Emulate SkiaObjectCache deleting the picture
         picture.delete();

--- a/lib/web_ui/test/canvaskit/picture_test.dart
+++ b/lib/web_ui/test/canvaskit/picture_test.dart
@@ -41,12 +41,15 @@ void testMain() {
         }
 
         expect(actualError, isNotNull);
-        expect('$actualError', startsWith(
-          'Bad state: Test.\n'
-          'The picture has been disposed. '
-          'When the picture was disposed the stack trace was:\n'
-          'Error\n'
-          '    at Object.StackTrace_current'
+
+        // TODO(yjbanov): cannot test precise message due to https://github.com/flutter/flutter/issues/96298
+        expect('$actualError', allOf(
+          startsWith(
+            'Bad state: Test.\n'
+            'The picture has been disposed. '
+            'When the picture was disposed the stack trace was:\n'
+          ),
+          contains('StackTrace_current'),
         ));
 
         // Emulate SkiaObjectCache deleting the picture


### PR DESCRIPTION
Check that picture is not disposed prior to drawing it, and include the disposal stack trace in the error message. Otherwise, the engine fails farther down the stack with an obscure error message in the resurrection logic, which it should never reach.

Improves error messages for situations like https://github.com/flutter/flutter/issues/94906.
