### PR TITLE
Fix copy/paste when scribble enabled

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h
@@ -148,6 +148,7 @@ FLUTTER_DARWIN_EXPORT
 @property(nonatomic) FlutterScribbleFocusStatus scribbleFocusStatus;
 @property(nonatomic, strong) NSArray<FlutterTextSelectionRect*>* selectionRects;
 - (void)resetScribbleInteractionStatusIfEnding;
+- (BOOL)isScribbleAvailable;
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -1048,7 +1048,7 @@ static BOOL IsScribbleAvailable() {
 - (BOOL)canPerformAction:(SEL)action withSender:(id)sender {
   // When scribble is available, the FlutterTextInputView will display the native toolbar unless
   // these text editing actions are disabled.
-  if (IsScribbleAvailable()) {
+  if (IsScribbleAvailable() && sender == NULL) {
     return NO;
   }
   if (action == @selector(paste:)) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -467,17 +467,6 @@ static BOOL IsSelectionRectCloserToPoint(CGPoint point,
                                  (isBelowBottomOfLine && isFartherToRight))));
 }
 
-// Checks whether Scribble features are possibly available – meaning this is an iPad running iOS
-// 14 or higher.
-static BOOL IsScribbleAvailable() {
-  if (@available(iOS 14.0, *)) {
-    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
-      return YES;
-    }
-  }
-  return NO;
-}
-
 #pragma mark - FlutterTextPosition
 
 @implementation FlutterTextPosition
