### PR TITLE
Do not capture a reference to the ResourceContext in the lambda created in the UnrefQueue dtor

### DIFF
--- a/flow/skia_gpu_object.h
+++ b/flow/skia_gpu_object.h
@@ -74,9 +74,13 @@ class UnrefQueue : public fml::RefCountedThreadSafe<UnrefQueue<T>> {
         context_(context) {}
 
   ~UnrefQueue() {
+    // The ResourceContext must be deleted on the task runner thread.
+    // Transfer ownership of the UnrefQueue's ResourceContext reference
+    // into a task queued to that thread.
+    ResourceContext* raw_context = context_.release();
     fml::TaskRunner::RunNowOrPostTask(
-        task_runner_, [objects = std::move(objects_),
-                       context = std::move(context_)]() mutable {
+        task_runner_, [objects = std::move(objects_), raw_context]() mutable {
+          sk_sp<ResourceContext> context(raw_context);
           DoDrain(objects, context);
           context.reset();
         });

--- a/flow/skia_gpu_object_unittests.cc
+++ b/flow/skia_gpu_object_unittests.cc
@@ -145,7 +145,8 @@ TEST_F(SkiaGpuObjectTest, UnrefResourceContextInTaskRunnerThread) {
     auto resource_context =
         sk_make_sp<TestResourceContext>(latch, &dtor_task_queue_id);
     unref_queue = fml::MakeRefCounted<UnrefQueue<TestResourceContext>>(
-        unref_task_runner(), fml::TimeDelta::FromSeconds(0), resource_context);
+        unref_task_runner(), fml::TimeDelta::FromSeconds(0),
+        std::move(resource_context));
     latch->Signal();
   });
   latch->Wait();


### PR DESCRIPTION
The lambda is destructed on the thread that runs the UnrefQueue dtor.
If the lambda itself owns a reference to the ResourceContext, then the
last reference to the ResourceContext could be deleted on the wrong thread.

See https://github.com/flutter/flutter/issues/105066
