### PR TITLE
[web] Correct text baseline when rendering to DOM

### DIFF
--- a/lib/web_ui/lib/src/engine/text/canvas_paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/canvas_paragraph.dart
@@ -258,7 +258,9 @@ void _positionSpanElement(html.Element element, EngineLineMetrics line, RangeBox
     ..top = '${boxRect.top}px'
     ..left = '${boxRect.left}px'
     // This is needed for space-only spans that are used to justify the paragraph.
-    ..width = '${boxRect.width}px';
+    ..width = '${boxRect.width}px'
+    // Makes sure the baseline of each span is positioned as expected.
+    ..lineHeight = '${boxRect.height}px';
 }
 
 /// A common interface for all types of spans that make up a paragraph.

--- a/lib/web_ui/lib/src/engine/text/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/paragraph.dart
@@ -699,9 +699,6 @@ void applyTextStyleToElement({
   if (background != null) {
     cssStyle.backgroundColor = colorToCssString(background);
   }
-  if (style.height != null) {
-    cssStyle.lineHeight = '${style.height}';
-  }
   final double? fontSize = style.fontSize;
   if (fontSize != null) {
     cssStyle.fontSize = '${fontSize.floor()}px';

--- a/lib/web_ui/test/text/canvas_paragraph_builder_test.dart
+++ b/lib/web_ui/test/text/canvas_paragraph_builder_test.dart
@@ -168,7 +168,7 @@ Future<void> testMain() async {
     expectOuterHtml(
       paragraph,
       '<flt-paragraph style="${paragraphStyle()}">'
-      '<flt-span style="${spanStyle(top: 0, left: 0, width: (9+2)*5, lineHeight: 1.5, fontSize: 9, fontWeight: 'bold', fontStyle: 'italic', letterSpacing: 2)}">'
+      '<flt-span style="${spanStyle(top: 0, left: 0, width: (9+2)*5, lineHeight: 1.5*9, fontSize: 9, fontWeight: 'bold', fontStyle: 'italic', letterSpacing: 2)}">'
       'Hello'
       '</flt-span>'
       '</flt-paragraph>',
@@ -280,7 +280,7 @@ Future<void> testMain() async {
     expectOuterHtml(
       paragraph,
       '<flt-paragraph style="${paragraphStyle()}">'
-      '<flt-span style="${spanStyle(top: 0, left: 0, width: 13*5, lineHeight: 2, fontSize: 13, fontWeight: 'bold')}">'
+      '<flt-span style="${spanStyle(top: 0, left: 0, width: 13*5, lineHeight: 2*13, fontSize: 13, fontWeight: 'bold')}">'
       'Hello'
       '</flt-span>'
       '<flt-span style="${spanStyle(top: 6, left: 65, width: 13*1, fontSize: 13, fontWeight: 'bold', fontStyle: 'italic')}">'
@@ -458,7 +458,6 @@ String spanStyle({
 }) {
   return <String>[
     'color: rgb(255, 0, 0);',
-    if (lineHeight != null) 'line-height: $lineHeight;',
     'font-size: ${fontSize}px;',
     if (fontWeight != null) 'font-weight: $fontWeight;',
     if (fontStyle != null) 'font-style: $fontStyle;',
@@ -468,6 +467,7 @@ String spanStyle({
     if (top != null) 'top: ${top}px;',
     if (left != null) 'left: ${left}px;',
     if (width != null) 'width: ${width}px;',
+    'line-height: ${lineHeight ?? fontSize}px;',
   ].join(' ');
 }
 
@@ -494,19 +494,23 @@ TextStyle styleWithDefaults({
 void expectOuterHtml(CanvasParagraph paragraph, String expected, {required bool ignorePositions}) {
   String outerHtml = paragraph.toDomElement().outerHtml!;
   if (ignorePositions) {
-    outerHtml = removePositionInfo(outerHtml);
-    expected = removePositionInfo(expected);
+    outerHtml = removeMeasurementInfo(outerHtml);
+    expected = removeMeasurementInfo(expected);
   }
 
   expect(outerHtml, expected);
 }
 
-/// Removes "top" and "left" CSS styles from the given html string.
+/// Removes CSS styles that are based on text measurement from the given html
+/// string.
 ///
-/// This is needed when the positioning information in the html output is
-/// unknown and could be different depending on browser and environment.
-String removePositionInfo(String outerHtml) {
+/// Examples: top, left, line-height, width.
+///
+/// This is needed when the measurement is unknown or could be different
+/// depending on browser and environment.
+String removeMeasurementInfo(String outerHtml) {
   return outerHtml
+      .replaceAll(RegExp(r'\s*line-height:\s*[\d\.]+px\s*;\s*'), '')
       .replaceAll(RegExp(r'\s*width:\s*[\d\.]+px\s*;\s*'), '')
       .replaceAll(RegExp(r'\s*top:\s*[\d\.]+px\s*;\s*'), '')
       .replaceAll(RegExp(r'\s*left:\s*[\d\.]+px\s*;\s*'), '');


### PR DESCRIPTION
With certain international languages (e.g. Hindi, Arabic), the DOM could apply a different baseline than what we measured. In order to fix this, we set a specific `line-height` on each span so the text is vertically positioned according to our text layout, instead of browser's text layout.

Here's the issue being fixed:
![line height issue](https://user-images.githubusercontent.com/1278212/160452793-1b016cd1-5e05-48ea-9db3-ae4c62c54c2b.png)
Notice the English text is on the same vertical position in canvas and DOM, while the Hindi text is shifted downwards in DOM.
