### PR TITLE
[fuchsia] add input shield to Flatland

### DIFF
--- a/shell/platform/fuchsia/flutter/flatland_external_view_embedder.cc
+++ b/shell/platform/fuchsia/flutter/flatland_external_view_embedder.cc
@@ -272,6 +272,14 @@ void FlatlandExternalViewEmbedder::SubmitFrame(
             flatland_layers_[flatland_layer_index].transform_id);
         child_transforms_.emplace_back(
             flatland_layers_[flatland_layer_index].transform_id);
+
+        // Attach full-screen hit testing shield.
+        flatland_->flatland()->SetHitRegions(
+            flatland_layers_[flatland_layer_index].transform_id,
+            {{{0, 0, std::numeric_limits<float>::max(),
+               std::numeric_limits<float>::max()},
+              fuchsia::ui::composition::HitTestInteraction::
+                  SEMANTICALLY_INVISIBLE}});
       }
 
       // Reset for the next pass:

--- a/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland.cc
+++ b/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland.cc
@@ -766,6 +766,29 @@ void FakeFlatland::ReleaseImage(fuchsia::ui::composition::ContentId image_id) {
   pending_graph_.content_map.erase(found_content);
 }
 
+void FakeFlatland::SetHitRegions(
+    fuchsia::ui::composition::TransformId transform_id,
+    std::vector<fuchsia::ui::composition::HitRegion> regions) {
+  if (transform_id.value == 0) {
+    // TODO(fxb/85619): Raise a FlatlandError here
+    FML_CHECK(false)
+        << "FakeFlatland::SetTranslation: TransformId 0 is invalid.";
+    return;
+  }
+
+  auto found_transform = pending_graph_.transform_map.find(transform_id.value);
+  if (found_transform == pending_graph_.transform_map.end()) {
+    // TODO(fxb/85619): Raise a FlatlandError here
+    FML_CHECK(false) << "FakeFlatland::SetTranslation: TransformId "
+                     << transform_id.value << " does not exist.";
+    return;
+  }
+
+  auto& transform = found_transform->second;
+  FML_CHECK(transform);
+  transform->num_hit_regions = regions.size();
+}
+
 void FakeFlatland::Clear() {
   parents_map_.clear();
   pending_graph_.Clear();

--- a/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland.h
+++ b/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland.h
@@ -298,6 +298,11 @@ class FakeFlatland
   void ReleaseImage(fuchsia::ui::composition::ContentId image_id) override;
 
   // |fuchsia::ui::composition::Flatland|
+  void SetHitRegions(
+      fuchsia::ui::composition::TransformId transform_id,
+      std::vector<fuchsia::ui::composition::HitRegion> regions) override;
+
+  // |fuchsia::ui::composition::Flatland|
   void Clear() override;
 
   // |fuchsia::ui::composition::Flatland|

--- a/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland_types.cc
+++ b/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland_types.cc
@@ -70,6 +70,7 @@ std::shared_ptr<FakeTransform> CloneFakeTransform(
                            .children = CloneFakeTransformVector(
                                transform->children, transform_cache),
                            .content = CloneFakeContent(transform->content),
+                           .num_hit_regions = transform->num_hit_regions,
                        }));
   FML_CHECK(success);
 
