### PR TITLE
Allow providing max_cache_entry flag to Dart

### DIFF
--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -535,6 +535,7 @@ TEST_F(ShellTest,
 #if !FLUTTER_RELEASE
   flags.push_back("--max_profile_depth 1");
   flags.push_back("--random_seed 42");
+  flags.push_back("--max_subtype_cache_entries=22")
   if (!DartVM::IsRunningPrecompiledCode()) {
     flags.push_back("--enable_mirrors");
   }

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -535,7 +535,7 @@ TEST_F(ShellTest,
 #if !FLUTTER_RELEASE
   flags.push_back("--max_profile_depth 1");
   flags.push_back("--random_seed 42");
-  flags.push_back("--max_subtype_cache_entries=22")
+  flags.push_back("--max_subtype_cache_entries=22");
   if (!DartVM::IsRunningPrecompiledCode()) {
     flags.push_back("--enable_mirrors");
   }

--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -68,6 +68,7 @@ static const std::string gAllowedDartFlags[] = {
     "--strict_null_safety_checks",
     "--enable-display-list",
     "--no-enable-display-list",
+    "--max_subtype_cache_entries",
 };
 // clang-format on
 


### PR DESCRIPTION
This flag is used to increase/decrease the size of the type check cache in native dart applications. This can be used to simulate the impact of running in an application that has many more subtypes of widget than a simple benchmark. This will allow us to determine whether it is worth making element generic to remove additional type checks