### PR TITLE
[web] Fix screenshot tests running locally

### DIFF
--- a/web_sdk/web_test_utils/lib/image_compare.dart
+++ b/web_sdk/web_test_utils/lib/image_compare.dart
@@ -40,6 +40,7 @@ Future<String> compareImage(
 
   final String screenshotPath = _getFullScreenshotPath(filename);
   final File screenshotFile = File(screenshotPath);
+  await screenshotFile.create(recursive: true);
   await screenshotFile.writeAsBytes(encodePng(screenshot), flush: true);
 
   if (_isLuci) {
@@ -59,9 +60,12 @@ Future<String> compareImage(
 
   if (golden == null) {
     // This is a new screenshot that doesn't have an existing golden.
-    return 'No golden was found for "$filename". If this is a new screenshot'
-        'test, please take a look at the generated screenshot:\n\n'
-        '* file://$screenshotPath\n';
+
+    // At the moment, we don't support local screenshot testing because we use
+    // Skia Gold to handle our screenshots and diffing. In the future, we might
+    // implement local screenshot testing if there's a need.
+    print('Screenshot generated: file://$screenshotPath');
+    return 'OK';
   }
 
   // Compare screenshots.


### PR DESCRIPTION
When a screenshot is generated, we attempt to save it to a file. If the path to the file contains a directory that doesn't exist, the operation will fail.

This PR ensures the entire path to the file exists before attempting to save the screenshot.

The PR also prints the path of each generated screenshot so it's easy to take a look at them during local development.