### PR TITLE
Update os dimension for engine v2 builders.

### DIFF
--- a/ci/builders/mac_ios_engine.json
+++ b/ci/builders/mac_ios_engine.json
@@ -5,7 +5,7 @@
             "drone_dimensions": [
                 "device_type=none",
                 "mac_model=Macmini8,1",
-                "os=Mac"
+                "os=Mac-12"
             ],
             "gn": [
                 "--ios",
@@ -26,7 +26,7 @@
             "drone_dimensions": [
                 "device_type=none",
                 "mac_model=Macmini8,1",
-                "os=Mac"
+                "os=Mac-12"
             ],
             "gn": [
                 "--bitcode",
@@ -46,7 +46,7 @@
             "drone_dimensions": [
                 "device_type=none",
                 "mac_model=Macmini8,1",
-                "os=Mac"
+                "os=Mac-12"
             ],
             "generators": {
                 "tasks": [

--- a/ci/builders/mac_ios_engine_profile.json
+++ b/ci/builders/mac_ios_engine_profile.json
@@ -5,7 +5,7 @@
             "drone_dimensions": [
                 "device_type=none",
                 "mac_model=Macmini8,1",
-                "os=Mac"
+                "os=Mac-12"
             ],
             "gn": [
                 "--ios",
@@ -26,7 +26,7 @@
             "drone_dimensions": [
                 "device_type=none",
                 "mac_model=Macmini8,1",
-                "os=Mac"
+                "os=Mac-12"
             ],
             "gn": [
                 "--ios",
@@ -46,7 +46,7 @@
             "drone_dimensions": [
                 "device_type=none",
                 "mac_model=Macmini8,1",
-                "os=Mac"
+                "os=Mac-12"
             ],
             "generators": {},
             "gn": [

--- a/ci/builders/mac_ios_engine_release.json
+++ b/ci/builders/mac_ios_engine_release.json
@@ -5,7 +5,7 @@
             "drone_dimensions": [
                 "device_type=none",
                 "mac_model=Macmini8,1",
-                "os=Mac"
+                "os=Mac-12"
             ],
             "gn": [
                 "--ios",
@@ -26,7 +26,7 @@
             "drone_dimensions": [
                 "device_type=none",
                 "mac_model=Macmini8,1",
-                "os=Mac"
+                "os=Mac-12"
             ],
             "gn": [
                 "--ios",
@@ -48,7 +48,7 @@
             "drone_dimensions": [
                 "device_type=none",
                 "mac_model=Macmini8,1",
-                "os=Mac"
+                "os=Mac-12"
             ],
             "generators": {},
             "gn": [


### PR DESCRIPTION
Engine V2 builders are failing since the version of xcode was updated to
13 because the current os dimension is set to Mac which allows builds to
pick Mac-10 bots that are not compatible with Xcode 13.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
