### PR TITLE
Reland: Roll clang and buildroot

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -2,6 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import("//build/toolchain/clang.gni")
 import("//flutter/common/config.gni")
 import("//flutter/examples/examples.gni")
 import("//flutter/shell/platform/config.gni")
@@ -25,9 +26,21 @@ config("config") {
 }
 
 config("export_dynamic_symbols") {
+  # --dynamic-list is the GNU linker syntax supported by ELF linkers.
+  # -exported_symbols_list is the macOS linker syntax. The different flags
+  # accept files formatted differently, so we have exported_symbols.sym for GNU
+  # linker syntax, and exported_symbols_mac.sym for the macOS linker syntax.
   if (is_linux || is_fuchsia) {
     inputs = [ "//flutter/common/exported_symbols.sym" ]
     ldflags = [ "-Wl,--dynamic-list=" + rebase_path(inputs[0], root_build_dir) ]
+  } else if (is_mac && !use_xcode) {
+    inputs = [ "//flutter/common/exported_symbols_mac.sym" ]
+    ldflags = [
+      "-Xlinker",
+      "-exported_symbols_list",
+      "-Xlinker",
+      rebase_path(inputs[0], root_build_dir),
+    ]
   }
 }
 

--- a/DEPS
+++ b/DEPS
@@ -111,7 +111,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '63f03c89282242d3f2938e0cc17038f35276c1e8',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '897fdb3e87b252f03915e20ba276302d8f029632',
 
    # Fuchsia compatibility
    #
