### PR TITLE
Migrate RuntimeEnvironment#application to ApplicationProvider#getApplicationContext

### DIFF
--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
@@ -24,6 +24,7 @@ import android.net.Uri;
 import android.view.View;
 import androidx.annotation.NonNull;
 import androidx.lifecycle.Lifecycle;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import io.flutter.FlutterInjector;
 import io.flutter.embedding.android.FlutterActivityAndFragmentDelegate.Host;
@@ -54,13 +55,13 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.robolectric.Robolectric;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 
 @Config(manifest = Config.NONE)
 @RunWith(AndroidJUnit4.class)
 public class FlutterActivityAndFragmentDelegateTest {
+  private final Context ctx = ApplicationProvider.getApplicationContext();
   private FlutterEngine mockFlutterEngine;
   private FlutterActivityAndFragmentDelegate.Host mockHost;
 
@@ -73,7 +74,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // Create a mocked Host, which is required by the delegate being tested.
     mockHost = mock(FlutterActivityAndFragmentDelegate.Host.class);
-    when(mockHost.getContext()).thenReturn(RuntimeEnvironment.application);
+    when(mockHost.getContext()).thenReturn(ctx);
     when(mockHost.getActivity()).thenReturn(Robolectric.setupActivity(Activity.class));
     when(mockHost.getLifecycle()).thenReturn(mock(Lifecycle.class));
     when(mockHost.getFlutterShellArgs()).thenReturn(new FlutterShellArgs(new String[] {}));
@@ -98,7 +99,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // We're testing lifecycle behaviors, which require/expect that certain methods have already
     // been executed by the time they run. Therefore, we run those expected methods first.
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
     delegate.onCreateView(null, null, null, 0, true);
 
     // --- Execute the behavior under test ---
@@ -151,7 +152,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // We're testing lifecycle behaviors, which require/expect that certain methods have already
     // been executed by the time they run. Therefore, we run those expected methods first.
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
     delegate.onCreateView(null, null, null, 0, true);
     delegate.onStart();
     delegate.onResume();
@@ -173,7 +174,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // --- Execute the behavior under test ---
     // The FlutterEngine is created in onAttach().
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
 
     // Verify that the host was asked to provide a FlutterEngine.
     verify(mockHost, times(1)).provideFlutterEngine(any(Context.class));
@@ -200,7 +201,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // --- Execute the behavior under test ---
     // The FlutterEngine is obtained in onAttach().
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
     delegate.onCreateView(null, null, null, 0, true);
     delegate.onStart();
     delegate.onResume();
@@ -230,7 +231,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // --- Execute the behavior under test ---
     // The FlutterEngine existence is verified in onAttach()
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
 
     // Expect IllegalStateException.
   }
@@ -243,7 +244,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // --- Execute the behavior under test ---
     // The FlutterEngine is created in onAttach().
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
 
     // Verify that the host was asked to configure our FlutterEngine.
     verify(mockHost, times(1)).configureFlutterEngine(mockFlutterEngine);
