### PR TITLE
DisplayList savelayer opacity peephole optimization

### DIFF
--- a/display_list/display_list.cc
+++ b/display_list/display_list.cc
@@ -11,11 +11,9 @@
 
 namespace flutter {
 
-const DisplayListSaveLayerFlags DisplayListSaveLayerFlags::kWithAttributes =
-    DisplayListSaveLayerFlags(
-        DisplayListSaveLayerFlags::kRendersWithAttributesFlag);
-const DisplayListSaveLayerFlags DisplayListSaveLayerFlags::kNoAttributes =
-    DisplayListSaveLayerFlags(0);
+const SaveLayerOptions SaveLayerOptions::kNoAttributes = SaveLayerOptions();
+const SaveLayerOptions SaveLayerOptions::kWithAttributes =
+    kNoAttributes.with_renders_with_attributes();
 
 const SkSamplingOptions DisplayList::NearestSampling =
     SkSamplingOptions(SkFilterMode::kNearest, SkMipmapMode::kNone);

--- a/display_list/display_list.cc
+++ b/display_list/display_list.cc
@@ -11,6 +11,12 @@
 
 namespace flutter {
 
+const DisplayListSaveLayerFlags DisplayListSaveLayerFlags::kWithAttributes =
+    DisplayListSaveLayerFlags(
+        DisplayListSaveLayerFlags::kRendersWithAttributesFlag);
+const DisplayListSaveLayerFlags DisplayListSaveLayerFlags::kNoAttributes =
+    DisplayListSaveLayerFlags(0);
+
 const SkSamplingOptions DisplayList::NearestSampling =
     SkSamplingOptions(SkFilterMode::kNearest, SkMipmapMode::kNone);
 const SkSamplingOptions DisplayList::LinearSampling =

--- a/display_list/display_list.h
+++ b/display_list/display_list.h
@@ -172,17 +172,11 @@ class SaveLayerOptions {
     return options;
   }
 
-  bool has_single_opacity_compatible_child() const {
-    return fHasSingleOpacityCompatibleChild;
-  }
-  SaveLayerOptions with_has_single_opacity_compatible_child() const {
+  bool can_distribute_opacity() const { return fCanDistributeOpacity; }
+  SaveLayerOptions with_can_distribute_opacity() const {
     SaveLayerOptions options(this);
-    options.fHasSingleOpacityCompatibleChild = true;
+    options.fCanDistributeOpacity = true;
     return options;
-  }
-
-  bool can_distribute_opacity() const {
-    return (fHasSingleOpacityCompatibleChild);
   }
 
   bool operator==(const SaveLayerOptions& other) const {
@@ -196,7 +190,7 @@ class SaveLayerOptions {
   union {
     struct {
       unsigned fRendersWithAttributes : 1;
-      unsigned fHasSingleOpacityCompatibleChild : 1;
+      unsigned fCanDistributeOpacity : 1;
     };
     uint32_t flags_;
   };

--- a/display_list/display_list.h
+++ b/display_list/display_list.h
@@ -192,7 +192,7 @@ class SaveLayerOptions {
   SaveLayerOptions with_children_can_render_opacity() const {
     SaveLayerOptions options(this);
     options.fChildrenCanRenderOpacity = true;
-    return *this;
+    return options;
   }
 
   bool can_distribute_opacity() const {

--- a/display_list/display_list.h
+++ b/display_list/display_list.h
@@ -172,41 +172,31 @@ class SaveLayerOptions {
     return options;
   }
 
-  bool has_single_child() const { return fHasSingleChild; }
-  SaveLayerOptions with_has_single_child() const {
-    SaveLayerOptions options(this);
-    options.fHasSingleChild = true;
-    return options;
+  bool has_single_opacity_compatible_child() const {
+    return fHasSingleOpacityCompatibleChild;
   }
-
-  bool has_nonoverlapping_children() const {
-    return fHasNonoverlappingChildren;
-  }
-  SaveLayerOptions with_has_nonoverlapping_children() const {
+  SaveLayerOptions with_has_single_opacity_compatible_child() const {
     SaveLayerOptions options(this);
-    options.fHasNonoverlappingChildren = true;
-    return options;
-  }
-
-  bool children_can_render_opacity() const { return fChildrenCanRenderOpacity; }
-  SaveLayerOptions with_children_can_render_opacity() const {
-    SaveLayerOptions options(this);
-    options.fChildrenCanRenderOpacity = true;
+    options.fHasSingleOpacityCompatibleChild = true;
     return options;
   }
 
   bool can_distribute_opacity() const {
-    return ((fHasSingleChild || fHasNonoverlappingChildren) &&
-            fChildrenCanRenderOpacity);
+    return (fHasSingleOpacityCompatibleChild);
+  }
+
+  bool operator==(const SaveLayerOptions& other) const {
+    return flags_ == other.flags_;
+  }
+  bool operator!=(const SaveLayerOptions& other) const {
+    return flags_ != other.flags_;
   }
 
  private:
   union {
     struct {
       unsigned fRendersWithAttributes : 1;
-      unsigned fHasSingleChild : 1;
-      unsigned fHasNonoverlappingChildren : 1;
-      unsigned fChildrenCanRenderOpacity : 1;
+      unsigned fHasSingleOpacityCompatibleChild : 1;
     };
     uint32_t flags_;
   };

--- a/display_list/display_list.h
+++ b/display_list/display_list.h
@@ -150,6 +150,45 @@ enum class DisplayListOpType { FOR_EACH_DISPLAY_LIST_OP(DL_OP_TO_ENUM_VALUE) };
 class Dispatcher;
 class DisplayListBuilder;
 
+class DisplayListSaveLayerFlags {
+ public:
+  static const uint32_t kRendersWithAttributesFlag = 0x1 << 0;
+  static const uint32_t kSingleChildFlag = 0x1 << 1;
+  static const uint32_t kNonoverlappingChildrenFlag = 0x1 << 2;
+  static const uint32_t kOpacityOptimizationFlag = 0x1 << 3;
+
+  static const DisplayListSaveLayerFlags kWithAttributes;
+  static const DisplayListSaveLayerFlags kNoAttributes;
+
+  explicit DisplayListSaveLayerFlags(uint32_t flags) : flags_(flags) {}
+
+  DisplayListSaveLayerFlags without_optimizations() {
+    return DisplayListSaveLayerFlags(flags_ & kRendersWithAttributesFlag);
+  }
+
+  uint32_t flags() { return flags_; }
+
+  DisplayListSaveLayerFlags with(DisplayListSaveLayerFlags other_flags) {
+    return DisplayListSaveLayerFlags(flags_ | other_flags.flags_);
+  }
+
+  DisplayListSaveLayerFlags with(uint32_t new_flags) {
+    return DisplayListSaveLayerFlags(flags_ | new_flags);
+  }
+
+  bool renders_with_attributes() {
+    return (flags_ & kRendersWithAttributesFlag) != 0;
+  }
+
+  bool can_distribute_opacity() {
+    return ((flags_ & (kSingleChildFlag | kNonoverlappingChildrenFlag)) != 0 &&
+            (flags_ & kOpacityOptimizationFlag) != 0);
+  }
+
+ private:
+  uint32_t flags_;
+};
+
 // The base class that contains a sequence of rendering operations
 // for dispatch to a Dispatcher. These objects must be instantiated
 // through an instance of DisplayListBuilder::build().

--- a/display_list/display_list_builder.cc
+++ b/display_list/display_list_builder.cc
@@ -239,6 +239,18 @@ void DisplayListBuilder::restore() {
     Push<RestoreOp>(0, 1);
     if (layer_info.has_layer) {
       if (layer_info.is_group_opacity_compatible()) {
+        // We are now going to go back and modify the matching saveLayer
+        // call to add the option indicating it can distribute an opacity
+        // value to its children.
+        //
+        // Note that this operation cannot and does not change the size
+        // or structure of the SaveLayerOp record. It only sets an option
+        // flag on an existing field.
+        //
+        // Note that these kinds of modification operations on data already
+        // in the DisplayList are only allowed *during* the build phase.
+        // Once built, the DisplayList records must remain read only to
+        // ensure consistency of rendering and |Equals()| behavior.
         SaveLayerOp* op = reinterpret_cast<SaveLayerOp*>(
             storage_.get() + layer_info.save_layer_offset);
         op->options = op->options.with_can_distribute_opacity();

--- a/display_list/display_list_builder.cc
+++ b/display_list/display_list_builder.cc
@@ -238,7 +238,7 @@ void DisplayListBuilder::restore() {
     current_layer_ = &layer_stack_.back();
     Push<RestoreOp>(0, 1);
     if (layer_info.has_layer) {
-      if (!layer_info.cannot_inherit_opacity) {
+      if (layer_info.is_group_opacity_compatible()) {
         SaveLayerOp* op = reinterpret_cast<SaveLayerOp*>(
             storage_.get() + layer_info.save_layer_offset);
         op->options = op->options  //
@@ -474,6 +474,8 @@ void DisplayListBuilder::drawVertices(const sk_sp<SkVertices> vertices,
   Push<DrawVerticesOp>(0, 1, std::move(vertices), mode);
   // DrawVertices applies its colors to the paint so we have no way
   // of controlling opacity using the current paint attributes.
+  // Although, examination of the |mode| might find some predictable
+  // cases.
   UpdateLayerOpacityCompatibility(false);
 }
 

--- a/display_list/display_list_builder.cc
+++ b/display_list/display_list_builder.cc
@@ -241,9 +241,7 @@ void DisplayListBuilder::restore() {
       if (layer_info.is_group_opacity_compatible()) {
         SaveLayerOp* op = reinterpret_cast<SaveLayerOp*>(
             storage_.get() + layer_info.save_layer_offset);
-        op->options = op->options  //
-                          .with_has_single_child()
-                          .with_children_can_render_opacity();
+        op->options = op->options.with_has_single_opacity_compatible_child();
       }
     } else {
       // For regular save() ops there was no protecting layer so we have to

--- a/display_list/display_list_builder.cc
+++ b/display_list/display_list_builder.cc
@@ -241,7 +241,7 @@ void DisplayListBuilder::restore() {
       if (layer_info.is_group_opacity_compatible()) {
         SaveLayerOp* op = reinterpret_cast<SaveLayerOp*>(
             storage_.get() + layer_info.save_layer_offset);
-        op->options = op->options.with_has_single_opacity_compatible_child();
+        op->options = op->options.with_can_distribute_opacity();
       }
     } else {
       // For regular save() ops there was no protecting layer so we have to

--- a/display_list/display_list_builder.h
+++ b/display_list/display_list_builder.h
@@ -287,7 +287,14 @@ class DisplayListBuilder final : public virtual Dispatcher,
           cannot_inherit_opacity(false),
           has_compatible_op(false) {}
 
+    // The offset into the memory buffer where the saveLayer DLOp record
+    // for this saveLayer() call is placed. This may be needed if the
+    // eventual restore() call has discovered important information about
+    // the records inside the saveLayer that may impact how the saveLayer
+    // is handled (e.g., |cannot_inherit_opacity| == false).
+    // This offset is only valid if |has_layer| is true.
     size_t save_layer_offset;
+
     bool has_layer;
     bool cannot_inherit_opacity;
     bool has_compatible_op;

--- a/display_list/display_list_builder.h
+++ b/display_list/display_list_builder.h
@@ -153,18 +153,16 @@ class DisplayListBuilder final : public virtual Dispatcher,
   sk_sp<SkImageFilter> getImageFilter() const { return current_image_filter_; }
 
   void save() override;
-  // Only the |kRendersWithAttributesFlag| should be specified here, using
-  // the convenient |kWithAttributes| and |kNoAttributes| constants. Any other
-  // flags will be ignored and calculated anew as the DisplayList is built.
-  // Alternatively, use the convenience |saveLayer(SkRect, bool)| method.
-  void saveLayer(const SkRect* bounds,
-                 DisplayListSaveLayerFlags flags) override;
+  // Only the |renders_with_attributes()| option will be accepted here. Any
+  // other flags will be ignored and calculated anew as the DisplayList is
+  // built. Alternatively, use the |saveLayer(SkRect, bool)| method.
+  void saveLayer(const SkRect* bounds, const SaveLayerOptions options) override;
   // Convenience method with just a boolean to indicate whether the saveLayer
   // should apply the rendering attributes.
   void saveLayer(const SkRect* bounds, bool renders_with_attributes) {
     saveLayer(bounds, renders_with_attributes
-                          ? DisplayListSaveLayerFlags::kWithAttributes
-                          : DisplayListSaveLayerFlags::kNoAttributes);
+                          ? SaveLayerOptions::kWithAttributes
+                          : SaveLayerOptions::kNoAttributes);
   }
   void restore() override;
   int getSaveCount() { return layer_stack_.size(); }

--- a/display_list/display_list_builder.h
+++ b/display_list/display_list_builder.h
@@ -153,12 +153,19 @@ class DisplayListBuilder final : public virtual Dispatcher,
   sk_sp<SkImageFilter> getImageFilter() const { return current_image_filter_; }
 
   void save() override;
-  // children_can_inherit_opacity should not be specified when
-  // building a DisplayList. The value will be ignored and
-  // calculated from the contents of the built DisplayList.
+  // Only the |kRendersWithAttributesFlag| should be specified here, using
+  // the convenient |kWithAttributes| and |kNoAttributes| constants. Any other
+  // flags will be ignored and calculated anew as the DisplayList is built.
+  // Alternatively, use the convenience |saveLayer(SkRect, bool)| method.
   void saveLayer(const SkRect* bounds,
-                 bool restore_with_paint,
-                 bool children_can_inherit_opacity = false) override;
+                 DisplayListSaveLayerFlags flags) override;
+  // Convenience method with just a boolean to indicate whether the saveLayer
+  // should apply the rendering attributes.
+  void saveLayer(const SkRect* bounds, bool renders_with_attributes) {
+    saveLayer(bounds, renders_with_attributes
+                          ? DisplayListSaveLayerFlags::kWithAttributes
+                          : DisplayListSaveLayerFlags::kNoAttributes);
+  }
   void restore() override;
   int getSaveCount() { return layer_stack_.size(); }
 

--- a/display_list/display_list_builder.h
+++ b/display_list/display_list_builder.h
@@ -153,7 +153,12 @@ class DisplayListBuilder final : public virtual Dispatcher,
   sk_sp<SkImageFilter> getImageFilter() const { return current_image_filter_; }
 
   void save() override;
-  void saveLayer(const SkRect* bounds, bool restore_with_paint) override;
+  // children_can_inherit_opacity should not be specified when
+  // building a DisplayList. The value will be ignored and
+  // calculated from the contents of the built DisplayList.
+  void saveLayer(const SkRect* bounds,
+                 bool restore_with_paint,
+                 bool children_can_inherit_opacity = false) override;
   void restore() override;
   int getSaveCount() { return layer_stack_.size(); }
 
@@ -271,11 +276,13 @@ class DisplayListBuilder final : public virtual Dispatcher,
   }
 
   struct LayerInfo {
-    LayerInfo(bool has_layer = false)
-        : has_layer(has_layer),
+    LayerInfo(size_t save_layer_offset = 0, bool has_layer = false)
+        : save_layer_offset(save_layer_offset),
+          has_layer(has_layer),
           cannot_inherit_opacity(false),
           has_compatible_op(false) {}
 
+    size_t save_layer_offset;
     bool has_layer;
     bool cannot_inherit_opacity;
     bool has_compatible_op;

--- a/display_list/display_list_canvas_dispatcher.cc
+++ b/display_list/display_list_canvas_dispatcher.cc
@@ -33,15 +33,13 @@ void DisplayListCanvasDispatcher::restore() {
   restore_opacity();
 }
 void DisplayListCanvasDispatcher::saveLayer(const SkRect* bounds,
-                                            bool restore_with_paint,
-                                            bool children_can_inherit_opacity) {
-  if (children_can_inherit_opacity) {
-    // FML_LOG(ERROR) << "Eliding a saveLayer";
+                                            DisplayListSaveLayerFlags flags) {
+  if (flags.can_distribute_opacity()) {
     canvas_->save();
     save_opacity(true, true);
   } else {
     TRACE_EVENT0("flutter", "Canvas::saveLayer");
-    canvas_->saveLayer(bounds, safe_paint(restore_with_paint));
+    canvas_->saveLayer(bounds, safe_paint(flags.renders_with_attributes()));
     save_opacity(true, false);
   }
 }

--- a/display_list/display_list_canvas_dispatcher.cc
+++ b/display_list/display_list_canvas_dispatcher.cc
@@ -26,17 +26,24 @@ const SkPaint* DisplayListCanvasDispatcher::safe_paint(bool use_attributes) {
 
 void DisplayListCanvasDispatcher::save() {
   canvas_->save();
-  save_opacity(false);
+  save_opacity(false, false);
 }
 void DisplayListCanvasDispatcher::restore() {
   canvas_->restore();
   restore_opacity();
 }
 void DisplayListCanvasDispatcher::saveLayer(const SkRect* bounds,
-                                            bool restore_with_paint) {
-  TRACE_EVENT0("flutter", "Canvas::saveLayer");
-  canvas_->saveLayer(bounds, safe_paint(restore_with_paint));
-  save_opacity(true);
+                                            bool restore_with_paint,
+                                            bool children_can_inherit_opacity) {
+  if (children_can_inherit_opacity) {
+    // FML_LOG(ERROR) << "Eliding a saveLayer";
+    canvas_->save();
+    save_opacity(true, true);
+  } else {
+    TRACE_EVENT0("flutter", "Canvas::saveLayer");
+    canvas_->saveLayer(bounds, safe_paint(restore_with_paint));
+    save_opacity(true, false);
+  }
 }
 
 void DisplayListCanvasDispatcher::translate(SkScalar tx, SkScalar ty) {

--- a/display_list/display_list_canvas_dispatcher.cc
+++ b/display_list/display_list_canvas_dispatcher.cc
@@ -45,7 +45,7 @@ void DisplayListCanvasDispatcher::saveLayer(const SkRect* bounds,
     // - no bounds is needed for clipping here
     // - the current attributes only have an alpha
     // - the children are compatible with individually rendering with
-    //   an inherited alpha
+    //   an inherited opacity
     // Therefore we can just use a save instead of a saveLayer and pass the
     // intended opacity to the children.
     canvas_->save();

--- a/display_list/display_list_canvas_dispatcher.h
+++ b/display_list/display_list_canvas_dispatcher.h
@@ -29,7 +29,9 @@ class DisplayListCanvasDispatcher : public virtual Dispatcher,
 
   void save() override;
   void restore() override;
-  void saveLayer(const SkRect* bounds, bool restore_with_paint) override;
+  void saveLayer(const SkRect* bounds,
+                 bool restore_with_paint,
+                 bool children_can_inherit_opacity) override;
 
   void translate(SkScalar tx, SkScalar ty) override;
   void scale(SkScalar sx, SkScalar sy) override;

--- a/display_list/display_list_canvas_dispatcher.h
+++ b/display_list/display_list_canvas_dispatcher.h
@@ -29,8 +29,7 @@ class DisplayListCanvasDispatcher : public virtual Dispatcher,
 
   void save() override;
   void restore() override;
-  void saveLayer(const SkRect* bounds,
-                 DisplayListSaveLayerFlags flags) override;
+  void saveLayer(const SkRect* bounds, const SaveLayerOptions options) override;
 
   void translate(SkScalar tx, SkScalar ty) override;
   void scale(SkScalar sx, SkScalar sy) override;

--- a/display_list/display_list_canvas_dispatcher.h
+++ b/display_list/display_list_canvas_dispatcher.h
@@ -30,8 +30,7 @@ class DisplayListCanvasDispatcher : public virtual Dispatcher,
   void save() override;
   void restore() override;
   void saveLayer(const SkRect* bounds,
-                 bool restore_with_paint,
-                 bool children_can_inherit_opacity) override;
+                 DisplayListSaveLayerFlags flags) override;
 
   void translate(SkScalar tx, SkScalar ty) override;
   void scale(SkScalar sx, SkScalar sy) override;

--- a/display_list/display_list_canvas_recorder.cc
+++ b/display_list/display_list_canvas_recorder.cc
@@ -61,10 +61,9 @@ SkCanvas::SaveLayerStrategy DisplayListCanvasRecorder::getSaveLayerStrategy(
     const SaveLayerRec& rec) {
   if (rec.fPaint) {
     builder_->setAttributesFromPaint(*rec.fPaint, kSaveLayerWithPaintFlags);
-    builder_->saveLayer(rec.fBounds,
-                        DisplayListSaveLayerFlags::kWithAttributes);
+    builder_->saveLayer(rec.fBounds, true);
   } else {
-    builder_->saveLayer(rec.fBounds, DisplayListSaveLayerFlags::kNoAttributes);
+    builder_->saveLayer(rec.fBounds, false);
   }
   return SaveLayerStrategy::kNoLayer_SaveLayerStrategy;
 }

--- a/display_list/display_list_canvas_recorder.cc
+++ b/display_list/display_list_canvas_recorder.cc
@@ -61,9 +61,10 @@ SkCanvas::SaveLayerStrategy DisplayListCanvasRecorder::getSaveLayerStrategy(
     const SaveLayerRec& rec) {
   if (rec.fPaint) {
     builder_->setAttributesFromPaint(*rec.fPaint, kSaveLayerWithPaintFlags);
-    builder_->saveLayer(rec.fBounds, true);
+    builder_->saveLayer(rec.fBounds,
+                        DisplayListSaveLayerFlags::kWithAttributes);
   } else {
-    builder_->saveLayer(rec.fBounds, false);
+    builder_->saveLayer(rec.fBounds, DisplayListSaveLayerFlags::kNoAttributes);
   }
   return SaveLayerStrategy::kNoLayer_SaveLayerStrategy;
 }

--- a/display_list/display_list_dispatcher.h
+++ b/display_list/display_list_dispatcher.h
@@ -56,17 +56,17 @@ class Dispatcher {
   // All of the following methods are nearly 1:1 with their counterparts
   // in |SkCanvas| and have the same behavior and output.
   virtual void save() = 0;
-  // The |flags| parameter can specify whether the existing rendering
+  // The |options| parameter can specify whether the existing rendering
   // attributes will be applied to the save layer surface while rendering
   // it back to the current surface. If the flag is false then this method
   // is equivalent to |SkCanvas::saveLayer| with a null paint object.
-  // The |flags| parameter may contain other flags that indicate some
+  // The |options| parameter may contain other options that indicate some
   // specific optimizations may be made by the underlying implementation
-  // to avoid creating a temporary layer, these optimization flags will
+  // to avoid creating a temporary layer, these optimization options will
   // be determined as the |DisplayList| is constructed and should not be
   // specified in calling a |DisplayListBuilder| as they will be ignored.
   virtual void saveLayer(const SkRect* bounds,
-                         DisplayListSaveLayerFlags flags) = 0;
+                         const SaveLayerOptions options) = 0;
   virtual void restore() = 0;
 
   virtual void translate(SkScalar tx, SkScalar ty) = 0;

--- a/display_list/display_list_dispatcher.h
+++ b/display_list/display_list_dispatcher.h
@@ -62,7 +62,9 @@ class Dispatcher {
   // rendering it back to the current surface. If the parameter is false
   // then this method is equivalent to |SkCanvas::saveLayer| with a null
   // paint object.
-  virtual void saveLayer(const SkRect* bounds, bool restore_with_paint) = 0;
+  virtual void saveLayer(const SkRect* bounds,
+                         bool restore_with_paint,
+                         bool children_can_inherit_opacity) = 0;
   virtual void restore() = 0;
 
   virtual void translate(SkScalar tx, SkScalar ty) = 0;

--- a/display_list/display_list_dispatcher.h
+++ b/display_list/display_list_dispatcher.h
@@ -5,8 +5,7 @@
 #ifndef FLUTTER_DISPLAY_LIST_DISPLAY_LIST_DISPATCHER_H_
 #define FLUTTER_DISPLAY_LIST_DISPLAY_LIST_DISPATCHER_H_
 
-#include "flutter/display_list/types.h"
-#include "flutter/fml/macros.h"
+#include "flutter/display_list/display_list.h"
 
 namespace flutter {
 
@@ -57,14 +56,17 @@ class Dispatcher {
   // All of the following methods are nearly 1:1 with their counterparts
   // in |SkCanvas| and have the same behavior and output.
   virtual void save() = 0;
-  // The |restore_with_paint| parameter determines whether the existing
-  // rendering attributes will be applied to the save layer surface while
-  // rendering it back to the current surface. If the parameter is false
-  // then this method is equivalent to |SkCanvas::saveLayer| with a null
-  // paint object.
+  // The |flags| parameter can specify whether the existing rendering
+  // attributes will be applied to the save layer surface while rendering
+  // it back to the current surface. If the flag is false then this method
+  // is equivalent to |SkCanvas::saveLayer| with a null paint object.
+  // The |flags| parameter may contain other flags that indicate some
+  // specific optimizations may be made by the underlying implementation
+  // to avoid creating a temporary layer, these optimization flags will
+  // be determined as the |DisplayList| is constructed and should not be
+  // specified in calling a |DisplayListBuilder| as they will be ignored.
   virtual void saveLayer(const SkRect* bounds,
-                         bool restore_with_paint,
-                         bool children_can_inherit_opacity) = 0;
+                         DisplayListSaveLayerFlags flags) = 0;
   virtual void restore() = 0;
 
   virtual void translate(SkScalar tx, SkScalar ty) = 0;

--- a/display_list/display_list_ops.h
+++ b/display_list/display_list_ops.h
@@ -215,26 +215,26 @@ struct SaveOp final : DLOp {
 struct SaveLayerOp final : DLOp {
   static const auto kType = DisplayListOpType::kSaveLayer;
 
-  explicit SaveLayerOp(DisplayListSaveLayerFlags flags) : flags(flags) {}
+  explicit SaveLayerOp(const SaveLayerOptions options) : options(options) {}
 
-  DisplayListSaveLayerFlags flags;
+  SaveLayerOptions options;
 
   void dispatch(Dispatcher& dispatcher) const {
-    dispatcher.saveLayer(nullptr, flags);
+    dispatcher.saveLayer(nullptr, options);
   }
 };
 // 4 byte header + 20 byte payload packs evenly into 24 bytes
 struct SaveLayerBoundsOp final : DLOp {
   static const auto kType = DisplayListOpType::kSaveLayerBounds;
 
-  SaveLayerBoundsOp(SkRect rect, DisplayListSaveLayerFlags flags)
-      : flags(flags), rect(rect) {}
+  SaveLayerBoundsOp(SkRect rect, const SaveLayerOptions options)
+      : options(options), rect(rect) {}
 
-  DisplayListSaveLayerFlags flags;
+  SaveLayerOptions options;
   const SkRect rect;
 
   void dispatch(Dispatcher& dispatcher) const {
-    dispatcher.saveLayer(&rect, flags);
+    dispatcher.saveLayer(&rect, options);
   }
 };
 // 4 byte header + no payload uses minimum 8 bytes (4 bytes unused)

--- a/display_list/display_list_ops.h
+++ b/display_list/display_list_ops.h
@@ -215,31 +215,26 @@ struct SaveOp final : DLOp {
 struct SaveLayerOp final : DLOp {
   static const auto kType = DisplayListOpType::kSaveLayer;
 
-  explicit SaveLayerOp(bool with_paint)
-      : with_paint(with_paint), children_can_inherit_opacity(false) {}
+  explicit SaveLayerOp(DisplayListSaveLayerFlags flags) : flags(flags) {}
 
-  uint16_t with_paint;
-  uint16_t children_can_inherit_opacity;
+  DisplayListSaveLayerFlags flags;
 
   void dispatch(Dispatcher& dispatcher) const {
-    dispatcher.saveLayer(nullptr, with_paint, children_can_inherit_opacity);
+    dispatcher.saveLayer(nullptr, flags);
   }
 };
 // 4 byte header + 20 byte payload packs evenly into 24 bytes
 struct SaveLayerBoundsOp final : DLOp {
   static const auto kType = DisplayListOpType::kSaveLayerBounds;
 
-  SaveLayerBoundsOp(SkRect rect, bool with_paint)
-      : with_paint(with_paint),
-        children_can_inherit_opacity(false),
-        rect(rect) {}
+  SaveLayerBoundsOp(SkRect rect, DisplayListSaveLayerFlags flags)
+      : flags(flags), rect(rect) {}
 
-  uint16_t with_paint;
-  uint16_t children_can_inherit_opacity;
+  DisplayListSaveLayerFlags flags;
   const SkRect rect;
 
   void dispatch(Dispatcher& dispatcher) const {
-    dispatcher.saveLayer(&rect, with_paint, children_can_inherit_opacity);
+    dispatcher.saveLayer(&rect, flags);
   }
 };
 // 4 byte header + no payload uses minimum 8 bytes (4 bytes unused)

--- a/display_list/display_list_ops.h
+++ b/display_list/display_list_ops.h
@@ -215,12 +215,14 @@ struct SaveOp final : DLOp {
 struct SaveLayerOp final : DLOp {
   static const auto kType = DisplayListOpType::kSaveLayer;
 
-  explicit SaveLayerOp(bool with_paint) : with_paint(with_paint) {}
+  explicit SaveLayerOp(bool with_paint)
+      : with_paint(with_paint), children_can_inherit_opacity(false) {}
 
-  bool with_paint;
+  uint16_t with_paint;
+  uint16_t children_can_inherit_opacity;
 
   void dispatch(Dispatcher& dispatcher) const {
-    dispatcher.saveLayer(nullptr, with_paint);
+    dispatcher.saveLayer(nullptr, with_paint, children_can_inherit_opacity);
   }
 };
 // 4 byte header + 20 byte payload packs evenly into 24 bytes
@@ -228,13 +230,16 @@ struct SaveLayerBoundsOp final : DLOp {
   static const auto kType = DisplayListOpType::kSaveLayerBounds;
 
   SaveLayerBoundsOp(SkRect rect, bool with_paint)
-      : with_paint(with_paint), rect(rect) {}
+      : with_paint(with_paint),
+        children_can_inherit_opacity(false),
+        rect(rect) {}
 
-  bool with_paint;
+  uint16_t with_paint;
+  uint16_t children_can_inherit_opacity;
   const SkRect rect;
 
   void dispatch(Dispatcher& dispatcher) const {
-    dispatcher.saveLayer(&rect, with_paint);
+    dispatcher.saveLayer(&rect, with_paint, children_can_inherit_opacity);
   }
 };
 // 4 byte header + no payload uses minimum 8 bytes (4 bytes unused)

--- a/display_list/display_list_unittests.cc
+++ b/display_list/display_list_unittests.cc
@@ -1626,7 +1626,8 @@ class SaveLayerOptionsExpector : public virtual Dispatcher,
                                  public IgnoreTransformDispatchHelper,
                                  public IgnoreDrawDispatchHelper {
  public:
-  SaveLayerOptionsExpector(SaveLayerOptions expected) : expected_(expected) {}
+  explicit SaveLayerOptionsExpector(SaveLayerOptions expected)
+      : expected_(expected) {}
 
   void saveLayer(const SkRect* bounds,
                  const SaveLayerOptions options) override {

--- a/display_list/display_list_unittests.cc
+++ b/display_list/display_list_unittests.cc
@@ -1643,8 +1643,8 @@ class SaveLayerOptionsExpector : public virtual Dispatcher,
 };
 
 TEST(DisplayList, SaveLayerOneSimpleOpSupportsOpacityOptimization) {
-  SaveLayerOptions expected = SaveLayerOptions::kWithAttributes
-                                  .with_has_single_opacity_compatible_child();
+  SaveLayerOptions expected =
+      SaveLayerOptions::kWithAttributes.with_can_distribute_opacity();
   SaveLayerOptionsExpector expector(expected);
 
   DisplayListBuilder builder;
@@ -1716,8 +1716,8 @@ TEST(DisplayList, SaveLayerSrcBlendPreventsOpacityOptimization) {
 }
 
 TEST(DisplayList, SaveLayerImageFilterOnChildSupportsOpacityOptimization) {
-  SaveLayerOptions expected = SaveLayerOptions::kWithAttributes
-                                  .with_has_single_opacity_compatible_child();
+  SaveLayerOptions expected =
+      SaveLayerOptions::kWithAttributes.with_can_distribute_opacity();
   SaveLayerOptionsExpector expector(expected);
 
   DisplayListBuilder builder;

--- a/display_list/display_list_utils.cc
+++ b/display_list/display_list_utils.cc
@@ -306,11 +306,10 @@ void DisplayListBoundsCalculator::save() {
   accumulator_ = layer_infos_.back()->layer_accumulator();
 }
 void DisplayListBoundsCalculator::saveLayer(const SkRect* bounds,
-                                            bool with_paint,
-                                            bool children_can_inherit_opacity) {
+                                            DisplayListSaveLayerFlags flags) {
   SkMatrixDispatchHelper::save();
   ClipBoundsDispatchHelper::save();
-  if (with_paint) {
+  if (flags.renders_with_attributes()) {
     layer_infos_.emplace_back(std::make_unique<SaveLayerData>(
         accumulator_, image_filter_, paint_nops_on_transparency()));
   } else {

--- a/display_list/display_list_utils.h
+++ b/display_list/display_list_utils.h
@@ -91,6 +91,73 @@ class IgnoreTransformDispatchHelper : public virtual Dispatcher {
   // clang-format on
 };
 
+class IgnoreDrawDispatchHelper : public virtual Dispatcher {
+ public:
+  void save() override {}
+  void saveLayer(const SkRect* bounds,
+                 const SaveLayerOptions options) override {}
+  void restore() override {}
+  void drawColor(SkColor color, SkBlendMode mode) override {}
+  void drawPaint() override {}
+  void drawLine(const SkPoint& p0, const SkPoint& p1) override {}
+  void drawRect(const SkRect& rect) override {}
+  void drawOval(const SkRect& bounds) override {}
+  void drawCircle(const SkPoint& center, SkScalar radius) override {}
+  void drawRRect(const SkRRect& rrect) override {}
+  void drawDRRect(const SkRRect& outer, const SkRRect& inner) override {}
+  void drawPath(const SkPath& path) override {}
+  void drawArc(const SkRect& oval_bounds,
+               SkScalar start_degrees,
+               SkScalar sweep_degrees,
+               bool use_center) override {}
+  void drawPoints(SkCanvas::PointMode mode,
+                  uint32_t count,
+                  const SkPoint points[]) override {}
+  void drawVertices(const sk_sp<SkVertices> vertices,
+                    SkBlendMode mode) override {}
+  void drawImage(const sk_sp<SkImage> image,
+                 const SkPoint point,
+                 const SkSamplingOptions& sampling,
+                 bool render_with_attributes) override {}
+  void drawImageRect(const sk_sp<SkImage> image,
+                     const SkRect& src,
+                     const SkRect& dst,
+                     const SkSamplingOptions& sampling,
+                     bool render_with_attributes,
+                     SkCanvas::SrcRectConstraint constraint) override {}
+  void drawImageNine(const sk_sp<SkImage> image,
+                     const SkIRect& center,
+                     const SkRect& dst,
+                     SkFilterMode filter,
+                     bool render_with_attributes) override {}
+  void drawImageLattice(const sk_sp<SkImage> image,
+                        const SkCanvas::Lattice& lattice,
+                        const SkRect& dst,
+                        SkFilterMode filter,
+                        bool render_with_attributes) override {}
+  void drawAtlas(const sk_sp<SkImage> atlas,
+                 const SkRSXform xform[],
+                 const SkRect tex[],
+                 const SkColor colors[],
+                 int count,
+                 SkBlendMode mode,
+                 const SkSamplingOptions& sampling,
+                 const SkRect* cull_rect,
+                 bool render_with_attributes) override {}
+  void drawPicture(const sk_sp<SkPicture> picture,
+                   const SkMatrix* matrix,
+                   bool render_with_attributes) override {}
+  void drawDisplayList(const sk_sp<DisplayList> display_list) override {}
+  void drawTextBlob(const sk_sp<SkTextBlob> blob,
+                    SkScalar x,
+                    SkScalar y) override {}
+  void drawShadow(const SkPath& path,
+                  const SkColor color,
+                  const SkScalar elevation,
+                  bool transparent_occluder,
+                  SkScalar dpr) override {}
+};
+
 // A utility class that will monitor the Dispatcher methods relating
 // to the rendering attributes and accumulate them into an SkPaint
 // which can be accessed at any time via paint().

--- a/display_list/display_list_utils.h
+++ b/display_list/display_list_utils.h
@@ -126,7 +126,7 @@ class SkPaintDispatchHelper : public virtual Dispatcher {
   bool has_opacity() { return opacity_ < SK_Scalar1; }
 
  protected:
-  void save_opacity(bool reset_and_restore);
+  void save_opacity(bool reset_and_restore, bool children_can_inherit_opacity);
   void restore_opacity();
 
  private:
@@ -324,7 +324,9 @@ class DisplayListBoundsCalculator final
   void setMaskBlurFilter(SkBlurStyle style, SkScalar sigma) override;
 
   void save() override;
-  void saveLayer(const SkRect* bounds, bool with_paint) override;
+  void saveLayer(const SkRect* bounds,
+                 bool with_paint,
+                 bool children_can_inherit_opacity) override;
   void restore() override;
 
   void drawPaint() override;

--- a/display_list/display_list_utils.h
+++ b/display_list/display_list_utils.h
@@ -325,8 +325,7 @@ class DisplayListBoundsCalculator final
 
   void save() override;
   void saveLayer(const SkRect* bounds,
-                 bool with_paint,
-                 bool children_can_inherit_opacity) override;
+                 DisplayListSaveLayerFlags flags) override;
   void restore() override;
 
   void drawPaint() override;

--- a/testing/dart/observatory/tracing_test.dart
+++ b/testing/dart/observatory/tracing_test.dart
@@ -29,8 +29,10 @@ void main() {
       canvas.drawColor(const Color(0xff0000ff), BlendMode.srcOut);
       canvas.drawPaint(Paint()..imageFilter = ImageFilter.blur(sigmaX: 2, sigmaY: 3));
       canvas.saveLayer(null, Paint());
+      canvas.drawRect(const Rect.fromLTRB(10, 10, 20, 20), Paint());
       canvas.saveLayer(const Rect.fromLTWH(0, 0, 100, 100), Paint());
       canvas.drawRect(const Rect.fromLTRB(10, 10, 20, 20), Paint());
+      canvas.drawRect(const Rect.fromLTRB(15, 15, 25, 25), Paint());
       canvas.restore();
       canvas.restore();
       final Picture picture = recorder.endRecording();


### PR DESCRIPTION
These changes introduce the ability for `saveLayer` calls within a DisplayList to implement opacity peephole optimization under very specific conditions. In particular, only a single encapsulated rendering primitive is allowed.

This mechanism will eventually be able to handle multiple overlapping primitives if the bounds calculations are factored into the determination. Currently overlap detection is difficult to do as the bounds are calculated inside a Dispatcher object which only sees the data stream from a DisplayList and cannot access its records to modify their state. In order for the bounds calculator to update the DisplayList to provide information about non-overlapping children it will either need to be incorporated directly into the Builder, or will have to use a new iteration process that allows Dispatcher implementations to update the records they are being dispatched from.