### PR TITLE
[web] Migrate Flutter Web DOM usage to JS static interop - 5

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/initialization.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/initialization.dart
@@ -4,7 +4,6 @@
 library canvaskit_initialization;
 
 import 'dart:async';
-import 'dart:html' as html;
 
 import '../../engine.dart' show kProfileMode;
 import '../browser_detection.dart';
@@ -119,4 +118,4 @@ void ensureSkiaFontCollectionInitialized() {
 }
 
 /// The scene host, where the root canvas and overlay canvases are added to.
-html.Element? skiaSceneHost;
+DomElement? skiaSceneHost;

--- a/lib/web_ui/lib/src/engine/canvaskit/surface.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/surface.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:html' as html;
-
 import 'package:ui/ui.dart' as ui;
 
 import '../browser_detection.dart';
@@ -133,7 +131,7 @@ class Surface {
 
   void addToScene() {
     if (!_addedToScene) {
-      skiaSceneHost!.children.insert(0, htmlElement as html.Element);
+      skiaSceneHost!.prepend(htmlElement);
     }
     _addedToScene = true;
   }
@@ -210,8 +208,8 @@ class Surface {
     final double logicalWidth = _pixelWidth / window.devicePixelRatio;
     final double logicalHeight = _pixelHeight / window.devicePixelRatio;
     final DomCSSStyleDeclaration style = htmlCanvas!.style;
-    style.setProperty('width', '${logicalWidth}px');
-    style.setProperty('height', '${logicalHeight}px');
+    style.width = '${logicalWidth}px';
+    style.height = '${logicalHeight}px';
   }
 
   /// Translate the canvas so the surface covers the visible portion of the
@@ -226,7 +224,7 @@ class Surface {
     final int surfaceHeight = _currentSurfaceSize!.height.ceil();
     final double offset =
         (_pixelHeight - surfaceHeight) / window.devicePixelRatio;
-    htmlCanvas!.style.setProperty('transform', 'translate(0, -${offset}px)');
+    htmlCanvas!.style.transform = 'translate(0, -${offset}px)';
   }
 
   void _contextRestoredListener(DomEvent event) {
@@ -296,7 +294,7 @@ class Surface {
     // accessible.
     htmlCanvas.setAttribute('aria-hidden', 'true');
 
-    htmlCanvas.style.setProperty('position', 'absolute');
+    htmlCanvas.style.position = 'absolute';
     _updateLogicalHtmlCanvasSize();
 
     // When the browser tab using WebGL goes dormant the browser and/or OS may

--- a/lib/web_ui/lib/src/engine/dom.dart
+++ b/lib/web_ui/lib/src/engine/dom.dart
@@ -112,6 +112,7 @@ extension DomElementExtension on DomElement {
   external /* List<DomElement> */ List<Object?> get children;
   external DomCSSStyleDeclaration get style;
   external void append(DomNode node);
+  external void prepend(DomNode node);
   external void setAttribute(String name, Object value);
 }
 
@@ -120,6 +121,23 @@ extension DomElementExtension on DomElement {
 class DomCSSStyleDeclaration {}
 
 extension DomCSSStyleDeclarationExtension on DomCSSStyleDeclaration {
+  set width(String value) => setProperty('width', value);
+  set height(String value) => setProperty('height', value);
+  set position(String value) => setProperty('position', value);
+  set clip(String value) => setProperty('clip', value);
+  set clipPath(String value) => setProperty('clip-path', value);
+  set transform(String value) => setProperty('transform', value);
+  set transformOrigin(String value) => setProperty('transform-origin', value);
+  set opacity(String value) => setProperty('opacity', value);
+  String get width => getPropertyValue('width');
+  String get height => getPropertyValue('height');
+  String get position => getPropertyValue('position');
+  String get clip => getPropertyValue('clip');
+  String get clipPath => getPropertyValue('clip-path');
+  String get transform => getPropertyValue('transform');
+  String get transformOrigin => getPropertyValue('transform-origin');
+  String get opacity => getPropertyValue('opacity');
+
   external String getPropertyValue(String property);
   external void setProperty(String propertyName, String value, [String
       priority]);

--- a/lib/web_ui/lib/src/engine/embedder.dart
+++ b/lib/web_ui/lib/src/engine/embedder.dart
@@ -11,6 +11,7 @@ import '../engine.dart' show buildMode, registerHotRestartListener;
 import 'browser_detection.dart';
 import 'canvaskit/initialization.dart';
 import 'configuration.dart';
+import 'dom.dart';
 import 'host_node.dart';
 import 'keyboard_binding.dart';
 import 'platform_dispatcher.dart';
@@ -295,8 +296,8 @@ class FlutterViewEmbedder {
     /// added eagerly during initialization here and never touched, unless the
     /// system is reset due to hot restart or in a test.
     if (useCanvasKit) {
-      skiaSceneHost = html.Element.tag('flt-scene');
-      addSceneToSceneHost(skiaSceneHost);
+      skiaSceneHost = createDomElement('flt-scene');
+      addSceneToSceneHost(skiaSceneHost as html.Element?);
     }
 
     final html.Element semanticsHostElement =

--- a/lib/web_ui/test/canvaskit/surface_test.dart
+++ b/lib/web_ui/test/canvaskit/surface_test.dart
@@ -29,8 +29,8 @@ void testMain() {
       // Expect exact requested dimensions.
       expect(original.width, 9);
       expect(original.height, 19);
-      expect(original.style.getPropertyValue('width'), '9px');
-      expect(original.style.getPropertyValue('height'), '19px');
+      expect(original.style.width, '9px');
+      expect(original.style.height, '19px');
       expect(originalSurface.width(), 9);
       expect(originalSurface.height(), 19);
 
@@ -39,8 +39,8 @@ void testMain() {
           surface.acquireFrame(const ui.Size(5, 15)).skiaSurface;
       final DomCanvasElement shrunk = surface.htmlCanvas!;
       expect(shrunk, same(original));
-      expect(shrunk.style.getPropertyValue('width'), '9px');
-      expect(shrunk.style.getPropertyValue('height'), '19px');
+      expect(shrunk.style.width, '9px');
+      expect(shrunk.style.height, '19px');
       expect(shrunkSurface, isNot(same(original)));
       expect(shrunkSurface.width(), 5);
       expect(shrunkSurface.height(), 15);
@@ -56,8 +56,8 @@ void testMain() {
       // Expect overallocated dimensions
       expect(firstIncrease.width, 14);
       expect(firstIncrease.height, 28);
-      expect(firstIncrease.style.getPropertyValue('width'), '14px');
-      expect(firstIncrease.style.getPropertyValue('height'), '28px');
+      expect(firstIncrease.style.width, '14px');
+      expect(firstIncrease.style.height, '28px');
       expect(firstIncreaseSurface.width(), 10);
       expect(firstIncreaseSurface.height(), 20);
 
@@ -79,8 +79,8 @@ void testMain() {
       // Also over-allocated
       expect(huge.width, 28);
       expect(huge.height, 56);
-      expect(huge.style.getPropertyValue('width'), '28px');
-      expect(huge.style.getPropertyValue('height'), '56px');
+      expect(huge.style.width, '28px');
+      expect(huge.style.height, '56px');
       expect(hugeSurface.width(), 20);
       expect(hugeSurface.height(), 40);
 
@@ -154,8 +154,8 @@ void testMain() {
 
       expect(original.width(), 10);
       expect(original.height(), 16);
-      expect(surface.htmlCanvas!.style.getPropertyValue('width'), '10px');
-      expect(surface.htmlCanvas!.style.getPropertyValue('height'), '16px');
+      expect(surface.htmlCanvas!.style.width, '10px');
+      expect(surface.htmlCanvas!.style.height, '16px');
 
       // Increase device-pixel ratio: this makes CSS pixels bigger, so we need
       // fewer of them to cover the browser window.
@@ -164,8 +164,8 @@ void testMain() {
           surface.acquireFrame(const ui.Size(10, 16)).skiaSurface;
       expect(highDpr.width(), 10);
       expect(highDpr.height(), 16);
-      expect(surface.htmlCanvas!.style.getPropertyValue('width'), '5px');
-      expect(surface.htmlCanvas!.style.getPropertyValue('height'), '8px');
+      expect(surface.htmlCanvas!.style.width, '5px');
+      expect(surface.htmlCanvas!.style.height, '8px');
 
       // Decrease device-pixel ratio: this makes CSS pixels smaller, so we need
       // more of them to cover the browser window.
@@ -174,8 +174,8 @@ void testMain() {
           surface.acquireFrame(const ui.Size(10, 16)).skiaSurface;
       expect(lowDpr.width(), 10);
       expect(lowDpr.height(), 16);
-      expect(surface.htmlCanvas!.style.getPropertyValue('width'), '20px');
-      expect(surface.htmlCanvas!.style.getPropertyValue('height'), '32px');
+      expect(surface.htmlCanvas!.style.width, '20px');
+      expect(surface.htmlCanvas!.style.height, '32px');
     });
   }, skip: isIosSafari);
 }


### PR DESCRIPTION
This is CL 5 in a series of CLs to migrate Flutter Web DOM usage to the new JS static interop API.