### PR TITLE
Fix issue about multi-engine loading assets throws exception after engines restart

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1356,6 +1356,7 @@ FILE: ../../../flutter/shell/platform/android/android_surface_software.cc
 FILE: ../../../flutter/shell/platform/android/android_surface_software.h
 FILE: ../../../flutter/shell/platform/android/apk_asset_provider.cc
 FILE: ../../../flutter/shell/platform/android/apk_asset_provider.h
+FILE: ../../../flutter/shell/platform/android/apk_asset_provider_unittests.cc
 FILE: ../../../flutter/shell/platform/android/context/android_context.cc
 FILE: ../../../flutter/shell/platform/android/context/android_context.h
 FILE: ../../../flutter/shell/platform/android/external_view_embedder/external_view_embedder.cc

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -41,6 +41,7 @@ executable("flutter_shell_native_unittests") {
   sources = [
     "android_context_gl_unittests.cc",
     "android_shell_holder_unittests.cc",
+    "apk_asset_provider_unittests.cc",
     "flutter_shell_native_unittests.cc",
   ]
   public_configs = [ "//flutter:config" ]

--- a/shell/platform/android/android_shell_holder.cc
+++ b/shell/platform/android/android_shell_holder.cc
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "flutter/shell/platform/android/apk_asset_provider.h"
 #define FML_USED_ON_EMBEDDER
 
 #include "flutter/shell/platform/android/android_shell_holder.h"

--- a/shell/platform/android/android_shell_holder.h
+++ b/shell/platform/android/android_shell_holder.h
@@ -15,6 +15,7 @@
 #include "flutter/shell/common/run_configuration.h"
 #include "flutter/shell/common/shell.h"
 #include "flutter/shell/common/thread_host.h"
+#include "flutter/shell/platform/android/apk_asset_provider.h"
 #include "flutter/shell/platform/android/jni/platform_view_android_jni.h"
 #include "flutter/shell/platform/android/platform_message_handler_android.h"
 #include "flutter/shell/platform/android/platform_view_android.h"
@@ -83,7 +84,7 @@ class AndroidShellHolder {
       const std::string& initial_route,
       const std::vector<std::string>& entrypoint_args) const;
 
-  void Launch(std::shared_ptr<AssetManager> asset_manager,
+  void Launch(std::unique_ptr<APKAssetProvider> apk_asset_provider,
               const std::string& entrypoint,
               const std::string& libraryUrl,
               const std::vector<std::string>& entrypoint_args);
@@ -95,7 +96,7 @@ class AndroidShellHolder {
   Rasterizer::Screenshot Screenshot(Rasterizer::ScreenshotType type,
                                     bool base64_encode);
 
-  void UpdateAssetManager(fml::RefPtr<flutter::AssetManager> asset_manager);
+  // void UpdateAssetManager(fml::RefPtr<flutter::AssetManager> asset_manager);
 
   void NotifyLowMemoryWarning();
 
@@ -112,7 +113,8 @@ class AndroidShellHolder {
   std::unique_ptr<Shell> shell_;
   bool is_valid_ = false;
   uint64_t next_pointer_flow_id_ = 0;
-  std::shared_ptr<AssetManager> asset_manager_;
+  // std::shared_ptr<AssetManager> asset_manager_;
+  std::unique_ptr<APKAssetProvider> apk_asset_provider_;
 
   //----------------------------------------------------------------------------
   /// @brief      Constructor with its components injected.
@@ -132,7 +134,6 @@ class AndroidShellHolder {
                      const fml::WeakPtr<PlatformViewAndroid>& platform_view);
   static void ThreadDestructCallback(void* value);
   std::optional<RunConfiguration> BuildRunConfiguration(
-      std::shared_ptr<flutter::AssetManager> asset_manager,
       const std::string& entrypoint,
       const std::string& libraryUrl,
       const std::vector<std::string>& entrypoint_args) const;

--- a/shell/platform/android/android_shell_holder.h
+++ b/shell/platform/android/android_shell_holder.h
@@ -96,8 +96,6 @@ class AndroidShellHolder {
   Rasterizer::Screenshot Screenshot(Rasterizer::ScreenshotType type,
                                     bool base64_encode);
 
-  // void UpdateAssetManager(fml::RefPtr<flutter::AssetManager> asset_manager);
-
   void NotifyLowMemoryWarning();
 
   const std::shared_ptr<PlatformMessageHandler>& GetPlatformMessageHandler()
@@ -113,7 +111,6 @@ class AndroidShellHolder {
   std::unique_ptr<Shell> shell_;
   bool is_valid_ = false;
   uint64_t next_pointer_flow_id_ = 0;
-  // std::shared_ptr<AssetManager> asset_manager_;
   std::unique_ptr<APKAssetProvider> apk_asset_provider_;
 
   //----------------------------------------------------------------------------

--- a/shell/platform/android/apk_asset_provider.cc
+++ b/shell/platform/android/apk_asset_provider.cc
@@ -49,8 +49,8 @@ class APKAssetProviderImpl : public APKAssetProviderInternal {
       const std::string& asset_name) const override {
     std::stringstream ss;
     ss << directory_.c_str() << "/" << asset_name;
-    AAsset* asset =
-        AAssetManager_open(asset_manager_, ss.str().c_str(), AASSET_MODE_BUFFER);
+    AAsset* asset = AAssetManager_open(asset_manager_, ss.str().c_str(),
+                                       AASSET_MODE_BUFFER);
     if (!asset) {
       return nullptr;
     }

--- a/shell/platform/android/apk_asset_provider.cc
+++ b/shell/platform/android/apk_asset_provider.cc
@@ -13,29 +13,6 @@
 
 namespace flutter {
 
-APKAssetProviderImpl::APKAssetProviderImpl(JNIEnv* env,
-                                           jobject jassetManager,
-                                           std::string directory)
-    : java_asset_manager_(env, jassetManager),
-      directory_(std::move(directory)) {
-  assetManager_ = AAssetManager_fromJava(env, jassetManager);
-}
-
-APKAssetProviderImpl::~APKAssetProviderImpl() = default;
-
-bool APKAssetProviderImpl::IsValid() const {
-  return true;
-}
-
-bool APKAssetProviderImpl::IsValidAfterAssetManagerChange() const {
-  return true;
-}
-
-// |AssetResolver|
-AssetResolver::AssetResolverType APKAssetProviderImpl::GetType() const {
-  return AssetResolver::AssetResolverType::kApkAssetProvider;
-}
-
 class APKAssetMapping : public fml::Mapping {
  public:
   explicit APKAssetMapping(AAsset* asset) : asset_(asset) {}
@@ -56,17 +33,72 @@ class APKAssetMapping : public fml::Mapping {
   FML_DISALLOW_COPY_AND_ASSIGN(APKAssetMapping);
 };
 
-std::unique_ptr<fml::Mapping> APKAssetProviderImpl::GetAsMapping(
-    const std::string& asset_name) const {
-  std::stringstream ss;
-  ss << directory_.c_str() << "/" << asset_name;
-  AAsset* asset =
-      AAssetManager_open(assetManager_, ss.str().c_str(), AASSET_MODE_BUFFER);
-  if (!asset) {
-    return nullptr;
+class APKAssetProviderImpl {
+ public:
+  explicit APKAssetProviderImpl(JNIEnv* env,
+                                jobject jassetManager,
+                                std::string directory)
+      : java_asset_manager_(env, jassetManager),
+        directory_(std::move(directory)) {
+    assetManager_ = AAssetManager_fromJava(env, jassetManager);
   }
 
-  return std::make_unique<APKAssetMapping>(asset);
+  ~APKAssetProviderImpl() = default;
+
+  std::unique_ptr<fml::Mapping> GetAsMapping(
+      const std::string& asset_name) const {
+    std::stringstream ss;
+    ss << directory_.c_str() << "/" << asset_name;
+    AAsset* asset =
+        AAssetManager_open(assetManager_, ss.str().c_str(), AASSET_MODE_BUFFER);
+    if (!asset) {
+      return nullptr;
+    }
+
+    return std::make_unique<APKAssetMapping>(asset);
+  };
+
+ private:
+  fml::jni::ScopedJavaGlobalRef<jobject> java_asset_manager_;
+  AAssetManager* assetManager_;
+  const std::string directory_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(APKAssetProviderImpl);
+};
+
+APKAssetProvider::APKAssetProvider(JNIEnv* env,
+                                   jobject assetManager,
+                                   std::string directory)
+    : impl_(std::make_shared<APKAssetProviderImpl>(env,
+                                                   assetManager,
+                                                   std::move(directory))) {}
+
+APKAssetProvider::APKAssetProvider(std::shared_ptr<APKAssetProviderImpl> impl)
+    : impl_(impl) {}
+
+// |AssetResolver|
+bool APKAssetProvider::IsValid() const {
+  return true;
+}
+
+// |AssetResolver|
+bool APKAssetProvider::IsValidAfterAssetManagerChange() const {
+  return true;
+}
+
+// |AssetResolver|
+AssetResolver::AssetResolverType APKAssetProvider::GetType() const {
+  return AssetResolver::AssetResolverType::kApkAssetProvider;
+}
+
+// |AssetResolver|
+std::unique_ptr<fml::Mapping> APKAssetProvider::GetAsMapping(
+    const std::string& asset_name) const {
+  return impl_->GetAsMapping(asset_name);
+}
+
+std::unique_ptr<APKAssetProvider> APKAssetProvider::Clone() const {
+  return std::make_unique<APKAssetProvider>(impl_);
 }
 
 }  // namespace flutter

--- a/shell/platform/android/apk_asset_provider.cc
+++ b/shell/platform/android/apk_asset_provider.cc
@@ -13,26 +13,26 @@
 
 namespace flutter {
 
-APKAssetProvider::APKAssetProvider(JNIEnv* env,
-                                   jobject jassetManager,
-                                   std::string directory)
+APKAssetProviderImpl::APKAssetProviderImpl(JNIEnv* env,
+                                           jobject jassetManager,
+                                           std::string directory)
     : java_asset_manager_(env, jassetManager),
       directory_(std::move(directory)) {
   assetManager_ = AAssetManager_fromJava(env, jassetManager);
 }
 
-APKAssetProvider::~APKAssetProvider() = default;
+APKAssetProviderImpl::~APKAssetProviderImpl() = default;
 
-bool APKAssetProvider::IsValid() const {
+bool APKAssetProviderImpl::IsValid() const {
   return true;
 }
 
-bool APKAssetProvider::IsValidAfterAssetManagerChange() const {
+bool APKAssetProviderImpl::IsValidAfterAssetManagerChange() const {
   return true;
 }
 
 // |AssetResolver|
-AssetResolver::AssetResolverType APKAssetProvider::GetType() const {
+AssetResolver::AssetResolverType APKAssetProviderImpl::GetType() const {
   return AssetResolver::AssetResolverType::kApkAssetProvider;
 }
 
@@ -56,7 +56,7 @@ class APKAssetMapping : public fml::Mapping {
   FML_DISALLOW_COPY_AND_ASSIGN(APKAssetMapping);
 };
 
-std::unique_ptr<fml::Mapping> APKAssetProvider::GetAsMapping(
+std::unique_ptr<fml::Mapping> APKAssetProviderImpl::GetAsMapping(
     const std::string& asset_name) const {
   std::stringstream ss;
   ss << directory_.c_str() << "/" << asset_name;

--- a/shell/platform/android/apk_asset_provider.h
+++ b/shell/platform/android/apk_asset_provider.h
@@ -7,7 +7,6 @@
 
 #include <android/asset_manager_jni.h>
 #include <jni.h>
-#include <memory>
 
 #include "flutter/assets/asset_resolver.h"
 #include "flutter/fml/memory/ref_counted.h"

--- a/shell/platform/android/apk_asset_provider.h
+++ b/shell/platform/android/apk_asset_provider.h
@@ -14,7 +14,14 @@
 
 namespace flutter {
 
-class APKAssetProviderImpl;
+class APKAssetProviderInternal {
+ public:
+  virtual std::unique_ptr<fml::Mapping> GetAsMapping(
+      const std::string& asset_name) const = 0;
+
+ protected:
+  virtual ~APKAssetProviderInternal() = default;
+};
 
 class APKAssetProvider final : public AssetResolver {
  public:
@@ -22,14 +29,22 @@ class APKAssetProvider final : public AssetResolver {
                             jobject assetManager,
                             std::string directory);
 
-  explicit APKAssetProvider(std::shared_ptr<APKAssetProviderImpl> impl);
+  explicit APKAssetProvider(std::shared_ptr<APKAssetProviderInternal> impl);
 
   ~APKAssetProvider() = default;
 
+  // Returns a new 'std::unique_ptr<APKAssetProvider>' with the same 'impl_' as
+  // this provider.
   std::unique_ptr<APKAssetProvider> Clone() const;
 
+  // Obtain a raw pointer to the APKAssetProviderInternal.
+  //
+  // This method is intended for use in tests. Callers must not
+  // delete the returned pointer.
+  APKAssetProviderInternal* GetImpl() const { return impl_.get(); }
+
  private:
-  std::shared_ptr<APKAssetProviderImpl> impl_;
+  std::shared_ptr<APKAssetProviderInternal> impl_;
 
   // |flutter::AssetResolver|
   bool IsValid() const override;

--- a/shell/platform/android/apk_asset_provider.h
+++ b/shell/platform/android/apk_asset_provider.h
@@ -14,17 +14,22 @@
 
 namespace flutter {
 
-class APKAssetProviderImpl final : public AssetResolver {
+class APKAssetProviderImpl;
+
+class APKAssetProvider final : public AssetResolver {
  public:
-  explicit APKAssetProviderImpl(JNIEnv* env,
-                                jobject assetManager,
-                                std::string directory);
-  ~APKAssetProviderImpl() override;
+  explicit APKAssetProvider(JNIEnv* env,
+                            jobject assetManager,
+                            std::string directory);
+
+  explicit APKAssetProvider(std::shared_ptr<APKAssetProviderImpl> impl);
+
+  ~APKAssetProvider() = default;
+
+  std::unique_ptr<APKAssetProvider> Clone() const;
 
  private:
-  fml::jni::ScopedJavaGlobalRef<jobject> java_asset_manager_;
-  AAssetManager* assetManager_;
-  const std::string directory_;
+  std::shared_ptr<APKAssetProviderImpl> impl_;
 
   // |flutter::AssetResolver|
   bool IsValid() const override;
@@ -38,48 +43,6 @@ class APKAssetProviderImpl final : public AssetResolver {
   // |flutter::AssetResolver|
   std::unique_ptr<fml::Mapping> GetAsMapping(
       const std::string& asset_name) const override;
-  friend class APKAssetProvider;
-  FML_DISALLOW_COPY_AND_ASSIGN(APKAssetProviderImpl);
-};
-
-class APKAssetProvider final : public AssetResolver {
- public:
-  explicit APKAssetProvider(JNIEnv* env,
-                            jobject assetManager,
-                            std::string directory)
-      : impl_(std::make_shared<APKAssetProviderImpl>(env,
-                                                     assetManager,
-                                                     std::move(directory))) {}
-
-  explicit APKAssetProvider(std::shared_ptr<APKAssetProviderImpl> impl)
-      : impl_(impl) {}
-  ~APKAssetProvider() = default;
-
-  std::unique_ptr<APKAssetProvider> Clone() {
-    return std::make_unique<APKAssetProvider>(impl_);
-  }
-
- private:
-  std::shared_ptr<APKAssetProviderImpl> impl_;
-
-  // |flutter::AssetResolver|
-  bool IsValid() const override { return impl_->IsValid(); }
-
-  // |flutter::AssetResolver|
-  bool IsValidAfterAssetManagerChange() const override {
-    return impl_->IsValidAfterAssetManagerChange();
-  }
-
-  // |AssetResolver|
-  AssetResolver::AssetResolverType GetType() const override {
-    return impl_->GetType();
-  }
-
-  // |flutter::AssetResolver|
-  std::unique_ptr<fml::Mapping> GetAsMapping(
-      const std::string& asset_name) const override {
-    return impl_->GetAsMapping(asset_name);
-  }
 
   FML_DISALLOW_COPY_AND_ASSIGN(APKAssetProvider);
 };

--- a/shell/platform/android/apk_asset_provider.h
+++ b/shell/platform/android/apk_asset_provider.h
@@ -7,6 +7,7 @@
 
 #include <android/asset_manager_jni.h>
 #include <jni.h>
+#include <memory>
 
 #include "flutter/assets/asset_resolver.h"
 #include "flutter/fml/memory/ref_counted.h"
@@ -14,12 +15,12 @@
 
 namespace flutter {
 
-class APKAssetProvider final : public AssetResolver {
+class APKAssetProviderImpl final : public AssetResolver {
  public:
-  explicit APKAssetProvider(JNIEnv* env,
-                            jobject assetManager,
-                            std::string directory);
-  ~APKAssetProvider() override;
+  explicit APKAssetProviderImpl(JNIEnv* env,
+                                jobject assetManager,
+                                std::string directory);
+  ~APKAssetProviderImpl() override;
 
  private:
   fml::jni::ScopedJavaGlobalRef<jobject> java_asset_manager_;
@@ -38,6 +39,48 @@ class APKAssetProvider final : public AssetResolver {
   // |flutter::AssetResolver|
   std::unique_ptr<fml::Mapping> GetAsMapping(
       const std::string& asset_name) const override;
+  friend class APKAssetProvider;
+  FML_DISALLOW_COPY_AND_ASSIGN(APKAssetProviderImpl);
+};
+
+class APKAssetProvider final : public AssetResolver {
+ public:
+  explicit APKAssetProvider(JNIEnv* env,
+                            jobject assetManager,
+                            std::string directory)
+      : impl_(std::make_shared<APKAssetProviderImpl>(env,
+                                                     assetManager,
+                                                     std::move(directory))) {}
+
+  explicit APKAssetProvider(std::shared_ptr<APKAssetProviderImpl> impl)
+      : impl_(impl) {}
+  ~APKAssetProvider() = default;
+
+  std::unique_ptr<APKAssetProvider> Clone() {
+    return std::make_unique<APKAssetProvider>(impl_);
+  }
+
+ private:
+  std::shared_ptr<APKAssetProviderImpl> impl_;
+
+  // |flutter::AssetResolver|
+  bool IsValid() const override { return impl_->IsValid(); }
+
+  // |flutter::AssetResolver|
+  bool IsValidAfterAssetManagerChange() const override {
+    return impl_->IsValidAfterAssetManagerChange();
+  }
+
+  // |AssetResolver|
+  AssetResolver::AssetResolverType GetType() const override {
+    return impl_->GetType();
+  }
+
+  // |flutter::AssetResolver|
+  std::unique_ptr<fml::Mapping> GetAsMapping(
+      const std::string& asset_name) const override {
+    return impl_->GetAsMapping(asset_name);
+  }
 
   FML_DISALLOW_COPY_AND_ASSIGN(APKAssetProvider);
 };

--- a/shell/platform/android/apk_asset_provider_unittests.cc
+++ b/shell/platform/android/apk_asset_provider_unittests.cc
@@ -1,0 +1,25 @@
+#include "flutter/shell/platform/android/apk_asset_provider.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace flutter {
+namespace testing {
+class MockAPKAssetProviderImpl : public APKAssetProviderInternal {
+ public:
+  MOCK_CONST_METHOD1(
+      GetAsMapping,
+      std::unique_ptr<fml::Mapping>(const std::string& asset_name));
+};
+
+TEST(APKAssetProvider, Clone) {
+  auto first_provider = std::make_unique<APKAssetProvider>(
+      std::make_shared<MockAPKAssetProviderImpl>());
+  auto second_provider = std::make_unique<APKAssetProvider>(
+      std::make_shared<MockAPKAssetProviderImpl>());
+  auto third_provider = first_provider->Clone();
+
+  ASSERT_NE(first_provider->GetImpl(), second_provider->GetImpl());
+  ASSERT_EQ(first_provider->GetImpl(), third_provider->GetImpl());
+}
+}  // namespace testing
+}  // namespace flutter

--- a/shell/platform/android/platform_view_android_jni_impl.cc
+++ b/shell/platform/android/platform_view_android_jni_impl.cc
@@ -241,20 +241,17 @@ static void RunBundleAndSnapshotFromLibrary(JNIEnv* env,
                                             jstring jLibraryUrl,
                                             jobject jAssetManager,
                                             jobject jEntrypointArgs) {
-  auto asset_manager = std::make_shared<flutter::AssetManager>();
-
-  asset_manager->PushBack(std::make_unique<flutter::APKAssetProvider>(
-      env,                                             // jni environment
-      jAssetManager,                                   // asset manager
-      fml::jni::JavaStringToString(env, jBundlePath))  // apk asset dir
+  auto apk_asset_provider = std::make_unique<flutter::APKAssetProvider>(
+      env,                                            // jni environment
+      jAssetManager,                                  // asset manager
+      fml::jni::JavaStringToString(env, jBundlePath)  // apk asset dir
   );
-
   auto entrypoint = fml::jni::JavaStringToString(env, jEntrypoint);
   auto libraryUrl = fml::jni::JavaStringToString(env, jLibraryUrl);
   auto entrypoint_args = fml::jni::StringListToVector(env, jEntrypointArgs);
 
-  ANDROID_SHELL_HOLDER->Launch(asset_manager, entrypoint, libraryUrl,
-                               entrypoint_args);
+  ANDROID_SHELL_HOLDER->Launch(std::move(apk_asset_provider), entrypoint,
+                               libraryUrl, entrypoint_args);
 }
 
 static jobject LookupCallbackInformation(JNIEnv* env,


### PR DESCRIPTION
fix https://github.com/flutter/flutter/issues/107091

On the Android platform, the current implementation is that multiple lightweight engines share the same `AssetManager`, and the relationship between the engine and the `AssetManager` is Nv1. After engine restart, each engine will regenerate its own `AssetManager`, and the relationship between the engine and the `AssetManager` becomes 1v1.

Due to the following code, only one of these new AssetManagers will hold the original `APKAssetProvider`.
https://github.com/flutter/engine/blob/main/shell/common/shell.cc#L1632-L1641
``` c++
  // Preserve any original asset resolvers to avoid syncing unchanged assets
  // over the DevFS connection.
  auto old_asset_manager = engine_->GetAssetManager();
  if (old_asset_manager != nullptr) {
    for (auto& old_resolver : old_asset_manager->TakeResolvers()) {
      if (old_resolver->IsValidAfterAssetManagerChange()) {
        configuration.AddAssetResolver(std::move(old_resolver));
      }
    }
  }
```

## proposed solution
1. Lightweight engines no longer share `AssetManager`, each engine has own `AssetManager`, and each `AssetManager` has an `APKAssetProvider` inside.

2. There is an `APKAssetProviderImpl` inside the `APKAssetProvider`, which is used to encapsulate the specific implementation. In a lightweight engine scenario, multiple `APKAssetProvider`s share the same `APKAssetProviderImpl`

3. `APKAssetProvider` provides a `Clone` method to create a new `APKAssetProvider`, the new provider shares `APKAssetProviderImpl` with the current provider.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

