### PR TITLE
[web] move some vector functions into vector_math.dart

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_canvas.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_canvas.dart
@@ -6,8 +6,8 @@ import 'dart:typed_data';
 
 import 'package:ui/ui.dart' as ui;
 
-import '../../engine.dart' show toMatrix32;
 import '../validators.dart';
+import '../vector_math.dart';
 import 'canvas.dart';
 import 'canvaskit_api.dart';
 import 'image.dart';

--- a/lib/web_ui/lib/src/engine/canvaskit/layer_scene_builder.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/layer_scene_builder.dart
@@ -6,7 +6,6 @@ import 'dart:typed_data';
 
 import 'package:ui/ui.dart' as ui;
 
-import '../../engine.dart' show toMatrix32;
 import '../vector_math.dart';
 import 'layer.dart';
 import 'layer_tree.dart';

--- a/lib/web_ui/lib/src/engine/html/canvas.dart
+++ b/lib/web_ui/lib/src/engine/html/canvas.dart
@@ -7,10 +7,10 @@ import 'dart:typed_data';
 
 import 'package:ui/ui.dart' as ui;
 
-import '../../engine.dart' show toMatrix32;
 import '../picture.dart';
 import '../util.dart';
 import '../validators.dart';
+import '../vector_math.dart';
 import 'painting.dart';
 import 'recording_canvas.dart';
 import 'render_vertices.dart';

--- a/lib/web_ui/lib/src/engine/html/path/path.dart
+++ b/lib/web_ui/lib/src/engine/html/path/path.dart
@@ -7,9 +7,9 @@ import 'dart:typed_data';
 
 import 'package:ui/ui.dart' as ui;
 
-import '../../../engine.dart' show toMatrix32;
 import '../../util.dart';
 import '../../validators.dart';
+import '../../vector_math.dart';
 import 'conic.dart';
 import 'cubic.dart';
 import 'path_iterator.dart';

--- a/lib/web_ui/lib/src/engine/html/scene_builder.dart
+++ b/lib/web_ui/lib/src/engine/html/scene_builder.dart
@@ -6,7 +6,7 @@ import 'dart:typed_data';
 
 import 'package:ui/ui.dart' as ui;
 
-import '../../engine.dart' show kProfileApplyFrame, kProfilePrerollFrame, toMatrix32;
+import '../../engine.dart' show kProfileApplyFrame, kProfilePrerollFrame;
 import '../picture.dart';
 import '../profiler.dart';
 import '../util.dart';

--- a/lib/web_ui/lib/src/engine/initialization.dart
+++ b/lib/web_ui/lib/src/engine/initialization.dart
@@ -318,39 +318,3 @@ void _addUrlStrategyListener() {
 /// rendering of PlatformViews into the web app.
 // TODO(dit): How to make this overridable from tests?
 final PlatformViewManager platformViewManager = PlatformViewManager();
-
-// TODO(yjbanov): this does not belong here.
-//                https://github.com/flutter/flutter/issues/100394
-
-/// Converts a matrix represented using [Float64List] to one represented using
-/// [Float32List].
-///
-/// 32-bit precision is sufficient because Flutter Engine itself (as well as
-/// Skia) use 32-bit precision under the hood anyway.
-///
-/// 32-bit matrices require 2x less memory and in V8 they are allocated on the
-/// JavaScript heap, thus avoiding a malloc.
-///
-/// See also:
-/// * https://bugs.chromium.org/p/v8/issues/detail?id=9199
-/// * https://bugs.chromium.org/p/v8/issues/detail?id=2022
-Float32List toMatrix32(Float64List matrix64) {
-  final Float32List matrix32 = Float32List(16);
-  matrix32[15] = matrix64[15];
-  matrix32[14] = matrix64[14];
-  matrix32[13] = matrix64[13];
-  matrix32[12] = matrix64[12];
-  matrix32[11] = matrix64[11];
-  matrix32[10] = matrix64[10];
-  matrix32[9] = matrix64[9];
-  matrix32[8] = matrix64[8];
-  matrix32[7] = matrix64[7];
-  matrix32[6] = matrix64[6];
-  matrix32[5] = matrix64[5];
-  matrix32[4] = matrix64[4];
-  matrix32[3] = matrix64[3];
-  matrix32[2] = matrix64[2];
-  matrix32[1] = matrix64[1];
-  matrix32[0] = matrix64[0];
-  return matrix32;
-}

--- a/lib/web_ui/lib/src/engine/initialization.dart
+++ b/lib/web_ui/lib/src/engine/initialization.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 import 'dart:developer' as developer;
 import 'dart:html' as html;
-import 'dart:typed_data';
 
 import 'package:ui/src/engine/assets.dart';
 import 'package:ui/src/engine/browser_detection.dart';

--- a/lib/web_ui/lib/src/engine/util.dart
+++ b/lib/web_ui/lib/src/engine/util.dart
@@ -499,24 +499,6 @@ void applyWebkitClipFix(html.Element? containerElement) {
   }
 }
 
