### PR TITLE
[Impeller] Allow for the specification of pipeline stage information at runtime.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -111,7 +111,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '8ce3dadcb6bb3e05570e1b5748fbc2716d264bb0',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'a41648143b1095abf4e19d5fc8608be408e1fa20',
 
    # Fuchsia compatibility
    #
@@ -149,6 +149,8 @@ deps = {
   'src/third_party/spirv_cross':
    Var('github_git') + '/KhronosGroup/SPIRV-Cross.git' + '@' + '418542eaefdb609f548d25a1e3962fb69d80da63',
 
+  'src/third_party/flatbuffers':
+   Var('github_git') + '/google/flatbuffers.git' + '@' + '967df08b1dbddc62f867464c2e0d58d8027438ad',
 
    # Chromium-style
    #

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -475,6 +475,8 @@ FILE: ../../../flutter/impeller/compiler/includer.h
 FILE: ../../../flutter/impeller/compiler/logger.h
 FILE: ../../../flutter/impeller/compiler/reflector.cc
 FILE: ../../../flutter/impeller/compiler/reflector.h
+FILE: ../../../flutter/impeller/compiler/runtime_stage_data.cc
+FILE: ../../../flutter/impeller/compiler/runtime_stage_data.h
 FILE: ../../../flutter/impeller/compiler/source_options.cc
 FILE: ../../../flutter/impeller/compiler/source_options.h
 FILE: ../../../flutter/impeller/compiler/switches.cc
@@ -780,6 +782,12 @@ FILE: ../../../flutter/impeller/renderer/vertex_buffer_builder.cc
 FILE: ../../../flutter/impeller/renderer/vertex_buffer_builder.h
 FILE: ../../../flutter/impeller/renderer/vertex_descriptor.cc
 FILE: ../../../flutter/impeller/renderer/vertex_descriptor.h
+FILE: ../../../flutter/impeller/runtime_stage/runtime_stage.cc
+FILE: ../../../flutter/impeller/runtime_stage/runtime_stage.fbs
+FILE: ../../../flutter/impeller/runtime_stage/runtime_stage.h
+FILE: ../../../flutter/impeller/runtime_stage/runtime_stage_playground.cc
+FILE: ../../../flutter/impeller/runtime_stage/runtime_stage_playground.h
+FILE: ../../../flutter/impeller/runtime_stage/runtime_stage_unittests.cc
 FILE: ../../../flutter/impeller/tessellator/c/tessellator.cc
 FILE: ../../../flutter/impeller/tessellator/c/tessellator.h
 FILE: ../../../flutter/impeller/tessellator/dart/lib/tessellator.dart

--- a/ci/licenses_golden/licenses_third_party
+++ b/ci/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: 356ee23cb18832ea8023244e999bbf3b
+Signature: 199d1be0bd174db5609d6907bf86ef6e
 
 UNUSED LICENSES:
 
@@ -223,6 +223,7 @@ LIBRARY: abseil-cpp
 LIBRARY: angle
 LIBRARY: boringssl
 LIBRARY: expat
+LIBRARY: flatbuffers
 LIBRARY: fuchsia-vulkan
 LIBRARY: khronos
 LIBRARY: libwebp
@@ -1145,6 +1146,508 @@ FILE: ../../../third_party/boringssl/src/third_party/wycheproof_testvectors/x448
 FILE: ../../../third_party/boringssl/src/third_party/wycheproof_testvectors/xchacha20_poly1305_test.json
 FILE: ../../../third_party/expat/expat/fuzz/xml_parse_fuzzer.c
 FILE: ../../../third_party/expat/expat/fuzz/xml_parsebuffer_fuzzer.c
+FILE: ../../../third_party/flatbuffers/.bazelci/presubmit.yml
+FILE: ../../../third_party/flatbuffers/.editorconfig
+FILE: ../../../third_party/flatbuffers/.eslintrc.js
+FILE: ../../../third_party/flatbuffers/BUILD.bazel
+FILE: ../../../third_party/flatbuffers/CMake/CMakeLists_legacy.cmake.in
+FILE: ../../../third_party/flatbuffers/CMake/FlatbuffersConfigVersion.cmake.in
+FILE: ../../../third_party/flatbuffers/CMake/flatbuffers.pc.in
+FILE: ../../../third_party/flatbuffers/WORKSPACE
+FILE: ../../../third_party/flatbuffers/android/AndroidManifest.xml
+FILE: ../../../third_party/flatbuffers/android/app/proguard-rules.pro
+FILE: ../../../third_party/flatbuffers/android/app/src/main/AndroidManifest.xml
+FILE: ../../../third_party/flatbuffers/android/app/src/main/cpp/animals.cpp
+FILE: ../../../third_party/flatbuffers/android/app/src/main/cpp/generated/animal_generated.h
+FILE: ../../../third_party/flatbuffers/android/app/src/main/fbs/animal.fbs
+FILE: ../../../third_party/flatbuffers/android/app/src/main/java/com/flatbuffers/app/MainActivity.kt
+FILE: ../../../third_party/flatbuffers/android/app/src/main/java/generated/com/fbs/app/Animal.kt
+FILE: ../../../third_party/flatbuffers/android/app/src/main/res/drawable-v24/ic_launcher_foreground.xml
+FILE: ../../../third_party/flatbuffers/android/app/src/main/res/drawable/ic_launcher_background.xml
+FILE: ../../../third_party/flatbuffers/android/app/src/main/res/layout/activity_main.xml
+FILE: ../../../third_party/flatbuffers/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+FILE: ../../../third_party/flatbuffers/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+FILE: ../../../third_party/flatbuffers/android/app/src/main/res/mipmap-hdpi/ic_launcher.png
+FILE: ../../../third_party/flatbuffers/android/app/src/main/res/mipmap-hdpi/ic_launcher_round.png
+FILE: ../../../third_party/flatbuffers/android/app/src/main/res/mipmap-mdpi/ic_launcher.png
+FILE: ../../../third_party/flatbuffers/android/app/src/main/res/mipmap-mdpi/ic_launcher_round.png
+FILE: ../../../third_party/flatbuffers/android/app/src/main/res/mipmap-xhdpi/ic_launcher.png
+FILE: ../../../third_party/flatbuffers/android/app/src/main/res/mipmap-xhdpi/ic_launcher_round.png
+FILE: ../../../third_party/flatbuffers/android/app/src/main/res/mipmap-xxhdpi/ic_launcher.png
+FILE: ../../../third_party/flatbuffers/android/app/src/main/res/mipmap-xxhdpi/ic_launcher_round.png
+FILE: ../../../third_party/flatbuffers/android/app/src/main/res/mipmap-xxxhdpi/ic_launcher.png
+FILE: ../../../third_party/flatbuffers/android/app/src/main/res/mipmap-xxxhdpi/ic_launcher_round.png
+FILE: ../../../third_party/flatbuffers/android/app/src/main/res/values/colors.xml
+FILE: ../../../third_party/flatbuffers/android/app/src/main/res/values/strings.xml
+FILE: ../../../third_party/flatbuffers/android/app/src/main/res/values/styles.xml
+FILE: ../../../third_party/flatbuffers/android/gradle.properties
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/META-INF/MANIFEST.MF
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/gradle-wrapper-classpath.properties
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/AbstractCommandLineConverter.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/AbstractPropertiesCommandLineConverter.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/CommandLineArgumentException.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/CommandLineConverter.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/CommandLineOption.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/CommandLineParser$1.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/CommandLineParser$AfterFirstSubCommand.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/CommandLineParser$AfterOptions.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/CommandLineParser$BeforeFirstSubCommand.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/CommandLineParser$CaseInsensitiveStringComparator.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/CommandLineParser$KnownOptionParserState.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/CommandLineParser$MissingOptionArgState.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/CommandLineParser$OptionAwareParserState.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/CommandLineParser$OptionComparator.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/CommandLineParser$OptionParserState.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/CommandLineParser$OptionString.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/CommandLineParser$OptionStringComparator.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/CommandLineParser$ParserState.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/CommandLineParser$UnknownOptionParserState.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/CommandLineParser.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/ParsedCommandLine.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/ParsedCommandLineOption.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/ProjectPropertiesCommandLineConverter.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/SystemPropertiesCommandLineConverter.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/wrapper/BootstrapMainStarter$1.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/wrapper/BootstrapMainStarter.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/wrapper/Download$1.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/wrapper/Download$DefaultDownloadProgressListener.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/wrapper/Download$ProxyAuthenticator.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/wrapper/Download.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/wrapper/DownloadProgressListener.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/wrapper/ExclusiveFileAccessManager.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/wrapper/GradleUserHomeLookup.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/wrapper/GradleWrapperMain.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/wrapper/IDownload.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/wrapper/Install$1.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/wrapper/Install$InstallCheck.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/wrapper/Install.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/wrapper/Logger.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/wrapper/PathAssembler$LocalDistribution.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/wrapper/PathAssembler.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/wrapper/SystemPropertiesHandler.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/wrapper/WrapperConfiguration.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.jar!/org/gradle/wrapper/WrapperExecutor.class
+FILE: ../../../third_party/flatbuffers/android/gradle/wrapper/gradle-wrapper.properties
+FILE: ../../../third_party/flatbuffers/android/gradlew
+FILE: ../../../third_party/flatbuffers/benchmarks/cpp/bench.h
+FILE: ../../../third_party/flatbuffers/benchmarks/cpp/benchmark_main.cpp
+FILE: ../../../third_party/flatbuffers/benchmarks/cpp/flatbuffers/bench.fbs
+FILE: ../../../third_party/flatbuffers/benchmarks/cpp/flatbuffers/bench_generated.h
+FILE: ../../../third_party/flatbuffers/benchmarks/cpp/flatbuffers/fb_bench.cpp
+FILE: ../../../third_party/flatbuffers/benchmarks/cpp/flatbuffers/fb_bench.h
+FILE: ../../../third_party/flatbuffers/benchmarks/cpp/raw/raw_bench.cpp
+FILE: ../../../third_party/flatbuffers/benchmarks/cpp/raw/raw_bench.h
+FILE: ../../../third_party/flatbuffers/build_defs.bzl
+FILE: ../../../third_party/flatbuffers/composer.json
+FILE: ../../../third_party/flatbuffers/conan/test_package/test_package.cpp
+FILE: ../../../third_party/flatbuffers/dart/example/example.dart
+FILE: ../../../third_party/flatbuffers/docs/footer.html
+FILE: ../../../third_party/flatbuffers/docs/header.html
+FILE: ../../../third_party/flatbuffers/docs/images/fpl_logo_small.png
+FILE: ../../../third_party/flatbuffers/docs/images/ftv2mnode.png
+FILE: ../../../third_party/flatbuffers/docs/images/ftv2pnode.png
+FILE: ../../../third_party/flatbuffers/docs/source/doxygen_layout.xml
+FILE: ../../../third_party/flatbuffers/docs/source/groups
+FILE: ../../../third_party/flatbuffers/go/BUILD.bazel
+FILE: ../../../third_party/flatbuffers/go/builder.go
+FILE: ../../../third_party/flatbuffers/go/doc.go
+FILE: ../../../third_party/flatbuffers/go/encode.go
+FILE: ../../../third_party/flatbuffers/go/grpc.go
+FILE: ../../../third_party/flatbuffers/go/lib.go
+FILE: ../../../third_party/flatbuffers/go/sizes.go
+FILE: ../../../third_party/flatbuffers/go/struct.go
+FILE: ../../../third_party/flatbuffers/go/table.go
+FILE: ../../../third_party/flatbuffers/grpc/boringssl.patch
+FILE: ../../../third_party/flatbuffers/grpc/examples/go/greeter/client/go.mod
+FILE: ../../../third_party/flatbuffers/grpc/examples/go/greeter/client/main.go
+FILE: ../../../third_party/flatbuffers/grpc/examples/go/greeter/models/Greeter_grpc.go
+FILE: ../../../third_party/flatbuffers/grpc/examples/go/greeter/models/HelloReply.go
+FILE: ../../../third_party/flatbuffers/grpc/examples/go/greeter/models/HelloRequest.go
+FILE: ../../../third_party/flatbuffers/grpc/examples/go/greeter/models/go.mod
+FILE: ../../../third_party/flatbuffers/grpc/examples/go/greeter/server/go.mod
+FILE: ../../../third_party/flatbuffers/grpc/examples/go/greeter/server/main.go
+FILE: ../../../third_party/flatbuffers/grpc/examples/greeter.fbs
+FILE: ../../../third_party/flatbuffers/grpc/examples/swift/Greeter/Package.swift
+FILE: ../../../third_party/flatbuffers/grpc/examples/swift/Greeter/Sources/Model/greeter.grpc.swift
+FILE: ../../../third_party/flatbuffers/grpc/examples/swift/Greeter/Sources/Model/greeter_generated.swift
+FILE: ../../../third_party/flatbuffers/grpc/examples/swift/Greeter/Sources/client/main.swift
+FILE: ../../../third_party/flatbuffers/grpc/examples/swift/Greeter/Sources/server/main.swift
+FILE: ../../../third_party/flatbuffers/grpc/examples/ts/greeter/package.json
+FILE: ../../../third_party/flatbuffers/grpc/examples/ts/greeter/src/client.ts
+FILE: ../../../third_party/flatbuffers/grpc/examples/ts/greeter/src/greeter.ts
+FILE: ../../../third_party/flatbuffers/grpc/examples/ts/greeter/src/greeter_grpc.d.ts
+FILE: ../../../third_party/flatbuffers/grpc/examples/ts/greeter/src/greeter_grpc.js
+FILE: ../../../third_party/flatbuffers/grpc/examples/ts/greeter/src/models/hello-reply.ts
+FILE: ../../../third_party/flatbuffers/grpc/examples/ts/greeter/src/models/hello-request.ts
+FILE: ../../../third_party/flatbuffers/grpc/examples/ts/greeter/src/server.ts
+FILE: ../../../third_party/flatbuffers/grpc/examples/ts/greeter/tsconfig.json
+FILE: ../../../third_party/flatbuffers/grpc/flatbuffers-java-grpc/src/main/java/com/google/flatbuffers/grpc/FlatbuffersUtils.java
+FILE: ../../../third_party/flatbuffers/grpc/samples/greeter/client.cpp
+FILE: ../../../third_party/flatbuffers/grpc/samples/greeter/greeter.fbs
+FILE: ../../../third_party/flatbuffers/grpc/samples/greeter/server.cpp
+FILE: ../../../third_party/flatbuffers/grpc/src/compiler/BUILD.bazel
+FILE: ../../../third_party/flatbuffers/grpc/src/compiler/cpp_generator.cc
+FILE: ../../../third_party/flatbuffers/grpc/src/compiler/cpp_generator.h
+FILE: ../../../third_party/flatbuffers/grpc/src/compiler/go_generator.cc
+FILE: ../../../third_party/flatbuffers/grpc/src/compiler/go_generator.h
+FILE: ../../../third_party/flatbuffers/grpc/src/compiler/java_generator.cc
+FILE: ../../../third_party/flatbuffers/grpc/src/compiler/java_generator.h
+FILE: ../../../third_party/flatbuffers/grpc/src/compiler/python_generator.cc
+FILE: ../../../third_party/flatbuffers/grpc/src/compiler/python_generator.h
+FILE: ../../../third_party/flatbuffers/grpc/src/compiler/schema_interface.h
+FILE: ../../../third_party/flatbuffers/grpc/src/compiler/swift_generator.cc
+FILE: ../../../third_party/flatbuffers/grpc/src/compiler/swift_generator.h
+FILE: ../../../third_party/flatbuffers/grpc/src/compiler/ts_generator.cc
+FILE: ../../../third_party/flatbuffers/grpc/src/compiler/ts_generator.h
+FILE: ../../../third_party/flatbuffers/include/flatbuffers/allocator.h
+FILE: ../../../third_party/flatbuffers/include/flatbuffers/array.h
+FILE: ../../../third_party/flatbuffers/include/flatbuffers/base.h
+FILE: ../../../third_party/flatbuffers/include/flatbuffers/bfbs_generator.h
+FILE: ../../../third_party/flatbuffers/include/flatbuffers/buffer.h
+FILE: ../../../third_party/flatbuffers/include/flatbuffers/buffer_ref.h
+FILE: ../../../third_party/flatbuffers/include/flatbuffers/code_generators.h
+FILE: ../../../third_party/flatbuffers/include/flatbuffers/default_allocator.h
+FILE: ../../../third_party/flatbuffers/include/flatbuffers/detached_buffer.h
+FILE: ../../../third_party/flatbuffers/include/flatbuffers/flatbuffer_builder.h
+FILE: ../../../third_party/flatbuffers/include/flatbuffers/flatbuffers.h
+FILE: ../../../third_party/flatbuffers/include/flatbuffers/flatc.h
+FILE: ../../../third_party/flatbuffers/include/flatbuffers/flex_flat_util.h
+FILE: ../../../third_party/flatbuffers/include/flatbuffers/flexbuffers.h
+FILE: ../../../third_party/flatbuffers/include/flatbuffers/grpc.h
+FILE: ../../../third_party/flatbuffers/include/flatbuffers/hash.h
+FILE: ../../../third_party/flatbuffers/include/flatbuffers/idl.h
+FILE: ../../../third_party/flatbuffers/include/flatbuffers/minireflect.h
+FILE: ../../../third_party/flatbuffers/include/flatbuffers/pch/flatc_pch.h
+FILE: ../../../third_party/flatbuffers/include/flatbuffers/pch/pch.h
+FILE: ../../../third_party/flatbuffers/include/flatbuffers/reflection.h
+FILE: ../../../third_party/flatbuffers/include/flatbuffers/reflection_generated.h
+FILE: ../../../third_party/flatbuffers/include/flatbuffers/registry.h
+FILE: ../../../third_party/flatbuffers/include/flatbuffers/stl_emulation.h
+FILE: ../../../third_party/flatbuffers/include/flatbuffers/string.h
+FILE: ../../../third_party/flatbuffers/include/flatbuffers/struct.h
+FILE: ../../../third_party/flatbuffers/include/flatbuffers/table.h
+FILE: ../../../third_party/flatbuffers/include/flatbuffers/util.h
+FILE: ../../../third_party/flatbuffers/include/flatbuffers/vector.h
+FILE: ../../../third_party/flatbuffers/include/flatbuffers/vector_downward.h
+FILE: ../../../third_party/flatbuffers/include/flatbuffers/verifier.h
+FILE: ../../../third_party/flatbuffers/java/com/google/flatbuffers/ArrayReadWriteBuf.java
+FILE: ../../../third_party/flatbuffers/java/com/google/flatbuffers/BaseVector.java
+FILE: ../../../third_party/flatbuffers/java/com/google/flatbuffers/BooleanVector.java
+FILE: ../../../third_party/flatbuffers/java/com/google/flatbuffers/ByteBufferReadWriteBuf.java
+FILE: ../../../third_party/flatbuffers/java/com/google/flatbuffers/ByteBufferUtil.java
+FILE: ../../../third_party/flatbuffers/java/com/google/flatbuffers/ByteVector.java
+FILE: ../../../third_party/flatbuffers/java/com/google/flatbuffers/Constants.java
+FILE: ../../../third_party/flatbuffers/java/com/google/flatbuffers/DoubleVector.java
+FILE: ../../../third_party/flatbuffers/java/com/google/flatbuffers/FlatBufferBuilder.java
+FILE: ../../../third_party/flatbuffers/java/com/google/flatbuffers/FlexBuffers.java
+FILE: ../../../third_party/flatbuffers/java/com/google/flatbuffers/FlexBuffersBuilder.java
+FILE: ../../../third_party/flatbuffers/java/com/google/flatbuffers/FloatVector.java
+FILE: ../../../third_party/flatbuffers/java/com/google/flatbuffers/IntVector.java
+FILE: ../../../third_party/flatbuffers/java/com/google/flatbuffers/LongVector.java
+FILE: ../../../third_party/flatbuffers/java/com/google/flatbuffers/ReadBuf.java
+FILE: ../../../third_party/flatbuffers/java/com/google/flatbuffers/ReadWriteBuf.java
+FILE: ../../../third_party/flatbuffers/java/com/google/flatbuffers/ShortVector.java
+FILE: ../../../third_party/flatbuffers/java/com/google/flatbuffers/StringVector.java
+FILE: ../../../third_party/flatbuffers/java/com/google/flatbuffers/Struct.java
+FILE: ../../../third_party/flatbuffers/java/com/google/flatbuffers/Table.java
+FILE: ../../../third_party/flatbuffers/java/com/google/flatbuffers/UnionVector.java
+FILE: ../../../third_party/flatbuffers/java/com/google/flatbuffers/Utf8.java
+FILE: ../../../third_party/flatbuffers/java/com/google/flatbuffers/Utf8Old.java
+FILE: ../../../third_party/flatbuffers/java/com/google/flatbuffers/Utf8Safe.java
+FILE: ../../../third_party/flatbuffers/kotlin/benchmark/build.gradle.kts
+FILE: ../../../third_party/flatbuffers/kotlin/benchmark/src/jvmMain/java/com/google/flatbuffers/ArrayReadWriteBuf.java
+FILE: ../../../third_party/flatbuffers/kotlin/benchmark/src/jvmMain/java/com/google/flatbuffers/BaseVector.java
+FILE: ../../../third_party/flatbuffers/kotlin/benchmark/src/jvmMain/java/com/google/flatbuffers/BooleanVector.java
+FILE: ../../../third_party/flatbuffers/kotlin/benchmark/src/jvmMain/java/com/google/flatbuffers/ByteBufferReadWriteBuf.java
+FILE: ../../../third_party/flatbuffers/kotlin/benchmark/src/jvmMain/java/com/google/flatbuffers/ByteBufferUtil.java
+FILE: ../../../third_party/flatbuffers/kotlin/benchmark/src/jvmMain/java/com/google/flatbuffers/ByteVector.java
+FILE: ../../../third_party/flatbuffers/kotlin/benchmark/src/jvmMain/java/com/google/flatbuffers/Constants.java
+FILE: ../../../third_party/flatbuffers/kotlin/benchmark/src/jvmMain/java/com/google/flatbuffers/DoubleVector.java
+FILE: ../../../third_party/flatbuffers/kotlin/benchmark/src/jvmMain/java/com/google/flatbuffers/FlatBufferBuilder.java
+FILE: ../../../third_party/flatbuffers/kotlin/benchmark/src/jvmMain/java/com/google/flatbuffers/FlexBuffers.java
+FILE: ../../../third_party/flatbuffers/kotlin/benchmark/src/jvmMain/java/com/google/flatbuffers/FlexBuffersBuilder.java
+FILE: ../../../third_party/flatbuffers/kotlin/benchmark/src/jvmMain/java/com/google/flatbuffers/FloatVector.java
+FILE: ../../../third_party/flatbuffers/kotlin/benchmark/src/jvmMain/java/com/google/flatbuffers/IntVector.java
+FILE: ../../../third_party/flatbuffers/kotlin/benchmark/src/jvmMain/java/com/google/flatbuffers/LongVector.java
+FILE: ../../../third_party/flatbuffers/kotlin/benchmark/src/jvmMain/java/com/google/flatbuffers/ReadBuf.java
+FILE: ../../../third_party/flatbuffers/kotlin/benchmark/src/jvmMain/java/com/google/flatbuffers/ReadWriteBuf.java
+FILE: ../../../third_party/flatbuffers/kotlin/benchmark/src/jvmMain/java/com/google/flatbuffers/ShortVector.java
+FILE: ../../../third_party/flatbuffers/kotlin/benchmark/src/jvmMain/java/com/google/flatbuffers/StringVector.java
+FILE: ../../../third_party/flatbuffers/kotlin/benchmark/src/jvmMain/java/com/google/flatbuffers/Struct.java
+FILE: ../../../third_party/flatbuffers/kotlin/benchmark/src/jvmMain/java/com/google/flatbuffers/Table.java
+FILE: ../../../third_party/flatbuffers/kotlin/benchmark/src/jvmMain/java/com/google/flatbuffers/UnionVector.java
+FILE: ../../../third_party/flatbuffers/kotlin/benchmark/src/jvmMain/java/com/google/flatbuffers/Utf8.java
+FILE: ../../../third_party/flatbuffers/kotlin/benchmark/src/jvmMain/java/com/google/flatbuffers/Utf8Old.java
+FILE: ../../../third_party/flatbuffers/kotlin/benchmark/src/jvmMain/java/com/google/flatbuffers/Utf8Safe.java
+FILE: ../../../third_party/flatbuffers/kotlin/benchmark/src/jvmMain/kotlin/com/google/flatbuffers/kotlin/benchmark/FlexBuffersBenchmark.kt
+FILE: ../../../third_party/flatbuffers/kotlin/benchmark/src/jvmMain/kotlin/com/google/flatbuffers/kotlin/benchmark/JsonBenchmark.kt
+FILE: ../../../third_party/flatbuffers/kotlin/benchmark/src/jvmMain/kotlin/com/google/flatbuffers/kotlin/benchmark/UTF8Benchmark.kt
+FILE: ../../../third_party/flatbuffers/kotlin/build.gradle.kts
+FILE: ../../../third_party/flatbuffers/kotlin/flatbuffers-kotlin/build.gradle.kts
+FILE: ../../../third_party/flatbuffers/kotlin/flatbuffers-kotlin/src/commonMain/kotlin/com/google/flatbuffers/kotlin/Buffers.kt
+FILE: ../../../third_party/flatbuffers/kotlin/flatbuffers-kotlin/src/commonMain/kotlin/com/google/flatbuffers/kotlin/ByteArray.kt
+FILE: ../../../third_party/flatbuffers/kotlin/flatbuffers-kotlin/src/commonMain/kotlin/com/google/flatbuffers/kotlin/FlexBuffers.kt
+FILE: ../../../third_party/flatbuffers/kotlin/flatbuffers-kotlin/src/commonMain/kotlin/com/google/flatbuffers/kotlin/FlexBuffersBuilder.kt
+FILE: ../../../third_party/flatbuffers/kotlin/flatbuffers-kotlin/src/commonMain/kotlin/com/google/flatbuffers/kotlin/FlexBuffersInternals.kt
+FILE: ../../../third_party/flatbuffers/kotlin/flatbuffers-kotlin/src/commonMain/kotlin/com/google/flatbuffers/kotlin/JSON.kt
+FILE: ../../../third_party/flatbuffers/kotlin/flatbuffers-kotlin/src/commonMain/kotlin/com/google/flatbuffers/kotlin/Utf8.kt
+FILE: ../../../third_party/flatbuffers/kotlin/flatbuffers-kotlin/src/commonTest/kotlin/com/google/flatbuffers/kotlin/ByteArrayTest.kt
+FILE: ../../../third_party/flatbuffers/kotlin/flatbuffers-kotlin/src/commonTest/kotlin/com/google/flatbuffers/kotlin/FlexBuffersTest.kt
+FILE: ../../../third_party/flatbuffers/kotlin/flatbuffers-kotlin/src/commonTest/kotlin/com/google/flatbuffers/kotlin/JSONTest.kt
+FILE: ../../../third_party/flatbuffers/kotlin/flatbuffers-kotlin/src/jsMain/kotlin/com/google/flatbuffers/kotlin/ByteArray.kt
+FILE: ../../../third_party/flatbuffers/kotlin/flatbuffers-kotlin/src/jvmMain/kotlin/com/google/flatbuffers/kotlin/ByteArray.kt
+FILE: ../../../third_party/flatbuffers/kotlin/flatbuffers-kotlin/src/jvmTest/kotlin/com/google/flatbuffers/kotlin/Utf8Test.kt
+FILE: ../../../third_party/flatbuffers/kotlin/flatbuffers-kotlin/src/nativeMain/kotlin/com/google/flatbuffers/kotlin/ByteArray.kt
+FILE: ../../../third_party/flatbuffers/kotlin/gradle.properties
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/libs.versions.toml
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/META-INF/MANIFEST.MF
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/gradle-wrapper-classpath.properties
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/AbstractCommandLineConverter.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/AbstractPropertiesCommandLineConverter.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/CommandLineArgumentException.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/CommandLineConverter.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/CommandLineOption.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/CommandLineParser$1.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/CommandLineParser$AfterFirstSubCommand.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/CommandLineParser$AfterOptions.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/CommandLineParser$BeforeFirstSubCommand.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/CommandLineParser$CaseInsensitiveStringComparator.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/CommandLineParser$KnownOptionParserState.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/CommandLineParser$MissingOptionArgState.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/CommandLineParser$OptionAwareParserState.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/CommandLineParser$OptionComparator.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/CommandLineParser$OptionParserState.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/CommandLineParser$OptionString.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/CommandLineParser$OptionStringComparator.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/CommandLineParser$ParserState.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/CommandLineParser$UnknownOptionParserState.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/CommandLineParser.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/ParsedCommandLine.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/ParsedCommandLineOption.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/ProjectPropertiesCommandLineConverter.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/cli/SystemPropertiesCommandLineConverter.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/wrapper/BootstrapMainStarter$1.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/wrapper/BootstrapMainStarter.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/wrapper/Download$1.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/wrapper/Download$DefaultDownloadProgressListener.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/wrapper/Download$ProxyAuthenticator.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/wrapper/Download.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/wrapper/DownloadProgressListener.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/wrapper/ExclusiveFileAccessManager.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/wrapper/GradleUserHomeLookup.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/wrapper/GradleWrapperMain.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/wrapper/IDownload.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/wrapper/Install$1.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/wrapper/Install$InstallCheck.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/wrapper/Install.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/wrapper/Logger.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/wrapper/PathAssembler$LocalDistribution.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/wrapper/PathAssembler.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/wrapper/SystemPropertiesHandler.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/wrapper/WrapperConfiguration.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.jar!/org/gradle/wrapper/WrapperExecutor.class
+FILE: ../../../third_party/flatbuffers/kotlin/gradle/wrapper/gradle-wrapper.properties
+FILE: ../../../third_party/flatbuffers/kotlin/settings.gradle.kts
+FILE: ../../../third_party/flatbuffers/kotlin/spotless/spotless.kt
+FILE: ../../../third_party/flatbuffers/lobster/flatbuffers.lobster
+FILE: ../../../third_party/flatbuffers/lua/flatbuffers.lua
+FILE: ../../../third_party/flatbuffers/lua/flatbuffers/binaryarray.lua
+FILE: ../../../third_party/flatbuffers/lua/flatbuffers/builder.lua
+FILE: ../../../third_party/flatbuffers/lua/flatbuffers/compat.lua
+FILE: ../../../third_party/flatbuffers/lua/flatbuffers/compat_5_1.lua
+FILE: ../../../third_party/flatbuffers/lua/flatbuffers/compat_5_3.lua
+FILE: ../../../third_party/flatbuffers/lua/flatbuffers/compat_luajit.lua
+FILE: ../../../third_party/flatbuffers/lua/flatbuffers/numTypes.lua
+FILE: ../../../third_party/flatbuffers/lua/flatbuffers/view.lua
+FILE: ../../../third_party/flatbuffers/net/FlatBuffers/ByteBuffer.cs
+FILE: ../../../third_party/flatbuffers/net/FlatBuffers/ByteBufferUtil.cs
+FILE: ../../../third_party/flatbuffers/net/FlatBuffers/FlatBufferBuilder.cs
+FILE: ../../../third_party/flatbuffers/net/FlatBuffers/FlatBufferConstants.cs
+FILE: ../../../third_party/flatbuffers/net/FlatBuffers/FlatBuffers.csproj
+FILE: ../../../third_party/flatbuffers/net/FlatBuffers/FlatBuffers.net35.csproj
+FILE: ../../../third_party/flatbuffers/net/FlatBuffers/IFlatbufferObject.cs
+FILE: ../../../third_party/flatbuffers/net/FlatBuffers/Offset.cs
+FILE: ../../../third_party/flatbuffers/net/FlatBuffers/Properties/AssemblyInfo.cs
+FILE: ../../../third_party/flatbuffers/net/FlatBuffers/Struct.cs
+FILE: ../../../third_party/flatbuffers/net/FlatBuffers/Table.cs
+FILE: ../../../third_party/flatbuffers/package.json
+FILE: ../../../third_party/flatbuffers/php/ByteBuffer.php
+FILE: ../../../third_party/flatbuffers/php/Constants.php
+FILE: ../../../third_party/flatbuffers/php/FlatbufferBuilder.php
+FILE: ../../../third_party/flatbuffers/php/Struct.php
+FILE: ../../../third_party/flatbuffers/php/Table.php
+FILE: ../../../third_party/flatbuffers/python/setup.cfg
+FILE: ../../../third_party/flatbuffers/reflection/BUILD.bazel
+FILE: ../../../third_party/flatbuffers/reflection/reflection.fbs
+FILE: ../../../third_party/flatbuffers/rust/flatbuffers/Cargo.toml
+FILE: ../../../third_party/flatbuffers/rust/flatbuffers/src/array.rs
+FILE: ../../../third_party/flatbuffers/rust/flatbuffers/src/builder.rs
+FILE: ../../../third_party/flatbuffers/rust/flatbuffers/src/endian_scalar.rs
+FILE: ../../../third_party/flatbuffers/rust/flatbuffers/src/follow.rs
+FILE: ../../../third_party/flatbuffers/rust/flatbuffers/src/get_root.rs
+FILE: ../../../third_party/flatbuffers/rust/flatbuffers/src/lib.rs
+FILE: ../../../third_party/flatbuffers/rust/flatbuffers/src/primitives.rs
+FILE: ../../../third_party/flatbuffers/rust/flatbuffers/src/push.rs
+FILE: ../../../third_party/flatbuffers/rust/flatbuffers/src/table.rs
+FILE: ../../../third_party/flatbuffers/rust/flatbuffers/src/vector.rs
+FILE: ../../../third_party/flatbuffers/rust/flatbuffers/src/verifier.rs
+FILE: ../../../third_party/flatbuffers/rust/flatbuffers/src/vtable.rs
+FILE: ../../../third_party/flatbuffers/rust/flatbuffers/src/vtable_writer.rs
+FILE: ../../../third_party/flatbuffers/rust/flexbuffers/Cargo.toml
+FILE: ../../../third_party/flatbuffers/rust/flexbuffers/src/bitwidth.rs
+FILE: ../../../third_party/flatbuffers/rust/flexbuffers/src/buffer.rs
+FILE: ../../../third_party/flatbuffers/rust/flexbuffers/src/builder/map.rs
+FILE: ../../../third_party/flatbuffers/rust/flexbuffers/src/builder/mod.rs
+FILE: ../../../third_party/flatbuffers/rust/flexbuffers/src/builder/push.rs
+FILE: ../../../third_party/flatbuffers/rust/flexbuffers/src/builder/ser.rs
+FILE: ../../../third_party/flatbuffers/rust/flexbuffers/src/builder/value.rs
+FILE: ../../../third_party/flatbuffers/rust/flexbuffers/src/builder/vector.rs
+FILE: ../../../third_party/flatbuffers/rust/flexbuffers/src/flexbuffer_type.rs
+FILE: ../../../third_party/flatbuffers/rust/flexbuffers/src/lib.rs
+FILE: ../../../third_party/flatbuffers/rust/flexbuffers/src/reader/de.rs
+FILE: ../../../third_party/flatbuffers/rust/flexbuffers/src/reader/iter.rs
+FILE: ../../../third_party/flatbuffers/rust/flexbuffers/src/reader/map.rs
+FILE: ../../../third_party/flatbuffers/rust/flexbuffers/src/reader/mod.rs
+FILE: ../../../third_party/flatbuffers/rust/flexbuffers/src/reader/serialize.rs
+FILE: ../../../third_party/flatbuffers/rust/flexbuffers/src/reader/vector.rs
+FILE: ../../../third_party/flatbuffers/samples/SampleBinary.cs
+FILE: ../../../third_party/flatbuffers/samples/SampleBinary.java
+FILE: ../../../third_party/flatbuffers/samples/SampleBinary.kt
+FILE: ../../../third_party/flatbuffers/samples/SampleBinary.php
+FILE: ../../../third_party/flatbuffers/samples/lua/MyGame/Sample/Color.lua
+FILE: ../../../third_party/flatbuffers/samples/lua/MyGame/Sample/Equipment.lua
+FILE: ../../../third_party/flatbuffers/samples/lua/MyGame/Sample/Monster.lua
+FILE: ../../../third_party/flatbuffers/samples/lua/MyGame/Sample/Vec3.lua
+FILE: ../../../third_party/flatbuffers/samples/lua/MyGame/Sample/Weapon.lua
+FILE: ../../../third_party/flatbuffers/samples/monster.bfbs
+FILE: ../../../third_party/flatbuffers/samples/monster.fbs
+FILE: ../../../third_party/flatbuffers/samples/monster_generated.h
+FILE: ../../../third_party/flatbuffers/samples/monster_generated.lobster
+FILE: ../../../third_party/flatbuffers/samples/monster_generated.swift
+FILE: ../../../third_party/flatbuffers/samples/monsterdata.json
+FILE: ../../../third_party/flatbuffers/samples/rust_generated/mod.rs
+FILE: ../../../third_party/flatbuffers/samples/rust_generated/my_game/sample/color_generated.rs
+FILE: ../../../third_party/flatbuffers/samples/rust_generated/my_game/sample/equipment_generated.rs
+FILE: ../../../third_party/flatbuffers/samples/rust_generated/my_game/sample/monster_generated.rs
+FILE: ../../../third_party/flatbuffers/samples/rust_generated/my_game/sample/vec_3_generated.rs
+FILE: ../../../third_party/flatbuffers/samples/rust_generated/my_game/sample/weapon_generated.rs
+FILE: ../../../third_party/flatbuffers/samples/sample_bfbs.cpp
+FILE: ../../../third_party/flatbuffers/samples/sample_binary.cpp
+FILE: ../../../third_party/flatbuffers/samples/sample_binary.go
+FILE: ../../../third_party/flatbuffers/samples/sample_binary.lobster
+FILE: ../../../third_party/flatbuffers/samples/sample_binary.lua
+FILE: ../../../third_party/flatbuffers/samples/sample_binary.rs
+FILE: ../../../third_party/flatbuffers/samples/sample_binary.swift
+FILE: ../../../third_party/flatbuffers/samples/sample_flexbuffers.rs
+FILE: ../../../third_party/flatbuffers/samples/sample_flexbuffers_serde.rs
+FILE: ../../../third_party/flatbuffers/samples/sample_text.cpp
+FILE: ../../../third_party/flatbuffers/samples/sample_text.lobster
+FILE: ../../../third_party/flatbuffers/src/BUILD.bazel
+FILE: ../../../third_party/flatbuffers/src/annotated_binary_text_gen.cpp
+FILE: ../../../third_party/flatbuffers/src/annotated_binary_text_gen.h
+FILE: ../../../third_party/flatbuffers/src/bfbs_gen.h
+FILE: ../../../third_party/flatbuffers/src/bfbs_gen_lua.cpp
+FILE: ../../../third_party/flatbuffers/src/bfbs_gen_lua.h
+FILE: ../../../third_party/flatbuffers/src/bfbs_namer.h
+FILE: ../../../third_party/flatbuffers/src/binary_annotator.cpp
+FILE: ../../../third_party/flatbuffers/src/binary_annotator.h
+FILE: ../../../third_party/flatbuffers/src/code_generators.cpp
+FILE: ../../../third_party/flatbuffers/src/flatc.cpp
+FILE: ../../../third_party/flatbuffers/src/flatc_main.cpp
+FILE: ../../../third_party/flatbuffers/src/flathash.cpp
+FILE: ../../../third_party/flatbuffers/src/idl_gen_cpp.cpp
+FILE: ../../../third_party/flatbuffers/src/idl_gen_csharp.cpp
+FILE: ../../../third_party/flatbuffers/src/idl_gen_dart.cpp
+FILE: ../../../third_party/flatbuffers/src/idl_gen_fbs.cpp
+FILE: ../../../third_party/flatbuffers/src/idl_gen_go.cpp
+FILE: ../../../third_party/flatbuffers/src/idl_gen_grpc.cpp
+FILE: ../../../third_party/flatbuffers/src/idl_gen_java.cpp
+FILE: ../../../third_party/flatbuffers/src/idl_gen_json_schema.cpp
+FILE: ../../../third_party/flatbuffers/src/idl_gen_kotlin.cpp
+FILE: ../../../third_party/flatbuffers/src/idl_gen_lobster.cpp
+FILE: ../../../third_party/flatbuffers/src/idl_gen_lua.cpp
+FILE: ../../../third_party/flatbuffers/src/idl_gen_php.cpp
+FILE: ../../../third_party/flatbuffers/src/idl_gen_python.cpp
+FILE: ../../../third_party/flatbuffers/src/idl_gen_rust.cpp
+FILE: ../../../third_party/flatbuffers/src/idl_gen_swift.cpp
+FILE: ../../../third_party/flatbuffers/src/idl_gen_text.cpp
+FILE: ../../../third_party/flatbuffers/src/idl_gen_ts.cpp
+FILE: ../../../third_party/flatbuffers/src/idl_namer.h
+FILE: ../../../third_party/flatbuffers/src/idl_parser.cpp
+FILE: ../../../third_party/flatbuffers/src/namer.h
+FILE: ../../../third_party/flatbuffers/src/reflection.cpp
+FILE: ../../../third_party/flatbuffers/src/util.cpp
+FILE: ../../../third_party/flatbuffers/swift/BUILD.bazel
+FILE: ../../../third_party/flatbuffers/swift/FlatBuffers.podspec
+FILE: ../../../third_party/flatbuffers/swift/Package.swift
+FILE: ../../../third_party/flatbuffers/swift/Package@swift-5.5.swift
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/ByteBuffer.swift
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/Constants.swift
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/Documentation.docc/Resources/code/fbs/monster_step_1.fbs
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/Documentation.docc/Resources/code/fbs/monster_step_2.fbs
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/Documentation.docc/Resources/code/fbs/monster_step_3.fbs
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/Documentation.docc/Resources/code/fbs/monster_step_4.fbs
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/Documentation.docc/Resources/code/fbs/monster_step_5.fbs
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/Documentation.docc/Resources/code/fbs/monster_step_6.fbs
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/Documentation.docc/Resources/code/fbs/monster_step_7.fbs
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/Documentation.docc/Resources/code/swift/swift_code_1.swift
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/Documentation.docc/Resources/code/swift/swift_code_10.swift
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/Documentation.docc/Resources/code/swift/swift_code_11.swift
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/Documentation.docc/Resources/code/swift/swift_code_12.swift
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/Documentation.docc/Resources/code/swift/swift_code_13.swift
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/Documentation.docc/Resources/code/swift/swift_code_2.swift
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/Documentation.docc/Resources/code/swift/swift_code_3.swift
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/Documentation.docc/Resources/code/swift/swift_code_4.swift
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/Documentation.docc/Resources/code/swift/swift_code_5.swift
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/Documentation.docc/Resources/code/swift/swift_code_6.swift
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/Documentation.docc/Resources/code/swift/swift_code_7.swift
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/Documentation.docc/Resources/code/swift/swift_code_8.swift
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/Documentation.docc/Resources/code/swift/swift_code_9.swift
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/Documentation.docc/Resources/images/tutorial_cover_image_1.png
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/Documentation.docc/Tutorials/Tutorial_Table_of_Contents.tutorial
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/Documentation.docc/Tutorials/create_your_first_buffer.tutorial
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/Documentation.docc/Tutorials/creating_flatbuffer_schema.tutorial
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/Documentation.docc/Tutorials/reading_bytebuffer.tutorial
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/Enum.swift
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/FlatBufferBuilder.swift
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/FlatBufferObject.swift
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/FlatBuffersUtils.swift
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/FlatbuffersErrors.swift
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/Int+extension.swift
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/Message.swift
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/Mutable.swift
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/NativeObject.swift
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/Offset.swift
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/Root.swift
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/String+extension.swift
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/Struct.swift
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/Table.swift
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/TableVerifier.swift
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/VeriferOptions.swift
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/Verifiable.swift
+FILE: ../../../third_party/flatbuffers/swift/Sources/FlatBuffers/Verifier.swift
+FILE: ../../../third_party/flatbuffers/ts/BUILD.bazel
+FILE: ../../../third_party/flatbuffers/ts/builder.ts
+FILE: ../../../third_party/flatbuffers/ts/byte-buffer.ts
+FILE: ../../../third_party/flatbuffers/ts/constants.ts
+FILE: ../../../third_party/flatbuffers/ts/encoding.ts
+FILE: ../../../third_party/flatbuffers/ts/flexbuffers.ts
+FILE: ../../../third_party/flatbuffers/ts/flexbuffers/bit-width-util.ts
+FILE: ../../../third_party/flatbuffers/ts/flexbuffers/bit-width.ts
+FILE: ../../../third_party/flatbuffers/ts/flexbuffers/builder.ts
+FILE: ../../../third_party/flatbuffers/ts/flexbuffers/flexbuffers-util.ts
+FILE: ../../../third_party/flatbuffers/ts/flexbuffers/reference-util.ts
+FILE: ../../../third_party/flatbuffers/ts/flexbuffers/reference.ts
+FILE: ../../../third_party/flatbuffers/ts/flexbuffers/stack-value.ts
+FILE: ../../../third_party/flatbuffers/ts/flexbuffers/value-type-util.ts
+FILE: ../../../third_party/flatbuffers/ts/flexbuffers/value-type.ts
+FILE: ../../../third_party/flatbuffers/ts/index.ts
+FILE: ../../../third_party/flatbuffers/ts/types.ts
+FILE: ../../../third_party/flatbuffers/ts/utils.ts
+FILE: ../../../third_party/flatbuffers/tsconfig.json
+FILE: ../../../third_party/flatbuffers/tsconfig.mjs.json
+FILE: ../../../third_party/flatbuffers/typescript.bzl
+FILE: ../../../third_party/flatbuffers/yarn.lock
 FILE: ../../../third_party/fuchsia-vulkan/cmake/cmake_uninstall.cmake.in
 FILE: ../../../third_party/fuchsia-vulkan/include/vk_video/vulkan_video_codec_h264std.h
 FILE: ../../../third_party/fuchsia-vulkan/include/vk_video/vulkan_video_codec_h264std_decode.h
@@ -9545,6 +10048,401 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ====================================================================================================
 LIBRARY: dart
+LIBRARY: flatbuffers
+ORIGIN: ../../../third_party/dart/runtime/bin/crypto_fuchsia.cc + ../../../third_party/dart/LICENSE
+TYPE: LicenseType.bsd
+FILE: ../../../third_party/dart/runtime/bin/crypto_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/bin/crypto_test.cc
+FILE: ../../../third_party/dart/runtime/bin/directory_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/bin/directory_test.cc
+FILE: ../../../third_party/dart/runtime/bin/eventhandler_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/bin/eventhandler_fuchsia.h
+FILE: ../../../third_party/dart/runtime/bin/file_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/bin/file_support.cc
+FILE: ../../../third_party/dart/runtime/bin/file_system_watcher_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/bin/loader.cc
+FILE: ../../../third_party/dart/runtime/bin/loader.h
+FILE: ../../../third_party/dart/runtime/bin/platform_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/bin/process_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/bin/reference_counting.h
+FILE: ../../../third_party/dart/runtime/bin/root_certificates_unsupported.cc
+FILE: ../../../third_party/dart/runtime/bin/socket_base_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/bin/socket_base_fuchsia.h
+FILE: ../../../third_party/dart/runtime/bin/socket_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/bin/stdio_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/bin/thread_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/bin/thread_fuchsia.h
+FILE: ../../../third_party/dart/runtime/bin/utils_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/lib/stacktrace.h
+FILE: ../../../third_party/dart/runtime/observatory/lib/event.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/models.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/repositories.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/app/notification.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/class_allocation_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/containers/virtual_collection.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/containers/virtual_tree.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/error_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/general_error.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/helpers/custom_element.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/helpers/nav_bar.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/helpers/nav_menu.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/helpers/rendering_queue.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/helpers/rendering_scheduler.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/helpers/uris.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/inbound_references.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/isolate/counter_chart.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/isolate/location.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/isolate/run_state.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/isolate/shared_summary.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/isolate/summary.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/metric/details.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/metric/graph.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/nav/class_menu.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/nav/isolate_menu.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/nav/library_menu.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/nav/menu_item.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/nav/notify.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/nav/notify_event.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/nav/notify_exception.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/nav/refresh.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/nav/top_menu.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/nav/vm_menu.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/retaining_path.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/source_link.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/strongly_reachable_instances.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/vm_connect_target.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/exceptions.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/allocation_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/breakpoint.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/class.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/code.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/context.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/error.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/event.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/extension_data.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/field.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/flag.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/frame.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/function.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/guarded.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/heap_space.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/icdata.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/inbound_references.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/instance.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/isolate.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/library.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/local_var_descriptors.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/map_association.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/megamorphiccache.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/metric.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/notification.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/object.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/objectpool.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/objectstore.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/pc_descriptors.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/persistent_handles.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/ports.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/retaining_path.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/sample_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/script.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/sentinel.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/source_location.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/target.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/timeline_event.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/type_arguments.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/unknown.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/vm.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/allocation_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/breakpoint.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/class.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/context.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/editor.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/eval.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/event.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/field.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/flag.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/function.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/heap_snapshot.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/icdata.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/inbound_references.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/instance.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/isolate.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/library.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/megamorphiccache.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/metric.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/notification.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/object.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/objectpool.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/objectstore.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/persistent_handles.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/ports.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/reachable_size.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/retained_size.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/retaining_path.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/sample_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/script.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/strongly_reachable_instances.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/target.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/type_arguments.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/allocation_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/breakpoint.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/class.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/context.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/editor.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/eval.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/event.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/field.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/flag.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/function.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/heap_snapshot.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/icdata.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/inbound_references.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/instance.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/isolate.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/library.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/megamorphiccache.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/metric.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/notification.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/object.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/objectpool.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/objectstore.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/persistent_handles.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/ports.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/reachable_size.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/retained_size.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/retaining_path.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/sample_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/script.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/settings.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/strongly_reachable_instances.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/target.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/type_arguments.dart
+FILE: ../../../third_party/dart/runtime/observatory/web/timeline_message_handler.js
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/event.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/models.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/repositories.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/app/notification.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/class_allocation_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/containers/virtual_collection.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/containers/virtual_tree.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/error_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/general_error.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/helpers/custom_element.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/helpers/nav_bar.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/helpers/nav_menu.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/helpers/rendering_queue.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/helpers/rendering_scheduler.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/helpers/tag.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/helpers/uris.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/inbound_references.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/isolate/counter_chart.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/isolate/location.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/isolate/run_state.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/isolate/shared_summary.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/isolate/summary.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/metric/details.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/metric/graph.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/nav/class_menu.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/nav/isolate_menu.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/nav/library_menu.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/nav/menu_item.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/nav/notify.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/nav/notify_event.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/nav/notify_exception.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/nav/refresh.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/nav/top_menu.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/nav/vm_menu.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/retaining_path.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/source_link.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/strongly_reachable_instances.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/vm_connect_target.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/exceptions.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/allocation_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/breakpoint.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/class.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/code.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/context.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/error.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/event.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/extension_data.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/field.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/flag.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/frame.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/function.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/guarded.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/heap_space.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/icdata.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/inbound_references.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/instance.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/isolate.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/library.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/local_var_descriptors.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/map_association.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/megamorphiccache.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/metric.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/notification.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/object.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/objectpool.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/objectstore.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/pc_descriptors.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/persistent_handles.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/ports.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/retaining_path.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/sample_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/script.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/sentinel.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/source_location.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/target.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/timeline_event.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/type_arguments.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/unknown.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/vm.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/allocation_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/breakpoint.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/class.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/context.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/editor.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/eval.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/event.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/field.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/flag.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/function.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/heap_snapshot.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/icdata.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/inbound_references.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/instance.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/isolate.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/library.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/megamorphiccache.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/metric.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/notification.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/object.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/objectpool.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/objectstore.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/persistent_handles.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/ports.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/reachable_size.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/retained_size.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/retaining_path.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/sample_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/script.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/strongly_reachable_instances.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/target.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/type_arguments.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/allocation_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/breakpoint.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/class.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/context.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/editor.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/eval.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/event.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/field.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/flag.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/function.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/heap_snapshot.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/icdata.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/inbound_references.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/instance.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/isolate.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/library.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/megamorphiccache.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/metric.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/notification.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/object.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/objectpool.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/objectstore.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/persistent_handles.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/ports.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/reachable_size.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/retained_size.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/retaining_path.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/sample_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/script.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/settings.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/strongly_reachable_instances.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/target.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/type_arguments.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/web/timeline_message_handler.js
+FILE: ../../../third_party/dart/runtime/platform/syslog_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/platform/utils_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/platform/utils_fuchsia.h
+FILE: ../../../third_party/dart/runtime/vm/app_snapshot.cc
+FILE: ../../../third_party/dart/runtime/vm/app_snapshot.h
+FILE: ../../../third_party/dart/runtime/vm/canonical_tables.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/branch_optimizer.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/branch_optimizer.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/redundancy_elimination.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/redundancy_elimination.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/kernel_binary_flowgraph.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/kernel_to_il.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/kernel_to_il.h
+FILE: ../../../third_party/dart/runtime/vm/cpuinfo_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/vm/dart_api_state.cc
+FILE: ../../../third_party/dart/runtime/vm/heap/become.cc
+FILE: ../../../third_party/dart/runtime/vm/heap/become.h
+FILE: ../../../third_party/dart/runtime/vm/heap/safepoint.cc
+FILE: ../../../third_party/dart/runtime/vm/heap/safepoint.h
+FILE: ../../../third_party/dart/runtime/vm/isolate_reload.cc
+FILE: ../../../third_party/dart/runtime/vm/isolate_reload.h
+FILE: ../../../third_party/dart/runtime/vm/isolate_reload_test.cc
+FILE: ../../../third_party/dart/runtime/vm/kernel.cc
+FILE: ../../../third_party/dart/runtime/vm/kernel.h
+FILE: ../../../third_party/dart/runtime/vm/kernel_binary.cc
+FILE: ../../../third_party/dart/runtime/vm/kernel_isolate.cc
+FILE: ../../../third_party/dart/runtime/vm/kernel_isolate.h
+FILE: ../../../third_party/dart/runtime/vm/kernel_loader.cc
+FILE: ../../../third_party/dart/runtime/vm/kernel_loader.h
+FILE: ../../../third_party/dart/runtime/vm/lockers.cc
+FILE: ../../../third_party/dart/runtime/vm/native_symbol_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/vm/object_reload.cc
+FILE: ../../../third_party/dart/runtime/vm/object_service.cc
+FILE: ../../../third_party/dart/runtime/vm/os_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/vm/os_thread_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/vm/os_thread_fuchsia.h
+FILE: ../../../third_party/dart/runtime/vm/signal_handler_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/vm/thread_interrupter_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/vm/token_position.cc
+FILE: ../../../third_party/dart/runtime/vm/token_position.h
+FILE: ../../../third_party/dart/runtime/vm/uri.cc
+FILE: ../../../third_party/dart/runtime/vm/uri.h
+FILE: ../../../third_party/dart/runtime/vm/uri_test.cc
+FILE: ../../../third_party/dart/runtime/vm/virtual_memory_fuchsia.cc
+FILE: ../../../third_party/dart/sdk/lib/developer/service.dart
+FILE: ../../../third_party/dart/sdk/lib/js_util/js_util.dart
+FILE: ../../../third_party/dart/sdk/lib/vmservice/devfs.dart
+FILE: ../../../third_party/flatbuffers/dart/lib/flat_buffers.dart
+----------------------------------------------------------------------------------------------------
+Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+for details. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google LLC nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: dart
 ORIGIN: ../../../third_party/dart/LICENSE
 TYPE: LicenseType.bsd
 FILE: ../../../third_party/dart/.gitconfig
@@ -11491,399 +12389,6 @@ FILE: ../../../third_party/dart/sdk/lib/js/_js_server.dart
 FILE: ../../../third_party/dart/sdk/lib/typed_data/unmodifiable_typed_data.dart
 ----------------------------------------------------------------------------------------------------
 Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
-for details. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      disclaimer in the documentation and/or other materials provided
-      with the distribution.
-    * Neither the name of Google LLC nor the names of its
-      contributors may be used to endorse or promote products derived
-      from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-====================================================================================================
-
-====================================================================================================
-LIBRARY: dart
-ORIGIN: ../../../third_party/dart/runtime/bin/crypto_fuchsia.cc + ../../../third_party/dart/LICENSE
-TYPE: LicenseType.bsd
-FILE: ../../../third_party/dart/runtime/bin/crypto_fuchsia.cc
-FILE: ../../../third_party/dart/runtime/bin/crypto_test.cc
-FILE: ../../../third_party/dart/runtime/bin/directory_fuchsia.cc
-FILE: ../../../third_party/dart/runtime/bin/directory_test.cc
-FILE: ../../../third_party/dart/runtime/bin/eventhandler_fuchsia.cc
-FILE: ../../../third_party/dart/runtime/bin/eventhandler_fuchsia.h
-FILE: ../../../third_party/dart/runtime/bin/file_fuchsia.cc
-FILE: ../../../third_party/dart/runtime/bin/file_support.cc
-FILE: ../../../third_party/dart/runtime/bin/file_system_watcher_fuchsia.cc
-FILE: ../../../third_party/dart/runtime/bin/loader.cc
-FILE: ../../../third_party/dart/runtime/bin/loader.h
-FILE: ../../../third_party/dart/runtime/bin/platform_fuchsia.cc
-FILE: ../../../third_party/dart/runtime/bin/process_fuchsia.cc
-FILE: ../../../third_party/dart/runtime/bin/reference_counting.h
-FILE: ../../../third_party/dart/runtime/bin/root_certificates_unsupported.cc
-FILE: ../../../third_party/dart/runtime/bin/socket_base_fuchsia.cc
-FILE: ../../../third_party/dart/runtime/bin/socket_base_fuchsia.h
-FILE: ../../../third_party/dart/runtime/bin/socket_fuchsia.cc
-FILE: ../../../third_party/dart/runtime/bin/stdio_fuchsia.cc
-FILE: ../../../third_party/dart/runtime/bin/thread_fuchsia.cc
-FILE: ../../../third_party/dart/runtime/bin/thread_fuchsia.h
-FILE: ../../../third_party/dart/runtime/bin/utils_fuchsia.cc
-FILE: ../../../third_party/dart/runtime/lib/stacktrace.h
-FILE: ../../../third_party/dart/runtime/observatory/lib/event.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/models.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/repositories.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/app/notification.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/class_allocation_profile.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/containers/virtual_collection.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/containers/virtual_tree.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/error_ref.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/general_error.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/helpers/custom_element.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/helpers/nav_bar.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/helpers/nav_menu.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/helpers/rendering_queue.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/helpers/rendering_scheduler.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/helpers/uris.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/inbound_references.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/isolate/counter_chart.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/isolate/location.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/isolate/run_state.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/isolate/shared_summary.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/isolate/summary.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/metric/details.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/metric/graph.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/nav/class_menu.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/nav/isolate_menu.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/nav/library_menu.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/nav/menu_item.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/nav/notify.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/nav/notify_event.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/nav/notify_exception.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/nav/refresh.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/nav/top_menu.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/nav/vm_menu.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/retaining_path.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/source_link.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/strongly_reachable_instances.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/vm_connect_target.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/exceptions.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/allocation_profile.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/breakpoint.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/class.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/code.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/context.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/error.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/event.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/extension_data.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/field.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/flag.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/frame.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/function.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/guarded.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/heap_space.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/icdata.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/inbound_references.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/instance.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/isolate.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/library.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/local_var_descriptors.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/map_association.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/megamorphiccache.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/metric.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/notification.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/object.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/objectpool.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/objectstore.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/pc_descriptors.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/persistent_handles.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/ports.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/retaining_path.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/sample_profile.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/script.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/sentinel.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/source_location.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/target.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/timeline_event.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/type_arguments.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/unknown.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/vm.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/allocation_profile.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/breakpoint.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/class.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/context.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/editor.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/eval.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/event.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/field.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/flag.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/function.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/heap_snapshot.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/icdata.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/inbound_references.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/instance.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/isolate.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/library.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/megamorphiccache.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/metric.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/notification.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/object.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/objectpool.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/objectstore.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/persistent_handles.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/ports.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/reachable_size.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/retained_size.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/retaining_path.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/sample_profile.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/script.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/strongly_reachable_instances.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/target.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/type_arguments.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/allocation_profile.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/breakpoint.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/class.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/context.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/editor.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/eval.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/event.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/field.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/flag.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/function.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/heap_snapshot.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/icdata.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/inbound_references.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/instance.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/isolate.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/library.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/megamorphiccache.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/metric.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/notification.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/object.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/objectpool.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/objectstore.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/persistent_handles.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/ports.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/reachable_size.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/retained_size.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/retaining_path.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/sample_profile.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/script.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/settings.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/strongly_reachable_instances.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/target.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/type_arguments.dart
-FILE: ../../../third_party/dart/runtime/observatory/web/timeline_message_handler.js
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/event.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/models.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/repositories.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/app/notification.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/class_allocation_profile.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/containers/virtual_collection.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/containers/virtual_tree.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/error_ref.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/general_error.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/helpers/custom_element.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/helpers/nav_bar.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/helpers/nav_menu.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/helpers/rendering_queue.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/helpers/rendering_scheduler.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/helpers/tag.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/helpers/uris.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/inbound_references.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/isolate/counter_chart.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/isolate/location.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/isolate/run_state.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/isolate/shared_summary.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/isolate/summary.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/metric/details.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/metric/graph.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/nav/class_menu.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/nav/isolate_menu.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/nav/library_menu.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/nav/menu_item.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/nav/notify.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/nav/notify_event.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/nav/notify_exception.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/nav/refresh.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/nav/top_menu.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/nav/vm_menu.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/retaining_path.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/source_link.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/strongly_reachable_instances.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/vm_connect_target.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/exceptions.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/allocation_profile.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/breakpoint.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/class.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/code.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/context.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/error.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/event.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/extension_data.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/field.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/flag.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/frame.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/function.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/guarded.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/heap_space.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/icdata.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/inbound_references.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/instance.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/isolate.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/library.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/local_var_descriptors.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/map_association.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/megamorphiccache.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/metric.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/notification.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/object.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/objectpool.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/objectstore.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/pc_descriptors.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/persistent_handles.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/ports.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/retaining_path.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/sample_profile.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/script.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/sentinel.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/source_location.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/target.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/timeline_event.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/type_arguments.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/unknown.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/vm.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/allocation_profile.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/breakpoint.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/class.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/context.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/editor.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/eval.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/event.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/field.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/flag.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/function.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/heap_snapshot.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/icdata.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/inbound_references.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/instance.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/isolate.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/library.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/megamorphiccache.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/metric.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/notification.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/object.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/objectpool.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/objectstore.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/persistent_handles.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/ports.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/reachable_size.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/retained_size.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/retaining_path.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/sample_profile.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/script.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/strongly_reachable_instances.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/target.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/type_arguments.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/allocation_profile.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/breakpoint.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/class.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/context.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/editor.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/eval.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/event.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/field.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/flag.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/function.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/heap_snapshot.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/icdata.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/inbound_references.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/instance.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/isolate.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/library.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/megamorphiccache.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/metric.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/notification.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/object.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/objectpool.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/objectstore.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/persistent_handles.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/ports.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/reachable_size.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/retained_size.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/retaining_path.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/sample_profile.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/script.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/settings.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/strongly_reachable_instances.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/target.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/type_arguments.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/web/timeline_message_handler.js
-FILE: ../../../third_party/dart/runtime/platform/syslog_fuchsia.cc
-FILE: ../../../third_party/dart/runtime/platform/utils_fuchsia.cc
-FILE: ../../../third_party/dart/runtime/platform/utils_fuchsia.h
-FILE: ../../../third_party/dart/runtime/vm/app_snapshot.cc
-FILE: ../../../third_party/dart/runtime/vm/app_snapshot.h
-FILE: ../../../third_party/dart/runtime/vm/canonical_tables.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/backend/branch_optimizer.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/backend/branch_optimizer.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/backend/redundancy_elimination.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/backend/redundancy_elimination.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/kernel_binary_flowgraph.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/kernel_to_il.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/kernel_to_il.h
-FILE: ../../../third_party/dart/runtime/vm/cpuinfo_fuchsia.cc
-FILE: ../../../third_party/dart/runtime/vm/dart_api_state.cc
-FILE: ../../../third_party/dart/runtime/vm/heap/become.cc
-FILE: ../../../third_party/dart/runtime/vm/heap/become.h
-FILE: ../../../third_party/dart/runtime/vm/heap/safepoint.cc
-FILE: ../../../third_party/dart/runtime/vm/heap/safepoint.h
-FILE: ../../../third_party/dart/runtime/vm/isolate_reload.cc
-FILE: ../../../third_party/dart/runtime/vm/isolate_reload.h
-FILE: ../../../third_party/dart/runtime/vm/isolate_reload_test.cc
-FILE: ../../../third_party/dart/runtime/vm/kernel.cc
-FILE: ../../../third_party/dart/runtime/vm/kernel.h
-FILE: ../../../third_party/dart/runtime/vm/kernel_binary.cc
-FILE: ../../../third_party/dart/runtime/vm/kernel_isolate.cc
-FILE: ../../../third_party/dart/runtime/vm/kernel_isolate.h
-FILE: ../../../third_party/dart/runtime/vm/kernel_loader.cc
-FILE: ../../../third_party/dart/runtime/vm/kernel_loader.h
-FILE: ../../../third_party/dart/runtime/vm/lockers.cc
-FILE: ../../../third_party/dart/runtime/vm/native_symbol_fuchsia.cc
-FILE: ../../../third_party/dart/runtime/vm/object_reload.cc
-FILE: ../../../third_party/dart/runtime/vm/object_service.cc
-FILE: ../../../third_party/dart/runtime/vm/os_fuchsia.cc
-FILE: ../../../third_party/dart/runtime/vm/os_thread_fuchsia.cc
-FILE: ../../../third_party/dart/runtime/vm/os_thread_fuchsia.h
-FILE: ../../../third_party/dart/runtime/vm/signal_handler_fuchsia.cc
-FILE: ../../../third_party/dart/runtime/vm/thread_interrupter_fuchsia.cc
-FILE: ../../../third_party/dart/runtime/vm/token_position.cc
-FILE: ../../../third_party/dart/runtime/vm/token_position.h
-FILE: ../../../third_party/dart/runtime/vm/uri.cc
-FILE: ../../../third_party/dart/runtime/vm/uri.h
-FILE: ../../../third_party/dart/runtime/vm/uri_test.cc
-FILE: ../../../third_party/dart/runtime/vm/virtual_memory_fuchsia.cc
-FILE: ../../../third_party/dart/sdk/lib/developer/service.dart
-FILE: ../../../third_party/dart/sdk/lib/js_util/js_util.dart
-FILE: ../../../third_party/dart/sdk/lib/vmservice/devfs.dart
-----------------------------------------------------------------------------------------------------
-Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
 for details. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -13985,6 +14490,219 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: flatbuffers
+ORIGIN: ../../../third_party/flatbuffers/dart/LICENSE
+TYPE: LicenseType.apache
+FILE: ../../../third_party/flatbuffers/dart/example/monster_my_game.sample_generated.dart
+FILE: ../../../third_party/flatbuffers/dart/lib/flex_buffers.dart
+FILE: ../../../third_party/flatbuffers/dart/lib/src/builder.dart
+FILE: ../../../third_party/flatbuffers/dart/lib/src/reference.dart
+FILE: ../../../third_party/flatbuffers/dart/lib/src/types.dart
+----------------------------------------------------------------------------------------------------
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright 2014 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 ====================================================================================================
 
 ====================================================================================================
@@ -26596,4 +27314,4 @@ freely, subject to the following restrictions:
    misrepresented as being the original software.
 3. This notice may not be removed or altered from any source distribution.
 ====================================================================================================
-Total license count: 416
+Total license count: 417

--- a/ci/licenses_golden/tool_signature
+++ b/ci/licenses_golden/tool_signature
@@ -1,2 +1,2 @@
-Signature: 2b69b9b3b985d18a9c148d38f9cefb46
+Signature: 1177a4d90f87bc4a0198864901db40ab
 

--- a/impeller/BUILD.gn
+++ b/impeller/BUILD.gn
@@ -64,7 +64,9 @@ group("impeller") {
   }
 }
 
