### PR TITLE
Minimally crop advanced blends in EntityPass

### DIFF
--- a/impeller/entity/contents/filters/filter_contents.cc
+++ b/impeller/entity/contents/filters/filter_contents.cc
@@ -116,6 +116,10 @@ void FilterContents::SetInputs(FilterInput::Vector inputs) {
   inputs_ = std::move(inputs);
 }
 
+void FilterContents::SetCoverageCrop(std::optional<Rect> coverage_crop) {
+  coverage_crop_ = coverage_crop;
+}
+
 bool FilterContents::Render(const ContentContext& renderer,
                             const Entity& entity,
                             RenderPass& pass) const {
@@ -175,6 +179,9 @@ std::optional<Rect> FilterContents::GetFilterCoverage(
       continue;
     }
     result = result->Union(coverage.value());
+  }
+  if (coverage_crop_.has_value() && result.has_value()) {
+    result->Union(coverage_crop_.value());
   }
   return result;
 }

--- a/impeller/entity/contents/filters/filter_contents.cc
+++ b/impeller/entity/contents/filters/filter_contents.cc
@@ -154,7 +154,13 @@ std::optional<Rect> FilterContents::GetCoverage(const Entity& entity) const {
   Entity entity_with_local_transform = entity;
   entity_with_local_transform.SetTransformation(
       GetTransform(entity.GetTransformation()));
-  return GetFilterCoverage(inputs_, entity_with_local_transform);
+
+  auto coverage = GetFilterCoverage(inputs_, entity_with_local_transform);
+  if (coverage_crop_.has_value() && coverage.has_value()) {
+    coverage = coverage->Union(coverage_crop_.value());
+  }
+
+  return coverage;
 }
 
 std::optional<Rect> FilterContents::GetFilterCoverage(
@@ -179,9 +185,6 @@ std::optional<Rect> FilterContents::GetFilterCoverage(
       continue;
     }
     result = result->Union(coverage.value());
-  }
-  if (coverage_crop_.has_value() && result.has_value()) {
-    result->Union(coverage_crop_.value());
   }
   return result;
 }

