### PR TITLE
Set Platform.executable on startup

### DIFF
--- a/common/settings.h
+++ b/common/settings.h
@@ -157,6 +157,10 @@ struct Settings {
   // Dart code is executed.
   std::string advisory_script_entrypoint = "main";
 
+  // The executable path associated with this process. This is returned by
+  // Platform.executable from dart:io. If unknown, defaults to "Flutter".
+  std::string executable_name = "Flutter";
+
   // Observatory settings
 
   // Whether the Dart VM service should be enabled.

--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -436,6 +436,8 @@ DartVM::DartVM(std::shared_ptr<const DartVMData> vm_data,
 
   DartUI::InitForGlobal();
 
+  dart::bin::SetExecutableName(settings_.executable_name.c_str());
+
   {
     TRACE_EVENT0("flutter", "Dart_Initialize");
     Dart_InitializeParams params = {};

--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -233,6 +233,11 @@ std::unique_ptr<fml::Mapping> GetSymbolMapping(std::string symbol_prefix,
 Settings SettingsFromCommandLine(const fml::CommandLine& command_line) {
   Settings settings = {};
 
+  // Set executable name.
+  if (command_line.has_argv0()) {
+    settings.executable_name = command_line.argv0();
+  }
+
   // Enable Observatory
   settings.enable_observatory =
       !command_line.HasOption(FlagForSwitch(Switch::DisableObservatory));

--- a/shell/platform/embedder/fixtures/main.dart
+++ b/shell/platform/embedder/fixtures/main.dart
@@ -42,6 +42,14 @@ void terminateExitCodeHandler() {
 
 
 @pragma('vm:entry-point')
+void executableNameNotNull() {
+  notifyStringValue(Platform.executable);
+}
+
+void notifyStringValue(String value) native 'NotifyStringValue';
+
+
+@pragma('vm:entry-point')
 void invokePlatformTaskRunner() {
   PlatformDispatcher.instance.sendPlatformMessage('OhHi', null, null);
 }

--- a/shell/platform/embedder/tests/embedder_config_builder.cc
+++ b/shell/platform/embedder/tests/embedder_config_builder.cc
@@ -102,8 +102,8 @@ EmbedderConfigBuilder::EmbedderConfigBuilder(
             SkImage::MakeFromBitmap(bitmap));
       };
 
-  // The first argument is treated as the executable name. Don't make tests have
-  // to do this manually.
+  // The first argument is always the executable name. Don't make tests have to
+  // do this manually.
   AddCommandLineArgument("embedder_unittest");
 
   if (preference != InitializationPreference::kNoInitialize) {
@@ -262,6 +262,13 @@ void EmbedderConfigBuilder::SetLogTag(std::string tag) {
 void EmbedderConfigBuilder::SetLocalizationCallbackHooks() {
   project_args_.compute_platform_resolved_locale_callback =
       EmbedderTestContext::GetComputePlatformResolvedLocaleCallbackHook();
+}
+
+void EmbedderConfigBuilder::SetExecutableName(std::string executable_name) {
+  if (executable_name.size() == 0) {
+    return;
+  }
+  command_line_arguments_[0] = std::move(executable_name);
 }
 
 void EmbedderConfigBuilder::SetDartEntrypoint(std::string entrypoint) {

--- a/shell/platform/embedder/tests/embedder_config_builder.h
+++ b/shell/platform/embedder/tests/embedder_config_builder.h
@@ -85,6 +85,8 @@ class EmbedderConfigBuilder {
 
   void SetLocalizationCallbackHooks();
 
+  void SetExecutableName(std::string executable_name);
+
   void SetDartEntrypoint(std::string entrypoint);
 
   void AddCommandLineArgument(std::string arg);


### PR DESCRIPTION
Previously, using Platform.executable (from dart:io) returned null (if
non-null-by-default was disabled) or threw an exception (if NNBD was
enabled) since we weren't setting it.

We now pass the executable name to Dart during VM startup based on the
first value in the FlutterProjectArgs::command_line_argv array passed to
FlutterEngineRun (or FlutterEngineInitialize) on startup. argv[0] (if
specified) is explicitly documented as being required to be the
executable name in embedder.h. In the case where no argv[0] is
specified, we instead set Platform.executable to "Flutter" in order to
avoid violating the (non-nullable) type annoation on
Platform.executable.

Note that dart::bin::SetExecutableName() does NOT make a copy of the
input string, so that value needs to be available for the entire lifetime
of the VM.

This also adds EmbedderConfigBuilder::SetExecutableName() to support
setting a fake executable name in unittests. By default, we continue to
set the name "embedder_unittest" unless overridden using this method.

See: https://api.flutter.dev/flutter/dart-io/Platform/executable.html
See: https://github.com/dart-lang/sdk/issues/48427

Issue: https://github.com/flutter/flutter/issues/83921


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
