### PR TITLE
[Linux, Keyboard] Make keyboard tests use unique_ptr and vector

### DIFF
--- a/shell/platform/linux/fl_keyboard_manager.cc
+++ b/shell/platform/linux/fl_keyboard_manager.cc
@@ -373,8 +373,6 @@ static void dispatch_to_responder(gpointer responder_data,
 
 gboolean fl_keyboard_manager_handle_event(FlKeyboardManager* self,
                                           FlKeyEvent* event) {
-  printf("handle\n");
-  fflush(stdout);
   g_return_val_if_fail(FL_IS_KEYBOARD_MANAGER(self), FALSE);
   g_return_val_if_fail(event != nullptr, FALSE);
 

--- a/shell/platform/linux/fl_keyboard_manager.cc
+++ b/shell/platform/linux/fl_keyboard_manager.cc
@@ -28,7 +28,7 @@ struct _FlKeyboardPendingEvent {
   // The target event.
   //
   // This is freed by #FlKeyboardPendingEvent.
-  FlKeyEvent* event;
+  std::unique_ptr<FlKeyEvent> event;
 
   // Self-incrementing ID attached to an event sent to the framework.
   //
@@ -52,7 +52,9 @@ static void fl_keyboard_pending_event_dispose(GObject* object) {
   g_return_if_fail(FL_IS_KEYBOARD_PENDING_EVENT(object));
 
   FlKeyboardPendingEvent* self = FL_KEYBOARD_PENDING_EVENT(object);
-  fl_key_event_dispose(self->event);
+  if (self->event != nullptr) {
+    fl_key_event_dispose(self->event.release());
+  }
   G_OBJECT_CLASS(fl_keyboard_pending_event_parent_class)->dispose(object);
 }
 
@@ -81,17 +83,18 @@ static uint64_t fl_keyboard_manager_get_event_hash(FlKeyEvent* event) {
 // the sequence ID, and the number of responders that will reply.
 //
 // This will acquire the ownership of the event.
-FlKeyboardPendingEvent* fl_keyboard_pending_event_new(FlKeyEvent* event,
-                                                      uint64_t sequence_id,
-                                                      size_t to_reply) {
+FlKeyboardPendingEvent* fl_keyboard_pending_event_new(
+    std::unique_ptr<FlKeyEvent> event,
+    uint64_t sequence_id,
+    size_t to_reply) {
   FlKeyboardPendingEvent* self = FL_KEYBOARD_PENDING_EVENT(
       g_object_new(fl_keyboard_pending_event_get_type(), nullptr));
 
-  self->event = event;
+  self->event = std::move(event);
   self->sequence_id = sequence_id;
   self->unreplied = to_reply;
   self->any_handled = false;
-  self->hash = fl_keyboard_manager_get_event_hash(event);
+  self->hash = fl_keyboard_manager_get_event_hash(self->event.get());
   return self;
 }
 
@@ -313,12 +316,13 @@ static void responder_handle_event_callback(bool handled,
         g_ptr_array_remove_index_fast(self->pending_responds, result_index);
     g_return_if_fail(removed == pending);
     bool should_redispatch =
-        !pending->any_handled && (self->text_input_plugin == nullptr ||
-                                  !fl_text_input_plugin_filter_keypress(
-                                      self->text_input_plugin, pending->event));
+        !pending->any_handled &&
+        (self->text_input_plugin == nullptr ||
+         !fl_text_input_plugin_filter_keypress(self->text_input_plugin,
+                                               pending->event.get()));
     if (should_redispatch) {
       g_ptr_array_add(self->pending_redispatches, pending);
-      self->redispatch_callback(pending->event->origin);
+      self->redispatch_callback(std::move(pending->event));
     } else {
       g_object_unref(pending);
     }
@@ -369,6 +373,8 @@ static void dispatch_to_responder(gpointer responder_data,
 
 gboolean fl_keyboard_manager_handle_event(FlKeyboardManager* self,
                                           FlKeyEvent* event) {
+  printf("handle\n");
+  fflush(stdout);
   g_return_val_if_fail(FL_IS_KEYBOARD_MANAGER(self), FALSE);
   g_return_val_if_fail(event != nullptr, FALSE);
 
@@ -378,7 +384,8 @@ gboolean fl_keyboard_manager_handle_event(FlKeyboardManager* self,
   }
 
   FlKeyboardPendingEvent* pending = fl_keyboard_pending_event_new(
-      event, ++self->last_sequence_id, self->responder_list->len);
+      std::unique_ptr<FlKeyEvent>(event), ++self->last_sequence_id,
+      self->responder_list->len);
 
   g_ptr_array_add(self->pending_responds, pending);
   FlKeyboardManagerUserData* user_data =

--- a/shell/platform/linux/fl_keyboard_manager.cc
+++ b/shell/platform/linux/fl_keyboard_manager.cc
@@ -337,7 +337,7 @@ FlKeyboardManager* fl_keyboard_manager_new(
       g_object_new(fl_keyboard_manager_get_type(), nullptr));
 
   self->text_input_plugin = text_input_plugin;
-  self->redispatch_callback = redispatch_callback;
+  self->redispatch_callback = std::move(redispatch_callback);
   self->responder_list = g_ptr_array_new_with_free_func(g_object_unref);
 
   self->pending_responds = g_ptr_array_new();

--- a/shell/platform/linux/fl_keyboard_manager.h
+++ b/shell/platform/linux/fl_keyboard_manager.h
@@ -17,8 +17,12 @@
  *
  * The signature for a callback with which a #FlKeyboardManager redispatches
  * key events that are not handled by anyone.
+ *
+ * The callee takes ownership of the received event, and is responsible to
+ * dispose it.
  **/
-typedef std::function<void(gpointer)> FlKeyboardManagerRedispatcher;
+typedef std::function<void(std::unique_ptr<FlKeyEvent>)>
+    FlKeyboardManagerRedispatcher;
 
 G_BEGIN_DECLS
 

--- a/shell/platform/linux/fl_keyboard_manager.h
+++ b/shell/platform/linux/fl_keyboard_manager.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_SHELL_PLATFORM_LINUX_FL_KEYBOARD_MANAGER_H_
 #define FLUTTER_SHELL_PLATFORM_LINUX_FL_KEYBOARD_MANAGER_H_
 
+#include <functional>
 #include <gdk/gdk.h>
 
 #include "flutter/shell/platform/linux/fl_key_responder.h"
@@ -17,7 +18,7 @@
  * The signature for a callback with which a #FlKeyboardManager redispatches
  * key events that are not handled by anyone.
  **/
-typedef void (*FlKeyboardManagerRedispatcher)(gpointer event);
+typedef std::function<void(gpointer)> FlKeyboardManagerRedispatcher;
 
 G_BEGIN_DECLS
 

--- a/shell/platform/linux/fl_keyboard_manager.h
+++ b/shell/platform/linux/fl_keyboard_manager.h
@@ -18,8 +18,8 @@
  * The signature for a callback with which a #FlKeyboardManager redispatches
  * key events that are not handled by anyone.
  *
- * The callee takes ownership of the received event, and is responsible to
- * dispose it.
+ * The callee takes ownership of the received event, and is responsible for
+ * disposing of it.
  **/
 typedef std::function<void(std::unique_ptr<FlKeyEvent>)>
     FlKeyboardManagerRedispatcher;

--- a/shell/platform/linux/fl_keyboard_manager.h
+++ b/shell/platform/linux/fl_keyboard_manager.h
@@ -5,8 +5,8 @@
 #ifndef FLUTTER_SHELL_PLATFORM_LINUX_FL_KEYBOARD_MANAGER_H_
 #define FLUTTER_SHELL_PLATFORM_LINUX_FL_KEYBOARD_MANAGER_H_
 
-#include <functional>
 #include <gdk/gdk.h>
+#include <functional>
 
 #include "flutter/shell/platform/linux/fl_key_responder.h"
 #include "flutter/shell/platform/linux/fl_text_input_plugin.h"

--- a/shell/platform/linux/fl_keyboard_manager_test.cc
+++ b/shell/platform/linux/fl_keyboard_manager_test.cc
@@ -124,10 +124,8 @@ static void fl_key_mock_responder_handle_event(
     FlKeyResponderAsyncCallback callback,
     gpointer user_data) {
   FlKeyMockResponder* self = FL_KEY_MOCK_RESPONDER(responder);
-  if (self->call_records != nullptr) {
-    self->call_records->push_back(CallRecord(
-        self, fl_key_event_clone_information_only(event), callback, user_data));
-  }
+  self->call_records->push_back(CallRecord(
+      self, fl_key_event_clone_information_only(event), callback, user_data));
   self->callback_handler(callback, user_data);
 }
 
@@ -203,9 +201,9 @@ class KeyboardTester {
 // unresolved pending events.
 TEST(FlKeyboardManagerTest, DisposeWithUnresolvedPends) {
   KeyboardTester tester(nullptr);
-  // std::vector<CallRecord> call_records;
+  std::vector<CallRecord> call_records;
 
-  FlKeyMockResponder* responder = fl_key_mock_responder_new(nullptr, 1);
+  FlKeyMockResponder* responder = fl_key_mock_responder_new(&call_records, 1);
   fl_keyboard_manager_add_responder(tester.manager(),
                                     FL_KEY_RESPONDER(responder));
 

--- a/shell/platform/linux/fl_keyboard_manager_test.cc
+++ b/shell/platform/linux/fl_keyboard_manager_test.cc
@@ -242,12 +242,12 @@ TEST(FlKeyboardManagerTest, DisposeWithUnresolvedPends) {
   responder->callback_handler = dont_respond;
   fl_keyboard_manager_handle_event(
       tester.manager(),
-      fl_key_event_new_by_mock(true, GDK_KEY_a, kKeyCodeKeyA, 0x10, false));
+      fl_key_event_new_by_mock(true, GDK_KEY_a, kKeyCodeKeyA, 0x0, false));
 
   responder->callback_handler = respond_true;
   fl_keyboard_manager_handle_event(
       tester.manager(),
-      fl_key_event_new_by_mock(true, GDK_KEY_a, kKeyCodeKeyA, 0x10, false));
+      fl_key_event_new_by_mock(false, GDK_KEY_a, kKeyCodeKeyA, 0x0, false));
 
   g_ptr_array_unref(call_records);
 
@@ -271,7 +271,7 @@ TEST(FlKeyboardManagerTest, SingleDelegateWithAsyncResponds) {
   // Dispatch a key event
   manager_handled = fl_keyboard_manager_handle_event(
       tester.manager(),
-      fl_key_event_new_by_mock(true, GDK_KEY_a, kKeyCodeKeyA, 0x10, false));
+      fl_key_event_new_by_mock(true, GDK_KEY_a, kKeyCodeKeyA, 0x0, false));
   EXPECT_EQ(manager_handled, true);
   EXPECT_EQ(redispatched.size(), 0u);
   EXPECT_EQ(call_records->len, 1u);
@@ -289,7 +289,7 @@ TEST(FlKeyboardManagerTest, SingleDelegateWithAsyncResponds) {
   /// Test 2: Two events that are unhandled by the framework
   manager_handled = fl_keyboard_manager_handle_event(
       tester.manager(),
-      fl_key_event_new_by_mock(true, GDK_KEY_a, kKeyCodeKeyA, 0x10, false));
+      fl_key_event_new_by_mock(false, GDK_KEY_a, kKeyCodeKeyA, 0x0, false));
   EXPECT_EQ(manager_handled, true);
   EXPECT_EQ(redispatched.size(), 0u);
   EXPECT_EQ(call_records->len, 1u);
@@ -301,7 +301,7 @@ TEST(FlKeyboardManagerTest, SingleDelegateWithAsyncResponds) {
   // Dispatch another key event
   manager_handled = fl_keyboard_manager_handle_event(
       tester.manager(),
-      fl_key_event_new_by_mock(true, GDK_KEY_b, kKeyCodeKeyB, 0x10, false));
+      fl_key_event_new_by_mock(true, GDK_KEY_b, kKeyCodeKeyB, 0x0, false));
   EXPECT_EQ(manager_handled, true);
   EXPECT_EQ(redispatched.size(), 0u);
   EXPECT_EQ(call_records->len, 2u);
@@ -342,7 +342,7 @@ TEST(FlKeyboardManagerTest, SingleDelegateWithAsyncResponds) {
   /// redispatching only works once.
   manager_handled = fl_keyboard_manager_handle_event(
       tester.manager(),
-      fl_key_event_new_by_mock(true, GDK_KEY_a, kKeyCodeKeyA, 0x10, false));
+      fl_key_event_new_by_mock(true, GDK_KEY_a, kKeyCodeKeyA, 0x0, false));
   EXPECT_EQ(manager_handled, true);
   EXPECT_EQ(redispatched.size(), 0u);
   EXPECT_EQ(call_records->len, 1u);
@@ -373,7 +373,7 @@ TEST(FlKeyboardManagerTest, SingleDelegateWithSyncResponds) {
   responder->callback_handler = respond_true;
   manager_handled = fl_keyboard_manager_handle_event(
       tester.manager(),
-      fl_key_event_new_by_mock(true, GDK_KEY_a, kKeyCodeKeyA, 0x10, false));
+      fl_key_event_new_by_mock(true, GDK_KEY_a, kKeyCodeKeyA, 0x0, false));
   EXPECT_EQ(manager_handled, true);
   EXPECT_EQ(call_records->len, 1u);
   record = FL_KEYBOARD_CALL_RECORD(g_ptr_array_index(call_records, 0));
@@ -389,7 +389,7 @@ TEST(FlKeyboardManagerTest, SingleDelegateWithSyncResponds) {
   responder->callback_handler = respond_false;
   manager_handled = fl_keyboard_manager_handle_event(
       tester.manager(),
-      fl_key_event_new_by_mock(true, GDK_KEY_a, kKeyCodeKeyA, 0x10, false));
+      fl_key_event_new_by_mock(false, GDK_KEY_a, kKeyCodeKeyA, 0x0, false));
   EXPECT_EQ(manager_handled, true);
   EXPECT_EQ(call_records->len, 1u);
   record = FL_KEYBOARD_CALL_RECORD(g_ptr_array_index(call_records, 0));
@@ -432,7 +432,7 @@ TEST(FlKeyboardManagerTest, WithTwoAsyncDelegates) {
 
   manager_handled = fl_keyboard_manager_handle_event(
       tester.manager(),
-      fl_key_event_new_by_mock(true, GDK_KEY_a, kKeyCodeKeyA, 0x10, false));
+      fl_key_event_new_by_mock(true, GDK_KEY_a, kKeyCodeKeyA, 0x0, false));
 
   EXPECT_EQ(manager_handled, true);
   EXPECT_EQ(redispatched.size(), 0u);
@@ -456,7 +456,7 @@ TEST(FlKeyboardManagerTest, WithTwoAsyncDelegates) {
   /// Test 2: All delegates respond false
   manager_handled = fl_keyboard_manager_handle_event(
       tester.manager(),
-      fl_key_event_new_by_mock(true, GDK_KEY_a, kKeyCodeKeyA, 0x10, false));
+      fl_key_event_new_by_mock(false, GDK_KEY_a, kKeyCodeKeyA, 0x0, false));
 
   EXPECT_EQ(manager_handled, true);
   EXPECT_EQ(redispatched.size(), 0u);

--- a/shell/platform/linux/fl_keyboard_manager_test.cc
+++ b/shell/platform/linux/fl_keyboard_manager_test.cc
@@ -228,16 +228,12 @@ TEST(FlKeyboardManagerTest, SingleDelegateWithAsyncResponds) {
   std::vector<std::unique_ptr<FlKeyEvent>> redispatched;
 
   gboolean manager_handled = false;
-  printf("1\n");
-  fflush(stdout);
   fl_keyboard_manager_add_responder(
       tester.manager(),
       FL_KEY_RESPONDER(fl_key_mock_responder_new(&call_records, 1)));
 
   /// Test 1: One event that is handled by the framework
   tester.recordRedispatchedEventsTo(redispatched);
-  printf("2\n");
-  fflush(stdout);
 
   // Dispatch a key event
   manager_handled = fl_keyboard_manager_handle_event(
@@ -249,16 +245,12 @@ TEST(FlKeyboardManagerTest, SingleDelegateWithAsyncResponds) {
   EXPECT_EQ(call_records[0].responder->delegate_id, 1);
   EXPECT_EQ(call_records[0].event->keyval, 0x61u);
   EXPECT_EQ(call_records[0].event->keycode, 0x26u);
-  printf("3\n");
-  fflush(stdout);
 
   call_records[0].callback(true);
   EXPECT_EQ(redispatched.size(), 0u);
 
   EXPECT_TRUE(fl_keyboard_manager_is_state_clear(tester.manager()));
   call_records.clear();
-  printf("4\n");
-  fflush(stdout);
 
   /// Test 2: Two events that are unhandled by the framework
   manager_handled = fl_keyboard_manager_handle_event(
@@ -270,8 +262,6 @@ TEST(FlKeyboardManagerTest, SingleDelegateWithAsyncResponds) {
   EXPECT_EQ(call_records[0].responder->delegate_id, 1);
   EXPECT_EQ(call_records[0].event->keyval, 0x61u);
   EXPECT_EQ(call_records[0].event->keycode, 0x26u);
-  printf("5\n");
-  fflush(stdout);
 
   // Dispatch another key event
   manager_handled = fl_keyboard_manager_handle_event(
@@ -283,8 +273,6 @@ TEST(FlKeyboardManagerTest, SingleDelegateWithAsyncResponds) {
   EXPECT_EQ(call_records[1].responder->delegate_id, 1);
   EXPECT_EQ(call_records[1].event->keyval, 0x62u);
   EXPECT_EQ(call_records[1].event->keycode, 0x38u);
-  printf("6\n");
-  fflush(stdout);
 
   // Resolve the second event first to test out-of-order response
   call_records[1].callback(false);
@@ -293,41 +281,31 @@ TEST(FlKeyboardManagerTest, SingleDelegateWithAsyncResponds) {
   call_records[0].callback(false);
   EXPECT_EQ(redispatched.size(), 2u);
   EXPECT_EQ(redispatched[1]->keyval, 0x61u);
-  printf("7\n");
-  fflush(stdout);
 
   call_records.clear();
 
   // Resolve redispatches
   manager_handled = fl_keyboard_manager_handle_event(tester.manager(),
                                                      redispatched[0].release());
-  printf("7.1\n");
-  fflush(stdout);
   EXPECT_EQ(manager_handled, false);
   manager_handled = fl_keyboard_manager_handle_event(tester.manager(),
                                                      redispatched[1].release());
   EXPECT_EQ(manager_handled, false);
   EXPECT_EQ(call_records.size(), 0u);
-  printf("8\n");
-  fflush(stdout);
 
   redispatched.clear();
   EXPECT_TRUE(fl_keyboard_manager_is_state_clear(tester.manager()));
-  printf("9\n");
-  fflush(stdout);
 
   /// Test 3: Dispatch the same event again to ensure that prevention from
   /// redispatching only works once.
   manager_handled = fl_keyboard_manager_handle_event(
       tester.manager(),
-      fl_key_event_new_by_mock(true, GDK_KEY_a, kKeyCodeKeyA, 0x0, false));
+      fl_key_event_new_by_mock(false, GDK_KEY_a, kKeyCodeKeyA, 0x0, false));
   EXPECT_EQ(manager_handled, true);
   EXPECT_EQ(redispatched.size(), 0u);
   EXPECT_EQ(call_records.size(), 1u);
 
   call_records[0].callback(true);
-  printf("10\n");
-  fflush(stdout);
 
   redispatched.clear();
   EXPECT_TRUE(fl_keyboard_manager_is_state_clear(tester.manager()));

--- a/shell/platform/linux/fl_keyboard_manager_test.cc
+++ b/shell/platform/linux/fl_keyboard_manager_test.cc
@@ -314,24 +314,20 @@ TEST(FlKeyboardManagerTest, SingleDelegateWithAsyncResponds) {
   record = FL_KEYBOARD_CALL_RECORD(g_ptr_array_index(call_records, 1));
   record->callback(false, record->user_data);
   EXPECT_EQ(redispatched.size(), 1u);
-  EXPECT_EQ(FL_KEY_EVENT(redispatched.back())->keyval,
-            0x62u);
+  EXPECT_EQ(FL_KEY_EVENT(redispatched.back())->keyval, 0x62u);
   record = FL_KEYBOARD_CALL_RECORD(g_ptr_array_index(call_records, 0));
   record->callback(false, record->user_data);
   EXPECT_EQ(redispatched.size(), 2u);
-  EXPECT_EQ(FL_KEY_EVENT(redispatched.back())->keyval,
-            0x61u);
+  EXPECT_EQ(FL_KEY_EVENT(redispatched.back())->keyval, 0x61u);
 
   g_ptr_array_clear(call_records);
 
   // Resolve redispatches
   manager_handled = fl_keyboard_manager_handle_event(
-      tester.manager(),
-      FL_KEY_EVENT(redispatched[0]));
+      tester.manager(), FL_KEY_EVENT(redispatched[0]));
   EXPECT_EQ(manager_handled, false);
   manager_handled = fl_keyboard_manager_handle_event(
-      tester.manager(),
-      FL_KEY_EVENT(redispatched[1]));
+      tester.manager(), FL_KEY_EVENT(redispatched[1]));
   EXPECT_EQ(manager_handled, false);
   EXPECT_EQ(call_records->len, 0u);
 
@@ -402,8 +398,7 @@ TEST(FlKeyboardManagerTest, SingleDelegateWithSyncResponds) {
 
   // Resolve redispatch
   manager_handled = fl_keyboard_manager_handle_event(
-      tester.manager(),
-      FL_KEY_EVENT(redispatched[0]));
+      tester.manager(), FL_KEY_EVENT(redispatched[0]));
   EXPECT_EQ(manager_handled, false);
   EXPECT_EQ(call_records->len, 0u);
 
@@ -473,8 +468,7 @@ TEST(FlKeyboardManagerTest, WithTwoAsyncDelegates) {
 
   // Resolve redispatch
   manager_handled = fl_keyboard_manager_handle_event(
-      tester.manager(),
-      FL_KEY_EVENT(redispatched[0]));
+      tester.manager(), FL_KEY_EVENT(redispatched[0]));
   EXPECT_EQ(manager_handled, false);
   EXPECT_EQ(call_records->len, 0u);
 
@@ -511,8 +505,7 @@ TEST(FlKeyboardManagerTest, TextInputPluginReturnsFalse) {
 
   // Resolve redispatched event.
   manager_handled = fl_keyboard_manager_handle_event(
-      tester.manager(),
-      FL_KEY_EVENT(redispatched[0]));
+      tester.manager(), FL_KEY_EVENT(redispatched[0]));
   EXPECT_EQ(manager_handled, false);
 
   redispatched.clear();

--- a/shell/platform/linux/fl_keyboard_manager_test.cc
+++ b/shell/platform/linux/fl_keyboard_manager_test.cc
@@ -174,7 +174,7 @@ static FlKeyEvent* fl_key_event_new_by_mock(bool is_press,
 
 class KeyboardTester {
  public:
-  KeyboardTester(FlTextInputPlugin* text_input_plugin) {
+  explicit KeyboardTester(FlTextInputPlugin* text_input_plugin) {
     manager_ = fl_keyboard_manager_new(
         text_input_plugin, [this](std::unique_ptr<FlKeyEvent> event) {
           if (real_redispatcher_ != nullptr) {

--- a/shell/platform/linux/fl_view.cc
+++ b/shell/platform/linux/fl_view.cc
@@ -82,8 +82,9 @@ static gboolean text_input_im_filter_by_gtk(GtkIMContext* im_context,
   return gtk_im_context_filter_keypress(im_context, event);
 }
 
-static void redispatch_key_event_by_gtk(gpointer raw_event) {
-  GdkEvent* gdk_event = reinterpret_cast<GdkEvent*>(raw_event);
+static void redispatch_key_event_by_gtk(std::unique_ptr<FlKeyEvent> in_event) {
+  g_autofree FlKeyEvent* event = in_event.release();
+  GdkEvent* gdk_event = reinterpret_cast<GdkEvent*>(event->origin);
   GdkEventType type = gdk_event->type;
   g_return_if_fail(type == GDK_KEY_PRESS || type == GDK_KEY_RELEASE);
   gdk_event_put(gdk_event);


### PR DESCRIPTION
This PR refactors the Linux keyboard unit tests so that they use `vector`s and `unique_ptr`s instead of GTK objects. This makes code a lot cleaner, and is part of the work to "modernize" Linux keyboard system, avoiding the GTK system whenever possible.

This PR is largely refactor-only, except for the following semantic changes:
1. Instead of redispatching `GtkEventKey` (as `gpointer`), `FlKeyboardManager` now redispatches `FlKeyEvent`.
    - In this way, the redispatched objects can be easily re-inserted back the the keyboard manager, which will be implemented in the future.
2. A few events in the test cases are changed. They now have alternating `is_pressed`, and has `0x0` modifier bits instead of `0x10`.
    - This makes the events closer to real event sequences, which will be required when the keyboard tests start to use real EmbedderResponder.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
