### PR TITLE
Revert "Reland: Roll clang and buildroot"

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -2,7 +2,6 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//build/toolchain/clang.gni")
 import("//flutter/common/config.gni")
 import("//flutter/examples/examples.gni")
 import("//flutter/shell/platform/config.gni")
@@ -26,21 +25,9 @@ config("config") {
 }
 
 config("export_dynamic_symbols") {
-  # --dynamic-list is the GNU linker syntax supported by ELF linkers.
-  # -exported_symbols_list is the macOS linker syntax. The different flags
-  # accept files formatted differently, so we have exported_symbols.sym for GNU
-  # linker syntax, and exported_symbols_mac.sym for the macOS linker syntax.
   if (is_linux || is_fuchsia) {
     inputs = [ "//flutter/common/exported_symbols.sym" ]
     ldflags = [ "-Wl,--dynamic-list=" + rebase_path(inputs[0], root_build_dir) ]
-  } else if (is_mac && !use_xcode && flutter_runtime_mode == "debug") {
-    inputs = [ "//flutter/common/exported_symbols_mac.sym" ]
-    ldflags = [
-      "-Xlinker",
-      "-exported_symbols_list",
-      "-Xlinker",
-      rebase_path(inputs[0], root_build_dir),
-    ]
   }
 }
 

--- a/DEPS
+++ b/DEPS
@@ -111,7 +111,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '897fdb3e87b252f03915e20ba276302d8f029632',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '63f03c89282242d3f2938e0cc17038f35276c1e8',
 
    # Fuchsia compatibility
    #
@@ -566,7 +566,7 @@ deps = {
     'packages': [
       {
         'package': 'fuchsia/third_party/clang/mac-amd64',
-        'version': 'pjqtsy0EkprqQK20GImo0tXIwVJ5oygbAPUHOqmGRlwC'
+        'version': 'gi-ivU51hLEmgL3m_giEo-uJOhzJgdYslQ0dvUvAJxcC'
       }
     ],
     'condition': 'host_os == "mac"',
@@ -577,7 +577,7 @@ deps = {
     'packages': [
       {
         'package': 'fuchsia/third_party/clang/linux-amd64',
-        'version': 'xuUT1-3_9KoN3I7wncLinqPEYOMfQ16o53bxWJp0lIkC'
+        'version': 'Fn7lDYhKDAwbGQ2SOL_Anwt8fzO1Yho7UjpoS9Hv8N8C'
       }
     ],
     'condition': 'host_os == "linux"',
@@ -588,7 +588,7 @@ deps = {
     'packages': [
       {
         'package': 'fuchsia/third_party/clang/windows-amd64',
-        'version': 'X7Z_tBCdyVsbPRX99U7jBZnMfJ5RS11wocVcia798jwC'
+        'version': '25xTI5-MiVJ87YWFvdlrwmn4O0DVDz-j3oHlszZAyoQC'
       }
     ],
     'condition': 'download_windows_deps',

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -24,7 +24,6 @@ FILE: ../../../flutter/benchmarking/library.cc
 FILE: ../../../flutter/benchmarking/library.h
 FILE: ../../../flutter/common/constants.h
 FILE: ../../../flutter/common/exported_symbols.sym
-FILE: ../../../flutter/common/exported_symbols_mac.sym
 FILE: ../../../flutter/common/graphics/gl_context_switch.cc
 FILE: ../../../flutter/common/graphics/gl_context_switch.h
 FILE: ../../../flutter/common/graphics/persistent_cache.cc

--- a/common/exported_symbols_mac.sym
+++ b/common/exported_symbols_mac.sym
@@ -1,6 +1,0 @@
-# These symbols are looked up from within the executable at runtime and must
-# be exported in the dynamic symbol table.
-_kDartVmSnapshotData
-_kDartVmSnapshotInstructions
-_kDartIsolateSnapshotData
-_kDartIsolateSnapshotInstructions

--- a/shell/platform/darwin/ios/framework/Source/FlutterChannelKeyResponderTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterChannelKeyResponderTest.mm
@@ -74,8 +74,8 @@ API_AVAILABLE(ios(13.4))
                 }];
 
   XCTAssertEqual([messages count], 1u);
-  XCTAssertStrEqual([messages lastObject][@"keymap"], @"ios");
-  XCTAssertStrEqual([messages lastObject][@"type"], @"keydown");
+  XCTAssertEqual([messages lastObject][@"keymap"], @"ios");
+  XCTAssertEqual([messages lastObject][@"type"], @"keydown");
   XCTAssertEqual([[messages lastObject][@"keyCode"] intValue], keyACode);
   XCTAssertEqual([[messages lastObject][@"modifiers"] intValue], 0x0);
   XCTAssertStrEqual([messages lastObject][@"characters"], @"a");
@@ -95,8 +95,8 @@ API_AVAILABLE(ios(13.4))
                 }];
 
   XCTAssertEqual([messages count], 1u);
