### PR TITLE
reduce the number of dependencies declared by flutter_frontend_server

### DIFF
--- a/flutter_frontend_server/pubspec.yaml
+++ b/flutter_frontend_server/pubspec.yaml
@@ -22,22 +22,8 @@ environment:
 
 dependencies:
   args: any
-  async: any
-  charcode: any
-  collection: any
-  convert: any
-  crypto: any
-  front_end: any
   frontend_server: any
-  kernel: any
-  logging: any
-  meta: any
-  package_config: any
   path: any
-  source_span: any
-  typed_data: any
-  usage: any
-  vm: any
 
 dev_dependencies:
   litetest: any
@@ -49,40 +35,22 @@ dependency_overrides:
     path: ../../third_party/dart/pkg/_js_interop_checks
   args:
     path: ../../third_party/dart/third_party/pkg/args
-  async:
-    path: ../../third_party/dart/third_party/pkg/async
   async_helper:
     path: ../../third_party/dart/pkg/async_helper
-  bazel_worker:
-    path: ../../third_party/dart/third_party/pkg/bazel_worker
   build_integration:
     path: ../../third_party/dart/pkg/build_integration
-  charcode:
-    path: ../../third_party/dart/third_party/pkg/charcode
-  cli_util:
-    path: ../../third_party/dart/third_party/pkg/cli_util
-  collection:
-    path: ../../third_party/dart/third_party/pkg/collection
   compiler:
     path: ../../third_party/dart/pkg/compiler
-  convert:
-    path: ../../third_party/dart/third_party/pkg/convert
-  crypto:
-    path: ../../third_party/dart/third_party/pkg/crypto
   dart2js_info:
     path: ../../third_party/dart/pkg/dart2js_info
   dev_compiler:
     path: ../../third_party/dart/pkg/dev_compiler
   expect:
     path: ../../third_party/dart/pkg/expect
-  fixnum:
-    path: ../../third_party/dart/third_party/pkg/fixnum
   front_end:
     path: ../../third_party/dart/pkg/front_end
   frontend_server:
     path: ../../third_party/dart/pkg/frontend_server
-  http_parser:
-    path: ../../third_party/dart/third_party/pkg/http_parser
   js_ast:
     path: ../../third_party/dart/pkg/js_ast
   js_runtime:
@@ -93,45 +61,11 @@ dependency_overrides:
     path: ../../third_party/dart/pkg/kernel
   litetest:
     path: ../testing/litetest
-  logging:
-    path: ../../third_party/dart/third_party/pkg/logging
-  matcher:
-    path: ../../third_party/dart/third_party/pkg/matcher
-  meta:
-    path: ../../third_party/dart/pkg/meta
-  mime:
-    path: ../../third_party/dart/third_party/pkg/mime
   package_config:
     path: ../../third_party/dart/third_party/pkg_tested/package_config
   path:
     path: ../../third_party/dart/third_party/pkg/path
-  protobuf:
-    path: ../../third_party/dart/third_party/pkg/protobuf/protobuf
-  shelf:
-    path: ../../third_party/dart/third_party/pkg/shelf/pkgs/shelf
-  shelf_static:
-    path: ../../third_party/dart/third_party/pkg/shelf/pkgs/shelf_static
   smith:
     path: ../../third_party/dart/pkg/smith
-  source_maps:
-    path: ../../third_party/dart/third_party/pkg/source_maps
-  source_span:
-    path: ../../third_party/dart/third_party/pkg/source_span
-  stack_trace:
-    path: ../../third_party/dart/third_party/pkg/stack_trace
-  stream_channel:
-    path: ../../third_party/dart/third_party/pkg/stream_channel
-  string_scanner:
-    path: ../../third_party/dart/third_party/pkg/string_scanner
-  term_glyph:
-    path: ../../third_party/dart/third_party/pkg/term_glyph
-  typed_data:
-    path: ../../third_party/dart/third_party/pkg/typed_data
-  usage:
-    path: ../../third_party/dart/third_party/pkg/usage
   vm:
     path: ../../third_party/dart/pkg/vm
-  vm_service:
-    path: ../../third_party/dart/pkg/vm_service
-  yaml:
-    path: ../../third_party/dart/third_party/pkg/yaml

