### PR TITLE
Fix archive names for windows_host_engine.

### DIFF
--- a/ci/builders/windows_host_engine.json
+++ b/ci/builders/windows_host_engine.json
@@ -11,7 +11,7 @@
                         "out/host_debug/zip_archives/windows-x64/flutter-cpp-client-wrapper.zip",
                         "out/host_debug/zip_archives/windows-x64/font-subset.zip",
                         "out/host_debug/zip_archives/dart-sdk-windows-x64.zip",
-                        "out/host_debug/zip_archives/flutter-web-sdk-linux-x64.zip"
+                        "out/host_debug/zip_archives/flutter-web-sdk-windows-x64.zip"
                     ],
                     "name": "host_debug"
                 }


### PR DESCRIPTION
The web_sdk package was referencing the linux version instead of the
windows one.

Bug: https://github.com/flutter/flutter/issues/81855

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
