### PR TITLE
Remove unused pkg/pedantic dependency.

### DIFF
--- a/flutter_frontend_server/pubspec.yaml
+++ b/flutter_frontend_server/pubspec.yaml
@@ -99,8 +99,6 @@ dependency_overrides:
     path: ../../third_party/dart/third_party/pkg_tested/package_config
   path:
     path: ../../third_party/dart/third_party/pkg/path
-  pedantic:
-    path: ../../third_party/dart/third_party/pkg/pedantic
   protobuf:
     path: ../../third_party/dart/third_party/pkg/protobuf/protobuf
   shelf:

--- a/testing/benchmark/pubspec.yaml
+++ b/testing/benchmark/pubspec.yaml
@@ -63,8 +63,6 @@ dependency_overrides:
     path: ../../../third_party/pkg/flutter_packages/packages/metrics_center
   path:
     path: ../../../third_party/dart/third_party/pkg/path
-  pedantic:
-    path: ../../../third_party/dart/third_party/pkg/pedantic
   smith:
     path: ../../../third_party/dart/pkg/smith
   source_span:


### PR DESCRIPTION
The dependency is unused, but its presence causes breakages during latest attempts to roll dart since https://dart.googlesource.com/sdk/+/aa63ef8f4f506ffa9f160b960158e861be370b4a removed pkg/pedantic from dart sdk DEPS.
