### PR TITLE
Send locales to Flutter in FlutterEngine initialization instead of FlutterView

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -1195,7 +1195,6 @@ public class FlutterView extends FrameLayout
             false,
             systemSettingsObserver);
 
-    localizationPlugin.sendLocalesToFlutter(getResources().getConfiguration());
     sendViewportMetricsToFlutter();
 
     flutterEngine.getPlatformViewsController().attachToView(this);

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
@@ -349,7 +349,8 @@ public class FlutterEngine {
     this.pluginRegistry =
         new FlutterEngineConnectionRegistry(context.getApplicationContext(), this, flutterLoader);
 
-    localizationPlugin.sendLocalesToFlutter(context.getApplicationContect().getResources().getConfiguration());
+    localizationPlugin.sendLocalesToFlutter(
+        context.getApplicationContect().getResources().getConfiguration());
 
     // Only automatically register plugins if both constructor parameter and
     // loaded AndroidManifest config turn this feature on.

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
@@ -5,6 +5,8 @@
 package io.flutter.embedding.engine;
 
 import android.content.Context;
+import android.content.res.Resources;
+import android.content.res.Configuration;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.res.AssetManager;
 import androidx.annotation.NonNull;
@@ -349,8 +351,11 @@ public class FlutterEngine {
     this.pluginRegistry =
         new FlutterEngineConnectionRegistry(context.getApplicationContext(), this, flutterLoader);
 
+    // Context ctx = context.getApplicationContext();
+    // Resources r = context.getResources();
+    // Configuration c = r.getConfiguration();
     localizationPlugin.sendLocalesToFlutter(
-        context.getApplicationContext().getResources().getConfiguration());
+       context.getResources().getConfiguration());
 
     // Only automatically register plugins if both constructor parameter and
     // loaded AndroidManifest config turn this feature on.

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
@@ -5,8 +5,6 @@
 package io.flutter.embedding.engine;
 
 import android.content.Context;
-import android.content.res.Resources;
-import android.content.res.Configuration;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.res.AssetManager;
 import androidx.annotation.NonNull;
@@ -351,11 +349,7 @@ public class FlutterEngine {
     this.pluginRegistry =
         new FlutterEngineConnectionRegistry(context.getApplicationContext(), this, flutterLoader);
 
-    // Context ctx = context.getApplicationContext();
-    // Resources r = context.getResources();
-    // Configuration c = r.getConfiguration();
-    localizationPlugin.sendLocalesToFlutter(
-       context.getResources().getConfiguration());
+    localizationPlugin.sendLocalesToFlutter(context.getResources().getConfiguration());
 
     // Only automatically register plugins if both constructor parameter and
     // loaded AndroidManifest config turn this feature on.

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
@@ -350,7 +350,7 @@ public class FlutterEngine {
         new FlutterEngineConnectionRegistry(context.getApplicationContext(), this, flutterLoader);
 
     localizationPlugin.sendLocalesToFlutter(
-        context.getApplicationContect().getResources().getConfiguration());
+        context.getApplicationContext().getResources().getConfiguration());
 
     // Only automatically register plugins if both constructor parameter and
     // loaded AndroidManifest config turn this feature on.

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
@@ -349,6 +349,8 @@ public class FlutterEngine {
     this.pluginRegistry =
         new FlutterEngineConnectionRegistry(context.getApplicationContext(), this, flutterLoader);
 
+    localizationPlugin.sendLocalesToFlutter(context.getApplicationContect().getResources().getConfiguration());
+
     // Only automatically register plugins if both constructor parameter and
     // loaded AndroidManifest config turn this feature on.
     if (automaticallyRegisterPlugins && flutterLoader.automaticallyRegisterPlugins()) {

--- a/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineTest.java
@@ -8,9 +8,10 @@ import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -46,7 +47,7 @@ import org.robolectric.shadows.ShadowLog;
 @RunWith(AndroidJUnit4.class)
 public class FlutterEngineTest {
   private final Context ctx = ApplicationProvider.getApplicationContext();
-  private Context spyCtx = ApplicationProvider.getApplicationContext();
+  private final Context mockContext = mock(Context.class);
   @Mock FlutterJNI flutterJNI;
   boolean jniAttached;
 
@@ -54,13 +55,11 @@ public class FlutterEngineTest {
   public void setUp() {
     MockitoAnnotations.openMocks(this);
 
-    // spyCtx = spy(ctx);
-    // Resources mockResources = mock(Resources.class);
-    // Configuration mockConfiguration = mock(Configuration.class);
-    // doReturn(spyCtx).when(spyCtx).getApplicationContext();
-    // doReturn(mockResources).when(spyCtx).getResources();
-    // doReturn(mockConfiguration).when(mockResources).getConfiguration();
-    // doReturn(LocaleList.getEmptyLocaleList()).when(mockConfiguration).getLocales();
+    Resources mockResources = mock(Resources.class);
+    Configuration mockConfiguration = mock(Configuration.class);
+    doReturn(mockResources).when(mockContext).getResources();
+    doReturn(mockConfiguration).when(mockResources).getConfiguration();
+    doReturn(LocaleList.getEmptyLocaleList()).when(mockConfiguration).getLocales();
 
     jniAttached = false;
     when(flutterJNI.isAttached()).thenAnswer(invocation -> jniAttached);
@@ -99,12 +98,15 @@ public class FlutterEngineTest {
 
   @Test
   public void itSendLocalesOnEngineInit() {
+    FlutterJNI mockFlutterJNI = mock(FlutterJNI.class);
+    when(mockFlutterJNI.isAttached()).thenReturn(true);
+
     assertTrue(GeneratedPluginRegistrant.getRegisteredEngines().isEmpty());
     FlutterLoader mockFlutterLoader = mock(FlutterLoader.class);
     when(mockFlutterLoader.automaticallyRegisterPlugins()).thenReturn(true);
-    FlutterEngine flutterEngine = new FlutterEngine(ctx, mockFlutterLoader, flutterJNI);
+    FlutterEngine flutterEngine = new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJNI);
 
-    verify(flutterJNI, times(1)).dispatchPlatformMessage("flutter/localization", any(), any(), any());
+    verify(mockFlutterJNI, times(1)).dispatchPlatformMessage(eq("flutter/localization"), any(), anyInt(), anyInt());
   }
 
   // Helps show the root cause of MissingPluginException type errors like
@@ -219,36 +221,34 @@ public class FlutterEngineTest {
 
   @Test
   public void itUsesApplicationContext() throws NameNotFoundException {
-    Context context = mock(Context.class);
     Context packageContext = mock(Context.class);
 
-    when(context.createPackageContext(any(), anyInt())).thenReturn(packageContext);
+    when(mockContext.createPackageContext(any(), anyInt())).thenReturn(packageContext);
 
     new FlutterEngine(
-        context,
+        mockContext,
         mock(FlutterLoader.class),
         flutterJNI,
         /*dartVmArgs=*/ new String[] {},
         /*automaticallyRegisterPlugins=*/ false);
 
-    verify(context, atLeast(1)).getApplicationContext();
+    verify(mockContext, atLeast(1)).getApplicationContext();
   }
 
   @Test
   public void itUsesPackageContextForAssetManager() throws NameNotFoundException {
-    Context context = mock(Context.class);
     Context packageContext = mock(Context.class);
-    when(context.createPackageContext(any(), anyInt())).thenReturn(packageContext);
+    when(mockContext.createPackageContext(any(), anyInt())).thenReturn(packageContext);
 
     new FlutterEngine(
-        context,
+        mockContext,
         mock(FlutterLoader.class),
         flutterJNI,
         /*dartVmArgs=*/ new String[] {},
         /*automaticallyRegisterPlugins=*/ false);
 
     verify(packageContext, atLeast(1)).getAssets();
-    verify(context, times(0)).getAssets();
+    verify(mockContext, times(0)).getAssets();
   }
 
   @Test
@@ -257,7 +257,6 @@ public class FlutterEngineTest {
     FlutterLoader mockFlutterLoader = mock(FlutterLoader.class);
     FlutterInjector.setInstance(
         new FlutterInjector.Builder().setFlutterLoader(mockFlutterLoader).build());
-    Context mockContext = mock(Context.class);
     Context packageContext = mock(Context.class);
 
     when(mockContext.createPackageContext(any(), anyInt())).thenReturn(packageContext);
@@ -271,14 +270,13 @@ public class FlutterEngineTest {
 
   @Test
   public void itNotifiesListenersForDestruction() throws NameNotFoundException {
-    Context context = mock(Context.class);
     Context packageContext = mock(Context.class);
 
-    when(context.createPackageContext(any(), anyInt())).thenReturn(packageContext);
+    when(mockContext.createPackageContext(any(), anyInt())).thenReturn(packageContext);
 
     FlutterEngine engineUnderTest =
         new FlutterEngine(
-            context,
+            mockContext,
             mock(FlutterLoader.class),
             flutterJNI,
             /*dartVmArgs=*/ new String[] {},
@@ -292,15 +290,14 @@ public class FlutterEngineTest {
 
   @Test
   public void itDoesNotAttachAgainWhenBuiltWithAnAttachedJNI() throws NameNotFoundException {
-    Context context = mock(Context.class);
     Context packageContext = mock(Context.class);
 
-    when(context.createPackageContext(any(), anyInt())).thenReturn(packageContext);
+    when(mockContext.createPackageContext(any(), anyInt())).thenReturn(packageContext);
     when(flutterJNI.isAttached()).thenReturn(true);
 
     FlutterEngine engineUnderTest =
         new FlutterEngine(
-            context,
+            mockContext,
             mock(FlutterLoader.class),
             flutterJNI,
             /*dartVmArgs=*/ new String[] {},
@@ -311,15 +308,14 @@ public class FlutterEngineTest {
 
   @Test
   public void itComesWithARunningDartExecutorIfJNIIsAlreadyAttached() throws NameNotFoundException {
-    Context context = mock(Context.class);
     Context packageContext = mock(Context.class);
 
-    when(context.createPackageContext(any(), anyInt())).thenReturn(packageContext);
+    when(mockContext.createPackageContext(any(), anyInt())).thenReturn(packageContext);
     when(flutterJNI.isAttached()).thenReturn(true);
 
     FlutterEngine engineUnderTest =
         new FlutterEngine(
-            context,
+            mockContext,
             mock(FlutterLoader.class),
             flutterJNI,
             /*dartVmArgs=*/ new String[] {},

--- a/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineTest.java
@@ -12,14 +12,13 @@ import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import android.content.Context;
 import android.content.pm.PackageManager.NameNotFoundException;
-import android.content.res.Resources;
 import android.content.res.Configuration;
+import android.content.res.Resources;
 import android.os.LocaleList;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -106,7 +105,8 @@ public class FlutterEngineTest {
     when(mockFlutterLoader.automaticallyRegisterPlugins()).thenReturn(true);
     FlutterEngine flutterEngine = new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJNI);
 
-    verify(mockFlutterJNI, times(1)).dispatchPlatformMessage(eq("flutter/localization"), any(), anyInt(), anyInt());
+    verify(mockFlutterJNI, times(1))
+        .dispatchPlatformMessage(eq("flutter/localization"), any(), anyInt(), anyInt());
   }
 
   // Helps show the root cause of MissingPluginException type errors like

--- a/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineTest.java
@@ -7,14 +7,19 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import android.content.Context;
 import android.content.pm.PackageManager.NameNotFoundException;
+import android.content.res.Resources;
+import android.content.res.Configuration;
+import android.os.LocaleList;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import io.flutter.FlutterInjector;
@@ -41,12 +46,22 @@ import org.robolectric.shadows.ShadowLog;
 @RunWith(AndroidJUnit4.class)
 public class FlutterEngineTest {
   private final Context ctx = ApplicationProvider.getApplicationContext();
+  private Context spyCtx = ApplicationProvider.getApplicationContext();
   @Mock FlutterJNI flutterJNI;
   boolean jniAttached;
 
   @Before
   public void setUp() {
     MockitoAnnotations.openMocks(this);
+
+    // spyCtx = spy(ctx);
+    // Resources mockResources = mock(Resources.class);
+    // Configuration mockConfiguration = mock(Configuration.class);
+    // doReturn(spyCtx).when(spyCtx).getApplicationContext();
+    // doReturn(mockResources).when(spyCtx).getResources();
+    // doReturn(mockConfiguration).when(mockResources).getConfiguration();
+    // doReturn(LocaleList.getEmptyLocaleList()).when(mockConfiguration).getLocales();
+
     jniAttached = false;
     when(flutterJNI.isAttached()).thenAnswer(invocation -> jniAttached);
     doAnswer(
@@ -80,6 +95,16 @@ public class FlutterEngineTest {
     List<FlutterEngine> registeredEngines = GeneratedPluginRegistrant.getRegisteredEngines();
     assertEquals(1, registeredEngines.size());
     assertEquals(flutterEngine, registeredEngines.get(0));
+  }
+
+  @Test
+  public void itSendLocalesOnEngineInit() {
+    assertTrue(GeneratedPluginRegistrant.getRegisteredEngines().isEmpty());
+    FlutterLoader mockFlutterLoader = mock(FlutterLoader.class);
+    when(mockFlutterLoader.automaticallyRegisterPlugins()).thenReturn(true);
+    FlutterEngine flutterEngine = new FlutterEngine(ctx, mockFlutterLoader, flutterJNI);
+
+    verify(flutterJNI, times(1)).dispatchPlatformMessage("flutter/localization", any(), any(), any());
   }
 
   // Helps show the root cause of MissingPluginException type errors like


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/106130

Sends the android locales to flutter in the FlutterEngine instead of FlutterView, allowing earlier access to locales as well as locales when using an engine in the background with no FlutterView.