### PR TITLE
Delete .cirrus.yml again

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,0 @@
-container:
-  image: gcc:latest
-task:
-  name: build_and_test_linux_unopt_debug
-  clone_script: echo "Remove this when https://github.com/flutter/flutter/issues/106712 is resolved"


### PR DESCRIPTION
Reverts flutter/engine#34344

This should be safe now that https://github.com/flutter/cocoon/pull/1950 has had time to propagate.