### PR TITLE
[Android] Get the right frame_budget when device frame_rate is not 60

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -78,6 +78,7 @@ FILE: ../../../flutter/flow/frame_timings_recorder_unittests.cc
 FILE: ../../../flutter/flow/gl_context_switch_unittests.cc
 FILE: ../../../flutter/flow/instrumentation.cc
 FILE: ../../../flutter/flow/instrumentation.h
+FILE: ../../../flutter/flow/instrumentation_unittests.cc
 FILE: ../../../flutter/flow/layers/backdrop_filter_layer.cc
 FILE: ../../../flutter/flow/layers/backdrop_filter_layer.h
 FILE: ../../../flutter/flow/layers/backdrop_filter_layer_unittests.cc

--- a/flow/BUILD.gn
+++ b/flow/BUILD.gn
@@ -135,6 +135,7 @@ if (enable_unittests) {
       "flow_test_utils.h",
       "frame_timings_recorder_unittests.cc",
       "gl_context_switch_unittests.cc",
+      "instrumentation_unittests.cc",
       "layers/backdrop_filter_layer_unittests.cc",
       "layers/checkerboard_layertree_unittests.cc",
       "layers/clip_path_layer_unittests.cc",

--- a/flow/compositor_context.cc
+++ b/flow/compositor_context.cc
@@ -43,10 +43,12 @@ std::optional<SkRect> FrameDamage::ComputeClipRect(
   }
 }
 
-CompositorContext::CompositorContext() : raster_time_(), ui_time_() {}
+CompositorContext::CompositorContext()
+    : raster_time_(fixed_refresh_rate_updater_),
+      ui_time_(fixed_refresh_rate_updater_) {}
 
-CompositorContext::CompositorContext(Stopwatch::Delegate& delegate)
-    : raster_time_(&delegate), ui_time_(&delegate) {}
+CompositorContext::CompositorContext(Stopwatch::RefreshRateUpdater& updater)
+    : raster_time_(updater), ui_time_(updater) {}
 
 CompositorContext::~CompositorContext() = default;
 

--- a/flow/compositor_context.cc
+++ b/flow/compositor_context.cc
@@ -43,8 +43,10 @@ std::optional<SkRect> FrameDamage::ComputeClipRect(
   }
 }
 
-CompositorContext::CompositorContext(fml::Milliseconds frame_budget)
-    : raster_time_(frame_budget), ui_time_(frame_budget) {}
+CompositorContext::CompositorContext() : raster_time_(), ui_time_() {}
+
+CompositorContext::CompositorContext(Stopwatch::Delegate& delegate)
+    : raster_time_(&delegate), ui_time_(&delegate) {}
 
 CompositorContext::~CompositorContext() = default;
 

--- a/flow/compositor_context.h
+++ b/flow/compositor_context.h
@@ -138,8 +138,9 @@ class CompositorContext {
     FML_DISALLOW_COPY_AND_ASSIGN(ScopedFrame);
   };
 
-  explicit CompositorContext(
-      fml::Milliseconds frame_budget = fml::kDefaultFrameBudget);
+  CompositorContext();
+
+  explicit CompositorContext(Stopwatch::Delegate& delegate);
 
   virtual ~CompositorContext();
 

