### PR TITLE
[Impeller] OpenGL texture parameters on the right texture target.

### DIFF
--- a/impeller/renderer/backend/gles/buffer_bindings_gles.cc
+++ b/impeller/renderer/backend/gles/buffer_bindings_gles.cc
@@ -317,7 +317,7 @@ bool BufferBindingsGLES::BindTextures(const ProcTableGLES& gl,
     auto sampler = bindings.samplers.find(texture.first);
     if (sampler != bindings.samplers.end()) {
       const auto& sampler_gles = SamplerGLES::Cast(*sampler->second.resource);
-      if (!sampler_gles.ConfigureBoundTexture(gl)) {
+      if (!sampler_gles.ConfigureBoundTexture(texture_gles, gl)) {
         return false;
       }
     }

--- a/impeller/renderer/backend/gles/formats_gles.h
+++ b/impeller/renderer/backend/gles/formats_gles.h
@@ -163,4 +163,16 @@ constexpr std::optional<GLenum> ToVertexAttribType(ShaderType type) {
   FML_UNREACHABLE();
 }
 
+constexpr std::optional<GLenum> ToTextureTarget(TextureType type) {
+  switch (type) {
+    case TextureType::kTexture2D:
+      return GL_TEXTURE_2D;
+    case TextureType::kTexture2DMultisample:
+      return std::nullopt;
+    case TextureType::kTextureCube:
+      return GL_TEXTURE_CUBE_MAP;
+  }
+  FML_UNREACHABLE();
+}
+
 }  // namespace impeller

--- a/impeller/renderer/backend/gles/sampler_gles.cc
+++ b/impeller/renderer/backend/gles/sampler_gles.cc
@@ -4,7 +4,9 @@
 
 #include "impeller/renderer/backend/gles/sampler_gles.h"
 
+#include "impeller/renderer/backend/gles/formats_gles.h"
 #include "impeller/renderer/backend/gles/proc_table_gles.h"
+#include "impeller/renderer/backend/gles/texture_gles.h"
 
 namespace impeller {
 
@@ -38,19 +40,26 @@ static GLint ToAddressMode(SamplerAddressMode mode) {
   FML_UNREACHABLE();
 }
 
-bool SamplerGLES::ConfigureBoundTexture(const ProcTableGLES& gl) const {
+bool SamplerGLES::ConfigureBoundTexture(const TextureGLES& texture,
+                                        const ProcTableGLES& gl) const {
   if (!IsValid()) {
     return false;
   }
 
+  auto target = ToTextureTarget(texture.GetTextureDescriptor().type);
+
+  if (!target.has_value()) {
+    return false;
+  }
+
   const auto& desc = GetDescriptor();
-  gl.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER,
+  gl.TexParameteri(target.value(), GL_TEXTURE_MIN_FILTER,
                    ToParam(desc.min_filter));
-  gl.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER,
+  gl.TexParameteri(target.value(), GL_TEXTURE_MAG_FILTER,
                    ToParam(desc.mag_filter));
-  gl.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S,
+  gl.TexParameteri(target.value(), GL_TEXTURE_WRAP_S,
                    ToAddressMode(desc.width_address_mode));
-  gl.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T,
+  gl.TexParameteri(target.value(), GL_TEXTURE_WRAP_T,
                    ToAddressMode(desc.height_address_mode));
   return true;
 }

--- a/impeller/renderer/backend/gles/sampler_gles.h
+++ b/impeller/renderer/backend/gles/sampler_gles.h
@@ -10,6 +10,7 @@
 
 namespace impeller {
 
+class TextureGLES;
 class SamplerLibraryGLES;
 class ProcTableGLES;
 
@@ -18,7 +19,8 @@ class SamplerGLES final : public Sampler,
  public:
   ~SamplerGLES();
 
-  bool ConfigureBoundTexture(const ProcTableGLES& gl) const;
+  bool ConfigureBoundTexture(const TextureGLES& texture,
+                             const ProcTableGLES& gl) const;
 
  private:
   friend class SamplerLibraryGLES;

--- a/impeller/renderer/backend/gles/texture_gles.cc
+++ b/impeller/renderer/backend/gles/texture_gles.cc
@@ -11,6 +11,7 @@
 #include "impeller/base/allocation.h"
 #include "impeller/base/config.h"
 #include "impeller/base/validation.h"
+#include "impeller/renderer/backend/gles/formats_gles.h"
 
 namespace impeller {
 
@@ -346,18 +347,6 @@ void TextureGLES::InitializeContentsIfNecessary() const {
       }
       break;
   }
-}
-
-static std::optional<GLenum> ToTextureTarget(TextureType type) {
-  switch (type) {
-    case TextureType::kTexture2D:
-      return GL_TEXTURE_2D;
-    case TextureType::kTexture2DMultisample:
-      return std::nullopt;
-    case TextureType::kTextureCube:
-      return GL_TEXTURE_CUBE_MAP;
-  }
-  FML_UNREACHABLE();
 }
 
 bool TextureGLES::Bind() const {


### PR DESCRIPTION
We would bind the texture target as either a 2D or Cube type but only set
parameters such as min/mag filters and wrap modes on the 2D target. This fixes
the rendering the Impeller showcase with the OpenGL backend.

Fixes https://github.com/flutter/flutter/issues/104786
<img width="1136" alt="Screen Shot 2022-06-07 at 5 59 53 PM" src="https://user-images.githubusercontent.com/44085/172509044-98664136-04ca-4ee9-b45a-bb061740470c.png">

