### PR TITLE
[web] Migrate Flutter Web to JS static interop - 9.

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -2071,9 +2071,13 @@ extension SkFontFeatureExtension on SkFontFeature {
 class SkTypeface {}
 
 @JS('window.flutterCanvasKit.Font')
+@staticInterop
 class SkFont {
   external factory SkFont(SkTypeface typeface);
-  external Uint8List getGlyphIDs(String text);
+}
+
+extension SkFontExtension on SkFont {
+  external Uint16List getGlyphIDs(String text);
   external void getGlyphBounds(
       List<int> glyphs, SkPaint? paint, Uint8List? output);
 }

--- a/lib/web_ui/lib/src/engine/canvaskit/font_fallbacks.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/font_fallbacks.dart
@@ -131,7 +131,7 @@ class FontFallbackData {
         List<bool>.filled(codeUnits.length, false);
     final String testString = String.fromCharCodes(codeUnits);
     for (final SkFont font in fonts) {
-      final Uint8List glyphs = font.getGlyphIDs(testString);
+      final Uint16List glyphs = font.getGlyphIDs(testString);
       assert(glyphs.length == codeUnitsSupported.length);
       for (int i = 0; i < glyphs.length; i++) {
         codeUnitsSupported[i] |= glyphs[i] != 0 || _isControlCode(codeUnits[i]);
@@ -182,7 +182,7 @@ class FontFallbackData {
         continue;
       }
       for (final SkFont font in fontsForFamily) {
-        final Uint8List glyphs = font.getGlyphIDs(testString);
+        final Uint16List glyphs = font.getGlyphIDs(testString);
         assert(glyphs.length == codeUnitsSupported.length);
         for (int i = 0; i < glyphs.length; i++) {
           final bool codeUnitSupported = glyphs[i] != 0;


### PR DESCRIPTION
This is CL 9 in a series of CLs to migrate Flutter Web to the new JS static interop API.

This CL migrates SkFont on its own because it needed a change to a type signature.