@@ -1013,6 +1002,17 @@ static BOOL IsScribbleAvailable() {
 
 #pragma mark UIScribbleInteractionDelegate
 
+// Checks whether Scribble features are possibly available – meaning this is an iPad running iOS
+// 14 or higher.
+- (BOOL)isScribbleAvailable {
+  if (@available(iOS 14.0, *)) {
+    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+      return YES;
+    }
+  }
+  return NO;
+}
+
 - (void)scribbleInteractionWillBeginWriting:(UIScribbleInteraction*)interaction
     API_AVAILABLE(ios(14.0)) {
   _scribbleInteractionStatus = FlutterScribbleInteractionStatusStarted;
@@ -1048,7 +1048,7 @@ static BOOL IsScribbleAvailable() {
 - (BOOL)canPerformAction:(SEL)action withSender:(id)sender {
   // When scribble is available, the FlutterTextInputView will display the native toolbar unless
   // these text editing actions are disabled.
-  if (IsScribbleAvailable() && sender == NULL) {
+  if ([self isScribbleAvailable] && sender == NULL) {
     return NO;
   }
   if (action == @selector(paste:)) {
@@ -2077,7 +2077,7 @@ static BOOL IsScribbleAvailable() {
 
 - (void)setEditableSizeAndTransform:(NSDictionary*)dictionary {
   [_activeView setEditableTransform:dictionary[@"transform"]];
-  if (IsScribbleAvailable()) {
+  if ([_activeView isScribbleAvailable]) {
     // This is necessary to set up where the scribble interactable element will be.
     int leftIndex = 12;
     int topIndex = 13;

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -867,28 +867,28 @@ FLUTTER_ASSERT_ARC
 }
 
 - (void)testCanCopyPasteWithScribbleEnabled {
-  if (UI_USER_INTERFACE_IDIOM() != UIUserInterfaceIdiomPad) {
-    return;
-  }
   if (@available(iOS 14.0, *)) {
     NSDictionary* config = self.mutableTemplateCopy;
     [self setClientId:123 configuration:config];
     NSArray<FlutterTextInputView*>* inputFields = self.installedInputViews;
     FlutterTextInputView* inputView = inputFields[0];
 
-    [inputView insertText:@"aaaa"];
-    [inputView selectAll:nil];
+    FlutterTextInputView* mockInputView = OCMPartialMock(inputView);
+    OCMStub([mockInputView isScribbleAvailable]).andReturn(YES);
 
-    XCTAssertFalse([inputView canPerformAction:@selector(copy:) withSender:NULL]);
-    XCTAssertTrue([inputView canPerformAction:@selector(copy:) withSender:@"sender"]);
-    XCTAssertFalse([inputView canPerformAction:@selector(paste:) withSender:NULL]);
-    XCTAssertFalse([inputView canPerformAction:@selector(paste:) withSender:@"sender"]);
+    [mockInputView insertText:@"aaaa"];
+    [mockInputView selectAll:nil];
 
-    [inputView copy:NULL];
-    XCTAssertFalse([inputView canPerformAction:@selector(copy:) withSender:NULL]);
-    XCTAssertTrue([inputView canPerformAction:@selector(copy:) withSender:@"sender"]);
-    XCTAssertFalse([inputView canPerformAction:@selector(paste:) withSender:NULL]);
-    XCTAssertTrue([inputView canPerformAction:@selector(paste:) withSender:@"sender"]);
+    XCTAssertFalse([mockInputView canPerformAction:@selector(copy:) withSender:NULL]);
+    XCTAssertTrue([mockInputView canPerformAction:@selector(copy:) withSender:@"sender"]);
+    XCTAssertFalse([mockInputView canPerformAction:@selector(paste:) withSender:NULL]);
+    XCTAssertFalse([mockInputView canPerformAction:@selector(paste:) withSender:@"sender"]);
+
+    [mockInputView copy:NULL];
+    XCTAssertFalse([mockInputView canPerformAction:@selector(copy:) withSender:NULL]);
+    XCTAssertTrue([mockInputView canPerformAction:@selector(copy:) withSender:@"sender"]);
+    XCTAssertFalse([mockInputView canPerformAction:@selector(paste:) withSender:NULL]);
+    XCTAssertTrue([mockInputView canPerformAction:@selector(paste:) withSender:@"sender"]);
   }
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -866,6 +866,32 @@ FLUTTER_ASSERT_ARC
   XCTAssertEqual(updateCount, 2);
 }
 
+- (void)testCanCopyPasteWithScribbleEnabled {
+  if (UI_USER_INTERFACE_IDIOM() != UIUserInterfaceIdiomPad) {
+    return;
+  }
+  if (@available(iOS 14.0, *)) {
+    NSDictionary* config = self.mutableTemplateCopy;
+    [self setClientId:123 configuration:config];
+    NSArray<FlutterTextInputView*>* inputFields = self.installedInputViews;
+    FlutterTextInputView* inputView = inputFields[0];
+
+    [inputView insertText:@"aaaa"];
+    [inputView selectAll:nil];
+
+    XCTAssertFalse([inputView canPerformAction:@selector(copy:) withSender:NULL]);
+    XCTAssertTrue([inputView canPerformAction:@selector(copy:) withSender:@"sender"]);
+    XCTAssertFalse([inputView canPerformAction:@selector(paste:) withSender:NULL]);
+    XCTAssertFalse([inputView canPerformAction:@selector(paste:) withSender:@"sender"]);
+
+    [inputView copy:NULL];
+    XCTAssertFalse([inputView canPerformAction:@selector(copy:) withSender:NULL]);
+    XCTAssertTrue([inputView canPerformAction:@selector(copy:) withSender:@"sender"]);
+    XCTAssertFalse([inputView canPerformAction:@selector(paste:) withSender:NULL]);
+    XCTAssertTrue([inputView canPerformAction:@selector(paste:) withSender:@"sender"]);
+  }
+}
+
 - (void)testSetMarkedTextDuringScribbleDoesNotTriggerUpdateEditingClient {
   if (@available(iOS 14.0, *)) {
     FlutterTextInputView* inputView = [[FlutterTextInputView alloc] initWithOwner:textInputPlugin];


### PR DESCRIPTION
The recent scribble PR (https://github.com/flutter/engine/pull/24224) broke cmd+c and cmd+v on scribble enabled devices.  The reason was [this line](https://github.com/flutter/engine/blob/main/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm#L1051), which seems to have been added to avoid the "[app] pasted" notification from showing up on every keystroke.

This solution returns YES when it receives a real copy/paste action and not just a key input, so copy and paste work and you won't get the notification on normal keyboard input.

Fixes https://github.com/flutter/flutter/issues/98832

CC @fbcouch 