### PR TITLE
[web] Avoid returning `List` from DOM apis.

### DIFF
--- a/lib/web_ui/lib/src/engine/html/surface_stats.dart
+++ b/lib/web_ui/lib/src/engine/html/surface_stats.dart
@@ -291,7 +291,7 @@ void debugPrintSurfaceStats(PersistedScene scene, int frameNumber) {
   // A microtask will fire after the DOM is flushed, letting us probe into
   // actual <canvas> tags.
   scheduleMicrotask(() {
-    final List<DomElement> canvasElements = domDocument.querySelectorAll('canvas');
+    final Iterable<DomElement> canvasElements = domDocument.querySelectorAll('canvas');
     final StringBuffer canvasInfo = StringBuffer();
     final int pixelCount = canvasElements
         .cast<DomCanvasElement>()

--- a/lib/web_ui/test/engine/surface/scene_builder_test.dart
+++ b/lib/web_ui/test/engine/surface/scene_builder_test.dart
@@ -248,7 +248,7 @@ void testMain() {
 
       final DomElement contentAfterReuse = builder2.build().webOnlyRootElement!;
       final List<DomCanvasElement> list =
-          contentAfterReuse.querySelectorAll('canvas').cast<DomCanvasElement>();
+          contentAfterReuse.querySelectorAll('canvas').cast<DomCanvasElement>().toList();
       expect(list[0].style.zIndex, '-1');
       expect(list[1].style.zIndex, '');
     });
@@ -268,7 +268,7 @@ void testMain() {
     final DomElement content = builder.build().webOnlyRootElement!;
     domDocument.body!.append(content);
     List<DomHTMLImageElement> list =
-        content.querySelectorAll('img').cast<DomHTMLImageElement>();
+        content.querySelectorAll('img').cast<DomHTMLImageElement>().toList();
     for (final DomHTMLImageElement image in list) {
       image.alt = 'marked';
     }
@@ -284,7 +284,8 @@ void testMain() {
     builder2.pop();
 
     final DomElement contentAfterReuse = builder2.build().webOnlyRootElement!;
-    list = contentAfterReuse.querySelectorAll('img').cast<DomHTMLImageElement>();
+    list =
+        contentAfterReuse.querySelectorAll('img').cast<DomHTMLImageElement>().toList();
     for (final DomHTMLImageElement image in list) {
       expect(image.alt, 'marked');
     }
@@ -515,7 +516,8 @@ void testMain() {
         renderedLayers[char] = pushChild(builder, char, oldLayer: renderedLayers[char]);
       }
       final SurfaceScene scene = builder.build();
-      final List<DomElement> pTags = scene.webOnlyRootElement!.querySelectorAll('flt-paragraph');
+      final List<DomElement> pTags =
+          scene.webOnlyRootElement!.querySelectorAll('flt-paragraph').toList();
       expect(pTags, hasLength(string.length));
       expect(
         scene.webOnlyRootElement!.querySelectorAll('flt-paragraph').map((DomElement p) => p.innerText).join(''),

--- a/lib/web_ui/test/text_test.dart
+++ b/lib/web_ui/test/text_test.dart
@@ -225,7 +225,7 @@ Future<void> testMain() async {
     paragraph.layout(const ParagraphConstraints(width: 800.0));
     expect(paragraph.plainText, 'abcdef');
     final List<Element> spans =
-        paragraph.toDomElement().querySelectorAll('flt-span').cast<Element>();
+        paragraph.toDomElement().querySelectorAll('flt-span').cast<Element>().toList();
     expect(spans[0].style.fontFamily, 'Ahem, $fallback, sans-serif');
     // The nested span here should not set it's family to default sans-serif.
     expect(spans[1].style.fontFamily, 'Ahem, $fallback, sans-serif');


### PR DESCRIPTION
Returning a `List` from DOM APIs can result in dangerous corner cases, i.e. inserting into a static `NodeList`. This CL changes those APIs to return Iterables wrapping static interop objects which should be safer.