### PR TITLE
[Keyboard, Android] Mint physical keys on the Android plane

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/KeyEmbedderResponder.java
+++ b/shell/platform/android/io/flutter/embedding/android/KeyEmbedderResponder.java
@@ -72,7 +72,7 @@ public class KeyEmbedderResponder implements KeyboardManager.Responder {
     // key from the key code so that keys can be told apart.
     if (scancode == 0) {
       // The key code can't also be 0, since those events have been filtered.
-      return keyOfPlane(event.getKeyCode(), KeyboardMap.kLogicalPlane);
+      return keyOfPlane(event.getKeyCode(), KeyboardMap.kAndroidPlane);
     }
     final Long byMapping = KeyboardMap.scanCodeToPhysical.get(scancode);
     if (byMapping != null) {

--- a/shell/platform/android/io/flutter/embedding/android/KeyboardMap.java
+++ b/shell/platform/android/io/flutter/embedding/android/KeyboardMap.java
@@ -614,6 +614,5 @@ public class KeyboardMap {
 
   public static final long kValueMask = 0x000ffffffffL;
   public static final long kUnicodePlane = 0x00000000000L;
-  public static final long kLogicalPlane = 0x00300000000L;
   public static final long kAndroidPlane = 0x01100000000L;
 }

--- a/shell/platform/android/test/io/flutter/embedding/android/KeyboardManagerTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/KeyboardManagerTest.java
@@ -799,7 +799,7 @@ public class KeyboardManagerTest {
   }
 
   @Test
-  public void eventsWithForgedCodes() {
+  public void eventsWithMintedCodes() {
     final KeyboardTester tester = new KeyboardTester();
     final ArrayList<CallRecord> calls = new ArrayList<>();
 
@@ -814,7 +814,7 @@ public class KeyboardManagerTest {
     verifyEmbedderEvents(
         calls,
         new KeyData[] {
-          buildKeyData(Type.kDown, 0x300000042L, LOGICAL_ENTER, "\n", false),
+          buildKeyData(Type.kDown, 0x1100000042L, LOGICAL_ENTER, "\n", false),
         });
     calls.clear();
 


### PR DESCRIPTION
The Android keyboard embedder responder has to mint physical keys from logical keys when the scan code is empty, and currently it does so onto a new plane called "logical plane". 

This PR makes it mint physical keys onto the existing Android plane instead. This avoids creating a new plane just for this purpose and aligns with how other platforms behave.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
