### PR TITLE
Allow additional expose_dirs in flutter_runner

### DIFF
--- a/shell/platform/fuchsia/flutter/program_metadata.h
+++ b/shell/platform/fuchsia/flutter/program_metadata.h
@@ -26,6 +26,9 @@ struct ProgramMetadata {
 
   /// The preferred heap size for the Flutter component in megabytes.
   std::optional<int64_t> old_gen_heap_size = std::nullopt;
+
+  /// A list of additional directories that we will expose in out/
+  std::vector<std::string> expose_dirs;
 };
 
 }  // namespace flutter_runner

--- a/tools/fuchsia/devshell/serve.sh
+++ b/tools/fuchsia/devshell/serve.sh
@@ -247,7 +247,7 @@ while true; do
     config_url="http://${addr}:${port}/config.json"
 
     if [[ ${component_framework_version} == 2 ]]; then
-      run_ssh_command pkgctl repo add \
+      run_ssh_command pkgctl repo add url \
         -n "engine" \
         "${config_url}"
     else


### PR DESCRIPTION
Users can add an expose_dirs entry to the program field in a
component's cml file to optionally expose extra directories
from their out/ directory.

BUG: fxbug.dev/89690
