### PR TITLE
[Impeller] Fix application of paint alpha for textures/savelayers

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -469,14 +469,14 @@ TEST_P(AiksTest, PaintBlendModeIsRespected) {
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
-TEST_P(AiksTest, CanDrawWithAdvancedBlend) {
+TEST_P(AiksTest, ColorWheel) {
   // Compare with https://fiddle.skia.org/c/@BlendModes
 
   std::vector<const char*> blend_mode_names;
   std::vector<Entity::BlendMode> blend_mode_values;
   {
     const std::vector<std::tuple<const char*, Entity::BlendMode>> blends = {
-        // Pipeline blends (Porter-Duff/alpha blends)
+        // Pipeline blends (Porter-Duff alpha compositing)
         {"Clear", Entity::BlendMode::kClear},
         {"Source", Entity::BlendMode::kSource},
         {"Destination", Entity::BlendMode::kDestination},
@@ -491,7 +491,7 @@ TEST_P(AiksTest, CanDrawWithAdvancedBlend) {
         {"Xor", Entity::BlendMode::kXor},
         {"Plus", Entity::BlendMode::kPlus},
         {"Modulate", Entity::BlendMode::kModulate},
-        // Advanced blends (non Porter-Duff/color blends)
+        // Advanced blends (color component blends)
         {"Screen", Entity::BlendMode::kScreen},
         {"ColorBurn", Entity::BlendMode::kColorBurn},
     };
@@ -572,16 +572,17 @@ TEST_P(AiksTest, CanDrawWithAdvancedBlend) {
     draw_color_wheel(canvas);
 
     // Draw 3 circles to a subpass and blend it in.
-    canvas.SaveLayer({.blend_mode = blend_mode_values[current_blend_index]});
+    canvas.SaveLayer({.color = Color::White().WithAlpha(alpha),
+                      .blend_mode = blend_mode_values[current_blend_index]});
     {
       paint.blend_mode = Entity::BlendMode::kPlus;
       const Scalar x = std::sin(k2Pi / 3);
       const Scalar y = -std::cos(k2Pi / 3);
-      paint.color = Color::Red().WithAlpha(alpha);
+      paint.color = Color::Red();
       canvas.DrawCircle(Point(-x, y) * 45, 65, paint);
-      paint.color = Color::Green().WithAlpha(alpha);
+      paint.color = Color::Green();
       canvas.DrawCircle(Point(0, -1) * 45, 65, paint);
-      paint.color = Color::Blue().WithAlpha(alpha);
+      paint.color = Color::Blue();
       canvas.DrawCircle(Point(x, y) * 45, 65, paint);
     }
     canvas.Restore();

--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -233,6 +233,7 @@ void Canvas::DrawImageRect(std::shared_ptr<Image> image,
   contents->SetTexture(image->GetTexture());
   contents->SetSourceRect(source);
   contents->SetSamplerDescriptor(std::move(sampler));
+  contents->SetOpacity(paint.color.alpha);
 
   Entity entity;
   entity.SetBlendMode(paint.blend_mode);

--- a/impeller/entity/shaders/texture_fill.frag
+++ b/impeller/entity/shaders/texture_fill.frag
@@ -11,6 +11,5 @@ out vec4 frag_color;
 
 void main() {
   vec4 sampled = texture(texture_sampler, v_texture_coords);
-  sampled.w *= v_alpha;
-  frag_color = sampled;
+  frag_color = sampled * v_alpha;
 }


### PR DESCRIPTION
Our pipeline blends are additive and expect premultiplied source colors, so the color components need to be multiplied.
Also fixed the color wheel test to make the layer transparent instead of the circles. Makes it easier to see the subtle difference between plus/screen and multiply/colorburn.

https://user-images.githubusercontent.com/919017/168910691-d7af28af-57bb-4120-9e7d-648a20d752aa.mov

