### PR TITLE
Adds scripts for cross-arch macOS framework

### DIFF
--- a/sky/tools/create_macos_framework.py
+++ b/sky/tools/create_macos_framework.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+#
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import argparse
+import subprocess
+import shutil
+import sys
+import os
+
+from create_xcframework import create_xcframework
+
+DSYMUTIL = os.path.join(os.path.dirname(__file__), '..', '..', '..',
+                        'buildtools', 'mac-x64', 'clang', 'bin', 'dsymutil')
+
+def main():
+  parser = argparse.ArgumentParser(description='Creates FlutterMacOS.framework for macOS')
+
+  parser.add_argument('--dst', type=str, required=True)
+  parser.add_argument('--arm64-out-dir', type=str, required=True)
+  parser.add_argument('--x64-out-dir', type=str, required=True)
+  parser.add_argument('--strip', action="store_true", default=False)
+  parser.add_argument('--dsym', action="store_true", default=False)
+
+  args = parser.parse_args()
+
+  fat_framework = os.path.join(args.dst, 'FlutterMacOS.framework')
+  arm64_framework = os.path.join(args.arm64_out_dir, 'FlutterMacOS.framework')
+  x64_framework = os.path.join(args.x64_out_dir, 'FlutterMacOS.framework')
+
+  arm64_dylib = os.path.join(arm64_framework, 'FlutterMacOS')
+  x64_dylib = os.path.join(x64_framework, 'FlutterMacOS')
+
+  if not os.path.isdir(arm64_framework):
+    print('Cannot find macOS arm64 Framework at %s' % arm64_framework)
+    return 1
+
+  if not os.path.isdir(x64_framework):
+    print('Cannot find macOS x64 Framework at %s' % x64_framework)
+    return 1
+
+  if not os.path.isfile(arm64_dylib):
+    print('Cannot find macOS arm64 dylib at %s' % arm64_dylib)
+    return 1
+
+  if not os.path.isfile(x64_dylib):
+    print('Cannot find macOS x64 dylib at %s' % x64_dylib)
+    return 1
+
+  if not os.path.isfile(DSYMUTIL):
+    print('Cannot find dsymutil at %s' % DSYMUTIL)
+    return 1
+
+  shutil.rmtree(fat_framework, True)
+  shutil.copytree(arm64_framework, fat_framework, symlinks=True)
+
+  fat_framework_binary = os.path.join(fat_framework, 'Versions', 'A', 'FlutterMacOS')
+
+  # Create the arm64/x64 fat framework.
+  subprocess.check_call([
+    'lipo',
+    arm64_dylib,
+    x64_dylib,
+    '-create',
+    '-output',
+    fat_framework_binary
+  ])
+  process_framework(args, fat_framework, fat_framework_binary)
+
+
+def process_framework(args, fat_framework, fat_framework_binary):
+  if args.dsym:
+    dsym_out = os.path.splitext(fat_framework)[0] + '.dSYM'
+    subprocess.check_call([DSYMUTIL, '-o', dsym_out, fat_framework_binary])
+
+  if args.strip:
+    # copy unstripped
+    unstripped_out = os.path.join(args.dst, 'FlutterMacOS.unstripped')
+    shutil.copyfile(fat_framework_binary, unstripped_out)
+
+    subprocess.check_call(["strip", "-x", "-S", fat_framework_binary])
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/sky/tools/create_macos_gen_snapshots.py
+++ b/sky/tools/create_macos_gen_snapshots.py
@@ -11,28 +11,45 @@ import os
 
 
 def main():
-  parser = argparse.ArgumentParser(description='Copies architecture-dependent gen_snapshot binaries to output dir')
+  parser = argparse.ArgumentParser(
+      description='Copies architecture-dependent gen_snapshot binaries to output dir'
+  )
 
   parser.add_argument('--dst', type=str, required=True)
+  parser.add_argument('--x64-out-dir', type=str)
   parser.add_argument('--arm64-out-dir', type=str)
   parser.add_argument('--armv7-out-dir', type=str)
 
   args = parser.parse_args()
 
+  if args.x64_out_dir:
+    generate_gen_snapshot(
+        args.x64_out_dir,
+        os.path.join(args.dst, 'gen_snapshot_x64')
+    )
+
   if args.arm64_out_dir:
-    generate_gen_snapshot(args.arm64_out_dir, os.path.join(args.dst, 'gen_snapshot_arm64'))
+    generate_gen_snapshot(
+        os.path.join(args.arm64_out_dir, 'clang_x64'),
+        os.path.join(args.dst, 'gen_snapshot_arm64')
+    )
 
   if args.armv7_out_dir:
-    generate_gen_snapshot(args.armv7_out_dir, os.path.join(args.dst, 'gen_snapshot_armv7'))
+    generate_gen_snapshot(
+        os.path.join(args.armv7_out_dir, 'clang_x64'),
+        os.path.join(args.dst, 'gen_snapshot_armv7')
+    )
 
 
 def generate_gen_snapshot(directory, destination):
-  gen_snapshot_dir = os.path.join(directory, 'clang_x64', 'gen_snapshot')
+  gen_snapshot_dir = os.path.join(directory, 'gen_snapshot')
   if not os.path.isfile(gen_snapshot_dir):
     print('Cannot find gen_snapshot at %s' % gen_snapshot_dir)
     sys.exit(1)
 
-  subprocess.check_call(['xcrun', 'bitcode_strip', '-r', gen_snapshot_dir, '-o', destination])
+  subprocess.check_call(
+      ['xcrun', 'bitcode_strip', '-r', gen_snapshot_dir, '-o', destination]
+  )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds scripts to allow implementing an analogue of `PackageIOSVariant` (here: https://flutter.googlesource.com/recipes/+/refs/heads/main/recipes/engine.py#1202) for macOS.

I have verified that after the tool change here https://github.com/flutter/flutter/pull/97111, apps targeting x64 still work with a framework packaged with this script.