### PR TITLE
Do not update virtual display size

### DIFF
--- a/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java
@@ -45,19 +45,8 @@ class VirtualDisplayController {
     }
     // Prevent https://github.com/flutter/flutter/issues/2897.
     if (selectedWidth > metrics.widthPixels || selectedHeight > metrics.heightPixels) {
-      float aspectRatio = (float) selectedWidth / (float) selectedHeight;
-      int maybeWidth = (int) (metrics.heightPixels * aspectRatio);
-      int maybeHeight = (int) (metrics.widthPixels / aspectRatio);
-
-      if (maybeHeight <= metrics.heightPixels) {
-        selectedWidth = metrics.widthPixels;
-        selectedHeight = maybeHeight;
-      } else if (maybeWidth <= metrics.widthPixels) {
-        selectedHeight = metrics.heightPixels;
-        selectedWidth = maybeWidth;
-      } else {
-        return null;
-      }
+      selectedWidth = Math.min(selectedWidth, metrics.widthPixels);
+      selectedHeight = Math.min(selectedHeight, metrics.heightPixels);
 
       String message =
           String.format(

--- a/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java
@@ -17,9 +17,7 @@ import android.view.View;
 import android.view.ViewTreeObserver;
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
-import io.flutter.Log;
 import io.flutter.view.TextureRegistry;
-import java.util.Locale;
 
 @TargetApi(20)
 class VirtualDisplayController {
@@ -48,8 +46,7 @@ class VirtualDisplayController {
 
     int densityDpi = context.getResources().getDisplayMetrics().densityDpi;
     VirtualDisplay virtualDisplay =
-        displayManager.createVirtualDisplay(
-            "flutter-vd", width, height, densityDpi, surface, 0);
+        displayManager.createVirtualDisplay("flutter-vd", width, height, densityDpi, surface, 0);
 
     if (virtualDisplay == null) {
       return null;

--- a/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java
@@ -39,6 +39,16 @@ class VirtualDisplayController {
       return null;
     }
 
+    // Virtual Display crashes for some PlatformViews if the width or height is bigger
+    // than the physical screen size. We have tried to clamp or scale down the size to prevent
+    // the crash, but both solutions lead to unwanted behavior because the
+    // AndroidPlatformView(https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/widgets/platform_view.dart#L677) widget doesn't
+    // scale or clamp, which leads to a mismatch between the size of the widget and the size of
+    // virtual display.
+    // This mismatch leads to some test failures: https://github.com/flutter/flutter/issues/106750
+    // TODO(cyanglaz): find a way to prevent the crash without introducing size mistach betewen
+    // virtual display and AndroidPlatformView widget.
+    // https://github.com/flutter/flutter/issues/93115
     textureEntry.surfaceTexture().setDefaultBufferSize(width, height);
     Surface surface = new Surface(textureEntry.surfaceTexture());
     DisplayManager displayManager =

--- a/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java
@@ -36,33 +36,12 @@ class VirtualDisplayController {
       Object createParams,
       OnFocusChangeListener focusChangeListener) {
 
-    int selectedWidth = width;
-    int selectedHeight = height;
-
     DisplayMetrics metrics = context.getResources().getDisplayMetrics();
-    if (selectedWidth == 0 || selectedHeight == 0) {
+    if (width == 0 || height == 0) {
       return null;
     }
-    // Prevent https://github.com/flutter/flutter/issues/2897.
-    if (selectedWidth > metrics.widthPixels || selectedHeight > metrics.heightPixels) {
-      selectedWidth = Math.min(selectedWidth, metrics.widthPixels);
-      selectedHeight = Math.min(selectedHeight, metrics.heightPixels);
 
-      String message =
-          String.format(
-              Locale.US,
-              "Resizing virtual display of size: [%d, %d] to size [%d, %d] "
-                  + "since it's larger than the device display size [%d, %d].",
-              width,
-              height,
-              selectedWidth,
-              selectedHeight,
-              metrics.widthPixels,
-              metrics.heightPixels);
-      Log.w(TAG, message);
-    }
-
-    textureEntry.surfaceTexture().setDefaultBufferSize(selectedWidth, selectedHeight);
+    textureEntry.surfaceTexture().setDefaultBufferSize(width, height);
     Surface surface = new Surface(textureEntry.surfaceTexture());
     DisplayManager displayManager =
         (DisplayManager) context.getSystemService(Context.DISPLAY_SERVICE);
@@ -70,7 +49,7 @@ class VirtualDisplayController {
     int densityDpi = context.getResources().getDisplayMetrics().densityDpi;
     VirtualDisplay virtualDisplay =
         displayManager.createVirtualDisplay(
-            "flutter-vd", selectedWidth, selectedHeight, densityDpi, surface, 0);
+            "flutter-vd", width, height, densityDpi, surface, 0);
 
     if (virtualDisplay == null) {
       return null;
@@ -86,8 +65,8 @@ class VirtualDisplayController {
             focusChangeListener,
             viewId,
             createParams);
-    controller.bufferWidth = selectedWidth;
-    controller.bufferHeight = selectedHeight;
+    controller.bufferWidth = width;
+    controller.bufferHeight = height;
     return controller;
   }
 


### PR DESCRIPTION
This reverts part of https://github.com/flutter/engine/pull/33599

https://github.com/flutter/engine/pull/33599 added a logic in virtual display to resize if it is larger than the physical screen of the device. This is implemented to avoid a crash where virtual display is requested larger than the screen, see: https://github.com/flutter/flutter/issues/93115
It creates a mismatch between the size of the flutter widget and the size of the virtual display and also breaks some tests: https://github.com/flutter/flutter/issues/106750

We should revert this and reinvestigate a better fix for https://github.com/flutter/flutter/issues/93115

Fixes: https://github.com/flutter/flutter/issues/106750

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
