### PR TITLE
Remove logcat flush

### DIFF
--- a/testing/scenario_app/bin/android_integration_tests.dart
+++ b/testing/scenario_app/bin/android_integration_tests.dart
@@ -215,10 +215,6 @@ void main(List<String> args) async {
       await Future.wait(pendingComparisons);
     });
 
-    await step('Flush logcat...', () async {
-      await logcat.flush();
-    });
-
     exit(0);
   }
 }


### PR DESCRIPTION
`IOSink.flush` cannot be called while a write operation is happening. 
It also doesn't seem like `flush` actually flushes the bytes to disk.
For context https://github.com/dart-lang/sdk/issues/25277#issuecomment-165226923

Fixes https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8812362342732992161/+/u/Scenario_App_Integration_Tests/stdout?format=raw

