### PR TITLE
Add support for getting the current thread name and id

### DIFF
--- a/fml/platform/android/jni_util.cc
+++ b/fml/platform/android/jni_util.cc
@@ -10,6 +10,7 @@
 
 #include "flutter/fml/logging.h"
 #include "flutter/fml/string_conversion.h"
+#include "flutter/fml/thread.h"
 #include "flutter/fml/thread_local.h"
 
 namespace fml {
@@ -44,14 +45,8 @@ JNIEnv* AttachCurrentThread() {
   JavaVMAttachArgs args;
   args.version = JNI_VERSION_1_4;
   args.group = nullptr;
-  // 16 is the maximum size for thread names on Android.
-  char thread_name[16];
-  int err = prctl(PR_GET_NAME, thread_name);
-  if (err < 0) {
-    args.name = nullptr;
-  } else {
-    args.name = thread_name;
-  }
+  args.name = fml::Thread::GetCurrentName().c_str();
+
   [[maybe_unused]] jint ret = g_jvm->AttachCurrentThread(&env, &args);
   FML_DCHECK(JNI_OK == ret);
 

--- a/fml/thread.cc
+++ b/fml/thread.cc
@@ -73,8 +73,12 @@ void Thread::SetCurrentThreadName(const Thread::ThreadConfig& config) {
   SetThreadName(config.name);
 }
 
-std::string Thread::GetName() {
+std::string Thread::GetCurrentName() {
   return *(tls_thread_name.get());
+}
+
+ThreadId Thread::GetCurrentId() {
+  return std::this_thread::get_id();
 }
 
 Thread::Thread(const std::string& name)

--- a/fml/thread.h
+++ b/fml/thread.h
@@ -16,7 +16,8 @@
 
 namespace fml {
 
-typedef std::thread::id ThreadId;
+typedef uint64_t PlatformThreadId;
+const PlatformThreadId kInvalidThreadId(0);
 
 class Thread {
  public:
@@ -61,11 +62,12 @@ class Thread {
 
   static void SetCurrentThreadName(const ThreadConfig& config);
 
-  /// Gets the current thread name, which previously set.
+  /// Gets the thread name of the calling thread, which was previously set.
   static std::string GetCurrentName();
 
-  /// Gets the current thread id, which may be useful for logging purposes.
-  static ThreadId GetCurrentId();
+  /// Gets the system-wide thread id of the calling thread, which may be useful
+  /// for logging purposes.
+  static PlatformThreadId GetCurrentId();
 
  private:
   std::unique_ptr<std::thread> thread_;

--- a/fml/thread.h
+++ b/fml/thread.h
@@ -16,6 +16,8 @@
 
 namespace fml {
 
+typedef std::thread::id ThreadId;
+
 class Thread {
  public:
   /// Valid values for priority of Thread.
@@ -59,8 +61,11 @@ class Thread {
 
   static void SetCurrentThreadName(const ThreadConfig& config);
 
-  // Gets the current thread name, which may be useful for logging purposes.
-  static std::string GetName();
+  /// Gets the current thread name, which previously set.
+  static std::string GetCurrentName();
+
+  /// Gets the current thread id, which may be useful for logging purposes.
+  static ThreadId GetCurrentId();
 
  private:
   std::unique_ptr<std::thread> thread_;

--- a/fml/thread.h
+++ b/fml/thread.h
@@ -59,6 +59,9 @@ class Thread {
 
   static void SetCurrentThreadName(const ThreadConfig& config);
 
+  // Gets the current thread name, which may be useful for logging purposes.
+  static std::string GetName();
+
  private:
   std::unique_ptr<std::thread> thread_;
 

--- a/fml/thread_unittests.cc
+++ b/fml/thread_unittests.cc
@@ -37,15 +37,15 @@ TEST(Thread, HasARunningMessageLoop) {
   ASSERT_TRUE(done);
 }
 
-TEST(Thread, GetName) {
+TEST(Thread, GetCurrentName) {
   const std::string name = "Thread1";
   fml::Thread thread(name);
 
   thread.GetTaskRunner()->PostTask([&name]() {
-    ASSERT_EQ(fml::Thread::GetName(), name);
+    ASSERT_EQ(fml::Thread::GetCurrentName(), name);
     const std::string new_name = "Thread2";
     fml::Thread::SetCurrentThreadName(fml::Thread::ThreadConfig(new_name));
-    ASSERT_EQ(fml::Thread::GetName(), new_name);
+    ASSERT_EQ(fml::Thread::GetCurrentName(), new_name);
   });
   thread.Join();
 }
@@ -62,7 +62,7 @@ TEST(Thread, ThreadNameCreatedWithConfig) {
     pthread_t current_thread = pthread_self();
     pthread_getname_np(current_thread, thread_name, 8);
     ASSERT_EQ(thread_name, name);
-    ASSERT_EQ(fml::Thread::GetName(), thread_name);
+    ASSERT_EQ(fml::Thread::GetCurrentName(), thread_name);
   });
   thread.Join();
   ASSERT_TRUE(done);
@@ -103,6 +103,7 @@ TEST(Thread, ThreadPriorityCreatedWithConfig) {
     pthread_getname_np(current_thread, thread_name, 8);
     pthread_getschedparam(current_thread, &policy, &param);
     ASSERT_EQ(thread_name, thread1_name);
+    ASSERT_EQ(fml::Thread::GetCurrentName(), thread_name);
     ASSERT_EQ(policy, SCHED_OTHER);
     ASSERT_EQ(param.sched_priority, 1);
   });
@@ -117,6 +118,7 @@ TEST(Thread, ThreadPriorityCreatedWithConfig) {
     pthread_getname_np(current_thread, thread_name, 8);
     pthread_getschedparam(current_thread, &policy, &param);
     ASSERT_EQ(thread_name, thread2_name);
+    ASSERT_EQ(fml::Thread::GetCurrentName(), thread_name);
     ASSERT_EQ(policy, SCHED_OTHER);
     ASSERT_EQ(param.sched_priority, 10);
   });

--- a/fml/thread_unittests.cc
+++ b/fml/thread_unittests.cc
@@ -37,6 +37,19 @@ TEST(Thread, HasARunningMessageLoop) {
   ASSERT_TRUE(done);
 }
 
+TEST(Thread, GetName) {
+  const std::string name = "Thread1";
+  fml::Thread thread(name);
+
+  thread.GetTaskRunner()->PostTask([&name]() {
+    ASSERT_EQ(fml::Thread::GetName(), name);
+    const std::string new_name = "Thread2";
+    fml::Thread::SetCurrentThreadName(fml::Thread::ThreadConfig(new_name));
+    ASSERT_EQ(fml::Thread::GetName(), new_name);
+  });
+  thread.Join();
+}
+
 #if FLUTTER_PTHREAD_SUPPORTED
 TEST(Thread, ThreadNameCreatedWithConfig) {
   const std::string name = "Thread1";
@@ -49,6 +62,7 @@ TEST(Thread, ThreadNameCreatedWithConfig) {
     pthread_t current_thread = pthread_self();
     pthread_getname_np(current_thread, thread_name, 8);
     ASSERT_EQ(thread_name, name);
+    ASSERT_EQ(fml::Thread::GetName(), thread_name);
   });
   thread.Join();
   ASSERT_TRUE(done);

--- a/fml/thread_unittests.cc
+++ b/fml/thread_unittests.cc
@@ -50,6 +50,18 @@ TEST(Thread, GetCurrentName) {
   thread.Join();
 }
 
+TEST(Thread, GetCurrentId) {
+  fml::Thread thread;
+  thread.GetTaskRunner()->PostTask([]() {
+    fml::PlatformThreadId thread_id = fml::Thread::GetCurrentId();
+    ASSERT_NE(thread_id, fml::kInvalidThreadId);
+
+    // Make sure that the thread ID is the same across calls.
+    ASSERT_EQ(thread_id, fml::Thread::GetCurrentId());
+  });
+  thread.Join();
+}
+
 #if FLUTTER_PTHREAD_SUPPORTED
 TEST(Thread, ThreadNameCreatedWithConfig) {
   const std::string name = "Thread1";

--- a/shell/platform/fuchsia/flutter/tests/engine_unittests.cc
+++ b/shell/platform/fuchsia/flutter/tests/engine_unittests.cc
@@ -17,6 +17,7 @@
 #include "third_party/skia/include/core/SkPictureRecorder.h"
 #include "third_party/skia/include/core/SkSerialProcs.h"
 
+#include "flutter/fml/thread.h"
 #include "flutter/shell/platform/fuchsia/flutter/logging.h"
 #include "flutter/shell/platform/fuchsia/flutter/runner.h"
 #include "flutter/shell/platform/fuchsia/flutter/vulkan_surface_producer.h"
@@ -99,33 +100,21 @@ TEST_F(EngineTest, ThreadNames) {
   std::string prefix = GetCurrentTestName();
   flutter::ThreadHost engine_thread_host = Engine::CreateThreadHost(prefix);
 
-  char thread_name[ZX_MAX_NAME_LEN];
-  zx::thread::self()->get_property(ZX_PROP_NAME, thread_name,
-                                   sizeof(thread_name));
-  EXPECT_EQ(std::string(thread_name), prefix + std::string(".platform"));
+  EXPECT_EQ(fml::Thread::GetCurrentName(), prefix + std::string(".platform"));
   EXPECT_EQ(engine_thread_host.platform_thread, nullptr);
 
   engine_thread_host.raster_thread->GetTaskRunner()->PostTask([&prefix]() {
-    char thread_name[ZX_MAX_NAME_LEN];
-    zx::thread::self()->get_property(ZX_PROP_NAME, thread_name,
-                                     sizeof(thread_name));
-    EXPECT_EQ(std::string(thread_name), prefix + std::string(".raster"));
+    EXPECT_EQ(fml::Thread::GetCurrentName(), prefix + std::string(".raster"));
   });
   engine_thread_host.raster_thread->Join();
 
   engine_thread_host.ui_thread->GetTaskRunner()->PostTask([&prefix]() {
-    char thread_name[ZX_MAX_NAME_LEN];
-    zx::thread::self()->get_property(ZX_PROP_NAME, thread_name,
-                                     sizeof(thread_name));
-    EXPECT_EQ(std::string(thread_name), prefix + std::string(".ui"));
+    EXPECT_EQ(fml::Thread::GetCurrentName(), prefix + std::string(".ui"));
   });
   engine_thread_host.ui_thread->Join();
 
   engine_thread_host.io_thread->GetTaskRunner()->PostTask([&prefix]() {
-    char thread_name[ZX_MAX_NAME_LEN];
-    zx::thread::self()->get_property(ZX_PROP_NAME, thread_name,
-                                     sizeof(thread_name));
-    EXPECT_EQ(std::string(thread_name), prefix + std::string(".io"));
+    EXPECT_EQ(fml::Thread::GetCurrentName(), prefix + std::string(".io"));
   });
   engine_thread_host.io_thread->Join();
 }


### PR DESCRIPTION
Add support for getting the current thread name and the system-wide id.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
