### PR TITLE
Windows: Fix plugin destruction

### DIFF
--- a/shell/platform/windows/flutter_windows.cc
+++ b/shell/platform/windows/flutter_windows.cc
@@ -174,7 +174,7 @@ FlutterDesktopMessengerRef FlutterDesktopPluginRegistrarGetMessenger(
 void FlutterDesktopPluginRegistrarSetDestructionHandler(
     FlutterDesktopPluginRegistrarRef registrar,
     FlutterDesktopOnPluginRegistrarDestroyed callback) {
-  registrar->engine->SetPluginRegistrarDestructionCallback(callback);
+  registrar->engine->AddPluginRegistrarDestructionCallback(callback, registrar);
 }
 
 bool FlutterDesktopMessengerSendWithReply(FlutterDesktopMessengerRef messenger,

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -314,8 +314,9 @@ bool FlutterWindowsEngine::RunWithEntrypoint(const char* entrypoint) {
 
 bool FlutterWindowsEngine::Stop() {
   if (engine_) {
-    if (plugin_registrar_destruction_callback_) {
-      plugin_registrar_destruction_callback_(plugin_registrar_.get());
+    for (const auto& [callback, registrar] :
+         plugin_registrar_destruction_callbacks_) {
+      callback(registrar);
     }
     FlutterEngineResult result = embedder_api_.Shutdown(engine_);
     engine_ = nullptr;
@@ -333,9 +334,10 @@ FlutterDesktopPluginRegistrarRef FlutterWindowsEngine::GetRegistrar() {
   return plugin_registrar_.get();
 }
 
-void FlutterWindowsEngine::SetPluginRegistrarDestructionCallback(
-    FlutterDesktopOnPluginRegistrarDestroyed callback) {
-  plugin_registrar_destruction_callback_ = callback;
+void FlutterWindowsEngine::AddPluginRegistrarDestructionCallback(
+    FlutterDesktopOnPluginRegistrarDestroyed callback,
+    FlutterDesktopPluginRegistrarRef registrar) {
+  plugin_registrar_destruction_callbacks_[callback] = registrar;
 }
 
 void FlutterWindowsEngine::SendWindowMetricsEvent(

--- a/shell/platform/windows/flutter_windows_engine.h
+++ b/shell/platform/windows/flutter_windows_engine.h
@@ -71,9 +71,10 @@ class FlutterWindowsEngine {
   // Returns the currently configured Plugin Registrar.
   FlutterDesktopPluginRegistrarRef GetRegistrar();
 
-  // Sets |callback| to be called when the plugin registrar is destroyed.
-  void SetPluginRegistrarDestructionCallback(
-      FlutterDesktopOnPluginRegistrarDestroyed callback);
+  // Registers |callback| to be called when the plugin registrar is destroyed.
+  void AddPluginRegistrarDestructionCallback(
+      FlutterDesktopOnPluginRegistrarDestroyed callback,
+      FlutterDesktopPluginRegistrarRef registrar);
 
   // Sets switches member to the given switches.
   void SetSwitches(const std::vector<std::string>& switches);
@@ -215,10 +216,11 @@ class FlutterWindowsEngine {
   // The MethodChannel used for communication with the Flutter engine.
   std::unique_ptr<BasicMessageChannel<rapidjson::Document>> settings_channel_;
 
-  // A callback to be called when the engine (and thus the plugin registrar)
-  // is being destroyed.
-  FlutterDesktopOnPluginRegistrarDestroyed
-      plugin_registrar_destruction_callback_ = nullptr;
+  // Callbacks to be called when the engine (and thus the plugin registrar) is
+  // being destroyed.
+  std::map<FlutterDesktopOnPluginRegistrarDestroyed,
+           FlutterDesktopPluginRegistrarRef>
+      plugin_registrar_destruction_callbacks_;
 
   bool semantics_enabled_ = false;
 

--- a/shell/platform/windows/flutter_windows_engine_unittests.cc
+++ b/shell/platform/windows/flutter_windows_engine_unittests.cc
@@ -7,6 +7,7 @@
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/embedder/test_utils/proc_table_replacement.h"
 #include "flutter/shell/platform/windows/testing/engine_modifier.h"
+#include "flutter/shell/platform/windows/testing/test_keyboard.h"
 #include "gtest/gtest.h"
 
 namespace flutter {
@@ -253,6 +254,36 @@ TEST(FlutterWindowsEngine, DispatchSemanticsAction) {
   engine->DispatchSemanticsAction(42, kFlutterSemanticsActionDismiss,
                                   std::move(data));
   EXPECT_TRUE(called);
+}
+
+TEST(FlutterWindowsEngine, AddPluginRegistrarDestructionCallback) {
+  std::unique_ptr<FlutterWindowsEngine> engine = GetTestEngine();
+  EngineModifier modifier(engine.get());
+
+  MockEmbedderApiForKeyboard(modifier,
+                             std::make_shared<MockKeyResponseController>());
+
+  engine->RunWithEntrypoint(nullptr);
+
+  // Verify that destruction handlers don't overwrite each other.
+  int result1 = 0;
+  int result2 = 0;
+  engine->AddPluginRegistrarDestructionCallback(
+      [](FlutterDesktopPluginRegistrarRef ref) {
+        auto result = reinterpret_cast<int*>(ref);
+        *result = 1;
+      },
+      reinterpret_cast<FlutterDesktopPluginRegistrarRef>(&result1));
+  engine->AddPluginRegistrarDestructionCallback(
+      [](FlutterDesktopPluginRegistrarRef ref) {
+        auto result = reinterpret_cast<int*>(ref);
+        *result = 2;
+      },
+      reinterpret_cast<FlutterDesktopPluginRegistrarRef>(&result2));
+
+  engine->Stop();
+  EXPECT_EQ(result1, 1);
+  EXPECT_EQ(result2, 2);
 }
 
 }  // namespace testing


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/93234

This small fix prevents plugin registrar destruction callbacks from overwriting each other.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
