### PR TITLE
use new DlObjects throughout the DisplayList code

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -56,12 +56,14 @@ FILE: ../../../flutter/display_list/display_list_canvas_dispatcher.h
 FILE: ../../../flutter/display_list/display_list_canvas_recorder.cc
 FILE: ../../../flutter/display_list/display_list_canvas_recorder.h
 FILE: ../../../flutter/display_list/display_list_canvas_unittests.cc
+FILE: ../../../flutter/display_list/display_list_color.h
 FILE: ../../../flutter/display_list/display_list_color_filter.cc
 FILE: ../../../flutter/display_list/display_list_color_filter.h
 FILE: ../../../flutter/display_list/display_list_color_filter_unittests.cc
 FILE: ../../../flutter/display_list/display_list_color_source.cc
 FILE: ../../../flutter/display_list/display_list_color_source.h
 FILE: ../../../flutter/display_list/display_list_color_source_unittests.cc
+FILE: ../../../flutter/display_list/display_list_color_unittests.cc
 FILE: ../../../flutter/display_list/display_list_comparable.h
 FILE: ../../../flutter/display_list/display_list_complexity.cc
 FILE: ../../../flutter/display_list/display_list_complexity.h

--- a/display_list/BUILD.gn
+++ b/display_list/BUILD.gn
@@ -18,6 +18,7 @@ source_set("display_list") {
     "display_list_canvas_dispatcher.h",
     "display_list_canvas_recorder.cc",
     "display_list_canvas_recorder.h",
+    "display_list_color.h",
     "display_list_color_filter.cc",
     "display_list_color_filter.h",
     "display_list_color_source.cc",
@@ -86,6 +87,7 @@ if (enable_unittests) {
     sources = [
       "display_list_color_filter_unittests.cc",
       "display_list_color_source_unittests.cc",
+      "display_list_color_unittests.cc",
       "display_list_complexity_unittests.cc",
       "display_list_enum_unittests.cc",
       "display_list_image_filter_unittests.cc",

--- a/display_list/display_list_benchmarks.cc
+++ b/display_list/display_list_benchmarks.cc
@@ -698,7 +698,7 @@ std::shared_ptr<DlVertices> GetTestVertices(SkPoint center,
       GetPolygonPoints(outer_vertex_count, center, radius);
 
   std::vector<SkPoint> vertices;
-  std::vector<SkColor> colors;
+  std::vector<DlColor> colors;
 
   switch (mode) {
     case DlVertexMode::kTriangleFan:

--- a/display_list/display_list_builder.h
+++ b/display_list/display_list_builder.h
@@ -31,52 +31,52 @@ class DisplayListBuilder final : public virtual Dispatcher,
   ~DisplayListBuilder();
 
   void setAntiAlias(bool aa) override {
-    if (current_anti_alias_ != aa) {
+    if (current_.isAntiAlias() != aa) {
       onSetAntiAlias(aa);
     }
   }
   void setDither(bool dither) override {
-    if (current_dither_ != dither) {
+    if (current_.isDither() != dither) {
       onSetDither(dither);
     }
   }
   void setInvertColors(bool invert) override {
-    if (current_invert_colors_ != invert) {
+    if (current_.isInvertColors() != invert) {
       onSetInvertColors(invert);
     }
   }
-  void setStrokeCap(SkPaint::Cap cap) override {
-    if (current_stroke_cap_ != cap) {
+  void setStrokeCap(DlStrokeCap cap) override {
+    if (current_.getStrokeCap() != cap) {
       onSetStrokeCap(cap);
     }
   }
-  void setStrokeJoin(SkPaint::Join join) override {
-    if (current_stroke_join_ != join) {
+  void setStrokeJoin(DlStrokeJoin join) override {
+    if (current_.getStrokeJoin() != join) {
       onSetStrokeJoin(join);
     }
   }
-  void setStyle(SkPaint::Style style) override {
-    if (current_style_ != style) {
+  void setStyle(DlDrawStyle style) override {
+    if (current_.getDrawStyle() != style) {
       onSetStyle(style);
     }
   }
-  void setStrokeWidth(SkScalar width) override {
-    if (current_stroke_width_ != width) {
+  void setStrokeWidth(float width) override {
+    if (current_.getStrokeWidth() != width) {
       onSetStrokeWidth(width);
     }
   }
-  void setStrokeMiter(SkScalar limit) override {
-    if (current_stroke_miter_ != limit) {
+  void setStrokeMiter(float limit) override {
+    if (current_.getStrokeMiter() != limit) {
       onSetStrokeMiter(limit);
     }
   }
-  void setColor(SkColor color) override {
-    if (current_color_ != color) {
+  void setColor(DlColor color) override {
+    if (current_.getColor() != color) {
       onSetColor(color);
     }
   }
   void setBlendMode(DlBlendMode mode) override {
-    if (current_blender_ || current_blend_mode_ != mode) {
+    if (current_blender_ || current_.getBlendMode() != mode) {
       onSetBlendMode(mode);
     }
   }
@@ -88,17 +88,17 @@ class DisplayListBuilder final : public virtual Dispatcher,
     }
   }
   void setColorSource(const DlColorSource* source) override {
-    if (NotEquals(current_color_source_, source)) {
+    if (NotEquals(current_.getColorSource(), source)) {
       onSetColorSource(source);
     }
   }
   void setImageFilter(const DlImageFilter* filter) override {
-    if (NotEquals(current_image_filter_, filter)) {
+    if (NotEquals(current_.getImageFilter(), filter)) {
       onSetImageFilter(filter);
     }
   }
   void setColorFilter(const DlColorFilter* filter) override {
-    if (NotEquals(current_color_filter_, filter)) {
+    if (NotEquals(current_.getColorFilter(), filter)) {
       onSetColorFilter(filter);
     }
   }
@@ -108,43 +108,43 @@ class DisplayListBuilder final : public virtual Dispatcher,
     }
   }
   void setMaskFilter(const DlMaskFilter* filter) override {
-    if (NotEquals(current_mask_filter_, filter)) {
+    if (NotEquals(current_.getMaskFilter(), filter)) {
       onSetMaskFilter(filter);
     }
   }
 
-  bool isAntiAlias() const { return current_anti_alias_; }
-  bool isDither() const { return current_dither_; }
-  SkPaint::Style getStyle() const { return current_style_; }
-  SkColor getColor() const { return current_color_; }
-  SkScalar getStrokeWidth() const { return current_stroke_width_; }
-  SkScalar getStrokeMiter() const { return current_stroke_miter_; }
-  SkPaint::Cap getStrokeCap() const { return current_stroke_cap_; }
-  SkPaint::Join getStrokeJoin() const { return current_stroke_join_; }
+  bool isAntiAlias() const { return current_.isAntiAlias(); }
+  bool isDither() const { return current_.isDither(); }
+  DlDrawStyle getStyle() const { return current_.getDrawStyle(); }
+  DlColor getColor() const { return current_.getColor(); }
+  float getStrokeWidth() const { return current_.getStrokeWidth(); }
+  float getStrokeMiter() const { return current_.getStrokeMiter(); }
+  DlStrokeCap getStrokeCap() const { return current_.getStrokeCap(); }
+  DlStrokeJoin getStrokeJoin() const { return current_.getStrokeJoin(); }
   std::shared_ptr<const DlColorSource> getColorSource() const {
-    return current_color_source_;
+    return current_.getColorSource();
   }
   std::shared_ptr<const DlColorFilter> getColorFilter() const {
-    return current_color_filter_;
+    return current_.getColorFilter();
   }
-  bool isInvertColors() const { return current_invert_colors_; }
+  bool isInvertColors() const { return current_.isInvertColors(); }
   std::optional<DlBlendMode> getBlendMode() const {
     if (current_blender_) {
       // The setters will turn "Mode" style blenders into "blend_mode"s
       return {};
     }
-    return current_blend_mode_;
+    return current_.getBlendMode();
   }
   sk_sp<SkBlender> getBlender() const {
     return current_blender_ ? current_blender_
-                            : SkBlender::Mode(ToSk(current_blend_mode_));
+                            : SkBlender::Mode(ToSk(current_.getBlendMode()));
   }
   sk_sp<SkPathEffect> getPathEffect() const { return current_path_effect_; }
   std::shared_ptr<const DlMaskFilter> getMaskFilter() const {
-    return current_mask_filter_;
+    return current_.getMaskFilter();
   }
-  std::shared_ptr<DlImageFilter> getImageFilter() const {
-    return current_image_filter_;
+  std::shared_ptr<const DlImageFilter> getImageFilter() const {
+    return current_.getImageFilter();
   }
 
   void save() override;
@@ -196,7 +196,7 @@ class DisplayListBuilder final : public virtual Dispatcher,
 
   void drawPaint() override;
   void drawPaint(const DlPaint& paint);
-  void drawColor(SkColor color, DlBlendMode mode) override;
+  void drawColor(DlColor color, DlBlendMode mode) override;
   void drawLine(const SkPoint& p0, const SkPoint& p1) override;
   void drawLine(const SkPoint& p0, const SkPoint& p1, const DlPaint& paint);
   void drawRect(const SkRect& rect) override;
@@ -285,7 +285,7 @@ class DisplayListBuilder final : public virtual Dispatcher,
   void drawAtlas(const sk_sp<DlImage> atlas,
                  const SkRSXform xform[],
                  const SkRect tex[],
-                 const SkColor colors[],
+                 const DlColor colors[],
                  int count,
                  DlBlendMode mode,
                  const SkSamplingOptions& sampling,
@@ -294,7 +294,7 @@ class DisplayListBuilder final : public virtual Dispatcher,
   void drawAtlas(const sk_sp<DlImage> atlas,
                  const SkRSXform xform[],
                  const SkRect tex[],
-                 const SkColor colors[],
+                 const DlColor colors[],
                  int count,
                  DlBlendMode mode,
                  const SkSamplingOptions& sampling,
@@ -308,7 +308,7 @@ class DisplayListBuilder final : public virtual Dispatcher,
                     SkScalar x,
                     SkScalar y) override;
   void drawShadow(const SkPath& path,
-                  const SkColor color,
+                  const DlColor color,
                   const SkScalar elevation,
                   bool transparent_occluder,
                   SkScalar dpr) override;
@@ -398,11 +398,11 @@ class DisplayListBuilder final : public virtual Dispatcher,
   }
 
   void UpdateCurrentOpacityCompatibility() {
-    current_opacity_compatibility_ =         //
-        current_color_filter_ == nullptr &&  //
-        !current_invert_colors_ &&           //
-        current_blender_ == nullptr &&       //
-        IsOpacityCompatible(current_blend_mode_);
+    current_opacity_compatibility_ =             //
+        current_.getColorFilter() == nullptr &&  //
+        !current_.isInvertColors() &&            //
+        current_blender_ == nullptr &&           //
+        IsOpacityCompatible(current_.getBlendMode());
   }
 
   // Update the opacity compatibility flags of the current layer for an op
@@ -428,7 +428,8 @@ class DisplayListBuilder final : public virtual Dispatcher,
   void CheckLayerOpacityHairlineCompatibility() {
     UpdateLayerOpacityCompatibility(
         current_opacity_compatibility_ &&
-        (current_style_ == SkPaint::kFill_Style || current_stroke_width_ > 0));
+        (current_.getDrawStyle() == DlDrawStyle::kFill ||
+         current_.getStrokeWidth() > 0));
   }
 
   // Check for opacity compatibility for an op that ignores the current
@@ -441,12 +442,12 @@ class DisplayListBuilder final : public virtual Dispatcher,
   void onSetAntiAlias(bool aa);
   void onSetDither(bool dither);
   void onSetInvertColors(bool invert);
-  void onSetStrokeCap(SkPaint::Cap cap);
-  void onSetStrokeJoin(SkPaint::Join join);
-  void onSetStyle(SkPaint::Style style);
+  void onSetStrokeCap(DlStrokeCap cap);
+  void onSetStrokeJoin(DlStrokeJoin join);
+  void onSetStyle(DlDrawStyle style);
   void onSetStrokeWidth(SkScalar width);
   void onSetStrokeMiter(SkScalar limit);
-  void onSetColor(SkColor color);
+  void onSetColor(DlColor color);
   void onSetBlendMode(DlBlendMode mode);
   void onSetBlender(sk_sp<SkBlender> blender);
   void onSetColorSource(const DlColorSource* source);
@@ -456,24 +457,10 @@ class DisplayListBuilder final : public virtual Dispatcher,
   void onSetMaskFilter(const DlMaskFilter* filter);
   void onSetMaskBlurFilter(SkBlurStyle style, SkScalar sigma);
 
-  // These values should match the defaults of the Dart Paint object.
-  bool current_anti_alias_ = false;
-  bool current_dither_ = false;
-  bool current_invert_colors_ = false;
-  SkColor current_color_ = 0xFF000000;
-  SkPaint::Style current_style_ = SkPaint::Style::kFill_Style;
-  SkScalar current_stroke_width_ = 0.0;
-  SkScalar current_stroke_miter_ = 4.0;
-  SkPaint::Cap current_stroke_cap_ = SkPaint::Cap::kButt_Cap;
-  SkPaint::Join current_stroke_join_ = SkPaint::Join::kMiter_Join;
-  // If |current_blender_| is set then |current_blend_mode_| should be ignored
-  DlBlendMode current_blend_mode_ = DlBlendMode::kSrcOver;
+  DlPaint current_;
+  // If |current_blender_| is set then ignore |current_.getBlendMode()|
   sk_sp<SkBlender> current_blender_;
-  std::shared_ptr<const DlColorSource> current_color_source_;
-  std::shared_ptr<const DlColorFilter> current_color_filter_;
-  std::shared_ptr<DlImageFilter> current_image_filter_;
   sk_sp<SkPathEffect> current_path_effect_;
-  std::shared_ptr<const DlMaskFilter> current_mask_filter_;
 };
 
 }  // namespace flutter

--- a/display_list/display_list_canvas_dispatcher.cc
+++ b/display_list/display_list_canvas_dispatcher.cc
@@ -131,7 +131,7 @@ void DisplayListCanvasDispatcher::drawPaint() {
   }
   canvas_->drawPaint(sk_paint);
 }
-void DisplayListCanvasDispatcher::drawColor(SkColor color, DlBlendMode mode) {
+void DisplayListCanvasDispatcher::drawColor(DlColor color, DlBlendMode mode) {
   // SkCanvas::drawColor(SkColor) does the following conversion anyway
   // We do it here manually to increase precision on applying opacity
   SkColor4f color4f = SkColor4f::FromColor(color);
@@ -234,7 +234,7 @@ void DisplayListCanvasDispatcher::drawImageLattice(
 void DisplayListCanvasDispatcher::drawAtlas(const sk_sp<DlImage> atlas,
                                             const SkRSXform xform[],
                                             const SkRect tex[],
-                                            const SkColor colors[],
+                                            const DlColor colors[],
                                             int count,
                                             DlBlendMode mode,
                                             const SkSamplingOptions& sampling,
@@ -247,7 +247,8 @@ void DisplayListCanvasDispatcher::drawAtlas(const sk_sp<DlImage> atlas,
   if (!skia_atlas) {
     return;
   }
-  canvas_->drawAtlas(skia_atlas.get(), xform, tex, colors, count, ToSk(mode),
+  const SkColor* sk_colors = reinterpret_cast<const SkColor*>(colors);
+  canvas_->drawAtlas(skia_atlas.get(), xform, tex, sk_colors, count, ToSk(mode),
                      sampling, cullRect, safe_paint(render_with_attributes));
 }
 void DisplayListCanvasDispatcher::drawPicture(const sk_sp<SkPicture> picture,
@@ -288,7 +289,7 @@ SkRect DisplayListCanvasDispatcher::ComputeShadowBounds(const SkPath& path,
 
 void DisplayListCanvasDispatcher::DrawShadow(SkCanvas* canvas,
                                              const SkPath& path,
-                                             SkColor color,
+                                             DlColor color,
                                              float elevation,
                                              bool transparentOccluder,
                                              SkScalar dpr) {
@@ -311,7 +312,7 @@ void DisplayListCanvasDispatcher::DrawShadow(SkCanvas* canvas,
 }
 
 void DisplayListCanvasDispatcher::drawShadow(const SkPath& path,
-                                             const SkColor color,
+                                             const DlColor color,
                                              const SkScalar elevation,
                                              bool transparent_occluder,
                                              SkScalar dpr) {

--- a/display_list/display_list_canvas_dispatcher.h
+++ b/display_list/display_list_canvas_dispatcher.h
@@ -54,7 +54,7 @@ class DisplayListCanvasDispatcher : public virtual Dispatcher,
   void clipPath(const SkPath& path, SkClipOp clip_op, bool is_aa) override;
 
   void drawPaint() override;
-  void drawColor(SkColor color, DlBlendMode mode) override;
+  void drawColor(DlColor color, DlBlendMode mode) override;
   void drawLine(const SkPoint& p0, const SkPoint& p1) override;
   void drawRect(const SkRect& rect) override;
   void drawOval(const SkRect& bounds) override;
@@ -95,7 +95,7 @@ class DisplayListCanvasDispatcher : public virtual Dispatcher,
   void drawAtlas(const sk_sp<DlImage> atlas,
                  const SkRSXform xform[],
                  const SkRect tex[],
-                 const SkColor colors[],
+                 const DlColor colors[],
                  int count,
                  DlBlendMode mode,
                  const SkSamplingOptions& sampling,
@@ -109,7 +109,7 @@ class DisplayListCanvasDispatcher : public virtual Dispatcher,
                     SkScalar x,
                     SkScalar y) override;
   void drawShadow(const SkPath& path,
-                  const SkColor color,
+                  const DlColor color,
                   const SkScalar elevation,
                   bool transparent_occluder,
                   SkScalar dpr) override;
@@ -121,7 +121,7 @@ class DisplayListCanvasDispatcher : public virtual Dispatcher,
 
   static void DrawShadow(SkCanvas* canvas,
                          const SkPath& path,
-                         SkColor color,
+                         DlColor color,
                          float elevation,
                          bool transparentOccluder,
                          SkScalar dpr);

--- a/display_list/display_list_canvas_recorder.cc
+++ b/display_list/display_list_canvas_recorder.cc
@@ -200,7 +200,8 @@ void DisplayListCanvasRecorder::onDrawAtlas2(const SkImage* image,
   if (paint != nullptr) {
     builder_->setAttributesFromPaint(*paint, kDrawAtlasWithPaintFlags);
   }
-  builder_->drawAtlas(DlImage::Make(image), xform, src, colors, count,
+  const DlColor* dl_colors = reinterpret_cast<const DlColor*>(colors);
+  builder_->drawAtlas(DlImage::Make(image), xform, src, dl_colors, count,
                       ToDl(mode), sampling, cull, paint != nullptr);
 }
 

--- a/display_list/display_list_canvas_unittests.cc
+++ b/display_list/display_list_canvas_unittests.cc
@@ -277,7 +277,7 @@ class RenderEnvironment {
   }
 
   std::unique_ptr<RenderSurface> MakeSurface(
-      const DlColor bg = DlColors::kTransparent,
+      const DlColor bg = DlColor::kTransparent(),
       int width = TestWidth,
       int height = TestHeight) const {
     sk_sp<SkSurface> surface =
@@ -286,7 +286,7 @@ class RenderEnvironment {
     return std::make_unique<RenderSurface>(surface);
   }
 
-  void init_ref(CvRenderer& cv_renderer, DlColor bg = DlColors::kTransparent) {
+  void init_ref(CvRenderer& cv_renderer, DlColor bg = DlColor::kTransparent()) {
     init_ref([=](SkCanvas*, SkPaint&) {}, cv_renderer,
              [=](DisplayListBuilder&) {}, bg);
   }
@@ -294,7 +294,7 @@ class RenderEnvironment {
   void init_ref(CvSetup& cv_setup,
                 CvRenderer& cv_renderer,
                 DlRenderer& dl_setup,
-                DlColor bg = DlColors::kTransparent) {
+                DlColor bg = DlColor::kTransparent()) {
     ref_canvas()->clear(bg);
     dl_setup(ref_attr_);
     SkPaint paint;
@@ -724,7 +724,7 @@ class CanvasCompareTester {
                                     const BoundsTolerance& tolerance) {
     SkRect clip = SkRect::MakeXYWH(RenderCenterX - 1, RenderCenterY - 1, 2, 2);
     SkRect rect = SkRect::MakeXYWH(RenderCenterX, RenderCenterY, 10, 10);
-    DlColor alpha_layer_color = DlColors::kCyan.withAlpha(0x7f);
+    DlColor alpha_layer_color = DlColor::kCyan().withAlpha(0x7f);
     DlColor default_color = DlPaint::kDefaultColor;
     CvRenderer cv_safe_restore = [=](SkCanvas* cv, const SkPaint& p) {
       // Draw another primitive to disable peephole optimizations
@@ -971,7 +971,7 @@ class CanvasCompareTester {
       // primitives (mainly drawLine and drawPoints) do not show much
       // dithering so we use a non-trivial stroke width as well.
       RenderEnvironment dither_env = RenderEnvironment::Make565();
-      DlColor dither_bg = DlColors::kBlack;
+      DlColor dither_bg = DlColor::kBlack();
       CvSetup cv_dither_setup = [=](SkCanvas*, SkPaint& p) {
         p.setShader(testImageColorSource.skia_object());
         p.setAlpha(0xf0);
@@ -1025,8 +1025,8 @@ class CanvasCompareTester {
 
     {
       // half opaque cyan
-      DlColor blendableColor = DlColors::kCyan.withAlpha(0x7f);
-      DlColor bg = DlColors::kWhite;
+      DlColor blendableColor = DlColor::kCyan().withAlpha(0x7f);
+      DlColor bg = DlColor::kWhite();
 
       RenderWith(testP, env, tolerance,
                  CaseParameters(
@@ -1197,32 +1197,32 @@ class CanvasCompareTester {
       // clang-format on
       DlMatrixColorFilter filter(rotate_color_matrix);
       {
-        DlColor bg = DlColors::kWhite;
+        DlColor bg = DlColor::kWhite();
         RenderWith(testP, env, tolerance,
                    CaseParameters(
                        "ColorFilter == RotateRGB",
                        [=](SkCanvas*, SkPaint& p) {
-                         p.setColor(DlColors::kYellow);
+                         p.setColor(DlColor::kYellow());
                          p.setColorFilter(filter.skia_object());
                        },
                        [=](DisplayListBuilder& b) {
-                         b.setColor(DlColors::kYellow);
+                         b.setColor(DlColor::kYellow());
                          b.setColorFilter(&filter);
                        })
                        .with_bg(bg));
       }
       filter = DlMatrixColorFilter(invert_color_matrix);
       {
-        DlColor bg = DlColors::kWhite;
+        DlColor bg = DlColor::kWhite();
         RenderWith(testP, env, tolerance,
                    CaseParameters(
                        "ColorFilter == Invert",
                        [=](SkCanvas*, SkPaint& p) {
-                         p.setColor(DlColors::kYellow);
+                         p.setColor(DlColor::kYellow());
                          p.setColorFilter(filter.skia_object());
                        },
                        [=](DisplayListBuilder& b) {
-                         b.setColor(DlColors::kYellow);
+                         b.setColor(DlColor::kYellow());
                          b.setInvertColors(true);
                        })
                        .with_bg(bg));
@@ -1315,9 +1315,9 @@ class CanvasCompareTester {
           SkPoint::Make(RenderBounds.fRight, RenderBounds.fBottom),
       };
       DlColor colors[] = {
-          DlColors::kGreen,
-          DlColors::kYellow.withAlpha(0x7f),
-          DlColors::kBlue,
+          DlColor::kGreen(),
+          DlColor::kYellow().withAlpha(0x7f),
+          DlColor::kBlue(),
       };
       float stops[] = {
           0.0,
@@ -3105,7 +3105,7 @@ TEST_F(DisplayListCanvas, DrawShadow) {
           RenderBottom - 20,
       },
       RenderCornerRadius, RenderCornerRadius);
-  const DlColor color = DlColors::kDarkGrey;
+  const DlColor color = DlColor::kDarkGrey();
   const SkScalar elevation = 5;
 
   CanvasCompareTester::RenderAll(  //
@@ -3132,7 +3132,7 @@ TEST_F(DisplayListCanvas, DrawShadowTransparentOccluder) {
           RenderBottom - 20,
       },
       RenderCornerRadius, RenderCornerRadius);
-  const DlColor color = DlColors::kDarkGrey;
+  const DlColor color = DlColor::kDarkGrey();
   const SkScalar elevation = 5;
 
   CanvasCompareTester::RenderAll(  //
@@ -3159,7 +3159,7 @@ TEST_F(DisplayListCanvas, DrawShadowDpr) {
           RenderBottom - 20,
       },
       RenderCornerRadius, RenderCornerRadius);
-  const DlColor color = DlColors::kDarkGrey;
+  const DlColor color = DlColor::kDarkGrey();
   const SkScalar elevation = 5;
 
   CanvasCompareTester::RenderAll(  //

--- a/display_list/display_list_canvas_unittests.cc
+++ b/display_list/display_list_canvas_unittests.cc
@@ -277,7 +277,7 @@ class RenderEnvironment {
   }
 
   std::unique_ptr<RenderSurface> MakeSurface(
-      const SkColor bg = SK_ColorTRANSPARENT,
+      const DlColor bg = DlColors::kTransparent,
       int width = TestWidth,
       int height = TestHeight) const {
     sk_sp<SkSurface> surface =
@@ -286,7 +286,7 @@ class RenderEnvironment {
     return std::make_unique<RenderSurface>(surface);
   }
 
-  void init_ref(CvRenderer& cv_renderer, SkColor bg = SK_ColorTRANSPARENT) {
+  void init_ref(CvRenderer& cv_renderer, DlColor bg = DlColors::kTransparent) {
     init_ref([=](SkCanvas*, SkPaint&) {}, cv_renderer,
              [=](DisplayListBuilder&) {}, bg);
   }
@@ -294,7 +294,7 @@ class RenderEnvironment {
   void init_ref(CvSetup& cv_setup,
                 CvRenderer& cv_renderer,
                 DlRenderer& dl_setup,
-                SkColor bg = SK_ColorTRANSPARENT) {
+                DlColor bg = DlColors::kTransparent) {
     ref_canvas()->clear(bg);
     dl_setup(ref_attr_);
     SkPaint paint;
@@ -418,7 +418,7 @@ class TestParameters {
       if (ref_attr.getStrokeJoin() != attr.getStrokeJoin()) {
         return false;
       }
-      if (ref_attr.getStrokeJoin() == SkPaint::kMiter_Join) {
+      if (ref_attr.getStrokeJoin() == DlStrokeJoin::kMiter) {
         SkScalar ref_miter = ref_attr.getStrokeMiter();
         SkScalar test_miter = attr.getStrokeMiter();
         // miter limit < 1.4 affects right angles
@@ -433,11 +433,11 @@ class TestParameters {
     return true;
   }
 
-  SkPaint::Cap getCap(const DisplayListBuilder& attr,
-                      DisplayListSpecialGeometryFlags geo_flags) const {
-    SkPaint::Cap cap = attr.getStrokeCap();
-    if (geo_flags.butt_cap_becomes_square() && cap == SkPaint::kButt_Cap) {
-      return SkPaint::kSquare_Cap;
+  DlStrokeCap getCap(const DisplayListBuilder& attr,
+                     DisplayListSpecialGeometryFlags geo_flags) const {
+    DlStrokeCap cap = attr.getStrokeCap();
+    if (geo_flags.butt_cap_becomes_square() && cap == DlStrokeCap::kButt) {
+      return DlStrokeCap::kSquare;
     }
     return cap;
   }
@@ -628,7 +628,7 @@ class CaseParameters {
                  DlRenderer dl_setup,
                  CvRenderer cv_restore,
                  DlRenderer dl_restore,
-                 SkColor bg,
+                 DlColor bg,
                  bool has_diff_clip,
                  bool has_mutating_save_layer,
                  bool fuzzy_compare_components)
@@ -651,7 +651,7 @@ class CaseParameters {
                           fuzzy_compare_components);
   }
 
-  CaseParameters with_bg(SkColor bg) {
+  CaseParameters with_bg(DlColor bg) {
     return CaseParameters(info_, cv_setup_, dl_setup_, cv_restore_, dl_restore_,
                           bg, has_diff_clip_, has_mutating_save_layer_,
                           fuzzy_compare_components_);
@@ -664,7 +664,7 @@ class CaseParameters {
   }
 
   std::string info() const { return info_; }
-  SkColor bg() const { return bg_; }
+  DlColor bg() const { return bg_; }
   bool has_diff_clip() const { return has_diff_clip_; }
   bool has_mutating_save_layer() const { return has_mutating_save_layer_; }
   bool fuzzy_compare_components() const { return fuzzy_compare_components_; }
@@ -692,7 +692,7 @@ class CaseParameters {
 
  private:
   const std::string info_;
-  const SkColor bg_;
+  const DlColor bg_;
   const CvSetup cv_setup_;
   const DlRenderer dl_setup_;
   const CvRenderer cv_restore_;
@@ -724,8 +724,8 @@ class CanvasCompareTester {
                                     const BoundsTolerance& tolerance) {
     SkRect clip = SkRect::MakeXYWH(RenderCenterX - 1, RenderCenterY - 1, 2, 2);
     SkRect rect = SkRect::MakeXYWH(RenderCenterX, RenderCenterY, 10, 10);
-    SkColor alpha_layer_color = SkColorSetARGB(0x7f, 0x00, 0xff, 0xff);
-    SkColor default_color = SkPaint().getColor();
+    DlColor alpha_layer_color = DlColors::kCyan.withAlpha(0x7f);
+    DlColor default_color = DlPaint::kDefaultColor;
     CvRenderer cv_safe_restore = [=](SkCanvas* cv, const SkPaint& p) {
       // Draw another primitive to disable peephole optimizations
       cv->drawRect(RenderBounds.makeOffset(500, 500), p);
@@ -971,7 +971,7 @@ class CanvasCompareTester {
       // primitives (mainly drawLine and drawPoints) do not show much
       // dithering so we use a non-trivial stroke width as well.
       RenderEnvironment dither_env = RenderEnvironment::Make565();
-      SkColor dither_bg = SK_ColorBLACK;
+      DlColor dither_bg = DlColors::kBlack;
       CvSetup cv_dither_setup = [=](SkCanvas*, SkPaint& p) {
         p.setShader(testImageColorSource.skia_object());
         p.setAlpha(0xf0);
@@ -979,7 +979,7 @@ class CanvasCompareTester {
       };
       DlRenderer dl_dither_setup = [=](DisplayListBuilder& b) {
         b.setColorSource(&testImageColorSource);
-        b.setColor(SkColor(0xf0000000));
+        b.setColor(DlColor(0xf0000000));
         b.setStrokeWidth(5.0);
       };
       dither_env.init_ref(cv_dither_setup, testP.cv_renderer(),  //
@@ -1025,8 +1025,8 @@ class CanvasCompareTester {
 
     {
       // half opaque cyan
-      SkColor blendableColor = SkColorSetARGB(0x7f, 0x00, 0xff, 0xff);
-      SkColor bg = SK_ColorWHITE;
+      DlColor blendableColor = DlColors::kCyan.withAlpha(0x7f);
+      DlColor bg = DlColors::kWhite;
 
       RenderWith(testP, env, tolerance,
                  CaseParameters(
@@ -1197,32 +1197,32 @@ class CanvasCompareTester {
       // clang-format on
       DlMatrixColorFilter filter(rotate_color_matrix);
       {
-        SkColor bg = SK_ColorWHITE;
+        DlColor bg = DlColors::kWhite;
         RenderWith(testP, env, tolerance,
                    CaseParameters(
                        "ColorFilter == RotateRGB",
                        [=](SkCanvas*, SkPaint& p) {
-                         p.setColor(SK_ColorYELLOW);
+                         p.setColor(DlColors::kYellow);
                          p.setColorFilter(filter.skia_object());
                        },
                        [=](DisplayListBuilder& b) {
-                         b.setColor(SK_ColorYELLOW);
+                         b.setColor(DlColors::kYellow);
                          b.setColorFilter(&filter);
                        })
                        .with_bg(bg));
       }
       filter = DlMatrixColorFilter(invert_color_matrix);
       {
-        SkColor bg = SK_ColorWHITE;
+        DlColor bg = DlColors::kWhite;
         RenderWith(testP, env, tolerance,
                    CaseParameters(
                        "ColorFilter == Invert",
                        [=](SkCanvas*, SkPaint& p) {
-                         p.setColor(SK_ColorYELLOW);
+                         p.setColor(DlColors::kYellow);
                          p.setColorFilter(filter.skia_object());
                        },
                        [=](DisplayListBuilder& b) {
-                         b.setColor(SK_ColorYELLOW);
+                         b.setColor(DlColors::kYellow);
                          b.setInvertColors(true);
                        })
                        .with_bg(bg));
@@ -1314,10 +1314,10 @@ class CanvasCompareTester {
           SkPoint::Make(RenderBounds.fLeft, RenderBounds.fTop),
           SkPoint::Make(RenderBounds.fRight, RenderBounds.fBottom),
       };
-      SkColor colors[] = {
-          SK_ColorGREEN,
-          SkColorSetA(SK_ColorYELLOW, 0x7f),
-          SK_ColorBLUE,
+      DlColor colors[] = {
+          DlColors::kGreen,
+          DlColors::kYellow.withAlpha(0x7f),
+          DlColors::kBlue,
       };
       float stops[] = {
           0.0,
@@ -1355,7 +1355,7 @@ class CanvasCompareTester {
                      p.setStyle(SkPaint::kFill_Style);
                    },
                    [=](DisplayListBuilder& b) {  //
-                     b.setStyle(SkPaint::kFill_Style);
+                     b.setStyle(DlDrawStyle::kFill);
                    }));
     RenderWith(testP, env, tolerance,
                CaseParameters(
@@ -1364,7 +1364,7 @@ class CanvasCompareTester {
                      p.setStyle(SkPaint::kStroke_Style);
                    },
                    [=](DisplayListBuilder& b) {  //
-                     b.setStyle(SkPaint::kStroke_Style);
+                     b.setStyle(DlDrawStyle::kStroke);
                    }));
 
     RenderWith(testP, env, tolerance,
@@ -1375,7 +1375,7 @@ class CanvasCompareTester {
                      p.setStrokeWidth(10.0);
                    },
                    [=](DisplayListBuilder& b) {
-                     b.setStyle(SkPaint::kFill_Style);
+                     b.setStyle(DlDrawStyle::kFill);
                      b.setStrokeWidth(10.0);
                    }));
 
@@ -1385,7 +1385,7 @@ class CanvasCompareTester {
       p.setStrokeWidth(5.0);
     };
     DlRenderer dl_stroke_setup = [=](DisplayListBuilder& b) {
-      b.setStyle(SkPaint::kStroke_Style);
+      b.setStyle(DlDrawStyle::kStroke);
       b.setStrokeWidth(5.0);
     };
     stroke_base_env.init_ref(cv_stroke_setup, testP.cv_renderer(),
@@ -1399,7 +1399,7 @@ class CanvasCompareTester {
                      p.setStrokeWidth(10.0);
                    },
                    [=](DisplayListBuilder& b) {
-                     b.setStyle(SkPaint::kStroke_Style);
+                     b.setStyle(DlDrawStyle::kStroke);
                      b.setStrokeWidth(10.0);
                    }));
     RenderWith(testP, stroke_base_env, tolerance,
@@ -1410,7 +1410,7 @@ class CanvasCompareTester {
                      p.setStrokeWidth(5.0);
                    },
                    [=](DisplayListBuilder& b) {
-                     b.setStyle(SkPaint::kStroke_Style);
+                     b.setStyle(DlDrawStyle::kStroke);
                      b.setStrokeWidth(5.0);
                    }));
 
@@ -1423,9 +1423,9 @@ class CanvasCompareTester {
                      p.setStrokeCap(SkPaint::kSquare_Cap);
                    },
                    [=](DisplayListBuilder& b) {
-                     b.setStyle(SkPaint::kStroke_Style);
+                     b.setStyle(DlDrawStyle::kStroke);
                      b.setStrokeWidth(5.0);
-                     b.setStrokeCap(SkPaint::kSquare_Cap);
+                     b.setStrokeCap(DlStrokeCap::kSquare);
                    }));
     RenderWith(testP, stroke_base_env, tolerance,
                CaseParameters(
@@ -1436,9 +1436,9 @@ class CanvasCompareTester {
                      p.setStrokeCap(SkPaint::kRound_Cap);
                    },
                    [=](DisplayListBuilder& b) {
-                     b.setStyle(SkPaint::kStroke_Style);
+                     b.setStyle(DlDrawStyle::kStroke);
                      b.setStrokeWidth(5.0);
-                     b.setStrokeCap(SkPaint::kRound_Cap);
+                     b.setStrokeCap(DlStrokeCap::kRound);
                    }));
 
     RenderWith(testP, stroke_base_env, tolerance,
@@ -1450,9 +1450,9 @@ class CanvasCompareTester {
                      p.setStrokeJoin(SkPaint::kBevel_Join);
                    },
                    [=](DisplayListBuilder& b) {
-                     b.setStyle(SkPaint::kStroke_Style);
+                     b.setStyle(DlDrawStyle::kStroke);
                      b.setStrokeWidth(5.0);
-                     b.setStrokeJoin(SkPaint::kBevel_Join);
+                     b.setStrokeJoin(DlStrokeJoin::kBevel);
                    }));
     RenderWith(testP, stroke_base_env, tolerance,
                CaseParameters(
@@ -1463,9 +1463,9 @@ class CanvasCompareTester {
                      p.setStrokeJoin(SkPaint::kRound_Join);
                    },
                    [=](DisplayListBuilder& b) {
-                     b.setStyle(SkPaint::kStroke_Style);
+                     b.setStyle(DlDrawStyle::kStroke);
                      b.setStrokeWidth(5.0);
-                     b.setStrokeJoin(SkPaint::kRound_Join);
+                     b.setStrokeJoin(DlStrokeJoin::kRound);
                    }));
 
     RenderWith(testP, stroke_base_env, tolerance,
@@ -1478,10 +1478,10 @@ class CanvasCompareTester {
                      p.setStrokeJoin(SkPaint::kMiter_Join);
                    },
                    [=](DisplayListBuilder& b) {
-                     b.setStyle(SkPaint::kStroke_Style);
+                     b.setStyle(DlDrawStyle::kStroke);
                      b.setStrokeWidth(5.0);
                      b.setStrokeMiter(10.0);
-                     b.setStrokeJoin(SkPaint::kMiter_Join);
+                     b.setStrokeJoin(DlStrokeJoin::kMiter);
                    }));
 
     RenderWith(testP, stroke_base_env, tolerance,
@@ -1494,10 +1494,10 @@ class CanvasCompareTester {
                      p.setStrokeJoin(SkPaint::kMiter_Join);
                    },
                    [=](DisplayListBuilder& b) {
-                     b.setStyle(SkPaint::kStroke_Style);
+                     b.setStyle(DlDrawStyle::kStroke);
                      b.setStrokeWidth(5.0);
                      b.setStrokeMiter(0.0);
-                     b.setStrokeJoin(SkPaint::kMiter_Join);
+                     b.setStrokeJoin(DlStrokeJoin::kMiter);
                    }));
 
     {
@@ -1517,7 +1517,7 @@ class CanvasCompareTester {
                        },
                        [=](DisplayListBuilder& b) {
                          // Need stroke style to see dashing properly
-                         b.setStyle(SkPaint::kStroke_Style);
+                         b.setStyle(DlDrawStyle::kStroke);
                          // Provide some non-trivial stroke size to get dashed
                          b.setStrokeWidth(5.0);
                          b.setPathEffect(effect);
@@ -1539,7 +1539,7 @@ class CanvasCompareTester {
                        },
                        [=](DisplayListBuilder& b) {
                          // Need stroke style to see dashing properly
-                         b.setStyle(SkPaint::kStroke_Style);
+                         b.setStyle(DlDrawStyle::kStroke);
                          // Provide some non-trivial stroke size to get dashed
                          b.setStrokeWidth(5.0);
                          b.setPathEffect(effect);
@@ -1735,7 +1735,7 @@ class CanvasCompareTester {
     // sk_surface is a direct rendering via SkCanvas to SkSurface
     // DisplayList mechanisms are not involved in this operation
     const std::string info = caseP.info();
-    const SkColor bg = caseP.bg();
+    const DlColor bg = caseP.bg();
     std::unique_ptr<RenderSurface> sk_surface = env.MakeSurface(bg);
     SkCanvas* sk_canvas = sk_surface->canvas();
     SkPaint sk_paint;
@@ -1892,7 +1892,7 @@ class CanvasCompareTester {
                                 sk_sp<DisplayList> display_list,
                                 const SkPixmap* ref_pixmap,
                                 const std::string info,
-                                SkColor bg) {
+                                DlColor bg) {
     SkScalar opacity = 128.0 / 255.0;
 
     std::unique_ptr<RenderSurface> group_opacity_surface = env.MakeSurface(bg);
@@ -1925,11 +1925,11 @@ class CanvasCompareTester {
       for (int x = 0; x < TestWidth; x++) {
         uint32_t ref_pixel = ref_row[x];
         uint32_t test_pixel = test_row[x];
-        if (ref_pixel != bg || test_pixel != bg) {
+        if (ref_pixel != bg.argb || test_pixel != bg.argb) {
           pixels_touched++;
           for (int i = 0; i < 32; i += 8) {
             int ref_comp = (ref_pixel >> i) & 0xff;
-            int bg_comp = (bg >> i) & 0xff;
+            int bg_comp = (bg.argb >> i) & 0xff;
             SkScalar faded_comp = bg_comp + (ref_comp - bg_comp) * opacity;
             int test_comp = (test_pixel >> i) & 0xff;
             if (std::abs(faded_comp - test_comp) > fudge) {
@@ -1947,8 +1947,8 @@ class CanvasCompareTester {
   static void checkPixels(const SkPixmap* ref_pixels,
                           const SkRect ref_bounds,
                           const std::string info,
-                          const SkColor bg) {
-    SkPMColor untouched = SkPreMultiplyColor(bg);
+                          const DlColor bg) {
+    uint32_t untouched = bg.premultipliedArgb();
     int pixels_touched = 0;
     int pixels_oob = 0;
     SkIRect i_bounds = ref_bounds.roundOut();
@@ -1997,12 +1997,12 @@ class CanvasCompareTester {
                                  const std::string info,
                                  SkRect* bounds,
                                  const BoundsTolerance* tolerance,
-                                 const SkColor bg,
+                                 const DlColor bg,
                                  bool fuzzyCompares = false,
                                  int width = TestWidth,
                                  int height = TestHeight,
                                  bool printMismatches = false) {
-    SkPMColor untouched = SkPreMultiplyColor(bg);
+    uint32_t untouched = bg.premultipliedArgb();
     ASSERT_EQ(test_pixels->width(), width) << info;
     ASSERT_EQ(test_pixels->height(), height) << info;
     ASSERT_EQ(test_pixels->info().bytesPerPixel(), 4) << info;
@@ -2542,7 +2542,7 @@ TEST_F(DisplayListCanvas, DrawVerticesWithColors) {
       SkPoint::Make(RenderLeft, RenderCenterY),
       SkPoint::Make(RenderRight, RenderBottom),
   };
-  const SkColor colors[6] = {
+  const DlColor colors[6] = {
       SK_ColorRED,  SK_ColorBLUE,   SK_ColorGREEN,
       SK_ColorCYAN, SK_ColorYELLOW, SK_ColorMAGENTA,
   };
@@ -2870,7 +2870,7 @@ TEST_F(DisplayListCanvas, DrawAtlasNearest) {
       {0,               RenderHalfHeight, RenderHalfWidth, RenderHeight},
       // clang-format on
   };
-  const SkColor colors[] = {
+  const DlColor colors[] = {
       SK_ColorBLUE,
       SK_ColorGREEN,
       SK_ColorYELLOW,
@@ -2881,11 +2881,13 @@ TEST_F(DisplayListCanvas, DrawAtlasNearest) {
   CanvasCompareTester::RenderAll(  //
       TestParameters(
           [=](SkCanvas* canvas, const SkPaint& paint) {
-            canvas->drawAtlas(image.get(), xform, tex, colors, 4,
+            const SkColor* sk_colors = reinterpret_cast<const SkColor*>(colors);
+            canvas->drawAtlas(image.get(), xform, tex, sk_colors, 4,
                               SkBlendMode::kSrcOver, sampling, nullptr, &paint);
           },
           [=](DisplayListBuilder& builder) {
-            builder.drawAtlas(DlImage::Make(image), xform, tex, colors, 4,  //
+            const DlColor* dl_colors = reinterpret_cast<const DlColor*>(colors);
+            builder.drawAtlas(DlImage::Make(image), xform, tex, dl_colors, 4,
                               DlBlendMode::kSrcOver, sampling, nullptr, true);
           },
           kDrawAtlasWithPaintFlags)
@@ -2909,7 +2911,7 @@ TEST_F(DisplayListCanvas, DrawAtlasNearestNoPaint) {
       {0,               RenderHalfHeight, RenderHalfWidth, RenderHeight},
       // clang-format on
   };
-  const SkColor colors[] = {
+  const DlColor colors[] = {
       SK_ColorBLUE,
       SK_ColorGREEN,
       SK_ColorYELLOW,
@@ -2920,13 +2922,15 @@ TEST_F(DisplayListCanvas, DrawAtlasNearestNoPaint) {
   CanvasCompareTester::RenderAll(  //
       TestParameters(
           [=](SkCanvas* canvas, const SkPaint& paint) {
-            canvas->drawAtlas(image.get(), xform, tex, colors, 4,
+            const SkColor* sk_colors = reinterpret_cast<const SkColor*>(colors);
+            canvas->drawAtlas(image.get(), xform, tex, sk_colors, 4,
                               SkBlendMode::kSrcOver, sampling,  //
                               nullptr, nullptr);
           },
           [=](DisplayListBuilder& builder) {
-            builder.drawAtlas(DlImage::Make(image), xform, tex, colors, 4,  //
-                              DlBlendMode::kSrcOver, sampling,              //
+            const DlColor* dl_colors = reinterpret_cast<const DlColor*>(colors);
+            builder.drawAtlas(DlImage::Make(image), xform, tex, dl_colors, 4,
+                              DlBlendMode::kSrcOver, sampling,  //
                               nullptr, false);
           },
           kDrawAtlasFlags)
@@ -2950,7 +2954,7 @@ TEST_F(DisplayListCanvas, DrawAtlasLinear) {
       {0,               RenderHalfHeight, RenderHalfWidth, RenderHeight},
       // clang-format on
   };
-  const SkColor colors[] = {
+  const DlColor colors[] = {
       SK_ColorBLUE,
       SK_ColorGREEN,
       SK_ColorYELLOW,
@@ -2961,11 +2965,13 @@ TEST_F(DisplayListCanvas, DrawAtlasLinear) {
   CanvasCompareTester::RenderAll(  //
       TestParameters(
           [=](SkCanvas* canvas, const SkPaint& paint) {
-            canvas->drawAtlas(image.get(), xform, tex, colors, 2,  //
+            const SkColor* sk_colors = reinterpret_cast<const SkColor*>(colors);
+            canvas->drawAtlas(image.get(), xform, tex, sk_colors, 2,  //
                               SkBlendMode::kSrcOver, sampling, nullptr, &paint);
           },
           [=](DisplayListBuilder& builder) {
-            builder.drawAtlas(DlImage::Make(image), xform, tex, colors, 2,  //
+            const DlColor* dl_colors = reinterpret_cast<const DlColor*>(colors);
+            builder.drawAtlas(DlImage::Make(image), xform, tex, dl_colors, 2,
                               DlBlendMode::kSrcOver, sampling, nullptr, true);
           },
           kDrawAtlasWithPaintFlags)
@@ -3030,7 +3036,7 @@ TEST_F(DisplayListCanvas, DrawPictureWithPaint) {
 
 sk_sp<DisplayList> makeTestDisplayList() {
   DisplayListBuilder builder;
-  builder.setStyle(SkPaint::kFill_Style);
+  builder.setStyle(DlDrawStyle::kFill);
   builder.setColor(SK_ColorRED);
   builder.drawRect({RenderLeft, RenderTop, RenderCenterX, RenderCenterY});
   builder.setColor(SK_ColorBLUE);
@@ -3099,7 +3105,7 @@ TEST_F(DisplayListCanvas, DrawShadow) {
           RenderBottom - 20,
       },
       RenderCornerRadius, RenderCornerRadius);
-  const SkColor color = SK_ColorDKGRAY;
+  const DlColor color = DlColors::kDarkGrey;
   const SkScalar elevation = 5;
 
   CanvasCompareTester::RenderAll(  //
@@ -3126,7 +3132,7 @@ TEST_F(DisplayListCanvas, DrawShadowTransparentOccluder) {
           RenderBottom - 20,
       },
       RenderCornerRadius, RenderCornerRadius);
-  const SkColor color = SK_ColorDKGRAY;
+  const DlColor color = DlColors::kDarkGrey;
   const SkScalar elevation = 5;
 
   CanvasCompareTester::RenderAll(  //
@@ -3153,7 +3159,7 @@ TEST_F(DisplayListCanvas, DrawShadowDpr) {
           RenderBottom - 20,
       },
       RenderCornerRadius, RenderCornerRadius);
-  const SkColor color = SK_ColorDKGRAY;
+  const DlColor color = DlColors::kDarkGrey;
   const SkScalar elevation = 5;
 
   CanvasCompareTester::RenderAll(  //

--- a/display_list/display_list_color.h
+++ b/display_list/display_list_color.h
@@ -1,0 +1,91 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_DISPLAY_LIST_DISPLAY_LIST_COLOR_H_
+#define FLUTTER_DISPLAY_LIST_DISPLAY_LIST_COLOR_H_
+
+#include "flutter/display_list/types.h"
+
+namespace flutter {
+
+struct DlColor {
+ public:
+  constexpr DlColor() : argb(0xFF000000) {}
+  constexpr DlColor(uint32_t argb) : argb(argb) {}
+
+  uint32_t argb;
+
+  bool isOpaque() const { return getAlpha() == 0xFF; }
+
+  int getAlpha() const { return argb >> 24; }
+  int getRed() const { return (argb >> 16) & 0xFF; }
+  int getGreen() const { return (argb >> 8) & 0xFF; }
+  int getBlue() const { return argb & 0xFF; }
+
+  float getAlphaF() const { return toF(getAlpha()); }
+  float getRedF() const { return toF(getRed()); }
+  float getGreenF() const { return toF(getGreen()); }
+  float getBlueF() const { return toF(getBlue()); }
+
+  uint32_t premultipliedArgb() const {
+    if (isOpaque()) {
+      return argb;
+    }
+    float f = getAlphaF();
+    return (argb & 0xFF000000) |        //
+           toC(getRedF() * f) << 16 |   //
+           toC(getGreenF() * f) << 8 |  //
+           toC(getBlueF() * f);
+  }
+
+  DlColor withAlpha(uint8_t alpha) const {  //
+    return (argb & 0x00FFFFFF) | (alpha << 24);
+  }
+  DlColor withRed(uint8_t red) const {  //
+    return (argb & 0xFF00FFFF) | (red << 16);
+  }
+  DlColor withGreen(uint8_t green) const {  //
+    return (argb & 0xFFFF00FF) | (green << 8);
+  }
+  DlColor withBlue(uint8_t blue) const {  //
+    return (argb & 0xFFFFFF00) | (blue << 0);
+  }
+
+  DlColor modulateOpacity(float opacity) const {
+    return opacity <= 0   ? withAlpha(0)
+           : opacity >= 1 ? *this
+                          : withAlpha(round(getAlpha() * opacity));
+  }
+
+  operator uint32_t() const { return argb; }
+  bool operator==(DlColor const& other) const { return argb == other.argb; }
+  bool operator!=(DlColor const& other) const { return argb != other.argb; }
+  bool operator==(uint32_t const& other) const { return argb == other; }
+  bool operator!=(uint32_t const& other) const { return argb != other; }
+
+ private:
+  static float toF(uint8_t comp) { return comp * (1.0 / 255); }
+  static uint8_t toC(float fComp) { return round(fComp * 255); }
+};
+
+struct DlColors {
+  // clang-format off
+  static constexpr DlColor kTransparent           {0x00000000};
+  static constexpr DlColor kBlack                 {0xFF000000};
+  static constexpr DlColor kWhite                 {0xFFFFFFFF};
+  static constexpr DlColor kRed                   {0xFFFF0000};
+  static constexpr DlColor kGreen                 {0xFF00FF00};
+  static constexpr DlColor kBlue                  {0xFF0000FF};
+  static constexpr DlColor kCyan                  {0xFF00FFFF};
+  static constexpr DlColor kMagenta               {0xFFFF00FF};
+  static constexpr DlColor kYellow                {0xFFFFFF00};
+  static constexpr DlColor kDarkGrey              {0xFF3F3F3F};
+  static constexpr DlColor kMidGrey               {0xFF808080};
+  static constexpr DlColor kLightGrey             {0xFFC0C0C0};
+  // clang-format on
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_DISPLAY_LIST_DISPLAY_LIST_COLOR_H_

--- a/display_list/display_list_color.h
+++ b/display_list/display_list_color.h
@@ -14,6 +14,21 @@ struct DlColor {
   constexpr DlColor() : argb(0xFF000000) {}
   constexpr DlColor(uint32_t argb) : argb(argb) {}
 
+  // clang-format off
+  static constexpr DlColor kTransparent()        {return 0x00000000;};
+  static constexpr DlColor kBlack()              {return 0xFF000000;};
+  static constexpr DlColor kWhite()              {return 0xFFFFFFFF;};
+  static constexpr DlColor kRed()                {return 0xFFFF0000;};
+  static constexpr DlColor kGreen()              {return 0xFF00FF00;};
+  static constexpr DlColor kBlue()               {return 0xFF0000FF;};
+  static constexpr DlColor kCyan()               {return 0xFF00FFFF;};
+  static constexpr DlColor kMagenta()            {return 0xFFFF00FF;};
+  static constexpr DlColor kYellow()             {return 0xFFFFFF00;};
+  static constexpr DlColor kDarkGrey()           {return 0xFF3F3F3F;};
+  static constexpr DlColor kMidGrey()            {return 0xFF808080;};
+  static constexpr DlColor kLightGrey()          {return 0xFFC0C0C0;};
+  // clang-format on
+
   uint32_t argb;
 
   bool isOpaque() const { return getAlpha() == 0xFF; }
@@ -67,23 +82,6 @@ struct DlColor {
  private:
   static float toF(uint8_t comp) { return comp * (1.0 / 255); }
   static uint8_t toC(float fComp) { return round(fComp * 255); }
-};
-
-struct DlColors {
-  // clang-format off
-  static constexpr DlColor kTransparent           {0x00000000};
-  static constexpr DlColor kBlack                 {0xFF000000};
-  static constexpr DlColor kWhite                 {0xFFFFFFFF};
-  static constexpr DlColor kRed                   {0xFFFF0000};
-  static constexpr DlColor kGreen                 {0xFF00FF00};
-  static constexpr DlColor kBlue                  {0xFF0000FF};
-  static constexpr DlColor kCyan                  {0xFF00FFFF};
-  static constexpr DlColor kMagenta               {0xFFFF00FF};
-  static constexpr DlColor kYellow                {0xFFFFFF00};
-  static constexpr DlColor kDarkGrey              {0xFF3F3F3F};
-  static constexpr DlColor kMidGrey               {0xFF808080};
-  static constexpr DlColor kLightGrey             {0xFFC0C0C0};
-  // clang-format on
 };
 
 }  // namespace flutter

--- a/display_list/display_list_color_filter.cc
+++ b/display_list/display_list_color_filter.cc
@@ -4,6 +4,8 @@
 
 #include "flutter/display_list/display_list_color_filter.h"
 
+#include "flutter/display_list/display_list_color.h"
+
 namespace flutter {
 
 std::shared_ptr<DlColorFilter> DlColorFilter::From(SkColorFilter* sk_filter) {
@@ -22,7 +24,7 @@ std::shared_ptr<DlColorFilter> DlColorFilter::From(SkColorFilter* sk_filter) {
     SkColor color;
     SkBlendMode mode;
     if (sk_filter->asAColorMode(&color, &mode)) {
-      return std::make_shared<DlBlendColorFilter>(color, mode);
+      return std::make_shared<DlBlendColorFilter>(color, ToDl(mode));
     }
   }
   {

--- a/display_list/display_list_color_filter.h
+++ b/display_list/display_list_color_filter.h
@@ -6,6 +6,8 @@
 #define FLUTTER_DISPLAY_LIST_DISPLAY_LIST_COLOR_FILTER_H_
 
 #include "flutter/display_list/display_list_attributes.h"
+#include "flutter/display_list/display_list_blend_mode.h"
+#include "flutter/display_list/display_list_color.h"
 #include "flutter/display_list/types.h"
 #include "flutter/fml/logging.h"
 
@@ -75,7 +77,7 @@ class DlColorFilter
 // filter is then used to combine those colors.
 class DlBlendColorFilter final : public DlColorFilter {
  public:
-  DlBlendColorFilter(SkColor color, SkBlendMode mode)
+  DlBlendColorFilter(DlColor color, DlBlendMode mode)
       : color_(color), mode_(mode) {}
   DlBlendColorFilter(const DlBlendColorFilter& filter)
       : DlBlendColorFilter(filter.color_, filter.mode_) {}
@@ -96,13 +98,13 @@ class DlBlendColorFilter final : public DlColorFilter {
   }
 
   sk_sp<SkColorFilter> skia_object() const override {
-    return SkColorFilters::Blend(color_, mode_);
+    return SkColorFilters::Blend(color_, ToSk(mode_));
   }
 
   const DlBlendColorFilter* asBlend() const override { return this; }
 
-  SkColor color() const { return color_; }
-  SkBlendMode mode() const { return mode_; }
+  DlColor color() const { return color_; }
+  DlBlendMode mode() const { return mode_; }
 
  protected:
   bool equals_(DlColorFilter const& other) const override {
@@ -112,8 +114,8 @@ class DlBlendColorFilter final : public DlColorFilter {
   }
 
  private:
-  SkColor color_;
-  SkBlendMode mode_;
+  DlColor color_;
+  DlBlendMode mode_;
 };
 
 // The Matrix type of ColorFilter which runs every pixel drawn by

--- a/display_list/display_list_color_filter_unittests.cc
+++ b/display_list/display_list_color_filter_unittests.cc
@@ -18,7 +18,7 @@ static const float matrix[20] = {
 };
 
 TEST(DisplayListColorFilter, BuilderSetGet) {
-  DlBlendColorFilter filter(SK_ColorRED, SkBlendMode::kDstATop);
+  DlBlendColorFilter filter(DlColors::kRed, DlBlendMode::kDstATop);
   DisplayListBuilder builder;
   ASSERT_EQ(builder.getColorFilter(), nullptr);
   builder.setColorFilter(&filter);
@@ -39,11 +39,11 @@ TEST(DisplayListColorFilter, FromSkiaBlendFilter) {
   sk_sp<SkColorFilter> sk_filter =
       SkColorFilters::Blend(SK_ColorRED, SkBlendMode::kDstATop);
   std::shared_ptr<DlColorFilter> filter = DlColorFilter::From(sk_filter);
-  DlBlendColorFilter dl_filter(SK_ColorRED, SkBlendMode::kDstATop);
+  DlBlendColorFilter dl_filter(DlColors::kRed, DlBlendMode::kDstATop);
   ASSERT_EQ(filter->type(), DlColorFilterType::kBlend);
   ASSERT_EQ(*filter->asBlend(), dl_filter);
-  ASSERT_EQ(filter->asBlend()->color(), SK_ColorRED);
-  ASSERT_EQ(filter->asBlend()->mode(), SkBlendMode::kDstATop);
+  ASSERT_EQ(filter->asBlend()->color(), DlColors::kRed);
+  ASSERT_EQ(filter->asBlend()->mode(), DlBlendMode::kDstATop);
 
   ASSERT_EQ(filter->asMatrix(), nullptr);
 }
@@ -96,43 +96,43 @@ TEST(DisplayListColorFilter, FromSkiaUnrecognizedFilter) {
 }
 
 TEST(DisplayListColorFilter, BlendConstructor) {
-  DlBlendColorFilter filter(SK_ColorRED, SkBlendMode::kDstATop);
+  DlBlendColorFilter filter(DlColors::kRed, DlBlendMode::kDstATop);
 }
 
 TEST(DisplayListColorFilter, BlendShared) {
-  DlBlendColorFilter filter(SK_ColorRED, SkBlendMode::kDstATop);
+  DlBlendColorFilter filter(DlColors::kRed, DlBlendMode::kDstATop);
   ASSERT_NE(filter.shared().get(), &filter);
   ASSERT_EQ(*filter.shared(), filter);
 }
 
 TEST(DisplayListColorFilter, BlendAsBlend) {
-  DlBlendColorFilter filter(SK_ColorRED, SkBlendMode::kDstATop);
+  DlBlendColorFilter filter(DlColors::kRed, DlBlendMode::kDstATop);
   ASSERT_NE(filter.asBlend(), nullptr);
   ASSERT_EQ(filter.asBlend(), &filter);
 }
 
 TEST(DisplayListColorFilter, BlendContents) {
-  DlBlendColorFilter filter(SK_ColorRED, SkBlendMode::kDstATop);
-  ASSERT_EQ(filter.color(), SK_ColorRED);
-  ASSERT_EQ(filter.mode(), SkBlendMode::kDstATop);
+  DlBlendColorFilter filter(DlColors::kRed, DlBlendMode::kDstATop);
+  ASSERT_EQ(filter.color(), DlColors::kRed);
+  ASSERT_EQ(filter.mode(), DlBlendMode::kDstATop);
 }
 
 TEST(DisplayListColorFilter, BlendEquals) {
-  DlBlendColorFilter filter1(SK_ColorRED, SkBlendMode::kDstATop);
-  DlBlendColorFilter filter2(SK_ColorRED, SkBlendMode::kDstATop);
+  DlBlendColorFilter filter1(DlColors::kRed, DlBlendMode::kDstATop);
+  DlBlendColorFilter filter2(DlColors::kRed, DlBlendMode::kDstATop);
   TestEquals(filter1, filter2);
 }
 
 TEST(DisplayListColorFilter, BlendNotEquals) {
-  DlBlendColorFilter filter1(SK_ColorRED, SkBlendMode::kDstATop);
-  DlBlendColorFilter filter2(SK_ColorBLUE, SkBlendMode::kDstATop);
-  DlBlendColorFilter filter3(SK_ColorRED, SkBlendMode::kDstIn);
+  DlBlendColorFilter filter1(DlColors::kRed, DlBlendMode::kDstATop);
+  DlBlendColorFilter filter2(DlColors::kBlue, DlBlendMode::kDstATop);
+  DlBlendColorFilter filter3(DlColors::kRed, DlBlendMode::kDstIn);
   TestNotEquals(filter1, filter2, "Color differs");
   TestNotEquals(filter1, filter3, "Blend mode differs");
 }
 
 TEST(DisplayListColorFilter, NopBlendShouldNotCrash) {
-  DlBlendColorFilter filter(SK_ColorTRANSPARENT, SkBlendMode::kSrcOver);
+  DlBlendColorFilter filter(DlColors::kTransparent, DlBlendMode::kSrcOver);
   ASSERT_FALSE(filter.modifies_transparent_black());
 }
 

--- a/display_list/display_list_color_filter_unittests.cc
+++ b/display_list/display_list_color_filter_unittests.cc
@@ -18,7 +18,7 @@ static const float matrix[20] = {
 };
 
 TEST(DisplayListColorFilter, BuilderSetGet) {
-  DlBlendColorFilter filter(DlColors::kRed, DlBlendMode::kDstATop);
+  DlBlendColorFilter filter(DlColor::kRed(), DlBlendMode::kDstATop);
   DisplayListBuilder builder;
   ASSERT_EQ(builder.getColorFilter(), nullptr);
   builder.setColorFilter(&filter);
@@ -39,10 +39,10 @@ TEST(DisplayListColorFilter, FromSkiaBlendFilter) {
   sk_sp<SkColorFilter> sk_filter =
       SkColorFilters::Blend(SK_ColorRED, SkBlendMode::kDstATop);
   std::shared_ptr<DlColorFilter> filter = DlColorFilter::From(sk_filter);
-  DlBlendColorFilter dl_filter(DlColors::kRed, DlBlendMode::kDstATop);
+  DlBlendColorFilter dl_filter(DlColor::kRed(), DlBlendMode::kDstATop);
   ASSERT_EQ(filter->type(), DlColorFilterType::kBlend);
   ASSERT_EQ(*filter->asBlend(), dl_filter);
-  ASSERT_EQ(filter->asBlend()->color(), DlColors::kRed);
+  ASSERT_EQ(filter->asBlend()->color(), DlColor::kRed());
   ASSERT_EQ(filter->asBlend()->mode(), DlBlendMode::kDstATop);
 
   ASSERT_EQ(filter->asMatrix(), nullptr);
@@ -96,43 +96,43 @@ TEST(DisplayListColorFilter, FromSkiaUnrecognizedFilter) {
 }
 
 TEST(DisplayListColorFilter, BlendConstructor) {
-  DlBlendColorFilter filter(DlColors::kRed, DlBlendMode::kDstATop);
+  DlBlendColorFilter filter(DlColor::kRed(), DlBlendMode::kDstATop);
 }
 
 TEST(DisplayListColorFilter, BlendShared) {
-  DlBlendColorFilter filter(DlColors::kRed, DlBlendMode::kDstATop);
+  DlBlendColorFilter filter(DlColor::kRed(), DlBlendMode::kDstATop);
   ASSERT_NE(filter.shared().get(), &filter);
   ASSERT_EQ(*filter.shared(), filter);
 }
 
 TEST(DisplayListColorFilter, BlendAsBlend) {
-  DlBlendColorFilter filter(DlColors::kRed, DlBlendMode::kDstATop);
+  DlBlendColorFilter filter(DlColor::kRed(), DlBlendMode::kDstATop);
   ASSERT_NE(filter.asBlend(), nullptr);
   ASSERT_EQ(filter.asBlend(), &filter);
 }
 
 TEST(DisplayListColorFilter, BlendContents) {
-  DlBlendColorFilter filter(DlColors::kRed, DlBlendMode::kDstATop);
-  ASSERT_EQ(filter.color(), DlColors::kRed);
+  DlBlendColorFilter filter(DlColor::kRed(), DlBlendMode::kDstATop);
+  ASSERT_EQ(filter.color(), DlColor::kRed());
   ASSERT_EQ(filter.mode(), DlBlendMode::kDstATop);
 }
 
 TEST(DisplayListColorFilter, BlendEquals) {
-  DlBlendColorFilter filter1(DlColors::kRed, DlBlendMode::kDstATop);
-  DlBlendColorFilter filter2(DlColors::kRed, DlBlendMode::kDstATop);
+  DlBlendColorFilter filter1(DlColor::kRed(), DlBlendMode::kDstATop);
+  DlBlendColorFilter filter2(DlColor::kRed(), DlBlendMode::kDstATop);
   TestEquals(filter1, filter2);
 }
 
 TEST(DisplayListColorFilter, BlendNotEquals) {
-  DlBlendColorFilter filter1(DlColors::kRed, DlBlendMode::kDstATop);
-  DlBlendColorFilter filter2(DlColors::kBlue, DlBlendMode::kDstATop);
-  DlBlendColorFilter filter3(DlColors::kRed, DlBlendMode::kDstIn);
+  DlBlendColorFilter filter1(DlColor::kRed(), DlBlendMode::kDstATop);
+  DlBlendColorFilter filter2(DlColor::kBlue(), DlBlendMode::kDstATop);
+  DlBlendColorFilter filter3(DlColor::kRed(), DlBlendMode::kDstIn);
   TestNotEquals(filter1, filter2, "Color differs");
   TestNotEquals(filter1, filter3, "Blend mode differs");
 }
 
 TEST(DisplayListColorFilter, NopBlendShouldNotCrash) {
-  DlBlendColorFilter filter(DlColors::kTransparent, DlBlendMode::kSrcOver);
+  DlBlendColorFilter filter(DlColor::kTransparent(), DlBlendMode::kSrcOver);
   ASSERT_FALSE(filter.modifies_transparent_black());
 }
 

--- a/display_list/display_list_color_source.cc
+++ b/display_list/display_list_color_source.cc
@@ -49,6 +49,7 @@ std::shared_ptr<DlColorSource> DlColorSource::From(SkShader* sk_shader) {
     FML_DCHECK(count == info.fColorCount);
   }
   DlTileMode mode = ToDl(info.fTileMode);
+  DlColor* dl_colors = reinterpret_cast<DlColor*>(info.fColors);
   std::shared_ptr<DlColorSource> source;
   switch (type) {
     case SkShader::kNone_GradientType:
@@ -59,19 +60,19 @@ std::shared_ptr<DlColorSource> DlColorSource::From(SkShader* sk_shader) {
       break;
     case SkShader::kLinear_GradientType:
       source = MakeLinear(info.fPoint[0], info.fPoint[1], info.fColorCount,
-                          info.fColors, info.fColorOffsets, mode);
+                          dl_colors, info.fColorOffsets, mode);
       break;
     case SkShader::kRadial_GradientType:
       source = MakeRadial(info.fPoint[0], info.fRadius[0], info.fColorCount,
-                          info.fColors, info.fColorOffsets, mode);
+                          dl_colors, info.fColorOffsets, mode);
       break;
     case SkShader::kConical_GradientType:
       source = MakeConical(info.fPoint[0], info.fRadius[0], info.fPoint[1],
-                           info.fRadius[1], info.fColorCount, info.fColors,
+                           info.fRadius[1], info.fColorCount, dl_colors,
                            info.fColorOffsets, mode);
       break;
     case SkShader::kSweep_GradientType:
-      source = MakeSweep(info.fPoint[0], 0, 360, info.fColorCount, info.fColors,
+      source = MakeSweep(info.fPoint[0], 0, 360, info.fColorCount, dl_colors,
                          info.fColorOffsets, mode);
       break;
   }
@@ -97,7 +98,7 @@ std::shared_ptr<DlColorSource> DlColorSource::MakeLinear(
     const SkPoint start_point,
     const SkPoint end_point,
     uint32_t stop_count,
-    const uint32_t* colors,
+    const DlColor* colors,
     const float* stops,
     DlTileMode tile_mode,
     const SkMatrix* matrix) {
@@ -118,7 +119,7 @@ std::shared_ptr<DlColorSource> DlColorSource::MakeRadial(
     SkPoint center,
     SkScalar radius,
     uint32_t stop_count,
-    const uint32_t* colors,
+    const DlColor* colors,
     const float* stops,
     DlTileMode tile_mode,
     const SkMatrix* matrix) {
@@ -140,7 +141,7 @@ std::shared_ptr<DlColorSource> DlColorSource::MakeConical(
     SkPoint end_center,
     SkScalar end_radius,
     uint32_t stop_count,
-    const uint32_t* colors,
+    const DlColor* colors,
     const float* stops,
     DlTileMode tile_mode,
     const SkMatrix* matrix) {
@@ -162,7 +163,7 @@ std::shared_ptr<DlColorSource> DlColorSource::MakeSweep(
     SkScalar start,
     SkScalar end,
     uint32_t stop_count,
-    const uint32_t* colors,
+    const DlColor* colors,
     const float* stops,
     DlTileMode tile_mode,
     const SkMatrix* matrix) {

--- a/display_list/display_list_color_source.h
+++ b/display_list/display_list_color_source.h
@@ -7,6 +7,7 @@
 
 #include "flutter/display_list/display_list.h"
 #include "flutter/display_list/display_list_attributes.h"
+#include "flutter/display_list/display_list_color.h"
 #include "flutter/display_list/display_list_tile_mode.h"
 #include "flutter/display_list/types.h"
 #include "flutter/fml/logging.h"
@@ -66,7 +67,7 @@ class DlColorSource
       const SkPoint start_point,
       const SkPoint end_point,
       uint32_t stop_count,
-      const uint32_t* colors,
+      const DlColor* colors,
       const float* stops,
       DlTileMode tile_mode,
       const SkMatrix* matrix = nullptr);
@@ -75,7 +76,7 @@ class DlColorSource
       SkPoint center,
       SkScalar radius,
       uint32_t stop_count,
-      const uint32_t* colors,
+      const DlColor* colors,
       const float* stops,
       DlTileMode tile_mode,
       const SkMatrix* matrix = nullptr);
@@ -86,7 +87,7 @@ class DlColorSource
       SkPoint end_center,
       SkScalar end_radius,
       uint32_t stop_count,
-      const uint32_t* colors,
+      const DlColor* colors,
       const float* stops,
       DlTileMode tile_mode,
       const SkMatrix* matrix = nullptr);
@@ -96,7 +97,7 @@ class DlColorSource
       SkScalar start,
       SkScalar end,
       uint32_t stop_count,
-      const uint32_t* colors,
+      const DlColor* colors,
       const float* stops,
       DlTileMode tile_mode,
       const SkMatrix* matrix = nullptr);
@@ -149,7 +150,7 @@ class DlColorSource
 
 class DlColorColorSource final : public DlColorSource {
  public:
-  DlColorColorSource(uint32_t color) : color_(color) {}
+  DlColorColorSource(DlColor color) : color_(color) {}
 
   std::shared_ptr<DlColorSource> shared() const override {
     return std::make_shared<DlColorColorSource>(color_);
@@ -162,7 +163,7 @@ class DlColorColorSource final : public DlColorSource {
 
   bool is_opaque() const override { return (color_ >> 24) == 255; }
 
-  uint32_t color() const { return color_; }
+  DlColor color() const { return color_; }
 
   sk_sp<SkShader> skia_object() const override {
     return SkShaders::Color(color_);
@@ -176,7 +177,7 @@ class DlColorColorSource final : public DlColorSource {
   }
 
  private:
-  uint32_t color_;
+  DlColor color_;
 
   FML_DISALLOW_COPY_ASSIGN_AND_MOVE(DlColorColorSource);
 };
@@ -265,7 +266,7 @@ class DlGradientColorSourceBase : public DlMatrixColorSourceBase {
     if (mode_ == DlTileMode::kDecal) {
       return false;
     }
-    const uint32_t* my_colors = colors();
+    const DlColor* my_colors = colors();
     for (uint32_t i = 0; i < stop_count_; i++) {
       if ((my_colors[i] >> 24) < 255) {
         return false;
@@ -276,8 +277,8 @@ class DlGradientColorSourceBase : public DlMatrixColorSourceBase {
 
   DlTileMode tile_mode() const { return mode_; }
   int stop_count() const { return stop_count_; }
-  const uint32_t* colors() const {
-    return reinterpret_cast<const uint32_t*>(pod());
+  const DlColor* colors() const {
+    return reinterpret_cast<const DlColor*>(pod());
   }
   const float* stops() const {
     return reinterpret_cast<const float*>(colors() + stop_count());
@@ -292,7 +293,7 @@ class DlGradientColorSourceBase : public DlMatrixColorSourceBase {
         stop_count_(stop_count) {}
 
   size_t vector_sizes() const {
-    return stop_count_ * (sizeof(uint32_t) + sizeof(float));
+    return stop_count_ * (sizeof(DlColor) + sizeof(float));
   }
 
   virtual const void* pod() const = 0;
@@ -302,22 +303,17 @@ class DlGradientColorSourceBase : public DlMatrixColorSourceBase {
         stop_count_ != other_base->stop_count_) {
       return false;
     }
-    const uint32_t* my_colors = colors();
-    const float* my_stops = stops();
-    const uint32_t* other_colors = other_base->colors();
-    const float* other_stops = other_base->stops();
-    for (uint32_t i = 0; i < stop_count_; i++) {
-      if (my_colors[i] != other_colors[i] || my_stops[i] != other_stops[i]) {
-        return false;
-      }
-    }
-    return true;
+    static_assert(sizeof(colors()[0]) == 4);
+    static_assert(sizeof(stops()[0]) == 4);
+    int num_bytes = stop_count_ * 4;
+    return (memcmp(colors(), other_base->colors(), num_bytes) == 0 &&
+            memcmp(stops(), other_base->stops(), num_bytes) == 0);
   }
 
   void store_color_stops(void* pod,
-                         const uint32_t* color_data,
+                         const DlColor* color_data,
                          const float* stop_data) {
-    uint32_t* color_storage = reinterpret_cast<uint32_t*>(pod);
+    DlColor* color_storage = reinterpret_cast<DlColor*>(pod);
     memcpy(color_storage, color_data, stop_count_ * sizeof(*color_data));
     float* stop_storage = reinterpret_cast<float*>(color_storage + stop_count_);
     if (stop_data) {
@@ -361,7 +357,8 @@ class DlLinearGradientColorSource final : public DlGradientColorSourceBase {
 
   sk_sp<SkShader> skia_object() const override {
     SkPoint pts[] = {start_point_, end_point_};
-    return SkGradientShader::MakeLinear(pts, colors(), stops(), stop_count(),
+    const SkColor* sk_colors = reinterpret_cast<const SkColor*>(colors());
+    return SkGradientShader::MakeLinear(pts, sk_colors, stops(), stop_count(),
                                         ToSk(tile_mode()), 0, matrix_ptr());
   }
 
@@ -379,7 +376,7 @@ class DlLinearGradientColorSource final : public DlGradientColorSourceBase {
   DlLinearGradientColorSource(const SkPoint start_point,
                               const SkPoint end_point,
                               uint32_t stop_count,
-                              const uint32_t* colors,
+                              const DlColor* colors,
                               const float* stops,
                               DlTileMode tile_mode,
                               const SkMatrix* matrix = nullptr)
@@ -427,7 +424,8 @@ class DlRadialGradientColorSource final : public DlGradientColorSourceBase {
   SkScalar radius() const { return radius_; }
 
   sk_sp<SkShader> skia_object() const override {
-    return SkGradientShader::MakeRadial(center_, radius_, colors(), stops(),
+    const SkColor* sk_colors = reinterpret_cast<const SkColor*>(colors());
+    return SkGradientShader::MakeRadial(center_, radius_, sk_colors, stops(),
                                         stop_count(), ToSk(tile_mode()), 0,
                                         matrix_ptr());
   }
@@ -446,7 +444,7 @@ class DlRadialGradientColorSource final : public DlGradientColorSourceBase {
   DlRadialGradientColorSource(SkPoint center,
                               SkScalar radius,
                               uint32_t stop_count,
-                              const uint32_t* colors,
+                              const DlColor* colors,
                               const float* stops,
                               DlTileMode tile_mode,
                               const SkMatrix* matrix = nullptr)
@@ -497,8 +495,9 @@ class DlConicalGradientColorSource final : public DlGradientColorSourceBase {
   SkScalar end_radius() const { return end_radius_; }
 
   sk_sp<SkShader> skia_object() const override {
+    const SkColor* sk_colors = reinterpret_cast<const SkColor*>(colors());
     return SkGradientShader::MakeTwoPointConical(
-        start_center_, start_radius_, end_center_, end_radius_, colors(),
+        start_center_, start_radius_, end_center_, end_radius_, sk_colors,
         stops(), stop_count(), ToSk(tile_mode()), 0, matrix_ptr());
   }
 
@@ -520,7 +519,7 @@ class DlConicalGradientColorSource final : public DlGradientColorSourceBase {
                                SkPoint end_center,
                                SkScalar end_radius,
                                uint32_t stop_count,
-                               const uint32_t* colors,
+                               const DlColor* colors,
                                const float* stops,
                                DlTileMode tile_mode,
                                const SkMatrix* matrix = nullptr)
@@ -575,7 +574,8 @@ class DlSweepGradientColorSource final : public DlGradientColorSourceBase {
   SkScalar end() const { return end_; }
 
   sk_sp<SkShader> skia_object() const override {
-    return SkGradientShader::MakeSweep(center_.x(), center_.y(), colors(),
+    const SkColor* sk_colors = reinterpret_cast<const SkColor*>(colors());
+    return SkGradientShader::MakeSweep(center_.x(), center_.y(), sk_colors,
                                        stops(), stop_count(), ToSk(tile_mode()),
                                        start_, end_, 0, matrix_ptr());
   }
@@ -595,7 +595,7 @@ class DlSweepGradientColorSource final : public DlGradientColorSourceBase {
                              SkScalar start,
                              SkScalar end,
                              uint32_t stop_count,
-                             const uint32_t* colors,
+                             const DlColor* colors,
                              const float* stops,
                              DlTileMode tile_mode,
                              const SkMatrix* matrix = nullptr)

--- a/display_list/display_list_color_source_unittests.cc
+++ b/display_list/display_list_color_source_unittests.cc
@@ -39,15 +39,15 @@ static const SkMatrix TestMatrix2 =
                       0, 0, 1);
 // clang-format on
 static constexpr int kTestStopCount = 3;
-static constexpr SkColor TestColors[kTestStopCount] = {
-    SK_ColorRED,
-    SK_ColorGREEN,
-    SK_ColorBLUE,
+static constexpr DlColor TestColors[kTestStopCount] = {
+    DlColors::kRed,
+    DlColors::kGreen,
+    DlColors::kBlue,
 };
-static constexpr SkColor TestAlphaColors[kTestStopCount] = {
-    SkColorSetA(SK_ColorBLUE, 0x7f),
-    SkColorSetA(SK_ColorRED, 0x2f),
-    SkColorSetA(SK_ColorGREEN, 0xcf),
+static const DlColor TestAlphaColors[kTestStopCount] = {
+    DlColors::kBlue.withAlpha(0x7F),
+    DlColors::kRed.withAlpha(0x2F),
+    DlColors::kGreen.withAlpha(0xCF),
 };
 static constexpr float TestStops[kTestStopCount] = {
     0.0f,
@@ -133,8 +133,9 @@ TEST(DisplayListColorSource, FromSkiaImageShader) {
 TEST(DisplayListColorSource, FromSkiaLinearGradient) {
   // We can read back all of the parameters of a Linear gradient
   // except for matrix.
+  const SkColor* sk_colors = reinterpret_cast<const SkColor*>(TestColors);
   sk_sp<SkShader> shader = SkGradientShader::MakeLinear(
-      TestPoints, TestColors, TestStops, kTestStopCount, SkTileMode::kClamp);
+      TestPoints, sk_colors, TestStops, kTestStopCount, SkTileMode::kClamp);
   std::shared_ptr<DlColorSource> source = DlColorSource::From(shader);
   std::shared_ptr<DlColorSource> dl_source =
       DlColorSource::MakeLinear(TestPoints[0], TestPoints[1], kTestStopCount,
@@ -162,8 +163,9 @@ TEST(DisplayListColorSource, FromSkiaLinearGradient) {
 TEST(DisplayListColorSource, FromSkiaRadialGradient) {
   // We can read back all of the parameters of a Radial gradient
   // except for matrix.
+  const SkColor* sk_colors = reinterpret_cast<const SkColor*>(TestColors);
   sk_sp<SkShader> shader =
-      SkGradientShader::MakeRadial(TestPoints[0], 10.0, TestColors, TestStops,
+      SkGradientShader::MakeRadial(TestPoints[0], 10.0, sk_colors, TestStops,
                                    kTestStopCount, SkTileMode::kClamp);
   std::shared_ptr<DlColorSource> source = DlColorSource::From(shader);
   std::shared_ptr<DlColorSource> dl_source =
@@ -192,8 +194,9 @@ TEST(DisplayListColorSource, FromSkiaRadialGradient) {
 TEST(DisplayListColorSource, FromSkiaConicalGradient) {
   // We can read back all of the parameters of a Conical gradient
   // except for matrix.
+  const SkColor* sk_colors = reinterpret_cast<const SkColor*>(TestColors);
   sk_sp<SkShader> shader = SkGradientShader::MakeTwoPointConical(
-      TestPoints[0], 10.0, TestPoints[1], 20.0, TestColors, TestStops,
+      TestPoints[0], 10.0, TestPoints[1], 20.0, sk_colors, TestStops,
       kTestStopCount, SkTileMode::kClamp);
   std::shared_ptr<DlColorSource> source = DlColorSource::From(shader);
   std::shared_ptr<DlColorSource> dl_source = DlColorSource::MakeConical(
@@ -224,9 +227,9 @@ TEST(DisplayListColorSource, FromSkiaConicalGradient) {
 TEST(DisplayListColorSource, FromSkiaSweepGradient) {
   // We can read back all of the parameters of a Sweep gradient
   // except for matrix and the start/stop angles.
-  sk_sp<SkShader> shader =
-      SkGradientShader::MakeSweep(TestPoints[0].fX, TestPoints[0].fY,
-                                  TestColors, TestStops, kTestStopCount);
+  const SkColor* sk_colors = reinterpret_cast<const SkColor*>(TestColors);
+  sk_sp<SkShader> shader = SkGradientShader::MakeSweep(
+      TestPoints[0].fX, TestPoints[0].fY, sk_colors, TestStops, kTestStopCount);
   std::shared_ptr<DlColorSource> source = DlColorSource::From(shader);
   std::shared_ptr<DlColorSource> dl_source =
       DlColorSource::MakeSweep(TestPoints[0], 0, 360, kTestStopCount,

--- a/display_list/display_list_color_source_unittests.cc
+++ b/display_list/display_list_color_source_unittests.cc
@@ -40,14 +40,14 @@ static const SkMatrix TestMatrix2 =
 // clang-format on
 static constexpr int kTestStopCount = 3;
 static constexpr DlColor TestColors[kTestStopCount] = {
-    DlColors::kRed,
-    DlColors::kGreen,
-    DlColors::kBlue,
+    DlColor::kRed(),
+    DlColor::kGreen(),
+    DlColor::kBlue(),
 };
 static const DlColor TestAlphaColors[kTestStopCount] = {
-    DlColors::kBlue.withAlpha(0x7F),
-    DlColors::kRed.withAlpha(0x2F),
-    DlColors::kGreen.withAlpha(0xCF),
+    DlColor::kBlue().withAlpha(0x7F),
+    DlColor::kRed().withAlpha(0x2F),
+    DlColor::kGreen().withAlpha(0xCF),
 };
 static constexpr float TestStops[kTestStopCount] = {
     0.0f,

--- a/display_list/display_list_color_unittests.cc
+++ b/display_list/display_list_color_unittests.cc
@@ -28,10 +28,10 @@ TEST(DisplayListColor, ArrayInterchangeableWithUint32) {
       0xF1F2F3F4,
   };
   DlColor colors[5] = {
-      DlColors::kBlack,  //
-      DlColors::kRed,    //
-      DlColors::kGreen,  //
-      DlColors::kBlue,   //
+      DlColor::kBlack(),  //
+      DlColor::kRed(),    //
+      DlColor::kGreen(),  //
+      DlColor::kBlue(),   //
       DlColor(0xF1F2F3F4),
   };
   arraysEqual(ints, colors, 5);
@@ -40,10 +40,10 @@ TEST(DisplayListColor, ArrayInterchangeableWithUint32) {
 }
 
 TEST(DisplayListColor, DlColorDirectlyComparesToSkColor) {
-  EXPECT_EQ(DlColors::kBlack, SK_ColorBLACK);
-  EXPECT_EQ(DlColors::kRed, SK_ColorRED);
-  EXPECT_EQ(DlColors::kGreen, SK_ColorGREEN);
-  EXPECT_EQ(DlColors::kBlue, SK_ColorBLUE);
+  EXPECT_EQ(DlColor::kBlack(), SK_ColorBLACK);
+  EXPECT_EQ(DlColor::kRed(), SK_ColorRED);
+  EXPECT_EQ(DlColor::kGreen(), SK_ColorGREEN);
+  EXPECT_EQ(DlColor::kBlue(), SK_ColorBLUE);
 }
 
 }  // namespace testing

--- a/display_list/display_list_color_unittests.cc
+++ b/display_list/display_list_color_unittests.cc
@@ -1,0 +1,50 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/display_list/display_list_attributes_testing.h"
+#include "flutter/display_list/display_list_builder.h"
+#include "flutter/display_list/display_list_color_source.h"
+#include "flutter/display_list/types.h"
+#include "third_party/skia/include/core/SkSurface.h"
+
+namespace flutter {
+namespace testing {
+
+static void arraysEqual(const uint32_t* ints,
+                        const DlColor* colors,
+                        int count) {
+  for (int i = 0; i < count; i++) {
+    EXPECT_TRUE(ints[i] == colors[i]);
+  }
+}
+
+TEST(DisplayListColor, ArrayInterchangeableWithUint32) {
+  uint32_t ints[5] = {
+      0xFF000000,  //
+      0xFFFF0000,  //
+      0xFF00FF00,  //
+      0xFF0000FF,  //
+      0xF1F2F3F4,
+  };
+  DlColor colors[5] = {
+      DlColors::kBlack,  //
+      DlColors::kRed,    //
+      DlColors::kGreen,  //
+      DlColors::kBlue,   //
+      DlColor(0xF1F2F3F4),
+  };
+  arraysEqual(ints, colors, 5);
+  arraysEqual(reinterpret_cast<const uint32_t*>(colors),
+              reinterpret_cast<const DlColor*>(ints), 5);
+}
+
+TEST(DisplayListColor, DlColorDirectlyComparesToSkColor) {
+  EXPECT_EQ(DlColors::kBlack, SK_ColorBLACK);
+  EXPECT_EQ(DlColors::kRed, SK_ColorRED);
+  EXPECT_EQ(DlColors::kGreen, SK_ColorGREEN);
+  EXPECT_EQ(DlColors::kBlue, SK_ColorBLUE);
+}
+
+}  // namespace testing
+}  // namespace flutter

--- a/display_list/display_list_complexity_gl.cc
+++ b/display_list/display_list_complexity_gl.cc
@@ -658,7 +658,7 @@ void DisplayListGLComplexityCalculator::GLHelper::drawTextBlob(
 
 void DisplayListGLComplexityCalculator::GLHelper::drawShadow(
     const SkPath& path,
-    const SkColor color,
+    const DlColor color,
     const SkScalar elevation,
     bool transparent_occluder,
     SkScalar dpr) {

--- a/display_list/display_list_complexity_gl.h
+++ b/display_list/display_list_complexity_gl.h
@@ -70,7 +70,7 @@ class DisplayListGLComplexityCalculator
                       SkScalar x,
                       SkScalar y) override;
     void drawShadow(const SkPath& path,
-                    const SkColor color,
+                    const DlColor color,
                     const SkScalar elevation,
                     bool transparent_occluder,
                     SkScalar dpr) override;

--- a/display_list/display_list_complexity_helper.h
+++ b/display_list/display_list_complexity_helper.h
@@ -103,10 +103,10 @@ class ComplexityCalculatorHelper
 
   void setDither(bool dither) override {}
   void setInvertColors(bool invert) override {}
-  void setStrokeCap(SkPaint::Cap cap) override {}
-  void setStrokeJoin(SkPaint::Join join) override {}
+  void setStrokeCap(DlStrokeCap cap) override {}
+  void setStrokeJoin(DlStrokeJoin join) override {}
   void setStrokeMiter(SkScalar limit) override {}
-  void setColor(SkColor color) override {}
+  void setColor(DlColor color) override {}
   void setBlendMode(DlBlendMode mode) override {}
   void setBlender(sk_sp<SkBlender> blender) override {}
   void setColorSource(const DlColorSource* source) override {}
@@ -121,15 +121,15 @@ class ComplexityCalculatorHelper
 
   void setAntiAlias(bool aa) override { current_paint_.setAntiAlias(aa); }
 
-  void setStyle(SkPaint::Style style) override {
-    current_paint_.setStyle(style);
+  void setStyle(DlDrawStyle style) override {
+    current_paint_.setStyle(ToSk(style));
   }
 
   void setStrokeWidth(SkScalar width) override {
     current_paint_.setStrokeWidth(width);
   }
 
-  void drawColor(SkColor color, DlBlendMode mode) override {
+  void drawColor(DlColor color, DlBlendMode mode) override {
     if (IsComplex()) {
       return;
     }
@@ -178,7 +178,7 @@ class ComplexityCalculatorHelper
   void drawAtlas(const sk_sp<DlImage> atlas,
                  const SkRSXform xform[],
                  const SkRect tex[],
-                 const SkColor colors[],
+                 const DlColor colors[],
                  int count,
                  DlBlendMode mode,
                  const SkSamplingOptions& sampling,

--- a/display_list/display_list_complexity_metal.cc
+++ b/display_list/display_list_complexity_metal.cc
@@ -604,7 +604,7 @@ void DisplayListMetalComplexityCalculator::MetalHelper::drawTextBlob(
 
 void DisplayListMetalComplexityCalculator::MetalHelper::drawShadow(
     const SkPath& path,
-    const SkColor color,
+    const DlColor color,
     const SkScalar elevation,
     bool transparent_occluder,
     SkScalar dpr) {

--- a/display_list/display_list_complexity_metal.h
+++ b/display_list/display_list_complexity_metal.h
@@ -71,7 +71,7 @@ class DisplayListMetalComplexityCalculator
                       SkScalar x,
                       SkScalar y) override;
     void drawShadow(const SkPath& path,
-                    const SkColor color,
+                    const DlColor color,
                     const SkScalar elevation,
                     bool transparent_occluder,
                     SkScalar dpr) override;

--- a/display_list/display_list_complexity_unittests.cc
+++ b/display_list/display_list_complexity_unittests.cc
@@ -110,12 +110,12 @@ TEST(DisplayListComplexity, StrokeWidth) {
 
 TEST(DisplayListComplexity, Style) {
   DisplayListBuilder builder_filled;
-  builder_filled.setStyle(SkPaint::Style::kFill_Style);
+  builder_filled.setStyle(DlDrawStyle::kFill);
   builder_filled.drawRect(SkRect::MakeXYWH(10, 10, 80, 80));
   auto display_list_filled = builder_filled.Build();
 
   DisplayListBuilder builder_stroked;
-  builder_stroked.setStyle(SkPaint::Style::kStroke_Style);
+  builder_stroked.setStyle(DlDrawStyle::kStroke);
   builder_stroked.drawRect(SkRect::MakeXYWH(10, 10, 80, 80));
   auto display_list_stroked = builder_stroked.Build();
 

--- a/display_list/display_list_dispatcher.h
+++ b/display_list/display_list_dispatcher.h
@@ -12,6 +12,7 @@
 #include "flutter/display_list/display_list_image.h"
 #include "flutter/display_list/display_list_image_filter.h"
 #include "flutter/display_list/display_list_mask_filter.h"
+#include "flutter/display_list/display_list_paint.h"
 #include "flutter/display_list/display_list_vertices.h"
 
 namespace flutter {
@@ -36,12 +37,12 @@ class Dispatcher {
   // attributes is not affected by |save| and |restore|.
   virtual void setAntiAlias(bool aa) = 0;
   virtual void setDither(bool dither) = 0;
-  virtual void setStyle(SkPaint::Style style) = 0;
-  virtual void setColor(SkColor color) = 0;
-  virtual void setStrokeWidth(SkScalar width) = 0;
-  virtual void setStrokeMiter(SkScalar limit) = 0;
-  virtual void setStrokeCap(SkPaint::Cap cap) = 0;
-  virtual void setStrokeJoin(SkPaint::Join join) = 0;
+  virtual void setStyle(DlDrawStyle style) = 0;
+  virtual void setColor(DlColor color) = 0;
+  virtual void setStrokeWidth(float width) = 0;
+  virtual void setStrokeMiter(float limit) = 0;
+  virtual void setStrokeCap(DlStrokeCap cap) = 0;
+  virtual void setStrokeJoin(DlStrokeJoin join) = 0;
   virtual void setColorSource(const DlColorSource* source) = 0;
   virtual void setColorFilter(const DlColorFilter* filter) = 0;
   // setInvertColors does not exist in SkPaint, but is a quick way to set
@@ -190,7 +191,7 @@ class Dispatcher {
   // method, the methods here will generally offer a boolean parameter
   // which specifies whether to honor the attributes of the display list
   // stream, or assume default attributes.
-  virtual void drawColor(SkColor color, DlBlendMode mode) = 0;
+  virtual void drawColor(DlColor color, DlBlendMode mode) = 0;
   virtual void drawPaint() = 0;
   virtual void drawLine(const SkPoint& p0, const SkPoint& p1) = 0;
   virtual void drawRect(const SkRect& rect) = 0;
@@ -232,7 +233,7 @@ class Dispatcher {
   virtual void drawAtlas(const sk_sp<DlImage> atlas,
                          const SkRSXform xform[],
                          const SkRect tex[],
-                         const SkColor colors[],
+                         const DlColor colors[],
                          int count,
                          DlBlendMode mode,
                          const SkSamplingOptions& sampling,
@@ -246,7 +247,7 @@ class Dispatcher {
                             SkScalar x,
                             SkScalar y) = 0;
   virtual void drawShadow(const SkPath& path,
-                          const SkColor color,
+                          const DlColor color,
                           const SkScalar elevation,
                           bool transparent_occluder,
                           SkScalar dpr) = 0;

--- a/display_list/display_list_flags.h
+++ b/display_list/display_list_flags.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_DISPLAY_LIST_DISPLAY_LIST_FLAGS_H_
 #define FLUTTER_DISPLAY_LIST_DISPLAY_LIST_FLAGS_H_
 
+#include "flutter/display_list/display_list_paint.h"
 #include "flutter/display_list/types.h"
 #include "flutter/fml/logging.h"
 
@@ -216,10 +217,9 @@ class DisplayListAttributeFlags : DisplayListFlagsBase {
 
   bool is_geometric() const { return has_any(kIsAnyGeometryMask_); }
   bool always_stroked() const { return has_any(kIsStrokedGeometry_); }
-  bool is_stroked(SkPaint::Style style = SkPaint::Style::kStroke_Style) const {
-    return (
-        has_any(kIsStrokedGeometry_) ||
-        (style != SkPaint::Style::kFill_Style && has_any(kIsDrawnGeometry_)));
+  bool is_stroked(DlDrawStyle style = DlDrawStyle::kStroke) const {
+    return (has_any(kIsStrokedGeometry_) ||
+            (style != DlDrawStyle::kFill && has_any(kIsDrawnGeometry_)));
   }
 
   bool is_flood() const { return has_any(kFloodsSurface_); }

--- a/display_list/display_list_image_filter_unittests.cc
+++ b/display_list/display_list_image_filter_unittests.cc
@@ -124,7 +124,7 @@ TEST(DisplayListImageFilter, FromSkiaColorFilterImageFilter) {
   sk_sp<SkImageFilter> sk_image_filter =
       SkImageFilters::ColorFilter(sk_color_filter, nullptr);
   std::shared_ptr<DlImageFilter> filter = DlImageFilter::From(sk_image_filter);
-  DlBlendColorFilter dl_color_filter(DlColors::kRed, DlBlendMode::kSrcIn);
+  DlBlendColorFilter dl_color_filter(DlColor::kRed(), DlBlendMode::kSrcIn);
   DlColorFilterImageFilter dl_image_filter(dl_color_filter.shared());
 
   ASSERT_EQ(filter->type(), DlImageFilterType::kColorFilter);
@@ -414,19 +414,19 @@ TEST(DisplayListImageFilter, ComposeNotEquals) {
 }
 
 TEST(DisplayListImageFilter, ColorFilterConstructor) {
-  DlBlendColorFilter dl_color_filter(DlColors::kRed, DlBlendMode::kLighten);
+  DlBlendColorFilter dl_color_filter(DlColor::kRed(), DlBlendMode::kLighten);
   DlColorFilterImageFilter filter(dl_color_filter);
 }
 
 TEST(DisplayListImageFilter, ColorFilterShared) {
-  DlBlendColorFilter dl_color_filter(DlColors::kRed, DlBlendMode::kLighten);
+  DlBlendColorFilter dl_color_filter(DlColor::kRed(), DlBlendMode::kLighten);
   DlColorFilterImageFilter filter(dl_color_filter);
 
   ASSERT_EQ(*filter.shared(), filter);
 }
 
 TEST(DisplayListImageFilter, ColorFilterAsColorFilter) {
-  DlBlendColorFilter dl_color_filter(DlColors::kRed, DlBlendMode::kLighten);
+  DlBlendColorFilter dl_color_filter(DlColor::kRed(), DlBlendMode::kLighten);
   DlColorFilterImageFilter filter(dl_color_filter);
 
   ASSERT_NE(filter.asColorFilter(), nullptr);
@@ -434,30 +434,30 @@ TEST(DisplayListImageFilter, ColorFilterAsColorFilter) {
 }
 
 TEST(DisplayListImageFilter, ColorFilterContents) {
-  DlBlendColorFilter dl_color_filter(DlColors::kRed, DlBlendMode::kLighten);
+  DlBlendColorFilter dl_color_filter(DlColor::kRed(), DlBlendMode::kLighten);
   DlColorFilterImageFilter filter(dl_color_filter);
 
   ASSERT_EQ(*filter.color_filter().get(), dl_color_filter);
 }
 
 TEST(DisplayListImageFilter, ColorFilterEquals) {
-  DlBlendColorFilter dl_color_filter1(DlColors::kRed, DlBlendMode::kLighten);
+  DlBlendColorFilter dl_color_filter1(DlColor::kRed(), DlBlendMode::kLighten);
   DlColorFilterImageFilter filter1(dl_color_filter1);
 
-  DlBlendColorFilter dl_color_filter2(DlColors::kRed, DlBlendMode::kLighten);
+  DlBlendColorFilter dl_color_filter2(DlColor::kRed(), DlBlendMode::kLighten);
   DlColorFilterImageFilter filter2(dl_color_filter2);
 
   TestEquals(filter1, filter2);
 }
 
 TEST(DisplayListImageFilter, ColorFilterNotEquals) {
-  DlBlendColorFilter dl_color_filter1(DlColors::kRed, DlBlendMode::kLighten);
+  DlBlendColorFilter dl_color_filter1(DlColor::kRed(), DlBlendMode::kLighten);
   DlColorFilterImageFilter filter1(dl_color_filter1);
 
-  DlBlendColorFilter dl_color_filter2(DlColors::kBlue, DlBlendMode::kLighten);
+  DlBlendColorFilter dl_color_filter2(DlColor::kBlue(), DlBlendMode::kLighten);
   DlColorFilterImageFilter filter2(dl_color_filter2);
 
-  DlBlendColorFilter dl_color_filter3(DlColors::kRed, DlBlendMode::kDarken);
+  DlBlendColorFilter dl_color_filter3(DlColor::kRed(), DlBlendMode::kDarken);
   DlColorFilterImageFilter filter3(dl_color_filter3);
 
   TestNotEquals(filter1, filter2, "Color differs");

--- a/display_list/display_list_image_filter_unittests.cc
+++ b/display_list/display_list_image_filter_unittests.cc
@@ -124,7 +124,7 @@ TEST(DisplayListImageFilter, FromSkiaColorFilterImageFilter) {
   sk_sp<SkImageFilter> sk_image_filter =
       SkImageFilters::ColorFilter(sk_color_filter, nullptr);
   std::shared_ptr<DlImageFilter> filter = DlImageFilter::From(sk_image_filter);
-  DlBlendColorFilter dl_color_filter(SK_ColorRED, SkBlendMode::kSrcIn);
+  DlBlendColorFilter dl_color_filter(DlColors::kRed, DlBlendMode::kSrcIn);
   DlColorFilterImageFilter dl_image_filter(dl_color_filter.shared());
 
   ASSERT_EQ(filter->type(), DlImageFilterType::kColorFilter);
@@ -414,19 +414,19 @@ TEST(DisplayListImageFilter, ComposeNotEquals) {
 }
 
 TEST(DisplayListImageFilter, ColorFilterConstructor) {
-  DlBlendColorFilter dl_color_filter(SK_ColorRED, SkBlendMode::kLighten);
+  DlBlendColorFilter dl_color_filter(DlColors::kRed, DlBlendMode::kLighten);
   DlColorFilterImageFilter filter(dl_color_filter);
 }
 
 TEST(DisplayListImageFilter, ColorFilterShared) {
-  DlBlendColorFilter dl_color_filter(SK_ColorRED, SkBlendMode::kLighten);
+  DlBlendColorFilter dl_color_filter(DlColors::kRed, DlBlendMode::kLighten);
   DlColorFilterImageFilter filter(dl_color_filter);
 
   ASSERT_EQ(*filter.shared(), filter);
 }
 
 TEST(DisplayListImageFilter, ColorFilterAsColorFilter) {
-  DlBlendColorFilter dl_color_filter(SK_ColorRED, SkBlendMode::kLighten);
+  DlBlendColorFilter dl_color_filter(DlColors::kRed, DlBlendMode::kLighten);
   DlColorFilterImageFilter filter(dl_color_filter);
 
   ASSERT_NE(filter.asColorFilter(), nullptr);
@@ -434,30 +434,30 @@ TEST(DisplayListImageFilter, ColorFilterAsColorFilter) {
 }
 
 TEST(DisplayListImageFilter, ColorFilterContents) {
-  DlBlendColorFilter dl_color_filter(SK_ColorRED, SkBlendMode::kLighten);
+  DlBlendColorFilter dl_color_filter(DlColors::kRed, DlBlendMode::kLighten);
   DlColorFilterImageFilter filter(dl_color_filter);
 
   ASSERT_EQ(*filter.color_filter().get(), dl_color_filter);
 }
 
 TEST(DisplayListImageFilter, ColorFilterEquals) {
-  DlBlendColorFilter dl_color_filter1(SK_ColorRED, SkBlendMode::kLighten);
+  DlBlendColorFilter dl_color_filter1(DlColors::kRed, DlBlendMode::kLighten);
   DlColorFilterImageFilter filter1(dl_color_filter1);
 
-  DlBlendColorFilter dl_color_filter2(SK_ColorRED, SkBlendMode::kLighten);
+  DlBlendColorFilter dl_color_filter2(DlColors::kRed, DlBlendMode::kLighten);
   DlColorFilterImageFilter filter2(dl_color_filter2);
 
   TestEquals(filter1, filter2);
 }
 
 TEST(DisplayListImageFilter, ColorFilterNotEquals) {
-  DlBlendColorFilter dl_color_filter1(SK_ColorRED, SkBlendMode::kLighten);
+  DlBlendColorFilter dl_color_filter1(DlColors::kRed, DlBlendMode::kLighten);
   DlColorFilterImageFilter filter1(dl_color_filter1);
 
-  DlBlendColorFilter dl_color_filter2(SK_ColorBLUE, SkBlendMode::kLighten);
+  DlBlendColorFilter dl_color_filter2(DlColors::kBlue, DlBlendMode::kLighten);
   DlColorFilterImageFilter filter2(dl_color_filter2);
 
-  DlBlendColorFilter dl_color_filter3(SK_ColorRED, SkBlendMode::kDarken);
+  DlBlendColorFilter dl_color_filter3(DlColors::kRed, DlBlendMode::kDarken);
   DlColorFilterImageFilter filter3(dl_color_filter3);
 
   TestNotEquals(filter1, filter2, "Color differs");

--- a/display_list/display_list_paint.cc
+++ b/display_list/display_list_paint.cc
@@ -14,8 +14,8 @@ DlPaint::DlPaint()
       isAntiAlias_(false),
       isDither_(false),
       isInvertColors_(false),
-      strokeWidth_(0.0),
-      strokeMiter_(4.0) {}
+      strokeWidth_(kDefaultWidth),
+      strokeMiter_(kDefaultMiter) {}
 
 bool DlPaint::operator==(DlPaint const& other) const {
   return blendMode_ == other.blendMode_ &&            //

--- a/display_list/display_list_paint.h
+++ b/display_list/display_list_paint.h
@@ -6,23 +6,13 @@
 #define FLUTTER_DISPLAY_LIST_DISPLAY_LIST_PAINT_H_
 
 #include "flutter/display_list/display_list_blend_mode.h"
+#include "flutter/display_list/display_list_color.h"
 #include "flutter/display_list/display_list_color_filter.h"
 #include "flutter/display_list/display_list_color_source.h"
 #include "flutter/display_list/display_list_image_filter.h"
 #include "flutter/display_list/display_list_mask_filter.h"
 
 namespace flutter {
-
-class DlColor {
- public:
-  DlColor() : argb(0xFF000000) {}
-  DlColor(uint32_t argb) : argb(argb) {}
-
-  uint32_t argb;
-
-  bool operator==(DlColor const& other) const { return argb == other.argb; }
-  bool operator!=(DlColor const& other) const { return argb != other.argb; }
-};
 
 enum class DlDrawStyle {
   kFill,           //!< fills interior of shapes
@@ -77,6 +67,10 @@ inline SkPaint::Join ToSk(DlStrokeJoin join) {
 
 class DlPaint {
  public:
+  static constexpr DlColor kDefaultColor = DlColors::kBlack;
+  static constexpr float kDefaultWidth = 0.0;
+  static constexpr float kDefaultMiter = 4.0;
+
   DlPaint();
 
   bool isAntiAlias() const { return isAntiAlias_; }
@@ -99,7 +93,7 @@ class DlPaint {
 
   DlColor getColor() const { return color_; }
   DlPaint& setColor(DlColor color) {
-    color_.argb = color.argb;
+    color_ = color;
     return *this;
   }
 
@@ -153,27 +147,55 @@ class DlPaint {
     return *this;
   }
 
-  std::shared_ptr<DlColorSource> getColorSource() const { return colorSource_; }
-  DlPaint& setColorSource(std::shared_ptr<DlColorSource> source) {
+  std::shared_ptr<const DlColorSource> getColorSource() const {
+    return colorSource_;
+  }
+  const DlColorSource* getColorSourcePtr() const { return colorSource_.get(); }
+  DlPaint& setColorSource(std::shared_ptr<const DlColorSource> source) {
     colorSource_ = source;
     return *this;
   }
-
-  std::shared_ptr<DlColorFilter> getColorFilter() const { return colorFilter_; }
-  DlPaint& setColorFilter(std::shared_ptr<DlColorFilter> filter) {
-    colorFilter_ = filter;
+  DlPaint& setColorSource(const DlColorSource* source) {
+    colorSource_ = source ? source->shared() : nullptr;
     return *this;
   }
 
-  std::shared_ptr<DlImageFilter> getImageFilter() const { return imageFilter_; }
+  std::shared_ptr<const DlColorFilter> getColorFilter() const {
+    return colorFilter_;
+  }
+  const DlColorFilter* getColorFilterPtr() const { return colorFilter_.get(); }
+  DlPaint& setColorFilter(std::shared_ptr<DlColorFilter> filter) {
+    colorFilter_ = filter ? filter->shared() : nullptr;
+    return *this;
+  }
+  DlPaint& setColorFilter(const DlColorFilter* filter) {
+    colorFilter_ = filter ? filter->shared() : nullptr;
+    return *this;
+  }
+
+  std::shared_ptr<const DlImageFilter> getImageFilter() const {
+    return imageFilter_;
+  }
+  const DlImageFilter* getImageFilterPtr() const { return imageFilter_.get(); }
   DlPaint& setImageFilter(std::shared_ptr<DlImageFilter> filter) {
     imageFilter_ = filter;
     return *this;
   }
+  DlPaint& setImageFilter(const DlImageFilter* filter) {
+    imageFilter_ = filter ? filter->shared() : nullptr;
+    return *this;
+  }
 
-  std::shared_ptr<DlMaskFilter> getMaskFilter() const { return maskFilter_; }
+  std::shared_ptr<const DlMaskFilter> getMaskFilter() const {
+    return maskFilter_;
+  }
+  const DlMaskFilter* getMaskFilterPtr() const { return maskFilter_.get(); }
   DlPaint& setMaskFilter(std::shared_ptr<DlMaskFilter> filter) {
     maskFilter_ = filter;
+    return *this;
+  }
+  DlPaint& setMaskFilter(const DlMaskFilter* filter) {
+    maskFilter_ = filter ? filter->shared() : nullptr;
     return *this;
   }
 
@@ -210,10 +232,10 @@ class DlPaint {
   float strokeWidth_;
   float strokeMiter_;
 
-  std::shared_ptr<DlColorSource> colorSource_;
-  std::shared_ptr<DlColorFilter> colorFilter_;
-  std::shared_ptr<DlImageFilter> imageFilter_;
-  std::shared_ptr<DlMaskFilter> maskFilter_;
+  std::shared_ptr<const DlColorSource> colorSource_;
+  std::shared_ptr<const DlColorFilter> colorFilter_;
+  std::shared_ptr<const DlImageFilter> imageFilter_;
+  std::shared_ptr<const DlMaskFilter> maskFilter_;
   // missing (as compared to SkPaint):
   // DlPathEffect - waiting for https://github.com/flutter/engine/pull/32159
   // DlBlender - not planning on using that object in a pure DisplayList world

--- a/display_list/display_list_paint.h
+++ b/display_list/display_list_paint.h
@@ -67,7 +67,7 @@ inline SkPaint::Join ToSk(DlStrokeJoin join) {
 
 class DlPaint {
  public:
-  static constexpr DlColor kDefaultColor = DlColors::kBlack;
+  static constexpr DlColor kDefaultColor = DlColor::kBlack();
   static constexpr float kDefaultWidth = 0.0;
   static constexpr float kDefaultMiter = 4.0;
 

--- a/display_list/display_list_paint_unittests.cc
+++ b/display_list/display_list_paint_unittests.cc
@@ -15,14 +15,14 @@ TEST(DisplayListPaint, ConstructorDefaults) {
   EXPECT_FALSE(paint.isAntiAlias());
   EXPECT_FALSE(paint.isDither());
   EXPECT_FALSE(paint.isInvertColors());
-  EXPECT_EQ(paint.getColor(), DlColor{0xFF000000});
+  EXPECT_EQ(paint.getColor(), DlPaint::kDefaultColor);
   EXPECT_EQ(paint.getAlpha(), 0xFF);
   EXPECT_EQ(paint.getBlendMode(), DlBlendMode::kDefaultMode);
   EXPECT_EQ(paint.getDrawStyle(), DlDrawStyle::kDefaultStyle);
   EXPECT_EQ(paint.getStrokeCap(), DlStrokeCap::kDefaultCap);
   EXPECT_EQ(paint.getStrokeJoin(), DlStrokeJoin::kDefaultJoin);
-  EXPECT_EQ(paint.getStrokeWidth(), 0.0);
-  EXPECT_EQ(paint.getStrokeMiter(), 4.0);
+  EXPECT_EQ(paint.getStrokeWidth(), DlPaint::kDefaultWidth);
+  EXPECT_EQ(paint.getStrokeMiter(), DlPaint::kDefaultMiter);
   EXPECT_EQ(paint.getColorSource(), nullptr);
   EXPECT_EQ(paint.getColorFilter(), nullptr);
   EXPECT_EQ(paint.getImageFilter(), nullptr);
@@ -33,12 +33,16 @@ TEST(DisplayListPaint, ConstructorDefaults) {
   EXPECT_EQ(DlStrokeCap::kDefaultCap, DlStrokeCap::kButt);
   EXPECT_EQ(DlStrokeJoin::kDefaultJoin, DlStrokeJoin::kMiter);
 
+  EXPECT_EQ(DlPaint::kDefaultColor, DlColors::kBlack);
+  EXPECT_EQ(DlPaint::kDefaultWidth, 0.0);
+  EXPECT_EQ(DlPaint::kDefaultMiter, 4.0);
+
   EXPECT_EQ(paint, DlPaint());
 
   EXPECT_NE(paint, DlPaint().setAntiAlias(true));
   EXPECT_NE(paint, DlPaint().setDither(true));
   EXPECT_NE(paint, DlPaint().setInvertColors(true));
-  EXPECT_NE(paint, DlPaint().setColor(DlColor(0xFF00FF00)));
+  EXPECT_NE(paint, DlPaint().setColor(DlColors::kGreen));
   EXPECT_NE(paint, DlPaint().setAlpha(0x7f));
   EXPECT_NE(paint, DlPaint().setBlendMode(DlBlendMode::kDstIn));
   EXPECT_NE(paint, DlPaint().setDrawStyle(DlDrawStyle::kStrokeAndFill));
@@ -47,10 +51,10 @@ TEST(DisplayListPaint, ConstructorDefaults) {
   EXPECT_NE(paint, DlPaint().setStrokeWidth(6));
   EXPECT_NE(paint, DlPaint().setStrokeMiter(7));
 
-  DlColorColorSource colorSource(0xFFFF00FF);
+  DlColorColorSource colorSource(DlColors::kMagenta);
   EXPECT_NE(paint, DlPaint().setColorSource(colorSource.shared()));
 
-  DlBlendColorFilter colorFilter(0xFFFFFF00, SkBlendMode::kDstIn);
+  DlBlendColorFilter colorFilter(DlColors::kYellow, DlBlendMode::kDstIn);
   EXPECT_NE(paint, DlPaint().setColorFilter(colorFilter.shared()));
 
   DlBlurImageFilter imageFilter(1.3, 4.7, DlTileMode::kClamp);
@@ -60,23 +64,48 @@ TEST(DisplayListPaint, ConstructorDefaults) {
   EXPECT_NE(paint, DlPaint().setMaskFilter(maskFilter.shared()));
 }
 
+TEST(DisplayListPaint, NullPointerSetGet) {
+  DlColorSource* nullColorSource = nullptr;
+  DlColorFilter* nullColorFilter = nullptr;
+  DlImageFilter* nullImageFilter = nullptr;
+  DlMaskFilter* nullMaskFilter = nullptr;
+  DlPaint paint;
+  EXPECT_EQ(paint.setColorSource(nullColorSource).getColorSource(), nullptr);
+  EXPECT_EQ(paint.setColorFilter(nullColorFilter).getColorFilter(), nullptr);
+  EXPECT_EQ(paint.setImageFilter(nullImageFilter).getImageFilter(), nullptr);
+  EXPECT_EQ(paint.setMaskFilter(nullMaskFilter).getMaskFilter(), nullptr);
+}
+
+TEST(DisplayListPaint, NullSharedPointerSetGet) {
+  std::shared_ptr<DlColorSource> nullColorSource;
+  std::shared_ptr<DlColorFilter> nullColorFilter;
+  std::shared_ptr<DlImageFilter> nullImageFilter;
+  std::shared_ptr<DlMaskFilter> nullMaskFilter;
+  DlPaint paint;
+  EXPECT_EQ(paint.setColorSource(nullColorSource).getColorSource(), nullptr);
+  EXPECT_EQ(paint.setColorFilter(nullColorFilter).getColorFilter(), nullptr);
+  EXPECT_EQ(paint.setImageFilter(nullImageFilter).getImageFilter(), nullptr);
+  EXPECT_EQ(paint.setMaskFilter(nullMaskFilter).getMaskFilter(), nullptr);
+}
+
 TEST(DisplayListPaint, ChainingConstructor) {
   DlPaint paint =
-      DlPaint()                                                     //
-          .setAntiAlias(true)                                       //
-          .setDither(true)                                          //
-          .setInvertColors(true)                                    //
-          .setColor({0xFF00FF00})                                   //
-          .setAlpha(0x7F)                                           //
-          .setBlendMode(DlBlendMode::kLuminosity)                   //
-          .setDrawStyle(DlDrawStyle::kStrokeAndFill)                //
-          .setStrokeCap(DlStrokeCap::kSquare)                       //
-          .setStrokeJoin(DlStrokeJoin::kBevel)                      //
-          .setStrokeWidth(42)                                       //
-          .setStrokeMiter(1.5)                                      //
-          .setColorSource(DlColorColorSource(0xFFFF00FF).shared())  //
+      DlPaint()                                                             //
+          .setAntiAlias(true)                                               //
+          .setDither(true)                                                  //
+          .setInvertColors(true)                                            //
+          .setColor(DlColors::kGreen)                                       //
+          .setAlpha(0x7F)                                                   //
+          .setBlendMode(DlBlendMode::kLuminosity)                           //
+          .setDrawStyle(DlDrawStyle::kStrokeAndFill)                        //
+          .setStrokeCap(DlStrokeCap::kSquare)                               //
+          .setStrokeJoin(DlStrokeJoin::kBevel)                              //
+          .setStrokeWidth(42)                                               //
+          .setStrokeMiter(1.5)                                              //
+          .setColorSource(DlColorColorSource(DlColors::kMagenta).shared())  //
           .setColorFilter(
-              DlBlendColorFilter(0xFFFFFF00, SkBlendMode::kDstIn).shared())
+              DlBlendColorFilter(DlColors::kYellow, DlBlendMode::kDstIn)
+                  .shared())
           .setImageFilter(
               DlBlurImageFilter(1.3, 4.7, DlTileMode::kClamp).shared())
           .setMaskFilter(
@@ -84,7 +113,7 @@ TEST(DisplayListPaint, ChainingConstructor) {
   EXPECT_TRUE(paint.isAntiAlias());
   EXPECT_TRUE(paint.isDither());
   EXPECT_TRUE(paint.isInvertColors());
-  EXPECT_EQ(paint.getColor(), DlColor{0x7F00FF00});
+  EXPECT_EQ(paint.getColor(), DlColors::kGreen.withAlpha(0x7F));
   EXPECT_EQ(paint.getAlpha(), 0x7F);
   EXPECT_EQ(paint.getBlendMode(), DlBlendMode::kLuminosity);
   EXPECT_EQ(paint.getDrawStyle(), DlDrawStyle::kStrokeAndFill);
@@ -92,16 +121,13 @@ TEST(DisplayListPaint, ChainingConstructor) {
   EXPECT_EQ(paint.getStrokeJoin(), DlStrokeJoin::kBevel);
   EXPECT_EQ(paint.getStrokeWidth(), 42);
   EXPECT_EQ(paint.getStrokeMiter(), 1.5);
-  EXPECT_TRUE(
-      Equals(paint.getColorSource(), DlColorColorSource(0xFFFF00FF).shared()));
-  EXPECT_TRUE(
-      Equals(paint.getColorFilter(),
-             DlBlendColorFilter(0xFFFFFF00, SkBlendMode::kDstIn).shared()));
-  EXPECT_TRUE(Equals(paint.getImageFilter(),
-                     DlBlurImageFilter(1.3, 4.7, DlTileMode::kClamp).shared()));
-  EXPECT_TRUE(
-      Equals(paint.getMaskFilter(),
-             DlBlurMaskFilter(SkBlurStyle::kInner_SkBlurStyle, 3.14).shared()));
+  EXPECT_EQ(*paint.getColorSource(), DlColorColorSource(DlColors::kMagenta));
+  EXPECT_EQ(*paint.getColorFilter(),
+            DlBlendColorFilter(DlColors::kYellow, DlBlendMode::kDstIn));
+  EXPECT_EQ(*paint.getImageFilter(),
+            DlBlurImageFilter(1.3, 4.7, DlTileMode::kClamp));
+  EXPECT_EQ(*paint.getMaskFilter(),
+            DlBlurMaskFilter(SkBlurStyle::kInner_SkBlurStyle, 3.14));
 
   EXPECT_NE(paint, DlPaint());
 }

--- a/display_list/display_list_paint_unittests.cc
+++ b/display_list/display_list_paint_unittests.cc
@@ -33,7 +33,7 @@ TEST(DisplayListPaint, ConstructorDefaults) {
   EXPECT_EQ(DlStrokeCap::kDefaultCap, DlStrokeCap::kButt);
   EXPECT_EQ(DlStrokeJoin::kDefaultJoin, DlStrokeJoin::kMiter);
 
-  EXPECT_EQ(DlPaint::kDefaultColor, DlColors::kBlack);
+  EXPECT_EQ(DlPaint::kDefaultColor, DlColor::kBlack());
   EXPECT_EQ(DlPaint::kDefaultWidth, 0.0);
   EXPECT_EQ(DlPaint::kDefaultMiter, 4.0);
 
@@ -42,7 +42,7 @@ TEST(DisplayListPaint, ConstructorDefaults) {
   EXPECT_NE(paint, DlPaint().setAntiAlias(true));
   EXPECT_NE(paint, DlPaint().setDither(true));
   EXPECT_NE(paint, DlPaint().setInvertColors(true));
-  EXPECT_NE(paint, DlPaint().setColor(DlColors::kGreen));
+  EXPECT_NE(paint, DlPaint().setColor(DlColor::kGreen()));
   EXPECT_NE(paint, DlPaint().setAlpha(0x7f));
   EXPECT_NE(paint, DlPaint().setBlendMode(DlBlendMode::kDstIn));
   EXPECT_NE(paint, DlPaint().setDrawStyle(DlDrawStyle::kStrokeAndFill));
@@ -51,10 +51,10 @@ TEST(DisplayListPaint, ConstructorDefaults) {
   EXPECT_NE(paint, DlPaint().setStrokeWidth(6));
   EXPECT_NE(paint, DlPaint().setStrokeMiter(7));
 
-  DlColorColorSource colorSource(DlColors::kMagenta);
+  DlColorColorSource colorSource(DlColor::kMagenta());
   EXPECT_NE(paint, DlPaint().setColorSource(colorSource.shared()));
 
-  DlBlendColorFilter colorFilter(DlColors::kYellow, DlBlendMode::kDstIn);
+  DlBlendColorFilter colorFilter(DlColor::kYellow(), DlBlendMode::kDstIn);
   EXPECT_NE(paint, DlPaint().setColorFilter(colorFilter.shared()));
 
   DlBlurImageFilter imageFilter(1.3, 4.7, DlTileMode::kClamp);
@@ -90,21 +90,21 @@ TEST(DisplayListPaint, NullSharedPointerSetGet) {
 
 TEST(DisplayListPaint, ChainingConstructor) {
   DlPaint paint =
-      DlPaint()                                                             //
-          .setAntiAlias(true)                                               //
-          .setDither(true)                                                  //
-          .setInvertColors(true)                                            //
-          .setColor(DlColors::kGreen)                                       //
-          .setAlpha(0x7F)                                                   //
-          .setBlendMode(DlBlendMode::kLuminosity)                           //
-          .setDrawStyle(DlDrawStyle::kStrokeAndFill)                        //
-          .setStrokeCap(DlStrokeCap::kSquare)                               //
-          .setStrokeJoin(DlStrokeJoin::kBevel)                              //
-          .setStrokeWidth(42)                                               //
-          .setStrokeMiter(1.5)                                              //
-          .setColorSource(DlColorColorSource(DlColors::kMagenta).shared())  //
+      DlPaint()                                                              //
+          .setAntiAlias(true)                                                //
+          .setDither(true)                                                   //
+          .setInvertColors(true)                                             //
+          .setColor(DlColor::kGreen())                                       //
+          .setAlpha(0x7F)                                                    //
+          .setBlendMode(DlBlendMode::kLuminosity)                            //
+          .setDrawStyle(DlDrawStyle::kStrokeAndFill)                         //
+          .setStrokeCap(DlStrokeCap::kSquare)                                //
+          .setStrokeJoin(DlStrokeJoin::kBevel)                               //
+          .setStrokeWidth(42)                                                //
+          .setStrokeMiter(1.5)                                               //
+          .setColorSource(DlColorColorSource(DlColor::kMagenta()).shared())  //
           .setColorFilter(
-              DlBlendColorFilter(DlColors::kYellow, DlBlendMode::kDstIn)
+              DlBlendColorFilter(DlColor::kYellow(), DlBlendMode::kDstIn)
                   .shared())
           .setImageFilter(
               DlBlurImageFilter(1.3, 4.7, DlTileMode::kClamp).shared())
@@ -113,7 +113,7 @@ TEST(DisplayListPaint, ChainingConstructor) {
   EXPECT_TRUE(paint.isAntiAlias());
   EXPECT_TRUE(paint.isDither());
   EXPECT_TRUE(paint.isInvertColors());
-  EXPECT_EQ(paint.getColor(), DlColors::kGreen.withAlpha(0x7F));
+  EXPECT_EQ(paint.getColor(), DlColor::kGreen().withAlpha(0x7F));
   EXPECT_EQ(paint.getAlpha(), 0x7F);
   EXPECT_EQ(paint.getBlendMode(), DlBlendMode::kLuminosity);
   EXPECT_EQ(paint.getDrawStyle(), DlDrawStyle::kStrokeAndFill);
@@ -121,9 +121,9 @@ TEST(DisplayListPaint, ChainingConstructor) {
   EXPECT_EQ(paint.getStrokeJoin(), DlStrokeJoin::kBevel);
   EXPECT_EQ(paint.getStrokeWidth(), 42);
   EXPECT_EQ(paint.getStrokeMiter(), 1.5);
-  EXPECT_EQ(*paint.getColorSource(), DlColorColorSource(DlColors::kMagenta));
+  EXPECT_EQ(*paint.getColorSource(), DlColorColorSource(DlColor::kMagenta()));
   EXPECT_EQ(*paint.getColorFilter(),
-            DlBlendColorFilter(DlColors::kYellow, DlBlendMode::kDstIn));
+            DlBlendColorFilter(DlColor::kYellow(), DlBlendMode::kDstIn));
   EXPECT_EQ(*paint.getImageFilter(),
             DlBlurImageFilter(1.3, 4.7, DlTileMode::kClamp));
   EXPECT_EQ(*paint.getMaskFilter(),

--- a/display_list/display_list_unittests.cc
+++ b/display_list/display_list_unittests.cc
@@ -24,9 +24,9 @@ constexpr SkPoint end_points[] = {
     {100, 100},
 };
 const DlColor colors[] = {
-    DlColors::kGreen,
-    DlColors::kYellow,
-    DlColors::kBlue,
+    DlColor::kGreen(),
+    DlColor::kYellow(),
+    DlColor::kBlue(),
 };
 constexpr float stops[] = {
     0.0,
@@ -130,11 +130,11 @@ static const std::shared_ptr<DlColorSource> TestSource5 =
                              colors,
                              stops,
                              DlTileMode::kDecal);
-static const DlBlendColorFilter TestBlendColorFilter1(DlColors::kRed,
+static const DlBlendColorFilter TestBlendColorFilter1(DlColor::kRed(),
                                                       DlBlendMode::kDstATop);
-static const DlBlendColorFilter TestBlendColorFilter2(DlColors::kBlue,
+static const DlBlendColorFilter TestBlendColorFilter2(DlColor::kBlue(),
                                                       DlBlendMode::kDstATop);
-static const DlBlendColorFilter TestBlendColorFilter3(DlColors::kRed,
+static const DlBlendColorFilter TestBlendColorFilter3(DlColor::kRed(),
                                                       DlBlendMode::kDstIn);
 static const DlMatrixColorFilter TestMatrixColorFilter1(rotate_color_matrix);
 static const DlMatrixColorFilter TestMatrixColorFilter2(invert_color_matrix);
@@ -789,13 +789,13 @@ std::vector<DisplayListInvocationGroup> allGroups = {
       {1, 40 + 32 + 32 + 8, -1, 40 + 32 + 32 + 8, [](DisplayListBuilder& b) {
         static SkRSXform xforms[] = { {1, 0, 0, 0}, {0, 1, 0, 0} };
         static SkRect texs[] = { { 10, 10, 20, 20 }, {20, 20, 30, 30} };
-        static DlColor colors[] = { DlColors::kBlue, DlColors::kGreen };
+        static DlColor colors[] = { DlColor::kBlue(), DlColor::kGreen() };
         b.drawAtlas(TestImage1, xforms, texs, colors, 2, DlBlendMode::kSrcIn,
                     NearestSampling, nullptr, false);}},
       {1, 56 + 32 + 32 + 8, -1, 56 + 32 + 32 + 8, [](DisplayListBuilder& b) {
         static SkRSXform xforms[] = { {1, 0, 0, 0}, {0, 1, 0, 0} };
         static SkRect texs[] = { { 10, 10, 20, 20 }, {20, 20, 30, 30} };
-        static DlColor colors[] = { DlColors::kBlue, DlColors::kGreen };
+        static DlColor colors[] = { DlColor::kBlue(), DlColor::kGreen() };
         static SkRect cullRect = { 0, 0, 200, 200 };
         b.drawAtlas(TestImage1, xforms, texs, colors, 2, DlBlendMode::kSrcIn,
                     NearestSampling, &cullRect, false);}},

--- a/display_list/display_list_unittests.cc
+++ b/display_list/display_list_unittests.cc
@@ -23,10 +23,10 @@ constexpr SkPoint end_points[] = {
     {0, 0},
     {100, 100},
 };
-constexpr SkColor colors[] = {
-    SK_ColorGREEN,
-    SK_ColorYELLOW,
-    SK_ColorBLUE,
+const DlColor colors[] = {
+    DlColors::kGreen,
+    DlColors::kYellow,
+    DlColors::kBlue,
 };
 constexpr float stops[] = {
     0.0,
@@ -130,12 +130,12 @@ static const std::shared_ptr<DlColorSource> TestSource5 =
                              colors,
                              stops,
                              DlTileMode::kDecal);
-static const DlBlendColorFilter TestBlendColorFilter1(SK_ColorRED,
-                                                      SkBlendMode::kDstATop);
-static const DlBlendColorFilter TestBlendColorFilter2(SK_ColorBLUE,
-                                                      SkBlendMode::kDstATop);
-static const DlBlendColorFilter TestBlendColorFilter3(SK_ColorRED,
-                                                      SkBlendMode::kDstIn);
+static const DlBlendColorFilter TestBlendColorFilter1(DlColors::kRed,
+                                                      DlBlendMode::kDstATop);
+static const DlBlendColorFilter TestBlendColorFilter2(DlColors::kBlue,
+                                                      DlBlendMode::kDstATop);
+static const DlBlendColorFilter TestBlendColorFilter3(DlColors::kRed,
+                                                      DlBlendMode::kDstIn);
 static const DlMatrixColorFilter TestMatrixColorFilter1(rotate_color_matrix);
 static const DlMatrixColorFilter TestMatrixColorFilter2(invert_color_matrix);
 static const DlBlurImageFilter TestBlurImageFilter1(5.0,
@@ -339,21 +339,21 @@ std::vector<DisplayListInvocationGroup> allGroups = {
     }
   },
   { "SetStrokeCap", {
-      {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setStrokeCap(SkPaint::kRound_Cap);}},
-      {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setStrokeCap(SkPaint::kSquare_Cap);}},
-      {0, 0, 0, 0, [](DisplayListBuilder& b) {b.setStrokeCap(SkPaint::kButt_Cap);}},
+      {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setStrokeCap(DlStrokeCap::kRound);}},
+      {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setStrokeCap(DlStrokeCap::kSquare);}},
+      {0, 0, 0, 0, [](DisplayListBuilder& b) {b.setStrokeCap(DlStrokeCap::kButt);}},
     }
   },
   { "SetStrokeJoin", {
-      {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setStrokeJoin(SkPaint::kBevel_Join);}},
-      {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setStrokeJoin(SkPaint::kRound_Join);}},
-      {0, 0, 0, 0, [](DisplayListBuilder& b) {b.setStrokeJoin(SkPaint::kMiter_Join);}},
+      {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setStrokeJoin(DlStrokeJoin::kBevel);}},
+      {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setStrokeJoin(DlStrokeJoin::kRound);}},
+      {0, 0, 0, 0, [](DisplayListBuilder& b) {b.setStrokeJoin(DlStrokeJoin::kMiter);}},
     }
   },
   { "SetStyle", {
-      {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setStyle(SkPaint::kStroke_Style);}},
-      {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setStyle(SkPaint::kStrokeAndFill_Style);}},
-      {0, 0, 0, 0, [](DisplayListBuilder& b) {b.setStyle(SkPaint::kFill_Style);}},
+      {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setStyle(DlDrawStyle::kStroke);}},
+      {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setStyle(DlDrawStyle::kStrokeAndFill);}},
+      {0, 0, 0, 0, [](DisplayListBuilder& b) {b.setStyle(DlDrawStyle::kFill);}},
     }
   },
   { "SetStrokeWidth", {
@@ -789,13 +789,13 @@ std::vector<DisplayListInvocationGroup> allGroups = {
       {1, 40 + 32 + 32 + 8, -1, 40 + 32 + 32 + 8, [](DisplayListBuilder& b) {
         static SkRSXform xforms[] = { {1, 0, 0, 0}, {0, 1, 0, 0} };
         static SkRect texs[] = { { 10, 10, 20, 20 }, {20, 20, 30, 30} };
-        static SkColor colors[] = { SK_ColorBLUE, SK_ColorGREEN };
+        static DlColor colors[] = { DlColors::kBlue, DlColors::kGreen };
         b.drawAtlas(TestImage1, xforms, texs, colors, 2, DlBlendMode::kSrcIn,
                     NearestSampling, nullptr, false);}},
       {1, 56 + 32 + 32 + 8, -1, 56 + 32 + 32 + 8, [](DisplayListBuilder& b) {
         static SkRSXform xforms[] = { {1, 0, 0, 0}, {0, 1, 0, 0} };
         static SkRect texs[] = { { 10, 10, 20, 20 }, {20, 20, 30, 30} };
-        static SkColor colors[] = { SK_ColorBLUE, SK_ColorGREEN };
+        static DlColor colors[] = { DlColors::kBlue, DlColors::kGreen };
         static SkRect cullRect = { 0, 0, 200, 200 };
         b.drawAtlas(TestImage1, xforms, texs, colors, 2, DlBlendMode::kSrcIn,
                     NearestSampling, &cullRect, false);}},

--- a/display_list/display_list_utils.cc
+++ b/display_list/display_list_utils.cc
@@ -47,14 +47,14 @@ void SkPaintDispatchHelper::setInvertColors(bool invert) {
   invert_colors_ = invert;
   paint_.setColorFilter(makeColorFilter());
 }
-void SkPaintDispatchHelper::setStrokeCap(SkPaint::Cap cap) {
-  paint_.setStrokeCap(cap);
+void SkPaintDispatchHelper::setStrokeCap(DlStrokeCap cap) {
+  paint_.setStrokeCap(ToSk(cap));
 }
-void SkPaintDispatchHelper::setStrokeJoin(SkPaint::Join join) {
-  paint_.setStrokeJoin(join);
+void SkPaintDispatchHelper::setStrokeJoin(DlStrokeJoin join) {
+  paint_.setStrokeJoin(ToSk(join));
 }
-void SkPaintDispatchHelper::setStyle(SkPaint::Style style) {
-  paint_.setStyle(style);
+void SkPaintDispatchHelper::setStyle(DlDrawStyle style) {
+  paint_.setStyle(ToSk(style));
 }
 void SkPaintDispatchHelper::setStrokeWidth(SkScalar width) {
   paint_.setStrokeWidth(width);
@@ -62,7 +62,7 @@ void SkPaintDispatchHelper::setStrokeWidth(SkScalar width) {
 void SkPaintDispatchHelper::setStrokeMiter(SkScalar limit) {
   paint_.setStrokeMiter(limit);
 }
-void SkPaintDispatchHelper::setColor(SkColor color) {
+void SkPaintDispatchHelper::setColor(DlColor color) {
   current_color_ = color;
   paint_.setColor(color);
   if (has_opacity()) {
@@ -243,13 +243,13 @@ DisplayListBoundsCalculator::DisplayListBoundsCalculator(
   layer_infos_.emplace_back(std::make_unique<LayerData>(nullptr));
   accumulator_ = layer_infos_.back()->layer_accumulator();
 }
-void DisplayListBoundsCalculator::setStrokeCap(SkPaint::Cap cap) {
-  cap_is_square_ = (cap == SkPaint::kSquare_Cap);
+void DisplayListBoundsCalculator::setStrokeCap(DlStrokeCap cap) {
+  cap_is_square_ = (cap == DlStrokeCap::kSquare);
 }
-void DisplayListBoundsCalculator::setStrokeJoin(SkPaint::Join join) {
-  join_is_miter_ = (join == SkPaint::kMiter_Join);
+void DisplayListBoundsCalculator::setStrokeJoin(DlStrokeJoin join) {
+  join_is_miter_ = (join == DlStrokeJoin::kMiter);
 }
-void DisplayListBoundsCalculator::setStyle(SkPaint::Style style) {
+void DisplayListBoundsCalculator::setStyle(DlDrawStyle style) {
   style_ = style;
 }
 void DisplayListBoundsCalculator::setStrokeWidth(SkScalar width) {
@@ -377,7 +377,7 @@ void DisplayListBoundsCalculator::restore() {
 void DisplayListBoundsCalculator::drawPaint() {
   AccumulateUnbounded();
 }
-void DisplayListBoundsCalculator::drawColor(SkColor color, DlBlendMode mode) {
+void DisplayListBoundsCalculator::drawColor(DlColor color, DlBlendMode mode) {
   AccumulateUnbounded();
 }
 void DisplayListBoundsCalculator::drawLine(const SkPoint& p0,
@@ -504,7 +504,7 @@ void DisplayListBoundsCalculator::drawImageLattice(
 void DisplayListBoundsCalculator::drawAtlas(const sk_sp<DlImage> atlas,
                                             const SkRSXform xform[],
                                             const SkRect tex[],
-                                            const SkColor colors[],
+                                            const DlColor colors[],
                                             int count,
                                             DlBlendMode mode,
                                             const SkSamplingOptions& sampling,
@@ -551,7 +551,7 @@ void DisplayListBoundsCalculator::drawTextBlob(const sk_sp<SkTextBlob> blob,
   AccumulateOpBounds(blob->bounds().makeOffset(x, y), kDrawTextBlobFlags);
 }
 void DisplayListBoundsCalculator::drawShadow(const SkPath& path,
-                                             const SkColor color,
+                                             const DlColor color,
                                              const SkScalar elevation,
                                              bool transparent_occluder,
                                              SkScalar dpr) {

--- a/display_list/display_list_utils.h
+++ b/display_list/display_list_utils.h
@@ -47,12 +47,12 @@ class IgnoreAttributeDispatchHelper : public virtual Dispatcher {
   void setAntiAlias(bool aa) override {}
   void setDither(bool dither) override {}
   void setInvertColors(bool invert) override {}
-  void setStrokeCap(SkPaint::Cap cap) override {}
-  void setStrokeJoin(SkPaint::Join join) override {}
-  void setStyle(SkPaint::Style style) override {}
-  void setStrokeWidth(SkScalar width) override {}
-  void setStrokeMiter(SkScalar limit) override {}
-  void setColor(SkColor color) override {}
+  void setStrokeCap(DlStrokeCap cap) override {}
+  void setStrokeJoin(DlStrokeJoin join) override {}
+  void setStyle(DlDrawStyle style) override {}
+  void setStrokeWidth(float width) override {}
+  void setStrokeMiter(float limit) override {}
+  void setColor(DlColor color) override {}
   void setBlendMode(DlBlendMode mode) override {}
   void setBlender(sk_sp<SkBlender> blender) override {}
   void setColorSource(const DlColorSource* source) override {}
@@ -98,7 +98,7 @@ class IgnoreDrawDispatchHelper : public virtual Dispatcher {
   void saveLayer(const SkRect* bounds,
                  const SaveLayerOptions options) override {}
   void restore() override {}
-  void drawColor(SkColor color, DlBlendMode mode) override {}
+  void drawColor(DlColor color, DlBlendMode mode) override {}
   void drawPaint() override {}
   void drawLine(const SkPoint& p0, const SkPoint& p1) override {}
   void drawRect(const SkRect& rect) override {}
@@ -140,7 +140,7 @@ class IgnoreDrawDispatchHelper : public virtual Dispatcher {
   void drawAtlas(const sk_sp<DlImage> atlas,
                  const SkRSXform xform[],
                  const SkRect tex[],
-                 const SkColor colors[],
+                 const DlColor colors[],
                  int count,
                  DlBlendMode mode,
                  const SkSamplingOptions& sampling,
@@ -154,7 +154,7 @@ class IgnoreDrawDispatchHelper : public virtual Dispatcher {
                     SkScalar x,
                     SkScalar y) override {}
   void drawShadow(const SkPath& path,
-                  const SkColor color,
+                  const DlColor color,
                   const SkScalar elevation,
                   bool transparent_occluder,
                   SkScalar dpr) override {}
@@ -174,12 +174,12 @@ class SkPaintDispatchHelper : public virtual Dispatcher {
 
   void setAntiAlias(bool aa) override;
   void setDither(bool dither) override;
-  void setStyle(SkPaint::Style style) override;
-  void setColor(SkColor color) override;
+  void setStyle(DlDrawStyle style) override;
+  void setColor(DlColor color) override;
   void setStrokeWidth(SkScalar width) override;
   void setStrokeMiter(SkScalar limit) override;
-  void setStrokeCap(SkPaint::Cap cap) override;
-  void setStrokeJoin(SkPaint::Join join) override;
+  void setStrokeCap(DlStrokeCap cap) override;
+  void setStrokeJoin(DlStrokeJoin join) override;
   void setColorSource(const DlColorSource* source) override;
   void setColorFilter(const DlColorFilter* filter) override;
   void setInvertColors(bool invert) override;
@@ -395,9 +395,9 @@ class DisplayListBoundsCalculator final
   // The flag should never be set if a cull_rect is provided.
   explicit DisplayListBoundsCalculator(const SkRect* cull_rect = nullptr);
 
-  void setStrokeCap(SkPaint::Cap cap) override;
-  void setStrokeJoin(SkPaint::Join join) override;
-  void setStyle(SkPaint::Style style) override;
+  void setStrokeCap(DlStrokeCap cap) override;
+  void setStrokeJoin(DlStrokeJoin join) override;
+  void setStyle(DlDrawStyle style) override;
   void setStrokeWidth(SkScalar width) override;
   void setStrokeMiter(SkScalar limit) override;
   void setBlendMode(DlBlendMode mode) override;
@@ -412,7 +412,7 @@ class DisplayListBoundsCalculator final
   void restore() override;
 
   void drawPaint() override;
-  void drawColor(SkColor color, DlBlendMode mode) override;
+  void drawColor(DlColor color, DlBlendMode mode) override;
   void drawLine(const SkPoint& p0, const SkPoint& p1) override;
   void drawRect(const SkRect& rect) override;
   void drawOval(const SkRect& bounds) override;
@@ -453,7 +453,7 @@ class DisplayListBoundsCalculator final
   void drawAtlas(const sk_sp<DlImage> atlas,
                  const SkRSXform xform[],
                  const SkRect tex[],
-                 const SkColor colors[],
+                 const DlColor colors[],
                  int count,
                  DlBlendMode mode,
                  const SkSamplingOptions& sampling,
@@ -467,7 +467,7 @@ class DisplayListBoundsCalculator final
                     SkScalar x,
                     SkScalar y) override;
   void drawShadow(const SkPath& path,
-                  const SkColor color,
+                  const DlColor color,
                   const SkScalar elevation,
                   bool transparent_occluder,
                   SkScalar dpr) override;
@@ -578,7 +578,7 @@ class DisplayListBoundsCalculator final
 
   SkScalar half_stroke_width_ = kMinStrokeWidth;
   SkScalar miter_limit_ = 4.0;
-  SkPaint::Style style_ = SkPaint::Style::kFill_Style;
+  DlDrawStyle style_ = DlDrawStyle::kFill;
   bool join_is_miter_ = true;
   bool cap_is_square_ = false;
   std::shared_ptr<DlImageFilter> image_filter_;

--- a/display_list/display_list_vertices.h
+++ b/display_list/display_list_vertices.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_DISPLAY_LIST_DISPLAY_LIST_VERTICES_H_
 #define FLUTTER_DISPLAY_LIST_DISPLAY_LIST_VERTICES_H_
 
+#include "flutter/display_list/display_list_color.h"
 #include "flutter/display_list/types.h"
 
 namespace flutter {
@@ -144,7 +145,16 @@ class DlVertices {
     ///
     /// fails if colors have already been supplied or if they were not
     /// promised by the flags.has_colors.
-    void store_colors(const SkColor colors[]);
+    void store_colors(const DlColor colors[]);
+
+    /// @brief Copies the indicated list of unsigned ints as vertex colors
+    ///        in the 32-bit RGBA format.
+    ///
+    /// fails if colors have already been supplied or if they were not
+    /// promised by the flags.has_colors.
+    void store_colors(const uint32_t colors[]) {
+      store_colors(reinterpret_cast<const DlColor*>(colors));
+    }
 
     /// @brief Copies the indicated list of 16-bit indices as vertex indices.
     ///
@@ -178,7 +188,7 @@ class DlVertices {
                                           int vertex_count,
                                           const SkPoint vertices[],
                                           const SkPoint texture_coordinates[],
-                                          const SkColor colors[],
+                                          const DlColor colors[],
                                           int index_count = 0,
                                           const uint16_t indices[] = nullptr);
 
@@ -209,8 +219,8 @@ class DlVertices {
 
   /// Returns a pointer to the vertex colors
   /// or null if none were provided.
-  const SkColor* colors() const {
-    return static_cast<const SkColor*>(pod(colors_offset_));
+  const DlColor* colors() const {
+    return static_cast<const DlColor*>(pod(colors_offset_));
   }
 
   /// Returns a pointer to the count of vertex indices
@@ -239,7 +249,7 @@ class DlVertices {
              int vertex_count,
              const SkPoint vertices[],
              const SkPoint texture_coordinates[],
-             const SkColor colors[],
+             const DlColor colors[],
              int index_count,
              const uint16_t indices[],
              const SkRect* bounds = nullptr);

--- a/display_list/display_list_vertices_unittests.cc
+++ b/display_list/display_list_vertices_unittests.cc
@@ -50,9 +50,9 @@ TEST(DisplayListVertices, MakeWithTexAndColorAndIndices) {
       SkPoint::Make(115, 120),
   };
   DlColor colors[3] = {
-      DlColors::kRed,
-      DlColors::kCyan,
-      DlColors::kGreen,
+      DlColor::kRed(),
+      DlColor::kCyan(),
+      DlColor::kGreen(),
   };
   uint16_t indices[6] = {
       2, 1, 0,  //
@@ -94,9 +94,9 @@ TEST(DisplayListVertices, MakeWithTexAndColor) {
       SkPoint::Make(115, 120),
   };
   DlColor colors[3] = {
-      DlColors::kRed,
-      DlColors::kCyan,
-      DlColors::kGreen,
+      DlColor::kRed(),
+      DlColor::kCyan(),
+      DlColor::kGreen(),
   };
 
   std::shared_ptr<const DlVertices> vertices = DlVertices::Make(
@@ -164,9 +164,9 @@ TEST(DisplayListVertices, MakeWithColorAndIndices) {
       SkPoint::Make(15, 20),
   };
   DlColor colors[3] = {
-      DlColors::kRed,
-      DlColors::kCyan,
-      DlColors::kGreen,
+      DlColor::kRed(),
+      DlColor::kCyan(),
+      DlColor::kGreen(),
   };
   uint16_t indices[6] = {
       2, 1, 0,  //
@@ -233,9 +233,9 @@ TEST(DisplayListVertices, MakeWithColor) {
       SkPoint::Make(15, 20),
   };
   DlColor colors[3] = {
-      DlColors::kRed,
-      DlColors::kCyan,
-      DlColors::kGreen,
+      DlColor::kRed(),
+      DlColor::kCyan(),
+      DlColor::kGreen(),
   };
 
   std::shared_ptr<const DlVertices> vertices = DlVertices::Make(
@@ -454,9 +454,9 @@ TEST(DisplayListVertices, BuildWithTexAndColorAndIndices) {
       SkPoint::Make(115, 120),
   };
   DlColor colors[3] = {
-      DlColors::kRed,
-      DlColors::kCyan,
-      DlColors::kGreen,
+      DlColor::kRed(),
+      DlColor::kCyan(),
+      DlColor::kGreen(),
   };
   uint16_t indices[6] = {
       2, 1, 0,  //
@@ -518,9 +518,9 @@ TEST(DisplayListVertices, BuildWithTexAndColor) {
       SkPoint::Make(115, 120),
   };
   DlColor colors[3] = {
-      DlColors::kRed,
-      DlColors::kCyan,
-      DlColors::kGreen,
+      DlColor::kRed(),
+      DlColor::kCyan(),
+      DlColor::kGreen(),
   };
 
   Builder builder(DlVertexMode::kTriangles, 3,  //
@@ -871,9 +871,9 @@ TEST(DisplayListVertices, TestEquals) {
       SkPoint::Make(115, 120),
   };
   DlColor colors[3] = {
-      DlColors::kRed,
-      DlColors::kCyan,
-      DlColors::kGreen,
+      DlColor::kRed(),
+      DlColor::kCyan(),
+      DlColor::kGreen(),
   };
   uint16_t indices[6] = {
       2, 1, 0,  //
@@ -913,16 +913,16 @@ TEST(DisplayListVertices, TestNotEquals) {
       SkPoint::Make(153, 162),
   };
   DlColor colors[4] = {
-      DlColors::kRed,
-      DlColors::kCyan,
-      DlColors::kGreen,
-      DlColors::kMagenta,
+      DlColor::kRed(),
+      DlColor::kCyan(),
+      DlColor::kGreen(),
+      DlColor::kMagenta(),
   };
   DlColor wrong_colors[4] = {
-      DlColors::kRed,
-      DlColors::kBlue,
-      DlColors::kGreen,
-      DlColors::kMagenta,
+      DlColor::kRed(),
+      DlColor::kBlue(),
+      DlColor::kGreen(),
+      DlColor::kMagenta(),
   };
   uint16_t indices[9] = {
       2, 1, 0,  //

--- a/display_list/display_list_vertices_unittests.cc
+++ b/display_list/display_list_vertices_unittests.cc
@@ -49,10 +49,10 @@ TEST(DisplayListVertices, MakeWithTexAndColorAndIndices) {
       SkPoint::Make(105, 106),
       SkPoint::Make(115, 120),
   };
-  SkColor colors[3] = {
-      SK_ColorRED,
-      SK_ColorCYAN,
-      SK_ColorGREEN,
+  DlColor colors[3] = {
+      DlColors::kRed,
+      DlColors::kCyan,
+      DlColors::kGreen,
   };
   uint16_t indices[6] = {
       2, 1, 0,  //
@@ -93,10 +93,10 @@ TEST(DisplayListVertices, MakeWithTexAndColor) {
       SkPoint::Make(105, 106),
       SkPoint::Make(115, 120),
   };
-  SkColor colors[3] = {
-      SK_ColorRED,
-      SK_ColorCYAN,
-      SK_ColorGREEN,
+  DlColor colors[3] = {
+      DlColors::kRed,
+      DlColors::kCyan,
+      DlColors::kGreen,
   };
 
   std::shared_ptr<const DlVertices> vertices = DlVertices::Make(
@@ -163,10 +163,10 @@ TEST(DisplayListVertices, MakeWithColorAndIndices) {
       SkPoint::Make(5, 6),
       SkPoint::Make(15, 20),
   };
-  SkColor colors[3] = {
-      SK_ColorRED,
-      SK_ColorCYAN,
-      SK_ColorGREEN,
+  DlColor colors[3] = {
+      DlColors::kRed,
+      DlColors::kCyan,
+      DlColors::kGreen,
   };
   uint16_t indices[6] = {
       2, 1, 0,  //
@@ -232,10 +232,10 @@ TEST(DisplayListVertices, MakeWithColor) {
       SkPoint::Make(5, 6),
       SkPoint::Make(15, 20),
   };
-  SkColor colors[3] = {
-      SK_ColorRED,
-      SK_ColorCYAN,
-      SK_ColorGREEN,
+  DlColor colors[3] = {
+      DlColors::kRed,
+      DlColors::kCyan,
+      DlColors::kGreen,
   };
 
   std::shared_ptr<const DlVertices> vertices = DlVertices::Make(
@@ -453,10 +453,10 @@ TEST(DisplayListVertices, BuildWithTexAndColorAndIndices) {
       SkPoint::Make(105, 106),
       SkPoint::Make(115, 120),
   };
-  SkColor colors[3] = {
-      SK_ColorRED,
-      SK_ColorCYAN,
-      SK_ColorGREEN,
+  DlColor colors[3] = {
+      DlColors::kRed,
+      DlColors::kCyan,
+      DlColors::kGreen,
   };
   uint16_t indices[6] = {
       2, 1, 0,  //
@@ -517,10 +517,10 @@ TEST(DisplayListVertices, BuildWithTexAndColor) {
       SkPoint::Make(105, 106),
       SkPoint::Make(115, 120),
   };
-  SkColor colors[3] = {
-      SK_ColorRED,
-      SK_ColorCYAN,
-      SK_ColorGREEN,
+  DlColor colors[3] = {
+      DlColors::kRed,
+      DlColors::kCyan,
+      DlColors::kGreen,
   };
 
   Builder builder(DlVertexMode::kTriangles, 3,  //
@@ -870,10 +870,10 @@ TEST(DisplayListVertices, TestEquals) {
       SkPoint::Make(105, 106),
       SkPoint::Make(115, 120),
   };
-  SkColor colors[3] = {
-      SK_ColorRED,
-      SK_ColorCYAN,
-      SK_ColorGREEN,
+  DlColor colors[3] = {
+      DlColors::kRed,
+      DlColors::kCyan,
+      DlColors::kGreen,
   };
   uint16_t indices[6] = {
       2, 1, 0,  //
@@ -912,17 +912,17 @@ TEST(DisplayListVertices, TestNotEquals) {
       SkPoint::Make(115, 121),
       SkPoint::Make(153, 162),
   };
-  SkColor colors[4] = {
-      SK_ColorRED,
-      SK_ColorCYAN,
-      SK_ColorGREEN,
-      SK_ColorMAGENTA,
+  DlColor colors[4] = {
+      DlColors::kRed,
+      DlColors::kCyan,
+      DlColors::kGreen,
+      DlColors::kMagenta,
   };
-  SkColor wrong_colors[4] = {
-      SK_ColorRED,
-      SK_ColorBLUE,
-      SK_ColorGREEN,
-      SK_ColorMAGENTA,
+  DlColor wrong_colors[4] = {
+      DlColors::kRed,
+      DlColors::kBlue,
+      DlColors::kGreen,
+      DlColors::kMagenta,
   };
   uint16_t indices[9] = {
       2, 1, 0,  //

--- a/flow/layers/opacity_layer_unittests.cc
+++ b/flow/layers/opacity_layer_unittests.cc
@@ -304,7 +304,7 @@ TEST_F(OpacityLayerTest, HalfTransparent) {
   expected_layer_bounds.makeOffset(-layer_offset.fX, -layer_offset.fY)
       .roundOut(&opacity_bounds);
   DlPaint save_paint = DlPaint().setAlpha(alpha_half);
-  DlPaint child_dl_paint = DlPaint().setColor(DlColors::kGreen);
+  DlPaint child_dl_paint = DlPaint().setColor(DlColor::kGreen());
 
   auto expected_builder = DisplayListBuilder();
   expected_builder.save();

--- a/flow/layers/opacity_layer_unittests.cc
+++ b/flow/layers/opacity_layer_unittests.cc
@@ -303,8 +303,8 @@ TEST_F(OpacityLayerTest, HalfTransparent) {
   SkRect opacity_bounds;
   expected_layer_bounds.makeOffset(-layer_offset.fX, -layer_offset.fY)
       .roundOut(&opacity_bounds);
-  DlPaint save_paint = DlPaint().setColor(DlColor(alpha_half << 24));
-  DlPaint child_dl_paint = DlPaint().setColor(DlColor(SK_ColorGREEN));
+  DlPaint save_paint = DlPaint().setAlpha(alpha_half);
+  DlPaint child_dl_paint = DlPaint().setColor(DlColors::kGreen);
 
   auto expected_builder = DisplayListBuilder();
   expected_builder.save();

--- a/impeller/display_list/display_list_dispatcher.cc
+++ b/impeller/display_list/display_list_dispatcher.cc
@@ -33,13 +33,13 @@ void DisplayListDispatcher::setAntiAlias(bool aa) {
 // |flutter::Dispatcher|
 void DisplayListDispatcher::setDither(bool dither) {}
 
-static Paint::Style ToStyle(SkPaint::Style style) {
+static Paint::Style ToStyle(flutter::DlDrawStyle style) {
   switch (style) {
-    case SkPaint::kFill_Style:
+    case flutter::DlDrawStyle::kFill:
       return Paint::Style::kFill;
-    case SkPaint::kStroke_Style:
+    case flutter::DlDrawStyle::kStroke:
       return Paint::Style::kStroke;
-    case SkPaint::kStrokeAndFill_Style:
+    case flutter::DlDrawStyle::kStrokeAndFill:
       UNIMPLEMENTED;
       break;
   }
@@ -47,17 +47,17 @@ static Paint::Style ToStyle(SkPaint::Style style) {
 }
 
 // |flutter::Dispatcher|
-void DisplayListDispatcher::setStyle(SkPaint::Style style) {
+void DisplayListDispatcher::setStyle(flutter::DlDrawStyle style) {
   paint_.style = ToStyle(style);
 }
 
 // |flutter::Dispatcher|
-void DisplayListDispatcher::setColor(SkColor color) {
+void DisplayListDispatcher::setColor(flutter::DlColor color) {
   paint_.color = {
-      SkColorGetR(color) / 255.0f,  // red
-      SkColorGetG(color) / 255.0f,  // green
-      SkColorGetB(color) / 255.0f,  // blue
-      SkColorGetA(color) / 255.0f   // alpha
+      color.getRedF(),
+      color.getGreenF(),
+      color.getBlueF(),
+      color.getAlphaF(),
   };
 }
 
@@ -72,30 +72,30 @@ void DisplayListDispatcher::setStrokeMiter(SkScalar limit) {
 }
 
 // |flutter::Dispatcher|
-void DisplayListDispatcher::setStrokeCap(SkPaint::Cap cap) {
+void DisplayListDispatcher::setStrokeCap(flutter::DlStrokeCap cap) {
   switch (cap) {
-    case SkPaint::kButt_Cap:
+    case flutter::DlStrokeCap::kButt:
       paint_.stroke_cap = SolidStrokeContents::Cap::kButt;
       break;
-    case SkPaint::kRound_Cap:
+    case flutter::DlStrokeCap::kRound:
       paint_.stroke_cap = SolidStrokeContents::Cap::kRound;
       break;
-    case SkPaint::kSquare_Cap:
+    case flutter::DlStrokeCap::kSquare:
       paint_.stroke_cap = SolidStrokeContents::Cap::kSquare;
       break;
   }
 }
 
 // |flutter::Dispatcher|
-void DisplayListDispatcher::setStrokeJoin(SkPaint::Join join) {
+void DisplayListDispatcher::setStrokeJoin(flutter::DlStrokeJoin join) {
   switch (join) {
-    case SkPaint::kMiter_Join:
+    case flutter::DlStrokeJoin::kMiter:
       paint_.stroke_join = SolidStrokeContents::Join::kMiter;
       break;
-    case SkPaint::kRound_Join:
+    case flutter::DlStrokeJoin::kRound:
       paint_.stroke_join = SolidStrokeContents::Join::kRound;
       break;
-    case SkPaint::kBevel_Join:
+    case flutter::DlStrokeJoin::kBevel:
       paint_.stroke_join = SolidStrokeContents::Join::kBevel;
       break;
   }
@@ -501,7 +501,7 @@ void DisplayListDispatcher::clipPath(const SkPath& path,
 }
 
 // |flutter::Dispatcher|
-void DisplayListDispatcher::drawColor(SkColor color,
+void DisplayListDispatcher::drawColor(flutter::DlColor color,
                                       flutter::DlBlendMode dl_mode) {
   Paint paint;
   paint.color = ToColor(color);
@@ -682,7 +682,7 @@ void DisplayListDispatcher::drawImageLattice(
 void DisplayListDispatcher::drawAtlas(const sk_sp<flutter::DlImage> atlas,
                                       const SkRSXform xform[],
                                       const SkRect tex[],
-                                      const SkColor colors[],
+                                      const flutter::DlColor colors[],
                                       int count,
                                       flutter::DlBlendMode mode,
                                       const SkSamplingOptions& sampling,
@@ -724,7 +724,7 @@ void DisplayListDispatcher::drawTextBlob(const sk_sp<SkTextBlob> blob,
 
 // |flutter::Dispatcher|
 void DisplayListDispatcher::drawShadow(const SkPath& path,
-                                       const SkColor color,
+                                       const flutter::DlColor color,
                                        const SkScalar elevation,
                                        bool transparent_occluder,
                                        SkScalar dpr) {

--- a/impeller/display_list/display_list_dispatcher.h
+++ b/impeller/display_list/display_list_dispatcher.h
@@ -28,10 +28,10 @@ class DisplayListDispatcher final : public flutter::Dispatcher {
   void setDither(bool dither) override;
 
   // |flutter::Dispatcher|
-  void setStyle(SkPaint::Style style) override;
+  void setStyle(flutter::DlDrawStyle style) override;
 
   // |flutter::Dispatcher|
-  void setColor(SkColor color) override;
+  void setColor(flutter::DlColor color) override;
 
   // |flutter::Dispatcher|
   void setStrokeWidth(SkScalar width) override;
@@ -40,10 +40,10 @@ class DisplayListDispatcher final : public flutter::Dispatcher {
   void setStrokeMiter(SkScalar limit) override;
 
   // |flutter::Dispatcher|
-  void setStrokeCap(SkPaint::Cap cap) override;
+  void setStrokeCap(flutter::DlStrokeCap cap) override;
 
   // |flutter::Dispatcher|
-  void setStrokeJoin(SkPaint::Join join) override;
+  void setStrokeJoin(flutter::DlStrokeJoin join) override;
 
   // |flutter::Dispatcher|
   void setColorSource(const flutter::DlColorSource* source) override;
@@ -130,7 +130,7 @@ class DisplayListDispatcher final : public flutter::Dispatcher {
   void clipPath(const SkPath& path, SkClipOp clip_op, bool is_aa) override;
 
   // |flutter::Dispatcher|
-  void drawColor(SkColor color, flutter::DlBlendMode mode) override;
+  void drawColor(flutter::DlColor color, flutter::DlBlendMode mode) override;
 
   // |flutter::Dispatcher|
   void drawPaint() override;
@@ -207,7 +207,7 @@ class DisplayListDispatcher final : public flutter::Dispatcher {
   void drawAtlas(const sk_sp<flutter::DlImage> atlas,
                  const SkRSXform xform[],
                  const SkRect tex[],
-                 const SkColor colors[],
+                 const flutter::DlColor colors[],
                  int count,
                  flutter::DlBlendMode mode,
                  const SkSamplingOptions& sampling,
@@ -229,7 +229,7 @@ class DisplayListDispatcher final : public flutter::Dispatcher {
 
   // |flutter::Dispatcher|
   void drawShadow(const SkPath& path,
-                  const SkColor color,
+                  const flutter::DlColor color,
                   const SkScalar elevation,
                   bool transparent_occluder,
                   SkScalar dpr) override;

--- a/impeller/display_list/display_list_unittests.cc
+++ b/impeller/display_list/display_list_unittests.cc
@@ -48,7 +48,7 @@ TEST_P(DisplayListTest, CanDrawImage) {
 TEST_P(DisplayListTest, CanDrawCapsAndJoins) {
   flutter::DisplayListBuilder builder;
 
-  builder.setStyle(SkPaint::Style::kStroke_Style);
+  builder.setStyle(flutter::DlDrawStyle::kStroke);
   builder.setStrokeWidth(30);
   builder.setColor(SK_ColorRED);
 
@@ -57,8 +57,8 @@ TEST_P(DisplayListTest, CanDrawCapsAndJoins) {
 
   builder.translate(100, 100);
   {
-    builder.setStrokeCap(SkPaint::Cap::kButt_Cap);
-    builder.setStrokeJoin(SkPaint::Join::kMiter_Join);
+    builder.setStrokeCap(flutter::DlStrokeCap::kButt);
+    builder.setStrokeJoin(flutter::DlStrokeJoin::kMiter);
     builder.setStrokeMiter(4);
     builder.drawPath(path);
   }
@@ -75,15 +75,15 @@ TEST_P(DisplayListTest, CanDrawCapsAndJoins) {
 
   builder.translate(150, 0);
   {
-    builder.setStrokeCap(SkPaint::Cap::kSquare_Cap);
-    builder.setStrokeJoin(SkPaint::Join::kBevel_Join);
+    builder.setStrokeCap(flutter::DlStrokeCap::kSquare);
+    builder.setStrokeJoin(flutter::DlStrokeJoin::kBevel);
     builder.drawPath(path);
   }
 
   builder.translate(150, 0);
   {
-    builder.setStrokeCap(SkPaint::Cap::kRound_Cap);
-    builder.setStrokeJoin(SkPaint::Join::kRound_Join);
+    builder.setStrokeCap(flutter::DlStrokeCap::kRound);
+    builder.setStrokeJoin(flutter::DlStrokeJoin::kRound);
     builder.drawPath(path);
   }
 
@@ -113,9 +113,9 @@ TEST_P(DisplayListTest, CanDrawArc) {
         Point(200, 200), Point(400, 400), 20, Color::White(), Color::White());
 
     flutter::DisplayListBuilder builder;
-    builder.setStyle(SkPaint::Style::kStroke_Style);
-    builder.setStrokeCap(SkPaint::Cap::kRound_Cap);
-    builder.setStrokeJoin(SkPaint::Join::kMiter_Join);
+    builder.setStyle(flutter::DlDrawStyle::kStroke);
+    builder.setStrokeCap(flutter::DlStrokeCap::kRound);
+    builder.setStrokeJoin(flutter::DlStrokeJoin::kMiter);
     builder.setStrokeMiter(10);
     auto rect = SkRect::MakeLTRB(p1.x, p1.y, p2.x, p2.y);
     builder.setColor(SK_ColorGREEN);
@@ -133,7 +133,7 @@ TEST_P(DisplayListTest, CanDrawArc) {
 TEST_P(DisplayListTest, StrokedPathsDrawCorrectly) {
   flutter::DisplayListBuilder builder;
   builder.setColor(SK_ColorRED);
-  builder.setStyle(SkPaint::Style::kStroke_Style);
+  builder.setStyle(flutter::DlDrawStyle::kStroke);
   builder.setStrokeWidth(10);
 
   // Rectangle
@@ -162,7 +162,7 @@ TEST_P(DisplayListTest, StrokedPathsDrawCorrectly) {
 
   // Contour with duplicate end points
   {
-    builder.setStrokeCap(SkPaint::Cap::kRound_Cap);
+    builder.setStrokeCap(flutter::DlStrokeCap::kRound);
     builder.translate(150, 0);
     SkPath path;
     path.moveTo(0, 0);

--- a/lib/ui/painting/canvas.cc
+++ b/lib/ui/painting/canvas.cc
@@ -283,7 +283,7 @@ void Canvas::drawPaint(const Paint& paint, const PaintData& paint_data) {
   FML_DCHECK(paint.isNotNull());
   if (display_list_recorder_) {
     paint.sync_to(builder(), kDrawPaintFlags);
-    std::shared_ptr<DlImageFilter> filter = builder()->getImageFilter();
+    std::shared_ptr<const DlImageFilter> filter = builder()->getImageFilter();
     if (filter && !filter->asColorFilter()) {
       // drawPaint does an implicit saveLayer if an SkImageFilter is
       // present that cannot be replaced by an SkColorFilter.
@@ -646,7 +646,7 @@ void Canvas::drawAtlas(const Paint& paint,
     builder()->drawAtlas(
         dl_image, reinterpret_cast<const SkRSXform*>(transforms.data()),
         reinterpret_cast<const SkRect*>(rects.data()),
-        reinterpret_cast<const SkColor*>(colors.data()),
+        reinterpret_cast<const DlColor*>(colors.data()),
         rects.num_elements() / 4,  // SkRect have four floats.
         blend_mode, sampling, reinterpret_cast<const SkRect*>(cull_rect.data()),
         with_attributes);

--- a/lib/ui/painting/color_filter.cc
+++ b/lib/ui/painting/color_filter.cc
@@ -41,7 +41,7 @@ fml::RefPtr<ColorFilter> ColorFilter::Create() {
 
 void ColorFilter::initMode(int color, int blend_mode) {
   filter_ = std::make_shared<DlBlendColorFilter>(
-      static_cast<SkColor>(color), static_cast<SkBlendMode>(blend_mode));
+      static_cast<DlColor>(color), static_cast<DlBlendMode>(blend_mode));
 }
 
 void ColorFilter::initMatrix(const tonic::Float32List& color_matrix) {

--- a/lib/ui/painting/gradient.cc
+++ b/lib/ui/painting/gradient.cc
@@ -60,8 +60,7 @@ void CanvasGradient::initLinear(const tonic::Float32List& end_points,
 
   SkPoint p0 = SkPoint::Make(end_points[0], end_points[1]);
   SkPoint p1 = SkPoint::Make(end_points[2], end_points[3]);
-  const uint32_t* colors_array =
-      reinterpret_cast<const uint32_t*>(colors.data());
+  const DlColor* colors_array = reinterpret_cast<const DlColor*>(colors.data());
 
   dl_shader_ = DlColorSource::MakeLinear(
       p0, p1, colors.num_elements(), colors_array, color_stops.data(),
@@ -87,8 +86,7 @@ void CanvasGradient::initRadial(double center_x,
     sk_matrix = ToSkMatrix(matrix4);
   }
 
-  const uint32_t* colors_array =
-      reinterpret_cast<const uint32_t*>(colors.data());
+  const DlColor* colors_array = reinterpret_cast<const DlColor*>(colors.data());
 
   dl_shader_ = DlColorSource::MakeRadial(
       SkPoint::Make(center_x, center_y), radius, colors.num_elements(),
@@ -116,8 +114,7 @@ void CanvasGradient::initSweep(double center_x,
     sk_matrix = ToSkMatrix(matrix4);
   }
 
-  const uint32_t* colors_array =
-      reinterpret_cast<const uint32_t*>(colors.data());
+  const DlColor* colors_array = reinterpret_cast<const DlColor*>(colors.data());
 
   dl_shader_ = DlColorSource::MakeSweep(
       SkPoint::Make(center_x, center_y), start_angle * 180.0 / M_PI,
@@ -147,8 +144,7 @@ void CanvasGradient::initTwoPointConical(double start_x,
     sk_matrix = ToSkMatrix(matrix4);
   }
 
-  const uint32_t* colors_array =
-      reinterpret_cast<const uint32_t*>(colors.data());
+  const DlColor* colors_array = reinterpret_cast<const DlColor*>(colors.data());
 
   dl_shader_ = DlColorSource::MakeConical(
       SkPoint::Make(start_x, start_y), start_radius,            //

--- a/lib/ui/painting/paint.cc
+++ b/lib/ui/painting/paint.cc
@@ -267,7 +267,7 @@ bool Paint::sync_to(DisplayListBuilder* builder,
 
   if (flags.applies_style()) {
     uint32_t style = uint_data[kStyleIndex];
-    builder->setStyle(static_cast<SkPaint::Style>(style));
+    builder->setStyle(static_cast<DlDrawStyle>(style));
   }
 
   if (flags.is_stroked(builder->getStyle())) {
@@ -278,10 +278,10 @@ bool Paint::sync_to(DisplayListBuilder* builder,
     builder->setStrokeMiter(stroke_miter_limit + kStrokeMiterLimitDefault);
 
     uint32_t stroke_cap = uint_data[kStrokeCapIndex];
-    builder->setStrokeCap(static_cast<SkPaint::Cap>(stroke_cap));
+    builder->setStrokeCap(static_cast<DlStrokeCap>(stroke_cap));
 
     uint32_t stroke_join = uint_data[kStrokeJoinIndex];
-    builder->setStrokeJoin(static_cast<SkPaint::Join>(stroke_join));
+    builder->setStrokeJoin(static_cast<DlStrokeJoin>(stroke_join));
   }
 
   if (flags.applies_color_filter()) {

--- a/testing/display_list_testing.cc
+++ b/testing/display_list_testing.cc
@@ -169,31 +169,31 @@ static std::ostream& operator<<(std::ostream& os, const SkClipOp& op) {
   }
 }
 
-static std::ostream& operator<<(std::ostream& os, const SkPaint::Cap& cap) {
+static std::ostream& operator<<(std::ostream& os, const DlStrokeCap& cap) {
   switch (cap) {
-    case SkPaint::kButt_Cap:   return os << "Cap::kButt";
-    case SkPaint::kRound_Cap:  return os << "Cap::kRound";
-    case SkPaint::kSquare_Cap: return os << "Cap::kSquare";
+    case DlStrokeCap::kButt:   return os << "Cap::kButt";
+    case DlStrokeCap::kRound:  return os << "Cap::kRound";
+    case DlStrokeCap::kSquare: return os << "Cap::kSquare";
 
     default: return os << "Cap::????";
   }
 }
 
-static std::ostream& operator<<(std::ostream& os, const SkPaint::Join& join) {
+static std::ostream& operator<<(std::ostream& os, const DlStrokeJoin& join) {
   switch (join) {
-    case SkPaint::kMiter_Join: return os << "Join::kMiter";
-    case SkPaint::kRound_Join: return os << "Join::kRound";
-    case SkPaint::kBevel_Join: return os << "Join::kBevel";
+    case DlStrokeJoin::kMiter: return os << "Join::kMiter";
+    case DlStrokeJoin::kRound: return os << "Join::kRound";
+    case DlStrokeJoin::kBevel: return os << "Join::kBevel";
 
     default: return os << "Join::????";
   }
 }
 
-static std::ostream& operator<<(std::ostream& os, const SkPaint::Style& style) {
+static std::ostream& operator<<(std::ostream& os, const DlDrawStyle& style) {
   switch (style) {
-    case SkPaint::kFill_Style:          return os << "Style::kFill";
-    case SkPaint::kStroke_Style:        return os << "Style::kStroke";
-    case SkPaint::kStrokeAndFill_Style: return os << "Style::kStrokeAnFill";
+    case DlDrawStyle::kFill:          return os << "Style::kFill";
+    case DlDrawStyle::kStroke:        return os << "Style::kStroke";
+    case DlDrawStyle::kStrokeAndFill: return os << "Style::kStrokeAnFill";
 
     default: return os << "Style::????";
   }
@@ -230,14 +230,8 @@ static std::ostream& operator<<(std::ostream& os, const SkFilterMode& mode) {
   }
 }
 
-class SK_Color {
- public:
-  explicit SK_Color(SkColor color) : color(color) {}
-  SkColor color;
-};
-
-static std::ostream& operator<<(std::ostream& os, const SK_Color& color) {
-  return os << "SkColor(" << std::hex << color.color << std::dec << ")";
+static std::ostream& operator<<(std::ostream& os, const DlColor& color) {
+  return os << "DlColor(" << std::hex << color.argb << std::dec << ")";
 }
 
 static std::ostream& operator<<(std::ostream& os,
@@ -308,8 +302,8 @@ std::ostream& DisplayListStreamDispatcher::startl() {
 
 template <class T>
 std::ostream& DisplayListStreamDispatcher::out_array(std::string name,
-                                                      int count,
-                                                      const T array[]) {
+                                                     int count,
+                                                     const T array[]) {
   if (array == nullptr || count < 0) {
     return os_ << "no " << name;
   }
@@ -325,35 +319,17 @@ std::ostream& DisplayListStreamDispatcher::out_array(std::string name,
   return os_;
 }
 
-std::ostream& DisplayListStreamDispatcher::out_colors(std::string name,
-                                                      int count,
-                                                      const SkColor colors[]) {
-  if (colors == nullptr || count < 0) {
-    return os_ << "no " << name;
-  }
-  os_ << name << "[" << count << "] = [" << std::endl;
-  indent();
-  indent();
-  for (int i = 0; i < count; i++) {
-    startl() << SK_Color(colors[i]) << "," << std::endl;
-  }
-  outdent();
-  startl() << "]";
-  outdent();
-  return os_;
-}
-
 void DisplayListStreamDispatcher::setAntiAlias(bool aa) {
   startl() << "setAntiAlias(" << aa << ");" << std::endl;
 }
 void DisplayListStreamDispatcher::setDither(bool dither) {
   startl() << "setDither(" << dither << ");" << std::endl;
 }
-void DisplayListStreamDispatcher::setStyle(SkPaint::Style style) {
+void DisplayListStreamDispatcher::setStyle(DlDrawStyle style) {
   startl() << "setStyle(" << style << ");" << std::endl;
 }
-void DisplayListStreamDispatcher::setColor(SkColor color) {
-  startl() << "setColor(" << SK_Color(color) << ");" << std::endl;
+void DisplayListStreamDispatcher::setColor(DlColor color) {
+  startl() << "setColor(" << color << ");" << std::endl;
 }
 void DisplayListStreamDispatcher::setStrokeWidth(SkScalar width) {
   startl() << "setStrokeWidth(" << width << ");" << std::endl;
@@ -361,10 +337,10 @@ void DisplayListStreamDispatcher::setStrokeWidth(SkScalar width) {
 void DisplayListStreamDispatcher::setStrokeMiter(SkScalar limit) {
   startl() << "setStrokeMiter(" << limit << ");" << std::endl;
 }
-void DisplayListStreamDispatcher::setStrokeCap(SkPaint::Cap cap) {
+void DisplayListStreamDispatcher::setStrokeCap(DlStrokeCap cap) {
   startl() << "setStrokeCap(" << cap << ");" << std::endl;
 }
-void DisplayListStreamDispatcher::setStrokeJoin(SkPaint::Join join) {
+void DisplayListStreamDispatcher::setStrokeJoin(DlStrokeJoin join) {
   startl() << "setStrokeJoin(" << join << ");" << std::endl;
 }
 void DisplayListStreamDispatcher::setColorSource(const DlColorSource* source) {
@@ -397,7 +373,7 @@ void DisplayListStreamDispatcher::setColorSource(const DlColorSource* source) {
       os_ << "DlLinearGradientSource("
                                  << "start: " << linear_src->start_point()
                                  << ", end: " << linear_src->end_point() << ", ";
-                                 out_colors("colors", linear_src->stop_count(), linear_src->colors()) << ", ";
+                                 out_array("colors", linear_src->stop_count(), linear_src->colors()) << ", ";
                                  out_array("stops", linear_src->stop_count(), linear_src->stops()) << ", "
                                  << linear_src->tile_mode() << ", " << linear_src->matrix_ptr() << ")";
       break;
@@ -408,7 +384,7 @@ void DisplayListStreamDispatcher::setColorSource(const DlColorSource* source) {
       os_ << "DlRadialGradientSource("
                                  << "center: " << radial_src->center()
                                  << ", radius: " << radial_src->radius() << ", ";
-                                 out_colors("colors", radial_src->stop_count(), radial_src->colors()) << ", ";
+                                 out_array("colors", radial_src->stop_count(), radial_src->colors()) << ", ";
                                  out_array("stops", radial_src->stop_count(), radial_src->stops()) << ", "
                                  << radial_src->tile_mode() << ", " << radial_src->matrix_ptr() << ")";
       break;
@@ -421,7 +397,7 @@ void DisplayListStreamDispatcher::setColorSource(const DlColorSource* source) {
                                  << ", start radius: " << conical_src->start_radius()
                                  << ", end center: " << conical_src->end_center()
                                  << ", end radius: " << conical_src->end_radius() << ", ";
-                                 out_colors("colors", conical_src->stop_count(), conical_src->colors()) << ", ";
+                                 out_array("colors", conical_src->stop_count(), conical_src->colors()) << ", ";
                                  out_array("stops", conical_src->stop_count(), conical_src->stops()) << ", "
                                  << conical_src->tile_mode() << ", " << conical_src->matrix_ptr() << ")";
       break;
@@ -433,7 +409,7 @@ void DisplayListStreamDispatcher::setColorSource(const DlColorSource* source) {
                                  << "center: " << sweep_src->center()
                                  << ", start: " << sweep_src->start() << ", "
                                  << ", end: " << sweep_src->end() << ", ";
-                                 out_colors("colors", sweep_src->stop_count(), sweep_src->colors()) << ", ";
+                                 out_array("colors", sweep_src->stop_count(), sweep_src->colors()) << ", ";
                                  out_array("stops", sweep_src->stop_count(), sweep_src->stops()) << ", "
                                  << sweep_src->tile_mode() << ", " << sweep_src->matrix_ptr() << ")";
       break;
@@ -449,7 +425,7 @@ void DisplayListStreamDispatcher::out(const DlColorFilter* filter) {
     case DlColorFilterType::kBlend: {
       const DlBlendColorFilter* blend = filter->asBlend();
       FML_DCHECK(blend);
-      os_ << "DlBlendColorFilter(" << SK_Color(blend->color()) << ", "
+      os_ << "DlBlendColorFilter(" << blend->color() << ", "
                                    << static_cast<int>(blend->mode()) << ")";
       break;
     }
@@ -680,9 +656,9 @@ void DisplayListStreamDispatcher::clipPath(const SkPath& path, SkClipOp clip_op,
            << ");" << std::endl;
 }
 
-void DisplayListStreamDispatcher::drawColor(SkColor color, DlBlendMode mode) {
+void DisplayListStreamDispatcher::drawColor(DlColor color, DlBlendMode mode) {
   startl() << "drawColor("
-           << SK_Color(color) << ", "
+           << color << ", "
            << mode
            << ");" << std::endl;
 }
@@ -793,7 +769,7 @@ void DisplayListStreamDispatcher::drawImageLattice(const sk_sp<DlImage> image,
 void DisplayListStreamDispatcher::drawAtlas(const sk_sp<DlImage> atlas,
                                             const SkRSXform xform[],
                                             const SkRect tex[],
-                                            const SkColor colors[],
+                                            const DlColor colors[],
                                             int count,
                                             DlBlendMode mode,
                                             const SkSamplingOptions& sampling,
@@ -802,7 +778,7 @@ void DisplayListStreamDispatcher::drawAtlas(const sk_sp<DlImage> atlas,
   startl() << "drawAtlas(" << atlas.get() << ", ";
                    out_array("xforms", count, xform) << ", ";
                    out_array("tex_coords", count, tex) << ", ";
-                   out_colors("colors", count, colors) << ", "
+                   out_array("colors", count, colors) << ", "
                    << mode << ", " << sampling << ", cull: " << cull_rect << ", "
                    << "with attributes: " << render_with_attributes
            << ");" << std::endl;
@@ -828,13 +804,13 @@ void DisplayListStreamDispatcher::drawTextBlob(const sk_sp<SkTextBlob> blob,
            << x << ", " << y << ");" << std::endl;
 }
 void DisplayListStreamDispatcher::drawShadow(const SkPath& path,
-                                             const SkColor color,
+                                             const DlColor color,
                                              const SkScalar elevation,
                                              bool transparent_occluder,
                                              SkScalar dpr) {
   startl() << "drawShadow("
            << path << ", "
-           << SK_Color(color) << ", "
+           << color << ", "
            << elevation << ", "
            << transparent_occluder << ", "
            << dpr

--- a/testing/display_list_testing.h
+++ b/testing/display_list_testing.h
@@ -42,12 +42,12 @@ class DisplayListStreamDispatcher final : public Dispatcher {
 
   void setAntiAlias(bool aa) override;
   void setDither(bool dither) override;
-  void setStyle(SkPaint::Style style) override;
-  void setColor(SkColor color) override;
+  void setStyle(DlDrawStyle style) override;
+  void setColor(DlColor color) override;
   void setStrokeWidth(SkScalar width) override;
   void setStrokeMiter(SkScalar limit) override;
-  void setStrokeCap(SkPaint::Cap cap) override;
-  void setStrokeJoin(SkPaint::Join join) override;
+  void setStrokeCap(DlStrokeCap cap) override;
+  void setStrokeJoin(DlStrokeJoin join) override;
   void setColorSource(const DlColorSource* source) override;
   void setColorFilter(const DlColorFilter* filter) override;
   void setInvertColors(bool invert) override;
@@ -80,7 +80,7 @@ class DisplayListStreamDispatcher final : public Dispatcher {
   void clipRRect(const SkRRect& rrect, SkClipOp clip_op, bool is_aa) override;
   void clipPath(const SkPath& path, SkClipOp clip_op, bool is_aa) override;
 
-  void drawColor(SkColor color, DlBlendMode mode) override;
+  void drawColor(DlColor color, DlBlendMode mode) override;
   void drawPaint() override;
   void drawLine(const SkPoint& p0, const SkPoint& p1) override;
   void drawRect(const SkRect& rect) override;
@@ -122,7 +122,7 @@ class DisplayListStreamDispatcher final : public Dispatcher {
   void drawAtlas(const sk_sp<DlImage> atlas,
                  const SkRSXform xform[],
                  const SkRect tex[],
-                 const SkColor colors[],
+                 const DlColor colors[],
                  int count,
                  DlBlendMode mode,
                  const SkSamplingOptions& sampling,
@@ -136,7 +136,7 @@ class DisplayListStreamDispatcher final : public Dispatcher {
                     SkScalar x,
                     SkScalar y) override;
   void drawShadow(const SkPath& path,
-                  const SkColor color,
+                  const DlColor color,
                   const SkScalar elevation,
                   bool transparent_occluder,
                   SkScalar dpr) override;
@@ -151,9 +151,6 @@ class DisplayListStreamDispatcher final : public Dispatcher {
 
   template <class T>
   std::ostream& out_array(std::string name, int count, const T array[]);
-
-  // colors must be handled separately otherwise we just get a list of ints
-  std::ostream& out_colors(std::string name, int count, const SkColor colors[]);
 
   std::ostream& startl();
 


### PR DESCRIPTION
As we've been creating DisplayList versions of the Skia objects we've used in our rendering buffers, we haven't always been back-filling their uses into the existing DisplayList source base.

This PR replaces a number of the Sk* objects in the display_list directory (and Impeller) with the new Dl* versions.

Associated Impeller changes: https://github.com/flutter/impeller/pull/157