### PR TITLE
Fix local text value and selection not updating when delta is sent to…

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -436,6 +436,7 @@ static flutter::TextRange RangeFromBaseExtent(NSNumber* base,
 
   [_channel invokeMethod:kUpdateEditStateWithDeltasResponseMethod
                arguments:@[ self.clientID, deltas ]];
+  [self updateTextAndSelection];
 }
 
 - (void)updateTextAndSelection {
@@ -632,7 +633,6 @@ static flutter::TextRange RangeFromBaseExtent(NSNumber* base,
   BOOL isAttributedString = [string isKindOfClass:[NSAttributedString class]];
   std::string marked_text = isAttributedString ? [[string string] UTF8String] : [string UTF8String];
   _activeModel->UpdateComposingText(marked_text);
-
   if (_enableDeltaModel) {
     flutter::TextRange composing = _activeModel->composing_range();
     [self updateEditStateWithDelta:flutter::TextEditingDelta(textBeforeChange, composing,

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -633,6 +633,7 @@ static flutter::TextRange RangeFromBaseExtent(NSNumber* base,
   BOOL isAttributedString = [string isKindOfClass:[NSAttributedString class]];
   std::string marked_text = isAttributedString ? [[string string] UTF8String] : [string UTF8String];
   _activeModel->UpdateComposingText(marked_text);
+
   if (_enableDeltaModel) {
     flutter::TextRange composing = _activeModel->composing_range();
     [self updateEditStateWithDelta:flutter::TextEditingDelta(textBeforeChange, composing,

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
@@ -404,6 +404,66 @@
   return true;
 }
 
+- (bool)testLocalTextAndSelectionUpdateAfterDelta {
+  id engineMock = OCMClassMock([FlutterEngine class]);
+  id binaryMessengerMock = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
+  OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
+      [engineMock binaryMessenger])
+      .andReturn(binaryMessengerMock);
+
+  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engineMock
+                                                                                nibName:@""
+                                                                                 bundle:nil];
+
+  FlutterTextInputPlugin* plugin =
+      [[FlutterTextInputPlugin alloc] initWithViewController:viewController];
+
+  [plugin handleMethodCall:[FlutterMethodCall
+                               methodCallWithMethodName:@"TextInput.setClient"
+                                              arguments:@[
+                                                @(1), @{
+                                                  @"inputAction" : @"action",
+                                                  @"enableDeltaModel" : @"true",
+                                                  @"inputType" : @{@"name" : @"inputName"},
+                                                }
+                                              ]]
+                    result:^(id){
+                    }];
+  [plugin insertText:@"text to insert"];
+
+  NSDictionary* deltaToFramework = @{
+    @"oldText" : @"",
+    @"deltaText" : @"text to insert",
+    @"deltaStart" : @(0),
+    @"deltaEnd" : @(0),
+    @"selectionBase" : @(14),
+    @"selectionExtent" : @(14),
+    @"selectionAffinity" : @"TextAffinity.upstream",
+    @"selectionIsDirectional" : @(false),
+    @"composingBase" : @(-1),
+    @"composingExtent" : @(-1),
+  };
+  NSDictionary* expectedState = @{
+    @"deltas" : @[ deltaToFramework ],
+  };
+
+  NSData* updateCall = [[FlutterJSONMethodCodec sharedInstance]
+      encodeMethodCall:[FlutterMethodCall
+                           methodCallWithMethodName:@"TextInputClient.updateEditingStateWithDeltas"
+                                          arguments:@[ @(1), expectedState ]]];
+
+  @try {
+    OCMVerify(  // NOLINT(google-objc-avoid-throwing-exception)
+        [binaryMessengerMock sendOnChannel:@"flutter/textinput" message:updateCall]);
+  } @catch (...) {
+    return false;
+  }
+
+  bool localTextAndSelectionUpdated = [plugin.string isEqualToString:@"text to insert"] && NSEqualRanges(plugin.selectedRange, NSMakeRange(14, 0));
+    
+  return localTextAndSelectionUpdated;
+}
+
 @end
 
 namespace flutter::testing {
@@ -437,6 +497,10 @@ TEST(FlutterTextInputPluginTest, TestSetEditingStateWithTextEditingDelta) {
 
 TEST(FlutterTextInputPluginTest, TestOperationsThatTriggerDelta) {
   ASSERT_TRUE([[FlutterInputPluginTestObjc alloc] testOperationsThatTriggerDelta]);
+}
+
+TEST(FlutterTextInputPluginTest, TestLocalTextAndSelectionUpdateAfterDelta) {
+  ASSERT_TRUE([[FlutterInputPluginTestObjc alloc] testLocalTextAndSelectionUpdateAfterDelta]);
 }
 
 TEST(FlutterTextInputPluginTest, CanWorkWithFlutterTextField) {

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
@@ -459,7 +459,7 @@
     return false;
   }
 
-  bool localTextAndSelectionUpdated = [plugin.string isEqualToString:@"text to insert"] && NSEqualRanges(plugin.selectedRange, NSMakeRange(14, 0));
+bool localTextAndSelectionUpdated = [plugin.string isEqualToString:@"text to insert"] && NSEqualRanges(plugin.selectedRange, NSMakeRange(14, 0));
     
   return localTextAndSelectionUpdated;
 }

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
@@ -459,7 +459,8 @@
     return false;
   }
 
-  bool localTextAndSelectionUpdated = [plugin.string isEqualToString:@"text to insert"] && NSEqualRanges(plugin.selectedRange, NSMakeRange(14, 0));
+  bool localTextAndSelectionUpdated = [plugin.string isEqualToString:@"text to insert"] &&
+                                      NSEqualRanges(plugin.selectedRange, NSMakeRange(14, 0));
 
   return localTextAndSelectionUpdated;
 }

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
@@ -459,8 +459,8 @@
     return false;
   }
 
-bool localTextAndSelectionUpdated = [plugin.string isEqualToString:@"text to insert"] && NSEqualRanges(plugin.selectedRange, NSMakeRange(14, 0));
-    
+  bool localTextAndSelectionUpdated = [plugin.string isEqualToString:@"text to insert"] && NSEqualRanges(plugin.selectedRange, NSMakeRange(14, 0));
+
   return localTextAndSelectionUpdated;
 }
 


### PR DESCRIPTION
This change fixes an issue where the local selection and text were not being updated when deltas are sent to the framework.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
