### PR TITLE
Avoid vsync scheduling delay

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1483,6 +1483,7 @@ FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/platform/Platfor
 FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/platform/SingleViewPresentation.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java
+FILE: ../../../flutter/shell/platform/android/io/flutter/util/HandlerCompat.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/util/PathUtils.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/util/Preconditions.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/util/Predicate.java

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -288,6 +288,7 @@ android_java_sources = [
   "io/flutter/plugin/platform/PlatformViewsController.java",
   "io/flutter/plugin/platform/SingleViewPresentation.java",
   "io/flutter/plugin/platform/VirtualDisplayController.java",
+  "io/flutter/util/HandlerCompat.java",
   "io/flutter/util/PathUtils.java",
   "io/flutter/util/Preconditions.java",
   "io/flutter/util/Predicate.java",

--- a/shell/platform/android/io/flutter/embedding/engine/dart/PlatformTaskQueue.java
+++ b/shell/platform/android/io/flutter/embedding/engine/dart/PlatformTaskQueue.java
@@ -7,10 +7,13 @@ package io.flutter.embedding.engine.dart;
 import android.os.Handler;
 import android.os.Looper;
 import androidx.annotation.NonNull;
+import io.flutter.util.HandlerCompat;
 
 /** A BinaryMessenger.TaskQueue that posts to the platform thread (aka main thread). */
 public class PlatformTaskQueue implements DartMessenger.DartMessengerTaskQueue {
-  @NonNull private final Handler handler = new Handler(Looper.getMainLooper());
+  // Use an async handler because the default is subject to vsync synchronization and can result
+  // in delays when dispatching tasks.
+  @NonNull private final Handler handler = HandlerCompat.createAsyncHandler(Looper.getMainLooper());
 
   @Override
   public void dispatch(@NonNull Runnable runnable) {

--- a/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
@@ -23,6 +23,7 @@ import io.flutter.BuildConfig;
 import io.flutter.FlutterInjector;
 import io.flutter.Log;
 import io.flutter.embedding.engine.FlutterJNI;
+import io.flutter.util.HandlerCompat;
 import io.flutter.util.PathUtils;
 import io.flutter.util.TraceSection;
 import io.flutter.view.VsyncWaiter;
@@ -385,7 +386,7 @@ public class FlutterLoader {
             Log.e(TAG, "Flutter initialization failed.", e);
             throw new RuntimeException(e);
           }
-          new Handler(Looper.getMainLooper())
+          HandlerCompat.createAsyncHandler(Looper.getMainLooper())
               .post(
                   () -> {
                     ensureInitializationComplete(applicationContext.getApplicationContext(), args);

--- a/shell/platform/android/io/flutter/util/HandlerCompat.java
+++ b/shell/platform/android/io/flutter/util/HandlerCompat.java
@@ -1,0 +1,35 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.util;
+
+import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
+
+/** Compatability wrapper over {@link Handler}. */
+public final class HandlerCompat {
+  /**
+   * Create a new Handler whose posted messages and runnables are not subject to synchronization
+   * barriers such as display vsync.
+   *
+   * <p>Messages sent to an async handler are guaranteed to be ordered with respect to one another,
+   * but not necessarily with respect to messages from other Handlers. Compatibility behavior:
+   *
+   * <ul>
+   *   <li>SDK 28 and above, this method matches platform behavior.
+   *   <li>Otherwise, returns a synchronous handler instance.
+   * </ul>
+   *
+   * @param looper the Looper that the new Handler should be bound to
+   * @return a new async Handler instance
+   * @see Handler#createAsync(Looper)
+   */
+  public static Handler createAsyncHandler(Looper looper) {
+    if (Build.VERSION.SDK_INT >= 28) {
+      return Handler.createAsync(looper);
+    }
+    return new Handler(looper);
+  }
+}

--- a/shell/platform/android/test/io/flutter/util/HandlerCompatTest.java
+++ b/shell/platform/android/test/io/flutter/util/HandlerCompatTest.java
@@ -1,0 +1,29 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.util;
+
+import static org.junit.Assert.assertTrue;
+
+import android.os.Handler;
+import android.os.Looper;
+import android.os.Message;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+public class HandlerCompatTest {
+  @Test
+  @Config(sdk = 28)
+  public void createAsync_createsAnAsyncHandler() {
+    Handler handler = Handler.createAsync(Looper.getMainLooper());
+
+    Message message = Message.obtain();
+    handler.sendMessageAtTime(message, 0);
+
+    assertTrue(message.isAsynchronous());
+  }
+}

--- a/tools/android_lint/project.xml
+++ b/tools/android_lint/project.xml
@@ -23,6 +23,7 @@
     <src file="../../../flutter/shell/platform/android/io/flutter/util/Predicate.java" />
     <src file="../../../flutter/shell/platform/android/io/flutter/util/TraceSection.java" />
     <src file="../../../flutter/shell/platform/android/io/flutter/util/PathUtils.java" />
+    <src file="../../../flutter/shell/platform/android/io/flutter/util/HandlerCompat.java" />
     <src file="../../../flutter/shell/platform/android/io/flutter/embedding/android/KeyboardMap.java" />
     <src file="../../../flutter/shell/platform/android/io/flutter/embedding/android/KeyboardManager.java" />
     <src file="../../../flutter/shell/platform/android/io/flutter/embedding/android/AndroidTouchProcessor.java" />


### PR DESCRIPTION
The `Handler` created through `new Handler(Looper.getMainLooper())` is subject to synchronization barriers like vsync. This means that posting tasks to it can result in scheduling delays of up to 16ms. Empirically I have noticed this happening only before the first frame has been drawn, but not sure if it might happen on other occasions.

This is a common pattern for platform message handlers on the main thread, and the delay can stack up and affect startup latency when apps do something like:

```dart
void main() async {
  final a = await sendPlatformMessage();
  final b = await sendPlatformMessageWithA(a);
  final c = await sendPlatformMessageWithB(b);

  runApp(MyApp(c));
}
```

`Handler.createAsync` helps to avoid this, but this API is only available on SDK >=28. Ideally we would use [`androidx.core.os.HandlerCompat`](https://developer.android.com/reference/androidx/core/os/HandlerCompat#createAsync(android.os.Looper)) but we don't have a dependency on it so I opted for a small reimplementation. It differs slightly in that we [don't do](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:core/core/src/main/java/androidx/core/os/HandlerCompat.java;l=110-111;drc=7e9c4bfcbd0a3bebc25ec4747922bcf80cd278fe) the reflection fallback to keep things simple. 

Tested: Internal global presubmit. I did not add new tests since this is an implementation change and should be covered by existing tests.

This also improves the startup latency for `customer:money` by 3%. See b/237035671 for more details.

## Related Issues

b/237035671
Might be related to https://github.com/flutter/flutter/issues/81559#issuecomment-843613233

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
