### PR TITLE
[Impeller] Interpret odd path winding in the dispatcher

### DIFF
--- a/impeller/display_list/display_list_dispatcher.cc
+++ b/impeller/display_list/display_list_dispatcher.cc
@@ -12,6 +12,7 @@
 #include "impeller/entity/contents/linear_gradient_contents.h"
 #include "impeller/entity/contents/solid_stroke_contents.h"
 #include "impeller/entity/entity.h"
+#include "impeller/geometry/path.h"
 #include "impeller/geometry/path_builder.h"
 #include "impeller/geometry/scalar.h"
 #include "impeller/geometry/vertices.h"
@@ -490,8 +491,22 @@ static Path ToPath(const SkPath& path) {
         break;
     }
   } while (verb != SkPath::Verb::kDone_Verb);
-  // TODO: Convert fill types.
-  return builder.TakePath();
+
+  FillType fill_type;
+  switch (path.getFillType()) {
+    case SkPathFillType::kWinding:
+      fill_type = FillType::kNonZero;
+      break;
+    case SkPathFillType::kEvenOdd:
+      fill_type = FillType::kOdd;
+      break;
+    case SkPathFillType::kInverseWinding:
+    case SkPathFillType::kInverseEvenOdd:
+      UNIMPLEMENTED;
+      fill_type = FillType::kNonZero;
+      break;
+  }
+  return builder.TakePath(fill_type);
 }
 
 static Path ToPath(const SkRRect& rrect) {
@@ -558,7 +573,7 @@ void DisplayListDispatcher::clipRRect(const SkRRect& rrect,
 void DisplayListDispatcher::clipPath(const SkPath& path,
                                      SkClipOp clip_op,
                                      bool is_aa) {
-  canvas_.ClipPath(ToPath(path));
+  canvas_.ClipPath(ToPath(path), ToClipOperation(clip_op));
 }
 
 // |flutter::Dispatcher|

--- a/impeller/display_list/display_list_dispatcher.cc
+++ b/impeller/display_list/display_list_dispatcher.cc
@@ -502,6 +502,7 @@ static Path ToPath(const SkPath& path) {
       break;
     case SkPathFillType::kInverseWinding:
     case SkPathFillType::kInverseEvenOdd:
+      // TODO(104848): Support the inverse winding modes.
       UNIMPLEMENTED;
       fill_type = FillType::kNonZero;
       break;

--- a/impeller/display_list/display_list_unittests.cc
+++ b/impeller/display_list/display_list_unittests.cc
@@ -176,6 +176,21 @@ TEST_P(DisplayListTest, StrokedPathsDrawCorrectly) {
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
 
+TEST_P(DisplayListTest, CanDrawWithOddPathWinding) {
+  flutter::DisplayListBuilder builder;
+  builder.setColor(SK_ColorRED);
+  builder.setStyle(flutter::DlDrawStyle::kFill);
+
+  builder.translate(300, 300);
+  SkPath path;
+  path.setFillType(SkPathFillType::kEvenOdd);
+  path.addCircle(0, 0, 100);
+  path.addCircle(0, 0, 50);
+  builder.drawPath(path);
+
+  ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
+}
+
 TEST_P(DisplayListTest, CanDrawWithMaskBlur) {
   auto texture = CreateTextureForFixture("embarcadero.jpg");
   flutter::DisplayListBuilder builder;


### PR DESCRIPTION
`impeller_unittests --gtest_filter=Play/DisplayListTest.CanDrawWithOddPathWinding/Metal --timeout=0`:
![image](https://user-images.githubusercontent.com/919017/170679631-2537af43-f591-4937-82f4-b8af66d20130.png)
