### PR TITLE
Changed the default a11y node role from ATK_ROLE_FRAME to ATK_ROLE_PANEL

### DIFF
--- a/shell/platform/linux/fl_accessible_node.cc
+++ b/shell/platform/linux/fl_accessible_node.cc
@@ -186,7 +186,7 @@ static AtkRole fl_accessible_node_get_role(AtkObject* accessible) {
     return ATK_ROLE_IMAGE;
   }
 
-  return ATK_ROLE_FRAME;
+  return ATK_ROLE_PANEL;
 }
 
 // Implements AtkObject::ref_state_set.

--- a/shell/platform/linux/fl_view_accessible.cc
+++ b/shell/platform/linux/fl_view_accessible.cc
@@ -56,7 +56,7 @@ static AtkObject* fl_view_accessible_ref_child(AtkObject* accessible, gint i) {
 
 // Implements AtkObject::get_role
 static AtkRole fl_view_accessible_get_role(AtkObject* accessible) {
-  return ATK_ROLE_FRAME;
+  return ATK_ROLE_PANEL;
 }
 
 static void fl_view_accessible_class_init(FlViewAccessibleClass* klass) {


### PR DESCRIPTION
ATK_ROLE_FRAME refers to a top-level window, ATK_ROLE_PANEL is what is used for containers in GTK.

Fixes https://github.com/flutter/flutter/issues/98897

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.