### PR TITLE
[web] Migrate Flutter Web DOM usage to JS static interop - 39.

### DIFF
--- a/lib/web_ui/lib/src/engine/dom.dart
+++ b/lib/web_ui/lib/src/engine/dom.dart
@@ -797,6 +797,7 @@ DomFontFace createDomFontFace(String family, Object source,
 extension DomFontFaceExtension on DomFontFace {
   Future<DomFontFace> load() =>
       js_util.promiseToFuture(js_util.callMethod(this, 'load', <Object>[]));
+  external String? get family;
 }
 
 @JS()
@@ -806,7 +807,11 @@ class DomFontFaceSet extends DomEventTarget {}
 extension DomFontFaceSetExtension on DomFontFaceSet {
   external DomFontFaceSet? add(DomFontFace font);
   external void clear();
+  external void forEach(DomFontFaceSetForEachCallback callback);
 }
+
+typedef DomFontFaceSetForEachCallback = void Function(
+    DomFontFace fontFace, DomFontFace fontFaceAgain, DomFontFaceSet set);
 
 @JS()
 @staticInterop

--- a/lib/web_ui/lib/src/engine/util.dart
+++ b/lib/web_ui/lib/src/engine/util.dart
@@ -557,7 +557,7 @@ bool unsafeIsNull(dynamic object) {
   return object == null;
 }
 
-/// A typed variant of [html.Window.fetch].
+/// A typed variant of [domWindow.fetch].
 Future<DomResponse> httpFetch(String url) async {
   final Object? result = await domWindow.fetch(url);
   return result! as DomResponse;

--- a/lib/web_ui/test/engine/profiler_test.dart
+++ b/lib/web_ui/test/engine/profiler_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:html' as html;
 import 'dart:js' as js;
 import 'dart:js_util' as js_util;
 
@@ -160,7 +159,7 @@ class BenchmarkDatapoint {
 
 void jsOnBenchmark(dynamic listener) {
   js_util.setProperty(
-    html.window,
+    domWindow,
     '_flutter_internal_on_benchmark',
     listener is Function
       ? js.allowInterop(listener)

--- a/lib/web_ui/test/engine/window_test.dart
+++ b/lib/web_ui/test/engine/window_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:html' as html;
 import 'dart:js_util' as js_util;
 import 'dart:typed_data';
 
@@ -302,7 +301,7 @@ Future<void> testMain() async {
 
   /// Regression test for https://github.com/flutter/flutter/issues/66128.
   test('setPreferredOrientation responds even if browser doesn\'t support api', () async {
-    final html.Screen screen = html.window.screen!;
+    final DomScreen screen = domWindow.screen!;
     js_util.setProperty(screen, 'orientation', null);
 
     final Completer<bool> completer = Completer<bool>();
@@ -343,14 +342,15 @@ Future<void> testMain() async {
     expect(window.locales, isEmpty);
     expect(window.locale, equals(const ui.Locale.fromSubtags()));
     expect(localeChangedCount, 0);
-    html.window.dispatchEvent(html.Event('languagechange'));
+    domWindow.dispatchEvent(createDomEvent('Event', 'languagechange'));
     expect(window.locales, isNotEmpty);
     expect(localeChangedCount, 1);
   });
 
   test('dispatches browser event on flutter/service_worker channel', () async {
     final Completer<void> completer = Completer<void>();
-    html.window.addEventListener('flutter-first-frame', completer.complete);
+    domWindow.addEventListener('flutter-first-frame',
+        allowInterop(completer.complete));
     final Zone innerZone = Zone.current.fork();
 
     innerZone.runGuarded(() {

--- a/lib/web_ui/test/html/bitmap_canvas_golden_test.dart
+++ b/lib/web_ui/test/html/bitmap_canvas_golden_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:html' as html;
 import 'dart:math' as math;
 
 import 'package:test/bootstrap/browser.dart';
@@ -24,16 +23,15 @@ Future<void> testMain() async {
 
   void appendToScene() {
     // Create a <flt-scene> element to make sure our CSS reset applies correctly.
-    final html.Element testScene = html.Element.tag('flt-scene');
+    final DomElement testScene = createDomElement('flt-scene');
     if (isIosSafari) {
       // Shrink to fit on the iPhone screen.
       testScene.style.position = 'absolute';
       testScene.style.transformOrigin = '0 0 0';
       testScene.style.transform = 'scale(0.3)';
     }
-    testScene.append(canvas.rootElement as html.Node);
-    flutterViewEmbedder.glassPaneShadow!.querySelector('flt-scene-host')!.append(testScene
-        as DomElement);
+    testScene.append(canvas.rootElement);
+    flutterViewEmbedder.glassPaneShadow!.querySelector('flt-scene-host')!.append(testScene);
   }
 
   setUpStableTestFonts();

--- a/lib/web_ui/test/html/canvas_context_golden_test.dart
+++ b/lib/web_ui/test/html/canvas_context_golden_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:html' as html;
-
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart' as engine;
@@ -32,7 +30,7 @@ Future<void> testMain() async {
     rc.apply(engineCanvas, screenRect);
 
     // Wrap in <flt-scene> so that our CSS selectors kick in.
-    final html.Element sceneElement = html.Element.tag('flt-scene');
+    final engine.DomElement sceneElement = engine.createDomElement('flt-scene');
     if (isIosSafari) {
       // Shrink to fit on the iPhone screen.
       sceneElement.style.position = 'absolute';
@@ -41,8 +39,8 @@ Future<void> testMain() async {
     }
 
     try {
-      sceneElement.append(engineCanvas.rootElement as html.Element);
-      html.document.body!.append(sceneElement);
+      sceneElement.append(engineCanvas.rootElement);
+      engine.domDocument.body!.append(sceneElement);
       // TODO(yjbanov): 10% diff rate is excessive. Update goldens.
       await matchGoldenFile('$fileName.png', region: region);
     } finally {

--- a/lib/web_ui/test/html/compositing/compositing_golden_test.dart
+++ b/lib/web_ui/test/html/compositing/compositing_golden_test.dart
@@ -691,8 +691,8 @@ void _testCullRectComputation() {
         .toFloat64());
 
     // TODO(yjbanov): see the TODO below.
-    // final double screenWidth = html.window.innerWidth.toDouble();
-    // final double screenHeight = html.window.innerHeight.toDouble();
+    // final double screenWidth = domWindow.innerWidth.toDouble();
+    // final double screenHeight = domWindow.innerHeight.toDouble();
 
     final Matrix4 scaleTransform = Matrix4.identity().scaled(0.5, 0.2);
     builder.pushTransform(

--- a/lib/web_ui/test/html/drawing/canvas_draw_color_golden_test.dart
+++ b/lib/web_ui/test/html/drawing/canvas_draw_color_golden_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:html' as html;
-
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
@@ -25,7 +23,7 @@ Future<void> testMain() async {
   });
 
   tearDown(() {
-    for (final html.Node scene in html.document.querySelectorAll('flt-scene')) {
+    for (final DomNode scene in domDocument.querySelectorAll('flt-scene')) {
       scene.remove();
     }
   });

--- a/lib/web_ui/test/html/shaders/gradient_golden_test.dart
+++ b/lib/web_ui/test/html/shaders/gradient_golden_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:html' as html;
 import 'dart:math' as math;
 import 'dart:typed_data';
 import 'dart:web_gl';
@@ -392,8 +391,8 @@ Future<void> testMain() async {
 
   test('Creating lots of gradients doesn\'t create too many webgl contexts',
       () async {
-    final html.CanvasElement sideCanvas =
-        html.CanvasElement(width: 5, height: 5);
+    final DomCanvasElement sideCanvas =
+        createDomCanvasElement(width: 5, height: 5);
     final RenderingContext? context =
         sideCanvas.getContext('webgl') as RenderingContext?;
     expect(context, isNotNull);

--- a/lib/web_ui/test/html/shaders/shader_mask_golden_test.dart
+++ b/lib/web_ui/test/html/shaders/shader_mask_golden_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:html' as html;
-
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart'
@@ -38,8 +36,8 @@ Future<void> testMain() async {
 
   setUp(() async {
     SurfaceSceneBuilder.debugForgetFrameScene();
-    for (final html.Node scene in
-        flutterViewEmbedder.sceneHostElement!.querySelectorAll('flt-scene').cast<html.Node>()) {
+    for (final DomNode scene in
+        flutterViewEmbedder.sceneHostElement!.querySelectorAll('flt-scene').cast<DomNode>()) {
       scene.remove();
     }
     initWebGl();

--- a/lib/web_ui/test/path_test.dart
+++ b/lib/web_ui/test/path_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 
-import 'dart:html' as html;
 import 'dart:js_util' as js_util;
 import 'dart:typed_data';
 import 'package:test/bootstrap/browser.dart';
@@ -412,7 +411,7 @@ void testMain() {
 
     // Regression test for https://github.com/flutter/flutter/issues/44470
     test('Should handle contains for devicepixelratio != 1.0', () {
-      js_util.setProperty(html.window, 'devicePixelRatio', 4.0);
+      js_util.setProperty(domWindow, 'devicePixelRatio', 4.0);
       window.debugOverrideDevicePixelRatio(4.0);
       final Path path = Path()
         ..moveTo(50, 0)
@@ -421,7 +420,7 @@ void testMain() {
         ..lineTo(50, 0)
         ..close();
       expect(path.contains(const Offset(50, 50)), isTrue);
-      js_util.setProperty(html.window, 'devicePixelRatio', 1.0);
+      js_util.setProperty(domWindow, 'devicePixelRatio', 1.0);
       window.debugOverrideDevicePixelRatio(1.0);
       // TODO(ferhat): Investigate failure on CI. Locally this passes.
       // [Exception... "Failure"  nsresult: "0x80004005 (NS_ERROR_FAILURE)"

--- a/lib/web_ui/test/text/font_collection_test.dart
+++ b/lib/web_ui/test/text/font_collection_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:html' as html;
-
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 
@@ -23,7 +21,7 @@ void testMain() {
     });
 
     tearDown(() {
-      html.document.fonts!.clear();
+      domDocument.fonts!.clear();
     });
 
     group('regular special characters', () {
@@ -34,10 +32,10 @@ void testMain() {
         fontManager.registerAsset(
             _testFontFamily, 'url($_testFontUrl)', const <String, String>{});
         await fontManager.ensureFontsLoaded();
-        html.document.fonts!
-            .forEach((html.FontFace f, html.FontFace f2, html.FontFaceSet s) {
+        domDocument.fonts!
+            .forEach(allowInterop((DomFontFace f, DomFontFace f2, DomFontFaceSet s) {
           fontFamilyList.add(f.family!);
-        });
+        }));
 
         expect(fontFamilyList.length, equals(1));
         expect(fontFamilyList.first, 'Ahem');
@@ -52,10 +50,10 @@ void testMain() {
         fontManager.registerAsset(
             _testFontFamily, 'url($_testFontUrl)', const <String, String>{});
         await fontManager.ensureFontsLoaded();
-        html.document.fonts!
-            .forEach((html.FontFace f, html.FontFace f2, html.FontFaceSet s) {
+        domDocument.fonts!
+            .forEach(allowInterop((DomFontFace f, DomFontFace f2, DomFontFaceSet s) {
           fontFamilyList.add(f.family!);
-        });
+        }));
 
         expect(fontFamilyList.length, equals(1));
         expect(fontFamilyList.first, 'Ahem ahem ahem');
@@ -72,10 +70,10 @@ void testMain() {
         fontManager.registerAsset(
             _testFontFamily, 'url($_testFontUrl)', const <String, String>{});
         await fontManager.ensureFontsLoaded();
-        html.document.fonts!
-            .forEach((html.FontFace f, html.FontFace f2, html.FontFaceSet s) {
+        domDocument.fonts!
+            .forEach(allowInterop((DomFontFace f, DomFontFace f2, DomFontFaceSet s) {
           fontFamilyList.add(f.family!);
-        });
+        }));
 
         expect(fontFamilyList.length, equals(1));
         expect(fontFamilyList.first, 'AhEm');
@@ -92,10 +90,10 @@ void testMain() {
         fontManager.registerAsset(
             _testFontFamily, 'url($_testFontUrl)', const <String, String>{});
         await fontManager.ensureFontsLoaded();
-        html.document.fonts!
-            .forEach((html.FontFace f, html.FontFace f2, html.FontFaceSet s) {
+        domDocument.fonts!
+            .forEach(allowInterop((DomFontFace f, DomFontFace f2, DomFontFaceSet s) {
           fontFamilyList.add(f.family!);
-        });
+        }));
 
         if (browserEngine != BrowserEngine.firefox) {
           expect(fontFamilyList.length, equals(2));
@@ -118,10 +116,10 @@ void testMain() {
         fontManager.registerAsset(
             _testFontFamily, 'url($_testFontUrl)', const <String, String>{});
         await fontManager.ensureFontsLoaded();
-        html.document.fonts!
-            .forEach((html.FontFace f, html.FontFace f2, html.FontFaceSet s) {
+        domDocument.fonts!
+            .forEach(allowInterop((DomFontFace f, DomFontFace f2, DomFontFaceSet s) {
           fontFamilyList.add(f.family!);
-        });
+        }));
 
         if (browserEngine != BrowserEngine.firefox) {
           expect(fontFamilyList.length, equals(2));
@@ -144,10 +142,10 @@ void testMain() {
         fontManager.registerAsset(
             _testFontFamily, 'url($_testFontUrl)', const <String, String>{});
         await fontManager.ensureFontsLoaded();
-        html.document.fonts!
-            .forEach((html.FontFace f, html.FontFace f2, html.FontFaceSet s) {
+        domDocument.fonts!
+            .forEach(allowInterop((DomFontFace f, DomFontFace f2, DomFontFaceSet s) {
           fontFamilyList.add(f.family!);
-        });
+        }));
 
         if (browserEngine != BrowserEngine.firefox) {
           expect(fontFamilyList.length, equals(2));
@@ -171,10 +169,10 @@ void testMain() {
         fontManager.registerAsset(
             testFontFamily, 'url($_testFontUrl)', const <String, String>{});
         await fontManager.ensureFontsLoaded();
-        html.document.fonts!
-            .forEach((html.FontFace f, html.FontFace f2, html.FontFaceSet s) {
+        domDocument.fonts!
+            .forEach(allowInterop((DomFontFace f, DomFontFace f2, DomFontFaceSet s) {
           fontFamilyList.add(f.family!);
-        });
+        }));
 
         if (browserEngine != BrowserEngine.firefox) {
           expect(fontFamilyList.length, equals(2));

--- a/lib/web_ui/test/text/font_loading_test.dart
+++ b/lib/web_ui/test/text/font_loading_test.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:html' as html;
 import 'dart:typed_data';
 
 import 'package:test/bootstrap/browser.dart';
@@ -22,7 +21,7 @@ Future<void> testMain() async {
     const String _testFontUrl = '/assets/fonts/ahem.ttf';
 
     tearDown(() {
-      html.document.fonts!.clear();
+      domDocument.fonts!.clear();
     });
 
     test('surfaces error from invalid font buffer', () async {
@@ -38,7 +37,7 @@ Future<void> testMain() async {
     test('loads Blehm font from buffer', () async {
       expect(_containsFontFamily('Blehm'), isFalse);
 
-      final html.HttpRequest response = await html.HttpRequest.request(
+      final DomXMLHttpRequest response = await domHttpRequest(
           _testFontUrl,
           responseType: 'arraybuffer');
       await ui.loadFontFromList(Uint8List.view(response.response as ByteBuffer),
@@ -64,7 +63,7 @@ Future<void> testMain() async {
 
       // Now, loads a new font using loadFontFromList. This should clear the
       // cache
-      final html.HttpRequest response = await html.HttpRequest.request(
+      final DomXMLHttpRequest response = await domHttpRequest(
           _testFontUrl,
           responseType: 'arraybuffer');
       await ui.loadFontFromList(Uint8List.view(response.response as ByteBuffer),
@@ -91,13 +90,13 @@ Future<void> testMain() async {
             buffer.asUint8List(data.offsetInBytes, data.lengthInBytes);
         message = utf8.decode(list);
       };
-      final html.HttpRequest response = await html.HttpRequest.request(
+      final DomXMLHttpRequest response = await domHttpRequest(
           _testFontUrl,
           responseType: 'arraybuffer');
       await ui.loadFontFromList(Uint8List.view(response.response as ByteBuffer),
           fontFamily: 'Blehm');
       final Completer<void> completer = Completer<void>();
-      html.window.requestAnimationFrame( (_) { completer.complete(); } );
+      domWindow.requestAnimationFrame(allowInterop((_) { completer.complete();}) );
       await (completer.future); // ignore: unnecessary_parenthesis
       window.onPlatformMessage = oldHandler;
       expect(actualName, 'flutter/system');
@@ -112,11 +111,11 @@ Future<void> testMain() async {
 
 bool _containsFontFamily(String family) {
   bool found = false;
-  html.document.fonts!.forEach((html.FontFace fontFace,
-      html.FontFace fontFaceAgain, html.FontFaceSet fontFaceSet) {
+  domDocument.fonts!.forEach(allowInterop((DomFontFace fontFace,
+      DomFontFace fontFaceAgain, DomFontFaceSet fontFaceSet) {
     if (fontFace.family == family) {
       found = true;
     }
-  });
+  }));
   return found;
 }

--- a/lib/web_ui/test/window_test.dart
+++ b/lib/web_ui/test/window_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:html' as html;
 import 'dart:js_util' as js_util;
 
 import 'package:test/bootstrap/browser.dart';
@@ -472,7 +471,7 @@ void testMain() {
 
 void jsSetUrlStrategy(dynamic strategy) {
   js_util.callMethod<void>(
-    html.window,
+    domWindow,
     '_flutter_web_set_location_strategy',
     <dynamic>[strategy],
   );


### PR DESCRIPTION
This is CL 39 in a series of CLs to migrate Flutter Web DOM usage to the new JS static interop API.