### PR TITLE
[Linux] do not destroy unowned GdkKeymap instance

### DIFF
--- a/shell/platform/linux/fl_view.cc
+++ b/shell/platform/linux/fl_view.cc
@@ -811,8 +811,6 @@ static void fl_view_remove(GtkContainer* container, GtkWidget* widget) {
   if (widget == GTK_WIDGET(self->event_box)) {
     g_clear_object(&self->event_box);
   }
-
-  g_clear_object(&self->keymap);
 }
 
 // Implements GtkContainer::forall


### PR DESCRIPTION
[`gdk_keymap_get_for_display()`](https://docs.gtk.org/gdk3/type_func.Keymap.get_for_display.html) does not transfer ownership to the caller. Destroying the keymap object would cause problems down the road when `GtkWindow` gets to clean up and tries to disconnect from the same keymap that `FlView` already destroyed.

Since #32665, when closing any Flutter application that uses [`HdyWindow`](https://gitlab.gnome.org/GNOME/libhandy) instead of a plain `GtkWindow` that has a slightly different object tree structure:

```
GLib-GObject-WARNING **: 12:42:44.304: instance of invalid non-instantiatable type '(null)'
GLib-GObject-CRITICAL **: 12:42:44.304: g_signal_handlers_disconnect_matched: assertion 'G_TYPE_CHECK_INSTANCE (instance)' failed
```

Where the callstack looks like this:
```
#0  0x00007ffff4cd0447 in g_logv () at /lib/x86_64-linux-gnu/libglib-2.0.so.0
#1  0x00007ffff4cd0703 in g_log () at /lib/x86_64-linux-gnu/libglib-2.0.so.0
#2  0x00007ffff4de5e92 in g_type_check_instance () at /lib/x86_64-linux-gnu/libgobject-2.0.so.0
#3  0x00007ffff4dd76a8 in g_signal_handlers_disconnect_matched () at /lib/x86_64-linux-gnu/libgobject-2.0.so.0
#4  0x00007ffff55c42d8 in _gtk_key_hash_free (key_hash=0x555555aded80) at ../gtk/gtkkeyhash.c:172
#5  0x00007ffff5765693 in gtk_window_free_key_hash (window=0x55555576a3f0) at ../gtk/gtkwindow.c:11976
#6  0x00007ffff5775db6 in gtk_window_destroy (widget=0x55555576a3f0) at ../gtk/gtkwindow.c:5958
#7  0x00007ffff4dc0d2f in g_closure_invoke () at /lib/x86_64-linux-gnu/libgobject-2.0.so.0
#8  0x00007ffff4ddcae0 in  () at /lib/x86_64-linux-gnu/libgobject-2.0.so.0
#9  0x00007ffff4dde554 in g_signal_emit_valist () at /lib/x86_64-linux-gnu/libgobject-2.0.so.0
#10 0x00007ffff4dde7a3 in g_signal_emit () at /lib/x86_64-linux-gnu/libgobject-2.0.so.0
#11 0x00007ffff575801c in gtk_widget_dispose (object=0x55555576a3f0) at ../gtk/gtkwidget.c:12166
#12 0x00007ffff576d770 in gtk_window_dispose (object=0x55555576a3f0) at ../gtk/gtkwindow.c:3167
#13 0x00007ffff5493aa6 in gtk_application_window_dispose (object=0x55555576a3f0) at ../gtk/gtkapplicationwindow.c:804
#14 0x00007ffff4dcee71 in g_object_run_dispose () at /lib/x86_64-linux-gnu/libgobject-2.0.so.0
#15 0x00007ffff55e4725 in gtk_main_do_event (event=0x5555555a1a80) at ../gtk/gtkmain.c:1824
#16 gtk_main_do_event (event=<optimized out>) at ../gtk/gtkmain.c:1691
#17 0x00007ffff52fc459 in _gdk_event_emit (event=event@entry=0x5555555a1a80) at ../gdk/gdkevents.c:73
#18 0x00007ffff532b376 in gdk_event_source_dispatch (base=<optimized out>, callback=<optimized out>, data=<optimized out>) at ../gdk/wayland/gdkeventsource.c:124
#19 0x00007ffff4cc7d3b in g_main_context_dispatch () at /lib/x86_64-linux-gnu/libglib-2.0.so.0
#20 0x00007ffff4d1c6a8 in  () at /lib/x86_64-linux-gnu/libglib-2.0.so.0
#21 0x00007ffff4cc53e3 in g_main_context_iteration () at /lib/x86_64-linux-gnu/libglib-2.0.so.0
#22 0x00007ffff4eecca5 in g_application_run () at /lib/x86_64-linux-gnu/libgio-2.0.so.0
#23 0x00005555555563b1 in main(int, char**) (argc=1, argv=0x7fffffffd958) at /home/jpnurmi/Temp/flutter_window_key_hash/linux/main.cc:5
```

Taking a reference could be another option, but generally, native GTK widgets do not take a reference to the keymap probably because the keymap is managed per display and thus, supposed to outlive any widget and window instance. Therefore, the proposal is to simply remove the `g_clear_object()` call.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
