### PR TITLE
[Win32, Keyboard] Lift redispatching to messages, via SendMessage.

### DIFF
--- a/shell/platform/windows/flutter_window_win32_unittests.cc
+++ b/shell/platform/windows/flutter_window_win32_unittests.cc
@@ -93,13 +93,9 @@ class SpyTextInputPlugin : public TextInputPlugin,
   std::unique_ptr<TextInputPlugin> real_implementation_;
 };
 
-class MockFlutterWindowWin32 : public FlutterWindowWin32,
-                               public MockMessageQueue {
+class MockFlutterWindowWin32 : public FlutterWindowWin32 {
  public:
-  MockFlutterWindowWin32(WPARAM virtual_key = 0, bool is_printable = true)
-      : virtual_key_(virtual_key),
-        is_printable_(is_printable),
-        FlutterWindowWin32(800, 600) {
+  MockFlutterWindowWin32() : FlutterWindowWin32(800, 600) {
     ON_CALL(*this, GetDpiScale())
         .WillByDefault(Return(this->FlutterWindowWin32::GetDpiScale()));
   }
@@ -111,25 +107,6 @@ class MockFlutterWindowWin32 : public FlutterWindowWin32,
 
   // Wrapper for GetCurrentDPI() which is a protected method.
   UINT GetDpi() { return GetCurrentDPI(); }
-
-  // Simulates a WindowProc message from the OS.
-  LRESULT InjectWindowMessage(UINT const message,
-                              WPARAM const wparam,
-                              LPARAM const lparam) {
-    return Win32SendMessage(message, wparam, lparam);
-  }
-
-  void InjectMessages(int count, Win32Message message1, ...) {
-    Win32Message messages[count];
-    messages[0] = message1;
-    va_list args;
-    va_start(args, message1);
-    for (int i = 1; i < count; i += 1) {
-      messages[i] = va_arg(args, Win32Message);
-    }
-    va_end(args);
-    InjectMessageList(count, messages);
-  }
 
   MOCK_METHOD1(OnDpiScale, void(unsigned int));
   MOCK_METHOD2(OnResize, void(unsigned int, unsigned int));
@@ -147,17 +124,11 @@ class MockFlutterWindowWin32 : public FlutterWindowWin32,
   MOCK_METHOD0(IsVisible, bool());
   MOCK_METHOD1(UpdateCursorRect, void(const Rect&));
   MOCK_METHOD0(OnResetImeComposing, void());
+  MOCK_METHOD3(Win32DispatchMessage, UINT(UINT, WPARAM, LPARAM));
+  MOCK_METHOD4(Win32PeekMessage, BOOL(LPMSG, UINT, UINT, UINT));
+  MOCK_METHOD1(Win32MapVkToChar, uint32_t(uint32_t ));
 
  protected:
-  // |KeyboardManagerWin32::WindowDelegate|
-  BOOL Win32PeekMessage(LPMSG lpMsg,
-                        UINT wMsgFilterMin,
-                        UINT wMsgFilterMax,
-                        UINT wRemoveMsg) override {
-    return MockMessageQueue::Win32PeekMessage(lpMsg, wMsgFilterMin,
-                                              wMsgFilterMax, wRemoveMsg);
-  }
-
   // |KeyboardManagerWin32::WindowDelegate|
   LRESULT Win32DefWindowProc(HWND hWnd,
                              UINT Msg,
@@ -165,52 +136,6 @@ class MockFlutterWindowWin32 : public FlutterWindowWin32,
                              LPARAM lParam) override {
     return kWmResultDefault;
   }
-
-  // |KeyboardManagerWin32::WindowDelegate|
-  UINT Win32DispatchEvent(UINT cInputs, LPINPUT pInputs, int cbSize) override {
-    for (UINT input_idx = 0; input_idx < cInputs; input_idx += 1) {
-      SendInput(pInputs[input_idx].ki);
-    }
-    return 1;
-  }
-
-  // |MockMessageQueue|
-  LRESULT Win32SendMessage(UINT const message,
-                           WPARAM const wparam,
-                           LPARAM const lparam) override {
-    return HandleMessage(message, wparam, lparam);
-  }
-
- private:
-  UINT SendInput(KEYBDINPUT kbdinput) {
-    // Simulate the event loop by just sending the event sent to
-    // "SendInput" directly to the window.
-    const bool is_key_up = kbdinput.dwFlags & KEYEVENTF_KEYUP;
-    const UINT message = is_key_up ? WM_KEYUP : WM_KEYDOWN;
-
-    const LPARAM lparam = CreateKeyEventLparam(
-        kbdinput.wScan, kbdinput.dwFlags & KEYEVENTF_EXTENDEDKEY, is_key_up);
-    // Windows would normally fill in the virtual key code for us, so we
-    // simulate it for the test with the key we know is in the test. The
-    // KBDINPUT we're passed doesn't have it filled in (on purpose, so that
-    // Windows will fill it in).
-    //
-    // TODO(dkwingsmt): Don't check the message results for redispatched
-    // messages for now, because making them work takes non-trivial rework
-    // to our current structure. https://github.com/flutter/flutter/issues/87843
-    // If this is resolved, change them to kWmResultDefault.
-    pending_responds_.push_back(
-        Win32Message{message, virtual_key_, lparam, kWmResultDontCheck});
-    if (is_printable_ && (kbdinput.dwFlags & KEYEVENTF_KEYUP) == 0) {
-      pending_responds_.push_back(
-          Win32Message{WM_CHAR, virtual_key_, lparam, kWmResultDontCheck});
-    }
-    return 1;
-  }
-
-  std::vector<Win32Message> pending_responds_;
-  WPARAM virtual_key_;
-  bool is_printable_;
 };
 
 class MockWindowBindingHandlerDelegate : public WindowBindingHandlerDelegate {

--- a/shell/platform/windows/flutter_window_win32_unittests.cc
+++ b/shell/platform/windows/flutter_window_win32_unittests.cc
@@ -126,7 +126,7 @@ class MockFlutterWindowWin32 : public FlutterWindowWin32 {
   MOCK_METHOD0(OnResetImeComposing, void());
   MOCK_METHOD3(Win32DispatchMessage, UINT(UINT, WPARAM, LPARAM));
   MOCK_METHOD4(Win32PeekMessage, BOOL(LPMSG, UINT, UINT, UINT));
-  MOCK_METHOD1(Win32MapVkToChar, uint32_t(uint32_t ));
+  MOCK_METHOD1(Win32MapVkToChar, uint32_t(uint32_t));
 
  protected:
   // |KeyboardManagerWin32::WindowDelegate|

--- a/shell/platform/windows/keyboard_manager_win32.cc
+++ b/shell/platform/windows/keyboard_manager_win32.cc
@@ -328,20 +328,20 @@ bool KeyboardManagerWin32::HandleMessage(UINT const action,
             .session = std::move(current_session_),
         });
         pending_texts_.push_back(PendingText{
-          .ready = false,
-          .content = text,
+            .ready = false,
+            .content = text,
         });
         auto pending_text = std::prev(pending_texts_.end());
         // SYS messages must not be handled by `HandleMessage` or be
         // redispatched.
         const bool is_syskey = action == WM_SYSCHAR || action == WM_SYSDEADCHAR;
-        OnKey(
-            std::move(event),
-            [this, char_action = action, pending_text, is_syskey](
-                std::unique_ptr<PendingEvent> event, bool handled) {
-              bool real_handled = handled || is_syskey;
-              HandleOnKeyResult(std::move(event), handled, char_action, pending_text);
-            });
+        OnKey(std::move(event),
+              [this, char_action = action, pending_text, is_syskey](
+                  std::unique_ptr<PendingEvent> event, bool handled) {
+                bool real_handled = handled || is_syskey;
+                HandleOnKeyResult(std::move(event), handled, char_action,
+                                  pending_text);
+              });
         return !is_syskey;
       }
 
@@ -357,8 +357,8 @@ bool KeyboardManagerWin32::HandleMessage(UINT const action,
       current_session_.clear();
       if (action == WM_CHAR && IsPrintable(wparam)) {
         pending_texts_.push_back(PendingText{
-          .ready = true,
-          .content = text,
+            .ready = true,
+            .content = text,
         });
         DispatchReadyTexts();
       }
@@ -413,12 +413,12 @@ bool KeyboardManagerWin32::HandleMessage(UINT const action,
       // SYS messages must not be handled by `HandleMessage` or be
       // redispatched.
       const bool is_syskey = action == WM_SYSKEYDOWN || action == WM_SYSKEYUP;
-      OnKey(
-          std::move(event),
-          [this, is_syskey](std::unique_ptr<PendingEvent> event, bool handled) {
-            bool real_handled = handled || is_syskey;
-            HandleOnKeyResult(std::move(event), handled, 0, pending_texts_.end());
-          });
+      OnKey(std::move(event), [this, is_syskey](
+                                  std::unique_ptr<PendingEvent> event,
+                                  bool handled) {
+        bool real_handled = handled || is_syskey;
+        HandleOnKeyResult(std::move(event), handled, 0, pending_texts_.end());
+      });
       return !is_syskey;
     }
     default:

--- a/shell/platform/windows/keyboard_manager_win32.cc
+++ b/shell/platform/windows/keyboard_manager_win32.cc
@@ -169,11 +169,9 @@ void KeyboardManagerWin32::RedispatchEvent(
     std::unique_ptr<PendingEvent> event) {
   for (const Win32Message& message : event->session) {
     UINT result = 0;
-    if (message.action != WM_CHAR) {
-      pending_redispatches_.push_back(message);
-      result = window_delegate_->Win32DispatchMessage(
-          message.action, message.wparam, message.lparam);
-    }
+    pending_redispatches_.push_back(message);
+    result = window_delegate_->Win32DispatchMessage(
+        message.action, message.wparam, message.lparam);
     if (result != 0) {
       std::cerr << "Unable to synthesize event for keyboard event."
                 << std::endl;
@@ -192,7 +190,7 @@ bool KeyboardManagerWin32::RemoveRedispatchedMessage(UINT const action,
                                                      LPARAM const lparam) {
   for (auto iter = pending_redispatches_.begin();
        iter != pending_redispatches_.end(); ++iter) {
-    if (action == iter->action && lparam == iter->lparam) {
+    if (action == iter->action && wparam == iter->wparam) {
       pending_redispatches_.erase(iter);
       return true;
     }

--- a/shell/platform/windows/keyboard_manager_win32.cc
+++ b/shell/platform/windows/keyboard_manager_win32.cc
@@ -287,7 +287,6 @@ bool KeyboardManagerWin32::HandleMessage(UINT const action,
       // OnText if the key down event is not handled.
       if (current_session_.front().IsGeneralKeyDown()) {
         const Win32Message first_message = current_session_.front();
-        current_session_.clear();
         const uint8_t scancode = (lparam >> 16) & 0xff;
         const uint16_t key_code = first_message.wparam;
         const bool extended = ((lparam >> 24) & 0x01) == 0x01;

--- a/shell/platform/windows/keyboard_manager_win32.cc
+++ b/shell/platform/windows/keyboard_manager_win32.cc
@@ -168,15 +168,14 @@ void KeyboardManagerWin32::DispatchEvent(const PendingEvent& event) {
 void KeyboardManagerWin32::RedispatchEvent(
     std::unique_ptr<PendingEvent> event) {
   for (const Win32Message& message : event->session) {
-    UINT accepted = 1;
+    UINT result = 0;
     if (message.action != WM_CHAR) {
-      accepted = window_delegate_->Win32DispatchMessage(
+      pending_redispatches_.push_back(message);
+      result = window_delegate_->Win32DispatchMessage(
           message.action, message.wparam, message.lparam);
     }
-    pending_redispatches_.push_back(message);
-    if (accepted != 1) {
-      std::cerr << "Unable to synthesize event for keyboard event. ("
-                << accepted << ")"
+    if (result != 0) {
+      std::cerr << "Unable to synthesize event for keyboard event."
                 << std::endl;
     }
   }

--- a/shell/platform/windows/keyboard_manager_win32.cc
+++ b/shell/platform/windows/keyboard_manager_win32.cc
@@ -136,9 +136,8 @@ KeyboardManagerWin32::KeyboardManagerWin32(WindowDelegate* delegate)
 void KeyboardManagerWin32::RedispatchEvent(
     std::unique_ptr<PendingEvent> event) {
   for (const Win32Message& message : event->session) {
-    UINT result = 0;
     pending_redispatches_.push_back(message);
-    result = window_delegate_->Win32DispatchMessage(
+    UINT result = window_delegate_->Win32DispatchMessage(
         message.action, message.wparam, message.lparam);
     if (result != 0) {
       std::cerr << "Unable to synthesize event for keyboard event."

--- a/shell/platform/windows/keyboard_manager_win32.h
+++ b/shell/platform/windows/keyboard_manager_win32.h
@@ -102,6 +102,7 @@ class KeyboardManagerWin32 {
   bool HandleMessage(UINT const message,
                      WPARAM const wparam,
                      LPARAM const lparam);
+
  protected:
   struct Win32Message {
     UINT action;
@@ -128,7 +129,7 @@ class KeyboardManagerWin32 {
     std::vector<Win32Message> session;
   };
 
-   virtual void RedispatchEvent(std::unique_ptr<PendingEvent> event);
+  virtual void RedispatchEvent(std::unique_ptr<PendingEvent> event);
 
  private:
   using OnKeyCallback =

--- a/shell/platform/windows/keyboard_manager_win32.h
+++ b/shell/platform/windows/keyboard_manager_win32.h
@@ -75,13 +75,6 @@ class KeyboardManagerWin32 {
     // Used to process key messages.
     virtual uint32_t Win32MapVkToChar(uint32_t virtual_key) = 0;
 
-    // Win32's |SendInput|.
-    //
-    // Used to synthesize key events.
-    virtual UINT Win32DispatchEvent(UINT cInputs,
-                                    LPINPUT pInputs,
-                                    int cbSize) = 0;
-
     // Win32's |SendMessage|.
     //
     // Used to synthesize key messages.
@@ -92,7 +85,7 @@ class KeyboardManagerWin32 {
 
   using KeyEventCallback = WindowDelegate::KeyEventCallback;
 
-  KeyboardManagerWin32(WindowDelegate* delegate);
+  explicit KeyboardManagerWin32(WindowDelegate* delegate);
 
   // Processes Win32 messages related to keyboard and text.
   //
@@ -109,8 +102,7 @@ class KeyboardManagerWin32 {
   bool HandleMessage(UINT const message,
                      WPARAM const wparam,
                      LPARAM const lparam);
-
- private:
+ protected:
   struct Win32Message {
     UINT action;
     WPARAM wparam;
@@ -134,12 +126,11 @@ class KeyboardManagerWin32 {
     bool was_down;
 
     std::vector<Win32Message> session;
-
-    // A value calculated out of critical event information that can be used
-    // to identify redispatched events.
-    uint64_t Hash() const { return ComputeEventHash(*this); }
   };
 
+   virtual void RedispatchEvent(std::unique_ptr<PendingEvent> event);
+
+ private:
   using OnKeyCallback =
       std::function<void(std::unique_ptr<PendingEvent>, bool)>;
 
@@ -159,14 +150,11 @@ class KeyboardManagerWin32 {
   // If there's no message, returns 0.
   UINT PeekNextMessageType(UINT wMsgFilterMin, UINT wMsgFilterMax);
 
-  void DispatchEvent(const PendingEvent& event);
-
   // Find an event in the redispatch list that matches the given one.
   //
   // If an matching event is found, removes the matching event from the
   // redispatch list, and returns true. Otherwise, returns false;
   bool RemoveRedispatchedMessage(UINT action, WPARAM wparam, LPARAM lparam);
-  void RedispatchEvent(std::unique_ptr<PendingEvent> event);
 
   WindowDelegate* window_delegate_;
 

--- a/shell/platform/windows/keyboard_win32_unittests.cc
+++ b/shell/platform/windows/keyboard_win32_unittests.cc
@@ -1397,15 +1397,15 @@ TEST(KeyboardTest, DeadKeyTwiceThenLetter) {
           kWmResultZero));
 
   EXPECT_EQ(recorded_callbacks.size(), 1);
-  EXPECT_EQ(key_calls.size(), 2);
+  EXPECT_EQ(key_calls.size(), 1);
   EXPECT_CALL_IS_EVENT(key_calls[0], kFlutterKeyEventTypeDown, kPhysicalBackquote,
                        kLogicalBackquote, "`", kNotSynthesized);
-  EXPECT_CALL_IS_TEXT(key_calls[1], u"`");
   clear_key_calls();
   // Key down event responded with false.
   recorded_callbacks.front()(false);
-  EXPECT_EQ(key_calls.size(), 1);
+  EXPECT_EQ(key_calls.size(), 2);
   EXPECT_CALL_IS_TEXT(key_calls[0], u"`");
+  EXPECT_CALL_IS_TEXT(key_calls[1], u"`");
   clear_key_calls();
 
   tester.Responding(false);
@@ -1540,15 +1540,15 @@ TEST(KeyboardTest, DisorderlyRespondedEvents) {
   // Resolve the second event first to test disordered responses.
   recorded_callbacks.back()(false);
 
-  EXPECT_EQ(key_calls.size(), 1);
-  EXPECT_CALL_IS_TEXT(key_calls[0], u"b");
+  EXPECT_EQ(key_calls.size(), 0);
   clear_key_calls();
 
   // Resolve the first event.
   recorded_callbacks.front()(false);
 
-  EXPECT_EQ(key_calls.size(), 1);
+  EXPECT_EQ(key_calls.size(), 2);
   EXPECT_CALL_IS_TEXT(key_calls[0], u"a");
+  EXPECT_CALL_IS_TEXT(key_calls[1], u"b");
   clear_key_calls();
 }
 

--- a/shell/platform/windows/keyboard_win32_unittests.cc
+++ b/shell/platform/windows/keyboard_win32_unittests.cc
@@ -148,11 +148,21 @@ class MockKeyboardManagerWin32Delegate
     return 1;
   }
 
+  UINT Win32DispatchMessage(UINT Msg, WPARAM wParam, LPARAM lParam) override {
+    pending_messages_.push_back(Win32Message{
+      .message = Msg,
+      .wParam = wParam,
+      .lParam = lParam,
+    });
+    return 1;
+  }
+
  private:
   WindowBindingHandlerDelegate* view_;
   std::unique_ptr<KeyboardManagerWin32> keyboard_manager_;
   MapVkToCharHandler map_vk_to_char_;
   std::vector<KEYBDINPUT> pending_responds_;
+  std::vector<Win32Message> pending_messages_;
 };
 
 class TestKeystate {

--- a/shell/platform/windows/keyboard_win32_unittests.cc
+++ b/shell/platform/windows/keyboard_win32_unittests.cc
@@ -1367,13 +1367,12 @@ TEST(KeyboardTest, DeadKeyTwiceThenLetter) {
 
   // Release `
   tester.InjectMessages(
-      1, WmKeyUpInfo{0xC0, kScanCodeBackquote, kNotExtended}.Build(
-             kWmResultZero));
+      1,
+      WmKeyUpInfo{0xC0, kScanCodeBackquote, kNotExtended}.Build(kWmResultZero));
 
   EXPECT_EQ(key_calls.size(), 1);
-  EXPECT_CALL_IS_EVENT(key_calls[0], kFlutterKeyEventTypeUp,
-                       kPhysicalBackquote, kLogicalBackquote, "",
-                       kNotSynthesized);
+  EXPECT_CALL_IS_EVENT(key_calls[0], kFlutterKeyEventTypeUp, kPhysicalBackquote,
+                       kLogicalBackquote, "", kNotSynthesized);
   clear_key_calls();
 
   // Press ` again.
@@ -1390,16 +1389,17 @@ TEST(KeyboardTest, DeadKeyTwiceThenLetter) {
       3,
       WmKeyDownInfo{0xC0, kScanCodeBackquote, kNotExtended, kWasUp}.Build(
           kWmResultZero),
-      WmCharInfo{'`', kScanCodeBackquote, kNotExtended, kWasUp,
-                     kBeingReleased, kNoContext, 1, /*bit25*/ true}
+      WmCharInfo{'`', kScanCodeBackquote, kNotExtended, kWasUp, kBeingReleased,
+                 kNoContext, 1, /*bit25*/ true}
           .Build(kWmResultZero),
       WmCharInfo{'`', kScanCodeBackquote, kNotExtended, kWasUp}.Build(
           kWmResultZero));
 
   EXPECT_EQ(recorded_callbacks.size(), 1);
   EXPECT_EQ(key_calls.size(), 1);
-  EXPECT_CALL_IS_EVENT(key_calls[0], kFlutterKeyEventTypeDown, kPhysicalBackquote,
-                       kLogicalBackquote, "`", kNotSynthesized);
+  EXPECT_CALL_IS_EVENT(key_calls[0], kFlutterKeyEventTypeDown,
+                       kPhysicalBackquote, kLogicalBackquote, "`",
+                       kNotSynthesized);
   clear_key_calls();
   // Key down event responded with false.
   recorded_callbacks.front()(false);
@@ -1412,13 +1412,12 @@ TEST(KeyboardTest, DeadKeyTwiceThenLetter) {
 
   // Release `
   tester.InjectMessages(
-      1, WmKeyUpInfo{0xC0, kScanCodeBackquote, kNotExtended}.Build(
-             kWmResultZero));
+      1,
+      WmKeyUpInfo{0xC0, kScanCodeBackquote, kNotExtended}.Build(kWmResultZero));
 
   EXPECT_EQ(key_calls.size(), 1);
-  EXPECT_CALL_IS_EVENT(key_calls[0], kFlutterKeyEventTypeUp,
-                       kPhysicalBackquote, kLogicalBackquote, "",
-                       kNotSynthesized);
+  EXPECT_CALL_IS_EVENT(key_calls[0], kFlutterKeyEventTypeUp, kPhysicalBackquote,
+                       kLogicalBackquote, "", kNotSynthesized);
   clear_key_calls();
 }
 

--- a/shell/platform/windows/keyboard_win32_unittests.cc
+++ b/shell/platform/windows/keyboard_win32_unittests.cc
@@ -1035,11 +1035,11 @@ TEST(KeyboardTest, AltGrModifiedKey) {
       WmSysKeyUpInfo{VK_MENU, kScanCodeAlt, kExtended}.Build(kWmResultDefault));
 
   EXPECT_EQ(key_calls.size(), 2);
-  EXPECT_CALL_IS_EVENT(key_calls[0], kFlutterKeyEventTypeUp, kPhysicalAltRight,
-                       kLogicalAltRight, "", kNotSynthesized);
-  EXPECT_CALL_IS_EVENT(key_calls[1], kFlutterKeyEventTypeUp,
+  EXPECT_CALL_IS_EVENT(key_calls[0], kFlutterKeyEventTypeUp,
                        kPhysicalControlLeft, kLogicalControlLeft, "",
                        kNotSynthesized);
+  EXPECT_CALL_IS_EVENT(key_calls[1], kFlutterKeyEventTypeUp, kPhysicalAltRight,
+                       kLogicalAltRight, "", kNotSynthesized);
   clear_key_calls();
 }
 
@@ -1090,11 +1090,11 @@ TEST(KeyboardTest, AltGrTwice) {
       1,
       WmSysKeyUpInfo{VK_MENU, kScanCodeAlt, kExtended}.Build(kWmResultDefault));
   EXPECT_EQ(key_calls.size(), 2);
-  EXPECT_CALL_IS_EVENT(key_calls[0], kFlutterKeyEventTypeUp, kPhysicalAltRight,
-                       kLogicalAltRight, "", kNotSynthesized);
-  EXPECT_CALL_IS_EVENT(key_calls[1], kFlutterKeyEventTypeUp,
+  EXPECT_CALL_IS_EVENT(key_calls[0], kFlutterKeyEventTypeUp,
                        kPhysicalControlLeft, kLogicalControlLeft, "",
                        kNotSynthesized);
+  EXPECT_CALL_IS_EVENT(key_calls[1], kFlutterKeyEventTypeUp, kPhysicalAltRight,
+                       kLogicalAltRight, "", kNotSynthesized);
   clear_key_calls();
 
   // 3. AltGr down (or: ControlLeft down then AltRight down.)
@@ -1125,18 +1125,20 @@ TEST(KeyboardTest, AltGrTwice) {
       1,
       WmSysKeyUpInfo{VK_MENU, kScanCodeAlt, kExtended}.Build(kWmResultDefault));
   EXPECT_EQ(key_calls.size(), 2);
-  EXPECT_CALL_IS_EVENT(key_calls[0], kFlutterKeyEventTypeUp, kPhysicalAltRight,
-                       kLogicalAltRight, "", kNotSynthesized);
-  EXPECT_CALL_IS_EVENT(key_calls[1], kFlutterKeyEventTypeUp,
+  EXPECT_CALL_IS_EVENT(key_calls[0], kFlutterKeyEventTypeUp,
                        kPhysicalControlLeft, kLogicalControlLeft, "",
                        kNotSynthesized);
+  EXPECT_CALL_IS_EVENT(key_calls[1], kFlutterKeyEventTypeUp, kPhysicalAltRight,
+                       kLogicalAltRight, "", kNotSynthesized);
   clear_key_calls();
 
   // 5. For key sequence 2: a real ControlLeft up.
   tester.InjectMessages(
       1, WmKeyUpInfo{VK_LCONTROL, kScanCodeControl, kNotExtended}.Build(
-             kWmResultDefault));
-  EXPECT_EQ(key_calls.size(), 0);
+             kWmResultZero));
+  EXPECT_EQ(key_calls.size(), 1);
+  EXPECT_CALL_IS_EVENT(key_calls[0], kFlutterKeyEventTypeDown, 0, 0, "",
+                       kNotSynthesized);
   clear_key_calls();
 }
 

--- a/shell/platform/windows/testing/wm_builders.cc
+++ b/shell/platform/windows/testing/wm_builders.cc
@@ -34,7 +34,8 @@ Win32Message WmKeyUpInfo::Build(LRESULT expected_result, HWND hWnd) {
 
 Win32Message WmCharInfo::Build(LRESULT expected_result, HWND hWnd) {
   uint32_t lParam = (repeat_count << 0) | (scan_code << 16) | (extended << 24) |
-                    (context << 30) | (prev_state << 30) | (transition << 31);
+                    (bit25 << 25) | (context << 29) | (prev_state << 30) |
+                    (transition << 31);
   return Win32Message{
       .message = WM_CHAR,
       .wParam = char_code,
@@ -72,7 +73,8 @@ Win32Message WmSysKeyUpInfo::Build(LRESULT expected_result, HWND hWnd) {
 
 Win32Message WmDeadCharInfo::Build(LRESULT expected_result, HWND hWnd) {
   uint32_t lParam = (repeat_count << 0) | (scan_code << 16) | (extended << 24) |
-                    (context << 30) | (prev_state << 30) | (transition << 31);
+                    (context << 30) | (prev_state << 30) |
+                    (transition << 31);
   return Win32Message{
       .message = WM_DEADCHAR,
       .wParam = char_code,

--- a/shell/platform/windows/testing/wm_builders.cc
+++ b/shell/platform/windows/testing/wm_builders.cc
@@ -73,8 +73,7 @@ Win32Message WmSysKeyUpInfo::Build(LRESULT expected_result, HWND hWnd) {
 
 Win32Message WmDeadCharInfo::Build(LRESULT expected_result, HWND hWnd) {
   uint32_t lParam = (repeat_count << 0) | (scan_code << 16) | (extended << 24) |
-                    (context << 30) | (prev_state << 30) |
-                    (transition << 31);
+                    (context << 30) | (prev_state << 30) | (transition << 31);
   return Win32Message{
       .message = WM_DEADCHAR,
       .wParam = char_code,

--- a/shell/platform/windows/testing/wm_builders.h
+++ b/shell/platform/windows/testing/wm_builders.h
@@ -111,6 +111,9 @@ typedef struct WmCharInfo {
 
   uint16_t repeat_count = 1;
 
+  // Some messages are sent with bit25. It's meaning is unknown.
+  bool bit25 = 0;
+
   Win32Message Build(LRESULT expected_result = kWmResultDontCheck,
                      HWND hWnd = NULL);
 } WmCharInfo;

--- a/shell/platform/windows/testing/wm_builders.h
+++ b/shell/platform/windows/testing/wm_builders.h
@@ -113,7 +113,7 @@ typedef struct WmCharInfo {
 
   // The 25th bit of the LParam.
   //
-  // Some messages are sent bit25 set. It's meaning is yet unknown.
+  // Some messages are sent with bit25 set. Its meaning is yet unknown.
   bool bit25 = 0;
 
   Win32Message Build(LRESULT expected_result = kWmResultDontCheck,

--- a/shell/platform/windows/testing/wm_builders.h
+++ b/shell/platform/windows/testing/wm_builders.h
@@ -111,7 +111,9 @@ typedef struct WmCharInfo {
 
   uint16_t repeat_count = 1;
 
-  // Some messages are sent with bit25. It's meaning is unknown.
+  // The 25th bit of the LParam.
+  //
+  // Some messages are sent bit25 set. It's meaning is yet unknown.
   bool bit25 = 0;
 
   Win32Message Build(LRESULT expected_result = kWmResultDontCheck,

--- a/shell/platform/windows/window_win32.cc
+++ b/shell/platform/windows/window_win32.cc
@@ -557,4 +557,8 @@ UINT WindowWin32::Win32DispatchEvent(UINT cInputs,
   return ::SendInput(cInputs, pInputs, cbSize);
 }
 
+UINT WindowWin32::Win32DispatchMessage(UINT Msg, WPARAM wParam, LPARAM lParam) {
+  return ::PostMessage(window_handle_, Msg, wParam, lParam);
+}
+
 }  // namespace flutter

--- a/shell/platform/windows/window_win32.cc
+++ b/shell/platform/windows/window_win32.cc
@@ -558,7 +558,7 @@ UINT WindowWin32::Win32DispatchEvent(UINT cInputs,
 }
 
 UINT WindowWin32::Win32DispatchMessage(UINT Msg, WPARAM wParam, LPARAM lParam) {
-  return ::PostMessage(window_handle_, Msg, wParam, lParam);
+  return ::SendMessage(window_handle_, Msg, wParam, lParam);
 }
 
 }  // namespace flutter

--- a/shell/platform/windows/window_win32.cc
+++ b/shell/platform/windows/window_win32.cc
@@ -551,12 +551,6 @@ uint32_t WindowWin32::Win32MapVkToChar(uint32_t virtual_key) {
   return ::MapVirtualKey(virtual_key, MAPVK_VK_TO_CHAR);
 }
 
-UINT WindowWin32::Win32DispatchEvent(UINT cInputs,
-                                     LPINPUT pInputs,
-                                     int cbSize) {
-  return ::SendInput(cInputs, pInputs, cbSize);
-}
-
 UINT WindowWin32::Win32DispatchMessage(UINT Msg, WPARAM wParam, LPARAM lParam) {
   return ::SendMessage(window_handle_, Msg, wParam, lParam);
 }

--- a/shell/platform/windows/window_win32.h
+++ b/shell/platform/windows/window_win32.h
@@ -49,11 +49,6 @@ class WindowWin32 : public KeyboardManagerWin32::WindowDelegate {
   virtual uint32_t Win32MapVkToChar(uint32_t virtual_key) override;
 
   // |KeyboardManagerWin32::WindowDelegate|
-  virtual UINT Win32DispatchEvent(UINT cInputs,
-                                  LPINPUT pInputs,
-                                  int cbSize) override;
-
-  // |KeyboardManagerWin32::WindowDelegate|
   virtual UINT Win32DispatchMessage(UINT Msg, WPARAM wParam, LPARAM lParam) override;
 
  protected:

--- a/shell/platform/windows/window_win32.h
+++ b/shell/platform/windows/window_win32.h
@@ -53,6 +53,9 @@ class WindowWin32 : public KeyboardManagerWin32::WindowDelegate {
                                   LPINPUT pInputs,
                                   int cbSize) override;
 
+  // |KeyboardManagerWin32::WindowDelegate|
+  virtual UINT Win32DispatchMessage(UINT Msg, WPARAM wParam, LPARAM lParam) override;
+
  protected:
   // Converts a c string to a wide unicode string.
   std::wstring NarrowToWide(const char* source);

--- a/shell/platform/windows/window_win32.h
+++ b/shell/platform/windows/window_win32.h
@@ -49,7 +49,9 @@ class WindowWin32 : public KeyboardManagerWin32::WindowDelegate {
   virtual uint32_t Win32MapVkToChar(uint32_t virtual_key) override;
 
   // |KeyboardManagerWin32::WindowDelegate|
-  virtual UINT Win32DispatchMessage(UINT Msg, WPARAM wParam, LPARAM lParam) override;
+  virtual UINT Win32DispatchMessage(UINT Msg,
+                                    WPARAM wParam,
+                                    LPARAM lParam) override;
 
  protected:
   // Converts a c string to a wide unicode string.


### PR DESCRIPTION
Currently, event redispatching is checked at the start of `OnKey`, and events are redispatched with `SendInput`. With this PR, event redispatching is checked at the start of `HandleMessage`, and events are redispatched with `SendMessage`.

This change has the following benefits:
- Redispatching via `SendMessage` keeps the exact content of messages, instead of having them twisted by `SendInput`. Notably, this allows redispatching SYS messages and character messages with diacritics.
- Similarly, filtering at the top-most `HandleMessage` level makes filtering much more precise, including their direct result.

Since `SendMessage` is processed synchronously, instantly, without going through the message queue. This means that redispatched messages will no longer be mistaken as real messages, or vice versa.

Additionally, since it is no longer needed to convert between inputs and messages, or to put inputs in a queue, the mock classes have been greatly simplified. 

This PR fixes https://github.com/flutter/flutter/issues/84210, fixes https://github.com/flutter/flutter/issues/95479, fixes https://github.com/flutter/flutter/issues/88388, and fixes https://github.com/flutter/flutter/issues/87843.

This PR is likely a fix to https://github.com/flutter/flutter/issues/77179 and https://github.com/flutter/flutter/issues/91482, since I can't reproduce them any more. But removing their temporary code will be done in a separate PR for the convenience of reference and revert.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
