### PR TITLE
Standardize the embedder file name.

### DIFF
--- a/build/archives/BUILD.gn
+++ b/build/archives/BUILD.gn
@@ -42,9 +42,9 @@ zip_bundle("artifacts") {
   }
 }
 
-if (host_os == "linux") {
-  group("linux-embedder") {
-    deps = [ "//flutter/shell/platform/embedder:linux-embedder-archive" ]
+if (host_os == "linux" || host_os == "win") {
+  group("embedder") {
+    deps = [ "//flutter/shell/platform/embedder:embedder-archive" ]
   }
 }
 

--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -428,9 +428,9 @@ group("flutter_engine") {
   }
 }
 
-if (host_os == "linux") {
+if (host_os == "linux" || host_os == "win") {
   zip_bundle("linux-embedder-archive") {
-    output = "${host_os}-${target_cpu}/${host_os}-${target_cpu}-embedder"
+    output = "$full_platform_name/$full_platform_name-embedder.zip"
     deps = [
       "//flutter/shell/platform/embedder:copy_headers",
       "//flutter/shell/platform/embedder:flutter_engine_library",
@@ -440,10 +440,26 @@ if (host_os == "linux") {
         source = "$root_out_dir/flutter_embedder.h"
         destination = "flutter_embedder.h"
       },
-      {
-        source = "$root_out_dir/libflutter_engine.so"
-        destination = "libflutter_engine.so"
-      },
     ]
+    if (host_os == "linux") {
+      files += [
+        {
+          source = "$root_out_dir/libflutter_engine.so"
+          destination = "libflutter_engine.so"
+        },
+      ]
+    }
+    if (host_os == "win") {
+      files += [
+        {
+          source = "$root_out_dir/flutter_engine.dll"
+          destination = "flutter_engine.dll"
+        },
+        {
+          source = "$root_out_dir/flutter_engine.dll.lib"
+          destination = "flutter_engine.dll.lib"
+        },
+      ]
+    }
   }
 }

--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -429,7 +429,7 @@ group("flutter_engine") {
 }
 
 if (host_os == "linux" || host_os == "win") {
-  zip_bundle("linux-embedder-archive") {
+  zip_bundle("embedder-archive") {
     output = "$full_platform_name/$full_platform_name-embedder.zip"
     deps = [
       "//flutter/shell/platform/embedder:copy_headers",


### PR DESCRIPTION
The file in linux didn't end with ".zip" while the one in windows does.

Bug: https://github.com/flutter/flutter/issues/99137

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
