### PR TITLE
[web:a11y] fix traversal and hit-test orders

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
@@ -242,7 +242,7 @@ class HtmlViewEmbedder {
     }
 
     // Apply mutators to the slot
-    _applyMutators(params.mutators, slot, viewId);
+    _applyMutators(params, slot, viewId);
   }
 
   int _countClips(MutatorsStack mutators) {
@@ -309,9 +309,12 @@ class HtmlViewEmbedder {
   }
 
   void _applyMutators(
-      MutatorsStack mutators, html.Element embeddedView, int viewId) {
+      EmbeddedViewParams params, html.Element embeddedView, int viewId) {
+    final MutatorsStack mutators = params.mutators;
     html.Element head = embeddedView;
-    Matrix4 headTransform = Matrix4.identity();
+    Matrix4 headTransform = params.offset == ui.Offset.zero
+      ? Matrix4.identity()
+      : Matrix4.translationValues(params.offset.dx, params.offset.dy, 0);
     double embeddedOpacity = 1.0;
     _resetAnchor(head);
     _cleanUpClipDefs(viewId);

--- a/lib/web_ui/lib/src/engine/canvaskit/surface.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/surface.dart
@@ -282,6 +282,18 @@ class Surface {
       height: _pixelHeight,
     );
     this.htmlCanvas = htmlCanvas;
+
+    // The DOM elements used to render pictures are used purely to put pixels on
+    // the screen. They have no semantic information. If an assistive technology
+    // attempts to scan picture content it will look like garbage and confuse
+    // users. UI semantics are exported as a separate DOM tree rendered parallel
+    // to pictures.
+    //
+    // Why are layer and scene elements not hidden from ARIA? Because those
+    // elements may contain platform views, and platform views must be
+    // accessible.
+    htmlCanvas.setAttribute('aria-hidden', 'true');
+
     htmlCanvas.style.position = 'absolute';
     _updateLogicalHtmlCanvasSize();
 

--- a/lib/web_ui/lib/src/engine/embedder.dart
+++ b/lib/web_ui/lib/src/engine/embedder.dart
@@ -290,9 +290,20 @@ class FlutterViewEmbedder {
         .prepareAccessibilityPlaceholder();
 
     glassPaneElementHostNode.nodes.addAll(<html.Node>[
-      semanticsHostElement,
       _accessibilityPlaceholder,
       _sceneHostElement!,
+
+      // The semantic host goes last because hit-test order-wise we want it to
+      // be first. If semantics goes under the scene host, platform views will
+      // obscure semantic elements.
+      //
+      // You may be wondering: wouldn't semantics obscure platform views and
+      // make then not accessible? At least with some careful planning, that
+      // should not be the case. The semantics tree makes all of its non-leaf
+      // elements transparent. This way, if a platform view appears among other
+      // interactive Flutter widgets, as long as those widgets do not intersect
+      // with the platform view, the platform view will be reachable.
+      semanticsHostElement,
     ]);
 
     // When debugging semantics, make the scene semi-transparent so that the
@@ -303,11 +314,6 @@ class FlutterViewEmbedder {
 
     PointerBinding.initInstance(glassPaneElement);
     KeyboardBinding.initInstance(glassPaneElement);
-
-    // Hide the DOM nodes used to render the scene from accessibility, because
-    // the accessibility tree is built from the SemanticsNode tree as a parallel
-    // DOM tree.
-    _sceneHostElement!.setAttribute('aria-hidden', 'true');
 
     if (html.window.visualViewport == null && isWebKit) {
       // Older Safari versions sometimes give us bogus innerWidth/innerHeight

--- a/lib/web_ui/lib/src/engine/embedder.dart
+++ b/lib/web_ui/lib/src/engine/embedder.dart
@@ -83,7 +83,7 @@ class FlutterViewEmbedder {
   /// This element is created and inserted in the HTML DOM once. It is never
   /// removed or moved.
   ///
-  /// We render semantics inside the glasspane for proper focus and event
+  /// Render semantics inside the glasspane for proper focus and event
   /// handling. If semantics is behind the glasspane, the phone will disable
   /// focusing by touch, only by tabbing around the UI. If semantics is in
   /// front of glasspane, then DOM event won't bubble up to the glasspane so
@@ -99,7 +99,7 @@ class FlutterViewEmbedder {
   html.Element? _sceneElement;
 
   /// This is state persistent across hot restarts that indicates what
-  /// to clear.  We delay removal of old visible state to make the
+  /// to clear.  Delay removal of old visible state to make the
   /// transition appear smooth.
   static const String _staleHotRestartStore = '__flutter_state';
   List<html.Element?>? _staleHotRestartState;
@@ -133,7 +133,7 @@ class FlutterViewEmbedder {
     }
   }
 
-  /// We don't want to unnecessarily move DOM nodes around. If a DOM node is
+  /// Don't unnecessarily move DOM nodes around. If a DOM node is
   /// already in the right place, skip DOM mutation. This is both faster and
   /// more correct, because moving DOM nodes loses internal state, such as
   /// text selection.
@@ -203,7 +203,7 @@ class FlutterViewEmbedder {
     setElementStyle(bodyElement, 'padding', '0');
     setElementStyle(bodyElement, 'margin', '0');
 
-    // TODO(yjbanov): fix this when we support KVM I/O. Currently we scroll
+    // TODO(yjbanov): fix this when KVM I/O support is added. Currently scroll
     //                using drag, and text selection interferes.
     setElementStyle(bodyElement, 'user-select', 'none');
     setElementStyle(bodyElement, '-webkit-user-select', 'none');
@@ -211,7 +211,7 @@ class FlutterViewEmbedder {
     setElementStyle(bodyElement, '-moz-user-select', 'none');
 
     // This is required to prevent the browser from doing any native touch
-    // handling. If we don't do this, the browser doesn't report 'pointermove'
+    // handling. If this is not done, the browser doesn't report 'pointermove'
     // events properly.
     setElementStyle(bodyElement, 'touch-action', 'none');
 
@@ -227,7 +227,7 @@ class FlutterViewEmbedder {
     for (final html.Element viewportMeta
         in html.document.head!.querySelectorAll('meta[name="viewport"]')) {
       if (assertionsEnabled) {
-        // Filter out the meta tag that we ourselves placed on the page. This is
+        // Filter out the meta tag that the engine placed on the page. This is
         // to avoid UI flicker during hot restart. Hot restart will clean up the
         // old meta tag synchronously with the first post-restart frame.
         if (!viewportMeta.hasAttribute('flt-viewport')) {
@@ -265,7 +265,8 @@ class FlutterViewEmbedder {
       ..bottom = '0'
       ..left = '0';
 
-    // This must be appended to the body, so we can create a host node properly.
+    // This must be appended to the body, so the engine can create a host node
+    // properly.
     bodyElement.append(glassPaneElement);
 
     // Create a [HostNode] under the glass pane element, and attach everything
@@ -293,8 +294,8 @@ class FlutterViewEmbedder {
       _accessibilityPlaceholder,
       _sceneHostElement!,
 
-      // The semantic host goes last because hit-test order-wise we want it to
-      // be first. If semantics goes under the scene host, platform views will
+      // The semantic host goes last because hit-test order-wise it must be
+      // first. If semantics goes under the scene host, platform views will
       // obscure semantic elements.
       //
       // You may be wondering: wouldn't semantics obscure platform views and
@@ -327,10 +328,11 @@ class FlutterViewEmbedder {
       //
       // VisualViewport API is not enabled in Firefox as well. On the other hand
       // Firefox returns correct values for innerHeight, innerWidth.
-      // Firefox also triggers html.window.onResize therefore we don't need this
-      // timer to be set up for Firefox.
+      // Firefox also triggers html.window.onResize therefore this timer does
+      // not need to be set up for Firefox.
       final int initialInnerWidth = html.window.innerWidth!;
-      // Counts how many times we checked screen size. We check up to 5 times.
+      // Counts how many times screen size was checked. It is checked up to 5
+      // times.
       int checkCount = 0;
       Timer.periodic(const Duration(milliseconds: 100), (Timer t) {
         checkCount += 1;
@@ -367,7 +369,7 @@ class FlutterViewEmbedder {
   }
 
   /// The framework specifies semantics in physical pixels, but CSS uses
-  /// logical pixels. To compensate, we inject an inverse scale at the root
+  /// logical pixels. To compensate, an inverse scale is injected at the root
   /// level.
   void updateSemanticsScreenProperties() {
     _semanticsHostElement!.style.transform =

--- a/lib/web_ui/lib/src/engine/html/picture.dart
+++ b/lib/web_ui/lib/src/engine/html/picture.dart
@@ -122,7 +122,20 @@ class PersistedPicture extends PersistedLeafSurface {
 
   @override
   html.Element createElement() {
-    return defaultCreateElement('flt-picture');
+    final html.Element element = defaultCreateElement('flt-picture');
+
+    // The DOM elements used to render pictures are used purely to put pixels on
+    // the screen. They have no semantic information. If an assistive technology
+    // attempts to scan picture content it will look like garbage and confuse
+    // users. UI semantics are exported as a separate DOM tree rendered parallel
+    // to pictures.
+    //
+    // Why do we not hide layer and scene elements from ARIA? Because those
+    // elements may contain platform views, and we do want platform views to be
+    // accessible.
+    element.setAttribute('aria-hidden', 'true');
+
+    return element;
   }
 
   @override

--- a/lib/web_ui/lib/src/engine/html/picture.dart
+++ b/lib/web_ui/lib/src/engine/html/picture.dart
@@ -130,8 +130,8 @@ class PersistedPicture extends PersistedLeafSurface {
     // users. UI semantics are exported as a separate DOM tree rendered parallel
     // to pictures.
     //
-    // Why do we not hide layer and scene elements from ARIA? Because those
-    // elements may contain platform views, and we do want platform views to be
+    // Why are layer and scene elements not hidden from ARIA? Because those
+    // elements may contain platform views, and platform views must be
     // accessible.
     element.setAttribute('aria-hidden', 'true');
 

--- a/lib/web_ui/lib/src/engine/initialization.dart
+++ b/lib/web_ui/lib/src/engine/initialization.dart
@@ -256,12 +256,6 @@ Future<void> initializeEngineUi() async {
   Keyboard.initialize(onMacOs: operatingSystem == OperatingSystem.macOs);
   MouseCursor.initialize();
   ensureFlutterViewEmbedderInitialized();
-
-  if (useCanvasKit) {
-    /// Add a Skia scene host.
-    skiaSceneHost = html.Element.tag('flt-scene');
-    flutterViewEmbedder.renderScene(skiaSceneHost);
-  }
   _initializationState = DebugEngineInitializationState.initialized;
 }
 

--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -607,7 +607,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
       rasterizer!.draw(layerScene.layerTree);
     } else {
       final SurfaceScene surfaceScene = scene as SurfaceScene;
-      flutterViewEmbedder.renderScene(surfaceScene.webOnlyRootElement);
+      flutterViewEmbedder.addSceneToSceneHost(surfaceScene.webOnlyRootElement);
     }
     frameTimingsOnRasterFinish();
   }

--- a/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -972,10 +972,6 @@ class SemanticsObject {
 
     // Both non-empty case.
 
-    // Indices into the new child list pointing at children that also exist in
-    // the old child list.
-    final List<int> intersectionIndicesNew = <int>[];
-
     // Indices into the old child list pointing at children that also exist in
     // the new child list.
     final List<int> intersectionIndicesOld = <int>[];
@@ -989,7 +985,6 @@ class SemanticsObject {
     while (newIndex < minLength &&
         previousChildrenInRenderOrder[newIndex] ==
             childrenInRenderOrder[newIndex]) {
-      intersectionIndicesNew.add(newIndex);
       intersectionIndicesOld.add(newIndex);
       newIndex += 1;
     }
@@ -1007,7 +1002,6 @@ class SemanticsObject {
           oldIndex += 1) {
         if (previousChildrenInRenderOrder[oldIndex] ==
             childrenInRenderOrder[newIndex]) {
-          intersectionIndicesNew.add(newIndex);
           intersectionIndicesOld.add(oldIndex);
           break;
         }

--- a/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -972,6 +972,20 @@ class SemanticsObject {
 
     // Both non-empty case.
 
+    // Problem: child nodes have been added, removed, and/or reordered. On the
+    //          web, many assistive technologies cannot track DOM elements
+    //          moving around, losing focus. The best approach is to try to keep
+    //          child elements as stable as possible.
+    // Solution: find all common elements in both lists and record their indices
+    //           in the old list (in the `intersectionIndicesOld` variable). The
+    //           longest increases subsequence provides the longest chain of
+    //           semantics nodes that didn't move relative to each other. Those
+    //           nodes (represented by the `stationaryIds` variable) are kept
+    //           stationary, while all others are moved/inserted/deleted around
+    //           them. This gives the maximum node stability, and covers most
+    //           use-cases, including scrolling in any direction, insertions,
+    //           deletions, drag'n'drop, etc.
+
     // Indices into the old child list pointing at children that also exist in
     // the new child list.
     final List<int> intersectionIndicesOld = <int>[];
@@ -997,9 +1011,7 @@ class SemanticsObject {
     // If child lists are not identical, continue computing the intersection
     // between the two lists.
     while (newIndex < childCount) {
-      for (int oldIndex = 0;
-          oldIndex < previousCount;
-          oldIndex += 1) {
+      for (int oldIndex = 0; oldIndex < previousCount; oldIndex += 1) {
         if (previousChildrenInRenderOrder[oldIndex] ==
             childrenInRenderOrder[newIndex]) {
           intersectionIndicesOld.add(oldIndex);

--- a/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -278,11 +278,11 @@ class SemanticsObject {
 
     // The root node has some properties that other nodes do not.
     if (id == 0 && !configuration.debugShowSemanticsNodes) {
-      // Make all semantics transparent. We use `filter` instead of `opacity`
+      // Make all semantics transparent. Use `filter` instead of `opacity`
       // attribute because `filter` is stronger. `opacity` does not apply to
       // some elements, particularly on iOS, such as the slider thumb and track.
       //
-      // We use transparency instead of "visibility:hidden" or "display:none"
+      // Use transparency instead of "visibility:hidden" or "display:none"
       // so that a screen reader does not ignore these elements.
       element.style.filter = 'opacity(0%)';
 
@@ -292,7 +292,7 @@ class SemanticsObject {
     }
 
     // Make semantic elements visible for debugging by outlining them using a
-    // green border. We do not use `border` attribute because it affects layout
+    // green border. Do not use `border` attribute because it affects layout
     // (`outline` does not).
     if (configuration.debugShowSemanticsNodes) {
       element.style.outline = '1px solid green';
@@ -902,13 +902,13 @@ class SemanticsObject {
         _childrenInHitTestOrder!.isEmpty) {
       if (_currentChildrenInRenderOrder == null ||
           _currentChildrenInRenderOrder!.isEmpty) {
-        // We must not have created a container element when child list is empty.
+        // A container element must not have been created when child list is empty.
         assert(_childContainerElement == null);
         _currentChildrenInRenderOrder = null;
         return;
       }
 
-      // We must have created a container element when child list is not empty.
+      // A container element must have been created when child list is not empty.
       assert(_childContainerElement != null);
 
       // Remove all children from this semantics object.
@@ -922,7 +922,7 @@ class SemanticsObject {
       return;
     }
 
-    // At this point we're guaranteed to have at least one child.
+    // At this point it is guaranteed to have at least one child.
     final Int32List childrenInTraversalOrder = _childrenInTraversalOrder!;
     final Int32List childrenInHitTestOrder = _childrenInHitTestOrder!;
     final int childCount = childrenInHitTestOrder.length;
@@ -930,7 +930,7 @@ class SemanticsObject {
 
     assert(childrenInTraversalOrder.length == childrenInHitTestOrder.length);
 
-    // We always render in traversal order, because the accessibility traversal
+    // Always render in traversal order, because the accessibility traversal
     // is determined by the DOM order of elements.
     final List<SemanticsObject> childrenInRenderOrder = <SemanticsObject>[];
     for (int i = 0; i < childCount; i++) {
@@ -966,7 +966,7 @@ class SemanticsObject {
       return;
     }
 
-    // At this point we're guaranteed to have had a non-empty previous child list.
+    // At this point it is guaranteed to have had a non-empty previous child list.
     final List<SemanticsObject> previousChildrenInRenderOrder = _currentChildrenInRenderOrder!;
     final int previousCount = previousChildrenInRenderOrder.length;
 
@@ -1059,10 +1059,10 @@ class SemanticsObject {
   ///
   /// If [condition] is false, removes the HTML "role" attribute from [element]
   /// if the current role is set to [ariaRoleName]. Otherwise, leaves the value
-  /// unchanged. This is done so we gracefully handle multiple competing roles.
+  /// unchanged. This is done to gracefully handle multiple competing roles.
   /// For example, if the role changes from "button" to "img" and tappable role
   /// manager attempts to clean up after the image role manager applied the new
-  /// role, we do not want it to erase the new role.
+  /// role, semantics avoids erasing the new role.
   void setAriaRole(String ariaRoleName, bool condition) {
     if (condition) {
       element.setAttribute('role', ariaRoleName);
@@ -1093,8 +1093,8 @@ class SemanticsObject {
 
     final bool shouldUseTappableRole =
       (hasAction(ui.SemanticsAction.tap) || hasFlag(ui.SemanticsFlag.isButton)) &&
-      // Text fields manage their own focus/tap interactions. We don't need the
-      // tappable role manager. It only confuses AT.
+      // Text fields manage their own focus/tap interactions. Tappable role
+      // manager is not needed. It only confuses AT.
       !isTextField;
 
     _updateRole(Role.tappable, shouldUseTappableRole);
@@ -1121,8 +1121,8 @@ class SemanticsObject {
       manager.dispose();
       _roleManagers.remove(role);
     }
-    // Nothing to do in the "else case" as it means that we want to disable a
-    // role that we don't currently have in the first place.
+    // Nothing to do in the "else case". There's no existing role manager to
+    // disable.
   }
 
   /// Whether the object represents an UI element with "increase" or "decrease"
@@ -1257,15 +1257,15 @@ class SemanticsObject {
 /// Controls how pointer events and browser-detected gestures are treated by
 /// the Web Engine.
 enum AccessibilityMode {
-  /// We are not told whether the assistive technology is enabled or not.
+  /// Flutter is not told whether the assistive technology is enabled or not.
   ///
   /// This is the default mode.
   ///
-  /// In this mode we use a gesture recognition system that deduplicates
+  /// In this mode a gesture recognition system is used that deduplicates
   /// gestures detected by Flutter with gestures detected by the browser.
   unknown,
 
-  /// We are told whether the assistive technology is enabled.
+  /// Flutter is told whether the assistive technology is enabled.
   known,
 }
 
@@ -1430,7 +1430,7 @@ class EngineSemanticsOwner {
     _semanticsEnabled = value;
 
     if (!_semanticsEnabled) {
-      // We do not process browser events at all when semantics is explicitly
+      // Do not process browser events at all when semantics is explicitly
       // disabled. All gestures are handled by the framework-level gesture
       // recognizers from pointer events.
       if (_gestureMode != GestureMode.pointerEvents) {
@@ -1488,8 +1488,7 @@ class EngineSemanticsOwner {
     return _gestureModeClock;
   }
 
-  /// Disables browser gestures temporarily because we have detected pointer
-  /// events.
+  /// Disables browser gestures temporarily because pointer events were detected.
   ///
   /// This is used to deduplicate gestures detected by Flutter and gestures
   /// detected by the browser. Flutter-detected gestures have higher precedence.
@@ -1509,29 +1508,29 @@ class EngineSemanticsOwner {
   /// The browser sends us both raw pointer events and gestures from
   /// [SemanticsObject.element]s. There could be three possibilities:
   ///
-  /// 1. Assistive technology is enabled and we know that it is.
-  /// 2. Assistive technology is disabled and we know that it isn't.
-  /// 3. We do not know whether an assistive technology is enabled.
+  /// 1. Assistive technology is enabled and Flutter knows that it is.
+  /// 2. Assistive technology is disabled and Flutter knows that it isn't.
+  /// 3. Flutter does not know whether an assistive technology is enabled.
   ///
   /// If [autoEnableOnTap] was called, this will automatically enable semantics
   /// if the user requests it.
   ///
-  /// In the first case we can ignore raw pointer events and only interpret
+  /// In the first case ignore raw pointer events and only interpret
   /// high-level gestures, e.g. "click".
   ///
-  /// In the second case we can ignore high-level gestures and interpret the raw
+  /// In the second case ignore high-level gestures and interpret the raw
   /// pointer events directly.
   ///
-  /// Finally, in a mode when we do not know if an assistive technology is
-  /// enabled or not we do a best-effort estimate which to respond to, raw
-  /// pointer or high-level gestures. We avoid doing both because that will
+  /// Finally, in a mode when Flutter does not know if an assistive technology
+  /// is enabled or not do a best-effort estimate which to respond to, raw
+  /// pointer or high-level gestures. Avoid doing both because that will
   /// result in double-firing of event listeners, such as `onTap` on a button.
-  /// An approach we use is to measure the distance between the last pointer
+  /// The approach is to measure the distance between the last pointer
   /// event and a gesture event. If a gesture is receive "soon" after the last
   /// received pointer event (determined by a heuristic), it is debounced as it
   /// is likely that the gesture detected from the pointer even will do the
-  /// right thing. However, if we receive a standalone gesture we will map it
-  /// onto a [ui.SemanticsAction] to be processed by the framework.
+  /// right thing. However, if a standalone gesture is received, map it onto a
+  /// [ui.SemanticsAction] to be processed by the framework.
   bool receiveGlobalEvent(html.Event event) {
     // For pointer event reference see:
     //
@@ -1598,7 +1597,7 @@ class EngineSemanticsOwner {
   /// [semanticsEnabled] is `false`.
   ///
   /// If [mode] is [AccessibilityMode.unknown] the gesture is accepted if it is
-  /// not accompanied by pointer events. In the presence of pointer events we
+  /// not accompanied by pointer events. In the presence of pointer events,
   /// delegate to Flutter's gesture detection system to produce gestures.
   bool shouldAcceptBrowserGesture(String eventType) {
     if (_mode == AccessibilityMode.known) {
@@ -1658,7 +1657,7 @@ class EngineSemanticsOwner {
     }
 
     // Second, fix the tree structure. This is moved out into its own loop,
-    // because we must make sure each object's own information is up-to-date.
+    // because each object's own information must be updated first.
     for (final SemanticsNodeUpdate nodeUpdate in update._nodeUpdates!) {
       final SemanticsObject object = _semanticsTree[nodeUpdate.id]!;
       object.updateChildren();
@@ -1682,7 +1681,7 @@ class EngineSemanticsOwner {
         // Dirty fields should be cleared after the tree has been finalized.
         assert(object._dirtyFields == 0);
 
-        // Make sure we create a child container only when there are children.
+        // Make sure a child container is created only when there are children.
         assert(object._childContainerElement == null || object.hasChildren);
 
         // Ensure child ID list is consistent with the parent-child
@@ -1754,8 +1753,7 @@ List<int> longestIncreasingSubsequence(List<int> list) {
       mins[expansionIndex] = i;
     }
     if (expansionIndex > longest) {
-      // If we found a subsequence longer than any we've
-      // found yet, update `longest`
+      // Record the longest subsequence found so far.
       longest = expansionIndex;
     }
   }

--- a/lib/web_ui/test/canvaskit/embedded_views_test.dart
+++ b/lib/web_ui/test/canvaskit/embedded_views_test.dart
@@ -130,6 +130,34 @@ void testMain() {
       );
     });
 
+    test('correctly offsets platform views', () async {
+      ui.platformViewRegistry.registerViewFactory(
+        'test-platform-view',
+        (int viewId) => html.DivElement()..id = 'view-0',
+      );
+      await createPlatformView(0, 'test-platform-view');
+
+      final EnginePlatformDispatcher dispatcher =
+          ui.window.platformDispatcher as EnginePlatformDispatcher;
+      final LayerSceneBuilder sb = LayerSceneBuilder();
+      sb.addPlatformView(0, offset: const ui.Offset(3, 4), width: 5, height: 6);
+      dispatcher.rasterizer!.draw(sb.build().layerTree);
+
+      final html.Element slotHost =
+          flutterViewEmbedder.sceneElement!.querySelector('flt-platform-view-slot')!;
+      final html.CssStyleDeclaration style = slotHost.style;
+
+      expect(style.transform, 'matrix(1, 0, 0, 1, 3, 4)');
+      expect(style.width, '5px');
+      expect(style.height, '6px');
+
+      final html.Rectangle<num> slotRect = slotHost.getBoundingClientRect();
+      expect(slotRect.left, 3);
+      expect(slotRect.top, 4);
+      expect(slotRect.right, 8);
+      expect(slotRect.bottom, 10);
+    });
+
     // Returns the list of CSS transforms applied to the ancestor chain of
     // elements starting from `viewHost`, up until and excluding <flt-scene>.
     List<String> getTransformChain(html.Element viewHost) {

--- a/lib/web_ui/test/canvaskit/semantics_test.dart
+++ b/lib/web_ui/test/canvaskit/semantics_test.dart
@@ -1,0 +1,25 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@TestOn('chrome || safari || firefox')
+
+import 'dart:async';
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+
+import '../engine/semantics/semantics_test.dart';
+import 'common.dart';
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+// Run the same semantics tests in CanvasKit mode because as of today we do not
+// yet share platform view logic with the HTML renderer, which affects
+// semantics.
+Future<void> testMain() async {
+  setUpCanvasKitTest();
+  runSemanticsTests();
+}

--- a/lib/web_ui/test/canvaskit/semantics_test.dart
+++ b/lib/web_ui/test/canvaskit/semantics_test.dart
@@ -20,6 +20,10 @@ void main() {
 // yet share platform view logic with the HTML renderer, which affects
 // semantics.
 Future<void> testMain() async {
-  setUpCanvasKitTest();
-  runSemanticsTests();
+  group('CanvasKit semantics', () {
+    setUpCanvasKitTest();
+
+    runSemanticsTests();
+    // TODO(hterkelsen): https://github.com/flutter/flutter/issues/60040
+  }, skip: isIosSafari);
 }

--- a/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -15,6 +15,7 @@ import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' as ui;
 
+import '../../common.dart';
 import 'semantics_tester.dart';
 
 DateTime _testTime = DateTime(2018, 12, 17);
@@ -537,21 +538,12 @@ void _testContainer() {
     );
 
     semantics().updateSemantics(builder.build());
-    if (browserEngine == BrowserEngine.edge) {
-      expectSemanticsTree('''
-<sem style="color: rgba(0, 0, 0, 0); filter: opacity(0%)">
-  <sem-c>
-    <sem></sem>
-  </sem-c>
-</sem>''');
-    } else {
-      expectSemanticsTree('''
+    expectSemanticsTree('''
 <sem style="$rootSemanticStyle">
   <sem-c>
     <sem></sem>
   </sem-c>
 </sem>''');
-    }
 
     final html.Element parentElement =
         appHostNode.querySelector('flt-semantics')!;
@@ -1094,9 +1086,7 @@ void _testIncrementables() {
     expect(await logger.actionLog.first, ui.SemanticsAction.decrease);
 
     semantics().semanticsEnabled = false;
-  },
-      // TODO(yjbanov): https://github.com/flutter/flutter/issues/50754
-      skip: browserEngine == BrowserEngine.edge);
+  });
 
   test('renders a node that can both increment and decrement', () async {
     semantics()
@@ -1125,9 +1115,7 @@ void _testIncrementables() {
 </sem>''');
 
     semantics().semanticsEnabled = false;
-  },
-      // TODO(yjbanov): https://github.com/flutter/flutter/issues/50754
-      skip: browserEngine == BrowserEngine.edge);
+  });
 }
 
 void _testTextField() {
@@ -1154,9 +1142,7 @@ void _testTextField() {
 </sem>''');
 
     semantics().semanticsEnabled = false;
-  },
-      // TODO(yjbanov): https://github.com/flutter/flutter/issues/50754
-      skip: browserEngine == BrowserEngine.edge);
+  });
 
   // TODO(yjbanov): this test will need to be adjusted for Safari when we add
   //                Safari testing.
@@ -1223,9 +1209,7 @@ void _testCheckables() {
 ''');
 
     semantics().semanticsEnabled = false;
-  },
-      // TODO(yjbanov): https://github.com/flutter/flutter/issues/50754
-      skip: browserEngine == BrowserEngine.edge);
+  });
 
   test('renders a switched on disabled switch element', () async {
     semantics()
@@ -1251,9 +1235,7 @@ void _testCheckables() {
 ''');
 
     semantics().semanticsEnabled = false;
-  },
-      // TODO(yjbanov): https://github.com/flutter/flutter/issues/50754
-      skip: browserEngine == BrowserEngine.edge);
+  });
 
   test('renders a switched off switch element', () async {
     semantics()
@@ -1279,9 +1261,7 @@ void _testCheckables() {
 ''');
 
     semantics().semanticsEnabled = false;
-  },
-      // TODO(yjbanov): https://github.com/flutter/flutter/issues/50754
-      skip: browserEngine == BrowserEngine.edge);
+  });
 
   test('renders a checked checkbox', () async {
     semantics()
@@ -1308,9 +1288,7 @@ void _testCheckables() {
 ''');
 
     semantics().semanticsEnabled = false;
-  },
-      // TODO(yjbanov): https://github.com/flutter/flutter/issues/50754
-      skip: browserEngine == BrowserEngine.edge);
+  });
 
   test('renders a checked disabled checkbox', () async {
     semantics()
@@ -1336,9 +1314,7 @@ void _testCheckables() {
 ''');
 
     semantics().semanticsEnabled = false;
-  },
-      // TODO(yjbanov): https://github.com/flutter/flutter/issues/50754
-      skip: browserEngine == BrowserEngine.edge);
+  });
 
   test('renders an unchecked checkbox', () async {
     semantics()
@@ -1364,9 +1340,7 @@ void _testCheckables() {
 ''');
 
     semantics().semanticsEnabled = false;
-  },
-      // TODO(yjbanov): https://github.com/flutter/flutter/issues/50754
-      skip: browserEngine == BrowserEngine.edge);
+  });
 
   test('renders a checked radio button', () async {
     semantics()
@@ -1394,9 +1368,7 @@ void _testCheckables() {
 ''');
 
     semantics().semanticsEnabled = false;
-  },
-      // TODO(yjbanov): https://github.com/flutter/flutter/issues/50754
-      skip: browserEngine == BrowserEngine.edge);
+  });
 
   test('renders a checked disabled radio button', () async {
     semantics()
@@ -1423,9 +1395,7 @@ void _testCheckables() {
 ''');
 
     semantics().semanticsEnabled = false;
-  },
-      // TODO(yjbanov): https://github.com/flutter/flutter/issues/50754
-      skip: browserEngine == BrowserEngine.edge);
+  });
 
   test('renders an unchecked checkbox', () async {
     semantics()
@@ -1452,9 +1422,7 @@ void _testCheckables() {
 ''');
 
     semantics().semanticsEnabled = false;
-  },
-      // TODO(yjbanov): https://github.com/flutter/flutter/issues/50754
-      skip: browserEngine == BrowserEngine.edge);
+  });
 }
 
 void _testTappable() {
@@ -1481,9 +1449,7 @@ void _testTappable() {
     expect(tester.getSemanticsObject(0).element.tabIndex, 0);
 
     semantics().semanticsEnabled = false;
-  },
-      // TODO(yjbanov): https://github.com/flutter/flutter/issues/50754
-      skip: browserEngine == BrowserEngine.edge);
+  });
 
   test('renders a disabled tappable widget', () async {
     semantics()
@@ -1508,9 +1474,7 @@ void _testTappable() {
 ''');
 
     semantics().semanticsEnabled = false;
-  },
-      // TODO(yjbanov): https://github.com/flutter/flutter/issues/50754
-      skip: browserEngine == BrowserEngine.edge);
+  });
 }
 
 void _testImage() {
@@ -1536,9 +1500,7 @@ void _testImage() {
 ''');
 
     semantics().semanticsEnabled = false;
-  },
-      // TODO(yjbanov): https://github.com/flutter/flutter/issues/50754
-      skip: browserEngine == BrowserEngine.edge);
+  });
 
   test('renders an image with a child node and with a label', () async {
     semantics()
@@ -1575,9 +1537,7 @@ void _testImage() {
 </sem>''');
 
     semantics().semanticsEnabled = false;
-  },
-      // TODO(yjbanov): https://github.com/flutter/flutter/issues/50754
-      skip: browserEngine == BrowserEngine.edge);
+  });
 
   test('renders an image with no child nodes without a label', () async {
     semantics()
@@ -1599,9 +1559,7 @@ void _testImage() {
         '''<sem role="img" style="$rootSemanticStyle"></sem>''');
 
     semantics().semanticsEnabled = false;
-  },
-      // TODO(yjbanov): https://github.com/flutter/flutter/issues/50754
-      skip: browserEngine == BrowserEngine.edge);
+  });
 
   test('renders an image with a child node and without a label', () async {
     semantics()
@@ -1637,9 +1595,7 @@ void _testImage() {
 </sem>''');
 
     semantics().semanticsEnabled = false;
-  },
-      // TODO(yjbanov): https://github.com/flutter/flutter/issues/50754
-      skip: browserEngine == BrowserEngine.edge);
+  });
 }
 
 void _testLiveRegion() {
@@ -1665,9 +1621,7 @@ void _testLiveRegion() {
 ''');
 
     semantics().semanticsEnabled = false;
-  },
-      // TODO(yjbanov): https://github.com/flutter/flutter/issues/50754
-      skip: browserEngine == BrowserEngine.edge);
+  });
 
   test('does not render a live region if there is no label', () async {
     semantics()
@@ -1848,7 +1802,13 @@ void _testPlatformView() {
     // root, it would be reachable both from the shadow root (by hitting the
     // corresponding <slot> tag) and from the document (by hitting the platform
     // view element itself).
-    expect(shadowRoot.elementFromPoint(10, 30)!, platformViewElement);
+
+    // Browsers disagree about which element should be returned when hit testing
+    // a shadow root. However, they do agree when hit testing `document`.
+    //
+    // See:
+    //   * https://github.com/w3c/csswg-drafts/issues/556
+    //   * https://bugzilla.mozilla.org/show_bug.cgi?id=1502369
     expect(html.document.elementFromPoint(10, 30)!, platformViewElement);
 
     // Hit test overlap between child 2 and 3
@@ -1858,7 +1818,11 @@ void _testPlatformView() {
     expect(shadowRoot.elementFromPoint(10, 50)!, child3);
 
     semantics().semanticsEnabled = false;
-  });
+    // TODO(yjbanov): unable to debug this test on iOS Safari as hacking on a
+    //                Linux machine. iOS Safari returns getBoundingClientRect
+    //                values that are half of desktop browsers, possibly due to
+    //                devicePixelRatio but need to confirm.
+  }, skip: isIosSafari);
 }
 
 /// A facade in front of [ui.SemanticsUpdateBuilder.updateNode] that

--- a/lib/web_ui/test/engine/semantics/semantics_tester.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_tester.dart
@@ -360,8 +360,9 @@ class SemanticsTester {
 
 /// Verifies the HTML structure of the current semantics tree.
 void expectSemanticsTree(String semanticsHtml) {
+  const List<String> ignoredAttributes = <String>['pointer-events'];
   expect(
-    canonicalizeHtml(appHostNode.querySelector('flt-semantics')!.outerHtml!),
+    canonicalizeHtml(appHostNode.querySelector('flt-semantics')!.outerHtml!, ignoredAttributes: ignoredAttributes),
     canonicalizeHtml(semanticsHtml),
   );
 }

--- a/lib/web_ui/test/matchers.dart
+++ b/lib/web_ui/test/matchers.dart
@@ -225,9 +225,12 @@ enum HtmlComparisonMode {
 /// [throwOnUnusedAttributes] to `true` to check that expected HTML strings do
 /// not contain irrelevant attributes. It is ok for actual HTML to contain all
 /// kinds of attributes. They only need to be filtered out before testing.
-String canonicalizeHtml(String htmlContent,
-    {HtmlComparisonMode mode = HtmlComparisonMode.nonLayoutOnly,
-    bool throwOnUnusedAttributes = false}) {
+String canonicalizeHtml(
+  String htmlContent, {
+  HtmlComparisonMode mode = HtmlComparisonMode.nonLayoutOnly,
+  bool throwOnUnusedAttributes = false,
+  List<String>? ignoredAttributes,
+}) {
   if (htmlContent.trim().isEmpty) {
     return '';
   }
@@ -331,6 +334,11 @@ String canonicalizeHtml(String htmlContent,
                 final List<String> parts = attr.split(':');
                 if (parts.length == 2) {
                   final String name = parts.first;
+
+                  if (ignoredAttributes != null && ignoredAttributes.contains(name)) {
+                    return null;
+                  }
+
                   // Whether the attribute is one that's set to the same value and
                   // never changes. Such attributes are usually not interesting to
                   // test.


### PR DESCRIPTION
Fix traversal and hit test orders for web.

Problems with the previous approach:

* The ARIA semantics tree was rendered behind the scene host. This was done to allow platform views be reachable using assistive technology. Putting semantics on top used to obscure the underlying platform views. However, now we ended up with the opposite problem: platform views obscure semantics. For example, a pointer interceptor that's meant to simply forward pointer events to the framework can frequently stretch across the whole screen, so no pointer events could land on the semantics tree at all. This is not a problem when users use accessibility shortcuts, but it is a problem when users use touch to explore UI.
  * **Fix**: move the semantics tree on top of the scene host. So the platform views are still reachable, make container nodes transparent hit-test wise using CSS `pointer-events: none`.
* Child semantics nodes were always rendered in traversal order. Hit test order was ignored. This became problematic when the framework started customizing hit test order (e.g. https://github.com/flutter/flutter/pull/59290).
  * **Fix**: use `z-index` CSS property to implement child hit test order.
* We used `aria-hidden: true` on the `<flt-scene-host>` element, but because that property applies to the whole subtree and platform views are composited under it, platform views were hidden from accessibility too, even though they still received regular pointer and keyboard events.
  * **Fix**: do not hide `<flt-scene-host>`, but hide `<flt-picture>` elements instead. We are only interested in hiding DOM used to render pixels for widgets, so hiding just the pictures is sufficient.

Fixes https://github.com/flutter/flutter/issues/100157