### PR TITLE
Source the Vulkan headers from KhronosGroup/Vulkan-Headers

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -410,9 +410,9 @@ deps = {
   'src/third_party/pyyaml':
    Var('fuchsia_git') + '/third_party/pyyaml.git' + '@' + '25e97546488eee166b1abb229a27856cecd8b7ac',
 
-   # Upstream Khronos Vulkan Headers (v1.1.91)
-   'src/third_party/vulkan':
-   Var('github_git') + '/KhronosGroup/Vulkan-Docs.git' + '@' + 'v1.1.91',
+   # Upstream Khronos Vulkan Headers (v1.1.130)
+   'src/third_party/vulkan-headers':
+   Var('github_git') + '/KhronosGroup/Vulkan-Headers.git' + '@' + 'v1.1.130',
 
    # Downstream Fuchsia Vulkan Headers (v1.2.198)
   'src/third_party/fuchsia-vulkan':

--- a/ci/licenses_golden/licenses_third_party
+++ b/ci/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: b643518b93c707fdbf4876118d1401b4
+Signature: bd338c6b1d6afb707bc79f300deb2d0a
 
 UNUSED LICENSES:
 
@@ -227,8 +227,8 @@ LIBRARY: fuchsia-vulkan
 LIBRARY: khronos
 LIBRARY: libwebp
 LIBRARY: pkg
-LIBRARY: vulkan
 LIBRARY: vulkan-deps
+LIBRARY: vulkan-headers
 LIBRARY: wuffs
 ORIGIN: ../../../flutter/third_party/txt/LICENSE
 TYPE: LicenseType.apache
@@ -1258,19 +1258,28 @@ FILE: ../../../third_party/pkg/quiver/lib/src/time/duration_unit_constants.dart
 FILE: ../../../third_party/pkg/quiver/lib/src/time/util.dart
 FILE: ../../../third_party/pkg/quiver/lib/strings.dart
 FILE: ../../../third_party/pkg/quiver/lib/time.dart
-FILE: ../../../third_party/vulkan/include/vulkan/vk_platform.h
-FILE: ../../../third_party/vulkan/include/vulkan/vulkan.h
-FILE: ../../../third_party/vulkan/include/vulkan/vulkan_android.h
-FILE: ../../../third_party/vulkan/include/vulkan/vulkan_core.h
-FILE: ../../../third_party/vulkan/include/vulkan/vulkan_fuchsia.h
-FILE: ../../../third_party/vulkan/include/vulkan/vulkan_ios.h
-FILE: ../../../third_party/vulkan/include/vulkan/vulkan_macos.h
-FILE: ../../../third_party/vulkan/include/vulkan/vulkan_vi.h
-FILE: ../../../third_party/vulkan/include/vulkan/vulkan_wayland.h
-FILE: ../../../third_party/vulkan/include/vulkan/vulkan_win32.h
-FILE: ../../../third_party/vulkan/include/vulkan/vulkan_xcb.h
-FILE: ../../../third_party/vulkan/include/vulkan/vulkan_xlib.h
-FILE: ../../../third_party/vulkan/include/vulkan/vulkan_xlib_xrandr.h
+FILE: ../../../third_party/vulkan-headers/cmake/cmake_uninstall.cmake.in
+FILE: ../../../third_party/vulkan-headers/include/vulkan/vk_icd.h
+FILE: ../../../third_party/vulkan-headers/include/vulkan/vk_layer.h
+FILE: ../../../third_party/vulkan-headers/include/vulkan/vk_platform.h
+FILE: ../../../third_party/vulkan-headers/include/vulkan/vk_sdk_platform.h
+FILE: ../../../third_party/vulkan-headers/include/vulkan/vulkan.h
+FILE: ../../../third_party/vulkan-headers/include/vulkan/vulkan.hpp
+FILE: ../../../third_party/vulkan-headers/include/vulkan/vulkan_android.h
+FILE: ../../../third_party/vulkan-headers/include/vulkan/vulkan_core.h
+FILE: ../../../third_party/vulkan-headers/include/vulkan/vulkan_fuchsia.h
+FILE: ../../../third_party/vulkan-headers/include/vulkan/vulkan_ggp.h
+FILE: ../../../third_party/vulkan-headers/include/vulkan/vulkan_ios.h
+FILE: ../../../third_party/vulkan-headers/include/vulkan/vulkan_macos.h
+FILE: ../../../third_party/vulkan-headers/include/vulkan/vulkan_metal.h
+FILE: ../../../third_party/vulkan-headers/include/vulkan/vulkan_vi.h
+FILE: ../../../third_party/vulkan-headers/include/vulkan/vulkan_wayland.h
+FILE: ../../../third_party/vulkan-headers/include/vulkan/vulkan_win32.h
+FILE: ../../../third_party/vulkan-headers/include/vulkan/vulkan_xcb.h
+FILE: ../../../third_party/vulkan-headers/include/vulkan/vulkan_xlib.h
+FILE: ../../../third_party/vulkan-headers/include/vulkan/vulkan_xlib_xrandr.h
+FILE: ../../../third_party/vulkan-headers/registry/validusage.json
+FILE: ../../../third_party/vulkan-headers/registry/vk.xml
 FILE: ../../../third_party/wuffs/release/c/wuffs-v0.2.c
 FILE: ../../../third_party/wuffs/release/c/wuffs-v0.3.c
 ----------------------------------------------------------------------------------------------------

--- a/vulkan/BUILD.gn
+++ b/vulkan/BUILD.gn
@@ -11,10 +11,7 @@ config("vulkan_config") {
     include_dirs += [ "//third_party/fuchsia-vulkan/include" ]
     defines += [ "VK_USE_PLATFORM_FUCHSIA=1" ]
   } else {
-    include_dirs += [
-      "//third_party/vulkan/src",
-      "//third_party/vulkan/include",
-    ]
+    include_dirs += [ "//third_party/vulkan-headers/include" ]
   }
 }
 


### PR DESCRIPTION
Motivations:
* **Vulkan-Docs** no longer contains generated headers from the spec description (e.g. `vulkan_core.h`).
* **Vulkan-Headers** now conveniently includes `vulkan.hpp` builds, so we won't need to update multiple repos in lockstep when using `vulkan.hpp`.

Note: I changed the directory name from `vulkan` to `vulkan-headers` to avoid a mass inconvenience event; I noticed that `gclient sync -D` doesn't hard reset to the new ref when switching remotes on gclient 0.7. Still need to nail down the versions affected and file a bug.