### PR TITLE
Use explicit ndk version instead of ndk-bundle.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -574,7 +574,7 @@ deps = {
      'packages': [
        {
         'package': 'flutter/android/sdk/all/${{platform}}',
-        'version': 'version:32v1'
+        'version': 'version:32v5'
        }
      ],
      'condition': 'download_android_deps',

--- a/tools/android_sdk/create_cipd_packages.sh
+++ b/tools/android_sdk/create_cipd_packages.sh
@@ -99,8 +99,11 @@ for platform in "${platforms[@]}"; do
   done
 
   # Special treatment for NDK to move to expected directory.
-  mv $upload_dir/sdk/ndk-bundle $upload_dir
-  mv $upload_dir/ndk-bundle $upload_dir/ndk
+  mv $upload_dir/sdk/ndk $upload_dir/ndk-bundle
+  ndk_sub_paths=`find $upload_dir/ndk-bundle -maxdepth 1 -type d`
+  ndk_sub_paths_arr=($ndk_sub_paths)
+  mv ${ndk_sub_paths_arr[1]} $upload_dir/ndk
+  rm -rf $upload_dir/ndk-bundle
 
   # Accept all licenses to ensure they are generated and uploaded.
   yes "y" | $sdkmanager_path --licenses --sdk_root=$sdk_root

--- a/tools/android_sdk/packages.txt
+++ b/tools/android_sdk/packages.txt
@@ -3,4 +3,4 @@ cmdline-tools;latest:cmdline-tools
 build-tools;33.0.0-rc4:build-tools
 platform-tools:platform-tools
 tools:tools
-ndk-bundle:ndk-bundle
+ndk;24.0.8215888:ndk


### PR DESCRIPTION
`ndk-bundle` tends to be a few versions behind state-of-the-art.

In order to support building android engine on m1 mac, we need NDK 24+.

This does some path renaming to massage the downloaded ndk into the format we expect.

Additional changes are needed to support building on M1, this is a first step to obtain necessary dependencies.