@@ -132,7 +133,8 @@ bool FakeImage::operator==(const FakeImage& other) const {
 bool FakeTransform::operator==(const FakeTransform& other) const {
   return id == other.id && translation == other.translation &&
          clip_bounds == other.clip_bounds && orientation == other.orientation &&
-         children == other.children && content == other.content;
+         children == other.children && content == other.content &&
+         num_hit_regions == other.num_hit_regions;
 }
 
 bool FakeGraph::operator==(const FakeGraph& other) const {

--- a/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland_types.h
+++ b/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland_types.h
@@ -180,6 +180,7 @@ struct FakeTransform {
 
   std::vector<std::shared_ptr<FakeTransform>> children;
   std::shared_ptr<FakeContent> content;
+  size_t num_hit_regions;
 };
 
 struct FakeGraph {

--- a/shell/platform/fuchsia/flutter/tests/flatland_external_view_embedder_unittests.cc
+++ b/shell/platform/fuchsia/flutter/tests/flatland_external_view_embedder_unittests.cc
@@ -217,7 +217,7 @@ Matcher<FakeGraph> IsFlutterGraph(
           /*id*/ _, FakeTransform::kDefaultTranslation,
           FakeTransform::kDefaultClipBounds, FakeTransform::kDefaultOrientation,
           /*children*/ ElementsAreArray(layer_matchers),
-          /*content*/ Eq(nullptr))),
+          /*content*/ Eq(nullptr), /*num_hit_regions*/ _)),
       Eq(FakeView{
           .view_token = viewport_token_koids.second,
           .view_ref = view_ref_koids.first,
@@ -232,7 +232,8 @@ Matcher<FakeGraph> IsFlutterGraph(
 
 Matcher<std::shared_ptr<FakeTransform>> IsImageLayer(
     const fuchsia::math::SizeU& layer_size,
-    fuchsia::ui::composition::BlendMode blend_mode) {
+    fuchsia::ui::composition::BlendMode blend_mode,
+    size_t num_hit_regions) {
   return Pointee(FieldsAre(
       /*id*/ _, FakeTransform::kDefaultTranslation,
       FakeTransform::kDefaultClipBounds, FakeTransform::kDefaultOrientation,
@@ -242,7 +243,8 @@ Matcher<std::shared_ptr<FakeTransform>> IsImageLayer(
           /*id*/ _, IsImageProperties(layer_size),
           FakeImage::kDefaultSampleRegion, layer_size,
           FakeImage::kDefaultOpacity, blend_mode,
-          /*buffer_import_token*/ _, /*vmo_index*/ 0)))));
+          /*buffer_import_token*/ _, /*vmo_index*/ 0))),
+      num_hit_regions));
 }
 
 Matcher<std::shared_ptr<FakeTransform>> IsViewportLayer(
@@ -257,7 +259,8 @@ Matcher<std::shared_ptr<FakeTransform>> IsViewportLayer(
                 Pointee(VariantWith<FakeViewport>(FieldsAre(
                     /* id */ _, IsViewportProperties(view_logical_size),
                     /* viewport_token */ GetKoids(view_token).second,
-                    /* child_view_watcher */ _)))));
+                    /* child_view_watcher */ _))),
+                /*num_hit_regions*/ 0));
 }
 
 fuchsia::ui::composition::OnNextFrameBeginValues WithPresentCredits(
@@ -466,7 +469,7 @@ TEST_F(FlatlandExternalViewEmbedderTest, SimpleScene) {
       fake_flatland().graph(),
       IsFlutterGraph(parent_viewport_watcher, viewport_creation_token, view_ref,
                      /*layers*/
-                     {IsImageLayer(frame_size, kFirstLayerBlendMode)}));
+                     {IsImageLayer(frame_size, kFirstLayerBlendMode, 1)}));
 }
 
 TEST_F(FlatlandExternalViewEmbedderTest, SceneWithOneView) {
@@ -555,9 +558,9 @@ TEST_F(FlatlandExternalViewEmbedderTest, SceneWithOneView) {
       fake_flatland().graph(),
       IsFlutterGraph(
           parent_viewport_watcher, viewport_creation_token, view_ref, /*layers*/
-          {IsImageLayer(frame_size, kFirstLayerBlendMode),
+          {IsImageLayer(frame_size, kFirstLayerBlendMode, 1),
            IsViewportLayer(child_view_token, child_view_size, {0, 0}),
-           IsImageLayer(frame_size, kUpperLayerBlendMode)}));
+           IsImageLayer(frame_size, kUpperLayerBlendMode, 1)}));
 
   // Destroy the view.  The scene graph shouldn't change yet.
   external_view_embedder.DestroyView(
@@ -566,9 +569,9 @@ TEST_F(FlatlandExternalViewEmbedderTest, SceneWithOneView) {
       fake_flatland().graph(),
       IsFlutterGraph(
           parent_viewport_watcher, viewport_creation_token, view_ref, /*layers*/
-          {IsImageLayer(frame_size, kFirstLayerBlendMode),
+          {IsImageLayer(frame_size, kFirstLayerBlendMode, 1),
            IsViewportLayer(child_view_token, child_view_size, {0, 0}),
-           IsImageLayer(frame_size, kUpperLayerBlendMode)}));
+           IsImageLayer(frame_size, kUpperLayerBlendMode, 1)}));
 
   // Draw another frame without the view.  The scene graph shouldn't change yet.
   DrawSimpleFrame(
@@ -587,16 +590,135 @@ TEST_F(FlatlandExternalViewEmbedderTest, SceneWithOneView) {
       fake_flatland().graph(),
       IsFlutterGraph(
           parent_viewport_watcher, viewport_creation_token, view_ref, /*layers*/
-          {IsImageLayer(frame_size, kFirstLayerBlendMode),
+          {IsImageLayer(frame_size, kFirstLayerBlendMode, 1),
            IsViewportLayer(child_view_token, child_view_size, {0, 0}),
-           IsImageLayer(frame_size, kUpperLayerBlendMode)}));
+           IsImageLayer(frame_size, kUpperLayerBlendMode, 1)}));
 
   // Pump the message loop.  The scene updates should propagate to flatland.
   loop().RunUntilIdle();
