### PR TITLE
[fuchsia] Switch from core-jit to core snapshots.

### DIFF
--- a/shell/platform/fuchsia/dart_runner/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/BUILD.gn
@@ -225,18 +225,8 @@ template("jit_runner_package") {
       },
       {
         path = rebase_path(
-                "$target_gen_dir/kernel/vm_instructions${product_suffix}.bin")
-        dest = "vm_snapshot_instructions.bin"
-      },
-      {
-        path = rebase_path(
                 "$target_gen_dir/kernel/isolate_data${product_suffix}.bin")
         dest = "isolate_core_snapshot_data.bin"
-      },
-      {
-        path = rebase_path(
-                "$target_gen_dir/kernel/isolate_instructions${product_suffix}.bin")
-        dest = "isolate_core_snapshot_instructions.bin"
       },
     ]
 

--- a/shell/platform/fuchsia/dart_runner/dart_component_controller.cc
+++ b/shell/platform/fuchsia/dart_runner/dart_component_controller.cc
@@ -205,14 +205,10 @@ bool DartComponentController::SetupFromKernel() {
           isolate_snapshot_data_)) {
     return false;
   }
-  if (!dart_utils::MappedResource::LoadFromNamespace(
-          nullptr, "/pkg/data/isolate_core_snapshot_instructions.bin",
-          isolate_snapshot_instructions_, true /* executable */)) {
-    return false;
-  }
 
+  // The core snapshot does not separate instructions from data.
   if (!CreateIsolate(isolate_snapshot_data_.address(),
-                     isolate_snapshot_instructions_.address())) {
+                     nullptr /* isolate_snapshot_instructions */)) {
     return false;
   }
 
@@ -276,16 +272,16 @@ bool DartComponentController::SetupFromAppSnapshot() {
       return false;
     }
   } else {
+    // TODO(fxb/91200): This code path was broken for over a year and is
+    // probably not used.
     if (!dart_utils::MappedResource::LoadFromNamespace(
             namespace_, data_path_ + "/isolate_snapshot_data.bin",
             isolate_snapshot_data_)) {
       return false;
     }
-    if (!dart_utils::MappedResource::LoadFromNamespace(
-            namespace_, data_path_ + "/isolate_snapshot_instructions.bin",
-            isolate_snapshot_instructions_, true /* executable */)) {
-      return false;
-    }
+    isolate_data = isolate_snapshot_data_.address();
+    // We don't separate instructions from data in 'core' snapshots.
+    isolate_instructions = nullptr;
   }
   return CreateIsolate(isolate_data, isolate_instructions);
 #endif  // defined(AOT_RUNTIME)

--- a/shell/platform/fuchsia/dart_runner/dart_component_controller_v2.cc
+++ b/shell/platform/fuchsia/dart_runner/dart_component_controller_v2.cc
@@ -213,6 +213,7 @@ bool DartComponentControllerV2::CreateAndBindNamespace() {
 
 bool DartComponentControllerV2::SetUpFromKernel() {
   dart_utils::MappedResource manifest;
+
   if (!dart_utils::MappedResource::LoadFromNamespace(
           namespace_, data_path_ + "/app.dilplist", manifest)) {
     return false;
@@ -223,14 +224,10 @@ bool DartComponentControllerV2::SetUpFromKernel() {
           isolate_snapshot_data_)) {
     return false;
   }
-  if (!dart_utils::MappedResource::LoadFromNamespace(
-          nullptr, "/pkg/data/isolate_core_snapshot_instructions.bin",
-          isolate_snapshot_instructions_, true /* executable */)) {
-    return false;
-  }
 
+  // The core snapshot does not separate instructions from data.
   if (!CreateIsolate(isolate_snapshot_data_.address(),
-                     isolate_snapshot_instructions_.address())) {
+                     nullptr /* isolate_snapshot_instructions */)) {
     return false;
   }
 
@@ -295,16 +292,16 @@ bool DartComponentControllerV2::SetUpFromAppSnapshot() {
       return false;
     }
   } else {
+    // TODO(fxb/91200): This code path was broken for over a year and is
+    // probably not used.
     if (!dart_utils::MappedResource::LoadFromNamespace(
             namespace_, data_path_ + "/isolate_snapshot_data.bin",
             isolate_snapshot_data_)) {
       return false;
     }
-    if (!dart_utils::MappedResource::LoadFromNamespace(
-            namespace_, data_path_ + "/isolate_snapshot_instructions.bin",
-            isolate_snapshot_instructions_, true /* executable */)) {
-      return false;
-    }
+    isolate_data = isolate_snapshot_data_.address();
+    // We don't separate instructions from data in 'core' snapshots.
+    isolate_instructions = nullptr;
   }
   return CreateIsolate(isolate_data, isolate_instructions);
 #endif  // defined(AOT_RUNTIME)

