### PR TITLE
Ensure that PlatformViewIOS does not call into Shell semantics APIs during destruction

### DIFF
--- a/shell/platform/darwin/ios/platform_view_ios.h
+++ b/shell/platform/darwin/ios/platform_view_ios.h
@@ -113,20 +113,20 @@ class PlatformViewIOS final : public PlatformView {
     id<NSObject> observer_;
   };
 
-  /// Smart pointer that guarantees we communicate clearing Accessibility
+  /// Wrapper that guarantees we communicate clearing Accessibility
   /// information to Dart.
-  class AccessibilityBridgePtr {
+  class AccessibilityBridgeManager {
    public:
-    explicit AccessibilityBridgePtr(const std::function<void(bool)>& set_semantics_enabled);
-    AccessibilityBridgePtr(const std::function<void(bool)>& set_semantics_enabled,
-                           AccessibilityBridge* bridge);
-    ~AccessibilityBridgePtr();
+    explicit AccessibilityBridgeManager(const std::function<void(bool)>& set_semantics_enabled);
+    AccessibilityBridgeManager(const std::function<void(bool)>& set_semantics_enabled,
+                               AccessibilityBridge* bridge);
     explicit operator bool() const noexcept { return static_cast<bool>(accessibility_bridge_); }
-    AccessibilityBridge* operator->() const noexcept { return accessibility_bridge_.get(); }
-    void reset(AccessibilityBridge* bridge = nullptr);
+    AccessibilityBridge* get() const noexcept { return accessibility_bridge_.get(); }
+    void Set(std::unique_ptr<AccessibilityBridge> bridge);
+    void Clear();
 
    private:
-    FML_DISALLOW_COPY_AND_ASSIGN(AccessibilityBridgePtr);
+    FML_DISALLOW_COPY_AND_ASSIGN(AccessibilityBridgeManager);
     std::unique_ptr<AccessibilityBridge> accessibility_bridge_;
     std::function<void(bool)> set_semantics_enabled_;
   };
@@ -138,7 +138,7 @@ class PlatformViewIOS final : public PlatformView {
   std::unique_ptr<IOSSurface> ios_surface_;
   std::shared_ptr<IOSContext> ios_context_;
   const std::shared_ptr<FlutterPlatformViewsController>& platform_views_controller_;
-  AccessibilityBridgePtr accessibility_bridge_;
+  AccessibilityBridgeManager accessibility_bridge_;
   fml::scoped_nsprotocol<FlutterTextInputPlugin*> text_input_plugin_;
   fml::closure firstFrameCallback_;
   ScopedObserver dealloc_view_controller_observer_;


### PR DESCRIPTION
PlatformViewIOS uses an AccessibilityBridge wrapper that calls
PlatformView::SetSemanticsEnabled whenever the AccessibilityBridge is created
or destroyed.  However, the SetSemanticsEnabled call should not happen
during destruction of the PlatformView.  SetSemanticsEnabled calls into a
Shell API, and the PlatformView is deleted while the Shell is being
destructed.

Fixes https://github.com/flutter/flutter/issues/95844