### PR TITLE
[android] Fix leak of bitmap object (android.graphics.Bitmap of Java) while using platform image decoder.

### DIFF
--- a/shell/platform/android/android_image_generator.cc
+++ b/shell/platform/android/android_image_generator.cc
@@ -97,10 +97,9 @@ void AndroidImageGenerator::DoDecodeImage() {
                                     data_->size()));
 
   auto bitmap = std::make_unique<fml::jni::ScopedJavaGlobalRef<jobject>>(
-      env, env->CallStaticObjectMethod(g_flutter_jni_class->obj(),
-                                       g_decode_image_method,
-                                       direct_buffer.obj(),
-                                       reinterpret_cast<long>(this)));
+      env, env->CallStaticObjectMethod(
+               g_flutter_jni_class->obj(), g_decode_image_method,
+               direct_buffer.obj(), reinterpret_cast<long>(this)));
   FML_CHECK(fml::jni::CheckException(env));
 
   if (bitmap->is_null()) {

--- a/shell/platform/android/android_image_generator.cc
+++ b/shell/platform/android/android_image_generator.cc
@@ -100,7 +100,7 @@ void AndroidImageGenerator::DoDecodeImage() {
       env, env->CallStaticObjectMethod(g_flutter_jni_class->obj(),
                                        g_decode_image_method,
                                        direct_buffer.obj(),
-                                       reinterpret_cast<long>(this));
+                                       reinterpret_cast<long>(this)));
   FML_CHECK(fml::jni::CheckException(env));
 
   if (bitmap->is_null()) {

--- a/shell/platform/android/android_image_generator.cc
+++ b/shell/platform/android/android_image_generator.cc
@@ -99,7 +99,8 @@ void AndroidImageGenerator::DoDecodeImage() {
   auto bitmap = std::make_unique<fml::jni::ScopedJavaGlobalRef<jobject>>(
       env, env->CallStaticObjectMethod(g_flutter_jni_class->obj(),
                                        g_decode_image_method,
-                                       direct_buffer.obj(), (long)this));
+                                       direct_buffer.obj(),
+                                       reinterpret_cast<long>(this));
   FML_CHECK(fml::jni::CheckException(env));
 
   if (bitmap->is_null()) {

--- a/shell/platform/android/android_image_generator.cc
+++ b/shell/platform/android/android_image_generator.cc
@@ -4,6 +4,8 @@
 
 #include "flutter/shell/platform/android/android_image_generator.h"
 
+#include <memory>
+
 #include <android/bitmap.h>
 #include <android/hardware_buffer.h>
 
@@ -94,11 +96,10 @@ void AndroidImageGenerator::DoDecodeImage() {
       env, env->NewDirectByteBuffer(const_cast<void*>(data_->data()),
                                     data_->size()));
 
-  fml::jni::ScopedJavaGlobalRef<jobject>* bitmap =
-      new fml::jni::ScopedJavaGlobalRef(
-          env, env->CallStaticObjectMethod(
-                   g_flutter_jni_class->obj(), g_decode_image_method,
-                   direct_buffer.obj(), reinterpret_cast<long>(this)));
+  auto bitmap = std::make_unique<fml::jni::ScopedJavaGlobalRef<jobject>>(
+      env, env->CallStaticObjectMethod(g_flutter_jni_class->obj(),
+                                       g_decode_image_method,
+                                       direct_buffer.obj(), (long)this));
   FML_CHECK(fml::jni::CheckException(env));
 
   if (bitmap->is_null()) {
@@ -127,11 +128,12 @@ void AndroidImageGenerator::DoDecodeImage() {
         reinterpret_cast<fml::jni::ScopedJavaGlobalRef<jobject>*>(context);
     auto env = fml::jni::AttachCurrentThread();
     AndroidBitmap_unlockPixels(env, bitmap->obj());
+    delete bitmap;
   };
 
   software_decoded_data_ = SkData::MakeWithProc(
       pixel_lock, info.width * info.height * sizeof(uint32_t), on_release,
-      bitmap);
+      bitmap.release());
 }
 
 bool AndroidImageGenerator::Register(JNIEnv* env) {


### PR DESCRIPTION
[android] Fix leak of bitmap object (android.graphics.Bitmap of Java) while using platform image decoder.

We will use a platform decoder to decode the image that skia not support (such as .heic) and holding a RAW pointer (from new operator) of fml::jni::ScopedJavaGlobalRef<jobject>. The java bitmap object associated with the RAW pointer is not deleted in all return path.