### PR TITLE
Document PointerChange and PointerDeviceKind

### DIFF
--- a/lib/ui/pointer.dart
+++ b/lib/ui/pointer.dart
@@ -104,12 +104,13 @@ enum PointerDeviceKind {
   ///
   /// Some platforms don't support (or don't fully support) trackpad
   /// gestures, and might convert trackpad gestures into fake pointer events
-  /// that simulate dragging. This includes Web, and iOS when
-  /// `UIApplicationSupportsIndirectInputEvents` isn't present in `Info.plist`
-  /// or returns NO.
+  /// that simulate dragging. These events typically have kind [touch] or
+  /// [mouse] instead of [trackpad]. This includes (but is not limited to) Web,
+  /// and iOS when `UIApplicationSupportsIndirectInputEvents` isn't present in
+  /// `Info.plist` or returns NO.
   ///
-  /// Moving the pointing cursor or clicking typically triggers [touch] or
-  /// [mouse] events, but never triggers [trackpad] events.
+  /// Moving the pointing cursor or clicking with a trackpad typically triggers
+  /// [touch] or [mouse] events, but never triggers [trackpad] events.
   ///
   /// See also:
   ///

--- a/lib/ui/pointer.dart
+++ b/lib/ui/pointer.dart
@@ -38,12 +38,18 @@ enum PointerChange {
   up,
 
   /// A pan/zoom has started on this pointer.
+  ///
+  /// This type of events will always have kind [PointerDeviceKind.trackpad].
   panZoomStart,
 
   /// The pan/zoom on this pointer has updated.
+  ///
+  /// This type of events will always have kind [PointerDeviceKind.trackpad].
   panZoomUpdate,
 
   /// The pan/zoom on this pointer has ended.
+  ///
+  /// This type of events will always have kind [PointerDeviceKind.trackpad].
   panZoomEnd,
 }
 

--- a/lib/ui/pointer.dart
+++ b/lib/ui/pointer.dart
@@ -39,17 +39,17 @@ enum PointerChange {
 
   /// A pan/zoom has started on this pointer.
   ///
-  /// This type of events will always have kind [PointerDeviceKind.trackpad].
+  /// This type of event will always have kind [PointerDeviceKind.trackpad].
   panZoomStart,
 
   /// The pan/zoom on this pointer has updated.
   ///
-  /// This type of events will always have kind [PointerDeviceKind.trackpad].
+  /// This type of event will always have kind [PointerDeviceKind.trackpad].
   panZoomUpdate,
 
   /// The pan/zoom on this pointer has ended.
   ///
-  /// This type of events will always have kind [PointerDeviceKind.trackpad].
+  /// This type of event will always have kind [PointerDeviceKind.trackpad].
   panZoomEnd,
 }
 
@@ -59,10 +59,10 @@ enum PointerDeviceKind {
   ///
   /// The most common case is a touch screen.
   ///
-  /// When the user is operating with a trackpad on iOS (for example, Magic
-  /// Keyboard on iPad), clicking will also dispatch events with kind [touch] if
-  /// `Info.plist` is not present or returns NO for
-  /// `UIApplicationSupportsIndirectInputEvents`.
+  /// When the user is operating with a trackpad on iOS, clicking will also
+  /// dispatch events with kind [touch] if
+  /// `UIApplicationSupportsIndirectInputEvents` is not present in `Info.plist`
+  /// or returns NO.
   ///
   /// See also:
   ///
@@ -73,10 +73,11 @@ enum PointerDeviceKind {
   ///
   /// The most common case is a mouse on the desktop or Web.
   ///
-  /// When the user is operating with a trackpad on iOS (for example, Magic
-  /// Keyboard on iPad), moving the pointing cursor will also dispatch events
-  /// with kind [mouse], and clicking will dispatch events with kind [mouse] if
-  /// `Info.plist` returns YES for `UIApplicationSupportsIndirectInputEvents`.
+  /// When the user is operating with a trackpad on iOS, moving the pointing
+  /// cursor will also dispatch events with kind [mouse], and clicking will
+  /// dispatch events with kind [mouse] if
+  /// `UIApplicationSupportsIndirectInputEvents` is not present in `Info.plist`
+  /// or returns NO.
   ///
   /// See also:
   ///
@@ -89,21 +90,26 @@ enum PointerDeviceKind {
   /// A pointer device with a stylus that has been inverted.
   invertedStylus,
 
-  /// Gestures from a touch-based pointer device with an indirect surface.
+  /// Gestures from a trackpad.
   ///
-  /// On supporting platforms, when the user is operating on a physical
-  /// trackpad, events with kind [trackpad] are dispatched when the user
-  /// performs gestures on the trackpad, such as panning, zooming, scrolling,
-  /// or rotating. The [trackpad] kind is only found with [PointerChange] `add`,
+  /// A trackpad here is defined as a touch-based pointer device with an
+  /// indirect surface (the user operates the screen by touching something that
+  /// is not the screen).
+  ///
+  /// When the user makes zoom, pan, scroll or rotate gestures with a physical
+  /// trackpad, supporting platforms dispatch events with kind [trackpad].
+  ///
+  /// Events with kind [trackpad] can only have a [PointerChange] of `add`,
   /// `remove`, and pan-zoom related values.
   ///
-  /// Some platforms do not support or fully support trackpad gestures, and
-  /// might convert trackpad gestures into fake pointer events that simulate
-  /// dragging. This include Web, and iOS when `Info.plist` is not present or
-  /// returns NO for `UIApplicationSupportsIndirectInputEvents`.
+  /// Some platforms don't support (or don't fully support) trackpad
+  /// gestures, and might convert trackpad gestures into fake pointer events
+  /// that simulate dragging. This includes Web, and iOS when
+  /// `UIApplicationSupportsIndirectInputEvents` isn't present in `Info.plist`
+  /// or returns NO.
   ///
-  /// Moving the pointing cursor or clicking never triggers events with
-  /// kind [trackpad], but typically [touch] or [mouse].
+  /// Moving the pointing cursor or clicking typically triggers [touch] or
+  /// [mouse] events, but never triggers [trackpad] events.
   ///
   /// See also:
   ///

--- a/lib/ui/pointer.dart
+++ b/lib/ui/pointer.dart
@@ -94,8 +94,8 @@ enum PointerDeviceKind {
   /// On supporting platforms, when the user is operating on a physical
   /// trackpad, events with kind [trackpad] are dispatched when the user
   /// performs gestures on the trackpad, such as panning, zooming, scrolling,
-  /// or rotating. The [trackpad] kind is only found with pan-zoom
-  /// [PointerChange]s.
+  /// or rotating. The [trackpad] kind is only found with [PointerChange] `add`,
+  /// `remove`, and pan-zoom related values.
   ///
   /// Some platforms do not support or fully support trackpad gestures, and
   /// might convert trackpad gestures into fake pointer events that simulate

--- a/lib/ui/pointer.dart
+++ b/lib/ui/pointer.dart
@@ -66,7 +66,7 @@ enum PointerDeviceKind {
   ///
   /// See also:
   ///
-  ///  * [UIKit's documentation for UIApplicationSupportsIndirectInputEvents](https://developer.apple.com/documentation/bundleresources/information_property_list/uiapplicationsupportsindirectinputevents?language=objc).
+  ///  * [UIApplicationSupportsIndirectInputEvents](https://developer.apple.com/documentation/bundleresources/information_property_list/uiapplicationsupportsindirectinputevents?language=objc).
   touch,
 
   /// A mouse-based pointer device.
@@ -80,7 +80,7 @@ enum PointerDeviceKind {
   ///
   /// See also:
   ///
-  ///  * https://developer.apple.com/documentation/bundleresources/information_property_list/uiapplicationsupportsindirectinputevents?language=objc
+  ///  * [UIApplicationSupportsIndirectInputEvents](https://developer.apple.com/documentation/bundleresources/information_property_list/uiapplicationsupportsindirectinputevents?language=objc).
   mouse,
 
   /// A pointer device with a stylus.
@@ -107,7 +107,7 @@ enum PointerDeviceKind {
   ///
   /// See also:
   ///
-  ///  * https://developer.apple.com/documentation/bundleresources/information_property_list/uiapplicationsupportsindirectinputevents?language=objc
+  ///  * [UIApplicationSupportsIndirectInputEvents](https://developer.apple.com/documentation/bundleresources/information_property_list/uiapplicationsupportsindirectinputevents?language=objc).
   trackpad,
 
   /// An unknown pointer device.

--- a/lib/ui/pointer.dart
+++ b/lib/ui/pointer.dart
@@ -50,9 +50,31 @@ enum PointerChange {
 /// The kind of pointer device.
 enum PointerDeviceKind {
   /// A touch-based pointer device.
+  ///
+  /// The most common case is a touch screen.
+  ///
+  /// When the user is operating with a trackpad on iOS (for example, Magic
+  /// Keyboard on iPad), clicking will also dispatch events with kind [touch] if
+  /// `Info.plist` is not present or returns NO for
+  /// `UIApplicationSupportsIndirectInputEvents`.
+  ///
+  /// See also:
+  ///
+  ///  * [UIKit's documentation for UIApplicationSupportsIndirectInputEvents](https://developer.apple.com/documentation/bundleresources/information_property_list/uiapplicationsupportsindirectinputevents?language=objc).
   touch,
 
   /// A mouse-based pointer device.
+  ///
+  /// The most common case is a mouse on the desktop or Web.
+  ///
+  /// When the user is operating with a trackpad on iOS (for example, Magic
+  /// Keyboard on iPad), moving the pointing cursor will also dispatch events
+  /// with kind [mouse], and clicking will dispatch events with kind [mouse] if
+  /// `Info.plist` returns YES for `UIApplicationSupportsIndirectInputEvents`.
+  ///
+  /// See also:
+  ///
+  ///  * https://developer.apple.com/documentation/bundleresources/information_property_list/uiapplicationsupportsindirectinputevents?language=objc
   mouse,
 
   /// A pointer device with a stylus.
@@ -61,7 +83,25 @@ enum PointerDeviceKind {
   /// A pointer device with a stylus that has been inverted.
   invertedStylus,
 
-  /// A touch-based pointer device with an indirect surface.
+  /// Gestures from a touch-based pointer device with an indirect surface.
+  ///
+  /// On supporting platforms, when the user is operating on a physical
+  /// trackpad, events with kind [trackpad] are dispatched when the user
+  /// performs gestures on the trackpad, such as panning, zooming, scrolling,
+  /// or rotating. The [trackpad] kind is only found with pan-zoom
+  /// [PointerChange]s.
+  ///
+  /// Some platforms do not support or fully support trackpad gestures, and
+  /// might convert trackpad gestures into fake pointer events that simulate
+  /// dragging. This include Web, and iOS when `Info.plist` is not present or
+  /// returns NO for `UIApplicationSupportsIndirectInputEvents`.
+  ///
+  /// Moving the pointing cursor or clicking never triggers events with
+  /// kind [trackpad], but typically [touch] or [mouse].
+  ///
+  /// See also:
+  ///
+  ///  * https://developer.apple.com/documentation/bundleresources/information_property_list/uiapplicationsupportsindirectinputevents?language=objc
   trackpad,
 
   /// An unknown pointer device.


### PR DESCRIPTION
This PR adds some documentation to `PointerChange` and `PointerDeviceKind`.

The relationship between them and the situation for the values have been complicated with the addition of support for trackpad.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
