### PR TITLE
Ignore armv7 in ios framework script

### DIFF
--- a/sky/tools/create_ios_framework.py
+++ b/sky/tools/create_ios_framework.py
@@ -30,25 +30,19 @@ def main():
 
   args = parser.parse_args()
 
-  fat_framework = os.path.join(args.dst, 'Flutter.framework')
-  fat_simulator_framework = os.path.join(args.dst, 'sim', 'Flutter.framework')
+  framework = os.path.join(args.dst, 'Flutter.framework')
+  simulator_framework = os.path.join(args.dst, 'sim', 'Flutter.framework')
   arm64_framework = os.path.join(args.arm64_out_dir, 'Flutter.framework')
-  armv7_framework = os.path.join(args.armv7_out_dir, 'Flutter.framework')
   simulator_x64_framework = os.path.join(args.simulator_x64_out_dir, 'Flutter.framework')
   if args.simulator_arm64_out_dir is not None:
     simulator_arm64_framework = os.path.join(args.simulator_arm64_out_dir, 'Flutter.framework')
     simulator_arm64_dylib = os.path.join(simulator_arm64_framework, 'Flutter')
 
   arm64_dylib = os.path.join(arm64_framework, 'Flutter')
-  armv7_dylib = os.path.join(armv7_framework, 'Flutter')
   simulator_x64_dylib = os.path.join(simulator_x64_framework, 'Flutter')
 
   if not os.path.isdir(arm64_framework):
     print('Cannot find iOS arm64 Framework at %s' % arm64_framework)
-    return 1
-
-  if not os.path.isdir(armv7_framework):
-    print('Cannot find iOS armv7 Framework at %s' % armv7_framework)
     return 1
 
   if not os.path.isdir(simulator_x64_framework):
@@ -59,10 +53,6 @@ def main():
     print('Cannot find iOS arm64 dylib at %s' % arm64_dylib)
     return 1
 
-  if not os.path.isfile(armv7_dylib):
-    print('Cannot find iOS armv7 dylib at %s' % armv7_dylib)
-    return 1
-
   if not os.path.isfile(simulator_x64_dylib):
     print('Cannot find iOS simulator dylib at %s' % simulator_dylib)
     return 1
@@ -71,27 +61,16 @@ def main():
     print('Cannot find dsymutil at %s' % DSYMUTIL)
     return 1
 
-  shutil.rmtree(fat_framework, True)
-  shutil.copytree(arm64_framework, fat_framework)
-
-  fat_framework_binary = os.path.join(fat_framework, 'Flutter')
-
-  # Create the arm-only fat framework.
-  subprocess.check_call([
-    'lipo',
-    arm64_dylib,
-    armv7_dylib,
-    '-create',
-    '-output',
-    fat_framework_binary
-  ])
-  process_framework(args, fat_framework, fat_framework_binary)
+  shutil.rmtree(framework, True)
+  shutil.copytree(arm64_framework, framework)
+  framework_binary = os.path.join(framework, 'Flutter')
+  process_framework(args, framework, framework_binary)
 
   if args.simulator_arm64_out_dir is not None:
-    shutil.rmtree(fat_simulator_framework, True)
-    shutil.copytree(simulator_arm64_framework, fat_simulator_framework)
+    shutil.rmtree(simulator_framework, True)
+    shutil.copytree(simulator_arm64_framework, simulator_framework)
 
-    fat_simulator_framework_binary = os.path.join(fat_simulator_framework, 'Flutter')
+    simulator_framework_binary = os.path.join(simulator_framework, 'Flutter')
 
     # Create the arm64/x64 simulator fat framework.
     subprocess.check_call([
@@ -100,46 +79,45 @@ def main():
       simulator_arm64_dylib,
       '-create',
       '-output',
-      fat_simulator_framework_binary
+      simulator_framework_binary
     ])
-    process_framework(args, fat_simulator_framework, fat_simulator_framework_binary)
-    simulator_framework = fat_simulator_framework
+    process_framework(args, simulator_framework, simulator_framework_binary)
+    simulator_framework = simulator_framework
   else:
     simulator_framework = simulator_x64_framework
 
   # Create XCFramework from the arm-only fat framework and the arm64/x64 simulator frameworks, or just the
   # x64 simulator framework if only that one exists.
-  xcframeworks = [simulator_framework, fat_framework]
+  xcframeworks = [simulator_framework, framework]
   create_xcframework(location=args.dst, name='Flutter', frameworks=xcframeworks)
 
   # Add the x64 simulator into the fat framework
   subprocess.check_call([
     'lipo',
     arm64_dylib,
-    armv7_dylib,
     simulator_x64_dylib,
     '-create',
     '-output',
-    fat_framework_binary
+    framework_binary
   ])
 
-  process_framework(args, fat_framework, fat_framework_binary)
+  process_framework(args, framework, framework_binary)
 
 
-def process_framework(args, fat_framework, fat_framework_binary):
+def process_framework(args, framework, framework_binary):
   if args.strip_bitcode:
-    subprocess.check_call(['xcrun', 'bitcode_strip', '-r', fat_framework_binary, '-o', fat_framework_binary])
+    subprocess.check_call(['xcrun', 'bitcode_strip', '-r', framework_binary, '-o', framework_binary])
 
   if args.dsym:
-    dsym_out = os.path.splitext(fat_framework)[0] + '.dSYM'
-    subprocess.check_call([DSYMUTIL, '-o', dsym_out, fat_framework_binary])
+    dsym_out = os.path.splitext(framework)[0] + '.dSYM'
+    subprocess.check_call([DSYMUTIL, '-o', dsym_out, framework_binary])
 
   if args.strip:
     # copy unstripped
     unstripped_out = os.path.join(args.dst, 'Flutter.unstripped')
-    shutil.copyfile(fat_framework_binary, unstripped_out)
+    shutil.copyfile(framework_binary, unstripped_out)
 
-    subprocess.check_call(["strip", "-x", "-S", fat_framework_binary])
+    subprocess.check_call(["strip", "-x", "-S", framework_binary])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR ignores armv7 in the script that creates the iOS framework. If this rolls into flutter/flutter without problems, the next step is to stop building armv7 iOS in CI.

https://github.com/flutter/flutter/issues/97327