### PR TITLE
Fix typo in Impeller FAQ

### DIFF
--- a/impeller/docs/faq.md
+++ b/impeller/docs/faq.md
@@ -15,7 +15,7 @@
   * When running with Impeller, Flutter does not create a Skia graphics context.
   * However, while Impeller still performs text rendering, text layout and
     shaping needs to be done by a separate component. This component happens to
-    the SkParagraph which is part of Skia.
+    be SkParagraph which is part of Skia.
   * Similarly, Impeller does not perform image decompression. Flutter uses a
     standard set of codecs wrapped by Skia before querying the system supplied
     image formats.


### PR DESCRIPTION
The sentence explaining why Skia is used for text rendering is confusing due to a typo. This PR fixes the typo and should make the explanation clear.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
