### PR TITLE
Fix incorrect handling of error handling in case an isolate initialization fails

### DIFF
--- a/runtime/dart_isolate.h
+++ b/runtime/dart_isolate.h
@@ -421,7 +421,16 @@ class DartIsolate : public UIDartState {
               bool is_root_isolate,
               const UIDartState::Context& context);
 
-  [[nodiscard]] bool Initialize(Dart_Isolate isolate);
+  //----------------------------------------------------------------------------
+  /// @brief      Initializes the given (current) isolate.
+  ///
+  /// @param[in]  dart_isolate  The current isolate that is to be initialized.
+  ///
+  /// @return     Whether the initialization succeeded. Irrespective of whether
+  ///             the initialization suceeded, the current isolate will still be
+  ///             active.
+  ///
+  [[nodiscard]] bool Initialize(Dart_Isolate dart_isolate);
 
   void SetMessageHandlingTaskRunner(fml::RefPtr<fml::TaskRunner> runner);
 

--- a/runtime/dart_isolate_unittests.cc
+++ b/runtime/dart_isolate_unittests.cc
@@ -13,6 +13,7 @@
 #include "flutter/testing/dart_isolate_runner.h"
 #include "flutter/testing/fixture_test.h"
 #include "flutter/testing/testing.h"
+#include "third_party/dart/runtime/include/dart_api.h"
 #include "third_party/tonic/converter/dart_converter.h"
 #include "third_party/tonic/scopes/dart_isolate_scope.h"
 
@@ -256,6 +257,44 @@ TEST_F(DartSecondaryIsolateTest, CanLaunchSecondaryIsolates) {
   ASSERT_FALSE(RootIsolateIsSignaled());
   LatchWait();  // wait for last NotifyNative called by main isolate
   // root isolate will be auto-shutdown
+}
+
+/// Tests error handling path of `Isolate.spawn()` in the engine.
+class IsolateStartupFailureTest : public FixtureTest {
+ public:
+  IsolateStartupFailureTest() : latch_(1) {}
+  void NotifyDone() { latch_.CountDown(); }
+  void WaitForDone() { latch_.Wait(); }
+
+ private:
+  fml::CountDownLatch latch_;
+  FML_DISALLOW_COPY_AND_ASSIGN(IsolateStartupFailureTest);
+};
+
+TEST_F(IsolateStartupFailureTest,
+       HandlesIsolateInitializationFailureCorrectly) {
+  AddNativeCallback("MakeNextIsolateSpawnFail",
+                    CREATE_NATIVE_ENTRY(([](Dart_NativeArguments args) {
+                      Dart_SetRootLibrary(Dart_Null());
+                    })));
+  AddNativeCallback("NotifyNative",
+                    CREATE_NATIVE_ENTRY(
+                        ([this](Dart_NativeArguments args) { NotifyDone(); })));
+  auto settings = CreateSettingsForFixture();
+  auto vm_ref = DartVMRef::Create(settings);
+  auto thread = CreateNewThread();
+  TaskRunners task_runners(GetCurrentTestName(),  //
+                           thread,                //
+                           thread,                //
+                           thread,                //
+                           thread                 //
+  );
+  auto isolate = RunDartCodeInIsolate(vm_ref, settings, task_runners,
+                                      "testIsolateStartupFailure", {},
+                                      GetDefaultKernelFilePath());
+  ASSERT_TRUE(isolate);
+  ASSERT_EQ(isolate->get()->GetPhase(), DartIsolate::Phase::Running);
+  WaitForDone();
 }
 
 TEST_F(DartIsolateTest, CanReceiveArguments) {


### PR DESCRIPTION
For isolates spawned by the application via `Isolate.spawn()`ed, the VM
will create a "lightweight" isolate and invoke the "initialize_isolate"
embedder callback to initialize it.

The embedder-provided callback will be invoked with the active isolate
and is expected to return with that active isolate - irrespective of
whether it succeeded to initialize or not.
=> The unsuccessful path was using `Dart_ExitIsolate()` - which is
   incorrect.

This PR fixes that by not exiting the isolate. As a side-effect of the
fix, we also do less `Dart_EnterIsolate()`/`Dart_ExitIsolate()` calls in
initialization (which makes it faster) and handle failure to spawn the
root isolate. Furthermore this PR removes some dead code and replaces it
with `FML_DCHECK()`s instead.

Due to no way to reproduce this failure to initialize isolate in normal
circumstances, this PR was tested manually by injecting a `return
false`
into the non-root isolate case of `DartIsolate::InitializeIsolate()` and
ensuring that an appropriate exception gets thrown on the Dart
side (i.e. the `await Isolate.spawn()` call).

Fixes https://github.com/flutter/flutter/issues/90478