### PR TITLE
[lint] Enforce k prefix for global constants

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,6 +2,7 @@
 Checks: "google-*,\
 clang-analyzer-*,\
 clang-diagnostic-*,\
+readability-identifier-naming,\
 -google-objc-global-variable-declaration,\
 -google-objc-avoid-throwing-exception,\
 -clang-analyzer-nullability.NullPassedToNonnull,\
@@ -15,6 +16,11 @@ clang-diagnostic-*,\
 # to prevent new warnings being introduced.
 # https://github.com/flutter/flutter/issues/93279
 WarningsAsErrors: "clang-analyzer-*,\
+readability-identifier-naming,\
 clang-diagnostic-*,\
 google-objc-*,\
 google-explicit-constructor"
+
+CheckOptions:
+  - key: readability-identifier-naming.GlobalConstantPrefix
+    value: k

--- a/display_list/display_list_canvas_unittests.cc
+++ b/display_list/display_list_canvas_unittests.cc
@@ -20,25 +20,25 @@
 namespace flutter {
 namespace testing {
 
-constexpr int TestWidth = 200;
-constexpr int TestHeight = 200;
-constexpr int RenderWidth = 100;
-constexpr int RenderHeight = 100;
-constexpr int RenderHalfWidth = 50;
-constexpr int RenderHalfHeight = 50;
-constexpr int RenderLeft = (TestWidth - RenderWidth) / 2;
-constexpr int RenderTop = (TestHeight - RenderHeight) / 2;
-constexpr int RenderRight = RenderLeft + RenderWidth;
-constexpr int RenderBottom = RenderTop + RenderHeight;
-constexpr int RenderCenterX = (RenderLeft + RenderRight) / 2;
-constexpr int RenderCenterY = (RenderTop + RenderBottom) / 2;
-constexpr SkScalar RenderRadius = std::min(RenderWidth, RenderHeight) / 2.0;
-constexpr SkScalar RenderCornerRadius = RenderRadius / 5.0;
+constexpr int kTestWidth = 200;
+constexpr int kTestHeight = 200;
+constexpr int kRenderWidth = 100;
+constexpr int kRenderHeight = 100;
+constexpr int kRenderHalfWidth = 50;
+constexpr int kRenderHalfHeight = 50;
+constexpr int kRenderLeft = (kTestWidth - kRenderWidth) / 2;
+constexpr int kRenderTop = (kTestHeight - kRenderHeight) / 2;
+constexpr int kRenderRight = kRenderLeft + kRenderWidth;
+constexpr int kRenderBottom = kRenderTop + kRenderHeight;
+constexpr int kRenderCenterX = (kRenderLeft + kRenderRight) / 2;
+constexpr int kRenderCenterY = (kRenderTop + kRenderBottom) / 2;
+constexpr SkScalar kRenderRadius = std::min(kRenderWidth, kRenderHeight) / 2.0;
+constexpr SkScalar kRenderCornerRadius = kRenderRadius / 5.0;
 
-constexpr SkPoint TestCenter = SkPoint::Make(TestWidth / 2, TestHeight / 2);
-constexpr SkRect TestBounds = SkRect::MakeWH(TestWidth, TestHeight);
-constexpr SkRect RenderBounds =
-    SkRect::MakeLTRB(RenderLeft, RenderTop, RenderRight, RenderBottom);
+constexpr SkPoint kTestCenter = SkPoint::Make(kTestWidth / 2, kTestHeight / 2);
+constexpr SkRect kTestBounds = SkRect::MakeWH(kTestWidth, kTestHeight);
+constexpr SkRect kRenderBounds =
+    SkRect::MakeLTRB(kRenderLeft, kRenderTop, kRenderRight, kRenderBottom);
 
 // The tests try 3 miter limit values, 0.0, 4.0 (the default), and 10.0
 // These values will allow us to construct a diamond that spans the
@@ -50,29 +50,29 @@ constexpr SkRect RenderBounds =
 
 // The X offsets which will be used for tall vertical diamonds are
 // expressed in terms of the rendering height to obtain the proper angle
-constexpr SkScalar MiterExtremeDiamondOffsetX = RenderHeight * 0.04;
-constexpr SkScalar Miter10DiamondOffsetX = RenderHeight * 0.051;
-constexpr SkScalar Miter4DiamondOffsetX = RenderHeight * 0.14;
+constexpr SkScalar kMiterExtremeDiamondOffsetX = kRenderHeight * 0.04;
+constexpr SkScalar kMiter10DiamondOffsetX = kRenderHeight * 0.051;
+constexpr SkScalar kMiter4DiamondOffsetX = kRenderHeight * 0.14;
 
 // The Y offsets which will be used for long horizontal diamonds are
 // expressed in terms of the rendering width to obtain the proper angle
-constexpr SkScalar MiterExtremeDiamondOffsetY = RenderWidth * 0.04;
-constexpr SkScalar Miter10DiamondOffsetY = RenderWidth * 0.051;
-constexpr SkScalar Miter4DiamondOffsetY = RenderWidth * 0.14;
+constexpr SkScalar kMiterExtremeDiamondOffsetY = kRenderWidth * 0.04;
+constexpr SkScalar kMiter10DiamondOffsetY = kRenderWidth * 0.051;
+constexpr SkScalar kMiter4DiamondOffsetY = kRenderWidth * 0.14;
 
 // Render 3 vertical and horizontal diamonds each
 // designed to break at the tested miter limits
 // 0.0, 4.0 and 10.0
 // Center is biased by 0.5 to include more pixel centers in the
 // thin miters
-constexpr SkScalar x_off_0 = RenderCenterX + 0.5;
-constexpr SkScalar x_off_l1 = x_off_0 - Miter4DiamondOffsetX;
-constexpr SkScalar x_off_l2 = x_off_l1 - Miter10DiamondOffsetX;
-constexpr SkScalar x_off_l3 = x_off_l2 - Miter10DiamondOffsetX;
-constexpr SkScalar x_off_r1 = x_off_0 + Miter4DiamondOffsetX;
-constexpr SkScalar x_off_r2 = x_off_r1 + MiterExtremeDiamondOffsetX;
-constexpr SkScalar x_off_r3 = x_off_r2 + MiterExtremeDiamondOffsetX;
-constexpr SkPoint VerticalMiterDiamondPoints[] = {
+constexpr SkScalar kX_off_0 = kRenderCenterX + 0.5;
+constexpr SkScalar kX_off_l1 = kX_off_0 - kMiter4DiamondOffsetX;
+constexpr SkScalar kX_off_l2 = kX_off_l1 - kMiter10DiamondOffsetX;
+constexpr SkScalar kX_off_l3 = kX_off_l2 - kMiter10DiamondOffsetX;
+constexpr SkScalar kX_off_r1 = kX_off_0 + kMiter4DiamondOffsetX;
+constexpr SkScalar kX_off_r2 = kX_off_r1 + kMiterExtremeDiamondOffsetX;
+constexpr SkScalar kX_off_r3 = kX_off_r2 + kMiterExtremeDiamondOffsetX;
+constexpr SkPoint kVerticalMiterDiamondPoints[] = {
     // Vertical diamonds:
     //  M10   M4  Mextreme
     //   /\   /|\   /\       top of RenderBounds
@@ -81,54 +81,55 @@ constexpr SkPoint VerticalMiterDiamondPoints[] = {
     //  \  / \ | / \  /              to
     //   \/   \|/   \/      bottom of RenderBounds
     // clang-format off
-    SkPoint::Make(x_off_l3, RenderCenterY),
-    SkPoint::Make(x_off_l2, RenderTop),
-    SkPoint::Make(x_off_l1, RenderCenterY),
-    SkPoint::Make(x_off_0,  RenderTop),
-    SkPoint::Make(x_off_r1, RenderCenterY),
-    SkPoint::Make(x_off_r2, RenderTop),
-    SkPoint::Make(x_off_r3, RenderCenterY),
-    SkPoint::Make(x_off_r2, RenderBottom),
-    SkPoint::Make(x_off_r1, RenderCenterY),
-    SkPoint::Make(x_off_0,  RenderBottom),
-    SkPoint::Make(x_off_l1, RenderCenterY),
-    SkPoint::Make(x_off_l2, RenderBottom),
-    SkPoint::Make(x_off_l3, RenderCenterY),
+    SkPoint::Make(kX_off_l3, kRenderCenterY),
+    SkPoint::Make(kX_off_l2, kRenderTop),
+    SkPoint::Make(kX_off_l1, kRenderCenterY),
+    SkPoint::Make(kX_off_0,  kRenderTop),
+    SkPoint::Make(kX_off_r1, kRenderCenterY),
+    SkPoint::Make(kX_off_r2, kRenderTop),
+    SkPoint::Make(kX_off_r3, kRenderCenterY),
+    SkPoint::Make(kX_off_r2, kRenderBottom),
+    SkPoint::Make(kX_off_r1, kRenderCenterY),
+    SkPoint::Make(kX_off_0,  kRenderBottom),
+    SkPoint::Make(kX_off_l1, kRenderCenterY),
+    SkPoint::Make(kX_off_l2, kRenderBottom),
+    SkPoint::Make(kX_off_l3, kRenderCenterY),
     // clang-format on
 };
-const int VerticalMiterDiamondPointCount =
-    sizeof(VerticalMiterDiamondPoints) / sizeof(VerticalMiterDiamondPoints[0]);
+const int kVerticalMiterDiamondPointCount =
+    sizeof(kVerticalMiterDiamondPoints) /
+    sizeof(kVerticalMiterDiamondPoints[0]);
 
-constexpr SkScalar y_off_0 = RenderCenterY + 0.5;
-constexpr SkScalar y_off_u1 = x_off_0 - Miter4DiamondOffsetY;
-constexpr SkScalar y_off_u2 = y_off_u1 - Miter10DiamondOffsetY;
-constexpr SkScalar y_off_u3 = y_off_u2 - Miter10DiamondOffsetY;
-constexpr SkScalar y_off_d1 = x_off_0 + Miter4DiamondOffsetY;
-constexpr SkScalar y_off_d2 = y_off_d1 + MiterExtremeDiamondOffsetY;
-constexpr SkScalar y_off_d3 = y_off_d2 + MiterExtremeDiamondOffsetY;
-const SkPoint HorizontalMiterDiamondPoints[] = {
+constexpr SkScalar kY_off_0 = kRenderCenterY + 0.5;
+constexpr SkScalar kY_off_u1 = kX_off_0 - kMiter4DiamondOffsetY;
+constexpr SkScalar kY_off_u2 = kY_off_u1 - kMiter10DiamondOffsetY;
+constexpr SkScalar kY_off_u3 = kY_off_u2 - kMiter10DiamondOffsetY;
+constexpr SkScalar kY_off_d1 = kX_off_0 + kMiter4DiamondOffsetY;
+constexpr SkScalar kY_off_d2 = kY_off_d1 + kMiterExtremeDiamondOffsetY;
+constexpr SkScalar kY_off_d3 = kY_off_d2 + kMiterExtremeDiamondOffsetY;
+const SkPoint kHorizontalMiterDiamondPoints[] = {
     // Horizontal diamonds
     // Same configuration as Vertical diamonds above but
     // rotated 90 degrees
     // clang-format off
-    SkPoint::Make(RenderCenterX, y_off_u3),
-    SkPoint::Make(RenderLeft,    y_off_u2),
-    SkPoint::Make(RenderCenterX, y_off_u1),
-    SkPoint::Make(RenderLeft,    y_off_0),
-    SkPoint::Make(RenderCenterX, y_off_d1),
-    SkPoint::Make(RenderLeft,    y_off_d2),
-    SkPoint::Make(RenderCenterX, y_off_d3),
-    SkPoint::Make(RenderRight,   y_off_d2),
-    SkPoint::Make(RenderCenterX, y_off_d1),
-    SkPoint::Make(RenderRight,   y_off_0),
-    SkPoint::Make(RenderCenterX, y_off_u1),
-    SkPoint::Make(RenderRight,   y_off_u2),
-    SkPoint::Make(RenderCenterX, y_off_u3),
+    SkPoint::Make(kRenderCenterX, kY_off_u3),
+    SkPoint::Make(kRenderLeft,    kY_off_u2),
+    SkPoint::Make(kRenderCenterX, kY_off_u1),
+    SkPoint::Make(kRenderLeft,    kY_off_0),
+    SkPoint::Make(kRenderCenterX, kY_off_d1),
+    SkPoint::Make(kRenderLeft,    kY_off_d2),
+    SkPoint::Make(kRenderCenterX, kY_off_d3),
+    SkPoint::Make(kRenderRight,   kY_off_d2),
+    SkPoint::Make(kRenderCenterX, kY_off_d1),
+    SkPoint::Make(kRenderRight,   kY_off_0),
+    SkPoint::Make(kRenderCenterX, kY_off_u1),
+    SkPoint::Make(kRenderRight,   kY_off_u2),
+    SkPoint::Make(kRenderCenterX, kY_off_u3),
     // clang-format on
 };
-const int HorizontalMiterDiamondPointCount =
-    (sizeof(HorizontalMiterDiamondPoints) /
-     sizeof(HorizontalMiterDiamondPoints[0]));
+const int kHorizontalMiterDiamondPointCount =
+    (sizeof(kHorizontalMiterDiamondPoints) /
+     sizeof(kHorizontalMiterDiamondPoints[0]));
 
 // A class to specify how much tolerance to allow in bounds estimates.
 // For some attributes, the machinery must make some conservative
@@ -278,8 +279,8 @@ class RenderEnvironment {
 
   std::unique_ptr<RenderSurface> MakeSurface(
       const DlColor bg = DlColor::kTransparent(),
-      int width = TestWidth,
-      int height = TestHeight) const {
+      int width = kTestWidth,
+      int height = kTestHeight) const {
     sk_sp<SkSurface> surface =
         SkSurface::MakeRaster(info_.makeWH(width, height));
     surface->getCanvas()->clear(bg);
@@ -723,18 +724,19 @@ class CanvasCompareTester {
   static void RenderWithSaveRestore(const TestParameters& testP,
                                     const RenderEnvironment& env,
                                     const BoundsTolerance& tolerance) {
-    SkRect clip = SkRect::MakeXYWH(RenderCenterX - 1, RenderCenterY - 1, 2, 2);
-    SkRect rect = SkRect::MakeXYWH(RenderCenterX, RenderCenterY, 10, 10);
+    SkRect clip =
+        SkRect::MakeXYWH(kRenderCenterX - 1, kRenderCenterY - 1, 2, 2);
+    SkRect rect = SkRect::MakeXYWH(kRenderCenterX, kRenderCenterY, 10, 10);
     DlColor alpha_layer_color = DlColor::kCyan().withAlpha(0x7f);
     DlColor default_color = DlPaint::kDefaultColor;
     CvRenderer cv_safe_restore = [=](SkCanvas* cv, const SkPaint& p) {
       // Draw another primitive to disable peephole optimizations
-      cv->drawRect(RenderBounds.makeOffset(500, 500), p);
+      cv->drawRect(kRenderBounds.makeOffset(500, 500), p);
       cv->restore();
     };
     DlRenderer dl_safe_restore = [=](DisplayListBuilder& b) {
       // Draw another primitive to disable peephole optimizations
-      b.drawRect(RenderBounds.makeOffset(500, 500));
+      b.drawRect(kRenderBounds.makeOffset(500, 500));
       b.restore();
     };
     CvRenderer cv_opt_restore = [=](SkCanvas* cv, const SkPaint& p) {
@@ -745,7 +747,7 @@ class CanvasCompareTester {
       // Just a simple restore to allow peephole optimizations to occur
       b.restore();
     };
-    SkRect layer_bounds = RenderBounds.makeInset(15, 15);
+    SkRect layer_bounds = kRenderBounds.makeInset(15, 15);
     RenderWith(testP, env, tolerance,
                CaseParameters(
                    "With prior save/clip/restore",
@@ -865,12 +867,12 @@ class CanvasCompareTester {
                        [=](SkCanvas* cv, SkPaint& p) {
                          SkPaint save_p;
                          save_p.setColorFilter(filter.skia_object());
-                         cv->saveLayer(RenderBounds, &save_p);
+                         cv->saveLayer(kRenderBounds, &save_p);
                          p.setStrokeWidth(5.0);
                        },
                        [=](DisplayListBuilder& b) {
                          b.setColorFilter(&filter);
-                         b.saveLayer(&RenderBounds, true);
+                         b.saveLayer(&kRenderBounds, true);
                          b.setColorFilter(nullptr);
                          b.setStrokeWidth(5.0);
                        })
@@ -906,12 +908,12 @@ class CanvasCompareTester {
                        [=](SkCanvas* cv, SkPaint& p) {
                          SkPaint save_p;
                          save_p.setImageFilter(filter.skia_object());
-                         cv->saveLayer(RenderBounds, &save_p);
+                         cv->saveLayer(kRenderBounds, &save_p);
                          p.setStrokeWidth(5.0);
                        },
                        [=](DisplayListBuilder& b) {
                          b.setImageFilter(&filter);
-                         b.saveLayer(&RenderBounds, true);
+                         b.saveLayer(&kRenderBounds, true);
                          b.setImageFilter(nullptr);
                          b.setStrokeWidth(5.0);
                        })
@@ -974,12 +976,12 @@ class CanvasCompareTester {
       RenderEnvironment dither_env = RenderEnvironment::Make565();
       DlColor dither_bg = DlColor::kBlack();
       CvSetup cv_dither_setup = [=](SkCanvas*, SkPaint& p) {
-        p.setShader(testImageColorSource.skia_object());
+        p.setShader(kTestImageColorSource.skia_object());
         p.setAlpha(0xf0);
         p.setStrokeWidth(5.0);
       };
       DlRenderer dl_dither_setup = [=](DisplayListBuilder& b) {
-        b.setColorSource(&testImageColorSource);
+        b.setColorSource(&kTestImageColorSource);
         b.setColor(DlColor(0xf0000000));
         b.setStrokeWidth(5.0);
       };
@@ -1083,11 +1085,11 @@ class CanvasCompareTester {
       // (for drawPaint) so we create a new environment for these tests.
       RenderEnvironment blur_env = RenderEnvironment::MakeN32();
       CvSetup cv_blur_setup = [=](SkCanvas*, SkPaint& p) {
-        p.setShader(testImageColorSource.skia_object());
+        p.setShader(kTestImageColorSource.skia_object());
         p.setStrokeWidth(5.0);
       };
       DlRenderer dl_blur_setup = [=](DisplayListBuilder& b) {
-        b.setColorSource(&testImageColorSource);
+        b.setColorSource(&kTestImageColorSource);
         b.setStrokeWidth(5.0);
       };
       blur_env.init_ref(cv_blur_setup, testP.cv_renderer(), dl_blur_setup);
@@ -1128,11 +1130,11 @@ class CanvasCompareTester {
       // (for drawPaint) so we create a new environment for these tests.
       RenderEnvironment dilate_env = RenderEnvironment::MakeN32();
       CvSetup cv_dilate_setup = [=](SkCanvas*, SkPaint& p) {
-        p.setShader(testImageColorSource.skia_object());
+        p.setShader(kTestImageColorSource.skia_object());
         p.setStrokeWidth(5.0);
       };
       DlRenderer dl_dilate_setup = [=](DisplayListBuilder& b) {
-        b.setColorSource(&testImageColorSource);
+        b.setColorSource(&kTestImageColorSource);
         b.setStrokeWidth(5.0);
       };
       dilate_env.init_ref(cv_dilate_setup, testP.cv_renderer(),
@@ -1157,11 +1159,11 @@ class CanvasCompareTester {
       // (for drawPaint) so we create a new environment for these tests.
       RenderEnvironment erode_env = RenderEnvironment::MakeN32();
       CvSetup cv_erode_setup = [=](SkCanvas*, SkPaint& p) {
-        p.setShader(testImageColorSource.skia_object());
+        p.setShader(kTestImageColorSource.skia_object());
         p.setStrokeWidth(6.0);
       };
       DlRenderer dl_erode_setup = [=](DisplayListBuilder& b) {
-        b.setColorSource(&testImageColorSource);
+        b.setColorSource(&kTestImageColorSource);
         b.setStrokeWidth(6.0);
       };
       erode_env.init_ref(cv_erode_setup, testP.cv_renderer(), dl_erode_setup);
@@ -1312,8 +1314,8 @@ class CanvasCompareTester {
 
     {
       SkPoint end_points[] = {
-          SkPoint::Make(RenderBounds.fLeft, RenderBounds.fTop),
-          SkPoint::Make(RenderBounds.fRight, RenderBounds.fBottom),
+          SkPoint::Make(kRenderBounds.fLeft, kRenderBounds.fTop),
+          SkPoint::Make(kRenderBounds.fRight, kRenderBounds.fBottom),
       };
       DlColor colors[] = {
           DlColor::kGreen(),
@@ -1596,15 +1598,15 @@ class CanvasCompareTester {
                      }));
     }
     {
-      SkM44 m44 = SkM44(1, 0, 0, RenderCenterX,  //
-                        0, 1, 0, RenderCenterY,  //
-                        0, 0, 1, 0,              //
+      SkM44 m44 = SkM44(1, 0, 0, kRenderCenterX,  //
+                        0, 1, 0, kRenderCenterY,  //
+                        0, 0, 1, 0,               //
                         0, 0, .001, 1);
       m44.preConcat(
           SkM44::Rotate({1, 0, 0}, math::kPi / 60));  // 3 degrees around X
       m44.preConcat(
           SkM44::Rotate({0, 1, 0}, math::kPi / 45));  // 4 degrees around Y
-      m44.preTranslate(-RenderCenterX, -RenderCenterY);
+      m44.preTranslate(-kRenderCenterX, -kRenderCenterY);
       RenderWith(
           testP, env, skewed_tolerance,
           CaseParameters(
@@ -1623,7 +1625,7 @@ class CanvasCompareTester {
   static void RenderWithClips(const TestParameters& testP,
                               const RenderEnvironment& env,
                               const BoundsTolerance& diff_tolerance) {
-    SkRect r_clip = RenderBounds.makeInset(15.5, 15.5);
+    SkRect r_clip = kRenderBounds.makeInset(15.5, 15.5);
     BoundsTolerance intersect_tolerance = diff_tolerance.clip(r_clip);
     RenderWith(testP, env, intersect_tolerance,
                CaseParameters(
@@ -1685,7 +1687,7 @@ class CanvasCompareTester {
     SkPath path_clip = SkPath();
     path_clip.setFillType(SkPathFillType::kEvenOdd);
     path_clip.addRect(r_clip);
-    path_clip.addCircle(RenderCenterX, RenderCenterY, 1.0);
+    path_clip.addCircle(kRenderCenterX, kRenderCenterY, 1.0);
     RenderWith(testP, env, intersect_tolerance,
                CaseParameters(
                    "Hard ClipPath inset by 15.5",
@@ -1720,7 +1722,7 @@ class CanvasCompareTester {
                                        const CaseParameters& caseP) {
     SkPictureRecorder recorder;
     SkRTreeFactory rtree_factory;
-    SkCanvas* cv = recorder.beginRecording(TestBounds, &rtree_factory);
+    SkCanvas* cv = recorder.beginRecording(kTestBounds, &rtree_factory);
     caseP.render_to(cv, testP);
     return recorder.finishRecordingAsPicture();
   }
@@ -1746,8 +1748,8 @@ class CanvasCompareTester {
     const sk_sp<SkPicture> sk_picture = getSkPicture(testP, caseP);
     SkRect sk_bounds = sk_picture->cullRect();
     const SkPixmap* sk_pixels = sk_surface->pixmap();
-    ASSERT_EQ(sk_pixels->width(), TestWidth) << info;
-    ASSERT_EQ(sk_pixels->height(), TestHeight) << info;
+    ASSERT_EQ(sk_pixels->width(), kTestWidth) << info;
+    ASSERT_EQ(sk_pixels->height(), kTestHeight) << info;
     ASSERT_EQ(sk_pixels->info().bytesPerPixel(), 4) << info;
     checkPixels(sk_pixels, sk_bounds, info + " (Skia reference)", bg);
 
@@ -1767,7 +1769,7 @@ class CanvasCompareTester {
       // This sequence plays the provided equivalently constructed
       // DisplayList onto the SkCanvas of the surface
       // DisplayList => direct rendering
-      DisplayListBuilder builder(TestBounds);
+      DisplayListBuilder builder(kTestBounds);
       caseP.render_to(builder, testP);
       sk_sp<DisplayList> display_list = builder.Build();
       SkRect dl_bounds = display_list->bounds();
@@ -1824,7 +1826,7 @@ class CanvasCompareTester {
       // plays them back on SkCanvas to SkSurface
       // SkCanvas calls => DisplayList => rendering
       std::unique_ptr<RenderSurface> cv_dl_surface = env.MakeSurface(bg);
-      DisplayListCanvasRecorder dl_recorder(TestBounds);
+      DisplayListCanvasRecorder dl_recorder(kTestBounds);
       caseP.render_to(&dl_recorder, testP);
       dl_recorder.builder()->Build()->RenderTo(cv_dl_surface->canvas());
       compareToReference(cv_dl_surface->pixmap(), sk_pixels,
@@ -1839,12 +1841,12 @@ class CanvasCompareTester {
       // renders both back under a transform (scale(2x)) to see if their
       // rendering is affected differently by a change of matrix between
       // recording time and rendering time.
-      const int TestWidth2 = TestWidth * 2;
-      const int TestHeight2 = TestHeight * 2;
+      const int TestWidth2 = kTestWidth * 2;
+      const int TestHeight2 = kTestHeight * 2;
       const SkScalar TestScale = 2.0;
 
       SkPictureRecorder sk_x2_recorder;
-      SkCanvas* ref_canvas = sk_x2_recorder.beginRecording(TestBounds);
+      SkCanvas* ref_canvas = sk_x2_recorder.beginRecording(kTestBounds);
       SkPaint ref_paint;
       caseP.render_to(ref_canvas, testP);
       sk_sp<SkPicture> ref_x2_picture =
@@ -1859,7 +1861,7 @@ class CanvasCompareTester {
       ASSERT_EQ(ref_x2_pixels->height(), TestHeight2) << info;
       ASSERT_EQ(ref_x2_pixels->info().bytesPerPixel(), 4) << info;
 
-      DisplayListBuilder builder_x2(TestBounds);
+      DisplayListBuilder builder_x2(kTestBounds);
       caseP.render_to(builder_x2, testP);
       sk_sp<DisplayList> display_list_x2 = builder_x2.Build();
       std::unique_ptr<RenderSurface> test_x2_surface =
@@ -1897,12 +1899,12 @@ class CanvasCompareTester {
     display_list->RenderTo(group_opacity_canvas, opacity);
     const SkPixmap* group_opacity_pixmap = group_opacity_surface->pixmap();
 
-    ASSERT_EQ(group_opacity_pixmap->width(), TestWidth) << info;
-    ASSERT_EQ(group_opacity_pixmap->height(), TestHeight) << info;
+    ASSERT_EQ(group_opacity_pixmap->width(), kTestWidth) << info;
+    ASSERT_EQ(group_opacity_pixmap->height(), kTestHeight) << info;
     ASSERT_EQ(group_opacity_pixmap->info().bytesPerPixel(), 4) << info;
 
-    ASSERT_EQ(ref_pixmap->width(), TestWidth) << info;
-    ASSERT_EQ(ref_pixmap->height(), TestHeight) << info;
+    ASSERT_EQ(ref_pixmap->width(), kTestWidth) << info;
+    ASSERT_EQ(ref_pixmap->height(), kTestHeight) << info;
     ASSERT_EQ(ref_pixmap->info().bytesPerPixel(), 4) << info;
 
     int pixels_touched = 0;
@@ -1916,10 +1918,10 @@ class CanvasCompareTester {
     // converting 31 steps to 255 steps with an average step size of
     // 8.23 - 24 of the steps are by 8, but 7 of them are by 9.)
     int fudge = env.info().bytesPerPixel() < 4 ? 9 : 2;
-    for (int y = 0; y < TestHeight; y++) {
+    for (int y = 0; y < kTestHeight; y++) {
       const uint32_t* ref_row = ref_pixmap->addr32(0, y);
       const uint32_t* test_row = group_opacity_pixmap->addr32(0, y);
-      for (int x = 0; x < TestWidth; x++) {
+      for (int x = 0; x < kTestWidth; x++) {
         uint32_t ref_pixel = ref_row[x];
         uint32_t test_pixel = test_row[x];
         if (ref_pixel != bg.argb || test_pixel != bg.argb) {
@@ -1949,9 +1951,9 @@ class CanvasCompareTester {
     int pixels_touched = 0;
     int pixels_oob = 0;
     SkIRect i_bounds = ref_bounds.roundOut();
-    for (int y = 0; y < TestHeight; y++) {
+    for (int y = 0; y < kTestHeight; y++) {
       const uint32_t* ref_row = ref_pixels->addr32(0, y);
-      for (int x = 0; x < TestWidth; x++) {
+      for (int x = 0; x < kTestWidth; x++) {
         if (ref_row[x] != untouched) {
           pixels_touched++;
           if (!i_bounds.contains(x, y)) {
@@ -1996,8 +1998,8 @@ class CanvasCompareTester {
                                  const BoundsTolerance* tolerance,
                                  const DlColor bg,
                                  bool fuzzyCompares = false,
-                                 int width = TestWidth,
-                                 int height = TestHeight,
+                                 int width = kTestWidth,
+                                 int height = kTestHeight,
                                  bool printMismatches = false) {
     uint32_t untouched = bg.premultipliedArgb();
     ASSERT_EQ(test_pixels->width(), width) << info;
@@ -2103,10 +2105,10 @@ class CanvasCompareTester {
     }
   }
 
-  static const sk_sp<SkImage> testImage;
+  static const sk_sp<SkImage> kTestImage;
   static const sk_sp<SkImage> makeTestImage() {
     sk_sp<SkSurface> surface =
-        SkSurface::MakeRasterN32Premul(RenderWidth, RenderHeight);
+        SkSurface::MakeRasterN32Premul(kRenderWidth, kRenderHeight);
     SkCanvas* canvas = surface->getCanvas();
     SkPaint p0, p1;
     p0.setStyle(SkPaint::kFill_Style);
@@ -2116,8 +2118,8 @@ class CanvasCompareTester {
     // Some pixels need some transparency for DstIn testing
     p1.setAlpha(128);
     int cbdim = 5;
-    for (int y = 0; y < RenderHeight; y += cbdim) {
-      for (int x = 0; x < RenderWidth; x += cbdim) {
+    for (int y = 0; y < kRenderHeight; y += cbdim) {
+      for (int x = 0; x < kRenderWidth; x += cbdim) {
         SkPaint& cellp = ((x + y) & 1) == 0 ? p0 : p1;
         canvas->drawRect(SkRect::MakeXYWH(x, y, cbdim, cbdim), cellp);
       }
@@ -2125,7 +2127,7 @@ class CanvasCompareTester {
     return surface->makeImageSnapshot();
   }
 
-  static const DlImageColorSource testImageColorSource;
+  static const DlImageColorSource kTestImageColorSource;
 
   static sk_sp<SkTextBlob> MakeTextBlob(std::string string,
                                         SkScalar font_height) {
@@ -2139,9 +2141,9 @@ class CanvasCompareTester {
 BoundsTolerance CanvasCompareTester::DefaultTolerance =
     BoundsTolerance().addAbsolutePadding(1, 1);
 
-const sk_sp<SkImage> CanvasCompareTester::testImage = makeTestImage();
-const DlImageColorSource CanvasCompareTester::testImageColorSource(
-    testImage,
+const sk_sp<SkImage> CanvasCompareTester::kTestImage = makeTestImage();
+const DlImageColorSource CanvasCompareTester::kTestImageColorSource(
+    kTestImage,
     DlTileMode::kRepeat,
     DlTileMode::kRepeat,
     SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone));
@@ -2184,10 +2186,10 @@ TEST_F(DisplayListCanvas, DrawColor) {
 }
 
 TEST_F(DisplayListCanvas, DrawDiagonalLines) {
-  SkPoint p1 = SkPoint::Make(RenderLeft, RenderTop);
-  SkPoint p2 = SkPoint::Make(RenderRight, RenderBottom);
-  SkPoint p3 = SkPoint::Make(RenderLeft, RenderBottom);
-  SkPoint p4 = SkPoint::Make(RenderRight, RenderTop);
+  SkPoint p1 = SkPoint::Make(kRenderLeft, kRenderTop);
+  SkPoint p2 = SkPoint::Make(kRenderRight, kRenderBottom);
+  SkPoint p3 = SkPoint::Make(kRenderLeft, kRenderBottom);
+  SkPoint p4 = SkPoint::Make(kRenderRight, kRenderTop);
 
   CanvasCompareTester::RenderAll(  //
       TestParameters(
@@ -2209,8 +2211,8 @@ TEST_F(DisplayListCanvas, DrawDiagonalLines) {
 }
 
 TEST_F(DisplayListCanvas, DrawHorizontalLine) {
-  SkPoint p1 = SkPoint::Make(RenderLeft, RenderCenterY);
-  SkPoint p2 = SkPoint::Make(RenderRight, RenderCenterY);
+  SkPoint p1 = SkPoint::Make(kRenderLeft, kRenderCenterY);
+  SkPoint p2 = SkPoint::Make(kRenderRight, kRenderCenterY);
 
   CanvasCompareTester::RenderAll(  //
       TestParameters(
@@ -2231,8 +2233,8 @@ TEST_F(DisplayListCanvas, DrawHorizontalLine) {
 }
 
 TEST_F(DisplayListCanvas, DrawVerticalLine) {
-  SkPoint p1 = SkPoint::Make(RenderCenterX, RenderTop);
-  SkPoint p2 = SkPoint::Make(RenderCenterY, RenderBottom);
+  SkPoint p1 = SkPoint::Make(kRenderCenterX, kRenderTop);
+  SkPoint p2 = SkPoint::Make(kRenderCenterY, kRenderBottom);
 
   CanvasCompareTester::RenderAll(  //
       TestParameters(
@@ -2257,16 +2259,16 @@ TEST_F(DisplayListCanvas, DrawRect) {
   CanvasCompareTester::RenderAll(  //
       TestParameters(
           [=](SkCanvas* canvas, const SkPaint& paint) {  //
-            canvas->drawRect(RenderBounds.makeOffset(0.5, 0.5), paint);
+            canvas->drawRect(kRenderBounds.makeOffset(0.5, 0.5), paint);
           },
           [=](DisplayListBuilder& builder) {  //
-            builder.drawRect(RenderBounds.makeOffset(0.5, 0.5));
+            builder.drawRect(kRenderBounds.makeOffset(0.5, 0.5));
           },
           kDrawRectFlags));
 }
 
 TEST_F(DisplayListCanvas, DrawOval) {
-  SkRect rect = RenderBounds.makeInset(0, 10);
+  SkRect rect = kRenderBounds.makeInset(0, 10);
 
   CanvasCompareTester::RenderAll(  //
       TestParameters(
@@ -2283,17 +2285,17 @@ TEST_F(DisplayListCanvas, DrawCircle) {
   CanvasCompareTester::RenderAll(  //
       TestParameters(
           [=](SkCanvas* canvas, const SkPaint& paint) {  //
-            canvas->drawCircle(TestCenter, RenderRadius, paint);
+            canvas->drawCircle(kTestCenter, kRenderRadius, paint);
           },
           [=](DisplayListBuilder& builder) {  //
-            builder.drawCircle(TestCenter, RenderRadius);
+            builder.drawCircle(kTestCenter, kRenderRadius);
           },
           kDrawCircleFlags));
 }
 
 TEST_F(DisplayListCanvas, DrawRRect) {
-  SkRRect rrect =
-      SkRRect::MakeRectXY(RenderBounds, RenderCornerRadius, RenderCornerRadius);
+  SkRRect rrect = SkRRect::MakeRectXY(kRenderBounds, kRenderCornerRadius,
+                                      kRenderCornerRadius);
   CanvasCompareTester::RenderAll(  //
       TestParameters(
           [=](SkCanvas* canvas, const SkPaint& paint) {  //
@@ -2306,11 +2308,11 @@ TEST_F(DisplayListCanvas, DrawRRect) {
 }
 
 TEST_F(DisplayListCanvas, DrawDRRect) {
-  SkRRect outer =
-      SkRRect::MakeRectXY(RenderBounds, RenderCornerRadius, RenderCornerRadius);
-  SkRect innerBounds = RenderBounds.makeInset(30.0, 30.0);
-  SkRRect inner =
-      SkRRect::MakeRectXY(innerBounds, RenderCornerRadius, RenderCornerRadius);
+  SkRRect outer = SkRRect::MakeRectXY(kRenderBounds, kRenderCornerRadius,
+                                      kRenderCornerRadius);
+  SkRect innerBounds = kRenderBounds.makeInset(30.0, 30.0);
+  SkRRect inner = SkRRect::MakeRectXY(innerBounds, kRenderCornerRadius,
+                                      kRenderCornerRadius);
   CanvasCompareTester::RenderAll(  //
       TestParameters(
           [=](SkCanvas* canvas, const SkPaint& paint) {  //
@@ -2326,22 +2328,22 @@ TEST_F(DisplayListCanvas, DrawPath) {
   SkPath path;
 
   // unclosed lines to show some caps
-  path.moveTo(RenderLeft + 15, RenderTop + 15);
-  path.lineTo(RenderRight - 15, RenderBottom - 15);
-  path.moveTo(RenderLeft + 15, RenderBottom - 15);
-  path.lineTo(RenderRight - 15, RenderTop + 15);
+  path.moveTo(kRenderLeft + 15, kRenderTop + 15);
+  path.lineTo(kRenderRight - 15, kRenderBottom - 15);
+  path.moveTo(kRenderLeft + 15, kRenderBottom - 15);
+  path.lineTo(kRenderRight - 15, kRenderTop + 15);
 
-  path.addRect(RenderBounds);
+  path.addRect(kRenderBounds);
 
   // miter diamonds horizontally and vertically to show miters
-  path.moveTo(VerticalMiterDiamondPoints[0]);
-  for (int i = 1; i < VerticalMiterDiamondPointCount; i++) {
-    path.lineTo(VerticalMiterDiamondPoints[i]);
+  path.moveTo(kVerticalMiterDiamondPoints[0]);
+  for (int i = 1; i < kVerticalMiterDiamondPointCount; i++) {
+    path.lineTo(kVerticalMiterDiamondPoints[i]);
   }
   path.close();
-  path.moveTo(HorizontalMiterDiamondPoints[0]);
-  for (int i = 1; i < HorizontalMiterDiamondPointCount; i++) {
-    path.lineTo(HorizontalMiterDiamondPoints[i]);
+  path.moveTo(kHorizontalMiterDiamondPoints[0]);
+  for (int i = 1; i < kHorizontalMiterDiamondPointCount; i++) {
+    path.lineTo(kHorizontalMiterDiamondPoints[i]);
   }
   path.close();
 
@@ -2360,10 +2362,10 @@ TEST_F(DisplayListCanvas, DrawArc) {
   CanvasCompareTester::RenderAll(  //
       TestParameters(
           [=](SkCanvas* canvas, const SkPaint& paint) {  //
-            canvas->drawArc(RenderBounds, 60, 330, false, paint);
+            canvas->drawArc(kRenderBounds, 60, 330, false, paint);
           },
           [=](DisplayListBuilder& builder) {  //
-            builder.drawArc(RenderBounds, 60, 330, false);
+            builder.drawArc(kRenderBounds, 60, 330, false);
           },
           kDrawArcNoCenterFlags));
 }
@@ -2382,10 +2384,10 @@ TEST_F(DisplayListCanvas, DrawArcCenter) {
   CanvasCompareTester::RenderAll(  //
       TestParameters(
           [=](SkCanvas* canvas, const SkPaint& paint) {  //
-            canvas->drawArc(RenderBounds, 60, 360 - 12, true, paint);
+            canvas->drawArc(kRenderBounds, 60, 360 - 12, true, paint);
           },
           [=](DisplayListBuilder& builder) {  //
-            builder.drawArc(RenderBounds, 60, 360 - 12, true);
+            builder.drawArc(kRenderBounds, 60, 360 - 12, true);
           },
           kDrawArcWithCenterFlags)
           .set_draw_arc_center());
@@ -2395,21 +2397,21 @@ TEST_F(DisplayListCanvas, DrawPointsAsPoints) {
   // The +/- 16 points are designed to fall just inside the clips
   // that are tested against so we avoid lots of undrawn pixels
   // in the accumulated bounds.
-  const SkScalar x0 = RenderLeft;
-  const SkScalar x1 = RenderLeft + 16;
-  const SkScalar x2 = (RenderLeft + RenderCenterX) * 0.5;
-  const SkScalar x3 = RenderCenterX + 0.1;
-  const SkScalar x4 = (RenderRight + RenderCenterX) * 0.5;
-  const SkScalar x5 = RenderRight - 16;
-  const SkScalar x6 = RenderRight;
+  const SkScalar x0 = kRenderLeft;
+  const SkScalar x1 = kRenderLeft + 16;
+  const SkScalar x2 = (kRenderLeft + kRenderCenterX) * 0.5;
+  const SkScalar x3 = kRenderCenterX + 0.1;
+  const SkScalar x4 = (kRenderRight + kRenderCenterX) * 0.5;
+  const SkScalar x5 = kRenderRight - 16;
+  const SkScalar x6 = kRenderRight;
 
-  const SkScalar y0 = RenderTop;
-  const SkScalar y1 = RenderTop + 16;
-  const SkScalar y2 = (RenderTop + RenderCenterY) * 0.5;
-  const SkScalar y3 = RenderCenterY + 0.1;
-  const SkScalar y4 = (RenderBottom + RenderCenterY) * 0.5;
-  const SkScalar y5 = RenderBottom - 16;
-  const SkScalar y6 = RenderBottom;
+  const SkScalar y0 = kRenderTop;
+  const SkScalar y1 = kRenderTop + 16;
+  const SkScalar y2 = (kRenderTop + kRenderCenterY) * 0.5;
+  const SkScalar y3 = kRenderCenterY + 0.1;
+  const SkScalar y4 = (kRenderBottom + kRenderCenterY) * 0.5;
+  const SkScalar y5 = kRenderBottom - 16;
+  const SkScalar y6 = kRenderBottom;
 
   // clang-format off
   const SkPoint points[] = {
@@ -2443,15 +2445,15 @@ TEST_F(DisplayListCanvas, DrawPointsAsPoints) {
 }
 
 TEST_F(DisplayListCanvas, DrawPointsAsLines) {
-  const SkScalar x0 = RenderLeft + 1;
-  const SkScalar x1 = RenderLeft + 16;
-  const SkScalar x2 = RenderRight - 16;
-  const SkScalar x3 = RenderRight - 1;
+  const SkScalar x0 = kRenderLeft + 1;
+  const SkScalar x1 = kRenderLeft + 16;
+  const SkScalar x2 = kRenderRight - 16;
+  const SkScalar x3 = kRenderRight - 1;
 
-  const SkScalar y0 = RenderTop;
-  const SkScalar y1 = RenderTop + 16;
-  const SkScalar y2 = RenderBottom - 16;
-  const SkScalar y3 = RenderBottom;
+  const SkScalar y0 = kRenderTop;
+  const SkScalar y1 = kRenderTop + 16;
+  const SkScalar y2 = kRenderBottom - 16;
+  const SkScalar y3 = kRenderBottom;
 
   // clang-format off
   const SkPoint points[] = {
@@ -2493,12 +2495,12 @@ TEST_F(DisplayListCanvas, DrawPointsAsLines) {
 TEST_F(DisplayListCanvas, DrawPointsAsPolygon) {
   const SkPoint points1[] = {
       // RenderBounds box with a diagonal
-      SkPoint::Make(RenderLeft, RenderTop),
-      SkPoint::Make(RenderRight, RenderTop),
-      SkPoint::Make(RenderRight, RenderBottom),
-      SkPoint::Make(RenderLeft, RenderBottom),
-      SkPoint::Make(RenderLeft, RenderTop),
-      SkPoint::Make(RenderRight, RenderBottom),
+      SkPoint::Make(kRenderLeft, kRenderTop),
+      SkPoint::Make(kRenderRight, kRenderTop),
+      SkPoint::Make(kRenderRight, kRenderBottom),
+      SkPoint::Make(kRenderLeft, kRenderBottom),
+      SkPoint::Make(kRenderLeft, kRenderTop),
+      SkPoint::Make(kRenderRight, kRenderBottom),
   };
   const int count1 = sizeof(points1) / sizeof(points1[0]);
 
@@ -2531,13 +2533,13 @@ TEST_F(DisplayListCanvas, DrawVerticesWithColors) {
   // +----------|
   const SkPoint pts[6] = {
       // Upper-Right corner, full top, half right coverage
-      SkPoint::Make(RenderLeft, RenderTop),
-      SkPoint::Make(RenderRight, RenderTop),
-      SkPoint::Make(RenderRight, RenderCenterY),
+      SkPoint::Make(kRenderLeft, kRenderTop),
+      SkPoint::Make(kRenderRight, kRenderTop),
+      SkPoint::Make(kRenderRight, kRenderCenterY),
       // Lower-Left corner, full bottom, half left coverage
-      SkPoint::Make(RenderLeft, RenderBottom),
-      SkPoint::Make(RenderLeft, RenderCenterY),
-      SkPoint::Make(RenderRight, RenderBottom),
+      SkPoint::Make(kRenderLeft, kRenderBottom),
+      SkPoint::Make(kRenderLeft, kRenderCenterY),
+      SkPoint::Make(kRenderRight, kRenderBottom),
   };
   const DlColor colors[6] = {
       SK_ColorRED,  SK_ColorBLUE,   SK_ColorGREEN,
@@ -2571,21 +2573,21 @@ TEST_F(DisplayListCanvas, DrawVerticesWithImage) {
   // +----------|
   const SkPoint pts[6] = {
       // Upper-Right corner, full top, half right coverage
-      SkPoint::Make(RenderLeft, RenderTop),
-      SkPoint::Make(RenderRight, RenderTop),
-      SkPoint::Make(RenderRight, RenderCenterY),
+      SkPoint::Make(kRenderLeft, kRenderTop),
+      SkPoint::Make(kRenderRight, kRenderTop),
+      SkPoint::Make(kRenderRight, kRenderCenterY),
       // Lower-Left corner, full bottom, half left coverage
-      SkPoint::Make(RenderLeft, RenderBottom),
-      SkPoint::Make(RenderLeft, RenderCenterY),
-      SkPoint::Make(RenderRight, RenderBottom),
+      SkPoint::Make(kRenderLeft, kRenderBottom),
+      SkPoint::Make(kRenderLeft, kRenderCenterY),
+      SkPoint::Make(kRenderRight, kRenderBottom),
   };
   const SkPoint tex[6] = {
-      SkPoint::Make(RenderWidth / 2.0, 0),
-      SkPoint::Make(0, RenderHeight),
-      SkPoint::Make(RenderWidth, RenderHeight),
-      SkPoint::Make(RenderWidth / 2, RenderHeight),
+      SkPoint::Make(kRenderWidth / 2.0, 0),
+      SkPoint::Make(0, kRenderHeight),
+      SkPoint::Make(kRenderWidth, kRenderHeight),
+      SkPoint::Make(kRenderWidth / 2, kRenderHeight),
       SkPoint::Make(0, 0),
-      SkPoint::Make(RenderWidth, 0),
+      SkPoint::Make(kRenderWidth, 0),
   };
   const std::shared_ptr<DlVertices> vertices =
       DlVertices::Make(DlVertexMode::kTriangles, 6, pts, tex, nullptr);
@@ -2596,7 +2598,7 @@ TEST_F(DisplayListCanvas, DrawVerticesWithImage) {
             SkPaint v_paint = paint;
             if (v_paint.getShader() == nullptr) {
               v_paint.setShader(
-                  CanvasCompareTester::testImageColorSource.skia_object());
+                  CanvasCompareTester::kTestImageColorSource.skia_object());
             }
             canvas->drawVertices(vertices->skia_object(), SkBlendMode::kSrcOver,
                                  v_paint);
@@ -2604,7 +2606,7 @@ TEST_F(DisplayListCanvas, DrawVerticesWithImage) {
           [=](DisplayListBuilder& builder) {  //
             if (builder.getColorSource() == nullptr) {
               builder.setColorSource(
-                  &CanvasCompareTester::testImageColorSource);
+                  &CanvasCompareTester::kTestImageColorSource);
             }
             builder.drawVertices(vertices, DlBlendMode::kSrcOver);
           },
@@ -2615,14 +2617,14 @@ TEST_F(DisplayListCanvas, DrawVerticesWithImage) {
 TEST_F(DisplayListCanvas, DrawImageNearest) {
   CanvasCompareTester::RenderAll(  //
       TestParameters(
-          [=](SkCanvas* canvas, const SkPaint& paint) {        //
-            canvas->drawImage(CanvasCompareTester::testImage,  //
-                              RenderLeft, RenderTop,
+          [=](SkCanvas* canvas, const SkPaint& paint) {         //
+            canvas->drawImage(CanvasCompareTester::kTestImage,  //
+                              kRenderLeft, kRenderTop,
                               DisplayList::NearestSampling, &paint);
           },
           [=](DisplayListBuilder& builder) {  //
-            builder.drawImage(DlImage::Make(CanvasCompareTester::testImage),
-                              SkPoint::Make(RenderLeft, RenderTop),
+            builder.drawImage(DlImage::Make(CanvasCompareTester::kTestImage),
+                              SkPoint::Make(kRenderLeft, kRenderTop),
                               DisplayList::NearestSampling, true);
           },
           kDrawImageWithPaintFlags));
@@ -2631,14 +2633,14 @@ TEST_F(DisplayListCanvas, DrawImageNearest) {
 TEST_F(DisplayListCanvas, DrawImageNearestNoPaint) {
   CanvasCompareTester::RenderAll(  //
       TestParameters(
-          [=](SkCanvas* canvas, const SkPaint& paint) {        //
-            canvas->drawImage(CanvasCompareTester::testImage,  //
-                              RenderLeft, RenderTop,
+          [=](SkCanvas* canvas, const SkPaint& paint) {         //
+            canvas->drawImage(CanvasCompareTester::kTestImage,  //
+                              kRenderLeft, kRenderTop,
                               DisplayList::NearestSampling, nullptr);
           },
           [=](DisplayListBuilder& builder) {  //
-            builder.drawImage(DlImage::Make(CanvasCompareTester::testImage),
-                              SkPoint::Make(RenderLeft, RenderTop),
+            builder.drawImage(DlImage::Make(CanvasCompareTester::kTestImage),
+                              SkPoint::Make(kRenderLeft, kRenderTop),
                               DisplayList::NearestSampling, false);
           },
           kDrawImageFlags));
@@ -2647,75 +2649,77 @@ TEST_F(DisplayListCanvas, DrawImageNearestNoPaint) {
 TEST_F(DisplayListCanvas, DrawImageLinear) {
   CanvasCompareTester::RenderAll(  //
       TestParameters(
-          [=](SkCanvas* canvas, const SkPaint& paint) {        //
-            canvas->drawImage(CanvasCompareTester::testImage,  //
-                              RenderLeft, RenderTop,
+          [=](SkCanvas* canvas, const SkPaint& paint) {         //
+            canvas->drawImage(CanvasCompareTester::kTestImage,  //
+                              kRenderLeft, kRenderTop,
                               DisplayList::LinearSampling, &paint);
           },
           [=](DisplayListBuilder& builder) {  //
-            builder.drawImage(DlImage::Make(CanvasCompareTester::testImage),
-                              SkPoint::Make(RenderLeft, RenderTop),
+            builder.drawImage(DlImage::Make(CanvasCompareTester::kTestImage),
+                              SkPoint::Make(kRenderLeft, kRenderTop),
                               DisplayList::LinearSampling, true);
           },
           kDrawImageWithPaintFlags));
 }
 
 TEST_F(DisplayListCanvas, DrawImageRectNearest) {
-  SkRect src = SkRect::MakeIWH(RenderWidth, RenderHeight).makeInset(5, 5);
-  SkRect dst = RenderBounds.makeInset(10.5, 10.5);
+  SkRect src = SkRect::MakeIWH(kRenderWidth, kRenderHeight).makeInset(5, 5);
+  SkRect dst = kRenderBounds.makeInset(10.5, 10.5);
   CanvasCompareTester::RenderAll(  //
       TestParameters(
           [=](SkCanvas* canvas, const SkPaint& paint) {  //
-            canvas->drawImageRect(CanvasCompareTester::testImage, src, dst,
+            canvas->drawImageRect(CanvasCompareTester::kTestImage, src, dst,
                                   DisplayList::NearestSampling, &paint,
                                   SkCanvas::kFast_SrcRectConstraint);
           },
           [=](DisplayListBuilder& builder) {  //
-            builder.drawImageRect(DlImage::Make(CanvasCompareTester::testImage),
-                                  src, dst, DisplayList::NearestSampling, true);
+            builder.drawImageRect(
+                DlImage::Make(CanvasCompareTester::kTestImage), src, dst,
+                DisplayList::NearestSampling, true);
           },
           kDrawImageRectWithPaintFlags));
 }
 
 TEST_F(DisplayListCanvas, DrawImageRectNearestNoPaint) {
-  SkRect src = SkRect::MakeIWH(RenderWidth, RenderHeight).makeInset(5, 5);
-  SkRect dst = RenderBounds.makeInset(10.5, 10.5);
+  SkRect src = SkRect::MakeIWH(kRenderWidth, kRenderHeight).makeInset(5, 5);
+  SkRect dst = kRenderBounds.makeInset(10.5, 10.5);
   CanvasCompareTester::RenderAll(  //
       TestParameters(
           [=](SkCanvas* canvas, const SkPaint& paint) {  //
-            canvas->drawImageRect(CanvasCompareTester::testImage, src, dst,
+            canvas->drawImageRect(CanvasCompareTester::kTestImage, src, dst,
                                   DisplayList::NearestSampling, nullptr,
                                   SkCanvas::kFast_SrcRectConstraint);
           },
           [=](DisplayListBuilder& builder) {  //
-            builder.drawImageRect(DlImage::Make(CanvasCompareTester::testImage),
-                                  src, dst, DisplayList::NearestSampling,
-                                  false);
+            builder.drawImageRect(
+                DlImage::Make(CanvasCompareTester::kTestImage), src, dst,
+                DisplayList::NearestSampling, false);
           },
           kDrawImageRectFlags));
 }
 
 TEST_F(DisplayListCanvas, DrawImageRectLinear) {
-  SkRect src = SkRect::MakeIWH(RenderWidth, RenderHeight).makeInset(5, 5);
-  SkRect dst = RenderBounds.makeInset(10.5, 10.5);
+  SkRect src = SkRect::MakeIWH(kRenderWidth, kRenderHeight).makeInset(5, 5);
+  SkRect dst = kRenderBounds.makeInset(10.5, 10.5);
   CanvasCompareTester::RenderAll(  //
       TestParameters(
           [=](SkCanvas* canvas, const SkPaint& paint) {  //
-            canvas->drawImageRect(CanvasCompareTester::testImage, src, dst,
+            canvas->drawImageRect(CanvasCompareTester::kTestImage, src, dst,
                                   DisplayList::LinearSampling, &paint,
                                   SkCanvas::kFast_SrcRectConstraint);
           },
           [=](DisplayListBuilder& builder) {  //
-            builder.drawImageRect(DlImage::Make(CanvasCompareTester::testImage),
-                                  src, dst, DisplayList::LinearSampling, true);
+            builder.drawImageRect(
+                DlImage::Make(CanvasCompareTester::kTestImage), src, dst,
+                DisplayList::LinearSampling, true);
           },
           kDrawImageRectWithPaintFlags));
 }
 
 TEST_F(DisplayListCanvas, DrawImageNineNearest) {
-  SkIRect src = SkIRect::MakeWH(RenderWidth, RenderHeight).makeInset(25, 25);
-  SkRect dst = RenderBounds.makeInset(10.5, 10.5);
-  sk_sp<SkImage> image = CanvasCompareTester::testImage;
+  SkIRect src = SkIRect::MakeWH(kRenderWidth, kRenderHeight).makeInset(25, 25);
+  SkRect dst = kRenderBounds.makeInset(10.5, 10.5);
+  sk_sp<SkImage> image = CanvasCompareTester::kTestImage;
   CanvasCompareTester::RenderAll(  //
       TestParameters(
           [=](SkCanvas* canvas, const SkPaint& paint) {
@@ -2730,9 +2734,9 @@ TEST_F(DisplayListCanvas, DrawImageNineNearest) {
 }
 
 TEST_F(DisplayListCanvas, DrawImageNineNearestNoPaint) {
-  SkIRect src = SkIRect::MakeWH(RenderWidth, RenderHeight).makeInset(25, 25);
-  SkRect dst = RenderBounds.makeInset(10.5, 10.5);
-  sk_sp<SkImage> image = CanvasCompareTester::testImage;
+  SkIRect src = SkIRect::MakeWH(kRenderWidth, kRenderHeight).makeInset(25, 25);
+  SkRect dst = kRenderBounds.makeInset(10.5, 10.5);
+  sk_sp<SkImage> image = CanvasCompareTester::kTestImage;
   CanvasCompareTester::RenderAll(  //
       TestParameters(
           [=](SkCanvas* canvas, const SkPaint& paint) {
@@ -2747,9 +2751,9 @@ TEST_F(DisplayListCanvas, DrawImageNineNearestNoPaint) {
 }
 
 TEST_F(DisplayListCanvas, DrawImageNineLinear) {
-  SkIRect src = SkIRect::MakeWH(RenderWidth, RenderHeight).makeInset(25, 25);
-  SkRect dst = RenderBounds.makeInset(10.5, 10.5);
-  sk_sp<SkImage> image = CanvasCompareTester::testImage;
+  SkIRect src = SkIRect::MakeWH(kRenderWidth, kRenderHeight).makeInset(25, 25);
+  SkRect dst = kRenderBounds.makeInset(10.5, 10.5);
+  sk_sp<SkImage> image = CanvasCompareTester::kTestImage;
   CanvasCompareTester::RenderAll(  //
       TestParameters(
           [=](SkCanvas* canvas, const SkPaint& paint) {
@@ -2764,21 +2768,21 @@ TEST_F(DisplayListCanvas, DrawImageNineLinear) {
 }
 
 TEST_F(DisplayListCanvas, DrawImageLatticeNearest) {
-  const SkRect dst = RenderBounds.makeInset(10.5, 10.5);
+  const SkRect dst = kRenderBounds.makeInset(10.5, 10.5);
   const int divX[] = {
-      RenderWidth * 1 / 4,
-      RenderWidth * 2 / 4,
-      RenderWidth * 3 / 4,
+      kRenderWidth * 1 / 4,
+      kRenderWidth * 2 / 4,
+      kRenderWidth * 3 / 4,
   };
   const int divY[] = {
-      RenderHeight * 1 / 4,
-      RenderHeight * 2 / 4,
-      RenderHeight * 3 / 4,
+      kRenderHeight * 1 / 4,
+      kRenderHeight * 2 / 4,
+      kRenderHeight * 3 / 4,
   };
   SkCanvas::Lattice lattice = {
       divX, divY, nullptr, 3, 3, nullptr, nullptr,
   };
-  sk_sp<SkImage> image = CanvasCompareTester::testImage;
+  sk_sp<SkImage> image = CanvasCompareTester::kTestImage;
   CanvasCompareTester::RenderAll(  //
       TestParameters(
           [=](SkCanvas* canvas, const SkPaint& paint) {
@@ -2793,21 +2797,21 @@ TEST_F(DisplayListCanvas, DrawImageLatticeNearest) {
 }
 
 TEST_F(DisplayListCanvas, DrawImageLatticeNearestNoPaint) {
-  const SkRect dst = RenderBounds.makeInset(10.5, 10.5);
+  const SkRect dst = kRenderBounds.makeInset(10.5, 10.5);
   const int divX[] = {
-      RenderWidth * 1 / 4,
-      RenderWidth * 2 / 4,
-      RenderWidth * 3 / 4,
+      kRenderWidth * 1 / 4,
+      kRenderWidth * 2 / 4,
+      kRenderWidth * 3 / 4,
   };
   const int divY[] = {
-      RenderHeight * 1 / 4,
-      RenderHeight * 2 / 4,
-      RenderHeight * 3 / 4,
+      kRenderHeight * 1 / 4,
+      kRenderHeight * 2 / 4,
+      kRenderHeight * 3 / 4,
   };
   SkCanvas::Lattice lattice = {
       divX, divY, nullptr, 3, 3, nullptr, nullptr,
   };
-  sk_sp<SkImage> image = CanvasCompareTester::testImage;
+  sk_sp<SkImage> image = CanvasCompareTester::kTestImage;
   CanvasCompareTester::RenderAll(  //
       TestParameters(
           [=](SkCanvas* canvas, const SkPaint& paint) {
@@ -2822,21 +2826,21 @@ TEST_F(DisplayListCanvas, DrawImageLatticeNearestNoPaint) {
 }
 
 TEST_F(DisplayListCanvas, DrawImageLatticeLinear) {
-  const SkRect dst = RenderBounds.makeInset(10.5, 10.5);
+  const SkRect dst = kRenderBounds.makeInset(10.5, 10.5);
   const int divX[] = {
-      RenderWidth / 4,
-      RenderWidth / 2,
-      RenderWidth * 3 / 4,
+      kRenderWidth / 4,
+      kRenderWidth / 2,
+      kRenderWidth * 3 / 4,
   };
   const int divY[] = {
-      RenderHeight / 4,
-      RenderHeight / 2,
-      RenderHeight * 3 / 4,
+      kRenderHeight / 4,
+      kRenderHeight / 2,
+      kRenderHeight * 3 / 4,
   };
   SkCanvas::Lattice lattice = {
       divX, divY, nullptr, 3, 3, nullptr, nullptr,
   };
-  sk_sp<SkImage> image = CanvasCompareTester::testImage;
+  sk_sp<SkImage> image = CanvasCompareTester::kTestImage;
   CanvasCompareTester::RenderAll(  //
       TestParameters(
           [=](SkCanvas* canvas, const SkPaint& paint) {
@@ -2853,18 +2857,18 @@ TEST_F(DisplayListCanvas, DrawImageLatticeLinear) {
 TEST_F(DisplayListCanvas, DrawAtlasNearest) {
   const SkRSXform xform[] = {
       // clang-format off
-      { 1.2f,  0.0f, RenderLeft,  RenderTop},
-      { 0.0f,  1.2f, RenderRight, RenderTop},
-      {-1.2f,  0.0f, RenderRight, RenderBottom},
-      { 0.0f, -1.2f, RenderLeft,  RenderBottom},
+      { 1.2f,  0.0f, kRenderLeft,  kRenderTop},
+      { 0.0f,  1.2f, kRenderRight, kRenderTop},
+      {-1.2f,  0.0f, kRenderRight, kRenderBottom},
+      { 0.0f, -1.2f, kRenderLeft,  kRenderBottom},
       // clang-format on
   };
   const SkRect tex[] = {
       // clang-format off
-      {0,               0,                RenderHalfWidth, RenderHalfHeight},
-      {RenderHalfWidth, 0,                RenderWidth,     RenderHalfHeight},
-      {RenderHalfWidth, RenderHalfHeight, RenderWidth,     RenderHeight},
-      {0,               RenderHalfHeight, RenderHalfWidth, RenderHeight},
+      {0,                0,                 kRenderHalfWidth, kRenderHalfHeight},
+      {kRenderHalfWidth, 0,                 kRenderWidth,     kRenderHalfHeight},
+      {kRenderHalfWidth, kRenderHalfHeight, kRenderWidth,     kRenderHeight},
+      {0,                kRenderHalfHeight, kRenderHalfWidth, kRenderHeight},
       // clang-format on
   };
   const DlColor colors[] = {
@@ -2873,7 +2877,7 @@ TEST_F(DisplayListCanvas, DrawAtlasNearest) {
       SK_ColorYELLOW,
       SK_ColorMAGENTA,
   };
-  const sk_sp<SkImage> image = CanvasCompareTester::testImage;
+  const sk_sp<SkImage> image = CanvasCompareTester::kTestImage;
   const SkSamplingOptions sampling = DisplayList::NearestSampling;
   CanvasCompareTester::RenderAll(  //
       TestParameters(
@@ -2894,18 +2898,18 @@ TEST_F(DisplayListCanvas, DrawAtlasNearest) {
 TEST_F(DisplayListCanvas, DrawAtlasNearestNoPaint) {
   const SkRSXform xform[] = {
       // clang-format off
-      { 1.2f,  0.0f, RenderLeft,  RenderTop},
-      { 0.0f,  1.2f, RenderRight, RenderTop},
-      {-1.2f,  0.0f, RenderRight, RenderBottom},
-      { 0.0f, -1.2f, RenderLeft,  RenderBottom},
+      { 1.2f,  0.0f, kRenderLeft,  kRenderTop},
+      { 0.0f,  1.2f, kRenderRight, kRenderTop},
+      {-1.2f,  0.0f, kRenderRight, kRenderBottom},
+      { 0.0f, -1.2f, kRenderLeft,  kRenderBottom},
       // clang-format on
   };
   const SkRect tex[] = {
       // clang-format off
-      {0,               0,                RenderHalfWidth, RenderHalfHeight},
-      {RenderHalfWidth, 0,                RenderWidth,     RenderHalfHeight},
-      {RenderHalfWidth, RenderHalfHeight, RenderWidth,     RenderHeight},
-      {0,               RenderHalfHeight, RenderHalfWidth, RenderHeight},
+      {0,                0,                 kRenderHalfWidth, kRenderHalfHeight},
+      {kRenderHalfWidth, 0,                 kRenderWidth,     kRenderHalfHeight},
+      {kRenderHalfWidth, kRenderHalfHeight, kRenderWidth,     kRenderHeight},
+      {0,                kRenderHalfHeight, kRenderHalfWidth, kRenderHeight},
       // clang-format on
   };
   const DlColor colors[] = {
@@ -2914,7 +2918,7 @@ TEST_F(DisplayListCanvas, DrawAtlasNearestNoPaint) {
       SK_ColorYELLOW,
       SK_ColorMAGENTA,
   };
-  const sk_sp<SkImage> image = CanvasCompareTester::testImage;
+  const sk_sp<SkImage> image = CanvasCompareTester::kTestImage;
   const SkSamplingOptions sampling = DisplayList::NearestSampling;
   CanvasCompareTester::RenderAll(  //
       TestParameters(
@@ -2937,18 +2941,18 @@ TEST_F(DisplayListCanvas, DrawAtlasNearestNoPaint) {
 TEST_F(DisplayListCanvas, DrawAtlasLinear) {
   const SkRSXform xform[] = {
       // clang-format off
-      { 1.2f,  0.0f, RenderLeft,  RenderTop},
-      { 0.0f,  1.2f, RenderRight, RenderTop},
-      {-1.2f,  0.0f, RenderRight, RenderBottom},
-      { 0.0f, -1.2f, RenderLeft,  RenderBottom},
+      { 1.2f,  0.0f, kRenderLeft,  kRenderTop},
+      { 0.0f,  1.2f, kRenderRight, kRenderTop},
+      {-1.2f,  0.0f, kRenderRight, kRenderBottom},
+      { 0.0f, -1.2f, kRenderLeft,  kRenderBottom},
       // clang-format on
   };
   const SkRect tex[] = {
       // clang-format off
-      {0,               0,                RenderHalfWidth, RenderHalfHeight},
-      {RenderHalfWidth, 0,                RenderWidth,     RenderHalfHeight},
-      {RenderHalfWidth, RenderHalfHeight, RenderWidth,     RenderHeight},
-      {0,               RenderHalfHeight, RenderHalfWidth, RenderHeight},
+      {0,                0,                 kRenderHalfWidth, kRenderHalfHeight},
+      {kRenderHalfWidth, 0,                 kRenderWidth,     kRenderHalfHeight},
+      {kRenderHalfWidth, kRenderHalfHeight, kRenderWidth,     kRenderHeight},
+      {0,                kRenderHalfHeight, kRenderHalfWidth, kRenderHeight},
       // clang-format on
   };
   const DlColor colors[] = {
@@ -2957,7 +2961,7 @@ TEST_F(DisplayListCanvas, DrawAtlasLinear) {
       SK_ColorYELLOW,
       SK_ColorMAGENTA,
   };
-  const sk_sp<SkImage> image = CanvasCompareTester::testImage;
+  const sk_sp<SkImage> image = CanvasCompareTester::kTestImage;
   const SkSamplingOptions sampling = DisplayList::LinearSampling;
   CanvasCompareTester::RenderAll(  //
       TestParameters(
@@ -2977,17 +2981,18 @@ TEST_F(DisplayListCanvas, DrawAtlasLinear) {
 
 sk_sp<SkPicture> makeTestPicture() {
   SkPictureRecorder recorder;
-  SkCanvas* cv = recorder.beginRecording(RenderBounds);
+  SkCanvas* cv = recorder.beginRecording(kRenderBounds);
   SkPaint p;
   p.setStyle(SkPaint::kFill_Style);
   p.setColor(SK_ColorRED);
-  cv->drawRect({RenderLeft, RenderTop, RenderCenterX, RenderCenterY}, p);
+  cv->drawRect({kRenderLeft, kRenderTop, kRenderCenterX, kRenderCenterY}, p);
   p.setColor(SK_ColorBLUE);
-  cv->drawRect({RenderCenterX, RenderTop, RenderRight, RenderCenterY}, p);
+  cv->drawRect({kRenderCenterX, kRenderTop, kRenderRight, kRenderCenterY}, p);
   p.setColor(SK_ColorGREEN);
-  cv->drawRect({RenderLeft, RenderCenterY, RenderCenterX, RenderBottom}, p);
+  cv->drawRect({kRenderLeft, kRenderCenterY, kRenderCenterX, kRenderBottom}, p);
   p.setColor(SK_ColorYELLOW);
-  cv->drawRect({RenderCenterX, RenderCenterY, RenderRight, RenderBottom}, p);
+  cv->drawRect({kRenderCenterX, kRenderCenterY, kRenderRight, kRenderBottom},
+               p);
   return recorder.finishRecordingAsPicture();
 }
 
@@ -3035,13 +3040,15 @@ sk_sp<DisplayList> makeTestDisplayList() {
   DisplayListBuilder builder;
   builder.setStyle(DlDrawStyle::kFill);
   builder.setColor(SK_ColorRED);
-  builder.drawRect({RenderLeft, RenderTop, RenderCenterX, RenderCenterY});
+  builder.drawRect({kRenderLeft, kRenderTop, kRenderCenterX, kRenderCenterY});
   builder.setColor(SK_ColorBLUE);
-  builder.drawRect({RenderCenterX, RenderTop, RenderRight, RenderCenterY});
+  builder.drawRect({kRenderCenterX, kRenderTop, kRenderRight, kRenderCenterY});
   builder.setColor(SK_ColorGREEN);
-  builder.drawRect({RenderLeft, RenderCenterY, RenderCenterX, RenderBottom});
+  builder.drawRect(
+      {kRenderLeft, kRenderCenterY, kRenderCenterX, kRenderBottom});
   builder.setColor(SK_ColorYELLOW);
-  builder.drawRect({RenderCenterX, RenderCenterY, RenderRight, RenderBottom});
+  builder.drawRect(
+      {kRenderCenterX, kRenderCenterY, kRenderRight, kRenderBottom});
   return builder.Build();
 }
 
@@ -3067,20 +3074,20 @@ TEST_F(DisplayListCanvas, DrawTextBlob) {
   GTEST_SKIP() << "Rendering comparisons require a valid default font manager";
 #endif  // OS_FUCHSIA
   sk_sp<SkTextBlob> blob =
-      CanvasCompareTester::MakeTextBlob("Testing", RenderHeight * 0.33f);
-  SkScalar RenderY1_3 = RenderTop + RenderHeight * 0.3;
-  SkScalar RenderY2_3 = RenderTop + RenderHeight * 0.6;
+      CanvasCompareTester::MakeTextBlob("Testing", kRenderHeight * 0.33f);
+  SkScalar RenderY1_3 = kRenderTop + kRenderHeight * 0.3;
+  SkScalar RenderY2_3 = kRenderTop + kRenderHeight * 0.6;
   CanvasCompareTester::RenderAll(  //
       TestParameters(
           [=](SkCanvas* canvas, const SkPaint& paint) {  //
-            canvas->drawTextBlob(blob, RenderLeft, RenderY1_3, paint);
-            canvas->drawTextBlob(blob, RenderLeft, RenderY2_3, paint);
-            canvas->drawTextBlob(blob, RenderLeft, RenderBottom, paint);
+            canvas->drawTextBlob(blob, kRenderLeft, RenderY1_3, paint);
+            canvas->drawTextBlob(blob, kRenderLeft, RenderY2_3, paint);
+            canvas->drawTextBlob(blob, kRenderLeft, kRenderBottom, paint);
           },
           [=](DisplayListBuilder& builder) {  //
-            builder.drawTextBlob(blob, RenderLeft, RenderY1_3);
-            builder.drawTextBlob(blob, RenderLeft, RenderY2_3);
-            builder.drawTextBlob(blob, RenderLeft, RenderBottom);
+            builder.drawTextBlob(blob, kRenderLeft, RenderY1_3);
+            builder.drawTextBlob(blob, kRenderLeft, RenderY2_3);
+            builder.drawTextBlob(blob, kRenderLeft, kRenderBottom);
           },
           kDrawTextBlobFlags)
           .set_draw_text_blob(),
@@ -3096,12 +3103,12 @@ TEST_F(DisplayListCanvas, DrawShadow) {
   SkPath path;
   path.addRoundRect(
       {
-          RenderLeft + 10,
-          RenderTop,
-          RenderRight - 10,
-          RenderBottom - 20,
+          kRenderLeft + 10,
+          kRenderTop,
+          kRenderRight - 10,
+          kRenderBottom - 20,
       },
-      RenderCornerRadius, RenderCornerRadius);
+      kRenderCornerRadius, kRenderCornerRadius);
   const DlColor color = DlColor::kDarkGrey();
   const SkScalar elevation = 5;
 
@@ -3123,12 +3130,12 @@ TEST_F(DisplayListCanvas, DrawShadowTransparentOccluder) {
   SkPath path;
   path.addRoundRect(
       {
-          RenderLeft + 10,
-          RenderTop,
-          RenderRight - 10,
-          RenderBottom - 20,
+          kRenderLeft + 10,
+          kRenderTop,
+          kRenderRight - 10,
+          kRenderBottom - 20,
       },
-      RenderCornerRadius, RenderCornerRadius);
+      kRenderCornerRadius, kRenderCornerRadius);
   const DlColor color = DlColor::kDarkGrey();
   const SkScalar elevation = 5;
 
@@ -3150,12 +3157,12 @@ TEST_F(DisplayListCanvas, DrawShadowDpr) {
   SkPath path;
   path.addRoundRect(
       {
-          RenderLeft + 10,
-          RenderTop,
-          RenderRight - 10,
-          RenderBottom - 20,
+          kRenderLeft + 10,
+          kRenderTop,
+          kRenderRight - 10,
+          kRenderBottom - 20,
       },
-      RenderCornerRadius, RenderCornerRadius);
+      kRenderCornerRadius, kRenderCornerRadius);
   const DlColor color = DlColor::kDarkGrey();
   const SkScalar elevation = 5;
 

--- a/display_list/display_list_canvas_unittests.cc
+++ b/display_list/display_list_canvas_unittests.cc
@@ -65,13 +65,13 @@ constexpr SkScalar kMiter4DiamondOffsetY = kRenderWidth * 0.14;
 // 0.0, 4.0 and 10.0
 // Center is biased by 0.5 to include more pixel centers in the
 // thin miters
-constexpr SkScalar kX_off_0 = kRenderCenterX + 0.5;
-constexpr SkScalar kX_off_l1 = kX_off_0 - kMiter4DiamondOffsetX;
-constexpr SkScalar kX_off_l2 = kX_off_l1 - kMiter10DiamondOffsetX;
-constexpr SkScalar kX_off_l3 = kX_off_l2 - kMiter10DiamondOffsetX;
-constexpr SkScalar kX_off_r1 = kX_off_0 + kMiter4DiamondOffsetX;
-constexpr SkScalar kX_off_r2 = kX_off_r1 + kMiterExtremeDiamondOffsetX;
-constexpr SkScalar kX_off_r3 = kX_off_r2 + kMiterExtremeDiamondOffsetX;
+constexpr SkScalar kXOffset0 = kRenderCenterX + 0.5;
+constexpr SkScalar kXOffsetL1 = kXOffset0 - kMiter4DiamondOffsetX;
+constexpr SkScalar kXOffsetL2 = kXOffsetL1 - kMiter10DiamondOffsetX;
+constexpr SkScalar kXOffsetL3 = kXOffsetL2 - kMiter10DiamondOffsetX;
+constexpr SkScalar kXOffsetR1 = kXOffset0 + kMiter4DiamondOffsetX;
+constexpr SkScalar kXOffsetR2 = kXOffsetR1 + kMiterExtremeDiamondOffsetX;
+constexpr SkScalar kXOffsetR3 = kXOffsetR2 + kMiterExtremeDiamondOffsetX;
 constexpr SkPoint kVerticalMiterDiamondPoints[] = {
     // Vertical diamonds:
     //  M10   M4  Mextreme
@@ -81,50 +81,50 @@ constexpr SkPoint kVerticalMiterDiamondPoints[] = {
     //  \  / \ | / \  /              to
     //   \/   \|/   \/      bottom of RenderBounds
     // clang-format off
-    SkPoint::Make(kX_off_l3, kRenderCenterY),
-    SkPoint::Make(kX_off_l2, kRenderTop),
-    SkPoint::Make(kX_off_l1, kRenderCenterY),
-    SkPoint::Make(kX_off_0,  kRenderTop),
-    SkPoint::Make(kX_off_r1, kRenderCenterY),
-    SkPoint::Make(kX_off_r2, kRenderTop),
-    SkPoint::Make(kX_off_r3, kRenderCenterY),
-    SkPoint::Make(kX_off_r2, kRenderBottom),
-    SkPoint::Make(kX_off_r1, kRenderCenterY),
-    SkPoint::Make(kX_off_0,  kRenderBottom),
-    SkPoint::Make(kX_off_l1, kRenderCenterY),
-    SkPoint::Make(kX_off_l2, kRenderBottom),
-    SkPoint::Make(kX_off_l3, kRenderCenterY),
+    SkPoint::Make(kXOffsetL3, kRenderCenterY),
+    SkPoint::Make(kXOffsetL2, kRenderTop),
+    SkPoint::Make(kXOffsetL1, kRenderCenterY),
+    SkPoint::Make(kXOffset0,  kRenderTop),
+    SkPoint::Make(kXOffsetR1, kRenderCenterY),
+    SkPoint::Make(kXOffsetR2, kRenderTop),
+    SkPoint::Make(kXOffsetR3, kRenderCenterY),
+    SkPoint::Make(kXOffsetR2, kRenderBottom),
+    SkPoint::Make(kXOffsetR1, kRenderCenterY),
+    SkPoint::Make(kXOffset0,  kRenderBottom),
+    SkPoint::Make(kXOffsetL1, kRenderCenterY),
+    SkPoint::Make(kXOffsetL2, kRenderBottom),
+    SkPoint::Make(kXOffsetL3, kRenderCenterY),
     // clang-format on
 };
 const int kVerticalMiterDiamondPointCount =
     sizeof(kVerticalMiterDiamondPoints) /
     sizeof(kVerticalMiterDiamondPoints[0]);
 
-constexpr SkScalar kY_off_0 = kRenderCenterY + 0.5;
-constexpr SkScalar kY_off_u1 = kX_off_0 - kMiter4DiamondOffsetY;
-constexpr SkScalar kY_off_u2 = kY_off_u1 - kMiter10DiamondOffsetY;
-constexpr SkScalar kY_off_u3 = kY_off_u2 - kMiter10DiamondOffsetY;
-constexpr SkScalar kY_off_d1 = kX_off_0 + kMiter4DiamondOffsetY;
-constexpr SkScalar kY_off_d2 = kY_off_d1 + kMiterExtremeDiamondOffsetY;
-constexpr SkScalar kY_off_d3 = kY_off_d2 + kMiterExtremeDiamondOffsetY;
+constexpr SkScalar kYOffset0 = kRenderCenterY + 0.5;
+constexpr SkScalar kYOffsetU1 = kXOffset0 - kMiter4DiamondOffsetY;
+constexpr SkScalar kYOffsetU2 = kYOffsetU1 - kMiter10DiamondOffsetY;
+constexpr SkScalar kYOffsetU3 = kYOffsetU2 - kMiter10DiamondOffsetY;
+constexpr SkScalar kYOffsetD1 = kXOffset0 + kMiter4DiamondOffsetY;
+constexpr SkScalar kYOffsetD2 = kYOffsetD1 + kMiterExtremeDiamondOffsetY;
+constexpr SkScalar kYOffsetD3 = kYOffsetD2 + kMiterExtremeDiamondOffsetY;
 const SkPoint kHorizontalMiterDiamondPoints[] = {
     // Horizontal diamonds
     // Same configuration as Vertical diamonds above but
     // rotated 90 degrees
     // clang-format off
-    SkPoint::Make(kRenderCenterX, kY_off_u3),
-    SkPoint::Make(kRenderLeft,    kY_off_u2),
-    SkPoint::Make(kRenderCenterX, kY_off_u1),
-    SkPoint::Make(kRenderLeft,    kY_off_0),
-    SkPoint::Make(kRenderCenterX, kY_off_d1),
-    SkPoint::Make(kRenderLeft,    kY_off_d2),
-    SkPoint::Make(kRenderCenterX, kY_off_d3),
-    SkPoint::Make(kRenderRight,   kY_off_d2),
-    SkPoint::Make(kRenderCenterX, kY_off_d1),
-    SkPoint::Make(kRenderRight,   kY_off_0),
-    SkPoint::Make(kRenderCenterX, kY_off_u1),
-    SkPoint::Make(kRenderRight,   kY_off_u2),
-    SkPoint::Make(kRenderCenterX, kY_off_u3),
+    SkPoint::Make(kRenderCenterX, kYOffsetU3),
+    SkPoint::Make(kRenderLeft,    kYOffsetU2),
+    SkPoint::Make(kRenderCenterX, kYOffsetU1),
+    SkPoint::Make(kRenderLeft,    kYOffset0),
+    SkPoint::Make(kRenderCenterX, kYOffsetD1),
+    SkPoint::Make(kRenderLeft,    kYOffsetD2),
+    SkPoint::Make(kRenderCenterX, kYOffsetD3),
+    SkPoint::Make(kRenderRight,   kYOffsetD2),
+    SkPoint::Make(kRenderCenterX, kYOffsetD1),
+    SkPoint::Make(kRenderRight,   kYOffset0),
+    SkPoint::Make(kRenderCenterX, kYOffsetU1),
+    SkPoint::Make(kRenderRight,   kYOffsetU2),
+    SkPoint::Make(kRenderCenterX, kYOffsetU3),
     // clang-format on
 };
 const int kHorizontalMiterDiamondPointCount =

--- a/display_list/display_list_color_filter_unittests.cc
+++ b/display_list/display_list_color_filter_unittests.cc
@@ -10,7 +10,7 @@
 namespace flutter {
 namespace testing {
 
-static const float matrix[20] = {
+static const float kMatrix[20] = {
     1,  2,  3,  4,  5,   //
     6,  7,  8,  9,  10,  //
     11, 12, 13, 14, 15,  //
@@ -49,14 +49,14 @@ TEST(DisplayListColorFilter, FromSkiaBlendFilter) {
 }
 
 TEST(DisplayListColorFilter, FromSkiaMatrixFilter) {
-  sk_sp<SkColorFilter> sk_filter = SkColorFilters::Matrix(matrix);
+  sk_sp<SkColorFilter> sk_filter = SkColorFilters::Matrix(kMatrix);
   std::shared_ptr<DlColorFilter> filter = DlColorFilter::From(sk_filter);
-  DlMatrixColorFilter dl_filter(matrix);
+  DlMatrixColorFilter dl_filter(kMatrix);
   ASSERT_EQ(filter->type(), DlColorFilterType::kMatrix);
   ASSERT_EQ(*filter->asMatrix(), dl_filter);
   const DlMatrixColorFilter* matrix_filter = filter->asMatrix();
   for (int i = 0; i < 20; i++) {
-    ASSERT_EQ((*matrix_filter)[i], matrix[i]);
+    ASSERT_EQ((*matrix_filter)[i], kMatrix[i]);
   }
 
   ASSERT_EQ(filter->asBlend(), nullptr);
@@ -137,24 +137,24 @@ TEST(DisplayListColorFilter, NopBlendShouldNotCrash) {
 }
 
 TEST(DisplayListColorFilter, MatrixConstructor) {
-  DlMatrixColorFilter filter(matrix);
+  DlMatrixColorFilter filter(kMatrix);
 }
 
 TEST(DisplayListColorFilter, MatrixShared) {
-  DlMatrixColorFilter filter(matrix);
+  DlMatrixColorFilter filter(kMatrix);
   ASSERT_NE(filter.shared().get(), &filter);
   ASSERT_EQ(*filter.shared(), filter);
 }
 
 TEST(DisplayListColorFilter, MatrixAsMatrix) {
-  DlMatrixColorFilter filter(matrix);
+  DlMatrixColorFilter filter(kMatrix);
   ASSERT_NE(filter.asMatrix(), nullptr);
   ASSERT_EQ(filter.asMatrix(), &filter);
 }
 
 TEST(DisplayListColorFilter, MatrixContents) {
   float matrix_[20];
-  memcpy(matrix_, matrix, sizeof(matrix_));
+  memcpy(matrix_, kMatrix, sizeof(matrix_));
   DlMatrixColorFilter filter(matrix_);
 
   // Test deref operator []
@@ -176,14 +176,14 @@ TEST(DisplayListColorFilter, MatrixContents) {
 }
 
 TEST(DisplayListColorFilter, MatrixEquals) {
-  DlMatrixColorFilter filter1(matrix);
-  DlMatrixColorFilter filter2(matrix);
+  DlMatrixColorFilter filter1(kMatrix);
+  DlMatrixColorFilter filter2(kMatrix);
   TestEquals(filter1, filter2);
 }
 
 TEST(DisplayListColorFilter, MatrixNotEquals) {
   float matrix_[20];
-  memcpy(matrix_, matrix, sizeof(matrix_));
+  memcpy(matrix_, kMatrix, sizeof(matrix_));
   DlMatrixColorFilter filter1(matrix_);
   matrix_[4] += 101;
   DlMatrixColorFilter filter2(matrix_);

--- a/display_list/display_list_color_source_unittests.cc
+++ b/display_list/display_list_color_source_unittests.cc
@@ -25,58 +25,58 @@ static sk_sp<SkImage> MakeTestImage(int w, int h, SkColor color) {
   return surface->makeImageSnapshot();
 }
 
-static const sk_sp<SkImage> TestImage1 = MakeTestImage(10, 10, SK_ColorGREEN);
-static const sk_sp<SkImage> TestAlphaImage1 =
+static const sk_sp<SkImage> kTestImage1 = MakeTestImage(10, 10, SK_ColorGREEN);
+static const sk_sp<SkImage> kTestAlphaImage1 =
     MakeTestImage(10, 10, SK_ColorTRANSPARENT);
 // clang-format off
-static const SkMatrix TestMatrix1 =
+static const SkMatrix kTestMatrix1 =
     SkMatrix::MakeAll(2, 0, 10,
                       0, 3, 12,
                       0, 0, 1);
-static const SkMatrix TestMatrix2 =
+static const SkMatrix kTestMatrix2 =
     SkMatrix::MakeAll(4, 0, 15,
                       0, 7, 17,
                       0, 0, 1);
 // clang-format on
 static constexpr int kTestStopCount = 3;
-static constexpr DlColor TestColors[kTestStopCount] = {
+static constexpr DlColor kTestColors[kTestStopCount] = {
     DlColor::kRed(),
     DlColor::kGreen(),
     DlColor::kBlue(),
 };
-static const DlColor TestAlphaColors[kTestStopCount] = {
+static const DlColor kTestAlphaColors[kTestStopCount] = {
     DlColor::kBlue().withAlpha(0x7F),
     DlColor::kRed().withAlpha(0x2F),
     DlColor::kGreen().withAlpha(0xCF),
 };
-static constexpr float TestStops[kTestStopCount] = {
+static constexpr float kTestStops[kTestStopCount] = {
     0.0f,
     0.7f,
     1.0f,
 };
-static constexpr float TestStops2[kTestStopCount] = {
+static constexpr float kTestStops2[kTestStopCount] = {
     0.0f,
     0.3f,
     1.0f,
 };
-static constexpr SkPoint TestPoints[2] = {
+static constexpr SkPoint kTestPoints[2] = {
     SkPoint::Make(5, 15),
     SkPoint::Make(7, 18),
 };
-static constexpr SkPoint TestPoints2[2] = {
+static constexpr SkPoint kTestPoints2[2] = {
     SkPoint::Make(100, 115),
     SkPoint::Make(107, 118),
 };
-static const sk_sp<SkShader> shaderA = SkShaders::Color(SK_ColorRED);
-static const sk_sp<SkShader> shaderB = SkShaders::Color(SK_ColorBLUE);
-static const sk_sp<SkShader> TestUnknownShader =
-    SkShaders::Blend(SkBlendMode::kOverlay, shaderA, shaderB);
-static const sk_sp<SkShader> TestAlphaUnknownShader =
-    SkShaders::Blend(SkBlendMode::kDstOut, shaderA, shaderB);
+static const sk_sp<SkShader> kShaderA = SkShaders::Color(SK_ColorRED);
+static const sk_sp<SkShader> kShaderB = SkShaders::Color(SK_ColorBLUE);
+static const sk_sp<SkShader> kTestUnknownShader =
+    SkShaders::Blend(SkBlendMode::kOverlay, kShaderA, kShaderB);
+static const sk_sp<SkShader> kTestAlphaUnknownShader =
+    SkShaders::Blend(SkBlendMode::kDstOut, kShaderA, kShaderB);
 
 TEST(DisplayListColorSource, BuilderSetGet) {
-  DlImageColorSource source(TestImage1, DlTileMode::kClamp, DlTileMode::kClamp,
-                            DisplayList::LinearSampling, &TestMatrix1);
+  DlImageColorSource source(kTestImage1, DlTileMode::kClamp, DlTileMode::kClamp,
+                            DisplayList::LinearSampling, &kTestMatrix1);
   DisplayListBuilder builder;
   ASSERT_EQ(builder.getColorSource(), nullptr);
   builder.setColorSource(&source);
@@ -117,15 +117,15 @@ TEST(DisplayListColorSource, FromSkiaColorShader) {
 
 TEST(DisplayListColorSource, FromSkiaImageShader) {
   sk_sp<SkShader> shader =
-      TestImage1->makeShader(DisplayList::LinearSampling, &TestMatrix1);
+      kTestImage1->makeShader(DisplayList::LinearSampling, &kTestMatrix1);
   std::shared_ptr<DlColorSource> source = DlColorSource::From(shader);
-  DlImageColorSource dl_source(TestImage1, DlTileMode::kClamp,
+  DlImageColorSource dl_source(kTestImage1, DlTileMode::kClamp,
                                DlTileMode::kClamp, DisplayList::LinearSampling,
-                               &TestMatrix1);
+                               &kTestMatrix1);
   ASSERT_EQ(source->type(), DlColorSourceType::kImage);
   ASSERT_EQ(*source->asImage(), dl_source);
-  ASSERT_EQ(source->asImage()->image(), TestImage1);
-  ASSERT_EQ(source->asImage()->matrix(), TestMatrix1);
+  ASSERT_EQ(source->asImage()->image(), kTestImage1);
+  ASSERT_EQ(source->asImage()->matrix(), kTestMatrix1);
   ASSERT_EQ(source->asImage()->horizontal_tile_mode(), DlTileMode::kClamp);
   ASSERT_EQ(source->asImage()->vertical_tile_mode(), DlTileMode::kClamp);
   ASSERT_EQ(source->asImage()->sampling(), DisplayList::LinearSampling);
@@ -141,9 +141,9 @@ TEST(DisplayListColorSource, FromSkiaLinearGradient) {
   // We cannot read back the matrix parameter from a Skia LinearGradient
   // so we conservatively use an UnknownColorSource wrapper so as to not
   // lose any data.
-  const SkColor* sk_colors = reinterpret_cast<const SkColor*>(TestColors);
+  const SkColor* sk_colors = reinterpret_cast<const SkColor*>(kTestColors);
   sk_sp<SkShader> shader = SkGradientShader::MakeLinear(
-      TestPoints, sk_colors, TestStops, kTestStopCount, SkTileMode::kClamp);
+      kTestPoints, sk_colors, kTestStops, kTestStopCount, SkTileMode::kClamp);
   std::shared_ptr<DlColorSource> source = DlColorSource::From(shader);
   ASSERT_EQ(source->type(), DlColorSourceType::kUnknown);
   ASSERT_EQ(source->skia_object(), shader);
@@ -160,9 +160,9 @@ TEST(DisplayListColorSource, FromSkiaRadialGradient) {
   // We cannot read back the matrix parameter from a Skia RadialGradient
   // so we conservatively use an UnknownColorSource wrapper so as to not
   // lose any data.
-  const SkColor* sk_colors = reinterpret_cast<const SkColor*>(TestColors);
+  const SkColor* sk_colors = reinterpret_cast<const SkColor*>(kTestColors);
   sk_sp<SkShader> shader =
-      SkGradientShader::MakeRadial(TestPoints[0], 10.0, sk_colors, TestStops,
+      SkGradientShader::MakeRadial(kTestPoints[0], 10.0, sk_colors, kTestStops,
                                    kTestStopCount, SkTileMode::kClamp);
   std::shared_ptr<DlColorSource> source = DlColorSource::From(shader);
   ASSERT_EQ(source->type(), DlColorSourceType::kUnknown);
@@ -180,9 +180,9 @@ TEST(DisplayListColorSource, FromSkiaConicalGradient) {
   // We cannot read back the matrix parameter from a Skia ConicalGradient
   // so we conservatively use an UnknownColorSource wrapper so as to not
   // lose any data.
-  const SkColor* sk_colors = reinterpret_cast<const SkColor*>(TestColors);
+  const SkColor* sk_colors = reinterpret_cast<const SkColor*>(kTestColors);
   sk_sp<SkShader> shader = SkGradientShader::MakeTwoPointConical(
-      TestPoints[0], 10.0, TestPoints[1], 20.0, sk_colors, TestStops,
+      kTestPoints[0], 10.0, kTestPoints[1], 20.0, sk_colors, kTestStops,
       kTestStopCount, SkTileMode::kClamp);
   std::shared_ptr<DlColorSource> source = DlColorSource::From(shader);
   ASSERT_EQ(source->type(), DlColorSourceType::kUnknown);
@@ -200,9 +200,10 @@ TEST(DisplayListColorSource, FromSkiaSweepGradient) {
   // We cannot read back the matrix parameter, nor the sweep parameters from a
   // Skia SweepGradient so we conservatively use an UnknownColorSource wrapper
   // so as to not lose any data.
-  const SkColor* sk_colors = reinterpret_cast<const SkColor*>(TestColors);
-  sk_sp<SkShader> shader = SkGradientShader::MakeSweep(
-      TestPoints[0].fX, TestPoints[0].fY, sk_colors, TestStops, kTestStopCount);
+  const SkColor* sk_colors = reinterpret_cast<const SkColor*>(kTestColors);
+  sk_sp<SkShader> shader =
+      SkGradientShader::MakeSweep(kTestPoints[0].fX, kTestPoints[0].fY,
+                                  sk_colors, kTestStops, kTestStopCount);
   std::shared_ptr<DlColorSource> source = DlColorSource::From(shader);
   ASSERT_EQ(source->type(), DlColorSourceType::kUnknown);
   ASSERT_EQ(source->skia_object(), shader);
@@ -217,9 +218,9 @@ TEST(DisplayListColorSource, FromSkiaSweepGradient) {
 
 TEST(DisplayListColorSource, FromSkiaUnrecognizedShader) {
   std::shared_ptr<DlColorSource> source =
-      DlColorSource::From(TestUnknownShader);
+      DlColorSource::From(kTestUnknownShader);
   ASSERT_EQ(source->type(), DlColorSourceType::kUnknown);
-  ASSERT_EQ(source->skia_object(), TestUnknownShader);
+  ASSERT_EQ(source->skia_object(), kTestUnknownShader);
 
   ASSERT_EQ(source->asColor(), nullptr);
   ASSERT_EQ(source->asImage(), nullptr);
@@ -276,20 +277,20 @@ TEST(DisplayListColorSource, ColorNotEquals) {
 }
 
 TEST(DisplayListColorSource, ImageConstructor) {
-  DlImageColorSource source(TestImage1, DlTileMode::kClamp, DlTileMode::kClamp,
-                            DisplayList::LinearSampling, &TestMatrix1);
+  DlImageColorSource source(kTestImage1, DlTileMode::kClamp, DlTileMode::kClamp,
+                            DisplayList::LinearSampling, &kTestMatrix1);
 }
 
 TEST(DisplayListColorSource, ImageShared) {
-  DlImageColorSource source(TestImage1, DlTileMode::kClamp, DlTileMode::kClamp,
-                            DisplayList::LinearSampling, &TestMatrix1);
+  DlImageColorSource source(kTestImage1, DlTileMode::kClamp, DlTileMode::kClamp,
+                            DisplayList::LinearSampling, &kTestMatrix1);
   ASSERT_NE(source.shared().get(), &source);
   ASSERT_EQ(*source.shared(), source);
 }
 
 TEST(DisplayListColorSource, ImageAsImage) {
-  DlImageColorSource source(TestImage1, DlTileMode::kClamp, DlTileMode::kClamp,
-                            DisplayList::LinearSampling, &TestMatrix1);
+  DlImageColorSource source(kTestImage1, DlTileMode::kClamp, DlTileMode::kClamp,
+                            DisplayList::LinearSampling, &kTestMatrix1);
   ASSERT_NE(source.asImage(), nullptr);
   ASSERT_EQ(source.asImage(), &source);
 
@@ -301,93 +302,93 @@ TEST(DisplayListColorSource, ImageAsImage) {
 }
 
 TEST(DisplayListColorSource, ImageContents) {
-  DlImageColorSource source(TestImage1, DlTileMode::kRepeat,
+  DlImageColorSource source(kTestImage1, DlTileMode::kRepeat,
                             DlTileMode::kMirror, DisplayList::LinearSampling,
-                            &TestMatrix1);
-  ASSERT_EQ(source.image(), TestImage1);
+                            &kTestMatrix1);
+  ASSERT_EQ(source.image(), kTestImage1);
   ASSERT_EQ(source.horizontal_tile_mode(), DlTileMode::kRepeat);
   ASSERT_EQ(source.vertical_tile_mode(), DlTileMode::kMirror);
   ASSERT_EQ(source.sampling(), DisplayList::LinearSampling);
-  ASSERT_EQ(source.matrix(), TestMatrix1);
+  ASSERT_EQ(source.matrix(), kTestMatrix1);
   ASSERT_EQ(source.is_opaque(), true);
 }
 
 TEST(DisplayListColorSource, AlphaImageContents) {
-  DlImageColorSource source(TestAlphaImage1, DlTileMode::kRepeat,
+  DlImageColorSource source(kTestAlphaImage1, DlTileMode::kRepeat,
                             DlTileMode::kMirror, DisplayList::LinearSampling,
-                            &TestMatrix1);
-  ASSERT_EQ(source.image(), TestAlphaImage1);
+                            &kTestMatrix1);
+  ASSERT_EQ(source.image(), kTestAlphaImage1);
   ASSERT_EQ(source.horizontal_tile_mode(), DlTileMode::kRepeat);
   ASSERT_EQ(source.vertical_tile_mode(), DlTileMode::kMirror);
   ASSERT_EQ(source.sampling(), DisplayList::LinearSampling);
-  ASSERT_EQ(source.matrix(), TestMatrix1);
+  ASSERT_EQ(source.matrix(), kTestMatrix1);
   ASSERT_EQ(source.is_opaque(), false);
 }
 
 TEST(DisplayListColorSource, ImageEquals) {
-  DlImageColorSource source1(TestImage1, DlTileMode::kClamp,
+  DlImageColorSource source1(kTestImage1, DlTileMode::kClamp,
                              DlTileMode::kMirror, DisplayList::LinearSampling,
-                             &TestMatrix1);
-  DlImageColorSource source2(TestImage1, DlTileMode::kClamp,
+                             &kTestMatrix1);
+  DlImageColorSource source2(kTestImage1, DlTileMode::kClamp,
                              DlTileMode::kMirror, DisplayList::LinearSampling,
-                             &TestMatrix1);
+                             &kTestMatrix1);
   TestEquals(source1, source2);
 }
 
 TEST(DisplayListColorSource, ImageNotEquals) {
-  DlImageColorSource source1(TestImage1, DlTileMode::kClamp,
+  DlImageColorSource source1(kTestImage1, DlTileMode::kClamp,
                              DlTileMode::kMirror, DisplayList::LinearSampling,
-                             &TestMatrix1);
+                             &kTestMatrix1);
   {
-    DlImageColorSource source2(TestAlphaImage1, DlTileMode::kClamp,
+    DlImageColorSource source2(kTestAlphaImage1, DlTileMode::kClamp,
                                DlTileMode::kMirror, DisplayList::LinearSampling,
-                               &TestMatrix1);
+                               &kTestMatrix1);
     TestNotEquals(source1, source2, "Image differs");
   }
   {
-    DlImageColorSource source2(TestImage1, DlTileMode::kRepeat,
+    DlImageColorSource source2(kTestImage1, DlTileMode::kRepeat,
                                DlTileMode::kMirror, DisplayList::LinearSampling,
-                               &TestMatrix1);
+                               &kTestMatrix1);
     TestNotEquals(source1, source2, "hTileMode differs");
   }
   {
-    DlImageColorSource source2(TestImage1, DlTileMode::kClamp,
+    DlImageColorSource source2(kTestImage1, DlTileMode::kClamp,
                                DlTileMode::kRepeat, DisplayList::LinearSampling,
-                               &TestMatrix1);
+                               &kTestMatrix1);
     TestNotEquals(source1, source2, "vTileMode differs");
   }
   {
-    DlImageColorSource source2(TestImage1, DlTileMode::kClamp,
+    DlImageColorSource source2(kTestImage1, DlTileMode::kClamp,
                                DlTileMode::kMirror, DisplayList::CubicSampling,
-                               &TestMatrix1);
+                               &kTestMatrix1);
     TestNotEquals(source1, source2, "Sampling differs");
   }
   {
-    DlImageColorSource source2(TestImage1, DlTileMode::kClamp,
+    DlImageColorSource source2(kTestImage1, DlTileMode::kClamp,
                                DlTileMode::kMirror, DisplayList::LinearSampling,
-                               &TestMatrix2);
+                               &kTestMatrix2);
     TestNotEquals(source1, source2, "Matrix differs");
   }
 }
 
 TEST(DisplayListColorSource, LinearGradientConstructor) {
   std::shared_ptr<DlColorSource> source = DlColorSource::MakeLinear(
-      TestPoints[0], TestPoints[1], kTestStopCount, TestColors, TestStops,
-      DlTileMode::kClamp, &TestMatrix1);
+      kTestPoints[0], kTestPoints[1], kTestStopCount, kTestColors, kTestStops,
+      DlTileMode::kClamp, &kTestMatrix1);
 }
 
 TEST(DisplayListColorSource, LinearGradientShared) {
   std::shared_ptr<DlColorSource> source = DlColorSource::MakeLinear(
-      TestPoints[0], TestPoints[1], kTestStopCount, TestColors, TestStops,
-      DlTileMode::kClamp, &TestMatrix1);
+      kTestPoints[0], kTestPoints[1], kTestStopCount, kTestColors, kTestStops,
+      DlTileMode::kClamp, &kTestMatrix1);
   ASSERT_NE(source->shared().get(), source.get());
   ASSERT_EQ(*source->shared().get(), *source.get());
 }
 
 TEST(DisplayListColorSource, LinearGradientAsLinear) {
   std::shared_ptr<DlColorSource> source = DlColorSource::MakeLinear(
-      TestPoints[0], TestPoints[1], kTestStopCount, TestColors, TestStops,
-      DlTileMode::kClamp, &TestMatrix1);
+      kTestPoints[0], kTestPoints[1], kTestStopCount, kTestColors, kTestStops,
+      DlTileMode::kClamp, &kTestMatrix1);
   ASSERT_NE(source->asLinearGradient(), nullptr);
   ASSERT_EQ(source->asLinearGradient(), source.get());
 
@@ -400,112 +401,112 @@ TEST(DisplayListColorSource, LinearGradientAsLinear) {
 
 TEST(DisplayListColorSource, LinearGradientContents) {
   std::shared_ptr<DlColorSource> source = DlColorSource::MakeLinear(
-      TestPoints[0], TestPoints[1], kTestStopCount, TestColors, TestStops,
-      DlTileMode::kClamp, &TestMatrix1);
-  ASSERT_EQ(source->asLinearGradient()->start_point(), TestPoints[0]);
-  ASSERT_EQ(source->asLinearGradient()->end_point(), TestPoints[1]);
+      kTestPoints[0], kTestPoints[1], kTestStopCount, kTestColors, kTestStops,
+      DlTileMode::kClamp, &kTestMatrix1);
+  ASSERT_EQ(source->asLinearGradient()->start_point(), kTestPoints[0]);
+  ASSERT_EQ(source->asLinearGradient()->end_point(), kTestPoints[1]);
   ASSERT_EQ(source->asLinearGradient()->stop_count(), kTestStopCount);
   for (int i = 0; i < kTestStopCount; i++) {
-    ASSERT_EQ(source->asLinearGradient()->colors()[i], TestColors[i]);
-    ASSERT_EQ(source->asLinearGradient()->stops()[i], TestStops[i]);
+    ASSERT_EQ(source->asLinearGradient()->colors()[i], kTestColors[i]);
+    ASSERT_EQ(source->asLinearGradient()->stops()[i], kTestStops[i]);
   }
   ASSERT_EQ(source->asLinearGradient()->tile_mode(), DlTileMode::kClamp);
-  ASSERT_EQ(source->asLinearGradient()->matrix(), TestMatrix1);
+  ASSERT_EQ(source->asLinearGradient()->matrix(), kTestMatrix1);
   ASSERT_EQ(source->is_opaque(), true);
 }
 
 TEST(DisplayListColorSource, AlphaLinearGradientContents) {
   std::shared_ptr<DlColorSource> source = DlColorSource::MakeLinear(
-      TestPoints[0], TestPoints[1], kTestStopCount, TestAlphaColors, TestStops,
-      DlTileMode::kClamp, &TestMatrix1);
-  ASSERT_EQ(source->asLinearGradient()->start_point(), TestPoints[0]);
-  ASSERT_EQ(source->asLinearGradient()->end_point(), TestPoints[1]);
+      kTestPoints[0], kTestPoints[1], kTestStopCount, kTestAlphaColors,
+      kTestStops, DlTileMode::kClamp, &kTestMatrix1);
+  ASSERT_EQ(source->asLinearGradient()->start_point(), kTestPoints[0]);
+  ASSERT_EQ(source->asLinearGradient()->end_point(), kTestPoints[1]);
   ASSERT_EQ(source->asLinearGradient()->stop_count(), kTestStopCount);
   for (int i = 0; i < kTestStopCount; i++) {
-    ASSERT_EQ(source->asLinearGradient()->colors()[i], TestAlphaColors[i]);
-    ASSERT_EQ(source->asLinearGradient()->stops()[i], TestStops[i]);
+    ASSERT_EQ(source->asLinearGradient()->colors()[i], kTestAlphaColors[i]);
+    ASSERT_EQ(source->asLinearGradient()->stops()[i], kTestStops[i]);
   }
   ASSERT_EQ(source->asLinearGradient()->tile_mode(), DlTileMode::kClamp);
-  ASSERT_EQ(source->asLinearGradient()->matrix(), TestMatrix1);
+  ASSERT_EQ(source->asLinearGradient()->matrix(), kTestMatrix1);
   ASSERT_EQ(source->is_opaque(), false);
 }
 
 TEST(DisplayListColorSource, LinearGradientEquals) {
   std::shared_ptr<DlColorSource> source1 = DlColorSource::MakeLinear(
-      TestPoints[0], TestPoints[1], kTestStopCount, TestColors, TestStops,
-      DlTileMode::kClamp, &TestMatrix1);
+      kTestPoints[0], kTestPoints[1], kTestStopCount, kTestColors, kTestStops,
+      DlTileMode::kClamp, &kTestMatrix1);
   std::shared_ptr<DlColorSource> source2 = DlColorSource::MakeLinear(
-      TestPoints[0], TestPoints[1], kTestStopCount, TestColors, TestStops,
-      DlTileMode::kClamp, &TestMatrix1);
+      kTestPoints[0], kTestPoints[1], kTestStopCount, kTestColors, kTestStops,
+      DlTileMode::kClamp, &kTestMatrix1);
   TestEquals(*source1, *source2);
 }
 
 TEST(DisplayListColorSource, LinearGradientNotEquals) {
   std::shared_ptr<DlColorSource> source1 = DlColorSource::MakeLinear(
-      TestPoints[0], TestPoints[1], kTestStopCount, TestColors, TestStops,
-      DlTileMode::kClamp, &TestMatrix1);
+      kTestPoints[0], kTestPoints[1], kTestStopCount, kTestColors, kTestStops,
+      DlTileMode::kClamp, &kTestMatrix1);
   {
     std::shared_ptr<DlColorSource> source2 = DlColorSource::MakeLinear(
-        TestPoints2[0], TestPoints[1], kTestStopCount, TestColors, TestStops,
-        DlTileMode::kClamp, &TestMatrix1);
+        kTestPoints2[0], kTestPoints[1], kTestStopCount, kTestColors,
+        kTestStops, DlTileMode::kClamp, &kTestMatrix1);
     TestNotEquals(*source1, *source2, "Point 0 differs");
   }
   {
     std::shared_ptr<DlColorSource> source2 = DlColorSource::MakeLinear(
-        TestPoints[0], TestPoints2[1], kTestStopCount, TestColors, TestStops,
-        DlTileMode::kClamp, &TestMatrix1);
+        kTestPoints[0], kTestPoints2[1], kTestStopCount, kTestColors,
+        kTestStops, DlTileMode::kClamp, &kTestMatrix1);
     TestNotEquals(*source1, *source2, "Point 1 differs");
   }
   {
     std::shared_ptr<DlColorSource> source2 = DlColorSource::MakeLinear(
-        TestPoints[0], TestPoints[1], 2, TestColors, TestStops,  //
-        DlTileMode::kClamp, &TestMatrix1);
+        kTestPoints[0], kTestPoints[1], 2, kTestColors, kTestStops,  //
+        DlTileMode::kClamp, &kTestMatrix1);
     TestNotEquals(*source1, *source2, "Stop count differs");
   }
   {
     std::shared_ptr<DlColorSource> source2 = DlColorSource::MakeLinear(
-        TestPoints[0], TestPoints[1], kTestStopCount, TestAlphaColors,
-        TestStops, DlTileMode::kClamp, &TestMatrix1);
+        kTestPoints[0], kTestPoints[1], kTestStopCount, kTestAlphaColors,
+        kTestStops, DlTileMode::kClamp, &kTestMatrix1);
     TestNotEquals(*source1, *source2, "Colors differ");
   }
   {
     std::shared_ptr<DlColorSource> source2 = DlColorSource::MakeLinear(
-        TestPoints[0], TestPoints[1], kTestStopCount, TestColors, TestStops2,
-        DlTileMode::kClamp, &TestMatrix1);
+        kTestPoints[0], kTestPoints[1], kTestStopCount, kTestColors,
+        kTestStops2, DlTileMode::kClamp, &kTestMatrix1);
     TestNotEquals(*source1, *source2, "Stops differ");
   }
   {
     std::shared_ptr<DlColorSource> source2 = DlColorSource::MakeLinear(
-        TestPoints[0], TestPoints[1], kTestStopCount, TestColors, TestStops,
-        DlTileMode::kMirror, &TestMatrix1);
+        kTestPoints[0], kTestPoints[1], kTestStopCount, kTestColors, kTestStops,
+        DlTileMode::kMirror, &kTestMatrix1);
     TestNotEquals(*source1, *source2, "Tile Mode differs");
   }
   {
     std::shared_ptr<DlColorSource> source2 = DlColorSource::MakeLinear(
-        TestPoints[0], TestPoints[1], kTestStopCount, TestColors, TestStops,
-        DlTileMode::kClamp, &TestMatrix2);
+        kTestPoints[0], kTestPoints[1], kTestStopCount, kTestColors, kTestStops,
+        DlTileMode::kClamp, &kTestMatrix2);
     TestNotEquals(*source1, *source2, "Matrix differs");
   }
 }
 
 TEST(DisplayListColorSource, RadialGradientConstructor) {
-  std::shared_ptr<DlColorSource> source =
-      DlColorSource::MakeRadial(TestPoints[0], 10.0, kTestStopCount, TestColors,
-                                TestStops, DlTileMode::kClamp, &TestMatrix1);
+  std::shared_ptr<DlColorSource> source = DlColorSource::MakeRadial(
+      kTestPoints[0], 10.0, kTestStopCount, kTestColors, kTestStops,
+      DlTileMode::kClamp, &kTestMatrix1);
 }
 
 TEST(DisplayListColorSource, RadialGradientShared) {
-  std::shared_ptr<DlColorSource> source =
-      DlColorSource::MakeRadial(TestPoints[0], 10.0, kTestStopCount, TestColors,
-                                TestStops, DlTileMode::kClamp, &TestMatrix1);
+  std::shared_ptr<DlColorSource> source = DlColorSource::MakeRadial(
+      kTestPoints[0], 10.0, kTestStopCount, kTestColors, kTestStops,
+      DlTileMode::kClamp, &kTestMatrix1);
   ASSERT_NE(source->shared().get(), source.get());
   ASSERT_EQ(*source->shared().get(), *source.get());
 }
 
 TEST(DisplayListColorSource, RadialGradientAsRadial) {
-  std::shared_ptr<DlColorSource> source =
-      DlColorSource::MakeRadial(TestPoints[0], 10.0, kTestStopCount, TestColors,
-                                TestStops, DlTileMode::kClamp, &TestMatrix1);
+  std::shared_ptr<DlColorSource> source = DlColorSource::MakeRadial(
+      kTestPoints[0], 10.0, kTestStopCount, kTestColors, kTestStops,
+      DlTileMode::kClamp, &kTestMatrix1);
   ASSERT_NE(source->asRadialGradient(), nullptr);
   ASSERT_EQ(source->asRadialGradient(), source.get());
 
@@ -517,113 +518,113 @@ TEST(DisplayListColorSource, RadialGradientAsRadial) {
 }
 
 TEST(DisplayListColorSource, RadialGradientContents) {
-  std::shared_ptr<DlColorSource> source =
-      DlColorSource::MakeRadial(TestPoints[0], 10.0, kTestStopCount, TestColors,
-                                TestStops, DlTileMode::kClamp, &TestMatrix1);
-  ASSERT_EQ(source->asRadialGradient()->center(), TestPoints[0]);
+  std::shared_ptr<DlColorSource> source = DlColorSource::MakeRadial(
+      kTestPoints[0], 10.0, kTestStopCount, kTestColors, kTestStops,
+      DlTileMode::kClamp, &kTestMatrix1);
+  ASSERT_EQ(source->asRadialGradient()->center(), kTestPoints[0]);
   ASSERT_EQ(source->asRadialGradient()->radius(), 10.0);
   ASSERT_EQ(source->asRadialGradient()->stop_count(), kTestStopCount);
   for (int i = 0; i < kTestStopCount; i++) {
-    ASSERT_EQ(source->asRadialGradient()->colors()[i], TestColors[i]);
-    ASSERT_EQ(source->asRadialGradient()->stops()[i], TestStops[i]);
+    ASSERT_EQ(source->asRadialGradient()->colors()[i], kTestColors[i]);
+    ASSERT_EQ(source->asRadialGradient()->stops()[i], kTestStops[i]);
   }
   ASSERT_EQ(source->asRadialGradient()->tile_mode(), DlTileMode::kClamp);
-  ASSERT_EQ(source->asRadialGradient()->matrix(), TestMatrix1);
+  ASSERT_EQ(source->asRadialGradient()->matrix(), kTestMatrix1);
   ASSERT_EQ(source->is_opaque(), true);
 }
 
 TEST(DisplayListColorSource, AlphaRadialGradientContents) {
   std::shared_ptr<DlColorSource> source = DlColorSource::MakeRadial(
-      TestPoints[0], 10.0, kTestStopCount, TestAlphaColors, TestStops,
-      DlTileMode::kClamp, &TestMatrix1);
-  ASSERT_EQ(source->asRadialGradient()->center(), TestPoints[0]);
+      kTestPoints[0], 10.0, kTestStopCount, kTestAlphaColors, kTestStops,
+      DlTileMode::kClamp, &kTestMatrix1);
+  ASSERT_EQ(source->asRadialGradient()->center(), kTestPoints[0]);
   ASSERT_EQ(source->asRadialGradient()->radius(), 10.0);
   ASSERT_EQ(source->asRadialGradient()->stop_count(), kTestStopCount);
   for (int i = 0; i < kTestStopCount; i++) {
-    ASSERT_EQ(source->asRadialGradient()->colors()[i], TestAlphaColors[i]);
-    ASSERT_EQ(source->asRadialGradient()->stops()[i], TestStops[i]);
+    ASSERT_EQ(source->asRadialGradient()->colors()[i], kTestAlphaColors[i]);
+    ASSERT_EQ(source->asRadialGradient()->stops()[i], kTestStops[i]);
   }
   ASSERT_EQ(source->asRadialGradient()->tile_mode(), DlTileMode::kClamp);
-  ASSERT_EQ(source->asRadialGradient()->matrix(), TestMatrix1);
+  ASSERT_EQ(source->asRadialGradient()->matrix(), kTestMatrix1);
   ASSERT_EQ(source->is_opaque(), false);
 }
 
 TEST(DisplayListColorSource, RadialGradientEquals) {
-  std::shared_ptr<DlColorSource> source1 =
-      DlColorSource::MakeRadial(TestPoints[0], 10.0, kTestStopCount, TestColors,
-                                TestStops, DlTileMode::kClamp, &TestMatrix1);
-  std::shared_ptr<DlColorSource> source2 =
-      DlColorSource::MakeRadial(TestPoints[0], 10.0, kTestStopCount, TestColors,
-                                TestStops, DlTileMode::kClamp, &TestMatrix1);
+  std::shared_ptr<DlColorSource> source1 = DlColorSource::MakeRadial(
+      kTestPoints[0], 10.0, kTestStopCount, kTestColors, kTestStops,
+      DlTileMode::kClamp, &kTestMatrix1);
+  std::shared_ptr<DlColorSource> source2 = DlColorSource::MakeRadial(
+      kTestPoints[0], 10.0, kTestStopCount, kTestColors, kTestStops,
+      DlTileMode::kClamp, &kTestMatrix1);
   TestEquals(*source1, *source2);
 }
 
 TEST(DisplayListColorSource, RadialGradientNotEquals) {
-  std::shared_ptr<DlColorSource> source1 =
-      DlColorSource::MakeRadial(TestPoints[0], 10.0, kTestStopCount, TestColors,
-                                TestStops, DlTileMode::kClamp, &TestMatrix1);
+  std::shared_ptr<DlColorSource> source1 = DlColorSource::MakeRadial(
+      kTestPoints[0], 10.0, kTestStopCount, kTestColors, kTestStops,
+      DlTileMode::kClamp, &kTestMatrix1);
   {
     std::shared_ptr<DlColorSource> source2 = DlColorSource::MakeRadial(
-        TestPoints2[0], 10.0, kTestStopCount, TestColors, TestStops,
-        DlTileMode::kClamp, &TestMatrix1);
+        kTestPoints2[0], 10.0, kTestStopCount, kTestColors, kTestStops,
+        DlTileMode::kClamp, &kTestMatrix1);
     TestNotEquals(*source1, *source2, "Center differs");
   }
   {
     std::shared_ptr<DlColorSource> source2 = DlColorSource::MakeRadial(
-        TestPoints[0], 20.0, kTestStopCount, TestColors, TestStops,
-        DlTileMode::kClamp, &TestMatrix1);
+        kTestPoints[0], 20.0, kTestStopCount, kTestColors, kTestStops,
+        DlTileMode::kClamp, &kTestMatrix1);
     TestNotEquals(*source1, *source2, "Radius differs");
   }
   {
     std::shared_ptr<DlColorSource> source2 = DlColorSource::MakeRadial(
-        TestPoints[0], 10.0, 2, TestColors, TestStops,  //
-        DlTileMode::kClamp, &TestMatrix1);
+        kTestPoints[0], 10.0, 2, kTestColors, kTestStops,  //
+        DlTileMode::kClamp, &kTestMatrix1);
     TestNotEquals(*source1, *source2, "Stop count differs");
   }
   {
     std::shared_ptr<DlColorSource> source2 = DlColorSource::MakeRadial(
-        TestPoints[0], 10.0, kTestStopCount, TestAlphaColors, TestStops,
-        DlTileMode::kClamp, &TestMatrix1);
+        kTestPoints[0], 10.0, kTestStopCount, kTestAlphaColors, kTestStops,
+        DlTileMode::kClamp, &kTestMatrix1);
     TestNotEquals(*source1, *source2, "Colors differ");
   }
   {
     std::shared_ptr<DlColorSource> source2 = DlColorSource::MakeRadial(
-        TestPoints[0], 10.0, kTestStopCount, TestColors, TestStops2,
-        DlTileMode::kClamp, &TestMatrix1);
+        kTestPoints[0], 10.0, kTestStopCount, kTestColors, kTestStops2,
+        DlTileMode::kClamp, &kTestMatrix1);
     TestNotEquals(*source1, *source2, "Stops differ");
   }
   {
     std::shared_ptr<DlColorSource> source2 = DlColorSource::MakeRadial(
-        TestPoints[0], 10.0, kTestStopCount, TestColors, TestStops,
-        DlTileMode::kMirror, &TestMatrix1);
+        kTestPoints[0], 10.0, kTestStopCount, kTestColors, kTestStops,
+        DlTileMode::kMirror, &kTestMatrix1);
     TestNotEquals(*source1, *source2, "Tile Mode differs");
   }
   {
     std::shared_ptr<DlColorSource> source2 = DlColorSource::MakeRadial(
-        TestPoints[0], 10.0, kTestStopCount, TestColors, TestStops,
-        DlTileMode::kClamp, &TestMatrix2);
+        kTestPoints[0], 10.0, kTestStopCount, kTestColors, kTestStops,
+        DlTileMode::kClamp, &kTestMatrix2);
     TestNotEquals(*source1, *source2, "Matrix differs");
   }
 }
 
 TEST(DisplayListColorSource, ConicalGradientConstructor) {
   std::shared_ptr<DlColorSource> source = DlColorSource::MakeConical(
-      TestPoints[0], 10.0, TestPoints[1], 20.0, kTestStopCount, TestColors,
-      TestStops, DlTileMode::kClamp, &TestMatrix1);
+      kTestPoints[0], 10.0, kTestPoints[1], 20.0, kTestStopCount, kTestColors,
+      kTestStops, DlTileMode::kClamp, &kTestMatrix1);
 }
 
 TEST(DisplayListColorSource, ConicalGradientShared) {
   std::shared_ptr<DlColorSource> source = DlColorSource::MakeConical(
-      TestPoints[0], 10.0, TestPoints[1], 20.0, kTestStopCount, TestColors,
-      TestStops, DlTileMode::kClamp, &TestMatrix1);
+      kTestPoints[0], 10.0, kTestPoints[1], 20.0, kTestStopCount, kTestColors,
+      kTestStops, DlTileMode::kClamp, &kTestMatrix1);
   ASSERT_NE(source->shared().get(), source.get());
   ASSERT_EQ(*source->shared().get(), *source.get());
 }
 
 TEST(DisplayListColorSource, ConicalGradientAsConical) {
   std::shared_ptr<DlColorSource> source = DlColorSource::MakeConical(
-      TestPoints[0], 10.0, TestPoints[1], 20.0, kTestStopCount, TestColors,
-      TestStops, DlTileMode::kClamp, &TestMatrix1);
+      kTestPoints[0], 10.0, kTestPoints[1], 20.0, kTestStopCount, kTestColors,
+      kTestStops, DlTileMode::kClamp, &kTestMatrix1);
   ASSERT_NE(source->asConicalGradient(), nullptr);
   ASSERT_EQ(source->asConicalGradient(), source.get());
 
@@ -636,128 +637,128 @@ TEST(DisplayListColorSource, ConicalGradientAsConical) {
 
 TEST(DisplayListColorSource, ConicalGradientContents) {
   std::shared_ptr<DlColorSource> source = DlColorSource::MakeConical(
-      TestPoints[0], 10.0, TestPoints[1], 20.0, kTestStopCount, TestColors,
-      TestStops, DlTileMode::kClamp, &TestMatrix1);
-  ASSERT_EQ(source->asConicalGradient()->start_center(), TestPoints[0]);
+      kTestPoints[0], 10.0, kTestPoints[1], 20.0, kTestStopCount, kTestColors,
+      kTestStops, DlTileMode::kClamp, &kTestMatrix1);
+  ASSERT_EQ(source->asConicalGradient()->start_center(), kTestPoints[0]);
   ASSERT_EQ(source->asConicalGradient()->start_radius(), 10.0);
-  ASSERT_EQ(source->asConicalGradient()->end_center(), TestPoints[1]);
+  ASSERT_EQ(source->asConicalGradient()->end_center(), kTestPoints[1]);
   ASSERT_EQ(source->asConicalGradient()->end_radius(), 20.0);
   ASSERT_EQ(source->asConicalGradient()->stop_count(), kTestStopCount);
   for (int i = 0; i < kTestStopCount; i++) {
-    ASSERT_EQ(source->asConicalGradient()->colors()[i], TestColors[i]);
-    ASSERT_EQ(source->asConicalGradient()->stops()[i], TestStops[i]);
+    ASSERT_EQ(source->asConicalGradient()->colors()[i], kTestColors[i]);
+    ASSERT_EQ(source->asConicalGradient()->stops()[i], kTestStops[i]);
   }
   ASSERT_EQ(source->asConicalGradient()->tile_mode(), DlTileMode::kClamp);
-  ASSERT_EQ(source->asConicalGradient()->matrix(), TestMatrix1);
+  ASSERT_EQ(source->asConicalGradient()->matrix(), kTestMatrix1);
   ASSERT_EQ(source->is_opaque(), true);
 }
 
 TEST(DisplayListColorSource, AlphaConicalGradientContents) {
   std::shared_ptr<DlColorSource> source = DlColorSource::MakeConical(
-      TestPoints[0], 10.0, TestPoints[1], 20.0, kTestStopCount, TestAlphaColors,
-      TestStops, DlTileMode::kClamp, &TestMatrix1);
-  ASSERT_EQ(source->asConicalGradient()->start_center(), TestPoints[0]);
+      kTestPoints[0], 10.0, kTestPoints[1], 20.0, kTestStopCount,
+      kTestAlphaColors, kTestStops, DlTileMode::kClamp, &kTestMatrix1);
+  ASSERT_EQ(source->asConicalGradient()->start_center(), kTestPoints[0]);
   ASSERT_EQ(source->asConicalGradient()->start_radius(), 10.0);
-  ASSERT_EQ(source->asConicalGradient()->end_center(), TestPoints[1]);
+  ASSERT_EQ(source->asConicalGradient()->end_center(), kTestPoints[1]);
   ASSERT_EQ(source->asConicalGradient()->end_radius(), 20.0);
   ASSERT_EQ(source->asConicalGradient()->stop_count(), kTestStopCount);
   for (int i = 0; i < kTestStopCount; i++) {
-    ASSERT_EQ(source->asConicalGradient()->colors()[i], TestAlphaColors[i]);
-    ASSERT_EQ(source->asConicalGradient()->stops()[i], TestStops[i]);
+    ASSERT_EQ(source->asConicalGradient()->colors()[i], kTestAlphaColors[i]);
+    ASSERT_EQ(source->asConicalGradient()->stops()[i], kTestStops[i]);
   }
   ASSERT_EQ(source->asConicalGradient()->tile_mode(), DlTileMode::kClamp);
-  ASSERT_EQ(source->asConicalGradient()->matrix(), TestMatrix1);
+  ASSERT_EQ(source->asConicalGradient()->matrix(), kTestMatrix1);
   ASSERT_EQ(source->is_opaque(), false);
 }
 
 TEST(DisplayListColorSource, ConicalGradientEquals) {
   std::shared_ptr<DlColorSource> source1 = DlColorSource::MakeConical(
-      TestPoints[0], 10.0, TestPoints[1], 20.0, kTestStopCount, TestColors,
-      TestStops, DlTileMode::kClamp, &TestMatrix1);
+      kTestPoints[0], 10.0, kTestPoints[1], 20.0, kTestStopCount, kTestColors,
+      kTestStops, DlTileMode::kClamp, &kTestMatrix1);
   std::shared_ptr<DlColorSource> source2 = DlColorSource::MakeConical(
-      TestPoints[0], 10.0, TestPoints[1], 20.0, kTestStopCount, TestColors,
-      TestStops, DlTileMode::kClamp, &TestMatrix1);
+      kTestPoints[0], 10.0, kTestPoints[1], 20.0, kTestStopCount, kTestColors,
+      kTestStops, DlTileMode::kClamp, &kTestMatrix1);
   TestEquals(*source1, *source2);
 }
 
 TEST(DisplayListColorSource, ConicalGradientNotEquals) {
   std::shared_ptr<DlColorSource> source1 = DlColorSource::MakeConical(
-      TestPoints[0], 10.0, TestPoints[1], 20.0, kTestStopCount, TestColors,
-      TestStops, DlTileMode::kClamp, &TestMatrix1);
+      kTestPoints[0], 10.0, kTestPoints[1], 20.0, kTestStopCount, kTestColors,
+      kTestStops, DlTileMode::kClamp, &kTestMatrix1);
   {
     std::shared_ptr<DlColorSource> source2 = DlColorSource::MakeConical(
-        TestPoints2[0], 10.0, TestPoints[1], 20.0, kTestStopCount, TestColors,
-        TestStops, DlTileMode::kClamp, &TestMatrix1);
+        kTestPoints2[0], 10.0, kTestPoints[1], 20.0, kTestStopCount,
+        kTestColors, kTestStops, DlTileMode::kClamp, &kTestMatrix1);
     TestNotEquals(*source1, *source2, "Start Center differs");
   }
   {
     std::shared_ptr<DlColorSource> source2 = DlColorSource::MakeConical(
-        TestPoints[0], 15.0, TestPoints[1], 20.0, kTestStopCount, TestColors,
-        TestStops, DlTileMode::kClamp, &TestMatrix1);
+        kTestPoints[0], 15.0, kTestPoints[1], 20.0, kTestStopCount, kTestColors,
+        kTestStops, DlTileMode::kClamp, &kTestMatrix1);
     TestNotEquals(*source1, *source2, "Start Radius differs");
   }
   {
     std::shared_ptr<DlColorSource> source2 = DlColorSource::MakeConical(
-        TestPoints[0], 10.0, TestPoints2[1], 20.0, kTestStopCount, TestColors,
-        TestStops, DlTileMode::kClamp, &TestMatrix1);
+        kTestPoints[0], 10.0, kTestPoints2[1], 20.0, kTestStopCount,
+        kTestColors, kTestStops, DlTileMode::kClamp, &kTestMatrix1);
     TestNotEquals(*source1, *source2, "End Center differs");
   }
   {
     std::shared_ptr<DlColorSource> source2 = DlColorSource::MakeConical(
-        TestPoints[0], 10.0, TestPoints[1], 25.0, kTestStopCount, TestColors,
-        TestStops, DlTileMode::kClamp, &TestMatrix1);
+        kTestPoints[0], 10.0, kTestPoints[1], 25.0, kTestStopCount, kTestColors,
+        kTestStops, DlTileMode::kClamp, &kTestMatrix1);
     TestNotEquals(*source1, *source2, "End Radius differs");
   }
   {
     std::shared_ptr<DlColorSource> source2 = DlColorSource::MakeConical(
-        TestPoints[0], 10.0, TestPoints[1], 20.0, 2, TestColors, TestStops,
-        DlTileMode::kClamp, &TestMatrix1);
+        kTestPoints[0], 10.0, kTestPoints[1], 20.0, 2, kTestColors, kTestStops,
+        DlTileMode::kClamp, &kTestMatrix1);
     TestNotEquals(*source1, *source2, "Stop count differs");
   }
   {
     std::shared_ptr<DlColorSource> source2 = DlColorSource::MakeConical(
-        TestPoints[0], 10.0, TestPoints[1], 20.0, kTestStopCount,
-        TestAlphaColors, TestStops, DlTileMode::kClamp, &TestMatrix1);
+        kTestPoints[0], 10.0, kTestPoints[1], 20.0, kTestStopCount,
+        kTestAlphaColors, kTestStops, DlTileMode::kClamp, &kTestMatrix1);
     TestNotEquals(*source1, *source2, "Colors differ");
   }
   {
     std::shared_ptr<DlColorSource> source2 = DlColorSource::MakeConical(
-        TestPoints[0], 10.0, TestPoints[1], 20.0, kTestStopCount, TestColors,
-        TestStops2, DlTileMode::kClamp, &TestMatrix1);
+        kTestPoints[0], 10.0, kTestPoints[1], 20.0, kTestStopCount, kTestColors,
+        kTestStops2, DlTileMode::kClamp, &kTestMatrix1);
     TestNotEquals(*source1, *source2, "Stops differ");
   }
   {
     std::shared_ptr<DlColorSource> source2 = DlColorSource::MakeConical(
-        TestPoints[0], 10.0, TestPoints[1], 20.0, kTestStopCount, TestColors,
-        TestStops, DlTileMode::kMirror, &TestMatrix1);
+        kTestPoints[0], 10.0, kTestPoints[1], 20.0, kTestStopCount, kTestColors,
+        kTestStops, DlTileMode::kMirror, &kTestMatrix1);
     TestNotEquals(*source1, *source2, "Tile Mode differs");
   }
   {
     std::shared_ptr<DlColorSource> source2 = DlColorSource::MakeConical(
-        TestPoints[0], 10.0, TestPoints[1], 20.0, kTestStopCount, TestColors,
-        TestStops, DlTileMode::kClamp, &TestMatrix2);
+        kTestPoints[0], 10.0, kTestPoints[1], 20.0, kTestStopCount, kTestColors,
+        kTestStops, DlTileMode::kClamp, &kTestMatrix2);
     TestNotEquals(*source1, *source2, "Matrix differs");
   }
 }
 
 TEST(DisplayListColorSource, SweepGradientConstructor) {
   std::shared_ptr<DlColorSource> source = DlColorSource::MakeSweep(
-      TestPoints[0], 10.0, 20.0, kTestStopCount, TestColors, TestStops,
-      DlTileMode::kClamp, &TestMatrix1);
+      kTestPoints[0], 10.0, 20.0, kTestStopCount, kTestColors, kTestStops,
+      DlTileMode::kClamp, &kTestMatrix1);
 }
 
 TEST(DisplayListColorSource, SweepGradientShared) {
   std::shared_ptr<DlColorSource> source = DlColorSource::MakeSweep(
-      TestPoints[0], 10.0, 20.0, kTestStopCount, TestColors, TestStops,
-      DlTileMode::kClamp, &TestMatrix1);
+      kTestPoints[0], 10.0, 20.0, kTestStopCount, kTestColors, kTestStops,
+      DlTileMode::kClamp, &kTestMatrix1);
   ASSERT_NE(source->shared().get(), source.get());
   ASSERT_EQ(*source->shared().get(), *source.get());
 }
 
 TEST(DisplayListColorSource, SweepGradientAsSweep) {
   std::shared_ptr<DlColorSource> source = DlColorSource::MakeSweep(
-      TestPoints[0], 10.0, 20.0, kTestStopCount, TestColors, TestStops,
-      DlTileMode::kClamp, &TestMatrix1);
+      kTestPoints[0], 10.0, 20.0, kTestStopCount, kTestColors, kTestStops,
+      DlTileMode::kClamp, &kTestMatrix1);
   ASSERT_NE(source->asSweepGradient(), nullptr);
   ASSERT_EQ(source->asSweepGradient(), source.get());
 
@@ -770,114 +771,114 @@ TEST(DisplayListColorSource, SweepGradientAsSweep) {
 
 TEST(DisplayListColorSource, SweepGradientContents) {
   std::shared_ptr<DlColorSource> source = DlColorSource::MakeSweep(
-      TestPoints[0], 10.0, 20.0, kTestStopCount, TestColors, TestStops,
-      DlTileMode::kClamp, &TestMatrix1);
-  ASSERT_EQ(source->asSweepGradient()->center(), TestPoints[0]);
+      kTestPoints[0], 10.0, 20.0, kTestStopCount, kTestColors, kTestStops,
+      DlTileMode::kClamp, &kTestMatrix1);
+  ASSERT_EQ(source->asSweepGradient()->center(), kTestPoints[0]);
   ASSERT_EQ(source->asSweepGradient()->start(), 10.0);
   ASSERT_EQ(source->asSweepGradient()->end(), 20.0);
   ASSERT_EQ(source->asSweepGradient()->stop_count(), kTestStopCount);
   for (int i = 0; i < kTestStopCount; i++) {
-    ASSERT_EQ(source->asSweepGradient()->colors()[i], TestColors[i]);
-    ASSERT_EQ(source->asSweepGradient()->stops()[i], TestStops[i]);
+    ASSERT_EQ(source->asSweepGradient()->colors()[i], kTestColors[i]);
+    ASSERT_EQ(source->asSweepGradient()->stops()[i], kTestStops[i]);
   }
   ASSERT_EQ(source->asSweepGradient()->tile_mode(), DlTileMode::kClamp);
-  ASSERT_EQ(source->asSweepGradient()->matrix(), TestMatrix1);
+  ASSERT_EQ(source->asSweepGradient()->matrix(), kTestMatrix1);
   ASSERT_EQ(source->is_opaque(), true);
 }
 
 TEST(DisplayListColorSource, AlphaSweepGradientContents) {
   std::shared_ptr<DlColorSource> source = DlColorSource::MakeSweep(
-      TestPoints[0], 10.0, 20.0, kTestStopCount, TestAlphaColors, TestStops,
-      DlTileMode::kClamp, &TestMatrix1);
-  ASSERT_EQ(source->asSweepGradient()->center(), TestPoints[0]);
+      kTestPoints[0], 10.0, 20.0, kTestStopCount, kTestAlphaColors, kTestStops,
+      DlTileMode::kClamp, &kTestMatrix1);
+  ASSERT_EQ(source->asSweepGradient()->center(), kTestPoints[0]);
   ASSERT_EQ(source->asSweepGradient()->start(), 10.0);
   ASSERT_EQ(source->asSweepGradient()->end(), 20.0);
   ASSERT_EQ(source->asSweepGradient()->stop_count(), kTestStopCount);
   for (int i = 0; i < kTestStopCount; i++) {
-    ASSERT_EQ(source->asSweepGradient()->colors()[i], TestAlphaColors[i]);
-    ASSERT_EQ(source->asSweepGradient()->stops()[i], TestStops[i]);
+    ASSERT_EQ(source->asSweepGradient()->colors()[i], kTestAlphaColors[i]);
+    ASSERT_EQ(source->asSweepGradient()->stops()[i], kTestStops[i]);
   }
   ASSERT_EQ(source->asSweepGradient()->tile_mode(), DlTileMode::kClamp);
-  ASSERT_EQ(source->asSweepGradient()->matrix(), TestMatrix1);
+  ASSERT_EQ(source->asSweepGradient()->matrix(), kTestMatrix1);
   ASSERT_EQ(source->is_opaque(), false);
 }
 
 TEST(DisplayListColorSource, SweepGradientEquals) {
   std::shared_ptr<DlColorSource> source1 = DlColorSource::MakeSweep(
-      TestPoints[0], 10.0, 20.0, kTestStopCount, TestColors, TestStops,
-      DlTileMode::kClamp, &TestMatrix1);
+      kTestPoints[0], 10.0, 20.0, kTestStopCount, kTestColors, kTestStops,
+      DlTileMode::kClamp, &kTestMatrix1);
   std::shared_ptr<DlColorSource> source2 = DlColorSource::MakeSweep(
-      TestPoints[0], 10.0, 20.0, kTestStopCount, TestColors, TestStops,
-      DlTileMode::kClamp, &TestMatrix1);
+      kTestPoints[0], 10.0, 20.0, kTestStopCount, kTestColors, kTestStops,
+      DlTileMode::kClamp, &kTestMatrix1);
   TestEquals(*source1, *source2);
 }
 
 TEST(DisplayListColorSource, SweepGradientNotEquals) {
   std::shared_ptr<DlColorSource> source1 = DlColorSource::MakeSweep(
-      TestPoints[0], 10.0, 20.0, kTestStopCount, TestColors, TestStops,
-      DlTileMode::kClamp, &TestMatrix1);
+      kTestPoints[0], 10.0, 20.0, kTestStopCount, kTestColors, kTestStops,
+      DlTileMode::kClamp, &kTestMatrix1);
   {
     std::shared_ptr<DlColorSource> source2 = DlColorSource::MakeSweep(
-        TestPoints2[0], 10.0, 20.0, kTestStopCount, TestColors, TestStops,
-        DlTileMode::kClamp, &TestMatrix1);
+        kTestPoints2[0], 10.0, 20.0, kTestStopCount, kTestColors, kTestStops,
+        DlTileMode::kClamp, &kTestMatrix1);
     TestNotEquals(*source1, *source2, "Center differs");
   }
   {
     std::shared_ptr<DlColorSource> source2 = DlColorSource::MakeSweep(
-        TestPoints[0], 15.0, 20.0, kTestStopCount, TestColors, TestStops,
-        DlTileMode::kClamp, &TestMatrix1);
+        kTestPoints[0], 15.0, 20.0, kTestStopCount, kTestColors, kTestStops,
+        DlTileMode::kClamp, &kTestMatrix1);
     TestNotEquals(*source1, *source2, "Start Angle differs");
   }
   {
     std::shared_ptr<DlColorSource> source2 = DlColorSource::MakeSweep(
-        TestPoints[0], 10.0, 25.0, kTestStopCount, TestColors, TestStops,
-        DlTileMode::kClamp, &TestMatrix1);
+        kTestPoints[0], 10.0, 25.0, kTestStopCount, kTestColors, kTestStops,
+        DlTileMode::kClamp, &kTestMatrix1);
     TestNotEquals(*source1, *source2, "End Angle differs");
   }
   {
     std::shared_ptr<DlColorSource> source2 = DlColorSource::MakeSweep(
-        TestPoints[0], 10.0, 20.0, 2, TestColors, TestStops,  //
-        DlTileMode::kClamp, &TestMatrix1);
+        kTestPoints[0], 10.0, 20.0, 2, kTestColors, kTestStops,  //
+        DlTileMode::kClamp, &kTestMatrix1);
     TestNotEquals(*source1, *source2, "Stop count differs");
   }
   {
     std::shared_ptr<DlColorSource> source2 = DlColorSource::MakeSweep(
-        TestPoints[0], 10.0, 20.0, kTestStopCount, TestAlphaColors, TestStops,
-        DlTileMode::kClamp, &TestMatrix1);
+        kTestPoints[0], 10.0, 20.0, kTestStopCount, kTestAlphaColors,
+        kTestStops, DlTileMode::kClamp, &kTestMatrix1);
     TestNotEquals(*source1, *source2, "Colors differ");
   }
   {
     std::shared_ptr<DlColorSource> source2 = DlColorSource::MakeSweep(
-        TestPoints[0], 10.0, 20.0, kTestStopCount, TestColors, TestStops2,
-        DlTileMode::kClamp, &TestMatrix1);
+        kTestPoints[0], 10.0, 20.0, kTestStopCount, kTestColors, kTestStops2,
+        DlTileMode::kClamp, &kTestMatrix1);
     TestNotEquals(*source1, *source2, "Stops differ");
   }
   {
     std::shared_ptr<DlColorSource> source2 = DlColorSource::MakeSweep(
-        TestPoints[0], 10.0, 20.0, kTestStopCount, TestColors, TestStops,
-        DlTileMode::kMirror, &TestMatrix1);
+        kTestPoints[0], 10.0, 20.0, kTestStopCount, kTestColors, kTestStops,
+        DlTileMode::kMirror, &kTestMatrix1);
     TestNotEquals(*source1, *source2, "Tile Mode differs");
   }
   {
     std::shared_ptr<DlColorSource> source2 = DlColorSource::MakeSweep(
-        TestPoints[0], 10.0, 20.0, kTestStopCount, TestColors, TestStops,
-        DlTileMode::kClamp, &TestMatrix2);
+        kTestPoints[0], 10.0, 20.0, kTestStopCount, kTestColors, kTestStops,
+        DlTileMode::kClamp, &kTestMatrix2);
     TestNotEquals(*source1, *source2, "Matrix differs");
   }
 }
 
 TEST(DisplayListColorSource, UnknownConstructor) {
-  DlUnknownColorSource source(TestUnknownShader);
+  DlUnknownColorSource source(kTestUnknownShader);
 }
 
 TEST(DisplayListColorSource, UnknownShared) {
-  DlUnknownColorSource source(TestUnknownShader);
+  DlUnknownColorSource source(kTestUnknownShader);
   ASSERT_NE(source.shared().get(), &source);
   ASSERT_EQ(*source.shared(), source);
 }
 
 TEST(DisplayListColorSource, UnknownAsNone) {
-  DlUnknownColorSource source(TestUnknownShader);
+  DlUnknownColorSource source(kTestUnknownShader);
   ASSERT_EQ(source.asColor(), nullptr);
   ASSERT_EQ(source.asImage(), nullptr);
   ASSERT_EQ(source.asLinearGradient(), nullptr);
@@ -887,28 +888,28 @@ TEST(DisplayListColorSource, UnknownAsNone) {
 }
 
 TEST(DisplayListColorSource, UnknownContents) {
-  DlUnknownColorSource source(TestUnknownShader);
-  ASSERT_EQ(source.skia_object(), TestUnknownShader);
+  DlUnknownColorSource source(kTestUnknownShader);
+  ASSERT_EQ(source.skia_object(), kTestUnknownShader);
   // Blend shaders always return false for is_opaque.
   // See: https://bugs.chromium.org/p/skia/issues/detail?id=13046
   ASSERT_EQ(source.is_opaque(), false);
 }
 
 TEST(DisplayListColorSource, AlphaUnknownContents) {
-  DlUnknownColorSource source(TestAlphaUnknownShader);
-  ASSERT_EQ(source.skia_object(), TestAlphaUnknownShader);
+  DlUnknownColorSource source(kTestAlphaUnknownShader);
+  ASSERT_EQ(source.skia_object(), kTestAlphaUnknownShader);
   ASSERT_EQ(source.is_opaque(), false);
 }
 
 TEST(DisplayListColorSource, UnknownEquals) {
-  DlUnknownColorSource source1(TestUnknownShader);
-  DlUnknownColorSource source2(TestUnknownShader);
+  DlUnknownColorSource source1(kTestUnknownShader);
+  DlUnknownColorSource source2(kTestUnknownShader);
   TestEquals(source1, source2);
 }
 
 TEST(DisplayListColorSource, UnknownNotEquals) {
-  DlUnknownColorSource source1(TestUnknownShader);
-  DlUnknownColorSource source2(TestAlphaUnknownShader);
+  DlUnknownColorSource source1(kTestUnknownShader);
+  DlUnknownColorSource source2(kTestAlphaUnknownShader);
   TestNotEquals(source1, source2, "SkShader differs");
 }
 

--- a/display_list/display_list_unittests.cc
+++ b/display_list/display_list_unittests.cc
@@ -20,31 +20,31 @@
 namespace flutter {
 namespace testing {
 
-constexpr SkPoint end_points[] = {
+constexpr SkPoint kEndPoints[] = {
     {0, 0},
     {100, 100},
 };
-const DlColor colors[] = {
+const DlColor kColors[] = {
     DlColor::kGreen(),
     DlColor::kYellow(),
     DlColor::kBlue(),
 };
-constexpr float stops[] = {
+constexpr float kStops[] = {
     0.0,
     0.5,
     1.0,
 };
-std::vector<uint32_t> color_vector(colors, colors + 3);
-std::vector<float> stops_vector(stops, stops + 3);
+std::vector<uint32_t> color_vector(kColors, kColors + 3);
+std::vector<float> stops_vector(kStops, kStops + 3);
 
 // clang-format off
-constexpr float rotate_color_matrix[20] = {
+constexpr float kRotateColorMatrix[20] = {
     0, 1, 0, 0, 0,
     0, 0, 1, 0, 0,
     1, 0, 0, 0, 0,
     0, 0, 0, 1, 0,
 };
-constexpr float invert_color_matrix[20] = {
+constexpr float kInvertColorMatrix[20] = {
     -1.0,    0,    0, 1.0,   0,
        0, -1.0,    0, 1.0,   0,
        0,    0, -1.0, 1.0,   0,
@@ -52,8 +52,8 @@ constexpr float invert_color_matrix[20] = {
 };
 // clang-format on
 
-const SkScalar TestDashes1[] = {4.0, 2.0};
-const SkScalar TestDashes2[] = {1.0, 1.5};
+const SkScalar kTestDashes1[] = {4.0, 2.0};
+const SkScalar kTestDashes2[] = {1.0, 1.5};
 
 constexpr SkPoint TestPoints[] = {
     {10, 10},
@@ -63,9 +63,9 @@ constexpr SkPoint TestPoints[] = {
 };
 #define TestPointCount sizeof(TestPoints) / (sizeof(TestPoints[0]))
 
-static const SkSamplingOptions NearestSampling =
+static const SkSamplingOptions kNearestSampling =
     SkSamplingOptions(SkFilterMode::kNearest, SkMipmapMode::kNone);
-static const SkSamplingOptions LinearSampling =
+static const SkSamplingOptions kLinearSampling =
     SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone);
 
 static sk_sp<DlImage> MakeTestImage(int w, int h, int checker_size) {
@@ -90,132 +90,137 @@ static sk_sp<DlImage> MakeTestImage(int w, int h, int checker_size) {
 static auto TestImage1 = MakeTestImage(40, 40, 5);
 static auto TestImage2 = MakeTestImage(50, 50, 5);
 
-static const sk_sp<SkBlender> TestBlender1 =
+static const sk_sp<SkBlender> kTestBlender1 =
     SkBlenders::Arithmetic(0.2, 0.2, 0.2, 0.2, false);
-static const sk_sp<SkBlender> TestBlender2 =
+static const sk_sp<SkBlender> kTestBlender2 =
     SkBlenders::Arithmetic(0.2, 0.2, 0.2, 0.2, true);
-static const sk_sp<SkBlender> TestBlender3 =
+static const sk_sp<SkBlender> kTestBlender3 =
     SkBlenders::Arithmetic(0.3, 0.3, 0.3, 0.3, true);
-static const DlImageColorSource TestSource1(TestImage1->skia_image(),
-                                            DlTileMode::kClamp,
-                                            DlTileMode::kMirror,
-                                            LinearSampling);
-static const std::shared_ptr<DlColorSource> TestSource2 =
-    DlColorSource::MakeLinear(end_points[0],
-                              end_points[1],
+static const DlImageColorSource kTestSource1(TestImage1->skia_image(),
+                                             DlTileMode::kClamp,
+                                             DlTileMode::kMirror,
+                                             kLinearSampling);
+static const std::shared_ptr<DlColorSource> kTestSource2 =
+    DlColorSource::MakeLinear(kEndPoints[0],
+                              kEndPoints[1],
                               3,
-                              colors,
-                              stops,
+                              kColors,
+                              kStops,
                               DlTileMode::kMirror);
-static const std::shared_ptr<DlColorSource> TestSource3 =
-    DlColorSource::MakeRadial(end_points[0],
+static const std::shared_ptr<DlColorSource> kTestSource3 =
+    DlColorSource::MakeRadial(kEndPoints[0],
                               10.0,
                               3,
-                              colors,
-                              stops,
+                              kColors,
+                              kStops,
                               DlTileMode::kMirror);
-static const std::shared_ptr<DlColorSource> TestSource4 =
-    DlColorSource::MakeConical(end_points[0],
+static const std::shared_ptr<DlColorSource> kTestSource4 =
+    DlColorSource::MakeConical(kEndPoints[0],
                                10.0,
-                               end_points[1],
+                               kEndPoints[1],
                                200.0,
                                3,
-                               colors,
-                               stops,
+                               kColors,
+                               kStops,
                                DlTileMode::kDecal);
-static const std::shared_ptr<DlColorSource> TestSource5 =
-    DlColorSource::MakeSweep(end_points[0],
+static const std::shared_ptr<DlColorSource> kTestSource5 =
+    DlColorSource::MakeSweep(kEndPoints[0],
                              0.0,
                              360.0,
                              3,
-                             colors,
-                             stops,
+                             kColors,
+                             kStops,
                              DlTileMode::kDecal);
-static const DlBlendColorFilter TestBlendColorFilter1(DlColor::kRed(),
-                                                      DlBlendMode::kDstATop);
-static const DlBlendColorFilter TestBlendColorFilter2(DlColor::kBlue(),
-                                                      DlBlendMode::kDstATop);
-static const DlBlendColorFilter TestBlendColorFilter3(DlColor::kRed(),
-                                                      DlBlendMode::kDstIn);
-static const DlMatrixColorFilter TestMatrixColorFilter1(rotate_color_matrix);
-static const DlMatrixColorFilter TestMatrixColorFilter2(invert_color_matrix);
-static const DlBlurImageFilter TestBlurImageFilter1(5.0,
-                                                    5.0,
-                                                    DlTileMode::kClamp);
-static const DlBlurImageFilter TestBlurImageFilter2(6.0,
-                                                    5.0,
-                                                    DlTileMode::kClamp);
-static const DlBlurImageFilter TestBlurImageFilter3(5.0,
-                                                    6.0,
-                                                    DlTileMode::kClamp);
-static const DlBlurImageFilter TestBlurImageFilter4(5.0,
-                                                    5.0,
-                                                    DlTileMode::kDecal);
-static const DlDilateImageFilter TestDilateImageFilter1(5.0, 5.0);
-static const DlDilateImageFilter TestDilateImageFilter2(6.0, 5.0);
-static const DlDilateImageFilter TestDilateImageFilter3(5.0, 6.0);
-static const DlErodeImageFilter TestErodeImageFilter1(5.0, 5.0);
-static const DlErodeImageFilter TestErodeImageFilter2(6.0, 5.0);
-static const DlErodeImageFilter TestErodeImageFilter3(5.0, 6.0);
-static const DlMatrixImageFilter TestMatrixImageFilter1(SkMatrix::RotateDeg(45),
-                                                        NearestSampling);
-static const DlMatrixImageFilter TestMatrixImageFilter2(SkMatrix::RotateDeg(85),
-                                                        NearestSampling);
-static const DlMatrixImageFilter TestMatrixImageFilter3(SkMatrix::RotateDeg(45),
-                                                        LinearSampling);
-static const DlComposeImageFilter TestComposeImageFilter1(
-    TestBlurImageFilter1,
-    TestMatrixImageFilter1);
-static const DlComposeImageFilter TestComposeImageFilter2(
-    TestBlurImageFilter2,
-    TestMatrixImageFilter1);
-static const DlComposeImageFilter TestComposeImageFilter3(
-    TestBlurImageFilter1,
-    TestMatrixImageFilter2);
-static const DlColorFilterImageFilter TestCFImageFilter1(TestBlendColorFilter1);
-static const DlColorFilterImageFilter TestCFImageFilter2(TestBlendColorFilter2);
-static const std::shared_ptr<DlPathEffect> TestPathEffect1 =
-    DlDashPathEffect::Make(TestDashes1, 2, 0.0f);
-static const std::shared_ptr<DlPathEffect> TestPathEffect2 =
-    DlDashPathEffect::Make(TestDashes2, 2, 0.0f);
-static const DlBlurMaskFilter TestMaskFilter1(kNormal_SkBlurStyle, 3.0);
-static const DlBlurMaskFilter TestMaskFilter2(kNormal_SkBlurStyle, 5.0);
-static const DlBlurMaskFilter TestMaskFilter3(kSolid_SkBlurStyle, 3.0);
-static const DlBlurMaskFilter TestMaskFilter4(kInner_SkBlurStyle, 3.0);
-static const DlBlurMaskFilter TestMaskFilter5(kOuter_SkBlurStyle, 3.0);
-constexpr SkRect TestBounds = SkRect::MakeLTRB(10, 10, 50, 60);
-static const SkRRect TestRRect = SkRRect::MakeRectXY(TestBounds, 5, 5);
-static const SkRRect TestRRectRect = SkRRect::MakeRect(TestBounds);
-static const SkRRect TestInnerRRect =
-    SkRRect::MakeRectXY(TestBounds.makeInset(5, 5), 2, 2);
-static const SkPath TestPathRect = SkPath::Rect(TestBounds);
-static const SkPath TestPathOval = SkPath::Oval(TestBounds);
-static const SkPath TestPath1 =
+static const DlBlendColorFilter kTestBlendColorFilter1(DlColor::kRed(),
+                                                       DlBlendMode::kDstATop);
+static const DlBlendColorFilter kTestBlendColorFilter2(DlColor::kBlue(),
+                                                       DlBlendMode::kDstATop);
+static const DlBlendColorFilter kTestBlendColorFilter3(DlColor::kRed(),
+                                                       DlBlendMode::kDstIn);
+static const DlMatrixColorFilter kTestMatrixColorFilter1(kRotateColorMatrix);
+static const DlMatrixColorFilter kTestMatrixColorFilter2(kInvertColorMatrix);
+static const DlBlurImageFilter kTestBlurImageFilter1(5.0,
+                                                     5.0,
+                                                     DlTileMode::kClamp);
+static const DlBlurImageFilter kTestBlurImageFilter2(6.0,
+                                                     5.0,
+                                                     DlTileMode::kClamp);
+static const DlBlurImageFilter kTestBlurImageFilter3(5.0,
+                                                     6.0,
+                                                     DlTileMode::kClamp);
+static const DlBlurImageFilter kTestBlurImageFilter4(5.0,
+                                                     5.0,
+                                                     DlTileMode::kDecal);
+static const DlDilateImageFilter kTestDilateImageFilter1(5.0, 5.0);
+static const DlDilateImageFilter kTestDilateImageFilter2(6.0, 5.0);
+static const DlDilateImageFilter kTestDilateImageFilter3(5.0, 6.0);
+static const DlErodeImageFilter kTestErodeImageFilter1(5.0, 5.0);
+static const DlErodeImageFilter kTestErodeImageFilter2(6.0, 5.0);
+static const DlErodeImageFilter kTestErodeImageFilter3(5.0, 6.0);
+static const DlMatrixImageFilter kTestMatrixImageFilter1(
+    SkMatrix::RotateDeg(45),
+    kNearestSampling);
+static const DlMatrixImageFilter kTestMatrixImageFilter2(
+    SkMatrix::RotateDeg(85),
+    kNearestSampling);
+static const DlMatrixImageFilter kTestMatrixImageFilter3(
+    SkMatrix::RotateDeg(45),
+    kLinearSampling);
+static const DlComposeImageFilter kTestComposeImageFilter1(
+    kTestBlurImageFilter1,
+    kTestMatrixImageFilter1);
+static const DlComposeImageFilter kTestComposeImageFilter2(
+    kTestBlurImageFilter2,
+    kTestMatrixImageFilter1);
+static const DlComposeImageFilter kTestComposeImageFilter3(
+    kTestBlurImageFilter1,
+    kTestMatrixImageFilter2);
+static const DlColorFilterImageFilter kTestCFImageFilter1(
+    kTestBlendColorFilter1);
+static const DlColorFilterImageFilter kTestCFImageFilter2(
+    kTestBlendColorFilter2);
+static const std::shared_ptr<DlPathEffect> kTestPathEffect1 =
+    DlDashPathEffect::Make(kTestDashes1, 2, 0.0f);
+static const std::shared_ptr<DlPathEffect> kTestPathEffect2 =
+    DlDashPathEffect::Make(kTestDashes2, 2, 0.0f);
+static const DlBlurMaskFilter kTestMaskFilter1(kNormal_SkBlurStyle, 3.0);
+static const DlBlurMaskFilter kTestMaskFilter2(kNormal_SkBlurStyle, 5.0);
+static const DlBlurMaskFilter kTestMaskFilter3(kSolid_SkBlurStyle, 3.0);
+static const DlBlurMaskFilter kTestMaskFilter4(kInner_SkBlurStyle, 3.0);
+static const DlBlurMaskFilter kTestMaskFilter5(kOuter_SkBlurStyle, 3.0);
+constexpr SkRect kTestBounds = SkRect::MakeLTRB(10, 10, 50, 60);
+static const SkRRect kTestRRect = SkRRect::MakeRectXY(kTestBounds, 5, 5);
+static const SkRRect kTestRRectRect = SkRRect::MakeRect(kTestBounds);
+static const SkRRect kTestInnerRRect =
+    SkRRect::MakeRectXY(kTestBounds.makeInset(5, 5), 2, 2);
+static const SkPath kTestPathRect = SkPath::Rect(kTestBounds);
+static const SkPath kTestPathOval = SkPath::Oval(kTestBounds);
+static const SkPath kTestPath1 =
     SkPath::Polygon({{0, 0}, {10, 10}, {10, 0}, {0, 10}}, true);
-static const SkPath TestPath2 =
+static const SkPath kTestPath2 =
     SkPath::Polygon({{0, 0}, {10, 10}, {0, 10}, {10, 0}}, true);
-static const SkPath TestPath3 =
+static const SkPath kTestPath3 =
     SkPath::Polygon({{0, 0}, {10, 10}, {10, 0}, {0, 10}}, false);
-static const SkMatrix TestMatrix1 = SkMatrix::Scale(2, 2);
-static const SkMatrix TestMatrix2 = SkMatrix::RotateDeg(45);
+static const SkMatrix kTestMatrix1 = SkMatrix::Scale(2, 2);
+static const SkMatrix kTestMatrix2 = SkMatrix::RotateDeg(45);
 
 static std::shared_ptr<const DlVertices> TestVertices1 =
     DlVertices::Make(DlVertexMode::kTriangles,  //
                      3,
                      TestPoints,
                      nullptr,
-                     colors);
+                     kColors);
 static std::shared_ptr<const DlVertices> TestVertices2 =
     DlVertices::Make(DlVertexMode::kTriangleFan,  //
                      3,
                      TestPoints,
                      nullptr,
-                     colors);
+                     kColors);
 
-static constexpr int TestDivs1[] = {10, 20, 30};
-static constexpr int TestDivs2[] = {15, 20, 25};
-static constexpr int TestDivs3[] = {15, 25};
-static constexpr SkCanvas::Lattice::RectType TestRTypes[] = {
+static constexpr int kTestDivs1[] = {10, 20, 30};
+static constexpr int kTestDivs2[] = {15, 20, 25};
+static constexpr int kTestDivs3[] = {15, 25};
+static constexpr SkCanvas::Lattice::RectType kTestRTypes[] = {
     SkCanvas::Lattice::RectType::kDefault,
     SkCanvas::Lattice::RectType::kTransparent,
     SkCanvas::Lattice::RectType::kFixedColor,
@@ -226,17 +231,17 @@ static constexpr SkCanvas::Lattice::RectType TestRTypes[] = {
     SkCanvas::Lattice::RectType::kTransparent,
     SkCanvas::Lattice::RectType::kFixedColor,
 };
-static constexpr SkColor TestLatticeColors[] = {
+static constexpr SkColor kTestLatticeColors[] = {
     SK_ColorBLUE, SK_ColorGREEN, SK_ColorYELLOW,
     SK_ColorBLUE, SK_ColorGREEN, SK_ColorYELLOW,
     SK_ColorBLUE, SK_ColorGREEN, SK_ColorYELLOW,
 };
-static constexpr SkIRect TestLatticeSrcRect = {1, 1, 39, 39};
+static constexpr SkIRect kTestLatticeSrcRect = {1, 1, 39, 39};
 
 static sk_sp<SkPicture> MakeTestPicture(int w, int h, SkColor color) {
   SkPictureRecorder recorder;
   SkRTreeFactory rtree_factory;
-  SkCanvas* cv = recorder.beginRecording(TestBounds, &rtree_factory);
+  SkCanvas* cv = recorder.beginRecording(kTestBounds, &rtree_factory);
   SkPaint paint;
   paint.setColor(color);
   paint.setStyle(SkPaint::kFill_Style);
@@ -378,51 +383,51 @@ std::vector<DisplayListInvocationGroup> allGroups = {
   { "SetBlendModeOrBlender", {
       {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setBlendMode(DlBlendMode::kSrcIn);}},
       {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setBlendMode(DlBlendMode::kDstIn);}},
-      {0, 16, 0, 0, [](DisplayListBuilder& b) {b.setBlender(TestBlender1);}},
-      {0, 16, 0, 0, [](DisplayListBuilder& b) {b.setBlender(TestBlender2);}},
-      {0, 16, 0, 0, [](DisplayListBuilder& b) {b.setBlender(TestBlender3);}},
+      {0, 16, 0, 0, [](DisplayListBuilder& b) {b.setBlender(kTestBlender1);}},
+      {0, 16, 0, 0, [](DisplayListBuilder& b) {b.setBlender(kTestBlender2);}},
+      {0, 16, 0, 0, [](DisplayListBuilder& b) {b.setBlender(kTestBlender3);}},
       {0, 0, 0, 0, [](DisplayListBuilder& b) {b.setBlendMode(DlBlendMode::kSrcOver);}},
       {0, 0, 0, 0, [](DisplayListBuilder& b) {b.setBlender(nullptr);}},
     }
   },
   { "SetColorSource", {
-      {0, 112, 0, 0, [](DisplayListBuilder& b) {b.setColorSource(&TestSource1);}},
+      {0, 112, 0, 0, [](DisplayListBuilder& b) {b.setColorSource(&kTestSource1);}},
       // stop_count * (sizeof(float) + sizeof(uint32_t)) = 80
-      {0, 80 + 6 * 4, 0, 0, [](DisplayListBuilder& b) {b.setColorSource(TestSource2.get());}},
-      {0, 80 + 6 * 4, 0, 0, [](DisplayListBuilder& b) {b.setColorSource(TestSource3.get());}},
-      {0, 88 + 6 * 4, 0, 0, [](DisplayListBuilder& b) {b.setColorSource(TestSource4.get());}},
-      {0, 80 + 6 * 4, 0, 0, [](DisplayListBuilder& b) {b.setColorSource(TestSource5.get());}},
+      {0, 80 + 6 * 4, 0, 0, [](DisplayListBuilder& b) {b.setColorSource(kTestSource2.get());}},
+      {0, 80 + 6 * 4, 0, 0, [](DisplayListBuilder& b) {b.setColorSource(kTestSource3.get());}},
+      {0, 88 + 6 * 4, 0, 0, [](DisplayListBuilder& b) {b.setColorSource(kTestSource4.get());}},
+      {0, 80 + 6 * 4, 0, 0, [](DisplayListBuilder& b) {b.setColorSource(kTestSource5.get());}},
       {0, 0, 0, 0, [](DisplayListBuilder& b) {b.setColorSource(nullptr);}},
     }
   },
   { "SetImageFilter", {
-      {0, 32, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(&TestBlurImageFilter1);}},
-      {0, 32, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(&TestBlurImageFilter2);}},
-      {0, 32, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(&TestBlurImageFilter3);}},
-      {0, 32, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(&TestBlurImageFilter4);}},
-      {0, 24, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(&TestDilateImageFilter1);}},
-      {0, 24, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(&TestDilateImageFilter2);}},
-      {0, 24, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(&TestDilateImageFilter3);}},
-      {0, 24, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(&TestErodeImageFilter1);}},
-      {0, 24, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(&TestErodeImageFilter2);}},
-      {0, 24, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(&TestErodeImageFilter3);}},
-      {0, 80, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(&TestMatrixImageFilter1);}},
-      {0, 80, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(&TestMatrixImageFilter2);}},
-      {0, 80, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(&TestMatrixImageFilter3);}},
-      {0, 24, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(&TestComposeImageFilter1);}},
-      {0, 24, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(&TestComposeImageFilter2);}},
-      {0, 24, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(&TestComposeImageFilter3);}},
-      {0, 24, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(&TestCFImageFilter1);}},
-      {0, 24, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(&TestCFImageFilter2);}},
+      {0, 32, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(&kTestBlurImageFilter1);}},
+      {0, 32, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(&kTestBlurImageFilter2);}},
+      {0, 32, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(&kTestBlurImageFilter3);}},
+      {0, 32, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(&kTestBlurImageFilter4);}},
+      {0, 24, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(&kTestDilateImageFilter1);}},
+      {0, 24, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(&kTestDilateImageFilter2);}},
+      {0, 24, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(&kTestDilateImageFilter3);}},
+      {0, 24, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(&kTestErodeImageFilter1);}},
+      {0, 24, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(&kTestErodeImageFilter2);}},
+      {0, 24, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(&kTestErodeImageFilter3);}},
+      {0, 80, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(&kTestMatrixImageFilter1);}},
+      {0, 80, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(&kTestMatrixImageFilter2);}},
+      {0, 80, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(&kTestMatrixImageFilter3);}},
+      {0, 24, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(&kTestComposeImageFilter1);}},
+      {0, 24, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(&kTestComposeImageFilter2);}},
+      {0, 24, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(&kTestComposeImageFilter3);}},
+      {0, 24, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(&kTestCFImageFilter1);}},
+      {0, 24, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(&kTestCFImageFilter2);}},
       {0, 0, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(nullptr);}},
     }
   },
   { "SetColorFilter", {
-      {0, 24, 0, 0, [](DisplayListBuilder& b) {b.setColorFilter(&TestBlendColorFilter1);}},
-      {0, 24, 0, 0, [](DisplayListBuilder& b) {b.setColorFilter(&TestBlendColorFilter2);}},
-      {0, 24, 0, 0, [](DisplayListBuilder& b) {b.setColorFilter(&TestBlendColorFilter3);}},
-      {0, 96, 0, 0, [](DisplayListBuilder& b) {b.setColorFilter(&TestMatrixColorFilter1);}},
-      {0, 96, 0, 0, [](DisplayListBuilder& b) {b.setColorFilter(&TestMatrixColorFilter2);}},
+      {0, 24, 0, 0, [](DisplayListBuilder& b) {b.setColorFilter(&kTestBlendColorFilter1);}},
+      {0, 24, 0, 0, [](DisplayListBuilder& b) {b.setColorFilter(&kTestBlendColorFilter2);}},
+      {0, 24, 0, 0, [](DisplayListBuilder& b) {b.setColorFilter(&kTestBlendColorFilter3);}},
+      {0, 96, 0, 0, [](DisplayListBuilder& b) {b.setColorFilter(&kTestMatrixColorFilter1);}},
+      {0, 96, 0, 0, [](DisplayListBuilder& b) {b.setColorFilter(&kTestMatrixColorFilter2);}},
       {0, 16, 0, 0, [](DisplayListBuilder& b) {b.setColorFilter(DlSrgbToLinearGammaColorFilter::instance.get());}},
       {0, 16, 0, 0, [](DisplayListBuilder& b) {b.setColorFilter(DlLinearToSrgbGammaColorFilter::instance.get());}},
       {0, 0, 0, 0, [](DisplayListBuilder& b) {b.setColorFilter(nullptr);}},
@@ -430,17 +435,17 @@ std::vector<DisplayListInvocationGroup> allGroups = {
   },
   { "SetPathEffect", {
       // sizeof(DlDashPathEffect) + 2 * sizeof(SkScalar)
-      {0, 32, 0, 0, [](DisplayListBuilder& b) {b.setPathEffect(TestPathEffect1.get());}},
-      {0, 32, 0, 0, [](DisplayListBuilder& b) {b.setPathEffect(TestPathEffect2.get());}},
+      {0, 32, 0, 0, [](DisplayListBuilder& b) {b.setPathEffect(kTestPathEffect1.get());}},
+      {0, 32, 0, 0, [](DisplayListBuilder& b) {b.setPathEffect(kTestPathEffect2.get());}},
       {0, 0, 0, 0, [](DisplayListBuilder& b) {b.setPathEffect(nullptr);}},
     }
   },
   { "SetMaskFilter", {
-      {0, 24, 0, 0, [](DisplayListBuilder& b) {b.setMaskFilter(&TestMaskFilter1);}},
-      {0, 24, 0, 0, [](DisplayListBuilder& b) {b.setMaskFilter(&TestMaskFilter2);}},
-      {0, 24, 0, 0, [](DisplayListBuilder& b) {b.setMaskFilter(&TestMaskFilter3);}},
-      {0, 24, 0, 0, [](DisplayListBuilder& b) {b.setMaskFilter(&TestMaskFilter4);}},
-      {0, 24, 0, 0, [](DisplayListBuilder& b) {b.setMaskFilter(&TestMaskFilter5);}},
+      {0, 24, 0, 0, [](DisplayListBuilder& b) {b.setMaskFilter(&kTestMaskFilter1);}},
+      {0, 24, 0, 0, [](DisplayListBuilder& b) {b.setMaskFilter(&kTestMaskFilter2);}},
+      {0, 24, 0, 0, [](DisplayListBuilder& b) {b.setMaskFilter(&kTestMaskFilter3);}},
+      {0, 24, 0, 0, [](DisplayListBuilder& b) {b.setMaskFilter(&kTestMaskFilter4);}},
+      {0, 24, 0, 0, [](DisplayListBuilder& b) {b.setMaskFilter(&kTestMaskFilter5);}},
       {0, 0, 0, 0, [](DisplayListBuilder& b) {b.setMaskFilter(nullptr);}},
     }
   },
@@ -473,14 +478,14 @@ std::vector<DisplayListInvocationGroup> allGroups = {
         b.restore();
       }},
       {5, 104, 5, 104, [](DisplayListBuilder& b) {
-        b.saveLayer(&TestBounds, false);
+        b.saveLayer(&kTestBounds, false);
         b.clipRect({0, 0, 25, 25}, SkClipOp::kIntersect, true);
         b.drawRect({5, 5, 15, 15});
         b.drawRect({10, 10, 20, 20});
         b.restore();
       }},
       {5, 104, 5, 104, [](DisplayListBuilder& b) {
-        b.saveLayer(&TestBounds, true);
+        b.saveLayer(&kTestBounds, true);
         b.clipRect({0, 0, 25, 25}, SkClipOp::kIntersect, true);
         b.drawRect({5, 5, 15, 15});
         b.drawRect({10, 10, 20, 20});
@@ -544,34 +549,34 @@ std::vector<DisplayListInvocationGroup> allGroups = {
     }
   },
   { "ClipRect", {
-      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipRect(TestBounds, SkClipOp::kIntersect, true);}},
-      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipRect(TestBounds.makeOffset(1, 1),
+      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipRect(kTestBounds, SkClipOp::kIntersect, true);}},
+      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipRect(kTestBounds.makeOffset(1, 1),
                                                            SkClipOp::kIntersect, true);}},
-      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipRect(TestBounds, SkClipOp::kIntersect, false);}},
-      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipRect(TestBounds, SkClipOp::kDifference, true);}},
-      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipRect(TestBounds, SkClipOp::kDifference, false);}},
+      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipRect(kTestBounds, SkClipOp::kIntersect, false);}},
+      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipRect(kTestBounds, SkClipOp::kDifference, true);}},
+      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipRect(kTestBounds, SkClipOp::kDifference, false);}},
     }
   },
   { "ClipRRect", {
-      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.clipRRect(TestRRect, SkClipOp::kIntersect, true);}},
-      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.clipRRect(TestRRect.makeOffset(1, 1),
+      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.clipRRect(kTestRRect, SkClipOp::kIntersect, true);}},
+      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.clipRRect(kTestRRect.makeOffset(1, 1),
                                                             SkClipOp::kIntersect, true);}},
-      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.clipRRect(TestRRect, SkClipOp::kIntersect, false);}},
-      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.clipRRect(TestRRect, SkClipOp::kDifference, true);}},
-      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.clipRRect(TestRRect, SkClipOp::kDifference, false);}},
+      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.clipRRect(kTestRRect, SkClipOp::kIntersect, false);}},
+      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.clipRRect(kTestRRect, SkClipOp::kDifference, true);}},
+      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.clipRRect(kTestRRect, SkClipOp::kDifference, false);}},
     }
   },
   { "ClipPath", {
-      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipPath(TestPath1, SkClipOp::kIntersect, true);}},
-      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipPath(TestPath2, SkClipOp::kIntersect, true);}},
-      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipPath(TestPath3, SkClipOp::kIntersect, true);}},
-      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipPath(TestPath1, SkClipOp::kIntersect, false);}},
-      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipPath(TestPath1, SkClipOp::kDifference, true);}},
-      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipPath(TestPath1, SkClipOp::kDifference, false);}},
+      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipPath(kTestPath1, SkClipOp::kIntersect, true);}},
+      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipPath(kTestPath2, SkClipOp::kIntersect, true);}},
+      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipPath(kTestPath3, SkClipOp::kIntersect, true);}},
+      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipPath(kTestPath1, SkClipOp::kIntersect, false);}},
+      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipPath(kTestPath1, SkClipOp::kDifference, true);}},
+      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipPath(kTestPath1, SkClipOp::kDifference, false);}},
       // clipPath(rect) becomes clipRect
-      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipPath(TestPathRect, SkClipOp::kIntersect, true);}},
+      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipPath(kTestPathRect, SkClipOp::kIntersect, true);}},
       // clipPath(oval) becomes clipRRect
-      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.clipPath(TestPathOval, SkClipOp::kIntersect, true);}},
+      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.clipPath(kTestPathOval, SkClipOp::kIntersect, true);}},
     }
   },
   { "DrawPaint", {
@@ -614,31 +619,31 @@ std::vector<DisplayListInvocationGroup> allGroups = {
     }
   },
   { "DrawRRect", {
-      {1, 56, 1, 56, [](DisplayListBuilder& b) {b.drawRRect(TestRRect);}},
-      {1, 56, 1, 56, [](DisplayListBuilder& b) {b.drawRRect(TestRRect.makeOffset(5, 5));}},
+      {1, 56, 1, 56, [](DisplayListBuilder& b) {b.drawRRect(kTestRRect);}},
+      {1, 56, 1, 56, [](DisplayListBuilder& b) {b.drawRRect(kTestRRect.makeOffset(5, 5));}},
     }
   },
   { "DrawDRRect", {
-      {1, 112, 1, 112, [](DisplayListBuilder& b) {b.drawDRRect(TestRRect, TestInnerRRect);}},
-      {1, 112, 1, 112, [](DisplayListBuilder& b) {b.drawDRRect(TestRRect.makeOffset(5, 5),
-                                                               TestInnerRRect.makeOffset(4, 4));}},
+      {1, 112, 1, 112, [](DisplayListBuilder& b) {b.drawDRRect(kTestRRect, kTestInnerRRect);}},
+      {1, 112, 1, 112, [](DisplayListBuilder& b) {b.drawDRRect(kTestRRect.makeOffset(5, 5),
+                                                               kTestInnerRRect.makeOffset(4, 4));}},
     }
   },
   { "DrawPath", {
-      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.drawPath(TestPath1);}},
-      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.drawPath(TestPath2);}},
-      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.drawPath(TestPath3);}},
-      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.drawPath(TestPathRect);}},
-      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.drawPath(TestPathOval);}},
+      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.drawPath(kTestPath1);}},
+      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.drawPath(kTestPath2);}},
+      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.drawPath(kTestPath3);}},
+      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.drawPath(kTestPathRect);}},
+      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.drawPath(kTestPathOval);}},
     }
   },
   { "DrawArc", {
-      {1, 32, 1, 32, [](DisplayListBuilder& b) {b.drawArc(TestBounds, 45, 270, false);}},
-      {1, 32, 1, 32, [](DisplayListBuilder& b) {b.drawArc(TestBounds.makeOffset(1, 1),
+      {1, 32, 1, 32, [](DisplayListBuilder& b) {b.drawArc(kTestBounds, 45, 270, false);}},
+      {1, 32, 1, 32, [](DisplayListBuilder& b) {b.drawArc(kTestBounds.makeOffset(1, 1),
                                                           45, 270, false);}},
-      {1, 32, 1, 32, [](DisplayListBuilder& b) {b.drawArc(TestBounds, 30, 270, false);}},
-      {1, 32, 1, 32, [](DisplayListBuilder& b) {b.drawArc(TestBounds, 45, 260, false);}},
-      {1, 32, 1, 32, [](DisplayListBuilder& b) {b.drawArc(TestBounds, 45, 270, true);}},
+      {1, 32, 1, 32, [](DisplayListBuilder& b) {b.drawArc(kTestBounds, 30, 270, false);}},
+      {1, 32, 1, 32, [](DisplayListBuilder& b) {b.drawArc(kTestBounds, 45, 260, false);}},
+      {1, 32, 1, 32, [](DisplayListBuilder& b) {b.drawArc(kTestBounds, 45, 270, true);}},
     }
   },
   { "DrawPoints", {
@@ -667,30 +672,30 @@ std::vector<DisplayListInvocationGroup> allGroups = {
     }
   },
   { "DrawImage", {
-      {1, 48, -1, 48, [](DisplayListBuilder& b) {b.drawImage(TestImage1, {10, 10}, NearestSampling, false);}},
-      {1, 48, -1, 48, [](DisplayListBuilder& b) {b.drawImage(TestImage1, {10, 10}, NearestSampling, true);}},
-      {1, 48, -1, 48, [](DisplayListBuilder& b) {b.drawImage(TestImage1, {20, 10}, NearestSampling, false);}},
-      {1, 48, -1, 48, [](DisplayListBuilder& b) {b.drawImage(TestImage1, {10, 20}, NearestSampling, false);}},
-      {1, 48, -1, 48, [](DisplayListBuilder& b) {b.drawImage(TestImage1, {10, 10}, LinearSampling, false);}},
-      {1, 48, -1, 48, [](DisplayListBuilder& b) {b.drawImage(TestImage2, {10, 10}, NearestSampling, false);}},
+      {1, 48, -1, 48, [](DisplayListBuilder& b) {b.drawImage(TestImage1, {10, 10}, kNearestSampling, false);}},
+      {1, 48, -1, 48, [](DisplayListBuilder& b) {b.drawImage(TestImage1, {10, 10}, kNearestSampling, true);}},
+      {1, 48, -1, 48, [](DisplayListBuilder& b) {b.drawImage(TestImage1, {20, 10}, kNearestSampling, false);}},
+      {1, 48, -1, 48, [](DisplayListBuilder& b) {b.drawImage(TestImage1, {10, 20}, kNearestSampling, false);}},
+      {1, 48, -1, 48, [](DisplayListBuilder& b) {b.drawImage(TestImage1, {10, 10}, kLinearSampling, false);}},
+      {1, 48, -1, 48, [](DisplayListBuilder& b) {b.drawImage(TestImage2, {10, 10}, kNearestSampling, false);}},
     }
   },
   { "DrawImageRect", {
       {1, 80, -1, 80, [](DisplayListBuilder& b) {b.drawImageRect(TestImage1, {10, 10, 20, 20}, {10, 10, 80, 80},
-                                                                NearestSampling, false);}},
+                                                                kNearestSampling, false);}},
       {1, 80, -1, 80, [](DisplayListBuilder& b) {b.drawImageRect(TestImage1, {10, 10, 20, 20}, {10, 10, 80, 80},
-                                                                NearestSampling, true);}},
+                                                                kNearestSampling, true);}},
       {1, 80, -1, 80, [](DisplayListBuilder& b) {b.drawImageRect(TestImage1, {10, 10, 20, 20}, {10, 10, 80, 80},
-                                                                NearestSampling, false,
+                                                                kNearestSampling, false,
                                                                 SkCanvas::SrcRectConstraint::kStrict_SrcRectConstraint);}},
       {1, 80, -1, 80, [](DisplayListBuilder& b) {b.drawImageRect(TestImage1, {10, 10, 25, 20}, {10, 10, 80, 80},
-                                                                NearestSampling, false);}},
+                                                                kNearestSampling, false);}},
       {1, 80, -1, 80, [](DisplayListBuilder& b) {b.drawImageRect(TestImage1, {10, 10, 20, 20}, {10, 10, 85, 80},
-                                                                NearestSampling, false);}},
+                                                                kNearestSampling, false);}},
       {1, 80, -1, 80, [](DisplayListBuilder& b) {b.drawImageRect(TestImage1, {10, 10, 20, 20}, {10, 10, 80, 80},
-                                                                LinearSampling, false);}},
+                                                                kLinearSampling, false);}},
       {1, 80, -1, 80, [](DisplayListBuilder& b) {b.drawImageRect(TestImage2, {10, 10, 15, 15}, {10, 10, 80, 80},
-                                                                NearestSampling, false);}},
+                                                                kNearestSampling, false);}},
     }
   },
   { "DrawImageNine", {
@@ -721,34 +726,34 @@ std::vector<DisplayListInvocationGroup> allGroups = {
       // size = 64 + fXCount * 4 + fYCount * 4
       // if fColors and fRectTypes are not null, add (fXCount + 1) * (fYCount + 1) * 5
       {1, 88, -1, 88, [](DisplayListBuilder& b) {b.drawImageLattice(TestImage1,
-                                                                   {TestDivs1, TestDivs1, nullptr, 3, 3, nullptr, nullptr},
+                                                                   {kTestDivs1, kTestDivs1, nullptr, 3, 3, nullptr, nullptr},
                                                                    {10, 10, 40, 40}, SkFilterMode::kNearest, false);}},
       {1, 88, -1, 88, [](DisplayListBuilder& b) {b.drawImageLattice(TestImage1,
-                                                                   {TestDivs1, TestDivs1, nullptr, 3, 3, nullptr, nullptr},
+                                                                   {kTestDivs1, kTestDivs1, nullptr, 3, 3, nullptr, nullptr},
                                                                    {10, 10, 40, 45}, SkFilterMode::kNearest, false);}},
       {1, 88, -1, 88, [](DisplayListBuilder& b) {b.drawImageLattice(TestImage1,
-                                                                   {TestDivs2, TestDivs1, nullptr, 3, 3, nullptr, nullptr},
+                                                                   {kTestDivs2, kTestDivs1, nullptr, 3, 3, nullptr, nullptr},
                                                                    {10, 10, 40, 40}, SkFilterMode::kNearest, false);}},
       // One less yDiv does not change the allocation due to 8-byte alignment
       {1, 88, -1, 88, [](DisplayListBuilder& b) {b.drawImageLattice(TestImage1,
-                                                                   {TestDivs1, TestDivs1, nullptr, 3, 2, nullptr, nullptr},
+                                                                   {kTestDivs1, kTestDivs1, nullptr, 3, 2, nullptr, nullptr},
                                                                    {10, 10, 40, 40}, SkFilterMode::kNearest, false);}},
       {1, 88, -1, 88, [](DisplayListBuilder& b) {b.drawImageLattice(TestImage1,
-                                                                   {TestDivs1, TestDivs1, nullptr, 3, 3, nullptr, nullptr},
+                                                                   {kTestDivs1, kTestDivs1, nullptr, 3, 3, nullptr, nullptr},
                                                                    {10, 10, 40, 40}, SkFilterMode::kLinear, false);}},
       {1, 96, -1, 96, [](DisplayListBuilder& b) {b.setColor(SK_ColorMAGENTA);
                                                 b.drawImageLattice(TestImage1,
-                                                                   {TestDivs1, TestDivs1, nullptr, 3, 3, nullptr, nullptr},
+                                                                   {kTestDivs1, kTestDivs1, nullptr, 3, 3, nullptr, nullptr},
                                                                    {10, 10, 40, 40}, SkFilterMode::kNearest, true);}},
       {1, 88, -1, 88, [](DisplayListBuilder& b) {b.drawImageLattice(TestImage2,
-                                                                   {TestDivs1, TestDivs1, nullptr, 3, 3, nullptr, nullptr},
+                                                                   {kTestDivs1, kTestDivs1, nullptr, 3, 3, nullptr, nullptr},
                                                                    {10, 10, 40, 40}, SkFilterMode::kNearest, false);}},
       // Supplying fBounds does not change size because the Op record always includes it
       {1, 88, -1, 88, [](DisplayListBuilder& b) {b.drawImageLattice(TestImage1,
-                                                                   {TestDivs1, TestDivs1, nullptr, 3, 3, &TestLatticeSrcRect, nullptr},
+                                                                   {kTestDivs1, kTestDivs1, nullptr, 3, 3, &kTestLatticeSrcRect, nullptr},
                                                                    {10, 10, 40, 40}, SkFilterMode::kNearest, false);}},
       {1, 128, -1, 128, [](DisplayListBuilder& b) {b.drawImageLattice(TestImage1,
-                                                                     {TestDivs3, TestDivs3, TestRTypes, 2, 2, nullptr, TestLatticeColors},
+                                                                     {kTestDivs3, kTestDivs3, kTestRTypes, 2, 2, nullptr, kTestLatticeColors},
                                                                      {10, 10, 40, 40}, SkFilterMode::kNearest, false);}},
     }
   },
@@ -757,51 +762,51 @@ std::vector<DisplayListInvocationGroup> allGroups = {
         static SkRSXform xforms[] = { {1, 0, 0, 0}, {0, 1, 0, 0} };
         static SkRect texs[] = { { 10, 10, 20, 20 }, {20, 20, 30, 30} };
         b.drawAtlas(TestImage1, xforms, texs, nullptr, 2, DlBlendMode::kSrcIn,
-                    NearestSampling, nullptr, false);}},
+                    kNearestSampling, nullptr, false);}},
       {1, 48 + 32 + 32, -1, 48 + 32 + 32, [](DisplayListBuilder& b) {
         static SkRSXform xforms[] = { {1, 0, 0, 0}, {0, 1, 0, 0} };
         static SkRect texs[] = { { 10, 10, 20, 20 }, {20, 20, 30, 30} };
         b.drawAtlas(TestImage1, xforms, texs, nullptr, 2, DlBlendMode::kSrcIn,
-                    NearestSampling, nullptr, true);}},
+                    kNearestSampling, nullptr, true);}},
       {1, 48 + 32 + 32, -1, 48 + 32 + 32, [](DisplayListBuilder& b) {
         static SkRSXform xforms[] = { {0, 1, 0, 0}, {0, 1, 0, 0} };
         static SkRect texs[] = { { 10, 10, 20, 20 }, {20, 20, 30, 30} };
         b.drawAtlas(TestImage1, xforms, texs, nullptr, 2, DlBlendMode::kSrcIn,
-                    NearestSampling, nullptr, false);}},
+                    kNearestSampling, nullptr, false);}},
       {1, 48 + 32 + 32, -1, 48 + 32 + 32, [](DisplayListBuilder& b) {
         static SkRSXform xforms[] = { {1, 0, 0, 0}, {0, 1, 0, 0} };
         static SkRect texs[] = { { 10, 10, 20, 20 }, {20, 25, 30, 30} };
         b.drawAtlas(TestImage1, xforms, texs, nullptr, 2, DlBlendMode::kSrcIn,
-                    NearestSampling, nullptr, false);}},
+                    kNearestSampling, nullptr, false);}},
       {1, 48 + 32 + 32, -1, 48 + 32 + 32, [](DisplayListBuilder& b) {
         static SkRSXform xforms[] = { {1, 0, 0, 0}, {0, 1, 0, 0} };
         static SkRect texs[] = { { 10, 10, 20, 20 }, {20, 20, 30, 30} };
         b.drawAtlas(TestImage1, xforms, texs, nullptr, 2, DlBlendMode::kSrcIn,
-                    LinearSampling, nullptr, false);}},
+                    kLinearSampling, nullptr, false);}},
       {1, 48 + 32 + 32, -1, 48 + 32 + 32, [](DisplayListBuilder& b) {
         static SkRSXform xforms[] = { {1, 0, 0, 0}, {0, 1, 0, 0} };
         static SkRect texs[] = { { 10, 10, 20, 20 }, {20, 20, 30, 30} };
         b.drawAtlas(TestImage1, xforms, texs, nullptr, 2, DlBlendMode::kDstIn,
-                    NearestSampling, nullptr, false);}},
+                    kNearestSampling, nullptr, false);}},
       {1, 64 + 32 + 32, -1, 64 + 32 + 32, [](DisplayListBuilder& b) {
         static SkRSXform xforms[] = { {1, 0, 0, 0}, {0, 1, 0, 0} };
         static SkRect texs[] = { { 10, 10, 20, 20 }, {20, 20, 30, 30} };
         static SkRect cullRect = { 0, 0, 200, 200 };
         b.drawAtlas(TestImage2, xforms, texs, nullptr, 2, DlBlendMode::kSrcIn,
-                    NearestSampling, &cullRect, false);}},
+                    kNearestSampling, &cullRect, false);}},
       {1, 48 + 32 + 32 + 8, -1, 48 + 32 + 32 + 8, [](DisplayListBuilder& b) {
         static SkRSXform xforms[] = { {1, 0, 0, 0}, {0, 1, 0, 0} };
         static SkRect texs[] = { { 10, 10, 20, 20 }, {20, 20, 30, 30} };
         static DlColor colors[] = { DlColor::kBlue(), DlColor::kGreen() };
         b.drawAtlas(TestImage1, xforms, texs, colors, 2, DlBlendMode::kSrcIn,
-                    NearestSampling, nullptr, false);}},
+                    kNearestSampling, nullptr, false);}},
       {1, 64 + 32 + 32 + 8, -1, 64 + 32 + 32 + 8, [](DisplayListBuilder& b) {
         static SkRSXform xforms[] = { {1, 0, 0, 0}, {0, 1, 0, 0} };
         static SkRect texs[] = { { 10, 10, 20, 20 }, {20, 20, 30, 30} };
         static DlColor colors[] = { DlColor::kBlue(), DlColor::kGreen() };
         static SkRect cullRect = { 0, 0, 200, 200 };
         b.drawAtlas(TestImage1, xforms, texs, colors, 2, DlBlendMode::kSrcIn,
-                    NearestSampling, &cullRect, false);}},
+                    kNearestSampling, &cullRect, false);}},
     }
   },
   { "DrawPicture", {
@@ -809,9 +814,9 @@ std::vector<DisplayListInvocationGroup> allGroups = {
       {1, 16, -1, 16, [](DisplayListBuilder& b) {b.drawPicture(TestPicture1, nullptr, false);}},
       {1, 16, -1, 16, [](DisplayListBuilder& b) {b.drawPicture(TestPicture2, nullptr, false);}},
       {1, 16, -1, 16, [](DisplayListBuilder& b) {b.drawPicture(TestPicture1, nullptr, true);}},
-      {1, 56, -1, 56, [](DisplayListBuilder& b) {b.drawPicture(TestPicture1, &TestMatrix1, false);}},
-      {1, 56, -1, 56, [](DisplayListBuilder& b) {b.drawPicture(TestPicture1, &TestMatrix2, false);}},
-      {1, 56, -1, 56, [](DisplayListBuilder& b) {b.drawPicture(TestPicture1, &TestMatrix1, true);}},
+      {1, 56, -1, 56, [](DisplayListBuilder& b) {b.drawPicture(TestPicture1, &kTestMatrix1, false);}},
+      {1, 56, -1, 56, [](DisplayListBuilder& b) {b.drawPicture(TestPicture1, &kTestMatrix2, false);}},
+      {1, 56, -1, 56, [](DisplayListBuilder& b) {b.drawPicture(TestPicture1, &kTestMatrix1, true);}},
     }
   },
   { "DrawDisplayList", {
@@ -834,12 +839,12 @@ std::vector<DisplayListInvocationGroup> allGroups = {
   // See: https://bugs.chromium.org/p/skia/issues/detail?id=12125
   { "DrawShadow", {
       // cv shadows are turned into an opaque ShadowRec which is not exposed
-      {1, 32, -1, 32, [](DisplayListBuilder& b) {b.drawShadow(TestPath1, SK_ColorGREEN, 1.0, false, 1.0);}},
-      {1, 32, -1, 32, [](DisplayListBuilder& b) {b.drawShadow(TestPath2, SK_ColorGREEN, 1.0, false, 1.0);}},
-      {1, 32, -1, 32, [](DisplayListBuilder& b) {b.drawShadow(TestPath1, SK_ColorBLUE, 1.0, false, 1.0);}},
-      {1, 32, -1, 32, [](DisplayListBuilder& b) {b.drawShadow(TestPath1, SK_ColorGREEN, 2.0, false, 1.0);}},
-      {1, 32, -1, 32, [](DisplayListBuilder& b) {b.drawShadow(TestPath1, SK_ColorGREEN, 1.0, true, 1.0);}},
-      {1, 32, -1, 32, [](DisplayListBuilder& b) {b.drawShadow(TestPath1, SK_ColorGREEN, 1.0, false, 2.5);}},
+      {1, 32, -1, 32, [](DisplayListBuilder& b) {b.drawShadow(kTestPath1, SK_ColorGREEN, 1.0, false, 1.0);}},
+      {1, 32, -1, 32, [](DisplayListBuilder& b) {b.drawShadow(kTestPath2, SK_ColorGREEN, 1.0, false, 1.0);}},
+      {1, 32, -1, 32, [](DisplayListBuilder& b) {b.drawShadow(kTestPath1, SK_ColorBLUE, 1.0, false, 1.0);}},
+      {1, 32, -1, 32, [](DisplayListBuilder& b) {b.drawShadow(kTestPath1, SK_ColorGREEN, 2.0, false, 1.0);}},
+      {1, 32, -1, 32, [](DisplayListBuilder& b) {b.drawShadow(kTestPath1, SK_ColorGREEN, 1.0, true, 1.0);}},
+      {1, 32, -1, 32, [](DisplayListBuilder& b) {b.drawShadow(kTestPath1, SK_ColorGREEN, 1.0, false, 2.5);}},
     }
   },
 };
@@ -1451,13 +1456,13 @@ TEST(DisplayList, SingleOpsMightSupportGroupOpacityWithOrWithoutBlendMode) {
                                 TestPoints);
              , false);
   RUN_TESTS2(builder.drawVertices(TestVertices1, DlBlendMode::kSrc);, false);
-  RUN_TESTS(builder.drawImage(TestImage1, {0, 0}, LinearSampling, true););
-  RUN_TESTS2(builder.drawImage(TestImage1, {0, 0}, LinearSampling, false);
+  RUN_TESTS(builder.drawImage(TestImage1, {0, 0}, kLinearSampling, true););
+  RUN_TESTS2(builder.drawImage(TestImage1, {0, 0}, kLinearSampling, false);
              , true);
   RUN_TESTS(builder.drawImageRect(TestImage1, {10, 10, 20, 20}, {0, 0, 10, 10},
-                                  NearestSampling, true););
+                                  kNearestSampling, true););
   RUN_TESTS2(builder.drawImageRect(TestImage1, {10, 10, 20, 20}, {0, 0, 10, 10},
-                                   NearestSampling, false);
+                                   kNearestSampling, false);
              , true);
   RUN_TESTS(builder.drawImageNine(TestImage2, {20, 20, 30, 30}, {0, 0, 20, 20},
                                   SkFilterMode::kLinear, true););
