### PR TITLE
Replace TestUtil#setApiVersion with Robolectric's sdk in Config

### DIFF
--- a/shell/platform/android/test/io/flutter/TestUtils.java
+++ b/shell/platform/android/test/io/flutter/TestUtils.java
@@ -7,29 +7,12 @@ package io.flutter;
 import static org.junit.Assert.assertTrue;
 
 import android.content.res.Configuration;
-import android.os.Build;
 import androidx.annotation.NonNull;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.Locale;
 
 public class TestUtils {
-
-  public static void setApiVersion(int apiVersion) {
-    try {
-      Field field = Build.VERSION.class.getField("SDK_INT");
-
-      field.setAccessible(true);
-      Field modifiersField = Field.class.getDeclaredField("modifiers");
-      modifiersField.setAccessible(true);
-      modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
-
-      field.set(null, apiVersion);
-    } catch (Exception e) {
-      assertTrue(false);
-    }
-  }
-
   public static void setLegacyLocale(@NonNull Configuration config, @NonNull Locale locale) {
     try {
       Field field = config.getClass().getField("locale");

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
@@ -30,7 +30,6 @@ import androidx.lifecycle.DefaultLifecycleObserver;
 import androidx.lifecycle.LifecycleOwner;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import io.flutter.FlutterInjector;
-import io.flutter.TestUtils;
 import io.flutter.embedding.android.FlutterActivityLaunchConfigs.BackgroundMode;
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.FlutterEngineCache;
@@ -447,9 +446,10 @@ public class FlutterActivityTest {
   }
 
   @Test
-  @Config(shadows = {SplashShadowResources.class})
+  @Config(
+      sdk = Build.VERSION_CODES.KITKAT,
+      shadows = {SplashShadowResources.class})
   public void itLoadsSplashScreenDrawable() throws PackageManager.NameNotFoundException {
-    TestUtils.setApiVersion(19);
     Intent intent = FlutterActivity.createDefaultIntent(RuntimeEnvironment.application);
     ActivityController<FlutterActivity> activityController =
         Robolectric.buildActivity(FlutterActivity.class, intent);
@@ -471,13 +471,14 @@ public class FlutterActivityTest {
   }
 
   @Test
-  @Config(shadows = {SplashShadowResources.class})
+  @Config(
+      sdk = Build.VERSION_CODES.LOLLIPOP,
+      shadows = {SplashShadowResources.class})
   @TargetApi(21) // Theme references in drawables requires API 21+
   public void itLoadsThemedSplashScreenDrawable() throws PackageManager.NameNotFoundException {
     // A drawable with theme references can be parsed only if the app theme is supplied
     // in getDrawable methods. This test verifies it by fetching a (fake) themed drawable.
     // On failure, a Resource.NotFoundException will ocurr.
-    TestUtils.setApiVersion(21);
     Intent intent = FlutterActivity.createDefaultIntent(RuntimeEnvironment.application);
     ActivityController<FlutterActivity> activityController =
         Robolectric.buildActivity(FlutterActivity.class, intent);
@@ -519,7 +520,8 @@ public class FlutterActivityTest {
   }
 
   @Test
-  public void fullyDrawn() {
+  @Config(minSdk = Build.VERSION_CODES.JELLY_BEAN, maxSdk = Build.VERSION_CODES.P)
+  public void fullyDrawn_beforeAndroidQ() {
     Intent intent =
         FlutterActivityWithReportFullyDrawn.createDefaultIntent(RuntimeEnvironment.application);
     ActivityController<FlutterActivityWithReportFullyDrawn> activityController =
@@ -528,21 +530,22 @@ public class FlutterActivityTest {
 
     // See https://github.com/flutter/flutter/issues/46172, and
     // https://github.com/flutter/flutter/issues/88767.
-    for (int version = Build.VERSION_CODES.JELLY_BEAN; version < Build.VERSION_CODES.Q; version++) {
-      TestUtils.setApiVersion(version);
-      flutterActivity.onFlutterUiDisplayed();
-      assertFalse(
-          "reportFullyDrawn isn't used in API level " + version, flutterActivity.isFullyDrawn());
-    }
+    flutterActivity.onFlutterUiDisplayed();
+    assertFalse("reportFullyDrawn isn't used", flutterActivity.isFullyDrawn());
+  }
 
-    final int versionCodeS = 31;
-    for (int version = Build.VERSION_CODES.Q; version < versionCodeS; version++) {
-      TestUtils.setApiVersion(version);
-      flutterActivity.onFlutterUiDisplayed();
-      assertTrue(
-          "reportFullyDrawn is used in API level " + version, flutterActivity.isFullyDrawn());
-      flutterActivity.resetFullyDrawn();
-    }
+  @Test
+  @Config(minSdk = Build.VERSION_CODES.Q)
+  public void fullyDrawn_fromAndroidQ() {
+    Intent intent =
+        FlutterActivityWithReportFullyDrawn.createDefaultIntent(RuntimeEnvironment.application);
+    ActivityController<FlutterActivityWithReportFullyDrawn> activityController =
+        Robolectric.buildActivity(FlutterActivityWithReportFullyDrawn.class, intent);
+    FlutterActivityWithReportFullyDrawn flutterActivity = activityController.get();
+
+    flutterActivity.onFlutterUiDisplayed();
+    assertTrue("reportFullyDrawn is used", flutterActivity.isFullyDrawn());
+    flutterActivity.resetFullyDrawn();
   }
 
   static class FlutterActivityWithProvidedEngine extends FlutterActivity {

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentActivityTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentActivityTest.java
@@ -16,6 +16,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
+import android.os.Build;
 import android.os.Bundle;
 import android.view.View;
 import android.view.ViewGroup;
@@ -25,7 +26,6 @@ import androidx.annotation.Nullable;
 import androidx.test.core.app.ActivityScenario;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import io.flutter.FlutterInjector;
-import io.flutter.TestUtils;
 import io.flutter.embedding.android.FlutterActivityLaunchConfigs.BackgroundMode;
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.FlutterJNI;
@@ -268,9 +268,10 @@ public class FlutterFragmentActivityTest {
   }
 
   @Test
-  @Config(shadows = {SplashShadowResources.class})
+  @Config(
+      sdk = Build.VERSION_CODES.KITKAT,
+      shadows = {SplashShadowResources.class})
   public void itLoadsSplashScreenDrawable() throws PackageManager.NameNotFoundException {
-    TestUtils.setApiVersion(19);
     Intent intent = FlutterFragmentActivity.createDefaultIntent(RuntimeEnvironment.application);
     ActivityController<FlutterFragmentActivity> activityController =
         Robolectric.buildActivity(FlutterFragmentActivity.class, intent);
@@ -292,13 +293,14 @@ public class FlutterFragmentActivityTest {
   }
 
   @Test
-  @Config(shadows = {SplashShadowResources.class})
+  @Config(
+      sdk = Build.VERSION_CODES.LOLLIPOP,
+      shadows = {SplashShadowResources.class})
   @TargetApi(21) // Theme references in drawables requires API 21+
   public void itLoadsThemedSplashScreenDrawable() throws PackageManager.NameNotFoundException {
     // A drawable with theme references can be parsed only if the app theme is supplied
     // in getDrawable methods. This test verifies it by fetching a (fake) themed drawable.
     // On failure, a Resource.NotFoundException will ocurr.
-    TestUtils.setApiVersion(21);
     Intent intent = FlutterFragmentActivity.createDefaultIntent(RuntimeEnvironment.application);
     ActivityController<FlutterFragmentActivity> activityController =
         Robolectric.buildActivity(FlutterFragmentActivity.class, intent);

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
@@ -40,7 +40,6 @@ import androidx.core.util.Consumer;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.window.layout.FoldingFeature;
 import androidx.window.layout.WindowLayoutInfo;
-import io.flutter.TestUtils;
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.FlutterJNI;
 import io.flutter.embedding.engine.loader.FlutterLoader;
@@ -983,9 +982,8 @@ public class FlutterViewTest {
 
   @Test
   @SuppressLint("PrivateApi")
+  @Config(sdk = Build.VERSION_CODES.P)
   public void findViewByAccessibilityIdTraversal_returnsRootViewOnAndroid28() throws Exception {
-    TestUtils.setApiVersion(28);
-
     FlutterView flutterView = new FlutterView(RuntimeEnvironment.application);
 
     Method getAccessibilityViewIdMethod = View.class.getDeclaredMethod("getAccessibilityViewId");
@@ -995,10 +993,9 @@ public class FlutterViewTest {
   }
 
   @Test
+  @Config(sdk = Build.VERSION_CODES.P)
   @SuppressLint("PrivateApi")
   public void findViewByAccessibilityIdTraversal_returnsChildViewOnAndroid28() throws Exception {
-    TestUtils.setApiVersion(28);
-
     FlutterView flutterView = new FlutterView(RuntimeEnvironment.application);
     FrameLayout childView1 = new FrameLayout(RuntimeEnvironment.application);
     flutterView.addView(childView1);
@@ -1013,10 +1010,9 @@ public class FlutterViewTest {
   }
 
   @Test
+  @Config(sdk = Build.VERSION_CODES.Q)
   @SuppressLint("PrivateApi")
   public void findViewByAccessibilityIdTraversal_returnsRootViewOnAndroid29() throws Exception {
-    TestUtils.setApiVersion(29);
-
     FlutterView flutterView = new FlutterView(RuntimeEnvironment.application);
 
     Method getAccessibilityViewIdMethod = View.class.getDeclaredMethod("getAccessibilityViewId");

--- a/shell/platform/android/test/io/flutter/embedding/android/SplashShadowResources.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/SplashShadowResources.java
@@ -4,7 +4,8 @@ import android.content.res.Resources;
 import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
-import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.shadow.api.Shadow;
@@ -16,14 +17,16 @@ public class SplashShadowResources {
   public static final int SPLASH_DRAWABLE_ID = 191919;
   public static final int THEMED_SPLASH_DRAWABLE_ID = 212121;
 
-  // All other getDrawable() calls, call this method internally.
-  @NonNull
-  public Drawable getDrawableForDensity(int id, int density, @NonNull Resources.Theme theme)
-      throws Exception {
+  @Implementation
+  protected Drawable getDrawable(int id) {
     if (id == SPLASH_DRAWABLE_ID) {
       return new ColorDrawable(Color.BLUE);
     }
+    return Shadow.directlyOn(resources, Resources.class).getDrawable(id);
+  }
 
+  @Implementation
+  protected Drawable getDrawable(int id, @Nullable Resources.Theme theme) {
     if (id == THEMED_SPLASH_DRAWABLE_ID) {
       // We pretend the drawable contains theme references. It can't be parsed without the app
       // theme.
@@ -33,7 +36,6 @@ public class SplashShadowResources {
       }
       return new ColorDrawable(Color.GRAY);
     }
-
-    return Shadow.directlyOn(resources, Resources.class).getDrawableForDensity(id, density, theme);
+    return Shadow.directlyOn(resources, Resources.class).getDrawable(id, theme);
   }
 }

--- a/shell/platform/android/test/io/flutter/plugin/localization/LocalizationPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/localization/LocalizationPluginTest.java
@@ -10,6 +10,7 @@ import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.content.res.Resources;
+import android.os.Build;
 import android.os.LocaleList;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import io.flutter.TestUtils;
@@ -31,9 +32,9 @@ import org.robolectric.annotation.Config;
 public class LocalizationPluginTest {
   // This test should be synced with the version for API 24.
   @Test
+  @Config(sdk = Build.VERSION_CODES.O)
   public void computePlatformResolvedLocaleAPI26() {
     // --- Test Setup ---
-    TestUtils.setApiVersion(26);
     FlutterJNI flutterJNI = new FlutterJNI();
 
     Context context = mock(Context.class);
@@ -139,9 +140,9 @@ public class LocalizationPluginTest {
 
   // This test should be synced with the version for API 26.
   @Test
+  @Config(sdk = Build.VERSION_CODES.N)
   public void computePlatformResolvedLocaleAPI24() {
     // --- Test Setup ---
-    TestUtils.setApiVersion(24);
     FlutterJNI flutterJNI = new FlutterJNI();
 
     Context context = mock(Context.class);
@@ -234,9 +235,9 @@ public class LocalizationPluginTest {
 
   // Tests the legacy pre API 24 algorithm.
   @Test
+  @Config(sdk = Build.VERSION_CODES.JELLY_BEAN)
   public void computePlatformResolvedLocaleAPI16() {
     // --- Test Setup ---
-    TestUtils.setApiVersion(16);
     FlutterJNI flutterJNI = new FlutterJNI();
 
     Context context = mock(Context.class);


### PR DESCRIPTION
Replace `TestUtil#setApiVersion` with Robolectric `Config`'s `sdk` to set api version, and remove `TestUtil#setApiVersion`.  The `Resources#getDrawableForDensity` doesn't work on `KITKAT` and `LOOLIPOP`, and this CL provides the same functionability with adding shadows for `getDrawable(int id)` and `getDrawable(int id, Theme theme)`.  

The relationship between `VERSION_CODES` and API version is here: https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/java/android/os/Build.java;l=770-1157?q=Build.java&ss=android.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
