### PR TITLE
Added flag to disable the dart profiler on iOS

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -173,6 +173,12 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle) {
     settings.trace_systrace = enableTraceSystrace.boolValue;
   }
 
+  NSNumber* enableDartProfiling = [mainBundle objectForInfoDictionaryKey:@"FLTEnableDartProfiling"];
+  // Change the default only if the option is present.
+  if (enableDartProfiling != nil) {
+    settings.enable_dart_profiling = enableDartProfiling.boolValue;
+  }
+
   // Leak Dart VM settings, set whether leave or clean up the VM after the last shell shuts down.
   NSNumber* leakDartVM = [mainBundle objectForInfoDictionaryKey:@"FLTLeakDartVM"];
   // It will change the default leak_vm value in settings only if the key exists.

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProjectTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProjectTest.mm
@@ -80,6 +80,15 @@ FLUTTER_ASSERT_ARC
   XCTAssertEqual(settings.trace_systrace, NO);
 }
 
+- (void)testEnableDartProflingSettingIsCorrectlyParsed {
+  NSBundle* mainBundle = [NSBundle mainBundle];
+  NSNumber* enableTraceSystrace = [mainBundle objectForInfoDictionaryKey:@"FLTEnableDartProfiling"];
+  XCTAssertNotNil(enableTraceSystrace);
+  XCTAssertEqual(enableTraceSystrace.boolValue, NO);
+  auto settings = FLTDefaultSettingsForBundle();
+  XCTAssertEqual(settings.trace_systrace, NO);
+}
+
 - (void)testEmptySettingsAreCorrect {
   XCTAssertFalse([FlutterDartProject allowsArbitraryLoads:[[NSDictionary alloc] init]]);
   XCTAssertEqualObjects(@"", [FlutterDartProject domainNetworkPolicy:[[NSDictionary alloc] init]]);

--- a/testing/ios/IosUnitTests/App/Info.plist
+++ b/testing/ios/IosUnitTests/App/Info.plist
@@ -50,6 +50,8 @@
 	<false/>
 	<key>FLTTraceSystrace</key>
 	<false/>
+	<key>FLTEnableDartProfiling</key>
+	<false/>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>


### PR DESCRIPTION
issue: https://github.com/flutter/flutter/issues/105152

I don't think this PR fixes that issue, but it unblocks me from my profiling work.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
