### PR TITLE
Prevent TalkBack from announcing view in non-virtual a11y hierarchies

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
+++ b/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
@@ -10,6 +10,7 @@ import android.graphics.Path;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewTreeObserver;
+import android.view.accessibility.AccessibilityEvent;
 import android.widget.FrameLayout;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -158,6 +159,14 @@ public class FlutterMutatorView extends FrameLayout {
   @Override
   public boolean onInterceptTouchEvent(MotionEvent event) {
     return true;
+  }
+
+  @Override
+  public boolean requestSendAccessibilityEvent(View child, AccessibilityEvent event) {
+    if (getChildCount() == 1 && getChildAt(0).isImportantForAccessibility()) {
+      return super.requestSendAccessibilityEvent(child, event);
+    }
+    return false;
   }
 
   @Override

--- a/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
+++ b/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
@@ -3,6 +3,7 @@ package io.flutter.embedding.engine.mutatorsstack;
 import static android.view.View.OnFocusChangeListener;
 
 import android.annotation.SuppressLint;
+import android.annotation.TargetApi;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Matrix;
@@ -162,15 +163,19 @@ public class FlutterMutatorView extends FrameLayout {
   }
 
   @Override
+  @TargetApi(21)
   public boolean requestSendAccessibilityEvent(View child, AccessibilityEvent event) {
-    if (child != null && child.isImportantForAccessibility()) {
-      // Forward the request only if the child view is in the Flutter accessibility tree.
-      // The embedded view may be ignored when the framework doesn't populate a SemanticNode
-      // for the current platform view.
-      // See AccessibilityBridge for more.
-      return super.requestSendAccessibilityEvent(child, event);
+    final View embeddedView = getChildAt(0);
+    if (embeddedView != null
+        && embeddedView.getImportantForAccessibility()
+            == View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS) {
+      return false;
     }
-    return false;
+    // Forward the request only if the embedded view is in the Flutter accessibility tree.
+    // The embedded view may be ignored when the framework doesn't populate a SemanticNode
+    // for the current platform view.
+    // See AccessibilityBridge for more.
+    return super.requestSendAccessibilityEvent(child, event);
   }
 
   @Override

--- a/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
+++ b/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
@@ -23,6 +23,7 @@ import io.flutter.util.ViewUtils;
  * A view that applies the {@link io.flutter.embedding.engine.mutatorsstack.FlutterMutatorsStack} to
  * its children.
  */
+@TargetApi(19)
 public class FlutterMutatorView extends FrameLayout {
   private FlutterMutatorsStack mutatorsStack;
   private float screenDensity;
@@ -163,7 +164,6 @@ public class FlutterMutatorView extends FrameLayout {
   }
 
   @Override
-  @TargetApi(21)
   public boolean requestSendAccessibilityEvent(View child, AccessibilityEvent event) {
     final View embeddedView = getChildAt(0);
     if (embeddedView != null

--- a/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
+++ b/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
@@ -163,7 +163,11 @@ public class FlutterMutatorView extends FrameLayout {
 
   @Override
   public boolean requestSendAccessibilityEvent(View child, AccessibilityEvent event) {
-    if (getChildCount() == 1 && getChildAt(0).isImportantForAccessibility()) {
+    if (child != null && child.isImportantForAccessibility()) {
+      // Forward the request only if the child view is in the Flutter accessibility tree.
+      // The embedded view may be ignored when the framework doesn't populate a SemanticNode
+      // for the current platform view.
+      // See AccessibilityBridge for more.
       return super.requestSendAccessibilityEvent(child, event);
     }
     return false;

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewWrapper.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewWrapper.java
@@ -245,14 +245,22 @@ class PlatformViewWrapper extends FrameLayout {
 
   @Override
   public boolean requestSendAccessibilityEvent(View child, AccessibilityEvent event) {
-    if (child != null && child.isImportantForAccessibility()) {
-      // Forward the request only if the child view is in the Flutter accessibility tree.
-      // The embedded view may be ignored when the framework doesn't populate a SemanticNode
-      // for the current platform view.
-      // See AccessibilityBridge for more.
-      return super.requestSendAccessibilityEvent(child, event);
+    final View embeddedView = getChildAt(0);
+    if (embeddedView != null) {
+      io.flutter.Log.e(
+          "flutter", "getImportantForAccessibility=" + embeddedView.getImportantForAccessibility());
     }
-    return false;
+
+    if (embeddedView != null
+        && embeddedView.getImportantForAccessibility()
+            == View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS) {
+      return false;
+    }
+    // Forward the request only if the embedded view is in the Flutter accessibility tree.
+    // The embedded view may be ignored when the framework doesn't populate a SemanticNode
+    // for the current platform view.
+    // See AccessibilityBridge for more.
+    return super.requestSendAccessibilityEvent(child, event);
   }
 
   /** Used on Android O+, {@link invalidateChildInParent} used for previous versions. */

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewWrapper.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewWrapper.java
@@ -246,11 +246,6 @@ class PlatformViewWrapper extends FrameLayout {
   @Override
   public boolean requestSendAccessibilityEvent(View child, AccessibilityEvent event) {
     final View embeddedView = getChildAt(0);
-    if (embeddedView != null) {
-      io.flutter.Log.e(
-          "flutter", "getImportantForAccessibility=" + embeddedView.getImportantForAccessibility());
-    }
-
     if (embeddedView != null
         && embeddedView.getImportantForAccessibility()
             == View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS) {

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewWrapper.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewWrapper.java
@@ -21,6 +21,7 @@ import android.view.Surface;
 import android.view.View;
 import android.view.ViewParent;
 import android.view.ViewTreeObserver;
+import android.view.accessibility.AccessibilityEvent;
 import android.widget.FrameLayout;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -240,6 +241,14 @@ class PlatformViewWrapper extends FrameLayout {
   @Override
   public boolean onInterceptTouchEvent(@NonNull MotionEvent event) {
     return true;
+  }
+
+  @Override
+  public boolean requestSendAccessibilityEvent(View child, AccessibilityEvent event) {
+    if (getChildCount() == 1 && getChildAt(0).isImportantForAccessibility()) {
+      return super.requestSendAccessibilityEvent(child, event);
+    }
+    return false;
   }
 
   /** Used on Android O+, {@link invalidateChildInParent} used for previous versions. */

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewWrapper.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewWrapper.java
@@ -245,7 +245,11 @@ class PlatformViewWrapper extends FrameLayout {
 
   @Override
   public boolean requestSendAccessibilityEvent(View child, AccessibilityEvent event) {
-    if (getChildCount() == 1 && getChildAt(0).isImportantForAccessibility()) {
+    if (child != null && child.isImportantForAccessibility()) {
+      // Forward the request only if the child view is in the Flutter accessibility tree.
+      // The embedded view may be ignored when the framework doesn't populate a SemanticNode
+      // for the current platform view.
+      // See AccessibilityBridge for more.
       return super.requestSendAccessibilityEvent(child, event);
     }
     return false;

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -223,16 +223,16 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
           layoutParams.leftMargin = physicalLeft;
           wrapperView.setLayoutParams(layoutParams);
 
-          final View view = platformView.getView();
-          if (view == null) {
+          final View embeddedView = platformView.getView();
+          if (embeddedView == null) {
             throw new IllegalStateException(
                 "PlatformView#getView() returned null, but an Android view reference was expected.");
           } else if (view.getParent() != null) {
             throw new IllegalStateException(
                 "The Android view returned from PlatformView#getView() was already added to a parent view.");
           }
-          view.setLayoutParams(new FrameLayout.LayoutParams(physicalWidth, physicalHeight));
-          view.setLayoutDirection(request.direction);
+          embeddedView.setLayoutParams(new FrameLayout.LayoutParams(physicalWidth, physicalHeight));
+          embeddedView.setLayoutDirection(request.direction);
 
           // Accessibility is initially disabled, and it's e-enabled by AccessibilityBridge after
           // the
@@ -243,9 +243,10 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
           // SemanticsNode is populated.
           // To prevent races, the framework populate the SemanticsNode after the platform view has
           // been created.
-          view.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS);
+          embeddedView.setImportantForAccessibility(
+              View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS);
 
-          wrapperView.addView(view);
+          wrapperView.addView(embeddedView);
           wrapperView.setOnDescendantFocusChangeListener(
               (v, hasFocus) -> {
                 if (hasFocus) {

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -750,6 +750,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
    *     testing.
    */
   @VisibleForTesting
+  @TargetApi(Build.VERSION_CODES.KITKAT)
   void initializePlatformViewIfNeeded(int viewId) {
     final PlatformView platformView = platformViews.get(viewId);
     if (platformView == null) {

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -235,8 +235,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
           embeddedView.setLayoutDirection(request.direction);
 
           // Accessibility is initially disabled, and it's e-enabled by AccessibilityBridge after
-          // the
-          // framework populates the SemanticsNode.
+          // the framework populates the SemanticsNode.
           // If there's no SemanticsNode for a platform view, then the platform view remains
           // inaccessible to TalkBack.
           // For example, if you wrap a platform view widget with a ExcludeSemantics widget, no

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -227,7 +227,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
           if (embeddedView == null) {
             throw new IllegalStateException(
                 "PlatformView#getView() returned null, but an Android view reference was expected.");
-          } else if (view.getParent() != null) {
+          } else if (embeddedView.getParent() != null) {
             throw new IllegalStateException(
                 "The Android view returned from PlatformView#getView() was already added to a parent view.");
           }

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -234,12 +234,11 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
           embeddedView.setLayoutParams(new FrameLayout.LayoutParams(physicalWidth, physicalHeight));
           embeddedView.setLayoutDirection(request.direction);
 
-          // Accessibility is initially disabled, and it's e-enabled by AccessibilityBridge after
-          // the framework populates the SemanticsNode.
-          // If there's no SemanticsNode for a platform view, then the platform view remains
-          // inaccessible to TalkBack.
-          // For example, if you wrap a platform view widget with a ExcludeSemantics widget, no
-          // SemanticsNode is populated.
+          // Accessibility in the embedded view is initially disabled because if a Flutter app
+          // disabled accessibility in the first frame, the embedding won't receive an update to
+          // disable accessibility since the embedding never received an update to enable it.
+          // The AccessibilityBridge keeps track of the accessibility nodes, and handles the deltas
+          // when the framework sends a new a11y tree to the embedding.
           // To prevent races, the framework populate the SemanticsNode after the platform view has
           // been created.
           embeddedView.setImportantForAccessibility(
@@ -784,12 +783,11 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
 
     platformViewParent.put(viewId, parentView);
 
-    // Accessibility is initially disabled, and it's e-enabled by AccessibilityBridge after the
-    // framework populates the SemanticsNode.
-    // If there's no SemanticsNode for a platform view, then the platform view remains inaccessible
-    // to TalkBack.
-    // For example, if you wrap a platform view widget with a ExcludeSemantics widget, no
-    // SemanticsNode is populated.
+    // Accessibility in the embedded view is initially disabled because if a Flutter app disabled
+    // accessibility in the first frame, the embedding won't receive an update to disable
+    // accessibility since the embedding never received an update to enable it.
+    // The AccessibilityBridge keeps track of the accessibility nodes, and handles the deltas when
+    // the framework sends a new a11y tree to the embedding.
     // To prevent races, the framework populate the SemanticsNode after the platform view has been
     // created.
     embeddedView.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS);

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewWrapperTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewWrapperTest.java
@@ -13,7 +13,9 @@ import android.graphics.Color;
 import android.graphics.SurfaceTexture;
 import android.view.Surface;
 import android.view.View;
+import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
+import android.view.accessibility.AccessibilityEvent;
 import androidx.annotation.NonNull;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -21,6 +23,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.robolectric.annotation.Config;
+import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
 @TargetApi(31)
@@ -295,6 +298,56 @@ public class PlatformViewWrapperTest {
     verify(viewTreeObserver, times(1)).removeOnGlobalFocusChangeListener(activeFocusListener);
   }
 
+  @Test
+  @Config(
+      shadows = {
+        ShadowViewGroup.class,
+      })
+  public void ignoreAccessibilityEvents() {
+    final PlatformViewWrapper wrapperView = new PlatformViewWrapper(ctx);
+
+    final View embeddedView = mock(View.class);
+    wrapperView.addView(embeddedView);
+
+    when(embeddedView.getImportantForAccessibility())
+        .thenReturn(View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS);
+    final boolean eventSent =
+        wrapperView.requestSendAccessibilityEvent(embeddedView, mock(AccessibilityEvent.class));
+    assertFalse(eventSent);
+  }
+
+  @Test
+  @Config(
+      shadows = {
+        ShadowViewGroup.class,
+      })
+  public void sendAccessibilityEvents() {
+    final PlatformViewWrapper wrapperView = new PlatformViewWrapper(ctx);
+
+    final View embeddedView = mock(View.class);
+    wrapperView.addView(embeddedView);
+
+    when(embeddedView.getImportantForAccessibility())
+        .thenReturn(View.IMPORTANT_FOR_ACCESSIBILITY_YES);
+    boolean eventSent =
+        wrapperView.requestSendAccessibilityEvent(embeddedView, mock(AccessibilityEvent.class));
+    assertTrue(eventSent);
+
+    when(embeddedView.getImportantForAccessibility())
+        .thenReturn(View.IMPORTANT_FOR_ACCESSIBILITY_AUTO);
+    eventSent =
+        wrapperView.requestSendAccessibilityEvent(embeddedView, mock(AccessibilityEvent.class));
+    assertTrue(eventSent);
+  }
+
   @Implements(View.class)
   public static class ShadowView {}
+
+  @Implements(ViewGroup.class)
+  public static class ShadowViewGroup extends org.robolectric.shadows.ShadowView {
+    @Implementation
+    public boolean requestSendAccessibilityEvent(View child, AccessibilityEvent event) {
+      return true;
+    }
+  }
 }

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
@@ -213,6 +213,33 @@ public class PlatformViewsControllerTest {
 
   @Test
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
+  public void createPlatformViewMessage__disablesAccessibility() {
+    PlatformViewsController platformViewsController = new PlatformViewsController();
+    platformViewsController.setSoftwareRendering(true);
+
+    int platformViewId = 0;
+    assertNull(platformViewsController.getPlatformViewById(platformViewId));
+
+    PlatformViewFactory viewFactory = mock(PlatformViewFactory.class);
+    PlatformView platformView = mock(PlatformView.class);
+
+    View androidView = mock(View.class);
+    when(platformView.getView()).thenReturn(androidView);
+    when(viewFactory.create(any(), eq(platformViewId), any())).thenReturn(platformView);
+    platformViewsController.getRegistry().registerViewFactory("testType", viewFactory);
+
+    FlutterJNI jni = new FlutterJNI();
+    attach(jni, platformViewsController);
+
+    // Simulate create call from the framework.
+    createPlatformView(
+        jni, platformViewsController, platformViewId, "testType", /* hybrid=*/ false);
+    verify(androidView, times(1))
+        .setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS);
+  }
+
+  @Test
+  @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
   public void createPlatformViewMessage__throwsIfViewIsNull() {
     PlatformViewsController platformViewsController = new PlatformViewsController();
 


### PR DESCRIPTION
Ensures that accessibility events aren't forwarded to the parent view when
the embedded view should not be read by TalkBack.


<details>
<summary>Code sample</summary>

<!--
      Please create a minimal reproducible sample that shows the problem
      and attach it below between the lines with the backticks.

      To create it you can use `flutter create bug` command and update the `main.dart` file.

      Alternatively, you can use https://dartpad.dev/
      which is capable of creating and running small Flutter apps.

      Without this we will unlikely be able to progress on the issue, and because of that
      we regretfully will have to close it.
-->

```dart

ExcludeSemantics(
    child: GoogleMap(
        ...
    ),
);
```



</details>

Fixes https://github.com/flutter/flutter/issues/105658
Fixes  https://github.com/flutter/flutter/issues/29717
