### PR TITLE
(WIP) maintain ColorFilter construction details for embedding in DisplayList

### DIFF
--- a/display_list/display_list.h
+++ b/display_list/display_list.h
@@ -78,6 +78,10 @@ namespace flutter {
   V(ClearShader)                    \
   V(SetColorFilter)                 \
   V(ClearColorFilter)               \
+  V(SetBlendColorFilter)            \
+  V(SetMatrixColorFilter)           \
+  V(SetSrgbToLinearColorFilter)     \
+  V(SetLinearToSrgbColorFilter)     \
   V(SetImageFilter)                 \
   V(ClearImageFilter)               \
   V(SetPathEffect)                  \
@@ -146,6 +150,15 @@ namespace flutter {
 #define DL_OP_TO_ENUM_VALUE(name) k##name,
 enum class DisplayListOpType { FOR_EACH_DISPLAY_LIST_OP(DL_OP_TO_ENUM_VALUE) };
 #undef DL_OP_TO_ENUM_VALUE
+
+enum ColorFilterType {
+  kNone,
+  kBlend,
+  kMatrix,
+  kSrgbToLinear,
+  kLinearToSrgb,
+  kUnknown,
+};
 
 class Dispatcher;
 class DisplayListBuilder;

--- a/display_list/display_list_dispatcher.h
+++ b/display_list/display_list_dispatcher.h
@@ -43,6 +43,10 @@ class Dispatcher {
   // It is not reset by |setColorFilter|, but instead composed with that
   // filter so that the color inversion happens after the ColorFilter.
   virtual void setInvertColors(bool invert) = 0;
+  virtual void setBlendColorFilter(SkColor color, SkBlendMode mode) = 0;
+  virtual void setMatrixColorFilter(const float matrix[20]) = 0;
+  virtual void setSrgbToLinearGammaColorFilter() = 0;
+  virtual void setLinearToSrgbGammaColorFilter() = 0;
   virtual void setBlendMode(SkBlendMode mode) = 0;
   virtual void setBlender(sk_sp<SkBlender> blender) = 0;
   virtual void setPathEffect(sk_sp<SkPathEffect> effect) = 0;

--- a/display_list/display_list_ops.h
+++ b/display_list/display_list_ops.h
@@ -182,6 +182,60 @@ DEFINE_SET_CLEAR_SKREF_OP(MaskFilter, filter)
 DEFINE_SET_CLEAR_SKREF_OP(PathEffect, effect)
 #undef DEFINE_SET_CLEAR_SKREF_OP
 
+// 4 byte header + 8 byte payload uses 16 bytes (4 bytes unused)
+struct SetBlendColorFilterOp final : DLOp {
+  static const auto kType = DisplayListOpType::kSetBlendColorFilter;
+
+  explicit SetBlendColorFilterOp(SkColor color, SkBlendMode mode)
+      : color(color), mode(mode) {}
+
+  SkColor color;
+  SkBlendMode mode;
+
+  void dispatch(Dispatcher& dispatcher) const {
+    dispatcher.setBlendColorFilter(color, mode);
+  }
+};
+
+// 4 byte header + 80 byte payload uses 88 bytes (4 bytes unused)
+struct SetMatrixColorFilterOp final : DLOp {
+  static const auto kType = DisplayListOpType::kSetMatrixColorFilter;
+
+  explicit SetMatrixColorFilterOp(const float matrix[20]) {
+    memcpy(this->matrix, matrix, sizeof(this->matrix));
+  }
+
+  float matrix[20];
+
+  void dispatch(Dispatcher& dispatcher) const {
+    float matrix_copy[20];
+    memcpy(matrix_copy, matrix, sizeof(matrix));
+    dispatcher.setMatrixColorFilter(matrix_copy);
+  }
+};
+
+// 4 byte header with no payload uses 8 bytes (4 bytes unused)
+struct SetSrgbToLinearColorFilterOp final : DLOp {
+  static const auto kType = DisplayListOpType::kSetSrgbToLinearColorFilter;
+
+  SetSrgbToLinearColorFilterOp() {}
+
+  void dispatch(Dispatcher& dispatcher) const {
+    dispatcher.setSrgbToLinearGammaColorFilter();
+  }
+};
+
+// 4 byte header with no payload uses 8 bytes (4 bytes unused)
+struct SetLinearToSrgbColorFilterOp final : DLOp {
+  static const auto kType = DisplayListOpType::kSetLinearToSrgbColorFilter;
+
+  SetLinearToSrgbColorFilterOp() {}
+
+  void dispatch(Dispatcher& dispatcher) const {
+    dispatcher.setLinearToSrgbGammaColorFilter();
+  }
+};
+
 // 4 byte header + 4 byte payload packs into minimum 8 bytes
 // Note that the "blur style" is packed into the OpType to prevent
 // needing an additional 8 bytes for a 4-value enum.

--- a/display_list/display_list_unittests.cc
+++ b/display_list/display_list_unittests.cc
@@ -1594,5 +1594,77 @@ TEST(DisplayList, SaveLayerBoundsSnapshotsImageFilter) {
   EXPECT_EQ(bounds, SkRect::MakeLTRB(50, 50, 100, 100));
 }
 
+TEST(DisplayList, SetBlendColorFilterMatchesSetColorFilter) {
+  DisplayListBuilder builder1;
+  builder1.setColorFilter(SkColorFilters::Blend(SK_ColorRED, SkBlendMode::kHue));
+  sk_sp<DisplayList> display_list1 = builder1.Build();
+
+  DisplayListBuilder builder2;
+  builder2.setBlendColorFilter(SK_ColorRED, SkBlendMode::kHue);
+  sk_sp<DisplayList> display_list2 = builder2.Build();
+
+  EXPECT_EQ(display_list1->bounds(), display_list2->bounds());
+  EXPECT_EQ(display_list1->op_count(true), display_list2->op_count(true));
+  EXPECT_EQ(display_list1->op_count(false), display_list2->op_count(false));
+  EXPECT_EQ(display_list1->bytes(true), display_list2->bytes(true));
+  EXPECT_EQ(display_list1->bytes(false), display_list2->bytes(false));
+  EXPECT_TRUE(display_list1->Equals(*display_list2));
+}
+
+TEST(DisplayList, SetMatrixColorFilterMatchesSetColorFilter) {
+  DisplayListBuilder builder1;
+  builder1.setColorFilter(SkColorFilters::Matrix(rotate_color_matrix));
+  sk_sp<DisplayList> display_list1 = builder1.Build();
+
+  DisplayListBuilder builder2;
+  builder2.setMatrixColorFilter(rotate_color_matrix);
+  sk_sp<DisplayList> display_list2 = builder2.Build();
+
+  EXPECT_EQ(display_list1->bounds(), display_list2->bounds());
+  EXPECT_EQ(display_list1->op_count(true), display_list2->op_count(true));
+  EXPECT_EQ(display_list1->op_count(false), display_list2->op_count(false));
+  EXPECT_EQ(display_list1->bytes(true), display_list2->bytes(true));
+  EXPECT_EQ(display_list1->bytes(false), display_list2->bytes(false));
+  EXPECT_TRUE(display_list1->Equals(*display_list2));
+}
+
+TEST(DisplayList, SetSrgbToLinearColorFilterMatchesSetColorFilter) {
+  DisplayListBuilder builder1;
+  builder1.setColorFilter(SkColorFilters::SRGBToLinearGamma());
+  sk_sp<DisplayList> display_list1 = builder1.Build();
+
+  DisplayListBuilder builder2;
+  builder2.setSrgbToLinearGammaColorFilter();
+  sk_sp<DisplayList> display_list2 = builder2.Build();
+
+  EXPECT_EQ(display_list1->bounds(), display_list2->bounds());
+  EXPECT_EQ(display_list1->op_count(true), display_list2->op_count(true));
+  EXPECT_EQ(display_list1->op_count(false), display_list2->op_count(false));
+  // Unfortunately, until we can recapture these gamma shifting ColorFilters
+  // from their Skia objects, the following tests will fail
+  // EXPECT_EQ(display_list1->bytes(true), display_list2->bytes(true));
+  // EXPECT_EQ(display_list1->bytes(false), display_list2->bytes(false));
+  // EXPECT_TRUE(display_list1->Equals(*display_list2));
+}
+
+TEST(DisplayList, SetLinearToSrgbColorFilterMatchesSetColorFilter) {
+  DisplayListBuilder builder1;
+  builder1.setColorFilter(SkColorFilters::LinearToSRGBGamma());
+  sk_sp<DisplayList> display_list1 = builder1.Build();
+
+  DisplayListBuilder builder2;
+  builder2.setLinearToSrgbGammaColorFilter();
+  sk_sp<DisplayList> display_list2 = builder2.Build();
+
+  EXPECT_EQ(display_list1->bounds(), display_list2->bounds());
+  EXPECT_EQ(display_list1->op_count(true), display_list2->op_count(true));
+  EXPECT_EQ(display_list1->op_count(false), display_list2->op_count(false));
+  // Unfortunately, until we can recapture these gamma shifting ColorFilters
+  // from their Skia objects, the following tests will fail
+  // EXPECT_EQ(display_list1->bytes(true), display_list2->bytes(true));
+  // EXPECT_EQ(display_list1->bytes(false), display_list2->bytes(false));
+  // EXPECT_TRUE(display_list1->Equals(*display_list2));
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/display_list/display_list_unittests.cc
+++ b/display_list/display_list_unittests.cc
@@ -1596,7 +1596,8 @@ TEST(DisplayList, SaveLayerBoundsSnapshotsImageFilter) {
 
 TEST(DisplayList, SetBlendColorFilterMatchesSetColorFilter) {
   DisplayListBuilder builder1;
-  builder1.setColorFilter(SkColorFilters::Blend(SK_ColorRED, SkBlendMode::kHue));
+  builder1.setColorFilter(
+      SkColorFilters::Blend(SK_ColorRED, SkBlendMode::kHue));
   sk_sp<DisplayList> display_list1 = builder1.Build();
 
   DisplayListBuilder builder2;

--- a/display_list/display_list_unittests.cc
+++ b/display_list/display_list_unittests.cc
@@ -95,10 +95,12 @@ static const sk_sp<SkImageFilter> TestImageFilter1 =
     SkImageFilters::Blur(5.0, 5.0, SkTileMode::kDecal, nullptr, nullptr);
 static const sk_sp<SkImageFilter> TestImageFilter2 =
     SkImageFilters::Blur(5.0, 5.0, SkTileMode::kClamp, nullptr, nullptr);
-static const sk_sp<SkColorFilter> TestColorFilter1 =
-    SkColorFilters::Matrix(rotate_color_matrix);
-static const sk_sp<SkColorFilter> TestColorFilter2 =
-    SkColorFilters::Matrix(invert_color_matrix);
+static const sk_sp<SkColorFilter> TestColorFilter1 = SkColorFilters::Compose(
+    SkColorFilters::Matrix(rotate_color_matrix),
+    SkColorFilters::Blend(SK_ColorRED, SkBlendMode::kSrcIn));
+static const sk_sp<SkColorFilter> TestColorFilter2 = SkColorFilters::Compose(
+    SkColorFilters::Matrix(invert_color_matrix),
+    SkColorFilters::Blend(SK_ColorRED, SkBlendMode::kSrcIn));
 static const sk_sp<SkPathEffect> TestPathEffect1 =
     SkDashPathEffect::Make(TestDashes1, 2, 0.0f);
 static const sk_sp<SkPathEffect> TestPathEffect2 =
@@ -343,6 +345,13 @@ std::vector<DisplayListInvocationGroup> allGroups = {
   { "SetColorFilter", {
       {0, 16, 0, 0, [](DisplayListBuilder& b) {b.setColorFilter(TestColorFilter1);}},
       {0, 16, 0, 0, [](DisplayListBuilder& b) {b.setColorFilter(TestColorFilter2);}},
+      {0, 16, 0, 0, [](DisplayListBuilder& b) {b.setBlendColorFilter(SK_ColorRED, SkBlendMode::kSrcIn);}},
+      {0, 16, 0, 0, [](DisplayListBuilder& b) {b.setBlendColorFilter(SK_ColorRED, SkBlendMode::kDstIn);}},
+      {0, 16, 0, 0, [](DisplayListBuilder& b) {b.setBlendColorFilter(SK_ColorBLUE, SkBlendMode::kSrcIn);}},
+      {0, 88, 0, 0, [](DisplayListBuilder& b) {b.setMatrixColorFilter(rotate_color_matrix);}},
+      {0, 88, 0, 0, [](DisplayListBuilder& b) {b.setMatrixColorFilter(invert_color_matrix);}},
+      {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setSrgbToLinearGammaColorFilter();}},
+      {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setLinearToSrgbGammaColorFilter();}},
       {0, 0, 0, 0, [](DisplayListBuilder& b) {b.setColorFilter(nullptr);}},
     }
   },
@@ -1230,8 +1239,9 @@ TEST(DisplayList, DisplayListColorFilterRefHandling) {
     bool ref_is_unique() const override { return color_filter->unique(); }
 
    private:
-    sk_sp<SkColorFilter> color_filter =
-        SkColorFilters::Blend(SK_ColorBLUE, SkBlendMode::kSrcIn);
+    sk_sp<SkColorFilter> color_filter = SkColorFilters::Compose(
+        SkColorFilters::Matrix(rotate_color_matrix),
+        SkColorFilters::Blend(SK_ColorBLUE, SkBlendMode::kSrcIn));
   };
 
   ColorFilterRefTester tester;

--- a/display_list/display_list_utils.cc
+++ b/display_list/display_list_utils.cc
@@ -93,6 +93,19 @@ void SkPaintDispatchHelper::setColorFilter(sk_sp<SkColorFilter> filter) {
   color_filter_ = filter;
   paint_.setColorFilter(makeColorFilter());
 }
+void SkPaintDispatchHelper::setBlendColorFilter(SkColor color,
+                                                SkBlendMode mode) {
+  setColorFilter(SkColorFilters::Blend(color, mode));
+}
+void SkPaintDispatchHelper::setMatrixColorFilter(const float matrix[20]) {
+  setColorFilter(SkColorFilters::Matrix(matrix));
+}
+void SkPaintDispatchHelper::setSrgbToLinearGammaColorFilter() {
+  setColorFilter(SkColorFilters::SRGBToLinearGamma());
+}
+void SkPaintDispatchHelper::setLinearToSrgbGammaColorFilter() {
+  setColorFilter(SkColorFilters::LinearToSRGBGamma());
+}
 void SkPaintDispatchHelper::setPathEffect(sk_sp<SkPathEffect> effect) {
   paint_.setPathEffect(effect);
 }
@@ -278,6 +291,19 @@ void DisplayListBoundsCalculator::setImageFilter(sk_sp<SkImageFilter> filter) {
 }
 void DisplayListBoundsCalculator::setColorFilter(sk_sp<SkColorFilter> filter) {
   color_filter_ = std::move(filter);
+}
+void DisplayListBoundsCalculator::setBlendColorFilter(SkColor color,
+                                                      SkBlendMode mode) {
+  color_filter_ = SkColorFilters::Blend(color, mode);
+}
+void DisplayListBoundsCalculator::setMatrixColorFilter(const float matrix[20]) {
+  color_filter_ = SkColorFilters::Matrix(matrix);
+}
+void DisplayListBoundsCalculator::setSrgbToLinearGammaColorFilter() {
+  color_filter_ = SkColorFilters::SRGBToLinearGamma();
+}
+void DisplayListBoundsCalculator::setLinearToSrgbGammaColorFilter() {
+  color_filter_ = SkColorFilters::LinearToSRGBGamma();
 }
 void DisplayListBoundsCalculator::setPathEffect(sk_sp<SkPathEffect> effect) {
   path_effect_ = std::move(effect);

--- a/display_list/display_list_utils.h
+++ b/display_list/display_list_utils.h
@@ -57,6 +57,10 @@ class IgnoreAttributeDispatchHelper : public virtual Dispatcher {
   void setShader(sk_sp<SkShader> shader) override {}
   void setImageFilter(sk_sp<SkImageFilter> filter) override {}
   void setColorFilter(sk_sp<SkColorFilter> filter) override {}
+  void setBlendColorFilter(SkColor color, SkBlendMode mode) override {}
+  void setMatrixColorFilter(const float matrix[20]) override {}
+  void setSrgbToLinearGammaColorFilter() override {}
+  void setLinearToSrgbGammaColorFilter() override {}
   void setPathEffect(sk_sp<SkPathEffect> effect) override {}
   void setMaskFilter(sk_sp<SkMaskFilter> filter) override {}
   void setMaskBlurFilter(SkBlurStyle style, SkScalar sigma) override {}
@@ -113,6 +117,10 @@ class SkPaintDispatchHelper : public virtual Dispatcher {
   void setStrokeJoin(SkPaint::Join join) override;
   void setShader(sk_sp<SkShader> shader) override;
   void setColorFilter(sk_sp<SkColorFilter> filter) override;
+  void setBlendColorFilter(SkColor color, SkBlendMode mode) override;
+  void setMatrixColorFilter(const float matrix[20]) override;
+  void setSrgbToLinearGammaColorFilter() override;
+  void setLinearToSrgbGammaColorFilter() override;
   void setInvertColors(bool invert) override;
   void setBlendMode(SkBlendMode mode) override;
   void setBlender(sk_sp<SkBlender> blender) override;
@@ -319,6 +327,10 @@ class DisplayListBoundsCalculator final
   void setBlender(sk_sp<SkBlender> blender) override;
   void setImageFilter(sk_sp<SkImageFilter> filter) override;
   void setColorFilter(sk_sp<SkColorFilter> filter) override;
+  void setBlendColorFilter(SkColor color, SkBlendMode mode) override;
+  void setMatrixColorFilter(const float matrix[20]) override;
+  void setSrgbToLinearGammaColorFilter() override;
+  void setLinearToSrgbGammaColorFilter() override;
   void setPathEffect(sk_sp<SkPathEffect> effect) override;
   void setMaskFilter(sk_sp<SkMaskFilter> filter) override;
   void setMaskBlurFilter(SkBlurStyle style, SkScalar sigma) override;

--- a/lib/ui/painting/color_filter.cc
+++ b/lib/ui/painting/color_filter.cc
@@ -40,32 +40,37 @@ fml::RefPtr<ColorFilter> ColorFilter::Create() {
 }
 
 void ColorFilter::initMode(int color, int blend_mode) {
-  filter_ = SkColorFilters::Blend(static_cast<SkColor>(color),
-                                  static_cast<SkBlendMode>(blend_mode));
+  type_ = kBlend;
+  color_ = static_cast<SkColor>(color);
+  mode_ = static_cast<SkBlendMode>(blend_mode);
+  filter_ = SkColorFilters::Blend(color_, mode_);
 }
 
 sk_sp<SkColorFilter> ColorFilter::MakeColorMatrixFilter255(
     const float array[20]) {
-  float tmp[20];
-  memcpy(tmp, array, sizeof(tmp));
-  tmp[4] *= 1.0f / 255;
-  tmp[9] *= 1.0f / 255;
-  tmp[14] *= 1.0f / 255;
-  tmp[19] *= 1.0f / 255;
-  return SkColorFilters::Matrix(tmp);
+  memcpy(matrix_, array, sizeof(matrix_));
+  matrix_[4] *= 1.0f / 255;
+  matrix_[9] *= 1.0f / 255;
+  matrix_[14] *= 1.0f / 255;
+  matrix_[19] *= 1.0f / 255;
+  return SkColorFilters::Matrix(matrix_);
 }
 
 void ColorFilter::initMatrix(const tonic::Float32List& color_matrix) {
   FML_CHECK(color_matrix.num_elements() == 20);
 
+  type_ = kMatrix;
+  // MakeColorMatrixFilter255 will transfer the data to |matrix_|
   filter_ = MakeColorMatrixFilter255(color_matrix.data());
 }
 
 void ColorFilter::initLinearToSrgbGamma() {
+  type_ = kLinearToSrgb;
   filter_ = SkColorFilters::LinearToSRGBGamma();
 }
 
 void ColorFilter::initSrgbToLinearGamma() {
+  type_ = kSrgbToLinear;
   filter_ = SkColorFilters::SRGBToLinearGamma();
 }
 

--- a/lib/ui/painting/color_filter.h
+++ b/lib/ui/painting/color_filter.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_LIB_UI_COLOR_FILTER_H_
 #define FLUTTER_LIB_UI_COLOR_FILTER_H_
 
+#include "flutter/display_list/display_list.h"
 #include "flutter/lib/ui/dart_wrapper.h"
 #include "third_party/skia/include/core/SkColorFilter.h"
 #include "third_party/tonic/typed_data/typed_list.h"
@@ -30,7 +31,7 @@ class ColorFilter : public RefCountedDartWrappable<ColorFilter> {
   // Flutter still defines the matrix to be biased by 255 in the last column
   // (translate). skia is normalized, treating the last column as 0...1, so we
   // post-scale here before calling the skia factory.
-  static sk_sp<SkColorFilter> MakeColorMatrixFilter255(const float array[20]);
+  sk_sp<SkColorFilter> MakeColorMatrixFilter255(const float array[20]);
 
   void initMode(int color, int blend_mode);
   void initMatrix(const tonic::Float32List& color_matrix);
@@ -40,11 +41,24 @@ class ColorFilter : public RefCountedDartWrappable<ColorFilter> {
   ~ColorFilter() override;
 
   sk_sp<SkColorFilter> filter() const { return filter_; }
+  ColorFilterType type() const { return type_; }
+  SkColor color() const { return color_; }
+  SkBlendMode mode() const { return mode_; }
+  const float* matrix() const { return matrix_; }
 
   static void RegisterNatives(tonic::DartLibraryNatives* natives);
 
  private:
   sk_sp<SkColorFilter> filter_;
+  ColorFilterType type_ = kNone;
+
+  union {
+    struct {
+      SkColor color_;
+      SkBlendMode mode_;
+    };
+    float matrix_[20];
+  };
 };
 
 }  // namespace flutter

--- a/lib/ui/painting/paint.cc
+++ b/lib/ui/painting/paint.cc
@@ -156,8 +156,7 @@ const SkPaint* Paint::paint(SkPaint& paint) const {
   }
 
   if (uint_data[kInvertColorIndex]) {
-    sk_sp<SkColorFilter> invert_filter =
-        ColorFilter::MakeColorMatrixFilter255(invert_colors);
+    sk_sp<SkColorFilter> invert_filter = SkColorFilters::Matrix(invert_colors);
     sk_sp<SkColorFilter> current_filter = paint.refColorFilter();
     if (current_filter) {
       invert_filter = invert_filter->makeComposed(current_filter);
@@ -235,7 +234,26 @@ bool Paint::sync_to(DisplayListBuilder* builder,
       } else {
         ColorFilter* decoded_color_filter =
             tonic::DartConverter<ColorFilter*>::FromDart(color_filter);
-        builder->setColorFilter(decoded_color_filter->filter());
+        sk_sp<SkColorFilter> sk_filter = decoded_color_filter->filter();
+        switch (decoded_color_filter->type()) {
+          case kNone:
+          case kUnknown:
+            builder->setColorFilter(sk_filter);
+            break;
+          case kBlend:
+            builder->setBlendColorFilter(decoded_color_filter->color(),
+                                         decoded_color_filter->mode());
+            break;
+          case kMatrix:
+            builder->setMatrixColorFilter(decoded_color_filter->matrix());
+            break;
+          case kSrgbToLinear:
+            builder->setSrgbToLinearGammaColorFilter();
+            break;
+          case kLinearToSrgb:
+            builder->setLinearToSrgbGammaColorFilter();
+            break;
+        }
       }
     }
 


### PR DESCRIPTION
An initial stab at maintaining data for ColorFilter objects in the engine's own data structures so that we can use it directly for optimizations. This code may serve as a prototype for how we keep our own data around for other structures like ImageFilter and Shaders.

Note that even if we deal with a part of the system that can only communicate to us via SkCanvas operations, we can still dig out the Blend and Matrix types of Color Filters when they get used in a DisplayList. Only the Srgb <-> Linear ColorFilters can get lost in that type of flow.