### PR TITLE
[web] small felt fixes in compile and run sub-commands

### DIFF
--- a/lib/web_ui/dev/steps/compile_tests_step.dart
+++ b/lib/web_ui/dev/steps/compile_tests_step.dart
@@ -212,7 +212,7 @@ Future<void> compileTests(List<FilePath> testFiles) async {
 }
 
 // Maximum number of concurrent dart2js processes to use.
-const int _dart2jsConcurrency = int.fromEnvironment('FELT_DART2JS_CONCURRENCY', defaultValue: 8);
+int _dart2jsConcurrency = int.parse(io.Platform.environment['FELT_DART2JS_CONCURRENCY'] ?? '8');
 
 final Pool _dart2jsPool = Pool(_dart2jsConcurrency);
 

--- a/lib/web_ui/dev/steps/run_tests_step.dart
+++ b/lib/web_ui/dev/steps/run_tests_step.dart
@@ -51,17 +51,6 @@ class RunTestsStep implements PipelineStep {
 
   final BrowserEnvironment _browserEnvironment;
 
-  /// Global list of shards that failed.
-  ///
-  /// This is used to make sure that when there's a test failure anywhere we
-  /// exit with a non-zero exit code.
-  ///
-  /// Shards must never be removed from this list, only added.
-  List<String> failedShards = <String>[];
-
-  /// Whether all test shards succeeded.
-  bool get allShardsPassed => failedShards.isEmpty;
-
   @override
   String get description => 'run_tests';
 
@@ -88,27 +77,10 @@ class RunTestsStep implements PipelineStep {
       skiaClient: skiaClient,
       overridePathToCanvasKit: overridePathToCanvasKit,
     );
-    _checkExitCode('Unit tests');
 
-    if (!allShardsPassed) {
-      throw ToolExit(_createFailedShardsMessage());
-    }
-  }
-
-  void _checkExitCode(String shard) {
     if (io.exitCode != 0) {
-      failedShards.add(shard);
+      throw ToolExit('Some tests failed');
     }
-  }
-
-  String _createFailedShardsMessage() {
-    final StringBuffer message = StringBuffer(
-      'The following test shards failed:\n',
-    );
-    for (final String failedShard in failedShards) {
-      message.writeln(' - $failedShard');
-    }
-    return message.toString();
   }
 
   Future<SkiaGoldClient?> _createSkiaClient() async {


### PR DESCRIPTION
A couple of small felt fixes:

* Read `FELT_DART2JS_CONCURRENCY` dynamically so that the value can be changed when using `felt` snapshot (otherwise the constant gets compiled into the binary).
* Remove "shards" from `run_tests_step.dart` as we don't have shards, and are unlikely to have them (instead of adding shard into a `felt run` step, we should just add more run steps).