### PR TITLE
Fix debug string evaluation

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -430,10 +430,10 @@ import java.util.List;
         "Executing Dart entrypoint: "
                     + host.getDartEntrypointFunctionName()
                     + ", library uri: "
-                    + libraryUri
+                    + (libraryUri
                 == null
             ? "\"\""
-            : libraryUri + ", and sending initial route: " + initialRoute);
+            : libraryUri + ", and sending initial route: " + initialRoute));
 
     // The engine needs to receive the Flutter app's initial route before executing any
     // Dart code to ensure that the initial route arrives in time to be applied.


### PR DESCRIPTION
The following string can never be evaluated to null:

```
"Executing Dart entrypoint: "
                    + host.getDartEntrypointFunctionName()
                    + ", library uri: "
                    + libraryUri
                == null
            ? "\"\""
            : libraryUri + ", and sending initial route: " + initialRoute);
```

 So, even when `libraryUrl` is null, the result is
 
 ```
"null and sending initial route: " + initialRoute
 ```
 
The variable to be tested should be `libraryUrl`, so the following expression should have enclosing parenthesis:

```
libraryUri == null 
    ? "\"\""
    : libraryUri + ", and sending initial route: " + initialRoute
```

This PR fixes this bug.