### PR TITLE
Refactor type of deadline in the method NotifyIdle to fml::TimePoint

### DIFF
--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -205,7 +205,7 @@ bool RuntimeController::ReportTimings(std::vector<int64_t> timings) {
   return false;
 }
 
-bool RuntimeController::NotifyIdle(int64_t deadline) {
+bool RuntimeController::NotifyIdle(fml::TimePoint deadline) {
   std::shared_ptr<DartIsolate> root_isolate = root_isolate_.lock();
   if (!root_isolate) {
     return false;
@@ -213,12 +213,12 @@ bool RuntimeController::NotifyIdle(int64_t deadline) {
 
   tonic::DartState::Scope scope(root_isolate);
 
-  Dart_NotifyIdle(deadline);
+  Dart_NotifyIdle(deadline.ToEpochDelta().ToMicroseconds());
 
   // Idle notifications being in isolate scope are part of the contract.
   if (idle_notification_callback_) {
     TRACE_EVENT0("flutter", "EmbedderIdleNotification");
-    idle_notification_callback_(deadline);
+    idle_notification_callback_(deadline.ToEpochDelta().ToMicroseconds());
   }
   return true;
 }

--- a/runtime/runtime_controller.h
+++ b/runtime/runtime_controller.h
@@ -350,13 +350,12 @@ class RuntimeController : public PlatformConfigurationClient {
   /// @bug        The `deadline` argument must be converted to `std::chrono`
   ///             instead of a raw integer.
   ///
-  /// @param[in]  deadline  The deadline measures in microseconds against the
-  ///             system's monotonic time. The clock can be accessed via
-  ///             `Dart_TimelineGetMicros`.
+  /// @param[in]  deadline  The deadline is used by the VM to determine if the
+  ///             corresponding sweep can be performed within the deadline.
   ///
   /// @return     If the idle notification was forwarded to the running isolate.
   ///
-  virtual bool NotifyIdle(int64_t deadline);
+  virtual bool NotifyIdle(fml::TimePoint deadline);
 
   //----------------------------------------------------------------------------
   /// @brief      Returns if the root isolate is running. The isolate must be

--- a/shell/common/animator.cc
+++ b/shell/common/animator.cc
@@ -168,8 +168,9 @@ void Animator::BeginFrame(
           if (notify_idle_task_id == self->notify_idle_task_id_ &&
               !self->frame_scheduled_) {
             TRACE_EVENT0("flutter", "BeginFrame idle callback");
-            self->delegate_.OnAnimatorNotifyIdle(Dart_TimelineGetMicros() +
-                                                 100000);
+            self->delegate_.OnAnimatorNotifyIdle(
+                FxlToDartOrEarlier(fml::TimePoint::Now() +
+                                   fml::TimeDelta::FromMicroseconds(100000)));
           }
         },
         kNotifyIdleTaskWaitTime);
@@ -270,8 +271,7 @@ void Animator::AwaitVSync() {
         }
       });
   if (has_rendered_) {
-    delegate_.OnAnimatorNotifyIdle(
-        dart_frame_deadline_.ToEpochDelta().ToMicroseconds());
+    delegate_.OnAnimatorNotifyIdle(dart_frame_deadline_);
   }
 }
 

