### PR TITLE
Replace 'std::mutex' inside 'SyncSwitch' to 'fml::SharedMutex'

### DIFF
--- a/fml/synchronization/sync_switch.cc
+++ b/fml/synchronization/sync_switch.cc
@@ -18,10 +18,12 @@ SyncSwitch::Handlers& SyncSwitch::Handlers::SetIfFalse(
   return *this;
 }
 
-SyncSwitch::SyncSwitch(bool value) : value_(value) {}
+SyncSwitch::SyncSwitch(bool value)
+    : mutex_(std::unique_ptr<fml::SharedMutex>(fml::SharedMutex::Create())),
+      value_(value) {}
 
 void SyncSwitch::Execute(const SyncSwitch::Handlers& handlers) const {
-  std::scoped_lock guard(mutex_);
+  fml::SharedLock lock(*mutex_);
   if (value_) {
     handlers.true_handler();
   } else {
@@ -30,7 +32,7 @@ void SyncSwitch::Execute(const SyncSwitch::Handlers& handlers) const {
 }
 
 void SyncSwitch::SetSwitch(bool value) {
-  std::scoped_lock guard(mutex_);
+  fml::UniqueLock lock(*mutex_);
   value_ = value;
 }
 

--- a/fml/synchronization/sync_switch.h
+++ b/fml/synchronization/sync_switch.h
@@ -7,9 +7,10 @@
 
 #include <forward_list>
 #include <functional>
-#include <mutex>
+#include <memory>
 
 #include "flutter/fml/macros.h"
+#include "flutter/fml/synchronization/shared_mutex.h"
 
 namespace fml {
 
@@ -53,7 +54,7 @@ class SyncSwitch {
   void SetSwitch(bool value);
 
  private:
-  mutable std::mutex mutex_;
+  mutable std::unique_ptr<fml::SharedMutex> mutex_;
   bool value_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(SyncSwitch);


### PR DESCRIPTION
SyncSwitch will be used for both frame rasterization on the Raster thread and texture upload on the IO thread.

But SyncSwitch uses `std::mutex` internally, which means only one thread can access it at a time. This poses a potential risk to the performance of raster threads.

This PR proposes to change the `std::mutex` to a `fml::SharedMutex`.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

