### PR TITLE
[web] Migrate Flutter Web to JS static interop - 15.

### DIFF
--- a/lib/web_ui/lib/src/engine/safe_browser_api.dart
+++ b/lib/web_ui/lib/src/engine/safe_browser_api.dart
@@ -251,6 +251,7 @@ void debugResetBrowserSupportsImageDecoder() {
 /// [Future] API.
 @JS()
 @anonymous
+@staticInterop
 class JsPromise {}
 
 /// Corresponds to the browser's `ImageDecoder` type.
@@ -259,8 +260,12 @@ class JsPromise {}
 ///
 ///  * https://www.w3.org/TR/webcodecs/#imagedecoder-interface
 @JS('window.ImageDecoder')
+@staticInterop
 class ImageDecoder {
-  external ImageDecoder(ImageDecoderOptions options);
+  external factory ImageDecoder(ImageDecoderOptions options);
+}
+
+extension ImageDecoderExtension on ImageDecoder {
   external ImageTrackList get tracks;
   external bool get complete;
   external JsPromise decode(DecodeOptions options);
@@ -274,6 +279,7 @@ class ImageDecoder {
 ///  * https://www.w3.org/TR/webcodecs/#imagedecoderinit-interface
 @JS()
 @anonymous
+@staticInterop
 class ImageDecoderOptions {
   external factory ImageDecoderOptions({
     required String type,
@@ -293,7 +299,10 @@ class ImageDecoderOptions {
 ///  * https://www.w3.org/TR/webcodecs/#imagedecoderesult-interface
 @JS()
 @anonymous
-class DecodeResult {
+@staticInterop
+class DecodeResult {}
+
+extension DecodeResultExtension on DecodeResult {
   external VideoFrame get image;
   external bool get complete;
 }
@@ -305,6 +314,7 @@ class DecodeResult {
 ///  * https://www.w3.org/TR/webcodecs/#dictdef-imagedecodeoptions
 @JS()
 @anonymous
+@staticInterop
 class DecodeOptions {
   external factory DecodeOptions({
     required int frameIndex,
@@ -339,7 +349,10 @@ class VideoFrame implements html.CanvasImageSource {
 ///  * https://www.w3.org/TR/webcodecs/#imagetracklist-interface
 @JS()
 @anonymous
-class ImageTrackList {
+@staticInterop
+class ImageTrackList {}
+
+extension ImageTrackListExtension on ImageTrackList {
   external JsPromise get ready;
   external ImageTrack? get selectedTrack;
 }
@@ -351,7 +364,10 @@ class ImageTrackList {
 ///  * https://www.w3.org/TR/webcodecs/#imagetrack
 @JS()
 @anonymous
-class ImageTrack {
+@staticInterop
+class ImageTrack {}
+
+extension ImageTrackExtension on ImageTrack {
   external int get repetitionCount;
   external int get frameCount;
 }


### PR DESCRIPTION
This is CL 15 in a series of CLs to migrate Flutter Web to the new JS static interop API.

This should be close to the last CL in the first phase of the migration. It migrates everything in safe_browser_api.dart, with the exception of `VideoFrame` which extends a `dart:html` class. We will handle `VideoFrame` in phase 2 of the migration.