### PR TITLE
Minor unique_ptr initialization cleanup

### DIFF
--- a/lib/ui/window/platform_configuration.cc
+++ b/lib/ui/window/platform_configuration.cc
@@ -203,9 +203,8 @@ void PlatformConfiguration::DidCreateIsolate() {
                   Dart_GetField(library, tonic::ToDart("_drawFrame")));
   report_timings_.Set(tonic::DartState::Current(),
                       Dart_GetField(library, tonic::ToDart("_reportTimings")));
-  windows_.insert(
-      std::make_pair(0, std::unique_ptr<Window>(new Window{
-                            0, ViewportMetrics{1.0, 0.0, 0.0, -1}})));
+  windows_.insert(std::make_pair(
+      0, std::make_unique<Window>(0, ViewportMetrics{1.0, 0.0, 0.0, -1})));
 }
 
 void PlatformConfiguration::UpdateLocales(

--- a/shell/platform/windows/flutter_windows_texture_registrar_unittests.cc
+++ b/shell/platform/windows/flutter_windows_texture_registrar_unittests.cc
@@ -115,7 +115,8 @@ TEST(FlutterWindowsTextureRegistrarTest, PopulatePixelBufferTexture) {
   bool release_callback_called = false;
   size_t width = 100;
   size_t height = 100;
-  std::unique_ptr<uint8_t[]> pixels(new uint8_t[width * height * 4]);
+  std::unique_ptr<uint8_t[]> pixels =
+      std::make_unique<uint8_t[]>(width * height * 4);
   FlutterDesktopPixelBuffer pixel_buffer = {};
   pixel_buffer.width = width;
   pixel_buffer.height = height;

--- a/testing/test_vulkan_context.cc
+++ b/testing/test_vulkan_context.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include <cassert>
+#include <memory>
 #include <optional>
 
 #include "flutter/fml/logging.h"
@@ -50,10 +51,9 @@ TestVulkanContext::TestVulkanContext() {
     return;
   }
 
-  application_ =
-      std::unique_ptr<vulkan::VulkanApplication>(new vulkan::VulkanApplication(
-          *vk_, "Flutter Unittests", {}, VK_MAKE_VERSION(1, 0, 0),
-          VK_MAKE_VERSION(1, 0, 0), true));
+  application_ = std::make_unique<vulkan::VulkanApplication>(
+      *vk_, "Flutter Unittests", std::vector<std::string>{},
+      VK_MAKE_VERSION(1, 0, 0), VK_MAKE_VERSION(1, 0, 0), true);
   if (!application_->IsValid()) {
     FML_LOG(ERROR) << "Failed to initialize basic Vulkan state.";
     return;

--- a/third_party/accessibility/base/string_utils.h
+++ b/third_party/accessibility/base/string_utils.h
@@ -18,7 +18,7 @@ template <typename... Args>
 std::string StringPrintf(const std::string& format, Args... args) {
   // Calculate the buffer size.
   int size = snprintf(nullptr, 0, format.c_str(), args...) + 1;
-  std::unique_ptr<char[]> buf(new char[size]);
+  std::unique_ptr<char[]> buf = std::make_unique<char[]>(size);
   snprintf(buf.get(), size, format.c_str(), args...);
   return std::string(buf.get(), buf.get() + size - 1);
 }

--- a/third_party/tonic/common/log.cc
+++ b/third_party/tonic/common/log.cc
@@ -27,7 +27,7 @@ void Log(const char* format, ...) {
   }
 
   int size = result + 1;
-  std::unique_ptr<char[]> message(new char[size]);
+  std::unique_ptr<char[]> message = std::make_unique<char[]>(size);
   va_start(ap, format);
   result = vsnprintf(message.get(), size, format, ap);
   va_end(ap);

--- a/third_party/txt/src/skia/paragraph_builder_skia.cc
+++ b/third_party/txt/src/skia/paragraph_builder_skia.cc
@@ -195,7 +195,7 @@ void ParagraphBuilderSkia::AddPlaceholder(PlaceholderRun& span) {
 }
 
 std::unique_ptr<Paragraph> ParagraphBuilderSkia::Build() {
-  return std::unique_ptr<Paragraph>(new ParagraphSkia(builder_->Build()));
+  return std::make_unique<ParagraphSkia>(builder_->Build());
 }
 
 }  // namespace txt

--- a/third_party/txt/tests/UnicodeUtils.cpp
+++ b/third_party/txt/tests/UnicodeUtils.cpp
@@ -95,7 +95,7 @@ void ParseUnicode(uint16_t* buf,
 
 std::vector<uint16_t> parseUnicodeStringWithOffset(const std::string& in,
                                                    size_t* offset) {
-  std::unique_ptr<uint16_t[]> buffer(new uint16_t[in.size()]);
+  std::unique_ptr<uint16_t[]> buffer = std::make_unique<uint16_t[]>(in.size());
   size_t result_size = 0;
   ParseUnicode(buffer.get(), in.size(), in.c_str(), &result_size, offset);
   return std::vector<uint16_t>(buffer.get(), buffer.get() + result_size);


### PR DESCRIPTION
Cleans up a few cases of std::unique_ptr(new T) that could have been
using std::make_unique<T>(...).

No tests since no semantic changes, just object allocation cleanup.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
