### PR TITLE
Fix Canvas.drawParagraph should assert that Paragraph.layout has been called

### DIFF
--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -4784,6 +4784,7 @@ class Canvas extends NativeFieldWrapperClass1 {
   void drawParagraph(Paragraph paragraph, Offset offset) {
     assert(paragraph != null);
     assert(_offsetIsValid(offset));
+    assert(!paragraph._needsLayout);
     paragraph._paint(this, offset.dx, offset.dy);
   }
 

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -2669,6 +2669,8 @@ class Paragraph extends NativeFieldWrapperClass1 {
   @pragma('vm:entry-point')
   Paragraph._();
 
+  bool _needsLayout = true;
+
   /// The amount of horizontal space this paragraph occupies.
   ///
   /// Valid only after [layout] has been called.
@@ -2717,7 +2719,10 @@ class Paragraph extends NativeFieldWrapperClass1 {
   /// Computes the size and position of each glyph in the paragraph.
   ///
   /// The [ParagraphConstraints] control how wide the text is allowed to be.
-  void layout(ParagraphConstraints constraints) => _layout(constraints.width);
+  void layout(ParagraphConstraints constraints) {
+    _layout(constraints.width);
+    _needsLayout = false;
+  }
   void _layout(double width) native 'Paragraph_layout';
 
   List<TextBox> _decodeTextBoxes(Float32List encoded) {

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -2721,7 +2721,10 @@ class Paragraph extends NativeFieldWrapperClass1 {
   /// The [ParagraphConstraints] control how wide the text is allowed to be.
   void layout(ParagraphConstraints constraints) {
     _layout(constraints.width);
-    _needsLayout = false;
+    assert(() {
+      _needsLayout = false;
+      return true;
+    }());
   }
   void _layout(double width) native 'Paragraph_layout';
 

--- a/testing/dart/canvas_test.dart
+++ b/testing/dart/canvas_test.dart
@@ -411,6 +411,13 @@ void main() {
   }, skip: !Platform.isLinux); // https://github.com/flutter/flutter/issues/53784
 
   test('Canvas.drawParagraph throws when Paragraph.layout was not called', () async {
+    // Regression test for https://github.com/flutter/flutter/issues/97172
+    bool assertsEnabled = false;
+    assert(() {
+      assertsEnabled = true;
+      return true;
+    }());
+
     Object? error;
     try {
       await toImage((Canvas canvas) {
@@ -422,6 +429,10 @@ void main() {
     } catch (e) {
       error = e;
     }
-    expect(error, isNotNull);
+    if (assertsEnabled) {
+      expect(error, isNotNull);
+    } else {
+      expect(error, isNull);
+    }
   });
 }

--- a/testing/dart/canvas_test.dart
+++ b/testing/dart/canvas_test.dart
@@ -409,4 +409,19 @@ void main() {
     await fuzzyGoldenImageCompare(image, 'text_with_gradient_with_matrix.png');
     expect(areEqual, true);
   }, skip: !Platform.isLinux); // https://github.com/flutter/flutter/issues/53784
+
+  test('Canvas.drawParagraph throws when Paragraph.layout was not called', () async {
+    Object? error;
+    try {
+      await toImage((Canvas canvas) {
+        final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle());
+        builder.addText('Woodstock!');
+        final Paragraph woodstock = builder.build();
+        canvas.drawParagraph(woodstock, const Offset(0, 50));
+      }, 100, 100);
+    } catch (e) {
+      error = e;
+    }
+    expect(error, isNotNull);
+  });
 }


### PR DESCRIPTION
## Description

This PR adds an assert to `Canvas.drawParagraph` to check that `Paragraph.layout` has been called.

## Related Issue

Fixes https://github.com/flutter/flutter/issues/97172

## Tests

Adds 1 test.