### PR TITLE
Roll clang and buildroot

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -112,7 +112,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '63f03c89282242d3f2938e0cc17038f35276c1e8',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '897fdb3e87b252f03915e20ba276302d8f029632',
 
    # Fuchsia compatibility
    #
@@ -579,7 +579,7 @@ deps = {
     'packages': [
       {
         'package': 'fuchsia/third_party/clang/mac-amd64',
-        'version': 'gi-ivU51hLEmgL3m_giEo-uJOhzJgdYslQ0dvUvAJxcC'
+        'version': 'pjqtsy0EkprqQK20GImo0tXIwVJ5oygbAPUHOqmGRlwC'
       }
     ],
     'condition': 'host_os == "mac"',
@@ -590,7 +590,7 @@ deps = {
     'packages': [
       {
         'package': 'fuchsia/third_party/clang/linux-amd64',
-        'version': 'Fn7lDYhKDAwbGQ2SOL_Anwt8fzO1Yho7UjpoS9Hv8N8C'
+        'version': 'xuUT1-3_9KoN3I7wncLinqPEYOMfQ16o53bxWJp0lIkC'
       }
     ],
     'condition': 'host_os == "linux"',
@@ -601,7 +601,7 @@ deps = {
     'packages': [
       {
         'package': 'fuchsia/third_party/clang/windows-amd64',
-        'version': '25xTI5-MiVJ87YWFvdlrwmn4O0DVDz-j3oHlszZAyoQC'
+        'version': 'X7Z_tBCdyVsbPRX99U7jBZnMfJ5RS11wocVcia798jwC'
       }
     ],
     'condition': 'download_windows_deps',

--- a/shell/platform/darwin/ios/framework/Source/FlutterChannelKeyResponderTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterChannelKeyResponderTest.mm
@@ -74,8 +74,8 @@ API_AVAILABLE(ios(13.4))
                 }];
 
   XCTAssertEqual([messages count], 1u);
-  XCTAssertEqual([messages lastObject][@"keymap"], @"ios");
-  XCTAssertEqual([messages lastObject][@"type"], @"keydown");
+  XCTAssertStrEqual([messages lastObject][@"keymap"], @"ios");
+  XCTAssertStrEqual([messages lastObject][@"type"], @"keydown");
   XCTAssertEqual([[messages lastObject][@"keyCode"] intValue], keyACode);
   XCTAssertEqual([[messages lastObject][@"modifiers"] intValue], 0x0);
   XCTAssertStrEqual([messages lastObject][@"characters"], @"a");
@@ -95,8 +95,8 @@ API_AVAILABLE(ios(13.4))
                 }];
 
   XCTAssertEqual([messages count], 1u);
-  XCTAssertEqual([messages lastObject][@"keymap"], @"ios");
-  XCTAssertEqual([messages lastObject][@"type"], @"keyup");
+  XCTAssertStrEqual([messages lastObject][@"keymap"], @"ios");
+  XCTAssertStrEqual([messages lastObject][@"type"], @"keyup");
   XCTAssertEqual([[messages lastObject][@"keyCode"] intValue], keyACode);
   XCTAssertEqual([[messages lastObject][@"modifiers"] intValue], 0x0);
 
@@ -132,8 +132,8 @@ API_AVAILABLE(ios(13.4))
                 }];
 
   XCTAssertEqual([messages count], 1u);
-  XCTAssertEqual([messages lastObject][@"keymap"], @"ios");
-  XCTAssertEqual([messages lastObject][@"type"], @"keydown");
+  XCTAssertStrEqual([messages lastObject][@"keymap"], @"ios");
+  XCTAssertStrEqual([messages lastObject][@"type"], @"keydown");
   XCTAssertEqual([[messages lastObject][@"keyCode"] intValue], keyACode);
   XCTAssertEqual([[messages lastObject][@"modifiers"] intValue], 0x0);
   XCTAssertStrEqual([messages lastObject][@"characters"], @"a");

--- a/shell/platform/darwin/macos/framework/Source/FlutterChannelKeyResponderUnittests.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterChannelKeyResponderUnittests.mm
@@ -232,8 +232,8 @@ TEST(FlutterChannelKeyResponderUnittests, EmptyResponseIsTakenAsHandled) {
   EXPECT_STREQ([[messages lastObject][@"type"] UTF8String], "keydown");
   EXPECT_EQ([[messages lastObject][@"keyCode"] intValue], 0);
   EXPECT_EQ([[messages lastObject][@"modifiers"] intValue], 0);
-  EXPECT_EQ([[messages lastObject][@"characters"] UTF8String], "a");
-  EXPECT_EQ([[messages lastObject][@"charactersIgnoringModifiers"] UTF8String], "a");
+  EXPECT_STREQ([[messages lastObject][@"characters"] UTF8String], "a");
+  EXPECT_STREQ([[messages lastObject][@"charactersIgnoringModifiers"] UTF8String], "a");
 
   EXPECT_EQ([responses count], 1u);
   EXPECT_EQ([[responses lastObject] boolValue], TRUE);

--- a/tools/gn
+++ b/tools/gn
@@ -287,7 +287,7 @@ def to_gn_args(args):
 
     if gn_args['target_os'] == 'ios':
       gn_args['use_ios_simulator'] = args.simulator
-    elif gn_args['target_os'] == 'mac':
+    else:
       gn_args['use_ios_simulator'] = False
 
     if args.dart_debug:


### PR DESCRIPTION
Rolls the buildroot to pick up a compensating change for new warnings: https://github.com/flutter/buildroot/commit/8a1cf1585c74083389274dacdb3510778e0c8486, https://github.com/flutter/buildroot/commit/9f99fc042af1c595a5c4db7873c18361c7d30b8f

And combines the three rolls:
https://github.com/flutter/engine/pull/33278
https://github.com/flutter/engine/pull/33279
https://github.com/flutter/engine/pull/33280