### PR TITLE
Remove use of deprecated, unused dart io properties.

### DIFF
--- a/lib/io/dart_io.cc
+++ b/lib/io/dart_io.cc
@@ -22,21 +22,6 @@ void DartIO::InitForIsolate(bool may_insecurely_connect_to_all_domains,
                                               dart::bin::LookupIONativeSymbol);
   FML_CHECK(!CheckAndHandleError(result));
 
-  Dart_Handle embedder_config_type =
-      Dart_GetNonNullableType(io_lib, ToDart("_EmbedderConfig"), 0, nullptr);
-  FML_CHECK(!CheckAndHandleError(embedder_config_type));
-
-  Dart_Handle allow_insecure_connections_result = Dart_SetField(
-      embedder_config_type, ToDart("_mayInsecurelyConnectToAllDomains"),
-      ToDart(may_insecurely_connect_to_all_domains));
-  FML_CHECK(!CheckAndHandleError(allow_insecure_connections_result));
-
-  Dart_Handle dart_args[1];
-  dart_args[0] = ToDart(domain_network_policy);
-  Dart_Handle set_domain_network_policy_result = Dart_Invoke(
-      embedder_config_type, ToDart("_setDomainPolicies"), 1, dart_args);
-  FML_CHECK(!CheckAndHandleError(set_domain_network_policy_result));
-
   Dart_Handle ui_lib = Dart_LookupLibrary(ToDart("dart:ui"));
   Dart_Handle dart_validate_args[1];
   dart_validate_args[0] = ToDart(may_insecurely_connect_to_all_domains);


### PR DESCRIPTION
These are getting finally removed from dart sdk in https://dart-review.googlesource.com/c/sdk/+/248220.

Clean up to address https://github.com/flutter/flutter/issues/54448