### PR TITLE
Move the args for `GLContextPresent` into a struct

### DIFF
--- a/shell/common/shell_test_platform_view_gl.cc
+++ b/shell/common/shell_test_platform_view_gl.cc
@@ -64,8 +64,7 @@ bool ShellTestPlatformViewGL::GLContextClearCurrent() {
 
 // |GPUSurfaceGLDelegate|
 bool ShellTestPlatformViewGL::GLContextPresent(
-    uint32_t fbo_id,
-    const std::optional<SkIRect>& damage) {
+    const GLPresentInfo& present_info) {
   return gl_surface_.Present();
 }
 

--- a/shell/common/shell_test_platform_view_gl.h
+++ b/shell/common/shell_test_platform_view_gl.h
@@ -58,8 +58,7 @@ class ShellTestPlatformViewGL : public ShellTestPlatformView,
   bool GLContextClearCurrent() override;
 
   // |GPUSurfaceGLDelegate|
-  bool GLContextPresent(uint32_t fbo_id,
-                        const std::optional<SkIRect>& damage) override;
+  bool GLContextPresent(const GLPresentInfo& present_info) override;
 
   // |GPUSurfaceGLDelegate|
   intptr_t GLContextFBO(GLFrameInfo frame_info) const override;

--- a/shell/gpu/gpu_surface_gl_delegate.h
+++ b/shell/gpu/gpu_surface_gl_delegate.h
@@ -22,6 +22,15 @@ struct GLFrameInfo {
   uint32_t height;
 };
 
+// Information passed during presentation of a frame.
+struct GLPresentInfo {
+  uint32_t fbo_id;
+
+  // Damage is a hint to compositor telling it which parts of front buffer
+  // need to be updated
+  const std::optional<SkIRect>& damage;
+};
+
 class GPUSurfaceGLDelegate {
  public:
   ~GPUSurfaceGLDelegate();
@@ -39,11 +48,7 @@ class GPUSurfaceGLDelegate {
 
   // Called to present the main GL surface. This is only called for the main GL
   // context and not any of the contexts dedicated for IO.
-  //
-  // Damage is a hint to compositor telling it which parts of front buffer
-  // need to be updated
-  virtual bool GLContextPresent(uint32_t fbo_id,
-                                const std::optional<SkIRect>& damage) = 0;
+  virtual bool GLContextPresent(const GLPresentInfo& present_info) = 0;
 
   // The ID of the main window bound framebuffer. Typically FBO0.
   virtual intptr_t GLContextFBO(GLFrameInfo frame_info) const = 0;

--- a/shell/gpu/gpu_surface_gl_impeller.cc
+++ b/shell/gpu/gpu_surface_gl_impeller.cc
@@ -60,7 +60,11 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceGLImpeller::AcquireFrame(
   auto swap_callback = [weak = weak_factory_.GetWeakPtr(),
                         delegate = delegate_]() -> bool {
     if (weak) {
-      delegate->GLContextPresent(0u, std::nullopt);
+      GLPresentInfo present_info = {
+          .fbo_id = 0,
+          .damage = std::nullopt,
+      };
+      delegate->GLContextPresent(present_info);
     }
     return true;
   };

--- a/shell/gpu/gpu_surface_gl_skia.cc
+++ b/shell/gpu/gpu_surface_gl_skia.cc
@@ -10,6 +10,7 @@
 #include "flutter/fml/size.h"
 #include "flutter/fml/trace_event.h"
 #include "flutter/shell/common/context_options.h"
+#include "flutter/shell/gpu/gpu_surface_gl_delegate.h"
 #include "third_party/skia/include/core/SkAlphaType.h"
 #include "third_party/skia/include/core/SkColorFilter.h"
 #include "third_party/skia/include/core/SkColorSpace.h"
@@ -265,7 +266,8 @@ bool GPUSurfaceGLSkia::PresentSurface(const SurfaceFrame& frame,
     onscreen_surface_->getCanvas()->flush();
   }
 
-  if (!delegate_->GLContextPresent(fbo_id_, frame.submit_info().frame_damage)) {
+  GLPresentInfo present_info = {fbo_id_, frame.submit_info().frame_damage};
+  if (!delegate_->GLContextPresent(present_info)) {
     return false;
   }
 

--- a/shell/platform/android/android_surface_gl_impeller.cc
+++ b/shell/platform/android/android_surface_gl_impeller.cc
@@ -285,8 +285,7 @@ void AndroidSurfaceGLImpeller::GLContextSetDamageRegion(
 
 // |GPUSurfaceGLDelegate|
 bool AndroidSurfaceGLImpeller::GLContextPresent(
-    uint32_t fbo_id,
-    const std::optional<SkIRect>& damage) {
+    const GLPresentInfo& present_info) {
   // The FBO ID is superfluous and was introduced for iOS where the default
   // framebuffer was not FBO0.
   if (!onscreen_surface_) {

--- a/shell/platform/android/android_surface_gl_impeller.h
+++ b/shell/platform/android/android_surface_gl_impeller.h
@@ -65,8 +65,7 @@ class AndroidSurfaceGLImpeller final : public GPUSurfaceGLDelegate,
   void GLContextSetDamageRegion(const std::optional<SkIRect>& region) override;
 
   // |GPUSurfaceGLDelegate|
-  bool GLContextPresent(uint32_t fbo_id,
-                        const std::optional<SkIRect>& damage) override;
+  bool GLContextPresent(const GLPresentInfo& present_info) override;
 
   // |GPUSurfaceGLDelegate|
   intptr_t GLContextFBO(GLFrameInfo frame_info) const override;

--- a/shell/platform/android/android_surface_gl_skia.cc
+++ b/shell/platform/android/android_surface_gl_skia.cc
@@ -153,12 +153,10 @@ void AndroidSurfaceGLSkia::GLContextSetDamageRegion(
   onscreen_surface_->SetDamageRegion(region);
 }
 
-bool AndroidSurfaceGLSkia::GLContextPresent(
-    uint32_t fbo_id,
-    const std::optional<SkIRect>& damage) {
+bool AndroidSurfaceGLSkia::GLContextPresent(const GLPresentInfo& present_info) {
   FML_DCHECK(IsValid());
   FML_DCHECK(onscreen_surface_);
-  return onscreen_surface_->SwapBuffers(damage);
+  return onscreen_surface_->SwapBuffers(present_info.damage);
 }
 
 intptr_t AndroidSurfaceGLSkia::GLContextFBO(GLFrameInfo frame_info) const {

--- a/shell/platform/android/android_surface_gl_skia.h
+++ b/shell/platform/android/android_surface_gl_skia.h
@@ -64,8 +64,7 @@ class AndroidSurfaceGLSkia final : public GPUSurfaceGLDelegate,
   void GLContextSetDamageRegion(const std::optional<SkIRect>& region) override;
 
   // |GPUSurfaceGLDelegate|
-  bool GLContextPresent(uint32_t fbo_id,
-                        const std::optional<SkIRect>& damage) override;
+  bool GLContextPresent(const GLPresentInfo& present_info) override;
 
   // |GPUSurfaceGLDelegate|
   intptr_t GLContextFBO(GLFrameInfo frame_info) const override;

--- a/shell/platform/android/surface/android_surface_mock.cc
+++ b/shell/platform/android/surface/android_surface_mock.cc
@@ -18,9 +18,7 @@ bool AndroidSurfaceMock::GLContextClearCurrent() {
   return true;
 }
 
-bool AndroidSurfaceMock::GLContextPresent(
-    uint32_t fbo_id,
-    const std::optional<SkIRect>& damage) {
+bool AndroidSurfaceMock::GLContextPresent(const GLPresentInfo& present_info) {
   return true;
 }
 

--- a/shell/platform/android/surface/android_surface_mock.h
+++ b/shell/platform/android/surface/android_surface_mock.h
@@ -48,8 +48,7 @@ class AndroidSurfaceMock final : public GPUSurfaceGLDelegate,
   bool GLContextClearCurrent() override;
 
   // |GPUSurfaceGLDelegate|
-  bool GLContextPresent(uint32_t fbo_id,
-                        const std::optional<SkIRect>& damage) override;
+  bool GLContextPresent(const GLPresentInfo& present_info) override;
 
   // |GPUSurfaceGLDelegate|
   intptr_t GLContextFBO(GLFrameInfo frame_info) const override;

--- a/shell/platform/darwin/ios/ios_surface_gl.h
+++ b/shell/platform/darwin/ios/ios_surface_gl.h
@@ -38,7 +38,7 @@ class IOSSurfaceGL final : public IOSSurface, public GPUSurfaceGLDelegate {
   bool GLContextClearCurrent() override;
 
   // |GPUSurfaceGLDelegate|
-  bool GLContextPresent(uint32_t fbo_id, const std::optional<SkIRect>& damage) override;
+  bool GLContextPresent(const GLPresentInfo& present_info) override;
 
   // |GPUSurfaceGLDelegate|
   intptr_t GLContextFBO(GLFrameInfo frame_info) const override;

--- a/shell/platform/darwin/ios/ios_surface_gl.mm
+++ b/shell/platform/darwin/ios/ios_surface_gl.mm
@@ -86,7 +86,7 @@ bool IOSSurfaceGL::GLContextClearCurrent() {
 }
 
 // |GPUSurfaceGLDelegate|
-bool IOSSurfaceGL::GLContextPresent(uint32_t fbo_id, const std::optional<SkIRect>& damage) {
+bool IOSSurfaceGL::GLContextPresent(const GLPresentInfo& present_info) {
   TRACE_EVENT0("flutter", "IOSSurfaceGL::GLContextPresent");
   return IsValid() && render_target_->PresentRenderBuffer();
 }

--- a/shell/platform/embedder/embedder_surface_gl.cc
+++ b/shell/platform/embedder/embedder_surface_gl.cc
@@ -45,9 +45,8 @@ bool EmbedderSurfaceGL::GLContextClearCurrent() {
 }
 
 // |GPUSurfaceGLDelegate|
-bool EmbedderSurfaceGL::GLContextPresent(uint32_t fbo_id,
-                                         const std::optional<SkIRect>& damage) {
-  return gl_dispatch_table_.gl_present_callback(fbo_id);
+bool EmbedderSurfaceGL::GLContextPresent(const GLPresentInfo& present_info) {
+  return gl_dispatch_table_.gl_present_callback(present_info.fbo_id);
 }
 
 // |GPUSurfaceGLDelegate|

--- a/shell/platform/embedder/embedder_surface_gl.h
+++ b/shell/platform/embedder/embedder_surface_gl.h
@@ -56,8 +56,7 @@ class EmbedderSurfaceGL final : public EmbedderSurface,
   bool GLContextClearCurrent() override;
 
   // |GPUSurfaceGLDelegate|
-  bool GLContextPresent(uint32_t fbo_id,
-                        const std::optional<SkIRect>& damage) override;
+  bool GLContextPresent(const GLPresentInfo& present_info) override;
 
   // |GPUSurfaceGLDelegate|
   intptr_t GLContextFBO(GLFrameInfo frame_info) const override;


### PR DESCRIPTION
This refactor enables easier additions to the method for fields that can be optionally consumed by various platforms.
