### PR TITLE
Make Get GetVsyncWaiter return weak_ptr to prevent dangling pointer crash

### DIFF
--- a/shell/common/animator.cc
+++ b/shell/common/animator.cc
@@ -196,8 +196,9 @@ void Animator::Render(std::unique_ptr<flutter::LayerTree> layer_tree) {
                            std::move(frame_timings_recorder_));
 }
 
-const VsyncWaiter& Animator::GetVsyncWaiter() const {
-  return *waiter_.get();
+const std::weak_ptr<VsyncWaiter> Animator::GetVsyncWaiter() const {
+  std::weak_ptr<VsyncWaiter> weak = waiter_;
+  return weak;
 }
 
 bool Animator::CanReuseLastLayerTree() {

--- a/shell/common/animator.h
+++ b/shell/common/animator.h
@@ -54,7 +54,7 @@ class Animator final {
 
   void Render(std::unique_ptr<flutter::LayerTree> layer_tree);
 
-  const VsyncWaiter& GetVsyncWaiter() const;
+  const std::weak_ptr<VsyncWaiter> GetVsyncWaiter() const;
 
   //--------------------------------------------------------------------------
   /// @brief    Schedule a secondary callback to be executed right after the

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -557,7 +557,7 @@ void Engine::LoadDartDeferredLibraryError(intptr_t loading_unit_id,
   }
 }
 
-const VsyncWaiter& Engine::GetVsyncWaiter() const {
+const std::weak_ptr<VsyncWaiter> Engine::GetVsyncWaiter() const {
   return animator_->GetVsyncWaiter();
 }
 

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -870,7 +870,7 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
     return runtime_controller_.get();
   }
 
-  const VsyncWaiter& GetVsyncWaiter() const;
+  const std::weak_ptr<VsyncWaiter> GetVsyncWaiter() const;
 
  private:
   // |RuntimeDelegate|

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -1912,7 +1912,7 @@ Shell::GetPlatformMessageHandler() const {
   return platform_message_handler_;
 }
 
-const VsyncWaiter& Shell::GetVsyncWaiter() const {
+const std::weak_ptr<VsyncWaiter> Shell::GetVsyncWaiter() const {
   return engine_->GetVsyncWaiter();
 }
 

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -401,7 +401,7 @@ class Shell final : public PlatformView::Delegate,
   const std::shared_ptr<PlatformMessageHandler>& GetPlatformMessageHandler()
       const;
 
-  const VsyncWaiter& GetVsyncWaiter() const;
+  const std::weak_ptr<VsyncWaiter> GetVsyncWaiter() const;
 
  private:
   using ServiceProtocolHandler =

--- a/shell/common/variable_refresh_rate_display.cc
+++ b/shell/common/variable_refresh_rate_display.cc
@@ -10,12 +10,17 @@ namespace flutter {
 VariableRefreshRateDisplay::VariableRefreshRateDisplay(
     DisplayId display_id,
     const std::weak_ptr<VariableRefreshRateReporter> refresh_rate_reporter)
-    : Display(display_id, refresh_rate_reporter.lock()->GetRefreshRate()),
+    : Display(display_id,
+              refresh_rate_reporter.lock() == nullptr
+                  ? 0
+                  : refresh_rate_reporter.lock()->GetRefreshRate()),
       refresh_rate_reporter_(refresh_rate_reporter) {}
 
 VariableRefreshRateDisplay::VariableRefreshRateDisplay(
     const std::weak_ptr<VariableRefreshRateReporter> refresh_rate_reporter)
-    : Display(refresh_rate_reporter.lock()->GetRefreshRate()),
+    : Display(refresh_rate_reporter.lock() == nullptr
+                  ? 0
+                  : refresh_rate_reporter.lock()->GetRefreshRate()),
       refresh_rate_reporter_(refresh_rate_reporter) {}
 
 double VariableRefreshRateDisplay::GetRefreshRate() const {

--- a/shell/common/variable_refresh_rate_display.cc
+++ b/shell/common/variable_refresh_rate_display.cc
@@ -5,29 +5,30 @@
 #include "flutter/shell/common/variable_refresh_rate_display.h"
 #include "flutter/fml/logging.h"
 
+static double GetInitialRefreshRate(
+    const std::weak_ptr<flutter::VariableRefreshRateReporter>&
+        refresh_rate_reporter) {
+  if (auto reporter = refresh_rate_reporter.lock()) {
+    return reporter->GetRefreshRate();
+  }
+  return 0;
+}
+
 namespace flutter {
 
 VariableRefreshRateDisplay::VariableRefreshRateDisplay(
     DisplayId display_id,
     const std::weak_ptr<VariableRefreshRateReporter> refresh_rate_reporter)
-    : Display(display_id,
-              refresh_rate_reporter.lock() == nullptr
-                  ? 0
-                  : refresh_rate_reporter.lock()->GetRefreshRate()),
+    : Display(display_id, GetInitialRefreshRate(refresh_rate_reporter)),
       refresh_rate_reporter_(refresh_rate_reporter) {}
 
 VariableRefreshRateDisplay::VariableRefreshRateDisplay(
     const std::weak_ptr<VariableRefreshRateReporter> refresh_rate_reporter)
-    : Display(refresh_rate_reporter.lock() == nullptr
-                  ? 0
-                  : refresh_rate_reporter.lock()->GetRefreshRate()),
+    : Display(GetInitialRefreshRate(refresh_rate_reporter)),
       refresh_rate_reporter_(refresh_rate_reporter) {}
 
 double VariableRefreshRateDisplay::GetRefreshRate() const {
-  if (auto refresh_rate = refresh_rate_reporter_.lock()) {
-    return refresh_rate->GetRefreshRate();
-  }
-  return 0;
+  return GetInitialRefreshRate(refresh_rate_reporter_);
 }
 
 }  // namespace flutter

--- a/shell/common/variable_refresh_rate_display.cc
+++ b/shell/common/variable_refresh_rate_display.cc
@@ -9,17 +9,20 @@ namespace flutter {
 
 VariableRefreshRateDisplay::VariableRefreshRateDisplay(
     DisplayId display_id,
-    const VariableRefreshRateReporter& refresh_rate_reporter)
-    : Display(display_id, refresh_rate_reporter.GetRefreshRate()),
+    const std::weak_ptr<VariableRefreshRateReporter> refresh_rate_reporter)
+    : Display(display_id, refresh_rate_reporter.lock()->GetRefreshRate()),
       refresh_rate_reporter_(refresh_rate_reporter) {}
 
 VariableRefreshRateDisplay::VariableRefreshRateDisplay(
-    const VariableRefreshRateReporter& refresh_rate_reporter)
-    : Display(refresh_rate_reporter.GetRefreshRate()),
+    const std::weak_ptr<VariableRefreshRateReporter> refresh_rate_reporter)
+    : Display(refresh_rate_reporter.lock()->GetRefreshRate()),
       refresh_rate_reporter_(refresh_rate_reporter) {}
 
 double VariableRefreshRateDisplay::GetRefreshRate() const {
-  return refresh_rate_reporter_.GetRefreshRate();
+  if (auto refresh_rate = refresh_rate_reporter_.lock()) {
+    return refresh_rate->GetRefreshRate();
+  }
+  return 0;
 }
 
 }  // namespace flutter

--- a/shell/common/variable_refresh_rate_display.h
+++ b/shell/common/variable_refresh_rate_display.h
@@ -18,16 +18,16 @@ class VariableRefreshRateDisplay : public Display {
  public:
   explicit VariableRefreshRateDisplay(
       DisplayId display_id,
-      const VariableRefreshRateReporter& refresh_rate_reporter);
+      const std::weak_ptr<VariableRefreshRateReporter> refresh_rate_reporter);
   explicit VariableRefreshRateDisplay(
-      const VariableRefreshRateReporter& refresh_rate_reporter);
+      const std::weak_ptr<VariableRefreshRateReporter> refresh_rate_reporter);
   ~VariableRefreshRateDisplay() = default;
 
   // |Display|
   double GetRefreshRate() const override;
 
  private:
-  const VariableRefreshRateReporter& refresh_rate_reporter_;
+  const std::weak_ptr<VariableRefreshRateReporter> refresh_rate_reporter_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(VariableRefreshRateDisplay);
 };

--- a/shell/common/variable_refresh_rate_display_unittests.cc
+++ b/shell/common/variable_refresh_rate_display_unittests.cc
@@ -26,11 +26,20 @@ TEST(VariableRefreshRateDisplayTest, ReportCorrectRefreshRateWhenUpdated) {
 }
 
 TEST(VariableRefreshRateDisplayTest,
-     Report0IfReporterSharedPointerIsDestroyed) {
+     Report0IfReporterSharedPointerIsDestroyedAfterDisplayCreation) {
   auto refresh_rate_reporter = std::make_shared<TestRefreshRateReporter>(60);
   auto display = flutter::VariableRefreshRateDisplay(
       std::weak_ptr<TestRefreshRateReporter>(refresh_rate_reporter));
   refresh_rate_reporter.reset();
+  ASSERT_EQ(display.GetRefreshRate(), 0);
+}
+
+TEST(VariableRefreshRateDisplayTest,
+     Report0IfReporterSharedPointerIsDestroyedBeforeDisplayCreation) {
+  auto refresh_rate_reporter = std::make_shared<TestRefreshRateReporter>(60);
+  refresh_rate_reporter.reset();
+  auto display = flutter::VariableRefreshRateDisplay(
+      std::weak_ptr<TestRefreshRateReporter>(refresh_rate_reporter));
   ASSERT_EQ(display.GetRefreshRate(), 0);
 }
 

--- a/shell/common/variable_refresh_rate_display_unittests.cc
+++ b/shell/common/variable_refresh_rate_display_unittests.cc
@@ -11,18 +11,26 @@ namespace flutter {
 namespace testing {
 
 TEST(VariableRefreshRateDisplayTest, ReportCorrectInitialRefreshRate) {
-  auto refresh_rate_reporter = std::make_unique<TestRefreshRateReporter>(60);
+  auto refresh_rate_reporter = std::make_shared<TestRefreshRateReporter>(60);
   auto display =
-      flutter::VariableRefreshRateDisplay(*refresh_rate_reporter.get());
+      flutter::VariableRefreshRateDisplay(std::weak_ptr<TestRefreshRateReporter>(refresh_rate_reporter));
   ASSERT_EQ(display.GetRefreshRate(), 60);
 }
 
 TEST(VariableRefreshRateDisplayTest, ReportCorrectRefreshRateWhenUpdated) {
-  auto refresh_rate_reporter = std::make_unique<TestRefreshRateReporter>(60);
+  auto refresh_rate_reporter = std::make_shared<TestRefreshRateReporter>(60);
   auto display =
-      flutter::VariableRefreshRateDisplay(*refresh_rate_reporter.get());
+      flutter::VariableRefreshRateDisplay(std::weak_ptr<TestRefreshRateReporter>(refresh_rate_reporter));
   refresh_rate_reporter->UpdateRefreshRate(30);
   ASSERT_EQ(display.GetRefreshRate(), 30);
+}
+
+TEST(VariableRefreshRateDisplayTest, Report0IfReporterSharedPointerIsDestroyed) {
+  auto refresh_rate_reporter = std::make_shared<TestRefreshRateReporter>(60);
+  auto display =
+      flutter::VariableRefreshRateDisplay(std::weak_ptr<TestRefreshRateReporter>(refresh_rate_reporter));
+  refresh_rate_reporter.reset();
+  ASSERT_EQ(display.GetRefreshRate(), 0);
 }
 
 }  // namespace testing

--- a/shell/common/variable_refresh_rate_display_unittests.cc
+++ b/shell/common/variable_refresh_rate_display_unittests.cc
@@ -12,23 +12,24 @@ namespace testing {
 
 TEST(VariableRefreshRateDisplayTest, ReportCorrectInitialRefreshRate) {
   auto refresh_rate_reporter = std::make_shared<TestRefreshRateReporter>(60);
-  auto display =
-      flutter::VariableRefreshRateDisplay(std::weak_ptr<TestRefreshRateReporter>(refresh_rate_reporter));
+  auto display = flutter::VariableRefreshRateDisplay(
+      std::weak_ptr<TestRefreshRateReporter>(refresh_rate_reporter));
   ASSERT_EQ(display.GetRefreshRate(), 60);
 }
 
 TEST(VariableRefreshRateDisplayTest, ReportCorrectRefreshRateWhenUpdated) {
   auto refresh_rate_reporter = std::make_shared<TestRefreshRateReporter>(60);
-  auto display =
-      flutter::VariableRefreshRateDisplay(std::weak_ptr<TestRefreshRateReporter>(refresh_rate_reporter));
+  auto display = flutter::VariableRefreshRateDisplay(
+      std::weak_ptr<TestRefreshRateReporter>(refresh_rate_reporter));
   refresh_rate_reporter->UpdateRefreshRate(30);
   ASSERT_EQ(display.GetRefreshRate(), 30);
 }
 
-TEST(VariableRefreshRateDisplayTest, Report0IfReporterSharedPointerIsDestroyed) {
+TEST(VariableRefreshRateDisplayTest,
+     Report0IfReporterSharedPointerIsDestroyed) {
   auto refresh_rate_reporter = std::make_shared<TestRefreshRateReporter>(60);
-  auto display =
-      flutter::VariableRefreshRateDisplay(std::weak_ptr<TestRefreshRateReporter>(refresh_rate_reporter));
+  auto display = flutter::VariableRefreshRateDisplay(
+      std::weak_ptr<TestRefreshRateReporter>(refresh_rate_reporter));
   refresh_rate_reporter.reset();
   ASSERT_EQ(display.GetRefreshRate(), 0);
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -758,8 +758,7 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
 
 - (void)initializeDisplays {
   auto vsync_waiter = std::shared_ptr<flutter::VsyncWaiter>(_shell->GetVsyncWaiter().lock());
-  auto vsync_waiter_ios =
-      std::static_pointer_cast<flutter::VsyncWaiterIOS>(vsync_waiter);
+  auto vsync_waiter_ios = std::static_pointer_cast<flutter::VsyncWaiterIOS>(vsync_waiter);
   std::vector<std::unique_ptr<flutter::Display>> displays;
   displays.push_back(std::make_unique<flutter::VariableRefreshRateDisplay>(vsync_waiter_ios));
   _shell->OnDisplayUpdates(flutter::DisplayUpdateType::kStartup, std::move(displays));

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -757,8 +757,9 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
 }
 
 - (void)initializeDisplays {
-  const flutter::VsyncWaiterIOS& vsync_waiter_ios =
-      static_cast<const flutter::VsyncWaiterIOS&>(_shell->GetVsyncWaiter());
+  auto vsync_waiter = std::shared_ptr<flutter::VsyncWaiter>(_shell->GetVsyncWaiter().lock());
+  auto vsync_waiter_ios =
+      std::static_pointer_cast<flutter::VsyncWaiterIOS>(vsync_waiter);
   std::vector<std::unique_ptr<flutter::Display>> displays;
   displays.push_back(std::make_unique<flutter::VariableRefreshRateDisplay>(vsync_waiter_ios));
   _shell->OnDisplayUpdates(flutter::DisplayUpdateType::kStartup, std::move(displays));


### PR DESCRIPTION
`VariableRefreshRateDisplay` used to hold a reference of VariableRefreshRateReporter, which might cause a dangling pointer if the `VariableRefreshRateReporter` is destroyed while the Display is still alive.
This is possible because `VariableRefreshRateReporter` is owned by the `engine` while `Display` is owned by `shell`. And the `engine` might destroy before `shell`. See https://github.com/flutter/engine/blob/main/shell/common/shell.cc#L435-L486

This PR makes the `VariableRefreshRateReporter` a weak_pointer, so `VariableRefreshRateDisplay` returns a default value: 0, when `VariableRefreshRateReporter` is null.

Fixes: https://github.com/flutter/flutter/issues/99925

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
