### PR TITLE
Fix #77084: flutter website doesn't resize properly when zoomed in/ou…

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/surface.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/surface.dart
@@ -161,6 +161,7 @@ class Surface {
       // The existing surface is still reusable.
       if (window.devicePixelRatio != _currentDevicePixelRatio) {
         _updateLogicalHtmlCanvasSize();
+        _translateCanvas();
       }
       return _surface!;
     }

--- a/lib/web_ui/test/canvaskit/surface_test.dart
+++ b/lib/web_ui/test/canvaskit/surface_test.dart
@@ -31,7 +31,7 @@ void testMain() {
       expect(original.height, 19);
       expect(original.style.width, '9px');
       expect(original.style.height, '19px');
-      expect(original.style.transform, 'translate(0px, 0px)');
+      expect(original.style.transform, _isTranslate(0, 0));
       expect(originalSurface.width(), 9);
       expect(originalSurface.height(), 19);
 
@@ -42,7 +42,7 @@ void testMain() {
       expect(shrunk, same(original));
       expect(shrunk.style.width, '9px');
       expect(shrunk.style.height, '19px');
-      expect(shrunk.style.transform, 'translate(0px, -4px)');
+      expect(shrunk.style.transform, _isTranslate(0, -4));
       expect(shrunkSurface, isNot(same(original)));
       expect(shrunkSurface.width(), 5);
       expect(shrunkSurface.height(), 15);
@@ -60,7 +60,7 @@ void testMain() {
       expect(firstIncrease.height, 28);
       expect(firstIncrease.style.width, '14px');
       expect(firstIncrease.style.height, '28px');
-      expect(firstIncrease.style.transform, 'translate(0px, -8px)');
+      expect(firstIncrease.style.transform, _isTranslate(0, -8));
       expect(firstIncreaseSurface.width(), 10);
       expect(firstIncreaseSurface.height(), 20);
 
@@ -69,7 +69,7 @@ void testMain() {
           surface.acquireFrame(const ui.Size(11, 22)).skiaSurface;
       final DomCanvasElement secondIncrease = surface.htmlCanvas!;
       expect(secondIncrease, same(firstIncrease));
-      expect(secondIncrease.style.transform, 'translate(0px, -6px)');
+      expect(secondIncrease.style.transform, _isTranslate(0, -6));
       expect(secondIncreaseSurface, isNot(same(firstIncreaseSurface)));
       expect(secondIncreaseSurface.width(), 11);
       expect(secondIncreaseSurface.height(), 22);
@@ -85,7 +85,7 @@ void testMain() {
       expect(huge.height, 56);
       expect(huge.style.width, '28px');
       expect(huge.style.height, '56px');
-      expect(huge.style.transform, 'translate(0px, -16px)');
+      expect(huge.style.transform, _isTranslate(0, -16));
       expect(hugeSurface.width(), 20);
       expect(hugeSurface.height(), 40);
 
@@ -96,7 +96,7 @@ void testMain() {
       expect(shrunk2, same(huge));
       expect(shrunk2.style.width, '28px');
       expect(shrunk2.style.height, '56px');
-      expect(shrunk2.style.transform, 'translate(0px, -41px)');
+      expect(shrunk2.style.transform, _isTranslate(0, -41));
       expect(shrunkSurface2, isNot(same(hugeSurface)));
       expect(shrunkSurface2.width(), 5);
       expect(shrunkSurface2.height(), 15);
@@ -110,7 +110,7 @@ void testMain() {
       expect(dpr2Canvas, same(huge));
       expect(dpr2Canvas.style.width, '14px');
       expect(dpr2Canvas.style.height, '28px');
-      expect(dpr2Canvas.style.transform, 'translate(0px, -20.5px)');
+      expect(dpr2Canvas.style.transform, _isTranslate(0, -20.5));
       expect(dpr2Surface2, isNot(same(hugeSurface)));
       expect(dpr2Surface2.width(), 5);
       expect(dpr2Surface2.height(), 15);
@@ -179,7 +179,7 @@ void testMain() {
       expect(original.height(), 16);
       expect(surface.htmlCanvas!.style.width, '10px');
       expect(surface.htmlCanvas!.style.height, '16px');
-      expect(surface.htmlCanvas!.style.transform, 'translate(0px, 0px)');
+      expect(surface.htmlCanvas!.style.transform, _isTranslate(0, 0));
 
       // Increase device-pixel ratio: this makes CSS pixels bigger, so we need
       // fewer of them to cover the browser window.
@@ -190,7 +190,7 @@ void testMain() {
       expect(highDpr.height(), 16);
       expect(surface.htmlCanvas!.style.width, '5px');
       expect(surface.htmlCanvas!.style.height, '8px');
-      expect(surface.htmlCanvas!.style.transform, 'translate(0px, 0px)');
+      expect(surface.htmlCanvas!.style.transform, _isTranslate(0, 0));
 
       // Decrease device-pixel ratio: this makes CSS pixels smaller, so we need
       // more of them to cover the browser window.
@@ -201,7 +201,7 @@ void testMain() {
       expect(lowDpr.height(), 16);
       expect(surface.htmlCanvas!.style.width, '20px');
       expect(surface.htmlCanvas!.style.height, '32px');
-      expect(surface.htmlCanvas!.style.transform, 'translate(0px, 0px)');
+      expect(surface.htmlCanvas!.style.transform, _isTranslate(0, 0));
 
       // See https://github.com/flutter/flutter/issues/77084#issuecomment-1120151172
       window.debugOverrideDevicePixelRatio(2.0);
@@ -211,7 +211,26 @@ void testMain() {
       expect(changeRatioAndSize.height(), 16);
       expect(surface.htmlCanvas!.style.width, '5px');
       expect(surface.htmlCanvas!.style.height, '8px');
-      expect(surface.htmlCanvas!.style.transform, 'translate(0px, 0px)');
+      expect(surface.htmlCanvas!.style.transform, _isTranslate(0, 0));
     });
   });
+}
+
+/// Checks that the CSS 'transform' property is a translation in a cross-browser way.
+/// 
+/// Assumes that the `x` and `y` values are round enough for their `toString` values
+/// to match the stringified CSS length value.
+Matcher _isTranslate(double x, double y) {
+  // When the y coordinate is zero, Firefox omits it, e.g.:
+  //   Chrome/Safari/Edge: translate(0px, 0px)
+  //   Firefox:            translate(0px)
+  final String fullFormat = 'translate(${x}px, ${y}px)';
+  if (y != 0) {
+    return equals(fullFormat);
+  } else {
+    return anyOf(
+      fullFormat,  // Non-Firefox browsers use this format.
+      'translate(${x}px)',  // Firefox omits y when it's zero.
+    );
+  }
 }

--- a/lib/web_ui/test/canvaskit/surface_test.dart
+++ b/lib/web_ui/test/canvaskit/surface_test.dart
@@ -31,16 +31,18 @@ void testMain() {
       expect(original.height, 19);
       expect(original.style.width, '9px');
       expect(original.style.height, '19px');
+      expect(original.style.transform, 'translate(0px, 0px)');
       expect(originalSurface.width(), 9);
       expect(originalSurface.height(), 19);
 
-      // Shrinking reuses the existing canvas straight-up.
+      // Shrinking reuses the existing canvas but translates it so Skia renders into the visible area.
       final CkSurface shrunkSurface =
           surface.acquireFrame(const ui.Size(5, 15)).skiaSurface;
       final DomCanvasElement shrunk = surface.htmlCanvas!;
       expect(shrunk, same(original));
       expect(shrunk.style.width, '9px');
       expect(shrunk.style.height, '19px');
+      expect(shrunk.style.transform, 'translate(0px, -4px)');
       expect(shrunkSurface, isNot(same(original)));
       expect(shrunkSurface.width(), 5);
       expect(shrunkSurface.height(), 15);
@@ -58,6 +60,7 @@ void testMain() {
       expect(firstIncrease.height, 28);
       expect(firstIncrease.style.width, '14px');
       expect(firstIncrease.style.height, '28px');
+      expect(firstIncrease.style.transform, 'translate(0px, -8px)');
       expect(firstIncreaseSurface.width(), 10);
       expect(firstIncreaseSurface.height(), 20);
 
@@ -66,6 +69,7 @@ void testMain() {
           surface.acquireFrame(const ui.Size(11, 22)).skiaSurface;
       final DomCanvasElement secondIncrease = surface.htmlCanvas!;
       expect(secondIncrease, same(firstIncrease));
+      expect(secondIncrease.style.transform, 'translate(0px, -6px)');
       expect(secondIncreaseSurface, isNot(same(firstIncreaseSurface)));
       expect(secondIncreaseSurface.width(), 11);
       expect(secondIncreaseSurface.height(), 22);
@@ -81,6 +85,7 @@ void testMain() {
       expect(huge.height, 56);
       expect(huge.style.width, '28px');
       expect(huge.style.height, '56px');
+      expect(huge.style.transform, 'translate(0px, -16px)');
       expect(hugeSurface.width(), 20);
       expect(hugeSurface.height(), 40);
 
@@ -89,9 +94,27 @@ void testMain() {
           surface.acquireFrame(const ui.Size(5, 15)).skiaSurface;
       final DomCanvasElement shrunk2 = surface.htmlCanvas!;
       expect(shrunk2, same(huge));
+      expect(shrunk2.style.width, '28px');
+      expect(shrunk2.style.height, '56px');
+      expect(shrunk2.style.transform, 'translate(0px, -41px)');
       expect(shrunkSurface2, isNot(same(hugeSurface)));
       expect(shrunkSurface2.width(), 5);
       expect(shrunkSurface2.height(), 15);
+
+      // Doubling the DPR should halve the CSS width, height, and translation of the canvas.
+      // This tests https://github.com/flutter/flutter/issues/77084
+      window.debugOverrideDevicePixelRatio(2.0);
+      final CkSurface dpr2Surface2 =
+          surface.acquireFrame(const ui.Size(5, 15)).skiaSurface;
+      final DomCanvasElement dpr2Canvas = surface.htmlCanvas!;
+      expect(dpr2Canvas, same(huge));
+      expect(dpr2Canvas.style.width, '14px');
+      expect(dpr2Canvas.style.height, '28px');
+      expect(dpr2Canvas.style.transform, 'translate(0px, -20.5px)');
+      expect(dpr2Surface2, isNot(same(hugeSurface)));
+      expect(dpr2Surface2.width(), 5);
+      expect(dpr2Surface2.height(), 15);
+
       // Skipping on Firefox for now since Firefox headless doesn't support WebGL
       // This causes issues in the test since we create a Canvas-backed surface,
       // which cannot be a different size from the canvas.
@@ -156,6 +179,7 @@ void testMain() {
       expect(original.height(), 16);
       expect(surface.htmlCanvas!.style.width, '10px');
       expect(surface.htmlCanvas!.style.height, '16px');
+      expect(surface.htmlCanvas!.style.transform, 'translate(0px, 0px)');
 
       // Increase device-pixel ratio: this makes CSS pixels bigger, so we need
       // fewer of them to cover the browser window.
@@ -166,6 +190,7 @@ void testMain() {
       expect(highDpr.height(), 16);
       expect(surface.htmlCanvas!.style.width, '5px');
       expect(surface.htmlCanvas!.style.height, '8px');
+      expect(surface.htmlCanvas!.style.transform, 'translate(0px, 0px)');
 
       // Decrease device-pixel ratio: this makes CSS pixels smaller, so we need
       // more of them to cover the browser window.
@@ -176,6 +201,7 @@ void testMain() {
       expect(lowDpr.height(), 16);
       expect(surface.htmlCanvas!.style.width, '20px');
       expect(surface.htmlCanvas!.style.height, '32px');
+      expect(surface.htmlCanvas!.style.transform, 'translate(0px, 0px)');
 
       // See https://github.com/flutter/flutter/issues/77084#issuecomment-1120151172
       window.debugOverrideDevicePixelRatio(2.0);
@@ -185,6 +211,7 @@ void testMain() {
       expect(changeRatioAndSize.height(), 16);
       expect(surface.htmlCanvas!.style.width, '5px');
       expect(surface.htmlCanvas!.style.height, '8px');
+      expect(surface.htmlCanvas!.style.transform, 'translate(0px, 0px)');
     });
   });
 }

--- a/lib/web_ui/test/canvaskit/surface_test.dart
+++ b/lib/web_ui/test/canvaskit/surface_test.dart
@@ -217,7 +217,7 @@ void testMain() {
 }
 
 /// Checks that the CSS 'transform' property is a translation in a cross-browser way.
-/// 
+///
 /// Assumes that the `x` and `y` values are round enough for their `toString` values
 /// to match the stringified CSS length value.
 Matcher _isTranslate(double x, double y) {


### PR DESCRIPTION
This is a continuation of issue #77084 as the fix done there is only a partial fix.

A comment by @HeinrichJanzing said:

> Interestingly, as @linxuebin1990 noticed, size.width and size.height often suffer from precision issues, making them subtly different, causing this path to not be taken as often as expected. When it is taken, the devicePixelRatio change is detected, the logical size of the canvas is updated to match, but the canvas' translation, intended to compensate for the canvas being oversized, isn't updated. This translation is expressed in logical pixels and thus should also be updated.

> If this doesn't happen, it causes the Flutter UI to appear shifted vertically in the browser's viewport. This can be reproduced in any Flutter web app by using Ctrl+mousewheel to change the zoom level. Sooner or later it pops up. Luckily, changing the zoom level again or resizing the window does trigger the call to _translateCanvas() and fixes things.

This ticket aims to fix this issue. 

Fixes https://github.com/flutter/flutter/issues/77084

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
