### PR TITLE
Remove reference to deprecated field

### DIFF
--- a/fml/logging_unittests.cc
+++ b/fml/logging_unittests.cc
@@ -53,11 +53,13 @@ class LoggingSocketTest : public ::testing::Test {
     zx::socket local;
     ASSERT_EQ(ZX_OK, zx::socket::create(ZX_SOCKET_DATAGRAM, &local, &socket_));
 
-    fx_logger_config_t config = {.min_severity = FX_LOG_INFO,
-                                 .console_fd = -1,
-                                 .log_service_channel = local.release(),
-                                 .tags = nullptr,
-                                 .num_tags = 0};
+    fx_logger_config_t config = {
+        .min_severity = FX_LOG_INFO,
+        .console_fd = -1,
+        .log_sink_socket = local.release(),
+        .tags = nullptr,
+        .num_tags = 0,
+    };
 
     fx_log_reconfigure(&config);
   }


### PR DESCRIPTION
log_service_channel is being renamed to log_sink_socket.

@arbreng