### PR TITLE
[web] Send input action even in multiline editing mode

### DIFF
--- a/lib/web_ui/lib/src/engine/text_editing/input_type.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/input_type.dart
@@ -68,9 +68,6 @@ abstract class EngineInputType {
   /// <https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode>.
   String? get inputmodeAttribute;
 
-  /// Whether this input type allows the "Enter" key to submit the input action.
-  bool get submitActionOnEnter => true;
-
   /// Create the appropriate DOM element for this input type.
   html.HtmlElement createDomElement() => html.InputElement();
 
@@ -157,9 +154,6 @@ class MultilineInputType extends EngineInputType {
 
   @override
   String? get inputmodeAttribute => null;
-
-  @override
-  bool get submitActionOnEnter => false;
 
   @override
   html.HtmlElement createDomElement() => html.TextAreaElement();

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -1302,12 +1302,8 @@ abstract class DefaultTextEditingStrategy implements TextEditingStrategy {
   }
 
   void maybeSendAction(html.Event event) {
-    if (event is html.KeyboardEvent) {
-      if (inputConfiguration.inputType.submitActionOnEnter &&
-          event.keyCode == _kReturnKeyCode) {
-        event.preventDefault();
-        onAction!(inputConfiguration.inputAction);
-      }
+    if (event is html.KeyboardEvent && event.keyCode == _kReturnKeyCode) {
+      onAction!(inputConfiguration.inputAction);
     }
   }
 

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -353,7 +353,7 @@ Future<void> testMain() async {
         // TODO(mdebbar): https://github.com/flutter/flutter/issues/50769
         skip: browserEngine == BrowserEngine.edge);
 
-    test('Does not trigger input action in multi-line mode', () {
+    test('Triggers input action in multi-line mode', () {
       final InputConfiguration config = InputConfiguration(
         inputType: EngineInputType.multiline,
         inputAction: 'TextInputAction.done',
@@ -373,8 +373,8 @@ Future<void> testMain() async {
         keyCode: _kReturnKeyCode,
       );
 
-      // Still no input action.
-      expect(lastInputAction, isNull);
+      // Input action is triggered!
+      expect(lastInputAction, 'TextInputAction.done');
       // And default behavior of keyboard event shouldn't have been prevented.
       expect(event.defaultPrevented, isFalse);
     });
@@ -1903,7 +1903,7 @@ Future<void> testMain() async {
         // TODO(mdebbar): https://github.com/flutter/flutter/issues/50769
         skip: browserEngine == BrowserEngine.edge);
 
-    test('does not send input action in multi-line mode', () {
+    test('sends input action in multi-line mode', () {
       showKeyboard(
         inputType: 'multiline',
         inputAction: 'TextInputAction.next',
@@ -1915,8 +1915,14 @@ Future<void> testMain() async {
         keyCode: _kReturnKeyCode,
       );
 
-      // No input action and no platform message have been sent.
-      expect(spy.messages, isEmpty);
+      // Input action is sent as a platform message.
+      expect(spy.messages, hasLength(1));
+      expect(spy.messages[0].channel, 'flutter/textinput');
+      expect(spy.messages[0].methodName, 'TextInputClient.performAction');
+      expect(
+        spy.messages[0].methodArguments,
+        <dynamic>[clientId, 'TextInputAction.next'],
+      );
       // And default behavior of keyboard event shouldn't have been prevented.
       expect(event.defaultPrevented, isFalse);
     });


### PR DESCRIPTION
On non-web platforms, the engine **always** sends an input action message to the framework when ENTER is clicked (regardless of the field being single or multi-line).

On the web, we don't send an input action for multi-line fields. This PR fixes it so we always send an input action just like the native engine does.

Fixes https://github.com/flutter/flutter/issues/99900