### PR TITLE
Disable building examples by default

### DIFF
--- a/examples/examples.gni
+++ b/examples/examples.gni
@@ -4,6 +4,6 @@
 
 declare_args() {
   # The example embedders may use dependencies not suitable on all platforms.
-  # Use this GN arg to disable building the examples.
-  build_embedder_examples = is_mac || is_linux
+  # Use this GN arg to enable building the examples.
+  build_embedder_examples = false
 }


### PR DESCRIPTION
This should be paired with a recipe change to enable building the example on CI that I'll prepare shortly.
