### PR TITLE
Android Input Failed When TextInputType Is Phone, Number

### DIFF
--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -287,6 +287,8 @@ class InputConnectionAdaptor extends BaseInputConnection
         return handleVerticalMovement(false, event.isShiftPressed());
         // When the enter key is pressed on a non-multiline field, consider it a
         // submit instead of a newline.
+      } else if (event.getKeyCode() == KeyEvent.KEYCODE_DEL) {
+        return handleDelete();
       } else if ((event.getKeyCode() == KeyEvent.KEYCODE_ENTER
               || event.getKeyCode() == KeyEvent.KEYCODE_NUMPAD_ENTER)
           && (InputType.TYPE_TEXT_FLAG_MULTI_LINE & mEditorInfo.inputType) == 0) {
@@ -297,12 +299,12 @@ class InputConnectionAdaptor extends BaseInputConnection
         final int selStart = Selection.getSelectionStart(mEditable);
         final int selEnd = Selection.getSelectionEnd(mEditable);
         final int character = event.getUnicodeChar();
-        if (selStart < 0 || selEnd < 0 || character == 0) {
+        if (character == 0) {
           return false;
         }
 
-        final int selMin = Math.min(selStart, selEnd);
-        final int selMax = Math.max(selStart, selEnd);
+        final int selMin = Math.max(Math.min(selStart, selEnd), 0);
+        final int selMax = Math.max(Math.max(selStart, selEnd), 0);
         beginBatchEdit();
         if (selMin != selMax) mEditable.delete(selMin, selMax);
         mEditable.insert(selMin, String.valueOf((char) character));
@@ -371,6 +373,20 @@ class InputConnectionAdaptor extends BaseInputConnection
       }
       setSelection(Selection.getSelectionStart(mEditable), Selection.getSelectionEnd(mEditable));
     }
+    endBatchEdit();
+    return true;
+  }
+
+  private boolean handleDelete() {
+    final int selStart = Selection.getSelectionStart(mEditable);
+    final int selEnd = Selection.getSelectionEnd(mEditable);
+
+    if (selStart <= 0 || selEnd <= 0) {
+      return false;
+    }
+    beginBatchEdit();
+    mEditable.delete(selStart - 1, selEnd);
+    setSelection(selStart - 1, selEnd - 1);
     endBatchEdit();
     return true;
   }

--- a/shell/platform/android/test/io/flutter/util/FakeKeyEvent.java
+++ b/shell/platform/android/test/io/flutter/util/FakeKeyEvent.java
@@ -1,17 +1,36 @@
 package io.flutter.util;
 
 import android.view.KeyEvent;
+import java.util.HashMap;
+import java.util.Map;
 
 // In the test environment, keyEvent.getUnicodeChar throws an exception. This
 // class works around the exception by hardcoding the returned value.
 public class FakeKeyEvent extends KeyEvent {
+
+  private Map<Integer, Integer> keyCodeMap = new HashMap<>();
+
   public FakeKeyEvent(int action, int keyCode) {
     super(action, keyCode);
+    keyCodeMap.put(KEYCODE_1, (int) '1');
+    keyCodeMap.put(KEYCODE_2, (int) '2');
+    keyCodeMap.put(KEYCODE_3, (int) '3');
+    keyCodeMap.put(KEYCODE_4, (int) '4');
+    keyCodeMap.put(KEYCODE_5, (int) '5');
+    keyCodeMap.put(KEYCODE_6, (int) '6');
+    keyCodeMap.put(KEYCODE_7, (int) '7');
+    keyCodeMap.put(KEYCODE_8, (int) '8');
+    keyCodeMap.put(KEYCODE_9, (int) '9');
+    keyCodeMap.put(KEYCODE_0, (int) '0');
   }
 
   public final int getUnicodeChar() {
-    if (getKeyCode() == KeyEvent.KEYCODE_BACK) {
+    int code = getKeyCode();
+    if (code == KeyEvent.KEYCODE_BACK) {
       return 0;
+    }
+    if (keyCodeMap.containsKey(code)) {
+      return keyCodeMap.get(code);
     }
     return 1;
   }


### PR DESCRIPTION
Fix Issue:  [98352](https://github.com/flutter/flutter/issues/98352)

**In current case is not `cursor selector` but current logic number input is will check the `Selection` range**

When the `TextInputType` is `Number`, and you input text, the keyboard will `sendKeyEvent`, and next entry the `handleKeyEvent` method 
```
public boolean handleKeyEvent(KeyEvent event) {
   ...
        // Enter a character.
        final int selStart = Selection.getSelectionStart(mEditable);
        final int selEnd = Selection.getSelectionEnd(mEditable);
        final int character = event.getUnicodeChar();
        if (selStart < 0 || selEnd < 0 || character == 0) {
          return false;
        }
...
  }
```
**When first number entry this method the `selStart` and `selEnd` will be `-1`, because there is no cursor  and thus the Selection.start is not attach. The `getSelectionStart` will return -1**

We need to support logic that without a cursor, and need support delete action.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
