### PR TITLE
Revert "[web] Remove the --passfail flag when calling goldctl in post-submit"

### DIFF
--- a/web_sdk/web_test_utils/lib/skia_client.dart
+++ b/web_sdk/web_test_utils/lib/skia_client.dart
@@ -137,6 +137,7 @@ class SkiaGoldClient {
       '--commit', commitHash,
       '--keys-file', keys.path,
       '--failure-file', failures.path,
+      '--passfail',
     ];
 
     if (imgtestInitCommand.contains(null)) {
@@ -227,9 +228,6 @@ class SkiaGoldClient {
       '--commit', commitHash,
       '--keys-file', keys.path,
       '--failure-file', failures.path,
-      // This is running in pre-submit so it's okay for the `goldctl` commands
-      // to fail when the images don't match. But during post-submit
-      // (in `_imgtestInit`) we shouldn't let the command fail.
       '--passfail',
       '--crs', 'github',
       '--patchset_id', commitHash,


### PR DESCRIPTION
Reverts flutter/engine#32071

The issue on Gold's side has been fixed. Let's try to put back the `--passfail` flag now.

cc @kjlubick 