### PR TITLE
Set the VM's file callbacks.

### DIFF
--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -456,8 +456,12 @@ DartVM::DartVM(std::shared_ptr<const DartVMData> vm_data,
     params.cleanup_group = reinterpret_cast<decltype(params.cleanup_group)>(
         DartIsolate::DartIsolateGroupCleanupCallback);
     params.thread_exit = ThreadExitCallback;
-    params.get_service_assets = GetVMServiceAssetsArchiveCallback;
+    params.file_open = dart::bin::OpenFile;
+    params.file_read = dart::bin::ReadFile;
+    params.file_write = dart::bin::WriteFile;
+    params.file_close = dart::bin::CloseFile;
     params.entropy_source = dart::bin::GetEntropy;
+    params.get_service_assets = GetVMServiceAssetsArchiveCallback;
     DartVMInitializer::Initialize(&params,
                                   settings_.enable_timeline_event_handler);
     // Send the earliest available timestamp in the application lifecycle to


### PR DESCRIPTION
These are used to output various tracing enabled by VM flags.