-executable("impeller_unittests") {
+impeller_component("impeller_unittests") {
+  target_type = "executable"
+
   testonly = true
 
   deps = [
@@ -73,6 +75,7 @@ executable("impeller_unittests") {
     "blobcat:blobcat_unittests",
     "compiler:compiler_unittests",
     "geometry:geometry_unittests",
+    "runtime_stage:runtime_stage_unittests",
     "tessellator:tessellator_unittests",
   ]
 

--- a/impeller/base/strings.cc
+++ b/impeller/base/strings.cc
@@ -22,6 +22,14 @@ bool HasPrefix(const std::string& string, const std::string& prefix) {
   return string.find(prefix) == 0u;
 }
 
+bool HasSuffix(const std::string& string, const std::string& suffix) {
+  auto position = string.rfind(suffix);
+  if (position == std::string::npos) {
+    return false;
+  }
+  return position == string.size() - suffix.size();
+}
+
 std::string StripPrefix(const std::string& string,
                         const std::string& to_strip) {
   if (!HasPrefix(string, to_strip)) {

--- a/impeller/base/strings.h
+++ b/impeller/base/strings.h
@@ -15,6 +15,8 @@ std::string SPrintF(const char* format, ...);
 
 bool HasPrefix(const std::string& string, const std::string& prefix);
 
+bool HasSuffix(const std::string& string, const std::string& suffix);
+
 std::string StripPrefix(const std::string& string, const std::string& to_strip);
 
 }  // namespace impeller

--- a/impeller/base/validation.cc
+++ b/impeller/base/validation.cc
@@ -4,15 +4,29 @@
 
 #include "impeller/base/validation.h"
 
+#include <atomic>
+
 #include "flutter/fml/logging.h"
 
 namespace impeller {
 
+static std::atomic_int32_t sValidationLogsDisabledCount = 0;
+
+ScopedValidationDisable::ScopedValidationDisable() {
+  sValidationLogsDisabledCount++;
+}
+
+ScopedValidationDisable::~ScopedValidationDisable() {
+  sValidationLogsDisabledCount--;
+}
+
 ValidationLog::ValidationLog() = default;
 
 ValidationLog::~ValidationLog() {
-  FML_LOG(ERROR) << stream_.str();
-  ImpellerValidationBreak();
+  if (sValidationLogsDisabledCount <= 0) {
+    FML_LOG(ERROR) << stream_.str();
+    ImpellerValidationBreak();
+  }
 }
 
 std::ostream& ValidationLog::GetStream() {

--- a/impeller/base/validation.h
+++ b/impeller/base/validation.h
@@ -26,6 +26,14 @@ class ValidationLog {
 
 void ImpellerValidationBreak();
 
+struct ScopedValidationDisable {
+  ScopedValidationDisable();
+
+  ~ScopedValidationDisable();
+
+  FML_DISALLOW_COPY_AND_ASSIGN(ScopedValidationDisable);
+};
+
 }  // namespace impeller
 
 #define VALIDATION_LOG ::impeller::ValidationLog{}.GetStream()

--- a/impeller/compiler/BUILD.gn
+++ b/impeller/compiler/BUILD.gn
@@ -18,6 +18,8 @@ impeller_component("compiler_lib") {
     "logger.h",
     "reflector.cc",
     "reflector.h",
+    "runtime_stage_data.cc",
+    "runtime_stage_data.h",
     "source_options.cc",
     "source_options.h",
     "switches.cc",
@@ -31,6 +33,7 @@ impeller_component("compiler_lib") {
   public_deps = [
     "../base",
     "../geometry",
+    "../runtime_stage",
     "//flutter/fml",
 
     # All third_party deps must be reflected below in the impellerc_license

--- a/impeller/compiler/compiler.cc
+++ b/impeller/compiler/compiler.cc
@@ -53,10 +53,12 @@ static bool EntryPointMustBeNamedMain(TargetPlatform platform) {
       FML_UNREACHABLE();
     case TargetPlatform::kMetalDesktop:
     case TargetPlatform::kMetalIOS:
+    case TargetPlatform::kRuntimeStageMetal:
       return false;
     case TargetPlatform::kFlutterSPIRV:
     case TargetPlatform::kOpenGLES:
     case TargetPlatform::kOpenGLDesktop:
+    case TargetPlatform::kRuntimeStageGLES:
       return true;
   }
   FML_UNREACHABLE();
@@ -68,6 +70,8 @@ static CompilerBackend CreateCompiler(const spirv_cross::ParsedIR& ir,
   switch (source_options.target_platform) {
     case TargetPlatform::kMetalDesktop:
     case TargetPlatform::kMetalIOS:
+    case TargetPlatform::kRuntimeStageMetal:
+    case TargetPlatform::kRuntimeStageGLES:
       compiler = CreateMSLCompiler(ir, source_options);
       break;
     case TargetPlatform::kUnknown:
@@ -85,7 +89,6 @@ static CompilerBackend CreateCompiler(const spirv_cross::ParsedIR& ir,
     backend->rename_entry_point("main", source_options.entry_point_name,
                                 ToExecutionModel(source_options.type));
   }
-
   return compiler;
 }
 
@@ -130,12 +133,22 @@ Compiler::Compiler(const fml::Mapping& source_mapping,
     case TargetPlatform::kOpenGLES:
     case TargetPlatform::kOpenGLDesktop:
       spirv_options.SetOptimizationLevel(
-          shaderc_optimization_level::shaderc_optimization_level_zero);
+          shaderc_optimization_level::shaderc_optimization_level_performance);
       spirv_options.SetTargetEnvironment(
           shaderc_target_env::shaderc_target_env_vulkan,
           shaderc_env_version::shaderc_env_version_vulkan_1_1);
       spirv_options.SetTargetSpirv(
           shaderc_spirv_version::shaderc_spirv_version_1_3);
+      break;
+    case TargetPlatform::kRuntimeStageMetal:
+    case TargetPlatform::kRuntimeStageGLES:
+      spirv_options.SetOptimizationLevel(
+          shaderc_optimization_level::shaderc_optimization_level_performance);
+      spirv_options.SetTargetEnvironment(
+          shaderc_target_env::shaderc_target_env_opengl,
+          shaderc_env_version::shaderc_env_version_opengl_4_5);
+      spirv_options.SetTargetSpirv(
+          shaderc_spirv_version::shaderc_spirv_version_1_0);
       break;
     case TargetPlatform::kFlutterSPIRV:
       // With any optimization level above 'zero' enabled, shaderc will emit
@@ -237,6 +250,7 @@ Compiler::Compiler(const fml::Mapping& source_mapping,
 
   reflector_ = std::make_unique<Reflector>(std::move(reflector_options),  //
                                            parsed_ir,                     //
+                                           GetSLShaderSource(),           //
                                            sl_compiler                    //
   );
 

--- a/impeller/compiler/compiler_unittests.cc
+++ b/impeller/compiler/compiler_unittests.cc
@@ -49,6 +49,7 @@ TEST_P(CompilerTest, MustFailDueToMultipleLocationPerStructMember) {
     // This is a failure of reflection which this target doesn't perform.
     GTEST_SKIP();
   }
+  ScopedValidationDisable disable_validation;
   ASSERT_FALSE(CanCompileAndReflect("struct_def_bug.vert"));
 }
 

--- a/impeller/compiler/impellerc_main.cc
+++ b/impeller/compiler/impellerc_main.cc
@@ -98,9 +98,9 @@ bool Main(const fml::CommandLine& command_line) {
         std::cerr << "Runtime stage data could not be created." << std::endl;
         return false;
       }
-      if (!fml::WriteAtomically(*switches.working_directory,  //
-                                sl_file_name.c_str(),         //
-                                *stage_data_mapping           //
+      if (!fml::WriteAtomically(*switches.working_directory,    //
+                                sl_file_name.string().c_str(),  //
+                                *stage_data_mapping             //
                                 )) {
         std::cerr << "Could not write file to " << switches.sl_file_name
                   << std::endl;

--- a/impeller/compiler/impellerc_main.cc
+++ b/impeller/compiler/impellerc_main.cc
@@ -9,6 +9,7 @@
 #include "flutter/fml/file.h"
 #include "flutter/fml/macros.h"
 #include "flutter/fml/mapping.h"
+#include "impeller/base/strings.h"
 #include "impeller/compiler/compiler.h"
 #include "impeller/compiler/source_options.h"
 #include "impeller/compiler/switches.h"
@@ -51,6 +52,7 @@ bool Main(const fml::CommandLine& command_line) {
       SourceTypeFromFileName(switches.source_file_name));
 
   Reflector::Options reflector_options;
+  reflector_options.target_platform = switches.target_platform;
   reflector_options.entry_point_name = options.entry_point_name;
   reflector_options.shader_name =
       InferShaderNameFromPath(switches.source_file_name);
@@ -79,12 +81,39 @@ bool Main(const fml::CommandLine& command_line) {
   if (TargetPlatformNeedsSL(options.target_platform)) {
     auto sl_file_name = std::filesystem::absolute(
         std::filesystem::current_path() / switches.sl_file_name);
-    if (!fml::WriteAtomically(*switches.working_directory,
-                              sl_file_name.string().c_str(),
-                              *compiler.GetSLShaderSource())) {
-      std::cerr << "Could not write file to " << switches.spirv_file_name
-                << std::endl;
-      return false;
+    const bool is_runtime_stage_data = HasSuffix(switches.sl_file_name, "iplr");
+    if (is_runtime_stage_data) {
+      auto reflector = compiler.GetReflector();
+      if (reflector == nullptr) {
+        std::cerr << "Could not create reflector." << std::endl;
+        return false;
+      }
+      auto stage_data = reflector->GetRuntimeStageData();
+      if (!stage_data) {
+        std::cerr << "Runtime stage information was nil." << std::endl;
+        return false;
+      }
+      auto stage_data_mapping = stage_data->CreateMapping();
+      if (!stage_data_mapping) {
+        std::cerr << "Runtime stage data could not be created." << std::endl;
+        return false;
+      }
+      if (!fml::WriteAtomically(*switches.working_directory,  //
+                                sl_file_name.c_str(),         //
+                                *stage_data_mapping           //
+                                )) {
+        std::cerr << "Could not write file to " << switches.sl_file_name
+                  << std::endl;
+        return false;
+      }
+    } else {
+      if (!fml::WriteAtomically(*switches.working_directory,
+                                sl_file_name.string().c_str(),
+                                *compiler.GetSLShaderSource())) {
+        std::cerr << "Could not write file to " << switches.sl_file_name
+                  << std::endl;
+        return false;
+      }
     }
   }
 
@@ -137,6 +166,8 @@ bool Main(const fml::CommandLine& command_line) {
       case TargetPlatform::kMetalIOS:
       case TargetPlatform::kOpenGLES:
       case TargetPlatform::kOpenGLDesktop:
+      case TargetPlatform::kRuntimeStageMetal:
+      case TargetPlatform::kRuntimeStageGLES:
         result_file = switches.sl_file_name;
         break;
       case TargetPlatform::kFlutterSPIRV:

--- a/impeller/compiler/reflector.h
+++ b/impeller/compiler/reflector.h
@@ -10,6 +10,7 @@
 #include "flutter/fml/macros.h"
 #include "flutter/fml/mapping.h"
 #include "impeller/compiler/compiler_backend.h"
+#include "impeller/compiler/runtime_stage_data.h"
 #include "inja/inja.hpp"
 #include "third_party/spirv_cross/spirv_msl.hpp"
 #include "third_party/spirv_cross/spirv_parser.hpp"
@@ -39,6 +40,7 @@ struct StructMember {
 class Reflector {
  public:
   struct Options {
+    TargetPlatform target_platform = TargetPlatform::kUnknown;
     std::string entry_point_name;
     std::string shader_name;
     std::string header_file_name;
@@ -46,6 +48,7 @@ class Reflector {
 
   Reflector(Options options,
             std::shared_ptr<const spirv_cross::ParsedIR> ir,
+            std::shared_ptr<fml::Mapping> shader_data,
             CompilerBackend compiler);
 
   ~Reflector();
@@ -57,6 +60,8 @@ class Reflector {
   std::shared_ptr<fml::Mapping> GetReflectionHeader() const;
 
   std::shared_ptr<fml::Mapping> GetReflectionCC() const;
+
+  std::shared_ptr<RuntimeStageData> GetRuntimeStageData() const;
 
  private:
   struct StructDefinition {
@@ -79,10 +84,12 @@ class Reflector {
 
   const Options options_;
   const std::shared_ptr<const spirv_cross::ParsedIR> ir_;
+  const std::shared_ptr<fml::Mapping> shader_data_;
   const CompilerBackend compiler_;
   std::unique_ptr<const nlohmann::json> template_arguments_;
   std::shared_ptr<fml::Mapping> reflection_header_;
   std::shared_ptr<fml::Mapping> reflection_cc_;
+  std::shared_ptr<RuntimeStageData> runtime_stage_data_;
   bool is_valid_ = false;
 
   std::optional<nlohmann::json> GenerateTemplateArguments() const;
@@ -90,6 +97,8 @@ class Reflector {
   std::shared_ptr<fml::Mapping> GenerateReflectionHeader() const;
 
   std::shared_ptr<fml::Mapping> GenerateReflectionCC() const;
+
+  std::shared_ptr<RuntimeStageData> GenerateRuntimeStageData() const;
 
   std::shared_ptr<fml::Mapping> InflateTemplate(std::string_view tmpl) const;
 

--- a/impeller/compiler/runtime_stage_data.cc
+++ b/impeller/compiler/runtime_stage_data.cc
@@ -1,0 +1,167 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/compiler/runtime_stage_data.h"
+
+#include <optional>
+
+#include "impeller/base/validation.h"
+#include "impeller/runtime_stage/runtime_stage_flatbuffers.h"
+
+namespace impeller {
+namespace compiler {
+
+RuntimeStageData::RuntimeStageData(std::string entrypoint,
+                                   spv::ExecutionModel stage,
+                                   TargetPlatform target_platform)
+    : entrypoint_(std::move(entrypoint)),
+      stage_(stage),
+      target_platform_(target_platform) {}
+
+RuntimeStageData::~RuntimeStageData() = default;
+
+void RuntimeStageData::AddUniformDescription(UniformDescription uniform) {
+  uniforms_.emplace_back(std::move(uniform));
+}
+
+void RuntimeStageData::SetShaderData(std::shared_ptr<fml::Mapping> shader) {
+  shader_ = std::move(shader);
+}
+
+static std::optional<fb::Stage> ToStage(spv::ExecutionModel stage) {
+  switch (stage) {
+    case spv::ExecutionModel::ExecutionModelVertex:
+      return fb::Stage::kVertex;
+    case spv::ExecutionModel::ExecutionModelFragment:
+      return fb::Stage::kFragment;
+    case spv::ExecutionModel::ExecutionModelGLCompute:
+      return fb::Stage::kCompute;
+    case spv::ExecutionModel::ExecutionModelTessellationControl:
+      return fb::Stage::kTessellationControl;
+    case spv::ExecutionModel::ExecutionModelTessellationEvaluation:
+      return fb::Stage::kTessellationEvaluation;
+    default:
+      return std::nullopt;
+  }
+  FML_UNREACHABLE();
+}
+
+static std::optional<fb::TargetPlatform> ToTargetPlatform(
+    TargetPlatform platform) {
+  switch (platform) {
+    case TargetPlatform::kUnknown:
+    case TargetPlatform::kMetalDesktop:
+    case TargetPlatform::kMetalIOS:
+    case TargetPlatform::kFlutterSPIRV:
+    case TargetPlatform::kOpenGLES:
+    case TargetPlatform::kOpenGLDesktop:
+      return std::nullopt;
+    case TargetPlatform::kRuntimeStageMetal:
+      return fb::TargetPlatform::kMetal;
+    case TargetPlatform::kRuntimeStageGLES:
+      return fb::TargetPlatform::kOpenGLES;
+  }
+  FML_UNREACHABLE();
+}
+
+static std::optional<fb::UniformDataType> ToType(
+    spirv_cross::SPIRType::BaseType type) {
+  switch (type) {
+    case spirv_cross::SPIRType::Boolean:
+      return fb::UniformDataType::kBoolean;
+    case spirv_cross::SPIRType::SByte:
+      return fb::UniformDataType::kSignedByte;
+    case spirv_cross::SPIRType::UByte:
+      return fb::UniformDataType::kUnsignedByte;
+    case spirv_cross::SPIRType::Short:
+      return fb::UniformDataType::kSignedShort;
+    case spirv_cross::SPIRType::UShort:
+      return fb::UniformDataType::kUnsignedShort;
+    case spirv_cross::SPIRType::Int:
+      return fb::UniformDataType::kSignedInt;
+    case spirv_cross::SPIRType::UInt:
+      return fb::UniformDataType::kUnsignedInt;
+    case spirv_cross::SPIRType::Int64:
+      return fb::UniformDataType::kSignedInt64;
+    case spirv_cross::SPIRType::UInt64:
+      return fb::UniformDataType::kUnsignedInt64;
+    case spirv_cross::SPIRType::Half:
+      return fb::UniformDataType::kHalfFloat;
+    case spirv_cross::SPIRType::Float:
+      return fb::UniformDataType::kFloat;
+    case spirv_cross::SPIRType::Double:
+      return fb::UniformDataType::kDouble;
+    case spirv_cross::SPIRType::SampledImage:
+      return fb::UniformDataType::kSampledImage;
+    case spirv_cross::SPIRType::AccelerationStructure:
+    case spirv_cross::SPIRType::AtomicCounter:
+    case spirv_cross::SPIRType::Char:
+    case spirv_cross::SPIRType::ControlPointArray:
+    case spirv_cross::SPIRType::Image:
+    case spirv_cross::SPIRType::Interpolant:
+    case spirv_cross::SPIRType::RayQuery:
+    case spirv_cross::SPIRType::Sampler:
+    case spirv_cross::SPIRType::Struct:
+    case spirv_cross::SPIRType::Unknown:
+    case spirv_cross::SPIRType::Void:
+      return std::nullopt;
+  }
+  FML_UNREACHABLE();
+}
+
+std::shared_ptr<fml::Mapping> RuntimeStageData::CreateMapping() const {
+  // The high level object API is used here for writing to the buffer. This is
+  // just a convenience.
+  fb::RuntimeStageT runtime_stage;
+  runtime_stage.entrypoint = entrypoint_;
+  const auto stage = ToStage(stage_);
+  if (!stage.has_value()) {
+    VALIDATION_LOG << "Invalid runtime stage.";
+    return nullptr;
+  }
+  runtime_stage.stage = stage.value();
+  const auto target_platform = ToTargetPlatform(target_platform_);
+  if (!target_platform.has_value()) {
+    VALIDATION_LOG << "Invalid target platform for runtime stage.";
+    return nullptr;
+  }
+  runtime_stage.target_platform = target_platform.value();
+  if (!shader_) {
+    VALIDATION_LOG << "No shader specified for runtime stage.";
+    return nullptr;
+  }
+  if (shader_->GetSize() > 0u) {
+    runtime_stage.shader = {shader_->GetMapping(),
+                            shader_->GetMapping() + shader_->GetSize()};
+  }
+  for (const auto& uniform : uniforms_) {
+    auto desc = std::make_unique<fb::UniformDescriptionT>();
+
+    desc->name = uniform.name;
+    if (desc->name.empty()) {
+      VALIDATION_LOG << "Uniform name cannot be empty.";
+      return nullptr;
+    }
+    desc->location = uniform.location;
+    desc->rows = uniform.rows;
+    desc->columns = uniform.columns;
+    auto uniform_type = ToType(uniform.type);
+    if (!uniform_type.has_value()) {
+      VALIDATION_LOG << "Invalid uniform type for runtime stage.";
+      return nullptr;
+    }
+    desc->type = uniform_type.value();
+
+    runtime_stage.uniforms.emplace_back(std::move(desc));
+  }
+  auto builder = std::make_shared<flatbuffers::FlatBufferBuilder>();
+  builder->Finish(fb::RuntimeStage::Pack(*builder.get(), &runtime_stage),
+                  fb::RuntimeStageIdentifier());
+  return std::make_shared<fml::NonOwnedMapping>(builder->GetBufferPointer(),
+                                                builder->GetSize(),
+                                                [builder](auto, auto) {});
+}
+
+}  // namespace compiler
+}  // namespace impeller

--- a/impeller/compiler/runtime_stage_data.h
+++ b/impeller/compiler/runtime_stage_data.h
@@ -1,0 +1,51 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "flutter/fml/macros.h"
+#include "flutter/fml/mapping.h"
+#include "impeller/compiler/types.h"
+#include "third_party/spirv_cross/spirv_parser.hpp"
+
+namespace impeller {
+namespace compiler {
+
+struct UniformDescription {
+  std::string name;
+  size_t location = 0u;
+  spirv_cross::SPIRType::BaseType type = spirv_cross::SPIRType::BaseType::Float;
+  size_t rows = 0u;
+  size_t columns = 0u;
+};
+
+class RuntimeStageData {
+ public:
+  RuntimeStageData(std::string entrypoint,
+                   spv::ExecutionModel stage,
+                   TargetPlatform target_platform);
+
+  ~RuntimeStageData();
+
+  void AddUniformDescription(UniformDescription uniform);
+
+  void SetShaderData(std::shared_ptr<fml::Mapping> shader);
+
+  std::shared_ptr<fml::Mapping> CreateMapping() const;
+
+ private:
+  const std::string entrypoint_;
+  const spv::ExecutionModel stage_;
+  const TargetPlatform target_platform_;
+  std::vector<UniformDescription> uniforms_;
+  std::shared_ptr<fml::Mapping> shader_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(RuntimeStageData);
+};
+
+}  // namespace compiler
+}  // namespace impeller

--- a/impeller/compiler/switches.cc
+++ b/impeller/compiler/switches.cc
@@ -18,10 +18,17 @@ static const std::map<std::string, TargetPlatform> kKnownPlatforms = {
     {"opengl-es", TargetPlatform::kOpenGLES},
     {"opengl-desktop", TargetPlatform::kOpenGLDesktop},
     {"flutter-spirv", TargetPlatform::kFlutterSPIRV},
+    {"runtime-stage-metal", TargetPlatform::kRuntimeStageMetal},
+    {"runtime-stage-gles", TargetPlatform::kRuntimeStageGLES},
 };
 
 void Switches::PrintHelp(std::ostream& stream) {
-  stream << std::endl << "Valid Argument are:" << std::endl;
+  stream << std::endl;
+  stream << "ImpellerC is an offline shader processor and reflection engine."
+         << std::endl;
+  stream << "---------------------------------------------------------------"
+         << std::endl;
+  stream << "Valid Argument are:" << std::endl;
   stream << "One of [";
   for (const auto& platform : kKnownPlatforms) {
     stream << " --" << platform.first;

--- a/impeller/compiler/types.cc
+++ b/impeller/compiler/types.cc
@@ -63,6 +63,10 @@ std::string TargetPlatformToString(TargetPlatform platform) {
       return "OpenGLES";
     case TargetPlatform::kOpenGLDesktop:
       return "OpenGLDesktop";
+    case TargetPlatform::kRuntimeStageMetal:
+      return "RuntimeStageMetal";
+    case TargetPlatform::kRuntimeStageGLES:
+      return "RuntimeStageGLES";
   }
   FML_UNREACHABLE();
 }
@@ -102,6 +106,8 @@ bool TargetPlatformNeedsSL(TargetPlatform platform) {
     case TargetPlatform::kMetalDesktop:
     case TargetPlatform::kOpenGLES:
     case TargetPlatform::kOpenGLDesktop:
+    case TargetPlatform::kRuntimeStageMetal:
+    case TargetPlatform::kRuntimeStageGLES:
       return true;
     case TargetPlatform::kUnknown:
     case TargetPlatform::kFlutterSPIRV:
@@ -116,6 +122,8 @@ bool TargetPlatformNeedsReflection(TargetPlatform platform) {
     case TargetPlatform::kMetalDesktop:
     case TargetPlatform::kOpenGLES:
     case TargetPlatform::kOpenGLDesktop:
+    case TargetPlatform::kRuntimeStageMetal:
+    case TargetPlatform::kRuntimeStageGLES:
       return true;
     case TargetPlatform::kUnknown:
     case TargetPlatform::kFlutterSPIRV:
@@ -189,12 +197,14 @@ spirv_cross::CompilerMSL::Options::Platform TargetPlatformToMSLPlatform(
     TargetPlatform platform) {
   switch (platform) {
     case TargetPlatform::kMetalIOS:
+    case TargetPlatform::kRuntimeStageMetal:
       return spirv_cross::CompilerMSL::Options::Platform::iOS;
     case TargetPlatform::kMetalDesktop:
       return spirv_cross::CompilerMSL::Options::Platform::macOS;
     case TargetPlatform::kFlutterSPIRV:
     case TargetPlatform::kOpenGLES:
     case TargetPlatform::kOpenGLDesktop:
+    case TargetPlatform::kRuntimeStageGLES:
     case TargetPlatform::kUnknown:
       return spirv_cross::CompilerMSL::Options::Platform::macOS;
   }
@@ -225,10 +235,12 @@ std::string TargetPlatformSLExtension(TargetPlatform platform) {
       return "unknown";
     case TargetPlatform::kMetalDesktop:
     case TargetPlatform::kMetalIOS:
+    case TargetPlatform::kRuntimeStageMetal:
       return "metal";
     case TargetPlatform::kFlutterSPIRV:
     case TargetPlatform::kOpenGLES:
     case TargetPlatform::kOpenGLDesktop:
+    case TargetPlatform::kRuntimeStageGLES:
       return "glsl";
   }
   FML_UNREACHABLE();
@@ -247,26 +259,33 @@ bool TargetPlatformIsOpenGL(TargetPlatform platform) {
   switch (platform) {
     case TargetPlatform::kOpenGLES:
     case TargetPlatform::kOpenGLDesktop:
+    case TargetPlatform::kRuntimeStageGLES:
       return true;
     case TargetPlatform::kMetalDesktop:
+    case TargetPlatform::kRuntimeStageMetal:
     case TargetPlatform::kMetalIOS:
     case TargetPlatform::kUnknown:
     case TargetPlatform::kFlutterSPIRV:
       return false;
   }
+  FML_UNREACHABLE();
 }
 
 bool TargetPlatformIsMetal(TargetPlatform platform) {
   switch (platform) {
     case TargetPlatform::kMetalDesktop:
     case TargetPlatform::kMetalIOS:
+    case TargetPlatform::kRuntimeStageMetal:
       return true;
     case TargetPlatform::kUnknown:
     case TargetPlatform::kFlutterSPIRV:
     case TargetPlatform::kOpenGLES:
     case TargetPlatform::kOpenGLDesktop:
+    case TargetPlatform::kRuntimeStageGLES:
       return false;
+      break;
   }
+  FML_UNREACHABLE();
 }
 
 }  // namespace compiler

--- a/impeller/compiler/types.h
+++ b/impeller/compiler/types.h
@@ -32,6 +32,8 @@ enum class TargetPlatform {
   kFlutterSPIRV,
   kOpenGLES,
   kOpenGLDesktop,
+  kRuntimeStageMetal,
+  kRuntimeStageGLES,
 };
 
 bool TargetPlatformIsMetal(TargetPlatform platform);

--- a/impeller/fixtures/BUILD.gn
+++ b/impeller/fixtures/BUILD.gn
@@ -5,34 +5,43 @@
 import("//flutter/impeller/tools/impeller.gni")
 import("//flutter/testing/testing.gni")
 
-import("//flutter/impeller/tools/impeller.gni")
-
 impeller_shaders("shader_fixtures") {
   name = "fixtures"
   shaders = [
-    "box_fade.vert",
     "box_fade.frag",
-    "impeller.vert",
+    "box_fade.vert",
     "impeller.frag",
-    "instanced_draw.vert",
+    "impeller.vert",
     "instanced_draw.frag",
-    "test_texture.vert",
+    "instanced_draw.vert",
+    "sample.vert",
+    "simple.vert",
     "test_texture.frag",
+    "test_texture.vert",
   ]
+}
+
+impellerc("runtime_stages") {
+  shaders = [ "ink_sparkle.frag" ]
+  sl_file_extension = "iplr"
+  shader_target_flag = "--runtime-stage-metal"
 }
 
 test_fixtures("file_fixtures") {
   fixtures = [
+    "//flutter/third_party/txt/third_party/fonts/HomemadeApple.ttf",
+    "//flutter/third_party/txt/third_party/fonts/NotoColorEmoji.ttf",
+    "//flutter/third_party/txt/third_party/fonts/Roboto-Regular.ttf",
     "airplane.jpg",
     "bay_bridge.jpg",
-    "boston.jpg",
     "blue_noise.png",
+    "boston.jpg",
     "embarcadero.jpg",
     "kalimba.jpg",
-    "sample.vert",
+    "sample.comp",
     "sample.tesc",
     "sample.tese",
-    "sample.comp",
+    "sample.vert",
     "struct_def_bug.vert",
     "table_mountain_nx.png",
     "table_mountain_ny.png",
@@ -40,12 +49,12 @@ test_fixtures("file_fixtures") {
     "table_mountain_px.png",
     "table_mountain_py.png",
     "table_mountain_pz.png",
-    "types.h",
     "test_texture.frag",
-    "//flutter/third_party/txt/third_party/fonts/Roboto-Regular.ttf",
-    "//flutter/third_party/txt/third_party/fonts/NotoColorEmoji.ttf",
-    "//flutter/third_party/txt/third_party/fonts/HomemadeApple.ttf",
+    "types.h",
   ]
+  fixtures +=
+      filter_include(get_target_outputs(":runtime_stages"), [ "*.iplr" ])
+  deps = [ ":runtime_stages" ]
 }
 
 group("fixtures") {

--- a/impeller/fixtures/ink_sparkle.frag
+++ b/impeller/fixtures/ink_sparkle.frag
@@ -1,0 +1,104 @@
+#version 320 es
+
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+precision highp float;
+
+layout(location = 0) uniform vec4 u_color;
+layout(location = 1) uniform float u_alpha;
+layout(location = 2) uniform vec4 u_sparkle_color;
+layout(location = 3) uniform float u_sparkle_alpha;
+layout(location = 4) uniform float u_blur;
+layout(location = 5) uniform vec2 u_center;
+layout(location = 6) uniform float u_radius_scale;
+layout(location = 7) uniform float u_max_radius;
+layout(location = 8) uniform vec2 u_resolution_scale;
+layout(location = 9) uniform vec2 u_noise_scale;
+layout(location = 10) uniform float u_noise_phase;
+layout(location = 11) uniform vec2 u_circle1;
+layout(location = 12) uniform vec2 u_circle2;
+layout(location = 13) uniform vec2 u_circle3;
+layout(location = 14) uniform vec2 u_rotation1;
+layout(location = 15) uniform vec2 u_rotation2;
+layout(location = 16) uniform vec2 u_rotation3;
+
+layout(location = 0) out vec4 fragColor;
+
+const float PI = 3.1415926535897932384626;
+const float PI_ROTATE_RIGHT = PI * 0.0078125;
+const float PI_ROTATE_LEFT = PI * -0.0078125;
+const float ONE_THIRD = 1./3.;
+const vec2 TURBULENCE_SCALE = vec2(0.8);
+
+float saturate(float x) {
+  return clamp(x, 0.0, 1.0);
+}
+
+float triangle_noise(highp vec2 n) {
+  n = fract(n * vec2(5.3987, 5.4421));
+  n += dot(n.yx, n.xy + vec2(21.5351, 14.3137));
+  float xy = n.x * n.y;
+  return fract(xy * 95.4307) + fract(xy * 75.04961) - 1.0;
+}
+
+float threshold(float v, float l, float h) {
+  return step(l, v) * (1.0 - step(h, v));
+}
+
+mat2 rotate2d(vec2 rad){
+  return mat2(rad.x, -rad.y, rad.y, rad.x);
+}
+
+float soft_circle(vec2 uv, vec2 xy, float radius, float blur) {
+  float blur_half = blur * 0.5;
+  float d = distance(uv, xy);
+  return 1.0 - smoothstep(1.0 - blur_half, 1.0 + blur_half, d / radius);
+}
+
+float soft_ring(vec2 uv, vec2 xy, float radius, float thickness, float blur) {
+  float circle_outer = soft_circle(uv, xy, radius + thickness, blur);
+  float circle_inner = soft_circle(uv, xy, max(radius - thickness, 0.0), blur);
+  return saturate(circle_outer - circle_inner);
+}
+
+float circle_grid(vec2 resolution, vec2 p, vec2 xy, vec2 rotation, float cell_diameter) {
+  p = rotate2d(rotation) * (xy - p) + xy;
+  p = mod(p, cell_diameter) / resolution;
+  float cell_uv = cell_diameter / resolution.y * 0.5;
+  float r = 0.65 * cell_uv;
+  return soft_circle(p, vec2(cell_uv), r, r * 50.0);
+}
+
+float sparkle(vec2 uv, float t) {
+  float n = triangle_noise(uv);
+  float s = threshold(n, 0.0, 0.05);
+  s += threshold(n + sin(PI * (t + 0.35)), 0.1, 0.15);
+  s += threshold(n + sin(PI * (t + 0.7)), 0.2, 0.25);
+  s += threshold(n + sin(PI * (t + 1.05)), 0.3, 0.35);
+  return saturate(s) * 0.55;
+}
+
+float turbulence(vec2 uv) {
+  vec2 uv_scale = uv * TURBULENCE_SCALE;
+  float g1 = circle_grid(TURBULENCE_SCALE, uv_scale, u_circle1, u_rotation1, 0.17);
+  float g2 = circle_grid(TURBULENCE_SCALE, uv_scale, u_circle2, u_rotation2, 0.2);
+  float g3 = circle_grid(TURBULENCE_SCALE, uv_scale, u_circle3, u_rotation3, 0.275);
+  float v = (g1 * g1 + g2 - g3) * 0.5;
+  return saturate(0.45 + 0.8 * v);
+}
+
+void main() {
+  vec2 p = gl_FragCoord.xy;
+  vec2 uv = p * u_resolution_scale;
+  vec2 density_uv = uv - mod(p, u_noise_scale);
+  float radius = u_max_radius * u_radius_scale;
+  float turbulence = turbulence(uv);
+  float ring = soft_ring(p, u_center, radius, 0.05 * u_max_radius, u_blur);
+  float sparkle = sparkle(density_uv, u_noise_phase) * ring * turbulence * u_sparkle_alpha;
+  float wave_alpha = soft_circle(p, u_center, radius, u_blur) * u_alpha * u_color.a;
+  vec4 wave_color = vec4(u_color.rgb * wave_alpha, wave_alpha);
+  vec4 sparkle_color = vec4(u_sparkle_color.rgb * u_sparkle_color.a, u_sparkle_color.a);
+  fragColor = mix(wave_color, sparkle_color, sparkle);
+}

--- a/impeller/fixtures/simple.vert
+++ b/impeller/fixtures/simple.vert
@@ -1,0 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+void main() {
+  gl_Position = vec4(1.0);
+}

--- a/impeller/renderer/backend/gles/shader_library_gles.cc
+++ b/impeller/renderer/backend/gles/shader_library_gles.cc
@@ -6,6 +6,7 @@
 
 #include <sstream>
 
+#include "flutter/fml/closure.h"
 #include "impeller/base/config.h"
 #include "impeller/base/validation.h"
 #include "impeller/blobcat/blob_library.h"
@@ -54,11 +55,10 @@ static std::string GLESShaderNameToShaderKeyName(const std::string& name,
 ShaderLibraryGLES::ShaderLibraryGLES(
     std::vector<std::shared_ptr<fml::Mapping>> shader_libraries) {
   ShaderFunctionMap functions;
-  UniqueID library_id;
-  auto iterator = [&functions, &library_id](auto type,           //
-                                            const auto& name,    //
-                                            const auto& mapping  //
-                                            ) -> bool {
+  auto iterator = [&functions, library_id = library_id_](auto type,           //
+                                                         const auto& name,    //
+                                                         const auto& mapping  //
+                                                         ) -> bool {
     const auto stage = ToShaderStage(type);
     const auto key_name = GLESShaderNameToShaderKeyName(name, stage);
 
@@ -96,11 +96,43 @@ bool ShaderLibraryGLES::IsValid() const {
 std::shared_ptr<const ShaderFunction> ShaderLibraryGLES::GetFunction(
     std::string_view name,
     ShaderStage stage) {
+  ReaderLock lock(functions_mutex_);
   const auto key = ShaderKey{name, stage};
   if (auto found = functions_.find(key); found != functions_.end()) {
     return found->second;
   }
   return nullptr;
+}
+
+// |ShaderLibrary|
+void ShaderLibraryGLES::RegisterFunction(std::string name,
+                                         ShaderStage stage,
+                                         std::shared_ptr<fml::Mapping> code,
+                                         RegistrationCallback callback) {
+  if (!callback) {
+    callback = [](auto) {};
+  }
+  fml::ScopedCleanupClosure auto_fail([callback]() { callback(false); });
+  if (name.empty() || stage == ShaderStage::kUnknown || code == nullptr ||
+      code->GetMapping() == nullptr) {
+    VALIDATION_LOG << "Invalid runtime stage registration.";
+    return;
+  }
+  const auto key = ShaderKey{name, stage};
+  WriterLock lock(functions_mutex_);
+  if (functions_.count(key) != 0) {
+    VALIDATION_LOG << "Runtime stage named " << name
+                   << " has already been registered.";
+    return;
+  }
+  functions_[key] = std::shared_ptr<ShaderFunctionGLES>(new ShaderFunctionGLES(
+      library_id_,                                 //
+      stage,                                       //
+      GLESShaderNameToShaderKeyName(name, stage),  //
+      code                                         //
+      ));
+  auto_fail.Release();
+  callback(true);
 }
 
 }  // namespace impeller

--- a/impeller/renderer/backend/gles/shader_library_gles.h
+++ b/impeller/renderer/backend/gles/shader_library_gles.h
@@ -8,6 +8,8 @@
 
 #include "flutter/fml/macros.h"
 #include "flutter/fml/mapping.h"
+#include "impeller/base/comparable.h"
+#include "impeller/base/thread.h"
 #include "impeller/renderer/shader_key.h"
 #include "impeller/renderer/shader_library.h"
 
@@ -23,7 +25,9 @@ class ShaderLibraryGLES final : public ShaderLibrary {
 
  private:
   friend class ContextGLES;
-  ShaderFunctionMap functions_;
+  const UniqueID library_id_;
+  mutable RWMutex functions_mutex_;
+  ShaderFunctionMap functions_ IPLR_GUARDED_BY(functions_mutex_);
   bool is_valid_ = false;
 
   ShaderLibraryGLES(
@@ -32,6 +36,12 @@ class ShaderLibraryGLES final : public ShaderLibrary {
   // |ShaderLibrary|
   std::shared_ptr<const ShaderFunction> GetFunction(std::string_view name,
                                                     ShaderStage stage) override;
+
+  // |ShaderLibrary|
+  void RegisterFunction(std::string name,
+                        ShaderStage stage,
+                        std::shared_ptr<fml::Mapping> code,
+                        RegistrationCallback callback) override;
 
   FML_DISALLOW_COPY_AND_ASSIGN(ShaderLibraryGLES);
 };

--- a/impeller/renderer/backend/metal/shader_library_mtl.mm
+++ b/impeller/renderer/backend/metal/shader_library_mtl.mm
@@ -4,12 +4,14 @@
 
 #include "impeller/renderer/backend/metal/shader_library_mtl.h"
 
+#include "flutter/fml/closure.h"
+#include "impeller/base/validation.h"
 #include "impeller/renderer/backend/metal/shader_function_mtl.h"
 
 namespace impeller {
 
 ShaderLibraryMTL::ShaderLibraryMTL(NSArray<id<MTLLibrary>>* libraries)
-    : libraries_(libraries) {
+    : libraries_([libraries mutableCopy]) {
   if (libraries_ == nil || libraries_.count == 0) {
     return;
   }
@@ -23,10 +25,30 @@ bool ShaderLibraryMTL::IsValid() const {
   return is_valid_;
 }
 
+static MTLFunctionType ToMTLFunctionType(ShaderStage stage) {
+  switch (stage) {
+    case ShaderStage::kVertex:
+      return MTLFunctionTypeVertex;
+    case ShaderStage::kFragment:
+      return MTLFunctionTypeFragment;
+    case ShaderStage::kUnknown:
+    case ShaderStage::kTessellationControl:
+    case ShaderStage::kTessellationEvaluation:
+    case ShaderStage::kCompute:
+      return MTLFunctionTypeKernel;
+  }
+  FML_UNREACHABLE();
+}
+
 std::shared_ptr<const ShaderFunction> ShaderLibraryMTL::GetFunction(
     std::string_view name,
     ShaderStage stage) {
   if (!IsValid()) {
+    return nullptr;
+  }
+
+  if (name.empty()) {
+    VALIDATION_LOG << "Library function name was empty.";
     return nullptr;
   }
 
@@ -38,14 +60,24 @@ std::shared_ptr<const ShaderFunction> ShaderLibraryMTL::GetFunction(
 
   id<MTLFunction> function = nil;
 
-  for (size_t i = 0, count = [libraries_ count]; i < count; i++) {
-    function = [libraries_[i] newFunctionWithName:@(name.data())];
-    if (function) {
-      break;
+  {
+    ReaderLock lock(libraries_mutex_);
+    for (size_t i = 0, count = [libraries_ count]; i < count; i++) {
+      function = [libraries_[i] newFunctionWithName:@(name.data())];
+      if (function) {
+        break;
+      }
     }
   }
 
   if (function == nil) {
+    VALIDATION_LOG << "No library function found for name: " << name;
+    return nullptr;
+  }
+
+  if (function.functionType != ToMTLFunctionType(stage)) {
+    VALIDATION_LOG << "Library function named " << name
+                   << " was for an unexpected shader stage.";
     return nullptr;
   }
 
@@ -53,6 +85,66 @@ std::shared_ptr<const ShaderFunction> ShaderLibraryMTL::GetFunction(
       library_id_, function, {name.data(), name.size()}, stage));
   functions_[key] = func;
   return func;
+}
+
+id<MTLDevice> ShaderLibraryMTL::GetDevice() const {
+  ReaderLock lock(libraries_mutex_);
+  if (libraries_.count > 0u) {
+    return libraries_[0].device;
+  }
+  return nil;
+}
+
+// |ShaderLibrary|
+void ShaderLibraryMTL::RegisterFunction(std::string name,   // unused
+                                        ShaderStage stage,  // unused
+                                        std::shared_ptr<fml::Mapping> code,
+                                        RegistrationCallback callback) {
+  if (!callback) {
+    callback = [](auto) {};
+  }
+  auto failure_callback = std::make_shared<fml::ScopedCleanupClosure>(
+      [callback]() { callback(false); });
+  if (!IsValid()) {
+    return;
+  }
+  if (code == nullptr || code->GetMapping() == nullptr) {
+    return;
+  }
+  auto device = GetDevice();
+  if (device == nil) {
+    return;
+  }
+
+  auto source = [[NSString alloc] initWithBytes:code->GetMapping()
+                                         length:code->GetSize()
+                                       encoding:NSUTF8StringEncoding];
+
+  auto weak_this = weak_from_this();
+  [device newLibraryWithSource:source
+                       options:NULL
+             completionHandler:^(id<MTLLibrary> library, NSError* error) {
+               auto strong_this = weak_this.lock();
+               if (!strong_this) {
+                 VALIDATION_LOG << "Shader library was collected before "
+                                   "dynamic shader stage could be registered.";
+                 return;
+               }
+               if (!library) {
+                 VALIDATION_LOG << "Could not register dynamic stage library: "
+                                << error.localizedDescription.UTF8String;
+                 return;
+               }
+               reinterpret_cast<ShaderLibraryMTL*>(strong_this.get())
+                   ->RegisterLibrary(library);
+               failure_callback->Release();
+               callback(true);
+             }];
+}
+
+void ShaderLibraryMTL::RegisterLibrary(id<MTLLibrary> library) {
+  WriterLock lock(libraries_mutex_);
+  [libraries_ addObject:library];
 }
 
 }  // namespace impeller

--- a/impeller/renderer/pipeline_builder.h
+++ b/impeller/renderer/pipeline_builder.h
@@ -61,7 +61,7 @@ struct PipelineBuilder {
       const Context& context,
       PipelineDescriptor& desc) {
     // Setup debug instrumentation.
-    desc.SetLabel(SPrintF("%s Pipeline", VertexShader::kLabel.data()));
+    desc.SetLabel(SPrintF("%s Pipeline", FragmentShader::kLabel.data()));
 
     // Resolve pipeline entrypoints.
     {

--- a/impeller/renderer/shader_library.cc
+++ b/impeller/renderer/shader_library.cc
@@ -10,4 +10,13 @@ ShaderLibrary::ShaderLibrary() = default;
 
 ShaderLibrary::~ShaderLibrary() = default;
 
+void ShaderLibrary::RegisterFunction(std::string name,
+                                     ShaderStage stage,
+                                     std::shared_ptr<fml::Mapping> code,
+                                     RegistrationCallback callback) {
+  if (callback) {
+    callback(false);
+  }
+}
+
 }  // namespace impeller

--- a/impeller/renderer/shader_library.h
+++ b/impeller/renderer/shader_library.h
@@ -4,10 +4,12 @@
 
 #pragma once
 
+#include <future>
 #include <memory>
 #include <string_view>
 
 #include "flutter/fml/macros.h"
+#include "fml/mapping.h"
 #include "impeller/renderer/shader_types.h"
 
 namespace impeller {
@@ -15,7 +17,7 @@ namespace impeller {
 class Context;
 class ShaderFunction;
 
-class ShaderLibrary {
+class ShaderLibrary : public std::enable_shared_from_this<ShaderLibrary> {
  public:
   virtual ~ShaderLibrary();
 
@@ -24,6 +26,12 @@ class ShaderLibrary {
   virtual std::shared_ptr<const ShaderFunction> GetFunction(
       std::string_view name,
       ShaderStage stage) = 0;
+
+  using RegistrationCallback = std::function<void(bool)>;
+  virtual void RegisterFunction(std::string name,
+                                ShaderStage stage,
+                                std::shared_ptr<fml::Mapping> code,
+                                RegistrationCallback callback);
 
  protected:
   ShaderLibrary();

--- a/impeller/runtime_stage/BUILD.gn
+++ b/impeller/runtime_stage/BUILD.gn
@@ -1,0 +1,45 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//third_party/flatbuffers/flatbuffers.gni")
+import("../tools/impeller.gni")
+
+config("runtime_stage_config") {
+  configs = [ "//flutter/impeller:impeller_public_config" ]
+  include_dirs = [ "$root_gen_dir/flutter" ]
+}
+
+flatbuffers("runtime_stage_flatbuffers") {
+  flatbuffers = [ "runtime_stage.fbs" ]
+  public_configs = [ ":runtime_stage_config" ]
+  public_deps = [ "//third_party/flatbuffers" ]
+}
+
+impeller_component("runtime_stage") {
+  sources = [
+    "runtime_stage.cc",
+    "runtime_stage.h",
+  ]
+  public_deps = [
+    ":runtime_stage_flatbuffers",
+    "../base",
+    "../renderer",
+    "//flutter/fml",
+  ]
+}
+
+impeller_component("runtime_stage_unittests") {
+  testonly = true
+
+  sources = [
+    "runtime_stage_playground.cc",
+    "runtime_stage_playground.h",
+    "runtime_stage_unittests.cc",
+  ]
+  deps = [
+    ":runtime_stage",
+    "../playground",
+    "//flutter/testing",
+  ]
+}

--- a/impeller/runtime_stage/runtime_stage.cc
+++ b/impeller/runtime_stage/runtime_stage.cc
@@ -1,0 +1,132 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/runtime_stage/runtime_stage.h"
+
+#include "impeller/base/validation.h"
+#include "impeller/runtime_stage/runtime_stage_flatbuffers.h"
+
+namespace impeller {
+
+static RuntimeUniformType ToType(fb::UniformDataType type) {
+  switch (type) {
+    case fb::UniformDataType::kBoolean:
+      return RuntimeUniformType::kBoolean;
+    case fb::UniformDataType::kSignedByte:
+      return RuntimeUniformType::kSignedByte;
+    case fb::UniformDataType::kUnsignedByte:
+      return RuntimeUniformType::kUnsignedByte;
+    case fb::UniformDataType::kSignedShort:
+      return RuntimeUniformType::kSignedShort;
+    case fb::UniformDataType::kUnsignedShort:
+      return RuntimeUniformType::kUnsignedShort;
+    case fb::UniformDataType::kSignedInt:
+      return RuntimeUniformType::kSignedInt;
+    case fb::UniformDataType::kUnsignedInt:
+      return RuntimeUniformType::kUnsignedInt;
+    case fb::UniformDataType::kSignedInt64:
+      return RuntimeUniformType::kSignedInt64;
+    case fb::UniformDataType::kUnsignedInt64:
+      return RuntimeUniformType::kUnsignedInt64;
+    case fb::UniformDataType::kHalfFloat:
+      return RuntimeUniformType::kHalfFloat;
+    case fb::UniformDataType::kFloat:
+      return RuntimeUniformType::kFloat;
+    case fb::UniformDataType::kDouble:
+      return RuntimeUniformType::kDouble;
+    case fb::UniformDataType::kSampledImage:
+      return RuntimeUniformType::kSampledImage;
+  }
+  FML_UNREACHABLE();
+}
+
+static ShaderStage ToShaderStage(fb::Stage stage) {
+  switch (stage) {
+    case fb::Stage::kVertex:
+      return ShaderStage::kVertex;
+    case fb::Stage::kFragment:
+      return ShaderStage::kFragment;
+    case fb::Stage::kCompute:
+      return ShaderStage::kCompute;
+    case fb::Stage::kTessellationControl:
+      return ShaderStage::kTessellationControl;
+    case fb::Stage::kTessellationEvaluation:
+      return ShaderStage::kTessellationEvaluation;
+  }
+  FML_UNREACHABLE();
+}
+
+RuntimeStage::RuntimeStage(std::shared_ptr<fml::Mapping> payload)
+    : payload_(std::move(payload)) {
+  if (payload_ == nullptr || !payload_->GetMapping()) {
+    return;
+  }
+  if (!fb::RuntimeStageBufferHasIdentifier(payload_->GetMapping())) {
+    VALIDATION_LOG
+        << "Impeller Runtime stage has invalid magic. Perhaps the stage "
+           "information is for the incorrect backend or the data is corrupted?";
+    return;
+  }
+  auto runtime_stage = fb::GetRuntimeStage(payload_->GetMapping());
+  if (!runtime_stage) {
+    return;
+  }
+
+  stage_ = ToShaderStage(runtime_stage->stage());
+  entrypoint_ = runtime_stage->entrypoint()->str();
+
+  for (auto i = runtime_stage->uniforms()->begin(),
+            end = runtime_stage->uniforms()->end();
+       i != end; i++) {
+    RuntimeUniformDescription desc;
+    desc.name = i->name()->str();
+    desc.location = i->location();
+    desc.type = ToType(i->type());
+    desc.dimensions = RuntimeUniformDimensions{i->rows(), i->columns()};
+    uniforms_.emplace_back(std::move(desc));
+  }
+
+  code_mapping_ = std::make_shared<fml::NonOwnedMapping>(
+      runtime_stage->shader()->data(),     //
+      runtime_stage->shader()->size(),     //
+      [payload = payload_](auto, auto) {}  //
+  );
+
+  is_valid_ = true;
+}
+
+RuntimeStage::~RuntimeStage() = default;
+
+bool RuntimeStage::IsValid() const {
+  return is_valid_;
+}
+
+const std::shared_ptr<fml::Mapping>& RuntimeStage::GetCodeMapping() const {
+  return code_mapping_;
+}
+
+const std::vector<RuntimeUniformDescription>& RuntimeStage::GetUniforms()
+    const {
+  return uniforms_;
+}
+
+const RuntimeUniformDescription* RuntimeStage::GetUniform(
+    const std::string& name) const {
+  for (const auto& uniform : uniforms_) {
+    if (uniform.name == name) {
+      return &uniform;
+    }
+  }
+  return nullptr;
+}
+
+const std::string& RuntimeStage::GetEntrypoint() const {
+  return entrypoint_;
+}
+
+ShaderStage RuntimeStage::GetShaderStage() const {
+  return stage_;
+}
+
+}  // namespace impeller

--- a/impeller/runtime_stage/runtime_stage.fbs
+++ b/impeller/runtime_stage/runtime_stage.fbs
@@ -1,0 +1,53 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+namespace impeller.fb;
+
+enum Stage:byte {
+  kVertex,
+  kFragment,
+  kCompute,
+  kTessellationControl,
+  kTessellationEvaluation,
+}
+
+enum TargetPlatform:byte {
+  kMetal,
+  kOpenGLES,
+}
+
+enum UniformDataType:uint32 {
+  kBoolean,
+  kSignedByte,
+  kUnsignedByte,
+  kSignedShort,
+  kUnsignedShort,
+  kSignedInt,
+  kUnsignedInt,
+  kSignedInt64,
+  kUnsignedInt64,
+  kHalfFloat,
+  kFloat,
+  kDouble,
+  kSampledImage,
+}
+
+table UniformDescription {
+  name: string;
+  location: uint64;
+  type: UniformDataType;
+  rows: uint64;
+  columns: uint64;
+}
+
+table RuntimeStage {
+  stage: Stage;
+  target_platform: TargetPlatform;
+  entrypoint: string;
+  uniforms: [UniformDescription];
+  shader: [ubyte];
+}
+
+root_type RuntimeStage;
+file_identifier "IPLR";

--- a/impeller/runtime_stage/runtime_stage.h
+++ b/impeller/runtime_stage/runtime_stage.h
@@ -1,0 +1,74 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "flutter/fml/macros.h"
+#include "flutter/fml/mapping.h"
+#include "impeller/renderer/shader_function.h"
+#include "impeller/renderer/shader_types.h"
+
+namespace impeller {
+
+enum RuntimeUniformType {
+  kBoolean,
+  kSignedByte,
+  kUnsignedByte,
+  kSignedShort,
+  kUnsignedShort,
+  kSignedInt,
+  kUnsignedInt,
+  kSignedInt64,
+  kUnsignedInt64,
+  kHalfFloat,
+  kFloat,
+  kDouble,
+  kSampledImage,
+};
+
+struct RuntimeUniformDimensions {
+  size_t rows = 0;
+  size_t cols = 0;
+};
+
+struct RuntimeUniformDescription {
+  std::string name;
+  size_t location = 0u;
+  RuntimeUniformType type = kFloat;
+  RuntimeUniformDimensions dimensions;
+};
+
+class RuntimeStage {
+ public:
+  RuntimeStage(std::shared_ptr<fml::Mapping> payload);
+
+  ~RuntimeStage();
+
+  bool IsValid() const;
+
+  ShaderStage GetShaderStage() const;
+
+  const std::vector<RuntimeUniformDescription>& GetUniforms() const;
+
+  const std::string& GetEntrypoint() const;
+
+  const RuntimeUniformDescription* GetUniform(const std::string& name) const;
+
+  const std::shared_ptr<fml::Mapping>& GetCodeMapping() const;
+
+ private:
+  ShaderStage stage_ = ShaderStage::kUnknown;
+  std::shared_ptr<fml::Mapping> payload_;
+  std::string entrypoint_;
+  std::shared_ptr<fml::Mapping> code_mapping_;
+  std::vector<RuntimeUniformDescription> uniforms_;
+  bool is_valid_ = false;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(RuntimeStage);
+};
+
+}  // namespace impeller

--- a/impeller/runtime_stage/runtime_stage_playground.cc
+++ b/impeller/runtime_stage/runtime_stage_playground.cc
@@ -1,0 +1,44 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/impeller/runtime_stage/runtime_stage_playground.h"
+
+#include <future>
+
+#include "flutter/fml/make_copyable.h"
+#include "flutter/testing/testing.h"
+#include "impeller/renderer/shader_library.h"
+
+namespace impeller {
+
+RuntimeStagePlayground::RuntimeStagePlayground() = default;
+
+RuntimeStagePlayground::~RuntimeStagePlayground() = default;
+
+std::unique_ptr<RuntimeStage> RuntimeStagePlayground::CreateStageFromFixture(
+    const std::string& fixture_name) const {
+  auto fixture = flutter::testing::OpenFixtureAsMapping(fixture_name);
+  if (!fixture || fixture->GetSize() == 0) {
+    return nullptr;
+  }
+  auto stage = std::make_unique<RuntimeStage>(std::move(fixture));
+  if (!stage->IsValid()) {
+    return nullptr;
+  }
+  return stage;
+}
+
+bool RuntimeStagePlayground::RegisterStage(const RuntimeStage& stage) {
+  std::promise<bool> registration;
+  auto future = registration.get_future();
+  auto library = GetContext()->GetShaderLibrary();
+  GetContext()->GetShaderLibrary()->RegisterFunction(
+      stage.GetEntrypoint(), stage.GetShaderStage(), stage.GetCodeMapping(),
+      fml::MakeCopyable([reg = std::move(registration)](bool result) mutable {
+        reg.set_value(result);
+      }));
+  return future.get();
+}
+
+}  // namespace impeller

--- a/impeller/runtime_stage/runtime_stage_playground.h
+++ b/impeller/runtime_stage/runtime_stage_playground.h
@@ -1,0 +1,28 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#pragma once
+
+#include "flutter/fml/macros.h"
+#include "impeller/playground/playground.h"
+#include "impeller/runtime_stage/runtime_stage.h"
+
+namespace impeller {
+
+class RuntimeStagePlayground : public Playground {
+ public:
+  RuntimeStagePlayground();
+
+  ~RuntimeStagePlayground();
+
+  std::unique_ptr<RuntimeStage> CreateStageFromFixture(
+      const std::string& fixture_name) const;
+
+  bool RegisterStage(const RuntimeStage& stage);
+
+ private:
+  FML_DISALLOW_COPY_AND_ASSIGN(RuntimeStagePlayground);
+};
+
+}  // namespace impeller

--- a/impeller/runtime_stage/runtime_stage_unittests.cc
+++ b/impeller/runtime_stage/runtime_stage_unittests.cc
@@ -1,0 +1,247 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <future>
+
+#include "flutter/fml/make_copyable.h"
+#include "flutter/impeller/fixtures/simple.vert.h"
+#include "flutter/testing/testing.h"
+#include "impeller/base/allocation.h"
+#include "impeller/base/validation.h"
+#include "impeller/playground/playground.h"
+#include "impeller/renderer/pipeline_descriptor.h"
+#include "impeller/renderer/pipeline_library.h"
+#include "impeller/renderer/shader_library.h"
+#include "impeller/runtime_stage/runtime_stage.h"
+#include "impeller/runtime_stage/runtime_stage_playground.h"
+
+namespace impeller {
+namespace testing {
+
+using RuntimeStageTest = RuntimeStagePlayground;
+INSTANTIATE_PLAYGROUND_SUITE(RuntimeStageTest);
+
+TEST(RuntimeStageTest, CanReadValidBlob) {
+  auto fixture =
+      flutter::testing::OpenFixtureAsMapping("ink_sparkle.frag.iplr");
+  ASSERT_TRUE(fixture);
+  ASSERT_GT(fixture->GetSize(), 0u);
+  RuntimeStage stage(std::move(fixture));
+  ASSERT_TRUE(stage.IsValid());
+  ASSERT_EQ(stage.GetShaderStage(), ShaderStage::kFragment);
+}
+
+TEST(RuntimeStageTest, CanRejectInvalidBlob) {
+  ScopedValidationDisable disable_validation;
+  auto fixture =
+      flutter::testing::OpenFixtureAsMapping("ink_sparkle.frag.iplr");
+  ASSERT_TRUE(fixture);
+  auto junk_allocation = std::make_shared<Allocation>();
+  ASSERT_TRUE(junk_allocation->Truncate(fixture->GetSize(), false));
+  // Not meant to be secure. Just reject obviously bad blobs using magic
+  // numbers.
+  ::memset(junk_allocation->GetBuffer(), 127, junk_allocation->GetLength());
+  RuntimeStage stage(CreateMappingFromAllocation(std::move(junk_allocation)));
+  ASSERT_FALSE(stage.IsValid());
+}
+
+TEST(RuntimeStageTest, CanReadUniforms) {
+  auto fixture =
+      flutter::testing::OpenFixtureAsMapping("ink_sparkle.frag.iplr");
+  ASSERT_TRUE(fixture);
+  ASSERT_GT(fixture->GetSize(), 0u);
+  RuntimeStage stage(std::move(fixture));
+  ASSERT_TRUE(stage.IsValid());
+  ASSERT_EQ(stage.GetUniforms().size(), 17u);
+  {
+    auto uni = stage.GetUniform("u_color");
+    ASSERT_NE(uni, nullptr);
+    ASSERT_EQ(uni->dimensions.rows, 4u);
+    ASSERT_EQ(uni->dimensions.cols, 1u);
+    ASSERT_EQ(uni->location, 0u);
+    ASSERT_EQ(uni->type, RuntimeUniformType::kFloat);
+  }
+  {
+    auto uni = stage.GetUniform("u_alpha");
+    ASSERT_NE(uni, nullptr);
+    ASSERT_EQ(uni->dimensions.rows, 1u);
+    ASSERT_EQ(uni->dimensions.cols, 1u);
+    ASSERT_EQ(uni->location, 1u);
+    ASSERT_EQ(uni->type, RuntimeUniformType::kFloat);
+  }
+  {
+    auto uni = stage.GetUniform("u_sparkle_color");
+    ASSERT_NE(uni, nullptr);
+    ASSERT_EQ(uni->dimensions.rows, 4u);
+    ASSERT_EQ(uni->dimensions.cols, 1u);
+    ASSERT_EQ(uni->location, 2u);
+    ASSERT_EQ(uni->type, RuntimeUniformType::kFloat);
+  }
+  {
+    auto uni = stage.GetUniform("u_sparkle_alpha");
+    ASSERT_NE(uni, nullptr);
+    ASSERT_EQ(uni->dimensions.rows, 1u);
+    ASSERT_EQ(uni->dimensions.cols, 1u);
+    ASSERT_EQ(uni->location, 3u);
+    ASSERT_EQ(uni->type, RuntimeUniformType::kFloat);
+  }
+  {
+    auto uni = stage.GetUniform("u_blur");
+    ASSERT_NE(uni, nullptr);
+    ASSERT_EQ(uni->dimensions.rows, 1u);
+    ASSERT_EQ(uni->dimensions.cols, 1u);
+    ASSERT_EQ(uni->location, 4u);
+    ASSERT_EQ(uni->type, RuntimeUniformType::kFloat);
+  }
+  {
+    auto uni = stage.GetUniform("u_radius_scale");
+    ASSERT_NE(uni, nullptr);
+    ASSERT_EQ(uni->dimensions.rows, 1u);
+    ASSERT_EQ(uni->dimensions.cols, 1u);
+    ASSERT_EQ(uni->location, 6u);
+    ASSERT_EQ(uni->type, RuntimeUniformType::kFloat);
+  }
+  {
+    auto uni = stage.GetUniform("u_max_radius");
+    ASSERT_NE(uni, nullptr);
+    ASSERT_EQ(uni->dimensions.rows, 1u);
+    ASSERT_EQ(uni->dimensions.cols, 1u);
+    ASSERT_EQ(uni->location, 7u);
+    ASSERT_EQ(uni->type, RuntimeUniformType::kFloat);
+  }
+  {
+    auto uni = stage.GetUniform("u_resolution_scale");
+    ASSERT_NE(uni, nullptr);
+    ASSERT_EQ(uni->dimensions.rows, 2u);
+    ASSERT_EQ(uni->dimensions.cols, 1u);
+    ASSERT_EQ(uni->location, 8u);
+    ASSERT_EQ(uni->type, RuntimeUniformType::kFloat);
+  }
+  {
+    auto uni = stage.GetUniform("u_noise_scale");
+    ASSERT_NE(uni, nullptr);
+    ASSERT_EQ(uni->dimensions.rows, 2u);
+    ASSERT_EQ(uni->dimensions.cols, 1u);
+    ASSERT_EQ(uni->location, 9u);
+    ASSERT_EQ(uni->type, RuntimeUniformType::kFloat);
+  }
+  {
+    auto uni = stage.GetUniform("u_noise_phase");
+    ASSERT_NE(uni, nullptr);
+    ASSERT_EQ(uni->dimensions.rows, 1u);
+    ASSERT_EQ(uni->dimensions.cols, 1u);
+    ASSERT_EQ(uni->location, 10u);
+    ASSERT_EQ(uni->type, RuntimeUniformType::kFloat);
+  }
+
+  {
+    auto uni = stage.GetUniform("u_circle1");
+    ASSERT_NE(uni, nullptr);
+    ASSERT_EQ(uni->dimensions.rows, 2u);
+    ASSERT_EQ(uni->dimensions.cols, 1u);
+    ASSERT_EQ(uni->location, 11u);
+    ASSERT_EQ(uni->type, RuntimeUniformType::kFloat);
+  }
+  {
+    auto uni = stage.GetUniform("u_circle2");
+    ASSERT_NE(uni, nullptr);
+    ASSERT_EQ(uni->dimensions.rows, 2u);
+    ASSERT_EQ(uni->dimensions.cols, 1u);
+    ASSERT_EQ(uni->location, 12u);
+    ASSERT_EQ(uni->type, RuntimeUniformType::kFloat);
+  }
+  {
+    auto uni = stage.GetUniform("u_circle3");
+    ASSERT_NE(uni, nullptr);
+    ASSERT_EQ(uni->dimensions.rows, 2u);
+    ASSERT_EQ(uni->dimensions.cols, 1u);
+    ASSERT_EQ(uni->location, 13u);
+    ASSERT_EQ(uni->type, RuntimeUniformType::kFloat);
+  }
+  {
+    auto uni = stage.GetUniform("u_rotation1");
+    ASSERT_NE(uni, nullptr);
+    ASSERT_EQ(uni->dimensions.rows, 2u);
+    ASSERT_EQ(uni->dimensions.cols, 1u);
+    ASSERT_EQ(uni->location, 14u);
+    ASSERT_EQ(uni->type, RuntimeUniformType::kFloat);
+  }
+  {
+    auto uni = stage.GetUniform("u_rotation2");
+    ASSERT_NE(uni, nullptr);
+    ASSERT_EQ(uni->dimensions.rows, 2u);
+    ASSERT_EQ(uni->dimensions.cols, 1u);
+    ASSERT_EQ(uni->location, 15u);
+    ASSERT_EQ(uni->type, RuntimeUniformType::kFloat);
+  }
+  {
+    auto uni = stage.GetUniform("u_rotation3");
+    ASSERT_NE(uni, nullptr);
+    ASSERT_EQ(uni->dimensions.rows, 2u);
+    ASSERT_EQ(uni->dimensions.cols, 1u);
+    ASSERT_EQ(uni->location, 16u);
+    ASSERT_EQ(uni->type, RuntimeUniformType::kFloat);
+  }
+}
+
+TEST_P(RuntimeStageTest, CanRegisterStage) {
+  if (GetBackend() != PlaygroundBackend::kMetal) {
+    GTEST_SKIP_("Skipped: https://github.com/flutter/flutter/issues/105538");
+  }
+  auto fixture =
+      flutter::testing::OpenFixtureAsMapping("ink_sparkle.frag.iplr");
+  ASSERT_TRUE(fixture);
+  ASSERT_GT(fixture->GetSize(), 0u);
+  RuntimeStage stage(std::move(fixture));
+  ASSERT_TRUE(stage.IsValid());
+  std::promise<bool> registration;
+  auto future = registration.get_future();
+  auto library = GetContext()->GetShaderLibrary();
+  library->RegisterFunction(
+      stage.GetEntrypoint(),   //
+      stage.GetShaderStage(),  //
+      stage.GetCodeMapping(),  //
+      fml::MakeCopyable([reg = std::move(registration)](bool result) mutable {
+        reg.set_value(result);
+      }));
+  ASSERT_TRUE(future.get());
+  auto function =
+      library->GetFunction(stage.GetEntrypoint(), ShaderStage::kFragment);
+  ASSERT_NE(function, nullptr);
+}
+
+TEST_P(RuntimeStageTest, CanCreatePipelineFromRuntimeStage) {
+  if (GetBackend() != PlaygroundBackend::kMetal) {
+    GTEST_SKIP_("Skipped: https://github.com/flutter/flutter/issues/105538");
+  }
+  auto stage = CreateStageFromFixture("ink_sparkle.frag.iplr");
+  ASSERT_NE(stage, nullptr);
+  ASSERT_TRUE(RegisterStage(*stage));
+  auto library = GetContext()->GetShaderLibrary();
+  using VS = SimpleVertexShader;
+  PipelineDescriptor desc;
+  desc.SetLabel("Runtime Stage InkSparkle");
+  desc.AddStageEntrypoint(
+      library->GetFunction(VS::kEntrypointName, ShaderStage::kVertex));
+  desc.AddStageEntrypoint(
+      library->GetFunction(stage->GetEntrypoint(), ShaderStage::kFragment));
+  auto vertex_descriptor = std::make_shared<VertexDescriptor>();
+  ASSERT_TRUE(vertex_descriptor->SetStageInputs(VS::kAllShaderStageInputs));
+  desc.SetVertexDescriptor(std::move(vertex_descriptor));
+  ColorAttachmentDescriptor color0;
+  color0.format = PixelFormat::kDefaultColor;
+  StencilAttachmentDescriptor stencil0;
+  stencil0.stencil_compare = CompareFunction::kEqual;
+  desc.SetColorAttachmentDescriptor(0u, color0);
+  desc.SetStencilAttachmentDescriptors(stencil0);
+  desc.SetStencilPixelFormat(PixelFormat::kDefaultStencil);
+  auto pipeline = GetContext()
+                      ->GetPipelineLibrary()
+                      ->GetRenderPipeline(std::move(desc))
+                      .get();
+  ASSERT_NE(pipeline, nullptr);
+}
+
+}  // namespace testing
+}  // namespace impeller

--- a/impeller/tools/impeller.gni
+++ b/impeller/tools/impeller.gni
@@ -496,6 +496,10 @@ template("impeller_shaders") {
     }
   }
 
+  if (!impeller_shaders_supports_platform) {
+    not_needed(invoker, "*")
+  }
+
   group(target_name) {
     public_deps = []
     if (impeller_enable_metal) {

--- a/shell/gpu/BUILD.gn
+++ b/shell/gpu/BUILD.gn
@@ -63,11 +63,18 @@ source_set("gpu_surface_metal") {
   sources = [
     "gpu_surface_metal_delegate.cc",
     "gpu_surface_metal_delegate.h",
-    "gpu_surface_metal_impeller.h",
-    "gpu_surface_metal_impeller.mm",
     "gpu_surface_metal_skia.h",
     "gpu_surface_metal_skia.mm",
   ]
 
-  public_deps = gpu_common_deps + [ "//flutter/impeller" ]
+  public_deps = gpu_common_deps
+
+  if (impeller_enable_metal) {
+    sources += [
+      "gpu_surface_metal_impeller.h",
+      "gpu_surface_metal_impeller.mm",
+    ]
+
+    public_deps += [ "//flutter/impeller" ]
+  }
 }

--- a/sky/packages/sky_engine/LICENSE
+++ b/sky/packages/sky_engine/LICENSE
@@ -293,6 +293,7 @@ angle
 boringssl
 etc1
 expat
+flatbuffers
 fuchsia-vulkan
 khronos
 libwebp
@@ -4928,36 +4929,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 --------------------------------------------------------------------------------
 dart
 
-Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
-for details. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      disclaimer in the documentation and/or other materials provided
-      with the distribution.
-    * Neither the name of Google LLC nor the names of its
-      contributors may be used to endorse or promote products derived
-      from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---------------------------------------------------------------------------------
-dart
-
 Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 for details. All rights reserved.
 
@@ -5247,6 +5218,37 @@ met:
       disclaimer in the documentation and/or other materials provided
       with the distribution.
     * Neither the name of Google Inc. nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--------------------------------------------------------------------------------
+dart
+flatbuffers
+
+Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+for details. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google LLC nor the names of its
       contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
 
@@ -6318,6 +6320,210 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+--------------------------------------------------------------------------------
+flatbuffers
+
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright 2014 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 --------------------------------------------------------------------------------
 freetype2
 

--- a/testing/testing.gni
+++ b/testing/testing.gni
@@ -260,6 +260,7 @@ template("copy_fixtures") {
     copy(target_name) {
       sources = invoker.fixtures
       outputs = [ "$target_gen_dir/assets/{{source_file_part}}" ]
+      forward_variables_from(invoker, [ "deps" ])
     }
   } else {
     group(target_name) {
@@ -308,6 +309,7 @@ template("test_fixtures") {
     copy_fixtures_target_name = "_cf_$target_name"
     copy_fixtures(copy_fixtures_target_name) {
       fixtures = invoker.fixtures
+      forward_variables_from(invoker, [ "deps" ])
     }
     test_public_deps += [ ":$copy_fixtures_target_name" ]
   }

--- a/tools/licenses/lib/filesystem.dart
+++ b/tools/licenses/lib/filesystem.dart
@@ -221,6 +221,7 @@ FileType identifyFile(String name, Reader reader) {
     case '.keystore': return FileType.binary;
     case '.icc': return FileType.binary; // Color profile
     case '.swp': return FileType.binary; // Vim swap file
+    case '.bfbs': return FileType.binary; // Flatbuffers Binary Schema
     // Archives
     case '.zip': return FileType.zip; // ZIP
     case '.tar': return FileType.tar; // Tar

--- a/tools/licenses/lib/main.dart
+++ b/tools/licenses/lib/main.dart
@@ -54,7 +54,7 @@ abstract class _RepositoryLicensedFile extends _RepositoryFile {
   static final RegExp _readmeNamePattern = RegExp(r'\b_*(?:readme|contributing|patents)_*\b', caseSensitive: false);
   static final RegExp _buildTimePattern = RegExp(r'^(?!.*gen$)(?:CMakeLists\.txt|(?:pkgdata)?Makefile(?:\.inc)?(?:\.am|\.in|)|configure(?:\.ac|\.in)?|config\.(?:sub|guess)|.+\.m4|install-sh|.+\.sh|.+\.bat|.+\.pyc?|.+\.pl|icu-configure|.+\.gypi?|.*\.gni?|.+\.mk|.+\.cmake|.+\.gradle|.+\.yaml|pubspec\.lock|\.packages|vms_make\.com|pom\.xml|\.project|source\.properties|.+\.obj|.+\.autopkg|Brewfile)$', caseSensitive: false);
   static final RegExp _docsPattern = RegExp(r'^(?:INSTALL|NEWS|OWNERS|AUTHORS|ChangeLog(?:\.rst|\.[0-9]+)?|.+\.txt|.+\.md|.+\.log|.+\.css|.+\.1|doxygen\.config|Doxyfile|.+\.spec(?:\.in)?)$', caseSensitive: false);
-  static final RegExp _devPattern = RegExp(r'^(?:codereview\.settings|.+\.~|.+\.~[0-9]+~|\.clang-format|\.gitattributes|\.landmines|\.DS_Store|\.travis\.yml|\.cirrus\.yml|\.cache|\.mailmap)$', caseSensitive: false);
+  static final RegExp _devPattern = RegExp(r'^(?:codereview\.settings|.+\.~|.+\.~[0-9]+~|\.clang-format|swift\.swiftformat|\.gitattributes|\.landmines|\.DS_Store|\.travis\.yml|\.cirrus\.yml|\.cache|\.mailmap)$', caseSensitive: false);
   static final RegExp _testsPattern = RegExp(r'^(?:tj(?:bench|example)test\.(?:java\.)?in|example\.c)$', caseSensitive: false);
   // The ICU library has sample code that will never get linked.
   static final RegExp _icuSamplesPattern = RegExp(r'.*(?:icu\/source\/samples).*$', caseSensitive: false);


### PR DESCRIPTION
Towards implementing the FragmentProgram API in Impeller.

Specifies an Impeller specific format for data the renderer can use to create
pipelines with user supplied shader stages at runtime.

The data is in the form of a flatbuffer with a known schema.

This patch implements the wire format, creating and loading the program
payloads, and creating pipeline state objects using these payloads.

If the user supplied SPIRV intended for the older API, the loader will reject
this invalid payload. This is probably not going to be too much of an issue
because the FragmentProgram API will probably be modified to only allow buffers
loaded from asset managers. But still, in the meantime, I am using the old API
to pass these new buffers.

Fixes https://github.com/flutter/flutter/issues/104750
Fixes https://github.com/flutter/flutter/issues/105542
Towards resolving https://github.com/flutter/flutter/issues/102853