### PR TITLE
[iOS] Fixes state restoration not work

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterRestorationPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterRestorationPluginTest.mm
@@ -9,6 +9,8 @@
 
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterChannels.h"
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterMacros.h"
+#import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h"
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h"
 
 FLUTTER_ASSERT_ARC
 
@@ -35,6 +37,33 @@ FLUTTER_ASSERT_ARC
 }
 
 #pragma mark - Tests
+
+- (void)testRestoratonViewControllerEncodeAndDecode {
+  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"test"
+                                                      project:nil
+                                       allowHeadlessExecution:YES
+                                           restorationEnabled:YES];
+  [engine run];
+  FlutterViewController* flutterViewController =
+      [[FlutterViewController alloc] initWithEngine:engine nibName:nil bundle:nil];
+  FlutterRestorationPlugin* restorationPlugin = flutterViewController.restorationPlugin;
+
+  NSData* data = [@"testrestortiondata" dataUsingEncoding:NSUTF8StringEncoding];
+  [restorationPlugin setRestorationData:data];
+
+  NSKeyedArchiver* archiver = [[NSKeyedArchiver alloc] initRequiringSecureCoding:YES];
+  [flutterViewController encodeRestorableStateWithCoder:archiver];
+
+  XCTAssertEqual([restorationPlugin restorationData], archiver.encodedData);
+
+  [restorationPlugin setRestorationData:nil];
+
+  NSKeyedUnarchiver* unarchiver =
+      [[NSKeyedUnarchiver alloc] initForReadingWithData:archiver.encodedData];
+  [flutterViewController decodeRestorableStateWithCoder:unarchiver];
+
+  XCTAssertEqual([restorationPlugin restorationData], archiver.encodedData);
+}
 
 - (void)testRestorationEnabledWaitsForData {
   FlutterRestorationPlugin* restorationPlugin =

--- a/shell/platform/darwin/ios/framework/Source/FlutterRestorationPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterRestorationPluginTest.mm
@@ -54,15 +54,14 @@ FLUTTER_ASSERT_ARC
   NSKeyedArchiver* archiver = [[NSKeyedArchiver alloc] initRequiringSecureCoding:YES];
   [flutterViewController encodeRestorableStateWithCoder:archiver];
 
-  XCTAssertEqual([restorationPlugin restorationData], archiver.encodedData);
-
   [restorationPlugin setRestorationData:nil];
 
   NSKeyedUnarchiver* unarchiver =
       [[NSKeyedUnarchiver alloc] initForReadingWithData:archiver.encodedData];
   [flutterViewController decodeRestorableStateWithCoder:unarchiver];
 
-  XCTAssertEqual([restorationPlugin restorationData], archiver.encodedData);
+  XCTAssert([[restorationPlugin restorationData] isEqualToData:data],
+            "Restoration state data must be equal");
 }
 
 - (void)testRestorationEnabledWaitsForData {

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -32,6 +32,8 @@
 static constexpr int kMicrosecondsPerSecond = 1000 * 1000;
 static constexpr CGFloat kScrollViewContentSize = 2.0;
 
+static NSString* const kFlutterRestorationStateAppData = @"FlutterRestorationStateAppData";
+
 NSNotificationName const FlutterSemanticsUpdateNotification = @"FlutterSemanticsUpdate";
 NSNotificationName const FlutterViewControllerWillDealloc = @"FlutterViewControllerWillDealloc";
 NSNotificationName const FlutterViewControllerHideHomeIndicator =
@@ -1811,12 +1813,17 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 
 - (void)encodeRestorableStateWithCoder:(NSCoder*)coder {
   NSData* restorationData = [[_engine.get() restorationPlugin] restorationData];
-  [coder encodeDataObject:restorationData];
+  [coder encodeBytes:(const unsigned char*)restorationData.bytes
+              length:restorationData.length
+              forKey:kFlutterRestorationStateAppData];
   [super encodeRestorableStateWithCoder:coder];
 }
 
 - (void)decodeRestorableStateWithCoder:(NSCoder*)coder {
-  NSData* restorationData = [coder decodeDataObject];
+  NSUInteger restorationDataLength;
+  const unsigned char* restorationBytes = [coder decodeBytesForKey:kFlutterRestorationStateAppData
+                                                    returnedLength:&restorationDataLength];
+  NSData* restorationData = [NSData dataWithBytes:restorationBytes length:restorationDataLength];
   [[_engine.get() restorationPlugin] setRestorationData:restorationData];
 }
 


### PR DESCRIPTION
Actually, the `coder` of `decodeRestorableStateWithCoder` in `FlutterViewController` seems is not support to use `encode/decodeDataObject`, it would throw exception. So we changed to bytes encoded.

```
Exception occurred restoring state value for key '$0' was of unexpected class 'NSMutableData' (0x1db4082a8) [/System/Library/Frameworks/CoreFoundation.framework].
Allowed classes are:
 {(
)}
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
