### PR TITLE
[Win32, Keyboard] Fix text input after pressing Enter or Ctrl-Digit 

### DIFF
--- a/shell/platform/windows/keyboard_manager_win32.cc
+++ b/shell/platform/windows/keyboard_manager_win32.cc
@@ -416,12 +416,12 @@ bool KeyboardManagerWin32::HandleMessage(UINT const action,
       // SYS messages must not be handled by `HandleMessage` or be
       // redispatched.
       const bool is_syskey = action == WM_SYSKEYDOWN || action == WM_SYSKEYUP;
-      OnKey(std::move(event), [this, is_syskey](
-                                  std::unique_ptr<PendingEvent> event,
-                                  bool handled) {
-        bool real_handled = handled || is_syskey;
-        HandleOnKeyResult(std::move(event), handled, pending_texts_.end());
-      });
+      OnKey(
+          std::move(event),
+          [this, is_syskey](std::unique_ptr<PendingEvent> event, bool handled) {
+            bool real_handled = handled || is_syskey;
+            HandleOnKeyResult(std::move(event), handled, pending_texts_.end());
+          });
       return !is_syskey;
     }
     default:

--- a/shell/platform/windows/keyboard_manager_win32.cc
+++ b/shell/platform/windows/keyboard_manager_win32.cc
@@ -211,7 +211,6 @@ void KeyboardManagerWin32::DispatchReadyTexts() {
 void KeyboardManagerWin32::HandleOnKeyResult(
     std::unique_ptr<PendingEvent> event,
     bool handled,
-    int char_action,
     std::list<PendingText>::iterator pending_text) {
   // First, patch |handled|, because some key events must always be treated as
   // handled.
@@ -238,13 +237,7 @@ void KeyboardManagerWin32::HandleOnKeyResult(
 
   // For unhandled events, dispatch them to OnText.
 
-  // Of the messages handled here, only WM_CHAR should be treated as
-  // characters. WM_SYS*CHAR are not part of text input, and WM_DEADCHAR
-  // will be incorporated into a later WM_CHAR with the full character.
-  // Non-printable event characters have been filtered out before being passed
-  // to OnKey.
-  if (char_action == WM_CHAR && event->character != 0 &&
-      pending_text != pending_texts_.end()) {
+  if (pending_text != pending_texts_.end()) {
     pending_text->ready = true;
     DispatchReadyTexts();
   }
@@ -326,20 +319,31 @@ bool KeyboardManagerWin32::HandleMessage(UINT const action,
             .was_down = was_down,
             .session = std::move(current_session_),
         });
-        pending_texts_.push_back(PendingText{
-            .ready = false,
-            .content = text,
-        });
-        auto pending_text = std::prev(pending_texts_.end());
+        // Compute the text that might be dispatched later.
+        //
+        // Of the messages handled here, only WM_CHAR should be treated as
+        // characters. WM_SYS*CHAR are not part of text input, and WM_DEADCHAR
+        // will be incorporated into a later WM_CHAR with the full character.
+        //
+        // Checking `character` filters out non-printable event characters.
+        std::list<PendingText>::iterator pending_text;
+        if (action == WM_CHAR && character != 0) {
+          pending_texts_.push_back(PendingText{
+              .ready = false,
+              .content = text,
+          });
+          pending_text = std::prev(pending_texts_.end());
+        } else {
+          pending_text = pending_texts_.end();
+        }
         // SYS messages must not be handled by `HandleMessage` or be
         // redispatched.
         const bool is_syskey = action == WM_SYSCHAR || action == WM_SYSDEADCHAR;
         OnKey(std::move(event),
-              [this, char_action = action, pending_text, is_syskey](
+              [this, pending_text, is_syskey](
                   std::unique_ptr<PendingEvent> event, bool handled) {
                 bool real_handled = handled || is_syskey;
-                HandleOnKeyResult(std::move(event), handled, char_action,
-                                  pending_text);
+                HandleOnKeyResult(std::move(event), handled, pending_text);
               });
         return !is_syskey;
       }
@@ -416,7 +420,7 @@ bool KeyboardManagerWin32::HandleMessage(UINT const action,
                                   std::unique_ptr<PendingEvent> event,
                                   bool handled) {
         bool real_handled = handled || is_syskey;
-        HandleOnKeyResult(std::move(event), handled, 0, pending_texts_.end());
+        HandleOnKeyResult(std::move(event), handled, pending_texts_.end());
       });
       return !is_syskey;
     }

--- a/shell/platform/windows/keyboard_manager_win32.h
+++ b/shell/platform/windows/keyboard_manager_win32.h
@@ -154,7 +154,6 @@ class KeyboardManagerWin32 {
   // end(). In the latter case, this OnKey message does not contain a text.
   void HandleOnKeyResult(std::unique_ptr<PendingEvent> event,
                          bool handled,
-                         int char_action,
                          std::list<PendingText>::iterator pending_text);
 
   // Returns the type of the next WM message.

--- a/shell/platform/windows/keyboard_win32_unittests.cc
+++ b/shell/platform/windows/keyboard_win32_unittests.cc
@@ -1709,6 +1709,34 @@ TEST(KeyboardTest, TextInputSubmit) {
       R"|("args":[108,"TextInputAction.none"])|"
       "}");
   clear_key_calls();
+
+  // Make sure OnText is not obstructed after pressing Enter.
+  //
+  // Regression test for https://github.com/flutter/flutter/issues/97706.
+
+  // Press A
+  tester.InjectMessages(
+      2,
+      WmKeyDownInfo{kVirtualKeyA, kScanCodeKeyA, kNotExtended, kWasUp}.Build(
+          kWmResultZero),
+      WmCharInfo{'a', kScanCodeKeyA, kNotExtended, kWasUp}.Build(
+          kWmResultZero));
+
+  EXPECT_EQ(key_calls.size(), 1);
+  EXPECT_CALL_IS_EVENT(key_calls[0], kFlutterKeyEventTypeDown, kPhysicalKeyA,
+                       kLogicalKeyA, "a", kNotSynthesized);
+  clear_key_calls();
+
+  // Release A
+  tester.InjectMessages(
+      1, WmKeyUpInfo{kVirtualKeyA, kScanCodeKeyA, kNotExtended}.Build(
+             kWmResultZero));
+
+  EXPECT_EQ(key_calls.size(), 1);
+  EXPECT_CALL_IS_EVENT(key_calls[0], kFlutterKeyEventTypeUp, kPhysicalKeyA,
+                       kLogicalKeyA, "", kNotSynthesized);
+  clear_key_calls();
+
 }
 
 }  // namespace testing

