### PR TITLE
Fix sampling mode conversion for Metal

### DIFF
--- a/impeller/fixtures/impeller.frag
+++ b/impeller/fixtures/impeller.frag
@@ -62,8 +62,7 @@ vec2 Hash(float seed) {
 }
 
 vec4 BlueNoise(vec2 uv) {
-  // Remove mod once repeat sampling works.
-  return texture(blue_noise, mod(uv, 1.0));
+  return texture(blue_noise, uv);
 }
 
 vec4 BlueNoiseWithRandomOffset(vec2 screen_position, float seed) {

--- a/impeller/renderer/backend/metal/sampler_library_mtl.mm
+++ b/impeller/renderer/backend/metal/sampler_library_mtl.mm
@@ -25,9 +25,9 @@ std::shared_ptr<const Sampler> SamplerLibraryMTL::GetSampler(
   auto desc = [[MTLSamplerDescriptor alloc] init];
   desc.minFilter = ToMTLSamplerMinMagFilter(descriptor.min_filter);
   desc.magFilter = ToMTLSamplerMinMagFilter(descriptor.mag_filter);
-  desc.sAddressMode = MTLSamplerAddressMode(descriptor.width_address_mode);
-  desc.tAddressMode = MTLSamplerAddressMode(descriptor.height_address_mode);
-  desc.rAddressMode = MTLSamplerAddressMode(descriptor.depth_address_mode);
+  desc.sAddressMode = ToMTLSamplerAddressMode(descriptor.width_address_mode);
+  desc.tAddressMode = ToMTLSamplerAddressMode(descriptor.height_address_mode);
+  desc.rAddressMode = ToMTLSamplerAddressMode(descriptor.depth_address_mode);
 
   if (!descriptor.label.empty()) {
     desc.label = @(descriptor.label.c_str());


### PR DESCRIPTION
Noticed this because `kRepeat` wasn't working when I tried to rely on it in the new demo shader.