### PR TITLE
[web] improve types using a firstWhereOrNull utility

### DIFF
--- a/lib/web_ui/lib/src/engine/assets.dart
+++ b/lib/web_ui/lib/src/engine/assets.dart
@@ -25,8 +25,8 @@ class AssetManager {
   String? get _baseUrl {
     return html.window.document
         .querySelectorAll('meta')
-        .whereType<html.MetaElement?>()
-        .firstWhere((dynamic e) => e.name == 'assetBase', orElse: () => null)
+        .whereType<html.MetaElement>()
+        .firstWhereOrNull((html.MetaElement element) => element.name == 'assetBase')
         ?.content;
   }
 

--- a/lib/web_ui/lib/src/engine/host_node.dart
+++ b/lib/web_ui/lib/src/engine/host_node.dart
@@ -75,7 +75,7 @@ abstract class HostNode {
   ///
   /// See:
   /// * [Document.querySelectorAll](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelectorAll)
-  List<html.Node> querySelectorAll(String selectors);
+  List<html.Element> querySelectorAll(String selectors);
 }
 
 /// A [HostNode] implementation, backed by a [html.ShadowRoot].
@@ -125,7 +125,7 @@ class ShadowDomHostNode implements HostNode {
   }
 
   @override
-  List<html.Node> querySelectorAll(String selectors) {
+  List<html.Element> querySelectorAll(String selectors) {
     return _shadow.querySelectorAll(selectors);
   }
 
@@ -168,7 +168,7 @@ class ElementHostNode implements HostNode {
   }
 
   @override
-  List<html.Node> querySelectorAll(String selectors) {
+  List<html.Element> querySelectorAll(String selectors) {
     return _element.querySelectorAll(selectors);
   }
 

--- a/lib/web_ui/lib/src/engine/util.dart
+++ b/lib/web_ui/lib/src/engine/util.dart
@@ -741,3 +741,18 @@ void removeAllChildren(html.Node node) {
     node.lastChild!.remove();
   }
 }
+
+/// A helper that finds an element in an iterable that satisfy a predicate, or
+/// returns null otherwise.
+///
+/// This is mostly useful for iterables containing non-null elements.
+extension FirstWhereOrNull<T> on Iterable<T> {
+  T? firstWhereOrNull(bool Function(T element) test) {
+    for (final T element in this) {
+      if (test(element)) {
+        return element;
+      }
+    }
+    return null;
+  }
+}

--- a/lib/web_ui/test/engine/semantics/semantics_tester.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_tester.dart
@@ -368,9 +368,9 @@ void expectSemanticsTree(String semanticsHtml) {
 
 /// Finds the first HTML element in the semantics tree used for scrolling.
 html.Element? findScrollable() {
-  return appHostNode.querySelectorAll('flt-semantics').cast<html.Element>().firstWhereOrNull(
-    (html.Element? element) {
-      return element!.style.overflow == 'hidden' ||
+  return appHostNode.querySelectorAll('flt-semantics').firstWhereOrNull(
+    (html.Element element) {
+      return element.style.overflow == 'hidden' ||
         element.style.overflowY == 'scroll' ||
         element.style.overflowX == 'scroll';
     },

--- a/lib/web_ui/test/engine/semantics/semantics_tester.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_tester.dart
@@ -368,13 +368,13 @@ void expectSemanticsTree(String semanticsHtml) {
 
 /// Finds the first HTML element in the semantics tree used for scrolling.
 html.Element? findScrollable() {
-  return appHostNode.querySelectorAll('flt-semantics').cast<html.Element?>().firstWhere(
-        (html.Element? element) =>
-            element!.style.overflow == 'hidden' ||
-            element.style.overflowY == 'scroll' ||
-            element.style.overflowX == 'scroll',
-        orElse: () => null,
-      );
+  return appHostNode.querySelectorAll('flt-semantics').cast<html.Element>().firstWhereOrNull(
+    (html.Element? element) {
+      return element!.style.overflow == 'hidden' ||
+        element.style.overflowY == 'scroll' ||
+        element.style.overflowX == 'scroll';
+    },
+  );
 }
 
 /// Logs semantics actions dispatched to [ui.window].


### PR DESCRIPTION
Cleans up type casts in a couple of cases:

- Remove usage of `dynamic`.
- Remove the need to cast to nullable just to satisfy a limitation in `firstWhere`.