### PR TITLE
[fuchsia] Fix --unopt build for Fuchsia.

### DIFF
--- a/shell/platform/fuchsia/flutter/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/BUILD.gn
@@ -132,6 +132,7 @@ template("runner_sources") {
       "//flutter/assets",
       "//flutter/common",
       "//flutter/fml",
+      "//flutter/shell/platform/common/client_wrapper:client_wrapper_library_stubs",
       "//flutter/vulkan",
     ]
 
@@ -507,6 +508,7 @@ if (enable_unittests) {
              ":flutter_runner_sources",
              "//build/fuchsia/pkg:async-testing",
              "//build/fuchsia/pkg:sys_cpp_testing",
+             "//flutter/shell/platform/common/client_wrapper:client_wrapper_library_stubs",
              "//flutter/testing",
            ] + flutter_deps
   }
@@ -525,6 +527,7 @@ if (enable_unittests) {
     # embedder API.
     flutter_deps = [
       "//flutter/lib/ui",
+      "//flutter/shell/platform/common/client_wrapper:client_wrapper_library_stubs",
       "//third_party/dart/runtime:libdart_jit",
       "//third_party/dart/runtime/platform:libdart_platform_jit",
     ]

--- a/shell/platform/fuchsia/flutter/integration_flutter_tests/embedder/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/integration_flutter_tests/embedder/BUILD.gn
@@ -49,6 +49,7 @@ executable("flutter-embedder-test2-bin") {
     "$fuchsia_sdk_root/pkg:zx",
     "//flutter/shell/platform/fuchsia/flutter/integration_flutter_tests/fuchsia_testing/src/lib/ui/base_view",
     "//flutter/shell/platform/fuchsia/flutter/integration_flutter_tests/fuchsia_testing/src/ui/testing/views",
+    "//third_party/dart/runtime:libdart_jit",
     "//third_party/googletest:gtest_main",
   ]
 }

--- a/shell/platform/fuchsia/flutter/platform_view.cc
+++ b/shell/platform/fuchsia/flutter/platform_view.cc
@@ -441,7 +441,7 @@ void PlatformView::OnKeyEvent(
 }
 
 void PlatformView::ActivateIme() {
-  DEBUG_CHECK(last_text_state_, LOG_TAG, "");
+  DEBUG_CHECK(last_text_state_ != nullptr, LOG_TAG, "");
 
   text_sync_service_->GetInputMethodEditor(
       fuchsia::ui::input::KeyboardType::TEXT,       // keyboard type

--- a/shell/platform/fuchsia/runtime/dart/utils/BUILD.gn
+++ b/shell/platform/fuchsia/runtime/dart/utils/BUILD.gn
@@ -6,6 +6,7 @@ assert(is_fuchsia)
 
 import("//build/fuchsia/sdk.gni")
 import("//flutter/common/config.gni")
+import("//flutter/testing/testing.gni")
 
 config("utils_config") {
   include_dirs = [ "../../.." ]
@@ -80,6 +81,10 @@ make_utils("utils") {
   deps = [ "//third_party/dart/runtime/bin:elf_loader" ]
 }
 
+test_fixtures("utils_fixtures") {
+  fixtures = []
+}
+
 executable("dart_utils_unittests") {
   testonly = true
 
@@ -87,13 +92,18 @@ executable("dart_utils_unittests") {
 
   sources = [ "build_info_unittests.cc" ]
 
-  # This is needed for //third_party/googletest for linking zircon symbols.
-  libs = [ "$fuchsia_sdk_path/arch/$target_cpu/sysroot/lib/libzircon.so" ]
+  libs = [
+    # This is needed for //third_party/googletest for linking zircon symbols.
+    "$fuchsia_sdk_path/arch/$target_cpu/sysroot/lib/libzircon.so",
+  ]
 
   deps = [
     ":utils",
+    ":utils_fixtures",
     "$fuchsia_sdk_root/pkg:sys_inspect_cpp",
     "//flutter/testing",
+    "//third_party/dart/runtime:libdart_jit",
+    "//third_party/dart/runtime/bin:dart_io_api",
   ]
 }
 


### PR DESCRIPTION
Several symbols were failing to link in the `--unopt` build for Fuchsia. I assume this is because those symbols are not being optimized out of the build.

To fix this I added several dependencies to some unit tests:

- [`client_wrapper_library_stubs`](https://github.com/flutter/engine/blob/2962099077b36704071802ea5595f4a016a1c214/shell/platform/common/client_wrapper/testing/stub_flutter_api.cc): Used to define stub versions of a few desktop messaging methods, e.g. `FlutterDesktopMessengerSend `.
- `libdart_jit`: Implementations of Dart C++ APIs used by the Dart SDK.
- `dart_io_api`: Implementations of IO-related Dart C++ APIs used by the Dart SDK.

I also had to add a dependency on `client_wrapper_library_stubs` to our runners to make them link in `--unopt`. That seems weird. I'm doing some additional testing to see if those stubs are actually getting linked into non-`--unopt` builds or discarded.