### PR TITLE
[android] Remove the FlutterView casting, add a @NonNull and fix code style

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -1193,7 +1193,7 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
     flutterEngine.getPlatformViewsController().detachFromView();
 
     // Disconnect the FlutterEngine's PlatformViewsController from the AccessibilityBridge.
-    flutterEngine.getPlatformViewsController().detachAccessibiltyBridge();
+    flutterEngine.getPlatformViewsController().detachAccessibilityBridge();
 
     // Disconnect and clean up the AccessibilityBridge.
     accessibilityBridge.release();

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformView.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformView.java
@@ -68,7 +68,7 @@ public interface PlatformView {
    */
   // Default interface methods are supported on all min SDK versions of Android.
   @SuppressLint("NewApi")
-  default void onInputConnectionLocked() {};
+  default void onInputConnectionLocked() {}
 
   /**
    * Callback fired when the platform input connection has been unlocked. See also {@link
@@ -79,5 +79,5 @@ public interface PlatformView {
    */
   // Default interface methods are supported on all min SDK versions of Android.
   @SuppressLint("NewApi")
-  default void onInputConnectionUnlocked() {};
+  default void onInputConnectionUnlocked() {}
 }

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsAccessibilityDelegate.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsAccessibilityDelegate.java
@@ -32,5 +32,5 @@ public interface PlatformViewsAccessibilityDelegate {
    * <p>Any accessibility events sent by platform views belonging to this delegate will be ignored
    * until a new accessibility bridge is attached.
    */
-  void detachAccessibiltyBridge();
+  void detachAccessibilityBridge();
 }

--- a/shell/platform/android/io/flutter/plugin/platform/SingleViewPresentation.java
+++ b/shell/platform/android/io/flutter/plugin/platform/SingleViewPresentation.java
@@ -4,7 +4,6 @@
 
 package io.flutter.plugin.platform;
 
-import static android.content.Context.INPUT_METHOD_SERVICE;
 import static android.content.Context.WINDOW_SERVICE;
 import static android.view.View.OnFocusChangeListener;
 
@@ -99,7 +98,7 @@ class SingleViewPresentation extends Presentation {
   // presentation.
   private FrameLayout container;
 
-  private PresentationState state;
+  private final PresentationState state;
 
   private boolean startFocused = false;
 

--- a/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java
@@ -64,7 +64,7 @@ class VirtualDisplayController {
   private final OnFocusChangeListener focusChangeListener;
   private VirtualDisplay virtualDisplay;
   @VisibleForTesting SingleViewPresentation presentation;
-  private Surface surface;
+  private final Surface surface;
 
   private VirtualDisplayController(
       Context context,

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -137,8 +137,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
   @NonNull private final AccessibilityViewEmbedder accessibilityViewEmbedder;
 
   // The delegate for interacting with embedded platform views. Used to embed accessibility data for
-  // an embedded
-  // view in the accessibility tree.
+  // an embedded view in the accessibility tree.
   @NonNull private final PlatformViewsAccessibilityDelegate platformViewsAccessibilityDelegate;
 
   // Android's {@link ContentResolver}, which is used to observe the global
@@ -386,11 +385,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
       @NonNull AccessibilityChannel accessibilityChannel,
       @NonNull AccessibilityManager accessibilityManager,
       @NonNull ContentResolver contentResolver,
-      // This should be @NonNull once the plumbing for
-      // io.flutter.embedding.engine.android.FlutterView is done.
-      // TODO(mattcarrol): Add the annotation once the plumbing is done.
-      // https://github.com/flutter/flutter/issues/29618
-      PlatformViewsAccessibilityDelegate platformViewsAccessibilityDelegate) {
+      @NonNull PlatformViewsAccessibilityDelegate platformViewsAccessibilityDelegate) {
     this(
         rootAccessibilityView,
         accessibilityChannel,
@@ -407,11 +402,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
       @NonNull AccessibilityManager accessibilityManager,
       @NonNull ContentResolver contentResolver,
       @NonNull AccessibilityViewEmbedder accessibilityViewEmbedder,
-      // This should be @NonNull once the plumbing for
-      // io.flutter.embedding.engine.android.FlutterView is done.
-      // TODO(mattcarrol): Add the annotation once the plumbing is done.
-      // https://github.com/flutter/flutter/issues/29618
-      PlatformViewsAccessibilityDelegate platformViewsAccessibilityDelegate) {
+      @NonNull PlatformViewsAccessibilityDelegate platformViewsAccessibilityDelegate) {
     this.rootAccessibilityView = rootAccessibilityView;
     this.accessibilityChannel = accessibilityChannel;
     this.accessibilityManager = accessibilityManager;
@@ -464,13 +455,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
       this.contentResolver.registerContentObserver(transitionUri, false, animationScaleObserver);
     }
 
-    // platformViewsAccessibilityDelegate should be @NonNull once the plumbing
-    // for io.flutter.embedding.engine.android.FlutterView is done.
-    // TODO(mattcarrol): Remove the null check once the plumbing is done.
-    // https://github.com/flutter/flutter/issues/29618
-    if (platformViewsAccessibilityDelegate != null) {
-      platformViewsAccessibilityDelegate.attachAccessibilityBridge(this);
-    }
+    platformViewsAccessibilityDelegate.attachAccessibilityBridge(this);
   }
 
   /**
@@ -482,13 +467,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
    */
   public void release() {
     isReleased = true;
-    // platformViewsAccessibilityDelegate should be @NonNull once the plumbing
-    // for io.flutter.embedding.engine.android.FlutterView is done.
-    // TODO(mattcarrol): Remove the null check once the plumbing is done.
-    // https://github.com/flutter/flutter/issues/29618
-    if (platformViewsAccessibilityDelegate != null) {
-      platformViewsAccessibilityDelegate.detachAccessibiltyBridge();
-    }
+    platformViewsAccessibilityDelegate.detachAccessibilityBridge();
     setOnAccessibilityChangeListener(null);
     accessibilityManager.removeAccessibilityStateChangeListener(accessibilityStateChangeListener);
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
@@ -59,7 +59,7 @@ public class PlatformViewsControllerTest {
   public void itNotifiesVirtualDisplayControllersOfViewAttachmentAndDetachment() {
     // Setup test structure.
     // Create a fake View that represents the View that renders a Flutter UI.
-    View fakeFlutterView = new View(RuntimeEnvironment.systemContext);
+    FlutterView fakeFlutterView = new FlutterView(RuntimeEnvironment.systemContext);
 
     // Create fake VirtualDisplayControllers. This requires internal knowledge of
     // PlatformViewsController. We know that all PlatformViewsController does is


### PR DESCRIPTION
1. Remove the `(FlutterView) flutterView` casts in `PlatformViewsController.java`:
* https://github.com/flutter/flutter/issues/96273
2. Add `@NonNull` for the `platformViewsAccessibilityDelegate` parameter and member (although issue closed, should remove the issue id in comments):
* https://github.com/flutter/flutter/issues/29618
3. Fix some typos and code styles




## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
