### PR TITLE
[web] cache canvaskit detection

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/initialization.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/initialization.dart
@@ -16,15 +16,15 @@ import 'fonts.dart';
 
 /// Whether to use CanvasKit as the rendering backend.
 final bool useCanvasKit = FlutterConfiguration.flutterWebAutoDetect
-  ? _detectedRenderer
+  ? _hasCanvasKit
   : FlutterConfiguration.useSkia;
 
 /// Returns true if CanvasKit is used.
 ///
 /// Otherwise, returns false.
-final bool _detectedRenderer = _detectRenderer();
+final bool _hasCanvasKit = _detectCanvasKit();
 
-bool _detectRenderer() {
+bool _detectCanvasKit() {
   if (requestedRendererType != null) {
     return requestedRendererType! == 'canvaskit';
   }

--- a/lib/web_ui/lib/src/engine/canvaskit/initialization.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/initialization.dart
@@ -15,11 +15,15 @@ import 'canvaskit_api.dart';
 import 'fonts.dart';
 
 /// Whether to use CanvasKit as the rendering backend.
-bool get useCanvasKit => FlutterConfiguration.flutterWebAutoDetect ? _detectRenderer() : FlutterConfiguration.useSkia;
+final bool useCanvasKit = FlutterConfiguration.flutterWebAutoDetect
+  ? _detectedRenderer
+  : FlutterConfiguration.useSkia;
 
 /// Returns true if CanvasKit is used.
 ///
 /// Otherwise, returns false.
+final bool _detectedRenderer = _detectRenderer();
+
 bool _detectRenderer() {
   if (requestedRendererType != null) {
     return requestedRendererType! == 'canvaskit';


### PR DESCRIPTION
`_detectRenderer` is showing up in the top ~N hot functions. Since it appears that it only needs to run once (?), take advantage of lazy statics to cache the value once to avoid recomputing.


![image](https://user-images.githubusercontent.com/8975114/150405625-28e1f675-af8b-4e00-af44-5319aa4a0d76.png)
