### PR TITLE
Disable compressed pointers on iOS.

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -508,9 +508,10 @@ def to_gn_args(args):
       sys.exit(1)
     gn_args['enable_vulkan_validation_layers'] = True
 
-  # Enable pointer compression on 64-bit mobile targets.
-  if args.target_os in ['android', 'ios'
-                       ] and gn_args['target_cpu'] in ['x64', 'arm64']:
+  # Enable pointer compression on 64-bit mobile targets. iOS is excluded due to
+  # its inability to allocate address space without allocating memory.
+  if args.target_os in ['android'] and gn_args['target_cpu'] in ['x64', 'arm64'
+                                                                ]:
     gn_args['dart_use_compressed_pointers'] = True
 
   if args.fuchsia_target_api_level is not None:


### PR DESCRIPTION
Because we are unable to allocate address space without also allocating memory, even unused portions of the compressed heap make less memory available to all other allocators in the process. The memory savings in the compressed heap will only out-weight the lost memory for other allocations if nearly all of the application's memory usage is in Dart, rather than, say, graphics or plugins.

Bug: https://github.com/flutter/flutter/issues/105183
Bug: b/235279083