### PR TITLE
Remove unactionable verbose log about ignored viewport metrics.

### DIFF
--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -918,11 +918,7 @@ void Shell::OnPlatformViewSetViewportMetrics(const ViewportMetrics& metrics) {
 
   if (metrics.device_pixel_ratio <= 0 || metrics.physical_width <= 0 ||
       metrics.physical_height <= 0) {
-    FML_DLOG(ERROR)
-        << "Embedding reported invalid ViewportMetrics, ignoring update."
-        << "\nphysical_width: " << metrics.physical_width
-        << "\nphysical_height: " << metrics.physical_height
-        << "\ndevice_pixel_ratio: " << metrics.device_pixel_ratio;
+    // Ignore invalid view-port metrics.
     return;
   }
 


### PR DESCRIPTION
This isn't useful the end user or the Flutter engine developer. I suspect this
was left in the codebase for so long because not too many folks run an unopt
engine.