### PR TITLE
Linux/GTK: Do not jump cursor to start on preedit change

### DIFF
--- a/shell/platform/linux/fl_text_input_plugin.cc
+++ b/shell/platform/linux/fl_text_input_plugin.cc
@@ -274,10 +274,13 @@ static void im_preedit_changed_cb(FlTextInputPlugin* self) {
   gint cursor_offset = 0;
   gtk_im_context_get_preedit_string(priv->im_context, &buf, nullptr,
                                     &cursor_offset);
-  cursor_offset += priv->text_model->composing_range().base();
+  if (priv->text_model->composing()) {
+    cursor_offset += priv->text_model->composing_range().start();
+  } else {
+    cursor_offset += priv->text_model->selection().start();
+  }
   priv->text_model->UpdateComposingText(buf);
-  priv->text_model->SetSelection(
-      flutter::TextRange(cursor_offset, cursor_offset));
+  priv->text_model->SetSelection(flutter::TextRange(cursor_offset));
 
   if (priv->enable_delta_model) {
     std::string text(buf);


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/97032

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
