### PR TITLE
Use darwin instead of mac for artifacts location.

### DIFF
--- a/build/archives/BUILD.gn
+++ b/build/archives/BUILD.gn
@@ -174,7 +174,7 @@ if (host_os == "win") {
 }
 
 # Archives Flutter Mac Artifacts
-if (is_mac || is_ios) {
+if (is_mac) {
   group("macos_flutter_framework") {
     deps = [
       "//flutter/shell/platform/darwin/macos:macos_flutter_framework_archive",

--- a/build/archives/BUILD.gn
+++ b/build/archives/BUILD.gn
@@ -15,7 +15,14 @@ if (build_engine_artifacts) {
       "//flutter/shell/testing:testing",
       "//flutter/shell/testing:testing_fractional_translation",
     ]
-    prefix = "$full_target_platform_name/"
+    if (is_mac) {
+      # TODO(godofredoc): Remove after paths are standardized flutter/flutter#105351.
+      # Mac artifacts sometimes use mac and sometimes darwin. Standardizing the
+      # names will require changes in the list of artifacts the tool is downloading.
+      prefix = "darwin-$target_cpu/"
+    } else {
+      prefix = "$full_target_platform_name/"
+    }
     if (flutter_runtime_mode != "debug") {
       prefix = "$full_platform_name-$flutter_runtime_mode/"
     }
@@ -167,7 +174,7 @@ if (host_os == "win") {
 }
 
 # Archives Flutter Mac Artifacts
-if (is_mac) {
+if (is_mac || is_ios) {
   group("macos_flutter_framework") {
     deps = [
       "//flutter/shell/platform/darwin/macos:macos_flutter_framework_archive",


### PR DESCRIPTION
Flutter tool expects the artifacts in a darwin folder rather than mac.

Bug: https://github.com/flutter/flutter/issues/81855

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
