### PR TITLE
[impeller] Revert ShaderLibraryGLES validity check

### DIFF
--- a/impeller/.clang-tidy
+++ b/impeller/.clang-tidy
@@ -1,5 +1,11 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,google-*,readability-identifier-naming,-google-explicit-constructor,cppcoreguidelines-prefer-member-initializer,modernize-use-default-member-init'
+Checks: 'clang-diagnostic-*,\
+clang-analyzer-*,\
+google-*,\
+readability-identifier-naming,\
+-google-explicit-constructor,\
+modernize-use-default-member-init'
+
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false

--- a/impeller/renderer/backend/gles/shader_library_gles.cc
+++ b/impeller/renderer/backend/gles/shader_library_gles.cc
@@ -52,8 +52,7 @@ static std::string GLESShaderNameToShaderKeyName(const std::string& name,
 }
 
 ShaderLibraryGLES::ShaderLibraryGLES(
-    std::vector<std::shared_ptr<fml::Mapping>> shader_libraries)
-    : is_valid_(true) {
+    std::vector<std::shared_ptr<fml::Mapping>> shader_libraries) {
   ShaderFunctionMap functions;
   UniqueID library_id;
   auto iterator = [&functions, &library_id](auto type,           //
@@ -82,6 +81,7 @@ ShaderLibraryGLES::ShaderLibraryGLES(
   }
 
   functions_ = functions;
+  is_valid_ = true;
 }
 
 // |ShaderLibrary|


### PR DESCRIPTION
In https://github.com/flutter/engine/pull/33666, I landed a bulk lint
cleanup that applied fixes to global constant naming using the `--fix`
option to the linter script, but also caught a few straggling linter
violations that hadn't been previously fixed.

As part of this patch, the linter applied a change that moved
ShaderLibraryGLES's is_valid_ initialisation from the ctor body to the
initialiser list, always initialised to true. This is unsafe because
prior to is_valid_ initialisation in the ctor body, there was a bailout
if any of the shader_libraries wasn't valid.

This eliminates the use of the
`cppcoreguidelines-prefer-member-initializer` lint, which incorrectly
flagged this code due to the following issue:
https://github.com/llvm/llvm-project/issues/52837

This is a partial revert of https://github.com/flutter/engine/pull/33666.
Reintroduction of this issue is prevented by the removal of the 
`cppcoreguidelines-prefer-member-initializer` lint in this patch.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
