### PR TITLE
[Impeller] Control GL error checking and tracing via GN options.

### DIFF
--- a/impeller/BUILD.gn
+++ b/impeller/BUILD.gn
@@ -25,6 +25,14 @@ config("impeller_public_config") {
     defines += [ "IMPELLER_ENABLE_OPENGLES=1" ]
   }
 
+  if (impeller_trace_all_gl_calls) {
+    defines += [ "IMPELLER_TRACE_ALL_GL_CALLS" ]
+  }
+
+  if (impeller_error_check_all_gl_calls) {
+    defines += [ "IMPELLER_ERROR_CHECK_ALL_GL_CALLS" ]
+  }
+
   if (is_win) {
     defines += [
       "_USE_MATH_DEFINES",

--- a/impeller/renderer/backend/gles/proc_table_gles.h
+++ b/impeller/renderer/backend/gles/proc_table_gles.h
@@ -11,6 +11,7 @@
 #include "flutter/fml/logging.h"
 #include "flutter/fml/macros.h"
 #include "flutter/fml/mapping.h"
+#include "flutter/fml/trace_event.h"
 #include "impeller/renderer/backend/gles/capabilities_gles.h"
 #include "impeller/renderer/backend/gles/description_gles.h"
 #include "impeller/renderer/backend/gles/gles.h"
@@ -64,7 +65,12 @@ struct GLProc {
   ///
   template <class... Args>
   auto operator()(Args&&... args) const {
+#ifdef IMPELLER_ERROR_CHECK_ALL_GL_CALLS
     AutoErrorCheck error(error_fn, name);
+#endif  // IMPELLER_ERROR_CHECK_ALL_GL_CALLS
+#ifdef IMPELLER_TRACE_ALL_GL_CALLS
+    TRACE_EVENT0("impeller", name);
+#endif  // IMPELLER_TRACE_ALL_GL_CALLS
     return function(std::forward<Args>(args)...);
   }
 

--- a/impeller/tools/impeller.gni
+++ b/impeller/tools/impeller.gni
@@ -23,6 +23,13 @@ declare_args() {
   # If this is the empty string, impellerc will be built.
   # If it is non-empty, it should be the absolute path to impellerc.
   impeller_use_prebuilt_impellerc = ""
+
+  # If enabled, all OpenGL calls will be traced. Because additional trace
+  # overhead may be substantial, this is not enabled by default.
+  impeller_trace_all_gl_calls = false
+
+  # Call glGetError after each OpenGL call and log failures.
+  impeller_error_check_all_gl_calls = is_debug
 }
 
 declare_args() {


### PR DESCRIPTION
Now that https://github.com/flutter/flutter/issues/104712 is complete, it no
longer makes sense to perform an error check after every single OpenGL call.
Only restrict to debug modes but allow configuration based on GN args. Also
allow tracing all OpenGL calls based on a GN flag.