### PR TITLE
Remove full platform name from patched_sdk path.

### DIFF
--- a/build/archives/BUILD.gn
+++ b/build/archives/BUILD.gn
@@ -89,7 +89,7 @@ zip_bundle("flutter_patched_sdk") {
     file_suffix = "_product"
     path_prefix = "flutter_patched_sdk_product/"
   }
-  output = "flutter_patched_sdk${file_suffix}.zip"
+  output = "$full_target_platform_name/flutter_patched_sdk${file_suffix}.zip"
   deps = [ "//flutter/lib/snapshot:strong_platform" ]
   files = [
     {

--- a/build/archives/BUILD.gn
+++ b/build/archives/BUILD.gn
@@ -89,7 +89,7 @@ zip_bundle("flutter_patched_sdk") {
     file_suffix = "_product"
     path_prefix = "flutter_patched_sdk_product/"
   }
-  output = "$full_target_platform_name/flutter_patched_sdk${file_suffix}.zip"
+  output = "flutter_patched_sdk${file_suffix}.zip"
   deps = [ "//flutter/lib/snapshot:strong_platform" ]
   files = [
     {

--- a/ci/builders/linux_host_engine.json
+++ b/ci/builders/linux_host_engine.json
@@ -36,7 +36,7 @@
                         "out/host_debug/zip_archives/linux-x64/artifacts.zip",
                         "out/host_debug/zip_archives/linux-x64/linux-x64-embedder.zip",
                         "out/host_debug/zip_archives/linux-x64/font-subset.zip",
-                        "out/host_debug/zip_archives/linux-x64/flutter_patched_sdk.zip",
+                        "out/host_debug/zip_archives/flutter_patched_sdk.zip",
                         "out/host_debug/zip_archives/dart-sdk-linux-x64.zip",
                         "out/host_debug/zip_archives/flutter-web-sdk-linux-x64.zip",
                         "out/host_debug/zip_archives/linux-x64/linux-x64-flutter-gtk.zip"


### PR DESCRIPTION
flutter_patched_sdk is expected on the root folder by the flutter tool.

Bug: https://github.com/flutter/flutter/issues/81855


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
