### PR TITLE
Add a license file for impellerc, rename font-subset license

### DIFF
--- a/impeller/compiler/BUILD.gn
+++ b/impeller/compiler/BUILD.gn
@@ -3,6 +3,7 @@
 # found in the LICENSE file.
 
 import("//flutter/impeller/tools/impeller.gni")
+import("//flutter/shell/version/version.gni")
 
 impeller_component("compiler_lib") {
   sources = [
@@ -31,9 +32,49 @@ impeller_component("compiler_lib") {
     "../base",
     "../geometry",
     "//flutter/fml",
+
+    # All third_party deps must be reflected below in the impellerc_license
+    # target.
     "//third_party/inja",
     "//third_party/shaderc_flutter",
     "//third_party/spirv_cross_flutter",
+  ]
+}
+
+generated_file("impellerc_license") {
+  source_path = rebase_path(".", "//flutter")
+  git_url = "https://github.com/flutter/engine/tree/$engine_version"
+  outputs = [ "$target_gen_dir/LICENSE.impellerc.md" ]
+  contents = [
+    "# impellerc",
+    "",
+    "This tool is used by the Flutter SDK to compile shaders.",
+    "",
+    "Source code for this tool: [flutter/engine/$source_path]($git_url/$source_path).",
+    "",
+    "## Licenses",
+    "",
+    "### impellerc",
+    "",
+    read_file("//flutter/sky/packages/sky_engine/LICENSE", "string"),
+    "",
+
+    # These licenses are ignored by the main license checker, since they are not
+    # shipped to end-application binaries and only shipped as part of developer
+    # tooling in impellerc. Add them here.
+    "## Additional open source licenses",
+    "",
+    "### inja",
+    "",
+    read_file("//third_party/inja/LICENSE", "string"),
+    "",
+    "### shaderc",
+    "",
+    read_file("//third_party/shaderc/LICENSE", "string"),
+    "",
+    "### spirv_cross",
+    "",
+    read_file("//third_party/spirv_cross/LICENSE", "string"),
   ]
 }
 
@@ -46,7 +87,10 @@ impeller_component("impellerc") {
 }
 
 group("compiler") {
-  deps = [ ":impellerc" ]
+  deps = [
+    ":impellerc",
+    ":impellerc_license",
+  ]
 }
 
 impeller_component("compiler_unittests") {

--- a/tools/font-subset/BUILD.gn
+++ b/tools/font-subset/BUILD.gn
@@ -29,7 +29,7 @@ generated_file("_font-subset-license") {
   license_path =
       rebase_path("//flutter/sky/packages/sky_engine/LICENSE", "//flutter")
   git_url = "https://github.com/flutter/engine/tree/$engine_version"
-  outputs = [ "$target_gen_dir/README.md" ]
+  outputs = [ "$target_gen_dir/LICENSE.font-subset.md" ]
   contents = [
     "# font-subset",
     "",
@@ -64,8 +64,8 @@ zip_bundle("font-subset") {
       destination = "const_finder.dart.snapshot"
     },
     {
-      source = "$target_gen_dir/README.md"
-      destination = "README.md"
+      source = "$target_gen_dir/LICENSE.font-subset.md"
+      destination = "LICENSE.font-subset.md"
     },
   ]
 

--- a/tools/licenses/lib/main.dart
+++ b/tools/licenses/lib/main.dart
@@ -1855,14 +1855,14 @@ class _RepositoryRootThirdPartyDirectory extends _RepositoryGenericThirdPartyDir
         && entry.name != 'skia' // treated as a separate component
         && entry.name != 'fontconfig' // not used in standard configurations
         && entry.name != 'swiftshader' // only used on hosts for tests
-        && entry.name != 'shaderc' // only used on hosts for tests
+        && entry.name != 'shaderc' // Used by impellerc with separate license and host tests.
         && entry.name != 'glslang' // only used on hosts for tests
         && entry.name != 'spirv_tools' // only used on hosts for tests
         && entry.name != 'spirv_headers' // only used on hosts for tests
-        && entry.name != 'spirv_cross' // only used on hosts for tests
+        && entry.name != 'spirv_cross' // Used by impellerc with separate license and host tests.
         && entry.name != 'ocmock' // only used for tests
         && entry.name != 'java' // only used for Android builds
-        && entry.name != 'inja' // only used on hosts for builds
+        && entry.name != 'inja' // Only used by impellerc, which ships a separate license
         && super.shouldRecurse(entry);
   }
 


### PR DESCRIPTION
The rename is to disambiguate files that end up in the same zip archive

A separate recipe change will be needed once this lands to have the recipe pick up the new license file and vend it to the tool.

I've updated the license script comments to clarify these dependency exclusions. 

If we ever ship SwiftShader as part of flutter_tester, there will be more of these to deal with, but AFAICT these are the only ones that are part of impellerc.