### PR TITLE
[canvaskit] Correctly get the directionality of the text boxes

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/text.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/text.dart
@@ -728,16 +728,14 @@ class CkParagraph extends SkiaObject<SkParagraph> implements ui.Paragraph {
 
     for (int i = 0; i < skRects.length; i++) {
       final Float32List rect = skRects[i];
-      final Object? skTextDirection = getJsProperty(rect, 'direction');
-      final int skTextDirectionValue = skTextDirection != null
-          ? getJsProperty(skTextDirection, 'value')
-          : 0;
+      final int skTextDirection =
+          getJsProperty(getJsProperty(rect, 'direction'), 'value');
       result.add(ui.TextBox.fromLTRBD(
         rect[0],
         rect[1],
         rect[2],
         rect[3],
-        ui.TextDirection.values[skTextDirectionValue],
+        ui.TextDirection.values[skTextDirection],
       ));
     }
 

--- a/lib/web_ui/lib/src/engine/canvaskit/text.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/text.dart
@@ -2,12 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:js_util' as js_util;
 import 'dart:typed_data';
 
 import 'package:meta/meta.dart';
 import 'package:ui/ui.dart' as ui;
 
+import '../safe_browser_api.dart';
 import '../util.dart';
 import 'canvaskit_api.dart';
 import 'font_fallbacks.dart';
@@ -728,9 +728,9 @@ class CkParagraph extends SkiaObject<SkParagraph> implements ui.Paragraph {
 
     for (int i = 0; i < skRects.length; i++) {
       final Float32List rect = skRects[i];
-      final Object? skTextDirection = js_util.getProperty(rect, 'direction');
+      final Object? skTextDirection = getJsProperty(rect, 'direction');
       final int skTextDirectionValue = skTextDirection != null
-          ? js_util.getProperty(skTextDirection, 'value')
+          ? getJsProperty(skTextDirection, 'value')
           : 0;
       result.add(ui.TextBox.fromLTRBD(
         rect[0],

--- a/lib/web_ui/lib/src/engine/canvaskit/text.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/text.dart
@@ -45,7 +45,6 @@ class CkParagraphStyle implements ui.ParagraphStyle {
           ellipsis,
           locale,
         ),
-        _textDirection = textDirection ?? ui.TextDirection.ltr,
         _fontFamily = ui.debugEmulateFlutterTesterEnvironment ? 'Ahem' : fontFamily,
         _fontSize = fontSize,
         _height = height,
@@ -54,7 +53,6 @@ class CkParagraphStyle implements ui.ParagraphStyle {
         _fontStyle = fontStyle;
 
   final SkParagraphStyle skParagraphStyle;
-  final ui.TextDirection? _textDirection;
   final String? _fontFamily;
   final double? _fontSize;
   final double? _height;

--- a/lib/web_ui/lib/src/engine/canvaskit/text.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/text.dart
@@ -46,8 +46,7 @@ class CkParagraphStyle implements ui.ParagraphStyle {
           locale,
         ),
         _textDirection = textDirection ?? ui.TextDirection.ltr,
-        _fontFamily =
-            ui.debugEmulateFlutterTesterEnvironment ? 'Ahem' : fontFamily,
+        _fontFamily = ui.debugEmulateFlutterTesterEnvironment ? 'Ahem' : fontFamily,
         _fontSize = fontSize,
         _height = height,
         _leadingDistribution = textHeightBehavior?.leadingDistribution,
@@ -468,10 +467,8 @@ class CkStrutStyle implements ui.StrutStyle {
     ui.FontWeight? fontWeight,
     ui.FontStyle? fontStyle,
     bool? forceStrutHeight,
-  })  : _fontFamily =
-            ui.debugEmulateFlutterTesterEnvironment ? 'Ahem' : fontFamily,
-        _fontFamilyFallback =
-            ui.debugEmulateFlutterTesterEnvironment ? null : fontFamilyFallback,
+  })  : _fontFamily = ui.debugEmulateFlutterTesterEnvironment ? 'Ahem' : fontFamily,
+        _fontFamilyFallback = ui.debugEmulateFlutterTesterEnvironment ? null : fontFamilyFallback,
         _fontSize = fontSize,
         _height = height,
         _leadingDistribution = leadingDistribution,
@@ -616,8 +613,9 @@ class CkParagraph extends SkiaObject<SkParagraph> implements ui.Paragraph {
         _maxIntrinsicWidth = paragraph.getMaxIntrinsicWidth();
         _minIntrinsicWidth = paragraph.getMinIntrinsicWidth();
         _width = paragraph.getMaxWidth();
-        _boxesForPlaceholders = skRectsToTextBoxes(
-            paragraph.getRectsForPlaceholders().cast<Float32List>());
+        _boxesForPlaceholders =
+            skRectsToTextBoxes(
+                paragraph.getRectsForPlaceholders().cast<Float32List>());
       } catch (e) {
         printWarning('CanvasKit threw an exception while laying '
             'out the paragraph. The font was "${_paragraphStyle._fontFamily}". '
@@ -717,14 +715,12 @@ class CkParagraph extends SkiaObject<SkParagraph> implements ui.Paragraph {
     }
 
     final SkParagraph paragraph = _ensureInitialized(_lastLayoutConstraints!);
-    final List<Float32List> skRects = paragraph
-        .getRectsForRange(
-          start,
-          end,
-          toSkRectHeightStyle(boxHeightStyle),
-          toSkRectWidthStyle(boxWidthStyle),
-        )
-        .cast<Float32List>();
+    final List<Float32List> skRects = paragraph.getRectsForRange(
+      start,
+      end,
+      toSkRectHeightStyle(boxHeightStyle),
+      toSkRectWidthStyle(boxWidthStyle),
+    ).cast<Float32List>();
 
     return skRectsToTextBoxes(skRects);
   }
@@ -875,8 +871,7 @@ class CkParagraphBuilder implements ui.ParagraphBuilder {
     // Require a baseline to be specified if using a baseline-based alignment.
     assert(!(alignment == ui.PlaceholderAlignment.aboveBaseline ||
             alignment == ui.PlaceholderAlignment.belowBaseline ||
-            alignment == ui.PlaceholderAlignment.baseline) ||
-        baseline != null);
+            alignment == ui.PlaceholderAlignment.baseline) || baseline != null);
 
     _placeholderCount++;
     _placeholderScales.add(scale);

--- a/lib/web_ui/lib/src/engine/canvaskit/text.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/text.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:js_util' as js_util;
 import 'dart:typed_data';
 
 import 'package:meta/meta.dart';
@@ -45,7 +46,8 @@ class CkParagraphStyle implements ui.ParagraphStyle {
           locale,
         ),
         _textDirection = textDirection ?? ui.TextDirection.ltr,
-        _fontFamily = ui.debugEmulateFlutterTesterEnvironment ? 'Ahem' : fontFamily,
+        _fontFamily =
+            ui.debugEmulateFlutterTesterEnvironment ? 'Ahem' : fontFamily,
         _fontSize = fontSize,
         _height = height,
         _leadingDistribution = textHeightBehavior?.leadingDistribution,
@@ -466,8 +468,10 @@ class CkStrutStyle implements ui.StrutStyle {
     ui.FontWeight? fontWeight,
     ui.FontStyle? fontStyle,
     bool? forceStrutHeight,
-  })  : _fontFamily = ui.debugEmulateFlutterTesterEnvironment ? 'Ahem' : fontFamily,
-        _fontFamilyFallback = ui.debugEmulateFlutterTesterEnvironment ? null : fontFamilyFallback,
+  })  : _fontFamily =
+            ui.debugEmulateFlutterTesterEnvironment ? 'Ahem' : fontFamily,
+        _fontFamilyFallback =
+            ui.debugEmulateFlutterTesterEnvironment ? null : fontFamilyFallback,
         _fontSize = fontSize,
         _height = height,
         _leadingDistribution = leadingDistribution,
