### PR TITLE
Fix an issue that deleting an emoji may crash the app

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -1899,6 +1899,8 @@ static BOOL IsSelectionRectCloserToPoint(CGPoint point,
     if (oldRange.location > 0) {
       NSRange newRange = NSMakeRange(oldRange.location - 1, 1);
 
+      // We should check if the last character is a part of emoji.
+      // If so, we must delete the entire emoji to prevent the text from being malformed.
       NSRange charRange = fml::RangeForCharacterAtIndex(self.text, oldRange.location - 1);
       UChar32 codePoint;
       BOOL gotCodePoint = [self.text getBytes:&codePoint
@@ -1909,9 +1911,9 @@ static BOOL IsSelectionRectCloserToPoint(CGPoint point,
                                         range:charRange
                                remainingRange:NULL];
       if (gotCodePoint && u_hasBinaryProperty(codePoint, UCHAR_EMOJI)) {
-        // We should make sure the entire emoji is deleted.
         newRange = NSMakeRange(charRange.location, oldRange.location - charRange.location);
       }
+
       _selectedTextRange = [[FlutterTextRange rangeWithNSRange:newRange] copy];
       [oldSelectedRange release];
     }

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -1895,7 +1895,8 @@ static BOOL IsSelectionRectCloserToPoint(CGPoint point,
     UITextRange* oldSelectedRange = _selectedTextRange;
     NSRange oldRange = ((FlutterTextRange*)oldSelectedRange).range;
     if (oldRange.location > 0) {
-      NSRange newRange = NSMakeRange(oldRange.location - 1, 1);
+      NSRange charRange = fml::RangeForCharacterAtIndex(self.text, oldRange.location - 1);
+      NSRange newRange = NSMakeRange(charRange.location, oldRange.location - charRange.location);
       _selectedTextRange = [[FlutterTextRange rangeWithNSRange:newRange] copy];
       [oldSelectedRange release];
     }

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -406,6 +406,23 @@ FLUTTER_ASSERT_ARC
   XCTAssertEqualObjects(substring, @"bbbbaaaabbbbaaaa");
 }
 
+- (void)testDeletingBackwardWorksWithEmoji {
+  NSDictionary* config = self.mutableTemplateCopy;
+  [self setClientId:123 configuration:config];
+  NSArray<FlutterTextInputView*>* inputFields = self.installedInputViews;
+  FlutterTextInputView* inputView = inputFields[0];
+
+  [inputView insertText:@"😀🥰👨‍👩‍👧‍👦🇺🇳"];
+  [inputView deleteBackward];
+  XCTAssertEqualObjects(inputView.text, @"😀🥰👨‍👩‍👧‍👦");
+  [inputView deleteBackward];
+  XCTAssertEqualObjects(inputView.text, @"😀🥰");
+  [inputView deleteBackward];
+  XCTAssertEqualObjects(inputView.text, @"😀");
+  [inputView deleteBackward];
+  XCTAssertEqualObjects(inputView.text, @"");
+}
+
 - (void)testPastingNonTextDisallowed {
   NSDictionary* config = self.mutableTemplateCopy;
   [self setClientId:123 configuration:config];

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -412,29 +412,31 @@ FLUTTER_ASSERT_ARC
   NSArray<FlutterTextInputView*>* inputFields = self.installedInputViews;
   FlutterTextInputView* inputView = inputFields[0];
 
-  [inputView insertText:@"😀 text 🥰👨‍👩‍👧‍👦🇺🇳ดี "];
+  [inputView insertText:@"ឹ😀 text 🥰👨‍👩‍👧‍👦🇺🇳ดี "];
   [inputView deleteBackward];
   [inputView deleteBackward];
 
   // Thai vowel is removed.
-  XCTAssertEqualObjects(inputView.text, @"😀 text 🥰👨‍👩‍👧‍👦🇺🇳ด");
+  XCTAssertEqualObjects(inputView.text, @"ឹ😀 text 🥰👨‍👩‍👧‍👦🇺🇳ด");
   [inputView deleteBackward];
-  XCTAssertEqualObjects(inputView.text, @"😀 text 🥰👨‍👩‍👧‍👦🇺🇳");
+  XCTAssertEqualObjects(inputView.text, @"ឹ😀 text 🥰👨‍👩‍👧‍👦🇺🇳");
   [inputView deleteBackward];
-  XCTAssertEqualObjects(inputView.text, @"😀 text 🥰👨‍👩‍👧‍👦");
+  XCTAssertEqualObjects(inputView.text, @"ឹ😀 text 🥰👨‍👩‍👧‍👦");
   [inputView deleteBackward];
-  XCTAssertEqualObjects(inputView.text, @"😀 text 🥰");
-  [inputView deleteBackward];
-
-  XCTAssertEqualObjects(inputView.text, @"😀 text ");
-  [inputView deleteBackward];
-  [inputView deleteBackward];
-  [inputView deleteBackward];
-  [inputView deleteBackward];
-  [inputView deleteBackward];
+  XCTAssertEqualObjects(inputView.text, @"ឹ😀 text 🥰");
   [inputView deleteBackward];
 
-  XCTAssertEqualObjects(inputView.text, @"😀");
+  XCTAssertEqualObjects(inputView.text, @"ឹ😀 text ");
+  [inputView deleteBackward];
+  [inputView deleteBackward];
+  [inputView deleteBackward];
+  [inputView deleteBackward];
+  [inputView deleteBackward];
+  [inputView deleteBackward];
+
+  XCTAssertEqualObjects(inputView.text, @"ឹ😀");
+  [inputView deleteBackward];
+  XCTAssertEqualObjects(inputView.text, @"ឹ");
   [inputView deleteBackward];
   XCTAssertEqualObjects(inputView.text, @"");
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -406,18 +406,34 @@ FLUTTER_ASSERT_ARC
   XCTAssertEqualObjects(substring, @"bbbbaaaabbbbaaaa");
 }
 
-- (void)testDeletingBackwardWorksWithEmoji {
+- (void)testDeletingBackward {
   NSDictionary* config = self.mutableTemplateCopy;
   [self setClientId:123 configuration:config];
   NSArray<FlutterTextInputView*>* inputFields = self.installedInputViews;
   FlutterTextInputView* inputView = inputFields[0];
 
-  [inputView insertText:@"😀🥰👨‍👩‍👧‍👦🇺🇳"];
+  [inputView insertText:@"😀 text 🥰👨‍👩‍👧‍👦🇺🇳ดี "];
   [inputView deleteBackward];
-  XCTAssertEqualObjects(inputView.text, @"😀🥰👨‍👩‍👧‍👦");
   [inputView deleteBackward];
-  XCTAssertEqualObjects(inputView.text, @"😀🥰");
+
+  // Thai vowel is removed.
+  XCTAssertEqualObjects(inputView.text, @"😀 text 🥰👨‍👩‍👧‍👦🇺🇳ด");
   [inputView deleteBackward];
+  XCTAssertEqualObjects(inputView.text, @"😀 text 🥰👨‍👩‍👧‍👦🇺🇳");
+  [inputView deleteBackward];
+  XCTAssertEqualObjects(inputView.text, @"😀 text 🥰👨‍👩‍👧‍👦");
+  [inputView deleteBackward];
+  XCTAssertEqualObjects(inputView.text, @"😀 text 🥰");
+  [inputView deleteBackward];
+
+  XCTAssertEqualObjects(inputView.text, @"😀 text ");
+  [inputView deleteBackward];
+  [inputView deleteBackward];
+  [inputView deleteBackward];
+  [inputView deleteBackward];
+  [inputView deleteBackward];
+  [inputView deleteBackward];
+
   XCTAssertEqualObjects(inputView.text, @"😀");
   [inputView deleteBackward];
   XCTAssertEqualObjects(inputView.text, @"");

--- a/testing/ios/IosUnitTests/IosUnitTests.xcodeproj/xcshareddata/xcschemes/IosUnitTests.xcscheme
+++ b/testing/ios/IosUnitTests/IosUnitTests.xcodeproj/xcshareddata/xcschemes/IosUnitTests.xcscheme
@@ -78,6 +78,12 @@
             ReferencedContainer = "container:IosUnitTests.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "--icu-data-file-path=Frameworks/Flutter.framework/icudtl.dat"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
An emoji may consist of two or more characters. We should make sure that deleting backward should remove the entire emoji.

Fixes https://github.com/flutter/flutter/issues/106933

This issue was introduced in https://github.com/flutter/engine/pull/32223

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
