### PR TITLE
Reland jit snapshots

### DIFF
--- a/runtime/dart_snapshot.cc
+++ b/runtime/dart_snapshot.cc
@@ -59,7 +59,12 @@ static std::shared_ptr<const fml::Mapping> SearchMapping(
   // Ask the embedder. There is no fallback as we expect the embedders (via
   // their embedding APIs) to just specify the mappings directly.
   if (embedder_mapping_callback) {
-    return embedder_mapping_callback();
+    // Note that mapping will be nullptr if the mapping callback returns an
+    // invalid mapping. If all the other methods for resolving the data also
+    // fail, the engine will stop with accompanying error logs.
+    if (auto mapping = embedder_mapping_callback()) {
+      return mapping;
+    }
   }
 
   // Attempt to open file at path specified.

--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -233,6 +233,25 @@ if (enable_unittests) {
       "//third_party/skia",
     ]
 
+    _lib_snapshot_label = "//flutter/lib/snapshot:vm_isolate_snapshot.bin"
+    _lib_snapshot_gen_dir =
+        get_label_info(_lib_snapshot_label, "target_gen_dir")
+
+    _isolate_snapshot_data = "${_lib_snapshot_gen_dir}/isolate_snapshot.bin"
+    _isolate_snapshot_instructions =
+        "${_lib_snapshot_gen_dir}/isolate_snapshot_instructions.bin"
+    _vm_snapshot_data = "${_lib_snapshot_gen_dir}/vm_isolate_snapshot.bin"
+    _vm_snapshot_instructions =
+        "${_lib_snapshot_gen_dir}/vm_snapshot_instructions.bin"
+
+    # For testing JIT snapshot setup.
+    defines = [
+      "TEST_ISOLATE_SNAPSHOT_DATA=\"${_isolate_snapshot_data}\"",
+      "TEST_ISOLATE_SNAPSHOT_INSTRUCTIONS=\"${_isolate_snapshot_instructions}\"",
+      "TEST_VM_SNAPSHOT_DATA=\"${_vm_snapshot_data}\"",
+      "TEST_VM_SNAPSHOT_INSTRUCTIONS=\"${_vm_snapshot_instructions}\"",
+    ]
+
     if (test_enable_gl) {
       sources += [
         "tests/embedder_test_compositor_gl.cc",

--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -29,6 +29,26 @@ config("embedder_header_config") {
   include_dirs = [ "." ]
 }
 
+config("embedder_jit_snapshot_setup") {
+  _lib_snapshot_label = "//flutter/lib/snapshot:vm_isolate_snapshot.bin"
+  _lib_snapshot_gen_dir = get_label_info(_lib_snapshot_label, "target_gen_dir")
+
+  _isolate_snapshot_data = "${_lib_snapshot_gen_dir}/isolate_snapshot.bin"
+  _isolate_snapshot_instructions =
+      "${_lib_snapshot_gen_dir}/isolate_snapshot_instructions.bin"
+  _vm_snapshot_data = "${_lib_snapshot_gen_dir}/vm_isolate_snapshot.bin"
+  _vm_snapshot_instructions =
+      "${_lib_snapshot_gen_dir}/vm_snapshot_instructions.bin"
+
+  # For testing JIT snapshot setup.
+  defines = [
+    "TEST_ISOLATE_SNAPSHOT_DATA=\"${_isolate_snapshot_data}\"",
+    "TEST_ISOLATE_SNAPSHOT_INSTRUCTIONS=\"${_isolate_snapshot_instructions}\"",
+    "TEST_VM_SNAPSHOT_DATA=\"${_vm_snapshot_data}\"",
+    "TEST_VM_SNAPSHOT_INSTRUCTIONS=\"${_vm_snapshot_instructions}\"",
+  ]
+}
+
 # Template for the embedder build. Used to allow building it multiple times with
 # different flags.
 template("embedder_source_set") {
@@ -233,25 +253,6 @@ if (enable_unittests) {
       "//third_party/skia",
     ]
 
-    _lib_snapshot_label = "//flutter/lib/snapshot:vm_isolate_snapshot.bin"
-    _lib_snapshot_gen_dir =
-        get_label_info(_lib_snapshot_label, "target_gen_dir")
-
-    _isolate_snapshot_data = "${_lib_snapshot_gen_dir}/isolate_snapshot.bin"
-    _isolate_snapshot_instructions =
-        "${_lib_snapshot_gen_dir}/isolate_snapshot_instructions.bin"
-    _vm_snapshot_data = "${_lib_snapshot_gen_dir}/vm_isolate_snapshot.bin"
-    _vm_snapshot_instructions =
-        "${_lib_snapshot_gen_dir}/vm_snapshot_instructions.bin"
-
-    # For testing JIT snapshot setup.
-    defines = [
-      "TEST_ISOLATE_SNAPSHOT_DATA=\"${_isolate_snapshot_data}\"",
-      "TEST_ISOLATE_SNAPSHOT_INSTRUCTIONS=\"${_isolate_snapshot_instructions}\"",
-      "TEST_VM_SNAPSHOT_DATA=\"${_vm_snapshot_data}\"",
-      "TEST_VM_SNAPSHOT_INSTRUCTIONS=\"${_vm_snapshot_instructions}\"",
-    ]
-
     if (test_enable_gl) {
       sources += [
         "tests/embedder_test_compositor_gl.cc",
@@ -296,6 +297,7 @@ if (enable_unittests) {
     testonly = true
 
     configs += [
+      ":embedder_jit_snapshot_setup",
       ":embedder_gpu_configuration_config",
       "//flutter:export_dynamic_symbols",
     ]

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -1006,7 +1006,44 @@ FlutterEngineResult FlutterEngineCollectAOTData(FlutterEngineAOTData data) {
   return kSuccess;
 }
 
-void PopulateSnapshotMappingCallbacks(
+// Constructs appropriate mapping callbacks if JIT snapshot locations have been
+// explictly specified.
+void PopulateJITSnapshotMappingCallbacks(const FlutterProjectArgs* args,
+                                         flutter::Settings& settings) {
+  auto make_mapping_callback = [](const char* path, bool executable) {
+    return [path, executable]() {
+      if (executable) {
+        return fml::FileMapping::CreateReadExecute(path);
+      } else {
+        return fml::FileMapping::CreateReadOnly(path);
+      }
+    };
+  };
+
+  // Users are allowed to specify only certain snapshots if they so desire.
+  if (SAFE_ACCESS(args, vm_snapshot_data, nullptr) != nullptr) {
+    settings.vm_snapshot_data = make_mapping_callback(
+        reinterpret_cast<const char*>(args->vm_snapshot_data), false);
+  }
+
+  if (SAFE_ACCESS(args, vm_snapshot_instructions, nullptr) != nullptr) {
+    settings.vm_snapshot_instr = make_mapping_callback(
+        reinterpret_cast<const char*>(args->vm_snapshot_instructions), true);
+  }
+
+  if (SAFE_ACCESS(args, isolate_snapshot_data, nullptr) != nullptr) {
+    settings.isolate_snapshot_data = make_mapping_callback(
+        reinterpret_cast<const char*>(args->isolate_snapshot_data), false);
+  }
+
+  if (SAFE_ACCESS(args, isolate_snapshot_instructions, nullptr) != nullptr) {
+    settings.isolate_snapshot_instr = make_mapping_callback(
+        reinterpret_cast<const char*>(args->isolate_snapshot_instructions),
+        true);
+  }
+}
+
+void PopulateAOTSnapshotMappingCallbacks(
     const FlutterProjectArgs* args,
     flutter::Settings& settings) {  // NOLINT(google-runtime-references)
   // There are no ownership concerns here as all mappings are owned by the
@@ -1017,43 +1054,41 @@ void PopulateSnapshotMappingCallbacks(
     };
   };
 
-  if (flutter::DartVM::IsRunningPrecompiledCode()) {
-    if (SAFE_ACCESS(args, aot_data, nullptr) != nullptr) {
-      settings.vm_snapshot_data =
-          make_mapping_callback(args->aot_data->vm_snapshot_data, 0);
+  if (SAFE_ACCESS(args, aot_data, nullptr) != nullptr) {
+    settings.vm_snapshot_data =
+        make_mapping_callback(args->aot_data->vm_snapshot_data, 0);
 
-      settings.vm_snapshot_instr =
-          make_mapping_callback(args->aot_data->vm_snapshot_instrs, 0);
+    settings.vm_snapshot_instr =
+        make_mapping_callback(args->aot_data->vm_snapshot_instrs, 0);
 
-      settings.isolate_snapshot_data =
-          make_mapping_callback(args->aot_data->vm_isolate_data, 0);
+    settings.isolate_snapshot_data =
+        make_mapping_callback(args->aot_data->vm_isolate_data, 0);
 
-      settings.isolate_snapshot_instr =
-          make_mapping_callback(args->aot_data->vm_isolate_instrs, 0);
-    }
+    settings.isolate_snapshot_instr =
+        make_mapping_callback(args->aot_data->vm_isolate_instrs, 0);
+  }
 
-    if (SAFE_ACCESS(args, vm_snapshot_data, nullptr) != nullptr) {
-      settings.vm_snapshot_data = make_mapping_callback(
-          args->vm_snapshot_data, SAFE_ACCESS(args, vm_snapshot_data_size, 0));
-    }
+  if (SAFE_ACCESS(args, vm_snapshot_data, nullptr) != nullptr) {
+    settings.vm_snapshot_data = make_mapping_callback(
+        args->vm_snapshot_data, SAFE_ACCESS(args, vm_snapshot_data_size, 0));
+  }
 
-    if (SAFE_ACCESS(args, vm_snapshot_instructions, nullptr) != nullptr) {
-      settings.vm_snapshot_instr = make_mapping_callback(
-          args->vm_snapshot_instructions,
-          SAFE_ACCESS(args, vm_snapshot_instructions_size, 0));
-    }
+  if (SAFE_ACCESS(args, vm_snapshot_instructions, nullptr) != nullptr) {
+    settings.vm_snapshot_instr = make_mapping_callback(
+        args->vm_snapshot_instructions,
+        SAFE_ACCESS(args, vm_snapshot_instructions_size, 0));
+  }
 
-    if (SAFE_ACCESS(args, isolate_snapshot_data, nullptr) != nullptr) {
-      settings.isolate_snapshot_data = make_mapping_callback(
-          args->isolate_snapshot_data,
-          SAFE_ACCESS(args, isolate_snapshot_data_size, 0));
-    }
+  if (SAFE_ACCESS(args, isolate_snapshot_data, nullptr) != nullptr) {
+    settings.isolate_snapshot_data =
+        make_mapping_callback(args->isolate_snapshot_data,
+                              SAFE_ACCESS(args, isolate_snapshot_data_size, 0));
+  }
 
-    if (SAFE_ACCESS(args, isolate_snapshot_instructions, nullptr) != nullptr) {
-      settings.isolate_snapshot_instr = make_mapping_callback(
-          args->isolate_snapshot_instructions,
-          SAFE_ACCESS(args, isolate_snapshot_instructions_size, 0));
-    }
+  if (SAFE_ACCESS(args, isolate_snapshot_instructions, nullptr) != nullptr) {
+    settings.isolate_snapshot_instr = make_mapping_callback(
+        args->isolate_snapshot_instructions,
+        SAFE_ACCESS(args, isolate_snapshot_instructions_size, 0));
   }
 
 #if !OS_FUCHSIA && (FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG)
@@ -1161,7 +1196,11 @@ FlutterEngineResult FlutterEngineInitialize(size_t version,
     }
   }
 
-  PopulateSnapshotMappingCallbacks(args, settings);
+  if (flutter::DartVM::IsRunningPrecompiledCode()) {
+    PopulateAOTSnapshotMappingCallbacks(args, settings);
+  } else {
+    PopulateJITSnapshotMappingCallbacks(args, settings);
+  }
 
   settings.icu_data_path = icu_data_path;
   settings.assets_path = args->assets_path;

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -1294,6 +1294,232 @@ TEST_F(EmbedderTest, CanLaunchAndShutdownWithAValidElfSource) {
   engine.reset();
 }
 
+#if defined(__clang_analyzer__)
+#define TEST_VM_SNAPSHOT_DATA nullptr
+#define TEST_VM_SNAPSHOT_INSTRUCTIONS nullptr
+#define TEST_ISOLATE_SNAPSHOT_DATA nullptr
+#define TEST_ISOLATE_SNAPSHOT_INSTRUCTIONS nullptr
+#endif
+
+//------------------------------------------------------------------------------
+/// PopulateJITSnapshotMappingCallbacks should successfully change the callbacks
+/// of the snapshots in the engine's settings when JIT snapshots are explicitly
+/// defined.
+///
+TEST_F(EmbedderTest, CanSuccessfullyPopulateSpecificJITSnapshotCallbacks) {
+// TODO(#107263): Inconsistent snapshot paths in the Linux Fuchsia FEMU test.
+#if defined(OS_FUCHSIA)
+  GTEST_SKIP() << "Inconsistent paths in Fuchsia.";
+#endif  // OS_FUCHSIA
+
+  // This test is only relevant in JIT mode.
+  if (DartVM::IsRunningPrecompiledCode()) {
+    GTEST_SKIP();
+    return;
+  }
+
+  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  EmbedderConfigBuilder builder(context);
+  builder.SetSoftwareRendererConfig();
+
+  // Construct the location of valid JIT snapshots.
+  const std::string src_path = GetSourcePath();
+  const std::string vm_snapshot_data =
+      fml::paths::JoinPaths({src_path, TEST_VM_SNAPSHOT_DATA});
+  const std::string vm_snapshot_instructions =
+      fml::paths::JoinPaths({src_path, TEST_VM_SNAPSHOT_INSTRUCTIONS});
+  const std::string isolate_snapshot_data =
+      fml::paths::JoinPaths({src_path, TEST_ISOLATE_SNAPSHOT_DATA});
+  const std::string isolate_snapshot_instructions =
+      fml::paths::JoinPaths({src_path, TEST_ISOLATE_SNAPSHOT_INSTRUCTIONS});
+
+  // Explicitly define the locations of the JIT snapshots
+  builder.GetProjectArgs().vm_snapshot_data =
+      reinterpret_cast<const uint8_t*>(vm_snapshot_data.c_str());
+  builder.GetProjectArgs().vm_snapshot_instructions =
+      reinterpret_cast<const uint8_t*>(vm_snapshot_instructions.c_str());
+  builder.GetProjectArgs().isolate_snapshot_data =
+      reinterpret_cast<const uint8_t*>(isolate_snapshot_data.c_str());
+  builder.GetProjectArgs().isolate_snapshot_instructions =
+      reinterpret_cast<const uint8_t*>(isolate_snapshot_instructions.c_str());
+
+  auto engine = builder.LaunchEngine();
+
+  flutter::Shell& shell = ToEmbedderEngine(engine.get())->GetShell();
+  const Settings settings = shell.GetSettings();
+
+  ASSERT_NE(settings.vm_snapshot_data(), nullptr);
+  ASSERT_NE(settings.vm_snapshot_instr(), nullptr);
+  ASSERT_NE(settings.isolate_snapshot_data(), nullptr);
+  ASSERT_NE(settings.isolate_snapshot_instr(), nullptr);
+}
+
+//------------------------------------------------------------------------------
+/// PopulateJITSnapshotMappingCallbacks should still be able to successfully
+/// change the callbacks of the snapshots in the engine's settings when JIT
+/// snapshots are explicitly defined. However, if those snapshot locations are
+/// invalid, the callbacks should return a nullptr.
+///
+TEST_F(EmbedderTest, JITSnapshotCallbacksFailWithInvalidLocation) {
+// TODO(#107263): Inconsistent snapshot paths in the Linux Fuchsia FEMU test.
+#if defined(OS_FUCHSIA)
+  GTEST_SKIP() << "Inconsistent paths in Fuchsia.";
+#endif  // OS_FUCHSIA
+
+  // This test is only relevant in JIT mode.
+  if (DartVM::IsRunningPrecompiledCode()) {
+    GTEST_SKIP();
+    return;
+  }
+
+  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  EmbedderConfigBuilder builder(context);
+  builder.SetSoftwareRendererConfig();
+
+  // Explicitly define the locations of the invalid JIT snapshots
+  builder.GetProjectArgs().vm_snapshot_data =
+      reinterpret_cast<const uint8_t*>("invalid_vm_data");
+  builder.GetProjectArgs().vm_snapshot_instructions =
+      reinterpret_cast<const uint8_t*>("invalid_vm_instructions");
+  builder.GetProjectArgs().isolate_snapshot_data =
+      reinterpret_cast<const uint8_t*>("invalid_snapshot_data");
+  builder.GetProjectArgs().isolate_snapshot_instructions =
+      reinterpret_cast<const uint8_t*>("invalid_snapshot_instructions");
+
+  auto engine = builder.LaunchEngine();
+
+  flutter::Shell& shell = ToEmbedderEngine(engine.get())->GetShell();
+  const Settings settings = shell.GetSettings();
+
+  ASSERT_EQ(settings.vm_snapshot_data(), nullptr);
+  ASSERT_EQ(settings.vm_snapshot_instr(), nullptr);
+  ASSERT_EQ(settings.isolate_snapshot_data(), nullptr);
+  ASSERT_EQ(settings.isolate_snapshot_instr(), nullptr);
+}
+
+//------------------------------------------------------------------------------
+/// The embedder must be able to run explicitly specified snapshots in JIT mode
+/// (i.e. when those are present in known locations).
+///
+TEST_F(EmbedderTest, CanLaunchEngineWithSpecifiedJITSnapshots) {
+  // This test is only relevant in JIT mode.
+  if (DartVM::IsRunningPrecompiledCode()) {
+    GTEST_SKIP();
+    return;
+  }
+
+  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  EmbedderConfigBuilder builder(context);
+  builder.SetSoftwareRendererConfig();
+
+  // Construct the location of valid JIT snapshots.
+  const std::string src_path = GetSourcePath();
+  const std::string vm_snapshot_data =
+      fml::paths::JoinPaths({src_path, TEST_VM_SNAPSHOT_DATA});
+  const std::string vm_snapshot_instructions =
+      fml::paths::JoinPaths({src_path, TEST_VM_SNAPSHOT_INSTRUCTIONS});
+  const std::string isolate_snapshot_data =
+      fml::paths::JoinPaths({src_path, TEST_ISOLATE_SNAPSHOT_DATA});
+  const std::string isolate_snapshot_instructions =
+      fml::paths::JoinPaths({src_path, TEST_ISOLATE_SNAPSHOT_INSTRUCTIONS});
+
+  // Explicitly define the locations of the JIT snapshots
+  builder.GetProjectArgs().vm_snapshot_data =
+      reinterpret_cast<const uint8_t*>(vm_snapshot_data.c_str());
+  builder.GetProjectArgs().vm_snapshot_instructions =
+      reinterpret_cast<const uint8_t*>(vm_snapshot_instructions.c_str());
+  builder.GetProjectArgs().isolate_snapshot_data =
+      reinterpret_cast<const uint8_t*>(isolate_snapshot_data.c_str());
+  builder.GetProjectArgs().isolate_snapshot_instructions =
+      reinterpret_cast<const uint8_t*>(isolate_snapshot_instructions.c_str());
+
+  auto engine = builder.LaunchEngine();
+  ASSERT_TRUE(engine.is_valid());
+}
+
+//------------------------------------------------------------------------------
+/// The embedder must be able to run in JIT mode when only some snapshots are
+/// specified.
+///
+TEST_F(EmbedderTest, CanLaunchEngineWithSomeSpecifiedJITSnapshots) {
+  // This test is only relevant in JIT mode.
+  if (DartVM::IsRunningPrecompiledCode()) {
+    GTEST_SKIP();
+    return;
+  }
+
+  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  EmbedderConfigBuilder builder(context);
+  builder.SetSoftwareRendererConfig();
+
+  // Construct the location of valid JIT snapshots.
+  const std::string src_path = GetSourcePath();
+  const std::string vm_snapshot_data =
+      fml::paths::JoinPaths({src_path, TEST_VM_SNAPSHOT_DATA});
+  const std::string vm_snapshot_instructions =
+      fml::paths::JoinPaths({src_path, TEST_VM_SNAPSHOT_INSTRUCTIONS});
+
+  // Explicitly define the locations of the JIT snapshots
+  builder.GetProjectArgs().vm_snapshot_data =
+      reinterpret_cast<const uint8_t*>(vm_snapshot_data.c_str());
+  builder.GetProjectArgs().vm_snapshot_instructions =
+      reinterpret_cast<const uint8_t*>(vm_snapshot_instructions.c_str());
+
+  auto engine = builder.LaunchEngine();
+  ASSERT_TRUE(engine.is_valid());
+}
+
+//------------------------------------------------------------------------------
+/// The embedder must be able to run in JIT mode even when the specfied
+/// snapshots are invalid. It should be able to resolve them as it would when
+/// the snapshots are not specified.
+///
+TEST_F(EmbedderTest, CanLaunchEngineWithInvalidJITSnapshots) {
+  // This test is only relevant in JIT mode.
+  if (DartVM::IsRunningPrecompiledCode()) {
+    GTEST_SKIP();
+    return;
+  }
+
+  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  EmbedderConfigBuilder builder(context);
+  builder.SetSoftwareRendererConfig();
+
+  // Explicitly define the locations of the JIT snapshots
+  builder.GetProjectArgs().isolate_snapshot_data =
+      reinterpret_cast<const uint8_t*>("invalid_snapshot_data");
+  builder.GetProjectArgs().isolate_snapshot_instructions =
+      reinterpret_cast<const uint8_t*>("invalid_snapshot_instructions");
+
+  auto engine = builder.LaunchEngine();
+  ASSERT_TRUE(engine.is_valid());
+  ASSERT_EQ(FlutterEngineRunInitialized(engine.get()), kInvalidArguments);
+}
+
+//------------------------------------------------------------------------------
+/// The embedder must be able to launch even when the snapshots are not
+/// explicitly defined in JIT mode. It must be able to resolve those snapshots.
+///
+TEST_F(EmbedderTest, CanLaunchEngineWithUnspecifiedJITSnapshots) {
+  // This test is only relevant in JIT mode.
+  if (DartVM::IsRunningPrecompiledCode()) {
+    GTEST_SKIP();
+    return;
+  }
+
+  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  EmbedderConfigBuilder builder(context);
+  builder.SetSoftwareRendererConfig();
+
+  ASSERT_EQ(builder.GetProjectArgs().vm_snapshot_data, nullptr);
+  ASSERT_EQ(builder.GetProjectArgs().vm_snapshot_instructions, nullptr);
+  ASSERT_EQ(builder.GetProjectArgs().isolate_snapshot_data, nullptr);
+  ASSERT_EQ(builder.GetProjectArgs().isolate_snapshot_instructions, nullptr);
+
+  auto engine = builder.LaunchEngine();
+  ASSERT_TRUE(engine.is_valid());
+}
+
 TEST_F(EmbedderTest, InvalidFlutterWindowMetricsEvent) {
   auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
   EmbedderConfigBuilder builder(context);


### PR DESCRIPTION
This PR relands https://github.com/flutter/engine/pull/34244 after fixing the errors stemming from building with host_debug.

The changes proposed in this PR will enable users to explicitly specify JIT snapshots. Currently, the engine relies on the asset resolver to identify the snapshot asset locations. There have been requests for increased flexibility when determining such locations, especially in cases in which the asset resolver fails to find a valid snapshot. Additionally, this PR was conceived with the goal of making the JIT mode consistent with the existing AOT mode, which allows users to explicitly describe such asset paths.

As such, the engine will call the PopulateJITSnapshotMappingCallbacks function, which will set the snapshots to their corresponding mapping callbacks as defined by the user (using the embedder's Project Args) and add them to the Settings. In the cases in which no snapshots are explicitly defined, the engine will resolve the assets as before since the snapshots will be set to nullptr in the Settings.

This PR stems from the discussion raised in https://github.com/flutter/flutter/issues/100640.