### PR TITLE
Standardize embedder archive name.

### DIFF
--- a/build/archives/BUILD.gn
+++ b/build/archives/BUILD.gn
@@ -97,6 +97,7 @@ if (host_os == "win") {
     deps = [
       "//flutter/shell/platform/common:publish_headers",
       "//flutter/shell/platform/windows:flutter_windows",
+      "//flutter/shell/platform/windows:publish_headers_windows",
     ]
     files = [
       {

--- a/build/archives/BUILD.gn
+++ b/build/archives/BUILD.gn
@@ -89,3 +89,40 @@ if (!is_fuchsia) {
     deps = [ "//flutter/web_sdk:flutter_web_sdk_archive" ]
   }
 }
+
+# Archives Flutter Windows Artifacts
+if (host_os == "win") {
+  zip_bundle("windows_flutter") {
+    output = "$full_platform_name-$flutter_runtime_mode/$full_platform_name-flutter.zip"
+    deps = [
+      "//flutter/shell/platform/common:publish_headers",
+      "//flutter/shell/platform/windows:flutter_windows",
+    ]
+    files = [
+      {
+        source = "$root_out_dir/flutter_export.h"
+        destination = "flutter_export.h"
+      },
+      {
+        source = "$root_out_dir/flutter_windows.h"
+        destination = "flutter_windows.h"
+      },
+      {
+        source = "$root_out_dir/flutter_messenger.h"
+        destination = "flutter_messenger.h"
+      },
+      {
+        source = "$root_out_dir/flutter_plugin_registrar.h"
+        destination = "flutter_plugin_registrar.h"
+      },
+      {
+        source = "$root_out_dir/flutter_texture_registrar.h"
+        destination = "flutter_texture_registrar.h"
+      },
+      {
+        source = "$root_out_dir/flutter_windows.dll"
+        destination = "flutter_windows.dll"
+      },
+    ]
+  }
+}

--- a/shell/platform/windows/client_wrapper/BUILD.gn
+++ b/shell/platform/windows/client_wrapper/BUILD.gn
@@ -115,7 +115,7 @@ if (host_os == "win") {
     deps = [
       ":client_wrapper_windows",
       "//flutter/shell/platform/common/client_wrapper:client_wrapper",
-      "//flutter/shell/platform/common/client_wrapper:publish_wrapper_windows",
+      "//flutter/shell/platform/windows/client_wrapper:publish_wrapper_windows",
     ]
     tmp_files = []
     foreach(source, client_wrapper_file_archive_list) {

--- a/shell/platform/windows/client_wrapper/BUILD.gn
+++ b/shell/platform/windows/client_wrapper/BUILD.gn
@@ -97,3 +97,45 @@ executable("client_wrapper_windows_unittests") {
     "//third_party/dart/runtime:libdart_jit",
   ]
 }
+
+if (host_os == "win") {
+  client_wrapper_file_archive_list = [
+    "core_implementations.cc",
+    "engine_method_result.cc",
+    "flutter_engine.cc",
+    "flutter_view_controller.cc",
+    "plugin_registrar.cc",
+    "README",
+    "standard_codec.cc",
+  ]
+
+  zip_bundle("client_wrapper_archive") {
+    output = "$full_platform_name/flutter-cpp-client-wrapper.zip"
+    deps = [
+      ":client_wrapper_windows",
+      "//flutter/shell/platform/common/client_wrapper:client_wrapper",
+    ]
+    tmp_files = []
+    foreach(source, client_wrapper_file_archive_list) {
+      tmp_files += [
+        {
+          source = "//flutter/shell/platform/common/client_wrapper/$source"
+          destination = "cpp_client_wrapper/$source"
+        },
+      ]
+    }
+    sources = core_cpp_client_wrapper_includes +
+              core_cpp_client_wrapper_internal_headers
+    foreach(source, sources) {
+      rebased_path =
+          rebase_path(source, "//flutter/shell/platform/common/client_wrapper")
+      tmp_files += [
+        {
+          source = source
+          destination = "cpp_client_wrapper/$rebased_path"
+        },
+      ]
+    }
+    files = tmp_files
+  }
+}

--- a/shell/platform/windows/client_wrapper/BUILD.gn
+++ b/shell/platform/windows/client_wrapper/BUILD.gn
@@ -115,6 +115,7 @@ if (host_os == "win") {
     deps = [
       ":client_wrapper_windows",
       "//flutter/shell/platform/common/client_wrapper:client_wrapper",
+      "//flutter/shell/platform/common/client_wrapper:publish_wrapper_windows",
     ]
     tmp_files = []
     foreach(source, client_wrapper_file_archive_list) {

--- a/shell/platform/windows/client_wrapper/BUILD.gn
+++ b/shell/platform/windows/client_wrapper/BUILD.gn
@@ -2,6 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import("//flutter/build/zip_bundle.gni")
 import("//flutter/shell/platform/common/client_wrapper/publish.gni")
 import("//flutter/testing/testing.gni")
 

--- a/shell/platform/windows/client_wrapper/BUILD.gn
+++ b/shell/platform/windows/client_wrapper/BUILD.gn
@@ -99,58 +99,56 @@ executable("client_wrapper_windows_unittests") {
   ]
 }
 
-if (host_os == "win") {
-  client_wrapper_file_archive_list = [
-    "core_implementations.cc",
-    "engine_method_result.cc",
-    "plugin_registrar.cc",
-    "README",
-    "standard_codec.cc",
-  ]
+client_wrapper_file_archive_list = [
+  "core_implementations.cc",
+  "engine_method_result.cc",
+  "plugin_registrar.cc",
+  "README",
+  "standard_codec.cc",
+]
 
-  win_client_wrapper_file_archive_list = [
-    "flutter_engine.cc",
-    "flutter_view_controller.cc",
-  ]
+win_client_wrapper_file_archive_list = [
+  "flutter_engine.cc",
+  "flutter_view_controller.cc",
+]
 
-  zip_bundle("client_wrapper_archive") {
-    output = "$full_platform_name/flutter-cpp-client-wrapper.zip"
-    deps = [
-      ":client_wrapper_windows",
-      "//flutter/shell/platform/common/client_wrapper:client_wrapper",
-      "//flutter/shell/platform/windows/client_wrapper:publish_wrapper_windows",
+zip_bundle("client_wrapper_archive") {
+  output = "$full_platform_name/flutter-cpp-client-wrapper.zip"
+  deps = [
+    ":client_wrapper_windows",
+    ":publish_wrapper_windows",
+    "//flutter/shell/platform/common/client_wrapper:client_wrapper",
+  ]
+  tmp_files = []
+  foreach(source, client_wrapper_file_archive_list) {
+    tmp_files += [
+      {
+        source = "//flutter/shell/platform/common/client_wrapper/$source"
+        destination = "cpp_client_wrapper/$source"
+      },
     ]
-    tmp_files = []
-    foreach(source, client_wrapper_file_archive_list) {
-      tmp_files += [
-        {
-          source = "//flutter/shell/platform/common/client_wrapper/$source"
-          destination = "cpp_client_wrapper/$source"
-        },
-      ]
-    }
-
-    # Windows specific source code files
-    foreach(source, win_client_wrapper_file_archive_list) {
-      tmp_files += [
-        {
-          source = "//flutter/shell/platform/windows/client_wrapper/$source"
-          destination = "cpp_client_wrapper/$source"
-        },
-      ]
-    }
-    headers = core_cpp_client_wrapper_includes +
-              core_cpp_client_wrapper_internal_headers
-    foreach(header, headers) {
-      rebased_path =
-          rebase_path(header, "//flutter/shell/platform/common/client_wrapper")
-      tmp_files += [
-        {
-          source = header
-          destination = "cpp_client_wrapper/$rebased_path"
-        },
-      ]
-    }
-    files = tmp_files
   }
+
+  # Windows specific source code files
+  foreach(source, win_client_wrapper_file_archive_list) {
+    tmp_files += [
+      {
+        source = "//flutter/shell/platform/windows/client_wrapper/$source"
+        destination = "cpp_client_wrapper/$source"
+      },
+    ]
+  }
+  headers = core_cpp_client_wrapper_includes +
+            core_cpp_client_wrapper_internal_headers
+  foreach(header, headers) {
+    rebased_path =
+        rebase_path(header, "//flutter/shell/platform/common/client_wrapper")
+    tmp_files += [
+      {
+        source = header
+        destination = "cpp_client_wrapper/$rebased_path"
+      },
+    ]
+  }
+  files = tmp_files
 }

--- a/shell/platform/windows/client_wrapper/BUILD.gn
+++ b/shell/platform/windows/client_wrapper/BUILD.gn
@@ -103,11 +103,14 @@ if (host_os == "win") {
   client_wrapper_file_archive_list = [
     "core_implementations.cc",
     "engine_method_result.cc",
-    "flutter_engine.cc",
-    "flutter_view_controller.cc",
     "plugin_registrar.cc",
     "README",
     "standard_codec.cc",
+  ]
+
+  win_client_wrapper_file_archive_list = [
+    "flutter_engine.cc",
+    "flutter_view_controller.cc",
   ]
 
   zip_bundle("client_wrapper_archive") {
@@ -126,14 +129,24 @@ if (host_os == "win") {
         },
       ]
     }
-    sources = core_cpp_client_wrapper_includes +
-              core_cpp_client_wrapper_internal_headers
-    foreach(source, sources) {
-      rebased_path =
-          rebase_path(source, "//flutter/shell/platform/common/client_wrapper")
+
+    # Windows specific source code files
+    foreach(source, win_client_wrapper_file_archive_list) {
       tmp_files += [
         {
-          source = source
+          source = "//flutter/shell/platform/windows/client_wrapper/$source"
+          destination = "cpp_client_wrapper/$source"
+        },
+      ]
+    }
+    headers = core_cpp_client_wrapper_includes +
+              core_cpp_client_wrapper_internal_headers
+    foreach(header, headers) {
+      rebased_path =
+          rebase_path(header, "//flutter/shell/platform/common/client_wrapper")
+      tmp_files += [
+        {
+          source = header
           destination = "cpp_client_wrapper/$rebased_path"
         },
       ]


### PR DESCRIPTION
Add archive targets for windows cpp client wrappers and windows flutter. These zip files were created manually in the windows host recipes.

Bug: 

https://github.com/flutter/flutter/issues/81855


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
