### PR TITLE
[fuchsia] Remove to be deprecated pixel_scale field

### DIFF
--- a/shell/platform/fuchsia/flutter/flatland_platform_view.cc
+++ b/shell/platform/fuchsia/flutter/flatland_platform_view.cc
@@ -74,10 +74,6 @@ void FlatlandPlatformView::OnGetLayout(
                         static_cast<float>(info.logical_size().height)};
 
   // TODO(fxbug.dev/94000): Set device pixel ratio.
-  if (info.pixel_scale().width != 1 || info.pixel_scale().height != 1) {
-    FML_LOG(ERROR)
-        << "Flutter does not currently support pixel_scale's other than 1";
-  }
 
   SetViewportMetrics({
       1,                              // device_pixel_ratio

--- a/shell/platform/fuchsia/flutter/tests/flatland_platform_view_unittest.cc
+++ b/shell/platform/fuchsia/flutter/tests/flatland_platform_view_unittest.cc
@@ -287,18 +287,11 @@ class MockParentViewportWatcher
     }
   }
 
-  void SetLayout(uint32_t logical_size_x,
-                 uint32_t logical_size_y,
-                 uint32_t pixel_scale_x = 1u,
-                 uint32_t pixel_scale_y = 1u) {
+  void SetLayout(uint32_t logical_size_x, uint32_t logical_size_y) {
     ::fuchsia::math::SizeU logical_size;
     logical_size.width = logical_size_x;
     logical_size.height = logical_size_y;
     layout_.set_logical_size(logical_size);
-    ::fuchsia::math::SizeU pixel_scale;
-    pixel_scale.width = pixel_scale_x;
-    pixel_scale.height = pixel_scale_y;
-    layout_.set_pixel_scale(pixel_scale);
 
     if (pending_callback_valid_) {
       pending_layout_callback_(std::move(layout_));


### PR DESCRIPTION
This field was expected to be 1, making no effect. It will go away as part of scale plan.

Bug: https://bugs.fuchsia.dev/p/fuchsia/issues/detail?id=102163