### PR TITLE
[web] Migrate Flutter Web to JS static interop - 12.

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -2388,7 +2388,10 @@ class SkiaObjectCollectionError implements Error {
 /// Any Skia object that has a `delete` method.
 @JS()
 @anonymous
-class SkDeletable {
+@staticInterop
+class SkDeletable {}
+
+extension SkDeletableExtension on SkDeletable {
   /// Deletes the C++ side object.
   external void delete();
 
@@ -2403,7 +2406,10 @@ class SkDeletable {
 
 @JS()
 @anonymous
-class JsConstructor {
+@staticInterop
+class JsConstructor {}
+
+extension JsConstructorExtension on JsConstructor {
   /// The name of the "constructor", typically the function name called with
   /// the `new` keyword, or the ES6 class name.
   ///


### PR DESCRIPTION
This is CL 12 in a series of CLs to migrate Flutter Web to the new JS static interop API.

This CL migrates SkDeletable and JsConstructor. I handled these two separately due to the need for a mock.