### PR TITLE
Remove unused setPersistentIsolateData function

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -337,24 +337,4 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle) {
   return @"io.flutter.flutter.app";
 }
 
-#pragma mark - Settings utilities
-
-- (void)setPersistentIsolateData:(NSData*)data {
-  if (data == nil) {
-    return;
-  }
-
-  NSData* persistent_isolate_data = [data copy];
-  fml::NonOwnedMapping::ReleaseProc data_release_proc = [persistent_isolate_data](auto, auto) {
-    [persistent_isolate_data release];
-  };
-  _settings.persistent_isolate_data = std::make_shared<fml::NonOwnedMapping>(
-      static_cast<const uint8_t*>(persistent_isolate_data.bytes),  // bytes
-      persistent_isolate_data.length,                              // byte length
-      data_release_proc                                            // release proc
-  );
-}
-
-#pragma mark - PlatformData utilities
-
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject_Internal.h
@@ -36,19 +36,6 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle = nil);
 + (NSString*)domainNetworkPolicy:(NSDictionary*)appTransportSecurity;
 + (bool)allowsArbitraryLoads:(NSDictionary*)appTransportSecurity;
 
-/**
- * The embedder can specify data that the isolate can request synchronously on launch. Engines
- * launched using this configuration can access the persistent isolate data via the
- * `PlatformDispatcher.getPersistentIsolateData` accessor.
- *
- * @param data The persistent isolate data. This data is persistent for the duration of the Flutter
- *             application and is available even after isolate restarts. Because of this lifecycle,
- *             the size of this data must be kept to a minimum and platform channels used for
- *             communication that does not require synchronous embedder to isolate communication
- *             close to isolate launch.
- **/
-- (void)setPersistentIsolateData:(NSData*)data;
-
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
`FlutterDartProject.setPersistentIsolateData` is neither a public API nor is it used anywhere internally. And its purpose is easily misunderstood by contributors.

It seems that there was a plan to use persistent isolate data to store some persistent data such as user settings data and lifecycle state, but we never started doing it.

Even if we need to use it to store user settings data and lifecycle state in the future, we still should not set it by `FlutterDartProject.setPersistentIsolateData`, because lightweight engines share the same `FlutterDartProject`, while each engine needs to have its own settings data and lifecycle state. So `RunConfiguration` would be a better choice than `FlutterDartProject.setPersistentIsolateData`.



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
