### PR TITLE
[Linux] FlTextInputPlugin: use FlView as GTK IM client window

### DIFF
--- a/shell/platform/linux/fl_text_input_plugin.cc
+++ b/shell/platform/linux/fl_text_input_plugin.cc
@@ -259,9 +259,8 @@ static void im_preedit_start_cb(FlTextInputPlugin* self) {
       fl_text_input_plugin_get_instance_private(self));
   priv->text_model->BeginComposing();
 
-  // Set the top-level window used for system input method windows.
-  GdkWindow* window =
-      gtk_widget_get_window(gtk_widget_get_toplevel(GTK_WIDGET(priv->view)));
+  // Set the native window used for system input method windows.
+  GdkWindow* window = gtk_widget_get_window(GTK_WIDGET(priv->view));
   gtk_im_context_set_client_window(priv->im_context, window);
 }
 
@@ -420,9 +419,8 @@ static FlMethodResponse* show(FlTextInputPlugin* self) {
     return hide(self);
   }
 
-  // Set the top-level window used for system input method windows.
-  GdkWindow* window =
-      gtk_widget_get_window(gtk_widget_get_toplevel(GTK_WIDGET(priv->view)));
+  // Set the native window used for system input method windows.
+  GdkWindow* window = gtk_widget_get_window(GTK_WIDGET(priv->view));
   gtk_im_context_set_client_window(priv->im_context, window);
 
   gtk_im_context_focus_in(priv->im_context);
@@ -483,7 +481,7 @@ static FlMethodResponse* clear_client(FlTextInputPlugin* self) {
 // over the text input channel: updates to the composing rect (cursor rect when
 // not in IME composing mode) and updates to the matrix transform from local
 // coordinates to Flutter root coordinates. This function is called after each
-// of these updates. It transforms the composing rect to GTK window coordinates
+// of these updates. It transforms the composing rect to GDK window coordinates
 // and notifies GTK of the updated cursor position.
 static void update_im_cursor_position(FlTextInputPlugin* self) {
   FlTextInputPluginPrivate* priv = static_cast<FlTextInputPluginPrivate*>(
@@ -503,14 +501,9 @@ static void update_im_cursor_position(FlTextInputPlugin* self) {
            priv->composing_rect.y * priv->editabletext_transform[1][1] +
            priv->editabletext_transform[3][1] + priv->composing_rect.height;
 
-  // Transform from Flutter view coordinates to GTK window coordinates.
-  GdkRectangle preedit_rect;
-  gtk_widget_translate_coordinates(
-      GTK_WIDGET(priv->view), gtk_widget_get_toplevel(GTK_WIDGET(priv->view)),
-      x, y, &preedit_rect.x, &preedit_rect.y);
-
   // Set the cursor location in window coordinates so that GTK can position any
   // system input method windows.
+  GdkRectangle preedit_rect = {x, y, 0, 0};
   gtk_im_context_set_cursor_location(priv->im_context, &preedit_rect);
 }
 


### PR DESCRIPTION
GTK IM operates in [coordinates relative to its client window](https://docs.gtk.org/gtk3/method.IMContext.set_cursor_location.html#:~:text=The%20location%20is%20relative%20to%20the%20client%C2%A0window.). Let GTK
IM use the native window that backs FlView, which is the same native
window that is used for key event processing - see GDK_KEY_XXX_MASK in
fl_view_realize().

This is an important step towards testable FlTextInputPlugin because it
eliminates the depency to GtkWidget's coordinate translation API and
that way paves the road for replacing FlTextInputPlugin's FlView
instance with a plain GdkWindow. In tests, that window can be an
instance of GdkOffscreenWindow.

There are no tests included yet but after a few more refactoring steps
it will be possible to execute tests like this: [fl_text_input_plugin_test.cc](https://github.com/jpnurmi/engine/blob/f2e0d91b59c0375d08fcc1397d164827168725d7/shell/platform/linux/fl_text_input_plugin_test.cc).
The other refactoring steps are visible at [jpnurmi/engine/commits/text-input-plugin](https://github.com/jpnurmi/engine/commits/text-input-plugin).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.