### PR TITLE
Fix gtk targets for arm64 artifacts.

### DIFF
--- a/common/config.gni
+++ b/common/config.gni
@@ -68,14 +68,14 @@ if (is_ios || is_mac) {
 
 # A combo of host os name and cpu is used in several locations to
 # generate the names of the archived artifacts.
-_platform_name = host_os
-if (_platform_name == "mac") {
-  _platform_name = "darwin"
-} else if (_platform_name == "win") {
-  _platform_name = "windows"
+platform_name = host_os
+if (platform_name == "mac") {
+  platform_name = "darwin"
+} else if (platform_name == "win") {
+  platform_name = "windows"
 }
 
-full_platform_name = "$_platform_name-$host_cpu"
+full_platform_name = "$platform_name-$host_cpu"
 
 _platform_target_name = target_os
 if (_platform_target_name == "mac") {

--- a/common/config.gni
+++ b/common/config.gni
@@ -77,14 +77,14 @@ if (platform_name == "mac") {
 
 full_platform_name = "$platform_name-$host_cpu"
 
-_platform_target_name = target_os
-if (_platform_target_name == "mac") {
-  _platform_target_name = "darwin"
-} else if (_platform_target_name == "win") {
-  _platform_target_name = "windows"
+target_platform_name = target_os
+if (target_platform_name == "mac") {
+  platform_target_name = "darwin"
+} else if (target_platform_name == "win") {
+  target_platform_name = "windows"
 }
 
-full_target_platform_name = "$_platform_target_name-$target_cpu"
+full_target_platform_name = "$target_platform_name-$target_cpu"
 
 # Prebuilt Dart SDK location
 

--- a/shell/platform/linux/BUILD.gn
+++ b/shell/platform/linux/BUILD.gn
@@ -265,10 +265,11 @@ copy("publish_headers_linux") {
 
 zip_bundle("flutter_gtk") {
   prefix = ""
-  if (flutter_runtime_mode != "debug") {
-    prefix = "$full_platform_name-$flutter_runtime_mode/"
+  if (flutter_runtime_mode != "debug" ||
+      (flutter_runtime_mode == "debug" && target_cpu != "x64")) {
+    prefix = "$platform_name-$target_cpu-$flutter_runtime_mode/"
   }
-  output = "$prefix$full_platform_name-flutter-gtk.zip"
+  output = "${prefix}${platform_name}-${target_cpu}-flutter-gtk.zip"
   deps = [
     ":flutter_linux_gtk",
     ":publish_headers_linux",

--- a/shell/platform/linux/BUILD.gn
+++ b/shell/platform/linux/BUILD.gn
@@ -267,9 +267,9 @@ zip_bundle("flutter_gtk") {
   prefix = ""
   if (flutter_runtime_mode != "debug" ||
       (flutter_runtime_mode == "debug" && target_cpu != "x64")) {
-    prefix = "$target_platform_name-$target_cpu-$flutter_runtime_mode/"
+    prefix = "$full_target_platform_name-$flutter_runtime_mode/"
   }
-  output = "${prefix}${target_platform_name}-${target_cpu}-flutter-gtk.zip"
+  output = "${prefix}${full_target_platform_name}-flutter-gtk.zip"
   deps = [
     ":flutter_linux_gtk",
     ":publish_headers_linux",

--- a/shell/platform/linux/BUILD.gn
+++ b/shell/platform/linux/BUILD.gn
@@ -267,9 +267,9 @@ zip_bundle("flutter_gtk") {
   prefix = ""
   if (flutter_runtime_mode != "debug" ||
       (flutter_runtime_mode == "debug" && target_cpu != "x64")) {
-    prefix = "$platform_name-$target_cpu-$flutter_runtime_mode/"
+    prefix = "$target_platform_name-$target_cpu-$flutter_runtime_mode/"
   }
-  output = "${prefix}${platform_name}-${target_cpu}-flutter-gtk.zip"
+  output = "${prefix}${target_platform_name}-${target_cpu}-flutter-gtk.zip"
   deps = [
     ":flutter_linux_gtk",
     ":publish_headers_linux",


### PR DESCRIPTION
The artifact name and location were using the host_cpu instead of the
target_cpu.

Bug: https://github.com/flutter/flutter/issues/81855

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
