### PR TITLE
[Impeller] Fix calling `release()` in OpenFixtureAsSkData relying on execution order of arguments.

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -395,12 +395,14 @@ static sk_sp<SkData> OpenFixtureAsSkData(const char* fixture_name) {
   if (!mapping) {
     return nullptr;
   }
-  return SkData::MakeWithProc(
+  auto data = SkData::MakeWithProc(
       mapping->GetMapping(), mapping->GetSize(),
       [](const void* ptr, void* context) {
         delete reinterpret_cast<fml::Mapping*>(context);
       },
-      mapping.release());
+      mapping.get());
+  mapping.release();
+  return data;
 }
 
 bool RenderTextInCanvas(std::shared_ptr<Context> context,

--- a/impeller/display_list/display_list_playground.cc
+++ b/impeller/display_list/display_list_playground.cc
@@ -52,12 +52,14 @@ static sk_sp<SkData> OpenFixtureAsSkData(const char* fixture_name) {
   if (!mapping) {
     return nullptr;
   }
-  return SkData::MakeWithProc(
+  auto data = SkData::MakeWithProc(
       mapping->GetMapping(), mapping->GetSize(),
       [](const void* ptr, void* context) {
         delete reinterpret_cast<fml::Mapping*>(context);
       },
-      mapping.release());
+      mapping.get());
+  mapping.release();
+  return data;
 }
 
 SkFont DisplayListPlayground::CreateTestFontOfSize(SkScalar scalar) {


### PR DESCRIPTION
I found this when I was trying to enable to run impeller_unittests on Windows and saw some tests fail with SEH exceptions.
The execution order of arguments is different in GCC and MSVC.

This PR will fix code relying on this behavior.

<details>
<summary>Example</summary>

```c++
#include <sstream>
#include <iostream>

int gen_a() {
    int a = 10;
    std::cout << "Generating a as: " << a << std::endl;
    return a;
}

int gen_b() {
    int b = 20;
    std::cout << "Generating b as: " << b << std::endl;
    return b;
}

void all(int a, int b) {
    std::cout << "Final: " << a << " and " << b << std::endl;
}

/*
This will print:

Generating b as: 20
Generating a as: 10
Final: 10 and 20
*/
void main() {
    all(gen_a(), gen_b());
}
```
</details>

No changes in the [flutter/tests] repo.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
