### PR TITLE
DlAttribute base class

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -110,7 +110,7 @@ deps = {
   'src': 'https://github.com/flutter/buildroot.git' + '@' + 'e4cee118fc80c7cd3b8f8959aa02747a67c38a63',
 
   'src/flutter/impeller':
-  Var('github_git') + '/flutter/impeller' + '@' + '827d2f81eac75a64c7f9383d23dfae6b32f1c054',
+  Var('github_git') + '/flutter/impeller' + '@' + '189a9e74c881929f0c7d74323c8fb94974ac45db',
 
    # Fuchsia compatibility
    #

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -36,6 +36,7 @@ FILE: ../../../flutter/common/task_runners.cc
 FILE: ../../../flutter/common/task_runners.h
 FILE: ../../../flutter/display_list/display_list.cc
 FILE: ../../../flutter/display_list/display_list.h
+FILE: ../../../flutter/display_list/display_list_attributes.h
 FILE: ../../../flutter/display_list/display_list_benchmarks.cc
 FILE: ../../../flutter/display_list/display_list_benchmarks.h
 FILE: ../../../flutter/display_list/display_list_benchmarks_canvas_provider.h

--- a/display_list/BUILD.gn
+++ b/display_list/BUILD.gn
@@ -8,6 +8,7 @@ source_set("display_list") {
   sources = [
     "display_list.cc",
     "display_list.h",
+    "display_list_attributes.h",
     "display_list_builder.cc",
     "display_list_builder.h",
     "display_list_canvas_dispatcher.cc",

--- a/display_list/display_list_attributes.h
+++ b/display_list/display_list_attributes.h
@@ -1,0 +1,123 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_DISPLAY_LIST_DISPLAY_LIST_ATTRIBUTES_H_
+#define FLUTTER_DISPLAY_LIST_DISPLAY_LIST_ATTRIBUTES_H_
+
+#include "flutter/display_list/types.h"
+#include "flutter/fml/logging.h"
+
+namespace flutter {
+
+// ===========================================================================
+
+// The base class for a family of DisplayList attribute classes.
+//
+// This class is designed to support the following properties for any
+// attribute to facilitate the storage of the attribute in a DisplayList
+// and for use in code that inspects or creates DisplayList objects:
+//
+// - Typed:
+//     Even though most references and pointers are passed around as the
+//     attribute's base class, a Type property can be queried using the |type|
+//     method to determine which type of the attribute is being used. For
+//     example, the Blend type of ColorFilter will return DlColorFilter::kBlend
+//     from its type method.
+//
+// - Inspectable:
+//     Any parameters required to full specify the action of the attribute are
+//     provided on the type-specific classes.
+//
+// - Safely Downcast:
+//     For the subclasses that have specific data to query, methods are
+//     provided to safely downcast the reference for inspection. The down
+//     casting method will either return a pointer to the instance with
+//     its type-specific class type, or nullptr if it is executed on the
+//     wrong type of instance.
+//     (eg. DlColorFilter::asBlend() or DlMaskFilter::asBlur())
+//
+// - Skiafiable:
+//     The classes override an |skia_object| method to easily obtain a Skia
+//     version of the attribute on demand.
+//
+// - Immutable:
+//     Neither the base class or any of the subclasses specify any mutation
+//     methods. Instances are often passed around as const as a reminder,
+//     but the classes have no mutation methods anyway.
+//
+// - Flat and Embeddable:
+//     Bulk freed + bulk compared + zero memory fragmentation.
+//
+//     All of these classes are designed to be stored in the DisplayList
+//     buffer allocated in-line with the rest of the data to avoid dangling
+//     pointers that require explicit freeing when the DisplayList goes
+//     away, or that fragment the memory needed to read the operations in
+//     the DisplayList. Furthermore, the data in the classes can be bulk
+//     compared using a |memcmp| when performing a |DisplayList::Equals|.
+//
+// - Passed by Pointer:
+//     The data shared via the |Dispatcher::set<Attribute>| calls are stored
+//     in the buffer itself and so their lifetime is controlled by the
+//     DisplayList. That memory cannot be shared as by a |shared_ptr|
+//     because the memory may be freed outside the control of the shared
+//     pointer. Creating a shared version of the object would require a
+//     new instantiation which we'd like to avoid on every dispatch call,
+//     so a raw (const) pointer is shared in those dispatch calls instead,
+//     with all of the responsibilities of non-ownership in the called method.
+//
+//     But, for methods that need to keep a copy of the data...
+//
+// - Shared_Ptr-able:
+//     The classes support a method to return a |std::shared_ptr| version of
+//     themselves, safely instantiating a new copy of the object into a
+//     shared_ptr using |std::make_shared|. For those dispatcher objects
+//     that may want to hold on to the contents of the object (typically
+//     in a |current_attribute_| field), they can obtain a shared_ptr
+//     copy safely and easily using the |shared| method.
+
+// ===========================================================================
+
+// |D| is the base type for the attribute
+//     (i.e. DlColorFilter, etc.)
+// |S| is the base type for the Skia version of the attribute
+//     (i.e. SkColorFilter, etc.)
+// |T| is the enum that describes the specific subclasses
+//     (i.e DlColorFilterType, etc.)
+template <class D, class S, typename T>
+class DlAttribute {
+ public:
+  // Return the recognized specific type of the attribute.
+  virtual T type() const = 0;
+
+  // Return the size of the instantiated data (typically used to allocate)
+  // storage in the DisplayList buffer.
+  virtual size_t size() const = 0;
+
+  // Return a shared version of |this| attribute. The |shared_ptr| returned
+  // will reference a copy of this object so that the lifetime of the shared
+  // version is not tied to the storage of this particular instance.
+  virtual std::shared_ptr<D> shared() const = 0;
+
+  // Return an equivalent sk_sp<Skia> version of this object.
+  virtual sk_sp<S> skia_object() const = 0;
+
+  // Perform a content aware |==| comparison of the ColorFilter.
+  bool operator==(D const& other) const {
+    return type() == other.type() && equals_(other);
+  }
+  // Perform a content aware |!=| comparison of the ColorFilter.
+  bool operator!=(D const& other) const {
+    return !(*this == other);
+  }
+
+  virtual ~DlAttribute() = default;
+
+ protected:
+  // Virtual comparison method to support |==| and |!=|.
+  virtual bool equals_(D const& other) const = 0;
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_DISPLAY_LIST_DISPLAY_LIST_ATTRIBUTES_H_

--- a/display_list/display_list_attributes.h
+++ b/display_list/display_list_attributes.h
@@ -107,9 +107,7 @@ class DlAttribute {
     return type() == other.type() && equals_(other);
   }
   // Perform a content aware |!=| comparison of the ColorFilter.
-  bool operator!=(D const& other) const {
-    return !(*this == other);
-  }
+  bool operator!=(D const& other) const { return !(*this == other); }
 
   virtual ~DlAttribute() = default;
 

--- a/display_list/display_list_attributes.h
+++ b/display_list/display_list_attributes.h
@@ -6,7 +6,6 @@
 #define FLUTTER_DISPLAY_LIST_DISPLAY_LIST_ATTRIBUTES_H_
 
 #include "flutter/display_list/types.h"
-#include "flutter/fml/logging.h"
 
 namespace flutter {
 

--- a/display_list/display_list_builder.cc
+++ b/display_list/display_list_builder.cc
@@ -141,32 +141,32 @@ void DisplayListBuilder::onSetColorFilter(const DlColorFilter* filter) {
   } else {
     current_color_filter_ = filter->shared();
     switch (filter->type()) {
-      case DlColorFilter::kBlend: {
+      case DlColorFilterType::kBlend: {
         const DlBlendColorFilter* blend_filter = filter->asBlend();
         FML_DCHECK(blend_filter);
         void* pod = Push<SetColorFilterOp>(blend_filter->size(), 0);
         new (pod) DlBlendColorFilter(blend_filter);
         break;
       }
-      case DlColorFilter::kMatrix: {
+      case DlColorFilterType::kMatrix: {
         const DlMatrixColorFilter* matrix_filter = filter->asMatrix();
         FML_DCHECK(matrix_filter);
         void* pod = Push<SetColorFilterOp>(matrix_filter->size(), 0);
         new (pod) DlMatrixColorFilter(matrix_filter);
         break;
       }
-      case DlColorFilter::kSrgbToLinearGamma: {
+      case DlColorFilterType::kSrgbToLinearGamma: {
         void* pod = Push<SetColorFilterOp>(filter->size(), 0);
         new (pod) DlSrgbToLinearGammaColorFilter();
         break;
       }
-      case DlColorFilter::kLinearToSrgbGamma: {
+      case DlColorFilterType::kLinearToSrgbGamma: {
         void* pod = Push<SetColorFilterOp>(filter->size(), 0);
         new (pod) DlLinearToSrgbGammaColorFilter();
         break;
       }
-      case DlColorFilter::kUnknown: {
-        Push<SetSkColorFilterOp>(0, 0, filter->sk_filter());
+      case DlColorFilterType::kUnknown: {
+        Push<SetSkColorFilterOp>(0, 0, filter->skia_object());
         break;
       }
     }
@@ -185,15 +185,15 @@ void DisplayListBuilder::onSetMaskFilter(const DlMaskFilter* filter) {
   } else {
     current_mask_filter_ = filter->shared();
     switch (filter->type()) {
-      case DlMaskFilter::kBlur: {
+      case DlMaskFilterType::kBlur: {
         const DlBlurMaskFilter* blur_filter = filter->asBlur();
         FML_DCHECK(blur_filter);
         void* pod = Push<SetMaskFilterOp>(blur_filter->size(), 0);
         new (pod) DlBlurMaskFilter(blur_filter);
         break;
       }
-      case DlMaskFilter::kUnknown:
-        Push<SetSkMaskFilterOp>(0, 0, filter->sk_filter());
+      case DlMaskFilterType::kUnknown:
+        Push<SetSkMaskFilterOp>(0, 0, filter->skia_object());
         break;
     }
   }

--- a/display_list/display_list_canvas_unittests.cc
+++ b/display_list/display_list_canvas_unittests.cc
@@ -843,7 +843,7 @@ class CanvasCompareTester {
                        "saveLayer ColorFilter, no bounds",
                        [=](SkCanvas* cv, SkPaint& p) {
                          SkPaint save_p;
-                         save_p.setColorFilter(filter.sk_filter());
+                         save_p.setColorFilter(filter.skia_object());
                          cv->saveLayer(nullptr, &save_p);
                          p.setStrokeWidth(5.0);
                        },
@@ -861,7 +861,7 @@ class CanvasCompareTester {
                        "saveLayer ColorFilter and bounds",
                        [=](SkCanvas* cv, SkPaint& p) {
                          SkPaint save_p;
-                         save_p.setColorFilter(filter.sk_filter());
+                         save_p.setColorFilter(filter.skia_object());
                          cv->saveLayer(RenderBounds, &save_p);
                          p.setStrokeWidth(5.0);
                        },
@@ -1149,7 +1149,7 @@ class CanvasCompareTester {
                        "ColorFilter == RotateRGB",
                        [=](SkCanvas*, SkPaint& p) {
                          p.setColor(SK_ColorYELLOW);
-                         p.setColorFilter(filter.sk_filter());
+                         p.setColorFilter(filter.skia_object());
                        },
                        [=](DisplayListBuilder& b) {
                          b.setColor(SK_ColorYELLOW);
@@ -1165,7 +1165,7 @@ class CanvasCompareTester {
                        "ColorFilter == Invert",
                        [=](SkCanvas*, SkPaint& p) {
                          p.setColor(SK_ColorYELLOW);
-                         p.setColorFilter(filter.sk_filter());
+                         p.setColorFilter(filter.skia_object());
                        },
                        [=](DisplayListBuilder& b) {
                          b.setColor(SK_ColorYELLOW);
@@ -1246,7 +1246,7 @@ class CanvasCompareTester {
                        "MaskFilter == Blur 5",
                        [=](SkCanvas*, SkPaint& p) {
                          p.setStrokeWidth(5.0);
-                         p.setMaskFilter(filter.sk_filter());
+                         p.setMaskFilter(filter.skia_object());
                        },
                        [=](DisplayListBuilder& b) {
                          b.setStrokeWidth(5.0);

--- a/display_list/display_list_color_filter_unittests.cc
+++ b/display_list/display_list_color_filter_unittests.cc
@@ -27,7 +27,7 @@ TEST(DisplayListColorFilter, FromSkiaBlendFilter) {
       SkColorFilters::Blend(SK_ColorRED, SkBlendMode::kDstATop);
   std::shared_ptr<DlColorFilter> filter = DlColorFilter::From(sk_filter);
   DlBlendColorFilter dl_filter(SK_ColorRED, SkBlendMode::kDstATop);
-  ASSERT_EQ(filter->type(), DlColorFilter::kBlend);
+  ASSERT_EQ(filter->type(), DlColorFilterType::kBlend);
   ASSERT_NE(filter->asBlend(), nullptr);
   ASSERT_EQ(filter->asMatrix(), nullptr);
   ASSERT_EQ(*filter->asBlend(), dl_filter);
@@ -39,7 +39,7 @@ TEST(DisplayListColorFilter, FromSkiaMatrixFilter) {
   sk_sp<SkColorFilter> sk_filter = SkColorFilters::Matrix(matrix);
   std::shared_ptr<DlColorFilter> filter = DlColorFilter::From(sk_filter);
   DlMatrixColorFilter dl_filter(matrix);
-  ASSERT_EQ(filter->type(), DlColorFilter::kMatrix);
+  ASSERT_EQ(filter->type(), DlColorFilterType::kMatrix);
   ASSERT_EQ(filter->asBlend(), nullptr);
   ASSERT_NE(filter->asMatrix(), nullptr);
   ASSERT_EQ(*filter->asMatrix(), dl_filter);
@@ -52,7 +52,7 @@ TEST(DisplayListColorFilter, FromSkiaMatrixFilter) {
 TEST(DisplayListColorFilter, FromSkiaSrgbToLinearFilter) {
   sk_sp<SkColorFilter> sk_filter = SkColorFilters::SRGBToLinearGamma();
   std::shared_ptr<DlColorFilter> filter = DlColorFilter::From(sk_filter);
-  ASSERT_EQ(filter->type(), DlColorFilter::kSrgbToLinearGamma);
+  ASSERT_EQ(filter->type(), DlColorFilterType::kSrgbToLinearGamma);
   ASSERT_EQ(filter->asBlend(), nullptr);
   ASSERT_EQ(filter->asMatrix(), nullptr);
 }
@@ -60,7 +60,7 @@ TEST(DisplayListColorFilter, FromSkiaSrgbToLinearFilter) {
 TEST(DisplayListColorFilter, FromSkiaLinearToSrgbFilter) {
   sk_sp<SkColorFilter> sk_filter = SkColorFilters::LinearToSRGBGamma();
   std::shared_ptr<DlColorFilter> filter = DlColorFilter::From(sk_filter);
-  ASSERT_EQ(filter->type(), DlColorFilter::kLinearToSrgbGamma);
+  ASSERT_EQ(filter->type(), DlColorFilterType::kLinearToSrgbGamma);
   ASSERT_EQ(filter->asBlend(), nullptr);
   ASSERT_EQ(filter->asMatrix(), nullptr);
 }
@@ -73,10 +73,10 @@ TEST(DisplayListColorFilter, FromSkiaUnrecognizedFilter) {
   sk_sp<SkColorFilter> sk_filter =
       SkColorFilters::Compose(sk_inputA, sk_inputB);
   std::shared_ptr<DlColorFilter> filter = DlColorFilter::From(sk_filter);
-  ASSERT_EQ(filter->type(), DlColorFilter::kUnknown);
+  ASSERT_EQ(filter->type(), DlColorFilterType::kUnknown);
   ASSERT_EQ(filter->asBlend(), nullptr);
   ASSERT_EQ(filter->asMatrix(), nullptr);
-  ASSERT_EQ(filter->sk_filter(), sk_filter);
+  ASSERT_EQ(filter->skia_object(), sk_filter);
 }
 
 TEST(DisplayListColorFilter, BlendConstructor) {
@@ -233,8 +233,8 @@ TEST(DisplayListColorFilter, UnknownShared) {
 TEST(DisplayListColorFilter, UnknownContents) {
   sk_sp<SkColorFilter> sk_filter = SkColorFilters::LinearToSRGBGamma();
   DlUnknownColorFilter filter(sk_filter);
-  ASSERT_EQ(sk_filter, filter.sk_filter());
-  ASSERT_EQ(sk_filter.get(), filter.sk_filter().get());
+  ASSERT_EQ(sk_filter, filter.skia_object());
+  ASSERT_EQ(sk_filter.get(), filter.skia_object().get());
 }
 
 TEST(DisplayListColorFilter, UnknownEquals) {

--- a/display_list/display_list_mask_filter.h
+++ b/display_list/display_list_mask_filter.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_DISPLAY_LIST_DISPLAY_LIST_MASK_FILTER_H_
 #define FLUTTER_DISPLAY_LIST_DISPLAY_LIST_MASK_FILTER_H_
 
+#include "flutter/display_list/display_list_attributes.h"
 #include "flutter/display_list/types.h"
 #include "flutter/fml/logging.h"
 
@@ -12,73 +13,24 @@ namespace flutter {
 
 class DlBlurMaskFilter;
 
-// The DisplayList MaskFilter class. This class was designed to be:
-//
-// - Typed:
-//     Even though most references and pointers are passed around as the
-//     base class, a DlMaskFilter::Type can be queried using the |type|
-//     method to determine which type of MaskFilter is being used.
-//
-// - Inspectable:
-//     Any parameters required to full specify the filtering operations are
-//     provided on the specific base classes.
-//
-// - Safely Downcast:
-//     For the subclasses that have specific data to query, methods |asBlur|
-//     are provided to safely downcast the reference for inspection.
-//
-// - Skiafiable:
-//     The classes override an |sk_filter| method to easily obtain a Skia
-//     version of the filter on demand.
-//
-// - Immutable:
-//     Neither the base class or any of the subclasses specify any mutation
-//     methods. Instances are often passed around as const as a reminder,
-//     but the classes have no mutation methods anyway.
-//
-// - Flat and Embeddable:
-//     Bulk freed + bulk compared + zero memory fragmentation.
-//
-//     All of these classes are designed to be stored in the DisplayList
-//     buffer allocated in-line with the rest of the data to avoid dangling
-//     pointers that require explicit freeing when the DisplayList goes
-//     away, or that fragment the memory needed to read the operations in
-//     the DisplayList. Furthermore, the data in the classes can be bulk
-//     compared using a |memcmp| when performing a |DisplayList::Equals|.
-//
-// - Passed by Pointer:
-//     The data shared via the |Dispatcher::setMaskFilter| call is stored
-//     in the buffer itself and so its lifetime is controlled by the
-//     DisplayList. That memory cannot be shared as by a |shared_ptr|
-//     because the memory may be freed outside the control of the shared
-//     pointer. Creating a shared version of the object would require a
-//     new instantiation which we'd like to avoid on every dispatch call,
-//     so a raw (const) pointer is shared instead with all of the
-//     responsibilities of non-ownership in the called method.
-//
-//     But, for methods that need to keep a copy of the data...
-//
-// - Shared_Ptr-able:
-//     The classes support a method to return a |std::shared_ptr| version of
-//     themselves, safely instantiating a new copy of the object into a
-//     shared_ptr using |std::make_shared|. For those dispatcher objects
-//     that may want to hold on to the contents of the object (typically
-//     in a |current_mask_filter_| field), they can obtain a shared_ptr
-//     copy safely and easily using the |shared| method.
+// The DisplayList MaskFilter class. This class implements all of the
+// facilities and adheres to the design goals of the |DlAttribute| base
+// class.
 
-class DlMaskFilter {
+// An enumerated type for the recognized MaskFilter operations.
+// If a custom MaskFilter outside of the recognized types is needed
+// then a |kUnknown| type that simply defers to an SkMaskFilter is
+// provided as a fallback.
+enum class DlMaskFilterType { kBlur, kUnknown };
+
+class DlMaskFilter
+    : public DlAttribute<DlMaskFilter, SkMaskFilter, DlMaskFilterType> {
  public:
-  // An enumerated type for the recognized MaskFilter operations.
-  // If a custom MaskFilter outside of the recognized types is needed
-  // then a |kUnknown| type that simply defers to an SkMaskFilter is
-  // provided as a fallback.
-  enum Type { kBlur, kUnknown };
-
   // Return a shared_ptr holding a DlMaskFilter representing the indicated
   // Skia SkMaskFilter pointer.
   //
   // Since there is no public SkBlurMaskFilter and since the SkMaskFilter
-  // class provides no |asABlur| style type inference methods, we cannot
+  // class provides no |asABlur| style type inference method, we cannot
   // infer any specific data from the SkMaskFilter. As a result, the return
   // value in this case will always be nullptr or DlUnknownMaskFilter.
   static std::shared_ptr<DlMaskFilter> From(SkMaskFilter* sk_filter);
@@ -94,37 +46,9 @@ class DlMaskFilter {
     return From(sk_filter.get());
   }
 
-  // Return the recognized type of the MaskFilter operation.
-  virtual Type type() const = 0;
-
-  // Return the size of the instantiated data (typically used to allocate)
-  // storage in the DisplayList buffer.
-  virtual size_t size() const = 0;
-
-  // Return a shared version of |this| MaskFilter. The |shared_ptr| returned
-  // will reference a copy of this object so that the lifetime of the shared
-  // version is not tied to the storage of this particular instance.
-  virtual std::shared_ptr<DlMaskFilter> shared() const = 0;
-
-  // Return an equivalent |SkMaskFilter| version of this object.
-  virtual sk_sp<SkMaskFilter> sk_filter() const = 0;
-
   // Return a DlBlurMaskFilter pointer to this object iff it is a Blur
   // type of MaskFilter, otherwise return nullptr.
   virtual const DlBlurMaskFilter* asBlur() const { return nullptr; }
-
-  // Perform a content aware |==| comparison of the MaskFilter.
-  bool operator==(DlMaskFilter const& other) const {
-    return type() == other.type() && equals_(other);
-  }
-  // Perform a content aware |!=| comparison of the ColorFilter.
-  bool operator!=(DlMaskFilter const& other) const { return !(*this == other); }
-
-  virtual ~DlMaskFilter() = default;
-
- protected:
-  // Virtual comparison method to support |==| and |!=|.
-  virtual bool equals_(DlMaskFilter const& other) const = 0;
 };
 
 // The Blur type of MaskFilter which specifies modifying the
@@ -141,14 +65,14 @@ class DlBlurMaskFilter final : public DlMaskFilter {
   DlBlurMaskFilter(const DlBlurMaskFilter* filter)
       : DlBlurMaskFilter(filter->style_, filter->sigma_) {}
 
-  Type type() const override { return kBlur; }
+  DlMaskFilterType type() const override { return DlMaskFilterType::kBlur; }
   size_t size() const override { return sizeof(*this); }
 
   std::shared_ptr<DlMaskFilter> shared() const override {
     return std::make_shared<DlBlurMaskFilter>(this);
   }
 
-  sk_sp<SkMaskFilter> sk_filter() const override {
+  sk_sp<SkMaskFilter> skia_object() const override {
     return SkMaskFilter::MakeBlur(style_, sigma_);
   }
 
@@ -159,7 +83,7 @@ class DlBlurMaskFilter final : public DlMaskFilter {
 
  protected:
   bool equals_(DlMaskFilter const& other) const override {
-    FML_DCHECK(other.type() == kBlur);
+    FML_DCHECK(other.type() == DlMaskFilterType::kBlur);
     auto that = static_cast<DlBlurMaskFilter const&>(other);
     return style_ == that.style_ && sigma_ == that.sigma_;
   }
@@ -185,20 +109,20 @@ class DlUnknownMaskFilter final : public DlMaskFilter {
   DlUnknownMaskFilter(const DlUnknownMaskFilter* filter)
       : DlUnknownMaskFilter(filter->sk_filter_) {}
 
-  Type type() const override { return kUnknown; }
+  DlMaskFilterType type() const override { return DlMaskFilterType::kUnknown; }
   size_t size() const override { return sizeof(*this); }
 
   std::shared_ptr<DlMaskFilter> shared() const override {
     return std::make_shared<DlUnknownMaskFilter>(this);
   }
 
-  sk_sp<SkMaskFilter> sk_filter() const override { return sk_filter_; }
+  sk_sp<SkMaskFilter> skia_object() const override { return sk_filter_; }
 
   virtual ~DlUnknownMaskFilter() = default;
 
  protected:
   bool equals_(const DlMaskFilter& other) const override {
-    FML_DCHECK(other.type() == kUnknown);
+    FML_DCHECK(other.type() == DlMaskFilterType::kUnknown);
     auto that = static_cast<DlUnknownMaskFilter const&>(other);
     return sk_filter_ == that.sk_filter_;
   }

--- a/display_list/display_list_mask_filter_unittests.cc
+++ b/display_list/display_list_mask_filter_unittests.cc
@@ -20,9 +20,9 @@ TEST(DisplayListMaskFilter, FromSkiaBlurFilter) {
   sk_sp<SkMaskFilter> sk_filter =
       SkMaskFilter::MakeBlur(SkBlurStyle::kNormal_SkBlurStyle, 5.0);
   std::shared_ptr<DlMaskFilter> filter = DlMaskFilter::From(sk_filter);
-  ASSERT_EQ(filter->type(), DlMaskFilter::kUnknown);
+  ASSERT_EQ(filter->type(), DlMaskFilterType::kUnknown);
   ASSERT_EQ(filter->asBlur(), nullptr);
-  ASSERT_EQ(filter->sk_filter(), sk_filter);
+  ASSERT_EQ(filter->skia_object(), sk_filter);
 }
 
 TEST(DisplayListMaskFilter, BlurConstructor) {
@@ -86,8 +86,8 @@ TEST(DisplayListMaskFilter, UnknownContents) {
   sk_sp<SkMaskFilter> sk_filter =
       SkMaskFilter::MakeBlur(SkBlurStyle::kNormal_SkBlurStyle, 5.0);
   DlUnknownMaskFilter filter(sk_filter);
-  ASSERT_EQ(filter.sk_filter(), sk_filter);
-  ASSERT_EQ(filter.sk_filter().get(), sk_filter.get());
+  ASSERT_EQ(filter.skia_object(), sk_filter);
+  ASSERT_EQ(filter.skia_object().get(), sk_filter.get());
 }
 
 TEST(DisplayListMaskFilter, UnknownEquals) {

--- a/display_list/display_list_unittests.cc
+++ b/display_list/display_list_unittests.cc
@@ -1044,7 +1044,7 @@ TEST(DisplayList, DisplayListSaveLayerBoundsWithAlphaFilter) {
     SkRTreeFactory rtree_factory;
     SkCanvas* canvas = recorder.beginRecording(build_bounds, &rtree_factory);
     SkPaint p1;
-    p1.setColorFilter(alpha_color_filter.sk_filter());
+    p1.setColorFilter(alpha_color_filter.skia_object());
     canvas->saveLayer(save_bounds, &p1);
     SkPaint p2;
     canvas->drawRect(rect, p2);
@@ -1086,7 +1086,7 @@ TEST(DisplayList, DisplayListSaveLayerBoundsWithAlphaFilter) {
     // generate the same behavior as setting it as a ColorFilter
     DisplayListBuilder builder(build_bounds);
     builder.setImageFilter(
-        SkImageFilters::ColorFilter(base_color_filter.sk_filter(), nullptr));
+        SkImageFilters::ColorFilter(base_color_filter.skia_object(), nullptr));
     builder.saveLayer(&save_bounds, true);
     builder.setImageFilter(nullptr);
     builder.drawRect(rect);
@@ -1100,7 +1100,7 @@ TEST(DisplayList, DisplayListSaveLayerBoundsWithAlphaFilter) {
     // will generate the same behavior as setting it as a ColorFilter
     DisplayListBuilder builder(build_bounds);
     builder.setImageFilter(
-        SkImageFilters::ColorFilter(alpha_color_filter.sk_filter(), nullptr));
+        SkImageFilters::ColorFilter(alpha_color_filter.skia_object(), nullptr));
     builder.saveLayer(&save_bounds, true);
     builder.setImageFilter(nullptr);
     builder.drawRect(rect);
@@ -1113,7 +1113,7 @@ TEST(DisplayList, DisplayListSaveLayerBoundsWithAlphaFilter) {
     // Same as above (ImageFilter hiding ColorFilter) with no save bounds
     DisplayListBuilder builder(build_bounds);
     builder.setImageFilter(
-        SkImageFilters::ColorFilter(alpha_color_filter.sk_filter(), nullptr));
+        SkImageFilters::ColorFilter(alpha_color_filter.skia_object(), nullptr));
     builder.saveLayer(nullptr, true);
     builder.setImageFilter(nullptr);
     builder.drawRect(rect);

--- a/display_list/display_list_utils.cc
+++ b/display_list/display_list_utils.cc
@@ -87,17 +87,17 @@ void SkPaintDispatchHelper::setPathEffect(sk_sp<SkPathEffect> effect) {
   paint_.setPathEffect(effect);
 }
 void SkPaintDispatchHelper::setMaskFilter(const DlMaskFilter* filter) {
-  paint_.setMaskFilter(filter ? filter->sk_filter() : nullptr);
+  paint_.setMaskFilter(filter ? filter->skia_object() : nullptr);
 }
 
 sk_sp<SkColorFilter> SkPaintDispatchHelper::makeColorFilter() const {
   if (!invert_colors_) {
-    return color_filter_ ? color_filter_->sk_filter() : nullptr;
+    return color_filter_ ? color_filter_->skia_object() : nullptr;
   }
   sk_sp<SkColorFilter> invert_filter =
       SkColorFilters::Matrix(invert_color_matrix);
   if (color_filter_) {
-    invert_filter = invert_filter->makeComposed(color_filter_->sk_filter());
+    invert_filter = invert_filter->makeComposed(color_filter_->skia_object());
   }
   return invert_filter;
 }
@@ -597,7 +597,7 @@ bool DisplayListBoundsCalculator::AdjustBoundsForPaint(
         bounds.outset(mask_sigma_pad, mask_sigma_pad);
       } else {
         SkPaint p;
-        p.setMaskFilter(mask_filter_->sk_filter());
+        p.setMaskFilter(mask_filter_->skia_object());
         if (!p.canComputeFastBounds()) {
           return false;
         }

--- a/lib/ui/compositing/scene_builder.cc
+++ b/lib/ui/compositing/scene_builder.cc
@@ -177,7 +177,7 @@ void SceneBuilder::pushColorFilter(Dart_Handle layer_handle,
                                    const ColorFilter* color_filter,
                                    fml::RefPtr<EngineLayer> oldLayer) {
   auto layer = std::make_shared<flutter::ColorFilterLayer>(
-      color_filter->filter()->sk_filter());
+      color_filter->filter()->skia_object());
   PushLayer(layer);
   EngineLayer::MakeRetained(layer_handle, layer);
 

--- a/lib/ui/painting/image_filter.cc
+++ b/lib/ui/painting/image_filter.cc
@@ -92,7 +92,7 @@ void ImageFilter::initMatrix(const tonic::Float64List& matrix4,
 
 void ImageFilter::initColorFilter(ColorFilter* colorFilter) {
   filter_ = SkImageFilters::ColorFilter(
-      colorFilter ? colorFilter->filter()->sk_filter() : nullptr, nullptr);
+      colorFilter ? colorFilter->filter()->skia_object() : nullptr, nullptr);
 }
 
 void ImageFilter::initComposeFilter(ImageFilter* outer, ImageFilter* inner) {

--- a/lib/ui/painting/paint.cc
+++ b/lib/ui/painting/paint.cc
@@ -105,7 +105,7 @@ const SkPaint* Paint::paint(SkPaint& paint) const {
     if (!Dart_IsNull(color_filter)) {
       ColorFilter* decoded_color_filter =
           tonic::DartConverter<ColorFilter*>::FromDart(color_filter);
-      paint.setColorFilter(decoded_color_filter->filter()->sk_filter());
+      paint.setColorFilter(decoded_color_filter->filter()->skia_object());
     }
 
     Dart_Handle image_filter = values[kImageFilterIndex];


### PR DESCRIPTION
Per the https://github.com/flutter/engine/pull/31535#discussion_r809661631 comment when the DlMaskFilter objects were created I am collecting the common methods for the 2 existing DisplayList attributes (DlColorFilter and DlMaskFilter) into a common attribute-spanning base class.

This PR adds no new functionality. It is just a code consolidation cleanup.