### PR TITLE
Revert "[gn] Extract target_os, target_cpu resolution"

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -120,37 +120,6 @@ def can_use_prebuilt_dart(args):
     prebuilts_dir = os.path.join(SRC_ROOT, 'flutter', 'prebuilts', prebuilt)
   return prebuilts_dir != None and os.path.isdir(prebuilts_dir)
 
-
-def get_target_cpu(args):
-  if args.target_os == 'android':
-    target_cpu = args.android_cpu
-  elif args.target_os == 'ios':
-    if args.simulator:
-      target_cpu = args.simulator_cpu
-    else:
-      target_cpu = args.ios_cpu
-  elif args.target_os == 'mac':
-    target_cpu = args.mac_cpu
-  elif args.target_os == 'linux':
-    target_cpu = args.linux_cpu
-  elif args.target_os == 'fuchsia':
-    target_cpu = args.fuchsia_cpu
-  elif args.target_os == 'wasm':
-    target_cpu = 'wasm'
-  elif args.target_os == 'win':
-    target_cpu = args.windows_cpu
-  else:
-    # Building host artifacts
-    target_cpu = 'x64'
-
-  # No cross-compilation on Windows (for now).
-  # See: https://github.com/flutter/engine/pull/3883
-  if sys.platform.startswith(('cygwin', 'win')) and args.target_os != 'win':
-    target_cpu = cpu_for_target_arch(target_cpu)
-
-  return target_cpu
-
-
 def to_gn_args(args):
     if args.simulator:
         if args.target_os != 'ios':
@@ -220,14 +189,20 @@ def to_gn_args(args):
       # The GN arg is not available in the windows toolchain.
       gn_args['enable_lto'] = enable_lto
 
-    if args.target_os:
-      gn_args['target_os'] = args.target_os
-    gn_args['target_cpu'] = get_target_cpu(args)
-
-    if args.target_os == 'ios':
-      gn_args['use_ios_simulator'] = args.simulator
+    if args.target_os == 'android':
+        gn_args['target_os'] = 'android'
+    elif args.target_os == 'ios':
+        gn_args['target_os'] = 'ios'
+        gn_args['use_ios_simulator'] = args.simulator
     elif args.target_os == 'mac':
-      gn_args['use_ios_simulator'] = False
+        gn_args['target_os'] = 'mac'
+        gn_args['use_ios_simulator'] = False
+    elif args.target_os == 'fuchsia':
+        gn_args['target_os'] = 'fuchsia'
+    elif args.target_os == 'wasm':
+        gn_args['target_os'] = 'wasm'
+    elif args.target_os is not None:
+        gn_args['target_os'] = args.target_os
 
     if args.dart_debug:
         gn_args['dart_debug'] = True
@@ -235,6 +210,27 @@ def to_gn_args(args):
     if args.full_dart_debug:
       gn_args['dart_debug'] = True
       gn_args['dart_debug_optimization_level'] = '0'
+
+    if args.target_os == 'android':
+        gn_args['target_cpu'] = args.android_cpu
+    elif args.target_os == 'ios':
+        if args.simulator:
+            gn_args['target_cpu'] = args.simulator_cpu
+        else:
+            gn_args['target_cpu'] = args.ios_cpu
+    elif args.target_os == 'mac':
+      gn_args['target_cpu'] = args.mac_cpu
+    elif args.target_os == 'linux':
+      gn_args['target_cpu'] = args.linux_cpu
+    elif args.target_os == 'fuchsia':
+      gn_args['target_cpu'] = args.fuchsia_cpu
+    elif args.target_os == 'wasm':
+      gn_args['target_cpu'] = 'wasm'
+    elif args.target_os == 'win':
+      gn_args['target_cpu'] = args.windows_cpu
+    else:
+        # Building host artifacts
+        gn_args['target_cpu'] = 'x64'
 
     # Flutter-specific arguments which don't apply for a CanvasKit build.
     if args.target_os != 'wasm':
@@ -273,6 +269,10 @@ def to_gn_args(args):
     # DBC is not supported anymore.
     if args.interpreter:
       raise Exception('--interpreter is no longer needed on any supported platform.')
+
+    if sys.platform.startswith(('cygwin', 'win')) and args.target_os != 'win':
+      if 'target_cpu' in gn_args:
+        gn_args['target_cpu'] = cpu_for_target_arch(gn_args['target_cpu'])
 
     if args.target_os is None:
       if sys.platform.startswith(('cygwin', 'win')):


### PR DESCRIPTION
Reverts flutter/engine#33224

Not sure how yet, but this appears to be causing failures on Windows  in the roll to the framework: https://github.com/flutter/flutter/pull/103419