### PR TITLE
[fuchsia][a11y] Implements flow control for semantics. 

### DIFF
--- a/shell/platform/fuchsia/flutter/flutter_runner_fakes.h
+++ b/shell/platform/fuchsia/flutter/flutter_runner_fakes.h
@@ -78,6 +78,18 @@ class MockSemanticsManager
   int UpdateCount() const { return update_count_; }
   bool UpdateOverflowed() const { return update_overflowed_; }
 
+  bool ShouldHoldCommitResponse() const { return should_hold_commit_response_; }
+
+  void SetShouldHoldCommitResponse(bool value) {
+    should_hold_commit_response_ = value;
+  }
+
+  void InvokeCommitCallback() {
+    if (commit_callback_) {
+      commit_callback_();
+    }
+  }
+
   int CommitCount() const { return commit_count_; }
 
   const std::vector<fuchsia::accessibility::semantics::Node>& LastUpdatedNodes()
@@ -87,6 +99,11 @@ class MockSemanticsManager
 
   void CommitUpdates(CommitUpdatesCallback callback) override {
     commit_count_++;
+    if (should_hold_commit_response_) {
+      commit_callback_ = std::move(callback);
+      return;
+    }
+    callback();
   }
 
   void SendSemanticEvent(
@@ -112,6 +129,8 @@ class MockSemanticsManager
   int delete_count_;
   bool delete_overflowed_;
   std::vector<uint32_t> last_deleted_node_ids_;
+  bool should_hold_commit_response_ = false;
+  CommitUpdatesCallback commit_callback_;
   int commit_count_;
   std::vector<fuchsia::accessibility::semantics::SemanticEvent> last_events_;
 };


### PR DESCRIPTION
*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*
- In change description.
*List which issues are fixed by this PR. You must list at least one issue.*
https://bugs.fuchsia.dev/p/fuchsia/issues/detail?id=97596
*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
