### PR TITLE
Only install iOS simulator runtimes on builders that use them

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -58,11 +58,9 @@ platform_properties:
       caches: >-
         [
           {"name":"flutter_cocoapods","path":"cocoapods"},
-          {"name":"osx_sdk_13a233_13_15","path":"osx_sdk"},
+          {"name":"osx_sdk_13a233","path":"osx_sdk"},
           {"name":"builder_mac_engine","path":"builder"},
-          {"name":"openjdk","path":"java"},
-          {"name":"xcode_runtime_ios_13_0","path":"xcode_runtime_ios_13_0"},
-          {"name":"xcode_runtime_ios_15_0","path":"xcode_runtime_ios_15_0"}
+          {"name":"openjdk","path":"java"}
         ]
       # CIPD flutter_internal/java/openjdk/$platform
       dependencies: >-
@@ -72,11 +70,6 @@ platform_properties:
       device_type: none
       mac_model: "Macmini8,1"
       os: Mac-12
-      runtime_versions: >-
-        [
-          "ios-13-0",
-          "ios-15-0"
-        ]
       xcode: 13a233 # xcode 13.0
   windows:
     properties:
@@ -283,6 +276,20 @@ targets:
     properties:
       add_recipes_cq: "true"
       jazzy_version: "0.14.1"
+      caches: >-
+        [
+          {"name":"flutter_cocoapods","path":"cocoapods"},
+          {"name":"osx_sdk_13a233_13_15","path":"osx_sdk"},
+          {"name":"builder_mac_engine","path":"builder"},
+          {"name":"openjdk","path":"java"},
+          {"name":"xcode_runtime_ios_13_0","path":"xcode_runtime_ios_13_0"},
+          {"name":"xcode_runtime_ios_15_0","path":"xcode_runtime_ios_15_0"}
+        ]
+      runtime_versions: >-
+        [
+          "ios-13-0",
+          "ios-15-0"
+        ]
     timeout: 75
 
   - name: Mac clang-tidy
@@ -317,9 +324,6 @@ targets:
           {"dependency": "goldctl"}
         ]
       os: Mac-10.15
-      runtime_versions: >-
-        [
-        ]
       xcode: 12c33 # xcode 12.3
     timeout: 60
     runIf:


### PR DESCRIPTION
iOS 13 and 15 runtime simulators are only needed for `Mac Unopt` at the moment.  Remove `runtime_versions` as default on Mac builders and only set the property where needed.  This should reduce the build time by ~4 minutes per builder.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
