### PR TITLE
[Windows] handle repaint message in FlutterView window

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -22,3 +22,4 @@ Callum Moffat <callum@moffatman.com>
 Koutaro Mori <koutaro.mo@gmail.com>
 TheOneWithTheBraid <the-one@with-the-braid.cf>
 Twin Sun, LLC <google-contrib@twinsunsolutions.com>
+Qixing Cao <qixing.cao.83@gmail.com>

--- a/shell/platform/windows/flutter_window_win32.cc
+++ b/shell/platform/windows/flutter_window_win32.cc
@@ -135,6 +135,12 @@ void FlutterWindowWin32::OnResize(unsigned int width, unsigned int height) {
   }
 }
 
+void FlutterWindowWin32::OnPaint() {
+  if (binding_handler_delegate_ != nullptr) {
+    binding_handler_delegate_->OnWindowRepaint();
+  }
+}
+
 void FlutterWindowWin32::OnPointerMove(double x,
                                        double y,
                                        FlutterPointerDeviceKind device_kind,

--- a/shell/platform/windows/flutter_window_win32.h
+++ b/shell/platform/windows/flutter_window_win32.h
@@ -37,6 +37,9 @@ class FlutterWindowWin32 : public WindowWin32, public WindowBindingHandler {
   void OnResize(unsigned int width, unsigned int height) override;
 
   // |WindowWin32|
+  void OnPaint() override;
+
+  // |WindowWin32|
   void OnPointerMove(double x,
                      double y,
                      FlutterPointerDeviceKind device_kind,

--- a/shell/platform/windows/flutter_window_win32_unittests.cc
+++ b/shell/platform/windows/flutter_window_win32_unittests.cc
@@ -109,6 +109,13 @@ class MockFlutterWindowWin32 : public FlutterWindowWin32 {
   // Wrapper for GetCurrentDPI() which is a protected method.
   UINT GetDpi() { return GetCurrentDPI(); }
 
+  // Simulates a WindowProc message from the OS.
+  LRESULT InjectWindowMessage(UINT const message,
+                              WPARAM const wparam,
+                              LPARAM const lparam) {
+    return HandleMessage(message, wparam, lparam);
+  }
+
   MOCK_METHOD1(OnDpiScale, void(unsigned int));
   MOCK_METHOD2(OnResize, void(unsigned int, unsigned int));
   MOCK_METHOD4(OnPointerMove,
@@ -344,6 +351,16 @@ TEST(FlutterWindowWin32Test, OnScrollCallsGetScrollOffsetMultiplier) {
 
   win32window.OnScroll(0.0f, 0.0f, kFlutterPointerDeviceKindMouse,
                        kDefaultPointerDeviceId);
+}
+
+TEST(FlutterWindowWin32Test, OnWindowRepaint) {
+  MockFlutterWindowWin32 win32window;
+  MockWindowBindingHandlerDelegate delegate;
+  win32window.SetView(&delegate);
+
+  EXPECT_CALL(delegate, OnWindowRepaint()).Times(1);
+
+  win32window.InjectWindowMessage(WM_PAINT, 0, 0);
 }
 
 }  // namespace testing

--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -163,6 +163,10 @@ void FlutterWindowsView::OnWindowSizeChanged(size_t width, size_t height) {
   }
 }
 
+void FlutterWindowsView::OnWindowRepaint() {
+  ForceRedraw();
+}
+
 void FlutterWindowsView::OnPointerMove(double x,
                                        double y,
                                        FlutterPointerDeviceKind device_kind,
@@ -603,6 +607,8 @@ void FlutterWindowsView::CreateRenderSurface() {
     PhysicalWindowBounds bounds = binding_handler_->GetPhysicalWindowBounds();
     engine_->surface_manager()->CreateSurface(GetRenderTarget(), bounds.width,
                                               bounds.height);
+    resize_target_width_ = bounds.width;
+    resize_target_height_ = bounds.height;
   }
 }
 

--- a/shell/platform/windows/flutter_windows_view.h
+++ b/shell/platform/windows/flutter_windows_view.h
@@ -100,6 +100,9 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate,
   void OnWindowSizeChanged(size_t width, size_t height) override;
 
   // |WindowBindingHandlerDelegate|
+  void OnWindowRepaint() override;
+
+  // |WindowBindingHandlerDelegate|
   void OnPointerMove(double x,
                      double y,
                      FlutterPointerDeviceKind device_kind,

--- a/shell/platform/windows/testing/mock_window_binding_handler_delegate.h
+++ b/shell/platform/windows/testing/mock_window_binding_handler_delegate.h
@@ -22,6 +22,7 @@ class MockWindowBindingHandlerDelegate : public WindowBindingHandlerDelegate {
       MockWindowBindingHandlerDelegate const&) = delete;
 
   MOCK_METHOD2(OnWindowSizeChanged, void(size_t, size_t));
+  MOCK_METHOD0(OnWindowRepaint, void());
   MOCK_METHOD4(OnPointerMove,
                void(double, double, FlutterPointerDeviceKind, int32_t));
   MOCK_METHOD5(OnPointerDown,

--- a/shell/platform/windows/testing/mock_window_win32.h
+++ b/shell/platform/windows/testing/mock_window_win32.h
@@ -37,6 +37,7 @@ class MockWin32Window : public WindowWin32 {
 
   MOCK_METHOD1(OnDpiScale, void(unsigned int));
   MOCK_METHOD2(OnResize, void(unsigned int, unsigned int));
+  MOCK_METHOD0(OnPaint, void());
   MOCK_METHOD4(OnPointerMove,
                void(double, double, FlutterPointerDeviceKind, int32_t));
   MOCK_METHOD5(OnPointerDown,

--- a/shell/platform/windows/window_binding_handler_delegate.h
+++ b/shell/platform/windows/window_binding_handler_delegate.h
@@ -22,6 +22,10 @@ class WindowBindingHandlerDelegate {
   // called on the platform thread.
   virtual void OnWindowSizeChanged(size_t width, size_t height) = 0;
 
+  // Notifies delegate that backing window needs to be repainted.
+  // Typically called by currently configured WindowBindingHandler
+  virtual void OnWindowRepaint() = 0;
+
   // Notifies delegate that backing window mouse has moved.
   // Typically called by currently configured WindowBindingHandler
   virtual void OnPointerMove(double x,

--- a/shell/platform/windows/window_binding_handler_delegate.h
+++ b/shell/platform/windows/window_binding_handler_delegate.h
@@ -23,18 +23,18 @@ class WindowBindingHandlerDelegate {
   virtual void OnWindowSizeChanged(size_t width, size_t height) = 0;
 
   // Notifies delegate that backing window needs to be repainted.
-  // Typically called by currently configured WindowBindingHandler
+  // Typically called by currently configured WindowBindingHandler.
   virtual void OnWindowRepaint() = 0;
 
   // Notifies delegate that backing window mouse has moved.
-  // Typically called by currently configured WindowBindingHandler
+  // Typically called by currently configured WindowBindingHandler.
   virtual void OnPointerMove(double x,
                              double y,
                              FlutterPointerDeviceKind device_kind,
                              int32_t device_id) = 0;
 
   // Notifies delegate that backing window mouse pointer button has been
-  // pressed. Typically called by currently configured WindowBindingHandler
+  // pressed. Typically called by currently configured WindowBindingHandler.
   virtual void OnPointerDown(double x,
                              double y,
                              FlutterPointerDeviceKind device_kind,
@@ -42,7 +42,7 @@ class WindowBindingHandlerDelegate {
                              FlutterPointerMouseButtons button) = 0;
 
   // Notifies delegate that backing window mouse pointer button has been
-  // released. Typically called by currently configured WindowBindingHandler
+  // released. Typically called by currently configured WindowBindingHandler.
   virtual void OnPointerUp(double x,
                            double y,
                            FlutterPointerDeviceKind device_kind,
@@ -50,18 +50,18 @@ class WindowBindingHandlerDelegate {
                            FlutterPointerMouseButtons button) = 0;
 
   // Notifies delegate that backing window mouse pointer has left the window.
-  // Typically called by currently configured WindowBindingHandler
+  // Typically called by currently configured WindowBindingHandler.
   virtual void OnPointerLeave(double x,
                               double y,
                               FlutterPointerDeviceKind device_kind,
                               int32_t device_id) = 0;
 
   // Notifies delegate that a pan/zoom gesture has started.
-  // Typically called by DirectManipulationEventHandler
+  // Typically called by DirectManipulationEventHandler.
   virtual void OnPointerPanZoomStart(int32_t device_id) = 0;
 
   // Notifies delegate that a pan/zoom gesture has updated.
-  // Typically called by DirectManipulationEventHandler
+  // Typically called by DirectManipulationEventHandler.
   virtual void OnPointerPanZoomUpdate(int32_t device_id,
                                       double pan_x,
                                       double pan_y,
@@ -69,11 +69,11 @@ class WindowBindingHandlerDelegate {
                                       double rotation) = 0;
 
   // Notifies delegate that a pan/zoom gesture has ended.
-  // Typically called by DirectManipulationEventHandler
+  // Typically called by DirectManipulationEventHandler.
   virtual void OnPointerPanZoomEnd(int32_t device_id) = 0;
 
   // Notifies delegate that backing window has received text.
-  // Typically called by currently configured WindowBindingHandler
+  // Typically called by currently configured WindowBindingHandler.
   virtual void OnText(const std::u16string&) = 0;
 
   // Notifies delegate that backing window size has received key press. Should
@@ -113,7 +113,7 @@ class WindowBindingHandlerDelegate {
   virtual void OnComposeChange(const std::u16string& text, int cursor_pos) = 0;
 
   // Notifies delegate that backing window size has recevied scroll.
-  // Typically called by currently configured WindowBindingHandler
+  // Typically called by currently configured WindowBindingHandler.
   virtual void OnScroll(double x,
                         double y,
                         double delta_x,

--- a/shell/platform/windows/window_win32.cc
+++ b/shell/platform/windows/window_win32.cc
@@ -335,6 +335,9 @@ WindowWin32::HandleMessage(UINT const message,
       current_height_ = height;
       HandleResize(width, height);
       break;
+    case WM_PAINT:
+      OnPaint();
+      break;
     case WM_TOUCH: {
       UINT num_points = LOWORD(wparam);
       touch_points_.resize(num_points);

--- a/shell/platform/windows/window_win32.h
+++ b/shell/platform/windows/window_win32.h
@@ -96,6 +96,9 @@ class WindowWin32 : public KeyboardManagerWin32::WindowDelegate {
   // Called when a resize occurs.
   virtual void OnResize(UINT width, UINT height) = 0;
 
+  // Called when a paint is requested.
+  virtual void OnPaint() = 0;
+
   // Called when the pointer moves within the
   // window bounds.
   virtual void OnPointerMove(double x,

--- a/shell/platform/windows/window_win32_unittests.cc
+++ b/shell/platform/windows/window_win32_unittests.cc
@@ -273,5 +273,11 @@ TEST(MockWin32Window, KeyDownWithCtrlToggled) {
   SetKeyboardState(keyboard_state);
 }
 
+TEST(MockWin32Window, Paint) {
+  MockWin32Window window;
+  EXPECT_CALL(window, OnPaint()).Times(1);
+  window.InjectWindowMessage(WM_PAINT, 0, 0);
+}
+
 }  // namespace testing
 }  // namespace flutter


### PR DESCRIPTION
This PR will fix the blank FlutterView issue by handling the reapint message in FlutterView window.

Currently, WM_PAINT msg is not handled in flutter window and the default WindowProc will do nothing but painting the background. In some user cases, e.g., hide/show/min/max the app window, this will cause blank FlutterView described in the following 2 issues, as the framework has no knowledge of it and will not trigger a new frame if the content is static and there are no running animation.

*This PR will fix:*
https://github.com/flutter/flutter/issues/101339
https://github.com/flutter/flutter/issues/102030

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
