### PR TITLE
Fixes for the Windows arm64 build

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -111,7 +111,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '53abad0fa9c9e0285e80f9b0682316d5d39705be',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'f582982073b6f04b7a70bc284bac8fafa6c0a846',
 
    # Fuchsia compatibility
    #

--- a/DEPS
+++ b/DEPS
@@ -405,6 +405,16 @@ deps = {
     'dep_type': 'cipd',
     'condition': 'host_os == "win"'
   },
+  'src/flutter/prebuilts/windows-arm64/dart-sdk': {
+    'packages': [
+      {
+        'package': 'flutter/dart-sdk/windows-arm64',
+        'version': 'git_revision:'+Var('dart_revision')
+      }
+    ],
+    'dep_type': 'cipd',
+    'condition': 'host_os == "win"'
+  },
 
   'src/third_party/colorama/src':
    Var('chromium_git') + '/external/colorama.git' + '@' + '799604a1041e9b3bc5d2789ecbd7e8db2e18e6b8',

--- a/DEPS
+++ b/DEPS
@@ -111,7 +111,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '6c00bc8d3d3c80e07e58c1f91d255dcefc420641',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '53abad0fa9c9e0285e80f9b0682316d5d39705be',
 
    # Fuchsia compatibility
    #

--- a/build/git_revision.py
+++ b/build/git_revision.py
@@ -6,21 +6,26 @@
 
 """Get the Git HEAD revision of a specified Git repository."""
 
-
-
-
 import sys
 import subprocess
 import os
 import argparse
+
+def IsWindows():
+  os_id = sys.platform
+  return os_id.startswith('win32') or os_id.startswith('cygwin')
+
 
 def GetRepositoryVersion(repository):
   "Returns the Git HEAD for the supplied repository path as a string."
   if not os.path.exists(repository):
     raise IOError("path doesn't exist")
 
+  git = 'git'
+  if IsWindows():
+    git = 'git.bat'
   version = subprocess.check_output([
-    'git',
+    git,
     '-C',
     repository,
     'rev-parse',
@@ -28,6 +33,7 @@ def GetRepositoryVersion(repository):
   ])
 
   return str(version.strip(), 'utf-8')
+
 
 def main():
   parser = argparse.ArgumentParser()
@@ -43,6 +49,7 @@ def main():
   print(version.strip())
 
   return 0
+
 
 if __name__ == '__main__':
   sys.exit(main())

--- a/tools/gn
+++ b/tools/gn
@@ -116,6 +116,8 @@ def can_use_prebuilt_dart(args):
     prebuilt = 'linux-%s' % args.linux_cpu
   elif args.target_os == 'mac' and args.mac_cpu in ['x64', 'arm64']:
     prebuilt = 'macos-%s' % args.mac_cpu
+  elif args.target_os == 'win' and args.windows_cpu in ['x64', 'arm64']:
+    prebuilt = 'windows-%s' % args.windows_cpu
 
   prebuilts_dir = None
   if prebuilt != None:


### PR DESCRIPTION
Pulls in the prebuilt Windows arm64 Dart SDK, and ensures that it is used.

Needs https://github.com/flutter/buildroot/pull/577

Rolls buildroot to 53abad0fa9c9e0285e80f9b0682316d5d39705be