### PR TITLE
Fix Memory Leak in MakeSkSurfaceFromBackingStore

### DIFF
--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -566,7 +566,7 @@ static sk_sp<SkSurface> MakeSkSurfaceFromBackingStore(
       const_cast<void*>(software->allocation),  // pixels
       software->row_bytes,                      // row bytes
       release_proc,                             // release proc
-      captures.get()                        // release context
+      captures.get()                            // get context
   );
 
   if (!surface) {

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -558,6 +558,7 @@ static sk_sp<SkSurface> MakeSkSurfaceFromBackingStore(
     if (captures->destruction_callback) {
       captures->destruction_callback(captures->user_data);
     }
+    delete captures;
   };
 
   auto surface = SkSurface::MakeRasterDirectReleaseProc(
@@ -565,7 +566,7 @@ static sk_sp<SkSurface> MakeSkSurfaceFromBackingStore(
       const_cast<void*>(software->allocation),  // pixels
       software->row_bytes,                      // row bytes
       release_proc,                             // release proc
-      captures.release()                        // release context
+      captures.get()                        // release context
   );
 
   if (!surface) {
@@ -575,6 +576,9 @@ static sk_sp<SkSurface> MakeSkSurfaceFromBackingStore(
       software->destruction_callback(software->user_data);
     }
     return nullptr;
+  }
+  if (surface) {
+    captures.release(); // Skia has assumed ownership of the struct.
   }
   return surface;
 }

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -578,7 +578,7 @@ static sk_sp<SkSurface> MakeSkSurfaceFromBackingStore(
     return nullptr;
   }
   if (surface) {
-    captures.release(); // Skia has assumed ownership of the struct.
+    captures.release();  // Skia has assumed ownership of the struct.
   }
   return surface;
 }


### PR DESCRIPTION
Capture struct from release_proc callback and release if surface returns null inside shell/platform/embedder.cc. 

https://github.com/flutter/flutter/issues/94241

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
