### PR TITLE
[web] Use the inputMode property

### DIFF
--- a/lib/web_ui/lib/src/engine/text_editing/input_type.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/input_type.dart
@@ -85,7 +85,7 @@ abstract class EngineInputType {
     if (operatingSystem == OperatingSystem.iOs ||
         operatingSystem == OperatingSystem.android ||
         inputmodeAttribute == EngineInputType.none.inputmodeAttribute) {
-      domElement.setAttribute('inputmode', inputmodeAttribute!);
+      domElement.inputMode = inputmodeAttribute;
     }
   }
 }

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -1134,7 +1134,7 @@ abstract class DefaultTextEditingStrategy implements TextEditingStrategy {
     }
 
     if (config.inputType == EngineInputType.none) {
-      activeDomElement.setAttribute('inputmode', 'none');
+      activeDomElement.inputMode = 'none';
     }
 
     final AutofillInfo? autofill = config.autofill;

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -451,7 +451,7 @@ Future<void> testMain() async {
     }
 
     String? getEditingInputMode() {
-      return textEditing!.strategy.domElement!.getAttribute('inputmode');
+      return textEditing!.strategy.domElement!.inputMode;
     }
 
     setUp(() {


### PR DESCRIPTION
After the comments [here](https://github.com/flutter/engine/pull/33298#discussion_r871849803) and [here](https://github.com/dart-lang/sdk/issues/49014#issuecomment-1126805479), we are changing this to use the `inputMode` property instead of setting as an attribute.