### PR TITLE
[WIP] Recator API 'SceneBulder.addPicture' to return 'PictureEngineLayer'

### DIFF
--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -198,6 +198,15 @@ class PhysicalShapeEngineLayer extends _EngineLayerWrapper {
   PhysicalShapeEngineLayer._(EngineLayer nativeLayer) : super._(nativeLayer);
 }
 
+/// An opaque handle to a picture engine layer.
+///
+/// Instances of this class are created by [SceneBuilder.addPicture].
+///
+/// {@macro dart.ui.sceneBuilder.oldLayerCompatibility}
+class PictureEngineLayer extends _EngineLayerWrapper {
+  PictureEngineLayer._(EngineLayer nativeLayer) : super._(nativeLayer);
+}
+
 /// Builds a [Scene] containing the given visuals.
 ///
 /// A [Scene] can then be rendered using [FlutterView.render].
@@ -712,18 +721,27 @@ class SceneBuilder extends NativeFieldWrapperClass1 {
   /// Adds a [Picture] to the scene.
   ///
   /// The picture is rasterized at the given offset.
-  void addPicture(
+  ///
+  /// {@macro dart.ui.sceneBuilder.oldLayer}
+  ///
+  /// {@macro dart.ui.sceneBuilder.oldLayerVsRetained}
+  PictureEngineLayer addPicture(
     Offset offset,
     Picture picture, {
     bool isComplexHint = false,
     bool willChangeHint = false,
+    PictureEngineLayer? oldLayer,
   }) {
     assert(!picture.debugDisposed);
+    assert(_debugCheckCanBeUsedAsOldLayer(oldLayer, 'addPicture'));
+    final EngineLayer engineLayer = EngineLayer._();
     final int hints = (isComplexHint ? 1 : 0) | (willChangeHint ? 2 : 0);
-    _addPicture(offset.dx, offset.dy, picture, hints);
+    _addPicture(engineLayer, offset.dx, offset.dy, picture, hints, oldLayer?._nativeLayer);
+    final PictureEngineLayer layer = PictureEngineLayer._(engineLayer);
+    return layer;
   }
 
-  void _addPicture(double dx, double dy, Picture picture, int hints)
+  void _addPicture(EngineLayer engineLayer, double dx, double dy, Picture picture, int hints, EngineLayer? oldLayer)
       native 'SceneBuilder_addPicture';
 
   /// Adds a backend texture to the scene.

--- a/lib/ui/compositing/scene_builder.h
+++ b/lib/ui/compositing/scene_builder.h
@@ -97,7 +97,12 @@ class SceneBuilder : public RefCountedDartWrappable<SceneBuilder> {
                              double top,
                              double bottom);
 
-  void addPicture(double dx, double dy, Picture* picture, int hints);
+  void addPicture(Dart_Handle layer_handle,
+                  double dx,
+                  double dy,
+                  Picture* picture,
+                  int hints,
+                  fml::RefPtr<EngineLayer> oldLayer);
 
   void addTexture(double dx,
                   double dy,

--- a/lib/ui/fixtures/ui_test.dart
+++ b/lib/ui/fixtures/ui_test.dart
@@ -274,20 +274,22 @@ Future<void> pumpImage() async {
   );
   final Image image = await completer.future;
   late Picture picture;
-  late OffsetEngineLayer layer;
+  late OffsetEngineLayer offsetLayer;
+  late PictureEngineLayer pictureLayer;
 
   void renderBlank(Duration duration) {
     image.dispose();
     picture.dispose();
-    layer.dispose();
+    offsetLayer.dispose();
+    pictureLayer.dispose();
 
     final PictureRecorder recorder = PictureRecorder();
     final Canvas canvas = Canvas(recorder);
     canvas.drawPaint(Paint());
     picture = recorder.endRecording();
     final SceneBuilder builder = SceneBuilder();
-    layer = builder.pushOffset(0, 0);
-    builder.addPicture(Offset.zero, picture);
+    offsetLayer = builder.pushOffset(0, 0);
+    pictureLayer = builder.addPicture(Offset.zero, picture);
 
     final Scene scene = builder.build();
     window.render(scene);
@@ -303,8 +305,8 @@ Future<void> pumpImage() async {
     picture = recorder.endRecording();
 
     final SceneBuilder builder = SceneBuilder();
-    layer = builder.pushOffset(0, 0);
-    builder.addPicture(Offset.zero, picture);
+    offsetLayer = builder.pushOffset(0, 0);
+    pictureLayer = builder.addPicture(Offset.zero, picture);
 
     _captureImageAndPicture(image, picture);
 

--- a/lib/ui/painting/engine_layer.cc
+++ b/lib/ui/painting/engine_layer.cc
@@ -20,7 +20,7 @@ IMPLEMENT_WRAPPERTYPEINFO(ui, EngineLayer);
 
 DART_BIND_ALL(EngineLayer, FOR_EACH_BINDING)
 
-EngineLayer::EngineLayer(std::shared_ptr<flutter::ContainerLayer> layer)
+EngineLayer::EngineLayer(std::shared_ptr<flutter::Layer> layer)
     : layer_(layer) {}
 
 EngineLayer::~EngineLayer() = default;

--- a/lib/ui/painting/engine_layer.h
+++ b/lib/ui/painting/engine_layer.h
@@ -23,7 +23,7 @@ class EngineLayer : public RefCountedDartWrappable<EngineLayer> {
   ~EngineLayer() override;
 
   static void MakeRetained(Dart_Handle dart_handle,
-                           std::shared_ptr<flutter::ContainerLayer> layer) {
+                           std::shared_ptr<flutter::Layer> layer) {
     auto engine_layer = fml::MakeRefCounted<EngineLayer>(layer);
     engine_layer->AssociateWithDartWrapper(dart_handle);
   }
@@ -32,11 +32,11 @@ class EngineLayer : public RefCountedDartWrappable<EngineLayer> {
 
   void dispose();
 
-  std::shared_ptr<flutter::ContainerLayer> Layer() const { return layer_; }
+  std::shared_ptr<flutter::Layer> Layer() const { return layer_; }
 
  private:
-  explicit EngineLayer(std::shared_ptr<flutter::ContainerLayer> layer);
-  std::shared_ptr<flutter::ContainerLayer> layer_;
+  explicit EngineLayer(std::shared_ptr<flutter::Layer> layer);
+  std::shared_ptr<flutter::Layer> layer_;
 
   FML_FRIEND_MAKE_REF_COUNTED(EngineLayer);
 };

--- a/lib/web_ui/lib/compositing.dart
+++ b/lib/web_ui/lib/compositing.dart
@@ -31,6 +31,8 @@ abstract class ShaderMaskEngineLayer implements EngineLayer {}
 
 abstract class PhysicalShapeEngineLayer implements EngineLayer {}
 
+abstract class PictureEngineLayer implements EngineLayer {}
+
 abstract class SceneBuilder {
   factory SceneBuilder() {
     if (engine.useCanvasKit) {
@@ -99,11 +101,12 @@ abstract class SceneBuilder {
   void addRetained(EngineLayer retainedLayer);
   void pop();
   void addPerformanceOverlay(int enabledOptions, Rect bounds);
-  void addPicture(
+  PictureEngineLayer addPicture(
     Offset offset,
     Picture picture, {
     bool isComplexHint = false,
     bool willChangeHint = false,
+    PictureEngineLayer? oldLayer,
   });
   void addTexture(
     int textureId, {

--- a/lib/web_ui/lib/src/engine/canvaskit/layer.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/layer.dart
@@ -446,7 +446,7 @@ class ShaderMaskEngineLayer extends ContainerLayer
 }
 
 /// A layer containing a [Picture].
-class PictureLayer extends Layer {
+class PictureLayer extends Layer implements ui.PictureEngineLayer {
   /// The picture to paint into the canvas.
   final CkPicture picture;
 

--- a/lib/web_ui/lib/src/engine/canvaskit/layer_scene_builder.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/layer_scene_builder.dart
@@ -43,14 +43,17 @@ class LayerSceneBuilder implements ui.SceneBuilder {
   }
 
   @override
-  void addPicture(
+  PictureLayer addPicture(
     ui.Offset offset,
     ui.Picture picture, {
     bool isComplexHint = false,
     bool willChangeHint = false,
+    ui.EngineLayer? oldLayer,
   }) {
-    currentLayer.add(PictureLayer(
-        picture as CkPicture, offset, isComplexHint, willChangeHint));
+    final PictureLayer layer = PictureLayer(
+        picture as CkPicture, offset, isComplexHint, willChangeHint);
+    currentLayer.add(layer);
+    return layer;
   }
 
   @override

--- a/lib/web_ui/lib/src/engine/html/picture.dart
+++ b/lib/web_ui/lib/src/engine/html/picture.dart
@@ -95,7 +95,7 @@ void _recycleCanvas(EngineCanvas? canvas) {
 
 /// A surface that uses a combination of `<canvas>`, `<div>` and `<p>` elements
 /// to draw shapes and text.
-class PersistedPicture extends PersistedLeafSurface {
+class PersistedPicture extends PersistedLeafSurface implements ui.PictureEngineLayer {
   PersistedPicture(this.dx, this.dy, this.picture, this.hints)
       : localPaintBounds = picture.recordingCanvas!.pictureBounds;
 

--- a/lib/web_ui/lib/src/engine/html/scene_builder.dart
+++ b/lib/web_ui/lib/src/engine/html/scene_builder.dart
@@ -383,11 +383,12 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
   ///
   /// The picture is rasterized at the given offset.
   @override
-  void addPicture(
+  ui.PictureEngineLayer addPicture(
     ui.Offset offset,
     ui.Picture picture, {
     bool isComplexHint = false,
     bool willChangeHint = false,
+    ui.PictureEngineLayer? oldLayer
   }) {
     int hints = 0;
     if (isComplexHint) {
@@ -396,8 +397,10 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
     if (willChangeHint) {
       hints |= 2;
     }
-    _addSurface(PersistedPicture(
-        offset.dx, offset.dy, picture as EnginePicture, hints));
+    final PersistedPicture surface = PersistedPicture(
+        offset.dx, offset.dy, picture as EnginePicture, hints);
+    _addSurface(surface);
+    return surface;
   }
 
   /// Adds a backend texture to the scene.

--- a/testing/dart/compositing_test.dart
+++ b/testing/dart/compositing_test.dart
@@ -105,15 +105,17 @@ void main() {
   });
 
   // Attempts to use the same layer first as `oldLayer` then in `addRetained`.
-  void testPushThenIllegalRetain(_TestNoSharingFunction pushFunction) {
+  void testPushOrAddThenIllegalRetain(_TestNoSharingFunction pushOrAddFunction, {bool shouldPop = true}) {
     final SceneBuilder builder1 = SceneBuilder();
-    final EngineLayer layer = pushFunction(builder1, null);
-    builder1.pop();
+    final EngineLayer layer = pushOrAddFunction(builder1, null);
+    if (shouldPop)
+      builder1.pop();
     builder1.build();
 
     final SceneBuilder builder2 = SceneBuilder();
-    pushFunction(builder2, layer);
-    builder2.pop();
+    pushOrAddFunction(builder2, layer);
+    if (shouldPop)
+      builder2.pop();
     assert(() {
       try {
         builder2.addRetained(layer);
@@ -127,17 +129,18 @@ void main() {
   }
 
   // Attempts to use the same layer first in `addRetained` then as `oldLayer`.
-  void testAddRetainedThenIllegalPush(_TestNoSharingFunction pushFunction) {
+  void testAddRetainedThenIllegalPush(_TestNoSharingFunction pushOrAddFunction, {bool shouldPop = true}) {
     final SceneBuilder builder1 = SceneBuilder();
-    final EngineLayer layer = pushFunction(builder1, null);
-    builder1.pop();
+    final EngineLayer layer = pushOrAddFunction(builder1, null);
+    if (shouldPop)
+      builder1.pop();
     builder1.build();
 
     final SceneBuilder builder2 = SceneBuilder();
     builder2.addRetained(layer);
     assert(() {
       try {
-        pushFunction(builder2, layer);
+        pushOrAddFunction(builder2, layer);
         fail('Expected push to throw AssertionError but it returned successully');
       } on AssertionError catch (error) {
         expect(error.toString(), contains('The layer is already being used'));
@@ -148,10 +151,11 @@ void main() {
   }
 
   // Attempts to retain the same layer twice in the same scene.
-  void testDoubleAddRetained(_TestNoSharingFunction pushFunction) {
+  void testDoubleAddRetained(_TestNoSharingFunction pushOrAddFunction, {bool shouldPop = true}) {
     final SceneBuilder builder1 = SceneBuilder();
-    final EngineLayer layer = pushFunction(builder1, null);
-    builder1.pop();
+    final EngineLayer layer = pushOrAddFunction(builder1, null);
+    if (shouldPop)
+      builder1.pop();
     builder1.build();
 
     final SceneBuilder builder2 = SceneBuilder();
@@ -169,17 +173,18 @@ void main() {
   }
 
   // Attempts to use the same layer as `oldLayer` twice in the same scene.
-  void testPushOldLayerTwice(_TestNoSharingFunction pushFunction) {
+  void testPushOrAddOldLayerTwice(_TestNoSharingFunction pushOrAddFunction, {bool shouldPop = true}) {
     final SceneBuilder builder1 = SceneBuilder();
-    final EngineLayer layer = pushFunction(builder1, null);
-    builder1.pop();
+    final EngineLayer layer = pushOrAddFunction(builder1, null);
+    if (shouldPop)
+      builder1.pop();
     builder1.build();
 
     final SceneBuilder builder2 = SceneBuilder();
-    pushFunction(builder2, layer);
+    pushOrAddFunction(builder2, layer);
     assert(() {
       try {
-        pushFunction(builder2, layer);
+        pushOrAddFunction(builder2, layer);
         fail('Expected push to throw AssertionError but it returned successully');
       } on AssertionError catch (error) {
         expect(error.toString(), contains('was previously used as oldLayer'));
@@ -237,15 +242,17 @@ void main() {
   }
 
   // Attempts to retain a layer that has been used as `oldLayer` in a previous frame.
-  void testRetainOldLayer(_TestNoSharingFunction pushFunction) {
+  void testRetainOldLayer(_TestNoSharingFunction pushOrAddFunction, {bool shouldPop = true}) {
     final SceneBuilder builder1 = SceneBuilder();
-    final EngineLayer layer = pushFunction(builder1, null);
-    builder1.pop();
+    final EngineLayer layer = pushOrAddFunction(builder1, null);
+    if (shouldPop)
+      builder1.pop();
     builder1.build();
 
     final SceneBuilder builder2 = SceneBuilder();
-    pushFunction(builder2, layer);
-    builder2.pop();
+    pushOrAddFunction(builder2, layer);
+    if (shouldPop)
+      builder2.pop();
     assert(() {
       try {
         final SceneBuilder builder3 = SceneBuilder();
@@ -260,19 +267,21 @@ void main() {
   }
 
   // Attempts to pass layer as `oldLayer` that has been used as `oldLayer` in a previous frame.
-  void testPushOldLayer(_TestNoSharingFunction pushFunction) {
+  void testPushOrAddOldLayer(_TestNoSharingFunction pushOrAddFunction, {bool shouldPop = true}) {
     final SceneBuilder builder1 = SceneBuilder();
-    final EngineLayer layer = pushFunction(builder1, null);
-    builder1.pop();
+    final EngineLayer layer = pushOrAddFunction(builder1, null);
+    if (shouldPop)
+      builder1.pop();
     builder1.build();
 
     final SceneBuilder builder2 = SceneBuilder();
-    pushFunction(builder2, layer);
-    builder2.pop();
+    pushOrAddFunction(builder2, layer);
+    if (shouldPop)
+      builder2.pop();
     assert(() {
       try {
         final SceneBuilder builder3 = SceneBuilder();
-        pushFunction(builder3, layer);
+        pushOrAddFunction(builder3, layer);
         fail('Expected addRetained to throw AssertionError but it returned successully');
       } on AssertionError catch (error) {
         expect(error.toString(), contains('was previously used as oldLayer'));
@@ -307,41 +316,50 @@ void main() {
     builder2.build();
   }
 
-  void testNoSharing(_TestNoSharingFunction pushFunction) {
-    testPushThenIllegalRetain(pushFunction);
+  void testNoSharingForPushFunction(_TestNoSharingFunction pushFunction) {
+    testPushOrAddThenIllegalRetain(pushFunction);
     testAddRetainedThenIllegalPush(pushFunction);
     testDoubleAddRetained(pushFunction);
-    testPushOldLayerTwice(pushFunction);
+    testPushOrAddOldLayerTwice(pushFunction);
+    testRetainOldLayer(pushFunction);
+    testPushOrAddOldLayer(pushFunction);
     testPushChildLayerOfRetainedLayer(pushFunction);
     testRetainParentLayerOfPushedChild(pushFunction);
-    testRetainOldLayer(pushFunction);
-    testPushOldLayer(pushFunction);
     testRetainsParentOfOldLayer(pushFunction);
   }
 
+  void testNoSharingForAddFunction(_TestNoSharingFunction addFunction) {
+    testPushOrAddThenIllegalRetain(addFunction, shouldPop: false);
+    testAddRetainedThenIllegalPush(addFunction, shouldPop: false);
+    testDoubleAddRetained(addFunction, shouldPop: false);
+    testPushOrAddOldLayerTwice(addFunction, shouldPop: false);
+    testRetainOldLayer(addFunction, shouldPop: false);
+    testPushOrAddOldLayer(addFunction, shouldPop: false);
+  }
+
   test('SceneBuilder does not share a layer between addRetained and push*', () {
-    testNoSharing((SceneBuilder builder, EngineLayer? oldLayer) {
+    testNoSharingForPushFunction((SceneBuilder builder, EngineLayer? oldLayer) {
       return builder.pushOffset(0, 0, oldLayer: oldLayer as OffsetEngineLayer?);
     });
-    testNoSharing((SceneBuilder builder, EngineLayer? oldLayer) {
+    testNoSharingForPushFunction((SceneBuilder builder, EngineLayer? oldLayer) {
       return builder.pushTransform(Float64List(16), oldLayer: oldLayer as TransformEngineLayer?);
     });
-    testNoSharing((SceneBuilder builder, EngineLayer? oldLayer) {
+    testNoSharingForPushFunction((SceneBuilder builder, EngineLayer? oldLayer) {
       return builder.pushClipRect(Rect.zero, oldLayer: oldLayer as ClipRectEngineLayer?);
     });
-    testNoSharing((SceneBuilder builder, EngineLayer? oldLayer) {
+    testNoSharingForPushFunction((SceneBuilder builder, EngineLayer? oldLayer) {
       return builder.pushClipRRect(RRect.zero, oldLayer: oldLayer as ClipRRectEngineLayer?);
     });
-    testNoSharing((SceneBuilder builder, EngineLayer? oldLayer) {
+    testNoSharingForPushFunction((SceneBuilder builder, EngineLayer? oldLayer) {
       return builder.pushClipPath(Path(), oldLayer: oldLayer as ClipPathEngineLayer?);
     });
-    testNoSharing((SceneBuilder builder, EngineLayer? oldLayer) {
+    testNoSharingForPushFunction((SceneBuilder builder, EngineLayer? oldLayer) {
       return builder.pushOpacity(100, oldLayer: oldLayer as OpacityEngineLayer?);
     });
-    testNoSharing((SceneBuilder builder, EngineLayer? oldLayer) {
+    testNoSharingForPushFunction((SceneBuilder builder, EngineLayer? oldLayer) {
       return builder.pushBackdropFilter(ImageFilter.blur(), oldLayer: oldLayer as BackdropFilterEngineLayer?);
     });
-    testNoSharing((SceneBuilder builder, EngineLayer? oldLayer) {
+    testNoSharingForPushFunction((SceneBuilder builder, EngineLayer? oldLayer) {
       return builder.pushShaderMask(
         Gradient.radial(
           const Offset(0, 0),
@@ -353,10 +371,10 @@ void main() {
         oldLayer: oldLayer as ShaderMaskEngineLayer?,
       );
     });
-    testNoSharing((SceneBuilder builder, EngineLayer? oldLayer) {
+    testNoSharingForPushFunction((SceneBuilder builder, EngineLayer? oldLayer) {
       return builder.pushPhysicalShape(path: Path(), color: const Color.fromARGB(0, 0, 0, 0), oldLayer: oldLayer as PhysicalShapeEngineLayer?, elevation: 0.0);
     });
-    testNoSharing((SceneBuilder builder, EngineLayer? oldLayer) {
+    testNoSharingForPushFunction((SceneBuilder builder, EngineLayer? oldLayer) {
       return builder.pushColorFilter(
         const ColorFilter.mode(
           Color.fromARGB(0, 0, 0, 0),
@@ -365,7 +383,7 @@ void main() {
         oldLayer: oldLayer as ColorFilterEngineLayer?,
       );
     });
-    testNoSharing((SceneBuilder builder, EngineLayer? oldLayer) {
+    testNoSharingForPushFunction((SceneBuilder builder, EngineLayer? oldLayer) {
       return builder.pushColorFilter(
         const ColorFilter.matrix(<double>[
           1, 0, 0, 0, 0,
@@ -376,37 +394,37 @@ void main() {
         oldLayer: oldLayer as ColorFilterEngineLayer?,
       );
     });
-    testNoSharing((SceneBuilder builder, EngineLayer? oldLayer) {
+    testNoSharingForPushFunction((SceneBuilder builder, EngineLayer? oldLayer) {
       return builder.pushColorFilter(
         const ColorFilter.linearToSrgbGamma(),
         oldLayer: oldLayer as ColorFilterEngineLayer?,
       );
     });
-    testNoSharing((SceneBuilder builder, EngineLayer? oldLayer) {
+    testNoSharingForPushFunction((SceneBuilder builder, EngineLayer? oldLayer) {
       return builder.pushColorFilter(
         const ColorFilter.srgbToLinearGamma(),
         oldLayer: oldLayer as ColorFilterEngineLayer?,
       );
     });
-    testNoSharing((SceneBuilder builder, EngineLayer? oldLayer) {
+    testNoSharingForPushFunction((SceneBuilder builder, EngineLayer? oldLayer) {
       return builder.pushImageFilter(
         ImageFilter.blur(sigmaX: 10.0, sigmaY: 10.0),
         oldLayer: oldLayer as ImageFilterEngineLayer?,
       );
     });
-    testNoSharing((SceneBuilder builder, EngineLayer? oldLayer) {
+    testNoSharingForPushFunction((SceneBuilder builder, EngineLayer? oldLayer) {
       return builder.pushImageFilter(
         ImageFilter.dilate(radiusX: 10.0, radiusY: 10.0),
         oldLayer: oldLayer as ImageFilterEngineLayer?,
       );
     });
-    testNoSharing((SceneBuilder builder, EngineLayer? oldLayer) {
+    testNoSharingForPushFunction((SceneBuilder builder, EngineLayer? oldLayer) {
       return builder.pushImageFilter(
         ImageFilter.erode(radiusX: 10.0, radiusY: 10.0),
         oldLayer: oldLayer as ImageFilterEngineLayer?,
       );
     });
-    testNoSharing((SceneBuilder builder, EngineLayer? oldLayer) {
+    testNoSharingForPushFunction((SceneBuilder builder, EngineLayer? oldLayer) {
       return builder.pushImageFilter(
         ImageFilter.matrix(Float64List.fromList(<double>[
           1, 0, 0, 0,
@@ -417,6 +435,17 @@ void main() {
         oldLayer: oldLayer as ImageFilterEngineLayer?,
       );
     });
+    testNoSharingForAddFunction((SceneBuilder builder, EngineLayer? oldLayer) {
+      final PictureRecorder recorder = PictureRecorder();
+      final Canvas canvas = Canvas(recorder);
+      canvas.drawPaint(Paint());
+      final Picture picture = recorder.endRecording();
+      return builder.addPicture(
+        Offset.zero,
+        picture,
+        oldLayer: oldLayer as PictureEngineLayer?
+      );
+    }, );
   });
 }
 


### PR DESCRIPTION
fix https://github.com/flutter/flutter/issues/101872

framework change probably looks like this

``` diff
diff --git a/packages/flutter/lib/src/rendering/layer.dart b/packages/flutter/lib/src/rendering/layer.dart
index 4644180ddf..13115dafc8 100644
--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -711,7 +711,7 @@ class PictureLayer extends Layer {
   @override
   void addToScene(ui.SceneBuilder builder) {
     assert(picture != null);
-    builder.addPicture(Offset.zero, picture!, isComplexHint: isComplexHint, willChangeHint: willChangeHint);
+    engineLayer = builder.addPicture(Offset.zero, picture!, isComplexHint: isComplexHint, willChangeHint: willChangeHint, oldLayer: _engineLayer as ui.PictureEngineLayer?);
   }
```


## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

