### PR TITLE
[web] Migrate Flutter Web DOM usage to JS static interop - 10.

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/image_web_codecs.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image_web_codecs.dart
@@ -457,7 +457,7 @@ Future<Uint8List> encodeVideoFrameAsPng(VideoFrame videoFrame) async {
   final int height = videoFrame.displayHeight;
   final DomCanvasElement canvas = createDomCanvasElement(width: width, height:
       height);
-  final DomCanvasRenderingContext2D ctx = canvas.getContext2D;
+  final DomCanvasRenderingContext2D ctx = canvas.context2D;
   ctx.drawImage(videoFrame as DomCanvasImageSource, 0, 0);
   final String pngBase64 = canvas.toDataURL().substring('data:image/png;base64,'.length);
   return base64.decode(pngBase64);

--- a/lib/web_ui/lib/src/engine/dom.dart
+++ b/lib/web_ui/lib/src/engine/dom.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:typed_data';
+
 import 'package:js/js.dart';
 import 'package:js/js_util.dart' as js_util;
 
@@ -55,6 +57,7 @@ extension DomNavigatorExtension on DomNavigator {
 class DomDocument {}
 
 extension DomDocumentExtension on DomDocument {
+  external DomElement? querySelector(String selectors);
   external /* List<Node> */ List<Object?> querySelectorAll(String selectors);
   external DomElement createElement(String name, [dynamic options]);
   external DomHTMLScriptElement? get currentScript;
@@ -206,6 +209,13 @@ DomHTMLScriptElement createDomHTMLScriptElement() =>
 
 @JS()
 @staticInterop
+class DomHTMLDivElement extends DomHTMLElement {}
+
+DomHTMLDivElement createDomHTMLDivElement() =>
+    domDocument.createElement('div') as DomHTMLDivElement;
+
+@JS()
+@staticInterop
 class DomPerformance extends DomEventTarget {}
 
 extension DomPerformanceExtension on DomPerformance {
@@ -252,7 +262,7 @@ extension DomCanvasElementExtension on DomCanvasElement {
     ]);
   }
 
-  DomCanvasRenderingContext2D get getContext2D =>
+  DomCanvasRenderingContext2D get context2D =>
       getContext('2d')! as DomCanvasRenderingContext2D;
 }
 
@@ -265,7 +275,19 @@ abstract class DomCanvasImageSource {}
 class DomCanvasRenderingContext2D {}
 
 extension DomCanvasRenderingContext2DExtension on DomCanvasRenderingContext2D {
+  external Object? get fillStyle;
+  external set fillStyle(Object? style);
   external void drawImage(DomCanvasImageSource source, num destX, num destY);
+  external void fillRect(num x, num y, num width, num height);
+  external DomImageData getImageData(int x, int y, int sw, int sh);
+}
+
+@JS()
+@staticInterop
+class DomImageData {}
+
+extension DomImageDataExtension on DomImageData {
+  external Uint8ClampedList get data;
 }
 
 @JS()

--- a/lib/web_ui/test/canvaskit/canvas_golden_test.dart
+++ b/lib/web_ui/test/canvaskit/canvas_golden_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:html' as html;
 import 'dart:math' as math;
 import 'dart:typed_data';
 
@@ -1144,10 +1143,8 @@ void drawTestPicture(CkCanvas canvas) {
 }
 
 CkImage generateTestImage() {
-  final html.CanvasElement canvas = html.CanvasElement()
-    ..width = 20
-    ..height = 20;
-  final html.CanvasRenderingContext2D ctx = canvas.context2D;
+  final DomCanvasElement canvas = createDomCanvasElement(width: 20, height: 20);
+  final DomCanvasRenderingContext2D ctx = canvas.context2D;
   ctx.fillStyle = '#FF0000';
   ctx.fillRect(0, 0, 10, 10);
   ctx.fillStyle = '#00FF00';

--- a/lib/web_ui/test/canvaskit/initialization_services_vs_ui_test.dart
+++ b/lib/web_ui/test/canvaskit/initialization_services_vs_ui_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:html' as html;
-
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
@@ -48,6 +46,6 @@ void testMain() {
   }, skip: isIosSafari);
 }
 
-html.Element? findGlassPane() {
-  return html.document.querySelector('flt-glass-pane');
+DomElement? findGlassPane() {
+  return domDocument.querySelector('flt-glass-pane');
 }


### PR DESCRIPTION
This is CL 10 in a series of CLs to migrate Flutter Web DOM usage to the new JS static interop API.