### PR TITLE
[web] Migrate Flutter Web DOM usage to JS static interop - 26.

### DIFF
--- a/lib/web_ui/lib/src/engine/onscreen_logging.dart
+++ b/lib/web_ui/lib/src/engine/onscreen_logging.dart
@@ -2,10 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:html' as html;
+import 'dom.dart';
 
-html.Element? _logElement;
-late html.Element _logContainer;
+DomElement? _logElement;
+late DomElement _logContainer;
 List<_LogMessage> _logBuffer = <_LogMessage>[];
 
 class _LogMessage {
@@ -51,7 +51,7 @@ void printOnScreen(Object object) {
 }
 
 void _initialize() {
-  _logElement = html.Element.tag('flt-onscreen-log');
+  _logElement = createDomElement('flt-onscreen-log');
   _logElement!.setAttribute('aria-hidden', 'true');
   _logElement!.style
     ..position = 'fixed'
@@ -66,14 +66,14 @@ void _initialize() {
     ..overflow = 'hidden'
     ..zIndex = '1000';
 
-  _logContainer = html.Element.tag('flt-log-container');
+  _logContainer = createDomElement('flt-log-container');
   _logContainer.setAttribute('aria-hidden', 'true');
   _logContainer.style
     ..position = 'absolute'
     ..bottom = '0';
   _logElement!.append(_logContainer);
 
-  html.document.body!.append(_logElement!);
+  domDocument.body!.append(_logElement!);
 }
 
 /// Dump the current stack to the console using [print] and


### PR DESCRIPTION
This is CL 26 in a series of CLs to migrate Flutter Web DOM usage to the new JS static interop API.