### PR TITLE
[Win32, Keyboard] Correctly process modifier events in IME mode

### DIFF
--- a/shell/platform/windows/keyboard_win32_unittests.cc
+++ b/shell/platform/windows/keyboard_win32_unittests.cc
@@ -1545,7 +1545,7 @@ TEST(KeyboardTest, MultibyteCharacter) {
   tester.Responding(false);
 
   // Gothic Keyboard layout. (We need a layout that yields non-BMP characters
-  // without IME, which that is actually very rare.)
+  // without IME, which is actually very rare.)
 
   // Press key W of a US keyboard, which should yield character '𐍅'.
   tester.InjectMessages(
@@ -1615,6 +1615,33 @@ TEST(KeyboardTest, NeverRedispatchShiftRightKeyDown) {
   // Try to dispatch events. There should be nothing.
   EXPECT_EQ(tester.InjectPendingEvents(), 0);
   EXPECT_EQ(key_calls.size(), 0);
+}
+
+// Pressing modifiers during IME events should work properly by not sending any
+// events.
+//
+// Regression test for https://github.com/flutter/flutter/issues/95888 .
+TEST(KeyboardTest, ImeModifierEventsAreIgnored) {
+  KeyboardTester tester;
+  tester.Responding(false);
+
+  // US Keyboard layout.
+
+  // To make the keyboard into IME mode, there should have been events like
+  // letter key down with VK_PROCESSKEY. Omit them in this test since they don't
+  // seem significant.
+
+  // Press CtrlRight in IME mode.
+  tester.SetKeyState(VK_RCONTROL, true, false);
+  tester.InjectMessages(
+      1,
+      WmKeyDownInfo{VK_PROCESSKEY, kScanCodeControl, kExtended, kWasUp}.Build(
+          kWmResultZero));
+
+  EXPECT_EQ(key_calls.size(), 1);
+  EXPECT_CALL_IS_EVENT(key_calls[0], kFlutterKeyEventTypeDown, 0, 0, "",
+                       kNotSynthesized);
+  clear_key_calls();
 }
 
 TEST(KeyboardTest, DisorderlyRespondedEvents) {


### PR DESCRIPTION
Although the Win32 keyboard logic correctly ignores IME key events from letter keys (identified by virtual key `VK_PROCESSKEY`), it didn't handle modifier keys during IME mode well, which is a result of two mistakes:
1. It incorrectly synthesizes a key down event, since the key state is set, while the virtual key is not the usual virtual key for the modifier.
2. It incorrectly dispatches a non-synthesized key down event if the extended bit is set, because `result_logical_key` will not be `0xe5` but with an extended bit.

This PR fixes the first problem by moving the `VK_PROCESSKEY` branch to before modifier synthesization, and adding an exception rule to the logical key conversion. As a result, IME events will no longer trigger modifier synthesization at all. It's a little sad, but acceptable.

Fixes https://github.com/flutter/flutter/issues/95888.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
