### PR TITLE
dont pixel snap raster cache if SUPPORT_FRACTIONAL_TRANSLATION is enabled

### DIFF
--- a/flow/layer_snapshot_store.cc
+++ b/flow/layer_snapshot_store.cc
@@ -12,7 +12,7 @@ namespace flutter {
 LayerSnapshotData::LayerSnapshotData(int64_t layer_unique_id,
                                      const fml::TimeDelta& duration,
                                      const sk_sp<SkData>& snapshot,
-                                     const SkIRect& bounds)
+                                     const SkRect& bounds)
     : layer_unique_id_(layer_unique_id),
       duration_(duration),
       snapshot_(snapshot),

--- a/flow/layer_snapshot_store.h
+++ b/flow/layer_snapshot_store.h
@@ -26,7 +26,7 @@ class LayerSnapshotData {
   LayerSnapshotData(int64_t layer_unique_id,
                     const fml::TimeDelta& duration,
                     const sk_sp<SkData>& snapshot,
-                    const SkIRect& bounds);
+                    const SkRect& bounds);
 
   ~LayerSnapshotData() = default;
 
@@ -36,13 +36,13 @@ class LayerSnapshotData {
 
   sk_sp<SkData> GetSnapshot() const { return snapshot_; }
 
-  SkIRect GetBounds() const { return bounds_; }
+  SkRect GetBounds() const { return bounds_; }
 
  private:
   const int64_t layer_unique_id_;
   const fml::TimeDelta duration_;
   const sk_sp<SkData> snapshot_;
-  const SkIRect bounds_;
+  const SkRect bounds_;
 };
 
 /// Collects snapshots of layers during frame rasterization.

