### PR TITLE
Windows: Fix regression introduced by eliminating use of OpenGL ES 3.1 symbols

### DIFF
--- a/shell/platform/windows/external_texture_d3d.cc
+++ b/shell/platform/windows/external_texture_d3d.cc
@@ -45,7 +45,7 @@ bool ExternalTextureD3d::PopulateTexture(size_t width,
   // Populate the texture object used by the engine.
   opengl_texture->target = GL_TEXTURE_2D;
   opengl_texture->name = gl_texture_;
-  opengl_texture->format = GL_RGBA;
+  opengl_texture->format = GL_RGBA8_OES;
   opengl_texture->destruction_callback = nullptr;
   opengl_texture->user_data = nullptr;
   opengl_texture->width = SAFE_ACCESS(descriptor, visible_width, 0);

--- a/shell/platform/windows/external_texture_pixelbuffer.cc
+++ b/shell/platform/windows/external_texture_pixelbuffer.cc
@@ -36,7 +36,7 @@ bool ExternalTexturePixelBuffer::PopulateTexture(
   // Populate the texture object used by the engine.
   opengl_texture->target = GL_TEXTURE_2D;
   opengl_texture->name = state_->gl_texture;
-  opengl_texture->format = GL_RGBA;
+  opengl_texture->format = GL_RGBA8_OES;
   opengl_texture->destruction_callback = nullptr;
   opengl_texture->user_data = nullptr;
   opengl_texture->width = width;


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/102925

This fixes a regression introduced in #32780 (by changing `GL_RGBA8` to an unsized `GL_RGBA`).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
