### PR TITLE
[fml] Pass OPEN_ALWAYS for create_if_necessary

### DIFF
--- a/fml/platform/win/file_win.cc
+++ b/fml/platform/win/file_win.cc
@@ -169,7 +169,7 @@ fml::UniqueFD OpenFile(const char* path,
   }
 
   const DWORD creation_disposition =
-      create_if_necessary ? CREATE_NEW : OPEN_EXISTING;
+      create_if_necessary ? OPEN_ALWAYS : OPEN_EXISTING;
 
   const DWORD flags = FILE_ATTRIBUTE_NORMAL;
 


### PR DESCRIPTION
`CREATE_NEW` fails if the file already exists.

`OPEN_ALWAYS` does what the flag says and creates the file if needed.

See https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea