### PR TITLE
Use the correct 'SnapshotDelegate' in 'RuntimeController::Spawn'

### DIFF
--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -51,9 +51,10 @@ std::unique_ptr<RuntimeController> RuntimeController::Spawn(
     std::shared_ptr<const fml::Mapping> p_persistent_isolate_data,
     fml::WeakPtr<IOManager> io_manager,
     fml::WeakPtr<ImageDecoder> image_decoder,
-    fml::WeakPtr<ImageGeneratorRegistry> image_generator_registry) const {
+    fml::WeakPtr<ImageGeneratorRegistry> image_generator_registry,
+    fml::WeakPtr<SnapshotDelegate> snapshot_delegate) const {
   UIDartState::Context spawned_context{
-      context_.task_runners,         context_.snapshot_delegate,
+      context_.task_runners,         std::move(snapshot_delegate),
       std::move(io_manager),         context_.unref_queue,
       std::move(image_decoder),      std::move(image_generator_registry),
       advisory_script_uri,           advisory_script_entrypoint,

--- a/runtime/runtime_controller.h
+++ b/runtime/runtime_controller.h
@@ -106,7 +106,8 @@ class RuntimeController : public PlatformConfigurationClient {
       std::shared_ptr<const fml::Mapping> persistent_isolate_data,
       fml::WeakPtr<IOManager> io_manager,
       fml::WeakPtr<ImageDecoder> image_decoder,
-      fml::WeakPtr<ImageGeneratorRegistry> image_generator_registry) const;
+      fml::WeakPtr<ImageGeneratorRegistry> image_generator_registry,
+      fml::WeakPtr<SnapshotDelegate> snapshot_delegate) const;
 
   // |PlatformConfigurationClient|
   ~RuntimeController() override;

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -109,7 +109,8 @@ std::unique_ptr<Engine> Engine::Spawn(
     Settings settings,
     std::unique_ptr<Animator> animator,
     const std::string& initial_route,
-    fml::WeakPtr<IOManager> io_manager) const {
+    fml::WeakPtr<IOManager> io_manager,
+    fml::WeakPtr<SnapshotDelegate> snapshot_delegate) const {
   auto result = std::make_unique<Engine>(
       /*delegate=*/delegate,
       /*dispatcher_maker=*/dispatcher_maker,
@@ -131,7 +132,8 @@ std::unique_ptr<Engine> Engine::Spawn(
       /*persistent_isolate_data=*/settings.persistent_isolate_data,
       /*io_manager=*/io_manager,
       /*image_decoder=*/result->GetImageDecoderWeakPtr(),
-      /*image_generator_registry=*/result->GetImageGeneratorRegistry());
+      /*image_generator_registry=*/result->GetImageGeneratorRegistry(),
+      /*snapshot_delegate=*/snapshot_delegate);
   result->initial_route_ = initial_route;
   return result;
 }

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -375,7 +375,8 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
       Settings settings,
       std::unique_ptr<Animator> animator,
       const std::string& initial_route,
-      fml::WeakPtr<IOManager> io_manager) const;
+      fml::WeakPtr<IOManager> io_manager,
+      fml::WeakPtr<SnapshotDelegate> snapshot_delegate) const;
 
   //----------------------------------------------------------------------------
   /// @brief      Destroys the engine engine. Called by the shell on the UI task

--- a/shell/common/engine_unittests.cc
+++ b/shell/common/engine_unittests.cc
@@ -141,6 +141,7 @@ class EngineTest : public testing::FixtureTest {
   fml::WeakPtr<IOManager> io_manager_;
   std::unique_ptr<RuntimeController> runtime_controller_;
   std::shared_ptr<fml::ConcurrentTaskRunner> image_decoder_task_runner_;
+  fml::WeakPtr<SnapshotDelegate> snapshot_delegate_;
 };
 }  // namespace
 
@@ -270,7 +271,7 @@ TEST_F(EngineTest, SpawnSharesFontLibrary) {
         /*runtime_controller=*/std::move(mock_runtime_controller));
 
     auto spawn = engine->Spawn(delegate_, dispatcher_maker_, settings_, nullptr,
-                               std::string(), io_manager_);
+                               std::string(), io_manager_, snapshot_delegate_);
     EXPECT_TRUE(spawn != nullptr);
     EXPECT_EQ(&engine->GetFontCollection(), &spawn->GetFontCollection());
   });
@@ -296,7 +297,7 @@ TEST_F(EngineTest, SpawnWithCustomInitialRoute) {
         /*runtime_controller=*/std::move(mock_runtime_controller));
 
     auto spawn = engine->Spawn(delegate_, dispatcher_maker_, settings_, nullptr,
-                               "/foo", io_manager_);
+                               "/foo", io_manager_, snapshot_delegate_);
     EXPECT_TRUE(spawn != nullptr);
     ASSERT_EQ("/foo", spawn->InitialRoute());
   });
@@ -332,7 +333,7 @@ TEST_F(EngineTest, SpawnResetsViewportMetrics) {
     EXPECT_EQ(old_platform_data.viewport_metrics.physical_height, kViewHeight);
 
     auto spawn = engine->Spawn(delegate_, dispatcher_maker_, settings_, nullptr,
-                               std::string(), io_manager_);
+                               std::string(), io_manager_, snapshot_delegate_);
     EXPECT_TRUE(spawn != nullptr);
     auto& new_viewport_metrics =
         spawn->GetRuntimeController()->GetPlatformData().viewport_metrics;
