### PR TITLE
Support software rendering when textures are used

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngineConnectionRegistry.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngineConnectionRegistry.java
@@ -330,6 +330,12 @@ import java.util.Set;
   private void attachToActivityInternal(@NonNull Activity activity, @NonNull Lifecycle lifecycle) {
     this.activityPluginBinding = new FlutterEngineActivityPluginBinding(activity, lifecycle);
 
+    final boolean useSoftwareRendering =
+        activity
+            .getIntent()
+            .getBooleanExtra(FlutterShellArgs.ARG_KEY_ENABLE_SOFTWARE_RENDERING, false);
+    flutterEngine.getPlatformViewsController().setSoftwareRendering(useSoftwareRendering);
+
     // Activate the PlatformViewsController. This must happen before any plugins attempt
     // to use it, otherwise an error stack trace will appear that says there is no
     // flutter/platform_views channel.

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewWrapper.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewWrapper.java
@@ -54,7 +54,6 @@ class PlatformViewWrapper extends FrameLayout {
   private AndroidTouchProcessor touchProcessor;
 
   @Nullable @VisibleForTesting ViewTreeObserver.OnGlobalFocusChangeListener activeFocusListener;
-  @Nullable private TextureRegistry.SurfaceTextureEntry textureEntry;
   private final AtomicLong pendingFramesCount = new AtomicLong(0L);
 
   private final TextureRegistry.OnFrameConsumedListener listener =
@@ -88,7 +87,6 @@ class PlatformViewWrapper extends FrameLayout {
   public PlatformViewWrapper(
       @NonNull Context context, @NonNull TextureRegistry.SurfaceTextureEntry textureEntry) {
     this(context);
-    this.textureEntry = textureEntry;
     textureEntry.setOnFrameConsumedListener(listener);
     setTexture(textureEntry.surfaceTexture());
   }
@@ -230,7 +228,12 @@ class PlatformViewWrapper extends FrameLayout {
   @Override
   @SuppressLint("NewApi")
   public void draw(Canvas canvas) {
-    if (surface == null || !surface.isValid()) {
+    if (surface == null) {
+      super.draw(canvas);
+      Log.e(TAG, "Platform view cannot be composed without a surface.");
+      return;
+    }
+    if (!surface.isValid()) {
       Log.e(TAG, "Invalid surface. The platform view cannot be displayed.");
       return;
     }

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -235,8 +235,12 @@ void PlatformViewAndroid::UpdateSemantics(
 void PlatformViewAndroid::RegisterExternalTexture(
     int64_t texture_id,
     const fml::jni::ScopedJavaGlobalRef<jobject>& surface_texture) {
-  RegisterTexture(std::make_shared<AndroidExternalTextureGL>(
-      texture_id, surface_texture, std::move(jni_facade_)));
+  if (android_context_->RenderingApi() == AndroidRenderingAPI::kOpenGLES) {
+    RegisterTexture(std::make_shared<AndroidExternalTextureGL>(
+        texture_id, surface_texture, std::move(jni_facade_)));
+  } else {
+    FML_LOG(INFO) << "Attempted to use a GL texture in a non GL context.";
+  }
 }
 
 // |PlatformView|

--- a/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineConnectionRegistryTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineConnectionRegistryTest.java
@@ -1,10 +1,8 @@
 package io.flutter.embedding.engine;
 
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 import android.app.Activity;
 import android.content.Context;
@@ -113,6 +111,36 @@ public class FlutterEngineConnectionRegistryTest {
 
     // The order of the listeners in the HashSet is random: So just check the sum of calls
     assertEquals(3, listener1.callCount + listener2.callCount);
+  }
+
+  @Test
+  public void softwareRendering() {
+    Context context = mock(Context.class);
+
+    FlutterEngine flutterEngine = mock(FlutterEngine.class);
+    PlatformViewsController platformViewsController = mock(PlatformViewsController.class);
+    when(flutterEngine.getPlatformViewsController()).thenReturn(platformViewsController);
+
+    FlutterLoader flutterLoader = mock(FlutterLoader.class);
+
+    ExclusiveAppComponent appComponent = mock(ExclusiveAppComponent.class);
+    Activity activity = mock(Activity.class);
+    when(appComponent.getAppComponent()).thenReturn(activity);
+
+    Intent intent = mock(Intent.class);
+    when(intent.getBooleanExtra("enable-software-rendering", false)).thenReturn(false);
+    when(activity.getIntent()).thenReturn(intent);
+
+    FlutterEngineConnectionRegistry registry =
+        new FlutterEngineConnectionRegistry(context, flutterEngine, flutterLoader);
+
+    registry.attachToActivity(appComponent, mock(Lifecycle.class));
+    verify(platformViewsController).setSoftwareRendering(false);
+
+    when(intent.getBooleanExtra("enable-software-rendering", false)).thenReturn(true);
+
+    registry.attachToActivity(appComponent, mock(Lifecycle.class));
+    verify(platformViewsController).setSoftwareRendering(true);
   }
 
   private static class FakeFlutterPlugin implements FlutterPlugin {

--- a/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineConnectionRegistryTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineConnectionRegistryTest.java
@@ -80,8 +80,10 @@ public class FlutterEngineConnectionRegistryTest {
     Activity activity = mock(Activity.class);
     when(appComponent.getAppComponent()).thenReturn(activity);
 
-    Lifecycle lifecycle = mock(Lifecycle.class);
     Intent intent = mock(Intent.class);
+    when(activity.getIntent()).thenReturn(intent);
+
+    Lifecycle lifecycle = mock(Lifecycle.class);
     AtomicBoolean isFirstCall = new AtomicBoolean(true);
 
     // Set up the environment to get the required internal data

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewWrapperTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewWrapperTest.java
@@ -21,6 +21,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+import org.robolectric.annotation.Implements;
 
 @TargetApi(31)
 @RunWith(AndroidJUnit4.class)
@@ -115,6 +117,28 @@ public class PlatformViewWrapperTest {
     verify(surface, times(1)).unlockCanvasAndPost(canvas);
     verifyNoMoreInteractions(surface);
     verifyNoMoreInteractions(canvas);
+  }
+
+  @Test
+  @Config(
+      shadows = {
+        ShadowView.class,
+      })
+  public void draw_withoutSurface() {
+    final Context ctx = ApplicationProvider.getApplicationContext();
+    final PlatformViewWrapper wrapper =
+        new PlatformViewWrapper(ctx) {
+          @Override
+          public void onDraw(Canvas canvas) {
+            canvas.drawColor(Color.RED);
+          }
+        };
+    // Test.
+    final Canvas canvas = mock(Canvas.class);
+    wrapper.draw(canvas);
+
+    // Verify.
+    verify(canvas, times(1)).drawColor(Color.RED);
   }
 
   @Test
@@ -274,4 +298,7 @@ public class PlatformViewWrapperTest {
     view.unsetOnDescendantFocusChangeListener();
     verify(viewTreeObserver, times(1)).removeOnGlobalFocusChangeListener(activeFocusListener);
   }
+
+  @Implements(View.class)
+  public static class ShadowView {}
 }


### PR DESCRIPTION
Fixes b/225379923

Software rendering is used for testing scenarios.

When this is used, GL textures cannot be used because they need a valid
GL context that is current in the calling thread.

This PR disables registration of textures for non GL contexts, and allows an Android views
to render without Flutter-level composition.