### PR TITLE
Remove redundant trace events

### DIFF
--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -511,10 +511,7 @@ void RasterCache::SweepOneCacheAfterFrame(RasterCacheKey::Map<Entry>& cache,
 void RasterCache::CleanupAfterFrame() {
   picture_metrics_ = {};
   layer_metrics_ = {};
-  {
-    TRACE_EVENT0("flutter", "RasterCache::SweepCaches");
-    SweepOneCacheAfterFrame(cache_, picture_metrics_, layer_metrics_);
-  }
+  SweepOneCacheAfterFrame(cache_, picture_metrics_, layer_metrics_);
   TraceStatsToTimeline();
 }
 

--- a/fml/message_loop_impl.cc
+++ b/fml/message_loop_impl.cc
@@ -11,7 +11,6 @@
 
 #include "flutter/fml/build_config.h"
 #include "flutter/fml/logging.h"
-#include "flutter/fml/trace_event.h"
 
 #if FML_OS_MACOSX
 #include "flutter/fml/platform/darwin/message_loop_darwin.h"
@@ -118,8 +117,6 @@ void MessageLoopImpl::DoTerminate() {
 }
 
 void MessageLoopImpl::FlushTasks(FlushType type) {
-  TRACE_EVENT0("fml", "MessageLoop::FlushTasks");
-
   const auto now = fml::TimePoint::Now();
   fml::closure invocation;
   do {

--- a/lib/ui/volatile_path_tracker.cc
+++ b/lib/ui/volatile_path_tracker.cc
@@ -27,13 +27,6 @@ void VolatilePathTracker::OnFrame() {
   if (!enabled_) {
     return;
   }
-#if !FLUTTER_RELEASE
-  std::string total_count = std::to_string(paths_.size());
-  TRACE_EVENT1("flutter", "VolatilePathTracker::OnFrame", "total_count",
-               total_count.c_str());
-#else
-  TRACE_EVENT0("flutter", "VolatilePathTracker::OnFrame");
-#endif
 
   paths_.erase(std::remove_if(paths_.begin(), paths_.end(),
                               [](std::weak_ptr<TrackedPath> weak_path) {
@@ -50,12 +43,6 @@ void VolatilePathTracker::OnFrame() {
                                 return false;
                               }),
                paths_.end());
-
-#if !FLUTTER_RELEASE
-  std::string post_removal_count = std::to_string(paths_.size());
-  TRACE_EVENT_INSTANT1("flutter", "VolatilePathTracker::OnFrame",
-                       "remaining_count", post_removal_count.c_str());
-#endif
 }
 
 }  // namespace flutter

--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -227,8 +227,7 @@ bool RuntimeController::NotifyIdle(fml::TimePoint deadline) {
 bool RuntimeController::DispatchPlatformMessage(
     std::unique_ptr<PlatformMessage> message) {
   if (auto* platform_configuration = GetPlatformConfigurationIfAvailable()) {
-    TRACE_EVENT1("flutter", "RuntimeController::DispatchPlatformMessage",
-                 "mode", "basic");
+    TRACE_EVENT0("flutter", "RuntimeController::DispatchPlatformMessage");
     platform_configuration->DispatchPlatformMessage(std::move(message));
     return true;
   }
@@ -239,8 +238,7 @@ bool RuntimeController::DispatchPlatformMessage(
 bool RuntimeController::DispatchPointerDataPacket(
     const PointerDataPacket& packet) {
   if (auto* platform_configuration = GetPlatformConfigurationIfAvailable()) {
-    TRACE_EVENT1("flutter", "RuntimeController::DispatchPointerDataPacket",
-                 "mode", "basic");
+    TRACE_EVENT0("flutter", "RuntimeController::DispatchPointerDataPacket");
     platform_configuration->get_window(0)->DispatchPointerDataPacket(packet);
     return true;
   }

--- a/shell/common/animator.cc
+++ b/shell/common/animator.cc
@@ -57,16 +57,6 @@ void Animator::EnqueueTraceFlowId(uint64_t trace_flow_id) {
       });
 }
 
-// This Parity is used by the timeline component to correctly align
-// GPU Workloads events with their respective Framework Workload.
-const char* Animator::FrameParity() {
-  if (!frame_timings_recorder_) {
-    return "even";
-  }
-  uint64_t frame_number = frame_timings_recorder_->GetFrameNumber();
-  return (frame_number % 2) ? "even" : "odd";
-}
-
 static fml::TimePoint FxlToDartOrEarlier(fml::TimePoint time) {
   auto dart_now = fml::TimeDelta::FromMicroseconds(Dart_TimelineGetMicros());
   fml::TimePoint fxl_now = fml::TimePoint::Now();
@@ -121,12 +111,8 @@ void Animator::BeginFrame(
   const fml::TimePoint frame_target_time =
       frame_timings_recorder_->GetVsyncTargetTime();
   dart_frame_deadline_ = FxlToDartOrEarlier(frame_target_time);
-  {
-    TRACE_EVENT2("flutter", "Framework Workload", "mode", "basic", "frame",
-                 FrameParity());
-    uint64_t frame_number = frame_timings_recorder_->GetFrameNumber();
-    delegate_.OnAnimatorBeginFrame(frame_target_time, frame_number);
-  }
+  uint64_t frame_number = frame_timings_recorder_->GetFrameNumber();
+  delegate_.OnAnimatorBeginFrame(frame_target_time, frame_number);
 
   if (!frame_scheduled_ && has_rendered_) {
     // Under certain workloads (such as our parent view resizing us, which is

--- a/shell/common/animator.h
+++ b/shell/common/animator.h
@@ -94,8 +94,6 @@ class Animator final {
 
   void AwaitVSync();
 
-  const char* FrameParity();
-
   // Clear |trace_flow_ids_| if |frame_scheduled_| is false.
   void ScheduleMaybeClearTraceFlowIds();
 

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -244,7 +244,6 @@ Engine::RunStatus Engine::Run(RunConfiguration configuration) {
 }
 
 void Engine::BeginFrame(fml::TimePoint frame_time, uint64_t frame_number) {
-  TRACE_EVENT0("flutter", "Engine::BeginFrame");
   runtime_controller_->BeginFrame(frame_time, frame_number);
 }
 

--- a/shell/common/pipeline.h
+++ b/shell/common/pipeline.h
@@ -165,10 +165,7 @@ class Pipeline {
       items_count = queue_.size();
     }
 
-    {
-      TRACE_EVENT0("flutter", "PipelineConsume");
-      consumer(std::move(resource));
-    }
+    consumer(std::move(resource));
 
     empty_.Signal();
     --inflight_;

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -492,7 +492,6 @@ RasterStatus Rasterizer::DoDraw(
 RasterStatus Rasterizer::DrawToSurface(
     FrameTimingsRecorder& frame_timings_recorder,
     flutter::LayerTree& layer_tree) {
-  TRACE_EVENT0("flutter", "Rasterizer::DrawToSurface");
   FML_DCHECK(surface_);
 
   RasterStatus raster_status;
@@ -517,7 +516,6 @@ RasterStatus Rasterizer::DrawToSurface(
 RasterStatus Rasterizer::DrawToSurfaceUnsafe(
     FrameTimingsRecorder& frame_timings_recorder,
     flutter::LayerTree& layer_tree) {
-  TRACE_EVENT0("flutter", "Rasterizer::DrawToSurfaceUnsafe");
   FML_DCHECK(surface_);
 
   compositor_context_->ui_time().SetLapTime(
@@ -629,7 +627,6 @@ RasterStatus Rasterizer::DrawToSurfaceUnsafe(
     FireNextFrameCallbackIfPresent();
 
     if (surface_->GetContext()) {
-      TRACE_EVENT0("flutter", "PerformDeferredSkiaCleanup");
       surface_->GetContext()->performDeferredCleanup(kSkiaCleanupExpiration);
     }
 


### PR DESCRIPTION
Removes a number of tracing events that are redundant.

Removes all `"mode", "basic"` tracing information, which is related to https://github.com/flutter/flutter/pull/101382.

Removes the one instance of using tracing from FML, which should make it easier to detangle FML from the Dart VM and resolve issues like https://github.com/flutter/flutter/issues/101866

/cc @arbreng - can you help verify that Fuchsia does not depend on these events for performance tracing?
/cc @kenzieschmoll FYI
/cc @zanderso fyi

I think this makes more sense to request a test exemption for (deleting code) rather than trying to write tests that assert we don't add these back. I anticipate this will make small positive differences in benchmarks upstream.