### PR TITLE
De-flake CanCreateShellsWithMetalBackend

### DIFF
--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -3206,8 +3206,8 @@ TEST_F(ShellTest, CanCreateShellsWithGLBackend) {
       );
   ASSERT_NE(shell, nullptr);
   ASSERT_TRUE(shell->IsSetup());
-  PlatformViewNotifyCreated(shell.get());
   auto configuration = RunConfiguration::InferFromSettings(settings);
+  PlatformViewNotifyCreated(shell.get());
   configuration.SetEntrypoint("emptyMain");
   RunEngine(shell.get(), std::move(configuration));
   PumpOneFrame(shell.get());
@@ -3230,8 +3230,8 @@ TEST_F(ShellTest, CanCreateShellsWithVulkanBackend) {
       );
   ASSERT_NE(shell, nullptr);
   ASSERT_TRUE(shell->IsSetup());
-  PlatformViewNotifyCreated(shell.get());
   auto configuration = RunConfiguration::InferFromSettings(settings);
+  PlatformViewNotifyCreated(shell.get());
   configuration.SetEntrypoint("emptyMain");
   RunEngine(shell.get(), std::move(configuration));
   PumpOneFrame(shell.get());
@@ -3254,8 +3254,8 @@ TEST_F(ShellTest, CanCreateShellsWithMetalBackend) {
       );
   ASSERT_NE(shell, nullptr);
   ASSERT_TRUE(shell->IsSetup());
-  PlatformViewNotifyCreated(shell.get());
   auto configuration = RunConfiguration::InferFromSettings(settings);
+  PlatformViewNotifyCreated(shell.get());
   configuration.SetEntrypoint("emptyMain");
   RunEngine(shell.get(), std::move(configuration));
   PumpOneFrame(shell.get());


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/96807.

The race:
* The `RunConfiguration` constructor assigns `PersistentCache::asset_manager_` (global state).
* For the Metal backend, the platform view create event reads `PersistentCache::asset_manager_`.
* The test thread usually wins the race against the platform event loop, but occasionally it doesn't.

The behavior of the callback itself doesn't seem unreasonable to me, but we can probably add a seatbelt to this test harness to prevent this kind of thing in the future.