### PR TITLE
Tweak drawTextBlob cost based on multiple draw calls and update the benchmark accordingly

### DIFF
--- a/display_list/display_list_complexity_gl.h
+++ b/display_list/display_list_complexity_gl.h
@@ -32,7 +32,13 @@ class DisplayListGLComplexityCalculator
  private:
   class GLHelper : public ComplexityCalculatorHelper {
    public:
-    GLHelper(unsigned int ceiling) : ComplexityCalculatorHelper(ceiling) {}
+    GLHelper(unsigned int ceiling)
+        : ComplexityCalculatorHelper(ceiling),
+          save_layer_count_(0),
+          draw_text_blob_count_(0) {}
+
+    void saveLayer(const SkRect* bounds,
+                   const SaveLayerOptions options) override;
 
     void drawLine(const SkPoint& p0, const SkPoint& p1) override;
     void drawRect(const SkRect& rect) override;
@@ -75,7 +81,11 @@ class DisplayListGLComplexityCalculator
                    bool render_with_attributes,
                    SkCanvas::SrcRectConstraint constraint) override;
 
-    unsigned int SaveLayerComplexity() override;
+    unsigned int BatchedComplexity() override;
+
+   private:
+    unsigned int save_layer_count_;
+    unsigned int draw_text_blob_count_;
   };
 
   DisplayListGLComplexityCalculator()

--- a/display_list/display_list_complexity_metal.h
+++ b/display_list/display_list_complexity_metal.h
@@ -32,7 +32,13 @@ class DisplayListMetalComplexityCalculator
  private:
   class MetalHelper : public ComplexityCalculatorHelper {
    public:
-    MetalHelper(unsigned int ceiling) : ComplexityCalculatorHelper(ceiling) {}
+    MetalHelper(unsigned int ceiling)
+        : ComplexityCalculatorHelper(ceiling),
+          save_layer_count_(0),
+          draw_text_blob_count_(0) {}
+
+    void saveLayer(const SkRect* bounds,
+                   const SaveLayerOptions options) override;
 
     void drawLine(const SkPoint& p0, const SkPoint& p1) override;
     void drawRect(const SkRect& rect) override;
@@ -75,7 +81,11 @@ class DisplayListMetalComplexityCalculator
                    bool render_with_attributes,
                    SkCanvas::SrcRectConstraint constraint) override;
 
-    unsigned int SaveLayerComplexity() override;
+    unsigned int BatchedComplexity() override;
+
+   private:
+    unsigned int save_layer_count_;
+    unsigned int draw_text_blob_count_;
   };
 
   DisplayListMetalComplexityCalculator()

--- a/display_list/display_list_complexity_unittests.cc
+++ b/display_list/display_list_complexity_unittests.cc
@@ -304,9 +304,16 @@ TEST(DisplayListComplexity, DrawTextBlob) {
   builder.drawTextBlob(text_blob, 0.0f, 0.0f);
   auto display_list = builder.Build();
 
+  DisplayListBuilder builder_multiple;
+  builder_multiple.drawTextBlob(text_blob, 0.0f, 0.0f);
+  builder_multiple.drawTextBlob(text_blob, 0.0f, 0.0f);
+  auto display_list_multiple = builder_multiple.Build();
+
   auto calculators = AccumulatorCalculators();
   for (auto calculator : calculators) {
     ASSERT_NE(calculator->Compute(display_list.get()), 0u);
+    ASSERT_GT(calculator->Compute(display_list_multiple.get()),
+              calculator->Compute(display_list.get()));
   }
 }
 


### PR DESCRIPTION
It turns out that with drawTextBlob it's more important to consider the number of times it was called during a single frame rather than the number of glyphs in the drawTextBlob. This seems to be because drawTextBlob calls are deferred and batched if possible, thus we only pay the (high) upfront cost once or a few times instead of every time.

This tweaks the benchmark so that we are measuring the impact of multiple drawTextBlob calls, and also updates the calculators to use data gathered from the new benchmark instead. This also involved a minor refactoring to better cater to "batched complexities" like saveLayer and drawTextBlob.

There is more work to be done here, at a minimum we'd need to consider the following:

* How is batching affected by other draw ops interspersed between the drawTextBlob calls?
* Does the font matter? *Note: if it is, this is not easily actionable right now as we have no way to determine the font being used at calculation time.*
* How does the glyph count vary things *Note: as with the font, we have no way to determine glyph count either.*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.