### PR TITLE
simplify the logic around computing subtree opacity inheritance

### DIFF
--- a/flow/layers/clip_path_layer.cc
+++ b/flow/layers/clip_path_layer.cc
@@ -10,7 +10,6 @@ namespace flutter {
 ClipPathLayer::ClipPathLayer(const SkPath& clip_path, Clip clip_behavior)
     : clip_path_(clip_path), clip_behavior_(clip_behavior) {
   FML_DCHECK(clip_behavior != Clip::none);
-  set_layer_can_inherit_opacity(true);
 }
 
 void ClipPathLayer::Diff(DiffContext* context, const Layer* old_layer) {
@@ -41,10 +40,20 @@ void ClipPathLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
       Layer::AutoPrerollSaveLayerState::Create(context, UsesSaveLayer());
   context->mutators_stack.PushClipPath(clip_path_);
 
+  // We can pass opacity along to our children if they are
+  // well behaved.
+  context->subtree_can_inherit_opacity = true;
+
   SkRect child_paint_bounds = SkRect::MakeEmpty();
   PrerollChildren(context, matrix, &child_paint_bounds);
   if (child_paint_bounds.intersect(clip_path_bounds)) {
     set_paint_bounds(child_paint_bounds);
+  }
+
+  // If we use a SaveLayer then we can accept opacity on behalf
+  // of our children and apply it in the saveLayer.
+  if (UsesSaveLayer()) {
+    context->subtree_can_inherit_opacity = true;
   }
 
   context->mutators_stack.Pop();

--- a/flow/layers/clip_rect_layer.cc
+++ b/flow/layers/clip_rect_layer.cc
@@ -10,7 +10,6 @@ namespace flutter {
 ClipRectLayer::ClipRectLayer(const SkRect& clip_rect, Clip clip_behavior)
     : clip_rect_(clip_rect), clip_behavior_(clip_behavior) {
   FML_DCHECK(clip_behavior != Clip::none);
-  set_layer_can_inherit_opacity(true);
 }
 
 void ClipRectLayer::Diff(DiffContext* context, const Layer* old_layer) {
@@ -40,10 +39,20 @@ void ClipRectLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
       Layer::AutoPrerollSaveLayerState::Create(context, UsesSaveLayer());
   context->mutators_stack.PushClipRect(clip_rect_);
 
+  // We can pass opacity along to our children if they are
+  // well behaved.
+  context->subtree_can_inherit_opacity = true;
+
   SkRect child_paint_bounds = SkRect::MakeEmpty();
   PrerollChildren(context, matrix, &child_paint_bounds);
   if (child_paint_bounds.intersect(clip_rect_)) {
     set_paint_bounds(child_paint_bounds);
+  }
+
+  // If we use a SaveLayer then we can accept opacity on behalf
+  // of our children and apply it in the saveLayer.
+  if (UsesSaveLayer()) {
+    context->subtree_can_inherit_opacity = true;
   }
 
   context->mutators_stack.Pop();

--- a/flow/layers/container_layer.cc
+++ b/flow/layers/container_layer.cc
@@ -136,16 +136,16 @@ void ContainerLayer::PrerollChildren(PrerollContext* context,
   FML_DCHECK(!context->has_platform_view);
   bool child_has_platform_view = false;
   bool child_has_texture_layer = false;
-  bool subtree_can_inherit_opacity = layer_can_inherit_opacity();
+  bool subtree_can_inherit_opacity = context->subtree_can_inherit_opacity;
 
   for (auto& layer : layers_) {
     // Reset context->has_platform_view to false so that layers aren't treated
     // as if they have a platform view based on one being previously found in a
     // sibling tree.
     context->has_platform_view = false;
-    // Initialize the "inherit opacity" flag to the value recorded in the layer
-    // and allow it to override the answer during its |Preroll|
-    context->subtree_can_inherit_opacity = layer->layer_can_inherit_opacity();
+    // Initialize the "inherit opacity" flag to false and allow the layer to
+    // override the answer during its |Preroll|
+    context->subtree_can_inherit_opacity = false;
 
     layer->Preroll(context, child_matrix);
 

--- a/flow/layers/display_list_layer.cc
+++ b/flow/layers/display_list_layer.cc
@@ -16,12 +16,7 @@ DisplayListLayer::DisplayListLayer(const SkPoint& offset,
     : offset_(offset),
       display_list_(std::move(display_list)),
       is_complex_(is_complex),
-      will_change_(will_change) {
-  if (display_list_.skia_object()) {
-    set_layer_can_inherit_opacity(
-        display_list_.skia_object()->can_apply_group_opacity());
-  }
-}
+      will_change_(will_change) {}
 
 bool DisplayListLayer::IsReplacing(DiffContext* context,
                                    const Layer* layer) const {
@@ -96,6 +91,10 @@ void DisplayListLayer::Preroll(PrerollContext* context,
   DisplayList* disp_list = display_list();
 
   SkRect bounds = disp_list->bounds().makeOffset(offset_.x(), offset_.y());
+
+  if (disp_list->can_apply_group_opacity()) {
+    context->subtree_can_inherit_opacity = true;
+  }
 
   if (auto* cache = context->raster_cache) {
     TRACE_EVENT0("flutter", "DisplayListLayer::RasterCache (Preroll)");

--- a/flow/layers/image_filter_layer.cc
+++ b/flow/layers/image_filter_layer.cc
@@ -44,6 +44,7 @@ void ImageFilterLayer::Preroll(PrerollContext* context,
 
   SkRect child_bounds = SkRect::MakeEmpty();
   PrerollChildren(context, matrix, &child_bounds);
+  context->subtree_can_inherit_opacity = true;
 
   if (!filter_) {
     set_paint_bounds(child_bounds);
@@ -95,31 +96,32 @@ void ImageFilterLayer::Paint(PaintContext& context) const {
   TRACE_EVENT0("flutter", "ImageFilterLayer::Paint");
   FML_DCHECK(needs_painting(context));
 
+  AutoCachePaint cache_paint(context);
+
   if (context.raster_cache) {
     if (context.raster_cache->Draw(this, *context.leaf_nodes_canvas,
-                                   RasterCacheLayerStrategy::kLayer)) {
+                                   RasterCacheLayerStrategy::kLayer,
+                                   cache_paint.paint())) {
       return;
     }
     if (transformed_filter_) {
-      SkPaint paint;
-      paint.setImageFilter(transformed_filter_);
+      cache_paint.setImageFilter(transformed_filter_);
       if (context.raster_cache->Draw(this, *context.leaf_nodes_canvas,
                                      RasterCacheLayerStrategy::kLayerChildren,
-                                     &paint)) {
+                                     cache_paint.paint())) {
         return;
       }
     }
   }
 
-  SkPaint paint;
-  paint.setImageFilter(filter_);
+  cache_paint.setImageFilter(filter_);
 
   // Normally a save_layer is sized to the current layer bounds, but in this
   // case the bounds of the child may not be the same as the filtered version
   // so we use the bounds of the child container which do not include any
   // modifications that the filter might apply.
-  Layer::AutoSaveLayer save_layer =
-      Layer::AutoSaveLayer::Create(context, child_paint_bounds(), &paint);
+  Layer::AutoSaveLayer save_layer = Layer::AutoSaveLayer::Create(
+      context, child_paint_bounds(), cache_paint.paint());
   PaintChildren(context);
 }
 

--- a/flow/layers/layer.cc
+++ b/flow/layers/layer.cc
@@ -13,8 +13,7 @@ Layer::Layer()
     : paint_bounds_(SkRect::MakeEmpty()),
       unique_id_(NextUniqueID()),
       original_layer_id_(unique_id_),
-      subtree_has_platform_view_(false),
-      layer_can_inherit_opacity_(false) {}
+      subtree_has_platform_view_(false) {}
 
 Layer::~Layer() = default;
 

--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -63,23 +63,41 @@ struct PrerollContext {
   // prescence of a texture layer during Preroll.
   bool has_texture_layer = false;
 
-  // This value indicates that the entire subtree below the layer can inherit
-  // an opacity value and modulate its own visibility accordingly.
-  // For Layers which cannot either apply such an inherited opacity nor pass
-  // it along to their children, they can ignore this value as its default
-  // behavior is "opt-in".
-  // For Layers that support this condition, it can be recorded in their
-  // constructor using the |set_layer_can_inherit_opacity| method and the
-  // value will be accumulated and recorded by the |PrerollChidren| method
-  // automatically.
-  // If the property is more dynamic then the Layer can dynamically set this
-  // flag before returning from the |Preroll| method.
-  // For ContainerLayers that need to know if their children can inherit
-  // the value, the |PrerollChildren| method will have set this value in
-  // the context before it returns. If the container can support it as long
-  // as the subtree can support it, no further work needs to be done other
-  // than to remember the value so that it can choose the right strategy
-  // for its |Paint| method.
+  // This field indicates whether the subtree rooted at this layer can
+  // inherit an opacity value and modulate its visibility accordingly.
+  //
+  // Any layer is free to ignore this flag. Its value will be false upon
+  // entry into its Preroll method, it will remain false if it calls
+  // PrerollChildren on any children it might have, and it will remain
+  // false upon exit from the Preroll method unless it takes specific
+  // action compute if it should be true. Thus, this property is "opt-in".
+  //
+  // If the value is false when the Preroll method exits, then the
+  // |PaintContext::inherited_opacity| value should always be set to
+  // 1.0 when its |Paint| method is called.
+  //
+  // Leaf layers need only be concerned with their own rendering and
+  // can set the value according to whether they can apply the opacity.
+  //
+  // For containers, there are 3 ways to interact with this field:
+  //
+  // 1. If you need to know whether your children are compatible, then
+  //    set the field to true before you call PrerollChildren. That
+  //    method will then reset the field to false if it detects any
+  //    incompatible children.
+  //
+  // 2. If you need to do change any logic depending on the answer
+  //    from the children, then remember the value of the field when
+  //    PrerollChildren returns. (eg. OpacityLayer remembers this
+  //    value to control whether to set the opacity value into the
+  //    PaintContext::inherited_opacity field before recursing to
+  //    its children in Paint)
+  //
+  // 3. If you want to indicate to your parents that you can accept
+  //    inherited opacity regardless of whether your children were
+  //    compatible then set this field to true before returning
+  //    from your Preroll method. (eg. layers that always apply a
+  //    saveLayer when rendering anyway can apply the opacity there)
   bool subtree_can_inherit_opacity = false;
 };
 
@@ -196,6 +214,11 @@ class Layer {
 
     ~AutoCachePaint() { context_.inherited_opacity = paint_.getAlphaf(); }
 
+    void setImageFilter(sk_sp<SkImageFilter> filter) {
+      paint_.setImageFilter(filter);
+      needs_paint_ = filter != nullptr || paint_.getAlphaf() < SK_Scalar1;
+    }
+
     const SkPaint* paint() { return needs_paint_ ? &paint_ : nullptr; }
 
    private:
@@ -271,18 +294,6 @@ class Layer {
     subtree_has_platform_view_ = value;
   }
 
-  // Returns true if the layer can render with an added opacity value inherited
-  // from an OpacityLayer ancestor and delivered to its |Paint| method through
-  // the |PaintContext.inherited_opacity| field. This flag can be set either
-  // in the Layer's constructor if it is a lifetime constant value, or during
-  // the |Preroll| method if it must determine the capability based on data
-  // only available when it is part of a tree. It must set this value before
-  // recursing to its children if it is a |ContainerLayer|.
-  bool layer_can_inherit_opacity() const { return layer_can_inherit_opacity_; }
-  void set_layer_can_inherit_opacity(bool value) {
-    layer_can_inherit_opacity_ = value;
-  }
-
   // Returns the paint bounds in the layer's local coordinate system
   // as determined during Preroll().  The bounds should include any
   // transform, clip or distortions performed by the layer itself,
@@ -353,7 +364,6 @@ class Layer {
   uint64_t unique_id_;
   uint64_t original_layer_id_;
   bool subtree_has_platform_view_;
-  bool layer_can_inherit_opacity_;
 
   static uint64_t NextUniqueID();
 

--- a/flow/layers/opacity_layer.cc
+++ b/flow/layers/opacity_layer.cc
@@ -10,12 +10,7 @@
 namespace flutter {
 
 OpacityLayer::OpacityLayer(SkAlpha alpha, const SkPoint& offset)
-    : alpha_(alpha), offset_(offset), children_can_accept_opacity_(false) {
-  // We can always inhert opacity even if we cannot pass it along to
-  // our children as we can accumulate the inherited opacity into our
-  // own opacity value before we recurse.
-  set_layer_can_inherit_opacity(true);
-}
+    : alpha_(alpha), offset_(offset), children_can_accept_opacity_(false) {}
 
 void OpacityLayer::Diff(DiffContext* context, const Layer* old_layer) {
   DiffContext::AutoSubtreeRestore subtree(context);
@@ -51,11 +46,23 @@ void OpacityLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   context->mutators_stack.PushOpacity(alpha_);
   Layer::AutoPrerollSaveLayerState save =
       Layer::AutoPrerollSaveLayerState::Create(context);
-  ContainerLayer::Preroll(context, child_matrix);
-  context->mutators_stack.Pop();
-  context->mutators_stack.Pop();
 
+  // We can pass our opacity along to our children only if they are
+  // well behaved.
+  context->subtree_can_inherit_opacity = true;
+
+  // ContainerLayer will turn the flag off if any children are
+  // incompatible or if they overlap
+  ContainerLayer::Preroll(context, child_matrix);
+
+  // We remember whether our children were compatible here for use in |Paint|
   set_children_can_accept_opacity(context->subtree_can_inherit_opacity);
+
+  // Now we let our parent layers know that we, too, can inherit opacity
+  context->subtree_can_inherit_opacity = true;
+
+  context->mutators_stack.Pop();
+  context->mutators_stack.Pop();
 
   set_paint_bounds(paint_bounds().makeOffset(offset_.fX, offset_.fY));
 

--- a/flow/layers/shader_mask_layer.cc
+++ b/flow/layers/shader_mask_layer.cc
@@ -12,9 +12,7 @@ ShaderMaskLayer::ShaderMaskLayer(sk_sp<SkShader> shader,
     : shader_(shader),
       mask_rect_(mask_rect),
       blend_mode_(blend_mode),
-      render_count_(1) {
-  set_layer_can_inherit_opacity(true);
-}
+      render_count_(1) {}
 
 void ShaderMaskLayer::Diff(DiffContext* context, const Layer* old_layer) {
   DiffContext::AutoSubtreeRestore subtree(context);
@@ -49,13 +47,15 @@ void ShaderMaskLayer::Paint(PaintContext& context) const {
   TRACE_EVENT0("flutter", "ShaderMaskLayer::Paint");
   FML_DCHECK(needs_painting(context));
 
+  AutoCachePaint cache_paint(context);
+
   if (context.raster_cache &&
       context.raster_cache->Draw(this, *context.leaf_nodes_canvas,
-                                 RasterCacheLayerStrategy::kLayer)) {
+                                 RasterCacheLayerStrategy::kLayer,
+                                 cache_paint.paint())) {
     return;
   }
 
-  AutoCachePaint cache_paint(context);
   Layer::AutoSaveLayer save = Layer::AutoSaveLayer::Create(
       context, paint_bounds(), cache_paint.paint());
   PaintChildren(context);

--- a/flow/layers/texture_layer.cc
+++ b/flow/layers/texture_layer.cc
@@ -17,9 +17,7 @@ TextureLayer::TextureLayer(const SkPoint& offset,
       size_(size),
       texture_id_(texture_id),
       freeze_(freeze),
-      sampling_(sampling) {
-  set_layer_can_inherit_opacity(true);
-}
+      sampling_(sampling) {}
 
 void TextureLayer::Diff(DiffContext* context, const Layer* old_layer) {
   DiffContext::AutoSubtreeRestore subtree(context);
@@ -48,6 +46,7 @@ void TextureLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   set_paint_bounds(SkRect::MakeXYWH(offset_.x(), offset_.y(), size_.width(),
                                     size_.height()));
   context->has_texture_layer = true;
+  context->subtree_can_inherit_opacity = true;
 }
 
 void TextureLayer::Paint(PaintContext& context) const {

--- a/flow/layers/transform_layer.cc
+++ b/flow/layers/transform_layer.cc
@@ -24,7 +24,6 @@ TransformLayer::TransformLayer(const SkMatrix& transform)
     FML_LOG(ERROR) << "TransformLayer is constructed with an invalid matrix.";
     transform_.setIdentity();
   }
-  set_layer_can_inherit_opacity(true);
 }
 
 void TransformLayer::Diff(DiffContext* context, const Layer* old_layer) {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/101957

This PR fixes a flaw in how the opacity inheritance flags are computed between layers of the tree. It is still somewhat of a work in progress as I want to revisit all of the layers and check their logic, but at least for the combination of a FadeTransition with a ScaleTransition child, the layer cache no longer re-populates the cache on every frame and the rasterizer times are way down with a complex child.

This PR also adds the inheritance logic to ImageFilterLayer which used to not participate in opacity inheritance, so that is an additional win with this fix, but each part of this PR (both the part that fixes the logic and the new inheritance in ImageFilterLayer) are important to the example above. Fixing either still ends up with problems.

Note that there is one more problem I've discovered before this is a total solution for the Fade/Scale pair and that is that we fumble the coordinates a bit for an animated scale with the filterQuality. The reasons for that are in our cache rendering logic and I'm still investigating those.