### PR TITLE
[Impeller] Account for differences in coordinate spaces between OpenGL & Metal.

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -225,6 +225,47 @@ TEST_P(AiksTest, CanRenderGroupOpacity) {
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
+TEST_P(AiksTest, CoordinateConversionsAreCorrect) {
+  Canvas canvas;
+
+  // Render a texture directly.
+  {
+    Paint paint;
+    auto image =
+        std::make_shared<Image>(CreateTextureForFixture("kalimba.jpg"));
+    paint.color = Color::Red();
+
+    canvas.Save();
+    canvas.Translate({100, 200, 0});
+    canvas.Scale(Vector2{0.5, 0.5});
+    canvas.DrawImage(image, Point::MakeXY(100.0, 100.0), paint);
+    canvas.Restore();
+  }
+
+  // Render an offscreen rendered texture.
+  {
+    Paint red;
+    red.color = Color::Red();
+    Paint green;
+    green.color = Color::Green();
+    Paint blue;
+    blue.color = Color::Blue();
+
+    Paint alpha;
+    alpha.color = Color::Red().WithAlpha(0.5);
+
+    canvas.SaveLayer(alpha);
+
+    canvas.DrawRect({000, 000, 100, 100}, red);
+    canvas.DrawRect({020, 020, 100, 100}, green);
+    canvas.DrawRect({040, 040, 100, 100}, blue);
+
+    canvas.Restore();
+  }
+
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
 TEST_P(AiksTest, CanPerformFullScreenMSAA) {
   Canvas canvas;
 

--- a/impeller/entity/contents/texture_contents.cc
+++ b/impeller/entity/contents/texture_contents.cc
@@ -101,6 +101,9 @@ bool TextureContents::Render(const ContentContext& renderer,
                    entity.GetTransformation();
   frame_info.alpha = opacity_;
 
+  FS::FragInfo frag_info;
+  frag_info.texture_sampler_y_coord_scale = texture_->GetYCoordScale();
+
   Command cmd;
   cmd.label = "TextureFill";
   cmd.pipeline =
@@ -108,6 +111,7 @@ bool TextureContents::Render(const ContentContext& renderer,
   cmd.stencil_reference = entity.GetStencilDepth();
   cmd.BindVertices(vertex_builder.CreateVertexBuffer(host_buffer));
   VS::BindFrameInfo(cmd, host_buffer.EmplaceUniform(frame_info));
+  FS::BindFragInfo(cmd, host_buffer.EmplaceUniform(frag_info));
   FS::BindTextureSampler(cmd, texture_,
                          renderer.GetContext()->GetSamplerLibrary()->GetSampler(
                              sampler_descriptor_));

--- a/impeller/entity/shaders/texture_fill.frag
+++ b/impeller/entity/shaders/texture_fill.frag
@@ -2,7 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "utils.sl.h"
+
 uniform sampler2D texture_sampler;
+uniform FragInfo {
+  float texture_sampler_y_coord_scale;
+} frag_info;
 
 in vec2 v_texture_coords;
 in float v_alpha;
@@ -10,6 +15,6 @@ in float v_alpha;
 out vec4 frag_color;
 
 void main() {
-  vec4 sampled = texture(texture_sampler, v_texture_coords);
+  vec4 sampled = ImpellerTexture(texture_sampler, v_texture_coords, frag_info.texture_sampler_y_coord_scale);
   frag_color = sampled * v_alpha;
 }

--- a/impeller/entity/shaders/utils.sl.h
+++ b/impeller/entity/shaders/utils.sl.h
@@ -1,0 +1,12 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+vec4 ImpellerTexture(sampler2D texture_sampler,
+                     vec2 coords,
+                     float y_coord_scale) {
+  if (y_coord_scale < 0.0) {
+    coords.y = 1.0 - coords.y;
+  }
+  return texture(texture_sampler, coords);
+}

--- a/impeller/renderer/backend/gles/texture_gles.cc
+++ b/impeller/renderer/backend/gles/texture_gles.cc
@@ -344,7 +344,6 @@ void TextureGLES::InitializeContentsIfNecessary() const {
                                size.height                    // height
         );
       }
-
       break;
   }
 }
@@ -431,6 +430,17 @@ bool TextureGLES::SetAsFramebufferAttachment(GLuint fbo,
       break;
   }
   return true;
+}
+
+// |Texture|
+Scalar TextureGLES::GetYCoordScale() const {
+  switch (GetIntent()) {
+    case TextureIntent::kUploadFromHost:
+      return 1.0;
+    case TextureIntent::kRenderToTexture:
+      return -1.0;
+  }
+  FML_UNREACHABLE();
 }
 
 }  // namespace impeller

