### PR TITLE
PlatformView to set the correct overlay view frame, merge thread at the endFrame

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -277,7 +277,6 @@ PostPrerollResult FlutterPlatformViewsController::PostPrerollAction(
     // Eventually, the frame is submitted once this method returns `kSuccess`.
     // At that point, the raster tasks are handled on the platform thread.
     CancelFrame();
-    raster_thread_merger->MergeWithLease(kDefaultMergedLeaseDuration);
     return PostPrerollResult::kSkipAndRetryFrame;
   }
   // If the post preroll action is successful, we will display platform views in the current frame.
@@ -287,6 +286,14 @@ PostPrerollResult FlutterPlatformViewsController::PostPrerollAction(
   BeginCATransaction();
   raster_thread_merger->ExtendLeaseTo(kDefaultMergedLeaseDuration);
   return PostPrerollResult::kSuccess;
+}
+
+void FlutterPlatformViewsController::EndFrame(
+    bool should_resubmit_frame,
+    fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) {
+  if (should_resubmit_frame) {
+    raster_thread_merger->MergeWithLease(kDefaultMergedLeaseDuration);
+  }
 }
 
 void FlutterPlatformViewsController::PrerollCompositeEmbeddedView(
@@ -609,14 +616,18 @@ std::shared_ptr<FlutterPlatformViewLayer> FlutterPlatformViewsController::GetLay
   // This wrapper view masks the overlay view.
   overlay_view_wrapper.frame = CGRectMake(rect.x() / screenScale, rect.y() / screenScale,
                                           rect.width() / screenScale, rect.height() / screenScale);
-  // Set a unique view identifier, so the overlay wrapper can be identified in unit tests.
+  // Set a unique view identifier, so the overlay_view_wrapper can be identified in XCUITests.
   overlay_view_wrapper.accessibilityIdentifier =
       [NSString stringWithFormat:@"platform_view[%lld].overlay[%lld]", view_id, overlay_id];
 
   UIView* overlay_view = layer->overlay_view.get();
   // Set the size of the overlay view.
   // This size is equal to the device screen size.
-  overlay_view.frame = flutter_view_.get().bounds;
+  overlay_view.frame = [flutter_view_.get() convertRect:flutter_view_.get().bounds
+                                                 toView:overlay_view_wrapper];
+  // Set a unique view identifier, so the overlay_view can be identified in XCUITests.
+  overlay_view.accessibilityIdentifier =
+      [NSString stringWithFormat:@"platform_view[%lld].overlay_view[%lld]", view_id, overlay_id];
 
   std::unique_ptr<SurfaceFrame> frame = layer->surface->AcquireFrame(frame_size_);
   // If frame is null, AcquireFrame already printed out an error message.
@@ -625,9 +636,6 @@ std::shared_ptr<FlutterPlatformViewLayer> FlutterPlatformViewsController::GetLay
   }
   SkCanvas* overlay_canvas = frame->SkiaCanvas();
   overlay_canvas->clear(SK_ColorTRANSPARENT);
