### PR TITLE
Use sRGB colorspace for IOSurface

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterIOSurfaceHolder.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterIOSurfaceHolder.mm
@@ -51,6 +51,7 @@
   };
 
   _ioSurface = IOSurfaceCreate((CFDictionaryRef)options);
+  IOSurfaceSetValue(_ioSurface, kIOSurfaceColorSpace, kCGColorSpaceSRGB);
 }
 
 - (const IOSurfaceRef&)ioSurface {

--- a/shell/platform/darwin/macos/framework/Source/FlutterIOSurfaceHolder.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterIOSurfaceHolder.mm
@@ -51,7 +51,7 @@
   };
 
   _ioSurface = IOSurfaceCreate((CFDictionaryRef)options);
-  IOSurfaceSetValue(_ioSurface, kIOSurfaceColorSpace, kCGColorSpaceSRGB);
+  IOSurfaceSetValue(_ioSurface, CFSTR("IOSurfaceColorSpace"), kCGColorSpaceSRGB);
 }
 
 - (const IOSurfaceRef&)ioSurface {


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/107103

This ensures that IOSurface used on macOS has sRGB colorspace set so that it gets properly displayed on P3 devices. Otherwise the sRGB colors get stretched out to cover full P3 colorspace which results in oversaturated colors.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
