### PR TITLE
Reland "Update Web Engine to use Mac-12."

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -327,16 +327,21 @@ targets:
       caches: >-
         [
           {"name":"flutter_cocoapods","path":"cocoapods"},
-          {"name":"old_osx_sdk","path":"osx_sdk"},
+          {"name":"osx_sdk_13a233_13_15","path":"osx_sdk"},
           {"name":"builder_mac_engine","path":"builder"},
-          {"name":"openjdk","path":"java"}
+          {"name":"openjdk","path":"java"},
+          {"name":"xcode_runtime_ios_13_0","path":"xcode_runtime_ios_13_0"},
+          {"name":"xcode_runtime_ios_15_0","path":"xcode_runtime_ios_15_0"}
         ]
       dependencies: >-
         [
           {"dependency": "goldctl"}
         ]
-      os: Mac-10.15
-      xcode: 12c33 # xcode 12.3
+      runtime_versions: >-
+        [
+          "ios-13-0",
+          "ios-15-0"
+        ]
     timeout: 60
     runIf:
       - DEPS


### PR DESCRIPTION
Reverts flutter/engine#32632

The timeout issue was being caused by a different problem that has already been fixed.