### PR TITLE
[ci.yaml] Migrate remaining targets to cocoon scheduler

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -107,7 +107,6 @@ targets:
       android_sdk_license: \n24333f8a63b6825ea9c5514f83c2829b004d1fee
       android_sdk_preview_license: \n84831b9409646a918e30573bab4c9c91346d8abd
     timeout: 60
-    scheduler: luci
 
   - name: Linux Android Debug Engine
     recipe: engine/engine
@@ -119,7 +118,6 @@ targets:
       android_sdk_license: \n24333f8a63b6825ea9c5514f83c2829b004d1fee
       android_sdk_preview_license: \n84831b9409646a918e30573bab4c9c91346d8abd
     timeout: 60
-    scheduler: luci
 
   - name: Linux Android Emulator Tests
     bringup: true # Recipe issue https://github.com/flutter/flutter/issues/86427
@@ -143,7 +141,6 @@ targets:
       build_host: "true"
       upload_metrics: "true"
     timeout: 60
-    scheduler: luci
 
   - name: Linux Benchmarks (no-upload)
     recipe: engine/engine_metrics
@@ -151,7 +148,6 @@ targets:
       build_host: "true"
       upload_metrics: "false"
     timeout: 60
-    scheduler: luci
 
   - name: Linux Fuchsia
     recipe: engine/engine
@@ -160,7 +156,6 @@ targets:
       build_fuchsia: "true"
       fuchsia_ctl_version: version:0.0.27
     timeout: 90
-    scheduler: luci
 
   - name: Linux Fuchsia FEMU
     recipe: engine/femu_test
@@ -169,7 +164,6 @@ targets:
       build_fuchsia: "true"
       fuchsia_ctl_version: version:0.0.27
     timeout: 60
-    scheduler: luci
 
   - name: Linux Framework Smoke Tests
     recipe: engine/framework_smoke
@@ -177,7 +171,6 @@ targets:
       - main
       - master
     timeout: 60
-    scheduler: luci
 
   - name: Linux Host Engine
     recipe: engine/engine
@@ -185,7 +178,6 @@ targets:
       add_recipes_cq: "true"
       build_host: "true"
     timeout: 60
-    scheduler: luci
 
   - name: Linux Unopt
     recipe: engine/engine_unopt
@@ -193,14 +185,12 @@ targets:
       add_recipes_cq: "true"
       clobber: "true"
     timeout: 60
-    scheduler: luci
 
   - name: Linux clang-tidy
     recipe: engine/engine_lint
     properties:
       add_recipes_cq: "true"
     timeout: 60
-    scheduler: luci
 
   - name: Linux Arm Host Engine
     recipe: engine/engine_arm
@@ -208,7 +198,6 @@ targets:
       add_recipes_cq: "true"
       build_host: "true"
     timeout: 90
-    scheduler: luci
 
   - name: Linux linux_host_engine
     recipe: engine_v2/engine_v2
@@ -228,7 +217,6 @@ targets:
           {"dependency": "goldctl"}
         ]
     timeout: 60
-    scheduler: luci
     runIf:
       - DEPS
       - lib/web_ui/**
@@ -249,7 +237,6 @@ targets:
       subshards: >-
               ["0", "1", "2", "3", "4", "5", "6", "7_last"]
     timeout: 60
-    scheduler: luci
     runIf:
       - DEPS
       - lib/web_ui/**
@@ -266,7 +253,6 @@ targets:
       build_android_aot: "true"
       jazzy_version: "0.14.1"
     timeout: 60
-    scheduler: luci
 
   - name: Mac Host Engine
     recipe: engine/engine
@@ -275,7 +261,6 @@ targets:
       build_host: "true"
       jazzy_version: "0.14.1"
     timeout: 75
-    scheduler: luci
 
   - name: Mac Unopt
     recipe: engine/engine_unopt
@@ -283,7 +268,6 @@ targets:
       add_recipes_cq: "true"
       jazzy_version: "0.14.1"
     timeout: 75
-    scheduler: luci
 
   - name: Mac clang-tidy
     recipe: engine/engine_lint
@@ -291,7 +275,6 @@ targets:
       add_recipes_cq: "true"
       jazzy_version: "0.14.1"
     timeout: 75
-    scheduler: luci
 
   - name: Mac iOS Engine
     recipe: engine/engine
@@ -300,7 +283,6 @@ targets:
       ios_debug: "true"
       jazzy_version: "0.14.1"
     timeout: 60
-    scheduler: luci
 
   - name: Mac Web Engine
     recipe: engine/web_engine
@@ -312,7 +294,6 @@ targets:
           {"dependency": "goldctl"}
         ]
     timeout: 60
-    scheduler: luci
     runIf:
       - DEPS
       - lib/web_ui/**
@@ -356,7 +337,6 @@ targets:
       android_sdk_license: \n24333f8a63b6825ea9c5514f83c2829b004d1fee
       android_sdk_preview_license: \n84831b9409646a918e30573bab4c9c91346d8abd
     timeout: 60
-    scheduler: luci
 
   - name: Windows Host Engine
     recipe: engine/engine
@@ -364,7 +344,6 @@ targets:
     properties:
       add_recipes_cq: "true"
       build_host: "true"
-    scheduler: luci
 
   - name: Windows windows_android_aot_engine
     recipe: engine_v2/engine_v2
@@ -387,21 +366,18 @@ targets:
     properties:
       add_recipes_cq: "true"
     timeout: 75
-    scheduler: luci
 
   - name: Windows UWP Engine
     recipe: engine/engine
     properties:
       build_windows_uwp: "true"
     timeout: 60
-    scheduler: luci
 
   - name: Windows Web Engine
     recipe: engine/web_engine
     properties:
       gcs_goldens_bucket: flutter_logs
     timeout: 60
-    scheduler: luci
     runIf:
       - DEPS
       - lib/web_ui/**
@@ -415,7 +391,6 @@ targets:
       ios_profile: "true"
       jazzy_version: "0.14.1"
     timeout: 90
-    scheduler: luci
 
   - name: Mac iOS Engine Release
     presubmit: false
@@ -425,7 +400,6 @@ targets:
       ios_release: "true"
       jazzy_version: "0.14.1"
     timeout: 90
-    scheduler: luci
 
   - name: Linux ci_yaml engine roller
     bringup: true


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/92300

This moves the rollout from 30% to 100% (adding 25 targets).

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
