### PR TITLE
Macos deltas composing fix

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -570,19 +570,22 @@ static flutter::TextRange RangeFromBaseExtent(NSNumber* base,
   }
 
   flutter::TextRange oldSelection = _activeModel->selection();
+  flutter::TextRange composingBeforeChange = _activeModel->composing_range();
+  flutter::TextRange replacedRange(-1,-1);
 
   std::string textBeforeChange = _activeModel->GetText().c_str();
   std::string utf8String = [string UTF8String];
   _activeModel->AddText(utf8String);
   if (_activeModel->composing()) {
+    replacedRange = composingBeforeChange;
     _activeModel->CommitComposing();
     _activeModel->EndComposing();
+  } else {
+    replacedRange = range.location == NSNotFound
+              ? flutter::TextRange(oldSelection.base(), oldSelection.extent())
+              : flutter::TextRange(range.location, range.location + range.length);
   }
   if (_enableDeltaModel) {
-    flutter::TextRange replacedRange =
-        range.location == NSNotFound
-            ? flutter::TextRange(oldSelection.base(), oldSelection.extent())
-            : flutter::TextRange(range.location, range.location + range.length);
     [self updateEditStateWithDelta:flutter::TextEditingDelta(textBeforeChange, replacedRange,
                                                              utf8String)];
   } else {
@@ -625,6 +628,7 @@ static flutter::TextRange RangeFromBaseExtent(NSNumber* base,
   if (!_activeModel->composing()) {
     _activeModel->BeginComposing();
   }
+  flutter::TextRange composingBeforeChange = _activeModel->composing_range();
 
   // Input string may be NSString or NSAttributedString.
   BOOL isAttributedString = [string isKindOfClass:[NSAttributedString class]];
@@ -641,8 +645,7 @@ static flutter::TextRange RangeFromBaseExtent(NSNumber* base,
   _activeModel->SetSelection(flutter::TextRange(base, extent));
 
   if (_enableDeltaModel) {
-    flutter::TextRange composing = _activeModel->composing_range();
-    [self updateEditStateWithDelta:flutter::TextEditingDelta(textBeforeChange, composing,
+    [self updateEditStateWithDelta:flutter::TextEditingDelta(textBeforeChange, composingBeforeChange,
                                                              marked_text)];
   } else {
     [self updateEditState];

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -571,7 +571,7 @@ static flutter::TextRange RangeFromBaseExtent(NSNumber* base,
 
   flutter::TextRange oldSelection = _activeModel->selection();
   flutter::TextRange composingBeforeChange = _activeModel->composing_range();
-  flutter::TextRange replacedRange(-1,-1);
+  flutter::TextRange replacedRange(-1, -1);
 
   std::string textBeforeChange = _activeModel->GetText().c_str();
   std::string utf8String = [string UTF8String];
@@ -582,8 +582,8 @@ static flutter::TextRange RangeFromBaseExtent(NSNumber* base,
     _activeModel->EndComposing();
   } else {
     replacedRange = range.location == NSNotFound
-              ? flutter::TextRange(oldSelection.base(), oldSelection.extent())
-              : flutter::TextRange(range.location, range.location + range.length);
+                        ? flutter::TextRange(oldSelection.base(), oldSelection.extent())
+                        : flutter::TextRange(range.location, range.location + range.length);
   }
   if (_enableDeltaModel) {
     [self updateEditStateWithDelta:flutter::TextEditingDelta(textBeforeChange, replacedRange,
@@ -645,8 +645,8 @@ static flutter::TextRange RangeFromBaseExtent(NSNumber* base,
   _activeModel->SetSelection(flutter::TextRange(base, extent));
 
   if (_enableDeltaModel) {
-    [self updateEditStateWithDelta:flutter::TextEditingDelta(textBeforeChange, composingBeforeChange,
-                                                             marked_text)];
+    [self updateEditStateWithDelta:flutter::TextEditingDelta(textBeforeChange,
+                                                             composingBeforeChange, marked_text)];
   } else {
     [self updateEditState];
   }


### PR DESCRIPTION
This fixes an issue where the incorrect composing region was sent as a delta to the framework, causing no delta to be created on the framework side because the offset did not exist. Sending the correct composing region also fixes inserting of special characters with opt+n / opt+u

Fixes flutter/flutter#101013

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.