### PR TITLE
Add dependency_override for the new implicit dependency of frontend-server: vm_service

### DIFF
--- a/flutter_frontend_server/pubspec.yaml
+++ b/flutter_frontend_server/pubspec.yaml
@@ -131,5 +131,7 @@ dependency_overrides:
     path: ../../third_party/dart/third_party/pkg/usage
   vm:
     path: ../../third_party/dart/pkg/vm
+  vm_service:
+    path: ../../third_party/dart/pkg/vm_service
   yaml:
     path: ../../third_party/dart/third_party/pkg/yaml


### PR DESCRIPTION
The new dependency was added in Dart SDK in https://github.com/dart-lang/sdk/commit/077a7907e6d362ca728cdb90d505a7cd75674b3f.
This change is needed to unblock the Dart SDK -> engine roll.