### PR TITLE
[impeller] Enable Impeller playground if an environment variable is set.

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -433,6 +433,8 @@ def to_gn_args(args):
     # Impeller flags.
     if args.enable_impeller_playground:
       gn_args['impeller_enable_playground'] = args.enable_impeller_playground
+    elif os.getenv('FLUTTER_IMPELLER_ENABLE_PLAYGROUND', '0') == '1':
+      gn_args['impeller_enable_playground'] = True
 
     return gn_args
 


### PR DESCRIPTION
The environment variable is `FLUTTER_IMPELLER_ENABLE_PLAYGROUND`

This deals with the issue of running ./flutter/tools/gn and losing your
playground preferences.

If a command line flag is specified, it takes precedence.

This follows the same principle as the goma symlinks flag.