### PR TITLE
ios text input plugin ignores selection calls when interactive selection is disabled

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -52,6 +52,7 @@ static NSString* const kKeyboardType = @"inputType";
 static NSString* const kKeyboardAppearance = @"keyboardAppearance";
 static NSString* const kInputAction = @"inputAction";
 static NSString* const kEnableDeltaModel = @"enableDeltaModel";
+static NSString* const kEnableInteractiveSelection = @"enableInteractiveSelection";
 
 static NSString* const kSmartDashesType = @"smartDashesType";
 static NSString* const kSmartQuotesType = @"smartQuotesType";
@@ -732,6 +733,7 @@ static BOOL IsSelectionRectCloserToPoint(CGPoint point,
   // The view has reached end of life, and is no longer
   // allowed to access its textInputDelegate.
   BOOL _decommissioned;
+  bool _enableInteractiveSelection;
 }
 
 @synthesize tokenizer = _tokenizer;
@@ -765,6 +767,7 @@ static BOOL IsSelectionRectCloserToPoint(CGPoint point,
     _returnKeyType = UIReturnKeyDone;
     _secureTextEntry = NO;
     _enableDeltaModel = NO;
+    _enableInteractiveSelection = YES;
     _accessibilityEnabled = NO;
     _decommissioned = NO;
     if (@available(iOS 11.0, *)) {
@@ -796,7 +799,7 @@ static BOOL IsSelectionRectCloserToPoint(CGPoint point,
   self.keyboardType = ToUIKeyboardType(inputType);
   self.returnKeyType = ToUIReturnKeyType(configuration[kInputAction]);
   self.autocapitalizationType = ToUITextAutoCapitalizationType(configuration);
-
+  _enableInteractiveSelection = [configuration[kEnableInteractiveSelection] boolValue];
   if (@available(iOS 11.0, *)) {
     NSString* smartDashesType = configuration[kSmartDashesType];
     // This index comes from the SmartDashesType enum in the framework.
@@ -1115,6 +1118,10 @@ static BOOL IsSelectionRectCloserToPoint(CGPoint point,
 }
 
 - (void)setSelectedTextRange:(UITextRange*)selectedTextRange {
+  if (!_enableInteractiveSelection) {
+    return;
+  }
+
   [self setSelectedTextRangeLocal:selectedTextRange];
 
   if (_enableDeltaModel) {
@@ -1740,7 +1747,6 @@ static BOOL IsSelectionRectCloserToPoint(CGPoint point,
     composingBase = ((FlutterTextPosition*)self.markedTextRange.start).index;
     composingExtent = ((FlutterTextPosition*)self.markedTextRange.end).index;
   }
-
   NSDictionary* state = @{
     @"selectionBase" : @(selectionBase),
     @"selectionExtent" : @(selectionExtent),

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -270,7 +270,7 @@ FLUTTER_ASSERT_ARC
                                 withClient:0]);
 }
 
-- (void)testIngoresSelectionChangeIfselectionIsDisabled {
+- (void)testIngoresSelectionChangeIfSelectionIsDisabled {
   FlutterTextInputView* inputView = [[FlutterTextInputView alloc] initWithOwner:textInputPlugin];
   __block int updateCount = 0;
   OCMStub([engine flutterTextInputView:inputView updateEditingClient:0 withState:[OCMArg isNotNil]])

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -25,7 +25,7 @@ FLUTTER_ASSERT_ARC
 - (void)updateEditingState;
 - (BOOL)isVisibleToAutofill;
 - (id<FlutterTextInputDelegate>)textInputDelegate;
-
+- (void)configureWithDictionary:(NSDictionary*)configuration;
 @end
 
 @interface FlutterTextInputViewSpy : FlutterTextInputView
@@ -139,7 +139,8 @@ FLUTTER_ASSERT_ARC
       @"inputAction" : @"TextInputAction.unspecified",
       @"smartDashesType" : @"0",
       @"smartQuotesType" : @"0",
-      @"autocorrect" : @YES
+      @"autocorrect" : @YES,
+      @"enableInteractiveSelection" : @YES,
     };
   }
 
@@ -267,6 +268,34 @@ FLUTTER_ASSERT_ARC
       showAutocorrectionPromptRectForStart:0
                                        end:1
                                 withClient:0]);
+}
+
+- (void)testIngoresSelectionChangeIfselectionIsDisabled {
+  FlutterTextInputView* inputView = [[FlutterTextInputView alloc] initWithOwner:textInputPlugin];
+  __block int updateCount = 0;
+  OCMStub([engine flutterTextInputView:inputView updateEditingClient:0 withState:[OCMArg isNotNil]])
+      .andDo(^(NSInvocation* invocation) {
+        updateCount++;
+      });
+
+  [inputView.text setString:@"Some initial text"];
+  XCTAssertEqual(updateCount, 0);
+
+  FlutterTextRange* textRange = [FlutterTextRange rangeWithNSRange:NSMakeRange(0, 1)];
+  [inputView setSelectedTextRange:textRange];
+  XCTAssertEqual(updateCount, 1);
+
+  // Disable the interactive selection.
+  NSDictionary* config = self.mutableTemplateCopy;
+  [config setValue:@(NO) forKey:@"enableInteractiveSelection"];
+  [config setValue:@(NO) forKey:@"obscureText"];
+  [config setValue:@(NO) forKey:@"enableDeltaModel"];
+  [inputView configureWithDictionary:config];
+
+  textRange = [FlutterTextRange rangeWithNSRange:NSMakeRange(2, 3)];
+  [inputView setSelectedTextRange:textRange];
+  // The update count does not change.
+  XCTAssertEqual(updateCount, 1);
 }
 
 - (void)testAutocorrectionPromptRectDoesNotAppearDuringScribble {


### PR DESCRIPTION
requires https://github.com/flutter/flutter/pull/100649

fixes https://github.com/flutter/flutter/issues/99284

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
