### PR TITLE
[fuchsia] Remove spurious ERROR log 

### DIFF
--- a/shell/platform/fuchsia/flutter/flatland_platform_view.cc
+++ b/shell/platform/fuchsia/flutter/flatland_platform_view.cc
@@ -32,7 +32,8 @@ FlatlandPlatformView::FlatlandPlatformView(
     AwaitVsyncCallback await_vsync_callback,
     AwaitVsyncForSecondaryCallbackCallback
         await_vsync_for_secondary_callback_callback)
-    : PlatformView(delegate,
+    : PlatformView(true /* is_flatland */,
+                   delegate,
                    std::move(task_runners),
                    std::move(view_ref),
                    std::move(external_view_embedder),

--- a/shell/platform/fuchsia/flutter/gfx_platform_view.cc
+++ b/shell/platform/fuchsia/flutter/gfx_platform_view.cc
@@ -33,7 +33,8 @@ GfxPlatformView::GfxPlatformView(
     AwaitVsyncCallback await_vsync_callback,
     AwaitVsyncForSecondaryCallbackCallback
         await_vsync_for_secondary_callback_callback)
-    : PlatformView(delegate,
+    : PlatformView(false /* is_flatland */,
+                   delegate,
                    std::move(task_runners),
                    std::move(view_ref),
                    std::move(external_view_embedder),

--- a/shell/platform/fuchsia/flutter/platform_view.cc
+++ b/shell/platform/fuchsia/flutter/platform_view.cc
@@ -51,6 +51,7 @@ void SetInterfaceErrorHandler(fidl::Binding<T>& binding, std::string name) {
 }
 
 PlatformView::PlatformView(
+    bool is_flatland,
     flutter::PlatformView::Delegate& delegate,
     flutter::TaskRunners task_runners,
     fuchsia::ui::views::ViewRef view_ref,
@@ -121,30 +122,33 @@ PlatformView::PlatformView(
   });
 
   // Begin watching for pointer events.
-  pointer_delegate_->WatchLoop([weak = weak_factory_.GetWeakPtr()](
-                                   std::vector<flutter::PointerData> events) {
-    if (!weak) {
-      FML_LOG(WARNING) << "PlatformView use-after-free attempted. Ignoring.";
-      return;
-    }
+  if (is_flatland) {  // TODO(fxbug.dev/85125): make unconditional
+    pointer_delegate_->WatchLoop([weak = weak_factory_.GetWeakPtr()](
+                                     std::vector<flutter::PointerData> events) {
+      if (!weak) {
+        FML_LOG(WARNING) << "PlatformView use-after-free attempted. Ignoring.";
+        return;
+      }
 
-    if (events.size() == 0) {
-      return;  // No work, bounce out.
-    }
+      if (events.size() == 0) {
+        return;  // No work, bounce out.
+      }
 
-    // If pixel ratio hasn't been set, use a default value of 1.
-    const float pixel_ratio = weak->view_pixel_ratio_.value_or(1.f);
-    auto packet = std::make_unique<flutter::PointerDataPacket>(events.size());
-    for (size_t i = 0; i < events.size(); ++i) {
-      auto& event = events[i];
-      // Translate logical to physical coordinates, as per flutter::PointerData
-      // contract. Done here because pixel ratio comes from the graphics API.
-      event.physical_x = event.physical_x * pixel_ratio;
-      event.physical_y = event.physical_y * pixel_ratio;
-      packet->SetPointerData(i, event);
-    }
-    weak->DispatchPointerDataPacket(std::move(packet));
-  });
+      // If pixel ratio hasn't been set, use a default value of 1.
+      const float pixel_ratio = weak->view_pixel_ratio_.value_or(1.f);
+      auto packet = std::make_unique<flutter::PointerDataPacket>(events.size());
+      for (size_t i = 0; i < events.size(); ++i) {
+        auto& event = events[i];
+        // Translate logical to physical coordinates, as per
+        // flutter::PointerData contract. Done here because pixel ratio comes
+        // from the graphics API.
+        event.physical_x = event.physical_x * pixel_ratio;
+        event.physical_y = event.physical_y * pixel_ratio;
+        packet->SetPointerData(i, event);
+      }
+      weak->DispatchPointerDataPacket(std::move(packet));
+    });
+  }
 
   // Finally! Register the native platform message handlers.
   RegisterPlatformMessageHandlers();

--- a/shell/platform/fuchsia/flutter/platform_view.h
+++ b/shell/platform/fuchsia/flutter/platform_view.h
@@ -64,6 +64,7 @@ class PlatformView : public flutter::PlatformView,
                      private fuchsia::ui::input::InputMethodEditorClient {
  public:
   PlatformView(
+      bool is_flatland,
       flutter::PlatformView::Delegate& delegate,
       flutter::TaskRunners task_runners,
       fuchsia::ui::views::ViewRef view_ref,

--- a/shell/platform/fuchsia/flutter/platform_view_unittest.cc
+++ b/shell/platform/fuchsia/flutter/platform_view_unittest.cc
@@ -1385,7 +1385,8 @@ TEST_F(PlatformViewTests, OnShaderWarmup) {
   EXPECT_EQ(expected_result_string, response->result_string);
 }
 
-TEST_F(PlatformViewTests, TouchSourceLogicalToPhysicalConversion) {
+// TODO(fxbug.dev/85125): Enable when GFX converts to TouchSource.
+TEST_F(PlatformViewTests, DISABLED_TouchSourceLogicalToPhysicalConversion) {
   constexpr std::array<std::array<float, 2>, 2> kRect = {{{0, 0}, {20, 20}}};
   constexpr std::array<float, 9> kIdentity = {1, 0, 0, 0, 1, 0, 0, 0, 1};
   constexpr fuchsia::ui::pointer::TouchInteractionId kIxnOne = {


### PR DESCRIPTION
This PR avoids setting up the fuchsia.ui.pointer.TouchSource/MouseSource watch loop when in GFX mode. We employ a boolean parameter to tell the difference to the superclass PlatformView constructor, and the scoping is limited to that ctor. 

[Noisy PlatformView constructor](https://github.com/flutter/flutter/issues/102396)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ x I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

