### PR TITLE
[macOS TextInputPlugin] Reactivate input context on key event

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -470,6 +470,12 @@ static flutter::TextRange RangeFromBaseExtent(NSNumber* base,
   if (!_shown) {
     return NO;
   }
+  // NSTextInputContext sometimes randomly deactivates itself without calling
+  // deactivate. One such example is when the composing region is deleted.
+  // TODO(LongCatIsLooong): put FlutterTextInputPlugin in the view hierarchy and
+  // request/resign first responder when needed. Activate/deactivate shouldn't
+  // be called by the application.
+  [_textInputContext activate];
   return [_textInputContext handleEvent:event];
 }
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -471,7 +471,7 @@ static flutter::TextRange RangeFromBaseExtent(NSNumber* base,
     return NO;
   }
 
-  // NSTextInputContext sometimes randomly deactivates itself without calling
+  // NSTextInputContext sometimes deactivates itself without calling
   // deactivate. One such example is when the composing region is deleted.
   // TODO(LongCatIsLooong): put FlutterTextInputPlugin in the view hierarchy and
   // request/resign first responder when needed. Activate/deactivate shouldn't

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -470,6 +470,7 @@ static flutter::TextRange RangeFromBaseExtent(NSNumber* base,
   if (!_shown) {
     return NO;
   }
+
   // NSTextInputContext sometimes randomly deactivates itself without calling
   // deactivate. One such example is when the composing region is deleted.
   // TODO(LongCatIsLooong): put FlutterTextInputPlugin in the view hierarchy and
@@ -540,6 +541,10 @@ static flutter::TextRange RangeFromBaseExtent(NSNumber* base,
 
 - (void)scrollWheel:(NSEvent*)event {
   [self.flutterViewController scrollWheel:event];
+}
+
+- (NSTextInputContext*)inputContext {
+  return _textInputContext;
 }
 
 #pragma mark -


### PR DESCRIPTION
Quick and dirty workaround for https://github.com/flutter/flutter/issues/100272. See also https://github.com/flutter/flutter/issues/100272#issuecomment-1071973612.

Ideally text input plugin should be put in the view hierarchy but that would be a larger and riskier patch to land, and to test in a short time frame. (I did the same on iOS not long ago and that introduced several new issues).

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
