### PR TITLE
Sync accessibility flags in embedder.h

### DIFF
--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -209,6 +209,12 @@ typedef enum {
   /// `PageView` widget does not have implicit scrolling, so that users don't
   /// navigate to the next page when reaching the end of the current one.
   kFlutterSemanticsFlagHasImplicitScrolling = 1 << 18,
+  /// Whether the value of the semantics node is coming from a multi-line text
+  /// field.
+  ///
+  /// This is used for text fields to distinguish single-line text fields from
+  /// multi-line ones.
+  kFlutterSemanticsFlagIsMultiline = 1 << 19,
   /// Whether the semantic node is read only.
   ///
   /// Only applicable when kFlutterSemanticsFlagIsTextField flag is on.

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -92,8 +92,10 @@ typedef enum {
   /// Request that text be rendered at a bold font weight.
   kFlutterAccessibilityFeatureBoldText = 1 << 3,
   /// Request that certain animations be simplified and parallax effects
-  // removed.
+  /// removed.
   kFlutterAccessibilityFeatureReduceMotion = 1 << 4,
+  /// Request that UI be rendered with darker colors.
+  kFlutterAccessibilityFeatureHighContrast = 1 << 5,
 } FlutterAccessibilityFeature;
 
 /// The set of possible actions that can be conveyed to a semantics node.

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -96,6 +96,8 @@ typedef enum {
   kFlutterAccessibilityFeatureReduceMotion = 1 << 4,
   /// Request that UI be rendered with darker colors.
   kFlutterAccessibilityFeatureHighContrast = 1 << 5,
+  /// Request to show on/off labels inside switches.
+  kFlutterAccessibilityFeatureOnOffSwitchLabels = 1 << 6,
 } FlutterAccessibilityFeature;
 
 /// The set of possible actions that can be conveyed to a semantics node.

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -153,6 +153,8 @@ typedef enum {
   kFlutterSemanticsActionMoveCursorForwardByWord = 1 << 19,
   /// Move the cursor backward by one word.
   kFlutterSemanticsActionMoveCursorBackwardByWord = 1 << 20,
+  /// Replace the current text in the text field.
+  kFlutterSemanticsActionSetText = 1 << 21,
 } FlutterSemanticsAction;
 
 /// The set of properties that may be associated with a semantics node.


### PR DESCRIPTION
The following enum types in `embedder.h` must match with the corresponding Dart/C++ classes in `dart:ui` but some values are missing.

- `FlutterAccessibilityFeature`
- `FlutterSemanticsAction`
- `FlutterSemanticsFlag`

The comments say

https://github.com/flutter/engine/blob/2d29e2f3b5e4c951809eb7578ff5f114f91efbeb/shell/platform/embedder/embedder.h#L83

https://github.com/flutter/engine/blob/2d29e2f3b5e4c951809eb7578ff5f114f91efbeb/lib/ui/window.dart#L784-L785

No linked issue because the fix is trivial enough.
