### PR TITLE
Fix signals adding/removing a11y nodes in Linux.

### DIFF
--- a/shell/platform/linux/fl_accessible_node.cc
+++ b/shell/platform/linux/fl_accessible_node.cc
@@ -118,6 +118,17 @@ static ActionData* get_action(FlAccessibleNode* self, gint index) {
   return static_cast<ActionData*>(g_ptr_array_index(self->actions, index));
 }
 
+// Checks if [object] is in [children].
+static gboolean has_child(GPtrArray* children, AtkObject* object) {
+  for (guint i = 0; i < children->len; i++) {
+    if (g_ptr_array_index(children, i) == object) {
+      return TRUE;
+    }
+  }
+
+  return FALSE;
+}
+
 static void fl_accessible_node_dispose(GObject* object) {
   FlAccessibleNode* self = FL_ACCESSIBLE_NODE(object);
 
@@ -330,11 +341,25 @@ void fl_accessible_node_set_children(FlAccessibleNode* self,
                                      GPtrArray* children) {
   g_return_if_fail(FL_IS_ACCESSIBLE_NODE(self));
 
-  g_ptr_array_remove_range(self->children, 0, self->children->len);
+  // Remove nodes that are no longer required.
+  for (guint i = 0; i < self->children->len;) {
+    AtkObject* object = ATK_OBJECT(g_ptr_array_index(self->children, i));
+    if (has_child(children, object)) {
+      i++;
+    } else {
+      g_signal_emit_by_name(self, "children-changed::remove", i, object,
+                            nullptr);
+      g_ptr_array_remove_index(self->children, i);
+    }
+  }
+
+  // Add new nodes.
   for (guint i = 0; i < children->len; i++) {
     AtkObject* object = ATK_OBJECT(g_ptr_array_index(children, i));
-    g_ptr_array_add(self->children, g_object_ref(object));
-    g_signal_emit_by_name(self, "children-changed::add", i, object, nullptr);
+    if (!has_child(self->children, object)) {
+      g_ptr_array_add(self->children, g_object_ref(object));
+      g_signal_emit_by_name(self, "children-changed::add", i, object, nullptr);
+    }
   }
 }
 


### PR DESCRIPTION
Previously each time a node changed all its children were being notified as being added.
No signals were being generated for removed nodes.

Fixes https://github.com/flutter/flutter/issues/98896

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
