### PR TITLE
Fixing bug when `ListenableEditingState` is provided `initialState` with a valid composing range, `android.view.inputmethod.BaseInputConnection.setComposingRegion(int, int)` has NPE

### DIFF
--- a/shell/platform/android/io/flutter/plugin/editing/ListenableEditingState.java
+++ b/shell/platform/android/io/flutter/plugin/editing/ListenableEditingState.java
@@ -60,9 +60,6 @@ class ListenableEditingState extends SpannableStringBuilder {
   public ListenableEditingState(
       @Nullable TextInputChannel.TextEditState initialState, @NonNull View view) {
     super();
-    if (initialState != null) {
-      setEditingState(initialState);
-    }
 
     Editable self = this;
     mDummyConnection =
@@ -72,6 +69,10 @@ class ListenableEditingState extends SpannableStringBuilder {
             return self;
           }
         };
+
+    if (initialState != null) {
+      setEditingState(initialState);
+    }
   }
 
   public ArrayList<TextEditingDelta> extractBatchTextEditingDeltas() {
@@ -141,11 +142,7 @@ class ListenableEditingState extends SpannableStringBuilder {
     if (composingStart < 0 || composingStart >= composingEnd) {
       BaseInputConnection.removeComposingSpans(this);
     } else {
-      if (mDummyConnection != null) {
-        mDummyConnection.setComposingRegion(composingStart, composingEnd);
-      } else {
-        Log.w(TAG, "setComposingRange skip since mDummyConnection is null");
-      }
+      mDummyConnection.setComposingRegion(composingStart, composingEnd);
     }
   }
 

--- a/shell/platform/android/io/flutter/plugin/editing/ListenableEditingState.java
+++ b/shell/platform/android/io/flutter/plugin/editing/ListenableEditingState.java
@@ -141,7 +141,11 @@ class ListenableEditingState extends SpannableStringBuilder {
     if (composingStart < 0 || composingStart >= composingEnd) {
       BaseInputConnection.removeComposingSpans(this);
     } else {
-      mDummyConnection.setComposingRegion(composingStart, composingEnd);
+      if (mDummyConnection != null) {
+        mDummyConnection.setComposingRegion(composingStart, composingEnd);
+      } else {
+        Log.w(TAG, "setComposingRange skip since mDummyConnection is null");
+      }
     }
   }
 

--- a/shell/platform/android/test/io/flutter/plugin/editing/ListenableEditingStateTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/ListenableEditingStateTest.java
@@ -42,6 +42,12 @@ public class ListenableEditingStateTest {
     MockitoAnnotations.openMocks(this);
   }
 
+  @Test
+  public void testConstructor() {
+    // When provided valid composing range, should not fail
+    new ListenableEditingState(new TextInputChannel.TextEditState("hello", 1, 4, 1, 4), new View(RuntimeEnvironment.application));
+  }
+
   // -------- Start: Test BatchEditing   -------
   @Test
   public void testBatchEditing() {

--- a/shell/platform/android/test/io/flutter/plugin/editing/ListenableEditingStateTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/ListenableEditingStateTest.java
@@ -45,7 +45,9 @@ public class ListenableEditingStateTest {
   @Test
   public void testConstructor() {
     // When provided valid composing range, should not fail
-    new ListenableEditingState(new TextInputChannel.TextEditState("hello", 1, 4, 1, 4), new View(RuntimeEnvironment.application));
+    new ListenableEditingState(
+        new TextInputChannel.TextEditState("hello", 1, 4, 1, 4),
+        new View(RuntimeEnvironment.application));
   }
 
   // -------- Start: Test BatchEditing   -------


### PR DESCRIPTION
*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*
See https://github.com/flutter/flutter/issues/96570

*List which issues are fixed by this PR. You must list at least one issue.*
Fix https://github.com/flutter/flutter/issues/96570

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
