### PR TITLE
[Impeller] Fix failing CanDrawWithBlendColorFilter test.

### DIFF
--- a/impeller/display_list/display_list_dispatcher.cc
+++ b/impeller/display_list/display_list_dispatcher.cc
@@ -34,44 +34,55 @@ DisplayListDispatcher::~DisplayListDispatcher() = default;
 
 static std::optional<Entity::BlendMode> ToBlendMode(flutter::DlBlendMode mode) {
   // TODO(100086): Implement remaining advanced blends.
-  static const std::unordered_map<flutter::DlBlendMode,
-                                  std::optional<Entity::BlendMode>>
-      blends = {
-          {flutter::DlBlendMode::kClear, Entity::BlendMode::kClear},
-          {flutter::DlBlendMode::kSrc, Entity::BlendMode::kSource},
-          {flutter::DlBlendMode::kDst, Entity::BlendMode::kDestination},
-          {flutter::DlBlendMode::kSrcOver, Entity::BlendMode::kSourceOver},
-          {flutter::DlBlendMode::kDstOver, Entity::BlendMode::kDestinationOver},
-          {flutter::DlBlendMode::kSrcIn, Entity::BlendMode::kSourceIn},
-          {flutter::DlBlendMode::kDstIn, Entity::BlendMode::kDestinationIn},
-          {flutter::DlBlendMode::kSrcOut, Entity::BlendMode::kSourceOut},
-          {flutter::DlBlendMode::kDstOut, Entity::BlendMode::kDestinationOut},
-          {flutter::DlBlendMode::kSrcATop, Entity::BlendMode::kSourceATop},
-          {flutter::DlBlendMode::kDstATop, Entity::BlendMode::kDestinationATop},
-          {flutter::DlBlendMode::kXor, Entity::BlendMode::kXor},
-          {flutter::DlBlendMode::kPlus, Entity::BlendMode::kPlus},
-          {flutter::DlBlendMode::kModulate, Entity::BlendMode::kModulate},
-          {flutter::DlBlendMode::kScreen, Entity::BlendMode::kScreen},
-          {flutter::DlBlendMode::kOverlay, std::nullopt},
-          {flutter::DlBlendMode::kDarken, std::nullopt},
-          {flutter::DlBlendMode::kLighten, std::nullopt},
-          {flutter::DlBlendMode::kColorDodge, std::nullopt},
-          {flutter::DlBlendMode::kColorBurn, Entity::BlendMode::kColorBurn},
-          {flutter::DlBlendMode::kHardLight, std::nullopt},
-          {flutter::DlBlendMode::kSoftLight, std::nullopt},
-          {flutter::DlBlendMode::kDifference, std::nullopt},
-          {flutter::DlBlendMode::kExclusion, std::nullopt},
-          {flutter::DlBlendMode::kMultiply, std::nullopt},
-          {flutter::DlBlendMode::kHue, std::nullopt},
-          {flutter::DlBlendMode::kSaturation, std::nullopt},
-          {flutter::DlBlendMode::kColor, std::nullopt},
-          {flutter::DlBlendMode::kLuminosity, std::nullopt},
-      };
-  FML_DCHECK(blends.size() ==
-             static_cast<size_t>(Entity::BlendMode::kLastAdvancedBlendMode) +
-                 1);
-
-  return blends.at(mode);
+  switch (mode) {
+    case flutter::DlBlendMode::kClear:
+      return Entity::BlendMode::kClear;
+    case flutter::DlBlendMode::kSrc:
+      return Entity::BlendMode::kSource;
+    case flutter::DlBlendMode::kDst:
+      return Entity::BlendMode::kDestination;
+    case flutter::DlBlendMode::kSrcOver:
+      return Entity::BlendMode::kSourceOver;
+    case flutter::DlBlendMode::kDstOver:
+      return Entity::BlendMode::kDestinationOver;
+    case flutter::DlBlendMode::kSrcIn:
+      return Entity::BlendMode::kSourceIn;
+    case flutter::DlBlendMode::kDstIn:
+      return Entity::BlendMode::kDestinationIn;
+    case flutter::DlBlendMode::kSrcOut:
+      return Entity::BlendMode::kSourceOut;
+    case flutter::DlBlendMode::kDstOut:
+      return Entity::BlendMode::kDestinationOut;
+    case flutter::DlBlendMode::kSrcATop:
+      return Entity::BlendMode::kSourceATop;
+    case flutter::DlBlendMode::kDstATop:
+      return Entity::BlendMode::kDestinationATop;
+    case flutter::DlBlendMode::kXor:
+      return Entity::BlendMode::kXor;
+    case flutter::DlBlendMode::kPlus:
+      return Entity::BlendMode::kPlus;
+    case flutter::DlBlendMode::kModulate:
+      return Entity::BlendMode::kModulate;
+    case flutter::DlBlendMode::kScreen:
+      return Entity::BlendMode::kScreen;
+    case flutter::DlBlendMode::kColorBurn:
+      return Entity::BlendMode::kColorBurn;
+    case flutter::DlBlendMode::kOverlay:
+    case flutter::DlBlendMode::kDarken:
+    case flutter::DlBlendMode::kLighten:
+    case flutter::DlBlendMode::kColorDodge:
+    case flutter::DlBlendMode::kHardLight:
+    case flutter::DlBlendMode::kSoftLight:
+    case flutter::DlBlendMode::kDifference:
+    case flutter::DlBlendMode::kExclusion:
+    case flutter::DlBlendMode::kMultiply:
+    case flutter::DlBlendMode::kHue:
+    case flutter::DlBlendMode::kSaturation:
+    case flutter::DlBlendMode::kColor:
+    case flutter::DlBlendMode::kLuminosity:
+      return std::nullopt;
+  }
+  FML_UNREACHABLE();
 }
 
 // |flutter::Dispatcher|

--- a/impeller/entity/contents/filters/blend_filter_contents.cc
+++ b/impeller/entity/contents/filters/blend_filter_contents.cc
@@ -98,6 +98,9 @@ static bool AdvancedBlend(const FilterInput::Vector& inputs,
   if (foreground_color.has_value()) {
     blend_info.color_factor = 1;
     blend_info.color = foreground_color.value();
+    // This texture will not be sampled from due to the color factor. But this
+    // is present so that validation doesn't trip on a missing binding.
+    FS::BindTextureSamplerSrc(cmd, dst_snapshot->texture, sampler);
   } else {
     blend_info.color_factor = 0;
     FS::BindTextureSamplerSrc(cmd, src_snapshot->texture, sampler);


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/105071.

Lets use switches instead of maps. First, they don't encounter runtime
constructors. Second, they will yell at static analysis if there is a
missing case (as long as we don't have `default`s).

Also fixed a Metal validation issue. Since we weren't sampling from the
source in case of a foreground, we weren't binding a texture and sampler
at that location. I just bound the dest to that spot and everyone is
happy. We won't actually sample from that binding.