### PR TITLE
Add a message when a key response takes too long.

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterKeyboardManager.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterKeyboardManager.mm
@@ -121,6 +121,7 @@ static constexpr CFTimeInterval kReasonableInterval = 2.0;
         NSLog(@"Flutter framework failed to process a key event in a reasonable time. Continuing "
               @"to wait.");
         CFRunLoopRunInMode(fml::MessageLoopDarwin::kMessageLoopCFRunLoopMode, kDistantFuture, NO);
+        NSLog(@"Flutter framework finally responded. Exiting nested event loop.");
       }
       break;
     }

--- a/shell/platform/darwin/ios/framework/Source/FlutterKeyboardManager.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterKeyboardManager.mm
@@ -7,6 +7,7 @@
 #include "flutter/fml/platform/darwin/message_loop_darwin.h"
 
 static constexpr CFTimeInterval kDistantFuture = 1.0e10;
+static constexpr CFTimeInterval kReasonableInterval = 2.0;
 
 @interface FlutterKeyboardManager ()
 
@@ -114,7 +115,13 @@ static constexpr CFTimeInterval kDistantFuture = 1.0e10;
       //
       // We need to run in this mode so that UIKit doesn't give us new
       // events until we are done processing this one.
-      CFRunLoopRunInMode(fml::MessageLoopDarwin::kMessageLoopCFRunLoopMode, kDistantFuture, NO);
+      CFRunLoopRunResult result = CFRunLoopRunInMode(
+          fml::MessageLoopDarwin::kMessageLoopCFRunLoopMode, kReasonableInterval, NO);
+      if (result == kCFRunLoopRunTimedOut) {
+        NSLog(@"Flutter framework failed to process a key event in a reasonable time. Continuing "
+              @"to wait.");
+        CFRunLoopRunInMode(fml::MessageLoopDarwin::kMessageLoopCFRunLoopMode, kDistantFuture, NO);
+      }
       break;
     }
     case UIPressPhaseChanged:

--- a/shell/platform/darwin/ios/framework/Source/FlutterKeyboardManagerTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterKeyboardManagerTest.mm
@@ -7,6 +7,7 @@
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
 #include <_types/_uint32_t.h>
+#import <strstream>
 
 #include "flutter/fml/platform/darwin/message_loop_darwin.h"
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterMacros.h"
@@ -372,6 +373,59 @@ typedef BOOL (^BoolGetter)();
   // Start a nested CFRunLoop so we can wait for both presses to complete before exiting the test
   CFRunLoopRun();
   XCTAssertFalse(key2Handled);
+  XCTAssertFalse(key1Handled);
+}
+
+- (void)testLogWhenEventHandlingTakesTooLong API_AVAILABLE(ios(13.4)) {
+  constexpr UIKeyboardHIDUsage keyId1 = (UIKeyboardHIDUsage)0x50;
+  FlutterUIPressProxy* event1 = keyDownEvent(keyId1);
+  __block FlutterAsyncKeyCallback key1Callback;
+  __block bool key1Handled = true;
+
+  // Redirect the stderr to a string buffer.
+  std::stringstream cerrBuffer;
+  std::streambuf* realCerr = std::cerr.rdbuf(cerrBuffer.rdbuf());
+
+  FlutterKeyboardManager* manager = [[FlutterKeyboardManager alloc] init];
+  [manager addPrimaryResponder:[self mockPrimaryResponder:^(FlutterUIPressProxy* press,
+                                                            FlutterAsyncKeyCallback callback) {
+             if (press == event1) {
+               key1Callback = callback;
+             }
+           }]];
+
+  // Add both presses into the main CFRunLoop queue
+  CFRunLoopTimerRef timer0 = CFRunLoopTimerCreateWithHandler(
+      kCFAllocatorDefault, CFAbsoluteTimeGetCurrent(), 0, 0, 0, ^(CFRunLoopTimerRef timerRef) {
+        [manager handlePress:event1
+                  nextAction:^() {
+                    key1Handled = false;
+                  }];
+      });
+  CFRunLoopAddTimer(CFRunLoopGetCurrent(), timer0, kCFRunLoopCommonModes);
+
+  // Call the callback, but do it too late, so that we get a log message.
+  CFRunLoopTimerRef timer1 = CFRunLoopTimerCreateWithHandler(
+      kCFAllocatorDefault, CFAbsoluteTimeGetCurrent() + 3, 0, 0, 0, ^(CFRunLoopTimerRef timerRef) {
+        // No processing should be done on key2 yet
+        XCTAssertTrue(key1Callback != nil);
+        key1Callback(false);
+      });
+  CFRunLoopAddTimer(CFRunLoopGetCurrent(), timer1,
+                    fml::MessageLoopDarwin::kMessageLoopCFRunLoopMode);
+
+  // Start a nested CFRunLoop so we can wait for both presses to complete before exiting the test
+  CFRunLoopRun();
+
+  // Check the log output.
+  std::cerr.flush();
+  std::string logOutput =
+      cerrBuffer.str();  // Get the stderr output that happened while the loop was running.
+  XCTAssertTrue(logOutput.find("Flutter framework failed to process a key event in a reasonable "
+                               "time. Continuing to wait.") != std::string::npos);
+  std::cerr.rdbuf(realCerr);
+  // In case there was other useful cerr output in the test, write it to the real cerr.
+  std::cerr << logOutput;
   XCTAssertFalse(key1Handled);
 }
 


### PR DESCRIPTION
## Description

This splits the nested event loop in the keyboard manager on iOS into two parts: The first times out after 2 seconds, and if that happens, prints an `NSLog` indicating that the framework took a long time to respond, and then it enters the event loop again, waiting forever this time.  This means the behavior doesn't change from what it is now, but will log when things take a long time. 

## Related Issues
 -  https://github.com/flutter/flutter/issues/98419

## Tests
 - I tried to write a test for this, but redirecting cerr into a strstream didn't work, and I don't know of another way to redirect NSLog output so that a test can read it.  Therefore I'm going to ask for a test exemption.