### PR TITLE
Clean obsolete 'shared_resource_context'

### DIFF
--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -539,7 +539,6 @@ std::unique_ptr<Shell> Shell::Spawn(
                              /*io_manager=*/std::move(io_manager));
       },
       is_gpu_disabled);
-  result->shared_resource_context_ = io_manager_->GetSharedResourceContext();
   result->RunEngine(std::move(run_configuration));
   return result;
 }
@@ -798,16 +797,11 @@ void Shell::OnPlatformViewCreated(std::unique_ptr<Surface> surface) {
 
   auto io_task = [io_manager = io_manager_->GetWeakPtr(), platform_view,
                   ui_task_runner = task_runners_.GetUITaskRunner(), ui_task,
-                  shared_resource_context = shared_resource_context_,
                   raster_task_runner = task_runners_.GetRasterTaskRunner(),
                   raster_task, should_post_raster_task, &latch] {
     if (io_manager && !io_manager->GetResourceContext()) {
-      sk_sp<GrDirectContext> resource_context;
-      if (shared_resource_context) {
-        resource_context = shared_resource_context;
-      } else {
-        resource_context = platform_view->CreateResourceContext();
-      }
+      sk_sp<GrDirectContext> resource_context =
+          platform_view->CreateResourceContext();
       io_manager->NotifyResourceContextAvailable(resource_context);
     }
     // Step 1: Post a task on the UI thread to tell the engine that it has

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -476,8 +476,6 @@ class Shell final : public PlatformView::Delegate,
   // How many frames have been timed since last report.
   size_t UnreportedFramesCount() const;
 
-  sk_sp<GrDirectContext> shared_resource_context_;
-
   Shell(DartVMRef vm,
         TaskRunners task_runners,
         fml::RefPtr<fml::RasterThreadMerger> parent_merger,

--- a/shell/common/shell_io_manager.cc
+++ b/shell/common/shell_io_manager.cc
@@ -119,8 +119,4 @@ std::shared_ptr<impeller::Context> ShellIOManager::GetImpellerContext() const {
   return impeller_context_;
 }
 
-sk_sp<GrDirectContext> ShellIOManager::GetSharedResourceContext() const {
-  return resource_context_;
-};
-
 }  // namespace flutter

--- a/shell/common/shell_io_manager.h
+++ b/shell/common/shell_io_manager.h
@@ -62,8 +62,6 @@ class ShellIOManager final : public IOManager {
   // |IOManager|
   std::shared_ptr<impeller::Context> GetImpellerContext() const override;
 
-  sk_sp<GrDirectContext> GetSharedResourceContext() const;
-
  private:
   // Resource context management.
   sk_sp<GrDirectContext> resource_context_;


### PR DESCRIPTION
`shared_resource_context` introduced in https://github.com/flutter/engine/commit/4c11ced794d6716a9c2e7b44675c84143853c733 for sharing the resource context between `shell_io_manager`s

After this commit https://github.com/flutter/engine/commit/5ad06c2130f50910171208d5a68c6205018b969d,   `shell_io_manager` is shared between lightweight engines, so we don't need to provide `shared_resource_context` anymore.

The test is exists.
https://github.com/flutter/engine/blob/c2de44a59cf1e41709c27f67b507081d52fd3dd7/shell/common/shell_unittests.cc#L3042-L3046

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

