### PR TITLE
Refactor initializeCanvasKit

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/initialization.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/initialization.dart
@@ -37,76 +37,72 @@ String get canvasKitBuildUrl =>
     configuration.canvasKitBaseUrl + (kProfileMode ? 'profiling/' : '');
 String get canvasKitJavaScriptBindingsUrl =>
     canvasKitBuildUrl + 'canvaskit.js';
-String canvasKitWasmModuleUrl(String file) => _currentCanvasKitBase! + file;
-
-/// The script element which CanvasKit is loaded from.
-html.ScriptElement? _canvasKitScript;
-
-/// A [Future] which completes when the CanvasKit script has been loaded.
-Future<void>? _canvasKitLoaded;
-
-/// The currently used base URL for loading CanvasKit.
-String? _currentCanvasKitBase;
+String canvasKitWasmModuleUrl(String canvasKitBase, String file) =>
+    canvasKitBase + file;
 
 /// Initialize CanvasKit.
 ///
-/// This calls `CanvasKitInit` and assigns the global [canvasKit] object.
-Future<void> initializeCanvasKit({String? canvasKitBase}) {
-  final Completer<void> canvasKitCompleter = Completer<void>();
+/// Uses a cached implemenation if it exists. Otherwise downloads CanvasKit.
+/// Assigns the global [canvasKit] object.
+Future<void> initializeCanvasKit({String? canvasKitBase}) async {
   if (windowFlutterCanvasKit != null) {
     canvasKit = windowFlutterCanvasKit!;
-    canvasKitCompleter.complete();
   } else {
-    _startDownloadingCanvasKit(canvasKitBase);
-    _canvasKitLoaded!.then((_) {
-      final CanvasKitInitPromise canvasKitInitPromise =
-          CanvasKitInit(CanvasKitInitOptions(
-        locateFile: allowInterop(
-            (String file, String unusedBase) => canvasKitWasmModuleUrl(file)),
-      ));
-      canvasKitInitPromise.then(allowInterop((CanvasKit ck) {
-        canvasKit = ck;
-        windowFlutterCanvasKit = canvasKit;
-        canvasKitCompleter.complete();
-      }));
-    });
+    canvasKit = await downloadCanvasKit(canvasKitBase: canvasKitBase);
+    windowFlutterCanvasKit = canvasKit;
   }
 
   /// Add a Skia scene host.
   skiaSceneHost = html.Element.tag('flt-scene');
   flutterViewEmbedder.renderScene(skiaSceneHost);
-  return canvasKitCompleter.future;
 }
 
-/// Starts downloading the CanvasKit JavaScript file at [canvasKitBase] and sets
-/// [_canvasKitLoaded].
-void _startDownloadingCanvasKit(String? canvasKitBase) {
+/// Download and initialize the CanvasKit module.
+///
+/// Downloads the CanvasKit JavaScript, then calls `CanvasKitInit` to download
+/// and intialize the CanvasKit wasm.
+Future<CanvasKit> downloadCanvasKit({String? canvasKitBase}) async {
+  await _downloadCanvasKitJs(canvasKitBase: canvasKitBase);
+  final Completer<CanvasKit> canvasKitInitCompleter = Completer<CanvasKit>();
+  final CanvasKitInitPromise canvasKitInitPromise =
+      CanvasKitInit(CanvasKitInitOptions(
+    locateFile: allowInterop((String file, String unusedBase) =>
+        canvasKitWasmModuleUrl(canvasKitBase ?? canvasKitBuildUrl, file)),
+  ));
+  canvasKitInitPromise.then(allowInterop((CanvasKit ck) {
+    canvasKitInitCompleter.complete(ck);
+  }));
+  return canvasKitInitCompleter.future;
+}
+
+/// Downloads the CanvasKit JavaScript file at [canvasKitBase].
+Future<void> _downloadCanvasKitJs({String? canvasKitBase}) {
   final String canvasKitJavaScriptUrl = canvasKitBase != null
       ? canvasKitBase + 'canvaskit.js'
       : canvasKitJavaScriptBindingsUrl;
-  _currentCanvasKitBase = canvasKitBase ?? canvasKitBuildUrl;
-  // Only reset CanvasKit if it's not already available.
-  if (windowFlutterCanvasKit == null) {
-    _canvasKitScript?.remove();
-    _canvasKitScript = html.ScriptElement();
-    _canvasKitScript!.src = canvasKitJavaScriptUrl;
 
-    final Completer<void> canvasKitLoadCompleter = Completer<void>();
-    _canvasKitLoaded = canvasKitLoadCompleter.future;
+  final html.ScriptElement canvasKitScript = html.ScriptElement();
+  canvasKitScript.src = canvasKitJavaScriptUrl;
 
-    late StreamSubscription<html.Event> loadSubscription;
-    loadSubscription = _canvasKitScript!.onLoad.listen((_) {
-      loadSubscription.cancel();
-      canvasKitLoadCompleter.complete();
-    });
+  final Completer<void> canvasKitLoadCompleter = Completer<void>();
+  late StreamSubscription<html.Event> loadSubscription;
+  loadSubscription = canvasKitScript.onLoad.listen((_) {
+    loadSubscription.cancel();
+    canvasKitLoadCompleter.complete();
+  });
 
-    patchCanvasKitModule(_canvasKitScript!);
-  }
+  patchCanvasKitModule(canvasKitScript);
+
+  return canvasKitLoadCompleter.future;
 }
 
 /// The Skia font collection.
 SkiaFontCollection get skiaFontCollection => _skiaFontCollection!;
 SkiaFontCollection? _skiaFontCollection;
+
+void debugSetSkiaFontCollection(SkiaFontCollection? value) {
+  _skiaFontCollection = value;
+}
 
 /// Initializes [skiaFontCollection].
 void ensureSkiaFontCollectionInitialized() {

--- a/lib/web_ui/lib/src/engine/canvaskit/initialization.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/initialization.dart
@@ -100,10 +100,6 @@ Future<void> _downloadCanvasKitJs({String? canvasKitBase}) {
 SkiaFontCollection get skiaFontCollection => _skiaFontCollection!;
 SkiaFontCollection? _skiaFontCollection;
 
-void debugSetSkiaFontCollection(SkiaFontCollection? value) {
-  _skiaFontCollection = value;
-}
-
 /// Initializes [skiaFontCollection].
 void ensureSkiaFontCollectionInitialized() {
   _skiaFontCollection ??= SkiaFontCollection();


### PR DESCRIPTION
Splits out the CanvasKitInitOptions call to a separate downloadCanvasKit
function.

Removes some unnecessary global variables.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
