### PR TITLE
Render DisplayLists to leaf_builder by reference and handle opacity

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -115,7 +115,7 @@ deps = {
   'src': 'https://github.com/flutter/buildroot.git' + '@' + '2c41cfc742586b44984595960fc161c30252d8d6',
 
   'src/flutter/impeller':
-   Var('github_git') + '/flutter/impeller' + '@' + 'c833f7de604f5c4298216494fb7b7ff378353601',
+   Var('github_git') + '/flutter/impeller' + '@' + '380e45d7f27c6815638287c99fbb0a0b136fd861',
 
    # Fuchsia compatibility
    #

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -478,8 +478,6 @@ FILE: ../../../flutter/impeller/display_list/display_list_playground.cc
 FILE: ../../../flutter/impeller/display_list/display_list_playground.h
 FILE: ../../../flutter/impeller/display_list/display_list_unittests.cc
 FILE: ../../../flutter/impeller/docs/shader_pipeline.png
-FILE: ../../../flutter/impeller/entity/contents/clear_contents.cc
-FILE: ../../../flutter/impeller/entity/contents/clear_contents.h
 FILE: ../../../flutter/impeller/entity/contents/clip_contents.cc
 FILE: ../../../flutter/impeller/entity/contents/clip_contents.h
 FILE: ../../../flutter/impeller/entity/contents/content_context.cc

--- a/display_list/display_list_ops.h
+++ b/display_list/display_list_ops.h
@@ -894,6 +894,12 @@ struct DrawDisplayListOp final : DLOp {
   void dispatch(Dispatcher& dispatcher) const {
     dispatcher.drawDisplayList(display_list);
   }
+
+  DisplayListCompare equals(const DrawDisplayListOp* other) const {
+    return display_list->Equals(other->display_list)
+               ? DisplayListCompare::kEqual
+               : DisplayListCompare::kNotEqual;
+  }
 };
 
 // 4 byte header + 8 payload bytes + an aligned pointer take 24 bytes

--- a/display_list/display_list_paint.h
+++ b/display_list/display_list_paint.h
@@ -103,6 +103,12 @@ class DlPaint {
     return *this;
   }
 
+  uint8_t getAlpha() const { return color_.argb >> 24; }
+  DlPaint& setAlpha(uint8_t alpha) {
+    color_.argb = alpha << 24 | (color_.argb & 0x00FFFFFF);
+    return *this;
+  }
+
   DlBlendMode getBlendMode() const {
     return static_cast<DlBlendMode>(blendMode_);
   }

--- a/display_list/display_list_paint_unittests.cc
+++ b/display_list/display_list_paint_unittests.cc
@@ -16,6 +16,7 @@ TEST(DisplayListPaint, ConstructorDefaults) {
   EXPECT_FALSE(paint.isDither());
   EXPECT_FALSE(paint.isInvertColors());
   EXPECT_EQ(paint.getColor(), DlColor{0xFF000000});
+  EXPECT_EQ(paint.getAlpha(), 0xFF);
   EXPECT_EQ(paint.getBlendMode(), DlBlendMode::kDefaultMode);
   EXPECT_EQ(paint.getDrawStyle(), DlDrawStyle::kDefaultStyle);
   EXPECT_EQ(paint.getStrokeCap(), DlStrokeCap::kDefaultCap);
@@ -38,6 +39,7 @@ TEST(DisplayListPaint, ConstructorDefaults) {
   EXPECT_NE(paint, DlPaint().setDither(true));
   EXPECT_NE(paint, DlPaint().setInvertColors(true));
   EXPECT_NE(paint, DlPaint().setColor(DlColor(0xFF00FF00)));
+  EXPECT_NE(paint, DlPaint().setAlpha(0x7f));
   EXPECT_NE(paint, DlPaint().setBlendMode(DlBlendMode::kDstIn));
   EXPECT_NE(paint, DlPaint().setDrawStyle(DlDrawStyle::kStrokeAndFill));
   EXPECT_NE(paint, DlPaint().setStrokeCap(DlStrokeCap::kRound));
@@ -65,6 +67,7 @@ TEST(DisplayListPaint, ChainingConstructor) {
           .setDither(true)                                          //
           .setInvertColors(true)                                    //
           .setColor({0xFF00FF00})                                   //
+          .setAlpha(0x7F)                                           //
           .setBlendMode(DlBlendMode::kLuminosity)                   //
           .setDrawStyle(DlDrawStyle::kStrokeAndFill)                //
           .setStrokeCap(DlStrokeCap::kSquare)                       //
@@ -81,7 +84,8 @@ TEST(DisplayListPaint, ChainingConstructor) {
   EXPECT_TRUE(paint.isAntiAlias());
   EXPECT_TRUE(paint.isDither());
   EXPECT_TRUE(paint.isInvertColors());
-  EXPECT_EQ(paint.getColor(), DlColor{0xFF00FF00});
+  EXPECT_EQ(paint.getColor(), DlColor{0x7F00FF00});
+  EXPECT_EQ(paint.getAlpha(), 0x7F);
   EXPECT_EQ(paint.getBlendMode(), DlBlendMode::kLuminosity);
   EXPECT_EQ(paint.getDrawStyle(), DlDrawStyle::kStrokeAndFill);
   EXPECT_EQ(paint.getStrokeCap(), DlStrokeCap::kSquare);

--- a/flow/layers/display_list_layer.cc
+++ b/flow/layers/display_list_layer.cc
@@ -160,12 +160,10 @@ void DisplayListLayer::Paint(PaintContext& context) const {
     AutoCachePaint save_paint(context);
     int restore_count = context.leaf_nodes_builder->getSaveCount();
     if (save_paint.paint() != nullptr) {
-      context.leaf_nodes_builder->setAttributesFromPaint(
-          *save_paint.paint(), DisplayListOpFlags::kSaveLayerWithPaintFlags);
-      context.leaf_nodes_builder->saveLayer(&paint_bounds(), true);
+      DlPaint paint = DlPaint().setAlpha(save_paint.paint()->getAlpha());
+      context.leaf_nodes_builder->saveLayer(&paint_bounds(), &paint);
     }
-    display_list()->RenderTo(context.leaf_nodes_builder,
-                             context.inherited_opacity);
+    context.leaf_nodes_builder->drawDisplayList(display_list_.skia_object());
     context.leaf_nodes_builder->restoreToCount(restore_count);
   } else {
     display_list()->RenderTo(context.leaf_nodes_canvas,

--- a/flow/layers/display_list_layer_unittests.cc
+++ b/flow/layers/display_list_layer_unittests.cc
@@ -131,6 +131,10 @@ TEST_F(DisplayListLayerTest, SimpleDisplayListOpacityInheritance) {
   opacity_layer->Preroll(context, SkMatrix::I());
   EXPECT_TRUE(opacity_layer->children_can_accept_opacity());
 
+  DisplayListBuilder child_builder;
+  child_builder.drawRect(picture_bounds);
+  auto child_display_list = child_builder.Build();
+
   auto save_layer_bounds =
       picture_bounds.makeOffset(layer_offset.fX, layer_offset.fY);
   auto opacity_integral_matrix =
@@ -159,7 +163,7 @@ TEST_F(DisplayListLayerTest, SimpleDisplayListOpacityInheritance) {
           expected_builder.setColor(opacity_alpha << 24);
           expected_builder.saveLayer(&save_layer_bounds, true);
           /* display_list contents */ {  //
-            expected_builder.drawRect(picture_bounds);
+            expected_builder.drawDisplayList(child_display_list);
           }
           expected_builder.restore();
         }
@@ -200,6 +204,11 @@ TEST_F(DisplayListLayerTest, IncompatibleDisplayListOpacityInheritance) {
   opacity_layer->Preroll(context, SkMatrix::I());
   EXPECT_FALSE(opacity_layer->children_can_accept_opacity());
 
+  DisplayListBuilder child_builder;
+  child_builder.drawRect(picture1_bounds);
+  child_builder.drawRect(picture2_bounds);
+  auto child_display_list = child_builder.Build();
+
   auto display_list_bounds = picture1_bounds;
   display_list_bounds.join(picture2_bounds);
   auto save_layer_bounds =
@@ -231,8 +240,7 @@ TEST_F(DisplayListLayerTest, IncompatibleDisplayListOpacityInheritance) {
             expected_builder.transformReset();
             expected_builder.transform(layer_offset_integral_matrix);
 #endif
-            expected_builder.drawRect(picture1_bounds);
-            expected_builder.drawRect(picture2_bounds);
+            expected_builder.drawDisplayList(child_display_list);
           }
           expected_builder.restore();
         }


### PR DESCRIPTION
Replaces https://github.com/flutter/engine/pull/32442 with a much simpler implementation

The previous way of rendering DisplayList objects in DisplayListLayer by embedding them in the frame builder would result in a lot of copying and not reasonably preserve the initial state for the layer's DisplayList.

This PR now renders them by reference (an approach enabled by https://github.com/flutter/impeller/pull/153) and thus they should render with their appropriate state.