### PR TITLE
[web] Restore terminal's echo setting after felt quits

### DIFF
--- a/lib/web_ui/dev/pipeline.dart
+++ b/lib/web_ui/dev/pipeline.dart
@@ -201,6 +201,12 @@ class PipelineWatcher {
     io.stdin.echoMode = false;
     io.stdin.lineMode = false;
 
+    // Reset these settings when the felt command is done.
+    cleanupCallbacks.add(() async {
+      io.stdin.echoMode = true;
+      io.stdin.lineMode = true;
+    });
+
     await io.stdin.firstWhere((List<int> event) {
       const int qKeyCode = 113;
       final bool qEntered = event.isNotEmpty && event.first == qKeyCode;

--- a/lib/web_ui/dev/utils.dart
+++ b/lib/web_ui/dev/utils.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:convert' show utf8, LineSplitter;
 import 'dart:io' as io;
+import 'dart:io';
 
 import 'package:args/command_runner.dart';
 import 'package:meta/meta.dart';
@@ -367,6 +368,9 @@ Future<void> cleanup() async {
   for (final AsyncCallback callback in cleanupCallbacks) {
     await callback();
   }
+
+  stdin.lineMode = true;
+  stdin.echoMode = true;
 }
 
 /// Scans the test/ directory for test files and returns them.

--- a/lib/web_ui/dev/utils.dart
+++ b/lib/web_ui/dev/utils.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 import 'dart:convert' show utf8, LineSplitter;
 import 'dart:io' as io;
-import 'dart:io';
 
 import 'package:args/command_runner.dart';
 import 'package:meta/meta.dart';

--- a/lib/web_ui/dev/utils.dart
+++ b/lib/web_ui/dev/utils.dart
@@ -368,9 +368,6 @@ Future<void> cleanup() async {
   for (final AsyncCallback callback in cleanupCallbacks) {
     await callback();
   }
-
-  stdin.lineMode = true;
-  stdin.echoMode = true;
 }
 
 /// Scans the test/ directory for test files and returns them.


### PR DESCRIPTION
We are starting to see [this issue](https://github.com/flutter/flutter/issues/105255) in the engine when using the `felt` tool.

This PR restores the terminal's echo setting similar to how the flutter tool [does](https://github.com/flutter/flutter/pull/105283).