### PR TITLE
Use empty in place of size checks vs 0

### DIFF
--- a/assets/asset_manager.cc
+++ b/assets/asset_manager.cc
@@ -60,7 +60,7 @@ std::deque<std::unique_ptr<AssetResolver>> AssetManager::TakeResolvers() {
 // |AssetResolver|
 std::unique_ptr<fml::Mapping> AssetManager::GetAsMapping(
     const std::string& asset_name) const {
-  if (asset_name.size() == 0) {
+  if (asset_name.empty()) {
     return nullptr;
   }
   TRACE_EVENT1("flutter", "AssetManager::GetAsMapping", "name",
@@ -80,7 +80,7 @@ std::vector<std::unique_ptr<fml::Mapping>> AssetManager::GetAsMappings(
     const std::string& asset_pattern,
     const std::optional<std::string>& subdir) const {
   std::vector<std::unique_ptr<fml::Mapping>> mappings;
-  if (asset_pattern.size() == 0) {
+  if (asset_pattern.empty()) {
     return mappings;
   }
   TRACE_EVENT1("flutter", "AssetManager::GetAsMappings", "pattern",
@@ -96,7 +96,7 @@ std::vector<std::unique_ptr<fml::Mapping>> AssetManager::GetAsMappings(
 
 // |AssetResolver|
 bool AssetManager::IsValid() const {
-  return resolvers_.size() > 0;
+  return !resolvers_.empty();
 }
 
 // |AssetResolver|

--- a/common/graphics/persistent_cache.cc
+++ b/common/graphics/persistent_cache.cc
@@ -332,7 +332,7 @@ sk_sp<SkData> PersistentCache::load(const SkData& key) {
     return nullptr;
   }
   auto file_name = SkKeyToFilePath(key);
-  if (file_name.size() == 0) {
+  if (file_name.empty()) {
     return nullptr;
   }
   auto result =
@@ -405,7 +405,7 @@ void PersistentCache::store(const SkData& key, const SkData& data) {
 
   auto file_name = SkKeyToFilePath(key);
 
-  if (file_name.size() == 0) {
+  if (file_name.empty()) {
     return;
   }
 

--- a/flow/skia_gpu_object.h
+++ b/flow/skia_gpu_object.h
@@ -89,7 +89,7 @@ class UnrefQueue : public fml::RefCountedThreadSafe<UnrefQueue<T>> {
       skia_object->unref();
     }
 
-    if (context && skia_objects.size() > 0) {
+    if (context && !skia_objects.empty()) {
       context->performDeferredCleanup(std::chrono::milliseconds(0));
     }
   }

--- a/fml/concurrent_message_loop.cc
+++ b/fml/concurrent_message_loop.cc
@@ -78,7 +78,7 @@ void ConcurrentMessageLoop::WorkerMain() {
   while (true) {
     std::unique_lock lock(tasks_mutex_);
     tasks_condition_.wait(lock, [&]() {
-      return tasks_.size() > 0 || shutdown_ || HasThreadTasksLocked();
+      return !tasks_.empty() || shutdown_ || HasThreadTasksLocked();
     });
 
     // Shutdown cannot be read with the task mutex unlocked.
@@ -86,7 +86,7 @@ void ConcurrentMessageLoop::WorkerMain() {
     fml::closure task;
     std::vector<fml::closure> thread_tasks;
 
-    if (tasks_.size() != 0) {
+    if (!tasks_.empty()) {
       task = tasks_.front();
       tasks_.pop();
     }

--- a/fml/file.cc
+++ b/fml/file.cc
@@ -37,7 +37,7 @@ fml::UniqueFD CreateDirectory(const fml::UniqueFD& base_directory,
     return {};
   }
 
-  if (components.size() == 0) {
+  if (components.empty()) {
     return {};
   }
 

--- a/fml/mapping.cc
+++ b/fml/mapping.cc
@@ -24,7 +24,7 @@ std::unique_ptr<FileMapping> FileMapping::CreateReadOnly(
 std::unique_ptr<FileMapping> FileMapping::CreateReadOnly(
     const fml::UniqueFD& base_fd,
     const std::string& sub_path) {
-  if (sub_path.size() != 0) {
+  if (!sub_path.empty()) {
     return CreateReadOnly(
         OpenFile(base_fd, sub_path.c_str(), false, FilePermission::kRead), "");
   }
@@ -48,7 +48,7 @@ std::unique_ptr<FileMapping> FileMapping::CreateReadExecute(
 std::unique_ptr<FileMapping> FileMapping::CreateReadExecute(
     const fml::UniqueFD& base_fd,
     const std::string& sub_path) {
-  if (sub_path.size() != 0) {
+  if (!sub_path.empty()) {
     return CreateReadExecute(
         OpenFile(base_fd, sub_path.c_str(), false, FilePermission::kRead), "");
   }

--- a/fml/platform/posix/paths_posix.cc
+++ b/fml/platform/posix/paths_posix.cc
@@ -27,7 +27,7 @@ std::string GetCurrentDirectory() {
 }  // namespace
 
 std::string AbsolutePath(const std::string& path) {
-  if (path.size() > 0) {
+  if (!path.empty()) {
     if (path[0] == '/') {
       // Path is already absolute.
       return path;

--- a/fml/platform/win/file_win.cc
+++ b/fml/platform/win/file_win.cc
@@ -40,7 +40,7 @@ static bool IsAbsolutePath(const char* path) {
   }
 
   auto wpath = Utf8ToWideString({path});
-  if (wpath.size() == 0) {
+  if (wpath.empty()) {
     return false;
   }
 
@@ -107,7 +107,7 @@ static DWORD GetFileAttributesForUtf8Path(const fml::UniqueFD& base_directory,
 std::string CreateTemporaryDirectory() {
   // Get the system temporary directory.
   auto temp_dir_container = GetTemporaryDirectoryPath();
-  if (temp_dir_container.size() == 0) {
+  if (temp_dir_container.empty()) {
     FML_DLOG(ERROR) << "Could not get system temporary directory.";
     return {};
   }
@@ -164,7 +164,7 @@ fml::UniqueFD OpenFile(const char* path,
 
   auto file_name = Utf8ToWideString({path});
 
-  if (file_name.size() == 0) {
+  if (file_name.empty()) {
     return {};
   }
 
@@ -207,7 +207,7 @@ fml::UniqueFD OpenDirectory(const char* path,
 
   auto file_name = Utf8ToWideString({path});
 
-  if (file_name.size() == 0) {
+  if (file_name.empty()) {
     return {};
   }
 

--- a/fml/platform/win/paths_win.cc
+++ b/fml/platform/win/paths_win.cc
@@ -19,7 +19,7 @@ constexpr char kFileURLPrefix[] = "file:///";
 constexpr size_t kFileURLPrefixLength = sizeof(kFileURLPrefix) - 1;
 
 size_t RootLength(const std::string& path) {
-  if (path.size() == 0)
+  if (path.empty())
     return 0;
   if (path[0] == '/')
     return 1;

--- a/lib/ui/dart_runtime_hooks.cc
+++ b/lib/ui/dart_runtime_hooks.cc
@@ -187,7 +187,7 @@ void Logger_PrintString(Dart_NativeArguments args) {
 
   if (dart::bin::ShouldCaptureStdout()) {
     std::stringstream stream;
-    if (tag.size() > 0) {
+    if (!tag.empty()) {
       stream << tag << ": ";
     }
     stream << message;

--- a/lib/ui/ui_dart_state.cc
+++ b/lib/ui/ui_dart_state.cc
@@ -197,14 +197,14 @@ void UIDartState::LogMessage(const std::string& tag,
                         (int)message.size(), message.c_str());
 #elif defined(FML_OS_IOS)
     std::stringstream stream;
-    if (tag.size() > 0) {
+    if (!tag.empty()) {
       stream << tag << ": ";
     }
     stream << message;
     std::string log = stream.str();
     syslog(1 /* LOG_ALERT */, "%.*s", (int)log.size(), log.c_str());
 #else
-    if (tag.size() > 0) {
+    if (!tag.empty()) {
       std::cout << tag << ": ";
     }
     std::cout << message << std::endl;

--- a/runtime/dart_lifecycle_unittests.cc
+++ b/runtime/dart_lifecycle_unittests.cc
@@ -48,7 +48,7 @@ static std::shared_ptr<DartIsolate> CreateAndRunRootIsolate(
     const DartVMData& vm,
     fml::RefPtr<fml::TaskRunner> task_runner,
     std::string entrypoint) {
-  FML_CHECK(entrypoint.size() > 0);
+  FML_CHECK(!entrypoint.empty());
   TaskRunners runners("io.flutter.test", task_runner, task_runner, task_runner,
                       task_runner);
 

--- a/runtime/dart_snapshot.cc
+++ b/runtime/dart_snapshot.cc
@@ -63,7 +63,7 @@ static std::shared_ptr<const fml::Mapping> SearchMapping(
   }
 
   // Attempt to open file at path specified.
-  if (file_path.size() > 0) {
+  if (!file_path.empty()) {
     if (auto file_mapping = GetFileMapping(file_path, is_executable)) {
       return file_mapping;
     }

--- a/runtime/service_protocol.cc
+++ b/runtime/service_protocol.cc
@@ -193,7 +193,7 @@ bool ServiceProtocol::HandleMessage(std::string_view method,
 
   fml::SharedLock lock(*handlers_mutex_);
 
-  if (handlers_.size() == 0) {
+  if (handlers_.empty()) {
     WriteServerErrorResponse(response,
                              "There are no running service protocol handlers.");
     return false;

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -107,7 +107,7 @@ void PerformInitializationTasks(Settings& settings) {
     }
 
     if (settings.icu_initialization_required) {
-      if (settings.icu_data_path.size() != 0) {
+      if (!settings.icu_data_path.empty()) {
         fml::icu::InitializeICU(settings.icu_data_path);
       } else if (settings.icu_mapper) {
         fml::icu::InitializeICUFromMapping(settings.icu_mapper());

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -237,7 +237,7 @@ static void ValidateDestroyPlatformView(Shell* shell) {
 }
 
 static std::string CreateFlagsString(std::vector<const char*>& flags) {
-  if (flags.size() == 0) {
+  if (flags.empty()) {
     return "";
   }
   std::string flags_string = flags[0];
@@ -649,7 +649,7 @@ TEST_F(ShellTest, ReportTimingsIsCalled) {
   DestroyShell(std::move(shell));
 
   fml::TimePoint finish = fml::TimePoint::Now();
-  ASSERT_TRUE(timestamps.size() > 0);
+  ASSERT_TRUE(!timestamps.empty());
   ASSERT_TRUE(timestamps.size() % FrameTiming::kCount == 0);
   std::vector<FrameTiming> timings(timestamps.size() / FrameTiming::kCount);
 

--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -377,11 +377,11 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line) {
       FlagForSwitch(Switch::IsolateSnapshotInstructions),
       &isolate_snapshot_instr_filename);
 
-  if (aot_shared_library_name.size() > 0) {
+  if (!aot_shared_library_name.empty()) {
     for (std::string_view name : aot_shared_library_name) {
       settings.application_library_path.emplace_back(name);
     }
-  } else if (snapshot_asset_path.size() > 0) {
+  } else if (!snapshot_asset_path.empty()) {
     settings.vm_snapshot_data_path =
         fml::paths::JoinPaths({snapshot_asset_path, vm_snapshot_data_filename});
     settings.vm_snapshot_instr_path = fml::paths::JoinPaths(

--- a/shell/platform/android/android_shell_holder.cc
+++ b/shell/platform/android/android_shell_holder.cc
@@ -337,13 +337,13 @@ std::optional<RunConfiguration> AndroidShellHolder::BuildRunConfiguration(
                           std::move(asset_manager));
 
   {
-    if ((entrypoint.size() > 0) && (libraryUrl.size() > 0)) {
+    if (!entrypoint.empty() && !libraryUrl.empty()) {
       config.SetEntrypointAndLibrary(std::move(entrypoint),
                                      std::move(libraryUrl));
-    } else if (entrypoint.size() > 0) {
+    } else if (!entrypoint.empty()) {
       config.SetEntrypoint(std::move(entrypoint));
     }
-    if (entrypoint_args.size() > 0) {
+    if (!entrypoint_args.empty()) {
       config.SetEntrypointArgs(std::move(entrypoint_args));
     }
   }

--- a/shell/platform/android/external_view_embedder/external_view_embedder.cc
+++ b/shell/platform/android/external_view_embedder/external_view_embedder.cc
@@ -242,7 +242,7 @@ PostPrerollResult AndroidExternalViewEmbedder::PostPrerollAction(
 }
 
 bool AndroidExternalViewEmbedder::FrameHasPlatformLayers() {
-  return composition_order_.size() > 0;
+  return !composition_order_.empty();
 }
 
 // |ExternalViewEmbedder|

--- a/shell/platform/android/external_view_embedder/surface_pool.cc
+++ b/shell/platform/android/external_view_embedder/surface_pool.cc
@@ -80,7 +80,7 @@ void SurfacePool::RecycleLayers() {
 
 bool SurfacePool::HasLayers() {
   std::lock_guard lock(mutex_);
-  return layers_.size() > 0;
+  return !layers_.empty();
 }
 
 void SurfacePool::DestroyLayers(
@@ -91,7 +91,7 @@ void SurfacePool::DestroyLayers(
 
 void SurfacePool::DestroyLayersLocked(
     std::shared_ptr<PlatformViewAndroidJNI> jni_facade) {
-  if (layers_.size() == 0) {
+  if (layers_.empty()) {
     return;
   }
   jni_facade->FlutterViewDestroyOverlaySurfaces();

--- a/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate.cc
+++ b/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate.cc
@@ -209,12 +209,12 @@ void PlatformViewAndroidDelegate::UpdateSemantics(
 
     // Calling NewDirectByteBuffer in API level 22 and below with a size of zero
     // will cause a JNI crash.
-    if (actions_buffer.size() > 0) {
+    if (!actions_buffer.empty()) {
       jni_facade_->FlutterViewUpdateCustomAccessibilityActions(actions_buffer,
                                                                action_strings);
     }
 
-    if (buffer.size() > 0) {
+    if (!buffer.empty()) {
       jni_facade_->FlutterViewUpdateSemantics(buffer, strings,
                                               string_attribute_args);
     }

--- a/shell/platform/common/accessibility_bridge.cc
+++ b/shell/platform/common/accessibility_bridge.cc
@@ -263,7 +263,7 @@ void AccessibilityBridge::SetRoleFromFlutterUpdate(ui::AXNodeData& node_data,
   }
   // If the state cannot be derived from the flutter flags, we fallback to group
   // or static text.
-  if (node.children_in_traversal_order.size() == 0) {
+  if (node.children_in_traversal_order.empty()) {
     node_data.role = ax::mojom::Role::kStaticText;
   } else {
     node_data.role = ax::mojom::Role::kGroup;
@@ -346,7 +346,7 @@ void AccessibilityBridge::SetBooleanAttributesFromFlutterUpdate(
       actions & FlutterSemanticsAction::kFlutterSemanticsActionTap);
   // TODO(chunhtai): figure out if there is a node that does not clip overflow.
   node_data.AddBoolAttribute(ax::mojom::BoolAttribute::kClipsChildren,
-                             node.children_in_traversal_order.size() != 0);
+                             !node.children_in_traversal_order.empty());
   node_data.AddBoolAttribute(
       ax::mojom::BoolAttribute::kSelected,
       flags & FlutterSemanticsFlag::kFlutterSemanticsFlagIsSelected);

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -66,7 +66,7 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle) {
     // TODO(cbracken): replace this with os_log-based approach.
     // https://github.com/flutter/flutter/issues/44030
     std::stringstream stream;
-    if (tag.size() > 0) {
+    if (!tag.empty()) {
       stream << tag << ": ";
     }
     stream << message;
@@ -78,7 +78,7 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle) {
   // defaults.
 
   // Flutter ships the ICU data file in the bundle of the engine. Look for it there.
-  if (settings.icu_data_path.size() == 0) {
+  if (settings.icu_data_path.empty()) {
     NSString* icuDataPath = [engineBundle pathForResource:@"icudtl" ofType:@"dat"];
     if (icuDataPath.length > 0) {
       settings.icu_data_path = icuDataPath.UTF8String;
@@ -94,7 +94,7 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle) {
     }
 
     // No application bundle specified.  Try a known location from the main bundle's Info.plist.
-    if (settings.application_library_path.size() == 0) {
+    if (settings.application_library_path.empty()) {
       NSString* libraryName = [mainBundle objectForInfoDictionaryKey:@"FLTLibraryPath"];
       NSString* libraryPath = [mainBundle pathForResource:libraryName ofType:@""];
       if (libraryPath.length > 0) {
@@ -107,7 +107,7 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle) {
 
     // In case the application bundle is still not specified, look for the App.framework in the
     // Frameworks directory.
-    if (settings.application_library_path.size() == 0) {
+    if (settings.application_library_path.empty()) {
       NSString* applicationFrameworkPath = [mainBundle pathForResource:@"Frameworks/App.framework"
                                                                 ofType:@""];
       if (applicationFrameworkPath.length > 0) {
@@ -121,7 +121,7 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle) {
   }
 
   // Checks to see if the flutter assets directory is already present.
-  if (settings.assets_path.size() == 0) {
+  if (settings.assets_path.empty()) {
     NSString* assetsName = [FlutterDartProject flutterAssetsName:bundle];
     NSString* assetsPath = [bundle pathForResource:assetsName ofType:@""];
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -255,7 +255,7 @@ void FlutterPlatformViewsController::CancelFrame() {
 // Make this method check if there are pending view operations instead.
 // Also rename it to `HasPendingViewOperations`.
 bool FlutterPlatformViewsController::HasPlatformViewThisOrNextFrame() {
-  return composition_order_.size() > 0 || active_composition_order_.size() > 0;
+  return !composition_order_.empty() || !active_composition_order_.empty();
 }
 
 const int FlutterPlatformViewsController::kDefaultMergedLeaseDuration;

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -104,7 +104,7 @@ void AccessibilityBridge::UpdateSemantics(flutter::SemanticsNodeUpdates nodes,
       [newChildren addObject:child];
     }
     object.children = newChildren;
-    if (node.customAccessibilityActions.size() > 0) {
+    if (!node.customAccessibilityActions.empty()) {
       NSMutableArray<FlutterCustomAccessibilityAction*>* accessibilityCustomActions =
           [[[NSMutableArray alloc] init] autorelease];
       for (int32_t action_id : node.customAccessibilityActions) {

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -282,7 +282,7 @@ static void OnPlatformMessage(const FlutterPlatformMessage* message, FlutterEngi
   flutterArguments.assets_path = _project.assetsPath.UTF8String;
   flutterArguments.icu_data_path = _project.ICUDataPath.UTF8String;
   flutterArguments.command_line_argc = static_cast<int>(argv.size());
-  flutterArguments.command_line_argv = argv.size() > 0 ? argv.data() : nullptr;
+  flutterArguments.command_line_argv = argv.empty() ? nullptr : argv.data();
   flutterArguments.platform_message_callback = (FlutterPlatformMessageCallback)OnPlatformMessage;
   flutterArguments.update_semantics_node_callback = [](const FlutterSemanticsNode* node,
                                                        void* user_data) {

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -1499,7 +1499,7 @@ FlutterEngineResult FlutterEngineInitialize(size_t version,
 
   if (SAFE_ACCESS(args, custom_dart_entrypoint, nullptr) != nullptr) {
     auto dart_entrypoint = std::string{args->custom_dart_entrypoint};
-    if (dart_entrypoint.size() != 0) {
+    if (!dart_entrypoint.empty()) {
       run_configuration.SetEntrypoint(std::move(dart_entrypoint));
     }
   }
@@ -2257,7 +2257,7 @@ static bool DispatchJSONPlatformMessage(FLUTTER_API_SYMBOL(FlutterEngine)
                                             engine,
                                         rapidjson::Document document,
                                         const std::string& channel_name) {
-  if (channel_name.size() == 0) {
+  if (channel_name.empty()) {
     return false;
   }
 

--- a/shell/platform/embedder/embedder_render_target_cache.cc
+++ b/shell/platform/embedder/embedder_render_target_cache.cc
@@ -24,7 +24,7 @@ EmbedderRenderTargetCache::GetExistingTargetsInCache(
     }
     auto& compatible_targets =
         cached_render_targets_[external_view->CreateRenderTargetDescriptor()];
-    if (compatible_targets.size() == 0) {
+    if (compatible_targets.empty()) {
       unmatched_identifiers.insert(view.first);
     } else {
       std::unique_ptr<EmbedderRenderTarget> target =

--- a/shell/platform/embedder/tests/embedder_config_builder.cc
+++ b/shell/platform/embedder/tests/embedder_config_builder.cc
@@ -265,14 +265,14 @@ void EmbedderConfigBuilder::SetLocalizationCallbackHooks() {
 }
 
 void EmbedderConfigBuilder::SetExecutableName(std::string executable_name) {
-  if (executable_name.size() == 0) {
+  if (executable_name.empty()) {
     return;
   }
   command_line_arguments_[0] = std::move(executable_name);
 }
 
 void EmbedderConfigBuilder::SetDartEntrypoint(std::string entrypoint) {
-  if (entrypoint.size() == 0) {
+  if (entrypoint.empty()) {
     return;
   }
 
@@ -281,7 +281,7 @@ void EmbedderConfigBuilder::SetDartEntrypoint(std::string entrypoint) {
 }
 
 void EmbedderConfigBuilder::AddCommandLineArgument(std::string arg) {
-  if (arg.size() == 0) {
+  if (arg.empty()) {
     return;
   }
 
@@ -289,7 +289,7 @@ void EmbedderConfigBuilder::AddCommandLineArgument(std::string arg) {
 }
 
 void EmbedderConfigBuilder::AddDartEntrypointArgument(std::string arg) {
-  if (arg.size() == 0) {
+  if (arg.empty()) {
     return;
   }
 
@@ -394,7 +394,7 @@ UniqueEngine EmbedderConfigBuilder::SetupEngine(bool run) const {
     args.push_back(arg.c_str());
   }
 
-  if (args.size() > 0) {
+  if (!args.empty()) {
     project_args.command_line_argv = args.data();
     project_args.command_line_argc = args.size();
   } else {
@@ -411,7 +411,7 @@ UniqueEngine EmbedderConfigBuilder::SetupEngine(bool run) const {
     dart_args.push_back(arg.c_str());
   }
 
-  if (dart_args.size() > 0) {
+  if (!dart_args.empty()) {
     project_args.dart_entrypoint_argv = dart_args.data();
     project_args.dart_entrypoint_argc = dart_args.size();
   } else {

--- a/shell/platform/embedder/tests/embedder_unittests_gl.cc
+++ b/shell/platform/embedder/tests/embedder_unittests_gl.cc
@@ -2995,7 +2995,7 @@ TEST_F(EmbedderTest, CompositorRenderTargetsAreInStableOrder) {
       [&](const FlutterLayer** layers, size_t layers_count) {
         ASSERT_EQ(layers_count, 20u);
 
-        if (first_frame_backing_store_user_data.size() == 0u) {
+        if (first_frame_backing_store_user_data.empty()) {
           for (size_t i = 0; i < layers_count; ++i) {
             if (layers[i]->type == kFlutterLayerContentTypeBackingStore) {
               first_frame_backing_store_user_data.push_back(

--- a/shell/platform/fuchsia/flutter/component_v1.cc
+++ b/shell/platform/fuchsia/flutter/component_v1.cc
@@ -418,7 +418,7 @@ ComponentV1::ComponentV1(
 
   settings_.log_message_callback = [](const std::string& tag,
                                       const std::string& message) {
-    if (tag.size() > 0) {
+    if (!tag.empty()) {
       std::cout << tag << ": ";
     }
     std::cout << message << std::endl;
@@ -519,7 +519,7 @@ void ComponentV1::OnEngineTerminate(const Engine* shell_holder) {
 
   shell_holders_.erase(found);
 
-  if (shell_holders_.size() == 0) {
+  if (shell_holders_.empty()) {
     FML_VLOG(-1) << "Killing component because all shell holders have been "
                     "terminated.";
     Kill();

--- a/shell/platform/fuchsia/flutter/component_v2.cc
+++ b/shell/platform/fuchsia/flutter/component_v2.cc
@@ -482,7 +482,7 @@ ComponentV2::ComponentV2(
 
   settings_.log_message_callback = [](const std::string& tag,
                                       const std::string& message) {
-    if (tag.size() > 0) {
+    if (!tag.empty()) {
       std::cout << tag << ": ";
     }
     std::cout << message << std::endl;
@@ -615,7 +615,7 @@ void ComponentV2::OnEngineTerminate(const Engine* shell_holder) {
 
   shell_holders_.erase(found);
 
-  if (shell_holders_.size() == 0) {
+  if (shell_holders_.empty()) {
     FML_VLOG(-1) << "Killing component because all shell holders have been "
                     "terminated.";
     Kill();

--- a/shell/platform/fuchsia/flutter/engine.cc
+++ b/shell/platform/fuchsia/flutter/engine.cc
@@ -898,7 +898,7 @@ void Engine::WarmupSkps(
       skp_mappings = asset_manager->GetAsMappings(".*\\.skp$", "shaders");
     }
 
-    if (skp_mappings.size() == 0) {
+    if (skp_mappings.empty()) {
       FML_LOG(WARNING)
           << "Engine::WarmupSkps got zero SKP mappings, returning early";
       completion_callback(0);

--- a/shell/platform/fuchsia/flutter/platform_view.cc
+++ b/shell/platform/fuchsia/flutter/platform_view.cc
@@ -128,7 +128,7 @@ PlatformView::PlatformView(
       return;
     }
 
-    if (events.size() == 0) {
+    if (events.empty()) {
       return;  // No work, bounce out.
     }
 

--- a/shell/platform/fuchsia/flutter/pointer_delegate.cc
+++ b/shell/platform/fuchsia/flutter/pointer_delegate.cc
@@ -62,8 +62,7 @@ bool HasValidatedMouseSample(const fup_MouseEvent& event) {
   const auto& sample = event.pointer_sample();
   FML_DCHECK(sample.has_device_id()) << "API guarantee";
   FML_DCHECK(sample.has_position_in_viewport()) << "API guarantee";
-  FML_DCHECK(!sample.has_pressed_buttons() ||
-             sample.pressed_buttons().size() > 0)
+  FML_DCHECK(!sample.has_pressed_buttons() || !sample.pressed_buttons().empty())
       << "API guarantee";
 
   return true;

--- a/shell/platform/fuchsia/flutter/runner.cc
+++ b/shell/platform/fuchsia/flutter/runner.cc
@@ -168,7 +168,7 @@ Runner::Runner(fml::RefPtr<fml::TaskRunner> task_runner,
         dart_utils::VMServiceObject::LazyEntryVector out;
         dart_utils::VMServiceObject().GetContents(&out);
         std::string name = "";
-        if (out.size() > 0) {
+        if (!out.empty()) {
           name = out[0].name;
         }
         inspector.GetRoot().CreateString("vm_service_port", name, &inspector);

--- a/shell/platform/glfw/client_wrapper/flutter_engine.cc
+++ b/shell/platform/glfw/client_wrapper/flutter_engine.cc
@@ -32,7 +32,7 @@ bool FlutterEngine::Start(const std::string& icu_data_path,
   std::transform(
       arguments.begin(), arguments.end(), std::back_inserter(engine_switches),
       [](const std::string& arg) -> const char* { return arg.c_str(); });
-  if (engine_switches.size() > 0) {
+  if (!engine_switches.empty()) {
     c_engine_properties.switches = &engine_switches[0];
     c_engine_properties.switches_count = engine_switches.size();
   }

--- a/shell/platform/glfw/client_wrapper/flutter_window_controller.cc
+++ b/shell/platform/glfw/client_wrapper/flutter_window_controller.cc
@@ -54,7 +54,7 @@ bool FlutterWindowController::CreateWindow(
   std::transform(
       arguments.begin(), arguments.end(), std::back_inserter(engine_switches),
       [](const std::string& arg) -> const char* { return arg.c_str(); });
-  if (engine_switches.size() > 0) {
+  if (!engine_switches.empty()) {
     c_engine_properties.switches = &engine_switches[0];
     c_engine_properties.switches_count = engine_switches.size();
   }

--- a/shell/platform/windows/client_wrapper/flutter_engine.cc
+++ b/shell/platform/windows/client_wrapper/flutter_engine.cc
@@ -28,7 +28,7 @@ FlutterEngine::FlutterEngine(const DartProject& project) {
   c_engine_properties.dart_entrypoint_argc =
       static_cast<int>(entrypoint_argv.size());
   c_engine_properties.dart_entrypoint_argv =
-      entrypoint_argv.size() > 0 ? entrypoint_argv.data() : nullptr;
+      entrypoint_argv.empty() ? nullptr : entrypoint_argv.data();
 
   engine_ = FlutterDesktopEngineCreate(&c_engine_properties);
 

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -258,10 +258,10 @@ bool FlutterWindowsEngine::RunWithEntrypoint(const char* entrypoint) {
   args.assets_path = assets_path_string.c_str();
   args.icu_data_path = icu_path_string.c_str();
   args.command_line_argc = static_cast<int>(argv.size());
-  args.command_line_argv = argv.size() > 0 ? argv.data() : nullptr;
+  args.command_line_argv = argv.empty() ? nullptr : argv.data();
   args.dart_entrypoint_argc = static_cast<int>(entrypoint_argv.size());
   args.dart_entrypoint_argv =
-      entrypoint_argv.size() > 0 ? entrypoint_argv.data() : nullptr;
+      entrypoint_argv.empty() ? nullptr : entrypoint_argv.data();
   args.platform_message_callback =
       [](const FlutterPlatformMessage* engine_message,
          void* user_data) -> void {

--- a/shell/platform/windows/system_utils_win32.cc
+++ b/shell/platform/windows/system_utils_win32.cc
@@ -50,7 +50,7 @@ std::vector<std::wstring> GetPreferredLanguages() {
     }
     // Read the next null-terminated language.
     std::wstring language(buffer.c_str() + start);
-    if (language.size() == 0) {
+    if (language.empty()) {
       break;
     }
     languages.push_back(language);

--- a/shell/testing/tester_main.cc
+++ b/shell/testing/tester_main.cc
@@ -361,18 +361,18 @@ int main(int argc, char* argv[]) {
   }
 
   auto settings = flutter::SettingsFromCommandLine(command_line);
-  if (command_line.positional_args().size() > 0) {
+  if (!command_line.positional_args().empty()) {
     // The tester may not use the switch for the main dart file path. Specifying
     // it as a positional argument instead.
     settings.application_kernel_asset = command_line.positional_args()[0];
   }
 
-  if (settings.application_kernel_asset.size() == 0) {
+  if (settings.application_kernel_asset.empty()) {
     FML_LOG(ERROR) << "Dart kernel file not specified.";
     return EXIT_FAILURE;
   }
 
-  if (settings.icu_data_path.size() == 0) {
+  if (settings.icu_data_path.empty()) {
     settings.icu_data_path = "icudtl.dat";
   }
 
@@ -381,7 +381,7 @@ int main(int argc, char* argv[]) {
 
   settings.log_message_callback = [](const std::string& tag,
                                      const std::string& message) {
-    if (tag.size() > 0) {
+    if (!tag.empty()) {
       std::cout << tag << ": ";
     }
     std::cout << message << std::endl;

--- a/third_party/accessibility/ax/ax_event_generator.cc
+++ b/third_party/accessibility/ax/ax_event_generator.cc
@@ -873,7 +873,7 @@ void AXEventGenerator::PostprocessEvents() {
 
     // If this was the only event, remove the node entirely from the
     // tree events.
-    if (node_events.size() == 0)
+    if (node_events.empty())
       iter = tree_events_.erase(iter);
     else
       ++iter;

--- a/third_party/tonic/filesystem/filesystem/path_posix.cc
+++ b/third_party/tonic/filesystem/filesystem/path_posix.cc
@@ -145,7 +145,7 @@ std::string SimplifyPath(std::string path) {
 }
 
 std::string AbsolutePath(const std::string& path) {
-  if (path.size() > 0) {
+  if (!path.empty()) {
     if (path[0] == '/') {
       // Path is already absolute.
       return path;

--- a/third_party/tonic/filesystem/filesystem/path_win.cc
+++ b/third_party/tonic/filesystem/filesystem/path_win.cc
@@ -22,7 +22,7 @@ namespace filesystem {
 namespace {
 
 size_t RootLength(const std::string& path) {
-  if (path.size() == 0)
+  if (path.empty())
     return 0;
   if (path[0] == '/')
     return 1;

--- a/vulkan/vulkan_swapchain.cc
+++ b/vulkan/vulkan_swapchain.cc
@@ -257,7 +257,7 @@ bool VulkanSwapchain::CreateSwapchainImages(GrDirectContext* skia_context,
                                             VkImageUsageFlags usage_flags) {
   std::vector<VkImage> images = GetImages();
 
-  if (images.size() == 0) {
+  if (images.empty()) {
     return false;
   }
 


### PR DESCRIPTION
While size() on std::string, std::vector, std::deque, std::map are
specified to be a constant time lookup as of C++11, this improves
readability of checks for empty strings and containers, plus it's very
marginally shorter.

No test changes since there are no semantic changes.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
