### PR TITLE
Parse impeller setting from the bundle on Android

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
@@ -40,6 +40,8 @@ public class FlutterLoader {
       "io.flutter.embedding.android.OldGenHeapSize";
   private static final String ENABLE_SKPARAGRAPH_META_DATA_KEY =
       "io.flutter.embedding.android.EnableSkParagraph";
+  private static final String ENABLE_IMPELLER_META_DATA_KEY =
+      "io.flutter.embedding.android.EnableImpeller";
 
   /**
    * Set whether leave or clean up the VM after the last shell shuts down. It can be set from app's
@@ -316,8 +318,10 @@ public class FlutterLoader {
       shellArgs.add("--prefetched-default-font-manager");
 
       if (metaData == null || metaData.getBoolean(ENABLE_SKPARAGRAPH_META_DATA_KEY, true)) {
-
         shellArgs.add("--enable-skparagraph");
+      }
+      if (metaData != null && metaData.getBoolean(ENABLE_IMPELLER_META_DATA_KEY, false)) {
+        shellArgs.add("--enable-impeller");
       }
 
       final String leakVM = isLeakVM(metaData) ? "true" : "false";


### PR DESCRIPTION
This PR adds an option that goes in the `AndroidManifest.xml` file as follows, which results in `--enable-impeller` being passed to the engine:
```
        <meta-data
            android:name="io.flutter.embedding.android.EnableImpeller"
            android:value="true"/>
```