### PR TITLE
Generate a11y events for widgets that use kFlutterSemanticsFlagIsToggled

### DIFF
--- a/shell/platform/linux/fl_accessible_node.cc
+++ b/shell/platform/linux/fl_accessible_node.cc
@@ -16,7 +16,10 @@ static struct {
     {ATK_STATE_CHECKABLE, kFlutterSemanticsFlagHasCheckedState, FALSE},
     {ATK_STATE_FOCUSABLE, kFlutterSemanticsFlagIsFocusable, FALSE},
     {ATK_STATE_FOCUSED, kFlutterSemanticsFlagIsFocused, FALSE},
-    {ATK_STATE_CHECKED, kFlutterSemanticsFlagIsChecked, FALSE},
+    {ATK_STATE_CHECKED,
+     static_cast<FlutterSemanticsFlag>(kFlutterSemanticsFlagIsChecked |
+                                       kFlutterSemanticsFlagIsToggled),
+     FALSE},
     {ATK_STATE_SELECTED, kFlutterSemanticsFlagIsSelected, FALSE},
     {ATK_STATE_ENABLED, kFlutterSemanticsFlagIsEnabled, FALSE},
     {ATK_STATE_READ_ONLY, kFlutterSemanticsFlagIsReadOnly, FALSE},


### PR DESCRIPTION
ATK only uses a "checked" state, where Flutter has both Checked and Toggled.

Fixes https://github.com/flutter/flutter/issues/98845.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
