### PR TITLE
[Impeller] Add shader library; reduce branching in advanced blends

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -475,6 +475,10 @@ FILE: ../../../flutter/impeller/compiler/reflector.cc
 FILE: ../../../flutter/impeller/compiler/reflector.h
 FILE: ../../../flutter/impeller/compiler/runtime_stage_data.cc
 FILE: ../../../flutter/impeller/compiler/runtime_stage_data.h
+FILE: ../../../flutter/impeller/compiler/shader_lib/impeller/branching.glsl
+FILE: ../../../flutter/impeller/compiler/shader_lib/impeller/color.glsl
+FILE: ../../../flutter/impeller/compiler/shader_lib/impeller/constants.glsl
+FILE: ../../../flutter/impeller/compiler/shader_lib/impeller/texture.glsl
 FILE: ../../../flutter/impeller/compiler/source_options.cc
 FILE: ../../../flutter/impeller/compiler/source_options.h
 FILE: ../../../flutter/impeller/compiler/switches.cc

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -606,7 +606,6 @@ FILE: ../../../flutter/impeller/entity/shaders/solid_stroke.frag
 FILE: ../../../flutter/impeller/entity/shaders/solid_stroke.vert
 FILE: ../../../flutter/impeller/entity/shaders/texture_fill.frag
 FILE: ../../../flutter/impeller/entity/shaders/texture_fill.vert
-FILE: ../../../flutter/impeller/entity/shaders/utils.sl.h
 FILE: ../../../flutter/impeller/entity/shaders/vertices.frag
 FILE: ../../../flutter/impeller/entity/shaders/vertices.vert
 FILE: ../../../flutter/impeller/geometry/color.cc

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -479,6 +479,7 @@ FILE: ../../../flutter/impeller/compiler/shader_lib/impeller/branching.glsl
 FILE: ../../../flutter/impeller/compiler/shader_lib/impeller/color.glsl
 FILE: ../../../flutter/impeller/compiler/shader_lib/impeller/constants.glsl
 FILE: ../../../flutter/impeller/compiler/shader_lib/impeller/texture.glsl
+FILE: ../../../flutter/impeller/compiler/shader_lib/impeller/types.glsl
 FILE: ../../../flutter/impeller/compiler/source_options.cc
 FILE: ../../../flutter/impeller/compiler/source_options.h
 FILE: ../../../flutter/impeller/compiler/switches.cc

--- a/impeller/compiler/shader_lib/impeller/branching.glsl
+++ b/impeller/compiler/shader_lib/impeller/branching.glsl
@@ -1,0 +1,34 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef BRANCHING_GLSL_
+#define BRANCHING_GLSL_
+
+#include <impeller/constants.glsl>
+
+vec3 EqualTo3(vec3 x, float y) {
+  return 1 - abs(sign(x - y));
+}
+
+float GreaterThan(float x, float y) {
+  return max(sign(x - y), 0);
+}
+
+vec3 GreaterThan3(vec3 x, float y) {
+  return max(sign(x - y), 0);
+}
+
+float LessThan(float x, float y) {
+  return max(sign(y - x), 0);
+}
+
+vec3 MixCutoff(vec3 a, vec3 b, vec3 value, float cutoff) {
+  return mix(a, b, GreaterThan3(value, cutoff));
+}
+
+vec3 MixHalf(vec3 a, vec3 b, vec3 value) {
+  return MixCutoff(a, b, value, 0.5);
+}
+
+#endif

--- a/impeller/compiler/shader_lib/impeller/branching.glsl
+++ b/impeller/compiler/shader_lib/impeller/branching.glsl
@@ -6,29 +6,44 @@
 #define BRANCHING_GLSL_
 
 #include <impeller/constants.glsl>
+#include <impeller/types.glsl>
 
