### PR TITLE
[Impeller] Fix remaining problems with advanced blends

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -501,6 +501,7 @@ FILE: ../../../flutter/impeller/entity/contents/filters/inputs/filter_contents_f
 FILE: ../../../flutter/impeller/entity/contents/filters/inputs/filter_contents_filter_input.h
 FILE: ../../../flutter/impeller/entity/contents/filters/inputs/filter_input.cc
 FILE: ../../../flutter/impeller/entity/contents/filters/inputs/filter_input.h
+FILE: ../../../flutter/impeller/entity/contents/filters/inputs/filter_input_unittests.cc
 FILE: ../../../flutter/impeller/entity/contents/filters/inputs/texture_filter_input.cc
 FILE: ../../../flutter/impeller/entity/contents/filters/inputs/texture_filter_input.h
 FILE: ../../../flutter/impeller/entity/contents/linear_gradient_contents.cc

--- a/impeller/aiks/canvas.h
+++ b/impeller/aiks/canvas.h
@@ -104,7 +104,8 @@ class Canvas {
 
   size_t GetStencilDepth() const;
 
-  void Save(bool create_subpass);
+  void Save(bool create_subpass,
+            Entity::BlendMode = Entity::BlendMode::kSourceOver);
 
   void RestoreClip();
 

--- a/impeller/entity/BUILD.gn
+++ b/impeller/entity/BUILD.gn
@@ -88,6 +88,7 @@ impeller_component("entity_unittests") {
   testonly = true
 
   sources = [
+    "contents/filters/inputs/filter_input_unittests.cc",
     "entity_playground.cc",
     "entity_playground.h",
     "entity_unittests.cc",

--- a/impeller/entity/contents/filters/inputs/filter_input.cc
+++ b/impeller/entity/contents/filters/inputs/filter_input.cc
@@ -4,6 +4,8 @@
 
 #include "impeller/entity/contents/filters/inputs/filter_input.h"
 
+#include <memory>
+
 #include "flutter/fml/logging.h"
 #include "impeller/entity/contents/filters/filter_contents.h"
 #include "impeller/entity/contents/filters/inputs/contents_filter_input.h"
@@ -26,11 +28,16 @@ FilterInput::Ref FilterInput::Make(Variant input) {
   }
 
   if (auto texture = std::get_if<std::shared_ptr<Texture>>(&input)) {
-    return std::static_pointer_cast<FilterInput>(
-        std::shared_ptr<TextureFilterInput>(new TextureFilterInput(*texture)));
+    return Make(*texture, Matrix());
   }
 
   FML_UNREACHABLE();
+}
+
+FilterInput::Ref FilterInput::Make(std::shared_ptr<Texture> texture,
+                                   Matrix local_transform) {
+  return std::shared_ptr<TextureFilterInput>(
+      new TextureFilterInput(texture, local_transform));
 }
 
 FilterInput::Vector FilterInput::Make(std::initializer_list<Variant> inputs) {

--- a/impeller/entity/contents/filters/inputs/filter_input.h
+++ b/impeller/entity/contents/filters/inputs/filter_input.h
@@ -38,6 +38,9 @@ class FilterInput {
 
   static FilterInput::Ref Make(Variant input);
 
+  static FilterInput::Ref Make(std::shared_ptr<Texture> input,
+                               Matrix local_transform);
+
   static FilterInput::Vector Make(std::initializer_list<Variant> inputs);
 
   virtual Variant GetInput() const = 0;

--- a/impeller/entity/contents/filters/inputs/filter_input_unittests.cc
+++ b/impeller/entity/contents/filters/inputs/filter_input_unittests.cc
@@ -1,0 +1,29 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <memory>
+#include "flutter/testing/testing.h"
+#include "gtest/gtest.h"
+#include "impeller/entity/contents/filters/inputs/filter_input.h"
+#include "impeller/entity/entity.h"
+#include "impeller/geometry/geometry_unittests.h"
+
+namespace impeller {
+namespace testing {
+
+TEST(FilterInputTest, CanSetLocalTransformForTexture) {
+  std::shared_ptr<Texture> texture = nullptr;
+  auto input =
+      FilterInput::Make(texture, Matrix::MakeTranslation({1.0, 0.0, 0.0}));
+  Entity e;
+  e.SetTransformation(Matrix::MakeTranslation({0.0, 2.0, 0.0}));
+
+  ASSERT_MATRIX_NEAR(input->GetLocalTransform(e),
+                     Matrix::MakeTranslation({1.0, 0.0, 0.0}));
+  ASSERT_MATRIX_NEAR(input->GetTransform(e),
+                     Matrix::MakeTranslation({1.0, 2.0, 0.0}));
+}
+
+}  // namespace testing
+}  // namespace impeller

--- a/impeller/entity/contents/filters/inputs/texture_filter_input.cc
+++ b/impeller/entity/contents/filters/inputs/texture_filter_input.cc
@@ -6,8 +6,9 @@
 
 namespace impeller {
 
-TextureFilterInput::TextureFilterInput(std::shared_ptr<Texture> texture)
-    : texture_(texture) {}
+TextureFilterInput::TextureFilterInput(std::shared_ptr<Texture> texture,
+                                       Matrix local_transform)
+    : texture_(texture), local_transform_(local_transform) {}
 
 TextureFilterInput::~TextureFilterInput() = default;
 
@@ -25,6 +26,10 @@ std::optional<Rect> TextureFilterInput::GetCoverage(
     const Entity& entity) const {
   return Rect::MakeSize(Size(texture_->GetSize()))
       .TransformBounds(GetTransform(entity));
+}
+
+Matrix TextureFilterInput::GetLocalTransform(const Entity& entity) const {
+  return local_transform_;
 }
 
 }  // namespace impeller

--- a/impeller/entity/contents/filters/inputs/texture_filter_input.h
+++ b/impeller/entity/contents/filters/inputs/texture_filter_input.h
@@ -6,6 +6,8 @@
 
 #include "impeller/entity/contents/filters/inputs/filter_input.h"
 
+#include "impeller/geometry/matrix.h"
+
 namespace impeller {
 
 class TextureFilterInput final : public FilterInput {
@@ -22,10 +24,15 @@ class TextureFilterInput final : public FilterInput {
   // |FilterInput|
   std::optional<Rect> GetCoverage(const Entity& entity) const override;
 
+  // |FilterInput|
+  Matrix GetLocalTransform(const Entity& entity) const override;
+
  private:
-  TextureFilterInput(std::shared_ptr<Texture> texture);
+  TextureFilterInput(std::shared_ptr<Texture> texture,
+                     Matrix local_transform = Matrix());
 
   std::shared_ptr<Texture> texture_;
+  Matrix local_transform_;
 
   friend FilterInput;
 };

--- a/impeller/entity/shaders/texture_blend_screen.frag
+++ b/impeller/entity/shaders/texture_blend_screen.frag
@@ -26,9 +26,11 @@ vec4 Unpremultiply(vec4 color) {
 }
 
 void main() {
-  vec4 dst = texture(texture_sampler_dst, v_dst_texture_coords);
+  vec4 dst = SampleWithBorder(texture_sampler_dst, v_dst_texture_coords);
   vec4 d = Unpremultiply(dst);
   vec4 src = SampleWithBorder(texture_sampler_src, v_src_texture_coords);
   vec4 s = Unpremultiply(src);
-  frag_color = 1 - ((1 - s) * (1 - d));
+
+  vec3 color = d.rgb + s.rgb - (d.rgb * s.rgb);
+  frag_color = vec4(color, d.a - s.a + s.a);
 }


### PR DESCRIPTION
Adds a local transform setting for texture inputs and corrects the color problems in the Screen shader. Also fixes an issue where the root EntityPass was still rendering to the surface texture rather than the offscreen texture for advanced blends.