### PR TITLE
[Linux] add MockSignalHandler for testing GObject signals

### DIFF
--- a/shell/platform/linux/BUILD.gn
+++ b/shell/platform/linux/BUILD.gn
@@ -209,6 +209,7 @@ executable("flutter_linux_unittests") {
     "testing/mock_epoxy.cc",
     "testing/mock_plugin_registrar.cc",
     "testing/mock_renderer.cc",
+    "testing/mock_signal_handler.cc",
     "testing/mock_text_input_plugin.cc",
     "testing/mock_texture_registrar.cc",
   ]

--- a/shell/platform/linux/testing/mock_signal_handler.cc
+++ b/shell/platform/linux/testing/mock_signal_handler.cc
@@ -1,0 +1,26 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/linux/testing/mock_signal_handler.h"
+
+namespace flutter {
+namespace testing {
+
+SignalHandler::SignalHandler(gpointer instance,
+                             const gchar* name,
+                             GCallback callback) {
+  id_ = g_signal_connect_data(instance, name, callback, this, nullptr,
+                              G_CONNECT_SWAPPED);
+  g_object_add_weak_pointer(G_OBJECT(instance), &instance_);
+}
+
+SignalHandler::~SignalHandler() {
+  if (instance_) {
+    g_signal_handler_disconnect(instance_, id_);
+    g_object_remove_weak_pointer(G_OBJECT(instance_), &instance_);
+  }
+}
+
+}  // namespace testing
+}  // namespace flutter

--- a/shell/platform/linux/testing/mock_signal_handler.cc
+++ b/shell/platform/linux/testing/mock_signal_handler.cc
@@ -9,7 +9,8 @@ namespace testing {
 
 SignalHandler::SignalHandler(gpointer instance,
                              const gchar* name,
-                             GCallback callback) {
+                             GCallback callback)
+    : instance_(instance) {
   id_ = g_signal_connect_data(instance, name, callback, this, nullptr,
                               G_CONNECT_SWAPPED);
   g_object_add_weak_pointer(G_OBJECT(instance), &instance_);

--- a/shell/platform/linux/testing/mock_signal_handler.h
+++ b/shell/platform/linux/testing/mock_signal_handler.h
@@ -1,0 +1,90 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_LINUX_MOCK_SIGNAL_HANDLER_H_
+#define FLUTTER_SHELL_PLATFORM_LINUX_MOCK_SIGNAL_HANDLER_H_
+
+#include <glib-object.h>
+#include <glib.h>
+
+#include "gmock/gmock.h"
+
+// Expects a signal that has no arguments.
+//
+// MockSignalHandler timeout(timer, "timeout");
+// EXPECT_SIGNAL(timeout).Times(3);
+//
+#define EXPECT_SIGNAL(mock) EXPECT_CALL(mock, Handler())
+
+// Expects a signal that has 1 argument.
+//
+// MockSignalHandler1<int> name_changed(object, "name-changed");
+// EXPECT_SIGNAL(name_changed, testing::StrEq("example"));
+//
+#define EXPECT_SIGNAL1(mock, a1) EXPECT_CALL(mock, Handler1(a1))
+
+// Expects a signal that has 2 arguments.
+//
+// MockSignalHandler2<int, GObject*> child_added(parent, "children::add");
+// EXPECT_SIGNAL2(child_added, testing::Eq(1), testing::A<GObject*>());
+//
+#define EXPECT_SIGNAL2(mock, a1, a2) EXPECT_CALL(mock, Handler2(a1, a2))
+
+namespace flutter {
+namespace testing {
+
+class SignalHandler {
+ public:
+  SignalHandler(gpointer instance, const gchar* name, GCallback callback);
+  virtual ~SignalHandler();
+
+ private:
+  gulong id_ = 0;
+  gpointer instance_ = nullptr;
+};
+
+// A mock signal handler that has no arguments. Used with EXPECT_SIGNAL().
+class MockSignalHandler : public SignalHandler {
+ public:
+  MockSignalHandler(gpointer instance, const gchar* name)
+      : SignalHandler(instance, name, G_CALLBACK(OnSignal)) {}
+
+  MOCK_METHOD0(Handler, void());
+
+ private:
+  static void OnSignal(MockSignalHandler* mock) { mock->Handler(); }
+};
+
+// A mock signal handler that has 1 argument. Used with EXPECT_SIGNAL1().
+template <typename A1>
+class MockSignalHandler1 : public SignalHandler {
+ public:
+  MockSignalHandler1(gpointer instance, const gchar* name)
+      : SignalHandler(instance, name, G_CALLBACK(OnSignal1)) {}
+
+  MOCK_METHOD1(Handler1, void(A1 a1));
+
+ private:
+  static void OnSignal1(MockSignalHandler1* mock, A1 a1) { mock->Handler1(a1); }
+};
+
+// A mock signal handler that has 2 arguments. Used with EXPECT_SIGNAL2().
+template <typename A1, typename A2>
+class MockSignalHandler2 : public SignalHandler {
+ public:
+  MockSignalHandler2(gpointer instance, const gchar* name)
+      : SignalHandler(instance, name, G_CALLBACK(OnSignal2)) {}
+
+  MOCK_METHOD2(Handler2, void(A1 a1, A2 a2));
+
+ private:
+  static void OnSignal2(MockSignalHandler2* mock, A1 a1, A2 a2) {
+    mock->Handler2(a1, a2);
+  }
+};
+
+}  // namespace testing
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_PLATFORM_LINUX_MOCK_SIGNAL_HANDLER_H_


### PR DESCRIPTION
This is a preparation step split off from #32618 that will eventually fix light
vs. dark theme detection on Linux (flutter/flutter#101438).

`MockSignalHandler` is a helper class that allows settings GMock expectations
on `GObject` signals:

```c
GObject* foo_object = ...;

flutter::testing::MockSignalHandler foo_changed(foo_object, "changed");
EXPECT_SIGNAL(foo_changed).Times(1);

foo_set_something(foo_object, ...);
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
