### PR TITLE
iOS: A11y only disable during app resigning to background when voice over on

### DIFF
--- a/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h
@@ -180,6 +180,14 @@ FLUTTER_DARWIN_EXPORT
 - (id<FlutterPluginRegistry>)pluginRegistry;
 
 /**
+ * A wrapper around UIAccessibilityIsVoiceOverRunning().
+ *
+ * As a C function, UIAccessibilityIsVoiceOverRunning() cannot be mocked in testing. Mock
+ * this class method to testing features depends on UIAccessibilityIsVoiceOverRunning().
+ */
++ (BOOL)isUIAccessibilityIsVoiceOverRunning;
+
+/**
  * True if at least one frame has rendered and the ViewController has appeared.
  *
  * This property is reset to false when the ViewController disappears. It is

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -826,7 +826,9 @@ static void SendFakeTouchEvent(FlutterEngine* engine,
 
 - (void)applicationWillResignActive:(NSNotification*)notification {
   TRACE_EVENT0("flutter", "applicationWillResignActive");
-  self.view.accessibilityElementsHidden = YES;
+  if ([FlutterViewController isUIAccessibilityIsVoiceOverRunning]) {
+    self.view.accessibilityElementsHidden = YES;
+  }
   [self goToApplicationLifecycle:@"AppLifecycleState.inactive"];
 }
 
@@ -1716,6 +1718,10 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 
 - (id<FlutterPluginRegistry>)pluginRegistry {
   return _engine;
+}
+
++ (BOOL)isUIAccessibilityIsVoiceOverRunning {
+  return UIAccessibilityIsVoiceOverRunning();
 }
 
 #pragma mark - FlutterPluginRegistry

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -939,6 +939,9 @@ typedef enum UIAccessibilityContrast : NSInteger {
   FlutterViewController* realVC = [[FlutterViewController alloc] initWithEngine:engine
                                                                         nibName:nil
                                                                          bundle:nil];
+  id flutterViewControllerClassMOCK = OCMClassMock([FlutterViewController class]);
+  OCMStub([flutterViewControllerClassMOCK isUIAccessibilityIsVoiceOverRunning]).andReturn(@YES);
+
   XCTAssertFalse(realVC.view.accessibilityElementsHidden);
   [[NSNotificationCenter defaultCenter]
       postNotificationName:UIApplicationWillResignActiveNotification
@@ -949,6 +952,32 @@ typedef enum UIAccessibilityContrast : NSInteger {
                     object:nil];
   XCTAssertFalse(realVC.view.accessibilityElementsHidden);
   engine.viewController = nil;
+
+  [flutterViewControllerClassMOCK stopMocking];
+}
+
+- (void)testDontHideA11yElementsWhenVoiceOverIsOff {
+  FlutterDartProject* project = [[FlutterDartProject alloc] init];
+  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"foobar" project:project];
+  [engine createShell:@"" libraryURI:@"" initialRoute:nil];
+  FlutterViewController* realVC = [[FlutterViewController alloc] initWithEngine:engine
+                                                                        nibName:nil
+                                                                         bundle:nil];
+  id flutterViewControllerClassMOCK = OCMClassMock([FlutterViewController class]);
+  OCMStub([flutterViewControllerClassMOCK isUIAccessibilityIsVoiceOverRunning]).andReturn(@NO);
+
+  XCTAssertFalse(realVC.view.accessibilityElementsHidden);
+  [[NSNotificationCenter defaultCenter]
+      postNotificationName:UIApplicationWillResignActiveNotification
+                    object:nil];
+  XCTAssertTrue(realVC.view.accessibilityElementsHidden);
+  [[NSNotificationCenter defaultCenter]
+      postNotificationName:UIApplicationDidBecomeActiveNotification
+                    object:nil];
+  XCTAssertFalse(realVC.view.accessibilityElementsHidden);
+  engine.viewController = nil;
+
+  [flutterViewControllerClassMOCK stopMocking];
 }
 
 - (void)testNotifyLowMemory {

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -940,7 +940,7 @@ typedef enum UIAccessibilityContrast : NSInteger {
                                                                         nibName:nil
                                                                          bundle:nil];
   id flutterViewControllerClassMOCK = OCMClassMock([FlutterViewController class]);
-  OCMStub([flutterViewControllerClassMOCK isUIAccessibilityIsVoiceOverRunning]).andReturn(@YES);
+  [[[flutterViewControllerClassMOCK stub] andReturnValue:@YES] isUIAccessibilityIsVoiceOverRunning];
 
   XCTAssertFalse(realVC.view.accessibilityElementsHidden);
   [[NSNotificationCenter defaultCenter]
@@ -964,13 +964,13 @@ typedef enum UIAccessibilityContrast : NSInteger {
                                                                         nibName:nil
                                                                          bundle:nil];
   id flutterViewControllerClassMOCK = OCMClassMock([FlutterViewController class]);
-  OCMStub([flutterViewControllerClassMOCK isUIAccessibilityIsVoiceOverRunning]).andReturn(@NO);
+  [[[flutterViewControllerClassMOCK stub] andReturnValue:@NO] isUIAccessibilityIsVoiceOverRunning];
 
   XCTAssertFalse(realVC.view.accessibilityElementsHidden);
   [[NSNotificationCenter defaultCenter]
       postNotificationName:UIApplicationWillResignActiveNotification
                     object:nil];
-  XCTAssertTrue(realVC.view.accessibilityElementsHidden);
+  XCTAssertFalse(realVC.view.accessibilityElementsHidden);
   [[NSNotificationCenter defaultCenter]
       postNotificationName:UIApplicationDidBecomeActiveNotification
                     object:nil];


### PR DESCRIPTION
This PR as another condition to when the accessibility is disabled. The new condition is when the voice over is on.

Disabling accessibility when app resigning to the background breaks XCUITests that contains a system popup. Because XCUITests uses accessibility but doesn't require the voice over feature to be on, we can keep the accessibility enabled while voice over is off so the tests would work again.

Fixes: https://github.com/flutter/flutter/issues/93504

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
