### PR TITLE
Use git exec candidate list on all platforms for build

### DIFF
--- a/build/git_revision.py
+++ b/build/git_revision.py
@@ -22,9 +22,15 @@ def get_repository_version(repository):
   if not os.path.exists(repository):
     raise IOError('path does not exist')
 
-  git = 'git'
-  if is_windows():
-    git = 'git.bat'
+  # Natively supported since python 3.3
+  from shutil import which
+
+  git_candidates = ['git', 'git.sh', 'git.bat']
+  git = next(filter(which, git_candidates), None)
+  if git is None:
+    candidates = "', '".join(git_candidates)
+    raise IOError(f"Looks like GIT is not on the path. Tried '{candidates}'")
+
   version = subprocess.check_output([
       git,
       '-C',

--- a/build/git_revision.py
+++ b/build/git_revision.py
@@ -10,6 +10,7 @@ import sys
 import subprocess
 import os
 import argparse
+from shutil import which # Natively supported since python 3.3
 
 
 def is_windows():
@@ -21,9 +22,6 @@ def get_repository_version(repository):
   'Returns the Git HEAD for the supplied repository path as a string.'
   if not os.path.exists(repository):
     raise IOError('path does not exist')
-
-  # Natively supported since python 3.3
-  from shutil import which
 
   git_candidates = ['git', 'git.sh', 'git.bat']
   git = next(filter(which, git_candidates), None)

--- a/build/git_revision.py
+++ b/build/git_revision.py
@@ -10,12 +10,7 @@ import sys
 import subprocess
 import os
 import argparse
-from shutil import which # Natively supported since python 3.3
-
-
-def is_windows():
-  os_id = sys.platform
-  return os_id.startswith('win32') or os_id.startswith('cygwin')
+from shutil import which  # Natively supported since python 3.3
 
 
 def get_repository_version(repository):

--- a/shell/testing/tester_main.cc
+++ b/shell/testing/tester_main.cc
@@ -27,10 +27,6 @@
 #include "third_party/dart/runtime/include/bin/dart_io_api.h"
 #include "third_party/dart/runtime/include/dart_api.h"
 
-#if defined(FML_OS_WIN)
-#include <combaseapi.h>
-#endif  // defined(FML_OS_WIN)
-
 #if defined(FML_OS_POSIX)
 #include <signal.h>
 #endif  // defined(FML_OS_POSIX)
@@ -417,11 +413,6 @@ int main(int argc, char* argv[]) {
     ::exit(1);
     return true;
   };
-
-#if defined(FML_OS_WIN)
-  CoInitializeEx(nullptr,
-                 COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
-#endif  // defined(FML_OS_WIN)
 
   return flutter::RunTester(settings,
                             command_line.HasOption(flutter::FlagForSwitch(

--- a/shell/testing/tester_main.cc
+++ b/shell/testing/tester_main.cc
@@ -27,6 +27,10 @@
 #include "third_party/dart/runtime/include/bin/dart_io_api.h"
 #include "third_party/dart/runtime/include/dart_api.h"
 
+#if defined(FML_OS_WIN)
+#include <combaseapi.h>
+#endif  // defined(FML_OS_WIN)
+
 #if defined(FML_OS_POSIX)
 #include <signal.h>
 #endif  // defined(FML_OS_POSIX)
@@ -413,6 +417,11 @@ int main(int argc, char* argv[]) {
     ::exit(1);
     return true;
   };
+
+#if defined(FML_OS_WIN)
+  CoInitializeEx(nullptr,
+                 COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
+#endif  // defined(FML_OS_WIN)
 
   return flutter::RunTester(settings,
                             command_line.HasOption(flutter::FlagForSwitch(

--- a/tools/githooks/setup.py
+++ b/tools/githooks/setup.py
@@ -10,6 +10,7 @@ Sets up githooks.
 import os
 import subprocess
 import sys
+from shutil import which  # Natively supported since python 3.3
 
 SRC_ROOT = os.path.dirname(
     os.path.dirname(
@@ -18,18 +19,13 @@ SRC_ROOT = os.path.dirname(
 )
 FLUTTER_DIR = os.path.join(SRC_ROOT, 'flutter')
 
-
-def IsWindows():
-  os_id = sys.platform
-  return os_id.startswith('win32') or os_id.startswith('cygwin')
-
-
 def Main(argv):
-  git = 'git'
   githooks = os.path.join(FLUTTER_DIR, 'tools', 'githooks')
-  if IsWindows():
-    git = 'git.bat'
-    githooks = os.path.join(githooks, 'windows')
+  git_candidates = ['git', 'git.sh', 'git.bat']
+  git = next(filter(which, git_candidates), None)
+  if git is None:
+    candidates = "', '".join(git_candidates)
+    raise IOError(f"Looks like GIT is not on the path. Tried '{candidates}'")
   result = subprocess.run([
       git,
       'config',

--- a/tools/githooks/setup.py
+++ b/tools/githooks/setup.py
@@ -19,6 +19,7 @@ SRC_ROOT = os.path.dirname(
 )
 FLUTTER_DIR = os.path.join(SRC_ROOT, 'flutter')
 
+
 def Main(argv):
   githooks = os.path.join(FLUTTER_DIR, 'tools', 'githooks')
   git_candidates = ['git', 'git.sh', 'git.bat']


### PR DESCRIPTION
`build/git_revision.py` now uses a git executable name search list on all platforms, avoiding issues with some Windows installations.

### Linked issues

- Fixes flutter/flutter#106615

### Impact on [flutter/tests] repo
This PR does not affect the [flutter/tests] repo.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
