### PR TITLE
BUGFIX: addTimingCallback return wrong timestamp

### DIFF
--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -214,16 +214,15 @@ RasterStatus Rasterizer::Draw(
   // between successive tries.
   switch (consume_result) {
     case PipelineConsumeResult::MoreAvailable: {
-      delegate_.GetTaskRunners().GetRasterTaskRunner()->PostTask(
-          fml::MakeCopyable(
-              [weak_this = weak_factory_.GetWeakPtr(), pipeline,
-               resubmit_recorder = std::move(resubmit_recorder),
-               discard_callback = std::move(discard_callback)]() mutable {
-                if (weak_this) {
-                  weak_this->Draw(std::move(resubmit_recorder), pipeline,
-                                  std::move(discard_callback));
-                }
-              }));
+      if (raster_status != RasterStatus::kSuccess)
+        delegate_.GetTaskRunners().GetRasterTaskRunner()->PostTask(
+            fml::MakeCopyable(
+                [weak_this = weak_factory_.GetWeakPtr(), pipeline,
+                 resubmit_recorder = std::move(resubmit_recorder)]() mutable {
+                  if (weak_this) {
+                    weak_this->Draw(std::move(resubmit_recorder), pipeline);
+                  }
+                }));
       break;
     }
     default:


### PR DESCRIPTION
This PR adds a if before Rasterizer::Draw to post task to RasterTaskRunner.
There is a scenario that two items stored in pipeline. After pipeline->consume is invoked the pipeline's consume_result is MoreAvailable and raster_status is kSuccess. At the end of function Rasterizer::Draw will post task to RasterizerTaskRunner with resubmit_recorder, which will result in next new layer_tree is added by ui thread matches the task with resubmit_recorder.

Personally, i consider that switch case at the end of Rasterizer::Draw should only address PipelineConsumeResult::MoreAvailable when raster_status are kResubmit, kSkipAndRetry, kEnqueuePipeline.

The issue link
https://github.com/flutter/flutter/issues/96699  
