### PR TITLE
Pass the --enable-skparagraph=false flag if the EnableSkParagraph manifest metadata value is false

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
@@ -317,9 +317,10 @@ public class FlutterLoader {
 
       shellArgs.add("--prefetched-default-font-manager");
 
-      if (metaData == null || metaData.getBoolean(ENABLE_SKPARAGRAPH_META_DATA_KEY, true)) {
-        shellArgs.add("--enable-skparagraph");
-      }
+      boolean enableSkParagraph =
+          metaData == null || metaData.getBoolean(ENABLE_SKPARAGRAPH_META_DATA_KEY, true);
+      shellArgs.add("--enable-skparagraph=" + enableSkParagraph);
+
       if (metaData != null && metaData.getBoolean(ENABLE_IMPELLER_META_DATA_KEY, false)) {
         shellArgs.add("--enable-impeller");
       }

--- a/shell/platform/android/test/io/flutter/embedding/engine/loader/FlutterLoaderTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/loader/FlutterLoaderTest.java
@@ -198,6 +198,44 @@ public class FlutterLoaderTest {
   }
 
   @Test
+  public void itSetsEnableSkParagraphByDefault() {
+    // SkParagraph is enabled by default
+    FlutterJNI mockFlutterJNI = mock(FlutterJNI.class);
+    FlutterLoader flutterLoader = new FlutterLoader(mockFlutterJNI);
+    FlutterLoader.Settings settings = new FlutterLoader.Settings();
+    flutterLoader.startInitialization(ctx, settings);
+    flutterLoader.ensureInitializationComplete(ctx, null);
+    shadowOf(getMainLooper()).idle();
+
+    ArgumentCaptor<String[]> shellArgsCaptor = ArgumentCaptor.forClass(String[].class);
+    verify(mockFlutterJNI, times(1))
+        .init(eq(ctx), shellArgsCaptor.capture(), anyString(), anyString(), anyString(), anyLong());
+    List<String> arguments = Arrays.asList(shellArgsCaptor.getValue());
+    assertTrue(arguments.contains("--enable-skparagraph=true"));
+  }
+
+  @Test
+  public void itSetsEnableSkParagraphFromMetaData() {
+    // SkParagraph can be disabled using metadata.
+    FlutterJNI mockFlutterJNI = mock(FlutterJNI.class);
+    FlutterLoader flutterLoader = new FlutterLoader(mockFlutterJNI);
+    Bundle metaData = new Bundle();
+    metaData.putBoolean("io.flutter.embedding.android.EnableSkParagraph", false);
+    ctx.getApplicationInfo().metaData = metaData;
+
+    FlutterLoader.Settings settings = new FlutterLoader.Settings();
+    flutterLoader.startInitialization(ctx, settings);
+    flutterLoader.ensureInitializationComplete(ctx, null);
+    shadowOf(getMainLooper()).idle();
+
+    ArgumentCaptor<String[]> shellArgsCaptor = ArgumentCaptor.forClass(String[].class);
+    verify(mockFlutterJNI, times(1))
+        .init(eq(ctx), shellArgsCaptor.capture(), anyString(), anyString(), anyString(), anyLong());
+    List<String> arguments = Arrays.asList(shellArgsCaptor.getValue());
+    assertTrue(arguments.contains("--enable-skparagraph=false"));
+  }
+
+  @Test
   @TargetApi(23)
   @Config(sdk = 23)
   public void itReportsFpsToVsyncWaiterAndroidM() {


### PR DESCRIPTION
Without this, apps would need to explicitly pass an --enable-skparagraph=false
flag to the shell in addition to disabling SkParagraph in the manifest.
