### PR TITLE
allow flutter tester to disable font loading from asset bundle

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -810,6 +810,7 @@ FILE: ../../../flutter/lib/ui/dart_ui.cc
 FILE: ../../../flutter/lib/ui/dart_ui.h
 FILE: ../../../flutter/lib/ui/dart_wrapper.h
 FILE: ../../../flutter/lib/ui/fixtures/DashInNooglerHat.jpg
+FILE: ../../../flutter/lib/ui/fixtures/FontManifest.json
 FILE: ../../../flutter/lib/ui/fixtures/Horizontal.jpg
 FILE: ../../../flutter/lib/ui/fixtures/Horizontal.png
 FILE: ../../../flutter/lib/ui/fixtures/hello_loop_2.gif

--- a/common/settings.h
+++ b/common/settings.h
@@ -190,6 +190,8 @@ struct Settings {
   // Font settings
   bool use_test_fonts = false;
 
+  bool use_asset_fonts = true;
+
   // Indicates whether the embedding started a prefetch of the default font
   // manager before creating the engine.
   bool prefetched_default_font_manager = false;

--- a/lib/ui/BUILD.gn
+++ b/lib/ui/BUILD.gn
@@ -187,6 +187,8 @@ if (enable_unittests) {
       "fixtures/Horizontal.png",
       "fixtures/hello_loop_2.gif",
       "fixtures/hello_loop_2.webp",
+      "fixtures/FontManifest.json",
+      "//flutter/third_party/txt/third_party/fonts/Roboto-Medium.ttf",
     ]
   }
 

--- a/lib/ui/fixtures/FontManifest.json
+++ b/lib/ui/fixtures/FontManifest.json
@@ -1,0 +1,1 @@
+[{"family":"Roboto","fonts":[{"asset":"Roboto-Medium.ttf"}]}]

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -172,7 +172,9 @@ bool Engine::UpdateAssetManager(
   }
 
   // Using libTXT as the text engine.
-  font_collection_->RegisterFonts(asset_manager_);
+  if (settings_.use_asset_fonts) {
+    font_collection_->RegisterFonts(asset_manager_);
+  }
 
   if (settings_.use_test_fonts) {
     font_collection_->RegisterTestFonts();

--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -419,12 +419,10 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line) {
     }
   }
 
-#if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
   settings.use_test_fonts =
       command_line.HasOption(FlagForSwitch(Switch::UseTestFonts));
   settings.use_asset_fonts =
       !command_line.HasOption(FlagForSwitch(Switch::DisableAssetFonts));
-#endif  // FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
 
   std::string enable_skparagraph = command_line.GetOptionValueWithDefault(
       FlagForSwitch(Switch::EnableSkParagraph), "");

--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -419,10 +419,12 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line) {
     }
   }
 
+#if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
   settings.use_test_fonts =
       command_line.HasOption(FlagForSwitch(Switch::UseTestFonts));
   settings.use_asset_fonts =
       !command_line.HasOption(FlagForSwitch(Switch::DisableAssetFonts));
+#endif // FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
 
   std::string enable_skparagraph = command_line.GetOptionValueWithDefault(
       FlagForSwitch(Switch::EnableSkParagraph), "");

