### PR TITLE
[fuchsia] fidl_dart - Use the tools from the proper directory

### DIFF
--- a/tools/fuchsia/dart/fidl_dart.gni
+++ b/tools/fuchsia/dart/fidl_dart.gni
@@ -2,12 +2,12 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//build/fuchsia/sdk.gni")
 import("//flutter/tools/executable_action.gni")
 import("//flutter/tools/fuchsia/dart/dart_library.gni")
 import("//flutter/tools/fuchsia/dart/toolchain.gni")
 import("//flutter/tools/fuchsia/fidl/fidl.gni")
 import("//flutter/tools/fuchsia/fidl/toolchain.gni")
+import("//flutter/tools/fuchsia/gn-sdk/config/config.gni")
 
 # Generates some Dart bindings for a FIDL library.
 #
@@ -41,7 +41,7 @@ template("fidl_dart") {
   executable_action(generation_target_name) {
     visibility = [ ":*" ]
 
-    tool = "${fuchsia_sdk_path}/tools/fidlgen_dart"
+    tool = "${fuchsia_tool_dir}/fidlgen_dart"
 
     inputs = [ json_representation ]
 


### PR DESCRIPTION
fidl_dart.gni currently uses the tools from the SDK's top level tools directory (/tools). These tools will soon be removed as they are a simple copy of the tools in the architecture-specific subdirectory (e.g. /tools/x64).