### PR TITLE
[Linux, Keyboard] Convert duplicate down events to repeat events 

### DIFF
--- a/shell/platform/linux/fl_key_embedder_responder.cc
+++ b/shell/platform/linux/fl_key_embedder_responder.cc
@@ -752,16 +752,13 @@ static void fl_key_embedder_responder_handle_event_impl(
   if (is_down_event) {
     if (last_logical_record) {
       // A key has been pressed that has the exact physical key as a currently
-      // pressed one, usually indicating multiple keyboards are pressing keys
-      // with the same physical key, or the up event was lost during a loss of
-      // focus. The down event is ignored.
-      callback(true, user_data);
-      return;
+      // pressed one. This can happen during repeated events.
+      out_event.type = kFlutterKeyEventTypeRepeat;
     } else {
       out_event.type = kFlutterKeyEventTypeDown;
-      character_to_free = event_to_character(event);  // Might be null
-      out_event.character = character_to_free;
     }
+    character_to_free = event_to_character(event);  // Might be null
+    out_event.character = character_to_free;
   } else {  // is_down_event false
     if (!last_logical_record) {
       // The physical key has been released before. It might indicate a missed


### PR DESCRIPTION
With this PR, if a down event is observed for an already pressed key, this down event will be converted to a key repeat event instead of being ignored.

GTK's key event only has 2 types, down and up, and has no "isRepeat" flags. In my previous tests, holding a key sends repeated "down-up" pairs, but during my latest tests, it becomes multiple down events followed by an up. The current implementation causes such behavior to ignore repeats. This PR fixes this problem.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
