### PR TITLE
Removed error log statement for dart plugin registrant.

### DIFF
--- a/runtime/dart_plugin_registrant.cc
+++ b/runtime/dart_plugin_registrant.cc
@@ -58,7 +58,6 @@ bool FindAndInvokeDartPluginRegistrant() {
   std::string registrant_file_uri_string =
       tonic::DartConverter<std::string>::FromDart(registrant_file_uri);
   if (registrant_file_uri_string.empty()) {
-    FML_LOG(ERROR) << "Unexpected empty dartPluginRegistrantLibrary.";
     return false;
   }
 


### PR DESCRIPTION
I was thinking this situation would be rare but it is actually common and not worth printing a log statement.  Situations where it may be printed:
1) Google 1p apps
1) Flutter apps that don't have any plugins that require the Dart Plugin Registrant.

fixes b/227291550

test exempt: Removing log statement.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
