### PR TITLE
[fuchsia] Update Flatland Clipping API

### DIFF
--- a/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland.cc
+++ b/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland.cc
@@ -7,7 +7,6 @@
 #include <zircon/types.h>
 
 #include <algorithm>  // For std::remove_if
-#include <cmath>
 #include <memory>
 
 #include "flutter/fml/logging.h"

--- a/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland.cc
+++ b/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland.cc
@@ -14,6 +14,10 @@
 
 namespace flutter_runner::testing {
 
+// Rects are defined in terms of their origin point (x,y), which is located
+// on the top-left, and their size (width, height). The default unclipped
+// region has its top-left origin point at the origin, and a width and
+// height of INT_MAX.
 const fuchsia::math::Rect kUnclippedBounds = {0, 0, INT_MAX, INT_MAX};
 
 FakeFlatland::FakeFlatland()

--- a/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland.cc
+++ b/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland.cc
@@ -14,12 +14,6 @@
 
 namespace flutter_runner::testing {
 
-// Rects are defined in terms of their origin point (x,y), which is located
-// on the top-left, and their size (width, height). The default unclipped
-// region has its top-left origin point at the origin, and a width and
-// height of INT_MAX.
-const fuchsia::math::Rect kUnclippedBounds = {0, 0, INT_MAX, INT_MAX};
-
 FakeFlatland::FakeFlatland()
     : allocator_binding_(this),
       flatland_binding_(this),
@@ -262,7 +256,7 @@ void FakeFlatland::SetClipBoundary(
   auto& transform = found_transform->second;
   FML_CHECK(transform);
   if (bounds == nullptr) {
-    transform->clip_bounds = kUnclippedBounds;
+    transform->clip_bounds = std::nullopt;
     return;
   }
 

--- a/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland.cc
+++ b/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland.cc
@@ -14,8 +14,7 @@
 
 namespace flutter_runner::testing {
 
-const fuchsia::math::Rect kUnclippedBounds = {-INT_MAX / 2, -INT_MAX / 2,
-                                              INT_MAX, INT_MAX};
+const fuchsia::math::Rect kUnclippedBounds = {0, 0, INT_MAX, INT_MAX};
 
 FakeFlatland::FakeFlatland()
     : allocator_binding_(this),

--- a/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland.h
+++ b/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland.h
@@ -227,8 +227,8 @@ class FakeFlatland
       fuchsia::ui::composition::Orientation orientation) override;
 
   // |fuchsia::ui::composition::Flatland|
-  void SetClipBounds(fuchsia::ui::composition::TransformId transform_id,
-                     fuchsia::math::Rect clip_bounds) override;
+  void SetClipBoundary(fuchsia::ui::composition::TransformId transform_id,
+                       std::unique_ptr<fuchsia::math::Rect> bounds) override;
 
   // TODO(fxbug.dev/89111): Re-enable once SDK rolls.
   //   // |fuchsia::ui::composition::Flatland|

--- a/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland_types.cc
+++ b/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland_types.cc
@@ -132,9 +132,9 @@ bool FakeImage::operator==(const FakeImage& other) const {
 
 bool FakeTransform::operator==(const FakeTransform& other) const {
   return id == other.id && translation == other.translation &&
-         clip_bounds == other.clip_bounds && orientation == other.orientation &&
-         children == other.children && content == other.content &&
-         num_hit_regions == other.num_hit_regions;
+         *clip_bounds == *other.clip_bounds &&
+         orientation == other.orientation && children == other.children &&
+         content == other.content && num_hit_regions == other.num_hit_regions;
 }
 
 bool FakeGraph::operator==(const FakeGraph& other) const {

--- a/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland_types.h
+++ b/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland_types.h
@@ -165,10 +165,6 @@ struct FakeTransform {
   bool operator==(const FakeTransform& other) const;
 
   constexpr static fuchsia::math::Vec kDefaultTranslation{.x = 0, .y = 0};
-  constexpr static fuchsia::math::Rect kDefaultClipBounds{.x = 0,
-                                                          .y = 0,
-                                                          .width = 0,
-                                                          .height = 0};
   constexpr static fuchsia::ui::composition::Orientation kDefaultOrientation{
       fuchsia::ui::composition::Orientation::CCW_0_DEGREES};
 

--- a/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland_types.h
+++ b/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland_types.h
@@ -175,7 +175,7 @@ struct FakeTransform {
   fuchsia::ui::composition::TransformId id{kInvalidTransformId};
 
   fuchsia::math::Vec translation{kDefaultTranslation};
-  fuchsia::math::Rect clip_bounds{kDefaultClipBounds};
+  std::optional<fuchsia::math::Rect> clip_bounds;
   fuchsia::ui::composition::Orientation orientation{kDefaultOrientation};
 
   std::vector<std::shared_ptr<FakeTransform>> children;

--- a/shell/platform/fuchsia/flutter/tests/flatland_external_view_embedder_unittests.cc
+++ b/shell/platform/fuchsia/flutter/tests/flatland_external_view_embedder_unittests.cc
@@ -215,8 +215,7 @@ Matcher<FakeGraph> IsFlutterGraph(
       /*content_map*/ _, /*transform_map*/ _,
       Pointee(FieldsAre(
           /*id*/ _, FakeTransform::kDefaultTranslation,
-          ::testing::Optional(FakeTransform::kDefaultClipBounds),
-          FakeTransform::kDefaultOrientation,
+          /*clip_bounds*/ _, FakeTransform::kDefaultOrientation,
           /*children*/ ElementsAreArray(layer_matchers),
           /*content*/ Eq(nullptr), /*num_hit_regions*/ _)),
       Eq(FakeView{
@@ -237,8 +236,7 @@ Matcher<std::shared_ptr<FakeTransform>> IsImageLayer(
     size_t num_hit_regions) {
   return Pointee(FieldsAre(
       /*id*/ _, FakeTransform::kDefaultTranslation,
-      ::testing::Optional(FakeTransform::kDefaultClipBounds),
-      FakeTransform::kDefaultOrientation,
+      /*clip_bounds*/ _, FakeTransform::kDefaultOrientation,
       /*children*/ IsEmpty(),
       /*content*/
       Pointee(VariantWith<FakeImage>(FieldsAre(
@@ -254,9 +252,8 @@ Matcher<std::shared_ptr<FakeTransform>> IsViewportLayer(
     const fuchsia::math::SizeU& view_logical_size,
     const fuchsia::math::Vec& view_transform) {
   return Pointee(
-      FieldsAre(_ /* id */, view_transform,
-                ::testing::Optional(FakeTransform::kDefaultClipBounds),
-                FakeTransform::kDefaultOrientation,
+      FieldsAre(/* id */ _, view_transform,
+                /*clip_bounds*/ _, FakeTransform::kDefaultOrientation,
                 /*children*/ IsEmpty(),
                 /*content*/
                 Pointee(VariantWith<FakeViewport>(FieldsAre(

--- a/shell/platform/fuchsia/flutter/tests/flatland_external_view_embedder_unittests.cc
+++ b/shell/platform/fuchsia/flutter/tests/flatland_external_view_embedder_unittests.cc
@@ -215,7 +215,8 @@ Matcher<FakeGraph> IsFlutterGraph(
       /*content_map*/ _, /*transform_map*/ _,
       Pointee(FieldsAre(
           /*id*/ _, FakeTransform::kDefaultTranslation,
-          FakeTransform::kDefaultClipBounds, FakeTransform::kDefaultOrientation,
+          ::testing::Optional(FakeTransform::kDefaultClipBounds),
+          FakeTransform::kDefaultOrientation,
           /*children*/ ElementsAreArray(layer_matchers),
           /*content*/ Eq(nullptr), /*num_hit_regions*/ _)),
       Eq(FakeView{
@@ -236,7 +237,8 @@ Matcher<std::shared_ptr<FakeTransform>> IsImageLayer(
     size_t num_hit_regions) {
   return Pointee(FieldsAre(
       /*id*/ _, FakeTransform::kDefaultTranslation,
-      FakeTransform::kDefaultClipBounds, FakeTransform::kDefaultOrientation,
+      ::testing::Optional(FakeTransform::kDefaultClipBounds),
+      FakeTransform::kDefaultOrientation,
       /*children*/ IsEmpty(),
       /*content*/
       Pointee(VariantWith<FakeImage>(FieldsAre(
@@ -252,7 +254,8 @@ Matcher<std::shared_ptr<FakeTransform>> IsViewportLayer(
     const fuchsia::math::SizeU& view_logical_size,
     const fuchsia::math::Vec& view_transform) {
   return Pointee(
-      FieldsAre(_ /* id */, view_transform, FakeTransform::kDefaultClipBounds,
+      FieldsAre(_ /* id */, view_transform,
+                ::testing::Optional(FakeTransform::kDefaultClipBounds),
                 FakeTransform::kDefaultOrientation,
                 /*children*/ IsEmpty(),
                 /*content*/


### PR DESCRIPTION
Update FakeFlatland to make use of the new SetClipBoundary API instead of the deprecated SetClipBounds API

