### PR TITLE
Designated field initialization of Paint/PrerollContexts

### DIFF
--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -54,7 +54,7 @@ struct PrerollContext {
   const Stopwatch& ui_time;
   TextureRegistry& texture_registry;
   const bool checkerboard_offscreen_layers;
-  const float frame_device_pixel_ratio;
+  const float frame_device_pixel_ratio = 1.0f;
 
   // These allow us to track properties like elevation, opacity, and the
   // prescence of a platform view during Preroll.
@@ -167,12 +167,12 @@ class Layer {
     TextureRegistry& texture_registry;
     const RasterCache* raster_cache;
     const bool checkerboard_offscreen_layers;
-    const float frame_device_pixel_ratio;
+    const float frame_device_pixel_ratio = 1.0f;
 
     // Snapshot store to collect leaf layer snapshots. The store is non-null
     // only when leaf layer tracing is enabled.
-    bool enable_leaf_layer_tracing = false;
     LayerSnapshotStore* layer_snapshot_store = nullptr;
+    bool enable_leaf_layer_tracing = false;
 
     // The following value should be used to modulate the opacity of the
     // layer during |Paint|. If the layer does not set the corresponding

--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -39,18 +39,22 @@ bool LayerTree::Preroll(CompositorContext::ScopedFrame& frame,
       checkerboard_raster_cache_images_);
   MutatorsStack stack;
   PrerollContext context = {
-      ignore_raster_cache ? nullptr : &frame.context().raster_cache(),
-      frame.gr_context(),
-      frame.view_embedder(),
-      stack,
-      color_space,
-      cull_rect,
-      false,
-      frame.context().raster_time(),
-      frame.context().ui_time(),
-      frame.context().texture_registry(),
-      checkerboard_offscreen_layers_,
-      device_pixel_ratio_};
+      // clang-format off
+      .raster_cache                  =
+          ignore_raster_cache ? nullptr : &frame.context().raster_cache(),
+      .gr_context                    = frame.gr_context(),
+      .view_embedder                 = frame.view_embedder(),
+      .mutators_stack                = stack,
+      .dst_color_space               = color_space,
+      .cull_rect                     = cull_rect,
+      .surface_needs_readback        = false,
+      .raster_time                   = frame.context().raster_time(),
+      .ui_time                       = frame.context().ui_time(),
+      .texture_registry              = frame.context().texture_registry(),
+      .checkerboard_offscreen_layers = checkerboard_offscreen_layers_,
+      .frame_device_pixel_ratio      = device_pixel_ratio_,
+      // clang-format on
+  };
 
   root_layer_->Preroll(&context, frame.root_surface_transformation());
   return context.surface_needs_readback;
@@ -82,21 +86,25 @@ void LayerTree::Paint(CompositorContext::ScopedFrame& frame,
     snapshot_store = &frame.context().snapshot_store();
   }
 
+  RasterCache* cache =
+      ignore_raster_cache ? nullptr : &frame.context().raster_cache();
   Layer::PaintContext context = {
-      static_cast<SkCanvas*>(&internal_nodes_canvas),
-      frame.canvas(),
-      frame.gr_context(),
-      frame.view_embedder(),
-      frame.context().raster_time(),
-      frame.context().ui_time(),
-      frame.context().texture_registry(),
-      ignore_raster_cache ? nullptr : &frame.context().raster_cache(),
-      checkerboard_offscreen_layers_,
-      device_pixel_ratio_,
-      enable_leaf_layer_tracing_,
-      snapshot_store,
-      SK_Scalar1,
-      frame.display_list_builder(),
+      // clang-format off
+      .internal_nodes_canvas         = &internal_nodes_canvas,
+      .leaf_nodes_canvas             = frame.canvas(),
+      .gr_context                    = frame.gr_context(),
+      .view_embedder                 = frame.view_embedder(),
+      .raster_time                   = frame.context().raster_time(),
+      .ui_time                       = frame.context().ui_time(),
+      .texture_registry              = frame.context().texture_registry(),
+      .raster_cache                  = cache,
+      .checkerboard_offscreen_layers = checkerboard_offscreen_layers_,
+      .frame_device_pixel_ratio      = device_pixel_ratio_,
+      .layer_snapshot_store          = snapshot_store,
+      .enable_leaf_layer_tracing     = enable_leaf_layer_tracing_,
+      .inherited_opacity             = SK_Scalar1,
+      .leaf_nodes_builder            = frame.display_list_builder(),
+      // clang-format on
   };
 
   if (root_layer_->needs_painting(context)) {
@@ -122,18 +130,20 @@ sk_sp<SkPicture> LayerTree::Flatten(const SkRect& bounds) {
   root_surface_transformation.reset();
 
   PrerollContext preroll_context{
-      nullptr,                  // raster_cache (don't consult the cache)
-      nullptr,                  // gr_context  (used for the raster cache)
-      nullptr,                  // external view embedder
-      unused_stack,             // mutator stack
-      nullptr,                  // SkColorSpace* dst_color_space
-      kGiantRect,               // SkRect cull_rect
-      false,                    // layer reads from surface
-      unused_stopwatch,         // frame time (dont care)
-      unused_stopwatch,         // engine time (dont care)
-      unused_texture_registry,  // texture registry (not supported)
-      false,                    // checkerboard_offscreen_layers
-      device_pixel_ratio_       // ratio between logical and physical
+      // clang-format off
+      .raster_cache                  = nullptr,
+      .gr_context                    = nullptr,
+      .view_embedder                 = nullptr,
+      .mutators_stack                = unused_stack,
+      .dst_color_space               = nullptr,
+      .cull_rect                     = kGiantRect,
+      .surface_needs_readback        = false,
+      .raster_time                   = unused_stopwatch,
+      .ui_time                       = unused_stopwatch,
+      .texture_registry              = unused_texture_registry,
+      .checkerboard_offscreen_layers = false,
+      .frame_device_pixel_ratio      = device_pixel_ratio_
+      // clang-format on
   };
 
   SkISize canvas_size = canvas->getBaseLayerSize();
@@ -141,18 +151,20 @@ sk_sp<SkPicture> LayerTree::Flatten(const SkRect& bounds) {
   internal_nodes_canvas.addCanvas(canvas);
 
   Layer::PaintContext paint_context = {
-      static_cast<SkCanvas*>(&internal_nodes_canvas),
-      canvas,  // canvas
-      nullptr,
-      nullptr,
-      unused_stopwatch,         // frame time (dont care)
-      unused_stopwatch,         // engine time (dont care)
-      unused_texture_registry,  // texture registry (not supported)
-      nullptr,                  // raster cache
-      false,                    // checkerboard offscreen layers
-      device_pixel_ratio_,      // ratio between logical and physical
-      false,                    // enable_leaf_layer_tracing
-      nullptr                   // layer_snapshot_store
+      // clang-format off
+      .internal_nodes_canvas         = &internal_nodes_canvas,
+      .leaf_nodes_canvas             = canvas,
+      .gr_context                    = nullptr,
+      .view_embedder                 = nullptr,
+      .raster_time                   = unused_stopwatch,
+      .ui_time                       = unused_stopwatch,
+      .texture_registry              = unused_texture_registry,
+      .raster_cache                  = nullptr,
+      .checkerboard_offscreen_layers = false,
+      .frame_device_pixel_ratio      = device_pixel_ratio_,
+      .layer_snapshot_store          = nullptr,
+      .enable_leaf_layer_tracing     = false,
+      // clang-format on
   };
 
   // Even if we don't have a root layer, we still need to create an empty

--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -38,10 +38,11 @@ bool LayerTree::Preroll(CompositorContext::ScopedFrame& frame,
   frame.context().raster_cache().SetCheckboardCacheImages(
       checkerboard_raster_cache_images_);
   MutatorsStack stack;
+  RasterCache* cache =
+      ignore_raster_cache ? nullptr : &frame.context().raster_cache();
   PrerollContext context = {
       // clang-format off
-      .raster_cache                  =
-          ignore_raster_cache ? nullptr : &frame.context().raster_cache(),
+      .raster_cache                  = cache,
       .gr_context                    = frame.gr_context(),
       .view_embedder                 = frame.view_embedder(),
       .mutators_stack                = stack,

--- a/flow/layers/layer_tree_unittests.cc
+++ b/flow/layers/layer_tree_unittests.cc
@@ -248,8 +248,8 @@ TEST_F(LayerTreeTest, PaintContextInitialization) {
   FixedRefreshRateStopwatch mock_ui_time;
   TextureRegistry mock_registry;
 
-  auto expect_defaults = [&mock_raster_time, &mock_ui_time, &mock_registry]
-      (const Layer::PaintContext& context) {
+  auto expect_defaults = [&mock_raster_time, &mock_ui_time,
+                          &mock_registry](const Layer::PaintContext& context) {
     EXPECT_EQ(context.internal_nodes_canvas, nullptr);
     EXPECT_EQ(context.leaf_nodes_canvas, nullptr);
     EXPECT_EQ(context.gr_context, nullptr);

--- a/flow/layers/layer_tree_unittests.cc
+++ b/flow/layers/layer_tree_unittests.cc
@@ -193,5 +193,89 @@ TEST_F(LayerTreeTest, NeedsSystemComposite) {
                                                child_path2, child_paint2}}}));
 }
 
+TEST_F(LayerTreeTest, PrerollContextInitialization) {
+  // This EXPECT macro will ensure that if any fields get added to the
+  // PrerollContext that this test must be revisited and updated.
+  // If any fields get removed or replaced, then the expect_defaults closure
+  // will fail to compile, again bringing attention to updating this test.
+  EXPECT_EQ(sizeof(PrerollContext), size_t(104));
+
+  MutatorsStack mock_mutators;
+  FixedRefreshRateStopwatch mock_raster_time;
+  FixedRefreshRateStopwatch mock_ui_time;
+  TextureRegistry mock_registry;
+
+  auto expect_defaults = [&mock_mutators, &mock_raster_time, &mock_ui_time,
+                          &mock_registry](const PrerollContext& context) {
+    EXPECT_EQ(context.raster_cache, nullptr);
+    EXPECT_EQ(context.gr_context, nullptr);
+    EXPECT_EQ(context.view_embedder, nullptr);
+    EXPECT_EQ(&context.mutators_stack, &mock_mutators);
+    EXPECT_EQ(context.dst_color_space, nullptr);
+    EXPECT_EQ(context.cull_rect, SkRect::MakeEmpty());
+    EXPECT_EQ(context.surface_needs_readback, false);
+
+    EXPECT_EQ(&context.raster_time, &mock_raster_time);
+    EXPECT_EQ(&context.ui_time, &mock_ui_time);
+    EXPECT_EQ(&context.texture_registry, &mock_registry);
+    EXPECT_EQ(context.checkerboard_offscreen_layers, false);
+    EXPECT_EQ(context.frame_device_pixel_ratio, 1.0f);
+
+    EXPECT_EQ(context.has_platform_view, false);
+    EXPECT_EQ(context.has_texture_layer, false);
+
+    EXPECT_EQ(context.subtree_can_inherit_opacity, false);
+  };
+
+  // These 4 initializers are required because they are handled by reference
+  PrerollContext context{
+      .mutators_stack = mock_mutators,
+      .raster_time = mock_raster_time,
+      .ui_time = mock_ui_time,
+      .texture_registry = mock_registry,
+  };
+  expect_defaults(context);
+}
+
+TEST_F(LayerTreeTest, PaintContextInitialization) {
+  // This EXPECT macro will ensure that if any fields get added to the
+  // PaintContext that this test must be revisited and updated.
+  // If any fields get removed or replaced, then the expect_defaults closure
+  // will fail to compile, again bringing attention to updating this test.
+  EXPECT_EQ(sizeof(Layer::PaintContext), size_t(96));
+
+  FixedRefreshRateStopwatch mock_raster_time;
+  FixedRefreshRateStopwatch mock_ui_time;
+  TextureRegistry mock_registry;
+
+  auto expect_defaults = [&mock_raster_time, &mock_ui_time, &mock_registry]
+      (const Layer::PaintContext& context) {
+    EXPECT_EQ(context.internal_nodes_canvas, nullptr);
+    EXPECT_EQ(context.leaf_nodes_canvas, nullptr);
+    EXPECT_EQ(context.gr_context, nullptr);
+    EXPECT_EQ(context.view_embedder, nullptr);
+    EXPECT_EQ(&context.raster_time, &mock_raster_time);
+    EXPECT_EQ(&context.ui_time, &mock_ui_time);
+    EXPECT_EQ(&context.texture_registry, &mock_registry);
+    EXPECT_EQ(context.raster_cache, nullptr);
+    EXPECT_EQ(context.checkerboard_offscreen_layers, false);
+    EXPECT_EQ(context.frame_device_pixel_ratio, 1.0f);
+
+    EXPECT_EQ(context.enable_leaf_layer_tracing, false);
+    EXPECT_EQ(context.layer_snapshot_store, nullptr);
+
+    EXPECT_EQ(context.inherited_opacity, SK_Scalar1);
+    EXPECT_EQ(context.leaf_nodes_builder, nullptr);
+  };
+
+  // These 4 initializers are required because they are handled by reference
+  Layer::PaintContext context{
+      .raster_time = mock_raster_time,
+      .ui_time = mock_ui_time,
+      .texture_registry = mock_registry,
+  };
+  expect_defaults(context);
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/flow/layers/performance_overlay_layer_unittests.cc
+++ b/flow/layers/performance_overlay_layer_unittests.cc
@@ -60,8 +60,19 @@ static void TestPerformanceOverlayLayerGold(int refresh_rate) {
 
   flutter::TextureRegistry unused_texture_registry;
   flutter::Layer::PaintContext paintContext = {
-      nullptr,        surface->getCanvas(),    nullptr, nullptr, mock_stopwatch,
-      mock_stopwatch, unused_texture_registry, nullptr, false};
+      // clang-format off
+      .internal_nodes_canvas         = nullptr,
+      .leaf_nodes_canvas             = surface->getCanvas(),
+      .gr_context                    = nullptr,
+      .view_embedder                 = nullptr,
+      .raster_time                   = mock_stopwatch,
+      .ui_time                       = mock_stopwatch,
+      .texture_registry              = unused_texture_registry,
+      .raster_cache                  = nullptr,
+      .checkerboard_offscreen_layers = false,
+      .frame_device_pixel_ratio      = 1.0f,
+      // clang-format on
+  };
 
   // Specify font file to ensure the same font across different operation
   // systems.

--- a/flow/testing/layer_test.h
+++ b/flow/testing/layer_test.h
@@ -40,38 +40,51 @@ class LayerTestBase : public CanvasTestBase<BaseT> {
 
  public:
   LayerTestBase()
-      : preroll_context_({
-            nullptr, /* raster_cache */
-            nullptr, /* gr_context */
-            nullptr, /* external_view_embedder */
-            mutators_stack_, TestT::mock_canvas().imageInfo().colorSpace(),
-            kGiantRect, /* cull_rect */
-            false,      /* layer reads from surface */
-            raster_time_, ui_time_, texture_registry_,
-            false, /* checkerboard_offscreen_layers */
-            1.0f,  /* frame_device_pixel_ratio */
-            false, /* has_platform_view */
-        }),
-        paint_context_({
-            TestT::mock_canvas().internal_canvas(), /* internal_nodes_canvas */
-            &TestT::mock_canvas(),                  /* leaf_nodes_canvas */
-            nullptr,                                /* gr_context */
-            nullptr,                                /* external_view_embedder */
-            raster_time_, ui_time_, texture_registry_,
-            nullptr, /* raster_cache */
-            false,   /* checkerboard_offscreen_layers */
-            1.0f,    /* frame_device_pixel_ratio */
-        }),
-        check_board_context_({
-            TestT::mock_canvas().internal_canvas(), /* internal_nodes_canvas */
-            &TestT::mock_canvas(),                  /* leaf_nodes_canvas */
-            nullptr,                                /* gr_context */
-            nullptr,                                /* external_view_embedder */
-            raster_time_, ui_time_, texture_registry_,
-            nullptr, /* raster_cache */
-            true,    /* checkerboard_offscreen_layers */
-            1.0f,    /* frame_device_pixel_ratio */
-        }) {
+      : preroll_context_{
+            // clang-format off
+            .raster_cache                  = nullptr,
+            .gr_context                    = nullptr,
+            .view_embedder                 = nullptr,
+            .mutators_stack                = mutators_stack_,
+            .dst_color_space               = TestT::mock_color_space(),
+            .cull_rect                     = kGiantRect,
+            .surface_needs_readback        = false,
+            .raster_time                   = raster_time_,
+            .ui_time                       = ui_time_,
+            .texture_registry              = texture_registry_,
+            .checkerboard_offscreen_layers = false,
+            .frame_device_pixel_ratio      = 1.0f,
+            .has_platform_view             = false,
+            // clang-format on
+        },
+        paint_context_{
+            // clang-format off
+            .internal_nodes_canvas         = TestT::mock_internal_canvas(),
+            .leaf_nodes_canvas             = &TestT::mock_canvas(),
+            .gr_context                    = nullptr,
+            .view_embedder                 = nullptr,
+            .raster_time                   = raster_time_,
+            .ui_time                       = ui_time_,
+            .texture_registry              = texture_registry_,
+            .raster_cache                  = nullptr,
+            .checkerboard_offscreen_layers = false,
+            .frame_device_pixel_ratio      = 1.0f,
+            // clang-format on
+        },
+        check_board_context_{
+            // clang-format off
+            .internal_nodes_canvas         = TestT::mock_internal_canvas(),
+            .leaf_nodes_canvas             = &TestT::mock_canvas(),
+            .gr_context                    = nullptr,
+            .view_embedder                 = nullptr,
+            .raster_time                   = raster_time_,
+            .ui_time                       = ui_time_,
+            .texture_registry              = texture_registry_,
+            .raster_cache                  = nullptr,
+            .checkerboard_offscreen_layers = true,
+            .frame_device_pixel_ratio      = 1.0f,
+            // clang-format on
+        } {
     use_null_raster_cache();
   }
 

--- a/flow/testing/mock_raster_cache.h
+++ b/flow/testing/mock_raster_cache.h
@@ -81,20 +81,22 @@ class MockRasterCache : public RasterCache {
   FixedRefreshRateStopwatch ui_time_;
   TextureRegistry texture_registry_;
   PrerollContext preroll_context_ = {
-      nullptr,           /* raster_cache */
-      nullptr,           /* gr_context */
-      nullptr,           /* external_view_embedder */
-      mutators_stack_,   /* mutators_stack */
-      color_space_,      /* color_space */
-      kGiantRect,        /* cull_rect */
-      false,             /* layer reads from surface */
-      raster_time_,      /* raster stopwatch */
-      ui_time_,          /* frame build stopwatch */
-      texture_registry_, /* texture_registry */
-      false,             /* checkerboard_offscreen_layers */
-      1.0f,              /* frame_device_pixel_ratio */
-      false,             /* has_platform_view */
-      false,             /* has_texture_layer */
+      // clang-format off
+      .raster_cache                  = nullptr,
+      .gr_context                    = nullptr,
+      .view_embedder                 = nullptr,
+      .mutators_stack                = mutators_stack_,
+      .dst_color_space               = color_space_,
+      .cull_rect                     = kGiantRect,
+      .surface_needs_readback        = false,
+      .raster_time                   = raster_time_,
+      .ui_time                       = ui_time_,
+      .texture_registry              = texture_registry_,
+      .checkerboard_offscreen_layers = false,
+      .frame_device_pixel_ratio      = 1.0f,
+      .has_platform_view             = false,
+      .has_texture_layer             = false,
+      // clang-format on
   };
 };
 

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -2474,16 +2474,21 @@ TEST_F(ShellTest, OnServiceProtocolEstimateRasterCacheMemoryWorks) {
         MutatorsStack mutators_stack;
         TextureRegistry texture_registry;
         PrerollContext preroll_context = {
-            nullptr,                 /* raster_cache */
-            nullptr,                 /* gr_context */
-            nullptr,                 /* external_view_embedder */
-            mutators_stack, nullptr, /* color_space */
-            kGiantRect,              /* cull_rect */
-            false,                   /* layer reads from surface */
-            raster_time,    ui_time, texture_registry,
-            false, /* checkerboard_offscreen_layers */
-            1.0f,  /* frame_device_pixel_ratio */
-            false, /* has_platform_view */
+            // clang-format off
+            .raster_cache                  = nullptr,
+            .gr_context                    = nullptr,
+            .view_embedder                 = nullptr,
+            .mutators_stack                = mutators_stack,
+            .dst_color_space               = nullptr,
+            .cull_rect                     = kGiantRect,
+            .surface_needs_readback        = false,
+            .raster_time                   = raster_time,
+            .ui_time                       = ui_time,
+            .texture_registry              = texture_registry,
+            .checkerboard_offscreen_layers = false,
+            .frame_device_pixel_ratio      = 1.0f,
+            .has_platform_view             = false,
+            // clang-format on
         };
 
         // 2.1. Rasterize the picture. Call Draw multiple times to pass the

--- a/testing/canvas_test.h
+++ b/testing/canvas_test.h
@@ -19,6 +19,8 @@ class CanvasTestBase : public BaseT {
   CanvasTestBase() = default;
 
   MockCanvas& mock_canvas() { return canvas_; }
+  SkColorSpace* mock_color_space() { return canvas_.imageInfo().colorSpace(); }
+  SkNWayCanvas* mock_internal_canvas() { return canvas_.internal_canvas(); }
 
  private:
   MockCanvas canvas_;


### PR DESCRIPTION
We've apparently had access to this C++ feature for a while, but have been using ad-hoc comments to document/manage our initializations of the PaintContext and PrerollContext. Using the designated field initializers (`{ .field = val, ...}`), the initializers are self-documenting and could even be pared down to the bare minimum of fields that are required.

I did not pare down any existing initializers, but the added unit tests demonstrate just how minimal the initializer lists can be.