### PR TITLE
Eliminates Dart->Host copy for mutable responses

### DIFF
--- a/assets/BUILD.gn
+++ b/assets/BUILD.gn
@@ -18,3 +18,15 @@ source_set("assets") {
 
   public_configs = [ "//flutter:config" ]
 }
+
+source_set("assets_unittests") {
+  sources = [ "directory_asset_bundle_unittests.cc" ]
+
+  deps = [
+    ":assets",
+    "//flutter/testing",
+  ]
+
+  public_configs = [ "//flutter:config" ]
+  testonly = true
+}

--- a/assets/directory_asset_bundle_unittests.cc
+++ b/assets/directory_asset_bundle_unittests.cc
@@ -1,0 +1,40 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/assets/directory_asset_bundle.h"
+#include "gtest/gtest.h"
+
+namespace flutter {
+namespace testing {
+
+TEST(DirectoryAssetBundle, MappingIsReadWrite) {
+  fml::ScopedTemporaryDirectory temp_dir;
+  const char* filename = "foo.txt";
+  fml::MallocMapping write_mapping(static_cast<uint8_t*>(calloc(1, 4)), 4);
+  fml::WriteAtomically(temp_dir.fd(), filename, write_mapping);
+  fml::UniqueFD descriptor =
+      fml::OpenDirectory(temp_dir.path().c_str(), /*create_if_necessary=*/false,
+                         fml::FilePermission::kRead);
+  std::unique_ptr<AssetResolver> bundle =
+      std::make_unique<DirectoryAssetBundle>(
+          std::move(descriptor), /*is_valid_after_asset_manager_change=*/true);
+  EXPECT_TRUE(bundle->IsValid());
+  std::unique_ptr<fml::Mapping> read_mapping = bundle->GetAsMapping(filename);
+  ASSERT_TRUE(read_mapping);
+
+#if defined(OS_FUCHSIA) || defined(FML_OS_WIN)
+  ASSERT_FALSE(read_mapping->GetMutableMapping());
+#else
+  ASSERT_TRUE(read_mapping->GetMutableMapping());
+  EXPECT_EQ(read_mapping->GetSize(), 4u);
+  read_mapping->GetMutableMapping()[0] = 'A';
+  EXPECT_EQ(read_mapping->GetMapping()[0], 'A');
+  std::unique_ptr<fml::Mapping> read_after_write_mapping =
+      bundle->GetAsMapping(filename);
+  EXPECT_EQ(read_after_write_mapping->GetMapping()[0], '\0');
+#endif
+}
+
+}  // namespace testing
+}  // namespace flutter

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -20,6 +20,7 @@ FILE: ../../../flutter/assets/asset_manager.h
 FILE: ../../../flutter/assets/asset_resolver.h
 FILE: ../../../flutter/assets/directory_asset_bundle.cc
 FILE: ../../../flutter/assets/directory_asset_bundle.h
+FILE: ../../../flutter/assets/directory_asset_bundle_unittests.cc
 FILE: ../../../flutter/benchmarking/benchmarking.cc
 FILE: ../../../flutter/benchmarking/benchmarking.h
 FILE: ../../../flutter/benchmarking/library.cc

