### PR TITLE
Allow builder to skip building examples.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -3,6 +3,7 @@
 # found in the LICENSE file.
 
 import("//flutter/common/config.gni")
+import("//flutter/examples/examples.gni")
 import("//flutter/shell/platform/config.gni")
 import("//flutter/shell/platform/glfw/config.gni")
 import("//flutter/testing/testing.gni")
@@ -80,7 +81,7 @@ group("flutter") {
   ]
 
   # Ensure the example for a sample embedder compiles.
-  if (is_mac || is_linux) {
+  if (build_embedder_examples) {
     public_deps += [ "//flutter/examples/glfw" ]
   }
 

--- a/examples/examples.gni
+++ b/examples/examples.gni
@@ -1,0 +1,9 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+declare_args() {
+  # The example embedders may use dependencies not suitable on all platforms.
+  # Use this GN arg to disable building the examples.
+  build_embedder_examples = is_mac || is_linux
+}

--- a/examples/glfw/BUILD.gn
+++ b/examples/glfw/BUILD.gn
@@ -2,13 +2,17 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-executable("glfw") {
-  output_name = "embedder_example"
+import("//flutter/examples/examples.gni")
 
-  sources = [ "FlutterEmbedderGLFW.cc" ]
+if (build_embedder_examples) {
+  executable("glfw") {
+    output_name = "embedder_example"
 
-  deps = [
-    "//flutter/shell/platform/embedder:embedder",
-    "//third_party/glfw",
-  ]
+    sources = [ "FlutterEmbedderGLFW.cc" ]
+
+    deps = [
+      "//flutter/shell/platform/embedder:embedder",
+      "//third_party/glfw",
+    ]
+  }
 }

--- a/tools/gn
+++ b/tools/gn
@@ -371,6 +371,9 @@ def to_gn_args(args):
     if args.build_glfw_shell is not None:
       gn_args['build_glfw_shell'] = args.build_glfw_shell
 
+    if args.build_embedder_examples is not None:
+      gn_args['build_embedder_examples'] = args.build_embedder_examples
+
     gn_args['stripped_symbols'] = args.stripped
 
     if args.msan:
@@ -503,6 +506,10 @@ def parse_args(args):
                       help='Build the GLFW shell on supported platforms where it is not built by default.')
   parser.add_argument('--no-build-glfw-shell', dest='build_glfw_shell', action='store_const', const=False,
                       help='Do not build the GLFW shell on platforms where it is built by default.')
+  parser.add_argument('--build-embedder-examples', action='store_const', const=True,
+                      help='Build the example embedders using the Embedder API.')
+  parser.add_argument('--no-build-embedder-examples', dest='build_embedder_examples', action='store_const', const=False,
+                      help='Do not build the example embedders using the Embedder API.')
 
   parser.add_argument('--bitcode', default=False, action='store_true',
                       help='Enable bitcode for iOS targets. On debug runtime modes, this will be a marker only.')


### PR DESCRIPTION
We recently started building the examples in the `examples` directory. However,
those examples use the GLFW dependency that not all embedders have. This broke
their build. Those builder may now use `--build-embedder-examples` to avoid
building the examples.

Fixes https://github.com/flutter/flutter/issues/95711
