### PR TITLE
Fix entering newline on deltas for windows

### DIFF
--- a/shell/platform/windows/text_input_plugin.cc
+++ b/shell/platform/windows/text_input_plugin.cc
@@ -446,14 +446,13 @@ void TextInputPlugin::SendStateUpdateWithDelta(const TextInputModel& model,
 
 void TextInputPlugin::EnterPressed(TextInputModel* model) {
   if (input_type_ == kMultilineInputType) {
-    std::u16string text_before_change =
-        fml::Utf8ToUtf16(active_model_->GetText());
-    std::u16string text = std::u16string({u'\n'});
-    TextRange selection_before_change = active_model_->selection();
     model->AddText(std::u16string({u'\n'}));
     if (enable_delta_model) {
-      TextEditingDelta delta =
-          TextEditingDelta(text_before_change, selection_before_change, text);
+      std::u16string text_before_change =
+          fml::Utf8ToUtf16(active_model_->GetText());
+      TextRange selection_before_change = active_model_->selection();
+      TextEditingDelta delta(text_before_change, selection_before_change,
+                             std::u16string({u'\n'}));
       SendStateUpdateWithDelta(*active_model_, &delta);
     } else {
       SendStateUpdate(*model);

--- a/shell/platform/windows/text_input_plugin.cc
+++ b/shell/platform/windows/text_input_plugin.cc
@@ -446,7 +446,8 @@ void TextInputPlugin::SendStateUpdateWithDelta(const TextInputModel& model,
 
 void TextInputPlugin::EnterPressed(TextInputModel* model) {
   if (input_type_ == kMultilineInputType) {
-    std::u16string text_before_change = fml::Utf8ToUtf16(active_model_->GetText());
+    std::u16string text_before_change =
+        fml::Utf8ToUtf16(active_model_->GetText());
     std::u16string text = std::u16string({u'\n'});
     TextRange selection_before_change = active_model_->selection();
     model->AddText(std::u16string({u'\n'}));

--- a/shell/platform/windows/text_input_plugin.cc
+++ b/shell/platform/windows/text_input_plugin.cc
@@ -446,13 +446,12 @@ void TextInputPlugin::SendStateUpdateWithDelta(const TextInputModel& model,
 
 void TextInputPlugin::EnterPressed(TextInputModel* model) {
   if (input_type_ == kMultilineInputType) {
+    std::u16string text_before_change =
+        fml::Utf8ToUtf16(active_model_->GetText());
+    TextRange selection_before_change = active_model_->selection();
     model->AddText(std::u16string({u'\n'}));
     if (enable_delta_model) {
-      std::u16string text_before_change =
-          fml::Utf8ToUtf16(active_model_->GetText());
-      TextRange selection_before_change = active_model_->selection();
-      TextEditingDelta delta(text_before_change, selection_before_change,
-                             std::u16string({u'\n'}));
+      TextEditingDelta delta(text_before_change, selection_before_change, u"\n");
       SendStateUpdateWithDelta(*model, &delta);
     } else {
       SendStateUpdate(*model);

--- a/shell/platform/windows/text_input_plugin.cc
+++ b/shell/platform/windows/text_input_plugin.cc
@@ -448,7 +448,7 @@ void TextInputPlugin::EnterPressed(TextInputModel* model) {
   if (input_type_ == kMultilineInputType) {
     std::u16string text_before_change = fml::Utf8ToUtf16(model->GetText());
     TextRange selection_before_change = model->selection();
-    model->AddText(std::u16string({u'\n'}));
+    model->AddText(u"\n");
     if (enable_delta_model) {
       TextEditingDelta delta(text_before_change, selection_before_change,
                              u"\n");

--- a/shell/platform/windows/text_input_plugin.cc
+++ b/shell/platform/windows/text_input_plugin.cc
@@ -453,7 +453,7 @@ void TextInputPlugin::EnterPressed(TextInputModel* model) {
       TextRange selection_before_change = active_model_->selection();
       TextEditingDelta delta(text_before_change, selection_before_change,
                              std::u16string({u'\n'}));
-      SendStateUpdateWithDelta(*active_model_, &delta);
+      SendStateUpdateWithDelta(*model, &delta);
     } else {
       SendStateUpdate(*model);
     }

--- a/shell/platform/windows/text_input_plugin.cc
+++ b/shell/platform/windows/text_input_plugin.cc
@@ -446,8 +446,17 @@ void TextInputPlugin::SendStateUpdateWithDelta(const TextInputModel& model,
 
 void TextInputPlugin::EnterPressed(TextInputModel* model) {
   if (input_type_ == kMultilineInputType) {
+    std::string text_before_change = active_model_->GetText();
+    std::string text = "\n";
+    TextRange selection_before_change = active_model_->selection();
     model->AddText(std::u16string({u'\n'}));
-    SendStateUpdate(*model);
+    if (enable_delta_model) {
+      TextEditingDelta delta =
+          TextEditingDelta(text_before_change, selection_before_change, text);
+      SendStateUpdateWithDelta(*active_model_, &delta);
+    } else {
+      SendStateUpdate(*model);
+    }
   }
   auto args = std::make_unique<rapidjson::Document>(rapidjson::kArrayType);
   auto& allocator = args->GetAllocator();

--- a/shell/platform/windows/text_input_plugin.cc
+++ b/shell/platform/windows/text_input_plugin.cc
@@ -447,8 +447,8 @@ void TextInputPlugin::SendStateUpdateWithDelta(const TextInputModel& model,
 void TextInputPlugin::EnterPressed(TextInputModel* model) {
   if (input_type_ == kMultilineInputType) {
     std::u16string text_before_change =
-        fml::Utf8ToUtf16(active_model_->GetText());
-    TextRange selection_before_change = active_model_->selection();
+        fml::Utf8ToUtf16(model->GetText());
+    TextRange selection_before_change = model->selection();
     model->AddText(std::u16string({u'\n'}));
     if (enable_delta_model) {
       TextEditingDelta delta(text_before_change, selection_before_change, u"\n");

--- a/shell/platform/windows/text_input_plugin.cc
+++ b/shell/platform/windows/text_input_plugin.cc
@@ -446,12 +446,12 @@ void TextInputPlugin::SendStateUpdateWithDelta(const TextInputModel& model,
 
 void TextInputPlugin::EnterPressed(TextInputModel* model) {
   if (input_type_ == kMultilineInputType) {
-    std::u16string text_before_change =
-        fml::Utf8ToUtf16(model->GetText());
+    std::u16string text_before_change = fml::Utf8ToUtf16(model->GetText());
     TextRange selection_before_change = model->selection();
     model->AddText(std::u16string({u'\n'}));
     if (enable_delta_model) {
-      TextEditingDelta delta(text_before_change, selection_before_change, u"\n");
+      TextEditingDelta delta(text_before_change, selection_before_change,
+                             u"\n");
       SendStateUpdateWithDelta(*model, &delta);
     } else {
       SendStateUpdate(*model);

--- a/shell/platform/windows/text_input_plugin.cc
+++ b/shell/platform/windows/text_input_plugin.cc
@@ -446,8 +446,8 @@ void TextInputPlugin::SendStateUpdateWithDelta(const TextInputModel& model,
 
 void TextInputPlugin::EnterPressed(TextInputModel* model) {
   if (input_type_ == kMultilineInputType) {
-    std::string text_before_change = active_model_->GetText();
-    std::string text = "\n";
+    std::u16string text_before_change = fml::Utf8ToUtf16(active_model_->GetText());
+    std::u16string text = std::u16string({u'\n'});
     TextRange selection_before_change = active_model_->selection();
     model->AddText(std::u16string({u'\n'}));
     if (enable_delta_model) {


### PR DESCRIPTION
This PR fixes an issue where entering a newline would not register on Windows when `enable_delta_model` is set to `true`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.