### PR TITLE
Roll Impeller to flutter/impeller@5b60aea4ae628ea64d1e7f65259d38e38c69910d

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -117,7 +117,7 @@ deps = {
   'src': 'https://github.com/flutter/buildroot.git' + '@' + '60d942d91bf97e9c9f0876fb54d6cfba77c17dfb',
 
   'src/flutter/impeller':
-   Var('github_git') + '/flutter/impeller' + '@' + '2adc41bb87acffab0bca6bcdb9bc8da330068cc9',
+   Var('github_git') + '/flutter/impeller' + '@' + 'a93986f7e50e5ec959e6e64c30579c448b78fbd9',
 
    # Fuchsia compatibility
    #

--- a/DEPS
+++ b/DEPS
@@ -117,7 +117,7 @@ deps = {
   'src': 'https://github.com/flutter/buildroot.git' + '@' + '60d942d91bf97e9c9f0876fb54d6cfba77c17dfb',
 
   'src/flutter/impeller':
-   Var('github_git') + '/flutter/impeller' + '@' + 'a93986f7e50e5ec959e6e64c30579c448b78fbd9',
+   Var('github_git') + '/flutter/impeller' + '@' + '5b60aea4ae628ea64d1e7f65259d38e38c69910d',
 
    # Fuchsia compatibility
    #

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -424,7 +424,7 @@ FILE: ../../../flutter/impeller/archivist/archivist_unittests.cc
 FILE: ../../../flutter/impeller/base/allocation.cc
 FILE: ../../../flutter/impeller/base/allocation.h
 FILE: ../../../flutter/impeller/base/backend_cast.h
-FILE: ../../../flutter/impeller/base/base.h
+FILE: ../../../flutter/impeller/base/base_unittests.cc
 FILE: ../../../flutter/impeller/base/comparable.cc
 FILE: ../../../flutter/impeller/base/comparable.h
 FILE: ../../../flutter/impeller/base/config.h
@@ -432,6 +432,10 @@ FILE: ../../../flutter/impeller/base/promise.cc
 FILE: ../../../flutter/impeller/base/promise.h
 FILE: ../../../flutter/impeller/base/strings.cc
 FILE: ../../../flutter/impeller/base/strings.h
+FILE: ../../../flutter/impeller/base/thread.cc
+FILE: ../../../flutter/impeller/base/thread.h
+FILE: ../../../flutter/impeller/base/thread_safety.cc
+FILE: ../../../flutter/impeller/base/thread_safety.h
 FILE: ../../../flutter/impeller/base/validation.cc
 FILE: ../../../flutter/impeller/base/validation.h
 FILE: ../../../flutter/impeller/compiler/code_gen_template.h

--- a/lib/ui/BUILD.gn
+++ b/lib/ui/BUILD.gn
@@ -154,7 +154,7 @@ source_set("ui") {
     "//third_party/skia",
   ]
 
-  if (impeller_supports_platform) {
+  if (impeller_supports_rendering) {
     sources += [
       "painting/image_decoder_impeller.cc",
       "painting/image_decoder_impeller.h",


### PR DESCRIPTION
flutter/impeller@5b60aea4ae628ea64d1e7f65259d38e38c69910d

See also #32658 and #32677.

Verified locally that release build with Xcode/bitcode does not expose new symbols.