### PR TITLE
Always update the latest frame target time when the 'Animator::Render' method is called

### DIFF
--- a/shell/common/animator.cc
+++ b/shell/common/animator.cc
@@ -174,6 +174,9 @@ void Animator::Render(std::unique_ptr<flutter::LayerTree> layer_tree) {
                                 "Animator::Render");
   frame_timings_recorder_->RecordBuildEnd(fml::TimePoint::Now());
 
+  delegate_.OnAnimatorUpdateLatestFrameTargetTime(
+      frame_timings_recorder_->GetVsyncTargetTime());
+
   // Commit the pending continuation.
   PipelineProduceResult result =
       producer_continuation_.Complete(std::move(layer_tree));

--- a/shell/common/animator.h
+++ b/shell/common/animator.h
@@ -36,6 +36,9 @@ class Animator final {
 
     virtual void OnAnimatorNotifyIdle(fml::TimePoint deadline) = 0;
 
+    virtual void OnAnimatorUpdateLatestFrameTargetTime(
+        fml::TimePoint frame_target_time) = 0;
+
     virtual void OnAnimatorDraw(
         std::shared_ptr<Pipeline<flutter::LayerTree>> pipeline,
         std::unique_ptr<FrameTimingsRecorder> frame_timings_recorder) = 0;

--- a/shell/common/animator_unittests.cc
+++ b/shell/common/animator_unittests.cc
@@ -32,6 +32,9 @@ class FakeAnimatorDelegate : public Animator::Delegate {
     notify_idle_called_ = true;
   }
 
+  MOCK_METHOD1(OnAnimatorUpdateLatestFrameTargetTime,
+               void(fml::TimePoint frame_target_time));
+
   MOCK_METHOD2(
       OnAnimatorDraw,
       void(std::shared_ptr<Pipeline<flutter::LayerTree>> pipeline,
@@ -222,9 +225,12 @@ TEST_F(ShellTest, AnimatorDoesNotNotifyDelegateIfPipelineIsNotEmpty) {
           [&](fml::TimePoint frame_target_time, uint64_t frame_number) {
             begin_frame_latch.Signal();
           });
-
-  // It will only be called once even though we call the method Animator::Render
-  // twice. because it will only be called when the pipeline is empty.
+  // It should always be called when the method 'Animator::Render' is called,
+  // regardless of whether the pipeline is empty or not.
+  EXPECT_CALL(delegate, OnAnimatorUpdateLatestFrameTargetTime).Times(2);
+  // It will only be called once even though we call the method
+  // 'Animator::Render' twice. because it will only be called when the pipeline
+  // is empty.
   EXPECT_CALL(delegate, OnAnimatorDraw).Times(1);
 
   for (int i = 0; i < 2; i++) {

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -1106,23 +1106,26 @@ void Shell::OnAnimatorNotifyIdle(fml::TimePoint deadline) {
   }
 }
 
-// |Animator::Delegate|
-void Shell::OnAnimatorDraw(
-    std::shared_ptr<Pipeline<flutter::LayerTree>> pipeline,
-    std::unique_ptr<FrameTimingsRecorder> frame_timings_recorder) {
+void Shell::OnAnimatorUpdateLatestFrameTargetTime(
+    fml::TimePoint frame_target_time) {
   FML_DCHECK(is_setup_);
 
   // record the target time for use by rasterizer.
   {
     std::scoped_lock time_recorder_lock(time_recorder_mutex_);
-    const fml::TimePoint frame_target_time =
-        frame_timings_recorder->GetVsyncTargetTime();
     if (!latest_frame_target_time_) {
       latest_frame_target_time_ = frame_target_time;
     } else if (latest_frame_target_time_ < frame_target_time) {
       latest_frame_target_time_ = frame_target_time;
     }
   }
+}
+
+// |Animator::Delegate|
+void Shell::OnAnimatorDraw(
+    std::shared_ptr<Pipeline<flutter::LayerTree>> pipeline,
+    std::unique_ptr<FrameTimingsRecorder> frame_timings_recorder) {
+  FML_DCHECK(is_setup_);
 
   auto discard_callback = [this](flutter::LayerTree& tree) {
     std::scoped_lock<std::mutex> lock(resize_mutex_);

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -580,6 +580,10 @@ class Shell final : public PlatformView::Delegate,
   void OnAnimatorNotifyIdle(fml::TimePoint deadline) override;
 
   // |Animator::Delegate|
+  void OnAnimatorUpdateLatestFrameTargetTime(
+      fml::TimePoint frame_target_time) override;
+
+  // |Animator::Delegate|
   void OnAnimatorDraw(
       std::shared_ptr<Pipeline<flutter::LayerTree>> pipeline,
       std::unique_ptr<FrameTimingsRecorder> frame_timings_recorder) override;


### PR DESCRIPTION
tiny patch for https://github.com/flutter/engine/pull/31727

We should always update the latest frame target time when the method 'Animator::Render' is called, regardless of whether the pipeline is empty or not.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.
