### PR TITLE
Generate fonts in the expected location.

### DIFF
--- a/build/archives/BUILD.gn
+++ b/build/archives/BUILD.gn
@@ -1,7 +1,7 @@
 import("//flutter/build/zip_bundle.gni")
 
 zip_bundle("artifacts") {
-  output = "$host_os_cpu_name/artifacts.zip"
+  output = "$full_platform_name/artifacts.zip"
   deps = [
     "//flutter/flutter_frontend_server:frontend_server",
     "//flutter/lib/snapshot:generate_snapshot_bin",

--- a/common/config.gni
+++ b/common/config.gni
@@ -87,8 +87,15 @@ if (flutter_prebuilt_dart_sdk) {
     _target_os_name = "windows"
   }
 
+  _host_os_name = host_os
+  if (_host_os_name == "mac") {
+    _host_os_name = "macos"
+  } else if (_host_os_name == "win" || _host_os_name == "winuwp") {
+    _host_os_name = "windows"
+  }
+
   _target_prebuilt_dart_sdk_config = "$_target_os_name-$target_cpu"
-  _host_prebuilt_dart_sdk_config = "$full_platform_name"
+  _host_prebuilt_dart_sdk_config = "$_host_os_name-$host_cpu"
   _target_prebuilt_dart_sdk_archive = "//flutter/prebuilts/dartsdk-$_target_prebuilt_dart_sdk_config-release.zip"
   _host_prebuilt_dart_sdk_archive =
       "//flutter/prebuilts/dartsdk-$_host_prebuilt_dart_sdk_config-release.zip"

--- a/common/config.gni
+++ b/common/config.gni
@@ -69,9 +69,9 @@ if (is_ios || is_mac) {
 # A combo of host os name and cpu is used in several locations to
 # generate the names of the archived artifacts.
 _platform_name = host_os
-if (_host_os_name == "mac") {
+if (_platform_name == "mac") {
   _platform_name = "darwin"
-} else if (_host_os_name == "win" || _host_os_name == "winuwp") {
+} else if (_platform_name == "win" || _platform_name == "winuwp") {
   _platform_name = "windows"
 }
 

--- a/common/config.gni
+++ b/common/config.gni
@@ -68,14 +68,14 @@ if (is_ios || is_mac) {
 
 # A combo of host os name and cpu is used in several locations to
 # generate the names of the archived artifacts.
-_host_os_name = host_os
+_platform_name = host_os
 if (_host_os_name == "mac") {
-  _host_os_name = "macos"
+  _platform_name = "darwin"
 } else if (_host_os_name == "win" || _host_os_name == "winuwp") {
-  _host_os_name = "windows"
+  _platform_name = "windows"
 }
 
-host_os_cpu_name = "$_host_os_name-$host_cpu"
+full_platform_name = "$_platform_name-$host_cpu"
 
 # Prebuilt Dart SDK location
 
@@ -88,7 +88,7 @@ if (flutter_prebuilt_dart_sdk) {
   }
 
   _target_prebuilt_dart_sdk_config = "$_target_os_name-$target_cpu"
-  _host_prebuilt_dart_sdk_config = "$host_os_cpu_name"
+  _host_prebuilt_dart_sdk_config = "$full_platform_name"
   _target_prebuilt_dart_sdk_archive = "//flutter/prebuilts/dartsdk-$_target_prebuilt_dart_sdk_config-release.zip"
   _host_prebuilt_dart_sdk_archive =
       "//flutter/prebuilts/dartsdk-$_host_prebuilt_dart_sdk_config-release.zip"

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -21,7 +21,7 @@ out_dir = os.path.join(buildroot_dir, 'out')
 golden_dir = os.path.join(buildroot_dir, 'flutter', 'testing', 'resources')
 fonts_dir = os.path.join(buildroot_dir, 'flutter', 'third_party', 'txt', 'third_party', 'fonts')
 roboto_font_path = os.path.join(fonts_dir, 'Roboto-Regular.ttf')
-font_subset_dir = os.path.join(buildroot_dir, 'flutter', 'tools', 'font-subset')
+font_subset_dir = os.path.join(buildroot_dir, 'flutter', 'tools', 'linux-x64', 'font-subset')
 
 fml_unittests_filter = '--gtest_filter=-*TimeSensitiveTest*'
 

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -21,7 +21,7 @@ out_dir = os.path.join(buildroot_dir, 'out')
 golden_dir = os.path.join(buildroot_dir, 'flutter', 'testing', 'resources')
 fonts_dir = os.path.join(buildroot_dir, 'flutter', 'third_party', 'txt', 'third_party', 'fonts')
 roboto_font_path = os.path.join(fonts_dir, 'Roboto-Regular.ttf')
-font_subset_dir = os.path.join(buildroot_dir, 'flutter', 'tools', 'linux-x64', 'font-subset')
+font_subset_dir = os.path.join(buildroot_dir, 'flutter', 'tools', 'font-subset')
 
 fml_unittests_filter = '--gtest_filter=-*TimeSensitiveTest*'
 

--- a/tools/font-subset/BUILD.gn
+++ b/tools/font-subset/BUILD.gn
@@ -41,7 +41,7 @@ generated_file("_font-subset-license") {
 }
 
 zip_bundle("font-subset") {
-  output = "${host_os_cpu_name}/font-subset.zip"
+  output = "${full_platform_name}/font-subset.zip"
 
   font_subset_bin = "font-subset"
   if (is_win) {

--- a/tools/font-subset/BUILD.gn
+++ b/tools/font-subset/BUILD.gn
@@ -41,7 +41,7 @@ generated_file("_font-subset-license") {
 }
 
 zip_bundle("font-subset") {
-  output = "font-subset.zip"
+  output = "${host_os_cpu_name}/font-subset.zip"
 
   font_subset_bin = "font-subset"
   if (is_win) {

--- a/tools/font-subset/test.py
+++ b/tools/font-subset/test.py
@@ -91,6 +91,8 @@ def RunCmd(cmd, codepoints, fail=False):
 
 
 def TestZip():
+  print('zzzz %s' % sys.platform)
+  print('zzzz %s' %FONT_SUBSET_ZIP)
   with ZipFile(FONT_SUBSET_ZIP, 'r') as zip:
     files = zip.namelist()
     if 'font-subset%s' % EXE not in files:

--- a/tools/font-subset/test.py
+++ b/tools/font-subset/test.py
@@ -33,7 +33,7 @@ IS_WINDOWS = sys.platform.startswith(('cygwin', 'win'))
 EXE = '.exe' if IS_WINDOWS else ''
 BAT = '.bat' if IS_WINDOWS else ''
 FONT_SUBSET = os.path.join(SRC_DIR, 'out', 'host_debug', 'font-subset' + EXE)
-FONT_SUBSET_ZIP = os.path.join(SRC_DIR, 'out', 'host_debug', 'zip_archives', 'font-subset.zip')
+FONT_SUBSET_ZIP = os.path.join(SRC_DIR, 'out', 'host_debug', 'zip_archives', PLATFORM_2_PATH.get(sys.platform, ''), 'font-subset.zip')
 if not os.path.isfile(FONT_SUBSET):
   FONT_SUBSET = os.path.join(SRC_DIR, 'out', 'host_debug_unopt', 'font-subset' + EXE)
   FONT_SUBSET_ZIP = os.path.join(SRC_DIR, 'out', 'host_debug_unopt', 'zip_archives', PLATFORM_2_PATH.get(sys.platform, ''), 'font-subset.zip')

--- a/tools/font-subset/test.py
+++ b/tools/font-subset/test.py
@@ -20,6 +20,7 @@ from zipfile import ZipFile
 PLATFORM_2_PATH = {
     'darwin': 'darwin-x64',
     'linux': 'linux-x64',
+    'linux2': 'linux-x64',
     'cygwin': 'windows-x64',
     'win': 'windows-x64',
     'win32': 'windows-x64',

--- a/tools/font-subset/test.py
+++ b/tools/font-subset/test.py
@@ -15,12 +15,14 @@ import sys
 from zipfile import ZipFile
 
 
-
+# Dictionary to map the platform name to the output directory
+# of the font artifacts.
 PLATFORM_2_PATH = {
     'darwin': 'darwin-x64',
     'linux': 'linux-x64',
     'cygwin': 'windows-x64',
-    'win': 'windows-x64'
+    'win': 'windows-x64',
+    'win32': 'windows-64',
 }
 
 

--- a/tools/font-subset/test.py
+++ b/tools/font-subset/test.py
@@ -22,7 +22,7 @@ PLATFORM_2_PATH = {
     'linux': 'linux-x64',
     'cygwin': 'windows-x64',
     'win': 'windows-x64',
-    'win32': 'windows-64',
+    'win32': 'windows-x32',
 }
 
 

--- a/tools/font-subset/test.py
+++ b/tools/font-subset/test.py
@@ -20,7 +20,7 @@ PLATFORM_2_PATH = {
     'darwin': 'darwin-x64',
     'linux': 'linux-x64',
     'cygwin': 'windows-x64',
-    'wind': 'windows-64'
+    'win': 'windows-x64'
 }
 
 

--- a/tools/font-subset/test.py
+++ b/tools/font-subset/test.py
@@ -22,7 +22,7 @@ PLATFORM_2_PATH = {
     'linux': 'linux-x64',
     'cygwin': 'windows-x64',
     'win': 'windows-x64',
-    'win32': 'windows-x32',
+    'win32': 'windows-x64',
 }
 
 

--- a/tools/font-subset/test.py
+++ b/tools/font-subset/test.py
@@ -93,8 +93,6 @@ def RunCmd(cmd, codepoints, fail=False):
 
 
 def TestZip():
-  print('zzzz %s' % sys.platform)
-  print('zzzz %s' %FONT_SUBSET_ZIP)
   with ZipFile(FONT_SUBSET_ZIP, 'r') as zip:
     files = zip.namelist()
     if 'font-subset%s' % EXE not in files:

--- a/tools/font-subset/test.py
+++ b/tools/font-subset/test.py
@@ -14,6 +14,16 @@ import subprocess
 import sys
 from zipfile import ZipFile
 
+
+
+PLATFORM_2_PATH = {
+    'darwin': 'darwin-x64',
+    'linux': 'linux-x64',
+    'cygwin': 'windows-x64',
+    'wind': 'windows-64'
+}
+
+
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 SRC_DIR = os.path.normpath(os.path.join(SCRIPT_DIR, '..', '..', '..'))
 MATERIAL_TTF = os.path.join(SCRIPT_DIR, 'fixtures', 'MaterialIcons-Regular.ttf')
@@ -24,7 +34,7 @@ FONT_SUBSET = os.path.join(SRC_DIR, 'out', 'host_debug', 'font-subset' + EXE)
 FONT_SUBSET_ZIP = os.path.join(SRC_DIR, 'out', 'host_debug', 'zip_archives', 'font-subset.zip')
 if not os.path.isfile(FONT_SUBSET):
   FONT_SUBSET = os.path.join(SRC_DIR, 'out', 'host_debug_unopt', 'font-subset' + EXE)
-  FONT_SUBSET_ZIP = os.path.join(SRC_DIR, 'out', 'host_debug_unopt', 'zip_archives', 'font-subset.zip')
+  FONT_SUBSET_ZIP = os.path.join(SRC_DIR, 'out', 'host_debug_unopt', 'zip_archives', PLATFORM_2_PATH.get(sys.platform, ''), 'font-subset.zip')
 if not os.path.isfile(FONT_SUBSET):
   raise Exception('Could not locate font-subset%s in host_debug or host_debug_unopt - build before running this script.' % EXE)
 

--- a/web_sdk/BUILD.gn
+++ b/web_sdk/BUILD.gn
@@ -568,7 +568,7 @@ _kernel_worker("flutter_dartdevc_kernel_sdk_outline_sound") {
 # Archives Flutter Web SDK
 if (!is_fuchsia) {
   zip_bundle("flutter_web_sdk_archive") {
-    output = "flutter-web-sdk-${host_os_cpu_name}.zip"
+    output = "flutter-web-sdk-${full_platform_name}.zip"
     deps = [
       ":flutter_dartdevc_canvaskit_html_kernel_sdk",
       ":flutter_dartdevc_canvaskit_html_kernel_sdk_sound",


### PR DESCRIPTION
Fonts-subset is generated directly in out/../zip_archives but the final
destination is expected to be inside a folder like linux-x64. This PR
generates the file directly in the expected path.

Bug: https://github.com/flutter/flutter/issues/81855

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