--- a/shell/platform/fuchsia/dart_runner/dart_runner.cc
+++ b/shell/platform/fuchsia/dart_runner/dart_runner.cc
@@ -200,13 +200,7 @@ DartRunner::DartRunner(sys::ComponentContext* context) : context_(context) {
           nullptr, "/pkg/data/vm_snapshot_data.bin", vm_snapshot_data_)) {
     FX_LOG(FATAL, LOG_TAG, "Failed to load vm snapshot data");
   }
-  if (!dart_utils::MappedResource::LoadFromNamespace(
-          nullptr, "/pkg/data/vm_snapshot_instructions.bin",
-          vm_snapshot_instructions_, true /* executable */)) {
-    FX_LOG(FATAL, LOG_TAG, "Failed to load vm snapshot instructions");
-  }
   params.vm_snapshot_data = vm_snapshot_data_.address();
-  params.vm_snapshot_instructions = vm_snapshot_instructions_.address();
 #endif
   params.create_group = IsolateGroupCreateCallback;
   params.shutdown_isolate = IsolateShutdownCallback;

--- a/shell/platform/fuchsia/dart_runner/kernel/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/kernel/BUILD.gn
@@ -40,17 +40,11 @@ template("create_kernel_core_snapshot") {
     inputs = [ platform_dill ]
 
     vm_snapshot_data = "$target_gen_dir/vm_data${product_suffix}.bin"
-    vm_snapshot_instructions =
-        "$target_gen_dir/vm_instructions${product_suffix}.bin"
     isolate_snapshot_data = "$target_gen_dir/isolate_data${product_suffix}.bin"
-    isolate_snapshot_instructions =
-        "$target_gen_dir/isolate_instructions${product_suffix}.bin"
     snapshot_profile = "$target_gen_dir/snapshot_profile${product_suffix}.json"
     outputs = [
       vm_snapshot_data,
-      vm_snapshot_instructions,
       isolate_snapshot_data,
-      isolate_snapshot_instructions,
       snapshot_profile,
     ]
 
@@ -65,14 +59,10 @@ template("create_kernel_core_snapshot") {
       "--lazy_async_stacks",
       "--enable_mirrors=false",
       "--deterministic",
-      "--snapshot_kind=core-jit",
+      "--snapshot_kind=core",
       "--vm_snapshot_data=" + rebase_path(vm_snapshot_data, root_build_dir),
-      "--vm_snapshot_instructions=" +
-          rebase_path(vm_snapshot_instructions, root_build_dir),
       "--isolate_snapshot_data=" +
           rebase_path(isolate_snapshot_data, root_build_dir),
-      "--isolate_snapshot_instructions=" +
-          rebase_path(isolate_snapshot_instructions, root_build_dir),
       "--write_v8_snapshot_profile_to=" +
           rebase_path(snapshot_profile, root_build_dir),
     ]

--- a/shell/platform/fuchsia/dart_runner/service_isolate.cc
+++ b/shell/platform/fuchsia/dart_runner/service_isolate.cc
@@ -95,12 +95,6 @@ Dart_Isolate CreateServiceIsolate(const char* uri,
         "/pkg/data/vmservice_isolate_snapshot_data.bin";
     const char* snapshot_instructions_path =
         "/pkg/data/vmservice_isolate_snapshot_instructions.bin";
-#else
-  // The VM service is embedded in the core snapshot.
-  const char* snapshot_data_path = "/pkg/data/isolate_core_snapshot_data.bin";
-  const char* snapshot_instructions_path =
-      "/pkg/data/isolate_core_snapshot_instructions.bin";
-#endif
 
     if (!dart_utils::MappedResource::LoadFromNamespace(
             nullptr, snapshot_data_path, mapped_isolate_snapshot_data)) {
@@ -118,8 +112,21 @@ Dart_Isolate CreateServiceIsolate(const char* uri,
 
     vmservice_data = mapped_isolate_snapshot_data.address();
     vmservice_instructions = mapped_isolate_snapshot_instructions.address();
-#if defined(AOT_RUNTIME)
   }
+#else
+  // The VM service is embedded in the core snapshot.
+  // 'core' snapshot_kinds do not separate instructions from data, so we don't
+  // load an instructions file.
+  const char* snapshot_data_path = "/pkg/data/isolate_core_snapshot_data.bin";
+  if (!dart_utils::MappedResource::LoadFromNamespace(
+          nullptr, snapshot_data_path, mapped_isolate_snapshot_data)) {
+    *error = strdup("Failed to load snapshot for service isolate");
+    FX_LOG(ERROR, LOG_TAG, *error);
+    return nullptr;
+  }
+
+  vmservice_data = mapped_isolate_snapshot_data.address();
+  vmservice_instructions = nullptr;
 #endif
 
   auto state = new std::shared_ptr<tonic::DartState>(new tonic::DartState());

--- a/shell/platform/fuchsia/flutter/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/BUILD.gn
@@ -348,18 +348,8 @@ template("jit_runner") {
       },
       {
         path = rebase_path(
-                "$snapshot_gen_dir/vm_snapshot_instructions${product_suffix}.bin")
-        dest = "vm_snapshot_instructions.bin"
-      },
-      {
-        path = rebase_path(
                 "$snapshot_gen_dir/isolate_snapshot${product_suffix}.bin")
         dest = "isolate_core_snapshot_data.bin"
-      },
-      {
-        path = rebase_path(
-                "$snapshot_gen_dir/isolate_snapshot_instructions${product_suffix}.bin")
-        dest = "isolate_core_snapshot_instructions.bin"
       },
     ]
 

--- a/shell/platform/fuchsia/flutter/component_v1.cc
+++ b/shell/platform/fuchsia/flutter/component_v1.cc
@@ -348,19 +348,13 @@ ComponentV1::ComponentV1(
       return MakeFileMapping("/pkg/data/vm_snapshot_data.bin",
                              false /* executable */);
     };
-    settings_.vm_snapshot_instr = []() {
-      return MakeFileMapping("/pkg/data/vm_snapshot_instructions.bin",
-                             true /* executable */);
-    };
-
     settings_.isolate_snapshot_data = []() {
       return MakeFileMapping("/pkg/data/isolate_core_snapshot_data.bin",
                              false /* executable */);
     };
-    settings_.isolate_snapshot_instr = [] {
-      return MakeFileMapping("/pkg/data/isolate_core_snapshot_instructions.bin",
-                             true /* executable */);
-    };
+
+    // 'core' snapshots do not separate instructions from data, so we
+    // don't set isolate_snapshot_instr here.
   }
 
 #if defined(DART_PRODUCT)

--- a/shell/platform/fuchsia/flutter/component_v2.cc
+++ b/shell/platform/fuchsia/flutter/component_v2.cc
@@ -390,19 +390,13 @@ ComponentV2::ComponentV2(
       return MakeFileMapping("/pkg/data/vm_snapshot_data.bin",
                              false /* executable */);
     };
-    settings_.vm_snapshot_instr = []() {
-      return MakeFileMapping("/pkg/data/vm_snapshot_instructions.bin",
-                             true /* executable */);
-    };
-
     settings_.isolate_snapshot_data = []() {
       return MakeFileMapping("/pkg/data/isolate_core_snapshot_data.bin",
                              false /* executable */);
     };
-    settings_.isolate_snapshot_instr = [] {
-      return MakeFileMapping("/pkg/data/isolate_core_snapshot_instructions.bin",
-                             true /* executable */);
-    };
+
+    // 'core' snapshots do not separate instructions from data, so we
+    // don't set isolate_snapshot_instr here.
   }
 
 #if defined(DART_PRODUCT)

