### PR TITLE
[fuchsia] Allow multiple vsync requests before the first Present

### DIFF
--- a/shell/platform/fuchsia/flutter/flatland_connection.h
+++ b/shell/platform/fuchsia/flutter/flatland_connection.h
@@ -80,15 +80,14 @@ class FlatlandConnection final {
   bool present_pending_ = false;
 
   // This struct contains state that is accessed from both from the UI thread
-  // (in AwaitVsync) and the raster thread (in OnNextFrameBegin). You should
-  // always lock mutex_ before touching anything in this struct
+  // (in AwaitVsync) and the raster thread (in OnNextFrameBegin and Present).
+  // You should always lock mutex_ before touching anything in this struct
   struct {
     std::mutex mutex_;
     FireCallbackCallback fire_callback_;
     bool fire_callback_pending_ = false;
+    bool first_present_called_ = false;
   } threadsafe_state_;
-
-  bool first_call_to_await_vsync_ = true;
 
   std::vector<zx::event> acquire_fences_;
   std::vector<zx::event> current_present_release_fences_;

--- a/shell/platform/fuchsia/flutter/tests/flatland_connection_unittests.cc
+++ b/shell/platform/fuchsia/flutter/tests/flatland_connection_unittests.cc
@@ -194,17 +194,52 @@ TEST_F(FlatlandConnectionTest, BasicPresent) {
   EXPECT_EQ(release_fence_handle, first_release_fence_handle);
 }
 
+TEST_F(FlatlandConnectionTest, AwaitVsyncBeforePresent) {
+  // Set up callbacks which allow sensing of how many presents were handled.
+  size_t presents_called = 0u;
+  fake_flatland().SetPresentHandler(
+      [&presents_called](auto present_args) { presents_called++; });
+
+  // Create the FlatlandConnection but don't pump the loop.  No FIDL calls are
+  // completed yet.
+  flutter_runner::FlatlandConnection flatland_connection(
+      GetCurrentTestName(), TakeFlatlandHandle(), []() { FAIL(); },
+      [](auto...) {}, 1, fml::TimeDelta::Zero());
+  EXPECT_EQ(presents_called, 0u);
+
+  // Pump the loop. Nothing is called.
+  loop().RunUntilIdle();
+  EXPECT_EQ(presents_called, 0u);
+
+  // Simulate an AwaitVsync that comes before the first Present.
+  bool await_vsync_callback_fired = false;
+  AwaitVsyncChecked(flatland_connection, await_vsync_callback_fired,
+                    kDefaultFlatlandPresentationInterval);
+  EXPECT_TRUE(await_vsync_callback_fired);
+
+  // Another AwaitVsync that comes before the first Present.
+  await_vsync_callback_fired = false;
+  AwaitVsyncChecked(flatland_connection, await_vsync_callback_fired,
+                    kDefaultFlatlandPresentationInterval);
+  EXPECT_TRUE(await_vsync_callback_fired);
+
+  // Queue Present.
+  flatland_connection.Present();
+  loop().RunUntilIdle();
+  EXPECT_EQ(presents_called, 1u);
+
+  // Set the callback with AwaitVsync, callback should not be fired
+  await_vsync_callback_fired = false;
+  AwaitVsyncChecked(flatland_connection, await_vsync_callback_fired,
+                    kDefaultFlatlandPresentationInterval);
+  EXPECT_FALSE(await_vsync_callback_fired);
+}
+
 TEST_F(FlatlandConnectionTest, OutOfOrderAwait) {
   // Set up callbacks which allow sensing of how many presents were handled.
   size_t presents_called = 0u;
-  zx_handle_t release_fence_handle;
-  fake_flatland().SetPresentHandler([&presents_called,
-                                     &release_fence_handle](auto present_args) {
-    presents_called++;
-    release_fence_handle = present_args.release_fences().empty()
-                               ? ZX_HANDLE_INVALID
-                               : present_args.release_fences().front().get();
-  });
+  fake_flatland().SetPresentHandler(
+      [&presents_called](auto present_args) { presents_called++; });
 
   // Set up a callback which allows sensing of how many vsync's
   // (`OnFramePresented` events) were handled.
@@ -226,11 +261,16 @@ TEST_F(FlatlandConnectionTest, OutOfOrderAwait) {
   EXPECT_EQ(presents_called, 0u);
   EXPECT_EQ(vsyncs_handled, 0u);
 
-  // Simulate an AwaitVsync that comes after the first call.
+  // Simulate an AwaitVsync that comes before the first Present.
   bool await_vsync_callback_fired = false;
   AwaitVsyncChecked(flatland_connection, await_vsync_callback_fired,
                     kDefaultFlatlandPresentationInterval);
   EXPECT_TRUE(await_vsync_callback_fired);
+
+  // Queue Present.
+  flatland_connection.Present();
+  loop().RunUntilIdle();
+  EXPECT_EQ(presents_called, 1u);
 
   // Set the callback with AwaitVsync, callback should not be fired
   await_vsync_callback_fired = false;
@@ -304,7 +344,7 @@ TEST_F(FlatlandConnectionTest, PresentCreditExhaustion) {
   loop().RunUntilIdle();
   EXPECT_EQ(num_presents_called, 0u);
 
-  // Simulate an AwaitVsync that comes after the first call.
+  // Simulate an AwaitVsync that comes before the first Present.
   flatland_connection.AwaitVsync([](fml::TimePoint, fml::TimePoint) {});
   loop().RunUntilIdle();
   EXPECT_EQ(num_presents_called, 0u);
@@ -323,16 +363,10 @@ TEST_F(FlatlandConnectionTest, PresentCreditExhaustion) {
     flatland_connection.Present();
   };
 
-  // Call Await Vsync with a callback that triggers Present, but this should not
-  // present until ONFB is delivered below.
+  // Call Await Vsync with a callback that triggers Present and consumes the one
+  // and only present credit we start with.
   reset_test_counters();
   flatland_connection.AwaitVsync(fire_callback);
-  loop().RunUntilIdle();
-  EXPECT_EQ(num_presents_called, 0u);
-
-  // Call ONFB ands supply 0 present credits. This causes `Present` to be
-  // called and consumes the one and only present credit we start with.
-  OnNextFrameBegin(0);
   loop().RunUntilIdle();
   EXPECT_EQ(num_presents_called, 1u);
   EXPECT_EQ(num_acquire_fences, 1u);


### PR DESCRIPTION
This CL changes the flatland render loop so that we fire vsync callbacks immediately before the first present.

Bug: https://bugs.fuchsia.dev/p/fuchsia/issues/detail?id=93179