### PR TITLE
[gn] Extract target_os, target_cpu resolution

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -120,6 +120,29 @@ def can_use_prebuilt_dart(args):
     prebuilts_dir = os.path.join(SRC_ROOT, 'flutter', 'prebuilts', prebuilt)
   return prebuilts_dir != None and os.path.isdir(prebuilts_dir)
 
+
+def get_target_cpu(args):
+  if args.target_os == 'android':
+    return args.android_cpu
+  if args.target_os == 'ios':
+    if args.simulator:
+      return args.simulator_cpu
+    else:
+      return args.ios_cpu
+  if args.target_os == 'mac':
+    return args.mac_cpu
+  if args.target_os == 'linux':
+    return args.linux_cpu
+  if args.target_os == 'fuchsia':
+    return args.fuchsia_cpu
+  if args.target_os == 'wasm':
+    return 'wasm'
+  if args.target_os == 'win':
+    return args.windows_cpu
+  # Building host artifacts. Default to x64.
+  return 'x64'
+
+
 def to_gn_args(args):
     if args.simulator:
         if args.target_os != 'ios':
@@ -189,20 +212,20 @@ def to_gn_args(args):
       # The GN arg is not available in the windows toolchain.
       gn_args['enable_lto'] = enable_lto
 
-    if args.target_os == 'android':
-        gn_args['target_os'] = 'android'
-    elif args.target_os == 'ios':
-        gn_args['target_os'] = 'ios'
-        gn_args['use_ios_simulator'] = args.simulator
+    if args.target_os:
+      gn_args['target_os'] = args.target_os
+    gn_args['target_cpu'] = get_target_cpu(args)
+    gn_args['dart_target_arch'] = gn_args['target_cpu']
+
+    # No cross-compilation on Windows (for now).
+    # See: https://github.com/flutter/engine/pull/3883
+    if sys.platform.startswith(('cygwin', 'win')) and args.target_os != 'win':
+      gn_args['target_cpu'] = cpu_for_target_arch(gn_args['target_cpu'])
+
+    if args.target_os == 'ios':
+      gn_args['use_ios_simulator'] = args.simulator
     elif args.target_os == 'mac':
-        gn_args['target_os'] = 'mac'
-        gn_args['use_ios_simulator'] = False
-    elif args.target_os == 'fuchsia':
-        gn_args['target_os'] = 'fuchsia'
-    elif args.target_os == 'wasm':
-        gn_args['target_os'] = 'wasm'
-    elif args.target_os is not None:
-        gn_args['target_os'] = args.target_os
+      gn_args['use_ios_simulator'] = False
 
     if args.dart_debug:
         gn_args['dart_debug'] = True
@@ -211,27 +234,6 @@ def to_gn_args(args):
       gn_args['dart_debug'] = True
       gn_args['dart_debug_optimization_level'] = '0'
 
-    if args.target_os == 'android':
-        gn_args['target_cpu'] = args.android_cpu
-    elif args.target_os == 'ios':
-        if args.simulator:
-            gn_args['target_cpu'] = args.simulator_cpu
-        else:
-            gn_args['target_cpu'] = args.ios_cpu
-    elif args.target_os == 'mac':
-      gn_args['target_cpu'] = args.mac_cpu
-    elif args.target_os == 'linux':
-      gn_args['target_cpu'] = args.linux_cpu
-    elif args.target_os == 'fuchsia':
-      gn_args['target_cpu'] = args.fuchsia_cpu
-    elif args.target_os == 'wasm':
-      gn_args['target_cpu'] = 'wasm'
-    elif args.target_os == 'win':
-      gn_args['target_cpu'] = args.windows_cpu
-    else:
-        # Building host artifacts
-        gn_args['target_cpu'] = 'x64'
-
     # Flutter-specific arguments which don't apply for a CanvasKit build.
     if args.target_os != 'wasm':
       gn_args['flutter_use_fontconfig'] = args.enable_fontconfig
@@ -239,7 +241,6 @@ def to_gn_args(args):
       gn_args['dart_component_kind'] = 'static_library' # Always link Dart in statically.
       gn_args['embedder_for_target'] = args.embedder_for_target
       gn_args['dart_lib_export_symbols'] = False
-      gn_args['dart_target_arch'] = gn_args['target_cpu']
       gn_args['flutter_runtime_mode'] = runtime_mode
       gn_args['full_dart_sdk'] = args.full_dart_sdk
       gn_args['dart_version_git_info'] = not args.no_dart_version_git_info
@@ -269,10 +270,6 @@ def to_gn_args(args):
     # DBC is not supported anymore.
     if args.interpreter:
       raise Exception('--interpreter is no longer needed on any supported platform.')
-
-    if sys.platform.startswith(('cygwin', 'win')) and args.target_os != 'win':
-      if 'target_cpu' in gn_args:
-        gn_args['target_cpu'] = cpu_for_target_arch(gn_args['target_cpu'])
 
     if args.target_os is None:
       if sys.platform.startswith(('cygwin', 'win')):


### PR DESCRIPTION
This is a minor refactoring to extract functions that resolve target_os
and target_cpu gn settings.

This is cleanup prior to adding support for host builds on Apple Silicon
Macs.

Issue: https://github.com/flutter/flutter/issues/96745

This is a reland of https://github.com/flutter/engine/pull/33224
That patch was reverted in https://github.com/flutter/engine/pull/33231

On non-host Windows builds (e.g. android builds of gen_snapshot)
target_cpu is rewritten to either x86 or x64. However, dart_target_arch
should remain the original target_cpu (e.g. arm or arm64). The previous
version of this refactor inlined that logic into get_target_cpu() which
happens before we set dart_target_arch, thus incorrectly causing
gen_snapshot to be built to target x86 or x64 instead of the original
target architecture.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
