### PR TITLE
Web: treat modifier key without location (generate key map from flutter/flutter#98460)

### DIFF
--- a/lib/web_ui/lib/src/engine/key_map.dart
+++ b/lib/web_ui/lib/src/engine/key_map.dart
@@ -609,20 +609,20 @@ const Map<String, List<int?>> kWebLogicalLocationMap = <String, List<int?>>{
   '7': <int?>[0x00000000037, null, null, 0x00200000237], // digit7, null, null, numpad7
   '8': <int?>[0x00000000038, null, null, 0x00200000238], // digit8, null, null, numpad8
   '9': <int?>[0x00000000039, null, null, 0x00200000239], // digit9, null, null, numpad9
-  'Alt': <int?>[null, 0x00200000104, 0x00200000105, null], // null, altLeft, altRight, null
+  'Alt': <int?>[0x00200000104, 0x00200000104, 0x00200000105, null], // altLeft, altLeft, altRight, null
   'ArrowDown': <int?>[0x00100000301, null, null, 0x00200000232], // arrowDown, null, null, numpad2
   'ArrowLeft': <int?>[0x00100000302, null, null, 0x00200000234], // arrowLeft, null, null, numpad4
   'ArrowRight': <int?>[0x00100000303, null, null, 0x00200000236], // arrowRight, null, null, numpad6
   'ArrowUp': <int?>[0x00100000304, null, null, 0x00200000238], // arrowUp, null, null, numpad8
   'Clear': <int?>[0x00100000401, null, null, 0x00200000235], // clear, null, null, numpad5
-  'Control': <int?>[null, 0x00200000100, 0x00200000101, null], // null, controlLeft, controlRight, null
+  'Control': <int?>[0x00200000100, 0x00200000100, 0x00200000101, null], // controlLeft, controlLeft, controlRight, null
   'Delete': <int?>[0x0010000007f, null, null, 0x0020000022e], // delete, null, null, numpadDecimal
   'End': <int?>[0x00100000305, null, null, 0x00200000231], // end, null, null, numpad1
   'Enter': <int?>[0x0010000000d, null, null, 0x0020000020d], // enter, null, null, numpadEnter
   'Home': <int?>[0x00100000306, null, null, 0x00200000237], // home, null, null, numpad7
   'Insert': <int?>[0x00100000407, null, null, 0x00200000230], // insert, null, null, numpad0
-  'Meta': <int?>[null, 0x00200000106, 0x00200000107, null], // null, metaLeft, metaRight, null
+  'Meta': <int?>[0x00200000106, 0x00200000106, 0x00200000107, null], // metaLeft, metaLeft, metaRight, null
   'PageDown': <int?>[0x00100000307, null, null, 0x00200000233], // pageDown, null, null, numpad3
   'PageUp': <int?>[0x00100000308, null, null, 0x00200000239], // pageUp, null, null, numpad9
-  'Shift': <int?>[null, 0x00200000102, 0x00200000103, null], // null, shiftLeft, shiftRight, null
+  'Shift': <int?>[0x00200000102, 0x00200000102, 0x00200000103, null], // shiftLeft, shiftLeft, shiftRight, null
 };

--- a/lib/web_ui/test/keyboard_converter_test.dart
+++ b/lib/web_ui/test/keyboard_converter_test.dart
@@ -9,6 +9,7 @@ import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' as ui;
 
+const int kLocationStandard = 0;
 const int kLocationLeft = 1;
 const int kLocationRight = 2;
 const int kLocationNumpad = 3;
@@ -24,6 +25,8 @@ final int kPhysicalMetaLeft = kWebToPhysicalKey['MetaLeft']!;
 final int kPhysicalTab = kWebToPhysicalKey['Tab']!;
 final int kPhysicalCapsLock = kWebToPhysicalKey['CapsLock']!;
 final int kPhysicalScrollLock = kWebToPhysicalKey['ScrollLock']!;
+// A web-specific physical key when code is empty.
+const int kPhysicalEmptyCode = 0x1700000000;
 
 const int kLogicalKeyA = 0x00000000061;
 const int kLogicalKeyU = 0x00000000075;
@@ -31,6 +34,8 @@ const int kLogicalDigit1 = 0x00000000031;
 final int kLogicalNumpad1 = kWebLogicalLocationMap['1']![kLocationNumpad]!;
 final int kLogicalShiftLeft = kWebLogicalLocationMap['Shift']![kLocationLeft]!;
 final int kLogicalShiftRight = kWebLogicalLocationMap['Shift']![kLocationRight]!;
+final int kLogicalCtrlLeft = kWebLogicalLocationMap['Control']![kLocationLeft]!;
+final int kLogicalAltLeft = kWebLogicalLocationMap['Alt']![kLocationLeft]!;
 final int kLogicalMetaLeft = kWebLogicalLocationMap['Meta']![kLocationLeft]!;
 const int kLogicalTab = 0x0000000009;
 final int kLogicalCapsLock = kWebToLogicalKey['CapsLock']!;
@@ -260,6 +265,78 @@ void testMain() {
       type: ui.KeyEventType.up,
       physical: kPhysicalShiftRight,
       logical: kLogicalShiftRight,
+      character: null,
+    );
+  });
+
+  test('Treat modifiers at standard locations as if at left', () {
+    final List<ui.KeyData> keyDataList = <ui.KeyData>[];
+    final KeyboardConverter converter = KeyboardConverter((ui.KeyData key) {
+      keyDataList.add(key);
+      return true;
+    });
+
+    converter.handleEvent(keyDownEvent('', 'Shift', kShift, kLocationStandard));
+    expectKeyData(keyDataList.last,
+      type: ui.KeyEventType.down,
+      physical: kPhysicalEmptyCode,
+      logical: kLogicalShiftLeft,
+      character: null,
+    );
+
+    converter.handleEvent(keyUpEvent('', 'Shift', kShift, kLocationStandard));
+    expectKeyData(keyDataList.last,
+      type: ui.KeyEventType.up,
+      physical: kPhysicalEmptyCode,
+      logical: kLogicalShiftLeft,
+      character: null,
+    );
+
+    converter.handleEvent(keyDownEvent('', 'Control', kCtrl, kLocationStandard));
+    expectKeyData(keyDataList.last,
+      type: ui.KeyEventType.down,
+      physical: kPhysicalEmptyCode,
+      logical: kLogicalCtrlLeft,
+      character: null,
+    );
+
+    converter.handleEvent(keyUpEvent('', 'Control', kCtrl, kLocationStandard));
+    expectKeyData(keyDataList.last,
+      type: ui.KeyEventType.up,
+      physical: kPhysicalEmptyCode,
+      logical: kLogicalCtrlLeft,
+      character: null,
+    );
+
+    converter.handleEvent(keyDownEvent('', 'Alt', kAlt, kLocationStandard));
+    expectKeyData(keyDataList.last,
+      type: ui.KeyEventType.down,
+      physical: kPhysicalEmptyCode,
+      logical: kLogicalAltLeft,
+      character: null,
+    );
+
+    converter.handleEvent(keyUpEvent('', 'Alt', kAlt, kLocationStandard));
+    expectKeyData(keyDataList.last,
+      type: ui.KeyEventType.up,
+      physical: kPhysicalEmptyCode,
+      logical: kLogicalAltLeft,
+      character: null,
+    );
+
+    converter.handleEvent(keyDownEvent('', 'Meta', kMeta, kLocationStandard));
+    expectKeyData(keyDataList.last,
+      type: ui.KeyEventType.down,
+      physical: kPhysicalEmptyCode,
+      logical: kLogicalMetaLeft,
+      character: null,
+    );
+
+    converter.handleEvent(keyUpEvent('', 'Meta', kMeta, kLocationStandard));
+    expectKeyData(keyDataList.last,
+      type: ui.KeyEventType.up,
+      physical: kPhysicalEmptyCode,
+      logical: kLogicalMetaLeft,
       character: null,
     );
   });


### PR DESCRIPTION
Re-generate `lib\web_ui\lib\src\engine\key_map.dart` by the changes from flutter/flutter#98460, and add test for flutter/flutter#98460.

Framework PR: flutter/flutter#98460

No changes in `flutter/tests`.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [ ] All existing and new tests are passing.