### PR TITLE
Add support for new VM service message

### DIFF
--- a/shell/testing/observatory/launcher.dart
+++ b/shell/testing/observatory/launcher.dart
@@ -33,13 +33,13 @@ class ShellProcess {
     return _observatoryUriCompleter.future;
   }
 
-  Uri _extractVMServiceUri(String str) {
+  Uri? _extractVMServiceUri(String str) {
     final listeningMessageRegExp = RegExp(
       r'(?:Observatory|Dart VM Service) listening on ((http|//)[a-zA-Z0-9:/=_\-\.\[\]]+)',
     );
     final match = listeningMessageRegExp.firstMatch(str);
     if (match != null) {
-      return Uri.parse(match[1]);
+      return Uri.parse(match[1]!);
     }
     return null;
   }

--- a/shell/testing/observatory/launcher.dart
+++ b/shell/testing/observatory/launcher.dart
@@ -18,10 +18,8 @@ class ShellProcess {
         .transform(utf8.decoder)
         .transform(const LineSplitter())
         .listen((String line) {
-      const String observatoryUriPrefix = 'Observatory listening on ';
-      if (line.startsWith(observatoryUriPrefix)) {
-        print(line);
-        final Uri uri = Uri.parse(line.substring(observatoryUriPrefix.length));
+      final uri = _extractVMServiceUri(line);
+      if (uri != null) {
         _observatoryUriCompleter.complete(uri);
       }
     });
@@ -33,6 +31,17 @@ class ShellProcess {
 
   Future<Uri> waitForObservatory() async {
     return _observatoryUriCompleter.future;
+  }
+
+  Uri _extractVMServiceUri(String str) {
+    final listeningMessageRegExp = RegExp(
+      r'(?:Observatory|Dart VM Service) listening on ((http|//)[a-zA-Z0-9:/=_\-\.\[\]]+)',
+    );
+    final match = listeningMessageRegExp.firstMatch(str);
+    if (match != null) {
+      return Uri.parse(match[1]);
+    }
+    return null;
   }
 }
 

--- a/testing/android_systrace_test.py
+++ b/testing/android_systrace_test.py
@@ -61,7 +61,7 @@ def LaunchPackage(package_name, activity_name, adb_path='adb'):
           '%s/%s' % (package_name, activity_name)], stderr=subprocess.STDOUT)
   for line in logcat.stdout:
     print('>>>>>>>> ' + line.strip())
-    if 'Observatory listening' in line:
+    if ('Observatory listening' in line) or ('Dart VM Service listening' in line):
       logcat.kill()
       break
 


### PR DESCRIPTION
"Observatory listening on..." is eventually being updated to "Dart VM
Service listening on...". This change allows for parsing the VM service
URI from messages of either format.

See https://github.com/dart-lang/sdk/issues/46756