--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -422,7 +422,7 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line) {
   settings.use_test_fonts =
       command_line.HasOption(FlagForSwitch(Switch::UseTestFonts));
   settings.use_asset_fonts =
-       !command_line.HasOption(FlagForSwitch(Switch::DisableAssetFonts));
+      !command_line.HasOption(FlagForSwitch(Switch::DisableAssetFonts));
 
   std::string enable_skparagraph = command_line.GetOptionValueWithDefault(
       FlagForSwitch(Switch::EnableSkParagraph), "");

--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -424,7 +424,7 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line) {
       command_line.HasOption(FlagForSwitch(Switch::UseTestFonts));
   settings.use_asset_fonts =
       !command_line.HasOption(FlagForSwitch(Switch::DisableAssetFonts));
-#endif // FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
+#endif  // FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
 
   std::string enable_skparagraph = command_line.GetOptionValueWithDefault(
       FlagForSwitch(Switch::EnableSkParagraph), "");

--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -421,6 +421,8 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line) {
 
   settings.use_test_fonts =
       command_line.HasOption(FlagForSwitch(Switch::UseTestFonts));
+  settings.use_asset_fonts =
+       !command_line.HasOption(FlagForSwitch(Switch::DisableAssetFonts));
 
   std::string enable_skparagraph = command_line.GetOptionValueWithDefault(
       FlagForSwitch(Switch::EnableSkParagraph), "");

--- a/shell/common/switches.h
+++ b/shell/common/switches.h
@@ -176,6 +176,11 @@ DEF_SWITCH(UseTestFonts,
            "will make font resolution default to the Ahem test font on all "
            "platforms (See https://www.w3.org/Style/CSS/Test/Fonts/Ahem/). "
            "This option is only available on the desktop test shells.")
+DEF_SWITCH(DisableAssetFonts,
+           "disable-asset-fonts",
+           "Prevents usage of any non-test fonts unless they were explicitly "
+           "Loaded via dart:ui font APIs. This option is only available on the "
+           "desktop test shells.")
 DEF_SWITCH(PrefetchedDefaultFontManager,
            "prefetched-default-font-manager",
            "Indicates whether the embedding started a prefetch of the "

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -637,13 +637,13 @@ def main():
     RunCCTests(build_dir, engine_filter, args.coverage, args.engine_capture_core_dump)
 
   if 'dart' in types:
-#    assert not IsWindows(), "Dart tests can't be run on windows. https://github.com/flutter/flutter/issues/36301."
+    assert not IsWindows(), "Dart tests can't be run on windows. https://github.com/flutter/flutter/issues/36301."
     dart_filter = args.dart_filter.split(',') if args.dart_filter else None
-    # RunDartSmokeTest(build_dir, args.verbose_dart_snapshot)
-    # RunLitetestTests(build_dir)
-    # RunGithooksTests(build_dir)
-    # RunClangTidyTests(build_dir)
-    # RunApiConsistencyTests(build_dir)
+    RunDartSmokeTest(build_dir, args.verbose_dart_snapshot)
+    RunLitetestTests(build_dir)
+    RunGithooksTests(build_dir)
+    RunClangTidyTests(build_dir)
+    RunApiConsistencyTests(build_dir)
     RunDartTests(build_dir, dart_filter, args.verbose_dart_snapshot)
     RunConstFinderTests(build_dir)
     RunFrontEndServerTests(build_dir)

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -286,7 +286,8 @@ def RunDartTest(build_dir, test_packages, dart_file, verbose_dart_snapshot, mult
   command_args += [
     '--use-test-fonts',
     '--icu-data-file-path=%s' % os.path.join(build_dir, 'icudtl.dat'),
-    '--flutter-assets-dir=%s' % os.path.join(build_dir, 'gen', 'flutter', 'lib', 'ui'),
+    '--flutter-assets-dir=%s' % os.path.join(build_dir, 'gen', 'flutter', 'lib', 'ui', 'assets'),
+    '--disable-asset-fonts',
     kernel_file_output,
   ]
 
@@ -636,13 +637,13 @@ def main():
     RunCCTests(build_dir, engine_filter, args.coverage, args.engine_capture_core_dump)
 
   if 'dart' in types:
-    assert not IsWindows(), "Dart tests can't be run on windows. https://github.com/flutter/flutter/issues/36301."
+#    assert not IsWindows(), "Dart tests can't be run on windows. https://github.com/flutter/flutter/issues/36301."
     dart_filter = args.dart_filter.split(',') if args.dart_filter else None
-    RunDartSmokeTest(build_dir, args.verbose_dart_snapshot)
-    RunLitetestTests(build_dir)
-    RunGithooksTests(build_dir)
-    RunClangTidyTests(build_dir)
-    RunApiConsistencyTests(build_dir)
+    # RunDartSmokeTest(build_dir, args.verbose_dart_snapshot)
+    # RunLitetestTests(build_dir)
+    # RunGithooksTests(build_dir)
+    # RunClangTidyTests(build_dir)
+    # RunApiConsistencyTests(build_dir)
     RunDartTests(build_dir, dart_filter, args.verbose_dart_snapshot)
     RunConstFinderTests(build_dir)
     RunFrontEndServerTests(build_dir)


### PR DESCRIPTION
Work towards https://github.com/flutter/flutter/issues/103724

TLDR: We want to make the tester able to load assets by passing flutter-asset-dir. Unfortunately that also causes tests to fallback to bundled fonts ahead of Ahem font which is massively breaking to scuba and not necessarily something we want to be easy. Add a flag that prevents registering fonts located in the asset bundle.

