### PR TITLE
Make sure that 'BeginFrame' and 'EndFrame' of the 'ExternalViewEmbedder' are paired

### DIFF
--- a/flow/embedded_views.h
+++ b/flow/embedded_views.h
@@ -337,13 +337,13 @@ class ExternalViewEmbedder {
 
   // Change the flag about whether it is used in this frame, it will be set to
   // true when 'BeginFrame' and false when 'EndFrame'.
-  void set_used_this_frame(bool used_this_frame) {
+  void SetUsedThisFrame(bool used_this_frame) {
     used_this_frame_ = used_this_frame;
   }
 
   // Whether it is used in this frame, returns true between 'BeginFrame' and
   // 'EndFrame', otherwise returns false.
-  bool used_this_frame() const { return used_this_frame_; }
+  bool GetUsedThisFrame() const { return used_this_frame_; }
 
  private:
   bool used_this_frame_ = false;

--- a/flow/embedded_views.h
+++ b/flow/embedded_views.h
@@ -335,6 +335,19 @@ class ExternalViewEmbedder {
   // embedder.
   virtual void Teardown();
 
+  // Change the flag about whether it is used in this frame, it will be set to
+  // true when 'BeginFrame' and false when 'EndFrame'.
+  void set_used_this_frame(bool used_this_frame) {
+    used_this_frame_ = used_this_frame;
+  }
+
+  // Whether it is used in this frame, returns true between 'BeginFrame' and
+  // 'EndFrame', otherwise returns false.
+  bool used_this_frame() const { return used_this_frame_; }
+
+ private:
+  bool used_this_frame_ = false;
+
   FML_DISALLOW_COPY_AND_ASSIGN(ExternalViewEmbedder);
 
 };  // ExternalViewEmbedder

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -151,10 +151,11 @@ void Rasterizer::DrawLastLayerTree(
       DrawToSurface(*frame_timings_recorder, *last_layer_tree_);
 
   // EndFrame should perform cleanups for the external_view_embedder.
-  if (external_view_embedder_) {
+  if (external_view_embedder_ && external_view_embedder_->used_this_frame()) {
     bool should_resubmit_frame = ShouldResubmitFrame(raster_status);
     external_view_embedder_->EndFrame(should_resubmit_frame,
                                       raster_thread_merger_);
+    external_view_embedder_->set_used_this_frame(false);
   }
 }
 
@@ -208,9 +209,11 @@ RasterStatus Rasterizer::Draw(
   }
 
   // EndFrame should perform cleanups for the external_view_embedder.
-  if (surface_ && external_view_embedder_) {
+  if (surface_ && external_view_embedder_ &&
+      external_view_embedder_->used_this_frame()) {
     external_view_embedder_->EndFrame(should_resubmit_frame,
                                       raster_thread_merger_);
+    external_view_embedder_->set_used_this_frame(false);
   }
 
   // Consume as many pipeline items as possible. But yield the event loop
@@ -524,6 +527,7 @@ RasterStatus Rasterizer::DrawToSurfaceUnsafe(
     external_view_embedder_->BeginFrame(
         layer_tree.frame_size(), surface_->GetContext(),
         layer_tree.device_pixel_ratio(), raster_thread_merger_);
+    external_view_embedder_->set_used_this_frame(true);
     embedder_root_canvas = external_view_embedder_->GetRootCanvas();
   }
 

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -151,11 +151,11 @@ void Rasterizer::DrawLastLayerTree(
       DrawToSurface(*frame_timings_recorder, *last_layer_tree_);
 
   // EndFrame should perform cleanups for the external_view_embedder.
-  if (external_view_embedder_ && external_view_embedder_->used_this_frame()) {
+  if (external_view_embedder_ && external_view_embedder_->GetUsedThisFrame()) {
     bool should_resubmit_frame = ShouldResubmitFrame(raster_status);
     external_view_embedder_->EndFrame(should_resubmit_frame,
                                       raster_thread_merger_);
-    external_view_embedder_->set_used_this_frame(false);
+    external_view_embedder_->SetUsedThisFrame(false);
   }
 }
 
@@ -210,10 +210,10 @@ RasterStatus Rasterizer::Draw(
 
   // EndFrame should perform cleanups for the external_view_embedder.
   if (surface_ && external_view_embedder_ &&
-      external_view_embedder_->used_this_frame()) {
+      external_view_embedder_->GetUsedThisFrame()) {
     external_view_embedder_->EndFrame(should_resubmit_frame,
                                       raster_thread_merger_);
-    external_view_embedder_->set_used_this_frame(false);
+    external_view_embedder_->SetUsedThisFrame(false);
   }
 
   // Consume as many pipeline items as possible. But yield the event loop
@@ -524,10 +524,11 @@ RasterStatus Rasterizer::DrawToSurfaceUnsafe(
 
   SkCanvas* embedder_root_canvas = nullptr;
   if (external_view_embedder_) {
+    FML_DCHECK(!external_view_embedder_->GetUsedThisFrame());
+    external_view_embedder_->SetUsedThisFrame(true);
     external_view_embedder_->BeginFrame(
         layer_tree.frame_size(), surface_->GetContext(),
         layer_tree.device_pixel_ratio(), raster_thread_merger_);
-    external_view_embedder_->set_used_this_frame(true);
     embedder_root_canvas = external_view_embedder_->GetRootCanvas();
   }
 

--- a/shell/common/rasterizer_unittests.cc
+++ b/shell/common/rasterizer_unittests.cc
@@ -419,6 +419,59 @@ TEST(RasterizerTest, externalViewEmbedderDoesntEndFrameWhenNoSurfaceIsSet) {
   latch.Wait();
 }
 
+TEST(RasterizerTest, externalViewEmbedderDoesntEndFrameWhenNotUsedThisFrame) {
+  std::string test_name =
+      ::testing::UnitTest::GetInstance()->current_test_info()->name();
+  ThreadHost thread_host("io.flutter.test." + test_name + ".",
+                         ThreadHost::Type::Platform | ThreadHost::Type::RASTER |
+                             ThreadHost::Type::IO | ThreadHost::Type::UI);
+  TaskRunners task_runners("test", thread_host.platform_thread->GetTaskRunner(),
+                           thread_host.raster_thread->GetTaskRunner(),
+                           thread_host.ui_thread->GetTaskRunner(),
+                           thread_host.io_thread->GetTaskRunner());
+  MockDelegate delegate;
+  EXPECT_CALL(delegate, GetTaskRunners())
+      .WillRepeatedly(ReturnRef(task_runners));
+
+  auto rasterizer = std::make_unique<Rasterizer>(delegate);
+  auto surface = std::make_unique<MockSurface>();
+  EXPECT_CALL(*surface, MakeRenderContextCurrent())
+      .WillOnce(Return(ByMove(std::make_unique<GLContextDefaultResult>(true))));
+
+  std::shared_ptr<MockExternalViewEmbedder> external_view_embedder =
+      std::make_shared<MockExternalViewEmbedder>();
+  rasterizer->SetExternalViewEmbedder(external_view_embedder);
+  rasterizer->Setup(std::move(surface));
+
+  EXPECT_CALL(*external_view_embedder,
+              BeginFrame(/*frame_size=*/SkISize(), /*context=*/nullptr,
+                         /*device_pixel_ratio=*/2.0,
+                         /*raster_thread_merger=*/_))
+      .Times(0);
+  EXPECT_CALL(
+      *external_view_embedder,
+      EndFrame(/*should_resubmit_frame=*/false,
+               /*raster_thread_merger=*/fml::RefPtr<fml::RasterThreadMerger>(
+                   nullptr)))
+      .Times(0);
+
+  fml::AutoResetWaitableEvent latch;
+  thread_host.raster_thread->GetTaskRunner()->PostTask([&] {
+    auto pipeline = std::make_shared<Pipeline<LayerTree>>(/*depth=*/10);
+    auto layer_tree = std::make_unique<LayerTree>(/*frame_size=*/SkISize(),
+                                                  /*device_pixel_ratio=*/2.0f);
+    PipelineProduceResult result =
+        pipeline->Produce().Complete(std::move(layer_tree));
+    EXPECT_TRUE(result.success);
+    auto no_discard = [](LayerTree&) { return true; };
+    RasterStatus status =
+        rasterizer->Draw(CreateFinishedBuildRecorder(), pipeline, no_discard);
+    EXPECT_EQ(status, RasterStatus::kDiscarded);
+    latch.Signal();
+  });
+  latch.Wait();
+}
+
 TEST(RasterizerTest, externalViewEmbedderDoesntEndFrameWhenPipelineIsEmpty) {
   std::string test_name =
       ::testing::UnitTest::GetInstance()->current_test_info()->name();

--- a/shell/common/rasterizer_unittests.cc
+++ b/shell/common/rasterizer_unittests.cc
@@ -463,9 +463,10 @@ TEST(RasterizerTest, externalViewEmbedderDoesntEndFrameWhenNotUsedThisFrame) {
     PipelineProduceResult result =
         pipeline->Produce().Complete(std::move(layer_tree));
     EXPECT_TRUE(result.success);
-    auto no_discard = [](LayerTree&) { return true; };
-    RasterStatus status =
-        rasterizer->Draw(CreateFinishedBuildRecorder(), pipeline, no_discard);
+    // Always discard the layer tree.
+    auto discard_callback = [](LayerTree&) { return true; };
+    RasterStatus status = rasterizer->Draw(CreateFinishedBuildRecorder(),
+                                           pipeline, discard_callback);
     EXPECT_EQ(status, RasterStatus::kDiscarded);
     latch.Signal();
   });

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -2396,6 +2396,8 @@ TEST_F(ShellTest, OnServiceProtocolEstimateRasterCacheMemoryWorks) {
 
 // TODO(https://github.com/flutter/flutter/issues/100273): Disabled due to
 // flakiness.
+// TODO(https://github.com/flutter/flutter/issues/100299): Fix it when
+// re-enabling.
 TEST_F(ShellTest, DISABLED_DiscardLayerTreeOnResize) {
   auto settings = CreateSettingsForFixture();
 
@@ -2448,6 +2450,8 @@ TEST_F(ShellTest, DISABLED_DiscardLayerTreeOnResize) {
 
 // TODO(https://github.com/flutter/flutter/issues/100273): Disabled due to
 // flakiness.
+// TODO(https://github.com/flutter/flutter/issues/100299): Fix it when
+// re-enabling.
 TEST_F(ShellTest, DISABLED_DiscardResubmittedLayerTreeOnResize) {
   auto settings = CreateSettingsForFixture();
 


### PR DESCRIPTION
fix https://github.com/flutter/flutter/issues/100207

There is still a situation where `BeginFrame` and `EndFrame` are not paired. For example, when `RasterStatus` is `RasterStatus::kDiscarded`, `BeginFrame` is not called, but `EndFrame` is called.

And when we try to pair `BeginFrame` and `EndFrame`, the tests `ShellTest.DiscardLayerTreeOnResize` and `ShellTest.DiscardResubmittedLayerTreeOnResize` are failed. so we have two options:

1. Disable these tests:
We're actually going to do that https://github.com/flutter/engine/pull/32059 , and the reason for doing it is that these tests introduce this Issue: https://github.com/flutter/flutter/issues/95751

2. Introduce a new mechanism, such as adding a closure called `draw_layer_tree_finished_callback` in `Settings`.
At the end of each `Rasterizer::Draw` and `Rasterizer::DrawLastLayerTree`, no matter whether it is succeeded or failed, this closure is called back, and this mechanism is used to replace the `ExternalViewEmbedder` in these tests.

cc @dnfield @cyanglaz @blasten 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

