### PR TITLE
 Reference canonical fuchsia.io constants

### DIFF
--- a/shell/platform/fuchsia/flutter/component_v1.cc
+++ b/shell/platform/fuchsia/flutter/component_v1.cc
@@ -196,9 +196,9 @@ ComponentV1::ComponentV1(
 
   // LaunchInfo::service_request optional.
   if (launch_info.directory_request) {
-    outgoing_dir_->Serve(fuchsia::io::OPEN_RIGHT_READABLE |
-                             fuchsia::io::OPEN_RIGHT_WRITABLE |
-                             fuchsia::io::OPEN_FLAG_DIRECTORY,
+    outgoing_dir_->Serve(fuchsia::io::OpenFlags::RIGHT_READABLE |
+                             fuchsia::io::OpenFlags::RIGHT_WRITABLE |
+                             fuchsia::io::OpenFlags::DIRECTORY,
                          std::move(launch_info.directory_request));
   }
 
@@ -216,9 +216,9 @@ ComponentV1::ComponentV1(
   composed_service_dir->set_fallback(std::move(flutter_public_dir));
 
   // Clone and check if client is servicing the directory.
-  directory_ptr_->Clone(fuchsia::io::OPEN_FLAG_DESCRIBE |
-                            fuchsia::io::OPEN_RIGHT_READABLE |
-                            fuchsia::io::OPEN_RIGHT_WRITABLE,
+  directory_ptr_->Clone(fuchsia::io::OpenFlags::DESCRIBE |
+                            fuchsia::io::OpenFlags::RIGHT_READABLE |
+                            fuchsia::io::OpenFlags::RIGHT_WRITABLE,
                         cloned_directory_ptr_.NewRequest());
 
   cloned_directory_ptr_.events().OnOpen =

--- a/shell/platform/fuchsia/flutter/component_v2.cc
+++ b/shell/platform/fuchsia/flutter/component_v2.cc
@@ -238,17 +238,17 @@ ComponentV2::ComponentV2(
 
   // ComponentStartInfo::runtime_dir (optional).
   if (start_info.has_runtime_dir()) {
-    runtime_dir_->Serve(fuchsia::io::OPEN_RIGHT_READABLE |
-                            fuchsia::io::OPEN_RIGHT_WRITABLE |
-                            fuchsia::io::OPEN_FLAG_DIRECTORY,
+    runtime_dir_->Serve(fuchsia::io::OpenFlags::RIGHT_READABLE |
+                            fuchsia::io::OpenFlags::RIGHT_WRITABLE |
+                            fuchsia::io::OpenFlags::DIRECTORY,
                         start_info.mutable_runtime_dir()->TakeChannel());
   }
 
   // ComponentStartInfo::outgoing_dir (optional).
   if (start_info.has_outgoing_dir()) {
-    outgoing_dir_->Serve(fuchsia::io::OPEN_RIGHT_READABLE |
-                             fuchsia::io::OPEN_RIGHT_WRITABLE |
-                             fuchsia::io::OPEN_FLAG_DIRECTORY,
+    outgoing_dir_->Serve(fuchsia::io::OpenFlags::RIGHT_READABLE |
+                             fuchsia::io::OpenFlags::RIGHT_WRITABLE |
+                             fuchsia::io::OpenFlags::DIRECTORY,
                          start_info.mutable_outgoing_dir()->TakeChannel());
   }
 
@@ -266,9 +266,9 @@ ComponentV2::ComponentV2(
   composed_service_dir->set_fallback(std::move(flutter_public_dir));
 
   // Clone and check if client is servicing the directory.
-  directory_ptr_->Clone(fuchsia::io::OPEN_FLAG_DESCRIBE |
-                            fuchsia::io::OPEN_RIGHT_READABLE |
-                            fuchsia::io::OPEN_RIGHT_WRITABLE,
+  directory_ptr_->Clone(fuchsia::io::OpenFlags::DESCRIBE |
+                            fuchsia::io::OpenFlags::RIGHT_READABLE |
+                            fuchsia::io::OpenFlags::RIGHT_WRITABLE,
                         cloned_directory_ptr_.NewRequest());
 
   // Collect our standard set of directories along with directories that are

--- a/shell/platform/fuchsia/flutter/file_in_namespace_buffer.cc
+++ b/shell/platform/fuchsia/flutter/file_in_namespace_buffer.cc
@@ -74,9 +74,9 @@ std::unique_ptr<fml::Mapping> LoadFile(int namespace_fd,
 
 std::unique_ptr<fml::FileMapping> MakeFileMapping(const char* path,
                                                   bool executable) {
-  auto flags = fuchsia::io::OPEN_RIGHT_READABLE;
+  auto flags = fuchsia::io::OpenFlags::RIGHT_READABLE;
   if (executable) {
-    flags |= fuchsia::io::OPEN_RIGHT_EXECUTABLE;
+    flags |= fuchsia::io::OpenFlags::RIGHT_EXECUTABLE;
   }
 
   // The returned file descriptor is compatible with standard posix operations

--- a/shell/platform/fuchsia/runtime/dart/utils/mapped_resource.cc
+++ b/shell/platform/fuchsia/runtime/dart/utils/mapped_resource.cc
@@ -109,17 +109,17 @@ static int OpenFdExec(const std::string& path, int dirfd) {
     // fdio_open_fd_at does not support AT_FDCWD, by design.  Use fdio_open_fd
     // and expect an absolute path for that usage pattern.
     dart_utils::Check(path[0] == '/', LOG_TAG);
-    result =
-        fdio_open_fd(path.c_str(),
-                     static_cast<uint32_t>(fuchsia::io::OPEN_RIGHT_READABLE |
-                                           fuchsia::io::OPEN_RIGHT_EXECUTABLE),
-                     &fd);
+    result = fdio_open_fd(
+        path.c_str(),
+        static_cast<uint32_t>(fuchsia::io::OpenFlags::RIGHT_READABLE |
+                              fuchsia::io::OpenFlags::RIGHT_EXECUTABLE),
+        &fd);
   } else {
     dart_utils::Check(path[0] != '/', LOG_TAG);
     result = fdio_open_fd_at(
         dirfd, path.c_str(),
-        static_cast<uint32_t>(fuchsia::io::OPEN_RIGHT_READABLE |
-                              fuchsia::io::OPEN_RIGHT_EXECUTABLE),
+        static_cast<uint32_t>(fuchsia::io::OpenFlags::RIGHT_READABLE |
+                              fuchsia::io::OpenFlags::RIGHT_EXECUTABLE),
         &fd);
   }
   if (result != ZX_OK) {

--- a/shell/platform/fuchsia/runtime/dart/utils/vmo.cc
+++ b/shell/platform/fuchsia/runtime/dart/utils/vmo.cc
@@ -59,9 +59,9 @@ bool VmoFromFilename(const std::string& filename,
   // Note: the implementation here cannot be shared with VmoFromFilenameAt
   // because fdio_open_fd_at does not aim to provide POSIX compatibility, and
   // thus does not handle AT_FDCWD as dirfd.
-  auto flags = fuchsia::io::OPEN_RIGHT_READABLE;
+  auto flags = fuchsia::io::OpenFlags::RIGHT_READABLE;
   if (executable) {
-    flags |= fuchsia::io::OPEN_RIGHT_EXECUTABLE;
+    flags |= fuchsia::io::OpenFlags::RIGHT_EXECUTABLE;
   }
 
   int fd;
@@ -81,9 +81,9 @@ bool VmoFromFilenameAt(int dirfd,
                        const std::string& filename,
                        bool executable,
                        fuchsia::mem::Buffer* buffer) {
-  auto flags = fuchsia::io::OPEN_RIGHT_READABLE;
+  auto flags = fuchsia::io::OpenFlags::RIGHT_READABLE;
   if (executable) {
-    flags |= fuchsia::io::OPEN_RIGHT_EXECUTABLE;
+    flags |= fuchsia::io::OpenFlags::RIGHT_EXECUTABLE;
   }
 
   int fd;


### PR DESCRIPTION
 These aliases are in the process of being removed.

This requires https://fuchsia-review.googlesource.com/c/fuchsia/+/661784 to have been pulled in via SDK roll; I believe that to have already happened.

This is a follow-up to #32250.

@chinmaygarde @arbreng 