### PR TITLE
Uncomment SemanticsFlag.isMultiline in enums

### DIFF
--- a/lib/ui/semantics/semantics_node.h
+++ b/lib/ui/semantics/semantics_node.h
@@ -81,8 +81,7 @@ enum class SemanticsFlags : int32_t {
   kHasToggledState = 1 << 16,
   kIsToggled = 1 << 17,
   kHasImplicitScrolling = 1 << 18,
-  // The Dart API defines the following flag but it isn't used in iOS.
-  // kIsMultiline = 1 << 19,
+  kIsMultiline = 1 << 19,
   kIsReadOnly = 1 << 20,
   kIsFocusable = 1 << 21,
   kIsLink = 1 << 22,

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -2045,8 +2045,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
     HAS_TOGGLED_STATE(1 << 16),
     IS_TOGGLED(1 << 17),
     HAS_IMPLICIT_SCROLLING(1 << 18),
-    // The Dart API defines the following flag but it isn't used in Android.
-    // IS_MULTILINE(1 << 19);
+    IS_MULTILINE(1 << 19),
     IS_READ_ONLY(1 << 20),
     IS_FOCUSABLE(1 << 21),
     IS_LINK(1 << 22),


### PR DESCRIPTION
Uncomments the Java Flag.IS_MULTILINE and C++ SemanticsFlag.kIsMultiline
enum values. While these values aren't used in the Android or iOS
embeddings, in practice we maintain the same set of enum values across
all embeddings so as to match the public API defined in dart:ui, found
in lib/ui/semantics/semantics.dart.

This also helps with automated checking that all enums across all
languages are consistent.

This will be added to the embedder API in
https://github.com/flutter/engine/pull/32332.

Issue: https://github.com/flutter/flutter/issues/101217

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
