### PR TITLE
override delete operators in DlGradient classes

### DIFF
--- a/display_list/display_list_color_source.cc
+++ b/display_list/display_list_color_source.cc
@@ -98,8 +98,10 @@ std::shared_ptr<DlColorSource> DlColorSource::MakeLinear(
   void* storage = ::operator new(needed);
 
   std::shared_ptr<DlLinearGradientColorSource> ret;
-  ret.reset(new (storage) DlLinearGradientColorSource(
-      start_point, end_point, stop_count, colors, stops, tile_mode, matrix));
+  ret.reset(new (storage)
+                DlLinearGradientColorSource(start_point, end_point, stop_count,
+                                            colors, stops, tile_mode, matrix),
+            [needed](auto p) { ::operator delete(p, needed); });
   return std::move(ret);
 }
 
@@ -118,7 +120,8 @@ std::shared_ptr<DlColorSource> DlColorSource::MakeRadial(
 
   std::shared_ptr<DlRadialGradientColorSource> ret;
   ret.reset(new (storage) DlRadialGradientColorSource(
-      center, radius, stop_count, colors, stops, tile_mode, matrix));
+                center, radius, stop_count, colors, stops, tile_mode, matrix),
+            [needed](auto p) { ::operator delete(p, needed); });
   return std::move(ret);
 }
 
@@ -139,8 +142,9 @@ std::shared_ptr<DlColorSource> DlColorSource::MakeConical(
 
   std::shared_ptr<DlConicalGradientColorSource> ret;
   ret.reset(new (storage) DlConicalGradientColorSource(
-      start_center, start_radius, end_center, end_radius, stop_count, colors,
-      stops, tile_mode, matrix));
+                start_center, start_radius, end_center, end_radius, stop_count,
+                colors, stops, tile_mode, matrix),
+            [needed](auto p) { ::operator delete(p, needed); });
   return std::move(ret);
 }
 
@@ -159,8 +163,10 @@ std::shared_ptr<DlColorSource> DlColorSource::MakeSweep(
   void* storage = ::operator new(needed);
 
   std::shared_ptr<DlSweepGradientColorSource> ret;
-  ret.reset(new (storage) DlSweepGradientColorSource(
-      center, start, end, stop_count, colors, stops, tile_mode, matrix));
+  ret.reset(new (storage)
+                DlSweepGradientColorSource(center, start, end, stop_count,
+                                           colors, stops, tile_mode, matrix),
+            [needed](auto p) { ::operator delete(p, needed); });
   return std::move(ret);
 }
 

--- a/display_list/display_list_color_source.cc
+++ b/display_list/display_list_color_source.cc
@@ -84,6 +84,10 @@ std::shared_ptr<DlColorSource> DlColorSource::From(SkShader* sk_shader) {
   return source;
 }
 
+static void DlGradientDeleter(void* p) {
+  ::operator delete(p, static_cast<DlColorSource*>(p)->size());
+}
+
 std::shared_ptr<DlColorSource> DlColorSource::MakeLinear(
     const SkPoint start_point,
     const SkPoint end_point,
@@ -101,7 +105,7 @@ std::shared_ptr<DlColorSource> DlColorSource::MakeLinear(
   ret.reset(new (storage)
                 DlLinearGradientColorSource(start_point, end_point, stop_count,
                                             colors, stops, tile_mode, matrix),
-            [needed](auto p) { ::operator delete(p, needed); });
+            DlGradientDeleter);
   return std::move(ret);
 }
 
@@ -121,7 +125,7 @@ std::shared_ptr<DlColorSource> DlColorSource::MakeRadial(
   std::shared_ptr<DlRadialGradientColorSource> ret;
   ret.reset(new (storage) DlRadialGradientColorSource(
                 center, radius, stop_count, colors, stops, tile_mode, matrix),
-            [needed](auto p) { ::operator delete(p, needed); });
+            DlGradientDeleter);
   return std::move(ret);
 }
 
@@ -144,7 +148,7 @@ std::shared_ptr<DlColorSource> DlColorSource::MakeConical(
   ret.reset(new (storage) DlConicalGradientColorSource(
                 start_center, start_radius, end_center, end_radius, stop_count,
                 colors, stops, tile_mode, matrix),
-            [needed](auto p) { ::operator delete(p, needed); });
+            DlGradientDeleter);
   return std::move(ret);
 }
 
@@ -166,7 +170,7 @@ std::shared_ptr<DlColorSource> DlColorSource::MakeSweep(
   ret.reset(new (storage)
                 DlSweepGradientColorSource(center, start, end, stop_count,
                                            colors, stops, tile_mode, matrix),
-            [needed](auto p) { ::operator delete(p, needed); });
+            DlGradientDeleter);
   return std::move(ret);
 }
 

--- a/display_list/display_list_color_source.cc
+++ b/display_list/display_list_color_source.cc
@@ -85,7 +85,12 @@ std::shared_ptr<DlColorSource> DlColorSource::From(SkShader* sk_shader) {
 }
 
 static void DlGradientDeleter(void* p) {
-  ::operator delete(p, static_cast<DlColorSource*>(p)->size());
+  // Some of our target environments would prefer a sized delete,
+  // but other target environments do not have that operator.
+  // Use an unsized delete until we get better agreement in the
+  // environments.
+  // See https://github.com/flutter/flutter/issues/100327
+  ::operator delete(p);
 }
 
 std::shared_ptr<DlColorSource> DlColorSource::MakeLinear(

--- a/display_list/display_list_color_source.h
+++ b/display_list/display_list_color_source.h
@@ -282,6 +282,12 @@ class DlGradientColorSourceBase : public DlMatrixColorSourceBase {
     return reinterpret_cast<const float*>(colors() + stop_count());
   }
 
+  void operator delete(void* p) { ::operator delete(p); }
+
+  void operator delete(void* p, size_t s) {
+    ::operator delete(p, static_cast<DlGradientColorSourceBase*>(p)->size());
+  }
+
  protected:
   DlGradientColorSourceBase(uint32_t stop_count,
                             DlTileMode tile_mode,

--- a/display_list/display_list_color_source.h
+++ b/display_list/display_list_color_source.h
@@ -282,12 +282,6 @@ class DlGradientColorSourceBase : public DlMatrixColorSourceBase {
     return reinterpret_cast<const float*>(colors() + stop_count());
   }
 
-  void operator delete(void* p) { ::operator delete(p); }
-
-  void operator delete(void* p, size_t s) {
-    ::operator delete(p, static_cast<DlGradientColorSourceBase*>(p)->size());
-  }
-
  protected:
   DlGradientColorSourceBase(uint32_t stop_count,
                             DlTileMode tile_mode,


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/100305

Override the delete operators in the DlGradient classes since they were allocated manually with the new operator with a custom size.

The non-sized variant `delete(p)` is called during our engine unit tests, but apparently the sized version is called in some downstream tests so both are implemented.