### PR TITLE
Fix PerformanceOverlay do not resize

### DIFF
--- a/flow/instrumentation.cc
+++ b/flow/instrumentation.cc
@@ -86,6 +86,14 @@ fml::TimeDelta Stopwatch::AverageDelta() const {
 // Initialize the SkSurface for drawing into. Draws the base background and any
 // timing data from before the initial Visualize() call.
 void Stopwatch::InitVisualizeSurface(const SkRect& rect) const {
+  // Mark as dirty if the size has changed.
+  if (visualize_cache_surface_) {
+    if (rect.width() != visualize_cache_surface_->width() ||
+        rect.height() != visualize_cache_surface_->height()) {
+      cache_dirty_ = true;
+    };
+  }
+
   if (!cache_dirty_) {
     return;
   }

--- a/flow/layers/performance_overlay_layer_unittests.cc
+++ b/flow/layers/performance_overlay_layer_unittests.cc
@@ -191,6 +191,31 @@ TEST_F(PerformanceOverlayLayerTest, SimpleRasterizerStatistics) {
                                             text_position}}}));
 }
 
+TEST_F(PerformanceOverlayLayerTest, MarkAsDirtyWhenResized) {
+  // Regression test for https://github.com/flutter/flutter/issues/54188
+
+  // Create a PerformanceOverlayLayer.
+  const uint64_t overlay_opts = kVisualizeRasterizerStatistics;
+  auto layer = std::make_shared<PerformanceOverlayLayer>(overlay_opts);
+  layer->set_paint_bounds(SkRect::MakeLTRB(0.0f, 0.0f, 48.0f, 48.0f));
+  layer->Preroll(preroll_context(), SkMatrix());
+  layer->Paint(paint_context());
+  auto data = mock_canvas().draw_calls().front().data;
+  auto imageData = std::get<MockCanvas::DrawImageDataNoPaint>(data);
+  auto first_draw_width = imageData.image->width();
+
+  // Create a second PerformanceOverlayLayer with different bounds.
+  layer = std::make_shared<PerformanceOverlayLayer>(overlay_opts);
+  layer->set_paint_bounds(SkRect::MakeLTRB(0.0f, 0.0f, 64.0f, 64.0f));
+  layer->Preroll(preroll_context(), SkMatrix());
+  layer->Paint(paint_context());
+  data = mock_canvas().draw_calls().back().data;
+  imageData = std::get<MockCanvas::DrawImageDataNoPaint>(data);
+  auto refreshed_draw_width = imageData.image->width();
+
+  EXPECT_NE(first_draw_width, refreshed_draw_width);
+}
+
 TEST(PerformanceOverlayLayerDefault, Gold) {
   TestPerformanceOverlayLayerGold(60);
 }


### PR DESCRIPTION
## Description

This PR updates `Stopwatch::InitVisualizeSurface` to invalidate the cache when the PerformanceOverlay is resized.

Android screenshots showing how the PerformanceOverlay is displayed when the device orientation has changed:

**Before this PR**
![image](https://user-images.githubusercontent.com/840911/172408650-c5173fc0-549e-4a1b-a1ab-4804ce018fbd.png)


**After this PR**
![image](https://user-images.githubusercontent.com/840911/172409299-012a036b-734f-4524-a07a-9fa2ede979f4.png)


## Related Issue

Fixes https://github.com/flutter/flutter/issues/54188

## Tests

Adds 1 test.