### PR TITLE
[WIP]Make the callback of VsyncWaiter protected with the mutex only when needed

### DIFF
--- a/shell/common/vsync_waiter.h
+++ b/shell/common/vsync_waiter.h
@@ -40,7 +40,7 @@ class VsyncWaiter : public std::enable_shared_from_this<VsyncWaiter> {
 
   const TaskRunners task_runners_;
 
-  explicit VsyncWaiter(TaskRunners task_runners);
+  explicit VsyncWaiter(TaskRunners task_runners, bool use_callback_lock);
 
   // There are two distinct situations where VsyncWaiter wishes to awaken at
   // the next vsync. Although the functionality can be the same, the intent is
@@ -75,6 +75,7 @@ class VsyncWaiter : public std::enable_shared_from_this<VsyncWaiter> {
   std::mutex callback_mutex_;
   Callback callback_;
   std::unordered_map<uintptr_t, fml::closure> secondary_callbacks_;
+  const bool use_callback_lock_;
 
   void PauseDartMicroTasks();
   static void ResumeDartMicroTasks(fml::TaskQueueId ui_task_queue_id);

--- a/shell/common/vsync_waiter_fallback.cc
+++ b/shell/common/vsync_waiter_fallback.cc
@@ -27,7 +27,7 @@ static fml::TimePoint SnapToNextTick(fml::TimePoint value,
 
 VsyncWaiterFallback::VsyncWaiterFallback(TaskRunners task_runners,
                                          bool for_testing)
-    : VsyncWaiter(std::move(task_runners)),
+    : VsyncWaiter(std::move(task_runners), /**use_callback_lock=*/false),
       phase_(fml::TimePoint::Now()),
       for_testing_(for_testing) {}
 

--- a/shell/common/vsync_waiters_test.h
+++ b/shell/common/vsync_waiters_test.h
@@ -51,7 +51,7 @@ class ConstantFiringVsyncWaiter : public VsyncWaiter {
       fml::TimePoint::FromEpochDelta(fml::TimeDelta::FromSeconds(100));
 
   explicit ConstantFiringVsyncWaiter(TaskRunners task_runners)
-      : VsyncWaiter(std::move(task_runners), /**use_callback_lock=*/false) {}
+      : VsyncWaiter(std::move(task_runners), /**use_callback_lock=*/true) {}
 
  protected:
   void AwaitVSync() override;

--- a/shell/common/vsync_waiters_test.h
+++ b/shell/common/vsync_waiters_test.h
@@ -32,7 +32,8 @@ class ShellTestVsyncWaiter : public VsyncWaiter {
  public:
   ShellTestVsyncWaiter(TaskRunners task_runners,
                        std::shared_ptr<ShellTestVsyncClock> clock)
-      : VsyncWaiter(std::move(task_runners)), clock_(clock) {}
+      : VsyncWaiter(std::move(task_runners), /**use_callback_lock=*/true),
+        clock_(clock) {}
 
  protected:
   void AwaitVSync() override;
@@ -50,7 +51,7 @@ class ConstantFiringVsyncWaiter : public VsyncWaiter {
       fml::TimePoint::FromEpochDelta(fml::TimeDelta::FromSeconds(100));
 
   explicit ConstantFiringVsyncWaiter(TaskRunners task_runners)
-      : VsyncWaiter(std::move(task_runners)) {}
+      : VsyncWaiter(std::move(task_runners), /**use_callback_lock=*/false) {}
 
  protected:
   void AwaitVSync() override;

--- a/shell/platform/android/vsync_waiter_android.cc
+++ b/shell/platform/android/vsync_waiter_android.cc
@@ -22,9 +22,14 @@ static jmethodID g_async_wait_for_vsync_method_ = nullptr;
 static std::atomic_uint g_refresh_rate_ = 60;
 
 VsyncWaiterAndroid::VsyncWaiterAndroid(flutter::TaskRunners task_runners)
-    : VsyncWaiter(std::move(task_runners)),
-      use_ndk_choreographer_(
-          AndroidChoreographer::ShouldUseNDKChoreographer()) {}
+    : VsyncWaiterAndroid(std::move(task_runners),
+                         AndroidChoreographer::ShouldUseNDKChoreographer()) {}
+
+VsyncWaiterAndroid::VsyncWaiterAndroid(flutter::TaskRunners task_runners,
+                                       bool use_ndk_choreographer)
+    : VsyncWaiter(std::move(task_runners),
+                  /**use_callback_lock=*/!use_ndk_choreographer),
+      use_ndk_choreographer_(use_ndk_choreographer) {}
 
 VsyncWaiterAndroid::~VsyncWaiterAndroid() = default;
 

--- a/shell/platform/android/vsync_waiter_android.h
+++ b/shell/platform/android/vsync_waiter_android.h
@@ -25,6 +25,9 @@ class VsyncWaiterAndroid final : public VsyncWaiter {
   ~VsyncWaiterAndroid() override;
 
  private:
+  explicit VsyncWaiterAndroid(flutter::TaskRunners task_runners,
+                              bool use_ndk_choreographer);
+
   // |VsyncWaiter|
   void AwaitVSync() override;
 

--- a/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
+++ b/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
@@ -17,7 +17,7 @@
 namespace flutter {
 
 VsyncWaiterIOS::VsyncWaiterIOS(flutter::TaskRunners task_runners)
-    : VsyncWaiter(std::move(task_runners)) {
+    : VsyncWaiter(std::move(task_runners), /**use_callback_lock=*/false) {
   auto callback = [this](std::unique_ptr<flutter::FrameTimingsRecorder> recorder) {
     const fml::TimePoint start_time = recorder->GetVsyncStartTime();
     const fml::TimePoint target_time = recorder->GetVsyncTargetTime();

--- a/shell/platform/embedder/vsync_waiter_embedder.cc
+++ b/shell/platform/embedder/vsync_waiter_embedder.cc
@@ -8,7 +8,8 @@ namespace flutter {
 
 VsyncWaiterEmbedder::VsyncWaiterEmbedder(const VsyncCallback& vsync_callback,
                                          flutter::TaskRunners task_runners)
-    : VsyncWaiter(std::move(task_runners)), vsync_callback_(vsync_callback) {
+    : VsyncWaiter(std::move(task_runners), /**use_callback_lock=*/false),
+      vsync_callback_(vsync_callback) {
   FML_DCHECK(vsync_callback_);
 }
 

--- a/shell/platform/fuchsia/flutter/vsync_waiter.cc
+++ b/shell/platform/fuchsia/flutter/vsync_waiter.cc
@@ -22,7 +22,7 @@ VsyncWaiter::VsyncWaiter(AwaitVsyncCallback await_vsync_callback,
                          AwaitVsyncForSecondaryCallbackCallback
                              await_vsync_for_secondary_callback_callback,
                          flutter::TaskRunners task_runners)
-    : flutter::VsyncWaiter(task_runners),
+    : flutter::VsyncWaiter(task_runners, /**use_callback_lock=*/false),
       await_vsync_callback_(await_vsync_callback),
       await_vsync_for_secondary_callback_callback_(
           await_vsync_for_secondary_callback_callback),


### PR DESCRIPTION
In the current implementation, `callback_mutex_` is used to ensure thread safety when accessing `callback_` or `secondary_callbacks_` in `VsyncWaiter`. However, in most platform implementations, `VsyncWaiter::FireCallback` is called on the UI thread, which means that `callback_` and `secondary_callbacks_` will only be accessed on the UI thread. It seems that we can ignore `callback_mutex_` in this case.

fix https://github.com/flutter/flutter/issues/103121

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
