### PR TITLE
[Impeller] Implement DlImageFilterType::kBlur

### DIFF
--- a/impeller/aiks/paint.cc
+++ b/impeller/aiks/paint.cc
@@ -48,6 +48,11 @@ std::shared_ptr<Contents> Paint::WithFilters(
     input = filter(FilterInput::Make(input), is_solid_color_val);
   }
 
+  if (image_filter.has_value()) {
+    const ImageFilterProc& filter = image_filter.value();
+    input = filter(FilterInput::Make(input));
+  }
+
   if (color_filter.has_value()) {
     const ColorFilterProc& filter = color_filter.value();
     input = filter(FilterInput::Make(input));

--- a/impeller/aiks/paint.h
+++ b/impeller/aiks/paint.h
@@ -17,11 +17,12 @@
 namespace impeller {
 
 struct Paint {
+  using ImageFilterProc =
+      std::function<std::shared_ptr<FilterContents>(FilterInput::Ref)>;
+  using ColorFilterProc = ImageFilterProc;
   using MaskFilterProc =
       std::function<std::shared_ptr<FilterContents>(FilterInput::Ref,
                                                     bool is_solid_color)>;
-  using ColorFilterProc =
-      std::function<std::shared_ptr<FilterContents>(FilterInput::Ref)>;
 
   enum class Style {
     kFill,
@@ -38,8 +39,9 @@ struct Paint {
   Style style = Style::kFill;
   Entity::BlendMode blend_mode = Entity::BlendMode::kSourceOver;
 
-  std::optional<MaskFilterProc> mask_filter;
+  std::optional<ImageFilterProc> image_filter;
   std::optional<ColorFilterProc> color_filter;
+  std::optional<MaskFilterProc> mask_filter;
 
   /// @brief      Wrap this paint's configured filters to the given contents.
   /// @param[in]  input           The contents to wrap with paint's filters.

--- a/impeller/display_list/display_list_dispatcher.cc
+++ b/impeller/display_list/display_list_dispatcher.cc
@@ -9,6 +9,7 @@
 
 #include "display_list/display_list_blend_mode.h"
 #include "display_list/display_list_path_effect.h"
+#include "display_list/display_list_tile_mode.h"
 #include "flutter/fml/logging.h"
 #include "flutter/fml/trace_event.h"
 #include "impeller/entity/contents/filters/filter_contents.h"
@@ -321,6 +322,11 @@ void DisplayListDispatcher::setImageFilter(
       auto blur = filter->asBlur();
       auto sigma_x = FilterContents::Sigma(blur->sigma_x());
       auto sigma_y = FilterContents::Sigma(blur->sigma_y());
+
+      if (blur->tile_mode() != flutter::DlTileMode::kClamp) {
+        // TODO(105072): Implement tile mode for blur filter.
+        UNIMPLEMENTED;
+      }
 
       paint_.image_filter = [sigma_x, sigma_y](FilterInput::Ref input) {
         return FilterContents::MakeGaussianBlur(input, sigma_x, sigma_y);

--- a/impeller/display_list/display_list_dispatcher.cc
+++ b/impeller/display_list/display_list_dispatcher.cc
@@ -316,7 +316,27 @@ void DisplayListDispatcher::setMaskFilter(const flutter::DlMaskFilter* filter) {
 // |flutter::Dispatcher|
 void DisplayListDispatcher::setImageFilter(
     const flutter::DlImageFilter* filter) {
-  UNIMPLEMENTED;
+  switch (filter->type()) {
+    case flutter::DlImageFilterType::kBlur: {
+      auto blur = filter->asBlur();
+      auto sigma_x = FilterContents::Sigma(blur->sigma_x());
+      auto sigma_y = FilterContents::Sigma(blur->sigma_y());
+
+      paint_.image_filter = [sigma_x, sigma_y](FilterInput::Ref input) {
+        return FilterContents::MakeGaussianBlur(input, sigma_x, sigma_y);
+      };
+
+      break;
+    }
+    case flutter::DlImageFilterType::kDilate:
+    case flutter::DlImageFilterType::kErode:
+    case flutter::DlImageFilterType::kMatrix:
+    case flutter::DlImageFilterType::kComposeFilter:
+    case flutter::DlImageFilterType::kColorFilter:
+    case flutter::DlImageFilterType::kUnknown:
+      UNIMPLEMENTED;
+      break;
+  }
 }
 
 // |flutter::Dispatcher|

--- a/impeller/display_list/display_list_unittests.cc
+++ b/impeller/display_list/display_list_unittests.cc
@@ -4,6 +4,8 @@
 
 #include "display_list/display_list_blend_mode.h"
 #include "display_list/display_list_color_filter.h"
+#include "display_list/display_list_image_filter.h"
+#include "display_list/display_list_tile_mode.h"
 #include "gtest/gtest.h"
 #include "third_party/imgui/imgui.h"
 #include "third_party/skia/include/core/SkColor.h"
@@ -250,6 +252,37 @@ TEST_P(DisplayListTest, CanDrawWithBlendColorFilter) {
   }
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
+}
+
+TEST_P(DisplayListTest, CanDrawWithImageBlurFilter) {
+  auto texture = CreateTextureForFixture("embarcadero.jpg");
+
+  bool first_frame = true;
+  auto callback = [&]() {
+    if (first_frame) {
+      first_frame = false;
+      ImGui::SetNextWindowSize({400, 100});
+      ImGui::SetNextWindowPos({300, 550});
+    }
+
+    static float sigma[] = {10, 10};
+
+    ImGui::Begin("Controls");
+    ImGui::SliderFloat2("Sigma", sigma, 0, 100);
+    ImGui::End();
+
+    flutter::DisplayListBuilder builder;
+
+    auto filter = flutter::DlBlurImageFilter(sigma[0], sigma[1],
+                                             flutter::DlTileMode::kClamp);
+    builder.setImageFilter(&filter);
+    builder.drawImage(DlImageImpeller::Make(texture), SkPoint::Make(200, 200),
+                      SkSamplingOptions{}, true);
+
+    return builder.Build();
+  };
+
+  ASSERT_TRUE(OpenPlaygroundHere(callback));
 }
 
 }  // namespace testing


### PR DESCRIPTION
Handle image blurs in the display list dispatcher.

`impeller_unittests --gtest_filter="Play/DisplayListTest.CanDrawWithImageBlurFilter/Metal" --timeout=0`

https://user-images.githubusercontent.com/919017/171300549-469bb401-e579-49b2-8389-c83d37867785.mov


Right now, this filter only supports clamp mode sampling. Added a bug here for this: https://github.com/flutter/flutter/issues/105072