### PR TITLE
Rename toGpuImage to toImageSync

### DIFF
--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -21,22 +21,22 @@ class Scene extends NativeFieldWrapperClass1 {
   @pragma('vm:entry-point')
   Scene._();
 
-  /// Creates a GPU resident image from this scene.
+  /// Synchronously creates a handle to an image from this scene.
   ///
-  /// {@macro dart.ui.painting.Picture.toGpuImage}
-  Image toGpuImage(int width, int height) {
+  /// {@macro dart.ui.painting.Picture.toImageSync}
+  Image toImageSync(int width, int height) {
     if (width <= 0 || height <= 0) {
       throw Exception('Invalid image dimensions.');
     }
 
     final _Image image = _Image._();
-    final String? result =  _toGpuImage(width, height, image);
+    final String? result =  _toImageSync(width, height, image);
     if (result != null) {
       throw PictureRasterizationException._(result);
     }
     return Image._(image, image.width, image.height);
   }
-  String? _toGpuImage(int width, int height, _Image outImage) native 'Scene_toGpuImage';
+  String? _toImageSync(int width, int height, _Image outImage) native 'Scene_toImageSync';
 
   /// Creates a raster image representation of the current state of the scene.
   /// This is a slow operation that is performed on a background thread.

--- a/lib/ui/compositing/scene.cc
+++ b/lib/ui/compositing/scene.cc
@@ -22,7 +22,7 @@ namespace flutter {
 IMPLEMENT_WRAPPERTYPEINFO(ui, Scene);
 
 #define FOR_EACH_BINDING(V) \
-  V(Scene, toGpuImage)      \
+  V(Scene, toImageSync)     \
   V(Scene, toImage)         \
   V(Scene, dispose)
 
@@ -67,10 +67,10 @@ void Scene::dispose() {
   ClearDartWrapper();
 }
 
-Dart_Handle Scene::toGpuImage(uint32_t width,
-                              uint32_t height,
-                              Dart_Handle raw_image_handle) {
-  TRACE_EVENT0("flutter", "Scene::toGpuImage");
+Dart_Handle Scene::toImageSync(uint32_t width,
+                               uint32_t height,
+                               Dart_Handle raw_image_handle) {
+  TRACE_EVENT0("flutter", "Scene::toImageSync");
 
   if (!layer_tree_) {
     return tonic::ToDart("Scene did not contain a layer tree.");
@@ -81,7 +81,7 @@ Dart_Handle Scene::toGpuImage(uint32_t width,
     return tonic::ToDart("Could not flatten scene into a layer tree.");
   }
 
-  Picture::RasterizeToGpuImage(picture, width, height, raw_image_handle);
+  Picture::RasterizeToImageSync(picture, width, height, raw_image_handle);
   return Dart_Null();
 }
 

--- a/lib/ui/compositing/scene.h
+++ b/lib/ui/compositing/scene.h
@@ -32,9 +32,9 @@ class Scene : public RefCountedDartWrappable<Scene> {
 
   std::unique_ptr<flutter::LayerTree> takeLayerTree();
 
-  Dart_Handle toGpuImage(uint32_t width,
-                         uint32_t height,
-                         Dart_Handle raw_image_handle);
+  Dart_Handle toImageSync(uint32_t width,
+                          uint32_t height,
+                          Dart_Handle raw_image_handle);
 
   Dart_Handle toImage(uint32_t width,
                       uint32_t height,

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -5375,9 +5375,9 @@ class Picture extends NativeFieldWrapperClass1 {
   }
   String? _toImage(int width, int height, _Callback<_Image?> callback) native 'Picture_toImage';
 
-  /// Creates a GPU resident image from this picture.
+  /// Synchronously creates a handle to an image of this picture.
   ///
-  /// {@template dart.ui.painting.Picture.toGpuImage}
+  /// {@template dart.ui.painting.Picture.toImageSync}
   /// The returned image will be `width` pixels wide and `height` pixels high.
   /// The picture is rasterized within the 0 (left), 0 (top), `width` (right),
   /// `height` (bottom) bounds. Content outside these bounds is clipped.
@@ -5386,20 +5386,23 @@ class Picture extends NativeFieldWrapperClass1 {
   /// asynchronously. If the rasterization fails, an exception will be thrown
   /// when the image is drawn to a [Canvas].
   ///
-  /// In the flutter_tester, this will always created a light gray and white
-  /// checkerboard bitmap with the requested dimensions.
+  /// If a GPU context is available, this image will be created as GPU resident
+  /// and not copied back to the host. This means the image will be more
+  /// efficient to draw.
+  ///
+  /// If no GPU context is availalbe, the image will be rasterized on the CPU.
   /// {@endtemplate}
-  Image toGpuImage(int width, int height) {
+  Image toImageSync(int width, int height) {
     assert(!_disposed);
     if (width <= 0 || height <= 0) {
       throw Exception('Invalid image dimensions.');
     }
 
     final _Image image = _Image._();
-    _toGpuImage(width, height, image);
+    _toImageSync(width, height, image);
     return Image._(image, image.width, image.height);
   }
-  void _toGpuImage(int width, int height, _Image outImage) native 'Picture_toGpuImage';
+  void _toImageSync(int width, int height, _Image outImage) native 'Picture_toImageSync';
 
   /// Release the resources used by this object. The object is no longer usable
   /// after this method is called.
@@ -5909,7 +5912,7 @@ Future<T> _futurize<T>(_Callbacker<T> callbacker) {
 }
 
 /// An exception thrown by [Canvas.drawImage] and related methods when drawing
-/// an [Image] created via [Picture.toGpuImage] that is in an invalid state.
+/// an [Image] created via [Picture.toImageSync] that is in an invalid state.
 ///
 /// This exception may be thrown if the requested image dimensions exceeded the
 /// maximum 2D texture size allowed by the GPU, or if no GPU surface or context
@@ -5920,7 +5923,7 @@ class PictureRasterizationException implements Exception {
   /// A string containing details about the failure.
   final String message;
 
-  /// If available, the stack trace at the time [Picture.toGpuImage] was called.
+  /// If available, the stack trace at the time [Picture.toImageSync] was called.
   final StackTrace? stack;
 
   @override

--- a/lib/ui/painting/image_encoding.cc
+++ b/lib/ui/painting/image_encoding.cc
@@ -157,11 +157,11 @@ sk_sp<SkData> CopyImageByteData(sk_sp<SkImage> raster_image,
     FML_LOG(ERROR) << "Could not copy pixels from the raster image.";
     return nullptr;
   }
-  FML_LOG(ERROR) << "pct: " << pixmap.colorType() << " .. " << color_type;
+
   // The color types already match. No need to swizzle. Return early.
-  // if (pixmap.colorType() == color_type && pixmap.alphaType() == alpha_type) {
-  //   return SkData::MakeWithCopy(pixmap.addr(), pixmap.computeByteSize());
-  // }
+  if (pixmap.colorType() == color_type && pixmap.alphaType() == alpha_type) {
+    return SkData::MakeWithCopy(pixmap.addr(), pixmap.computeByteSize());
+  }
 
   // Perform swizzle if the type doesnt match the specification.
   auto surface = SkSurface::MakeRaster(

--- a/lib/ui/painting/image_encoding.cc
+++ b/lib/ui/painting/image_encoding.cc
@@ -157,11 +157,11 @@ sk_sp<SkData> CopyImageByteData(sk_sp<SkImage> raster_image,
     FML_LOG(ERROR) << "Could not copy pixels from the raster image.";
     return nullptr;
   }
-
+  FML_LOG(ERROR) << "pct: " << pixmap.colorType() << " .. " << color_type;
   // The color types already match. No need to swizzle. Return early.
-  if (pixmap.colorType() == color_type && pixmap.alphaType() == alpha_type) {
-    return SkData::MakeWithCopy(pixmap.addr(), pixmap.computeByteSize());
-  }
+  // if (pixmap.colorType() == color_type && pixmap.alphaType() == alpha_type) {
+  //   return SkData::MakeWithCopy(pixmap.addr(), pixmap.computeByteSize());
+  // }
 
   // Perform swizzle if the type doesnt match the specification.
   auto surface = SkSurface::MakeRaster(

--- a/lib/ui/painting/picture.cc
+++ b/lib/ui/painting/picture.cc
@@ -23,7 +23,7 @@ IMPLEMENT_WRAPPERTYPEINFO(ui, Picture);
 
 #define FOR_EACH_BINDING(V) \
   V(Picture, toImage)       \
-  V(Picture, toGpuImage)    \
+  V(Picture, toImageSync)   \
   V(Picture, dispose)       \
   V(Picture, GetAllocationSize)
 
@@ -53,19 +53,19 @@ Dart_Handle Picture::toImage(uint32_t width,
                           raw_image_callback);
 }
 
-void Picture::toGpuImage(uint32_t width,
-                         uint32_t height,
-                         Dart_Handle raw_image_handle) {
+void Picture::toImageSync(uint32_t width,
+                          uint32_t height,
+                          Dart_Handle raw_image_handle) {
   FML_DCHECK(display_list_.skia_object());
-  RasterizeToGpuImage(display_list_.skia_object(), width, height,
-                      raw_image_handle);
+  RasterizeToImageSync(display_list_.skia_object(), width, height,
+                       raw_image_handle);
 }
 
 // static
-void Picture::RasterizeToGpuImage(sk_sp<DisplayList> display_list,
-                                  uint32_t width,
-                                  uint32_t height,
-                                  Dart_Handle raw_image_handle) {
+void Picture::RasterizeToImageSync(sk_sp<DisplayList> display_list,
+                                   uint32_t width,
+                                   uint32_t height,
+                                   Dart_Handle raw_image_handle) {
   auto* dart_state = UIDartState::Current();
   auto unref_queue = dart_state->GetSkiaUnrefQueue();
   auto snapshot_delegate = dart_state->GetSnapshotDelegate();

--- a/lib/ui/painting/picture.h
+++ b/lib/ui/painting/picture.h
@@ -37,9 +37,9 @@ class Picture : public RefCountedDartWrappable<Picture> {
                       uint32_t height,
                       Dart_Handle raw_image_callback);
 
-  void toGpuImage(uint32_t width,
-                  uint32_t height,
-                  Dart_Handle raw_image_handle);
+  void toImageSync(uint32_t width,
+                   uint32_t height,
+                   Dart_Handle raw_image_handle);
 
   void dispose();
 
@@ -47,10 +47,10 @@ class Picture : public RefCountedDartWrappable<Picture> {
 
   static void RegisterNatives(tonic::DartLibraryNatives* natives);
 
-  static void RasterizeToGpuImage(sk_sp<DisplayList> display_list,
-                                  uint32_t width,
-                                  uint32_t height,
-                                  Dart_Handle raw_image_handle);
+  static void RasterizeImageSync(sk_sp<DisplayList> display_list,
+                                 uint32_t width,
+                                 uint32_t height,
+                                 Dart_Handle raw_image_handle);
 
   static Dart_Handle RasterizeToImage(sk_sp<DisplayList> display_list,
                                       uint32_t width,

--- a/lib/ui/painting/picture.h
+++ b/lib/ui/painting/picture.h
@@ -47,10 +47,10 @@ class Picture : public RefCountedDartWrappable<Picture> {
 
   static void RegisterNatives(tonic::DartLibraryNatives* natives);
 
-  static void RasterizeImageSync(sk_sp<DisplayList> display_list,
-                                 uint32_t width,
-                                 uint32_t height,
-                                 Dart_Handle raw_image_handle);
+  static void RasterizeToImageSync(sk_sp<DisplayList> display_list,
+                                   uint32_t width,
+                                   uint32_t height,
+                                   Dart_Handle raw_image_handle);
 
   static Dart_Handle RasterizeToImage(sk_sp<DisplayList> display_list,
                                       uint32_t width,

--- a/lib/web_ui/lib/canvas.dart
+++ b/lib/web_ui/lib/canvas.dart
@@ -155,7 +155,7 @@ abstract class Canvas {
 
 abstract class Picture {
   Future<Image> toImage(int width, int height);
-  Image toGpuImage(int width, int height);
+  Image toImageSync(int width, int height);
   void dispose();
   bool get debugDisposed;
   int get approximateBytesUsed;

--- a/lib/web_ui/lib/compositing.dart
+++ b/lib/web_ui/lib/compositing.dart
@@ -6,7 +6,7 @@ part of ui;
 
 abstract class Scene {
   Future<Image> toImage(int width, int height);
-  Image toGpuImage(int width, int height);
+  Image toImageSync(int width, int height);
   void dispose();
 }
 

--- a/lib/web_ui/lib/src/engine/canvaskit/layer_scene_builder.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/layer_scene_builder.dart
@@ -27,9 +27,9 @@ class LayerScene implements ui.Scene {
   }
 
   @override
-  ui.Image toGpuImage(int width, int height) {
+  ui.Image toImageSync(int width, int height) {
     final ui.Picture picture = layerTree.flatten();
-    return picture.toGpuImage(width, height);
+    return picture.toImageSync(width, height);
   }
 }
 

--- a/lib/web_ui/lib/src/engine/canvaskit/picture.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/picture.dart
@@ -92,11 +92,11 @@ class CkPicture extends ManagedSkiaObject<SkPicture> implements ui.Picture {
 
   @override
   Future<ui.Image> toImage(int width, int height) async {
-    return toGpuImage(width, height);
+    return toImageSync(width, height);
   }
 
   @override
-  ui.Image toGpuImage(int width, int height) {
+  ui.Image toImageSync(int width, int height) {
     assert(debugCheckNotDisposed('Cannot convert picture to image.'));
     final SkSurface skSurface = canvasKit.MakeSurface(width, height);
     final SkCanvas skCanvas = skSurface.getCanvas();

--- a/lib/web_ui/lib/src/engine/html/scene.dart
+++ b/lib/web_ui/lib/src/engine/html/scene.dart
@@ -25,8 +25,8 @@ class SurfaceScene implements ui.Scene {
   }
 
   @override
-  ui.Image toGpuImage(int width, int height) {
-    throw UnsupportedError('toGpuImage is not supported on the Web');
+  ui.Image toImageSync(int width, int height) {
+    throw UnsupportedError('toImageSync is not supported on the Web');
   }
 
   /// Releases the resources used by this scene.

--- a/lib/web_ui/lib/src/engine/picture.dart
+++ b/lib/web_ui/lib/src/engine/picture.dart
@@ -89,8 +89,8 @@ class EnginePicture implements ui.Picture {
   }
 
   @override
-  ui.Image toGpuImage(int width, int height) {
-    throw UnsupportedError('toGpuImage is not supported on the HTML backend. Use drawPicture instead, or toImage.');
+  ui.Image toImageSync(int width, int height) {
+    throw UnsupportedError('toImageSync is not supported on the HTML backend. Use drawPicture instead, or toImage.');
   }
 
   bool _disposed = false;

--- a/lib/web_ui/test/canvaskit/picture_test.dart
+++ b/lib/web_ui/test/canvaskit/picture_test.dart
@@ -86,13 +86,13 @@ void testMain() {
       });
     });
 
-    test('toGpuImage', () async {
+    test('toImageSync', () async {
       const ui.Color color = ui.Color(0xFFAAAAAA);
       final ui.PictureRecorder recorder = ui.PictureRecorder();
       final ui.Canvas canvas = ui.Canvas(recorder);
       canvas.drawPaint(ui.Paint()..color = color);
       final ui.Picture picture = recorder.endRecording();
-      final ui.Image image = picture.toGpuImage(10, 15);
+      final ui.Image image = picture.toImageSync(10, 15);
 
       expect(image.width, 10);
       expect(image.height, 15);

--- a/shell/common/fixtures/shell_test.dart
+++ b/shell/common/fixtures/shell_test.dart
@@ -324,13 +324,13 @@ void scene_with_red_box() {
 
 
 @pragma('vm:entry-point')
-Future<void> toGpuImage() async {
+Future<void> toImageSync() async {
   final PictureRecorder recorder = PictureRecorder();
   final Canvas canvas = Canvas(recorder);
   canvas.drawPaint(Paint()..color = const Color(0xFFAAAAAA));
   final Picture picture = recorder.endRecording();
 
-  final Image image = picture.toGpuImage(20, 25);
+  final Image image = picture.toImageSync(20, 25);
   void expect(Object? a, Object? b) {
     if (a != b) {
       throw 'Expected $a to == $b';

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -248,28 +248,25 @@ bool Rasterizer::ShouldResubmitFrame(const RasterStatus& raster_status) {
 }
 
 namespace {
-std::pair<sk_sp<SkImage>, std::string> MakeBitmapImage(SkISize picture_size) {
+std::pair<sk_sp<SkImage>, std::string> MakeBitmapImage(
+    sk_sp<DisplayList> display_list,
+    SkImageInfo image_info) {
   // Use 16384 as a proxy for the maximum texture size for a GPU image.
   // This is meant to be large enough to avoid false positives in test contexts,
   // but not so artificially large to be completely unrealistic on any platform.
   // This limit is taken from the Metal specification. D3D, Vulkan, and GL
   // generally have lower limits.
-  if (picture_size.width() > 16384 || picture_size.height() > 16384) {
+  if (image_info.width() > 16384 || image_info.height() > 16384) {
     return {nullptr, "unable to create render target at specified size"};
   }
-  SkBitmap bitmap;
-  if (!bitmap.tryAllocN32Pixels(picture_size.width(), picture_size.height())) {
-    return {nullptr, "unable to create render target at specified size"};
-  }
-  bitmap.eraseColor(SK_ColorLTGRAY);
-  uint32_t half_width = std::floor(picture_size.width() / 2);
-  uint32_t half_height = std::floor(picture_size.height() / 2);
-  bitmap.erase(SK_ColorWHITE, SkIRect::MakeLTRB(0, 0, half_width, half_height));
-  bitmap.erase(SK_ColorWHITE,
-               SkIRect::MakeLTRB(half_width, half_height, picture_size.width(),
-                                 picture_size.height()));
-  bitmap.setImmutable();
-  return {bitmap.asImage(), ""};
+
+  sk_sp<SkSurface> surface = SkSurface::MakeRaster(image_info);
+  SkCanvas* canvas = surface->getCanvas();
+  canvas->clear(SK_ColorTRANSPARENT);
+  display_list->RenderTo(canvas);
+
+  sk_sp<SkImage> image = surface->makeImageSnapshot();
+  return {image, image ? "" : "Unable to create image"};
 }
 }  // namespace
 
@@ -279,23 +276,22 @@ std::pair<sk_sp<SkImage>, std::string> Rasterizer::MakeGpuImage(
   TRACE_EVENT0("flutter", "Rasterizer::MakeGpuImage");
   FML_DCHECK(display_list);
 
-  switch (gpu_image_behavior_) {
-    case MakeGpuImageBehavior::kGpu:
-      break;
-    case MakeGpuImageBehavior::kBitmap:
-      return MakeBitmapImage(picture_size);
-  }
+  const SkImageInfo image_info = SkImageInfo::MakeN32Premul(picture_size);
+  bool gpu_available = true;
+  delegate_.GetIsGpuDisabledSyncSwitch()->Execute(
+      fml::SyncSwitch::Handlers().SetIfTrue(
+          [&gpu_available] { gpu_available = false; }));
 
-  if (!surface_) {
-    return {nullptr, "GPU surface unavilable"};
+  if (!gpu_available || !surface_ ||
+      gpu_image_behavior_ == MakeGpuImageBehavior::kBitmap) {
+    return MakeBitmapImage(std::move(display_list), image_info);
   }
 
   auto* context = surface_->GetContext();
   if (!context) {
-    return {nullptr, "GPU context unavailable"};
+    return MakeBitmapImage(std::move(display_list), image_info);
   }
 
-  const SkImageInfo image_info = SkImageInfo::MakeN32Premul(picture_size);
   sk_sp<SkSurface> surface =
       SkSurface::MakeRenderTarget(context, SkBudgeted::kYes, image_info);
   if (!surface) {

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -3754,7 +3754,7 @@ TEST_F(ShellTest, SpawnWorksWithOnError) {
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
 }
 
-TEST_F(ShellTest, PictureToGpuImage) {
+TEST_F(ShellTest, PictureToImageSync) {
 #if !SHELL_ENABLE_GL
   // GL emulation does not exist on Fuchsia.
   GTEST_SKIP();
@@ -3778,7 +3778,7 @@ TEST_F(ShellTest, PictureToGpuImage) {
   ASSERT_TRUE(shell->IsSetup());
   auto configuration = RunConfiguration::InferFromSettings(settings);
   PlatformViewNotifyCreated(shell.get());
-  configuration.SetEntrypoint("toGpuImage");
+  configuration.SetEntrypoint("toImageSync");
   RunEngine(shell.get(), std::move(configuration));
   PumpOneFrame(shell.get());
 

--- a/testing/dart/canvas_test.dart
+++ b/testing/dart/canvas_test.dart
@@ -501,10 +501,10 @@ void main() {
 
     expect(data, isNotNull);
     expect(data!.lengthInBytes, 6 * 8 * 4);
-    final Uint32List bytes = data.buffer.asUint32List();
-    print(color.value.toRadixString(16));
-    print(bytes.first.toRadixString(16));
-    expect(bytes, List<int>.filled(bytes.length, color.value));
+    expect(data.buffer.asUint8List()[0], 0x12);
+    expect(data.buffer.asUint8List()[1], 0x34);
+    expect(data.buffer.asUint8List()[2], 0x56);
+    expect(data.buffer.asUint8List()[3], 0xFF);
   });
 
   test('Canvas.drawParagraph throws when Paragraph.layout was not called', () async {

--- a/testing/dart/canvas_test.dart
+++ b/testing/dart/canvas_test.dart
@@ -410,12 +410,12 @@ void main() {
     expect(areEqual, true);
   }, skip: !Platform.isLinux); // https://github.com/flutter/flutter/issues/53784
 
-  test('toGpuImage - too big', () async {
+  test('toImageSync - too big', () async {
     PictureRecorder recorder = PictureRecorder();
     Canvas canvas = Canvas(recorder);
     canvas.drawPaint(Paint()..color = const Color(0xFF123456));
     final Picture picture = recorder.endRecording();
-    final Image image = picture.toGpuImage(300000, 4000000);
+    final Image image = picture.toImageSync(300000, 4000000);
     picture.dispose();
 
     expect(image.width, 300000);
@@ -454,12 +454,12 @@ void main() {
     );
   });
 
-  test('toGpuImage - succeeds', () async {
+  test('toImageSync - succeeds', () async {
     PictureRecorder recorder = PictureRecorder();
     Canvas canvas = Canvas(recorder);
     canvas.drawPaint(Paint()..color = const Color(0xFF123456));
     final Picture picture = recorder.endRecording();
-    final Image image = picture.toGpuImage(30, 40);
+    final Image image = picture.toImageSync(30, 40);
     picture.dispose();
 
     expect(image.width, 30);
@@ -485,36 +485,26 @@ void main() {
     );
   });
 
-  test('toGpuImage - toByteData', () async {
+  test('toImageSync - toByteData', () async {
     const Color color = Color(0xFF123456);
     final PictureRecorder recorder = PictureRecorder();
     final Canvas canvas = Canvas(recorder);
     canvas.drawPaint(Paint()..color = color);
     final Picture picture = recorder.endRecording();
-    final Image image = picture.toGpuImage(6, 8);
+    final Image image = picture.toImageSync(6, 8);
     picture.dispose();
 
     expect(image.width, 6);
     expect(image.height, 8);
 
-    final ByteData? data = await image.toByteData();
+    final ByteData? data = await image.toByteData(format: ImageByteFormat.rawRgba);
 
     expect(data, isNotNull);
     expect(data!.lengthInBytes, 6 * 8 * 4);
     final Uint32List bytes = data.buffer.asUint32List();
-    // Draws a checkerboard due to flutter_tester not having a GPU context.
-    const int white = 0xFFFFFFFF;
-    const int grey  = 0xFFCCCCCC;
-    expect(bytes, const <int>[
-      white, white, white, grey,  grey,  grey, //
-      white, white, white, grey,  grey,  grey,
-      white, white, white, grey,  grey,  grey,
-      white, white, white, grey,  grey,  grey,
-      grey,  grey,  grey,  white, white, white,
-      grey,  grey,  grey,  white, white, white,
-      grey,  grey,  grey,  white, white, white,
-      grey,  grey,  grey,  white, white, white,
-    ]);
+    print(color.value.toRadixString(16));
+    print(bytes.first.toRadixString(16));
+    expect(bytes, List<int>.filled(bytes.length, color.value));
   });
 
   test('Canvas.drawParagraph throws when Paragraph.layout was not called', () async {

--- a/testing/dart/compositing_test.dart
+++ b/testing/dart/compositing_test.dart
@@ -30,8 +30,10 @@ void main() {
 
     expect(data, isNotNull);
     expect(data!.lengthInBytes, 6 * 8 * 4);
-    final Uint32List bytes = data.buffer.asUint32List();
-    expect(bytes, List<int>.filled(bytes.length, color.value));
+    expect(data.buffer.asUint8List()[0], 0x12);
+    expect(data.buffer.asUint8List()[1], 0x34);
+    expect(data.buffer.asUint8List()[2], 0x56);
+    expect(data.buffer.asUint8List()[3], 0xFF);
   });
 
   test('addPicture with disposed picture does not crash', () {

--- a/testing/dart/compositing_test.dart
+++ b/testing/dart/compositing_test.dart
@@ -11,7 +11,8 @@ void main() {
   test('Scene.toImageSync succeeds', () async {
     final PictureRecorder recorder = PictureRecorder();
     final Canvas canvas = Canvas(recorder);
-    canvas.drawPaint(Paint()..color = const Color(0xFF123456));
+    const Color color = Color(0xFF123456);
+    canvas.drawPaint(Paint()..color = color);
     final Picture picture = recorder.endRecording();
     final SceneBuilder builder = SceneBuilder();
     builder.pushOffset(10, 10);
@@ -30,19 +31,7 @@ void main() {
     expect(data, isNotNull);
     expect(data!.lengthInBytes, 6 * 8 * 4);
     final Uint32List bytes = data.buffer.asUint32List();
-    // Draws a checkerboard due to flutter_tester not having a GPU context.
-    const int white = 0xFFFFFFFF;
-    const int grey  = 0xFFCCCCCC;
-    expect(bytes, const <int>[
-      white, white, white, grey,  grey,  grey, //
-      white, white, white, grey,  grey,  grey,
-      white, white, white, grey,  grey,  grey,
-      white, white, white, grey,  grey,  grey,
-      grey,  grey,  grey,  white, white, white,
-      grey,  grey,  grey,  white, white, white,
-      grey,  grey,  grey,  white, white, white,
-      grey,  grey,  grey,  white, white, white,
-    ]);
+    expect(bytes, List<int>.filled(bytes.length, color.value));
   });
 
   test('addPicture with disposed picture does not crash', () {

--- a/testing/dart/compositing_test.dart
+++ b/testing/dart/compositing_test.dart
@@ -8,7 +8,7 @@ import 'dart:ui';
 import 'package:litetest/litetest.dart';
 
 void main() {
-  test('Scene.toGpuImage succeeds', () async {
+  test('Scene.toImageSync succeeds', () async {
     final PictureRecorder recorder = PictureRecorder();
     final Canvas canvas = Canvas(recorder);
     canvas.drawPaint(Paint()..color = const Color(0xFF123456));
@@ -18,7 +18,7 @@ void main() {
     builder.addPicture(const Offset(5, 5), picture);
     final Scene scene = builder.build();
 
-    final Image image = scene.toGpuImage(6, 8);
+    final Image image = scene.toImageSync(6, 8);
     picture.dispose();
     scene.dispose();
 

--- a/testing/dart/image_shader_test.dart
+++ b/testing/dart/image_shader_test.dart
@@ -23,7 +23,7 @@ void main() {
     final Canvas canvas = Canvas(recorder);
     canvas.drawPaint(Paint()..color = const Color(0xFFABCDEF));
     final Picture picture = recorder.endRecording();
-    final Image image = picture.toGpuImage(50, 50);
+    final Image image = picture.toImageSync(50, 50);
     picture.dispose();
 
     // TODO(dnfield): this should not throw once


### PR DESCRIPTION
Updates documentation.

Makes toImageSync work in software contexts.