### PR TITLE
Enable leaf layer tracing in PaintContext

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -116,6 +116,8 @@ FILE: ../../../flutter/flow/gl_context_switch_unittests.cc
 FILE: ../../../flutter/flow/instrumentation.cc
 FILE: ../../../flutter/flow/instrumentation.h
 FILE: ../../../flutter/flow/instrumentation_unittests.cc
+FILE: ../../../flutter/flow/layer_snapshot_store.cc
+FILE: ../../../flutter/flow/layer_snapshot_store.h
 FILE: ../../../flutter/flow/layers/backdrop_filter_layer.cc
 FILE: ../../../flutter/flow/layers/backdrop_filter_layer.h
 FILE: ../../../flutter/flow/layers/backdrop_filter_layer_unittests.cc

--- a/flow/BUILD.gn
+++ b/flow/BUILD.gn
@@ -18,6 +18,8 @@ source_set("flow") {
     "frame_timings.h",
     "instrumentation.cc",
     "instrumentation.h",
+    "layer_snapshot_store.cc",
+    "layer_snapshot_store.h",
     "layers/backdrop_filter_layer.cc",
     "layers/backdrop_filter_layer.h",
     "layers/clip_path_layer.cc",

--- a/flow/compositor_context.h
+++ b/flow/compositor_context.h
@@ -12,6 +12,7 @@
 #include "flutter/flow/diff_context.h"
 #include "flutter/flow/embedded_views.h"
 #include "flutter/flow/instrumentation.h"
+#include "flutter/flow/layer_snapshot_store.h"
 #include "flutter/flow/raster_cache.h"
 #include "flutter/fml/macros.h"
 #include "flutter/fml/raster_thread_merger.h"
@@ -180,11 +181,14 @@ class CompositorContext {
 
   Stopwatch& ui_time() { return ui_time_; }
 
+  LayerSnapshotStore& snapshot_store() { return layer_snapshot_store_; }
+
  private:
   RasterCache raster_cache_;
   TextureRegistry texture_registry_;
   Stopwatch raster_time_;
   Stopwatch ui_time_;
+  LayerSnapshotStore layer_snapshot_store_;
 
   /// Only used by default constructor of `CompositorContext`.
   FixedRefreshRateUpdater fixed_refresh_rate_updater_;

--- a/flow/layer_snapshot_store.cc
+++ b/flow/layer_snapshot_store.cc
@@ -1,0 +1,29 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/flow/layer_snapshot_store.h"
+
+#include "flutter/fml/time/time_delta.h"
+#include "flutter/fml/time/time_point.h"
+
+namespace flutter {
+
+LayerSnapshotData::LayerSnapshotData(int64_t layer_unique_id,
+                                     fml::TimeDelta duration,
+                                     sk_sp<SkData> snapshot)
+    : layer_unique_id_(layer_unique_id),
+      duration_(duration),
+      snapshot_(snapshot) {}
+
+void LayerSnapshotStore::Clear() {
+  layer_snapshots_.clear();
+}
+
+void LayerSnapshotStore::Add(int64_t layer_unique_id,
+                             fml::TimeDelta duration,
+                             sk_sp<SkData> snapshot) {
+  layer_snapshots_.emplace_back(layer_unique_id, duration, snapshot);
+}
+
+}  // namespace flutter

--- a/flow/layer_snapshot_store.h
+++ b/flow/layer_snapshot_store.h
@@ -1,0 +1,77 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_FLOW_LAYER_SNAPSHOT_STORE_H_
+#define FLUTTER_FLOW_LAYER_SNAPSHOT_STORE_H_
+
+#include <vector>
+
+#include "flutter/fml/logging.h"
+#include "flutter/fml/time/time_delta.h"
+
+#include "third_party/skia/include/core/SkImageEncoder.h"
+#include "third_party/skia/include/core/SkPictureRecorder.h"
+#include "third_party/skia/include/core/SkSerialProcs.h"
+#include "third_party/skia/include/core/SkSurface.h"
+#include "third_party/skia/include/core/SkSurfaceCharacterization.h"
+#include "third_party/skia/include/utils/SkBase64.h"
+
+namespace flutter {
+
+/// Container for snapshot data pertaining to a given layer. A layer is
+/// identified by it's unique id.
+class LayerSnapshotData {
+ public:
+  LayerSnapshotData(int64_t layer_unique_id,
+                    fml::TimeDelta duration,
+                    sk_sp<SkData> snapshot);
+
+  ~LayerSnapshotData() = default;
+
+  int64_t GetLayerUniqueId() const { return layer_unique_id_; }
+
+  fml::TimeDelta GetDuration() const { return duration_; }
+
+  sk_sp<SkData> GetSnapshot() const { return snapshot_; }
+
+ private:
+  const int64_t layer_unique_id_;
+  const fml::TimeDelta duration_;
+  const sk_sp<SkData> snapshot_;
+};
+
+/// Collects snapshots of layers during frame rasterization.
+class LayerSnapshotStore {
+ public:
+  typedef std::vector<LayerSnapshotData> Snapshots;
+
+  LayerSnapshotStore() = default;
+
+  ~LayerSnapshotStore() = default;
+
+  /// Clears all the stored snapshots.
+  void Clear();
+
+  /// Adds snapshots for a given layer. `duration` marks the time taken to
+  /// rasterize this one layer.
+  void Add(int64_t layer_unique_id,
+           fml::TimeDelta duration,
+           sk_sp<SkData> base64_png_snapshot);
+
+  // Returns the number of snapshots collected.
+  size_t Size() const { return layer_snapshots_.size(); }
+
+  // make this class iterable
+  Snapshots::iterator begin() { return layer_snapshots_.begin(); }
+  Snapshots::iterator end() { return layer_snapshots_.end(); }
+
+ private:
+  Snapshots layer_snapshots_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(LayerSnapshotStore);
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_FLOW_LAYER_SNAPSHOT_STORE_H_

--- a/flow/layers/display_list_layer_unittests.cc
+++ b/flow/layers/display_list_layer_unittests.cc
@@ -178,5 +178,40 @@ TEST_F(DisplayListLayerDiffTest, DisplayListCompare) {
   EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(20, 20, 70, 70));
 }
 
+TEST_F(DisplayListLayerTest, LayerTreeSnapshotsWhenEnabled) {
+  const SkPoint layer_offset = SkPoint::Make(1.5f, -0.5f);
+  const SkRect picture_bounds = SkRect::MakeLTRB(5.0f, 6.0f, 20.5f, 21.5f);
+  DisplayListBuilder builder;
+  builder.drawRect(picture_bounds);
+  auto display_list = builder.Build();
+  auto layer = std::make_shared<DisplayListLayer>(
+      layer_offset, SkiaGPUObject(display_list, unref_queue()), false, false);
+
+  layer->Preroll(preroll_context(), SkMatrix());
+
+  enable_leaf_layer_tracing();
+  layer->Paint(paint_context());
+  disable_leaf_layer_tracing();
+
+  auto& snapshot_store = layer_snapshot_store();
+  EXPECT_EQ(1u, snapshot_store.Size());
+}
+
+TEST_F(DisplayListLayerTest, NoLayerTreeSnapshotsWhenDisabledByDefault) {
+  const SkPoint layer_offset = SkPoint::Make(1.5f, -0.5f);
+  const SkRect picture_bounds = SkRect::MakeLTRB(5.0f, 6.0f, 20.5f, 21.5f);
+  DisplayListBuilder builder;
+  builder.drawRect(picture_bounds);
+  auto display_list = builder.Build();
+  auto layer = std::make_shared<DisplayListLayer>(
+      layer_offset, SkiaGPUObject(display_list, unref_queue()), false, false);
+
+  layer->Preroll(preroll_context(), SkMatrix());
+  layer->Paint(paint_context());
+
+  auto& snapshot_store = layer_snapshot_store();
+  EXPECT_EQ(0u, snapshot_store.Size());
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -12,6 +12,7 @@
 #include "flutter/flow/diff_context.h"
 #include "flutter/flow/embedded_views.h"
 #include "flutter/flow/instrumentation.h"
+#include "flutter/flow/layer_snapshot_store.h"
 #include "flutter/flow/raster_cache.h"
 #include "flutter/fml/build_config.h"
 #include "flutter/fml/compiler_specific.h"
@@ -167,6 +168,11 @@ class Layer {
     const bool checkerboard_offscreen_layers;
     const float frame_device_pixel_ratio;
 
+    // Snapshot store to collect leaf layer snapshots. The store is non-null
+    // only when leaf layer tracing is enabled.
+    bool enable_leaf_layer_tracing = false;
+    LayerSnapshotStore* layer_snapshot_store = nullptr;
+
     // The following value should be used to modulate the opacity of the
     // layer during |Paint|. If the layer does not set the corresponding
     // |layer_can_inherit_opacity()| flag, then this value should always
@@ -179,7 +185,7 @@ class Layer {
 
   class AutoCachePaint {
    public:
-    AutoCachePaint(PaintContext& context) : context_(context) {
+    explicit AutoCachePaint(PaintContext& context) : context_(context) {
       needs_paint_ = context.inherited_opacity < SK_Scalar1;
       if (needs_paint_) {
         paint_.setAlphaf(context.inherited_opacity);

--- a/flow/layers/layer_tree.h
+++ b/flow/layers/layer_tree.h
@@ -68,6 +68,18 @@ class LayerTree {
     checkerboard_offscreen_layers_ = checkerboard;
   }
 
+  /// When `Paint` is called, if leaf layer tracing is enabled, additional
+  /// metadata around raterization of leaf layers is collected.
+  ///
+  /// See: `LayerSnapshotStore`
+  void enable_leaf_layer_tracing(bool enable) {
+    enable_leaf_layer_tracing_ = enable;
+  }
+
+  bool is_leaf_layer_tracing_enabled() const {
+    return enable_leaf_layer_tracing_;
+  }
+
  private:
   std::shared_ptr<Layer> root_layer_;
   SkISize frame_size_ = SkISize::MakeEmpty();  // Physical pixels.
@@ -75,6 +87,7 @@ class LayerTree {
   uint32_t rasterizer_tracing_threshold_;
   bool checkerboard_raster_cache_images_;
   bool checkerboard_offscreen_layers_;
+  bool enable_leaf_layer_tracing_ = false;
 
   PaintRegionMap paint_region_map_;
 

--- a/flow/testing/layer_test.h
+++ b/flow/testing/layer_test.h
@@ -5,6 +5,7 @@
 #ifndef FLOW_TESTING_LAYER_TEST_H_
 #define FLOW_TESTING_LAYER_TEST_H_
 
+#include "flutter/flow/layer_snapshot_store.h"
 #include "flutter/flow/layers/layer.h"
 
 #include <optional>
@@ -128,6 +129,17 @@ class LayerTestBase : public CanvasTestBase<BaseT> {
   PrerollContext* preroll_context() { return &preroll_context_; }
   Layer::PaintContext& paint_context() { return paint_context_; }
   Layer::PaintContext& check_board_context() { return check_board_context_; }
+  LayerSnapshotStore& layer_snapshot_store() { return snapshot_store_; }
+
+  void enable_leaf_layer_tracing() {
+    paint_context_.enable_leaf_layer_tracing = true;
+    paint_context_.layer_snapshot_store = &snapshot_store_;
+  }
+
+  void disable_leaf_layer_tracing() {
+    paint_context_.enable_leaf_layer_tracing = false;
+    paint_context_.layer_snapshot_store = nullptr;
+  }
 
  private:
   void set_raster_cache_(std::unique_ptr<RasterCache> raster_cache) {
@@ -145,6 +157,7 @@ class LayerTestBase : public CanvasTestBase<BaseT> {
   PrerollContext preroll_context_;
   Layer::PaintContext paint_context_;
   Layer::PaintContext check_board_context_;
+  LayerSnapshotStore snapshot_store_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(LayerTestBase);
 };


### PR DESCRIPTION
During performance debugging of a flutter application, it is useful to have additional data around how long subcomponents of the displayed frame contributed to the overall raster performance. Towards this goal, this change allows for a layer tree to request leaf-layer tracing. When this is enabled, the leaf layers are rendered to an off-screen texture and the texture is then stored in the `LayerSnapshotStore`.

In later changed, this stored snapshots will be transferred to the Flutter tool using a service protocol.
