### PR TITLE
Don't retain the MTLTexture or MTLDevice in TestMetalContext

### DIFF
--- a/testing/test_metal_context.mm
+++ b/testing/test_metal_context.mm
@@ -42,9 +42,6 @@ TestMetalContext::TestMetalContext() {
 
 TestMetalContext::~TestMetalContext() {
   std::scoped_lock lock(textures_mutex);
-  for (auto& [_, texture] : textures_) {
-    [(id)texture.get() release];
-  }
   textures_.clear();
   if (device_) {
     [(__bridge id)device_ release];

--- a/testing/test_metal_context.mm
+++ b/testing/test_metal_context.mm
@@ -65,11 +65,11 @@ sk_sp<GrDirectContext> TestMetalContext::GetSkiaContext() const {
 
 TestMetalContext::TextureInfo TestMetalContext::CreateMetalTexture(const SkISize& size) {
   std::scoped_lock lock(textures_mutex);
-  auto texture_descriptor = fml::scoped_nsobject{[MTLTextureDescriptor
-      texture2DDescriptorWithPixelFormat:MTLPixelFormatBGRA8Unorm
-                                   width:size.width()
-                                  height:size.height()
-                               mipmapped:NO]};
+  auto texture_descriptor = fml::scoped_nsobject{
+      [[MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatBGRA8Unorm
+                                                          width:size.width()
+                                                         height:size.height()
+                                                      mipmapped:NO] retain]};
 
   // The most pessimistic option and disables all optimizations but allows tests
   // the most flexible access to the surface. They may read and write to the


### PR DESCRIPTION
This fixes a memory leak where we weren't ever releasing the `MTLTexture`, `MTLDevice` or `MTLTextureDescriptor` in `TestMetalContext`.

Basically, in `CreateMetalTexture` we manually retain the `MTLTexture` and `MTLTextureDescriptor` when we create them, but this is unnecessary as we automatically take ownership of both of these. The `MTLTextureDescriptor` is automatically released at the end of the block by `scoped_nsobject`, but the `MTLTexture` needs to be released in the destructor.

Similarly in the `TestMetalContext` constructor, we manually `retain` the device returned by `MTLCreateSystemDefaultDevice()`, but as we are expected to have ownership of it this is unnecessary. The `fml::scoped_nsprotocol`/`scoped_nsobject` smart pointers adopt the ownership without calling `retain`, and `release` when going out of scope at the end of the constructor, which is fine because we assign them to the private members before then, with an additional `retain` call.

The additional `retain` calls at the end of the constructor are fine as they are balanced out by the `release` calls in the destructor.

This is poorly documented in the Apple docs, but I believe the "Create" rule described at https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFMemoryMgmt/Concepts/Ownership.html#//apple_ref/doc/uid/20001148-103029 should cover it.