### PR TITLE
[fuchsia flutter runner] Get data_path from the component name

### DIFF
--- a/shell/platform/fuchsia/flutter/component_v2.h
+++ b/shell/platform/fuchsia/flutter/component_v2.h
@@ -79,7 +79,8 @@ class ComponentV2 final
   ///
   /// |old_gen_heap_size| will be set to -1 if no value was specified.
   static ProgramMetadata ParseProgramMetadata(
-      const fuchsia::data::Dictionary& program_metadata);
+      const fuchsia::data::Dictionary& program_metadata,
+      const std::string url);
 
   const std::string& GetDebugLabel() const;
 


### PR DESCRIPTION
When launching the flutter_jit_runner from a Fuchsia Component Framework
v2 Realm, if the CML does not provide the `data` value under `program`,
the runner fails silently.

Mirroring the solution for the Dart runner for CFv2, the data_path can be
derived from the given URL.

Also, the LOG is changed from a DLOG, so exiting here will no longer
fail silently if the debug logs are turned off.

Fixes: flutter/flutter#102010

NOTE: I need to verify the crash was not because I was missing something when launching flutter_jit_runner. If this fix is legitimate, I will file and add an issue.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
