### PR TITLE
Reland: simplify the logic around computing subtree opacity inheritance

### DIFF
--- a/display_list/display_list_builder.cc
+++ b/display_list/display_list_builder.cc
@@ -386,6 +386,12 @@ void DisplayListBuilder::restore() {
     }
   }
 }
+void DisplayListBuilder::restoreToCount(int restore_count) {
+  FML_DCHECK(restore_count <= getSaveCount());
+  while (restore_count < getSaveCount()) {
+    restore();
+  }
+}
 void DisplayListBuilder::saveLayer(const SkRect* bounds,
                                    const SaveLayerOptions in_options) {
   SaveLayerOptions options = in_options.without_optimizations();

--- a/display_list/display_list_builder.h
+++ b/display_list/display_list_builder.h
@@ -160,6 +160,7 @@ class DisplayListBuilder final : public virtual Dispatcher,
   }
   void restore() override;
   int getSaveCount() { return layer_stack_.size(); }
+  void restoreToCount(int restore_count);
 
   void translate(SkScalar tx, SkScalar ty) override;
   void scale(SkScalar sx, SkScalar sy) override;

--- a/flow/layers/clip_path_layer.cc
+++ b/flow/layers/clip_path_layer.cc
@@ -10,7 +10,6 @@ namespace flutter {
 ClipPathLayer::ClipPathLayer(const SkPath& clip_path, Clip clip_behavior)
     : clip_path_(clip_path), clip_behavior_(clip_behavior) {
   FML_DCHECK(clip_behavior != Clip::none);
-  set_layer_can_inherit_opacity(true);
 }
 
 void ClipPathLayer::Diff(DiffContext* context, const Layer* old_layer) {
@@ -41,10 +40,20 @@ void ClipPathLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
       Layer::AutoPrerollSaveLayerState::Create(context, UsesSaveLayer());
   context->mutators_stack.PushClipPath(clip_path_);
 
+  // Collect inheritance information on our children in Preroll so that
+  // we can pass it along by default.
+  context->subtree_can_inherit_opacity = true;
+
   SkRect child_paint_bounds = SkRect::MakeEmpty();
   PrerollChildren(context, matrix, &child_paint_bounds);
   if (child_paint_bounds.intersect(clip_path_bounds)) {
     set_paint_bounds(child_paint_bounds);
+  }
+
+  // If we use a SaveLayer then we can accept opacity on behalf
+  // of our children and apply it in the saveLayer.
+  if (UsesSaveLayer()) {
+    context->subtree_can_inherit_opacity = true;
   }
 
   context->mutators_stack.Pop();

--- a/flow/layers/clip_path_layer_unittests.cc
+++ b/flow/layers/clip_path_layer_unittests.cc
@@ -4,6 +4,7 @@
 
 #include "flutter/flow/layers/clip_path_layer.h"
 
+#include "flutter/flow/layers/opacity_layer.h"
 #include "flutter/flow/testing/layer_test.h"
 #include "flutter/flow/testing/mock_layer.h"
 #include "flutter/fml/macros.h"
@@ -260,6 +261,237 @@ TEST_F(ClipPathLayerTest, Readback) {
   EXPECT_TRUE(ReadbackResult(context, hard, reader, true));
   EXPECT_TRUE(ReadbackResult(context, soft, reader, true));
   EXPECT_TRUE(ReadbackResult(context, save_layer, reader, true));
+}
+
+TEST_F(ClipPathLayerTest, OpacityInheritance) {
+  auto path1 = SkPath().addRect({10, 10, 30, 30});
+  auto mock1 = MockLayer::MakeOpacityCompatible(path1);
+  auto layer_clip = SkPath()
+                        .addRect(SkRect::MakeLTRB(5, 5, 25, 25))
+                        .addOval(SkRect::MakeLTRB(20, 20, 40, 50));
+  auto clip_path_layer =
+      std::make_shared<ClipPathLayer>(layer_clip, Clip::hardEdge);
+  clip_path_layer->Add(mock1);
+
+  // ClipRectLayer will pass through compatibility from a compatible child
+  PrerollContext* context = preroll_context();
+  context->subtree_can_inherit_opacity = false;
+  clip_path_layer->Preroll(context, SkMatrix::I());
+  EXPECT_TRUE(context->subtree_can_inherit_opacity);
+
+  auto path2 = SkPath().addRect({40, 40, 50, 50});
+  auto mock2 = MockLayer::MakeOpacityCompatible(path2);
+  clip_path_layer->Add(mock2);
+
+  // ClipRectLayer will pass through compatibility from multiple
+  // non-overlapping compatible children
+  context->subtree_can_inherit_opacity = false;
+  clip_path_layer->Preroll(context, SkMatrix::I());
+  EXPECT_TRUE(context->subtree_can_inherit_opacity);
+
+  auto path3 = SkPath().addRect({20, 20, 40, 40});
+  auto mock3 = MockLayer::MakeOpacityCompatible(path3);
+  clip_path_layer->Add(mock3);
+
+  // ClipRectLayer will not pass through compatibility from multiple
+  // overlapping children even if they are individually compatible
+  context->subtree_can_inherit_opacity = false;
+  clip_path_layer->Preroll(context, SkMatrix::I());
+  EXPECT_FALSE(context->subtree_can_inherit_opacity);
+
+  {
+    // ClipRectLayer(aa with saveLayer) will always be compatible
+    auto clip_path_saveLayer = std::make_shared<ClipPathLayer>(
+        layer_clip, Clip::antiAliasWithSaveLayer);
+    clip_path_saveLayer->Add(mock1);
+    clip_path_saveLayer->Add(mock2);
+
+    // Double check first two children are compatible and non-overlapping
+    context->subtree_can_inherit_opacity = false;
+    clip_path_saveLayer->Preroll(context, SkMatrix::I());
+    EXPECT_TRUE(context->subtree_can_inherit_opacity);
+
+    // Now add the overlapping child and test again, should still be compatible
+    clip_path_saveLayer->Add(mock3);
+    context->subtree_can_inherit_opacity = false;
+    clip_path_saveLayer->Preroll(context, SkMatrix::I());
+    EXPECT_TRUE(context->subtree_can_inherit_opacity);
+  }
+
+  // An incompatible, but non-overlapping child for the following tests
+  auto path4 = SkPath().addRect({60, 60, 70, 70});
+  auto mock4 = MockLayer::Make(path4);
+
+  {
+    // ClipRectLayer with incompatible child will not be compatible
+    auto clip_path_bad_child =
+        std::make_shared<ClipPathLayer>(layer_clip, Clip::hardEdge);
+    clip_path_bad_child->Add(mock1);
+    clip_path_bad_child->Add(mock2);
+
+    // Double check first two children are compatible and non-overlapping
+    context->subtree_can_inherit_opacity = false;
+    clip_path_bad_child->Preroll(context, SkMatrix::I());
+    EXPECT_TRUE(context->subtree_can_inherit_opacity);
+
+    clip_path_bad_child->Add(mock4);
+
+    // The third child is non-overlapping, but not compatible so the
+    // TransformLayer should end up incompatible
+    context->subtree_can_inherit_opacity = false;
+    clip_path_bad_child->Preroll(context, SkMatrix::I());
+    EXPECT_FALSE(context->subtree_can_inherit_opacity);
+  }
+
+  {
+    // ClipRectLayer(aa with saveLayer) will always be compatible
+    auto clip_path_saveLayer_bad_child = std::make_shared<ClipPathLayer>(
+        layer_clip, Clip::antiAliasWithSaveLayer);
+    clip_path_saveLayer_bad_child->Add(mock1);
+    clip_path_saveLayer_bad_child->Add(mock2);
+
+    // Double check first two children are compatible and non-overlapping
+    context->subtree_can_inherit_opacity = false;
+    clip_path_saveLayer_bad_child->Preroll(context, SkMatrix::I());
+    EXPECT_TRUE(context->subtree_can_inherit_opacity);
+
+    // Now add the incompatible child and test again, should still be compatible
+    clip_path_saveLayer_bad_child->Add(mock4);
+    context->subtree_can_inherit_opacity = false;
+    clip_path_saveLayer_bad_child->Preroll(context, SkMatrix::I());
+    EXPECT_TRUE(context->subtree_can_inherit_opacity);
+  }
+}
+
+TEST_F(ClipPathLayerTest, OpacityInheritancePainting) {
+  auto path1 = SkPath().addRect({10, 10, 30, 30});
+  auto mock1 = MockLayer::MakeOpacityCompatible(path1);
+  auto path2 = SkPath().addRect({40, 40, 50, 50});
+  auto mock2 = MockLayer::MakeOpacityCompatible(path2);
+  auto layer_clip = SkPath()
+                        .addRect(SkRect::MakeLTRB(5, 5, 25, 25))
+                        .addOval(SkRect::MakeLTRB(20, 20, 40, 50));
+  auto clip_path_layer =
+      std::make_shared<ClipPathLayer>(layer_clip, Clip::antiAlias);
+  clip_path_layer->Add(mock1);
+  clip_path_layer->Add(mock2);
+
+  // ClipRectLayer will pass through compatibility from multiple
+  // non-overlapping compatible children
+  PrerollContext* context = preroll_context();
+  context->subtree_can_inherit_opacity = false;
+  clip_path_layer->Preroll(context, SkMatrix::I());
+  EXPECT_TRUE(context->subtree_can_inherit_opacity);
+
+  int opacity_alpha = 0x7F;
+  SkPoint offset = SkPoint::Make(10, 10);
+  auto opacity_layer = std::make_shared<OpacityLayer>(opacity_alpha, offset);
+  opacity_layer->Add(clip_path_layer);
+  context->subtree_can_inherit_opacity = false;
+  opacity_layer->Preroll(context, SkMatrix::I());
+  EXPECT_TRUE(opacity_layer->children_can_accept_opacity());
+
+  auto opacity_integer_transform = SkM44::Translate(offset.fX, offset.fY);
+  DisplayListBuilder expected_builder;
+  /* OpacityLayer::Paint() */ {
+    expected_builder.save();
+    {
+      expected_builder.translate(offset.fX, offset.fY);
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+      expected_builder.transformReset();
+      expected_builder.transform(opacity_integer_transform);
+#endif
+      /* ClipRectLayer::Paint() */ {
+        expected_builder.save();
+        expected_builder.clipPath(layer_clip, SkClipOp::kIntersect, true);
+        /* child layer1 paint */ {
+          expected_builder.setColor(opacity_alpha << 24);
+          expected_builder.saveLayer(&path1.getBounds(), true);
+          {
+            expected_builder.setColor(0xFF000000);
+            expected_builder.drawPath(path1);
+          }
+          expected_builder.restore();
+        }
+        /* child layer2 paint */ {
+          expected_builder.setColor(opacity_alpha << 24);
+          expected_builder.saveLayer(&path2.getBounds(), true);
+          {
+            expected_builder.setColor(0xFF000000);
+            expected_builder.drawPath(path2);
+          }
+          expected_builder.restore();
+        }
+        expected_builder.restore();
+      }
+    }
+    expected_builder.restore();
+  }
+
+  opacity_layer->Paint(display_list_paint_context());
+  EXPECT_TRUE(DisplayListsEQ_Verbose(expected_builder.Build(), display_list()));
+}
+
+TEST_F(ClipPathLayerTest, OpacityInheritanceSaveLayerPainting) {
+  auto path1 = SkPath().addRect({10, 10, 30, 30});
+  auto mock1 = MockLayer::MakeOpacityCompatible(path1);
+  auto path2 = SkPath().addRect({20, 20, 40, 40});
+  auto mock2 = MockLayer::MakeOpacityCompatible(path2);
+  auto children_bounds = path1.getBounds();
+  children_bounds.join(path2.getBounds());
+  auto layer_clip = SkPath()
+                        .addRect(SkRect::MakeLTRB(5, 5, 25, 25))
+                        .addOval(SkRect::MakeLTRB(20, 20, 40, 50));
+  auto clip_path_layer =
+      std::make_shared<ClipPathLayer>(layer_clip, Clip::antiAliasWithSaveLayer);
+  clip_path_layer->Add(mock1);
+  clip_path_layer->Add(mock2);
+
+  // ClipRectLayer will pass through compatibility from multiple
+  // non-overlapping compatible children
+  PrerollContext* context = preroll_context();
+  context->subtree_can_inherit_opacity = false;
+  clip_path_layer->Preroll(context, SkMatrix::I());
+  EXPECT_TRUE(context->subtree_can_inherit_opacity);
+
+  int opacity_alpha = 0x7F;
+  SkPoint offset = SkPoint::Make(10, 10);
+  auto opacity_layer = std::make_shared<OpacityLayer>(opacity_alpha, offset);
+  opacity_layer->Add(clip_path_layer);
+  context->subtree_can_inherit_opacity = false;
+  opacity_layer->Preroll(context, SkMatrix::I());
+  EXPECT_TRUE(opacity_layer->children_can_accept_opacity());
+
+  auto opacity_integer_transform = SkM44::Translate(offset.fX, offset.fY);
+  DisplayListBuilder expected_builder;
+  /* OpacityLayer::Paint() */ {
+    expected_builder.save();
+    {
+      expected_builder.translate(offset.fX, offset.fY);
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+      expected_builder.transformReset();
+      expected_builder.transform(opacity_integer_transform);
+#endif
+      /* ClipRectLayer::Paint() */ {
+        expected_builder.save();
+        expected_builder.clipPath(layer_clip, SkClipOp::kIntersect, true);
+        expected_builder.setColor(opacity_alpha << 24);
+        expected_builder.saveLayer(&children_bounds, true);
+        /* child layer1 paint */ {
+          expected_builder.setColor(0xFF000000);
+          expected_builder.drawPath(path1);
+        }
+        /* child layer2 paint */ {  //
+          expected_builder.drawPath(path2);
+        }
+        expected_builder.restore();
+      }
+    }
+    expected_builder.restore();
+  }
+
+  opacity_layer->Paint(display_list_paint_context());
+  EXPECT_TRUE(DisplayListsEQ_Verbose(expected_builder.Build(), display_list()));
 }
 
 }  // namespace testing

--- a/flow/layers/clip_rrect_layer.cc
+++ b/flow/layers/clip_rrect_layer.cc
@@ -10,7 +10,6 @@ namespace flutter {
 ClipRRectLayer::ClipRRectLayer(const SkRRect& clip_rrect, Clip clip_behavior)
     : clip_rrect_(clip_rrect), clip_behavior_(clip_behavior) {
   FML_DCHECK(clip_behavior != Clip::none);
-  set_layer_can_inherit_opacity(true);
 }
 
 void ClipRRectLayer::Diff(DiffContext* context, const Layer* old_layer) {
@@ -41,10 +40,20 @@ void ClipRRectLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
       Layer::AutoPrerollSaveLayerState::Create(context, UsesSaveLayer());
   context->mutators_stack.PushClipRRect(clip_rrect_);
 
+  // Collect inheritance information on our children in Preroll so that
+  // we can pass it along by default.
+  context->subtree_can_inherit_opacity = true;
+
   SkRect child_paint_bounds = SkRect::MakeEmpty();
   PrerollChildren(context, matrix, &child_paint_bounds);
   if (child_paint_bounds.intersect(clip_rrect_bounds)) {
     set_paint_bounds(child_paint_bounds);
+  }
+
+  // If we use a SaveLayer then we can accept opacity on behalf
+  // of our children and apply it in the saveLayer.
+  if (UsesSaveLayer()) {
+    context->subtree_can_inherit_opacity = true;
   }
 
   context->mutators_stack.Pop();

--- a/flow/layers/clip_rrect_layer_unittests.cc
+++ b/flow/layers/clip_rrect_layer_unittests.cc
@@ -4,6 +4,7 @@
 
 #include "flutter/flow/layers/clip_rrect_layer.h"
 
+#include "flutter/flow/layers/opacity_layer.h"
 #include "flutter/flow/testing/layer_test.h"
 #include "flutter/flow/testing/mock_layer.h"
 #include "flutter/fml/macros.h"
@@ -263,6 +264,234 @@ TEST_F(ClipRRectLayerTest, Readback) {
   EXPECT_TRUE(ReadbackResult(context, hard, reader, true));
   EXPECT_TRUE(ReadbackResult(context, soft, reader, true));
   EXPECT_TRUE(ReadbackResult(context, save_layer, reader, true));
+}
+
+TEST_F(ClipRRectLayerTest, OpacityInheritance) {
+  auto path1 = SkPath().addRect({10, 10, 30, 30});
+  auto mock1 = MockLayer::MakeOpacityCompatible(path1);
+  SkRect clip_rect = SkRect::MakeWH(500, 500);
+  SkRRect clip_r_rect = SkRRect::MakeRectXY(clip_rect, 20, 20);
+  auto clip_r_rect_layer =
+      std::make_shared<ClipRRectLayer>(clip_r_rect, Clip::hardEdge);
+  clip_r_rect_layer->Add(mock1);
+
+  // ClipRectLayer will pass through compatibility from a compatible child
+  PrerollContext* context = preroll_context();
+  context->subtree_can_inherit_opacity = false;
+  clip_r_rect_layer->Preroll(context, SkMatrix::I());
+  EXPECT_TRUE(context->subtree_can_inherit_opacity);
+
+  auto path2 = SkPath().addRect({40, 40, 50, 50});
+  auto mock2 = MockLayer::MakeOpacityCompatible(path2);
+  clip_r_rect_layer->Add(mock2);
+
+  // ClipRectLayer will pass through compatibility from multiple
+  // non-overlapping compatible children
+  context->subtree_can_inherit_opacity = false;
+  clip_r_rect_layer->Preroll(context, SkMatrix::I());
+  EXPECT_TRUE(context->subtree_can_inherit_opacity);
+
+  auto path3 = SkPath().addRect({20, 20, 40, 40});
+  auto mock3 = MockLayer::MakeOpacityCompatible(path3);
+  clip_r_rect_layer->Add(mock3);
+
+  // ClipRectLayer will not pass through compatibility from multiple
+  // overlapping children even if they are individually compatible
+  context->subtree_can_inherit_opacity = false;
+  clip_r_rect_layer->Preroll(context, SkMatrix::I());
+  EXPECT_FALSE(context->subtree_can_inherit_opacity);
+
+  {
+    // ClipRectLayer(aa with saveLayer) will always be compatible
+    auto clip_r_rect_saveLayer = std::make_shared<ClipRRectLayer>(
+        clip_r_rect, Clip::antiAliasWithSaveLayer);
+    clip_r_rect_saveLayer->Add(mock1);
+    clip_r_rect_saveLayer->Add(mock2);
+
+    // Double check first two children are compatible and non-overlapping
+    context->subtree_can_inherit_opacity = false;
+    clip_r_rect_saveLayer->Preroll(context, SkMatrix::I());
+    EXPECT_TRUE(context->subtree_can_inherit_opacity);
+
+    // Now add the overlapping child and test again, should still be compatible
+    clip_r_rect_saveLayer->Add(mock3);
+    context->subtree_can_inherit_opacity = false;
+    clip_r_rect_saveLayer->Preroll(context, SkMatrix::I());
+    EXPECT_TRUE(context->subtree_can_inherit_opacity);
+  }
+
+  // An incompatible, but non-overlapping child for the following tests
+  auto path4 = SkPath().addRect({60, 60, 70, 70});
+  auto mock4 = MockLayer::Make(path4);
+
+  {
+    // ClipRectLayer with incompatible child will not be compatible
+    auto clip_r_rect_bad_child =
+        std::make_shared<ClipRRectLayer>(clip_r_rect, Clip::hardEdge);
+    clip_r_rect_bad_child->Add(mock1);
+    clip_r_rect_bad_child->Add(mock2);
+
+    // Double check first two children are compatible and non-overlapping
+    context->subtree_can_inherit_opacity = false;
+    clip_r_rect_bad_child->Preroll(context, SkMatrix::I());
+    EXPECT_TRUE(context->subtree_can_inherit_opacity);
+
+    clip_r_rect_bad_child->Add(mock4);
+
+    // The third child is non-overlapping, but not compatible so the
+    // TransformLayer should end up incompatible
+    context->subtree_can_inherit_opacity = false;
+    clip_r_rect_bad_child->Preroll(context, SkMatrix::I());
+    EXPECT_FALSE(context->subtree_can_inherit_opacity);
+  }
+
+  {
+    // ClipRectLayer(aa with saveLayer) will always be compatible
+    auto clip_r_rect_saveLayer_bad_child = std::make_shared<ClipRRectLayer>(
+        clip_r_rect, Clip::antiAliasWithSaveLayer);
+    clip_r_rect_saveLayer_bad_child->Add(mock1);
+    clip_r_rect_saveLayer_bad_child->Add(mock2);
+
+    // Double check first two children are compatible and non-overlapping
+    context->subtree_can_inherit_opacity = false;
+    clip_r_rect_saveLayer_bad_child->Preroll(context, SkMatrix::I());
+    EXPECT_TRUE(context->subtree_can_inherit_opacity);
+
+    // Now add the incompatible child and test again, should still be compatible
+    clip_r_rect_saveLayer_bad_child->Add(mock4);
+    context->subtree_can_inherit_opacity = false;
+    clip_r_rect_saveLayer_bad_child->Preroll(context, SkMatrix::I());
+    EXPECT_TRUE(context->subtree_can_inherit_opacity);
+  }
+}
+
+TEST_F(ClipRRectLayerTest, OpacityInheritancePainting) {
+  auto path1 = SkPath().addRect({10, 10, 30, 30});
+  auto mock1 = MockLayer::MakeOpacityCompatible(path1);
+  auto path2 = SkPath().addRect({40, 40, 50, 50});
+  auto mock2 = MockLayer::MakeOpacityCompatible(path2);
+  SkRect clip_rect = SkRect::MakeWH(500, 500);
+  SkRRect clip_r_rect = SkRRect::MakeRectXY(clip_rect, 20, 20);
+  auto clip_rect_layer =
+      std::make_shared<ClipRRectLayer>(clip_r_rect, Clip::antiAlias);
+  clip_rect_layer->Add(mock1);
+  clip_rect_layer->Add(mock2);
+
+  // ClipRectLayer will pass through compatibility from multiple
+  // non-overlapping compatible children
+  PrerollContext* context = preroll_context();
+  context->subtree_can_inherit_opacity = false;
+  clip_rect_layer->Preroll(context, SkMatrix::I());
+  EXPECT_TRUE(context->subtree_can_inherit_opacity);
+
+  int opacity_alpha = 0x7F;
+  SkPoint offset = SkPoint::Make(10, 10);
+  auto opacity_layer = std::make_shared<OpacityLayer>(opacity_alpha, offset);
+  opacity_layer->Add(clip_rect_layer);
+  context->subtree_can_inherit_opacity = false;
+  opacity_layer->Preroll(context, SkMatrix::I());
+  EXPECT_TRUE(opacity_layer->children_can_accept_opacity());
+
+  auto opacity_integer_transform = SkM44::Translate(offset.fX, offset.fY);
+  DisplayListBuilder expected_builder;
+  /* OpacityLayer::Paint() */ {
+    expected_builder.save();
+    {
+      expected_builder.translate(offset.fX, offset.fY);
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+      expected_builder.transformReset();
+      expected_builder.transform(opacity_integer_transform);
+#endif
+      /* ClipRectLayer::Paint() */ {
+        expected_builder.save();
+        expected_builder.clipRRect(clip_r_rect, SkClipOp::kIntersect, true);
+        /* child layer1 paint */ {
+          expected_builder.setColor(opacity_alpha << 24);
+          expected_builder.saveLayer(&path1.getBounds(), true);
+          {
+            expected_builder.setColor(0xFF000000);
+            expected_builder.drawPath(path1);
+          }
+          expected_builder.restore();
+        }
+        /* child layer2 paint */ {
+          expected_builder.setColor(opacity_alpha << 24);
+          expected_builder.saveLayer(&path2.getBounds(), true);
+          {
+            expected_builder.setColor(0xFF000000);
+            expected_builder.drawPath(path2);
+          }
+          expected_builder.restore();
+        }
+        expected_builder.restore();
+      }
+    }
+    expected_builder.restore();
+  }
+
+  opacity_layer->Paint(display_list_paint_context());
+  EXPECT_TRUE(DisplayListsEQ_Verbose(expected_builder.Build(), display_list()));
+}
+
+TEST_F(ClipRRectLayerTest, OpacityInheritanceSaveLayerPainting) {
+  auto path1 = SkPath().addRect({10, 10, 30, 30});
+  auto mock1 = MockLayer::MakeOpacityCompatible(path1);
+  auto path2 = SkPath().addRect({20, 20, 40, 40});
+  auto mock2 = MockLayer::MakeOpacityCompatible(path2);
+  auto children_bounds = path1.getBounds();
+  children_bounds.join(path2.getBounds());
+  SkRect clip_rect = SkRect::MakeWH(500, 500);
+  SkRRect clip_r_rect = SkRRect::MakeRectXY(clip_rect, 20, 20);
+  auto clip_r_rect_layer = std::make_shared<ClipRRectLayer>(
+      clip_r_rect, Clip::antiAliasWithSaveLayer);
+  clip_r_rect_layer->Add(mock1);
+  clip_r_rect_layer->Add(mock2);
+
+  // ClipRectLayer will pass through compatibility from multiple
+  // non-overlapping compatible children
+  PrerollContext* context = preroll_context();
+  context->subtree_can_inherit_opacity = false;
+  clip_r_rect_layer->Preroll(context, SkMatrix::I());
+  EXPECT_TRUE(context->subtree_can_inherit_opacity);
+
+  int opacity_alpha = 0x7F;
+  SkPoint offset = SkPoint::Make(10, 10);
+  auto opacity_layer = std::make_shared<OpacityLayer>(opacity_alpha, offset);
+  opacity_layer->Add(clip_r_rect_layer);
+  context->subtree_can_inherit_opacity = false;
+  opacity_layer->Preroll(context, SkMatrix::I());
+  EXPECT_TRUE(opacity_layer->children_can_accept_opacity());
+
+  auto opacity_integer_transform = SkM44::Translate(offset.fX, offset.fY);
+  DisplayListBuilder expected_builder;
+  /* OpacityLayer::Paint() */ {
+    expected_builder.save();
+    {
+      expected_builder.translate(offset.fX, offset.fY);
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+      expected_builder.transformReset();
+      expected_builder.transform(opacity_integer_transform);
+#endif
+      /* ClipRectLayer::Paint() */ {
+        expected_builder.save();
+        expected_builder.clipRRect(clip_r_rect, SkClipOp::kIntersect, true);
+        expected_builder.setColor(opacity_alpha << 24);
+        expected_builder.saveLayer(&children_bounds, true);
+        /* child layer1 paint */ {
+          expected_builder.setColor(0xFF000000);
+          expected_builder.drawPath(path1);
+        }
+        /* child layer2 paint */ {  //
+          expected_builder.drawPath(path2);
+        }
+        expected_builder.restore();
+      }
+    }
+    expected_builder.restore();
+  }
+
+  opacity_layer->Paint(display_list_paint_context());
+  EXPECT_TRUE(DisplayListsEQ_Verbose(expected_builder.Build(), display_list()));
 }
 
 }  // namespace testing

--- a/flow/layers/container_layer.cc
+++ b/flow/layers/container_layer.cc
@@ -136,16 +136,16 @@ void ContainerLayer::PrerollChildren(PrerollContext* context,
   FML_DCHECK(!context->has_platform_view);
   bool child_has_platform_view = false;
   bool child_has_texture_layer = false;
-  bool subtree_can_inherit_opacity = layer_can_inherit_opacity();
+  bool subtree_can_inherit_opacity = context->subtree_can_inherit_opacity;
 
   for (auto& layer : layers_) {
     // Reset context->has_platform_view to false so that layers aren't treated
     // as if they have a platform view based on one being previously found in a
     // sibling tree.
     context->has_platform_view = false;
-    // Initialize the "inherit opacity" flag to the value recorded in the layer
-    // and allow it to override the answer during its |Preroll|
-    context->subtree_can_inherit_opacity = layer->layer_can_inherit_opacity();
+    // Initialize the "inherit opacity" flag to false and allow the layer to
+    // override the answer during its |Preroll|
+    context->subtree_can_inherit_opacity = false;
 
     layer->Preroll(context, child_matrix);
 

--- a/flow/layers/display_list_layer_unittests.cc
+++ b/flow/layers/display_list_layer_unittests.cc
@@ -107,6 +107,232 @@ TEST_F(DisplayListLayerTest, SimpleDisplayList) {
   EXPECT_EQ(mock_canvas().draw_calls(), expected_draw_calls);
 }
 
+TEST_F(DisplayListLayerTest, SimpleDisplayListOpacityInheritance) {
+  const SkPoint layer_offset = SkPoint::Make(1.5f, -0.5f);
+  const SkRect picture_bounds = SkRect::MakeLTRB(5.0f, 6.0f, 20.5f, 21.5f);
+  DisplayListBuilder builder;
+  builder.drawRect(picture_bounds);
+  auto display_list = builder.Build();
+  auto display_list_layer = std::make_shared<DisplayListLayer>(
+      layer_offset, SkiaGPUObject(display_list, unref_queue()), false, false);
+  EXPECT_TRUE(display_list->can_apply_group_opacity());
+
+  auto context = preroll_context();
+  context->subtree_can_inherit_opacity = false;
+  display_list_layer->Preroll(preroll_context(), SkMatrix());
+  EXPECT_TRUE(context->subtree_can_inherit_opacity);
+
+  int opacity_alpha = 0x7F;
+  SkPoint opacity_offset = SkPoint::Make(10, 10);
+  auto opacity_layer =
+      std::make_shared<OpacityLayer>(opacity_alpha, opacity_offset);
+  opacity_layer->Add(display_list_layer);
+  context->subtree_can_inherit_opacity = false;
+  opacity_layer->Preroll(context, SkMatrix::I());
+  EXPECT_TRUE(opacity_layer->children_can_accept_opacity());
+
+  auto save_layer_bounds =
+      picture_bounds.makeOffset(layer_offset.fX, layer_offset.fY);
+  auto opacity_integral_matrix =
+      RasterCache::GetIntegralTransCTM(SkMatrix::Translate(opacity_offset));
+  SkMatrix layer_offset_matrix = opacity_integral_matrix;
+  layer_offset_matrix.postTranslate(layer_offset.fX, layer_offset.fY);
+  auto layer_offset_integral_matrix =
+      RasterCache::GetIntegralTransCTM(layer_offset_matrix);
+  DisplayListBuilder expected_builder;
+  /* opacity_layer::Paint() */ {
+    expected_builder.save();
+    {
+      expected_builder.translate(opacity_offset.fX, opacity_offset.fY);
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+      expected_builder.transformReset();
+      expected_builder.transform(opacity_integral_matrix);
+#endif
+      /* display_list_layer::Paint() */ {
+        expected_builder.save();
+        {
+          expected_builder.translate(layer_offset.fX, layer_offset.fY);
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+          expected_builder.transformReset();
+          expected_builder.transform(layer_offset_integral_matrix);
+#endif
+          expected_builder.setColor(opacity_alpha << 24);
+          expected_builder.saveLayer(&save_layer_bounds, true);
+          /* display_list contents */ {  //
+            expected_builder.drawRect(picture_bounds);
+          }
+          expected_builder.restore();
+        }
+        expected_builder.restore();
+      }
+    }
+    expected_builder.restore();
+  }
+
+  opacity_layer->Paint(display_list_paint_context());
+  EXPECT_TRUE(
+      DisplayListsEQ_Verbose(expected_builder.Build(), this->display_list()));
+}
+
+TEST_F(DisplayListLayerTest, IncompatibleDisplayListOpacityInheritance) {
+  const SkPoint layer_offset = SkPoint::Make(1.5f, -0.5f);
+  const SkRect picture1_bounds = SkRect::MakeLTRB(5.0f, 6.0f, 20.5f, 21.5f);
+  const SkRect picture2_bounds = SkRect::MakeLTRB(10.0f, 15.0f, 30.0f, 35.0f);
+  DisplayListBuilder builder;
+  builder.drawRect(picture1_bounds);
+  builder.drawRect(picture2_bounds);
+  auto display_list = builder.Build();
+  auto display_list_layer = std::make_shared<DisplayListLayer>(
+      layer_offset, SkiaGPUObject(display_list, unref_queue()), false, false);
+  EXPECT_FALSE(display_list->can_apply_group_opacity());
+
+  auto context = preroll_context();
+  context->subtree_can_inherit_opacity = false;
+  display_list_layer->Preroll(preroll_context(), SkMatrix());
+  EXPECT_FALSE(context->subtree_can_inherit_opacity);
+
+  int opacity_alpha = 0x7F;
+  SkPoint opacity_offset = SkPoint::Make(10, 10);
+  auto opacity_layer =
+      std::make_shared<OpacityLayer>(opacity_alpha, opacity_offset);
+  opacity_layer->Add(display_list_layer);
+  context->subtree_can_inherit_opacity = false;
+  opacity_layer->Preroll(context, SkMatrix::I());
+  EXPECT_FALSE(opacity_layer->children_can_accept_opacity());
+
+  auto display_list_bounds = picture1_bounds;
+  display_list_bounds.join(picture2_bounds);
+  auto save_layer_bounds =
+      display_list_bounds.makeOffset(layer_offset.fX, layer_offset.fY);
+  save_layer_bounds.roundOut(&save_layer_bounds);
+  auto opacity_integral_matrix =
+      RasterCache::GetIntegralTransCTM(SkMatrix::Translate(opacity_offset));
+  SkMatrix layer_offset_matrix = opacity_integral_matrix;
+  layer_offset_matrix.postTranslate(layer_offset.fX, layer_offset.fY);
+  auto layer_offset_integral_matrix =
+      RasterCache::GetIntegralTransCTM(layer_offset_matrix);
+  DisplayListBuilder expected_builder;
+  /* opacity_layer::Paint() */ {
+    expected_builder.save();
+    {
+      expected_builder.translate(opacity_offset.fX, opacity_offset.fY);
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+      expected_builder.transformReset();
+      expected_builder.transform(opacity_integral_matrix);
+#endif
+      expected_builder.setColor(opacity_alpha << 24);
+      expected_builder.saveLayer(&save_layer_bounds, true);
+      {
+        /* display_list_layer::Paint() */ {
+          expected_builder.save();
+          {
+            expected_builder.translate(layer_offset.fX, layer_offset.fY);
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+            expected_builder.transformReset();
+            expected_builder.transform(layer_offset_integral_matrix);
+#endif
+            expected_builder.drawRect(picture1_bounds);
+            expected_builder.drawRect(picture2_bounds);
+          }
+          expected_builder.restore();
+        }
+      }
+      expected_builder.restore();
+    }
+    expected_builder.restore();
+  }
+
+  opacity_layer->Paint(display_list_paint_context());
+  EXPECT_TRUE(
+      DisplayListsEQ_Verbose(expected_builder.Build(), this->display_list()));
+}
+
+TEST_F(DisplayListLayerTest, CachedIncompatibleDisplayListOpacityInheritance) {
+  const SkPoint layer_offset = SkPoint::Make(1.5f, -0.5f);
+  const SkRect picture1_bounds = SkRect::MakeLTRB(5.0f, 6.0f, 20.5f, 21.5f);
+  const SkRect picture2_bounds = SkRect::MakeLTRB(10.0f, 15.0f, 30.0f, 35.0f);
+  DisplayListBuilder builder;
+  builder.drawRect(picture1_bounds);
+  builder.drawRect(picture2_bounds);
+  auto display_list = builder.Build();
+  auto display_list_layer = std::make_shared<DisplayListLayer>(
+      layer_offset, SkiaGPUObject(display_list, unref_queue()), true, false);
+  EXPECT_FALSE(display_list->can_apply_group_opacity());
+
+  use_skia_raster_cache();
+
+  auto context = preroll_context();
+  context->subtree_can_inherit_opacity = false;
+  display_list_layer->Preroll(preroll_context(), SkMatrix());
+  EXPECT_FALSE(context->subtree_can_inherit_opacity);
+
+  // Pump the DisplayListLayer until it is ready to cache its DL
+  display_list_layer->Paint(paint_context());
+  display_list_layer->Paint(paint_context());
+  display_list_layer->Paint(paint_context());
+
+  int opacity_alpha = 0x7F;
+  SkPoint opacity_offset = SkPoint::Make(10, 10);
+  auto opacity_layer =
+      std::make_shared<OpacityLayer>(opacity_alpha, opacity_offset);
+  opacity_layer->Add(display_list_layer);
+  context->subtree_can_inherit_opacity = false;
+  opacity_layer->Preroll(context, SkMatrix::I());
+  EXPECT_TRUE(opacity_layer->children_can_accept_opacity());
+
+  // The following would be a great test of the painting of the above
+  // setup, but for the fact that the raster cache stores raw pointers
+  // to sk_sp<SkImage> and the canvas recorder then wraps each of those
+  // in a unique DlImage - which means the DisplayList objects will not
+  // compare with the Equals method since the addresses of the two
+  // DlImage objects will not be equal even if they point to the same
+  // SkImage on each frame.
+  // See https://github.com/flutter/flutter/issues/102331
+  //   auto display_list_bounds = picture1_bounds;
+  //   display_list_bounds.join(picture2_bounds);
+  //   auto save_layer_bounds =
+  //       display_list_bounds.makeOffset(layer_offset.fX, layer_offset.fY);
+  //   save_layer_bounds.roundOut(&save_layer_bounds);
+  //   auto opacity_integral_matrix =
+  //       RasterCache::GetIntegralTransCTM(SkMatrix::Translate(opacity_offset));
+  //   SkMatrix layer_offset_matrix = opacity_integral_matrix;
+  //   layer_offset_matrix.postTranslate(layer_offset.fX, layer_offset.fY);
+  //   auto layer_offset_integral_matrix =
+  //       RasterCache::GetIntegralTransCTM(layer_offset_matrix);
+  //   // Using a recorder instead of a DisplayListBuilder so we can hand it
+  //   // off to the RasterCache::Draw() method
+  //   DisplayListCanvasRecorder recorder(SkRect::MakeWH(1000, 1000));
+  //   /* opacity_layer::Paint() */ {
+  //     recorder.save();
+  //     {
+  //       recorder.translate(opacity_offset.fX, opacity_offset.fY);
+  // #ifndef SUPPORT_FRACTIONAL_TRANSLATION
+  //       recorder.resetMatrix();
+  //       recorder.concat(opacity_integral_matrix);
+  // #endif
+  //       /* display_list_layer::Paint() */ {
+  //         recorder.save();
+  //         {
+  //           recorder.translate(layer_offset.fX, layer_offset.fY);
+  // #ifndef SUPPORT_FRACTIONAL_TRANSLATION
+  //           recorder.resetMatrix();
+  //           recorder.concat(layer_offset_integral_matrix);
+  // #endif
+  //           SkPaint p;
+  //           p.setAlpha(opacity_alpha);
+  //           context->raster_cache->Draw(*display_list, recorder, &p);
+  //         }
+  //         recorder.restore();
+  //       }
+  //     }
+  //     recorder.restore();
+  //   }
+
+  //   opacity_layer->Paint(display_list_paint_context());
+  //   EXPECT_TRUE(
+  //       DisplayListsEQ_Verbose(recorder.Build(), this->display_list()));
+}
+
 using DisplayListLayerDiffTest = DiffContextTest;
 
 TEST_F(DisplayListLayerDiffTest, SimpleDisplayList) {

--- a/flow/layers/layer.cc
+++ b/flow/layers/layer.cc
@@ -13,8 +13,7 @@ Layer::Layer()
     : paint_bounds_(SkRect::MakeEmpty()),
       unique_id_(NextUniqueID()),
       original_layer_id_(unique_id_),
-      subtree_has_platform_view_(false),
-      layer_can_inherit_opacity_(false) {}
+      subtree_has_platform_view_(false) {}
 
 Layer::~Layer() = default;
 

--- a/flow/layers/opacity_layer_unittests.cc
+++ b/flow/layers/opacity_layer_unittests.cc
@@ -5,6 +5,8 @@
 #include "flutter/flow/layers/opacity_layer.h"
 
 #include "flutter/flow/layers/clip_rect_layer.h"
+#include "flutter/flow/layers/image_filter_layer.h"
+#include "flutter/flow/layers/transform_layer.h"
 #include "flutter/flow/testing/diff_context_test.h"
 #include "flutter/flow/testing/layer_test.h"
 #include "flutter/flow/testing/mock_layer.h"
@@ -465,6 +467,142 @@ TEST_F(OpacityLayerTest, CullRectIsTransformed) {
   clipRectLayer->Preroll(preroll_context(), SkMatrix::I());
   EXPECT_EQ(mockLayer->parent_cull_rect().fLeft, -20);
   EXPECT_EQ(mockLayer->parent_cull_rect().fTop, -20);
+}
+
+TEST_F(OpacityLayerTest, OpacityInheritanceCompatibleChild) {
+  auto opacityLayer =
+      std::make_shared<OpacityLayer>(128, SkPoint::Make(20, 20));
+  auto mockLayer = MockLayer::MakeOpacityCompatible(SkPath());
+  opacityLayer->Add(mockLayer);
+
+  PrerollContext* context = preroll_context();
+  context->subtree_can_inherit_opacity = false;
+  opacityLayer->Preroll(context, SkMatrix::I());
+  EXPECT_TRUE(context->subtree_can_inherit_opacity);
+  EXPECT_TRUE(opacityLayer->children_can_accept_opacity());
+}
+
+TEST_F(OpacityLayerTest, OpacityInheritanceIncompatibleChild) {
+  auto opacityLayer =
+      std::make_shared<OpacityLayer>(128, SkPoint::Make(20, 20));
+  auto mockLayer = MockLayer::Make(SkPath());
+  opacityLayer->Add(mockLayer);
+
+  PrerollContext* context = preroll_context();
+  context->subtree_can_inherit_opacity = false;
+  opacityLayer->Preroll(context, SkMatrix::I());
+  EXPECT_TRUE(context->subtree_can_inherit_opacity);
+  EXPECT_FALSE(opacityLayer->children_can_accept_opacity());
+}
+
+TEST_F(OpacityLayerTest, OpacityInheritanceThroughContainer) {
+  auto opacityLayer =
+      std::make_shared<OpacityLayer>(128, SkPoint::Make(20, 20));
+  auto containerLayer = std::make_shared<ContainerLayer>();
+  auto mockLayer = MockLayer::MakeOpacityCompatible(SkPath());
+  containerLayer->Add(mockLayer);
+  opacityLayer->Add(containerLayer);
+
+  PrerollContext* context = preroll_context();
+  context->subtree_can_inherit_opacity = false;
+  opacityLayer->Preroll(context, SkMatrix::I());
+  EXPECT_TRUE(context->subtree_can_inherit_opacity);
+  // By default a container layer will not pass opacity through to
+  // its children - specific subclasses will have to enable this
+  // pass through by setting the flag to true themselves before
+  // calling their super method ContainerLayer::Preroll().
+  EXPECT_FALSE(opacityLayer->children_can_accept_opacity());
+}
+
+TEST_F(OpacityLayerTest, OpacityInheritanceThroughTransform) {
+  auto opacityLayer =
+      std::make_shared<OpacityLayer>(128, SkPoint::Make(20, 20));
+  auto transformLayer = std::make_shared<TransformLayer>(SkMatrix::Scale(2, 2));
+  auto mockLayer = MockLayer::MakeOpacityCompatible(SkPath());
+  transformLayer->Add(mockLayer);
+  opacityLayer->Add(transformLayer);
+
+  PrerollContext* context = preroll_context();
+  context->subtree_can_inherit_opacity = false;
+  opacityLayer->Preroll(context, SkMatrix::I());
+  EXPECT_TRUE(context->subtree_can_inherit_opacity);
+  EXPECT_TRUE(opacityLayer->children_can_accept_opacity());
+}
+
+TEST_F(OpacityLayerTest, OpacityInheritanceThroughImageFilter) {
+  auto opacityLayer =
+      std::make_shared<OpacityLayer>(128, SkPoint::Make(20, 20));
+  auto filterLayer = std::make_shared<ImageFilterLayer>(
+      SkImageFilters::Blur(5.0, 5.0, nullptr));
+  auto mockLayer = MockLayer::MakeOpacityCompatible(SkPath());
+  filterLayer->Add(mockLayer);
+  opacityLayer->Add(filterLayer);
+
+  PrerollContext* context = preroll_context();
+  context->subtree_can_inherit_opacity = false;
+  opacityLayer->Preroll(context, SkMatrix::I());
+  EXPECT_TRUE(context->subtree_can_inherit_opacity);
+  EXPECT_TRUE(opacityLayer->children_can_accept_opacity());
+}
+
+TEST_F(OpacityLayerTest, OpacityInheritanceNested) {
+  SkPoint offset1 = SkPoint::Make(10, 20);
+  SkPoint offset2 = SkPoint::Make(20, 10);
+  SkPath mockPath = SkPath::Rect({10, 10, 20, 20});
+  auto opacityLayer1 = std::make_shared<OpacityLayer>(128, offset1);
+  auto opacityLayer2 = std::make_shared<OpacityLayer>(64, offset2);
+  auto mockLayer = MockLayer::MakeOpacityCompatible(mockPath);
+  opacityLayer2->Add(mockLayer);
+  opacityLayer1->Add(opacityLayer2);
+
+  PrerollContext* context = preroll_context();
+  context->subtree_can_inherit_opacity = false;
+  opacityLayer1->Preroll(context, SkMatrix::I());
+  EXPECT_TRUE(context->subtree_can_inherit_opacity);
+  EXPECT_TRUE(opacityLayer1->children_can_accept_opacity());
+  EXPECT_TRUE(opacityLayer2->children_can_accept_opacity());
+
+  SkPaint saveLayerPaint;
+  SkScalar inheritedOpacity = 128 * 1.0 / SK_AlphaOPAQUE;
+  inheritedOpacity *= 64 * 1.0 / SK_AlphaOPAQUE;
+  saveLayerPaint.setAlphaf(inheritedOpacity);
+
+  DisplayListBuilder expected_builder;
+  /* opacityLayer1::Paint */ {
+    expected_builder.save();
+    {
+      expected_builder.translate(offset1.fX, offset1.fY);
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+      expected_builder.transformReset();
+      expected_builder.transform(SkM44::Translate(offset1.fX, offset1.fY));
+#endif
+      /* opacityLayer2::Paint */ {
+        expected_builder.save();
+        {
+          expected_builder.translate(offset2.fX, offset2.fY);
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+          expected_builder.transformReset();
+          expected_builder.transform(SkM44::Translate(offset1.fX + offset2.fX,
+                                                      offset1.fY + offset2.fY));
+#endif
+          /* mockLayer::Paint */ {
+            expected_builder.setColor(saveLayerPaint.getAlpha() << 24);
+            expected_builder.saveLayer(&mockPath.getBounds(), true);
+            {
+              expected_builder.setColor(0xFF000000);
+              expected_builder.drawPath(mockPath);
+            }
+            expected_builder.restore();
+          }
+        }
+        expected_builder.restore();
+      }
+    }
+    expected_builder.restore();
+  }
+
+  opacityLayer1->Paint(display_list_paint_context());
+  EXPECT_TRUE(DisplayListsEQ_Verbose(expected_builder.Build(), display_list()));
 }
 
 using OpacityLayerDiffTest = DiffContextTest;

--- a/flow/layers/physical_shape_layer_unittests.cc
+++ b/flow/layers/physical_shape_layer_unittests.cc
@@ -416,6 +416,20 @@ TEST_F(PhysicalShapeLayerTest, Readback) {
   EXPECT_TRUE(ReadbackResult(context, save_layer, reader, true));
 }
 
+TEST_F(PhysicalShapeLayerTest, OpacityInheritance) {
+  SkPath layer_path;
+  layer_path.addRect(5.0f, 6.0f, 20.5f, 21.5f);
+  auto layer =
+      std::make_shared<PhysicalShapeLayer>(SK_ColorGREEN, SK_ColorBLACK,
+                                           0.0f,  // elevation
+                                           layer_path, Clip::none);
+
+  PrerollContext* context = preroll_context();
+  context->subtree_can_inherit_opacity = false;
+  layer->Preroll(context, SkMatrix());
+  EXPECT_FALSE(context->subtree_can_inherit_opacity);
+}
+
 using PhysicalShapeLayerDiffTest = DiffContextTest;
 
 TEST_F(PhysicalShapeLayerDiffTest, NoClipPaintRegion) {

--- a/flow/layers/picture_layer_unittests.cc
+++ b/flow/layers/picture_layer_unittests.cc
@@ -97,6 +97,64 @@ TEST_F(PictureLayerTest, SimplePicture) {
   EXPECT_EQ(mock_canvas().draw_calls(), expected_draw_calls);
 }
 
+TEST_F(PictureLayerTest, OpacityInheritanceCacheablePicture) {
+  use_mock_raster_cache();
+  const SkPoint layer_offset = SkPoint::Make(1.5f, -0.5f);
+  const SkRect picture_bounds = SkRect::MakeLTRB(5.0f, 6.0f, 20.5f, 21.5f);
+  auto mock_picture = SkPicture::MakePlaceholder(picture_bounds);
+  auto layer = std::make_shared<PictureLayer>(
+      layer_offset, SkiaGPUObject(mock_picture, unref_queue()), true, false);
+
+  // First try, no caching, cannot support opacity
+  PrerollContext* context = preroll_context();
+  context->subtree_can_inherit_opacity = false;
+  layer->Preroll(preroll_context(), SkMatrix());
+  EXPECT_EQ(raster_cache()->GetPictureCachedEntriesCount(), size_t(1));
+  EXPECT_EQ(raster_cache()->EstimatePictureCacheByteSize(), size_t(0));
+  EXPECT_FALSE(context->subtree_can_inherit_opacity);
+
+  // Paint it enough times to reach its cache threshold
+  layer->Paint(paint_context());
+  layer->Paint(paint_context());
+  layer->Paint(paint_context());
+
+  // This time it will cache and can now support opacity
+  context->subtree_can_inherit_opacity = false;
+  layer->Preroll(preroll_context(), SkMatrix());
+  EXPECT_EQ(raster_cache()->GetPictureCachedEntriesCount(), size_t(1));
+  EXPECT_NE(raster_cache()->EstimatePictureCacheByteSize(), size_t(0));
+  EXPECT_TRUE(context->subtree_can_inherit_opacity);
+}
+
+TEST_F(PictureLayerTest, OpacityInheritanceUncacheablePicture) {
+  use_mock_raster_cache();
+  const SkPoint layer_offset = SkPoint::Make(1.5f, -0.5f);
+  const SkRect picture_bounds = SkRect::MakeLTRB(5.0f, 6.0f, 20.5f, 21.5f);
+  auto mock_picture = SkPicture::MakePlaceholder(picture_bounds);
+  auto layer = std::make_shared<PictureLayer>(
+      layer_offset, SkiaGPUObject(mock_picture, unref_queue()), false, true);
+
+  PrerollContext* context = preroll_context();
+  context->subtree_can_inherit_opacity = false;
+  layer->Preroll(preroll_context(), SkMatrix());
+  EXPECT_EQ(raster_cache()->GetPictureCachedEntriesCount(), size_t(0));
+  EXPECT_EQ(raster_cache()->EstimatePictureCacheByteSize(), size_t(0));
+  // First try, no caching, cannot support opacity
+  EXPECT_FALSE(context->subtree_can_inherit_opacity);
+
+  // Paint it enough times to reach its cache threshold
+  layer->Paint(paint_context());
+  layer->Paint(paint_context());
+  layer->Paint(paint_context());
+
+  context->subtree_can_inherit_opacity = false;
+  layer->Preroll(preroll_context(), SkMatrix());
+  EXPECT_EQ(raster_cache()->GetPictureCachedEntriesCount(), size_t(0));
+  EXPECT_EQ(raster_cache()->EstimatePictureCacheByteSize(), size_t(0));
+  // It still is not compatible because it cannot cache
+  EXPECT_FALSE(context->subtree_can_inherit_opacity);
+}
+
 using PictureLayerDiffTest = DiffContextTest;
 
 TEST_F(PictureLayerDiffTest, SimplePicture) {

--- a/flow/layers/platform_view_layer_unittests.cc
+++ b/flow/layers/platform_view_layer_unittests.cc
@@ -83,5 +83,18 @@ TEST_F(PlatformViewLayerTest, ClippedPlatformViewPrerollsAndPaintsNothing) {
            MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
 }
 
+TEST_F(PlatformViewLayerTest, OpacityInheritance) {
+  const SkPoint layer_offset = SkPoint::Make(0.0f, 0.0f);
+  const SkSize layer_size = SkSize::Make(8.0f, 8.0f);
+  const int64_t view_id = 0;
+  auto layer =
+      std::make_shared<PlatformViewLayer>(layer_offset, layer_size, view_id);
+
+  PrerollContext* context = preroll_context();
+  context->subtree_can_inherit_opacity = false;
+  layer->Preroll(preroll_context(), SkMatrix());
+  EXPECT_FALSE(context->subtree_can_inherit_opacity);
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/flow/layers/texture_layer.cc
+++ b/flow/layers/texture_layer.cc
@@ -17,9 +17,7 @@ TextureLayer::TextureLayer(const SkPoint& offset,
       size_(size),
       texture_id_(texture_id),
       freeze_(freeze),
-      sampling_(sampling) {
-  set_layer_can_inherit_opacity(true);
-}
+      sampling_(sampling) {}
 
 void TextureLayer::Diff(DiffContext* context, const Layer* old_layer) {
   DiffContext::AutoSubtreeRestore subtree(context);
@@ -48,6 +46,7 @@ void TextureLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   set_paint_bounds(SkRect::MakeXYWH(offset_.x(), offset_.y(), size_.width(),
                                     size_.height()));
   context->has_texture_layer = true;
+  context->subtree_can_inherit_opacity = true;
 }
 
 void TextureLayer::Paint(PaintContext& context) const {

--- a/flow/layers/texture_layer_unittests.cc
+++ b/flow/layers/texture_layer_unittests.cc
@@ -116,5 +116,29 @@ TEST_F(TextureLayerDiffTest, TextureInRetainedLayer) {
   EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(0, 0, 100, 100));
 }
 
+TEST_F(TextureLayerTest, OpacityInheritance) {
+  const SkPoint layer_offset = SkPoint::Make(0.0f, 0.0f);
+  const SkSize layer_size = SkSize::Make(8.0f, 8.0f);
+  const int64_t texture_id = 0;
+  auto mock_texture = std::make_shared<MockTexture>(texture_id);
+  auto layer = std::make_shared<TextureLayer>(
+      layer_offset, layer_size, texture_id, false,
+      SkSamplingOptions(SkFilterMode::kLinear));
+
+  // Ensure the texture is located by the Layer.
+  preroll_context()->texture_registry.RegisterTexture(mock_texture);
+
+  // The texture layer always reports opacity compatibility.
+  PrerollContext* context = preroll_context();
+  context->subtree_can_inherit_opacity = false;
+  context->texture_registry.RegisterTexture(mock_texture);
+  layer->Preroll(context, SkMatrix::I());
+  EXPECT_TRUE(context->subtree_can_inherit_opacity);
+
+  // MockTexture has no actual textur to render into the
+  // PaintContext canvas so we have no way to verify its
+  // rendering.
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/flow/layers/transform_layer.cc
+++ b/flow/layers/transform_layer.cc
@@ -24,7 +24,6 @@ TransformLayer::TransformLayer(const SkMatrix& transform)
     FML_LOG(ERROR) << "TransformLayer is constructed with an invalid matrix.";
     transform_.setIdentity();
   }
-  set_layer_can_inherit_opacity(true);
 }
 
 void TransformLayer::Diff(DiffContext* context, const Layer* old_layer) {
@@ -56,6 +55,10 @@ void TransformLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   } else {
     context->cull_rect = kGiantRect;
   }
+
+  // Collect inheritance information on our children in Preroll so that
+  // we can pass it along by default.
+  context->subtree_can_inherit_opacity = true;
 
   SkRect child_paint_bounds = SkRect::MakeEmpty();
   PrerollChildren(context, child_matrix, &child_paint_bounds);

--- a/flow/testing/layer_test.h
+++ b/flow/testing/layer_test.h
@@ -39,6 +39,8 @@ template <typename BaseT>
 class LayerTestBase : public CanvasTestBase<BaseT> {
   using TestT = CanvasTestBase<BaseT>;
 
+  const SkRect kDlBounds = SkRect::MakeWH(500, 500);
+
  public:
   LayerTestBase()
       : preroll_context_{
@@ -72,8 +74,8 @@ class LayerTestBase : public CanvasTestBase<BaseT> {
             .frame_device_pixel_ratio      = 1.0f,
             // clang-format on
         },
-        display_list_recorder_(kGiantRect),
-        internal_display_list_canvas_(kGiantRect.width(), kGiantRect.height()),
+        display_list_recorder_(kDlBounds),
+        internal_display_list_canvas_(kDlBounds.width(), kDlBounds.height()),
         display_list_paint_context_{
             // clang-format off
             .internal_nodes_canvas         = &internal_display_list_canvas_,
@@ -193,6 +195,7 @@ class LayerTestBase : public CanvasTestBase<BaseT> {
     raster_cache_ = std::move(raster_cache);
     preroll_context_.raster_cache = raster_cache_.get();
     paint_context_.raster_cache = raster_cache_.get();
+    display_list_paint_context_.raster_cache = raster_cache_.get();
   }
 
   FixedRefreshRateStopwatch raster_time_;

--- a/flow/testing/mock_layer.h
+++ b/flow/testing/mock_layer.h
@@ -19,7 +19,17 @@ class MockLayer : public Layer {
   explicit MockLayer(SkPath path,
                      SkPaint paint = SkPaint(),
                      bool fake_has_platform_view = false,
-                     bool fake_reads_surface = false);
+                     bool fake_reads_surface = false,
+                     bool fake_opacity_compatible_ = false);
+
+  static std::shared_ptr<MockLayer> Make(SkPath path,
+                                         SkPaint paint = SkPaint()) {
+    return std::make_shared<MockLayer>(path, paint, false, false, false);
+  }
+
+  static std::shared_ptr<MockLayer> MakeOpacityCompatible(SkPath path) {
+    return std::make_shared<MockLayer>(path, SkPaint(), false, false, true);
+  }
 
   void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
   void Paint(PaintContext& context) const override;
@@ -42,6 +52,7 @@ class MockLayer : public Layer {
   bool parent_has_platform_view_ = false;
   bool fake_has_platform_view_ = false;
   bool fake_reads_surface_ = false;
+  bool fake_opacity_compatible_ = false;
 
   FML_DISALLOW_COPY_AND_ASSIGN(MockLayer);
 };

--- a/flow/testing/mock_layer_unittests.cc
+++ b/flow/testing/mock_layer_unittests.cc
@@ -78,5 +78,20 @@ TEST_F(MockLayerTest, SaveLayerOnLeafNodesCanvas) {
   EXPECT_EQ(preroll_context()->has_platform_view, true);
 }
 
+TEST_F(MockLayerTest, OpacityInheritance) {
+  auto path1 = SkPath().addRect({10, 10, 30, 30});
+  PrerollContext* context = preroll_context();
+
+  auto mock1 = std::make_shared<MockLayer>(path1);
+  context->subtree_can_inherit_opacity = false;
+  mock1->Preroll(context, SkMatrix::I());
+  EXPECT_FALSE(context->subtree_can_inherit_opacity);
+
+  auto mock2 = MockLayer::MakeOpacityCompatible(path1);
+  context->subtree_can_inherit_opacity = false;
+  mock2->Preroll(context, SkMatrix::I());
+  EXPECT_TRUE(context->subtree_can_inherit_opacity);
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/flow/testing/mock_raster_cache.cc
+++ b/flow/testing/mock_raster_cache.cc
@@ -25,6 +25,18 @@ std::unique_ptr<RasterCacheResult> MockRasterCache::RasterizePicture(
   return std::make_unique<MockRasterCacheResult>(cache_rect);
 }
 
+std::unique_ptr<RasterCacheResult> MockRasterCache::RasterizeDisplayList(
+    DisplayList* display_list,
+    GrDirectContext* context,
+    const SkMatrix& ctm,
+    SkColorSpace* dst_color_space,
+    bool checkerboard) const {
+  SkRect logical_rect = display_list->bounds();
+  SkIRect cache_rect = RasterCache::GetDeviceBounds(logical_rect, ctm);
+
+  return std::make_unique<MockRasterCacheResult>(cache_rect);
+}
+
 std::unique_ptr<RasterCacheResult> MockRasterCache::RasterizeLayer(
     PrerollContext* context,
     Layer* layer,

--- a/flow/testing/mock_raster_cache.h
+++ b/flow/testing/mock_raster_cache.h
@@ -63,6 +63,13 @@ class MockRasterCache : public RasterCache {
       SkColorSpace* dst_color_space,
       bool checkerboard) const override;
 
+  std::unique_ptr<RasterCacheResult> RasterizeDisplayList(
+      DisplayList* display_list,
+      GrDirectContext* context,
+      const SkMatrix& ctm,
+      SkColorSpace* dst_color_space,
+      bool checkerboard) const override;
+
   std::unique_ptr<RasterCacheResult> RasterizeLayer(
       PrerollContext* context,
       Layer* layer,

--- a/testing/display_list_testing.cc
+++ b/testing/display_list_testing.cc
@@ -593,9 +593,9 @@ void DisplayListStreamDispatcher::saveLayer(const SkRect* bounds,
   indent();
 }
 void DisplayListStreamDispatcher::restore() {
-  startl() << "restore();" << std::endl;
   outdent();
   startl() << "}" << std::endl;
+  startl() << "restore();" << std::endl;
 }
 
 void DisplayListStreamDispatcher::translate(SkScalar tx, SkScalar ty) {
@@ -651,7 +651,7 @@ void DisplayListStreamDispatcher::transformFullPerspective(
   startl() << ");" << std::endl;
 }
 void DisplayListStreamDispatcher::transformReset() {
-  startl() << "tranformReset();" << std::endl;
+  startl() << "transformReset();" << std::endl;
 }
 
 void DisplayListStreamDispatcher::clipRect(const SkRect& rect, SkClipOp clip_op,

--- a/testing/mock_canvas.cc
+++ b/testing/mock_canvas.cc
@@ -108,6 +108,21 @@ void MockCanvas::onDrawShadowRec(const SkPath& path,
   draw_calls_.emplace_back(DrawCall{current_layer_, DrawShadowData{path}});
 }
 
+void MockCanvas::onDrawImage2(const SkImage* image,
+                              SkScalar x,
+                              SkScalar y,
+                              const SkSamplingOptions& options,
+                              const SkPaint* paint) {
+  if (paint) {
+    draw_calls_.emplace_back(
+        DrawCall{current_layer_,
+                 DrawImageData{sk_ref_sp(image), x, y, options, *paint}});
+  } else {
+    draw_calls_.emplace_back(DrawCall{
+        current_layer_, DrawImageDataNoPaint{sk_ref_sp(image), x, y, options}});
+  }
+}
+
 void MockCanvas::onDrawPicture(const SkPicture* picture,
                                const SkMatrix* matrix,
                                const SkPaint* paint) {
@@ -217,14 +232,6 @@ void MockCanvas::onDrawArc(const SkRect&,
 }
 
 void MockCanvas::onDrawRRect(const SkRRect&, const SkPaint&) {
-  FML_DCHECK(false);
-}
-
-void MockCanvas::onDrawImage2(const SkImage*,
-                              SkScalar,
-                              SkScalar,
-                              const SkSamplingOptions&,
-                              const SkPaint*) {
   FML_DCHECK(false);
 }
 
@@ -355,6 +362,30 @@ bool operator==(const MockCanvas::DrawTextData& a,
 std::ostream& operator<<(std::ostream& os,
                          const MockCanvas::DrawTextData& data) {
   return os << data.serialized_text << " " << data.paint << " " << data.offset;
+}
+
+bool operator==(const MockCanvas::DrawImageData& a,
+                const MockCanvas::DrawImageData& b) {
+  return a.image == b.image && a.x == b.x && a.y == b.y &&
+         a.options == b.options && a.paint == b.paint;
+}
+
+std::ostream& operator<<(std::ostream& os,
+                         const MockCanvas::DrawImageData& data) {
+  return os << data.image << " " << data.x << " " << data.y << " "
+            << data.options << " " << data.paint;
+}
+
+bool operator==(const MockCanvas::DrawImageDataNoPaint& a,
+                const MockCanvas::DrawImageDataNoPaint& b) {
+  return a.image == b.image && a.x == b.x && a.y == b.y &&
+         a.options == b.options;
+}
+
+std::ostream& operator<<(std::ostream& os,
+                         const MockCanvas::DrawImageDataNoPaint& data) {
+  return os << data.image << " " << data.x << " " << data.y << " "
+            << data.options;
 }
 
 bool operator==(const MockCanvas::DrawPictureData& a,

--- a/testing/mock_canvas.h
+++ b/testing/mock_canvas.h
@@ -15,6 +15,7 @@
 #include "third_party/skia/include/core/SkCanvasVirtualEnforcer.h"
 #include "third_party/skia/include/core/SkClipOp.h"
 #include "third_party/skia/include/core/SkData.h"
+#include "third_party/skia/include/core/SkImage.h"
 #include "third_party/skia/include/core/SkImageFilter.h"
 #include "third_party/skia/include/core/SkM44.h"
 #include "third_party/skia/include/core/SkPath.h"
@@ -76,6 +77,21 @@ class MockCanvas : public SkCanvasVirtualEnforcer<SkCanvas> {
     SkPoint offset;
   };
 
+  struct DrawImageDataNoPaint {
+    sk_sp<SkImage> image;
+    SkScalar x;
+    SkScalar y;
+    SkSamplingOptions options;
+  };
+
+  struct DrawImageData {
+    sk_sp<SkImage> image;
+    SkScalar x;
+    SkScalar y;
+    SkSamplingOptions options;
+    SkPaint paint;
+  };
+
   struct DrawPictureData {
     sk_sp<SkData> serialized_picture;
     SkPaint paint;
@@ -118,6 +134,8 @@ class MockCanvas : public SkCanvasVirtualEnforcer<SkCanvas> {
                                     DrawRectData,
                                     DrawPathData,
                                     DrawTextData,
+                                    DrawImageDataNoPaint,
+                                    DrawImageData,
                                     DrawPictureData,
                                     DrawShadowData,
                                     ClipRectData,
@@ -268,6 +286,14 @@ extern bool operator==(const MockCanvas::DrawTextData& a,
                        const MockCanvas::DrawTextData& b);
 extern std::ostream& operator<<(std::ostream& os,
                                 const MockCanvas::DrawTextData& data);
+extern bool operator==(const MockCanvas::DrawImageData& a,
+                       const MockCanvas::DrawImageData& b);
+extern std::ostream& operator<<(std::ostream& os,
+                                const MockCanvas::DrawImageData& data);
+extern bool operator==(const MockCanvas::DrawImageDataNoPaint& a,
+                       const MockCanvas::DrawImageDataNoPaint& b);
+extern std::ostream& operator<<(std::ostream& os,
+                                const MockCanvas::DrawImageDataNoPaint& data);
 extern bool operator==(const MockCanvas::DrawPictureData& a,
                        const MockCanvas::DrawPictureData& b);
 extern std::ostream& operator<<(std::ostream& os,


### PR DESCRIPTION
The original PR was pushed before it was complete, but the mechanism is back with:

- more layers participating
- many many more unit tests verifying the flag propagation as well as the final rendering result
- some bugs fixed