### PR TITLE
[impeller] Pass const void* to fml::HashCombine instead of const char*.

### DIFF
--- a/impeller/renderer/shader_types.h
+++ b/impeller/renderer/shader_types.h
@@ -72,8 +72,8 @@ struct ShaderStageIOSlot {
   size_t columns;
 
   constexpr size_t GetHash() const {
-    return fml::HashCombine((const void*) name, location, set, binding, type,
-                            bit_width, vec_size, columns);
+    return fml::HashCombine(reinterpret_cast<const void*>(name), location, set,
+                            binding, type, bit_width, vec_size, columns);
   }
 
   constexpr bool operator==(const ShaderStageIOSlot& other) const {


### PR DESCRIPTION
Some implementation of STL will emit an error when const char* is passed
to std::hash, since it is hashing the pointer value and not the string
content.

In this case here we are hashing the pointer value, cast to const void*
to make the intention clear.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
