### PR TITLE
[web] reupload CanvasKit 0.32.0 with correct file permissions

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ vars = {
 
   # WARNING: DO NOT EDIT canvaskit_cipd_instance MANUALLY
   # See `lib/web_ui/README.md` for how to roll CanvasKit to a new version.
-  'canvaskit_cipd_instance': 'CQJGaIvKwSuYCIi4hxn3jdY-Pcrdkcnnu65ZVt18oW8C',
+  'canvaskit_cipd_instance': 'iQ9eejGGY3XWlCgOfF0YbnatDx_JMjC1vlOZBj4s3bUC',
 
   # When updating the Dart revision, ensure that all entries that are
   # dependencies of Dart are also updated to match the entries in the

--- a/lib/web_ui/dev/canvaskit_roller.dart
+++ b/lib/web_ui/dev/canvaskit_roller.dart
@@ -47,6 +47,7 @@ Future<void> main(List<String> args) async {
   await cipdConfigFile.writeAsString('''
 package: flutter/web/canvaskit_bundle
 description: A build of CanvasKit bundled with Flutter Web apps
+preserve_writable: true
 data:
   - dir: canvaskit
 ''');
@@ -56,7 +57,6 @@ data:
     'create',
     '--tag=version:$canvaskitVersion',
     '--pkg-def=cipd.yaml',
-    '--preserve-writable',
     '--json-output=result.json',
   ], workingDirectory: canvaskitDirectory.path);
 


### PR DESCRIPTION
Reupload CanvasKit 0.32.0 to CIPD but this time preserve the read-write permissions of the files in the package.