### PR TITLE
assertion failure on empty indices in ui.Vertices constructor

### DIFF
--- a/lib/ui/painting/vertices.cc
+++ b/lib/ui/painting/vertices.cc
@@ -67,7 +67,7 @@ bool Vertices::init(Dart_Handle vertices_handle,
     builder.store_colors(reinterpret_cast<const SkColor*>(colors.data()));
   }
 
-  if (indices.data()) {
+  if (indices.data() && indices.num_elements() > 0) {
     builder.store_indices(indices.data());
   }
 

--- a/testing/dart/canvas_test.dart
+++ b/testing/dart/canvas_test.dart
@@ -107,6 +107,10 @@ void testNoCrashes() {
     testCanvas((Canvas canvas) => canvas.skew(double.nan, double.nan));
     testCanvas((Canvas canvas) => canvas.transform(Float64List(16)));
     testCanvas((Canvas canvas) => canvas.translate(double.nan, double.nan));
+    testCanvas((Canvas canvas) => canvas.drawVertices(Vertices(VertexMode.triangles, <Offset>[],
+                                                               textureCoordinates: null,
+                                                               colors: null,
+                                                               indices: <int>[]), BlendMode.screen, paint));
   });
 }
 


### PR DESCRIPTION
Fixes a problem in an upstream test where an empty indices array was specified in a ui.Vertices constructor leading to a crash when the DlVertices::Builder did not expect us to deliver any vertices at all (even though the count was 0).

Fixes [b/228223653](https://b.corp.google.com/228223653)