### PR TITLE
Do not pass nullable parameters of simple types to Tonic-wrapped native functions

### DIFF
--- a/lib/ui/natives.dart
+++ b/lib/ui/natives.dart
@@ -24,17 +24,17 @@ class DartPluginRegistrant {
 }
 
 // Corelib 'print' implementation.
-void _print(Object? arg) {
-  _Logger._printString(arg.toString());
+void _print(String arg) {
+  _Logger._printString(arg);
 }
 
-void _printDebug(Object? arg) {
-  _Logger._printDebugString(arg.toString());
+void _printDebug(String arg) {
+  _Logger._printDebugString(arg);
 }
 
 class _Logger {
-  static void _printString(String? s) native 'Logger_PrintString';
-  static void _printDebugString(String? s) native 'Logger_PrintDebugString';
+  static void _printString(String s) native 'Logger_PrintString';
+  static void _printDebugString(String s) native 'Logger_PrintDebugString';
 }
 
 // If we actually run on big endian machines, we'll need to do something smarter

--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -913,7 +913,7 @@ class SemanticsUpdateBuilder extends NativeFieldWrapperClass1 {
       decreasedValueAttributes,
       hint,
       hintAttributes,
-      tooltip,
+      tooltip ?? '',
       textDirection != null ? textDirection.index + 1 : 0,
       transform,
       childrenInTraversalOrder,
@@ -951,7 +951,7 @@ class SemanticsUpdateBuilder extends NativeFieldWrapperClass1 {
     List<StringAttribute> decreasedValueAttributes,
     String hint,
     List<StringAttribute> hintAttributes,
-    String? tooltip,
+    String tooltip,
     int textDirection,
     Float64List transform,
     Int32List childrenInTraversalOrder,
@@ -977,12 +977,12 @@ class SemanticsUpdateBuilder extends NativeFieldWrapperClass1 {
   void updateCustomAction({required int id, String? label, String? hint, int overrideId = -1}) {
     assert(id != null);
     assert(overrideId != null);
-    _updateCustomAction(id, label, hint, overrideId);
+    _updateCustomAction(id, label ?? '', hint ?? '', overrideId);
   }
   void _updateCustomAction(
       int id,
-      String? label,
-      String? hint,
+      String label,
+      String hint,
       int overrideId) native 'SemanticsUpdateBuilder_updateCustomAction';
 
   /// Creates a [SemanticsUpdate] object that encapsulates the updates recorded

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -2883,11 +2883,11 @@ class ParagraphBuilder extends NativeFieldWrapperClass1 {
       _constructor(
         style._encoded,
         encodedStrutStyle,
-        style._fontFamily,
+        style._fontFamily ?? '',
         strutFontFamilies,
-        style._fontSize,
-        style._height,
-        style._ellipsis,
+        style._fontSize ?? 0,
+        style._height ?? 0,
+        style._ellipsis ?? '',
         _encodeLocale(style._locale)
       );
   }
@@ -2895,11 +2895,11 @@ class ParagraphBuilder extends NativeFieldWrapperClass1 {
   void _constructor(
     Int32List encoded,
     ByteData? strutData,
-    String? fontFamily,
+    String fontFamily,
     List<Object?>? strutFontFamily,
-    double? fontSize,
-    double? height,
-    String? ellipsis,
+    double fontSize,
+    double height,
+    String ellipsis,
     String locale
   ) native 'ParagraphBuilder_constructor';
 
@@ -2955,11 +2955,11 @@ class ParagraphBuilder extends NativeFieldWrapperClass1 {
     _pushStyle(
       encoded,
       fullFontFamilies,
-      style._fontSize,
-      style._letterSpacing,
-      style._wordSpacing,
-      style._height,
-      style._decorationThickness,
+      style._fontSize ?? 0,
+      style._letterSpacing ?? 0,
+      style._wordSpacing ?? 0,
+      style._height ?? 0,
+      style._decorationThickness ?? 0,
       _encodeLocale(style._locale),
       style._background?._objects,
       style._background?._data,
@@ -2974,11 +2974,11 @@ class ParagraphBuilder extends NativeFieldWrapperClass1 {
   void _pushStyle(
     Int32List encoded,
     List<Object?> fontFamilies,
-    double? fontSize,
-    double? letterSpacing,
-    double? wordSpacing,
-    double? height,
-    double? decorationThickness,
+    double fontSize,
+    double letterSpacing,
+    double wordSpacing,
+    double height,
+    double decorationThickness,
     String locale,
     List<Object?>? backgroundObjects,
     ByteData? backgroundData,
@@ -3068,11 +3068,11 @@ class ParagraphBuilder extends NativeFieldWrapperClass1 {
     // Default the baselineOffset to height if null. This will place the placeholder
     // fully above the baseline, similar to [PlaceholderAlignment.aboveBaseline].
     baselineOffset = baselineOffset ?? height;
-    _addPlaceholder(width * scale, height * scale, alignment.index, baselineOffset * scale, baseline?.index);
+    _addPlaceholder(width * scale, height * scale, alignment.index, baselineOffset * scale, (baseline ?? TextBaseline.alphabetic).index);
     _placeholderCount++;
     _placeholderScales.add(scale);
   }
-  String? _addPlaceholder(double width, double height, int alignment, double baselineOffset, int? baseline) native 'ParagraphBuilder_addPlaceholder';
+  String? _addPlaceholder(double width, double height, int alignment, double baselineOffset, int baseline) native 'ParagraphBuilder_addPlaceholder';
 
   /// Applies the given paragraph style and returns a [Paragraph] containing the
   /// added text and associated styling.
@@ -3095,7 +3095,7 @@ class ParagraphBuilder extends NativeFieldWrapperClass1 {
 Future<void> loadFontFromList(Uint8List list, {String? fontFamily}) {
   return _futurize(
     (_Callback<void> callback) {
-      _loadFontFromList(list, callback, fontFamily);
+      _loadFontFromList(list, callback, fontFamily ?? '');
     }
   ).then((_) => _sendFontChangeMessage());
 }
@@ -3119,4 +3119,4 @@ FutureOr<void> _sendFontChangeMessage() async {
   }
 }
 
-void _loadFontFromList(Uint8List list, _Callback<void> callback, String? fontFamily) native 'loadFontFromList';
+void _loadFontFromList(Uint8List list, _Callback<void> callback, String fontFamily) native 'loadFontFromList';


### PR DESCRIPTION
Tonic converters for simple types do not expect to receive nulls from Dart.
If the caller uses a null, then Tonic will pass the null to Dart APIs such as
Dart_GetNativeDoubleArgument which will return an error handle.  Tonic then
ignores the error and returns a default value for the converted type.

This PR does an explicit mapping from nulls to default values and avoids the
unnecessary overhead of constructing the error in the Dart APIs.

Also add a test that checks function signatures in the dart:ui package for
nullable arguments of these types.
