### PR TITLE
Modify some tests to work correctly on iOS 15.

### DIFF
--- a/lib/web_ui/test/engine/util_test.dart
+++ b/lib/web_ui/test/engine/util_test.dart
@@ -41,8 +41,9 @@ void testMain() {
     expect(isIdentityFloat32ListTransform(rotation2d), isFalse);
   });
 
-  test('canonicalizes font families correctly on iOS', () {
+  test('canonicalizes font families correctly on iOS (not 15)', () {
     debugOperatingSystemOverride = OperatingSystem.iOs;
+    debugIsIOS15 = false;
 
     expect(
       canonicalizeFontFamily('sans-serif'),
@@ -58,6 +59,7 @@ void testMain() {
     );
 
     debugOperatingSystemOverride = null;
+    debugIsIOS15 = null;
   });
 
   test('does not use -apple-system on iOS 15', () {

--- a/lib/web_ui/test/text_test.dart
+++ b/lib/web_ui/test/text_test.dart
@@ -26,7 +26,11 @@ Future<void> testMain() async {
   setUp(() {
     if (operatingSystem == OperatingSystem.macOs ||
         operatingSystem == OperatingSystem.iOs) {
-      fallback = '-apple-system, BlinkMacSystemFont';
+      if (isIOS15) {
+        fallback = 'BlinkMacSystemFont';
+      } else {
+        fallback = '-apple-system, BlinkMacSystemFont';
+      }
     } else {
       fallback = 'Arial';
     }


### PR DESCRIPTION
We have some special casing around fonts to work around a crash in iOS 15 Safari. Some of the unit tests exercise this, but the expectations on the unit tests aren't solid in the other direction (i.e., the tests fail if we're actually running our tests on iOS 15). As such, we need to change the expectations on some of the tests themselves.

This partially addresses https://github.com/flutter/flutter/issues/99885, but there are still some issues with the iOS simulator having issues launching Safari.