### PR TITLE
[fuchsia] Switch FML_DLOGs -> FML_LOGs.

### DIFF
--- a/shell/platform/fuchsia/flutter/accessibility_bridge.cc
+++ b/shell/platform/fuchsia/flutter/accessibility_bridge.cc
@@ -733,13 +733,13 @@ AccessibilityBridge::GetFlutterSemanticsAction(
       return flutter::SemanticsAction::kLongPress;
     // Set (input/non-accessibility) focus on this element.
     case fuchsia::accessibility::semantics::Action::SET_FOCUS:
-      FML_DLOG(WARNING)
+      FML_LOG(WARNING)
           << "Unsupported action SET_FOCUS sent for accessibility node "
           << node_id;
       return {};
     // Set the element's value.
     case fuchsia::accessibility::semantics::Action::SET_VALUE:
-      FML_DLOG(WARNING)
+      FML_LOG(WARNING)
           << "Unsupported action SET_VALUE sent for accessibility node "
           << node_id;
       return {};
@@ -751,9 +751,9 @@ AccessibilityBridge::GetFlutterSemanticsAction(
     case fuchsia::accessibility::semantics::Action::DECREMENT:
       return flutter::SemanticsAction::kDecrease;
     default:
-      FML_DLOG(WARNING) << "Unexpected action "
-                        << static_cast<int32_t>(fuchsia_action)
-                        << " sent for accessibility node " << node_id;
+      FML_LOG(WARNING) << "Unexpected action "
+                       << static_cast<int32_t>(fuchsia_action)
+                       << " sent for accessibility node " << node_id;
       return {};
   }
 }

