### PR TITLE
[web] Migrate Flutter Web to JS static interop - 14.

### DIFF
--- a/lib/web_ui/lib/src/engine/navigation/js_url_strategy.dart
+++ b/lib/web_ui/lib/src/engine/navigation/js_url_strategy.dart
@@ -29,6 +29,7 @@ typedef _HistoryMove = Future<void> Function(int count);
 /// bridge from the app to the engine.
 @JS()
 @anonymous
+@staticInterop
 abstract class JsUrlStrategy {
   /// Creates an instance of [JsUrlStrategy] from a bag of URL strategy
   /// functions.
@@ -41,7 +42,9 @@ abstract class JsUrlStrategy {
     required _StateOperation replaceState,
     required _HistoryMove go,
   });
+}
 
+extension JsUrlStrategyExtension on JsUrlStrategy {
   /// Adds a listener to the `popstate` event and returns a function that, when
   /// invoked, removes the listener.
   external ui.VoidCallback addPopStateListener(html.EventListener fn);


### PR DESCRIPTION
This is CL 14 in a series of CLs to migrate Flutter Web to the new JS static interop API.

This CL migrates a single class in js_url_strategy.dart.