### PR TITLE
Correct SpellCheckChannel Javadoc

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/SpellCheckChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/SpellCheckChannel.java
@@ -25,13 +25,13 @@ import org.json.JSONException;
  * fetch spell check results for the specified text.
  *
  * <p>Once the spell check results are received by the {@link
- * io.flutter.plugin.editing.SpellCheckPlugin}, it will send to the framework the message {@code
- * SpellCheck.updateSpellCheckResults} with the {@code ArrayList<String>} of encoded spell check
- * results (see {@link
- * io.flutter.plugin.editing.SpellCheckPlugin#onGetSentenceSuggestions(SentenceSuggestionsInfo[])}
- * for details) with the text that these results correspond to appeneded to the front as an
- * argument. For example, the argument may look like: {@code {"Hello, wrold!",
- * "7.11.world\nword\nold"}}.
+ * io.flutter.plugin.editing.SpellCheckPlugin}, it will send back to the framework the {@code
+ * ArrayList<String>} of encoded spell check results (see {@link
+ * io.flutter.plugin.editing.SpellCheckPlugin#onGetSentenceSuggestions} for details) with the text
+ * that these results correspond to appeneded to the front as an argument. For example, the argument
+ * may look like: {@code {"Hello, wrold!", "7.11.world\nword\nold"}}. Please note that the {@link
+ * io.flutter.plugin.editing.SpellCheckPlugin} only handles one request to fetch spell check results
+ * at a time; see {@link io.flutter.plugin.editing.SpellCheckPlugin#initiateSpellCheck} for details.
  *
  * <p>{@link io.flutter.plugin.editing.SpellCheckPlugin} implements {@link SpellCheckMethodHandler}
  * to initiate spell check. Implement {@link SpellCheckMethodHandler} to respond to spell check

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/SpellCheckChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/SpellCheckChannel.java
@@ -28,7 +28,7 @@ import org.json.JSONException;
  * io.flutter.plugin.editing.SpellCheckPlugin}, it will send back to the framework the {@code
  * ArrayList<String>} of encoded spell check results (see {@link
  * io.flutter.plugin.editing.SpellCheckPlugin#onGetSentenceSuggestions} for details) with the text
- * that these results correspond to appeneded to the front as an argument. For example, the argument
+ * that these results correspond to appended to the front as an argument. For example, the argument
  * may look like: {@code {"Hello, wrold!", "7.11.world\nword\nold"}}. Please note that the {@link
  * io.flutter.plugin.editing.SpellCheckPlugin} only handles one request to fetch spell check results
  * at a time; see {@link io.flutter.plugin.editing.SpellCheckPlugin#initiateSpellCheck} for details.

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/SpellCheckChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/SpellCheckChannel.java
@@ -29,7 +29,7 @@ import org.json.JSONException;
  * ArrayList<String>} of encoded spell check results (see {@link
  * io.flutter.plugin.editing.SpellCheckPlugin#onGetSentenceSuggestions} for details) with the text
  * that these results correspond to appended to the front as an argument. For example, the argument
- * may look like: {@code {"Hello, wrold!", "7.11.world\nword\nold"}}. Please note that the {@link
+ * may look like: {@code {"Hello, wrold!", "7.11.world\nword\nold"}}. The {@link
  * io.flutter.plugin.editing.SpellCheckPlugin} only handles one request to fetch spell check results
  * at a time; see {@link io.flutter.plugin.editing.SpellCheckPlugin#initiateSpellCheck} for details.
  *


### PR DESCRIPTION
Corrects Javadoc for [PR #30858](https://github.com/flutter/engine/pull/30858).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
