### PR TITLE
[Web] Ignore pointer up and pointer cancel for unknown device

### DIFF
--- a/lib/web_ui/lib/src/engine/pointer_binding.dart
+++ b/lib/web_ui/lib/src/engine/pointer_binding.dart
@@ -575,9 +575,12 @@ class _PointerAdapter extends _BaseAdapter with _WheelEventListenerMixin {
   }
 
   _ButtonSanitizer _getSanitizer(int device) {
-    final _ButtonSanitizer sanitizer = _sanitizers[device]!;
-    assert(sanitizer != null); // ignore: unnecessary_null_comparison
-    return sanitizer;
+    assert(_sanitizers[device] != null);
+    return _sanitizers[device]!;
+  }
+
+  bool _hasSanitizer(int device) {
+    return _sanitizers.containsKey(device);
   }
 
   void _removePointerIfUnhoverable(html.PointerEvent event) {
@@ -647,12 +650,14 @@ class _PointerAdapter extends _BaseAdapter with _WheelEventListenerMixin {
 
     _addPointerEventListener(html.window, 'pointerup', (html.PointerEvent event) {
       final int device = _getPointerId(event);
-      final List<ui.PointerData> pointerData = <ui.PointerData>[];
-      final _SanitizedDetails? details = _getSanitizer(device).sanitizeUpEvent(buttons: event.buttons);
-      _removePointerIfUnhoverable(event);
-      if (details != null) {
-        _convertEventsToPointerData(data: pointerData, event: event, details: details);
-        _callback(pointerData);
+      if (_hasSanitizer(device)) {
+        final List<ui.PointerData> pointerData = <ui.PointerData>[];
+        final _SanitizedDetails? details = _getSanitizer(device).sanitizeUpEvent(buttons: event.buttons);
+        _removePointerIfUnhoverable(event);
+        if (details != null) {
+          _convertEventsToPointerData(data: pointerData, event: event, details: details);
+          _callback(pointerData);
+        }
       }
     });
 
@@ -660,11 +665,13 @@ class _PointerAdapter extends _BaseAdapter with _WheelEventListenerMixin {
     // be able to generate events (example: device is deactivated)
     _addPointerEventListener(glassPaneElement, 'pointercancel', (html.PointerEvent event) {
       final int device = _getPointerId(event);
-      final List<ui.PointerData> pointerData = <ui.PointerData>[];
-      final _SanitizedDetails details = _getSanitizer(device).sanitizeCancelEvent();
-      _removePointerIfUnhoverable(event);
-      _convertEventsToPointerData(data: pointerData, event: event, details: details);
-      _callback(pointerData);
+      if (_hasSanitizer(device)) {
+        final List<ui.PointerData> pointerData = <ui.PointerData>[];
+        final _SanitizedDetails details = _getSanitizer(device).sanitizeCancelEvent();
+        _removePointerIfUnhoverable(event);
+        _convertEventsToPointerData(data: pointerData, event: event, details: details);
+        _callback(pointerData);
+      }
     });
 
     _addWheelEventListener((html.Event event) {

--- a/lib/web_ui/test/engine/pointer_binding_test.dart
+++ b/lib/web_ui/test/engine/pointer_binding_test.dart
@@ -2136,6 +2136,30 @@ void testMain() {
 
   _testEach<_PointerEventContext>(
     <_PointerEventContext>[
+      if (!isIosSafari) _PointerEventContext(),
+    ],
+    'ignores pointer up or pointer cancel events for unknown device',
+    (_PointerEventContext context) {
+      PointerBinding.instance!.debugOverrideDetector(context);
+      final List<ui.PointerDataPacket> packets = <ui.PointerDataPacket>[];
+      ui.window.onPointerDataPacket = (ui.PointerDataPacket packet) {
+        packets.add(packet);
+      };
+
+      context.multiTouchUp(const <_TouchDetails>[
+        _TouchDetails(pointer: 23, clientX: 200, clientY: 202),
+      ]).forEach(glassPane.dispatchEvent);
+      expect(packets, hasLength(0));
+
+      context.multiTouchCancel(const <_TouchDetails>[
+        _TouchDetails(pointer: 24, clientX: 200, clientY: 202),
+      ]).forEach(glassPane.dispatchEvent);
+      expect(packets, hasLength(0));
+    },
+  );
+
+  _testEach<_PointerEventContext>(
+    <_PointerEventContext>[
       _PointerEventContext(),
     ],
     'handles random pointer id on up events',


### PR DESCRIPTION
## Description

This PR is an attempt to fix the `Unexpected null value` error thrown when using the Chrome DevTools on mobile mode and clicking on the top left corner.

Before this PR, the error is thrown because the `pointerup` handler expects that there was a previous `pointerdown` handler which called `_ensureSanitizer` for the device.

This is not the case when opening DevTools and switching it to mobile mode, because :
- Chrome DevTools sends event of `PointerDeviceKind.touch` instead of `PointerDeviceKind.mouse` **and** create a new pointerId on each pointer down event.
- Chrome DevTools set the event target to the `html` DOM element when the event is on the top left corner (elsewhere the target is Flutter Web glass pane). This is related to the `<flt-semantics-placeholder>` DOM element (the problem doesn't occur when this element is removed).

The fix included in this PR is to ignore pointer up and pointer cancel events when the device is unknown. This is to improve the developer experience (especially when the debugger is configured to break on `Uncaught Exceptions`).

Alternative solutions :
- Digging in Chrome DevTools code (seems too complex for this case).
- Changing how the Semantic placeholder is created (it doesn't seem sensible to change it for this edge case and it is not obvious which change can be made).

## Related Issue

Fixes https://github.com/flutter/flutter/issues/105458

## Tests

Adds 1 test.