### PR TITLE
Detach from GL context before attaching

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/renderer/SurfaceTextureWrapper.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/SurfaceTextureWrapper.java
@@ -66,7 +66,7 @@ public class SurfaceTextureWrapper {
         surfaceTexture.detachFromGLContext();
         attached = false;
       }
-      if (!released) {
+      if (!attached && !released) {
         surfaceTexture.attachToGLContext(texName);
         attached = true;
       }
@@ -77,7 +77,7 @@ public class SurfaceTextureWrapper {
   @SuppressWarnings("unused")
   public void detachFromGLContext() {
     synchronized (this) {
-      if (!released) {
+      if (attached && !released) {
         surfaceTexture.detachFromGLContext();
         attached = false;
       }

--- a/shell/platform/android/io/flutter/embedding/engine/renderer/SurfaceTextureWrapper.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/SurfaceTextureWrapper.java
@@ -19,6 +19,7 @@ import androidx.annotation.NonNull;
 public class SurfaceTextureWrapper {
   private SurfaceTexture surfaceTexture;
   private boolean released;
+  private boolean attached;
 
   public SurfaceTextureWrapper(@NonNull SurfaceTexture surfaceTexture) {
     this.surfaceTexture = surfaceTexture;
@@ -45,6 +46,7 @@ public class SurfaceTextureWrapper {
       if (!released) {
         surfaceTexture.release();
         released = true;
+        attached = false;
       }
     }
   }
@@ -53,8 +55,20 @@ public class SurfaceTextureWrapper {
   @SuppressWarnings("unused")
   public void attachToGLContext(int texName) {
     synchronized (this) {
+      // When the rasterizer tasks run on a different thread, the GrContext is re-created.
+      // This causes the texture to be in an uninitialized state.
+      // This should *not* be an issue once platform views are always rendered as TextureLayers
+      // since thread merging will be always disabled on Android.
+      // For more see: AndroidExternalTextureGL::OnGrContextCreated in
+      // android_external_texture_gl.cc, and
+      // https://github.com/flutter/flutter/issues/98155
+      if (attached) {
+        surfaceTexture.detachFromGLContext();
+        attached = false;
+      }
       if (!released) {
         surfaceTexture.attachToGLContext(texName);
+        attached = true;
       }
     }
   }
@@ -62,7 +76,12 @@ public class SurfaceTextureWrapper {
   // Called by native.
   @SuppressWarnings("unused")
   public void detachFromGLContext() {
-    surfaceTexture.detachFromGLContext();
+    synchronized (this) {
+      if (!released) {
+        surfaceTexture.detachFromGLContext();
+        attached = false;
+      }
+    }
   }
 
   // Called by native.

--- a/shell/platform/android/io/flutter/embedding/engine/renderer/SurfaceTextureWrapper.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/SurfaceTextureWrapper.java
@@ -55,6 +55,9 @@ public class SurfaceTextureWrapper {
   @SuppressWarnings("unused")
   public void attachToGLContext(int texName) {
     synchronized (this) {
+      if (released) {
+        return;
+      }
       // When the rasterizer tasks run on a different thread, the GrContext is re-created.
       // This causes the texture to be in an uninitialized state.
       // This should *not* be an issue once platform views are always rendered as TextureLayers
@@ -64,12 +67,9 @@ public class SurfaceTextureWrapper {
       // https://github.com/flutter/flutter/issues/98155
       if (attached) {
         surfaceTexture.detachFromGLContext();
-        attached = false;
       }
-      if (!attached && !released) {
-        surfaceTexture.attachToGLContext(texName);
-        attached = true;
-      }
+      surfaceTexture.attachToGLContext(texName);
+      attached = true;
     }
   }
 

--- a/shell/platform/android/test/io/flutter/embedding/engine/renderer/SurfaceTextureWrapperTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/renderer/SurfaceTextureWrapperTest.java
@@ -1,0 +1,69 @@
+package io.flutter.embedding.engine.renderer;
+
+import static junit.framework.TestCase.*;
+import static org.mockito.Mockito.*;
+
+import android.graphics.SurfaceTexture;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class SurfaceTextureWrapperTest {
+
+  private SurfaceTextureWrapper textureWrapper;
+
+  @Test
+  public void attachToGLContext() {
+    final SurfaceTexture tx = mock(SurfaceTexture.class);
+    final SurfaceTextureWrapper wrapper = new SurfaceTextureWrapper(tx);
+
+    wrapper.attachToGLContext(0);
+    verify(tx, times(1)).attachToGLContext(0);
+    verifyNoMoreInteractions(tx);
+  }
+
+  @Test
+  public void attachToGLContext_detachesFromCurrentContext() {
+    final SurfaceTexture tx = mock(SurfaceTexture.class);
+    final SurfaceTextureWrapper wrapper = new SurfaceTextureWrapper(tx);
+
+    wrapper.attachToGLContext(0);
+
+    reset(tx);
+
+    wrapper.attachToGLContext(0);
+    verify(tx, times(1)).detachFromGLContext();
+    verify(tx, times(1)).attachToGLContext(0);
+    verifyNoMoreInteractions(tx);
+  }
+
+  @Test
+  public void attachToGLContext_doesNotDetacheFromCurrentContext() {
+    final SurfaceTexture tx = mock(SurfaceTexture.class);
+    final SurfaceTextureWrapper wrapper = new SurfaceTextureWrapper(tx);
+
+    wrapper.attachToGLContext(0);
+
+    wrapper.detachFromGLContext();
+
+    reset(tx);
+
+    wrapper.attachToGLContext(0);
+    verify(tx, times(1)).attachToGLContext(0);
+    verifyNoMoreInteractions(tx);
+  }
+
+  @Test
+  public void detachFromGLContext() {
+    final SurfaceTexture tx = mock(SurfaceTexture.class);
+    final SurfaceTextureWrapper wrapper = new SurfaceTextureWrapper(tx);
+
+    wrapper.attachToGLContext(0);
+    reset(tx);
+
+    wrapper.detachFromGLContext();
+    verify(tx, times(1)).detachFromGLContext();
+    verifyNoMoreInteractions(tx);
+  }
+}

--- a/shell/platform/android/test/io/flutter/embedding/engine/renderer/SurfaceTextureWrapperTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/renderer/SurfaceTextureWrapperTest.java
@@ -70,7 +70,6 @@ public class SurfaceTextureWrapperTest {
     final SurfaceTexture tx = mock(SurfaceTexture.class);
     final SurfaceTextureWrapper wrapper = new SurfaceTextureWrapper(tx);
 
-    wrapper.attachToGLContext(0);
     wrapper.release();
 
     verify(tx, times(1)).release();

--- a/shell/platform/android/test/io/flutter/embedding/engine/renderer/SurfaceTextureWrapperTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/renderer/SurfaceTextureWrapperTest.java
@@ -65,4 +65,19 @@ public class SurfaceTextureWrapperTest {
     verifyNoMoreInteractions(tx);
   }
 
+  @Test
+  public void release() {
+    final SurfaceTexture tx = mock(SurfaceTexture.class);
+    final SurfaceTextureWrapper wrapper = new SurfaceTextureWrapper(tx);
+
+    wrapper.attachToGLContext(0);
+    wrapper.release();
+
+    verify(tx, times(1)).release();
+    reset(tx);
+
+    wrapper.detachFromGLContext();
+    wrapper.attachToGLContext(0);
+    verifyNoMoreInteractions(tx);
+  }
 }

--- a/shell/platform/android/test/io/flutter/embedding/engine/renderer/SurfaceTextureWrapperTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/renderer/SurfaceTextureWrapperTest.java
@@ -64,4 +64,5 @@ public class SurfaceTextureWrapperTest {
     verify(tx, times(1)).detachFromGLContext();
     verifyNoMoreInteractions(tx);
   }
+
 }

--- a/shell/platform/android/test/io/flutter/embedding/engine/renderer/SurfaceTextureWrapperTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/renderer/SurfaceTextureWrapperTest.java
@@ -11,8 +11,6 @@ import org.junit.runner.RunWith;
 @RunWith(AndroidJUnit4.class)
 public class SurfaceTextureWrapperTest {
 
-  private SurfaceTextureWrapper textureWrapper;
-
   @Test
   public void attachToGLContext() {
     final SurfaceTexture tx = mock(SurfaceTexture.class);


### PR DESCRIPTION

When the rasterizer tasks run on a different thread, the GrContext is re-created.
This causes the texture to be in an uninitialized state.
This should *not* be an issue once platform views are always rendered as TextureLayers
since thread merging will be always disabled on Android.

Fixes https://github.com/flutter/flutter/issues/98155