-  // Offset the picture since its absolute position on the scene is determined
-  // by the position of the overlay view.
-  overlay_canvas->translate(-rect.x(), -rect.y());
   overlay_canvas->drawPicture(picture);
 
   layer->did_submit_last_frame = frame->Submit();

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -160,6 +160,9 @@ class FlutterPlatformViewsController {
 
   PostPrerollResult PostPrerollAction(fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger);
 
+  void EndFrame(bool should_resubmit_frame,
+                fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger);
+
   std::vector<SkCanvas*> GetCurrentCanvases();
 
   SkCanvas* CompositeEmbeddedView(int view_id);

--- a/shell/platform/darwin/ios/ios_external_view_embedder.mm
+++ b/shell/platform/darwin/ios/ios_external_view_embedder.mm
@@ -84,7 +84,7 @@ void IOSExternalViewEmbedder::SubmitFrame(GrDirectContext* context,
 void IOSExternalViewEmbedder::EndFrame(bool should_resubmit_frame,
                                        fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) {
   TRACE_EVENT0("flutter", "IOSExternalViewEmbedder::EndFrame");
-  FML_CHECK(platform_views_controller_);
+  platform_views_controller_->EndFrame(should_resubmit_frame, raster_thread_merger);
 }
 
 // |ExternalViewEmbedder|

--- a/testing/scenario_app/ios/Scenarios/ScenariosUITests/UnobstructedPlatformViewTests.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosUITests/UnobstructedPlatformViewTests.m
@@ -4,6 +4,8 @@
 
 #import <XCTest/XCTest.h>
 
+static const CGFloat kCompareAccuracy = 0.001;
+
 @interface UnobstructedPlatformViewTests : XCTestCase
 
 @end
@@ -60,6 +62,15 @@
   XCTAssertEqual(overlay.frame.origin.y, 150);
   XCTAssertEqual(overlay.frame.size.width, 50);
   XCTAssertEqual(overlay.frame.size.height, 50);
+
+  XCUIElement* overlayView = app.otherElements[@"platform_view[0].overlay_view[0]"];
+  XCTAssertTrue(overlayView.exists);
+  // Overlay should always be the same frame as the app.
+  XCTAssertEqualWithAccuracy(overlayView.frame.origin.x, app.frame.origin.x, kCompareAccuracy);
+  XCTAssertEqualWithAccuracy(overlayView.frame.origin.y, app.frame.origin.x, kCompareAccuracy);
+  XCTAssertEqualWithAccuracy(overlayView.frame.size.width, app.frame.size.width, kCompareAccuracy);
+  XCTAssertEqualWithAccuracy(overlayView.frame.size.height, app.frame.size.height,
+                             kCompareAccuracy);
 }
 
 // A is the layer above the platform view.
@@ -86,6 +97,15 @@
   XCTAssertEqual(overlay.frame.size.width, 50);
   // Half the height of the overlay.
   XCTAssertEqual(overlay.frame.size.height, 25);
+
+  XCUIElement* overlayView = app.otherElements[@"platform_view[0].overlay_view[0]"];
+  XCTAssertTrue(overlayView.exists);
+  // Overlay should always be the same frame as the app.
+  XCTAssertEqualWithAccuracy(overlayView.frame.origin.x, app.frame.origin.x, kCompareAccuracy);
+  XCTAssertEqualWithAccuracy(overlayView.frame.origin.y, app.frame.origin.x, kCompareAccuracy);
+  XCTAssertEqualWithAccuracy(overlayView.frame.size.width, app.frame.size.width, kCompareAccuracy);
+  XCTAssertEqualWithAccuracy(overlayView.frame.size.height, app.frame.size.height,
+                             kCompareAccuracy);
 }
 
 // A and B are the layers above the platform view.
@@ -149,6 +169,24 @@
   XCTAssertEqual(overlay2.frame.origin.y, 225);
   XCTAssertEqual(overlay2.frame.size.width, 50);
   XCTAssertEqual(overlay2.frame.size.height, 50);
+
+  XCUIElement* overlayView0 = app.otherElements[@"platform_view[0].overlay_view[0]"];
+  XCTAssertTrue(overlayView0.exists);
+  // Overlay should always be the same frame as the app.
+  XCTAssertEqualWithAccuracy(overlayView0.frame.origin.x, app.frame.origin.x, kCompareAccuracy);
+  XCTAssertEqualWithAccuracy(overlayView0.frame.origin.y, app.frame.origin.x, kCompareAccuracy);
+  XCTAssertEqualWithAccuracy(overlayView0.frame.size.width, app.frame.size.width, kCompareAccuracy);
+  XCTAssertEqualWithAccuracy(overlayView0.frame.size.height, app.frame.size.height,
+                             kCompareAccuracy);
+
+  XCUIElement* overlayView1 = app.otherElements[@"platform_view[0].overlay_view[0]"];
+  XCTAssertTrue(overlayView1.exists);
+  // Overlay should always be the same frame as the app.
+  XCTAssertEqualWithAccuracy(overlayView1.frame.origin.x, app.frame.origin.x, kCompareAccuracy);
+  XCTAssertEqualWithAccuracy(overlayView1.frame.origin.y, app.frame.origin.x, kCompareAccuracy);
+  XCTAssertEqualWithAccuracy(overlayView1.frame.size.width, app.frame.size.width, kCompareAccuracy);
+  XCTAssertEqualWithAccuracy(overlayView1.frame.size.height, app.frame.size.height,
+                             kCompareAccuracy);
 }
 
 // A is the layer, which z index is higher than the platform view.
@@ -179,6 +217,8 @@
 
   XCTAssertFalse(app.otherElements[@"platform_view[0].overlay[0]"].exists);
   XCTAssertFalse(app.otherElements[@"platform_view[1].overlay[0]"].exists);
+  XCTAssertFalse(app.otherElements[@"platform_view[0].overlay_view[0]"].exists);
+  XCTAssertFalse(app.otherElements[@"platform_view[1].overlay_view[0]"].exists);
 }
 
 // A is the layer above both platform view.
