### PR TITLE
Fix layer tree snapshot values

### DIFF
--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -950,6 +950,7 @@ void Shell::OnPlatformViewSetViewportMetrics(const ViewportMetrics& metrics) {
     std::scoped_lock<std::mutex> lock(resize_mutex_);
     expected_frame_size_ =
         SkISize::Make(metrics.physical_width, metrics.physical_height);
+    device_pixel_ratio_ = metrics.device_pixel_ratio;
   }
 }
 
@@ -1812,6 +1813,7 @@ bool Shell::OnServiceProtocolSetAssetBundlePath(
 }
 
 static rapidjson::Value SerializeLayerSnapshot(
+    double device_pixel_ratio,
     const LayerSnapshotData& snapshot,
     rapidjson::Document* response) {
   auto& allocator = response->GetAllocator();
@@ -1822,10 +1824,10 @@ static rapidjson::Value SerializeLayerSnapshot(
                    allocator);
 
   const SkRect bounds = snapshot.GetBounds();
-  result.AddMember("top", bounds.top(), allocator);
-  result.AddMember("left", bounds.left(), allocator);
-  result.AddMember("width", bounds.width(), allocator);
-  result.AddMember("height", bounds.height(), allocator);
+  result.AddMember("top", bounds.top() * device_pixel_ratio, allocator);
+  result.AddMember("left", bounds.left() * device_pixel_ratio, allocator);
+  result.AddMember("width", bounds.width() * device_pixel_ratio, allocator);
+  result.AddMember("height", bounds.height() * device_pixel_ratio, allocator);
 
   sk_sp<SkData> snapshot_bytes = snapshot.GetSnapshot();
   if (snapshot_bytes) {
@@ -1870,12 +1872,14 @@ bool Shell::OnServiceProtocolRenderFrameWithRasterStats(
     LayerSnapshotStore& store =
         rasterizer_->compositor_context()->snapshot_store();
     for (const LayerSnapshotData& data : store) {
-      snapshots.PushBack(SerializeLayerSnapshot(data, response), allocator);
+      snapshots.PushBack(
+          SerializeLayerSnapshot(device_pixel_ratio_, data, response),
+          allocator);
     }
 
     response->AddMember("snapshots", snapshots, allocator);
 
-    const auto& frame_size = last_layer_tree->frame_size();
+    const auto& frame_size = expected_frame_size_;
     response->AddMember("frame_width", frame_size.width(), allocator);
     response->AddMember("frame_height", frame_size.height(), allocator);
 

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -473,6 +473,9 @@ class Shell final : public PlatformView::Delegate,
   // used to discard wrong size layer tree produced during interactive resizing
   SkISize expected_frame_size_ = SkISize::MakeEmpty();
 
+  // Used to communicate the right frame bounds via service protocol.
+  double device_pixel_ratio_ = 0.0;
+
   // How many frames have been timed since last report.
   size_t UnreportedFramesCount() const;
 


### PR DESCRIPTION
* frame dimensions were not taking device pixel ratio into account.
* individual snapshot offsets and dimensions were also incorrect for not accounting device pixel ratio.