### PR TITLE
libtxt: Initialize ParagraphTxt::final_line_count_

### DIFF
--- a/third_party/txt/src/txt/paragraph_txt.h
+++ b/third_party/txt/src/txt/paragraph_txt.h
@@ -187,7 +187,7 @@ class ParagraphTxt : public Paragraph {
   mutable std::unique_ptr<icu::BreakIterator> word_breaker_;
 
   std::vector<LineMetrics> line_metrics_;
-  size_t final_line_count_;
+  size_t final_line_count_ = 0;
   std::vector<double> line_widths_;
 
   // Stores the result of Layout().


### PR DESCRIPTION
This will make ParagraphTxt::GetHeight safe to call for a paragraph that
has not yet been laid out.

Fixes https://github.com/flutter/flutter/issues/96596
