### PR TITLE
Add focus support for platform view

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -986,6 +986,37 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
                               arguments:@[ @(client) ]];
 }
 
+- (void)flutterTextInputViewDidResignFirstResponder:(FlutterTextInputView*)textInputView {
+  // Platform view's first responder detection logic
+  //
+  // All text input widgets (e.g. EditableText) are backed by a dummy UITextInput view
+  // in the text input plugin. When this dummy UITextInput view resigns first responder,
+  // check if any platform view becomes first responder. If any platform view becomes
+  // first responder, send a "viewFocused" channel message to inform the framework to un-focus
+  // the previously focused text input.
+  //
+  // Caveat:
+  // 1. This detection logic does not cover the scenario when a platform view becomes
+  // first responder without any flutter text input resigning its first responder status
+  // (e.g. user tapping on platform view first). For now it works fine because there can only be
+  // one first responder in iOS, so we do not need to keep platform view's first responder status
+  // in the text input plugin (which is different from Android implementation).
+  //
+  // 2. This detection logic assumes that all text input widgets are backed by a dummy
+  // UITextInput view in the text input plugin, which may not hold true in the future.
+
+  // Have to check in the next run loop, because iOS requests the previous first responder to
+  // resign before requesting the next view to become first responder.
+  dispatch_async(dispatch_get_main_queue(), ^(void) {
+    long platform_view_id = self.platformViewsController->FindFirstResponderPlatformViewId();
+    if (platform_view_id == -1) {
+      return;
+    }
+
+    [_platformViewsChannel.get() invokeMethod:@"viewFocused" arguments:@(platform_view_id)];
+  });
+}
+
 #pragma mark - Undo Manager Delegate
 
 - (void)flutterUndoManagerPlugin:(FlutterUndoManagerPlugin*)undoManagerPlugin

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -990,7 +990,7 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
   // Platform view's first responder detection logic
   //
   // All text input widgets (e.g. EditableText) are backed by a dummy UITextInput view
-  // in the text input plugin. When this dummy UITextInput view resigns first responder,
+  // in the TextInputPlugin. When this dummy UITextInput view resigns first responder,
   // check if any platform view becomes first responder. If any platform view becomes
   // first responder, send a "viewFocused" channel message to inform the framework to un-focus
   // the previously focused text input.
@@ -998,12 +998,11 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
   // Caveat:
   // 1. This detection logic does not cover the scenario when a platform view becomes
   // first responder without any flutter text input resigning its first responder status
-  // (e.g. user tapping on platform view first). For now it works fine because there can only be
-  // one first responder in iOS, so we do not need to keep platform view's first responder status
-  // in the text input plugin (which is different from Android implementation).
+  // (e.g. user tapping on platform view first). For now it works fine because the TextInputPlugin
+  // does not track the focused platform view id (which is different from Android implementation).
   //
   // 2. This detection logic assumes that all text input widgets are backed by a dummy
