### PR TITLE
[Impeller] Add high DPI support to the ImGui Impeller backend; make high DPI work in the Metal playground; make playground tests respect content scale

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -561,6 +561,7 @@ TEST_P(AiksTest, ColorWheel) {
     ImGui::End();
 
     Canvas canvas;
+    canvas.Scale(GetContentScale());
     Paint paint;
     // Default blend is kSourceOver.
     paint.color = Color::White();
@@ -653,6 +654,7 @@ TEST_P(AiksTest, SolidStrokesRenderCorrectly) {
     ImGui::End();
 
     Canvas canvas;
+    canvas.Scale(GetContentScale());
     Paint paint;
 
     paint.color = Color::White();

--- a/impeller/display_list/display_list_unittests.cc
+++ b/impeller/display_list/display_list_unittests.cc
@@ -115,6 +115,9 @@ TEST_P(DisplayListTest, CanDrawArc) {
         Point(200, 200), Point(400, 400), 20, Color::White(), Color::White());
 
     flutter::DisplayListBuilder builder;
+
+    Vector2 scale = GetContentScale();
+    builder.scale(scale.x, scale.y);
     builder.setStyle(flutter::DlDrawStyle::kStroke);
     builder.setStrokeCap(flutter::DlStrokeCap::kRound);
     builder.setStrokeJoin(flutter::DlStrokeJoin::kMiter);

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -105,6 +105,7 @@ TEST_P(EntityTest, EntityPassSubpassCoverageIsCorrect) {
 
 TEST_P(EntityTest, CanDrawRect) {
   Entity entity;
+  entity.SetTransformation(Matrix::MakeScale(GetContentScale()));
   entity.SetContents(SolidColorContents::Make(
       PathBuilder{}.AddRect({100, 100, 100, 100}).TakePath(), Color::Red()));
   ASSERT_TRUE(OpenPlaygroundHere(entity));
@@ -121,6 +122,7 @@ TEST_P(EntityTest, ThreeStrokesInOnePath) {
                   .TakePath();
 
   Entity entity;
+  entity.SetTransformation(Matrix::MakeScale(GetContentScale()));
   auto contents = std::make_unique<SolidStrokeContents>();
   contents->SetPath(std::move(path));
   contents->SetColor(Color::Red());
@@ -151,6 +153,7 @@ TEST_P(EntityTest, TriangleInsideASquare) {
                     .TakePath();
 
     Entity entity;
+    entity.SetTransformation(Matrix::MakeScale(GetContentScale()));
     auto contents = std::make_unique<SolidStrokeContents>();
     contents->SetPath(std::move(path));
     contents->SetColor(Color::Red());
@@ -316,6 +319,7 @@ TEST_P(EntityTest, CubicCurveTest) {
           .Close()
           .TakePath();
   Entity entity;
+  entity.SetTransformation(Matrix::MakeScale(GetContentScale()));
   entity.SetContents(SolidColorContents::Make(path, Color::Red()));
   ASSERT_TRUE(OpenPlaygroundHere(entity));
 }
@@ -543,6 +547,7 @@ TEST_P(EntityTest, CubicCurveAndOverlapTest) {
           .Close()
           .TakePath();
   Entity entity;
+  entity.SetTransformation(Matrix::MakeScale(GetContentScale()));
   entity.SetContents(SolidColorContents::Make(path, Color::Red()));
   ASSERT_TRUE(OpenPlaygroundHere(entity));
 }
@@ -645,8 +650,10 @@ TEST_P(EntityTest, BlendingModeOptions) {
       ImGui::SetNextWindowPos({200, 450});
     }
 
-    auto draw_rect = [&context, &pass](Rect rect, Color color,
-                                       Entity::BlendMode blend_mode) -> bool {
+    auto world_matrix = Matrix::MakeScale(GetContentScale());
+    auto draw_rect = [&context, &pass, &world_matrix](
+                         Rect rect, Color color,
+                         Entity::BlendMode blend_mode) -> bool {
       using VS = SolidFillPipeline::VertexShader;
       VertexBufferBuilder<VS::PerVertexData> vtx_builder;
       {
@@ -670,7 +677,8 @@ TEST_P(EntityTest, BlendingModeOptions) {
           vtx_builder.CreateVertexBuffer(pass.GetTransientsBuffer()));
 
       VS::FrameInfo frame_info;
-      frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize());
+      frame_info.mvp =
+          Matrix::MakeOrthographic(pass.GetRenderTargetSize()) * world_matrix;
       frame_info.color = color.Premultiply();
       VS::BindFrameInfo(cmd,
                         pass.GetTransientsBuffer().EmplaceUniform(frame_info));
@@ -712,6 +720,7 @@ TEST_P(EntityTest, BlendingModeOptions) {
 
 TEST_P(EntityTest, BezierCircleScaled) {
   Entity entity;
+  entity.SetTransformation(Matrix::MakeScale(GetContentScale()));
   auto path = PathBuilder{}
                   .MoveTo({97.325, 34.818})
                   .CubicCurveTo({98.50862885295136, 34.81812293973836},
@@ -753,7 +762,8 @@ TEST_P(EntityTest, Filters) {
         {fi_bridge, FilterInput::Make(blend0), fi_bridge, fi_bridge});
 
     Entity entity;
-    entity.SetTransformation(Matrix::MakeTranslation({500, 300}) *
+    entity.SetTransformation(Matrix::MakeScale(GetContentScale()) *
+                             Matrix::MakeTranslation({500, 300}) *
                              Matrix::MakeScale(Vector2{0.5, 0.5}));
     entity.SetContents(blend1);
     return entity.Render(context, pass);
@@ -825,7 +835,8 @@ TEST_P(EntityTest, GaussianBlurFilter) {
         blur_styles[selected_blur_style]);
 
     auto input_size = bridge->GetSize();
-    auto ctm = Matrix::MakeTranslation(Vector3(offset[0], offset[1])) *
+    auto ctm = Matrix::MakeScale(GetContentScale()) *
+               Matrix::MakeTranslation(Vector3(offset[0], offset[1])) *
                Matrix::MakeRotationZ(Radians(rotation)) *
                Matrix::MakeScale(Vector2(scale[0], scale[1])) *
                Matrix::MakeSkew(skew[0], skew[1]) *
@@ -966,6 +977,7 @@ TEST_P(EntityTest, DrawVerticesSolidColorTrianglesWithoutIndex) {
       std::make_shared<VerticesContents>(vertices);
   contents->SetColor(Color::White());
   Entity e;
+  e.SetTransformation(Matrix::MakeScale(GetContentScale()));
   e.SetContents(contents);
 
   ASSERT_TRUE(OpenPlaygroundHere(e));

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -192,7 +192,8 @@ TEST_P(EntityTest, StrokeCapAndJoinTest) {
     }
     ImGui::End();
 
-    auto render_path = [width = width, &context, &pass](
+    auto world_matrix = Matrix::MakeScale(GetContentScale());
+    auto render_path = [width = width, &context, &pass, &world_matrix](
                            Path path, SolidStrokeContents::Cap cap,
                            SolidStrokeContents::Join join) {
       auto contents = std::make_unique<SolidStrokeContents>();
@@ -204,6 +205,7 @@ TEST_P(EntityTest, StrokeCapAndJoinTest) {
       contents->SetStrokeMiter(miter_limit);
 
       Entity entity;
+      entity.SetTransformation(world_matrix);
       entity.SetContents(std::move(contents));
 
       auto coverage = entity.GetCoverage();

--- a/impeller/playground/backend/gles/playground_impl_gles.cc
+++ b/impeller/playground/backend/gles/playground_impl_gles.cc
@@ -124,7 +124,7 @@ std::shared_ptr<Context> PlaygroundImplGLES::GetContext() const {
 }
 
 // |PlaygroundImpl|
-PlaygroundImpl::WindowHandle PlaygroundImplGLES::GetWindowHandle() {
+PlaygroundImpl::WindowHandle PlaygroundImplGLES::GetWindowHandle() const {
   return handle_.get();
 }
 

--- a/impeller/playground/backend/gles/playground_impl_gles.h
+++ b/impeller/playground/backend/gles/playground_impl_gles.h
@@ -27,7 +27,7 @@ class PlaygroundImplGLES final : public PlaygroundImpl {
   std::shared_ptr<Context> GetContext() const override;
 
   // |PlaygroundImpl|
-  WindowHandle GetWindowHandle() override;
+  WindowHandle GetWindowHandle() const override;
 
   // |PlaygroundImpl|
   std::unique_ptr<Surface> AcquireSurfaceFrame(

--- a/impeller/playground/backend/metal/playground_impl_mtl.h
+++ b/impeller/playground/backend/metal/playground_impl_mtl.h
@@ -32,7 +32,7 @@ class PlaygroundImplMTL final : public PlaygroundImpl {
   std::shared_ptr<Context> GetContext() const override;
 
   // |PlaygroundImpl|
-  WindowHandle GetWindowHandle() override;
+  WindowHandle GetWindowHandle() const override;
 
   // |PlaygroundImpl|
   std::unique_ptr<Surface> AcquireSurfaceFrame(

--- a/impeller/playground/backend/metal/playground_impl_mtl.mm
+++ b/impeller/playground/backend/metal/playground_impl_mtl.mm
@@ -84,7 +84,7 @@ std::shared_ptr<Context> PlaygroundImplMTL::GetContext() const {
 }
 
 // |PlaygroundImpl|
-PlaygroundImpl::WindowHandle PlaygroundImplMTL::GetWindowHandle() {
+PlaygroundImpl::WindowHandle PlaygroundImplMTL::GetWindowHandle() const {
   return handle_.get();
 }
 
@@ -96,9 +96,10 @@ std::unique_ptr<Surface> PlaygroundImplMTL::AcquireSurfaceFrame(
   }
 
   const auto layer_size = data_->metal_layer.bounds.size;
-  const auto layer_scale = data_->metal_layer.contentsScale;
-  data_->metal_layer.drawableSize = CGSizeMake(layer_size.width * layer_scale,
-                                               layer_size.height * layer_scale);
+  const auto scale = GetContentScale();
+  data_->metal_layer.drawableSize =
+      CGSizeMake(layer_size.width * scale.x, layer_size.height * scale.y);
+
   return SurfaceMTL::WrapCurrentMetalLayerDrawable(context, data_->metal_layer);
 }
 

--- a/impeller/playground/playground.cc
+++ b/impeller/playground/playground.cc
@@ -150,6 +150,10 @@ ISize Playground::GetWindowSize() const {
   return window_size_;
 }
 
+Point Playground::GetContentScale() const {
+  return impl_->GetContentScale();
+}
+
 void Playground::SetCursorPosition(Point pos) {
   cursor_position_ = pos;
 }

--- a/impeller/playground/playground.h
+++ b/impeller/playground/playground.h
@@ -44,6 +44,8 @@ class Playground : public ::testing::TestWithParam<PlaygroundBackend> {
 
   ISize GetWindowSize() const;
 
+  Point GetContentScale() const;
+
   std::shared_ptr<Context> GetContext() const;
 
   bool OpenPlaygroundHere(Renderer::RenderCallback render_callback);

--- a/impeller/playground/playground_impl.cc
+++ b/impeller/playground/playground_impl.cc
@@ -42,11 +42,11 @@ PlaygroundImpl::~PlaygroundImpl() = default;
 
 Vector2 PlaygroundImpl::GetContentScale() const {
   auto window = reinterpret_cast<GLFWwindow*>(GetWindowHandle());
-  TSize<int> window_size, framebuffer_size;
-  ::glfwGetWindowSize(window, &window_size.width, &window_size.height);
-  ::glfwGetFramebufferSize(window, &framebuffer_size.width,
-                           &framebuffer_size.height);
-  return Vector2(framebuffer_size)/window_size;
+
+  Vector2 scale(1, 1);
+  ::glfwGetWindowContentScale(window, &scale.x, &scale.y);
+
+  return scale;
 }
 
 }  // namespace impeller

--- a/impeller/playground/playground_impl.cc
+++ b/impeller/playground/playground_impl.cc
@@ -4,6 +4,9 @@
 
 #include "impeller/playground/playground_impl.h"
 
+#define GLFW_INCLUDE_NONE
+#import "third_party/glfw/include/GLFW/glfw3.h"
+
 #if IMPELLER_ENABLE_METAL
 #include "impeller/playground/backend/metal/playground_impl_mtl.h"
 #endif  // IMPELLER_ENABLE_METAL
@@ -36,5 +39,14 @@ std::unique_ptr<PlaygroundImpl> PlaygroundImpl::Create(
 PlaygroundImpl::PlaygroundImpl() = default;
 
 PlaygroundImpl::~PlaygroundImpl() = default;
+
+Vector2 PlaygroundImpl::GetContentScale() const {
+  auto window = reinterpret_cast<GLFWwindow*>(GetWindowHandle());
+  TSize<int> window_size, framebuffer_size;
+  ::glfwGetWindowSize(window, &window_size.width, &window_size.height);
+  ::glfwGetFramebufferSize(window, &framebuffer_size.width,
+                           &framebuffer_size.height);
+  return Vector2(framebuffer_size)/window_size;
+}
 
 }  // namespace impeller

--- a/impeller/playground/playground_impl.cc
+++ b/impeller/playground/playground_impl.cc
@@ -5,7 +5,7 @@
 #include "impeller/playground/playground_impl.h"
 
 #define GLFW_INCLUDE_NONE
-#import "third_party/glfw/include/GLFW/glfw3.h"
+#include "third_party/glfw/include/GLFW/glfw3.h"
 
 #if IMPELLER_ENABLE_METAL
 #include "impeller/playground/backend/metal/playground_impl_mtl.h"

--- a/impeller/playground/playground_impl.h
+++ b/impeller/playground/playground_impl.h
@@ -21,12 +21,14 @@ class PlaygroundImpl {
 
   using WindowHandle = void*;
 
-  virtual WindowHandle GetWindowHandle() = 0;
+  virtual WindowHandle GetWindowHandle() const = 0;
 
   virtual std::shared_ptr<Context> GetContext() const = 0;
 
   virtual std::unique_ptr<Surface> AcquireSurfaceFrame(
       std::shared_ptr<Context> context) = 0;
+
+  Vector2 GetContentScale() const;
 
  protected:
   PlaygroundImpl();

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -76,7 +76,8 @@ TEST_P(RendererTest, CanCreateBoxPrimitive) {
     cmd.BindVertices(vertex_buffer);
 
     VS::UniformBuffer uniforms;
-    uniforms.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize());
+    uniforms.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
+                   Matrix::MakeScale(GetContentScale());
     VS::BindUniformBuffer(cmd,
                           pass.GetTransientsBuffer().EmplaceUniform(uniforms));
 
@@ -158,6 +159,7 @@ TEST_P(RendererTest, CanRenderMultiplePrimitives) {
       for (size_t j = 0; j < 1; j++) {
         VS::UniformBuffer uniforms;
         uniforms.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
+                       Matrix::MakeScale(GetContentScale()) *
                        Matrix::MakeTranslation({i * 50.0f, j * 50.0f, 0.0f});
         VS::BindUniformBuffer(
             cmd, pass.GetTransientsBuffer().EmplaceUniform(uniforms));
@@ -324,7 +326,8 @@ TEST_P(RendererTest, CanRenderInstanced) {
 
   ASSERT_TRUE(OpenPlaygroundHere([&](RenderPass& pass) -> bool {
     VS::FrameInfo frame_info;
-    frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize());
+    frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
+                     Matrix::MakeScale(GetContentScale());
     VS::BindFrameInfo(cmd,
                       pass.GetTransientsBuffer().EmplaceUniform(frame_info));
     VS::BindInstanceInfo(


### PR DESCRIPTION
Depends on https://github.com/flutter/engine/pull/33706.

* Make high DPI work in the Metal playground. Previously, the drawable size was always ending up with the window size in screen coordinates.
* Add high DPI support to the ImGui Impeller backend. Conveniently, ImGui keeps track of a content scale value, and platform backends like `imgui_impl_glfw` already set it correctly, so there's no need for extra params on e.g. `ImGui_ImplImpeller_RenderDrawData()`. :)
* Make all renderer/entity unittests and some some aiks/displaylist unittest (the ones that use ImGui) resolution independent.
* Smoke tested this for GLES and Metal for macOS + GLES on Windows.