@@ -1466,22 +1471,22 @@ TEST(DisplayList, SingleOpsMightSupportGroupOpacityWithOrWithoutBlendMode) {
              , true);
   RUN_TESTS(builder.drawImageLattice(
       TestImage1,
-      {TestDivs1, TestDivs1, nullptr, 3, 3, &TestLatticeSrcRect, nullptr},
+      {kTestDivs1, kTestDivs1, nullptr, 3, 3, &kTestLatticeSrcRect, nullptr},
       {10, 10, 40, 40}, SkFilterMode::kNearest, true););
   RUN_TESTS2(builder.drawImageLattice(
       TestImage1,
-      {TestDivs1, TestDivs1, nullptr, 3, 3, &TestLatticeSrcRect, nullptr},
+      {kTestDivs1, kTestDivs1, nullptr, 3, 3, &kTestLatticeSrcRect, nullptr},
       {10, 10, 40, 40}, SkFilterMode::kNearest, false);
              , true);
   static SkRSXform xforms[] = {{1, 0, 0, 0}, {0, 1, 0, 0}};
   static SkRect texs[] = {{10, 10, 20, 20}, {20, 20, 30, 30}};
   RUN_TESTS2(
       builder.drawAtlas(TestImage1, xforms, texs, nullptr, 2,
-                        DlBlendMode::kSrcIn, NearestSampling, nullptr, true);
+                        DlBlendMode::kSrcIn, kNearestSampling, nullptr, true);
       , false);
   RUN_TESTS2(
       builder.drawAtlas(TestImage1, xforms, texs, nullptr, 2,
-                        DlBlendMode::kSrcIn, NearestSampling, nullptr, false);
+                        DlBlendMode::kSrcIn, kNearestSampling, nullptr, false);
       , false);
   RUN_TESTS(builder.drawPicture(TestPicture1, nullptr, true););
   RUN_TESTS2(builder.drawPicture(TestPicture1, nullptr, false);, true);
