### PR TITLE
[fuchsia] Close runtime_dir when launching components

### DIFF
--- a/shell/platform/fuchsia/dart_runner/dart_component_controller_v2.cc
+++ b/shell/platform/fuchsia/dart_runner/dart_component_controller_v2.cc
@@ -133,6 +133,10 @@ DartComponentControllerV2::DartComponentControllerV2(
     idle_wait_.set_trigger(ZX_TIMER_SIGNALED);
     idle_wait_.Begin(async_get_default_dispatcher());
   }
+
+  // Close the runtime_dir channel if we don't intend to serve it. Otherwise any
+  // access to the runtime_dir will hang forever.
+  start_info_.clear_runtime_dir();
 }
 
 DartComponentControllerV2::~DartComponentControllerV2() {

--- a/shell/platform/fuchsia/dart_runner/dart_test_component_controller_v2.cc
+++ b/shell/platform/fuchsia/dart_runner/dart_test_component_controller_v2.cc
@@ -136,6 +136,10 @@ DartTestComponentControllerV2::DartTestComponentControllerV2(
     idle_wait_.set_trigger(ZX_TIMER_SIGNALED);
     idle_wait_.Begin(async_get_default_dispatcher());
   }
+
+  // Close the runtime_dir channel if we don't intend to serve it. Otherwise any
+  // access to the runtime_dir will hang forever.
+  start_info_.clear_runtime_dir();
 }
 
 DartTestComponentControllerV2::~DartTestComponentControllerV2() {


### PR DESCRIPTION
The runner is supposed to either serve the runtime_dir, or close the
channel immediately. Otherwise consumers will get blocked indefinitely.

BUG: fxbug.dev/103480
TESTED: build and deploy to fuchsia, the above command now returns "No such file or directory".
