### PR TITLE
Clear the path effect when syncing Dart paint to the display list builder

### DIFF
--- a/lib/ui/painting/paint.cc
+++ b/lib/ui/painting/paint.cc
@@ -311,6 +311,12 @@ bool Paint::sync_to(DisplayListBuilder* builder,
     }
   }
 
+  // The paint API exposed to Dart does not support path effects.  But other
+  // operations such as text may set a path effect, which must be cleared.
+  if (flags.applies_path_effect()) {
+    builder->setPathEffect(nullptr);
+  }
+
   return true;
 }
 


### PR DESCRIPTION
Dart paint objects do not have a path effect.

Fixes https://github.com/flutter/flutter/issues/101848
