### PR TITLE
run a gclient post-sync hook for the Dart SDK

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -662,6 +662,12 @@ deps = {
 
 hooks = [
   {
+    # Generate the Dart SDK's .dart_tool/package_confg.json file.
+    'name': 'Generate .dart_tool/package_confg.json',
+    'pattern': '.',
+    'action': ['python3', 'src/third_party/dart/tools/generate_package_config.py'],
+  },
+  {
     # Update the Windows toolchain if necessary.
     'name': 'win_toolchain',
     'condition': 'download_windows_deps',


### PR DESCRIPTION
This PR runs a gclient post-sync hook; this hook has been added to the DEPS file for the dart sdk repo (dart-lang/sdk); we need a corresponding hook for the engine repo.

Once the engine is calling this script, we can roll out a change in the dart sdk which will generate the .dart_tools/package_config.json and .packages files automatically as part of a gclient sync. In the future, this will make it easier to auto-roll packages updates into the dart sdk.

*List which issues are fixed by this PR. You must list at least one issue.*

For context, see:

- https://dart-review.googlesource.com/c/sdk/+/234320
- https://dart-review.googlesource.com/c/sdk/+/237441

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [-] I listed at least one issue that this PR fixes in the description above.
- [-] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
