### PR TITLE
Remove no-op flag from fidlc response gen

### DIFF
--- a/tools/fuchsia/fidl/gen_response_file.py
+++ b/tools/fuchsia/fidl/gen_response_file.py
@@ -86,8 +86,6 @@ def main():
 
   response_file = []
 
-  response_file.append('--experimental new_syntax_only')
-
   if args.json:
     response_file.append("--json %s" % args.json)
 


### PR DESCRIPTION
This change removes a  dead flag for the now-completed FIDL syntax
migration that was missed by the first removal pull request at
https://github.com/flutter/buildroot/pull/582.