### PR TITLE
Windows HasStrings error when backgrounded

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -2271,6 +2271,7 @@ FILE: ../../../flutter/shell/platform/windows/platform_handler.h
 FILE: ../../../flutter/shell/platform/windows/platform_handler_unittests.cc
 FILE: ../../../flutter/shell/platform/windows/platform_handler_win32.cc
 FILE: ../../../flutter/shell/platform/windows/platform_handler_win32.h
+FILE: ../../../flutter/shell/platform/windows/platform_handler_win32_unittests.cc
 FILE: ../../../flutter/shell/platform/windows/public/flutter_windows.h
 FILE: ../../../flutter/shell/platform/windows/sequential_id_generator.cc
 FILE: ../../../flutter/shell/platform/windows/sequential_id_generator.h

--- a/shell/platform/windows/BUILD.gn
+++ b/shell/platform/windows/BUILD.gn
@@ -183,6 +183,7 @@ executable("flutter_windows_unittests") {
     "keyboard_key_handler_unittests.cc",
     "keyboard_win32_unittests.cc",
     "platform_handler_unittests.cc",
+    "platform_handler_win32_unittests.cc",
     "sequential_id_generator_unittests.cc",
     "settings_plugin_unittests.cc",
     "system_utils_unittests.cc",

--- a/shell/platform/windows/platform_handler_win32.cc
+++ b/shell/platform/windows/platform_handler_win32.cc
@@ -141,13 +141,7 @@ int ScopedClipboard::Open(HWND window) {
   opened_ = ::OpenClipboard(window);
 
   if (!opened_) {
-    int error_code = ::GetLastError();
-    // Swallow errors of type ERROR_ACCESS_DENIED. These happen when the app is
-    // not in the foreground and HasStrings is irrelevant.
-    // See https://github.com/flutter/flutter/issues/95817.
-    if (error_code != kAccessDeniedErrorCode) {
-      return error_code;
-    }
+    return ::GetLastError();
   }
 
   return -1;
@@ -260,7 +254,7 @@ void PlatformHandlerWin32::GetHasStrings(
     rapidjson::Document error_code;
     error_code.SetInt(open_result);
     // Swallow errors of type ERROR_ACCESS_DENIED. These happen when the app is
-    // not in the foreground and HasStrings is irrelevant.
+    // not in the foreground and GetHasStrings is irrelevant.
     // See https://github.com/flutter/flutter/issues/95817.
     if (error_code != kAccessDeniedErrorCode) {
       result->Error(kClipboardError, "Unable to open clipboard", error_code);

--- a/shell/platform/windows/platform_handler_win32.cc
+++ b/shell/platform/windows/platform_handler_win32.cc
@@ -162,9 +162,6 @@ std::variant<std::wstring, int> ScopedClipboard::GetString() {
     return ::GetLastError();
   }
   ScopedGlobalLock locked_data(data);
-  if (!locked_data.get()) {
-    return ::GetLastError();
-  }
   std::optional<std::wstring> string = static_cast<wchar_t*>(locked_data.get());
   if (!string) {
     return ::GetLastError();

--- a/shell/platform/windows/platform_handler_win32.cc
+++ b/shell/platform/windows/platform_handler_win32.cc
@@ -100,30 +100,18 @@ class ScopedGlobalLock {
 class ScopedClipboard : public ScopedClipboardInterface {
  public:
   ScopedClipboard();
-  ~ScopedClipboard();
+  virtual ~ScopedClipboard();
 
   // Prevent copying.
   ScopedClipboard(ScopedClipboard const&) = delete;
   ScopedClipboard& operator=(ScopedClipboard const&) = delete;
 
-  // Attempts to open the clipboard for the given window, returning the error
-  // code in the case of failure and 0 otherwise.
   int Open(HWND window);
 
-  // Returns true if there is string data available to get.
   bool HasString();
 
-  // Returns string data from the clipboard.
-  //
-  // If getting a string fails, returns the error code.
-  //
-  // Open(...) must have succeeded to call this method.
   std::variant<std::wstring, int> GetString();
 
-  // Sets the string content of the clipboard, returning the error code on
-  // failure and 0 otherwise.
-  //
-  // Open(...) must have succeeded to call this method.
   int SetString(const std::wstring string);
 
  private:

--- a/shell/platform/windows/platform_handler_win32.cc
+++ b/shell/platform/windows/platform_handler_win32.cc
@@ -150,11 +150,11 @@ std::variant<std::wstring, int> ScopedClipboard::GetString() {
     return ::GetLastError();
   }
   ScopedGlobalLock locked_data(data);
-  std::optional<std::wstring> string = static_cast<wchar_t*>(locked_data.get());
-  if (!string) {
+
+  if (!locked_data.get()) {
     return ::GetLastError();
   }
-  return string.value();
+  return static_cast<wchar_t*>(locked_data.get());
 }
 
 int ScopedClipboard::SetString(const std::wstring string) {

--- a/shell/platform/windows/platform_handler_win32.cc
+++ b/shell/platform/windows/platform_handler_win32.cc
@@ -191,13 +191,13 @@ std::unique_ptr<PlatformHandler> PlatformHandler::Create(
 PlatformHandlerWin32::PlatformHandlerWin32(
     BinaryMessenger* messenger,
     FlutterWindowsView* view,
-    ScopedClipboardInterface* clipboard)
+    std::unique_ptr<ScopedClipboardInterface> clipboard)
     : PlatformHandler(messenger), view_(view) {
   if (clipboard == nullptr) {
-    ScopedClipboard scoped_clipboard;
-    clipboard = &scoped_clipboard;
+    clipboard_ = std::make_unique<ScopedClipboard>();
+  } else {
+    clipboard_ = std::move(clipboard);
   }
-  clipboard_ = clipboard;
 }
 
 PlatformHandlerWin32::~PlatformHandlerWin32() = default;

--- a/shell/platform/windows/platform_handler_win32.cc
+++ b/shell/platform/windows/platform_handler_win32.cc
@@ -191,7 +191,7 @@ std::unique_ptr<PlatformHandler> PlatformHandler::Create(
 PlatformHandlerWin32::PlatformHandlerWin32(
     BinaryMessenger* messenger,
     FlutterWindowsView* view,
-    ScopedClipboardInterface* clipboard = nullptr)
+    ScopedClipboardInterface* clipboard)
     : PlatformHandler(messenger), view_(view) {
   if (clipboard == nullptr) {
     ScopedClipboard scoped_clipboard;

--- a/shell/platform/windows/platform_handler_win32.cc
+++ b/shell/platform/windows/platform_handler_win32.cc
@@ -106,13 +106,13 @@ class ScopedClipboard : public ScopedClipboardInterface {
   ScopedClipboard(ScopedClipboard const&) = delete;
   ScopedClipboard& operator=(ScopedClipboard const&) = delete;
 
-  int Open(HWND window);
+  int Open(HWND window) override;
 
-  bool HasString();
+  bool HasString() override;
 
-  std::variant<std::wstring, int> GetString();
+  std::variant<std::wstring, int> GetString() override;
 
-  int SetString(const std::wstring string);
+  int SetString(const std::wstring string) override;
 
  private:
   bool opened_ = false;
@@ -191,13 +191,13 @@ std::unique_ptr<PlatformHandler> PlatformHandler::Create(
 PlatformHandlerWin32::PlatformHandlerWin32(
     BinaryMessenger* messenger,
     FlutterWindowsView* view,
-    std::optional<ScopedClipboardInterface*> clipboard_reference = nullptr)
+    ScopedClipboardInterface* clipboard = nullptr)
     : PlatformHandler(messenger), view_(view) {
-  if (clipboard_reference == nullptr) {
-    ScopedClipboard clipboard;
-    clipboard_reference = &clipboard;
+  if (clipboard == nullptr) {
+    ScopedClipboard scoped_clipboard;
+    clipboard = &scoped_clipboard;
   }
-  clipboard_ = clipboard_reference.value();
+  clipboard_ = clipboard;
 }
 
 PlatformHandlerWin32::~PlatformHandlerWin32() = default;

--- a/shell/platform/windows/platform_handler_win32.cc
+++ b/shell/platform/windows/platform_handler_win32.cc
@@ -202,15 +202,17 @@ std::unique_ptr<PlatformHandler> PlatformHandler::Create(
   return std::make_unique<PlatformHandlerWin32>(messenger, view);
 }
 
-PlatformHandlerWin32::PlatformHandlerWin32(BinaryMessenger* messenger,
-                                           FlutterWindowsView* view, std::optional<ScopedClipboardInterface*> clipboard_reference = nullptr)
+PlatformHandlerWin32::PlatformHandlerWin32(
+    BinaryMessenger* messenger,
+    FlutterWindowsView* view,
+    std::optional<ScopedClipboardInterface*> clipboard_reference = nullptr)
     : PlatformHandler(messenger), view_(view) {
-      if (clipboard_reference == nullptr) {
-        ScopedClipboard clipboard;
-        clipboard_reference = &clipboard;
-      }
-      clipboard_ = clipboard_reference.value();
-    }
+  if (clipboard_reference == nullptr) {
+    ScopedClipboard clipboard;
+    clipboard_reference = &clipboard;
+  }
+  clipboard_ = clipboard_reference.value();
+}
 
 PlatformHandlerWin32::~PlatformHandlerWin32() = default;
 
@@ -241,7 +243,9 @@ void PlatformHandlerWin32::GetPlainText(
   rapidjson::Document::AllocatorType& allocator = document.GetAllocator();
   document.AddMember(
       rapidjson::Value(key.data(), allocator),
-      rapidjson::Value(fml::WideStringToUtf8(std::get<std::wstring>(get_string_result)), allocator),
+      rapidjson::Value(
+          fml::WideStringToUtf8(std::get<std::wstring>(get_string_result)),
+          allocator),
       allocator);
   result->Success(document);
 }

--- a/shell/platform/windows/platform_handler_win32.h
+++ b/shell/platform/windows/platform_handler_win32.h
@@ -48,7 +48,7 @@ class PlatformHandlerWin32 : public PlatformHandler {
   explicit PlatformHandlerWin32(
       BinaryMessenger* messenger,
       FlutterWindowsView* view,
-      ScopedClipboardInterface* clipboard);
+      ScopedClipboardInterface* clipboard = nullptr);
 
   virtual ~PlatformHandlerWin32();
 
@@ -74,7 +74,7 @@ class PlatformHandlerWin32 : public PlatformHandler {
  private:
   // A reference to the Flutter view.
   FlutterWindowsView* view_;
-  // A clipboard instance that can be passed in.
+  // A clipboard instance that can be passed in for mocking in tests.
   ScopedClipboardInterface* clipboard_;
 };
 

--- a/shell/platform/windows/platform_handler_win32.h
+++ b/shell/platform/windows/platform_handler_win32.h
@@ -48,7 +48,7 @@ class PlatformHandlerWin32 : public PlatformHandler {
   explicit PlatformHandlerWin32(
       BinaryMessenger* messenger,
       FlutterWindowsView* view,
-      ScopedClipboardInterface* clipboard = nullptr);
+      std::unique_ptr<ScopedClipboardInterface> clipboard = nullptr);
 
   virtual ~PlatformHandlerWin32();
 
@@ -75,7 +75,7 @@ class PlatformHandlerWin32 : public PlatformHandler {
   // A reference to the Flutter view.
   FlutterWindowsView* view_;
   // A clipboard instance that can be passed in for mocking in tests.
-  ScopedClipboardInterface* clipboard_;
+  std::unique_ptr<ScopedClipboardInterface> clipboard_;
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/platform_handler_win32.h
+++ b/shell/platform/windows/platform_handler_win32.h
@@ -48,7 +48,7 @@ class PlatformHandlerWin32 : public PlatformHandler {
   explicit PlatformHandlerWin32(
       BinaryMessenger* messenger,
       FlutterWindowsView* view,
-      std::optional<ScopedClipboardInterface*> clipboard_reference);
+      ScopedClipboardInterface* clipboard);
 
   virtual ~PlatformHandlerWin32();
 

--- a/shell/platform/windows/platform_handler_win32.h
+++ b/shell/platform/windows/platform_handler_win32.h
@@ -19,7 +19,7 @@ class FlutterWindowsView;
 // PlatformHandlerWin32.
 class ScopedClipboardInterface {
  public:
-  virtual ~ScopedClipboardInterface() {};
+  virtual ~ScopedClipboardInterface(){};
 
   // Attempts to open the clipboard for the given window, returning the error
   // code in the case of failure and 0 otherwise.

--- a/shell/platform/windows/platform_handler_win32.h
+++ b/shell/platform/windows/platform_handler_win32.h
@@ -31,8 +31,10 @@ class ScopedClipboardInterface {
 // Win32 implementation of PlatformHandler.
 class PlatformHandlerWin32 : public PlatformHandler {
  public:
-  explicit PlatformHandlerWin32(BinaryMessenger* messenger,
-                                FlutterWindowsView* view, std::optional<ScopedClipboardInterface*> clipboard_reference);
+  explicit PlatformHandlerWin32(
+      BinaryMessenger* messenger,
+      FlutterWindowsView* view,
+      std::optional<ScopedClipboardInterface*> clipboard_reference);
 
   virtual ~PlatformHandlerWin32();
 

--- a/shell/platform/windows/platform_handler_win32.h
+++ b/shell/platform/windows/platform_handler_win32.h
@@ -15,11 +15,24 @@ namespace flutter {
 
 class FlutterWindowsView;
 
+// A public interface for ScopedClipboard, so that it can be injected into
+// PlatformHandlerWin32.
+class ScopedClipboardInterface {
+ public:
+  virtual int Open(HWND window) = 0;
+
+  virtual bool HasString() = 0;
+
+  virtual std::variant<std::wstring, int> GetString() = 0;
+
+  virtual int SetString(const std::wstring string) = 0;
+};
+
 // Win32 implementation of PlatformHandler.
 class PlatformHandlerWin32 : public PlatformHandler {
  public:
   explicit PlatformHandlerWin32(BinaryMessenger* messenger,
-                                FlutterWindowsView* view);
+                                FlutterWindowsView* view, std::optional<ScopedClipboardInterface*> clipboard_reference);
 
   virtual ~PlatformHandlerWin32();
 
@@ -45,6 +58,8 @@ class PlatformHandlerWin32 : public PlatformHandler {
  private:
   // A reference to the Flutter view.
   FlutterWindowsView* view_;
+  // A clipboard instance that can be passed in.
+  ScopedClipboardInterface* clipboard_;
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/platform_handler_win32.h
+++ b/shell/platform/windows/platform_handler_win32.h
@@ -19,12 +19,26 @@ class FlutterWindowsView;
 // PlatformHandlerWin32.
 class ScopedClipboardInterface {
  public:
+  virtual ~ScopedClipboardInterface() {};
+
+  // Attempts to open the clipboard for the given window, returning the error
+  // code in the case of failure and 0 otherwise.
   virtual int Open(HWND window) = 0;
 
+  // Returns true if there is string data available to get.
   virtual bool HasString() = 0;
 
+  // Returns string data from the clipboard.
+  //
+  // If getting a string fails, returns the error code.
+  //
+  // Open(...) must have succeeded to call this method.
   virtual std::variant<std::wstring, int> GetString() = 0;
 
+  // Sets the string content of the clipboard, returning the error code on
+  // failure and 0 otherwise.
+  //
+  // Open(...) must have succeeded to call this method.
   virtual int SetString(const std::wstring string) = 0;
 };
 

--- a/shell/platform/windows/platform_handler_win32_unittests.cc
+++ b/shell/platform/windows/platform_handler_win32_unittests.cc
@@ -89,11 +89,10 @@ class MockMethodResult : public MethodResult<rapidjson::Document> {
 
 TEST(PlatformHandlerWin32, HasStringsAccessDeniedReturnsFalseWithoutError) {
   TestBinaryMessenger messenger;
-  TestScopedClipboard clipboard_reference;
   FlutterWindowsView view(
       std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>());
   PlatformHandlerWin32 platform_handler(&messenger, &view,
-                                        &clipboard_reference);
+                                        std::make_unique<TestScopedClipboard>());
 
   auto args = std::make_unique<rapidjson::Document>(rapidjson::kStringType);
   auto& allocator = args->GetAllocator();

--- a/shell/platform/windows/platform_handler_win32_unittests.cc
+++ b/shell/platform/windows/platform_handler_win32_unittests.cc
@@ -41,13 +41,13 @@ class TestScopedClipboard : public ScopedClipboardInterface {
   TestScopedClipboard(TestScopedClipboard const&) = delete;
   TestScopedClipboard& operator=(TestScopedClipboard const&) = delete;
 
-  int Open(HWND window);
+  int Open(HWND window) override;
 
-  bool HasString();
+  bool HasString() override;
 
-  std::variant<std::wstring, int> GetString();
+  std::variant<std::wstring, int> GetString() override;
 
-  int SetString(const std::wstring string);
+  int SetString(const std::wstring string) override;
 
  private:
   bool opened_ = false;

--- a/shell/platform/windows/platform_handler_win32_unittests.cc
+++ b/shell/platform/windows/platform_handler_win32_unittests.cc
@@ -28,6 +28,7 @@ static constexpr char kTextPlainFormat[] = "text/plain";
 static constexpr char kValueKey[] = "value";
 static constexpr int kAccessDeniedErrorCode = 5;
 static constexpr int kErrorSuccess = 0;
+static constexpr int kArbitraryErrorCode = 1;
 
 }  // namespace
 
@@ -208,7 +209,8 @@ TEST(PlatformHandlerWin32, HasStringsError) {
       std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>());
   // HasStrings will fail.
   PlatformHandlerWin32 platform_handler(
-      &messenger, &view, std::make_unique<TestScopedClipboard>(1, true));
+      &messenger, &view,
+      std::make_unique<TestScopedClipboard>(kArbitraryErrorCode, true));
 
   auto args = std::make_unique<rapidjson::Document>(rapidjson::kStringType);
   auto& allocator = args->GetAllocator();

--- a/shell/platform/windows/platform_handler_win32_unittests.cc
+++ b/shell/platform/windows/platform_handler_win32_unittests.cc
@@ -91,8 +91,9 @@ TEST(PlatformHandlerWin32, HasStringsAccessDeniedReturnsFalseWithoutError) {
   TestBinaryMessenger messenger;
   TestScopedClipboard clipboard_reference;
   FlutterWindowsView view(
-            std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>());
-  PlatformHandlerWin32 platform_handler(&messenger, &view, &clipboard_reference);
+      std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>());
+  PlatformHandlerWin32 platform_handler(&messenger, &view,
+                                        &clipboard_reference);
 
   auto args = std::make_unique<rapidjson::Document>(rapidjson::kStringType);
   auto& allocator = args->GetAllocator();
@@ -104,7 +105,8 @@ TEST(PlatformHandlerWin32, HasStringsAccessDeniedReturnsFalseWithoutError) {
   MockMethodResult result;
   rapidjson::Document document;
   document.SetObject();
-  rapidjson::Document::AllocatorType& document_allocator = document.GetAllocator();
+  rapidjson::Document::AllocatorType& document_allocator =
+      document.GetAllocator();
   document.AddMember(rapidjson::Value(kValueKey, document_allocator),
                      rapidjson::Value(false), document_allocator);
 

--- a/shell/platform/windows/platform_handler_win32_unittests.cc
+++ b/shell/platform/windows/platform_handler_win32_unittests.cc
@@ -1,0 +1,124 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/windows/platform_handler_win32.h"
+
+#include <memory>
+
+#include "flutter/shell/platform/common/json_method_codec.h"
+#include "flutter/shell/platform/windows/testing/mock_window_binding_handler.h"
+#include "flutter/shell/platform/windows/testing/test_binary_messenger.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "rapidjson/document.h"
+
+namespace flutter {
+namespace testing {
+
+namespace {
+using ::testing::_;
+
+static constexpr char kChannelName[] = "flutter/platform";
+
+static constexpr char kHasStringsClipboardMethod[] = "Clipboard.hasStrings";
+
+static constexpr char kTextPlainFormat[] = "text/plain";
+
+static constexpr char kValueKey[] = "value";
+static constexpr int kAccessDeniedErrorCode = 5;
+
+}  // namespace
+
+// A test version of the private ScopedClipboard.
+class TestScopedClipboard : public ScopedClipboardInterface {
+ public:
+  TestScopedClipboard();
+  ~TestScopedClipboard();
+
+  // Prevent copying.
+  TestScopedClipboard(TestScopedClipboard const&) = delete;
+  TestScopedClipboard& operator=(TestScopedClipboard const&) = delete;
+
+  int Open(HWND window);
+
+  bool HasString();
+
+  std::variant<std::wstring, int> GetString();
+
+  int SetString(const std::wstring string);
+
+ private:
+  bool opened_ = false;
+};
+
+TestScopedClipboard::TestScopedClipboard() {}
+
+TestScopedClipboard::~TestScopedClipboard() {
+  if (opened_) {
+    ::CloseClipboard();
+  }
+}
+
+// Always fail to open with kAccessDeniedErrorCode.
+int TestScopedClipboard::Open(HWND window) {
+  return kAccessDeniedErrorCode;
+}
+
+bool TestScopedClipboard::HasString() {
+  return true;
+}
+
+std::variant<std::wstring, int> TestScopedClipboard::GetString() {
+  return -1;
+}
+
+int TestScopedClipboard::SetString(const std::wstring string) {
+  return -1;
+}
+
+class MockMethodResult : public MethodResult<rapidjson::Document> {
+ public:
+  MOCK_METHOD1(SuccessInternal, void(const rapidjson::Document*));
+  MOCK_METHOD3(ErrorInternal,
+               void(const std::string&,
+                    const std::string&,
+                    const rapidjson::Document*));
+  MOCK_METHOD0(NotImplementedInternal, void());
+};
+
+TEST(PlatformHandlerWin32, HasStringsAccessDeniedReturnsFalseWithoutError) {
+  TestBinaryMessenger messenger;
+  TestScopedClipboard clipboard_reference;
+  FlutterWindowsView view(
+            std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>());
+  PlatformHandlerWin32 platform_handler(&messenger, &view, &clipboard_reference);
+
+  auto args = std::make_unique<rapidjson::Document>(rapidjson::kStringType);
+  auto& allocator = args->GetAllocator();
+  args->SetString(kTextPlainFormat);
+  auto encoded = JsonMethodCodec::GetInstance().EncodeMethodCall(
+      MethodCall<rapidjson::Document>(kHasStringsClipboardMethod,
+                                      std::move(args)));
+
+  MockMethodResult result;
+  rapidjson::Document document;
+  document.SetObject();
+  rapidjson::Document::AllocatorType& document_allocator = document.GetAllocator();
+  document.AddMember(rapidjson::Value(kValueKey, document_allocator),
+                     rapidjson::Value(false), document_allocator);
+
+  EXPECT_CALL(result, SuccessInternal(_))
+      .WillOnce([](const rapidjson::Document* document) {
+        ASSERT_FALSE((*document)[kValueKey].GetBool());
+      });
+  EXPECT_TRUE(messenger.SimulateEngineMessage(
+      kChannelName, encoded->data(), encoded->size(),
+      [&](const uint8_t* reply, size_t reply_size) {
+        JsonMethodCodec::GetInstance().DecodeAndProcessResponseEnvelope(
+            reply, reply_size, &result);
+      }));
+}
+
+}  // namespace testing
+}  // namespace flutter


### PR DESCRIPTION
This PR works around an error that happened when HasStrings checked the clipboard (in order to see if the Paste button could be shown) when the app was not in the foreground.  That information isn't relevant when the app is in the background, so instead of logging an error and worrying developers, I'm swallowing the error and returning false.

Fixes https://github.com/flutter/flutter/issues/95817