### PR TITLE
Split tests for computePlatformResolvedLocale with N

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -1212,7 +1212,7 @@ public class FlutterJNI {
       String languageCode = strings[i + 0];
       String countryCode = strings[i + 1];
       String scriptCode = strings[i + 2];
-      // Convert to Locales via LocaleBuilder if available (API 24+) to include scriptCode.
+      // Convert to Locales via LocaleBuilder if available (API 21+) to include scriptCode.
       if (Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
         Locale.Builder localeBuilder = new Locale.Builder();
         if (!languageCode.isEmpty()) {
@@ -1226,7 +1226,7 @@ public class FlutterJNI {
         }
         supportedLocales.add(localeBuilder.build());
       } else {
-        // Pre-API 24, we fall back on scriptCode-less locales.
+        // Pre-API 21, we fall back on scriptCode-less locales.
         supportedLocales.add(new Locale(languageCode, countryCode));
       }
     }

--- a/shell/platform/android/test/io/flutter/plugin/localization/LocalizationPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/localization/LocalizationPluginTest.java
@@ -140,8 +140,8 @@ public class LocalizationPluginTest {
 
   // This test should be synced with the version for API 26.
   @Test
-  @Config(sdk = Build.VERSION_CODES.N)
-  public void computePlatformResolvedLocaleAPI24() {
+  @Config(minSdk = Build.VERSION_CODES.N)
+  public void computePlatformResolvedLocale_fromAndroidN() {
     // --- Test Setup ---
     FlutterJNI flutterJNI = new FlutterJNI();
 
@@ -235,8 +235,8 @@ public class LocalizationPluginTest {
 
   // Tests the legacy pre API 24 algorithm.
   @Test
-  @Config(sdk = Build.VERSION_CODES.JELLY_BEAN)
-  public void computePlatformResolvedLocaleAPI16() {
+  @Config(minSdk = Build.VERSION_CODES.JELLY_BEAN, maxSdk = Build.VERSION_CODES.M)
+  public void computePlatformResolvedLocale_beforeAndroidN() {
     // --- Test Setup ---
     FlutterJNI flutterJNI = new FlutterJNI();
 


### PR DESCRIPTION
It's better to run those tests for all related SDKs.

This PR also fixes obsolete comment for `computePlatformResolvedLocale` as `Locale.Build` was added from API 21, see https://developer.android.com/reference/java/util/Locale.Builder.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
