### PR TITLE
Roll buildroot to cf82ff8

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -107,7 +107,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '79643299bd052c53631b8b200bb582e8badb2708',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'cf82ff859b0ef52c59bfa9dd0b24fc9e3619bb26',
 
   'src/flutter/impeller':
   Var('github_git') + '/flutter/impeller' + '@' + 'c55014e747541b9a2cca15e6b2cb1b1ef9123da3',


### PR DESCRIPTION
To pick up https://github.com/flutter/buildroot/pull/546 to avoid hitting b/27730714

