### PR TITLE
[fuchsia] Update Vulkan header version to 1.2.198.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -414,9 +414,9 @@ deps = {
    'src/third_party/vulkan':
    Var('github_git') + '/KhronosGroup/Vulkan-Docs.git' + '@' + 'v1.1.91',
 
-   # Downstream Fuchsia Vulkan Headers (v1.2.174)
+   # Downstream Fuchsia Vulkan Headers (v1.2.198)
   'src/third_party/fuchsia-vulkan':
-   Var('fuchsia_git') + '/third_party/Vulkan-Headers.git' + '@' + '0255987d2457576907f046c6d52b89bc6131981d',
+   Var('fuchsia_git') + '/third_party/Vulkan-Headers.git' + '@' + '32640ad82ef648768c706c9bf828b77123a09bc2',
 
    'src/third_party/swiftshader':
    Var('swiftshader_git') + '/SwiftShader.git' + '@' + 'd4130e9ac3675dadbec8442dc2310a80ea4ddfb2',

--- a/ci/licenses_golden/licenses_third_party
+++ b/ci/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: f651dff37e63f8affc1c1981a8032b95
+Signature: a6c296a1a341b4bf66c0f202a397610c
 
 UNUSED LICENSES:
 
@@ -1171,6 +1171,13 @@ FILE: ../../../third_party/boringssl/src/third_party/wycheproof_testvectors/xcha
 FILE: ../../../third_party/expat/expat/fuzz/xml_parse_fuzzer.c
 FILE: ../../../third_party/expat/expat/fuzz/xml_parsebuffer_fuzzer.c
 FILE: ../../../third_party/fuchsia-vulkan/cmake/cmake_uninstall.cmake.in
+FILE: ../../../third_party/fuchsia-vulkan/include/vk_video/vulkan_video_codec_h264std.h
+FILE: ../../../third_party/fuchsia-vulkan/include/vk_video/vulkan_video_codec_h264std_decode.h
+FILE: ../../../third_party/fuchsia-vulkan/include/vk_video/vulkan_video_codec_h264std_encode.h
+FILE: ../../../third_party/fuchsia-vulkan/include/vk_video/vulkan_video_codec_h265std.h
+FILE: ../../../third_party/fuchsia-vulkan/include/vk_video/vulkan_video_codec_h265std_decode.h
+FILE: ../../../third_party/fuchsia-vulkan/include/vk_video/vulkan_video_codec_h265std_encode.h
+FILE: ../../../third_party/fuchsia-vulkan/include/vk_video/vulkan_video_codecs_common.h
 FILE: ../../../third_party/fuchsia-vulkan/include/vulkan/vk_icd.h
 FILE: ../../../third_party/fuchsia-vulkan/include/vulkan/vk_layer.h
 FILE: ../../../third_party/fuchsia-vulkan/include/vulkan/vk_platform.h
@@ -1181,12 +1188,17 @@ FILE: ../../../third_party/fuchsia-vulkan/include/vulkan/vulkan_android.h
 FILE: ../../../third_party/fuchsia-vulkan/include/vulkan/vulkan_beta.h
 FILE: ../../../third_party/fuchsia-vulkan/include/vulkan/vulkan_core.h
 FILE: ../../../third_party/fuchsia-vulkan/include/vulkan/vulkan_directfb.h
+FILE: ../../../third_party/fuchsia-vulkan/include/vulkan/vulkan_enums.hpp
 FILE: ../../../third_party/fuchsia-vulkan/include/vulkan/vulkan_fuchsia.h
+FILE: ../../../third_party/fuchsia-vulkan/include/vulkan/vulkan_funcs.hpp
 FILE: ../../../third_party/fuchsia-vulkan/include/vulkan/vulkan_ggp.h
+FILE: ../../../third_party/fuchsia-vulkan/include/vulkan/vulkan_handles.hpp
 FILE: ../../../third_party/fuchsia-vulkan/include/vulkan/vulkan_ios.h
 FILE: ../../../third_party/fuchsia-vulkan/include/vulkan/vulkan_macos.h
 FILE: ../../../third_party/fuchsia-vulkan/include/vulkan/vulkan_metal.h
+FILE: ../../../third_party/fuchsia-vulkan/include/vulkan/vulkan_raii.hpp
 FILE: ../../../third_party/fuchsia-vulkan/include/vulkan/vulkan_screen.h
+FILE: ../../../third_party/fuchsia-vulkan/include/vulkan/vulkan_structs.hpp
 FILE: ../../../third_party/fuchsia-vulkan/include/vulkan/vulkan_vi.h
 FILE: ../../../third_party/fuchsia-vulkan/include/vulkan/vulkan_wayland.h
 FILE: ../../../third_party/fuchsia-vulkan/include/vulkan/vulkan_win32.h


### PR DESCRIPTION
This updates the downstream Vulkan header for Fuchsia
to 1.2.198 so that it could support the upstream
FUCHSIA buffer collection extension.

TEST: build and no-op on Fuchsia
Bug: flutter/flutter#96312
