### PR TITLE
[web] Remove the --passfail flag when calling goldctl in post-submit

### DIFF
--- a/web_sdk/web_test_utils/lib/skia_client.dart
+++ b/web_sdk/web_test_utils/lib/skia_client.dart
@@ -132,7 +132,6 @@ class SkiaGoldClient {
       '--commit', commitHash,
       '--keys-file', keys.path,
       '--failure-file', failures.path,
-      '--passfail',
     ];
 
     if (imgtestInitCommand.contains(null)) {

--- a/web_sdk/web_test_utils/lib/skia_client.dart
+++ b/web_sdk/web_test_utils/lib/skia_client.dart
@@ -222,6 +222,9 @@ class SkiaGoldClient {
       '--commit', commitHash,
       '--keys-file', keys.path,
       '--failure-file', failures.path,
+      // This is running in pre-submit so it's okay for the `goldctl` commands
+      // to fail when the images don't match. But during post-submit
+      // (in `_imgtestInit`) we shouldn't let the command fail.
       '--passfail',
       '--crs', 'github',
       '--patchset_id', commitHash,


### PR DESCRIPTION
After talking to @kjlubick, he pointed out that the `--passfail` flag causes `goldctl` to perform the image comparison and fail sometimes in post-submit.