### PR TITLE
Remove bringup from 'Linux License' shard

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -180,7 +180,6 @@ targets:
 
   - name: Linux License
     recipe: engine/engine_license
-    bringup: true
     properties:
       add_recipes_cq: "true"
       clobber: "true"


### PR DESCRIPTION
After this, we can remove the license check from the other shard.