### PR TITLE
Convert Gfx PlatformView to use modern TouchSource API

### DIFF
--- a/shell/platform/fuchsia/flutter/engine.cc
+++ b/shell/platform/fuchsia/flutter/engine.cc
@@ -166,8 +166,8 @@ void Engine::Initialize(
   } else {
     gfx_protocols.set_view_focuser(focuser.NewRequest());
     gfx_protocols.set_view_ref_focused(view_ref_focused.NewRequest());
-    // TODO(fxbug.dev/85125): Enable TouchSource for GFX.
-    // gfx_protocols.set_touch_source(touch_source.NewRequest());
+    gfx_protocols.set_touch_source(touch_source.NewRequest());
+    // GFX used only on products without a mouse.
   }
   scenic->CreateSessionT(std::move(gfx_protocols), [] {});
 

--- a/shell/platform/fuchsia/flutter/flatland_platform_view.cc
+++ b/shell/platform/fuchsia/flutter/flatland_platform_view.cc
@@ -32,8 +32,7 @@ FlatlandPlatformView::FlatlandPlatformView(
     AwaitVsyncCallback await_vsync_callback,
     AwaitVsyncForSecondaryCallbackCallback
         await_vsync_for_secondary_callback_callback)
-    : PlatformView(true /* is_flatland */,
-                   delegate,
+    : PlatformView(delegate,
                    std::move(task_runners),
                    std::move(view_ref),
                    std::move(external_view_embedder),

--- a/shell/platform/fuchsia/flutter/gfx_platform_view.cc
+++ b/shell/platform/fuchsia/flutter/gfx_platform_view.cc
@@ -33,8 +33,7 @@ GfxPlatformView::GfxPlatformView(
     AwaitVsyncCallback await_vsync_callback,
     AwaitVsyncForSecondaryCallbackCallback
         await_vsync_for_secondary_callback_callback)
-    : PlatformView(false /* is_flatland */,
-                   delegate,
+    : PlatformView(delegate,
                    std::move(task_runners),
                    std::move(view_ref),
                    std::move(external_view_embedder),

--- a/shell/platform/fuchsia/flutter/platform_view.cc
+++ b/shell/platform/fuchsia/flutter/platform_view.cc
@@ -51,7 +51,6 @@ void SetInterfaceErrorHandler(fidl::Binding<T>& binding, std::string name) {
 }
 
 PlatformView::PlatformView(
-    bool is_flatland,
     flutter::PlatformView::Delegate& delegate,
     flutter::TaskRunners task_runners,
     fuchsia::ui::views::ViewRef view_ref,
@@ -122,33 +121,31 @@ PlatformView::PlatformView(
   });
 
   // Begin watching for pointer events.
-  if (is_flatland) {  // TODO(fxbug.dev/85125): make unconditional
-    pointer_delegate_->WatchLoop([weak = weak_factory_.GetWeakPtr()](
-                                     std::vector<flutter::PointerData> events) {
-      if (!weak) {
-        FML_LOG(WARNING) << "PlatformView use-after-free attempted. Ignoring.";
-        return;
-      }
+  pointer_delegate_->WatchLoop([weak = weak_factory_.GetWeakPtr()](
+                                   std::vector<flutter::PointerData> events) {
+    if (!weak) {
+      FML_LOG(WARNING) << "PlatformView use-after-free attempted. Ignoring.";
+      return;
+    }
 
-      if (events.size() == 0) {
-        return;  // No work, bounce out.
-      }
+    if (events.size() == 0) {
+      return;  // No work, bounce out.
+    }
 
-      // If pixel ratio hasn't been set, use a default value of 1.
-      const float pixel_ratio = weak->view_pixel_ratio_.value_or(1.f);
-      auto packet = std::make_unique<flutter::PointerDataPacket>(events.size());
-      for (size_t i = 0; i < events.size(); ++i) {
-        auto& event = events[i];
-        // Translate logical to physical coordinates, as per
-        // flutter::PointerData contract. Done here because pixel ratio comes
-        // from the graphics API.
-        event.physical_x = event.physical_x * pixel_ratio;
-        event.physical_y = event.physical_y * pixel_ratio;
-        packet->SetPointerData(i, event);
-      }
-      weak->DispatchPointerDataPacket(std::move(packet));
-    });
-  }
+    // If pixel ratio hasn't been set, use a default value of 1.
+    const float pixel_ratio = weak->view_pixel_ratio_.value_or(1.f);
+    auto packet = std::make_unique<flutter::PointerDataPacket>(events.size());
+    for (size_t i = 0; i < events.size(); ++i) {
+      auto& event = events[i];
+      // Translate logical to physical coordinates, as per
+      // flutter::PointerData contract. Done here because pixel ratio comes
+      // from the graphics API.
+      event.physical_x = event.physical_x * pixel_ratio;
+      event.physical_y = event.physical_y * pixel_ratio;
+      packet->SetPointerData(i, event);
+    }
+    weak->DispatchPointerDataPacket(std::move(packet));
+  });
 
   // Finally! Register the native platform message handlers.
   RegisterPlatformMessageHandlers();

--- a/shell/platform/fuchsia/flutter/platform_view.h
+++ b/shell/platform/fuchsia/flutter/platform_view.h
@@ -64,7 +64,6 @@ class PlatformView : public flutter::PlatformView,
                      private fuchsia::ui::input::InputMethodEditorClient {
  public:
   PlatformView(
-      bool is_flatland,
       flutter::PlatformView::Delegate& delegate,
       flutter::TaskRunners task_runners,
       fuchsia::ui::views::ViewRef view_ref,

--- a/shell/platform/fuchsia/flutter/platform_view_unittest.cc
+++ b/shell/platform/fuchsia/flutter/platform_view_unittest.cc
@@ -1385,8 +1385,7 @@ TEST_F(PlatformViewTests, OnShaderWarmup) {
   EXPECT_EQ(expected_result_string, response->result_string);
 }
 
-// TODO(fxbug.dev/85125): Enable when GFX converts to TouchSource.
-TEST_F(PlatformViewTests, DISABLED_TouchSourceLogicalToPhysicalConversion) {
+TEST_F(PlatformViewTests, TouchSourceLogicalToPhysicalConversion) {
   constexpr std::array<std::array<float, 2>, 2> kRect = {{{0, 0}, {20, 20}}};
   constexpr std::array<float, 9> kIdentity = {1, 0, 0, 0, 1, 0, 0, 0, 1};
   constexpr fuchsia::ui::pointer::TouchInteractionId kIxnOne = {

--- a/shell/platform/fuchsia/flutter/pointer_delegate.cc
+++ b/shell/platform/fuchsia/flutter/pointer_delegate.cc
@@ -411,7 +411,9 @@ void PointerDelegate::WatchLoop(
   // Start watching both channels.
   touch_source_->Watch(std::move(touch_responses_), /*copy*/ touch_responder_);
   touch_responses_.clear();
-  mouse_source_->Watch(/*copy*/ mouse_responder_);
+  if (mouse_source_) {
+    mouse_source_->Watch(/*copy*/ mouse_responder_);
+  }
 }
 
 }  // namespace flutter_runner


### PR DESCRIPTION
This PR switches the GfxPlatformView code to use the TouchSource/MouseSource API. After this PR, both GFX and Flatland will receive touch and mouse events over the new APIs, instead of the legacy GFX SessionListener API. 

[GFX uses TouchSource](https://github.com/flutter/flutter/issues/102412)

Test re-enabled: PlatformViewTests.TouchSourceLogicalToPhysicalConversion

This PR has been manually validated on a sherlock device running production code, with the following UI cases:
- ordinary usage of the System UI
- with child view (YouTube), bring up settings (Sys UI)
- with a partial-scren child view (Duo) interrupting another full-screen child view (YT), and both are still responsive to touch

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

