### PR TITLE
[macOS] Put FlutterTextInputPlugin in view hierarchy

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegate.mm
+++ b/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegate.mm
@@ -128,7 +128,7 @@ AccessibilityBridgeMacDelegate::MacOSEventsFromAXEvent(ui::AXEventGenerator::Eve
         // first responder.
         FlutterTextField* native_text_field = (FlutterTextField*)focused;
         if (native_text_field == mac_platform_node_delegate->GetFocus()) {
-          [native_text_field.window makeFirstResponder:native_text_field];
+          [native_text_field startEditing];
         }
         break;
       }
@@ -172,7 +172,7 @@ AccessibilityBridgeMacDelegate::MacOSEventsFromAXEvent(ui::AXEventGenerator::Eve
             (FlutterTextField*)mac_platform_node_delegate->GetNativeViewAccessible();
         id focused = mac_platform_node_delegate->GetFocus();
         if (!focused || native_text_field == focused) {
-          [native_text_field.window makeFirstResponder:native_text_field];
+          [native_text_field startEditing];
         }
         break;
       }

--- a/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegate.mm
+++ b/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegate.mm
@@ -128,7 +128,7 @@ AccessibilityBridgeMacDelegate::MacOSEventsFromAXEvent(ui::AXEventGenerator::Eve
         // first responder.
         FlutterTextField* native_text_field = (FlutterTextField*)focused;
         if (native_text_field == mac_platform_node_delegate->GetFocus()) {
-          [native_text_field becomeFirstResponder];
+          [native_text_field.window makeFirstResponder:native_text_field];
         }
         break;
       }
@@ -172,7 +172,7 @@ AccessibilityBridgeMacDelegate::MacOSEventsFromAXEvent(ui::AXEventGenerator::Eve
             (FlutterTextField*)mac_platform_node_delegate->GetNativeViewAccessible();
         id focused = mac_platform_node_delegate->GetFocus();
         if (!focused || native_text_field == focused) {
-          [native_text_field becomeFirstResponder];
+          [native_text_field.window makeFirstResponder:native_text_field];
         }
         break;
       }

--- a/shell/platform/darwin/macos/framework/Source/FlutterKeyboardManager.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterKeyboardManager.h
@@ -40,12 +40,12 @@
 - (void)handleEvent:(nonnull NSEvent*)event;
 
 /**
- * The event currently being redispatched.
+ * Returns yes if is event currently being redispatched.
  *
  * In some instances (i.e. emoji shortcut) the event may be redelivered by cocoa
  * as key equivalent to FlutterTextInput, in which case it shouldn't be
  * processed again.
  */
-@property(nonatomic, nullable) NSEvent* eventBeingDispatched;
+- (BOOL)isDispatchingKeyEvent:(nonnull NSEvent*)event;
 
 @end

--- a/shell/platform/darwin/macos/framework/Source/FlutterKeyboardManager.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterKeyboardManager.h
@@ -42,7 +42,7 @@
 /**
  * The event currently being redispatched.
  *
- * In some instances (i.e. emoji shortcut) the event may redelivered by cocoa
+ * In some instances (i.e. emoji shortcut) the event may be redelivered by cocoa
  * as key equivalent to FlutterTextInput, in which case it shouldn't be
  * processed again.
  */

--- a/shell/platform/darwin/macos/framework/Source/FlutterKeyboardManager.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterKeyboardManager.h
@@ -39,4 +39,13 @@
  */
 - (void)handleEvent:(nonnull NSEvent*)event;
 
+/**
+ * The event currently being redispatched.
+ *
+ * In some instances (i.e. emoji shortcut) the event may redelivered by cocoa
+ * as key equivalent to FlutterTextInput, in which case it shouldn't be
+ * processed again.
+ */
+@property(nonatomic, nullable) NSEvent* eventBeingDispatched;
+
 @end

--- a/shell/platform/darwin/macos/framework/Source/FlutterKeyboardManager.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterKeyboardManager.mm
@@ -230,6 +230,7 @@ typedef _Nullable _NSResponderPtr (^NextResponderProvider)();
   if (nextResponder == nil) {
     return;
   }
