### PR TITLE
Migrate the API of GrDirectContext about resource memory limit

### DIFF
--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -824,9 +824,7 @@ void Rasterizer::SetResourceCacheMaxBytes(size_t max_bytes, bool from_user) {
       return;
     }
 
-    int max_resources;
-    context->getResourceCacheLimits(&max_resources, nullptr);
-    context->setResourceCacheLimits(max_resources, max_bytes);
+    context->setResourceCacheLimit(max_bytes);
   }
 }
 
@@ -836,9 +834,7 @@ std::optional<size_t> Rasterizer::GetResourceCacheMaxBytes() const {
   }
   GrDirectContext* context = surface_->GetContext();
   if (context) {
-    size_t max_bytes;
-    context->getResourceCacheLimits(nullptr, &max_bytes);
-    return max_bytes;
+    return context->getResourceCacheLimit();
   }
   return std::nullopt;
 }

--- a/shell/common/shell_io_manager.cc
+++ b/shell/common/shell_io_manager.cc
@@ -23,7 +23,7 @@ sk_sp<GrDirectContext> ShellIOManager::CreateCompatibleResourceLoadingContext(
   if (auto context = GrDirectContext::MakeGL(gl_interface, options)) {
     // Do not cache textures created by the image decoder.  These textures
     // should be deleted when they are no longer referenced by an SkImage.
-    context->setResourceCacheLimits(0, 0);
+    context->setResourceCacheLimit(0);
     return context;
   }
 #endif

--- a/shell/common/shell_test_platform_view_vulkan.cc
+++ b/shell/common/shell_test_platform_view_vulkan.cc
@@ -125,8 +125,7 @@ bool ShellTestPlatformViewVulkan::OffScreenSurface::CreateSkiaGrContext() {
     return false;
   }
 
-  context->setResourceCacheLimits(vulkan::kGrCacheMaxCount,
-                                  vulkan::kGrCacheMaxByteSize);
+  context->setResourceCacheLimit(vulkan::kGrCacheMaxByteSize);
 
   context_ = context;
 

--- a/shell/gpu/gpu_surface_gl.cc
+++ b/shell/gpu/gpu_surface_gl.cc
@@ -25,9 +25,6 @@
 
 namespace flutter {
 
-// Default maximum number of budgeted resources in the cache.
-static const int kGrCacheMaxCount = 8192;
-
 // Default maximum number of bytes of GPU memory of budgeted resources in the
 // cache.
 // The shell will dynamically increase or decrease this cache based on the
@@ -54,7 +51,7 @@ sk_sp<GrDirectContext> GPUSurfaceGL::MakeGLContext(
     return nullptr;
   }
 
-  context->setResourceCacheLimits(kGrCacheMaxCount, kGrCacheMaxByteSize);
+  context->setResourceCacheLimit(kGrCacheMaxByteSize);
 
   PersistentCache::GetCacheForProcess()->PrecompileKnownSkSLs(context.get());
 

--- a/shell/platform/darwin/graphics/FlutterDarwinContextMetal.mm
+++ b/shell/platform/darwin/graphics/FlutterDarwinContextMetal.mm
@@ -60,7 +60,7 @@ FLUTTER_ASSERT_ARC
       return nil;
     }
 
-    _resourceContext->setResourceCacheLimits(0u, 0u);
+    _resourceContext->setResourceCacheLimit(0u);
   }
   return self;
 }

--- a/shell/platform/fuchsia/flutter/vulkan_surface_producer.cc
+++ b/shell/platform/fuchsia/flutter/vulkan_surface_producer.cc
@@ -22,7 +22,6 @@ namespace flutter_runner {
 
 namespace {
 
-constexpr int kGrCacheMaxCount = 8192;
 // Tuning advice:
 // If you see the following 3 things happening simultaneously in a trace:
 //   * Over budget ("flutter", "GPURasterizer::Draw") durations
@@ -150,7 +149,7 @@ bool VulkanSurfaceProducer::Initialize(scenic::Session* scenic_session) {
   }
 
   // Use local limits specified in this file above instead of flutter defaults.
-  context_->setResourceCacheLimits(kGrCacheMaxCount, kGrCacheMaxByteSize);
+  context_->setResourceCacheLimit(kGrCacheMaxByteSize);
 
   surface_pool_ =
       std::make_unique<VulkanSurfacePool>(*this, context_, scenic_session);

--- a/vulkan/vulkan_application.h
+++ b/vulkan/vulkan_application.h
@@ -15,7 +15,6 @@
 
 namespace vulkan {
 
-static const int kGrCacheMaxCount = 8192;
 static const size_t kGrCacheMaxByteSize = 512 * (1 << 20);
 
 class VulkanDevice;

--- a/vulkan/vulkan_window.cc
+++ b/vulkan/vulkan_window.cc
@@ -123,7 +123,7 @@ bool VulkanWindow::CreateSkiaGrContext() {
     return false;
   }
 
-  context->setResourceCacheLimits(kGrCacheMaxCount, kGrCacheMaxByteSize);
+  context->setResourceCacheLimit(kGrCacheMaxByteSize);
 
   skia_gr_context_ = context;
 


### PR DESCRIPTION
`setResourceCacheLimits` and `getResourceCacheLimits` are deprecated, we should use `setResourceCacheLimit` and 
`getResourceCacheLimit`

c.f.
https://github.com/google/skia/blob/d6245fc4aa6ed18279f3c19ba2771a7f67f5d296/include/gpu/GrDirectContext.h#L198-L213

https://github.com/google/skia/blob/d6245fc4aa6ed18279f3c19ba2771a7f67f5d296/include/gpu/GrDirectContext.h#L230-L247

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

