### PR TITLE
[impeller] OpenGL ES: Refactor handle table and debug label management.

### DIFF
--- a/impeller/renderer/backend/gles/device_buffer_gles.cc
+++ b/impeller/renderer/backend/gles/device_buffer_gles.cc
@@ -86,12 +86,11 @@ bool DeviceBufferGLES::BindAndUploadDataIfNecessary(BindingType type) const {
   gl.BindBuffer(target_type, buffer.value());
 
   if (upload_generation_ != generation_) {
-    TRACE_EVENT0("impeller", "BufferData");
+    TRACE_EVENT1("impeller", "BufferData", "Bytes",
+                 std::to_string(backing_store_->GetLength()).c_str());
     gl.BufferData(target_type, backing_store_->GetLength(),
                   backing_store_->GetBuffer(), GL_STATIC_DRAW);
     upload_generation_ = generation_;
-
-    reactor_->SetDebugLabel(handle_, label_);
   }
 
   return true;
@@ -99,10 +98,7 @@ bool DeviceBufferGLES::BindAndUploadDataIfNecessary(BindingType type) const {
 
 // |DeviceBuffer|
 bool DeviceBufferGLES::SetLabel(const std::string& label) {
-  label_ = label;
-  if (upload_generation_ > 0) {
-    reactor_->SetDebugLabel(handle_, label_);
-  }
+  reactor_->SetDebugLabel(handle_, label);
   return true;
 }
 

--- a/impeller/renderer/backend/gles/device_buffer_gles.h
+++ b/impeller/renderer/backend/gles/device_buffer_gles.h
@@ -38,7 +38,6 @@ class DeviceBufferGLES final
  private:
   ReactorGLES::Ref reactor_;
   HandleGLES handle_;
-  std::string label_;
   mutable std::shared_ptr<Allocation> backing_store_;
   mutable uint32_t generation_ = 0;
   mutable uint32_t upload_generation_ = 0;

--- a/impeller/renderer/backend/gles/handle_gles.cc
+++ b/impeller/renderer/backend/gles/handle_gles.cc
@@ -4,8 +4,26 @@
 
 #include "impeller/renderer/backend/gles/handle_gles.h"
 
+#include "flutter/fml/logging.h"
+
 namespace impeller {
 
-//
+std::string HandleTypeToString(HandleType type) {
+  switch (type) {
+    case HandleType::kUnknown:
+      return "Unknown";
+    case HandleType::kTexture:
+      return "Texture";
+    case HandleType::kBuffer:
+      return "Buffer";
+    case HandleType::kProgram:
+      return "Program";
+    case HandleType::kRenderBuffer:
+      return "RenderBuffer";
+    case HandleType::kFrameBuffer:
+      return "Framebuffer";
+  }
+  FML_UNREACHABLE();
+}
 
 }  // namespace impeller

--- a/impeller/renderer/backend/gles/proc_table_gles.h
+++ b/impeller/renderer/backend/gles/proc_table_gles.h
@@ -27,11 +27,9 @@ struct AutoErrorCheck {
   ~AutoErrorCheck() {
     if (error_fn) {
       auto error = error_fn();
-      if (error != GL_NO_ERROR) {
-        FML_LOG(ERROR) << "GL Error " << GLErrorToString(error) << "(" << error
-                       << ")"
-                       << " encountered on call to " << name;
-      }
+      FML_CHECK(error == GL_NO_ERROR)
+          << "GL Error " << GLErrorToString(error) << "(" << error << ")"
+          << " encountered on call to " << name;
     }
   }
 };
@@ -130,8 +128,12 @@ struct GLProc {
   PROC(GetShaderiv);                         \
   PROC(GetString);                           \
   PROC(GetUniformLocation);                  \
+  PROC(IsBuffer);                            \
   PROC(IsFramebuffer);                       \
   PROC(IsProgram);                           \
+  PROC(IsRenderbuffer);                      \
+  PROC(IsShader);                            \
+  PROC(IsTexture);                           \
   PROC(LinkProgram);                         \
   PROC(RenderbufferStorage);                 \
   PROC(Scissor);                             \
@@ -191,7 +193,7 @@ class ProcTableGLES {
 
   bool IsCurrentFramebufferComplete() const;
 
-  void SetDebugLabel(DebugResourceType type,
+  bool SetDebugLabel(DebugResourceType type,
                      GLint name,
                      const std::string& label) const;
 

--- a/impeller/renderer/backend/gles/texture_gles.cc
+++ b/impeller/renderer/backend/gles/texture_gles.cc
@@ -69,10 +69,7 @@ bool TextureGLES::IsValid() const {
 
 // |Texture|
 void TextureGLES::SetLabel(const std::string_view& label) {
-  label_ = std::string{label.data(), label.size()};
-  if (contents_initialized_) {
-    reactor_->SetDebugLabel(handle_, label_);
-  }
+  reactor_->SetDebugLabel(handle_, std::string{label.data(), label.size()});
 }
 
 struct TexImage2DData {
@@ -247,9 +244,6 @@ bool TextureGLES::OnSetContents(std::shared_ptr<const fml::Mapping> mapping,
   };
 
   contents_initialized_ = reactor_->AddOperation(texture_upload);
-  if (contents_initialized_) {
-    reactor_->SetDebugLabel(handle_, label_);
-  }
   return contents_initialized_;
 }
 
@@ -342,7 +336,6 @@ void TextureGLES::InitializeContentsIfNecessary() const {
 
       break;
   }
-  reactor_->SetDebugLabel(handle_, label_);
 }
 
 bool TextureGLES::Bind() const {

--- a/impeller/renderer/backend/gles/texture_gles.h
+++ b/impeller/renderer/backend/gles/texture_gles.h
@@ -55,7 +55,6 @@ class TextureGLES final : public Texture,
   HandleGLES handle_;
   mutable bool contents_initialized_ = false;
   const bool is_wrapped_;
-  std::string label_;
   bool is_valid_ = false;
 
   TextureGLES(std::shared_ptr<ReactorGLES> reactor,


### PR DESCRIPTION
Acquires fewer locks and doesn't throw GL errors when setting labels on
create-on-bind resources that haven't been bound yet. In such cases, the
label will be set on the next reaction.