### PR TITLE
[MacOS] Accept first mouse-down 

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterView.mm
@@ -102,7 +102,7 @@
  * Declares that the initial mouse-down when the view is not in focus will send an event to the
  * view.
  */
-- (BOOL)acceptsFirstMouse:(NSEvent *)event {
+- (BOOL)acceptsFirstMouse:(NSEvent*)event {
   return YES;
 }
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterView.mm
@@ -102,7 +102,7 @@
  * Declares that the initial mouse-down when the view is not in focus will send an event to the
  * view.
  */
-- (BOOL)acceptsFirstMouse {
+- (BOOL)acceptsFirstMouse:(NSEvent *)event {
   return YES;
 }
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterView.mm
@@ -98,6 +98,10 @@
   return YES;
 }
 
+- (BOOL)acceptsFirstMouse {
+  return YES;
+}
+
 - (BOOL)acceptsFirstResponder {
   return YES;
 }

--- a/shell/platform/darwin/macos/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterView.mm
@@ -98,6 +98,10 @@
   return YES;
 }
 
+/**
+ * Declares that the initial mouse-down when the view is not in focus will send an event to the
+ * view.
+ */
 - (BOOL)acceptsFirstMouse {
   return YES;
 }

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
@@ -74,7 +74,7 @@ TEST(FlutterViewController, HasViewThatHidesOtherViewsInAccessibility) {
 TEST(FlutterViewController, FlutterViewAcceptsFirstMouse) {
   FlutterViewController* viewControllerMock = CreateMockViewController();
   [viewControllerMock loadView];
-  EXPECT_EQ([viewControllerMock.view acceptsFirstMouse:nil], YES);
+  EXPECT_EQ([viewControllerMock.flutterView acceptsFirstMouse:nil], YES);
 }
 
 TEST(FlutterViewController, ReparentsPluginWhenAccessibilityDisabled) {

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
@@ -73,6 +73,7 @@ TEST(FlutterViewController, HasViewThatHidesOtherViewsInAccessibility) {
 
 TEST(FlutterViewController, FlutterViewAcceptsFirstMouse) {
   FlutterViewController* viewControllerMock = CreateMockViewController();
+  [viewControllerMock loadView];
   EXPECT_EQ([viewControllerMock.view acceptsFirstMouse:nil], YES);
 }
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
@@ -71,6 +71,11 @@ TEST(FlutterViewController, HasViewThatHidesOtherViewsInAccessibility) {
   EXPECT_EQ(accessibilityChildren[0], viewControllerMock.flutterView);
 }
 
+TEST(FlutterViewController, FlutterViewAcceptsFirstMouse) {
+  FlutterViewController* viewControllerMock = CreateMockViewController();
+  EXPECT_EQ([viewControllerMock.view acceptsFirstMouse:nil], YES);
+}
+
 TEST(FlutterViewController, ReparentsPluginWhenAccessibilityDisabled) {
   FlutterEngine* engine = CreateTestEngine();
   NSString* fixtures = @(testing::GetFixturesPath());


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/88915

Overriding the `NSView` method `acceptsFirstMouse` will allow the initial mouse-down event when the window is not focused to pass to the view. 

Since not all developers may want this, this could ideally be a settable control, but this behavior at least matches Windows. It would also be possible for a developer to simulate this behavior in their application.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
