### PR TITLE
Windows scrolling integration

### DIFF
--- a/shell/platform/windows/flutter_window_win32.cc
+++ b/shell/platform/windows/flutter_window_win32.cc
@@ -222,14 +222,9 @@ void FlutterWindowWin32::OnScroll(double delta_x,
   POINT point;
   GetCursorPos(&point);
 
-  // This logic is based off Chromiums implementation
-  // https://source.chromium.org/chromium/chromium/src/+/main:ui/events/blink/web_input_event_builders_win.cc;l=319-331
-  int scrollOffsetMultiplier =
-      static_cast<float>(GetCurrentWheelScrollLines()) * 100.0 / 3.0;
-
   ScreenToClient(GetWindowHandle(), &point);
   binding_handler_delegate_->OnScroll(point.x, point.y, delta_x, delta_y,
-                                      scrollOffsetMultiplier, device_kind,
+                                      GetScrollOffsetMultiplier(), device_kind,
                                       device_id);
 }
 

--- a/shell/platform/windows/flutter_window_win32.cc
+++ b/shell/platform/windows/flutter_window_win32.cc
@@ -16,10 +16,6 @@ namespace {
 // constant for machines running at 100% scaling.
 constexpr int base_dpi = 96;
 
-// TODO: See if this can be queried from the OS; this value is chosen
-// arbitrarily to get something that feels reasonable.
-constexpr int kScrollOffsetMultiplier = 20;
-
 // Maps a Flutter cursor name to an HCURSOR.
 //
 // Returns the arrow cursor for unknown constants.
@@ -226,9 +222,14 @@ void FlutterWindowWin32::OnScroll(double delta_x,
   POINT point;
   GetCursorPos(&point);
 
+  // This logic is based off Chromiums implementation
+  // https://source.chromium.org/chromium/chromium/src/+/main:ui/events/blink/web_input_event_builders_win.cc;l=319-331
+  int scrollOffsetMultiplier =
+      static_cast<float>(GetCurrentWheelScrollLines()) * 100.0 / 3.0;
+
   ScreenToClient(GetWindowHandle(), &point);
   binding_handler_delegate_->OnScroll(point.x, point.y, delta_x, delta_y,
-                                      kScrollOffsetMultiplier, device_kind,
+                                      scrollOffsetMultiplier, device_kind,
                                       device_id);
 }
 

--- a/shell/platform/windows/flutter_window_win32_unittests.cc
+++ b/shell/platform/windows/flutter_window_win32_unittests.cc
@@ -333,13 +333,16 @@ TEST(FlutterWindowWin32Test, OnScrollCallsGetScrollOffsetMultiplier) {
   MockWindowBindingHandlerDelegate delegate;
   win32window.SetView(&delegate);
 
-  ON_CALL(win32window, GetScrollOffsetMultiplier()).WillByDefault(Return(120.0f));
+  ON_CALL(win32window, GetScrollOffsetMultiplier())
+      .WillByDefault(Return(120.0f));
   EXPECT_CALL(win32window, GetScrollOffsetMultiplier()).Times(1);
 
-  EXPECT_CALL(delegate, OnScroll(_, _, 0, 0, 120.0f, 
-              kFlutterPointerDeviceKindMouse, kDefaultPointerDeviceId)).Times(1);
+  EXPECT_CALL(delegate,
+              OnScroll(_, _, 0, 0, 120.0f, kFlutterPointerDeviceKindMouse,
+                       kDefaultPointerDeviceId))
+      .Times(1);
 
-  win32window.OnScroll(0.0f, 0.0f, kFlutterPointerDeviceKindMouse, 
+  win32window.OnScroll(0.0f, 0.0f, kFlutterPointerDeviceKindMouse,
                        kDefaultPointerDeviceId);
 }
 

--- a/shell/platform/windows/flutter_window_win32_unittests.cc
+++ b/shell/platform/windows/flutter_window_win32_unittests.cc
@@ -120,8 +120,7 @@ class MockFlutterWindowWin32 : public FlutterWindowWin32 {
   MOCK_METHOD4(OnPointerLeave,
                void(double, double, FlutterPointerDeviceKind, int32_t));
   MOCK_METHOD0(OnSetCursor, void());
-  MOCK_METHOD4(OnScroll,
-               void(double, double, FlutterPointerDeviceKind, int32_t));
+  MOCK_METHOD0(GetScrollOffsetMultiplier, float());
   MOCK_METHOD0(GetDpiScale, float());
   MOCK_METHOD0(IsVisible, bool());
   MOCK_METHOD1(UpdateCursorRect, void(const Rect&));
@@ -325,6 +324,23 @@ TEST(FlutterWindowWin32Test, OnPointerStarSendsDeviceType) {
                           kDefaultPointerDeviceId, WM_LBUTTONDOWN);
   win32window.OnPointerLeave(10.0, 10.0, kFlutterPointerDeviceKindStylus,
                              kDefaultPointerDeviceId);
+}
+
+// Tests that calls to OnScroll in turn calls GetScrollOffsetMultiplier
+// for mapping scroll ticks to pixels.
+TEST(FlutterWindowWin32Test, OnScrollCallsGetScrollOffsetMultiplier) {
+  MockFlutterWindowWin32 win32window;
+  MockWindowBindingHandlerDelegate delegate;
+  win32window.SetView(&delegate);
+
+  ON_CALL(win32window, GetScrollOffsetMultiplier()).WillByDefault(Return(120.0f));
+  EXPECT_CALL(win32window, GetScrollOffsetMultiplier()).Times(1);
+
+  EXPECT_CALL(delegate, OnScroll(_, _, 0, 0, 120.0f, 
+              kFlutterPointerDeviceKindMouse, kDefaultPointerDeviceId)).Times(1);
+
+  win32window.OnScroll(0.0f, 0.0f, kFlutterPointerDeviceKindMouse, 
+                       kDefaultPointerDeviceId);
 }
 
 }  // namespace testing

--- a/shell/platform/windows/window_win32.cc
+++ b/shell/platform/windows/window_win32.cc
@@ -49,6 +49,8 @@ char32_t CodePointFromSurrogatePair(wchar_t high, wchar_t low) {
 static const int kMinTouchDeviceId = 0;
 static const int kMaxTouchDeviceId = 128;
 
+static const int kLinesPerScrollWindowsDefault = 3;
+
 }  // namespace
 
 WindowWin32::WindowWin32() : WindowWin32(nullptr) {}
@@ -568,8 +570,7 @@ void WindowWin32::UpdateScrollOffsetMultiplier() {
   UINT lines_per_scroll;
   // Get lines per scroll wheel value from Windows
   if (SystemParametersInfo(SPI_GETWHEELSCROLLLINES, 0, &lines_per_scroll, 0) == 0) {
-    // Windows default
-    lines_per_scroll = 3;
+    lines_per_scroll = kLinesPerScrollWindowsDefault;
   }
 
   // This logic is based off Chromium's implementation

--- a/shell/platform/windows/window_win32.cc
+++ b/shell/platform/windows/window_win32.cc
@@ -572,7 +572,7 @@ void WindowWin32::UpdateScrollOffsetMultiplier() {
     lines_per_scroll = 3;
   }
 
-  // This logic is based off Chromiums implementation
+  // This logic is based off Chromium's implementation
   // https://source.chromium.org/chromium/chromium/src/+/main:ui/events/blink/web_input_event_builders_win.cc;l=319-331
   scroll_offset_multiplier_ = static_cast<float>(lines_per_scroll) * 100.0 / 3.0;
 }

--- a/shell/platform/windows/window_win32.cc
+++ b/shell/platform/windows/window_win32.cc
@@ -539,10 +539,6 @@ WindowWin32::HandleMessage(UINT const message,
         return 0;
       }
       break;
-    case WM_SETTINGCHANGE:
-      // Update wheel scroll lines on settings change
-      UpdateScrollOffsetMultiplier();
-      break;
   }
 
   return Win32DefWindowProc(window_handle_, message, wparam, result_lparam);

