### PR TITLE
Reland: Trackpad gesture PointerData types

### DIFF
--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -341,7 +341,7 @@ class PlatformDispatcher {
   //  * pointer_data.cc
   //  * pointer.dart
   //  * AndroidTouchProcessor.java
-  static const int _kPointerDataFieldCount = 29;
+  static const int _kPointerDataFieldCount = 35;
 
   static PointerDataPacket _unpackPointerDataPacket(ByteData packet) {
     const int kStride = Int64List.bytesPerElement;
@@ -381,6 +381,12 @@ class PlatformDispatcher {
         platformData: packet.getInt64(kStride * offset++, _kFakeHostEndian),
         scrollDeltaX: packet.getFloat64(kStride * offset++, _kFakeHostEndian),
         scrollDeltaY: packet.getFloat64(kStride * offset++, _kFakeHostEndian),
+        panX: packet.getFloat64(kStride * offset++, _kFakeHostEndian),
+        panY: packet.getFloat64(kStride * offset++, _kFakeHostEndian),
+        panDeltaX: packet.getFloat64(kStride * offset++, _kFakeHostEndian),
+        panDeltaY: packet.getFloat64(kStride * offset++, _kFakeHostEndian),
+        scale: packet.getFloat64(kStride * offset++, _kFakeHostEndian),
+        rotation: packet.getFloat64(kStride * offset++, _kFakeHostEndian),
       ));
       assert(offset == (i + 1) * _kPointerDataFieldCount);
     }

--- a/lib/ui/pointer.dart
+++ b/lib/ui/pointer.dart
@@ -36,6 +36,15 @@ enum PointerChange {
 
   /// The pointer has stopped making contact with the device.
   up,
+
+  /// A pan/zoom has started on this pointer.
+  panZoomStart,
+
+  /// The pan/zoom on this pointer has updated.
+  panZoomUpdate,
+
+  /// The pan/zoom on this pointer has ended.
+  panZoomEnd,
 }
 
 /// The kind of pointer device.
@@ -51,6 +60,9 @@ enum PointerDeviceKind {
 
   /// A pointer device with a stylus that has been inverted.
   invertedStylus,
+
+  /// A touch-based pointer device with an indirect surface.
+  trackpad,
 
   /// An unknown pointer device.
   unknown
@@ -101,6 +113,12 @@ class PointerData {
     this.platformData = 0,
     this.scrollDeltaX = 0.0,
     this.scrollDeltaY = 0.0,
+    this.panX = 0.0,
+    this.panY = 0.0,
+    this.panDeltaX = 0.0,
+    this.panDeltaY = 0.0,
+    this.scale = 0.0,
+    this.rotation = 0.0,
   });
 
   /// Unique identifier that ties the [PointerEvent] to embedder event created it.
@@ -265,6 +283,40 @@ class PointerData {
   /// The amount to scroll in the y direction, in physical pixels.
   final double scrollDeltaY;
 
+  /// For events with change of PointerChange.panZoomUpdate:
+  ///
+  /// The current panning magnitude of the pan/zoom in the x direction, in
+  /// physical pixels.
+  final double panX;
+
+  /// For events with change of PointerChange.panZoomUpdate:
+  ///
+  /// The current panning magnitude of the pan/zoom in the y direction, in
+  /// physical pixels.
+  final double panY;
+
+  /// For events with change of PointerChange.panZoomUpdate:
+  ///
+  /// The difference in panning of the pan/zoom in the x direction since the
+  /// latest panZoomUpdate event, in physical pixels.
+  final double panDeltaX;
+
+  /// For events with change of PointerChange.panZoomUpdate:
+  ///
+  /// The difference in panning of the pan/zoom in the y direction since the
+  /// last panZoomUpdate event, in physical pixels.
+  final double panDeltaY;
+
+  /// For events with change of PointerChange.panZoomUpdate:
+  ///
+  /// The current scale of the pan/zoom (unitless), with 1.0 as the initial scale.
+  final double scale;
+
+  /// For events with change of PointerChange.panZoomUpdate:
+  ///
+  /// The current angle of the pan/zoom in radians, with 0.0 as the initial angle.
+  final double rotation;
+
   @override
   String toString() => 'PointerData(x: $physicalX, y: $physicalY)';
 
@@ -298,7 +350,13 @@ class PointerData {
              'tilt: $tilt, '
              'platformData: $platformData, '
              'scrollDeltaX: $scrollDeltaX, '
-             'scrollDeltaY: $scrollDeltaY'
+             'scrollDeltaY: $scrollDeltaY, '
+             'panX: $panX, '
+             'panY: $panY, '
+             'panDeltaX: $panDeltaX, '
+             'panDeltaY: $panDeltaY, '
+             'scale: $scale, '
+             'rotation: $rotation'
            ')';
   }
 }

