### PR TITLE
Use only mac x64 machines.

### DIFF
--- a/ci/builders/mac_host_engine.json
+++ b/ci/builders/mac_host_engine.json
@@ -17,7 +17,8 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12"
+                "os=Mac-12",
+		"cpu=x64"
             ],
             "gclient_custom_vars": {
                 "download_android_deps": false
@@ -58,7 +59,8 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12"
+                "os=Mac-12",
+		"cpu=x64"
             ],
             "gclient_custom_vars": {
                 "download_android_deps": false
@@ -111,7 +113,8 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12"
+                "os=Mac-12",
+		"cpu=x64"
             ],
             "gclient_custom_vars": {
                 "download_android_deps": false
@@ -147,7 +150,8 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12"
+                "os=Mac-12",
+		"cpu=x64"
             ],
             "gclient_custom_vars": {
                 "download_android_deps": false
@@ -181,7 +185,8 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12"
+                "os=Mac-12",
+		"cpu=x64"
             ],
             "gclient_custom_vars": {
                 "download_android_deps": false
@@ -212,7 +217,8 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12"
+                "os=Mac-12",
+		"cpu=x64"
             ],
             "gclient_custom_vars": {
                 "download_android_deps": false


### PR DESCRIPTION
Mac host engine is failing on Mac M1s because CIPD packages for goma
and Android are not available for arm64.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
