### PR TITLE
Move platform-specific stuff from macOS FVC to FlutterEngine

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -38,9 +38,9 @@ static FlutterLocale FlutterLocaleFromNSLocale(NSLocale* locale) {
 }
 
 /// The private notification for voice over.
-static NSString* const EnhancedUserInterfaceNotification =
+static const NSString* EnhancedUserInterfaceNotification =
     @"NSApplicationDidChangeAccessibilityEnhancedUserInterfaceNotification";
-static NSString* const EnhancedUserInterfaceKey = @"AXEnhancedUserInterface";
+static const NSString* EnhancedUserInterfaceKey = @"AXEnhancedUserInterface";
 
 /// Clipboard plain text format.
 constexpr char kTextPlainFormat[] = "text/plain";

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -117,8 +117,6 @@ constexpr char kTextPlainFormat[] = "text/plain";
  */
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result;
 
-// - (NSPasteboard*)pasteboard;
-
 @end
 
 #pragma mark -
@@ -763,19 +761,7 @@ static void OnPlatformMessage(const FlutterPlatformMessage* message, FlutterEngi
 
 - (void)onAccessibilityStatusChanged:(NSNotification*)notification {
   BOOL enabled = [notification.userInfo[EnhancedUserInterfaceKey] boolValue];
-  // TODO(goderbauer): WHAT?
-  // if (!enabled && self.viewLoaded && [_textInputPlugin isFirstResponder]) {
-  //   // The client (i.e. the FlutterTextField) of the textInputPlugin is a sibling
-  //   // of the FlutterView. macOS will pick the ancestor to be the next responder
-  //   // when the client is removed from the view hierarchy, which is the result of
-  //   // turning off semantics. This will cause the keyboard focus to stick at the
-  //   // NSWindow.
-  //   //
-  //   // Since the view controller creates the illustion that the FlutterTextField is
-  //   // below the FlutterView in accessibility (See FlutterViewWrapper), it has to
-  //   // manually pick the next responder.
-  //   [self.view.window makeFirstResponder:_flutterView];
-  // }
+  [self.viewController onAccessibilityStatusChanged:enabled];
   self.semanticsEnabled = enabled;
 }
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -38,9 +38,9 @@ static FlutterLocale FlutterLocaleFromNSLocale(NSLocale* locale) {
 }
 
 /// The private notification for voice over.
-static NSString* const EnhancedUserInterfaceNotification =
+static NSString* const kEnhancedUserInterfaceNotification =
     @"NSApplicationDidChangeAccessibilityEnhancedUserInterfaceNotification";
-static const NSString* EnhancedUserInterfaceKey = @"AXEnhancedUserInterface";
+static NSString* const kEnhancedUserInterfaceKey = @"AXEnhancedUserInterface";
 
 /// Clipboard plain text format.
 constexpr char kTextPlainFormat[] = "text/plain";
@@ -730,7 +730,7 @@ static void OnPlatformMessage(const FlutterPlatformMessage* message, FlutterEngi
   // macOS fires this private message when VoiceOver turns on or off.
   [center addObserver:self
              selector:@selector(onAccessibilityStatusChanged:)
-                 name:EnhancedUserInterfaceNotification
+                 name:kEnhancedUserInterfaceNotification
                object:nil];
   [center addObserver:self
              selector:@selector(applicationWillTerminate:)
@@ -760,7 +760,7 @@ static void OnPlatformMessage(const FlutterPlatformMessage* message, FlutterEngi
 }
 
 - (void)onAccessibilityStatusChanged:(NSNotification*)notification {
-  BOOL enabled = [notification.userInfo[EnhancedUserInterfaceKey] boolValue];
+  BOOL enabled = [notification.userInfo[kEnhancedUserInterfaceKey] boolValue];
   [self.viewController onAccessibilityStatusChanged:enabled];
   self.semanticsEnabled = enabled;
 }

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -38,7 +38,7 @@ static FlutterLocale FlutterLocaleFromNSLocale(NSLocale* locale) {
 }
 
 /// The private notification for voice over.
-static const NSString* EnhancedUserInterfaceNotification =
+static NSString* const EnhancedUserInterfaceNotification =
     @"NSApplicationDidChangeAccessibilityEnhancedUserInterfaceNotification";
 static const NSString* EnhancedUserInterfaceKey = @"AXEnhancedUserInterface";
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -112,6 +112,13 @@ constexpr char kTextPlainFormat[] = "text/plain";
  */
 - (void)setUpPlatformViewChannel;
 
+/**
+ * Handles messages received from the Flutter engine on the _*Channel channels.
+ */
+- (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result;
+
+// - (NSPasteboard*)pasteboard;
+
 @end
 
 #pragma mark -

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
@@ -520,6 +520,42 @@ TEST_F(FlutterEngineTest, MessengerCleanupConnectionWorks) {
   EXPECT_EQ(record, 21);
 }
 
+TEST(FlutterEngine, HasStringsWhenPasteboardEmpty) {
+  id engineMock = CreateMockFlutterEngine(nil);
+
+  // Call hasStrings and expect it to be false.
+  __block bool calledAfterClear = false;
+  __block bool valueAfterClear;
+  FlutterResult resultAfterClear = ^(id result) {
+    calledAfterClear = true;
+    NSNumber* valueNumber = [result valueForKey:@"value"];
+    valueAfterClear = [valueNumber boolValue];
+  };
+  FlutterMethodCall* methodCallAfterClear =
+      [FlutterMethodCall methodCallWithMethodName:@"Clipboard.hasStrings" arguments:nil];
+  [engineMock handleMethodCall:methodCallAfterClear result:resultAfterClear];
+  EXPECT_TRUE(calledAfterClear);
+  EXPECT_FALSE(valueAfterClear);
+}
+
+TEST(FlutterEngine, HasStringsWhenPasteboardFull) {
+  id engineMock = CreateMockFlutterEngine(@"some string");
+
+  // Call hasStrings and expect it to be true.
+  __block bool called = false;
+  __block bool value;
+  FlutterResult result = ^(id result) {
+    called = true;
+    NSNumber* valueNumber = [result valueForKey:@"value"];
+    value = [valueNumber boolValue];
+  };
+  FlutterMethodCall* methodCall =
+      [FlutterMethodCall methodCallWithMethodName:@"Clipboard.hasStrings" arguments:nil];
+  [engineMock handleMethodCall:methodCall result:result];
+  EXPECT_TRUE(called);
+  EXPECT_TRUE(value);
+}
+
 }  // namespace flutter::testing
 
 // NOLINTEND(clang-analyzer-core.StackAddressEscape)

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngineTestUtils.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngineTestUtils.h
@@ -4,6 +4,7 @@
 
 #import "flutter/shell/platform/darwin/macos/framework/Headers/FlutterEngine.h"
 
+#import <OCMock/OCMock.h>
 #include "flutter/testing/test_dart_native_resolver.h"
 #include "gtest/gtest.h"
 
@@ -30,5 +31,9 @@ class FlutterEngineTest : public ::testing::Test {
 
   FML_DISALLOW_COPY_AND_ASSIGN(FlutterEngineTest);
 };
+
+// Returns a mock FlutterEngine that is able to work in environments
+// without a real pasteboard.
+id CreateMockFlutterEngine(NSString* pasteboardString);
 
 }  // namespace flutter::testing

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h
@@ -45,6 +45,11 @@
 @property(nonatomic, readonly, nonnull) NSString* executableName;
 
 /**
+ * This just returns the NSPasteboard so that it can be mocked in the tests.
+ */
+@property(nonatomic, readonly, nonnull) NSPasteboard* pasteboard;
+
+/**
  * Informs the engine that the associated view controller's view size has changed.
  */
 - (void)updateWindowMetrics;

--- a/shell/platform/darwin/macos/framework/Source/FlutterGLCompositorUnittests.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterGLCompositorUnittests.mm
@@ -11,7 +11,7 @@
 namespace flutter::testing {
 
 TEST(FlutterGLCompositorTest, TestPresent) {
-  id mockViewController = CreateMockViewController(nil);
+  id mockViewController = CreateMockViewController();
 
   std::unique_ptr<flutter::FlutterGLCompositor> macos_compositor =
       std::make_unique<FlutterGLCompositor>(mockViewController, nullptr);

--- a/shell/platform/darwin/macos/framework/Source/FlutterMetalCompositorUnittests.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterMetalCompositorUnittests.mm
@@ -11,7 +11,7 @@
 namespace flutter::testing {
 
 TEST(FlutterMetalCompositorTest, TestPresent) {
-  id mockViewController = CreateMockViewController(nil);
+  id mockViewController = CreateMockViewController();
 
   std::unique_ptr<flutter::FlutterMetalCompositor> macos_compositor =
       std::make_unique<FlutterMetalCompositor>(
@@ -28,7 +28,7 @@ TEST(FlutterMetalCompositorTest, TestPresent) {
 }
 
 TEST(FlutterMetalCompositorTest, TestCreate) {
-  id mockViewController = CreateMockViewController(nil);
+  id mockViewController = CreateMockViewController();
   [mockViewController loadView];
 
   std::unique_ptr<flutter::FlutterMetalCompositor> macos_compositor =
@@ -50,7 +50,7 @@ TEST(FlutterMetalCompositorTest, TestCreate) {
 }
 
 TEST(FlutterMetalCompositorTest, TestCompositing) {
-  id mockViewController = CreateMockViewController(nil);
+  id mockViewController = CreateMockViewController();
   [mockViewController loadView];
 
   std::unique_ptr<flutter::FlutterMetalCompositor> macos_compositor =

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -216,8 +216,6 @@ static flutter::TextRange RangeFromBaseExtent(NSNumber* base,
     _textInputContext = [[NSTextInputContext alloc] initWithClient:unsafeSelf];
     _previouslyPressedFlags = 0;
 
-    _flutterViewController = viewController;
-
     // Initialize with the zero matrix which is not
     // an affine transform.
     _editableTransform = CATransform3D();

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -14,9 +14,7 @@
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterKeyPrimaryResponder.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterKeyboardManager.h"
-#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterMenuPlugin.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterMetalRenderer.h"
-#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterMouseCursorPlugin.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterOpenGLRenderer.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterRenderingBackend.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterTextInputSemanticsObject.h"
@@ -26,14 +24,6 @@
 namespace {
 using flutter::KeyboardLayoutNotifier;
 using flutter::LayoutClue;
-
-/// Clipboard plain text format.
-constexpr char kTextPlainFormat[] = "text/plain";
-
-/// The private notification for voice over.
-static NSString* const kEnhancedUserInterfaceNotification =
-    @"NSApplicationDidChangeAccessibilityEnhancedUserInterfaceNotification";
-static NSString* const kEnhancedUserInterfaceKey = @"AXEnhancedUserInterface";
 
 // Use different device ID for mouse and pan/zoom events, since we can't differentiate the actual
 // device (mouse v.s. trackpad).
@@ -209,11 +199,6 @@ NSData* currentKeyboardLayoutData() {
 - (void)configureTrackingArea;
 
 /**
- * Creates and registers plugins used by this view controller.
- */
-- (void)addInternalPlugins;
-
-/**
  * Creates and registers keyboard related components.
  */
 - (void)initializeKeyboard;
@@ -235,51 +220,8 @@ NSData* currentKeyboardLayoutData() {
  */
 - (void)dispatchMouseEvent:(nonnull NSEvent*)event phase:(FlutterPointerPhase)phase;
 
-/**
- * Initializes the KVO for user settings and passes the initial user settings to the engine.
- */
-- (void)sendInitialSettings;
-
-/**
- * Responds to updates in the user settings and passes this data to the engine.
- */
-- (void)onSettingsChanged:(NSNotification*)notification;
-
-/**
- * Responds to updates in accessibility.
- */
-- (void)onAccessibilityStatusChanged:(NSNotification*)notification;
-
 // TODO
 - (void)onKeyboardLayoutChanged;
-
-/**
- * Handles messages received from the Flutter engine on the _*Channel channels.
- */
-- (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result;
-
-/**
- * Plays a system sound. |soundType| specifies which system sound to play. Valid
- * values can be found in the SystemSoundType enum in the services SDK package.
- */
-- (void)playSystemSound:(NSString*)soundType;
-
-/**
- * Reads the data from the clipboard. |format| specifies the media type of the
- * data to obtain.
- */
-- (NSDictionary*)getClipboardData:(NSString*)format;
-
-/**
- * Clears contents and writes new data into clipboard. |data| is a dictionary where
- * the keys are the type of data, and tervalue the data to be stored.
- */
-- (void)setClipboardData:(NSDictionary*)data;
-
-/**
- * Returns true iff the clipboard contains nonempty string data.
- */
-- (BOOL)clipboardHasStrings;
 
 @end
 
@@ -325,12 +267,6 @@ void OnKeyboardLayoutChanged(CFNotificationCenterRef center,
 @implementation FlutterViewController {
   // The project to run in this controller's engine.
   FlutterDartProject* _project;
-
-  // A message channel for sending user settings to the flutter engine.
-  FlutterBasicMessageChannel* _settingsChannel;
-
-  // A method channel for miscellaneous platform functionality.
-  FlutterMethodChannel* _platformChannel;
 }
 
 @dynamic view;
@@ -346,16 +282,6 @@ static void CommonInit(FlutterViewController* controller) {
   }
   controller->_mouseTrackingMode = FlutterMouseTrackingModeInKeyWindow;
   controller->_textInputPlugin = [[FlutterTextInputPlugin alloc] initWithViewController:controller];
-  NSNotificationCenter* center = [NSNotificationCenter defaultCenter];
-  // macOS fires this private message when VoiceOver turns on or off.
-  [center addObserver:controller
-             selector:@selector(onAccessibilityStatusChanged:)
-                 name:kEnhancedUserInterfaceNotification
-               object:nil];
-  [center addObserver:controller
-             selector:@selector(applicationWillTerminate:)
-                 name:NSApplicationWillTerminateNotification
-               object:nil];
   // macOS fires this message when changing IMEs.
   CFNotificationCenterRef cfCenter = CFNotificationCenterGetDistributedCenter();
   __weak FlutterViewController* weakSelf = controller;
@@ -480,17 +406,13 @@ static void CommonInit(FlutterViewController* controller) {
 #pragma mark - Private methods
 
 - (BOOL)launchEngine {
-  // Register internal plugins before starting the engine.
-  [self addInternalPlugins];
+  // TODO(goderbauer): Should/could this be moved to the Engine?
+  [self initializeKeyboard];
 
   _engine.viewController = self;
   if (![_engine runWithEntrypoint:nil]) {
     return NO;
   }
-  // Send the initial user settings such as brightness and text scale factor
-  // to the engine.
-  // TODO(stuartmorgan): Move this logic to FlutterEngine.
-  [self sendInitialSettings];
   return YES;
 }
 
@@ -555,24 +477,6 @@ static void CommonInit(FlutterViewController* controller) {
   __weak FlutterViewController* weakSelf = self;
   _textInputPlugin = [[FlutterTextInputPlugin alloc] initWithViewController:weakSelf];
   _keyboardManager = [[FlutterKeyboardManager alloc] initWithViewDelegate:weakSelf];
-}
-
-- (void)addInternalPlugins {
-  __weak FlutterViewController* weakSelf = self;
-  [FlutterMouseCursorPlugin registerWithRegistrar:[self registrarForPlugin:@"mousecursor"]];
-  [FlutterMenuPlugin registerWithRegistrar:[self registrarForPlugin:@"menu"]];
-  [self initializeKeyboard];
-  _settingsChannel =
-      [FlutterBasicMessageChannel messageChannelWithName:@"flutter/settings"
-                                         binaryMessenger:_engine.binaryMessenger
-                                                   codec:[FlutterJSONMessageCodec sharedInstance]];
-  _platformChannel =
-      [FlutterMethodChannel methodChannelWithName:@"flutter/platform"
-                                  binaryMessenger:_engine.binaryMessenger
-                                            codec:[FlutterJSONMethodCodec sharedInstance]];
-  [_platformChannel setMethodCallHandler:^(FlutterMethodCall* call, FlutterResult result) {
-    [weakSelf handleMethodCall:call result:result];
-  }];
 }
 
 - (void)dispatchMouseEvent:(nonnull NSEvent*)event {
@@ -723,111 +627,11 @@ static void CommonInit(FlutterViewController* controller) {
   }
 }
 
-- (void)applicationWillTerminate:(NSNotification*)notification {
-  if (!_engine) {
-    return;
-  }
-  [_engine shutDownEngine];
-}
-
-- (void)onAccessibilityStatusChanged:(NSNotification*)notification {
-  if (!_engine) {
-    return;
-  }
-  BOOL enabled = [notification.userInfo[kEnhancedUserInterfaceKey] boolValue];
-  if (!enabled && self.viewLoaded && [_textInputPlugin isFirstResponder]) {
-    // The client (i.e. the FlutterTextField) of the textInputPlugin is a sibling
-    // of the FlutterView. macOS will pick the ancestor to be the next responder
-    // when the client is removed from the view hierarchy, which is the result of
-    // turning off semantics. This will cause the keyboard focus to stick at the
-    // NSWindow.
-    //
-    // Since the view controller creates the illustion that the FlutterTextField is
-    // below the FlutterView in accessibility (See FlutterViewWrapper), it has to
-    // manually pick the next responder.
-    [self.view.window makeFirstResponder:_flutterView];
-  }
-  _engine.semanticsEnabled = [notification.userInfo[kEnhancedUserInterfaceKey] boolValue];
-}
-
-- (void)onSettingsChanged:(NSNotification*)notification {
-  // TODO(jonahwilliams): https://github.com/flutter/flutter/issues/32015.
-  NSString* brightness =
-      [[NSUserDefaults standardUserDefaults] stringForKey:@"AppleInterfaceStyle"];
-  [_settingsChannel sendMessage:@{
-    @"platformBrightness" : [brightness isEqualToString:@"Dark"] ? @"dark" : @"light",
-    // TODO(jonahwilliams): https://github.com/flutter/flutter/issues/32006.
-    @"textScaleFactor" : @1.0,
-    @"alwaysUse24HourFormat" : @false
-  }];
-}
-
 - (void)onKeyboardLayoutChanged {
   _keyboardLayoutData = nil;
   if (_keyboardLayoutNotifier != nil) {
     _keyboardLayoutNotifier();
   }
-}
-
-- (void)sendInitialSettings {
-  // TODO(jonahwilliams): https://github.com/flutter/flutter/issues/32015.
-  [[NSDistributedNotificationCenter defaultCenter]
-      addObserver:self
-         selector:@selector(onSettingsChanged:)
-             name:@"AppleInterfaceThemeChangedNotification"
-           object:nil];
-  [self onSettingsChanged:nil];
-}
-
-- (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
-  if ([call.method isEqualToString:@"SystemNavigator.pop"]) {
-    [NSApp terminate:self];
-    result(nil);
-  } else if ([call.method isEqualToString:@"SystemSound.play"]) {
-    [self playSystemSound:call.arguments];
-    result(nil);
-  } else if ([call.method isEqualToString:@"Clipboard.getData"]) {
-    result([self getClipboardData:call.arguments]);
-  } else if ([call.method isEqualToString:@"Clipboard.setData"]) {
-    [self setClipboardData:call.arguments];
-    result(nil);
-  } else if ([call.method isEqualToString:@"Clipboard.hasStrings"]) {
-    result(@{@"value" : @([self clipboardHasStrings])});
-  } else {
-    result(FlutterMethodNotImplemented);
-  }
-}
-
-- (void)playSystemSound:(NSString*)soundType {
-  if ([soundType isEqualToString:@"SystemSoundType.alert"]) {
-    NSBeep();
-  }
-}
-
-- (NSDictionary*)getClipboardData:(NSString*)format {
-  NSPasteboard* pasteboard = self.pasteboard;
-  if ([format isEqualToString:@(kTextPlainFormat)]) {
-    NSString* stringInPasteboard = [pasteboard stringForType:NSPasteboardTypeString];
-    return stringInPasteboard == nil ? nil : @{@"text" : stringInPasteboard};
-  }
-  return nil;
-}
-
-- (void)setClipboardData:(NSDictionary*)data {
-  NSPasteboard* pasteboard = self.pasteboard;
-  NSString* text = data[@"text"];
-  [pasteboard clearContents];
-  if (text && ![text isEqual:[NSNull null]]) {
-    [pasteboard setString:text forType:NSPasteboardTypeString];
-  }
-}
-
-- (BOOL)clipboardHasStrings {
-  return [self.pasteboard stringForType:NSPasteboardTypeString].length > 0;
-}
-
-- (NSPasteboard*)pasteboard {
-  return [NSPasteboard generalPasteboard];
 }
 
 #pragma mark - FlutterViewReshapeListener

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
@@ -72,7 +72,7 @@ TEST(FlutterViewController, HasViewThatHidesOtherViewsInAccessibility) {
   EXPECT_EQ(accessibilityChildren[0], viewControllerMock.flutterView);
 }
 
-TEST(FlutterViewController, DISABLED_SetsFlutterViewFirstResponderWhenAccessibilityDisabled) {
+TEST(FlutterViewController, SetsFlutterViewFirstResponderWhenAccessibilityDisabled) {
   FlutterEngine* engine = CreateTestEngine();
   NSString* fixtures = @(testing::GetFixturesPath());
   FlutterDartProject* project = [[FlutterDartProject alloc]
@@ -92,14 +92,7 @@ TEST(FlutterViewController, DISABLED_SetsFlutterViewFirstResponderWhenAccessibil
   // Makes sure the textInputPlugin can be the first responder.
   EXPECT_TRUE([window makeFirstResponder:viewController.textInputPlugin]);
   EXPECT_EQ([window firstResponder], viewController.textInputPlugin);
-  // Sends a notification to turn off the accessibility.
-  NSDictionary* userInfo = @{
-    @"AXEnhancedUserInterface" : @(NO),
-  };
-  NSNotification* accessibilityOff = [NSNotification notificationWithName:@""
-                                                                   object:nil
-                                                                 userInfo:userInfo];
-  [viewController onAccessibilityStatusChanged:accessibilityOff];
+  [viewController onAccessibilityStatusChanged:NO];
   // FlutterView becomes the first responder.
   EXPECT_EQ([window firstResponder], viewController.flutterView);
 }

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
@@ -51,47 +51,8 @@ NSResponder* mockResponder() {
 }
 }  // namespace
 
-TEST(FlutterViewController, HasStringsWhenPasteboardEmpty) {
-  // Mock FlutterViewController so that it behaves like the pasteboard is empty.
-  id viewControllerMock = CreateMockViewController(nil);
-
-  // Call hasStrings and expect it to be false.
-  __block bool calledAfterClear = false;
-  __block bool valueAfterClear;
-  FlutterResult resultAfterClear = ^(id result) {
-    calledAfterClear = true;
-    NSNumber* valueNumber = [result valueForKey:@"value"];
-    valueAfterClear = [valueNumber boolValue];
-  };
-  FlutterMethodCall* methodCallAfterClear =
-      [FlutterMethodCall methodCallWithMethodName:@"Clipboard.hasStrings" arguments:nil];
-  [viewControllerMock handleMethodCall:methodCallAfterClear result:resultAfterClear];
-  EXPECT_TRUE(calledAfterClear);
-  EXPECT_FALSE(valueAfterClear);
-}
-
-TEST(FlutterViewController, HasStringsWhenPasteboardFull) {
-  // Mock FlutterViewController so that it behaves like the pasteboard has a
-  // valid string.
-  id viewControllerMock = CreateMockViewController(@"some string");
-
-  // Call hasStrings and expect it to be true.
-  __block bool called = false;
-  __block bool value;
-  FlutterResult result = ^(id result) {
-    called = true;
-    NSNumber* valueNumber = [result valueForKey:@"value"];
-    value = [valueNumber boolValue];
-  };
-  FlutterMethodCall* methodCall =
-      [FlutterMethodCall methodCallWithMethodName:@"Clipboard.hasStrings" arguments:nil];
-  [viewControllerMock handleMethodCall:methodCall result:result];
-  EXPECT_TRUE(called);
-  EXPECT_TRUE(value);
-}
-
 TEST(FlutterViewController, HasViewThatHidesOtherViewsInAccessibility) {
-  FlutterViewController* viewControllerMock = CreateMockViewController(nil);
+  FlutterViewController* viewControllerMock = CreateMockViewController();
 
   [viewControllerMock loadView];
   auto subViews = [viewControllerMock.view subviews];
@@ -111,7 +72,7 @@ TEST(FlutterViewController, HasViewThatHidesOtherViewsInAccessibility) {
   EXPECT_EQ(accessibilityChildren[0], viewControllerMock.flutterView);
 }
 
-TEST(FlutterViewController, SetsFlutterViewFirstResponderWhenAccessibilityDisabled) {
+TEST(FlutterViewController, DISABLED_SetsFlutterViewFirstResponderWhenAccessibilityDisabled) {
   FlutterEngine* engine = CreateTestEngine();
   NSString* fixtures = @(testing::GetFixturesPath());
   FlutterDartProject* project = [[FlutterDartProject alloc]

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTestUtils.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTestUtils.h
@@ -11,8 +11,7 @@
 
 namespace flutter::testing {
 
-// Returns a mock FlutterViewController that is able to work in environments
-// without a real pasteboard.
-id CreateMockViewController(NSString* pasteboardString);
+// Returns a mock FlutterViewController.
+id CreateMockViewController();
 
-}
+}  // namespace flutter::testing

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTestUtils.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTestUtils.mm
@@ -6,23 +6,14 @@
 
 namespace flutter::testing {
 
-id CreateMockViewController(NSString* pasteboardString) {
+id CreateMockViewController() {
   {
     NSString* fixtures = @(testing::GetFixturesPath());
     FlutterDartProject* project = [[FlutterDartProject alloc]
         initWithAssetsPath:fixtures
                ICUDataPath:[fixtures stringByAppendingString:@"/icudtl.dat"]];
     FlutterViewController* viewController = [[FlutterViewController alloc] initWithProject:project];
-
-    // Mock pasteboard so that this test will work in environments without a
-    // real pasteboard.
-    id pasteboardMock = OCMClassMock([NSPasteboard class]);
-    OCMExpect([pasteboardMock stringForType:[OCMArg any]]).andDo(^(NSInvocation* invocation) {
-      NSString* returnValue = pasteboardString.length > 0 ? pasteboardString : nil;
-      [invocation setReturnValue:&returnValue];
-    });
     id viewControllerMock = OCMPartialMock(viewController);
-    OCMStub([viewControllerMock pasteboard]).andReturn(pasteboardMock);
     return viewControllerMock;
   }
 }

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h
@@ -14,11 +14,6 @@
 @property(nonatomic, readonly, nullable) FlutterView* flutterView;
 
 /**
- * This just returns the NSPasteboard so that it can be mocked in the tests.
- */
-@property(nonatomic, readonly, nonnull) NSPasteboard* pasteboard;
-
-/**
  * The text input plugin that handles text editing state for text fields.
  */
 @property(nonatomic, readonly, nonnull) FlutterTextInputPlugin* textInputPlugin;

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h
@@ -35,5 +35,5 @@
 
 // Private methods made visible for testing
 @interface FlutterViewController (TestMethods)
-- (void)onAccessibilityStatusChanged:(nonnull NSNotification*)notification;
+- (void)onAccessibilityStatusChanged:(BOOL)enabled;
 @end


### PR DESCRIPTION
This PR moves logic out of FlutterViewController into FlutterEngine that is not specific to a given ViewController and should be a singleton across all ViewControllers in a multi-view world. It addresses a number of TODOs in the code base around this issue.

However, this does not (yet) change how keyboard and text input is treated. The TextInputPlugin will likely have to be split up into engine parts that move into FlutterEngine and into some parts that remain in each ViewController instance. I left a TODO for that work, but doing it will likely require a little more exploration around how we actually want to handle text input in a multi-view world on the framework-side. 