--- a/flow/layers/color_filter_layer.cc
+++ b/flow/layers/color_filter_layer.cc
@@ -25,20 +25,21 @@ void ColorFilterLayer::Diff(DiffContext* context, const Layer* old_layer) {
 #endif
 
   DiffChildren(context, prev);
+
   context->SetLayerPaintRegion(this, context->CurrentSubtreeRegion());
 }
 
 void ColorFilterLayer::Preroll(PrerollContext* context,
                                const SkMatrix& matrix) {
-  auto child_matrix = matrix;
   Layer::AutoPrerollSaveLayerState save =
       Layer::AutoPrerollSaveLayerState::Create(context);
-  ContainerLayer::Preroll(context, child_matrix);
+  ContainerLayer::Preroll(context, matrix);
 
   // We always use a saveLayer (or a cached rendering), so we
   // can always apply opacity in those cases.
   context->subtree_can_inherit_opacity = true;
 
+  SkMatrix child_matrix(matrix);
 #ifndef SUPPORT_FRACTIONAL_TRANSLATION
   child_matrix = RasterCache::GetIntegralTransCTM(child_matrix);
 #endif

--- a/flow/layers/display_list_layer.cc
+++ b/flow/layers/display_list_layer.cc
@@ -155,7 +155,7 @@ void DisplayListLayer::Paint(PaintContext& context) const {
     const fml::TimeDelta offscreen_render_time =
         fml::TimePoint::Now() - start_time;
 
-    const SkIRect device_bounds =
+    const SkRect device_bounds =
         RasterCache::GetDeviceBounds(paint_bounds(), ctm);
     sk_sp<SkData> raster_data = offscreen_surface->GetRasterData(true);
     LayerSnapshotData snapshot_data(unique_id(), offscreen_render_time,

--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -128,11 +128,11 @@ static std::unique_ptr<RasterCacheResult> Rasterize(
 
   SkRect dest_rect = RasterCache::GetDeviceBounds(logical_rect, ctm);
   // we always round out here so that the texture is integer sized.
-  SkIRect cache_rect;
-  dest_rect.roundOut(&cache_rect);
+  int width = SkScalarCeilToInt(dest_rect.width());
+  int height = SkScalarCeilToInt(dest_rect.height());
 
-  const SkImageInfo image_info = SkImageInfo::MakeN32Premul(
-      cache_rect.width(), cache_rect.height(), sk_ref_sp(dst_color_space));
+  const SkImageInfo image_info =
+      SkImageInfo::MakeN32Premul(width, height, sk_ref_sp(dst_color_space));
 
   sk_sp<SkSurface> surface =
       context

--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -126,7 +126,10 @@ static std::unique_ptr<RasterCacheResult> Rasterize(
     const std::function<void(SkCanvas*)>& draw_function) {
   TRACE_EVENT0("flutter", "RasterCachePopulate");
 
-  SkRect cache_rect = RasterCache::GetDeviceBounds(logical_rect, ctm);
+  SkRect dest_rect = RasterCache::GetDeviceBounds(logical_rect, ctm);
+  // we always round out here so that the texture is integer sized.
+  SkIRect cache_rect;
+  dest_rect.roundOut(&cache_rect);
 
   const SkImageInfo image_info = SkImageInfo::MakeN32Premul(
       cache_rect.width(), cache_rect.height(), sk_ref_sp(dst_color_space));
@@ -142,7 +145,7 @@ static std::unique_ptr<RasterCacheResult> Rasterize(
 
   SkCanvas* canvas = surface->getCanvas();
   canvas->clear(SK_ColorTRANSPARENT);
-  canvas->translate(-cache_rect.left(), -cache_rect.top());
+  canvas->translate(-dest_rect.left(), -dest_rect.top());
   canvas->concat(ctm);
   draw_function(canvas);
 

--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -29,11 +29,11 @@ RasterCacheResult::RasterCacheResult(sk_sp<SkImage> image,
 void RasterCacheResult::draw(SkCanvas& canvas, const SkPaint* paint) const {
   TRACE_EVENT0("flutter", "RasterCacheResult::draw");
   SkAutoCanvasRestore auto_restore(&canvas, true);
-  SkIRect bounds =
+
+  SkRect bounds =
       RasterCache::GetDeviceBounds(logical_rect_, canvas.getTotalMatrix());
-  FML_DCHECK(
-      std::abs(bounds.size().width() - image_->dimensions().width()) <= 1 &&
-      std::abs(bounds.size().height() - image_->dimensions().height()) <= 1);
+  FML_DCHECK(std::abs(bounds.width() - image_->dimensions().width()) <= 1 &&
+             std::abs(bounds.height() - image_->dimensions().height()) <= 1);
   canvas.resetMatrix();
   flow_.Step();
   canvas.drawImage(image_, bounds.fLeft, bounds.fTop, SkSamplingOptions(),
@@ -125,7 +125,8 @@ static std::unique_ptr<RasterCacheResult> Rasterize(
     const char* type,
     const std::function<void(SkCanvas*)>& draw_function) {
   TRACE_EVENT0("flutter", "RasterCachePopulate");
-  SkIRect cache_rect = RasterCache::GetDeviceBounds(logical_rect, ctm);
+
+  SkRect cache_rect = RasterCache::GetDeviceBounds(logical_rect, ctm);
 
   const SkImageInfo image_info = SkImageInfo::MakeN32Premul(
       cache_rect.width(), cache_rect.height(), sk_ref_sp(dst_color_space));

--- a/flow/raster_cache.h
+++ b/flow/raster_cache.h
@@ -153,13 +153,9 @@ class RasterCache {
     SkRect device_rect;
     ctm.mapRect(&device_rect, rect);
 #ifndef SUPPORT_FRACTIONAL_TRANSLATION
-    SkIRect bounds;
-    device_rect.roundOut(&bounds);
-    return SkRect::MakeLTRB(bounds.fLeft, bounds.fTop, bounds.fRight,
-                            bounds.fBottom);
-#else
-    return device_rect;
+    device_rect.roundOut(&device_rect);
 #endif
+    return device_rect;
   }
 
   /**

--- a/flow/raster_cache.h
+++ b/flow/raster_cache.h
@@ -150,16 +150,14 @@ class RasterCache {
       bool checkerboard) const;
 
   static SkRect GetDeviceBounds(const SkRect& rect, const SkMatrix& ctm) {
-#ifndef SUPPORT_FRACTIONAL_TRANSLATION
     SkRect device_rect;
     ctm.mapRect(&device_rect, rect);
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
     SkIRect bounds;
     device_rect.roundOut(&bounds);
     return SkRect::MakeLTRB(bounds.fLeft, bounds.fTop, bounds.fRight,
                             bounds.fBottom);
 #else
-    SkRect device_rect;
-    ctm.mapRect(&device_rect, rect);
     return device_rect;
 #endif
   }

--- a/flow/raster_cache.h
+++ b/flow/raster_cache.h
@@ -256,12 +256,8 @@ class RasterCache {
 
   void SetCheckboardCacheImages(bool checkerboard);
 
-  const RasterCacheMetrics& picture_metrics() const {
-    return picture_metrics_;
-  }
-  const RasterCacheMetrics& layer_metrics() const {
-    return layer_metrics_;
-  }
+  const RasterCacheMetrics& picture_metrics() const { return picture_metrics_; }
+  const RasterCacheMetrics& layer_metrics() const { return layer_metrics_; }
 
   size_t GetCachedEntriesCount() const;
 
@@ -307,9 +303,7 @@ class RasterCache {
    * If the number is one, then it must be prepared and drawn on 1 frame
    * and it will then be cached on the next frame if it is prepared.
    */
-  int access_threshold() const {
-    return access_threshold_;
-  }
+  int access_threshold() const { return access_threshold_; }
 
  private:
   struct Entry {

--- a/flow/raster_cache.h
+++ b/flow/raster_cache.h
@@ -149,12 +149,19 @@ class RasterCache {
       const SkMatrix& ctm,
       bool checkerboard) const;
 
-  static SkIRect GetDeviceBounds(const SkRect& rect, const SkMatrix& ctm) {
+  static SkRect GetDeviceBounds(const SkRect& rect, const SkMatrix& ctm) {
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
     SkRect device_rect;
     ctm.mapRect(&device_rect, rect);
     SkIRect bounds;
     device_rect.roundOut(&bounds);
-    return bounds;
+    return SkRect::MakeLTRB(bounds.fLeft, bounds.fTop, bounds.fRight,
+                            bounds.fBottom);
+#else
+    SkRect device_rect;
+    ctm.mapRect(&device_rect, rect);
+    return device_rect;
+#endif
   }
 
   /**
@@ -249,8 +256,12 @@ class RasterCache {
 
   void SetCheckboardCacheImages(bool checkerboard);
 
-  const RasterCacheMetrics& picture_metrics() const { return picture_metrics_; }
-  const RasterCacheMetrics& layer_metrics() const { return layer_metrics_; }
+  const RasterCacheMetrics& picture_metrics() const {
+    return picture_metrics_;
+  }
+  const RasterCacheMetrics& layer_metrics() const {
+    return layer_metrics_;
+  }
 
   size_t GetCachedEntriesCount() const;
 
@@ -296,7 +307,9 @@ class RasterCache {
    * If the number is one, then it must be prepared and drawn on 1 frame
    * and it will then be cached on the next frame if it is prepared.
    */
-  int access_threshold() const { return access_threshold_; }
+  int access_threshold() const {
+    return access_threshold_;
+  }
 
  private:
   struct Entry {

--- a/flow/raster_cache_unittests.cc
+++ b/flow/raster_cache_unittests.cc
@@ -330,6 +330,19 @@ TEST(RasterCache, DeviceRectRoundOutForSkPicture) {
   ASSERT_TRUE(cache.Draw(*picture, canvas));
 }
 
+// The device rect is pixel snapped if SUPPORT_FRACTIONAL_TRANSLATION
+// is disabled.
+TEST(RasterCache, ComputeDeviceRectBasedOnFractionalTranslation) {
+  SkRect logical_rect = SkRect::MakeLTRB(0, 0, 300.2, 300.3);
+  SkMatrix ctm = SkMatrix::MakeAll(2.0, 0, 0, 0, 2.0, 0, 0, 0, 1);
+  auto result = RasterCache::GetDeviceBounds(logical_rect, ctm);
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+  ASSERT_EQ(result, SkRect::MakeLTRB(0.0, 0.0, 601.0, 601.0));
+#else
+  ASSERT_EQ(result, SkRect::MakeLTRB(0.0, 0.0, 600.4, 600.6));
+#endif
+}
+
 // Construct a cache result whose device target rectangle rounds out to be one
 // pixel wider than the cached image.  Verify that it can be drawn without
 // triggering any assertions.

--- a/flow/testing/mock_raster_cache.cc
+++ b/flow/testing/mock_raster_cache.cc
@@ -9,7 +9,7 @@
 namespace flutter {
 namespace testing {
 
-MockRasterCacheResult::MockRasterCacheResult(SkIRect device_rect)
+MockRasterCacheResult::MockRasterCacheResult(SkRect device_rect)
     : RasterCacheResult(nullptr, SkRect::MakeEmpty(), "RasterCacheFlow::test"),
       device_rect_(device_rect) {}
 
@@ -20,7 +20,7 @@ std::unique_ptr<RasterCacheResult> MockRasterCache::RasterizePicture(
     SkColorSpace* dst_color_space,
     bool checkerboard) const {
   SkRect logical_rect = picture->cullRect();
-  SkIRect cache_rect = RasterCache::GetDeviceBounds(logical_rect, ctm);
+  SkRect cache_rect = RasterCache::GetDeviceBounds(logical_rect, ctm);
 
   return std::make_unique<MockRasterCacheResult>(cache_rect);
 }
@@ -32,7 +32,7 @@ std::unique_ptr<RasterCacheResult> MockRasterCache::RasterizeDisplayList(
     SkColorSpace* dst_color_space,
     bool checkerboard) const {
   SkRect logical_rect = display_list->bounds();
-  SkIRect cache_rect = RasterCache::GetDeviceBounds(logical_rect, ctm);
+  SkRect cache_rect = RasterCache::GetDeviceBounds(logical_rect, ctm);
 
   return std::make_unique<MockRasterCacheResult>(cache_rect);
 }
@@ -44,7 +44,7 @@ std::unique_ptr<RasterCacheResult> MockRasterCache::RasterizeLayer(
     const SkMatrix& ctm,
     bool checkerboard) const {
   SkRect logical_rect = layer->paint_bounds();
-  SkIRect cache_rect = RasterCache::GetDeviceBounds(logical_rect, ctm);
+  SkRect cache_rect = RasterCache::GetDeviceBounds(logical_rect, ctm);
 
   return std::make_unique<MockRasterCacheResult>(cache_rect);
 }

--- a/flow/testing/mock_raster_cache.h
+++ b/flow/testing/mock_raster_cache.h
@@ -26,11 +26,13 @@ namespace testing {
  */
 class MockRasterCacheResult : public RasterCacheResult {
  public:
-  explicit MockRasterCacheResult(SkIRect device_rect);
+  explicit MockRasterCacheResult(SkRect device_rect);
 
   void draw(SkCanvas& canvas, const SkPaint* paint = nullptr) const override{};
 
-  SkISize image_dimensions() const override { return device_rect_.size(); };
+  SkISize image_dimensions() const override {
+    return SkSize::Make(device_rect_.width(), device_rect_.height()).toCeil();
+};
 
   int64_t image_bytes() const override {
     return image_dimensions().area() *
@@ -38,7 +40,7 @@ class MockRasterCacheResult : public RasterCacheResult {
   }
 
  private:
-  SkIRect device_rect_;
+  SkRect device_rect_;
 };
 
 /**

--- a/flow/testing/mock_raster_cache.h
+++ b/flow/testing/mock_raster_cache.h
@@ -32,7 +32,7 @@ class MockRasterCacheResult : public RasterCacheResult {
 
   SkISize image_dimensions() const override {
     return SkSize::Make(device_rect_.width(), device_rect_.height()).toCeil();
-};
+  };
 
   int64_t image_bytes() const override {
     return image_dimensions().area() *

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -1819,7 +1819,7 @@ static rapidjson::Value SerializeLayerSnapshot(
   result.AddMember("duration_micros", snapshot.GetDuration().ToMicroseconds(),
                    allocator);
 
-  const SkIRect bounds = snapshot.GetBounds();
+  const SkRect bounds = snapshot.GetBounds();
   result.AddMember("top", bounds.top(), allocator);
   result.AddMember("left", bounds.left(), allocator);
   result.AddMember("width", bounds.width(), allocator);


### PR DESCRIPTION
Required to support https://github.com/flutter/flutter/issues/103909

When drawing from the raster cache, the engine unconditionally snaps to physical pixels. If we want to enable SUPPORT_FRACTIONAL_TRANSLATION , this will be incorrect.

Remove the round out when SUPPORT_FRACTIONAL_TRANSLATION , change several APIs that accept SKIRect to SkRect