### PR TITLE
[web] Make "felt build" wait for both engine and canvaskit builds

### DIFF
--- a/lib/web_ui/dev/build.dart
+++ b/lib/web_ui/dev/build.dart
@@ -133,7 +133,7 @@ class NinjaPipelineStep extends ProcessStep {
       'autoninja',
       <String>[
         '-C',
-        environment.hostDebugUnoptDir.path,
+        target.path,
       ],
     );
   }

--- a/lib/web_ui/dev/build.dart
+++ b/lib/web_ui/dev/build.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io' show Platform;
+import 'dart:io' show Directory, Platform;
 
 import 'package:args/command_runner.dart';
 import 'package:path/path.dart' as path;
@@ -43,10 +43,17 @@ class BuildCommand extends Command<bool> with ArgUtils<bool> {
   @override
   FutureOr<bool> run() async {
     final FilePath libPath = FilePath.fromWebUi('lib');
-    final Pipeline buildPipeline = Pipeline(steps: <PipelineStep>[
-      GnPipelineStep(buildCanvasKit),
-      NinjaPipelineStep(buildCanvasKit),
-    ]);
+    final List<PipelineStep> steps = <PipelineStep>[
+      GnPipelineStep(target: 'engine'),
+      NinjaPipelineStep(target: environment.hostDebugUnoptDir),
+    ];
+    if (buildCanvasKit) {
+      steps.addAll(<PipelineStep>[
+        GnPipelineStep(target: 'canvaskit'),
+        NinjaPipelineStep(target: environment.canvasKitOutDir),
+      ]);
+    }
+    final Pipeline buildPipeline = Pipeline(steps: steps);
     await buildPipeline.run();
 
     if (isWatchMode) {
@@ -68,7 +75,8 @@ class BuildCommand extends Command<bool> with ArgUtils<bool> {
 /// Not safe to interrupt as it may leave the `out/` directory in a corrupted
 /// state. GN is pretty quick though, so it's OK to not support interruption.
 class GnPipelineStep extends ProcessStep {
-  GnPipelineStep(this.buildCanvasKit);
+  GnPipelineStep({this.target = 'engine'})
+      : assert(target == 'engine' || target == 'sdk');
 
   @override
   String get description => 'gn';
@@ -76,31 +84,30 @@ class GnPipelineStep extends ProcessStep {
   @override
   bool get isSafeToInterrupt => false;
 
-  /// Whether or not to build CanvasKit.
-  final bool buildCanvasKit;
+  /// The target to build with gn.
+  ///
+  /// Acceptable values: engine, canvaskit
+  final String target;
 
   @override
   Future<ProcessManager> createProcess() {
     print('Running gn...');
-    Future<ProcessManager> gnProcess = startProcess(
-      path.join(environment.flutterDirectory.path, 'tools', 'gn'),
-      <String>[
+    final List<String> gnArgs = <String>[];
+    if (target == 'engine') {
+      gnArgs.addAll(<String>[
         '--unopt',
         if (Platform.isMacOS) '--xcode-symlinks',
         '--full-dart-sdk',
-      ],
-    );
-    if (buildCanvasKit) {
-      gnProcess = gnProcess.then((_) {
-        return startProcess(
-          path.join(environment.flutterDirectory.path, 'tools', 'gn'),
-          <String>[
-            '--wasm',
-          ],
-        );
-      });
+      ]);
+    } else if (target == 'canvaskit') {
+      gnArgs.add('--wasm');
+    } else {
+      throw StateError('Target was not engine or canvaskit: $target');
     }
-    return gnProcess;
+    return startProcess(
+      path.join(environment.flutterDirectory.path, 'tools', 'gn'),
+      gnArgs,
+    );
   }
 }
 
@@ -108,7 +115,7 @@ class GnPipelineStep extends ProcessStep {
 ///
 /// Can be safely interrupted.
 class NinjaPipelineStep extends ProcessStep {
-  NinjaPipelineStep(this.buildCanvasKit);
+  NinjaPipelineStep({required this.target});
 
   @override
   String get description => 'ninja';
@@ -116,30 +123,18 @@ class NinjaPipelineStep extends ProcessStep {
   @override
   bool get isSafeToInterrupt => true;
 
-  /// Whether or not to build CanvasKit.
-  final bool buildCanvasKit;
+  /// The target directory to build.
+  final Directory target;
 
   @override
   Future<ProcessManager> createProcess() {
     print('Running autoninja...');
-    Future<ProcessManager> ninjaProcess = startProcess(
+    return startProcess(
       'autoninja',
       <String>[
         '-C',
         environment.hostDebugUnoptDir.path,
       ],
     );
-    if (buildCanvasKit) {
-      ninjaProcess = ninjaProcess.then((_) {
-        return startProcess(
-          'autoninja',
-          <String>[
-            '-C',
-            environment.canvasKitOutDir.path,
-          ],
-        );
-      });
-    }
-    return ninjaProcess;
   }
 }


### PR DESCRIPTION
Refactors `felt build` so that it builds CanvasKit in its own pipeline steps. The way it's being done currently creates a race condition between the two builds.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
