### PR TITLE
[macOS] Fix some incorrectly-named string constants

### DIFF
--- a/shell/platform/darwin/common/framework/Source/FlutterChannels.mm
+++ b/shell/platform/darwin/common/framework/Source/FlutterChannels.mm
@@ -6,14 +6,14 @@
 
 #pragma mark - Basic message channel
 
-static NSString* const FlutterChannelBuffersChannel = @"dev.flutter/channel-buffers";
+static NSString* const kFlutterChannelBuffersChannel = @"dev.flutter/channel-buffers";
 
 static void ResizeChannelBuffer(NSObject<FlutterBinaryMessenger>* binaryMessenger,
                                 NSString* channel,
                                 NSInteger newSize) {
   NSString* messageString = [NSString stringWithFormat:@"resize\r%@\r%@", channel, @(newSize)];
   NSData* message = [messageString dataUsingEncoding:NSUTF8StringEncoding];
-  [binaryMessenger sendOnChannel:FlutterChannelBuffersChannel message:message];
+  [binaryMessenger sendOnChannel:kFlutterChannelBuffersChannel message:message];
 }
 
 static FlutterBinaryMessengerConnection SetMessageHandler(

--- a/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegate.mm
+++ b/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegate.mm
@@ -13,12 +13,12 @@
 namespace flutter {
 
 // Native mac notifications fired. These notifications are not publicly documented.
-static NSString* const AccessibilityLoadCompleteNotification = @"AXLoadComplete";
-static NSString* const AccessibilityInvalidStatusChangedNotification = @"AXInvalidStatusChanged";
-static NSString* const AccessibilityLiveRegionCreatedNotification = @"AXLiveRegionCreated";
-static NSString* const AccessibilityLiveRegionChangedNotification = @"AXLiveRegionChanged";
-static NSString* const AccessibilityExpandedChanged = @"AXExpandedChanged";
-static NSString* const AccessibilityMenuItemSelectedNotification = @"AXMenuItemSelected";
+static NSString* const kAccessibilityLoadCompleteNotification = @"AXLoadComplete";
+static NSString* const kAccessibilityInvalidStatusChangedNotification = @"AXInvalidStatusChanged";
+static NSString* const kAccessibilityLiveRegionCreatedNotification = @"AXLiveRegionCreated";
+static NSString* const kAccessibilityLiveRegionChangedNotification = @"AXLiveRegionChanged";
+static NSString* const kAccessibilityExpandedChanged = @"AXExpandedChanged";
+static NSString* const kAccessibilityMenuItemSelectedNotification = @"AXMenuItemSelected";
 
 AccessibilityBridgeMacDelegate::AccessibilityBridgeMacDelegate(
     __weak FlutterEngine* flutter_engine,
@@ -81,14 +81,14 @@ AccessibilityBridgeMacDelegate::MacOSEventsFromAXEvent(ui::AXEventGenerator::Eve
       break;
     case ui::AXEventGenerator::Event::LOAD_COMPLETE:
       events.push_back({
-          .name = AccessibilityLoadCompleteNotification,
+          .name = kAccessibilityLoadCompleteNotification,
           .target = native_node,
           .user_info = nil,
       });
       break;
     case ui::AXEventGenerator::Event::INVALID_STATUS_CHANGED:
       events.push_back({
-          .name = AccessibilityInvalidStatusChangedNotification,
+          .name = kAccessibilityInvalidStatusChangedNotification,
           .target = native_node,
           .user_info = nil,
       });
@@ -197,14 +197,14 @@ AccessibilityBridgeMacDelegate::MacOSEventsFromAXEvent(ui::AXEventGenerator::Eve
     }
     case ui::AXEventGenerator::Event::LIVE_REGION_CREATED:
       events.push_back({
-          .name = AccessibilityLiveRegionCreatedNotification,
+          .name = kAccessibilityLiveRegionCreatedNotification,
           .target = native_node,
           .user_info = nil,
       });
       break;
     case ui::AXEventGenerator::Event::ALERT: {
       events.push_back({
-          .name = AccessibilityLiveRegionCreatedNotification,
+          .name = kAccessibilityLiveRegionCreatedNotification,
           .target = native_node,
           .user_info = nil,
       });
@@ -242,7 +242,7 @@ AccessibilityBridgeMacDelegate::MacOSEventsFromAXEvent(ui::AXEventGenerator::Eve
       }
       // Uses native VoiceOver support for live regions.
       events.push_back({
-          .name = AccessibilityLiveRegionChangedNotification,
+          .name = kAccessibilityLiveRegionChangedNotification,
           .target = native_node,
           .user_info = nil,
       });
@@ -261,7 +261,7 @@ AccessibilityBridgeMacDelegate::MacOSEventsFromAXEvent(ui::AXEventGenerator::Eve
           ax_node.data().role == ax::mojom::Role::kTreeItem) {
         mac_notification = NSAccessibilityRowExpandedNotification;
       } else {
-        mac_notification = AccessibilityExpandedChanged;
+        mac_notification = kAccessibilityExpandedChanged;
       }
       events.push_back({
           .name = mac_notification,
@@ -276,7 +276,7 @@ AccessibilityBridgeMacDelegate::MacOSEventsFromAXEvent(ui::AXEventGenerator::Eve
           ax_node.data().role == ax::mojom::Role::kTreeItem) {
         mac_notification = NSAccessibilityRowCollapsedNotification;
       } else {
-        mac_notification = AccessibilityExpandedChanged;
+        mac_notification = kAccessibilityExpandedChanged;
       }
       events.push_back({
           .name = mac_notification,
@@ -287,7 +287,7 @@ AccessibilityBridgeMacDelegate::MacOSEventsFromAXEvent(ui::AXEventGenerator::Eve
     }
     case ui::AXEventGenerator::Event::MENU_ITEM_SELECTED:
       events.push_back({
-          .name = AccessibilityMenuItemSelectedNotification,
+          .name = kAccessibilityMenuItemSelectedNotification,
           .target = native_node,
           .user_info = nil,
       });

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -24,16 +24,16 @@
 #import "flutter/shell/platform/embedder/embedder.h"
 
 namespace {
-using flutter::LayoutClue;
 using flutter::KeyboardLayoutNotifier;
+using flutter::LayoutClue;
 
 /// Clipboard plain text format.
 constexpr char kTextPlainFormat[] = "text/plain";
 
 /// The private notification for voice over.
-static NSString* const EnhancedUserInterfaceNotification =
+static NSString* const kEnhancedUserInterfaceNotification =
     @"NSApplicationDidChangeAccessibilityEnhancedUserInterfaceNotification";
-static NSString* const EnhancedUserInterfaceKey = @"AXEnhancedUserInterface";
+static NSString* const kEnhancedUserInterfaceKey = @"AXEnhancedUserInterface";
 
 // Use different device ID for mouse and pan/zoom events, since we can't differentiate the actual
 // device (mouse v.s. trackpad).
@@ -350,7 +350,7 @@ static void CommonInit(FlutterViewController* controller) {
   // macOS fires this private message when VoiceOver turns on or off.
   [center addObserver:controller
              selector:@selector(onAccessibilityStatusChanged:)
-                 name:EnhancedUserInterfaceNotification
+                 name:kEnhancedUserInterfaceNotification
                object:nil];
   [center addObserver:controller
              selector:@selector(applicationWillTerminate:)
@@ -734,7 +734,7 @@ static void CommonInit(FlutterViewController* controller) {
   if (!_engine) {
     return;
   }
-  BOOL enabled = [notification.userInfo[EnhancedUserInterfaceKey] boolValue];
+  BOOL enabled = [notification.userInfo[kEnhancedUserInterfaceKey] boolValue];
   if (!enabled && self.viewLoaded && [_textInputPlugin isFirstResponder]) {
     // The client (i.e. the FlutterTextField) of the textInputPlugin is a sibling
     // of the FlutterView. macOS will pick the ancestor to be the next responder
@@ -747,7 +747,7 @@ static void CommonInit(FlutterViewController* controller) {
     // manually pick the next responder.
     [self.view.window makeFirstResponder:_flutterView];
   }
-  _engine.semanticsEnabled = [notification.userInfo[EnhancedUserInterfaceKey] boolValue];
+  _engine.semanticsEnabled = [notification.userInfo[kEnhancedUserInterfaceKey] boolValue];
 }
 
 - (void)onSettingsChanged:(NSNotification*)notification {


### PR DESCRIPTION
Renames from `FooBarBaz` to `kFooBarBaz` in line with style guide.
Also alphabetises `using` statements so the formatter doesn't yell.

No tests since no functional changes are being made.

Ref: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#begin-global-constant-names-with-prefix-k

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
