### PR TITLE
Remove ~SurfaceFrame

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -197,6 +197,7 @@ FILE: ../../../flutter/flow/surface.cc
 FILE: ../../../flutter/flow/surface.h
 FILE: ../../../flutter/flow/surface_frame.cc
 FILE: ../../../flutter/flow/surface_frame.h
+FILE: ../../../flutter/flow/surface_frame_unittests.cc
 FILE: ../../../flutter/flow/texture_unittests.cc
 FILE: ../../../flutter/fml/ascii_trie.cc
 FILE: ../../../flutter/fml/ascii_trie.h

--- a/flow/BUILD.gn
+++ b/flow/BUILD.gn
@@ -163,6 +163,7 @@ if (enable_unittests) {
       "raster_cache_unittests.cc",
       "rtree_unittests.cc",
       "skia_gpu_object_unittests.cc",
+      "surface_frame_unittests.cc",
       "testing/auto_save_layer_unittests.cc",
       "testing/mock_layer_unittests.cc",
       "testing/mock_texture_unittests.cc",

--- a/flow/surface_frame.cc
+++ b/flow/surface_frame.cc
@@ -33,13 +33,6 @@ SurfaceFrame::SurfaceFrame(sk_sp<SkSurface> surface,
   }
 }
 
-SurfaceFrame::~SurfaceFrame() {
-  if (submit_callback_ && !submitted_) {
-    // Dropping without a Submit.
-    submit_callback_(*this, nullptr);
-  }
-}
-
 bool SurfaceFrame::Submit() {
   if (submitted_) {
     return false;

--- a/flow/surface_frame.h
+++ b/flow/surface_frame.h
@@ -59,8 +59,6 @@ class SurfaceFrame {
                std::unique_ptr<GLContextResult> context_result = nullptr,
                bool display_list_fallback = false);
 
-  ~SurfaceFrame();
-
   struct SubmitInfo {
     // The frame damage for frame n is the difference between frame n and
     // frame (n-1), and represents the area that a compositor must recompose.

--- a/flow/surface_frame_unittests.cc
+++ b/flow/surface_frame_unittests.cc
@@ -1,0 +1,23 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#define FML_USED_ON_EMBEDDER
+
+#include "flutter/flow/surface_frame.h"
+#include "flutter/testing/testing.h"
+
+namespace flutter {
+
+TEST(FlowTest, SurfaceFrameDoesNotSubmitInDtor) {
+  SurfaceFrame::FramebufferInfo framebuffer_info;
+  auto surface_frame = std::make_unique<SurfaceFrame>(
+      /*surface=*/nullptr, framebuffer_info,
+      /*submit_callback=*/[](const SurfaceFrame&, SkCanvas*) {
+        EXPECT_FALSE(true);
+        return true;
+      });
+  surface_frame.reset();
+}
+
+}  // namespace flutter


### PR DESCRIPTION
In all implementations except the impeller implementation, there is an early return when the `SkCanvas` is null.

In impeller, it doesn't necessarily make sense to check the canvas since it's an SkCanvas (even though it's just an implementation of SkCanvas rather than a real Skia implementation).

Fixes https://github.com/flutter/flutter/issues/102516

However, with this patch, impeller is also not rendering anything in new gallery for me locally...