### PR TITLE
[revert] Convert Gfx PlatformView to use modern TouchSource API

### DIFF
--- a/shell/platform/fuchsia/flutter/engine.cc
+++ b/shell/platform/fuchsia/flutter/engine.cc
@@ -166,8 +166,8 @@ void Engine::Initialize(
   } else {
     gfx_protocols.set_view_focuser(focuser.NewRequest());
     gfx_protocols.set_view_ref_focused(view_ref_focused.NewRequest());
-    gfx_protocols.set_touch_source(touch_source.NewRequest());
-    // GFX used only on products without a mouse.
+    // TODO(fxbug.dev/85125): Enable TouchSource for GFX.
+    // gfx_protocols.set_touch_source(touch_source.NewRequest());
   }
   scenic->CreateSessionT(std::move(gfx_protocols), [] {});
 

--- a/shell/platform/fuchsia/flutter/flatland_platform_view.cc
+++ b/shell/platform/fuchsia/flutter/flatland_platform_view.cc
@@ -32,7 +32,8 @@ FlatlandPlatformView::FlatlandPlatformView(
     AwaitVsyncCallback await_vsync_callback,
     AwaitVsyncForSecondaryCallbackCallback
         await_vsync_for_secondary_callback_callback)
-    : PlatformView(delegate,
+    : PlatformView(true /* is_flatland */,
+                   delegate,
                    std::move(task_runners),
                    std::move(view_ref),
                    std::move(external_view_embedder),

--- a/shell/platform/fuchsia/flutter/gfx_platform_view.cc
+++ b/shell/platform/fuchsia/flutter/gfx_platform_view.cc
@@ -33,7 +33,8 @@ GfxPlatformView::GfxPlatformView(
     AwaitVsyncCallback await_vsync_callback,
     AwaitVsyncForSecondaryCallbackCallback
         await_vsync_for_secondary_callback_callback)
-    : PlatformView(delegate,
+    : PlatformView(false /* is_flatland */,
+                   delegate,
                    std::move(task_runners),
                    std::move(view_ref),
                    std::move(external_view_embedder),

--- a/shell/platform/fuchsia/flutter/platform_view.h
+++ b/shell/platform/fuchsia/flutter/platform_view.h
@@ -64,6 +64,7 @@ class PlatformView : public flutter::PlatformView,
                      private fuchsia::ui::input::InputMethodEditorClient {
  public:
   PlatformView(
+      bool is_flatland,
       flutter::PlatformView::Delegate& delegate,
       flutter::TaskRunners task_runners,
       fuchsia::ui::views::ViewRef view_ref,

--- a/shell/platform/fuchsia/flutter/platform_view_unittest.cc
+++ b/shell/platform/fuchsia/flutter/platform_view_unittest.cc
@@ -1385,7 +1385,8 @@ TEST_F(PlatformViewTests, OnShaderWarmup) {
   EXPECT_EQ(expected_result_string, response->result_string);
 }
 
-TEST_F(PlatformViewTests, TouchSourceLogicalToPhysicalConversion) {
+// TODO(fxbug.dev/85125): Enable when GFX converts to TouchSource.
+TEST_F(PlatformViewTests, DISABLED_TouchSourceLogicalToPhysicalConversion) {
   constexpr std::array<std::array<float, 2>, 2> kRect = {{{0, 0}, {20, 20}}};
   constexpr std::array<float, 9> kIdentity = {1, 0, 0, 0, 1, 0, 0, 0, 1};
   constexpr fuchsia::ui::pointer::TouchInteractionId kIxnOne = {

--- a/shell/platform/fuchsia/flutter/pointer_delegate.cc
+++ b/shell/platform/fuchsia/flutter/pointer_delegate.cc
@@ -429,9 +429,7 @@ void PointerDelegate::WatchLoop(
   // Start watching both channels.
   touch_source_->Watch(std::move(touch_responses_), /*copy*/ touch_responder_);
   touch_responses_.clear();
-  if (mouse_source_) {
-    mouse_source_->Watch(/*copy*/ mouse_responder_);
-  }
+  mouse_source_->Watch(/*copy*/ mouse_responder_);
 }
 
 }  // namespace flutter_runner


### PR DESCRIPTION
This CL was causing the flutter-embedder tests to fail in fuchsia.git