--- a/shell/platform/fuchsia/flutter/component_v1.cc
+++ b/shell/platform/fuchsia/flutter/component_v1.cc
@@ -144,8 +144,8 @@ ComponentV1::ComponentV1(
       ParseProgramMetadata(startup_info.program_metadata);
 
   if (metadata.data_path.empty()) {
-    FML_DLOG(ERROR) << "Could not find a /pkg/data directory for "
-                    << package.resolved_url;
+    FML_LOG(ERROR) << "Could not find a /pkg/data directory for "
+                   << package.resolved_url;
     return;
   }
 
@@ -170,7 +170,7 @@ ComponentV1::ComponentV1(
 
     zx_handle_t dir_handle = dir.release();
     if (fdio_ns_bind(fdio_ns_.get(), path.data(), dir_handle) != ZX_OK) {
-      FML_DLOG(ERROR) << "Could not bind path to namespace: " << path;
+      FML_LOG(ERROR) << "Could not bind path to namespace: " << path;
       zx_handle_close(dir_handle);
     }
   }
@@ -543,7 +543,7 @@ void ComponentV1::CreateViewWithViewRef(
     fuchsia::ui::views::ViewRefControl control_ref,
     fuchsia::ui::views::ViewRef view_ref) {
   if (!svc_) {
-    FML_DLOG(ERROR)
+    FML_LOG(ERROR)
         << "Component incoming services was invalid when attempting to "
            "create a shell for a view provider request.";
     return;
@@ -570,7 +570,7 @@ void ComponentV1::CreateViewWithViewRef(
 
 void ComponentV1::CreateView2(fuchsia::ui::app::CreateView2Args view_args) {
   if (!svc_) {
-    FML_DLOG(ERROR)
+    FML_LOG(ERROR)
         << "Component incoming services was invalid when attempting to "
            "create a shell for a view provider request.";
     return;

--- a/shell/platform/fuchsia/flutter/component_v2.cc
+++ b/shell/platform/fuchsia/flutter/component_v2.cc
@@ -177,8 +177,8 @@ ComponentV2::ComponentV2(
   ProgramMetadata metadata = ParseProgramMetadata(start_info.program());
 
   if (metadata.data_path.empty()) {
-    FML_DLOG(ERROR) << "Could not find a /pkg/data directory for "
-                    << start_info.resolved_url();
+    FML_LOG(ERROR) << "Could not find a /pkg/data directory for "
+                   << start_info.resolved_url();
     return;
   }
 
@@ -198,8 +198,8 @@ ComponentV2::ComponentV2(
       // We should never receive namespace entries without a directory, but we
       // check it anyways to avoid crashing if we do.
       if (!entry.has_directory()) {
-        FML_DLOG(ERROR) << "Namespace entry at path (" << path
-                        << ") has no directory.";
+        FML_LOG(ERROR) << "Namespace entry at path (" << path
+                       << ") has no directory.";
         continue;
       }
 
@@ -214,7 +214,7 @@ ComponentV2::ComponentV2(
 
       zx_handle_t dir_handle = dir.release();
       if (fdio_ns_bind(fdio_ns_.get(), path.data(), dir_handle) != ZX_OK) {
-        FML_DLOG(ERROR) << "Could not bind path to namespace: " << path;
+        FML_LOG(ERROR) << "Could not bind path to namespace: " << path;
         zx_handle_close(dir_handle);
       }
     }
@@ -639,7 +639,7 @@ void ComponentV2::CreateViewWithViewRef(
     fuchsia::ui::views::ViewRefControl control_ref,
     fuchsia::ui::views::ViewRef view_ref) {
   if (!svc_) {
-    FML_DLOG(ERROR)
+    FML_LOG(ERROR)
         << "Component incoming services was invalid when attempting to "
            "create a shell for a view provider request.";
     return;
@@ -666,7 +666,7 @@ void ComponentV2::CreateViewWithViewRef(
 
 void ComponentV2::CreateView2(fuchsia::ui::app::CreateView2Args view_args) {
   if (!svc_) {
-    FML_DLOG(ERROR)
+    FML_LOG(ERROR)
         << "Component incoming services was invalid when attempting to "
            "create a shell for a view provider request.";
     return;

--- a/shell/platform/fuchsia/flutter/engine.cc
+++ b/shell/platform/fuchsia/flutter/engine.cc
@@ -715,13 +715,9 @@ void Engine::OnMainIsolateStart() {
     FML_LOG(ERROR) << "Could not configure some native embedder bindings for a "
                       "new root isolate.";
   }
-  FML_DLOG(INFO) << "Main isolate for engine '" << thread_label_
-                 << "' was started.";
 }
 
 void Engine::OnMainIsolateShutdown() {
-  FML_DLOG(INFO) << "Main isolate for engine '" << thread_label_
-                 << "' shutting down.";
   Terminate();
 }
 

--- a/shell/platform/fuchsia/flutter/flatland_external_view_embedder.cc
+++ b/shell/platform/fuchsia/flutter/flatland_external_view_embedder.cc
@@ -35,7 +35,7 @@ FlatlandExternalViewEmbedder::~FlatlandExternalViewEmbedder() = default;
 SkCanvas* FlatlandExternalViewEmbedder::GetRootCanvas() {
   auto found = frame_layers_.find(kRootLayerId);
   if (found == frame_layers_.end()) {
-    FML_DLOG(WARNING)
+    FML_LOG(WARNING)
         << "No root canvas could be found. This is extremely unlikely and "
            "indicates that the external view embedder did not receive the "
            "notification to begin the frame.";

--- a/shell/platform/fuchsia/flutter/gfx_external_view_embedder.cc
+++ b/shell/platform/fuchsia/flutter/gfx_external_view_embedder.cc
@@ -142,7 +142,7 @@ GfxExternalViewEmbedder::~GfxExternalViewEmbedder() = default;
 SkCanvas* GfxExternalViewEmbedder::GetRootCanvas() {
   auto found = frame_layers_.find(kRootLayerId);
   if (found == frame_layers_.end()) {
-    FML_DLOG(WARNING)
+    FML_LOG(WARNING)
         << "No root canvas could be found. This is extremely unlikely and "
            "indicates that the external view embedder did not receive the "
            "notification to begin the frame.";

--- a/shell/platform/fuchsia/flutter/gfx_platform_view.cc
+++ b/shell/platform/fuchsia/flutter/gfx_platform_view.cc
@@ -84,7 +84,7 @@ void GfxPlatformView::OnScenicEvent(
                 event.gfx().metrics().metrics;
             const float new_view_pixel_ratio = metrics.scale_x;
             if (new_view_pixel_ratio <= 0.f) {
-              FML_DLOG(ERROR)
+              FML_LOG(ERROR)
                   << "Got an invalid pixel ratio from Scenic; ignoring: "
                   << new_view_pixel_ratio;
               break;
@@ -94,9 +94,6 @@ void GfxPlatformView::OnScenicEvent(
             // expensive.
             if (view_pixel_ratio_.has_value() &&
                 *view_pixel_ratio_ == new_view_pixel_ratio) {
-              FML_DLOG(ERROR)
-                  << "Got an identical pixel ratio from Scenic; ignoring: "
-                  << new_view_pixel_ratio;
               break;
             }
 
@@ -111,7 +108,7 @@ void GfxPlatformView::OnScenicEvent(
                 std::max(bounding_box.max.x - bounding_box.min.x, 0.0f),
                 std::max(bounding_box.max.y - bounding_box.min.y, 0.0f)};
             if (new_view_size[0] <= 0.f || new_view_size[1] <= 0.f) {
-              FML_DLOG(ERROR)
+              FML_LOG(ERROR)
                   << "Got an invalid view size from Scenic; ignoring: "
                   << new_view_size[0] << " " << new_view_size[1];
               break;
@@ -121,9 +118,6 @@ void GfxPlatformView::OnScenicEvent(
             // expensive.
             if (view_logical_size_.has_value() &&
                 *view_logical_size_ == new_view_size) {
-              FML_DLOG(ERROR)
-                  << "Got an identical view size from Scenic; ignoring: "
-                  << new_view_size[0] << " " << new_view_size[1];
               break;
             }
 

--- a/shell/platform/fuchsia/flutter/main.cc
+++ b/shell/platform/fuchsia/flutter/main.cc
@@ -43,8 +43,6 @@ int main(int argc, char const* argv[]) {
   // Set up the process-wide /tmp memfs.
   dart_utils::RunnerTemp runner_temp;
 
-  FML_DLOG(INFO) << "Flutter application services initialized.";
-
   fml::MessageLoop& loop = fml::MessageLoop::GetCurrent();
   flutter_runner::Runner runner(loop.GetTaskRunner(), context.get());
 
@@ -52,7 +50,6 @@ int main(int argc, char const* argv[]) {
   context->outgoing()->ServeFromStartupInfo();
 
   loop.Run();
-  FML_DLOG(INFO) << "Flutter application services terminated.";
 
   return EXIT_SUCCESS;
 }

--- a/shell/platform/fuchsia/flutter/platform_view.cc
+++ b/shell/platform/fuchsia/flutter/platform_view.cc
@@ -365,17 +365,17 @@ bool PlatformView::OnHandlePointerEvent(
       break;
     case flutter::PointerData::Change::kAdd:
       if (down_pointers_.count(pointer_data.device) != 0) {
-        FML_DLOG(ERROR) << "Received add event for down pointer.";
+        FML_LOG(ERROR) << "Received add event for down pointer.";
       }
       break;
     case flutter::PointerData::Change::kRemove:
       if (down_pointers_.count(pointer_data.device) != 0) {
-        FML_DLOG(ERROR) << "Received remove event for down pointer.";
+        FML_LOG(ERROR) << "Received remove event for down pointer.";
       }
       break;
     case flutter::PointerData::Change::kHover:
       if (down_pointers_.count(pointer_data.device) != 0) {
-        FML_DLOG(ERROR) << "Received hover event for down pointer.";
+        FML_LOG(ERROR) << "Received hover event for down pointer.";
       }
       break;
     case flutter::PointerData::Change::kPanZoomStart:
@@ -411,7 +411,7 @@ void PlatformView::OnKeyEvent(
       break;
   }
   if (type == nullptr) {
-    FML_DLOG(ERROR) << "Unknown key event phase.";
+    FML_LOG(ERROR) << "Unknown key event phase.";
     callback(fuchsia::ui::input3::KeyEventStatus::NOT_HANDLED);
     return;
   }
@@ -658,8 +658,8 @@ bool PlatformView::HandleFlutterTextInputChannelPlatformMessage(
     last_text_state_ = nullptr;
     DeactivateIme();
   } else {
-    FML_DLOG(ERROR) << "Unknown " << message->channel() << " method "
-                    << method->value.GetString();
+    FML_LOG(ERROR) << "Unknown " << message->channel() << " method "
+                   << method->value.GetString();
   }
   // Complete with an empty response.
   return false;
@@ -832,7 +832,7 @@ bool PlatformView::HandleFlutterPlatformViewsChannelPlatformMessage(
   } else if (method.rfind("View.focus", 0) == 0) {
     return focus_delegate_->HandlePlatformMessage(root, message->response());
   } else {
-    FML_DLOG(ERROR) << "Unknown " << message->channel() << " method " << method;
+    FML_LOG(ERROR) << "Unknown " << message->channel() << " method " << method;
   }
   // Complete with an empty response by default.
   return false;


### PR DESCRIPTION
FML_DLOG only works on unoptimized builds (fxb/93877)
but our Flutter runner is never built in
unoptimized mode, so we miss out on a lot of error logs as a result. This
change allows developers to see those log messages without risk of
introducing performance regressions to dev builds of our Flutter runner
(and also I [need that unoptimized build for ASAN](https://flutter-review.googlesource.com/c/recipes/+/28562)).