### PR TITLE
Fix build on Linux

### DIFF
--- a/shell/platform/linux/fl_accessible_node.cc
+++ b/shell/platform/linux/fl_accessible_node.cc
@@ -80,7 +80,7 @@ struct FlAccessibleNodePrivate {
   FlutterSemanticsFlag flags;
 };
 
-enum { PROP_0, PROP_ENGINE, PROP_ID, PROP_LAST };
+enum { kProp0, kPropEngine, kPropId, kPropLast };
 
 #define FL_ACCESSIBLE_NODE_GET_PRIVATE(node)                          \
   ((FlAccessibleNodePrivate*)fl_accessible_node_get_instance_private( \
@@ -147,13 +147,13 @@ static void fl_accessible_node_set_property(GObject* object,
                                             GParamSpec* pspec) {
   FlAccessibleNodePrivate* priv = FL_ACCESSIBLE_NODE_GET_PRIVATE(object);
   switch (prop_id) {
-    case PROP_ENGINE:
+    case kPropEngine:
       g_assert(priv->engine == nullptr);
       priv->engine = FL_ENGINE(g_value_get_object(value));
       g_object_add_weak_pointer(object,
                                 reinterpret_cast<gpointer*>(&priv->engine));
       break;
-    case PROP_ID:
+    case kPropId:
       priv->id = g_value_get_int(value);
       break;
     default:
@@ -450,13 +450,13 @@ static void fl_accessible_node_class_init(FlAccessibleNodeClass* klass) {
       fl_accessible_node_perform_action_impl;
 
   g_object_class_install_property(
-      G_OBJECT_CLASS(klass), PROP_ENGINE,
+      G_OBJECT_CLASS(klass), kPropEngine,
       g_param_spec_object(
           "engine", "engine", "Flutter engine", fl_engine_get_type(),
           static_cast<GParamFlags>(G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY |
                                    G_PARAM_STATIC_STRINGS)));
   g_object_class_install_property(
-      G_OBJECT_CLASS(klass), PROP_ID,
+      G_OBJECT_CLASS(klass), kPropId,
       g_param_spec_int(
           "id", "id", "Accessibility node ID", 0, G_MAXINT, 0,
           static_cast<GParamFlags>(G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY |

--- a/shell/platform/linux/fl_engine.cc
+++ b/shell/platform/linux/fl_engine.cc
@@ -73,7 +73,7 @@ G_DEFINE_TYPE_WITH_CODE(
     G_IMPLEMENT_INTERFACE(fl_plugin_registry_get_type(),
                           fl_engine_plugin_registry_iface_init))
 
-enum { PROP_0, PROP_BINARY_MESSENGER, PROP_LAST };
+enum { kProp0, kPropBinaryMessenger, kPropLast };
 
 // Parse a locale into its components.
 static void parse_locale(const gchar* locale,
@@ -359,7 +359,7 @@ static void fl_engine_set_property(GObject* object,
                                    GParamSpec* pspec) {
   FlEngine* self = FL_ENGINE(object);
   switch (prop_id) {
-    case PROP_BINARY_MESSENGER:
+    case kPropBinaryMessenger:
       g_set_object(&self->binary_messenger,
                    FL_BINARY_MESSENGER(g_value_get_object(value)));
       break;
@@ -418,7 +418,7 @@ static void fl_engine_class_init(FlEngineClass* klass) {
   G_OBJECT_CLASS(klass)->set_property = fl_engine_set_property;
 
   g_object_class_install_property(
-      G_OBJECT_CLASS(klass), PROP_BINARY_MESSENGER,
+      G_OBJECT_CLASS(klass), kPropBinaryMessenger,
       g_param_spec_object(
           "binary-messenger", "messenger", "Binary messenger",
           fl_binary_messenger_get_type(),

--- a/shell/platform/linux/fl_settings_plugin_test.cc
+++ b/shell/platform/linux/fl_settings_plugin_test.cc
@@ -41,8 +41,9 @@ TEST(FlSettingsPluginTest, AlwaysUse24HourFormat) {
   ::testing::NiceMock<flutter::testing::MockSettings> settings;
   ::testing::NiceMock<flutter::testing::MockBinaryMessenger> messenger;
 
-  g_autoptr(FlEngine) engine = FL_ENGINE(g_object_new(
-      fl_engine_get_type(), "binary-messenger", messenger, nullptr));
+  g_autoptr(FlEngine) engine =
+      FL_ENGINE(g_object_new(fl_engine_get_type(), "binary-messenger",
+                             FL_BINARY_MESSENGER(messenger), nullptr));
   g_autoptr(FlSettingsPlugin) plugin = fl_settings_plugin_new(engine);
 
   g_autoptr(FlValue) use_12h = fl_value_new_bool(false);
@@ -66,8 +67,9 @@ TEST(FlSettingsPluginTest, PlatformBrightness) {
   ::testing::NiceMock<flutter::testing::MockSettings> settings;
   ::testing::NiceMock<flutter::testing::MockBinaryMessenger> messenger;
 
-  g_autoptr(FlEngine) engine = FL_ENGINE(g_object_new(
-      fl_engine_get_type(), "binary-messenger", messenger, nullptr));
+  g_autoptr(FlEngine) engine =
+      FL_ENGINE(g_object_new(fl_engine_get_type(), "binary-messenger",
+                             FL_BINARY_MESSENGER(messenger), nullptr));
   g_autoptr(FlSettingsPlugin) plugin = fl_settings_plugin_new(engine);
 
   g_autoptr(FlValue) light = fl_value_new_string("light");
@@ -91,8 +93,9 @@ TEST(FlSettingsPluginTest, TextScaleFactor) {
   ::testing::NiceMock<flutter::testing::MockSettings> settings;
   ::testing::NiceMock<flutter::testing::MockBinaryMessenger> messenger;
 
-  g_autoptr(FlEngine) engine = FL_ENGINE(g_object_new(
-      fl_engine_get_type(), "binary-messenger", messenger, nullptr));
+  g_autoptr(FlEngine) engine =
+      FL_ENGINE(g_object_new(fl_engine_get_type(), "binary-messenger",
+                             FL_BINARY_MESSENGER(messenger), nullptr));
   g_autoptr(FlSettingsPlugin) plugin = fl_settings_plugin_new(engine);
 
   g_autoptr(FlValue) one = fl_value_new_float(1.0);


### PR DESCRIPTION
a) #33955 and #33313 did not conform to the new clang-tidy rules enabled in #33692: https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8810225690269242849/+/u/test:_lint_host_debug/stdout

b) MockBinaryMessenger tweaks applied by #33955 caused the newly added tests in #33313 to not build: https://github.com/flutter/engine/runs/7063741502
