### PR TITLE
[Impeller] Limit coverage of all subpasses to the root texture

### DIFF
--- a/impeller/aiks/picture.cc
+++ b/impeller/aiks/picture.cc
@@ -5,6 +5,7 @@
 #include "impeller/aiks/picture.h"
 
 #include <memory>
+#include <optional>
 
 #include "impeller/base/validation.h"
 #include "impeller/entity/entity.h"
@@ -14,7 +15,7 @@
 namespace impeller {
 
 std::optional<Snapshot> Picture::Snapshot(AiksContext& context) {
-  auto coverage = pass->GetElementsCoverage();
+  auto coverage = pass->GetElementsCoverage(std::nullopt);
   if (!coverage.has_value() || coverage->IsEmpty()) {
     return std::nullopt;
   }

--- a/impeller/entity/entity_pass.h
+++ b/impeller/entity/entity_pass.h
@@ -60,9 +60,12 @@ class EntityPass {
 
   void SetBackdropFilter(std::optional<BackdropFilterProc> proc);
 
-  std::optional<Rect> GetSubpassCoverage(const EntityPass& subpass) const;
+  std::optional<Rect> GetSubpassCoverage(
+      const EntityPass& subpass,
+      std::optional<Rect> coverage_clip) const;
 
-  std::optional<Rect> GetElementsCoverage() const;
+  std::optional<Rect> GetElementsCoverage(
+      std::optional<Rect> coverage_clip) const;
 
  private:
   struct EntityResult {
@@ -91,11 +94,13 @@ class EntityPass {
   EntityResult GetEntityForElement(const EntityPass::Element& element,
                                    ContentContext& renderer,
                                    InlinePassContext& pass_context,
+                                   ISize root_pass_size,
                                    Point position,
                                    uint32_t pass_depth,
                                    size_t stencil_depth_floor) const;
 
   bool OnRender(ContentContext& renderer,
+                ISize root_pass_size,
                 RenderTarget render_target,
                 Point position,
                 Point parent_position,

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -64,30 +64,24 @@ class TestPassDelegate final : public EntityPassDelegate {
   const std::optional<Rect> coverage_;
 };
 
-TEST_P(EntityTest, EntityPassSubpassCoverageIsCorrect) {
+TEST_P(EntityTest, EntityPassCoverageRespectsBoundsHint) {
   EntityPass pass;
 
-  auto subpass0 = std::make_unique<EntityPass>();
-  {
+  auto create_pass_with_rect_path = [](Rect rect,
+                                       std::optional<Rect> bounds_hint) {
+    auto subpass = std::make_unique<EntityPass>();
     Entity entity;
     entity.SetContents(SolidColorContents::Make(
-        PathBuilder{}.AddRect(Rect::MakeLTRB(0, 0, 100, 100)).TakePath(),
-        Color::Red()));
-    subpass0->AddEntity(entity);
-    subpass0->SetDelegate(
-        std::make_unique<TestPassDelegate>(Rect::MakeLTRB(50, 50, 150, 150)));
-  }
+        PathBuilder{}.AddRect(rect).TakePath(), Color::Red()));
+    subpass->AddEntity(entity);
+    subpass->SetDelegate(std::make_unique<TestPassDelegate>(bounds_hint));
+    return subpass;
+  };
 
-  auto subpass1 = std::make_unique<EntityPass>();
-  {
-    Entity entity;
-    entity.SetContents(SolidColorContents::Make(
-        PathBuilder{}.AddRect(Rect::MakeLTRB(500, 500, 1000, 1000)).TakePath(),
-        Color::Red()));
-    subpass1->AddEntity(entity);
-    subpass1->SetDelegate(
-        std::make_unique<TestPassDelegate>(Rect::MakeLTRB(800, 800, 900, 900)));
-  }
+  auto subpass0 = create_pass_with_rect_path(Rect::MakeLTRB(0, 0, 100, 100),
+                                             Rect::MakeLTRB(50, 50, 150, 150));
+  auto subpass1 = create_pass_with_rect_path(
+      Rect::MakeLTRB(500, 500, 1000, 1000), Rect::MakeLTRB(800, 800, 900, 900));
 
   auto subpass0_coverage =
       pass.GetSubpassCoverage(*subpass0.get(), std::nullopt);

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include <memory>
+#include <optional>
 
 #include "flutter/testing/testing.h"
 #include "impeller/entity/contents/filters/blend_filter_contents.h"
@@ -88,11 +89,13 @@ TEST_P(EntityTest, EntityPassSubpassCoverageIsCorrect) {
         std::make_unique<TestPassDelegate>(Rect::MakeLTRB(800, 800, 900, 900)));
   }
 
-  auto subpass0_coverage = pass.GetSubpassCoverage(*subpass0.get());
+  auto subpass0_coverage =
+      pass.GetSubpassCoverage(*subpass0.get(), std::nullopt);
   ASSERT_TRUE(subpass0_coverage.has_value());
   ASSERT_RECT_NEAR(subpass0_coverage.value(), Rect::MakeLTRB(50, 50, 100, 100));
 
-  auto subpass1_coverage = pass.GetSubpassCoverage(*subpass1.get());
+  auto subpass1_coverage =
+      pass.GetSubpassCoverage(*subpass1.get(), std::nullopt);
   ASSERT_TRUE(subpass1_coverage.has_value());
   ASSERT_RECT_NEAR(subpass1_coverage.value(),
                    Rect::MakeLTRB(800, 800, 900, 900));
@@ -100,7 +103,7 @@ TEST_P(EntityTest, EntityPassSubpassCoverageIsCorrect) {
   pass.AddSubpass(std::move(subpass0));
   pass.AddSubpass(std::move(subpass1));
 
-  auto coverage = pass.GetElementsCoverage();
+  auto coverage = pass.GetElementsCoverage(std::nullopt);
   ASSERT_TRUE(coverage.has_value());
   ASSERT_RECT_NEAR(coverage.value(), Rect::MakeLTRB(50, 50, 900, 900));
 }

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -114,11 +114,20 @@ TEST_P(EntityTest, EntityPassCoverageRespectsCoverageLimit) {
                      Rect::MakeLTRB(-200, -200, -100, -100));
   }
 
-  // With positive coverage limit.
+  // With limit that doesn't overlap.
   {
     auto pass_coverage =
         pass->GetElementsCoverage(Rect::MakeLTRB(0, 0, 100, 100));
     ASSERT_FALSE(pass_coverage.has_value());
+  }
+
+  // With limit that partially overlaps.
+  {
+    auto pass_coverage =
+        pass->GetElementsCoverage(Rect::MakeLTRB(-150, -150, 0, 0));
+    ASSERT_TRUE(pass_coverage.has_value());
+    ASSERT_RECT_NEAR(pass_coverage.value(),
+                     Rect::MakeLTRB(-150, -150, -100, -100));
   }
 }
 


### PR DESCRIPTION
Also factors the root pass coverage into the per-entity computation.

Consider a situation where the framework asks to render a path using an advanced blend, but the origin of the coverage of the path is -10000 pixels in the y direction for whatever reason. Absent of this change, the offscreen advanced blend texture ends up with a height of >11000 pixels. With this change, such an element will get excluded during the EntityPass coverage routine, which will cause the pass itself to have no coverage, which will cause the pass to get skipped.