### PR TITLE
Remove uses of --lazy-async-stack Dart VM flag

### DIFF
--- a/build/dart/rules.gni
+++ b/build/dart/rules.gni
@@ -120,7 +120,7 @@ template("flutter_snapshot") {
     deps = [ ":$kernel_target" ]
     outputs = []
 
-    args = [ "--lazy_async_stacks" ]
+    args = []
 
     if (is_debug && flutter_runtime_mode != "profile" &&
         flutter_runtime_mode != "release" &&

--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -53,7 +53,6 @@ static const char* kDartAllConfigsArgs[] = {
     // clang-format off
     "--enable_mirrors=false",
     "--background_compilation",
-    "--lazy_async_stacks",
     // 'mark_when_idle' appears to cause a regression, turning off for now.
     // "--mark_when_idle",
     // clang-format on

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -529,7 +529,6 @@ TEST_F(ShellTest, AllowedDartVMFlag) {
   std::vector<const char*> flags = {
       "--enable-isolate-groups",
       "--no-enable-isolate-groups",
-      "--lazy_async_stacks",
   };
 #if !FLUTTER_RELEASE
   flags.push_back("--max_profile_depth 1");

--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -43,7 +43,6 @@ struct SwitchDesc {
 static const std::string kAllowedDartFlags[] = {
     "--enable-isolate-groups",
     "--no-enable-isolate-groups",
-    "--lazy_async_stacks",
 };
 // clang-format on
 
@@ -55,7 +54,6 @@ static const std::string kAllowedDartFlags[] = {
     "--no-enable-isolate-groups",
     "--enable_mirrors",
     "--enable-service-port-fallback",
-    "--lazy_async_stacks",
     "--max_profile_depth",
     "--profile_period",
     "--random_seed",

--- a/shell/platform/fuchsia/dart_runner/dart_runner.cc
+++ b/shell/platform/fuchsia/dart_runner/dart_runner.cc
@@ -41,7 +41,6 @@ namespace {
 
 const char* kDartVMArgs[] = {
     // clang-format off
-    "--lazy_async_stacks",
 
     "--systrace_timeline",
     "--timeline_streams=Compiler,Dart,Debugger,Embedder,GC,Isolate,VM",

--- a/shell/platform/fuchsia/dart_runner/embedder/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/embedder/BUILD.gn
@@ -46,7 +46,6 @@ template("create_aot_snapshot") {
     }
 
     args = [
-      "--lazy_async_stacks",
       "--deterministic",
       "--snapshot_kind=vm-aot-assembly",
       "--assembly=" + rebase_path(snapshot_assembly),

--- a/shell/platform/fuchsia/dart_runner/kernel/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/kernel/BUILD.gn
@@ -62,7 +62,6 @@ template("create_kernel_core_snapshot") {
     tool = gen_snapshot_to_use
 
     args = [
-      "--lazy_async_stacks",
       "--enable_mirrors=false",
       "--deterministic",
       "--snapshot_kind=core-jit",

--- a/shell/platform/fuchsia/dart_runner/vmservice/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/vmservice/BUILD.gn
@@ -57,7 +57,6 @@ template("aot_snapshot") {
     }
 
     args = [
-      "--lazy_async_stacks",
       "--deterministic",
       "--snapshot_kind=app-aot-elf",
       "--elf=" + rebase_path(snapshot_path),

--- a/shell/platform/fuchsia/flutter/component_v1.cc
+++ b/shell/platform/fuchsia/flutter/component_v1.cc
@@ -424,7 +424,7 @@ ComponentV1::ComponentV1(
     std::cout << message << std::endl;
   };
 
-  settings_.dart_flags = {"--lazy_async_stacks"};
+  settings_.dart_flags = {};
 
   // Don't collect CPU samples from Dart VM C++ code.
   settings_.dart_flags.push_back("--no_profile_vm");

--- a/shell/platform/fuchsia/flutter/component_v2.cc
+++ b/shell/platform/fuchsia/flutter/component_v2.cc
@@ -488,7 +488,7 @@ ComponentV2::ComponentV2(
     std::cout << message << std::endl;
   };
 
-  settings_.dart_flags = {"--lazy_async_stacks"};
+  settings_.dart_flags = {};
 
   // Don't collect CPU samples from Dart VM C++ code.
   settings_.dart_flags.push_back("--no_profile_vm");

--- a/shell/platform/fuchsia/flutter/kernel/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/kernel/BUILD.gn
@@ -66,7 +66,6 @@ template("core_snapshot") {
     tool = gen_snapshot_to_use
 
     args = [
-      "--lazy_async_stacks",
       "--enable_mirrors=false",
       "--deterministic",
       "--snapshot_kind=core-jit",

--- a/testing/testing.gni
+++ b/testing/testing.gni
@@ -179,7 +179,6 @@ template("dart_snapshot_aot") {
     outputs = [ elf_object ]
 
     args = [
-      "--lazy_async_stacks",
       "--deterministic",
       "--snapshot_kind=app-aot-elf",
       "--loading_unit_manifest=" + rebase_path(loading_unit_manifest),


### PR DESCRIPTION
This flag was enabled by default more than a year ago.
Now it is being removed from Dart VM.