+  NSAssert(_eventBeingDispatched == nil, @"An event is already being dispached.");
   _eventBeingDispatched = event;
   switch (event.type) {
     case NSEventTypeKeyDown:
@@ -250,6 +251,7 @@ typedef _Nullable _NSResponderPtr (^NextResponderProvider)();
     default:
       NSAssert(false, @"Unexpected key event type (got %lu).", event.type);
   }
+  NSAssert(_eventBeingDispatched != nil, @"_eventBeingDispatched was cleared unexpectedly.");
   _eventBeingDispatched = nil;
 }
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterKeyboardManager.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterKeyboardManager.mm
@@ -230,6 +230,7 @@ typedef _Nullable _NSResponderPtr (^NextResponderProvider)();
   if (nextResponder == nil) {
     return;
   }
+  _eventBeingDispatched = event;
   switch (event.type) {
     case NSEventTypeKeyDown:
       if ([nextResponder respondsToSelector:@selector(keyDown:)]) {
@@ -249,6 +250,7 @@ typedef _Nullable _NSResponderPtr (^NextResponderProvider)();
     default:
       NSAssert(false, @"Unexpected key event type (got %lu).", event.type);
   }
+  _eventBeingDispatched = nil;
 }
 
 - (void)buildLayout {

--- a/shell/platform/darwin/macos/framework/Source/FlutterKeyboardManager.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterKeyboardManager.mm
@@ -70,6 +70,8 @@ typedef _Nullable _NSResponderPtr (^NextResponderProvider)();
 
 @property(nonatomic) NSMutableDictionary<NSNumber*, NSNumber*>* layoutMap;
 
+@property(nonatomic, nullable) NSEvent* eventBeingDispatched;
+
 /**
  * Add a primary responder, which asynchronously decides whether to handle an
  * event.
@@ -166,6 +168,10 @@ typedef _Nullable _NSResponderPtr (^NextResponderProvider)();
 
   [_pendingEvents addObject:event];
   [self processNextEvent];
+}
+
+- (BOOL)isDispatchingKeyEvent:(NSEvent*)event {
+  return _eventBeingDispatched == event;
 }
 
 #pragma mark - Private

--- a/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm
@@ -293,9 +293,8 @@ TEST(FlutterPlatformNodeDelegateMac, TextFieldUsesFlutterTextField) {
   EXPECT_EQ(NSEqualRects(native_text_field.frame, NSMakeRect(0, 600 - expectedFrameSize,
                                                              expectedFrameSize, expectedFrameSize)),
             YES);
-  // The text of TextInputPlugin only starts syncing editing state to the
-  // native text field when it becomes the first responder.
-  [native_text_field.window makeFirstResponder:native_text_field];
+
+  [native_text_field startEditing];
   EXPECT_EQ([native_text_field.stringValue isEqualToString:@"textfield"], YES);
 }
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm
@@ -295,7 +295,7 @@ TEST(FlutterPlatformNodeDelegateMac, TextFieldUsesFlutterTextField) {
             YES);
   // The text of TextInputPlugin only starts syncing editing state to the
   // native text field when it becomes the first responder.
-  [native_text_field becomeFirstResponder];
+  [native_text_field.window makeFirstResponder:native_text_field];
   EXPECT_EQ([native_text_field.stringValue isEqualToString:@"textfield"], YES);
 }
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -373,7 +373,7 @@ static flutter::TextRange RangeFromBaseExtent(NSNumber* base,
     [_textInputContext discardMarkedText];
   }
   if (_client != nil) {
-    [self.window makeFirstResponder:_client];
+    [_client startEditing];
   }
   [self updateTextAndSelection];
 }

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -372,9 +372,8 @@ static flutter::TextRange RangeFromBaseExtent(NSNumber* base,
   if (composing_range.collapsed() && wasComposing) {
     [_textInputContext discardMarkedText];
   }
-  if (_client != nil) {
-    [_client startEditing];
-  }
+  [_client startEditing];
+
   [self updateTextAndSelection];
 }
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -237,6 +237,16 @@ static flutter::TextRange RangeFromBaseExtent(NSNumber* base,
 
 #pragma mark - Private
 
+- (void)resignAndRemoveFromSuperview {
+  if (self.superview != nil) {
+    // With accessiblity enabled TextInputPlugin is inside _client, so take the
+    // nextResponder from the _client.
+    NSResponder* nextResponder = _client != nil ? _client.nextResponder : self.nextResponder;
+    [self.window makeFirstResponder:nextResponder];
+    [self removeFromSuperview];
+  }
+}
+
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
   BOOL handled = YES;
   NSString* method = call.method;
@@ -271,13 +281,10 @@ static flutter::TextRange RangeFromBaseExtent(NSNumber* base,
     [self.window makeFirstResponder:self];
     _shown = TRUE;
   } else if ([method isEqualToString:kHideMethod]) {
-    // With accessiblity enabled TextInputPlugin is inside _client, so take the
-    // nextResponder from the _client.
-    NSResponder* nextResponder = _client != nil ? _client.nextResponder : self.nextResponder;
-    [self.window makeFirstResponder:nextResponder];
-    [self removeFromSuperview];
+    [self resignAndRemoveFromSuperview];
     _shown = FALSE;
   } else if ([method isEqualToString:kClearClientMethod]) {
+    [self resignAndRemoveFromSuperview];
     // If there's an active mark region, commit it, end composing, and clear the IME's mark text.
     if (_activeModel && _activeModel->composing()) {
       _activeModel->CommitComposing();

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -490,7 +490,7 @@ static flutter::TextRange RangeFromBaseExtent(NSNumber* base,
 }
 
 - (BOOL)performKeyEquivalent:(NSEvent*)event {
-  if (_flutterViewController.keyboardManager.eventBeingDispatched == event) {
+  if ([_flutterViewController isDispatchingKeyEvent:event]) {
     // When NSWindow is nextResponder, keyboard manager will send to it
     // unhandled events (through [NSWindow keyDown:]). If event has has both
     // control and cmd modifiers set (i.e. cmd+control+space - emoji picker)

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
@@ -865,12 +865,14 @@
 
 - (bool)testPerformKeyEquivalent {
   __block NSEvent* eventBeingDispatchedByKeyboardManager = nil;
-  id keyboardManagerMock = OCMClassMock([FlutterKeyboardManager class]);
-  OCMStub([keyboardManagerMock eventBeingDispatched]).andDo(^(NSInvocation* invocation) {
-    [invocation setReturnValue:&eventBeingDispatchedByKeyboardManager];
-  });
   FlutterViewController* viewControllerMock = OCMClassMock([FlutterViewController class]);
-  OCMStub([viewControllerMock keyboardManager]).andReturn(keyboardManagerMock);
+  OCMStub([viewControllerMock isDispatchingKeyEvent:[OCMArg any]])
+      .andDo(^(NSInvocation* invocation) {
+        NSEvent* event;
+        [invocation getArgument:(void*)&event atIndex:2];
+        BOOL result = event == eventBeingDispatchedByKeyboardManager;
+        [invocation setReturnValue:&result];
+      });
 
   NSEvent* event = [NSEvent keyEventWithType:NSEventTypeKeyDown
                                     location:NSZeroPoint

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
@@ -1070,7 +1070,7 @@ TEST(FlutterTextInputPluginTest, CanWorkWithFlutterTextField) {
       [[FlutterTextFieldMock alloc] initWithPlatformNode:&text_platform_node
                                              fieldEditor:viewController.textInputPlugin];
   [viewController.view addSubview:mockTextField];
-  [mockTextField becomeFirstResponder];
+  [mockTextField startEditing];
 
   NSDictionary* arguments = @{
     @"inputAction" : @"action",

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
@@ -1075,4 +1075,40 @@ TEST(FlutterTextInputPluginTest, CanNotBecomeResponderIfNoViewController) {
   EXPECT_EQ([textField becomeFirstResponder], NO);
 }
 
+TEST(FlutterTextInputPluginTest, IsAddedAndRemovedFromViewHierarchy) {
+  FlutterEngine* engine = CreateTestEngine();
+  NSString* fixtures = @(testing::GetFixturesPath());
+  FlutterDartProject* project = [[FlutterDartProject alloc]
+      initWithAssetsPath:fixtures
+             ICUDataPath:[fixtures stringByAppendingString:@"/icudtl.dat"]];
+  FlutterViewController* viewController = [[FlutterViewController alloc] initWithProject:project];
+  [viewController loadView];
+  [engine setViewController:viewController];
+
+  NSWindow* window = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 800, 600)
+                                                 styleMask:NSBorderlessWindowMask
+                                                   backing:NSBackingStoreBuffered
+                                                     defer:NO];
+  window.contentView = viewController.view;
+
+  ASSERT_EQ(viewController.textInputPlugin.superview, nil);
+  ASSERT_FALSE(window.firstResponder == viewController.textInputPlugin);
+
+  [viewController.textInputPlugin
+      handleMethodCall:[FlutterMethodCall methodCallWithMethodName:@"TextInput.show" arguments:@[]]
+                result:^(id){
+                }];
+
+  ASSERT_EQ(viewController.textInputPlugin.superview, viewController.view);
+  ASSERT_TRUE(window.firstResponder == viewController.textInputPlugin);
+
+  [viewController.textInputPlugin
+      handleMethodCall:[FlutterMethodCall methodCallWithMethodName:@"TextInput.hide" arguments:@[]]
+                result:^(id){
+                }];
+
+  ASSERT_EQ(viewController.textInputPlugin.superview, nil);
+  ASSERT_FALSE(window.firstResponder == viewController.textInputPlugin);
+}
+
 }  // namespace flutter::testing

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
@@ -250,60 +250,6 @@
   return true;
 }
 
-- (bool)testInputContextIsKeptActive {
-  id engineMock = OCMClassMock([FlutterEngine class]);
-  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engineMock
-                                                                                nibName:@""
-                                                                                 bundle:nil];
-
-  FlutterTextInputPlugin* plugin =
-      [[FlutterTextInputPlugin alloc] initWithViewController:viewController];
-
-  [plugin handleMethodCall:[FlutterMethodCall
-                               methodCallWithMethodName:@"TextInput.setClient"
-                                              arguments:@[
-                                                @(1), @{
-                                                  @"inputAction" : @"action",
-                                                  @"inputType" : @{@"name" : @"inputName"},
-                                                }
-                                              ]]
-                    result:^(id){
-                    }];
-
-  [plugin handleMethodCall:[FlutterMethodCall methodCallWithMethodName:@"TextInput.setEditingState"
-                                                             arguments:@{
-                                                               @"text" : @"",
-                                                               @"selectionBase" : @(0),
-                                                               @"selectionExtent" : @(0),
-                                                               @"composingBase" : @(-1),
-                                                               @"composingExtent" : @(-1),
-                                                             }]
-                    result:^(id){
-                    }];
-
-  [plugin handleMethodCall:[FlutterMethodCall methodCallWithMethodName:@"TextInput.show"
-                                                             arguments:@[]]
-                    result:^(id){
-                    }];
-
-  [plugin.inputContext deactivate];
-  EXPECT_EQ(plugin.inputContext.isActive, NO);
-  NSEvent* keyEvent = [NSEvent keyEventWithType:NSEventTypeKeyDown
-                                       location:NSZeroPoint
-                                  modifierFlags:0x100
-                                      timestamp:0
-                                   windowNumber:0
-                                        context:nil
-                                     characters:@""
-                    charactersIgnoringModifiers:@""
-                                      isARepeat:NO
-                                        keyCode:0x50];
-
-  [plugin handleKeyEvent:keyEvent];
-  EXPECT_EQ(plugin.inputContext.isActive, YES);
-  return true;
-}
-
 - (bool)testClearClientDuringComposing {
   // Set up FlutterTextInputPlugin.
   id engineMock = OCMClassMock([FlutterEngine class]);
@@ -1003,10 +949,6 @@ TEST(FlutterTextInputPluginTest, TestSetMarkedTextWithSelectionChange) {
 
 TEST(FlutterTextInputPluginTest, TestComposingRegionRemovedByFramework) {
   ASSERT_TRUE([[FlutterInputPluginTestObjc alloc] testComposingRegionRemovedByFramework]);
-}
-
-TEST(FlutterTextInputPluginTest, TestTextInputContextIsKeptAlive) {
-  ASSERT_TRUE([[FlutterInputPluginTestObjc alloc] testInputContextIsKeptActive]);
 }
 
 TEST(FlutterTextInputPluginTest, TestClearClientDuringComposing) {

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputSemanticsObject.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputSemanticsObject.h
@@ -89,4 +89,10 @@ class FlutterTextPlatformNode : public ui::AXPlatformNodeBase {
  */
 - (void)updateString:(NSString*)string withSelection:(NSRange)selection;
 
+/**
+ * Makes the field editor (plugin) current editor for this TextField, meaning
+ * that the text field will start getting editing events.
+ */
+- (void)startEditing;
+
 @end

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -176,6 +176,13 @@ NSData* currentKeyboardLayoutData() {
  */
 @property(nonatomic) id keyUpMonitor;
 
+/**
+ * Pointer to a keyboard manager, a hub that manages how key events are
+ * dispatched to various Flutter key responders, and whether the event is
+ * propagated to the next NSResponder.
+ */
+@property(nonatomic, readonly, nonnull) FlutterKeyboardManager* keyboardManager;
+
 @property(nonatomic) KeyboardLayoutNotifier keyboardLayoutNotifier;
 
 @property(nonatomic) NSData* keyboardLayoutData;
@@ -332,6 +339,10 @@ static void CommonInit(FlutterViewController* controller) {
   }
 
   return self;
+}
+
+- (BOOL)isDispatchingKeyEvent:(NSEvent*)event {
+  return [_keyboardManager isDispatchingKeyEvent:event];
 }
 
 - (void)loadView {

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -628,16 +628,11 @@ static void CommonInit(FlutterViewController* controller) {
 
 - (void)onAccessibilityStatusChanged:(BOOL)enabled {
   if (!enabled && self.viewLoaded && [_textInputPlugin isFirstResponder]) {
-    // The client (i.e. the FlutterTextField) of the textInputPlugin is a sibling
-    // of the FlutterView. macOS will pick the ancestor to be the next responder
-    // when the client is removed from the view hierarchy, which is the result of
-    // turning off semantics. This will cause the keyboard focus to stick at the
-    // NSWindow.
-    //
-    // Since the view controller creates the illustion that the FlutterTextField is
-    // below the FlutterView in accessibility (See FlutterViewWrapper), it has to
-    // manually pick the next responder.
-    [self.view.window makeFirstResponder:_flutterView];
+    // Normally TextInputPlugin, when editing, is child of FlutterViewWrapper.
+    // When accessiblity is enabled the TextInputPlugin gets added as an indirect
+    // child to FlutterTextField. When disabling the plugin needs to be reparented
+    // back.
+    [self.view addSubview:_textInputPlugin];
   }
 }
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
@@ -71,7 +71,7 @@ TEST(FlutterViewController, HasViewThatHidesOtherViewsInAccessibility) {
   EXPECT_EQ(accessibilityChildren[0], viewControllerMock.flutterView);
 }
 
-TEST(FlutterViewController, SetsFlutterViewFirstResponderWhenAccessibilityDisabled) {
+TEST(FlutterViewController, ReparentsPluginWhenAccessibilityDisabled) {
   FlutterEngine* engine = CreateTestEngine();
   NSString* fixtures = @(testing::GetFixturesPath());
   FlutterDartProject* project = [[FlutterDartProject alloc]
@@ -86,14 +86,17 @@ TEST(FlutterViewController, SetsFlutterViewFirstResponderWhenAccessibilityDisabl
                                                    backing:NSBackingStoreBuffered
                                                      defer:NO];
   window.contentView = viewController.view;
+  NSView* dummyView = [[NSView alloc] initWithFrame:CGRectZero];
+  [viewController.view addSubview:dummyView];
   // Attaches FlutterTextInputPlugin to the view;
-  [viewController.view addSubview:viewController.textInputPlugin];
+  [dummyView addSubview:viewController.textInputPlugin];
   // Makes sure the textInputPlugin can be the first responder.
   EXPECT_TRUE([window makeFirstResponder:viewController.textInputPlugin]);
   EXPECT_EQ([window firstResponder], viewController.textInputPlugin);
+  EXPECT_FALSE(viewController.textInputPlugin.superview == viewController.view);
   [viewController onAccessibilityStatusChanged:NO];
-  // FlutterView becomes the first responder.
-  EXPECT_EQ([window firstResponder], viewController.flutterView);
+  // FlutterView becomes child of view controller
+  EXPECT_TRUE(viewController.textInputPlugin.superview == viewController.view);
 }
 
 TEST(FlutterViewController, CanSetMouseTrackingModeBeforeViewLoaded) {

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
@@ -20,7 +20,6 @@
 - (bool)testKeyEventsArePropagatedIfNotHandled;
 - (bool)testKeyEventsAreNotPropagatedIfHandled;
 - (bool)testFlagsChangedEventsArePropagatedIfNotHandled;
-- (bool)testPerformKeyEquivalentSynthesizesKeyUp;
 - (bool)testKeyboardIsRestartedOnEngineRestart;
 - (bool)testTrackpadGesturesAreSentToFramework;
 
@@ -122,10 +121,6 @@ TEST(FlutterViewControllerTest, TestKeyEventsAreNotPropagatedIfHandled) {
 TEST(FlutterViewControllerTest, TestFlagsChangedEventsArePropagatedIfNotHandled) {
   ASSERT_TRUE(
       [[FlutterViewControllerTestObjC alloc] testFlagsChangedEventsArePropagatedIfNotHandled]);
-}
-
-TEST(FlutterViewControllerTest, TestPerformKeyEquivalentSynthesizesKeyUp) {
-  ASSERT_TRUE([[FlutterViewControllerTestObjC alloc] testPerformKeyEquivalentSynthesizesKeyUp]);
 }
 
 TEST(FlutterViewControllerTest, TestKeyboardIsRestartedOnEngineRestart) {
@@ -334,86 +329,6 @@ TEST(FlutterViewControllerTest, TestTrackpadGesturesAreSentToFramework) {
     OCMVerify(  // NOLINT(google-objc-avoid-throwing-exception)
         [binaryMessengerMock sendOnChannel:@"flutter/keyevent"
                                    message:encodedKeyEvent
-                               binaryReply:[OCMArg any]]);
-  } @catch (...) {
-    return false;
-  }
-  return true;
-}
-
-- (bool)testPerformKeyEquivalentSynthesizesKeyUp {
-  id engineMock = OCMClassMock([FlutterEngine class]);
-  id binaryMessengerMock = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
-  OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
-      [engineMock binaryMessenger])
-      .andReturn(binaryMessengerMock);
-  OCMStub([[engineMock ignoringNonObjectArgs] sendKeyEvent:FlutterKeyEvent {}
-                                                  callback:nil
-                                                  userData:nil])
-      .andCall([FlutterViewControllerTestObjC class],
-               @selector(respondFalseForSendEvent:callback:userData:));
-  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engineMock
-                                                                                nibName:@""
-                                                                                 bundle:nil];
-  id responderMock = flutter::testing::mockResponder();
-  viewController.nextResponder = responderMock;
-  NSDictionary* expectedKeyDownEvent = @{
-    @"keymap" : @"macos",
-    @"type" : @"keydown",
-    @"keyCode" : @(65),
-    @"modifiers" : @(538968064),
-    @"characters" : @".",
-    @"charactersIgnoringModifiers" : @".",
-  };
-  NSData* encodedKeyDownEvent =
-      [[FlutterJSONMessageCodec sharedInstance] encode:expectedKeyDownEvent];
-  NSDictionary* expectedKeyUpEvent = @{
-    @"keymap" : @"macos",
-    @"type" : @"keyup",
-    @"keyCode" : @(65),
-    @"modifiers" : @(538968064),
-    @"characters" : @".",
-    @"charactersIgnoringModifiers" : @".",
-  };
-  NSData* encodedKeyUpEvent = [[FlutterJSONMessageCodec sharedInstance] encode:expectedKeyUpEvent];
-  CGEventRef cgEvent = CGEventCreateKeyboardEvent(NULL, 65, TRUE);
-  NSEvent* event = [NSEvent eventWithCGEvent:cgEvent];
-  OCMExpect(  // NOLINT(google-objc-avoid-throwing-exception)
-      [binaryMessengerMock sendOnChannel:@"flutter/keyevent"
-                                 message:encodedKeyDownEvent
-                             binaryReply:[OCMArg any]])
-      .andDo((^(NSInvocation* invocation) {
-        FlutterBinaryReply handler;
-        [invocation getArgument:&handler atIndex:4];
-        NSDictionary* reply = @{
-          @"handled" : @(true),
-        };
-        NSData* encodedReply = [[FlutterJSONMessageCodec sharedInstance] encode:reply];
-        handler(encodedReply);
-      }));
-  OCMExpect(  // NOLINT(google-objc-avoid-throwing-exception)
-      [binaryMessengerMock sendOnChannel:@"flutter/keyevent"
-                                 message:encodedKeyUpEvent
-                             binaryReply:[OCMArg any]])
-      .andDo((^(NSInvocation* invocation) {
-        FlutterBinaryReply handler;
-        [invocation getArgument:&handler atIndex:4];
-        NSDictionary* reply = @{
-          @"handled" : @(true),
-        };
-        NSData* encodedReply = [[FlutterJSONMessageCodec sharedInstance] encode:reply];
-        handler(encodedReply);
-      }));
-  [viewController viewWillAppear];  // Initializes the event channel.
-  [viewController performKeyEquivalent:event];
-  @try {
-    OCMVerify(  // NOLINT(google-objc-avoid-throwing-exception)
-        [binaryMessengerMock sendOnChannel:@"flutter/keyevent"
-                                   message:encodedKeyDownEvent
-                               binaryReply:[OCMArg any]]);
-    OCMVerify(  // NOLINT(google-objc-avoid-throwing-exception)
-        [binaryMessengerMock sendOnChannel:@"flutter/keyevent"
-                                   message:encodedKeyUpEvent
                                binaryReply:[OCMArg any]]);
   } @catch (...) {
     return false;

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h
@@ -4,6 +4,7 @@
 
 #import "flutter/shell/platform/darwin/macos/framework/Headers/FlutterViewController.h"
 
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterKeyboardManager.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterKeyboardViewDelegate.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterView.h"
@@ -17,6 +18,13 @@
  * The text input plugin that handles text editing state for text fields.
  */
 @property(nonatomic, readonly, nonnull) FlutterTextInputPlugin* textInputPlugin;
+
+/**
+ * Pointer to a keyboard manager, a hub that manages how key events are
+ * dispatched to various Flutter key responders, and whether the event is
+ * propagated to the next NSResponder.
+ */
+@property(nonatomic, readonly, nonnull) FlutterKeyboardManager* keyboardManager;
 
 /**
  * Initializes this FlutterViewController with the specified `FlutterEngine`.

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h
@@ -20,13 +20,6 @@
 @property(nonatomic, readonly, nonnull) FlutterTextInputPlugin* textInputPlugin;
 
 /**
- * Pointer to a keyboard manager, a hub that manages how key events are
- * dispatched to various Flutter key responders, and whether the event is
- * propagated to the next NSResponder.
- */
-@property(nonatomic, readonly, nonnull) FlutterKeyboardManager* keyboardManager;
-
-/**
  * Initializes this FlutterViewController with the specified `FlutterEngine`.
  *
  * The initialized viewcontroller will attach itself to the engine as part of this process.
@@ -38,6 +31,11 @@
 - (nonnull instancetype)initWithEngine:(nonnull FlutterEngine*)engine
                                nibName:(nullable NSString*)nibName
                                 bundle:(nullable NSBundle*)nibBundle NS_DESIGNATED_INITIALIZER;
+
+/**
+ * Returns YES if provided event is being currently redispatched by keyboard manager.
+ */
+- (BOOL)isDispatchingKeyEvent:(nonnull NSEvent*)event;
 
 @end
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h
@@ -4,7 +4,6 @@
 
 #import "flutter/shell/platform/darwin/macos/framework/Headers/FlutterViewController.h"
 
-#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterKeyboardManager.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterKeyboardViewDelegate.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterView.h"


### PR DESCRIPTION
| Before | After |
| --- | --- |
|<img width="348" alt="Screenshot 2022-06-04 at 22 16 32" src="https://user-images.githubusercontent.com/96958/172024253-a0d09161-0be0-404c-9c1f-6c9995aafad5.png">|<img width="306" alt="Screenshot 2022-06-04 at 22 16 59" src="https://user-images.githubusercontent.com/96958/172024268-93ccb341-9874-4071-bbcd-2cc4cd0d0d5a.png">|

Emoji picker is different than the other IME popovers. In order for the picker to be attached properly, `FlutterTextInputPlugin` must be in view hierarchy and first responder.

Notable changes in this PR:
- `FlutterTextInputPlugin` is added to hierarchy in `TextInput.show`, removed in `TextInput.hide`.
- Manual `[TextInputContext activate]` and `deactivate` calls are not needed anymore and were removed. The context gets activated automatically now. I also removed the `TestTextInputContextIsKeptAlive` unit test. Unfortunately I wasn't able to get the context to activate in "headless" unit test environment, but in actual application the context gets activated/deactivated as expected (tested by overriding the `activate`/`deactivate` methods on context).
- I've removed key up event synthesising in `performKeyEquivalent:`. The `keyUp` event monitor in `FlutterViewController` takes care of this. It needed to be modified to allow `TextInputPlugin` as first responder (which is also works with accessibility text field)
- `[FlutterTestInputPlugin performKeyEquivalent:]` now simply calls `[FlutterViewController keyDown:]`. With one caveat: When the `CMD+CTRL+SPACE` emoji picker shortcut event gets redispached to `nextResponder` by `FlutterKeyboardManager`, the `nextResponder` is usually `NSWindow` and it routes the event to `[FlutterTestInputPlugin performKeyEquivalent:]`. Sending it again to controller would result in endless cycle, so the `FlutterTextInputPlugin` checks if the event in question is currently being redispatched by manager and if it is, it will not handle it. Not handling the event is also required for the emoji picker to actually show up.
- I've replaced calls to `becomeFirstResponder` with `[NSWindow makeFirstResponder:]`. Unlike UIKit, in AppKit the [becomeFirstResponder](https://developer.apple.com/documentation/appkit/nsresponder/1526750-becomefirstresponder?language=objc) documentation explicitely says not to call this method directly and in some cases it leads to crash with unhandled `NSInternalInconsistencyException`.
- `[FlutterTextField becomeFirstResponder]`, which was called directly has been replaced by `[FlutterTextField startEditing]`. This method sets `FlutterTextPlugin` as field editor to the `FlutterTextField`. This was previously happening as a side effect of `becomeFirstResponder` calling `selectText`.

Partially fixes https://github.com/flutter/flutter/issues/85328

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
