### PR TITLE
[Linux] Make unit tests abort on critical errors, and fix two such errors

### DIFF
--- a/shell/platform/linux/fl_dart_project_test.cc
+++ b/shell/platform/linux/fl_dart_project_test.cc
@@ -44,7 +44,7 @@ TEST(FlDartProjectTest, DartEntrypointArgs) {
   char** retrieved_args =
       fl_dart_project_get_dart_entrypoint_arguments(project);
 
-  EXPECT_EQ(g_strv_length(retrieved_args), 0U);
+  EXPECT_EQ(retrieved_args, nullptr);
 
   GPtrArray* args_array = g_ptr_array_new();
   g_ptr_array_add(args_array, const_cast<char*>("arg_one"));

--- a/shell/platform/linux/fl_engine_test.cc
+++ b/shell/platform/linux/fl_engine_test.cc
@@ -240,7 +240,7 @@ void on_pre_engine_restart_destroy_notify(gpointer user_data) {
 
 // Checks restarting the engine invokes the correct callback.
 TEST(FlEngineTest, OnPreEngineRestart) {
-  g_autoptr(FlEngine) engine = make_mock_engine();
+  FlEngine* engine = make_mock_engine();
   FlutterEngineProcTable* embedder_api = fl_engine_get_embedder_api(engine);
 
   OnPreEngineRestartCallback callback;
@@ -271,7 +271,10 @@ TEST(FlEngineTest, OnPreEngineRestart) {
 
   int count = 0;
 
-  // Set a handler, and the call should has an effect.
+  // Set handler so that:
+  //
+  //  * When the engine restarts, count += 1;
+  //  * When the engine is freed, count += 10.
   fl_engine_set_on_pre_engine_restart_handler(
       engine, on_pre_engine_restart_cb, &count,
       on_pre_engine_restart_destroy_notify);

--- a/shell/platform/linux/fl_key_embedder_responder.cc
+++ b/shell/platform/linux/fl_key_embedder_responder.cc
@@ -766,7 +766,9 @@ static void fl_key_embedder_responder_handle_event_impl(
     }
   }
 
-  update_pressing_state(self, physical_key, is_down_event ? logical_key : 0);
+  if (out_event.type != kFlutterKeyEventTypeRepeat) {
+    update_pressing_state(self, physical_key, is_down_event ? logical_key : 0);
+  }
   possibly_update_lock_bit(self, logical_key, is_down_event);
   if (is_down_event) {
     update_mapping_record(self, physical_key, logical_key);

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -139,9 +139,7 @@ def RunEngineExecutable(build_dir, executable_name, filter, flags=[],
   if not env:
     env = os.environ.copy()
   env['FLUTTER_BUILD_DIRECTORY'] = build_dir
-  for key, value in extra_env.items():
-    env[key] = value
-  print(env)
+  env |= extra_env
 
   try:
     RunCmd(test_command, cwd=cwd, forbidden_output=forbidden_output, expect_failure=expect_failure, env=env)

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -139,8 +139,9 @@ def RunEngineExecutable(build_dir, executable_name, filter, flags=[],
   if not env:
     env = os.environ.copy()
   env['FLUTTER_BUILD_DIRECTORY'] = build_dir
-  for key, value in extra_env:
+  for key, value in extra_env.items():
     env[key] = value
+  print(env)
 
   try:
     RunCmd(test_command, cwd=cwd, forbidden_output=forbidden_output, expect_failure=expect_failure, env=env)

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -139,7 +139,8 @@ def RunEngineExecutable(build_dir, executable_name, filter, flags=[],
   if not env:
     env = os.environ.copy()
   env['FLUTTER_BUILD_DIRECTORY'] = build_dir
-  env |= extra_env
+  for key, value in extra_env.items():
+    env[key] = value
 
   try:
     RunCmd(test_command, cwd=cwd, forbidden_output=forbidden_output, expect_failure=expect_failure, env=env)

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -106,7 +106,8 @@ def FindExecutablePath(path):
 
 
 def RunEngineExecutable(build_dir, executable_name, filter, flags=[],
-                        cwd=buildroot_dir, forbidden_output=[], expect_failure=False, coverage=False):
+                        cwd=buildroot_dir, forbidden_output=[], expect_failure=False, coverage=False,
+                        extra_env={}):
   if filter is not None and executable_name not in filter:
     print('Skipping %s due to filter.' % executable_name)
     return
@@ -138,6 +139,8 @@ def RunEngineExecutable(build_dir, executable_name, filter, flags=[],
   if not env:
     env = os.environ.copy()
   env['FLUTTER_BUILD_DIRECTORY'] = build_dir
+  for key, value in extra_env:
+    env[key] = value
 
   try:
     RunCmd(test_command, cwd=cwd, forbidden_output=forbidden_output, expect_failure=expect_failure, env=env)
@@ -238,7 +241,9 @@ def RunCCTests(build_dir, filter, coverage, capture_core_dump):
     RunEngineExecutable(build_dir, 'txt_unittests', filter, icu_flags + shuffle_flags, coverage=coverage)
 
   if IsLinux():
-    RunEngineExecutable(build_dir, 'flutter_linux_unittests', filter, shuffle_flags, coverage=coverage)
+    gtk_flags = ['--icu-data-file-path=%s' % os.path.join(build_dir, 'icudtl.dat')]
+    RunEngineExecutable(build_dir, 'flutter_linux_unittests', filter, shuffle_flags, coverage=coverage,
+                        extra_env={'G_DEBUG': 'fatal-criticals'})
     RunEngineExecutable(build_dir, 'flutter_glfw_unittests', filter, shuffle_flags, coverage=coverage)
 
   # Impeller tests are only supported on macOS for now.


### PR DESCRIPTION
This PR makes GTK unit tests abort on GTK critical errors. This including GTK internal errors and `g_return_if_fail` statements added by Flutter. This PR also fixes three such critical errors that have been ignored.

These `g_return_if_fail` statements have been used as (and practically are) the GTK version of `assert`s. However, currently these statements only logs to stderr, while the process goes on with a return value 0, making them pretty much ignored.

I've tried to look for a way to only return a non-zero value instead of aborting, but in vain.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
