### PR TITLE
[Impeller] Add Path::IsRectangle

### DIFF
--- a/impeller/geometry/geometry_unittests.cc
+++ b/impeller/geometry/geometry_unittests.cc
@@ -1120,6 +1120,31 @@ TEST(GeometryTest, PathPolylineDuplicatesAreRemovedForSameContour) {
   ASSERT_EQ(polyline.points[6], Point(0, 100));
 }
 
+TEST(GeometryTest, PathIsRectangle) {
+  {
+    Rect rect = Rect::MakeLTRB(100, 110, 210, 230);
+    Path path = PathBuilder{}.AddRect(rect).TakePath();
+    ASSERT_TRUE(path.IsRectangle());
+
+    auto bounds = path.GetBoundingBox();
+    ASSERT_TRUE(bounds.has_value());
+    ASSERT_RECT_NEAR(bounds.value(), rect);
+  }
+
+  {
+    Path path = PathBuilder{}
+                    .AddRect(Rect::MakeLTRB(100, 110, 210, 230))
+                    .AddRect(Rect::MakeLTRB(10, 10, 20, 20))
+                    .TakePath();
+    ASSERT_FALSE(path.IsRectangle());
+  }
+
+  {
+    Path path = PathBuilder{}.AddCircle(Point(), 10).TakePath();
+    ASSERT_FALSE(path.IsRectangle());
+  }
+}
+
 TEST(GeometryTest, VerticesConstructorAndGetters) {
   std::vector<Point> points = {Point(1, 2), Point(2, 3), Point(3, 4)};
   std::vector<uint16_t> indices = {0, 1, 2};

--- a/impeller/geometry/path.cc
+++ b/impeller/geometry/path.cc
@@ -274,6 +274,26 @@ Path::Polyline Path::CreatePolyline(
   }
   return polyline;
 }
+bool Path::IsRectangle() const {
+  // Typically, closed paths have a second, empty contour. Empty contours are
+  // not included in the generated polyline.
+  if (linears_.size() != 4 || contours_.size() > 2 || components_.size() > 6) {
+    return false;
+  }
+
+  auto polyline = CreatePolyline();
+  std::vector<Point>& points = polyline.points;
+  if (polyline.contours.size() != 1 || points.size() != 5 ||
+      points[0] != points[4]) {
+    return false;
+  }
+
+  Point diag = points[2] - points[0];
+  Point a = points[0] + Point(diag.x, 0);
+  Point b = points[0] + Point(0, diag.y);
+  return (points[1] == a && points[3] == b) ||
+         (points[1] == b && points[3] == a);
+}
 
 std::optional<Rect> Path::GetBoundingBox() const {
   auto min_max = GetMinMaxCoveragePoints();

--- a/impeller/geometry/path.h
+++ b/impeller/geometry/path.h
@@ -119,6 +119,8 @@ class Path {
   Polyline CreatePolyline(
       const SmoothingApproximation& approximation = {}) const;
 
+  bool IsRectangle() const;
+
   std::optional<Rect> GetBoundingBox() const;
 
   std::optional<Rect> GetTransformedBoundingBox(const Matrix& transform) const;


### PR DESCRIPTION
Used for detecting when a path is just a rectangle. This is useful for selecting an algorithm to use for producing shadows -- box shadows being among the most common.