### PR TITLE
[Impeller] Keep track of a stencil depth floor for non-collapsed subpasses

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -805,5 +805,29 @@ TEST_P(AiksTest, SiblingSaveLayerBoundsAreRespected) {
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
+TEST_P(AiksTest, CanRenderClippedLayers) {
+  Canvas canvas;
+
+  canvas.DrawPaint({.color = Color::White()});
+
+  // Draw a green circle on the screen.
+  {
+    // Increase the clip depth for the savelayer to contend with.
+    canvas.ClipPath(PathBuilder{}.AddCircle({100, 100}, 50).TakePath());
+
+    canvas.SaveLayer({}, Rect::MakeXYWH(50, 50, 100, 100));
+
+    // Fill the layer with white.
+    canvas.DrawRect(Rect::MakeSize({400, 400}), {.color = Color::White()});
+    // Fill the layer with green, but do so with a color blend that can't be
+    // collapsed into the parent pass.
+    canvas.DrawRect(
+        Rect::MakeSize({400, 400}),
+        {.color = Color::Green(), .blend_mode = Entity::BlendMode::kColorBurn});
+  }
+
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -266,7 +266,8 @@ size_t Canvas::GetStencilDepth() const {
 void Canvas::SaveLayer(Paint paint, std::optional<Rect> bounds) {
   Save(true, paint.blend_mode);
 
-  GetCurrentPass().SetDelegate(
+  auto& new_layer_pass = GetCurrentPass();
+  new_layer_pass.SetDelegate(
       std::make_unique<PaintPassDelegate>(paint, bounds));
 
   if (bounds.has_value()) {

--- a/impeller/entity/entity_pass.h
+++ b/impeller/entity/entity_pass.h
@@ -61,7 +61,8 @@ class EntityPass {
   bool RenderInternal(ContentContext& renderer,
                       RenderTarget render_target,
                       Point position,
-                      uint32_t depth) const;
+                      uint32_t pass_depth,
+                      size_t stencil_depth_floor = 0) const;
 
   std::vector<Element> elements_;
 


### PR DESCRIPTION
In the common case, `EntityPass` stencil textures are transient, and so we don't store/share the stencil texture between `EntityPasses` (unless the pass is collapsed into the parent pass). And so for every non-collapsed subpass, the stencil texture always starts off in a cleared state.

This means that at render time, if the `EntityPassDelegate` decides that a subpass can't be collapsed, the stencil depth of all that subpass' elements need to be decreased by the subpass's recorded stencil depth (i.e. so the first rendered element of said subpass will have a stencil depth of zero).

In a nutshell, this fix makes `SaveLayer` calls under clips work. Without this change, `SaveLayers` under clips always render as fully transparent black (because the stencil test always fails).