### PR TITLE
Remove dependencies on package charcode

### DIFF
--- a/flutter_frontend_server/pubspec.yaml
+++ b/flutter_frontend_server/pubspec.yaml
@@ -43,8 +43,6 @@ dependency_overrides:
     path: ../../third_party/dart/third_party/pkg/bazel_worker
   build_integration:
     path: ../../third_party/dart/pkg/build_integration
-  charcode:
-    path: ../../third_party/dart/third_party/pkg/charcode
   collection:
     path: ../../third_party/dart/third_party/pkg/collection
   compiler:

--- a/testing/benchmark/pubspec.yaml
+++ b/testing/benchmark/pubspec.yaml
@@ -33,8 +33,6 @@ dependency_overrides:
     path: ../../../third_party/dart/pkg/async_helper
   async:
     path: ../../../third_party/dart/third_party/pkg/async
-  charcode:
-    path: ../../../third_party/dart/third_party/pkg/charcode
   collection:
     path: ../../../third_party/dart/third_party/pkg/collection
   convert:

--- a/tools/api_check/pubspec.yaml
+++ b/tools/api_check/pubspec.yaml
@@ -44,8 +44,6 @@ dependency_overrides:
     path: ../../../third_party/dart/third_party/pkg/async
   async_helper:
     path: ../../../third_party/dart/pkg/async_helper
-  charcode:
-    path: ../../../third_party/dart/third_party/pkg/charcode
   collection:
     path: ../../../third_party/dart/third_party/pkg/collection
   convert:


### PR DESCRIPTION
The charcode package has been removed from the Dart SDK source
checkout, and the Flutter engine packages that list it in
their pubspecs do not depend on it directly or indirectly.

Remove it from their pubspecs, so they do not break when
the package disappears from the engine source checkout.

Bug: https://dart-review.googlesource.com/c/sdk/+/247500