### PR TITLE
[Keyboard] Key guard only on Mac

### DIFF
--- a/lib/web_ui/lib/src/engine/initialization.dart
+++ b/lib/web_ui/lib/src/engine/initialization.dart
@@ -144,7 +144,7 @@ void initializeEngine() {
     }
   };
 
-  Keyboard.initialize(operatingSystem == OperatingSystem.macOs);
+  Keyboard.initialize(onMacOs: operatingSystem == OperatingSystem.macOs);
   MouseCursor.initialize();
 }
 

--- a/lib/web_ui/lib/src/engine/initialization.dart
+++ b/lib/web_ui/lib/src/engine/initialization.dart
@@ -6,6 +6,7 @@ import 'dart:developer' as developer;
 import 'dart:html' as html;
 import 'dart:typed_data';
 
+import 'package:ui/src/engine/browser_detection.dart';
 import 'package:ui/src/engine/embedder.dart';
 import 'package:ui/src/engine/keyboard.dart';
 import 'package:ui/src/engine/mouse_cursor.dart';
@@ -143,7 +144,7 @@ void initializeEngine() {
     }
   };
 
-  Keyboard.initialize();
+  Keyboard.initialize(operatingSystem == OperatingSystem.macOs);
   MouseCursor.initialize();
 }
 

--- a/lib/web_ui/lib/src/engine/keyboard.dart
+++ b/lib/web_ui/lib/src/engine/keyboard.dart
@@ -13,17 +13,17 @@ import 'services.dart';
 /// After a keydown is received, this is the duration we wait for a repeat event
 /// before we decide to synthesize a keyup event.
 ///
