### PR TITLE
Move embedder_a11y_unittests to its own binary

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -166,6 +166,7 @@ group("unittests") {
       "//flutter/runtime:no_dart_plugin_registrant_unittests",
       "//flutter/runtime:runtime_unittests",
       "//flutter/shell/common:shell_unittests",
+      "//flutter/shell/platform/embedder:embedder_a11y_unittests",
       "//flutter/shell/platform/embedder:embedder_proctable_unittests",
       "//flutter/shell/platform/embedder:embedder_unittests",
       "//flutter/testing:testing_unittests",

--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -189,7 +189,7 @@ test_fixtures("fixtures") {
 }
 
 if (enable_unittests) {
-  executable("embedder_unittests") {
+  source_set("embedder_unittests_library") {
     testonly = true
 
     configs += [
@@ -200,7 +200,6 @@ if (enable_unittests) {
     include_dirs = [ "." ]
 
     sources = [
-      "tests/embedder_a11y_unittests.cc",
       "tests/embedder_config_builder.cc",
       "tests/embedder_config_builder.h",
       "tests/embedder_test.cc",
@@ -215,11 +214,10 @@ if (enable_unittests) {
       "tests/embedder_test_context.h",
       "tests/embedder_test_context_software.cc",
       "tests/embedder_test_context_software.h",
-      "tests/embedder_unittests.cc",
       "tests/embedder_unittests_util.cc",
     ]
 
-    deps = [
+    public_deps = [
       ":embedder",
       ":embedder_gpu_configuration",
       ":fixtures",
@@ -241,10 +239,9 @@ if (enable_unittests) {
         "tests/embedder_test_compositor_gl.h",
         "tests/embedder_test_context_gl.cc",
         "tests/embedder_test_context_gl.h",
-        "tests/embedder_unittests_gl.cc",
       ]
 
-      deps += [
+      public_deps += [
         "//flutter/testing:opengl",
         "//third_party/vulkan-deps/vulkan-headers/src:vulkan_headers",
       ]
@@ -256,10 +253,9 @@ if (enable_unittests) {
         "tests/embedder_test_compositor_metal.h",
         "tests/embedder_test_context_metal.cc",
         "tests/embedder_test_context_metal.h",
-        "tests/embedder_unittests_metal.mm",
       ]
 
-      deps += [ "//flutter/testing:metal" ]
+      public_deps += [ "//flutter/testing:metal" ]
     }
 
     if (test_enable_vulkan) {
@@ -270,11 +266,49 @@ if (enable_unittests) {
         "tests/embedder_test_context_vulkan.h",
       ]
 
-      deps += [
+      public_deps += [
         "//flutter/testing:vulkan",
         "//flutter/vulkan",
       ]
     }
+  }
+
+  executable("embedder_unittests") {
+    testonly = true
+
+    configs += [
+      ":embedder_gpu_configuration_config",
+      "//flutter:export_dynamic_symbols",
+    ]
+
+    include_dirs = [ "." ]
+
+    sources = [ "tests/embedder_unittests.cc" ]
+
+    deps = [ ":embedder_unittests_library" ]
+
+    if (test_enable_gl) {
+      sources += [ "tests/embedder_unittests_gl.cc" ]
+    }
+
+    if (test_enable_metal) {
+      sources += [ "tests/embedder_unittests_metal.mm" ]
+    }
+  }
+
+  executable("embedder_a11y_unittests") {
+    testonly = true
+
+    configs += [
+      ":embedder_gpu_configuration_config",
+      "//flutter:export_dynamic_symbols",
+    ]
+
+    include_dirs = [ "." ]
+
+    sources = [ "tests/embedder_a11y_unittests.cc" ]
+
+    deps = [ ":embedder_unittests_library" ]
   }
 
   # Tests that build in FLUTTER_ENGINE_NO_PROTOTYPES mode.

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -326,6 +326,7 @@ def RunCCTests(build_dir, filter, coverage, capture_core_dump):
       make_test('dart_plugin_registrant_unittests'),
       make_test('display_list_rendertests'),
       make_test('display_list_unittests'),
+      make_test('embedder_a11y_unittests'),
       make_test('embedder_proctable_unittests'),
       make_test('embedder_unittests'),
       make_test('fml_unittests', flags=[fml_unittests_filter] + repeat_flags),


### PR DESCRIPTION
Running the a11y unit test in parallel with the other embedder unit tests causes it to time out somewhat frequently in CI. Splitting it off into its own binary will ensure that it run without interference. However, since this will likely increase overall time to run tests, we should still consider other ways to test a11y.

Related: https://github.com/flutter/flutter/issues/106589