--- a/impeller/renderer/backend/gles/texture_gles.h
+++ b/impeller/renderer/backend/gles/texture_gles.h
@@ -79,6 +79,9 @@ class TextureGLES final : public Texture,
   // |Texture|
   ISize GetSize() const override;
 
+  // |Texture|
+  Scalar GetYCoordScale() const override;
+
   void InitializeContentsIfNecessary() const;
 
   FML_DISALLOW_COPY_AND_ASSIGN(TextureGLES);

--- a/impeller/renderer/formats.h
+++ b/impeller/renderer/formats.h
@@ -154,6 +154,11 @@ enum class TextureUsage : TextureUsageMask {
   kRenderTarget = 1 << 2,
 };
 
+enum class TextureIntent {
+  kUploadFromHost,
+  kRenderToTexture,
+};
+
 enum class CullMode {
   kNone,
   kFrontFace,

--- a/impeller/renderer/texture.cc
+++ b/impeller/renderer/texture.cc
@@ -19,7 +19,11 @@ bool Texture::SetContents(const uint8_t* contents,
     VALIDATION_LOG << "Invalid slice for texture.";
     return false;
   }
-  return OnSetContents(contents, length, slice);
+  if (!OnSetContents(contents, length, slice)) {
+    return false;
+  }
+  intent_ = TextureIntent::kUploadFromHost;
+  return true;
 }
 
 bool Texture::SetContents(std::shared_ptr<const fml::Mapping> mapping,
@@ -28,12 +32,14 @@ bool Texture::SetContents(std::shared_ptr<const fml::Mapping> mapping,
     VALIDATION_LOG << "Invalid slice for texture.";
     return false;
   }
-
   if (!mapping) {
     return false;
   }
-
-  return OnSetContents(std::move(mapping), slice);
+  if (!OnSetContents(std::move(mapping), slice)) {
+    return false;
+  }
+  intent_ = TextureIntent::kUploadFromHost;
+  return true;
 }
 
 const TextureDescriptor& Texture::GetTextureDescriptor() const {
@@ -49,6 +55,14 @@ bool Texture::IsSliceValid(size_t slice) const {
       return slice <= 5;
   }
   FML_UNREACHABLE();
+}
+
+TextureIntent Texture::GetIntent() const {
+  return intent_;
+}
+
+Scalar Texture::GetYCoordScale() const {
+  return 1.0;
 }
 
 }  // namespace impeller

--- a/impeller/renderer/texture.h
+++ b/impeller/renderer/texture.h
@@ -33,6 +33,10 @@ class Texture {
 
   const TextureDescriptor& GetTextureDescriptor() const;
 
+  TextureIntent GetIntent() const;
+
+  virtual Scalar GetYCoordScale() const;
+
  protected:
   Texture(TextureDescriptor desc);
 
@@ -45,6 +49,7 @@ class Texture {
       size_t slice) = 0;
 
  private:
+  TextureIntent intent_ = TextureIntent::kRenderToTexture;
   const TextureDescriptor desc_;
 
   bool IsSliceValid(size_t slice) const;


### PR DESCRIPTION
Impellers default coordinate system is that of Metal. While the NDC in Metal and
OpenGL is the same, texture coordinates in OpenGL are (0, 0) bottom-left origin
with +Y being up. OTOH, Metals texture coordinates are (0, 0) top-left origin
with +Y being down. If the texture was rendered to, there is nothing to do
because any fixups to the coordinate space are already applied. However, if the
texture data was specified from the host (via a call like `glTexImage2D`), the
fixup must be applied in the shader. The texture intent is now tracked in the
`impeller::Texture` and a uniform containing the scale specified to the shader
so a Y-flip may be applied according the texture intent.

I have applied this flip to the default texture fill shader which should catch
most instances of errors due to Y-flip in OpenGL. But there are others that I
have missed around the usage of intermediate textures in blends and such. I will
patch those in a subsequent patch. I have filed an issue for that.

Fixes https://github.com/flutter/flutter/issues/104754
Followup https://github.com/flutter/flutter/issues/105052, https://github.com/flutter/flutter/issues/105053