### PR TITLE
Use uncompressed image size as the basis for the fuzzy pixel matching threshold in the Skia Gold scenario tests

### DIFF
--- a/testing/scenario_app/bin/android_integration_tests.dart
+++ b/testing/scenario_app/bin/android_integration_tests.dart
@@ -76,7 +76,8 @@ void main(List<String> args) async {
         log('wrote ${goldenFile.absolute.path}');
         if (isSkiaGoldClientAvailable) {
           final Future<void> comparison = skiaGoldClient!
-            .addImg(fileName, goldenFile, screenshotSize: fileContent.lengthInBytes)
+            .addImg(fileName, goldenFile,
+                    screenshotSize: screenshot.pixelCount)
             .catchError((dynamic err) {
               panic(<String>['skia gold comparison failed: ${err.toString()}']);
             });

--- a/testing/scenario_app/bin/utils/screenshot_transformer.dart
+++ b/testing/scenario_app/bin/utils/screenshot_transformer.dart
@@ -8,13 +8,16 @@ import 'dart:typed_data';
 
 /// A screenshot from the Android emulator.
 class Screenshot {
-  Screenshot(this.filename, this.fileContent);
+  Screenshot(this.filename, this.fileContent, this.pixelCount);
 
   /// The name of the screenshot.
   final String filename;
 
   /// The binary content of the screenshot.
   final Uint8List fileContent;
+
+  /// The number of pixels in the screenshot.
+  final int pixelCount;
 }
 
 /// Takes the input stream and transforms it into [Screenshot]s.
@@ -28,7 +31,7 @@ class ScreenshotBlobTransformer extends StreamTransformerBase<Uint8List, Screens
     await for (final Uint8List blob in stream) {
       pending.add(blob);
 
-      if (pending.length < 8) {
+      if (pending.length < 12) {
         continue;
       }
 
@@ -41,9 +44,12 @@ class ScreenshotBlobTransformer extends StreamTransformerBase<Uint8List, Screens
       off += 4;
       final int fcontentLen = byteData.getInt32(off);
       off += 4;
+      final int pixelCount = byteData.getInt32(off);
+      off += 4;
 
       assert(fnameLen > 0);
       assert(fcontentLen > 0);
+      assert(pixelCount > 0);
 
       if (pending.length < off + fnameLen) {
         continue;
@@ -60,7 +66,7 @@ class ScreenshotBlobTransformer extends StreamTransformerBase<Uint8List, Screens
       pending.clear();
       pending.add(bytes.buffer.asUint8List(off));
 
-      yield Screenshot('$filename.png', fileContent);
+      yield Screenshot('$filename.png', fileContent, pixelCount);
     }
   }
 }

--- a/testing/skia_gold_client/lib/skia_gold_client.dart
+++ b/testing/skia_gold_client/lib/skia_gold_client.dart
@@ -185,11 +185,11 @@ class SkiaGoldClient {
   /// ```
   ///
   /// [differentPixelsRate] is the fraction of accepted pixels to be wrong in the range [0.0, 1.0].
-  /// Defaults to 0.1. A value of 0.1 means that 10% of the pixels are allowed to change.
+  /// Defaults to 0.01. A value of 0.01 means that 1% of the pixels are allowed to change.
   Future<void> addImg(
     String testName,
     File goldenFile, {
-    double differentPixelsRate = 0.1,
+    double differentPixelsRate = 0.01,
     int pixelColorDelta = 0,
     required int screenshotSize,
   }) async {


### PR DESCRIPTION
Previously this script was using the size of the compressed PNG file.