--- a/lib/ui/window/pointer_data.h
+++ b/lib/ui/window/pointer_data.h
@@ -10,7 +10,7 @@
 namespace flutter {
 
 // If this value changes, update the pointer data unpacking code in hooks.dart.
-static constexpr int kPointerDataFieldCount = 29;
+static constexpr int kPointerDataFieldCount = 35;
 static constexpr int kBytesPerField = sizeof(int64_t);
 // Must match the button constants in events.dart.
 enum PointerButtonMouse : int64_t {
@@ -42,6 +42,9 @@ struct alignas(8) PointerData {
     kDown,
     kMove,
     kUp,
+    kPanZoomStart,
+    kPanZoomUpdate,
+    kPanZoomEnd,
   };
 
   // Must match the PointerDeviceKind enum in pointer.dart.
@@ -50,6 +53,7 @@ struct alignas(8) PointerData {
     kMouse,
     kStylus,
     kInvertedStylus,
+    kTrackpad,
   };
 
   // Must match the PointerSignalKind enum in pointer.dart.
@@ -87,6 +91,12 @@ struct alignas(8) PointerData {
   int64_t platformData;
   double scroll_delta_x;
   double scroll_delta_y;
+  double pan_x;
+  double pan_y;
+  double pan_delta_x;
+  double pan_delta_y;
+  double scale;
+  double rotation;
 
   void Clear();
 };

--- a/lib/ui/window/pointer_data_packet_converter.cc
+++ b/lib/ui/window/pointer_data_packet_converter.cc
@@ -4,6 +4,7 @@
 
 #include "flutter/lib/ui/window/pointer_data_packet_converter.h"
 
+#include <cmath>
 #include <cstring>
 
 #include "flutter/fml/logging.h"
@@ -207,6 +208,88 @@ void PointerDataPacketConverter::ConvertPointerData(
         converted_pointers.push_back(pointer_data);
         break;
       }
+      case PointerData::Change::kPanZoomStart: {
+        // Makes sure we have an existing pointer
+        auto iter = states_.find(pointer_data.device);
+        PointerState state;
+        if (iter == states_.end()) {
+          // Synthesizes add event if the pointer is not previously added.
+          PointerData synthesized_add_event = pointer_data;
+          synthesized_add_event.change = PointerData::Change::kAdd;
+          synthesized_add_event.synthesized = 1;
+          synthesized_add_event.buttons = 0;
+          state = EnsurePointerState(synthesized_add_event);
+          converted_pointers.push_back(synthesized_add_event);
+        } else {
+          state = iter->second;
+        }
+        FML_DCHECK(!state.is_down);
+        FML_DCHECK(!state.is_pan_zoom_active);
+        if (LocationNeedsUpdate(pointer_data, state)) {
+          // Synthesizes a hover event if the location does not match.
+          PointerData synthesized_hover_event = pointer_data;
+          synthesized_hover_event.change = PointerData::Change::kHover;
+          synthesized_hover_event.synthesized = 1;
+          synthesized_hover_event.buttons = 0;
+
+          UpdateDeltaAndState(synthesized_hover_event, state);
+          converted_pointers.push_back(synthesized_hover_event);
+        }
+
+        UpdatePointerIdentifier(pointer_data, state, true);
+        state.is_pan_zoom_active = true;
+        state.pan_x = 0;
+        state.pan_y = 0;
+        state.scale = 1;
+        state.rotation = 0;
+        states_[pointer_data.device] = state;
+        converted_pointers.push_back(pointer_data);
+        break;
+      }
+      case PointerData::Change::kPanZoomUpdate: {
+        // Makes sure we have an existing pointer in pan_zoom_active state
+        auto iter = states_.find(pointer_data.device);
+        FML_DCHECK(iter != states_.end());
+        PointerState state = iter->second;
+        FML_DCHECK(!state.is_down);
+        FML_DCHECK(state.is_pan_zoom_active);
+
+        UpdatePointerIdentifier(pointer_data, state, false);
+        UpdateDeltaAndState(pointer_data, state);
+
+        converted_pointers.push_back(pointer_data);
+        break;
+      }
+      case PointerData::Change::kPanZoomEnd: {
+        // Makes sure we have an existing pointer in pan_zoom_active state
+        auto iter = states_.find(pointer_data.device);
+        FML_DCHECK(iter != states_.end());
+        PointerState state = iter->second;
+        FML_DCHECK(state.is_pan_zoom_active);
+
+        UpdatePointerIdentifier(pointer_data, state, false);
+
+        if (LocationNeedsUpdate(pointer_data, state)) {
+          // Synthesizes an update event if the location does not match.
+          PointerData synthesized_move_event = pointer_data;
+          synthesized_move_event.change = PointerData::Change::kPanZoomUpdate;
+          synthesized_move_event.pan_x = state.pan_x;
+          synthesized_move_event.pan_y = state.pan_y;
+          synthesized_move_event.pan_delta_x = 0;
+          synthesized_move_event.pan_delta_y = 0;
+          synthesized_move_event.scale = state.scale;
+          synthesized_move_event.rotation = state.rotation;
+          synthesized_move_event.synthesized = 1;
+
+          UpdateDeltaAndState(synthesized_move_event, state);
+          converted_pointers.push_back(synthesized_move_event);
+        }
+
+        state.is_pan_zoom_active = false;
+        states_[pointer_data.device] = state;
+        converted_pointers.push_back(pointer_data);
+        break;
+      }
       default: {
         converted_pointers.push_back(pointer_data);
         break;
@@ -261,8 +344,11 @@ PointerState PointerDataPacketConverter::EnsurePointerState(
   PointerState state;
   state.pointer_identifier = 0;
   state.is_down = false;
+  state.is_pan_zoom_active = false;
   state.physical_x = pointer_data.physical_x;
   state.physical_y = pointer_data.physical_y;
+  state.pan_x = 0;
+  state.pan_y = 0;
   states_[pointer_data.device] = state;
   return state;
 }
@@ -271,8 +357,14 @@ void PointerDataPacketConverter::UpdateDeltaAndState(PointerData& pointer_data,
                                                      PointerState& state) {
   pointer_data.physical_delta_x = pointer_data.physical_x - state.physical_x;
   pointer_data.physical_delta_y = pointer_data.physical_y - state.physical_y;
+  pointer_data.pan_delta_x = pointer_data.pan_x - state.pan_x;
+  pointer_data.pan_delta_y = pointer_data.pan_y - state.pan_y;
   state.physical_x = pointer_data.physical_x;
   state.physical_y = pointer_data.physical_y;
+  state.pan_x = pointer_data.pan_x;
+  state.pan_y = pointer_data.pan_y;
+  state.scale = pointer_data.scale;
+  state.rotation = pointer_data.rotation;
   states_[pointer_data.device] = state;
 }
 

--- a/lib/ui/window/pointer_data_packet_converter.h
+++ b/lib/ui/window/pointer_data_packet_converter.h
@@ -30,8 +30,13 @@ namespace flutter {
 struct PointerState {
   int64_t pointer_identifier;
   bool is_down;
+  bool is_pan_zoom_active;
   double physical_x;
   double physical_y;
+  double pan_x;
+  double pan_y;
+  double scale;
+  double rotation;
   int64_t buttons;
 };
 

--- a/lib/ui/window/pointer_data_packet_converter_unittests.cc
+++ b/lib/ui/window/pointer_data_packet_converter_unittests.cc
@@ -86,6 +86,51 @@ void CreateSimulatedMousePointerData(PointerData& data,  // NOLINT
   data.scroll_delta_y = scroll_delta_y;
 }
 
+void CreateSimulatedTrackpadGestureData(PointerData& data,  // NOLINT
+                                        PointerData::Change change,
+                                        int64_t device,
+                                        double dx,
+                                        double dy,
+                                        double pan_x,
+                                        double pan_y,
+                                        double scale,
+                                        double rotation) {
+  data.time_stamp = 0;
+  data.change = change;
+  data.kind = PointerData::DeviceKind::kMouse;
+  data.signal_kind = PointerData::SignalKind::kNone;
+  data.device = device;
+  data.pointer_identifier = 0;
+  data.physical_x = dx;
+  data.physical_y = dy;
+  data.physical_delta_x = 0.0;
+  data.physical_delta_y = 0.0;
+  data.buttons = 0;
+  data.obscured = 0;
+  data.synthesized = 0;
+  data.pressure = 0.0;
+  data.pressure_min = 0.0;
+  data.pressure_max = 0.0;
+  data.distance = 0.0;
+  data.distance_max = 0.0;
+  data.size = 0.0;
+  data.radius_major = 0.0;
+  data.radius_minor = 0.0;
+  data.radius_min = 0.0;
+  data.radius_max = 0.0;
+  data.orientation = 0.0;
+  data.tilt = 0.0;
+  data.platformData = 0;
+  data.scroll_delta_x = 0.0;
+  data.scroll_delta_y = 0.0;
+  data.pan_x = pan_x;
+  data.pan_y = pan_y;
+  data.pan_delta_x = 0.0;
+  data.pan_delta_y = 0.0;
+  data.scale = scale;
+  data.rotation = rotation;
+}
+
 void UnpackPointerPacket(std::vector<PointerData>& output,  // NOLINT
                          std::unique_ptr<PointerDataPacket> packet) {
   size_t kBytesPerPointerData = kPointerDataFieldCount * kBytesPerField;
@@ -597,6 +642,57 @@ TEST(PointerDataPacketConverterTest, CanConvetScroll) {
   ASSERT_EQ(result[6].physical_y, 49.0);
   ASSERT_EQ(result[6].scroll_delta_x, 50.0);
   ASSERT_EQ(result[6].scroll_delta_y, 0.0);
+}
+
+TEST(PointerDataPacketConverterTest, CanConvertTrackpadGesture) {
+  PointerDataPacketConverter converter;
+  auto packet = std::make_unique<PointerDataPacket>(3);
+  PointerData data;
+  CreateSimulatedTrackpadGestureData(data, PointerData::Change::kPanZoomStart,
+                                     0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0);
+  packet->SetPointerData(0, data);
+  CreateSimulatedTrackpadGestureData(data, PointerData::Change::kPanZoomUpdate,
+                                     0, 0.0, 0.0, 3.0, 4.0, 1.0, 0.0);
+  packet->SetPointerData(1, data);
+  CreateSimulatedTrackpadGestureData(data, PointerData::Change::kPanZoomEnd, 0,
+                                     0.0, 0.0, 0.0, 0.0, 1.0, 0.0);
+  packet->SetPointerData(2, data);
+  auto converted_packet = converter.Convert(std::move(packet));
+
+  std::vector<PointerData> result;
+  UnpackPointerPacket(result, std::move(converted_packet));
+
+  ASSERT_EQ(result.size(), (size_t)4);
+  ASSERT_EQ(result[0].change, PointerData::Change::kAdd);
+  ASSERT_EQ(result[0].device, 0);
+  ASSERT_EQ(result[0].synthesized, 1);
+
+  ASSERT_EQ(result[1].change, PointerData::Change::kPanZoomStart);
+  ASSERT_EQ(result[1].signal_kind, PointerData::SignalKind::kNone);
+  ASSERT_EQ(result[1].device, 0);
+  ASSERT_EQ(result[1].physical_x, 0.0);
+  ASSERT_EQ(result[1].physical_y, 0.0);
+  ASSERT_EQ(result[1].synthesized, 0);
+
+  ASSERT_EQ(result[2].change, PointerData::Change::kPanZoomUpdate);
+  ASSERT_EQ(result[2].signal_kind, PointerData::SignalKind::kNone);
+  ASSERT_EQ(result[2].device, 0);
+  ASSERT_EQ(result[2].physical_x, 0.0);
+  ASSERT_EQ(result[2].physical_y, 0.0);
+  ASSERT_EQ(result[2].pan_x, 3.0);
+  ASSERT_EQ(result[2].pan_y, 4.0);
+  ASSERT_EQ(result[2].pan_delta_x, 3.0);
+  ASSERT_EQ(result[2].pan_delta_y, 4.0);
+  ASSERT_EQ(result[2].scale, 1.0);
+  ASSERT_EQ(result[2].rotation, 0.0);
+  ASSERT_EQ(result[2].synthesized, 0);
+
+  ASSERT_EQ(result[3].change, PointerData::Change::kPanZoomEnd);
+  ASSERT_EQ(result[3].signal_kind, PointerData::SignalKind::kNone);
+  ASSERT_EQ(result[3].device, 0);
+  ASSERT_EQ(result[3].physical_x, 0.0);
+  ASSERT_EQ(result[3].physical_y, 0.0);
+  ASSERT_EQ(result[3].synthesized, 0);
 }
 
 }  // namespace testing

--- a/lib/web_ui/lib/pointer.dart
+++ b/lib/web_ui/lib/pointer.dart
@@ -12,6 +12,9 @@ enum PointerChange {
   down,
   move,
   up,
+  panZoomStart,
+  panZoomUpdate,
+  panZoomEnd,
 }
 
 enum PointerDeviceKind {
@@ -59,6 +62,12 @@ class PointerData {
     this.platformData = 0,
     this.scrollDeltaX = 0.0,
     this.scrollDeltaY = 0.0,
+    this.panX = 0.0,
+    this.panY = 0.0,
+    this.panDeltaX = 0.0,
+    this.panDeltaY = 0.0,
+    this.scale = 0.0,
+    this.rotation = 0.0,
   });
   final int embedderId;
   final Duration timeStamp;
@@ -89,6 +98,12 @@ class PointerData {
   final int platformData;
   final double scrollDeltaX;
   final double scrollDeltaY;
+  final double panX;
+  final double panY;
+  final double panDeltaX;
+  final double panDeltaY;
+  final double scale;
+  final double rotation;
 
   @override
   String toString() => 'PointerData(x: $physicalX, y: $physicalY)';
@@ -121,7 +136,13 @@ class PointerData {
            'tilt: $tilt, '
            'platformData: $platformData, '
            'scrollDeltaX: $scrollDeltaX, '
-           'scrollDeltaY: $scrollDeltaY'
+           'scrollDeltaY: $scrollDeltaY, '
+           'panX: $panX, '
+           'panY: $panY, '
+           'panDeltaX: $panDeltaX, '
+           'panDeltaY: $panDeltaY, '
+           'scale: $scale, '
+           'rotation: $rotation'
            ')';
   }
 }

--- a/lib/web_ui/lib/src/engine/pointer_converter.dart
+++ b/lib/web_ui/lib/src/engine/pointer_converter.dart
@@ -613,6 +613,12 @@ class PointerDataConverter {
           );
           _pointers.remove(device);
           break;
+        case ui.PointerChange.panZoomStart:
+        case ui.PointerChange.panZoomUpdate:
+        case ui.PointerChange.panZoomEnd:
+          // Pointer pan/zoom events are not generated on web.
+          assert(false);
+          break;
       }
     } else {
       switch (signalKind) {

--- a/shell/platform/android/io/flutter/embedding/android/AndroidTouchProcessor.java
+++ b/shell/platform/android/io/flutter/embedding/android/AndroidTouchProcessor.java
@@ -21,7 +21,10 @@ public class AndroidTouchProcessor {
     PointerChange.HOVER,
     PointerChange.DOWN,
     PointerChange.MOVE,
-    PointerChange.UP
+    PointerChange.UP,
+    PointerChange.PAN_ZOOM_START,
+    PointerChange.PAN_ZOOM_UPDATE,
+    PointerChange.PAN_ZOOM_END
   })
   private @interface PointerChange {
     int CANCEL = 0;
@@ -31,6 +34,9 @@ public class AndroidTouchProcessor {
     int DOWN = 4;
     int MOVE = 5;
     int UP = 6;
+    int PAN_ZOOM_START = 7;
+    int PAN_ZOOM_UPDATE = 8;
+    int PAN_ZOOM_END = 9;
   }
 
   // Must match the PointerDeviceKind enum in pointer.dart.
@@ -58,7 +64,7 @@ public class AndroidTouchProcessor {
   }
 
   // Must match the unpacking code in hooks.dart.
-  private static final int POINTER_DATA_FIELD_COUNT = 29;
+  private static final int POINTER_DATA_FIELD_COUNT = 35;
   private static final int BYTES_PER_FIELD = 8;
 
   // This value must match the value in framework's platform_view.dart.
@@ -308,6 +314,13 @@ public class AndroidTouchProcessor {
       packet.putDouble(0.0); // scroll_delta_x
       packet.putDouble(0.0); // scroll_delta_x
     }
+
+    packet.putDouble(0.0); // pan_x
+    packet.putDouble(0.0); // pan_y
+    packet.putDouble(0.0); // pan_delta_x
+    packet.putDouble(0.0); // pan_delta_y
+    packet.putDouble(1.0); // scale
+    packet.putDouble(0.0); // rotation
   }
 
   @PointerChange

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -948,6 +948,11 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
       case flutter::PointerData::Change::kRemove:
         // We don't use kAdd/kRemove.
         break;
+      case flutter::PointerData::Change::kPanZoomStart:
+      case flutter::PointerData::Change::kPanZoomUpdate:
+      case flutter::PointerData::Change::kPanZoomEnd:
+        // We don't send pan/zoom events here
+        break;
     }
 
     // pressure_min is always 0.0

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -1647,6 +1647,12 @@ inline flutter::PointerData::Change ToPointerDataChange(
       return flutter::PointerData::Change::kRemove;
     case kHover:
       return flutter::PointerData::Change::kHover;
+    case kPanZoomStart:
+      return flutter::PointerData::Change::kPanZoomStart;
+    case kPanZoomUpdate:
+      return flutter::PointerData::Change::kPanZoomUpdate;
+    case kPanZoomEnd:
+      return flutter::PointerData::Change::kPanZoomEnd;
   }
   return flutter::PointerData::Change::kCancel;
 }
@@ -1662,6 +1668,8 @@ inline flutter::PointerData::DeviceKind ToPointerDataKind(
       return flutter::PointerData::DeviceKind::kTouch;
     case kFlutterPointerDeviceKindStylus:
       return flutter::PointerData::DeviceKind::kStylus;
+    case kFlutterPointerDeviceKindTrackpad:
+      return flutter::PointerData::DeviceKind::kTrackpad;
   }
   return flutter::PointerData::DeviceKind::kMouse;
 }
