### PR TITLE
Create a DisplayList benchmarks dylib on iOS

### DIFF
--- a/benchmarking/BUILD.gn
+++ b/benchmarking/BUILD.gn
@@ -24,3 +24,26 @@ source_set("benchmarking") {
     ":benchmark_config",
   ]
 }
+
+config("benchmark_library_config") {
+  if (is_ios) {
+    ldflags = [ "-Wl,-exported_symbol,_RunBenchmarks" ]
+  }
+}
+
+source_set("benchmarking_library") {
+  testonly = true
+
+  sources = [
+    "library.cc",
+    "library.h",
+  ]
+
+  public_deps = [ "//third_party/benchmark" ]
+
+  public_configs = [
+    "//flutter:config",
+    ":benchmark_config",
+    ":benchmark_library_config",
+  ]
+}

--- a/benchmarking/library.cc
+++ b/benchmarking/library.cc
@@ -1,0 +1,16 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "third_party/benchmark/include/benchmark/benchmark.h"
+
+#include "library.h"
+
+extern "C" {
+
+int RunBenchmarks(int argc, char** argv) {
+  benchmark::Initialize(&argc, argv);
+  ::benchmark::RunSpecifiedBenchmarks();
+  return 0;
+}
+}

--- a/benchmarking/library.h
+++ b/benchmarking/library.h
@@ -1,0 +1,12 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_BENCHMARKING_LIBRARY_H_
+#define FLUTTER_BENCHMARKING_LIBRARY_H_
+
+extern "C" {
+__attribute__((visibility("default"))) int RunBenchmarks(int argc, char** argv);
+}
+
+#endif  // FLUTTER_BENCHMARKING_LIBRARY_H_

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -20,6 +20,8 @@ FILE: ../../../flutter/assets/directory_asset_bundle.cc
 FILE: ../../../flutter/assets/directory_asset_bundle.h
 FILE: ../../../flutter/benchmarking/benchmarking.cc
 FILE: ../../../flutter/benchmarking/benchmarking.h
+FILE: ../../../flutter/benchmarking/library.cc
+FILE: ../../../flutter/benchmarking/library.h
 FILE: ../../../flutter/common/constants.h
 FILE: ../../../flutter/common/exported_symbols.sym
 FILE: ../../../flutter/common/graphics/gl_context_switch.cc

--- a/display_list/BUILD.gn
+++ b/display_list/BUILD.gn
@@ -85,3 +85,42 @@ if (enable_unittests) {
     }
   }
 }
+
+if (is_ios) {
+  shared_library("ios_display_list_benchmarks") {
+    testonly = true
+    visibility = [ ":*" ]
+
+    configs -= [
+      "//build/config/gcc:symbol_visibility_hidden",
+      "//build/config:symbol_visibility_hidden",
+    ]
+    configs += [ "//flutter/benchmarking:benchmark_library_config" ]
+    cflags = [
+      "-fobjc-arc",
+      "-mios-simulator-version-min=$ios_testing_deployment_target",
+    ]
+    ldflags =
+        [ "-Wl,-install_name,@rpath/libios_display_list_benchmarks.dylib" ]
+
+    sources = [
+      "display_list_benchmarks.cc",
+      "display_list_benchmarks.h",
+      "display_list_benchmarks_metal.cc",
+    ]
+
+    deps = [
+      ":display_list",
+      ":display_list_benchmarks_fixtures",
+      "//flutter/benchmarking:benchmarking_library",
+      "//flutter/common/graphics",
+      "//flutter/fml",
+      "//flutter/testing:metal",
+      "//flutter/testing:skia",
+      "//flutter/testing:testing_lib",
+      "//third_party/benchmark",
+      "//third_party/dart/runtime:libdart_jit",  # for tracing
+      "//third_party/skia",
+    ]
+  }
+}

--- a/display_list/display_list_benchmarks.h
+++ b/display_list/display_list_benchmarks.h
@@ -5,10 +5,10 @@
 #ifndef FLUTTER_FLOW_DISPLAY_LIST_BENCHMARKS_H_
 #define FLUTTER_FLOW_DISPLAY_LIST_BENCHMARKS_H_
 