@@ -256,7 +257,7 @@ public class FlutterActivityAndFragmentDelegateTest {
     FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
 
     // --- Execute the behavior under test ---
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
     delegate.onCreateView(null, null, null, 0, true);
 
     // Verify that the host was asked to configure a FlutterSurfaceView.
@@ -267,7 +268,7 @@ public class FlutterActivityAndFragmentDelegateTest {
   public void itGivesHostAnOpportunityToConfigureFlutterTextureView() {
     // ---- Test setup ----
     Host customMockHost = mock(Host.class);
-    when(customMockHost.getContext()).thenReturn(RuntimeEnvironment.application);
+    when(customMockHost.getContext()).thenReturn(ctx);
     when(customMockHost.getActivity()).thenReturn(Robolectric.setupActivity(Activity.class));
     when(customMockHost.getLifecycle()).thenReturn(mock(Lifecycle.class));
     when(customMockHost.getFlutterShellArgs()).thenReturn(new FlutterShellArgs(new String[] {}));
@@ -285,7 +286,7 @@ public class FlutterActivityAndFragmentDelegateTest {
         new FlutterActivityAndFragmentDelegate(customMockHost);
 
     // --- Execute the behavior under test ---
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
     delegate.onCreateView(null, null, null, 0, false);
 
     // Verify that the host was asked to configure a FlutterTextureView.
@@ -300,7 +301,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // --- Execute the behavior under test ---
     // The FlutterEngine is created in onAttach().
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
     delegate.onDetach();
 
     // Verify that the host was asked to configure our FlutterEngine.
@@ -318,7 +319,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // --- Execute the behavior under test ---
     // The initial route is sent in onStart().
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
     delegate.onCreateView(null, null, null, 0, true);
     delegate.onStart();
 
@@ -342,7 +343,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // --- Execute the behavior under test ---
     // Dart is executed in onStart().
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
     delegate.onCreateView(null, null, null, 0, true);
     delegate.onStart();
 
@@ -369,7 +370,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // --- Execute the behavior under test ---
     // Dart is executed in onStart().
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
     delegate.onCreateView(null, null, null, 0, true);
     delegate.onStart();
 
@@ -389,7 +390,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
 
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
     delegate.onCreateView(null, null, null, 0, true);
     delegate.onStart();
 
@@ -418,7 +419,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // --- Execute the behavior under test ---
     // Dart is executed in onStart().
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
     delegate.onCreateView(null, null, null, 0, true);
     delegate.onStart();
 
@@ -441,7 +442,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // --- Execute the behavior under test ---
     // Flutter is attached to the surrounding Activity in onAttach.
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
 
     // Verify that the ActivityControlSurface was told to attach to an Activity.
     verify(mockFlutterEngine.getActivityControlSurface(), times(1))
@@ -471,7 +472,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // --- Execute the behavior under test ---
     // Flutter is attached to the surrounding Activity in onAttach.
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
 
     // Make sure all of the other lifecycle methods can run safely as well
     // without a valid Activity
@@ -498,7 +499,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // --- Execute the behavior under test ---
     // The FlutterEngine is set up in onAttach().
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
 
     // Emulate the host and inform our delegate that the back button was pressed.
     delegate.onBackPressed();
@@ -514,7 +515,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // --- Execute the behavior under test ---
     // The FlutterEngine is set up in onAttach().
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
 
     // Emulate the host and call the method that we expect to be forwarded.
     delegate.onRequestPermissionsResult(0, new String[] {}, new int[] {});
@@ -527,7 +528,7 @@ public class FlutterActivityAndFragmentDelegateTest {
   @Test
   public void
       itSendsInitialRouteFromIntentOnStartIfNoInitialRouteFromActivityAndShouldHandleDeeplinking() {
-    Intent intent = FlutterActivity.createDefaultIntent(RuntimeEnvironment.application);
+    Intent intent = FlutterActivity.createDefaultIntent(ctx);
     intent.setData(Uri.parse("http://myApp/custom/route?query=test"));
 
     ActivityController<FlutterActivity> activityController =
@@ -542,7 +543,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // --- Execute the behavior under test ---
     // The FlutterEngine is set up in onAttach().
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
     delegate.onCreateView(null, null, null, 0, true);
     // Emulate app start.
     delegate.onStart();
@@ -555,7 +556,7 @@ public class FlutterActivityAndFragmentDelegateTest {
   @Test
   public void
       itSendsInitialRouteFromIntentOnStartIfNoInitialRouteFromActivityAndShouldHandleDeeplinkingWithQueryParameterAndFragment() {
-    Intent intent = FlutterActivity.createDefaultIntent(RuntimeEnvironment.application);
+    Intent intent = FlutterActivity.createDefaultIntent(ctx);
     intent.setData(Uri.parse("http://myApp/custom/route?query=test#fragment"));
 
     ActivityController<FlutterActivity> activityController =
@@ -570,7 +571,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // --- Execute the behavior under test ---
     // The FlutterEngine is set up in onAttach().
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
     delegate.onCreateView(null, null, null, 0, true);
     // Emulate app start.
     delegate.onStart();
@@ -583,7 +584,7 @@ public class FlutterActivityAndFragmentDelegateTest {
   @Test
   public void
       itSendsInitialRouteFromIntentOnStartIfNoInitialRouteFromActivityAndShouldHandleDeeplinkingWithFragmentNoQueryParameter() {
-    Intent intent = FlutterActivity.createDefaultIntent(RuntimeEnvironment.application);
+    Intent intent = FlutterActivity.createDefaultIntent(ctx);
     intent.setData(Uri.parse("http://myApp/custom/route#fragment"));
 
     ActivityController<FlutterActivity> activityController =
@@ -598,7 +599,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // --- Execute the behavior under test ---
     // The FlutterEngine is set up in onAttach().
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
     delegate.onCreateView(null, null, null, 0, true);
     // Emulate app start.
     delegate.onStart();
@@ -611,7 +612,7 @@ public class FlutterActivityAndFragmentDelegateTest {
   @Test
   public void
       itSendsInitialRouteFromIntentOnStartIfNoInitialRouteFromActivityAndShouldHandleDeeplinkingNoQueryParameter() {
-    Intent intent = FlutterActivity.createDefaultIntent(RuntimeEnvironment.application);
+    Intent intent = FlutterActivity.createDefaultIntent(ctx);
     intent.setData(Uri.parse("http://myApp/custom/route"));
 
     ActivityController<FlutterActivity> activityController =
@@ -626,7 +627,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // --- Execute the behavior under test ---
     // The FlutterEngine is set up in onAttach().
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
     delegate.onCreateView(null, null, null, 0, true);
     // Emulate app start.
     delegate.onStart();
@@ -638,7 +639,7 @@ public class FlutterActivityAndFragmentDelegateTest {
   @Test
   public void itSendsdefaultInitialRouteOnStartIfNotDeepLinkingFromIntent() {
     // Creates an empty intent without launch uri.
-    Intent intent = FlutterActivity.createDefaultIntent(RuntimeEnvironment.application);
+    Intent intent = FlutterActivity.createDefaultIntent(ctx);
 
     ActivityController<FlutterActivity> activityController =
         Robolectric.buildActivity(FlutterActivity.class, intent);
@@ -652,7 +653,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // --- Execute the behavior under test ---
     // The FlutterEngine is set up in onAttach().
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
     delegate.onCreateView(null, null, null, 0, true);
     // Emulate app start.
     delegate.onStart();
@@ -669,7 +670,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // --- Execute the behavior under test ---
     // The FlutterEngine is set up in onAttach().
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
 
     Intent mockIntent = mock(Intent.class);
     when(mockIntent.getData()).thenReturn(Uri.parse("http://myApp/custom/route?query=test"));
@@ -689,7 +690,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // --- Execute the behavior under test ---
     // The FlutterEngine is set up in onAttach().
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
 
     Intent mockIntent = mock(Intent.class);
 
@@ -711,7 +712,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // --- Execute the behavior under test ---
     // The FlutterEngine is set up in onAttach().
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
 
     Intent mockIntent = mock(Intent.class);
     when(mockIntent.getData())
@@ -732,7 +733,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // --- Execute the behavior under test ---
     // The FlutterEngine is set up in onAttach().
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
 
     Intent mockIntent = mock(Intent.class);
     when(mockIntent.getData()).thenReturn(Uri.parse("http://myApp/custom/route#fragment"));
@@ -751,7 +752,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // --- Execute the behavior under test ---
     // The FlutterEngine is set up in onAttach().
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
 
     Intent mockIntent = mock(Intent.class);
     when(mockIntent.getData()).thenReturn(Uri.parse("http://myApp/custom/route"));
@@ -769,7 +770,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // --- Execute the behavior under test ---
     // The FlutterEngine is set up in onAttach().
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
 
     // Emulate the host and call the method that we expect to be forwarded.
     delegate.onNewIntent(mock(Intent.class));
@@ -785,7 +786,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // --- Execute the behavior under test ---
     // The FlutterEngine is set up in onAttach().
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
 
     // Emulate the host and call the method that we expect to be forwarded.
     delegate.onActivityResult(0, 0, null);
@@ -802,7 +803,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // --- Execute the behavior under test ---
     // The FlutterEngine is set up in onAttach().
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
 
     // Emulate the host and call the method that we expect to be forwarded.
     delegate.onUserLeaveHint();
@@ -818,7 +819,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // --- Execute the behavior under test ---
     // The FlutterEngine is set up in onAttach().
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
 
     // Test assumes no frames have been displayed.
     verify(mockHost, times(0)).onFlutterUiDisplayed();
@@ -870,7 +871,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // --- Execute the behavior under test ---
     // The FlutterEngine is set up in onAttach().
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
 
     // Emulate the host and call the method that we expect to be forwarded.
     delegate.onLowMemory();
@@ -891,7 +892,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // --- Execute the behavior under test ---
     // Push the delegate through all lifecycle methods all the way to destruction.
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
     delegate.onCreateView(null, null, null, 0, true);
     delegate.onStart();
     delegate.onResume();
@@ -915,7 +916,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // --- Execute the behavior under test ---
     // Push the delegate through all lifecycle methods all the way to destruction.
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
     delegate.onCreateView(null, null, null, 0, true);
     delegate.onStart();
     delegate.onResume();
@@ -946,7 +947,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // --- Execute the behavior under test ---
     // Push the delegate through all lifecycle methods all the way to destruction.
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
     delegate.onCreateView(null, null, null, 0, true);
     delegate.onStart();
     delegate.onResume();
@@ -978,7 +979,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // --- Execute the behavior under test ---
     // Push the delegate through all lifecycle methods all the way to destruction.
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
     delegate.onCreateView(null, null, null, 0, true);
     delegate.onStart();
     delegate.onResume();
@@ -998,7 +999,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // We're testing lifecycle behaviors, which require/expect that certain methods have already
     // been executed by the time they run. Therefore, we run those expected methods first.
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
 
     // --- Execute the behavior under test ---
     boolean shouldDelayFirstAndroidViewDraw = true;
@@ -1014,7 +1015,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // We're testing lifecycle behaviors, which require/expect that certain methods have already
     // been executed by the time they run. Therefore, we run those expected methods first.
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
 
     // --- Execute the behavior under test ---
     boolean shouldDelayFirstAndroidViewDraw = false;
@@ -1031,7 +1032,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // We're testing lifecycle behaviors, which require/expect that certain methods have already
     // been executed by the time they run. Therefore, we run those expected methods first.
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
 
     // --- Execute the behavior under test ---
     boolean shouldDelayFirstAndroidViewDraw = true;
@@ -1049,7 +1050,7 @@ public class FlutterActivityAndFragmentDelegateTest {
     FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
 
     // --- Execute the behavior under test ---
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
     delegate.onCreateView(null, null, null, 0, true);
     delegate.onStart();
     // Verify that the flutterView is visible.
@@ -1073,7 +1074,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // We're testing lifecycle behaviors, which require/expect that certain methods have already
     // been executed by the time they run. Therefore, we run those expected methods first.
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
 
     // --- Execute the behavior under test ---
     boolean shouldDelayFirstAndroidViewDraw = true;

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
@@ -28,6 +28,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.lifecycle.DefaultLifecycleObserver;
 import androidx.lifecycle.LifecycleOwner;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import io.flutter.FlutterInjector;
 import io.flutter.embedding.android.FlutterActivityLaunchConfigs.BackgroundMode;
@@ -48,13 +49,13 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 
 @Config(manifest = Config.NONE)
 @RunWith(AndroidJUnit4.class)
 public class FlutterActivityTest {
+  private final Context ctx = ApplicationProvider.getApplicationContext();
   boolean isDelegateAttached;
 
   @Before
@@ -77,7 +78,7 @@ public class FlutterActivityTest {
 
   @Test
   public void flutterViewHasId() {
-    Intent intent = FlutterActivity.createDefaultIntent(RuntimeEnvironment.application);
+    Intent intent = FlutterActivity.createDefaultIntent(ctx);
     ActivityController<FlutterActivity> activityController =
         Robolectric.buildActivity(FlutterActivity.class, intent);
     FlutterActivity activity = activityController.get();
@@ -89,7 +90,7 @@ public class FlutterActivityTest {
 
   @Test
   public void itCreatesDefaultIntentWithExpectedDefaults() {
-    Intent intent = FlutterActivity.createDefaultIntent(RuntimeEnvironment.application);
+    Intent intent = FlutterActivity.createDefaultIntent(ctx);
     ActivityController<FlutterActivity> activityController =
         Robolectric.buildActivity(FlutterActivity.class, intent);
     FlutterActivity flutterActivity = activityController.get();
@@ -116,7 +117,7 @@ public class FlutterActivityTest {
     // launching Intent, so this test explicitly verifies that even illegal Intents
     // result in the automatic destruction of a non-cached FlutterEngine, which prevents
     // the breakage of memory usage benchmark tests.
-    Intent intent = new Intent(RuntimeEnvironment.application, FlutterActivity.class);
+    Intent intent = new Intent(ctx, FlutterActivity.class);
     ActivityController<FlutterActivity> activityController =
         Robolectric.buildActivity(FlutterActivity.class, intent);
     FlutterActivity flutterActivity = activityController.get();
@@ -127,8 +128,7 @@ public class FlutterActivityTest {
 
   @Test
   public void itDoesNotDestroyFlutterEngineWhenProvidedByHost() {
-    Intent intent =
-        new Intent(RuntimeEnvironment.application, FlutterActivityWithProvidedEngine.class);
+    Intent intent = new Intent(ctx, FlutterActivityWithProvidedEngine.class);
     ActivityController<FlutterActivityWithProvidedEngine> activityController =
         Robolectric.buildActivity(FlutterActivityWithProvidedEngine.class, intent);
     activityController.create();
@@ -144,7 +144,7 @@ public class FlutterActivityTest {
             .initialRoute("/custom/route")
             .dartEntrypointArgs(new ArrayList<String>(Arrays.asList("foo", "bar")))
             .backgroundMode(BackgroundMode.transparent)
-            .build(RuntimeEnvironment.application);
+            .build(ctx);
     ActivityController<FlutterActivity> activityController =
         Robolectric.buildActivity(FlutterActivity.class, intent);
     FlutterActivity flutterActivity = activityController.get();
@@ -166,9 +166,7 @@ public class FlutterActivityTest {
   public void itReturnsValueFromMetaDataWhenCallsShouldHandleDeepLinkingCase1()
       throws PackageManager.NameNotFoundException {
     Intent intent =
-        FlutterActivity.withNewEngine()
-            .backgroundMode(BackgroundMode.transparent)
-            .build(RuntimeEnvironment.application);
+        FlutterActivity.withNewEngine().backgroundMode(BackgroundMode.transparent).build(ctx);
     ActivityController<FlutterActivity> activityController =
         Robolectric.buildActivity(FlutterActivity.class, intent);
     FlutterActivity flutterActivity = activityController.get();
@@ -183,9 +181,7 @@ public class FlutterActivityTest {
   public void itReturnsValueFromMetaDataWhenCallsShouldHandleDeepLinkingCase2()
       throws PackageManager.NameNotFoundException {
     Intent intent =
-        FlutterActivity.withNewEngine()
-            .backgroundMode(BackgroundMode.transparent)
-            .build(RuntimeEnvironment.application);
+        FlutterActivity.withNewEngine().backgroundMode(BackgroundMode.transparent).build(ctx);
     ActivityController<FlutterActivity> activityController =
         Robolectric.buildActivity(FlutterActivity.class, intent);
     FlutterActivity flutterActivity = activityController.get();
@@ -200,9 +196,7 @@ public class FlutterActivityTest {
   public void itReturnsValueFromMetaDataWhenCallsShouldHandleDeepLinkingCase3()
       throws PackageManager.NameNotFoundException {
     Intent intent =
-        FlutterActivity.withNewEngine()
-            .backgroundMode(BackgroundMode.transparent)
-            .build(RuntimeEnvironment.application);
+        FlutterActivity.withNewEngine().backgroundMode(BackgroundMode.transparent).build(ctx);
     ActivityController<FlutterActivity> activityController =
         Robolectric.buildActivity(FlutterActivity.class, intent);
     FlutterActivity flutterActivity = activityController.get();
@@ -219,7 +213,7 @@ public class FlutterActivityTest {
     Intent intent =
         FlutterActivity.withCachedEngine("my_cached_engine")
             .destroyEngineWithActivity(false)
-            .build(RuntimeEnvironment.application);
+            .build(ctx);
     ActivityController<FlutterActivity> activityController =
         Robolectric.buildActivity(FlutterActivity.class, intent);
     FlutterActivity flutterActivity = activityController.get();
@@ -235,7 +229,7 @@ public class FlutterActivityTest {
     Intent intent =
         FlutterActivity.withCachedEngine("my_cached_engine")
             .destroyEngineWithActivity(true)
-            .build(RuntimeEnvironment.application);
+            .build(ctx);
     ActivityController<FlutterActivity> activityController =
         Robolectric.buildActivity(FlutterActivity.class, intent);
     FlutterActivity flutterActivity = activityController.get();
@@ -248,7 +242,7 @@ public class FlutterActivityTest {
 
   @Test
   public void itRegistersPluginsAtConfigurationTime() {
-    Intent intent = FlutterActivity.createDefaultIntent(RuntimeEnvironment.application);
+    Intent intent = FlutterActivity.createDefaultIntent(ctx);
     ActivityController<FlutterActivity> activityController =
         Robolectric.buildActivity(FlutterActivity.class, intent);
     FlutterActivity activity = activityController.get();
@@ -269,8 +263,7 @@ public class FlutterActivityTest {
     FlutterEngine mockEngine = mock(FlutterEngine.class);
     FlutterEngineCache.getInstance().put("my_cached_engine", mockEngine);
 
-    Intent intent =
-        FlutterActivity.withCachedEngine("my_cached_engine").build(RuntimeEnvironment.application);
+    Intent intent = FlutterActivity.withCachedEngine("my_cached_engine").build(ctx);
     ActivityController<FlutterActivity> activityController =
         Robolectric.buildActivity(FlutterActivity.class, intent);
     FlutterActivity flutterActivity = activityController.get();
@@ -311,7 +304,7 @@ public class FlutterActivityTest {
 
   @Test
   public void itReturnsExclusiveAppComponent() {
-    Intent intent = FlutterActivity.createDefaultIntent(RuntimeEnvironment.application);
+    Intent intent = FlutterActivity.createDefaultIntent(ctx);
     ActivityController<FlutterActivity> activityController =
         Robolectric.buildActivity(FlutterActivity.class, intent);
     FlutterActivity flutterActivity = activityController.get();
@@ -324,7 +317,7 @@ public class FlutterActivityTest {
 
   @Test
   public void itDelaysDrawing() {
-    Intent intent = FlutterActivity.createDefaultIntent(RuntimeEnvironment.application);
+    Intent intent = FlutterActivity.createDefaultIntent(ctx);
     ActivityController<FlutterActivity> activityController =
         Robolectric.buildActivity(FlutterActivity.class, intent);
     FlutterActivity flutterActivity = activityController.get();
@@ -336,8 +329,7 @@ public class FlutterActivityTest {
 
   @Test
   public void itDoesNotDelayDrawingwhenUsingTextureRendering() {
-    Intent intent =
-        FlutterActivityWithTextureRendering.createDefaultIntent(RuntimeEnvironment.application);
+    Intent intent = FlutterActivityWithTextureRendering.createDefaultIntent(ctx);
     ActivityController<FlutterActivityWithTextureRendering> activityController =
         Robolectric.buildActivity(FlutterActivityWithTextureRendering.class, intent);
     FlutterActivityWithTextureRendering flutterActivity = activityController.get();
@@ -352,14 +344,12 @@ public class FlutterActivityTest {
     FlutterLoader mockFlutterLoader = mock(FlutterLoader.class);
     FlutterJNI mockFlutterJni = mock(FlutterJNI.class);
     when(mockFlutterJni.isAttached()).thenReturn(true);
-    FlutterEngine cachedEngine =
-        new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, mockFlutterJni);
+    FlutterEngine cachedEngine = new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni);
     FakeFlutterPlugin fakeFlutterPlugin = new FakeFlutterPlugin();
     cachedEngine.getPlugins().add(fakeFlutterPlugin);
     FlutterEngineCache.getInstance().put("my_cached_engine", cachedEngine);
 
-    Intent intent =
-        FlutterActivity.withCachedEngine("my_cached_engine").build(RuntimeEnvironment.application);
+    Intent intent = FlutterActivity.withCachedEngine("my_cached_engine").build(ctx);
     Robolectric.buildActivity(FlutterActivity.class, intent).setup();
     assertTrue(
         "Expected FakeFlutterPlugin onCreateCalled to be true", fakeFlutterPlugin.onCreateCalled);
@@ -367,8 +357,7 @@ public class FlutterActivityTest {
 
   @Test
   public void itDoesNotRegisterPluginsTwiceWhenUsingACachedEngine() {
-    Intent intent =
-        new Intent(RuntimeEnvironment.application, FlutterActivityWithProvidedEngine.class);
+    Intent intent = new Intent(ctx, FlutterActivityWithProvidedEngine.class);
     ActivityController<FlutterActivityWithProvidedEngine> activityController =
         Robolectric.buildActivity(FlutterActivityWithProvidedEngine.class, intent);
     activityController.create();
@@ -384,7 +373,7 @@ public class FlutterActivityTest {
 
   @Test
   public void itDoesNotCrashWhenSplashScreenMetadataIsNotDefined() {
-    Intent intent = FlutterActivity.createDefaultIntent(RuntimeEnvironment.application);
+    Intent intent = FlutterActivity.createDefaultIntent(ctx);
     ActivityController<FlutterActivity> activityController =
         Robolectric.buildActivity(FlutterActivity.class, intent);
     FlutterActivity flutterActivity = activityController.get();
@@ -405,8 +394,7 @@ public class FlutterActivityTest {
     FlutterEngine mockEngine = mock(FlutterEngine.class);
     FlutterEngineCache.getInstance().put("my_cached_engine", mockEngine);
 
-    Intent intent =
-        FlutterActivity.withCachedEngine("my_cached_engine").build(RuntimeEnvironment.application);
+    Intent intent = FlutterActivity.withCachedEngine("my_cached_engine").build(ctx);
     ActivityController<FlutterActivity> activityController =
         Robolectric.buildActivity(FlutterActivity.class, intent);
     FlutterActivity flutterActivity = activityController.get();
@@ -433,8 +421,7 @@ public class FlutterActivityTest {
     FlutterEngine mockEngine = mock(FlutterEngine.class);
     FlutterEngineCache.getInstance().put("my_cached_engine", mockEngine);
 
-    Intent intent =
-        FlutterActivity.withCachedEngine("my_cached_engine").build(RuntimeEnvironment.application);
+    Intent intent = FlutterActivity.withCachedEngine("my_cached_engine").build(ctx);
     ActivityController<FlutterActivity> activityController =
         Robolectric.buildActivity(FlutterActivity.class, intent);
     FlutterActivity flutterActivity = activityController.get();
@@ -456,20 +443,20 @@ public class FlutterActivityTest {
       sdk = Build.VERSION_CODES.KITKAT,
       shadows = {SplashShadowResources.class})
   public void itLoadsSplashScreenDrawable() throws PackageManager.NameNotFoundException {
-    Intent intent = FlutterActivity.createDefaultIntent(RuntimeEnvironment.application);
+    Intent intent = FlutterActivity.createDefaultIntent(ctx);
     ActivityController<FlutterActivity> activityController =
         Robolectric.buildActivity(FlutterActivity.class, intent);
     FlutterActivity flutterActivity = activityController.get();
 
     // Inject splash screen drawable resource id in the metadata.
-    PackageManager pm = RuntimeEnvironment.application.getPackageManager();
+    PackageManager pm = ctx.getPackageManager();
     ActivityInfo activityInfo =
         pm.getActivityInfo(flutterActivity.getComponentName(), PackageManager.GET_META_DATA);
     activityInfo.metaData = new Bundle();
     activityInfo.metaData.putInt(
         FlutterActivityLaunchConfigs.SPLASH_SCREEN_META_DATA_KEY,
         SplashShadowResources.SPLASH_DRAWABLE_ID);
-    shadowOf(RuntimeEnvironment.application.getPackageManager()).addOrUpdateActivity(activityInfo);
+    shadowOf(ctx.getPackageManager()).addOrUpdateActivity(activityInfo);
 
     // It should load the drawable.
     SplashScreen splashScreen = flutterActivity.provideSplashScreen();
@@ -485,20 +472,20 @@ public class FlutterActivityTest {
     // A drawable with theme references can be parsed only if the app theme is supplied
     // in getDrawable methods. This test verifies it by fetching a (fake) themed drawable.
     // On failure, a Resource.NotFoundException will ocurr.
-    Intent intent = FlutterActivity.createDefaultIntent(RuntimeEnvironment.application);
+    Intent intent = FlutterActivity.createDefaultIntent(ctx);
     ActivityController<FlutterActivity> activityController =
         Robolectric.buildActivity(FlutterActivity.class, intent);
     FlutterActivity flutterActivity = activityController.get();
 
     // Inject themed splash screen drawable resource id in the metadata.
-    PackageManager pm = RuntimeEnvironment.application.getPackageManager();
+    PackageManager pm = ctx.getPackageManager();
     ActivityInfo activityInfo =
         pm.getActivityInfo(flutterActivity.getComponentName(), PackageManager.GET_META_DATA);
     activityInfo.metaData = new Bundle();
     activityInfo.metaData.putInt(
         FlutterActivityLaunchConfigs.SPLASH_SCREEN_META_DATA_KEY,
         SplashShadowResources.THEMED_SPLASH_DRAWABLE_ID);
-    shadowOf(RuntimeEnvironment.application.getPackageManager()).addOrUpdateActivity(activityInfo);
+    shadowOf(ctx.getPackageManager()).addOrUpdateActivity(activityInfo);
 
     // It should load the drawable.
     SplashScreen splashScreen = flutterActivity.provideSplashScreen();
@@ -508,17 +495,17 @@ public class FlutterActivityTest {
   @Test
   public void itWithMetadataWithoutSplashScreenResourceKeyDoesNotProvideSplashScreen()
       throws PackageManager.NameNotFoundException {
-    Intent intent = FlutterActivity.createDefaultIntent(RuntimeEnvironment.application);
+    Intent intent = FlutterActivity.createDefaultIntent(ctx);
     ActivityController<FlutterActivity> activityController =
         Robolectric.buildActivity(FlutterActivity.class, intent);
     FlutterActivity flutterActivity = activityController.get();
 
     // Setup an empty metadata file.
-    PackageManager pm = RuntimeEnvironment.application.getPackageManager();
+    PackageManager pm = ctx.getPackageManager();
     ActivityInfo activityInfo =
         pm.getActivityInfo(flutterActivity.getComponentName(), PackageManager.GET_META_DATA);
     activityInfo.metaData = new Bundle();
-    shadowOf(RuntimeEnvironment.application.getPackageManager()).addOrUpdateActivity(activityInfo);
+    shadowOf(ctx.getPackageManager()).addOrUpdateActivity(activityInfo);
 
     // It should not load the drawable.
     SplashScreen splashScreen = flutterActivity.provideSplashScreen();
@@ -528,8 +515,7 @@ public class FlutterActivityTest {
   @Test
   @Config(minSdk = Build.VERSION_CODES.JELLY_BEAN, maxSdk = Build.VERSION_CODES.P)
   public void fullyDrawn_beforeAndroidQ() {
-    Intent intent =
-        FlutterActivityWithReportFullyDrawn.createDefaultIntent(RuntimeEnvironment.application);
+    Intent intent = FlutterActivityWithReportFullyDrawn.createDefaultIntent(ctx);
     ActivityController<FlutterActivityWithReportFullyDrawn> activityController =
         Robolectric.buildActivity(FlutterActivityWithReportFullyDrawn.class, intent);
     FlutterActivityWithReportFullyDrawn flutterActivity = activityController.get();
@@ -543,8 +529,7 @@ public class FlutterActivityTest {
   @Test
   @Config(minSdk = Build.VERSION_CODES.Q)
   public void fullyDrawn_fromAndroidQ() {
-    Intent intent =
-        FlutterActivityWithReportFullyDrawn.createDefaultIntent(RuntimeEnvironment.application);
+    Intent intent = FlutterActivityWithReportFullyDrawn.createDefaultIntent(ctx);
     ActivityController<FlutterActivityWithReportFullyDrawn> activityController =
         Robolectric.buildActivity(FlutterActivityWithReportFullyDrawn.class, intent);
     FlutterActivityWithReportFullyDrawn flutterActivity = activityController.get();

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterAndroidComponentTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterAndroidComponentTest.java
@@ -21,6 +21,7 @@ import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.lifecycle.Lifecycle;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.FlutterEngineCache;
@@ -40,13 +41,14 @@ import org.mockito.InOrder;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.robolectric.Robolectric;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 
 @Config(manifest = Config.NONE)
 @RunWith(AndroidJUnit4.class)
 public class FlutterAndroidComponentTest {
+  private final Context ctx = ApplicationProvider.getApplicationContext();
+
   @Test
   public void pluginsReceiveFlutterPluginBinding() {
     // ---- Test setup ----
@@ -54,8 +56,7 @@ public class FlutterAndroidComponentTest {
     FlutterLoader mockFlutterLoader = mock(FlutterLoader.class);
     FlutterJNI mockFlutterJni = mock(FlutterJNI.class);
     when(mockFlutterJni.isAttached()).thenReturn(true);
-    FlutterEngine cachedEngine =
-        spy(new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, mockFlutterJni));
+    FlutterEngine cachedEngine = spy(new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni));
     FlutterEngineCache.getInstance().put("my_flutter_engine", cachedEngine);
 
     // Add mock plugin.
@@ -71,7 +72,7 @@ public class FlutterAndroidComponentTest {
 
     // --- Execute the behavior under test ---
     // Push the delegate through all lifecycle methods all the way to destruction.
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
 
     // Verify that the plugin is attached to the FlutterEngine.
     ArgumentCaptor<FlutterPlugin.FlutterPluginBinding> pluginBindingCaptor =
@@ -109,8 +110,7 @@ public class FlutterAndroidComponentTest {
     FlutterLoader mockFlutterLoader = mock(FlutterLoader.class);
     FlutterJNI mockFlutterJni = mock(FlutterJNI.class);
     when(mockFlutterJni.isAttached()).thenReturn(true);
-    FlutterEngine cachedEngine =
-        spy(new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, mockFlutterJni));
+    FlutterEngine cachedEngine = spy(new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni));
     FlutterEngineCache.getInstance().put("my_flutter_engine", cachedEngine);
 
     // Add mock plugin.
@@ -143,7 +143,7 @@ public class FlutterAndroidComponentTest {
 
     // --- Execute the behavior under test ---
     // Push the delegate through all lifecycle methods all the way to destruction.
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
 
     // Verify plugin was given an ActivityPluginBinding.
     ArgumentCaptor<ActivityPluginBinding> pluginBindingCaptor =
@@ -182,8 +182,7 @@ public class FlutterAndroidComponentTest {
     FlutterLoader mockFlutterLoader = mock(FlutterLoader.class);
     FlutterJNI mockFlutterJni = mock(FlutterJNI.class);
     when(mockFlutterJni.isAttached()).thenReturn(true);
-    FlutterEngine cachedEngine =
-        spy(new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, mockFlutterJni));
+    FlutterEngine cachedEngine = spy(new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni));
     FlutterEngineCache.getInstance().put("my_flutter_engine", cachedEngine);
 
     // Create a fake Host, which is required by the delegate.
@@ -195,7 +194,7 @@ public class FlutterAndroidComponentTest {
 
     // --- Execute the behavior under test ---
     // Push the delegate through all lifecycle methods all the way to destruction.
-    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onAttach(ctx);
     delegate.onRestoreInstanceState(null);
     delegate.onCreateView(null, null, null, 0, true);
     delegate.onStart();
@@ -215,14 +214,12 @@ public class FlutterAndroidComponentTest {
     FlutterLoader mockFlutterLoader = mock(FlutterLoader.class);
     FlutterJNI mockFlutterJni = mock(FlutterJNI.class);
     when(mockFlutterJni.isAttached()).thenReturn(true);
-    FlutterEngine cachedEngine =
-        spy(new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, mockFlutterJni));
+    FlutterEngine cachedEngine = spy(new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni));
     FlutterEngineCache.getInstance().put("my_flutter_engine", cachedEngine);
     LifecycleChannel mockLifecycleChannel = mock(LifecycleChannel.class);
     when(cachedEngine.getLifecycleChannel()).thenReturn(mockLifecycleChannel);
 
-    Intent intent =
-        FlutterActivity.withCachedEngine("my_flutter_engine").build(RuntimeEnvironment.application);
+    Intent intent = FlutterActivity.withCachedEngine("my_flutter_engine").build(ctx);
     ActivityController<FlutterActivity> activityController1 =
         Robolectric.buildActivity(FlutterActivity.class, intent);
     activityController1.create().start().resume();
@@ -265,7 +262,7 @@ public class FlutterAndroidComponentTest {
     @NonNull
     @Override
     public Context getContext() {
-      return RuntimeEnvironment.application;
+      return ApplicationProvider.getApplicationContext();
     }
 
     @Nullable

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentActivityTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentActivityTest.java
@@ -24,6 +24,7 @@ import android.widget.FrameLayout;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.test.core.app.ActivityScenario;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import io.flutter.FlutterInjector;
 import io.flutter.embedding.android.FlutterActivityLaunchConfigs.BackgroundMode;
@@ -37,13 +38,14 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 
 @Config(manifest = Config.NONE)
 @RunWith(AndroidJUnit4.class)
 public class FlutterFragmentActivityTest {
+  private final Context ctx = ApplicationProvider.getApplicationContext();
+
   @Before
   public void setUp() {
     FlutterInjector.reset();
@@ -256,7 +258,7 @@ public class FlutterFragmentActivityTest {
 
   @Test
   public void itDoesNotCrashWhenSplashScreenMetadataIsNotDefined() {
-    Intent intent = FlutterFragmentActivity.createDefaultIntent(RuntimeEnvironment.application);
+    Intent intent = FlutterFragmentActivity.createDefaultIntent(ctx);
     ActivityController<FlutterFragmentActivity> activityController =
         Robolectric.buildActivity(FlutterFragmentActivity.class, intent);
     FlutterFragmentActivity fragmentActivity = activityController.get();
@@ -272,20 +274,20 @@ public class FlutterFragmentActivityTest {
       sdk = Build.VERSION_CODES.KITKAT,
       shadows = {SplashShadowResources.class})
   public void itLoadsSplashScreenDrawable() throws PackageManager.NameNotFoundException {
-    Intent intent = FlutterFragmentActivity.createDefaultIntent(RuntimeEnvironment.application);
+    Intent intent = FlutterFragmentActivity.createDefaultIntent(ctx);
     ActivityController<FlutterFragmentActivity> activityController =
         Robolectric.buildActivity(FlutterFragmentActivity.class, intent);
     FlutterFragmentActivity activity = activityController.get();
 
     // Inject splash screen drawable resource id in the metadata
-    PackageManager pm = RuntimeEnvironment.application.getPackageManager();
+    PackageManager pm = ctx.getPackageManager();
     ActivityInfo activityInfo =
         pm.getActivityInfo(activity.getComponentName(), PackageManager.GET_META_DATA);
     activityInfo.metaData = new Bundle();
     activityInfo.metaData.putInt(
         FlutterActivityLaunchConfigs.SPLASH_SCREEN_META_DATA_KEY,
         SplashShadowResources.SPLASH_DRAWABLE_ID);
-    shadowOf(RuntimeEnvironment.application.getPackageManager()).addOrUpdateActivity(activityInfo);
+    shadowOf(ctx.getPackageManager()).addOrUpdateActivity(activityInfo);
 
     // It should load the drawable.
     SplashScreen splashScreen = activity.provideSplashScreen();
@@ -301,20 +303,20 @@ public class FlutterFragmentActivityTest {
     // A drawable with theme references can be parsed only if the app theme is supplied
     // in getDrawable methods. This test verifies it by fetching a (fake) themed drawable.
     // On failure, a Resource.NotFoundException will ocurr.
-    Intent intent = FlutterFragmentActivity.createDefaultIntent(RuntimeEnvironment.application);
+    Intent intent = FlutterFragmentActivity.createDefaultIntent(ctx);
     ActivityController<FlutterFragmentActivity> activityController =
         Robolectric.buildActivity(FlutterFragmentActivity.class, intent);
     FlutterFragmentActivity activity = activityController.get();
 
     // Inject themed splash screen drawable resource id in the metadata.
-    PackageManager pm = RuntimeEnvironment.application.getPackageManager();
+    PackageManager pm = ctx.getPackageManager();
     ActivityInfo activityInfo =
         pm.getActivityInfo(activity.getComponentName(), PackageManager.GET_META_DATA);
     activityInfo.metaData = new Bundle();
     activityInfo.metaData.putInt(
         FlutterActivityLaunchConfigs.SPLASH_SCREEN_META_DATA_KEY,
         SplashShadowResources.THEMED_SPLASH_DRAWABLE_ID);
-    shadowOf(RuntimeEnvironment.application.getPackageManager()).addOrUpdateActivity(activityInfo);
+    shadowOf(ctx.getPackageManager()).addOrUpdateActivity(activityInfo);
 
     // It should load the drawable.
     SplashScreen splashScreen = activity.provideSplashScreen();
@@ -324,17 +326,17 @@ public class FlutterFragmentActivityTest {
   @Test
   public void itWithMetadataWithoutSplashScreenResourceKeyDoesNotProvideSplashScreen()
       throws PackageManager.NameNotFoundException {
-    Intent intent = FlutterFragmentActivity.createDefaultIntent(RuntimeEnvironment.application);
+    Intent intent = FlutterFragmentActivity.createDefaultIntent(ctx);
     ActivityController<FlutterFragmentActivity> activityController =
         Robolectric.buildActivity(FlutterFragmentActivity.class, intent);
     FlutterFragmentActivity activity = activityController.get();
 
     // Setup an empty metadata file.
-    PackageManager pm = RuntimeEnvironment.application.getPackageManager();
+    PackageManager pm = ctx.getPackageManager();
     ActivityInfo activityInfo =
         pm.getActivityInfo(activity.getComponentName(), PackageManager.GET_META_DATA);
     activityInfo.metaData = new Bundle();
-    shadowOf(RuntimeEnvironment.application.getPackageManager()).addOrUpdateActivity(activityInfo);
+    shadowOf(ctx.getPackageManager()).addOrUpdateActivity(activityInfo);
 
     // It should not load the drawable.
     SplashScreen splashScreen = activity.provideSplashScreen();

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
@@ -13,8 +13,10 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import android.content.Context;
 import androidx.activity.OnBackPressedCallback;
 import androidx.fragment.app.FragmentActivity;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.FlutterEngineCache;
@@ -26,12 +28,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 @Config(manifest = Config.NONE)
 @RunWith(AndroidJUnit4.class)
 public class FlutterFragmentTest {
+  private final Context ctx = ApplicationProvider.getApplicationContext();
   boolean isDelegateAttached;
 
   @Test
@@ -234,8 +236,7 @@ public class FlutterFragmentTest {
     when(flutterJNI.isAttached()).thenReturn(true);
 
     FlutterEngine flutterEngine =
-        new FlutterEngine(
-            RuntimeEnvironment.application, new FlutterLoader(), flutterJNI, null, false);
+        new FlutterEngine(ctx, new FlutterLoader(), flutterJNI, null, false);
     FlutterEngineCache.getInstance().put("my_cached_engine", flutterEngine);
 
     FlutterFragment fragment =
@@ -268,8 +269,7 @@ public class FlutterFragmentTest {
     when(flutterJNI.isAttached()).thenReturn(true);
 
     FlutterEngine flutterEngine =
-        new FlutterEngine(
-            RuntimeEnvironment.application, new FlutterLoader(), flutterJNI, null, false);
+        new FlutterEngine(ctx, new FlutterLoader(), flutterJNI, null, false);
     FlutterEngineCache.getInstance().put("my_cached_engine", flutterEngine);
 
     FlutterFragment fragment =

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterTextureViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterTextureViewTest.java
@@ -7,10 +7,10 @@ import android.annotation.TargetApi;
 import android.graphics.SurfaceTexture;
 import android.view.Surface;
 import android.view.TextureView;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 @Config(manifest = Config.NONE)
@@ -19,7 +19,8 @@ import org.robolectric.annotation.Config;
 public class FlutterTextureViewTest {
   @Test
   public void surfaceTextureListenerReleasesRenderer() {
-    final FlutterTextureView textureView = new FlutterTextureView(RuntimeEnvironment.application);
+    final FlutterTextureView textureView =
+        new FlutterTextureView(ApplicationProvider.getApplicationContext());
     final Surface mockRenderSurface = mock(Surface.class);
 
     textureView.setRenderSurface(mockRenderSurface);

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
@@ -37,6 +37,7 @@ import android.view.WindowInsets;
 import android.view.WindowManager;
 import android.widget.FrameLayout;
 import androidx.core.util.Consumer;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.window.layout.FoldingFeature;
 import androidx.window.layout.WindowLayoutInfo;
@@ -70,6 +71,7 @@ import org.robolectric.shadows.ShadowDisplay;
 @RunWith(AndroidJUnit4.class)
 @TargetApi(30)
 public class FlutterViewTest {
+  private final Context ctx = ApplicationProvider.getApplicationContext();
   @Mock FlutterJNI mockFlutterJni;
   @Mock FlutterLoader mockFlutterLoader;
   @Spy PlatformViewsController platformViewsController;
@@ -83,8 +85,7 @@ public class FlutterViewTest {
   @Test
   public void attachToFlutterEngine_alertsPlatformViews() {
     FlutterView flutterView = new FlutterView(Robolectric.setupActivity(Activity.class));
-    FlutterEngine flutterEngine =
-        spy(new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, mockFlutterJni));
+    FlutterEngine flutterEngine = spy(new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni));
     when(flutterEngine.getPlatformViewsController()).thenReturn(platformViewsController);
 
     flutterView.attachToFlutterEngine(flutterEngine);
@@ -95,8 +96,7 @@ public class FlutterViewTest {
   @Test
   public void detachFromFlutterEngine_alertsPlatformViews() {
     FlutterView flutterView = new FlutterView(Robolectric.setupActivity(Activity.class));
-    FlutterEngine flutterEngine =
-        spy(new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, mockFlutterJni));
+    FlutterEngine flutterEngine = spy(new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni));
     when(flutterEngine.getPlatformViewsController()).thenReturn(platformViewsController);
 
     flutterView.attachToFlutterEngine(flutterEngine);
@@ -108,8 +108,7 @@ public class FlutterViewTest {
   @Test
   public void detachFromFlutterEngine_turnsOffA11y() {
     FlutterView flutterView = new FlutterView(Robolectric.setupActivity(Activity.class));
-    FlutterEngine flutterEngine =
-        spy(new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, mockFlutterJni));
+    FlutterEngine flutterEngine = spy(new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni));
     FlutterRenderer flutterRenderer = spy(new FlutterRenderer(mockFlutterJni));
     when(flutterEngine.getRenderer()).thenReturn(flutterRenderer);
 
@@ -121,9 +120,8 @@ public class FlutterViewTest {
 
   @Test
   public void detachFromFlutterEngine_revertImageView() {
-    FlutterView flutterView = new FlutterView(RuntimeEnvironment.application);
-    FlutterEngine flutterEngine =
-        spy(new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, mockFlutterJni));
+    FlutterView flutterView = new FlutterView(ctx);
+    FlutterEngine flutterEngine = spy(new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni));
 
     flutterView.attachToFlutterEngine(flutterEngine);
     assertFalse(flutterView.renderSurface instanceof FlutterImageView);
@@ -137,9 +135,8 @@ public class FlutterViewTest {
 
   @Test
   public void detachFromFlutterEngine_removeImageView() {
-    FlutterView flutterView = new FlutterView(RuntimeEnvironment.application);
-    FlutterEngine flutterEngine =
-        spy(new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, mockFlutterJni));
+    FlutterView flutterView = new FlutterView(ctx);
+    FlutterEngine flutterEngine = spy(new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni));
 
     flutterView.attachToFlutterEngine(flutterEngine);
     flutterView.convertToImageView();
@@ -155,8 +152,7 @@ public class FlutterViewTest {
 
   @Test
   public void detachFromFlutterEngine_closesImageView() {
-    FlutterEngine flutterEngine =
-        spy(new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, mockFlutterJni));
+    FlutterEngine flutterEngine = spy(new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni));
 
     FlutterRenderer flutterRenderer = spy(new FlutterRenderer(mockFlutterJni));
     when(flutterEngine.getRenderer()).thenReturn(flutterRenderer);
@@ -164,7 +160,7 @@ public class FlutterViewTest {
     FlutterImageView imageViewMock = mock(FlutterImageView.class);
     when(imageViewMock.getAttachedRenderer()).thenReturn(flutterRenderer);
 
-    FlutterView flutterView = spy(new FlutterView(RuntimeEnvironment.application));
+    FlutterView flutterView = spy(new FlutterView(ctx));
     when(flutterView.createImageView()).thenReturn(imageViewMock);
 
     flutterView.attachToFlutterEngine(flutterEngine);
@@ -182,10 +178,9 @@ public class FlutterViewTest {
   @Test
   public void onConfigurationChanged_fizzlesWhenNullEngine() {
     FlutterView flutterView = new FlutterView(Robolectric.setupActivity(Activity.class));
-    FlutterEngine flutterEngine =
-        spy(new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, mockFlutterJni));
+    FlutterEngine flutterEngine = spy(new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni));
 
-    Configuration configuration = RuntimeEnvironment.application.getResources().getConfiguration();
+    Configuration configuration = ctx.getResources().getConfiguration();
     // 1 invocation of channels.
     flutterView.attachToFlutterEngine(flutterEngine);
     flutterView.onConfigurationChanged(configuration);
@@ -207,8 +202,7 @@ public class FlutterViewTest {
 
     // FYI - The default brightness is LIGHT, which is why we don't need to configure it.
     FlutterView flutterView = new FlutterView(Robolectric.setupActivity(Activity.class));
-    FlutterEngine flutterEngine =
-        spy(new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, mockFlutterJni));
+    FlutterEngine flutterEngine = spy(new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni));
 
     SettingsChannel fakeSettingsChannel = mock(SettingsChannel.class);
     SettingsChannel.MessageBuilder fakeMessageBuilder = mock(SettingsChannel.MessageBuilder.class);
@@ -258,8 +252,7 @@ public class FlutterViewTest {
     when(spiedResources.getConfiguration()).thenReturn(spiedConfiguration);
 
     FlutterView flutterView = new FlutterView(spiedContext);
-    FlutterEngine flutterEngine =
-        spy(new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, mockFlutterJni));
+    FlutterEngine flutterEngine = spy(new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni));
 
     SettingsChannel fakeSettingsChannel = mock(SettingsChannel.class);
     SettingsChannel.MessageBuilder fakeMessageBuilder = mock(SettingsChannel.MessageBuilder.class);
@@ -295,8 +288,7 @@ public class FlutterViewTest {
     AtomicReference<Boolean> reportedShowPassword = new AtomicReference<>();
 
     FlutterView flutterView = new FlutterView(Robolectric.setupActivity(Activity.class));
-    FlutterEngine flutterEngine =
-        spy(new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, mockFlutterJni));
+    FlutterEngine flutterEngine = spy(new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni));
     Settings.System.putInt(
         flutterView.getContext().getContentResolver(), Settings.System.TEXT_SHOW_PASSWORD, 1);
 
@@ -330,8 +322,7 @@ public class FlutterViewTest {
     AtomicReference<Boolean> reportedShowPassword = new AtomicReference<>();
 
     FlutterView flutterView = new FlutterView(Robolectric.setupActivity(Activity.class));
-    FlutterEngine flutterEngine =
-        spy(new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, mockFlutterJni));
+    FlutterEngine flutterEngine = spy(new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni));
     Settings.System.putInt(
         flutterView.getContext().getContentResolver(), Settings.System.TEXT_SHOW_PASSWORD, 0);
 
@@ -372,8 +363,7 @@ public class FlutterViewTest {
       })
   public void setPaddingTopToZeroForFullscreenMode() {
     FlutterView flutterView = new FlutterView(Robolectric.setupActivity(Activity.class));
-    FlutterEngine flutterEngine =
-        spy(new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, mockFlutterJni));
+    FlutterEngine flutterEngine = spy(new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni));
     FlutterRenderer flutterRenderer = spy(new FlutterRenderer(mockFlutterJni));
     when(flutterEngine.getRenderer()).thenReturn(flutterRenderer);
 
@@ -412,8 +402,7 @@ public class FlutterViewTest {
       })
   public void setPaddingTopToZeroForFullscreenModeLegacy() {
     FlutterView flutterView = new FlutterView(Robolectric.setupActivity(Activity.class));
-    FlutterEngine flutterEngine =
-        spy(new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, mockFlutterJni));
+    FlutterEngine flutterEngine = spy(new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni));
     FlutterRenderer flutterRenderer = spy(new FlutterRenderer(mockFlutterJni));
     when(flutterEngine.getRenderer()).thenReturn(flutterRenderer);
 
@@ -446,8 +435,7 @@ public class FlutterViewTest {
     FlutterView flutterView = new FlutterView(Robolectric.setupActivity(Activity.class));
     assertEquals(0, flutterView.getSystemUiVisibility());
 
-    FlutterEngine flutterEngine =
-        spy(new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, mockFlutterJni));
+    FlutterEngine flutterEngine = spy(new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni));
     FlutterRenderer flutterRenderer = spy(new FlutterRenderer(mockFlutterJni));
     when(flutterEngine.getRenderer()).thenReturn(flutterRenderer);
 
@@ -485,8 +473,7 @@ public class FlutterViewTest {
     FlutterView flutterView = new FlutterView(Robolectric.setupActivity(Activity.class));
     assertEquals(0, flutterView.getSystemUiVisibility());
 
-    FlutterEngine flutterEngine =
-        spy(new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, mockFlutterJni));
+    FlutterEngine flutterEngine = spy(new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni));
     FlutterRenderer flutterRenderer = spy(new FlutterRenderer(mockFlutterJni));
     when(flutterEngine.getRenderer()).thenReturn(flutterRenderer);
 
@@ -520,8 +507,7 @@ public class FlutterViewTest {
         .thenReturn(View.SYSTEM_UI_FLAG_FULLSCREEN | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION);
     when(flutterView.getContext()).thenReturn(RuntimeEnvironment.systemContext);
 
-    FlutterEngine flutterEngine =
-        spy(new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, mockFlutterJni));
+    FlutterEngine flutterEngine = spy(new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni));
     FlutterRenderer flutterRenderer = spy(new FlutterRenderer(mockFlutterJni));
     when(flutterEngine.getRenderer()).thenReturn(flutterRenderer);
 
@@ -557,8 +543,7 @@ public class FlutterViewTest {
         .thenReturn(View.SYSTEM_UI_FLAG_FULLSCREEN | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION);
     when(flutterView.getContext()).thenReturn(RuntimeEnvironment.systemContext);
 
-    FlutterEngine flutterEngine =
-        spy(new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, mockFlutterJni));
+    FlutterEngine flutterEngine = spy(new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni));
     FlutterRenderer flutterRenderer = spy(new FlutterRenderer(mockFlutterJni));
     when(flutterEngine.getRenderer()).thenReturn(flutterRenderer);
 
@@ -594,8 +579,7 @@ public class FlutterViewTest {
         .thenReturn(View.SYSTEM_UI_FLAG_FULLSCREEN | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION);
     when(flutterView.getContext()).thenReturn(RuntimeEnvironment.systemContext);
 
-    FlutterEngine flutterEngine =
-        spy(new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, mockFlutterJni));
+    FlutterEngine flutterEngine = spy(new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni));
     FlutterRenderer flutterRenderer = spy(new FlutterRenderer(mockFlutterJni));
     when(flutterEngine.getRenderer()).thenReturn(flutterRenderer);
 
@@ -634,8 +618,7 @@ public class FlutterViewTest {
         .thenReturn(View.SYSTEM_UI_FLAG_FULLSCREEN | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION);
     when(flutterView.getContext()).thenReturn(RuntimeEnvironment.systemContext);
 
-    FlutterEngine flutterEngine =
-        spy(new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, mockFlutterJni));
+    FlutterEngine flutterEngine = spy(new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni));
     FlutterRenderer flutterRenderer = spy(new FlutterRenderer(mockFlutterJni));
     when(flutterEngine.getRenderer()).thenReturn(flutterRenderer);
 
@@ -671,8 +654,7 @@ public class FlutterViewTest {
         .thenReturn(View.SYSTEM_UI_FLAG_FULLSCREEN | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION);
     when(flutterView.getContext()).thenReturn(RuntimeEnvironment.systemContext);
 
-    FlutterEngine flutterEngine =
-        spy(new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, mockFlutterJni));
+    FlutterEngine flutterEngine = spy(new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni));
     FlutterRenderer flutterRenderer = spy(new FlutterRenderer(mockFlutterJni));
     when(flutterEngine.getRenderer()).thenReturn(flutterRenderer);
 
@@ -708,8 +690,7 @@ public class FlutterViewTest {
     when(flutterView.getWindowSystemUiVisibility()).thenReturn(0);
     when(flutterView.getContext()).thenReturn(RuntimeEnvironment.systemContext);
 
-    FlutterEngine flutterEngine =
-        spy(new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, mockFlutterJni));
+    FlutterEngine flutterEngine = spy(new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni));
     FlutterRenderer flutterRenderer = spy(new FlutterRenderer(mockFlutterJni));
     when(flutterEngine.getRenderer()).thenReturn(flutterRenderer);
 
@@ -787,8 +768,7 @@ public class FlutterViewTest {
     WindowInfoRepositoryCallbackAdapterWrapper windowInfoRepo =
         mock(WindowInfoRepositoryCallbackAdapterWrapper.class);
     doReturn(windowInfoRepo).when(flutterView).createWindowInfoRepo();
-    FlutterEngine flutterEngine =
-        spy(new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, mockFlutterJni));
+    FlutterEngine flutterEngine = spy(new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni));
     FlutterRenderer flutterRenderer = spy(new FlutterRenderer(mockFlutterJni));
     when(flutterEngine.getRenderer()).thenReturn(flutterRenderer);
 
@@ -830,11 +810,7 @@ public class FlutterViewTest {
     when(mockReader.getMaxImages()).thenReturn(2);
 
     final FlutterImageView imageView =
-        spy(
-            new FlutterImageView(
-                RuntimeEnvironment.application,
-                mockReader,
-                FlutterImageView.SurfaceKind.background));
+        spy(new FlutterImageView(ctx, mockReader, FlutterImageView.SurfaceKind.background));
 
     final FlutterJNI jni = mock(FlutterJNI.class);
     imageView.attachToRenderer(new FlutterRenderer(jni));
@@ -867,11 +843,7 @@ public class FlutterViewTest {
         .thenReturn(mockImage);
 
     final FlutterImageView imageView =
-        spy(
-            new FlutterImageView(
-                RuntimeEnvironment.application,
-                mockReader,
-                FlutterImageView.SurfaceKind.background));
+        spy(new FlutterImageView(ctx, mockReader, FlutterImageView.SurfaceKind.background));
 
     final FlutterJNI jni = mock(FlutterJNI.class);
     imageView.attachToRenderer(new FlutterRenderer(jni));
@@ -905,11 +877,7 @@ public class FlutterViewTest {
     when(mockReader.acquireLatestImage()).thenReturn(mockImage);
 
     final FlutterImageView imageView =
-        spy(
-            new FlutterImageView(
-                RuntimeEnvironment.application,
-                mockReader,
-                FlutterImageView.SurfaceKind.background));
+        spy(new FlutterImageView(ctx, mockReader, FlutterImageView.SurfaceKind.background));
 
     final FlutterJNI jni = mock(FlutterJNI.class);
     imageView.attachToRenderer(new FlutterRenderer(jni));
@@ -931,11 +899,7 @@ public class FlutterViewTest {
     when(mockReader.getMaxImages()).thenReturn(2);
 
     final FlutterImageView imageView =
-        spy(
-            new FlutterImageView(
-                RuntimeEnvironment.application,
-                mockReader,
-                FlutterImageView.SurfaceKind.background));
+        spy(new FlutterImageView(ctx, mockReader, FlutterImageView.SurfaceKind.background));
 
     final FlutterJNI jni = mock(FlutterJNI.class);
     imageView.attachToRenderer(new FlutterRenderer(jni));
@@ -956,11 +920,7 @@ public class FlutterViewTest {
     when(mockReader.getMaxImages()).thenReturn(1);
 
     final FlutterImageView imageView =
-        spy(
-            new FlutterImageView(
-                RuntimeEnvironment.application,
-                mockReader,
-                FlutterImageView.SurfaceKind.background));
+        spy(new FlutterImageView(ctx, mockReader, FlutterImageView.SurfaceKind.background));
 
     imageView.closeImageReader();
     verify(mockReader, times(1)).close();
@@ -969,7 +929,7 @@ public class FlutterViewTest {
   @Test
   public void flutterSurfaceView_GathersTransparentRegion() {
     final Region mockRegion = mock(Region.class);
-    final FlutterSurfaceView surfaceView = new FlutterSurfaceView(RuntimeEnvironment.application);
+    final FlutterSurfaceView surfaceView = new FlutterSurfaceView(ctx);
 
     surfaceView.setAlpha(0.0f);
     assertFalse(surfaceView.gatherTransparentRegion(mockRegion));
@@ -984,7 +944,7 @@ public class FlutterViewTest {
   @SuppressLint("PrivateApi")
   @Config(sdk = Build.VERSION_CODES.P)
   public void findViewByAccessibilityIdTraversal_returnsRootViewOnAndroid28() throws Exception {
-    FlutterView flutterView = new FlutterView(RuntimeEnvironment.application);
+    FlutterView flutterView = new FlutterView(ctx);
 
     Method getAccessibilityViewIdMethod = View.class.getDeclaredMethod("getAccessibilityViewId");
     Integer accessibilityViewId = (Integer) getAccessibilityViewIdMethod.invoke(flutterView);
@@ -996,11 +956,11 @@ public class FlutterViewTest {
   @Config(sdk = Build.VERSION_CODES.P)
   @SuppressLint("PrivateApi")
   public void findViewByAccessibilityIdTraversal_returnsChildViewOnAndroid28() throws Exception {
-    FlutterView flutterView = new FlutterView(RuntimeEnvironment.application);
-    FrameLayout childView1 = new FrameLayout(RuntimeEnvironment.application);
+    FlutterView flutterView = new FlutterView(ctx);
+    FrameLayout childView1 = new FrameLayout(ctx);
     flutterView.addView(childView1);
 
-    FrameLayout childView2 = new FrameLayout(RuntimeEnvironment.application);
+    FrameLayout childView2 = new FrameLayout(ctx);
     childView1.addView(childView2);
 
     Method getAccessibilityViewIdMethod = View.class.getDeclaredMethod("getAccessibilityViewId");
@@ -1013,7 +973,7 @@ public class FlutterViewTest {
   @Config(sdk = Build.VERSION_CODES.Q)
   @SuppressLint("PrivateApi")
   public void findViewByAccessibilityIdTraversal_returnsRootViewOnAndroid29() throws Exception {
-    FlutterView flutterView = new FlutterView(RuntimeEnvironment.application);
+    FlutterView flutterView = new FlutterView(ctx);
 
     Method getAccessibilityViewIdMethod = View.class.getDeclaredMethod("getAccessibilityViewId");
     Integer accessibilityViewId = (Integer) getAccessibilityViewIdMethod.invoke(flutterView);
@@ -1023,16 +983,15 @@ public class FlutterViewTest {
 
   @Test
   public void flutterSplashView_itDoesNotCrashOnRestoreInstanceState() {
-    final FlutterSplashView splashView = new FlutterSplashView(RuntimeEnvironment.application);
+    final FlutterSplashView splashView = new FlutterSplashView(ctx);
     splashView.onRestoreInstanceState(View.BaseSavedState.EMPTY_STATE);
     // It should not crash and "splashScreenState" should be null.
     assertEquals(null, splashView.splashScreenState);
   }
 
   public void ViewportMetrics_initializedPhysicalTouchSlop() {
-    FlutterView flutterView = new FlutterView(RuntimeEnvironment.application);
-    FlutterEngine flutterEngine =
-        spy(new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, mockFlutterJni));
+    FlutterView flutterView = new FlutterView(ctx);
+    FlutterEngine flutterEngine = spy(new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni));
     FlutterRenderer flutterRenderer = spy(new FlutterRenderer(mockFlutterJni));
     when(flutterEngine.getRenderer()).thenReturn(flutterRenderer);
 

--- a/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.when;
 
 import android.content.Context;
 import android.content.pm.PackageManager.NameNotFoundException;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import io.flutter.FlutterInjector;
 import io.flutter.embedding.engine.FlutterEngine;
@@ -33,13 +34,13 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowLog;
 
 @Config(manifest = Config.NONE)
 @RunWith(AndroidJUnit4.class)
 public class FlutterEngineTest {
+  private final Context ctx = ApplicationProvider.getApplicationContext();
   @Mock FlutterJNI flutterJNI;
   boolean jniAttached;
 
@@ -74,8 +75,7 @@ public class FlutterEngineTest {
     assertTrue(GeneratedPluginRegistrant.getRegisteredEngines().isEmpty());
     FlutterLoader mockFlutterLoader = mock(FlutterLoader.class);
     when(mockFlutterLoader.automaticallyRegisterPlugins()).thenReturn(true);
-    FlutterEngine flutterEngine =
-        new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, flutterJNI);
+    FlutterEngine flutterEngine = new FlutterEngine(ctx, mockFlutterLoader, flutterJNI);
 
     List<FlutterEngine> registeredEngines = GeneratedPluginRegistrant.getRegisteredEngines();
     assertEquals(1, registeredEngines.size());
@@ -91,8 +91,7 @@ public class FlutterEngineTest {
         new RuntimeException("I'm a bug in the plugin");
     FlutterLoader mockFlutterLoader = mock(FlutterLoader.class);
     when(mockFlutterLoader.automaticallyRegisterPlugins()).thenReturn(true);
-    FlutterEngine flutterEngine =
-        new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, flutterJNI);
+    FlutterEngine flutterEngine = new FlutterEngine(ctx, mockFlutterLoader, flutterJNI);
 
     List<FlutterEngine> registeredEngines = GeneratedPluginRegistrant.getRegisteredEngines();
     // When it crashes, it doesn't end up registering anything.
@@ -117,7 +116,7 @@ public class FlutterEngineTest {
     assertTrue(GeneratedPluginRegistrant.getRegisteredEngines().isEmpty());
     FlutterLoader mockFlutterLoader = mock(FlutterLoader.class);
     when(mockFlutterLoader.automaticallyRegisterPlugins()).thenReturn(false);
-    new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, flutterJNI);
+    new FlutterEngine(ctx, mockFlutterLoader, flutterJNI);
 
     List<FlutterEngine> registeredEngines = GeneratedPluginRegistrant.getRegisteredEngines();
     assertTrue(registeredEngines.isEmpty());
@@ -129,7 +128,7 @@ public class FlutterEngineTest {
     FlutterLoader mockFlutterLoader = mock(FlutterLoader.class);
     when(mockFlutterLoader.automaticallyRegisterPlugins()).thenReturn(true);
     new FlutterEngine(
-        RuntimeEnvironment.application,
+        ctx,
         mockFlutterLoader,
         flutterJNI,
         /*dartVmArgs=*/ new String[] {},
@@ -152,7 +151,7 @@ public class FlutterEngineTest {
 
     // Execute behavior under test.
     new FlutterEngine(
-        RuntimeEnvironment.application,
+        ctx,
         mock(FlutterLoader.class),
         mockFlutterJNI,
         platformViewsController,
@@ -181,7 +180,7 @@ public class FlutterEngineTest {
     // Execute behavior under test.
     FlutterEngine engine =
         new FlutterEngine(
-            RuntimeEnvironment.application,
+            ctx,
             mock(FlutterLoader.class),
             flutterJNI,
             platformViewsController,

--- a/shell/platform/android/test/io/flutter/embedding/engine/PluginComponentTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/PluginComponentTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import androidx.annotation.NonNull;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.FlutterJNI;
@@ -17,7 +18,6 @@ import io.flutter.embedding.engine.loader.FlutterLoader;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 @Config(manifest = Config.NONE)
@@ -38,7 +38,7 @@ public class PluginComponentTest {
 
     // Execute behavior under test.
     FlutterEngine flutterEngine =
-        new FlutterEngine(RuntimeEnvironment.application, flutterLoader, flutterJNI);
+        new FlutterEngine(ApplicationProvider.getApplicationContext(), flutterLoader, flutterJNI);
 
     // As soon as our plugin is registered it will look up asset paths and store them
     // for our verification.

--- a/shell/platform/android/test/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManagerTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManagerTest.java
@@ -22,13 +22,13 @@ import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.res.AssetManager;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import io.flutter.embedding.engine.FlutterJNI;
 import io.flutter.embedding.engine.loader.ApplicationInfoLoader;
 import java.io.File;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 @Config(manifest = Config.NONE)
@@ -84,7 +84,7 @@ public class PlayStoreDeferredComponentManagerTest {
   }
 
   private Context createSpyContext(Bundle metadata) throws NameNotFoundException {
-    Context spyContext = spy(RuntimeEnvironment.application);
+    Context spyContext = spy(ApplicationProvider.getApplicationContext());
     doReturn(spyContext).when(spyContext).createPackageContext(any(), anyInt());
     if (metadata == null) {
       metadata = new Bundle();

--- a/shell/platform/android/test/io/flutter/embedding/engine/loader/ApplicationInfoLoaderTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/loader/ApplicationInfoLoaderTest.java
@@ -21,12 +21,12 @@ import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.content.res.XmlResourceParser;
 import android.os.Bundle;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import java.io.StringReader;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.stubbing.Answer;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserFactory;
@@ -37,7 +37,8 @@ public class ApplicationInfoLoaderTest {
 
   @Test
   public void itGeneratesCorrectApplicationInfoWithDefaultManifest() {
-    FlutterApplicationInfo info = ApplicationInfoLoader.load(RuntimeEnvironment.application);
+    FlutterApplicationInfo info =
+        ApplicationInfoLoader.load(ApplicationProvider.getApplicationContext());
     assertNotNull(info);
     assertEquals("libapp.so", info.aotSharedLibraryName);
     assertEquals("vm_snapshot_data", info.vmSnapshotData);

--- a/shell/platform/android/test/io/flutter/external/FlutterLaunchTests.java
+++ b/shell/platform/android/test/io/flutter/external/FlutterLaunchTests.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import android.content.Intent;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import io.flutter.embedding.android.FlutterActivity;
 import io.flutter.embedding.android.FlutterActivityLaunchConfigs.BackgroundMode;
@@ -14,7 +15,6 @@ import io.flutter.embedding.android.RobolectricFlutterActivity;
 import io.flutter.embedding.android.TransparencyMode;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 @Config(manifest = Config.NONE)
@@ -22,7 +22,8 @@ import org.robolectric.annotation.Config;
 public class FlutterLaunchTests {
   @Test
   public void launchFlutterActivity_with_defaultIntent_expect_defaultConfiguration() {
-    Intent intent = FlutterActivity.createDefaultIntent(RuntimeEnvironment.application);
+    Intent intent =
+        FlutterActivity.createDefaultIntent(ApplicationProvider.getApplicationContext());
     FlutterActivity flutterActivity = RobolectricFlutterActivity.createFlutterActivity(intent);
 
     assertEquals("main", flutterActivity.getDartEntrypointFunctionName());

--- a/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
@@ -32,6 +32,7 @@ import android.view.inputmethod.ExtractedText;
 import android.view.inputmethod.ExtractedTextRequest;
 import android.view.inputmethod.InputConnection;
 import android.view.inputmethod.InputMethodManager;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.lang.UProperty;
@@ -51,7 +52,6 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
@@ -63,6 +63,7 @@ import org.robolectric.shadows.ShadowInputMethodManager;
     shadows = {InputConnectionAdaptorTest.TestImm.class})
 @RunWith(AndroidJUnit4.class)
 public class InputConnectionAdaptorTest {
+  private final Context ctx = ApplicationProvider.getApplicationContext();
   @Mock KeyboardManager mockKeyboardManager;
   // Verifies the method and arguments for a captured method call.
   private void verifyMethodCall(ByteBuffer buffer, String methodName, String[] expectedArgs)
@@ -86,7 +87,7 @@ public class InputConnectionAdaptorTest {
 
   @Test
   public void inputConnectionAdaptor_ReceivesEnter() throws NullPointerException {
-    View testView = new View(RuntimeEnvironment.application);
+    View testView = new View(ctx);
     FlutterJNI mockFlutterJni = mock(FlutterJNI.class);
     DartExecutor dartExecutor = spy(new DartExecutor(mockFlutterJni, mock(AssetManager.class)));
     int inputTargetId = 0;
@@ -122,8 +123,7 @@ public class InputConnectionAdaptorTest {
 
   @Test
   public void testPerformContextMenuAction_cut() {
-    ClipboardManager clipboardManager =
-        RuntimeEnvironment.application.getSystemService(ClipboardManager.class);
+    ClipboardManager clipboardManager = ctx.getSystemService(ClipboardManager.class);
     int selStart = 6;
     int selEnd = 11;
     ListenableEditingState editable = sampleEditable(selStart, selEnd);
@@ -140,8 +140,7 @@ public class InputConnectionAdaptorTest {
 
   @Test
   public void testPerformContextMenuAction_copy() {
-    ClipboardManager clipboardManager =
-        RuntimeEnvironment.application.getSystemService(ClipboardManager.class);
+    ClipboardManager clipboardManager = ctx.getSystemService(ClipboardManager.class);
     int selStart = 6;
     int selEnd = 11;
     ListenableEditingState editable = sampleEditable(selStart, selEnd);
@@ -160,8 +159,7 @@ public class InputConnectionAdaptorTest {
 
   @Test
   public void testPerformContextMenuAction_paste() {
-    ClipboardManager clipboardManager =
-        RuntimeEnvironment.application.getSystemService(ClipboardManager.class);
+    ClipboardManager clipboardManager = ctx.getSystemService(ClipboardManager.class);
     String textToBePasted = "deadbeef";
     clipboardManager.setText(textToBePasted);
     ListenableEditingState editable = sampleEditable(0, 0);
@@ -175,7 +173,7 @@ public class InputConnectionAdaptorTest {
 
   @Test
   public void testPerformPrivateCommand_dataIsNull() throws JSONException {
-    View testView = new View(RuntimeEnvironment.application);
+    View testView = new View(ctx);
     int client = 0;
     FlutterJNI mockFlutterJNI = mock(FlutterJNI.class);
     DartExecutor dartExecutor = spy(new DartExecutor(mockFlutterJNI, mock(AssetManager.class)));
@@ -204,7 +202,7 @@ public class InputConnectionAdaptorTest {
 
   @Test
   public void testPerformPrivateCommand_dataIsByteArray() throws JSONException {
-    View testView = new View(RuntimeEnvironment.application);
+    View testView = new View(ctx);
     int client = 0;
     FlutterJNI mockFlutterJNI = mock(FlutterJNI.class);
     DartExecutor dartExecutor = spy(new DartExecutor(mockFlutterJNI, mock(AssetManager.class)));
@@ -239,7 +237,7 @@ public class InputConnectionAdaptorTest {
 
   @Test
   public void testPerformPrivateCommand_dataIsByte() throws JSONException {
-    View testView = new View(RuntimeEnvironment.application);
+    View testView = new View(ctx);
     int client = 0;
     FlutterJNI mockFlutterJNI = mock(FlutterJNI.class);
     DartExecutor dartExecutor = spy(new DartExecutor(mockFlutterJNI, mock(AssetManager.class)));
@@ -272,7 +270,7 @@ public class InputConnectionAdaptorTest {
 
   @Test
   public void testPerformPrivateCommand_dataIsCharArray() throws JSONException {
-    View testView = new View(RuntimeEnvironment.application);
+    View testView = new View(ctx);
     int client = 0;
     FlutterJNI mockFlutterJNI = mock(FlutterJNI.class);
     DartExecutor dartExecutor = spy(new DartExecutor(mockFlutterJNI, mock(AssetManager.class)));
@@ -308,7 +306,7 @@ public class InputConnectionAdaptorTest {
 
   @Test
   public void testPerformPrivateCommand_dataIsChar() throws JSONException {
-    View testView = new View(RuntimeEnvironment.application);
+    View testView = new View(ctx);
     int client = 0;
     FlutterJNI mockFlutterJNI = mock(FlutterJNI.class);
     DartExecutor dartExecutor = spy(new DartExecutor(mockFlutterJNI, mock(AssetManager.class)));
@@ -341,7 +339,7 @@ public class InputConnectionAdaptorTest {
 
   @Test
   public void testPerformPrivateCommand_dataIsCharSequenceArray() throws JSONException {
-    View testView = new View(RuntimeEnvironment.application);
+    View testView = new View(ctx);
     int client = 0;
     FlutterJNI mockFlutterJNI = mock(FlutterJNI.class);
     DartExecutor dartExecutor = spy(new DartExecutor(mockFlutterJNI, mock(AssetManager.class)));
@@ -378,7 +376,7 @@ public class InputConnectionAdaptorTest {
 
   @Test
   public void testPerformPrivateCommand_dataIsCharSequence() throws JSONException {
-    View testView = new View(RuntimeEnvironment.application);
+    View testView = new View(ctx);
     int client = 0;
     FlutterJNI mockFlutterJNI = mock(FlutterJNI.class);
     DartExecutor dartExecutor = spy(new DartExecutor(mockFlutterJNI, mock(AssetManager.class)));
@@ -413,7 +411,7 @@ public class InputConnectionAdaptorTest {
 
   @Test
   public void testPerformPrivateCommand_dataIsFloat() throws JSONException {
-    View testView = new View(RuntimeEnvironment.application);
+    View testView = new View(ctx);
     int client = 0;
     FlutterJNI mockFlutterJNI = mock(FlutterJNI.class);
     DartExecutor dartExecutor = spy(new DartExecutor(mockFlutterJNI, mock(AssetManager.class)));
@@ -446,7 +444,7 @@ public class InputConnectionAdaptorTest {
 
   @Test
   public void testPerformPrivateCommand_dataIsFloatArray() throws JSONException {
-    View testView = new View(RuntimeEnvironment.application);
+    View testView = new View(ctx);
     int client = 0;
     FlutterJNI mockFlutterJNI = mock(FlutterJNI.class);
     DartExecutor dartExecutor = spy(new DartExecutor(mockFlutterJNI, mock(AssetManager.class)));
@@ -980,7 +978,7 @@ public class InputConnectionAdaptorTest {
       return;
     }
     ListenableEditingState editable = sampleEditable(5, 5);
-    View testView = new View(RuntimeEnvironment.application);
+    View testView = new View(ctx);
     InputConnectionAdaptor adaptor =
         new InputConnectionAdaptor(
             testView,
@@ -989,9 +987,7 @@ public class InputConnectionAdaptorTest {
             mockKeyboardManager,
             editable,
             new EditorInfo());
-    TestImm testImm =
-        Shadow.extract(
-            RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
+    TestImm testImm = Shadow.extract(ctx.getSystemService(Context.INPUT_METHOD_SERVICE));
 
     testImm.resetStates();
 
@@ -1037,7 +1033,7 @@ public class InputConnectionAdaptorTest {
     }
 
     ListenableEditingState editable = sampleEditable(5, 5);
-    View testView = new View(RuntimeEnvironment.application);
+    View testView = new View(ctx);
     InputConnectionAdaptor adaptor =
         new InputConnectionAdaptor(
             testView,
@@ -1046,9 +1042,7 @@ public class InputConnectionAdaptorTest {
             mockKeyboardManager,
             editable,
             new EditorInfo());
-    TestImm testImm =
-        Shadow.extract(
-            RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
+    TestImm testImm = Shadow.extract(ctx.getSystemService(Context.INPUT_METHOD_SERVICE));
 
     testImm.resetStates();
 
@@ -1167,7 +1161,7 @@ public class InputConnectionAdaptorTest {
 
   private static ListenableEditingState sampleEditable(int selStart, int selEnd) {
     ListenableEditingState sample =
-        new ListenableEditingState(null, new View(RuntimeEnvironment.application));
+        new ListenableEditingState(null, new View(ApplicationProvider.getApplicationContext()));
     sample.replace(0, 0, SAMPLE_TEXT);
     Selection.setSelection(sample, selStart, selEnd);
     return sample;
@@ -1175,7 +1169,7 @@ public class InputConnectionAdaptorTest {
 
   private static ListenableEditingState sampleEditable(int selStart, int selEnd, String text) {
     ListenableEditingState sample =
-        new ListenableEditingState(null, new View(RuntimeEnvironment.application));
+        new ListenableEditingState(null, new View(ApplicationProvider.getApplicationContext()));
     sample.replace(0, 0, text);
     Selection.setSelection(sample, selStart, selEnd);
     return sample;
@@ -1188,7 +1182,7 @@ public class InputConnectionAdaptorTest {
 
   private static InputConnectionAdaptor sampleInputConnectionAdaptor(
       ListenableEditingState editable, KeyboardManager mockKeyboardManager) {
-    View testView = new View(RuntimeEnvironment.application);
+    View testView = new View(ApplicationProvider.getApplicationContext());
     int client = 0;
     TextInputChannel textInputChannel = mock(TextInputChannel.class);
     FlutterJNI mockFlutterJNI = mock(FlutterJNI.class);

--- a/shell/platform/android/test/io/flutter/plugin/editing/ListenableEditingStateTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/ListenableEditingStateTest.java
@@ -5,11 +5,13 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
+import android.content.Context;
 import android.text.Editable;
 import android.text.Selection;
 import android.view.View;
 import android.view.inputmethod.BaseInputConnection;
 import android.view.inputmethod.EditorInfo;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import io.flutter.embedding.android.KeyboardManager;
 import io.flutter.embedding.engine.systemchannels.TextInputChannel;
@@ -19,16 +21,16 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 @Config(manifest = Config.NONE)
 @RunWith(AndroidJUnit4.class)
 public class ListenableEditingStateTest {
+  private final Context ctx = ApplicationProvider.getApplicationContext();
   @Mock KeyboardManager mockKeyboardManager;
 
   private BaseInputConnection getTestInputConnection(View view, Editable mEditable) {
-    new View(RuntimeEnvironment.application);
+    new View(ctx);
     return new BaseInputConnection(view, true) {
       @Override
       public Editable getEditable() {
@@ -46,17 +48,15 @@ public class ListenableEditingStateTest {
   public void testConstructor() {
     // When provided valid composing range, should not fail
     new ListenableEditingState(
-        new TextInputChannel.TextEditState("hello", 1, 4, 1, 4),
-        new View(RuntimeEnvironment.application));
+        new TextInputChannel.TextEditState("hello", 1, 4, 1, 4), new View(ctx));
   }
 
   // -------- Start: Test BatchEditing   -------
   @Test
   public void testBatchEditing() {
-    final ListenableEditingState editingState =
-        new ListenableEditingState(null, new View(RuntimeEnvironment.application));
+    final ListenableEditingState editingState = new ListenableEditingState(null, new View(ctx));
     final Listener listener = new Listener();
-    final View testView = new View(RuntimeEnvironment.application);
+    final View testView = new View(ctx);
     final BaseInputConnection inputConnection = getTestInputConnection(testView, editingState);
 
     editingState.addEditingStateListener(listener);
@@ -108,8 +108,7 @@ public class ListenableEditingStateTest {
 
   @Test
   public void testBatchingEditing_callEndBeforeBegin() {
-    final ListenableEditingState editingState =
-        new ListenableEditingState(null, new View(RuntimeEnvironment.application));
+    final ListenableEditingState editingState = new ListenableEditingState(null, new View(ctx));
     final Listener listener = new Listener();
     editingState.addEditingStateListener(listener);
 
@@ -131,8 +130,7 @@ public class ListenableEditingStateTest {
 
   @Test
   public void testBatchingEditing_addListenerDuringBatchEdit() {
-    final ListenableEditingState editingState =
-        new ListenableEditingState(null, new View(RuntimeEnvironment.application));
+    final ListenableEditingState editingState = new ListenableEditingState(null, new View(ctx));
     final Listener listener = new Listener();
 
     editingState.beginBatchEdit();
@@ -166,8 +164,7 @@ public class ListenableEditingStateTest {
 
   @Test
   public void testBatchingEditing_removeListenerDuringBatchEdit() {
-    final ListenableEditingState editingState =
-        new ListenableEditingState(null, new View(RuntimeEnvironment.application));
+    final ListenableEditingState editingState = new ListenableEditingState(null, new View(ctx));
     final Listener listener = new Listener();
     editingState.addEditingStateListener(listener);
 
@@ -181,8 +178,7 @@ public class ListenableEditingStateTest {
 
   @Test
   public void testBatchingEditing_listenerCallsReplaceWhenBatchEditEnds() {
-    final ListenableEditingState editingState =
-        new ListenableEditingState(null, new View(RuntimeEnvironment.application));
+    final ListenableEditingState editingState = new ListenableEditingState(null, new View(ctx));
 
     final Listener listener =
         new Listener() {
@@ -208,8 +204,7 @@ public class ListenableEditingStateTest {
 
   @Test
   public void testSetComposingRegion() {
-    final ListenableEditingState editingState =
-        new ListenableEditingState(null, new View(RuntimeEnvironment.application));
+    final ListenableEditingState editingState = new ListenableEditingState(null, new View(ctx));
     editingState.replace(0, editingState.length(), "text");
 
     // (-1, -1) clears the composing region.
@@ -238,8 +233,7 @@ public class ListenableEditingStateTest {
 
   @Test
   public void testClearBatchDeltas() {
-    final ListenableEditingState editingState =
-        new ListenableEditingState(null, new View(RuntimeEnvironment.application));
+    final ListenableEditingState editingState = new ListenableEditingState(null, new View(ctx));
     editingState.replace(0, editingState.length(), "text");
     editingState.delete(0, 1);
     editingState.insert(0, "This is t");
@@ -249,8 +243,7 @@ public class ListenableEditingStateTest {
 
   @Test
   public void testExtractBatchTextEditingDeltas() {
-    final ListenableEditingState editingState =
-        new ListenableEditingState(null, new View(RuntimeEnvironment.application));
+    final ListenableEditingState editingState = new ListenableEditingState(null, new View(ctx));
 
     // Creating some deltas.
     editingState.replace(0, editingState.length(), "test");
@@ -266,7 +259,7 @@ public class ListenableEditingStateTest {
   public void inputMethod_batchEditingBeginAndEnd() {
     final ArrayList<String> batchMarkers = new ArrayList<>();
     final ListenableEditingState editingState =
-        new ListenableEditingState(null, new View(RuntimeEnvironment.application)) {
+        new ListenableEditingState(null, new View(ctx)) {
           @Override
           public final void beginBatchEdit() {
             super.beginBatchEdit();
@@ -281,7 +274,7 @@ public class ListenableEditingStateTest {
         };
 
     final Listener listener = new Listener();
-    final View testView = new View(RuntimeEnvironment.application);
+    final View testView = new View(ctx);
     final InputConnectionAdaptor inputConnection =
         new InputConnectionAdaptor(
             testView,
@@ -304,10 +297,9 @@ public class ListenableEditingStateTest {
 
   @Test
   public void inputMethod_testSetSelection() {
-    final ListenableEditingState editingState =
-        new ListenableEditingState(null, new View(RuntimeEnvironment.application));
+    final ListenableEditingState editingState = new ListenableEditingState(null, new View(ctx));
     final Listener listener = new Listener();
-    final View testView = new View(RuntimeEnvironment.application);
+    final View testView = new View(ctx);
     final InputConnectionAdaptor inputConnection =
         new InputConnectionAdaptor(
             testView,
@@ -339,10 +331,9 @@ public class ListenableEditingStateTest {
 
   @Test
   public void inputMethod_testSetComposition() {
-    final ListenableEditingState editingState =
-        new ListenableEditingState(null, new View(RuntimeEnvironment.application));
+    final ListenableEditingState editingState = new ListenableEditingState(null, new View(ctx));
     final Listener listener = new Listener();
-    final View testView = new View(RuntimeEnvironment.application);
+    final View testView = new View(ctx);
     final InputConnectionAdaptor inputConnection =
         new InputConnectionAdaptor(
             testView,
@@ -400,10 +391,9 @@ public class ListenableEditingStateTest {
 
   @Test
   public void inputMethod_testCommitText() {
-    final ListenableEditingState editingState =
-        new ListenableEditingState(null, new View(RuntimeEnvironment.application));
+    final ListenableEditingState editingState = new ListenableEditingState(null, new View(ctx));
     final Listener listener = new Listener();
-    final View testView = new View(RuntimeEnvironment.application);
+    final View testView = new View(ctx);
     final InputConnectionAdaptor inputConnection =
         new InputConnectionAdaptor(
             testView,

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -42,6 +42,7 @@ import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
 import android.view.inputmethod.InputMethodManager;
 import android.view.inputmethod.InputMethodSubtype;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import io.flutter.embedding.android.FlutterView;
 import io.flutter.embedding.android.KeyboardManager;
@@ -70,7 +71,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.Robolectric;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
@@ -84,6 +84,7 @@ import org.robolectric.shadows.ShadowInputMethodManager;
     shadows = {TextInputPluginTest.TestImm.class, TextInputPluginTest.TestAfm.class})
 @RunWith(AndroidJUnit4.class)
 public class TextInputPluginTest {
+  private final Context ctx = ApplicationProvider.getApplicationContext();
   @Mock FlutterJNI mockFlutterJni;
   @Mock FlutterLoader mockFlutterLoader;
 
@@ -120,11 +121,9 @@ public class TextInputPluginTest {
   public void textInputPlugin_RequestsReattachOnCreation() throws JSONException {
     // Initialize a general TextInputPlugin.
     InputMethodSubtype inputMethodSubtype = mock(InputMethodSubtype.class);
-    TestImm testImm =
-        Shadow.extract(
-            RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
+    TestImm testImm = Shadow.extract(ctx.getSystemService(Context.INPUT_METHOD_SERVICE));
     testImm.setCurrentInputMethodSubtype(inputMethodSubtype);
-    View testView = new View(RuntimeEnvironment.application);
+    View testView = new View(ctx);
 
     FlutterJNI mockFlutterJni = mock(FlutterJNI.class);
     DartExecutor dartExecutor = spy(new DartExecutor(mockFlutterJni, mock(AssetManager.class)));
@@ -144,11 +143,9 @@ public class TextInputPluginTest {
   public void setTextInputEditingState_doesNotInvokeUpdateEditingState() {
     // Initialize a general TextInputPlugin.
     InputMethodSubtype inputMethodSubtype = mock(InputMethodSubtype.class);
-    TestImm testImm =
-        Shadow.extract(
-            RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
+    TestImm testImm = Shadow.extract(ctx.getSystemService(Context.INPUT_METHOD_SERVICE));
     testImm.setCurrentInputMethodSubtype(inputMethodSubtype);
-    View testView = new View(RuntimeEnvironment.application);
+    View testView = new View(ctx);
     TextInputChannel textInputChannel = spy(new TextInputChannel(mock(DartExecutor.class)));
     TextInputPlugin textInputPlugin =
         new TextInputPlugin(testView, textInputChannel, mock(PlatformViewsController.class));
@@ -187,11 +184,9 @@ public class TextInputPluginTest {
   public void setTextInputEditingState_willNotThrowWithoutSetTextInputClient() {
     // Initialize a general TextInputPlugin.
     InputMethodSubtype inputMethodSubtype = mock(InputMethodSubtype.class);
-    TestImm testImm =
-        Shadow.extract(
-            RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
+    TestImm testImm = Shadow.extract(ctx.getSystemService(Context.INPUT_METHOD_SERVICE));
     testImm.setCurrentInputMethodSubtype(inputMethodSubtype);
-    View testView = new View(RuntimeEnvironment.application);
+    View testView = new View(ctx);
     TextInputChannel textInputChannel = spy(new TextInputChannel(mock(DartExecutor.class)));
     TextInputPlugin textInputPlugin =
         new TextInputPlugin(testView, textInputChannel, mock(PlatformViewsController.class));
@@ -206,11 +201,9 @@ public class TextInputPluginTest {
   public void setTextInputEditingState_doesNotInvokeUpdateEditingStateWithDeltas() {
     // Initialize a general TextInputPlugin.
     InputMethodSubtype inputMethodSubtype = mock(InputMethodSubtype.class);
-    TestImm testImm =
-        Shadow.extract(
-            RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
+    TestImm testImm = Shadow.extract(ctx.getSystemService(Context.INPUT_METHOD_SERVICE));
     testImm.setCurrentInputMethodSubtype(inputMethodSubtype);
-    View testView = new View(RuntimeEnvironment.application);
+    View testView = new View(ctx);
     TextInputChannel textInputChannel = spy(new TextInputChannel(mock(DartExecutor.class)));
     TextInputPlugin textInputPlugin =
         new TextInputPlugin(testView, textInputChannel, mock(PlatformViewsController.class));
@@ -255,11 +248,9 @@ public class TextInputPluginTest {
       throws NullPointerException {
     // Initialize a general TextInputPlugin.
     InputMethodSubtype inputMethodSubtype = mock(InputMethodSubtype.class);
-    TestImm testImm =
-        Shadow.extract(
-            RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
+    TestImm testImm = Shadow.extract(ctx.getSystemService(Context.INPUT_METHOD_SERVICE));
     testImm.setCurrentInputMethodSubtype(inputMethodSubtype);
-    View testView = new View(RuntimeEnvironment.application);
+    View testView = new View(ctx);
     EditorInfo outAttrs = new EditorInfo();
     outAttrs.inputType = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_MULTI_LINE;
     TextInputChannel textInputChannel = spy(new TextInputChannel(mock(DartExecutor.class)));
@@ -369,11 +360,9 @@ public class TextInputPluginTest {
       throws NullPointerException {
     // Initialize a general TextInputPlugin.
     InputMethodSubtype inputMethodSubtype = mock(InputMethodSubtype.class);
-    TestImm testImm =
-        Shadow.extract(
-            RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
+    TestImm testImm = Shadow.extract(ctx.getSystemService(Context.INPUT_METHOD_SERVICE));
     testImm.setCurrentInputMethodSubtype(inputMethodSubtype);
-    View testView = new View(RuntimeEnvironment.application);
+    View testView = new View(ctx);
     EditorInfo outAttrs = new EditorInfo();
     outAttrs.inputType = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_MULTI_LINE;
     TextInputChannel textInputChannel = spy(new TextInputChannel(mock(DartExecutor.class)));
@@ -499,11 +488,9 @@ public class TextInputPluginTest {
       throws NullPointerException {
     // Initialize a general TextInputPlugin.
     InputMethodSubtype inputMethodSubtype = mock(InputMethodSubtype.class);
-    TestImm testImm =
-        Shadow.extract(
-            RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
+    TestImm testImm = Shadow.extract(ctx.getSystemService(Context.INPUT_METHOD_SERVICE));
     testImm.setCurrentInputMethodSubtype(inputMethodSubtype);
-    View testView = new View(RuntimeEnvironment.application);
+    View testView = new View(ctx);
     EditorInfo outAttrs = new EditorInfo();
     outAttrs.inputType = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_MULTI_LINE;
     TextInputChannel textInputChannel = spy(new TextInputChannel(mock(DartExecutor.class)));
@@ -609,11 +596,9 @@ public class TextInputPluginTest {
       throws NullPointerException {
     // Initialize a general TextInputPlugin.
     InputMethodSubtype inputMethodSubtype = mock(InputMethodSubtype.class);
-    TestImm testImm =
-        Shadow.extract(
-            RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
+    TestImm testImm = Shadow.extract(ctx.getSystemService(Context.INPUT_METHOD_SERVICE));
     testImm.setCurrentInputMethodSubtype(inputMethodSubtype);
-    View testView = new View(RuntimeEnvironment.application);
+    View testView = new View(ctx);
     EditorInfo outAttrs = new EditorInfo();
     outAttrs.inputType = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_MULTI_LINE;
     TextInputChannel textInputChannel = spy(new TextInputChannel(mock(DartExecutor.class)));
@@ -720,11 +705,9 @@ public class TextInputPluginTest {
       throws NullPointerException {
     // Initialize a general TextInputPlugin.
     InputMethodSubtype inputMethodSubtype = mock(InputMethodSubtype.class);
-    TestImm testImm =
-        Shadow.extract(
-            RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
+    TestImm testImm = Shadow.extract(ctx.getSystemService(Context.INPUT_METHOD_SERVICE));
     testImm.setCurrentInputMethodSubtype(inputMethodSubtype);
-    View testView = new View(RuntimeEnvironment.application);
+    View testView = new View(ctx);
     EditorInfo outAttrs = new EditorInfo();
     outAttrs.inputType = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_MULTI_LINE;
     TextInputChannel textInputChannel = spy(new TextInputChannel(mock(DartExecutor.class)));
@@ -828,11 +811,9 @@ public class TextInputPluginTest {
   public void inputConnectionAdaptor_RepeatFilter() throws NullPointerException {
     // Initialize a general TextInputPlugin.
     InputMethodSubtype inputMethodSubtype = mock(InputMethodSubtype.class);
-    TestImm testImm =
-        Shadow.extract(
-            RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
+    TestImm testImm = Shadow.extract(ctx.getSystemService(Context.INPUT_METHOD_SERVICE));
     testImm.setCurrentInputMethodSubtype(inputMethodSubtype);
-    View testView = new View(RuntimeEnvironment.application);
+    View testView = new View(ctx);
     EditorInfo outAttrs = new EditorInfo();
     outAttrs.inputType = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_MULTI_LINE;
     TextInputChannel textInputChannel = spy(new TextInputChannel(mock(DartExecutor.class)));
@@ -922,11 +903,9 @@ public class TextInputPluginTest {
   public void setTextInputEditingState_doesNotRestartWhenTextIsIdentical() {
     // Initialize a general TextInputPlugin.
     InputMethodSubtype inputMethodSubtype = mock(InputMethodSubtype.class);
-    TestImm testImm =
-        Shadow.extract(
-            RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
+    TestImm testImm = Shadow.extract(ctx.getSystemService(Context.INPUT_METHOD_SERVICE));
     testImm.setCurrentInputMethodSubtype(inputMethodSubtype);
-    View testView = new View(RuntimeEnvironment.application);
+    View testView = new View(ctx);
     TextInputChannel textInputChannel = new TextInputChannel(mock(DartExecutor.class));
     TextInputPlugin textInputPlugin =
         new TextInputPlugin(testView, textInputChannel, mock(PlatformViewsController.class));
@@ -961,11 +940,9 @@ public class TextInputPluginTest {
   public void setTextInputEditingState_alwaysSetEditableWhenDifferent() {
     // Initialize a general TextInputPlugin.
     InputMethodSubtype inputMethodSubtype = mock(InputMethodSubtype.class);
-    TestImm testImm =
-        Shadow.extract(
-            RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
+    TestImm testImm = Shadow.extract(ctx.getSystemService(Context.INPUT_METHOD_SERVICE));
     testImm.setCurrentInputMethodSubtype(inputMethodSubtype);
-    View testView = new View(RuntimeEnvironment.application);
+    View testView = new View(ctx);
     TextInputChannel textInputChannel = new TextInputChannel(mock(DartExecutor.class));
     TextInputPlugin textInputPlugin =
         new TextInputPlugin(testView, textInputChannel, mock(PlatformViewsController.class));
@@ -1009,11 +986,9 @@ public class TextInputPluginTest {
     // Initialize a TextInputPlugin that needs to be always restarted.
     InputMethodSubtype inputMethodSubtype =
         new InputMethodSubtype(0, 0, /*locale=*/ "en", "", "", false, false);
-    TestImm testImm =
-        Shadow.extract(
-            RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
+    TestImm testImm = Shadow.extract(ctx.getSystemService(Context.INPUT_METHOD_SERVICE));
     testImm.setCurrentInputMethodSubtype(inputMethodSubtype);
-    View testView = new View(RuntimeEnvironment.application);
+    View testView = new View(ctx);
     TextInputChannel textInputChannel = new TextInputChannel(mock(DartExecutor.class));
     TextInputPlugin textInputPlugin =
         new TextInputPlugin(testView, textInputChannel, mock(PlatformViewsController.class));
@@ -1110,12 +1085,10 @@ public class TextInputPluginTest {
 
   @Test
   public void setTextInputEditingState_nullInputMethodSubtype() {
-    TestImm testImm =
-        Shadow.extract(
-            RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
+    TestImm testImm = Shadow.extract(ctx.getSystemService(Context.INPUT_METHOD_SERVICE));
     testImm.setCurrentInputMethodSubtype(null);
 
-    View testView = new View(RuntimeEnvironment.application);
+    View testView = new View(ctx);
     TextInputChannel textInputChannel = new TextInputChannel(mock(DartExecutor.class));
     TextInputPlugin textInputPlugin =
         new TextInputPlugin(testView, textInputChannel, mock(PlatformViewsController.class));
@@ -1141,7 +1114,7 @@ public class TextInputPluginTest {
 
   @Test
   public void destroy_clearTextInputMethodHandler() {
-    View testView = new View(RuntimeEnvironment.application);
+    View testView = new View(ctx);
     TextInputChannel textInputChannel = spy(new TextInputChannel(mock(DartExecutor.class)));
     TextInputPlugin textInputPlugin =
         new TextInputPlugin(testView, textInputChannel, mock(PlatformViewsController.class));
@@ -1152,11 +1125,9 @@ public class TextInputPluginTest {
 
   @Test
   public void inputConnection_createsActionFromEnter() throws JSONException {
-    TestImm testImm =
-        Shadow.extract(
-            RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
+    TestImm testImm = Shadow.extract(ctx.getSystemService(Context.INPUT_METHOD_SERVICE));
     FlutterJNI mockFlutterJni = mock(FlutterJNI.class);
-    View testView = new View(RuntimeEnvironment.application);
+    View testView = new View(ctx);
     DartExecutor dartExecutor = spy(new DartExecutor(mockFlutterJni, mock(AssetManager.class)));
     TextInputChannel textInputChannel = new TextInputChannel(dartExecutor);
     TextInputPlugin textInputPlugin =
@@ -1216,15 +1187,13 @@ public class TextInputPluginTest {
     InputMethodSubtype inputMethodSubtype =
         new InputMethodSubtype(0, 0, /*locale=*/ "en", "", "", false, false);
     Settings.Secure.putString(
-        RuntimeEnvironment.application.getContentResolver(),
+        ctx.getContentResolver(),
         Settings.Secure.DEFAULT_INPUT_METHOD,
         "com.sec.android.inputmethod/.SamsungKeypad");
-    TestImm testImm =
-        Shadow.extract(
-            RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
+    TestImm testImm = Shadow.extract(ctx.getSystemService(Context.INPUT_METHOD_SERVICE));
     testImm.setCurrentInputMethodSubtype(inputMethodSubtype);
     FlutterJNI mockFlutterJni = mock(FlutterJNI.class);
-    View testView = new View(RuntimeEnvironment.application);
+    View testView = new View(ctx);
     DartExecutor dartExecutor = spy(new DartExecutor(mockFlutterJni, mock(AssetManager.class)));
     TextInputChannel textInputChannel = new TextInputChannel(dartExecutor);
     TextInputPlugin textInputPlugin =
@@ -1261,7 +1230,7 @@ public class TextInputPluginTest {
 
   @Test
   public void inputConnection_textInputTypeNone() {
-    View testView = new View(RuntimeEnvironment.application);
+    View testView = new View(ctx);
     DartExecutor dartExecutor = mock(DartExecutor.class);
     TextInputChannel textInputChannel = new TextInputChannel(dartExecutor);
     TextInputPlugin textInputPlugin =
@@ -1289,10 +1258,8 @@ public class TextInputPluginTest {
 
   @Test
   public void showTextInput_textInputTypeNone() {
-    TestImm testImm =
-        Shadow.extract(
-            RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
-    View testView = new View(RuntimeEnvironment.application);
+    TestImm testImm = Shadow.extract(ctx.getSystemService(Context.INPUT_METHOD_SERVICE));
+    View testView = new View(ctx);
     DartExecutor dartExecutor = mock(DartExecutor.class);
     TextInputChannel textInputChannel = new TextInputChannel(dartExecutor);
     TextInputPlugin textInputPlugin =
@@ -1322,7 +1289,7 @@ public class TextInputPluginTest {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
       return;
     }
-    FlutterView testView = new FlutterView(RuntimeEnvironment.application);
+    FlutterView testView = new FlutterView(ctx);
     TextInputChannel textInputChannel = new TextInputChannel(mock(DartExecutor.class));
     TextInputPlugin textInputPlugin =
         new TextInputPlugin(testView, textInputChannel, mock(PlatformViewsController.class));
@@ -1379,7 +1346,7 @@ public class TextInputPluginTest {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
       return;
     }
-    FlutterView testView = new FlutterView(RuntimeEnvironment.application);
+    FlutterView testView = new FlutterView(ctx);
     TextInputChannel textInputChannel = new TextInputChannel(mock(DartExecutor.class));
     TextInputPlugin textInputPlugin =
         new TextInputPlugin(testView, textInputChannel, mock(PlatformViewsController.class));
@@ -1415,7 +1382,7 @@ public class TextInputPluginTest {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
       return;
     }
-    FlutterView testView = new FlutterView(RuntimeEnvironment.application);
+    FlutterView testView = new FlutterView(ctx);
     TextInputChannel textInputChannel = new TextInputChannel(mock(DartExecutor.class));
     TextInputPlugin textInputPlugin =
         new TextInputPlugin(testView, textInputChannel, mock(PlatformViewsController.class));
@@ -1595,8 +1562,7 @@ public class TextInputPluginTest {
       return;
     }
 
-    TestAfm testAfm =
-        Shadow.extract(RuntimeEnvironment.application.getSystemService(AutofillManager.class));
+    TestAfm testAfm = Shadow.extract(ctx.getSystemService(AutofillManager.class));
     FlutterView testView = new FlutterView(Robolectric.setupActivity(Activity.class));
     TextInputChannel textInputChannel = new TextInputChannel(mock(DartExecutor.class));
     TextInputPlugin textInputPlugin =
@@ -1726,8 +1692,7 @@ public class TextInputPluginTest {
       return;
     }
 
-    TestAfm testAfm =
-        Shadow.extract(RuntimeEnvironment.application.getSystemService(AutofillManager.class));
+    TestAfm testAfm = Shadow.extract(ctx.getSystemService(AutofillManager.class));
     FlutterView testView = new FlutterView(Robolectric.setupActivity(Activity.class));
     TextInputChannel textInputChannel = spy(new TextInputChannel(mock(DartExecutor.class)));
     TextInputPlugin textInputPlugin =
@@ -1820,8 +1785,7 @@ public class TextInputPluginTest {
       return;
     }
 
-    TestAfm testAfm =
-        Shadow.extract(RuntimeEnvironment.application.getSystemService(AutofillManager.class));
+    TestAfm testAfm = Shadow.extract(ctx.getSystemService(AutofillManager.class));
     FlutterView testView = new FlutterView(Robolectric.setupActivity(Activity.class));
     TextInputChannel textInputChannel = new TextInputChannel(mock(DartExecutor.class));
     TextInputPlugin textInputPlugin =
@@ -1926,12 +1890,10 @@ public class TextInputPluginTest {
     TextInputChannel textInputChannel = new TextInputChannel(mockBinaryMessenger);
 
     EventHandler mockEventHandler = mock(EventHandler.class);
-    TestImm testImm =
-        Shadow.extract(
-            RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
+    TestImm testImm = Shadow.extract(ctx.getSystemService(Context.INPUT_METHOD_SERVICE));
     testImm.setEventHandler(mockEventHandler);
 
-    View testView = new View(RuntimeEnvironment.application);
+    View testView = new View(ctx);
     TextInputPlugin textInputPlugin =
         new TextInputPlugin(testView, textInputChannel, mock(PlatformViewsController.class));
 
@@ -1957,12 +1919,10 @@ public class TextInputPluginTest {
     TextInputChannel textInputChannel = new TextInputChannel(mockBinaryMessenger);
 
     EventHandler mockEventHandler = mock(EventHandler.class);
-    TestImm testImm =
-        Shadow.extract(
-            RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
+    TestImm testImm = Shadow.extract(ctx.getSystemService(Context.INPUT_METHOD_SERVICE));
     testImm.setEventHandler(mockEventHandler);
 
-    View testView = new View(RuntimeEnvironment.application);
+    View testView = new View(ctx);
     TextInputPlugin textInputPlugin =
         new TextInputPlugin(testView, textInputChannel, mock(PlatformViewsController.class));
 
@@ -1991,8 +1951,7 @@ public class TextInputPluginTest {
     TextInputPlugin textInputPlugin =
         new TextInputPlugin(testView, textInputChannel, mock(PlatformViewsController.class));
     ImeSyncDeferringInsetsCallback imeSyncCallback = textInputPlugin.getImeSyncCallback();
-    FlutterEngine flutterEngine =
-        spy(new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, mockFlutterJni));
+    FlutterEngine flutterEngine = spy(new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni));
     FlutterRenderer flutterRenderer = spy(new FlutterRenderer(mockFlutterJni));
     when(flutterEngine.getRenderer()).thenReturn(flutterRenderer);
     testView.attachToFlutterEngine(flutterEngine);

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
@@ -25,6 +25,7 @@ import android.view.Window;
 import android.view.WindowInsetsController;
 import androidx.activity.OnBackPressedCallback;
 import androidx.fragment.app.FragmentActivity;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import io.flutter.embedding.engine.systemchannels.PlatformChannel;
 import io.flutter.embedding.engine.systemchannels.PlatformChannel.Brightness;
@@ -36,12 +37,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 @Config(manifest = Config.NONE)
 @RunWith(AndroidJUnit4.class)
 public class PlatformPluginTest {
+  private final Context ctx = ApplicationProvider.getApplicationContext();
+
   @Config(sdk = 16)
   @Test
   public void itIgnoresNewHapticEventsOnOldAndroidPlatforms() {
@@ -63,8 +65,7 @@ public class PlatformPluginTest {
   @Config(sdk = 29)
   @Test
   public void platformPlugin_getClipboardData() throws IOException {
-    ClipboardManager clipboardManager =
-        RuntimeEnvironment.application.getSystemService(ClipboardManager.class);
+    ClipboardManager clipboardManager = ctx.getSystemService(ClipboardManager.class);
 
     View fakeDecorView = mock(View.class);
     Window fakeWindow = mock(Window.class);
@@ -81,7 +82,7 @@ public class PlatformPluginTest {
     clipboardManager.setPrimaryClip(clip);
     assertNotNull(platformPlugin.mPlatformMessageHandler.getClipboardData(clipboardFormat));
 
-    ContentResolver contentResolver = RuntimeEnvironment.application.getContentResolver();
+    ContentResolver contentResolver = ctx.getContentResolver();
     when(fakeActivity.getContentResolver()).thenReturn(contentResolver);
     Uri uri = Uri.parse("content://media/external_primary/images/media/");
     clip = ClipData.newUri(contentResolver, "URI", uri);
@@ -92,8 +93,7 @@ public class PlatformPluginTest {
   @Config(sdk = 28)
   @Test
   public void platformPlugin_hasStrings() {
-    ClipboardManager clipboardManager =
-        spy(RuntimeEnvironment.application.getSystemService(ClipboardManager.class));
+    ClipboardManager clipboardManager = spy(ctx.getSystemService(ClipboardManager.class));
 
     View fakeDecorView = mock(View.class);
     Window fakeWindow = mock(Window.class);

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewWrapperTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewWrapperTest.java
@@ -20,16 +20,16 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 import org.robolectric.annotation.Implements;
 
 @TargetApi(31)
 @RunWith(AndroidJUnit4.class)
 public class PlatformViewWrapperTest {
+  private final Context ctx = ApplicationProvider.getApplicationContext();
+
   @Test
   public void invalidateChildInParent_callsInvalidate() {
-    final Context ctx = ApplicationProvider.getApplicationContext();
     final PlatformViewWrapper wrapper = spy(new PlatformViewWrapper(ctx));
 
     // Mock Android framework calls.
@@ -42,7 +42,6 @@ public class PlatformViewWrapperTest {
   @Test
   public void setTexture_writesToBuffer() {
     final Surface surface = mock(Surface.class);
-    final Context ctx = ApplicationProvider.getApplicationContext();
     final PlatformViewWrapper wrapper =
         new PlatformViewWrapper(ctx) {
           @Override
@@ -71,7 +70,6 @@ public class PlatformViewWrapperTest {
   @Test
   public void draw_writesToBuffer() {
     final Surface surface = mock(Surface.class);
-    final Context ctx = ApplicationProvider.getApplicationContext();
     final PlatformViewWrapper wrapper =
         new PlatformViewWrapper(ctx) {
           @Override
@@ -125,7 +123,6 @@ public class PlatformViewWrapperTest {
         ShadowView.class,
       })
   public void draw_withoutSurface() {
-    final Context ctx = ApplicationProvider.getApplicationContext();
     final PlatformViewWrapper wrapper =
         new PlatformViewWrapper(ctx) {
           @Override
@@ -144,7 +141,6 @@ public class PlatformViewWrapperTest {
   @Test
   public void release() {
     final Surface surface = mock(Surface.class);
-    final Context ctx = ApplicationProvider.getApplicationContext();
     final PlatformViewWrapper wrapper =
         new PlatformViewWrapper(ctx) {
           @Override
@@ -178,7 +174,7 @@ public class PlatformViewWrapperTest {
     when(viewTreeObserver.isAlive()).thenReturn(true);
 
     final PlatformViewWrapper view =
-        new PlatformViewWrapper(RuntimeEnvironment.application) {
+        new PlatformViewWrapper(ctx) {
           @Override
           public ViewTreeObserver getViewTreeObserver() {
             return viewTreeObserver;
@@ -207,7 +203,7 @@ public class PlatformViewWrapperTest {
     when(viewTreeObserver.isAlive()).thenReturn(true);
 
     final PlatformViewWrapper view =
-        new PlatformViewWrapper(RuntimeEnvironment.application) {
+        new PlatformViewWrapper(ctx) {
           @Override
           public ViewTreeObserver getViewTreeObserver() {
             return viewTreeObserver;
@@ -233,7 +229,7 @@ public class PlatformViewWrapperTest {
   @Test
   public void focusChangeListener_viewTreeObserverIsAliveFalseDoesNotThrow() {
     final PlatformViewWrapper view =
-        new PlatformViewWrapper(RuntimeEnvironment.application) {
+        new PlatformViewWrapper(ctx) {
           @Override
           public ViewTreeObserver getViewTreeObserver() {
             final ViewTreeObserver viewTreeObserver = mock(ViewTreeObserver.class);
@@ -250,7 +246,7 @@ public class PlatformViewWrapperTest {
     when(viewTreeObserver.isAlive()).thenReturn(true);
 
     final PlatformViewWrapper view =
-        new PlatformViewWrapper(RuntimeEnvironment.application) {
+        new PlatformViewWrapper(ctx) {
           @Override
           public ViewTreeObserver getViewTreeObserver() {
             return viewTreeObserver;
@@ -277,7 +273,7 @@ public class PlatformViewWrapperTest {
     when(viewTreeObserver.isAlive()).thenReturn(true);
 
     final PlatformViewWrapper view =
-        new PlatformViewWrapper(RuntimeEnvironment.application) {
+        new PlatformViewWrapper(ctx) {
           @Override
           public ViewTreeObserver getViewTreeObserver() {
             return viewTreeObserver;

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
@@ -17,6 +17,7 @@ import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 import android.view.View;
 import android.view.ViewParent;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import io.flutter.embedding.android.FlutterImageView;
 import io.flutter.embedding.android.FlutterView;
@@ -45,7 +46,6 @@ import java.util.Map;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
@@ -313,7 +313,7 @@ public class PlatformViewsControllerTest {
     PlatformViewFactory viewFactory = mock(PlatformViewFactory.class);
     PlatformView platformView = mock(PlatformView.class);
 
-    Context context = RuntimeEnvironment.application.getApplicationContext();
+    Context context = ApplicationProvider.getApplicationContext();
     View androidView = new View(context);
 
     when(platformView.getView()).thenReturn(androidView);
@@ -354,7 +354,7 @@ public class PlatformViewsControllerTest {
     PlatformViewFactory viewFactory = mock(PlatformViewFactory.class);
     PlatformView platformView = mock(PlatformView.class);
 
-    Context context = RuntimeEnvironment.application.getApplicationContext();
+    Context context = ApplicationProvider.getApplicationContext();
     View androidView = new View(context);
     when(platformView.getView()).thenReturn(androidView);
     when(viewFactory.create(any(), eq(platformViewId), any())).thenReturn(platformView);
@@ -891,7 +891,7 @@ public class PlatformViewsControllerTest {
 
   private static FlutterView attach(
       FlutterJNI jni, PlatformViewsController platformViewsController) {
-    final Context context = RuntimeEnvironment.application.getApplicationContext();
+    final Context context = ApplicationProvider.getApplicationContext();
     final FlutterView flutterView =
         new FlutterView(context, RenderMode.surface) {
           @Override
@@ -910,7 +910,7 @@ public class PlatformViewsControllerTest {
     final DartExecutor executor = new DartExecutor(jni, mock(AssetManager.class));
     executor.onAttachedToJNI();
 
-    final Context context = RuntimeEnvironment.application.getApplicationContext();
+    final Context context = ApplicationProvider.getApplicationContext();
     final TextureRegistry registry =
         new TextureRegistry() {
           public void TextureRegistry() {}

--- a/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -39,6 +39,7 @@ import android.view.WindowManager;
 import android.view.accessibility.AccessibilityEvent;
 import android.view.accessibility.AccessibilityManager;
 import android.view.accessibility.AccessibilityNodeInfo;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import io.flutter.embedding.engine.systemchannels.AccessibilityChannel;
 import io.flutter.plugin.platform.PlatformViewsAccessibilityDelegate;
@@ -51,7 +52,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 @Config(manifest = Config.NONE)
@@ -1439,7 +1439,7 @@ public class AccessibilityBridgeTest {
     PlatformViewsAccessibilityDelegate accessibilityDelegate =
         mock(PlatformViewsAccessibilityDelegate.class);
 
-    Context context = RuntimeEnvironment.application.getApplicationContext();
+    Context context = ApplicationProvider.getApplicationContext();
     View rootAccessibilityView = new View(context);
     AccessibilityViewEmbedder accessibilityViewEmbedder = mock(AccessibilityViewEmbedder.class);
     AccessibilityBridge accessibilityBridge =
@@ -1482,7 +1482,7 @@ public class AccessibilityBridgeTest {
     PlatformViewsAccessibilityDelegate accessibilityDelegate =
         mock(PlatformViewsAccessibilityDelegate.class);
 
-    Context context = RuntimeEnvironment.application.getApplicationContext();
+    Context context = ApplicationProvider.getApplicationContext();
     View rootAccessibilityView = new View(context);
     AccessibilityViewEmbedder accessibilityViewEmbedder = mock(AccessibilityViewEmbedder.class);
     AccessibilityBridge accessibilityBridge =
@@ -1516,7 +1516,7 @@ public class AccessibilityBridgeTest {
     PlatformViewsAccessibilityDelegate accessibilityDelegate =
         mock(PlatformViewsAccessibilityDelegate.class);
 
-    Context context = RuntimeEnvironment.application.getApplicationContext();
+    Context context = ApplicationProvider.getApplicationContext();
     View rootAccessibilityView = new View(context);
     AccessibilityViewEmbedder accessibilityViewEmbedder = mock(AccessibilityViewEmbedder.class);
     AccessibilityBridge accessibilityBridge =


### PR DESCRIPTION
The [RuntimeEnvironment#application is deprecated](http://robolectric.org/javadoc/4.7/org/robolectric/RuntimeEnvironment.html#application), and it's recommended to use `ApplicationProvider#getApplicationContext` to get application context for Robolectric tests. The `ApplicationProvider#getApplicationContext` also can help make test more compatible with AndroidX instrumentation tests.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
