### PR TITLE
[WIP] Remove getSystemUiVisibility Usages

### DIFF
--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -351,7 +352,9 @@ public class FlutterViewTest {
   public void reportSystemInsetWhenNotFullscreen() {
     // Without custom shadows, the default system ui visibility flags is 0.
     FlutterView flutterView = new FlutterView(Robolectric.setupActivity(Activity.class));
-    assertEquals(0, flutterView.getSystemUiVisibility());
+    View.OnApplyWindowInsetsListener listenerMock = mock(View.OnApplyWindowInsetsListener.class);
+    flutterView.setOnApplyWindowInsetsListener(listenerMock);
+    verify(listenerMock, never()).onApplyWindowInsets(any(), any());
 
     FlutterEngine flutterEngine =
         spy(new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, mockFlutterJni));
@@ -390,7 +393,9 @@ public class FlutterViewTest {
   public void reportSystemInsetWhenNotFullscreenLegacy() {
     // Without custom shadows, the default system ui visibility flags is 0.
     FlutterView flutterView = new FlutterView(Robolectric.setupActivity(Activity.class));
-    assertEquals(0, flutterView.getSystemUiVisibility());
+    View.OnApplyWindowInsetsListener listenerMock = mock(View.OnApplyWindowInsetsListener.class);
+    flutterView.setOnApplyWindowInsetsListener(listenerMock);
+    verify(listenerMock, never()).onApplyWindowInsets(any(), any());
 
     FlutterEngine flutterEngine =
         spy(new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, mockFlutterJni));
@@ -423,7 +428,9 @@ public class FlutterViewTest {
     RuntimeEnvironment.setQualifiers("+land");
     FlutterView flutterView = spy(new FlutterView(RuntimeEnvironment.systemContext));
     setExpectedDisplayRotation(Surface.ROTATION_90);
-    assertEquals(0, flutterView.getSystemUiVisibility());
+    View.OnApplyWindowInsetsListener listenerMock = mock(View.OnApplyWindowInsetsListener.class);
+    flutterView.setOnApplyWindowInsetsListener(listenerMock);
+    verify(listenerMock, never()).onApplyWindowInsets(any(), any());
     when(flutterView.getWindowSystemUiVisibility())
         .thenReturn(View.SYSTEM_UI_FLAG_FULLSCREEN | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION);
     when(flutterView.getContext()).thenReturn(RuntimeEnvironment.systemContext);
@@ -461,7 +468,10 @@ public class FlutterViewTest {
     RuntimeEnvironment.setQualifiers("+land");
     FlutterView flutterView = spy(new FlutterView(RuntimeEnvironment.systemContext));
     setExpectedDisplayRotation(Surface.ROTATION_270);
-    assertEquals(0, flutterView.getSystemUiVisibility());
+    View.OnApplyWindowInsetsListener listenerMock = mock(View.OnApplyWindowInsetsListener.class);
+    flutterView.setOnApplyWindowInsetsListener(listenerMock);
+    verify(listenerMock, never()).onApplyWindowInsets(any(), any());
+
     when(flutterView.getWindowSystemUiVisibility())
         .thenReturn(View.SYSTEM_UI_FLAG_FULLSCREEN | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION);
     when(flutterView.getContext()).thenReturn(RuntimeEnvironment.systemContext);
@@ -499,7 +509,10 @@ public class FlutterViewTest {
     RuntimeEnvironment.setQualifiers("+land");
     FlutterView flutterView = spy(new FlutterView(RuntimeEnvironment.systemContext));
     setExpectedDisplayRotation(Surface.ROTATION_270);
-    assertEquals(0, flutterView.getSystemUiVisibility());
+    View.OnApplyWindowInsetsListener listenerMock = mock(View.OnApplyWindowInsetsListener.class);
+    flutterView.setOnApplyWindowInsetsListener(listenerMock);
+    verify(listenerMock, never()).onApplyWindowInsets(any(), any());
+
     when(flutterView.getWindowSystemUiVisibility())
         .thenReturn(View.SYSTEM_UI_FLAG_FULLSCREEN | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION);
     when(flutterView.getContext()).thenReturn(RuntimeEnvironment.systemContext);
@@ -540,7 +553,10 @@ public class FlutterViewTest {
     RuntimeEnvironment.setQualifiers("+land");
     FlutterView flutterView = spy(new FlutterView(RuntimeEnvironment.systemContext));
     setExpectedDisplayRotation(Surface.ROTATION_270);
-    assertEquals(0, flutterView.getSystemUiVisibility());
+    View.OnApplyWindowInsetsListener listenerMock = mock(View.OnApplyWindowInsetsListener.class);
+    flutterView.setOnApplyWindowInsetsListener(listenerMock);
+    verify(listenerMock, never()).onApplyWindowInsets(any(), any());
+
     when(flutterView.getWindowSystemUiVisibility())
         .thenReturn(View.SYSTEM_UI_FLAG_FULLSCREEN | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION);
     when(flutterView.getContext()).thenReturn(RuntimeEnvironment.systemContext);
@@ -578,7 +594,9 @@ public class FlutterViewTest {
     RuntimeEnvironment.setQualifiers("+land");
     FlutterView flutterView = spy(new FlutterView(RuntimeEnvironment.systemContext));
     setExpectedDisplayRotation(Surface.ROTATION_270);
-    assertEquals(0, flutterView.getSystemUiVisibility());
+    View.OnApplyWindowInsetsListener listenerMock = mock(View.OnApplyWindowInsetsListener.class);
+    flutterView.setOnApplyWindowInsetsListener(listenerMock);
+    verify(listenerMock, never()).onApplyWindowInsets(any(), any());
     when(flutterView.getWindowSystemUiVisibility())
         .thenReturn(View.SYSTEM_UI_FLAG_FULLSCREEN | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION);
     when(flutterView.getContext()).thenReturn(RuntimeEnvironment.systemContext);
@@ -617,7 +635,9 @@ public class FlutterViewTest {
   public void systemInsetDisplayCutoutSimple() {
     RuntimeEnvironment.setQualifiers("+land");
     FlutterView flutterView = spy(new FlutterView(RuntimeEnvironment.systemContext));
-    assertEquals(0, flutterView.getSystemUiVisibility());
+    View.OnApplyWindowInsetsListener listenerMock = mock(View.OnApplyWindowInsetsListener.class);
+    flutterView.setOnApplyWindowInsetsListener(listenerMock);
+    verify(listenerMock, never()).onApplyWindowInsets(any(), any());
     when(flutterView.getWindowSystemUiVisibility()).thenReturn(0);
     when(flutterView.getContext()).thenReturn(RuntimeEnvironment.systemContext);
 


### PR DESCRIPTION
The `PlatformPlugin` for Android currently uses functionality from the old Android View API as noted in [Issue #91128](https://github.com/flutter/flutter/issues/91128). This PR replaces one of those for API 20+ -- `getSystemUiVisibility()`.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
