### PR TITLE
Change link to felt documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Framework](https://github.com/flutter/flutter), which provides a modern,
 reactive framework, and a rich set of platform, layout and foundation widgets.
 
 If you want to run/contribute to Flutter Web engine, more tooling can be
-found at [felt](https://github.com/flutter/engine/tree/main/lib/web_ui/dev#whats-felt).
+found at [felt](https://github.com/flutter/engine/tree/main/lib/web_ui#using-felt).
 This is a tool written to make web engine development experience easy.
 
 If you are new to Flutter, then you will find more general information


### PR DESCRIPTION
The link for "felt" in the main readme points to an anchor tag for a readme that seems like it no longer exists ("what's felt" in the `lib/web_ui/dev` folder, which has no readme at all). The parent directory has a readme with a "Using Felt" section that seems like it would be useful to link to instead.
