### PR TITLE
Revert "[ci.yaml] Test web engine on Mac 12"

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -308,12 +308,19 @@ targets:
       caches: >-
         [
           {"name":"flutter_cocoapods","path":"cocoapods"},
+          {"name":"old_osx_sdk","path":"osx_sdk"},
+          {"name":"builder_mac_engine","path":"builder"},
           {"name":"openjdk","path":"java"}
         ]
       dependencies: >-
         [
           {"dependency": "goldctl"}
         ]
+      os: Mac-10.15
+      runtime_versions: >-
+        [
+        ]
+      xcode: 12c33 # xcode 12.3
     timeout: 60
     runIf:
       - DEPS


### PR DESCRIPTION
Reverts flutter/engine#32337

The Mac Web Engine is timing out: https://ci.chromium.org/ui/p/flutter/builders/prod/Mac%20Web%20Engine/9556/overview

Context: https://github.com/flutter/flutter/issues/97303