### PR TITLE
Move SoftwareCanvasProvider into its own source file

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -40,6 +40,7 @@ FILE: ../../../flutter/display_list/display_list_benchmarks.cc
 FILE: ../../../flutter/display_list/display_list_benchmarks.h
 FILE: ../../../flutter/display_list/display_list_benchmarks_gl.cc
 FILE: ../../../flutter/display_list/display_list_benchmarks_metal.cc
+FILE: ../../../flutter/display_list/display_list_benchmarks_software.cc
 FILE: ../../../flutter/display_list/display_list_builder.cc
 FILE: ../../../flutter/display_list/display_list_builder.h
 FILE: ../../../flutter/display_list/display_list_canvas_dispatcher.cc

--- a/display_list/BUILD.gn
+++ b/display_list/BUILD.gn
@@ -60,6 +60,7 @@ if (enable_unittests) {
     sources = [
       "display_list_benchmarks.cc",
       "display_list_benchmarks.h",
+      "display_list_benchmarks_software.cc",
     ]
 
     deps = [

--- a/display_list/display_list_benchmarks.cc
+++ b/display_list/display_list_benchmarks.cc
@@ -11,29 +11,6 @@
 namespace flutter {
 namespace testing {
 
-class SoftwareCanvasProvider : public CanvasProvider {
- public:
-  virtual ~SoftwareCanvasProvider() = default;
-  void InitializeSurface(const size_t width, const size_t height) override {
-    surface_ = SkSurface::MakeRasterN32Premul(width, height);
-    surface_->getCanvas()->clear(SK_ColorTRANSPARENT);
-  }
-
-  sk_sp<SkSurface> GetSurface() override { return surface_; }
-
-  sk_sp<SkSurface> MakeOffscreenSurface(const size_t width,
-                                        const size_t height) override {
-    auto surface = SkSurface::MakeRasterN32Premul(width, height);
-    surface->getCanvas()->clear(SK_ColorTRANSPARENT);
-    return surface;
-  }
-
-  const std::string BackendName() override { return "Software"; }
-
- private:
-  sk_sp<SkSurface> surface_;
-};
-
 // Constants chosen to produce benchmark results in the region of 1-50ms
 constexpr size_t kLinesToDraw = 10000;
 constexpr size_t kRectsToDraw = 5000;
@@ -1053,8 +1030,6 @@ void BM_DrawShadow(benchmark::State& state,
                   std::to_string(elevation) + "-" + ".png";
   canvas_provider->Snapshot(filename);
 }
-
-RUN_DISPLAYLIST_BENCHMARKS(Software)
 
 }  // namespace testing
 }  // namespace flutter

--- a/display_list/display_list_benchmarks_software.cc
+++ b/display_list/display_list_benchmarks_software.cc
@@ -1,0 +1,39 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/display_list/display_list_benchmarks.h"
+#include "flutter/display_list/display_list_builder.h"
+#include "third_party/skia/include/core/SkPoint.h"
+#include "third_party/skia/include/core/SkTextBlob.h"
+
+namespace flutter {
+namespace testing {
+
+class SoftwareCanvasProvider : public CanvasProvider {
+ public:
+  virtual ~SoftwareCanvasProvider() = default;
+  void InitializeSurface(const size_t width, const size_t height) override {
+    surface_ = SkSurface::MakeRasterN32Premul(width, height);
+    surface_->getCanvas()->clear(SK_ColorTRANSPARENT);
+  }
+
+  sk_sp<SkSurface> GetSurface() override { return surface_; }
+
+  sk_sp<SkSurface> MakeOffscreenSurface(const size_t width,
+                                        const size_t height) override {
+    auto surface = SkSurface::MakeRasterN32Premul(width, height);
+    surface->getCanvas()->clear(SK_ColorTRANSPARENT);
+    return surface;
+  }
+
+  const std::string BackendName() override { return "Software"; }
+
+ private:
+  sk_sp<SkSurface> surface_;
+};
+
+RUN_DISPLAYLIST_BENCHMARKS(Software)
+
+}  // namespace testing
+}  // namespace flutter


### PR DESCRIPTION
Trivial refactor - simply move the DisplayListBenchmarks software things into their own file. Just makes it easier for platforms where we won't care about software rendering.