### PR TITLE
Make sure 'FlutterSplashView.onRestoreInstanceState' doesn't crash

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterSplashView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterSplashView.java
@@ -99,6 +99,10 @@ import io.flutter.embedding.engine.renderer.FlutterUiDisplayListener;
 
   @Override
   protected void onRestoreInstanceState(Parcelable state) {
+    if (!(state instanceof SavedState)) {
+      super.onRestoreInstanceState(state);
+      return;
+    }
     SavedState savedState = (SavedState) state;
     super.onRestoreInstanceState(savedState.getSuperState());
     previousCompletedSplashIsolate = savedState.previousCompletedSplashIsolate;

--- a/shell/platform/android/io/flutter/embedding/android/FlutterSplashView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterSplashView.java
@@ -14,6 +14,7 @@ import android.widget.FrameLayout;
 import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 import io.flutter.Log;
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.renderer.FlutterUiDisplayListener;
@@ -28,7 +29,7 @@ import io.flutter.embedding.engine.renderer.FlutterUiDisplayListener;
   @Nullable private SplashScreen splashScreen;
   @Nullable private FlutterView flutterView;
   @Nullable private View splashScreenView;
-  @Nullable private Bundle splashScreenState;
+  @VisibleForTesting @Nullable /* package */ Bundle splashScreenState;
   @Nullable private String transitioningIsolateId;
   @Nullable private String previousCompletedSplashIsolate;
 

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
@@ -955,6 +955,14 @@ public class FlutterViewTest {
     assertEquals(null, flutterView.findViewByAccessibilityIdTraversal(accessibilityViewId));
   }
 
+  @Test
+  public void flutterSplashView_itDoesNotCrashOnRestoreInstanceState() {
+    final FlutterSplashView splashView = new FlutterSplashView(RuntimeEnvironment.application);
+    splashView.onRestoreInstanceState(View.BaseSavedState.EMPTY_STATE);
+    // It should not crash and "splashScreenState" should be null.
+    assertEquals(null, splashView.splashScreenState);
+  }
+
   public void ViewportMetrics_initializedPhysicalTouchSlop() {
     FlutterView flutterView = new FlutterView(RuntimeEnvironment.application);
     FlutterEngine flutterEngine =


### PR DESCRIPTION
fix https://github.com/flutter/flutter/issues/94329

This crash also happened in my app, I think `FlutterSplashView` needs to add protection code here, just like `TextView`
https://android.googlesource.com/platform/frameworks/base/+/jb-mr0-release/core/java/android/widget/TextView.java#3270

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
