### PR TITLE
Add scenario_app target to iOS scenario test README

### DIFF
--- a/testing/scenario_app/README.md
+++ b/testing/scenario_app/README.md
@@ -21,7 +21,13 @@ platform channel.
 
 ## Running for iOS
 
-Build the `ios_debug_sim_unopt` engine variant, and run
+Build the `ios_debug_sim_unopt` engine variant and `scenario_app` target.
+
+```sh
+ninja -C out/ios_debug_sim_unopt scenario_app
+```
+
+Then run
 
 ```sh
 ./run_ios_tests.sh


### PR DESCRIPTION
Just building the `ios_debug_sim_unopt` does not generate the `scenario_app`.  Add instructions to the README to also build the `scenario_app` target.

See https://github.com/flutter/engine/pull/27302

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