@@ -220,6 +260,24 @@
   XCTAssertEqual(overlay2.frame.origin.y, 25);
   XCTAssertEqual(overlay2.frame.size.width, 200);
   XCTAssertEqual(overlay2.frame.size.height, 250);
+
+  XCUIElement* overlayView0 = app.otherElements[@"platform_view[0].overlay_view[0]"];
+  XCTAssertTrue(overlayView0.exists);
+  // Overlay should always be the same frame as the app.
+  XCTAssertEqualWithAccuracy(overlayView0.frame.origin.x, app.frame.origin.x, kCompareAccuracy);
+  XCTAssertEqualWithAccuracy(overlayView0.frame.origin.y, app.frame.origin.x, kCompareAccuracy);
+  XCTAssertEqualWithAccuracy(overlayView0.frame.size.width, app.frame.size.width, kCompareAccuracy);
+  XCTAssertEqualWithAccuracy(overlayView0.frame.size.height, app.frame.size.height,
+                             kCompareAccuracy);
+
+  XCUIElement* overlayView1 = app.otherElements[@"platform_view[1].overlay_view[0]"];
+  XCTAssertTrue(overlayView1.exists);
+  // Overlay should always be the same frame as the app.
+  XCTAssertEqualWithAccuracy(overlayView1.frame.origin.x, app.frame.origin.x, kCompareAccuracy);
+  XCTAssertEqualWithAccuracy(overlayView1.frame.origin.y, app.frame.origin.x, kCompareAccuracy);
+  XCTAssertEqualWithAccuracy(overlayView1.frame.size.width, app.frame.size.width, kCompareAccuracy);
+  XCTAssertEqualWithAccuracy(overlayView1.frame.size.height, app.frame.size.height,
+                             kCompareAccuracy);
 }
 
 // More then two overlays are merged into a single layer.
@@ -246,6 +304,18 @@
   XCTAssertTrue(overlay.exists);
   XCTAssertFalse(app.otherElements[@"platform_view[0].overlay[1]"].exists);
   XCTAssertTrue(CGRectContainsRect(platform_view.frame, overlay.frame));
+
+  XCUIElement* overlayView0 = app.otherElements[@"platform_view[0].overlay_view[0]"];
+  XCTAssertTrue(overlayView0.exists);
+  // Overlay should always be the same frame as the app.
+  XCTAssertEqualWithAccuracy(overlayView0.frame.origin.x, app.frame.origin.x, kCompareAccuracy);
+  XCTAssertEqualWithAccuracy(overlayView0.frame.origin.y, app.frame.origin.x, kCompareAccuracy);
+  XCTAssertEqualWithAccuracy(overlayView0.frame.size.width, app.frame.size.width, kCompareAccuracy);
+  XCTAssertEqualWithAccuracy(overlayView0.frame.size.height, app.frame.size.height,
+                             kCompareAccuracy);
+
+  XCUIElement* overlayView1 = app.otherElements[@"platform_view[0].overlay_view[1]"];
+  XCTAssertFalse(overlayVie1.exists);
 }
 
 @end

--- a/testing/scenario_app/ios/Scenarios/ScenariosUITests/UnobstructedPlatformViewTests.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosUITests/UnobstructedPlatformViewTests.m
@@ -315,7 +315,7 @@ static const CGFloat kCompareAccuracy = 0.001;
                              kCompareAccuracy);
 
   XCUIElement* overlayView1 = app.otherElements[@"platform_view[0].overlay_view[1]"];
-  XCTAssertFalse(overlayVie1.exists);
+  XCTAssertFalse(overlayView1.exists);
 }
 
 @end


### PR DESCRIPTION
1. This PR makes the OverlayView(which is masked by OverlayWrapper) to be at the correct frame. The new frame of the OverlayView is the same as the FlutterView. Because the Overlay is at the correct frame, we don't need to add a transform matrix to the skia canvas, so that skia doesn't draw off canvas.

This somehow fixes the flickering issue in https://github.com/flutter/flutter/issues/103076, I'm not sure the exact reason behind it but it seems like it is related to Skia trying to draw off canvas.

2. Makes the thread merging happen at the end of the last frame on raster thread. This prevents a new frame starts on the raster thread before the thread merging is completed. 

This fixes some occasional unsynchronized frame, also observed in https://github.com/flutter/flutter/issues/103076

I have observed another thread synchronization issue during thread un-merging. It seems a little more complicated so I'll create a separate PR for it .

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
