### PR TITLE
[web] Migrate Flutter Web to JS static interop - 3.

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -55,7 +55,10 @@ external set debugH5vccSetter(H5vcc? value);
 
 @JS()
 @anonymous
-abstract class H5vcc {
+@staticInterop
+abstract class H5vcc {}
+
+extension H5vccExtension on H5vcc {
   external CanvasKit? get canvasKit;
 }
 


### PR DESCRIPTION
This is CL 3 in a series of CLs to migrate Flutter Web to the new JS static interop API.

This CL migrates H5vcc to static interop and updates a test.