### PR TITLE
[Impeller] Log a message when using Impeller.

### DIFF
--- a/shell/platform/android/android_surface_gl_impeller.cc
+++ b/shell/platform/android/android_surface_gl_impeller.cc
@@ -72,7 +72,7 @@ static std::shared_ptr<impeller::Context> CreateImpellerContext(
     FML_LOG(ERROR) << "Could not add reactor worker.";
     return nullptr;
   }
-
+  FML_LOG(ERROR) << "Using the Impeller rendering backend.";
   return context;
 }
 

--- a/shell/platform/darwin/ios/ios_context_metal_impeller.mm
+++ b/shell/platform/darwin/ios/ios_context_metal_impeller.mm
@@ -19,6 +19,7 @@ static std::shared_ptr<impeller::Context> CreateImpellerContext() {
     FML_LOG(ERROR) << "Could not create Metal Impeller Context.";
     return nullptr;
   }
+  FML_LOG(ERROR) << "Using the Impeller rendering backend.";
   return context;
 }
 


### PR DESCRIPTION
Just logs "Using the Impeller rendering backend." to the non-verbose log
when using Impeller.

Fixes https://github.com/flutter/flutter/issues/104746