### PR TITLE
Do not depend on Dart in FML

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -369,8 +369,6 @@ FILE: ../../../flutter/fml/thread_local_unittests.cc
 FILE: ../../../flutter/fml/thread_unittests.cc
 FILE: ../../../flutter/fml/time/chrono_timestamp_provider.cc
 FILE: ../../../flutter/fml/time/chrono_timestamp_provider.h
-FILE: ../../../flutter/fml/time/dart_timestamp_provider.cc
-FILE: ../../../flutter/fml/time/dart_timestamp_provider.h
 FILE: ../../../flutter/fml/time/time_delta.h
 FILE: ../../../flutter/fml/time/time_delta_unittest.cc
 FILE: ../../../flutter/fml/time/time_point.cc
@@ -1103,6 +1101,8 @@ FILE: ../../../flutter/runtime/dart_service_isolate.h
 FILE: ../../../flutter/runtime/dart_service_isolate_unittests.cc
 FILE: ../../../flutter/runtime/dart_snapshot.cc
 FILE: ../../../flutter/runtime/dart_snapshot.h
+FILE: ../../../flutter/runtime/dart_timestamp_provider.cc
+FILE: ../../../flutter/runtime/dart_timestamp_provider.h
 FILE: ../../../flutter/runtime/dart_vm.cc
 FILE: ../../../flutter/runtime/dart_vm.h
 FILE: ../../../flutter/runtime/dart_vm_data.cc

