### PR TITLE
Prefix dart:ffi import to prevent name conflicts.

### DIFF
--- a/shell/platform/embedder/fixtures/main.dart
+++ b/shell/platform/embedder/fixtures/main.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:core';
-import 'dart:ffi';
+import 'dart:ffi' as ffi;
 import 'dart:io';
 import 'dart:isolate';
 import 'dart:typed_data';


### PR DESCRIPTION
https://dart.googlesource.com/sdk/+/85a87ca7ae6c9f028a0cbf6d8de3563b9a19b8e7 introduced Size to dart:ffi which conflicts with the one from dart:ui. See https://logs.chromium.org/logs/dart/buildbucket/cr-buildbucket/8824501487884216129/+/u/build_host_debug/stdout .

This will unblock dart->engine roll with that change.
