### PR TITLE
Move embedder jar file processing to GN.

### DIFF
--- a/build/android_artifacts.py
+++ b/build/android_artifacts.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+#
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+"""Copies and renames android artifacts."""
+
+
+
+import sys
+import shutil
+import os
+import argparse
+
+
+def cp_files(args):
+  """Copies files from source to destination.
+
+  It creates the destination folder if it does not exists yet.
+  """
+  for src, dst in args.input_pairs:
+    os.makedirs(os.path.dirname(dst), exist_ok=True)
+    shutil.copyfile(src, dst)
+
+
+def main():
+  parser = argparse.ArgumentParser()
+  parser.add_argument('-i', dest='input_pairs', nargs=2, action='append',
+      help='The input file and its destination.')
+  cp_files(parser.parse_args())
+
+  return 0
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/build/android_artifacts.py
+++ b/build/android_artifacts.py
@@ -6,12 +6,10 @@
 
 """Copies and renames android artifacts."""
 
-
-
-import sys
-import shutil
-import os
 import argparse
+import os
+import shutil
+import sys
 
 
 def cp_files(args):
@@ -29,8 +27,8 @@ def main():
   parser.add_argument('-i', dest='input_pairs', nargs=2, action='append',
       help='The input file and its destination.')
   cp_files(parser.parse_args())
-
   return 0
+
 
 if __name__ == '__main__':
   sys.exit(main())

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -607,3 +607,48 @@ group("android") {
     deps += [ ":gen_snapshot" ]
   }
 }
+
+# Renames embedding android artifacts and places them in the final
+# expected folder structure.
+action("embedding_jars") {
+  script = "//flutter/build/android_artifacts.py"
+
+  deps = [
+    ":flutter_shell_java",
+    ":pom_embedding",
+  ]
+  sources = [
+    "$root_out_dir/flutter_embedding_$flutter_runtime_mode.jar",
+    "$root_out_dir/flutter_embedding_$flutter_runtime_mode.pom",
+  ]
+  outputs = []
+  args = []
+  base_name = "$root_out_dir/zip_archives/flutter_download_io/" +
+              "flutter_embedding_$flutter_runtime_mode/1.0.0-$engine_version/" +
+              "flutter_embedding_$flutter_runtime_mode-1.0.0-${engine_version}"
+  foreach(source, sources) {
+    extension = get_path_info(source, "extension")
+    name = get_path_info(source, "name")
+    if (extension == "jar") {
+      outputs += [
+        "${base_name}.jar",
+        "${base_name}-sources.jar",
+      ]
+      args += [
+        "-i",
+        "${name}.jar",
+        rebase_path("${base_name}.jar"),
+        "-i",
+        "${name}-sources.jar",
+        rebase_path("${base_name}-sources.jar"),
+      ]
+    } else {
+      outputs += [ "${base_name}.${extension}" ]
+      args += [
+        "-i",
+        rebase_path(source),
+        rebase_path("${base_name}.${extension}"),
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Recipes currently contain a lot of logic to manipulate jar file names
and creating the expected folder structures. This PR moves the logic to
process embedder android artifacts to GN.

Bug: https://github.com/flutter/flutter/issues/81855

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
