### PR TITLE
Set UsedThisFrame before EndFrame

### DIFF
--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -154,9 +154,9 @@ void Rasterizer::DrawLastLayerTree(
   // EndFrame should perform cleanups for the external_view_embedder.
   if (external_view_embedder_ && external_view_embedder_->GetUsedThisFrame()) {
     bool should_resubmit_frame = ShouldResubmitFrame(raster_status);
+    external_view_embedder_->SetUsedThisFrame(false);
     external_view_embedder_->EndFrame(should_resubmit_frame,
                                       raster_thread_merger_);
-    external_view_embedder_->SetUsedThisFrame(false);
   }
 }
 
@@ -212,9 +212,9 @@ RasterStatus Rasterizer::Draw(
   // EndFrame should perform cleanups for the external_view_embedder.
   if (surface_ && external_view_embedder_ &&
       external_view_embedder_->GetUsedThisFrame()) {
+    external_view_embedder_->SetUsedThisFrame(false);
     external_view_embedder_->EndFrame(should_resubmit_frame,
                                       raster_thread_merger_);
-    external_view_embedder_->SetUsedThisFrame(false);
   }
 
   // Consume as many pipeline items as possible. But yield the event loop


### PR DESCRIPTION
The `external_view_embedder_->SetUsedThisFrame(false);` is called after `EndFrame`.
`EndFrame` is where threads were merging. So potentially, threads were merged before the flag is set. If there is a pending draw task posted on the raster task runner, the new draw tasks happen on platform thread immediately after `EndFrame`. This potentially leads the `external_view_embedder_->SetUsedThisFrame(false);` is called on the raster thread (1st frame), and `FML_DCHECK(!external_view_embedder_->GetUsedThisFrame());` called on the platform thread(2nd frame).
Which leads the flag mismatch.

This PR push the EndFrame after setting the flag.

fixes: https://github.com/flutter/flutter/issues/104745

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
