### PR TITLE
Set error handler

### DIFF
--- a/shell/platform/fuchsia/flutter/pointer_delegate.cc
+++ b/shell/platform/fuchsia/flutter/pointer_delegate.cc
@@ -5,6 +5,8 @@
 #include "pointer_delegate.h"
 
 #include <lib/trace/event.h>
+#include <zircon/status.h>
+#include <zircon/types.h>
 
 #include <limits>
 
@@ -318,6 +320,23 @@ void InsertIntoBuffer(
 }
 }  // namespace
 
+PointerDelegate::PointerDelegate(
+    fuchsia::ui::pointer::TouchSourceHandle touch_source,
+    fuchsia::ui::pointer::MouseSourceHandle mouse_source)
+    : touch_source_(touch_source.Bind()), mouse_source_(mouse_source.Bind()) {
+  if (touch_source_) {
+    touch_source_.set_error_handler([](zx_status_t status) {
+      FML_LOG(ERROR) << "TouchSource channel error: << "
+                     << zx_status_get_string(status);
+    });
+  }
+  if (mouse_source_) {
+    mouse_source_.set_error_handler([](zx_status_t status) {
+      FML_LOG(ERROR) << "MouseSource channel error: << "
+                     << zx_status_get_string(status);
+    });
+  }
+}
 // Core logic of this class.
 // Aim to keep state management in this function.
 void PointerDelegate::WatchLoop(

--- a/shell/platform/fuchsia/flutter/pointer_delegate.h
+++ b/shell/platform/fuchsia/flutter/pointer_delegate.h
@@ -35,9 +35,7 @@ struct IxnHasher {
 class PointerDelegate {
  public:
   PointerDelegate(fuchsia::ui::pointer::TouchSourceHandle touch_source,
-                  fuchsia::ui::pointer::MouseSourceHandle mouse_source)
-      : touch_source_(touch_source.Bind()),
-        mouse_source_(mouse_source.Bind()) {}
+                  fuchsia::ui::pointer::MouseSourceHandle mouse_source);
 
   // This function collects Fuchsia's TouchPointerSample and MousePointerSample
   // data and transforms them into flutter::PointerData structs. It then calls


### PR DESCRIPTION
Call SetErrorHandler on TouchSource and MouseSource channels, with a log message about channel closure.

https://github.com/flutter/flutter/issues/103928

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

