### PR TITLE
Stop sending text to framework

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/SpellCheckChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/SpellCheckChannel.java
@@ -27,9 +27,8 @@ import org.json.JSONException;
  * <p>Once the spell check results are received by the {@link
  * io.flutter.plugin.editing.SpellCheckPlugin}, it will send back to the framework the {@code
  * ArrayList<String>} of encoded spell check results (see {@link
- * io.flutter.plugin.editing.SpellCheckPlugin#onGetSentenceSuggestions} for details) with the text
- * that these results correspond to appended to the front as an argument. For example, the argument
- * may look like: {@code {"Hello, wrold!", "7.11.world\nword\nold"}}. The {@link
+ * io.flutter.plugin.editing.SpellCheckPlugin#onGetSentenceSuggestions} for details). For example,
+ * the argument may look like: {@code {"7.11.world\nword\nold"}}. The {@link
  * io.flutter.plugin.editing.SpellCheckPlugin} only handles one request to fetch spell check results
  * at a time; see {@link io.flutter.plugin.editing.SpellCheckPlugin#initiateSpellCheck} for details.
  *

--- a/shell/platform/android/io/flutter/plugin/editing/SpellCheckPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/SpellCheckPlugin.java
@@ -15,7 +15,6 @@ import io.flutter.embedding.engine.systemchannels.SpellCheckChannel;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.localization.LocalizationPlugin;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Locale;
 
 /**
@@ -36,7 +35,6 @@ public class SpellCheckPlugin
   private SpellCheckerSession mSpellCheckerSession;
 
   @VisibleForTesting MethodChannel.Result pendingResult;
-  @VisibleForTesting String pendingResultText;
 
   // The maximum number of suggestions that the Android spell check service is allowed to provide
   // per word. Same number that is used by default for Android's TextViews.
@@ -80,7 +78,6 @@ public class SpellCheckPlugin
     }
 
     pendingResult = result;
-    pendingResultText = text;
 
     performSpellCheck(locale, text);
   }
@@ -115,7 +112,7 @@ public class SpellCheckPlugin
   @Override
   public void onGetSentenceSuggestions(SentenceSuggestionsInfo[] results) {
     if (results.length == 0) {
-      pendingResult.success(new ArrayList<>(Arrays.asList(pendingResultText, "")));
+      pendingResult.success(new ArrayList<String>());
       pendingResult = null;
       return;
     }
@@ -146,7 +143,6 @@ public class SpellCheckPlugin
           spellCheckerSuggestionSpan.substring(0, spellCheckerSuggestionSpan.length() - 1));
     }
 
-    spellCheckerSuggestionSpans.add(0, pendingResultText);
     pendingResult.success(spellCheckerSuggestionSpans);
     pendingResult = null;
   }

--- a/shell/platform/android/test/io/flutter/plugin/editing/SpellCheckPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/SpellCheckPluginTest.java
@@ -182,11 +182,10 @@ public class SpellCheckPluginTest {
         spy(new SpellCheckPlugin(fakeTextServicesManager, fakeSpellCheckChannel));
     MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
     spellCheckPlugin.pendingResult = mockResult;
-    spellCheckPlugin.pendingResultText = "Hello, world!";
 
     spellCheckPlugin.onGetSentenceSuggestions(new SentenceSuggestionsInfo[] {});
 
-    verify(mockResult).success(new ArrayList<String>(Arrays.asList("Hello, world!", "")));
+    verify(mockResult).success(new ArrayList<String>());
   }
 
   @Test
@@ -197,7 +196,6 @@ public class SpellCheckPluginTest {
         spy(new SpellCheckPlugin(fakeTextServicesManager, fakeSpellCheckChannel));
     MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
     spellCheckPlugin.pendingResult = mockResult;
-    spellCheckPlugin.pendingResultText = "Hello, wrold!";
 
     spellCheckPlugin.onGetSentenceSuggestions(
         new SentenceSuggestionsInfo[] {
@@ -211,7 +209,6 @@ public class SpellCheckPluginTest {
               new int[] {5})
         });
 
-    verify(mockResult)
-        .success(new ArrayList<String>(Arrays.asList("Hello, wrold!", "7.11.world\nword\nold")));
+    verify(mockResult).success(new ArrayList<String>(Arrays.asList("7.11.world\nword\nold")));
   }
 }


### PR DESCRIPTION
Part of Issue [#34688](https://github.com/flutter/flutter/issues/34688) for Android. 

Stops Android engine from sending text to the framework. See [this comment](https://github.com/flutter/flutter/pull/104460#discussion_r884037551) for context.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
