### PR TITLE
Remove reference to FX_LOG_ALL

### DIFF
--- a/fml/log_settings.cc
+++ b/fml/log_settings.cc
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <cstring>
 #include <iostream>
+#include <limits>
 
 #include "flutter/fml/build_config.h"
 #include "flutter/fml/logging.h"
@@ -31,7 +32,11 @@ void SetLogSettings(const LogSettings& settings) {
       std::min(LOG_FATAL, settings.min_log_level);
 #if defined(OS_FUCHSIA)
   // Syslog should accept all logs, since filtering by severity is done by fml.
-  FX_LOG_SET_SEVERITY(ALL);
+  fx_logger_t* logger = fx_log_get_logger();
+  if (logger) {
+    fx_logger_set_min_severity(logger,
+                               std::numeric_limits<fx_log_severity_t>::min());
+  }
 #endif
 }
 


### PR DESCRIPTION
It was partially removed in
https://fuchsia-review.googlesource.com/c/fuchsia/+/674049; this commit
allows remaining references to be removed.

r? @akbiggs /cc @gbbosak