### PR TITLE
Fix web_engine_archive target.

### DIFF
--- a/build/zip.py
+++ b/build/zip.py
@@ -26,7 +26,7 @@ def main(args):
       file_dict_list = json.load(source_file)
       for file_dict in file_dict_list:
         if os.path.isdir(file_dict['source']):
-          _zip_dir(f, file_dict['source'], file_dict['destination'])
+          _zip_dir(file_dict['source'], zip_file, file_dict['destination'])
         else:
           zip_file.write(file_dict['source'], file_dict['destination'])
   else:

--- a/build/zip.py
+++ b/build/zip.py
@@ -5,6 +5,7 @@
 # found in the LICENSE file.
 
 import argparse
+import json
 import zipfile
 import os
 import sys
@@ -20,11 +21,20 @@ def _zip_dir(path, zip_file, prefix):
 
 def main(args):
   zip_file = zipfile.ZipFile(args.output, 'w', zipfile.ZIP_DEFLATED)
-  for path, archive_name in args.input_pairs:
-    if os.path.isdir(path):
-      _zip_dir(path, zip_file, archive_name)
-    else:
-      zip_file.write(path, archive_name)
+  if args.source_file:
+    with open(args.source_file) as source_file:
+      file_dict_list = json.load(source_file)
+      for file_dict in file_dict_list:
+        if os.path.isdir(file_dict['source']):
+          _zip_dir(f, file_dict['source'], file_dict['destination'])
+        else:
+          zip_file.write(file_dict['source'], file_dict['destination'])
+  else:
+    for path, archive_name in args.input_pairs:
+      if os.path.isdir(path):
+        _zip_dir(path, zip_file, archive_name)
+      else:
+        zip_file.write(path, archive_name)
   zip_file.close()
 
 
@@ -35,4 +45,6 @@ if __name__ == '__main__':
       help='The name of the output zip file.')
   parser.add_argument('-i', dest='input_pairs', nargs=2, action='append',
       help='The input file and its destination location in the zip archive.')
+  parser.add_argument('-f', dest='source_file', action='store',
+      help='The path to the file list to zip.')
   sys.exit(main(parser.parse_args()))

--- a/build/zip_bundle.gni
+++ b/build/zip_bundle.gni
@@ -58,3 +58,45 @@ template("zip_bundle") {
     }
   }
 }
+
+# Creates a zip file in the $root_build_dir/zip_archives folder.
+#
+# The output variable specifies the name of the zip file to create.
+# The files variable is an array of scopes that specify a source file or
+# directory and a destination path in the archive to create.
+#
+# For example, to create a zip file named archive.zip with all files in the
+# root directory of the archive:
+#
+# zip_bundle("sample") {
+#   output = "archive.zip"
+#   files = [
+#     {
+#       source = rebase_path("$root_build_dir/some/path/to/lib.so")
+#       destination = "lib.so"
+#     },
+#     {
+#       source = rebase_path("$root_build_dir/some/other/path/with/files")
+#       destination = "other_files"
+#     },
+#   ]
+# }
+template("zip_bundle_from_file") {
+  assert(defined(invoker.output), "output must be defined")
+  assert(defined(invoker.files), "files must be defined as a list of scopes")
+  action(target_name) {
+    script = "//flutter/build/zip.py"
+    outputs = [ "$root_build_dir/zip_archives/${invoker.output}" ]
+    sources = []
+    deps = invoker.deps
+    location_source_path = "$target_gen_dir/zip_bundle.txt"
+    write_file(location_source_path, invoker.files, "json")
+
+    args = [
+      "-o",
+      rebase_path(outputs[0]),
+      "-f",
+      rebase_path(location_source_path),
+    ]
+  }
+}

--- a/web_sdk/BUILD.gn
+++ b/web_sdk/BUILD.gn
@@ -568,7 +568,7 @@ _kernel_worker("flutter_dartdevc_kernel_sdk_outline_sound") {
 
 # Archives Flutter Web SDK
 if (!is_fuchsia) {
-  zip_bundle("flutter_web_sdk_archive") {
+  zip_bundle_from_file("flutter_web_sdk_archive") {
     output = "flutter-web-sdk-${full_platform_name}.zip"
     deps = [
       ":flutter_dartdevc_canvaskit_html_kernel_sdk",
@@ -598,7 +598,7 @@ if (!is_fuchsia) {
     foreach(source, sources) {
       tmp_files += [
         {
-          source = source
+          source = rebase_path(source)
           destination = rebase_path(source, "$root_build_dir")
         },
       ]
@@ -607,7 +607,7 @@ if (!is_fuchsia) {
       rebased_path = rebase_path(source, "//flutter/lib/web_ui/lib")
       tmp_files += [
         {
-          source = source
+          source = rebase_path(source)
           destination = "flutter_web_sdk/lib/ui/$rebased_path"
         },
       ]
@@ -616,7 +616,7 @@ if (!is_fuchsia) {
       rebased_path = rebase_path(source, "//flutter/lib/web_ui/lib/src")
       tmp_files += [
         {
-          source = source
+          source = rebase_path(source)
           destination = "flutter_web_sdk/lib/_engine/$rebased_path"
         },
       ]

--- a/web_sdk/BUILD.gn
+++ b/web_sdk/BUILD.gn
@@ -27,7 +27,8 @@ web_engine_sources =
                 ],
                 "list lines")
 
-web_engine_sources += [ "//flutter/lib/web_ui/lib/src/engine.dart" ]
+web_engine_sources +=
+    [ rebase_path("//flutter/lib/web_ui/lib/src/engine.dart") ]
 
 group("web_sdk") {
   deps = [


### PR DESCRIPTION
The target to archive web_engine fails on windows and we didn't catch it
on presubmit because we are not yet running those targets.

Bug: https://github.com/flutter/flutter/issues/81855

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
