### PR TITLE
[canvaskit] Normalize color matrix translation values

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/color_filter.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/color_filter.dart
@@ -115,18 +115,28 @@ class CkMatrixColorFilter extends CkColorFilter {
 
   final List<double> matrix;
 
+  /// Flutter documentation says the translation column of the color matrix
+  /// is specified in unnormalized 0..255 space. CanvasKit expects the
+  /// translation values to be normalized to 0..1 space.
+  ///
+  /// See [https://api.flutter.dev/flutter/dart-ui/ColorFilter/ColorFilter.matrix.html].
+  Float32List get _normalizedMatrix {
+    assert(matrix.length == 20, 'Color Matrix must have 20 entries.');
+    final Float32List result = Float32List(20);
+    const List<int> translationIndices = <int>[4, 9, 14, 19];
+    for (int i = 0; i < 20; i++) {
+      if (translationIndices.contains(i)) {
+        result[i] = matrix[i] / 255.0;
+      } else {
+        result[i] = matrix[i];
+      }
+    }
+    return result;
+  }
+
   @override
   SkColorFilter _initRawColorFilter() {
-    assert(this.matrix.length == 20, 'Color Matrix must have 20 entries.');
-    final List<double> matrix = this.matrix;
-    if (matrix is Float32List) {
-      return canvasKit.ColorFilter.MakeMatrix(matrix);
-    }
-    final Float32List float32Matrix = Float32List(20);
-    for (int i = 0; i < 20; i++) {
-      float32Matrix[i] = matrix[i];
-    }
-    return canvasKit.ColorFilter.MakeMatrix(float32Matrix);
+    return canvasKit.ColorFilter.MakeMatrix(_normalizedMatrix);
   }
 
   @override

--- a/lib/web_ui/test/canvaskit/color_filter_golden_test.dart
+++ b/lib/web_ui/test/canvaskit/color_filter_golden_test.dart
@@ -107,6 +107,35 @@ void testMain() {
 
       await matchSceneGolden('canvaskit_invertcolors.png', builder.build());
     });
+
+    test('ColorFilter.matrix works for inverse matrix', () async {
+      final LayerSceneBuilder builder = LayerSceneBuilder();
+
+      builder.pushOffset(0, 0);
+
+      // Draw a red, green, and blue square with the inverted color matrix.
+      builder.pushColorFilter(const ui.ColorFilter.matrix(<double>[
+        -1, 0, 0, 0, 255, //
+        0, -1, 0, 0, 255, //
+        0, 0, -1, 0, 255, //
+        0, 0, 0, 1, 0, //
+      ]));
+
+      final CkPictureRecorder recorder = CkPictureRecorder();
+
+      final CkCanvas canvas = recorder.beginRecording(region);
+      canvas.drawRect(const ui.Rect.fromLTWH(50, 50, 100, 100),
+          CkPaint()..color = const ui.Color.fromARGB(255, 255, 0, 0));
+      canvas.drawRect(const ui.Rect.fromLTWH(200, 50, 100, 100),
+          CkPaint()..color = const ui.Color.fromARGB(255, 0, 255, 0));
+      canvas.drawRect(const ui.Rect.fromLTWH(350, 50, 100, 100),
+          CkPaint()..color = const ui.Color.fromARGB(255, 0, 0, 255));
+      final CkPicture invertedSquares = recorder.endRecording();
+
+      builder.addPicture(ui.Offset.zero, invertedSquares);
+
+      await matchSceneGolden('canvaskit_inverse_colormatrix.png', builder.build(), write: true);
+    });
     // TODO(hterkelsen): https://github.com/flutter/flutter/issues/60040
     // TODO(hterkelsen): https://github.com/flutter/flutter/issues/71520
   }, skip: isIosSafari || isFirefox);


### PR DESCRIPTION
Flutter specifies that the values in the translation column of the color matrix are given in unnormalized 0..255 space. CanvasKit expects the translation values to be normalized. This change normalizes the color matrix. See https://api.flutter.dev/flutter/dart-ui/ColorFilter/ColorFilter.matrix.html

Fixes https://github.com/flutter/flutter/issues/85707

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
