### PR TITLE
Add Menu.isPluginAvailable to allow query of whether menus are available on the platform.

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterMenuPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterMenuPlugin.mm
@@ -12,6 +12,7 @@
 
 // Channel constants
 static NSString* const kChannelName = @"flutter/menu";
+static NSString* const kIsPluginAvailableMethod = @"Menu.isPluginAvailable";
 static NSString* const kMenuSetMenusMethod = @"Menu.setMenus";
 static NSString* const kMenuSelectedCallbackMethod = @"Menu.selectedCallback";
 static NSString* const kMenuOpenedMethod = @"Menu.opened";
@@ -377,7 +378,9 @@ static NSEventModifierFlags KeyEquivalentModifierMaskForModifiers(NSNumber* modi
 }
 
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
-  if ([call.method isEqualToString:kMenuSetMenusMethod]) {
+  if ([call.method isEqualToString:kIsPluginAvailableMethod]) {
+    result(@YES);
+  } else if ([call.method isEqualToString:kMenuSetMenusMethod]) {
     NSDictionary* menus = call.arguments;
     [self setMenus:menus];
     result(nil);

--- a/shell/platform/darwin/macos/framework/Source/FlutterMenuPluginTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterMenuPluginTest.mm
@@ -106,6 +106,15 @@
     ],
   };
 
+  __block id available = @NO;
+  [plugin handleMethodCall:[FlutterMethodCall methodCallWithMethodName:@"Menu.isPluginAvailable"
+                                                             arguments:nil]
+                    result:^(id _Nullable result) {
+                      available = result;
+                    }];
+
+  EXPECT_TRUE(available);
+
   [plugin handleMethodCall:[FlutterMethodCall methodCallWithMethodName:@"Menu.setMenus"
                                                              arguments:testMenus]
                     result:^(id _Nullable result){


### PR DESCRIPTION
## Description

Added a "Menu.isPluginAvailable" call to allow the framework to query whether a plugin for creating platform menus is available on the current platform.

This will allow the framework `MenuBar.adaptive` constructor to determine, based on the availability on the platform of the plugin, whether or not to render platform menus.  This replaces the old way, which was just to hard code which platforms support it (i.e. just macOS), but that won't work well if someone adds a plugin that supports a particular platform that isn't macOS.

## Tests
 - Added a test to make sure that `Menu.isPluginAvailable` returns true when called.