### PR TITLE
fix unused-variable error on SUPPORT_FRACTIONAL_TRANSLATION variant

### DIFF
--- a/flow/layers/clip_path_layer_unittests.cc
+++ b/flow/layers/clip_path_layer_unittests.cc
@@ -391,7 +391,9 @@ TEST_F(ClipPathLayerTest, OpacityInheritancePainting) {
   opacity_layer->Preroll(context, SkMatrix::I());
   EXPECT_TRUE(opacity_layer->children_can_accept_opacity());
 
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
   auto opacity_integer_transform = SkM44::Translate(offset.fX, offset.fY);
+#endif
   DisplayListBuilder expected_builder;
   /* OpacityLayer::Paint() */ {
     expected_builder.save();
@@ -462,7 +464,9 @@ TEST_F(ClipPathLayerTest, OpacityInheritanceSaveLayerPainting) {
   opacity_layer->Preroll(context, SkMatrix::I());
   EXPECT_TRUE(opacity_layer->children_can_accept_opacity());
 
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
   auto opacity_integer_transform = SkM44::Translate(offset.fX, offset.fY);
+#endif
   DisplayListBuilder expected_builder;
   /* OpacityLayer::Paint() */ {
     expected_builder.save();

--- a/flow/layers/clip_rect_layer_unittests.cc
+++ b/flow/layers/clip_rect_layer_unittests.cc
@@ -384,8 +384,9 @@ TEST_F(ClipRectLayerTest, OpacityInheritancePainting) {
   context->subtree_can_inherit_opacity = false;
   opacity_layer->Preroll(context, SkMatrix::I());
   EXPECT_TRUE(opacity_layer->children_can_accept_opacity());
-
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
   auto opacity_integer_transform = SkM44::Translate(offset.fX, offset.fY);
+#endif
   DisplayListBuilder expected_builder;
   /* OpacityLayer::Paint() */ {
     expected_builder.save();
@@ -453,8 +454,9 @@ TEST_F(ClipRectLayerTest, OpacityInheritanceSaveLayerPainting) {
   context->subtree_can_inherit_opacity = false;
   opacity_layer->Preroll(context, SkMatrix::I());
   EXPECT_TRUE(opacity_layer->children_can_accept_opacity());
-
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
   auto opacity_integer_transform = SkM44::Translate(offset.fX, offset.fY);
+#endif
   DisplayListBuilder expected_builder;
   /* OpacityLayer::Paint() */ {
     expected_builder.save();

--- a/flow/layers/clip_rrect_layer_unittests.cc
+++ b/flow/layers/clip_rrect_layer_unittests.cc
@@ -392,7 +392,9 @@ TEST_F(ClipRRectLayerTest, OpacityInheritancePainting) {
   opacity_layer->Preroll(context, SkMatrix::I());
   EXPECT_TRUE(opacity_layer->children_can_accept_opacity());
 
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
   auto opacity_integer_transform = SkM44::Translate(offset.fX, offset.fY);
+#endif
   DisplayListBuilder expected_builder;
   /* OpacityLayer::Paint() */ {
     expected_builder.save();
@@ -462,7 +464,9 @@ TEST_F(ClipRRectLayerTest, OpacityInheritanceSaveLayerPainting) {
   opacity_layer->Preroll(context, SkMatrix::I());
   EXPECT_TRUE(opacity_layer->children_can_accept_opacity());
 
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
   auto opacity_integer_transform = SkM44::Translate(offset.fX, offset.fY);
+#endif
   DisplayListBuilder expected_builder;
   /* OpacityLayer::Paint() */ {
     expected_builder.save();

--- a/flow/layers/color_filter_layer_unittests.cc
+++ b/flow/layers/color_filter_layer_unittests.cc
@@ -351,8 +351,10 @@ TEST_F(ColorFilterLayerTest, OpacityInheritance) {
   opacity_layer->Preroll(context, SkMatrix::I());
   EXPECT_TRUE(opacity_layer->children_can_accept_opacity());
 
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
   auto opacity_integer_transform = RasterCache::GetIntegralTransCTM(
       SkMatrix::Translate(offset.fX, offset.fY));
+#endif
   DisplayListBuilder expected_builder;
   /* opacity_layer::Paint() */ {
     expected_builder.save();

--- a/flow/layers/display_list_layer_unittests.cc
+++ b/flow/layers/display_list_layer_unittests.cc
@@ -141,8 +141,10 @@ TEST_F(DisplayListLayerTest, SimpleDisplayListOpacityInheritance) {
       RasterCache::GetIntegralTransCTM(SkMatrix::Translate(opacity_offset));
   SkMatrix layer_offset_matrix = opacity_integral_matrix;
   layer_offset_matrix.postTranslate(layer_offset.fX, layer_offset.fY);
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
   auto layer_offset_integral_matrix =
       RasterCache::GetIntegralTransCTM(layer_offset_matrix);
+#endif
   DisplayListBuilder expected_builder;
   /* opacity_layer::Paint() */ {
     expected_builder.save();
@@ -214,8 +216,10 @@ TEST_F(DisplayListLayerTest, IncompatibleDisplayListOpacityInheritance) {
   auto save_layer_bounds =
       display_list_bounds.makeOffset(layer_offset.fX, layer_offset.fY);
   save_layer_bounds.roundOut(&save_layer_bounds);
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
   auto opacity_integral_matrix =
       RasterCache::GetIntegralTransCTM(SkMatrix::Translate(opacity_offset));
+#endif
   SkMatrix layer_offset_matrix = opacity_integral_matrix;
   layer_offset_matrix.postTranslate(layer_offset.fX, layer_offset.fY);
   auto layer_offset_integral_matrix =

--- a/flow/layers/image_filter_layer_unittests.cc
+++ b/flow/layers/image_filter_layer_unittests.cc
@@ -401,8 +401,10 @@ TEST_F(ImageFilterLayerTest, OpacityInheritance) {
   opacity_layer->Preroll(context, SkMatrix::I());
   EXPECT_TRUE(opacity_layer->children_can_accept_opacity());
 
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
   auto opacity_integer_transform = RasterCache::GetIntegralTransCTM(
       SkMatrix::Translate(offset.fX, offset.fY));
+#endif
   auto dl_image_filter = DlImageFilter::From(layer_filter);
   DisplayListBuilder expected_builder;
   /* opacity_layer::Paint() */ {

--- a/flow/layers/shader_mask_layer_unittests.cc
+++ b/flow/layers/shader_mask_layer_unittests.cc
@@ -343,7 +343,9 @@ TEST_F(ShaderMaskLayerTest, OpacityInheritance) {
   opacity_layer->Preroll(context, SkMatrix::I());
   EXPECT_TRUE(opacity_layer->children_can_accept_opacity());
 
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
   auto opacity_integer_transform = SkM44::Translate(offset.fX, offset.fY);
+#endif
   DisplayListBuilder expected_builder;
   /* OpacityLayer::Paint() */ {
     expected_builder.save();

--- a/flow/layers/transform_layer_unittests.cc
+++ b/flow/layers/transform_layer_unittests.cc
@@ -311,7 +311,9 @@ TEST_F(TransformLayerTest, OpacityInheritancePainting) {
   opacity_layer->Preroll(context, SkMatrix::I());
   EXPECT_TRUE(opacity_layer->children_can_accept_opacity());
 
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
   auto opacity_integer_transform = SkM44::Translate(offset.fX, offset.fY);
+#endif
   DisplayListBuilder expected_builder;
   /* opacity_layer paint */ {
     expected_builder.save();


### PR DESCRIPTION
Fixes compile warnings from https://logs.chromium.org/logs/flutter/led/flutter-try-builder_chops-service-accounts.iam.gserviceaccount.com/e401b8d621fe41f03bfbbf04dc2ef892aeace6a32984c45ac52c979c570b6723/+/u/build_host_debug_fractional/stdout 
