### PR TITLE
Win32: The vertical offset of the IME is incorrect when compared with native Windows apps

### DIFF
--- a/shell/platform/windows/text_input_manager_win32.cc
+++ b/shell/platform/windows/text_input_manager_win32.cc
@@ -179,7 +179,7 @@ void TextInputManagerWin32::MoveImeWindow(HIMC imm_context) {
   COMPOSITIONFORM cf = {CFS_POINT, {x, y}};
   ::ImmSetCompositionWindow(imm_context, &cf);
 
-  CANDIDATEFORM candidate_form = {0, CFS_CANDIDATEPOS, {x, y}, {0, 0, 0, 0}};
+  CANDIDATEFORM candidate_form = {0, CFS_EXCLUDE, {x, y}, {0, 0, 0, 0}};
   ::ImmSetCandidateWindow(imm_context, &candidate_form);
 }
 


### PR DESCRIPTION
Setting `CFS_CANDIDATEPOS` in `CANDIDATEFORM` seems reserving spaces for text drawn by IME. The `CFS_EXCLUDE` remove it.
I couldn't write test for this.
![fixed example](https://user-images.githubusercontent.com/16546008/162584782-115db53f-5ff5-4032-acdc-da7fbd30d1f4.png)

Fix: flutter/flutter#101642

No changes in `flutter/tests`.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [x] All existing and new tests are passing.