### PR TITLE
[macOS] Remove isComposing workaround

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterKeyboardManager.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterKeyboardManager.mm
@@ -196,11 +196,6 @@ typedef _Nullable _NSResponderPtr (^NextResponderProvider)();
 }
 
 - (void)performProcessEvent:(NSEvent*)event onFinish:(VoidBlock)onFinish {
-  if (_viewDelegate.isComposing) {
-    [self dispatchTextEvent:event];
-    onFinish();
-    return;
-  }
 
   // Having no primary responders require extra logic, but Flutter hard-codes
   // all primary responders, so this is a situation that Flutter will never

--- a/shell/platform/darwin/macos/framework/Source/FlutterKeyboardManager.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterKeyboardManager.mm
@@ -196,7 +196,6 @@ typedef _Nullable _NSResponderPtr (^NextResponderProvider)();
 }
 
 - (void)performProcessEvent:(NSEvent*)event onFinish:(VoidBlock)onFinish {
-
   // Having no primary responders require extra logic, but Flutter hard-codes
   // all primary responders, so this is a situation that Flutter will never
   // encounter.

--- a/shell/platform/darwin/macos/framework/Source/FlutterKeyboardViewDelegate.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterKeyboardViewDelegate.h
@@ -74,16 +74,6 @@ typedef struct {
 - (BOOL)onTextInputKeyEvent:(nonnull NSEvent*)event;
 
 /**
- * Whether this FlutterKeyboardViewDelegate is actively taking provisional user text input.
- *
- * This is typically true when a Flutter text field is focused, and the user is entering composing
- * text into the text field.
- */
-// TODO (LongCatIsLooong): remove this method and implement a long-term fix for
-// https://github.com/flutter/flutter/issues/85328.
-- (BOOL)isComposing;
-
-/**
  * Add a listener that is called whenever the user changes keyboard layout.
  *
  * Only one listeners is supported. Adding new ones overwrites the current one.

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.h
@@ -64,4 +64,5 @@
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result;
 - (NSRect)firstRectForCharacterRange:(NSRange)range actualRange:(NSRangePointer)actualRange;
 - (NSDictionary*)editingState;
+@property(readwrite, nonatomic) NSString* customRunLoopMode;
 @end

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.h
@@ -46,15 +46,6 @@
 - (BOOL)isFirstResponder;
 
 /**
- * Whether this plugin has composing text.
- *
- * This is only true when the text input plugin is actively taking user input with composing text.
- */
-// TODO (LongCatIsLooong): remove this method and implement a long-term fix for
-// https://github.com/flutter/flutter/issues/85328.
-- (BOOL)isComposing;
-
-/**
  * Handles key down events received from the view controller, responding YES if
  * the event was handled.
  *

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -504,10 +504,6 @@ static char markerKey;
                                                              : kTextAffinityDownstream;
 }
 
-- (BOOL)isComposing {
-  return _activeModel && !_activeModel->composing_range().collapsed();
-}
-
 - (BOOL)handleKeyEvent:(NSEvent*)event {
   if (event.type == NSEventTypeKeyUp ||
       (event.type == NSEventTypeFlagsChanged && event.modifierFlags < _previouslyPressedFlags)) {

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -32,6 +32,7 @@ static NSString* const kUpdateEditStateResponseMethod = @"TextInputClient.update
 static NSString* const kUpdateEditStateWithDeltasResponseMethod =
     @"TextInputClient.updateEditingStateWithDeltas";
 static NSString* const kPerformAction = @"TextInputClient.performAction";
+static NSString* const kPerformIntent = @"TextInputClient.performIntent";
 static NSString* const kMultilineInputType = @"TextInputType.multiline";
 
 static NSString* const kTextAffinityDownstream = @"TextAffinity.downstream";
@@ -665,6 +666,16 @@ static char markerKey;
     IMP imp = [self methodForSelector:selector];
     void (*func)(id, SEL, id) = reinterpret_cast<void (*)(id, SEL, id)>(imp);
     func(self, selector, nil);
+  }
+  // All NSStandardKeyBindingResponding method have single trailing space.
+  // For now forward all selectors to framework
+  NSString* name = NSStringFromSelector(selector);
+
+  if ([name hasSuffix:@":"]) {
+    name = [name substringToIndex:name.length - 1];
+    if (![name containsString:@":"]) {
+      [_channel invokeMethod:kPerformIntent arguments:@[ self.clientID, name ]];
+    }
   }
 }
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -177,7 +177,7 @@ static char markerKey;
 
 /**
  * Used to gather multiple selectors performed in one run loop turn. These
- * will be all send in one platform channel call so that framework can process
+ * will be all sent in one platform channel call so that framework can process
  * them in single microtask.
  */
 @property(nonatomic) NSMutableArray* pendingSelectors;

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -703,6 +703,16 @@ static char markerKey;
   if (!_activeModel->composing()) {
     _activeModel->BeginComposing();
   }
+
+  if (replacementRange.location != NSNotFound) {
+    _activeModel->SetComposingRange(
+        flutter::TextRange(replacementRange.location,
+                           replacementRange.location + replacementRange.length),
+        0);
+    _activeModel->SetSelection(
+        flutter::TextRange(selectedRange.location, selectedRange.location + selectedRange.length));
+  }
+
   flutter::TextRange composingBeforeChange = _activeModel->composing_range();
   flutter::TextRange selectionBeforeChange = _activeModel->selection();
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -220,6 +220,11 @@ static char markerKey;
  */
 - (NSString*)textAffinityString;
 
+/**
+ * Allow overriding run loop mode for test.
+ */
+@property(readwrite, nonatomic) NSString* customRunLoopMode;
+
 @end
 
 @implementation FlutterTextInputPlugin {
@@ -689,10 +694,15 @@ static char markerKey;
   [_pendingSelectors addObject:name];
   __weak NSMutableArray* selectors = _pendingSelectors;
   __weak FlutterMethodChannel* channel = _channel;
+  __weak NSNumber* clientID = self.clientID;
 
-  dispatch_async(dispatch_get_main_queue(), ^{
+  CFStringRef runLoopMode = self.customRunLoopMode != nil
+                                ? (__bridge CFStringRef)self.customRunLoopMode
+                                : kCFRunLoopCommonModes;
+
+  CFRunLoopPerformBlock(CFRunLoopGetMain(), runLoopMode, ^{
     if (selectors.count > 0) {
-      [channel invokeMethod:kPerformSelector arguments:@[ self.clientID, selectors ]];
+      [channel invokeMethod:kPerformSelector arguments:@[ clientID, selectors ]];
       [selectors removeAllObjects];
     }
   });

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -692,20 +692,23 @@ static char markerKey;
     _pendingSelectors = [NSMutableArray array];
   }
   [_pendingSelectors addObject:name];
-  __weak NSMutableArray* selectors = _pendingSelectors;
-  __weak FlutterMethodChannel* channel = _channel;
-  __weak NSNumber* clientID = self.clientID;
 
-  CFStringRef runLoopMode = self.customRunLoopMode != nil
-                                ? (__bridge CFStringRef)self.customRunLoopMode
-                                : kCFRunLoopCommonModes;
+  if (_pendingSelectors.count == 1) {
+    __weak NSMutableArray* selectors = _pendingSelectors;
+    __weak FlutterMethodChannel* channel = _channel;
+    __weak NSNumber* clientID = self.clientID;
 
-  CFRunLoopPerformBlock(CFRunLoopGetMain(), runLoopMode, ^{
-    if (selectors.count > 0) {
-      [channel invokeMethod:kPerformSelectors arguments:@[ clientID, selectors ]];
-      [selectors removeAllObjects];
-    }
-  });
+    CFStringRef runLoopMode = self.customRunLoopMode != nil
+                                  ? (__bridge CFStringRef)self.customRunLoopMode
+                                  : kCFRunLoopCommonModes;
+
+    CFRunLoopPerformBlock(CFRunLoopGetMain(), runLoopMode, ^{
+      if (selectors.count > 0) {
+        [channel invokeMethod:kPerformSelectors arguments:@[ clientID, selectors ]];
+        [selectors removeAllObjects];
+      }
+    });
+  }
 }
 
 - (void)insertNewline:(id)sender {

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -685,8 +685,8 @@ static char markerKey;
     func(self, selector, nil);
   }
 
-  // Group multiple selector within single run loop turn so that framework can
-  // process them in single microtask
+  // Group multiple selectors received within a single run loop turn so that
+  // framework can process them in single microtask.
   NSString* name = NSStringFromSelector(selector);
   if (_pendingSelectors == nil) {
     _pendingSelectors = [NSMutableArray array];

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -738,8 +738,6 @@ static char markerKey;
         flutter::TextRange(replacementRange.location,
                            replacementRange.location + replacementRange.length),
         0);
-    _activeModel->SetSelection(
-        flutter::TextRange(selectedRange.location, selectedRange.location + selectedRange.length));
   }
 
   flutter::TextRange composingBeforeChange = _activeModel->composing_range();

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -177,7 +177,7 @@ static char markerKey;
 
 /**
  * Used to gather multiple selectors performed in one run loop turn. These
- * will be all sent in one platform channel call so that framework can process
+ * will be all sent in one platform channel call so that the framework can process
  * them in single microtask.
  */
 @property(nonatomic) NSMutableArray* pendingSelectors;
@@ -686,7 +686,7 @@ static char markerKey;
   }
 
   // Group multiple selectors received within a single run loop turn so that
-  // framework can process them in single microtask.
+  // the framework can process them in single microtask.
   NSString* name = NSStringFromSelector(selector);
   if (_pendingSelectors == nil) {
     _pendingSelectors = [NSMutableArray array];

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -737,6 +737,11 @@ static char markerKey;
   }
 
   if (replacementRange.location != NSNotFound) {
+    // According to the NSTextInputClient documentation replacementRange is
+    // computed from the beginning of the marked text. That doesn't seem to be
+    // the case, because in situations where the replacementRange is actually
+    // specified (i.e. when switching between characters equivalent after long
+    // key press) the replacementRange is provided while there is no composition.
     _activeModel->SetComposingRange(
         flutter::TextRange(replacementRange.location,
                            replacementRange.location + replacementRange.length),

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -685,6 +685,11 @@ static char markerKey;
     func(self, selector, nil);
   }
 
+  if (selector == @selector(insertNewline:)) {
+    // Already handled through text insertion (multiline) or action.
+    return;
+  }
+
   // Group multiple selectors received within a single run loop turn so that
   // the framework can process them in single microtask.
   NSString* name = NSStringFromSelector(selector);

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -32,7 +32,7 @@ static NSString* const kUpdateEditStateResponseMethod = @"TextInputClient.update
 static NSString* const kUpdateEditStateWithDeltasResponseMethod =
     @"TextInputClient.updateEditingStateWithDeltas";
 static NSString* const kPerformAction = @"TextInputClient.performAction";
-static NSString* const kPerformIntent = @"TextInputClient.performIntent";
+static NSString* const kPerformSelector = @"TextInputClient.performSelector";
 static NSString* const kMultilineInputType = @"TextInputType.multiline";
 
 static NSString* const kTextAffinityDownstream = @"TextAffinity.downstream";
@@ -667,16 +667,9 @@ static char markerKey;
     void (*func)(id, SEL, id) = reinterpret_cast<void (*)(id, SEL, id)>(imp);
     func(self, selector, nil);
   }
-  // All NSStandardKeyBindingResponding method have single trailing space.
-  // For now forward all selectors to framework
+  // Forward all selectors to framework
   NSString* name = NSStringFromSelector(selector);
-
-  if ([name hasSuffix:@":"]) {
-    name = [name substringToIndex:name.length - 1];
-    if (![name containsString:@":"]) {
-      [_channel invokeMethod:kPerformIntent arguments:@[ self.clientID, name ]];
-    }
-  }
+  [_channel invokeMethod:kPerformSelector arguments:@[ self.clientID, name ]];
 }
 
 - (void)insertNewline:(id)sender {

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -32,7 +32,7 @@ static NSString* const kUpdateEditStateResponseMethod = @"TextInputClient.update
 static NSString* const kUpdateEditStateWithDeltasResponseMethod =
     @"TextInputClient.updateEditingStateWithDeltas";
 static NSString* const kPerformAction = @"TextInputClient.performAction";
-static NSString* const kPerformSelector = @"TextInputClient.performSelectors";
+static NSString* const kPerformSelectors = @"TextInputClient.performSelectors";
 static NSString* const kMultilineInputType = @"TextInputType.multiline";
 
 static NSString* const kTextAffinityDownstream = @"TextAffinity.downstream";
@@ -702,7 +702,7 @@ static char markerKey;
 
   CFRunLoopPerformBlock(CFRunLoopGetMain(), runLoopMode, ^{
     if (selectors.count > 0) {
-      [channel invokeMethod:kPerformSelector arguments:@[ clientID, selectors ]];
+      [channel invokeMethod:kPerformSelectors arguments:@[ clientID, selectors ]];
       [selectors removeAllObjects];
     }
   });

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -612,6 +612,11 @@ static char markerKey;
 #pragma mark -
 #pragma mark NSTextInputClient
 
+- (void)insertTab:(id)sender {
+  // Implementing insertTab: makes AppKit send tab as command, instead of
+  // insertText with '\t'.
+}
+
 - (void)insertText:(id)string replacementRange:(NSRange)range {
   if (_activeModel == nullptr) {
     return;

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
@@ -173,6 +173,74 @@
   return true;
 }
 
+- (bool)testSetMarkedTextWithReplacementRange {
+  id engineMock = OCMClassMock([FlutterEngine class]);
+  id binaryMessengerMock = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
+  OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
+      [engineMock binaryMessenger])
+      .andReturn(binaryMessengerMock);
+
+  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engineMock
+                                                                                nibName:@""
+                                                                                 bundle:nil];
+
+  FlutterTextInputPlugin* plugin =
+      [[FlutterTextInputPlugin alloc] initWithViewController:viewController];
+
+  [plugin handleMethodCall:[FlutterMethodCall
+                               methodCallWithMethodName:@"TextInput.setClient"
+                                              arguments:@[
+                                                @(1), @{
+                                                  @"inputAction" : @"action",
+                                                  @"inputType" : @{@"name" : @"inputName"},
+                                                }
+                                              ]]
+                    result:^(id){
+                    }];
+
+  FlutterMethodCall* call = [FlutterMethodCall methodCallWithMethodName:@"TextInput.setEditingState"
+                                                              arguments:@{
+                                                                @"text" : @"1234",
+                                                                @"selectionBase" : @(3),
+                                                                @"selectionExtent" : @(3),
+                                                                @"composingBase" : @(-1),
+                                                                @"composingExtent" : @(-1),
+                                                              }];
+  [plugin handleMethodCall:call
+                    result:^(id){
+                    }];
+
+  [plugin setMarkedText:@"marked"
+          selectedRange:NSMakeRange(1, 0)
+       replacementRange:NSMakeRange(1, 2)];
+
+  NSDictionary* expectedState = @{
+    @"selectionBase" : @(2),
+    @"selectionExtent" : @(2),
+    @"selectionAffinity" : @"TextAffinity.upstream",
+    @"selectionIsDirectional" : @(NO),
+    @"composingBase" : @(1),
+    @"composingExtent" : @(7),
+    @"text" : @"1marked4",
+  };
+
+  NSData* updateCall = [[FlutterJSONMethodCodec sharedInstance]
+      encodeMethodCall:[FlutterMethodCall
+                           methodCallWithMethodName:@"TextInputClient.updateEditingState"
+                                          arguments:@[ @(1), expectedState ]]];
+
+  OCMExpect(  // NOLINT(google-objc-avoid-throwing-exception)
+      [binaryMessengerMock sendOnChannel:@"flutter/textinput" message:updateCall]);
+
+  @try {
+    OCMVerify(  // NOLINT(google-objc-avoid-throwing-exception)
+        [binaryMessengerMock sendOnChannel:@"flutter/textinput" message:updateCall]);
+  } @catch (...) {
+    return false;
+  }
+  return true;
+}
+
 - (bool)testComposingRegionRemovedByFramework {
   id engineMock = OCMClassMock([FlutterEngine class]);
   id binaryMessengerMock = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
@@ -1121,6 +1189,10 @@ TEST(FlutterTextInputPluginTest, TestEmptyCompositionRange) {
 
 TEST(FlutterTextInputPluginTest, TestSetMarkedTextWithSelectionChange) {
   ASSERT_TRUE([[FlutterInputPluginTestObjc alloc] testSetMarkedTextWithSelectionChange]);
+}
+
+TEST(FlutterTextInputPluginTest, TestSetMarkedTextWithReplacementRange) {
+  ASSERT_TRUE([[FlutterInputPluginTestObjc alloc] testSetMarkedTextWithReplacementRange]);
 }
 
 TEST(FlutterTextInputPluginTest, TestComposingRegionRemovedByFramework) {

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
@@ -1156,7 +1156,7 @@
   NSString* runLoopMode = @"FlutterTestRunLoopMode";
   plugin.customRunLoopMode = runLoopMode;
 
-  // Ensure both selectors are grouped in one platform channel call
+  // Ensure both selectors are grouped in one platform channel call.
   [plugin doCommandBySelector:@selector(moveUp:)];
   [plugin doCommandBySelector:@selector(moveRightAndModifySelection:)];
 
@@ -1166,7 +1166,7 @@
   });
 
   while (!done) {
-    // Each invocation will handle one source
+    // Each invocation will handle one source.
     CFRunLoopRunInMode((__bridge CFStringRef)runLoopMode, 0, true);
   }
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
@@ -1151,12 +1151,26 @@
                     result:^(id){
                     }];
 
