### PR TITLE
[web] tighten paragraph bounds estimate

### DIFF
--- a/lib/web_ui/lib/src/engine/html/recording_canvas.dart
+++ b/lib/web_ui/lib/src/engine/html/recording_canvas.dart
@@ -595,17 +595,18 @@ class RecordingCanvas {
       renderStrategy.hasArbitraryPaint = true;
     }
     renderStrategy.hasParagraphs = true;
-    final double left = offset.dx;
-    final double top = offset.dy;
     final PaintDrawParagraph command =
         PaintDrawParagraph(engineParagraph, offset);
+
+    final ui.Rect paragraphBounds = engineParagraph.paintBounds;
     _paintBounds.growLTRB(
-      left,
-      top,
-      left + engineParagraph.width,
-      top + engineParagraph.height,
+      offset.dx + paragraphBounds.left,
+      offset.dy + paragraphBounds.top,
+      offset.dx + paragraphBounds.right,
+      offset.dy + paragraphBounds.bottom,
       command,
     );
+
     _commands.add(command);
   }
 

--- a/lib/web_ui/lib/src/engine/text/canvas_paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/canvas_paragraph.dart
@@ -76,6 +76,9 @@ class CanvasParagraph implements ui.Paragraph {
   @override
   bool get didExceedMaxLines => _layoutService.didExceedMaxLines;
 
+  /// The bounds that contain the text painted inside this paragraph.
+  ui.Rect get paintBounds => _layoutService.paintBounds;
+
   /// Whether this paragraph has been laid out or not.
   bool isLaidOut = false;
 

--- a/lib/web_ui/lib/src/engine/text/layout_service.dart
+++ b/lib/web_ui/lib/src/engine/text/layout_service.dart
@@ -47,6 +47,10 @@ class TextLayoutService {
 
   final List<EngineLineMetrics> lines = <EngineLineMetrics>[];
 
+  /// The bounds that contain the text painted inside this paragraph.
+  ui.Rect get paintBounds => _paintBounds;
+  ui.Rect _paintBounds = ui.Rect.zero;
+
   // *** Convenient shortcuts used during layout *** //
 
   int? get maxLines => paragraph.paragraphStyle.maxLines;
@@ -204,10 +208,12 @@ class TextLayoutService {
       }
     }
 
-    // ************************************************** //
-    // *** PARAGRAPH BASELINE & HEIGHT & LONGEST LINE *** //
-    // ************************************************** //
+    // ***************************************************************** //
+    // *** PARAGRAPH BASELINE & HEIGHT & LONGEST LINE & PAINT BOUNDS *** //
+    // ***************************************************************** //
 
+    double boundsLeft = double.infinity;
+    double boundsRight = double.negativeInfinity;
     for (final EngineLineMetrics line in lines) {
       height += line.height;
       if (alphabeticBaseline == -1.0) {
@@ -218,7 +224,22 @@ class TextLayoutService {
       if (longestLineWidth < line.width) {
         longestLine = line;
       }
+
+      final double left = line.left;
+      if (left < boundsLeft) {
+        boundsLeft = left;
+      }
+      final double right = left + line.width;
+      if (right > boundsRight) {
+        boundsRight = right;
+      }
     }
+    _paintBounds = ui.Rect.fromLTRB(
+      boundsLeft,
+      0,
+      boundsRight,
+      height,
+    );
 
     // ********************** //
     // *** POSITION BOXES *** //

--- a/lib/web_ui/test/engine/recording_canvas_test.dart
+++ b/lib/web_ui/test/engine/recording_canvas_test.dart
@@ -7,6 +7,7 @@ import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart';
 
+import '../html/paragraph/text_scuba.dart';
 import '../mock_engine_canvas.dart';
 
 void main() {
@@ -14,6 +15,8 @@ void main() {
 }
 
 void testMain() {
+  setUpStableTestFonts();
+
   late RecordingCanvas underTest;
   late MockEngineCanvas mockCanvas;
   const Rect screenRect = Rect.largest;
@@ -21,6 +24,55 @@ void testMain() {
   setUp(() {
     underTest = RecordingCanvas(screenRect);
     mockCanvas = MockEngineCanvas();
+  });
+
+  group('paragraph bounds', () {
+    Paragraph _paragraphForBoundsTest(TextAlign alignment) {
+      final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle(
+        fontFamily: 'Ahem',
+        fontSize: 20,
+        textAlign: alignment,
+      ));
+      builder.addText('A AAAAA AAA');
+      return builder.build();
+    }
+
+    test('not laid out', () {
+      final Paragraph paragraph = _paragraphForBoundsTest(TextAlign.start);
+      underTest.drawParagraph(paragraph, Offset.zero);
+      underTest.endRecording();
+      expect(underTest.pictureBounds, Rect.zero);
+    });
+
+    test('finite width', () {
+      final Paragraph paragraph = _paragraphForBoundsTest(TextAlign.start);
+      paragraph.layout(const ParagraphConstraints(width: 110));
+      underTest.drawParagraph(paragraph, Offset.zero);
+      underTest.endRecording();
+      expect(paragraph.width, 110);
+      expect(paragraph.height, 60);
+      expect(underTest.pictureBounds, const Rect.fromLTRB(0, 0, 100, 60));
+    });
+
+    test('finite width center-aligned', () {
+      final Paragraph paragraph = _paragraphForBoundsTest(TextAlign.center);
+      paragraph.layout(const ParagraphConstraints(width: 110));
+      underTest.drawParagraph(paragraph, Offset.zero);
+      underTest.endRecording();
+      expect(paragraph.width, 110);
+      expect(paragraph.height, 60);
+      expect(underTest.pictureBounds, const Rect.fromLTRB(5, 0, 105, 60));
+    });
+
+    test('infinite width', () {
+      final Paragraph paragraph = _paragraphForBoundsTest(TextAlign.start);
+      paragraph.layout(const ParagraphConstraints(width: double.infinity));
+      underTest.drawParagraph(paragraph, Offset.zero);
+      underTest.endRecording();
+      expect(paragraph.width, double.infinity);
+      expect(paragraph.height, 20);
+      expect(underTest.pictureBounds, const Rect.fromLTRB(0, 0, 220, 20));
+    });
   });
 
   group('drawDRRect', () {

--- a/lib/web_ui/test/engine/recording_canvas_test.dart
+++ b/lib/web_ui/test/engine/recording_canvas_test.dart
@@ -15,6 +15,7 @@ void main() {
 }
 
 void testMain() {
+  debugEmulateFlutterTesterEnvironment = true;
   setUpStableTestFonts();
 
   late RecordingCanvas underTest;

--- a/lib/web_ui/test/html/paragraph/general_golden_test.dart
+++ b/lib/web_ui/test/html/paragraph/general_golden_test.dart
@@ -583,4 +583,56 @@ Future<void> testMain() async {
     testForegroundStyle(canvas);
     return takeScreenshot(canvas, bounds, 'canvas_paragraph_foreground_style_dom');
   });
+
+  test('paragraph bounds hug the text inside the paragraph', () async {
+    const Rect bounds = Rect.fromLTWH(0, 0, 150, 100);
+
+    final CanvasParagraphBuilder builder = CanvasParagraphBuilder(EngineParagraphStyle(
+      fontFamily: 'Ahem',
+      fontSize: 20,
+      textAlign: TextAlign.center,
+    ));
+
+    // Expected layout with center-alignment is something like this:
+    //
+    // ---------
+    // |   A   |
+    // | AAAAA |
+    // |  AAA  |
+    // ---------
+    //
+    // The width of the paragraph is bigger than the actual content because the
+    // longest line "AAAAA" is 50px, which is smaller than 55px specified in the
+    // constraint. After the layout and centering the paint bounds would "hug"
+    // the text inside the paragraph more tightly than the box allocated for the
+    // paragraph.
+    builder.addText('A AAAAA AAA');
+
+    final CanvasParagraph paragraph = builder.build();
+    paragraph.layout(const ParagraphConstraints(width: 110));
+    final BitmapCanvas canvas = BitmapCanvas(bounds, RenderStrategy());
+    canvas.translate(20, 20);
+    canvas.drawParagraph(paragraph, Offset.zero);
+    canvas.drawRect(
+      Rect.fromLTRB(
+        0,
+        0,
+        paragraph.width,
+        paragraph.height,
+      ),
+      SurfacePaintData()
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 1,
+    );
+
+    canvas.drawRect(
+      paragraph.paintBounds,
+      SurfacePaintData()
+        ..color = const Color(0xFF00FF00)
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 1,
+    );
+
+    await takeScreenshot(canvas, bounds, 'canvas_paragraph_bounds');
+  });
 }

--- a/lib/web_ui/test/html/paragraph/general_golden_test.dart
+++ b/lib/web_ui/test/html/paragraph/general_golden_test.dart
@@ -595,17 +595,22 @@ Future<void> testMain() async {
 
     // Expected layout with center-alignment is something like this:
     //
-    // ---------
-    // |   A   |
-    // | AAAAA |
-    // |  AAA  |
-    // ---------
+    // _________________
+    // |       A       |
+    // |    |AAAAA|    |
+    // |    | AAA |    |
+    // |----|-----|----|
+    // |    |<--->|    |
+    // |      100      |
+    // |               |
+    // |<------------->|
+    //        110
     //
     // The width of the paragraph is bigger than the actual content because the
-    // longest line "AAAAA" is 50px, which is smaller than 55px specified in the
-    // constraint. After the layout and centering the paint bounds would "hug"
-    // the text inside the paragraph more tightly than the box allocated for the
-    // paragraph.
+    // longest line "AAAAA" is 100px, which is smaller than 110px specified in
+    // the constraint. After the layout and centering the paint bounds would
+    // "hug" the text inside the paragraph more tightly than the box allocated
+    // for the paragraph.
     builder.addText('A AAAAA AAA');
 
     final CanvasParagraph paragraph = builder.build();


### PR DESCRIPTION
Use the actual text bounds when estimating paragraph paint bounds instead of the paragraph size. Paragraph size can frequently be bigger than the text. Common situations:

* Paragraph is laid out with `double.infinity` width constraint. While the constraint is infinite, that doesn't make the text infinitely wide. The text will still only take as much space as it needs.
* When `TextAlign.center` is used the text is shifted towards the center of the paragraph, so the left and right bounds of the text are padded away from the left and right walls of the paragraph.

In the example below center alignment is used. Notice that the text bounds (green box) is smaller than the paragraph bounds (black box):

![canvas_paragraph_bounds](https://user-images.githubusercontent.com/211513/152615625-4af67a7f-c82a-44f9-b96f-468325881d89.png)

Fixes: https://github.com/flutter/flutter/issues/97756
