### PR TITLE
[Windows] Add textScaleFactor support

### DIFF
--- a/shell/platform/windows/settings_plugin_win32.cc
+++ b/shell/platform/windows/settings_plugin_win32.cc
@@ -12,6 +12,10 @@ namespace {
 constexpr wchar_t kGetPreferredBrightnessRegKey[] =
     L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize";
 constexpr wchar_t kGetPreferredBrightnessRegValue[] = L"AppsUseLightTheme";
+
+constexpr wchar_t kGetTextScaleFactorRegKey[] =
+    L"Software\\Microsoft\\Accessibility";
+constexpr wchar_t kGetTextScaleFactorRegValue[] = L"TextScaleFactor";
 }  // namespace
 
 // static
@@ -26,21 +30,28 @@ SettingsPluginWin32::SettingsPluginWin32(BinaryMessenger* messenger,
     : SettingsPlugin(messenger, task_runner) {
   RegOpenKeyEx(HKEY_CURRENT_USER, kGetPreferredBrightnessRegKey,
                RRF_RT_REG_DWORD, KEY_NOTIFY, &preferred_brightness_reg_hkey_);
+  RegOpenKeyEx(HKEY_CURRENT_USER, kGetTextScaleFactorRegKey, RRF_RT_REG_DWORD,
+               KEY_NOTIFY, &text_scale_factor_reg_hkey_);
 }
 
 SettingsPluginWin32::~SettingsPluginWin32() {
   StopWatching();
   RegCloseKey(preferred_brightness_reg_hkey_);
+  RegCloseKey(text_scale_factor_reg_hkey_);
 }
 
 void SettingsPluginWin32::StartWatching() {
   if (preferred_brightness_reg_hkey_ != NULL) {
     WatchPreferredBrightnessChanged();
   }
+  if (text_scale_factor_reg_hkey_ != NULL) {
+    WatchTextScaleFactorChanged();
+  }
 }
 
 void SettingsPluginWin32::StopWatching() {
   preferred_brightness_changed_watcher_ = nullptr;
+  text_scale_factor_changed_watcher_ = nullptr;
 }
 
 bool SettingsPluginWin32::GetAlwaysUse24HourFormat() {
@@ -48,7 +59,18 @@ bool SettingsPluginWin32::GetAlwaysUse24HourFormat() {
 }
 
 float SettingsPluginWin32::GetTextScaleFactor() {
-  return 1.0;
+  DWORD text_scale_factor;
+  DWORD text_scale_factor_size = sizeof(text_scale_factor);
+  LONG result = RegGetValue(
+      HKEY_CURRENT_USER, kGetTextScaleFactorRegKey, kGetTextScaleFactorRegValue,
+      RRF_RT_REG_DWORD, nullptr, &text_scale_factor, &text_scale_factor_size);
+
+  if (result == 0) {
+    return text_scale_factor / 100.0;
+  } else {
+    // The current OS does not have text scale factor.
+    return 1.0;
+  }
 }
 
 SettingsPlugin::PlatformBrightness
@@ -81,6 +103,20 @@ void SettingsPluginWin32::WatchPreferredBrightnessChanged() {
   RegNotifyChangeKeyValue(
       preferred_brightness_reg_hkey_, FALSE, REG_NOTIFY_CHANGE_LAST_SET,
       preferred_brightness_changed_watcher_->GetHandle(), TRUE);
+}
+
+void SettingsPluginWin32::WatchTextScaleFactorChanged() {
+  text_scale_factor_changed_watcher_ =
+      std::make_unique<EventWatcherWin32>([this]() {
+        task_runner_->PostTask([this]() {
+          SendSettings();
+          WatchTextScaleFactorChanged();
+        });
+      });
+
+  RegNotifyChangeKeyValue(
+      text_scale_factor_reg_hkey_, FALSE, REG_NOTIFY_CHANGE_LAST_SET,
+      text_scale_factor_changed_watcher_->GetHandle(), TRUE);
 }
 
 }  // namespace flutter

--- a/shell/platform/windows/settings_plugin_win32.cc
+++ b/shell/platform/windows/settings_plugin_win32.cc
@@ -41,10 +41,10 @@ SettingsPluginWin32::~SettingsPluginWin32() {
 }
 
 void SettingsPluginWin32::StartWatching() {
-  if (preferred_brightness_reg_hkey_ != NULL) {
+  if (preferred_brightness_reg_hkey_ != nullptr) {
     WatchPreferredBrightnessChanged();
   }
-  if (text_scale_factor_reg_hkey_ != NULL) {
+  if (text_scale_factor_reg_hkey_ != nullptr) {
     WatchTextScaleFactorChanged();
   }
 }

--- a/shell/platform/windows/settings_plugin_win32.h
+++ b/shell/platform/windows/settings_plugin_win32.h
@@ -39,10 +39,14 @@ class SettingsPluginWin32 : public SettingsPlugin {
 
  private:
   void WatchPreferredBrightnessChanged();
+  void WatchTextScaleFactorChanged();
 
   HKEY preferred_brightness_reg_hkey_ = NULL;
+  HKEY text_scale_factor_reg_hkey_ = NULL;
 
   std::unique_ptr<EventWatcherWin32> preferred_brightness_changed_watcher_{
+      nullptr};
+  std::unique_ptr<EventWatcherWin32> text_scale_factor_changed_watcher_{
       nullptr};
 
   SettingsPluginWin32(const SettingsPluginWin32&) = delete;

--- a/shell/platform/windows/settings_plugin_win32.h
+++ b/shell/platform/windows/settings_plugin_win32.h
@@ -41,13 +41,11 @@ class SettingsPluginWin32 : public SettingsPlugin {
   void WatchPreferredBrightnessChanged();
   void WatchTextScaleFactorChanged();
 
-  HKEY preferred_brightness_reg_hkey_ = NULL;
-  HKEY text_scale_factor_reg_hkey_ = NULL;
+  HKEY preferred_brightness_reg_hkey_ = nullptr;
+  HKEY text_scale_factor_reg_hkey_ = nullptr;
 
-  std::unique_ptr<EventWatcherWin32> preferred_brightness_changed_watcher_{
-      nullptr};
-  std::unique_ptr<EventWatcherWin32> text_scale_factor_changed_watcher_{
-      nullptr};
+  std::unique_ptr<EventWatcherWin32> preferred_brightness_changed_watcher_;
+  std::unique_ptr<EventWatcherWin32> text_scale_factor_changed_watcher_;
 
   SettingsPluginWin32(const SettingsPluginWin32&) = delete;
   SettingsPluginWin32& operator=(const SettingsPluginWin32&) = delete;


### PR DESCRIPTION
This PR replaces hard-coded value and adds text scale factor support for Windows via reading and watching registry.
The settings_plugin_unittests will cover this.
This value can be changed from Settings / Ease of Access / Display / Make text bigger.

Fixes: flutter/flutter#103641.

No changes in `flutter/tests`.

| 100% | 150% | 
|-|-|
|![100% example](https://user-images.githubusercontent.com/16546008/168262532-b6933821-ee48-4f17-94cd-ac297385fce3.png)|![150% example](https://user-images.githubusercontent.com/16546008/168262529-72bb3971-48f0-49fb-bf42-a53658791de7.png)|

<details>
<summary>Example</summary>

```dart
import 'package:flutter/material.dart';

void main() {
  runApp(const MyApp());
}

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      title: 'Flutter Demo',
      theme: ThemeData(brightness: Brightness.light, primarySwatch: Colors.red),
      darkTheme:
          ThemeData(brightness: Brightness.dark, primarySwatch: Colors.red),
      home: const Content(),
    );
  }
}

class Content extends StatelessWidget {
  const Content({super.key});

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(
        title: const Text("Query accessibility features"),
      ),
      body: Center(
        child: Column(
          mainAxisAlignment: MainAxisAlignment.center,
          children: <Widget>[
            Text("devicePixelRatio ${MediaQuery.of(context).devicePixelRatio}"),
            Text("textScaleFactor ${MediaQuery.of(context).textScaleFactor}"),
            Text("highContrast ${MediaQuery.of(context).highContrast}"),
            Text(
                "disableAnimations ${MediaQuery.of(context).disableAnimations}"),
          ],
        ),
      ),
    );
  }
}
```
</details>

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
