### PR TITLE
Update the script to download fuchsia sdk.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -74,10 +74,11 @@ vars = {
   # Checkout Linux dependencies only when building on Linux.
   'download_linux_deps': 'host_os == "linux"',
 
-  # Downloads the fuchsia SDK as listed in .fuchsia_sdk_version. This variable
+  # Downloads the fuchsia SDK as listed in fuchsia_sdk_path var. This variable
   # is currently only used for the Fuchsia LSC process and is not intended for
   # local development.
   'download_fuchsia_sdk': False,
+  'fuchsia_sdk_path': ''
 
   # An LLVM backend needs LLVM binaries and headers. To avoid build time
   # increases we can use prebuilts. We don't want to download this on every
@@ -728,6 +729,8 @@ hooks = [
       '--verbose',
       '--host-os',
       Var('host_os'),
+      '--fuchsia-sdk-path',
+      Var('fuchsia_sdk_path'),
     ]
   },
   {

--- a/DEPS
+++ b/DEPS
@@ -78,7 +78,7 @@ vars = {
   # is currently only used for the Fuchsia LSC process and is not intended for
   # local development.
   'download_fuchsia_sdk': False,
-  'fuchsia_sdk_path': ''
+  'fuchsia_sdk_path': '',
 
   # An LLVM backend needs LLVM binaries and headers. To avoid build time
   # increases we can use prebuilts. We don't want to download this on every

--- a/tools/download_fuchsia_sdk.py
+++ b/tools/download_fuchsia_sdk.py
@@ -25,7 +25,7 @@ def eprint(*args, **kwargs):
 
 
 def FileNameForSdkPath(sdk_path):
-  return bucket.split('/')[-1]
+  return sdk_path.split('/')[-1]
 
 
 def DownloadFuchsiaSDKFromGCS(sdk_path, verbose):
@@ -134,8 +134,8 @@ def Main():
   host_os = args.host_os
   fuchsia_sdk_path = args.fuchsia_sdk_path
 
-  if bucket is None:
-    eprint('Unable to find bucket in version file')
+  if fuchsia_sdk_path is None:
+    eprint('sdk_path can not be empty')
     return fail_loudly
 
   archive = DownloadFuchsiaSDKFromGCS(fuchsia_sdk_path, verbose)

--- a/tools/download_fuchsia_sdk.py
+++ b/tools/download_fuchsia_sdk.py
@@ -24,13 +24,13 @@ def eprint(*args, **kwargs):
   print(*args, file=sys.stderr, **kwargs)
 
 
-def FileNameForBucket(bucket):
+def FileNameForSdkPath(sdk_path):
   return bucket.split('/')[-1]
 
 
-def DownloadFuchsiaSDKFromGCS(bucket, verbose):
-  file = FileNameForBucket(bucket)
-  url = 'https://storage.googleapis.com/{}'.format(bucket)
+def DownloadFuchsiaSDKFromGCS(sdk_path, verbose):
+  file = FileNameForSdkPath(sdk_path)
+  url = 'https://storage.googleapis.com/{}'.format(sdk_path)
   dest = os.path.join(FUCHSIA_SDK_DIR, file)
 
   if verbose:

--- a/tools/download_fuchsia_sdk.py
+++ b/tools/download_fuchsia_sdk.py
@@ -40,6 +40,8 @@ def DownloadFuchsiaSDKFromGCS(sdk_path, verbose):
   if os.path.isfile(dest):
     os.unlink(dest)
 
+  # Ensure destination folder exists.
+  os.makedirs(FUCHSIA_SDK_DIR, exist_ok=True)
   curl_command = [
     'curl',
     '--retry', '3',

--- a/tools/download_fuchsia_sdk.py
+++ b/tools/download_fuchsia_sdk.py
@@ -18,8 +18,6 @@ import sys
 SRC_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 FUCHSIA_SDK_DIR = os.path.join(SRC_ROOT, 'fuchsia', 'sdk')
 FLUTTER_DIR = os.path.join(SRC_ROOT, 'flutter')
-SDK_VERSION_INFO_FILE = os.path.join(FLUTTER_DIR, '.fuchsia_sdk_version')
-
 
 # Prints to stderr.
 def eprint(*args, **kwargs):
@@ -108,36 +106,6 @@ def ExtractGzipArchive(archive, host_os, verbose):
   shutil.move(extract_dest, sdk_dest)
 
 
-# Reads the version file and returns the bucket to download
-# The file is expected to live at the flutter directory and be named .fuchsia_sdk_version.
-#
-# The file is a JSON file which contains a single object with the following schema:
-# ```
-# {
-#    "protocol": "gcs",
-#    "identifiers": [
-#      {
-#        "host_os": "linux",
-#        "bucket": "fuchsia-artifacts/development/8824687191341324145/sdk/linux-amd64/core.tar.gz"
-#      }
-#    ]
-# }
-# ```
-def ReadVersionFile(host_os):
-  with open(SDK_VERSION_INFO_FILE) as f:
-    try:
-      version_obj = json.loads(f.read())
-      if version_obj['protocol'] != 'gcs':
-        eprint('The gcs protocol is the only suppoted protocl at this time')
-        return None
-      for id_obj in version_obj['identifiers']:
-        if id_obj['host_os'] == host_os:
-          return id_obj['bucket']
-    except:
-      eprint('Could not read JSON version file')
-      return None
-
-
 def Main():
   parser = argparse.ArgumentParser()
   parser.add_argument(
@@ -156,20 +124,23 @@ def Main():
     '--host-os',
     help='The host os')
 
+  parser.add_argument(
+    '--fuchsia-sdk-path',
+    help='The path in gcs to the fuchsia sdk to download')
+
   args = parser.parse_args()
   fail_loudly = 1 if args.fail_loudly else 0
   verbose = args.verbose
   host_os = args.host_os
-
-  bucket = ReadVersionFile(host_os)
+  fuchsia_sdk_path = args.fuchsia_sdk_path
 
   if bucket is None:
     eprint('Unable to find bucket in version file')
     return fail_loudly
 
-  archive = DownloadFuchsiaSDKFromGCS(bucket, verbose)
+  archive = DownloadFuchsiaSDKFromGCS(fuchsia_sdk_path, verbose)
   if archive is None:
-    eprint('Failed to download SDK from %s' % bucket)
+    eprint('Failed to download SDK from %s' % fuchsia_sdk_path)
     return fail_loudly
 
   ExtractGzipArchive(archive, host_os, verbose)

--- a/tools/download_fuchsia_sdk.py
+++ b/tools/download_fuchsia_sdk.py
@@ -30,7 +30,7 @@ def FileNameForSdkPath(sdk_path):
 
 def DownloadFuchsiaSDKFromGCS(sdk_path, verbose):
   file = FileNameForSdkPath(sdk_path)
-  url = 'https://storage.googleapis.com/{}'.format(sdk_path)
+  url = 'https://storage.googleapis.com/fuchsia-artifacts/{}'.format(sdk_path)
   dest = os.path.join(FUCHSIA_SDK_DIR, file)
 
   if verbose:


### PR DESCRIPTION
Rather than using a file to identify the fuchsia sdk to download we will
use a property. This will allow fuchsia to test the sdk on presubmit
without having to modify anything in the flutter side.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
