### PR TITLE
[Impeller] Fix bindings for Solid Stroke wrt to the GLES backend

### DIFF
--- a/impeller/entity/contents/solid_stroke_contents.cc
+++ b/impeller/entity/contents/solid_stroke_contents.cc
@@ -182,10 +182,8 @@ bool SolidStrokeContents::Render(const ContentContext& renderer,
   VS::FrameInfo frame_info;
   frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
                    entity.GetTransformation();
-
-  VS::StrokeInfo stroke_info;
-  stroke_info.color = color_.Premultiply();
-  stroke_info.size = stroke_size_;
+  frame_info.color = color_.Premultiply();
+  frame_info.size = stroke_size_;
 
   Command cmd;
   cmd.primitive_type = PrimitiveType::kTriangleStrip;
@@ -205,8 +203,6 @@ bool SolidStrokeContents::Render(const ContentContext& renderer,
                                              cap_proc_, join_proc_,
                                              miter_limit_, smoothing));
   VS::BindFrameInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frame_info));
-  VS::BindStrokeInfo(cmd,
-                     pass.GetTransientsBuffer().EmplaceUniform(stroke_info));
 
   pass.AddCommand(cmd);
 

--- a/impeller/entity/shaders/solid_stroke.vert
+++ b/impeller/entity/shaders/solid_stroke.vert
@@ -4,12 +4,9 @@
 
 uniform FrameInfo {
   mat4 mvp;
-} frame_info;
-
-uniform StrokeInfo {
   vec4 color;
   float size;
-} stroke_info;
+} frame_info;
 
 in vec2 vertex_position;
 in vec2 vertex_normal;
@@ -20,8 +17,8 @@ out float v_pen_down;
 
 void main() {
   // Push one vertex by the half stroke size along the normal vector.
-  vec2 offset = vertex_normal * vec2(stroke_info.size * 0.5);
+  vec2 offset = vertex_normal * vec2(frame_info.size * 0.5);
   gl_Position = frame_info.mvp * vec4(vertex_position + offset, 0.0, 1.0);
-  stroke_color = stroke_info.color;
+  stroke_color = frame_info.color;
   v_pen_down = pen_down;
 }


### PR DESCRIPTION
Make the binding layout work correctly with the GLES backend (as per https://github.com/flutter/flutter/issues/105156). I think we need to either make this situation error out in impellerc or make the binding layout behave correctly when there are multiple slots.

Linux before (proprietary nvidia):
![image](https://user-images.githubusercontent.com/919017/172689246-e85bf1e4-1424-4cfb-9e1c-d7ced4fb8e67.png)

Linux after (proprietary nvidia):
![image](https://user-images.githubusercontent.com/919017/172689348-410889cf-8f06-46f5-9196-0677630750fc.png)

