### PR TITLE
Don't remove views while the rasterizer is torn down

### DIFF
--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
@@ -657,17 +657,13 @@ public class PlatformViewsControllerTest {
 
     platformViewsController.detach();
 
-    assertThrows(
-        IllegalStateException.class,
-        () -> {
-          platformViewsController.onDisplayOverlaySurface(
-              overlaySurface.getId(), /* x=*/ 0, /* y=*/ 0, /* width=*/ 10, /* height=*/ 10);
-        });
+    verify(overlayImageView, times(1)).closeImageReader();
+    verify(overlayImageView, times(1)).detachFromRenderer();
   }
 
   @Test
   @Config(shadows = {ShadowFlutterSurfaceView.class, ShadowFlutterJNI.class})
-  public void detachFromView__removesOverlaySurfaces() {
+  public void detachFromView__removesAndDestroysOverlayViews() {
     final PlatformViewsController platformViewsController = new PlatformViewsController();
 
     final int platformViewId = 0;
@@ -683,6 +679,9 @@ public class PlatformViewsControllerTest {
     final FlutterJNI jni = new FlutterJNI();
     jni.attachToNative();
     attach(jni, platformViewsController);
+
+    final FlutterView flutterView = mock(FlutterView.class);
+    platformViewsController.attachToView(flutterView);
 
     final FlutterImageView overlayImageView = mock(FlutterImageView.class);
     when(overlayImageView.acquireLatestImage()).thenReturn(true);
@@ -695,17 +694,14 @@ public class PlatformViewsControllerTest {
 
     platformViewsController.detachFromView();
 
-    assertThrows(
-        IllegalStateException.class,
-        () -> {
-          platformViewsController.onDisplayOverlaySurface(
-              overlaySurface.getId(), /* x=*/ 0, /* y=*/ 0, /* width=*/ 10, /* height=*/ 10);
-        });
+    verify(overlayImageView, times(1)).closeImageReader();
+    verify(overlayImageView, times(1)).detachFromRenderer();
+    verify(flutterView, times(1)).removeView(overlayImageView);
   }
 
   @Test
   @Config(shadows = {ShadowFlutterSurfaceView.class, ShadowFlutterJNI.class})
-  public void destroyOverlaySurfaces__doesNotThrowIfControllerIsDetached() {
+  public void destroyOverlaySurfaces__doesNotThrowIfFlutterViewIsDetached() {
     final PlatformViewsController platformViewsController = new PlatformViewsController();
 
     final int platformViewId = 0;
@@ -721,6 +717,9 @@ public class PlatformViewsControllerTest {
     final FlutterJNI jni = new FlutterJNI();
     jni.attachToNative();
     attach(jni, platformViewsController);
+
+    final FlutterView flutterView = mock(FlutterView.class);
+    platformViewsController.attachToView(flutterView);
 
     final FlutterImageView overlayImageView = mock(FlutterImageView.class);
     when(overlayImageView.acquireLatestImage()).thenReturn(true);
@@ -735,6 +734,42 @@ public class PlatformViewsControllerTest {
 
     platformViewsController.destroyOverlaySurfaces();
     verify(overlayImageView, times(1)).closeImageReader();
+    verify(overlayImageView, times(1)).detachFromRenderer();
+  }
+
+  @Test
+  @Config(shadows = {ShadowFlutterSurfaceView.class, ShadowFlutterJNI.class})
+  public void destroyOverlaySurfaces__doesNotRemoveOverlayView() {
+    final PlatformViewsController platformViewsController = new PlatformViewsController();
+
+    final int platformViewId = 0;
+    assertNull(platformViewsController.getPlatformViewById(platformViewId));
+
+    final PlatformViewFactory viewFactory = mock(PlatformViewFactory.class);
+    final PlatformView platformView = mock(PlatformView.class);
+    when(platformView.getView()).thenReturn(mock(View.class));
+    when(viewFactory.create(any(), eq(platformViewId), any())).thenReturn(platformView);
+
+    platformViewsController.getRegistry().registerViewFactory("testType", viewFactory);
+
+    final FlutterJNI jni = new FlutterJNI();
+    jni.attachToNative();
+    attach(jni, platformViewsController);
+
+    final FlutterView flutterView = mock(FlutterView.class);
+    platformViewsController.attachToView(flutterView);
+
+    final FlutterImageView overlayImageView = mock(FlutterImageView.class);
+    when(overlayImageView.acquireLatestImage()).thenReturn(true);
+
+    final FlutterOverlaySurface overlaySurface =
+        platformViewsController.createOverlaySurface(overlayImageView);
+
+    platformViewsController.onDisplayOverlaySurface(
+        overlaySurface.getId(), /* x=*/ 0, /* y=*/ 0, /* width=*/ 10, /* height=*/ 10);
+
+    platformViewsController.destroyOverlaySurfaces();
+    verify(flutterView, never()).removeView(overlayImageView);
   }
 
   @Test


### PR DESCRIPTION
When `FlutterFragment` is used, the Android framework configures an animation.
The end animation recurses the view hierarchy and assumes that no views are removed during this time.

This PR removes the views when `Fragment#onDestroyView` is called.

Fixes https://github.com/flutter/flutter/issues/97679

