### PR TITLE
Win32: fix window commits last char when deleting text with IME

### DIFF
--- a/shell/platform/windows/window_win32.cc
+++ b/shell/platform/windows/window_win32.cc
@@ -212,6 +212,11 @@ void WindowWin32::OnImeComposition(UINT const message,
   // Update the IME window position.
   text_input_manager_->UpdateImeWindow();
 
+  if (lparam == 0) {
+    OnComposeChange(u"", 0);
+    OnComposeCommit();
+  }
+
   if (lparam & GCS_COMPSTR) {
     // Read the in-progress composing string.
     long pos = text_input_manager_->GetComposingCursorPosition();

--- a/shell/platform/windows/window_win32_unittests.cc
+++ b/shell/platform/windows/window_win32_unittests.cc
@@ -115,6 +115,23 @@ TEST(MockWin32Window, OnImeCompositionComposeAndResult) {
                              GCS_COMPSTR | GCS_RESULTSTR);
 }
 
+TEST(MockWin32Window, OnImeCompositionClearChange) {
+  MockTextInputManagerWin32* text_input_manager =
+      new MockTextInputManagerWin32();
+  std::unique_ptr<TextInputManagerWin32> text_input_manager_ptr(
+      text_input_manager);
+  MockWin32Window window(std::move(text_input_manager_ptr));
+  EXPECT_CALL(window, OnComposeChange(std::u16string(u""), 0)).Times(1);
+  EXPECT_CALL(window, OnComposeCommit()).Times(1);
+  ON_CALL(window, OnImeComposition)
+      .WillByDefault(Invoke(&window, &MockWin32Window::CallOnImeComposition));
+  EXPECT_CALL(window, OnImeComposition(_, _, _)).Times(1);
+
+  // send an IME_COMPOSITION event that contains both the result string and the
+  // composition string.
+  window.InjectWindowMessage(WM_IME_COMPOSITION, 0, 0);
+}
+
 TEST(MockWin32Window, HorizontalScroll) {
   MockWin32Window window;
   const int scroll_amount = 10;


### PR DESCRIPTION
Similar problem to flutter/flutter#92132 is occured by using Google Japanese Input, and Microsoft Japanese IME.
In this case, a WM_IME_COMPOSITION message with zero lparam is posted. (this behavior is documented in https://docs.microsoft.com/en-us/windows/win32/intl/wm-ime-composition)
This PR adds processing this.

Fixes: flutter/flutter#101953

No changes in `flutter/tests`.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [x] All existing and new tests are passing.
