### PR TITLE
Reply to accessibility method call even if semantics is not enabled

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/AccessibilityChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/AccessibilityChannel.java
@@ -2,6 +2,7 @@ package io.flutter.embedding.engine.systemchannels;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 import io.flutter.Log;
 import io.flutter.embedding.engine.FlutterJNI;
 import io.flutter.embedding.engine.dart.DartExecutor;
@@ -23,7 +24,8 @@ public class AccessibilityChannel {
   @NonNull public final FlutterJNI flutterJNI;
   @Nullable private AccessibilityMessageHandler handler;
 
-  private final BasicMessageChannel.MessageHandler<Object> parsingMessageHandler =
+  @VisibleForTesting
+  final BasicMessageChannel.MessageHandler<Object> parsingMessageHandler =
       new BasicMessageChannel.MessageHandler<Object>() {
         @Override
         public void onMessage(

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/AccessibilityChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/AccessibilityChannel.java
@@ -31,6 +31,7 @@ public class AccessibilityChannel {
           // If there is no handler to respond to this message then we don't need to
           // parse it. Return.
           if (handler == null) {
+            reply.reply(null);
             return;
           }
 

--- a/shell/platform/android/test/io/flutter/FlutterTestSuite.java
+++ b/shell/platform/android/test/io/flutter/FlutterTestSuite.java
@@ -26,6 +26,7 @@ import io.flutter.embedding.engine.loader.FlutterLoaderTest;
 import io.flutter.embedding.engine.mutatorsstack.FlutterMutatorViewTest;
 import io.flutter.embedding.engine.plugins.shim.ShimPluginRegistryTest;
 import io.flutter.embedding.engine.renderer.FlutterRendererTest;
+import io.flutter.embedding.engine.systemchannels.AccessibilityChannelTest;
 import io.flutter.embedding.engine.systemchannels.DeferredComponentChannelTest;
 import io.flutter.embedding.engine.systemchannels.KeyEventChannelTest;
 import io.flutter.embedding.engine.systemchannels.PlatformChannelTest;
@@ -56,6 +57,7 @@ import test.io.flutter.embedding.engine.PluginComponentTest;
 @RunWith(Suite.class)
 @SuiteClasses({
   AccessibilityBridgeTest.class,
+  AccessibilityChannelTest.class,
   ApplicationInfoLoaderTest.class,
   BinaryCodecTest.class,
   DartExecutorTest.class,

--- a/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/AccessibilityChannelTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/AccessibilityChannelTest.java
@@ -1,0 +1,33 @@
+package io.flutter.embedding.engine.systemchannels;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import android.annotation.TargetApi;
+import io.flutter.embedding.engine.dart.DartExecutor;
+import io.flutter.plugin.common.MethodCall;
+import io.flutter.plugin.common.MethodChannel;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@Config(
+    manifest = Config.NONE,
+    shadows = {})
+@RunWith(RobolectricTestRunner.class)
+@TargetApi(24)
+public class AccessibilityChannelTest {
+  @Test
+  public void repliesWhenNoAccessibilityHandler() throws JSONException {
+    AccessibilityChannel accessibilityChannel = new AccessibilityChannel(mock(DartExecutor.class));
+    JSONObject arguments = new JSONObject();
+    arguments.put("message", "my message");
+    MethodCall call = new MethodCall("announce", arguments);
+    MethodChannel.Result result = mock(MethodChannel.Result.class);
+    accessibilityChannel.parsingMethodHandler.onMethodCall(call, result);
+    verify(result).success(null);
+  }
+}

--- a/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/AccessibilityChannelTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/AccessibilityChannelTest.java
@@ -4,9 +4,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import android.annotation.TargetApi;
+import io.flutter.embedding.engine.FlutterJNI;
 import io.flutter.embedding.engine.dart.DartExecutor;
-import io.flutter.plugin.common.MethodCall;
-import io.flutter.plugin.common.MethodChannel;
+import io.flutter.plugin.common.BasicMessageChannel;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
@@ -22,12 +22,12 @@ import org.robolectric.annotation.Config;
 public class AccessibilityChannelTest {
   @Test
   public void repliesWhenNoAccessibilityHandler() throws JSONException {
-    AccessibilityChannel accessibilityChannel = new AccessibilityChannel(mock(DartExecutor.class));
+    AccessibilityChannel accessibilityChannel =
+        new AccessibilityChannel(mock(DartExecutor.class), mock(FlutterJNI.class));
     JSONObject arguments = new JSONObject();
-    arguments.put("message", "my message");
-    MethodCall call = new MethodCall("announce", arguments);
-    MethodChannel.Result result = mock(MethodChannel.Result.class);
-    accessibilityChannel.parsingMethodHandler.onMethodCall(call, result);
-    verify(result).success(null);
+    arguments.put("type", "announce");
+    BasicMessageChannel.Reply reply = mock(BasicMessageChannel.Reply.class);
+    accessibilityChannel.parsingMessageHandler.onMessage(arguments, reply);
+    verify(reply).reply(null);
   }
 }


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/94100

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
