### PR TITLE
[fuchsia] replace deprecated fdio_ns_connect

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -648,7 +648,7 @@ deps = {
      'packages': [
        {
         'package': 'fuchsia/sdk/core/mac-amd64',
-        'version': 'QB_6Q7LjQwHhLWYqTSBqThAcQ_AtyDLFkOkI_DZqR1MC'
+        'version': 'eXmUtsA82V2gHbD8YDU-Bb_GBvUvIyOsUQAxxkqSlDkC'
        }
      ],
      'condition': 'host_os == "mac" and not download_fuchsia_sdk',
@@ -658,7 +658,7 @@ deps = {
      'packages': [
        {
         'package': 'fuchsia/sdk/core/linux-amd64',
-        'version': 'aRT7s0Yct4Lq9GgwT91hdeaKh02yh-YUWqS_Vmy3kowC'
+        'version': 'ZBjjClCHXkZcV-OiBwSQDecMwaehQ6neEGir2XavgzsC'
        }
      ],
      'condition': 'host_os == "linux" and not download_fuchsia_sdk',

--- a/ci/licenses_golden/licenses_fuchsia
+++ b/ci/licenses_golden/licenses_fuchsia
@@ -1,4 +1,4 @@
-Signature: f2795d04df7d2bf137a1e99e569acc25
+Signature: 841a94fc3514a3c64d495ed7d25388cd
 
 UNUSED LICENSES:
 

--- a/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/system.cc
+++ b/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/system.cc
@@ -203,9 +203,8 @@ Dart_Handle System::ChannelCreate(uint32_t options) {
 
 zx_status_t System::ConnectToService(std::string path,
                                      fml::RefPtr<Handle> channel) {
-  return fdio_ns_connect(GetNamespace(), path.c_str(),
-                         ZX_FS_RIGHT_READABLE | ZX_FS_RIGHT_WRITABLE,
-                         channel->ReleaseHandle());
+  return fdio_ns_service_connect(GetNamespace(), path.c_str(),
+                                 channel->ReleaseHandle());
 }
 
 zx::channel System::CloneChannelFromFileDescriptor(int fd) {


### PR DESCRIPTION
fdio_ns_connect was deprecated and replaced with fdio_ns_service_connect.