### PR TITLE
Replace skstd::optional with std::optional.

### DIFF
--- a/display_list/display_list_builder.cc
+++ b/display_list/display_list_builder.cc
@@ -187,7 +187,7 @@ void DisplayListBuilder::setAttributesFromPaint(
     setColor(paint.getColor());
   }
   if (flags.applies_blend()) {
-    skstd::optional<SkBlendMode> mode_optional = paint.asBlendMode();
+    std::optional<SkBlendMode> mode_optional = paint.asBlendMode();
     if (mode_optional) {
       setBlendMode(mode_optional.value());
     } else {

--- a/display_list/display_list_utils.h
+++ b/display_list/display_list_utils.h
@@ -564,7 +564,7 @@ class DisplayListBoundsCalculator final
 
   static constexpr SkScalar kMinStrokeWidth = 0.01;
 
-  skstd::optional<SkBlendMode> blend_mode_ = SkBlendMode::kSrcOver;
+  std::optional<SkBlendMode> blend_mode_ = SkBlendMode::kSrcOver;
   sk_sp<SkColorFilter> color_filter_;
 
   SkScalar half_stroke_width_ = kMinStrokeWidth;


### PR DESCRIPTION
Skia now uses the native C++17 library types instead of replacement classes.

skstd::optional will be removed shortly.
