### PR TITLE
Prepare and restore DisplayListBuilder attributes across a DisplayList::RenderTo(Builder) operation

### DIFF
--- a/display_list/display_list.cc
+++ b/display_list/display_list.cc
@@ -194,7 +194,7 @@ void DisplayList::RenderTo(DisplayListBuilder* builder,
   DlAttributes restore_attributes = builder->getAttributes();
 
   int restore_count = builder->getSaveCount();
-  if (opacity < 255) {
+  if (alpha < 255) {
     DlAttributes save_layer_attributes;
     save_layer_attributes.color = alpha << 24;
     builder->setAttributes(&save_layer_attributes);

--- a/display_list/display_list.h
+++ b/display_list/display_list.h
@@ -246,7 +246,7 @@ class DisplayList : public SkRefCnt {
   uint32_t unique_id() const { return unique_id_; }
 
   const SkRect& bounds() {
-    if (bounds_.width() < 0.0) {
+    if (bounds_are_uninitialized()) {
       // ComputeBounds() will leave the variable with a
       // non-negative width and height
       ComputeBounds();
@@ -278,6 +278,14 @@ class DisplayList : public SkRefCnt {
 
   uint32_t unique_id_;
   SkRect bounds_;
+
+  bool bounds_are_uninitialized() const {
+    return bounds_.width() < 0.0;
+  }
+
+  const SkRect* bounds_if_initialized() const {
+    return (bounds_are_uninitialized()) ? nullptr : &bounds_;
+  }
 
   // Only used for drawPaint() and drawColor()
   SkRect bounds_cull_;

--- a/display_list/display_list.h
+++ b/display_list/display_list.h
@@ -279,9 +279,7 @@ class DisplayList : public SkRefCnt {
   uint32_t unique_id_;
   SkRect bounds_;
 
-  bool bounds_are_uninitialized() const {
-    return bounds_.width() < 0.0;
-  }
+  bool bounds_are_uninitialized() const { return bounds_.width() < 0.0; }
 
   const SkRect* bounds_if_initialized() const {
     return (bounds_are_uninitialized()) ? nullptr : &bounds_;

--- a/display_list/display_list_builder.h
+++ b/display_list/display_list_builder.h
@@ -136,12 +136,8 @@ class DisplayListBuilder final : public virtual Dispatcher,
   }
 
   void setAttributes(const DlAttributes* attributes);
-  void setAttributeDefaults() {
-    setAttributes(&kDefaultAttributes);
-  }
-  DlAttributes getAttributes() {
-    return DlAttributes(attr_);
-  }
+  void setAttributeDefaults() { setAttributes(&kDefaultAttributes); }
+  DlAttributes getAttributes() { return DlAttributes(attr_); }
 
   bool isAntiAlias() const { return attr_.anti_alias; }
   bool isDither() const { return attr_.dither; }
@@ -165,9 +161,7 @@ class DisplayListBuilder final : public virtual Dispatcher,
     }
     return attr_.blend_mode;
   }
-  sk_sp<SkBlender> getBlender() const {
-    return attr_.blender;
-  }
+  sk_sp<SkBlender> getBlender() const { return attr_.blender; }
   sk_sp<SkPathEffect> getPathEffect() const { return attr_.path_effect; }
   std::shared_ptr<const DlMaskFilter> getMaskFilter() const {
     return attr_.mask_filter;
@@ -371,7 +365,7 @@ class DisplayListBuilder final : public virtual Dispatcher,
   }
 
   void UpdateCurrentOpacityCompatibility() {
-    current_opacity_compatibility_ =         //
+    current_opacity_compatibility_ =      //
         attr_.color_filter == nullptr &&  //
         !attr_.invert_colors &&           //
         attr_.blender == nullptr &&       //

--- a/display_list/display_list_builder.h
+++ b/display_list/display_list_builder.h
@@ -166,8 +166,7 @@ class DisplayListBuilder final : public virtual Dispatcher,
     return attr_.blend_mode;
   }
   sk_sp<SkBlender> getBlender() const {
-    return attr_.blender ? attr_.blender
-                            : SkBlender::Mode(ToSk(attr_.blend_mode));
+    return attr_.blender;
   }
   sk_sp<SkPathEffect> getPathEffect() const { return attr_.path_effect; }
   std::shared_ptr<const DlMaskFilter> getMaskFilter() const {

--- a/display_list/display_list_canvas_unittests.cc
+++ b/display_list/display_list_canvas_unittests.cc
@@ -366,9 +366,18 @@ class TestParameters {
         ref_attr.getColor() != attr.getColor()) {
       return false;
     }
-    if (flags_.applies_blend() &&  //
-        ref_attr.getBlender() != attr.getBlender()) {
-      return false;
+    if (flags_.applies_blend()) {
+      if (ref_attr.getBlender() != attr.getBlender()) {
+        return false;
+      }
+      if (ref_attr.getBlendMode().has_value() !=
+          attr.getBlendMode().has_value()) {
+        return false;
+      }
+      if (ref_attr.getBlendMode().has_value() &&
+          ref_attr.getBlendMode().value() != attr.getBlendMode().value()) {
+        return false;
+      }
     }
     if (flags_.applies_color_filter() &&  //
         (ref_attr.isInvertColors() != attr.isInvertColors() ||

--- a/display_list/display_list_unittests.cc
+++ b/display_list/display_list_unittests.cc
@@ -1938,6 +1938,29 @@ TEST(DisplayList, DlAttributesDefaults) {
   EXPECT_EQ(attributes.mask_filter, nullptr);
 }
 
+TEST(DisplayList, DlAttributeskDefaultAttributes) {
+  EXPECT_FALSE(DisplayListBuilder::kDefaultAttributes.anti_alias);
+  EXPECT_FALSE(DisplayListBuilder::kDefaultAttributes.dither);
+  EXPECT_FALSE(DisplayListBuilder::kDefaultAttributes.invert_colors);
+  EXPECT_EQ(DisplayListBuilder::kDefaultAttributes.color, 0xFF000000);
+  EXPECT_EQ(DisplayListBuilder::kDefaultAttributes.style,
+            SkPaint::Style::kFill_Style);
+  EXPECT_EQ(DisplayListBuilder::kDefaultAttributes.stroke_width, 0.0);
+  EXPECT_EQ(DisplayListBuilder::kDefaultAttributes.stroke_miter, 4.0);
+  EXPECT_EQ(DisplayListBuilder::kDefaultAttributes.stroke_cap,
+            SkPaint::Cap::kButt_Cap);
+  EXPECT_EQ(DisplayListBuilder::kDefaultAttributes.stroke_join,
+            SkPaint::Join::kMiter_Join);
+  EXPECT_EQ(DisplayListBuilder::kDefaultAttributes.blend_mode,
+            DlBlendMode::kSrcOver);
+  EXPECT_EQ(DisplayListBuilder::kDefaultAttributes.blender, nullptr);
+  EXPECT_EQ(DisplayListBuilder::kDefaultAttributes.color_source, nullptr);
+  EXPECT_EQ(DisplayListBuilder::kDefaultAttributes.color_filter, nullptr);
+  EXPECT_EQ(DisplayListBuilder::kDefaultAttributes.image_filter, nullptr);
+  EXPECT_EQ(DisplayListBuilder::kDefaultAttributes.path_effect, nullptr);
+  EXPECT_EQ(DisplayListBuilder::kDefaultAttributes.mask_filter, nullptr);
+}
+
 TEST(DisplayList, DlAttributesResetToDefaults) {
   DisplayListBuilder::DlAttributes attributes;
   attributes.anti_alias = true;
@@ -2044,7 +2067,8 @@ TEST(DisplayList, DisplayListBuilderAttributeReset) {
   EXPECT_NE(builder.getStrokeCap(), SkPaint::Cap::kButt_Cap);
   EXPECT_NE(builder.getStrokeJoin(), SkPaint::Join::kMiter_Join);
   EXPECT_FALSE(builder.getBlendMode().has_value());
-  EXPECT_NE(builder.getBlendMode().value(), DlBlendMode::kSrcOver);
+  // We cannot test the value in this case because the blender overrides it
+  // EXPECT_NE(builder.getBlendMode().value(), DlBlendMode::kSrcOver);
   EXPECT_NE(builder.getBlender(), nullptr);
   EXPECT_NE(builder.getColorSource(), nullptr);
   EXPECT_NE(builder.getColorFilter(), nullptr);

--- a/display_list/display_list_unittests.cc
+++ b/display_list/display_list_unittests.cc
@@ -1918,5 +1918,160 @@ TEST(DisplayList, FlutterSvgIssue661BoundsWereEmpty) {
   EXPECT_EQ(display_list->bytes(), sizeof(DisplayList) + 304u);
 }
 
+TEST(DisplayList, DlAttributesDefaults) {
+  DisplayListBuilder::DlAttributes attributes;
+  EXPECT_FALSE(attributes.anti_alias);
+  EXPECT_FALSE(attributes.dither);
+  EXPECT_FALSE(attributes.invert_colors);
+  EXPECT_EQ(attributes.color, 0xFF000000);
+  EXPECT_EQ(attributes.style, SkPaint::Style::kFill_Style);
+  EXPECT_EQ(attributes.stroke_width, 0.0);
+  EXPECT_EQ(attributes.stroke_miter, 4.0);
+  EXPECT_EQ(attributes.stroke_cap, SkPaint::Cap::kButt_Cap);
+  EXPECT_EQ(attributes.stroke_join, SkPaint::Join::kMiter_Join);
+  EXPECT_EQ(attributes.blend_mode, DlBlendMode::kSrcOver);
+  EXPECT_EQ(attributes.blender, nullptr);
+  EXPECT_EQ(attributes.color_source, nullptr);
+  EXPECT_EQ(attributes.color_filter, nullptr);
+  EXPECT_EQ(attributes.image_filter, nullptr);
+  EXPECT_EQ(attributes.path_effect, nullptr);
+  EXPECT_EQ(attributes.mask_filter, nullptr);
+}
+
+TEST(DisplayList, DlAttributesResetToDefaults) {
+  DisplayListBuilder::DlAttributes attributes;
+  attributes.anti_alias = true;
+  attributes.dither = true;
+  attributes.invert_colors = true;
+  attributes.color = 42;
+  attributes.style = SkPaint::Style::kStrokeAndFill_Style;
+  attributes.stroke_width = 10.0;
+  attributes.stroke_miter = 10.0;
+  attributes.stroke_cap = SkPaint::Cap::kRound_Cap;
+  attributes.stroke_join = SkPaint::Join::kRound_Join;
+  attributes.blend_mode = DlBlendMode::kSrc;
+  attributes.blender = TestBlender1;
+  attributes.color_source = TestSource1.shared();
+  attributes.color_filter = TestBlendColorFilter1.shared();
+  attributes.image_filter = TestBlurImageFilter1.shared();
+  attributes.path_effect = TestPathEffect1;
+  attributes.mask_filter = TestMaskFilter1.shared();
+
+  EXPECT_TRUE(attributes.anti_alias);
+  EXPECT_TRUE(attributes.dither);
+  EXPECT_TRUE(attributes.invert_colors);
+  EXPECT_NE(attributes.color, 0xFF000000);
+  EXPECT_NE(attributes.style, SkPaint::Style::kFill_Style);
+  EXPECT_NE(attributes.stroke_width, 0.0);
+  EXPECT_NE(attributes.stroke_miter, 4.0);
+  EXPECT_NE(attributes.stroke_cap, SkPaint::Cap::kButt_Cap);
+  EXPECT_NE(attributes.stroke_join, SkPaint::Join::kMiter_Join);
+  EXPECT_NE(attributes.blend_mode, DlBlendMode::kSrcOver);
+  EXPECT_NE(attributes.blender, nullptr);
+  EXPECT_NE(attributes.color_source, nullptr);
+  EXPECT_NE(attributes.color_filter, nullptr);
+  EXPECT_NE(attributes.image_filter, nullptr);
+  EXPECT_NE(attributes.path_effect, nullptr);
+  EXPECT_NE(attributes.mask_filter, nullptr);
+
+  attributes = DisplayListBuilder::kDefaultAttributes;
+
+  EXPECT_FALSE(attributes.anti_alias);
+  EXPECT_FALSE(attributes.dither);
+  EXPECT_FALSE(attributes.invert_colors);
+  EXPECT_EQ(attributes.color, 0xFF000000);
+  EXPECT_EQ(attributes.style, SkPaint::Style::kFill_Style);
+  EXPECT_EQ(attributes.stroke_width, 0.0);
+  EXPECT_EQ(attributes.stroke_miter, 4.0);
+  EXPECT_EQ(attributes.stroke_cap, SkPaint::Cap::kButt_Cap);
+  EXPECT_EQ(attributes.stroke_join, SkPaint::Join::kMiter_Join);
+  EXPECT_EQ(attributes.blend_mode, DlBlendMode::kSrcOver);
+  EXPECT_EQ(attributes.blender, nullptr);
+  EXPECT_EQ(attributes.color_source, nullptr);
+  EXPECT_EQ(attributes.color_filter, nullptr);
+  EXPECT_EQ(attributes.image_filter, nullptr);
+  EXPECT_EQ(attributes.path_effect, nullptr);
+  EXPECT_EQ(attributes.mask_filter, nullptr);
+}
+
+TEST(DisplayList, DisplayListBuilderAttributeDefaults) {
+  DisplayListBuilder builder;
+  EXPECT_FALSE(builder.isAntiAlias());
+  EXPECT_FALSE(builder.isDither());
+  EXPECT_FALSE(builder.isInvertColors());
+  EXPECT_EQ(builder.getColor(), 0xFF000000);
+  EXPECT_EQ(builder.getStyle(), SkPaint::Style::kFill_Style);
+  EXPECT_EQ(builder.getStrokeWidth(), 0.0);
+  EXPECT_EQ(builder.getStrokeMiter(), 4.0);
+  EXPECT_EQ(builder.getStrokeCap(), SkPaint::Cap::kButt_Cap);
+  EXPECT_EQ(builder.getStrokeJoin(), SkPaint::Join::kMiter_Join);
+  EXPECT_TRUE(builder.getBlendMode().has_value());
+  EXPECT_EQ(builder.getBlendMode().value(), DlBlendMode::kSrcOver);
+  EXPECT_EQ(builder.getBlender(), nullptr);
+  EXPECT_EQ(builder.getColorSource(), nullptr);
+  EXPECT_EQ(builder.getColorFilter(), nullptr);
+  EXPECT_EQ(builder.getImageFilter(), nullptr);
+  EXPECT_EQ(builder.getPathEffect(), nullptr);
+  EXPECT_EQ(builder.getMaskFilter(), nullptr);
+}
+
+TEST(DisplayList, DisplayListBuilderAttributeReset) {
+  DisplayListBuilder builder;
+  builder.setAntiAlias(true);
+  builder.setDither(true);
+  builder.setInvertColors(true);
+  builder.setColor(42);
+  builder.setStyle(SkPaint::Style::kStrokeAndFill_Style);
+  builder.setStrokeWidth(10.0);
+  builder.setStrokeMiter(10.0);
+  builder.setStrokeCap(SkPaint::Cap::kRound_Cap);
+  builder.setStrokeJoin(SkPaint::Join::kRound_Join);
+  builder.setBlendMode(DlBlendMode::kSrc);
+  builder.setBlender(TestBlender1);
+  builder.setColorSource(&TestSource1);
+  builder.setColorFilter(&TestBlendColorFilter1);
+  builder.setImageFilter(&TestBlurImageFilter1);
+  builder.setPathEffect(TestPathEffect1);
+  builder.setMaskFilter(&TestMaskFilter1);
+
+  EXPECT_TRUE(builder.isAntiAlias());
+  EXPECT_TRUE(builder.isDither());
+  EXPECT_TRUE(builder.isInvertColors());
+  EXPECT_NE(builder.getColor(), 0xFF000000);
+  EXPECT_NE(builder.getStyle(), SkPaint::Style::kFill_Style);
+  EXPECT_NE(builder.getStrokeWidth(), 0.0);
+  EXPECT_NE(builder.getStrokeMiter(), 4.0);
+  EXPECT_NE(builder.getStrokeCap(), SkPaint::Cap::kButt_Cap);
+  EXPECT_NE(builder.getStrokeJoin(), SkPaint::Join::kMiter_Join);
+  EXPECT_FALSE(builder.getBlendMode().has_value());
+  EXPECT_NE(builder.getBlendMode().value(), DlBlendMode::kSrcOver);
+  EXPECT_NE(builder.getBlender(), nullptr);
+  EXPECT_NE(builder.getColorSource(), nullptr);
+  EXPECT_NE(builder.getColorFilter(), nullptr);
+  EXPECT_NE(builder.getImageFilter(), nullptr);
+  EXPECT_NE(builder.getPathEffect(), nullptr);
+  EXPECT_NE(builder.getMaskFilter(), nullptr);
+
+  builder.setAttributeDefaults();
+
+  EXPECT_FALSE(builder.isAntiAlias());
+  EXPECT_FALSE(builder.isDither());
+  EXPECT_FALSE(builder.isInvertColors());
+  EXPECT_EQ(builder.getColor(), 0xFF000000);
+  EXPECT_EQ(builder.getStyle(), SkPaint::Style::kFill_Style);
+  EXPECT_EQ(builder.getStrokeWidth(), 0.0);
+  EXPECT_EQ(builder.getStrokeMiter(), 4.0);
+  EXPECT_EQ(builder.getStrokeCap(), SkPaint::Cap::kButt_Cap);
+  EXPECT_EQ(builder.getStrokeJoin(), SkPaint::Join::kMiter_Join);
+  EXPECT_TRUE(builder.getBlendMode().has_value());
+  EXPECT_EQ(builder.getBlendMode().value(), DlBlendMode::kSrcOver);
+  EXPECT_EQ(builder.getBlender(), nullptr);
+  EXPECT_EQ(builder.getColorSource(), nullptr);
+  EXPECT_EQ(builder.getColorFilter(), nullptr);
+  EXPECT_EQ(builder.getImageFilter(), nullptr);
+  EXPECT_EQ(builder.getPathEffect(), nullptr);
+  EXPECT_EQ(builder.getMaskFilter(), nullptr);
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/lib/ui/painting/canvas.cc
+++ b/lib/ui/painting/canvas.cc
@@ -283,7 +283,7 @@ void Canvas::drawPaint(const Paint& paint, const PaintData& paint_data) {
   FML_DCHECK(paint.isNotNull());
   if (display_list_recorder_) {
     paint.sync_to(builder(), kDrawPaintFlags);
-    std::shared_ptr<DlImageFilter> filter = builder()->getImageFilter();
+    std::shared_ptr<const DlImageFilter> filter = builder()->getImageFilter();
     if (filter && !filter->asColorFilter()) {
       // drawPaint does an implicit saveLayer if an SkImageFilter is
       // present that cannot be replaced by an SkColorFilter.


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/100983

Each DisplayList is built assuming that all attributes are at default values when it builds its stream of records. This PR sets all of the attributes in the target builder to defaults before dumping the DisplayList into it.

Currently the only way we put data into a DLBuilder is either via canvas.cc or via this one call to DisplayList::RenderTo() and each of these entry points currently will set all indicated attributes before any rendering call, so the state of the attributes after a RenderTo() isn't necessarily depended on. But, just to present a consistent interface to anyone using these methods in a more manual manner, the RenderTo call will restore all attributes that were present before it pushed the DL data - so that the ending attributes have a consistent state that matches their values before the call.

To facilitate these changes, I created a small structure to encapsulate all rendering attributes and use it internally in DisplayListBuilder and now provide new methods to grab that state and set it back - utility methods for the RenderTo method. Eventually, the DisplayListBuilder could be rearchitected to provide these values in each rendering call, as in `drawRect(rect, attributes)` instead of individual get/set calls, but the currently simple structure should be made a little more formal before that happens and it becomes a first class object (rather than an "inner" class of DLBuilder).

Currently the struct is named "DlAttributes" which might be slightly confused with "DlAttribute" which is the base class for all complex rendering attributes (DlMaskFilter, DlColorFilter, etc.). It is also thematically similar to SkPaint, but I went with DlAttributes instead of DlPaint because the name "Paint" does not really match the data it holds. Discussion on this naming shouldn't be too critical until and unless we expose it more formally as in the architectural changes to the Builder draw methods - at which point developers would be exposed to the naming.

Tests include:
- basic tests on the new DlAttributes struct and the methods that use it.
- tests that confirm the undisturbed state before and after a call to RenderTo(builder)
- tests that demonstrate that the proper DisplayList is recorded in the DisplayListLayer (in a simulated impeller mode)