--- a/shell/platform/windows/keyboard_win32_unittests.cc
+++ b/shell/platform/windows/keyboard_win32_unittests.cc
@@ -1750,7 +1750,6 @@ TEST(KeyboardTest, TextInputSubmit) {
   EXPECT_CALL_IS_EVENT(key_calls[0], kFlutterKeyEventTypeUp, kPhysicalKeyA,
                        kLogicalKeyA, "", kNotSynthesized);
   clear_key_calls();
-
 }
 
 }  // namespace testing

--- a/shell/platform/windows/keyboard_win32_unittests.cc
+++ b/shell/platform/windows/keyboard_win32_unittests.cc
@@ -1696,8 +1696,11 @@ TEST(KeyboardTest, TextInputSubmit) {
 
   // Press Enter
   tester.InjectMessages(
-      1, WmKeyDownInfo{VK_RETURN, kScanCodeEnter, kNotExtended, kWasUp}.Build(
-             kWmResultZero));
+      2,
+      WmKeyDownInfo{VK_RETURN, kScanCodeEnter, kNotExtended, kWasUp}.Build(
+          kWmResultZero),
+      WmCharInfo{'\n', kScanCodeEnter, kNotExtended, kWasUp}.Build(
+          kWmResultZero));
 
   EXPECT_EQ(key_calls.size(), 2);
   EXPECT_CALL_IS_EVENT(key_calls[0], kFlutterKeyEventTypeDown, kPhysicalEnter,
@@ -1708,6 +1711,16 @@ TEST(KeyboardTest, TextInputSubmit) {
       R"|("method":"TextInputClient.performAction",)|"
       R"|("args":[108,"TextInputAction.none"])|"
       "}");
+  clear_key_calls();
+
+  // Release Enter
+  tester.InjectMessages(
+      1, WmKeyUpInfo{VK_RETURN, kScanCodeEnter, kNotExtended}.Build(
+             kWmResultZero));
+
+  EXPECT_EQ(key_calls.size(), 1);
+  EXPECT_CALL_IS_EVENT(key_calls[0], kFlutterKeyEventTypeUp, kPhysicalEnter,
+                       kLogicalEnter, "", kNotSynthesized);
   clear_key_calls();
 
   // Make sure OnText is not obstructed after pressing Enter.
@@ -1722,9 +1735,10 @@ TEST(KeyboardTest, TextInputSubmit) {
       WmCharInfo{'a', kScanCodeKeyA, kNotExtended, kWasUp}.Build(
           kWmResultZero));
 
-  EXPECT_EQ(key_calls.size(), 1);
+  EXPECT_EQ(key_calls.size(), 2);
   EXPECT_CALL_IS_EVENT(key_calls[0], kFlutterKeyEventTypeDown, kPhysicalKeyA,
                        kLogicalKeyA, "a", kNotSynthesized);
+  EXPECT_CALL_IS_TEXT(key_calls[1], u"a");
   clear_key_calls();
 
   // Release A


### PR DESCRIPTION
Fix https://github.com/flutter/flutter/issues/97706.

This problem happened because the keyboard manager now pushes all text into a queue, and only dispatches texts that are ready from the front, which means if any text is left un-ready, no text will ever be dispatched any more. However, enter and Ctrl-digit key presses insert some non-printable texts, which are skipped but not removed during the `OnKey`'s response callback. 

This PR fixes this issue by moving the filtering to before `OnKey`, therefore these non-printable texts will never be pushed into the queue.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
