### PR TITLE
Add a null check to AndroidImageGenerator::GetPixels

### DIFF
--- a/shell/platform/android/android_image_generator.cc
+++ b/shell/platform/android/android_image_generator.cc
@@ -52,6 +52,10 @@ bool AndroidImageGenerator::GetPixels(const SkImageInfo& info,
                                       std::optional<unsigned int> prior_frame) {
   fully_decoded_latch_.Wait();
 
+  if (!software_decoded_data_) {
+    return false;
+  }
+
   if (kRGBA_8888_SkColorType != info.colorType()) {
     return false;
   }


### PR DESCRIPTION
GetPixels must be safe to call even if image decoding fails to produce output.
