### PR TITLE
[Linux][Testing] reduce the boilerplate for MockBinaryMessenger

### DIFF
--- a/shell/platform/linux/fl_settings_plugin_test.cc
+++ b/shell/platform/linux/fl_settings_plugin_test.cc
@@ -25,19 +25,18 @@ MATCHER_P2(HasSetting, key, value, "") {
   return false;
 }
 
-#define EXPECT_SETTING(mock, messenger, key, value)                            \
-  EXPECT_CALL(mock, fl_binary_messenger_send_on_channel(                       \
-                        messenger, ::testing::StrEq("flutter/settings"),       \
-                        HasSetting(key, value), ::testing::A<GCancellable*>(), \
-                        ::testing::A<GAsyncReadyCallback>(),                   \
-                        ::testing::A<gpointer>()))
+#define EXPECT_SETTING(messenger, key, value)                                 \
+  EXPECT_CALL(                                                                \
+      messenger,                                                              \
+      fl_binary_messenger_send_on_channel(                                    \
+          ::testing::Eq<FlBinaryMessenger*>(messenger),                       \
+          ::testing::StrEq("flutter/settings"), HasSetting(key, value),       \
+          ::testing::A<GCancellable*>(), ::testing::A<GAsyncReadyCallback>(), \
+          ::testing::A<gpointer>()))
 
 TEST(FlSettingsPluginTest, AlwaysUse24HourFormat) {
   ::testing::NiceMock<flutter::testing::MockSettings> settings;
-
-  ::testing::NiceMock<flutter::testing::MockBinaryMessenger> mock_messenger;
-  g_autoptr(FlBinaryMessenger) messenger =
-      fl_binary_messenger_new_mock(&mock_messenger);
+  ::testing::NiceMock<flutter::testing::MockBinaryMessenger> messenger;
 
   g_autoptr(FlSettingsPlugin) plugin = fl_settings_plugin_new(messenger);
 
@@ -49,21 +48,18 @@ TEST(FlSettingsPluginTest, AlwaysUse24HourFormat) {
       .WillOnce(::testing::Return(FL_CLOCK_FORMAT_12H))
       .WillOnce(::testing::Return(FL_CLOCK_FORMAT_24H));
 
-  EXPECT_SETTING(mock_messenger, messenger, "alwaysUse24HourFormat", use_12h);
+  EXPECT_SETTING(messenger, "alwaysUse24HourFormat", use_12h);
 
   fl_settings_plugin_start(plugin, settings);
 
-  EXPECT_SETTING(mock_messenger, messenger, "alwaysUse24HourFormat", use_24h);
+  EXPECT_SETTING(messenger, "alwaysUse24HourFormat", use_24h);
 
   fl_settings_emit_changed(settings);
 }
 
 TEST(FlSettingsPluginTest, PlatformBrightness) {
   ::testing::NiceMock<flutter::testing::MockSettings> settings;
-
-  ::testing::NiceMock<flutter::testing::MockBinaryMessenger> mock_messenger;
-  g_autoptr(FlBinaryMessenger) messenger =
-      fl_binary_messenger_new_mock(&mock_messenger);
+  ::testing::NiceMock<flutter::testing::MockBinaryMessenger> messenger;
 
   g_autoptr(FlSettingsPlugin) plugin = fl_settings_plugin_new(messenger);
 
@@ -75,21 +71,18 @@ TEST(FlSettingsPluginTest, PlatformBrightness) {
       .WillOnce(::testing::Return(FL_COLOR_SCHEME_LIGHT))
       .WillOnce(::testing::Return(FL_COLOR_SCHEME_DARK));
 
-  EXPECT_SETTING(mock_messenger, messenger, "platformBrightness", light);
+  EXPECT_SETTING(messenger, "platformBrightness", light);
 
   fl_settings_plugin_start(plugin, settings);
 
-  EXPECT_SETTING(mock_messenger, messenger, "platformBrightness", dark);
+  EXPECT_SETTING(messenger, "platformBrightness", dark);
 
   fl_settings_emit_changed(settings);
 }
 
 TEST(FlSettingsPluginTest, TextScaleFactor) {
   ::testing::NiceMock<flutter::testing::MockSettings> settings;
-
-  ::testing::NiceMock<flutter::testing::MockBinaryMessenger> mock_messenger;
-  g_autoptr(FlBinaryMessenger) messenger =
-      fl_binary_messenger_new_mock(&mock_messenger);
+  ::testing::NiceMock<flutter::testing::MockBinaryMessenger> messenger;
 
   g_autoptr(FlSettingsPlugin) plugin = fl_settings_plugin_new(messenger);
 
@@ -101,11 +94,11 @@ TEST(FlSettingsPluginTest, TextScaleFactor) {
       .WillOnce(::testing::Return(1.0))
       .WillOnce(::testing::Return(2.0));
 
-  EXPECT_SETTING(mock_messenger, messenger, "textScaleFactor", one);
+  EXPECT_SETTING(messenger, "textScaleFactor", one);
 
   fl_settings_plugin_start(plugin, settings);
 
-  EXPECT_SETTING(mock_messenger, messenger, "textScaleFactor", two);
+  EXPECT_SETTING(messenger, "textScaleFactor", two);
 
   fl_settings_emit_changed(settings);
 }

--- a/shell/platform/linux/fl_text_input_plugin_test.cc
+++ b/shell/platform/linux/fl_text_input_plugin_test.cc
@@ -49,15 +49,14 @@ static FlValue* build_list(std::vector<FlValue*> args) {
 }
 
 TEST(FlTextInputPluginTest, SetClient) {
-  ::testing::NiceMock<flutter::testing::MockBinaryMessenger> mock;
-  g_autoptr(FlBinaryMessenger) messenger = fl_binary_messenger_new_mock(&mock);
+  ::testing::NiceMock<flutter::testing::MockBinaryMessenger> messenger;
   auto filter =
       +[](GtkIMContext* im_context, gpointer gdk_event) { return false; };
 
   fl_text_input_plugin_new(messenger, nullptr,
                            FlTextInputPluginImFilter(filter));
 
-  EXPECT_TRUE(mock.HasMessageHandler("flutter/textinput"));
+  EXPECT_TRUE(messenger.HasMessageHandler("flutter/textinput"));
 
   g_autoptr(FlValue) args = build_list({
       fl_value_new_int(1),  // client id
@@ -75,11 +74,11 @@ TEST(FlTextInputPluginTest, SetClient) {
       FL_METHOD_CODEC(codec), "TextInput.setClient", args, nullptr);
 
   g_autoptr(FlValue) null = fl_value_new_null();
-  EXPECT_CALL(mock, fl_binary_messenger_send_response(
-                        ::testing::Eq(messenger),
-                        ::testing::A<FlBinaryMessengerResponseHandle*>(),
-                        SuccessResponse(null), ::testing::A<GError**>()))
+  EXPECT_CALL(messenger, fl_binary_messenger_send_response(
+                             ::testing::Eq<FlBinaryMessenger*>(messenger),
+                             ::testing::A<FlBinaryMessengerResponseHandle*>(),
+                             SuccessResponse(null), ::testing::A<GError**>()))
       .WillOnce(::testing::Return(true));
 
-  mock.ReceiveMessage(messenger, "flutter/textinput", message);
+  messenger.ReceiveMessage("flutter/textinput", message);
 }

--- a/shell/platform/linux/testing/mock_binary_messenger.h
+++ b/shell/platform/linux/testing/mock_binary_messenger.h
@@ -17,6 +17,11 @@ namespace testing {
 // Mock for FlBinaryMessenger.
 class MockBinaryMessenger {
  public:
+  MockBinaryMessenger();
+  ~MockBinaryMessenger();
+
+  operator FlBinaryMessenger*();
+
   MOCK_METHOD5(fl_binary_messenger_set_message_handler_on_channel,
                void(FlBinaryMessenger* messenger,
                     const gchar* channel,
@@ -49,11 +54,10 @@ class MockBinaryMessenger {
                          FlBinaryMessengerMessageHandler handler,
                          gpointer user_data);
 
-  void ReceiveMessage(FlBinaryMessenger* messenger,
-                      const gchar* channel,
-                      GBytes* message);
+  void ReceiveMessage(const gchar* channel, GBytes* message);
 
  private:
+  FlBinaryMessenger* instance_ = nullptr;
   std::unordered_map<std::string, FlBinaryMessengerMessageHandler>
       message_handlers;
   std::unordered_map<std::string, FlBinaryMessengerResponseHandle*>
@@ -63,8 +67,5 @@ class MockBinaryMessenger {
 
 }  // namespace testing
 }  // namespace flutter
-
-FlBinaryMessenger* fl_binary_messenger_new_mock(
-    flutter::testing::MockBinaryMessenger* mock);
 
 #endif  // FLUTTER_SHELL_PLATFORM_LINUX_TESTING_MOCK_BINARY_MESSENGER_H_


### PR DESCRIPTION
Let `MockBinaryMessenger` internally manage the `FlBinaryMessenger` wrapper
instance and provide it via `operator FlBinaryMessenger*()` to avoid
having to create two objects in every test. The same technique was used
for `MockSettings` in #32618.

This helps to reduce the boilerplate required in the upcoming [text input
tests](https://github.com/jpnurmi/engine/commits/test-text-input) that heavily rely on `MockBinaryMessenger`.

Before:
```c++
::testing::NiceMock<flutter::testing::MockBinaryMessenger> mock_messenger;
g_autoptr(FlBinaryMessenger) messenger =
    fl_binary_messenger_new_mock(&mock_messenger);
// ...
mock.ReceiveMessage(messenger, "flutter/foo", message);
```

After:
```c++
::testing::NiceMock<flutter::testing::MockBinaryMessenger> messenger;
// ...
messenger.ReceiveMessage("flutter/foo", message);
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.