### PR TITLE
Print clang-tidy job exception

### DIFF
--- a/tools/clang_tidy/lib/clang_tidy.dart
+++ b/tools/clang_tidy/lib/clang_tidy.dart
@@ -229,6 +229,10 @@ class ClangTidy {
       }
       _errSink.writeln('❌ Failures for ${job.name}:');
       _errSink.writeln(job.result.stdout);
+      final Exception? exception = job.exception;
+      if (exception != null) {
+        _errSink.writeln(exception);
+      }
       result = 1;
     }
     return result;


### PR DESCRIPTION
When clang-tidy job has an exception, print the message.

On https://github.com/flutter/flutter/issues/105155 this went from printing nothing to:
```
❌ Failures for clang-tidy on /Users/m/Projects/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterMenuPlugin.mm:

ProcessRunnerException: Running "../../buildtools/mac-x64/clang/bin/clang-tidy /Users/m/Projects/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterMenuPlugin.mm --  ++ -MD  obj/flutter/shell/platform/darwin/macos/framework/Source/flutter_framework_source.FlutterMenuPlugin.o.d  -DFLUTTER_FRAMEWORK -DFLUTTER_ENGINE_NO_PROTOTYPES -DUSE_OPENSSL=1 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D_FORTIFY_SOURCE=2 -D_LIBCPP_DISABLE_AVAILABILITY=1 -D_LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS -D_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS -DNDEBUG -DNVALGRIND -DDYNAMIC_ANNOTATIONS_ENABLED=0 -DSK_GL -DSK_VULKAN -DSK_METAL -DSK_SUPPORT_GPU=1 -DSK_CODEC_DECODES_JPEG -DSK_ENCODE_JPEG -DSK_CODEC_DECODES_PNG -DSK_ENCODE_PNG -DSK_CODEC_DECODES_WEBP -DSK_ENCODE_WEBP -DSK_HAS_WUFFS_LIBRARY -DFLUTTER_RUNTIME_MODE_DEBUG=1 -DFLUTTER_RUNTIME_MODE_PROFILE=2 -DFLUTTER_RUNTIME_MODE_RELEASE=3 -DFLUTTER_RUNTIME_MODE_JIT_RELEASE=4 "-DDART_LEGACY_API=[[deprecated]]" -DFLUTTER_RUNTIME_MODE=1 -DFLUTTER_JIT_RUNTIME=1 -DVULKAN_HPP_NO_EXCEPTIONS=1 -DSK_ENABLE_DUMP_GPU -DSK_DISABLE_AAA -DSK_PARAGRAPH_LIBTXT_SPACES_RESOLUTION -DSK_LEGACY_INNER_JOINS -DSK_LEGACY_IGNORE_DRAW_VERTICES_BLEND_WITH_NO_SHADER -DSK_DISABLE_LEGACY_SHADERCONTEXT -DSK_DISABLE_LOWP_RASTER_PIPELINE -DSK_FORCE_RASTER_PIPELINE_BLITTER -DSK_DISABLE_EFFECT_DESERIALIZATION -DSK_ENABLE_SKSL -DSK_ENABLE_API_AVAILABLE -DU_USING_ICU_NAMESPACE=0 -DU_ENABLE_DYLOAD=0 -DUSE_CHROMIUM_ICU=1 -DU_ENABLE_TRACING=1 -DU_ENABLE_RESOURCE_TRACING=0 -DU_STATIC_IMPLEMENTATION -DICU_UTIL_DATA_IMPL=ICU_UTIL_DATA_FILE -DRAPIDJSON_HAS_STDSTRING -DRAPIDJSON_HAS_CXX11_RANGE_FOR -DRAPIDJSON_HAS_CXX11_RVALUE_REFS -DRAPIDJSON_HAS_CXX11_TYPETRAITS -DRAPIDJSON_HAS_CXX11_NOEXCEPT -DIMPELLER_SUPPORTS_PLATFORM=1 -DIMPELLER_SUPPORTS_RENDERING=1 -DIMPELLER_ENABLE_METAL=1 -DIMPELLER_ENABLE_OPENGLES=1 -DFLUTTER_API_SYMBOL_PREFIX=Embedder -DFLUTTER_NO_EXPORT -DSHELL_ENABLE_SOFTWARE -DSHELL_ENABLE_GL -DSHELL_ENABLE_VULKAN -DSHELL_ENABLE_METAL  -I../.. -Igen -I../../third_party/libcxx/include -I../../third_party/libcxxabi/include -I../../third_party/vulkan-headers/include -I../../third_party/skia -I../../flutter/third_party -I../../flutter -I../../third_party/dart/runtime -I../../third_party/dart/runtime/include -I../../flutter/third_party/txt/src -I../../third_party/harfbuzz/src -I../../third_party/icu/source/common -I../../third_party/icu/source/i18n -I../../third_party/rapidjson -I../../third_party/rapidjson/include -Igen/flutter -I../../third_party/angle/include -I../../flutter/third_party/accessibility -I../../flutter/shell/platform/embedder -I../../flutter/shell/platform/darwin/common/framework/Headers -isysroot /Users/m/Applications/Xcode-13-4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk -mmacosx-version-min=10.11.0  -fno-strict-aliasing -fstack-protector-all -arch x86_64 -fcolor-diagnostics -Wall -Wextra -Wendif-labels -Werror -Wno-missing-field-initializers -Wno-unused-parameter -Wno-unused-but-set-parameter -Wno-unused-but-set-variable -Wno-implicit-int-float-conversion -Wno-c99-designator -Wno-deprecated-copy -Wno-psabi -Wno-unqualified-std-cast-call -Wno-non-c-typedef-for-linkage -Wno-range-loop-construct -Wunguarded-availability -Wno-deprecated-declarations -fvisibility=hidden -stdlib=libc++ -Wstring-conversion -Wnewline-eof -O2 -fno-ident -fdata-sections -ffunction-sections -g2   -Werror=overriding-method-mismatch -Werror=undeclared-selector -fobjc-arc -fvisibility-inlines-hidden -fobjc-call-cxx-cdtors -std=c++17 -fno-rtti -nostdinc++ -nostdinc++ -fvisibility=hidden -fno-exceptions  -c ../../flutter/shell/platform/darwin/macos/framework/Source/FlutterMenuPlugin.mm -o  obj/flutter/shell/platform/darwin/macos/framework/Source/flutter_framework_source.FlutterMenuPlugin.o" in /Users/m/Projects/engine/src/out/host_debug exited with code -4
```

which doesn't really give much info, but at least says the command, working dir, and exit code instead of just nothing.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
