### PR TITLE
[impeller] OpenGL: Add support for threads and contexts.

### DIFF
--- a/impeller/base/comparable.h
+++ b/impeller/base/comparable.h
@@ -103,4 +103,12 @@ struct hash<impeller::UniqueID> {
   }
 };
 
+template <>
+struct less<impeller::UniqueID> {
+  constexpr bool operator()(const impeller::UniqueID& lhs,
+                            const impeller::UniqueID& rhs) const {
+    return lhs.id < rhs.id;
+  }
+};
+
 }  // namespace std

--- a/impeller/playground/backend/gles/playground_impl_gles.h
+++ b/impeller/playground/backend/gles/playground_impl_gles.h
@@ -16,9 +16,12 @@ class PlaygroundImplGLES final : public PlaygroundImpl {
   ~PlaygroundImplGLES();
 
  private:
+  class ReactorWorker;
+
   static void DestroyWindowHandle(WindowHandle handle);
   using UniqueHandle = std::unique_ptr<void, decltype(&DestroyWindowHandle)>;
   UniqueHandle handle_;
+  std::shared_ptr<ReactorWorker> worker_;
 
   // |PlaygroundImpl|
   std::shared_ptr<Context> GetContext() const override;

--- a/impeller/renderer/backend/gles/context_gles.cc
+++ b/impeller/renderer/backend/gles/context_gles.cc
@@ -9,10 +9,10 @@
 
 namespace impeller {
 
-std::shared_ptr<Context> ContextGLES::Create(
+std::shared_ptr<ContextGLES> ContextGLES::Create(
     std::unique_ptr<ProcTableGLES> gl,
     std::vector<std::shared_ptr<fml::Mapping>> shader_libraries) {
-  return std::shared_ptr<Context>(
+  return std::shared_ptr<ContextGLES>(
       new ContextGLES(std::move(gl), std::move(shader_libraries)));
 }
 
@@ -70,8 +70,23 @@ ContextGLES::ContextGLES(
 
 ContextGLES::~ContextGLES() = default;
 
-const ReactorGLES::Ref ContextGLES::GetReactor() const {
+const ReactorGLES::Ref& ContextGLES::GetReactor() const {
   return reactor_;
+}
+
+std::optional<ReactorGLES::WorkerID> ContextGLES::AddReactorWorker(
+    std::shared_ptr<ReactorGLES::Worker> worker) {
+  if (!IsValid()) {
+    return std::nullopt;
+  }
+  return reactor_->AddWorker(std::move(worker));
+}
+
+bool ContextGLES::RemoveReactorWorker(ReactorGLES::WorkerID id) {
+  if (!IsValid()) {
+    return false;
+  }
+  return reactor_->RemoveWorker(id);
 }
 
 bool ContextGLES::IsValid() const {

--- a/impeller/renderer/backend/gles/context_gles.h
+++ b/impeller/renderer/backend/gles/context_gles.h
@@ -19,14 +19,19 @@ namespace impeller {
 class ContextGLES final : public Context,
                           public BackendCast<ContextGLES, Context> {
  public:
-  static std::shared_ptr<Context> Create(
+  static std::shared_ptr<ContextGLES> Create(
       std::unique_ptr<ProcTableGLES> gl,
       std::vector<std::shared_ptr<fml::Mapping>> shader_libraries);
 
   // |Context|
   ~ContextGLES() override;
 
-  const ReactorGLES::Ref GetReactor() const;
+  const ReactorGLES::Ref& GetReactor() const;
+
+  std::optional<ReactorGLES::WorkerID> AddReactorWorker(
+      std::shared_ptr<ReactorGLES::Worker> worker);
+
+  bool RemoveReactorWorker(ReactorGLES::WorkerID id);
 
  private:
   ReactorGLES::Ref reactor_;

--- a/impeller/renderer/backend/gles/proc_table_gles.h
+++ b/impeller/renderer/backend/gles/proc_table_gles.h
@@ -27,9 +27,11 @@ struct AutoErrorCheck {
   ~AutoErrorCheck() {
     if (error_fn) {
       auto error = error_fn();
-      FML_CHECK(error == GL_NO_ERROR)
-          << "GL Error " << GLErrorToString(error) << "(" << error << ")"
-          << " encountered on call to " << name;
+      if (error != GL_NO_ERROR) {
+        FML_LOG(ERROR) << "GL Error " << GLErrorToString(error) << "(" << error
+                       << ")"
+                       << " encountered on call to " << name;
+      }
     }
   }
 };

--- a/impeller/renderer/backend/gles/reactor_gles.h
+++ b/impeller/renderer/backend/gles/reactor_gles.h
@@ -10,6 +10,7 @@
 
 #include "flutter/fml/closure.h"
 #include "flutter/fml/macros.h"
+#include "impeller/base/thread.h"
 #include "impeller/renderer/backend/gles/handle_gles.h"
 #include "impeller/renderer/backend/gles/proc_table_gles.h"
 
@@ -17,6 +18,16 @@ namespace impeller {
 
 class ReactorGLES {
  public:
+  using WorkerID = UniqueID;
+
+  class Worker {
+   public:
+    virtual ~Worker() = default;
+
+    virtual bool CanReactorReactOnCurrentThreadNow(
+        const ReactorGLES& reactor) const = 0;
+  };
+
   using Ref = std::shared_ptr<ReactorGLES>;
 
   ReactorGLES(std::unique_ptr<ProcTableGLES> gl);
@@ -25,7 +36,9 @@ class ReactorGLES {
 
   bool IsValid() const;
 
-  bool HasPendingOperations() const;
+  WorkerID AddWorker(std::weak_ptr<Worker> worker);
+
+  bool RemoveWorker(WorkerID);
 
   const ProcTableGLES& GetProcTable() const;
 
@@ -44,16 +57,32 @@ class ReactorGLES {
 
  private:
   std::unique_ptr<ProcTableGLES> proc_table_;
-  std::vector<Operation> pending_operations_;
-  GLESHandleMap<std::optional<GLuint>> live_gl_handles_;
-  GLESHandleMap<GLuint> gl_handles_to_collect_;
-  GLESHandleMap<std::string> pending_debug_labels_;
+
+  mutable Mutex ops_mutex_;
+  std::vector<Operation> pending_operations_ IPLR_GUARDED_BY(ops_mutex_);
+  GLESHandleMap<GLuint> gl_handles_to_collect_ IPLR_GUARDED_BY(ops_mutex_);
+
+  mutable RWMutex handles_mutex_;
+  GLESHandleMap<std::optional<GLuint>> live_gl_handles_
+      IPLR_GUARDED_BY(handles_mutex_);
+  GLESHandleMap<std::string> pending_debug_labels_
+      IPLR_GUARDED_BY(handles_mutex_);
+
+  mutable Mutex workers_mutex_;
+  mutable std::map<WorkerID, std::weak_ptr<Worker>> workers_
+      IPLR_GUARDED_BY(workers_mutex_);
+
+  // TODO(csg): Make this thread safe.
   bool in_reaction_ = false;
   bool can_set_debug_labels_ = false;
 
   bool is_valid_ = false;
 
   bool ReactOnce();
+
+  bool HasPendingOperations() const;
+
+  bool CanReactOnCurrentThread() const;
 
   FML_DISALLOW_COPY_AND_ASSIGN(ReactorGLES);
 };

--- a/impeller/toolkit/egl/BUILD.gn
+++ b/impeller/toolkit/egl/BUILD.gn
@@ -18,7 +18,10 @@ impeller_component("egl") {
     "surface.h",
   ]
 
-  deps = [ "//flutter/fml" ]
+  deps = [
+    "../../base",
+    "//flutter/fml",
+  ]
 
   libs = []
   if (is_android) {

--- a/lib/ui/painting/image_decoder_impeller.cc
+++ b/lib/ui/painting/image_decoder_impeller.cc
@@ -61,6 +61,7 @@ static sk_sp<DlImage> DecompressAndUploadTexture(
   TRACE_EVENT0("flutter", __FUNCTION__);
 
   if (!context || !descriptor) {
+    FML_DLOG(ERROR) << "Invalid context or descriptor.";
     return nullptr;
   }
 

--- a/shell/platform/android/android_surface_gl_impeller.h
+++ b/shell/platform/android/android_surface_gl_impeller.h
@@ -49,6 +49,9 @@ class AndroidSurfaceGLImpeller final : public GPUSurfaceGLDelegate,
   // |AndroidSurface|
   std::unique_ptr<Surface> CreateSnapshotSurface() override;
 
+  // |AndroidSurface|
+  std::shared_ptr<impeller::Context> GetImpellerContext() override;
+
   // |GPUSurfaceGLDelegate|
   std::unique_ptr<GLContextResult> GLContextMakeCurrent() override;
 
@@ -72,6 +75,9 @@ class AndroidSurfaceGLImpeller final : public GPUSurfaceGLDelegate,
   sk_sp<const GrGLInterface> GetGLInterface() const override;
 
  private:
+  class ReactorWorker;
+
+  std::shared_ptr<ReactorWorker> reactor_worker_;
   std::unique_ptr<impeller::egl::Display> display_;
   std::unique_ptr<impeller::egl::Config> onscreen_config_;
   std::unique_ptr<impeller::egl::Config> offscreen_config_;

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -333,6 +333,15 @@ void PlatformViewAndroid::ReleaseResourceContext() const {
 }
 
 // |PlatformView|
+std::shared_ptr<impeller::Context> PlatformViewAndroid::GetImpellerContext()
+    const {
+  if (android_surface_) {
+    return android_surface_->GetImpellerContext();
+  }
+  return nullptr;
+}
+
+// |PlatformView|
 std::unique_ptr<std::vector<std::string>>
 PlatformViewAndroid::ComputePlatformResolvedLocales(
     const std::vector<std::string>& supported_locale_data) {

--- a/shell/platform/android/platform_view_android.h
+++ b/shell/platform/android/platform_view_android.h
@@ -159,6 +159,9 @@ class PlatformViewAndroid final : public PlatformView {
   void ReleaseResourceContext() const override;
 
   // |PlatformView|
+  std::shared_ptr<impeller::Context> GetImpellerContext() const override;
+
+  // |PlatformView|
   std::unique_ptr<std::vector<std::string>> ComputePlatformResolvedLocales(
       const std::vector<std::string>& supported_locale_data) override;
 

--- a/shell/platform/android/surface/android_surface.cc
+++ b/shell/platform/android/surface/android_surface.cc
@@ -19,4 +19,8 @@ std::unique_ptr<Surface> AndroidSurface::CreateSnapshotSurface() {
   return nullptr;
 }
 
+std::shared_ptr<impeller::Context> AndroidSurface::GetImpellerContext() {
+  return nullptr;
+}
+
 }  // namespace flutter

--- a/shell/platform/android/surface/android_surface.h
+++ b/shell/platform/android/surface/android_surface.h
@@ -14,6 +14,10 @@
 #include "flutter/shell/platform/android/surface/android_native_window.h"
 #include "third_party/skia/include/core/SkSize.h"
 
+namespace impeller {
+class Context;
+}  // namespace impeller
+
 namespace flutter {
 
 class AndroidExternalViewEmbedder;
@@ -38,6 +42,8 @@ class AndroidSurface {
   virtual bool SetNativeWindow(fml::RefPtr<AndroidNativeWindow> window) = 0;
 
   virtual std::unique_ptr<Surface> CreateSnapshotSurface();
+
+  virtual std::shared_ptr<impeller::Context> GetImpellerContext();
 
  protected:
   explicit AndroidSurface(


### PR DESCRIPTION
I have temporarily made GL errors log instead of assert. But the only issues we
run into are with the "create on bind" resources and setting debug object labels
on them. I am going to rework setting debug labels right now. But, in the
meantime, the OpenGL ES backend can show cross-context textures.

There is also still an outstanding issue where cross-context textures will be
uploaded on the main context (in the same sharegroup) if the thread on which the
operation is dispatched doesn't have a context current. This will also be fixed
to pin those tasks to the worker context in an upcoming patch.
![screen](https://user-images.githubusercontent.com/44085/169920329-d028436e-ebcd-4052-8c00-909603bca940.png)