### PR TITLE
Add PointerDeviceKind.trackpad to Android and Web

### DIFF
--- a/lib/web_ui/lib/pointer.dart
+++ b/lib/web_ui/lib/pointer.dart
@@ -22,6 +22,7 @@ enum PointerDeviceKind {
   mouse,
   stylus,
   invertedStylus,
+  trackpad,
   unknown
 }
 

--- a/shell/platform/android/io/flutter/embedding/android/AndroidTouchProcessor.java
+++ b/shell/platform/android/io/flutter/embedding/android/AndroidTouchProcessor.java
@@ -45,6 +45,7 @@ public class AndroidTouchProcessor {
     PointerDeviceKind.MOUSE,
     PointerDeviceKind.STYLUS,
     PointerDeviceKind.INVERTED_STYLUS,
+    PointerDeviceKind.TRACKPAD,
     PointerDeviceKind.UNKNOWN
   })
   private @interface PointerDeviceKind {
@@ -52,7 +53,8 @@ public class AndroidTouchProcessor {
     int MOUSE = 1;
     int STYLUS = 2;
     int INVERTED_STYLUS = 3;
-    int UNKNOWN = 4;
+    int TRACKPAD = 4;
+    int UNKNOWN = 5;
   }
 
   // Must match the PointerSignalKind enum in pointer.dart.


### PR DESCRIPTION
A new PointerDeviceKind for trackpad gestures was added in https://github.com/flutter/engine/pull/31402, but it wasn't also added to the android and web implementations. 

Original issue: https://github.com/flutter/flutter/issues/23604

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
