### PR TITLE
Only call make gl context current if not already current

### DIFF
--- a/shell/platform/android/android_context_gl.cc
+++ b/shell/platform/android/android_context_gl.cc
@@ -252,7 +252,34 @@ bool AndroidEGLSurface::IsValid() const {
   return surface_ != EGL_NO_SURFACE;
 }
 
+bool AndroidEGLSurface::IsContextCurrent() const {
+  EGLContext current_egl_context = eglGetCurrentContext();
+  if (context_ != current_egl_context) {
+    return false;
+  }
+
+  EGLDisplay current_egl_display = eglGetCurrentDisplay();
+  if (display_ != current_egl_display) {
+    return false;
+  }
+
+  EGLSurface draw_surface = eglGetCurrentSurface(EGL_DRAW);
+  if (draw_surface != surface_) {
+    return false;
+  }
+
+  EGLSurface read_surface = eglGetCurrentSurface(EGL_READ);
+  if (read_surface != surface_) {
+    return false;
+  }
+
+  return true;
+}
+
 bool AndroidEGLSurface::MakeCurrent() const {
+  if (IsContextCurrent()) {
+    return true;
+  }
   if (eglMakeCurrent(display_, surface_, surface_, context_) != EGL_TRUE) {
     FML_LOG(ERROR) << "Could not make the context current";
     LogLastEGLError();

--- a/shell/platform/android/android_context_gl.h
+++ b/shell/platform/android/android_context_gl.h
@@ -25,6 +25,16 @@ namespace flutter {
 ///
 class AndroidEGLSurfaceDamage;
 
+/// Result of calling MakeCurrent on AndroidEGLSurface.
+enum class AndroidEGLSurfaceMakeCurrentStatus {
+  /// Success, the egl context for the surface was already current.
+  kSuccessAlreadyCurrent,
+  /// Success, the egl context for the surface made current.
+  kSuccessMadeCurrent,
+  /// Failed to make the egl context for the surface current.
+  kFailure,
+};
+
 class AndroidEGLSurface {
  public:
   AndroidEGLSurface(EGLSurface surface, EGLDisplay display, EGLContext context);
@@ -43,7 +53,7 @@ class AndroidEGLSurface {
   ///
   /// @return     Whether the surface was made current.
   ///
-  bool MakeCurrent() const;
+  AndroidEGLSurfaceMakeCurrentStatus MakeCurrent() const;
 
   //----------------------------------------------------------------------------
   ///

--- a/shell/platform/android/android_context_gl.h
+++ b/shell/platform/android/android_context_gl.h
@@ -81,6 +81,9 @@ class AndroidEGLSurface {
   SkISize GetSize() const;
 
  private:
+  /// Returns true if the EGLContext held is current for the display and surface
+  bool IsContextCurrent() const;
+
   const EGLSurface surface_;
   const EGLDisplay display_;
   const EGLContext context_;

--- a/shell/platform/android/android_surface_gl.cc
+++ b/shell/platform/android/android_surface_gl.cc
@@ -87,7 +87,8 @@ bool AndroidSurfaceGL::OnScreenSurfaceResize(const SkISize& size) {
 
 bool AndroidSurfaceGL::ResourceContextMakeCurrent() {
   FML_DCHECK(IsValid());
-  return offscreen_surface_->MakeCurrent();
+  auto status = offscreen_surface_->MakeCurrent();
+  return status != AndroidEGLSurfaceMakeCurrentStatus::kFailure;
 }
 
 bool AndroidSurfaceGL::ResourceContextClearCurrent() {
@@ -116,8 +117,9 @@ bool AndroidSurfaceGL::SetNativeWindow(
 std::unique_ptr<GLContextResult> AndroidSurfaceGL::GLContextMakeCurrent() {
   FML_DCHECK(IsValid());
   FML_DCHECK(onscreen_surface_);
+  auto status = onscreen_surface_->MakeCurrent();
   auto default_context_result = std::make_unique<GLContextDefaultResult>(
-      onscreen_surface_->MakeCurrent());
+      status != AndroidEGLSurfaceMakeCurrentStatus::kFailure);
   return std::move(default_context_result);
 }
 


### PR DESCRIPTION
Before: [go/gl-context-before-fltt](https://goto.google.com/gl-context-before-fltt) took ~2.6 seconds

After: [go/gl-context-after-fltt](https://goto.google.com/gl-context-after-fltt) took ~7 ms

