### PR TITLE
[macos] Register log handler

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -6,6 +6,7 @@
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h"
 
 #include <algorithm>
+#include <iostream>
 #include <vector>
 
 #import "flutter/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegate.h"
@@ -298,6 +299,13 @@ static void OnPlatformMessage(const FlutterPlatformMessage* message, FlutterEngi
   flutterArguments.dart_entrypoint_argc = dartEntrypointArgs.size();
   flutterArguments.dart_entrypoint_argv = dartEntrypointArgs.data();
   flutterArguments.root_isolate_create_callback = _project.rootIsolateCreateCallback;
+  flutterArguments.log_message_callback = [](const char* tag, const char* message,
+                                             void* user_data) {
+    if (tag && tag[0]) {
+      std::cout << tag << ": ";
+    }
+    std::cout << message << std::endl;
+  };
 
   static size_t sTaskRunnerIdentifiers = 0;
   const FlutterTaskRunnerDescription cocoa_task_runner_description = {

--- a/shell/platform/darwin/macos/framework/Source/fixtures/flutter_desktop_test.dart
+++ b/shell/platform/darwin/macos/framework/Source/fixtures/flutter_desktop_test.dart
@@ -3,8 +3,17 @@
 // found in the LICENSE file.
 
 import 'dart:ui';
-void main() {
 
+void signalNativeTest() native 'SignalNativeTest';
+
+void main() {
+}
+
+@pragma('vm:entry-point')
+void canLogToStdout() {
+  // Emit hello world message to output then signal the test.
+  print('Hello logging');
+  signalNativeTest();
 }
 
 Picture CreateSimplePicture() {
@@ -28,8 +37,6 @@ void can_composite_platform_views() {
   };
   PlatformDispatcher.instance.scheduleFrame();
 }
-
-void signalNativeTest() native 'SignalNativeTest';
 
 @pragma('vm:entry-point')
 void native_callback() {


### PR DESCRIPTION
Previously, the macOS embedder relied on the deprecated built-in log
handling in lib/ui/ui_dart_state.cc. Instead, we now register a
dedicated log handler for the macOS embedder. This is used, for example,
to output Dart 'print' calls.

While unlikely that we'll break the internal generic fallback logging,
it's preferable to keep platform-specific functionality in the
embedder.

Issue: https://github.com/flutter/flutter/issues/99636

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
