### PR TITLE
Support stencil buffers on OpenGL for Windows and Android

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1031,6 +1031,7 @@ FILE: ../../../flutter/shell/common/canvas_spy.h
 FILE: ../../../flutter/shell/common/canvas_spy_unittests.cc
 FILE: ../../../flutter/shell/common/context_options.cc
 FILE: ../../../flutter/shell/common/context_options.h
+FILE: ../../../flutter/shell/common/context_options_unittests.cc
 FILE: ../../../flutter/shell/common/dart_native_benchmarks.cc
 FILE: ../../../flutter/shell/common/display.cc
 FILE: ../../../flutter/shell/common/display.h

--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -261,6 +261,7 @@ if (enable_unittests) {
     sources = [
       "animator_unittests.cc",
       "canvas_spy_unittests.cc",
+      "context_options_unittests.cc",
       "engine_unittests.cc",
       "input_events_unittests.cc",
       "persistent_cache_unittests.cc",

--- a/shell/common/context_options.cc
+++ b/shell/common/context_options.cc
@@ -19,8 +19,6 @@ GrContextOptions MakeDefaultContextOptions(ContextType type,
   options.fPersistentCache = PersistentCache::GetCacheForProcess();
 
   if (api.has_value() && api.value() == GrBackendApi::kOpenGL) {
-    options.fAvoidStencilBuffers = true;
-
     // To get video playback on the widest range of devices, we limit Skia to
     // ES2 shading language when the ES3 external image extension is missing.
     options.fPreferExternalImagesOverES3 = true;

--- a/shell/common/context_options_unittests.cc
+++ b/shell/common/context_options_unittests.cc
@@ -1,0 +1,19 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "context_options.h"
+
+#include "gtest/gtest.h"
+
+namespace flutter {
+namespace testing {
+
+TEST(ContextOptionsTest, OpenGLAllowsStencilBuffers) {
+  auto options = MakeDefaultContextOptions(flutter::ContextType::kRender,
+                                           GrBackendApi::kOpenGL);
+  EXPECT_FALSE(options.fAvoidStencilBuffers);
+}
+
+}  // namespace testing
+}  // namespace flutter

--- a/shell/gpu/gpu_surface_gl.cc
+++ b/shell/gpu/gpu_surface_gl.cc
@@ -136,7 +136,7 @@ static sk_sp<SkSurface> WrapOnscreenSurface(GrDirectContext* context,
   GrBackendRenderTarget render_target(size.width(),     // width
                                       size.height(),    // height
                                       0,                // sample count
-                                      0,                // stencil bits (TODO)
+                                      8,                // stencil bits
                                       framebuffer_info  // framebuffer info
   );
 

--- a/shell/platform/android/android_context_gl.cc
+++ b/shell/platform/android/android_context_gl.cc
@@ -83,7 +83,7 @@ static EGLResult<EGLConfig> ChooseEGLConfiguration(EGLDisplay display) {
       EGL_BLUE_SIZE,       8,
       EGL_ALPHA_SIZE,      8,
       EGL_DEPTH_SIZE,      0,
-      EGL_STENCIL_SIZE,    0,
+      EGL_STENCIL_SIZE,    8,
       EGL_NONE,            // termination sentinel
       // clang-format on
   };

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -621,7 +621,7 @@ static sk_sp<SkSurface> MakeSkSurfaceFromBackingStore(
       config.size.width,   // width
       config.size.height,  // height
       1,                   // sample count
-      0,                   // stencil bits
+      8,                   // stencil bits
       framebuffer_info     // framebuffer info
   );
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/99934

In local testing on a low end and mid-ranged Android device, this doesn't seem to have any profound effect on raster times, but it does seem to give a slight improvement on average and worst case raster times. On the low end device, it causes no memory regression, on the Pixel 4 it causes an extra 10mb to be allocated for graphics.

I could use some help testing this change out on Windows, particularly to see if it has any positive impact for https://github.com/flutter/flutter/issues/97334.
