### PR TITLE
[Linux][A11y] use ATK_ROLE_PASSWORD_TEXT for obscured text

### DIFF
--- a/shell/platform/linux/fl_accessible_node.cc
+++ b/shell/platform/linux/fl_accessible_node.cc
@@ -208,6 +208,10 @@ static AtkRole fl_accessible_node_get_role(AtkObject* accessible) {
   if ((self->flags & kFlutterSemanticsFlagIsSlider) != 0) {
     return ATK_ROLE_SLIDER;
   }
+  if ((self->flags & kFlutterSemanticsFlagIsTextField) != 0 &&
+      (self->flags & kFlutterSemanticsFlagIsObscured) != 0) {
+    return ATK_ROLE_PASSWORD_TEXT;
+  }
   if ((self->flags & kFlutterSemanticsFlagIsTextField) != 0) {
     return ATK_ROLE_TEXT;
   }

--- a/shell/platform/linux/fl_accessible_node_test.cc
+++ b/shell/platform/linux/fl_accessible_node_test.cc
@@ -108,6 +108,14 @@ TEST(FlAccessibleNodeTest, GetRole) {
   fl_accessible_node_set_flags(node, static_cast<FlutterSemanticsFlag>(
                                          kFlutterSemanticsFlagHasToggledState));
   EXPECT_EQ(atk_object_get_role(ATK_OBJECT(node)), ATK_ROLE_TOGGLE_BUTTON);
+
+  fl_accessible_node_set_flags(node, kFlutterSemanticsFlagIsTextField);
+  EXPECT_EQ(atk_object_get_role(ATK_OBJECT(node)), ATK_ROLE_TEXT);
+
+  fl_accessible_node_set_flags(
+      node, static_cast<FlutterSemanticsFlag>(kFlutterSemanticsFlagIsTextField |
+                                              kFlutterSemanticsFlagIsObscured));
+  EXPECT_EQ(atk_object_get_role(ATK_OBJECT(node)), ATK_ROLE_PASSWORD_TEXT);
 }
 
 // Checks Flutter actions are mapped to the appropriate ATK actions.


### PR DESCRIPTION
This makes `TextField(obscureText: true)` report its accessiblity role correctly:

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/140617/167207088-252a0a85-e3e2-4a4d-9b9e-b6433cb0b31a.png) | ![image](https://user-images.githubusercontent.com/140617/167207098-c33e47cd-0bff-46d0-bac0-d071b537eef9.png) |

Fixes a small part of https://github.com/flutter/flutter/issues/103191.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.