@@ -1694,6 +1702,9 @@ inline int64_t PointerDataButtonsForLegacyEvent(
     case flutter::PointerData::Change::kRemove:
     case flutter::PointerData::Change::kHover:
     case flutter::PointerData::Change::kUp:
+    case flutter::PointerData::Change::kPanZoomStart:
+    case flutter::PointerData::Change::kPanZoomUpdate:
+    case flutter::PointerData::Change::kPanZoomEnd:
       return 0;
   }
   return 0;
@@ -1759,6 +1770,13 @@ FlutterEngineResult FlutterEngineSendPointerEvent(
         pointer_data.buttons = SAFE_ACCESS(current, buttons, 0);
       }
     }
+    pointer_data.pan_x = SAFE_ACCESS(current, pan_x, 0.0);
+    pointer_data.pan_y = SAFE_ACCESS(current, pan_y, 0.0);
+    // Delta will be generated in pointer_data_packet_converter.cc.
+    pointer_data.pan_delta_x = 0.0;
+    pointer_data.pan_delta_y = 0.0;
+    pointer_data.scale = SAFE_ACCESS(current, scale, 0.0);
+    pointer_data.rotation = SAFE_ACCESS(current, rotation, 0.0);
     packet->SetPointerData(i, pointer_data);
     current = reinterpret_cast<const FlutterPointerEvent*>(
         reinterpret_cast<const uint8_t*>(current) + current->struct_size);

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -717,6 +717,12 @@ typedef enum {
   kRemove,
   /// The pointer moved while up.
   kHover,
+  /// A pan/zoom started on this pointer.
+  kPanZoomStart,
+  /// The pan/zoom updated.
+  kPanZoomUpdate,
+  /// The pan/zoom ended.
+  kPanZoomEnd,
 } FlutterPointerPhase;
 
 /// The device type that created a pointer event.
