### PR TITLE
Add 'keyCode' field to eventData map created from html keyboard events.

### DIFF
--- a/lib/web_ui/lib/src/engine/keyboard.dart
+++ b/lib/web_ui/lib/src/engine/keyboard.dart
@@ -130,6 +130,7 @@ class Keyboard {
       'key': keyboardEvent.key,
       'location': keyboardEvent.location,
       'metaState': _lastMetaState,
+      'keyCode': keyboardEvent.keyCode,
     };
 
     EnginePlatformDispatcher.instance.invokeOnPlatformMessage('flutter/keyevent',
@@ -154,6 +155,7 @@ class Keyboard {
       'key': event.key,
       'location': event.location,
       'metaState': _lastMetaState,
+      'keyCode': event.keyCode,
     };
 
     EnginePlatformDispatcher.instance.invokeOnPlatformMessage('flutter/keyevent',

--- a/lib/web_ui/test/keyboard_test.dart
+++ b/lib/web_ui/test/keyboard_test.dart
@@ -53,7 +53,7 @@ void testMain() {
 
       html.KeyboardEvent event;
 
-      event = dispatchKeyboardEvent('keyup', key: 'SomeKey', code: 'SomeCode');
+      event = dispatchKeyboardEvent('keyup', key: 'SomeKey', code: 'SomeCode', keyCode: 1);
 
       expect(event.defaultPrevented, isFalse);
       expect(channelReceived, 'flutter/keyevent');
@@ -64,6 +64,7 @@ void testMain() {
         'location': 0,
         'key': 'SomeKey',
         'metaState': 0x0,
+        'keyCode': 1,
       });
 
       Keyboard.instance!.dispose();
@@ -85,7 +86,7 @@ void testMain() {
       html.KeyboardEvent event;
 
       event =
-          dispatchKeyboardEvent('keydown', key: 'SomeKey', code: 'SomeCode');
+          dispatchKeyboardEvent('keydown', key: 'SomeKey', code: 'SomeCode', keyCode: 1);
 
       expect(channelReceived, 'flutter/keyevent');
       expect(dataReceived, <String, dynamic>{
@@ -95,6 +96,7 @@ void testMain() {
         'key': 'SomeKey',
         'location': 0,
         'metaState': 0x0,
+        'keyCode': 1,
       });
       expect(event.defaultPrevented, isFalse);
 
@@ -129,6 +131,7 @@ void testMain() {
         'location': 0,
         //          ctrl
         'metaState': 0x4,
+        'keyCode': 0,
       });
 
       event = dispatchKeyboardEvent(
@@ -148,6 +151,7 @@ void testMain() {
         'location': 0,
         //          shift  alt   meta
         'metaState': 0x1 | 0x2 | 0x8,
+        'keyCode': 0,
       });
 
       Keyboard.instance!.dispose();
@@ -197,6 +201,7 @@ void testMain() {
         'key': 'SomeKey',
         'location': 0,
         'metaState': 0,
+        'keyCode': 0,
       };
       expect(messages, <Map<String, dynamic>>[
         expectedMessage,
@@ -394,6 +399,7 @@ void testMain() {
             'location': 1,
             //           meta
             'metaState': 0x8,
+            'keyCode': 0,
           },
           <String, dynamic>{
             'type': 'keydown',
@@ -403,6 +409,7 @@ void testMain() {
             'location': 1,
             //           alt   meta
             'metaState': 0x2 | 0x8,
+            'keyCode': 0,
           },
           <String, dynamic>{
             'type': 'keydown',
@@ -412,6 +419,7 @@ void testMain() {
             'location': 0,
             //           alt   meta
             'metaState': 0x2 | 0x8,
+            'keyCode': 0,
           },
           <String, dynamic>{
             'type': 'keyup',
@@ -421,6 +429,7 @@ void testMain() {
             'location': 1,
             //           alt
             'metaState': 0x2,
+            'keyCode': 0,
           },
           <String, dynamic>{
             'type': 'keyup',
@@ -429,6 +438,7 @@ void testMain() {
             'code': 'AltLeft',
             'location': 1,
             'metaState': 0x0,
+            'keyCode': 0,
           },
         ]);
         messages.clear();
@@ -446,6 +456,7 @@ void testMain() {
             'code': 'KeyI',
             'location': 0,
             'metaState': 0x0,
+            'keyCode': 0,
           }
         ]);
 
@@ -526,6 +537,7 @@ void testMain() {
             'code': 'KeyI',
             'location': 0,
             'metaState': 0x0,
+            'keyCode': 0,
           });
         }
         messages.clear();
@@ -621,6 +633,7 @@ void testMain() {
           'location': 0,
           //           alt
           'metaState': 0x2,
+          'keyCode': 0,
         }
       ]);
 
@@ -654,6 +667,7 @@ html.KeyboardEvent dispatchKeyboardEvent(
   bool isAltPressed = false,
   bool isControlPressed = false,
   bool isMetaPressed = false,
+  int keyCode = 0,
 }) {
   target ??= html.window;
 
@@ -670,6 +684,7 @@ html.KeyboardEvent dispatchKeyboardEvent(
       'altKey': isAltPressed,
       'ctrlKey': isControlPressed,
       'metaKey': isMetaPressed,
+      'keyCode': keyCode,
       'bubbles': true,
       'cancelable': true,
     }


### PR DESCRIPTION
Add 'keyCode' field to eventData map created from html keyboard events.

flutter/flutter#96479

@dkwingsmt 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
