### PR TITLE
[web] Log all goldctl commands

### DIFF
--- a/web_sdk/web_test_utils/lib/skia_client.dart
+++ b/web_sdk/web_test_utils/lib/skia_client.dart
@@ -93,7 +93,7 @@ class SkiaGoldClient {
       '--luci',
     ];
 
-    final ProcessResult result = await process.run(authCommand);
+    final ProcessResult result = await _runCommand(authCommand);
 
     if (result.exitCode != 0) {
       final StringBuffer buf = StringBuffer()
@@ -106,6 +106,11 @@ class SkiaGoldClient {
         ..writeln('stderr: ${result.stderr}');
       throw Exception(buf.toString());
     }
+  }
+
+  Future<ProcessResult> _runCommand(List<String> command) {
+    print(command.join(' '));
+    return process.run(command);
   }
 
   /// Executes the `imgtest init` command in the `goldctl` tool.
@@ -144,7 +149,7 @@ class SkiaGoldClient {
       throw Exception(buf.toString());
     }
 
-    final ProcessResult result = await process.run(imgtestInitCommand);
+    final ProcessResult result = await _runCommand(imgtestInitCommand);
 
     if (result.exitCode != 0) {
       final StringBuffer buf = StringBuffer()
@@ -186,7 +191,7 @@ class SkiaGoldClient {
       ..._getMatchingArguments(testName, screenshotSize, isCanvaskitTest),
     ];
 
-    final ProcessResult result = await process.run(imgtestCommand);
+    final ProcessResult result = await _runCommand(imgtestCommand);
 
     if (result.exitCode != 0) {
       // We do not want to throw for non-zero exit codes here, as an intentional
@@ -215,7 +220,7 @@ class SkiaGoldClient {
     await failures.create();
     final String commitHash = await _getCurrentCommit();
 
-    final List<String> imgtestInitCommand = <String>[
+    final List<String> tryjobInitCommand = <String>[
       _goldctl,
       'imgtest', 'init',
       '--instance', _instance,
@@ -229,16 +234,16 @@ class SkiaGoldClient {
       ...getCIArguments(),
     ];
 
-    if (imgtestInitCommand.contains(null)) {
+    if (tryjobInitCommand.contains(null)) {
       final StringBuffer buf = StringBuffer()
         ..writeln('A null argument was provided for Skia Gold tryjob init.')
         ..writeln('Please confirm the settings of your golden file test.')
         ..writeln('Arguments provided:');
-      imgtestInitCommand.forEach(buf.writeln);
+      tryjobInitCommand.forEach(buf.writeln);
       throw Exception(buf.toString());
     }
 
-    final ProcessResult result = await process.run(imgtestInitCommand);
+    final ProcessResult result = await _runCommand(tryjobInitCommand);
 
     if (result.exitCode != 0) {
       final StringBuffer buf = StringBuffer()
@@ -271,7 +276,7 @@ class SkiaGoldClient {
   ) async {
     await _tryjobInit();
 
-    final List<String> imgtestCommand = <String>[
+    final List<String> tryjobCommand = <String>[
       _goldctl,
       'imgtest', 'add',
       '--work-dir', _tempPath,
@@ -280,7 +285,7 @@ class SkiaGoldClient {
       ..._getMatchingArguments(testName, screenshotSize, isCanvaskitTest),
     ];
 
-    final ProcessResult result = await process.run(imgtestCommand);
+    final ProcessResult result = await _runCommand(tryjobCommand);
 
     final String resultStdout = result.stdout.toString();
     if (result.exitCode != 0 &&


### PR DESCRIPTION
Very simple PR to add logging for all `goldctl` commands. This makes investigating future issues easier.

A recent issue that would've benefited from extra logging: https://github.com/flutter/engine/pull/32071