### PR TITLE
Re-enable dart runner AOT builds

### DIFF
--- a/tools/fuchsia/dart/config.gni
+++ b/tools/fuchsia/dart/config.gni
@@ -5,19 +5,17 @@
 import("//flutter/tools/fuchsia/dart/dart_build_config.gni")
 
 declare_args() {
-  # TODO(fxbug.dev/86941) enable dart_runner_integration_tests
-  # TODO(fxbug.dev/64153) renable dart runner aot builds
-  # if (flutter_runtime_mode == "release") {
-  #   # Product AOT
-  #   dart_default_build_cfg = dart_release_build_cfg
-  # } else if (flutter_runtime_mode == "jit_release") {
-  #   # Product JIT
-  #   dart_default_build_cfg = dart_jit_release_build_cfg
-  # } else if (flutter_runtime_mode == "debug") {
-  # Non-product JIT
-  dart_default_build_cfg = dart_debug_build_cfg
-  # } else { # "profile"
-  #   # Non-product AOT
-  #   dart_default_build_cfg = dart_profile_build_cfg
-  # }
+  if (flutter_runtime_mode == "release") {
+    # Product AOT
+    dart_default_build_cfg = dart_release_build_cfg
+  } else if (flutter_runtime_mode == "jit_release") {
+    # Product JIT
+    dart_default_build_cfg = dart_jit_release_build_cfg
+  } else if (flutter_runtime_mode == "debug") {
+    # Non-product JIT
+    dart_default_build_cfg = dart_debug_build_cfg
+  } else {  # "profile"
+    # Non-product AOT
+    dart_default_build_cfg = dart_profile_build_cfg
+  }
 }


### PR DESCRIPTION
Fixed: fxbug.dev/64153

Note that I also removed the TODO for fxbug.dev/86941. After talking
with the bug author, this file is not directly relevant to that bug.

## Pre-launch Checklist

- [ x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
