### PR TITLE
[Linux] add GTest printer for FlValue

### DIFF
--- a/shell/platform/linux/testing/fl_test.cc
+++ b/shell/platform/linux/testing/fl_test.cc
@@ -62,3 +62,8 @@ FlEngine* make_mock_engine_with_project(FlDartProject* project) {
 
   return static_cast<FlEngine*>(g_object_ref(engine));
 }
+
+void PrintTo(FlValue* v, std::ostream* os) {
+  g_autofree gchar* s = fl_value_to_string(v);
+  *os << s;
+}

--- a/shell/platform/linux/testing/fl_test.h
+++ b/shell/platform/linux/testing/fl_test.h
@@ -6,9 +6,11 @@
 #define FLUTTER_SHELL_PLATFORM_LINUX_FL_TEST_H_
 
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_engine.h"
+#include "flutter/shell/platform/linux/public/flutter_linux/fl_value.h"
 
 #include <glib.h>
 #include <stdint.h>
+#include <ostream>
 
 G_BEGIN_DECLS
 
@@ -26,6 +28,9 @@ FlEngine* make_mock_engine();
 // Creates a mock engine using a specified FlDartProject that responds to
 // platform messages.
 FlEngine* make_mock_engine_with_project(FlDartProject* project);
+
+// GTest printer for FlValue.
+void PrintTo(FlValue* v, std::ostream* os);
 
 G_END_DECLS
 


### PR DESCRIPTION
Improves test failure messages when matching `FlValue` arguments.

For example, before:
```
  Expected arg #2: has setting ("platformBrightness", 0x32f0980)
           Actual: 0x7f81ec005990, 0x32f0900
```
And after:
```
  Expected arg #2: has setting ("platformBrightness", dark)
           Actual: 0x27bded0, {textScaleFactor: 0.0, alwaysUse24HourFormat: false, platformBrightness: light}
```

This is a preparation step split off from #32618 that will eventually fix light
vs. dark theme detection on Linux (flutter/flutter#101438).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
