### PR TITLE
Reuse the same temporary canvas for creating shader images

### DIFF
--- a/lib/web_ui/lib/src/engine/html/shaders/shader.dart
+++ b/lib/web_ui/lib/src/engine/html/shaders/shader.dart
@@ -22,6 +22,21 @@ import 'vertex_shaders.dart';
 const double kFltEpsilon = 1.19209290E-07; // == 1 / (2 ^ 23)
 const double kFltEpsilonSquared = 1.19209290E-07 * 1.19209290E-07;
 
+class TempCanvas {
+  OffScreenCanvas? _canvas;
+  int currentWidth = 0;
+  int currentHeight = 0;
+  GlContext checkOutContext(int width, int height) {
+    if(_canvas == null) {
+      _canvas = OffScreenCanvas(width, height);
+    } else {
+      _canvas!.resize(width, height);
+    }
+    return GlContext(_canvas!);
+  }
+}
+TempCanvas _tempCanvas = TempCanvas();
+
 abstract class EngineGradient implements ui.Gradient {
   /// Hidden constructor to prevent subclassing.
   EngineGradient._();
@@ -31,8 +46,7 @@ abstract class EngineGradient implements ui.Gradient {
       ui.Rect? shaderBounds, double density);
 
   /// Creates a CanvasImageSource to paint gradient.
-  Object createImageBitmap(
-      ui.Rect? shaderBounds, double density, bool createDataUrl);
+  Object createImageBitmap(ui.Rect? shaderBounds, double density, bool createDataUrl);
 }
 
 class GradientSweep extends EngineGradient {
@@ -58,9 +72,7 @@ class GradientSweep extends EngineGradient {
 
     initWebGl();
     // Render gradient into a bitmap and create a canvas pattern.
-    final OffScreenCanvas offScreenCanvas =
-        OffScreenCanvas(widthInPixels, heightInPixels);
-    final GlContext gl = GlContext(offScreenCanvas);
+    final GlContext gl = _tempCanvas.checkOutContext(widthInPixels, heightInPixels);
     gl.setViewportSize(widthInPixels, heightInPixels);
 
     final NormalizedGradient normalizedGradient =
@@ -222,9 +234,7 @@ class GradientLinear extends EngineGradient {
     assert(widthInPixels > 0 && heightInPixels > 0);
     initWebGl();
     // Render gradient into a bitmap and create a canvas pattern.
-    final OffScreenCanvas offScreenCanvas =
-        OffScreenCanvas(widthInPixels, heightInPixels);
-    final GlContext gl = GlContext(offScreenCanvas);
+    final GlContext gl = _tempCanvas.checkOutContext(widthInPixels, heightInPixels);
     gl.setViewportSize(widthInPixels, heightInPixels);
 
     final NormalizedGradient normalizedGradient =
@@ -490,9 +500,7 @@ class GradientRadial extends EngineGradient {
 
     initWebGl();
     // Render gradient into a bitmap and create a canvas pattern.
-    final OffScreenCanvas offScreenCanvas =
-        OffScreenCanvas(widthInPixels, heightInPixels);
-    final GlContext gl = GlContext(offScreenCanvas);
+    final GlContext gl = _tempCanvas.checkOutContext(widthInPixels, heightInPixels);
     gl.setViewportSize(widthInPixels, heightInPixels);
 
     final NormalizedGradient normalizedGradient =

--- a/lib/web_ui/lib/src/engine/html/shaders/shader.dart
+++ b/lib/web_ui/lib/src/engine/html/shaders/shader.dart
@@ -46,7 +46,8 @@ abstract class EngineGradient implements ui.Gradient {
       ui.Rect? shaderBounds, double density);
 
   /// Creates a CanvasImageSource to paint gradient.
-  Object createImageBitmap(ui.Rect? shaderBounds, double density, bool createDataUrl);
+  Object createImageBitmap(
+      ui.Rect? shaderBounds, double density, bool createDataUrl);
 }
 
 class GradientSweep extends EngineGradient {

--- a/lib/web_ui/lib/src/engine/safe_browser_api.dart
+++ b/lib/web_ui/lib/src/engine/safe_browser_api.dart
@@ -950,12 +950,31 @@ class OffScreenCanvas {
         height: height,
       );
       canvasElement!.className = 'gl-canvas';
-      final double cssWidth = width / EnginePlatformDispatcher.browserDevicePixelRatio;
-      final double cssHeight = height / EnginePlatformDispatcher.browserDevicePixelRatio;
-      canvasElement!.style
-        ..position = 'absolute'
-        ..width = '${cssWidth}px'
-        ..height = '${cssHeight}px';
+      _updateCanvasCssSize(canvasElement!);
+    }
+  }
+
+  void _updateCanvasCssSize(html.CanvasElement element) {
+    final double cssWidth = width / EnginePlatformDispatcher.browserDevicePixelRatio;
+    final double cssHeight = height / EnginePlatformDispatcher.browserDevicePixelRatio;
+    element.style
+      ..position = 'absolute'
+      ..width = '${cssWidth}px'
+      ..height = '${cssHeight}px';
+  }
+
+  void resize(int requestedWidth, int requestedHeight) {
+    if(requestedWidth != width && requestedHeight != height) {
+      width = requestedWidth;
+      height = requestedHeight;
+      if(offScreenCanvas != null) {
+        offScreenCanvas!.width = requestedWidth;
+        offScreenCanvas!.height = requestedHeight;
+      } else if (canvasElement != null) {
+        canvasElement!.width = requestedWidth;
+        canvasElement!.height = requestedHeight;
+        _updateCanvasCssSize(canvasElement!);
+      }
     }
   }
 

--- a/lib/web_ui/test/html/shaders/gradient_golden_test.dart
+++ b/lib/web_ui/test/html/shaders/gradient_golden_test.dart
@@ -421,7 +421,7 @@ Future<void> testMain() async {
     }
 
     expect(context!.isContextLost(), isFalse);
-  });
+  }, skip: isFirefox);
 
   test('Paints clamped, rotated and shifted linear gradient', () async {
     final RecordingCanvas canvas =

--- a/lib/web_ui/test/html/shaders/gradient_golden_test.dart
+++ b/lib/web_ui/test/html/shaders/gradient_golden_test.dart
@@ -5,6 +5,7 @@
 import 'dart:html' as html;
 import 'dart:math' as math;
 import 'dart:typed_data';
+import 'dart:web_gl';
 
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
@@ -388,6 +389,37 @@ Future<void> testMain() async {
         RenderStrategy());
     canvas.endRecording();
     canvas.apply(engineCanvas, screenRect);
+  });
+
+  test('Creating lots of gradients doesn\'t create too many webgl contexts',
+      () async {
+    final html.OffscreenCanvas sideCanvas = html.OffscreenCanvas(5, 5);
+    final RenderingContext? context =
+        sideCanvas.getContext('webgl') as RenderingContext?;
+    expect(context, isNotNull);
+
+    final EngineCanvas engineCanvas =
+        BitmapCanvas(const Rect.fromLTRB(0, 0, 100, 100), RenderStrategy());
+    for (double x = 0; x < 100; x += 10) {
+      for (double y = 0; y < 100; y += 10) {
+        const List<Color> colors = <Color>[
+          Color(0xFFFF0000),
+          Color(0xFF0000FF),
+        ];
+
+        final GradientLinear linearGradient = GradientLinear(
+            const Offset(0, 0),
+            const Offset(10, 10),
+            colors,
+            null,
+            TileMode.clamp,
+            Matrix4.identity().storage);
+        engineCanvas.drawRect(Rect.fromLTWH(x, y, 10, 10),
+            SurfacePaintData()..shader = linearGradient);
+      }
+    }
+
+    expect(context!.isContextLost(), isFalse);
   });
 
   test('Paints clamped, rotated and shifted linear gradient', () async {

--- a/lib/web_ui/test/html/shaders/gradient_golden_test.dart
+++ b/lib/web_ui/test/html/shaders/gradient_golden_test.dart
@@ -393,7 +393,8 @@ Future<void> testMain() async {
 
   test('Creating lots of gradients doesn\'t create too many webgl contexts',
       () async {
-    final html.OffscreenCanvas sideCanvas = html.OffscreenCanvas(5, 5);
+    final html.CanvasElement sideCanvas =
+        html.CanvasElement(width: 5, height: 5);
     final RenderingContext? context =
         sideCanvas.getContext('webgl') as RenderingContext?;
     expect(context, isNotNull);


### PR DESCRIPTION
Instead of creating a new offscreen canvas every time we render the image, just use one shared temporary canvas that is reused whenever needed.