### PR TITLE
Run formatter first in pre-push hook

### DIFF
--- a/tools/githooks/lib/src/pre_push_command.dart
+++ b/tools/githooks/lib/src/pre_push_command.dart
@@ -24,8 +24,8 @@ class PrePushCommand extends Command<bool> {
     final bool verbose = globalResults!['verbose']! as bool;
     final String flutterRoot = globalResults!['flutter']! as String;
     final List<bool> checkResults = <bool>[
-      await _runClangTidy(flutterRoot, verbose),
       await _runFormatter(flutterRoot, verbose),
+      await _runClangTidy(flutterRoot, verbose),
     ];
     sw.stop();
     io.stdout.writeln('pre-push checks finished in ${sw.elapsed}');


### PR DESCRIPTION
The formatter tends to run faster than the clang-tidy checks, so this PR will mean that formatting problems can be surfaced without waiting for all the clang-tidy checks to run.