### PR TITLE
Revert "[web] Migrate Flutter Web to JS static interop - 14."

### DIFF
--- a/lib/web_ui/lib/src/engine/navigation/js_url_strategy.dart
+++ b/lib/web_ui/lib/src/engine/navigation/js_url_strategy.dart
@@ -29,7 +29,6 @@ typedef _HistoryMove = Future<void> Function(int count);
 /// bridge from the app to the engine.
 @JS()
 @anonymous
-@staticInterop
 abstract class JsUrlStrategy {
   /// Creates an instance of [JsUrlStrategy] from a bag of URL strategy
   /// functions.
@@ -42,9 +41,7 @@ abstract class JsUrlStrategy {
     required _StateOperation replaceState,
     required _HistoryMove go,
   });
-}
 
-extension JsUrlStrategyExtension on JsUrlStrategy {
   /// Adds a listener to the `popstate` event and returns a function that, when
   /// invoked, removes the listener.
   external ui.VoidCallback addPopStateListener(html.EventListener fn);


### PR DESCRIPTION
Reverts flutter/engine#32683

This appears to be causing the engine -> framework roll to fail:

https://github.com/flutter/flutter/pull/102534

https://ci.chromium.org/ui/p/flutter/builders/try/Linux%20web_long_running_tests_3_5/15692/overview