--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -84,8 +84,6 @@ source_set("fml") {
     "thread.h",
     "thread_local.cc",
     "thread_local.h",
-    "time/dart_timestamp_provider.cc",
-    "time/dart_timestamp_provider.h",
     "time/time_delta.h",
     "time/time_point.cc",
     "time/time_point.h",
@@ -110,9 +108,11 @@ source_set("fml") {
     ":string_conversion",
   ]
 
+  # Do not depend on Dart in FML. Otherwise, other libraries using it end up
+  # with a substantial dependency they do not necessarily need. Prefer to use
+  # dependency inversion instead.
   deps = [
     "//third_party/abseil-cpp/absl/debugging:symbolize",
-    "//third_party/dart/runtime:dart_api",
 
     # These need to be in sync with the Fuchsia buildroot.
     "//third_party/icu",
@@ -291,7 +291,6 @@ if (enable_unittests) {
     deps = [
       "//flutter/benchmarking",
       "//flutter/fml",
-      "//flutter/runtime:libdart",
     ]
   }
 
@@ -349,6 +348,7 @@ if (enable_unittests) {
       ":fml_fixtures",
       "//flutter/fml",
       "//flutter/fml/dart",
+      "//flutter/runtime",
       "//flutter/runtime:libdart",
       "//flutter/testing",
     ]

--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -108,11 +108,9 @@ source_set("fml") {
     ":string_conversion",
   ]
 
-  # Do not depend on Dart in FML. Otherwise, other libraries using it end up
-  # with a substantial dependency they do not necessarily need. Prefer to use
-  # dependency inversion instead.
   deps = [
     "//third_party/abseil-cpp/absl/debugging:symbolize",
+    "//third_party/dart/runtime:dart_api",
 
     # These need to be in sync with the Fuchsia buildroot.
     "//third_party/icu",

--- a/fml/time/time_point.cc
+++ b/fml/time/time_point.cc
@@ -28,6 +28,7 @@ TimePoint TimePoint::CurrentWallTime() {
   return Now();
 }
 
+void TimePoint::SetClockSource(ClockSource source) {}
 #else
 
 namespace {

--- a/fml/time/time_point.cc
+++ b/fml/time/time_point.cc
@@ -16,9 +16,7 @@
 #endif
 
 namespace fml {
-namespace {
-std::atomic<TimePoint::ClockSource> gSteadyClockSource;
-}
+
 #if defined(OS_FUCHSIA)
 
 // static
@@ -31,6 +29,10 @@ TimePoint TimePoint::CurrentWallTime() {
 }
 
 #else
+
+namespace {
+std::atomic<TimePoint::ClockSource> gSteadyClockSource;
+}
 
 template <typename Clock, typename Duration>
 static int64_t NanosSinceEpoch(

--- a/fml/time/time_point.h
+++ b/fml/time/time_point.h
@@ -6,6 +6,7 @@
 #define FLUTTER_FML_TIME_TIME_POINT_H_
 
 #include <cstdint>
+#include <functional>
 #include <iosfwd>
 
 #include "flutter/fml/time/time_delta.h"
@@ -20,8 +21,12 @@ namespace fml {
 // reboots.
 class TimePoint {
  public:
+  using ClockSource = TimePoint (*)();
+
   // Default TimePoint with internal value 0 (epoch).
   constexpr TimePoint() = default;
+
+  static void SetClockSource(ClockSource source);
 
   static TimePoint Now();
 

--- a/fml/time/time_point_unittest.cc
+++ b/fml/time/time_point_unittest.cc
@@ -4,7 +4,7 @@
 
 #include "flutter/fml/time/chrono_timestamp_provider.h"
 
-#include "flutter/fml/time/dart_timestamp_provider.h"
+#include "flutter/runtime/dart_timestamp_provider.h"
 
 #include <thread>
 
@@ -20,11 +20,11 @@ TEST(TimePoint, Control) {
 
 TEST(TimePoint, DartClockIsMonotonic) {
   using namespace std::chrono_literals;
-  const auto t1 = DartTimelineTicksSinceEpoch();
+  const auto t1 = flutter::DartTimelineTicksSinceEpoch();
   std::this_thread::sleep_for(1us);
-  const auto t2 = DartTimelineTicksSinceEpoch();
+  const auto t2 = flutter::DartTimelineTicksSinceEpoch();
   std::this_thread::sleep_for(1us);
-  const auto t3 = DartTimelineTicksSinceEpoch();
+  const auto t3 = flutter::DartTimelineTicksSinceEpoch();
   EXPECT_LT(TimePoint::Min(), t1);
   EXPECT_LE(t1, t2);
   EXPECT_LE(t2, t3);

--- a/fml/trace_event.h
+++ b/fml/trace_event.h
@@ -155,7 +155,11 @@ typedef void (*TimelineEventHandler)(const char*,
                                      const char**,
                                      const char**);
 
+using TimelineMicrosSource = int64_t (*)();
+
 void TraceSetTimelineEventHandler(TimelineEventHandler handler);
+
+void TraceSetTimelineMicrosSource(TimelineMicrosSource source);
 
 void TraceTimelineEvent(TraceArg category_group,
                         TraceArg name,

--- a/runtime/BUILD.gn
+++ b/runtime/BUILD.gn
@@ -57,6 +57,8 @@ source_set("runtime") {
     "dart_service_isolate.h",
     "dart_snapshot.cc",
     "dart_snapshot.h",
+    "dart_timestamp_provider.cc",
+    "dart_timestamp_provider.h",
     "dart_vm.cc",
     "dart_vm.h",
     "dart_vm_data.cc",

--- a/runtime/dart_timestamp_provider.cc
+++ b/runtime/dart_timestamp_provider.cc
@@ -2,11 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "flutter/fml/time/dart_timestamp_provider.h"
+#include "dart_timestamp_provider.h"
 
 #include "dart_tools_api.h"
 
-namespace fml {
+namespace flutter {
 
 DartTimestampProvider::DartTimestampProvider() = default;
 
@@ -35,4 +35,4 @@ fml::TimePoint DartTimelineTicksSinceEpoch() {
   return DartTimestampProvider::Instance().Now();
 }
 
-}  // namespace fml
+}  // namespace flutter

--- a/runtime/dart_timestamp_provider.h
+++ b/runtime/dart_timestamp_provider.h
@@ -2,20 +2,20 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_FML_TIME_DART_TIMESTAMP_PROVIDER_H_
-#define FLUTTER_FML_TIME_DART_TIMESTAMP_PROVIDER_H_
+#ifndef FLUTTER_RUNTIME_DART_TIMESTAMP_PROVIDER_H_
+#define FLUTTER_RUNTIME_DART_TIMESTAMP_PROVIDER_H_
 
 #include "flutter/fml/time/timestamp_provider.h"
 
 #include "flutter/fml/macros.h"
 #include "flutter/fml/time/time_point.h"
 
-namespace fml {
+namespace flutter {
 
 fml::TimePoint DartTimelineTicksSinceEpoch();
 
 /// TimestampProvider implementation that is backed by Dart_TimelineGetTicks
-class DartTimestampProvider : TimestampProvider {
+class DartTimestampProvider : fml::TimestampProvider {
  public:
   static DartTimestampProvider& Instance() {
     static DartTimestampProvider instance;
@@ -36,6 +36,6 @@ class DartTimestampProvider : TimestampProvider {
   FML_DISALLOW_COPY_AND_ASSIGN(DartTimestampProvider);
 };
 
-}  // namespace fml
+}  // namespace flutter
 
-#endif  // FLUTTER_FML_TIME_DART_TIMESTAMP_PROVIDER_H_
+#endif  // FLUTTER_RUNTIME_DART_TIMESTAMP_PROVIDER_H_

--- a/runtime/dart_vm_initializer.cc
+++ b/runtime/dart_vm_initializer.cc
@@ -14,6 +14,8 @@
 #include "third_party/tonic/converter/dart_converter.h"
 #include "third_party/tonic/logging/dart_error.h"
 
+#include "dart_timestamp_provider.h"
+
 namespace {
 // Tracks whether Dart has been initialized and if it is safe to call Dart
 // APIs.
@@ -88,7 +90,9 @@ void DartVMInitializer::Initialize(Dart_InitializeParams* params) {
     gDartInitialized = true;
   }
 
+  fml::TimePoint::SetClockSource(flutter::DartTimelineTicksSinceEpoch);
   fml::tracing::TraceSetTimelineEventHandler(LogDartTimelineEvent);
+  fml::tracing::TraceSetTimelineMicrosSource(Dart_TimelineGetMicros);
   tonic::SetUnhandledExceptionReporter(&ReportUnhandledException);
 }
 


### PR DESCRIPTION
Allows us to fix https://github.com/flutter/flutter/issues/101866

Does the following:

- Moves DartTimestampProvider to `//flutter/runtime`.
- Installs that provider as the one to use for `fml::TimePoint::Now` when we initialize the Dart VM, falls back to stdlib's monotonic clock otherwise.
- Removes direct calls to `Dart_TimelineGetMicros` and instead installs that as a callback when we initialize the Dart VM.

Verified locally that this allows successful builds of impeller without dependencies on the Dart VM.