### PR TITLE
fix display list include path in ui.painting sources

### DIFF
--- a/lib/ui/painting/canvas.cc
+++ b/lib/ui/painting/canvas.cc
@@ -3,11 +3,11 @@
 // found in the LICENSE file.
 
 #include "flutter/lib/ui/painting/canvas.h"
-#include "display_list/display_list_blend_mode.h"
 #include "flutter/lib/ui/painting/image_filter.h"
 
 #include <cmath>
 
+#include "flutter/display_list/display_list_blend_mode.h"
 #include "flutter/display_list/display_list_builder.h"
 #include "flutter/display_list/display_list_canvas_dispatcher.h"
 #include "flutter/flow/layers/physical_shape_layer.h"

--- a/lib/ui/painting/canvas.h
+++ b/lib/ui/painting/canvas.h
@@ -5,7 +5,7 @@
 #ifndef FLUTTER_LIB_UI_PAINTING_CANVAS_H_
 #define FLUTTER_LIB_UI_PAINTING_CANVAS_H_
 
-#include "display_list/display_list_blend_mode.h"
+#include "flutter/display_list/display_list_blend_mode.h"
 #include "flutter/lib/ui/dart_wrapper.h"
 #include "flutter/lib/ui/painting/paint.h"
 #include "flutter/lib/ui/painting/path.h"


### PR DESCRIPTION
The recent engine PR https://github.com/flutter/engine/pull/32026 to add DlBlendMode objects had some incomplete paths for the display_list header files that somehow compiled in our local environments, but failed to resolve in downstream workspaces.