### PR TITLE
Enable DisplayList benchmarks to be built on Android

### DIFF
--- a/benchmarking/benchmarking.cc
+++ b/benchmarking/benchmarking.cc
@@ -5,6 +5,7 @@
 #include "benchmarking.h"
 
 #include "flutter/fml/backtrace.h"
+#include "flutter/fml/build_config.h"
 #include "flutter/fml/command_line.h"
 #include "flutter/fml/icu_util.h"
 
@@ -12,11 +13,13 @@ namespace benchmarking {
 
 int Main(int argc, char** argv) {
   fml::InstallCrashHandler();
+#if !defined(FML_OS_ANDROID)
   fml::CommandLine cmd = fml::CommandLineFromArgcArgv(argc, argv);
-  benchmark::Initialize(&argc, argv);
   std::string icudtl_path =
       cmd.GetOptionValueWithDefault("icu-data-file-path", "icudtl.dat");
   fml::icu::InitializeICU(icudtl_path);
+#endif
+  benchmark::Initialize(&argc, argv);
   ::benchmark::RunSpecifiedBenchmarks();
   return 0;
 }

--- a/display_list/BUILD.gn
+++ b/display_list/BUILD.gn
@@ -55,62 +55,72 @@ fixtures_location("display_list_benchmarks_fixtures") {
   assets_dir = "$target_gen_dir/"
 }
 
-if (enable_unittests || is_android) {
-  executable("display_list_benchmarks") {
-    testonly = true
+source_set("display_list_benchmarks_source") {
+  testonly = true
 
-    sources = [
-      "display_list_benchmarks.cc",
-      "display_list_benchmarks.h",
+  sources = [
+    "display_list_benchmarks.cc",
+    "display_list_benchmarks.h",
+  ]
+
+  deps = [
+    ":display_list",
+    ":display_list_benchmarks_fixtures",
+    "//flutter/benchmarking",
+    "//flutter/common/graphics",
+    "//flutter/fml",
+    "//flutter/testing:skia",
+    "//flutter/testing:testing_lib",
+    "//third_party/dart/runtime:libdart_jit",  # for tracing
+    "//third_party/skia",
+  ]
+
+  defines = []
+
+  if (is_android) {
+    libs = [
+      "android",
+      "EGL",
+      "GLESv2",
     ]
-
-    deps = [
-      ":display_list",
-      ":display_list_benchmarks_fixtures",
-      "//flutter/benchmarking",
-      "//flutter/common/graphics",
-      "//flutter/fml",
-      "//flutter/testing:skia",
-      "//flutter/testing:testing_lib",
-      "//third_party/dart/runtime:libdart_jit",  # for tracing
-      "//third_party/skia",
+  } else {
+    # We only do software benchmarks on non-mobile platforms
+    sources += [
+      "display_list_benchmarks_software.cc",
+      "display_list_benchmarks_software.h",
     ]
-
-    defines = []
-
-    if (is_android) {
-      libs = [
-        "android",
-        "EGL",
-        "GLESv2",
-      ]
-    } else {
-      # We only do software benchmarks on non-mobile platforms
-      sources += [
-        "display_list_benchmarks_software.cc",
-        "display_list_benchmarks_software.h",
-      ]
-      defines += [ "ENABLE_SOFTWARE_BENCHMARKS" ]
-    }
-
-    if (!is_fuchsia) {
-      defines += [ "ENABLE_OPENGL_BENCHMARKS" ]
-      sources += [
-        "display_list_benchmarks_gl.cc",
-        "display_list_benchmarks_gl.h",
-      ]
-      deps += [ "//flutter/testing:opengl" ]
-    }
-
-    if (is_mac) {
-      defines += [ "ENABLE_METAL_BENCHMARKS" ]
-      sources += [
-        "display_list_benchmarks_metal.cc",
-        "display_list_benchmarks_metal.h",
-      ]
-      deps += [ "//flutter/testing:metal" ]
-    }
+    defines += [ "ENABLE_SOFTWARE_BENCHMARKS" ]
   }
+
+  # iOS and Fuchsia don't support OpenGL
+  if (!is_fuchsia && !is_ios) {
+    defines += [ "ENABLE_OPENGL_BENCHMARKS" ]
+    sources += [
+      "display_list_benchmarks_gl.cc",
+      "display_list_benchmarks_gl.h",
+    ]
+    deps += [ "//flutter/testing:opengl" ]
+  }
+
+  if (is_mac || is_ios) {
+    defines += [ "ENABLE_METAL_BENCHMARKS" ]
+    sources += [
+      "display_list_benchmarks_metal.cc",
+      "display_list_benchmarks_metal.h",
+    ]
+    deps += [ "//flutter/testing:metal" ]
+  }
+
+  # Don't snapshot test results on mobile platforms
+  if (is_android || is_ios) {
+    defines += [ "BENCHMARKS_NO_SNAPSHOT" ]
+  }
+}
+
+executable("display_list_benchmarks") {
+  testonly = true
+
+  deps = [ ":display_list_benchmarks_source" ]
 }
 
 if (is_ios) {
@@ -129,29 +139,9 @@ if (is_ios) {
     ]
     ldflags =
         [ "-Wl,-install_name,@rpath/libios_display_list_benchmarks.dylib" ]
-    defines = [
-      "BENCHMARKS_NO_SNAPSHOT",
-      "ENABLE_METAL_BENCHMARKS",
-    ]
-    sources = [
-      "display_list_benchmarks.cc",
-      "display_list_benchmarks.h",
-      "display_list_benchmarks_metal.cc",
-      "display_list_benchmarks_metal.h",
-    ]
-
     deps = [
-      ":display_list",
-      ":display_list_benchmarks_fixtures",
+      ":display_list_benchmarks_source",
       "//flutter/benchmarking:benchmarking_library",
-      "//flutter/common/graphics",
-      "//flutter/fml",
-      "//flutter/testing:metal",
-      "//flutter/testing:skia",
-      "//flutter/testing:testing_lib",
-      "//third_party/benchmark",
-      "//third_party/dart/runtime:libdart_jit",  # for tracing
-      "//third_party/skia",
     ]
   }
 }

--- a/display_list/BUILD.gn
+++ b/display_list/BUILD.gn
@@ -83,8 +83,10 @@ source_set("display_list_benchmarks_source") {
       "EGL",
       "GLESv2",
     ]
-  } else {
-    # We only do software benchmarks on non-mobile platforms
+  }
+
+  # We only do software benchmarks on non-mobile platforms
+  if (!is_android && !is_ios) {
     sources += [
       "display_list_benchmarks_software.cc",
       "display_list_benchmarks_software.h",

--- a/display_list/BUILD.gn
+++ b/display_list/BUILD.gn
@@ -55,15 +55,13 @@ fixtures_location("display_list_benchmarks_fixtures") {
   assets_dir = "$target_gen_dir/"
 }
 
-if (enable_unittests) {
+if (enable_unittests || is_android) {
   executable("display_list_benchmarks") {
     testonly = true
 
     sources = [
       "display_list_benchmarks.cc",
       "display_list_benchmarks.h",
-      "display_list_benchmarks_software.cc",
-      "display_list_benchmarks_software.h",
     ]
 
     deps = [
@@ -78,7 +76,22 @@ if (enable_unittests) {
       "//third_party/skia",
     ]
 
-    defines = [ "ENABLE_SOFTWARE_BENCHMARKS" ]
+    defines = []
+
+    if (is_android) {
+      libs = [
+        "android",
+        "EGL",
+        "GLESv2",
+      ]
+    } else {
+      # We only do software benchmarks on non-mobile platforms
+      sources += [
+        "display_list_benchmarks_software.cc",
+        "display_list_benchmarks_software.h",
+      ]
+      defines += [ "ENABLE_SOFTWARE_BENCHMARKS" ]
+    }
 
     if (!is_fuchsia) {
       defines += [ "ENABLE_OPENGL_BENCHMARKS" ]

--- a/testing/BUILD.gn
+++ b/testing/BUILD.gn
@@ -185,7 +185,7 @@ if (enable_unittests) {
 # is exercised on platforms where Metal itself is available.
 #
 # On iOS, this is enabled to allow for Metal tests to run within a test app
-if (enable_unittests || is_ios) {
+if (is_mac || is_ios) {
   source_set("metal") {
     if (shell_enable_metal) {
       sources = [

--- a/testing/BUILD.gn
+++ b/testing/BUILD.gn
@@ -214,11 +214,8 @@ if (is_mac || is_ios) {
 
 # We only use SwiftShader on unittests and
 # SwiftShader only supports x86/x86_64
-if (enable_unittests && (target_cpu == "x86" || target_cpu == "x64")) {
-  use_swiftshader = true
-} else {
-  use_swiftshader = false
-}
+use_swiftshader =
+    enable_unittests && (target_cpu == "x86" || target_cpu == "x64")
 
 source_set("opengl") {
   testonly = true

--- a/testing/BUILD.gn
+++ b/testing/BUILD.gn
@@ -150,26 +150,6 @@ if (enable_unittests) {
     }
   }
 
-  # SwiftShader only supports x86/x86_64
-  if (target_cpu == "x86" || target_cpu == "x64") {
-    source_set("opengl") {
-      testonly = true
-
-      configs += [ "//third_party/swiftshader_flutter:swiftshader_config" ]
-
-      sources = [
-        "test_gl_surface.cc",
-        "test_gl_surface.h",
-      ]
-
-      deps = [
-        ":skia",
-        "//flutter/fml",
-        "//third_party/swiftshader_flutter:swiftshader_gl",
-      ]
-    }
-  }
-
   test_fixtures("testing_fixtures") {
     fixtures = []
   }
@@ -229,5 +209,32 @@ if (enable_unittests || is_ios) {
     }
 
     testonly = true
+  }
+}
+
+# We only use SwiftShader on unittests and
+# SwiftShader only supports x86/x86_64
+if (enable_unittests && (target_cpu == "x86" || target_cpu == "x64")) {
+  use_swiftshader = true
+} else {
+  use_swiftshader = false
+}
+
+source_set("opengl") {
+  testonly = true
+
+  sources = [
+    "test_gl_surface.cc",
+    "test_gl_surface.h",
+  ]
+
+  deps = [
+    ":skia",
+    "//flutter/fml",
+  ]
+
+  if (use_swiftshader) {
+    configs += [ "//third_party/swiftshader_flutter:swiftshader_config" ]
+    deps += [ "//third_party/swiftshader_flutter:swiftshader_gl" ]
   }
 }


### PR DESCRIPTION
This allows the display_list_benchmarks target to be built on Android.

* Only initialise ICU in benchmarking::Main() when not on Android (it causes an abort on startup, and we don't use ICU for the DisplayList benchmarks)
* Don't build the software benchmarks on mobile platforms as we don't use software rendering and the suite takes a really long time to run
* Don't tie testing:opengl (TestGLSurface etc) to SwiftShader as we use them for benchmarking and we want to use the native/hw OpenGL driver for those
