### PR TITLE
Fix a memory leak by using a local autorelease pool for Metal objects in DisplayList benchmarks

### DIFF
--- a/display_list/BUILD.gn
+++ b/display_list/BUILD.gn
@@ -81,7 +81,7 @@ if (enable_unittests) {
     }
 
     if (is_mac) {
-      sources += [ "display_list_benchmarks_metal.cc" ]
+      sources += [ "display_list_benchmarks_metal.mm" ]
       deps += [ "//flutter/testing:metal" ]
     }
   }
@@ -97,17 +97,14 @@ if (is_ios) {
       "//build/config:symbol_visibility_hidden",
     ]
     configs += [ "//flutter/benchmarking:benchmark_library_config" ]
-    cflags = [
-      "-fobjc-arc",
-      "-mios-simulator-version-min=$ios_testing_deployment_target",
-    ]
+    cflags = [ "-mios-simulator-version-min=$ios_testing_deployment_target" ]
     ldflags =
         [ "-Wl,-install_name,@rpath/libios_display_list_benchmarks.dylib" ]
 
     sources = [
       "display_list_benchmarks.cc",
       "display_list_benchmarks.h",
-      "display_list_benchmarks_metal.cc",
+      "display_list_benchmarks_metal.mm",
     ]
 
     deps = [


### PR DESCRIPTION
This is the memory leak that was causing my iPhone to OOM when trying to run the display list benchmarks.

Basically, the benchmarking library has a single method you call into which blocks until all the benchmarks are run. This blocks the main thread.

As a result, during the entire benchmark run we are continually adding obj-c objects to the autorelease pool, but we're never actually draining the pool because we don't unblock the main thread until every benchmark is finished.

This patch adds a new utility class based on Skia's `AutoreleasePool` class that we can just throw into an existing class as a member, which will create an `NSAutoreleasePool` that's tied to the life of that class. Doing this in the `MetalCanvasProvider` means that all the Metal objects we create in that class are assigned to that autorelease pool, which is correctly drained when the `MetalCanvasProvider` is destroyed.

This was not fun to debug.