### PR TITLE
[Impeller] Get current path as string instead of native format in blobcat CLI

### DIFF
--- a/impeller/blobcat/blobcat_main.cc
+++ b/impeller/blobcat/blobcat_main.cc
@@ -33,7 +33,7 @@ bool Main(const fml::CommandLine& command_line) {
   }
 
   auto current_directory =
-      fml::OpenDirectory(std::filesystem::current_path().native().c_str(),
+      fml::OpenDirectory(std::filesystem::current_path().string().c_str(),
                          false, fml::FilePermission::kReadWrite);
   if (!fml::WriteAtomically(current_directory, output.c_str(), *blob)) {
     std::cerr << "Could not write shader blob to path " << output << std::endl;

--- a/impeller/geometry/path_component.cc
+++ b/impeller/geometry/path_component.cc
@@ -221,8 +221,8 @@ static void CubicPathSmoothenRecursive(const SmoothingApproximation& approx,
         da1 = ::fabs(::atan2(p4.y - p3.y, p4.x - p3.x) -
                      ::atan2(p3.y - p2.y, p3.x - p2.x));
 
-        if (da1 >= M_PI) {
-          da1 = 2.0 * M_PI - da1;
+        if (da1 >= kPi) {
+          da1 = 2.0 * kPi - da1;
         }
 
         if (da1 < approx.angle_tolerance) {
@@ -257,8 +257,8 @@ static void CubicPathSmoothenRecursive(const SmoothingApproximation& approx,
         da1 = ::fabs(::atan2(p3.y - p2.y, p3.x - p2.x) -
                      ::atan2(p2.y - p1.y, p2.x - p1.x));
 
-        if (da1 >= M_PI) {
-          da1 = 2.0 * M_PI - da1;
+        if (da1 >= kPi) {
+          da1 = 2.0 * kPi - da1;
         }
 
         if (da1 < approx.angle_tolerance) {
@@ -298,12 +298,12 @@ static void CubicPathSmoothenRecursive(const SmoothingApproximation& approx,
         da1 = ::fabs(k - ::atan2(p2.y - p1.y, p2.x - p1.x));
         da2 = ::fabs(::atan2(p4.y - p3.y, p4.x - p3.x) - k);
 
-        if (da1 >= M_PI) {
-          da1 = 2.0 * M_PI - da1;
+        if (da1 >= kPi) {
+          da1 = 2.0 * kPi - da1;
         }
 
-        if (da2 >= M_PI) {
-          da2 = 2.0 * M_PI - da2;
+        if (da2 >= kPi) {
+          da2 = 2.0 * kPi - da2;
         }
 
         if (da1 + da2 < approx.angle_tolerance) {


### PR DESCRIPTION
On Windows, `path::native()` returns a `wchar_t*` rathat than a `char*`. This is the only change I had to make in Impeller to get the render layer + tools building on Windows with an [external cmake config](https://github.com/bdero/impeller-cmake).

Also, avoid using `M_PI`, since the `cmath` that ships with VS2022 doesn't include it. Avoids the need for [this hack](https://github.com/bdero/impeller-cmake/blob/2864a809d392b2f556253d39f19e4f9885b9942b/impeller_geometry.cmake#L12-L13).