### PR TITLE
Reland Enable MSAA behind a flag for iOS

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -27,6 +27,7 @@ FILE: ../../../flutter/common/exported_symbols.sym
 FILE: ../../../flutter/common/exported_symbols_mac.sym
 FILE: ../../../flutter/common/graphics/gl_context_switch.cc
 FILE: ../../../flutter/common/graphics/gl_context_switch.h
+FILE: ../../../flutter/common/graphics/msaa_sample_count.h
 FILE: ../../../flutter/common/graphics/persistent_cache.cc
 FILE: ../../../flutter/common/graphics/persistent_cache.h
 FILE: ../../../flutter/common/graphics/texture.cc

--- a/common/graphics/BUILD.gn
+++ b/common/graphics/BUILD.gn
@@ -9,6 +9,7 @@ source_set("graphics") {
   sources = [
     "gl_context_switch.cc",
     "gl_context_switch.h",
+    "msaa_sample_count.h",
     "persistent_cache.cc",
     "persistent_cache.h",
     "texture.cc",

--- a/common/graphics/msaa_sample_count.h
+++ b/common/graphics/msaa_sample_count.h
@@ -1,0 +1,17 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_COMMON_GRAPHICS_MSAA_SAMPLE_COUNT_H_
+#define FLUTTER_COMMON_GRAPHICS_MSAA_SAMPLE_COUNT_H_
+
+// Supported MSAA sample count values.
+enum class MsaaSampleCount {
+  kNone = 1,
+  kTwo = 2,
+  kFour = 4,
+  kEight = 8,
+  kSixteen = 16,
+};
+
+#endif  // FLUTTER_COMMON_GRAPHICS_MSAA_SAMPLE_COUNT_H_

--- a/shell/common/shell_test_platform_view_metal.mm
+++ b/shell/common/shell_test_platform_view_metal.mm
@@ -91,7 +91,7 @@ PointerDataDispatcherMaker ShellTestPlatformViewMetal::GetDispatcherMaker() {
 
 // |PlatformView|
 std::unique_ptr<Surface> ShellTestPlatformViewMetal::CreateRenderingSurface() {
-  return std::make_unique<GPUSurfaceMetalSkia>(this, [metal_context_->context() mainContext]);
+  return std::make_unique<GPUSurfaceMetalSkia>(this, [metal_context_->context() mainContext], 1);
 }
 
 // |GPUSurfaceMetalDelegate|

--- a/shell/common/shell_test_platform_view_metal.mm
+++ b/shell/common/shell_test_platform_view_metal.mm
@@ -91,7 +91,8 @@ PointerDataDispatcherMaker ShellTestPlatformViewMetal::GetDispatcherMaker() {
 
 // |PlatformView|
 std::unique_ptr<Surface> ShellTestPlatformViewMetal::CreateRenderingSurface() {
-  return std::make_unique<GPUSurfaceMetalSkia>(this, [metal_context_->context() mainContext], 1);
+  return std::make_unique<GPUSurfaceMetalSkia>(this, [metal_context_->context() mainContext],
+                                               MsaaSampleCount::kNone);
 }
 
 // |GPUSurfaceMetalDelegate|

--- a/shell/gpu/gpu_surface_metal_skia.h
+++ b/shell/gpu/gpu_surface_metal_skia.h
@@ -17,6 +17,7 @@ class SK_API_AVAILABLE_CA_METAL_LAYER GPUSurfaceMetalSkia : public Surface {
  public:
   GPUSurfaceMetalSkia(GPUSurfaceMetalDelegate* delegate,
                       sk_sp<GrDirectContext> context,
+                      int msaa_samples,
                       bool render_to_surface = true);
 
   // |Surface|
@@ -30,6 +31,7 @@ class SK_API_AVAILABLE_CA_METAL_LAYER GPUSurfaceMetalSkia : public Surface {
   const MTLRenderTargetType render_target_type_;
   sk_sp<GrDirectContext> context_;
   GrDirectContext* precompiled_sksl_context_ = nullptr;
+  int msaa_samples_ = 1;
   // TODO(38466): Refactor GPU surface APIs take into account the fact that an
   // external view embedder may want to render to the root surface. This is a
   // hack to make avoid allocating resources for the root surface when an

--- a/shell/gpu/gpu_surface_metal_skia.h
+++ b/shell/gpu/gpu_surface_metal_skia.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_SHELL_GPU_GPU_SURFACE_METAL_H_
 #define FLUTTER_SHELL_GPU_GPU_SURFACE_METAL_H_
 
+#include "flutter/common/graphics/msaa_sample_count.h"
 #include "flutter/flow/surface.h"
 #include "flutter/fml/macros.h"
 #include "flutter/shell/gpu/gpu_surface_metal_delegate.h"
@@ -17,7 +18,7 @@ class SK_API_AVAILABLE_CA_METAL_LAYER GPUSurfaceMetalSkia : public Surface {
  public:
   GPUSurfaceMetalSkia(GPUSurfaceMetalDelegate* delegate,
                       sk_sp<GrDirectContext> context,
-                      int msaa_samples,
+                      MsaaSampleCount msaa_samples,
                       bool render_to_surface = true);
 
   // |Surface|
@@ -31,7 +32,7 @@ class SK_API_AVAILABLE_CA_METAL_LAYER GPUSurfaceMetalSkia : public Surface {
   const MTLRenderTargetType render_target_type_;
   sk_sp<GrDirectContext> context_;
   GrDirectContext* precompiled_sksl_context_ = nullptr;
-  int msaa_samples_ = 1;
+  MsaaSampleCount msaa_samples_ = MsaaSampleCount::kNone;
   // TODO(38466): Refactor GPU surface APIs take into account the fact that an
   // external view embedder may want to render to the root surface. This is a
   // hack to make avoid allocating resources for the root surface when an

--- a/shell/gpu/gpu_surface_metal_skia.mm
+++ b/shell/gpu/gpu_surface_metal_skia.mm
@@ -33,32 +33,28 @@ namespace {
 sk_sp<SkSurface> CreateSurfaceFromMetalTexture(GrDirectContext* context,
                                                id<MTLTexture> texture,
                                                GrSurfaceOrigin origin,
-                                               int sample_cnt,
+                                               MsaaSampleCount sample_cnt,
                                                SkColorType color_type,
                                                sk_sp<SkColorSpace> color_space,
                                                const SkSurfaceProps* props) {
   GrMtlTextureInfo info;
   info.fTexture.reset([texture retain]);
   GrBackendTexture backend_texture(texture.width, texture.height, GrMipmapped::kNo, info);
-  return SkSurface::MakeFromBackendTexture(context, backend_texture, origin, sample_cnt, color_type,
-                                           color_space, props);
+  return SkSurface::MakeFromBackendTexture(context, backend_texture, origin,
+                                           static_cast<int>(sample_cnt), color_type, color_space,
+                                           props);
 }
 }  // namespace
 
 GPUSurfaceMetalSkia::GPUSurfaceMetalSkia(GPUSurfaceMetalDelegate* delegate,
                                          sk_sp<GrDirectContext> context,
-                                         int msaa_samples,
+                                         MsaaSampleCount msaa_samples,
                                          bool render_to_surface)
     : delegate_(delegate),
       render_target_type_(delegate->GetRenderTargetType()),
       context_(std::move(context)),
       msaa_samples_(msaa_samples),
-      render_to_surface_(render_to_surface) {
-  // Skia allows 0 and clamps it to 1.
-  FML_CHECK(msaa_samples_ == 0 || msaa_samples_ == 1 || msaa_samples_ == 2 || msaa_samples_ == 4 ||
-            msaa_samples_ == 8)
-      << "Invalid MSAA sample count value: " << msaa_samples_;
-}
+      render_to_surface_(render_to_surface) {}
 
 GPUSurfaceMetalSkia::~GPUSurfaceMetalSkia() = default;
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
@@ -19,6 +19,7 @@ namespace flutter {
 namespace {
 
 class FakeDelegate : public PlatformView::Delegate {
+ public:
   void OnPlatformViewCreated(std::unique_ptr<Surface> surface) override {}
   void OnPlatformViewDestroyed() override {}
   void OnPlatformViewScheduleFrame() override {}
@@ -47,7 +48,6 @@ class FakeDelegate : public PlatformView::Delegate {
   void UpdateAssetResolverByType(std::unique_ptr<AssetResolver> updated_asset_resolver,
                                  AssetResolver::AssetResolverType type) override {}
 
- private:
   flutter::Settings settings_;
 };
 
@@ -85,6 +85,29 @@ flutter::FakeDelegate fake_delegate;
 
 - (fml::WeakPtr<flutter::PlatformView>)platformViewReplacement {
   return weak_factory->GetWeakPtr();
+}
+
+- (void)testMsaaSampleCount {
+  // Default should be 1.
+  XCTAssertEqual(platform_view->GetIosContext()->GetMsaaSampleCount(), 1);
+
+  // Verify the platform view creates a new context with updated msaa_samples.
+  // Need to use Metal, since this is ignored for Software/GL.
+  fake_delegate.settings_.msaa_samples = 4;
+
+  auto thread_task_runner = fml::MessageLoop::GetCurrent().GetTaskRunner();
+  flutter::TaskRunners runners(/*label=*/self.name.UTF8String,
+                               /*platform=*/thread_task_runner,
+                               /*raster=*/thread_task_runner,
+                               /*ui=*/thread_task_runner,
+                               /*io=*/thread_task_runner);
+  auto msaa_4x_platform_view = std::make_unique<flutter::PlatformViewIOS>(
+      /*delegate=*/fake_delegate,
+      /*rendering_api=*/flutter::IOSRenderingAPI::kMetal,
+      /*platform_views_controller=*/nil,
+      /*task_runners=*/runners);
+
+  XCTAssertEqual(msaa_4x_platform_view->GetIosContext()->GetMsaaSampleCount(), 4);
 }
 
 - (void)testCallsNotifyLowMemory {

--- a/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
@@ -89,7 +89,7 @@ flutter::FakeDelegate fake_delegate;
 
 - (void)testMsaaSampleCount {
   // Default should be 1.
-  XCTAssertEqual(platform_view->GetIosContext()->GetMsaaSampleCount(), 1);
+  XCTAssertEqual(platform_view->GetIosContext()->GetMsaaSampleCount(), MsaaSampleCount::kNone);
 
   // Verify the platform view creates a new context with updated msaa_samples.
   // Need to use Metal, since this is ignored for Software/GL.
@@ -107,7 +107,8 @@ flutter::FakeDelegate fake_delegate;
       /*platform_views_controller=*/nil,
       /*task_runners=*/runners);
 
-  XCTAssertEqual(msaa_4x_platform_view->GetIosContext()->GetMsaaSampleCount(), 4);
+  XCTAssertEqual(msaa_4x_platform_view->GetIosContext()->GetMsaaSampleCount(),
+                 MsaaSampleCount::kFour);
 }
 
 - (void)testCallsNotifyLowMemory {

--- a/shell/platform/darwin/ios/ios_context.h
+++ b/shell/platform/darwin/ios/ios_context.h
@@ -21,6 +21,9 @@ class Context;
 
 namespace flutter {
 
+// Supported MSAA sample count values for iOS.
+enum class MsaaSampleCount { kNone = 1, kTwo = 2, kFour = 4, kEight = 8 };
+
 //------------------------------------------------------------------------------
 /// @brief      Manages the lifetime of the on-screen and off-screen rendering
 ///             contexts on iOS. On-screen contexts are used by Flutter for
@@ -45,10 +48,17 @@ class IOSContext {
   ///
   /// @param[in]  api       A client rendering API supported by the
   ///                       engine/platform.
+  /// @param[in]  backend   A client rendering backend supported by the
+  ///                       engine/platform.
+  /// @param[in]  msaa_samples
+  ///                       The number of MSAA samples to use. Only supplied to
+  ///                       Skia, must be either 0, 1, 2, 4, or 8.
   ///
   /// @return     A valid context on success. `nullptr` on failure.
   ///
-  static std::unique_ptr<IOSContext> Create(IOSRenderingAPI api, IOSRenderingBackend backend);
+  static std::unique_ptr<IOSContext> Create(IOSRenderingAPI api,
+                                            IOSRenderingBackend backend,
+                                            MsaaSampleCount msaa_samples);
 
   //----------------------------------------------------------------------------
   /// @brief      Collects the context object. This must happen on the thread on
@@ -133,10 +143,13 @@ class IOSContext {
 
   virtual std::shared_ptr<impeller::Context> GetImpellerContext() const;
 
+  int GetMsaaSampleCount() const { return static_cast<int>(msaa_samples_); }
+
  protected:
-  IOSContext();
+  explicit IOSContext(MsaaSampleCount msaa_samples);
 
  private:
+  MsaaSampleCount msaa_samples_ = MsaaSampleCount::kNone;
   FML_DISALLOW_COPY_AND_ASSIGN(IOSContext);
 };
 

--- a/shell/platform/darwin/ios/ios_context.h
+++ b/shell/platform/darwin/ios/ios_context.h
@@ -8,6 +8,7 @@
 #include <memory>
 
 #include "flutter/common/graphics/gl_context_switch.h"
+#include "flutter/common/graphics/msaa_sample_count.h"
 #include "flutter/common/graphics/texture.h"
 #include "flutter/fml/macros.h"
 #include "flutter/fml/platform/darwin/scoped_nsobject.h"
@@ -20,9 +21,6 @@ class Context;
 }  // namespace impeller
 
 namespace flutter {
-
-// Supported MSAA sample count values for iOS.
-enum class MsaaSampleCount { kNone = 1, kTwo = 2, kFour = 4, kEight = 8 };
 
 //------------------------------------------------------------------------------
 /// @brief      Manages the lifetime of the on-screen and off-screen rendering
@@ -143,7 +141,7 @@ class IOSContext {
 
   virtual std::shared_ptr<impeller::Context> GetImpellerContext() const;
 
-  int GetMsaaSampleCount() const { return static_cast<int>(msaa_samples_); }
+  MsaaSampleCount GetMsaaSampleCount() const { return msaa_samples_; }
 
  protected:
   explicit IOSContext(MsaaSampleCount msaa_samples);

--- a/shell/platform/darwin/ios/ios_context.mm
+++ b/shell/platform/darwin/ios/ios_context.mm
@@ -15,11 +15,13 @@
 
 namespace flutter {
 
-IOSContext::IOSContext() = default;
+IOSContext::IOSContext(MsaaSampleCount msaa_samples) : msaa_samples_(msaa_samples) {}
 
 IOSContext::~IOSContext() = default;
 
-std::unique_ptr<IOSContext> IOSContext::Create(IOSRenderingAPI api, IOSRenderingBackend backend) {
+std::unique_ptr<IOSContext> IOSContext::Create(IOSRenderingAPI api,
+                                               IOSRenderingBackend backend,
+                                               MsaaSampleCount msaa_samples) {
   switch (api) {
     case IOSRenderingAPI::kOpenGLES:
       return std::make_unique<IOSContextGL>();
@@ -29,7 +31,7 @@ std::unique_ptr<IOSContext> IOSContext::Create(IOSRenderingAPI api, IOSRendering
     case IOSRenderingAPI::kMetal:
       switch (backend) {
         case IOSRenderingBackend::kSkia:
-          return std::make_unique<IOSContextMetalSkia>();
+          return std::make_unique<IOSContextMetalSkia>(msaa_samples);
         case IOSRenderingBackend::kImpeller:
           return std::make_unique<IOSContextMetalImpeller>();
       }

--- a/shell/platform/darwin/ios/ios_context_gl.mm
+++ b/shell/platform/darwin/ios/ios_context_gl.mm
@@ -13,7 +13,7 @@
 
 namespace flutter {
 
-IOSContextGL::IOSContextGL() {
+IOSContextGL::IOSContextGL() : IOSContext(MsaaSampleCount::kNone) {
   resource_context_.reset([[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES3]);
   if (resource_context_ != nullptr) {
     context_.reset([[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES3

--- a/shell/platform/darwin/ios/ios_context_metal_impeller.mm
+++ b/shell/platform/darwin/ios/ios_context_metal_impeller.mm
@@ -22,7 +22,8 @@ static std::shared_ptr<impeller::Context> CreateImpellerContext() {
   return context;
 }
 
-IOSContextMetalImpeller::IOSContextMetalImpeller() : context_(CreateImpellerContext()) {}
+IOSContextMetalImpeller::IOSContextMetalImpeller()
+    : IOSContext(MsaaSampleCount::kFour), context_(CreateImpellerContext()) {}
 
 IOSContextMetalImpeller::~IOSContextMetalImpeller() = default;
 

--- a/shell/platform/darwin/ios/ios_context_metal_skia.h
+++ b/shell/platform/darwin/ios/ios_context_metal_skia.h
@@ -18,7 +18,7 @@ namespace flutter {
 
 class IOSContextMetalSkia final : public IOSContext {
  public:
-  IOSContextMetalSkia();
+  explicit IOSContextMetalSkia(MsaaSampleCount msaa_samples);
 
   ~IOSContextMetalSkia();
 

--- a/shell/platform/darwin/ios/ios_context_metal_skia.mm
+++ b/shell/platform/darwin/ios/ios_context_metal_skia.mm
@@ -12,7 +12,7 @@
 
 namespace flutter {
 
-IOSContextMetalSkia::IOSContextMetalSkia() {
+IOSContextMetalSkia::IOSContextMetalSkia(MsaaSampleCount msaa_samples) : IOSContext(msaa_samples) {
   darwin_context_metal_ = fml::scoped_nsobject<FlutterDarwinContextMetal>{
       [[FlutterDarwinContextMetal alloc] initWithDefaultMTLDevice]};
 

--- a/shell/platform/darwin/ios/ios_context_software.mm
+++ b/shell/platform/darwin/ios/ios_context_software.mm
@@ -3,10 +3,11 @@
 // found in the LICENSE file.
 
 #import "flutter/shell/platform/darwin/ios/ios_context_software.h"
+#include "ios_context.h"
 
 namespace flutter {
 
-IOSContextSoftware::IOSContextSoftware() = default;
+IOSContextSoftware::IOSContextSoftware() : IOSContext(MsaaSampleCount::kNone) {}
 
 // |IOSContext|
 IOSContextSoftware::~IOSContextSoftware() = default;

--- a/shell/platform/darwin/ios/ios_surface_metal_skia.mm
+++ b/shell/platform/darwin/ios/ios_surface_metal_skia.mm
@@ -42,8 +42,9 @@ void IOSSurfaceMetalSkia::UpdateStorageSizeIfNecessary() {
 // |IOSSurface|
 std::unique_ptr<Surface> IOSSurfaceMetalSkia::CreateGPUSurface(GrDirectContext* context) {
   FML_DCHECK(context);
-  return std::make_unique<GPUSurfaceMetalSkia>(this,               // layer
-                                               sk_ref_sp(context)  // context
+  return std::make_unique<GPUSurfaceMetalSkia>(this,                               // delegate
+                                               sk_ref_sp(context),                 // context
+                                               GetContext()->GetMsaaSampleCount()  // sample count
   );
 }
 

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -55,13 +55,15 @@ PlatformViewIOS::PlatformViewIOS(
     IOSRenderingAPI rendering_api,
     const std::shared_ptr<FlutterPlatformViewsController>& platform_views_controller,
     flutter::TaskRunners task_runners)
-    : PlatformViewIOS(delegate,
-                      IOSContext::Create(rendering_api,
-                                         delegate.OnPlatformViewGetSettings().enable_impeller
-                                             ? IOSRenderingBackend::kImpeller
-                                             : IOSRenderingBackend::kSkia),
-                      platform_views_controller,
-                      task_runners) {}
+    : PlatformViewIOS(
+          delegate,
+          IOSContext::Create(
+              rendering_api,
+              delegate.OnPlatformViewGetSettings().enable_impeller ? IOSRenderingBackend::kImpeller
+                                                                   : IOSRenderingBackend::kSkia,
+              static_cast<MsaaSampleCount>(delegate.OnPlatformViewGetSettings().msaa_samples)),
+          platform_views_controller,
+          task_runners) {}
 
 PlatformViewIOS::~PlatformViewIOS() = default;
 

--- a/shell/platform/embedder/embedder_surface_metal.mm
+++ b/shell/platform/embedder/embedder_surface_metal.mm
@@ -44,7 +44,7 @@ std::unique_ptr<Surface> EmbedderSurfaceMetal::CreateGPUSurface() API_AVAILABLE(
   }
 
   const bool render_to_surface = !external_view_embedder_;
-  auto surface = std::make_unique<GPUSurfaceMetalSkia>(this, main_context_, render_to_surface);
+  auto surface = std::make_unique<GPUSurfaceMetalSkia>(this, main_context_, render_to_surface, 1);
 
   if (!surface->IsValid()) {
     return nullptr;

--- a/shell/platform/embedder/embedder_surface_metal.mm
+++ b/shell/platform/embedder/embedder_surface_metal.mm
@@ -44,7 +44,8 @@ std::unique_ptr<Surface> EmbedderSurfaceMetal::CreateGPUSurface() API_AVAILABLE(
   }
 
   const bool render_to_surface = !external_view_embedder_;
-  auto surface = std::make_unique<GPUSurfaceMetalSkia>(this, main_context_, render_to_surface, 1);
+  auto surface = std::make_unique<GPUSurfaceMetalSkia>(this, main_context_, MsaaSampleCount::kNone,
+                                                       render_to_surface);
 
   if (!surface->IsValid()) {
     return nullptr;


### PR DESCRIPTION
Relands #33461 

The patch was previously reverted because of a mistake in the embedder code: I had transposed the position of the `render_to_surface` argument and the `msaa_samples` argument, and C++ did an implicit int to bool conversion which broke everything on desktop.

I've manually verified that desktop works, and I've switched to using an enum _everywhere_ for the MSAA sample count argument so that the type error won't happen again.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
