### PR TITLE
catch signals in flutter_tester and dump the stack

### DIFF
--- a/shell/testing/tester_main.cc
+++ b/shell/testing/tester_main.cc
@@ -11,6 +11,7 @@
 #include "flutter/assets/asset_manager.h"
 #include "flutter/assets/directory_asset_bundle.h"
 #include "flutter/flow/embedded_views.h"
+#include "flutter/fml/backtrace.h"
 #include "flutter/fml/build_config.h"
 #include "flutter/fml/file.h"
 #include "flutter/fml/make_copyable.h"
@@ -359,6 +360,7 @@ int RunTester(const flutter::Settings& settings,
 }  // namespace flutter
 
 int main(int argc, char* argv[]) {
+  fml::InstallCrashHandler();
   dart::bin::SetExecutableName(argv[0]);
   dart::bin::SetExecutableArguments(argc - 1, argv);
 

--- a/testing/dart/BUILD.gn
+++ b/testing/dart/BUILD.gn
@@ -5,6 +5,7 @@
 import("//flutter/testing/dart/compile_test.gni")
 
 tests = [
+  "abort.dart",
   "assets_test.dart",
   "canvas_test.dart",
   "channel_buffers_test.dart",

--- a/testing/dart/abort.dart
+++ b/testing/dart/abort.dart
@@ -1,0 +1,11 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+/// This file is used to test flutter_tester --run-forever
+void main() {
+  print('Sending SIGABRT');
+  Process.killPid(pid, ProcessSignal.sigabrt);
+}


### PR DESCRIPTION
Installs the crash handler for flutter_tester to print the stack when it crashes, at least on Linux and macOS.

Adds a test that forces a sigabrt and checks the output contains something resembling a stack trace.