### PR TITLE
Fix condition in OpacityLayer where it inherits opacity twice

### DIFF
--- a/flow/layers/opacity_layer.cc
+++ b/flow/layers/opacity_layer.cc
@@ -126,7 +126,9 @@ void OpacityLayer::Paint(PaintContext& context) const {
 
   Layer::AutoSaveLayer save_layer =
       Layer::AutoSaveLayer::Create(context, saveLayerBounds, &paint);
+  context.inherited_opacity = SK_Scalar1;
   PaintChildren(context);
+  context.inherited_opacity = inherited_opacity;
 }
 
 }  // namespace flutter


### PR DESCRIPTION
This PR fixes a problem found by code reading that will likely fix a problem encountered during an upstream roll.