### PR TITLE
[Android] Add support for disabling dynamic thread merging.

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1196,6 +1196,7 @@ FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/platform/Virtual
 FILE: ../../../flutter/shell/platform/android/io/flutter/util/PathUtils.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/util/Preconditions.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/util/Predicate.java
+FILE: ../../../flutter/shell/platform/android/io/flutter/util/ThreadUtils.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/util/ViewUtils.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/view/AccessibilityViewEmbedder.java

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -275,6 +275,7 @@ android_java_sources = [
   "io/flutter/util/PathUtils.java",
   "io/flutter/util/Preconditions.java",
   "io/flutter/util/Predicate.java",
+  "io/flutter/util/ThreadUtils.java",
   "io/flutter/util/ViewUtils.java",
   "io/flutter/view/AccessibilityBridge.java",
   "io/flutter/view/AccessibilityViewEmbedder.java",

--- a/shell/platform/android/external_view_embedder/external_view_embedder.cc
+++ b/shell/platform/android/external_view_embedder/external_view_embedder.cc
@@ -216,7 +216,9 @@ AndroidExternalViewEmbedder::CreateSurfaceIfNeeded(GrDirectContext* context,
 // |ExternalViewEmbedder|
 PostPrerollResult AndroidExternalViewEmbedder::PostPrerollAction(
     fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) {
-  if (!FrameHasPlatformLayers()) {
+  // The `raster_thread_merger` will be null if |SupportsDynamicThreadMerging|
+  // returns false.
+  if (!FrameHasPlatformLayers() || !raster_thread_merger) {
     return PostPrerollResult::kSuccess;
   }
   if (!raster_thread_merger->IsMerged()) {
@@ -272,10 +274,7 @@ void AndroidExternalViewEmbedder::BeginFrame(
     DestroySurfaces();
   }
   surface_pool_->SetFrameSize(frame_size);
-  // JNI method must be called on the platform thread.
-  if (raster_thread_merger->IsOnPlatformThread()) {
-    jni_facade_->FlutterViewBeginFrame();
-  }
+  jni_facade_->FlutterViewBeginFrame();
 
   frame_size_ = frame_size;
   device_pixel_ratio_ = device_pixel_ratio;
@@ -291,10 +290,7 @@ void AndroidExternalViewEmbedder::EndFrame(
     bool should_resubmit_frame,
     fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) {
   surface_pool_->RecycleLayers();
-  // JNI method must be called on the platform thread.
-  if (raster_thread_merger->IsOnPlatformThread()) {
-    jni_facade_->FlutterViewEndFrame();
-  }
+  jni_facade_->FlutterViewEndFrame();
 }
 
 // |ExternalViewEmbedder|

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -31,6 +31,7 @@ import io.flutter.plugin.common.StandardMessageCodec;
 import io.flutter.plugin.localization.LocalizationPlugin;
 import io.flutter.plugin.platform.PlatformViewsController;
 import io.flutter.util.Preconditions;
+import io.flutter.util.ThreadUtils;
 import io.flutter.view.AccessibilityBridge;
 import io.flutter.view.FlutterCallbackInformation;
 import java.io.IOException;
@@ -40,6 +41,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -1127,56 +1129,72 @@ public class FlutterJNI {
   @SuppressWarnings("unused")
   @UiThread
   public void onDisplayOverlaySurface(int id, int x, int y, int width, int height) {
-    ensureRunningOnMainThread();
-    if (platformViewsController == null) {
-      throw new RuntimeException(
-          "platformViewsController must be set before attempting to position an overlay surface");
-    }
-    platformViewsController.onDisplayOverlaySurface(id, x, y, width, height);
+    ThreadUtils.runOnUiThread(
+        () -> {
+          ensureRunningOnMainThread();
+          if (platformViewsController == null) {
+            throw new RuntimeException(
+                "platformViewsController must be set before attempting to position an overlay surface");
+          }
+          platformViewsController.onDisplayOverlaySurface(id, x, y, width, height);
+        });
   }
 
   @SuppressWarnings("unused")
   @UiThread
   public void onBeginFrame() {
-    ensureRunningOnMainThread();
-    if (platformViewsController == null) {
-      throw new RuntimeException(
-          "platformViewsController must be set before attempting to begin the frame");
-    }
-    platformViewsController.onBeginFrame();
+    ThreadUtils.runOnUiThread(
+        () -> {
+          ensureRunningOnMainThread();
+          if (platformViewsController == null) {
+            throw new RuntimeException(
+                "platformViewsController must be set before attempting to begin the frame");
+          }
+          platformViewsController.onBeginFrame();
+        });
   }
 
   @SuppressWarnings("unused")
   @UiThread
   public void onEndFrame() {
-    ensureRunningOnMainThread();
-    if (platformViewsController == null) {
-      throw new RuntimeException(
-          "platformViewsController must be set before attempting to end the frame");
-    }
-    platformViewsController.onEndFrame();
+    ThreadUtils.runOnUiThread(
+        () -> {
+          ensureRunningOnMainThread();
+          if (platformViewsController == null) {
+            throw new RuntimeException(
+                "platformViewsController must be set before attempting to end the frame");
+          }
+          platformViewsController.onEndFrame();
+        });
   }
 
   @SuppressWarnings("unused")
   @UiThread
   public FlutterOverlaySurface createOverlaySurface() {
-    ensureRunningOnMainThread();
-    if (platformViewsController == null) {
-      throw new RuntimeException(
-          "platformViewsController must be set before attempting to position an overlay surface");
-    }
-    return platformViewsController.createOverlaySurface();
+    return ThreadUtils.runOnUiThreadBlockingNoException(
+        (Callable<FlutterOverlaySurface>)
+            () -> {
+              ensureRunningOnMainThread();
+              if (platformViewsController == null) {
+                throw new RuntimeException(
+                    "platformViewsController must be set before attempting to position an overlay surface");
+              }
+              return platformViewsController.createOverlaySurface();
+            });
   }
 
   @SuppressWarnings("unused")
   @UiThread
   public void destroyOverlaySurfaces() {
-    ensureRunningOnMainThread();
-    if (platformViewsController == null) {
-      throw new RuntimeException(
-          "platformViewsController must be set before attempting to destroy an overlay surface");
-    }
-    platformViewsController.destroyOverlaySurfaces();
+    ThreadUtils.runOnUiThread(
+        () -> {
+          ensureRunningOnMainThread();
+          if (platformViewsController == null) {
+            throw new RuntimeException(
+                "platformViewsController must be set before attempting to destroy an overlay surface");
+          }
+          platformViewsController.destroyOverlaySurfaces();
+        });
   }
   // ----- End Engine Lifecycle Support ----
 
@@ -1362,13 +1380,16 @@ public class FlutterJNI {
       int viewWidth,
       int viewHeight,
       FlutterMutatorsStack mutatorsStack) {
-    ensureRunningOnMainThread();
-    if (platformViewsController == null) {
-      throw new RuntimeException(
-          "platformViewsController must be set before attempting to position a platform view");
-    }
-    platformViewsController.onDisplayPlatformView(
-        viewId, x, y, width, height, viewWidth, viewHeight, mutatorsStack);
+    ThreadUtils.runOnUiThread(
+        () -> {
+          ensureRunningOnMainThread();
+          if (platformViewsController == null) {
+            throw new RuntimeException(
+                "platformViewsController must be set before attempting to position a platform view");
+          }
+          platformViewsController.onDisplayPlatformView(
+              viewId, x, y, width, height, viewWidth, viewHeight, mutatorsStack);
+        });
   }
 
   // TODO(mattcarroll): determine if this is nonull or nullable

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -1127,7 +1127,6 @@ public class FlutterJNI {
   }
 
   @SuppressWarnings("unused")
-  @UiThread
   public void onDisplayOverlaySurface(int id, int x, int y, int width, int height) {
     ThreadUtils.runOnUiThread(
         () -> {
@@ -1141,7 +1140,6 @@ public class FlutterJNI {
   }
 
   @SuppressWarnings("unused")
-  @UiThread
   public void onBeginFrame() {
     ThreadUtils.runOnUiThread(
         () -> {
@@ -1155,7 +1153,6 @@ public class FlutterJNI {
   }
 
   @SuppressWarnings("unused")
-  @UiThread
   public void onEndFrame() {
     ThreadUtils.runOnUiThread(
         () -> {
@@ -1169,7 +1166,6 @@ public class FlutterJNI {
   }
 
   @SuppressWarnings("unused")
-  @UiThread
   public FlutterOverlaySurface createOverlaySurface() {
     return ThreadUtils.runOnUiThreadBlockingNoException(
         (Callable<FlutterOverlaySurface>)
@@ -1184,7 +1180,6 @@ public class FlutterJNI {
   }
 
   @SuppressWarnings("unused")
-  @UiThread
   public void destroyOverlaySurfaces() {
     ThreadUtils.runOnUiThread(
         () -> {
@@ -1370,7 +1365,6 @@ public class FlutterJNI {
   // ----- End Deferred Components Support ----
 
   // @SuppressWarnings("unused")
-  @UiThread
   public void onDisplayPlatformView(
       int viewId,
       int x,

--- a/shell/platform/android/io/flutter/util/ThreadUtils.java
+++ b/shell/platform/android/io/flutter/util/ThreadUtils.java
@@ -1,4 +1,4 @@
-// Copyright 2012 The Chromium Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/shell/platform/android/io/flutter/util/ThreadUtils.java
+++ b/shell/platform/android/io/flutter/util/ThreadUtils.java
@@ -1,0 +1,291 @@
+// Copyright 2012 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.util;
+
+import android.os.Handler;
+import android.os.Looper;
+import android.os.Process;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
+
+/** Helper methods to deal with threading related tasks. */
+public class ThreadUtils {
+
+  private static final Object sLock = new Object();
+
+  private static boolean sWillOverride;
+
+  private static Handler sUiThreadHandler;
+
+  private static boolean sThreadAssertsDisabled;
+
+  /**
+   * A helper object to ensure that interactions with a particular object only happens on a
+   * particular thread.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * class Foo {
+   *     // Valid thread is set during construction here.
+   *     private final ThreadChecker mThreadChecker = new ThreadChecker();
+   *
+   *     public void doFoo() {
+   *         mThreadChecker.assertOnValidThread();
+   *     }
+   * }
+   * }</pre>
+   *
+   * Another way to use this class is to also use the baked in support for destruction:
+   *
+   * <pre>{@code
+   * class Foo {
+   *     // Valid thread is set during construction here.
+   *     private final ThreadChecker mThreadChecker = new ThreadChecker();
+   *
+   *     public void doFoo() {
+   *         mThreadChecker.assertOnValidThreadAndState();
+   *     }
+   *
+   *     public void destroy() {
+   *         mThreadChecker.destroy();
+   *     }
+   * }
+   * }</pre>
+   */
+  public static class ThreadChecker {
+    private final long mThreadId = Process.myTid();
+
+    /**
+     * Asserts that the current thread is the same as the one the ThreadChecker was constructed on.
+     */
+    public void assertOnValidThread() {
+      assert sThreadAssertsDisabled || mThreadId == Process.myTid()
+          : "Must only be used on a single thread.";
+    }
+  }
+
+  public static void setWillOverrideUiThread(boolean willOverrideUiThread) {
+    synchronized (sLock) {
+      sWillOverride = willOverrideUiThread;
+    }
+  }
+
+  public static void setUiThread(Looper looper) {
+    synchronized (sLock) {
+      if (looper == null) {
+        // Used to reset the looper after tests.
+        sUiThreadHandler = null;
+        return;
+      }
+      if (sUiThreadHandler != null && sUiThreadHandler.getLooper() != looper) {
+        throw new RuntimeException(
+            "UI thread looper is already set to "
+                + sUiThreadHandler.getLooper()
+                + " (Main thread looper is "
+                + Looper.getMainLooper()
+                + "), cannot set to new looper "
+                + looper);
+      } else {
+        sUiThreadHandler = new Handler(looper);
+      }
+    }
+  }
+
+  public static Handler getUiThreadHandler() {
+    synchronized (sLock) {
+      if (sUiThreadHandler == null) {
+        if (sWillOverride) {
+          throw new RuntimeException("Did not yet override the UI thread");
+        }
+        sUiThreadHandler = new Handler(Looper.getMainLooper());
+      }
+    }
+    return sUiThreadHandler;
+  }
+
+  /**
+   * Run the supplied Runnable on the main thread. The method will block until the Runnable
+   * completes.
+   *
+   * @param r The Runnable to run.
+   */
+  public static void runOnUiThreadBlocking(final Runnable r) {
+    if (runningOnUiThread()) {
+      r.run();
+    } else {
+      FutureTask<Void> task = new FutureTask<Void>(r, null);
+      postOnUiThread(task);
+      try {
+        task.get();
+      } catch (Exception e) {
+        throw new RuntimeException("Exception occurred while waiting for runnable", e);
+      }
+    }
+  }
+
+  /**
+   * Run the supplied Callable on the main thread, wrapping any exceptions in a RuntimeException.
+   * The method will block until the Callable completes.
+   *
+   * @param c The Callable to run
+   * @return The result of the callable
+   */
+  public static <T> T runOnUiThreadBlockingNoException(Callable<T> c) {
+    try {
+      return runOnUiThreadBlocking(c);
+    } catch (ExecutionException e) {
+      throw new RuntimeException("Error occurred waiting for callable", e);
+    }
+  }
+
+  /**
+   * Run the supplied Callable on the main thread, The method will block until the Callable
+   * completes.
+   *
+   * @param c The Callable to run
+   * @return The result of the callable
+   * @throws ExecutionException c's exception
+   */
+  public static <T> T runOnUiThreadBlocking(Callable<T> c) throws ExecutionException {
+    FutureTask<T> task = new FutureTask<T>(c);
+    runOnUiThread(task);
+    try {
+      return task.get();
+    } catch (InterruptedException e) {
+      throw new RuntimeException("Interrupted waiting for callable", e);
+    }
+  }
+
+  /**
+   * Run the supplied FutureTask on the main thread. The method will block only if the current
+   * thread is the main thread.
+   *
+   * @param task The FutureTask to run
+   * @return The queried task (to aid inline construction)
+   */
+  public static <T> FutureTask<T> runOnUiThread(FutureTask<T> task) {
+    if (runningOnUiThread()) {
+      task.run();
+    } else {
+      postOnUiThread(task);
+    }
+    return task;
+  }
+
+  /**
+   * Run the supplied Callable on the main thread. The method will block only if the current thread
+   * is the main thread.
+   *
+   * @param c The Callable to run
+   * @return A FutureTask wrapping the callable to retrieve results
+   */
+  public static <T> FutureTask<T> runOnUiThread(Callable<T> c) {
+    return runOnUiThread(new FutureTask<T>(c));
+  }
+
+  /**
+   * Run the supplied Runnable on the main thread. The method will block only if the current thread
+   * is the main thread.
+   *
+   * @param r The Runnable to run
+   */
+  public static void runOnUiThread(Runnable r) {
+    if (runningOnUiThread()) {
+      r.run();
+    } else {
+      getUiThreadHandler().post(r);
+    }
+  }
+
+  /**
+   * Post the supplied FutureTask to run on the main thread. The method will not block, even if
+   * called on the UI thread.
+   *
+   * @param task The FutureTask to run
+   * @return The queried task (to aid inline construction)
+   */
+  public static <T> FutureTask<T> postOnUiThread(FutureTask<T> task) {
+    getUiThreadHandler().post(task);
+    return task;
+  }
+
+  /**
+   * Post the supplied Runnable to run on the main thread. The method will not block, even if called
+   * on the UI thread.
+   *
+   * @param task The Runnable to run
+   */
+  public static void postOnUiThread(Runnable task) {
+    getUiThreadHandler().post(task);
+  }
+
+  /**
+   * Post the supplied Runnable to run on the main thread after the given amount of time. The method
+   * will not block, even if called on the UI thread.
+   *
+   * @param task The Runnable to run
+   * @param delayMillis The delay in milliseconds until the Runnable will be run
+   */
+  public static void postOnUiThreadDelayed(Runnable task, long delayMillis) {
+    getUiThreadHandler().postDelayed(task, delayMillis);
+  }
+
+  /**
+   * Throw an exception (when DCHECKs are enabled) if currently not running on the UI thread.
+   *
+   * <p>Can be disabled by setThreadAssertsDisabledForTesting(true).
+   */
+  public static void assertOnUiThread() {
+    if (sThreadAssertsDisabled) return;
+
+    assert runningOnUiThread() : "Must be called on the UI thread.";
+  }
+
+  /**
+   * Throw an exception (regardless of build) if currently not running on the UI thread.
+   *
+   * <p>Can be disabled by setThreadAssertsEnabledForTesting(false).
+   *
+   * @see #assertOnUiThread()
+   */
+  public static void checkUiThread() {
+    if (!sThreadAssertsDisabled && !runningOnUiThread()) {
+      throw new IllegalStateException("Must be called on the UI thread.");
+    }
+  }
+
+  /**
+   * Throw an exception (when DCHECKs are enabled) if currently running on the UI thread.
+   *
+   * <p>Can be disabled by setThreadAssertsDisabledForTesting(true).
+   */
+  public static void assertOnBackgroundThread() {
+    if (sThreadAssertsDisabled) return;
+
+    assert !runningOnUiThread() : "Must be called on a thread other than UI.";
+  }
+
+  /**
+   * Disables thread asserts.
+   *
+   * <p>Can be used by tests where code that normally runs multi-threaded is going to run
+   * single-threaded for the test (otherwise asserts that are valid in production would fail in
+   * those tests).
+   */
+  public static void setThreadAssertsDisabledForTesting(boolean disabled) {
+    sThreadAssertsDisabled = disabled;
+  }
+
+  /** @return true iff the current thread is the main (UI) thread. */
+  public static boolean runningOnUiThread() {
+    return getUiThreadHandler().getLooper() == Looper.myLooper();
+  }
+
+  public static Looper getUiThreadLooper() {
+    return getUiThreadHandler().getLooper();
+  }
+}

--- a/tools/android_lint/project.xml
+++ b/tools/android_lint/project.xml
@@ -68,6 +68,7 @@
     <src file="../../../flutter/shell/platform/android/io/flutter/app/FlutterApplication.java" />
     <src file="../../../flutter/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java" />
     <src file="../../../flutter/shell/platform/android/io/flutter/util/Preconditions.java" />
+    <src file="../../../flutter/shell/platform/android/io/flutter/util/ThreadUtils.java" />
     <src file="../../../flutter/shell/platform/android/io/flutter/util/ViewUtils.java" />
     <src file="../../../flutter/shell/platform/android/io/flutter/util/Predicate.java" />
     <src file="../../../flutter/shell/platform/android/io/flutter/util/PathUtils.java" />


### PR DESCRIPTION
We make JNI functions callable from any thread here, not just the platform thread, to allow disable dynamic thread merging.

```c++
// |ExternalViewEmbedder|
bool AndroidExternalViewEmbedder::SupportsDynamicThreadMerging() {
  return false;
}
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
