### PR TITLE
[web] Fix typo in JS interop method.

### DIFF
--- a/lib/web_ui/lib/src/engine/dom.dart
+++ b/lib/web_ui/lib/src/engine/dom.dart
@@ -656,7 +656,7 @@ extension DomClipboardExtension on DomClipboard {
       js_util.callMethod(this, 'readText', <Object>[]));
 
   Future<dynamic> writeText(String data) => js_util
-      .promiseToFuture(js_util.callMethod(this, 'readText', <Object>[data]));
+      .promiseToFuture(js_util.callMethod(this, 'writeText', <Object>[data]));
 }
 
 extension DomResponseExtension on DomResponse {


### PR DESCRIPTION
This fixes a bug in the method name which can break copy / paste.