### PR TITLE
Avoid crash caused by flutterImageView be null

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -1370,7 +1370,7 @@ public class FlutterView extends FrameLayout
           public void onFlutterUiDisplayed() {
             renderer.removeIsDisplayingFlutterUiListener(this);
             onDone.run();
-            if (!(renderSurface instanceof FlutterImageView)) {
+            if (!(renderSurface instanceof FlutterImageView) && flutterImageView != null) {
               flutterImageView.detachFromRenderer();
             }
           }

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -1308,6 +1308,11 @@ public class FlutterView extends FrameLayout
         getContext(), getWidth(), getHeight(), FlutterImageView.SurfaceKind.background);
   }
 
+  @VisibleForTesting
+  public FlutterImageView getCurrentImageSurface() {
+    return flutterImageView;
+  }
+
   /**
    * Converts the current render surface to a {@link FlutterImageView} if it's not one already.
    * Otherwise, it resizes the {@link FlutterImageView} based on the current view size.

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
@@ -175,6 +175,32 @@ public class FlutterViewTest {
   }
 
   @Test
+  public void flutterImageView_revertImageViewAndAvoidNPE() {
+    FlutterView flutterView = new FlutterView(RuntimeEnvironment.application);
+    FlutterEngine flutterEngine =
+        spy(new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, mockFlutterJni));
+    FlutterRenderer flutterRenderer = spy(new FlutterRenderer(mockFlutterJni));
+    when(flutterEngine.getRenderer()).thenReturn(flutterRenderer);
+
+    flutterView.attachToFlutterEngine(flutterEngine);
+    flutterView.convertToImageView();
+    assertTrue(flutterView.renderSurface instanceof FlutterImageView);
+
+    // Register a `FlutterUiDisplayListener` callback.
+    // During callback execution it will invoke `flutterImageView.detachFromRenderer()`.
+    flutterView.revertImageView(() -> {
+      // No-op
+    });
+    assertFalse(flutterView.renderSurface instanceof FlutterImageView);
+
+    flutterView.detachFromFlutterEngine();
+    assertEquals(null, flutterView.getCurrentImageSurface());
+
+    // Invoke all registered `FlutterUiDisplayListener` callback
+    mockFlutterJni.onFirstFrame();
+  }
+
+  @Test
   public void onConfigurationChanged_fizzlesWhenNullEngine() {
     FlutterView flutterView = new FlutterView(Robolectric.setupActivity(Activity.class));
     FlutterEngine flutterEngine = spy(new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni));

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
@@ -176,9 +176,8 @@ public class FlutterViewTest {
 
   @Test
   public void flutterImageView_revertImageViewAndAvoidNPE() {
-    FlutterView flutterView = new FlutterView(RuntimeEnvironment.application);
-    FlutterEngine flutterEngine =
-        spy(new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, mockFlutterJni));
+    FlutterView flutterView = new FlutterView(ctx);
+    FlutterEngine flutterEngine = spy(new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni));
     FlutterRenderer flutterRenderer = spy(new FlutterRenderer(mockFlutterJni));
     when(flutterEngine.getRenderer()).thenReturn(flutterRenderer);
 
@@ -188,9 +187,10 @@ public class FlutterViewTest {
 
     // Register a `FlutterUiDisplayListener` callback.
     // During callback execution it will invoke `flutterImageView.detachFromRenderer()`.
-    flutterView.revertImageView(() -> {
-      // No-op
-    });
+    flutterView.revertImageView(
+        () -> {
+          // No-op
+        });
     assertFalse(flutterView.renderSurface instanceof FlutterImageView);
 
     flutterView.detachFromFlutterEngine();


### PR DESCRIPTION
On rare occasions, we had a crash where the flutterImageView was empty, and according to the stack,it's due to the flutterImageView NullPointerException. I guess is the renderer. addIsDisplayingFlutterUiListener register the callback. But by the time the flutter rendering is done, the platform thread called the detachFromFlutterEngine for some reason (and was faster) and left the flutterImageView empty. 
You can evaluate the need for a merger

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
