### PR TITLE
make fractional translation the default for desktop/tester

### DIFF
--- a/common/config.gni
+++ b/common/config.gni
@@ -59,6 +59,10 @@ if (flutter_runtime_mode == "debug") {
   feature_defines_list += [ "FLUTTER_RUNTIME_MODE=0" ]
 }
 
+if (is_linux || is_mac || is_win) {
+  support_fractional_translation = true
+}
+
 if (support_fractional_translation) {
   feature_defines_list += [ "SUPPORT_FRACTIONAL_TRANSLATION=1" ]
 }


### PR DESCRIPTION
Work towards https://github.com/flutter/flutter/issues/103909

Makes SUPPORT_FRACTIONAL_TRANSLATION the default for desktop/tester. This change will require clobbering the local engine out directories. This will also require disabling and regenerating the goldens for two customer testing test cases.

Google3 will be unaffected as they've already migrated to a tester that does not pixel snap.