### PR TITLE
Run some unit tests in parallel

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -161,6 +161,9 @@ deps = {
   'src/third_party/khronos':
    Var('chromium_git') + '/chromium/src/third_party/khronos.git' + '@' + '676d544d2b8f48903b7da9fceffaa534a5613978',
 
+   'src/third_party/gtest-parallel':
+   Var('chromium_git') + '/external/github.com/google/gtest-parallel' + '@' + '38191e2733d7cbaeaef6a3f1a942ddeb38a2ad14',
+
   'src/third_party/benchmark':
    Var('github_git') + '/google/benchmark' + '@' + '431abd149fd76a072f821913c0340137cc755f36',
 

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -1225,9 +1225,9 @@ TEST_F(ShellTest, GetUsedThisFrameShouldBeSetBeforeEndFrame) {
   auto end_frame_callback =
       [&](bool should_resubmit_frame,
           fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) {
-        end_frame_latch.Signal();
         // We expect `used_this_frame` to be false.
         used_this_frame = external_view_embedder->GetUsedThisFrame();
+        end_frame_latch.Signal();
       };
   external_view_embedder = std::make_shared<ShellTestExternalViewEmbedder>(
       end_frame_callback, PostPrerollResult::kSuccess, true);


### PR DESCRIPTION
Uses gtest-parallel to run gtest unit tests in parallel. Adds a dependence on https://chromium.googlesource.com/external/github.com/google/gtest-parallel/, and uses it in run_tests.py. This is a big speedup on my local machine with a lot of cores. It may be less helpful in CI where VMs might have fewer cores, but we'll see.