### PR TITLE
fix races associated with unawaited futures

### DIFF
--- a/lib/web_ui/analysis_options.yaml
+++ b/lib/web_ui/analysis_options.yaml
@@ -9,3 +9,4 @@ include: ../../analysis_options.yaml
 linter:
   rules:
     public_member_api_docs: false
+    unawaited_futures: true

--- a/lib/web_ui/dev/chrome.dart
+++ b/lib/web_ui/dev/chrome.dart
@@ -191,6 +191,12 @@ Future<Process> _spawnChromiumProcess(String executable, List<String> args, { St
     // A precaution that avoids accumulating browser processes, in case the
     // glibc bug doesn't cause the browser to quit and we keep looping and
     // launching more processes.
+
+    // It's OK to not await the future here, as this is a best-effort process
+    // clean-up only. If we're executing this line, this means things are off
+    // the rails already due to the glibc bug, and we're just scrambling to keep
+    // the system stable.
+    // ignore: unawaited_futures
     process.exitCode.timeout(const Duration(seconds: 1), onTimeout: () {
       process.kill();
       return -1;

--- a/lib/web_ui/dev/felt.dart
+++ b/lib/web_ui/dev/felt.dart
@@ -71,7 +71,7 @@ Future<void> main(List<String> rawArgs) async {
   io.exit(io.exitCode);
 }
 
-Future<void> _listenToShutdownSignals() async {
+void _listenToShutdownSignals() {
   io.ProcessSignal.sigint.watch().listen((_) async {
     print('Received SIGINT. Shutting down.');
     await cleanup();

--- a/lib/web_ui/dev/safari_macos.dart
+++ b/lib/web_ui/dev/safari_macos.dart
@@ -67,7 +67,7 @@ class SafariMacOs extends Browser {
       // Clean up trampoline files/directories before exiting felt.
       cleanupCallbacks.add(() async {
         if (trampolineDirectory.existsSync()) {
-          trampolineDirectory.delete(recursive: true);
+          await trampolineDirectory.delete(recursive: true);
         }
       });
 

--- a/lib/web_ui/lib/src/engine/canvaskit/font_fallbacks.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/font_fallbacks.dart
@@ -291,7 +291,7 @@ Future<void> findFontsForMissingCodeunits(List<int> codeUnits) async {
   // we try looking them up in the symbols and emojis fonts.
   if (missingCodeUnits.isNotEmpty || unmatchedCodeUnits.isNotEmpty) {
     if (!data.registeredSymbolsAndEmoji) {
-      _registerSymbolsAndEmoji();
+      await _registerSymbolsAndEmoji();
     } else {
       if (!notoDownloadQueue.isPending) {
         printWarning(

--- a/lib/web_ui/lib/src/engine/html_image_codec.dart
+++ b/lib/web_ui/lib/src/engine/html_image_codec.dart
@@ -47,6 +47,10 @@ class HtmlCodec implements ui.Codec {
       final html.ImageElement imgElement = html.ImageElement();
       imgElement.src = src;
       setJsProperty<String>(imgElement, 'decoding', 'async');
+
+      // Ignoring the returned future on purpose because we're communicating
+      // through the `completer`.
+      // ignore: unawaited_futures
       imgElement.decode().then((dynamic _) {
         chunkCallback?.call(100, 100);
         int naturalWidth = imgElement.naturalWidth;

--- a/lib/web_ui/lib/src/engine/picture.dart
+++ b/lib/web_ui/lib/src/engine/picture.dart
@@ -65,7 +65,12 @@ class EnginePicture implements ui.Picture {
     // The image loads asynchronously. We need to wait before returning,
     // otherwise the returned HtmlImage will be temporarily unusable.
     final Completer<ui.Image> onImageLoaded = Completer<ui.Image>.sync();
+
+    // Ignoring the returned futures from onError and onLoad because we're
+    // communicating through the `onImageLoaded` completer.
+    // ignore: unawaited_futures
     imageElement.onError.first.then(onImageLoaded.completeError);
+    // ignore: unawaited_futures
     imageElement.onLoad.first.then((_) {
       onImageLoaded.complete(HtmlImage(
         imageElement,

--- a/lib/web_ui/test/channel_buffers_test.dart
+++ b/lib/web_ui/test/channel_buffers_test.dart
@@ -60,6 +60,10 @@ void testMain() {
     final Completer<void> completer = Completer<void>();
     scheduleMicrotask(() { log.add('before drain, microtask'); });
     log.add('before drain');
+
+    // Ignoring the returned future because the completion of the drain is
+    // communicated using the `completer`.
+    // ignore: unawaited_futures
     buffers.drain(channel, (ByteData? drainedData, ui.PlatformMessageResponseCallback drainedCallback) async {
       log.add('callback');
       completer.complete();

--- a/lib/web_ui/test/engine/surface/scene_builder_test.dart
+++ b/lib/web_ui/test/engine/surface/scene_builder_test.dart
@@ -20,8 +20,8 @@ void main() {
 }
 
 void testMain() {
-  setUpAll(() {
-    ui.webOnlyInitializePlatform();
+  setUpAll(() async {
+    await ui.webOnlyInitializePlatform();
   });
 
   group('SceneBuilder', () {

--- a/lib/web_ui/test/engine/surface/shaders/shader_builder_test.dart
+++ b/lib/web_ui/test/engine/surface/shaders/shader_builder_test.dart
@@ -24,7 +24,7 @@ void testMain() {
       ')';
 
   setUpAll(() async {
-    webOnlyInitializePlatform();
+    await webOnlyInitializePlatform();
   });
 
   group('Shader Declarations', () {

--- a/lib/web_ui/test/engine/util_test.dart
+++ b/lib/web_ui/test/engine/util_test.dart
@@ -132,7 +132,7 @@ void testMain() {
 
   test('futurize converts error string to exception', () async {
     try {
-      futurize((Callback<String> callback) {
+      await futurize((Callback<String> callback) {
         return 'this is an error';
       });
       fail('Expected it to throw');
@@ -159,7 +159,7 @@ void testMain() {
 
   test('futurize converts sync null into a sync operation failure', () async {
     try {
-      futurize((Callback<String?> callback) {
+      await futurize((Callback<String?> callback) {
         callback(null);
         return null;
       });

--- a/lib/web_ui/test/window_test.dart
+++ b/lib/web_ui/test/window_test.dart
@@ -143,7 +143,7 @@ void testMain() {
     ), useSingle: false);
     expect(window.browserHistory, isA<MultiEntriesBrowserHistory>());
     final List<String> executionOrder = <String>[];
-    window.handleNavigationMessage(
+    await window.handleNavigationMessage(
       const JSONMethodCodec().encodeMethodCall(const MethodCall(
         'selectSingleEntryHistory',
         null,
@@ -151,7 +151,7 @@ void testMain() {
     ).then<void>((bool data) {
       executionOrder.add('1');
     });
-    window.handleNavigationMessage(
+    await window.handleNavigationMessage(
       const JSONMethodCodec().encodeMethodCall(const MethodCall(
         'selectMultiEntryHistory',
         null,
@@ -159,7 +159,7 @@ void testMain() {
     ).then<void>((bool data) {
       executionOrder.add('2');
     });
-    window.handleNavigationMessage(
+    await window.handleNavigationMessage(
         const JSONMethodCodec().encodeMethodCall(const MethodCall(
         'selectSingleEntryHistory',
         null,

--- a/lib/web_ui/tool/unicode_sync_script.dart
+++ b/lib/web_ui/tool/unicode_sync_script.dart
@@ -124,7 +124,7 @@ Future<void> main(List<String> arguments) async {
     result['dry'] as bool,
   );
 
-  syncer.perform();
+  await syncer.perform();
 }
 
 PropertiesSyncer getSyncer(

--- a/testing/dart/channel_buffers_test.dart
+++ b/testing/dart/channel_buffers_test.dart
@@ -49,6 +49,10 @@ void main() {
     final Completer<void> completer = Completer<void>();
     scheduleMicrotask(() { log.add('before drain, microtask'); });
     log.add('before drain');
+
+    // Ignoring the returned future because the completion of the drain is
+    // communicated using the `completer`.
+    // ignore: unawaited_futures
     buffers.drain(channel, (ByteData? drainedData, ui.PlatformMessageResponseCallback drainedCallback) async {
       log.add('callback');
       completer.complete();


### PR DESCRIPTION
Enable `unawaited_futures` lint for all web engine code, and fix code that's been ignoring the futures. In particular, this should fix test flakiness on Firefox, such as [this](https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8817169134885333377/+/u/felt_test:_firefox-unit-linux/stdout).