### PR TITLE
[Win32, Keyboard] Fix text submission

### DIFF
--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -381,7 +381,7 @@ void FlutterWindowsView::SendKey(int key,
                                  KeyEventCallback callback) {
   keyboard_key_handler_->KeyboardHook(
       key, scancode, action, character, extended, was_down,
-      [&, callback = std::move(callback)](bool handled) {
+      [=, callback = std::move(callback)](bool handled) {
         if (!handled) {
           text_input_plugin_->KeyboardHook(key, scancode, action, character,
                                            extended, was_down);

--- a/shell/platform/windows/keyboard_win32_unittests.cc
+++ b/shell/platform/windows/keyboard_win32_unittests.cc
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "flutter/shell/platform/common/json_message_codec.h"
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/embedder/test_utils/key_codes.h"
 #include "flutter/shell/platform/windows/flutter_windows_engine.h"
@@ -16,6 +17,8 @@
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "rapidjson/stringbuffer.h"
+#include "rapidjson/writer.h"
 
 #include <functional>
 #include <vector>
@@ -188,6 +191,35 @@ class TestFlutterWindowsView : public FlutterWindowsView {
     key_state_.Set(key, pressed, toggled_on);
   }
 
+  void HandleMessage(const char* channel,
+                     const char* method,
+                     const char* args) {
+    rapidjson::Document args_doc;
+    args_doc.Parse(args);
+    assert(!args_doc.HasParseError());
+
+    rapidjson::Document message_doc(rapidjson::kObjectType);
+    auto& allocator = message_doc.GetAllocator();
+    message_doc.AddMember("method", rapidjson::Value(method, allocator), allocator);
+    message_doc.AddMember("args", args_doc, allocator);
+
+    rapidjson::StringBuffer buffer;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+    message_doc.Accept(writer);
+
+    std::unique_ptr<std::vector<uint8_t>> data =
+        JsonMessageCodec::GetInstance().EncodeMessage(message_doc);
+    FlutterPlatformMessageResponseHandle response_handle;
+    const FlutterPlatformMessage message = {
+        sizeof(FlutterPlatformMessage),  // struct_size
+        channel,                         // channel
+        data->data(),                    // message
+        data->size(),                    // message_size
+        &response_handle,                // response_handle
+    };
+    GetEngine()->HandlePlatformMessage(&message);
+  }
+
  protected:
   std::unique_ptr<KeyboardHandlerBase> CreateKeyboardKeyHandler(
       BinaryMessenger* messenger,
@@ -204,16 +236,16 @@ class TestFlutterWindowsView : public FlutterWindowsView {
 typedef enum {
   kKeyCallOnKey,
   kKeyCallOnText,
-  kKeyCallMethodTextInput,
+  kKeyCallTextMethodCall,
 } KeyCallType;
 
 typedef struct {
   KeyCallType type;
 
   // Only one of the following fields should be assigned.
-  FlutterKeyEvent key_event;
-  std::u16string text;
-  std::unique_ptr<rapidjson::Document> document;
+  FlutterKeyEvent key_event;      // For kKeyCallOnKey
+  std::u16string text;            // For kKeyCallOnText
+  std::string text_method_call;   // For kKeyCallTextMethodCall
 } KeyCall;
 
 static std::vector<KeyCall> key_calls;
@@ -257,6 +289,8 @@ class KeyboardTester {
         }));
     window_ = std::make_unique<MockKeyboardManagerWin32Delegate>(view_.get());
   }
+
+  TestFlutterWindowsView& GetView() { return *view_; }
 
   void SetKeyState(uint32_t key, bool pressed, bool toggled_on) {
     view_->SetKeyState(key, pressed, toggled_on);
@@ -326,9 +360,12 @@ class KeyboardTester {
         std::move(embedder_callback_handler));
     key_response_controller->SetTextInputResponse(
         [](std::unique_ptr<rapidjson::Document> document) {
+          rapidjson::StringBuffer buffer;
+          rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+          document->Accept(writer);
           key_calls.push_back(KeyCall{
-              .type = kKeyCallMethodTextInput,
-              .document = std::move(document),
+              .type = kKeyCallTextMethodCall,
+              .text_method_call = buffer.GetString(),
           });
         });
 
@@ -364,6 +401,7 @@ constexpr uint64_t kScanCodeShiftLeft = 0x2a;
 constexpr uint64_t kScanCodeShiftRight = 0x36;
 constexpr uint64_t kScanCodeBracketLeft = 0x1a;
 constexpr uint64_t kScanCodeArrowLeft = 0x4b;
+constexpr uint64_t kScanCodeEnter = 0x1c;
 
 constexpr uint64_t kVirtualDigit1 = 0x31;
 constexpr uint64_t kVirtualKeyA = 0x41;
@@ -387,6 +425,10 @@ constexpr bool kNotSynthesized = false;
 #define EXPECT_CALL_IS_TEXT(_key_call, u16_string) \
   EXPECT_EQ(_key_call.type, kKeyCallOnText);       \
   EXPECT_EQ(_key_call.text, u16_string);
+
+#define EXPECT_CALL_IS_TEXT_METHOD_CALL(_key_call, json_string) \
+  EXPECT_EQ(_key_call.type, kKeyCallTextMethodCall);       \
+  EXPECT_STREQ(_key_call.text_method_call.c_str(), json_string);
 
 TEST(KeyboardTest, LowerCaseAHandled) {
   KeyboardTester tester;
@@ -1755,6 +1797,34 @@ TEST(KeyboardTest, SlowFrameworkResponse) {
   EXPECT_EQ(tester.InjectPendingEvents('a'), 2);
   EXPECT_EQ(key_calls.size(), 1);
   EXPECT_CALL_IS_TEXT(key_calls[0], u"a");
+  clear_key_calls();
+}
+
+TEST(KeyboardTest, TextInputSubmit) {
+  KeyboardTester tester;
+  tester.Responding(false);
+
+  // US Keyboard layout
+
+  tester.GetView().HandleMessage(
+      "flutter/textinput", "TextInput.setClient",
+      R"|([108, {"inputAction": "TextInputAction.none"}])|");
+
+  // Press Enter
+  tester.InjectMessages(
+      1, WmKeyDownInfo{VK_RETURN, kScanCodeEnter, kNotExtended, kWasUp}.Build(
+             kWmResultZero));
+
+  EXPECT_EQ(key_calls.size(), 2);
+  EXPECT_CALL_IS_EVENT(key_calls[0], kFlutterKeyEventTypeDown,
+                       kPhysicalEnter, kLogicalEnter, "",
+                       kNotSynthesized);
+  EXPECT_CALL_IS_TEXT_METHOD_CALL(
+      key_calls[1],
+      "{"
+      R"|("method":"TextInputClient.performAction",)|"
+      R"|("args":[108,"TextInputAction.none"])|"
+      "}");
   clear_key_calls();
 }
 

--- a/shell/platform/windows/keyboard_win32_unittests.cc
+++ b/shell/platform/windows/keyboard_win32_unittests.cc
@@ -200,7 +200,8 @@ class TestFlutterWindowsView : public FlutterWindowsView {
 
     rapidjson::Document message_doc(rapidjson::kObjectType);
     auto& allocator = message_doc.GetAllocator();
-    message_doc.AddMember("method", rapidjson::Value(method, allocator), allocator);
+    message_doc.AddMember("method", rapidjson::Value(method, allocator),
+                          allocator);
     message_doc.AddMember("args", args_doc, allocator);
 
     rapidjson::StringBuffer buffer;
@@ -243,9 +244,9 @@ typedef struct {
   KeyCallType type;
 
   // Only one of the following fields should be assigned.
-  FlutterKeyEvent key_event;      // For kKeyCallOnKey
-  std::u16string text;            // For kKeyCallOnText
-  std::string text_method_call;   // For kKeyCallTextMethodCall
+  FlutterKeyEvent key_event;     // For kKeyCallOnKey
+  std::u16string text;           // For kKeyCallOnText
+  std::string text_method_call;  // For kKeyCallTextMethodCall
 } KeyCall;
 
 static std::vector<KeyCall> key_calls;
@@ -427,7 +428,7 @@ constexpr bool kNotSynthesized = false;
   EXPECT_EQ(_key_call.text, u16_string);
 
 #define EXPECT_CALL_IS_TEXT_METHOD_CALL(_key_call, json_string) \
-  EXPECT_EQ(_key_call.type, kKeyCallTextMethodCall);       \
+  EXPECT_EQ(_key_call.type, kKeyCallTextMethodCall);            \
   EXPECT_STREQ(_key_call.text_method_call.c_str(), json_string);
 
 TEST(KeyboardTest, LowerCaseAHandled) {
@@ -1816,9 +1817,8 @@ TEST(KeyboardTest, TextInputSubmit) {
              kWmResultZero));
 
   EXPECT_EQ(key_calls.size(), 2);
-  EXPECT_CALL_IS_EVENT(key_calls[0], kFlutterKeyEventTypeDown,
-                       kPhysicalEnter, kLogicalEnter, "",
-                       kNotSynthesized);
+  EXPECT_CALL_IS_EVENT(key_calls[0], kFlutterKeyEventTypeDown, kPhysicalEnter,
+                       kLogicalEnter, "", kNotSynthesized);
   EXPECT_CALL_IS_TEXT_METHOD_CALL(
       key_calls[1],
       "{"

--- a/shell/platform/windows/keyboard_win32_unittests.cc
+++ b/shell/platform/windows/keyboard_win32_unittests.cc
@@ -204,6 +204,7 @@ class TestFlutterWindowsView : public FlutterWindowsView {
 typedef enum {
   kKeyCallOnKey,
   kKeyCallOnText,
+  kKeyCallMethodTextInput,
 } KeyCallType;
 
 typedef struct {
@@ -212,6 +213,7 @@ typedef struct {
   // Only one of the following fields should be assigned.
   FlutterKeyEvent key_event;
   std::u16string text;
+  std::unique_ptr<rapidjson::Document> document;
 } KeyCall;
 
 static std::vector<KeyCall> key_calls;
@@ -322,6 +324,13 @@ class KeyboardTester {
         std::make_shared<MockKeyResponseController>();
     key_response_controller->SetEmbedderResponse(
         std::move(embedder_callback_handler));
+    key_response_controller->SetTextInputResponse(
+        [](std::unique_ptr<rapidjson::Document> document) {
+          key_calls.push_back(KeyCall{
+              .type = kKeyCallMethodTextInput,
+              .document = std::move(document),
+          });
+        });
 
     MockEmbedderApiForKeyboard(modifier, key_response_controller);
 

--- a/shell/platform/windows/testing/test_keyboard.cc
+++ b/shell/platform/windows/testing/test_keyboard.cc
@@ -131,6 +131,17 @@ void MockEmbedderApiForKeyboard(
               });
           return kSuccess;
         }
+        if (std::string(message->channel) == std::string("flutter/textinput")) {
+          std::unique_ptr<rapidjson::Document> document =
+              flutter::JsonMessageCodec::GetInstance().DecodeMessage(
+                  message->message, message->message_size);
+          if (document == nullptr) {
+            return kInvalidArguments;
+          }
+          stored_response_controller->HandleTextInputMessage(
+              std::move(document));
+          return kSuccess;
+        }
         return kSuccess;
       };
 

--- a/shell/platform/windows/testing/test_keyboard.h
+++ b/shell/platform/windows/testing/test_keyboard.h
@@ -16,9 +16,13 @@
 
 #include "gtest/gtest.h"
 
+struct _FlutterPlatformMessageResponseHandle {
+  FlutterDesktopBinaryReply callback;
+  void* user_data;
+};
+
 namespace flutter {
 namespace testing {
-
 ::testing::AssertionResult _EventEquals(const char* expr_event,
                                         const char* expr_expected,
                                         const FlutterKeyEvent& event,

--- a/shell/platform/windows/testing/test_keyboard.h
+++ b/shell/platform/windows/testing/test_keyboard.h
@@ -48,10 +48,14 @@ class MockKeyResponseController {
   using EmbedderCallbackHandler =
       std::function<void(const FlutterKeyEvent*, ResponseCallback)>;
   using ChannelCallbackHandler = std::function<void(ResponseCallback)>;
+  using TextInputCallbackHandler =
+      std::function<void(std::unique_ptr<rapidjson::Document>)>;
 
   MockKeyResponseController()
       : channel_response_(ChannelRespondFalse),
-        embedder_response_(EmbedderRespondFalse) {}
+        embedder_response_(EmbedderRespondFalse),
+        text_input_response_(
+            [](std::unique_ptr<rapidjson::Document> document) {}) {}
 
   void SetChannelResponse(ChannelCallbackHandler handler) {
     channel_response_ = std::move(handler);
@@ -59,6 +63,10 @@ class MockKeyResponseController {
 
   void SetEmbedderResponse(EmbedderCallbackHandler handler) {
     embedder_response_ = std::move(handler);
+  }
+
+  void SetTextInputResponse(TextInputCallbackHandler handler) {
+    text_input_response_ = std::move(handler);
   }
 
   void HandleChannelMessage(ResponseCallback callback) {
@@ -70,9 +78,14 @@ class MockKeyResponseController {
     embedder_response_(event, std::move(callback));
   }
 
+  void HandleTextInputMessage(std::unique_ptr<rapidjson::Document> document) {
+    text_input_response_(std::move(document));
+  }
+
  private:
   EmbedderCallbackHandler embedder_response_;
   ChannelCallbackHandler channel_response_;
+  TextInputCallbackHandler text_input_response_;
 
   static void ChannelRespondFalse(ResponseCallback callback) {
     callback(false);


### PR DESCRIPTION
This PR fixes https://github.com/flutter/flutter/issues/96726.

This PR also adds a new kind of KeyCall, which records method channel invocation from `TextInputPlugin`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
