### PR TITLE
[web] fix re-enabling tappable semantic elements

### DIFF
--- a/lib/web_ui/lib/src/engine/semantics/tappable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/tappable.dart
@@ -38,6 +38,7 @@ class Tappable extends RoleManager {
       semanticsObject.element.setAttribute('aria-disabled', 'true');
       _stopListening();
     } else {
+      semanticsObject.element.removeAttribute('aria-disabled');
       // Excluding text fields because text fields have browser-specific logic
       // for recognizing taps and activating the keyboard.
       if (semanticsObject.hasAction(ui.SemanticsAction.tap) &&

--- a/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -1475,6 +1475,39 @@ void _testTappable() {
 
     semantics().semanticsEnabled = false;
   });
+
+  test('can switch tappable between enabled and disabled', () async {
+    semantics()
+      ..debugOverrideTimestampFunction(() => _testTime)
+      ..semanticsEnabled = true;
+
+    void updateTappable({required bool enabled}) {
+      final SemanticsTester tester = SemanticsTester(semantics());
+      tester.updateNode(
+        id: 0,
+        hasTap: true,
+        hasEnabledState: true,
+        isEnabled: enabled,
+        isButton: true,
+        rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
+      );
+      tester.apply();
+    }
+
+    updateTappable(enabled: false);
+    expectSemanticsTree('<sem role="button" aria-disabled="true" style="$rootSemanticStyle"></sem>');
+
+    updateTappable(enabled: true);
+    expectSemanticsTree('<sem role="button" style="$rootSemanticStyle"></sem>');
+
+    updateTappable(enabled: false);
+    expectSemanticsTree('<sem role="button" aria-disabled="true" style="$rootSemanticStyle"></sem>');
+
+    updateTappable(enabled: true);
+    expectSemanticsTree('<sem role="button" style="$rootSemanticStyle"></sem>');
+
+    semantics().semanticsEnabled = false;
+  });
 }
 
 void _testImage() {


### PR DESCRIPTION
Once disabled the `aria-disabled` stayed on the element permanently, which is wrong.