### PR TITLE
Display list test executables

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -140,8 +140,8 @@ group("unittests") {
   # Compile all unittests targets if enabled.
   if (enable_unittests) {
     public_deps += [
-      "//flutter/display_list:display_list_unittests",
       "//flutter/display_list:display_list_rendertests",
+      "//flutter/display_list:display_list_unittests",
       "//flutter/flow:flow_unittests",
       "//flutter/fml:fml_unittests",
       "//flutter/lib/spirv/test/exception_shaders:spirv_compile_exception_shaders",

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -140,6 +140,8 @@ group("unittests") {
   # Compile all unittests targets if enabled.
   if (enable_unittests) {
     public_deps += [
+      "//flutter/display_list:display_list_unittests",
+      "//flutter/display_list:display_list_rendertests",
       "//flutter/flow:flow_unittests",
       "//flutter/fml:fml_unittests",
       "//flutter/lib/spirv/test/exception_shaders:spirv_compile_exception_shaders",

--- a/display_list/BUILD.gn
+++ b/display_list/BUILD.gn
@@ -114,9 +114,7 @@ if (enable_unittests) {
   executable("display_list_rendertests") {
     testonly = true
 
-    sources = [
-      "display_list_canvas_unittests.cc",
-    ]
+    sources = [ "display_list_canvas_unittests.cc" ]
 
     deps = [
       ":display_list",

--- a/display_list/BUILD.gn
+++ b/display_list/BUILD.gn
@@ -2,6 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import("//flutter/common/config.gni")
 import("//flutter/testing/testing.gni")
 
 source_set("display_list") {
@@ -57,33 +58,81 @@ source_set("display_list") {
   ]
 }
 
-# Instead of creating a new test harness for display lists, the flow_unittests
-# harness includes these in its own.
-source_set("unittests") {
-  testonly = true
+if (enable_unittests) {
+  test_fixtures("display_list_fixtures") {
+    fixtures = []
+  }
 
-  sources = [
-    "display_list_attributes_testing.h",
-    "display_list_canvas_unittests.cc",
-    "display_list_color_filter_unittests.cc",
-    "display_list_color_source_unittests.cc",
-    "display_list_complexity_unittests.cc",
-    "display_list_enum_unittests.cc",
-    "display_list_image_filter_unittests.cc",
-    "display_list_mask_filter_unittests.cc",
-    "display_list_paint_unittests.cc",
-    "display_list_test_utils.cc",
-    "display_list_test_utils.h",
-    "display_list_unittests.cc",
-    "display_list_vertices_unittests.cc",
-  ]
+  source_set("display_list_testing") {
+    testonly = true
 
-  deps = [
-    "//flutter/testing:testing_lib",
-    "//third_party/skia",
-  ]
+    sources = [
+      "display_list_attributes_testing.h",
+      "display_list_test_utils.cc",
+      "display_list_test_utils.h",
+    ]
 
-  public_deps = [ ":display_list" ]
+    deps = [
+      "//flutter/testing:testing_lib",
+      "//third_party/skia",
+    ]
+
+    public_deps = [ ":display_list" ]
+  }
+
+  executable("display_list_unittests") {
+    testonly = true
+
+    sources = [
+      "display_list_color_filter_unittests.cc",
+      "display_list_color_source_unittests.cc",
+      "display_list_complexity_unittests.cc",
+      "display_list_enum_unittests.cc",
+      "display_list_image_filter_unittests.cc",
+      "display_list_mask_filter_unittests.cc",
+      "display_list_paint_unittests.cc",
+      "display_list_unittests.cc",
+      "display_list_vertices_unittests.cc",
+    ]
+
+    deps = [
+      ":display_list",
+      ":display_list_fixtures",
+      ":display_list_testing",
+      "//flutter/testing",
+    ]
+
+    if (!defined(defines)) {
+      defines = []
+    }
+    if (is_win) {
+      # Required for M_PI and others.
+      defines += [ "_USE_MATH_DEFINES" ]
+    }
+  }
+
+  executable("display_list_rendertests") {
+    testonly = true
+
+    sources = [
+      "display_list_canvas_unittests.cc",
+    ]
+
+    deps = [
+      ":display_list",
+      ":display_list_fixtures",
+      ":display_list_testing",
+      "//flutter/testing",
+    ]
+
+    if (!defined(defines)) {
+      defines = []
+    }
+    if (is_win) {
+      # Required for M_PI and others.
+      defines += [ "_USE_MATH_DEFINES" ]
+    }
+  }
 }
 
 fixtures_location("display_list_benchmarks_fixtures") {

--- a/flow/BUILD.gn
+++ b/flow/BUILD.gn
@@ -124,7 +124,6 @@ if (enable_unittests) {
     deps = [
       ":flow",
       "//flutter/common/graphics",
-      "//flutter/display_list:unittests",
     ]
   }
 
@@ -174,7 +173,7 @@ if (enable_unittests) {
       ":flow_fixtures",
       ":flow_testing",
       "//flutter/common/graphics",
-      "//flutter/display_list:unittests",
+      "//flutter/display_list:display_list_testing",
       "//flutter/fml",
       "//flutter/testing:skia",
       "//flutter/testing:testing_lib",

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -198,6 +198,10 @@ def RunCCTests(build_dir, filter, coverage, capture_core_dump):
 
   RunEngineExecutable(build_dir, 'fml_unittests', filter, [ fml_unittests_filter ] + shuffle_flags)
 
+  RunEngineExecutable(build_dir, 'display_list_unittests', filter, shuffle_flags)
+
+  RunEngineExecutable(build_dir, 'display_list_rendertests', filter, shuffle_flags)
+
   RunEngineExecutable(build_dir, 'runtime_unittests', filter, shuffle_flags, coverage=coverage)
 
   RunEngineExecutable(build_dir, 'tonic_unittests', filter, shuffle_flags, coverage=coverage)


### PR DESCRIPTION
Currently the flow_unittests take a really long time to run, mostly because they contain the display_list_canvas_unittests tests which take 40 seconds per run.

The fact that DisplayList code is tested under the "flow" suite is also someone odd as it really is a different module in the code.

This PR breaks the DisplayList tests out of the flow tests and makes 2 new executables for them. The first is just the basic unit tests under display_list_unittests and the second is the long running dl_canvas_unittests which are now in their own executable display_list_rendertests.