### PR TITLE
[web] Migrate Flutter Web DOM usage to JS static interop - 25.

### DIFF
--- a/lib/web_ui/lib/painting.dart
+++ b/lib/web_ui/lib/painting.dart
@@ -479,7 +479,7 @@ Future<Codec> instantiateImageCodec(
   if (engine.useCanvasKit) {
     return engine.skiaInstantiateImageCodec(list, targetWidth, targetHeight);
   } else {
-    final html.Blob blob = html.Blob(<dynamic>[list.buffer]);
+    final engine.DomBlob blob = engine.createDomBlob(<dynamic>[list.buffer]);
     return engine.HtmlBlobCodec(blob);
   }
 }
@@ -493,7 +493,7 @@ Future<Codec> instantiateImageCodecFromBuffer(
   if (engine.useCanvasKit) {
     return engine.skiaInstantiateImageCodec(buffer._list!, targetWidth, targetHeight);
   } else {
-    final html.Blob blob = html.Blob(<dynamic>[buffer._list!.buffer]);
+    final engine.DomBlob blob = engine.createDomBlob(<dynamic>[buffer._list!.buffer]);
     return engine.HtmlBlobCodec(blob);
   }
 }

--- a/lib/web_ui/lib/src/engine/html/bitmap_canvas.dart
+++ b/lib/web_ui/lib/src/engine/html/bitmap_canvas.dart
@@ -640,12 +640,11 @@ class BitmapCanvas extends EngineCanvas {
       }
     }
     // Can't reuse, create new instance.
-    final html.ImageElement newImageElement = htmlImage.cloneImageElement();
+    final DomHTMLImageElement newImageElement = htmlImage.cloneImageElement();
     if (_elementCache != null) {
-      _elementCache!.cache(cacheKey, newImageElement as DomHTMLImageElement,
-          _onEvictElement);
+      _elementCache!.cache(cacheKey, newImageElement, _onEvictElement);
     }
