### PR TITLE
[impeller] Drop support for R8 pixel format.

### DIFF
--- a/impeller/entity/shaders/glyph_atlas.frag
+++ b/impeller/entity/shaders/glyph_atlas.frag
@@ -19,5 +19,5 @@ void main() {
   frag_color = texture(
     glyph_atlas_sampler,
     v_unit_vertex * scale_perspective + offset
-  ).rrrr * v_text_color;
+  ).aaaa * v_text_color;
 }

--- a/impeller/renderer/backend/metal/formats_mtl.h
+++ b/impeller/renderer/backend/metal/formats_mtl.h
@@ -21,8 +21,6 @@ constexpr PixelFormat FromMTLPixelFormat(MTLPixelFormat format) {
   switch (format) {
     case MTLPixelFormatInvalid:
       return PixelFormat::kUnknown;
-    case MTLPixelFormatR8Unorm:
-      return PixelFormat::kR8UNormInt;
     case MTLPixelFormatBGRA8Unorm:
       return PixelFormat::kB8G8R8A8UNormInt;
     case MTLPixelFormatBGRA8Unorm_sRGB:
@@ -43,8 +41,8 @@ constexpr MTLPixelFormat ToMTLPixelFormat(PixelFormat format) {
   switch (format) {
     case PixelFormat::kUnknown:
       return MTLPixelFormatInvalid;
-    case PixelFormat::kR8UNormInt:
-      return MTLPixelFormatR8Unorm;
+    case PixelFormat::kA8UNormInt:
+      return MTLPixelFormatA8Unorm;
     case PixelFormat::kB8G8R8A8UNormInt:
       return MTLPixelFormatBGRA8Unorm;
     case PixelFormat::kB8G8R8A8UNormIntSRGB:

--- a/impeller/renderer/formats.h
+++ b/impeller/renderer/formats.h
@@ -49,7 +49,7 @@ class Texture;
 ///
 enum class PixelFormat {
   kUnknown,
-  kR8UNormInt,
+  kA8UNormInt,
   kR8G8B8A8UNormInt,
   kR8G8B8A8UNormIntSRGB,
   kB8G8R8A8UNormInt,
@@ -216,7 +216,7 @@ constexpr size_t BytesPerPixelForPixelFormat(PixelFormat format) {
   switch (format) {
     case PixelFormat::kUnknown:
       return 0u;
-    case PixelFormat::kR8UNormInt:
+    case PixelFormat::kA8UNormInt:
     case PixelFormat::kS8UInt:
       return 1u;
     case PixelFormat::kR8G8B8A8UNormInt:

--- a/impeller/typographer/backends/skia/text_render_context_skia.cc
+++ b/impeller/typographer/backends/skia/text_render_context_skia.cc
@@ -162,7 +162,7 @@ static std::shared_ptr<Texture> UploadGlyphTextureAtlas(
   const auto& pixmap = bitmap.pixmap();
 
   TextureDescriptor texture_descriptor;
-  texture_descriptor.format = PixelFormat::kR8UNormInt;
+  texture_descriptor.format = PixelFormat::kA8UNormInt;
   texture_descriptor.size = ISize::MakeWH(atlas_size, atlas_size);
 
   if (pixmap.rowBytes() * pixmap.height() !=


### PR DESCRIPTION
R8 cannot be supported on ES 2 without extensions and we can do with A8 instead.  Avoid buffer copy in GLES backend. Texture::SetContents should not involve any intermediate copies now.