### PR TITLE
[web] Migrate Flutter Web to JS static interop - 11.

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -2125,23 +2125,26 @@ extension SkLineMetricsExtension on SkLineMetrics {
 
 @JS()
 @anonymous
-class SkParagraph {
+@staticInterop
+class SkParagraph {}
+
+extension SkParagraphExtension on SkParagraph {
   external double getAlphabeticBaseline();
   external bool didExceedMaxLines();
   external double getHeight();
   external double getIdeographicBaseline();
-  external List<SkLineMetrics> getLineMetrics();
+  external /* List<SkLineMetrics> */ List<Object?> getLineMetrics();
   external double getLongestLine();
   external double getMaxIntrinsicWidth();
   external double getMinIntrinsicWidth();
   external double getMaxWidth();
-  external List<Float32List> getRectsForRange(
+  external /* List<Float32List> */ List<Object?> getRectsForRange(
     int start,
     int end,
     SkRectHeightStyle heightStyle,
     SkRectWidthStyle widthStyle,
   );
-  external List<dynamic> getRectsForPlaceholders();
+  external /* List<Float32List> */ List<Object?> getRectsForPlaceholders();
   external SkTextPosition getGlyphPositionAtCoordinate(
     double x,
     double y,

--- a/lib/web_ui/lib/src/engine/canvaskit/text.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/text.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:typed_data';
+
 import 'package:meta/meta.dart';
 import 'package:ui/ui.dart' as ui;
 
@@ -611,7 +613,8 @@ class CkParagraph extends SkiaObject<SkParagraph> implements ui.Paragraph {
         _minIntrinsicWidth = paragraph.getMinIntrinsicWidth();
         _width = paragraph.getMaxWidth();
         _boxesForPlaceholders =
-            skRectsToTextBoxes(paragraph.getRectsForPlaceholders());
+            skRectsToTextBoxes(
+                paragraph.getRectsForPlaceholders().cast<Float32List>());
       } catch (e) {
         printWarning('CanvasKit threw an exception while laying '
             'out the paragraph. The font was "${_paragraphStyle._fontFamily}". '
@@ -711,21 +714,21 @@ class CkParagraph extends SkiaObject<SkParagraph> implements ui.Paragraph {
     }
 
     final SkParagraph paragraph = _ensureInitialized(_lastLayoutConstraints!);
-    final List<List<double>> skRects = paragraph.getRectsForRange(
+    final List<Float32List> skRects = paragraph.getRectsForRange(
       start,
       end,
       toSkRectHeightStyle(boxHeightStyle),
       toSkRectWidthStyle(boxWidthStyle),
-    );
+    ).cast<Float32List>();
 
     return skRectsToTextBoxes(skRects);
   }
 
-  List<ui.TextBox> skRectsToTextBoxes(List<dynamic> skRects) {
+  List<ui.TextBox> skRectsToTextBoxes(List<Float32List> skRects) {
     final List<ui.TextBox> result = <ui.TextBox>[];
 
     for (int i = 0; i < skRects.length; i++) {
-      final List<double> rect = skRects[i] as List<double>;
+      final Float32List rect = skRects[i];
       result.add(ui.TextBox.fromLTRBD(
         rect[0],
         rect[1],
@@ -771,7 +774,8 @@ class CkParagraph extends SkiaObject<SkParagraph> implements ui.Paragraph {
   @override
   ui.TextRange getLineBoundary(ui.TextPosition position) {
     final SkParagraph paragraph = _ensureInitialized(_lastLayoutConstraints!);
-    final List<SkLineMetrics> metrics = paragraph.getLineMetrics();
+    final List<SkLineMetrics> metrics =
+        paragraph.getLineMetrics().cast<SkLineMetrics>();
     final int offset = position.offset;
     for (final SkLineMetrics metric in metrics) {
       if (offset >= metric.startIndex && offset <= metric.endIndex) {
@@ -784,7 +788,8 @@ class CkParagraph extends SkiaObject<SkParagraph> implements ui.Paragraph {
   @override
   List<ui.LineMetrics> computeLineMetrics() {
     final SkParagraph paragraph = _ensureInitialized(_lastLayoutConstraints!);
-    final List<SkLineMetrics> skLineMetrics = paragraph.getLineMetrics();
+    final List<SkLineMetrics> skLineMetrics =
+        paragraph.getLineMetrics().cast<SkLineMetrics>();
     final List<ui.LineMetrics> result = <ui.LineMetrics>[];
     for (final SkLineMetrics metric in skLineMetrics) {
       result.add(CkLineMetrics._(metric));

--- a/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
+++ b/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
@@ -1483,7 +1483,8 @@ void _paragraphTests() {
     expect(paragraph.getRectsForPlaceholders(), hasLength(1));
     expect(paragraph.getLineMetrics(), hasLength(1));
 
-    final SkLineMetrics lineMetrics = paragraph.getLineMetrics().single;
+    final SkLineMetrics lineMetrics =
+        paragraph.getLineMetrics().cast<SkLineMetrics>().single;
     expect(lineMetrics.ascent, within<double>(distance: 0.5, from: 20.7));
     expect(lineMetrics.descent, within<double>(distance: 0.2, from: 4.3));
     expect(lineMetrics.isHardBreak, isTrue);


### PR DESCRIPTION
This is CL 11 in a series of CLs to migrate Flutter Web to the new JS static interop API.

This CL migrates SkParagraph alone because it required some adjustments to type signatures on methods.