### PR TITLE
[macOS] Fix test fixture identifier style

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
@@ -357,7 +357,7 @@ TEST_F(FlutterEngineTest, ResetsAccessibilityBridgeWhenSetsNewViewController) {
 
 TEST_F(FlutterEngineTest, NativeCallbacks) {
   FlutterEngine* engine = GetFlutterEngine();
-  EXPECT_TRUE([engine runWithEntrypoint:@"native_callback"]);
+  EXPECT_TRUE([engine runWithEntrypoint:@"nativeCallback"]);
   EXPECT_TRUE(engine.running);
 
   fml::AutoResetWaitableEvent latch;
@@ -384,7 +384,7 @@ TEST(FlutterEngine, DISABLED_Compositor) {
   viewController.flutterView.frame = CGRectMake(0, 0, 800, 600);
   [engine setViewController:viewController];
 
-  EXPECT_TRUE([engine runWithEntrypoint:@"can_composite_platform_views"]);
+  EXPECT_TRUE([engine runWithEntrypoint:@"canCompositePlatformViews"]);
 
   // Latch to ensure the entire layer tree has been generated and presented.
   fml::AutoResetWaitableEvent latch;

--- a/shell/platform/darwin/macos/framework/Source/fixtures/flutter_desktop_test.dart
+++ b/shell/platform/darwin/macos/framework/Source/fixtures/flutter_desktop_test.dart
@@ -16,7 +16,22 @@ void canLogToStdout() {
   signalNativeTest();
 }
 
-Picture CreateSimplePicture() {
+@pragma('vm:entry-point')
+void canCompositePlatformViews() {
+  PlatformDispatcher.instance.onBeginFrame = (Duration duration) {
+    SceneBuilder builder = SceneBuilder();
+    builder.addPicture(Offset(1.0, 1.0), _createSimplePicture());
+    builder.pushOffset(1.0, 2.0);
+    builder.addPlatformView(42, width: 123.0, height: 456.0);
+    builder.addPicture(Offset(1.0, 1.0), _createSimplePicture());
+    builder.pop(); // offset
+    PlatformDispatcher.instance.views.first.render(builder.build());
+  };
+  PlatformDispatcher.instance.scheduleFrame();
+}
+
+/// Returns a [Picture] of a simple black square.
+Picture _createSimplePicture() {
   Paint blackPaint = Paint();
   PictureRecorder baseRecorder = PictureRecorder();
   Canvas canvas = Canvas(baseRecorder);
@@ -25,20 +40,6 @@ Picture CreateSimplePicture() {
 }
 
 @pragma('vm:entry-point')
-void can_composite_platform_views() {
-  PlatformDispatcher.instance.onBeginFrame = (Duration duration) {
-    SceneBuilder builder = SceneBuilder();
-    builder.addPicture(Offset(1.0, 1.0), CreateSimplePicture());
-    builder.pushOffset(1.0, 2.0);
-    builder.addPlatformView(42, width: 123.0, height: 456.0);
-    builder.addPicture(Offset(1.0, 1.0), CreateSimplePicture());
-    builder.pop(); // offset
-    PlatformDispatcher.instance.views.first.render(builder.build());
-  };
-  PlatformDispatcher.instance.scheduleFrame();
-}
-
-@pragma('vm:entry-point')
-void native_callback() {
+void nativeCallback() {
   signalNativeTest();
 }


### PR DESCRIPTION
Rename the C++ style can_composite_platform_views and native_callback
functions to the Dart-style identifiers canCompositePlatformViews and
nativeCallback in the macOS desktop test fixtures.

Also corrects the helper method identifier from CreateSimplePicture to
_createSimplePicture, thus making it library-private to help readers
understand it's a local helper.

Ref: [Flutter Style Guide](https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#naming)
Ref: [Effective Dart](https://dart.dev/guides/language/effective-dart/style#do-name-other-identifiers-using-lowercamelcase)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
