### PR TITLE
Fix compatibility issues with SurfaceTexture on Android Q.

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
@@ -121,7 +121,7 @@ public class FlutterRenderer implements TextureRegistry {
     private final long id;
     @NonNull private final SurfaceTextureWrapper textureWrapper;
     private boolean released;
-    @Nullable private ImageFrameListener listener;
+    @Nullable private OnFrameConsumedListener listener;
     private final Runnable onFrameConsumed =
         new Runnable() {
           @Override
@@ -161,10 +161,6 @@ public class FlutterRenderer implements TextureRegistry {
               // callback may still be called by a stale reference after released==true and
               // mNativeView==null.
               return;
-            }
-
-            if (listener != null) {
-              listener.onFrameAvailable();
             }
             markTextureFrameAvailable(id);
           }
@@ -211,7 +207,7 @@ public class FlutterRenderer implements TextureRegistry {
     }
 
     @Override
-    public void setImageFrameListener(@Nullable ImageFrameListener listener) {
+    public void setOnFrameConsumedListener(@Nullable OnFrameConsumedListener listener) {
       this.listener = listener;
     }
   }

--- a/shell/platform/android/io/flutter/embedding/engine/renderer/SurfaceTextureWrapper.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/SurfaceTextureWrapper.java
@@ -27,6 +27,14 @@ public class SurfaceTextureWrapper {
     this(surfaceTexture, null);
   }
 
+  /**
+   * A wrapper for a SurfaceTexture.
+   *
+   * <p>The provided {@code onFrameConsumed} callback must be invoked when the most recent image was
+   * consumed.
+   *
+   * @param onFrameConsumed The callback after the {@code updateTexImage} is called.
+   */
   public SurfaceTextureWrapper(
       @NonNull SurfaceTexture surfaceTexture, @Nullable Runnable onFrameConsumed) {
     this.surfaceTexture = surfaceTexture;

--- a/shell/platform/android/io/flutter/embedding/engine/renderer/SurfaceTextureWrapper.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/SurfaceTextureWrapper.java
@@ -7,6 +7,7 @@ package io.flutter.embedding.engine.renderer;
 import android.graphics.SurfaceTexture;
 import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * A wrapper for a SurfaceTexture that tracks whether the texture has been released.
@@ -20,10 +21,17 @@ public class SurfaceTextureWrapper {
   private SurfaceTexture surfaceTexture;
   private boolean released;
   private boolean attached;
+  private Runnable onFrameConsumed;
 
   public SurfaceTextureWrapper(@NonNull SurfaceTexture surfaceTexture) {
+    this(surfaceTexture, null);
+  }
+
+  public SurfaceTextureWrapper(
+      @NonNull SurfaceTexture surfaceTexture, @Nullable Runnable onFrameConsumed) {
     this.surfaceTexture = surfaceTexture;
     this.released = false;
+    this.onFrameConsumed = onFrameConsumed;
   }
 
   @NonNull
@@ -37,6 +45,9 @@ public class SurfaceTextureWrapper {
     synchronized (this) {
       if (!released) {
         surfaceTexture.updateTexImage();
+        if (onFrameConsumed != null) {
+          onFrameConsumed.run();
+        }
       }
     }
   }

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -188,10 +188,9 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
           final PlatformView platformView = viewFactory.create(context, viewId, createParams);
           platformViews.put(viewId, platformView);
 
-          final PlatformViewWrapper wrapperView = new PlatformViewWrapper(context);
           final TextureRegistry.SurfaceTextureEntry textureEntry =
               textureRegistry.createSurfaceTexture();
-          wrapperView.setTexture(textureEntry.surfaceTexture());
+          final PlatformViewWrapper wrapperView = new PlatformViewWrapper(context, textureEntry);
           wrapperView.setTouchProcessor(androidTouchProcessor);
 
           final int physicalWidth = toPhysicalPixels(request.logicalWidth);

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -37,7 +37,6 @@ import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
 import android.view.inputmethod.InputMethodManager;
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import androidx.annotation.UiThread;
 import io.flutter.Log;
@@ -887,20 +886,10 @@ public class FlutterView extends SurfaceView
     private final long id;
     private final SurfaceTextureWrapper textureWrapper;
     private boolean released;
-    @Nullable private ImageFrameListener listener;
-    private final Runnable onFrameConsumed =
-        new Runnable() {
-          @Override
-          public void run() {
-            if (listener != null) {
-              listener.onFrameConsumed();
-            }
-          }
-        };
 
     SurfaceTextureRegistryEntry(long id, SurfaceTexture surfaceTexture) {
       this.id = id;
-      this.textureWrapper = new SurfaceTextureWrapper(surfaceTexture, onFrameConsumed);
+      this.textureWrapper = new SurfaceTextureWrapper(surfaceTexture);
 
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
         // The callback relies on being executed on the UI thread (unsynchronised read of
@@ -929,9 +918,6 @@ public class FlutterView extends SurfaceView
               return;
             }
 
-            if (listener != null) {
-              listener.onFrameAvailable();
-            }
             mNativeView
                 .getFlutterJNI()
                 .markTextureFrameAvailable(SurfaceTextureRegistryEntry.this.id);
@@ -969,11 +955,6 @@ public class FlutterView extends SurfaceView
       surfaceTexture().setOnFrameAvailableListener(null);
       textureWrapper.release();
       mNativeView.getFlutterJNI().unregisterTexture(id);
-    }
-
-    @Override
-    public void setImageFrameListener(@Nullable ImageFrameListener listener) {
-      this.listener = listener;
     }
   }
 }

