### PR TITLE
Fix deltas when selection is active and composing begins on MacOS

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -629,6 +629,7 @@ static flutter::TextRange RangeFromBaseExtent(NSNumber* base,
     _activeModel->BeginComposing();
   }
   flutter::TextRange composingBeforeChange = _activeModel->composing_range();
+  flutter::TextRange selectionBeforeChange = _activeModel->selection();
 
   // Input string may be NSString or NSAttributedString.
   BOOL isAttributedString = [string isKindOfClass:[NSAttributedString class]];
@@ -646,7 +647,7 @@ static flutter::TextRange RangeFromBaseExtent(NSNumber* base,
 
   if (_enableDeltaModel) {
     [self updateEditStateWithDelta:flutter::TextEditingDelta(textBeforeChange,
-                                                             composingBeforeChange, marked_text)];
+                                                             selectionBeforeChange.collapsed() ? composingBeforeChange : selectionBeforeChange, marked_text)];
   } else {
     [self updateEditState];
   }

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -647,7 +647,10 @@ static flutter::TextRange RangeFromBaseExtent(NSNumber* base,
 
   if (_enableDeltaModel) {
     [self updateEditStateWithDelta:flutter::TextEditingDelta(textBeforeChange,
-                                                             selectionBeforeChange.collapsed() ? composingBeforeChange : selectionBeforeChange, marked_text)];
+                                                             selectionBeforeChange.collapsed()
+                                                                 ? composingBeforeChange
+                                                                 : selectionBeforeChange,
+                                                             marked_text)];
   } else {
     [self updateEditState];
   }

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
@@ -886,7 +886,7 @@
   [plugin setMarkedText:@"~"
           selectedRange:NSMakeRange(1, 0)
        replacementRange:NSMakeRange(NSNotFound, 0)];
-    
+
   NSDictionary* deltaToFramework = @{
     @"oldText" : @"Text",
     @"deltaText" : @"~",
@@ -902,7 +902,7 @@
   NSDictionary* expectedState = @{
     @"deltas" : @[ deltaToFramework ],
   };
-    
+
   NSData* updateCall = [[FlutterJSONMethodCodec sharedInstance]
       encodeMethodCall:[FlutterMethodCall
                            methodCallWithMethodName:@"TextInputClient.updateEditingStateWithDeltas"

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
@@ -845,6 +845,78 @@
   return true;
 }
 
+- (bool)testComposingWithDeltasWhenSelectionIsActive {
+  id engineMock = OCMClassMock([FlutterEngine class]);
+  id binaryMessengerMock = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
+  OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
+      [engineMock binaryMessenger])
+      .andReturn(binaryMessengerMock);
+
+  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engineMock
+                                                                                nibName:@""
+                                                                                 bundle:nil];
+
+  FlutterTextInputPlugin* plugin =
+      [[FlutterTextInputPlugin alloc] initWithViewController:viewController];
+
+  [plugin handleMethodCall:[FlutterMethodCall
+                               methodCallWithMethodName:@"TextInput.setClient"
+                                              arguments:@[
+                                                @(1), @{
+                                                  @"inputAction" : @"action",
+                                                  @"enableDeltaModel" : @"true",
+                                                  @"inputType" : @{@"name" : @"inputName"},
+                                                }
+                                              ]]
+                    result:^(id){
+                    }];
+
+  FlutterMethodCall* call = [FlutterMethodCall methodCallWithMethodName:@"TextInput.setEditingState"
+                                                              arguments:@{
+                                                                @"text" : @"Text",
+                                                                @"selectionBase" : @(0),
+                                                                @"selectionExtent" : @(4),
+                                                                @"composingBase" : @(-1),
+                                                                @"composingExtent" : @(-1),
+                                                              }];
+  [plugin handleMethodCall:call
+                    result:^(id){
+                    }];
+
+  [plugin setMarkedText:@"~"
+          selectedRange:NSMakeRange(1, 0)
+       replacementRange:NSMakeRange(NSNotFound, 0)];
+    
+  NSDictionary* deltaToFramework = @{
+    @"oldText" : @"Text",
+    @"deltaText" : @"~",
+    @"deltaStart" : @(0),
+    @"deltaEnd" : @(4),
+    @"selectionBase" : @(1),
+    @"selectionExtent" : @(1),
+    @"selectionAffinity" : @"TextAffinity.upstream",
+    @"selectionIsDirectional" : @(false),
+    @"composingBase" : @(0),
+    @"composingExtent" : @(1),
+  };
+  NSDictionary* expectedState = @{
+    @"deltas" : @[ deltaToFramework ],
+  };
+    
+  NSData* updateCall = [[FlutterJSONMethodCodec sharedInstance]
+      encodeMethodCall:[FlutterMethodCall
+                           methodCallWithMethodName:@"TextInputClient.updateEditingStateWithDeltas"
+                                          arguments:@[ @(1), expectedState ]]];
+
+  @try {
+    OCMVerify(  // NOLINT(google-objc-avoid-throwing-exception)
+        [binaryMessengerMock sendOnChannel:@"flutter/textinput" message:updateCall]);
+  } @catch (...) {
+    return false;
+  }
+  return true;
+}
+
 - (bool)testLocalTextAndSelectionUpdateAfterDelta {
   id engineMock = OCMClassMock([FlutterEngine class]);
   id binaryMessengerMock = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
@@ -955,6 +1027,10 @@ TEST(FlutterTextInputPluginTest, TestOperationsThatTriggerDelta) {
 
 TEST(FlutterTextInputPluginTest, TestComposingWithDelta) {
   ASSERT_TRUE([[FlutterInputPluginTestObjc alloc] testComposingWithDelta]);
+}
+
+TEST(FlutterTextInputPluginTest, testComposingWithDeltasWhenSelectionIsActive) {
+  ASSERT_TRUE([[FlutterInputPluginTestObjc alloc] testComposingWithDeltasWhenSelectionIsActive]);
 }
 
 TEST(FlutterTextInputPluginTest, TestLocalTextAndSelectionUpdateAfterDelta) {


### PR DESCRIPTION
When a selection is active (not collapsed) before starting to compose text, previously we would still send the composing region as the `deltaRange`. This was causing the new composed text to be inserted at the caret offset instead of replacing the active selection. This change adds a case to handle this situation, sending the previous composing region as the `deltaRange` when the selection is collapsed, and sending the selection as the `deltaRange` when the selection is active.

Fixes flutter/flutter#101013

## Pre-launch Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.