### PR TITLE
[Impeller] Add backdrop filter support; refactor EntityPass

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -568,6 +568,8 @@ FILE: ../../../flutter/impeller/entity/entity_pass_delegate.h
 FILE: ../../../flutter/impeller/entity/entity_playground.cc
 FILE: ../../../flutter/impeller/entity/entity_playground.h
 FILE: ../../../flutter/impeller/entity/entity_unittests.cc
+FILE: ../../../flutter/impeller/entity/inline_pass_context.cc
+FILE: ../../../flutter/impeller/entity/inline_pass_context.h
 FILE: ../../../flutter/impeller/entity/shaders/blending/advanced_blend.glsl
 FILE: ../../../flutter/impeller/entity/shaders/blending/advanced_blend.vert
 FILE: ../../../flutter/impeller/entity/shaders/blending/advanced_blend_color.frag

--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -275,7 +275,7 @@ void Canvas::SaveLayer(Paint paint,
       std::make_unique<PaintPassDelegate>(paint, bounds));
   new_layer_pass.SetBackdropFilter(backdrop_filter);
 
-  if (bounds.has_value()) {
+  if (bounds.has_value() && !backdrop_filter.has_value()) {
     // Render target switches due to a save layer can be elided. In such cases
     // where passes are collapsed into their parent, the clipping effect to
     // the size of the render target that would have been allocated will be

--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -265,12 +265,15 @@ size_t Canvas::GetStencilDepth() const {
   return xformation_stack_.back().stencil_depth;
 }
 
-void Canvas::SaveLayer(Paint paint, std::optional<Rect> bounds) {
+void Canvas::SaveLayer(Paint paint,
+                       std::optional<Rect> bounds,
+                       std::optional<Paint::ImageFilterProc> backdrop_filter) {
   Save(true, paint.blend_mode);
 
   auto& new_layer_pass = GetCurrentPass();
   new_layer_pass.SetDelegate(
       std::make_unique<PaintPassDelegate>(paint, bounds));
+  new_layer_pass.SetBackdropFilter(backdrop_filter);
 
   if (bounds.has_value()) {
     // Render target switches due to a save layer can be elided. In such cases

--- a/impeller/aiks/canvas.h
+++ b/impeller/aiks/canvas.h
@@ -35,7 +35,10 @@ class Canvas {
 
   void Save();
 
-  void SaveLayer(Paint paint, std::optional<Rect> bounds = std::nullopt);
+  void SaveLayer(
+      Paint paint,
+      std::optional<Rect> bounds = std::nullopt,
+      std::optional<Paint::ImageFilterProc> backdrop_filter = std::nullopt);
 
   bool Restore();
 

--- a/impeller/display_list/display_list_dispatcher.cc
+++ b/impeller/display_list/display_list_dispatcher.cc
@@ -324,9 +324,12 @@ void DisplayListDispatcher::setMaskFilter(const flutter::DlMaskFilter* filter) {
   }
 }
 
-// |flutter::Dispatcher|
-void DisplayListDispatcher::setImageFilter(
+static std::optional<Paint::ImageFilterProc> ToImageFilterProc(
     const flutter::DlImageFilter* filter) {
+  if (filter == nullptr) {
+    return std::nullopt;
+  }
+
   switch (filter->type()) {
     case flutter::DlImageFilterType::kBlur: {
       auto blur = filter->asBlur();
@@ -338,7 +341,7 @@ void DisplayListDispatcher::setImageFilter(
         UNIMPLEMENTED;
       }
 
-      paint_.image_filter = [sigma_x, sigma_y](FilterInput::Ref input) {
+      return [sigma_x, sigma_y](FilterInput::Ref input) {
         return FilterContents::MakeGaussianBlur(input, sigma_x, sigma_y);
       };
 
@@ -350,9 +353,14 @@ void DisplayListDispatcher::setImageFilter(
     case flutter::DlImageFilterType::kComposeFilter:
     case flutter::DlImageFilterType::kColorFilter:
     case flutter::DlImageFilterType::kUnknown:
-      UNIMPLEMENTED;
-      break;
+      return std::nullopt;
   }
+}
+
+// |flutter::Dispatcher|
+void DisplayListDispatcher::setImageFilter(
+    const flutter::DlImageFilter* filter) {
+  paint_.image_filter = ToImageFilterProc(filter);
 }
 
 // |flutter::Dispatcher|
@@ -371,11 +379,12 @@ static std::optional<Rect> ToRect(const SkRect* rect) {
 void DisplayListDispatcher::saveLayer(const SkRect* bounds,
                                       const flutter::SaveLayerOptions options,
                                       const flutter::DlImageFilter* backdrop) {
+  auto paint = options.renders_with_attributes() ? paint_ : Paint{};
   if (backdrop) {
-    UNIMPLEMENTED;
+    canvas_.SaveLayer(paint, ToRect(bounds), ToImageFilterProc(backdrop));
+  } else {
+    canvas_.SaveLayer(paint, ToRect(bounds));
   }
-  canvas_.SaveLayer(options.renders_with_attributes() ? paint_ : Paint{},
-                    ToRect(bounds));
 }
 
 // |flutter::Dispatcher|

--- a/impeller/display_list/display_list_dispatcher.cc
+++ b/impeller/display_list/display_list_dispatcher.cc
@@ -380,11 +380,8 @@ void DisplayListDispatcher::saveLayer(const SkRect* bounds,
                                       const flutter::SaveLayerOptions options,
                                       const flutter::DlImageFilter* backdrop) {
   auto paint = options.renders_with_attributes() ? paint_ : Paint{};
-  if (backdrop) {
-    canvas_.SaveLayer(paint, ToRect(bounds), ToImageFilterProc(backdrop));
-  } else {
-    canvas_.SaveLayer(paint, ToRect(bounds));
-  }
+  canvas_.SaveLayer(paint, ToRect(bounds),
+                    backdrop ? ToImageFilterProc(backdrop) : std::nullopt);
 }
 
 // |flutter::Dispatcher|

--- a/impeller/display_list/display_list_dispatcher.cc
+++ b/impeller/display_list/display_list_dispatcher.cc
@@ -380,8 +380,7 @@ void DisplayListDispatcher::saveLayer(const SkRect* bounds,
                                       const flutter::SaveLayerOptions options,
                                       const flutter::DlImageFilter* backdrop) {
   auto paint = options.renders_with_attributes() ? paint_ : Paint{};
-  canvas_.SaveLayer(paint, ToRect(bounds),
-                    backdrop ? ToImageFilterProc(backdrop) : std::nullopt);
+  canvas_.SaveLayer(paint, ToRect(bounds), ToImageFilterProc(backdrop));
 }
 
 // |flutter::Dispatcher|

--- a/impeller/entity/BUILD.gn
+++ b/impeller/entity/BUILD.gn
@@ -89,6 +89,8 @@ impeller_component("entity") {
     "entity_pass.h",
     "entity_pass_delegate.cc",
     "entity_pass_delegate.h",
+    "inline_pass_context.cc",
+    "inline_pass_context.h",
   ]
 
   public_deps = [

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -8,8 +8,8 @@
 #include <variant>
 
 #include "flutter/fml/logging.h"
+#include "flutter/fml/macros.h"
 #include "flutter/fml/trace_event.h"
-#include "fml/macros.h"
 #include "impeller/base/validation.h"
 #include "impeller/entity/contents/content_context.h"
 #include "impeller/entity/contents/filters/filter_contents.h"

--- a/impeller/entity/entity_pass.h
+++ b/impeller/entity/entity_pass.h
@@ -60,9 +60,7 @@ class EntityPass {
 
   void SetBackdropFilter(std::optional<BackdropFilterProc> proc);
 
-  std::optional<Rect> GetSubpassCoverage(
-      const EntityPass& subpass,
-      std::optional<Rect> backdrop_coverage = std::nullopt) const;
+  std::optional<Rect> GetSubpassCoverage(const EntityPass& subpass) const;
 
   std::optional<Rect> GetElementsCoverage() const;
 

--- a/impeller/entity/entity_pass.h
+++ b/impeller/entity/entity_pass.h
@@ -64,6 +64,48 @@ class EntityPass {
   std::optional<Rect> GetElementsCoverage() const;
 
  private:
+  class EntityPassContext {
+   public:
+    EntityPassContext(std::shared_ptr<Context> context, RenderTarget render_target);
+    ~EntityPassContext();
+
+    bool IsValid() const;
+    bool IsActive() const;
+    std::shared_ptr<Texture> GetTexture();
+    bool EndPass();
+    RenderTarget GetRenderTarget() const;
+    std::shared_ptr<RenderPass> GetRenderPass(uint32_t pass_depth);
+
+   private:
+    std::shared_ptr<Context> context_;
+    RenderTarget render_target_;
+    std::shared_ptr<CommandBuffer> command_buffer_;
+    std::shared_ptr<RenderPass> pass_;
+    uint32_t pass_count_ = 0;
+
+    FML_DISALLOW_COPY_AND_ASSIGN(EntityPassContext);
+  };
+
+  struct EntityResult {
+    /// @brief  The resulting entity that should be rendered. If `std::nullopt`,
+    ///         there is nothing to render.
+    std::optional<Entity> entity = std::nullopt;
+    /// @brief  This is set to `false` if there was an unexpected rendering
+    ///         error while resolving the Entity.
+    bool success = false;
+
+    static EntityResult Success(Entity e) { return {e, true}; }
+    static EntityResult Failure() { return {std::nullopt, false}; }
+    static EntityResult Empty() { return {std::nullopt, true}; }
+  };
+
+  EntityResult GetElementEntity(const EntityPass::Element& element,
+                                ContentContext& renderer,
+                                EntityPassContext& pass_context,
+                                Point position,
+                                uint32_t pass_depth,
+                                size_t stencil_depth_floor) const;
+
   bool OnRender(ContentContext& renderer,
                 RenderTarget render_target,
                 Point position,

--- a/impeller/entity/entity_pass.h
+++ b/impeller/entity/entity_pass.h
@@ -60,7 +60,9 @@ class EntityPass {
 
   void SetBackdropFilter(std::optional<BackdropFilterProc> proc);
 
-  std::optional<Rect> GetSubpassCoverage(const EntityPass& subpass) const;
+  std::optional<Rect> GetSubpassCoverage(
+      const EntityPass& subpass,
+      std::optional<Rect> backdrop_coverage = std::nullopt) const;
 
   std::optional<Rect> GetElementsCoverage() const;
 

--- a/impeller/entity/entity_pass.h
+++ b/impeller/entity/entity_pass.h
@@ -91,7 +91,7 @@ class EntityPass {
                 Point parent_position,
                 uint32_t pass_depth,
                 size_t stencil_depth_floor = 0,
-                std::shared_ptr<Texture> backdrop_texture = nullptr) const;
+                std::shared_ptr<Contents> backdrop_contents = nullptr) const;
 
   std::vector<Element> elements_;
 

--- a/impeller/entity/entity_pass.h
+++ b/impeller/entity/entity_pass.h
@@ -66,16 +66,26 @@ class EntityPass {
 
  private:
   struct EntityResult {
+    enum Status {
+      /// The entity was successfully resolved and can be rendered.
+      kSuccess,
+      /// An unexpected rendering error occurred while resolving the Entity.
+      kFailure,
+      /// The entity should be skipped because rendering it will contribute
+      /// nothing to the frame.
+      kSkip,
+    };
+
     /// @brief  The resulting entity that should be rendered. If `std::nullopt`,
     ///         there is nothing to render.
-    std::optional<Entity> entity = std::nullopt;
+    Entity entity;
     /// @brief  This is set to `false` if there was an unexpected rendering
     ///         error while resolving the Entity.
-    bool success = false;
+    Status status = kFailure;
 
-    static EntityResult Success(Entity e) { return {e, true}; }
-    static EntityResult Failure() { return {std::nullopt, false}; }
-    static EntityResult Skip() { return {std::nullopt, true}; }
+    static EntityResult Success(Entity e) { return {e, kSuccess}; }
+    static EntityResult Failure() { return {{}, kFailure}; }
+    static EntityResult Skip() { return {{}, kSkip}; }
   };
 
   EntityResult GetEntityForElement(const EntityPass::Element& element,

--- a/impeller/entity/entity_pass.h
+++ b/impeller/entity/entity_pass.h
@@ -14,6 +14,7 @@
 #include "impeller/entity/contents/filters/filter_contents.h"
 #include "impeller/entity/entity.h"
 #include "impeller/entity/entity_pass_delegate.h"
+#include "impeller/entity/inline_pass_context.h"
 #include "impeller/renderer/render_target.h"
 #include "impeller/typographer/lazy_glyph_atlas.h"
 
@@ -64,28 +65,6 @@ class EntityPass {
   std::optional<Rect> GetElementsCoverage() const;
 
  private:
-  class EntityPassContext {
-   public:
-    EntityPassContext(std::shared_ptr<Context> context, RenderTarget render_target);
-    ~EntityPassContext();
-
-    bool IsValid() const;
-    bool IsActive() const;
-    std::shared_ptr<Texture> GetTexture();
-    bool EndPass();
-    RenderTarget GetRenderTarget() const;
-    std::shared_ptr<RenderPass> GetRenderPass(uint32_t pass_depth);
-
-   private:
-    std::shared_ptr<Context> context_;
-    RenderTarget render_target_;
-    std::shared_ptr<CommandBuffer> command_buffer_;
-    std::shared_ptr<RenderPass> pass_;
-    uint32_t pass_count_ = 0;
-
-    FML_DISALLOW_COPY_AND_ASSIGN(EntityPassContext);
-  };
-
   struct EntityResult {
     /// @brief  The resulting entity that should be rendered. If `std::nullopt`,
     ///         there is nothing to render.
@@ -101,7 +80,7 @@ class EntityPass {
 
   EntityResult GetElementEntity(const EntityPass::Element& element,
                                 ContentContext& renderer,
-                                EntityPassContext& pass_context,
+                                InlinePassContext& pass_context,
                                 Point position,
                                 uint32_t pass_depth,
                                 size_t stencil_depth_floor) const;

--- a/impeller/entity/entity_pass.h
+++ b/impeller/entity/entity_pass.h
@@ -75,19 +75,20 @@ class EntityPass {
 
     static EntityResult Success(Entity e) { return {e, true}; }
     static EntityResult Failure() { return {std::nullopt, false}; }
-    static EntityResult Empty() { return {std::nullopt, true}; }
+    static EntityResult Skip() { return {std::nullopt, true}; }
   };
 
-  EntityResult GetElementEntity(const EntityPass::Element& element,
-                                ContentContext& renderer,
-                                InlinePassContext& pass_context,
-                                Point position,
-                                uint32_t pass_depth,
-                                size_t stencil_depth_floor) const;
+  EntityResult GetEntityForElement(const EntityPass::Element& element,
+                                   ContentContext& renderer,
+                                   InlinePassContext& pass_context,
+                                   Point position,
+                                   uint32_t pass_depth,
+                                   size_t stencil_depth_floor) const;
 
   bool OnRender(ContentContext& renderer,
                 RenderTarget render_target,
                 Point position,
+                Point parent_position,
                 uint32_t pass_depth,
                 size_t stencil_depth_floor = 0,
                 std::shared_ptr<Texture> backdrop_texture = nullptr) const;
@@ -98,7 +99,13 @@ class EntityPass {
   Matrix xformation_;
   size_t stencil_depth_ = 0u;
   Entity::BlendMode blend_mode_ = Entity::BlendMode::kSourceOver;
-  bool contains_advanced_blends_ = false;
+
+  /// This flag is set to `true` whenever an entity is added to the pass that
+  /// requires reading the pass texture during rendering. This can happen in the
+  /// following scenarios:
+  ///   1. An entity with an "advanced blend" is added to the pass.
+  ///   2. A subpass with a backdrop filter is added to the pass.
+  bool reads_from_pass_texture_ = false;
 
   std::optional<BackdropFilterProc> backdrop_filter_proc_ = std::nullopt;
 

--- a/impeller/entity/inline_pass_context.cc
+++ b/impeller/entity/inline_pass_context.cc
@@ -1,0 +1,102 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/entity/inline_pass_context.h"
+
+#include "impeller/renderer/command_buffer.h"
+
+namespace impeller {
+
+InlinePassContext::InlinePassContext(
+    std::shared_ptr<Context> context,
+    RenderTarget render_target)
+    : context_(context), render_target_(render_target) {}
+
+InlinePassContext::~InlinePassContext() {
+  EndPass();
+}
+
+bool InlinePassContext::IsValid() const {
+  return !render_target_.GetColorAttachments().empty();
+}
+
+bool InlinePassContext::IsActive() const {
+  return pass_ != nullptr;
+}
+
+std::shared_ptr<Texture> InlinePassContext::GetTexture() {
+  if (!IsValid()) {
+    return nullptr;
+  }
+  auto color0 = render_target_.GetColorAttachments().find(0)->second;
+  return color0.resolve_texture ? color0.resolve_texture : color0.texture;
+}
+
+bool InlinePassContext::EndPass() {
+  if (!IsActive()) {
+    return true;
+  }
+
+  if (!pass_->EncodeCommands(context_->GetTransientsAllocator())) {
+    return false;
+  }
+
+  if (!command_buffer_->SubmitCommands()) {
+    return false;
+  }
+
+  pass_ = nullptr;
+  command_buffer_ = nullptr;
+
+  return true;
+}
+
+RenderTarget InlinePassContext::GetRenderTarget() const {
+  return render_target_;
+}
+
+std::shared_ptr<RenderPass> InlinePassContext::GetRenderPass(
+    uint32_t pass_depth) {
+  // Create a new render pass if one isn't active.
+  if (!IsActive()) {
+    command_buffer_ = context_->CreateRenderCommandBuffer();
+    if (!command_buffer_) {
+      return nullptr;
+    }
+
+    command_buffer_->SetLabel(
+        "EntityPass Command Buffer: Depth=" + std::to_string(pass_depth) +
+        " Count=" + std::to_string(pass_count_));
+
+    // Never clear the texture for subsequent passes.
+    if (pass_count_ > 0) {
+      if (!render_target_.GetColorAttachments().empty()) {
+        auto color0 = render_target_.GetColorAttachments().find(0)->second;
+        color0.load_action = LoadAction::kLoad;
+        render_target_.SetColorAttachment(color0, 0);
+      }
+
+      if (auto stencil = render_target_.GetStencilAttachment();
+          stencil.has_value()) {
+        stencil->load_action = LoadAction::kLoad;
+        render_target_.SetStencilAttachment(stencil.value());
+      }
+    }
+
+    pass_ = command_buffer_->CreateRenderPass(render_target_);
+    if (!pass_) {
+      return nullptr;
+    }
+
+    pass_->SetLabel(
+        "EntityPass Render Pass: Depth=" + std::to_string(pass_depth) +
+        " Count=" + std::to_string(pass_count_));
+
+    ++pass_count_;
+  }
+
+  return pass_;
+}
+
+}

--- a/impeller/entity/inline_pass_context.cc
+++ b/impeller/entity/inline_pass_context.cc
@@ -8,9 +8,8 @@
 
 namespace impeller {
 
-InlinePassContext::InlinePassContext(
-    std::shared_ptr<Context> context,
-    RenderTarget render_target)
+InlinePassContext::InlinePassContext(std::shared_ptr<Context> context,
+                                     RenderTarget render_target)
     : context_(context), render_target_(render_target) {}
 
 InlinePassContext::~InlinePassContext() {
@@ -52,7 +51,7 @@ bool InlinePassContext::EndPass() {
   return true;
 }
 
-RenderTarget InlinePassContext::GetRenderTarget() const {
+const RenderTarget& InlinePassContext::GetRenderTarget() const {
   return render_target_;
 }
 
@@ -99,4 +98,4 @@ std::shared_ptr<RenderPass> InlinePassContext::GetRenderPass(
   return pass_;
 }
 
-}
+}  // namespace impeller

--- a/impeller/entity/inline_pass_context.h
+++ b/impeller/entity/inline_pass_context.h
@@ -1,0 +1,36 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#pragma once
+
+#include "impeller/renderer/context.h"
+#include "impeller/renderer/render_pass.h"
+#include "impeller/renderer/render_target.h"
+
+namespace impeller {
+
+class InlinePassContext {
+ public:
+  InlinePassContext(std::shared_ptr<Context> context,
+                    RenderTarget render_target);
+  ~InlinePassContext();
+
+  bool IsValid() const;
+  bool IsActive() const;
+  std::shared_ptr<Texture> GetTexture();
+  bool EndPass();
+  RenderTarget GetRenderTarget() const;
+  std::shared_ptr<RenderPass> GetRenderPass(uint32_t pass_depth);
+
+ private:
+  std::shared_ptr<Context> context_;
+  RenderTarget render_target_;
+  std::shared_ptr<CommandBuffer> command_buffer_;
+  std::shared_ptr<RenderPass> pass_;
+  uint32_t pass_count_ = 0;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(InlinePassContext);
+};
+
+}  // namespace impeller

--- a/impeller/entity/inline_pass_context.h
+++ b/impeller/entity/inline_pass_context.h
@@ -20,7 +20,8 @@ class InlinePassContext {
   bool IsActive() const;
   std::shared_ptr<Texture> GetTexture();
   bool EndPass();
-  RenderTarget GetRenderTarget() const;
+  const RenderTarget& GetRenderTarget() const;
+
   std::shared_ptr<RenderPass> GetRenderPass(uint32_t pass_depth);
 
  private:


### PR DESCRIPTION
Adding backdrop filter support required adding a little bit of additional logic to the `EntityPass`, which was in dire need for some simplification, so I ended up doing some refactoring here.

The first 3 commits of this PR are mostly a refactor to wrangle the EntityPass logic in a more reasonable way:
* Move the interleaving renderpass logic into an enclosed `InlinePassContext` with clear contracts. Passes can be ended at any time during `EntityPass::OnRender`. A new `RenderPass` with the right configuration will get created if necessary whenever the pass is fetched. This removes most of the state in the render method and makes reasoning about `EntityPass::OnRender` method way easier.
* Per-Element Entity resolution during at render time is now in its own method: `EntityPass::GetEntityForElement`
  * Part of the motivation here is to make the possible outcomes from this resolution clearer (skip, fail, and success if there's actually something to render). This can be broken down further in the future

Conveniently, most of the behavior we actually needed to support the backdrop filter was already done thanks to the prior work on advanced blends:
* A callback to generate the backdrop filter is stored in the `EntityPass` when `SaveLayer` is called.
* When the backdrop filter proc is set, the parent pass will hand the child pass its texture at render time.
* When said child pass is rendering, it runs the given texture through the backdrop filter proc as a `TextureFilterInput`, and then renders the resulting contents before any pass elements are rendered.
* The running `contains_advanced_blends_` flag is now `reads_from_pass_texture_`, and is set to `true` when the `EntityPass` contains any advanced blended elements or subpasses with backdrop filters. Behavior of this flag remains otherwise unchanged (it makes the root pass create an intermediate texture, and it makes subpasses create non-transient stencils).

https://user-images.githubusercontent.com/919017/172504772-47a73a87-3abe-4969-8631-c95ea276217e.mov

The demo started out more visually interesting, but it turns out that the presence of the backdrop filter is supposed to override the layer's coverage, whether or not entities or the SaveLayer bounds hint is present.