### PR TITLE
[gn] Always set host OS, CPU and target OS, CPU

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -256,33 +256,22 @@ def to_gn_args(args):
       gn_args['enable_lto'] = enable_lto
 
     # Set OS, CPU arch for host or target build.
-    if is_host_build(args):
-      gn_args['host_os'] = get_host_os()
-      gn_args['host_cpu'] = get_host_cpu(args)
-      gn_args['target_os'] = gn_args['host_os']
-      gn_args['target_cpu'] = get_target_cpu(args)
-      gn_args['dart_target_arch'] = gn_args['target_cpu']
-    else:
-      gn_args['target_os'] = args.target_os
-      gn_args['target_cpu'] = get_target_cpu(args)
-      gn_args['dart_target_arch'] = gn_args['target_cpu']
+    gn_args['host_os'] = get_host_os()
+    gn_args['host_cpu'] = get_host_cpu(args)
+    gn_args['target_os'] = gn_args['host_os']
+    gn_args['target_cpu'] = get_target_cpu(args)
+    gn_args['dart_target_arch'] = gn_args['target_cpu']
 
     # No cross-compilation on Windows (for now). Use host toolchain that
     # matches the bit-width of the target architecture.
-    if sys.platform.startswith(('cygwin', 'win')) and args.target_os != 'win':
+    if sys.platform.startswith(('cygwin', 'win')) and gn_args['target_os'] != 'win':
       gn_args['host_cpu'] = cpu_for_target_arch(gn_args['target_cpu'])
       gn_args['target_cpu'] = cpu_for_target_arch(gn_args['target_cpu'])
 
-    # macOS host builds (whether x64 or arm64) must currently be built under
-    # Rosetta on Apple Silicon Macs.
+    # macOS builds (whether x64 or arm64) must currently be built under Rosetta
+    # on Apple Silicon Macs.
     # TODO(cbracken): https://github.com/flutter/flutter/issues/103386
-    if is_host_build(args) and gn_args['host_os'] == 'mac':
-      gn_args['host_cpu'] = 'x64'
-
-    # macOS target builds (whether x64 or arm64) must currently be built under
-    # Rosetta on Apple Silicon Macs.
-    # TODO(cbracken): https://github.com/flutter/flutter/issues/103386
-    if 'target_os' in gn_args and gn_args['target_os'] == 'mac':
+    if gn_args['host_os'] == 'mac':
       gn_args['host_cpu'] = 'x64'
 
     if gn_args['target_os'] == 'ios':


### PR DESCRIPTION
For all builds, set all of host_os, host_cpu, target_os, target_cpu in
GN. Previously host_os and host_cpu were only set for Host builds and
MacOS target builds.

This reduces some conditional logic and makes the code/build easier to
reason about.

This is cleanup after landing:
https://github.com/flutter/engine/pull/33244

Issue: https://github.com/flutter/flutter/issues/79403

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