@@ -363,8 +364,9 @@ TEST_F(EngineTest, SpawnWithCustomSettings) {
     Settings custom_settings = settings_;
     custom_settings.persistent_isolate_data =
         std::make_shared<fml::DataMapping>("foo");
-    auto spawn = engine->Spawn(delegate_, dispatcher_maker_, custom_settings,
-                               nullptr, std::string(), io_manager_);
+    auto spawn =
+        engine->Spawn(delegate_, dispatcher_maker_, custom_settings, nullptr,
+                      std::string(), io_manager_, snapshot_delegate_);
     EXPECT_TRUE(spawn != nullptr);
     auto new_persistent_isolate_data =
         const_cast<RuntimeController*>(spawn->GetRuntimeController())

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -536,12 +536,14 @@ std::unique_ptr<Shell> Shell::Spawn(
           fml::RefPtr<SkiaUnrefQueue> unref_queue,
           fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
           std::shared_ptr<VolatilePathTracker> volatile_path_tracker) {
-        return engine->Spawn(/*delegate=*/delegate,
-                             /*dispatcher_maker=*/dispatcher_maker,
-                             /*settings=*/settings,
-                             /*animator=*/std::move(animator),
-                             /*initial_route=*/initial_route,
-                             /*io_manager=*/std::move(io_manager));
+        return engine->Spawn(
+            /*delegate=*/delegate,
+            /*dispatcher_maker=*/dispatcher_maker,
+            /*settings=*/settings,
+            /*animator=*/std::move(animator),
+            /*initial_route=*/initial_route,
+            /*io_manager=*/std::move(io_manager),
+            /*snapshot_delegate=*/std::move(snapshot_delegate));
       },
       is_gpu_disabled);
   result->RunEngine(std::move(run_configuration));

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -2984,25 +2984,34 @@ TEST_F(ShellTest, Spawn) {
         ASSERT_NE(nullptr, spawn.get());
         ASSERT_TRUE(ValidateShell(spawn.get()));
 
-        PostSync(spawner->GetTaskRunners().GetUITaskRunner(),
-                 [&spawn, &spawner, initial_route] {
-                   // Check second shell ran the second entrypoint.
-                   ASSERT_EQ("testCanLaunchSecondaryIsolate",
-                             spawn->GetEngine()->GetLastEntrypoint());
-                   ASSERT_EQ(initial_route, spawn->GetEngine()->InitialRoute());
+        PostSync(spawner->GetTaskRunners().GetUITaskRunner(), [&spawn, &spawner,
+                                                               initial_route] {
+          // Check second shell ran the second entrypoint.
+          ASSERT_EQ("testCanLaunchSecondaryIsolate",
+                    spawn->GetEngine()->GetLastEntrypoint());
+          ASSERT_EQ(initial_route, spawn->GetEngine()->InitialRoute());
 
-                   ASSERT_NE(spawner->GetEngine()
-                                 ->GetRuntimeController()
-                                 ->GetRootIsolateGroup(),
-                             0u);
-                   ASSERT_EQ(spawner->GetEngine()
-                                 ->GetRuntimeController()
-                                 ->GetRootIsolateGroup(),
-                             spawn->GetEngine()
-                                 ->GetRuntimeController()
-                                 ->GetRootIsolateGroup());
-                 });
-
+          ASSERT_NE(spawner->GetEngine()
+                        ->GetRuntimeController()
+                        ->GetRootIsolateGroup(),
+                    0u);
+          ASSERT_EQ(spawner->GetEngine()
+                        ->GetRuntimeController()
+                        ->GetRootIsolateGroup(),
+                    spawn->GetEngine()
+                        ->GetRuntimeController()
+                        ->GetRootIsolateGroup());
+          auto spawner_snapshot_delegate = spawner->GetEngine()
+                                               ->GetRuntimeController()
+                                               ->GetSnapshotDelegate();
+          auto spawn_snapshot_delegate =
+              spawn->GetEngine()->GetRuntimeController()->GetSnapshotDelegate();
+          PostSync(spawner->GetTaskRunners().GetRasterTaskRunner(),
+                   [spawner_snapshot_delegate, spawn_snapshot_delegate] {
+                     ASSERT_NE(spawner_snapshot_delegate.get(),
+                               spawn_snapshot_delegate.get());
+                   });
+        });
         PostSync(
             spawner->GetTaskRunners().GetIOTaskRunner(), [&spawner, &spawn] {
               ASSERT_EQ(spawner->GetIOManager()->GetResourceContext().get(),


### PR DESCRIPTION
fix issue https://github.com/flutter/flutter/issues/105392

In the current implementation, the `snapshot_delegate` of all lightweight engines is the same object - the `rasterizer` of the first engine. And when the `FlutterViewController` with first engine is not visible, then the `surface_` of `rasterizer` will be set to `nullptr`. At this time, if other engines call `Rasterizer::DoMakeRasterSnapshot`, the issue will occur.

#### proposed solution
Lightweight engines no longer share `snapshot_delegate`, each engine's `snapshot_delegate` is its own `rasterizer`.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

