### PR TITLE
Remove glitch when displaying platform views

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterSurfaceView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterSurfaceView.java
@@ -261,11 +261,7 @@ public class FlutterSurfaceView extends SurfaceView implements RenderSurface {
     // is paused, and rendering continues in a FlutterImageView buffer while the platform view
     // is displayed.
     //
-    // startRenderingToSurface may stop rendering to this surface if it believes it already started
-    // renderering to it.
-    //
-    // However, the flutter renderer isn't aware of this surface being paused.
-    // Therefore, the associated native resources should not be released.
+    // startRenderingToSurface stops rendering to an active surface if it isn't paused.
     flutterRenderer.startRenderingToSurface(getHolder().getSurface(), isPaused);
   }
 

--- a/shell/platform/android/io/flutter/embedding/android/FlutterTextureView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterTextureView.java
@@ -36,6 +36,7 @@ public class FlutterTextureView extends TextureView implements RenderSurface {
 
   private boolean isSurfaceAvailableForRendering = false;
   private boolean isAttachedToFlutterRenderer = false;
+  private boolean isPaused = false;
   @Nullable private FlutterRenderer flutterRenderer;
   @Nullable private Surface renderSurface;
 
@@ -187,6 +188,7 @@ public class FlutterTextureView extends TextureView implements RenderSurface {
   public void pause() {
     if (flutterRenderer != null) {
       flutterRenderer = null;
+      isPaused = true;
       isAttachedToFlutterRenderer = false;
     } else {
       Log.w(TAG, "pause() invoked when no FlutterRenderer was attached.");
@@ -217,7 +219,8 @@ public class FlutterTextureView extends TextureView implements RenderSurface {
     }
 
     renderSurface = new Surface(getSurfaceTexture());
-    flutterRenderer.startRenderingToSurface(renderSurface);
+    flutterRenderer.startRenderingToSurface(renderSurface, isPaused);
+    isPaused = false;
   }
 
   // FlutterRenderer must be non-null.

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
@@ -134,7 +134,7 @@ public class FlutterEngine {
    *
    * <p>A new {@code FlutterEngine} will not display any UI until a {@link RenderSurface} is
    * registered. See {@link #getRenderer()} and {@link
-   * FlutterRenderer#startRenderingToSurface(Surface)}.
+   * FlutterRenderer#startRenderingToSurface(Surface, boolean)}.
    *
    * <p>A new {@code FlutterEngine} automatically attaches all plugins. See {@link #getPlugins()}.
    *

--- a/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
@@ -225,7 +225,7 @@ public class FlutterRenderer implements TextureRegistry {
    * if the Engine expects to reuse this surface later. For example, this is true when platform
    * views are displayed in a frame, and then removed in the next frame.
    *
-   * <p>To avoid releasing of current surface resources, set {@code keepCurrentSurface} to true.
+   * <p>To avoid releasing the current surface resources, set {@code keepCurrentSurface} to true.
    *
    * <p>See {@link android.view.SurfaceHolder.Callback} and {@link
    * android.view.TextureView.SurfaceTextureListener}

--- a/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
@@ -221,11 +221,24 @@ public class FlutterRenderer implements TextureRegistry {
    * Notifies Flutter that the given {@code surface} was created and is available for Flutter
    * rendering.
    *
+   * <p>If called more than once, the current native resources are released. This can be undesired
+   * if the Engine expects to reuse this surface later. For example, this is true when platform
+   * views are displayed in a frame, and then removed in the next frame.
+   *
+   * <p>To avoid releasing of current surface resources, set {@code keepCurrentSurface} to true.
+   *
    * <p>See {@link android.view.SurfaceHolder.Callback} and {@link
    * android.view.TextureView.SurfaceTextureListener}
+   *
+   * @param surface The render surface.
+   * @param keepCurrentSurface True if the current active surface should not be released.
    */
-  public void startRenderingToSurface(@NonNull Surface surface) {
-    if (this.surface != null) {
+  public void startRenderingToSurface(@NonNull Surface surface, boolean keepCurrentSurface) {
+    // Don't stop rendering the surface if it's currently paused.
+    // Stop rendering to the surface releases the associated native resources, which
+    // causes a glitch when showing platform views.
+    // For more, https://github.com/flutter/flutter/issues/95343
+    if (this.surface != null && !keepCurrentSurface) {
       stopRenderingToSurface();
     }
 
@@ -248,8 +261,8 @@ public class FlutterRenderer implements TextureRegistry {
 
   /**
    * Notifies Flutter that a {@code surface} previously registered with {@link
-   * #startRenderingToSurface(Surface)} has changed size to the given {@code width} and {@code
-   * height}.
+   * #startRenderingToSurface(Surface, boolean)} has changed size to the given {@code width} and
+   * {@code height}.
    *
    * <p>See {@link android.view.SurfaceHolder.Callback} and {@link
    * android.view.TextureView.SurfaceTextureListener}
@@ -260,8 +273,8 @@ public class FlutterRenderer implements TextureRegistry {
 
   /**
    * Notifies Flutter that a {@code surface} previously registered with {@link
-   * #startRenderingToSurface(Surface)} has been destroyed and needs to be released and cleaned up
-   * on the Flutter side.
+   * #startRenderingToSurface(Surface, boolean)} has been destroyed and needs to be released and
+   * cleaned up on the Flutter side.
    *
    * <p>See {@link android.view.SurfaceHolder.Callback} and {@link
    * android.view.TextureView.SurfaceTextureListener}

--- a/shell/platform/android/io/flutter/embedding/engine/renderer/RenderSurface.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/RenderSurface.java
@@ -37,7 +37,7 @@ public interface RenderSurface {
    * FlutterRenderer} at the appropriate times:
    *
    * <ol>
-   *   <li>{@link FlutterRenderer#startRenderingToSurface(Surface)}
+   *   <li>{@link FlutterRenderer#startRenderingToSurface(Surface, boolean)}
    *   <li>{@link FlutterRenderer#surfaceChanged(int, int)}}
    *   <li>{@link FlutterRenderer#stopRenderingToSurface()}
    * </ol>

--- a/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
@@ -112,7 +112,7 @@ public class FlutterRendererTest {
   }
 
   @Test
-  public void iStopsRenderingToSurfaceWhenPossible() {
+  public void iStopsRenderingToSurfaceWhenSurfaceAlreadySet() {
     // Setup the test.
     FlutterRenderer flutterRenderer = new FlutterRenderer(fakeFlutterJNI);
 

--- a/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.anyFloat;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -45,7 +46,7 @@ public class FlutterRendererTest {
     FlutterRenderer flutterRenderer = new FlutterRenderer(fakeFlutterJNI);
 
     // Execute the behavior under test.
-    flutterRenderer.startRenderingToSurface(fakeSurface);
+    flutterRenderer.startRenderingToSurface(fakeSurface, /*keepCurrentSurface=*/ false);
 
     // Verify the behavior under test.
     verify(fakeFlutterJNI, times(1)).onSurfaceCreated(eq(fakeSurface));
@@ -57,7 +58,7 @@ public class FlutterRendererTest {
     Surface fakeSurface = mock(Surface.class);
     FlutterRenderer flutterRenderer = new FlutterRenderer(fakeFlutterJNI);
 
-    flutterRenderer.startRenderingToSurface(fakeSurface);
+    flutterRenderer.startRenderingToSurface(fakeSurface, /*keepCurrentSurface=*/ false);
 
     // Execute the behavior under test.
     flutterRenderer.surfaceChanged(100, 50);
@@ -72,7 +73,7 @@ public class FlutterRendererTest {
     Surface fakeSurface = mock(Surface.class);
     FlutterRenderer flutterRenderer = new FlutterRenderer(fakeFlutterJNI);
 
-    flutterRenderer.startRenderingToSurface(fakeSurface);
+    flutterRenderer.startRenderingToSurface(fakeSurface, /*keepCurrentSurface=*/ false);
 
     // Execute the behavior under test.
     flutterRenderer.stopRenderingToSurface();
@@ -87,10 +88,10 @@ public class FlutterRendererTest {
     Surface fakeSurface2 = mock(Surface.class);
     FlutterRenderer flutterRenderer = new FlutterRenderer(fakeFlutterJNI);
 
-    flutterRenderer.startRenderingToSurface(fakeSurface);
+    flutterRenderer.startRenderingToSurface(fakeSurface, /*keepCurrentSurface=*/ false);
 
     // Execute behavior under test.
-    flutterRenderer.startRenderingToSurface(fakeSurface2);
+    flutterRenderer.startRenderingToSurface(fakeSurface2, /*keepCurrentSurface=*/ false);
 
     // Verify behavior under test.
     verify(fakeFlutterJNI, times(1)).onSurfaceDestroyed(); // notification of 1st surface's removal.
@@ -101,13 +102,39 @@ public class FlutterRendererTest {
     // Setup the test.
     FlutterRenderer flutterRenderer = new FlutterRenderer(fakeFlutterJNI);
 
-    flutterRenderer.startRenderingToSurface(fakeSurface);
+    flutterRenderer.startRenderingToSurface(fakeSurface, /*keepCurrentSurface=*/ false);
 
     // Execute the behavior under test.
     flutterRenderer.stopRenderingToSurface();
 
     // Verify behavior under test.
     verify(fakeFlutterJNI, times(1)).onSurfaceDestroyed();
+  }
+
+  @Test
+  public void iStopsRenderingToSurfaceWhenPossible() {
+    // Setup the test.
+    FlutterRenderer flutterRenderer = new FlutterRenderer(fakeFlutterJNI);
+
+    flutterRenderer.startRenderingToSurface(fakeSurface, /*keepCurrentSurface=*/ false);
+
+    flutterRenderer.startRenderingToSurface(fakeSurface, /*keepCurrentSurface=*/ false);
+
+    // Verify behavior under test.
+    verify(fakeFlutterJNI, times(1)).onSurfaceDestroyed();
+  }
+
+  @Test
+  public void itNeverStopsRenderingToSurfaceWhenRequested() {
+    // Setup the test.
+    FlutterRenderer flutterRenderer = new FlutterRenderer(fakeFlutterJNI);
+
+    flutterRenderer.startRenderingToSurface(fakeSurface, /*keepCurrentSurface=*/ false);
+
+    flutterRenderer.startRenderingToSurface(fakeSurface, /*keepCurrentSurface=*/ true);
+
+    // Verify behavior under test.
+    verify(fakeFlutterJNI, never()).onSurfaceDestroyed();
   }
 
   @Test
@@ -120,7 +147,7 @@ public class FlutterRendererTest {
     FlutterRenderer.SurfaceTextureRegistryEntry entry =
         (FlutterRenderer.SurfaceTextureRegistryEntry) flutterRenderer.createSurfaceTexture();
 
-    flutterRenderer.startRenderingToSurface(fakeSurface);
+    flutterRenderer.startRenderingToSurface(fakeSurface, /*keepCurrentSurface=*/ false);
 
     // Execute the behavior under test.
     flutterRenderer.stopRenderingToSurface();
@@ -143,7 +170,7 @@ public class FlutterRendererTest {
         (FlutterRenderer.SurfaceTextureRegistryEntry)
             flutterRenderer.registerSurfaceTexture(surfaceTexture);
 
-    flutterRenderer.startRenderingToSurface(fakeSurface);
+    flutterRenderer.startRenderingToSurface(fakeSurface, /*keepCurrentSurface=*/ false);
 
     // Verify behavior under test.
     assertEquals(surfaceTexture, entry.surfaceTexture());
@@ -164,7 +191,7 @@ public class FlutterRendererTest {
         (FlutterRenderer.SurfaceTextureRegistryEntry) flutterRenderer.createSurfaceTexture();
     long id = entry.id();
 
-    flutterRenderer.startRenderingToSurface(fakeSurface);
+    flutterRenderer.startRenderingToSurface(fakeSurface, /*keepCurrentSurface=*/ false);
 
     // Execute the behavior under test.
     runFinalization(entry);
@@ -190,7 +217,7 @@ public class FlutterRendererTest {
         (FlutterRenderer.SurfaceTextureRegistryEntry) flutterRenderer.createSurfaceTexture();
     long id = entry.id();
 
-    flutterRenderer.startRenderingToSurface(fakeSurface);
+    flutterRenderer.startRenderingToSurface(fakeSurface, /*keepCurrentSurface=*/ false);
 
     flutterRenderer.stopRenderingToSurface();
 

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
@@ -1,9 +1,11 @@
 package io.flutter.plugin.platform;
 
+import static android.os.Looper.getMainLooper;
 import static io.flutter.embedding.engine.systemchannels.PlatformViewsChannel.PlatformViewTouch;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+import static org.robolectric.Shadows.shadowOf;
 
 import android.content.Context;
 import android.content.res.AssetManager;
@@ -486,10 +488,7 @@ public class PlatformViewsControllerTest {
     platformViewsController.onBeginFrame();
     platformViewsController.onEndFrame();
 
-    verify(overlayImageView, never()).detachFromRenderer();
-
-    // Simulate first frame from the framework.
-    jni.onFirstFrame();
+    shadowOf(getMainLooper()).idle();
     verify(overlayImageView, times(1)).detachFromRenderer();
   }
 


### PR DESCRIPTION
When `startRenderingToSurface` is called, any current active surface is destroyed.

This is undesired when platform views are displayed because the Engine will continue
to render to this surface once the platform views aren't rendered in the frame.

If the active surface is destroyed, there's a "glitch" caused by the time it takes to create
the new surface.

This issue was introduced after https://github.com/flutter/engine/pull/28894

Fixes https://github.com/flutter/flutter/issues/95343
Fixes https://github.com/flutter/flutter/issues/96177