### PR TITLE
[Impeller] Build Impeller on Windows

### DIFF
--- a/impeller/archivist/archive_database.h
+++ b/impeller/archivist/archive_database.h
@@ -6,6 +6,7 @@
 
 #include <map>
 #include <memory>
+#include <string>
 
 #include "flutter/fml/macros.h"
 #include "impeller/archivist/archive_transaction.h"

--- a/impeller/compiler/switches.cc
+++ b/impeller/compiler/switches.cc
@@ -85,8 +85,15 @@ Switches::Switches(const fml::CommandLine& command_line)
     if (!include_dir_path.data()) {
       continue;
     }
+
+    // fml::OpenDirectoryReadOnly for Windows doesn't handle relative paths
+    // beginning with `../` well, so we build an absolute path.
+    auto include_dir_absolute =
+        ToUtf8(std::filesystem::absolute(std::filesystem::current_path() /
+                                         include_dir_path)
+                   .native());
     auto dir = std::make_shared<fml::UniqueFD>(fml::OpenDirectoryReadOnly(
-        *working_directory, include_dir_path.data()));
+        *working_directory, include_dir_absolute.c_str()));
     if (!dir || !dir->is_valid()) {
       continue;
     }

--- a/impeller/entity/contents/vertices_contents.cc
+++ b/impeller/entity/contents/vertices_contents.cc
@@ -52,14 +52,14 @@ bool VerticesContents::Render(const ContentContext& renderer,
   VertexMode mode = vertices_.GetMode();
 
   if (indices.size() == 0) {
-    for (uint i = 0; i < points.size(); i += 1) {
+    for (size_t i = 0; i < points.size(); i += 1) {
       VS::PerVertexData data;
       data.point = points[i];
       data.vertex_color = color_;
       vertex_builder.AppendVertex(data);
     }
   } else {
-    for (uint i = 0; i < indices.size(); i += 1) {
+    for (size_t i = 0; i < indices.size(); i += 1) {
       VS::PerVertexData data;
       data.point = points[indices[i]];
       data.vertex_color = color_;

--- a/impeller/playground/backend/gles/playground_impl_gles.cc
+++ b/impeller/playground/backend/gles/playground_impl_gles.cc
@@ -5,7 +5,7 @@
 #include "impeller/playground/backend/gles/playground_impl_gles.h"
 
 #define GLFW_INCLUDE_NONE
-#import "third_party/glfw/include/GLFW/glfw3.h"
+#include "third_party/glfw/include/GLFW/glfw3.h"
 
 #include "flutter/fml/build_config.h"
 #include "impeller/entity/gles/entity_shaders_gles.h"

--- a/impeller/playground/playground.cc
+++ b/impeller/playground/playground.cc
@@ -11,7 +11,7 @@
 #include "impeller/renderer/command_buffer.h"
 
 #define GLFW_INCLUDE_NONE
-#import "third_party/glfw/include/GLFW/glfw3.h"
+#include "third_party/glfw/include/GLFW/glfw3.h"
 
 #include "flutter/fml/paths.h"
 #include "flutter/testing/testing.h"

--- a/impeller/renderer/backend/gles/BUILD.gn
+++ b/impeller/renderer/backend/gles/BUILD.gn
@@ -5,16 +5,13 @@
 import("../../../tools/impeller.gni")
 
 config("gles_config") {
-  include_dirs = []
-  if (!is_android) {
-    # Generic GL/GLES/EGL/Vulkan headers. Any will do. We just pick one from Angle
-    # because they are there.
-    include_dirs = [ "//third_party/angle/include" ]
-  }
+  # Generic GL/GLES/EGL/Vulkan headers. Any will do. We just pick one from Angle
+  # because they are there.
+  include_dirs = [ "//third_party/angle/include" ]
 }
 
 impeller_component("gles") {
-  public_configs = [ ":gles_config" ]
+  public_configs = []
 
   sources = [
     "allocator_gles.cc",
@@ -59,6 +56,14 @@ impeller_component("gles") {
     "texture_gles.cc",
     "texture_gles.h",
   ]
+
+  if (!is_android) {
+    public_configs = [ ":gles_config" ]
+    sources += [
+      "//third_party/angle/include/GLES2/gl2.h",
+      "//third_party/angle/include/GLES2/gl2ext.h",
+    ]
+  }
 
   public_deps = [
     "../../:renderer",

--- a/impeller/renderer/backend/gles/buffer_bindings_gles.cc
+++ b/impeller/renderer/backend/gles/buffer_bindings_gles.cc
@@ -64,7 +64,7 @@ static std::string NormalizeUniformKey(const std::string& key) {
     if (ch == '_') {
       continue;
     }
-    stream << static_cast<char>(std::toupper(ch));
+    stream << static_cast<char>(toupper(ch));
   }
   return stream.str();
 }

--- a/impeller/tools/impeller.gni
+++ b/impeller/tools/impeller.gni
@@ -17,7 +17,7 @@ declare_args() {
   impeller_enable_metal = is_mac || is_ios
 
   # Whether the OpenGLES backend is enabled.
-  impeller_enable_opengles = is_mac || is_linux || is_android
+  impeller_enable_opengles = is_mac || is_linux || is_android || is_win
 
   # Whether to use a prebuilt impellerc.
   # If this is the empty string, impellerc will be built.


### PR DESCRIPTION
* GN was mad about the GLES headers not being included as source files; ~~added the angle includes target which already does so~~ added the relevant includes to the sources list.
* `#import` is unsupported when using `clang-cl`; changed to `#include`.
*  Flip on `impeller_enable_opengles` for Windows.
* Add missing string include because it happens to not be included by map/memory in the Windows SDK headers.
* impellerc include paths beginning with `../` weren't getting normalized when converted to an absolute path within `fml::OpenDirectoryReadOnly`, so make the include path absolute and normalized before passing it in.

https://user-images.githubusercontent.com/919017/171105014-a6d92d24-96e3-40e6-915c-d7f68fa5a3ba.mp4

