### PR TITLE
Displaylist ColorFilter objects

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -110,7 +110,7 @@ deps = {
   'src': 'https://github.com/flutter/buildroot.git' + '@' + '79643299bd052c53631b8b200bb582e8badb2708',
 
   'src/flutter/impeller':
-  Var('github_git') + '/flutter/impeller' + '@' + 'c55014e747541b9a2cca15e6b2cb1b1ef9123da3',
+  Var('github_git') + '/flutter/impeller' + '@' + '78bc2a026c554c444b2e67b36fd44cd548341a51',
 
    # Fuchsia compatibility
    #

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -52,6 +52,7 @@ FILE: ../../../flutter/display_list/display_list_canvas_dispatcher.h
 FILE: ../../../flutter/display_list/display_list_canvas_recorder.cc
 FILE: ../../../flutter/display_list/display_list_canvas_recorder.h
 FILE: ../../../flutter/display_list/display_list_canvas_unittests.cc
+FILE: ../../../flutter/display_list/display_list_color_filter_unittests.cc
 FILE: ../../../flutter/display_list/display_list_color_filter.cc
 FILE: ../../../flutter/display_list/display_list_color_filter.h
 FILE: ../../../flutter/display_list/display_list_complexity.cc

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -52,6 +52,8 @@ FILE: ../../../flutter/display_list/display_list_canvas_dispatcher.h
 FILE: ../../../flutter/display_list/display_list_canvas_recorder.cc
 FILE: ../../../flutter/display_list/display_list_canvas_recorder.h
 FILE: ../../../flutter/display_list/display_list_canvas_unittests.cc
+FILE: ../../../flutter/display_list/display_list_color_filter.cc
+FILE: ../../../flutter/display_list/display_list_color_filter.h
 FILE: ../../../flutter/display_list/display_list_complexity.cc
 FILE: ../../../flutter/display_list/display_list_complexity.h
 FILE: ../../../flutter/display_list/display_list_dispatcher.cc

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -52,9 +52,9 @@ FILE: ../../../flutter/display_list/display_list_canvas_dispatcher.h
 FILE: ../../../flutter/display_list/display_list_canvas_recorder.cc
 FILE: ../../../flutter/display_list/display_list_canvas_recorder.h
 FILE: ../../../flutter/display_list/display_list_canvas_unittests.cc
-FILE: ../../../flutter/display_list/display_list_color_filter_unittests.cc
 FILE: ../../../flutter/display_list/display_list_color_filter.cc
 FILE: ../../../flutter/display_list/display_list_color_filter.h
+FILE: ../../../flutter/display_list/display_list_color_filter_unittests.cc
 FILE: ../../../flutter/display_list/display_list_complexity.cc
 FILE: ../../../flutter/display_list/display_list_complexity.h
 FILE: ../../../flutter/display_list/display_list_dispatcher.cc

--- a/display_list/BUILD.gn
+++ b/display_list/BUILD.gn
@@ -14,6 +14,8 @@ source_set("display_list") {
     "display_list_canvas_dispatcher.h",
     "display_list_canvas_recorder.cc",
     "display_list_canvas_recorder.h",
+    "display_list_color_filter.cc",
+    "display_list_color_filter.h",
     "display_list_complexity.cc",
     "display_list_complexity.h",
     "display_list_dispatcher.cc",

--- a/display_list/BUILD.gn
+++ b/display_list/BUILD.gn
@@ -42,6 +42,7 @@ source_set("unittests") {
 
   sources = [
     "display_list_canvas_unittests.cc",
+    "display_list_color_filter_unittests.cc",
     "display_list_unittests.cc",
   ]
 

--- a/display_list/display_list.h
+++ b/display_list/display_list.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_FLOW_DISPLAY_LIST_H_
-#define FLUTTER_FLOW_DISPLAY_LIST_H_
+#ifndef FLUTTER_DISPLAY_LIST_DISPLAY_LIST_H_
+#define FLUTTER_DISPLAY_LIST_DISPLAY_LIST_H_
 
 #include <optional>
 
@@ -76,12 +76,14 @@ namespace flutter {
   V(ClearBlender)                   \
   V(SetShader)                      \
   V(ClearShader)                    \
-  V(SetColorFilter)                 \
-  V(ClearColorFilter)               \
   V(SetImageFilter)                 \
   V(ClearImageFilter)               \
   V(SetPathEffect)                  \
   V(ClearPathEffect)                \
+                                    \
+  V(ClearColorFilter)               \
+  V(SetColorFilter)                 \
+  V(SetSkColorFilter)               \
                                     \
   V(ClearMaskFilter)                \
   V(SetMaskFilter)                  \
@@ -278,4 +280,4 @@ class DisplayList : public SkRefCnt {
 
 }  // namespace flutter
 
-#endif  // FLUTTER_FLOW_DISPLAY_LIST_H_
+#endif  // FLUTTER_DISPLAY_LIST_DISPLAY_LIST_H_

--- a/display_list/display_list_builder.h
+++ b/display_list/display_list_builder.h
@@ -94,9 +94,8 @@ class DisplayListBuilder final : public virtual Dispatcher,
     }
   }
   void setColorFilter(const DlColorFilter* filter) override {
-    if (!DlColorFilter::Equals(current_color_filter_.get(), filter)) {
-      onSetColorFilter(filter);
-    }
+    // onSetColorFilter will deal with whether the filter is new
+    onSetColorFilter(filter);
   }
   void setPathEffect(sk_sp<SkPathEffect> effect) override {
     if (current_path_effect_ != effect) {
@@ -339,10 +338,10 @@ class DisplayListBuilder final : public virtual Dispatcher,
   }
 
   void UpdateCurrentOpacityCompatibility() {
-    current_opacity_compatibility_ =                              //
-        current_color_filter_->type() == DlColorFilter::kNone &&  //
-        !current_invert_colors_ &&                                //
-        current_blender_ == nullptr &&                            //
+    current_opacity_compatibility_ =         //
+        current_color_filter_ == nullptr &&  //
+        !current_invert_colors_ &&           //
+        current_blender_ == nullptr &&       //
         IsOpacityCompatible(current_blend_mode_);
   }
 
@@ -411,7 +410,7 @@ class DisplayListBuilder final : public virtual Dispatcher,
   SkBlendMode current_blend_mode_ = SkBlendMode::kSrcOver;
   sk_sp<SkBlender> current_blender_;
   sk_sp<SkShader> current_shader_;
-  std::unique_ptr<DlColorFilter> current_color_filter_;
+  std::shared_ptr<const DlColorFilter> current_color_filter_;
   sk_sp<SkImageFilter> current_image_filter_;
   sk_sp<SkPathEffect> current_path_effect_;
   sk_sp<SkMaskFilter> current_mask_filter_;

--- a/display_list/display_list_builder.h
+++ b/display_list/display_list_builder.h
@@ -392,7 +392,6 @@ class DisplayListBuilder final : public virtual Dispatcher,
   void onSetBlender(sk_sp<SkBlender> blender);
   void onSetShader(sk_sp<SkShader> shader);
   void onSetImageFilter(sk_sp<SkImageFilter> filter);
-  void setColorFilter(sk_sp<SkColorFilter> filter);
   void onSetColorFilter(const DlColorFilter* filter);
   void onSetPathEffect(sk_sp<SkPathEffect> effect);
   void onSetMaskFilter(sk_sp<SkMaskFilter> filter);

--- a/display_list/display_list_canvas_unittests.cc
+++ b/display_list/display_list_canvas_unittests.cc
@@ -836,48 +836,43 @@ class CanvasCompareTester {
           0, 0, 0, 0.5, 0,
       };
       // clang-format on
-      sk_sp<SkColorFilter> filter =
-          SkColorFilters::Matrix(rotate_alpha_color_matrix);
+      DlColorFilter filter = DlMatrixColorFilter(rotate_alpha_color_matrix);
       {
         RenderWith(testP, env, tolerance,
                    CaseParameters(
                        "saveLayer ColorFilter, no bounds",
                        [=](SkCanvas* cv, SkPaint& p) {
                          SkPaint save_p;
-                         save_p.setColorFilter(filter);
+                         save_p.setColorFilter(filter.sk_filter());
                          cv->saveLayer(nullptr, &save_p);
                          p.setStrokeWidth(5.0);
                        },
                        [=](DisplayListBuilder& b) {
-                         b.setColorFilter(filter);
+                         b.setColorFilter(&filter);
                          b.saveLayer(nullptr, true);
                          b.setColorFilter(nullptr);
                          b.setStrokeWidth(5.0);
                        })
                        .with_restore(cv_safe_restore, dl_safe_restore, true));
       }
-      EXPECT_TRUE(filter->unique())
-          << "saveLayer ColorFilter, no bounds Cleanup";
       {
         RenderWith(testP, env, tolerance,
                    CaseParameters(
                        "saveLayer ColorFilter and bounds",
                        [=](SkCanvas* cv, SkPaint& p) {
                          SkPaint save_p;
-                         save_p.setColorFilter(filter);
+                         save_p.setColorFilter(filter.sk_filter());
                          cv->saveLayer(RenderBounds, &save_p);
                          p.setStrokeWidth(5.0);
                        },
                        [=](DisplayListBuilder& b) {
-                         b.setColorFilter(filter);
+                         b.setColorFilter(&filter);
                          b.saveLayer(&RenderBounds, true);
                          b.setColorFilter(nullptr);
                          b.setStrokeWidth(5.0);
                        })
                        .with_restore(cv_safe_restore, dl_safe_restore, true));
       }
-      EXPECT_TRUE(filter->unique())
-          << "saveLayer ColorFilter and bounds Cleanup";
     }
     {
       sk_sp<SkImageFilter> filter = SkImageFilters::Arithmetic(
@@ -1146,7 +1141,7 @@ class CanvasCompareTester {
          1.0,  1.0,  1.0, 1.0,   0,
       };
       // clang-format on
-      sk_sp<SkColorFilter> filter = SkColorFilters::Matrix(rotate_color_matrix);
+      DlColorFilter filter = DlMatrixColorFilter(rotate_color_matrix);
       {
         SkColor bg = SK_ColorWHITE;
         RenderWith(testP, env, tolerance,
@@ -1154,16 +1149,15 @@ class CanvasCompareTester {
                        "ColorFilter == RotateRGB",
                        [=](SkCanvas*, SkPaint& p) {
                          p.setColor(SK_ColorYELLOW);
-                         p.setColorFilter(filter);
+                         p.setColorFilter(filter.sk_filter());
                        },
                        [=](DisplayListBuilder& b) {
                          b.setColor(SK_ColorYELLOW);
-                         b.setColorFilter(filter);
+                         b.setColorFilter(&filter);
                        })
                        .with_bg(bg));
       }
-      EXPECT_TRUE(filter->unique()) << "ColorFilter == RotateRGB Cleanup";
-      filter = SkColorFilters::Matrix(invert_color_matrix);
+      filter = DlMatrixColorFilter(invert_color_matrix);
       {
         SkColor bg = SK_ColorWHITE;
         RenderWith(testP, env, tolerance,
@@ -1171,7 +1165,7 @@ class CanvasCompareTester {
                        "ColorFilter == Invert",
                        [=](SkCanvas*, SkPaint& p) {
                          p.setColor(SK_ColorYELLOW);
-                         p.setColorFilter(filter);
+                         p.setColorFilter(filter.sk_filter());
                        },
                        [=](DisplayListBuilder& b) {
                          b.setColor(SK_ColorYELLOW);
@@ -1179,7 +1173,6 @@ class CanvasCompareTester {
                        })
                        .with_bg(bg));
       }
-      EXPECT_TRUE(filter->unique()) << "ColorFilter == Invert Cleanup";
     }
 
     {

--- a/display_list/display_list_canvas_unittests.cc
+++ b/display_list/display_list_canvas_unittests.cc
@@ -836,7 +836,7 @@ class CanvasCompareTester {
           0, 0, 0, 0.5, 0,
       };
       // clang-format on
-      DlColorFilter filter = DlMatrixColorFilter(rotate_alpha_color_matrix);
+      DlMatrixColorFilter filter(rotate_alpha_color_matrix);
       {
         RenderWith(testP, env, tolerance,
                    CaseParameters(
@@ -1141,7 +1141,7 @@ class CanvasCompareTester {
          1.0,  1.0,  1.0, 1.0,   0,
       };
       // clang-format on
-      DlColorFilter filter = DlMatrixColorFilter(rotate_color_matrix);
+      DlMatrixColorFilter filter(rotate_color_matrix);
       {
         SkColor bg = SK_ColorWHITE;
         RenderWith(testP, env, tolerance,

--- a/display_list/display_list_color_filter.cc
+++ b/display_list/display_list_color_filter.cc
@@ -1,0 +1,134 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/display_list/display_list_color_filter.h"
+
+namespace flutter {
+
+DlColorFilter::~DlColorFilter() {
+  if (type_ == kUnknown) {
+    delete static_cast<const DlUnknownColorFilter*>(this);
+    type_ = kNone;
+  }
+}
+
+size_t DlColorFilter::size() const {
+  switch (type_) {
+    case kNone:
+      // This query is used for allocating raw storage within a buffer for
+      // storing these objects. Such a technique should not be used for
+      // the |kNone| version of these objects.
+      FML_DCHECK(false);
+      return 0;
+    case kBlend:
+      return static_cast<const DlBlendColorFilter*>(this)->size();
+    case kMatrix:
+      return static_cast<const DlMatrixColorFilter*>(this)->size();
+    case kSrgbToLinearGamma:
+      return static_cast<const DlSrgbToLinearGammaColorFilter*>(this)->size();
+    case kLinearToSrgbGamma:
+      return static_cast<const DlLinearToSrgbGammaColorFilter*>(this)->size();
+    case kUnknown:
+      return static_cast<const DlUnknownColorFilter*>(this)->size();
+  }
+}
+
+bool DlColorFilter::equals(const DlColorFilter* other) const {
+  return Equals(this, other);
+}
+
+bool DlColorFilter::Equals(const DlColorFilter* a, const DlColorFilter* b) {
+  if (a == b) {
+    return true;
+  }
+  if (a == nullptr || b == nullptr) {
+    return false;
+  }
+  if (a->type_ != b->type_) {
+    return false;
+  }
+  switch (a->type_) {
+    case kNone:
+      return true;
+    case kBlend:
+      return static_cast<const DlBlendColorFilter*>(a)->equals(
+        static_cast<const DlBlendColorFilter*>(b)
+      );
+    case kMatrix:
+      return static_cast<const DlMatrixColorFilter*>(a)->equals(
+        static_cast<const DlMatrixColorFilter*>(b)
+      );
+    case kSrgbToLinearGamma:
+    case kLinearToSrgbGamma:
+      return true;
+    case kUnknown:
+      return static_cast<const DlUnknownColorFilter*>(a)->equals(
+        static_cast<const DlUnknownColorFilter*>(b)
+      );
+  }
+}
+
+sk_sp<SkColorFilter> DlColorFilter::sk_filter() const {
+  switch (type_) {
+    case kNone:
+      return nullptr;
+    case kBlend:
+      return static_cast<const DlBlendColorFilter*>(this)->sk_filter();
+    case kMatrix:
+      return static_cast<const DlMatrixColorFilter*>(this)->sk_filter();
+    case kSrgbToLinearGamma:
+      return static_cast<const DlSrgbToLinearGammaColorFilter*>(this)->sk_filter();
+    case kLinearToSrgbGamma:
+      return static_cast<const DlLinearToSrgbGammaColorFilter*>(this)->sk_filter();
+    case kUnknown:
+      return static_cast<const DlUnknownColorFilter*>(this)->sk_filter();
+  }
+}
+
+std::shared_ptr<const DlColorFilter> DlColorFilter::shared() const {
+  switch (type_) {
+    case kNone:
+      return std::make_shared<DlNoColorFilter>();
+    case kBlend:
+      return std::make_shared<DlBlendColorFilter>(static_cast<const DlBlendColorFilter*>(this));
+    case kMatrix:
+      return std::make_shared<DlMatrixColorFilter>(static_cast<const DlMatrixColorFilter*>(this));
+    case kSrgbToLinearGamma:
+      return std::make_shared<DlSrgbToLinearGammaColorFilter>(static_cast<const DlSrgbToLinearGammaColorFilter*>(this));
+    case kLinearToSrgbGamma:
+      return std::make_shared<DlLinearToSrgbGammaColorFilter>(static_cast<const DlLinearToSrgbGammaColorFilter*>(this));
+    case kUnknown:
+      return std::make_shared<DlUnknownColorFilter>(static_cast<const DlUnknownColorFilter*>(this));
+  }
+}
+
+bool DlColorFilter::modifies_transparent_black() const {
+  switch (type_) {
+    case kNone:
+    case kSrgbToLinearGamma:
+    case kLinearToSrgbGamma:
+      return false;
+    case kBlend:
+      // Look at blend and color to make a faster determination?
+    case kMatrix:
+      // Look at the matrix to make a faster determination?
+      // Basically, are the translation components all 0?
+    case kUnknown:
+      return sk_filter()->filterColor(SK_ColorTRANSPARENT) != SK_ColorTRANSPARENT;
+  }
+}
+
+const DlNoColorFilter DlNoColorFilter::instance = DlNoColorFilter();
+
+const DlSrgbToLinearGammaColorFilter DlSrgbToLinearGammaColorFilter::instance =
+    DlSrgbToLinearGammaColorFilter();
+const sk_sp<SkColorFilter> DlSrgbToLinearGammaColorFilter::sk_filter_ =
+    SkColorFilters::SRGBToLinearGamma();
+
+const DlLinearToSrgbGammaColorFilter DlLinearToSrgbGammaColorFilter::instance =
+    DlLinearToSrgbGammaColorFilter();
+const sk_sp<SkColorFilter> DlLinearToSrgbGammaColorFilter::sk_filter_ =
+    SkColorFilters::LinearToSRGBGamma();
+
+}  // namespace flutter

--- a/display_list/display_list_color_filter.cc
+++ b/display_list/display_list_color_filter.cc
@@ -6,6 +6,26 @@
 
 namespace flutter {
 
+DlColorFilter DlColorFilter::From(SkColorFilter* sk_filter) {
+  if (sk_filter == nullptr) {
+    return DlNoColorFilter::instance;
+  }
+  {
+    SkColor color;
+    SkBlendMode mode;
+    if (sk_filter->asAColorMode(&color, &mode)) {
+      return DlBlendColorFilter(color, mode);
+    }
+  }
+  {
+    float matrix[20];
+    if (sk_filter->asAColorMatrix(matrix)) {
+      return DlMatrixColorFilter(matrix);
+    }
+  }
+  return DlUnknownColorFilter(sk_ref_sp(sk_filter));
+}
+
 DlColorFilter::~DlColorFilter() {
   if (type_ == kUnknown) {
     delete static_cast<const DlUnknownColorFilter*>(this);
@@ -53,19 +73,16 @@ bool DlColorFilter::Equals(const DlColorFilter* a, const DlColorFilter* b) {
       return true;
     case kBlend:
       return static_cast<const DlBlendColorFilter*>(a)->equals(
-        static_cast<const DlBlendColorFilter*>(b)
-      );
+          static_cast<const DlBlendColorFilter*>(b));
     case kMatrix:
       return static_cast<const DlMatrixColorFilter*>(a)->equals(
-        static_cast<const DlMatrixColorFilter*>(b)
-      );
+          static_cast<const DlMatrixColorFilter*>(b));
     case kSrgbToLinearGamma:
     case kLinearToSrgbGamma:
       return true;
     case kUnknown:
       return static_cast<const DlUnknownColorFilter*>(a)->equals(
-        static_cast<const DlUnknownColorFilter*>(b)
-      );
+          static_cast<const DlUnknownColorFilter*>(b));
   }
 }
 
@@ -78,9 +95,11 @@ sk_sp<SkColorFilter> DlColorFilter::sk_filter() const {
     case kMatrix:
       return static_cast<const DlMatrixColorFilter*>(this)->sk_filter();
     case kSrgbToLinearGamma:
-      return static_cast<const DlSrgbToLinearGammaColorFilter*>(this)->sk_filter();
+      return static_cast<const DlSrgbToLinearGammaColorFilter*>(this)
+          ->sk_filter();
     case kLinearToSrgbGamma:
-      return static_cast<const DlLinearToSrgbGammaColorFilter*>(this)->sk_filter();
+      return static_cast<const DlLinearToSrgbGammaColorFilter*>(this)
+          ->sk_filter();
     case kUnknown:
       return static_cast<const DlUnknownColorFilter*>(this)->sk_filter();
   }
@@ -91,15 +110,20 @@ std::shared_ptr<const DlColorFilter> DlColorFilter::shared() const {
     case kNone:
       return std::make_shared<DlNoColorFilter>();
     case kBlend:
-      return std::make_shared<DlBlendColorFilter>(static_cast<const DlBlendColorFilter*>(this));
+      return std::make_shared<DlBlendColorFilter>(
+          static_cast<const DlBlendColorFilter*>(this));
     case kMatrix:
-      return std::make_shared<DlMatrixColorFilter>(static_cast<const DlMatrixColorFilter*>(this));
+      return std::make_shared<DlMatrixColorFilter>(
+          static_cast<const DlMatrixColorFilter*>(this));
     case kSrgbToLinearGamma:
-      return std::make_shared<DlSrgbToLinearGammaColorFilter>(static_cast<const DlSrgbToLinearGammaColorFilter*>(this));
+      return std::make_shared<DlSrgbToLinearGammaColorFilter>(
+          static_cast<const DlSrgbToLinearGammaColorFilter*>(this));
     case kLinearToSrgbGamma:
-      return std::make_shared<DlLinearToSrgbGammaColorFilter>(static_cast<const DlLinearToSrgbGammaColorFilter*>(this));
+      return std::make_shared<DlLinearToSrgbGammaColorFilter>(
+          static_cast<const DlLinearToSrgbGammaColorFilter*>(this));
     case kUnknown:
-      return std::make_shared<DlUnknownColorFilter>(static_cast<const DlUnknownColorFilter*>(this));
+      return std::make_shared<DlUnknownColorFilter>(
+          static_cast<const DlUnknownColorFilter*>(this));
   }
 }
 
@@ -115,7 +139,8 @@ bool DlColorFilter::modifies_transparent_black() const {
       // Look at the matrix to make a faster determination?
       // Basically, are the translation components all 0?
     case kUnknown:
-      return sk_filter()->filterColor(SK_ColorTRANSPARENT) != SK_ColorTRANSPARENT;
+      return sk_filter()->filterColor(SK_ColorTRANSPARENT) !=
+             SK_ColorTRANSPARENT;
   }
 }
 

--- a/display_list/display_list_color_filter.cc
+++ b/display_list/display_list_color_filter.cc
@@ -6,153 +6,43 @@
 
 namespace flutter {
 
-DlColorFilter DlColorFilter::From(SkColorFilter* sk_filter) {
+std::shared_ptr<DlColorFilter> DlColorFilter::From(SkColorFilter* sk_filter) {
   if (sk_filter == nullptr) {
-    return DlNoColorFilter::instance;
+    return nullptr;
+  }
+  if (sk_filter == DlSrgbToLinearGammaColorFilter::sk_filter_.get()) {
+    // Skia implements these filters as a singleton.
+    return DlSrgbToLinearGammaColorFilter::instance;
+  }
+  if (sk_filter == DlLinearToSrgbGammaColorFilter::sk_filter_.get()) {
+    // Skia implements these filters as a singleton.
+    return DlLinearToSrgbGammaColorFilter::instance;
   }
   {
     SkColor color;
     SkBlendMode mode;
     if (sk_filter->asAColorMode(&color, &mode)) {
-      return DlBlendColorFilter(color, mode);
+      return std::make_shared<DlBlendColorFilter>(color, mode);
     }
   }
   {
     float matrix[20];
     if (sk_filter->asAColorMatrix(matrix)) {
-      return DlMatrixColorFilter(matrix);
+      return std::make_shared<DlMatrixColorFilter>(matrix);
     }
   }
-  return DlUnknownColorFilter(sk_ref_sp(sk_filter));
+  return std::make_shared<DlUnknownColorFilter>(sk_ref_sp(sk_filter));
 }
 
-DlColorFilter::~DlColorFilter() {
-  if (type_ == kUnknown) {
-    delete static_cast<const DlUnknownColorFilter*>(this);
-    type_ = kNone;
-  }
-}
-
-size_t DlColorFilter::size() const {
-  switch (type_) {
-    case kNone:
-      // This query is used for allocating raw storage within a buffer for
-      // storing these objects. Such a technique should not be used for
-      // the |kNone| version of these objects.
-      FML_DCHECK(false);
-      return 0;
-    case kBlend:
-      return static_cast<const DlBlendColorFilter*>(this)->size();
-    case kMatrix:
-      return static_cast<const DlMatrixColorFilter*>(this)->size();
-    case kSrgbToLinearGamma:
-      return static_cast<const DlSrgbToLinearGammaColorFilter*>(this)->size();
-    case kLinearToSrgbGamma:
-      return static_cast<const DlLinearToSrgbGammaColorFilter*>(this)->size();
-    case kUnknown:
-      return static_cast<const DlUnknownColorFilter*>(this)->size();
-  }
-}
-
-bool DlColorFilter::equals(const DlColorFilter* other) const {
-  return Equals(this, other);
-}
-
-bool DlColorFilter::Equals(const DlColorFilter* a, const DlColorFilter* b) {
-  if (a == b) {
-    return true;
-  }
-  if (a == nullptr || b == nullptr) {
-    return false;
-  }
-  if (a->type_ != b->type_) {
-    return false;
-  }
-  switch (a->type_) {
-    case kNone:
-      return true;
-    case kBlend:
-      return static_cast<const DlBlendColorFilter*>(a)->equals(
-          static_cast<const DlBlendColorFilter*>(b));
-    case kMatrix:
-      return static_cast<const DlMatrixColorFilter*>(a)->equals(
-          static_cast<const DlMatrixColorFilter*>(b));
-    case kSrgbToLinearGamma:
-    case kLinearToSrgbGamma:
-      return true;
-    case kUnknown:
-      return static_cast<const DlUnknownColorFilter*>(a)->equals(
-          static_cast<const DlUnknownColorFilter*>(b));
-  }
-}
-
-sk_sp<SkColorFilter> DlColorFilter::sk_filter() const {
-  switch (type_) {
-    case kNone:
-      return nullptr;
-    case kBlend:
-      return static_cast<const DlBlendColorFilter*>(this)->sk_filter();
-    case kMatrix:
-      return static_cast<const DlMatrixColorFilter*>(this)->sk_filter();
-    case kSrgbToLinearGamma:
-      return static_cast<const DlSrgbToLinearGammaColorFilter*>(this)
-          ->sk_filter();
-    case kLinearToSrgbGamma:
-      return static_cast<const DlLinearToSrgbGammaColorFilter*>(this)
-          ->sk_filter();
-    case kUnknown:
-      return static_cast<const DlUnknownColorFilter*>(this)->sk_filter();
-  }
-}
-
-std::shared_ptr<const DlColorFilter> DlColorFilter::shared() const {
-  switch (type_) {
-    case kNone:
-      return std::make_shared<DlNoColorFilter>();
-    case kBlend:
-      return std::make_shared<DlBlendColorFilter>(
-          static_cast<const DlBlendColorFilter*>(this));
-    case kMatrix:
-      return std::make_shared<DlMatrixColorFilter>(
-          static_cast<const DlMatrixColorFilter*>(this));
-    case kSrgbToLinearGamma:
-      return std::make_shared<DlSrgbToLinearGammaColorFilter>(
-          static_cast<const DlSrgbToLinearGammaColorFilter*>(this));
-    case kLinearToSrgbGamma:
-      return std::make_shared<DlLinearToSrgbGammaColorFilter>(
-          static_cast<const DlLinearToSrgbGammaColorFilter*>(this));
-    case kUnknown:
-      return std::make_shared<DlUnknownColorFilter>(
-          static_cast<const DlUnknownColorFilter*>(this));
-  }
-}
-
-bool DlColorFilter::modifies_transparent_black() const {
-  switch (type_) {
-    case kNone:
-    case kSrgbToLinearGamma:
-    case kLinearToSrgbGamma:
-      return false;
-    case kBlend:
-      // Look at blend and color to make a faster determination?
-    case kMatrix:
-      // Look at the matrix to make a faster determination?
-      // Basically, are the translation components all 0?
-    case kUnknown:
-      return sk_filter()->filterColor(SK_ColorTRANSPARENT) !=
-             SK_ColorTRANSPARENT;
-  }
-}
-
-const DlNoColorFilter DlNoColorFilter::instance = DlNoColorFilter();
-
-const DlSrgbToLinearGammaColorFilter DlSrgbToLinearGammaColorFilter::instance =
-    DlSrgbToLinearGammaColorFilter();
+const std::shared_ptr<DlSrgbToLinearGammaColorFilter>
+    DlSrgbToLinearGammaColorFilter::instance =
+        std::make_shared<DlSrgbToLinearGammaColorFilter>();
 const sk_sp<SkColorFilter> DlSrgbToLinearGammaColorFilter::sk_filter_ =
     SkColorFilters::SRGBToLinearGamma();
 
-const DlLinearToSrgbGammaColorFilter DlLinearToSrgbGammaColorFilter::instance =
-    DlLinearToSrgbGammaColorFilter();
+const std::shared_ptr<DlLinearToSrgbGammaColorFilter>
+    DlLinearToSrgbGammaColorFilter::instance =
+        std::make_shared<DlLinearToSrgbGammaColorFilter>();
 const sk_sp<SkColorFilter> DlLinearToSrgbGammaColorFilter::sk_filter_ =
     SkColorFilters::LinearToSRGBGamma();
 

--- a/display_list/display_list_color_filter.h
+++ b/display_list/display_list_color_filter.h
@@ -19,7 +19,6 @@ class DlUnknownColorFilter;
 class DlColorFilter {
  public:
   enum Type {
-    kNone,
     kBlend,
     kMatrix,
     kSrgbToLinearGamma,
@@ -27,83 +26,74 @@ class DlColorFilter {
     kUnknown
   };
 
-  Type type() const { return type_; }
-
-  static DlColorFilter From(SkColorFilter* sk_filter);
-
-  size_t size() const;
-  bool equals(const DlColorFilter* other) const;
-  static bool Equals(const DlColorFilter* a, const DlColorFilter* b);
-  sk_sp<SkColorFilter> sk_filter() const;
-  std::shared_ptr<const DlColorFilter> shared() const;
-  bool modifies_transparent_black() const;
-
-  const DlBlendColorFilter* asABlendFilter() const {
-    return type_ == kBlend ? reinterpret_cast<const DlBlendColorFilter*>(this)
-                           : nullptr;
+  static std::shared_ptr<DlColorFilter> From(SkColorFilter* sk_filter);
+  static std::shared_ptr<DlColorFilter> From(sk_sp<SkColorFilter> sk_filter) {
+    return From(sk_filter.get());
   }
 
-  const DlMatrixColorFilter* asAMatrixFilter() const {
-    return type_ == kMatrix ? reinterpret_cast<const DlMatrixColorFilter*>(this)
-                            : nullptr;
+  virtual Type type() const = 0;
+  virtual size_t size() const = 0;
+  virtual bool modifies_transparent_black() const = 0;
+
+  static std::shared_ptr<DlColorFilter> Shared(const DlColorFilter* filter) {
+    return filter == nullptr ? nullptr : filter->shared();
+  }
+  virtual std::shared_ptr<DlColorFilter> shared() const = 0;
+  virtual sk_sp<SkColorFilter> sk_filter() const = 0;
+
+  // asSrgb<->Linear and asUnknown are not needed because they
+  // have no properties to query. Their type fully specifies their
+  // operation or can be accessed via the common sk_filter() method.
+  virtual const DlBlendColorFilter* asBlend() const { return nullptr; }
+  virtual const DlMatrixColorFilter* asMatrix() const { return nullptr; }
+
+  bool operator==(DlColorFilter const& other) const {
+    return type() == other.type() && equals_(other);
+  }
+  bool operator!=(DlColorFilter const& other) const {
+    return !(*this == other);
   }
 
-  const DlSrgbToLinearGammaColorFilter* asASrgbToLinearFilter() const {
-    return type_ == kSrgbToLinearGamma
-               ? reinterpret_cast<const DlSrgbToLinearGammaColorFilter*>(this)
-               : nullptr;
-  }
-
-  const DlLinearToSrgbGammaColorFilter* asALinearToSrgbFilter() const {
-    return type_ == kLinearToSrgbGamma
-               ? reinterpret_cast<const DlLinearToSrgbGammaColorFilter*>(this)
-               : nullptr;
-  }
-
-  ~DlColorFilter();
+  virtual ~DlColorFilter() = default;
 
  protected:
-  DlColorFilter(Type type) : type_(type) {
-    FML_DCHECK(type >= kNone && type <= kUnknown);
-  }
-
- private:
-  Type type_;
-};
-
-class DlNoColorFilter final : public DlColorFilter {
- public:
-  static const DlNoColorFilter instance;
-
-  DlNoColorFilter() : DlColorFilter(kNone) {}
-  DlNoColorFilter(const DlNoColorFilter& filter) : DlColorFilter(kNone) {}
-  DlNoColorFilter(const DlNoColorFilter* filter) : DlColorFilter(kNone) {}
-
-  size_t size() const { return sizeof(*this); }
-  bool equals(const DlNoColorFilter* other) const { return true; }
-
-  sk_sp<SkColorFilter> sk_filter() const { return nullptr; }
+  virtual bool equals_(DlColorFilter const& other) const = 0;
 };
 
 class DlBlendColorFilter final : public DlColorFilter {
  public:
   DlBlendColorFilter(SkColor color, SkBlendMode mode)
-      : DlColorFilter(kBlend), color_(color), mode_(mode) {}
+      : color_(color), mode_(mode) {}
   DlBlendColorFilter(const DlBlendColorFilter& filter)
       : DlBlendColorFilter(filter.color_, filter.mode_) {}
   DlBlendColorFilter(const DlBlendColorFilter* filter)
       : DlBlendColorFilter(filter->color_, filter->mode_) {}
 
-  size_t size() const { return sizeof(*this); }
-  bool equals(const DlBlendColorFilter* other) const {
-    return color_ == other->color_ && mode_ == other->mode_;
+  Type type() const override { return kBlend; }
+  size_t size() const override { return sizeof(*this); }
+  bool modifies_transparent_black() const override {
+    // Look at blend and color to make a faster determination?
+    return sk_filter()->filterColor(SK_ColorTRANSPARENT) != SK_ColorTRANSPARENT;
   }
+
+  std::shared_ptr<DlColorFilter> shared() const override {
+    return std::make_shared<DlBlendColorFilter>(this);
+  }
+
+  sk_sp<SkColorFilter> sk_filter() const override {
+    return SkColorFilters::Blend(color_, mode_);
+  }
+
+  const DlBlendColorFilter* asBlend() const override { return this; }
 
   SkColor color() const { return color_; }
   SkBlendMode mode() const { return mode_; }
 
-  sk_sp<SkColorFilter> sk_filter() const {
-    return SkColorFilters::Blend(color_, mode_);
+ protected:
+  bool equals_(DlColorFilter const& other) const override {
+    FML_DCHECK(other.type() == kBlend);
+    auto that = static_cast<DlBlendColorFilter const&>(other);
+    return color_ == that.color_ && mode_ == that.mode_;
   }
 
  private:
@@ -113,26 +103,42 @@ class DlBlendColorFilter final : public DlColorFilter {
 
 class DlMatrixColorFilter final : public DlColorFilter {
  public:
-  DlMatrixColorFilter(const float matrix[20]) : DlColorFilter(kMatrix) {
-    memcpy(matrix_, &matrix, sizeof(matrix_));
+  DlMatrixColorFilter(const float matrix[20]) {
+    memcpy(matrix_, matrix, sizeof(matrix_));
   }
   DlMatrixColorFilter(const DlMatrixColorFilter& filter)
       : DlMatrixColorFilter(filter.matrix_) {}
   DlMatrixColorFilter(const DlMatrixColorFilter* filter)
       : DlMatrixColorFilter(filter->matrix_) {}
 
-  size_t size() const { return sizeof(*this); }
-  bool equals(const DlMatrixColorFilter* other) const {
-    return memcmp(matrix_, other->matrix_, sizeof(matrix_)) == 0;
+  Type type() const override { return kMatrix; }
+  size_t size() const override { return sizeof(*this); }
+  bool modifies_transparent_black() const override {
+    // Look at the matrix to make a faster determination?
+    // Basically, are the translation components all 0?
+    return sk_filter()->filterColor(SK_ColorTRANSPARENT) != SK_ColorTRANSPARENT;
   }
+
+  std::shared_ptr<DlColorFilter> shared() const override {
+    return std::make_shared<DlMatrixColorFilter>(this);
+  }
+
+  sk_sp<SkColorFilter> sk_filter() const override {
+    return SkColorFilters::Matrix(matrix_);
+  }
+
+  const DlMatrixColorFilter* asMatrix() const override { return this; }
 
   const float& operator[](int index) const { return matrix_[index]; }
   void get_matrix(float matrix[20]) const {
     memcpy(matrix, matrix_, sizeof(matrix_));
   }
 
-  sk_sp<SkColorFilter> sk_filter() const {
-    return SkColorFilters::Matrix(matrix_);
+ protected:
+  bool equals_(const DlColorFilter& other) const override {
+    FML_DCHECK(other.type() == kMatrix);
+    auto that = static_cast<DlMatrixColorFilter const&>(other);
+    return memcmp(matrix_, that.matrix_, sizeof(matrix_)) == 0;
   }
 
  private:
@@ -141,61 +147,89 @@ class DlMatrixColorFilter final : public DlColorFilter {
 
 class DlSrgbToLinearGammaColorFilter final : public DlColorFilter {
  public:
-  static const DlSrgbToLinearGammaColorFilter instance;
+  static const std::shared_ptr<DlSrgbToLinearGammaColorFilter> instance;
 
-  DlSrgbToLinearGammaColorFilter() : DlColorFilter(kSrgbToLinearGamma) {}
+  DlSrgbToLinearGammaColorFilter() {}
   DlSrgbToLinearGammaColorFilter(const DlSrgbToLinearGammaColorFilter& filter)
       : DlSrgbToLinearGammaColorFilter() {}
   DlSrgbToLinearGammaColorFilter(const DlSrgbToLinearGammaColorFilter* filter)
       : DlSrgbToLinearGammaColorFilter() {}
 
-  size_t size() const { return sizeof(*this); }
-  bool equals(const DlSrgbToLinearGammaColorFilter* other) const {
+  Type type() const override { return kSrgbToLinearGamma; }
+  size_t size() const override { return sizeof(*this); }
+  bool modifies_transparent_black() const override { return false; }
+
+  std::shared_ptr<DlColorFilter> shared() const override { return instance; }
+  sk_sp<SkColorFilter> sk_filter() const override { return sk_filter_; }
+
+ protected:
+  bool equals_(const DlColorFilter& other) const override {
+    FML_DCHECK(other.type() == kSrgbToLinearGamma);
     return true;
   }
 
-  sk_sp<SkColorFilter> sk_filter() const { return sk_filter_; }
-
  private:
   static const sk_sp<SkColorFilter> sk_filter_;
+  friend class DlColorFilter;
 };
 
 class DlLinearToSrgbGammaColorFilter final : public DlColorFilter {
  public:
-  static const DlLinearToSrgbGammaColorFilter instance;
+  static const std::shared_ptr<DlLinearToSrgbGammaColorFilter> instance;
 
-  DlLinearToSrgbGammaColorFilter() : DlColorFilter(kLinearToSrgbGamma) {}
+  DlLinearToSrgbGammaColorFilter() {}
   DlLinearToSrgbGammaColorFilter(const DlLinearToSrgbGammaColorFilter& filter)
       : DlLinearToSrgbGammaColorFilter() {}
   DlLinearToSrgbGammaColorFilter(const DlLinearToSrgbGammaColorFilter* filter)
       : DlLinearToSrgbGammaColorFilter() {}
 
-  size_t size() const { return sizeof(*this); }
-  bool equals(const DlLinearToSrgbGammaColorFilter* other) const {
+  Type type() const override { return kLinearToSrgbGamma; }
+  size_t size() const override { return sizeof(*this); }
+  bool modifies_transparent_black() const override { return false; }
+
+  std::shared_ptr<DlColorFilter> shared() const override { return instance; }
+  sk_sp<SkColorFilter> sk_filter() const override { return sk_filter_; }
+
+ protected:
+  bool equals_(const DlColorFilter& other) const override {
+    FML_DCHECK(other.type() == kLinearToSrgbGamma);
     return true;
   }
 
-  sk_sp<SkColorFilter> sk_filter() const { return sk_filter_; }
-
  private:
   static const sk_sp<SkColorFilter> sk_filter_;
+  friend class DlColorFilter;
 };
 
 class DlUnknownColorFilter final : public DlColorFilter {
  public:
   DlUnknownColorFilter(sk_sp<SkColorFilter> sk_filter)
-      : DlColorFilter(kUnknown), sk_filter_(std::move(sk_filter)) {}
+      : sk_filter_(std::move(sk_filter)) {}
   DlUnknownColorFilter(const DlUnknownColorFilter& filter)
       : DlUnknownColorFilter(filter.sk_filter_) {}
   DlUnknownColorFilter(const DlUnknownColorFilter* filter)
       : DlUnknownColorFilter(filter->sk_filter_) {}
 
-  size_t size() const { return sizeof(*this); }
-  bool equals(const DlUnknownColorFilter* other) const {
-    return sk_filter_ == other->sk_filter_;
+  Type type() const override { return kUnknown; }
+  size_t size() const override { return sizeof(*this); }
+  bool modifies_transparent_black() const override {
+    return sk_filter()->filterColor(SK_ColorTRANSPARENT) != SK_ColorTRANSPARENT;
   }
 
-  sk_sp<SkColorFilter> sk_filter() const { return sk_filter_; }
+  std::shared_ptr<DlColorFilter> shared() const override {
+    return std::make_shared<DlUnknownColorFilter>(this);
+  }
+
+  sk_sp<SkColorFilter> sk_filter() const override { return sk_filter_; }
+
+  virtual ~DlUnknownColorFilter() = default;
+
+ protected:
+  bool equals_(const DlColorFilter& other) const override {
+    FML_DCHECK(other.type() == kUnknown);
+    auto that = static_cast<DlUnknownColorFilter const&>(other);
+    return sk_filter_ == that.sk_filter_;
+  }
 
  private:
   sk_sp<SkColorFilter> sk_filter_;

--- a/display_list/display_list_color_filter.h
+++ b/display_list/display_list_color_filter.h
@@ -1,0 +1,210 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_DISPLAY_LIST_DISPLAY_LIST_COLOR_FILTER_H_
+#define FLUTTER_DISPLAY_LIST_DISPLAY_LIST_COLOR_FILTER_H_
+
+#include "flutter/display_list/types.h"
+#include "flutter/fml/logging.h"
+
+namespace flutter {
+
+class DlBlendColorFilter;
+class DlMatrixColorFilter;
+class DlSrgbToLinearGammaColorFilter;
+class DlLinearToSrgbGammaColorFilter;
+class DlUnknownColorFilter;
+
+class DlColorFilter {
+ public:
+  enum Type {
+    kNone,
+    kBlend,
+    kMatrix,
+    kSrgbToLinearGamma,
+    kLinearToSrgbGamma,
+    kUnknown
+  };
+
+  Type type() const { return type_; }
+
+  size_t size() const;
+  bool equals(const DlColorFilter* other) const;
+  static bool Equals(const DlColorFilter* a, const DlColorFilter* b);
+  sk_sp<SkColorFilter> sk_filter() const;
+  std::shared_ptr<const DlColorFilter> shared() const;
+  bool modifies_transparent_black() const;
+
+  const DlBlendColorFilter* asABlendFilter() const {
+    return type_ == kBlend
+               ? reinterpret_cast<const DlBlendColorFilter*>(this)
+               : nullptr;
+  }
+
+  const DlMatrixColorFilter* asAMatrixFilter() const {
+    return type_ == kMatrix
+               ? reinterpret_cast<const DlMatrixColorFilter*>(this)
+               : nullptr;
+  }
+
+  const DlSrgbToLinearGammaColorFilter* asASrgbToLinearFilter() const {
+    return type_ == kSrgbToLinearGamma
+               ? reinterpret_cast<const DlSrgbToLinearGammaColorFilter*>(this)
+               : nullptr;
+  }
+
+  const DlLinearToSrgbGammaColorFilter* asALinearToSrgbFilter() const {
+    return type_ == kLinearToSrgbGamma
+               ? reinterpret_cast<const DlLinearToSrgbGammaColorFilter*>(this)
+               : nullptr;
+  }
+
+  ~DlColorFilter();
+
+ protected:
+  DlColorFilter(Type type) : type_(type) {
+    FML_DCHECK(type >= kNone && type <= kUnknown);
+  }
+
+ private:
+  Type type_;
+};
+
+class DlNoColorFilter final : public DlColorFilter {
+ public:
+  static const DlNoColorFilter instance;
+
+  DlNoColorFilter() : DlColorFilter(kNone) {}
+  DlNoColorFilter(const DlNoColorFilter& filter) : DlColorFilter(kNone) {}
+  DlNoColorFilter(const DlNoColorFilter* filter) : DlColorFilter(kNone) {}
+
+  size_t size() const { return sizeof(*this); }
+  bool equals(const DlNoColorFilter* other) const { return true; }
+
+  sk_sp<SkColorFilter> sk_filter() const { return nullptr; }
+};
+
+class DlBlendColorFilter final : public DlColorFilter {
+ public:
+  DlBlendColorFilter(SkColor color, SkBlendMode mode)
+      : DlColorFilter(kBlend), color_(color), mode_(mode) {
+  }
+  DlBlendColorFilter(const DlBlendColorFilter& filter)
+      : DlBlendColorFilter(filter.color_, filter.mode_) {}
+  DlBlendColorFilter(const DlBlendColorFilter* filter)
+      : DlBlendColorFilter(filter->color_, filter->mode_) {}
+
+  size_t size() const { return sizeof(*this); }
+  bool equals(const DlBlendColorFilter* other) const {
+    return color_ == other->color_ && mode_ == other->mode_;
+  }
+
+  SkColor color() const { return color_; }
+  SkBlendMode mode() const { return mode_; }
+
+  sk_sp<SkColorFilter> sk_filter() const {
+    return SkColorFilters::Blend(color_, mode_);
+  }
+
+ private:
+  SkColor color_;
+  SkBlendMode mode_;
+};
+
+class DlMatrixColorFilter final : public DlColorFilter {
+ public:
+  DlMatrixColorFilter(const float matrix[20])
+      : DlColorFilter(kMatrix) {
+    memcpy(matrix_, &matrix, sizeof(matrix_));
+  }
+  DlMatrixColorFilter(const DlMatrixColorFilter& filter)
+      : DlMatrixColorFilter(filter.matrix_) {}
+  DlMatrixColorFilter(const DlMatrixColorFilter* filter)
+      : DlMatrixColorFilter(filter->matrix_) {}
+
+  size_t size() const { return sizeof(*this); }
+  bool equals(const DlMatrixColorFilter* other) const {
+    return memcmp(matrix_, other->matrix_, sizeof(matrix_)) == 0;
+  }
+
+  const float& operator[](int index) const { return matrix_[index]; }
+  void get_matrix(float matrix[20]) const {
+    memcpy(matrix, matrix_, sizeof(matrix_));
+  }
+
+  sk_sp<SkColorFilter> sk_filter() const {
+    return SkColorFilters::Matrix(matrix_);
+  }
+
+ private:
+  float matrix_[20];
+};
+
+class DlSrgbToLinearGammaColorFilter final : public DlColorFilter {
+ public:
+  static const DlSrgbToLinearGammaColorFilter instance;
+
+  DlSrgbToLinearGammaColorFilter() : DlColorFilter(kSrgbToLinearGamma) {}
+  DlSrgbToLinearGammaColorFilter(const DlSrgbToLinearGammaColorFilter& filter)
+      : DlSrgbToLinearGammaColorFilter() {}
+  DlSrgbToLinearGammaColorFilter(const DlSrgbToLinearGammaColorFilter* filter)
+      : DlSrgbToLinearGammaColorFilter() {}
+
+  size_t size() const { return sizeof(*this); }
+  bool equals(const DlSrgbToLinearGammaColorFilter* other) const {
+    return true;
+  }
+
+  sk_sp<SkColorFilter> sk_filter() const {
+    return sk_filter_;
+  }
+
+ private:
+  static const sk_sp<SkColorFilter> sk_filter_;
+};
+
+class DlLinearToSrgbGammaColorFilter final : public DlColorFilter {
+ public:
+  static const DlLinearToSrgbGammaColorFilter instance;
+
+  DlLinearToSrgbGammaColorFilter() : DlColorFilter(kLinearToSrgbGamma) {}
+  DlLinearToSrgbGammaColorFilter(const DlLinearToSrgbGammaColorFilter& filter)
+      : DlLinearToSrgbGammaColorFilter() {}
+  DlLinearToSrgbGammaColorFilter(const DlLinearToSrgbGammaColorFilter* filter)
+      : DlLinearToSrgbGammaColorFilter() {}
+
+  size_t size() const { return sizeof(*this); }
+  bool equals(const DlLinearToSrgbGammaColorFilter* other) const {
+    return true;
+  }
+
+  sk_sp<SkColorFilter> sk_filter() const { return sk_filter_; }
+
+ private:
+  static const sk_sp<SkColorFilter> sk_filter_;
+};
+
+class DlUnknownColorFilter final : public DlColorFilter {
+ public:
+  DlUnknownColorFilter(sk_sp<SkColorFilter> sk_filter)
+      : DlColorFilter(kUnknown), sk_filter_(std::move(sk_filter)) {}
+  DlUnknownColorFilter(const DlUnknownColorFilter& filter)
+      : DlUnknownColorFilter(filter.sk_filter_) {}
+  DlUnknownColorFilter(const DlUnknownColorFilter* filter)
+      : DlUnknownColorFilter(filter->sk_filter_) {}
+
+  size_t size() const { return sizeof(*this); }
+  bool equals(const DlUnknownColorFilter* other) const {
+    return sk_filter_ == other->sk_filter_;
+  }
+
+  sk_sp<SkColorFilter> sk_filter() const { return sk_filter_; }
+
+ private:
+  sk_sp<SkColorFilter> sk_filter_;
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_DISPLAY_LIST_DISPLAY_LIST_COLOR_FILTER_H_

--- a/display_list/display_list_color_filter.h
+++ b/display_list/display_list_color_filter.h
@@ -29,6 +29,8 @@ class DlColorFilter {
 
   Type type() const { return type_; }
 
+  static DlColorFilter From(SkColorFilter* sk_filter);
+
   size_t size() const;
   bool equals(const DlColorFilter* other) const;
   static bool Equals(const DlColorFilter* a, const DlColorFilter* b);
@@ -37,15 +39,13 @@ class DlColorFilter {
   bool modifies_transparent_black() const;
 
   const DlBlendColorFilter* asABlendFilter() const {
-    return type_ == kBlend
-               ? reinterpret_cast<const DlBlendColorFilter*>(this)
-               : nullptr;
+    return type_ == kBlend ? reinterpret_cast<const DlBlendColorFilter*>(this)
+                           : nullptr;
   }
 
   const DlMatrixColorFilter* asAMatrixFilter() const {
-    return type_ == kMatrix
-               ? reinterpret_cast<const DlMatrixColorFilter*>(this)
-               : nullptr;
+    return type_ == kMatrix ? reinterpret_cast<const DlMatrixColorFilter*>(this)
+                            : nullptr;
   }
 
   const DlSrgbToLinearGammaColorFilter* asASrgbToLinearFilter() const {
@@ -88,8 +88,7 @@ class DlNoColorFilter final : public DlColorFilter {
 class DlBlendColorFilter final : public DlColorFilter {
  public:
   DlBlendColorFilter(SkColor color, SkBlendMode mode)
-      : DlColorFilter(kBlend), color_(color), mode_(mode) {
-  }
+      : DlColorFilter(kBlend), color_(color), mode_(mode) {}
   DlBlendColorFilter(const DlBlendColorFilter& filter)
       : DlBlendColorFilter(filter.color_, filter.mode_) {}
   DlBlendColorFilter(const DlBlendColorFilter* filter)
@@ -114,8 +113,7 @@ class DlBlendColorFilter final : public DlColorFilter {
 
 class DlMatrixColorFilter final : public DlColorFilter {
  public:
-  DlMatrixColorFilter(const float matrix[20])
-      : DlColorFilter(kMatrix) {
+  DlMatrixColorFilter(const float matrix[20]) : DlColorFilter(kMatrix) {
     memcpy(matrix_, &matrix, sizeof(matrix_));
   }
   DlMatrixColorFilter(const DlMatrixColorFilter& filter)
@@ -156,9 +154,7 @@ class DlSrgbToLinearGammaColorFilter final : public DlColorFilter {
     return true;
   }
 
-  sk_sp<SkColorFilter> sk_filter() const {
-    return sk_filter_;
-  }
+  sk_sp<SkColorFilter> sk_filter() const { return sk_filter_; }
 
  private:
   static const sk_sp<SkColorFilter> sk_filter_;

--- a/display_list/display_list_color_filter_unittests.cc
+++ b/display_list/display_list_color_filter_unittests.cc
@@ -1,0 +1,286 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/display_list/display_list_color_filter.h"
+#include "flutter/display_list/types.h"
+#include "gtest/gtest.h"
+
+namespace flutter {
+namespace testing {
+
+TEST(DisplayListColorFilter, FromSkiaNullFilter) {
+  std::shared_ptr<DlColorFilter> filter = DlColorFilter::From(nullptr);
+  ASSERT_EQ(filter, nullptr);
+}
+
+TEST(DisplayListColorFilter, FromSkiaBlendFilter) {
+  sk_sp<SkColorFilter> sk_filter = SkColorFilters::Blend(SK_ColorRED,
+                                                         SkBlendMode::kDstATop);
+  std::shared_ptr<DlColorFilter> filter = DlColorFilter::From(sk_filter);
+  DlBlendColorFilter dl_filter(SK_ColorRED, SkBlendMode::kDstATop);
+  ASSERT_EQ(filter->type(), DlColorFilter::kBlend);
+  ASSERT_NE(filter->asBlend(), nullptr);
+  ASSERT_EQ(filter->asMatrix(), nullptr);
+  ASSERT_EQ(*filter->asBlend(), dl_filter);
+  ASSERT_EQ(filter->asBlend()->color(), SK_ColorRED);
+  ASSERT_EQ(filter->asBlend()->mode(), SkBlendMode::kDstATop);
+}
+
+TEST(DisplayListColorFilter, FromSkiaMatrixFilter) {
+  float matrix[20] = {
+    1, 2, 3, 4, 5,       //
+    6, 7, 8, 9, 10,      //
+    11, 12, 13, 14, 15,  //
+    16, 17, 18, 19, 20,  //
+  };
+  sk_sp<SkColorFilter> sk_filter = SkColorFilters::Matrix(matrix);
+  std::shared_ptr<DlColorFilter> filter = DlColorFilter::From(sk_filter);
+  DlMatrixColorFilter dl_filter(matrix);
+  ASSERT_EQ(filter->type(), DlColorFilter::kMatrix);
+  ASSERT_EQ(filter->asBlend(), nullptr);
+  ASSERT_NE(filter->asMatrix(), nullptr);
+  ASSERT_EQ(*filter->asMatrix(), dl_filter);
+  const DlMatrixColorFilter* matrix_filter = filter->asMatrix();
+  for (int i = 0; i < 20; i++) {
+    ASSERT_EQ((*matrix_filter)[i], matrix[i]);
+  }
+}
+
+TEST(DisplayListColorFilter, FromSkiaSrgbToLinearFilter) {
+  sk_sp<SkColorFilter> sk_filter = SkColorFilters::SRGBToLinearGamma();
+  std::shared_ptr<DlColorFilter> filter = DlColorFilter::From(sk_filter);
+  ASSERT_EQ(filter->type(), DlColorFilter::kSrgbToLinearGamma);
+  ASSERT_EQ(filter->asBlend(), nullptr);
+  ASSERT_EQ(filter->asMatrix(), nullptr);
+}
+
+TEST(DisplayListColorFilter, FromSkiaLinearToSrgbFilter) {
+  sk_sp<SkColorFilter> sk_filter = SkColorFilters::LinearToSRGBGamma();
+  std::shared_ptr<DlColorFilter> filter = DlColorFilter::From(sk_filter);
+  ASSERT_EQ(filter->type(), DlColorFilter::kLinearToSrgbGamma);
+  ASSERT_EQ(filter->asBlend(), nullptr);
+  ASSERT_EQ(filter->asMatrix(), nullptr);
+}
+
+TEST(DisplayListColorFilter, FromSkiaUnrecognizedFilter) {
+  sk_sp<SkColorFilter> sk_inputA = SkColorFilters::Blend(SK_ColorRED, SkBlendMode::kOverlay);
+  sk_sp<SkColorFilter> sk_inputB = SkColorFilters::Blend(SK_ColorBLUE, SkBlendMode::kScreen);
+  sk_sp<SkColorFilter> sk_filter = SkColorFilters::Compose(sk_inputA, sk_inputB);
+  std::shared_ptr<DlColorFilter> filter = DlColorFilter::From(sk_filter);
+  ASSERT_EQ(filter->type(), DlColorFilter::kUnknown);
+  ASSERT_EQ(filter->asBlend(), nullptr);
+  ASSERT_EQ(filter->asMatrix(), nullptr);
+}
+
+TEST(DisplayListColorFilter, BlendConstructor) {
+  DlBlendColorFilter filter(SK_ColorRED, SkBlendMode::kDstATop);
+}
+
+TEST(DisplayListColorFilter, BlendShared) {
+  DlBlendColorFilter filter(SK_ColorRED, SkBlendMode::kDstATop);
+  ASSERT_EQ(*filter.shared(), filter);
+}
+
+TEST(DisplayListColorFilter, BlendAsBlend) {
+  DlBlendColorFilter filter = DlBlendColorFilter(SK_ColorRED, SkBlendMode::kDstATop);
+  ASSERT_NE(filter.asBlend(), nullptr);
+  ASSERT_EQ(filter.asBlend(), &filter);
+}
+
+TEST(DisplayListColorFilter, BlendContents) {
+  DlBlendColorFilter filter(SK_ColorRED, SkBlendMode::kDstATop);
+  ASSERT_EQ(filter.color(), SK_ColorRED);
+  ASSERT_EQ(filter.mode(), SkBlendMode::kDstATop);
+}
+
+TEST(DisplayListColorFilter, BlendEquals) {
+  DlBlendColorFilter filter1(SK_ColorRED, SkBlendMode::kDstATop);
+  DlBlendColorFilter filter2(SK_ColorRED, SkBlendMode::kDstATop);
+  ASSERT_TRUE(filter1 == filter2);
+  ASSERT_TRUE(filter2 == filter1);
+  ASSERT_FALSE(filter1 != filter2);
+  ASSERT_FALSE(filter2 != filter1);
+  ASSERT_EQ(filter1, filter2);
+}
+
+TEST(DisplayListColorFilter, BlendNotEquals) {
+  DlBlendColorFilter filter1(SK_ColorRED, SkBlendMode::kDstATop);
+  DlBlendColorFilter filter2(SK_ColorBLUE, SkBlendMode::kDstATop);
+  DlBlendColorFilter filter3(SK_ColorRED, SkBlendMode::kDstIn);
+  ASSERT_FALSE(filter1 == filter2);
+  ASSERT_FALSE(filter2 == filter1);
+  ASSERT_TRUE(filter1 != filter2);
+  ASSERT_TRUE(filter2 != filter1);
+  ASSERT_NE(filter1, filter2);
+  ASSERT_NE(filter2, filter3);
+  ASSERT_NE(filter3, filter1);
+}
+
+TEST(DisplayListColorFilter, MatrixConstructor) {
+  float matrix[20] = {
+    1, 2, 3, 4, 5,       //
+    6, 7, 8, 9, 10,      //
+    11, 12, 13, 14, 15,  //
+    16, 17, 18, 19, 20,  //
+  };
+  DlMatrixColorFilter filter(matrix);
+}
+
+TEST(DisplayListColorFilter, MatrixShared) {
+  float matrix[20] = {
+    1, 2, 3, 4, 5,       //
+    6, 7, 8, 9, 10,      //
+    11, 12, 13, 14, 15,  //
+    16, 17, 18, 19, 20,  //
+  };
+  DlMatrixColorFilter filter(matrix);
+  ASSERT_EQ(*filter.shared(), filter);
+}
+
+TEST(DisplayListColorFilter, MatrixAsMatrix) {
+  float matrix[20] = {
+    1, 2, 3, 4, 5,       //
+    6, 7, 8, 9, 10,      //
+    11, 12, 13, 14, 15,  //
+    16, 17, 18, 19, 20,  //
+  };
+  DlMatrixColorFilter filter(matrix);
+  ASSERT_NE(filter.asMatrix(), nullptr);
+  ASSERT_EQ(filter.asMatrix(), &filter);
+}
+
+TEST(DisplayListColorFilter, MatrixContents) {
+  float matrix[20] = {
+     1,  2,  3,  4,  5,  //
+     6,  7,  8,  9, 10,  //
+    11, 12, 13, 14, 15,  //
+    16, 17, 18, 19, 20,  //
+  };
+  DlMatrixColorFilter filter(matrix);
+
+  // Test deref operator []
+  for (int i = 0; i < 20; i++) {
+    ASSERT_EQ(filter[i], matrix[i]);
+  }
+
+  // Test get_matrix
+  float matrix2[20];
+  filter.get_matrix(matrix2);
+  for (int i = 0; i < 20; i++) {
+    ASSERT_EQ(matrix2[i], matrix[i]);
+  }
+
+  // Test perturbing original array does not affect filter
+  float original_value = matrix[4];
+  matrix[4] += 101;
+  ASSERT_EQ(filter[4], original_value);
+}
+
+TEST(DisplayListColorFilter, MatrixEquals) {
+  float matrix[20] = {
+    1, 2, 3, 4, 5,       //
+    6, 7, 8, 9, 10,      //
+    11, 12, 13, 14, 15,  //
+    16, 17, 18, 19, 20,  //
+  };
+  DlMatrixColorFilter filter1(matrix);
+  DlMatrixColorFilter filter2(matrix);
+  ASSERT_EQ(filter1, filter2);
+}
+
+TEST(DisplayListColorFilter, MatrixNotEquals) {
+  float matrix[20] = {
+    1, 2, 3, 4, 5,       //
+    6, 7, 8, 9, 10,      //
+    11, 12, 13, 14, 15,  //
+    16, 17, 18, 19, 20,  //
+  };
+  DlMatrixColorFilter filter1(matrix);
+  matrix[4] += 101;
+  DlMatrixColorFilter filter2(matrix);
+  ASSERT_NE(filter1, filter2);
+}
+
+TEST(DisplayListColorFilter, SrgbToLinearConstructor) {
+  DlSrgbToLinearGammaColorFilter filter;
+}
+
+TEST(DisplayListColorFilter, SrgbToLinearShared) {
+  DlSrgbToLinearGammaColorFilter filter;
+  ASSERT_EQ(*filter.shared(), filter);
+}
+
+TEST(DisplayListColorFilter, SrgbToLinearEquals) {
+  DlSrgbToLinearGammaColorFilter filter1;
+  DlSrgbToLinearGammaColorFilter filter2;
+  ASSERT_TRUE(filter1 == filter2);
+  ASSERT_TRUE(filter2 == filter1);
+  ASSERT_FALSE(filter1 != filter2);
+  ASSERT_FALSE(filter2 != filter1);
+  ASSERT_EQ(filter1, filter2);
+  ASSERT_EQ(filter1, *DlSrgbToLinearGammaColorFilter::instance);
+}
+
+TEST(DisplayListColorFilter, LinearToSrgbConstructor) {
+  DlLinearToSrgbGammaColorFilter filter;
+}
+
+TEST(DisplayListColorFilter, LinearToSrgbShared) {
+  DlLinearToSrgbGammaColorFilter filter;
+  ASSERT_EQ(*filter.shared(), filter);
+}
+
+TEST(DisplayListColorFilter, LinearToSrgbEquals) {
+  DlLinearToSrgbGammaColorFilter filter1;
+  DlLinearToSrgbGammaColorFilter filter2;
+  ASSERT_TRUE(filter1 == filter2);
+  ASSERT_TRUE(filter2 == filter1);
+  ASSERT_FALSE(filter1 != filter2);
+  ASSERT_FALSE(filter2 != filter1);
+  ASSERT_EQ(filter1, filter2);
+  ASSERT_EQ(filter1, *DlLinearToSrgbGammaColorFilter::instance);
+}
+
+TEST(DisplayListColorFilter, UnknownConstructor) {
+  DlUnknownColorFilter filter(SkColorFilters::LinearToSRGBGamma());
+}
+
+TEST(DisplayListColorFilter, UnknownShared) {
+  DlUnknownColorFilter filter(SkColorFilters::LinearToSRGBGamma());
+  ASSERT_EQ(*filter.shared(), filter);
+}
+
+TEST(DisplayListColorFilter, UnknownContents) {
+  sk_sp<SkColorFilter> sk_filter = SkColorFilters::LinearToSRGBGamma();
+  DlUnknownColorFilter filter(sk_filter);
+  ASSERT_EQ(sk_filter, filter.sk_filter());
+  ASSERT_EQ(sk_filter.get(), filter.sk_filter().get());
+}
+
+TEST(DisplayListColorFilter, UnknownEquals) {
+  sk_sp<SkColorFilter> sk_filter = SkColorFilters::LinearToSRGBGamma();
+  DlUnknownColorFilter filter1(sk_filter);
+  DlUnknownColorFilter filter2(sk_filter);
+  ASSERT_TRUE(filter1 == filter2);
+  ASSERT_TRUE(filter2 == filter1);
+  ASSERT_FALSE(filter1 != filter2);
+  ASSERT_FALSE(filter2 != filter1);
+  ASSERT_EQ(filter1, filter2);
+}
+
+TEST(DisplayListColorFilter, UnknownNotEquals) {
+  // Even though the filter is the same, it is a different instance
+  // and we cannot currently tell them apart because the Skia
+  // ColorFilter objects do not implement ==
+  DlUnknownColorFilter filter1(SkColorFilters::Blend(SK_ColorRED, SkBlendMode::kDstATop));
+  DlUnknownColorFilter filter2(SkColorFilters::Blend(SK_ColorRED, SkBlendMode::kDstATop));
+  ASSERT_TRUE(filter1 != filter2);
+  ASSERT_TRUE(filter2 != filter1);
+  ASSERT_FALSE(filter1 == filter2);
+  ASSERT_FALSE(filter2 == filter1);
+  ASSERT_NE(filter1, filter2);
+}
+
+}  // namespace testing
+}  // namespace flutter

--- a/display_list/display_list_color_filter_unittests.cc
+++ b/display_list/display_list_color_filter_unittests.cc
@@ -83,6 +83,7 @@ TEST(DisplayListColorFilter, BlendConstructor) {
 
 TEST(DisplayListColorFilter, BlendShared) {
   DlBlendColorFilter filter(SK_ColorRED, SkBlendMode::kDstATop);
+  ASSERT_NE(filter.shared().get(), &filter);
   ASSERT_EQ(*filter.shared(), filter);
 }
 
@@ -128,6 +129,7 @@ TEST(DisplayListColorFilter, MatrixConstructor) {
 
 TEST(DisplayListColorFilter, MatrixShared) {
   DlMatrixColorFilter filter(matrix);
+  ASSERT_NE(filter.shared().get(), &filter);
   ASSERT_EQ(*filter.shared(), filter);
 }
 
@@ -181,6 +183,7 @@ TEST(DisplayListColorFilter, SrgbToLinearConstructor) {
 
 TEST(DisplayListColorFilter, SrgbToLinearShared) {
   DlSrgbToLinearGammaColorFilter filter;
+  ASSERT_NE(filter.shared().get(), &filter);
   ASSERT_EQ(*filter.shared(), filter);
 }
 
@@ -201,6 +204,7 @@ TEST(DisplayListColorFilter, LinearToSrgbConstructor) {
 
 TEST(DisplayListColorFilter, LinearToSrgbShared) {
   DlLinearToSrgbGammaColorFilter filter;
+  ASSERT_NE(filter.shared().get(), &filter);
   ASSERT_EQ(*filter.shared(), filter);
 }
 
@@ -221,6 +225,7 @@ TEST(DisplayListColorFilter, UnknownConstructor) {
 
 TEST(DisplayListColorFilter, UnknownShared) {
   DlUnknownColorFilter filter(SkColorFilters::LinearToSRGBGamma());
+  ASSERT_NE(filter.shared().get(), &filter);
   ASSERT_EQ(*filter.shared(), filter);
 }
 

--- a/display_list/display_list_color_filter_unittests.cc
+++ b/display_list/display_list_color_filter_unittests.cc
@@ -9,14 +9,21 @@
 namespace flutter {
 namespace testing {
 
+static const float matrix[20] = {
+    1,  2,  3,  4,  5,   //
+    6,  7,  8,  9,  10,  //
+    11, 12, 13, 14, 15,  //
+    16, 17, 18, 19, 20,  //
+};
+
 TEST(DisplayListColorFilter, FromSkiaNullFilter) {
   std::shared_ptr<DlColorFilter> filter = DlColorFilter::From(nullptr);
   ASSERT_EQ(filter, nullptr);
 }
 
 TEST(DisplayListColorFilter, FromSkiaBlendFilter) {
-  sk_sp<SkColorFilter> sk_filter = SkColorFilters::Blend(SK_ColorRED,
-                                                         SkBlendMode::kDstATop);
+  sk_sp<SkColorFilter> sk_filter =
+      SkColorFilters::Blend(SK_ColorRED, SkBlendMode::kDstATop);
   std::shared_ptr<DlColorFilter> filter = DlColorFilter::From(sk_filter);
   DlBlendColorFilter dl_filter(SK_ColorRED, SkBlendMode::kDstATop);
   ASSERT_EQ(filter->type(), DlColorFilter::kBlend);
@@ -28,12 +35,6 @@ TEST(DisplayListColorFilter, FromSkiaBlendFilter) {
 }
 
 TEST(DisplayListColorFilter, FromSkiaMatrixFilter) {
-  float matrix[20] = {
-    1, 2, 3, 4, 5,       //
-    6, 7, 8, 9, 10,      //
-    11, 12, 13, 14, 15,  //
-    16, 17, 18, 19, 20,  //
-  };
   sk_sp<SkColorFilter> sk_filter = SkColorFilters::Matrix(matrix);
   std::shared_ptr<DlColorFilter> filter = DlColorFilter::From(sk_filter);
   DlMatrixColorFilter dl_filter(matrix);
@@ -64,9 +65,12 @@ TEST(DisplayListColorFilter, FromSkiaLinearToSrgbFilter) {
 }
 
 TEST(DisplayListColorFilter, FromSkiaUnrecognizedFilter) {
-  sk_sp<SkColorFilter> sk_inputA = SkColorFilters::Blend(SK_ColorRED, SkBlendMode::kOverlay);
-  sk_sp<SkColorFilter> sk_inputB = SkColorFilters::Blend(SK_ColorBLUE, SkBlendMode::kScreen);
-  sk_sp<SkColorFilter> sk_filter = SkColorFilters::Compose(sk_inputA, sk_inputB);
+  sk_sp<SkColorFilter> sk_inputA =
+      SkColorFilters::Blend(SK_ColorRED, SkBlendMode::kOverlay);
+  sk_sp<SkColorFilter> sk_inputB =
+      SkColorFilters::Blend(SK_ColorBLUE, SkBlendMode::kScreen);
+  sk_sp<SkColorFilter> sk_filter =
+      SkColorFilters::Compose(sk_inputA, sk_inputB);
   std::shared_ptr<DlColorFilter> filter = DlColorFilter::From(sk_filter);
   ASSERT_EQ(filter->type(), DlColorFilter::kUnknown);
   ASSERT_EQ(filter->asBlend(), nullptr);
@@ -83,7 +87,8 @@ TEST(DisplayListColorFilter, BlendShared) {
 }
 
 TEST(DisplayListColorFilter, BlendAsBlend) {
-  DlBlendColorFilter filter = DlBlendColorFilter(SK_ColorRED, SkBlendMode::kDstATop);
+  DlBlendColorFilter filter =
+      DlBlendColorFilter(SK_ColorRED, SkBlendMode::kDstATop);
   ASSERT_NE(filter.asBlend(), nullptr);
   ASSERT_EQ(filter.asBlend(), &filter);
 }
@@ -118,87 +123,55 @@ TEST(DisplayListColorFilter, BlendNotEquals) {
 }
 
 TEST(DisplayListColorFilter, MatrixConstructor) {
-  float matrix[20] = {
-    1, 2, 3, 4, 5,       //
-    6, 7, 8, 9, 10,      //
-    11, 12, 13, 14, 15,  //
-    16, 17, 18, 19, 20,  //
-  };
   DlMatrixColorFilter filter(matrix);
 }
 
 TEST(DisplayListColorFilter, MatrixShared) {
-  float matrix[20] = {
-    1, 2, 3, 4, 5,       //
-    6, 7, 8, 9, 10,      //
-    11, 12, 13, 14, 15,  //
-    16, 17, 18, 19, 20,  //
-  };
   DlMatrixColorFilter filter(matrix);
   ASSERT_EQ(*filter.shared(), filter);
 }
 
 TEST(DisplayListColorFilter, MatrixAsMatrix) {
-  float matrix[20] = {
-    1, 2, 3, 4, 5,       //
-    6, 7, 8, 9, 10,      //
-    11, 12, 13, 14, 15,  //
-    16, 17, 18, 19, 20,  //
-  };
   DlMatrixColorFilter filter(matrix);
   ASSERT_NE(filter.asMatrix(), nullptr);
   ASSERT_EQ(filter.asMatrix(), &filter);
 }
 
 TEST(DisplayListColorFilter, MatrixContents) {
-  float matrix[20] = {
-     1,  2,  3,  4,  5,  //
-     6,  7,  8,  9, 10,  //
-    11, 12, 13, 14, 15,  //
-    16, 17, 18, 19, 20,  //
-  };
-  DlMatrixColorFilter filter(matrix);
+  float matrix_[20];
+  memcpy(matrix_, matrix, sizeof(matrix_));
+  DlMatrixColorFilter filter(matrix_);
 
   // Test deref operator []
   for (int i = 0; i < 20; i++) {
-    ASSERT_EQ(filter[i], matrix[i]);
+    ASSERT_EQ(filter[i], matrix_[i]);
   }
 
   // Test get_matrix
   float matrix2[20];
   filter.get_matrix(matrix2);
   for (int i = 0; i < 20; i++) {
-    ASSERT_EQ(matrix2[i], matrix[i]);
+    ASSERT_EQ(matrix2[i], matrix_[i]);
   }
 
   // Test perturbing original array does not affect filter
-  float original_value = matrix[4];
-  matrix[4] += 101;
+  float original_value = matrix_[4];
+  matrix_[4] += 101;
   ASSERT_EQ(filter[4], original_value);
 }
 
 TEST(DisplayListColorFilter, MatrixEquals) {
-  float matrix[20] = {
-    1, 2, 3, 4, 5,       //
-    6, 7, 8, 9, 10,      //
-    11, 12, 13, 14, 15,  //
-    16, 17, 18, 19, 20,  //
-  };
   DlMatrixColorFilter filter1(matrix);
   DlMatrixColorFilter filter2(matrix);
   ASSERT_EQ(filter1, filter2);
 }
 
 TEST(DisplayListColorFilter, MatrixNotEquals) {
-  float matrix[20] = {
-    1, 2, 3, 4, 5,       //
-    6, 7, 8, 9, 10,      //
-    11, 12, 13, 14, 15,  //
-    16, 17, 18, 19, 20,  //
-  };
-  DlMatrixColorFilter filter1(matrix);
-  matrix[4] += 101;
-  DlMatrixColorFilter filter2(matrix);
+  float matrix_[20];
+  memcpy(matrix_, matrix, sizeof(matrix_));
+  DlMatrixColorFilter filter1(matrix_);
+  matrix_[4] += 101;
+  DlMatrixColorFilter filter2(matrix_);
   ASSERT_NE(filter1, filter2);
 }
 
@@ -273,8 +246,10 @@ TEST(DisplayListColorFilter, UnknownNotEquals) {
   // Even though the filter is the same, it is a different instance
   // and we cannot currently tell them apart because the Skia
   // ColorFilter objects do not implement ==
-  DlUnknownColorFilter filter1(SkColorFilters::Blend(SK_ColorRED, SkBlendMode::kDstATop));
-  DlUnknownColorFilter filter2(SkColorFilters::Blend(SK_ColorRED, SkBlendMode::kDstATop));
+  DlUnknownColorFilter filter1(
+      SkColorFilters::Blend(SK_ColorRED, SkBlendMode::kDstATop));
+  DlUnknownColorFilter filter2(
+      SkColorFilters::Blend(SK_ColorRED, SkBlendMode::kDstATop));
   ASSERT_TRUE(filter1 != filter2);
   ASSERT_TRUE(filter2 != filter1);
   ASSERT_FALSE(filter1 == filter2);

--- a/display_list/display_list_dispatcher.h
+++ b/display_list/display_list_dispatcher.h
@@ -6,6 +6,7 @@
 #define FLUTTER_DISPLAY_LIST_DISPLAY_LIST_DISPATCHER_H_
 
 #include "flutter/display_list/display_list.h"
+#include "flutter/display_list/display_list_color_filter.h"
 
 namespace flutter {
 
@@ -36,7 +37,7 @@ class Dispatcher {
   virtual void setStrokeCap(SkPaint::Cap cap) = 0;
   virtual void setStrokeJoin(SkPaint::Join join) = 0;
   virtual void setShader(sk_sp<SkShader> shader) = 0;
-  virtual void setColorFilter(sk_sp<SkColorFilter> filter) = 0;
+  virtual void setColorFilter(const DlColorFilter* filter) = 0;
   // setInvertColors does not exist in SkPaint, but is a quick way to set
   // a ColorFilter that inverts the rgb values of all rendered colors.
   // It is not reset by |setColorFilter|, but instead composed with that

--- a/display_list/display_list_ops.h
+++ b/display_list/display_list_ops.h
@@ -187,7 +187,7 @@ struct ClearColorFilterOp final : DLOp {
   ClearColorFilterOp() {}
 
   void dispatch(Dispatcher& dispatcher) const {
-    dispatcher.setColorFilter(&DlNoColorFilter::instance);
+    dispatcher.setColorFilter(nullptr);
   }
 };
 
@@ -197,20 +197,22 @@ struct SetColorFilterOp final : DLOp {
   SetColorFilterOp() {}
 
   void dispatch(Dispatcher& dispatcher) const {
-    dispatcher.setColorFilter(reinterpret_cast<const DlColorFilter*>(this + 1));
+    const DlColorFilter* filter =
+        reinterpret_cast<const DlColorFilter*>(this + 1);
+    dispatcher.setColorFilter(filter);
   }
 };
 
 struct SetSkColorFilterOp final : DLOp {
   static const auto kType = DisplayListOpType::kSetSkColorFilter;
 
-  SetSkColorFilterOp(sk_sp<SkColorFilter> filter)
-      : filter(std::make_unique<DlUnknownColorFilter>(filter)) {}
+  SetSkColorFilterOp(sk_sp<SkColorFilter> filter) : filter(filter) {}
 
-  std::unique_ptr<const DlUnknownColorFilter> filter;
+  sk_sp<SkColorFilter> filter;
 
   void dispatch(Dispatcher& dispatcher) const {
-    dispatcher.setColorFilter(filter.get());
+    DlUnknownColorFilter dl_filter(filter);
+    dispatcher.setColorFilter(&dl_filter);
   }
 };
 

--- a/display_list/display_list_ops.h
+++ b/display_list/display_list_ops.h
@@ -177,10 +177,42 @@ struct SetBlendModeOp final : DLOp {
 DEFINE_SET_CLEAR_SKREF_OP(Blender, blender)
 DEFINE_SET_CLEAR_SKREF_OP(Shader, shader)
 DEFINE_SET_CLEAR_SKREF_OP(ImageFilter, filter)
-DEFINE_SET_CLEAR_SKREF_OP(ColorFilter, filter)
 DEFINE_SET_CLEAR_SKREF_OP(MaskFilter, filter)
 DEFINE_SET_CLEAR_SKREF_OP(PathEffect, effect)
 #undef DEFINE_SET_CLEAR_SKREF_OP
+
+struct ClearColorFilterOp final : DLOp {
+  static const auto kType = DisplayListOpType::kClearColorFilter;
+
+  ClearColorFilterOp() {}
+
+  void dispatch(Dispatcher& dispatcher) const {
+    dispatcher.setColorFilter(&DlNoColorFilter::instance);
+  }
+};
+
+struct SetColorFilterOp final : DLOp {
+  static const auto kType = DisplayListOpType::kSetColorFilter;
+
+  SetColorFilterOp() {}
+
+  void dispatch(Dispatcher& dispatcher) const {
+    dispatcher.setColorFilter(reinterpret_cast<const DlColorFilter*>(this + 1));
+  }
+};
+
+struct SetSkColorFilterOp final : DLOp {
+  static const auto kType = DisplayListOpType::kSetSkColorFilter;
+
+  SetSkColorFilterOp(sk_sp<SkColorFilter> filter)
+      : filter(std::make_unique<DlUnknownColorFilter>(filter)) {}
+
+  std::unique_ptr<const DlUnknownColorFilter> filter;
+
+  void dispatch(Dispatcher& dispatcher) const {
+    dispatcher.setColorFilter(filter.get());
+  }
+};
 
 // 4 byte header + 4 byte payload packs into minimum 8 bytes
 // Note that the "blur style" is packed into the OpType to prevent

--- a/display_list/display_list_utils.cc
+++ b/display_list/display_list_utils.cc
@@ -80,7 +80,7 @@ void SkPaintDispatchHelper::setImageFilter(sk_sp<SkImageFilter> filter) {
   paint_.setImageFilter(filter);
 }
 void SkPaintDispatchHelper::setColorFilter(const DlColorFilter* filter) {
-  color_filter_ = filter->shared();
+  color_filter_ = filter ? filter->shared() : nullptr;
   paint_.setColorFilter(makeColorFilter());
 }
 void SkPaintDispatchHelper::setPathEffect(sk_sp<SkPathEffect> effect) {
@@ -98,12 +98,12 @@ sk_sp<SkColorFilter> SkPaintDispatchHelper::makeColorFilter() const {
   if (!invert_colors_) {
     return color_filter_ ? color_filter_->sk_filter() : nullptr;
   }
+  sk_sp<SkColorFilter> invert_filter =
+      SkColorFilters::Matrix(invert_color_matrix);
   if (color_filter_) {
-    sk_sp<SkColorFilter> invert_filter =
-        SkColorFilters::Matrix(invert_color_matrix);
-    return invert_filter->makeComposed(color_filter_->sk_filter());
+    invert_filter = invert_filter->makeComposed(color_filter_->sk_filter());
   }
-  return SkColorFilters::Matrix(invert_color_matrix);
+  return invert_filter;
 }
 
 void SkMatrixDispatchHelper::translate(SkScalar tx, SkScalar ty) {
@@ -267,7 +267,7 @@ void DisplayListBoundsCalculator::setImageFilter(sk_sp<SkImageFilter> filter) {
   image_filter_ = std::move(filter);
 }
 void DisplayListBoundsCalculator::setColorFilter(const DlColorFilter* filter) {
-  color_filter_ = filter->shared();
+  color_filter_ = filter ? filter->shared() : nullptr;
 }
 void DisplayListBoundsCalculator::setPathEffect(sk_sp<SkPathEffect> effect) {
   path_effect_ = std::move(effect);

--- a/display_list/display_list_utils.cc
+++ b/display_list/display_list_utils.cc
@@ -94,8 +94,7 @@ void SkPaintDispatchHelper::setMaskBlurFilter(SkBlurStyle style,
   paint_.setMaskFilter(SkMaskFilter::MakeBlur(style, sigma));
 }
 
-sk_sp<SkColorFilter> SkPaintDispatchHelper::makeColorFilter()
-    const {
+sk_sp<SkColorFilter> SkPaintDispatchHelper::makeColorFilter() const {
   if (!invert_colors_) {
     return color_filter_ ? color_filter_->sk_filter() : nullptr;
   }

--- a/display_list/display_list_utils.cc
+++ b/display_list/display_list_utils.cc
@@ -79,8 +79,8 @@ void SkPaintDispatchHelper::setShader(sk_sp<SkShader> shader) {
 void SkPaintDispatchHelper::setImageFilter(sk_sp<SkImageFilter> filter) {
   paint_.setImageFilter(filter);
 }
-void SkPaintDispatchHelper::setColorFilter(sk_sp<SkColorFilter> filter) {
-  color_filter_ = filter;
+void SkPaintDispatchHelper::setColorFilter(const DlColorFilter* filter) {
+  color_filter_ = filter->shared();
   paint_.setColorFilter(makeColorFilter());
 }
 void SkPaintDispatchHelper::setPathEffect(sk_sp<SkPathEffect> effect) {
@@ -94,16 +94,17 @@ void SkPaintDispatchHelper::setMaskBlurFilter(SkBlurStyle style,
   paint_.setMaskFilter(SkMaskFilter::MakeBlur(style, sigma));
 }
 
-sk_sp<SkColorFilter> SkPaintDispatchHelper::makeColorFilter() {
+sk_sp<SkColorFilter> SkPaintDispatchHelper::makeColorFilter()
+    const {
   if (!invert_colors_) {
-    return color_filter_;
+    return color_filter_ ? color_filter_->sk_filter() : nullptr;
   }
-  sk_sp<SkColorFilter> invert_filter =
-      SkColorFilters::Matrix(invert_color_matrix);
   if (color_filter_) {
-    invert_filter = invert_filter->makeComposed(color_filter_);
+    sk_sp<SkColorFilter> invert_filter =
+        SkColorFilters::Matrix(invert_color_matrix);
+    return invert_filter->makeComposed(color_filter_->sk_filter());
   }
-  return invert_filter;
+  return SkColorFilters::Matrix(invert_color_matrix);
 }
 
 void SkMatrixDispatchHelper::translate(SkScalar tx, SkScalar ty) {
@@ -266,8 +267,8 @@ void DisplayListBoundsCalculator::setBlender(sk_sp<SkBlender> blender) {
 void DisplayListBoundsCalculator::setImageFilter(sk_sp<SkImageFilter> filter) {
   image_filter_ = std::move(filter);
 }
-void DisplayListBoundsCalculator::setColorFilter(sk_sp<SkColorFilter> filter) {
-  color_filter_ = std::move(filter);
+void DisplayListBoundsCalculator::setColorFilter(const DlColorFilter* filter) {
+  color_filter_ = filter->shared();
 }
 void DisplayListBoundsCalculator::setPathEffect(sk_sp<SkPathEffect> effect) {
   path_effect_ = std::move(effect);
@@ -657,8 +658,7 @@ bool DisplayListBoundsCalculator::paint_nops_on_transparency() {
   // save layer untouched out to the edge of the output surface.
   // This test assumes that the blend mode checked down below will
   // NOP on transparent black.
-  if (color_filter_ &&
-      color_filter_->filterColor(SK_ColorTRANSPARENT) != SK_ColorTRANSPARENT) {
+  if (color_filter_ && color_filter_->modifies_transparent_black()) {
     return false;
   }
 

--- a/display_list/display_list_utils.h
+++ b/display_list/display_list_utils.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_FLOW_DISPLAY_LIST_UTILS_H_
-#define FLUTTER_FLOW_DISPLAY_LIST_UTILS_H_
+#ifndef FLUTTER_DISPLAY_LIST_DISPLAY_LIST_UTILS_H_
+#define FLUTTER_DISPLAY_LIST_DISPLAY_LIST_UTILS_H_
 
 #include <optional>
 
@@ -56,7 +56,7 @@ class IgnoreAttributeDispatchHelper : public virtual Dispatcher {
   void setBlender(sk_sp<SkBlender> blender) override {}
   void setShader(sk_sp<SkShader> shader) override {}
   void setImageFilter(sk_sp<SkImageFilter> filter) override {}
-  void setColorFilter(sk_sp<SkColorFilter> filter) override {}
+  void setColorFilter(const DlColorFilter* filter) override {}
   void setPathEffect(sk_sp<SkPathEffect> effect) override {}
   void setMaskFilter(sk_sp<SkMaskFilter> filter) override {}
   void setMaskBlurFilter(SkBlurStyle style, SkScalar sigma) override {}
@@ -179,7 +179,7 @@ class SkPaintDispatchHelper : public virtual Dispatcher {
   void setStrokeCap(SkPaint::Cap cap) override;
   void setStrokeJoin(SkPaint::Join join) override;
   void setShader(sk_sp<SkShader> shader) override;
-  void setColorFilter(sk_sp<SkColorFilter> filter) override;
+  void setColorFilter(const DlColorFilter* filter) override;
   void setInvertColors(bool invert) override;
   void setBlendMode(SkBlendMode mode) override;
   void setBlender(sk_sp<SkBlender> blender) override;
@@ -209,9 +209,9 @@ class SkPaintDispatchHelper : public virtual Dispatcher {
  private:
   SkPaint paint_;
   bool invert_colors_ = false;
-  sk_sp<SkColorFilter> color_filter_;
+  std::shared_ptr<const DlColorFilter> color_filter_;
 
-  sk_sp<SkColorFilter> makeColorFilter();
+  sk_sp<SkColorFilter> makeColorFilter() const;
 
   struct SaveInfo {
     SaveInfo(SkScalar opacity) : opacity(opacity) {}
@@ -400,7 +400,7 @@ class DisplayListBoundsCalculator final
   void setBlendMode(SkBlendMode mode) override;
   void setBlender(sk_sp<SkBlender> blender) override;
   void setImageFilter(sk_sp<SkImageFilter> filter) override;
-  void setColorFilter(sk_sp<SkColorFilter> filter) override;
+  void setColorFilter(const DlColorFilter* filter) override;
   void setPathEffect(sk_sp<SkPathEffect> effect) override;
   void setMaskFilter(sk_sp<SkMaskFilter> filter) override;
   void setMaskBlurFilter(SkBlurStyle style, SkScalar sigma) override;
@@ -571,7 +571,7 @@ class DisplayListBoundsCalculator final
   static constexpr SkScalar kMinStrokeWidth = 0.01;
 
   std::optional<SkBlendMode> blend_mode_ = SkBlendMode::kSrcOver;
-  sk_sp<SkColorFilter> color_filter_;
+  std::shared_ptr<const DlColorFilter> color_filter_;
 
   SkScalar half_stroke_width_ = kMinStrokeWidth;
   SkScalar miter_limit_ = 4.0;
@@ -616,4 +616,4 @@ class DisplayListBoundsCalculator final
 
 }  // namespace flutter
 
-#endif  // FLUTTER_FLOW_DISPLAY_LIST_UTILS_H_
+#endif  // FLUTTER_DISPLAY_LIST_DISPLAY_LIST_UTILS_H_

--- a/lib/ui/compositing/scene_builder.cc
+++ b/lib/ui/compositing/scene_builder.cc
@@ -176,8 +176,8 @@ void SceneBuilder::pushOpacity(Dart_Handle layer_handle,
 void SceneBuilder::pushColorFilter(Dart_Handle layer_handle,
                                    const ColorFilter* color_filter,
                                    fml::RefPtr<EngineLayer> oldLayer) {
-  auto layer =
-      std::make_shared<flutter::ColorFilterLayer>(color_filter->filter());
+  auto layer = std::make_shared<flutter::ColorFilterLayer>(
+      color_filter->filter()->sk_filter());
   PushLayer(layer);
   EngineLayer::MakeRetained(layer_handle, layer);
 

--- a/lib/ui/painting/color_filter.cc
+++ b/lib/ui/painting/color_filter.cc
@@ -40,33 +40,31 @@ fml::RefPtr<ColorFilter> ColorFilter::Create() {
 }
 
 void ColorFilter::initMode(int color, int blend_mode) {
-  filter_ = SkColorFilters::Blend(static_cast<SkColor>(color),
-                                  static_cast<SkBlendMode>(blend_mode));
-}
-
-sk_sp<SkColorFilter> ColorFilter::MakeColorMatrixFilter255(
-    const float array[20]) {
-  float tmp[20];
-  memcpy(tmp, array, sizeof(tmp));
-  tmp[4] *= 1.0f / 255;
-  tmp[9] *= 1.0f / 255;
-  tmp[14] *= 1.0f / 255;
-  tmp[19] *= 1.0f / 255;
-  return SkColorFilters::Matrix(tmp);
+  filter_.reset(new DlBlendColorFilter(static_cast<SkColor>(color),
+                                       static_cast<SkBlendMode>(blend_mode)));
 }
 
 void ColorFilter::initMatrix(const tonic::Float32List& color_matrix) {
   FML_CHECK(color_matrix.num_elements() == 20);
 
-  filter_ = MakeColorMatrixFilter255(color_matrix.data());
+  // Flutter still defines the matrix to be biased by 255 in the last column
+  // (translate). skia is normalized, treating the last column as 0...1, so we
+  // post-scale here before calling the skia factory.
+  float matrix[20];
+  memcpy(matrix, color_matrix.data(), sizeof(matrix));
+  matrix[4] *= 1.0f / 255;
+  matrix[9] *= 1.0f / 255;
+  matrix[14] *= 1.0f / 255;
+  matrix[19] *= 1.0f / 255;
+  filter_.reset(new DlMatrixColorFilter(matrix));
 }
 
 void ColorFilter::initLinearToSrgbGamma() {
-  filter_ = SkColorFilters::LinearToSRGBGamma();
+  filter_.reset(&DlLinearToSrgbGammaColorFilter::instance);
 }
 
 void ColorFilter::initSrgbToLinearGamma() {
-  filter_ = SkColorFilters::SRGBToLinearGamma();
+  filter_.reset(&DlSrgbToLinearGammaColorFilter::instance);
 }
 
 ColorFilter::~ColorFilter() = default;

--- a/lib/ui/painting/color_filter.cc
+++ b/lib/ui/painting/color_filter.cc
@@ -40,8 +40,8 @@ fml::RefPtr<ColorFilter> ColorFilter::Create() {
 }
 
 void ColorFilter::initMode(int color, int blend_mode) {
-  filter_.reset(new DlBlendColorFilter(static_cast<SkColor>(color),
-                                       static_cast<SkBlendMode>(blend_mode)));
+  filter_ = std::make_shared<DlBlendColorFilter>(
+      static_cast<SkColor>(color), static_cast<SkBlendMode>(blend_mode));
 }
 
 void ColorFilter::initMatrix(const tonic::Float32List& color_matrix) {
@@ -56,15 +56,15 @@ void ColorFilter::initMatrix(const tonic::Float32List& color_matrix) {
   matrix[9] *= 1.0f / 255;
   matrix[14] *= 1.0f / 255;
   matrix[19] *= 1.0f / 255;
-  filter_.reset(new DlMatrixColorFilter(matrix));
+  filter_ = std::make_shared<DlMatrixColorFilter>(matrix);
 }
 
 void ColorFilter::initLinearToSrgbGamma() {
-  filter_.reset(&DlLinearToSrgbGammaColorFilter::instance);
+  filter_ = DlLinearToSrgbGammaColorFilter::instance;
 }
 
 void ColorFilter::initSrgbToLinearGamma() {
-  filter_.reset(&DlSrgbToLinearGammaColorFilter::instance);
+  filter_ = DlSrgbToLinearGammaColorFilter::instance;
 }
 
 ColorFilter::~ColorFilter() = default;

--- a/lib/ui/painting/color_filter.h
+++ b/lib/ui/painting/color_filter.h
@@ -5,10 +5,10 @@
 #ifndef FLUTTER_LIB_UI_COLOR_FILTER_H_
 #define FLUTTER_LIB_UI_COLOR_FILTER_H_
 
+#include "flutter/display_list/display_list_color_filter.h"
 #include "flutter/lib/ui/dart_wrapper.h"
 #include "third_party/skia/include/core/SkColorFilter.h"
 #include "third_party/tonic/typed_data/typed_list.h"
-#include "flutter/display_list/display_list_color_filter.h"
 
 using tonic::DartPersistentValue;
 

--- a/lib/ui/painting/color_filter.h
+++ b/lib/ui/painting/color_filter.h
@@ -35,7 +35,7 @@ class ColorFilter : public RefCountedDartWrappable<ColorFilter> {
 
   ~ColorFilter() override;
 
-  const DlColorFilter* filter() const { return filter_.get(); }
+  std::shared_ptr<const DlColorFilter> filter() const { return filter_; }
 
   static void RegisterNatives(tonic::DartLibraryNatives* natives);
 

--- a/lib/ui/painting/color_filter.h
+++ b/lib/ui/painting/color_filter.h
@@ -8,6 +8,7 @@
 #include "flutter/lib/ui/dart_wrapper.h"
 #include "third_party/skia/include/core/SkColorFilter.h"
 #include "third_party/tonic/typed_data/typed_list.h"
+#include "flutter/display_list/display_list_color_filter.h"
 
 using tonic::DartPersistentValue;
 
@@ -27,11 +28,6 @@ class ColorFilter : public RefCountedDartWrappable<ColorFilter> {
  public:
   static fml::RefPtr<ColorFilter> Create();
 
-  // Flutter still defines the matrix to be biased by 255 in the last column
-  // (translate). skia is normalized, treating the last column as 0...1, so we
-  // post-scale here before calling the skia factory.
-  static sk_sp<SkColorFilter> MakeColorMatrixFilter255(const float array[20]);
-
   void initMode(int color, int blend_mode);
   void initMatrix(const tonic::Float32List& color_matrix);
   void initSrgbToLinearGamma();
@@ -39,12 +35,12 @@ class ColorFilter : public RefCountedDartWrappable<ColorFilter> {
 
   ~ColorFilter() override;
 
-  sk_sp<SkColorFilter> filter() const { return filter_; }
+  const DlColorFilter* filter() const { return filter_.get(); }
 
   static void RegisterNatives(tonic::DartLibraryNatives* natives);
 
  private:
-  sk_sp<SkColorFilter> filter_;
+  std::shared_ptr<const DlColorFilter> filter_;
 };
 
 }  // namespace flutter

--- a/lib/ui/painting/image_filter.cc
+++ b/lib/ui/painting/image_filter.cc
@@ -92,7 +92,7 @@ void ImageFilter::initMatrix(const tonic::Float64List& matrix4,
 
 void ImageFilter::initColorFilter(ColorFilter* colorFilter) {
   filter_ = SkImageFilters::ColorFilter(
-      colorFilter ? colorFilter->filter() : nullptr, nullptr);
+      colorFilter ? colorFilter->filter()->sk_filter() : nullptr, nullptr);
 }
 
 void ImageFilter::initComposeFilter(ImageFilter* outer, ImageFilter* inner) {

--- a/lib/ui/painting/paint.cc
+++ b/lib/ui/painting/paint.cc
@@ -105,7 +105,7 @@ const SkPaint* Paint::paint(SkPaint& paint) const {
     if (!Dart_IsNull(color_filter)) {
       ColorFilter* decoded_color_filter =
           tonic::DartConverter<ColorFilter*>::FromDart(color_filter);
-      paint.setColorFilter(decoded_color_filter->filter());
+      paint.setColorFilter(decoded_color_filter->filter()->sk_filter());
     }
 
     Dart_Handle image_filter = values[kImageFilterIndex];
@@ -157,7 +157,7 @@ const SkPaint* Paint::paint(SkPaint& paint) const {
 
   if (uint_data[kInvertColorIndex]) {
     sk_sp<SkColorFilter> invert_filter =
-        ColorFilter::MakeColorMatrixFilter255(invert_colors);
+        SkColorFilters::Matrix(invert_colors);
     sk_sp<SkColorFilter> current_filter = paint.refColorFilter();
     if (current_filter) {
       invert_filter = invert_filter->makeComposed(current_filter);

--- a/lib/ui/painting/paint.cc
+++ b/lib/ui/painting/paint.cc
@@ -234,7 +234,7 @@ bool Paint::sync_to(DisplayListBuilder* builder,
       } else {
         ColorFilter* decoded_color_filter =
             tonic::DartConverter<ColorFilter*>::FromDart(color_filter);
-        builder->setColorFilter(decoded_color_filter->filter());
+        builder->setColorFilter(decoded_color_filter->filter().get());
       }
     }
 

--- a/lib/ui/painting/paint.cc
+++ b/lib/ui/painting/paint.cc
@@ -156,8 +156,7 @@ const SkPaint* Paint::paint(SkPaint& paint) const {
   }
 
   if (uint_data[kInvertColorIndex]) {
-    sk_sp<SkColorFilter> invert_filter =
-        SkColorFilters::Matrix(invert_colors);
+    sk_sp<SkColorFilter> invert_filter = SkColorFilters::Matrix(invert_colors);
     sk_sp<SkColorFilter> current_filter = paint.refColorFilter();
     if (current_filter) {
       invert_filter = invert_filter->makeComposed(current_filter);


### PR DESCRIPTION
This PR creates an inspectable object for DisplayLists to store ColorFilters. These objects can also be stored inline in the DisplayList buffer of records without requiring a dangling pointer that needs to be searched and freed when a DL is disposed.

The class can implement any of the ui.ColorFilter objects used in Dart ui code, and can recapture any of those ColorFilter types from an SkColorFilter as well for when we need to recapture rendering ops from code that only speaks to an SkCanvas (for the time being just the Paragraph code).

This PR can be compared and contrasted to [the previous PR ](https://github.com/flutter/engine/pull/31230)which accomplished this objective by creating a number of different DL records and Dispatcher.setFooColorFilter(args) methods. It feels a bit simpler to have these DlColorFilter objects instead of the plethora of dispatch methods. This PR also provides a ready storage format for keeping a shared DlColorFilter* reference where needed.