### PR TITLE
Disable the ExternalTextureTests scenario app test

### DIFF
--- a/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenariosui/ExternalTextureTests.java
+++ b/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenariosui/ExternalTextureTests.java
@@ -14,12 +14,14 @@ import androidx.test.rule.ActivityTestRule;
 import androidx.test.runner.AndroidJUnit4;
 import dev.flutter.scenarios.ExternalTextureFlutterActivity;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(AndroidJUnit4.class)
 @LargeTest
+@Ignore("Test had flakes in Skia Gold image matching.")
 public class ExternalTextureTests {
   private static final int SURFACE_WIDTH = 192;
   private static final int SURFACE_HEIGHT = 256;


### PR DESCRIPTION
This test was producing flakes in Skia Gold image matching.  Disable it for
now until the Skia Gold issues are resolved.

See https://github.com/flutter/flutter/issues/106673
