### PR TITLE
All layers with raster cache should use integer CTM (#33981)

### DIFF
--- a/flow/layers/checkerboard_layertree_unittests.cc
+++ b/flow/layers/checkerboard_layertree_unittests.cc
@@ -59,9 +59,6 @@ TEST_F(CheckerBoardLayerTest, ClipRectSaveLayerNotCheckBoard) {
            MockCanvas::DrawCall{
                1, MockCanvas::ClipRectData{layer_bounds, SkClipOp::kIntersect,
                                            MockCanvas::kSoft_ClipEdgeStyle}},
-#ifndef SUPPORT_FRACTIONAL_TRANSLATION
-           MockCanvas::DrawCall{1, MockCanvas::SetMatrixData{SkM44()}},
-#endif
            MockCanvas::DrawCall{
                1,
                MockCanvas::SaveLayerData{layer_bounds, clip_paint, nullptr, 2}},
@@ -153,9 +150,6 @@ TEST_F(CheckerBoardLayerTest, ClipPathSaveLayerNotCheckBoard) {
            MockCanvas::DrawCall{
                1, MockCanvas::ClipRectData{layer_bounds, SkClipOp::kIntersect,
                                            MockCanvas::kSoft_ClipEdgeStyle}},
-#ifndef SUPPORT_FRACTIONAL_TRANSLATION
-           MockCanvas::DrawCall{1, MockCanvas::SetMatrixData{SkM44()}},
-#endif
            MockCanvas::DrawCall{
                1,
                MockCanvas::SaveLayerData{child_bounds, clip_paint, nullptr, 2}},
@@ -238,9 +232,6 @@ TEST_F(CheckerBoardLayerTest, ClipRRectSaveLayerNotCheckBoard) {
            MockCanvas::DrawCall{
                1, MockCanvas::ClipRectData{layer_bounds, SkClipOp::kIntersect,
                                            MockCanvas::kSoft_ClipEdgeStyle}},
-#ifndef SUPPORT_FRACTIONAL_TRANSLATION
-           MockCanvas::DrawCall{1, MockCanvas::SetMatrixData{SkM44()}},
-#endif
            MockCanvas::DrawCall{
                1,
                MockCanvas::SaveLayerData{child_bounds, clip_paint, nullptr, 2}},

--- a/flow/layers/checkerboard_layertree_unittests.cc
+++ b/flow/layers/checkerboard_layertree_unittests.cc
@@ -59,6 +59,9 @@ TEST_F(CheckerBoardLayerTest, ClipRectSaveLayerNotCheckBoard) {
            MockCanvas::DrawCall{
                1, MockCanvas::ClipRectData{layer_bounds, SkClipOp::kIntersect,
                                            MockCanvas::kSoft_ClipEdgeStyle}},
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+           MockCanvas::DrawCall{1, MockCanvas::SetMatrixData{SkM44()}},
+#endif
            MockCanvas::DrawCall{
                1,
                MockCanvas::SaveLayerData{layer_bounds, clip_paint, nullptr, 2}},
@@ -150,6 +153,9 @@ TEST_F(CheckerBoardLayerTest, ClipPathSaveLayerNotCheckBoard) {
            MockCanvas::DrawCall{
                1, MockCanvas::ClipRectData{layer_bounds, SkClipOp::kIntersect,
                                            MockCanvas::kSoft_ClipEdgeStyle}},
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+           MockCanvas::DrawCall{1, MockCanvas::SetMatrixData{SkM44()}},
+#endif
            MockCanvas::DrawCall{
                1,
                MockCanvas::SaveLayerData{child_bounds, clip_paint, nullptr, 2}},
@@ -232,6 +238,9 @@ TEST_F(CheckerBoardLayerTest, ClipRRectSaveLayerNotCheckBoard) {
            MockCanvas::DrawCall{
                1, MockCanvas::ClipRectData{layer_bounds, SkClipOp::kIntersect,
                                            MockCanvas::kSoft_ClipEdgeStyle}},
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+           MockCanvas::DrawCall{1, MockCanvas::SetMatrixData{SkM44()}},
+#endif
            MockCanvas::DrawCall{
                1,
                MockCanvas::SaveLayerData{child_bounds, clip_paint, nullptr, 2}},

--- a/flow/layers/color_filter_layer_unittests.cc
+++ b/flow/layers/color_filter_layer_unittests.cc
@@ -58,14 +58,17 @@ TEST_F(ColorFilterLayerTest, EmptyFilter) {
   SkPaint filter_paint;
   filter_paint.setColorFilter(nullptr);
   layer->Paint(paint_context());
-  EXPECT_EQ(
-      mock_canvas().draw_calls(),
-      std::vector({MockCanvas::DrawCall{
-                       0, MockCanvas::SaveLayerData{child_bounds, filter_paint,
-                                                    nullptr, 1}},
-                   MockCanvas::DrawCall{
-                       1, MockCanvas::DrawPathData{child_path, child_paint}},
-                   MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
+  EXPECT_EQ(mock_canvas().draw_calls(),
+            std::vector({
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+                MockCanvas::DrawCall{0, MockCanvas::SetMatrixData{SkM44()}},
+#endif
+                MockCanvas::DrawCall{
+                    0, MockCanvas::SaveLayerData{child_bounds, filter_paint,
+                                                 nullptr, 1}},
+                MockCanvas::DrawCall{
+                    1, MockCanvas::DrawPathData{child_path, child_paint}},
+                MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
 }
 
 TEST_F(ColorFilterLayerTest, SimpleFilter) {
@@ -87,14 +90,17 @@ TEST_F(ColorFilterLayerTest, SimpleFilter) {
   SkPaint filter_paint;
   filter_paint.setColorFilter(layer_filter);
   layer->Paint(paint_context());
-  EXPECT_EQ(
-      mock_canvas().draw_calls(),
-      std::vector({MockCanvas::DrawCall{
-                       0, MockCanvas::SaveLayerData{child_bounds, filter_paint,
-                                                    nullptr, 1}},
-                   MockCanvas::DrawCall{
-                       1, MockCanvas::DrawPathData{child_path, child_paint}},
-                   MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
+  EXPECT_EQ(mock_canvas().draw_calls(),
+            std::vector({
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+                MockCanvas::DrawCall{0, MockCanvas::SetMatrixData{SkM44()}},
+#endif
+                MockCanvas::DrawCall{
+                    0, MockCanvas::SaveLayerData{child_bounds, filter_paint,
+                                                 nullptr, 1}},
+                MockCanvas::DrawCall{
+                    1, MockCanvas::DrawPathData{child_path, child_paint}},
+                MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
 }
 
 TEST_F(ColorFilterLayerTest, MultipleChildren) {
@@ -128,16 +134,19 @@ TEST_F(ColorFilterLayerTest, MultipleChildren) {
   SkPaint filter_paint;
   filter_paint.setColorFilter(layer_filter);
   layer->Paint(paint_context());
-  EXPECT_EQ(
-      mock_canvas().draw_calls(),
-      std::vector({MockCanvas::DrawCall{
-                       0, MockCanvas::SaveLayerData{children_bounds,
-                                                    filter_paint, nullptr, 1}},
-                   MockCanvas::DrawCall{
-                       1, MockCanvas::DrawPathData{child_path1, child_paint1}},
-                   MockCanvas::DrawCall{
-                       1, MockCanvas::DrawPathData{child_path2, child_paint2}},
-                   MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
+  EXPECT_EQ(mock_canvas().draw_calls(),
+            std::vector({
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+                MockCanvas::DrawCall{0, MockCanvas::SetMatrixData{SkM44()}},
+#endif
+                MockCanvas::DrawCall{
+                    0, MockCanvas::SaveLayerData{children_bounds, filter_paint,
+                                                 nullptr, 1}},
+                MockCanvas::DrawCall{
+                    1, MockCanvas::DrawPathData{child_path1, child_paint1}},
+                MockCanvas::DrawCall{
+                    1, MockCanvas::DrawPathData{child_path2, child_paint2}},
+                MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
 }
 
 TEST_F(ColorFilterLayerTest, Nested) {
@@ -178,20 +187,26 @@ TEST_F(ColorFilterLayerTest, Nested) {
   filter_paint1.setColorFilter(layer_filter1);
   filter_paint2.setColorFilter(layer_filter2);
   layer1->Paint(paint_context());
-  EXPECT_EQ(
-      mock_canvas().draw_calls(),
-      std::vector({MockCanvas::DrawCall{
-                       0, MockCanvas::SaveLayerData{children_bounds,
-                                                    filter_paint1, nullptr, 1}},
-                   MockCanvas::DrawCall{
-                       1, MockCanvas::DrawPathData{child_path1, child_paint1}},
-                   MockCanvas::DrawCall{
-                       1, MockCanvas::SaveLayerData{child_path2.getBounds(),
-                                                    filter_paint2, nullptr, 2}},
-                   MockCanvas::DrawCall{
-                       2, MockCanvas::DrawPathData{child_path2, child_paint2}},
-                   MockCanvas::DrawCall{2, MockCanvas::RestoreData{1}},
-                   MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
+  EXPECT_EQ(mock_canvas().draw_calls(),
+            std::vector({
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+                MockCanvas::DrawCall{0, MockCanvas::SetMatrixData{SkM44()}},
+#endif
+                MockCanvas::DrawCall{
+                    0, MockCanvas::SaveLayerData{children_bounds, filter_paint1,
+                                                 nullptr, 1}},
+                MockCanvas::DrawCall{
+                    1, MockCanvas::DrawPathData{child_path1, child_paint1}},
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+                MockCanvas::DrawCall{1, MockCanvas::SetMatrixData{SkM44()}},
+#endif
+                MockCanvas::DrawCall{
+                    1, MockCanvas::SaveLayerData{child_path2.getBounds(),
+                                                 filter_paint2, nullptr, 2}},
+                MockCanvas::DrawCall{
+                    2, MockCanvas::DrawPathData{child_path2, child_paint2}},
+                MockCanvas::DrawCall{2, MockCanvas::RestoreData{1}},
+                MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
 }
 
 TEST_F(ColorFilterLayerTest, Readback) {

--- a/flow/layers/image_filter_layer.cc
+++ b/flow/layers/image_filter_layer.cc
@@ -21,6 +21,11 @@ void ImageFilterLayer::Diff(DiffContext* context, const Layer* old_layer) {
     }
   }
 
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+  context->SetTransform(
+      RasterCache::GetIntegralTransCTM(context->GetTransform()));
+#endif
+
   if (filter_) {
     auto filter = filter_->makeWithLocalMatrix(context->GetTransform());
     if (filter) {
@@ -57,13 +62,18 @@ void ImageFilterLayer::Preroll(PrerollContext* context,
 
   set_paint_bounds(child_bounds);
 
+  SkMatrix child_matrix(matrix);
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+  child_matrix = RasterCache::GetIntegralTransCTM(child_matrix);
+#endif
+
   transformed_filter_ = nullptr;
   if (render_count_ >= kMinimumRendersBeforeCachingFilterLayer) {
     // We have rendered this same ImageFilterLayer object enough
     // times to consider its properties and children to be stable
     // from frame to frame so we try to cache the layer itself
     // for maximum performance.
-    TryToPrepareRasterCache(context, this, matrix);
+    TryToPrepareRasterCache(context, this, child_matrix);
   } else {
     // This ImageFilterLayer is not yet considered stable so we
     // increment the count to measure how many times it has been
@@ -77,7 +87,7 @@ void ImageFilterLayer::Preroll(PrerollContext* context,
     // instances can do this operation on some transforms and some
     // (filters or transforms) cannot. We can only cache the children
     // and apply the filter on the fly if this operation succeeds.
-    transformed_filter_ = filter_->makeWithLocalMatrix(matrix);
+    transformed_filter_ = filter_->makeWithLocalMatrix(child_matrix);
     if (transformed_filter_) {
       // With a modified SkImageFilter we can now try to cache the
       // children to avoid their rendering costs if they remain
@@ -93,30 +103,37 @@ void ImageFilterLayer::Paint(PaintContext& context) const {
   TRACE_EVENT0("flutter", "ImageFilterLayer::Paint");
   FML_DCHECK(needs_painting(context));
 
+  AutoCachePaint cache_paint(context);
+
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+  context.internal_nodes_canvas->setMatrix(RasterCache::GetIntegralTransCTM(
+      context.leaf_nodes_canvas->getTotalMatrix()));
+#endif
+
   if (context.raster_cache) {
-    if (context.raster_cache->Draw(this, *context.leaf_nodes_canvas)) {
+    if (context.raster_cache->Draw(this, *context.leaf_nodes_canvas,
+                                   cache_paint.paint())) {
       return;
     }
     if (transformed_filter_) {
-      SkPaint paint;
-      paint.setImageFilter(transformed_filter_);
+      cache_paint.setImageFilter(transformed_filter_);
 
       if (context.raster_cache->Draw(GetCacheableChild(),
-                                     *context.leaf_nodes_canvas, &paint)) {
+                                     *context.leaf_nodes_canvas,
+                                     cache_paint.paint())) {
         return;
       }
     }
   }
 
-  SkPaint paint;
-  paint.setImageFilter(filter_);
+  cache_paint.setImageFilter(filter_);
 
   // Normally a save_layer is sized to the current layer bounds, but in this
   // case the bounds of the child may not be the same as the filtered version
   // so we use the bounds of the child container which do not include any
   // modifications that the filter might apply.
   Layer::AutoSaveLayer save_layer = Layer::AutoSaveLayer::Create(
-      context, GetChildContainer()->paint_bounds(), &paint);
+      context, GetChildContainer()->paint_bounds(), cache_paint.paint());
   PaintChildren(context);
 }
 

--- a/flow/layers/image_filter_layer_unittests.cc
+++ b/flow/layers/image_filter_layer_unittests.cc
@@ -61,6 +61,9 @@ TEST_F(ImageFilterLayerTest, EmptyFilter) {
   layer->Paint(paint_context());
   EXPECT_EQ(mock_canvas().draw_calls(),
             std::vector({
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+                MockCanvas::DrawCall{0, MockCanvas::SetMatrixData{SkM44()}},
+#endif
                 MockCanvas::DrawCall{
                     0, MockCanvas::SaveLayerData{child_bounds, filter_paint,
                                                  nullptr, 1}},
@@ -95,6 +98,9 @@ TEST_F(ImageFilterLayerTest, SimpleFilter) {
   layer->Paint(paint_context());
   EXPECT_EQ(mock_canvas().draw_calls(),
             std::vector({
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+                MockCanvas::DrawCall{0, MockCanvas::SetMatrixData{SkM44()}},
+#endif
                 MockCanvas::DrawCall{
                     0, MockCanvas::SaveLayerData{child_bounds, filter_paint,
                                                  nullptr, 1}},
@@ -129,6 +135,9 @@ TEST_F(ImageFilterLayerTest, SimpleFilterBounds) {
   layer->Paint(paint_context());
   EXPECT_EQ(mock_canvas().draw_calls(),
             std::vector({
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+                MockCanvas::DrawCall{0, MockCanvas::SetMatrixData{SkM44()}},
+#endif
                 MockCanvas::DrawCall{
                     0, MockCanvas::SaveLayerData{child_bounds, filter_paint,
                                                  nullptr, 1}},
@@ -172,16 +181,19 @@ TEST_F(ImageFilterLayerTest, MultipleChildren) {
   SkPaint filter_paint;
   filter_paint.setImageFilter(layer_filter);
   layer->Paint(paint_context());
-  EXPECT_EQ(
-      mock_canvas().draw_calls(),
-      std::vector({MockCanvas::DrawCall{
-                       0, MockCanvas::SaveLayerData{children_bounds,
-                                                    filter_paint, nullptr, 1}},
-                   MockCanvas::DrawCall{
-                       1, MockCanvas::DrawPathData{child_path1, child_paint1}},
-                   MockCanvas::DrawCall{
-                       1, MockCanvas::DrawPathData{child_path2, child_paint2}},
-                   MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
+  EXPECT_EQ(mock_canvas().draw_calls(),
+            std::vector({
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+                MockCanvas::DrawCall{0, MockCanvas::SetMatrixData{SkM44()}},
+#endif
+                MockCanvas::DrawCall{
+                    0, MockCanvas::SaveLayerData{children_bounds, filter_paint,
+                                                 nullptr, 1}},
+                MockCanvas::DrawCall{
+                    1, MockCanvas::DrawPathData{child_path1, child_paint1}},
+                MockCanvas::DrawCall{
+                    1, MockCanvas::DrawPathData{child_path2, child_paint2}},
+                MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
 }
 
 TEST_F(ImageFilterLayerTest, Nested) {
@@ -231,11 +243,18 @@ TEST_F(ImageFilterLayerTest, Nested) {
   layer1->Paint(paint_context());
   EXPECT_EQ(mock_canvas().draw_calls(),
             std::vector({
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+                MockCanvas::DrawCall{0, MockCanvas::SetMatrixData{SkM44()}},
+#endif
+
                 MockCanvas::DrawCall{
                     0, MockCanvas::SaveLayerData{children_bounds, filter_paint1,
                                                  nullptr, 1}},
                 MockCanvas::DrawCall{
                     1, MockCanvas::DrawPathData{child_path1, child_paint1}},
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+                MockCanvas::DrawCall{1, MockCanvas::SetMatrixData{SkM44()}},
+#endif
                 MockCanvas::DrawCall{
                     1, MockCanvas::SaveLayerData{child_path2.getBounds(),
                                                  filter_paint2, nullptr, 2}},

--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -187,6 +187,22 @@ class Layer {
       }
     }
 
+    void setImageFilter(sk_sp<SkImageFilter> filter) {
+      paint_.setImageFilter(filter);
+      update_needs_paint();
+    }
+
+    void setColorFilter(sk_sp<SkColorFilter> filter) {
+      paint_.setColorFilter(filter);
+      update_needs_paint();
+    }
+
+    void update_needs_paint() {
+      needs_paint_ = paint_.getImageFilter() != nullptr ||
+                     paint_.getColorFilter() != nullptr ||
+                     paint_.getAlphaf() < SK_Scalar1;
+    }
+
     ~AutoCachePaint() { context_.inherited_opacity = paint_.getAlphaf(); }
 
     const SkPaint* paint() { return needs_paint_ ? &paint_ : nullptr; }


### PR DESCRIPTION
Cherry pick for https://github.com/flutter/flutter/issues/106523 . Manually verified with the example code that the artifacts are no longer present