+  // Ensure both selectors are grouped in one platform channel call
+  [plugin doCommandBySelector:@selector(moveUp:)];
   [plugin doCommandBySelector:@selector(moveRightAndModifySelection:)];
+
+  __block bool done = false;
+  dispatch_async(dispatch_get_main_queue(), ^{
+    done = true;
+  });
+
+  while (!done) {
+    // Each invocation will handle one source
+    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 1.0, true);
+  }
 
   NSData* performSelectorCall = [[FlutterJSONMethodCodec sharedInstance]
       encodeMethodCall:[FlutterMethodCall
-                           methodCallWithMethodName:@"TextInputClient.performSelector"
-                                          arguments:@[ @(1), @"moveRightAndModifySelection:" ]]];
+                           methodCallWithMethodName:@"TextInputClient.performSelectors"
+                                          arguments:@[
+                                            @(1), @[ @"moveUp:", @"moveRightAndModifySelection:" ]
+                                          ]]];
 
   @try {
     OCMVerify(  // NOLINT(google-objc-avoid-throwing-exception)

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -688,10 +688,6 @@ static void CommonInit(FlutterViewController* controller) {
 
 #pragma mark - FlutterKeyboardViewDelegate
 
-- (BOOL)isComposing {
-  return [_textInputPlugin isComposing];
-}
-
 - (void)sendKeyEvent:(const FlutterKeyEvent&)event
             callback:(nullable FlutterKeyEventCallback)callback
             userData:(nullable void*)userData {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/85328

Framework PR: https://github.com/flutter/flutter/pull/105407

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
