### PR TITLE
[Impeller] Don't discard GLES buffer for each copy; respect destination offset

### DIFF
--- a/impeller/renderer/backend/gles/allocator_gles.cc
+++ b/impeller/renderer/backend/gles/allocator_gles.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "impeller/renderer/backend/gles/allocator_gles.h"
+
 #include <memory>
 
 #include "impeller/base/allocation.h"
@@ -26,12 +27,12 @@ bool AllocatorGLES::IsValid() const {
 // |Allocator|
 std::shared_ptr<DeviceBuffer> AllocatorGLES::CreateBuffer(StorageMode mode,
                                                           size_t length) {
-  auto buffer = std::make_shared<Allocation>();
-  if (!buffer->Truncate(length)) {
+  auto backing_store = std::make_shared<Allocation>();
+  if (!backing_store->Truncate(length)) {
     return nullptr;
   }
-  return std::make_shared<DeviceBufferGLES>(reactor_, std::move(buffer), length,
-                                            mode);
+  return std::make_shared<DeviceBufferGLES>(reactor_, std::move(backing_store),
+                                            length, mode);
 }
 
 // |Allocator|

--- a/impeller/renderer/backend/gles/allocator_gles.cc
+++ b/impeller/renderer/backend/gles/allocator_gles.cc
@@ -3,7 +3,9 @@
 // found in the LICENSE file.
 
 #include "impeller/renderer/backend/gles/allocator_gles.h"
+#include <memory>
 
+#include "impeller/base/allocation.h"
 #include "impeller/base/config.h"
 #include "impeller/renderer/backend/gles/device_buffer_gles.h"
 #include "impeller/renderer/backend/gles/texture_gles.h"
@@ -24,7 +26,12 @@ bool AllocatorGLES::IsValid() const {
 // |Allocator|
 std::shared_ptr<DeviceBuffer> AllocatorGLES::CreateBuffer(StorageMode mode,
                                                           size_t length) {
-  return std::make_shared<DeviceBufferGLES>(reactor_, length, mode);
+  auto buffer = std::make_shared<Allocation>();
+  if (!buffer->Truncate(length)) {
+    return nullptr;
+  }
+  return std::make_shared<DeviceBufferGLES>(reactor_, std::move(buffer), length,
+                                            mode);
 }
 
 // |Allocator|

--- a/impeller/renderer/backend/gles/buffer_bindings_gles.cc
+++ b/impeller/renderer/backend/gles/buffer_bindings_gles.cc
@@ -192,8 +192,8 @@ bool BufferBindingsGLES::BindUniformBuffer(const ProcTableGLES& gl,
     return false;
   }
   const auto& device_buffer_gles = DeviceBufferGLES::Cast(*device_buffer);
-  const uint8_t* buffer_ptr = device_buffer_gles.GetBufferData()->GetMapping() +
-                              buffer.resource.range.offset;
+  const uint8_t* buffer_ptr =
+      device_buffer_gles.GetBufferData() + buffer.resource.range.offset;
 
   if (metadata->members.empty()) {
     VALIDATION_LOG << "Uniform buffer had no members. This is currently "

--- a/impeller/renderer/backend/gles/device_buffer_gles.h
+++ b/impeller/renderer/backend/gles/device_buffer_gles.h
@@ -4,7 +4,10 @@
 
 #pragma once
 
+#include <memory>
+
 #include "flutter/fml/macros.h"
+#include "impeller/base/allocation.h"
 #include "impeller/base/backend_cast.h"
 #include "impeller/renderer/backend/gles/reactor_gles.h"
 #include "impeller/renderer/device_buffer.h"
@@ -15,12 +18,15 @@ class DeviceBufferGLES final
     : public DeviceBuffer,
       public BackendCast<DeviceBufferGLES, DeviceBuffer> {
  public:
-  DeviceBufferGLES(ReactorGLES::Ref reactor, size_t size, StorageMode mode);
+  DeviceBufferGLES(ReactorGLES::Ref reactor,
+                   std::shared_ptr<Allocation> buffer,
+                   size_t size,
+                   StorageMode mode);
 
   // |DeviceBuffer|
   ~DeviceBufferGLES() override;
 
-  std::shared_ptr<fml::Mapping> GetBufferData() const;
+  const uint8_t* GetBufferData() const;
 
   enum class BindingType {
     kArrayBuffer,
@@ -33,8 +39,9 @@ class DeviceBufferGLES final
   ReactorGLES::Ref reactor_;
   HandleGLES handle_;
   std::string label_;
-  mutable std::shared_ptr<fml::Mapping> data_;
-  mutable bool uploaded_ = false;
+  mutable std::shared_ptr<Allocation> buffer_;
+  mutable bool dirty_ = false;
+  mutable bool has_uploaded_ = false;
 
   // |DeviceBuffer|
   bool CopyHostBuffer(const uint8_t* source,

--- a/impeller/renderer/backend/gles/device_buffer_gles.h
+++ b/impeller/renderer/backend/gles/device_buffer_gles.h
@@ -39,9 +39,9 @@ class DeviceBufferGLES final
   ReactorGLES::Ref reactor_;
   HandleGLES handle_;
   std::string label_;
-  mutable std::shared_ptr<Allocation> buffer_;
-  mutable bool dirty_ = false;
-  mutable bool has_uploaded_ = false;
+  mutable std::shared_ptr<Allocation> backing_store_;
+  mutable uint32_t generation_ = 0;
+  mutable uint32_t upload_generation_ = 0;
 
   // |DeviceBuffer|
   bool CopyHostBuffer(const uint8_t* source,


### PR DESCRIPTION
Ran into this while working on [impeller-cmake-example](https://github.com/bdero/impeller-cmake-example). The ImGui Impeller backend allocates one geometry buffer per frame, performing two contiguous buffer copies using `DeviceBuffer::CopyHostBuffer`: One for vertices and one for indices.

This fixes two problems:
* The buffer was getting discarded/recreated with each `CopyHostBuffer` call.
* The destination offset was not being respected, so writes to the buffer were always starting at the first byte.

Made lots of progress with [impeller-cmake](https://github.com/bdero/impeller-cmake) on Windows this weekend! Screenshot of the example so far:

![image](https://user-images.githubusercontent.com/919017/169716108-d3dfa2a0-b5c2-486f-9adc-388665d8095f.png)
