### PR TITLE
Fix PhysicalShapeLayer paint bounds with clipping disabled

### DIFF
--- a/flow/layers/physical_shape_layer.cc
+++ b/flow/layers/physical_shape_layer.cc
@@ -56,7 +56,7 @@ void PhysicalShapeLayer::Preroll(PrerollContext* context,
   Layer::AutoPrerollSaveLayerState save =
       Layer::AutoPrerollSaveLayerState::Create(context, UsesSaveLayer());
 
-  SkRect child_paint_bounds;
+  SkRect child_paint_bounds = SkRect::MakeEmpty();
   PrerollChildren(context, matrix, &child_paint_bounds);
 
   SkRect paint_bounds;

--- a/flow/layers/physical_shape_layer.cc
+++ b/flow/layers/physical_shape_layer.cc
@@ -59,15 +59,21 @@ void PhysicalShapeLayer::Preroll(PrerollContext* context,
   SkRect child_paint_bounds;
   PrerollChildren(context, matrix, &child_paint_bounds);
 
+  SkRect paint_bounds;
   if (elevation_ == 0) {
-    set_paint_bounds(path_.getBounds());
+    paint_bounds = path_.getBounds();
   } else {
     // We will draw the shadow in Paint(), so add some margin to the paint
-    // bounds to leave space for the shadow. We fill this whole region and clip
-    // children to it so we don't need to join the child paint bounds.
-    set_paint_bounds(DisplayListCanvasDispatcher::ComputeShadowBounds(
-        path_, elevation_, context->frame_device_pixel_ratio, matrix));
+    // bounds to leave space for the shadow.
+    paint_bounds = DisplayListCanvasDispatcher::ComputeShadowBounds(
+        path_, elevation_, context->frame_device_pixel_ratio, matrix);
   }
+
+  if (clip_behavior_ == Clip::none) {
+    paint_bounds.join(child_paint_bounds);
+  }
+
+  set_paint_bounds(paint_bounds);
 }
 
 void PhysicalShapeLayer::Paint(PaintContext& context) const {

--- a/flow/layers/physical_shape_layer_unittests.cc
+++ b/flow/layers/physical_shape_layer_unittests.cc
@@ -87,7 +87,7 @@ TEST_F(PhysicalShapeLayerTest, ChildrenLargerThanPathClip) {
   layer->Add(child1);
   layer->Add(child2);
 
-  SkRect child_paint_bounds;
+  SkRect child_paint_bounds = SkRect::MakeEmpty();
   layer->Preroll(preroll_context(), SkMatrix());
   child_paint_bounds.join(child1->paint_bounds());
   child_paint_bounds.join(child2->paint_bounds());
@@ -142,7 +142,7 @@ TEST_F(PhysicalShapeLayerTest, ChildrenLargerThanPathNoClip) {
   layer->Add(child1);
   layer->Add(child2);
 
-  SkRect total_bounds;
+  SkRect total_bounds = SkRect::MakeEmpty();
   layer->Preroll(preroll_context(), SkMatrix());
   total_bounds.join(child1->paint_bounds());
   total_bounds.join(child2->paint_bounds());

--- a/flow/layers/physical_shape_layer_unittests.cc
+++ b/flow/layers/physical_shape_layer_unittests.cc
@@ -66,7 +66,62 @@ TEST_F(PhysicalShapeLayerTest, NonEmptyLayer) {
                 0, MockCanvas::DrawPathData{layer_path, layer_paint}}}));
 }
 
