### PR TITLE
[fuchsia] Bump buildroot/ to fix Fuchsia SDK roll

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -101,7 +101,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '17aaf301a1774cc5b639df288bba0b28dbd4e744',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '3497b9dfe353e862a009df660e912573d0b28852',
 
    # Fuchsia compatibility
    #


### PR DESCRIPTION
Discussed the current SDK roll failure #96126 with the Fuchsia SDK team
and submitted
https://github.com/flutter/buildroot/commit/3497b9dfe353e862a009df660e912573d0b28852
for a fix.

This rolls that commit into engine/. It's the only commit being rolled:
https://github.com/flutter/buildroot/compare/3497b9dfe353e862a009df660e912573d0b28852..17aaf301a1774cc5b639df288bba0b28dbd4e744