### PR TITLE
Fix done button click not blur in iOS keyboard

### DIFF
--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -1453,24 +1453,13 @@ class IOSTextEditingStrategy extends GloballyPositionedTextEditingStrategy {
 
     _addTapListener();
 
-    // On iOS, blur is trigerred in the following cases:
-    //
-    // 1. The browser app is sent to the background (or the tab is changed). In
-    //    this case, the window loses focus (see [windowHasFocus]),
-    //    so we close the input connection with the framework.
-    // 2. The user taps on another focusable element. In this case, we refocus
-    //    the input field and wait for the framework to manage the focus change.
-    // 3. The virtual keyboard is closed by tapping "done". We can't detect this
-    //    programmatically, so we end up refocusing the input field. This is
-    //    okay because the virtual keyboard will hide, and as soon as the user
-    //    taps the text field again, the virtual keyboard will come up.
-    subscriptions.add(activeDomElement.onBlur.listen((_) {
-      if (windowHasFocus) {
-        activeDomElement.focus();
-      } else {
+    Future<void>.delayed(Duration.zero, () {
+      // On iOS, blur is trigerred if the virtual keyboard is closed or the
+      // browser is sent to background or the browser tab is changed.
+      subscriptions.add(activeDomElement.onBlur.listen((_) {
         owner.sendTextConnectionClosedToFrameworkIfAny();
-      }
-    }));
+      }));
+    });
   }
 
   @override

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -665,12 +665,24 @@ void testMain() {
       // DOM element is blurred.
       textEditing!.strategy.domElement!.blur();
 
-      // No connection close message sent.
-      expect(spy.messages, hasLength(0));
-      await Future<void>.delayed(Duration.zero);
-      // DOM element still keeps the focus.
-      expect(defaultTextEditingRoot.activeElement,
-          textEditing!.strategy.domElement);
+      // For ios-safari the connection is closed.
+      if (browserEngine == BrowserEngine.webkit &&
+          operatingSystem == OperatingSystem.iOs) {
+        expect(spy.messages, hasLength(1));
+        expect(spy.messages[0].channel, 'flutter/textinput');
+        expect(
+            spy.messages[0].methodName, 'TextInputClient.onConnectionClosed');
+        await Future<void>.delayed(Duration.zero);
+        // DOM element loses the focus.
+        expect(defaultTextEditingRoot.activeElement, null);
+      } else {
+        // No connection close message sent.
+        expect(spy.messages, hasLength(0));
+        await Future<void>.delayed(Duration.zero);
+        // DOM element still keeps the focus.
+        expect(defaultTextEditingRoot.activeElement,
+            textEditing!.strategy.domElement);
+      }
     },
         // TODO(mdebbar): https://github.com/flutter/flutter/issues/50769
         skip: browserEngine == BrowserEngine.edge);


### PR DESCRIPTION
- https://github.com/flutter/flutter/issues/96357

And besides I found the following issue is related to TextField focus:

- https://github.com/flutter/flutter/issues/91755

This commit resolves iOS virtual keyboard glitch and TextField focus issue in Safari. When tapping the done button above the keyboard, TextField blurs and closes the keyboard right away instead of refocusing and reopening afterward.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
