### PR TITLE
Add ThreadConfigSetter for Embedder api that can set thread priority

### DIFF
--- a/fml/thread_unittests.cc
+++ b/fml/thread_unittests.cc
@@ -4,7 +4,7 @@
 
 #include "flutter/fml/thread.h"
 
-#if defined(OS_MACOSX) || defined(OS_LINUX) || defined(OS_ANDROID)
+#if defined(FML_OS_MACOSX) || defined(FML_OS_LINUX) || defined(FML_OS_ANDROID)
 #define FLUTTER_PTHREAD_SUPPORTED 1
 #else
 #define FLUTTER_PTHREAD_SUPPORTED 0

--- a/shell/common/thread_host.cc
+++ b/shell/common/thread_host.cc
@@ -29,6 +29,33 @@ std::string ThreadHost::ThreadHostConfig::MakeThreadName(
   }
 }
 
+void ThreadHost::ThreadHostConfig::SetIOConfig(const ThreadConfig& config) {
+  type_mask |= ThreadHost::Type::IO;
+  io_config = config;
+}
+
+void ThreadHost::ThreadHostConfig::SetUIConfig(const ThreadConfig& config) {
+  type_mask |= ThreadHost::Type::UI;
+  ui_config = config;
+}
+
+void ThreadHost::ThreadHostConfig::SetPlatformConfig(
+    const ThreadConfig& config) {
+  type_mask |= ThreadHost::Type::Platform;
+  platform_config = config;
+}
+
+void ThreadHost::ThreadHostConfig::SetRasterConfig(const ThreadConfig& config) {
+  type_mask |= ThreadHost::Type::RASTER;
+  raster_config = config;
+}
+
+void ThreadHost::ThreadHostConfig::SetProfilerConfig(
+    const ThreadConfig& config) {
+  type_mask |= ThreadHost::Type::Profiler;
+  profiler_config = config;
+}
+
 std::unique_ptr<fml::Thread> ThreadHost::CreateThread(
     Type type,
     std::optional<ThreadConfig> thread_config,

--- a/shell/common/thread_host.h
+++ b/shell/common/thread_host.h
@@ -30,7 +30,9 @@ struct ThreadHost {
   /// The collection of all the thread configures, and we create custom thread
   /// configure in engine to info the thread.
   struct ThreadHostConfig {
-    ThreadHostConfig() : type_mask(0) {}
+    explicit ThreadHostConfig(
+        const ThreadConfigSetter& setter = fml::Thread::SetCurrentThreadName)
+        : type_mask(0), config_setter(setter) {}
 
     ThreadHostConfig(
         const std::string& name_prefix,
@@ -48,6 +50,21 @@ struct ThreadHost {
 
     /// Use the prefix and thread type to generator a thread name.
     static std::string MakeThreadName(Type type, const std::string& prefix);
+
+    /// Specified the UI Thread Config, meanwhile set the mask.
+    void SetUIConfig(const ThreadConfig&);
+
+    /// Specified the Platform Thread Config, meanwhile set the mask.
+    void SetPlatformConfig(const ThreadConfig&);
+
+    /// Specified the IO Thread Config, meanwhile set the mask.
+    void SetRasterConfig(const ThreadConfig&);
+
+    /// Specified the IO Thread Config, meanwhile set the mask.
+    void SetIOConfig(const ThreadConfig&);
+
+    /// Specified the ProfilerThread  Config, meanwhile set the mask.
+    void SetProfilerConfig(const ThreadConfig&);
 
     uint64_t type_mask;
 

--- a/shell/platform/embedder/embedder_thread_host.h
+++ b/shell/platform/embedder/embedder_thread_host.h
@@ -21,7 +21,9 @@ class EmbedderThreadHost {
  public:
   static std::unique_ptr<EmbedderThreadHost>
   CreateEmbedderOrEngineManagedThreadHost(
-      const FlutterCustomTaskRunners* custom_task_runners);
+      const FlutterCustomTaskRunners* custom_task_runners,
+      flutter::ThreadConfigSetter config_setter =
+          fml::Thread::SetCurrentThreadName);
 
   EmbedderThreadHost(
       ThreadHost host,
@@ -42,9 +44,13 @@ class EmbedderThreadHost {
   std::map<int64_t, fml::RefPtr<EmbedderTaskRunner>> runners_map_;
 
   static std::unique_ptr<EmbedderThreadHost> CreateEmbedderManagedThreadHost(
-      const FlutterCustomTaskRunners* custom_task_runners);
+      const FlutterCustomTaskRunners* custom_task_runners,
+      flutter::ThreadConfigSetter config_setter =
+          fml::Thread::SetCurrentThreadName);
 
-  static std::unique_ptr<EmbedderThreadHost> CreateEngineManagedThreadHost();
+  static std::unique_ptr<EmbedderThreadHost> CreateEngineManagedThreadHost(
+      flutter::ThreadConfigSetter config_setter =
+          fml::Thread::SetCurrentThreadName);
 
   FML_DISALLOW_COPY_AND_ASSIGN(EmbedderThreadHost);
 };


### PR DESCRIPTION
Change the `embedder.cc` create thread host api for that we can specified the thread priority

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
