### PR TITLE
Make the cmake GLFW embedder example easier to use

### DIFF
--- a/examples/glfw/CMakeLists.txt
+++ b/examples/glfw/CMakeLists.txt
@@ -7,13 +7,13 @@ add_executable(flutter_glfw FlutterEmbedderGLFW.cc)
 ############################################################
 # GLFW
 ############################################################
-find_path(GLFW_INCLUDE_PATH "glfw3.h"
-    /usr/local/Cellar/glfw/3.3/include/GLFW/
-    /usr/local/include/include/GLFW/
-    /usr/include/GLFW)
-include_directories(${GLFW_INCLUDE_PATH})
-find_library(GLFW_LIB glfw /usr/local/Cellar/glfw/3.3/lib)
-target_link_libraries(flutter_glfw ${GLFW_LIB})
+option(GLFW_BUILD_EXAMPLES "" OFF)
+option(GLFW_BUILD_TESTS "" OFF)
+option(GLFW_BUILD_DOCS "" OFF)
+option(GLFW_INSTALL "" OFF)
+add_subdirectory(${CMAKE_SOURCE_DIR}/../../../third_party/glfw glfw)
+target_link_libraries(flutter_glfw glfw)
+include_directories(${CMAKE_SOURCE_DIR}/../../../third_party/glfw/include)
 
 ############################################################
 # Flutter Engine

--- a/examples/glfw/FlutterEmbedderGLFW.cc
+++ b/examples/glfw/FlutterEmbedderGLFW.cc
@@ -6,8 +6,8 @@
 #include <chrono>
 #include <iostream>
 
-#include "embedder.h"
 #include "GLFW/glfw3.h"
+#include "embedder.h"
 
 // This value is calculated after the window is created.
 static double g_pixelRatio = 1.0;

--- a/examples/glfw/FlutterEmbedderGLFW.cc
+++ b/examples/glfw/FlutterEmbedderGLFW.cc
@@ -2,12 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <embedder.h>
-#include <glfw3.h>
-
 #include <cassert>
 #include <chrono>
 #include <iostream>
+
+#include "embedder.h"
+#include "GLFW/glfw3.h"
 
 // This value is calculated after the window is created.
 static double g_pixelRatio = 1.0;

--- a/examples/glfw/run.sh
+++ b/examples/glfw/run.sh
@@ -19,7 +19,9 @@ if [ ! -d myapp ]; then
 fi
 cd myapp
 cp ../../main.dart lib/main.dart
-flutter build bundle
+flutter build bundle \
+        --local-engine-src-path ../../../../../ \
+        --local-engine=host_debug_unopt
 cd -
 
 #################################################################

--- a/examples/vulkan_glfw/run.sh
+++ b/examples/vulkan_glfw/run.sh
@@ -16,7 +16,9 @@ if [ ! -d myapp ]; then
 fi
 pushd myapp > /dev/null
 #cp ../../main.dart lib/main.dart
-flutter build bundle
+flutter build bundle \
+        --local-engine-src-path ../../../../../ \
+        --local-engine=host_debug_unopt
 popd > /dev/null
 
 #################################################################


### PR DESCRIPTION
* Simplify the process of getting the GLFW example running by just using the GLFW dependency checkout. The GLFW CMake build is quite stable and simple across mac/linux/windows.
* When building the bundle, use the local engine configuration so that the correct Dart kernel binary will get roped in.