### PR TITLE
Revert mark idle

### DIFF
--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -54,7 +54,7 @@ static const char* kDartAllConfigsArgs[] = {
     "--enable_mirrors=false",
     "--background_compilation",
     "--lazy_async_stacks",
-    "--mark_when_idle",
+    // "--mark_when_idle", (appears to cause a regression, turning off for now).
     // clang-format on
 };
 

--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -54,7 +54,8 @@ static const char* kDartAllConfigsArgs[] = {
     "--enable_mirrors=false",
     "--background_compilation",
     "--lazy_async_stacks",
-    // "--mark_when_idle", (appears to cause a regression, turning off for now).
+    // 'mark_when_idle' appears to cause a regression, turning off for now.
+    // "--mark_when_idle",
     // clang-format on
 };
 


### PR DESCRIPTION
The option mark_when_idle appears to cause a regression on some benchmarks, reverting it for now until we  root cause the regression and fix it.