### PR TITLE
[macOS, Keyboard] Enqueue event processing

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterKeyboardManager.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterKeyboardManager.h
@@ -4,16 +4,7 @@
 
 #import <Cocoa/Cocoa.h>
 
-#import "flutter/shell/platform/darwin/macos/framework/Headers/FlutterEngine.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterKeyboardViewDelegate.h"
-
-namespace {
-// Someohow this pointer type must be defined as a single type for the compiler
-// to compile the function pointer type (due to _Nullable).
-typedef NSResponder* _NSResponderPtr;
-}
-
-typedef _Nullable _NSResponderPtr (^NextResponderProvider)();
 
 /**
  * Processes keyboard events and cooperate with |TextInputPlugin|.

--- a/shell/platform/darwin/macos/framework/Source/FlutterKeyboardManager.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterKeyboardManager.mm
@@ -40,11 +40,29 @@ typedef _Nullable _NSResponderPtr (^NextResponderProvider)();
  */
 - (void)addPrimaryResponder:(nonnull id<FlutterKeyPrimaryResponder>)responder;
 
+/**
+ * Start processing the next event if not started already.
+ *
+ * This function might initiate an async process, whose callback calls this
+ * function again.
+ */
 - (void)processNextEvent;
 
-- (void)processEvent:(NSEvent*)event onFinish:(VoidBlock)onFinish;
+/**
+ * Implement how to process an event.
+ *
+ * The `onFinish` must be called eventually, either during this function or
+ * asynchronously later, otherwise the event queue will be stuck.
+ *
+ * This function is called by processNextEvent.
+ */
+- (void)performProcessEvent:(NSEvent*)event onFinish:(nonnull VoidBlock)onFinish;
 
-- (void)dispatchTextEvent:(NSEvent*)pendingEvent;
+/**
+ * Dispatch an event that's not hadled by the responders to text input plugin,
+ * and potentially to the next responder.
+ */
+- (void)dispatchTextEvent:(nonnull NSEvent*)pendingEvent;
 
 @end
 
@@ -114,10 +132,10 @@ typedef _Nullable _NSResponderPtr (^NextResponderProvider)();
     weakSelf.processingEvent = FALSE;
     [weakSelf processNextEvent];
   };
-  [self processEvent:pendingEvent onFinish:onFinish];
+  [self performProcessEvent:pendingEvent onFinish:onFinish];
 }
 