-    return newImageElement as DomHTMLImageElement;
+    return newImageElement;
   }
 
   static void _onEvictElement(DomHTMLElement element) {

--- a/lib/web_ui/test/engine/surface/scene_builder_test.dart
+++ b/lib/web_ui/test/engine/surface/scene_builder_test.dart
@@ -5,7 +5,6 @@
 @TestOn('chrome || firefox')
 
 import 'dart:async';
-import 'dart:html' as html;
 import 'dart:js_util' as js_util;
 
 import 'package:test/bootstrap/browser.dart';
@@ -496,19 +495,19 @@ void testMain() {
     // Renders a `string` by breaking it up into individual characters and
     // rendering each character into its own layer.
     Future<void> testCase(String string, String description, { int deletions = 0, int additions = 0, int moves = 0 }) {
-      final Set<html.Node> actualDeletions = <html.Node>{};
-      final Set<html.Node> actualAdditions = <html.Node>{};
+      final Set<DomNode> actualDeletions = <DomNode>{};
+      final Set<DomNode> actualAdditions = <DomNode>{};
 
       // Watches DOM mutations and counts deletions and additions to the child
       // list of the `<flt-scene>` element.
-      final html.MutationObserver observer = html.MutationObserver((List<dynamic> mutations, _) {
-        for (final html.MutationRecord record in mutations.cast<html.MutationRecord>()) {
+      final DomMutationObserver observer = createDomMutationObserver(allowInterop((List<dynamic> mutations, _) {
+        for (final DomMutationRecord record in mutations.cast<DomMutationRecord>()) {
           actualDeletions.addAll(record.removedNodes!);
           actualAdditions.addAll(record.addedNodes!);
         }
-      });
+      }));
       observer.observe(
-          SurfaceSceneBuilder.debugLastFrameScene!.rootElement! as html.Node, childList: true);
+          SurfaceSceneBuilder.debugLastFrameScene!.rootElement!, childList: true);
 
       final SurfaceSceneBuilder builder = SurfaceSceneBuilder();
       for (int i = 0; i < string.length; i++) {
@@ -912,9 +911,9 @@ EnginePicture _drawPathImagePath() {
 }
 
 HtmlImage createTestImage({int width = 100, int height = 50}) {
-  final html.CanvasElement canvas =
-      html.CanvasElement(width: width, height: height);
-  final html.CanvasRenderingContext2D ctx = canvas.context2D;
+  final DomCanvasElement canvas =
+      createDomCanvasElement(width: width, height: height);
+  final DomCanvasRenderingContext2D ctx = canvas.context2D;
   ctx.fillStyle = '#E04040';
   ctx.fillRect(0, 0, 33, 50);
   ctx.fill();
@@ -924,7 +923,7 @@ HtmlImage createTestImage({int width = 100, int height = 50}) {
   ctx.fillStyle = '#2040E0';
   ctx.fillRect(66, 0, 33, 50);
   ctx.fill();
-  final html.ImageElement imageElement = html.ImageElement();
+  final DomHTMLImageElement imageElement = createDomHTMLImageElement();
   imageElement.src = js_util.callMethod<String>(canvas, 'toDataURL', <dynamic>[]);
   return HtmlImage(imageElement, width, height);
 }

--- a/lib/web_ui/test/html/canvas_clip_path_golden_test.dart
+++ b/lib/web_ui/test/html/canvas_clip_path_golden_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:html' as html;
 import 'dart:js_util' as js_util;
 
 import 'package:test/bootstrap/browser.dart';
@@ -127,9 +126,9 @@ Future<void> testMain() async {
 }
 
 engine.HtmlImage createTestImage({int width = 200, int height = 150}) {
-  final html.CanvasElement canvas =
-      html.CanvasElement(width: width, height: height);
-  final html.CanvasRenderingContext2D ctx = canvas.context2D;
+  final engine.DomCanvasElement canvas =
+      engine.createDomCanvasElement(width: width, height: height);
+  final engine.DomCanvasRenderingContext2D ctx = canvas.context2D;
   ctx.fillStyle = '#E04040';
   ctx.fillRect(0, 0, width / 3, height);
   ctx.fill();
@@ -139,7 +138,7 @@ engine.HtmlImage createTestImage({int width = 200, int height = 150}) {
   ctx.fillStyle = '#2040E0';
   ctx.fillRect(2 * width / 3, 0, width / 3, height);
   ctx.fill();
-  final html.ImageElement imageElement = html.ImageElement();
+  final engine.DomHTMLImageElement imageElement = engine.createDomHTMLImageElement();
   imageElement.src = js_util.callMethod<String>(canvas, 'toDataURL', <dynamic>[]);
   return engine.HtmlImage(imageElement, width, height);
 }

--- a/lib/web_ui/test/html/canvas_reuse_golden_test.dart
+++ b/lib/web_ui/test/html/canvas_reuse_golden_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:html' as html;
-
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
@@ -109,7 +107,7 @@ const String _base64Encoded20x20TestImage = 'iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAI
 
 HtmlImage _createRealTestImage() {
   return HtmlImage(
-    html.ImageElement()
+    createDomHTMLImageElement()
       ..src = 'data:text/plain;base64,$_base64Encoded20x20TestImage',
     20,
     20,

--- a/lib/web_ui/test/html/compositing/canvas_blend_golden_test.dart
+++ b/lib/web_ui/test/html/compositing/canvas_blend_golden_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:html' as html;
 import 'dart:js_util' as js_util;
 
 import 'package:test/bootstrap/browser.dart';
@@ -107,9 +106,9 @@ Future<void> testMain() async {
 HtmlImage createTestImage() {
   const int width = 100;
   const int height = 50;
-  final html.CanvasElement canvas =
-      html.CanvasElement(width: width, height: height);
-  final html.CanvasRenderingContext2D ctx = canvas.context2D;
+  final DomCanvasElement canvas =
+      createDomCanvasElement(width: width, height: height);
+  final DomCanvasRenderingContext2D ctx = canvas.context2D;
   ctx.fillStyle = '#E04040';
   ctx.fillRect(0, 0, 33, 50);
   ctx.fill();
@@ -119,7 +118,7 @@ HtmlImage createTestImage() {
   ctx.fillStyle = '#2040E0';
   ctx.fillRect(66, 0, 33, 50);
   ctx.fill();
-  final html.ImageElement imageElement = html.ImageElement();
+  final DomHTMLImageElement imageElement = createDomHTMLImageElement();
   imageElement.src = js_util.callMethod<String>(canvas, 'toDataURL', <dynamic>[]);
   return HtmlImage(imageElement, width, height);
 }

--- a/lib/web_ui/test/html/compositing/color_filter_golden_test.dart
+++ b/lib/web_ui/test/html/compositing/color_filter_golden_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:html' as html;
 import 'dart:js_util' as js_util;
 
 import 'package:test/bootstrap/browser.dart';
@@ -192,5 +191,5 @@ HtmlImage createTestImage({int width = 200, int height = 150}) {
   ctx.fill();
   final DomHTMLImageElement imageElement = createDomHTMLImageElement();
   imageElement.src = js_util.callMethod<String>(canvas, 'toDataURL', <dynamic>[]);
-  return HtmlImage(imageElement as html.ImageElement, width, height);
+  return HtmlImage(imageElement, width, height);
 }

--- a/lib/web_ui/test/html/drawing/canvas_draw_image_golden_test.dart
+++ b/lib/web_ui/test/html/drawing/canvas_draw_image_golden_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:html' as html;
 import 'dart:js_util' as js_util;
 import 'dart:math' as math;
 
@@ -726,16 +725,16 @@ const String base64ImageData = 'data:image/png;base64,iVBORw0KGgoAAAANSUh'
 
 HtmlImage createNineSliceImage() {
   return HtmlImage(
-    html.ImageElement()..src = base64ImageData,
+    createDomHTMLImageElement()..src = base64ImageData,
     60,
     60,
   );
 }
 
 HtmlImage createTestImage({int width = 100, int height = 50}) {
-  final html.CanvasElement canvas =
-      html.CanvasElement(width: width, height: height);
-  final html.CanvasRenderingContext2D ctx = canvas.context2D;
+  final DomCanvasElement canvas =
+      createDomCanvasElement(width: width, height: height);
+  final DomCanvasRenderingContext2D ctx = canvas.context2D;
   ctx.fillStyle = '#E04040';
   ctx.fillRect(0, 0, 33, 50);
   ctx.fill();
@@ -745,7 +744,7 @@ HtmlImage createTestImage({int width = 100, int height = 50}) {
   ctx.fillStyle = '#2040E0';
   ctx.fillRect(66, 0, 33, 50);
   ctx.fill();
-  final html.ImageElement imageElement = html.ImageElement();
+  final DomHTMLImageElement imageElement = createDomHTMLImageElement();
   imageElement.src = js_util.callMethod<String>(canvas, 'toDataURL', <dynamic>[]);
   return HtmlImage(imageElement, width, height);
 }

--- a/lib/web_ui/test/html/drawing/canvas_draw_picture_golden_test.dart
+++ b/lib/web_ui/test/html/drawing/canvas_draw_picture_golden_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:html' as html;
-
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
@@ -144,7 +142,7 @@ const String _base64Encoded20x20TestImage =
 
 HtmlImage _createRealTestImage() {
   return HtmlImage(
-    html.ImageElement()
+    createDomHTMLImageElement()
       ..src = 'data:text/plain;base64,$_base64Encoded20x20TestImage',
     20,
     20,

--- a/lib/web_ui/test/html/drawing/draw_vertices_golden_test.dart
+++ b/lib/web_ui/test/html/drawing/draw_vertices_golden_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:html' as html;
 import 'dart:js_util' as js_util;
 import 'dart:typed_data';
 
@@ -416,9 +415,9 @@ Future<void> testMain() async {
 }
 
 Future<HtmlImage> createTestImage({int width = 50, int height = 40}) {
-  final html.CanvasElement canvas =
-      html.CanvasElement(width: width, height: height);
-  final html.CanvasRenderingContext2D ctx = canvas.context2D;
+  final DomCanvasElement canvas =
+      createDomCanvasElement(width: width, height: height);
+  final DomCanvasRenderingContext2D ctx = canvas.context2D;
   ctx.fillStyle = '#E04040';
   ctx.fillRect(0, 0, width / 3, height);
   ctx.fill();
@@ -428,11 +427,11 @@ Future<HtmlImage> createTestImage({int width = 50, int height = 40}) {
   ctx.fillStyle = '#2040E0';
   ctx.fillRect(2 * width / 3, 0, width / 3, height);
   ctx.fill();
-  final html.ImageElement imageElement = html.ImageElement();
+  final DomHTMLImageElement imageElement = createDomHTMLImageElement();
   final Completer<HtmlImage> completer = Completer<HtmlImage>();
-  imageElement.onLoad.listen((html.Event event) {
+  imageElement.addEventListener('load', allowInterop((DomEvent event) {
     completer.complete(HtmlImage(imageElement, width, height));
-  });
+  }));
   imageElement.src = js_util.callMethod<String>(canvas, 'toDataURL', <dynamic>[]);
   return completer.future;
 }

--- a/lib/web_ui/test/html/image_test.dart
+++ b/lib/web_ui/test/html/image_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:html';
 import 'dart:typed_data';
 
 import 'package:test/bootstrap/browser.dart';
@@ -156,14 +155,14 @@ Future<void> testMain() async {
     // if any pixels are left semi-transparent, which might be caused by
     // converting to and from pre-multiplied values. See
     // https://github.com/flutter/flutter/issues/92958 .
-    final CanvasElement canvas = CanvasElement()
+    final DomCanvasElement canvas = createDomCanvasElement()
       ..width = 2
       ..height = 2;
-    final CanvasRenderingContext2D ctx = canvas.context2D;
+    final DomCanvasRenderingContext2D ctx = canvas.context2D;
     ctx.drawImage((blueBackground as HtmlImage).imgElement, 0, 0);
     ctx.drawImage((sourceImage as HtmlImage).imgElement, 0, 0);
 
-    final ImageData imageData = ctx.getImageData(0, 0, 2, 2);
+    final DomImageData imageData = ctx.getImageData(0, 0, 2, 2);
     final List<int> actualPixels = imageData.data;
 
     final Uint8List benchmarkPixels = _pixelsToBytes(

--- a/lib/web_ui/test/html/picture_golden_test.dart
+++ b/lib/web_ui/test/html/picture_golden_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:html' as html;
-
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
@@ -29,7 +27,7 @@ void testMain() {
       final ui.Picture picture = recorder.endRecording();
       final HtmlImage image = await picture.toImage(200, 100) as HtmlImage;
       expect(image, isNotNull);
-      html.document.body!
+      domDocument.body!
         ..style.margin = '0'
         ..append(image.imgElement);
       try {

--- a/lib/web_ui/test/html/recording_canvas_golden_test.dart
+++ b/lib/web_ui/test/html/recording_canvas_golden_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:html' as html;
 import 'dart:math' as math;
 import 'dart:typed_data';
 
@@ -723,7 +722,7 @@ const String _base64Encoded20x20TestImage = 'iVBORw0KGgoAAAANSUhEUgAAABQAAAAUC'
 
 HtmlImage _createRealTestImage() {
   return HtmlImage(
-    html.ImageElement()
+    createDomHTMLImageElement()
       ..src = 'data:text/plain;base64,$_base64Encoded20x20TestImage',
     20,
     20,

--- a/lib/web_ui/test/html/shaders/image_shader_golden_test.dart
+++ b/lib/web_ui/test/html/shaders/image_shader_golden_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:html' as html;
 import 'dart:js_util' as js_util;
 
 import 'package:test/bootstrap/browser.dart';
@@ -131,9 +130,9 @@ HtmlImage createTestImage() {
   const int width = 16;
   const int width2 = width ~/ 2;
   const int height = 16;
-  final html.CanvasElement canvas =
-      html.CanvasElement(width: width, height: height);
-  final html.CanvasRenderingContext2D ctx = canvas.context2D;
+  final DomCanvasElement canvas =
+      createDomCanvasElement(width: width, height: height);
+  final DomCanvasRenderingContext2D ctx = canvas.context2D;
   ctx.fillStyle = '#E04040';
   ctx.fillRect(0, 0, width2, width2);
   ctx.fill();
@@ -143,7 +142,7 @@ HtmlImage createTestImage() {
   ctx.fillStyle = '#2040E0';
   ctx.fillRect(width2, width2, width2, width2);
   ctx.fill();
-  final html.ImageElement imageElement = html.ImageElement();
+  final DomHTMLImageElement imageElement = createDomHTMLImageElement();
   imageElement.src = js_util.callMethod<String>(canvas, 'toDataURL', <dynamic>[]);
   return HtmlImage(imageElement, width, height);
 }

--- a/lib/web_ui/test/html/testimage.dart
+++ b/lib/web_ui/test/html/testimage.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:html' as html;
-
 import 'package:ui/src/engine.dart';
 
 /// 50x50 pixel flutter logo image that contains alpha ramps and colors
@@ -117,7 +115,7 @@ const String _flutterLogoBase64 =
 
 HtmlImage createFlutterLogoTestImage() {
   return HtmlImage(
-    html.ImageElement()
+    createDomHTMLImageElement()
       ..src = 'data:text/plain;base64,$_flutterLogoBase64',
     50,
     50,


### PR DESCRIPTION
This is CL 25 in a series of CLs to migrate Flutter Web DOM usage to the new JS static interop API.