### PR TITLE
[Windows] Remove remaining usage of winuwp flag

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -221,17 +221,10 @@ group("unittests") {
       }
 
       if (is_win) {
-        if (target_os == "winuwp") {
-          # TODO: Add winnup variant of client_wrapper_windows_unittests here; see
-          # https://github.com/flutter/flutter/issues/70197
-          public_deps +=
-              [ "//flutter/shell/platform/windows:flutter_windows_unittests" ]
-        } else {
-          public_deps += [
-            "//flutter/shell/platform/windows:flutter_windows_unittests",
-            "//flutter/shell/platform/windows/client_wrapper:client_wrapper_windows_unittests",
-          ]
-        }
+        public_deps += [
+          "//flutter/shell/platform/windows:flutter_windows_unittests",
+          "//flutter/shell/platform/windows/client_wrapper:client_wrapper_windows_unittests",
+        ]
       }
     }
   }


### PR DESCRIPTION
Fixes: flutter/flutter#103586.

No changes in `flutter/tests`.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
