### PR TITLE
[Impeller] Decode images at nearest supported size, and then resize of necessary.

### DIFF
--- a/lib/ui/painting/image_decoder_impeller.cc
+++ b/lib/ui/painting/image_decoder_impeller.cc
@@ -4,6 +4,8 @@
 
 #include "flutter/lib/ui/painting/image_decoder_impeller.h"
 
+#include <memory>
+
 #include "flutter/fml/closure.h"
 #include "flutter/fml/make_copyable.h"
 #include "flutter/fml/trace_event.h"
@@ -13,6 +15,7 @@
 #include "flutter/impeller/renderer/texture.h"
 #include "flutter/lib/ui/painting/image_decoder_skia.h"
 #include "impeller/base/strings.h"
+#include "include/core/SkSize.h"
 #include "third_party/skia/include/core/SkPixmap.h"
 
 namespace flutter {
@@ -67,9 +70,19 @@ static std::shared_ptr<SkBitmap> DecompressTexture(ImageDescriptor* descriptor,
     return nullptr;
   }
 
+  const SkISize source_size = descriptor->image_info().dimensions();
+  auto decode_size = descriptor->get_scaled_dimensions(std::max(
+      static_cast<double>(target_size.width()) / source_size.width(),
+      static_cast<double>(target_size.height()) / source_size.height()));
+
+  //----------------------------------------------------------------------------
+  /// 1. Decode the image into the closest size supported by the image
+  ///    generator.
+  ///
+
   const auto base_image_info = descriptor->image_info();
   const auto image_info =
-      base_image_info.makeWH(target_size.width(), target_size.height())
+      base_image_info.makeWH(decode_size.width(), decode_size.height())
           .makeColorType(ChooseCompatibleColorType(base_image_info.colorType()))
           .makeAlphaType(
               ChooseCompatibleAlphaType(base_image_info.alphaType()));
@@ -92,7 +105,30 @@ static std::shared_ptr<SkBitmap> DecompressTexture(ImageDescriptor* descriptor,
     return nullptr;
   }
 
-  return bitmap;
+  if (decode_size == target_size) {
+    return bitmap;
+  }
+
+  //----------------------------------------------------------------------------
+  /// 2. If the decoded image isn't the right target size, resize it.
+  ///
+
+  const auto scaled_image_info = image_info.makeDimensions(target_size);
+
+  auto scaled_bitmap = std::make_shared<SkBitmap>();
+  if (!scaled_bitmap->tryAllocPixels(scaled_image_info)) {
+    FML_LOG(ERROR)
+        << "Could not allocate scaled bitmap for image decompression.";
+    return nullptr;
+  }
+  if (!bitmap->pixmap().scalePixels(
+          scaled_bitmap->pixmap(),
+          SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone))) {
+    FML_LOG(ERROR) << "Could not scale decoded bitmap data.";
+  }
+  scaled_bitmap->setImmutable();
+
+  return scaled_bitmap;
 }
 
 static sk_sp<DlImage> UploadTexture(std::shared_ptr<impeller::Context> context,


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/104217.

The framework can request images be decoded into smaller sizes. A subset of image generators support subpixel decoding at some sizes, and a subset of those support arbitrary pixel decoding. This change makes the Impeller decoder decode into a buffer at the closest supported size by the generator, and then resizes the pixel data into a new buffer. (Which is what we do for Skia).