-  XCTAssertStrEqual([messages lastObject][@"keymap"], @"ios");
-  XCTAssertStrEqual([messages lastObject][@"type"], @"keyup");
+  XCTAssertEqual([messages lastObject][@"keymap"], @"ios");
+  XCTAssertEqual([messages lastObject][@"type"], @"keyup");
   XCTAssertEqual([[messages lastObject][@"keyCode"] intValue], keyACode);
   XCTAssertEqual([[messages lastObject][@"modifiers"] intValue], 0x0);
 
@@ -132,8 +132,8 @@ API_AVAILABLE(ios(13.4))
                 }];
 
   XCTAssertEqual([messages count], 1u);
-  XCTAssertStrEqual([messages lastObject][@"keymap"], @"ios");
-  XCTAssertStrEqual([messages lastObject][@"type"], @"keydown");
+  XCTAssertEqual([messages lastObject][@"keymap"], @"ios");
+  XCTAssertEqual([messages lastObject][@"type"], @"keydown");
   XCTAssertEqual([[messages lastObject][@"keyCode"] intValue], keyACode);
   XCTAssertEqual([[messages lastObject][@"modifiers"] intValue], 0x0);
   XCTAssertStrEqual([messages lastObject][@"characters"], @"a");

--- a/shell/platform/darwin/macos/framework/Source/FlutterChannelKeyResponderUnittests.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterChannelKeyResponderUnittests.mm
@@ -232,8 +232,8 @@ TEST(FlutterChannelKeyResponderUnittests, EmptyResponseIsTakenAsHandled) {
   EXPECT_STREQ([[messages lastObject][@"type"] UTF8String], "keydown");
   EXPECT_EQ([[messages lastObject][@"keyCode"] intValue], 0);
   EXPECT_EQ([[messages lastObject][@"modifiers"] intValue], 0);
-  EXPECT_STREQ([[messages lastObject][@"characters"] UTF8String], "a");
-  EXPECT_STREQ([[messages lastObject][@"charactersIgnoringModifiers"] UTF8String], "a");
+  EXPECT_EQ([[messages lastObject][@"characters"] UTF8String], "a");
+  EXPECT_EQ([[messages lastObject][@"charactersIgnoringModifiers"] UTF8String], "a");
 
   EXPECT_EQ([responses count], 1u);
   EXPECT_EQ([[responses lastObject] boolValue], TRUE);

--- a/tools/gn
+++ b/tools/gn
@@ -287,7 +287,7 @@ def to_gn_args(args):
 
     if gn_args['target_os'] == 'ios':
       gn_args['use_ios_simulator'] = args.simulator
-    else:
+    elif gn_args['target_os'] == 'mac':
       gn_args['use_ios_simulator'] = False
 
     if args.dart_debug:


### PR DESCRIPTION
Reverts flutter/engine#33325

The new tests on CI caught another issue: https://ci.chromium.org/ui/p/flutter/builders/prod/Mac%20Host%20Engine/15850/overview