### PR TITLE
Fix the CanvasPath::CreateNew signature to avoid unnecessary Dart API::NewError calls

### DIFF
--- a/lib/ui/painting/path.h
+++ b/lib/ui/painting/path.h
@@ -24,7 +24,7 @@ class CanvasPath : public RefCountedDartWrappable<CanvasPath> {
 
  public:
   ~CanvasPath() override;
-  static fml::RefPtr<CanvasPath> CreateNew(Dart_Handle path_handle) {
+  static fml::RefPtr<CanvasPath> CreateNew() {
     return fml::MakeRefCounted<CanvasPath>();
   }
 

--- a/third_party/tonic/converter/dart_converter.h
+++ b/third_party/tonic/converter/dart_converter.h
@@ -560,7 +560,9 @@ struct DartConverter<Dart_Handle> {
   static NativeType FromArguments(Dart_NativeArguments args,
                                   int index,
                                   Dart_Handle& exception) {
-    return Dart_GetNativeArgument(args, index);
+    Dart_Handle result = Dart_GetNativeArgument(args, index);
+    TONIC_DCHECK(!Dart_IsError(result));
+    return result;
   }
 
   static NativeType FromFfi(FfiType val) { return val; }


### PR DESCRIPTION
Tonic's DartCallConstructor calls Dart_GetNativeArgument based on the
indices of the arguments in the native function.  If the argument
count of the native function does not match that of the peer Dart
function, then this will result in failing Dart_GetNativeArgument calls.
The Dart runtime will then do potentially expensive work to construct
an error object that will be ignored.
