### PR TITLE
[impeller] Give textures content mappings so they may elide a copy.

### DIFF
--- a/impeller/playground/playground.cc
+++ b/impeller/playground/playground.cc
@@ -342,8 +342,7 @@ std::shared_ptr<Texture> Playground::CreateTextureForFixture(
   }
   texture->SetLabel(fixture_name);
 
-  auto uploaded = texture->SetContents(image->GetAllocation()->GetMapping(),
-                                       image->GetAllocation()->GetSize());
+  auto uploaded = texture->SetContents(image->GetAllocation());
   if (!uploaded) {
     VALIDATION_LOG << "Could not upload texture to device memory for fixture "
                    << fixture_name;

--- a/impeller/renderer/backend/gles/texture_gles.cc
+++ b/impeller/renderer/backend/gles/texture_gles.cc
@@ -132,7 +132,6 @@ struct TexImage2DData {
       }
 
       case PixelFormat::kR8G8B8A8UNormInt: {
-        TRACE_EVENT0("impeller", "R8G8B8A8UNormIntCopy");
         internal_format = GL_RGBA;
         format = GL_RGBA;
         type = GL_UNSIGNED_BYTE;

--- a/impeller/renderer/backend/gles/texture_gles.cc
+++ b/impeller/renderer/backend/gles/texture_gles.cc
@@ -7,6 +7,7 @@
 #include <optional>
 
 #include "flutter/fml/mapping.h"
+#include "flutter/fml/trace_event.h"
 #include "impeller/base/allocation.h"
 #include "impeller/base/config.h"
 #include "impeller/base/validation.h"
@@ -78,7 +79,7 @@ struct TexImage2DData {
   GLint internal_format = 0;
   GLenum format = GL_NONE;
   GLenum type = GL_NONE;
-  std::shared_ptr<fml::Mapping> data;
+  std::shared_ptr<const fml::Mapping> data;
 
   TexImage2DData(PixelFormat pixel_format) {
     switch (pixel_format) {
@@ -99,16 +100,18 @@ struct TexImage2DData {
   }
 
   TexImage2DData(PixelFormat pixel_format,
-                 const uint8_t* contents,
-                 size_t length) {
+                 std::shared_ptr<const fml::Mapping> mapping) {
     switch (pixel_format) {
       case PixelFormat::kUnknown:
         return;
-      case PixelFormat::kR8UNormInt:
+      case PixelFormat::kR8UNormInt: {
+        TRACE_EVENT0("impeller", "R8UNormIntCopy");
         internal_format = GL_RGBA;
         format = GL_RGBA;
         type = GL_UNSIGNED_SHORT_4_4_4_4;
         {
+          const auto length = mapping->GetSize();
+          const uint8_t* contents = mapping->GetMapping();
           auto allocation = std::make_shared<Allocation>();
           if (!allocation->Truncate(length * 2u, false)) {
             VALIDATION_LOG << "Could not allocate buffer for texture data.";
@@ -121,20 +124,21 @@ struct TexImage2DData {
           }
           data = CreateMappingFromAllocation(std::move(allocation));
           if (!data) {
+            VALIDATION_LOG << "Could not create mapping from allocation.";
             return;
           }
         }
         break;
-      case PixelFormat::kR8G8B8A8UNormInt:
+      }
+
+      case PixelFormat::kR8G8B8A8UNormInt: {
+        TRACE_EVENT0("impeller", "R8G8B8A8UNormIntCopy");
         internal_format = GL_RGBA;
         format = GL_RGBA;
         type = GL_UNSIGNED_BYTE;
-        data = CreateMappingWithCopy(contents, length);
-        if (!data) {
-          VALIDATION_LOG << "Could not copy texture data.";
-          return;
-        }
+        data = std::move(mapping);
         break;
+      }
       case PixelFormat::kR8G8B8A8UNormIntSRGB:
         return;
       case PixelFormat::kB8G8R8A8UNormInt:
@@ -157,8 +161,22 @@ struct TexImage2DData {
 bool TextureGLES::OnSetContents(const uint8_t* contents,
                                 size_t length,
                                 size_t slice) {
-  if (length == 0u) {
+  return OnSetContents(CreateMappingWithCopy(contents, length), slice);
+}
+
+// |Texture|
+bool TextureGLES::OnSetContents(std::shared_ptr<const fml::Mapping> mapping,
+                                size_t slice) {
+  if (!mapping) {
+    return false;
+  }
+
+  if (mapping->GetSize() == 0u) {
     return true;
+  }
+
+  if (mapping->GetMapping() == nullptr) {
+    return false;
   }
 
   if (GetType() != Type::kTexture) {
@@ -182,7 +200,8 @@ bool TextureGLES::OnSetContents(const uint8_t* contents,
     return false;
   }
 
-  if (length < tex_descriptor.GetByteSizeOfBaseMipLevel()) {
+  if (mapping->GetSize() < tex_descriptor.GetByteSizeOfBaseMipLevel()) {
+    return false;
   }
 
   GLenum texture_type;
@@ -202,8 +221,8 @@ bool TextureGLES::OnSetContents(const uint8_t* contents,
       break;
   }
 
-  auto data =
-      std::make_shared<TexImage2DData>(tex_descriptor.format, contents, length);
+  auto data = std::make_shared<TexImage2DData>(tex_descriptor.format,
+                                               std::move(mapping));
   if (!data || !data->IsValid()) {
     VALIDATION_LOG << "Invalid texture format.";
     return false;
@@ -228,16 +247,20 @@ bool TextureGLES::OnSetContents(const uint8_t* contents,
       tex_data = data->data->GetMapping();
     }
 
-    gl.TexImage2D(texture_target,         // target
-                  0u,                     // LOD level
-                  data->internal_format,  // internal format
-                  size.width,             // width
-                  size.height,            // height
-                  0u,                     // border
-                  data->format,           // format
-                  data->type,             // type
-                  tex_data                // data
-    );
+    {
+      TRACE_EVENT1("impeller", "TexImage2DUpload", "Bytes",
+                   std::to_string(data->data->GetSize()).c_str());
+      gl.TexImage2D(texture_target,         // target
+                    0u,                     // LOD level
+                    data->internal_format,  // internal format
+                    size.width,             // width
+                    size.height,            // height
+                    0u,                     // border
+                    data->format,           // format
+                    data->type,             // type
+                    tex_data                // data
+      );
+    }
   };
 
   contents_initialized_ = reactor_->AddOperation(texture_upload);
@@ -302,16 +325,20 @@ void TextureGLES::InitializeContentsIfNecessary() const {
         return;
       }
       gl.BindTexture(GL_TEXTURE_2D, handle.value());
-      gl.TexImage2D(GL_TEXTURE_2D,  // target
-                    0u,             // LOD level (base mip level size checked)
-                    tex_data.internal_format,  // internal format
-                    size.width,                // width
-                    size.height,               // height
-                    0u,                        // border
-                    tex_data.format,           // format
-                    tex_data.type,             // type
-                    nullptr                    // data
-      );
+      {
+        TRACE_EVENT0("impeller", "TexImage2DInitialization");
+        gl.TexImage2D(GL_TEXTURE_2D,  // target
+                      0u,             // LOD level (base mip level size checked)
+                      tex_data.internal_format,  // internal format
+                      size.width,                // width
+                      size.height,               // height
+                      0u,                        // border
+                      tex_data.format,           // format
+                      tex_data.type,             // type
+                      nullptr                    // data
+        );
+      }
+
     } break;
     case Type::kRenderBuffer:
       auto render_buffer_format =
@@ -321,11 +348,15 @@ void TextureGLES::InitializeContentsIfNecessary() const {
         return;
       }
       gl.BindRenderbuffer(GL_RENDERBUFFER, handle.value());
-      gl.RenderbufferStorage(GL_RENDERBUFFER,               // target
-                             render_buffer_format.value(),  // internal format
-                             size.width,                    // width
-                             size.height                    // height
-      );
+      {
+        TRACE_EVENT0("impeller", "RenderBufferStorageInitialization");
+        gl.RenderbufferStorage(GL_RENDERBUFFER,               // target
+                               render_buffer_format.value(),  // internal format
+                               size.width,                    // width
+                               size.height                    // height
+        );
+      }
+
       break;
   }
   reactor_->SetDebugLabel(handle_, label_);

--- a/impeller/renderer/backend/gles/texture_gles.h
+++ b/impeller/renderer/backend/gles/texture_gles.h
@@ -71,6 +71,10 @@ class TextureGLES final : public Texture,
                      size_t slice) override;
 
   // |Texture|
+  bool OnSetContents(std::shared_ptr<const fml::Mapping> mapping,
+                     size_t slice) override;
+
+  // |Texture|
   bool IsValid() const override;
 
   // |Texture|

--- a/impeller/renderer/backend/metal/texture_mtl.h
+++ b/impeller/renderer/backend/metal/texture_mtl.h
@@ -35,6 +35,10 @@ class TextureMTL final : public Texture,
                      size_t slice) override;
 
   // |Texture|
+  bool OnSetContents(std::shared_ptr<const fml::Mapping> mapping,
+                     size_t slice) override;
+
+  // |Texture|
   bool IsValid() const override;
 
   // |Texture|

--- a/impeller/renderer/backend/metal/texture_mtl.mm
+++ b/impeller/renderer/backend/metal/texture_mtl.mm
@@ -30,6 +30,15 @@ void TextureMTL::SetLabel(const std::string_view& label) {
   [texture_ setLabel:@(label.data())];
 }
 
+// |Texture|
+bool TextureMTL::OnSetContents(std::shared_ptr<const fml::Mapping> mapping,
+                               size_t slice) {
+  // Metal has no threading restrictions. So we can pass this data along to the
+  // client rendering API immediately.
+  return OnSetContents(mapping->GetMapping(), mapping->GetSize(), slice);
+}
+
+// |Texture|
 bool TextureMTL::OnSetContents(const uint8_t* contents,
                                size_t length,
                                size_t slice) {

--- a/impeller/renderer/texture.h
+++ b/impeller/renderer/texture.h
@@ -7,6 +7,7 @@
 #include <string_view>
 
 #include "flutter/fml/macros.h"
+#include "flutter/fml/mapping.h"
 #include "impeller/geometry/size.h"
 #include "impeller/renderer/formats.h"
 #include "impeller/renderer/texture_descriptor.h"
@@ -19,12 +20,11 @@ class Texture {
 
   virtual void SetLabel(const std::string_view& label) = 0;
 
-  [[nodiscard]] virtual bool OnSetContents(const uint8_t* contents,
-                                           size_t length,
-                                           size_t slice) = 0;
-
   [[nodiscard]] bool SetContents(const uint8_t* contents,
                                  size_t length,
+                                 size_t slice = 0);
+
+  [[nodiscard]] bool SetContents(std::shared_ptr<const fml::Mapping> mapping,
                                  size_t slice = 0);
 
   virtual bool IsValid() const = 0;
@@ -36,8 +36,18 @@ class Texture {
  protected:
   Texture(TextureDescriptor desc);
 
+  [[nodiscard]] virtual bool OnSetContents(const uint8_t* contents,
+                                           size_t length,
+                                           size_t slice) = 0;
+
+  [[nodiscard]] virtual bool OnSetContents(
+      std::shared_ptr<const fml::Mapping> mapping,
+      size_t slice) = 0;
+
  private:
   const TextureDescriptor desc_;
+
+  bool IsSliceValid(size_t slice) const;
 
   FML_DISALLOW_COPY_AND_ASSIGN(Texture);
 };


### PR DESCRIPTION
In the OpenGL ES backend, for texture formats where there is a native counterpart, there is no need to perform a copy. On Metal, this makes no difference.

Fixes the textures portion of https://github.com/flutter/flutter/issues/102262.