### PR TITLE
Adjust some names for consistency

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterMenuPluginTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterMenuPluginTest.mm
@@ -106,7 +106,7 @@
     ],
   };
 
-  [plugin handleMethodCall:[FlutterMethodCall methodCallWithMethodName:@"Menu.setMenu"
+  [plugin handleMethodCall:[FlutterMethodCall methodCallWithMethodName:@"Menu.setMenus"
                                                              arguments:testMenus]
                     result:^(id _Nullable result){
                     }];


### PR DESCRIPTION
## Description

This just changes some of the API names for consistency with the framework APIs (and themselves).
This is a very new method channel (it went in a couple of days ago), so it's not in use yet.

Matching framework PR is https://github.com/flutter/flutter/pull/101378