### PR TITLE
Add an option to use a prebuilt impellerc

### DIFF
--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -96,7 +96,7 @@ source_set("fml") {
     "wakeable.h",
   ]
 
-  if (is_mac || is_ios || is_linux) {
+  if (is_mac || is_linux || (is_ios && is_debug)) {
     sources += [ "backtrace.cc" ]
   } else {
     sources += [ "backtrace_stub.cc" ]
@@ -109,12 +109,16 @@ source_set("fml") {
   ]
 
   deps = [
-    "//third_party/abseil-cpp/absl/debugging:symbolize",
     "//third_party/dart/runtime:dart_api",
 
     # These need to be in sync with the Fuchsia buildroot.
     "//third_party/icu",
   ]
+
+  if (is_mac || is_linux || (is_ios && is_debug)) {
+    # This abseil dependency is only used by backtrace.cc.
+    deps += [ "//third_party/abseil-cpp/absl/debugging:symbolize" ]
+  }
 
   configs += [ "//third_party/icu:icu_config" ]
 

--- a/impeller/tools/impeller.gni
+++ b/impeller/tools/impeller.gni
@@ -18,6 +18,11 @@ declare_args() {
 
   # Whether the OpenGLES backend is enabled.
   impeller_enable_opengles = is_mac || is_linux
+
+  # Whether to use a prebuilt impellerc.
+  # If this is the empty string, impellerc will be built.
+  # If it is non-empty, it should be the absolute path to impellerc.
+  impeller_use_prebuilt_impellerc = ""
 }
 
 declare_args() {
@@ -195,6 +200,26 @@ template("embed_blob") {
   }
 }
 
+# Dispatches to the build or prebuilt impellerc depending on the value of
+# the impeller_use_prebuilt_impellerc argument. Forwards all variables to
+# compiled_action_foreach or action_foreach as appropriate.
+template("_impellerc") {
+  if (impeller_use_prebuilt_impellerc == "") {
+    compiled_action_foreach(target_name) {
+      forward_variables_from(invoker, "*")
+      tool = "//flutter/impeller/compiler:impellerc"
+    }
+  } else {
+    action_foreach(target_name) {
+      forward_variables_from(invoker, "*", [ "args" ])
+      script = "//build/gn_run_binary.py"
+      impellerc_path =
+          rebase_path(impeller_use_prebuilt_impellerc, root_build_dir)
+      args = [ impellerc_path ] + invoker.args
+    }
+  }
+}
+
 template("impellerc") {
   assert(defined(invoker.shaders), "Impeller shaders must be specified.")
   assert(defined(invoker.sl_file_extension),
@@ -208,9 +233,7 @@ template("impellerc") {
 
   sl_file_extension = invoker.sl_file_extension
 
-  compiled_action_foreach(target_name) {
-    tool = "//flutter/impeller/compiler:impellerc"
-
+  _impellerc(target_name) {
     sources = invoker.shaders
     if (defined(invoker.intermediates_subdir)) {
       subdir = invoker.intermediates_subdir

--- a/tools/gn
+++ b/tools/gn
@@ -436,6 +436,9 @@ def to_gn_args(args):
     elif os.getenv('FLUTTER_IMPELLER_ENABLE_PLAYGROUND', '0') == '1':
       gn_args['impeller_enable_playground'] = True
 
+    if args.prebuilt_impellerc is not None:
+      gn_args['impeller_use_prebuilt_impellerc'] = args.prebuilt_impellerc
+
     return gn_args
 
 def parse_args(args):
@@ -561,6 +564,9 @@ def parse_args(args):
   # Impeller flags.
   parser.add_argument('--enable-impeller-playground', default=False, action='store_true',
                       help='Whether impeller unit tests run in playground mode.')
+  parser.add_argument('--prebuilt-impellerc', default=None, type=str,
+                      help='Absolute path to a prebuilt impellerc. ' +
+                      'Do not use this outside of CI or with impellerc from a different engine version.')
 
   # Sanitizers.
   parser.add_argument('--asan', default=False, action='store_true')


### PR DESCRIPTION
Building the arm64 iOS simulator and iOS release configurations in CI are very expensive because they can't use goma. This PR removes a dependency on absiel from iOS generally, and adds an option to use a prebuilt impellerc, which we'll use on CI by building impellerc with host_debug first, which can use goma. This should save somewhere between 6-8 minutes on the long-pole build on CI.