### PR TITLE
[Win32, Keyboard] Fix AltGr's forged ControlLeft

### DIFF
--- a/shell/platform/windows/keyboard_manager_win32.cc
+++ b/shell/platform/windows/keyboard_manager_win32.cc
@@ -176,7 +176,7 @@ void KeyboardManagerWin32::OnKey(std::unique_ptr<PendingEvent> event,
           (1 /* repeat_count */ << 0) | (ctrl_left_scancode << 16) |
           (0 /* extended */ << 24) | (1 /* prev_state */ << 30) |
           (1 /* transition */ << 31);
-      window_delegate_->Win32DispatchMessage(WM_KEYUP, VK_LCONTROL, lParam);
+      window_delegate_->Win32DispatchMessage(WM_KEYUP, VK_CONTROL, lParam);
     }
   }
 

--- a/shell/platform/windows/keyboard_win32_unittests.cc
+++ b/shell/platform/windows/keyboard_win32_unittests.cc
@@ -1203,7 +1203,7 @@ TEST(KeyboardTest, AltGrModifiedKey) {
   tester.InjectKeyboardChanges(std::vector<KeyboardChange>{
       KeyStateChange{VK_LCONTROL, false, true},
       ExpectForgedMessage{
-          WmKeyUpInfo{VK_LCONTROL, kScanCodeControl, kNotExtended}.Build(
+          WmKeyUpInfo{VK_CONTROL, kScanCodeControl, kNotExtended}.Build(
               kWmResultZero)},
       KeyStateChange{VK_RMENU, false, true},
       WmSysKeyUpInfo{VK_MENU, kScanCodeAlt, kExtended}.Build(
@@ -1243,7 +1243,7 @@ TEST(KeyboardTest, AltGrTwice) {
   // AltLeft) down.
   tester.InjectKeyboardChanges(std::vector<KeyboardChange>{
       KeyStateChange{VK_LCONTROL, true, true},
-      WmKeyDownInfo{VK_LCONTROL, kScanCodeControl, kNotExtended, kWasUp}.Build(
+      WmKeyDownInfo{VK_CONTROL, kScanCodeControl, kNotExtended, kWasUp}.Build(
           kWmResultZero),
       KeyStateChange{VK_RMENU, true, true},
       WmKeyDownInfo{VK_MENU, kScanCodeAlt, kExtended, kWasUp}.Build(
@@ -1265,7 +1265,7 @@ TEST(KeyboardTest, AltGrTwice) {
   tester.InjectKeyboardChanges(std::vector<KeyboardChange>{
       KeyStateChange{VK_LCONTROL, false, true},
       ExpectForgedMessage{
-          WmKeyUpInfo{VK_LCONTROL, kScanCodeControl, kNotExtended}.Build(
+          WmKeyUpInfo{VK_CONTROL, kScanCodeControl, kNotExtended}.Build(
               kWmResultZero)},
       KeyStateChange{VK_RMENU, false, true},
       WmSysKeyUpInfo{VK_MENU, kScanCodeAlt, kExtended}.Build(
@@ -1284,7 +1284,7 @@ TEST(KeyboardTest, AltGrTwice) {
 
   tester.InjectKeyboardChanges(std::vector<KeyboardChange>{
       KeyStateChange{VK_LCONTROL, true, false},
-      WmKeyDownInfo{VK_LCONTROL, kScanCodeControl, kNotExtended, kWasUp}.Build(
+      WmKeyDownInfo{VK_CONTROL, kScanCodeControl, kNotExtended, kWasUp}.Build(
           kWmResultZero),
       KeyStateChange{VK_RMENU, true, true},
       WmKeyDownInfo{VK_MENU, kScanCodeAlt, kExtended, kWasUp}.Build(
@@ -1306,7 +1306,7 @@ TEST(KeyboardTest, AltGrTwice) {
   tester.InjectKeyboardChanges(std::vector<KeyboardChange>{
       KeyStateChange{VK_LCONTROL, false, false},
       ExpectForgedMessage{
-          WmKeyUpInfo{VK_LCONTROL, kScanCodeControl, kNotExtended}.Build(
+          WmKeyUpInfo{VK_CONTROL, kScanCodeControl, kNotExtended}.Build(
               kWmResultZero)},
       KeyStateChange{VK_RMENU, false, false},
       WmSysKeyUpInfo{VK_MENU, kScanCodeAlt, kExtended}.Build(
@@ -1323,7 +1323,7 @@ TEST(KeyboardTest, AltGrTwice) {
 
   // 5. For key sequence 2: a real ControlLeft up.
   tester.InjectKeyboardChanges(std::vector<KeyboardChange>{
-      WmKeyUpInfo{VK_LCONTROL, kScanCodeControl, kNotExtended}.Build(
+      WmKeyUpInfo{VK_CONTROL, kScanCodeControl, kNotExtended}.Build(
           kWmResultZero)});
   EXPECT_EQ(key_calls.size(), 1);
   EXPECT_CALL_IS_EVENT(key_calls[0], kFlutterKeyEventTypeDown, 0, 0, "",


### PR DESCRIPTION
This PR fixes https://github.com/flutter/flutter/issues/98071, where pressing AltGr while CtrlLeft is held causes crash. 

Flutter forges a ControlLeft keyup when AltGr is released, but since Flutter Win32 used to use `SendInput` to forge events, it sends `VK_LCONTROL` as virtual key, despite that the original event uses `VK_CONTROL`. Now that it has switched to `SendMessage`, it must use the exact VK.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
