### PR TITLE
Add constexpr endianness utilities to fml

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -176,6 +176,7 @@ FILE: ../../../flutter/fml/dart/dart_converter.h
 FILE: ../../../flutter/fml/delayed_task.cc
 FILE: ../../../flutter/fml/delayed_task.h
 FILE: ../../../flutter/fml/eintr_wrapper.h
+FILE: ../../../flutter/fml/endianness.cc
 FILE: ../../../flutter/fml/endianness.h
 FILE: ../../../flutter/fml/endianness_unittests.cc
 FILE: ../../../flutter/fml/file.cc

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -176,6 +176,8 @@ FILE: ../../../flutter/fml/dart/dart_converter.h
 FILE: ../../../flutter/fml/delayed_task.cc
 FILE: ../../../flutter/fml/delayed_task.h
 FILE: ../../../flutter/fml/eintr_wrapper.h
+FILE: ../../../flutter/fml/endianness.h
+FILE: ../../../flutter/fml/endianness_unittests.cc
 FILE: ../../../flutter/fml/file.cc
 FILE: ../../../flutter/fml/file.h
 FILE: ../../../flutter/fml/file_unittest.cc

--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -21,6 +21,8 @@ source_set("fml") {
     "delayed_task.cc",
     "delayed_task.h",
     "eintr_wrapper.h",
+    "endianness.cc",
+    "endianness.h",
     "file.cc",
     "file.h",
     "hash_combine.h",

--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -268,6 +268,7 @@ if (enable_unittests) {
       "backtrace_unittests.cc",
       "base32_unittest.cc",
       "command_line_unittest.cc",
+      "endianness_unittests.cc",
       "file_unittest.cc",
       "hash_combine_unittests.cc",
       "hex_codec_unittest.cc",

--- a/fml/endianness.cc
+++ b/fml/endianness.cc
@@ -1,0 +1,5 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/fml/endianness.h"

--- a/fml/endianness.h
+++ b/fml/endianness.h
@@ -1,0 +1,70 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_FML_ENDIANNESS_H_
+#define FLUTTER_FML_ENDIANNESS_H_
+
+#include <cstdint>
+#include <type_traits>
+#if defined(_MSC_VER)
+#include "intrin.h"
+#endif
+
+#include "flutter/fml/build_config.h"
+
+// Compiler intrinsics for flipping endianness.
+#define BYTESWAP16(n) __builtin_bswap16(n)
+#define BYTESWAP32(n) __builtin_bswap32(n)
+#define BYTESWAP64(n) __builtin_bswap64(n)
+
+#if defined(_MSC_VER)
+#define BYTESWAP16(n) _byteswap_ushort(n)
+#define BYTESWAP32(n) _byteswap_ulong(n)
+#define BYTESWAP64(n) _byteswap_uint64(n)
+#endif
+
+namespace fml {
+
+/// @brief  Flips the endianness of the given value.
+template <typename T>
+constexpr T ByteSwap(T n) {
+  if constexpr (sizeof(T) == 1) {
+    return n;
+  } else if constexpr (sizeof(T) == 2) {
+    return (T)BYTESWAP16((uint16_t)n);
+  } else if constexpr (sizeof(T) == 4) {
+    return (T)BYTESWAP32((uint32_t)n);
+  } else if constexpr (sizeof(T) == 8) {
+    return (T)BYTESWAP64((uint64_t)n);
+  } else {
+    static_assert(!sizeof(T), "Unsupported size");
+  }
+}
+
+/// @brief  Convert a known big endian value to match the endianness of the
+///         current architecture. This is effectively a cross platform
+///         ntohl/ntohs (as network byte order is always Big Endian).
+template <typename T>
+constexpr T BigEndianToArch(T n) {
+#if ARCH_CPU_LITTLE_ENDIAN
+  return ByteSwap<T>(n);
+#else
+  return n;
+#endif
+}
+
+/// @brief  Convert a known little endian value to match the endianness of the
+///         current architecture.
+template <typename T>
+constexpr T LittleEndianToArch(T n) {
+#if !ARCH_CPU_LITTLE_ENDIAN
+  return ByteSwap<T>(n);
+#else
+  return n;
+#endif
+}
+
+}  // namespace fml
+
+#endif  // FLUTTER_FML_ENDIANNESS_H_

--- a/fml/endianness.h
+++ b/fml/endianness.h
@@ -14,29 +14,30 @@
 #include "flutter/fml/build_config.h"
 
 // Compiler intrinsics for flipping endianness.
-#define BYTESWAP16(n) __builtin_bswap16(n)
-#define BYTESWAP32(n) __builtin_bswap32(n)
-#define BYTESWAP64(n) __builtin_bswap64(n)
+#define FML_BYTESWAP_16(n) __builtin_bswap16(n)
+#define FML_BYTESWAP_32(n) __builtin_bswap32(n)
+#define FML_BYTESWAP_64(n) __builtin_bswap64(n)
 
 #if defined(_MSC_VER)
-#define BYTESWAP16(n) _byteswap_ushort(n)
-#define BYTESWAP32(n) _byteswap_ulong(n)
-#define BYTESWAP64(n) _byteswap_uint64(n)
+#define FML_BYTESWAP_16(n) _byteswap_ushort(n)
+#define FML_BYTESWAP_32(n) _byteswap_ulong(n)
+#define FML_BYTESWAP_64(n) _byteswap_uint64(n)
 #endif
 
 namespace fml {
 
 /// @brief  Flips the endianness of the given value.
-template <typename T>
+///         The given value must be an integral type of size 1, 2, 4, or 8.
+template <typename T, class = std::enable_if_t<std::is_integral_v<T>>>
 constexpr T ByteSwap(T n) {
   if constexpr (sizeof(T) == 1) {
     return n;
   } else if constexpr (sizeof(T) == 2) {
-    return (T)BYTESWAP16((uint16_t)n);
+    return (T)FML_BYTESWAP_16((uint16_t)n);
   } else if constexpr (sizeof(T) == 4) {
-    return (T)BYTESWAP32((uint32_t)n);
+    return (T)FML_BYTESWAP_32((uint32_t)n);
   } else if constexpr (sizeof(T) == 8) {
-    return (T)BYTESWAP64((uint64_t)n);
+    return (T)FML_BYTESWAP_64((uint64_t)n);
   } else {
     static_assert(!sizeof(T), "Unsupported size");
   }
@@ -45,7 +46,8 @@ constexpr T ByteSwap(T n) {
 /// @brief  Convert a known big endian value to match the endianness of the
 ///         current architecture. This is effectively a cross platform
 ///         ntohl/ntohs (as network byte order is always Big Endian).
-template <typename T>
+///         The given value must be an integral type of size 1, 2, 4, or 8.
+template <typename T, class = std::enable_if_t<std::is_integral_v<T>>>
 constexpr T BigEndianToArch(T n) {
 #if ARCH_CPU_LITTLE_ENDIAN
   return ByteSwap<T>(n);
@@ -56,7 +58,8 @@ constexpr T BigEndianToArch(T n) {
 
 /// @brief  Convert a known little endian value to match the endianness of the
 ///         current architecture.
-template <typename T>
+///         The given value must be an integral type of size 1, 2, 4, or 8.
+template <typename T, class = std::enable_if_t<std::is_integral_v<T>>>
 constexpr T LittleEndianToArch(T n) {
 #if !ARCH_CPU_LITTLE_ENDIAN
   return ByteSwap<T>(n);

--- a/fml/endianness_unittests.cc
+++ b/fml/endianness_unittests.cc
@@ -1,0 +1,37 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/fml/endianness.h"
+
+#include "flutter/testing/testing.h"
+
+namespace fml {
+namespace testing {
+
+TEST(EndiannessTest, ByteSwap) {
+  ASSERT_EQ(ByteSwap<int16_t>(0x1122), 0x2211);
+  ASSERT_EQ(ByteSwap<int32_t>(0x11223344), 0x44332211);
+  ASSERT_EQ(ByteSwap<uint64_t>(0x1122334455667788), 0x8877665544332211);
+}
+
+TEST(EndiannessTest, BigEndianToArch) {
+#if ARCH_CPU_LITTLE_ENDIAN
+  uint32_t expected = 0x44332211;
+#else
+  uint32_t expected = 0x11223344;
+#endif
+  ASSERT_EQ(BigEndianToArch(0x11223344u), expected);
+}
+
+TEST(EndiannessTest, LittleEndianToArch) {
+#if ARCH_CPU_LITTLE_ENDIAN
+  uint32_t expected = 0x11223344;
+#else
+  uint32_t expected = 0x44332211;
+#endif
+  ASSERT_EQ(LittleEndianToArch(0x11223344u), expected);
+}
+
+}  // namespace testing
+}  // namespace fml


### PR DESCRIPTION
Pulled this out of the WIP APNG demuxer: https://github.com/flutter/engine/pull/31098

Uses byteswap compiler intrinsics. I think all the architectures we currently target are little endian, but this is convenient for parsing older big endian formats (like PNG chunks).