### PR TITLE
Manually roll the Mac/Linux clang SDKs

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -648,7 +648,7 @@ deps = {
      'packages': [
        {
         'package': 'fuchsia/sdk/core/mac-amd64',
-        'version': 'eXmUtsA82V2gHbD8YDU-Bb_GBvUvIyOsUQAxxkqSlDkC'
+        'version': 'Xzjb4GlztxhSOlH349Zm0VaYaSOaqIduyrLTyrsAm_wC'
        }
      ],
      'condition': 'host_os == "mac" and not download_fuchsia_sdk',
@@ -658,7 +658,7 @@ deps = {
      'packages': [
        {
         'package': 'fuchsia/sdk/core/linux-amd64',
-        'version': 'ZBjjClCHXkZcV-OiBwSQDecMwaehQ6neEGir2XavgzsC'
+        'version': 'WQUmE-JAKNB7HCTYHlelbgu2Fi53aPI0kZ_G8dAOhQcC'
        }
      ],
      'condition': 'host_os == "linux" and not download_fuchsia_sdk',

--- a/ci/licenses_golden/licenses_fuchsia
+++ b/ci/licenses_golden/licenses_fuchsia
@@ -1,4 +1,4 @@
-Signature: 841a94fc3514a3c64d495ed7d25388cd
+Signature: b66dc04f02b8ffbe7ecd2fba995bfaf3
 
 UNUSED LICENSES:
 


### PR DESCRIPTION
The Mac/Linux clang SDK rollers exceeded the max number of attempts for a single commit, and so they are permanently stalled.

The roll failures themselves were caused by https://github.com/flutter/flutter/issues/106712, but this should be resolved now as the breaking change has been reverted.