### PR TITLE
[impeller] Add missing pieces to the OpenGLES backend.

### DIFF
--- a/impeller/playground/imgui/imgui_impl_impeller.cc
+++ b/impeller/playground/imgui/imgui_impl_impeller.cc
@@ -78,6 +78,7 @@ bool ImGui_ImplImpeller_Init(std::shared_ptr<impeller::Context> context) {
         impeller::StorageMode::kHostVisible, texture_descriptor);
     IM_ASSERT(bd->font_texture != nullptr &&
               "Could not allocate ImGui font texture.");
+    bd->font_texture->SetLabel("ImGui Font Texture");
 
     [[maybe_unused]] bool uploaded = bd->font_texture->SetContents(
         pixels, texture_descriptor.GetByteSizeOfBaseMipLevel());

--- a/impeller/playground/playground.cc
+++ b/impeller/playground/playground.cc
@@ -200,6 +200,7 @@ bool Playground::OpenPlaygroundHere(Renderer::RenderCallback render_callback) {
       []() { ImGui_ImplImpeller_Shutdown(); });
 
   ::glfwSetWindowSize(window, GetWindowSize().width, GetWindowSize().height);
+  ::glfwSetWindowPos(window, 200, 100);
   ::glfwShowWindow(window);
 
   while (true) {

--- a/impeller/renderer/backend/gles/buffer_bindings_gles.cc
+++ b/impeller/renderer/backend/gles/buffer_bindings_gles.cc
@@ -4,6 +4,7 @@
 
 #include "impeller/renderer/backend/gles/buffer_bindings_gles.h"
 
+#include <algorithm>
 #include <sstream>
 
 #include "impeller/base/config.h"
@@ -21,7 +22,14 @@ BufferBindingsGLES::~BufferBindingsGLES() = default;
 
 bool BufferBindingsGLES::RegisterVertexStageInput(
     const ProcTableGLES& gl,
-    const std::vector<ShaderStageIOSlot>& inputs) {
+    const std::vector<ShaderStageIOSlot>& p_inputs) {
+  // Attrib locations have be iterated over in order or location because we will
+  // be calculating offsets later.
+  auto inputs = p_inputs;
+  std::sort(inputs.begin(), inputs.end(), [](const auto& lhs, const auto& rhs) {
+    return lhs.location < rhs.location;
+  });
+
   std::vector<VertexAttribPointer> vertex_attrib_arrays;
   size_t offset = 0u;
   for (const auto& input : inputs) {

--- a/impeller/renderer/backend/gles/buffer_bindings_gles.cc
+++ b/impeller/renderer/backend/gles/buffer_bindings_gles.cc
@@ -23,7 +23,7 @@ BufferBindingsGLES::~BufferBindingsGLES() = default;
 bool BufferBindingsGLES::RegisterVertexStageInput(
     const ProcTableGLES& gl,
     const std::vector<ShaderStageIOSlot>& p_inputs) {
-  // Attrib locations have be iterated over in order or location because we will
+  // Attrib locations have to be iterated over in order of location because we will
   // be calculating offsets later.
   auto inputs = p_inputs;
   std::sort(inputs.begin(), inputs.end(), [](const auto& lhs, const auto& rhs) {

--- a/impeller/renderer/backend/gles/buffer_bindings_gles.cc
+++ b/impeller/renderer/backend/gles/buffer_bindings_gles.cc
@@ -23,8 +23,8 @@ BufferBindingsGLES::~BufferBindingsGLES() = default;
 bool BufferBindingsGLES::RegisterVertexStageInput(
     const ProcTableGLES& gl,
     const std::vector<ShaderStageIOSlot>& p_inputs) {
-  // Attrib locations have to be iterated over in order of location because we will
-  // be calculating offsets later.
+  // Attrib locations have to be iterated over in order of location because we
+  // will be calculating offsets later.
   auto inputs = p_inputs;
   std::sort(inputs.begin(), inputs.end(), [](const auto& lhs, const auto& rhs) {
     return lhs.location < rhs.location;

--- a/impeller/renderer/backend/gles/device_buffer_gles.cc
+++ b/impeller/renderer/backend/gles/device_buffer_gles.cc
@@ -21,7 +21,7 @@ DeviceBufferGLES::DeviceBufferGLES(ReactorGLES::Ref reactor,
 
 // |DeviceBuffer|
 DeviceBufferGLES::~DeviceBufferGLES() {
-  if (!reactor_) {
+  if (!handle_.IsDead()) {
     reactor_->CollectHandle(handle_);
   }
 }

--- a/impeller/renderer/backend/gles/gles_handle.h
+++ b/impeller/renderer/backend/gles/gles_handle.h
@@ -21,6 +21,8 @@ enum class HandleType {
   kTexture,
   kBuffer,
   kProgram,
+  kRenderBuffer,
+  kFrameBuffer,
 };
 
 class ReactorGLES;

--- a/impeller/renderer/backend/gles/proc_table_gles.h
+++ b/impeller/renderer/backend/gles/proc_table_gles.h
@@ -80,6 +80,8 @@ struct GLProc {
   PROC(AttachShader);                        \
   PROC(BindAttribLocation);                  \
   PROC(BindBuffer);                          \
+  PROC(BindFramebuffer);                     \
+  PROC(BindRenderbuffer);                    \
   PROC(BindTexture);                         \
   PROC(BlendEquationSeparate);               \
   PROC(BlendFuncSeparate);                   \
@@ -95,7 +97,9 @@ struct GLProc {
   PROC(CreateShader);                        \
   PROC(CullFace);                            \
   PROC(DeleteBuffers);                       \
+  PROC(DeleteFramebuffers);                  \
   PROC(DeleteProgram);                       \
+  PROC(DeleteRenderbuffers);                 \
   PROC(DeleteShader);                        \
   PROC(DeleteTextures);                      \
   PROC(DepthFunc);                           \
@@ -107,8 +111,12 @@ struct GLProc {
   PROC(DrawElements);                        \
   PROC(Enable);                              \
   PROC(EnableVertexAttribArray);             \
+  PROC(FramebufferRenderbuffer);             \
+  PROC(FramebufferTexture2D);                \
   PROC(FrontFace);                           \
   PROC(GenBuffers);                          \
+  PROC(GenFramebuffers);                     \
+  PROC(GenRenderbuffers);                    \
   PROC(GenTextures);                         \
   PROC(GetActiveUniform);                    \
   PROC(GetBooleanv);                         \
@@ -123,6 +131,7 @@ struct GLProc {
   PROC(IsFramebuffer);                       \
   PROC(IsProgram);                           \
   PROC(LinkProgram);                         \
+  PROC(RenderbufferStorage);                 \
   PROC(Scissor);                             \
   PROC(ShaderBinary);                        \
   PROC(ShaderSource);                        \
@@ -141,6 +150,7 @@ struct GLProc {
   PROC(Viewport);
 
 #define FOR_EACH_IMPELLER_EXT_PROC(PROC) \
+  PROC(DiscardFramebufferEXT);           \
   PROC(PushDebugGroupKHR);               \
   PROC(PopDebugGroupKHR);                \
   PROC(ObjectLabelKHR);
@@ -150,6 +160,8 @@ enum class DebugResourceType {
   kBuffer,
   kProgram,
   kShader,
+  kRenderBuffer,
+  kFrameBuffer,
 };
 
 class ProcTableGLES {
@@ -181,9 +193,14 @@ class ProcTableGLES {
                      GLint name,
                      const std::string& label) const;
 
+  void PushDebugGroup(const std::string& string) const;
+
+  void PopDebugGroup() const;
+
  private:
   bool is_valid_ = false;
   std::unique_ptr<GLDescription> description_;
+  GLint debug_label_max_length_ = 0;
 
   FML_DISALLOW_COPY_AND_ASSIGN(ProcTableGLES);
 };

--- a/impeller/renderer/backend/gles/surface_gles.cc
+++ b/impeller/renderer/backend/gles/surface_gles.cc
@@ -25,31 +25,33 @@ std::unique_ptr<Surface> SurfaceGLES::WrapFBO(std::shared_ptr<Context> context,
   const auto& gl_context = ContextGLES::Cast(*context);
 
   TextureDescriptor color0_tex;
-  color0_tex.type = TextureType::kTexture2D;  // lies
+  color0_tex.type = TextureType::kTexture2D;
   color0_tex.format = color_format;
   color0_tex.size = fbo_size;
   color0_tex.usage = static_cast<TextureUsageMask>(TextureUsage::kRenderTarget);
-  color0_tex.sample_count = SampleCount::kCount4;
+  color0_tex.sample_count = SampleCount::kCount1;
 
   ColorAttachment color0;
-  color0.texture = std::make_shared<TextureGLES>(gl_context.GetReactor(),
-                                                 std::move(color0_tex));
+  color0.texture = std::make_shared<TextureGLES>(
+      gl_context.GetReactor(), std::move(color0_tex),
+      TextureGLES::IsWrapped::kWrapped);
   color0.clear_color = Color::DarkSlateGray();
   color0.load_action = LoadAction::kClear;
   color0.store_action = StoreAction::kStore;
 
   TextureDescriptor stencil0_tex;
-  stencil0_tex.type = TextureType::kTexture2D;  // lies
+  stencil0_tex.type = TextureType::kTexture2D;
   stencil0_tex.format = color_format;
   stencil0_tex.size = fbo_size;
   stencil0_tex.usage =
       static_cast<TextureUsageMask>(TextureUsage::kRenderTarget);
-  stencil0_tex.sample_count = SampleCount::kCount4;
+  stencil0_tex.sample_count = SampleCount::kCount1;
 
   StencilAttachment stencil0;
   stencil0.clear_stencil = 0;
-  stencil0.texture = std::make_shared<TextureGLES>(gl_context.GetReactor(),
-                                                   std::move(stencil0_tex));
+  stencil0.texture = std::make_shared<TextureGLES>(
+      gl_context.GetReactor(), std::move(stencil0_tex),
+      TextureGLES::IsWrapped::kWrapped);
   stencil0.load_action = LoadAction::kClear;
   stencil0.store_action = StoreAction::kDontCare;
 

--- a/impeller/renderer/backend/gles/texture_gles.h
+++ b/impeller/renderer/backend/gles/texture_gles.h
@@ -15,19 +15,52 @@ namespace impeller {
 class TextureGLES final : public Texture,
                           public BackendCast<TextureGLES, Texture> {
  public:
+  enum class Type {
+    kTexture,
+    kRenderBuffer,
+  };
+
+  enum class IsWrapped {
+    kWrapped,
+  };
+
   TextureGLES(ReactorGLES::Ref reactor, TextureDescriptor desc);
+
+  TextureGLES(ReactorGLES::Ref reactor,
+              TextureDescriptor desc,
+              IsWrapped wrapped);
 
   // |Texture|
   ~TextureGLES() override;
 
-  bool Bind() const;
+  [[nodiscard]] bool Bind() const;
+
+  enum class AttachmentPoint {
+    kColor0,
+    kDepth,
+    kStencil,
+  };
+  [[nodiscard]] bool SetAsFramebufferAttachment(GLuint fbo,
+                                                AttachmentPoint point) const;
+
+  Type GetType() const;
+
+  bool IsWrapped() const { return is_wrapped_; }
 
  private:
   friend class AllocatorMTL;
 
   ReactorGLES::Ref reactor_;
+  const Type type_;
   GLESHandle handle_;
+  mutable bool contents_initialized_ = false;
+  const bool is_wrapped_;
+  std::string label_;
   bool is_valid_ = false;
+
+  TextureGLES(std::shared_ptr<ReactorGLES> reactor,
+              TextureDescriptor desc,
+              bool is_wrapped);
 
   // |Texture|
   void SetLabel(const std::string_view& label) override;
@@ -40,6 +73,8 @@ class TextureGLES final : public Texture,
 
   // |Texture|
   ISize GetSize() const override;
+
+  void InitializeContentsIfNecessary() const;
 
   FML_DISALLOW_COPY_AND_ASSIGN(TextureGLES);
 };


### PR DESCRIPTION
This rounds out the support the new backend. The following fixes were made:
* Fix incorrect binding of vertex stage inputs due to order of items in the
  reflected stage inputs array not being consistent with the location attribute
  of stage inputs.
* Add support for using renderbuffers as the backing for textures whose usage is
  as a render target.
* Add support for debug object labeling.
* Add support for framebuffer discards.
* Add support for debug marker stacks.

Fixes text rendering tests.
<img width="1136" alt="167223892-0f581735-a1b4-41af-92a9-d8956d72788e" src="https://user-images.githubusercontent.com/44085/167506677-b495a755-b83e-4d2b-97fa-3ed81700b1c0.png">

Fixes debugging information not showing up in GPU frame captures.
<img width="2672" alt="Screen Shot 2022-05-09 at 3 08 27 PM" src="https://user-images.githubusercontent.com/44085/167506857-3e0eba22-93a3-4ac9-aa79-34ed79fac838.png">

Fixes all tests related to offscreen rendering.

Obsoletes the following patches:
* https://github.com/flutter/engine/pull/33184
* https://github.com/flutter/engine/pull/33183
