### PR TITLE
Canonicalize paths in sdk_rewriter.dart

### DIFF
--- a/web_sdk/sdk_rewriter.dart
+++ b/web_sdk/sdk_rewriter.dart
@@ -23,8 +23,8 @@ import\s*'src/engine.dart'\s*as\s+engine;
 '''), r'''
 import 'dart:_engine' as engine;
 '''),
-  AllReplacer(RegExp(
-    r'''
+  AllReplacer(
+    RegExp(r'''
 export\s*'src/engine.dart'
 '''),
     r'''
@@ -52,9 +52,11 @@ import 'dart:typed_data';
 import 'dart:ui' as ui;
 '''),
   // Replace exports of engine files with "part" directives.
-  MappedReplacer(RegExp(r'''
+  MappedReplacer(
+      RegExp(r'''
 export\s*'engine/(.*)';
-'''), (Match match) => '''
+'''),
+      (Match match) => '''
 part 'engine/${match.group(1)}';
 '''),
 ];
@@ -83,12 +85,15 @@ final List<Replacer> sharedPatterns = <Replacer>[
 // So far this only requires a replace of the library declarations.
 void main(List<String> arguments) {
   final ArgResults results = argParser.parse(arguments);
-  final Directory directory = Directory(results['output-dir'] as String);
-  final String inputDirectoryPath = results['input-dir'] as String;
-  for (final String inputFilePath in results['input'] as Iterable<String>) {
+  final Directory directory =
+      Directory(path.canonicalize(results['output-dir'] as String));
+  final String inputDirectoryPath =
+      path.canonicalize(results['input-dir'] as String);
+  for (var inputFilePath in results['input'] as Iterable<String>) {
+    inputFilePath = path.canonicalize(inputFilePath);
     final File inputFile = File(inputFilePath);
-    final File outputFile = File(path.join(
-        directory.path, inputFile.path.substring(inputDirectoryPath.length)))
+    final File outputFile = File(path.join(directory.path,
+        inputFile.path.substring(inputDirectoryPath.length + 1)))
       ..createSync(recursive: true);
     final String source = inputFile.readAsStringSync();
     final String rewrittenContent = rewriteFile(
@@ -104,7 +109,8 @@ void main(List<String> arguments) {
   }
 }
 
-String rewriteFile(String source, {required String filePath, required bool isUi, required bool isEngine}) {
+String rewriteFile(String source,
+    {required String filePath, required bool isUi, required bool isEngine}) {
   final List<Replacer> replacementPatterns = <Replacer>[];
   replacementPatterns.addAll(sharedPatterns);
   if (isUi) {
@@ -168,7 +174,8 @@ void _validateEngineSource(String engineDartPath, String engineDartCode) {
 }
 
 String _preprocessEnginePartFile(String source) {
-  if (source.startsWith('part of engine;') || source.contains('\npart of engine;')) {
+  if (source.startsWith('part of engine;') ||
+      source.contains('\npart of engine;')) {
     // The file hasn't been migrated yet.
     // Do nothing.
   } else {


### PR DESCRIPTION
Instead of using the paths given, we should canonicalize the paths to
determine the relative output file paths to avoid issues in mismatched
paths. For example, if input-dir is /tmp/./lib/./src/, and an input file
was /tmp/lib/src/not_bad_path.dart, using the input-dir as a prefix would get
the relative path bad_path.dart.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [TODO] I listed at least one issue that this PR fixes in the description above.
- [<Do we have tests to run the sdk_rewriter.dart besides what's used in BUILD.gn?>] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [N/A] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [ ] All existing and new tests are passing.