### PR TITLE
[impeller] Import the header file in the generated shader file.

### DIFF
--- a/impeller/tools/xxd.py
+++ b/impeller/tools/xxd.py
@@ -41,12 +41,14 @@ def Main():
 
   output_header = os.path.abspath(args.output_header)
   output_source = os.path.abspath(args.output_source)
+  output_header_basename = output_header[output_header.rfind('/') + 1:]
 
   MakeDirectories(os.path.dirname(output_header))
   MakeDirectories(os.path.dirname(output_source))
 
   with open(args.source, "rb") as source, open(output_source, "w") as output:
     data_len = 0
+    output.write(f"#include \"{output_header_basename}\"\n")
     output.write(f"const unsigned char impeller_{args.symbol_name}_data[] =\n")
     output.write("{\n")
     while True:
@@ -64,8 +66,8 @@ def Main():
     output.write("extern \"C\" {\n")
     output.write("#endif\n\n")
 
-    output.write(f"extern unsigned char impeller_{args.symbol_name}_data[];\n")
-    output.write(f"extern unsigned long impeller_{args.symbol_name}_length;\n\n")
+    output.write(f"extern const unsigned char impeller_{args.symbol_name}_data[];\n")
+    output.write(f"extern const unsigned long impeller_{args.symbol_name}_length;\n\n")
 
     output.write("#ifdef __cplusplus\n")
     output.write("}\n")


### PR DESCRIPTION
In the internal toolchain, a symbol is not exported if it is not already
included in the header file.

Include the header file in this file will make sure that the symbol will
be exported.

Also change the type in the header file to match the type in the
implementation file.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
