### PR TITLE
Make sure the secondary vsync callback is called after the vsync callback

### DIFF
--- a/shell/common/fixtures/shell_test.dart
+++ b/shell/common/fixtures/shell_test.dart
@@ -264,7 +264,7 @@ void canReceiveArgumentsWhenEngineSpawn(List<String> args) {
 }
 
 @pragma('vm:entry-point')
-void canScheduleFrameFromPlatform() {
+void onBeginFrameWithNotifyNativeMain() {
   PlatformDispatcher.instance.onBeginFrame = (Duration beginTime) {
     nativeOnBeginFrame(beginTime.inMicroseconds);
   };

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -1847,7 +1847,7 @@ TEST_F(ShellTest, CanScheduleFrameFromPlatform) {
   ASSERT_TRUE(shell->IsSetup());
 
   auto configuration = RunConfiguration::InferFromSettings(settings);
-  configuration.SetEntrypoint("canScheduleFrameFromPlatform");
+  configuration.SetEntrypoint("onBeginFrameWithNotifyNativeMain");
   RunEngine(shell.get(), std::move(configuration));
 
   // Wait for the application to attach the listener.
@@ -1857,6 +1857,50 @@ TEST_F(ShellTest, CanScheduleFrameFromPlatform) {
       shell->GetTaskRunners().GetPlatformTaskRunner(),
       [&shell]() { shell->GetPlatformView()->ScheduleFrame(); });
   check_latch.Wait();
+  DestroyShell(std::move(shell), std::move(task_runners));
+}
+
+TEST_F(ShellTest, SecondaryVsyncCallbackShouldBeCalledAfterVsyncCallback) {
+  bool is_on_begin_frame_called = false;
+  bool is_secondary_callback_called = false;
+  Settings settings = CreateSettingsForFixture();
+  TaskRunners task_runners = GetTaskRunnersForFixture();
+  fml::AutoResetWaitableEvent latch;
+  AddNativeCallback(
+      "NotifyNative",
+      CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) { latch.Signal(); }));
+  fml::CountDownLatch count_down_latch(2);
+  AddNativeCallback("NativeOnBeginFrame",
+                    CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
+                      EXPECT_FALSE(is_on_begin_frame_called);
+                      EXPECT_FALSE(is_secondary_callback_called);
+                      is_on_begin_frame_called = true;
+                      count_down_latch.CountDown();
+                    }));
+  std::unique_ptr<Shell> shell =
+      CreateShell(std::move(settings), std::move(task_runners));
+  ASSERT_TRUE(shell->IsSetup());
+
+  auto configuration = RunConfiguration::InferFromSettings(settings);
+  configuration.SetEntrypoint("onBeginFrameWithNotifyNativeMain");
+  RunEngine(shell.get(), std::move(configuration));
+
+  // Wait for the application to attach the listener.
+  latch.Wait();
+
+  fml::TaskRunner::RunNowOrPostTask(
+      shell->GetTaskRunners().GetUITaskRunner(), [&]() {
+        shell->GetEngine()->ScheduleSecondaryVsyncCallback(0, [&]() {
+          EXPECT_TRUE(is_on_begin_frame_called);
+          EXPECT_FALSE(is_secondary_callback_called);
+          is_secondary_callback_called = true;
+          count_down_latch.CountDown();
+        });
+        shell->GetEngine()->ScheduleFrame();
+      });
+  count_down_latch.Wait();
+  EXPECT_TRUE(is_on_begin_frame_called);
+  EXPECT_TRUE(is_secondary_callback_called);
   DestroyShell(std::move(shell), std::move(task_runners));
 }
 

--- a/shell/common/vsync_waiter.cc
+++ b/shell/common/vsync_waiter.cc
@@ -154,8 +154,7 @@ void VsyncWaiter::FireCallback(fml::TimePoint frame_start_time,
   }
 
   for (auto& secondary_callback : secondary_callbacks) {
-    task_runners_.GetUITaskRunner()->PostTaskForTime(
-        std::move(secondary_callback), frame_start_time);
+    task_runners_.GetUITaskRunner()->PostTask(std::move(secondary_callback));
   }
 }
 


### PR DESCRIPTION
fix https://github.com/flutter/flutter/issues/95986
https://github.com/flutter/flutter/issues/95838
https://github.com/flutter/flutter/issues/97998

We need to make sure that the secondary callback is called after the vsync callback, otherwise frames may drop in the scenarios mentioned in the Issue.

The issue was introduced in https://github.com/flutter/engine/pull/28817

/cc @iskakaushik @chinmaygarde @jason-simmons 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