@@ -1495,7 +1500,7 @@ TEST(DisplayList, SingleOpsMightSupportGroupOpacityWithOrWithoutBlendMode) {
     RUN_TESTS2(builder.drawDisplayList(display_list);, false);
   }
   RUN_TESTS(builder.drawTextBlob(TestBlob1, 0, 0););
-  RUN_TESTS2(builder.drawShadow(TestPath1, SK_ColorBLACK, 1.0, false, 1.0);
+  RUN_TESTS2(builder.drawShadow(kTestPath1, SK_ColorBLACK, 1.0, false, 1.0);
              , false);
 
 #undef RUN_TESTS2
@@ -1578,7 +1583,7 @@ TEST(DisplayList, SaveLayerBoundsSnapshotsImageFilter) {
   builder.saveLayer(nullptr, true);
   builder.drawRect({50, 50, 100, 100});
   // This image filter should be ignored since it was not set before saveLayer
-  builder.setImageFilter(&TestBlurImageFilter1);
+  builder.setImageFilter(&kTestBlurImageFilter1);
   builder.restore();
   SkRect bounds = builder.Build()->bounds();
   EXPECT_EQ(bounds, SkRect::MakeLTRB(50, 50, 100, 100));
@@ -1702,7 +1707,7 @@ TEST(DisplayList, SaveLayerImageFilterPreventsOpacityOptimization) {
 
   DisplayListBuilder builder;
   builder.setColor(SkColorSetARGB(127, 255, 255, 255));
-  builder.setImageFilter(&TestBlurImageFilter1);
+  builder.setImageFilter(&kTestBlurImageFilter1);
   builder.saveLayer(nullptr, true);
   builder.setImageFilter(nullptr);
   builder.drawRect({10, 10, 20, 20});
@@ -1718,7 +1723,7 @@ TEST(DisplayList, SaveLayerColorFilterPreventsOpacityOptimization) {
 
   DisplayListBuilder builder;
   builder.setColor(SkColorSetARGB(127, 255, 255, 255));
-  builder.setColorFilter(&TestMatrixColorFilter1);
+  builder.setColorFilter(&kTestMatrixColorFilter1);
   builder.saveLayer(nullptr, true);
   builder.setColorFilter(nullptr);
   builder.drawRect({10, 10, 20, 20});
@@ -1752,7 +1757,7 @@ TEST(DisplayList, SaveLayerImageFilterOnChildSupportsOpacityOptimization) {
   DisplayListBuilder builder;
   builder.setColor(SkColorSetARGB(127, 255, 255, 255));
   builder.saveLayer(nullptr, true);
-  builder.setImageFilter(&TestBlurImageFilter1);
+  builder.setImageFilter(&kTestBlurImageFilter1);
   builder.drawRect({10, 10, 20, 20});
   builder.restore();
 
@@ -1767,7 +1772,7 @@ TEST(DisplayList, SaveLayerColorFilterOnChildPreventsOpacityOptimization) {
   DisplayListBuilder builder;
   builder.setColor(SkColorSetARGB(127, 255, 255, 255));
   builder.saveLayer(nullptr, true);
-  builder.setColorFilter(&TestMatrixColorFilter1);
+  builder.setColorFilter(&kTestMatrixColorFilter1);
   builder.drawRect({10, 10, 20, 20});
   builder.restore();
 

--- a/display_list/display_list_utils.cc
+++ b/display_list/display_list_utils.cc
@@ -20,7 +20,7 @@
 namespace flutter {
 
 // clang-format off
-constexpr float invert_color_matrix[20] = {
+constexpr float kInvertColorMatrix[20] = {
   -1.0,    0,    0, 1.0, 0,
      0, -1.0,    0, 1.0, 0,
      0,    0, -1.0, 1.0, 0,
@@ -97,7 +97,7 @@ sk_sp<SkColorFilter> SkPaintDispatchHelper::makeColorFilter() const {
     return color_filter_ ? color_filter_->skia_object() : nullptr;
   }
   sk_sp<SkColorFilter> invert_filter =
-      SkColorFilters::Matrix(invert_color_matrix);
+      SkColorFilters::Matrix(kInvertColorMatrix);
   if (color_filter_) {
     invert_filter = invert_filter->makeComposed(color_filter_->skia_object());
   }

--- a/display_list/display_list_vertices.cc
+++ b/display_list/display_list_vertices.cc
@@ -117,7 +117,7 @@ DlVertices::DlVertices(DlVertexMode mode,
       offset += bytes;
       return ret;
     } else {
-      return size_t(0);
+      return static_cast<size_t>(0);
     }
   };
 
@@ -158,7 +158,7 @@ DlVertices::DlVertices(DlVertexMode mode,
       offset += bytes;
       return ret;
     } else {
-      return size_t(0);
+      return static_cast<size_t>(0);
     }
   };
 

--- a/impeller/renderer/backend/gles/shader_library_gles.cc
+++ b/impeller/renderer/backend/gles/shader_library_gles.cc
@@ -52,7 +52,8 @@ static std::string GLESShaderNameToShaderKeyName(const std::string& name,
 }
 
 ShaderLibraryGLES::ShaderLibraryGLES(
-    std::vector<std::shared_ptr<fml::Mapping>> shader_libraries) {
+    std::vector<std::shared_ptr<fml::Mapping>> shader_libraries)
+    : is_valid_(true) {
   ShaderFunctionMap functions;
   UniqueID library_id;
   auto iterator = [&functions, &library_id](auto type,           //
@@ -81,7 +82,6 @@ ShaderLibraryGLES::ShaderLibraryGLES(
   }
 
   functions_ = functions;
-  is_valid_ = true;
 }
 
 // |ShaderLibrary|

--- a/lib/ui/painting/image_filter.cc
+++ b/lib/ui/painting/image_filter.cc
@@ -40,7 +40,7 @@ fml::RefPtr<ImageFilter> ImageFilter::Create() {
   return fml::MakeRefCounted<ImageFilter>();
 }
 
-static const std::array<SkSamplingOptions, 4> filter_qualities = {
+static const std::array<SkSamplingOptions, 4> kFilterQualities = {
     SkSamplingOptions(SkFilterMode::kNearest, SkMipmapMode::kNone),
     SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone),
     SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kLinear),
@@ -49,12 +49,12 @@ static const std::array<SkSamplingOptions, 4> filter_qualities = {
 
 SkSamplingOptions ImageFilter::SamplingFromIndex(int filterQualityIndex) {
   if (filterQualityIndex < 0) {
-    return filter_qualities.front();
+    return kFilterQualities.front();
   } else if (static_cast<size_t>(filterQualityIndex) >=
-             filter_qualities.size()) {
-    return filter_qualities.back();
+             kFilterQualities.size()) {
+    return kFilterQualities.back();
   } else {
-    return filter_qualities[filterQualityIndex];
+    return kFilterQualities[filterQualityIndex];
   }
 }
 

--- a/lib/ui/painting/paint.cc
+++ b/lib/ui/painting/paint.cc
@@ -55,7 +55,7 @@ constexpr double kStrokeMiterLimitDefault = 4.0;
 
 // A color matrix which inverts colors.
 // clang-format off
-constexpr float invert_colors[20] = {
+constexpr float kInvertColors[20] = {
   -1.0,    0,    0, 1.0, 0,
      0, -1.0,    0, 1.0, 0,
      0,    0, -1.0, 1.0, 0,
@@ -156,7 +156,7 @@ const SkPaint* Paint::paint(SkPaint& paint) const {
   }
 
   if (uint_data[kInvertColorIndex]) {
-    sk_sp<SkColorFilter> invert_filter = SkColorFilters::Matrix(invert_colors);
+    sk_sp<SkColorFilter> invert_filter = SkColorFilters::Matrix(kInvertColors);
     sk_sp<SkColorFilter> current_filter = paint.refColorFilter();
     if (current_filter) {
       invert_filter = invert_filter->makeComposed(current_filter);

--- a/lib/ui/text/paragraph_builder.cc
+++ b/lib/ui/text/paragraph_builder.cc
@@ -32,75 +32,75 @@ namespace {
 
 // TextStyle
 
-const int tsLeadingDistributionIndex = 0;
-const int tsColorIndex = 1;
-const int tsTextDecorationIndex = 2;
-const int tsTextDecorationColorIndex = 3;
-const int tsTextDecorationStyleIndex = 4;
-const int tsFontWeightIndex = 5;
-const int tsFontStyleIndex = 6;
-const int tsTextBaselineIndex = 7;
-const int tsTextDecorationThicknessIndex = 8;
-const int tsFontFamilyIndex = 9;
-const int tsFontSizeIndex = 10;
-const int tsLetterSpacingIndex = 11;
-const int tsWordSpacingIndex = 12;
-const int tsHeightIndex = 13;
-const int tsLocaleIndex = 14;
-const int tsBackgroundIndex = 15;
-const int tsForegroundIndex = 16;
-const int tsTextShadowsIndex = 17;
-const int tsFontFeaturesIndex = 18;
-const int tsFontVariationsIndex = 19;
+const int kTsLeadingDistributionIndex = 0;
+const int kTsColorIndex = 1;
+const int kTsTextDecorationIndex = 2;
+const int kTsTextDecorationColorIndex = 3;
+const int kTsTextDecorationStyleIndex = 4;
+const int kTsFontWeightIndex = 5;
+const int kTsFontStyleIndex = 6;
+const int kTsTextBaselineIndex = 7;
+const int kTsTextDecorationThicknessIndex = 8;
+const int kTsFontFamilyIndex = 9;
+const int kTsFontSizeIndex = 10;
+const int kTsLetterSpacingIndex = 11;
+const int kTsWordSpacingIndex = 12;
+const int kTsHeightIndex = 13;
+const int kTsLocaleIndex = 14;
+const int kTsBackgroundIndex = 15;
+const int kTsForegroundIndex = 16;
+const int kTsTextShadowsIndex = 17;
+const int kTsFontFeaturesIndex = 18;
+const int kTsFontVariationsIndex = 19;
 
-const int tsLeadingDistributionMask = 1 << tsLeadingDistributionIndex;
-const int tsColorMask = 1 << tsColorIndex;
-const int tsTextDecorationMask = 1 << tsTextDecorationIndex;
-const int tsTextDecorationColorMask = 1 << tsTextDecorationColorIndex;
-const int tsTextDecorationStyleMask = 1 << tsTextDecorationStyleIndex;
-const int tsTextDecorationThicknessMask = 1 << tsTextDecorationThicknessIndex;
-const int tsFontWeightMask = 1 << tsFontWeightIndex;
-const int tsFontStyleMask = 1 << tsFontStyleIndex;
-const int tsTextBaselineMask = 1 << tsTextBaselineIndex;
-const int tsFontFamilyMask = 1 << tsFontFamilyIndex;
-const int tsFontSizeMask = 1 << tsFontSizeIndex;
-const int tsLetterSpacingMask = 1 << tsLetterSpacingIndex;
-const int tsWordSpacingMask = 1 << tsWordSpacingIndex;
-const int tsHeightMask = 1 << tsHeightIndex;
-const int tsLocaleMask = 1 << tsLocaleIndex;
-const int tsBackgroundMask = 1 << tsBackgroundIndex;
-const int tsForegroundMask = 1 << tsForegroundIndex;
-const int tsTextShadowsMask = 1 << tsTextShadowsIndex;
-const int tsFontFeaturesMask = 1 << tsFontFeaturesIndex;
-const int tsFontVariationsMask = 1 << tsFontVariationsIndex;
+const int kTsLeadingDistributionMask = 1 << kTsLeadingDistributionIndex;
+const int kTsColorMask = 1 << kTsColorIndex;
+const int kTsTextDecorationMask = 1 << kTsTextDecorationIndex;
+const int kTsTextDecorationColorMask = 1 << kTsTextDecorationColorIndex;
+const int kTsTextDecorationStyleMask = 1 << kTsTextDecorationStyleIndex;
+const int kTsTextDecorationThicknessMask = 1 << kTsTextDecorationThicknessIndex;
+const int kTsFontWeightMask = 1 << kTsFontWeightIndex;
+const int kTsFontStyleMask = 1 << kTsFontStyleIndex;
+const int kTsTextBaselineMask = 1 << kTsTextBaselineIndex;
+const int kTsFontFamilyMask = 1 << kTsFontFamilyIndex;
+const int kTsFontSizeMask = 1 << kTsFontSizeIndex;
+const int kTsLetterSpacingMask = 1 << kTsLetterSpacingIndex;
+const int kTsWordSpacingMask = 1 << kTsWordSpacingIndex;
+const int kTsHeightMask = 1 << kTsHeightIndex;
+const int kTsLocaleMask = 1 << kTsLocaleIndex;
+const int kTsBackgroundMask = 1 << kTsBackgroundIndex;
+const int kTsForegroundMask = 1 << kTsForegroundIndex;
+const int kTsTextShadowsMask = 1 << kTsTextShadowsIndex;
+const int kTsFontFeaturesMask = 1 << kTsFontFeaturesIndex;
+const int kTsFontVariationsMask = 1 << kTsFontVariationsIndex;
 
 // ParagraphStyle
 
-const int psTextAlignIndex = 1;
-const int psTextDirectionIndex = 2;
-const int psFontWeightIndex = 3;
-const int psFontStyleIndex = 4;
-const int psMaxLinesIndex = 5;
-const int psTextHeightBehaviorIndex = 6;
-const int psFontFamilyIndex = 7;
-const int psFontSizeIndex = 8;
-const int psHeightIndex = 9;
-const int psStrutStyleIndex = 10;
-const int psEllipsisIndex = 11;
-const int psLocaleIndex = 12;
+const int kPsTextAlignIndex = 1;
+const int kPsTextDirectionIndex = 2;
+const int kPsFontWeightIndex = 3;
+const int kPsFontStyleIndex = 4;
+const int kPsMaxLinesIndex = 5;
+const int kPsTextHeightBehaviorIndex = 6;
+const int kPsFontFamilyIndex = 7;
+const int kPsFontSizeIndex = 8;
+const int kPsHeightIndex = 9;
+const int kPsStrutStyleIndex = 10;
+const int kPsEllipsisIndex = 11;
+const int kPsLocaleIndex = 12;
 
-const int psTextAlignMask = 1 << psTextAlignIndex;
-const int psTextDirectionMask = 1 << psTextDirectionIndex;
-const int psFontWeightMask = 1 << psFontWeightIndex;
-const int psFontStyleMask = 1 << psFontStyleIndex;
-const int psMaxLinesMask = 1 << psMaxLinesIndex;
-const int psFontFamilyMask = 1 << psFontFamilyIndex;
-const int psFontSizeMask = 1 << psFontSizeIndex;
-const int psHeightMask = 1 << psHeightIndex;
-const int psTextHeightBehaviorMask = 1 << psTextHeightBehaviorIndex;
-const int psStrutStyleMask = 1 << psStrutStyleIndex;
-const int psEllipsisMask = 1 << psEllipsisIndex;
-const int psLocaleMask = 1 << psLocaleIndex;
+const int kPsTextAlignMask = 1 << kPsTextAlignIndex;
+const int kPsTextDirectionMask = 1 << kPsTextDirectionIndex;
+const int kPsFontWeightMask = 1 << kPsFontWeightIndex;
+const int kPsFontStyleMask = 1 << kPsFontStyleIndex;
+const int kPsMaxLinesMask = 1 << kPsMaxLinesIndex;
+const int kPsFontFamilyMask = 1 << kPsFontFamilyIndex;
+const int kPsFontSizeMask = 1 << kPsFontSizeIndex;
+const int kPsHeightMask = 1 << kPsHeightIndex;
+const int kPsTextHeightBehaviorMask = 1 << kPsTextHeightBehaviorIndex;
+const int kPsStrutStyleMask = 1 << kPsStrutStyleIndex;
+const int kPsEllipsisMask = 1 << kPsEllipsisIndex;
+const int kPsLocaleMask = 1 << kPsLocaleIndex;
 
 // TextShadows decoding
 
@@ -121,23 +121,23 @@ constexpr uint32_t kBytesPerFontVariation = 8;
 constexpr uint32_t kFontVariationTagLength = 4;
 
 // Strut decoding
-const int sFontWeightIndex = 0;
-const int sFontStyleIndex = 1;
-const int sFontFamilyIndex = 2;
-const int sLeadingDistributionIndex = 3;
-const int sFontSizeIndex = 4;
-const int sHeightIndex = 5;
-const int sLeadingIndex = 6;
-const int sForceStrutHeightIndex = 7;
+const int kSFontWeightIndex = 0;
+const int kSFontStyleIndex = 1;
+const int kSFontFamilyIndex = 2;
+const int kSLeadingDistributionIndex = 3;
+const int kSFontSizeIndex = 4;
+const int kSHeightIndex = 5;
+const int kSLeadingIndex = 6;
+const int kSForceStrutHeightIndex = 7;
 
-const int sFontWeightMask = 1 << sFontWeightIndex;
-const int sFontStyleMask = 1 << sFontStyleIndex;
-const int sFontFamilyMask = 1 << sFontFamilyIndex;
-const int sLeadingDistributionMask = 1 << sLeadingDistributionIndex;
-const int sFontSizeMask = 1 << sFontSizeIndex;
-const int sHeightMask = 1 << sHeightIndex;
-const int sLeadingMask = 1 << sLeadingIndex;
-const int sForceStrutHeightMask = 1 << sForceStrutHeightIndex;
+const int kSFontWeightMask = 1 << kSFontWeightIndex;
+const int kSFontStyleMask = 1 << kSFontStyleIndex;
+const int kSFontFamilyMask = 1 << kSFontFamilyIndex;
+const int kSLeadingDistributionMask = 1 << kSLeadingDistributionIndex;
+const int kSFontSizeMask = 1 << kSFontSizeIndex;
+const int kSHeightMask = 1 << kSHeightIndex;
+const int kSLeadingMask = 1 << kSLeadingIndex;
+const int kSForceStrutHeightMask = 1 << kSForceStrutHeightIndex;
 
 }  // namespace
 
@@ -199,16 +199,16 @@ void decodeStrut(Dart_Handle strut_data,
   // any 32 bit ints. In addition, the order of decoding is the same order
   // as it is encoded, and the order is used to maintain consistency.
   size_t byte_count = 1;
-  if (mask & sFontWeightMask) {
+  if (mask & kSFontWeightMask) {
     paragraph_style.strut_font_weight =
         static_cast<txt::FontWeight>(uint8_data[byte_count++]);
   }
-  if (mask & sFontStyleMask) {
+  if (mask & kSFontStyleMask) {
     paragraph_style.strut_font_style =
         static_cast<txt::FontStyle>(uint8_data[byte_count++]);
   }
 
-  paragraph_style.strut_half_leading = mask & sLeadingDistributionMask;
+  paragraph_style.strut_half_leading = mask & kSLeadingDistributionMask;
 
   std::vector<float> float_data;
   float_data.resize((byte_data.length_in_bytes() - byte_count) / 4);
@@ -216,22 +216,22 @@ void decodeStrut(Dart_Handle strut_data,
          static_cast<const char*>(byte_data.data()) + byte_count,
          byte_data.length_in_bytes() - byte_count);
   size_t float_count = 0;
-  if (mask & sFontSizeMask) {
+  if (mask & kSFontSizeMask) {
     paragraph_style.strut_font_size = float_data[float_count++];
   }
-  if (mask & sHeightMask) {
+  if (mask & kSHeightMask) {
     paragraph_style.strut_height = float_data[float_count++];
     paragraph_style.strut_has_height_override = true;
   }
-  if (mask & sLeadingMask) {
+  if (mask & kSLeadingMask) {
     paragraph_style.strut_leading = float_data[float_count++];
   }
 
   // The boolean is stored as the last bit in the bitmask, as null
   // and false have the same behavior.
-  paragraph_style.force_strut_height = mask & sForceStrutHeightMask;
+  paragraph_style.force_strut_height = mask & kSForceStrutHeightMask;
 
-  if (mask & sFontFamilyMask) {
+  if (mask & kSFontFamilyMask) {
     paragraph_style.strut_font_families = strut_font_families;
   } else {
     // Provide an empty font name so that the platform default font will be
@@ -252,53 +252,54 @@ ParagraphBuilder::ParagraphBuilder(
   int32_t mask = encoded[0];
   txt::ParagraphStyle style;
 
-  if (mask & psTextAlignMask) {
-    style.text_align = txt::TextAlign(encoded[psTextAlignIndex]);
+  if (mask & kPsTextAlignMask) {
+    style.text_align = static_cast<txt::TextAlign>(encoded[kPsTextAlignIndex]);
   }
 
-  if (mask & psTextDirectionMask) {
-    style.text_direction = txt::TextDirection(encoded[psTextDirectionIndex]);
+  if (mask & kPsTextDirectionMask) {
+    style.text_direction =
+        static_cast<txt::TextDirection>(encoded[kPsTextDirectionIndex]);
   }
 
-  if (mask & psFontWeightMask) {
+  if (mask & kPsFontWeightMask) {
     style.font_weight =
-        static_cast<txt::FontWeight>(encoded[psFontWeightIndex]);
+        static_cast<txt::FontWeight>(encoded[kPsFontWeightIndex]);
   }
 
-  if (mask & psFontStyleMask) {
-    style.font_style = static_cast<txt::FontStyle>(encoded[psFontStyleIndex]);
+  if (mask & kPsFontStyleMask) {
+    style.font_style = static_cast<txt::FontStyle>(encoded[kPsFontStyleIndex]);
   }
 
-  if (mask & psFontFamilyMask) {
+  if (mask & kPsFontFamilyMask) {
     style.font_family = fontFamily;
   }
 
-  if (mask & psFontSizeMask) {
+  if (mask & kPsFontSizeMask) {
     style.font_size = fontSize;
   }
 
-  if (mask & psHeightMask) {
+  if (mask & kPsHeightMask) {
     style.height = height;
     style.has_height_override = true;
   }
 
-  if (mask & psTextHeightBehaviorMask) {
-    style.text_height_behavior = encoded[psTextHeightBehaviorIndex];
+  if (mask & kPsTextHeightBehaviorMask) {
+    style.text_height_behavior = encoded[kPsTextHeightBehaviorIndex];
   }
 
-  if (mask & psStrutStyleMask) {
+  if (mask & kPsStrutStyleMask) {
     decodeStrut(strutData, strutFontFamilies, style);
   }
 
-  if (mask & psMaxLinesMask) {
-    style.max_lines = encoded[psMaxLinesIndex];
+  if (mask & kPsMaxLinesMask) {
+    style.max_lines = encoded[kPsMaxLinesIndex];
   }
 
-  if (mask & psEllipsisMask) {
+  if (mask & kPsEllipsisMask) {
     style.ellipsis = ellipsis;
   }
 
-  if (mask & psLocaleMask) {
+  if (mask & kPsLocaleMask) {
     style.locale = locale;
   }
 
@@ -412,70 +413,71 @@ void ParagraphBuilder::pushStyle(tonic::Int32List& encoded,
   // explicitly given.
   txt::TextStyle style = m_paragraphBuilder->PeekStyle();
 
-  style.half_leading = mask & tsLeadingDistributionMask;
+  style.half_leading = mask & kTsLeadingDistributionMask;
   // Only change the style property from the previous value if a new explicitly
   // set value is available
-  if (mask & tsColorMask) {
-    style.color = encoded[tsColorIndex];
+  if (mask & kTsColorMask) {
+    style.color = encoded[kTsColorIndex];
   }
 
-  if (mask & tsTextDecorationMask) {
+  if (mask & kTsTextDecorationMask) {
     style.decoration =
-        static_cast<txt::TextDecoration>(encoded[tsTextDecorationIndex]);
+        static_cast<txt::TextDecoration>(encoded[kTsTextDecorationIndex]);
   }
 
-  if (mask & tsTextDecorationColorMask) {
-    style.decoration_color = encoded[tsTextDecorationColorIndex];
+  if (mask & kTsTextDecorationColorMask) {
+    style.decoration_color = encoded[kTsTextDecorationColorIndex];
   }
 
-  if (mask & tsTextDecorationStyleMask) {
+  if (mask & kTsTextDecorationStyleMask) {
     style.decoration_style = static_cast<txt::TextDecorationStyle>(
-        encoded[tsTextDecorationStyleIndex]);
+        encoded[kTsTextDecorationStyleIndex]);
   }
 
-  if (mask & tsTextDecorationThicknessMask) {
+  if (mask & kTsTextDecorationThicknessMask) {
     style.decoration_thickness_multiplier = decorationThickness;
   }
 
-  if (mask & tsTextBaselineMask) {
+  if (mask & kTsTextBaselineMask) {
     // TODO(abarth): Implement TextBaseline. The CSS version of this
     // property wasn't wired up either.
   }
 
-  if (mask & (tsFontWeightMask | tsFontStyleMask | tsFontSizeMask |
-              tsLetterSpacingMask | tsWordSpacingMask)) {
-    if (mask & tsFontWeightMask) {
+  if (mask & (kTsFontWeightMask | kTsFontStyleMask | kTsFontSizeMask |
+              kTsLetterSpacingMask | kTsWordSpacingMask)) {
+    if (mask & kTsFontWeightMask) {
       style.font_weight =
-          static_cast<txt::FontWeight>(encoded[tsFontWeightIndex]);
+          static_cast<txt::FontWeight>(encoded[kTsFontWeightIndex]);
     }
 
-    if (mask & tsFontStyleMask) {
-      style.font_style = static_cast<txt::FontStyle>(encoded[tsFontStyleIndex]);
+    if (mask & kTsFontStyleMask) {
+      style.font_style =
+          static_cast<txt::FontStyle>(encoded[kTsFontStyleIndex]);
     }
 
-    if (mask & tsFontSizeMask) {
+    if (mask & kTsFontSizeMask) {
       style.font_size = fontSize;
     }
 
-    if (mask & tsLetterSpacingMask) {
+    if (mask & kTsLetterSpacingMask) {
       style.letter_spacing = letterSpacing;
     }
 
-    if (mask & tsWordSpacingMask) {
+    if (mask & kTsWordSpacingMask) {
       style.word_spacing = wordSpacing;
     }
   }
 
-  if (mask & tsHeightMask) {
+  if (mask & kTsHeightMask) {
     style.height = height;
     style.has_height_override = true;
   }
 
-  if (mask & tsLocaleMask) {
+  if (mask & kTsLocaleMask) {
     style.locale = locale;
   }
 
-  if (mask & tsBackgroundMask) {
+  if (mask & kTsBackgroundMask) {
     Paint background(background_objects, background_data);
     if (background.isNotNull()) {
       SkPaint sk_paint;
@@ -484,7 +486,7 @@ void ParagraphBuilder::pushStyle(tonic::Int32List& encoded,
     }
   }
 
-  if (mask & tsForegroundMask) {
+  if (mask & kTsForegroundMask) {
     Paint foreground(foreground_objects, foreground_data);
     if (foreground.isNotNull()) {
       SkPaint sk_paint;
@@ -493,22 +495,22 @@ void ParagraphBuilder::pushStyle(tonic::Int32List& encoded,
     }
   }
 
-  if (mask & tsTextShadowsMask) {
+  if (mask & kTsTextShadowsMask) {
     decodeTextShadows(shadows_data, style.text_shadows);
   }
 
-  if (mask & tsFontFamilyMask) {
+  if (mask & kTsFontFamilyMask) {
     // The child style's font families override the parent's font families.
     // If the child's fonts are not available, then the font collection will
     // use the system fallback fonts (not the parent's fonts).
     style.font_families = fontFamilies;
   }
 
-  if (mask & tsFontFeaturesMask) {
+  if (mask & kTsFontFeaturesMask) {
     decodeFontFeatures(font_features_data, style.font_features);
   }
 
-  if (mask & tsFontVariationsMask) {
+  if (mask & kTsFontVariationsMask) {
     decodeFontVariations(font_variations_data, style.font_variations);
   }
 

--- a/lib/ui/text/paragraph_builder.cc
+++ b/lib/ui/text/paragraph_builder.cc
@@ -32,75 +32,75 @@ namespace {
 
 // TextStyle
 
-const int kTsLeadingDistributionIndex = 0;
-const int kTsColorIndex = 1;
-const int kTsTextDecorationIndex = 2;
-const int kTsTextDecorationColorIndex = 3;
-const int kTsTextDecorationStyleIndex = 4;
-const int kTsFontWeightIndex = 5;
-const int kTsFontStyleIndex = 6;
-const int kTsTextBaselineIndex = 7;
-const int kTsTextDecorationThicknessIndex = 8;
-const int kTsFontFamilyIndex = 9;
-const int kTsFontSizeIndex = 10;
-const int kTsLetterSpacingIndex = 11;
-const int kTsWordSpacingIndex = 12;
-const int kTsHeightIndex = 13;
-const int kTsLocaleIndex = 14;
-const int kTsBackgroundIndex = 15;
-const int kTsForegroundIndex = 16;
-const int kTsTextShadowsIndex = 17;
-const int kTsFontFeaturesIndex = 18;
-const int kTsFontVariationsIndex = 19;
+const int kTSLeadingDistributionIndex = 0;
+const int kTSColorIndex = 1;
+const int kTSTextDecorationIndex = 2;
+const int kTSTextDecorationColorIndex = 3;
+const int kTSTextDecorationStyleIndex = 4;
+const int kTSFontWeightIndex = 5;
+const int kTSFontStyleIndex = 6;
+const int kTSTextBaselineIndex = 7;
+const int kTSTextDecorationThicknessIndex = 8;
+const int kTSFontFamilyIndex = 9;
+const int kTSFontSizeIndex = 10;
+const int kTSLetterSpacingIndex = 11;
+const int kTSWordSpacingIndex = 12;
+const int kTSHeightIndex = 13;
+const int kTSLocaleIndex = 14;
+const int kTSBackgroundIndex = 15;
+const int kTSForegroundIndex = 16;
+const int kTSTextShadowsIndex = 17;
+const int kTSFontFeaturesIndex = 18;
+const int kTSFontVariationsIndex = 19;
 
-const int kTsLeadingDistributionMask = 1 << kTsLeadingDistributionIndex;
-const int kTsColorMask = 1 << kTsColorIndex;
-const int kTsTextDecorationMask = 1 << kTsTextDecorationIndex;
-const int kTsTextDecorationColorMask = 1 << kTsTextDecorationColorIndex;
-const int kTsTextDecorationStyleMask = 1 << kTsTextDecorationStyleIndex;
-const int kTsTextDecorationThicknessMask = 1 << kTsTextDecorationThicknessIndex;
-const int kTsFontWeightMask = 1 << kTsFontWeightIndex;
-const int kTsFontStyleMask = 1 << kTsFontStyleIndex;
-const int kTsTextBaselineMask = 1 << kTsTextBaselineIndex;
-const int kTsFontFamilyMask = 1 << kTsFontFamilyIndex;
-const int kTsFontSizeMask = 1 << kTsFontSizeIndex;
-const int kTsLetterSpacingMask = 1 << kTsLetterSpacingIndex;
-const int kTsWordSpacingMask = 1 << kTsWordSpacingIndex;
-const int kTsHeightMask = 1 << kTsHeightIndex;
-const int kTsLocaleMask = 1 << kTsLocaleIndex;
-const int kTsBackgroundMask = 1 << kTsBackgroundIndex;
-const int kTsForegroundMask = 1 << kTsForegroundIndex;
-const int kTsTextShadowsMask = 1 << kTsTextShadowsIndex;
-const int kTsFontFeaturesMask = 1 << kTsFontFeaturesIndex;
-const int kTsFontVariationsMask = 1 << kTsFontVariationsIndex;
+const int kTSLeadingDistributionMask = 1 << kTSLeadingDistributionIndex;
+const int kTSColorMask = 1 << kTSColorIndex;
+const int kTSTextDecorationMask = 1 << kTSTextDecorationIndex;
+const int kTSTextDecorationColorMask = 1 << kTSTextDecorationColorIndex;
+const int kTSTextDecorationStyleMask = 1 << kTSTextDecorationStyleIndex;
+const int kTSTextDecorationThicknessMask = 1 << kTSTextDecorationThicknessIndex;
+const int kTSFontWeightMask = 1 << kTSFontWeightIndex;
+const int kTSFontStyleMask = 1 << kTSFontStyleIndex;
+const int kTSTextBaselineMask = 1 << kTSTextBaselineIndex;
+const int kTSFontFamilyMask = 1 << kTSFontFamilyIndex;
+const int kTSFontSizeMask = 1 << kTSFontSizeIndex;
+const int kTSLetterSpacingMask = 1 << kTSLetterSpacingIndex;
+const int kTSWordSpacingMask = 1 << kTSWordSpacingIndex;
+const int kTSHeightMask = 1 << kTSHeightIndex;
+const int kTSLocaleMask = 1 << kTSLocaleIndex;
+const int kTSBackgroundMask = 1 << kTSBackgroundIndex;
+const int kTSForegroundMask = 1 << kTSForegroundIndex;
+const int kTSTextShadowsMask = 1 << kTSTextShadowsIndex;
+const int kTSFontFeaturesMask = 1 << kTSFontFeaturesIndex;
+const int kTSFontVariationsMask = 1 << kTSFontVariationsIndex;
 
 // ParagraphStyle
 
-const int kPsTextAlignIndex = 1;
-const int kPsTextDirectionIndex = 2;
-const int kPsFontWeightIndex = 3;
-const int kPsFontStyleIndex = 4;
-const int kPsMaxLinesIndex = 5;
-const int kPsTextHeightBehaviorIndex = 6;
-const int kPsFontFamilyIndex = 7;
-const int kPsFontSizeIndex = 8;
-const int kPsHeightIndex = 9;
-const int kPsStrutStyleIndex = 10;
-const int kPsEllipsisIndex = 11;
-const int kPsLocaleIndex = 12;
+const int kPSTextAlignIndex = 1;
+const int kPSTextDirectionIndex = 2;
+const int kPSFontWeightIndex = 3;
+const int kPSFontStyleIndex = 4;
+const int kPSMaxLinesIndex = 5;
+const int kPSTextHeightBehaviorIndex = 6;
+const int kPSFontFamilyIndex = 7;
+const int kPSFontSizeIndex = 8;
+const int kPSHeightIndex = 9;
+const int kPSStrutStyleIndex = 10;
+const int kPSEllipsisIndex = 11;
+const int kPSLocaleIndex = 12;
 
-const int kPsTextAlignMask = 1 << kPsTextAlignIndex;
-const int kPsTextDirectionMask = 1 << kPsTextDirectionIndex;
-const int kPsFontWeightMask = 1 << kPsFontWeightIndex;
-const int kPsFontStyleMask = 1 << kPsFontStyleIndex;
-const int kPsMaxLinesMask = 1 << kPsMaxLinesIndex;
-const int kPsFontFamilyMask = 1 << kPsFontFamilyIndex;
-const int kPsFontSizeMask = 1 << kPsFontSizeIndex;
-const int kPsHeightMask = 1 << kPsHeightIndex;
-const int kPsTextHeightBehaviorMask = 1 << kPsTextHeightBehaviorIndex;
-const int kPsStrutStyleMask = 1 << kPsStrutStyleIndex;
-const int kPsEllipsisMask = 1 << kPsEllipsisIndex;
-const int kPsLocaleMask = 1 << kPsLocaleIndex;
+const int kPSTextAlignMask = 1 << kPSTextAlignIndex;
+const int kPSTextDirectionMask = 1 << kPSTextDirectionIndex;
+const int kPSFontWeightMask = 1 << kPSFontWeightIndex;
+const int kPSFontStyleMask = 1 << kPSFontStyleIndex;
+const int kPSMaxLinesMask = 1 << kPSMaxLinesIndex;
+const int kPSFontFamilyMask = 1 << kPSFontFamilyIndex;
+const int kPSFontSizeMask = 1 << kPSFontSizeIndex;
+const int kPSHeightMask = 1 << kPSHeightIndex;
+const int kPSTextHeightBehaviorMask = 1 << kPSTextHeightBehaviorIndex;
+const int kPSStrutStyleMask = 1 << kPSStrutStyleIndex;
+const int kPSEllipsisMask = 1 << kPSEllipsisIndex;
+const int kPSLocaleMask = 1 << kPSLocaleIndex;
 
 // TextShadows decoding
 
@@ -252,54 +252,54 @@ ParagraphBuilder::ParagraphBuilder(
   int32_t mask = encoded[0];
   txt::ParagraphStyle style;
 
-  if (mask & kPsTextAlignMask) {
-    style.text_align = static_cast<txt::TextAlign>(encoded[kPsTextAlignIndex]);
+  if (mask & kPSTextAlignMask) {
+    style.text_align = static_cast<txt::TextAlign>(encoded[kPSTextAlignIndex]);
   }
 
-  if (mask & kPsTextDirectionMask) {
+  if (mask & kPSTextDirectionMask) {
     style.text_direction =
-        static_cast<txt::TextDirection>(encoded[kPsTextDirectionIndex]);
+        static_cast<txt::TextDirection>(encoded[kPSTextDirectionIndex]);
   }
 
-  if (mask & kPsFontWeightMask) {
+  if (mask & kPSFontWeightMask) {
     style.font_weight =
-        static_cast<txt::FontWeight>(encoded[kPsFontWeightIndex]);
+        static_cast<txt::FontWeight>(encoded[kPSFontWeightIndex]);
   }
 
-  if (mask & kPsFontStyleMask) {
-    style.font_style = static_cast<txt::FontStyle>(encoded[kPsFontStyleIndex]);
+  if (mask & kPSFontStyleMask) {
+    style.font_style = static_cast<txt::FontStyle>(encoded[kPSFontStyleIndex]);
   }
 
-  if (mask & kPsFontFamilyMask) {
+  if (mask & kPSFontFamilyMask) {
     style.font_family = fontFamily;
   }
 
-  if (mask & kPsFontSizeMask) {
+  if (mask & kPSFontSizeMask) {
     style.font_size = fontSize;
   }
 
-  if (mask & kPsHeightMask) {
+  if (mask & kPSHeightMask) {
     style.height = height;
     style.has_height_override = true;
   }
 
-  if (mask & kPsTextHeightBehaviorMask) {
-    style.text_height_behavior = encoded[kPsTextHeightBehaviorIndex];
+  if (mask & kPSTextHeightBehaviorMask) {
+    style.text_height_behavior = encoded[kPSTextHeightBehaviorIndex];
   }
 
-  if (mask & kPsStrutStyleMask) {
+  if (mask & kPSStrutStyleMask) {
     decodeStrut(strutData, strutFontFamilies, style);
   }
 
-  if (mask & kPsMaxLinesMask) {
-    style.max_lines = encoded[kPsMaxLinesIndex];
+  if (mask & kPSMaxLinesMask) {
+    style.max_lines = encoded[kPSMaxLinesIndex];
   }
 
-  if (mask & kPsEllipsisMask) {
+  if (mask & kPSEllipsisMask) {
     style.ellipsis = ellipsis;
   }
 
-  if (mask & kPsLocaleMask) {
+  if (mask & kPSLocaleMask) {
     style.locale = locale;
   }
 
@@ -413,71 +413,71 @@ void ParagraphBuilder::pushStyle(tonic::Int32List& encoded,
   // explicitly given.
   txt::TextStyle style = m_paragraphBuilder->PeekStyle();
 
-  style.half_leading = mask & kTsLeadingDistributionMask;
+  style.half_leading = mask & kTSLeadingDistributionMask;
   // Only change the style property from the previous value if a new explicitly
   // set value is available
-  if (mask & kTsColorMask) {
-    style.color = encoded[kTsColorIndex];
+  if (mask & kTSColorMask) {
+    style.color = encoded[kTSColorIndex];
   }
 
-  if (mask & kTsTextDecorationMask) {
+  if (mask & kTSTextDecorationMask) {
     style.decoration =
-        static_cast<txt::TextDecoration>(encoded[kTsTextDecorationIndex]);
+        static_cast<txt::TextDecoration>(encoded[kTSTextDecorationIndex]);
   }
 
-  if (mask & kTsTextDecorationColorMask) {
-    style.decoration_color = encoded[kTsTextDecorationColorIndex];
+  if (mask & kTSTextDecorationColorMask) {
+    style.decoration_color = encoded[kTSTextDecorationColorIndex];
   }
 
-  if (mask & kTsTextDecorationStyleMask) {
+  if (mask & kTSTextDecorationStyleMask) {
     style.decoration_style = static_cast<txt::TextDecorationStyle>(
-        encoded[kTsTextDecorationStyleIndex]);
+        encoded[kTSTextDecorationStyleIndex]);
   }
 
-  if (mask & kTsTextDecorationThicknessMask) {
+  if (mask & kTSTextDecorationThicknessMask) {
     style.decoration_thickness_multiplier = decorationThickness;
   }
 
-  if (mask & kTsTextBaselineMask) {
+  if (mask & kTSTextBaselineMask) {
     // TODO(abarth): Implement TextBaseline. The CSS version of this
     // property wasn't wired up either.
   }
 
-  if (mask & (kTsFontWeightMask | kTsFontStyleMask | kTsFontSizeMask |
-              kTsLetterSpacingMask | kTsWordSpacingMask)) {
-    if (mask & kTsFontWeightMask) {
+  if (mask & (kTSFontWeightMask | kTSFontStyleMask | kTSFontSizeMask |
+              kTSLetterSpacingMask | kTSWordSpacingMask)) {
+    if (mask & kTSFontWeightMask) {
       style.font_weight =
-          static_cast<txt::FontWeight>(encoded[kTsFontWeightIndex]);
+          static_cast<txt::FontWeight>(encoded[kTSFontWeightIndex]);
     }
 
-    if (mask & kTsFontStyleMask) {
+    if (mask & kTSFontStyleMask) {
       style.font_style =
-          static_cast<txt::FontStyle>(encoded[kTsFontStyleIndex]);
+          static_cast<txt::FontStyle>(encoded[kTSFontStyleIndex]);
     }
 
-    if (mask & kTsFontSizeMask) {
+    if (mask & kTSFontSizeMask) {
       style.font_size = fontSize;
     }
 
-    if (mask & kTsLetterSpacingMask) {
+    if (mask & kTSLetterSpacingMask) {
       style.letter_spacing = letterSpacing;
     }
 
-    if (mask & kTsWordSpacingMask) {
+    if (mask & kTSWordSpacingMask) {
       style.word_spacing = wordSpacing;
     }
   }
 
-  if (mask & kTsHeightMask) {
+  if (mask & kTSHeightMask) {
     style.height = height;
     style.has_height_override = true;
   }
 
-  if (mask & kTsLocaleMask) {
+  if (mask & kTSLocaleMask) {
     style.locale = locale;
   }
 
-  if (mask & kTsBackgroundMask) {
+  if (mask & kTSBackgroundMask) {
     Paint background(background_objects, background_data);
     if (background.isNotNull()) {
       SkPaint sk_paint;
@@ -486,7 +486,7 @@ void ParagraphBuilder::pushStyle(tonic::Int32List& encoded,
     }
   }
 
-  if (mask & kTsForegroundMask) {
+  if (mask & kTSForegroundMask) {
     Paint foreground(foreground_objects, foreground_data);
     if (foreground.isNotNull()) {
       SkPaint sk_paint;
@@ -495,22 +495,22 @@ void ParagraphBuilder::pushStyle(tonic::Int32List& encoded,
     }
   }
 
-  if (mask & kTsTextShadowsMask) {
+  if (mask & kTSTextShadowsMask) {
     decodeTextShadows(shadows_data, style.text_shadows);
   }
 
-  if (mask & kTsFontFamilyMask) {
+  if (mask & kTSFontFamilyMask) {
     // The child style's font families override the parent's font families.
     // If the child's fonts are not available, then the font collection will
     // use the system fallback fonts (not the parent's fonts).
     style.font_families = fontFamilies;
   }
 
-  if (mask & kTsFontFeaturesMask) {
+  if (mask & kTSFontFeaturesMask) {
     decodeFontFeatures(font_features_data, style.font_features);
   }
 
-  if (mask & kTsFontVariationsMask) {
+  if (mask & kTSFontVariationsMask) {
     decodeFontVariations(font_variations_data, style.font_variations);
   }
 

--- a/runtime/dart_plugin_registrant_unittests.cc
+++ b/runtime/dart_plugin_registrant_unittests.cc
@@ -19,12 +19,12 @@
 namespace flutter {
 namespace testing {
 
-const std::string kernel_file_name = "plugin_registrant_kernel_blob.bin";
-const std::string elf_file_name = "plugin_registrant_app_elf_snapshot.so";
+const std::string kKernelFileName = "plugin_registrant_kernel_blob.bin";
+const std::string kElfFileName = "plugin_registrant_app_elf_snapshot.so";
 
 class DartIsolateTest : public FixtureTest {
  public:
-  DartIsolateTest() : FixtureTest(kernel_file_name, elf_file_name, "") {}
+  DartIsolateTest() : FixtureTest(kKernelFileName, kElfFileName, "") {}
 
   void OverrideDartPluginRegistrant(const std::string& override_value) {
     dart_plugin_registrant_library_ = override_value;
@@ -84,7 +84,7 @@ TEST_F(DartIsolateTest, DartPluginRegistrantIsPresent) {
   );
 
   auto kernel_path =
-      fml::paths::JoinPaths({GetFixturesPath(), kernel_file_name});
+      fml::paths::JoinPaths({GetFixturesPath(), kKernelFileName});
   auto isolate =
       RunDartCodeInIsolate(vm_ref, settings, task_runners,
                            "mainForPluginRegistrantTest", {}, kernel_path);
@@ -131,7 +131,7 @@ TEST_F(DartIsolateTest, DartPluginRegistrantFromBackgroundIsolate) {
   );
 
   auto kernel_path =
-      fml::paths::JoinPaths({GetFixturesPath(), kernel_file_name});
+      fml::paths::JoinPaths({GetFixturesPath(), kKernelFileName});
   auto isolate = RunDartCodeInIsolate(
       vm_ref, settings, task_runners,
       "callDartPluginRegistrantFromBackgroundIsolate", {}, kernel_path);
@@ -179,7 +179,7 @@ TEST_F(DartIsolateTest, DartPluginRegistrantNotFromBackgroundIsolate) {
   );
 
   auto kernel_path =
-      fml::paths::JoinPaths({GetFixturesPath(), kernel_file_name});
+      fml::paths::JoinPaths({GetFixturesPath(), kKernelFileName});
   auto isolate = RunDartCodeInIsolate(
       vm_ref, settings, task_runners,
       "dontCallDartPluginRegistrantFromBackgroundIsolate", {}, kernel_path);

--- a/runtime/no_dart_plugin_registrant_unittests.cc
+++ b/runtime/no_dart_plugin_registrant_unittests.cc
@@ -17,12 +17,12 @@
 namespace flutter {
 namespace testing {
 
-const std::string kernel_file_name = "no_plugin_registrant_kernel_blob.bin";
-const std::string elf_file_name = "no_plugin_registrant_app_elf_snapshot.so";
+const std::string kKernelFileName = "no_plugin_registrant_kernel_blob.bin";
+const std::string kElfFileName = "no_plugin_registrant_app_elf_snapshot.so";
 
 class DartIsolateTest : public FixtureTest {
  public:
-  DartIsolateTest() : FixtureTest(kernel_file_name, elf_file_name, "") {}
+  DartIsolateTest() : FixtureTest(kKernelFileName, kElfFileName, "") {}
 };
 
 TEST_F(DartIsolateTest, DartPluginRegistrantIsNotPresent) {
@@ -58,7 +58,7 @@ TEST_F(DartIsolateTest, DartPluginRegistrantIsNotPresent) {
   );
 
   auto kernel_path =
-      fml::paths::JoinPaths({GetFixturesPath(), kernel_file_name});
+      fml::paths::JoinPaths({GetFixturesPath(), kKernelFileName});
   auto isolate = RunDartCodeInIsolate(vm_ref, settings, task_runners, "main",
                                       {}, kernel_path);
 

--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -40,7 +40,7 @@ struct SwitchDesc {
 #if FLUTTER_RELEASE
 
 // clang-format off
-static const std::string gAllowedDartFlags[] = {
+static const std::string kAllowedDartFlags[] = {
     "--enable-isolate-groups",
     "--no-enable-isolate-groups",
     "--lazy_async_stacks",
@@ -50,7 +50,7 @@ static const std::string gAllowedDartFlags[] = {
 #else
 
 // clang-format off
-static const std::string gAllowedDartFlags[] = {
+static const std::string kAllowedDartFlags[] = {
     "--enable-isolate-groups",
     "--no-enable-isolate-groups",
     "--enable_mirrors",
@@ -167,8 +167,8 @@ static std::vector<std::string> ParseCommaDelimited(const std::string& input) {
 }
 
 static bool IsAllowedDartVMFlag(const std::string& flag) {
-  for (uint32_t i = 0; i < fml::size(gAllowedDartFlags); ++i) {
-    const std::string& allowed = gAllowedDartFlags[i];
+  for (uint32_t i = 0; i < fml::size(kAllowedDartFlags); ++i) {
+    const std::string& allowed = kAllowedDartFlags[i];
     // Check that the prefix of the flag matches one of the allowed flags. This
     // is to handle cases where flags take arguments, such as in
     // "--max_profile_depth 1".

--- a/shell/platform/common/client_wrapper/standard_codec.cc
+++ b/shell/platform/common/client_wrapper/standard_codec.cc
@@ -98,7 +98,7 @@ EncodableValue StandardCodecSerializer::ReadValue(
 void StandardCodecSerializer::WriteValue(const EncodableValue& value,
                                          ByteStreamWriter* stream) const {
   stream->WriteByte(static_cast<uint8_t>(EncodedTypeForValue(value)));
-  // TODO: Consider replacing this this with a std::visitor.
+  // TODO(cbracken): Consider replacing this this with std::visit.
   switch (value.index()) {
     case 0:
     case 1:

--- a/shell/platform/common/json_method_codec.cc
+++ b/shell/platform/common/json_method_codec.cc
@@ -66,9 +66,9 @@ JsonMethodCodec::DecodeMethodCallInternal(const uint8_t* message,
 
 std::unique_ptr<std::vector<uint8_t>> JsonMethodCodec::EncodeMethodCallInternal(
     const MethodCall<rapidjson::Document>& method_call) const {
-  // TODO: Consider revisiting the codec APIs to avoid the need to copy
-  // everything when doing encoding (e.g., by having a version that takes
-  // owership of the object to encode, so that it can be moved instead).
+  // TODO(stuartmorgan): Consider revisiting the codec APIs to avoid the need
+  // to copy everything when doing encoding (e.g., by having a version that
+  // takes owership of the object to encode, so that it can be moved instead).
   rapidjson::Document message(rapidjson::kObjectType);
   auto& allocator = message.GetAllocator();
   rapidjson::Value name(method_call.method_name(), allocator);

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -67,10 +67,10 @@ static void IOSPlatformThreadConfigSetter(const fml::Thread::ThreadConfig& confi
   }
 }
 
-NSString* const FlutterDefaultDartEntrypoint = nil;
-NSString* const FlutterDefaultInitialRoute = nil;
-NSString* const FlutterEngineWillDealloc = @"FlutterEngineWillDealloc";
-NSString* const FlutterKeyDataChannel = @"flutter/keydata";
+NSString* const kFlutterDefaultDartEntrypoint = nil;
+NSString* const kFlutterDefaultInitialRoute = nil;
+NSString* const kFlutterEngineWillDealloc = @"FlutterEngineWillDealloc";
+NSString* const kFlutterKeyDataChannel = @"flutter/keydata";
 static constexpr int kNumProfilerSamplesPerSec = 5;
 
 @interface FlutterEngineRegistrar : NSObject <FlutterPluginRegistrar>
@@ -233,7 +233,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
     }
   }];
 
-  [[NSNotificationCenter defaultCenter] postNotificationName:FlutterEngineWillDealloc
+  [[NSNotificationCenter defaultCenter] postNotificationName:kFlutterEngineWillDealloc
                                                       object:self
                                                     userInfo:nil];
 
@@ -352,7 +352,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
     callback(handled, userData);
   };
 
-  [self sendOnChannel:FlutterKeyDataChannel message:message binaryReply:response];
+  [self sendOnChannel:kFlutterKeyDataChannel message:message binaryReply:response];
 }
 
 - (void)ensureSemanticsEnabled {
@@ -794,19 +794,21 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
 }
 
 - (BOOL)run {
-  return [self runWithEntrypoint:FlutterDefaultDartEntrypoint
+  return [self runWithEntrypoint:kFlutterDefaultDartEntrypoint
                       libraryURI:nil
-                    initialRoute:FlutterDefaultInitialRoute];
+                    initialRoute:kFlutterDefaultInitialRoute];
 }
 
 - (BOOL)runWithEntrypoint:(NSString*)entrypoint libraryURI:(NSString*)libraryURI {
   return [self runWithEntrypoint:entrypoint
                       libraryURI:libraryURI
-                    initialRoute:FlutterDefaultInitialRoute];
+                    initialRoute:kFlutterDefaultInitialRoute];
 }
 
 - (BOOL)runWithEntrypoint:(NSString*)entrypoint {
-  return [self runWithEntrypoint:entrypoint libraryURI:nil initialRoute:FlutterDefaultInitialRoute];
+  return [self runWithEntrypoint:entrypoint
+                      libraryURI:nil
+                    initialRoute:kFlutterDefaultInitialRoute];
 }
 
 - (BOOL)runWithEntrypoint:(NSString*)entrypoint initialRoute:(NSString*)initialRoute {

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -67,8 +67,13 @@ static void IOSPlatformThreadConfigSetter(const fml::Thread::ThreadConfig& confi
   }
 }
 
-NSString* const kFlutterDefaultDartEntrypoint = nil;
-NSString* const kFlutterDefaultInitialRoute = nil;
+#pragma mark - Public exported constants
+
+NSString* const FlutterDefaultDartEntrypoint = nil;
+NSString* const FlutterDefaultInitialRoute = nil;
+
+#pragma mark - Internal constants
+
 NSString* const kFlutterEngineWillDealloc = @"FlutterEngineWillDealloc";
 NSString* const kFlutterKeyDataChannel = @"flutter/keydata";
 static constexpr int kNumProfilerSamplesPerSec = 5;
@@ -794,21 +799,19 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
 }
 
 - (BOOL)run {
-  return [self runWithEntrypoint:kFlutterDefaultDartEntrypoint
+  return [self runWithEntrypoint:FlutterDefaultDartEntrypoint
                       libraryURI:nil
-                    initialRoute:kFlutterDefaultInitialRoute];
+                    initialRoute:FlutterDefaultInitialRoute];
 }
 
 - (BOOL)runWithEntrypoint:(NSString*)entrypoint libraryURI:(NSString*)libraryURI {
   return [self runWithEntrypoint:entrypoint
                       libraryURI:libraryURI
-                    initialRoute:kFlutterDefaultInitialRoute];
+                    initialRoute:FlutterDefaultInitialRoute];
 }
 
 - (BOOL)runWithEntrypoint:(NSString*)entrypoint {
-  return [self runWithEntrypoint:entrypoint
-                      libraryURI:nil
-                    initialRoute:kFlutterDefaultInitialRoute];
+  return [self runWithEntrypoint:entrypoint libraryURI:nil initialRoute:FlutterDefaultInitialRoute];
 }
 
 - (BOOL)runWithEntrypoint:(NSString*)entrypoint initialRoute:(NSString*)initialRoute {

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngineGroup.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngineGroup.mm
@@ -86,7 +86,7 @@
   NSNotificationCenter* center = [NSNotificationCenter defaultCenter];
   [center addObserver:self
              selector:@selector(onEngineWillBeDealloced:)
-                 name:FlutterEngineWillDealloc
+                 name:kFlutterEngineWillDealloc
                object:engine];
 
   return engine;

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
@@ -227,7 +227,7 @@ FLUTTER_ASSERT_ARC
   id<NSObject> observer;
   @autoreleasepool {
     FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"foobar"];
-    observer = [center addObserverForName:FlutterEngineWillDealloc
+    observer = [center addObserverForName:kFlutterEngineWillDealloc
                                    object:engine
                                     queue:[NSOperationQueue mainQueue]
                                usingBlock:^(NSNotification* note) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
@@ -29,7 +29,7 @@
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h"
 #import "flutter/shell/platform/darwin/ios/platform_view_ios.h"
 
-extern NSString* _Nonnull const FlutterEngineWillDealloc;
+extern NSString* _Nonnull const kFlutterEngineWillDealloc;
 
 @interface FlutterEngine () <FlutterViewEngineDelegate>
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine_Test.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine_Test.h
@@ -6,7 +6,7 @@
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h"
 #import "flutter/shell/platform/darwin/ios/rendering_api_selection.h"
 
-extern NSString* const FlutterEngineWillDealloc;
+extern NSString* const kFlutterEngineWillDealloc;
 
 @class FlutterBinaryMessengerRelay;
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm
@@ -12,7 +12,7 @@
 
 static const char* kCallbackCacheSubDir = "Library/Caches/";
 
-static const SEL selectorsHandledByPlugins[] = {
+static const SEL kSelectorsHandledByPlugins[] = {
     @selector(application:didReceiveRemoteNotification:fetchCompletionHandler:),
     @selector(application:performFetchWithCompletionHandler:)};
 
@@ -76,7 +76,7 @@ static BOOL IsPowerOfTwo(NSUInteger x) {
 }
 
 - (BOOL)isSelectorAddedDynamically:(SEL)selector {
-  for (const SEL& aSelector : selectorsHandledByPlugins) {
+  for (const SEL& aSelector : kSelectorsHandledByPlugins) {
     if (selector == aSelector) {
       return YES;
     }

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -10,8 +10,8 @@
 #include "flutter/fml/logging.h"
 #include "flutter/fml/platform/darwin/string_range_sanitization.h"
 
-static const char _kTextAffinityDownstream[] = "TextAffinity.downstream";
-static const char _kTextAffinityUpstream[] = "TextAffinity.upstream";
+static const char kTextAffinityDownstream[] = "TextAffinity.downstream";
+static const char kTextAffinityUpstream[] = "TextAffinity.upstream";
 // A delay before enabling the accessibility of FlutterTextInputView after
 // it is activated.
 static constexpr double kUITextInputAccessibilityEnablingDelaySeconds = 0.5;
@@ -744,7 +744,7 @@ static BOOL IsSelectionRectCloserToPoint(CGPoint point,
   if (self) {
     _textInputPlugin = textInputPlugin.weakPtr;
     _textInputClient = 0;
-    _selectionAffinity = _kTextAffinityUpstream;
+    _selectionAffinity = kTextAffinityUpstream;
 
     // UITextInput
     _text = [[NSMutableString alloc] init];
@@ -952,9 +952,9 @@ static BOOL IsSelectionRectCloserToPoint(CGPoint point,
 
     [self setSelectedTextRangeLocal:[FlutterTextRange rangeWithNSRange:selectedRange]];
 
-    _selectionAffinity = _kTextAffinityDownstream;
-    if ([state[@"selectionAffinity"] isEqualToString:@(_kTextAffinityUpstream)]) {
-      _selectionAffinity = _kTextAffinityUpstream;
+    _selectionAffinity = kTextAffinityDownstream;
+    if ([state[@"selectionAffinity"] isEqualToString:@(kTextAffinityUpstream)]) {
+      _selectionAffinity = kTextAffinityUpstream;
     }
     [self.inputDelegate selectionDidChange:self];
   }
@@ -1848,7 +1848,7 @@ static BOOL IsSelectionRectCloserToPoint(CGPoint point,
   [self resetScribbleInteractionStatusIfEnding];
   self.selectionRects = copiedRects;
   [copiedRects release];
-  _selectionAffinity = _kTextAffinityDownstream;
+  _selectionAffinity = kTextAffinityDownstream;
   [self replaceRange:_selectedTextRange withText:text];
 }
 
@@ -1866,7 +1866,7 @@ static BOOL IsSelectionRectCloserToPoint(CGPoint point,
 }
 
 - (void)deleteBackward {
-  _selectionAffinity = _kTextAffinityDownstream;
+  _selectionAffinity = kTextAffinityDownstream;
   _scribbleFocusStatus = FlutterScribbleFocusStatusUnfocused;
   [self resetScribbleInteractionStatusIfEnding];
 

--- a/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.mm
@@ -7,7 +7,7 @@
 #import "flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.h"
 
-static const UIAccessibilityTraits UIAccessibilityTraitUndocumentedEmptyLine = 0x800000000000;
+static const UIAccessibilityTraits kUIAccessibilityTraitUndocumentedEmptyLine = 0x800000000000;
 
 @implementation FlutterInactiveTextInput {
 }
@@ -313,7 +313,7 @@ static const UIAccessibilityTraits UIAccessibilityTraitUndocumentedEmptyLine = 0
   // We remove an undocumented flag to get rid of a bug where single-tapping
   // a text input field incorrectly says "empty line".
   // See also: https://github.com/flutter/flutter/issues/52487
-  return results & (~UIAccessibilityTraitUndocumentedEmptyLine);
+  return results & (~kUIAccessibilityTraitUndocumentedEmptyLine);
 }
 
 #pragma mark - UITextInput overrides

--- a/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegateTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegateTest.mm
@@ -199,4 +199,4 @@ TEST(AccessibilityBridgeMacDelegateTest, doesNotSendAccessibilityCreateNotificat
   [engine shutDownEngine];
 }
 
-}  // flutter::testing
+}  // namespace flutter::testing

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -713,7 +713,7 @@ static flutter::TextRange RangeFromBaseExtent(NSNumber* base,
 }
 
 - (NSUInteger)characterIndexForPoint:(NSPoint)point {
-  // TODO: Implement.
+  // TODO(cbracken): Implement.
   // Note: This function can't easily be implemented under the system-message architecture.
   return 0;
 }

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputSemanticsObject.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputSemanticsObject.mm
@@ -214,4 +214,4 @@ void FlutterTextPlatformNode::EnsureDetachedFromView() {
   [appkit_text_field_ removeFromSuperview];
 }
 
-}
+}  // namespace flutter

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -1201,7 +1201,7 @@ TEST_F(EmbedderTest, InvalidAOTDataSourcesMustReturnError) {
   ASSERT_EQ(FlutterEngineCreateAOTData(&data_in, nullptr), kInvalidArguments);
 
   // Invalid FlutterEngineAOTDataSourceType type specified.
-  data_in.type = FlutterEngineAOTDataSourceType(-1);
+  data_in.type = static_cast<FlutterEngineAOTDataSourceType>(-1);
   ASSERT_EQ(FlutterEngineCreateAOTData(&data_in, &data_out), kInvalidArguments);
   ASSERT_EQ(data_out, nullptr);
 
@@ -1384,8 +1384,9 @@ TEST_F(EmbedderTest, KeyDataIsCorrectlySerialized) {
     echoed_event.type =
         UnserializeKeyEventKind(tonic::DartConverter<uint64_t>::FromDart(
             Dart_GetNativeArgument(args, 0)));
-    echoed_event.timestamp = (double)tonic::DartConverter<uint64_t>::FromDart(
-        Dart_GetNativeArgument(args, 1));
+    echoed_event.timestamp =
+        static_cast<double>(tonic::DartConverter<uint64_t>::FromDart(
+            Dart_GetNativeArgument(args, 1)));
     echoed_event.physical = tonic::DartConverter<uint64_t>::FromDart(
         Dart_GetNativeArgument(args, 2));
     echoed_event.logical = tonic::DartConverter<uint64_t>::FromDart(
@@ -1472,8 +1473,9 @@ TEST_F(EmbedderTest, KeyDataAreBuffered) {
 
   auto native_echo_event = [&](Dart_NativeArguments args) {
     echoed_events.push_back(FlutterKeyEvent{
-        .timestamp = (double)tonic::DartConverter<uint64_t>::FromDart(
-            Dart_GetNativeArgument(args, 1)),
+        .timestamp =
+            static_cast<double>(tonic::DartConverter<uint64_t>::FromDart(
+                Dart_GetNativeArgument(args, 1))),
         .type =
             UnserializeKeyEventKind(tonic::DartConverter<uint64_t>::FromDart(
                 Dart_GetNativeArgument(args, 0))),

--- a/shell/platform/linux/fl_key_embedder_responder.cc
+++ b/shell/platform/linux/fl_key_embedder_responder.cc
@@ -13,7 +13,7 @@
 
 constexpr uint64_t kMicrosecondsPerMillisecond = 1000;
 
-static const FlutterKeyEvent empty_event{
+static const FlutterKeyEvent kEmptyEvent{
     .struct_size = sizeof(FlutterKeyEvent),
     .timestamp = 0,
     .type = kFlutterKeyEventTypeDown,
@@ -791,6 +791,6 @@ static void fl_key_embedder_responder_handle_event(
   fl_key_embedder_responder_handle_event_impl(
       responder, event, specified_logical_key, callback, user_data);
   if (!self->sent_any_events) {
-    self->send_key_event(&empty_event, nullptr, nullptr);
+    self->send_key_event(&kEmptyEvent, nullptr, nullptr);
   }
 }

--- a/shell/platform/linux/fl_pixel_buffer_texture_test.cc
+++ b/shell/platform/linux/fl_pixel_buffer_texture_test.cc
@@ -12,10 +12,10 @@
 
 #include <epoxy/gl.h>
 
-static constexpr uint32_t BUFFER_WIDTH = 4u;
-static constexpr uint32_t BUFFER_HEIGHT = 4u;
-static constexpr uint32_t REAL_BUFFER_WIDTH = 2u;
-static constexpr uint32_t REAL_BUFFER_HEIGHT = 2u;
+static constexpr uint32_t kBufferWidth = 4u;
+static constexpr uint32_t kBufferHeight = 4u;
+static constexpr uint32_t kRealBufferWidth = 2u;
+static constexpr uint32_t kRealBufferHeight = 2u;
 
 G_DECLARE_FINAL_TYPE(FlTestPixelBufferTexture,
                      fl_test_pixel_buffer_texture,
@@ -44,11 +44,11 @@ static gboolean fl_test_pixel_buffer_texture_copy_pixels(
   static const uint8_t buffer[] = {0x0a, 0x1a, 0x2a, 0x3a, 0x4a, 0x5a,
                                    0x6a, 0x7a, 0x8a, 0x9a, 0xaa, 0xba,
                                    0xca, 0xda, 0xea, 0xfa};
-  EXPECT_EQ(*width, BUFFER_WIDTH);
-  EXPECT_EQ(*height, BUFFER_HEIGHT);
+  EXPECT_EQ(*width, kBufferWidth);
+  EXPECT_EQ(*height, kBufferHeight);
   *out_buffer = buffer;
-  *width = REAL_BUFFER_WIDTH;
-  *height = REAL_BUFFER_HEIGHT;
+  *width = kRealBufferWidth;
+  *height = kRealBufferHeight;
 
   return TRUE;
 }
@@ -81,8 +81,8 @@ TEST(FlPixelBufferTextureTest, PopulateTexture) {
   FlutterOpenGLTexture opengl_texture = {0};
   g_autoptr(GError) error = nullptr;
   EXPECT_TRUE(fl_pixel_buffer_texture_populate(
-      texture, BUFFER_WIDTH, BUFFER_HEIGHT, &opengl_texture, &error));
+      texture, kBufferWidth, kBufferHeight, &opengl_texture, &error));
   EXPECT_EQ(error, nullptr);
-  EXPECT_EQ(opengl_texture.width, REAL_BUFFER_WIDTH);
-  EXPECT_EQ(opengl_texture.height, REAL_BUFFER_HEIGHT);
+  EXPECT_EQ(opengl_texture.width, kRealBufferWidth);
+  EXPECT_EQ(opengl_texture.height, kRealBufferHeight);
 }

--- a/shell/platform/linux/fl_settings_portal.cc
+++ b/shell/platform/linux/fl_settings_portal.cc
@@ -9,7 +9,7 @@
 
 static constexpr char kPortalName[] = "org.freedesktop.portal.Desktop";
 static constexpr char kPortalPath[] = "/org/freedesktop/portal/desktop";
-static constexpr char pPortalSettings[] = "org.freedesktop.portal.Settings";
+static constexpr char kPortalSettings[] = "org.freedesktop.portal.Settings";
 
 struct FlSetting {
   const gchar* ns;
@@ -41,7 +41,7 @@ static const FlSetting kTextScalingFactor = {
     G_VARIANT_TYPE_DOUBLE,
 };
 
-static const FlSetting all_settings[] = {
+static const FlSetting kAllSettings[] = {
     kClockFormat,
     kColorScheme,
     kGtkTheme,
@@ -240,13 +240,13 @@ gboolean fl_settings_portal_start(FlSettingsPortal* self, GError** error) {
 
   self->dbus_proxy = g_dbus_proxy_new_for_bus_sync(
       G_BUS_TYPE_SESSION, G_DBUS_PROXY_FLAGS_NONE, nullptr, kPortalName,
-      kPortalPath, pPortalSettings, nullptr, error);
+      kPortalPath, kPortalSettings, nullptr, error);
 
   if (self->dbus_proxy == nullptr) {
     return false;
   }
 
-  for (const FlSetting setting : all_settings) {
+  for (const FlSetting setting : kAllSettings) {
     g_autoptr(GVariant) value = nullptr;
     if (settings_portal_read(self->dbus_proxy, setting.ns, setting.key,
                              &value)) {
@@ -256,7 +256,7 @@ gboolean fl_settings_portal_start(FlSettingsPortal* self, GError** error) {
 
   g_signal_connect_object(self->dbus_proxy, "g-signal",
                           G_CALLBACK(settings_portal_changed_cb), self,
-                          GConnectFlags(0));
+                          static_cast<GConnectFlags>(0));
 
   return true;
 }

--- a/shell/platform/linux/fl_texture_gl_test.cc
+++ b/shell/platform/linux/fl_texture_gl_test.cc
@@ -12,10 +12,10 @@
 
 #include <epoxy/gl.h>
 
-static constexpr uint32_t BUFFER_WIDTH = 4u;
-static constexpr uint32_t BUFFER_HEIGHT = 4u;
-static constexpr uint32_t REAL_BUFFER_WIDTH = 2u;
-static constexpr uint32_t REAL_BUFFER_HEIGHT = 2u;
+static constexpr uint32_t kBufferWidth = 4u;
+static constexpr uint32_t kBufferHeight = 4u;
+static constexpr uint32_t kRealBufferWidth = 2u;
+static constexpr uint32_t kRealBufferHeight = 2u;
 
 G_DECLARE_FINAL_TYPE(FlTestTexture,
                      fl_test_texture,
@@ -38,12 +38,12 @@ static gboolean fl_test_texture_populate(FlTextureGL* texture,
                                          GError** error) {
   EXPECT_TRUE(FL_IS_TEST_TEXTURE(texture));
 
-  EXPECT_EQ(*width, BUFFER_WIDTH);
-  EXPECT_EQ(*height, BUFFER_HEIGHT);
+  EXPECT_EQ(*width, kBufferWidth);
+  EXPECT_EQ(*height, kBufferHeight);
   *target = GL_TEXTURE_2D;
   *name = 1;
-  *width = REAL_BUFFER_WIDTH;
-  *height = REAL_BUFFER_HEIGHT;
+  *width = kRealBufferWidth;
+  *height = kRealBufferHeight;
 
   return TRUE;
 }
@@ -71,9 +71,9 @@ TEST(FlTextureTest, PopulateTexture) {
   g_autoptr(FlTextureGL) texture = FL_TEXTURE_GL(fl_test_texture_new());
   FlutterOpenGLTexture opengl_texture = {0};
   g_autoptr(GError) error = nullptr;
-  EXPECT_TRUE(fl_texture_gl_populate(texture, BUFFER_WIDTH, BUFFER_HEIGHT,
+  EXPECT_TRUE(fl_texture_gl_populate(texture, kBufferWidth, kBufferHeight,
                                      &opengl_texture, &error));
   EXPECT_EQ(error, nullptr);
-  EXPECT_EQ(opengl_texture.width, REAL_BUFFER_WIDTH);
-  EXPECT_EQ(opengl_texture.height, REAL_BUFFER_HEIGHT);
+  EXPECT_EQ(opengl_texture.width, kRealBufferWidth);
+  EXPECT_EQ(opengl_texture.height, kRealBufferHeight);
 }

--- a/shell/platform/linux/fl_texture_registrar_test.cc
+++ b/shell/platform/linux/fl_texture_registrar_test.cc
@@ -15,10 +15,10 @@
 
 #include <gmodule.h>
 
-static constexpr uint32_t BUFFER_WIDTH = 4u;
-static constexpr uint32_t BUFFER_HEIGHT = 4u;
-static constexpr uint32_t REAL_BUFFER_WIDTH = 2u;
-static constexpr uint32_t REAL_BUFFER_HEIGHT = 2u;
+static constexpr uint32_t kBufferWidth = 4u;
+static constexpr uint32_t kBufferHeight = 4u;
+static constexpr uint32_t kRealBufferWidth = 2u;
+static constexpr uint32_t kRealBufferHeight = 2u;
 
 G_DECLARE_FINAL_TYPE(FlTestRegistrarTexture,
                      fl_test_registrar_texture,
@@ -43,12 +43,12 @@ static gboolean fl_test_registrar_texture_populate(FlTextureGL* texture,
                                                    GError** error) {
   EXPECT_TRUE(FL_IS_TEST_REGISTRAR_TEXTURE(texture));
 
-  EXPECT_EQ(*width, BUFFER_WIDTH);
-  EXPECT_EQ(*height, BUFFER_HEIGHT);
+  EXPECT_EQ(*width, kBufferWidth);
+  EXPECT_EQ(*height, kBufferHeight);
   *target = GL_TEXTURE_2D;
   *format = GL_R8;
-  *width = REAL_BUFFER_WIDTH;
-  *height = REAL_BUFFER_HEIGHT;
+  *width = kRealBufferWidth;
+  *height = kRealBufferHeight;
 
   return TRUE;
 }

--- a/shell/platform/linux/testing/fl_test.cc
+++ b/shell/platform/linux/testing/fl_test.cc
@@ -17,7 +17,7 @@ class ImModuleEnv : public ::testing::Environment {
   }
 };
 
-testing::Environment* const env =
+testing::Environment* const kEnv =
     testing::AddGlobalTestEnvironment(new ImModuleEnv);
 }  // namespace
 

--- a/testing/scenario_app/ios/app_stub.c
+++ b/testing/scenario_app/ios/app_stub.c
@@ -1,2 +1,2 @@
 // This is a stub file used to create App.framework for JIT mode.
-__attribute__((unused)) static const int Moo = 88;
+__attribute__((unused)) static const int kMoo = 88;


### PR DESCRIPTION
Enforces that all global constants are prefixed with a 'k' as per the
style guide and updates the codebase into conformance where necessary.

This does not change any public API (or touch even private header
files).

Additional testing provided by the addition of the lint rule.

Ref: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#begin-global-constant-names-with-prefix-k

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