-/// On Linux and Windows, the typical ranges for keyboard repeat delay go up to
-/// 1000ms. On Mac, the range goes up to 2000ms.
-const Duration _keydownCancelDuration = Duration(milliseconds: 1000);
+/// This value is only for macOS, where the keyboard repeat delay goes up to
+/// 2000ms.
+const Duration _kKeydownCancelDurationMac = Duration(milliseconds: 1000);
 
 /// Provides keyboard bindings, such as the `flutter/keyevent` channel.
 class Keyboard {
   /// Initializes the [Keyboard] singleton.
   ///
   /// Use the [instance] getter to get the singleton after calling this method.
-  static void initialize() {
-    _instance ??= Keyboard._();
+  static void initialize(bool onMacOs) {
+    _instance ??= Keyboard._(onMacOs);
   }
 
   /// The [Keyboard] singleton.
@@ -39,7 +39,7 @@ class Keyboard {
   html.EventListener? _keydownListener;
   html.EventListener? _keyupListener;
 
-  Keyboard._() {
+  Keyboard._(this._onMacOs) {
     _keydownListener = (html.Event event) {
       _handleHtmlEvent(event);
     };
@@ -79,6 +79,20 @@ class Keyboard {
   /// Initializing with `0x0` which means no meta keys are pressed.
   int _lastMetaState = 0x0;
 
+  bool _onMacOs;
+
+  // When the user enters a browser/system shortcut (e.g. `cmd+alt+i`) on macOS,
+  // the browser doesn't send a keyup for it. This puts the framework in a
+  // corrupt state because it thinks the key was never released.
+  //
+  // To avoid this, we rely on the fact that browsers send repeat events
+  // while the key is held down by the user. If we don't receive a repeat
+  // event within a specific duration ([_kKeydownCancelDurationMac]) we assume
+  // the user has released the key and we synthesize a keyup event.
+  bool _shouldDoKeyGuard() {
+    return _onMacOs;
+  }
+
   void _handleHtmlEvent(html.Event event) {
     if (event is! html.KeyboardEvent) {
       return;
@@ -88,21 +102,13 @@ class Keyboard {
     final String timerKey = keyboardEvent.code!;
 
     // Don't handle synthesizing a keyup event for modifier keys
-    if (!_isModifierKey(event)) {
-      // When the user enters a browser/system shortcut (e.g. `cmd+alt+i`) the
-      // browser doesn't send a keyup for it. This puts the framework in a
-      // corrupt state because it thinks the key was never released.
-      //
-      // To avoid this, we rely on the fact that browsers send repeat events
-      // while the key is held down by the user. If we don't receive a repeat
-      // event within a specific duration ([_keydownCancelDuration]) we assume
-      // the user has released the key and we synthesize a keyup event.
+    if (!_isModifierKey(event) && _shouldDoKeyGuard()) {
       _keydownTimers[timerKey]?.cancel();
 
       // Only keys affected by modifiers, require synthesizing
       // because the browser always sends a keyup event otherwise
       if (event.type == 'keydown' && _isAffectedByModifiers(event)) {
-        _keydownTimers[timerKey] = Timer(_keydownCancelDuration, () {
+        _keydownTimers[timerKey] = Timer(_kKeydownCancelDurationMac, () {
           _keydownTimers.remove(timerKey);
           _synthesizeKeyup(event);
         });

--- a/lib/web_ui/lib/src/engine/keyboard.dart
+++ b/lib/web_ui/lib/src/engine/keyboard.dart
@@ -10,19 +10,12 @@ import '../engine.dart'  show registerHotRestartListener;
 import 'platform_dispatcher.dart';
 import 'services.dart';
 
-/// After a keydown is received, this is the duration we wait for a repeat event
-/// before we decide to synthesize a keyup event.
-///
-/// This value is only for macOS, where the keyboard repeat delay goes up to
-/// 2000ms.
-const Duration _kKeydownCancelDurationMac = Duration(milliseconds: 1000);
-
 /// Provides keyboard bindings, such as the `flutter/keyevent` channel.
 class Keyboard {
   /// Initializes the [Keyboard] singleton.
   ///
   /// Use the [instance] getter to get the singleton after calling this method.
-  static void initialize(bool onMacOs) {
+  static void initialize({bool onMacOs = false}) {
     _instance ??= Keyboard._(onMacOs);
   }
 
@@ -167,6 +160,13 @@ class Keyboard {
     EnginePlatformDispatcher.instance.invokeOnPlatformMessage('flutter/keyevent',
         _messageCodec.encodeMessage(eventData), _noopCallback);
   }
+
+  /// After a keydown is received, this is the duration we wait for a repeat event
+  /// before we decide to synthesize a keyup event.
+  ///
+  /// This value is only for macOS, where the keyboard repeat delay goes up to
+  /// 2000ms.
+  static const Duration _kKeydownCancelDurationMac = Duration(milliseconds: 2000);
 }
 
 const int _modifierNone = 0x00;

--- a/lib/web_ui/lib/src/engine/keyboard_binding.dart
+++ b/lib/web_ui/lib/src/engine/keyboard_binding.dart
@@ -43,13 +43,6 @@ final Map<int, _ModifierGetter> _kLogicalKeyToModifierGetter = <int, _ModifierGe
   _kLogicalMetaRight: (FlutterHtmlKeyboardEvent event) => event.metaKey,
 };
 
-/// After a keydown is received, this is the duration we wait for a repeat event
-/// before we decide to synthesize a keyup event.
-///
-/// This value is only for macOS, where the keyboard repeat delay goes up to
-/// 2000ms.
-const Duration _kKeydownCancelDurationMac = Duration(milliseconds: 2000);
-
 // ASCII for a, z, A, and Z
 const int _kCharLowerA = 0x61;
 const int _kCharLowerZ = 0x7a;
@@ -242,6 +235,13 @@ class KeyboardConverter {
   bool _shouldDoKeyGuard() {
     return onMacOs;
   }
+
+  /// After a keydown is received, this is the duration we wait for a repeat event
+  /// before we decide to synthesize a keyup event.
+  ///
+  /// This value is only for macOS, where the keyboard repeat delay goes up to
+  /// 2000ms.
+  static const Duration _kKeydownCancelDurationMac = Duration(milliseconds: 2000);
 
   static int _getPhysicalCode(String code) {
     return kWebToPhysicalKey[code] ?? (code.hashCode + _kWebKeyIdPlane);

--- a/lib/web_ui/lib/src/engine/keyboard_binding.dart
+++ b/lib/web_ui/lib/src/engine/keyboard_binding.dart
@@ -43,13 +43,12 @@ final Map<int, _ModifierGetter> _kLogicalKeyToModifierGetter = <int, _ModifierGe
   _kLogicalMetaRight: (FlutterHtmlKeyboardEvent event) => event.metaKey,
 };
 
-// After a keydown is received, this is the duration we wait for a repeat event
-// before we decide to synthesize a keyup event.
-//
-// On Linux and Windows, the typical ranges for keyboard repeat delay go up to
-// 1000ms. On Mac, the range goes up to 2000ms.
-const Duration _kKeydownCancelDurationNormal = Duration(milliseconds: 1000);
-const Duration _kKeydownCancelDurationMacOs = Duration(milliseconds: 2000);
+/// After a keydown is received, this is the duration we wait for a repeat event
+/// before we decide to synthesize a keyup event.
+///
+/// This value is only for macOS, where the keyboard repeat delay goes up to
+/// 2000ms.
+const Duration _kKeydownCancelDurationMac = Duration(milliseconds: 2000);
 
 // ASCII for a, z, A, and Z
 const int _kCharLowerA = 0x61;
@@ -230,7 +229,19 @@ class KeyboardConverter {
     return onMacOs;
   }
 
-  Duration get _keydownCancelDuration => onMacOs ? _kKeydownCancelDurationMacOs : _kKeydownCancelDurationNormal;
+  // ## About Key guards
+  //
+  // When the user enters a browser/system shortcut (e.g. `Cmd+Alt+i`) the
+  // browser doesn't send a keyup for it. This puts the framework in a corrupt
+  // state because it thinks the key was never released.
+  //
+  // To avoid this, we rely on the fact that browsers send repeat events
+  // while the key is held down by the user. If we don't receive a repeat
+  // event within a specific duration ([_keydownCancelDurationMac]) we assume
+  // the user has released the key and we synthesize a keyup event.
+  bool _shouldDoKeyGuard() {
+    return onMacOs;
+  }
 
   static int _getPhysicalCode(String code) {
     return kWebToPhysicalKey[code] ?? (code.hashCode + _kWebKeyIdPlane);
@@ -309,23 +320,15 @@ class KeyboardConverter {
     return () { canceled = true; };
   }
 
-  // ## About Key guards
-  //
-  // When the user enters a browser/system shortcut (e.g. `cmd+alt+i`) the
-  // browser doesn't send a keyup for it. This puts the framework in a corrupt
-  // state because it thinks the key was never released.
-  //
-  // To avoid this, we rely on the fact that browsers send repeat events
-  // while the key is held down by the user. If we don't receive a repeat
-  // event within a specific duration ([_keydownCancelDuration]) we assume
-  // the user has released the key and we synthesize a keyup event.
   final Map<int, _VoidCallback> _keyGuards = <int, _VoidCallback>{};
   // Call this method on the down or repeated event of a non-modifier key.
   void _startGuardingKey(int physicalKey, int logicalKey, Duration currentTimeStamp) {
+    if (!_shouldDoKeyGuard())
+      return;
     final _VoidCallback cancelingCallback = _scheduleAsyncEvent(
-      _keydownCancelDuration,
+      _kKeydownCancelDurationMac,
       () => ui.KeyData(
-        timeStamp: currentTimeStamp + _keydownCancelDuration,
+        timeStamp: currentTimeStamp + _kKeydownCancelDurationMac,
         type: ui.KeyEventType.up,
         physical: physicalKey,
         logical: logicalKey,

--- a/lib/web_ui/test/keyboard_converter_test.dart
+++ b/lib/web_ui/test/keyboard_converter_test.dart
@@ -615,12 +615,12 @@ void testMain() {
     );
   });
 
-  testFakeAsync('Key guards: key down events are guarded', (FakeAsync async) {
+  testFakeAsync('Key guards: key down events are guarded on macOS', (FakeAsync async) {
     final List<ui.KeyData> keyDataList = <ui.KeyData>[];
     final KeyboardConverter converter = KeyboardConverter((ui.KeyData key) {
       keyDataList.add(key);
       return true;
-    });
+    }, onMacOs: true);
 
     converter.handleEvent(keyDownEvent('MetaLeft', 'Meta', kMeta, kLocationLeft)..timeStamp = 100);
     async.elapse(const Duration(milliseconds: 100));
@@ -639,7 +639,7 @@ void testMain() {
 
     async.elapse(const Duration(milliseconds: 2500));
     expectKeyData(keyDataList.last,
-      timeStamp: const Duration(milliseconds: 1200),
+      timeStamp: const Duration(milliseconds: 2200),
       type: ui.KeyEventType.up,
       physical: kPhysicalKeyA,
       logical: kLogicalKeyA,
@@ -684,7 +684,7 @@ void testMain() {
     final KeyboardConverter converter = KeyboardConverter((ui.KeyData key) {
       keyDataList.add(key);
       return true;
-    });
+    }, onMacOs: true);
 
     converter.handleEvent(keyDownEvent('MetaLeft', 'Meta', kMeta, kLocationLeft)..timeStamp = 100);
     async.elapse(const Duration(milliseconds: 100));
@@ -700,9 +700,9 @@ void testMain() {
 
     // Keyup of KeyA is omitted due to being a shortcut.
 
-    async.elapse(const Duration(milliseconds: 2500));
+    async.elapse(const Duration(milliseconds: 2000));
     expectKeyData(keyDataList.last,
-      timeStamp: const Duration(milliseconds: 1700),
+      timeStamp: const Duration(milliseconds: 2700),
       type: ui.KeyEventType.up,
       physical: kPhysicalKeyA,
       logical: kLogicalKeyA,
@@ -797,6 +797,30 @@ void testMain() {
       logical: kLogicalKeyA,
       character: null,
     );
+  });
+
+  testFakeAsync('Key guards: key down events are not guarded on non-macOS', (FakeAsync async) {
+    final List<ui.KeyData> keyDataList = <ui.KeyData>[];
+    final KeyboardConverter converter = KeyboardConverter((ui.KeyData key) {
+      keyDataList.add(key);
+      return true;
+    }, onMacOs: false);
+
+    converter.handleEvent(keyDownEvent('MetaLeft', 'Meta', kMeta, kLocationLeft)..timeStamp = 100);
+    async.elapse(const Duration(milliseconds: 100));
+
+    converter.handleEvent(keyDownEvent('KeyA', 'a', kMeta)..timeStamp = 200);
+    expectKeyData(keyDataList.last,
+      timeStamp: const Duration(milliseconds: 200),
+      type: ui.KeyEventType.down,
+      physical: kPhysicalKeyA,
+      logical: kLogicalKeyA,
+      character: 'a',
+    );
+    keyDataList.clear();
+
+    async.elapse(const Duration(milliseconds: 2500));
+    expect(keyDataList, isEmpty);
   });
 
   testFakeAsync('Lock flags of other keys', (FakeAsync async) {


### PR DESCRIPTION
This PR limits the "key guarding" mechanism of the web embedding to macOS only.

The web embedding uses a mechanism called "key guarding". On macOS, when the user presses a shortcut, such as "Cmd-C", the keyup event of the letter key will not be sent from the system. The key guarding mechanism synthesizes an up event if no repeated events are received for a period of time.

The omission of the keyup events have only been observed on macOS as far as I know. Therefore we should limit its appliance.

Partially fixes https://github.com/flutter/flutter/issues/96724.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