@@ -566,7 +566,7 @@ deps = {
     'packages': [
       {
         'package': 'fuchsia/third_party/clang/mac-amd64',
-        'version': 'gi-ivU51hLEmgL3m_giEo-uJOhzJgdYslQ0dvUvAJxcC'
+        'version': 'pjqtsy0EkprqQK20GImo0tXIwVJ5oygbAPUHOqmGRlwC'
       }
     ],
     'condition': 'host_os == "mac"',
@@ -577,7 +577,7 @@ deps = {
     'packages': [
       {
         'package': 'fuchsia/third_party/clang/linux-amd64',
-        'version': 'Fn7lDYhKDAwbGQ2SOL_Anwt8fzO1Yho7UjpoS9Hv8N8C'
+        'version': 'xuUT1-3_9KoN3I7wncLinqPEYOMfQ16o53bxWJp0lIkC'
       }
     ],
     'condition': 'host_os == "linux"',
@@ -588,7 +588,7 @@ deps = {
     'packages': [
       {
         'package': 'fuchsia/third_party/clang/windows-amd64',
-        'version': '25xTI5-MiVJ87YWFvdlrwmn4O0DVDz-j3oHlszZAyoQC'
+        'version': 'X7Z_tBCdyVsbPRX99U7jBZnMfJ5RS11wocVcia798jwC'
       }
     ],
     'condition': 'download_windows_deps',

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -24,6 +24,7 @@ FILE: ../../../flutter/benchmarking/library.cc
 FILE: ../../../flutter/benchmarking/library.h
 FILE: ../../../flutter/common/constants.h
 FILE: ../../../flutter/common/exported_symbols.sym
+FILE: ../../../flutter/common/exported_symbols_mac.sym
 FILE: ../../../flutter/common/graphics/gl_context_switch.cc
 FILE: ../../../flutter/common/graphics/gl_context_switch.h
 FILE: ../../../flutter/common/graphics/persistent_cache.cc

--- a/common/exported_symbols_mac.sym
+++ b/common/exported_symbols_mac.sym
@@ -1,0 +1,6 @@
+# These symbols are looked up from within the executable at runtime and must
+# be exported in the dynamic symbol table.
+_kDartVmSnapshotData
+_kDartVmSnapshotInstructions
+_kDartIsolateSnapshotData
+_kDartIsolateSnapshotInstructions

--- a/lib/ui/BUILD.gn
+++ b/lib/ui/BUILD.gn
@@ -203,6 +203,7 @@ if (enable_unittests) {
       ":ui",
       ":ui_unittests_fixtures",
       "//flutter/benchmarking",
+      "//flutter/lib/snapshot",
       "//flutter/shell/common",
       "//flutter/testing:fixture_test",
     ]
@@ -231,6 +232,7 @@ if (enable_unittests) {
       ":ui",
       ":ui_unittests_fixtures",
       "//flutter/common",
+      "//flutter/lib/snapshot",
       "//flutter/shell/common:shell_test_fixture_sources",
       "//flutter/testing",
       "//flutter/testing:dart",

--- a/runtime/BUILD.gn
+++ b/runtime/BUILD.gn
@@ -169,6 +169,7 @@ if (enable_unittests) {
     public_deps = [
       ":no_plugin_registrant",
       "//flutter/fml",
+      "//flutter/lib/snapshot",
       "//flutter/testing",
       "//flutter/testing:fixture_test",
     ]
@@ -189,6 +190,7 @@ if (enable_unittests) {
     public_deps = [
       ":plugin_registrant",
       "//flutter/fml",
+      "//flutter/lib/snapshot",
       "//flutter/runtime:dart_plugin_registrant",
       "//flutter/testing",
       "//flutter/testing:fixture_test",

--- a/shell/platform/darwin/ios/framework/Source/FlutterChannelKeyResponderTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterChannelKeyResponderTest.mm
@@ -74,8 +74,8 @@ API_AVAILABLE(ios(13.4))
                 }];
 
   XCTAssertEqual([messages count], 1u);
-  XCTAssertEqual([messages lastObject][@"keymap"], @"ios");
-  XCTAssertEqual([messages lastObject][@"type"], @"keydown");
+  XCTAssertStrEqual([messages lastObject][@"keymap"], @"ios");
+  XCTAssertStrEqual([messages lastObject][@"type"], @"keydown");
   XCTAssertEqual([[messages lastObject][@"keyCode"] intValue], keyACode);
   XCTAssertEqual([[messages lastObject][@"modifiers"] intValue], 0x0);
   XCTAssertStrEqual([messages lastObject][@"characters"], @"a");
@@ -95,8 +95,8 @@ API_AVAILABLE(ios(13.4))
                 }];
 
   XCTAssertEqual([messages count], 1u);
-  XCTAssertEqual([messages lastObject][@"keymap"], @"ios");
-  XCTAssertEqual([messages lastObject][@"type"], @"keyup");
+  XCTAssertStrEqual([messages lastObject][@"keymap"], @"ios");
+  XCTAssertStrEqual([messages lastObject][@"type"], @"keyup");
   XCTAssertEqual([[messages lastObject][@"keyCode"] intValue], keyACode);
   XCTAssertEqual([[messages lastObject][@"modifiers"] intValue], 0x0);
 
@@ -132,8 +132,8 @@ API_AVAILABLE(ios(13.4))
                 }];
 
   XCTAssertEqual([messages count], 1u);
-  XCTAssertEqual([messages lastObject][@"keymap"], @"ios");
-  XCTAssertEqual([messages lastObject][@"type"], @"keydown");
+  XCTAssertStrEqual([messages lastObject][@"keymap"], @"ios");
+  XCTAssertStrEqual([messages lastObject][@"type"], @"keydown");
   XCTAssertEqual([[messages lastObject][@"keyCode"] intValue], keyACode);
   XCTAssertEqual([[messages lastObject][@"modifiers"] intValue], 0x0);
   XCTAssertStrEqual([messages lastObject][@"characters"], @"a");

--- a/shell/platform/darwin/macos/framework/Source/FlutterChannelKeyResponderUnittests.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterChannelKeyResponderUnittests.mm
@@ -232,8 +232,8 @@ TEST(FlutterChannelKeyResponderUnittests, EmptyResponseIsTakenAsHandled) {
   EXPECT_STREQ([[messages lastObject][@"type"] UTF8String], "keydown");
   EXPECT_EQ([[messages lastObject][@"keyCode"] intValue], 0);
   EXPECT_EQ([[messages lastObject][@"modifiers"] intValue], 0);
-  EXPECT_EQ([[messages lastObject][@"characters"] UTF8String], "a");
-  EXPECT_EQ([[messages lastObject][@"charactersIgnoringModifiers"] UTF8String], "a");
+  EXPECT_STREQ([[messages lastObject][@"characters"] UTF8String], "a");
+  EXPECT_STREQ([[messages lastObject][@"charactersIgnoringModifiers"] UTF8String], "a");
 
   EXPECT_EQ([responses count], 1u);
   EXPECT_EQ([[responses lastObject] boolValue], TRUE);

--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -224,6 +224,7 @@ if (enable_unittests) {
       ":embedder_gpu_configuration",
       ":fixtures",
       "//flutter/flow",
+      "//flutter/lib/snapshot",
       "//flutter/lib/ui",
       "//flutter/runtime",
       "//flutter/testing",
@@ -273,7 +274,7 @@ if (enable_unittests) {
     }
   }
 
-  # Tests the build in FLUTTER_ENGINE_NO_PROTOTYPES mode.
+  # Tests that build in FLUTTER_ENGINE_NO_PROTOTYPES mode.
   executable("embedder_proctable_unittests") {
     testonly = true
 
@@ -293,6 +294,7 @@ if (enable_unittests) {
       ":embedder",
       ":embedder_gpu_configuration",
       ":fixtures",
+      "//flutter/lib/snapshot",
       "//flutter/testing",
 
       #"//flutter/testing:dart",

--- a/third_party/tonic/tests/BUILD.gn
+++ b/third_party/tonic/tests/BUILD.gn
@@ -23,6 +23,7 @@ executable("tonic_unittests") {
 
   public_deps = [
     ":tonic_fixtures",
+    "//flutter/lib/snapshot",
     "//flutter/runtime:libdart",
     "//flutter/runtime:runtime",
     "//flutter/testing",

--- a/tools/gn
+++ b/tools/gn
@@ -287,7 +287,7 @@ def to_gn_args(args):
 
     if gn_args['target_os'] == 'ios':
       gn_args['use_ios_simulator'] = args.simulator
-    elif gn_args['target_os'] == 'mac':
+    else:
       gn_args['use_ios_simulator'] = False
 
     if args.dart_debug:


### PR DESCRIPTION
This is a reland of https://github.com/flutter/engine/pull/33325. It fixes `flutter_tester` in profile and release modes by including the new linker argument in those builds, which I had mistakenly excluded in the last PR due to link errors that were actually caused by an incomplete listing of dependencies on some unit tests.