### PR TITLE
[web] Use Canvas2d to measure text height

### DIFF
--- a/lib/web_ui/lib/src/engine/dom.dart
+++ b/lib/web_ui/lib/src/engine/dom.dart
@@ -656,6 +656,10 @@ DomText createDomText(String data) => domDocument.createTextNode(data);
 class DomTextMetrics {}
 
 extension DomTextMetricsExtension on DomTextMetrics {
+  external num? get actualBoundingBoxAscent;
+  external num? get actualBoundingBoxDescent;
+  external num? get fontBoundingBoxAscent;
+  external num? get fontBoundingBoxDescent;
   external num? get width;
 }
 

--- a/lib/web_ui/lib/src/engine/text/canvas_paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/canvas_paragraph.dart
@@ -256,7 +256,7 @@ class CanvasParagraph implements ui.Paragraph {
   }
 }
 
-void _positionSpanElement(DomElement element, ParagraphLine line, RangeBox box) {
+void _positionSpanElement(DomElement element, ParagraphLine line, SpanBox box) {
   final ui.Rect boxRect = box.toTextBox(line, forPainting: true).toRect();
   element.style
     ..position = 'absolute'

--- a/lib/web_ui/lib/src/engine/text/font_collection.dart
+++ b/lib/web_ui/lib/src/engine/text/font_collection.dart
@@ -205,10 +205,10 @@ class FontManager {
     final DomFontFace fontFace = createDomFontFace(family, list);
     return fontFace.load().then((_) {
       domDocument.fonts!.add(fontFace);
-      // There might be paragraph measurements for this new font before it is
-      // loaded. They were measured using fallback font, so we should clear the
-      // cache.
-      Spanometer.clearRulersCache();
+      // // There might be paragraph measurements for this new font before it is
+      // // loaded. They were measured using fallback font, so we should clear the
+      // // cache.
+      // Spanometer.clearRulersCache();
     }, onError: (dynamic exception) {
       // Failures here will throw an DomException which confusingly
       // does not implement Exception or Error. Rethrow an Exception so it can

--- a/lib/web_ui/lib/src/engine/text/measurement.dart
+++ b/lib/web_ui/lib/src/engine/text/measurement.dart
@@ -7,6 +7,10 @@ import 'dart:html' as html;
 import '../../engine.dart' show registerHotRestartListener;
 import '../dom.dart';
 import '../embedder.dart';
+import 'canvas_paragraph.dart';
+import 'line_breaker.dart';
+import 'paragraph.dart';
+import 'ruler.dart';
 
 // TODO(yjbanov): this is a hack we use to compute ideographic baseline; this
 //                number is the ratio ideographic/alphabetic for font Ahem,
@@ -123,5 +127,248 @@ double measureSubstring(
 }
 
 double _roundWidth(double width) {
+  // What we are doing here is we are rounding to the nearest 2nd decimal
+  // point. So 39.999423 becomes 40, and 11.243982 becomes 11.24.
+  // The reason we are doing this is because we noticed that canvas API has a
+  // ±0.001 error margin.
   return (width * 100).round() / 100;
+}
+
+/// Immutable data class that holds measurement results for a piece of text.
+class TextMetrics {
+  const TextMetrics._({
+    required this.ascent,
+    required this.descent,
+    required this.textAscent,
+    required this.textDescent,
+    required this.widthExcludingTrailingSpaces,
+    required this.widthIncludingTrailingSpaces,
+  });
+
+  factory TextMetrics._fromCanvasTextMetrics({
+    required DomTextMetrics excludingTrailingSpaces,
+    required DomTextMetrics includingTrailingSpaces,
+    required EngineTextStyle style,
+  }) {
+    final num height = style.height != null
+        ? (style.height! * style.fontSize!)
+        : (excludingTrailingSpaces.fontBoundingBoxAscent! +
+            excludingTrailingSpaces.fontBoundingBoxDescent!);
+
+    print('fullHeight: $height');
+
+    print('ratio (line-height?): ${height / style.fontSize!}');
+
+    final double textAscent = excludingTrailingSpaces.actualBoundingBoxAscent!.toDouble();
+    final double textDescent = excludingTrailingSpaces.actualBoundingBoxDescent!.toDouble();
+
+    // Divide the extra height equally between ascent and descent.
+    final double extraHeight = height - (textAscent + textDescent);
+    final double ascent = textAscent + extraHeight / 2;
+    final double descent = height - ascent;
+
+    return TextMetrics._(
+      ascent: ascent,
+      descent: descent,
+      textAscent: textAscent,
+      textDescent: textDescent,
+      widthExcludingTrailingSpaces:
+          _roundWidth(excludingTrailingSpaces.width!.toDouble()),
+      widthIncludingTrailingSpaces:
+          _roundWidth(includingTrailingSpaces.width!.toDouble()),
+    );
+  }
+
+  factory TextMetrics.forPlaceholder({
+    required PlaceholderSpan placeholder,
+    required double ascent,
+    required double descent,
+  }) {
+    assert(placeholder.height == ascent + descent);
+    return TextMetrics._(
+      ascent: ascent,
+      descent: descent,
+      textAscent: ascent,
+      textDescent: descent,
+      widthExcludingTrailingSpaces: placeholder.width,
+      widthIncludingTrailingSpaces: placeholder.width,
+    );
+  }
+
+  static const TextMetrics zero = TextMetrics._(
+    ascent: 0,
+    descent: 0,
+    textAscent: 0,
+    textDescent: 0,
+    widthExcludingTrailingSpaces: 0,
+    widthIncludingTrailingSpaces: 0,
+  );
+
+  /// The rise from the baseline as calculated from the font and style for this text.
+  final double ascent;
+
+  /// The drop from the baseline as calculated from the font and style for this text.
+  final double descent;
+
+  /// The rise from the baseline to the top of the bounding box of the measured text.
+  final double textAscent;
+
+  /// The drop from the baseline to the bottom of the bounding box of the measured text.
+  final double textDescent;
+
+  /// The width of the measured text, not including trailing spaces.
+  final double widthExcludingTrailingSpaces;
+
+  /// The width of the measured text, including any trailing spaces.
+  final double widthIncludingTrailingSpaces;
+
+  /// The width of trailing spaces in the measured text.
+  double get widthOfTrailingSpaces => widthIncludingTrailingSpaces - widthExcludingTrailingSpaces;
+
+  /// The total height as calculated from the font and style for this text.
+  double get height => ascent + descent;
+
+  /// The height of the measured text's bounding box.
+  double get textHeight => textAscent + textDescent;
+}
+
+/// Helper class that measures text in isolation and provides caching for better
+/// performance.
+class CachedMeasurements {
+  CachedMeasurements(this._canvasContext);
+
+  final DomCanvasRenderingContext2D _canvasContext;
+
+  /// A cache that maps: style -> text -> TextMetrics
+  final Map<String, Map<String, TextMetrics>> _cache =
+      <String, Map<String, TextMetrics>>{};
+
+  /// Measures the range of text between two line break results.
+  TextMetrics measureRange(
+    String text,
+    EngineTextStyle style,
+    LineBreakResult start,
+    LineBreakResult end,
+  ) {
+    return rawMeasure(
+      text: text,
+      style: style,
+      start: start.index,
+      endExcludingTrailingSpaces: end.indexWithoutTrailingSpaces,
+      // Trailing new lines should never be included in measurements.
+      endIncludingTrailingSpaces: end.indexWithoutTrailingNewlines,
+    );
+  }
+
+  TextMetrics measureText(String text, EngineTextStyle style) {
+    return rawMeasure(
+      text: text,
+      style: style,
+      start: 0,
+      endExcludingTrailingSpaces: text.length,
+      endIncludingTrailingSpaces: text.length,
+    );
+  }
+
+  TextMetrics measureSubstring(
+    String text,
+    EngineTextStyle style,
+    int start,
+    int end,
+  ) {
+    return rawMeasure(
+      text: text,
+      style: style,
+      start: start,
+      endExcludingTrailingSpaces: end,
+      endIncludingTrailingSpaces: end,
+    );
+  }
+
+  TextMetrics rawMeasure({
+    required String text,
+    required EngineTextStyle style,
+    required int start,
+    required int endExcludingTrailingSpaces,
+    required int endIncludingTrailingSpaces,
+  }) {
+    // 0 <= start <= endExcludingTrailingSpace <= endIncludingTrailingSpaces <= text.length.
+    assert(0 <= start);
+    assert(start <= endExcludingTrailingSpaces);
+    assert(endExcludingTrailingSpaces <= endIncludingTrailingSpaces);
+    assert(endIncludingTrailingSpaces <= text.length);
+
+    // Empty range.
+    if (start == endIncludingTrailingSpaces) {
+      return TextMetrics.zero;
+    }
+
+    final String cssFontString = style.cssFontString;
+    print('font: "$cssFontString"');
+
+    final String textIncludingTrailingSpaces =
+        _extractSubstring(text, start, endIncludingTrailingSpaces);
+
+    final Map<String, TextMetrics> fontCache =
+        _cache.putIfAbsent(cssFontString, () => <String, TextMetrics>{});
+    final TextMetrics? cachedMetrics = fontCache[textIncludingTrailingSpaces];
+    if (cachedMetrics != null) {
+      return cachedMetrics;
+    }
+
+    if (_canvasContext.font != cssFontString) {
+      _canvasContext.font = cssFontString;
+    }
+
+    // TODO(mdebbar): LETTER SPACING <-> CACHE!!
+
+    // // Now add letter spacing to the width.
+    // letterSpacing ??= 0.0;
+    // if (letterSpacing != 0.0) {
+    //   width += letterSpacing * (end - start);
+    // }
+
+    // TODO(mdebbar): FALLBACK TO DOM IF BROWSER DOESN'T SUPPORT HEIGHT METRICS.
+
+    final bool hasTrailingSpaces =
+        endIncludingTrailingSpaces != endExcludingTrailingSpaces;
+
+    final DomTextMetrics metricsIncludingTrailingSpaces =
+        _canvasContext.measureText(textIncludingTrailingSpaces);
+    final DomTextMetrics metricsExcludingTrailingSpaces;
+
+    if (hasTrailingSpaces) {
+      final String textExcludingTrailingSpaces =
+          _extractSubstring(text, start, endExcludingTrailingSpaces);
+      metricsExcludingTrailingSpaces =
+          _canvasContext.measureText(textExcludingTrailingSpaces);
+    } else {
+      metricsExcludingTrailingSpaces = metricsIncludingTrailingSpaces;
+    }
+
+    // print('text: "$textIncludingTrailingSpaces"');
+    // print(
+    //     'actual: (${_roundWidth(metricsIncludingTrailingSpaces.actualBoundingBoxAscent!.toDouble())}, ${_roundWidth(metricsIncludingTrailingSpaces.actualBoundingBoxDescent!.toDouble())})');
+    // print(
+    //     'font: (${_roundWidth(metricsIncludingTrailingSpaces.fontBoundingBoxAscent!.toDouble())}, ${_roundWidth(metricsIncludingTrailingSpaces.fontBoundingBoxDescent!.toDouble())})');
+    // print(
+    //     'ratio: ${(metricsIncludingTrailingSpaces.fontBoundingBoxAscent! + metricsIncludingTrailingSpaces.fontBoundingBoxDescent!) / (metricsIncludingTrailingSpaces.actualBoundingBoxAscent! + metricsIncludingTrailingSpaces.actualBoundingBoxDescent!)}');
+    // print(
+    //     'font ratio: ${(metricsIncludingTrailingSpaces.fontBoundingBoxAscent! + metricsIncludingTrailingSpaces.fontBoundingBoxDescent!) / style.fontSize!}');
+    final TextMetrics metrics = TextMetrics._fromCanvasTextMetrics(
+      excludingTrailingSpaces: metricsExcludingTrailingSpaces,
+      includingTrailingSpaces: metricsIncludingTrailingSpaces,
+      style: style,
+    );
+
+    fontCache[textIncludingTrailingSpaces] = metrics;
+
+    return metrics;
+  }
+}
+
+String _extractSubstring(String text, int start, int end) {
+  // Optimization to avoid calling `substring` if the range covers the entire
+  // string.
+  return start == 0 && end == text.length ? text : text.substring(start, end);
 }

--- a/lib/web_ui/lib/src/engine/text/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/paragraph.dart
@@ -114,6 +114,8 @@ class ParagraphLine {
     required double left,
     required double baseline,
     required int lineNumber,
+    required this.textAscent,
+    required this.textDescent,
     required this.ellipsis,
     required this.startIndex,
     required this.endIndex,
@@ -137,6 +139,9 @@ class ParagraphLine {
 
   /// Metrics for this line of the paragraph.
   final EngineLineMetrics lineMetrics;
+
+  final double textAscent;
+  final double textDescent;
 
   /// The string to be displayed as an overflow indicator.
   ///
@@ -204,6 +209,8 @@ class ParagraphLine {
   @override
   int get hashCode => Object.hash(
         lineMetrics,
+        textAscent,
+        textDescent,
         ellipsis,
         startIndex,
         endIndex,
@@ -225,6 +232,8 @@ class ParagraphLine {
     }
     return other is ParagraphLine &&
         other.lineMetrics == lineMetrics &&
+        other.textAscent == textAscent &&
+        other.textDescent == textDescent &&
         other.ellipsis == ellipsis &&
         other.startIndex == startIndex &&
         other.endIndex == endIndex &&

--- a/lib/web_ui/test/text/font_loading_test.dart
+++ b/lib/web_ui/test/text/font_loading_test.dart
@@ -51,33 +51,33 @@ Future<void> testMain() async {
         skip: browserEngine == BrowserEngine.edge ||
             browserEngine == BrowserEngine.webkit);
 
-    test('loading font should clear measurement caches', () async {
-      final EngineParagraphStyle style = EngineParagraphStyle();
-      const ui.ParagraphConstraints constraints =
-          ui.ParagraphConstraints(width: 30.0);
+    // test('loading font should clear measurement caches', () async {
+    //   final EngineParagraphStyle style = EngineParagraphStyle();
+    //   const ui.ParagraphConstraints constraints =
+    //       ui.ParagraphConstraints(width: 30.0);
 
-      final CanvasParagraphBuilder canvasBuilder = CanvasParagraphBuilder(style);
-      canvasBuilder.addText('test');
-      // Triggers the measuring and verifies the ruler cache has been populated.
-      canvasBuilder.build().layout(constraints);
-      expect(Spanometer.rulers.length, 1);
+    //   final CanvasParagraphBuilder canvasBuilder = CanvasParagraphBuilder(style);
+    //   canvasBuilder.addText('test');
+    //   // Triggers the measuring and verifies the ruler cache has been populated.
+    //   canvasBuilder.build().layout(constraints);
+    //   expect(Spanometer.rulers.length, 1);
 
-      // Now, loads a new font using loadFontFromList. This should clear the
-      // cache
-      final html.HttpRequest response = await html.HttpRequest.request(
-          _testFontUrl,
-          responseType: 'arraybuffer');
-      await ui.loadFontFromList(Uint8List.view(response.response as ByteBuffer),
-          fontFamily: 'Blehm');
+    //   // Now, loads a new font using loadFontFromList. This should clear the
+    //   // cache
+    //   final html.HttpRequest response = await html.HttpRequest.request(
+    //       _testFontUrl,
+    //       responseType: 'arraybuffer');
+    //   await ui.loadFontFromList(Uint8List.view(response.response as ByteBuffer),
+    //       fontFamily: 'Blehm');
 
-      // Verifies the font is loaded, and the cache is cleaned.
-      expect(_containsFontFamily('Blehm'), isTrue);
-      expect(Spanometer.rulers.length, 0);
-    },
-        // TODO(hterkelsen): https://github.com/flutter/flutter/issues/56702
-        // TODO(hterkelsen): https://github.com/flutter/flutter/issues/50770
-        skip: browserEngine == BrowserEngine.edge ||
-            browserEngine == BrowserEngine.webkit);
+    //   // Verifies the font is loaded, and the cache is cleaned.
+    //   expect(_containsFontFamily('Blehm'), isTrue);
+    //   expect(Spanometer.rulers.length, 0);
+    // },
+    //     // TODO(hterkelsen): https://github.com/flutter/flutter/issues/56702
+    //     // TODO(hterkelsen): https://github.com/flutter/flutter/issues/50770
+    //     skip: browserEngine == BrowserEngine.edge ||
+    //         browserEngine == BrowserEngine.webkit);
 
     test('loading font should send font change message', () async {
       final ui.PlatformMessageCallback? oldHandler = ui.window.onPlatformMessage;


### PR DESCRIPTION
Measure text height using canvas2d's [measureText](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/measureText) API. Height [metrics](https://developer.mozilla.org/en-US/docs/Web/API/TextMetrics) are available in most major browsers (Firefox doesn't support `fontBoundingBoxAscent`/`fontBoundingBoxDescent`).

This works well when rendering text into a canvas2d. But when rendering into DOM, the text isn't aligned to the baseline correctly. This is a blocker for the PR and I haven't found a solution to it yet.

Remaining tasks:
- [ ] Incorporate `TextHeightRuler` into the new `CachedMeasurements` class (as a fallback for browsers that don't support canvas2d height metrics).
- [ ] Adjust measurements (and caching) for letter spacing (if it's non-zero).
- [ ] Fix DOM rendering of some international characters.