### PR TITLE
fix impellerc on windows

### DIFF
--- a/fml/file_unittest.cc
+++ b/fml/file_unittest.cc
@@ -228,11 +228,6 @@ TEST(FileTest, CanStopVisitEarly) {
   ASSERT_TRUE(fml::UnlinkDirectory(dir.fd(), "a"));
 }
 
-#if FML_OS_WIN
-#define AtomicWriteTest DISABLED_AtomicWriteTest
-#else
-#define AtomicWriteTest AtomicWriteTest
-#endif
 TEST(FileTest, AtomicWriteTest) {
   fml::ScopedTemporaryDirectory dir;
 

--- a/fml/platform/win/file_win.cc
+++ b/fml/platform/win/file_win.cc
@@ -375,7 +375,8 @@ bool FileExists(const fml::UniqueFD& base_directory, const char* path) {
          INVALID_FILE_ATTRIBUTES;
 }
 
-// TODO(jonahwilliams): https://github.com/flutter/flutter/issues/102838 this is not atomic on Windows.
+// TODO(jonahwilliams): https://github.com/flutter/flutter/issues/102838 this is
+// not atomic on Windows.
 bool WriteAtomically(const fml::UniqueFD& base_directory,
                      const char* file_name,
                      const Mapping& mapping) {

--- a/fml/platform/win/file_win.cc
+++ b/fml/platform/win/file_win.cc
@@ -383,12 +383,8 @@ bool WriteAtomically(const fml::UniqueFD& base_directory,
   }
 
   auto file_path = GetAbsolutePath(base_directory, file_name);
-  std::stringstream stream;
-  stream << file_path << ".temp";
-  auto temp_file_path = stream.str();
-
   auto temp_file =
-      OpenFile(temp_file_path.c_str(), true, FilePermission::kReadWrite);
+      OpenFile(file_path.c_str(), true, FilePermission::kReadWrite);
 
   if (!temp_file.is_valid()) {
     FML_DLOG(ERROR) << "Could not create temporary file.";
@@ -435,15 +431,6 @@ bool WriteAtomically(const fml::UniqueFD& base_directory,
   }
 
   temp_file.reset();
-
-  if (!::MoveFile(Utf8ToWideString(temp_file_path).c_str(),
-                  Utf8ToWideString(file_path).c_str())) {
-    FML_DLOG(ERROR)
-        << "Could not replace temp file at correct path. File path: "
-        << file_path << ". Temp file path: " << temp_file_path << " "
-        << GetLastErrorMessage();
-    return false;
-  }
 
   return true;
 }

--- a/fml/platform/win/file_win.cc
+++ b/fml/platform/win/file_win.cc
@@ -375,6 +375,7 @@ bool FileExists(const fml::UniqueFD& base_directory, const char* path) {
          INVALID_FILE_ATTRIBUTES;
 }
 
+// TODO(jonahwilliams): https://github.com/flutter/flutter/issues/102838 this is not atomic on Windows.
 bool WriteAtomically(const fml::UniqueFD& base_directory,
                      const char* file_name,
                      const Mapping& mapping) {

--- a/impeller/compiler/impellerc_main.cc
+++ b/impeller/compiler/impellerc_main.cc
@@ -32,8 +32,8 @@ bool Main(const fml::CommandLine& command_line) {
     return false;
   }
 
-  auto source_file_mapping = fml::FileMapping::CreateReadOnly(
-      *switches.working_directory, switches.source_file_name);
+  auto source_file_mapping =
+      fml::FileMapping::CreateReadOnly(switches.source_file_name);
   if (!source_file_mapping) {
     std::cerr << "Could not open input file." << std::endl;
     return false;


### PR DESCRIPTION
OpenFile seems to mostly do the right thing with absolute and relative paths on windows. Not sure what the other use cases might be? we could always do an ifdef.

Fixes https://github.com/flutter/flutter/issues/102805