--- a/shell/platform/fuchsia/flutter/kernel/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/kernel/BUILD.gn
@@ -44,17 +44,11 @@ template("core_snapshot") {
     inputs = [ platform_dill ]
 
     vm_snapshot_data = "$target_gen_dir/vm_isolate_snapshot${suffix}.bin"
-    vm_snapshot_instructions =
-        "$target_gen_dir/vm_snapshot_instructions${suffix}.bin"
     isolate_snapshot_data = "$target_gen_dir/isolate_snapshot${suffix}.bin"
-    isolate_snapshot_instructions =
-        "$target_gen_dir/isolate_snapshot_instructions${suffix}.bin"
     snapshot_profile = "$target_gen_dir/snapshot_profile${suffix}.json"
     outputs = [
       vm_snapshot_data,
-      vm_snapshot_instructions,
       isolate_snapshot_data,
-      isolate_snapshot_instructions,
       snapshot_profile,
     ]
 
@@ -69,14 +63,10 @@ template("core_snapshot") {
       "--lazy_async_stacks",
       "--enable_mirrors=false",
       "--deterministic",
-      "--snapshot_kind=core-jit",
+      "--snapshot_kind=core",
       "--vm_snapshot_data=" + rebase_path(vm_snapshot_data, root_build_dir),
-      "--vm_snapshot_instructions=" +
-          rebase_path(vm_snapshot_instructions, root_build_dir),
       "--isolate_snapshot_data=" +
           rebase_path(isolate_snapshot_data, root_build_dir),
-      "--isolate_snapshot_instructions=" +
-          rebase_path(isolate_snapshot_instructions, root_build_dir),
       "--write_v8_snapshot_profile_to=" +
           rebase_path(snapshot_profile, root_build_dir),
     ]


### PR DESCRIPTION
`core-jit` is deprecated and will be removed.

Core snapshots no longer separate instructions snapshots from data snapshots. We remove the instructions args from the core snapshots and remove logic that loads them.

Tested: Used JIT Dart and Flutter runners to run Workstation.