### PR TITLE
[web] Reland 'Migrate Flutter Web DOM usage to JS static interop - 44.'

### DIFF
--- a/lib/web_ui/lib/src/engine/dom.dart
+++ b/lib/web_ui/lib/src/engine/dom.dart
@@ -49,6 +49,13 @@ extension DomWindowExtension on DomWindow {
       ]) as DomCSSStyleDeclaration;
   external DomScreen? get screen;
   external int requestAnimationFrame(DomRequestAnimationFrameCallback callback);
+  void postMessage(Object message, String targetOrigin,
+          [List<DomMessagePort>? messagePorts]) =>
+      js_util.callMethod(this, 'postMessage', <Object>[
+        message,
+        targetOrigin,
+        if (messagePorts != null) js_util.jsify(messagePorts)
+      ]);
 }
 
 typedef DomRequestAnimationFrameCallback = void Function(num highResTime);
@@ -936,6 +943,8 @@ extension DomLocationExtension on DomLocation {
   external String? get search;
   // We have to change the name here because 'hash' is inherited from [Object].
   String get locationHash => js_util.getProperty(this, 'hash');
+  external String get origin;
+  external String get href;
 }
 
 @JS()
@@ -1132,8 +1141,8 @@ extension DomCompositionEventExtension on DomCompositionEvent {
   external String? get data;
 }
 
-DomCompositionEvent createDomCompositionEvent(String type, [Map<dynamic,
-    dynamic>? options]) =>
+DomCompositionEvent createDomCompositionEvent(String type,
+        [Map<dynamic, dynamic>? options]) =>
     js_util.callConstructor(domGetConstructor('CompositionEvent')!,
         <Object>[type, if (options != null) js_util.jsify(options)]);
 
@@ -1174,6 +1183,7 @@ class DomTokenList {}
 
 extension DomTokenListExtension on DomTokenList {
   external void add(String value);
+  external void remove(String value);
   external bool contains(String token);
 }
 
@@ -1316,6 +1326,64 @@ class DomPoint {
 
   DomPoint(this.x, this.y);
 }
+
+@JS()
+@staticInterop
+class DomWebSocket extends DomEventTarget {}
+
+extension DomWebSocketExtension on DomWebSocket {
+  external void send(Object? data);
+}
+
+DomWebSocket createDomWebSocket(String url) =>
+    domCallConstructorString('WebSocket', <Object>[url])! as DomWebSocket;
+
+@JS()
+@staticInterop
+class DomMessageEvent extends DomEvent {}
+
+extension DomMessageEventExtension on DomMessageEvent {
+  dynamic get data => js_util.dartify(js_util.getProperty(this, 'data'));
+  external String get origin;
+}
+
+@JS()
+@staticInterop
+class DomHTMLIFrameElement extends DomHTMLElement {}
+
+extension DomHTMLIFrameElementExtension on DomHTMLIFrameElement {
+  external set src(String? value);
+  external String? get src;
+  external set height(String? value);
+  external set width(String? value);
+  external DomWindow get contentWindow;
+}
+
+DomHTMLIFrameElement createDomHTMLIFrameElement() =>
+    domDocument.createElement('iframe') as DomHTMLIFrameElement;
+
+@JS()
+@staticInterop
+class DomMessagePort extends DomEventTarget {}
+
+extension DomMessagePortExtension on DomMessagePort {
+  void postMessage(Object? message) => js_util.callMethod(this, 'postMessage',
+      <Object>[if (message != null) js_util.jsify(message)]);
+  external void start();
+}
+
+@JS()
+@staticInterop
+class DomMessageChannel {}
+
+extension DomMessageChannelExtension on DomMessageChannel {
+  external DomMessagePort get port1;
+  external DomMessagePort get port2;
+}
+
+DomMessageChannel createDomMessageChannel() =>
+    domCallConstructorString('MessageChannel', <Object>[])!
+        as DomMessageChannel;
 
 Object? domGetConstructor(String constructorName) =>
     js_util.getProperty(domWindow, constructorName);

--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:html' as html;
 import 'dart:typed_data';
 
 import 'package:meta/meta.dart';
