### PR TITLE
Ensure errors from Codec.getNextFrame can be caught

### DIFF
--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -1998,6 +1998,9 @@ class Codec extends NativeFieldWrapperClass1 {
     final String? error = _getNextFrame((_Image? image, int durationMilliseconds) {
       if (image == null) {
         final Exception exception = Exception('Codec failed to produce an image, possibly due to invalid image data.');
+        if (sync) {
+          throw exception;
+        }
         completer.completeError(exception);
       } else {
         completer.complete(FrameInfo._(

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -1994,9 +1994,15 @@ class Codec extends NativeFieldWrapperClass1 {
   /// [FrameInfo.image] on the returned object.
   Future<FrameInfo> getNextFrame() async {
     final Completer<FrameInfo> completer = Completer<FrameInfo>.sync();
+    bool sync = true;
     final String? error = _getNextFrame((_Image? image, int durationMilliseconds) {
       if (image == null) {
-        completer.completeError(Exception('Codec failed to produce an image, possibly due to invalid image data.'));
+        final Exception exception = Exception('Codec failed to produce an image, possibly due to invalid image data.');
+        if (sync) {
+          throw exception;
+        } else {
+          completer.completeError(exception);
+        }
       } else {
         completer.complete(FrameInfo._(
           image: Image._(image),
@@ -2004,6 +2010,7 @@ class Codec extends NativeFieldWrapperClass1 {
         ));
       }
     });
+    sync = false;
     if (error != null) {
       throw Exception(error);
     }

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -1998,11 +1998,7 @@ class Codec extends NativeFieldWrapperClass1 {
     final String? error = _getNextFrame((_Image? image, int durationMilliseconds) {
       if (image == null) {
         final Exception exception = Exception('Codec failed to produce an image, possibly due to invalid image data.');
-        if (sync) {
-          throw exception;
-        } else {
-          completer.completeError(exception);
-        }
+        completer.completeError(exception);
       } else {
         completer.complete(FrameInfo._(
           image: Image._(image),

--- a/testing/dart/codec_test.dart
+++ b/testing/dart/codec_test.dart
@@ -47,6 +47,16 @@ void main() {
     }
   });
 
+  test('getNextFrame fails with empty image data', () async {
+    final ui.Codec codec = await ui.instantiateImageCodec(Uint8List(0));
+    try {
+      await codec.getNextFrame();
+      fail('exception not thrown');
+    } on Exception catch (e) {
+      expect(e.toString(), contains('Codec failed'));
+    }
+  });
+
   test('nextFrame', () async {
     final Uint8List data = await _getSkiaResource('test640x479.gif').readAsBytes();
     final ui.Codec codec = await ui.instantiateImageCodec(data);

--- a/testing/dart/codec_test.dart
+++ b/testing/dart/codec_test.dart
@@ -48,7 +48,7 @@ void main() {
   });
 
   test('getNextFrame fails with empty image data', () async {
-    final ui.ImmutableBuffer buffer = await ui.ImmutableBuffer.fromUint8List(Uint8List(0));
+    final ui.ImmutableBuffer buffer = await ui.ImmutableBuffer.fromUint8List(Uint8List.fromList(<int>[1, 2, 3, 4, 5, 6, 7, 8]));
     final ui.ImageDescriptor descriptor = ui.ImageDescriptor.raw(
       buffer,
       width: 1,

--- a/testing/dart/codec_test.dart
+++ b/testing/dart/codec_test.dart
@@ -48,7 +48,15 @@ void main() {
   });
 
   test('getNextFrame fails with empty image data', () async {
-    final ui.Codec codec = await ui.instantiateImageCodec(Uint8List(0));
+    final ui.ImmutableBuffer buffer = await ui.ImmutableBuffer.fromUint8List(Uint8List(0));
+    final ui.ImageDescriptor descriptor = ui.ImageDescriptor.raw(
+      buffer,
+      width: 1,
+      height: 1,
+      rowBytes: 1,
+      pixelFormat: ui.PixelFormat.rgba8888,
+    );
+    final ui.Codec codec = await descriptor.instantiateCodec();
     try {
       await codec.getNextFrame();
       fail('exception not thrown');


### PR DESCRIPTION
See https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8819306090267051457/+/u/test:_Host_Tests_for_host_release__3_/stdout for a run without the change to painting.dart

Spoiler:

```
unittest-suite-success

[ERROR:flutter/lib/ui/painting/image_decoder.cc(88)] Could not create image from decompressed bytes.

Writing core dump analysis to /b/s/w/ir/x/w/recipe_cleanup/flutter_logs_dir/flutter_tester_linux2.txt
GDB=/b/s/w/ir/cache/builder/src/third_party/android_tools/ndk/prebuilt/linux-x86_64/bin/gdb

```

Same issue as futurize, certain errors result in the callback being invoked immediately which result in unhandled exceptions.