-- (void)processEvent:(NSEvent*)event onFinish:(VoidBlock)onFinish {
+- (void)performProcessEvent:(NSEvent*)event onFinish:(VoidBlock)onFinish {
   if (_viewDelegate.isComposing) {
     [self dispatchTextEvent:event];
     onFinish();

--- a/shell/platform/darwin/macos/framework/Source/FlutterKeyboardManager.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterKeyboardManager.mm
@@ -103,6 +103,9 @@ typedef _Nullable _NSResponderPtr (^NextResponderProvider)();
 }
 
 - (void)handleEvent:(nonnull NSEvent*)event {
+  // The `handleEvent` does not process the event immediately, but instead put
+  // events into a queue. Events are processed one by one by `processNextEvent`.
+
   // Be sure to add a handling method in propagateKeyEvent when allowing more
   // event types here.
   if (event.type != NSEventTypeKeyDown && event.type != NSEventTypeKeyUp &&

--- a/shell/platform/darwin/macos/framework/Source/FlutterKeyboardManagerUnittests.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterKeyboardManagerUnittests.mm
@@ -14,18 +14,32 @@
 namespace {
 
 typedef BOOL (^BoolGetter)();
-typedef void (^AsyncKeyCallback)(BOOL handled);
-typedef void (^AsyncKeyCallbackHandler)(AsyncKeyCallback callback);
+typedef void (^AsyncKeyCallbackHandler)(FlutterAsyncKeyCallback callback);
+typedef BOOL (^TextInputCallback)(NSEvent*);
 
-NSEvent* keyDownEvent(unsigned short keyCode) {
+// When the Vietnamese IME converts messages into "pure text" messages, their
+// key codes are set to "empty".
+//
+// The 0 also happens to be the key code for key A.
+constexpr uint16_t kKeyCodeEmpty = 0x00;
+
+constexpr uint16_t kKeyCodeKeyO = 0x1f;
+constexpr uint16_t kKeyCodeBackspace = 0x33;
+
+// Constants used for `recordCallTypesTo:forTypes:`.
+constexpr uint32_t kEmbedderCall = 0x1;
+constexpr uint32_t kChannelCall = 0x2;
+constexpr uint32_t kTextCall = 0x4;
+
+NSEvent* keyDownEvent(unsigned short keyCode, NSString* chars = @"", NSString* charsUnmod = @"") {
   return [NSEvent keyEventWithType:NSEventTypeKeyDown
                           location:NSZeroPoint
                      modifierFlags:0x100
                          timestamp:0
                       windowNumber:0
                            context:nil
-                        characters:@""
-       charactersIgnoringModifiers:@""
+                        characters:chars
+       charactersIgnoringModifiers:charsUnmod
                          isARepeat:NO
                            keyCode:keyCode];
 }
@@ -68,10 +82,35 @@ NSResponder* mockOwnerWithDownOnlyNext() {
 
 @interface KeyboardTester : NSObject
 - (nonnull instancetype)init;
+
+// Set embedder calls to respond immediately with the given response.
 - (void)respondEmbedderCallsWith:(BOOL)response;
+
+// Record embedder calls to the given storage.
+//
+// They are not responded until the stored callbacks are manually called.
 - (void)recordEmbedderCallsTo:(nonnull NSMutableArray<FlutterAsyncKeyCallback>*)storage;
+
+// Set channel calls to respond immediately with the given response.
 - (void)respondChannelCallsWith:(BOOL)response;
+
+// Record channel calls to the given storage.
+//
+// They are not responded until the stored callbacks are manually called.
 - (void)recordChannelCallsTo:(nonnull NSMutableArray<FlutterAsyncKeyCallback>*)storage;
+
+// Set text calls to respond with the given response.
+- (void)respondTextInputWith:(BOOL)response;
+
+// At the start of any kind of call, record the call type to the given storage.
+//
+// Only calls that are included in `typeMask` will be added. Options are
+// kEmbedderCall, kChannelCall, and kTextCall.
+//
+// This method does not conflict with other call settings, and the recording
+// takes place before the callbacks are (or are not) invoked.
+- (void)recordCallTypesTo:(nonnull NSMutableArray<NSNumber*>*)typeStorage
+                 forTypes:(uint32_t)typeMask;
 
 @property(nonatomic) FlutterKeyboardManager* manager;
 @property(nonatomic) NSResponder* nextResponder;
@@ -93,7 +132,10 @@ NSResponder* mockOwnerWithDownOnlyNext() {
 @implementation KeyboardTester {
   AsyncKeyCallbackHandler _embedderHandler;
   AsyncKeyCallbackHandler _channelHandler;
-  BOOL _textInputResponse;
+  TextInputCallback _textCallback;
+
+  NSMutableArray<NSNumber*>* _typeStorage;
+  uint32_t _typeStorageMask;
 }
 
 - (nonnull instancetype)init {
@@ -129,31 +171,39 @@ NSResponder* mockOwnerWithDownOnlyNext() {
 }
 
 - (void)respondEmbedderCallsWith:(BOOL)response {
-  _embedderHandler = ^(AsyncKeyCallback callback) {
+  _embedderHandler = ^(FlutterAsyncKeyCallback callback) {
     callback(response);
   };
 }
 
 - (void)recordEmbedderCallsTo:(nonnull NSMutableArray<FlutterAsyncKeyCallback>*)storage {
-  _embedderHandler = ^(AsyncKeyCallback callback) {
+  _embedderHandler = ^(FlutterAsyncKeyCallback callback) {
     [storage addObject:callback];
   };
 }
 
 - (void)respondChannelCallsWith:(BOOL)response {
-  _channelHandler = ^(AsyncKeyCallback callback) {
+  _channelHandler = ^(FlutterAsyncKeyCallback callback) {
     callback(response);
   };
 }
 
 - (void)recordChannelCallsTo:(nonnull NSMutableArray<FlutterAsyncKeyCallback>*)storage {
-  _channelHandler = ^(AsyncKeyCallback callback) {
+  _channelHandler = ^(FlutterAsyncKeyCallback callback) {
     [storage addObject:callback];
   };
 }
 
 - (void)respondTextInputWith:(BOOL)response {
-  _textInputResponse = response;
+  _textCallback = ^(NSEvent* event) {
+    return response;
+  };
+}
+
+- (void)recordCallTypesTo:(nonnull NSMutableArray<NSNumber*>*)typeStorage
+                 forTypes:(uint32_t)typeMask {
+  _typeStorage = typeStorage;
+  _typeStorageMask = typeMask;
 }
 
 #pragma mark - Private
@@ -161,6 +211,9 @@ NSResponder* mockOwnerWithDownOnlyNext() {
 - (void)handleEmbedderEvent:(const FlutterKeyEvent&)event
                    callback:(nullable FlutterKeyEventCallback)callback
                    userData:(nullable void*)userData {
+  if (_typeStorage != nil && (_typeStorageMask & kEmbedderCall) != 0) {
+    [_typeStorage addObject:@(kEmbedderCall)];
+  }
   if (callback != nullptr) {
     _embedderHandler(^(BOOL handled) {
       callback(handled, userData);
@@ -171,6 +224,9 @@ NSResponder* mockOwnerWithDownOnlyNext() {
 - (void)handleChannelMessage:(NSString*)channel
                      message:(NSData* _Nullable)message
                  binaryReply:(FlutterBinaryReply _Nullable)callback {
+  if (_typeStorage != nil && (_typeStorageMask & kChannelCall) != 0) {
+    [_typeStorage addObject:@(kChannelCall)];
+  }
   _channelHandler(^(BOOL handled) {
     NSDictionary* result = @{
       @"handled" : @(handled),
@@ -181,7 +237,10 @@ NSResponder* mockOwnerWithDownOnlyNext() {
 }
 
 - (BOOL)handleTextInputKeyEvent:(NSEvent*)event {
-  return _textInputResponse;
+  if (_typeStorage != nil && (_typeStorageMask & kTextCall) != 0) {
+    [_typeStorage addObject:@(kTextCall)];
+  }
+  return _textCallback(event);
 }
 
 @end
@@ -193,6 +252,7 @@ NSResponder* mockOwnerWithDownOnlyNext() {
 - (bool)textInputPlugin;
 - (bool)forwardKeyEventsToSystemWhenComposing;
 - (bool)emptyNextResponder;
+- (bool)racingConditionBetweenKeyAndText;
 @end
 
 namespace flutter::testing {
@@ -218,6 +278,10 @@ TEST(FlutterKeyboardManagerUnittests, handlingComposingText) {
 
 TEST(FlutterKeyboardManagerUnittests, EmptyNextResponder) {
   ASSERT_TRUE([[FlutterKeyboardManagerUnittestsObjC alloc] emptyNextResponder]);
+}
+
+TEST(FlutterKeyboardManagerUnittests, RacingConditionBetweenKeyAndText) {
+  ASSERT_TRUE([[FlutterKeyboardManagerUnittestsObjC alloc] racingConditionBetweenKeyAndText]);
 }
 
 }  // namespace flutter::testing
@@ -399,6 +463,82 @@ TEST(FlutterKeyboardManagerUnittests, EmptyNextResponder) {
   [tester.manager handleEvent:keyDownEvent(0x50)];
 
   // Passes if no error is thrown.
+  return true;
+}
+
+// Regression test for https://github.com/flutter/flutter/issues/82673.
+- (bool)racingConditionBetweenKeyAndText {
+  KeyboardTester* tester = [[KeyboardTester alloc] init];
+
+  // Use Vietnamese IME (GoTiengViet, Telex mode) to type "uco".
+
+  // The events received by the framework. The engine might receive
+  // a channel message "setEditingState" from the framework.
+  NSMutableArray<FlutterAsyncKeyCallback>* keyCallbacks =
+      [NSMutableArray<FlutterAsyncKeyCallback> array];
+  [tester recordEmbedderCallsTo:keyCallbacks];
+
+  NSMutableArray<NSNumber*>* allCalls = [NSMutableArray<NSNumber*> array];
+  [tester recordCallTypesTo:allCalls forTypes:(kEmbedderCall | kTextCall)];
+
+  // Tap key U, which is converted by IME into a pure text message "ư".
+
+  [tester.manager handleEvent:keyDownEvent(kKeyCodeEmpty, @"ư", @"ư")];
+  EXPECT_EQ([keyCallbacks count], 1u);
+  EXPECT_EQ([allCalls count], 1u);
+  EXPECT_EQ(allCalls[0], @(kEmbedderCall));
+  keyCallbacks[0](false);
+  EXPECT_EQ([keyCallbacks count], 1u);
+  EXPECT_EQ([allCalls count], 2u);
+  EXPECT_EQ(allCalls[1], @(kTextCall));
+  [keyCallbacks removeAllObjects];
+  [allCalls removeAllObjects];
+
+  [tester.manager handleEvent:keyUpEvent(kKeyCodeEmpty)];
+  EXPECT_EQ([keyCallbacks count], 1u);
+  keyCallbacks[0](false);
+  EXPECT_EQ([keyCallbacks count], 1u);
+  EXPECT_EQ([allCalls count], 2u);
+  [keyCallbacks removeAllObjects];
+  [allCalls removeAllObjects];
+
+  // Tap key O, which is converted to normal KeyO events, but the responses are
+  // slow.
+
+  [tester.manager handleEvent:keyDownEvent(kKeyCodeKeyO, @"o", @"o")];
+  [tester.manager handleEvent:keyUpEvent(kKeyCodeKeyO)];
+  EXPECT_EQ([keyCallbacks count], 1u);
+  EXPECT_EQ([allCalls count], 1u);
+  EXPECT_EQ(allCalls[0], @(kEmbedderCall));
+
+  // Tap key C, which results in two Backspace messages first - and here they
+  // arrive before the key O messages are responded.
+
+  [tester.manager handleEvent:keyDownEvent(kKeyCodeBackspace)];
+  [tester.manager handleEvent:keyUpEvent(kKeyCodeBackspace)];
+  EXPECT_EQ([keyCallbacks count], 1u);
+  EXPECT_EQ([allCalls count], 1u);
+
+  // The key O down is responded, which releases a text call (for KeyO down) and
+  // an embedder call (for KeyO up) immediately.
+  keyCallbacks[0](false);
+  EXPECT_EQ([keyCallbacks count], 2u);
+  EXPECT_EQ([allCalls count], 3u);
+  EXPECT_EQ(allCalls[1], @(kTextCall));  // The order is important!
+  EXPECT_EQ(allCalls[2], @(kEmbedderCall));
+
+  // The key O up is responded, which releases a text call (for KeyO up) and
+  // an embedder call (for Backspace down) immediately.
+  keyCallbacks[1](false);
+  EXPECT_EQ([keyCallbacks count], 3u);
+  EXPECT_EQ([allCalls count], 5u);
+  EXPECT_EQ(allCalls[3], @(kTextCall));  // The order is important!
+  EXPECT_EQ(allCalls[4], @(kEmbedderCall));
+
+  // Finish up callbacks.
+  keyCallbacks[2](false);
+  keyCallbacks[3](false);
+
   return true;
 }
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterKeyboardManagerUnittests.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterKeyboardManagerUnittests.mm
@@ -88,7 +88,7 @@ NSResponder* mockOwnerWithDownOnlyNext() {
 
 // Record embedder calls to the given storage.
 //
-// They are not responded until the stored callbacks are manually called.
+// They are not responded to until the stored callbacks are manually called.
 - (void)recordEmbedderCallsTo:(nonnull NSMutableArray<FlutterAsyncKeyCallback>*)storage;
 
 // Set channel calls to respond immediately with the given response.
@@ -96,7 +96,7 @@ NSResponder* mockOwnerWithDownOnlyNext() {
 
 // Record channel calls to the given storage.
 //
-// They are not responded until the stored callbacks are manually called.
+// They are not responded to until the stored callbacks are manually called.
 - (void)recordChannelCallsTo:(nonnull NSMutableArray<FlutterAsyncKeyCallback>*)storage;
 
 // Set text calls to respond with the given response.

--- a/shell/platform/darwin/macos/framework/Source/FlutterKeyboardViewDelegate.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterKeyboardViewDelegate.h
@@ -4,6 +4,7 @@
 
 #import <Cocoa/Cocoa.h>
 
+#import "flutter/shell/platform/darwin/common/framework/Headers/FlutterBinaryMessenger.h"
 #import "flutter/shell/platform/embedder/embedder.h"
 
 /**


### PR DESCRIPTION
This PR puts the procedure of handling a key event into a queue, so that before the last event is done processing (possibly  handled by `TextInputPlugin` and sent to the next responder), the next event will not be started at all. 

This PR fixes the macOS part of https://github.com/flutter/flutter/issues/82673, which is caused by the racing condition between the two steps of key handling: key events, and text events. The complete analysis is posted at https://github.com/flutter/flutter/issues/82673#issuecomment-1072799572.

However, by reducing (the problematic) parallelization, this fix unsurprisingly comes at a cost of slowing down the overall key event processing. This should not be a problem in other languages, but in Vienamese Telex IME, where one key press can result in as many as 5 messages, the result is noticeable, as shown below.

https://user-images.githubusercontent.com/1596656/159079895-2f5cd76d-0c90-47d4-b130-aa2195333f80.mov

Mitigating this problem might need bigger changes in the future. For now, let's land this PR to correct the behavior first.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
