### PR TITLE
Scroll inertia cancel for macOS

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -36,6 +36,27 @@ static constexpr int32_t kPointerPanZoomDeviceId = 1;
  */
 struct MouseState {
   /**
+   * The currently pressed buttons, as represented in FlutterPointerEvent.
+   */
+  int64_t buttons = 0;
+
+  /**
+   * The accumulated gesture pan.
+   */
+  CGFloat delta_x = 0;
+  CGFloat delta_y = 0;
+
+  /**
+   * The accumulated gesture zoom scale.
+   */
+  CGFloat scale = 0;
+
+  /**
+   * The accumulated gesture rotation.
+   */
+  CGFloat rotation = 0;
+
+  /**
    * Whether or not a kAdd event has been sent (or sent again since the last kRemove if tracking is
    * enabled). Used to determine whether to send a kAdd event before sending an incoming mouse
    * event, since Flutter expects pointers to be added before events are sent for them.
@@ -57,20 +78,9 @@ struct MouseState {
   bool has_pending_exit = false;
 
   /**
-   * The currently pressed buttons, as represented in FlutterPointerEvent.
-   */
-  int64_t buttons = 0;
-
-  /**
    * Pan gesture is currently sending us events.
    */
   bool pan_gesture_active = false;
-
-  /**
-   * The accumulated gesture pan.
-   */
-  CGFloat delta_x = 0;
-  CGFloat delta_y = 0;
 
   /**
    * Scale gesture is currently sending us events.
@@ -78,19 +88,14 @@ struct MouseState {
   bool scale_gesture_active = false;
 
   /**
-   * The accumulated gesture zoom scale.
-   */
-  CGFloat scale = 0;
-
-  /**
    * Rotate gesture is currently sending use events.
    */
   bool rotate_gesture_active = false;
 
   /**
-   * The accumulated gesture rotation.
+   * System scroll inertia is currently sending us events.
    */
-  CGFloat rotation = 0;
+  bool system_scroll_inertia_active = false;
 
   /**
    * Resets all gesture state to default values.
@@ -375,6 +380,7 @@ static void CommonInit(FlutterViewController* controller) {
 
 - (void)viewDidLoad {
   [self configureTrackingArea];
+  [self.view setAcceptsTouchEvents:YES];
 }
 
 - (void)viewWillAppear {
@@ -510,6 +516,12 @@ static void CommonInit(FlutterViewController* controller) {
   } else if (event.phase == NSEventPhaseNone && event.momentumPhase == NSEventPhaseNone) {
     [self dispatchMouseEvent:event phase:kHover];
   } else {
+    if (event.momentumPhase == NSEventPhaseBegan) {
+      _mouseState.system_scroll_inertia_active = true;
+    } else if (event.momentumPhase == NSEventPhaseEnded ||
+               event.momentumPhase == NSEventPhaseCancelled) {
+      _mouseState.system_scroll_inertia_active = false;
+    }
     // Skip momentum events, the framework will generate scroll momentum.
     NSAssert(event.momentumPhase != NSEventPhaseNone,
              @"Received gesture event with unexpected phase");
@@ -823,6 +835,33 @@ static void CommonInit(FlutterViewController* controller) {
 
 - (void)swipeWithEvent:(NSEvent*)event {
   // Not needed, it's handled by scrollWheel.
+}
+
+- (void)touchesBeganWithEvent:(NSEvent*)event {
+  if (@available(macOS 10.12, *)) {
+    NSTouch* touch = event.allTouches.anyObject;
+    if (touch != nil) {
+      if (_mouseState.system_scroll_inertia_active) {
+        // The trackpad has been touched and a scroll gesture is still sending inertia events.
+        // A scroll inertia cancel message should be sent to the framework.
+        NSPoint locationInView = [self.flutterView convertPoint:event.locationInWindow
+                                                       fromView:nil];
+        NSPoint locationInBackingCoordinates =
+            [self.flutterView convertPointToBacking:locationInView];
+        FlutterPointerEvent flutterEvent = {
+            .struct_size = sizeof(flutterEvent),
+            .timestamp = static_cast<size_t>(event.timestamp * USEC_PER_SEC),
+            .x = locationInBackingCoordinates.x,
+            .y = -locationInBackingCoordinates.y,  // convertPointToBacking makes this negative.
+            .device = kPointerPanZoomDeviceId,
+            .signal_kind = kFlutterPointerSignalKindScrollInertiaCancel,
+            .device_kind = kFlutterPointerDeviceKindTrackpad,
+        };
+
+        [_engine sendPointerEvent:flutterEvent];
+      }
+    }
+  }
 }
 
 @end

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -380,7 +380,10 @@ static void CommonInit(FlutterViewController* controller) {
 
 - (void)viewDidLoad {
   [self configureTrackingArea];
-  [self.view setAcceptsTouchEvents:YES];
+  if (@available(macOS 10.12.2, *)) {
+    [self.view setAllowedTouchTypes:NSTouchTypeMaskIndirect];
+    [self.view setWantsRestingTouches:YES];
+  }
 }
 
 - (void)viewWillAppear {
@@ -522,7 +525,7 @@ static void CommonInit(FlutterViewController* controller) {
                event.momentumPhase == NSEventPhaseCancelled) {
       _mouseState.system_scroll_inertia_active = false;
     }
-    // Skip momentum events, the framework will generate scroll momentum.
+    // Skip momentum update events, the framework will generate scroll momentum.
     NSAssert(event.momentumPhase != NSEventPhaseNone,
              @"Received gesture event with unexpected phase");
   }

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
@@ -485,6 +485,48 @@ TEST(FlutterViewControllerTest, testViewWillAppearCalledMultipleTimes) {
   EXPECT_EQ(last_event.device_kind, kFlutterPointerDeviceKindTrackpad);
   EXPECT_EQ(last_event.signal_kind, kFlutterPointerSignalKindNone);
 
+  if (@available(macOS 10.12, *)) {
+    // Start system momentum.
+    CGEventRef cgEventMomentumStart = CGEventCreateCopy(cgEventStart);
+    CGEventSetIntegerValueField(cgEventMomentumStart, kCGScrollWheelEventScrollPhase, 0);
+    CGEventSetIntegerValueField(cgEventMomentumStart, kCGScrollWheelEventMomentumPhase,
+                                kCGMomentumScrollPhaseBegin);
+
+    called = false;
+    [viewController scrollWheel:[NSEvent eventWithCGEvent:cgEventMomentumStart]];
+    EXPECT_FALSE(called);
+
+    // Mock a touch on the trackpad.
+    id touchMock = OCMClassMock([NSTouch class]);
+    NSSet* touchSet = [NSSet setWithObject:touchMock];
+    id touchEventMock = OCMClassMock([NSEvent class]);
+    OCMStub([touchEventMock allTouches]).andReturn(touchSet);
+    CGPoint touchLocation = {0, 0};
+    OCMStub([touchEventMock locationInWindow]).andReturn(touchLocation);
+
+    // Scroll inertia cancel event should be issued.
+    called = false;
+    [viewController touchesBeganWithEvent:touchEventMock];
+    EXPECT_TRUE(called);
+    EXPECT_EQ(last_event.signal_kind, kFlutterPointerSignalKindScrollInertiaCancel);
+    EXPECT_EQ(last_event.device_kind, kFlutterPointerDeviceKindTrackpad);
+
+    // End system momentum.
+    CGEventRef cgEventMomentumEnd = CGEventCreateCopy(cgEventStart);
+    CGEventSetIntegerValueField(cgEventMomentumEnd, kCGScrollWheelEventScrollPhase, 0);
+    CGEventSetIntegerValueField(cgEventMomentumEnd, kCGScrollWheelEventMomentumPhase,
+                                kCGMomentumScrollPhaseEnd);
+
+    called = false;
+    [viewController scrollWheel:[NSEvent eventWithCGEvent:cgEventMomentumEnd]];
+    EXPECT_FALSE(called);
+
+    // Scroll inertia cancel event should not be issued after momentum has ended.
+    called = false;
+    [viewController touchesBeganWithEvent:touchEventMock];
+    EXPECT_FALSE(called);
+  }
+
   // May-begin and cancel are used while macOS determines which type of gesture to choose.
   CGEventRef cgEventMayBegin = CGEventCreateCopy(cgEventStart);
   CGEventSetIntegerValueField(cgEventMayBegin, kCGScrollWheelEventScrollPhase,


### PR DESCRIPTION
Generate PointerScrollInertiaCancel event on macOS when the trackpad receives a touch during momentum scrolling. 

Part of https://github.com/flutter/flutter/issues/106979

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
