### PR TITLE
[fuchsia] Enable CQ on Fuchsia release branches.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -8,6 +8,7 @@
 enabled_branches:
   - main
   - flutter-\d+\.\d+-candidate\.\d+
+  - fuchsia_r\d+
 
 platform_properties:
   linux:


### PR DESCRIPTION
Used to validate cherrypicks into Fuchsia releases.