### PR TITLE
[macOS, Keyboard] Channel responder calls callback on duplicate modifiers

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterChannelKeyResponder.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterChannelKeyResponder.mm
@@ -57,11 +57,14 @@
       } else {
         // ignore duplicate modifiers; This can happen in situations like switching
         // between application windows when MacOS only sends the up event to new window.
+        callback(true);
         return;
       }
       break;
-    default:
+    default: {
       NSAssert(false, @"Unexpected key event type (got %lu).", event.type);
+      callback(false);
+    }
   }
   _previouslyPressedFlags = modifierFlags;
   NSMutableDictionary* keyMessage = [@{

--- a/shell/platform/darwin/macos/framework/Source/FlutterChannelKeyResponderUnittests.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterChannelKeyResponderUnittests.mm
@@ -56,7 +56,8 @@ TEST(FlutterChannelKeyResponderUnittests, BasicKeyEvent) {
       [[FlutterChannelKeyResponder alloc] initWithChannel:mockKeyEventChannel];
 
   // Initial empty modifiers. This can happen when user opens window while modifier key is pressed
-  // and then releases the modifier. Shouldn't result in an event being sent.
+  // and then releases the modifier. No events should be sent, but the callback
+  // should still be called.
   // Regression test for https://github.com/flutter/flutter/issues/87339.
   [responder handleEvent:keyEvent(NSEventTypeFlagsChanged, 0x100, @"", @"", FALSE, 60)
                 callback:^(BOOL handled) {
@@ -64,6 +65,9 @@ TEST(FlutterChannelKeyResponderUnittests, BasicKeyEvent) {
                 }];
 
   EXPECT_EQ([messages count], 0u);
+  EXPECT_EQ([responses count], 1u);
+  EXPECT_EQ([responses[0] boolValue], TRUE);
+  [responses removeAllObjects];
 
   // Key down
   [responder handleEvent:keyEvent(NSEventTypeKeyDown, 0x100, @"a", @"a", FALSE, 0)
@@ -182,7 +186,8 @@ TEST(FlutterChannelKeyResponderUnittests, BasicKeyEvent) {
   [messages removeAllObjects];
   [responses removeAllObjects];
 
-  // RShift up again, should be ignored and not produce a keydown event.
+  // RShift up again, should be ignored and not produce a keydown event, but the
+  // callback should be called.
   next_response = false;
   [responder handleEvent:keyEvent(NSEventTypeFlagsChanged, 0x100, @"", @"", FALSE, 60)
                 callback:^(BOOL handled) {
@@ -190,7 +195,8 @@ TEST(FlutterChannelKeyResponderUnittests, BasicKeyEvent) {
                 }];
 
   EXPECT_EQ([messages count], 0u);
-  EXPECT_EQ([responses count], 0u);
+  EXPECT_EQ([responses count], 1u);
+  EXPECT_EQ([responses[0] boolValue], TRUE);
 }
 
 TEST(FlutterChannelKeyResponderUnittests, EmptyResponseIsTakenAsHandled) {


### PR DESCRIPTION
This PR fixes an issue described in https://github.com/flutter/flutter/issues/82673#issuecomment-1080319357 where keyboard on macOS might stop working after switching apps. It fixes a case where the channel responder does not call the reply callback. 

The reply callback should always be called. This issue was not significant until [the recent change](https://github.com/flutter/engine/pull/32120) that queues up key events, so that any unreplied key event will stall future events.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
