### PR TITLE
Fix iOS keyboard physical keyboard doesn't work in add to app

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -654,13 +654,13 @@ static void SendFakeTouchEvent(FlutterEngine* engine,
   TRACE_EVENT0("flutter", "viewDidLoad");
 
   if (_engine && _engineNeedsLaunch) {
-    // Register internal plugins before starting the engine.
-    [self addInternalPlugins];
-
     [_engine.get() launchEngine:nil libraryURI:nil entrypointArgs:nil];
     [_engine.get() setViewController:self];
     _engineNeedsLaunch = NO;
   }
+
+  // Register internal plugins.
+  [self addInternalPlugins];
 
   if ([_engine.get() viewController] == self) {
     [_engine.get() attachView];

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -420,7 +420,7 @@ typedef enum UIAccessibilityContrast : NSInteger {
   }
 }
 
--(void)testInternalPluginsInvokeInViewDidLoad {
+- (void)testInternalPluginsInvokeInViewDidLoad {
   FlutterEngine* mockEngine = OCMPartialMock([[FlutterEngine alloc] init]);
   [mockEngine createShell:@"" libraryURI:@"" initialRoute:nil];
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:mockEngine

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -420,6 +420,7 @@ typedef enum UIAccessibilityContrast : NSInteger {
   }
 }
 
+// Regression test for https://github.com/flutter/engine/pull/32098.
 - (void)testInternalPluginsInvokeInViewDidLoad {
   FlutterEngine* mockEngine = OCMPartialMock([[FlutterEngine alloc] init]);
   [mockEngine createShell:@"" libraryURI:@"" initialRoute:nil];

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -420,6 +420,16 @@ typedef enum UIAccessibilityContrast : NSInteger {
   }
 }
 
+-(void)testInternalPluginsInvokeInViewDidLoad {
+  FlutterEngine* mockEngine = OCMPartialMock([[FlutterEngine alloc] init]);
+  [mockEngine createShell:@"" libraryURI:@"" initialRoute:nil];
+  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:mockEngine
+                                                                                nibName:nil
+                                                                                 bundle:nil];
+  [viewController viewDidLoad];
+  OCMVerify([viewController addInternalPlugins]);
+}
+
 - (void)testBinaryMessenger {
   FlutterViewController* vc = [[FlutterViewController alloc] initWithEngine:self.mockEngine
                                                                     nibName:nil


### PR DESCRIPTION
This PR is to fix physical keyboard unfunctional in add to app scenario.

In app to app scenario.

1. FlutterEngine instance initial first.
2. Using FlutterEngine instance as parameter to initial FlutterViewController with method `-[ FlutterViewController initWithEngine:nibName:bundle:]`.
3. Private property `_engineNeedsLaunch ` will be set to NO.
4. `[self addInternalPlugins]` will never be called in `viewDidLoad` which result in iOS keyboard-related feature unfunctional. [-[FluterViewController viewDidLoad]](https://github.com/flutter/engine/blob/6495796bce76276c19d252a855a316fafeec8dd9/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm#L653)

```objective-c
- (void)viewDidLoad {
  TRACE_EVENT0("flutter", "viewDidLoad");

  if (_engine && _engineNeedsLaunch) {
    // Register internal plugins before starting the engine.
    [self addInternalPlugins];

    [_engine.get() launchEngine:nil libraryURI:nil entrypointArgs:nil];
    [_engine.get() setViewController:self];
    _engineNeedsLaunch = NO;
  }
  ...
}
```

The solution is simple, move `[self addInternalPlugins]`  out of the if condition. and `[self addInternalPlugins]`  will call in any situation.


Related issues:
https://github.com/flutter/flutter/issues/92997
https://github.com/flutter/flutter/issues/96638

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