-  // UITextInput view in the text input plugin, which may not hold true in the future.
+  // UITextInput view in the TextInputPlugin, which may not hold true in the future.
 
   // Have to check in the next run loop, because iOS requests the previous first responder to
   // resign before requesting the next view to become first responder.

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -987,7 +987,7 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
 }
 
 - (void)flutterTextInputViewDidResignFirstResponder:(FlutterTextInputView*)textInputView {
-  // Platform view's first responder detection logic
+  // Platform view's first responder detection logic:
   //
   // All text input widgets (e.g. EditableText) are backed by a dummy UITextInput view
   // in the TextInputPlugin. When this dummy UITextInput view resigns first responder,

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -20,12 +20,12 @@
 #import "flutter/shell/platform/darwin/ios/ios_surface_gl.h"
 
 @implementation UIView (FirstResponder)
-- (BOOL)hasFirstResponderInViewHierarchySubtree {
+- (BOOL)flt_hasFirstResponderInViewHierarchySubtree {
   if (self.isFirstResponder) {
     return YES;
   }
   for (UIView* subview in self.subviews) {
-    if (subview.hasFirstResponderInViewHierarchySubtree) {
+    if (subview.flt_hasFirstResponderInViewHierarchySubtree) {
       return YES;
     }
   }
@@ -344,7 +344,7 @@ UIView* FlutterPlatformViewsController::GetPlatformViewByID(int view_id) {
 
 long FlutterPlatformViewsController::FindFirstResponderPlatformViewId() {
   for (auto const& [id, root_view] : root_views_) {
-    if ([(UIView*)root_view.get() hasFirstResponderInViewHierarchySubtree]) {
+    if ((UIView*)(root_view.get()).flt_hasFirstResponderInViewHierarchySubtree) {
       return id;
     }
   }

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -19,6 +19,20 @@
 #import "flutter/shell/platform/darwin/ios/ios_surface.h"
 #import "flutter/shell/platform/darwin/ios/ios_surface_gl.h"
 
+@implementation UIView (FirstResponder)
+- (BOOL)hasFirstResponderInViewHierarchySubtree {
+  if (self.isFirstResponder) {
+    return YES;
+  }
+  for (UIView* subview in self.subviews) {
+    if (subview.hasFirstResponderInViewHierarchySubtree) {
+      return YES;
+    }
+  }
+  return NO;
+}
+@end
+
 namespace flutter {
 
 std::shared_ptr<FlutterPlatformViewLayer> FlutterPlatformViewLayerPool::GetLayer(
@@ -326,6 +340,15 @@ UIView* FlutterPlatformViewsController::GetPlatformViewByID(int view_id) {
     return nil;
   }
   return [touch_interceptors_[view_id].get() embeddedView];
+}
+
+long FlutterPlatformViewsController::FindFirstResponderPlatformViewId() {
+  for (auto const& [id, root_view] : root_views_) {
+    if ([(UIView*)root_view.get() hasFirstResponderInViewHierarchySubtree]) {
+      return id;
+    }
+  }
+  return -1;
 }
 
 std::vector<SkCanvas*> FlutterPlatformViewsController::GetCurrentCanvases() {

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -1105,4 +1105,36 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   return pixel[3];
 }
 
+- (void)testHasFirstResponderInViewHierarchySubtree_viewItselfBecomesFirstResponder {
+  // For view to become the first responder, it must be a descendant of a UIWindow
+  UIWindow* window = [[UIWindow alloc] init];
+  UITextField* textField = [[UITextField alloc] init];
+  [window addSubview:textField];
+
+  [textField becomeFirstResponder];
+  XCTAssertTrue(textField.isFirstResponder);
+  XCTAssertTrue(textField.hasFirstResponderInViewHierarchySubtree);
+  [textField resignFirstResponder];
+  XCTAssertFalse(textField.isFirstResponder);
+  XCTAssertFalse(textField.hasFirstResponderInViewHierarchySubtree);
+}
+
+- (void)testHasFirstResponderInViewHierarchySubtree_descendantViewBecomesFirstResponder {
+  // For view to become the first responder, it must be a descendant of a UIWindow
+  UIWindow* window = [[UIWindow alloc] init];
+  UIView* view = [[UIView alloc] init];
+  UIView* childView = [[UIView alloc] init];
+  UITextField* textField = [[UITextField alloc] init];
+  [window addSubview:view];
+  [view addSubview:childView];
+  [childView addSubview:textField];
+
+  [textField becomeFirstResponder];
+  XCTAssertTrue(textField.isFirstResponder);
+  XCTAssertTrue(view.hasFirstResponderInViewHierarchySubtree);
+  [textField resignFirstResponder];
+  XCTAssertFalse(textField.isFirstResponder);
+  XCTAssertFalse(view.hasFirstResponderInViewHierarchySubtree);
+}
+
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -1113,10 +1113,10 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
 
   [textField becomeFirstResponder];
   XCTAssertTrue(textField.isFirstResponder);
-  XCTAssertTrue(textField.hasFirstResponderInViewHierarchySubtree);
+  XCTAssertTrue(textField.flt_hasFirstResponderInViewHierarchySubtree);
   [textField resignFirstResponder];
   XCTAssertFalse(textField.isFirstResponder);
-  XCTAssertFalse(textField.hasFirstResponderInViewHierarchySubtree);
+  XCTAssertFalse(textField.flt_hasFirstResponderInViewHierarchySubtree);
 }
 
 - (void)testHasFirstResponderInViewHierarchySubtree_descendantViewBecomesFirstResponder {
@@ -1131,10 +1131,10 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
 
   [textField becomeFirstResponder];
   XCTAssertTrue(textField.isFirstResponder);
-  XCTAssertTrue(view.hasFirstResponderInViewHierarchySubtree);
+  XCTAssertTrue(view.flt_hasFirstResponderInViewHierarchySubtree);
   [textField resignFirstResponder];
   XCTAssertFalse(textField.isFirstResponder);
-  XCTAssertFalse(view.hasFirstResponderInViewHierarchySubtree);
+  XCTAssertFalse(view.flt_hasFirstResponderInViewHierarchySubtree);
 }
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -177,6 +177,10 @@ class FlutterPlatformViewsController {
 
   void OnMethodCall(FlutterMethodCall* call, FlutterResult& result);
 
+  // Returns the platform view id if the platform view (or any of its descendant view) is the first
+  // responder. Returns -1 if no such platform view is found.
+  long FindFirstResponderPlatformViewId();
+
  private:
   static const size_t kMaxLayerAllocations = 2;
 
@@ -327,6 +331,11 @@ class FlutterPlatformViewsController {
 
 // Get embedded view
 - (UIView*)embeddedView;
+@end
+
+@interface UIView (FirstResponder)
+// Returns YES if a view or any of its descendant view is the first responder. Returns NO otherwise.
+@property(nonatomic, readonly) BOOL hasFirstResponderInViewHierarchySubtree;
 @end
 
 #endif  // FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERPLATFORMVIEWS_INTERNAL_H_

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -335,7 +335,7 @@ class FlutterPlatformViewsController {
 
 @interface UIView (FirstResponder)
 // Returns YES if a view or any of its descendant view is the first responder. Returns NO otherwise.
-@property(nonatomic, readonly) BOOL hasFirstResponderInViewHierarchySubtree;
+@property(nonatomic, readonly) BOOL flt_hasFirstResponderInViewHierarchySubtree;
 @end
 
 #endif  // FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERPLATFORMVIEWS_INTERNAL_H_

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputDelegate.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputDelegate.h
@@ -59,6 +59,7 @@ typedef NS_ENUM(NSInteger, FlutterFloatingCursorDragState) {
     insertTextPlaceholderWithSize:(CGSize)size
                        withClient:(int)client;
 - (void)flutterTextInputView:(FlutterTextInputView*)textInputView removeTextPlaceholder:(int)client;
+- (void)flutterTextInputViewDidResignFirstResponder:(FlutterTextInputView*)textInputView;
 
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -39,6 +39,7 @@ const CGRect kSpacePanBounds = {{-2500, -2500}, {5000, 5000}};
 static NSString* const kShowMethod = @"TextInput.show";
 static NSString* const kHideMethod = @"TextInput.hide";
 static NSString* const kSetClientMethod = @"TextInput.setClient";
+static NSString* const kSetPlatformViewClientMethod = @"TextInput.setPlatformViewClient";
 static NSString* const kSetEditingStateMethod = @"TextInput.setEditingState";
 static NSString* const kClearClientMethod = @"TextInput.clearClient";
 static NSString* const kSetEditableSizeAndTransformMethod =
@@ -1075,6 +1076,14 @@ static BOOL IsSelectionRectCloserToPoint(CGPoint point,
   return _textInputClient != 0;
 }
 
+- (BOOL)resignFirstResponder {
+  BOOL success = [super resignFirstResponder];
+  if (success) {
+    [self.textInputDelegate flutterTextInputViewDidResignFirstResponder:self];
+  }
+  return success;
+}
+
 - (BOOL)canPerformAction:(SEL)action withSender:(id)sender {
   // When scribble is available, the FlutterTextInputView will display the native toolbar unless
   // these text editing actions are disabled.
@@ -2071,6 +2080,9 @@ static BOOL IsSelectionRectCloserToPoint(CGPoint point,
   } else if ([method isEqualToString:kSetClientMethod]) {
     [self setTextInputClient:[args[0] intValue] withConfiguration:args[1]];
     result(nil);
+  } else if ([method isEqualToString:kSetPlatformViewClientMethod]) {
+    [self setPlatformViewTextInputClient:[args[@"platformViewId"] longValue]];
+    result(nil);
   } else if ([method isEqualToString:kSetEditingStateMethod]) {
     [self setTextInputEditingState:args];
     result(nil);
@@ -2185,6 +2197,16 @@ static BOOL IsSelectionRectCloserToPoint(CGPoint point,
 
   [self cleanUpViewHierarchy:YES clearText:!saveEntries delayRemoval:NO];
   [self addToInputParentViewIfNeeded:_activeView];
+}
+
+- (void)setPlatformViewTextInputClient:(long)platformViewID {
+  // No need to track the platformViewID for now (unlike in Android), because in iOS there can
+  // only be one single first responder. When a platform view becomes first responder, hide
+  // this dummy text input view (`_activeView`) for the previously focused widget.
+  [self removeEnableFlutterTextInputViewAccessibilityTimer];
+  _activeView.accessibilityEnabled = NO;
+  [_activeView removeFromSuperview];
+  [_inputHider removeFromSuperview];
 }
 
 - (void)setTextInputClient:(int)client withConfiguration:(NSDictionary*)configuration {

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -2081,7 +2081,8 @@ static BOOL IsSelectionRectCloserToPoint(CGPoint point,
     [self setTextInputClient:[args[0] intValue] withConfiguration:args[1]];
     result(nil);
   } else if ([method isEqualToString:kSetPlatformViewClientMethod]) {
-    [self setPlatformViewTextInputClient:[args[@"platformViewId"] longValue]];
+    // This method call has a `platformViewId` argument, but we do not need it for iOS for now.
+    [self setPlatformViewTextInputClient];
     result(nil);
   } else if ([method isEqualToString:kSetEditingStateMethod]) {
     [self setTextInputEditingState:args];
@@ -2199,10 +2200,10 @@ static BOOL IsSelectionRectCloserToPoint(CGPoint point,
   [self addToInputParentViewIfNeeded:_activeView];
 }
 
-- (void)setPlatformViewTextInputClient:(long)platformViewID {
-  // No need to track the platformViewID for now (unlike in Android), because in iOS there can
-  // only be one single first responder. When a platform view becomes first responder, hide
-  // this dummy text input view (`_activeView`) for the previously focused widget.
+- (void)setPlatformViewTextInputClient {
+  // No need to track the platformViewID (unlike in Android). When a platform view
+  // becomes the first responder, simply hide this dummy text input view (`_activeView`)
+  // for the previously focused widget.
   [self removeEnableFlutterTextInputViewAccessibilityTimer];
   _activeView.accessibilityEnabled = NO;
   [_activeView removeFromSuperview];

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -1866,4 +1866,31 @@ FLUTTER_ASSERT_ARC
   XCTAssertNotNil([flutterEngine.textInputPlugin hostView]);
 }
 
+- (void)testSetPlatformViewClient {
+  FlutterViewController* flutterViewController = [FlutterViewController new];
+  FlutterTextInputPlugin* myInputPlugin = [[FlutterTextInputPlugin alloc] initWithDelegate:engine];
+  myInputPlugin.viewController = flutterViewController;
+
+  __weak UIView* activeView;
+  @autoreleasepool {
+    FlutterMethodCall* setClientCall = [FlutterMethodCall
+        methodCallWithMethodName:@"TextInput.setClient"
+                       arguments:@[
+                         [NSNumber numberWithInt:123], self.mutablePasswordTemplateCopy
+                       ]];
+    [myInputPlugin handleMethodCall:setClientCall
+                             result:^(id _Nullable result){
+                             }];
+    activeView = myInputPlugin.textInputView;
+    XCTAssertNotNil(activeView.superview, @"activeView must be added to the view hierarchy.");
+    FlutterMethodCall* setPlatformViewClientCall = [FlutterMethodCall
+        methodCallWithMethodName:@"TextInput.setPlatformViewClient"
+                       arguments:@{@"platformViewId" : [NSNumber numberWithLong:456]}];
+    [myInputPlugin handleMethodCall:setPlatformViewClientCall
+                             result:^(id _Nullable result){
+                             }];
+    XCTAssertNil(activeView.superview, @"activeView must be removed from view hierarchy.");
+  }
+}
+
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -88,7 +88,7 @@ FLUTTER_ASSERT_ARC
 
   textInputPlugin = [[FlutterTextInputPlugin alloc] initWithDelegate:engine];
 
-  viewController = [FlutterViewController new];
+  viewController = [[FlutterViewController alloc] init];
   textInputPlugin.viewController = viewController;
 
   // Clear pasteboard between tests.
@@ -167,7 +167,7 @@ FLUTTER_ASSERT_ARC
 #pragma mark - Tests
 - (void)testNoDanglingEnginePointer {
   __weak FlutterTextInputPlugin* weakFlutterTextInputPlugin;
-  FlutterViewController* flutterViewController = [FlutterViewController new];
+  FlutterViewController* flutterViewController = [[FlutterViewController alloc] init];
   __weak FlutterEngine* weakFlutterEngine;
 
   FlutterTextInputView* currentView;
@@ -1825,7 +1825,7 @@ FLUTTER_ASSERT_ARC
 }
 
 - (void)testFlutterTextInputPluginRetainsFlutterTextInputView {
-  FlutterViewController* flutterViewController = [FlutterViewController new];
+  FlutterViewController* flutterViewController = [[FlutterViewController alloc] init];
   FlutterTextInputPlugin* myInputPlugin = [[FlutterTextInputPlugin alloc] initWithDelegate:engine];
   myInputPlugin.viewController = flutterViewController;
 
@@ -1858,7 +1858,7 @@ FLUTTER_ASSERT_ARC
 }
 
 - (void)testFlutterTextInputPluginHostViewNotNil {
-  FlutterViewController* flutterViewController = [FlutterViewController new];
+  FlutterViewController* flutterViewController = [[FlutterViewController alloc] init];
   FlutterEngine* flutterEngine = [[FlutterEngine alloc] init];
   [flutterEngine runWithEntrypoint:nil];
   flutterEngine.viewController = flutterViewController;
@@ -1867,30 +1867,25 @@ FLUTTER_ASSERT_ARC
 }
 
 - (void)testSetPlatformViewClient {
-  FlutterViewController* flutterViewController = [FlutterViewController new];
+  FlutterViewController* flutterViewController = [[FlutterViewController alloc] init];
   FlutterTextInputPlugin* myInputPlugin = [[FlutterTextInputPlugin alloc] initWithDelegate:engine];
   myInputPlugin.viewController = flutterViewController;
 
-  __weak UIView* activeView;
-  @autoreleasepool {
-    FlutterMethodCall* setClientCall = [FlutterMethodCall
-        methodCallWithMethodName:@"TextInput.setClient"
-                       arguments:@[
-                         [NSNumber numberWithInt:123], self.mutablePasswordTemplateCopy
-                       ]];
-    [myInputPlugin handleMethodCall:setClientCall
-                             result:^(id _Nullable result){
-                             }];
-    activeView = myInputPlugin.textInputView;
-    XCTAssertNotNil(activeView.superview, @"activeView must be added to the view hierarchy.");
-    FlutterMethodCall* setPlatformViewClientCall = [FlutterMethodCall
-        methodCallWithMethodName:@"TextInput.setPlatformViewClient"
-                       arguments:@{@"platformViewId" : [NSNumber numberWithLong:456]}];
-    [myInputPlugin handleMethodCall:setPlatformViewClientCall
-                             result:^(id _Nullable result){
-                             }];
-    XCTAssertNil(activeView.superview, @"activeView must be removed from view hierarchy.");
-  }
+  FlutterMethodCall* setClientCall = [FlutterMethodCall
+      methodCallWithMethodName:@"TextInput.setClient"
+                     arguments:@[ [NSNumber numberWithInt:123], self.mutablePasswordTemplateCopy ]];
+  [myInputPlugin handleMethodCall:setClientCall
+                           result:^(id _Nullable result){
+                           }];
+  UIView* activeView = myInputPlugin.textInputView;
+  XCTAssertNotNil(activeView.superview, @"activeView must be added to the view hierarchy.");
+  FlutterMethodCall* setPlatformViewClientCall = [FlutterMethodCall
+      methodCallWithMethodName:@"TextInput.setPlatformViewClient"
+                     arguments:@{@"platformViewId" : [NSNumber numberWithLong:456]}];
+  [myInputPlugin handleMethodCall:setPlatformViewClientCall
+                           result:^(id _Nullable result){
+                           }];
+  XCTAssertNil(activeView.superview, @"activeView must be removed from view hierarchy.");
 }
 
 @end


### PR DESCRIPTION
This PR continues the work to add Focus support for platform view. It mainly contains 2 parts: 
1. detects the platform view focus events and sends "viewFocused" channel message to the framework
2. handles the "TextInput.setPlatformViewClient" channel message from the framework

I wrote up [this proposal](https://docs.google.com/document/d/1UKLzcNXpd0AmaUtBk2huBaC_rETUCJ9fZ_y1bI-_Jrs/edit#heading=h.505uod9xb09w) to provide more context such as different approaches to detect first responder events. 

*List which issues are fixed by this PR. You must list at least one issue.*

https://github.com/flutter/flutter/issues/34187

The previous PR in framework repo is [here](https://github.com/flutter/flutter/pull/103019/)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
