### PR TITLE
Linux deltas double free and newline fix

### DIFF
--- a/shell/platform/linux/fl_text_input_plugin.cc
+++ b/shell/platform/linux/fl_text_input_plugin.cc
@@ -629,6 +629,7 @@ static gboolean fl_text_input_plugin_filter_keypress_default(
 
   std::string text_before_change = priv->text_model->GetText();
   flutter::TextRange selection_before_change = priv->text_model->selection();
+  std::string text = priv->text_model->GetText();
 
   // Handle the enter/return key.
   gboolean do_action = FALSE;
@@ -649,6 +650,7 @@ static gboolean fl_text_input_plugin_filter_keypress_default(
       case GDK_KEY_ISO_Enter:
         if (priv->input_type == FL_TEXT_INPUT_TYPE_MULTILINE) {
           priv->text_model->AddCodePoint('\n');
+          text = "\n";
           changed = TRUE;
         }
         do_action = TRUE;
@@ -676,8 +678,8 @@ static gboolean fl_text_input_plugin_filter_keypress_default(
   if (changed) {
     if (priv->enable_delta_model) {
       flutter::TextEditingDelta delta = flutter::TextEditingDelta(
-          text_before_change, priv->text_model->selection(),
-          priv->text_model->GetText());
+          text_before_change, selection_before_change,
+          text);
       update_editing_state_with_delta(self, &delta);
     } else {
       update_editing_state(self);

--- a/shell/platform/linux/fl_text_input_plugin.cc
+++ b/shell/platform/linux/fl_text_input_plugin.cc
@@ -678,8 +678,7 @@ static gboolean fl_text_input_plugin_filter_keypress_default(
   if (changed) {
     if (priv->enable_delta_model) {
       flutter::TextEditingDelta delta = flutter::TextEditingDelta(
-          text_before_change, selection_before_change,
-          text);
+          text_before_change, selection_before_change, text);
       update_editing_state_with_delta(self, &delta);
     } else {
       update_editing_state(self);

--- a/shell/platform/linux/fl_text_input_plugin.cc
+++ b/shell/platform/linux/fl_text_input_plugin.cc
@@ -216,7 +216,7 @@ static void update_editing_state_with_delta(FlTextInputPlugin* self,
 
   g_autoptr(FlValue) deltas = fl_value_new_list();
   fl_value_append(deltas, deltaValue);
-  g_autoptr(FlValue) value = fl_value_new_map();
+  FlValue* value = fl_value_new_map();
   fl_value_set_string_take(value, "deltas", deltas);
 
   fl_value_append(args, value);


### PR DESCRIPTION
This PR fixes:
* A double free error 
```
** (delta_guide:3387505): CRITICAL **: 14:40:24.958: void fl_value_unref(FlValue *): assertion 'self->ref_count > 0' failed
```
* Unable to enter a newline due to incorrect delta range and delta text passed to TextEditingDelta constructor.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.