### PR TITLE
[android] Fixes 'drawRenderNode called on a context with no surface' crash

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -844,22 +844,8 @@ import java.util.List;
         flutterEngine.getDartExecutor().notifyLowMemoryWarning();
         flutterEngine.getSystemChannel().sendMemoryPressureWarning();
       }
+      flutterEngine.getRenderer().onTrimMemory(level);
     }
-  }
-
-  /**
-   * Invoke this from {@link android.app.Activity#onLowMemory()}.
-   *
-   * <p>A {@code Fragment} host must have its containing {@code Activity} forward this call so that
-   * the {@code Fragment} can then invoke this method.
-   *
-   * <p>This method sends a "memory pressure warning" message to Flutter over the "system channel".
-   */
-  void onLowMemory() {
-    Log.v(TAG, "Forwarding onLowMemory() to FlutterEngine.");
-    ensureAlive();
-    flutterEngine.getDartExecutor().notifyLowMemoryWarning();
-    flutterEngine.getSystemChannel().sendMemoryPressureWarning();
   }
 
   /**

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
@@ -981,19 +981,6 @@ public class FlutterFragment extends Fragment
   }
 
   /**
-   * Callback invoked when memory is low.
-   *
-   * <p>This implementation forwards a memory pressure warning to the running Flutter app.
-   */
-  @Override
-  public void onLowMemory() {
-    super.onLowMemory();
-    if (stillAttachedForEvent("onLowMemory")) {
-      delegate.onLowMemory();
-    }
-  }
-
-  /**
    * {@link FlutterActivityAndFragmentDelegate.Host} method that is used by {@link
    * FlutterActivityAndFragmentDelegate} to obtain Flutter shell arguments when initializing
    * Flutter.

--- a/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
@@ -12,12 +12,17 @@ import android.os.Handler;
 import android.view.Surface;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 import io.flutter.Log;
 import io.flutter.embedding.engine.FlutterJNI;
 import io.flutter.view.TextureRegistry;
+import java.lang.ref.WeakReference;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -41,6 +46,10 @@ public class FlutterRenderer implements TextureRegistry {
   @Nullable private Surface surface;
   private boolean isDisplayingFlutterUi = false;
   private Handler handler = new Handler();
+
+  @NonNull
+  private final Set<WeakReference<TextureRegistry.OnTrimMemoryListener>> onTrimMemoryListeners =
+      new HashSet<>();
 
   @NonNull
   private final FlutterUiDisplayListener flutterUiDisplayListener =
@@ -89,6 +98,39 @@ public class FlutterRenderer implements TextureRegistry {
     flutterJNI.removeIsDisplayingFlutterUiListener(listener);
   }
 
+  private void clearDeadListeners() {
+    final Iterator<WeakReference<OnTrimMemoryListener>> iterator = onTrimMemoryListeners.iterator();
+    while (iterator.hasNext()) {
+      WeakReference<OnTrimMemoryListener> listenerRef = iterator.next();
+      final OnTrimMemoryListener listener = listenerRef.get();
+      if (listener == null) {
+        iterator.remove();
+      }
+    }
+  }
+
+  /** Adds a listener that is invoked when a memory pressure warning was forward. */
+  @VisibleForTesting
+  /* package */ void addOnTrimMemoryListener(@NonNull OnTrimMemoryListener listener) {
+    // Purge dead listener to avoid accumulating.
+    clearDeadListeners();
+    onTrimMemoryListeners.add(new WeakReference<>(listener));
+  }
+
+  /**
+   * Removes a {@link OnTrimMemoryListener} that was added with {@link
+   * #addOnTrimMemoryListener(OnTrimMemoryListener)}.
+   */
+  @VisibleForTesting
+  /* package */ void removeOnTrimMemoryListener(@NonNull OnTrimMemoryListener listener) {
+    for (WeakReference<OnTrimMemoryListener> listenerRef : onTrimMemoryListeners) {
+      if (listenerRef.get() == listener) {
+        onTrimMemoryListeners.remove(listenerRef);
+        break;
+      }
+    }
+  }
+
   // ------ START TextureRegistry IMPLEMENTATION -----
   /**
    * Creates and returns a new {@link SurfaceTexture} managed by the Flutter engine that is also
@@ -112,20 +154,38 @@ public class FlutterRenderer implements TextureRegistry {
         new SurfaceTextureRegistryEntry(nextTextureId.getAndIncrement(), surfaceTexture);
     Log.v(TAG, "New SurfaceTexture ID: " + entry.id());
     registerTexture(entry.id(), entry.textureWrapper());
+    addOnTrimMemoryListener(entry);
     return entry;
   }
 
-  final class SurfaceTextureRegistryEntry implements TextureRegistry.SurfaceTextureEntry {
+  @Override
+  public void onTrimMemory(int level) {
+    final Iterator<WeakReference<OnTrimMemoryListener>> iterator = onTrimMemoryListeners.iterator();
+    while (iterator.hasNext()) {
+      WeakReference<OnTrimMemoryListener> listenerRef = iterator.next();
+      final OnTrimMemoryListener listener = listenerRef.get();
+      if (listener != null) {
+        listener.onTrimMemory(level);
+      } else {
+        // Purge cleared refs to avoid accumulating a lot of dead listener
+        iterator.remove();
+      }
+    }
+  }
+
+  final class SurfaceTextureRegistryEntry
+      implements TextureRegistry.SurfaceTextureEntry, TextureRegistry.OnTrimMemoryListener {
     private final long id;
     @NonNull private final SurfaceTextureWrapper textureWrapper;
     private boolean released;
-    @Nullable private OnFrameConsumedListener listener;
+    @Nullable private OnTrimMemoryListener trimMemoryListener;
+    @Nullable private OnFrameConsumedListener frameConsumedListener;
     private final Runnable onFrameConsumed =
         new Runnable() {
           @Override
           public void run() {
-            if (listener != null) {
-              listener.onFrameConsumed();
+            if (frameConsumedListener != null) {
+              frameConsumedListener.onFrameConsumed();
             }
           }
         };
@@ -149,6 +209,13 @@ public class FlutterRenderer implements TextureRegistry {
       }
     }
 
+    @Override
+    public void onTrimMemory(int level) {
+      if (trimMemoryListener != null) {
+        trimMemoryListener.onTrimMemory(level);
+      }
+    }
+
     private SurfaceTexture.OnFrameAvailableListener onFrameListener =
         new SurfaceTexture.OnFrameAvailableListener() {
           @Override
@@ -163,6 +230,10 @@ public class FlutterRenderer implements TextureRegistry {
             markTextureFrameAvailable(id);
           }
         };
+
+    private void removeListener() {
+      removeOnTrimMemoryListener(this);
+    }
 
     @NonNull
     public SurfaceTextureWrapper textureWrapper() {
@@ -188,6 +259,7 @@ public class FlutterRenderer implements TextureRegistry {
       Log.v(TAG, "Releasing a SurfaceTexture (" + id + ").");
       textureWrapper.release();
       unregisterTexture(id);
+      removeListener();
       released = true;
     }
 
@@ -206,7 +278,12 @@ public class FlutterRenderer implements TextureRegistry {
 
     @Override
     public void setOnFrameConsumedListener(@Nullable OnFrameConsumedListener listener) {
-      this.listener = listener;
+      frameConsumedListener = listener;
+    }
+
+    @Override
+    public void setOnTrimMemoryListener(@Nullable OnTrimMemoryListener listener) {
+      trimMemoryListener = listener;
     }
   }
 

--- a/shell/platform/android/io/flutter/view/TextureRegistry.java
+++ b/shell/platform/android/io/flutter/view/TextureRegistry.java
@@ -31,6 +31,13 @@ public interface TextureRegistry {
   @NonNull
   SurfaceTextureEntry registerSurfaceTexture(@NonNull SurfaceTexture surfaceTexture);
 
+  /**
+   * Callback invoked when memory is low.
+   *
+   * <p>Invoke this from {@link android.app.Activity#onTrimMemory(int)}.
+   */
+  default void onTrimMemory(int level) {}
+
   /** A registry entry for a managed SurfaceTexture. */
   interface SurfaceTextureEntry {
     /** @return The managed SurfaceTexture. */
@@ -45,6 +52,9 @@ public interface TextureRegistry {
 
     /** Set a listener that will be notified when the most recent image has been consumed. */
     default void setOnFrameConsumedListener(@Nullable OnFrameConsumedListener listener) {}
+
+    /** Set a listener that will be notified when a memory pressure warning was forward. */
+    default void setOnTrimMemoryListener(@Nullable OnTrimMemoryListener listener) {}
   }
 
   /** Listener invoked when the most recent image has been consumed. */
@@ -54,5 +64,11 @@ public interface TextureRegistry {
      * consumed.
      */
     void onFrameConsumed();
+  }
+
+  /** Listener invoked when a memory pressure warning was forward. */
+  interface OnTrimMemoryListener {
+    /** This method will be invoked when a memory pressure warning was forward. */
+    void onTrimMemory(int level);
   }
 }

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
@@ -864,23 +864,6 @@ public class FlutterActivityAndFragmentDelegateTest {
   }
 
   @Test