+  EXPECT_THAT(
+      fake_flatland().graph(),
+      IsFlutterGraph(parent_viewport_watcher, viewport_creation_token,
+                     view_ref, /*layers*/
+                     {IsImageLayer(frame_size, kFirstLayerBlendMode, 1)}));
+}
+
+TEST_F(FlatlandExternalViewEmbedderTest, SceneWithOneView_NoOverlay) {
+  fuchsia::ui::composition::ParentViewportWatcherPtr parent_viewport_watcher;
+  fuchsia::ui::views::ViewportCreationToken viewport_creation_token;
+  fuchsia::ui::views::ViewCreationToken view_creation_token;
+  fuchsia::ui::views::ViewRef view_ref;
+  auto view_creation_token_status = zx::channel::create(
+      0u, &viewport_creation_token.value, &view_creation_token.value);
+  ASSERT_EQ(view_creation_token_status, ZX_OK);
+  auto view_ref_pair = scenic::ViewRefPair::New();
+  view_ref_pair.view_ref.Clone(&view_ref);
+
+  // Create the `FlatlandExternalViewEmbedder` and pump the message loop until
+  // the initial scene graph is setup.
+  FlatlandExternalViewEmbedder external_view_embedder(
+      std::move(view_creation_token),
+      fuchsia::ui::views::ViewIdentityOnCreation{
+          .view_ref = std::move(view_ref_pair.view_ref),
+          .view_ref_control = std::move(view_ref_pair.control_ref),
+      },
+      fuchsia::ui::composition::ViewBoundProtocols{},
+      parent_viewport_watcher.NewRequest(), flatland_connection(),
+      fake_surface_producer());
+  flatland_connection()->Present();
+  loop().RunUntilIdle();
+  fake_flatland().FireOnNextFrameBeginEvent(WithPresentCredits(1u));
+  loop().RunUntilIdle();
   EXPECT_THAT(fake_flatland().graph(),
               IsFlutterGraph(parent_viewport_watcher, viewport_creation_token,
-                             view_ref, /*layers*/
-                             {IsImageLayer(frame_size, kFirstLayerBlendMode)}));
+                             view_ref));
+
+  // Create the view before drawing the scene.
+  const SkSize child_view_size_signed = SkSize::Make(256.f, 512.f);
+  const fuchsia::math::SizeU child_view_size{
+      static_cast<uint32_t>(child_view_size_signed.width()),
+      static_cast<uint32_t>(child_view_size_signed.height())};
+  auto [child_view_token, child_viewport_token] = ViewTokenPair::New();
+  const uint32_t child_view_id = child_viewport_token.value.get();
+  flutter::EmbeddedViewParams child_view_params(
+      SkMatrix::I(), child_view_size_signed, flutter::MutatorsStack());
+  external_view_embedder.CreateView(
+      child_view_id, []() {},
+      [](fuchsia::ui::composition::ContentId,
+         fuchsia::ui::composition::ChildViewWatcherPtr) {});
+
+  // Draw the scene.  The scene graph shouldn't change yet.
+  const SkISize frame_size_signed = SkISize::Make(512, 512);
+  const fuchsia::math::SizeU frame_size{
+      static_cast<uint32_t>(frame_size_signed.width()),
+      static_cast<uint32_t>(frame_size_signed.height())};
+  DrawFrameWithView(
+      external_view_embedder, frame_size_signed, 1.f, child_view_id,
+      child_view_params,
+      [](SkCanvas* canvas) {
+        const SkSize canvas_size = SkSize::Make(canvas->imageInfo().width(),
+                                                canvas->imageInfo().height());
+        SkPaint rect_paint;
+        rect_paint.setColor(SK_ColorGREEN);
+        canvas->translate(canvas_size.width() / 4.f,
+                          canvas_size.height() / 2.f);
+        canvas->drawRect(SkRect::MakeWH(canvas_size.width() / 32.f,
+                                        canvas_size.height() / 32.f),
+                         rect_paint);
+      },
+      [](SkCanvas* canvas) {});
+  EXPECT_THAT(fake_flatland().graph(),
+              IsFlutterGraph(parent_viewport_watcher, viewport_creation_token,
+                             view_ref));
+
+  // Pump the message loop.  The scene updates should propagate to flatland.
+  loop().RunUntilIdle();
+  fake_flatland().FireOnNextFrameBeginEvent(WithPresentCredits(1u));
+  loop().RunUntilIdle();
+  EXPECT_THAT(
+      fake_flatland().graph(),
+      IsFlutterGraph(
+          parent_viewport_watcher, viewport_creation_token, view_ref, /*layers*/
+          {IsImageLayer(frame_size, kFirstLayerBlendMode, 1),
+           IsViewportLayer(child_view_token, child_view_size, {0, 0})}));
+
+  // Destroy the view.  The scene graph shouldn't change yet.
+  external_view_embedder.DestroyView(
+      child_view_id, [](fuchsia::ui::composition::ContentId) {});
+  EXPECT_THAT(
+      fake_flatland().graph(),
+      IsFlutterGraph(
+          parent_viewport_watcher, viewport_creation_token, view_ref, /*layers*/
+          {IsImageLayer(frame_size, kFirstLayerBlendMode, 1),
+           IsViewportLayer(child_view_token, child_view_size, {0, 0})}));
+
+  // Draw another frame without the view.  The scene graph shouldn't change yet.
+  DrawSimpleFrame(
+      external_view_embedder, frame_size_signed, 1.f, [](SkCanvas* canvas) {
+        const SkSize canvas_size = SkSize::Make(canvas->imageInfo().width(),
+                                                canvas->imageInfo().height());
+        SkPaint rect_paint;
+        rect_paint.setColor(SK_ColorGREEN);
+        canvas->translate(canvas_size.width() / 4.f,
+                          canvas_size.height() / 2.f);
+        canvas->drawRect(SkRect::MakeWH(canvas_size.width() / 32.f,
+                                        canvas_size.height() / 32.f),
+                         rect_paint);
+      });
+  EXPECT_THAT(
+      fake_flatland().graph(),
+      IsFlutterGraph(
+          parent_viewport_watcher, viewport_creation_token, view_ref, /*layers*/
+          {IsImageLayer(frame_size, kFirstLayerBlendMode, 1),
+           IsViewportLayer(child_view_token, child_view_size, {0, 0})}));
+
+  // Pump the message loop.  The scene updates should propagate to flatland.
+  loop().RunUntilIdle();
+  EXPECT_THAT(
+      fake_flatland().graph(),
+      IsFlutterGraph(parent_viewport_watcher, viewport_creation_token,
+                     view_ref, /*layers*/
+                     {IsImageLayer(frame_size, kFirstLayerBlendMode, 1)}));
 }
 
 }  // namespace flutter_runner::testing


### PR DESCRIPTION
Currently this is a no-op on Flatland. This work is part of the effort to
enable hit testing on Flatland, after a few CLs land platform-side.

Test: manual
Bug: fxbug.dev/72075