### PR TITLE
WIP: Fix build on mac/arm64 host

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -4,6 +4,7 @@
 
 import("//flutter/common/config.gni")
 import("//flutter/examples/examples.gni")
+import("//flutter/shell/config.gni")
 import("//flutter/shell/platform/config.gni")
 import("//flutter/shell/platform/glfw/config.gni")
 import("//flutter/testing/testing.gni")
@@ -145,10 +146,6 @@ group("flutter") {
     public_deps += [
       "//flutter/flow:flow_unittests",
       "//flutter/fml:fml_unittests",
-      "//flutter/lib/spirv/test/exception_shaders:spirv_compile_exception_shaders",
-      "//flutter/lib/spirv/test/general_shaders:spirv_compile_general_shaders",
-      "//flutter/lib/spirv/test/supported_glsl_op_shaders:spirv_compile_supported_glsl_shaders",
-      "//flutter/lib/spirv/test/supported_op_shaders:spirv_compile_supported_op_shaders",
       "//flutter/lib/ui:ui_unittests",
       "//flutter/runtime:no_dart_plugin_registrant_unittests",
       "//flutter/runtime:runtime_unittests",
@@ -161,6 +158,15 @@ group("flutter") {
       "//flutter/third_party/tonic/tests:tonic_unittests",
       "//flutter/third_party/txt:txt_unittests",
     ]
+
+    if (shell_enable_gl) {
+      public_deps += [
+        "//flutter/lib/spirv/test/exception_shaders:spirv_compile_exception_shaders",
+        "//flutter/lib/spirv/test/general_shaders:spirv_compile_general_shaders",
+        "//flutter/lib/spirv/test/supported_glsl_op_shaders:spirv_compile_supported_glsl_shaders",
+        "//flutter/lib/spirv/test/supported_op_shaders:spirv_compile_supported_op_shaders",
+      ]
+    }
 
     # The accessibility library only supports Mac and Windows at the moment.
     if (is_mac || is_win) {

--- a/display_list/BUILD.gn
+++ b/display_list/BUILD.gn
@@ -2,6 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import("//flutter/shell/config.gni")
 import("//flutter/testing/testing.gni")
 
 source_set("display_list") {
@@ -78,7 +79,7 @@ if (enable_unittests) {
 
     defines = [ "ENABLE_SOFTWARE_BENCHMARKS" ]
 
-    if (!is_fuchsia) {
+    if (!is_fuchsia && shell_enable_gl) {
       defines += [ "ENABLE_OPENGL_BENCHMARKS" ]
       sources += [
         "display_list_benchmarks_gl.cc",

--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -13,7 +13,8 @@ group("generate_snapshot_bins") {
     ":generate_snapshot_bin",
     ":kernel_platform_files",
   ]
-  if (host_os == "mac" && (target_cpu == "arm" || target_cpu == "arm64")) {
+  if (host_os == "mac" && target_os == "ios" &&
+      (target_cpu == "arm" || target_cpu == "arm64")) {
     deps += [ ":create_arm_gen_snapshot" ]
   }
 }
@@ -197,7 +198,8 @@ bin_to_linkable("platform_strong_dill_linkable") {
   executable = false
 }
 
-if (host_os == "mac" && (target_cpu == "arm" || target_cpu == "arm64")) {
+if (host_os == "mac" && target_os == "ios" &&
+    (target_cpu == "arm" || target_cpu == "arm64")) {
   action("create_arm_gen_snapshot") {
     output_dir = "$root_out_dir/clang_x64"
     script = "//flutter/sky/tools/create_macos_gen_snapshots.py"

--- a/lib/ui/BUILD.gn
+++ b/lib/ui/BUILD.gn
@@ -4,6 +4,7 @@
 
 import("//build/fuchsia/sdk.gni")
 import("//flutter/common/config.gni")
+import("//flutter/shell/config.gni")
 import("//flutter/testing/testing.gni")
 
 source_set("ui") {
@@ -222,7 +223,7 @@ if (enable_unittests) {
     ]
 
     # TODO(https://github.com/flutter/flutter/issues/63837): This test is hard-coded to use a TestGLSurface so it cannot run on fuchsia.
-    if (!is_fuchsia) {
+    if (!is_fuchsia && shell_enable_gl) {
       sources += [ "painting/image_decoder_unittests.cc" ]
 
       deps += [ "//flutter/testing:opengl" ]

--- a/shell/config.gni
+++ b/shell/config.gni
@@ -3,7 +3,9 @@
 # found in the LICENSE file.
 
 declare_args() {
-  shell_enable_gl = !is_fuchsia
+  # OpenGL depends on swift_shader, which doesn't support arm64
+  shell_enable_gl =
+      !is_fuchsia && !(target_os == "mac" && target_cpu == "arm64")
 
   # The logic for enabling Vulkan and Metal is in tools/gn.
   shell_enable_metal = false

--- a/testing/BUILD.gn
+++ b/testing/BUILD.gn
@@ -181,8 +181,11 @@ if (enable_unittests) {
       ":testing",
       ":testing_fixtures",
       "//flutter/runtime:libdart",
-      "//flutter/vulkan",
     ]
+
+    if (target_os != "mac" || target_cpu == "x64") {
+      deps += [ "//flutter/vulkan" ]
+    }
 
     if (shell_enable_metal) {
       sources += [ "test_metal_surface_unittests.cc" ]
@@ -218,7 +221,7 @@ if (enable_unittests || is_ios) {
 
       # Skia's Vulkan support is enabled for all platforms (except iOS), and so parts of
       # Skia's graphics context reference Vulkan symbols.
-      if (!is_ios) {
+      if (!is_ios && target_cpu == "x64") {
         deps += [ "//flutter/vulkan" ]
       }
     }

--- a/testing/BUILD.gn
+++ b/testing/BUILD.gn
@@ -183,7 +183,7 @@ if (enable_unittests) {
       "//flutter/runtime:libdart",
     ]
 
-    if (target_os != "mac" || target_cpu == "x64") {
+    if (shell_enable_vulkan) {
       deps += [ "//flutter/vulkan" ]
     }
 
@@ -221,7 +221,7 @@ if (enable_unittests || is_ios) {
 
       # Skia's Vulkan support is enabled for all platforms (except iOS), and so parts of
       # Skia's graphics context reference Vulkan symbols.
-      if (!is_ios && target_cpu == "x64") {
+      if (shell_enable_vulkan) {
         deps += [ "//flutter/vulkan" ]
       }
     }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/97503

This enables build on `arm64` host with `target_cpu=arm64`. 

The build also needs `skia_use_vulkan` and `shell_enable_vulkan` set to `false`, as vulkan requires `swift_shader`, which currently doesn't support `arm64`.

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