--- a/fml/mapping.cc
+++ b/fml/mapping.cc
@@ -11,7 +11,7 @@ namespace fml {
 
 // FileMapping
 
-uint8_t* FileMapping::GetMutableMapping() {
+uint8_t* FileMapping::GetMutableMapping() const {
   return mutable_mapping_;
 }
 
@@ -143,6 +143,10 @@ size_t MallocMapping::GetSize() const {
 }
 
 const uint8_t* MallocMapping::GetMapping() const {
+  return data_;
+}
+
+uint8_t* MallocMapping::GetMutableMapping() const {
   return data_;
 }
 

--- a/fml/mapping.h
+++ b/fml/mapping.h
@@ -28,6 +28,10 @@ class Mapping {
 
   virtual const uint8_t* GetMapping() const = 0;
 
+  /// Returns a non-const pointer to the data if one is available, otherwise it
+  /// returns nullptr.
+  virtual uint8_t* GetMutableMapping() const = 0;
+
   // Whether calling madvise(DONTNEED) on the mapping is non-destructive.
   // Generally true for file-mapped memory and false for anonymous memory.
   virtual bool IsDontNeedSafe() const = 0;
@@ -44,9 +48,15 @@ class FileMapping final : public Mapping {
     kExecute,
   };
 
-  explicit FileMapping(const fml::UniqueFD& fd,
-                       std::initializer_list<Protection> protection = {
-                           Protection::kRead});
+  enum class Flags {
+    kNone,
+    kCopyOnWrite,
+  };
+
+  explicit FileMapping(
+      const fml::UniqueFD& fd,
+      std::initializer_list<Protection> protection = {Protection::kRead},
+      std::initializer_list<Flags> flags = {Flags::kNone});
 
   ~FileMapping() override;
 
@@ -72,7 +82,8 @@ class FileMapping final : public Mapping {
   // |Mapping|
   bool IsDontNeedSafe() const override;
 
-  uint8_t* GetMutableMapping();
+  // |Mapping|
+  uint8_t* GetMutableMapping() const override;
 
   bool IsValid() const;
 
@@ -104,6 +115,9 @@ class DataMapping final : public Mapping {
   const uint8_t* GetMapping() const override;
 
   // |Mapping|
+  uint8_t* GetMutableMapping() const override { return nullptr; }
+
+  // |Mapping|
   bool IsDontNeedSafe() const override;
 
  private:
@@ -127,6 +141,9 @@ class NonOwnedMapping final : public Mapping {
 
   // |Mapping|
   const uint8_t* GetMapping() const override;
+
+  // |Mapping|
+  uint8_t* GetMutableMapping() const override { return nullptr; }
 
   // |Mapping|
   bool IsDontNeedSafe() const override;
@@ -178,6 +195,9 @@ class MallocMapping final : public Mapping {
   const uint8_t* GetMapping() const override;
 
   // |Mapping|
+  uint8_t* GetMutableMapping() const override;
+
+  // |Mapping|
   bool IsDontNeedSafe() const override;
 
   /// Removes ownership of the data buffer.
@@ -203,6 +223,9 @@ class SymbolMapping final : public Mapping {
 
   // |Mapping|
   const uint8_t* GetMapping() const override;
+
+  // |Mapping|
+  uint8_t* GetMutableMapping() const override { return nullptr; }
 
   // |Mapping|
   bool IsDontNeedSafe() const override;

--- a/lib/ui/window/platform_message_response_dart.cc
+++ b/lib/ui/window/platform_message_response_dart.cc
@@ -47,6 +47,12 @@ void PostCompletion(Callback&& callback,
 }
 }  // namespace
 
+namespace {
+void MappingFinalizer(void* isolate_callback_data, void* peer) {
+  delete static_cast<fml::Mapping*>(peer);
+}
+}  // anonymous namespace
+
 PlatformMessageResponseDart::PlatformMessageResponseDart(
     tonic::DartPersistentValue callback,
     fml::RefPtr<fml::TaskRunner> ui_task_runner,
@@ -64,9 +70,24 @@ PlatformMessageResponseDart::~PlatformMessageResponseDart() {
 
 void PlatformMessageResponseDart::Complete(std::unique_ptr<fml::Mapping> data) {
   PostCompletion(std::move(callback_), ui_task_runner_, &is_complete_, channel_,
-                 [data = std::move(data)] {
-                   return tonic::DartByteData::Create(data->GetMapping(),
-                                                      data->GetSize());
+                 [data = std::move(data)]() mutable {
+                   void* mapping = data->GetMutableMapping();
+                   Dart_Handle byte_buffer;
+                   if (mapping) {
+                     size_t data_size = data->GetSize();
+                     byte_buffer = Dart_NewExternalTypedDataWithFinalizer(
+                         /*type=*/Dart_TypedData_kByteData,
+                         /*data=*/mapping,
+                         /*length=*/data_size,
+                         /*peer=*/data.release(),
+                         /*external_allocation_size=*/data_size,
+                         /*callback=*/MappingFinalizer);
+
+                   } else {
+                     byte_buffer = tonic::DartByteData::Create(
+                         data->GetMapping(), data->GetSize());
+                   }
+                   return byte_buffer;
                  });
 }
 

--- a/runtime/BUILD.gn
+++ b/runtime/BUILD.gn
@@ -142,6 +142,7 @@ if (enable_unittests) {
       ":libdart",
       ":runtime",
       ":runtime_fixtures",
+      "//flutter/assets:assets_unittests",
       "//flutter/common",
       "//flutter/fml",
       "//flutter/lib/snapshot",

--- a/shell/platform/android/apk_asset_provider.cc
+++ b/shell/platform/android/apk_asset_provider.cc
@@ -25,6 +25,8 @@ class APKAssetMapping : public fml::Mapping {
     return reinterpret_cast<const uint8_t*>(AAsset_getBuffer(asset_));
   }
 
+  uint8_t* GetMutableMapping() const override { return nullptr; }
+
   bool IsDontNeedSafe() const override { return !AAsset_isAllocated(asset_); }
 
  private:

--- a/shell/platform/darwin/common/buffer_conversions.mm
+++ b/shell/platform/darwin/common/buffer_conversions.mm
@@ -19,12 +19,12 @@ class NSDataMapping : public fml::Mapping {
   }
 
   uint8_t* GetMutableMapping() const override {
-    // This is safe because the NSData instances we are wrapping all live in RAM
-    // and are short lived objects that live for the purpose of responding to
-    // messages.  We could convert the API to use NSMutableData but that is a
-    // breaking change and allocating a NSMutableData is much slower than NSData
-    // unfortunately.
-    return const_cast<uint8_t*>(static_cast<const uint8_t*>([data_.get() bytes]));
+    // TODO(tbd): Implement this so ownership can be passed to Dart.
+    // Previously this was attempted with a const_cast of the mapping.  That is
+    // safe in most cases since the data is ephemeral and we are the creaters
+    // and the sole owners of the data. That is not the case when the
+    // BinaryCodec is used however.
+    return nullptr;
   }
 
   bool IsDontNeedSafe() const override { return false; }

--- a/shell/platform/darwin/common/buffer_conversions.mm
+++ b/shell/platform/darwin/common/buffer_conversions.mm
@@ -18,6 +18,15 @@ class NSDataMapping : public fml::Mapping {
     return static_cast<const uint8_t*>([data_.get() bytes]);
   }
 
+  uint8_t* GetMutableMapping() const override {
+    // This is safe because the NSData instances we are wrapping all live in RAM
+    // and are short lived objects that live for the purpose of responding to
+    // messages.  We could convert the API to use NSMutableData but that is a
+    // breaking change and allocating a NSMutableData is much slower than NSData
+    // unfortunately.
+    return const_cast<uint8_t*>(static_cast<const uint8_t*>([data_.get() bytes]));
+  }
+
   bool IsDontNeedSafe() const override { return false; }
 
  private:

--- a/shell/platform/fuchsia/flutter/file_in_namespace_buffer.h
+++ b/shell/platform/fuchsia/flutter/file_in_namespace_buffer.h
@@ -23,6 +23,9 @@ class FileInNamespaceBuffer final : public fml::Mapping {
   const uint8_t* GetMapping() const override;
 
   // |fml::Mapping|
+  uint8_t* GetMutableMapping() const override { return nullptr; }
+
+  // |fml::Mapping|
   size_t GetSize() const override;
 
   // |fml::Mapping|

--- a/third_party/tonic/typed_data/dart_byte_data.cc
+++ b/third_party/tonic/typed_data/dart_byte_data.cc
@@ -11,16 +11,14 @@
 namespace tonic {
 
 namespace {
-
-// For large objects it is more efficient to use an external typed data object
-// with a buffer allocated outside the Dart heap.
-const int kExternalSizeThreshold = 1000;
-
 void FreeFinalizer(void* isolate_callback_data, void* peer) {
   free(peer);
 }
-
 }  // anonymous namespace
+
+// For large objects it is more efficient to use an external typed data object
+// with a buffer allocated outside the Dart heap.
+const size_t DartByteData::kExternalSizeThreshold = 1000;
 
 Dart_Handle DartByteData::Create(const void* data, size_t length) {
   if (length < kExternalSizeThreshold) {

--- a/third_party/tonic/typed_data/dart_byte_data.h
+++ b/third_party/tonic/typed_data/dart_byte_data.h
@@ -14,6 +14,7 @@ namespace tonic {
 
 class DartByteData {
  public:
+  static const size_t kExternalSizeThreshold;
   static Dart_Handle Create(const void* data, size_t length);
 
   explicit DartByteData(Dart_Handle list);


### PR DESCRIPTION
This makes `platform_channel_basic_binary_2host_1MB` go from 529.2 µs to 412.4 µs (22% improvement) in my local testing.

The test is in the platform channel benchmarks in the flutter repo.

I found this optimization when exploring asset loading, so it should be beneficial there as well by eliminating a copy.

**WARNING:** Do not merge until https://github.com/flutter/flutter/pull/105982 merges in the framework.

## local testing results
Executed on iOS device.

### before
```
BasicMessageChannel/StandardMessageCodec/Flutter->Host/Small: 56.8 µs
BasicMessageChannel/StandardMessageCodec/Flutter->Host/Large: 684.4 µs
BasicMessageChannel/BinaryCodec/Flutter->Host/Large: 49.7 µs
BasicMessageChannel/BinaryCodec/Flutter->Host/1MB: 529.2 µs
BasicMessageChannel/StandardMessageCodec/Flutter->Host/SmallParallel3: 26.1 µs
BasicMessageChannel/StandardMessageCodec/Flutter->Host (background)/Small: 39.6 µs
BasicMessageChannel/StandardMessageCodec/Flutter->Host (background)/SmallParallel3: 22.3 µs
```

### after
```
BasicMessageChannel/StandardMessageCodec/Flutter->Host/Small: 54.4 µs
BasicMessageChannel/StandardMessageCodec/Flutter->Host/Large: 685.3 µs
BasicMessageChannel/BinaryCodec/Flutter->Host/Large: 50.1 µs
BasicMessageChannel/BinaryCodec/Flutter->Host/1MB: 412.4 µs
BasicMessageChannel/StandardMessageCodec/Flutter->Host/SmallParallel3: 25.3 µs
BasicMessageChannel/StandardMessageCodec/Flutter->Host (background)/Small: 39.3 µs
BasicMessageChannel/StandardMessageCodec/Flutter->Host (background)/SmallParallel3: 22.4 µs
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