--- a/flow/compositor_context.h
+++ b/flow/compositor_context.h
@@ -140,7 +140,7 @@ class CompositorContext {
 
   CompositorContext();
 
-  explicit CompositorContext(Stopwatch::Delegate& delegate);
+  explicit CompositorContext(Stopwatch::RefreshRateUpdater& updater);
 
   virtual ~CompositorContext();
 
@@ -173,6 +173,9 @@ class CompositorContext {
   Counter frame_count_;
   Stopwatch raster_time_;
   Stopwatch ui_time_;
+
+  /// Only used by default constructor of `CompositorContext`.
+  FixedRefreshRateUpdater fixed_refresh_rate_updater_;
 
   void BeginFrame(ScopedFrame& frame, bool enable_instrumentation);
 

--- a/flow/instrumentation_unittests.cc
+++ b/flow/instrumentation_unittests.cc
@@ -1,0 +1,47 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/flow/instrumentation.h"
+#include "gtest/gtest.h"
+
+#include "gmock/gmock.h"
+
+using testing::Return;
+
+namespace flutter {
+namespace testing {
+
+class MockDelegate : public Stopwatch::Delegate {
+ public:
+  MOCK_METHOD0(GetFrameBudget, fml::Milliseconds());
+};
+
+TEST(Instrumentation, GetDefaultFrameBudgetTest) {
+  fml::Milliseconds frame_budget_60fps = fml::RefreshRateToFrameBudget(60);
+  // The default constructor sets the frame_budget to 16.6667 (60 fps).
+  Stopwatch stopwatch;
+  fml::Milliseconds actual_frame_budget = stopwatch.GetFrameBudget();
+  EXPECT_EQ(frame_budget_60fps, actual_frame_budget);
+}
+
+TEST(Instrumentation, GetOneShotFrameBudgetTest) {
+  fml::Milliseconds frame_budget_90fps = fml::RefreshRateToFrameBudget(90);
+  Stopwatch stopwatch(frame_budget_90fps);
+  fml::Milliseconds actual_frame_budget = stopwatch.GetFrameBudget();
+  EXPECT_EQ(frame_budget_90fps, actual_frame_budget);
+}
+
+TEST(Instrumentation, GetFrameBudgetFromDelegateTest) {
+  MockDelegate delegate;
+  fml::Milliseconds frame_budget_90fps = fml::RefreshRateToFrameBudget(90);
+  EXPECT_CALL(delegate, GetFrameBudget())
+      .Times(1)
+      .WillOnce(Return(frame_budget_90fps));
+  Stopwatch stopwatch(&delegate);
+  fml::Milliseconds actual_frame_budget = stopwatch.GetFrameBudget();
+  EXPECT_EQ(frame_budget_90fps, actual_frame_budget);
+}
+
+}  // namespace testing
+}  // namespace flutter

--- a/flow/instrumentation_unittests.cc
+++ b/flow/instrumentation_unittests.cc
@@ -3,42 +3,41 @@
 // found in the LICENSE file.
 
 #include "flutter/flow/instrumentation.h"
-#include "gtest/gtest.h"
-
 #include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using testing::Return;
 
 namespace flutter {
 namespace testing {
 
-class MockDelegate : public Stopwatch::Delegate {
+class MockRefreshRateUpdater : public Stopwatch::RefreshRateUpdater {
  public:
-  MOCK_METHOD0(GetFrameBudget, fml::Milliseconds());
+  MOCK_CONST_METHOD0(GetFrameBudget, fml::Milliseconds());
 };
 
 TEST(Instrumentation, GetDefaultFrameBudgetTest) {
   fml::Milliseconds frame_budget_60fps = fml::RefreshRateToFrameBudget(60);
   // The default constructor sets the frame_budget to 16.6667 (60 fps).
-  Stopwatch stopwatch;
+  FixedRefreshRateStopwatch stopwatch;
   fml::Milliseconds actual_frame_budget = stopwatch.GetFrameBudget();
   EXPECT_EQ(frame_budget_60fps, actual_frame_budget);
 }
 
 TEST(Instrumentation, GetOneShotFrameBudgetTest) {
   fml::Milliseconds frame_budget_90fps = fml::RefreshRateToFrameBudget(90);
-  Stopwatch stopwatch(frame_budget_90fps);
+  FixedRefreshRateStopwatch stopwatch(frame_budget_90fps);
   fml::Milliseconds actual_frame_budget = stopwatch.GetFrameBudget();
   EXPECT_EQ(frame_budget_90fps, actual_frame_budget);
 }
 
-TEST(Instrumentation, GetFrameBudgetFromDelegateTest) {
-  MockDelegate delegate;
+TEST(Instrumentation, GetFrameBudgetFromUpdaterTest) {
+  MockRefreshRateUpdater updater;
   fml::Milliseconds frame_budget_90fps = fml::RefreshRateToFrameBudget(90);
-  EXPECT_CALL(delegate, GetFrameBudget())
+  EXPECT_CALL(updater, GetFrameBudget())
       .Times(1)
       .WillOnce(Return(frame_budget_90fps));
-  Stopwatch stopwatch(&delegate);
+  Stopwatch stopwatch(updater);
   fml::Milliseconds actual_frame_budget = stopwatch.GetFrameBudget();
   EXPECT_EQ(frame_budget_90fps, actual_frame_budget);
 }

--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -102,7 +102,7 @@ sk_sp<SkPicture> LayerTree::Flatten(const SkRect& bounds) {
   }
 
   MutatorsStack unused_stack;
-  const Stopwatch unused_stopwatch;
+  const FixedRefreshRateStopwatch unused_stopwatch;
   TextureRegistry unused_texture_registry;
   SkMatrix root_surface_transformation;
   // No root surface transformation. So assume identity.

--- a/flow/layers/layer_tree_unittests.cc
+++ b/flow/layers/layer_tree_unittests.cc
@@ -19,7 +19,6 @@ class LayerTreeTest : public CanvasTest {
  public:
   LayerTreeTest()
       : layer_tree_(SkISize::Make(64, 64), 1.0f),
-        compositor_context_(fml::kDefaultFrameBudget),
         root_transform_(SkMatrix::Translate(1.0f, 1.0f)),
         scoped_frame_(compositor_context_.AcquireFrame(nullptr,
                                                        &mock_canvas(),

--- a/flow/layers/performance_overlay_layer_unittests.cc
+++ b/flow/layers/performance_overlay_layer_unittests.cc
@@ -10,11 +10,7 @@
 #include "flutter/flow/flow_test_utils.h"
 #include "flutter/flow/raster_cache.h"
 #include "flutter/flow/testing/layer_test.h"
-#include "flutter/flow/testing/mock_layer.h"
-#include "flutter/fml/build_config.h"
-#include "flutter/fml/macros.h"
 #include "flutter/testing/mock_canvas.h"
-#include "gtest/gtest.h"
 #include "third_party/skia/include/core/SkData.h"
 #include "third_party/skia/include/core/SkSerialProcs.h"
 #include "third_party/skia/include/core/SkSurface.h"
@@ -49,7 +45,7 @@ static void TestPerformanceOverlayLayerGold(int refresh_rate) {
   std::string golden_file_path = GetGoldenFilePath(refresh_rate, false);
   std::string new_golden_file_path = GetGoldenFilePath(refresh_rate, true);
 
-  flutter::Stopwatch mock_stopwatch(
+  FixedRefreshRateStopwatch mock_stopwatch(
       fml::RefreshRateToFrameBudget(refresh_rate));
   for (int i = 0; i < size(kMockedTimes); ++i) {
     mock_stopwatch.SetLapTime(

--- a/flow/testing/layer_test.h
+++ b/flow/testing/layer_test.h
@@ -136,8 +136,8 @@ class LayerTestBase : public CanvasTestBase<BaseT> {
     paint_context_.raster_cache = raster_cache_.get();
   }
 
-  Stopwatch raster_time_;
-  Stopwatch ui_time_;
+  FixedRefreshRateStopwatch raster_time_;
+  FixedRefreshRateStopwatch ui_time_;
   MutatorsStack mutators_stack_;
   TextureRegistry texture_registry_;
 

--- a/flow/testing/mock_raster_cache.cc
+++ b/flow/testing/mock_raster_cache.cc
@@ -66,8 +66,8 @@ void MockRasterCache::AddMockPicture(int width, int height) {
 }
 
 PrerollContextHolder GetSamplePrerollContextHolder() {
-  Stopwatch raster_time;
-  Stopwatch ui_time;
+  FixedRefreshRateStopwatch raster_time;
+  FixedRefreshRateStopwatch ui_time;
   MutatorsStack mutators_stack;
   TextureRegistry texture_registry;
   sk_sp<SkColorSpace> srgb = SkColorSpace::MakeSRGB();

--- a/flow/testing/mock_raster_cache.h
+++ b/flow/testing/mock_raster_cache.h
@@ -74,8 +74,8 @@ class MockRasterCache : public RasterCache {
   MockCanvas mock_canvas_;
   SkColorSpace* color_space_ = mock_canvas_.imageInfo().colorSpace();
   MutatorsStack mutators_stack_;
-  Stopwatch raster_time_;
-  Stopwatch ui_time_;
+  FixedRefreshRateStopwatch raster_time_;
+  FixedRefreshRateStopwatch ui_time_;
   TextureRegistry texture_registry_;
   PrerollContext preroll_context_ = {
       nullptr,           /* raster_cache */

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -14,7 +14,6 @@
 #include "flutter/fml/time/time_point.h"
 #include "flutter/shell/common/serialization_callbacks.h"
 #include "fml/make_copyable.h"
-#include "third_party/skia/include/core/SkEncodedImageFormat.h"
 #include "third_party/skia/include/core/SkImageEncoder.h"
 #include "third_party/skia/include/core/SkPictureRecorder.h"
 #include "third_party/skia/include/core/SkSerialProcs.h"
@@ -380,7 +379,7 @@ sk_sp<SkImage> Rasterizer::ConvertToRasterImage(sk_sp<SkImage> image) {
                               });
 }
 
-fml::Milliseconds Rasterizer::GetFrameBudget() {
+fml::Milliseconds Rasterizer::GetFrameBudget() const {
   return delegate_.GetFrameBudget();
 };
 

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -30,8 +30,7 @@ static constexpr std::chrono::milliseconds kSkiaCleanupExpiration(15000);
 
 Rasterizer::Rasterizer(Delegate& delegate)
     : delegate_(delegate),
-      compositor_context_(std::make_unique<flutter::CompositorContext>(
-          delegate.GetFrameBudget())),
+      compositor_context_(std::make_unique<flutter::CompositorContext>(*this)),
       user_override_resource_cache_bytes_(false),
       weak_factory_(this) {
   FML_DCHECK(compositor_context_);
@@ -380,6 +379,10 @@ sk_sp<SkImage> Rasterizer::ConvertToRasterImage(sk_sp<SkImage> image) {
                                 canvas->drawImage(image, 0, 0);
                               });
 }
+
+fml::Milliseconds Rasterizer::GetFrameBudget() {
+  return delegate_.GetFrameBudget();
+};
 
 RasterStatus Rasterizer::DoDraw(
     std::unique_ptr<FrameTimingsRecorder> frame_timings_recorder,

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -42,7 +42,8 @@ namespace flutter {
 /// and the on-screen render surface. The compositor context has all the GPU
 /// state necessary to render frames to the render surface.
 ///
-class Rasterizer final : public SnapshotDelegate, public Stopwatch::Delegate {
+class Rasterizer final : public SnapshotDelegate,
+                         public Stopwatch::RefreshRateUpdater {
  public:
   //----------------------------------------------------------------------------
   /// @brief      Used to forward events from the rasterizer to interested
@@ -464,7 +465,7 @@ class Rasterizer final : public SnapshotDelegate, public Stopwatch::Delegate {
   /// Time limit for a smooth frame.
   ///
   /// See: `DisplayManager::GetMainDisplayRefreshRate`.
-  fml::Milliseconds GetFrameBudget() override;
+  fml::Milliseconds GetFrameBudget() const override;
 
   sk_sp<SkData> ScreenshotLayerTreeAsImage(
       flutter::LayerTree* tree,

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -42,7 +42,7 @@ namespace flutter {
 /// and the on-screen render surface. The compositor context has all the GPU
 /// state necessary to render frames to the render surface.
 ///
-class Rasterizer final : public SnapshotDelegate {
+class Rasterizer final : public SnapshotDelegate, public Stopwatch::Delegate {
  public:
   //----------------------------------------------------------------------------
   /// @brief      Used to forward events from the rasterizer to interested
@@ -459,6 +459,12 @@ class Rasterizer final : public SnapshotDelegate {
 
   // |SnapshotDelegate|
   sk_sp<SkImage> ConvertToRasterImage(sk_sp<SkImage> image) override;
+
+  // |Stopwatch::Delegate|
+  /// Time limit for a smooth frame.
+  ///
+  /// See: `DisplayManager::GetMainDisplayRefreshRate`.
+  fml::Milliseconds GetFrameBudget() override;
 
   sk_sp<SkData> ScreenshotLayerTreeAsImage(
       flutter::LayerTree* tree,

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -2248,8 +2248,8 @@ TEST_F(ShellTest, OnServiceProtocolEstimateRasterCacheMemoryWorks) {
         auto* compositor_context = shell->GetRasterizer()->compositor_context();
         auto& raster_cache = compositor_context->raster_cache();
 
-        Stopwatch raster_time;
-        Stopwatch ui_time;
+        FixedRefreshRateStopwatch raster_time;
+        FixedRefreshRateStopwatch ui_time;
         MutatorsStack mutators_stack;
         TextureRegistry texture_registry;
         PrerollContext preroll_context = {


### PR DESCRIPTION
It fixes:
* https://github.com/flutter/flutter/issues/96857

Change the logic to query device refresh rate from `FlutterJNI` every time.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
