### PR TITLE
[Impeller] Setup mask filter factories in the dispatcher

### DIFF
--- a/impeller/aiks/paint.cc
+++ b/impeller/aiks/paint.cc
@@ -43,16 +43,9 @@ std::shared_ptr<Contents> Paint::WithFilters(
     std::optional<bool> is_solid_color) const {
   bool is_solid_color_val = is_solid_color.value_or(!contents);
 
-  if (mask_blur.has_value()) {
-    if (is_solid_color_val) {
-      input = FilterContents::MakeGaussianBlur(
-          FilterInput::Make(input), mask_blur->sigma, mask_blur->sigma,
-          mask_blur->blur_style);
-    } else {
-      input = FilterContents::MakeBorderMaskBlur(
-          FilterInput::Make(input), mask_blur->sigma, mask_blur->sigma,
-          mask_blur->blur_style);
-    }
+  if (mask_filter.has_value()) {
+    const MaskFilterProc& filter = mask_filter.value();
+    input = filter(FilterInput::Make(input), is_solid_color_val);
   }
 
   return input;

--- a/impeller/aiks/paint.h
+++ b/impeller/aiks/paint.h
@@ -16,12 +16,11 @@
 
 namespace impeller {
 
-struct MaskBlur {
-  FilterContents::BlurStyle blur_style;
-  FilterContents::Sigma sigma;
-};
-
 struct Paint {
+  using MaskFilterProc =
+      std::function<std::shared_ptr<FilterContents>(FilterInput::Ref,
+                                                    bool is_solid_color)>;
+
   enum class Style {
     kFill,
     kStroke,
@@ -36,7 +35,8 @@ struct Paint {
   Scalar stroke_miter = 4.0;
   Style style = Style::kFill;
   Entity::BlendMode blend_mode = Entity::BlendMode::kSourceOver;
-  std::optional<MaskBlur> mask_blur;
+
+  std::optional<MaskFilterProc> mask_filter;
 
   /// @brief      Wrap this paint's configured filters to the given contents.
   /// @param[in]  input           The contents to wrap with paint's filters.

--- a/impeller/display_list/display_list_dispatcher.cc
+++ b/impeller/display_list/display_list_dispatcher.cc
@@ -275,14 +275,23 @@ static FilterContents::BlurStyle ToBlurStyle(SkBlurStyle blur_style) {
 void DisplayListDispatcher::setMaskFilter(const flutter::DlMaskFilter* filter) {
   // Needs https://github.com/flutter/flutter/issues/95434
   if (filter == nullptr) {
-    paint_.mask_blur = std::nullopt;
+    paint_.mask_filter = std::nullopt;
     return;
   }
   switch (filter->type()) {
     case flutter::DlMaskFilterType::kBlur: {
       auto blur = filter->asBlur();
-      paint_.mask_blur = {.blur_style = ToBlurStyle(blur->style()),
-                          .sigma = FilterContents::Sigma(blur->sigma())};
+
+      auto style = ToBlurStyle(blur->style());
+      auto sigma = FilterContents::Sigma(blur->sigma());
+
+      paint_.mask_filter = [style, sigma](FilterInput::Ref input,
+                                          bool is_solid_color) {
+        if (is_solid_color) {
+          return FilterContents::MakeGaussianBlur(input, sigma, sigma, style);
+        }
+        return FilterContents::MakeBorderMaskBlur(input, sigma, sigma, style);
+      };
       break;
     }
     case flutter::DlMaskFilterType::kUnknown:


### PR DESCRIPTION
This pattern simplifies landing new filter types.

No semantic change; Play/DisplayListTest.CanDrawWithMaskBlur/Metal continues to work.