### PR TITLE
Fix SemanticsAction naming consistency

### DIFF
--- a/lib/ui/semantics/semantics_node.h
+++ b/lib/ui/semantics/semantics_node.h
@@ -39,8 +39,8 @@ enum class SemanticsAction : int32_t {
   kDidLoseAccessibilityFocus = 1 << 16,
   kCustomAction = 1 << 17,
   kDismiss = 1 << 18,
-  kMoveCursorForwardByWordIndex = 1 << 19,
-  kMoveCursorBackwardByWordIndex = 1 << 20,
+  kMoveCursorForwardByWord = 1 << 19,
+  kMoveCursorBackwardByWord = 1 << 20,
   kSetText = 1 << 21,
 };
 

--- a/shell/platform/fuchsia/flutter/accessibility_bridge.cc
+++ b/shell/platform/fuchsia/flutter/accessibility_bridge.cc
@@ -136,15 +136,14 @@ std::string NodeActionsToString(const flutter::SemanticsNode& node) {
           flutter::SemanticsAction::kMoveCursorBackwardByCharacter)) {
     output += "kMoveCursorBackwardByCharacter|";
   }
-  if (node.HasAction(
-          flutter::SemanticsAction::kMoveCursorBackwardByWordIndex)) {
-    output += "kMoveCursorBackwardByWordIndex|";
+  if (node.HasAction(flutter::SemanticsAction::kMoveCursorBackwardByWord)) {
+    output += "kMoveCursorBackwardByWord|";
   }
   if (node.HasAction(flutter::SemanticsAction::kMoveCursorForwardByCharacter)) {
     output += "kMoveCursorForwardByCharacter|";
   }
-  if (node.HasAction(flutter::SemanticsAction::kMoveCursorForwardByWordIndex)) {
-    output += "kMoveCursorForwardByWordIndex|";
+  if (node.HasAction(flutter::SemanticsAction::kMoveCursorForwardByWord)) {
+    output += "kMoveCursorForwardByWord|";
   }
   if (node.HasAction(flutter::SemanticsAction::kPaste)) {
     output += "kPaste|";


### PR DESCRIPTION
Removes the `Index` suffix from kMoveCursorForwardByWord and
kMoveCursorBackwardByWord values in the SemanticsAction enum. These were
erroneously copied as-is from the private class members in the dart:ui
implementation in lib/ui/semantics/semantics.dart where the class
members refer to the enum index here. This removes the trailing `Index`
for consistency with the other enum members here.

This is also useful in the context of automated testing for API
consistency between these enums, the ones in dart:ui (native and web
implementations) and the embedder API.

Issue: https://github.com/flutter/flutter/issues/101217

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
