### PR TITLE
[Web, Keyboard] Handle unreasonable modifier flags on ShiftLeft+MetaLeft

### DIFF
--- a/lib/web_ui/lib/src/engine/keyboard_binding.dart
+++ b/lib/web_ui/lib/src/engine/keyboard_binding.dart
@@ -475,20 +475,25 @@ class KeyboardConverter {
 
     // After updating _pressingRecords, synchronize modifier states. The
     // `event.***Key` fields can be used to reduce some omitted modifier key
-    // events. We can deduce key cancel events if they are false. Key sync
-    // events can not be deduced since we don't know which physical key they
+    // events. We can synthesize key up events if they are false. Key down
+    // events can not be synthesized since we don't know which physical key they
     // represent.
-    _kLogicalKeyToModifierGetter.forEach((int logicalKey, _ModifierGetter getModifier) {
-      if (_pressingRecords.containsValue(logicalKey) && !getModifier(event)) {
+    _kLogicalKeyToModifierGetter.forEach((int testeeLogicalKey, _ModifierGetter getModifier) {
+      // Do not synthesize for the key of the current event. The event is the
+      // ground truth.
+      if (logicalKey == testeeLogicalKey) {
+        return;
+      }
+      if (_pressingRecords.containsValue(testeeLogicalKey) && !getModifier(event)) {
         _pressingRecords.removeWhere((int physicalKey, int logicalRecord) {
-          if (logicalRecord != logicalKey)
+          if (logicalRecord != testeeLogicalKey)
             return false;
 
           _dispatchKeyData!(ui.KeyData(
             timeStamp: timeStamp,
             type: ui.KeyEventType.up,
             physical: physicalKey,
-            logical: logicalKey,
+            logical: testeeLogicalKey,
             character: null,
             synthesized: true,
           ));


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/99297.

In extremely rare cases, the modifier flags of an event will contradict to the event itself. This occurs on Chrome on Linux while holding ShiftLeft, where the MetaLeft down event has `metaKey` true, while the Meta up event has `metaKey` false.

This PR fixes it by ignoring the key of the current event during synthesization. After all, the current event is a ground truth.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
