### PR TITLE
Fix insecureAPI, NonLocalizedStringChecker, NewDeleteLeaks macOS clang errors

### DIFF
--- a/fml/synchronization/waitable_event_unittest.cc
+++ b/fml/synchronization/waitable_event_unittest.cc
@@ -4,6 +4,7 @@
 
 #include "flutter/fml/synchronization/waitable_event.h"
 
+#include <stdlib.h>
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
@@ -31,7 +32,7 @@ void SleepFor(TimeDelta duration) {
 
 void EpsilonRandomSleep() {
   TimeDelta duration =
-      TimeDelta::FromMilliseconds(static_cast<unsigned>(rand()) % 20u);
+      TimeDelta::FromMilliseconds(static_cast<unsigned>(arc4random()) % 20u);
   SleepFor(duration);
 }
 
@@ -73,7 +74,7 @@ TEST(AutoResetWaitableEventTest, MultipleWaiters) {
     std::vector<std::thread> threads;
     for (size_t j = 0u; j < 4u; j++) {
       threads.push_back(std::thread([&ev, &wake_count]() {
-        if (rand() % 2 == 0) {
+        if (arc4random() % 2 == 0) {
           ev.Wait();
         } else {
           EXPECT_FALSE(ev.WaitWithTimeout(kActionTimeout));
@@ -158,7 +159,7 @@ TEST(ManualResetWaitableEventTest, SignalMultiple) {
         threads.push_back(std::thread([&ev]() {
           EpsilonRandomSleep();
 
-          if (rand() % 2 == 0) {
+          if (arc4random() % 2 == 0) {
             ev.Wait();
           } else {
             EXPECT_FALSE(ev.WaitWithTimeout(kActionTimeout));

--- a/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegateTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegateTest.mm
@@ -199,4 +199,4 @@ TEST(AccessibilityBridgeMacDelegateTest, doesNotSendAccessibilityCreateNotificat
   [engine shutDownEngine];
 }
 
-}  // flutter::testing
+}  // namespace flutter::testing

--- a/shell/platform/darwin/macos/framework/Source/FlutterEmbedderKeyResponder.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEmbedderKeyResponder.mm
@@ -166,12 +166,12 @@ static uint64_t GetLogicalKeyForEvent(NSEvent* event, uint64_t physicalKey) {
     uint32_t* keyLabel = DecodeUtf16(keyLabelUtf16, &keyLabelLength);
     if (keyLabelLength == 1) {
       uint32_t keyLabelChar = *keyLabel;
-      delete[] keyLabel;
       NSCAssert(!IsControlCharacter(keyLabelChar) && !IsUnprintableKey(keyLabelChar),
                 @"Unexpected control or unprintable keylabel 0x%x", keyLabelChar);
       NSCAssert(keyLabelChar <= 0x10FFFF, @"Out of range keylabel 0x%x", keyLabelChar);
       character = keyLabelChar;
     }
+    delete[] keyLabel;
   }
   if (character != 0) {
     return KeyOfPlane(toLower(character), kUnicodePlane);

--- a/shell/platform/darwin/macos/framework/Source/FlutterEmbedderKeyResponderUnittests.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEmbedderKeyResponderUnittests.mm
@@ -31,7 +31,7 @@
   if (event->character != nullptr) {
     size_t len = strlen(event->character);
     char* character = new char[len + 1];
-    strcpy(character, event->character);
+    strlcpy(character, event->character, sizeof(character));
     _data->character = character;
   }
   _callback = callback;

--- a/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm
@@ -220,7 +220,12 @@ TEST(FlutterPlatformNodeDelegateMac, TextFieldUsesFlutterTextField) {
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithProject:project];
   [viewController loadView];
   [engine setViewController:viewController];
+
+  // Unit test localization is unnecessary.
+  // NOLINTBEGIN(clang-analyzer-optin.osx.cocoa.localizability.NonLocalizedStringChecker)
   viewController.textInputPlugin.string = @"textfield";
+  // NOLINTEND(clang-analyzer-optin.osx.cocoa.localizability.NonLocalizedStringChecker)
+
   // Creates a NSWindow so that the native text field can become first responder.
   NSWindow* window = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 800, 600)
                                                  styleMask:NSBorderlessWindowMask
@@ -291,4 +296,4 @@ TEST(FlutterPlatformNodeDelegateMac, TextFieldUsesFlutterTextField) {
   EXPECT_EQ([native_text_field.stringValue isEqualToString:@"textfield"], YES);
 }
 
-}  // flutter::testing
+}  // namespace flutter::testing


### PR DESCRIPTION
Fix some of the clang-tidy errors in the macOS embedder found in https://github.com/flutter/engine/pull/31291#issuecomment-1033040285.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
