### PR TITLE
Expose a iOS plist setting to disable partial repaint.

### DIFF
--- a/shell/gpu/gpu_surface_metal_skia.h
+++ b/shell/gpu/gpu_surface_metal_skia.h
@@ -38,6 +38,7 @@ class SK_API_AVAILABLE_CA_METAL_LAYER GPUSurfaceMetalSkia : public Surface {
   // hack to make avoid allocating resources for the root surface when an
   // external view embedder is present.
   bool render_to_surface_ = true;
+  bool disable_partial_repaint_ = false;
 
   // Accumulated damage for each framebuffer; Key is address of underlying
   // MTLTexture for each drawable

--- a/shell/gpu/gpu_surface_metal_skia.mm
+++ b/shell/gpu/gpu_surface_metal_skia.mm
@@ -54,7 +54,14 @@ GPUSurfaceMetalSkia::GPUSurfaceMetalSkia(GPUSurfaceMetalDelegate* delegate,
       render_target_type_(delegate->GetRenderTargetType()),
       context_(std::move(context)),
       msaa_samples_(msaa_samples),
-      render_to_surface_(render_to_surface) {}
+      render_to_surface_(render_to_surface) {
+  // If this preference is explicitly set, we allow for disabling partial repaint.
+  NSNumber* disablePartialRepaint =
+      [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FLTDisablePartialRepaint"];
+  if (disablePartialRepaint != nil) {
+    disable_partial_repaint_ = disablePartialRepaint.boolValue;
+  }
+}
 
 GPUSurfaceMetalSkia::~GPUSurfaceMetalSkia() = default;
 
@@ -149,17 +156,19 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetalSkia::AcquireFrameFromCAMetalLayer(
       canvas->flush();
     }
 
-    uintptr_t texture = reinterpret_cast<uintptr_t>(drawable.get().texture);
-    for (auto& entry : damage_) {
-      if (entry.first != texture) {
-        // Accumulate damage for other framebuffers
-        if (surface_frame.submit_info().frame_damage) {
-          entry.second.join(*surface_frame.submit_info().frame_damage);
+    if (!disable_partial_repaint_) {
+      uintptr_t texture = reinterpret_cast<uintptr_t>(drawable.get().texture);
+      for (auto& entry : damage_) {
+        if (entry.first != texture) {
+          // Accumulate damage for other framebuffers
+          if (surface_frame.submit_info().frame_damage) {
+            entry.second.join(*surface_frame.submit_info().frame_damage);
+          }
         }
       }
+      // Reset accumulated damage for current framebuffer
+      damage_[texture] = SkIRect::MakeEmpty();
     }
-    // Reset accumulated damage for current framebuffer
-    damage_[texture] = SkIRect::MakeEmpty();
 
     return delegate_->PresentDrawable(drawable);
   };
@@ -167,14 +176,17 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetalSkia::AcquireFrameFromCAMetalLayer(
   SurfaceFrame::FramebufferInfo framebuffer_info;
   framebuffer_info.supports_readback = true;
 
-  // Provide accumulated damage to rasterizer (area in current framebuffer that lags behind
-  // front buffer)
-  uintptr_t texture = reinterpret_cast<uintptr_t>(drawable.get().texture);
-  auto i = damage_.find(texture);
-  if (i != damage_.end()) {
-    framebuffer_info.existing_damage = i->second;
+  if (!disable_partial_repaint_) {
+    // Provide accumulated damage to rasterizer (area in current framebuffer that lags behind
+    // front buffer)
+    uintptr_t texture = reinterpret_cast<uintptr_t>(drawable.get().texture);
+    auto i = damage_.find(texture);
+    if (i != damage_.end()) {
+      framebuffer_info.existing_damage = i->second;
+    }
+    framebuffer_info.supports_partial_repaint = true;
   }
-  framebuffer_info.supports_partial_repaint = true;
+
   return std::make_unique<SurfaceFrame>(std::move(surface), framebuffer_info, submit_callback);
 }
 


### PR DESCRIPTION
If the following is added to Info.plist of the application, it will disable partial repaint:

```
  <key>FLTDisablePartialRepaint</key>
  <true/>
```

The primary intended use case for this is to enable applications to see if disabling partial repaint resolves: https://github.com/flutter/flutter/issues/100522.