-#include "flutter/benchmarking/benchmarking.h"
 #include "flutter/fml/mapping.h"
 #include "flutter/testing/testing.h"
 
+#include "third_party/benchmark/include/benchmark/benchmark.h"
 #include "third_party/skia/include/core/SkCanvas.h"
 #include "third_party/skia/include/core/SkPath.h"
 #include "third_party/skia/include/core/SkSurface.h"

--- a/testing/BUILD.gn
+++ b/testing/BUILD.gn
@@ -165,35 +165,6 @@ if (enable_unittests) {
     }
   }
 
-  # All targets on all platforms should be able to use the Metal utilities. On
-  # platforms where Metal is not available, the tests must be skipped or
-  # implemented to use another available client rendering API. This is usually
-  # either OpenGL which is portably implemented via SwiftShader or the software
-  # backend. This way, all tests compile on all platforms but the Metal backend
-  # is exercised on platforms where Metal itself is available.
-  source_set("metal") {
-    if (shell_enable_metal) {
-      sources = [
-        "test_metal_context.h",
-        "test_metal_context.mm",
-        "test_metal_surface.cc",
-        "test_metal_surface.h",
-        "test_metal_surface_impl.h",
-        "test_metal_surface_impl.mm",
-      ]
-
-      # Skia's Vulkan support is enabled for all platforms, and so parts of
-      # Skia's graphics context reference Vulkan symbols.
-      deps = [
-        ":skia",
-        "//flutter/fml",
-        "//flutter/vulkan",
-      ]
-    }
-
-    testonly = true
-  }
-
   test_fixtures("testing_fixtures") {
     fixtures = []
   }
@@ -218,5 +189,40 @@ if (enable_unittests) {
 
       deps += [ ":metal" ]
     }
+  }
+}
+
+# All targets on all platforms should be able to use the Metal utilities. On
+# platforms where Metal is not available, the tests must be skipped or
+# implemented to use another available client rendering API. This is usually
+# either OpenGL which is portably implemented via SwiftShader or the software
+# backend. This way, all tests compile on all platforms but the Metal backend
+# is exercised on platforms where Metal itself is available.
+#
+# On iOS, this is enabled to allow for Metal tests to run within a test app
+if (enable_unittests || is_ios) {
+  source_set("metal") {
+    if (shell_enable_metal) {
+      sources = [
+        "test_metal_context.h",
+        "test_metal_context.mm",
+        "test_metal_surface.cc",
+        "test_metal_surface.h",
+        "test_metal_surface_impl.h",
+        "test_metal_surface_impl.mm",
+      ]
+      deps = [
+        ":skia",
+        "//flutter/fml",
+      ]
+
+      # Skia's Vulkan support is enabled for all platforms (except iOS), and so parts of
+      # Skia's graphics context reference Vulkan symbols.
+      if (!is_ios) {
+        deps += [ "//flutter/vulkan" ]
+      }
+    }
+
+    testonly = true
   }
 }


### PR DESCRIPTION
Currently we have no way to run the engine unittests or benchmarks on an iOS device, because the build outputs a binary which we cannot execute on iOS.

This is a quick way for us to be able to run benchmarks on an actual device:

* On iOS, instead of generating a benchmarking executable, build a dylib that's linked against libbenchmark.a
* In that dylib, don't depend on the existing `//flutter/benchmarking` code (which implements a `main` function), but instead depend on the  `//flutter/benchmarking:benchmarking_library` dep, which exposes a `RunBenchmarks(argc,argv)` entrypoint.
* In the iOS test app, simply link against the generated `libios_display_list_benchmarks.dylib` library and call `RunBenchmarks(argc, argv)` in `main` and the benchmarks will run.

I will push the iOS test app in a future PR, but it is loosely modelled on the existing `IosUnitTests` app in `//testing/ios`.

https://github.com/flutter/flutter/issues/96569

No new tests as this *is* the test code.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
