### PR TITLE
Add an explicit null check to DartConverterWrappable::FromDart

### DIFF
--- a/third_party/tonic/dart_wrappable.cc
+++ b/third_party/tonic/dart_wrappable.cc
@@ -89,6 +89,9 @@ Dart_PersistentHandle DartWrappable::GetTypeForWrapper(
 }
 
 DartWrappable* DartConverterWrappable::FromDart(Dart_Handle handle) {
+  if (Dart_IsNull(handle)) {
+    return nullptr;
+  }
   intptr_t peer = 0;
   Dart_Handle result =
       Dart_GetNativeInstanceField(handle, DartWrappable::kPeerIndex, &peer);


### PR DESCRIPTION
This avoids the cost of returning an error handle if a null is passed
to Dart_GetNativeInstanceField.

(DartConverterWrappable::FromArguments uses the
Dart_GetNativeFieldsOfArgument API, which safely handles nulls)