-  public void itNotifiesDartExecutorAndSendsMessageOverSystemChannelWhenInformedOfLowMemory() {
-    // Create the real object that we're testing.
-    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
-
-    // --- Execute the behavior under test ---
-    // The FlutterEngine is set up in onAttach().
-    delegate.onAttach(ctx);
-
-    // Emulate the host and call the method that we expect to be forwarded.
-    delegate.onLowMemory();
-
-    // Verify that the call was forwarded to the engine.
-    verify(mockFlutterEngine.getDartExecutor(), times(1)).notifyLowMemoryWarning();
-    verify(mockFlutterEngine.getSystemChannel(), times(1)).sendMemoryPressureWarning();
-  }
-
-  @Test
   public void itDestroysItsOwnEngineIfHostRequestsIt() {
     // ---- Test setup ----
     // Adjust fake host to request engine destruction.


### PR DESCRIPTION
When a memory pressure warning is received and the level equal {@code ComponentCallbacks2.TRIM_MEMORY_COMPLETE}, the Android system release the underlying surface. If we continue to use the surface (e.g., call lockHardwareCanvas), a crash occurs, and we found that this crash appeared on Android 10 and above.

Steps to reproduce:
1. Open a PlatformView page in your app;
2. Switch your app to the **background**;
3. Simulate low memory : `adb shell am send-trim-memory <your_package_name_here> COMPLETE`;
4. Bring your app to the **foreground**;
5. Then crash

Here our workaround is to recreate the surface before using it.

Fixes https://github.com/flutter/flutter/issues/103870

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