-vec3 EqualTo3(vec3 x, float y) {
+/// Perform a branchless equality check for each vec3 component.
+///
+/// Returns 1.0 if x == y, otherwise 0.0.
+BoolV3 IPVec3IsEqual(vec3 x, vec3 y) {
   return 1 - abs(sign(x - y));
 }
 
-float GreaterThan(float x, float y) {
+/// Perform a branchless greater than check.
+///
+/// Returns 1.0 if x > y, otherwise 0.0.
+BoolF IPFloatIsGreaterThan(float x, float y) {
   return max(sign(x - y), 0);
 }
 
-vec3 GreaterThan3(vec3 x, float y) {
+/// Perform a branchless greater than check for each vec3 component.
+///
+/// Returns 1.0 if x > y, otherwise 0.0.
+BoolV3 IPVec3IsGreaterThan(vec3 x, vec3 y) {
   return max(sign(x - y), 0);
 }
 
-float LessThan(float x, float y) {
+/// Perform a branchless less than check.
+///
+/// Returns 1.0 if x < y, otherwise 0.0.
+BoolF IPFloatIsLessThan(float x, float y) {
   return max(sign(y - x), 0);
 }
 
-vec3 MixCutoff(vec3 a, vec3 b, vec3 value, float cutoff) {
-  return mix(a, b, GreaterThan3(value, cutoff));
+/// For each vec3 component, if value > cutoff, return b, otherwise return a.
+vec3 IPVec3ChooseCutoff(vec3 a, vec3 b, vec3 value, float cutoff) {
+  return mix(a, b, IPVec3IsGreaterThan(value, vec3(cutoff)));
 }
 
-vec3 MixHalf(vec3 a, vec3 b, vec3 value) {
-  return MixCutoff(a, b, value, 0.5);
+/// For each vec3 component, if value > 0.5, return b, otherwise return a.
+vec3 IPVec3Choose(vec3 a, vec3 b, BoolV3 value) {
+  return IPVec3ChooseCutoff(a, b, value, 0.5);
 }
 
 #endif

--- a/impeller/compiler/shader_lib/impeller/branching.glsl
+++ b/impeller/compiler/shader_lib/impeller/branching.glsl
@@ -8,11 +8,14 @@
 #include <impeller/constants.glsl>
 #include <impeller/types.glsl>
 
-/// Perform a branchless equality check for each vec3 component.
+/// Perform an equality check for each vec3 component.
 ///
 /// Returns 1.0 if x == y, otherwise 0.0.
-BoolV3 IPVec3IsEqual(vec3 x, vec3 y) {
-  return 1 - abs(sign(x - y));
+BoolV3 IPVec3IsEqual(vec3 x, float y) {
+  vec3 diff = abs(x - y);
+  return vec3(diff.r < kEhCloseEnough,  //
+              diff.g < kEhCloseEnough,  //
+              diff.b < kEhCloseEnough);
 }
 
 /// Perform a branchless greater than check.
@@ -42,7 +45,7 @@ vec3 IPVec3ChooseCutoff(vec3 a, vec3 b, vec3 value, float cutoff) {
 }
 
 /// For each vec3 component, if value > 0.5, return b, otherwise return a.
-vec3 IPVec3Choose(vec3 a, vec3 b, BoolV3 value) {
+vec3 IPVec3Choose(vec3 a, vec3 b, vec3 value) {
   return IPVec3ChooseCutoff(a, b, value, 0.5);
 }
 

--- a/impeller/compiler/shader_lib/impeller/color.glsl
+++ b/impeller/compiler/shader_lib/impeller/color.glsl
@@ -1,0 +1,14 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef COLOR_GLSL_
+#define COLOR_GLSL_
+
+#include <impeller/branching.glsl>
+
+vec4 Unpremultiply(vec4 color) {
+  return vec4(color.rgb / color.a * GreaterThan(color.a, 0), color.a);
+}
+
+#endif

--- a/impeller/compiler/shader_lib/impeller/color.glsl
+++ b/impeller/compiler/shader_lib/impeller/color.glsl
@@ -12,7 +12,10 @@
 ///
 /// Returns (0, 0, 0, 0) if the alpha component is 0.
 vec4 IPUnpremultiply(vec4 color) {
-  return vec4(color.rgb / color.a * IPFloatIsGreaterThan(color.a, 0), color.a);
+  if (color.a == 0) {
+    return vec4(0);
+  }
+  return vec4(color.rgb / color.a, color.a);
 }
 
 #endif

--- a/impeller/compiler/shader_lib/impeller/color.glsl
+++ b/impeller/compiler/shader_lib/impeller/color.glsl
@@ -7,8 +7,12 @@
 
 #include <impeller/branching.glsl>
 
-vec4 Unpremultiply(vec4 color) {
-  return vec4(color.rgb / color.a * GreaterThan(color.a, 0), color.a);
+/// Convert a premultiplied color (a color which has its color components
+/// multiplied with its alpha value) to an unpremultiplied color.
+///
+/// Returns (0, 0, 0, 0) if the alpha component is 0.
+vec4 IPUnpremultiply(vec4 color) {
+  return vec4(color.rgb / color.a * IPFloatIsGreaterThan(color.a, 0), color.a);
 }
 
 #endif

--- a/impeller/compiler/shader_lib/impeller/constants.glsl
+++ b/impeller/compiler/shader_lib/impeller/constants.glsl
@@ -1,0 +1,10 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CONSTANTS_GLSL_
+#define CONSTANTS_GLSL_
+
+const float kEhCloseEnough = 0.000001;
+
+#endif

--- a/impeller/compiler/shader_lib/impeller/texture.glsl
+++ b/impeller/compiler/shader_lib/impeller/texture.glsl
@@ -2,6 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#ifndef TEXTURE_GLSL_
+#define TEXTURE_GLSL_
+
+#include <impeller/branching.glsl>
+
 vec4 ImpellerTexture(sampler2D texture_sampler,
                      vec2 coords,
                      float y_coord_scale) {
@@ -10,3 +15,12 @@ vec4 ImpellerTexture(sampler2D texture_sampler,
   }
   return texture(texture_sampler, coords);
 }
+
+// Emulate SamplerAddressMode::ClampToBorder.
+vec4 SampleWithBorder(sampler2D tex, vec2 uv) {
+  float within_bounds = GreaterThan(uv.x, 0) * GreaterThan(uv.y, 0) *
+                        LessThan(uv.x, 1) * LessThan(uv.y, 1);
+  return texture(tex, uv) * within_bounds;
+}
+
+#endif

--- a/impeller/compiler/shader_lib/impeller/texture.glsl
+++ b/impeller/compiler/shader_lib/impeller/texture.glsl
@@ -7,19 +7,26 @@
 
 #include <impeller/branching.glsl>
 
-vec4 ImpellerTexture(sampler2D texture_sampler,
-                     vec2 coords,
-                     float y_coord_scale) {
+/// Sample from a texture.
+///
+/// If `y_coord_scale` < 0.0, the Y coordinate is flipped. This is useful
+/// for Impeller graphics backends that use a flipped framebuffer coordinate
+/// space.
+vec4 IPSample(sampler2D texture_sampler, vec2 coords, float y_coord_scale) {
   if (y_coord_scale < 0.0) {
     coords.y = 1.0 - coords.y;
   }
   return texture(texture_sampler, coords);
 }
 
-// Emulate SamplerAddressMode::ClampToBorder.
-vec4 SampleWithBorder(sampler2D tex, vec2 uv) {
-  float within_bounds = GreaterThan(uv.x, 0) * GreaterThan(uv.y, 0) *
-                        LessThan(uv.x, 1) * LessThan(uv.y, 1);
+/// Sample a texture, emulating SamplerAddressMode::ClampToBorder.
+///
+/// This is useful for Impeller graphics backend that don't support
+/// ClampToBorder.
+vec4 IPSampleClampToBorder(sampler2D tex, vec2 uv) {
+  float within_bounds = IPFloatIsGreaterThan(uv.x, 0) *
+                        IPFloatIsGreaterThan(uv.y, 0) *
+                        IPFloatIsLessThan(uv.x, 1) * IPFloatIsLessThan(uv.y, 1);
   return texture(tex, uv) * within_bounds;
 }
 

--- a/impeller/compiler/shader_lib/impeller/texture.glsl
+++ b/impeller/compiler/shader_lib/impeller/texture.glsl
@@ -24,9 +24,7 @@ vec4 IPSample(sampler2D texture_sampler, vec2 coords, float y_coord_scale) {
 /// This is useful for Impeller graphics backend that don't support
 /// ClampToBorder.
 vec4 IPSampleClampToBorder(sampler2D tex, vec2 uv) {
-  float within_bounds = IPFloatIsGreaterThan(uv.x, 0) *
-                        IPFloatIsGreaterThan(uv.y, 0) *
-                        IPFloatIsLessThan(uv.x, 1) * IPFloatIsLessThan(uv.y, 1);
+  float within_bounds = float(uv.x > 0 && uv.y > 0 && uv.x < 1 && uv.y < 1);
   return texture(tex, uv) * within_bounds;
 }
 

--- a/impeller/compiler/shader_lib/impeller/types.glsl
+++ b/impeller/compiler/shader_lib/impeller/types.glsl
@@ -1,0 +1,13 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef TYPES_GLSL_
+#define TYPES_GLSL_
+
+#define BoolF float
+#define BoolV2 vec2
+#define BoolV3 vec3
+#define BoolV4 vec4
+
+#endif

--- a/impeller/entity/shaders/blending/advanced_blend.glsl
+++ b/impeller/entity/shaders/blending/advanced_blend.glsl
@@ -2,6 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <impeller/branching.glsl>
+#include <impeller/color.glsl>
+#include <impeller/texture.glsl>
+
 uniform BlendInfo {
   float color_factor;
   vec4 color;  // This color input is expected to be unpremultiplied.
@@ -16,28 +20,12 @@ in vec2 v_src_texture_coords;
 
 out vec4 frag_color;
 
-// Emulate SamplerAddressMode::ClampToBorder.
-vec4 SampleWithBorder(sampler2D tex, vec2 uv) {
-  if (uv.x > 0 && uv.y > 0 && uv.x < 1 && uv.y < 1) {
-    return texture(tex, uv);
-  }
-  return vec4(0);
-}
-
-vec4 Unpremultiply(vec4 color) {
-  if (color.a == 0) {
-    return vec4(0);
-  }
-  return vec4(color.rgb / color.a, color.a);
-}
-
 void main() {
   vec4 dst = Unpremultiply(
       SampleWithBorder(texture_sampler_dst, v_dst_texture_coords));
-  vec4 src = blend_info.color_factor > 0
-                 ? blend_info.color
-                 : Unpremultiply(SampleWithBorder(texture_sampler_src,
-                                                  v_src_texture_coords));
+  vec4 src = mix(Unpremultiply(SampleWithBorder(texture_sampler_src,
+                                                v_src_texture_coords)),
+                 blend_info.color, GreaterThan(blend_info.color_factor, 0));
 
   vec3 blended = Blend(dst.rgb, src.rgb);
 

--- a/impeller/entity/shaders/blending/advanced_blend.glsl
+++ b/impeller/entity/shaders/blending/advanced_blend.glsl
@@ -21,11 +21,12 @@ in vec2 v_src_texture_coords;
 out vec4 frag_color;
 
 void main() {
-  vec4 dst = Unpremultiply(
-      SampleWithBorder(texture_sampler_dst, v_dst_texture_coords));
-  vec4 src = mix(Unpremultiply(SampleWithBorder(texture_sampler_src,
-                                                v_src_texture_coords)),
-                 blend_info.color, GreaterThan(blend_info.color_factor, 0));
+  vec4 dst = IPUnpremultiply(
+      IPSampleClampToBorder(texture_sampler_dst, v_dst_texture_coords));
+  vec4 src =
+      mix(IPUnpremultiply(
+              IPSampleClampToBorder(texture_sampler_src, v_src_texture_coords)),
+          blend_info.color, IPFloatIsGreaterThan(blend_info.color_factor, 0));
 
   vec3 blended = Blend(dst.rgb, src.rgb);
 

--- a/impeller/entity/shaders/blending/advanced_blend.glsl
+++ b/impeller/entity/shaders/blending/advanced_blend.glsl
@@ -23,10 +23,10 @@ out vec4 frag_color;
 void main() {
   vec4 dst = IPUnpremultiply(
       IPSampleClampToBorder(texture_sampler_dst, v_dst_texture_coords));
-  vec4 src =
-      mix(IPUnpremultiply(
-              IPSampleClampToBorder(texture_sampler_src, v_src_texture_coords)),
-          blend_info.color, IPFloatIsGreaterThan(blend_info.color_factor, 0));
+  vec4 src = blend_info.color_factor > 0
+                 ? blend_info.color
+                 : IPUnpremultiply(IPSampleClampToBorder(texture_sampler_src,
+                                                         v_src_texture_coords));
 
   vec3 blended = Blend(dst.rgb, src.rgb);
 

--- a/impeller/entity/shaders/blending/advanced_blend_colorburn.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_colorburn.frag
@@ -7,8 +7,8 @@
 vec3 Blend(vec3 dst, vec3 src) {
   // https://www.w3.org/TR/compositing-1/#blendingcolorburn
   vec3 color = 1 - min(vec3(1), (1 - dst) / src);
-  color = mix(color, vec3(1), ComponentIsValue(dst, 1.0));
-  color = mix(color, vec3(0), ComponentIsValue(src, 0.0));
+  color = mix(color, vec3(1), EqualTo3(dst, 1.0));
+  color = mix(color, vec3(0), EqualTo3(src, 0.0));
   return color;
 }
 

--- a/impeller/entity/shaders/blending/advanced_blend_colorburn.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_colorburn.frag
@@ -7,8 +7,24 @@
 vec3 Blend(vec3 dst, vec3 src) {
   // https://www.w3.org/TR/compositing-1/#blendingcolorburn
   vec3 color = 1 - min(vec3(1), (1 - dst) / src);
-  color = IPVec3Choose(color, vec3(1), IPVec3IsEqual(dst, vec3(1)));
-  color = IPVec3Choose(color, vec3(0), IPVec3IsEqual(src, vec3(0)));
+  if (1 - dst.r < kEhCloseEnough) {
+    color.r = 1;
+  }
+  if (1 - dst.g < kEhCloseEnough) {
+    color.g = 1;
+  }
+  if (1 - dst.b < kEhCloseEnough) {
+    color.b = 1;
+  }
+  if (src.r < kEhCloseEnough) {
+    color.r = 0;
+  }
+  if (src.g < kEhCloseEnough) {
+    color.g = 0;
+  }
+  if (src.b < kEhCloseEnough) {
+    color.b = 0;
+  }
   return color;
 }
 

--- a/impeller/entity/shaders/blending/advanced_blend_colorburn.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_colorburn.frag
@@ -7,8 +7,8 @@
 vec3 Blend(vec3 dst, vec3 src) {
   // https://www.w3.org/TR/compositing-1/#blendingcolorburn
   vec3 color = 1 - min(vec3(1), (1 - dst) / src);
-  color = mix(color, vec3(1), EqualTo3(dst, 1.0));
-  color = mix(color, vec3(0), EqualTo3(src, 0.0));
+  color = IPVec3Choose(color, vec3(1), IPVec3IsEqual(dst, vec3(1)));
+  color = IPVec3Choose(color, vec3(0), IPVec3IsEqual(src, vec3(0)));
   return color;
 }
 

--- a/impeller/entity/shaders/blending/advanced_blend_colordodge.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_colordodge.frag
@@ -7,8 +7,8 @@
 vec3 Blend(vec3 dst, vec3 src) {
   // https://www.w3.org/TR/compositing-1/#blendingcolordodge
   vec3 color = min(vec3(1), dst / (1 - src));
-  color = mix(color, vec3(0), ComponentIsValue(dst, 0.0));
-  color = mix(color, vec3(1), ComponentIsValue(src, 1.0));
+  color = mix(color, vec3(0), EqualTo3(dst, 0.0));
+  color = mix(color, vec3(1), EqualTo3(src, 1.0));
   return color;
 }
 

--- a/impeller/entity/shaders/blending/advanced_blend_colordodge.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_colordodge.frag
@@ -7,8 +7,8 @@
 vec3 Blend(vec3 dst, vec3 src) {
   // https://www.w3.org/TR/compositing-1/#blendingcolordodge
   vec3 color = min(vec3(1), dst / (1 - src));
-  color = mix(color, vec3(0), EqualTo3(dst, 0.0));
-  color = mix(color, vec3(1), EqualTo3(src, 1.0));
+  color = IPVec3Choose(color, vec3(0), IPVec3IsEqual(dst, vec3(0)));
+  color = IPVec3Choose(color, vec3(1), IPVec3IsEqual(src, vec3(1)));
   return color;
 }
 

--- a/impeller/entity/shaders/blending/advanced_blend_colordodge.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_colordodge.frag
@@ -7,8 +7,24 @@
 vec3 Blend(vec3 dst, vec3 src) {
   // https://www.w3.org/TR/compositing-1/#blendingcolordodge
   vec3 color = min(vec3(1), dst / (1 - src));
-  color = IPVec3Choose(color, vec3(0), IPVec3IsEqual(dst, vec3(0)));
-  color = IPVec3Choose(color, vec3(1), IPVec3IsEqual(src, vec3(1)));
+  if (dst.r < kEhCloseEnough) {
+    color.r = 0;
+  }
+  if (dst.g < kEhCloseEnough) {
+    color.g = 0;
+  }
+  if (dst.b < kEhCloseEnough) {
+    color.b = 0;
+  }
+  if (1 - src.r < kEhCloseEnough) {
+    color.r = 1;
+  }
+  if (1 - src.g < kEhCloseEnough) {
+    color.g = 1;
+  }
+  if (1 - src.b < kEhCloseEnough) {
+    color.b = 1;
+  }
   return color;
 }
 

--- a/impeller/entity/shaders/blending/advanced_blend_softlight.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_softlight.frag
@@ -7,10 +7,10 @@
 vec3 Blend(vec3 dst, vec3 src) {
   // https://www.w3.org/TR/compositing-1/#blendingsoftlight
 
-  vec3 D = MixComponents(((16 * dst - 12) * dst + 4) * dst,  //
-                         sqrt(dst),                          //
-                         dst,                                //
-                         0.25);
+  vec3 D = MixCutoff(((16 * dst - 12) * dst + 4) * dst,  //
+                     sqrt(dst),                          //
+                     dst,                                //
+                     0.25);
 
   return MixHalf(dst - (1 - 2 * src) * dst * (1 - dst),  //
                  dst + (2 * src - 1) * (D - dst),        //

--- a/impeller/entity/shaders/blending/advanced_blend_softlight.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_softlight.frag
@@ -7,14 +7,14 @@
 vec3 Blend(vec3 dst, vec3 src) {
   // https://www.w3.org/TR/compositing-1/#blendingsoftlight
 
-  vec3 D = MixCutoff(((16 * dst - 12) * dst + 4) * dst,  //
-                     sqrt(dst),                          //
-                     dst,                                //
-                     0.25);
+  vec3 D = IPVec3ChooseCutoff(((16 * dst - 12) * dst + 4) * dst,  //
+                              sqrt(dst),                          //
+                              dst,                                //
+                              0.25);
 
-  return MixHalf(dst - (1 - 2 * src) * dst * (1 - dst),  //
-                 dst + (2 * src - 1) * (D - dst),        //
-                 src);
+  return IPVec3Choose(dst - (1 - 2 * src) * dst * (1 - dst),  //
+                      dst + (2 * src - 1) * (D - dst),        //
+                      src);
 }
 
 #include "advanced_blend.glsl"

--- a/impeller/entity/shaders/blending/advanced_blend_utils.glsl
+++ b/impeller/entity/shaders/blending/advanced_blend_utils.glsl
@@ -2,24 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-const float kEhCloseEnough = 0.000001;
-
-vec3 ComponentIsValue(vec3 n, float value) {
-  vec3 diff = abs(n - value);
-  return vec3(diff.r < kEhCloseEnough,  //
-              diff.g < kEhCloseEnough,  //
-              diff.b < kEhCloseEnough);
-}
-
-vec3 MixComponents(vec3 a, vec3 b, vec3 weight, float cutoff) {
-  return vec3(mix(a.x, b.x, weight.x > cutoff),  //
-              mix(a.y, b.y, weight.y > cutoff),  //
-              mix(a.z, b.z, weight.z > cutoff));
-}
-
-vec3 MixHalf(vec3 a, vec3 b, vec3 weight) {
-  return MixComponents(a, b, weight, 0.5);
-}
+#include <impeller/constants.glsl>
+#include <impeller/branching.glsl>
 
 vec3 BlendScreen(vec3 dst, vec3 src) {
   return dst + src - (dst * src);

--- a/impeller/entity/shaders/blending/advanced_blend_utils.glsl
+++ b/impeller/entity/shaders/blending/advanced_blend_utils.glsl
@@ -10,7 +10,7 @@ vec3 BlendScreen(vec3 dst, vec3 src) {
 }
 
 vec3 BlendHardLight(vec3 dst, vec3 src) {
-  return MixHalf(dst * (2 * src), BlendScreen(dst, 2 * src - 1), src);
+  return IPVec3Choose(dst * (2 * src), BlendScreen(dst, 2 * src - 1), src);
 }
 
 //------------------------------------------------------------------------------

--- a/impeller/entity/shaders/gaussian_blur.frag
+++ b/impeller/entity/shaders/gaussian_blur.frag
@@ -9,6 +9,8 @@
 //     support for SamplerAddressMode::ClampToBorder in the texture sampler.
 //   * Sample from higher mipmap levels when the blur radius is high enough.
 
+#include <impeller/texture.glsl>
+
 uniform sampler2D texture_sampler;
 uniform sampler2D alpha_mask_sampler;
 
@@ -29,12 +31,6 @@ const float kSqrtTwoPi = 2.50662827463;
 float Gaussian(float x) {
   float variance = v_blur_sigma * v_blur_sigma;
   return exp(-0.5 * x * x / variance) / (kSqrtTwoPi * v_blur_sigma);
-}
-
-// Emulate SamplerAddressMode::ClampToBorder.
-vec4 SampleWithBorder(sampler2D tex, vec2 uv) {
-  float within_bounds = float(uv.x >= 0 && uv.y >= 0 && uv.x < 1 && uv.y < 1);
-  return texture(tex, uv) * within_bounds;
 }
 
 void main() {

--- a/impeller/entity/shaders/gaussian_blur.frag
+++ b/impeller/entity/shaders/gaussian_blur.frag
@@ -42,13 +42,14 @@ void main() {
     float gaussian = Gaussian(i);
     gaussian_integral += gaussian;
     total_color +=
-        gaussian * SampleWithBorder(texture_sampler,
-                                    v_texture_coords + blur_uv_offset * i);
+        gaussian * IPSampleClampToBorder(texture_sampler,
+                                         v_texture_coords + blur_uv_offset * i);
   }
 
   vec4 blur_color = total_color / gaussian_integral;
 
-  vec4 src_color = SampleWithBorder(alpha_mask_sampler, v_src_texture_coords);
+  vec4 src_color =
+      IPSampleClampToBorder(alpha_mask_sampler, v_src_texture_coords);
   float blur_factor = v_inner_blur_factor * float(src_color.a > 0) +
                       v_outer_blur_factor * float(src_color.a == 0);
 

--- a/impeller/entity/shaders/texture_fill.frag
+++ b/impeller/entity/shaders/texture_fill.frag
@@ -2,12 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "utils.sl.h"
+#include <impeller/texture.glsl>
 
 uniform sampler2D texture_sampler;
 uniform FragInfo {
   float texture_sampler_y_coord_scale;
-} frag_info;
+}
+frag_info;
 
 in vec2 v_texture_coords;
 in float v_alpha;
@@ -15,6 +16,7 @@ in float v_alpha;
 out vec4 frag_color;
 
 void main() {
-  vec4 sampled = ImpellerTexture(texture_sampler, v_texture_coords, frag_info.texture_sampler_y_coord_scale);
+  vec4 sampled = ImpellerTexture(texture_sampler, v_texture_coords,
+                                 frag_info.texture_sampler_y_coord_scale);
   frag_color = sampled * v_alpha;
 }

--- a/impeller/entity/shaders/texture_fill.frag
+++ b/impeller/entity/shaders/texture_fill.frag
@@ -16,7 +16,7 @@ in float v_alpha;
 out vec4 frag_color;
 
 void main() {
-  vec4 sampled = ImpellerTexture(texture_sampler, v_texture_coords,
-                                 frag_info.texture_sampler_y_coord_scale);
+  vec4 sampled = IPSample(texture_sampler, v_texture_coords,
+                          frag_info.texture_sampler_y_coord_scale);
   frag_color = sampled * v_alpha;
 }

--- a/impeller/tools/impeller.gni
+++ b/impeller/tools/impeller.gni
@@ -265,9 +265,11 @@ template("impellerc") {
     depfile_intermediate_path = rebase_path(depfile_path, root_build_dir)
     depfile = depfile_path
 
+    shader_lib_dir = rebase_path("//flutter/impeller/compiler/shader_lib")
     args = [
       "--input={{source}}",
       "--include={{source_dir}}",
+      "--include=$shader_lib_dir",
       "--depfile=$depfile_intermediate_path",
       "$shader_target_flag",
     ]


### PR DESCRIPTION
Introduce a library path for shaders and place some common utilities with header guards within. Remove a bunch of branches from advanced blends.