### PR TITLE
[Windows] Pass a function which returns ScopedClipboardInterface instead of ScopedClipboardInterface to PlatformHandlerWin32

### DIFF
--- a/shell/platform/windows/platform_handler_win32.cc
+++ b/shell/platform/windows/platform_handler_win32.cc
@@ -192,12 +192,14 @@ PlatformHandlerWin32::PlatformHandlerWin32(
     BinaryMessenger* messenger,
     FlutterWindowsView* view,
     std::optional<std::function<std::unique_ptr<ScopedClipboardInterface>()>>
-        clipboard_builder)
+        scoped_clipboard_provider)
     : PlatformHandler(messenger), view_(view) {
-  if (clipboard_builder.has_value()) {
-    clipboard_builder_ = clipboard_builder.value();
+  if (scoped_clipboard_provider.has_value()) {
+    scoped_clipboard_provider_ = scoped_clipboard_provider.value();
   } else {
-    clipboard_builder_ = []() { return std::make_unique<ScopedClipboard>(); };
+    scoped_clipboard_provider_ = []() {
+      return std::make_unique<ScopedClipboard>();
+    };
   }
 }
 
@@ -206,7 +208,8 @@ PlatformHandlerWin32::~PlatformHandlerWin32() = default;
 void PlatformHandlerWin32::GetPlainText(
     std::unique_ptr<MethodResult<rapidjson::Document>> result,
     std::string_view key) {
-  std::unique_ptr<ScopedClipboardInterface> clipboard = clipboard_builder_();
+  std::unique_ptr<ScopedClipboardInterface> clipboard =
+      scoped_clipboard_provider_();
 
   int open_result = clipboard->Open(std::get<HWND>(*view_->GetRenderTarget()));
   if (open_result != kErrorSuccess) {
@@ -241,7 +244,8 @@ void PlatformHandlerWin32::GetPlainText(
 
 void PlatformHandlerWin32::GetHasStrings(
     std::unique_ptr<MethodResult<rapidjson::Document>> result) {
-  std::unique_ptr<ScopedClipboardInterface> clipboard = clipboard_builder_();
+  std::unique_ptr<ScopedClipboardInterface> clipboard =
+      scoped_clipboard_provider_();
 
   bool hasStrings;
   int open_result = clipboard->Open(std::get<HWND>(*view_->GetRenderTarget()));
@@ -271,7 +275,8 @@ void PlatformHandlerWin32::GetHasStrings(
 void PlatformHandlerWin32::SetPlainText(
     const std::string& text,
     std::unique_ptr<MethodResult<rapidjson::Document>> result) {
-  std::unique_ptr<ScopedClipboardInterface> clipboard = clipboard_builder_();
+  std::unique_ptr<ScopedClipboardInterface> clipboard =
+      scoped_clipboard_provider_();
 
   int open_result = clipboard->Open(std::get<HWND>(*view_->GetRenderTarget()));
   if (open_result != kErrorSuccess) {

--- a/shell/platform/windows/platform_handler_win32.cc
+++ b/shell/platform/windows/platform_handler_win32.cc
@@ -206,7 +206,7 @@ PlatformHandlerWin32::~PlatformHandlerWin32() = default;
 void PlatformHandlerWin32::GetPlainText(
     std::unique_ptr<MethodResult<rapidjson::Document>> result,
     std::string_view key) {
-  auto clipboard = clipboard_builder_();
+  std::unique_ptr<ScopedClipboardInterface> clipboard = clipboard_builder_();
 
   int open_result = clipboard->Open(std::get<HWND>(*view_->GetRenderTarget()));
   if (open_result != kErrorSuccess) {
@@ -241,7 +241,7 @@ void PlatformHandlerWin32::GetPlainText(
 
 void PlatformHandlerWin32::GetHasStrings(
     std::unique_ptr<MethodResult<rapidjson::Document>> result) {
-  auto clipboard = clipboard_builder_();
+  std::unique_ptr<ScopedClipboardInterface> clipboard = clipboard_builder_();
 
   bool hasStrings;
   int open_result = clipboard->Open(std::get<HWND>(*view_->GetRenderTarget()));
@@ -271,7 +271,7 @@ void PlatformHandlerWin32::GetHasStrings(
 void PlatformHandlerWin32::SetPlainText(
     const std::string& text,
     std::unique_ptr<MethodResult<rapidjson::Document>> result) {
-  auto clipboard = clipboard_builder_();
+  std::unique_ptr<ScopedClipboardInterface> clipboard = clipboard_builder_();
 
   int open_result = clipboard->Open(std::get<HWND>(*view_->GetRenderTarget()));
   if (open_result != kErrorSuccess) {

--- a/shell/platform/windows/platform_handler_win32.h
+++ b/shell/platform/windows/platform_handler_win32.h
@@ -48,7 +48,8 @@ class PlatformHandlerWin32 : public PlatformHandler {
   explicit PlatformHandlerWin32(
       BinaryMessenger* messenger,
       FlutterWindowsView* view,
-      std::unique_ptr<ScopedClipboardInterface> clipboard = nullptr);
+      std::optional<std::function<std::unique_ptr<ScopedClipboardInterface>()>>
+          clipboard_builder = std::nullopt);
 
   virtual ~PlatformHandlerWin32();
 
@@ -74,8 +75,8 @@ class PlatformHandlerWin32 : public PlatformHandler {
  private:
   // A reference to the Flutter view.
   FlutterWindowsView* view_;
-  // A clipboard instance that can be passed in for mocking in tests.
-  std::unique_ptr<ScopedClipboardInterface> clipboard_;
+  // A clipboard builder that can be passed in for mocking in tests.
+  std::function<std::unique_ptr<ScopedClipboardInterface>()> clipboard_builder_;
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/platform_handler_win32.h
+++ b/shell/platform/windows/platform_handler_win32.h
@@ -77,7 +77,7 @@ class PlatformHandlerWin32 : public PlatformHandler {
   FlutterWindowsView* view_;
   // A scoped clipboard provider that can be passed in for mocking in tests.
   // Use this to acquire clipboard in each operation to avoid blocking clipboard
-  // unnecessary.
+  // unnecessarily. See flutter/flutter#103205.
   std::function<std::unique_ptr<ScopedClipboardInterface>()>
       scoped_clipboard_provider_;
 };

--- a/shell/platform/windows/platform_handler_win32.h
+++ b/shell/platform/windows/platform_handler_win32.h
@@ -49,7 +49,7 @@ class PlatformHandlerWin32 : public PlatformHandler {
       BinaryMessenger* messenger,
       FlutterWindowsView* view,
       std::optional<std::function<std::unique_ptr<ScopedClipboardInterface>()>>
-          clipboard_builder = std::nullopt);
+          scoped_clipboard_provider = std::nullopt);
 
   virtual ~PlatformHandlerWin32();
 
@@ -75,8 +75,11 @@ class PlatformHandlerWin32 : public PlatformHandler {
  private:
   // A reference to the Flutter view.
   FlutterWindowsView* view_;
-  // A clipboard builder that can be passed in for mocking in tests.
-  std::function<std::unique_ptr<ScopedClipboardInterface>()> clipboard_builder_;
+  // A scoped clipboard provider that can be passed in for mocking in tests.
+  // Use this to acquire clipboard in each operation to avoid blocking clipboard
+  // unnecessary.
+  std::function<std::unique_ptr<ScopedClipboardInterface>()>
+      scoped_clipboard_provider_;
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/platform_handler_win32_unittests.cc
+++ b/shell/platform/windows/platform_handler_win32_unittests.cc
@@ -51,20 +51,7 @@ class TestPlatformHandlerWin32 : public PlatformHandlerWin32 {
 
   virtual ~TestPlatformHandlerWin32() = default;
 
-  void CallGetPlainText(
-      std::unique_ptr<MethodResult<rapidjson::Document>> result,
-      std::string_view key) {
-    GetPlainText(std::move(result), key);
-  }
-  void CallGetHasStrings(
-      std::unique_ptr<MethodResult<rapidjson::Document>> result) {
-    GetHasStrings(std::move(result));
-  }
-  void CallSetPlainText(
-      const std::string& text,
-      std::unique_ptr<MethodResult<rapidjson::Document>> result) {
-    SetPlainText(text, std::move(result));
-  }
+  FRIEND_TEST(PlatformHandlerWin32, ReleaseClipboard);
 };
 
 // A test version of the private ScopedClipboard.
@@ -295,14 +282,13 @@ TEST(PlatformHandlerWin32, ReleaseClipboard) {
                                                      system_clipboard);
       });
 
-  platform_handler.CallGetPlainText(std::make_unique<MockMethodResult>(),
-                                    "text");
+  platform_handler.GetPlainText(std::make_unique<MockMethodResult>(), "text");
   ASSERT_FALSE(system_clipboard->opened);
 
-  platform_handler.CallGetHasStrings(std::make_unique<MockMethodResult>());
+  platform_handler.GetHasStrings(std::make_unique<MockMethodResult>());
   ASSERT_FALSE(system_clipboard->opened);
 
-  platform_handler.CallSetPlainText("", std::make_unique<MockMethodResult>());
+  platform_handler.SetPlainText("", std::make_unique<MockMethodResult>());
   ASSERT_FALSE(system_clipboard->opened);
 }
 

--- a/shell/platform/windows/platform_handler_win32_unittests.cc
+++ b/shell/platform/windows/platform_handler_win32_unittests.cc
@@ -46,8 +46,8 @@ class TestPlatformHandlerWin32 : public PlatformHandlerWin32 {
       BinaryMessenger* messenger,
       FlutterWindowsView* view,
       std::optional<std::function<std::unique_ptr<ScopedClipboardInterface>()>>
-          clipboard_builder = std::nullopt)
-      : PlatformHandlerWin32(messenger, view, clipboard_builder) {}
+          scoped_clipboard_provider = std::nullopt)
+      : PlatformHandlerWin32(messenger, view, scoped_clipboard_provider) {}
 
   virtual ~TestPlatformHandlerWin32() = default;
 


### PR DESCRIPTION
This PR fixes regression in flutter/flutter#103205 with https://github.com/flutter/flutter/issues/103205#issuecomment-1119733208, and adds test for it.

Fixes flutter/flutter#103205.

No changes in [flutter/tests].

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
