### PR TITLE
Use dart pub subcommand in pub_get_offline.py

### DIFF
--- a/tools/pub_get_offline.py
+++ b/tools/pub_get_offline.py
@@ -65,10 +65,10 @@ def CheckPackage(package):
 
 def Main():
   leading = os.path.join("src", "third_party", "dart", "tools", "sdks", "dart-sdk", "bin")
-  pub = "pub"
+  dart = "dart"
   if os.name == "nt":
-    pub = "pub.bat"
-  pubcmd = [os.path.abspath(os.path.join(leading, pub)), "get", "--offline"]
+    dart = "dart.exe"
+  pubcmd = [os.path.abspath(os.path.join(leading, dart)), "pub", "get", "--offline"]
 
   pub_count = 0
   for package in ALL_PACKAGES:


### PR DESCRIPTION
Dart 2.17 doesn't have a `pub` command anymore.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
