### PR TITLE
Check that filtering layer's children is not empty

### DIFF
--- a/flow/layers/color_filter_layer.cc
+++ b/flow/layers/color_filter_layer.cc
@@ -26,6 +26,9 @@ void ColorFilterLayer::Diff(DiffContext* context, const Layer* old_layer) {
 
 void ColorFilterLayer::Preroll(PrerollContext* context,
                                const SkMatrix& matrix) {
+  TRACE_EVENT0("flutter", "ColorFilterLayer::Preroll");
+  FML_DCHECK(!layers().empty());  // We can't be a leaf.
+
   Layer::AutoPrerollSaveLayerState save =
       Layer::AutoPrerollSaveLayerState::Create(context);
   ContainerLayer::Preroll(context, matrix);

--- a/flow/layers/image_filter_layer.cc
+++ b/flow/layers/image_filter_layer.cc
@@ -39,6 +39,8 @@ void ImageFilterLayer::Diff(DiffContext* context, const Layer* old_layer) {
 void ImageFilterLayer::Preroll(PrerollContext* context,
                                const SkMatrix& matrix) {
   TRACE_EVENT0("flutter", "ImageFilterLayer::Preroll");
+  FML_DCHECK(!layers().empty());  // We can't be a leaf.
+
   Layer::AutoPrerollSaveLayerState save =
       Layer::AutoPrerollSaveLayerState::Create(context);
 

--- a/flow/layers/image_filter_layer_unittests.cc
+++ b/flow/layers/image_filter_layer_unittests.cc
@@ -18,8 +18,17 @@ namespace testing {
 using ImageFilterLayerTest = LayerTest;
 
 #ifndef NDEBUG
-TEST_F(ImageFilterLayerTest, PaintingEmptyLayerDies) {
+TEST_F(ImageFilterLayerTest, LeafLayer) {
   auto layer = std::make_shared<ImageFilterLayer>(sk_sp<SkImageFilter>());
+
+  EXPECT_DEATH_IF_SUPPORTED(layer->Preroll(preroll_context(), SkMatrix()),
+                            "\\!layers\\(\\)\\.empty\\(\\)");
+}
+
+TEST_F(ImageFilterLayerTest, PaintingEmptyLayerDies) {
+  auto mock_layer = std::make_shared<MockLayer>(SkPath());
+  auto layer = std::make_shared<ImageFilterLayer>(sk_sp<SkImageFilter>());
+  layer->Add(mock_layer);
 
   layer->Preroll(preroll_context(), SkMatrix());
   EXPECT_EQ(layer->paint_bounds(), kEmptyRect);
@@ -260,14 +269,16 @@ TEST_F(ImageFilterLayerTest, Readback) {
   auto initial_transform = SkMatrix();
 
   // ImageFilterLayer does not read from surface
+  auto mock_layer = std::make_shared<MockLayer>(SkPath());
   auto layer = std::make_shared<ImageFilterLayer>(layer_filter);
+  layer->Add(mock_layer);
   preroll_context()->surface_needs_readback = false;
   layer->Preroll(preroll_context(), initial_transform);
   EXPECT_FALSE(preroll_context()->surface_needs_readback);
 
   // ImageFilterLayer blocks child with readback
-  auto mock_layer =
-      std::make_shared<MockLayer>(SkPath(), SkPaint(), false, true);
+  mock_layer = std::make_shared<MockLayer>(SkPath(), SkPaint(), false, true);
+  layer = std::make_shared<ImageFilterLayer>(layer_filter);
   layer->Add(mock_layer);
   preroll_context()->surface_needs_readback = false;
   layer->Preroll(preroll_context(), initial_transform);

--- a/flow/layers/shader_mask_layer.cc
+++ b/flow/layers/shader_mask_layer.cc
@@ -31,6 +31,9 @@ void ShaderMaskLayer::Diff(DiffContext* context, const Layer* old_layer) {
 }
 
 void ShaderMaskLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
+  TRACE_EVENT0("flutter", "ShaderMaskLayer::Preroll");
+  FML_DCHECK(!layers().empty());  // We can't be a leaf.
+
   Layer::AutoPrerollSaveLayerState save =
       Layer::AutoPrerollSaveLayerState::Create(context);
   ContainerLayer::Preroll(context, matrix);


### PR DESCRIPTION
## Description

This PR adds checks in `ImageFilterLayer`, `ColorFilterLayer` and `̀ShaderMaskLayer`, to make sure the "filtering" layer's children is not empty (as done in `OpacityLayer`). 

## Related Issue

Fixes https://github.com/flutter/flutter/issues/100687

## Tests

Adds 3 tests.