--- a/flutter_frontend_server/pubspec.yaml
+++ b/flutter_frontend_server/pubspec.yaml
@@ -35,24 +35,36 @@ dependency_overrides:
     path: ../../third_party/dart/pkg/_js_interop_checks
   args:
     path: ../../third_party/dart/third_party/pkg/args
+  async:
+    path: ../../third_party/dart/third_party/pkg/async
   async_helper:
     path: ../../third_party/dart/pkg/async_helper
   bazel_worker:
     path: ../../third_party/dart/third_party/pkg/bazel_worker
   build_integration:
     path: ../../third_party/dart/pkg/build_integration
+  charcode:
+    path: ../../third_party/dart/third_party/pkg/charcode
+  collection:
+    path: ../../third_party/dart/third_party/pkg/collection
   compiler:
     path: ../../third_party/dart/pkg/compiler
+  crypto:
+    path: ../../third_party/dart/third_party/pkg/crypto
   dart2js_info:
     path: ../../third_party/dart/pkg/dart2js_info
   dev_compiler:
     path: ../../third_party/dart/pkg/dev_compiler
   expect:
     path: ../../third_party/dart/pkg/expect
+  fixnum:
+    path: ../../third_party/dart/third_party/pkg/fixnum
   front_end:
     path: ../../third_party/dart/pkg/front_end
   frontend_server:
     path: ../../third_party/dart/pkg/frontend_server
+  http_parser:
+    path: ../../third_party/dart/third_party/pkg/http_parser
   js_ast:
     path: ../../third_party/dart/pkg/js_ast
   js_runtime:
@@ -63,13 +75,37 @@ dependency_overrides:
     path: ../../third_party/dart/pkg/kernel
   litetest:
     path: ../testing/litetest
+  meta:
+    path: ../../third_party/dart/pkg/meta
   package_config:
     path: ../../third_party/dart/third_party/pkg_tested/package_config
   path:
     path: ../../third_party/dart/third_party/pkg/path
+  protobuf:
+    path: ../../third_party/dart/third_party/pkg/protobuf/protobuf
+  shelf:
+    path: ../../third_party/dart/third_party/pkg/shelf/pkgs/shelf
   smith:
     path: ../../third_party/dart/pkg/smith
+  source_maps:
+    path: ../../third_party/dart/third_party/pkg/source_maps
+  source_span:
+    path: ../../third_party/dart/third_party/pkg/source_span
+  stack_trace:
+    path: ../../third_party/dart/third_party/pkg/stack_trace
+  stream_channel:
+    path: ../../third_party/dart/third_party/pkg/stream_channel
+  string_scanner:
+    path: ../../third_party/dart/third_party/pkg/string_scanner
+  term_glyph:
+    path: ../../third_party/dart/third_party/pkg/term_glyph
+  typed_data:
+    path: ../../third_party/dart/third_party/pkg/typed_data
   usage:
     path: ../../third_party/dart/third_party/pkg/usage
   vm:
     path: ../../third_party/dart/pkg/vm
+  vm_service:
+    path: ../../third_party/dart/pkg/vm_service
+  yaml:
+    path: ../../third_party/dart/third_party/pkg/yaml

--- a/flutter_frontend_server/pubspec.yaml
+++ b/flutter_frontend_server/pubspec.yaml
@@ -67,5 +67,7 @@ dependency_overrides:
     path: ../../third_party/dart/third_party/pkg/path
   smith:
     path: ../../third_party/dart/pkg/smith
+  usage:
+    path: ../../third_party/dart/third_party/pkg/usage
   vm:
     path: ../../third_party/dart/pkg/vm

--- a/flutter_frontend_server/pubspec.yaml
+++ b/flutter_frontend_server/pubspec.yaml
@@ -37,6 +37,8 @@ dependency_overrides:
     path: ../../third_party/dart/third_party/pkg/args
   async_helper:
     path: ../../third_party/dart/pkg/async_helper
+  bazel_worker:
+    path: ../../third_party/dart/third_party/pkg/bazel_worker
   build_integration:
     path: ../../third_party/dart/pkg/build_integration
   compiler:


### PR DESCRIPTION
This PR reduces the number of dependencies declared by flutter_frontend_server.

This should reduce some of the friction seen in recent dart sdk => flutter/engine rolls. Changes upstream in the dart sdk's deps break the roll, partly because the flutter_frontend_server deps are currently over-specified

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [-] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