--- a/shell/common/animator.h
+++ b/shell/common/animator.h
@@ -34,7 +34,7 @@ class Animator final {
     virtual void OnAnimatorBeginFrame(fml::TimePoint frame_target_time,
                                       uint64_t frame_number) = 0;
 
-    virtual void OnAnimatorNotifyIdle(int64_t deadline) = 0;
+    virtual void OnAnimatorNotifyIdle(fml::TimePoint deadline) = 0;
 
     virtual void OnAnimatorDraw(
         std::shared_ptr<Pipeline<flutter::LayerTree>> pipeline,

--- a/shell/common/animator_unittests.cc
+++ b/shell/common/animator_unittests.cc
@@ -23,7 +23,7 @@ class FakeAnimatorDelegate : public Animator::Delegate {
   void OnAnimatorBeginFrame(fml::TimePoint frame_target_time,
                             uint64_t frame_number) override {}
 
-  void OnAnimatorNotifyIdle(int64_t deadline) override {
+  void OnAnimatorNotifyIdle(fml::TimePoint deadline) override {
     notify_idle_called_ = true;
   }
 

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -252,8 +252,9 @@ void Engine::ReportTimings(std::vector<int64_t> timings) {
   runtime_controller_->ReportTimings(std::move(timings));
 }
 
-void Engine::NotifyIdle(int64_t deadline) {
-  auto trace_event = std::to_string(deadline - Dart_TimelineGetMicros());
+void Engine::NotifyIdle(fml::TimePoint deadline) {
+  auto trace_event = std::to_string(deadline.ToEpochDelta().ToMicroseconds() -
+                                    Dart_TimelineGetMicros());
   TRACE_EVENT1("flutter", "Engine::NotifyIdle", "deadline_now_delta",
                trace_event.c_str());
   runtime_controller_->NotifyIdle(deadline);

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -539,15 +539,12 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
   ///             collection, just gives the Dart VM more hints about opportune
   ///             moments to perform collections.
   ///
-  //  TODO(chinmaygarde): This should just use fml::TimePoint instead of having
-  //  to remember that the unit is microseconds (which is no used anywhere else
-  //  in the engine).
   ///
-  /// @param[in]  deadline  The deadline as a timepoint in microseconds measured
-  ///                       against the system monotonic clock. Use
-  ///                       `Dart_TimelineGetMicros()`, for consistency.
+  /// @param[in]  deadline  The deadline is used by the VM to determine if the
+  ///                       corresponding sweep can be performed within the
+  ///                       deadline.
   ///
-  void NotifyIdle(int64_t deadline);
+  void NotifyIdle(fml::TimePoint deadline);
 
   //----------------------------------------------------------------------------
   /// @brief      Dart code cannot fully measure the time it takes for a

--- a/shell/common/engine_unittests.cc
+++ b/shell/common/engine_unittests.cc
@@ -71,7 +71,7 @@ class MockRuntimeController : public RuntimeController {
   MOCK_METHOD3(LoadDartDeferredLibraryError,
                void(intptr_t, const std::string, bool));
   MOCK_CONST_METHOD0(GetDartVM, DartVM*());
-  MOCK_METHOD1(NotifyIdle, bool(int64_t));
+  MOCK_METHOD1(NotifyIdle, bool(fml::TimePoint));
 };
 
 std::unique_ptr<PlatformMessage> MakePlatformMessage(

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -1084,7 +1084,7 @@ void Shell::OnAnimatorBeginFrame(fml::TimePoint frame_target_time,
 }
 
 // |Animator::Delegate|
-void Shell::OnAnimatorNotifyIdle(int64_t deadline) {
+void Shell::OnAnimatorNotifyIdle(fml::TimePoint deadline) {
   FML_DCHECK(is_setup_);
   FML_DCHECK(task_runners_.GetUITaskRunner()->RunsTasksOnCurrentThread());
 

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -571,7 +571,7 @@ class Shell final : public PlatformView::Delegate,
                             uint64_t frame_number) override;
 
   // |Animator::Delegate|
-  void OnAnimatorNotifyIdle(int64_t deadline) override;
+  void OnAnimatorNotifyIdle(fml::TimePoint deadline) override;
 
   // |Animator::Delegate|
   void OnAnimatorDraw(

--- a/shell/common/shell_test.cc
+++ b/shell/common/shell_test.cc
@@ -152,7 +152,7 @@ void ShellTest::SetViewportMetrics(Shell* shell, double width, double height) {
   latch.Wait();
 }
 
-void ShellTest::NotifyIdle(Shell* shell, int64_t deadline) {
+void ShellTest::NotifyIdle(Shell* shell, fml::TimePoint deadline) {
   fml::AutoResetWaitableEvent latch;
   shell->GetTaskRunners().GetUITaskRunner()->PostTask(
       [&latch, engine = shell->weak_engine_, deadline]() {

--- a/shell/common/shell_test.h
+++ b/shell/common/shell_test.h
@@ -73,7 +73,7 @@ class ShellTest : public FixtureTest {
       std::function<void(std::shared_ptr<ContainerLayer> root)>;
 
   static void SetViewportMetrics(Shell* shell, double width, double height);
-  static void NotifyIdle(Shell* shell, int64_t deadline);
+  static void NotifyIdle(Shell* shell, fml::TimePoint deadline);
 
   static void PumpOneFrame(Shell* shell,
                            double width = 1,


### PR DESCRIPTION
This should just use fml::TimePoint instead of having to remember that the unit is microseconds (which is no used anywhere else in the engine). 

Here is the origin comment:
https://github.com/flutter/engine/blob/ad9ed227e96ee0df0e4ff282e34cdbcf6dc60891/shell/common/engine.h#L542-L544


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