--- a/shell/platform/windows/window_win32.cc
+++ b/shell/platform/windows/window_win32.cc
@@ -61,6 +61,11 @@ WindowWin32::WindowWin32(
   // supported, |current_dpi_| should be updated in the
   // kWmDpiChangedBeforeParent message.
   current_dpi_ = GetDpiForHWND(nullptr);
+
+  // Get initial value for wheel scroll lines
+  SystemParametersInfo(SPI_GETWHEELSCROLLLINES, 0, &current_wheel_scroll_lines_,
+                       0);
+
   if (text_input_manager_ == nullptr) {
     text_input_manager_ = std::make_unique<TextInputManagerWin32>();
   }
@@ -535,6 +540,11 @@ WindowWin32::HandleMessage(UINT const message,
         return 0;
       }
       break;
+    case WM_SETTINGCHANGE:
+      // Update wheel scroll lines on settings change
+      SystemParametersInfo(SPI_GETWHEELSCROLLLINES, 0,
+                           &current_wheel_scroll_lines_, 0);
+      break;
   }
 
   return Win32DefWindowProc(window_handle_, message, wparam, result_lparam);
@@ -554,6 +564,10 @@ UINT WindowWin32::GetCurrentHeight() {
 
 HWND WindowWin32::GetWindowHandle() {
   return window_handle_;
+}
+
+UINT WindowWin32::GetCurrentWheelScrollLines() {
+  return current_wheel_scroll_lines_;
 }
 
 void WindowWin32::Destroy() {

--- a/shell/platform/windows/window_win32.cc
+++ b/shell/platform/windows/window_win32.cc
@@ -562,7 +562,7 @@ HWND WindowWin32::GetWindowHandle() {
 
 float WindowWin32::GetScrollOffsetMultiplier() { 
   return scroll_offset_multiplier_; 
- }
+}
 
 void WindowWin32::UpdateScrollOffsetMultiplier() {
   UINT lines_per_scroll;

--- a/shell/platform/windows/window_win32.cc
+++ b/shell/platform/windows/window_win32.cc
@@ -562,20 +562,22 @@ HWND WindowWin32::GetWindowHandle() {
   return window_handle_;
 }
 
-float WindowWin32::GetScrollOffsetMultiplier() { 
-  return scroll_offset_multiplier_; 
+float WindowWin32::GetScrollOffsetMultiplier() {
+  return scroll_offset_multiplier_;
 }
 
 void WindowWin32::UpdateScrollOffsetMultiplier() {
   UINT lines_per_scroll;
   // Get lines per scroll wheel value from Windows
-  if (SystemParametersInfo(SPI_GETWHEELSCROLLLINES, 0, &lines_per_scroll, 0) == 0) {
+  if (SystemParametersInfo(SPI_GETWHEELSCROLLLINES, 0, &lines_per_scroll, 0) ==
+      0) {
     lines_per_scroll = kLinesPerScrollWindowsDefault;
   }
 
   // This logic is based off Chromium's implementation
   // https://source.chromium.org/chromium/chromium/src/+/main:ui/events/blink/web_input_event_builders_win.cc;l=319-331
-  scroll_offset_multiplier_ = static_cast<float>(lines_per_scroll) * 100.0 / 3.0;
+  scroll_offset_multiplier_ =
+      static_cast<float>(lines_per_scroll) * 100.0 / 3.0;
 }
 
 void WindowWin32::Destroy() {

--- a/shell/platform/windows/window_win32.cc
+++ b/shell/platform/windows/window_win32.cc
@@ -65,6 +65,8 @@ WindowWin32::WindowWin32(
   current_dpi_ = GetDpiForHWND(nullptr);
 
   // Get initial value for wheel scroll lines
+  // TODO: Listen to changes for this value
+  // https://github.com/flutter/flutter/issues/107248
   UpdateScrollOffsetMultiplier();
 
   if (text_input_manager_ == nullptr) {
@@ -567,12 +569,10 @@ float WindowWin32::GetScrollOffsetMultiplier() {
 }
 
 void WindowWin32::UpdateScrollOffsetMultiplier() {
-  UINT lines_per_scroll;
+  UINT lines_per_scroll = kLinesPerScrollWindowsDefault;
+
   // Get lines per scroll wheel value from Windows
-  if (SystemParametersInfo(SPI_GETWHEELSCROLLLINES, 0, &lines_per_scroll, 0) ==
-      0) {
-    lines_per_scroll = kLinesPerScrollWindowsDefault;
-  }
+  SystemParametersInfo(SPI_GETWHEELSCROLLLINES, 0, &lines_per_scroll, 0);
 
   // This logic is based off Chromium's implementation
   // https://source.chromium.org/chromium/chromium/src/+/main:ui/events/blink/web_input_event_builders_win.cc;l=319-331

--- a/shell/platform/windows/window_win32.h
+++ b/shell/platform/windows/window_win32.h
@@ -199,6 +199,8 @@ class WindowWin32 : public KeyboardManagerWin32::WindowDelegate {
 
   UINT GetCurrentHeight();
 
+  UINT GetCurrentWheelScrollLines();
+
  protected:
   // Win32's DefWindowProc.
   //
@@ -232,6 +234,7 @@ class WindowWin32 : public KeyboardManagerWin32::WindowDelegate {
   int current_dpi_ = 0;
   int current_width_ = 0;
   int current_height_ = 0;
+  UINT current_wheel_scroll_lines_ = 3;
 
   // WM_DPICHANGED_BEFOREPARENT defined in more recent Windows
   // SDK

--- a/shell/platform/windows/window_win32.h
+++ b/shell/platform/windows/window_win32.h
@@ -199,7 +199,7 @@ class WindowWin32 : public KeyboardManagerWin32::WindowDelegate {
 
   UINT GetCurrentHeight();
 
-  float GetScrollOffsetMultiplier();
+  virtual float GetScrollOffsetMultiplier();
 
  protected:
   // Win32's DefWindowProc.

--- a/shell/platform/windows/window_win32.h
+++ b/shell/platform/windows/window_win32.h
@@ -201,7 +201,6 @@ class WindowWin32 : public KeyboardManagerWin32::WindowDelegate {
 
   float GetScrollOffsetMultiplier();
 
-
  protected:
   // Win32's DefWindowProc.
   //

--- a/shell/platform/windows/window_win32.h
+++ b/shell/platform/windows/window_win32.h
@@ -199,6 +199,7 @@ class WindowWin32 : public KeyboardManagerWin32::WindowDelegate {
 
   UINT GetCurrentHeight();
 
+  // Returns the current pixel per scroll tick value.
   virtual float GetScrollOffsetMultiplier();
 
  protected:

--- a/shell/platform/windows/window_win32.h
+++ b/shell/platform/windows/window_win32.h
@@ -199,7 +199,8 @@ class WindowWin32 : public KeyboardManagerWin32::WindowDelegate {
 
   UINT GetCurrentHeight();
 
-  UINT GetCurrentWheelScrollLines();
+  float GetScrollOffsetMultiplier();
+
 
  protected:
   // Win32's DefWindowProc.
@@ -231,10 +232,15 @@ class WindowWin32 : public KeyboardManagerWin32::WindowDelegate {
   // Retrieves a class instance pointer for |window|
   static WindowWin32* GetThisFromHandle(HWND const window) noexcept;
 
+  // Updates the cached scroll_offset_multiplier_ value based off OS settings.
+  void UpdateScrollOffsetMultiplier();
+
   int current_dpi_ = 0;
   int current_width_ = 0;
   int current_height_ = 0;
-  UINT current_wheel_scroll_lines_ = 3;
+
+  // Holds the conversion factor from lines scrolled to pixels scrolled.
+  float scroll_offset_multiplier_;
 
   // WM_DPICHANGED_BEFOREPARENT defined in more recent Windows
   // SDK


### PR DESCRIPTION
Updates scrolling in Windows to respect the 'lines to scroll per scroll wheel tick' windows setting.

The scrolling amount per tick is also increased to match chrome (at 100px with default windows settings). This is also similar to what UWP does natively (approximately 96px based on observation).

Resolves https://github.com/flutter/flutter/issues/97924

~~In this PR, the windows 'lines per tick' value is only checked at startup. It should be possible to be notified when this changes by listening for the WM_SETTINGCHANGE event, but I couldn't get this to work. I suspect there is something I have missed in how events are delivered to the embedding. My attempt at this can be seen in https://github.com/Jon-Salmon/engine/commit/c0373103225320fd094b82551ef766c4b36b79a1~~

In this PR, the windows 'lines per tick' value is only checked at startup. It is possible to listen for the WM_SETTINGCHANGE event which is passed through to the runner. I'm not sure what the best way would be to add this, it looks like WM_FONTCHANGE is picked up in the runner's code and then passed to the engine. The same could be done for WM_SETTINGSCHANGE, but this would require developers to refresh their runner code.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
