### PR TITLE
Fix the CPU dimension for mac host engine v2.

### DIFF
--- a/ci/builders/mac_host_engine.json
+++ b/ci/builders/mac_host_engine.json
@@ -18,7 +18,7 @@
             "drone_dimensions": [
                 "device_type=none",
                 "os=Mac-12",
-		"cpu=x64"
+		"cpu=x86"
             ],
             "gclient_custom_vars": {
                 "download_android_deps": false
@@ -60,7 +60,7 @@
             "drone_dimensions": [
                 "device_type=none",
                 "os=Mac-12",
-		"cpu=x64"
+		"cpu=x86"
             ],
             "gclient_custom_vars": {
                 "download_android_deps": false
@@ -114,7 +114,7 @@
             "drone_dimensions": [
                 "device_type=none",
                 "os=Mac-12",
-		"cpu=x64"
+		"cpu=x86"
             ],
             "gclient_custom_vars": {
                 "download_android_deps": false
@@ -151,7 +151,7 @@
             "drone_dimensions": [
                 "device_type=none",
                 "os=Mac-12",
-		"cpu=x64"
+		"cpu=x86"
             ],
             "gclient_custom_vars": {
                 "download_android_deps": false
@@ -186,7 +186,7 @@
             "drone_dimensions": [
                 "device_type=none",
                 "os=Mac-12",
-		"cpu=x64"
+		"cpu=x86"
             ],
             "gclient_custom_vars": {
                 "download_android_deps": false
@@ -218,7 +218,7 @@
             "drone_dimensions": [
                 "device_type=none",
                 "os=Mac-12",
-		"cpu=x64"
+		"cpu=x86"
             ],
             "gclient_custom_vars": {
                 "download_android_deps": false


### PR DESCRIPTION
There was an update in the way we are collecting the dimensions of a bot
that changed the x64 dimension to x86-64. To make the configurations
consistent we are changing the dimension to x86.

Bug: https://github.com/flutter/flutter/issues/81855

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
