### PR TITLE
[macOS, Keyboard] Duplicate down events are no longer ignored, but kept and preceded by up events

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterEmbedderKeyResponder.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEmbedderKeyResponder.mm
@@ -680,18 +680,18 @@ const char* getEventString(NSString* characters) {
   bool isARepeat = event.isARepeat;
   NSNumber* pressedLogicalKey = _pressingRecords[@(physicalKey)];
   if (pressedLogicalKey != nil && !isARepeat) {
-    // Normally the key up events won't be missed since macOS always sends the
-    // key up event to the window where the corresponding key down occurred.
-    // However this might happen in add-to-app scenarios if the focus is changed
+    // This might happen in add-to-app scenarios if the focus is changed
     // from the native view to the Flutter view amid the key tap.
-
-    // TODO
+    //
+    // This might also happen when a key event is forged (such as by an
+    // IME) using the same keyCode as an unreleased key. See
+    // https://github.com/flutter/flutter/issues/82673#issuecomment-988661079
     FlutterKeyEvent flutterEvent = {
         .struct_size = sizeof(FlutterKeyEvent),
         .timestamp = GetFlutterTimestampFrom(event.timestamp),
         .type = kFlutterKeyEventTypeUp,
         .physical = physicalKey,
-        .logical = logicalKey,
+        .logical = [pressedLogicalKey unsignedLongLongValue],
         .character = nil,
         .synthesized = true,
     };

--- a/shell/platform/darwin/macos/framework/Source/FlutterEmbedderKeyResponder.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEmbedderKeyResponder.mm
@@ -684,8 +684,19 @@ const char* getEventString(NSString* characters) {
     // key up event to the window where the corresponding key down occurred.
     // However this might happen in add-to-app scenarios if the focus is changed
     // from the native view to the Flutter view amid the key tap.
-    [callback resolveTo:TRUE];
-    return;
+
+    // TODO
+    FlutterKeyEvent flutterEvent = {
+        .struct_size = sizeof(FlutterKeyEvent),
+        .timestamp = GetFlutterTimestampFrom(event.timestamp),
+        .type = kFlutterKeyEventTypeUp,
+        .physical = physicalKey,
+        .logical = logicalKey,
+        .character = nil,
+        .synthesized = true,
+    };
+    [self sendSynthesizedFlutterEvent:flutterEvent guard:callback];
+    pressedLogicalKey = nil;
   }
 
   if (pressedLogicalKey == nil) {


### PR DESCRIPTION
Before this PR, duplicate down events are regularized by ignoring the latter events.

For example, native KeyA down, KeyA down will result in Flutter KeyA down, (empty).

This PR changes so that the latter events are kept, and, for regularization purposes, preceded by synthesized up events. The example above will now result in Flutter KeyA down, (KeyA up) KeyA down. This change is similar to https://github.com/flutter/engine/pull/30488, but for a different reason.

This fixes the macOS part (which is the last part) of https://github.com/flutter/flutter/issues/82673. When using this Vietnamese IME and typing "laf", the `f` key down event will be converted to many events, including a key down event with keyCode 0 (KeyA) and character "à". However, if the typing is so fast that the A key is not released when the F key is pressed (which happens a lot), the current strategy will take the forged KeyA down event as a duplicate down event, ignore it by returning true, and this event will not be passed to the text input plugin. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
