### PR TITLE
Fix invalid usage of typed data detected via dart_debug=true

### DIFF
--- a/lib/ui/painting/fragment_program.cc
+++ b/lib/ui/painting/fragment_program.cc
@@ -55,7 +55,7 @@ void FragmentProgram::init(std::string sksl, bool debugPrintSksl) {
 
 fml::RefPtr<FragmentShader> FragmentProgram::shader(
     Dart_Handle shader,
-    const tonic::Float32List& uniforms,
+    tonic::Float32List& uniforms,
     Dart_Handle samplers) {
   auto sampler_shaders =
       tonic::DartConverter<std::vector<ImageShader*>>::FromDart(samplers);
@@ -69,6 +69,7 @@ fml::RefPtr<FragmentShader> FragmentProgram::shader(
   for (size_t i = 0; i < uniform_count; i++) {
     uniform_floats[i] = uniforms[i];
   }
+  uniforms.Release();
   std::vector<sk_sp<SkShader>> sk_samplers(sampler_shaders.size());
   for (size_t i = 0; i < sampler_shaders.size(); i++) {
     ImageShader* image_shader = sampler_shaders[i];

--- a/lib/ui/painting/fragment_program.h
+++ b/lib/ui/painting/fragment_program.h
@@ -31,7 +31,7 @@ class FragmentProgram : public RefCountedDartWrappable<FragmentProgram> {
   void init(std::string sksl, bool debugPrintSksl);
 
   fml::RefPtr<FragmentShader> shader(Dart_Handle shader,
-                                     const tonic::Float32List& uniforms,
+                                     tonic::Float32List& uniforms,
                                      Dart_Handle samplers);
 
   static void RegisterNatives(tonic::DartLibraryNatives* natives);

--- a/lib/ui/painting/path.cc
+++ b/lib/ui/painting/path.cc
@@ -253,16 +253,17 @@ void CanvasPath::addPathWithMatrix(CanvasPath* path,
                                    double dy,
                                    tonic::Float64List& matrix4) {
   if (!path) {
+    matrix4.Release();
     Dart_ThrowException(
         ToDart("Path.addPathWithMatrix called with non-genuine Path."));
     return;
   }
 
   SkMatrix matrix = ToSkMatrix(matrix4);
+  matrix4.Release();
   matrix.setTranslateX(matrix.getTranslateX() + dx);
   matrix.setTranslateY(matrix.getTranslateY() + dy);
   mutable_path().addPath(path->path(), matrix, SkPath::kAppend_AddPathMode);
-  matrix4.Release();
   resetVolatility();
 }
 
@@ -281,16 +282,17 @@ void CanvasPath::extendWithPathAndMatrix(CanvasPath* path,
                                          double dy,
                                          tonic::Float64List& matrix4) {
   if (!path) {
+    matrix4.Release();
     Dart_ThrowException(
         ToDart("Path.addPathWithMatrix called with non-genuine Path."));
     return;
   }
 
   SkMatrix matrix = ToSkMatrix(matrix4);
+  matrix4.Release();
   matrix.setTranslateX(matrix.getTranslateX() + dx);
   matrix.setTranslateY(matrix.getTranslateY() + dy);
   mutable_path().addPath(path->path(), matrix, SkPath::kExtend_AddPathMode);
-  matrix4.Release();
   resetVolatility();
 }
 
@@ -317,10 +319,11 @@ void CanvasPath::shift(Dart_Handle path_handle, double dx, double dy) {
 
 void CanvasPath::transform(Dart_Handle path_handle,
                            tonic::Float64List& matrix4) {
+  auto sk_matrix = ToSkMatrix(matrix4);
+  matrix4.Release();
   fml::RefPtr<CanvasPath> path = CanvasPath::Create(path_handle);
   auto& other_mutable_path = path->mutable_path();
-  mutable_path().transform(ToSkMatrix(matrix4), &other_mutable_path);
-  matrix4.Release();
+  mutable_path().transform(sk_matrix, &other_mutable_path);
 }
 
 tonic::Float32List CanvasPath::getBounds() {

--- a/lib/ui/painting/vertices.cc
+++ b/lib/ui/painting/vertices.cc
@@ -45,10 +45,10 @@ void Vertices::RegisterNatives(tonic::DartLibraryNatives* natives) {
 
 bool Vertices::init(Dart_Handle vertices_handle,
                     SkVertices::VertexMode vertex_mode,
-                    const tonic::Float32List& positions,
-                    const tonic::Float32List& texture_coordinates,
-                    const tonic::Int32List& colors,
-                    const tonic::Uint16List& indices) {
+                    tonic::Float32List& positions,
+                    tonic::Float32List& texture_coordinates,
+                    tonic::Int32List& colors,
+                    tonic::Uint16List& indices) {
   UIDartState::ThrowIfUIOperationsProhibited();
   uint32_t builderFlags = 0;
   if (texture_coordinates.data()) {
@@ -70,22 +70,27 @@ bool Vertices::init(Dart_Handle vertices_handle,
   if (positions.data()) {
     DecodePoints(positions, builder.positions());
   }
+  positions.Release();
 
   if (texture_coordinates.data()) {
     // SkVertices::Builder assumes equal numbers of elements
     FML_DCHECK(positions.num_elements() == texture_coordinates.num_elements());
     DecodePoints(texture_coordinates, builder.texCoords());
   }
+  texture_coordinates.Release();
+
   if (colors.data()) {
     // SkVertices::Builder assumes equal numbers of elements
     FML_DCHECK(positions.num_elements() / 2 == colors.num_elements());
     DecodeInts<SkColor>(colors, builder.colors());
   }
+  colors.Release();
 
   if (indices.data()) {
     std::copy(indices.data(), indices.data() + indices.num_elements(),
               builder.indices());
   }
+  indices.Release();
 
   auto vertices = fml::MakeRefCounted<Vertices>();
   vertices->vertices_ = builder.detach();

--- a/lib/ui/painting/vertices.cc
+++ b/lib/ui/painting/vertices.cc
@@ -70,26 +70,27 @@ bool Vertices::init(Dart_Handle vertices_handle,
   if (positions.data()) {
     DecodePoints(positions, builder.positions());
   }
-  positions.Release();
 
   if (texture_coordinates.data()) {
     // SkVertices::Builder assumes equal numbers of elements
     FML_DCHECK(positions.num_elements() == texture_coordinates.num_elements());
     DecodePoints(texture_coordinates, builder.texCoords());
   }
-  texture_coordinates.Release();
 
   if (colors.data()) {
     // SkVertices::Builder assumes equal numbers of elements
     FML_DCHECK(positions.num_elements() / 2 == colors.num_elements());
     DecodeInts<SkColor>(colors, builder.colors());
   }
-  colors.Release();
 
   if (indices.data()) {
     std::copy(indices.data(), indices.data() + indices.num_elements(),
               builder.indices());
   }
+
+  positions.Release();
+  texture_coordinates.Release();
+  colors.Release();
   indices.Release();
 
   auto vertices = fml::MakeRefCounted<Vertices>();

--- a/lib/ui/painting/vertices.h
+++ b/lib/ui/painting/vertices.h
@@ -26,10 +26,10 @@ class Vertices : public RefCountedDartWrappable<Vertices> {
 
   static bool init(Dart_Handle vertices_handle,
                    SkVertices::VertexMode vertex_mode,
-                   const tonic::Float32List& positions,
-                   const tonic::Float32List& texture_coordinates,
-                   const tonic::Int32List& colors,
-                   const tonic::Uint16List& indices);
+                   tonic::Float32List& positions,
+                   tonic::Float32List& texture_coordinates,
+                   tonic::Int32List& colors,
+                   tonic::Uint16List& indices);
 
   const sk_sp<SkVertices>& vertices() const { return vertices_; }
 

--- a/tools/gn
+++ b/tools/gn
@@ -206,7 +206,7 @@ def to_gn_args(args):
     gn_args['dart_lib_export_symbols'] = False
 
     if runtime_mode == 'debug':
-        gn_args['dart_debug'] = args.unoptimized
+        gn_args['dart_runtime_mode'] = 'develop'
     elif runtime_mode == 'jit_release':
         gn_args['dart_runtime_mode'] = 'release';
     else:

--- a/tools/gn
+++ b/tools/gn
@@ -206,7 +206,7 @@ def to_gn_args(args):
     gn_args['dart_lib_export_symbols'] = False
 
     if runtime_mode == 'debug':
-        gn_args['dart_runtime_mode'] = 'develop'
+        gn_args['dart_debug'] = args.unoptimized
     elif runtime_mode == 'jit_release':
         gn_args['dart_runtime_mode'] = 'release';
     else:


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/99347

These errors are detected if you do a build with `--dart-debug=true`. I would like to try to get this running on CI

@mraleph @mkustermann @a-siva @rmacnak-google fyi

This has no tests, but the plan is to test it by adding a flag in the `linux_unopt` recipe that will cause the Dart VM to assert if these are used incorrectly. Without these changes, existing tests fail when `dart_debug=true` in the gn args.