### PR TITLE
[Impeller] Upload textures on the IO context where available.

### DIFF
--- a/impeller/renderer/backend/gles/context_gles.cc
+++ b/impeller/renderer/backend/gles/context_gles.cc
@@ -123,4 +123,9 @@ std::shared_ptr<CommandBuffer> ContextGLES::CreateTransferCommandBuffer()
   return CreateRenderCommandBuffer();
 }
 
+// |Context|
+bool ContextGLES::HasThreadingRestrictions() const {
+  return true;
+}
+
 }  // namespace impeller

--- a/impeller/renderer/backend/gles/context_gles.h
+++ b/impeller/renderer/backend/gles/context_gles.h
@@ -69,6 +69,9 @@ class ContextGLES final : public Context,
   // |Context|
   std::shared_ptr<CommandBuffer> CreateTransferCommandBuffer() const override;
 
+  // |Context|
+  bool HasThreadingRestrictions() const override;
+
   FML_DISALLOW_COPY_AND_ASSIGN(ContextGLES);
 };
 

--- a/impeller/renderer/context.cc
+++ b/impeller/renderer/context.cc
@@ -10,4 +10,8 @@ Context::~Context() = default;
 
 Context::Context() = default;
 
+bool Context::HasThreadingRestrictions() const {
+  return false;
+}
+
 }  // namespace impeller

--- a/impeller/renderer/context.h
+++ b/impeller/renderer/context.h
@@ -46,6 +46,8 @@ class Context {
   virtual std::shared_ptr<CommandBuffer> CreateTransferCommandBuffer()
       const = 0;
 
+  virtual bool HasThreadingRestrictions() const;
+
  protected:
   Context();
 

--- a/lib/ui/painting/image_decoder_impeller.h
+++ b/lib/ui/painting/image_decoder_impeller.h
@@ -34,7 +34,6 @@ class ImageDecoderImpeller final : public ImageDecoder {
  private:
   using FutureContext = std::shared_future<std::shared_ptr<impeller::Context>>;
   FutureContext context_;
-  size_t label_count_ = 1u;
 
   FML_DISALLOW_COPY_AND_ASSIGN(ImageDecoderImpeller);
 };


### PR DESCRIPTION
In the OpenGL ES backend, if an Impeller operation happens on a thread
with no OpenGL context current, the reactor enqueues it for later
execution. This later execution may happen on the main context. To avoid
this pessimization, queue the upload to the IO thread (which already has
a context) instead.

I was hoping that the reactor would manage task pinning as well but that
change is more invasive and I wanted to add parity with the Metal
backend ASAP. Hence the post-task fix.

The proper fix for this is tracked in https://github.com/flutter/flutter/issues/104784

Fixes https://github.com/flutter/flutter/issues/104756
<img width="625" alt="Screen Shot 2022-05-26 at 5 56 54 PM" src="https://user-images.githubusercontent.com/44085/170607876-587a2b64-b474-4631-947b-886bb9b02ea6.png">

