### PR TITLE
[Linux] remove duplicate clone_string() in favor of g_strdup()

### DIFF
--- a/shell/platform/linux/fl_key_channel_responder_test.cc
+++ b/shell/platform/linux/fl_key_channel_responder_test.cc
@@ -29,20 +29,6 @@ static void responder_callback(bool handled, gpointer user_data) {
   g_main_loop_quit(static_cast<GMainLoop*>(user_data));
 }
 
-// Clone string onto the heap.
-//
-// If #string is nullptr, returns nullptr.  Otherwise, the returned pointer must
-// be freed with g_free.
-static char* clone_string(const char* string) {
-  if (string == nullptr) {
-    return nullptr;
-  }
-  size_t len = strlen(string);
-  char* result = g_new(char, len + 1);
-  strncpy(result, string, len + 1);
-  return result;
-}
-
 namespace {
 // A global variable to store new event. It is a global variable so that it can
 // be returned by #fl_key_event_new_by_mock for easy use.
@@ -69,7 +55,7 @@ static FlKeyEvent* fl_key_event_new_by_mock(guint32 time_in_milliseconds,
   _g_key_event.time = time_in_milliseconds;
   _g_key_event.state = state;
   _g_key_event.keyval = keyval;
-  _g_key_event.string = clone_string(string);
+  _g_key_event.string = g_strdup(string);
   _g_key_event.keycode = keycode;
   _g_key_event.origin = nullptr;
   _g_key_event.dispose_origin = nullptr;

--- a/shell/platform/linux/fl_key_event.cc
+++ b/shell/platform/linux/fl_key_event.cc
@@ -9,16 +9,6 @@ static void dispose_origin_from_gdk_event(gpointer origin) {
   gdk_event_free(reinterpret_cast<GdkEvent*>(origin));
 }
 
-static char* clone_string(const char* source) {
-  if (source == nullptr) {
-    return nullptr;
-  }
-  size_t length = strlen(source);
-  char* result = g_new(char, length + 1);
-  strncpy(result, source, length + 1);
-  return result;
-}
-
 FlKeyEvent* fl_key_event_new_from_gdk_event(GdkEvent* raw_event) {
   g_return_val_if_fail(raw_event != nullptr, nullptr);
   GdkEventKey* event = reinterpret_cast<GdkEventKey*>(raw_event);
@@ -32,7 +22,7 @@ FlKeyEvent* fl_key_event_new_from_gdk_event(GdkEvent* raw_event) {
   result->keycode = event->hardware_keycode;
   result->keyval = event->keyval;
   result->state = event->state;
-  result->string = clone_string(event->string);
+  result->string = g_strdup(event->string);
   result->group = event->group;
   result->origin = event;
   result->dispose_origin = dispose_origin_from_gdk_event;
@@ -53,6 +43,6 @@ void fl_key_event_dispose(FlKeyEvent* event) {
 FlKeyEvent* fl_key_event_clone(const FlKeyEvent* event) {
   FlKeyEvent* new_event = g_new(FlKeyEvent, 1);
   *new_event = *event;
-  new_event->string = clone_string(event->string);
+  new_event->string = g_strdup(event->string);
   return new_event;
 }


### PR DESCRIPTION
GLib's `g_strdup()` offers the same behavior that it returns `NULL` if the argument is `NULL`: https://docs.gtk.org/glib/func.strdup.html

For reference: [gstrfuncs.c#L344-L370](https://github.com/GNOME/glib/blob/2e1218ebe1e95a650a7328599e9dc1658e060939/glib/gstrfuncs.c#L344-L370)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.