### PR TITLE
Disable dart:io::exit(). It now throws UnsupportedError instead.

### DIFF
--- a/lib/io/dart_io.cc
+++ b/lib/io/dart_io.cc
@@ -37,6 +37,10 @@ void DartIO::InitForIsolate(bool may_insecurely_connect_to_all_domains,
       embedder_config_type, ToDart("_setDomainPolicies"), 1, dart_args);
   FML_CHECK(!CheckAndHandleError(set_domain_network_policy_result));
 
+  result =
+      Dart_SetField(embedder_config_type, ToDart("_mayExit"), Dart_False());
+  FML_CHECK(!CheckAndHandleError(result));
+
   Dart_Handle ui_lib = Dart_LookupLibrary(ToDart("dart:ui"));
   Dart_Handle dart_validate_args[1];
   dart_validate_args[0] = ToDart(may_insecurely_connect_to_all_domains);

--- a/testing/dart/BUILD.gn
+++ b/testing/dart/BUILD.gn
@@ -14,6 +14,7 @@ tests = [
   "compositing_test.dart",
   "dart_test.dart",
   "encoding_test.dart",
+  "exit_test.dart",
   "fragment_shader_test.dart",
   "geometry_test.dart",
   "gesture_settings_test.dart",

--- a/testing/dart/exit_test.dart
+++ b/testing/dart/exit_test.dart
@@ -1,0 +1,21 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io' as io;
+
+import 'package:litetest/litetest.dart';
+
+/// Verifies that io.exit() throws an exception.
+void main() {
+  test('dart:io exit() throws an exception', () async {
+    bool caught = false;
+    try {
+      io.exit(0);
+    } on UnsupportedError catch (e) {
+      expect(e.toString(), contains("disallows calling dart:io's exit()"));
+      caught = true;
+    }
+    expect(caught, true);
+  });
+}


### PR DESCRIPTION
When `exit()` is called in the Engine process, shutdown will not happen cleanly, and the Engine is prone to crashes, which confuses users and crash logging services. This PR toggles a Dart VM flag which changes the behavior of `dart:io` `exit()` to throw an exception rather than call `exit()`.

See for example https://github.com/flutter/flutter/issues/103587