### PR TITLE
Memoize Locale.hashCode

### DIFF
--- a/lib/ui/fixtures/ui_test.dart
+++ b/lib/ui/fixtures/ui_test.dart
@@ -450,6 +450,13 @@ void hooksTests() {
     }
   });
 
+  test('deprecated region equals', () {
+    const Locale x = Locale('en', 'ZR');
+    const Locale y = Locale('en', 'CD');
+    expectEquals(x, y);
+    expectEquals(x.countryCode, y.countryCode);
+  });
+
   test('Window padding/insets/viewPadding/systemGestureInsets', () {
     _callHook(
       '_updateWindowMetrics',

--- a/lib/ui/fixtures/ui_test.dart
+++ b/lib/ui/fixtures/ui_test.dart
@@ -451,6 +451,7 @@ void hooksTests() {
   });
 
   test('deprecated region equals', () {
+    // These are equal because ZR is deprecated and was mapped to CD.
     const Locale x = Locale('en', 'ZR');
     const Locale y = Locale('en', 'CD');
     expectEquals(x, y);

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -2019,17 +2019,23 @@ class Locale {
     if (other is! Locale) {
       return false;
     }
-    final String? countryCode = _countryCode;
+    final String? thisCountryCode = countryCode;
     final String? otherCountryCode = other.countryCode;
     return other.languageCode == languageCode
         && other.scriptCode == scriptCode // scriptCode cannot be ''
-        && (other.countryCode == countryCode // Treat '' as equal to null.
-            || otherCountryCode != null && otherCountryCode.isEmpty && countryCode == null
-            || countryCode != null && countryCode.isEmpty && other.countryCode == null);
+        && (other.countryCode == thisCountryCode // Treat '' as equal to null.
+            || otherCountryCode != null && otherCountryCode.isEmpty && thisCountryCode == null
+            || thisCountryCode != null && thisCountryCode.isEmpty && other.countryCode == null);
   }
 
   @override
-  int get hashCode => hashValues(languageCode, scriptCode, countryCode == '' ? null : countryCode);
+  int get hashCode => _hashCode[this] ??= hashValues(
+        languageCode,
+        scriptCode,
+        countryCode == '' ? null : countryCode,
+      );
+  // Memoize this value since languageCode and countryCode require lookups.
+  static final Expando<int> _hashCode = Expando<int>();
 
   static Locale? _cachedLocale;
   static String? _cachedLocaleString;

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -2034,7 +2034,7 @@ class Locale {
         scriptCode,
         countryCode == '' ? null : countryCode,
       );
-  // Memoize this value since languageCode and countryCode require lookups.
+  // Memoize hashCode since languageCode and countryCode require lookups.
   static final Expando<int> _hashCode = Expando<int>();
 
   static Locale? _cachedLocale;


### PR DESCRIPTION
1) Fixed bug with `Locale` where deprecated countries would return all the same data, but the would not be considered `==`
2) Memoized Locale.hashCode

I made this change because `Locale` is sometimes used as a key into a map, as it is in Flutter gallery.  When it is used in a Map it's `hashCode` is calculated, which is based on the country code and the language code, which requires lookups into these maps.

The reason I identified this as a potential performance fix is that I setup Flutter to continuously build frames and navigated through the Material section of Flutter gallery and noticed that `Locale.hashCode` shows up pretty high.  I also saw other Flutter users in Google using Locale as a key.
<img width="810" alt="Screen Shot 2022-05-03 at 10 47 11 AM" src="https://user-images.githubusercontent.com/30870216/166851999-b39ee1f9-b303-4e96-aa6f-b37a4b5839c5.png">

In local benchmarks on iOS this the following benchmark was 70% faster:
```dart
    int count = 100000;
    const Locale locale = Locale('en', 'US');
    {
      int tally = 0;
      var start = DateTime.now();
      for (int i = 0; i < count; ++i) {        
        tally += locale.hashCode;
      }
      print(tally);
      print('us: ${DateTime.now().difference(start).inMicroseconds}');
    }
```

Note:
1) I don't expect this to make a difference in `customer: money`.
1) This doesn't make the first calculation of hashCode faster, which might be used more.  I have ideas on that but I don't know if it's worth implementing.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
