### PR TITLE
[Impeller] WIP: Render shadows for rectangle paths

### DIFF
--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -129,8 +129,7 @@ void Canvas::DrawPath(Path path, Paint paint) {
   entity.SetTransformation(GetCurrentTransformation());
   entity.SetStencilDepth(GetStencilDepth());
   entity.SetBlendMode(paint.blend_mode);
-  entity.SetContents(
-      paint.WithFilters(paint.CreateContentsForEntity(std::move(path))));
+  entity.SetContents(paint.CreateContentsForEntity(std::move(path)));
 
   GetCurrentPass().AddEntity(std::move(entity));
 }
@@ -240,7 +239,7 @@ void Canvas::DrawImageRect(std::shared_ptr<Image> image,
   Entity entity;
   entity.SetBlendMode(paint.blend_mode);
   entity.SetStencilDepth(GetStencilDepth());
-  entity.SetContents(paint.WithFilters(contents, false));
+  entity.SetContents(paint.WithFilters(contents, true, false));
   entity.SetTransformation(GetCurrentTransformation());
 
   GetCurrentPass().AddEntity(std::move(entity));
@@ -297,7 +296,7 @@ void Canvas::DrawTextFrame(TextFrame text_frame, Point position, Paint paint) {
                            Matrix::MakeTranslation(position));
   entity.SetStencilDepth(GetStencilDepth());
   entity.SetBlendMode(paint.blend_mode);
-  entity.SetContents(paint.WithFilters(std::move(text_contents), true));
+  entity.SetContents(paint.WithFilters(std::move(text_contents), true, true));
 
   GetCurrentPass().AddEntity(std::move(entity));
 }
@@ -312,7 +311,7 @@ void Canvas::DrawVertices(Vertices vertices,
   entity.SetTransformation(GetCurrentTransformation());
   entity.SetStencilDepth(GetStencilDepth());
   entity.SetBlendMode(paint.blend_mode);
-  entity.SetContents(paint.WithFilters(std::move(contents), true));
+  entity.SetContents(paint.WithFilters(std::move(contents), false));
 
   GetCurrentPass().AddEntity(std::move(entity));
 }

--- a/impeller/aiks/paint.h
+++ b/impeller/aiks/paint.h
@@ -29,6 +29,11 @@ struct Paint {
     kStroke,
   };
 
+  struct MaskBlur {
+    FilterContents::Sigma sigma;
+    FilterContents::BlurStyle style;
+  };
+
   Color color = Color::Black();
   std::shared_ptr<LinearGradientContents> contents;
 
