### PR TITLE
Small cleanup to DisplayListComplexityScoreCalculator code

### DIFF
--- a/display_list/display_list_complexity.cc
+++ b/display_list/display_list_complexity.cc
@@ -1,4 +1,3 @@
-
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -111,7 +111,7 @@ static bool IsDisplayListWorthRasterizing(
 
   // TODO(abarth): We should find a better heuristic here that lets us avoid
   // wasting memory on trivial layers that are easy to re-rasterize every frame.
-  int complexity_score = complexity_calculator->compute(display_list);
+  unsigned int complexity_score = complexity_calculator->compute(display_list);
   return complexity_calculator->should_be_cached(complexity_score);
 }
 


### PR DESCRIPTION
Fixes a minor nit from https://github.com/flutter/engine/pull/31176 and a place where I was inadvertently casting from an unsigned int to an int.