### PR TITLE
[fuchsia] Fix precision errors occuring in layer tree frame size.

### DIFF
--- a/shell/platform/fuchsia/flutter/gfx_platform_view.cc
+++ b/shell/platform/fuchsia/flutter/gfx_platform_view.cc
@@ -232,19 +232,19 @@ void GfxPlatformView::OnScenicEvent(
     const float pixel_ratio = *view_pixel_ratio_;
     const std::array<float, 2> logical_size = *view_logical_size_;
     SetViewportMetrics({
-        pixel_ratio,                    // device_pixel_ratio
-        logical_size[0] * pixel_ratio,  // physical_width
-        logical_size[1] * pixel_ratio,  // physical_height
-        0.0f,                           // physical_padding_top
-        0.0f,                           // physical_padding_right
-        0.0f,                           // physical_padding_bottom
-        0.0f,                           // physical_padding_left
-        0.0f,                           // physical_view_inset_top
-        0.0f,                           // physical_view_inset_right
-        0.0f,                           // physical_view_inset_bottom
-        0.0f,                           // physical_view_inset_left
-        0.0f,                           // p_physical_system_gesture_inset_top
-        0.0f,                           // p_physical_system_gesture_inset_right
+        pixel_ratio,                                // device_pixel_ratio
+        std::round(logical_size[0] * pixel_ratio),  // physical_width
+        std::round(logical_size[1] * pixel_ratio),  // physical_height
+        0.0f,                                       // physical_padding_top
+        0.0f,                                       // physical_padding_right
+        0.0f,                                       // physical_padding_bottom
+        0.0f,                                       // physical_padding_left
+        0.0f,                                       // physical_view_inset_top
+        0.0f,                                       // physical_view_inset_right
+        0.0f,  // physical_view_inset_bottom
+        0.0f,  // physical_view_inset_left
+        0.0f,  // p_physical_system_gesture_inset_top
+        0.0f,  // p_physical_system_gesture_inset_right
         0.0f,  // p_physical_system_gesture_inset_bottom
         0.0f,  // p_physical_system_gesture_inset_left,
         -1.0,  // p_physical_touch_slop,

--- a/shell/platform/fuchsia/flutter/platform_view_unittest.cc
+++ b/shell/platform/fuchsia/flutter/platform_view_unittest.cc
@@ -632,10 +632,11 @@ TEST_F(PlatformViewTests, SetViewportMetrics) {
       })));
   session_listener->OnScenicEvent(std::move(events));
   RunLoopUntilIdle();
-  EXPECT_EQ(delegate.metrics(),
-            flutter::ViewportMetrics(
-                valid_pixel_ratio, valid_pixel_ratio * valid_max_bound,
-                valid_pixel_ratio * valid_max_bound, -1.0));
+  EXPECT_EQ(
+      delegate.metrics(),
+      flutter::ViewportMetrics(
+          valid_pixel_ratio, std::round(valid_pixel_ratio * valid_max_bound),
+          std::round(valid_pixel_ratio * valid_max_bound), -1.0));
 }
 
 // This test makes sure that the PlatformView correctly registers semantics


### PR DESCRIPTION
This PR fixes the precision error which occurs when casting a double to int32, causing an incorrect physical display size to be propagated in
the layer tree ultimately causing input events on the left edge of the
display to be dropped.