--- a/shell/platform/android/io/flutter/view/TextureRegistry.java
+++ b/shell/platform/android/io/flutter/view/TextureRegistry.java
@@ -43,15 +43,12 @@ public interface TextureRegistry {
     /** Deregisters and releases this SurfaceTexture. */
     void release();
 
-    /** Set a listener that will be notified when a image frame state changes. */
-    default void setImageFrameListener(@Nullable ImageFrameListener listener) {}
+    /** Set a listener that will be notified when the most recent image has been consumed. */
+    default void setOnFrameConsumedListener(@Nullable OnFrameConsumedListener listener) {}
   }
 
-  /** Listener invoked when a new image frame becomes available and has been consumed. */
-  interface ImageFrameListener {
-    /** This method will to be invoked when a new image frame becomes available. */
-    void onFrameAvailable();
-
+  /** Listener invoked when the most recent image has been consumed. */
+  interface OnFrameConsumedListener {
     /**
      * This method will to be invoked when the most recent image from the image stream has been
      * consumed.

--- a/shell/platform/android/io/flutter/view/TextureRegistry.java
+++ b/shell/platform/android/io/flutter/view/TextureRegistry.java
@@ -6,6 +6,7 @@ package io.flutter.view;
 
 import android.graphics.SurfaceTexture;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 // TODO(mattcarroll): re-evalute docs in this class and add nullability annotations.
 /**
@@ -41,5 +42,20 @@ public interface TextureRegistry {
 
     /** Deregisters and releases this SurfaceTexture. */
     void release();
+
+    /** Set a listener that will be notified when a image frame state changes. */
+    default void setImageFrameListener(@Nullable ImageFrameListener listener) {}
+  }
+
+  /** Listener invoked when a new image frame becomes available and has been consumed. */
+  interface ImageFrameListener {
+    /** This method will to be invoked when a new image frame becomes available. */
+    void onFrameAvailable();
+
+    /**
+     * This method will to be invoked when the most recent image from the image stream has been
+     * consumed.
+     */
+    void onFrameConsumed();
   }
 }

--- a/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
@@ -18,8 +18,10 @@ import android.os.Looper;
 import android.view.Surface;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import io.flutter.embedding.engine.FlutterJNI;
+import io.flutter.view.TextureRegistry;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -311,5 +313,33 @@ public class FlutterRendererTest {
           FlutterRenderer.DisplayFeatureState.UNKNOWN.encodedValue
         },
         stateCaptor.getValue());
+  }
+
+  @Test
+  public void itNotifyImageFrameListener() {
+    // Setup the test.
+    FlutterRenderer flutterRenderer = new FlutterRenderer(fakeFlutterJNI);
+
+    AtomicInteger invocationCount = new AtomicInteger(0);
+    final TextureRegistry.ImageFrameListener listener =
+        new TextureRegistry.ImageFrameListener() {
+          @Override
+          public void onFrameAvailable() {}
+
+          @Override
+          public void onFrameConsumed() {
+            invocationCount.incrementAndGet();
+          }
+        };
+
+    FlutterRenderer.SurfaceTextureRegistryEntry entry =
+        (FlutterRenderer.SurfaceTextureRegistryEntry) flutterRenderer.createSurfaceTexture();
+    entry.setImageFrameListener(listener);
+
+    // Execute the behavior under test.
+    entry.textureWrapper().updateTexImage();
+
+    // Verify behavior under test.
+    assertEquals(1, invocationCount.get());
   }
 }

--- a/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
@@ -321,11 +321,8 @@ public class FlutterRendererTest {
     FlutterRenderer flutterRenderer = new FlutterRenderer(fakeFlutterJNI);
 
     AtomicInteger invocationCount = new AtomicInteger(0);
-    final TextureRegistry.ImageFrameListener listener =
-        new TextureRegistry.ImageFrameListener() {
-          @Override
-          public void onFrameAvailable() {}
-
+    final TextureRegistry.OnFrameConsumedListener listener =
+        new TextureRegistry.OnFrameConsumedListener() {
           @Override
           public void onFrameConsumed() {
             invocationCount.incrementAndGet();
@@ -334,7 +331,7 @@ public class FlutterRendererTest {
 
     FlutterRenderer.SurfaceTextureRegistryEntry entry =
         (FlutterRenderer.SurfaceTextureRegistryEntry) flutterRenderer.createSurfaceTexture();
-    entry.setImageFrameListener(listener);
+    entry.setOnFrameConsumedListener(listener);
 
     // Execute the behavior under test.
     entry.textureWrapper().updateTexImage();


### PR DESCRIPTION
We've observed on Android Q that we have to wait for the consumer of `SurfaceTexture` to consume the last image before continuing to draw, otherwise, subsequent calls to `dequeueBuffer` to request a free buffer from the `BufferQueue` will fail.

/cc @blasten @dnfield 

Fixes: https://github.com/flutter/flutter/issues/98722

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
