### PR TITLE
[web][ck] Don't remove (then add) embedded views.

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
@@ -997,9 +997,14 @@ ViewListDiffResult? diffViewList(List<int> active, List<int> next) {
         }
       }
     }
+    // Remove all ids from viewsToRemove that also exist in viewsToAdd.
+    final List<int> viewsToAdd = next.sublist(active.length - index);
+    final Set<int> viewsToAddSet = viewsToAdd.toSet();
+    final List<int> viewsToRemove = active.sublist(0, index).where((int e) => !viewsToAddSet.contains(e)).toList();
+
     return ViewListDiffResult(
-      active.sublist(0, index),
-      next.sublist(active.length - index),
+      viewsToRemove,
+      viewsToAdd,
       false,
     );
   }
@@ -1011,9 +1016,15 @@ ViewListDiffResult? diffViewList(List<int> active, List<int> next) {
         return null;
       }
     }
+
+    // Remove all ids from viewsToRemove that also exist in viewsToAdd.
+    final List<int> viewsToAdd = active.sublist(index + 1);
+    final Set<int> viewsToAddSet = viewsToAdd.toSet();
+    final List<int> viewsToRemove = next.sublist(0, next.length - index - 1).where((int e) => !viewsToAddSet.contains(e)).toList();
+
     return ViewListDiffResult(
-      active.sublist(index + 1),
-      next.sublist(0, next.length - index - 1),
+      viewsToAdd,
+      viewsToRemove,
       true,
       viewToInsertBefore: active.first,
     );

--- a/lib/web_ui/test/canvaskit/embedded_views_test.dart
+++ b/lib/web_ui/test/canvaskit/embedded_views_test.dart
@@ -581,6 +581,39 @@ void testMain() {
       expect(result, isNull);
     });
 
+    test('diffViewList works for flutter/flutter#101580', () {
+      ViewListDiffResult? result;
+
+      // Reverse the list
+      result = diffViewList(<int>[1, 2, 3, 4], <int>[4, 3, 2, 1]);
+      expect(result, isNotNull);
+      expect(result!.viewsToAdd, <int>[3, 2, 1]);
+      expect(result.viewsToRemove, isEmpty);
+      expect(result.addToBeginning, isFalse);
+
+      // Sort the list
+      result = diffViewList(<int>[3, 4, 1, 2], <int>[1, 2, 3, 4]);
+      expect(result, isNotNull);
+      expect(result!.viewsToAdd, <int>[3, 4]);
+      expect(result.viewsToRemove, isEmpty);
+      expect(result.addToBeginning, isFalse);
+
+      // Move last view to the beginning
+      // (The algo explores the diff from left to right, but in this case, it'd
+      // more efficient to add [1] at the beginning. Maybe we should compute both
+      // diffs, from left and right, and return the one that results in fewer
+      // add/remove operations?)
+      result = diffViewList(<int>[2, 3, 4, 1], <int>[1, 2, 3, 4]);
+      expect(result, isNotNull);
+      expect(result!.viewsToAdd, <int>[2, 3, 4]);
+      expect(result.viewsToRemove, isEmpty);
+      expect(result.addToBeginning, isFalse);
+
+      // Shuffle the list
+      result = diffViewList(<int>[1, 2, 3, 4], <int>[2, 4, 1, 3]);
+      expect(result, isNull);
+    });
+
     test('does not crash when a prerolled platform view is not composited',
         () async {
       ui.platformViewRegistry.registerViewFactory(


### PR DESCRIPTION
When computing the diff of embedded views between a frame and the next (`diffViewList`), prevent viewIds from being returned both in the `viewsToRemove` and `viewsToAdd` of the diff (prefer them on `viewsToAdd`).

If we let the diff remove views that are going to be added immediately afterwards, they get [disposed of](https://github.com/flutter/engine/blob/main/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart#L488) and then they cause a [null access error](https://github.com/flutter/engine/blob/main/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart#L515) when the engine attempts to add them a few lines below (the framework would need an extra frame to re-inject the missing view after it's been removed).

The browser is able to understand that we want to "move" an html element just by adding it elsewhere; so the solution is to **ensure that `viewsToRemove` and `viewsToAdd` do not share view ids.** (or: remove all viewIds from `viewsToRemove` that are going to be added by `viewsToAdd`).

### Tests

* Added some extra unit tests for the new behavior (the old tests were passing after my changes!).

### Issue

* Fixes https://github.com/flutter/flutter/issues/101580 (maybe others?)
* Fixes https://github.com/flutter/flutter/issues/94945


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
