### PR TITLE
[Windows] Swap the order of processing GCS_RESULTSTR and GCS_COMPSTR to fix the behavior of partial committing with Google Japanese Input

### DIFF
--- a/shell/platform/windows/window_win32.cc
+++ b/shell/platform/windows/window_win32.cc
@@ -233,15 +233,9 @@ void WindowWin32::OnImeComposition(UINT const message,
     OnComposeCommit();
   }
 
-  if (lparam & GCS_COMPSTR) {
-    // Read the in-progress composing string.
-    long pos = text_input_manager_->GetComposingCursorPosition();
-    std::optional<std::u16string> text =
-        text_input_manager_->GetComposingString();
-    if (text) {
-      OnComposeChange(text.value(), pos);
-    }
-  }
+  // Process GCS_RESULTSTR at fisrt, because Google Japanese Input and ATOK send
+  // both GCS_RESULTSTR and GCS_COMPSTR to commit composed text and send new
+  // composing text.
   if (lparam & GCS_RESULTSTR) {
     // Commit but don't end composing.
     // Read the committed composing string.
@@ -250,6 +244,15 @@ void WindowWin32::OnImeComposition(UINT const message,
     if (text) {
       OnComposeChange(text.value(), pos);
       OnComposeCommit();
+    }
+  }
+  if (lparam & GCS_COMPSTR) {
+    // Read the in-progress composing string.
+    long pos = text_input_manager_->GetComposingCursorPosition();
+    std::optional<std::u16string> text =
+        text_input_manager_->GetComposingString();
+    if (text) {
+      OnComposeChange(text.value(), pos);
     }
   }
 }

--- a/shell/platform/windows/window_win32_unittests.cc
+++ b/shell/platform/windows/window_win32_unittests.cc
@@ -7,6 +7,7 @@
 #include "gtest/gtest.h"
 
 using testing::_;
+using testing::InSequence;
 using testing::Invoke;
 using testing::Return;
 
@@ -87,24 +88,34 @@ TEST(MockWin32Window, OnImeCompositionResult) {
   window.InjectWindowMessage(WM_IME_COMPOSITION, 0, GCS_RESULTSTR);
 }
 
-TEST(MockWin32Window, OnImeCompositionComposeAndResult) {
+TEST(MockWin32Window, OnImeCompositionResultAndCompose) {
   MockTextInputManagerWin32* text_input_manager =
       new MockTextInputManagerWin32();
   std::unique_ptr<TextInputManagerWin32> text_input_manager_ptr(
       text_input_manager);
   MockWin32Window window(std::move(text_input_manager_ptr));
-  EXPECT_CALL(*text_input_manager, GetComposingString())
-      .WillRepeatedly(
-          Return(std::optional<std::u16string>(std::u16string(u"nihao"))));
-  EXPECT_CALL(*text_input_manager, GetResultString())
-      .WillRepeatedly(
-          Return(std::optional<std::u16string>(std::u16string(u"`}"))));
+
+  // This situation is that Google Japanese Input finished composing "今日" in
+  // "今日は" but is still composing "は".
+  {
+    InSequence dummy;
+    EXPECT_CALL(*text_input_manager, GetResultString())
+        .WillRepeatedly(
+            Return(std::optional<std::u16string>(std::u16string(u"今日"))));
+    EXPECT_CALL(*text_input_manager, GetComposingString())
+        .WillRepeatedly(
+            Return(std::optional<std::u16string>(std::u16string(u"は"))));
+  }
+  {
+    InSequence dummy;
+    EXPECT_CALL(window, OnComposeChange(std::u16string(u"今日"), 0)).Times(1);
+    EXPECT_CALL(window, OnComposeCommit()).Times(1);
+    EXPECT_CALL(window, OnComposeChange(std::u16string(u"は"), 0)).Times(1);
+  }
+
   EXPECT_CALL(*text_input_manager, GetComposingCursorPosition())
       .WillRepeatedly(Return((int)0));
 
-  EXPECT_CALL(window, OnComposeChange(std::u16string(u"nihao"), 0)).Times(1);
-  EXPECT_CALL(window, OnComposeChange(std::u16string(u"`}"), 0)).Times(1);
-  EXPECT_CALL(window, OnComposeCommit()).Times(1);
   ON_CALL(window, OnImeComposition)
       .WillByDefault(Invoke(&window, &MockWin32Window::CallOnImeComposition));
   EXPECT_CALL(window, OnImeComposition(_, _, _)).Times(1);


### PR DESCRIPTION
Reproducible steps is in flutter/flutter#102021.

Fixes flutter/flutter#102021.

No changes in [flutter/tests] repo.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
