### PR TITLE
[macOS] Forward key events to NSTextInputContext when there's composing text

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterKeyboardManager.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterKeyboardManager.mm
@@ -72,6 +72,12 @@
       event.type != NSEventTypeFlagsChanged) {
     return;
   }
+
+  if (_viewDelegate.isComposing) {
+    [self dispatchToSecondaryResponders:event];
+    return;
+  }
+
   // Having no primary responders require extra logic, but Flutter hard-codes
   // all primary responders, so this is a situation that Flutter will never
   // encounter.

--- a/shell/platform/darwin/macos/framework/Source/FlutterKeyboardManagerUnittests.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterKeyboardManagerUnittests.mm
@@ -75,6 +75,7 @@ NSResponder* mockOwnerWithDownOnlyNext() {
 
 @property(nonatomic) FlutterKeyboardManager* manager;
 @property(nonatomic) NSResponder* nextResponder;
+@property(nonatomic, assign) BOOL isComposing;
 
 #pragma mark - Private
 
@@ -105,6 +106,7 @@ NSResponder* mockOwnerWithDownOnlyNext() {
   [self respondChannelCallsWith:FALSE];
   [self respondEmbedderCallsWith:FALSE];
   [self respondTextInputWith:FALSE];
+  _isComposing = NO;
 
   id messengerMock = OCMStrictProtocolMock(@protocol(FlutterBinaryMessenger));
   OCMStub([messengerMock sendOnChannel:@"flutter/keyevent"
@@ -117,6 +119,7 @@ NSResponder* mockOwnerWithDownOnlyNext() {
   OCMStub([viewDelegateMock onTextInputKeyEvent:[OCMArg any]])
       .andCall(self, @selector(handleTextInputKeyEvent:));
   OCMStub([viewDelegateMock getBinaryMessenger]).andReturn(messengerMock);
+  OCMStub([viewDelegateMock isComposing]).andCall(self, @selector(isComposing));
   OCMStub([viewDelegateMock sendKeyEvent:FlutterKeyEvent {} callback:nil userData:nil])
       .ignoringNonObjectArgs()
       .andCall(self, @selector(handleEmbedderEvent:callback:userData:));
@@ -188,6 +191,7 @@ NSResponder* mockOwnerWithDownOnlyNext() {
 - (bool)singlePrimaryResponder;
 - (bool)doublePrimaryResponder;
 - (bool)textInputPlugin;
+- (bool)forwardKeyEventsToSystemWhenComposing;
 - (bool)emptyNextResponder;
 @end
 
@@ -206,6 +210,10 @@ TEST(FlutterKeyboardManagerUnittests, DoublePrimaryResponder) {
 
 TEST(FlutterKeyboardManagerUnittests, SingleFinalResponder) {
   ASSERT_TRUE([[FlutterKeyboardManagerUnittestsObjC alloc] textInputPlugin]);
+}
+
+TEST(FlutterKeyboardManagerUnittests, handlingComposingText) {
+  ASSERT_TRUE([[FlutterKeyboardManagerUnittestsObjC alloc] forwardKeyEventsToSystemWhenComposing]);
 }
 
 TEST(FlutterKeyboardManagerUnittests, EmptyNextResponder) {
@@ -352,6 +360,40 @@ TEST(FlutterKeyboardManagerUnittests, EmptyNextResponder) {
   callbacks[0](FALSE);
   OCMVerify([tester.nextResponder keyDown:checkKeyDownEvent(0x50)]);
   [callbacks removeAllObjects];
+
+  return true;
+}
+
+- (bool)forwardKeyEventsToSystemWhenComposing {
+  KeyboardTester* tester = [[KeyboardTester alloc] init];
+
+  tester.isComposing = YES;
+  // Send a down event with composing == YES.
+  [tester.manager handleEvent:keyDownEvent(0x50)];
+
+  NSMutableArray<FlutterAsyncKeyCallback>* channelCallbacks =
+      [NSMutableArray<FlutterAsyncKeyCallback> array];
+  NSMutableArray<FlutterAsyncKeyCallback>* embedderCallbacks =
+      [NSMutableArray<FlutterAsyncKeyCallback> array];
+  [tester recordEmbedderCallsTo:embedderCallbacks];
+  [tester recordChannelCallsTo:channelCallbacks];
+  // TextInputPlugin does not claim the event.
+  [tester respondTextInputWith:NO];
+  [tester.manager handleEvent:keyUpEvent(0x50)];
+
+  // Nobody gets the event except for the text input plugin.
+  EXPECT_EQ([channelCallbacks count], 0u);
+  EXPECT_EQ([embedderCallbacks count], 0u);
+
+  // Send another down event with composing == NO.
+  tester.isComposing = NO;
+  [tester respondTextInputWith:YES];
+  [tester.manager handleEvent:keyDownEvent(0x50)];
+  // Now the responders get the event.
+  EXPECT_EQ([channelCallbacks count], 1u);
+  EXPECT_EQ([embedderCallbacks count], 1u);
+  embedderCallbacks[0](TRUE);
+  channelCallbacks[0](TRUE);
 
   return true;
 }

--- a/shell/platform/darwin/macos/framework/Source/FlutterKeyboardViewDelegate.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterKeyboardViewDelegate.h
@@ -50,4 +50,14 @@
  */
 - (BOOL)onTextInputKeyEvent:(nonnull NSEvent*)event;
 
+/**
+ * Whether this FlutterKeyboardViewDelegate is actively taking provisional user text input.
+ *
+ * This is typically true when a Flutter text field is focused, and the user is entering composing
+ * text into the text field.
+ */
+// TODO (LongCatIsLooong): remove this method and implement a long-term fix for
+// https://github.com/flutter/flutter/issues/85328.
+- (BOOL)isComposing;
+
 @end

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.h
@@ -46,6 +46,15 @@
 - (BOOL)isFirstResponder;
 
 /**
+ * Whether this plugin has composing text.
+ *
+ * This is only true when the text input plugin is actively taking user input with composing text.
+ */
+// TODO (LongCatIsLooong): remove this method and implement a long-term fix for
+// https://github.com/flutter/flutter/issues/85328.
+- (BOOL)isComposing;
+
+/**
  * Handles key down events received from the view controller, responding YES if
  * the event was handled.
  *

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -457,6 +457,10 @@ static flutter::TextRange RangeFromBaseExtent(NSNumber* base,
                                                             : kTextAffinityDownstream;
 }
 
+- (BOOL)isComposing {
+  return _activeModel && !_activeModel->composing_range().collapsed();
+}
+
 - (BOOL)handleKeyEvent:(NSEvent*)event {
   if (event.type == NSEventTypeKeyUp ||
       (event.type == NSEventTypeFlagsChanged && event.modifierFlags < _previouslyPressedFlags)) {

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -661,6 +661,10 @@ static void CommonInit(FlutterViewController* controller) {
 
 #pragma mark - FlutterKeyboardViewDelegate
 
+- (BOOL)isComposing {
+  return [_textInputPlugin isComposing];
+}
+
 - (void)sendKeyEvent:(const FlutterKeyEvent&)event
             callback:(nullable FlutterKeyEventCallback)callback
             userData:(nullable void*)userData {


### PR DESCRIPTION
Partially fixes https://github.com/flutter/flutter/issues/85328, still does not work in the macOS accent menu

Quick demo:

https://user-images.githubusercontent.com/31859944/158485133-ef552aeb-022f-491d-9753-b4beb6298d84.mov

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
