### PR TITLE
Wrap the global timeline event handler callback in a std::atomic

### DIFF
--- a/fml/trace_event.h
+++ b/fml/trace_event.h
@@ -147,13 +147,13 @@ using TraceIDArg = int64_t;
 
 void TraceSetAllowlist(const std::vector<std::string>& allowlist);
 
-using TimelineEventHandler = std::function<void(const char*,
-                                                int64_t,
-                                                int64_t,
-                                                Dart_Timeline_Event_Type,
-                                                intptr_t,
-                                                const char**,
-                                                const char**)>;
+typedef void (*TimelineEventHandler)(const char*,
+                                     int64_t,
+                                     int64_t,
+                                     Dart_Timeline_Event_Type,
+                                     intptr_t,
+                                     const char**,
+                                     const char**);
 
 void TraceSetTimelineEventHandler(TimelineEventHandler handler);
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/100238