### PR TITLE
Scroll inertia cancel for Win32

### DIFF
--- a/shell/platform/windows/direct_manipulation.cc
+++ b/shell/platform/windows/direct_manipulation.cc
@@ -4,6 +4,8 @@
 
 #include "flutter/fml/logging.h"
 
+#include <algorithm>
+
 #include "flutter/shell/platform/windows/direct_manipulation.h"
 #include "flutter/shell/platform/windows/window.h"
 #include "flutter/shell/platform/windows/window_binding_handler_delegate.h"

--- a/shell/platform/windows/direct_manipulation.cc
+++ b/shell/platform/windows/direct_manipulation.cc
@@ -66,7 +66,9 @@ HRESULT DirectManipulationEventHandler::OnViewportStatusChanged(
       owner_->binding_handler_delegate->OnPointerPanZoomEnd(GetDeviceId());
     }
   } else if (previous == DIRECTMANIPULATION_INERTIA) {
-    if (owner_->binding_handler_delegate && std::max(std::abs(last_pan_delta_x_), std::abs(last_pan_delta_y_)) > 0.01) {
+    if (owner_->binding_handler_delegate &&
+        (std::max)(std::abs(last_pan_delta_x_), std::abs(last_pan_delta_y_)) >
+            0.01) {
       owner_->binding_handler_delegate->OnScrollInertiaCancel(GetDeviceId());
     }
     // Need to reset the content transform to its original position

--- a/shell/platform/windows/direct_manipulation.cc
+++ b/shell/platform/windows/direct_manipulation.cc
@@ -24,6 +24,10 @@
 
 namespace flutter {
 
+int32_t DirectManipulationEventHandler::GetDeviceId() {
+  return (int32_t) reinterpret_cast<int64_t>(this);
+}
+
 STDMETHODIMP DirectManipulationEventHandler::QueryInterface(REFIID iid,
                                                             void** ppv) {
   if ((iid == IID_IUnknown) ||
@@ -50,8 +54,7 @@ HRESULT DirectManipulationEventHandler::OnViewportStatusChanged(
     if (!during_synthesized_reset_) {
       // Not a false event.
       if (owner_->binding_handler_delegate) {
-        owner_->binding_handler_delegate->OnPointerPanZoomStart(
-            (int32_t) reinterpret_cast<int64_t>(this));
+        owner_->binding_handler_delegate->OnPointerPanZoomStart(GetDeviceId());
       }
     }
   }
@@ -60,12 +63,11 @@ HRESULT DirectManipulationEventHandler::OnViewportStatusChanged(
     last_pan_delta_x_ = 0.0;
     last_pan_delta_y_ = 0.0;
     if (owner_->binding_handler_delegate) {
-      owner_->binding_handler_delegate->OnPointerPanZoomEnd(
-          (int32_t) reinterpret_cast<int64_t>(this));
+      owner_->binding_handler_delegate->OnPointerPanZoomEnd(GetDeviceId());
     }
   } else if (previous == DIRECTMANIPULATION_INERTIA) {
     if (owner_->binding_handler_delegate && std::max(std::abs(last_pan_delta_x_), std::abs(last_pan_delta_y_)) > 0.01) {
-      owner_->binding_handler_delegate->OnScrollInertiaCancel((int32_t) reinterpret_cast<int64_t>(this));
+      owner_->binding_handler_delegate->OnScrollInertiaCancel(GetDeviceId());
     }
     // Need to reset the content transform to its original position
     // so that we are ready for the next gesture.
@@ -123,7 +125,7 @@ HRESULT DirectManipulationEventHandler::OnContentUpdated(
     last_pan_y_ = pan_y;
     if (owner_->binding_handler_delegate && !during_inertia_) {
       owner_->binding_handler_delegate->OnPointerPanZoomUpdate(
-          (int32_t) reinterpret_cast<int64_t>(this), pan_x, pan_y, scale, 0);
+          GetDeviceId(), pan_x, pan_y, scale, 0);
     }
   }
   return S_OK;

--- a/shell/platform/windows/direct_manipulation.h
+++ b/shell/platform/windows/direct_manipulation.h
@@ -114,7 +114,8 @@ class DirectManipulationEventHandler
   // A flag is needed to ensure that false events created as the reset occurs
   // are not sent to the flutter framework.
   bool during_synthesized_reset_ = false;
-  // Store whether current events are from synthetic inertia rather than user input.
+  // Store whether current events are from synthetic inertia rather than user
+  // input.
   bool during_inertia_ = false;
   // Store the difference between the last pan offsets to determine if inertia
   // has been cancelled in the middle of an animation.

--- a/shell/platform/windows/direct_manipulation.h
+++ b/shell/platform/windows/direct_manipulation.h
@@ -106,6 +106,8 @@ class DirectManipulationEventHandler
                 DIRECTMANIPULATION_INTERACTION_TYPE interaction) override;
 
  private:
+  // Unique identifier to associate with all gesture event updates.
+  int32_t GetDeviceId();
   // Parent object, used to store the target for gesture event updates.
   DirectManipulationOwner* owner_;
   // We need to reset some parts of DirectManipulation after each gesture

--- a/shell/platform/windows/direct_manipulation.h
+++ b/shell/platform/windows/direct_manipulation.h
@@ -112,6 +112,14 @@ class DirectManipulationEventHandler
   // A flag is needed to ensure that false events created as the reset occurs
   // are not sent to the flutter framework.
   bool during_synthesized_reset_ = false;
+  // Store whether current events are from synthetic inertia rather than user input.
+  bool during_inertia_ = false;
+  // Store the difference between the last pan offsets to determine if inertia
+  // has been cancelled in the middle of an animation.
+  float last_pan_x_ = 0.0;
+  float last_pan_y_ = 0.0;
+  float last_pan_delta_x_ = 0.0;
+  float last_pan_delta_y_ = 0.0;
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/direct_manipulation_unittests.cc
+++ b/shell/platform/windows/direct_manipulation_unittests.cc
@@ -287,26 +287,25 @@ TEST(DirectManipulationTest, TestInertiaCancelSentForUserCancel) {
                                    DIRECTMANIPULATION_RUNNING);
   // Have pan_y change by 10 between inertia updates.
   EXPECT_CALL(content, GetContentTransform(_, 6))
-      .WillOnce(::testing::Invoke(
-          [](float* transform, DWORD size) {
-            transform[0] = 1;
-            transform[4] = 0;
-            transform[5] = 100;
-            return S_OK;
-          }));
+      .WillOnce(::testing::Invoke([](float* transform, DWORD size) {
+        transform[0] = 1;
+        transform[4] = 0;
+        transform[5] = 100;
+        return S_OK;
+      }));
   handler->OnContentUpdated((IDirectManipulationViewport*)&viewport,
                             (IDirectManipulationContent*)&content);
   EXPECT_CALL(content, GetContentTransform(_, 6))
-      .WillOnce(::testing::Invoke(
-          [](float* transform, DWORD size) {
-            transform[0] = 1;
-            transform[4] = 0;
-            transform[5] = 110;
-            return S_OK;
-          }));
+      .WillOnce(::testing::Invoke([](float* transform, DWORD size) {
+        transform[0] = 1;
+        transform[4] = 0;
+        transform[5] = 110;
+        return S_OK;
+      }));
   handler->OnContentUpdated((IDirectManipulationViewport*)&viewport,
                             (IDirectManipulationContent*)&content);
-  // This looks like an interruption in the middle of synthetic inertia because of user input.
+  // This looks like an interruption in the middle of synthetic inertia because
+  // of user input.
   EXPECT_CALL(delegate, OnScrollInertiaCancel(device_id));
   handler->OnViewportStatusChanged((IDirectManipulationViewport*)&viewport,
                                    DIRECTMANIPULATION_READY,
@@ -341,23 +340,21 @@ TEST(DirectManipulationTest, TestInertiaCamcelNotSentAtInertiaEnd) {
                                    DIRECTMANIPULATION_RUNNING);
   // Have no change in pan between events.
   EXPECT_CALL(content, GetContentTransform(_, 6))
-      .WillOnce(::testing::Invoke(
-          [](float* transform, DWORD size) {
-            transform[0] = 1;
-            transform[4] = 0;
-            transform[5] = 140;
-            return S_OK;
-          }));
+      .WillOnce(::testing::Invoke([](float* transform, DWORD size) {
+        transform[0] = 1;
+        transform[4] = 0;
+        transform[5] = 140;
+        return S_OK;
+      }));
   handler->OnContentUpdated((IDirectManipulationViewport*)&viewport,
                             (IDirectManipulationContent*)&content);
   EXPECT_CALL(content, GetContentTransform(_, 6))
-      .WillOnce(::testing::Invoke(
-          [](float* transform, DWORD size) {
-            transform[0] = 1;
-            transform[4] = 0;
-            transform[5] = 140;
-            return S_OK;
-          }));
+      .WillOnce(::testing::Invoke([](float* transform, DWORD size) {
+        transform[0] = 1;
+        transform[4] = 0;
+        transform[5] = 140;
+        return S_OK;
+      }));
   handler->OnContentUpdated((IDirectManipulationViewport*)&viewport,
                             (IDirectManipulationContent*)&content);
   // OnScrollInertiaCancel should not be called.

--- a/shell/platform/windows/direct_manipulation_unittests.cc
+++ b/shell/platform/windows/direct_manipulation_unittests.cc
@@ -259,5 +259,113 @@ TEST(DirectManipulationTest, TestRounding) {
                                    DIRECTMANIPULATION_INERTIA);
 }
 
+TEST(DirectManipulationTest, TestInertiaCancelSentForUserCancel) {
+  MockIDirectManipulationContent content;
+  MockWindowBindingHandlerDelegate delegate;
+  MockIDirectManipulationViewport viewport;
+  const int DISPLAY_WIDTH = 800;
+  const int DISPLAY_HEIGHT = 600;
+  auto owner = std::make_unique<DirectManipulationOwner>(nullptr);
+  owner->SetBindingHandlerDelegate(&delegate);
+  auto handler =
+      fml::MakeRefCounted<DirectManipulationEventHandler>(owner.get());
+  int32_t device_id = (int32_t) reinterpret_cast<int64_t>(handler.get());
+  // No need to mock the actual gesture, just start at the end.
+  EXPECT_CALL(viewport, GetViewportRect(_))
+      .WillOnce(::testing::Invoke([DISPLAY_WIDTH, DISPLAY_HEIGHT](RECT* rect) {
+        rect->left = 0;
+        rect->top = 0;
+        rect->right = DISPLAY_WIDTH;
+        rect->bottom = DISPLAY_HEIGHT;
+        return S_OK;
+      }));
+  EXPECT_CALL(viewport, ZoomToRect(0, 0, DISPLAY_WIDTH, DISPLAY_HEIGHT, false))
+      .WillOnce(::testing::Return(S_OK));
+  EXPECT_CALL(delegate, OnPointerPanZoomEnd(device_id));
+  handler->OnViewportStatusChanged((IDirectManipulationViewport*)&viewport,
+                                   DIRECTMANIPULATION_INERTIA,
+                                   DIRECTMANIPULATION_RUNNING);
+  // Have pan_y change by 10 between inertia updates.
+  EXPECT_CALL(content, GetContentTransform(_, 6))
+      .WillOnce(::testing::Invoke(
+          [](float* transform, DWORD size) {
+            transform[0] = 1;
+            transform[4] = 0;
+            transform[5] = 100;
+            return S_OK;
+          }));
+  handler->OnContentUpdated((IDirectManipulationViewport*)&viewport,
+                            (IDirectManipulationContent*)&content);
+  EXPECT_CALL(content, GetContentTransform(_, 6))
+      .WillOnce(::testing::Invoke(
+          [](float* transform, DWORD size) {
+            transform[0] = 1;
+            transform[4] = 0;
+            transform[5] = 110;
+            return S_OK;
+          }));
+  handler->OnContentUpdated((IDirectManipulationViewport*)&viewport,
+                            (IDirectManipulationContent*)&content);
+  // This looks like an interruption in the middle of synthetic inertia because of user input.
+  EXPECT_CALL(delegate, OnScrollInertiaCancel(device_id));
+  handler->OnViewportStatusChanged((IDirectManipulationViewport*)&viewport,
+                                   DIRECTMANIPULATION_READY,
+                                   DIRECTMANIPULATION_INERTIA);
+}
+
+TEST(DirectManipulationTest, TestInertiaCamcelNotSentAtInertiaEnd) {
+  MockIDirectManipulationContent content;
+  MockWindowBindingHandlerDelegate delegate;
+  MockIDirectManipulationViewport viewport;
+  const int DISPLAY_WIDTH = 800;
+  const int DISPLAY_HEIGHT = 600;
+  auto owner = std::make_unique<DirectManipulationOwner>(nullptr);
+  owner->SetBindingHandlerDelegate(&delegate);
+  auto handler =
+      fml::MakeRefCounted<DirectManipulationEventHandler>(owner.get());
+  int32_t device_id = (int32_t) reinterpret_cast<int64_t>(handler.get());
+  // No need to mock the actual gesture, just start at the end.
+  EXPECT_CALL(viewport, GetViewportRect(_))
+      .WillOnce(::testing::Invoke([DISPLAY_WIDTH, DISPLAY_HEIGHT](RECT* rect) {
+        rect->left = 0;
+        rect->top = 0;
+        rect->right = DISPLAY_WIDTH;
+        rect->bottom = DISPLAY_HEIGHT;
+        return S_OK;
+      }));
+  EXPECT_CALL(viewport, ZoomToRect(0, 0, DISPLAY_WIDTH, DISPLAY_HEIGHT, false))
+      .WillOnce(::testing::Return(S_OK));
+  EXPECT_CALL(delegate, OnPointerPanZoomEnd(device_id));
+  handler->OnViewportStatusChanged((IDirectManipulationViewport*)&viewport,
+                                   DIRECTMANIPULATION_INERTIA,
+                                   DIRECTMANIPULATION_RUNNING);
+  // Have no change in pan between events.
+  EXPECT_CALL(content, GetContentTransform(_, 6))
+      .WillOnce(::testing::Invoke(
+          [](float* transform, DWORD size) {
+            transform[0] = 1;
+            transform[4] = 0;
+            transform[5] = 140;
+            return S_OK;
+          }));
+  handler->OnContentUpdated((IDirectManipulationViewport*)&viewport,
+                            (IDirectManipulationContent*)&content);
+  EXPECT_CALL(content, GetContentTransform(_, 6))
+      .WillOnce(::testing::Invoke(
+          [](float* transform, DWORD size) {
+            transform[0] = 1;
+            transform[4] = 0;
+            transform[5] = 140;
+            return S_OK;
+          }));
+  handler->OnContentUpdated((IDirectManipulationViewport*)&viewport,
+                            (IDirectManipulationContent*)&content);
+  // OnScrollInertiaCancel should not be called.
+  EXPECT_CALL(delegate, OnScrollInertiaCancel(device_id)).Times(0);
+  handler->OnViewportStatusChanged((IDirectManipulationViewport*)&viewport,
+                                   DIRECTMANIPULATION_READY,
+                                   DIRECTMANIPULATION_INERTIA);
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -505,13 +505,17 @@ void FlutterWindowsView::SendScroll(double x,
   SendPointerEventWithData(event, state);
 }
 
-void FlutterWindowsView::SendScrollInertiaCancel(int32_t device_id, double x, double y) {
-  auto state = GetOrCreatePointerState(kFlutterPointerDeviceKindTrackpad, device_id);
+void FlutterWindowsView::SendScrollInertiaCancel(int32_t device_id,
+                                                 double x,
+                                                 double y) {
+  auto state =
+      GetOrCreatePointerState(kFlutterPointerDeviceKindTrackpad, device_id);
 
   FlutterPointerEvent event = {};
   event.x = x;
   event.y = y;
-  event.signal_kind = FlutterPointerSignalKind::kFlutterPointerSignalKindScrollInertiaCancel;
+  event.signal_kind =
+      FlutterPointerSignalKind::kFlutterPointerSignalKindScrollInertiaCancel;
   SetEventPhaseFromCursorButtonState(&event, state);
   SendPointerEventWithData(event, state);
 }

--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -264,6 +264,11 @@ void FlutterWindowsView::OnScroll(double x,
              device_id);
 }
 
+void FlutterWindowsView::OnScrollInertiaCancel(int32_t device_id) {
+  PointerLocation point = binding_handler_->GetPrimaryPointerLocation();
+  SendScrollInertiaCancel(device_id, point.x, point.y);
+}
+
 void FlutterWindowsView::OnUpdateSemanticsEnabled(bool enabled) {
   engine_->UpdateSemanticsEnabled(enabled);
 }
@@ -496,6 +501,17 @@ void FlutterWindowsView::SendScroll(double x,
   event.signal_kind = FlutterPointerSignalKind::kFlutterPointerSignalKindScroll;
   event.scroll_delta_x = delta_x * scroll_offset_multiplier;
   event.scroll_delta_y = delta_y * scroll_offset_multiplier;
+  SetEventPhaseFromCursorButtonState(&event, state);
+  SendPointerEventWithData(event, state);
+}
+
+void FlutterWindowsView::SendScrollInertiaCancel(int32_t device_id, double x, double y) {
+  auto state = GetOrCreatePointerState(kFlutterPointerDeviceKindTrackpad, device_id);
+
+  FlutterPointerEvent event = {};
+  event.x = x;
+  event.y = y;
+  event.signal_kind = FlutterPointerSignalKind::kFlutterPointerSignalKindScrollInertiaCancel;
   SetEventPhaseFromCursorButtonState(&event, state);
   SendPointerEventWithData(event, state);
 }

--- a/shell/platform/windows/flutter_windows_view.h
+++ b/shell/platform/windows/flutter_windows_view.h
@@ -335,9 +335,7 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate,
                   int32_t device_id);
 
   // Reports scroll inertia cancel events to Flutter engine.
-  void SendScrollInertiaCancel(int32_t device_id,
-                               double x,
-                               double y);
+  void SendScrollInertiaCancel(int32_t device_id, double x, double y);
 
   // Creates a PointerState object unless it already exists.
   PointerState* GetOrCreatePointerState(FlutterPointerDeviceKind device_kind,

--- a/shell/platform/windows/flutter_windows_view.h
+++ b/shell/platform/windows/flutter_windows_view.h
@@ -181,6 +181,9 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate,
                 int32_t device_id) override;
 
   // |WindowBindingHandlerDelegate|
+  void OnScrollInertiaCancel(int32_t device_id) override;
+
+  // |WindowBindingHandlerDelegate|
   virtual void OnUpdateSemanticsEnabled(bool enabled) override;
 
   // |WindowBindingHandlerDelegate|
@@ -330,6 +333,11 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate,
                   int scroll_offset_multiplier,
                   FlutterPointerDeviceKind device_kind,
                   int32_t device_id);
+
+  // Reports scroll inertia cancel events to Flutter engine.
+  void SendScrollInertiaCancel(int32_t device_id,
+                               double x,
+                               double y);
 
   // Creates a PointerState object unless it already exists.
   PointerState* GetOrCreatePointerState(FlutterPointerDeviceKind device_kind,

--- a/shell/platform/windows/testing/mock_window_binding_handler_delegate.h
+++ b/shell/platform/windows/testing/mock_window_binding_handler_delegate.h
@@ -60,6 +60,7 @@ class MockWindowBindingHandlerDelegate : public WindowBindingHandlerDelegate {
                     int,
                     FlutterPointerDeviceKind,
                     int32_t));
+  MOCK_METHOD1(OnScrollInertiaCancel, void(int32_t));
   MOCK_METHOD0(OnPlatformBrightnessChanged, void());
   MOCK_METHOD1(UpdateHighContrastEnabled, void(bool enabled));
 };

--- a/shell/platform/windows/window_binding_handler_delegate.h
+++ b/shell/platform/windows/window_binding_handler_delegate.h
@@ -122,6 +122,10 @@ class WindowBindingHandlerDelegate {
                         FlutterPointerDeviceKind device_kind,
                         int32_t device_id) = 0;
 
+  // Notifies delegate that scroll inertia should be cancelled.
+  // Typically called by DirectManipulationEventHandler
+  virtual void OnScrollInertiaCancel(int32_t device_id) = 0;
+
   // Notifies delegate that the Flutter semantics tree should be enabled or
   // disabled.
   virtual void OnUpdateSemanticsEnabled(bool enabled) = 0;


### PR DESCRIPTION
Generate PointerScrollInertiaCancel event on Win32 when DirectManipulation inertia is prematurely ended. This should correspond to a trackpad touch. 

Part of https://github.com/flutter/flutter/issues/106979

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
