### PR TITLE
[macOS] Set correct Platform.executable (argv[0])

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -516,11 +516,7 @@ static void OnPlatformMessage(const FlutterPlatformMessage* message, FlutterEngi
 }
 
 - (nonnull NSString*)executableName {
-  NSArray<NSString*>* arguments = [[NSProcessInfo processInfo] arguments];
-  if ([arguments count] < 1) {
-    return @"Flutter";
-  }
-  return [arguments objectAtIndex:0];
+  return [[[NSProcessInfo processInfo] arguments] firstObject] ?: @"Flutter";
 }
 
 - (void)updateWindowMetrics {

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
@@ -39,6 +39,23 @@ TEST_F(FlutterEngineTest, CanLaunch) {
   EXPECT_TRUE(engine.running);
 }
 
+TEST_F(FlutterEngineTest, HasNonNullExecutableName) {
+  // Launch the test entrypoint.
+  FlutterEngine* engine = GetFlutterEngine();
+  std::string executable_name = engine.executableName;
+  EXPECT_TRUE([engine runWithEntrypoint:@"executableNameNotNull"]);
+
+  // Block until notified by the Dart test of the value of Platform.executable.
+  fml::AutoResetWaitableEvent latch;
+  AddNativeCallback("NotifyStringValue", CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
+                      const auto dart_string = tonic::DartConverter<std::string>::FromDart(
+                          Dart_GetNativeArgument(args, 0));
+                      EXPECT_EQ(executable_name, dart_string);
+                      latch.Signal();
+                    }));
+  latch.Wait();
+}
+
 TEST_F(FlutterEngineTest, MessengerSend) {
   FlutterEngine* engine = GetFlutterEngine();
   EXPECT_TRUE([engine runWithEntrypoint:@"main"]);

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
@@ -42,7 +42,7 @@ TEST_F(FlutterEngineTest, CanLaunch) {
 TEST_F(FlutterEngineTest, HasNonNullExecutableName) {
   // Launch the test entrypoint.
   FlutterEngine* engine = GetFlutterEngine();
-  std::string executable_name = engine.executableName;
+  std::string executable_name = [[engine executableName] UTF8String];
   EXPECT_TRUE([engine runWithEntrypoint:@"executableNameNotNull"]);
 
   // Block until notified by the Dart test of the value of Platform.executable.

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h
@@ -40,6 +40,11 @@
 @property(nonatomic) BOOL semanticsEnabled;
 
 /**
+ * The executable name for the current process.
+ */
+@property(nonatomic, readonly, nonnull) const char* executableName;
+
+/**
  * Informs the engine that the associated view controller's view size has changed.
  */
 - (void)updateWindowMetrics;

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h
@@ -42,7 +42,7 @@
 /**
  * The executable name for the current process.
  */
-@property(nonatomic, readonly, nonnull) const char* executableName;
+@property(nonatomic, readonly, nonnull) NSString* executableName;
 
 /**
  * Informs the engine that the associated view controller's view size has changed.

--- a/shell/platform/darwin/macos/framework/Source/fixtures/flutter_desktop_test.dart
+++ b/shell/platform/darwin/macos/framework/Source/fixtures/flutter_desktop_test.dart
@@ -2,11 +2,23 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io';
 import 'dart:ui';
 
 void signalNativeTest() native 'SignalNativeTest';
 
 void main() {
+}
+
+/// Notifies the test of a string value.
+///
+/// This is used to notify the native side of the test of a string value from
+/// the Dart fixture under test.
+void notifyStringValue(String s) native 'NotifyStringValue';
+
+@pragma('vm:entry-point')
+void executableNameNotNull() {
+  notifyStringValue(Platform.executable);
 }
 
 @pragma('vm:entry-point')


### PR DESCRIPTION
Previously, in the macOS embedder, we set the first argument of
FlutterProjectArgs::command_line_argv to the hardcoded string
"placeholder". As per the documentation of embedder.h, this argument is
required to be the executable name, if present. This value is available
to Flutter applications via Platform.executable in dart:io.

This corrects the value to be the executable name for the current
process. In the case where the correct name cannot be determined, we
fall back to "Flutter" in order to avoid violating the (non-nullable)
type annoation on Platform.executable.

Since the string pointers in command_line_argv are required to
be valid for the lifetime of the Dart runtime, and since the name of the
executable associated with this process will not change over the
lifetime of the app, we hold this in a static.

This also adds the internal method [FlutterEngine executableName] in
order to facilitate testing.

See: https://api.flutter.dev/flutter/dart-io/Platform/executable.html
See: https://github.com/dart-lang/sdk/issues/48427

Issue: https://github.com/flutter/flutter/issues/83921

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