@@ -612,9 +616,8 @@ class CkParagraph extends SkiaObject<SkParagraph> implements ui.Paragraph {
         _maxIntrinsicWidth = paragraph.getMaxIntrinsicWidth();
         _minIntrinsicWidth = paragraph.getMinIntrinsicWidth();
         _width = paragraph.getMaxWidth();
-        _boxesForPlaceholders =
-            skRectsToTextBoxes(
-                paragraph.getRectsForPlaceholders().cast<Float32List>());
+        _boxesForPlaceholders = skRectsToTextBoxes(
+            paragraph.getRectsForPlaceholders().cast<Float32List>());
       } catch (e) {
         printWarning('CanvasKit threw an exception while laying '
             'out the paragraph. The font was "${_paragraphStyle._fontFamily}". '
@@ -714,12 +717,14 @@ class CkParagraph extends SkiaObject<SkParagraph> implements ui.Paragraph {
     }
 
     final SkParagraph paragraph = _ensureInitialized(_lastLayoutConstraints!);
-    final List<Float32List> skRects = paragraph.getRectsForRange(
-      start,
-      end,
-      toSkRectHeightStyle(boxHeightStyle),
-      toSkRectWidthStyle(boxWidthStyle),
-    ).cast<Float32List>();
+    final List<Float32List> skRects = paragraph
+        .getRectsForRange(
+          start,
+          end,
+          toSkRectHeightStyle(boxHeightStyle),
+          toSkRectWidthStyle(boxWidthStyle),
+        )
+        .cast<Float32List>();
 
     return skRectsToTextBoxes(skRects);
   }
@@ -729,12 +734,16 @@ class CkParagraph extends SkiaObject<SkParagraph> implements ui.Paragraph {
 
     for (int i = 0; i < skRects.length; i++) {
       final Float32List rect = skRects[i];
+      final Object? skTextDirection = js_util.getProperty(rect, 'direction');
+      final int skTextDirectionValue = skTextDirection != null
+          ? js_util.getProperty(skTextDirection, 'value')
+          : 0;
       result.add(ui.TextBox.fromLTRBD(
         rect[0],
         rect[1],
         rect[2],
         rect[3],
-        _paragraphStyle._textDirection!,
+        ui.TextDirection.values[skTextDirectionValue],
       ));
     }
 
@@ -866,7 +875,8 @@ class CkParagraphBuilder implements ui.ParagraphBuilder {
     // Require a baseline to be specified if using a baseline-based alignment.
     assert(!(alignment == ui.PlaceholderAlignment.aboveBaseline ||
             alignment == ui.PlaceholderAlignment.belowBaseline ||
-            alignment == ui.PlaceholderAlignment.baseline) || baseline != null);
+            alignment == ui.PlaceholderAlignment.baseline) ||
+        baseline != null);
 
     _placeholderCount++;
     _placeholderScales.add(scale);

--- a/lib/web_ui/test/canvaskit/text_test.dart
+++ b/lib/web_ui/test/canvaskit/text_test.dart
@@ -55,7 +55,8 @@ void testMain() {
       }
     });
 