-TEST_F(PhysicalShapeLayerTest, ChildrenLargerThanPath) {
+TEST_F(PhysicalShapeLayerTest, ChildrenLargerThanPathClip) {
+  SkPath layer_path;
+  layer_path.addRect(5.0f, 6.0f, 20.5f, 21.5f);
+  SkPath child1_path;
+  child1_path.addRect(4, 0, 12, 12).close();
+  SkPath child2_path;
+  child2_path.addRect(3, 2, 5, 15).close();
+  auto child1 = std::make_shared<PhysicalShapeLayer>(SK_ColorRED, SK_ColorBLACK,
+                                                     0.0f,  // elevation
+                                                     child1_path, Clip::none);
+  auto child2 =
+      std::make_shared<PhysicalShapeLayer>(SK_ColorBLUE, SK_ColorBLACK,
+                                           0.0f,  // elevation
+                                           child2_path, Clip::none);
+  auto layer =
+      std::make_shared<PhysicalShapeLayer>(SK_ColorGREEN, SK_ColorBLACK,
+                                           0.0f,  // elevation
+                                           layer_path, Clip::hardEdge);
+  layer->Add(child1);
+  layer->Add(child2);
+
+  SkRect child_paint_bounds;
+  layer->Preroll(preroll_context(), SkMatrix());
+  child_paint_bounds.join(child1->paint_bounds());
+  child_paint_bounds.join(child2->paint_bounds());
+  EXPECT_EQ(layer->paint_bounds(), layer_path.getBounds());
+  EXPECT_NE(layer->paint_bounds(), child_paint_bounds);
+  EXPECT_TRUE(layer->needs_painting(paint_context()));
+
+  SkPaint layer_paint;
+  layer_paint.setColor(SK_ColorGREEN);
+  layer_paint.setAntiAlias(true);
+  SkPaint child1_paint;
+  child1_paint.setColor(SK_ColorRED);
+  child1_paint.setAntiAlias(true);
+  SkPaint child2_paint;
+  child2_paint.setColor(SK_ColorBLUE);
+  child2_paint.setAntiAlias(true);
+  layer->Paint(paint_context());
+  EXPECT_EQ(mock_canvas().draw_calls(),
+            std::vector({
+                MockCanvas::DrawCall{
+                    0, MockCanvas::DrawPathData{layer_path, layer_paint}},
+                MockCanvas::DrawCall{0, MockCanvas::SaveData{1}},
+                MockCanvas::DrawCall{
+                    1, MockCanvas::ClipRectData{layer_path.getBounds(),
+                                                SkClipOp::kIntersect}},
+                MockCanvas::DrawCall{
+                    1, MockCanvas::DrawPathData{child1_path, child1_paint}},
+                MockCanvas::DrawCall{
+                    1, MockCanvas::DrawPathData{child2_path, child2_paint}},
+                MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}},
+            }));
+}
+
+TEST_F(PhysicalShapeLayerTest, ChildrenLargerThanPathNoClip) {
   SkPath layer_path;
   layer_path.addRect(5.0f, 6.0f, 20.5f, 21.5f);
   SkPath child1_path;
@@ -87,12 +142,13 @@ TEST_F(PhysicalShapeLayerTest, ChildrenLargerThanPath) {
   layer->Add(child1);
   layer->Add(child2);
 
-  SkRect child_paint_bounds;
+  SkRect total_bounds;
   layer->Preroll(preroll_context(), SkMatrix());
-  child_paint_bounds.join(child1->paint_bounds());
-  child_paint_bounds.join(child2->paint_bounds());
-  EXPECT_EQ(layer->paint_bounds(), layer_path.getBounds());
-  EXPECT_NE(layer->paint_bounds(), child_paint_bounds);
+  total_bounds.join(child1->paint_bounds());
+  total_bounds.join(child2->paint_bounds());
+  total_bounds.join(layer_path.getBounds());
+  EXPECT_NE(layer->paint_bounds(), layer_path.getBounds());
+  EXPECT_EQ(layer->paint_bounds(), total_bounds);
   EXPECT_TRUE(layer->needs_painting(paint_context()));
 
   SkPaint layer_paint;
@@ -174,10 +230,14 @@ TEST_F(PhysicalShapeLayerTest, ElevationComplex) {
     // On Fuchsia, the system compositor handles all elevated
     // PhysicalShapeLayers and their shadows , so we do not do any painting
     // there.
-    EXPECT_EQ(layers[i]->paint_bounds(),
-              (DisplayListCanvasDispatcher::ComputeShadowBounds(
-                  layer_path, initial_elevations[i], 1.0f /* pixel_ratio */,
-                  SkMatrix())));
+    SkRect paint_bounds = DisplayListCanvasDispatcher::ComputeShadowBounds(
+        layer_path, initial_elevations[i], 1.0f /* pixel_ratio */, SkMatrix());
+
+    // Without clipping the children will be painted as well
+    for (auto layer : layers[i]->layers()) {
+      paint_bounds.join(layer->paint_bounds());
+    }
+    EXPECT_EQ(layers[i]->paint_bounds(), paint_bounds);
     EXPECT_TRUE(layers[i]->needs_painting(paint_context()));
   }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/98739

If `PhysicalShapeLayer` `clip_behavior_` is set to `Clip::none`, the paint bounds after preroll should include bounds of child layers as well. Otherwise the bounds are calculated incorrectly and the layer may be culled during painting when it shouldn't.

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
