### PR TITLE
[macOS] Generate gen_snapshot_$arch by default

### DIFF
--- a/build/archives/BUILD.gn
+++ b/build/archives/BUILD.gn
@@ -1,5 +1,4 @@
 import("//flutter/build/zip_bundle.gni")
-import("//flutter/sky/tools/macos_snapshots.gni")
 
 zip_bundle("artifacts") {
   deps = [
@@ -141,14 +140,8 @@ if (is_mac) {
     ]
   }
 
-  macos_gen_snapshots("create_macos_gen_snapshots") {
-    visibility = [ ":*" ]
-    deps = [ "//flutter/lib/snapshot:generate_snapshot_bins" ]
-    arch = "$target_cpu"
-  }
-
   zip_bundle("archive_gen_snapshot") {
-    deps = [ ":create_macos_gen_snapshots" ]
+    deps = [ "//flutter/lib/snapshot:create_macos_gen_snapshots" ]
     suffix = "-$flutter_runtime_mode"
     if (flutter_runtime_mode == "debug") {
       suffix = ""

--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -6,6 +6,7 @@ import("//build/compiled_action.gni")
 import("//build/fuchsia/sdk.gni")
 import("//flutter/common/config.gni")
 import("//flutter/lib/ui/dart_ui.gni")
+import("//flutter/sky/tools/macos_snapshots.gni")
 import("//third_party/dart/utils/compile_platform.gni")
 
 group("generate_snapshot_bins") {
@@ -15,6 +16,9 @@ group("generate_snapshot_bins") {
   ]
   if (host_os == "mac" && (target_cpu == "arm" || target_cpu == "arm64")) {
     deps += [ ":create_arm_gen_snapshot" ]
+  }
+  if (host_os == "mac" && target_os == "mac") {
+    deps += [ ":create_macos_gen_snapshots" ]
   }
 }
 
@@ -220,6 +224,13 @@ if (host_os == "mac" && (target_cpu == "arm" || target_cpu == "arm64")) {
       ]
       outputs = [ "$output_dir/gen_snapshot_arm64" ]
     }
+  }
+}
+
+if (host_os == "mac" && target_os == "mac") {
+  macos_gen_snapshots("create_macos_gen_snapshots") {
+    deps = [ ":generate_snapshot_bin" ]
+    arch = "$target_cpu"
   }
 }
 


### PR DESCRIPTION
Moves //flutter/build/archives:create_macos_gen_snapshots target to
//flutter/lib/snapshot:create_macos_gen_snapshots and makes it part of
the :generate_bin_snapshots target in that BUILD.gn file. This makes it
part of the default build.

When performing a Flutter build using the --local-engine option, the
flutter tool looks for the architecture-specific gen_snapshot name, as
it does with iOS builds. As such, we should be building the
architecture-specific gen_snapshot binary as part of the default build
for the given architecture.

Issue: https://github.com/flutter/flutter/issues/100804


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