-    test('works for https://github.com/flutter/flutter/issues/78550', () {
+    // Regression test for https://github.com/flutter/flutter/issues/78550
+    test('getBoxesForRange works for LTR text in an RTL paragraph', () {
       // Create builder for an RTL paragraph.
       final ui.ParagraphBuilder builder = ui.ParagraphBuilder(
           ui.ParagraphStyle(fontSize: 16, textDirection: ui.TextDirection.rtl));

--- a/lib/web_ui/test/canvaskit/text_test.dart
+++ b/lib/web_ui/test/canvaskit/text_test.dart
@@ -54,6 +54,21 @@ void testMain() {
         expect(paragraph, isNotNull);
       }
     });
+
+    test('works for https://github.com/flutter/flutter/issues/78550', () {
+      // Create builder for an RTL paragraph.
+      final ui.ParagraphBuilder builder = ui.ParagraphBuilder(
+          ui.ParagraphStyle(fontSize: 16, textDirection: ui.TextDirection.rtl));
+      builder.addText('hello');
+      final ui.Paragraph paragraph = builder.build();
+      paragraph.layout(const ui.ParagraphConstraints(width: 100));
+      expect(paragraph, isNotNull);
+      final List<ui.TextBox> boxes = paragraph.getBoxesForRange(0, 1);
+      expect(boxes, hasLength(1));
+      // The direction for this span is LTR even though the paragraph is RTL
+      // because the directionality of the 'h' is LTR.
+      expect(boxes.single.direction, equals(ui.TextDirection.ltr));
+    });
     // TODO(hterkelsen): https://github.com/flutter/flutter/issues/60040
   }, skip: isIosSafari);
 }

--- a/web_sdk/test/js_access_test.dart
+++ b/web_sdk/test/js_access_test.dart
@@ -26,7 +26,6 @@ const List<String> _jsAccessLibraries = <String>[
 // safely.
 const List<String> _auditedLibraries = <String>[
   'lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart',
-  'lib/web_ui/lib/src/engine/canvaskit/text.dart',
   'lib/web_ui/lib/src/engine/safe_browser_api.dart',
 ];
 

--- a/web_sdk/test/js_access_test.dart
+++ b/web_sdk/test/js_access_test.dart
@@ -26,6 +26,7 @@ const List<String> _jsAccessLibraries = <String>[
 // safely.
 const List<String> _auditedLibraries = <String>[
   'lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart',
+  'lib/web_ui/lib/src/engine/canvaskit/text.dart',
   'lib/web_ui/lib/src/engine/safe_browser_api.dart',
 ];
 


### PR DESCRIPTION
The old code assumed the directionality of the TextBoxes was the same as the Paragraph. The new code gets the directionality from CanvasKit (which it computes using Unicode data).

Fixes https://github.com/flutter/flutter/issues/78550

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
