### PR TITLE
Mark BackdropFilter as inheriting opacity, enabling fading of BDFs

### DIFF
--- a/flow/layers/clip_shape_layer.h
+++ b/flow/layers/clip_shape_layer.h
@@ -89,13 +89,13 @@ class ClipShapeLayer : public CacheableContainerLayer {
 
     AutoCachePaint cache_paint(context);
     if (context.raster_cache) {
-      if (layer_raster_cache_item_->Draw(context, cache_paint.paint())) {
+      if (layer_raster_cache_item_->Draw(context, cache_paint.sk_paint())) {
         return;
       }
     }
 
     Layer::AutoSaveLayer save_layer = Layer::AutoSaveLayer::Create(
-        context, paint_bounds(), cache_paint.paint());
+        context, paint_bounds(), cache_paint.sk_paint());
     PaintChildren(context);
   }
 

--- a/flow/layers/color_filter_layer.cc
+++ b/flow/layers/color_filter_layer.cc
@@ -51,7 +51,7 @@ void ColorFilterLayer::Paint(PaintContext& context) const {
     if (layer_raster_cache_item_->IsCacheChildren()) {
       cache_paint.setColorFilter(filter_);
     }
-    if (layer_raster_cache_item_->Draw(context, cache_paint.paint())) {
+    if (layer_raster_cache_item_->Draw(context, cache_paint.sk_paint())) {
       return;
     }
   }
@@ -59,7 +59,7 @@ void ColorFilterLayer::Paint(PaintContext& context) const {
   cache_paint.setColorFilter(filter_);
 
   Layer::AutoSaveLayer save = Layer::AutoSaveLayer::Create(
-      context, paint_bounds(), cache_paint.paint());
+      context, paint_bounds(), cache_paint.sk_paint());
 
   PaintChildren(context);
 }

--- a/flow/layers/display_list_layer.cc
+++ b/flow/layers/display_list_layer.cc
@@ -114,7 +114,8 @@ void DisplayListLayer::Paint(PaintContext& context) const {
 
   if (context.raster_cache && display_list_raster_cache_item_) {
     AutoCachePaint cache_paint(context);
-    if (display_list_raster_cache_item_->Draw(context, cache_paint.paint())) {
+    if (display_list_raster_cache_item_->Draw(context,
+                                              cache_paint.sk_paint())) {
       TRACE_EVENT_INSTANT0("flutter", "raster cache hit");
       return;
     }
@@ -151,9 +152,9 @@ void DisplayListLayer::Paint(PaintContext& context) const {
   if (context.leaf_nodes_builder) {
     AutoCachePaint save_paint(context);
     int restore_count = context.leaf_nodes_builder->getSaveCount();
-    if (save_paint.paint() != nullptr) {
-      DlPaint paint = DlPaint().setAlpha(save_paint.paint()->getAlpha());
-      context.leaf_nodes_builder->saveLayer(&paint_bounds(), &paint);
+    if (save_paint.dl_paint() != nullptr) {
+      context.leaf_nodes_builder->saveLayer(&paint_bounds(),
+                                            save_paint.dl_paint());
     }
     context.leaf_nodes_builder->drawDisplayList(display_list_.skia_object());
     context.leaf_nodes_builder->restoreToCount(restore_count);

--- a/flow/layers/image_filter_layer.cc
+++ b/flow/layers/image_filter_layer.cc
@@ -87,7 +87,7 @@ void ImageFilterLayer::Paint(PaintContext& context) const {
   if (layer_raster_cache_item_->IsCacheChildren()) {
     cache_paint.setImageFilter(transformed_filter_);
   }
-  if (layer_raster_cache_item_->Draw(context, cache_paint.paint())) {
+  if (layer_raster_cache_item_->Draw(context, cache_paint.sk_paint())) {
     return;
   }
 
@@ -98,7 +98,7 @@ void ImageFilterLayer::Paint(PaintContext& context) const {
   // so we use the bounds of the child container which do not include any
   // modifications that the filter might apply.
   Layer::AutoSaveLayer save_layer = Layer::AutoSaveLayer::Create(
-      context, child_paint_bounds(), cache_paint.paint());
+      context, child_paint_bounds(), cache_paint.sk_paint());
   PaintChildren(context);
 }
 

--- a/flow/layers/shader_mask_layer.cc
+++ b/flow/layers/shader_mask_layer.cc
@@ -50,13 +50,13 @@ void ShaderMaskLayer::Paint(PaintContext& context) const {
   AutoCachePaint cache_paint(context);
 
   if (context.raster_cache) {
-    if (layer_raster_cache_item_->Draw(context, cache_paint.paint())) {
+    if (layer_raster_cache_item_->Draw(context, cache_paint.sk_paint())) {
       return;
     }
   }
 
   Layer::AutoSaveLayer save = Layer::AutoSaveLayer::Create(
-      context, paint_bounds(), cache_paint.paint());
+      context, paint_bounds(), cache_paint.sk_paint());
   PaintChildren(context);
 
   SkPaint paint;

--- a/flow/layers/texture_layer.cc
+++ b/flow/layers/texture_layer.cc
@@ -61,7 +61,7 @@ void TextureLayer::Paint(PaintContext& context) const {
   }
   AutoCachePaint cache_paint(context);
   texture->Paint(*context.leaf_nodes_canvas, paint_bounds(), freeze_,
-                 context.gr_context, ToSk(sampling_), cache_paint.paint());
+                 context.gr_context, ToSk(sampling_), cache_paint.sk_paint());
 }
 
 }  // namespace flutter


### PR DESCRIPTION
Customers have complained about BackdropFilter not working well with an enclosing OpacityLayer. This led to a bug in iOS dialogs from a few years back (see https://github.com/flutter/flutter/issues/31706).

While this PR does not solve all cases where a BackdropFilter was nullified by being inside an enclosing saveLayer, it does solve a common case where the BackdropFilter is a direct (and only) child of an OpacityLayer.

Basically the fix is to mark the BackdropFilterLayer as able to inherit opacity which allows it to combine the opacity of a parent OpacityLayer into its own saveLayer.

Some refactoring of the AutoCachePaint facility was involved to more easily enable sharing of the object for both DisplayList and SkCanvas paths in the layers (as the 2 rendering variants of BackdropFilterLayer now need to do).