### PR TITLE
[Impeller] Change imgui shader color attribute from int to vec4 & convert on host

### DIFF
--- a/impeller/playground/imgui/imgui_impl_impeller.cc
+++ b/impeller/playground/imgui/imgui_impl_impeller.cc
@@ -157,10 +157,17 @@ void ImGui_ImplImpeller_RenderDrawData(ImDrawData* draw_data,
     // `ImDrawVert` uses an `int` for the color and the impeller shader uses 4
     // floats (since GLSL ES 1 doesn't support integer vertex attributes).
     //
-    // Once the GLES 2 renderer lands, impellerc could be extended to map
-    // attribute ints on the host side to vec4s in the shader (possibly by way
-    // of a naming convention hint on the attribute itself). Such a feature
-    // would remove the need to double-copy/convert this data.
+    // Once the GLES 2 renderer lands, impellerc could be extended to map the 4
+    // color bytes to vec4s in the shader, i.e.:
+    //     glVertexAttribPointer(2, 4, GL_UNSIGNED_BYTE, false, 4, nullptr);
+    // ...as opposed to:
+    //     glVertexAttribPointer(2, 4, GL_FLOAT, false, 16, nullptr);
+    //
+    // impellerc could e.g. detect some kind of special naming convention hint
+    // from the attribute name to support this case:
+    //     in vec4 vertex_color__byte;
+    //
+    // Such a feature would remove the need to double-copy/convert this data.
 
     std::vector<VS::PerVertexData> vtx_data;
     vtx_data.reserve(cmd_list->VtxBuffer.size());

--- a/impeller/playground/imgui/imgui_raster.vert
+++ b/impeller/playground/imgui/imgui_raster.vert
@@ -9,23 +9,13 @@ uniforms;
 
 in vec2 vertex_position;
 in vec2 texture_coordinates;
-in int vertex_color;
+in vec4 vertex_color;
 
 out vec2 frag_texture_coordinates;
 out vec4 frag_vertex_color;
 
-vec4 ImVertexColorToVec4(int color) {
-  const float kScale = 1.0f / 255.0f;
-  return vec4(
-    ((color >> 0) & 0xFF)  * kScale,
-    ((color >> 8) & 0xFF)  * kScale,
-    ((color >> 16) & 0xFF) * kScale,
-    ((color >> 24) & 0xFF) * kScale
-  );
-}
-
 void main() {
   gl_Position = uniforms.mvp * vec4(vertex_position.xy, 0.0, 1.0);
   frag_texture_coordinates = texture_coordinates;
-  frag_vertex_color = ImVertexColorToVec4(vertex_color);
+  frag_vertex_color = vertex_color;
 }


### PR DESCRIPTION
Only affects playgrounds.

Changes the color attribute to `vec4` in the shader. On the host, convert `ImDrawVert`s to `ImguiRasterVertexShader::PerVertexData` before copying to the device buffer since they no longer map 1-1.

This works around the lack of support for int attributes and bitwise operations in GLSL ES 1.

I added a comment inline describing a possible impellerc-based solution to enable support for color ints that maybe we can try later.