### PR TITLE
allow either host_debug or host_debug_unopt for pre-push verification

### DIFF
--- a/tools/githooks/lib/src/pre_push_command.dart
+++ b/tools/githooks/lib/src/pre_push_command.dart
@@ -37,7 +37,7 @@ class PrePushCommand extends Command<bool> {
     final Stopwatch sw = Stopwatch()..start();
     // First ensure that out/host_debug/compile_commands.json exists by running
     // //flutter/tools/gn.
-    final io.File compileCommands = io.File(path.join(
+    io.File compileCommands = io.File(path.join(
       flutterRoot,
       '..',
       'out',
@@ -45,14 +45,14 @@ class PrePushCommand extends Command<bool> {
       'compile_commands.json',
     ));
     if (!compileCommands.existsSync()) {
-      final bool gnResult = await _runCheck(
+      compileCommands = io.File(path.join(
         flutterRoot,
-        path.join(flutterRoot, 'tools', 'gn'),
-        <String>[],
-        'GN for host_debug',
-        verbose: verbose,
-      );
-      if (!gnResult) {
+        '..',
+        'out',
+        'host_debug_unopt',
+        'compile_commands.json',
+      ));
+      if (!compileCommands.existsSync()) {
         return false;
       }
     }

--- a/tools/githooks/lib/src/pre_push_command.dart
+++ b/tools/githooks/lib/src/pre_push_command.dart
@@ -53,6 +53,7 @@ class PrePushCommand extends Command<bool> {
         'compile_commands.json',
       ));
       if (!compileCommands.existsSync()) {
+        io.stderr.writeln('clang-tidy requires a fully built host_debug or host_debug_unopt build directory');
         return false;
       }
     }


### PR DESCRIPTION
Since some developers never build a host_debug directory and some have a host_debug_unopt directory instead, it makes sense for the clang-tidy setup code to look for either directory.

Also, since the impeller sources were merged into the main repo the directory has to be fully built, not just generated using `gn`, so the fallback to create the directory using `gn` is no longer useful and the script should fail if it cannot find either variant.