### PR TITLE
[macOS] Clear IME mark text on clear input client

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.h
@@ -52,4 +52,5 @@
 @interface FlutterTextInputPlugin (TestMethods)
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result;
 - (NSRect)firstRectForCharacterRange:(NSRange)range actualRange:(NSRangePointer)actualRange;
+- (NSDictionary*)editingState;
 @end


### PR DESCRIPTION
When the embedder receives a TextInput.clearClient message from the
framework (typically when a text field loses focus), if the user is
currently inputting composing text using an IME, commit the composing
text, end composing, and clear the IME's composing state.

This also exposes a public `editingState` getter on
FlutterTextInputPlugin as part of the TestMethods informal protocol.
This allows us to get at the text editing state as a dictionary in
tests.

Issue: https://github.com/flutter/flutter/issues/92060

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
