### PR TITLE
[web] Migrate Flutter Web to JS static interop - 1.

### DIFF
--- a/lib/web_ui/lib/src/engine/configuration.dart
+++ b/lib/web_ui/lib/src/engine/configuration.dart
@@ -162,8 +162,10 @@ external JsFlutterConfiguration? get _jsConfiguration;
 
 /// The JS bindings for the object that's set as `window.flutterConfiguration`.
 @JS()
-@anonymous
-class JsFlutterConfiguration {
+@staticInterop
+class JsFlutterConfiguration {}
+
+extension JsFlutterConfigurationExtension on JsFlutterConfiguration {
   external String? get canvasKitBaseUrl;
   external bool? get canvasKitForceCpuOnly;
   external bool? get debugShowSemanticsNodes;

--- a/lib/web_ui/pubspec.yaml
+++ b/lib/web_ui/pubspec.yaml
@@ -6,7 +6,7 @@ environment:
   sdk: ">=2.12.0-0 <3.0.0"
 
 dependencies:
-  js: 0.6.3
+  js: 0.6.4
   meta: 1.3.0
 
 dev_dependencies:

--- a/web_sdk/web_engine_tester/pubspec.yaml
+++ b/web_sdk/web_engine_tester/pubspec.yaml
@@ -5,7 +5,7 @@ environment:
   sdk: ">=2.12.0-0 <3.0.0"
 
 dependencies:
-  js: 0.6.3
+  js: 0.6.4
   stream_channel: 2.1.0
   test: 1.17.7
   webkit_inspection_protocol: 1.0.0

--- a/web_sdk/web_test_utils/pubspec.yaml
+++ b/web_sdk/web_test_utils/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
   collection: 1.15.0
   crypto: 3.0.1
   image: 3.0.1
-  js: 0.6.3
+  js: 0.6.4
   meta: 1.3.0
   path: 1.8.0
   process: 4.2.3


### PR DESCRIPTION
This is the first CL in a series of CLs to migrate Flutter Web to the new JS static interop API.

This CL migrates JsFlutterConfiguration to the new static interop, and updates the necessary pubspec.yaml files to enable the JS static interop API.