### PR TITLE
Add no-prebuilt-dart-sdk support to fuchsia build

### DIFF
--- a/tools/fuchsia/build_fuchsia_artifacts.py
+++ b/tools/fuchsia/build_fuchsia_artifacts.py
@@ -268,7 +268,8 @@ def ProcessCIPDPackage(upload, engine_version):
   ])
 
 def BuildTarget(runtime_mode, arch, optimized, enable_lto, enable_legacy,
-                asan, dart_version_git_info, additional_targets=[]):
+                asan, dart_version_git_info, prebuilt_dart_sdk,
+                additional_targets=[]):
   unopt = "_unopt" if not optimized else ""
   out_dir = 'fuchsia_%s%s_%s' % (runtime_mode, unopt, arch)
   flags = [
@@ -290,6 +291,8 @@ def BuildTarget(runtime_mode, arch, optimized, enable_lto, enable_legacy,
     flags.append('--asan')
   if not dart_version_git_info:
     flags.append('--no-dart-version-git-info')
+  if not prebuilt_dart_sdk:
+    flags.append('--no-prebuilt-dart-sdk')
 
   RunGN(out_dir, flags)
   BuildNinjaTargets(out_dir, [ 'flutter' ] + additional_targets)
@@ -367,6 +370,12 @@ def main():
       action='store_true',
       default=False,
       help='If set, skips building and just creates packages.')
+  
+  parser.add_argument(
+      '--no-prebuilt-dart-sdk',
+      action='store_true',
+      default=False,
+      help='If set, builds the Dart SDK locally instead of downloading a prebuilt Dart SDK.')
 
   args = parser.parse_args()
   RemoveDirectoryIfExists(_bucket_directory)
@@ -379,6 +388,7 @@ def main():
   optimized = not args.unoptimized
   enable_lto = not args.no_lto
   enable_legacy = not args.no_legacy
+  prebuilt_dart_sdk = not args.no_prebuilt_dart_sdk
 
   # Build buckets
   for arch in archs:
@@ -389,6 +399,7 @@ def main():
         if not args.skip_build:
           BuildTarget(runtime_mode, arch, optimized, enable_lto, enable_legacy,
                       args.asan, not args.no_dart_version_git_info,
+                      prebuilt_dart_sdk,
                       args.targets.split(",") if args.targets else [])
         BuildBucket(runtime_mode, arch, optimized, product)
 

--- a/tools/fuchsia/build_fuchsia_artifacts.py
+++ b/tools/fuchsia/build_fuchsia_artifacts.py
@@ -370,7 +370,7 @@ def main():
       action='store_true',
       default=False,
       help='If set, skips building and just creates packages.')
-  
+
   parser.add_argument(
       '--no-prebuilt-dart-sdk',
       action='store_true',


### PR DESCRIPTION
build_fuchsia_artifacts.py is used by internal scripts to
build changes to the Flutter Engine for Fuchsia locally. If the user
has custom changes to the Dart SDK, this flag allows them to build
Flutter for Fuchsia with those custom changes included.