### PR TITLE
[Win32] Eliminate use of OpenGL ES 3.1 symbols

### DIFF
--- a/shell/platform/windows/external_texture_gl.cc
+++ b/shell/platform/windows/external_texture_gl.cc
@@ -36,7 +36,7 @@ bool ExternalTextureGL::PopulateTexture(size_t width,
   // Populate the texture object used by the engine.
   opengl_texture->target = GL_TEXTURE_2D;
   opengl_texture->name = state_->gl_texture;
-  opengl_texture->format = GL_RGBA8;
+  opengl_texture->format = GL_RGBA;
   opengl_texture->destruction_callback = nullptr;
   opengl_texture->user_data = nullptr;
   opengl_texture->width = width;
@@ -58,10 +58,8 @@ bool ExternalTextureGL::CopyPixelBuffer(size_t& width, size_t& height) {
     gl_.glGenTextures(1, &state_->gl_texture);
 
     gl_.glBindTexture(GL_TEXTURE_2D, state_->gl_texture);
-
-    gl_.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
-    gl_.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
-
+    gl_.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    gl_.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
     gl_.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     gl_.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 


### PR DESCRIPTION
In ANGLE commit [232e523656fccfacabeb8e5ce0cbc2e6dcc1ec4e][1], an Open GL
extension API was removed from ANGLE which included several symbols that
are not available until OpenGL ES 3.2. This was removed since it had no
known users, and cut the number of entrypoints ANGLE exports in half,
saving 130kB on Android.

Of the removed symbols, the Windows embedder used two:
* GL_RGBA8, which is not OpenGL ES, but rather OpenGL, and can be
  replaced with GL_RGBA which is lenient since it doesn't ask for a
  specific size.
* GL_CLAMP_TO_BORDER, which can be replaced with GL_CLAMP_TO_EDGE.
  https://open.gl/textures for details.

Issue: https://github.com/flutter/flutter/issues/102117

No test changes since no behavioural changes expected. This is purely to
unblock an ANGLE roll which would otherwise have compile errors.

[1]: https://chromium.googlesource.com/angle/angle/+/232e523656fccfacabeb8e5ce0cbc2e6dcc1ec4e

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
