### PR TITLE
set leaf_nodes_builder in LayerTree::Flatten

### DIFF
--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -138,8 +138,8 @@ sk_sp<DisplayList> LayerTree::Flatten(const SkRect& bounds) {
       .ui_time                       = unused_stopwatch,
       .texture_registry              = unused_texture_registry,
       .checkerboard_offscreen_layers = false,
-      .frame_device_pixel_ratio      = device_pixel_ratio_
-      .leaf_nodes_builder            = builder.builder(),
+      .frame_device_pixel_ratio      = device_pixel_ratio_,
+      .leaf_nodes_builder            = builder.builder()
       // clang-format on
   };
 

--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -139,6 +139,7 @@ sk_sp<DisplayList> LayerTree::Flatten(const SkRect& bounds) {
       .texture_registry              = unused_texture_registry,
       .checkerboard_offscreen_layers = false,
       .frame_device_pixel_ratio      = device_pixel_ratio_
+      .leaf_nodes_builder            = builder.builder(),
       // clang-format on
   };
 

--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -138,8 +138,7 @@ sk_sp<DisplayList> LayerTree::Flatten(const SkRect& bounds) {
       .ui_time                       = unused_stopwatch,
       .texture_registry              = unused_texture_registry,
       .checkerboard_offscreen_layers = false,
-      .frame_device_pixel_ratio      = device_pixel_ratio_,
-      .leaf_nodes_builder            = builder.builder()
+      .frame_device_pixel_ratio      = device_pixel_ratio_
       // clang-format on
   };
 
@@ -161,6 +160,7 @@ sk_sp<DisplayList> LayerTree::Flatten(const SkRect& bounds) {
       .frame_device_pixel_ratio      = device_pixel_ratio_,
       .layer_snapshot_store          = nullptr,
       .enable_leaf_layer_tracing     = false,
+      .leaf_nodes_builder            = builder.builder().get(),
       // clang-format on
   };
 

--- a/testing/dart/observatory/tracing_test.dart
+++ b/testing/dart/observatory/tracing_test.dart
@@ -65,6 +65,6 @@ void main() {
       }
     }
     expect(saveLayerRecordCount, 3);
-    expect(saveLayerCount, 6);
+    expect(saveLayerCount, 3);
   });
 }


### PR DESCRIPTION
Fixes issue introduced in https://github.com/flutter/engine/commit/2c279d1ae9771ce22c400578fd614251c2b0021f