### PR TITLE
added a clampDouble for faster clamping

### DIFF
--- a/lib/ui/lerp.dart
+++ b/lib/ui/lerp.dart
@@ -48,3 +48,18 @@ int _clampInt(int value, int min, int max) {
     return value;
   }
 }
+
+/// Same as [num.clamp] but optimized for non-null [double].
+double clampDouble(double x, double min, double max) {
+  assert(!x.isNaN);
+  assert(!max.isNaN);
+  assert(!min.isNaN);
+  assert(min <= max);
+  if (x < min) {
+    return min;
+  } else if (x > max) {
+    return max;
+  } else {
+    return x;
+  }
+}

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -323,7 +323,7 @@ class Color {
   /// The [opacity] value may not be null.
   static int getAlphaFromOpacity(double opacity) {
     assert(opacity != null);
-    return (opacity.clamp(0.0, 1.0) * 255).round();
+    return (clampDouble(opacity, 0.0, 1.0) * 255).round();
   }
 
   @override

--- a/testing/dart/BUILD.gn
+++ b/testing/dart/BUILD.gn
@@ -7,6 +7,7 @@ import("//flutter/testing/dart/compile_test.gni")
 tests = [
   "canvas_test.dart",
   "channel_buffers_test.dart",
+  "clamp_test.dart",
   "codec_test.dart",
   "color_filter_test.dart",
   "color_test.dart",

--- a/testing/dart/clamp_test.dart
+++ b/testing/dart/clamp_test.dart
@@ -1,0 +1,16 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui';
+
+import 'package:litetest/litetest.dart';
+
+void main() {
+  test('clampDouble', () {
+    expect(clampDouble(-1.0, 0.0, 1.0), equals(0.0));
+    expect(clampDouble(2.0, 0.0, 1.0), equals(1.0));
+    expect(clampDouble(double.infinity, 0.0, 1.0), equals(1.0));
+    expect(clampDouble(-double.infinity, 0.0, 1.0), equals(0.0));
+  });
+}


### PR DESCRIPTION
`clampDouble` is roughly 70% faster than using `num.clamp` since it avoids boxing.

framework pr: https://github.com/flutter/flutter/pull/103559

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