@@ -41,21 +46,23 @@ struct Paint {
 
   std::optional<ImageFilterProc> image_filter;
   std::optional<ColorFilterProc> color_filter;
-  std::optional<MaskFilterProc> mask_filter;
+  std::optional<MaskBlur> mask_blur;
 
   /// @brief      Wrap this paint's configured filters to the given contents.
-  /// @param[in]  input           The contents to wrap with paint's filters.
-  /// @param[in]  is_solid_color  Affects mask blurring behavior. If false, use
-  ///                             the image border for mask blurring. If true,
-  ///                             do a Gaussian blur to achieve the mask
-  ///                             blurring effect for arbitrary paths. If unset,
-  ///                             use the current paint configuration to infer
-  ///                             the result.
+  /// @param[in]  input             The contents to wrap with paint's filters.
+  /// @param[in]  with_mask_filter  If false, don't append the mask filter.
+  /// @param[in]  is_solid_color    Affects mask blurring behavior. If false,
+  ///                               use the image border for mask blurring. If
+  ///                               true, do a Gaussian blur to achieve the mask
+  ///                               blurring effect for arbitrary paths. If
+  ///                               unset, use the current paint configuration
+  ///                               to infer the result.
   /// @return     The filter-wrapped contents. If there are no filters that need
   ///             to be wrapped for the current paint configuration, the
   ///             original contents is returned.
   std::shared_ptr<Contents> WithFilters(
       std::shared_ptr<Contents> input,
+      bool with_mask_filter = true,
       std::optional<bool> is_solid_color = std::nullopt) const;
 
   std::shared_ptr<Contents> CreateContentsForEntity(Path path = {},

--- a/impeller/display_list/display_list_dispatcher.cc
+++ b/impeller/display_list/display_list_dispatcher.cc
@@ -256,6 +256,7 @@ void DisplayListDispatcher::setColorFilter(
     case flutter::DlColorFilterType::kLinearToSrgbGamma:
     case flutter::DlColorFilterType::kUnknown:
       UNIMPLEMENTED;
+      paint_.color_filter = std::nullopt;
       break;
   }
 }
@@ -299,7 +300,7 @@ static FilterContents::BlurStyle ToBlurStyle(SkBlurStyle blur_style) {
 void DisplayListDispatcher::setMaskFilter(const flutter::DlMaskFilter* filter) {
   // Needs https://github.com/flutter/flutter/issues/95434
   if (filter == nullptr) {
-    paint_.mask_filter = std::nullopt;
+    paint_.mask_blur = std::nullopt;
     return;
   }
   switch (filter->type()) {
@@ -309,17 +310,12 @@ void DisplayListDispatcher::setMaskFilter(const flutter::DlMaskFilter* filter) {
       auto style = ToBlurStyle(blur->style());
       auto sigma = FilterContents::Sigma(blur->sigma());
 
-      paint_.mask_filter = [style, sigma](FilterInput::Ref input,
-                                          bool is_solid_color) {
-        if (is_solid_color) {
-          return FilterContents::MakeGaussianBlur(input, sigma, sigma, style);
-        }
-        return FilterContents::MakeBorderMaskBlur(input, sigma, sigma, style);
-      };
+      paint_.mask_blur = {sigma, style};
       break;
     }
     case flutter::DlMaskFilterType::kUnknown:
       UNIMPLEMENTED;
+      paint_.mask_blur = std::nullopt;
       break;
   }
 }
@@ -351,6 +347,7 @@ void DisplayListDispatcher::setImageFilter(
     case flutter::DlImageFilterType::kColorFilter:
     case flutter::DlImageFilterType::kUnknown:
       UNIMPLEMENTED;
+      paint_.image_filter = std::nullopt;
       break;
   }
 }

--- a/impeller/entity/BUILD.gn
+++ b/impeller/entity/BUILD.gn
@@ -28,6 +28,8 @@ impeller_shaders("entity_shaders") {
     "shaders/blending/blend.vert",
     "shaders/border_mask_blur.frag",
     "shaders/border_mask_blur.vert",
+    "shaders/box_shadow.frag",
+    "shaders/box_shadow.vert",
     "shaders/gaussian_blur.frag",
     "shaders/gaussian_blur.vert",
     "shaders/glyph_atlas.frag",
@@ -47,6 +49,8 @@ impeller_shaders("entity_shaders") {
 
 impeller_component("entity") {
   sources = [
+    "contents/box_shadow_contents.cc",
+    "contents/box_shadow_contents.h",
     "contents/clip_contents.cc",
     "contents/clip_contents.h",
     "contents/content_context.cc",

--- a/impeller/entity/contents/box_shadow_contents.cc
+++ b/impeller/entity/contents/box_shadow_contents.cc
@@ -1,0 +1,147 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/entity/contents/box_shadow_contents.h"
+#include <optional>
+
+#include "impeller/entity/contents/content_context.h"
+#include "impeller/entity/entity.h"
+#include "impeller/geometry/path.h"
+#include "impeller/geometry/path_builder.h"
+#include "impeller/renderer/render_pass.h"
+#include "impeller/tessellator/tessellator.h"
+
+namespace impeller {
+
+BoxShadowContents::BoxShadowContents() = default;
+
+BoxShadowContents::~BoxShadowContents() = default;
+
+void BoxShadowContents::SetRect(std::optional<Rect> rect) {
+  rect_ = rect;
+}
+
+void BoxShadowContents::SetSigma(FilterContents::Sigma sigma) {
+  sigma_ = sigma;
+}
+
+void BoxShadowContents::SetColor(Color color) {
+  color_ = color.Premultiply();
+}
+
+std::optional<Rect> BoxShadowContents::GetCoverage(const Entity& entity) const {
+  if (!rect_.has_value()) {
+    return std::nullopt;
+  }
+
+  Scalar border = FilterContents::Radius{sigma_}.radius;
+  Rect bounds =
+      Rect::MakeLTRB(rect_->GetLeft() - border, rect_->GetTop() - border,
+                     rect_->GetRight() + border, rect_->GetBottom() + border);
+  return bounds.TransformBounds(entity.GetTransformation());
+};
+
+/// The box shadow consists of 9 quads built from 16 vertices; 4 inner vertices
+/// and 12 outset border vertices.
+///
+///   04---05----06---07
+///   |    |      |    |
+///   15---00----01---08
+///   |    |      |    |
+///   |    |      |    |
+///   14---03----02---09
+///   |    |      |    |
+///   13---12----11---10
+///
+const static size_t kIndexCount = 9 * 6;
+const static uint16_t kIndices[kIndexCount] = {
+    4,  5, 0,  4,  0,  15,  // Top left
+    5,  6, 1,  5,  1,  0,   // Top middle
+    6,  7, 8,  6,  8,  1,   // Top right
+    15, 0, 3,  15, 3,  14,  // Middle left
+    0,  1, 2,  1,  2,  3,   // Middle middle
+    1,  8, 9,  1,  9,  2,   // Middle right
+    14, 3, 12, 14, 12, 13,  // Bottom left
+    3,  2, 11, 3,  11, 12,  // Bottom middle
+    2,  9, 10, 2,  10, 11,  // Bottom right
+};
+
+bool BoxShadowContents::Render(const ContentContext& renderer,
+                               const Entity& entity,
+                               RenderPass& pass) const {
+  if (!rect_.has_value()) {
+    return true;
+  }
+
+  if (color_.IsTransparent()) {
+    return true;
+  }
+
+  using VS = BoxShadowPipeline::VertexShader;
+  using FS = BoxShadowPipeline::FragmentShader;
+
+  auto radius = FilterContents::Radius{sigma_}.radius;
+  auto box = rect_->GetPoints();
+  VS::PerVertexData vertices[16] = {
+      // Middle box
+      {box[0], Point()},
+      {box[1], Point()},
+      {box[3], Point()},
+      {box[2], Point()},
+
+      // Outset border
+      {box[0] + Point(-radius, -radius), Point(1, 1)},
+      {box[0] + Point(0, -radius), Point(0, 1)},
+      {box[1] + Point(0, -radius), Point(0, 1)},
+
+      {box[1] + Point(radius, -radius), Point(1, 1)},
+      {box[1] + Point(radius, 0), Point(1, 0)},
+      {box[2] + Point(radius, 0), Point(1, 0)},
+
+      {box[3] + Point(radius, radius), Point(1, 1)},
+      {box[3] + Point(0, radius), Point(0, 1)},
+      {box[2] + Point(0, radius), Point(0, 1)},
+
+      {box[2] + Point(-radius, radius), Point(1, 1)},
+      {box[2] + Point(-radius, 0), Point(1, 0)},
+      {box[0] + Point(-radius, 0), Point(1, 0)},
+  };
+
+  VertexBuffer vertex_buffer = {
+      .vertex_buffer = pass.GetTransientsBuffer().Emplace(
+          &vertices, sizeof(vertices), alignof(VS::PerVertexData)),
+      .index_buffer = pass.GetTransientsBuffer().Emplace(
+          &kIndices, sizeof(kIndices), alignof(uint16_t)),
+      .index_count = kIndexCount,
+      .index_type = IndexType::k16bit,
+  };
+
+  Command cmd;
+  cmd.label = "Box Shadow";
+  cmd.pipeline =
+      renderer.GetBoxShadowPipeline(OptionsFromPassAndEntity(pass, entity));
+  cmd.stencil_reference = entity.GetStencilDepth();
+
+  cmd.primitive_type = PrimitiveType::kTriangle;
+  cmd.BindVertices(vertex_buffer);
+
+  VS::VertexInfo vertex_info;
+  vertex_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
+                    entity.GetTransformation();
+  VS::BindVertexInfo(cmd,
+                     pass.GetTransientsBuffer().EmplaceUniform(vertex_info));
+
+  FS::FragmentInfo fragment_info;
+  fragment_info.color = color_;
+  FS::BindFragmentInfo(
+      cmd, pass.GetTransientsBuffer().EmplaceUniform(fragment_info));
+
+  if (!pass.AddCommand(std::move(cmd))) {
+    return false;
+  }
+
+  return true;
+}
+
+}  // namespace impeller

--- a/impeller/entity/contents/box_shadow_contents.h
+++ b/impeller/entity/contents/box_shadow_contents.h
@@ -1,0 +1,50 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <vector>
+
+#include "impeller/entity/contents/contents.h"
+#include "impeller/entity/contents/filters/filter_contents.h"
+#include "impeller/geometry/color.h"
+
+namespace impeller {
+
+class Path;
+class HostBuffer;
+struct VertexBuffer;
+
+class BoxShadowContents final : public Contents {
+ public:
+  BoxShadowContents();
+
+  ~BoxShadowContents() override;
+
+  void SetRect(std::optional<Rect> rect);
+
+  void SetSigma(FilterContents::Sigma sigma);
+
+  void SetColor(Color color);
+
+  // |Contents|
+  std::optional<Rect> GetCoverage(const Entity& entity) const override;
+
+  // |Contents|
+  bool Render(const ContentContext& renderer,
+              const Entity& entity,
+              RenderPass& pass) const override;
+
+ private:
+  std::optional<Rect> rect_;
+  FilterContents::Sigma sigma_;
+
+  Color color_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(BoxShadowContents);
+};
+
+}  // namespace impeller

--- a/impeller/entity/contents/content_context.cc
+++ b/impeller/entity/contents/content_context.cc
@@ -189,6 +189,8 @@ ContentContext::ContentContext(std::shared_ptr<Context> context)
       CreateDefaultPipeline<GaussianBlurPipeline>(*context_);
   border_mask_blur_pipelines_[{}] =
       CreateDefaultPipeline<BorderMaskBlurPipeline>(*context_);
+  box_shadow_pipelines_[{}] =
+      CreateDefaultPipeline<BoxShadowPipeline>(*context_);
   solid_stroke_pipelines_[{}] =
       CreateDefaultPipeline<SolidStrokePipeline>(*context_);
   glyph_atlas_pipelines_[{}] =

--- a/impeller/entity/contents/content_context.h
+++ b/impeller/entity/contents/content_context.h
@@ -31,6 +31,8 @@
 #include "impeller/entity/blend.vert.h"
 #include "impeller/entity/border_mask_blur.frag.h"
 #include "impeller/entity/border_mask_blur.vert.h"
+#include "impeller/entity/box_shadow.frag.h"
+#include "impeller/entity/box_shadow.vert.h"
 #include "impeller/entity/entity.h"
 #include "impeller/entity/gaussian_blur.frag.h"
 #include "impeller/entity/gaussian_blur.vert.h"
@@ -91,6 +93,8 @@ using GaussianBlurPipeline =
     PipelineT<GaussianBlurVertexShader, GaussianBlurFragmentShader>;
 using BorderMaskBlurPipeline =
     PipelineT<BorderMaskBlurVertexShader, BorderMaskBlurFragmentShader>;
+using BoxShadowPipeline =
+    PipelineT<BoxShadowVertexShader, BoxShadowFragmentShader>;
 using SolidStrokePipeline =
     PipelineT<SolidStrokeVertexShader, SolidStrokeFragmentShader>;
 using GlyphAtlasPipeline =
@@ -162,6 +166,11 @@ class ContentContext {
   std::shared_ptr<Pipeline> GetBorderMaskBlurPipeline(
       ContentContextOptions opts) const {
     return GetPipeline(border_mask_blur_pipelines_, opts);
+  }
+
+  std::shared_ptr<Pipeline> GetBoxShadowPipeline(
+      ContentContextOptions opts) const {
+    return GetPipeline(box_shadow_pipelines_, opts);
   }
 
   std::shared_ptr<Pipeline> GetSolidStrokePipeline(
@@ -288,6 +297,7 @@ class ContentContext {
   mutable Variants<TexturePipeline> texture_pipelines_;
   mutable Variants<GaussianBlurPipeline> gaussian_blur_pipelines_;
   mutable Variants<BorderMaskBlurPipeline> border_mask_blur_pipelines_;
+  mutable Variants<BoxShadowPipeline> box_shadow_pipelines_;
   mutable Variants<SolidStrokePipeline> solid_stroke_pipelines_;
   mutable Variants<ClipPipeline> clip_pipelines_;
   mutable Variants<GlyphAtlasPipeline> glyph_atlas_pipelines_;

--- a/impeller/entity/shaders/box_shadow.frag
+++ b/impeller/entity/shaders/box_shadow.frag
@@ -1,0 +1,22 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+uniform FragmentInfo {
+  vec4 color;
+}
+fragment_info;
+
+in vec2 v_border;
+
+out vec4 frag_color;
+
+// Simple logistic sigmoid with a domain and range of 0 to 1.
+float Sigmoid(float x) {
+  return 1.03597241992 / (1 + exp(-8 * x + 4)) - 0.0179862099621;
+}
+
+void main() {
+  float shadow_mask = Sigmoid(max(0.0, 1.0 - length(v_border)));
+  frag_color = fragment_info.color * shadow_mask;
+}

--- a/impeller/entity/shaders/box_shadow.vert
+++ b/impeller/entity/shaders/box_shadow.vert
@@ -1,0 +1,18 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+uniform VertexInfo {
+  mat4 mvp;
+}
+vertex_info;
+
+in vec2 position;
+in vec2 border;
+
+out vec2 v_border;
+
+void main() {
+  gl_Position = vertex_info.mvp * vec4(position, 0.0, 1.0);
+  v_border = border;
+}

--- a/impeller/geometry/geometry_unittests.cc
+++ b/impeller/geometry/geometry_unittests.cc
@@ -1120,6 +1120,31 @@ TEST(GeometryTest, PathPolylineDuplicatesAreRemovedForSameContour) {
   ASSERT_EQ(polyline.points[6], Point(0, 100));
 }
 
+TEST(GeometryTest, PathIsRectangle) {
+  {
+    Rect rect = Rect::MakeLTRB(100, 110, 210, 230);
+    Path path = PathBuilder{}.AddRect(rect).TakePath();
+    ASSERT_TRUE(path.IsRectangle());
+
+    auto bounds = path.GetBoundingBox();
+    ASSERT_TRUE(bounds.has_value());
+    ASSERT_RECT_NEAR(bounds.value(), rect);
+  }
+
+  {
+    Path path = PathBuilder{}
+                    .AddRect(Rect::MakeLTRB(100, 110, 210, 230))
+                    .AddRect(Rect::MakeLTRB(10, 10, 20, 20))
+                    .TakePath();
+    ASSERT_FALSE(path.IsRectangle());
+  }
+
+  {
+    Path path = PathBuilder{}.AddCircle(Point(), 10).TakePath();
+    ASSERT_FALSE(path.IsRectangle());
+  }
+}
+
 TEST(GeometryTest, VerticesConstructorAndGetters) {
   std::vector<Point> points = {Point(1, 2), Point(2, 3), Point(3, 4)};
   std::vector<uint16_t> indices = {0, 1, 2};

--- a/impeller/geometry/path.cc
+++ b/impeller/geometry/path.cc
@@ -274,6 +274,26 @@ Path::Polyline Path::CreatePolyline(
   }
   return polyline;
 }
+bool Path::IsRectangle() const {
+  // Typically, closed paths have a second, empty contour. Empty contours are
+  // not included in the generated polyline.
+  if (linears_.size() != 4 || contours_.size() > 2 || components_.size() > 6) {
+    return false;
+  }
+
+  auto polyline = CreatePolyline();
+  std::vector<Point>& points = polyline.points;
+  if (polyline.contours.size() != 1 || points.size() != 5 ||
+      points[0] != points[4]) {
+    return false;
+  }
+
+  Point diag = points[2] - points[0];
+  Point a = points[0] + Point(diag.x, 0);
+  Point b = points[0] + Point(0, diag.y);
+  return (points[1] == a && points[3] == b) ||
+         (points[1] == b && points[3] == a);
+}
 
 std::optional<Rect> Path::GetBoundingBox() const {
   auto min_max = GetMinMaxCoveragePoints();

--- a/impeller/geometry/path.h
+++ b/impeller/geometry/path.h
@@ -119,6 +119,8 @@ class Path {
   Polyline CreatePolyline(
       const SmoothingApproximation& approximation = {}) const;
 
+  bool IsRectangle() const;
+
   std::optional<Rect> GetBoundingBox() const;
 
   std::optional<Rect> GetTransformedBoundingBox(const Matrix& transform) const;


### PR DESCRIPTION
Depends on https://github.com/flutter/engine/pull/34083.

Part of https://github.com/flutter/flutter/issues/104715.

This is a simple fast path for blurring rectangular paths. It replaces using a gaussian blur for this situation.
