### PR TITLE
All layers with raster cache should use integer CTM

### DIFF
--- a/flow/layers/checkerboard_layertree_unittests.cc
+++ b/flow/layers/checkerboard_layertree_unittests.cc
@@ -59,6 +59,9 @@ TEST_F(CheckerBoardLayerTest, ClipRectSaveLayerNotCheckBoard) {
            MockCanvas::DrawCall{
                1, MockCanvas::ClipRectData{layer_bounds, SkClipOp::kIntersect,
                                            MockCanvas::kSoft_ClipEdgeStyle}},
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+           MockCanvas::DrawCall{1, MockCanvas::SetMatrixData{SkM44()}},
+#endif
            MockCanvas::DrawCall{
                1, MockCanvas::SaveLayerData{layer->paint_bounds(), clip_paint,
                                             nullptr, 2}},
@@ -150,6 +153,9 @@ TEST_F(CheckerBoardLayerTest, ClipPathSaveLayerNotCheckBoard) {
            MockCanvas::DrawCall{
                1, MockCanvas::ClipRectData{layer_bounds, SkClipOp::kIntersect,
                                            MockCanvas::kSoft_ClipEdgeStyle}},
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+           MockCanvas::DrawCall{1, MockCanvas::SetMatrixData{SkM44()}},
+#endif
            MockCanvas::DrawCall{
                1,
                MockCanvas::SaveLayerData{child_bounds, clip_paint, nullptr, 2}},
@@ -232,6 +238,9 @@ TEST_F(CheckerBoardLayerTest, ClipRRectSaveLayerNotCheckBoard) {
            MockCanvas::DrawCall{
                1, MockCanvas::ClipRectData{layer_bounds, SkClipOp::kIntersect,
                                            MockCanvas::kSoft_ClipEdgeStyle}},
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+           MockCanvas::DrawCall{1, MockCanvas::SetMatrixData{SkM44()}},
+#endif
            MockCanvas::DrawCall{
                1,
                MockCanvas::SaveLayerData{child_bounds, clip_paint, nullptr, 2}},

--- a/flow/layers/clip_path_layer_unittests.cc
+++ b/flow/layers/clip_path_layer_unittests.cc
@@ -479,6 +479,11 @@ TEST_F(ClipPathLayerTest, OpacityInheritanceSaveLayerPainting) {
       /* ClipRectLayer::Paint() */ {
         expected_builder.save();
         expected_builder.clipPath(layer_clip, SkClipOp::kIntersect, true);
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+        /* ClipShapeLayer::Paint() Integer CTM */
+        expected_builder.transformReset();
+        expected_builder.transform(opacity_integer_transform);
+#endif
         expected_builder.setColor(opacity_alpha << 24);
         expected_builder.saveLayer(&children_bounds, true);
         /* child layer1 paint */ {

--- a/flow/layers/clip_rect_layer_unittests.cc
+++ b/flow/layers/clip_rect_layer_unittests.cc
@@ -469,6 +469,11 @@ TEST_F(ClipRectLayerTest, OpacityInheritanceSaveLayerPainting) {
       /* ClipRectLayer::Paint() */ {
         expected_builder.save();
         expected_builder.clipRect(clip_rect, SkClipOp::kIntersect, true);
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+        /* ClipShapeLayer::Paint() Integer CTM */
+        expected_builder.transformReset();
+        expected_builder.transform(opacity_integer_transform);
+#endif
         expected_builder.setColor(opacity_alpha << 24);
         expected_builder.saveLayer(&children_bounds, true);
         /* child layer1 paint */ {

--- a/flow/layers/clip_rrect_layer_unittests.cc
+++ b/flow/layers/clip_rrect_layer_unittests.cc
@@ -479,6 +479,11 @@ TEST_F(ClipRRectLayerTest, OpacityInheritanceSaveLayerPainting) {
       /* ClipRectLayer::Paint() */ {
         expected_builder.save();
         expected_builder.clipRRect(clip_r_rect, SkClipOp::kIntersect, true);
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+        /* ClipShapeLayer::Paint() Integer CTM */
+        expected_builder.transformReset();
+        expected_builder.transform(opacity_integer_transform);
+#endif
         expected_builder.setColor(opacity_alpha << 24);
         expected_builder.saveLayer(&children_bounds, true);
         /* child layer1 paint */ {

--- a/flow/layers/color_filter_layer.cc
+++ b/flow/layers/color_filter_layer.cc
@@ -19,6 +19,11 @@ void ColorFilterLayer::Diff(DiffContext* context, const Layer* old_layer) {
     }
   }
 
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+  context->SetTransform(
+      RasterCache::GetIntegralTransCTM(context->GetTransform()));
+#endif
+
   DiffChildren(context, prev);
 
   context->SetLayerPaintRegion(this, context->CurrentSubtreeRegion());
@@ -34,12 +39,17 @@ void ColorFilterLayer::Preroll(PrerollContext* context,
   // can always apply opacity in those cases.
   context->subtree_can_inherit_opacity = true;
 
+  SkMatrix child_matrix(matrix);
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+  child_matrix = RasterCache::GetIntegralTransCTM(child_matrix);
+#endif
+
   if (render_count_ >= kMinimumRendersBeforeCachingFilterLayer) {
-    TryToPrepareRasterCache(context, this, matrix,
+    TryToPrepareRasterCache(context, this, child_matrix,
                             RasterCacheLayerStrategy::kLayer);
   } else {
     render_count_++;
-    TryToPrepareRasterCache(context, this, matrix,
+    TryToPrepareRasterCache(context, this, child_matrix,
                             RasterCacheLayerStrategy::kLayerChildren);
   }
 }
@@ -49,6 +59,11 @@ void ColorFilterLayer::Paint(PaintContext& context) const {
   FML_DCHECK(needs_painting(context));
 
   AutoCachePaint cache_paint(context);
+
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+  context.internal_nodes_canvas->setMatrix(RasterCache::GetIntegralTransCTM(
+      context.leaf_nodes_canvas->getTotalMatrix()));
+#endif
 
   if (context.raster_cache) {
     if (context.raster_cache->Draw(this, *context.leaf_nodes_canvas,

--- a/flow/layers/color_filter_layer_unittests.cc
+++ b/flow/layers/color_filter_layer_unittests.cc
@@ -63,14 +63,17 @@ TEST_F(ColorFilterLayerTest, EmptyFilter) {
   SkPaint filter_paint;
   filter_paint.setColorFilter(nullptr);
   layer->Paint(paint_context());
-  EXPECT_EQ(
-      mock_canvas().draw_calls(),
-      std::vector({MockCanvas::DrawCall{
-                       0, MockCanvas::SaveLayerData{child_bounds, filter_paint,
-                                                    nullptr, 1}},
-                   MockCanvas::DrawCall{
-                       1, MockCanvas::DrawPathData{child_path, child_paint}},
-                   MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
+  EXPECT_EQ(mock_canvas().draw_calls(),
+            std::vector({
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+                MockCanvas::DrawCall{0, MockCanvas::SetMatrixData{SkM44()}},
+#endif
+                MockCanvas::DrawCall{
+                    0, MockCanvas::SaveLayerData{child_bounds, filter_paint,
+                                                 nullptr, 1}},
+                MockCanvas::DrawCall{
+                    1, MockCanvas::DrawPathData{child_path, child_paint}},
+                MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
 }
 
 TEST_F(ColorFilterLayerTest, SimpleFilter) {
@@ -93,14 +96,17 @@ TEST_F(ColorFilterLayerTest, SimpleFilter) {
   SkPaint filter_paint;
   filter_paint.setColorFilter(layer_filter);
   layer->Paint(paint_context());
-  EXPECT_EQ(
-      mock_canvas().draw_calls(),
-      std::vector({MockCanvas::DrawCall{
-                       0, MockCanvas::SaveLayerData{child_bounds, filter_paint,
-                                                    nullptr, 1}},
-                   MockCanvas::DrawCall{
-                       1, MockCanvas::DrawPathData{child_path, child_paint}},
-                   MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
+  EXPECT_EQ(mock_canvas().draw_calls(),
+            std::vector({
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+                MockCanvas::DrawCall{0, MockCanvas::SetMatrixData{SkM44()}},
+#endif
+                MockCanvas::DrawCall{
+                    0, MockCanvas::SaveLayerData{child_bounds, filter_paint,
+                                                 nullptr, 1}},
+                MockCanvas::DrawCall{
+                    1, MockCanvas::DrawPathData{child_path, child_paint}},
+                MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
 }
 
 TEST_F(ColorFilterLayerTest, MultipleChildren) {
@@ -135,16 +141,19 @@ TEST_F(ColorFilterLayerTest, MultipleChildren) {
   SkPaint filter_paint;
   filter_paint.setColorFilter(layer_filter);
   layer->Paint(paint_context());
-  EXPECT_EQ(
-      mock_canvas().draw_calls(),
-      std::vector({MockCanvas::DrawCall{
-                       0, MockCanvas::SaveLayerData{children_bounds,
-                                                    filter_paint, nullptr, 1}},
-                   MockCanvas::DrawCall{
-                       1, MockCanvas::DrawPathData{child_path1, child_paint1}},
-                   MockCanvas::DrawCall{
-                       1, MockCanvas::DrawPathData{child_path2, child_paint2}},
-                   MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
+  EXPECT_EQ(mock_canvas().draw_calls(),
+            std::vector({
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+                MockCanvas::DrawCall{0, MockCanvas::SetMatrixData{SkM44()}},
+#endif
+                MockCanvas::DrawCall{
+                    0, MockCanvas::SaveLayerData{children_bounds, filter_paint,
+                                                 nullptr, 1}},
+                MockCanvas::DrawCall{
+                    1, MockCanvas::DrawPathData{child_path1, child_paint1}},
+                MockCanvas::DrawCall{
+                    1, MockCanvas::DrawPathData{child_path2, child_paint2}},
+                MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
 }
 
 TEST_F(ColorFilterLayerTest, Nested) {
@@ -187,20 +196,26 @@ TEST_F(ColorFilterLayerTest, Nested) {
   filter_paint1.setColorFilter(layer_filter1);
   filter_paint2.setColorFilter(layer_filter2);
   layer1->Paint(paint_context());
-  EXPECT_EQ(
-      mock_canvas().draw_calls(),
-      std::vector({MockCanvas::DrawCall{
-                       0, MockCanvas::SaveLayerData{children_bounds,
-                                                    filter_paint1, nullptr, 1}},
-                   MockCanvas::DrawCall{
-                       1, MockCanvas::DrawPathData{child_path1, child_paint1}},
-                   MockCanvas::DrawCall{
-                       1, MockCanvas::SaveLayerData{child_path2.getBounds(),
-                                                    filter_paint2, nullptr, 2}},
-                   MockCanvas::DrawCall{
-                       2, MockCanvas::DrawPathData{child_path2, child_paint2}},
-                   MockCanvas::DrawCall{2, MockCanvas::RestoreData{1}},
-                   MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
+  EXPECT_EQ(mock_canvas().draw_calls(),
+            std::vector({
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+                MockCanvas::DrawCall{0, MockCanvas::SetMatrixData{SkM44()}},
+#endif
+                MockCanvas::DrawCall{
+                    0, MockCanvas::SaveLayerData{children_bounds, filter_paint1,
+                                                 nullptr, 1}},
+                MockCanvas::DrawCall{
+                    1, MockCanvas::DrawPathData{child_path1, child_paint1}},
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+                MockCanvas::DrawCall{1, MockCanvas::SetMatrixData{SkM44()}},
+#endif
+                MockCanvas::DrawCall{
+                    1, MockCanvas::SaveLayerData{child_path2.getBounds(),
+                                                 filter_paint2, nullptr, 2}},
+                MockCanvas::DrawCall{
+                    2, MockCanvas::DrawPathData{child_path2, child_paint2}},
+                MockCanvas::DrawCall{2, MockCanvas::RestoreData{1}},
+                MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
 }
 
 TEST_F(ColorFilterLayerTest, Readback) {
@@ -356,19 +371,22 @@ TEST_F(ColorFilterLayerTest, OpacityInheritance) {
       SkMatrix::Translate(offset.fX, offset.fY));
 #endif
   DisplayListBuilder expected_builder;
-  /* opacity_layer::Paint() */ {
+  /* OpacityLayer::Paint() */ {
     expected_builder.save();
     {
       expected_builder.translate(offset.fX, offset.fY);
 #ifndef SUPPORT_FRACTIONAL_TRANSLATION
       expected_builder.transformReset();
       expected_builder.transform(opacity_integer_transform);
+      /* Integer CTM in ColorFilterLayer::Paint() */
+      expected_builder.transformReset();
+      expected_builder.transform(opacity_integer_transform);
 #endif
-      /* image_filter_layer::Paint() */ {
+      /* ColorFilterLayer::Paint() */ {
         expected_builder.setColor(opacity_alpha << 24);
         expected_builder.setColorFilter(&layer_filter);
         expected_builder.saveLayer(&child_path.getBounds(), true);
-        /* mock_layer::Paint() */ {
+        /* MockLayer::Paint() */ {
           expected_builder.setColor(0xFF000000);
           expected_builder.setColorFilter(nullptr);
           expected_builder.drawPath(child_path);

--- a/flow/layers/shader_mask_layer_unittests.cc
+++ b/flow/layers/shader_mask_layer_unittests.cc
@@ -71,20 +71,22 @@ TEST_F(ShaderMaskLayerTest, EmptyFilter) {
   layer->Paint(paint_context());
   EXPECT_EQ(
       mock_canvas().draw_calls(),
-      std::vector({MockCanvas::DrawCall{
-                       0, MockCanvas::SaveLayerData{child_bounds, SkPaint(),
-                                                    nullptr, 1}},
-                   MockCanvas::DrawCall{
-                       1, MockCanvas::DrawPathData{child_path, child_paint}},
-                   MockCanvas::DrawCall{
-                       1, MockCanvas::ConcatMatrixData{SkM44::Translate(
-                              layer_bounds.fLeft, layer_bounds.fTop)}},
-                   MockCanvas::DrawCall{
-                       1, MockCanvas::DrawRectData{SkRect::MakeWH(
-                                                       layer_bounds.width(),
-                                                       layer_bounds.height()),
-                                                   filter_paint}},
-                   MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
+      std::vector({
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+          MockCanvas::DrawCall{0, MockCanvas::SetMatrixData{SkM44()}},
+#endif
+          MockCanvas::DrawCall{
+              0,
+              MockCanvas::SaveLayerData{child_bounds, SkPaint(), nullptr, 1}},
+          MockCanvas::DrawCall{
+              1, MockCanvas::DrawPathData{child_path, child_paint}},
+          MockCanvas::DrawCall{1, MockCanvas::ConcatMatrixData{SkM44::Translate(
+                                      layer_bounds.fLeft, layer_bounds.fTop)}},
+          MockCanvas::DrawCall{
+              1, MockCanvas::DrawRectData{SkRect::MakeWH(layer_bounds.width(),
+                                                         layer_bounds.height()),
+                                          filter_paint}},
+          MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
 }
 
 TEST_F(ShaderMaskLayerTest, SimpleFilter) {
@@ -112,20 +114,22 @@ TEST_F(ShaderMaskLayerTest, SimpleFilter) {
   layer->Paint(paint_context());
   EXPECT_EQ(
       mock_canvas().draw_calls(),
-      std::vector({MockCanvas::DrawCall{
-                       0, MockCanvas::SaveLayerData{child_bounds, SkPaint(),
-                                                    nullptr, 1}},
-                   MockCanvas::DrawCall{
-                       1, MockCanvas::DrawPathData{child_path, child_paint}},
-                   MockCanvas::DrawCall{
-                       1, MockCanvas::ConcatMatrixData{SkM44::Translate(
-                              layer_bounds.fLeft, layer_bounds.fTop)}},
-                   MockCanvas::DrawCall{
-                       1, MockCanvas::DrawRectData{SkRect::MakeWH(
-                                                       layer_bounds.width(),
-                                                       layer_bounds.height()),
-                                                   filter_paint}},
-                   MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
+      std::vector({
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+          MockCanvas::DrawCall{0, MockCanvas::SetMatrixData{SkM44()}},
+#endif
+          MockCanvas::DrawCall{
+              0,
+              MockCanvas::SaveLayerData{child_bounds, SkPaint(), nullptr, 1}},
+          MockCanvas::DrawCall{
+              1, MockCanvas::DrawPathData{child_path, child_paint}},
+          MockCanvas::DrawCall{1, MockCanvas::ConcatMatrixData{SkM44::Translate(
+                                      layer_bounds.fLeft, layer_bounds.fTop)}},
+          MockCanvas::DrawCall{
+              1, MockCanvas::DrawRectData{SkRect::MakeWH(layer_bounds.width(),
+                                                         layer_bounds.height()),
+                                          filter_paint}},
+          MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
 }
 
 TEST_F(ShaderMaskLayerTest, MultipleChildren) {
@@ -165,22 +169,24 @@ TEST_F(ShaderMaskLayerTest, MultipleChildren) {
   layer->Paint(paint_context());
   EXPECT_EQ(
       mock_canvas().draw_calls(),
-      std::vector({MockCanvas::DrawCall{
-                       0, MockCanvas::SaveLayerData{children_bounds, SkPaint(),
-                                                    nullptr, 1}},
-                   MockCanvas::DrawCall{
-                       1, MockCanvas::DrawPathData{child_path1, child_paint1}},
-                   MockCanvas::DrawCall{
-                       1, MockCanvas::DrawPathData{child_path2, child_paint2}},
-                   MockCanvas::DrawCall{
-                       1, MockCanvas::ConcatMatrixData{SkM44::Translate(
-                              layer_bounds.fLeft, layer_bounds.fTop)}},
-                   MockCanvas::DrawCall{
-                       1, MockCanvas::DrawRectData{SkRect::MakeWH(
-                                                       layer_bounds.width(),
-                                                       layer_bounds.height()),
-                                                   filter_paint}},
-                   MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
+      std::vector({
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+          MockCanvas::DrawCall{0, MockCanvas::SetMatrixData{SkM44()}},
+#endif
+          MockCanvas::DrawCall{
+              0, MockCanvas::SaveLayerData{children_bounds, SkPaint(), nullptr,
+                                           1}},
+          MockCanvas::DrawCall{
+              1, MockCanvas::DrawPathData{child_path1, child_paint1}},
+          MockCanvas::DrawCall{
+              1, MockCanvas::DrawPathData{child_path2, child_paint2}},
+          MockCanvas::DrawCall{1, MockCanvas::ConcatMatrixData{SkM44::Translate(
+                                      layer_bounds.fLeft, layer_bounds.fTop)}},
+          MockCanvas::DrawCall{
+              1, MockCanvas::DrawRectData{SkRect::MakeWH(layer_bounds.width(),
+                                                         layer_bounds.height()),
+                                          filter_paint}},
+          MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
 }
 
 TEST_F(ShaderMaskLayerTest, Nested) {
@@ -230,35 +236,37 @@ TEST_F(ShaderMaskLayerTest, Nested) {
   layer1->Paint(paint_context());
   EXPECT_EQ(
       mock_canvas().draw_calls(),
-      std::vector(
-          {MockCanvas::DrawCall{
-               0, MockCanvas::SaveLayerData{children_bounds, SkPaint(), nullptr,
-                                            1}},
-           MockCanvas::DrawCall{
-               1, MockCanvas::DrawPathData{child_path1, child_paint1}},
-           MockCanvas::DrawCall{
-               1, MockCanvas::SaveLayerData{child_path2.getBounds(), SkPaint(),
-                                            nullptr, 2}},
-           MockCanvas::DrawCall{
-               2, MockCanvas::DrawPathData{child_path2, child_paint2}},
-           MockCanvas::DrawCall{2,
-                                MockCanvas::ConcatMatrixData{SkM44::Translate(
-                                    layer_bounds.fLeft, layer_bounds.fTop)}},
-           MockCanvas::DrawCall{
-               2,
-               MockCanvas::DrawRectData{
-                   SkRect::MakeWH(layer_bounds.width(), layer_bounds.height()),
-                   filter_paint2}},
-           MockCanvas::DrawCall{2, MockCanvas::RestoreData{1}},
-           MockCanvas::DrawCall{1,
-                                MockCanvas::ConcatMatrixData{SkM44::Translate(
-                                    layer_bounds.fLeft, layer_bounds.fTop)}},
-           MockCanvas::DrawCall{
-               1,
-               MockCanvas::DrawRectData{
-                   SkRect::MakeWH(layer_bounds.width(), layer_bounds.height()),
-                   filter_paint1}},
-           MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
+      std::vector({
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+          MockCanvas::DrawCall{0, MockCanvas::SetMatrixData{SkM44()}},
+#endif
+          MockCanvas::DrawCall{
+              0, MockCanvas::SaveLayerData{children_bounds, SkPaint(), nullptr,
+                                           1}},
+          MockCanvas::DrawCall{
+              1, MockCanvas::DrawPathData{child_path1, child_paint1}},
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+          MockCanvas::DrawCall{1, MockCanvas::SetMatrixData{SkM44()}},
+#endif
+          MockCanvas::DrawCall{
+              1, MockCanvas::SaveLayerData{child_path2.getBounds(), SkPaint(),
+                                           nullptr, 2}},
+          MockCanvas::DrawCall{
+              2, MockCanvas::DrawPathData{child_path2, child_paint2}},
+          MockCanvas::DrawCall{2, MockCanvas::ConcatMatrixData{SkM44::Translate(
+                                      layer_bounds.fLeft, layer_bounds.fTop)}},
+          MockCanvas::DrawCall{
+              2, MockCanvas::DrawRectData{SkRect::MakeWH(layer_bounds.width(),
+                                                         layer_bounds.height()),
+                                          filter_paint2}},
+          MockCanvas::DrawCall{2, MockCanvas::RestoreData{1}},
+          MockCanvas::DrawCall{1, MockCanvas::ConcatMatrixData{SkM44::Translate(
+                                      layer_bounds.fLeft, layer_bounds.fTop)}},
+          MockCanvas::DrawCall{
+              1, MockCanvas::DrawRectData{SkRect::MakeWH(layer_bounds.width(),
+                                                         layer_bounds.height()),
+                                          filter_paint1}},
+          MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
 }
 
 TEST_F(ShaderMaskLayerTest, Readback) {
@@ -352,6 +360,9 @@ TEST_F(ShaderMaskLayerTest, OpacityInheritance) {
     {
       expected_builder.translate(offset.fX, offset.fY);
 #ifndef SUPPORT_FRACTIONAL_TRANSLATION
+      expected_builder.transformReset();
+      expected_builder.transform(opacity_integer_transform);
+      /* Integer CTM in ShaderMaskLayer::Paint() */
       expected_builder.transformReset();
       expected_builder.transform(opacity_integer_transform);
 #endif


### PR DESCRIPTION
Layers that use raster cache should be painted at identical position regardless of whether they're raster cached or not. Otherwise the position calculated during Diff pass may be subtly wrong resulting in artefacts.

Also because rater cached layer is currently always painted on pixel boundaries, any layer using raster cache should snap the CTM to integer when painting uncached children to match the behavior.

Fixes https://github.com/flutter/flutter/issues/105674

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
