### PR TITLE
[web] Fix text field actions not triggered on Android

### DIFF
--- a/lib/web_ui/lib/src/engine/text_editing/input_type.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/input_type.dart
@@ -103,7 +103,7 @@ class TextInputType extends EngineInputType {
   const TextInputType();
 
   @override
-  String get inputmodeAttribute => 'text';
+  String? get inputmodeAttribute => null;
 }
 
 /// Numeric input type.

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -450,8 +450,8 @@ Future<void> testMain() async {
       sendFrameworkMessage(codec.encodeMethodCall(clearClient));
     }
 
-    String getEditingInputMode() {
-      return textEditing!.strategy.domElement!.getAttribute('inputmode')!;
+    String? getEditingInputMode() {
+      return textEditing!.strategy.domElement!.getAttribute('inputmode');
     }
 
     setUp(() {
@@ -1815,7 +1815,7 @@ Future<void> testMain() async {
       textEditing = HybridTextEditing();
 
       showKeyboard(inputType: 'text');
-      expect(getEditingInputMode(), 'text');
+      expect(getEditingInputMode(), null);
 
       showKeyboard(inputType: 'number');
       expect(getEditingInputMode(), 'numeric');
@@ -1850,7 +1850,7 @@ Future<void> testMain() async {
         textEditing = HybridTextEditing();
 
         showKeyboard(inputType: 'text');
-        expect(getEditingInputMode(), 'text');
+        expect(getEditingInputMode(), null);
 
         showKeyboard(inputType: 'number');
         expect(getEditingInputMode(), 'numeric');


### PR DESCRIPTION
The [`inputmode`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode) attribute is useful in mobile browsers to display the correct type of keyboard (e.g. numbers, email, etc).

For plain text input, we can either omit the `inputmode` attribute or use `inputmode="text"` (which corresponds to the default value). But in Android Chrome, using `inputmode="text"` causes the text field to not send the right `keyCode` for `ENTER`.

The fix is to omit `inputmode` in plain text fields.

Fixes https://github.com/flutter/flutter/issues/89384