### PR TITLE
Add pkg:smith as a dependency for flutter_frontend_server.

### DIFF
--- a/flutter_frontend_server/pubspec.yaml
+++ b/flutter_frontend_server/pubspec.yaml
@@ -107,6 +107,8 @@ dependency_overrides:
     path: ../../third_party/dart/third_party/pkg/shelf
   shelf_static:
     path: ../../third_party/dart/third_party/pkg/shelf_static
+  smith:
+    path: ../../third_party/dart/pkg/smith
   source_maps:
     path: ../../third_party/dart/third_party/pkg/source_maps
   source_span:

--- a/testing/benchmark/pubspec.yaml
+++ b/testing/benchmark/pubspec.yaml
@@ -65,6 +65,8 @@ dependency_overrides:
     path: ../../../third_party/dart/third_party/pkg/path
   pedantic:
     path: ../../../third_party/dart/third_party/pkg/pedantic
+  smith:
+    path: ../../../third_party/dart/pkg/smith
   source_span:
     path: ../../../third_party/dart/third_party/pkg/source_span
   string_scanner:

--- a/testing/dart/pubspec.yaml
+++ b/testing/dart/pubspec.yaml
@@ -34,6 +34,8 @@ dependency_overrides:
     path: ../../../third_party/dart/pkg/meta
   path:
     path: ../../../third_party/dart/third_party/pkg/path
+  smith:
+    path: ../../../third_party/dart/pkg/smith
   spirv:
     path: ../../lib/spirv
   sky_engine:

--- a/testing/litetest/pubspec.yaml
+++ b/testing/litetest/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   async_helper: any
   expect: any
   meta: any
+  smith: any
 
 dependency_overrides:
   async_helper:
@@ -28,3 +29,5 @@ dependency_overrides:
     path: ../../../third_party/dart/pkg/expect
   meta:
     path: ../../../third_party/dart/pkg/meta
+  smith:
+    path: ../../../third_party/dart/pkg/smith

--- a/testing/smoke_test_failure/pubspec.yaml
+++ b/testing/smoke_test_failure/pubspec.yaml
@@ -27,3 +27,5 @@ dependency_overrides:
     path: ../litetest
   meta:
     path: ../../../third_party/dart/pkg/meta
+  smith:
+    path: ../../../third_party/dart/pkg/smith

--- a/tools/clang_tidy/pubspec.yaml
+++ b/tools/clang_tidy/pubspec.yaml
@@ -26,6 +26,7 @@ dev_dependencies:
   async_helper: any
   expect: any
   litetest: any
+  smith: any
 
 dependency_overrides:
   args:
@@ -52,3 +53,5 @@ dependency_overrides:
     path: ../../../third_party/pkg/process
   process_runner:
     path: ../../../third_party/pkg/process_runner
+  smith:
+    path: ../../../third_party/dart/pkg/smith

--- a/tools/githooks/pubspec.yaml
+++ b/tools/githooks/pubspec.yaml
@@ -25,6 +25,7 @@ dev_dependencies:
   async_helper: any
   expect: any
   litetest: any
+  smith: any
 
 dependency_overrides:
   args:
@@ -53,3 +54,5 @@ dependency_overrides:
     path: ../../../third_party/pkg/process
   process_runner:
     path: ../../../third_party/pkg/process_runner
+  smith:
+    path: ../../../third_party/dart/pkg/smith


### PR DESCRIPTION
For all packages that depend on dart-sdk internal pkg:expect package add pkg:smith.

This is needed to roll dart past https://github.com/dart-lang/sdk/commit/b453c6bcba5526e127361e5ea45765d12431b996 which added pkg:smith as a dependency to pkg:expect.

Here is where dart->engine roller stumbles at the moment:

```
The roller failed to create a CL with:
Command exited with exit status 2: DEPOT_TOOLS_UPDATE=0 HOME=/home/skia LUCI_CONTEXT=/data/tmp/luci_context.170844833 PATH=/data/depot_tools:/cipd:/cipd/cipd_bin_packages:/cipd/cipd_bin_packages/bin:/cipd/cipd_bin_packages/cpython:/cipd/cipd_bin_packages/cpython/bin:/cipd/cipd_bin_packages/cpython3:/cipd/cipd_bin_packages/cpython3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin SKIP_GCE_AUTH_FOR_GIT=1 python /data/depot_tools/gclient.py sync --delete_unversioned_trees --force; Stdout+Stderr:
________ running 'python3 src/tools/remove_stale_pyc_files.py src/tools' in '/data'
________ running 'python3 src/build/linux/sysroot_scripts/install-sysroot.py --arch=x64' in '/data'
________ running 'python3 src/build/linux/sysroot_scripts/install-sysroot.py --arch=arm64' in '/data'
________ running 'python3 src/flutter/tools/pub_get_offline.py' in '/data'
'/data/src/third_party/dart/tools/sdks/dart-sdk/bin/pub get --offline' failed in 'src/flutter/flutter_frontend_server' with status 69:
b'Resolving dependencies...\nBecause every version of expect from path depends on smith any which is forbidden, expect from path is forbidden.\nSo, because flutter_frontend_server depends on expect from path, version solving failed.\n'
Error: Command 'python3 src/flutter/tools/pub_get_offline.py' returned non-zero exit status 1 in /data
'/data/src/third_party/dart/tools/sdks/dart-sdk/bin/pub get --offline' failed in 'src/flutter/flutter_frontend_server' with status 69:
b'Resolving dependencies...\nBecause every version of expect from path depends on smith any which is forbidden, expect from path is forbidden.\nSo, because flutter_frontend_server depends on expect from path, version solving failed.\n'

. At deps_local.go:73 deps_local.go:83 deps_local.go:138 git_common.go:158 git_checkout.go:74 autoroller.go:485 autoroller.go:442 state_machine.go:284 state_machine.go:53 state_machine.go:168 state_machine.go:839 state_machine.go:852 state_machine.go:858 autoroller.go:777 autoroller.go:336 util.go:391 cleanup.go:57 asm_amd64.s:1371
```
