### PR TITLE
Remove extraneous release of the MTLTexture in EmbedderTestBackingstoreProducer

### DIFF
--- a/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
+++ b/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
@@ -197,22 +197,15 @@ bool EmbedderTestBackingStoreProducer::CreateMTLTexture(
   // own MTLTexture and wrapping it.
   auto surface_size = SkISize::Make(config->size.width, config->size.height);
   auto texture_info = test_metal_context_->CreateMetalTexture(surface_size);
-  sk_cfp<FlutterMetalTextureHandle> texture;
-  texture.retain(texture_info.texture);
 
   GrMtlTextureInfo skia_texture_info;
-  skia_texture_info.fTexture = texture;
+  skia_texture_info.fTexture.reset(SkCFSafeRetain(texture_info.texture));
   GrBackendTexture backend_texture(surface_size.width(), surface_size.height(),
                                    GrMipmapped::kNo, skia_texture_info);
 
-  SkSurface::TextureReleaseProc release_mtltexture = [](void* user_data) {
-    SkCFSafeRelease(user_data);
-  };
-
   sk_sp<SkSurface> surface = SkSurface::MakeFromBackendTexture(
       context_.get(), backend_texture, kTopLeft_GrSurfaceOrigin, 1,
-      kBGRA_8888_SkColorType, nullptr, nullptr, release_mtltexture,
-      texture_info.texture);
+      kBGRA_8888_SkColorType, nullptr, nullptr);
 
   if (!surface) {
     FML_LOG(ERROR) << "Could not create Skia surface from a Metal texture.";


### PR DESCRIPTION
We don't need to explicitly pass in a texture release function as MTLTexture is a refcounted object that gets released without needing to do any additional work.

This brings the behaviour of this method in line with the other test code at https://github.com/flutter/engine/blob/main/testing/test_metal_surface_impl.mm#L42

https://github.com/flutter/flutter/issues/96807