### PR TITLE
[Impeller] Assign PaintPassDelegates to subpasses

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -649,5 +649,38 @@ TEST_P(AiksTest, SaveLayerDrawsBehindSubsequentEntities) {
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
+TEST_P(AiksTest, SiblingSaveLayerBoundsAreRespected) {
+  Canvas canvas;
+  Paint paint;
+  Rect layer_rect(25, 25, 25, 25);
+  Rect rect(0, 0, 1000, 1000);
+
+  // Black, green, and red squares offset by [10, 10].
+  {
+    canvas.SaveLayer({}, layer_rect);
+    paint.color = Color::Black();
+    canvas.DrawRect(rect, paint);
+    canvas.Restore();
+  }
+
+  canvas.Translate({10, 10});
+  {
+    canvas.SaveLayer({}, layer_rect);
+    paint.color = Color::Green();
+    canvas.DrawRect(rect, paint);
+    canvas.Restore();
+  }
+
+  canvas.Translate({10, 10});
+  {
+    canvas.SaveLayer({}, layer_rect);
+    paint.color = Color::Red();
+    canvas.DrawRect(rect, paint);
+    canvas.Restore();
+  }
+
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -652,28 +652,25 @@ TEST_P(AiksTest, SaveLayerDrawsBehindSubsequentEntities) {
 TEST_P(AiksTest, SiblingSaveLayerBoundsAreRespected) {
   Canvas canvas;
   Paint paint;
-  Rect layer_rect(25, 25, 25, 25);
   Rect rect(0, 0, 1000, 1000);
 
   // Black, green, and red squares offset by [10, 10].
   {
-    canvas.SaveLayer({}, layer_rect);
+    canvas.SaveLayer({}, Rect::MakeXYWH(25, 25, 25, 25));
     paint.color = Color::Black();
     canvas.DrawRect(rect, paint);
     canvas.Restore();
   }
 
-  canvas.Translate({10, 10});
   {
-    canvas.SaveLayer({}, layer_rect);
+    canvas.SaveLayer({}, Rect::MakeXYWH(35, 35, 25, 25));
     paint.color = Color::Green();
     canvas.DrawRect(rect, paint);
     canvas.Restore();
   }
 
-  canvas.Translate({10, 10});
   {
-    canvas.SaveLayer({}, layer_rect);
+    canvas.SaveLayer({}, Rect::MakeXYWH(45, 45, 25, 25));
     paint.color = Color::Red();
     canvas.DrawRect(rect, paint);
     canvas.Restore();

--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -138,11 +138,11 @@ void Canvas::DrawCircle(Point center, Scalar radius, Paint paint) {
 }
 
 void Canvas::SaveLayer(Paint paint, std::optional<Rect> bounds) {
-  GetCurrentPass().SetDelegate(
-      std::make_unique<PaintPassDelegate>(paint, bounds));
-
   Save(true);
   GetCurrentPass().SetBlendMode(paint.blend_mode);
+
+  GetCurrentPass().SetDelegate(
+      std::make_unique<PaintPassDelegate>(paint, bounds));
 
   if (bounds.has_value()) {
     // Render target switches due to a save layer can be elided. In such cases

--- a/impeller/entity/entity_pass.h
+++ b/impeller/entity/entity_pass.h
@@ -55,6 +55,10 @@ class EntityPass {
 
   void SetBlendMode(Entity::BlendMode blend_mode);
 
+  std::optional<Rect> GetSubpassCoverage(const EntityPass& subpass) const;
+
+  std::optional<Rect> GetElementsCoverage() const;
+
  private:
   std::vector<Element> elements_;
 
@@ -66,10 +70,6 @@ class EntityPass {
       EntityPassDelegate::MakeDefault();
   std::shared_ptr<LazyGlyphAtlas> lazy_glyph_atlas_ =
       std::make_shared<LazyGlyphAtlas>();
-
-  std::optional<Rect> GetSubpassCoverage(const EntityPass& subpass) const;
-
-  std::optional<Rect> GetElementsCoverage() const;
 
   FML_DISALLOW_COPY_AND_ASSIGN(EntityPass);
 };


### PR DESCRIPTION
When `SaveLayer` is called, assign the new `PaintPassDelegate` to the actual subpass rather than the parent pass. This makes it so `SaveLayer` `PaintPassDelegate` configs won't get overridden by sibling `SaveLayer`s in the same `EntityPass`.

Also fixed a problem I happened to notice where subpass coverage wasn't applying the savelayer bounds rect (causing coverage to be larger than necessary sometimes).

New Aiks playground `AiksTest.SiblingSaveLayerBoundsAreRespected`:

Before the fix, the three `SaveLayer`s are drawn using the bounds of the last `SaveLayer` in the root `EntityPass`.
![Screen Shot 2022-05-04 at 1 27 05 AM](https://user-images.githubusercontent.com/919017/166647286-1d861fdf-9e90-4c52-b14e-fcf12c2ac8e7.png)


After the fix, the bounds of each `SaveLayer` is respected.
![Screen Shot 2022-05-04 at 1 02 08 AM](https://user-images.githubusercontent.com/919017/166644855-1fe3b0b6-26c4-4df7-9127-0eb04812d6f6.png)

