### PR TITLE
Pass std::string_view by value not by ref

### DIFF
--- a/impeller/compiler/reflector.cc
+++ b/impeller/compiler/reflector.cc
@@ -304,7 +304,7 @@ static std::string ToString(CompilerBackend::Type type) {
 }
 
 std::shared_ptr<fml::Mapping> Reflector::InflateTemplate(
-    const std::string_view& tmpl) const {
+    std::string_view tmpl) const {
   inja::Environment env;
   env.set_trim_blocks(true);
   env.set_lstrip_blocks(true);

--- a/impeller/compiler/reflector.h
+++ b/impeller/compiler/reflector.h
@@ -91,8 +91,7 @@ class Reflector {
 
   std::shared_ptr<fml::Mapping> GenerateReflectionCC() const;
 
-  std::shared_ptr<fml::Mapping> InflateTemplate(
-      const std::string_view& tmpl) const;
+  std::shared_ptr<fml::Mapping> InflateTemplate(std::string_view tmpl) const;
 
   std::optional<nlohmann::json::object_t> ReflectResource(
       const spirv_cross::Resource& resource) const;

--- a/impeller/renderer/backend/gles/shader_library_gles.cc
+++ b/impeller/renderer/backend/gles/shader_library_gles.cc
@@ -94,7 +94,7 @@ bool ShaderLibraryGLES::IsValid() const {
 
 // |ShaderLibrary|
 std::shared_ptr<const ShaderFunction> ShaderLibraryGLES::GetFunction(
-    const std::string_view& name,
+    std::string_view name,
     ShaderStage stage) {
   const auto key = ShaderKey{name, stage};
   if (auto found = functions_.find(key); found != functions_.end()) {

--- a/impeller/renderer/backend/gles/shader_library_gles.h
+++ b/impeller/renderer/backend/gles/shader_library_gles.h
@@ -30,9 +30,8 @@ class ShaderLibraryGLES final : public ShaderLibrary {
       std::vector<std::shared_ptr<fml::Mapping>> shader_libraries);
 
   // |ShaderLibrary|
-  std::shared_ptr<const ShaderFunction> GetFunction(
-      const std::string_view& name,
-      ShaderStage stage) override;
+  std::shared_ptr<const ShaderFunction> GetFunction(std::string_view name,
+                                                    ShaderStage stage) override;
 
   FML_DISALLOW_COPY_AND_ASSIGN(ShaderLibraryGLES);
 };

--- a/impeller/renderer/backend/gles/texture_gles.cc
+++ b/impeller/renderer/backend/gles/texture_gles.cc
@@ -79,7 +79,7 @@ bool TextureGLES::IsValid() const {
 }
 
 // |Texture|
-void TextureGLES::SetLabel(const std::string_view& label) {
+void TextureGLES::SetLabel(std::string_view label) {
   reactor_->SetDebugLabel(handle_, std::string{label.data(), label.size()});
 }
 

--- a/impeller/renderer/backend/gles/texture_gles.h
+++ b/impeller/renderer/backend/gles/texture_gles.h
@@ -62,7 +62,7 @@ class TextureGLES final : public Texture,
               bool is_wrapped);
 
   // |Texture|
-  void SetLabel(const std::string_view& label) override;
+  void SetLabel(std::string_view label) override;
 
   // |Texture|
   bool OnSetContents(const uint8_t* contents,

--- a/impeller/renderer/backend/metal/shader_library_mtl.h
+++ b/impeller/renderer/backend/metal/shader_library_mtl.h
@@ -39,9 +39,8 @@ class ShaderLibraryMTL final : public ShaderLibrary {
   ShaderLibraryMTL(NSArray<id<MTLLibrary>>* libraries);
 
   // |ShaderLibrary|
-  std::shared_ptr<const ShaderFunction> GetFunction(
-      const std::string_view& name,
-      ShaderStage stage) override;
+  std::shared_ptr<const ShaderFunction> GetFunction(std::string_view name,
+                                                    ShaderStage stage) override;
 
   FML_DISALLOW_COPY_AND_ASSIGN(ShaderLibraryMTL);
 };

--- a/impeller/renderer/backend/metal/shader_library_mtl.mm
+++ b/impeller/renderer/backend/metal/shader_library_mtl.mm
@@ -24,7 +24,7 @@ bool ShaderLibraryMTL::IsValid() const {
 }
 
 std::shared_ptr<const ShaderFunction> ShaderLibraryMTL::GetFunction(
-    const std::string_view& name,
+    std::string_view name,
     ShaderStage stage) {
   if (!IsValid()) {
     return nullptr;

--- a/impeller/renderer/backend/metal/texture_mtl.h
+++ b/impeller/renderer/backend/metal/texture_mtl.h
@@ -27,7 +27,7 @@ class TextureMTL final : public Texture,
   bool is_valid_ = false;
 
   // |Texture|
-  void SetLabel(const std::string_view& label) override;
+  void SetLabel(std::string_view label) override;
 
   // |Texture|
   bool OnSetContents(const uint8_t* contents,

--- a/impeller/renderer/backend/metal/texture_mtl.mm
+++ b/impeller/renderer/backend/metal/texture_mtl.mm
@@ -26,7 +26,7 @@ TextureMTL::TextureMTL(TextureDescriptor p_desc, id<MTLTexture> texture)
 
 TextureMTL::~TextureMTL() = default;
 
-void TextureMTL::SetLabel(const std::string_view& label) {
+void TextureMTL::SetLabel(std::string_view label) {
   [texture_ setLabel:@(label.data())];
 }
 

--- a/impeller/renderer/shader_key.h
+++ b/impeller/renderer/shader_key.h
@@ -18,7 +18,7 @@ struct ShaderKey {
   std::string name;
   ShaderStage stage = ShaderStage::kUnknown;
 
-  ShaderKey(const std::string_view& p_name, ShaderStage p_stage)
+  ShaderKey(std::string_view p_name, ShaderStage p_stage)
       : name({p_name.data(), p_name.size()}), stage(p_stage) {}
 
   struct Hash {

--- a/impeller/renderer/shader_library.h
+++ b/impeller/renderer/shader_library.h
@@ -22,7 +22,7 @@ class ShaderLibrary {
   virtual bool IsValid() const = 0;
 
   virtual std::shared_ptr<const ShaderFunction> GetFunction(
-      const std::string_view& name,
+      std::string_view name,
       ShaderStage stage) = 0;
 
  protected:

--- a/impeller/renderer/texture.h
+++ b/impeller/renderer/texture.h
@@ -18,7 +18,7 @@ class Texture {
  public:
   virtual ~Texture();
 
-  virtual void SetLabel(const std::string_view& label) = 0;
+  virtual void SetLabel(std::string_view label) = 0;
 
   [[nodiscard]] bool SetContents(const uint8_t* contents,
                                  size_t length,


### PR DESCRIPTION
String views are small, cheap objects that fit in a couple registers, so
passing by value avoids pointer indirection and thus a memory load.

Fun related reading for future archaeologists:
https://quuxplusone.github.io/blog/2021/11/09/pass-string-view-by-value/

And a Windows-specific footnote:
https://quuxplusone.github.io/blog/2021/11/19/string-view-by-value-ps/

No test change since there is no semantic change.


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
