### PR TITLE
[fuchsia] Stop unimplemented TextInput from log spamming.

### DIFF
--- a/shell/platform/fuchsia/flutter/platform_view.cc
+++ b/shell/platform/fuchsia/flutter/platform_view.cc
@@ -661,6 +661,16 @@ bool PlatformView::HandleFlutterTextInputChannelPlatformMessage(
     current_text_input_client_ = 0;
     last_text_state_ = nullptr;
     DeactivateIme();
+  } else if (method->value == "TextInput.setCaretRect" ||
+             method->value == "TextInput.setEditableSizeAndTransform" ||
+             method->value == "TextInput.setMarkedTextRect" ||
+             method->value == "TextInput.setStyle") {
+    // We don't have these methods implemented and they get
+    // sent a lot during text input, so we create an empty case for them
+    // here to avoid "Unknown flutter/textinput method TextInput.*"
+    // log spam.
+    //
+    // TODO(fxb/101619): We should implement these.
   } else {
     FML_LOG(ERROR) << "Unknown " << message->channel() << " method "
                    << method->value.GetString();


### PR DESCRIPTION
We see a lot of complaints about log
spam related to this specific platform
message, and we haven't implemented it for a while,
so I'm turning off this specific error for
now. 