### PR TITLE
Force GTK IM context to initialize at start

### DIFF
--- a/shell/platform/linux/fl_text_input_plugin.cc
+++ b/shell/platform/linux/fl_text_input_plugin.cc
@@ -708,6 +708,10 @@ static void fl_text_input_plugin_init(FlTextInputPlugin* self) {
 
   priv->client_id = kClientIdUnset;
   priv->im_context = gtk_im_multicontext_new();
+  // On Wayland, this call sets up the input method so it can be enabled
+  // immediately when required. Without it, on-screen keyboard's don't come up
+  // the first time a text field is focused.
+  gtk_im_context_focus_out(priv->im_context);
   priv->input_type = FL_TEXT_INPUT_TYPE_TEXT;
   g_signal_connect_object(priv->im_context, "preedit-start",
                           G_CALLBACK(im_preedit_start_cb), self,

--- a/shell/platform/linux/testing/fl_test.cc
+++ b/shell/platform/linux/testing/fl_test.cc
@@ -9,6 +9,18 @@
 #include "flutter/shell/platform/linux/fl_engine_private.h"
 #include "flutter/shell/platform/linux/testing/mock_renderer.h"
 
+namespace {
+class ImModuleEnv : public ::testing::Environment {
+ public:
+  void SetUp() override {
+    setenv("GTK_IM_MODULE", "gtk-im-context-simple", true);
+  }
+};
+
+testing::Environment* const env =
+    testing::AddGlobalTestEnvironment(new ImModuleEnv);
+}  // namespace
+
 static uint8_t hex_digit_to_int(char value) {
   if (value >= '0' && value <= '9') {
     return value - '0';


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/100385

A bit hacky. There might be a better way.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
