### PR TITLE
Refactor SPIR-V transpiler.

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -579,6 +579,8 @@ FILE: ../../../flutter/lib/snapshot/libraries.json
 FILE: ../../../flutter/lib/snapshot/snapshot.h
 FILE: ../../../flutter/lib/spirv/lib/spirv.dart
 FILE: ../../../flutter/lib/spirv/lib/src/constants.dart
+FILE: ../../../flutter/lib/spirv/lib/src/function.dart
+FILE: ../../../flutter/lib/spirv/lib/src/instructions.dart
 FILE: ../../../flutter/lib/spirv/lib/src/transpiler.dart
 FILE: ../../../flutter/lib/spirv/lib/src/types.dart
 FILE: ../../../flutter/lib/ui/annotations.dart

--- a/lib/spirv/lib/spirv.dart
+++ b/lib/spirv/lib/spirv.dart
@@ -12,6 +12,8 @@ import 'dart:typed_data';
 // These parts only contain private members, all public
 // members are in this file (spirv.dart)
 part 'src/constants.dart';
+part 'src/function.dart';
+part 'src/instructions.dart';
 part 'src/transpiler.dart';
 part 'src/types.dart';
 

--- a/lib/spirv/lib/src/function.dart
+++ b/lib/spirv/lib/src/function.dart
@@ -21,6 +21,23 @@ class _Function {
   final Map<int, _Block> blocks = <int, _Block>{};
   final List<int> deps = <int>[];
 
+  _Block addBlock(int id) {
+    final _Block b = _Block();
+    blocks[id] = b;
+    entry ??= b;
+    return b;
+  }
+
+  void declareParam(int id, int paramType) {
+    final int i = declaredParams;
+    if (paramType != type.params[i]) {
+      throw TranspileException._(_opFunctionParameter,
+          'type mismatch for param $i of function $name');
+    }
+    params[i] = id;
+    declaredParams++;
+  }
+
   void write(_Transpiler t, StringBuffer out) {
     if (declaredParams != params.length) {
       throw t.failure('not all parameters declared for function $name');

--- a/lib/spirv/lib/src/function.dart
+++ b/lib/spirv/lib/src/function.dart
@@ -1,0 +1,74 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+part of spirv;
+
+class _Function {
+  final int name;
+  final _FunctionType type;
+  final List<int> params;
+
+  _Function(this.type, this.name) :
+    params = List<int>.filled(type.params.length, 0);
+
+  // entry point for the function
+  _Block? entry;
+
+  // The number of parameters declared so far.
+  int declaredParams = 0;
+
+  final Map<int, _Block> blocks = <int, _Block>{};
+  final List<int> deps = <int>[];
+
+  void write(_Transpiler t, StringBuffer out) {
+    if (declaredParams != params.length) {
+      throw t.failure('not all parameters declared for function $name');
+    }
+    if (entry == null) {
+      throw t.failure('function $name has no entry block');
+    }
+    String returnTypeString = t.resolveType(type.returnType);
+    if (t.target == TargetLanguage.sksl && name == t.entryPoint) {
+      returnTypeString = 'half4';
+    }
+    final String nameString = t.resolveName(name);
+    out.write('$returnTypeString $nameString(');
+
+    if (t.target == TargetLanguage.sksl && name == t.entryPoint) {
+      const String fragParam = 'float2 $_fragParamName';
+      out.write(fragParam);
+    }
+
+    for (int i = 0; i < params.length; i++) {
+      final String typeString = t.resolveType(type.params[i]);
+      final String nameString = t.resolveName(params[i]);
+      out.write('$typeString $nameString');
+      if (i < params.length - 1) {
+        out.write(', ');
+      }
+    }
+
+    out.writeln(') {');
+
+    // SkSL needs to return a value from main, so we maintain a variable
+    // that receives the value of gl_FragColor and returns it at the end.
+    if (t.target == TargetLanguage.sksl && name == t.entryPoint) {
+      if (t.fragCoord > 0) {
+        final String fragName = t.resolveName(t.fragCoord);
+        out.writeln('  float4 $fragName = float4($_fragParamName, 0, 0);');
+      }
+      out.writeln('  float4 $_colorVariableName;');
+    }
+
+    // write the actual function body
+    entry?.write(t, out, 1);
+
+    if (t.target == TargetLanguage.sksl && name == t.entryPoint) {
+      out.writeln('  return $_colorVariableName;');
+    }
+    out.writeln('}');
+    out.writeln();
+  }
+}
+

--- a/lib/spirv/lib/src/instructions.dart
+++ b/lib/spirv/lib/src/instructions.dart
@@ -1,0 +1,333 @@
+part of spirv;
+
+class _Block {
+  List<_Instruction> instructions = <_Instruction>[];
+
+  void add(_Instruction i) {
+    instructions.add(i);
+  }
+
+  void writeIndent(StringBuffer out, int indent) {
+    for (int i = 0; i < indent; i++) {
+      out.write('  ');
+    }
+  }
+
+  void write(_Transpiler t, StringBuffer out, int indent) {
+    for (final _Instruction inst in instructions) {
+      if (!inst.isResult) {
+        writeIndent(out, indent);
+        inst.write(t, out);
+        out.writeln(';');
+      } else if (inst.refCount > 1) {
+        writeIndent(out, indent);
+        final String typeString = t.resolveType(inst.type);
+        final String nameString = t.resolveName(inst.id);
+        out.write('$typeString $nameString = ');
+        inst.write(t, out);
+        out.writeln(';');
+      }
+    }
+  }
+}
+
+abstract class _Instruction {
+  int get type => 0;
+
+  int get id => 0;
+
+  bool get isResult => id != 0;
+
+  // How many times this instruction is referenced, a value
+  // of 2 or greater means that it will be stored into a variable.
+  int refCount = 0;
+
+  void write(_Transpiler t, StringBuffer out);
+}
+
+class _FunctionCall extends _Instruction {
+  @override
+  final int type;
+
+  @override
+  final int id;
+
+  final String function;
+  final List<int> args;
+
+  _FunctionCall(this.type, this.id, this.function, this.args);
+
+  @override
+  void write(_Transpiler t, StringBuffer out) {
+    out.write('$function(');
+    for (int i = 0; i < args.length; i++) {
+      out.write(t.resolveResult(args[i]));
+      if (i < args.length - 1) {
+        out.write(', ');
+      }
+    }
+    out.write(')');
+  }
+}
+
+class _StringInstruction extends _Instruction {
+  final String value;
+
+  _StringInstruction(this.value);
+
+  @override
+  void write(_Transpiler t, StringBuffer out) {
+    out.write(value);
+  }
+}
+
+class _Select extends _Instruction {
+  @override
+  final int type;
+
+  @override
+  final int id;
+
+  final int condition;
+  final int a;
+  final int b;
+
+  _Select(this.type, this.id, this.condition, this.a, this.b);
+
+  @override
+  void write(_Transpiler t, StringBuffer out) {
+    final String typeName = t.resolveType(type);
+    final String aName = t.resolveResult(a);
+    final String bName = t.resolveResult(b);
+    final String conditionName = t.resolveResult(condition);
+    out.write('mix($bName, $aName, $typeName($conditionName))');
+  }
+}
+
+class _Store extends _Instruction {
+  final int pointer;
+  final int object;
+  _Store(this.pointer, this.object);
+
+  @override
+  void write(_Transpiler t, StringBuffer out) {
+    final String pointerName = t.resolveResult(pointer);
+    final String objectName = t.resolveResult(object);
+    out.write('$pointerName = $objectName');
+  }
+}
+
+class _AccessChain extends _Instruction {
+  @override
+  final int type;
+
+  @override
+  final int id;
+
+  final int base;
+  final List<int> indices;
+
+  _AccessChain(this.type, this.id, this.base, this.indices);
+
+  @override
+  void write(_Transpiler t, StringBuffer out) {
+    out.write(t.resolveResult(base));
+    for (int i = 0; i < indices.length; i++) {
+      final String indexString = t.resolveResult(indices[i]);
+      out.write('[$indexString]');
+    }
+  }
+}
+
+class _VectorShuffle extends _Instruction {
+  @override
+  final int type;
+
+  @override
+  final int id;
+
+  final int vector;
+  final List<int> indices;
+
+  _VectorShuffle(this.type, this.id, this.vector, this.indices);
+
+  @override
+  void write(_Transpiler t, StringBuffer out) {
+    final String typeString = t.resolveType(type);
+    final String vectorString = t.resolveName(vector);
+    out.write('$typeString(');
+    for (int i = 0; i < indices.length; i++) {
+      final int index = indices[i];
+      out.write('$vectorString[$index]');
+      if (i < indices.length - 1) {
+        out.write(', ');
+      }
+    }
+    out.write(')');
+  }
+}
+
+class _CompositeConstruct extends _Instruction {
+  @override
+  final int type;
+
+  @override
+  final int id;
+
+  final List<int> components;
+
+  _CompositeConstruct(this.type, this.id, this.components);
+
+  @override
+  void write(_Transpiler t, StringBuffer out) {
+    final String typeString = t.resolveType(type);
+    out.write('$typeString(');
+    for (int i = 0; i < components.length; i++) {
+      out.write(t.resolveResult(components[i]));
+      if (i < components.length - 1) {
+        out.write(', ');
+      }
+    }
+    out.write(')');
+  }
+}
+
+class _CompositeExtract extends _Instruction {
+  @override
+  final int type;
+
+  @override
+  final int id;
+
+  final int src;
+  final List<int> indices;
+
+  _CompositeExtract(this.type, this.id, this.src, this.indices);
+
+  @override
+  void write(_Transpiler t, StringBuffer out) {
+    out.write(t.resolveResult(src));
+    for (int i = 0; i < indices.length; i++) {
+      out.write('[${indices[i]}]');
+    }
+  }
+}
+
+class _ImageSampleImplicitLod extends _Instruction {
+  @override
+  final int type;
+
+  @override
+  final int id;
+
+  final int sampledImage;
+  final int coordinate;
+
+  _ImageSampleImplicitLod(this.type, this.id, this.sampledImage, this.coordinate);
+
+  @override
+  void write(_Transpiler t, StringBuffer out) {
+    final String sampledImageString = t.resolveName(sampledImage);
+    final String coordinateString = t.resolveResult(coordinate);
+    if (t.target == TargetLanguage.sksl) {
+      out.write('$sampledImageString.eval(${sampledImageString}_size * $coordinateString)');
+    } else {
+      out.write('texture($sampledImageString, $coordinateString)');
+    }
+  }
+}
+
+class _Negate extends _Instruction {
+  @override
+  final int type;
+
+  @override
+  final int id;
+
+  final int operand;
+
+  _Negate(this.type, this.id, this.operand);
+
+  @override
+  void write(_Transpiler t, StringBuffer out) {
+    final String operandString = t.resolveResult(operand);
+    out.write('-$operandString');
+  }
+}
+
+class _ReturnValue extends _Instruction {
+  final int value;
+
+  _ReturnValue(this.value);
+
+  @override
+  void write(_Transpiler t, StringBuffer out) {
+    final String valueString = t.resolveResult(value);
+    out.write('return $valueString');
+  }
+}
+
+class _Operator extends _Instruction {
+  @override
+  final int type;
+
+  @override
+  final int id;
+
+  final String op;
+  final int a;
+  final int b;
+
+  _Operator(this.type, this.id, this.op, this.a, this.b);
+
+  @override
+  void write(_Transpiler t, StringBuffer out) {
+    final String aStr = t.resolveResult(a);
+    final String bStr = t.resolveResult(b);
+    out.write('$aStr $op $bStr');
+  }
+}
+
+class _BuiltinFunction extends _Instruction {
+  @override
+  final int type;
+
+  @override
+  final int id;
+
+  final String function;
+  final List<int> args;
+
+  _BuiltinFunction(this.type, this.id, this.function, this.args);
+
+  @override
+  void write(_Transpiler t, StringBuffer out) {
+    out.write('$function(');
+    for (int i = 0; i < args.length; i++) {
+      out.write(t.resolveResult(args[i]));
+      if (i < args.length - 1) {
+        out.write(', ');
+      }
+    }
+    out.write(')');
+  }
+}
+
+class _TypeCast extends _Instruction {
+  @override
+  final int type;
+
+  @override
+  final int id;
+
+  final int value;
+
+  _TypeCast(this.type, this.id, this.value);
+
+  @override
+  void write(_Transpiler t, StringBuffer out) {
+    final String typeString = t.resolveType(type);
+    final String valueString = t.resolveResult(value);
+    out.write('$typeString($valueString)');
+  }
+}

--- a/lib/spirv/lib/src/transpiler.dart
+++ b/lib/spirv/lib/src/transpiler.dart
@@ -50,21 +50,13 @@ const String _mainFunctionName = 'main';
 /// [opConstant] append `#OpConstant`, like the following:
 /// https://www.khronos.org/registry/spir-v/specs/unified1/SPIRV.html#OpConstant
 class _Transpiler {
-  _Transpiler(this.spirv, this.target) {
-    out = header;
-  }
+  _Transpiler(this.spirv, this.target);
 
   final Uint32List spirv;
   final TargetLanguage target;
 
   /// The resulting source code of the target language is written to src.
   final StringBuffer src = StringBuffer();
-
-  /// Contains shader header, constants, and uniforms.
-  final StringBuffer header = StringBuffer();
-
-  /// The main body of code, contains function definitions.
-  final StringBuffer body = StringBuffer();
 
   /// Uniform declarations.
   final Map<int, String> uniformDeclarations = <int, String>{};
@@ -83,12 +75,8 @@ class _Transpiler {
   /// ID mapped to function types.
   final Map<int, _FunctionType> functionTypes = <int, _FunctionType>{};
 
-  /// Function ID mapped to source-code definition.
-  final Map<int, StringBuffer> functionDefs = <int, StringBuffer>{};
-
-  /// Function ID mapped to referenced functions.
-  /// This is used to ensure they are written in the right order.
-  final Map<int, List<int>> functionDeps = <int, List<int>>{};
+  /// ID mapped to function definition.
+  final Map<int, _Function> functions = <int, _Function>{};
 
   /// ID mapped to location decorator.
   /// See [opDecorate] for more information.
@@ -99,6 +87,9 @@ class _Transpiler {
 
   /// ID mapped to a string to use instead of a generated name.
   final Map<int, String> nameOverloads = <int, String>{};
+
+  /// ID mapped to expression result
+  final Map<int, _Instruction> results = <int, _Instruction>{};
 
   /// The ID for a constant true value.
   /// See [opConstantTrue].
@@ -141,15 +132,16 @@ class _Transpiler {
   /// See [opTypeSampledImage].
   int sampledImageType = 0;
 
-  /// The ID of the function that is currently being defined.
+  /// The function that is currently being defined.
   /// Set by [opFunction] and unset by [opFunctionEnd].
-  int currentFunction = 0;
-
-  /// The type of [currentFunction], or null.
-  _FunctionType? currentFunctionType;
+  _Function? currentFunction;
 
   /// Count of parameters declared so far for the [currentFunction].
   int declaredParams = 0;
+
+  /// The block currently being defined. Set by [opLabel] and unset by
+  /// [opFunctionEnd].
+  _Block? currentBlock;
 
   /// The ID for the color output variable.
   /// Set by [opVariable].
@@ -165,13 +157,6 @@ class _Transpiler {
   /// The number of samplers used by uniforms.
   int samplerCount = 0;
 
-  /// Current indentation to prepend to new lines.
-  String indent = '';
-
-  /// Points to the source of the [currentFunction], or to [src] as a fallback.
-  /// The source of [currentFunction] is stored in [functionDefs].
-  late StringBuffer out;
-
   /// Scan through all the words and populate [out] with source code,
   /// or throw an exception. Calls to [parseInstruction] will affect
   /// the state of the transpiler, including [position] and [out].
@@ -179,8 +164,6 @@ class _Transpiler {
     parseHeader();
     writeHeader();
 
-    // Parse instructions and write to body.
-    out = body;
     while (position < spirv.length) {
       final int lastPosition = position;
       parseInstruction();
@@ -188,33 +171,31 @@ class _Transpiler {
       assert(position > lastPosition);
     }
 
-    // TODO(antrob): Investigate if `List<bool>.filled(maxFunctionId, false)` can be used here instead.
-    final Set<int> visited = <int>{};
-    writeFunctionAndDeps(visited, entryPoint);
-
     // Add uniform declarations to header.
     if (uniformDeclarations.isNotEmpty) {
-      header.writeln();
+      src.writeln();
       final List<int> locations = uniformDeclarations.keys.toList();
       locations.sort((int a, int b) => a - b);
       for (final int location in locations) {
-        header.writeln(uniformDeclarations[location]);
+        src.writeln(uniformDeclarations[location]);
       }
     }
 
     // Add SkSL sampler size declarations to header.
     if (samplerSizeDeclarations.isNotEmpty) {
-      header.writeln();
+      src.writeln();
       final List<int> locations = samplerSizeDeclarations.keys.toList();
       locations.sort((int a, int b) => a - b);
       for (final int location in locations) {
-        header.writeln(samplerSizeDeclarations[location]);
+        src.writeln(samplerSizeDeclarations[location]);
       }
     }
 
-    src.write(header);
     src.writeln();
-    src.write(body);
+
+    // TODO(antrob): Investigate if `List<bool>.filled(maxFunctionId, false)` can be used here instead.
+    final Set<int> visited = <int>{};
+    writeFunctionAndDeps(visited, entryPoint);
   }
 
   TranspileException failure(String why) =>
@@ -225,22 +206,23 @@ class _Transpiler {
       return;
     }
     visited.add(function);
-    for (final int dep in functionDeps[function]!) {
+    final _Function f = functions[function]!;
+    for (final int dep in f.deps) {
       writeFunctionAndDeps(visited, dep);
     }
-    out.write(functionDefs[function]!.toString());
+    f.write(this, src);
   }
 
   void writeHeader() {
     switch (target) {
       case TargetLanguage.glslES:
-        out.writeln('#version 100\n');
-        out.writeln('precision mediump float;\n');
+        src.writeln('#version 100\n');
+        src.writeln('precision mediump float;\n');
         break;
       case TargetLanguage.glslES300:
-        out.writeln('#version 300 es\n');
-        out.writeln('precision mediump float;\n');
-        out.writeln('layout ( location = 0 ) out vec4 $_colorVariableName;\n');
+        src.writeln('#version 300 es\n');
+        src.writeln('precision mediump float;\n');
+        src.writeln('layout ( location = 0 ) out vec4 $_colorVariableName;\n');
         break;
       default:
         break;
@@ -279,6 +261,21 @@ class _Transpiler {
     return _typeName(t, target);
   }
 
+  String resolveResult(int name) {
+    if (alias.containsKey(name)) {
+      return resolveResult(alias[name]!);
+    }
+    final _Instruction? res = results[name];
+    if (res != null && res.refCount <= 1) {
+      final StringBuffer buf = StringBuffer();
+      buf.write('(');
+      res.write(this, buf);
+      buf.write(')');
+      return buf.toString();
+    }
+    return resolveName(name);
+  }
+
   int readWord() {
     if (nextPosition != 0 && position > nextPosition) {
       throw failure('Read past the current instruction.');
@@ -312,13 +309,23 @@ class _Transpiler {
     throw failure('No null-terminating character found for string literal');
   }
 
-  void typeCast() {
-    final String type = resolveType(readWord());
-    final String name = resolveName(readWord());
-    final String value = resolveName(readWord());
-    out.writeln('$indent$type $name = $type($value);');
+  /// Increase the refcount of a result with name `id`.
+  void ref(int id) {
+    final int? a = alias[id];
+    if (a != null) {
+      ref(a);
+      return;
+    }
+    results[id]?.refCount++;
   }
 
+  /// Add the instruction to the current block
+  void add(_Instruction inst) {
+    if (inst.isResult) {
+      results[inst.id] = inst;
+    }
+    currentBlock!.add(inst);
+  }
 
   /// Read an instruction word, and handle the operation.
   ///
@@ -491,6 +498,14 @@ class _Transpiler {
         throw failure('Not a supported op.');
     }
     position = nextPosition;
+  }
+
+  void typeCast() {
+    final int type = readWord();
+    final int name = readWord();
+    final int value = readWord();
+    ref(value);
+    add(_TypeCast(type, name, value));
   }
 
   void opExtInstImport() {
@@ -720,112 +735,78 @@ class _Transpiler {
       valueString = '$v';
     }
     final String typeName = resolveType(type);
-    header.writeln('const $typeName $id = $valueString;');
+    src.writeln('const $typeName $id = $valueString;');
   }
 
   void opConstantComposite() {
     final String type = resolveType(readWord());
     final String id = resolveName(readWord());
-    header.write('const $type $id = $type(');
+    src.write('const $type $id = $type(');
     final int count = nextPosition - position;
     for (int i = 0; i < count; i++) {
-      header.write(resolveName(readWord()));
+      src.write(resolveName(readWord()));
       if (i < count - 1) {
-        header.write(', ');
+        src.write(', ');
       }
     }
-    header.writeln(');');
+    src.writeln(');');
   }
 
   void opFunction() {
-    String returnType = resolveType(readWord());
+    final int returnType = readWord();
     final int id = readWord();
-
-    if (target == TargetLanguage.sksl && id == entryPoint) {
-      returnType = 'half4';
-    }
 
     // ignore function control
     position++;
-
-    final String name = resolveName(id);
-    final String opening = '$returnType $name(';
-    final StringBuffer def = StringBuffer();
-    def.write(opening);
-
-    if (target == TargetLanguage.sksl && id == entryPoint) {
-      const String fragParam = 'float2 $_fragParamName';
-      def.write(fragParam);
-    }
 
     final int typeIndex = readWord();
     final _FunctionType? functionType = functionTypes[typeIndex];
     if (functionType == null) {
       throw failure('$typeIndex is not a registered function type');
     }
-
-    if (functionType.params.isEmpty) {
-      def.write(') ');
+    if (returnType != functionType.returnType) {
+      throw failure('function $id has return type mismatch');
     }
 
-    currentFunction = id;
-    currentFunctionType = functionType;
-    declaredParams = 0;
-    out = def;
-    functionDefs[id] = def;
-    functionDeps[id] = <int>[];
+    final _Function f = _Function(functionType, id);
+    functions[id] = f;
+    currentFunction = f;
   }
 
   void opFunctionParameter() {
-    if (declaredParams > 0) {
-      out.write(', ');
-    }
-
     final int type = readWord();
     final int id = readWord();
-    final String decl = resolveType(type) + ' ' + resolveName(id);
-    out.write(decl);
-    declaredParams++;
+    final _Function f = currentFunction!;
 
-    if (declaredParams == currentFunctionType?.params.length) {
-      out.write(') ');
+    final int i = f.declaredParams;
+    if (type != f.type.params[i]) {
+      throw failure('type mismatch for param $i of function ${f.name}');
     }
+    f.params[i] = id;
+    f.declaredParams++;
   }
 
   void opFunctionEnd() {
-    if (target == TargetLanguage.sksl && currentFunction == entryPoint) {
-      out.writeln('${indent}return $_colorVariableName;');
-    }
-    out.writeln('}');
-    out.writeln();
-    // Remove trailing two space characters, if present.
-    indent = indent.substring(0, max(0, indent.length - 2));
-    currentFunction = 0;
-    out = body;
-    currentFunctionType = null;
+    currentFunction = null;
+    currentBlock = null;
   }
 
   void opFunctionCall() {
-    final String type = resolveType(readWord());
-    final String name = resolveName(readWord());
+    final int type = readWord();
+    final int name = readWord();
     final int functionId = readWord();
     final String functionName = resolveName(functionId);
 
     // Make the current function depend on this function.
-    functionDeps[currentFunction]!.add(functionId);
+    currentFunction!.deps.add(functionId);
 
-    final List<String> args =
-        List<String>.generate(nextPosition - position, (int i) {
-      return resolveName(readWord());
-    });
-    out.write('$indent$type $name = $functionName(');
+    final List<int> args = List<int>.filled(nextPosition - position, 0);
     for (int i = 0; i < args.length; i++) {
-      out.write(args[i]);
-      if (i < args.length - 1) {
-        out.write(', ');
-      }
+      final int id = readWord();
+      ref(id);
+      args[i] = id;
     }
-    out.writeln(');');
+    add(_FunctionCall(type, name, functionName, args));
   }
 
   void opVariable() {
@@ -837,7 +818,7 @@ class _Transpiler {
 
     switch (storageClass) {
       case _storageClassUniformConstant:
-        int? location = locations[id];
+        final int? location = locations[id];
         if (location == null) {
           throw failure('$id had no location specified');
         }
@@ -867,7 +848,7 @@ class _Transpiler {
         }
         return;
       case _storageClassFunction:
-        out.writeln('$indent$type $name;');
+        add(_StringInstruction('$type $name'));
         return;
       default:
         throw failure('$storageClass is an unsupported Storage Class');
@@ -883,37 +864,42 @@ class _Transpiler {
   }
 
   void opSelect() {
-    final String type = resolveType(readWord());
-    final String name = resolveName(readWord());
-    final String condition = resolveName(readWord());
-    final String a = resolveName(readWord());
-    final String b = resolveName(readWord());
-    out.writeln('$indent$type $name = mix($b, $a, $type($condition));');
+    final int type = readWord();
+    final int name = readWord();
+    final int condition = readWord();
+    final int a = readWord();
+    final int b = readWord();
+    ref(condition);
+    ref(a);
+    ref(b);
+    add(_Select(type, name, condition, a, b));
   }
 
   void opStore() {
-    final String pointer = resolveName(readWord());
-    final String object = resolveName(readWord());
-    out.writeln('$indent$pointer = $object;');
+    final int pointer = readWord();
+    final int object = readWord();
+    ref(object);
+    add(_Store(pointer, object));
   }
 
   void opAccessChain() {
-    final String type = resolveType(readWord());
+    final int type = readWord();
     final int id = readWord();
-    final String base = resolveName(readWord());
+    final int base = readWord();
+    ref(base);
 
     // opAccessChain currently only supports indexed access.
     // Once struct support is added, this will need to be updated.
     // Currently, structs will be caught before this method is called,
     // since using the instruction to define a struct type will throw
     // an exception.
-    String overload = base;
-    final int count = nextPosition - position;
-    for (int i = 0; i < count; i++) {
-      final String index = resolveName(readWord());
-      overload += '[$index]';
+    final List<int> indices = List<int>.filled(nextPosition - position, 0);
+    for (int i = 0; i < indices.length; i++) {
+      final int id = readWord();
+      ref(id);
+      indices[i] = id;
     }
-    nameOverloads[id] = overload;
+    add(_AccessChain(type, id, base, indices));
   }
 
   void opDecorate() {
@@ -934,120 +920,105 @@ class _Transpiler {
   }
 
   void opVectorShuffle() {
-    final String type = resolveType(readWord());
-    final String name = resolveName(readWord());
-    final String vector1Name = resolveName(readWord());
+    final int type = readWord();
+    final int name = readWord();
+    final int vector = readWord();
     // ignore second vector
     position++;
-
-    out.write('$indent$type $name = $type(');
-
-    final int count = nextPosition - position;
-    for (int i = 0; i < count; i++) {
-      final int index = readWord();
-      out.write('$vector1Name[$index]');
-      if (i < count - 1) {
-        out.write(', ');
-      }
+    final List<int> indices = List<int>.filled(nextPosition - position, 0);
+    for (int i = 0; i < indices.length; i++) {
+      ref(vector); // each index references the vector
+      final int id = readWord();
+      indices[i] = id;
     }
-    out.writeln(');');
+    add(_VectorShuffle(type, name, vector, indices));
   }
 
   void opCompositeConstruct() {
-    final String type = resolveType(readWord());
-    final String name = resolveName(readWord());
-    out.write('$indent$type $name = $type(');
-    final int count = nextPosition - position;
-    for (int i = 0; i < count; i++) {
-      out.write(resolveName(readWord()));
-      if (i < count - 1) {
-        out.write(', ');
-      }
+    final int type = readWord();
+    final int name = readWord();
+    final List<int> components = List<int>.filled(nextPosition - position, 0);
+    for (int i = 0; i < components.length; i++) {
+      final int id = readWord();
+      ref(id);
+      components[i] = id;
     }
-    out.writeln(');');
+    add(_CompositeConstruct(type, name, components));
   }
 
   void opCompositeExtract() {
-    final String type = resolveType(readWord());
-    final String name = resolveName(readWord());
-    final String src = resolveName(readWord());
-    out.write('$indent$type $name = $src');
-    final int count = nextPosition - position;
-    for (int i = 0; i < count; i++) {
+    final int type = readWord();
+    final int name = readWord();
+    final int src = readWord();
+    ref(src);
+    final List<int> indices = List<int>.filled(nextPosition - position, 0);
+    for (int i = 0; i < indices.length; i++) {
       final int index = readWord();
-      out.write('[$index]');
+      indices[i] = index;
     }
-    out.writeln(';');
+    add(_CompositeExtract(type, name, src, indices));
   }
 
   void opImageSampleImplicitLod() {
-    final String type = resolveType(readWord());
-    final String name = resolveName(readWord());
-    final String sampledImage = resolveName(readWord());
-    final String coordinate = resolveName(readWord());
-    if (target == TargetLanguage.sksl) {
-      out.writeln('$indent$type $name = $sampledImage.eval(${sampledImage}_size * $coordinate);');
-    } else {
-      out.writeln('$indent$type $name = texture($sampledImage, $coordinate);');
-    }
+    final int type = readWord();
+    final int name = readWord();
+    final int sampledImage = readWord();
+    final int coordinate = readWord();
+    ref(coordinate);
+    add(_ImageSampleImplicitLod(type, name, sampledImage, coordinate));
   }
 
   void opFNegate() {
-    final String type = resolveType(readWord());
-    final String name = resolveName(readWord());
-    final String operand = resolveName(readWord());
-    out.writeln('$indent$type $name = -$operand;');
+    final int type = readWord();
+    final int name = readWord();
+    final int operand = readWord();
+    ref(operand);
+    add(_Negate(type, name, operand));
   }
 
   void opLabel() {
-    out.writeln('{');
-    indent = indent + '  ';
-    if (target == TargetLanguage.sksl && currentFunction == entryPoint) {
-      final String ind = indent;
-      if (fragCoord > 0) {
-        final String fragName = resolveName(fragCoord);
-        out
-          ..write(ind)
-          ..writeln('float4 $fragName = float4($_fragParamName, 0, 0);');
-      }
-      out
-        ..write(ind)
-        ..writeln('float4 $_colorVariableName;');
-    }
+    final int id = readWord();
+    final _Block b = _Block();
+    final _Function f = currentFunction!;
+    f.blocks[id] = b;
+    f.entry ??= b;
+    currentBlock = b;
   }
 
   void opReturn() {
-    if (currentFunction == entryPoint) {
+    if (currentFunction!.name == entryPoint) {
       return;
+    } else {
+      add(_StringInstruction('return'));
     }
-    out.writeln(indent + 'return;');
   }
 
   void opReturnValue() {
-    final String name = resolveName(readWord());
-    out.writeln(indent + 'return $name;');
+    final int value = readWord();
+    ref(value);
+    add(_ReturnValue(value));
   }
 
   void parseOperatorInst(String op) {
-    final String type = resolveType(readWord());
-    final String name = resolveName(readWord());
-    final String a = resolveName(readWord());
-    final String b = resolveName(readWord());
-    out.writeln('$indent$type $name = $a $op $b;');
+    final int type = readWord();
+    final int name = readWord();
+    final int a = readWord();
+    final int b = readWord();
+    ref(a);
+    ref(b);
+    add(_Operator(type, name, op, a, b));
   }
 
   void parseBuiltinFunction(String functionName) {
-    final String type = resolveType(readWord());
-    final String name = resolveName(readWord());
-    out.write('$indent$type $name = $functionName(');
-    final int count = nextPosition - position;
-    for (int i = 0; i < count; i++) {
-      out.write(resolveName(readWord()));
-      if (i < count - 1) {
-        out.write(', ');
-      }
+    final int type = readWord();
+    final int name = readWord();
+    final List<int> args = List<int>.filled(nextPosition - position, 0);
+    for (int i = 0; i < args.length; i++) {
+      final int id = readWord();
+      ref(id);
+      args[i] = id;
     }
-    out.writeln(');');
+    add(_BuiltinFunction(type, name, functionName, args));
   }
 
   void parseGLSLInst(int id, int type) {
@@ -1060,19 +1031,12 @@ class _Transpiler {
       throw failure('$id is not a supported GLSL instruction.');
     }
     final int argc = _glslStd450OpArgc[inst]!;
-    parseGLSLOp(id, type, opName, argc);
-  }
-
-  void parseGLSLOp(int id, int type, String name, int argCount) {
-    final String resultName = resolveName(id);
-    final String typeName = resolveType(type);
-    out.write('$indent$typeName $resultName = $name(');
-    for (int i = 0; i < argCount; i++) {
-      out.write(resolveName(readWord()));
-      if (i < argCount - 1) {
-        out.write(', ');
-      }
+    final List<int> args = List<int>.filled(argc, 0);
+    for (int i = 0; i < argc; i++) {
+      final int id = readWord();
+      ref(id);
+      args[i] = id;
     }
-    out.writeln(');');
+    add(_BuiltinFunction(type, id, opName, args));
   }
 }


### PR DESCRIPTION
No tests are modified because this commit does not make a change
to the API or behavior of the API.

This change prepares the transpiler for the addition of control flow by adding
an additonal layer of indirection between processing instructions from the
SPIR-V byte code and writing the shader source string.

The changes are the following:

- Functions are written to _Function objects
- Blocks are written to _Block objects
- Instructions per block are collected into _Instruction objects
- Instructions are written lazily when functions are written,
  allowing late-resolution of variable names, inlining of
  expressions that are only used once, and indenting at
  write time.

https://github.com/flutter/flutter/issues/85261

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
