### PR TITLE
Remove the unused FlutterImageView from FlutterView to avoid leaks

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -1226,8 +1226,8 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
 
     if (flutterImageView != null) {
       flutterImageView.closeImageReader();
-      // Remove the {@link FlutterImageView} that was previously added by {@code
-      // convertToImageView}.
+      // Remove the FlutterImageView that was previously added by {@code convertToImageView} to
+      // avoid leaks when this FlutterView is reused later.
       removeView(flutterImageView);
       flutterImageView = null;
     }

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -1226,6 +1226,9 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
 
     if (flutterImageView != null) {
       flutterImageView.closeImageReader();
+      // Remove the {@link FlutterImageView} that was previously added by {@code
+      // convertToImageView}.
+      removeView(flutterImageView);
       flutterImageView = null;
     }
     previousRenderSurface = null;

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -1227,7 +1227,8 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
     if (flutterImageView != null) {
       flutterImageView.closeImageReader();
       // Remove the FlutterImageView that was previously added by {@code convertToImageView} to
-      // avoid leaks when this FlutterView is reused later.
+      // avoid leaks when this FlutterView is reused later in the scenario where multiple
+      // FlutterActivitiy/FlutterFragment share one engine.
       removeView(flutterImageView);
       flutterImageView = null;
     }

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
@@ -136,6 +136,24 @@ public class FlutterViewTest {
   }
 
   @Test
+  public void detachFromFlutterEngine_removeImageView() {
+    FlutterView flutterView = new FlutterView(RuntimeEnvironment.application);
+    FlutterEngine flutterEngine =
+        spy(new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, mockFlutterJni));
+
+    flutterView.attachToFlutterEngine(flutterEngine);
+    flutterView.convertToImageView();
+    assertEquals(flutterView.getChildCount(), 2);
+    View view = flutterView.getChildAt(1);
+    assertTrue(view instanceof FlutterImageView);
+
+    flutterView.detachFromFlutterEngine();
+    assertEquals(flutterView.getChildCount(), 1);
+    view = flutterView.getChildAt(0);
+    assertFalse(view instanceof FlutterImageView);
+  }
+
+  @Test
   public void detachFromFlutterEngine_closesImageView() {
     FlutterEngine flutterEngine =
         spy(new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, mockFlutterJni));


### PR DESCRIPTION
Remove the unused `FlutterImageView` that was previously added by `convertToImageView`.

Fixes: https://github.com/flutter/flutter/issues/96513

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
