### PR TITLE
Output the scenario app lint results at the path expected by the GN script

### DIFF
--- a/testing/scenario_app/android/app/build.gradle
+++ b/testing/scenario_app/android/app/build.gradle
@@ -9,6 +9,9 @@ android {
         warningsAsErrors true
         checkTestSources true
         textOutput 'stdout'
+        htmlReport false
+        xmlReport true
+        xmlOutput file("${rootProject.buildDir}/reports/lint-results.xml")
         // UnpackedNativeCode can break stack unwinding - see b/193408481
         // NewerVersionAvailable and GradleDependency need to be taken care of
         // by a roller rather than as part of CI.


### PR DESCRIPTION
The android_lint step in `testing/scenario_app/android/BUILD.gn` declares a path for the step's output, but the step's action was not actually writing its results at that path.

This PR changes the action's output to match the declaration.