### PR TITLE
Remove unused Counter and CounterValues class.

### DIFF
--- a/flow/compositor_context.cc
+++ b/flow/compositor_context.cc
@@ -55,7 +55,6 @@ CompositorContext::~CompositorContext() = default;
 void CompositorContext::BeginFrame(ScopedFrame& frame,
                                    bool enable_instrumentation) {
   if (enable_instrumentation) {
-    frame_count_.Increment();
     raster_time_.Start();
   }
 }

--- a/flow/compositor_context.h
+++ b/flow/compositor_context.h
@@ -161,8 +161,6 @@ class CompositorContext {
 
   TextureRegistry& texture_registry() { return texture_registry_; }
 
-  const Counter& frame_count() const { return frame_count_; }
-
   const Stopwatch& raster_time() const { return raster_time_; }
 
   Stopwatch& ui_time() { return ui_time_; }
@@ -170,7 +168,6 @@ class CompositorContext {
  private:
   RasterCache raster_cache_;
   TextureRegistry texture_registry_;
-  Counter frame_count_;
   Stopwatch raster_time_;
   Stopwatch ui_time_;
 

--- a/flow/instrumentation.cc
+++ b/flow/instrumentation.cc
@@ -5,7 +5,6 @@
 #include "flutter/flow/instrumentation.h"
 
 #include <algorithm>
-#include <limits>
 
 #include "third_party/skia/include/core/SkPath.h"
 #include "third_party/skia/include/core/SkSurface.h"
@@ -239,94 +238,6 @@ void Stopwatch::Visualize(SkCanvas* canvas, const SkRect& rect) const {
 
 fml::Milliseconds Stopwatch::GetFrameBudget() const {
   return refresh_rate_updater_.GetFrameBudget();
-}
-
-CounterValues::CounterValues() : current_sample_(kMaxSamples - 1) {
-  values_.resize(kMaxSamples, 0);
-}
-
-CounterValues::~CounterValues() = default;
-
-void CounterValues::Add(int64_t value) {
-  current_sample_ = (current_sample_ + 1) % kMaxSamples;
-  values_[current_sample_] = value;
-}
-
-void CounterValues::Visualize(SkCanvas* canvas, const SkRect& rect) const {
-  size_t max_bytes = GetMaxValue();
-
-  if (max_bytes == 0) {
-    // The backend for this counter probably did not fill in any values.
-    return;
-  }
-
-  size_t min_bytes = GetMinValue();
-
-  SkPaint paint;
-
-  // Paint the background.
-  paint.setColor(0x99FFFFFF);
-  canvas->drawRect(rect, paint);
-
-  // Establish the graph position.
-  const SkScalar x = rect.x();
-  const SkScalar y = rect.y();
-  const SkScalar width = rect.width();
-  const SkScalar height = rect.height();
-  const SkScalar bottom = y + height;
-  const SkScalar right = x + width;
-
-  // Prepare a path for the data.
-  SkPath path;
-  path.moveTo(x, bottom);
-
-  for (size_t i = 0; i < kMaxSamples; ++i) {
-    int64_t current_bytes = values_[i];
-    double ratio = static_cast<double>(current_bytes - min_bytes) /
-                   static_cast<double>(max_bytes - min_bytes);
-    path.lineTo(
-        x + ((static_cast<double>(i) / static_cast<double>(kMaxSamples)) *
-             width),
-        y + ((1.0 - ratio) * height));
-  }
-
-  path.rLineTo(100, 0);
-  path.lineTo(right, bottom);
-  path.close();
-
-  // Draw the graph.
-  paint.setColor(0xAA0000FF);
-  canvas->drawPath(path, paint);
-
-  // Paint the vertical marker for the current frame.
-  const double sample_unit_width = (1.0 / kMaxSamples);
-  const double sample_margin_unit_width = sample_unit_width / 6.0;
-  const double sample_margin_width = width * sample_margin_unit_width;
-  paint.setStyle(SkPaint::Style::kFill_Style);
-  paint.setColor(SK_ColorGRAY);
-  double sample_x =
-      x + width * (static_cast<double>(current_sample_) / kMaxSamples) -
-      sample_margin_width;
-  const auto marker_rect = SkRect::MakeLTRB(
-      sample_x, y,
-      sample_x + width * sample_unit_width + sample_margin_width * 2, bottom);
-  canvas->drawRect(marker_rect, paint);
-}
-
-int64_t CounterValues::GetMaxValue() const {
-  auto max = std::numeric_limits<int64_t>::min();
-  for (size_t i = 0; i < kMaxSamples; ++i) {
-    max = std::max<int64_t>(max, values_[i]);
-  }
-  return max;
-}
-
-int64_t CounterValues::GetMinValue() const {
-  auto min = std::numeric_limits<int64_t>::max();
-  for (size_t i = 0; i < kMaxSamples; ++i) {
-    min = std::min<int64_t>(min, values_[i]);
-  }
-  return min;
 }
 
 fml::Milliseconds FixedRefreshRateUpdater::GetFrameBudget() const {

--- a/flow/instrumentation.h
+++ b/flow/instrumentation.h
@@ -89,43 +89,6 @@ class FixedRefreshRateStopwatch : public Stopwatch {
   FixedRefreshRateUpdater fixed_delegate_;
 };
 
-class Counter {
- public:
-  Counter() : count_(0) {}
-
-  size_t count() const { return count_; }
-
-  void Reset(size_t count = 0) { count_ = count; }
-
-  void Increment(size_t count = 1) { count_ += count; }
-
- private:
-  size_t count_;
-
-  FML_DISALLOW_COPY_AND_ASSIGN(Counter);
-};
-
-class CounterValues {
- public:
-  CounterValues();
-
-  ~CounterValues();
-
-  void Add(int64_t value);
-
-  void Visualize(SkCanvas* canvas, const SkRect& rect) const;
-
-  int64_t GetMaxValue() const;
-
-  int64_t GetMinValue() const;
-
- private:
-  std::vector<int64_t> values_;
-  size_t current_sample_;
-
-  FML_DISALLOW_COPY_AND_ASSIGN(CounterValues);
-};
-
 }  // namespace flutter
 
 #endif  // FLUTTER_FLOW_INSTRUMENTATION_H_


### PR DESCRIPTION
I checked in git blame and found that the `Counter` and `CounterValues` class in instrumentation.h are they are not actually used anymore since 2016. So I think we can remove them.

The `Visualize()` method is duplicated between the `Counter` and `Stopwatch` class, and the `Counter` is not used anymore, so I think the `Counter` can be removed.
 
And no tests are written because it's only a code removal. cc @Hixie ～

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
