### PR TITLE
Implemented library uri support for FlutterFragmentActivities

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
@@ -5,6 +5,7 @@
 package io.flutter.embedding.android;
 
 import static io.flutter.embedding.android.FlutterActivityLaunchConfigs.DART_ENTRYPOINT_META_DATA_KEY;
+import static io.flutter.embedding.android.FlutterActivityLaunchConfigs.DART_ENTRYPOINT_URI_META_DATA_KEY;
 import static io.flutter.embedding.android.FlutterActivityLaunchConfigs.DEFAULT_BACKGROUND_MODE;
 import static io.flutter.embedding.android.FlutterActivityLaunchConfigs.DEFAULT_DART_ENTRYPOINT;
 import static io.flutter.embedding.android.FlutterActivityLaunchConfigs.DEFAULT_INITIAL_ROUTE;
@@ -460,6 +461,9 @@ public class FlutterFragmentActivity extends FragmentActivity
               + "Dart entrypoint: "
               + getDartEntrypointFunctionName()
               + "\n"
+              + "Dart entrypoint library uri: "
+              + (getDartEntrypointLibraryUri() != null ? getDartEntrypointLibraryUri() : "\"\"")
+              + "\n"
               + "Initial route: "
               + getInitialRoute()
               + "\n"
@@ -471,6 +475,7 @@ public class FlutterFragmentActivity extends FragmentActivity
 
       return FlutterFragment.withNewEngine()
           .dartEntrypoint(getDartEntrypointFunctionName())
+          .dartLibraryUri(getDartEntrypointLibraryUri())
           .initialRoute(getInitialRoute())
           .appBundlePath(getAppBundlePath())
           .flutterShellArgs(FlutterShellArgs.fromIntent(getIntent()))
@@ -690,6 +695,32 @@ public class FlutterFragmentActivity extends FragmentActivity
       return desiredDartEntrypoint != null ? desiredDartEntrypoint : DEFAULT_DART_ENTRYPOINT;
     } catch (PackageManager.NameNotFoundException e) {
       return DEFAULT_DART_ENTRYPOINT;
+    }
+  }
+
+  /**
+   * The Dart library URI for the entrypoint that will be executed as soon as the Dart snapshot is
+   * loaded.
+   *
+   * <p>Example value: "package:foo/bar.dart"
+   *
+   * <p>This preference can be controlled by setting a {@code <meta-data>} called {@link
+   * FlutterActivityLaunchConfigs#DART_ENTRYPOINT_URI_META_DATA_KEY} within the Android manifest
+   * definition for this {@code FlutterFragmentActivity}.
+   *
+   * <p>A value of null means use the default root library.
+   *
+   * <p>Subclasses may override this method to directly control the Dart entrypoint uri.
+   */
+  @Nullable
+  public String getDartEntrypointLibraryUri() {
+    try {
+      Bundle metaData = getMetaData();
+      String desiredDartLibraryUri =
+          metaData != null ? metaData.getString(DART_ENTRYPOINT_URI_META_DATA_KEY) : null;
+      return desiredDartLibraryUri;
+    } catch (PackageManager.NameNotFoundException e) {
+      return null;
     }
   }
 

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentActivityTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentActivityTest.java
@@ -92,6 +92,19 @@ public class FlutterFragmentActivityTest {
   }
 
   @Test
+  public void createFlutterFragment__customDartEntrypointLibraryUri() {
+    final FlutterFragmentActivity activity =
+        new FakeFlutterFragmentActivity() {
+          @Override
+          public String getDartEntrypointLibraryUri() {
+            return "package:foo/bar.dart";
+          }
+        };
+    assertEquals(
+        activity.createFlutterFragment().getDartEntrypointLibraryUri(), "package:foo/bar.dart");
+  }
+
+  @Test
   public void itRegistersPluginsAtConfigurationTime() {
     try (ActivityScenario<FlutterFragmentActivity> scenario =
         ActivityScenario.launch(FlutterFragmentActivity.class)) {
@@ -346,6 +359,11 @@ public class FlutterFragmentActivityTest {
     @Override
     public String getDartEntrypointFunctionName() {
       return "";
+    }
+
+    @Nullable
+    public String getDartEntrypointLibraryUri() {
+      return null;
     }
 
     @Override


### PR DESCRIPTION
Since the superclass of `FlutterFragmentActivity` is `FragmentActivity` instead of `FlutterActivity`, It seems that we still need to add this feature to `FlutterFragmentActivity` :-) 

related issue : https://github.com/flutter/flutter/issues/91841
related PR : https://github.com/flutter/engine/pull/30726

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