@@ -47,14 +46,16 @@ class HighContrastSupport {
   final List<HighContrastListener> _listeners = <HighContrastListener>[];
 
   /// Reference to css media query that indicates whether high contrast is on.
-  final html.MediaQueryList _highContrastMediaQuery = html.window.matchMedia(_highContrastMediaQueryString);
+  final DomMediaQueryList _highContrastMediaQuery = domWindow.matchMedia(_highContrastMediaQueryString);
+  late final DomEventListener _onHighContrastChangeListener =
+      allowInterop(_onHighContrastChange);
 
   bool get isHighContrastEnabled => _highContrastMediaQuery.matches;
 
   /// Adds function to the list of listeners on high contrast changes
   void addListener(HighContrastListener listener) {
     if (_listeners.isEmpty) {
-      _highContrastMediaQuery.addListener(_onHighContrastChange);
+      _highContrastMediaQuery.addListener(_onHighContrastChangeListener);
     }
     _listeners.add(listener);
   }
@@ -63,12 +64,12 @@ class HighContrastSupport {
   void removeListener(HighContrastListener listener) {
     _listeners.remove(listener);
     if (_listeners.isEmpty) {
-      _highContrastMediaQuery.removeListener(_onHighContrastChange);
+      _highContrastMediaQuery.removeListener(_onHighContrastChangeListener);
     }
   }
 
-  void _onHighContrastChange(html.Event event) {
-    final html.MediaQueryListEvent mqEvent = event as html.MediaQueryListEvent;
+  void _onHighContrastChange(DomEvent event) {
+    final DomMediaQueryListEvent mqEvent = event as DomMediaQueryListEvent;
     final bool isHighContrastEnabled = mqEvent.matches!;
     for (final HighContrastListener listener in _listeners) {
       listener(isHighContrastEnabled);
@@ -542,7 +543,6 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
         _platformViewMessageHandler ??= PlatformViewMessageHandler(
           contentManager: platformViewManager,
           contentHandler: (DomElement content) {
-            // Remove cast to [html.Element] after migration.
             flutterViewEmbedder.glassPaneElement!.append(content);
           },
         );

--- a/web_sdk/sdk_rewriter.dart
+++ b/web_sdk/sdk_rewriter.dart
@@ -42,7 +42,6 @@ import 'dart:async';
 import 'dart:collection';
 import 'dart:convert' hide Codec;
 import 'dart:developer' as developer;
-import 'dart:html' as html;
 import 'dart:js' as js;
 import 'dart:js_util' as js_util;
 import 'dart:_js_annotations';

--- a/web_sdk/test/js_access_test.dart
+++ b/web_sdk/test/js_access_test.dart
@@ -64,8 +64,6 @@ export 'foo.dart';
       final _CheckResult result = _checkFile(
           File('lib/web_ui/lib/src/engine/alarm_clock.dart'),
 '''
-import 'dart:html'
-  show HtmlElement;
 import 'dart:async';
 import 'package:ui/ui.dart'
   as ui;
@@ -73,8 +71,7 @@ import 'package:ui/ui.dart'
       );
       expect(result.failed, isTrue);
       expect(result.violations, <String>[
-        "on line 1: import is broken up into multiple lines: import 'dart:html'",
-        "on line 4: import is broken up into multiple lines: import 'package:ui/ui.dart'",
+        "on line 2: import is broken up into multiple lines: import 'package:ui/ui.dart'",
       ]);
     }
 

--- a/web_sdk/test/sdk_rewriter_test.dart
+++ b/web_sdk/test/sdk_rewriter_test.dart
@@ -30,7 +30,6 @@ import 'dart:async';
 import 'dart:collection';
 import 'dart:convert' hide Codec;
 import 'dart:developer' as developer;
-import 'dart:html' as html;
 import 'dart:js' as js;
 import 'dart:js_util' as js_util;
 import 'dart:_js_annotations';

--- a/web_sdk/web_engine_tester/lib/golden_tester.dart
+++ b/web_sdk/web_engine_tester/lib/golden_tester.dart
@@ -4,14 +4,16 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:html' as html;
 
 import 'package:test/test.dart';
+// ignore: implementation_imports
 import 'package:ui/src/engine.dart' show operatingSystem, OperatingSystem, useCanvasKit;
+// ignore: implementation_imports
+import 'package:ui/src/engine/dom.dart';
 import 'package:ui/ui.dart';
 
 Future<dynamic> _callScreenshotServer(dynamic requestData) async {
-  final html.HttpRequest request = await html.HttpRequest.request(
+  final DomXMLHttpRequest request = await domHttpRequest(
     'screenshot',
     method: 'POST',
     sendData: json.encode(requestData),


### PR DESCRIPTION
Relands https://github.com/flutter/engine/pull/33380 without the changes to `sky_engine` that broke the framework.