### PR TITLE
[impeller] Reset GL state before starting a new render pass.

### DIFF
--- a/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -219,6 +219,14 @@ struct RenderPassData {
   if (pass_data.clear_stencil_attachment) {
     clear_bits |= GL_STENCIL_BUFFER_BIT;
   }
+
+  gl.Disable(GL_SCISSOR_TEST);
+  gl.Disable(GL_DEPTH_TEST);
+  gl.Disable(GL_STENCIL_TEST);
+  gl.Disable(GL_CULL_FACE);
+  gl.Disable(GL_BLEND);
+  gl.ColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+
   gl.Clear(clear_bits);
 
   for (const auto& command : commands) {


### PR DESCRIPTION
This fixes the issue observed in the playgrounds where the scissor test enabled by the last command of the previous render pass would cause the clear to be affected.

The docs for glClear point this out: `The pixel ownership test, the scissor test, dithering, and the buffer writemasks affect the operation of glClear. The scissor box bounds the cleared region.`. This also affects optimizations on mobile.
<img width="1136" alt="Screen Shot 2022-05-16 at 4 55 12 PM" src="https://user-images.githubusercontent.com/44085/168701570-e9ecd943-cd07-415e-b0ff-6569584b527b.png">
