### PR TITLE
Migrate `run_tests.py` to  `dart pub get`

### DIFF
--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -403,12 +403,12 @@ def RunDartTests(build_dir, filter, verbose_dart_snapshot):
   # Before running Dart tests, make sure to run just that target (NOT the whole engine)
   EnsureDebugUnoptSkyPackagesAreBuilt()
 
-  # Now that we have the Sky packages at the hardcoded location, run `pub get`.
+  # Now that we have the Sky packages at the hardcoded location, run `dart pub get`.
   RunEngineExecutable(
     build_dir,
-    os.path.join('dart-sdk', 'bin', 'pub'),
+    os.path.join('dart-sdk', 'bin', 'dart'),
     None,
-    flags=['get', '--offline'],
+    flags=['pub', 'get', '--offline'],
     cwd=dart_tests_dir,
   )
 


### PR DESCRIPTION
toplevel `pub` doesn't exist anymore as a top level executable as from Dart 2.17.

Breaking change announcement:

* https://github.com/dart-lang/sdk/issues/46100

This landed in the Dart SDK: https://dart-review.googlesource.com/c/sdk/+/229541 This breaks everything that still tries to use it.

* https://logs.chromium.org/logs/dart/buildbucket/cr-buildbucket/8823468713275524977/+/u/test_engine/stdout

This migrates `run_tests.py` from `pub get` to `dart pub get`.