@@ -724,6 +730,7 @@ typedef enum {
   kFlutterPointerDeviceKindMouse = 1,
   kFlutterPointerDeviceKindTouch,
   kFlutterPointerDeviceKindStylus,
+  kFlutterPointerDeviceKindTrackpad,
 } FlutterPointerDeviceKind;
 
 /// Flags for the `buttons` field of `FlutterPointerEvent` when `device_kind`
@@ -772,6 +779,14 @@ typedef struct {
   FlutterPointerDeviceKind device_kind;
   /// The buttons currently pressed, if any.
   int64_t buttons;
+  /// The x offset of the pan/zoom in physical pixels.
+  double pan_x;
+  /// The y offset of the pan/zoom in physical pixels.
+  double pan_y;
+  /// The scale of the pan/zoom, where 1.0 is the initial scale.
+  double scale;
+  /// The rotation of the pan/zoom in radians, where 0.0 is the initial angle.
+  double rotation;
 } FlutterPointerEvent;
 
 typedef enum {

--- a/shell/platform/fuchsia/flutter/platform_view.cc
+++ b/shell/platform/fuchsia/flutter/platform_view.cc
@@ -378,6 +378,11 @@ bool PlatformView::OnHandlePointerEvent(
         FML_DLOG(ERROR) << "Received hover event for down pointer.";
       }
       break;
+    case flutter::PointerData::Change::kPanZoomStart:
+    case flutter::PointerData::Change::kPanZoomUpdate:
+    case flutter::PointerData::Change::kPanZoomEnd:
+      FML_DLOG(ERROR) << "Unexpectedly received pointer pan/zoom event";
+      break;
   }
 
   auto packet = std::make_unique<flutter::PointerDataPacket>(1);


### PR DESCRIPTION
Original PR was https://github.com/flutter/engine/pull/28571
Reverted in https://github.com/flutter/engine/pull/31375
Should be acceptable now thanks to https://github.com/flutter/flutter/pull/98202

This commit adds support to the engine core for encoding trackpad gestures for to the framework. This covers zoom, rotate, and pan gestures. The changes to send trackpad gestures from each platform will come in follow-up PRs. 

1. New types of `PointerChange`: `panZoomStart`, `panZoomUpdate`, `panZoomEnd`
2. New fields on `PointerData` to handle two-finger trackpad gesture fields (`panX`, `panY`, `scale`, `rotation`)

[Design Document](https://flutter.dev/go/trackpad-gestures)

Framework PR: https://github.com/flutter/flutter/pull/89944

Addresses https://github.com/flutter/flutter/issues/23604

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
