### PR TITLE
Bump Robolectric to 4.8.1

### DIFF
--- a/shell/platform/android/test/README.md
+++ b/shell/platform/android/test/README.md
@@ -1,6 +1,6 @@
 # Unit testing Java code
 
-All Java code in the engine should now be able to be tested with Robolectric 4.7.3
+All Java code in the engine should now be able to be tested with Robolectric 4.8.1
 and JUnit 4. The test suite has been added after the bulk of the Java code was
 first written, so most of these classes do not have existing tests. Ideally code
 after this point should be tested, either with unit tests here or with

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
@@ -9,6 +9,7 @@ import static org.robolectric.Shadows.shadowOf;
 
 import android.content.Context;
 import android.content.res.AssetManager;
+import android.graphics.Canvas;
 import android.graphics.SurfaceTexture;
 import android.util.SparseArray;
 import android.view.MotionEvent;
@@ -51,6 +52,7 @@ import org.mockito.ArgumentCaptor;
 import org.robolectric.annotation.Config;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
+import org.robolectric.shadows.ShadowSurface;
 import org.robolectric.shadows.ShadowSurfaceView;
 
 @Config(manifest = Config.NONE)
@@ -469,7 +471,12 @@ public class PlatformViewsControllerTest {
   }
 
   @Test
-  @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
+  @Config(
+      shadows = {
+        ShadowFlutterJNI.class,
+        ShadowReleasedSurface.class,
+        ShadowPlatformTaskQueue.class
+      })
   public void disposeNullAndroidView() {
     PlatformViewsController platformViewsController = new PlatformViewsController();
 
@@ -489,6 +496,20 @@ public class PlatformViewsControllerTest {
     attach(jni, platformViewsController);
 
     // Simulate create call from the framework.
+    // Before Robolectric 4.8, Surface#lockHardwareCanvas will throw exception at
+    // PlatformViewWrapper#setTexture, because Robolectric doesn't support to shadow
+    // Surface#lockHardwareCanvas, and it uses real Android logic with native pointer address is 0.
+    // This failure will ensure embeddedView's parent is null, because
+    // PlatformViewsController#createForTextureLayer will fail because of previous mentioned error,
+    // and PlatformViewsController#createForTextureLayer will not add embeddedView to wrapperView.
+    // So this test can pass. From Robolectric 4.8, it supports to shadow Surface#lockHardwareCanvas
+    // and it can pass with default true valid value, and
+    // PlatformViewsController#createForTextureLayer will run correctly and add embeddedView to
+    // wrapperView, and initializePlatformViewIfNeeded will fail because embeddedView's parent is
+    // not null. So adding a new shadow class called ShadowReleasedSurface to simulate previous
+    // Surface#lockHardwareCanvas failure to ensure this test can work with Robolectric 4.8 and
+    // later versions. But it is just a workaround, the root cause is this test case depends on
+    // just-failure behavior of Surface#lockHardwareCanvas in old Robolectric.
     createPlatformView(
         jni, platformViewsController, platformViewId, "testType", /* hybrid=*/ false);
     platformViewsController.initializePlatformViewIfNeeded(platformViewId);
@@ -1107,6 +1128,22 @@ public class PlatformViewsControllerTest {
     @Implementation
     public void dispatch(Runnable runnable) {
       runnable.run();
+    }
+  }
+
+  /**
+   * The shadow class of {@link Surface} to simulate released surface.
+   *
+   * <p>This shadow class's usage is restricted, not for normal purpose.
+   */
+  @Implements(Surface.class)
+  public static class ShadowReleasedSurface extends ShadowSurface {
+    public ShadowReleasedSurface() {}
+
+    @Implementation
+    @Override
+    protected Canvas lockHardwareCanvas() {
+      throw new IllegalStateException("Surface has already been released.");
     }
   }
 

--- a/shell/platform/android/test_runner/build.gradle
+++ b/shell/platform/android/test_runner/build.gradle
@@ -69,8 +69,7 @@ android {
     implementation files(project.property("flutter_jar"))
     testImplementation "androidx.test:core:1.4.0"
     testImplementation "com.google.android.play:core:1.8.0"
-    testImplementation "com.ibm.icu:icu4j:69.1"
-    testImplementation "org.robolectric:robolectric:4.7.3"
+    testImplementation "org.robolectric:robolectric:4.8.1"
     testImplementation "junit:junit:4.13"
     testImplementation "androidx.test.ext:junit:1.1.3"
 

--- a/shell/platform/android/test_runner/src/main/resources/robolectric.properties
+++ b/shell/platform/android/test_runner/src/main/resources/robolectric.properties
@@ -1,2 +1,2 @@
-sdk=31
+sdk=32
 shadows=io.flutter.CustomShadowContextImpl


### PR DESCRIPTION
1. Bump sdk to 32.
2. Remove icu4j from testImplementation because Robolectric has a higher icu4j dependency.
3. Fix `PlatformViewsControllerTest#disposeNullAndroidView` with Robolectric 4.8.x.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
