### PR TITLE
Windows: IME window follows left edge of composing text, to match native Windows apps.

### DIFF
--- a/shell/platform/windows/text_input_manager_win32.cc
+++ b/shell/platform/windows/text_input_manager_win32.cc
@@ -172,14 +172,19 @@ void TextInputManagerWin32::MoveImeWindow(HIMC imm_context) {
   if (GetFocus() != window_handle_ || !ime_active_) {
     return;
   }
-  LONG x = caret_rect_.left();
-  LONG y = caret_rect_.top();
-  ::SetCaretPos(x, y);
+  LONG left = caret_rect_.left();
+  LONG top = caret_rect_.top();
+  LONG right = caret_rect_.right();
+  LONG bottom = caret_rect_.bottom();
+  ::SetCaretPos(left, bottom);
 
-  COMPOSITIONFORM cf = {CFS_POINT, {x, y}};
-  ::ImmSetCompositionWindow(imm_context, &cf);
+  // Set the position of composition text.
+  COMPOSITIONFORM composition_form = {CFS_POINT, {left, top}};
+  ::ImmSetCompositionWindow(imm_context, &composition_form);
 
-  CANDIDATEFORM candidate_form = {0, CFS_EXCLUDE, {x, y}, {0, 0, 0, 0}};
+  // Set the position of candidate window.
+  CANDIDATEFORM candidate_form = {
+      0, CFS_EXCLUDE, {left, bottom}, {left, top, right, bottom}};
   ::ImmSetCandidateWindow(imm_context, &candidate_form);
 }
 

--- a/shell/platform/windows/text_input_plugin.cc
+++ b/shell/platform/windows/text_input_plugin.cc
@@ -378,10 +378,10 @@ Rect TextInputPlugin::GetCursorRect() const {
   Point transformed_point = {
       composing_rect_.left() * editabletext_transform_[0][0] +
           composing_rect_.top() * editabletext_transform_[1][0] +
-          editabletext_transform_[3][0] + composing_rect_.width(),
+          editabletext_transform_[3][0],
       composing_rect_.left() * editabletext_transform_[0][1] +
           composing_rect_.top() * editabletext_transform_[1][1] +
-          editabletext_transform_[3][1] + composing_rect_.height()};
+          editabletext_transform_[3][1]};
   return {transformed_point, composing_rect_.size()};
 }
 


### PR DESCRIPTION
1. Fix the rect which `TextInputPlugin::GetCursorRect` returns by removing parallel transformation which adds width and height.
2. Sets CANDIDATEFORM's exclusion area to enable the IME window to avoid the area.

I tested on Japanese Microsoft IME, Google Japanese Input and ATOK.

|Before|After|
|-|-|
|![](https://user-images.githubusercontent.com/16546008/175779160-6047476f-bbfb-4924-8731-32be15eb8f97.png)|![](https://user-images.githubusercontent.com/16546008/175779161-008230e4-2652-47bf-b55f-0ffcabe0bc97.png)|
|![](https://user-images.githubusercontent.com/16546008/175779162-738e9e20-5122-41ed-a68b-747f06f06a4b.png)|![](https://user-images.githubusercontent.com/16546008/175779163-78965faf-fa9e-4278-a117-98fa5b7fc5d7.png)|

Fixes flutter/flutter#106555.

No changes in the [flutter/tests] repo.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
