### PR TITLE
Expose macOS -[FlutterViewController initWithEngine:::] in header

### DIFF
--- a/shell/platform/darwin/macos/framework/Headers/FlutterViewController.h
+++ b/shell/platform/darwin/macos/framework/Headers/FlutterViewController.h
@@ -55,6 +55,19 @@ FLUTTER_DARWIN_EXPORT
 - (nonnull instancetype)initWithCoder:(nonnull NSCoder*)nibNameOrNil NS_DESIGNATED_INITIALIZER;
 
 /**
+ * Initializes this FlutterViewController with the specified `FlutterEngine`.
+ *
+ * The initialized view controller will attach itself to the engine as part of this process.
+ *
+ * @param engine The `FlutterEngine` instance to attach to.
+ * @param nibName The NIB name to initialize this controller with.
+ * @param nibBundle The NIB bundle.
+ */
+- (nonnull instancetype)initWithEngine:(nonnull FlutterEngine*)engine
+                               nibName:(nullable NSString*)nibName
+                                bundle:(nullable NSBundle*)nibBundle NS_DESIGNATED_INITIALIZER;
+
+/**
  * Invoked by the engine right before the engine is restarted.
  *
  * This should reset states to as if the application has just started.  It

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
@@ -7,7 +7,6 @@
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterTextInputSemanticsObject.h"
-#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h"
 
 #import <OCMock/OCMock.h>
 #import "flutter/testing/testing.h"

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
@@ -50,6 +50,15 @@ NSResponder* mockResponder() {
 }
 }  // namespace
 
+TEST(FlutterViewController, SetsEngine) {
+  id engineMock = OCMClassMock([FlutterEngine class]);
+  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engineMock
+                                                                                nibName:nil
+                                                                                 bundle:nil];
+
+  EXPECT_EQ(viewController.engine, engineMock);
+}
+
 TEST(FlutterViewController, HasViewThatHidesOtherViewsInAccessibility) {
   FlutterViewController* viewControllerMock = CreateMockViewController();
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h
@@ -19,19 +19,6 @@
 @property(nonatomic, readonly, nonnull) FlutterTextInputPlugin* textInputPlugin;
 
 /**
- * Initializes this FlutterViewController with the specified `FlutterEngine`.
- *
- * The initialized viewcontroller will attach itself to the engine as part of this process.
- *
- * @param engine The `FlutterEngine` instance to attach to. Cannot be nil.
- * @param nibName The NIB name to initialize this controller with.
- * @param nibBundle The NIB bundle.
- */
-- (nonnull instancetype)initWithEngine:(nonnull FlutterEngine*)engine
-                               nibName:(nullable NSString*)nibName
-                                bundle:(nullable NSBundle*)nibBundle NS_DESIGNATED_INITIALIZER;
-
-/**
  * Returns YES if provided event is being currently redispatched by keyboard manager.
  */
 - (BOOL)isDispatchingKeyEvent:(nonnull NSEvent*)event;


### PR DESCRIPTION
To support macOS add-to-app, move `initWithEngine:` into header so the host app can run the warm up the engine and pass it into a view controller later to display the Flutter views.

This will match the iOS pattern documented in https://docs.flutter.dev/development/add-to-app/ios/add-flutter-screen?tab=engine-swift-tab#show-a-flutterviewcontroller-with-your-flutterengine

Fixes https://github.com/flutter/flutter/issues/105347

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
