### PR TITLE
[impellerc] Accept a command line flag that specifies the source type

### DIFF
--- a/impeller/compiler/compiler_test.cc
+++ b/impeller/compiler/compiler_test.cc
@@ -58,14 +58,15 @@ static std::string SLFileName(const char* fixture_name,
   return stream.str();
 }
 
-bool CompilerTest::CanCompileAndReflect(const char* fixture_name) const {
+bool CompilerTest::CanCompileAndReflect(const char* fixture_name,
+                                        SourceType source_type) const {
   auto fixture = flutter::testing::OpenFixtureAsMapping(fixture_name);
   if (!fixture->GetMapping()) {
     VALIDATION_LOG << "Could not find shader in fixtures: " << fixture_name;
     return false;
   }
 
-  SourceOptions source_options(fixture_name);
+  SourceOptions source_options(fixture_name, source_type);
   source_options.target_platform = GetParam();
   source_options.working_directory = std::make_shared<fml::UniqueFD>(
       flutter::testing::OpenFixturesDirectory());

--- a/impeller/compiler/compiler_test.h
+++ b/impeller/compiler/compiler_test.h
@@ -21,7 +21,9 @@ class CompilerTest : public ::testing::TestWithParam<TargetPlatform> {
 
   ~CompilerTest();
 
-  bool CanCompileAndReflect(const char* fixture_name) const;
+  bool CanCompileAndReflect(
+      const char* fixture_name,
+      SourceType source_type = SourceType::kUnknown) const;
 
  private:
   fml::UniqueFD intermediates_directory_;

--- a/impeller/compiler/compiler_unittests.cc
+++ b/impeller/compiler/compiler_unittests.cc
@@ -27,14 +27,19 @@ TEST(CompilerTest, ShaderKindMatchingIsSuccessful) {
 
 TEST_P(CompilerTest, CanCompile) {
   ASSERT_TRUE(CanCompileAndReflect("sample.vert"));
+  ASSERT_TRUE(CanCompileAndReflect("sample.vert", SourceType::kVertexShader));
 }
 
 TEST_P(CompilerTest, CanCompileTessellationControlShader) {
   ASSERT_TRUE(CanCompileAndReflect("sample.tesc"));
+  ASSERT_TRUE(CanCompileAndReflect("sample.tesc",
+                                   SourceType::kTessellationControlShader));
 }
 
 TEST_P(CompilerTest, CanCompileTessellationEvaluationShader) {
   ASSERT_TRUE(CanCompileAndReflect("sample.tese"));
+  ASSERT_TRUE(CanCompileAndReflect("sample.tese",
+                                   SourceType::kTessellationEvaluationShader));
 }
 
 TEST_P(CompilerTest, CanCompileComputeShader) {
@@ -42,6 +47,7 @@ TEST_P(CompilerTest, CanCompileComputeShader) {
     GTEST_SKIP_("Only enabled on Metal backends till ES 3.2 support is added.");
   }
   ASSERT_TRUE(CanCompileAndReflect("sample.comp"));
+  ASSERT_TRUE(CanCompileAndReflect("sample.comp", SourceType::kComputeShader));
 }
 
 TEST_P(CompilerTest, MustFailDueToMultipleLocationPerStructMember) {

--- a/impeller/compiler/impellerc_main.cc
+++ b/impeller/compiler/impellerc_main.cc
@@ -13,6 +13,7 @@
 #include "impeller/compiler/compiler.h"
 #include "impeller/compiler/source_options.h"
 #include "impeller/compiler/switches.h"
+#include "impeller/compiler/types.h"
 #include "impeller/compiler/utilities.h"
 #include "third_party/shaderc/libshaderc/include/shaderc/shaderc.hpp"
 
@@ -42,14 +43,17 @@ bool Main(const fml::CommandLine& command_line) {
 
   SourceOptions options;
   options.target_platform = switches.target_platform;
-  options.type = SourceTypeFromFileName(switches.source_file_name);
+  if (switches.input_type == SourceType::kUnknown) {
+    options.type = SourceTypeFromFileName(switches.source_file_name);
+  } else {
+    options.type = switches.input_type;
+  }
   options.working_directory = switches.working_directory;
   options.file_name = switches.source_file_name;
   options.include_dirs = switches.include_directories;
   options.defines = switches.defines;
   options.entry_point_name = EntryPointFunctionNameFromSourceName(
-      switches.source_file_name,
-      SourceTypeFromFileName(switches.source_file_name));
+      switches.source_file_name, options.type);
 
   Reflector::Options reflector_options;
   reflector_options.target_platform = switches.target_platform;

--- a/impeller/compiler/source_options.cc
+++ b/impeller/compiler/source_options.cc
@@ -9,8 +9,12 @@ namespace compiler {
 
 SourceOptions::SourceOptions() = default;
 
-SourceOptions::SourceOptions(const std::string& file_name)
-    : type(SourceTypeFromFileName(file_name)), file_name(file_name) {}
+SourceOptions::SourceOptions(const std::string& file_name,
+                             SourceType source_type)
+    : type(source_type == SourceType::kUnknown
+               ? SourceTypeFromFileName(file_name)
+               : source_type),
+      file_name(file_name) {}
 
 SourceOptions::~SourceOptions() = default;
 

--- a/impeller/compiler/source_options.h
+++ b/impeller/compiler/source_options.h
@@ -29,7 +29,8 @@ struct SourceOptions {
 
   ~SourceOptions();
 
-  SourceOptions(const std::string& file_name);
+  explicit SourceOptions(const std::string& file_name,
+                         SourceType source_type = SourceType::kUnknown);
 };
 
 }  // namespace compiler

--- a/impeller/compiler/switches.h
+++ b/impeller/compiler/switches.h
@@ -22,6 +22,7 @@ struct Switches {
   std::shared_ptr<fml::UniqueFD> working_directory;
   std::vector<IncludeDir> include_directories;
   std::string source_file_name;
+  SourceType input_type;
   std::string sl_file_name;
   std::string spirv_file_name;
   std::string reflection_json_name;


### PR DESCRIPTION
This will remove the restriction that custom fragment shaders listed in a pubspec.yaml have to end with `.frag`.