### PR TITLE
[linux] fix accessibility roles for radios and switches

### DIFF
--- a/shell/platform/linux/fl_accessible_node.cc
+++ b/shell/platform/linux/fl_accessible_node.cc
@@ -187,9 +187,15 @@ static AtkRole fl_accessible_node_get_role(AtkObject* accessible) {
   if ((self->flags & kFlutterSemanticsFlagIsButton) != 0) {
     return ATK_ROLE_PUSH_BUTTON;
   }
-  if ((self->flags & (kFlutterSemanticsFlagHasCheckedState |
-                      kFlutterSemanticsFlagHasToggledState)) != 0) {
+  if ((self->flags & kFlutterSemanticsFlagIsInMutuallyExclusiveGroup) != 0 &&
+      (self->flags & kFlutterSemanticsFlagHasCheckedState) != 0) {
+    return ATK_ROLE_RADIO_BUTTON;
+  }
+  if ((self->flags & kFlutterSemanticsFlagHasCheckedState) != 0) {
     return ATK_ROLE_CHECK_BOX;
+  }
+  if ((self->flags & kFlutterSemanticsFlagHasToggledState) != 0) {
+    return ATK_ROLE_TOGGLE_BUTTON;
   }
   if ((self->flags & kFlutterSemanticsFlagIsSlider) != 0) {
     return ATK_ROLE_SLIDER;

--- a/shell/platform/linux/fl_accessible_node_test.cc
+++ b/shell/platform/linux/fl_accessible_node_test.cc
@@ -79,6 +79,31 @@ TEST(FlAccessibleNodeTest, SetFlags) {
   g_object_unref(state);
 }
 
+// Checks Flutter flags are mapped to appropriate ATK roles.
+TEST(FlAccessibleNodeTest, GetRole) {
+  g_autoptr(FlEngine) engine = make_mock_engine();
+
+  g_autoptr(FlAccessibleNode) node = fl_accessible_node_new(engine, 0);
+
+  fl_accessible_node_set_flags(
+      node, static_cast<FlutterSemanticsFlag>(kFlutterSemanticsFlagIsButton));
+  EXPECT_EQ(atk_object_get_role(ATK_OBJECT(node)), ATK_ROLE_PUSH_BUTTON);
+
+  fl_accessible_node_set_flags(node, static_cast<FlutterSemanticsFlag>(
+                                         kFlutterSemanticsFlagHasCheckedState));
+  EXPECT_EQ(atk_object_get_role(ATK_OBJECT(node)), ATK_ROLE_CHECK_BOX);
+
+  fl_accessible_node_set_flags(
+      node, static_cast<FlutterSemanticsFlag>(
+                kFlutterSemanticsFlagHasCheckedState |
+                kFlutterSemanticsFlagIsInMutuallyExclusiveGroup));
+  EXPECT_EQ(atk_object_get_role(ATK_OBJECT(node)), ATK_ROLE_RADIO_BUTTON);
+
+  fl_accessible_node_set_flags(node, static_cast<FlutterSemanticsFlag>(
+                                         kFlutterSemanticsFlagHasToggledState));
+  EXPECT_EQ(atk_object_get_role(ATK_OBJECT(node)), ATK_ROLE_TOGGLE_BUTTON);
+}
+
 // Checks Flutter actions are mapped to the appropriate ATK actions.
 TEST(FlAccessibleNodeTest, SetActions) {
   g_autoptr(FlEngine) engine = make_mock_engine();


### PR DESCRIPTION
Match the behavior with GTK:

- Radio: checkable, mutually exclusive
- Checkbox: checkable
- Switch: toggleable

Fixes: flutter/flutter#101434

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.