-// Stores matrix in a form that allows zero allocation transforms.
-class FastMatrix32 {
-  final Float32List matrix;
-  double transformedX = 0, transformedY = 0;
-  FastMatrix32(this.matrix);
-
-  void transform(double x, double y) {
-    transformedX = matrix[12] + (matrix[0] * x) + (matrix[4] * y);
-    transformedY = matrix[13] + (matrix[1] * x) + (matrix[5] * y);
-  }
-
-  String debugToString() =>
-      '${matrix[0].toStringAsFixed(3)}, ${matrix[4].toStringAsFixed(3)}, ${matrix[8].toStringAsFixed(3)}, ${matrix[12].toStringAsFixed(3)}\n'
-      '${matrix[1].toStringAsFixed(3)}, ${matrix[5].toStringAsFixed(3)}, ${matrix[9].toStringAsFixed(3)}, ${matrix[13].toStringAsFixed(3)}\n'
-      '${matrix[2].toStringAsFixed(3)}, ${matrix[6].toStringAsFixed(3)}, ${matrix[10].toStringAsFixed(3)}, ${matrix[14].toStringAsFixed(3)}\n'
-      '${matrix[3].toStringAsFixed(3)}, ${matrix[7].toStringAsFixed(3)}, ${matrix[11].toStringAsFixed(3)}, ${matrix[15].toStringAsFixed(3)}\n';
-}
-
 /// Roughly the inverse of [ui.Shadow.convertRadiusToSigma].
 ///
 /// This does not inverse [ui.Shadow.convertRadiusToSigma] exactly, because on

--- a/lib/web_ui/test/engine/semantics/semantics_tester.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_tester.dart
@@ -7,8 +7,8 @@ import 'dart:html' as html;
 import 'dart:typed_data';
 
 import 'package:test/test.dart';
-import 'package:ui/src/engine.dart' show flutterViewEmbedder, toMatrix32;
 import 'package:ui/src/engine/browser_detection.dart';
+import 'package:ui/src/engine/embedder.dart';
 import 'package:ui/src/engine/host_node.dart';
 import 'package:ui/src/engine/semantics.dart';
 import 'package:ui/src/engine/util.dart';

--- a/lib/web_ui/test/engine/vector_math_test.dart
+++ b/lib/web_ui/test/engine/vector_math_test.dart
@@ -1,0 +1,45 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:typed_data';
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+
+import 'package:ui/src/engine/vector_math.dart';
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+void testMain() {
+  test('toMatrix32', () {
+    final List<double> data = <double>[
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
+    ];
+    final Float32List m32 = toMatrix32(Float64List.fromList(data));
+    expect(m32, Float32List.fromList(data));
+  });
+
+  test('FastMatrix32.transform', () {
+    final FastMatrix32 fast = FastMatrix32(Float32List.fromList(<double>[
+      2, 1, 0, 0,
+      1, 3, 0, 0,
+      0, 0, 0, 0,
+      4, 5, 0, 1
+    ]));
+    fast.transform(6, 7);
+
+    // Just make sure that the fast version produces a result consistent with
+    // the slow version.
+    final Matrix4 slow = Matrix4.fromFloat32List(fast.matrix);
+    final Float32List slowTransformed = Float32List.fromList(<double>[
+      6, 7, 0
+    ]);
+    slow.transform3(slowTransformed);
+
+    expect(fast.transformedX, slowTransformed[0]);
+    expect(fast.transformedY, slowTransformed[1]);
+  });
+}


### PR DESCRIPTION
Move `toMatrix32` and the (not so) `FastMatrix32` vector math utilities into the `vector_math.dart` library, where they belong.