--- a/impeller/entity/contents/filters/filter_contents.h
+++ b/impeller/entity/contents/filters/filter_contents.h
@@ -109,12 +109,15 @@ class FilterContents : public Contents {
 
   ~FilterContents() override;
 
-  /// @brief The input texture sources for this filter. Each input's emitted
-  ///        texture is expected to have premultiplied alpha colors.
+  /// @brief  The input texture sources for this filter. Each input's emitted
+  ///         texture is expected to have premultiplied alpha colors.
   ///
-  ///        The number of required or optional textures depends on the
-  ///        particular filter's implementation.
+  ///         The number of required or optional textures depends on the
+  ///         particular filter's implementation.
   void SetInputs(FilterInput::Vector inputs);
+
+  /// @brief  Screen space bounds to use for cropping the filter output.
+  void SetCoverageCrop(std::optional<Rect> coverage_crop);
 
   // |Contents|
   bool Render(const ContentContext& renderer,
@@ -146,6 +149,7 @@ class FilterContents : public Contents {
                             const Rect& coverage) const = 0;
 
   FilterInput::Vector inputs_;
+  std::optional<Rect> coverage_crop_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(FilterContents);
 };

--- a/impeller/entity/contents/filters/filter_contents.h
+++ b/impeller/entity/contents/filters/filter_contents.h
@@ -148,6 +148,8 @@ class FilterContents : public Contents {
                             RenderPass& pass,
                             const Rect& coverage) const = 0;
 
+  std::optional<Rect> GetLocalCoverage(const Entity& local_entity) const;
+
   FilterInput::Vector inputs_;
   std::optional<Rect> coverage_crop_;
 

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -65,7 +65,7 @@ const std::shared_ptr<LazyGlyphAtlas>& EntityPass::GetLazyGlyphAtlas() const {
 }
 
 std::optional<Rect> EntityPass::GetElementsCoverage(
-    std::optional<Rect> coverage_clip) const {
+    std::optional<Rect> coverage_crop) const {
   std::optional<Rect> result;
   for (const auto& element : elements_) {
     std::optional<Rect> coverage;
@@ -73,12 +73,12 @@ std::optional<Rect> EntityPass::GetElementsCoverage(
     if (auto entity = std::get_if<Entity>(&element)) {
       coverage = entity->GetCoverage();
 
-      if (coverage.has_value() && coverage_clip.has_value()) {
-        coverage = coverage->Intersection(coverage_clip.value());
+      if (coverage.has_value() && coverage_crop.has_value()) {
+        coverage = coverage->Intersection(coverage_crop.value());
       }
     } else if (auto subpass =
                    std::get_if<std::unique_ptr<EntityPass>>(&element)) {
-      coverage = GetSubpassCoverage(*subpass->get(), coverage_clip);
+      coverage = GetSubpassCoverage(*subpass->get(), coverage_crop);
     } else {
       FML_UNREACHABLE();
     }
@@ -427,8 +427,10 @@ bool EntityPass::OnRender(ContentContext& renderer,
           FilterInput::Make(result.entity.GetContents()),
           FilterInput::Make(texture,
                             result.entity.GetTransformation().Invert())};
-      result.entity.SetContents(
-          FilterContents::MakeBlend(result.entity.GetBlendMode(), inputs));
+      auto contents =
+          FilterContents::MakeBlend(result.entity.GetBlendMode(), inputs);
+      contents->SetCoverageCrop(result.entity.GetCoverage());
+
       result.entity.SetBlendMode(Entity::BlendMode::kSourceOver);
     }
 

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -430,7 +430,7 @@ bool EntityPass::OnRender(ContentContext& renderer,
       auto contents =
           FilterContents::MakeBlend(result.entity.GetBlendMode(), inputs);
       contents->SetCoverageCrop(result.entity.GetCoverage());
-
+      result.entity.SetContents(std::move(contents));
       result.entity.SetBlendMode(Entity::BlendMode::kSourceOver);
     }
 

--- a/impeller/entity/entity_pass.h
+++ b/impeller/entity/entity_pass.h
@@ -62,10 +62,10 @@ class EntityPass {
 
   std::optional<Rect> GetSubpassCoverage(
       const EntityPass& subpass,
-      std::optional<Rect> coverage_clip) const;
+      std::optional<Rect> coverage_crop) const;
 
   std::optional<Rect> GetElementsCoverage(
-      std::optional<Rect> coverage_clip) const;
+      std::optional<Rect> coverage_crop) const;
 
  private:
   struct EntityResult {

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -131,6 +131,31 @@ TEST_P(EntityTest, EntityPassCoverageRespectsCoverageLimit) {
   }
 }
 
+TEST_P(EntityTest, FilterCoverageRespectsCropRect) {
+  auto image = CreateTextureForFixture("boston.jpg");
+  auto filter = FilterContents::MakeBlend(Entity::BlendMode::kSoftLight,
+                                          FilterInput::Make({image}));
+
+  // Without the crop rect (default behavior).
+  {
+    auto actual = filter->GetCoverage({});
+    auto expected = Rect::MakeSize(Size(image->GetSize()));
+
+    ASSERT_TRUE(actual.has_value());
+    ASSERT_RECT_NEAR(actual.value(), expected);
+  }
+
+  // With the crop rect.
+  {
+    auto expected = Rect::MakeSize(Size(image->GetSize()));
+    filter->SetCoverageCrop(expected);
+    auto actual = filter->GetCoverage({});
+
+    ASSERT_TRUE(actual.has_value());
+    ASSERT_RECT_NEAR(actual.value(), expected);
+  }
+}
+
 TEST_P(EntityTest, CanDrawRect) {
   Entity entity;
   entity.SetTransformation(Matrix::MakeScale(GetContentScale()));


### PR DESCRIPTION
The default behavior for the blend filter is to union the coverage of all the inputs. Without this change, the advanced blend filter output ends up always being the full size of the backdrop texture. This is wasteful because EntityPass immediately blits the blend filter's output texture back onto the backdrop texture, and so for non-destructive blends, we only need to compute the blend within the source input's coverage.

Add `FilterContents::SetCoverageCrop()` and use it in `EntityPass` to exclude the backdrop texture coverage for advanced blends.

Note that all destructive blend modes (Clear, Source, SourceIn, DestinationIn, SourceOut, DestinationATop, and Modulate) are pipeline blends, and so this cropping behavior should always be safe.