### PR TITLE
[web] specialize transform and offset layers

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
@@ -312,14 +312,14 @@ class HtmlViewEmbedder {
         case MutatorType.transform:
           headTransform = mutator.matrix!.multiplied(headTransform);
           head.style.transform =
-              float64ListToCssTransform(headTransform.storage);
+              float32ListToCssTransform(headTransform.storage);
           break;
         case MutatorType.translate:
-          final Matrix4 translation = Matrix4.translationValues(mutator.dx!, mutator.dy!, 1);
+          final Matrix4 translation = Matrix4.translationValues(mutator.dx!, mutator.dy!, 0);
           translation.multiply(headTransform);
           headTransform = translation;
           head.style.transform =
-              float64ListToCssTransform(headTransform.storage);
+              float32ListToCssTransform(headTransform.storage);
           break;
         case MutatorType.clipRect:
         case MutatorType.clipRRect:
@@ -390,7 +390,7 @@ class HtmlViewEmbedder {
     final Matrix4 scaleMatrix =
         Matrix4.diagonal3Values(inverseScale, inverseScale, 1);
     headTransform = scaleMatrix.multiplied(headTransform);
-    head.style.transform = float64ListToCssTransform(headTransform.storage);
+    head.style.transform = float32ListToCssTransform(headTransform.storage);
   }
 
   /// Sets the transform origin to the top-left corner of the element.

--- a/lib/web_ui/lib/src/engine/html/bitmap_canvas.dart
+++ b/lib/web_ui/lib/src/engine/html/bitmap_canvas.dart
@@ -678,7 +678,7 @@ class BitmapCanvas extends EngineCanvas {
         _children.add(clipElement);
       }
     } else {
-      final String cssTransform = float64ListToCssTransform(
+      final String cssTransform = float32ListToCssTransform(
           transformWithOffset(_canvasPool.currentTransform, p).storage);
       imgElement.style
         ..transformOrigin = '0 0 0'

--- a/lib/web_ui/lib/src/engine/html/shaders/shader.dart
+++ b/lib/web_ui/lib/src/engine/html/shaders/shader.dart
@@ -743,10 +743,10 @@ class _BlurEngineImageFilter extends EngineImageFilter {
 
 class _MatrixEngineImageFilter extends EngineImageFilter {
   _MatrixEngineImageFilter({ required Float64List matrix, required this.filterQuality })
-      : webMatrix = Float64List.fromList(matrix),
+      : webMatrix = toMatrix32(matrix),
         super._();
 
-  final Float64List webMatrix;
+  final Float32List webMatrix;
   final ui.FilterQuality filterQuality;
 
   // TODO(yjbanov): implement FilterQuality.

--- a/lib/web_ui/lib/src/engine/html/shaders/shader.dart
+++ b/lib/web_ui/lib/src/engine/html/shaders/shader.dart
@@ -751,7 +751,7 @@ class _MatrixEngineImageFilter extends EngineImageFilter {
 
   // TODO(yjbanov): implement FilterQuality.
   @override
-  String get transformAttribute => float64ListToCssTransform(webMatrix);
+  String get transformAttribute => float32ListToCssTransform(webMatrix);
 
   @override
   bool operator ==(Object other) {

--- a/lib/web_ui/lib/src/engine/html/transform.dart
+++ b/lib/web_ui/lib/src/engine/html/transform.dart
@@ -49,7 +49,7 @@ class PersistedTransform extends PersistedContainerSurface
 
   @override
   void apply() {
-    rootElement!.style.transform = float64ListToCssTransform(_matrixStorage);
+    rootElement!.style.transform = float32ListToCssTransform(_matrixStorage);
   }
 
   @override

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -2361,7 +2361,7 @@ class EditableTextGeometry {
   /// tree the semantics tree provides the placement parameters, in which
   /// case this method should not be used.
   void applyToDomElement(DomHTMLElement domElement) {
-    final String cssTransform = float64ListToCssTransform(globalTransform);
+    final String cssTransform = float32ListToCssTransform(globalTransform);
     domElement.style
       ..width = '${width}px'
       ..height = '${height}px'

--- a/lib/web_ui/lib/src/engine/util.dart
+++ b/lib/web_ui/lib/src/engine/util.dart
@@ -72,16 +72,16 @@ Future<T> futurize<T>(Callbacker<T> callbacker) {
 
 /// Converts [matrix] to CSS transform value.
 String matrix4ToCssTransform(Matrix4 matrix) {
-  return float64ListToCssTransform(matrix.storage);
+  return float32ListToCssTransform(matrix.storage);
 }
 
 /// Applies a transform to the [element].
 ///
-/// See [float64ListToCssTransform] for details on how the CSS value is chosen.
+/// See [float32ListToCssTransform] for details on how the CSS value is chosen.
 void setElementTransform(DomElement element, Float32List matrix4) {
   element.style
     ..transformOrigin = '0 0 0'
-    ..transform = float64ListToCssTransform(matrix4);
+    ..transform = float32ListToCssTransform(matrix4);
 }
 
 /// Converts [matrix] to CSS transform value.
@@ -93,13 +93,13 @@ void setElementTransform(DomElement element, Float32List matrix4) {
 /// See also:
 ///  * https://github.com/flutter/flutter/issues/32274
 ///  * https://bugs.chromium.org/p/chromium/issues/detail?id=1040222
-String float64ListToCssTransform(Float32List matrix) {
+String float32ListToCssTransform(Float32List matrix) {
   assert(matrix.length == 16);
   final TransformKind transformKind = transformKindOf(matrix);
   if (transformKind == TransformKind.transform2d || transformKind == TransformKind.translation2d) {
-    return float64ListToCssTransform2d(matrix);
+    return float32ListToCssTransform2d(matrix);
   } else if (transformKind == TransformKind.complex) {
-    return float64ListToCssTransform3d(matrix);
+    return float32ListToCssTransform3d(matrix);
   } else {
     assert(transformKind == TransformKind.identity);
     return 'none';
@@ -196,13 +196,13 @@ bool isIdentityFloat32ListTransform(Float32List matrix) {
 /// permitted. However, it is inefficient to construct a matrix for an identity
 /// transform. Consider removing the CSS `transform` property from elements
 /// that apply identity transform.
-String float64ListToCssTransform2d(Float32List matrix) {
+String float32ListToCssTransform2d(Float32List matrix) {
   assert(transformKindOf(matrix) != TransformKind.complex);
   return 'matrix(${matrix[0]},${matrix[1]},${matrix[4]},${matrix[5]},${matrix[12]},${matrix[13]})';
 }
 
 /// Converts [matrix] to a 3D CSS transform value.
-String float64ListToCssTransform3d(List<double> matrix) {
+String float32ListToCssTransform3d(List<double> matrix) {
   assert(matrix.length == 16);
   final List<double> m = matrix;
   if (m[0] == 1.0 &&

--- a/lib/web_ui/lib/src/engine/vector_math.dart
+++ b/lib/web_ui/lib/src/engine/vector_math.dart
@@ -5,6 +5,8 @@
 import 'dart:math' as math;
 import 'dart:typed_data';
 
+import 'package:meta/meta.dart';
+
 import 'util.dart';
 
 class Matrix4 {
@@ -1082,6 +1084,16 @@ class Matrix4 {
     } else {
       return super.toString();
     }
+  }
+
+  /// A convenience method for converting the matrix storage to 64-bit format.
+  ///
+  /// Normally the engine uses 32-bit matrices, so this method must not be used
+  /// in production code. It's mostly useful to emulate interactions with the
+  /// framework, where 64-bit matrices are used.
+  @visibleForTesting
+  Float64List debugToFloat64List() {
+    return Float64List.fromList(storage);
   }
 }
 

--- a/lib/web_ui/test/canvaskit/layer_test.dart
+++ b/lib/web_ui/test/canvaskit/layer_test.dart
@@ -8,6 +8,7 @@ import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' as ui;
+import 'package:web_engine_tester/golden_tester.dart';
 
 import 'common.dart';
 
@@ -51,6 +52,66 @@ void testMain() {
       final CkPictureRecorder recorder = CkPictureRecorder();
       recorder.beginRecording(ui.Rect.zero);
       LayerSceneBuilder().addPicture(ui.Offset.zero, recorder.endRecording());
+    });
+
+    test('different layer transform kinds render correctly', () async {
+      const ui.Rect region = ui.Rect.fromLTRB(0, 0, 400, 100);
+      final CkPictureRecorder recorder = CkPictureRecorder();
+      final CkCanvas canvas = recorder.beginRecording(region);
+
+      for (int row = 0; row < 6; row++) {
+        for (int column = 0; column < 3; column++) {
+          const double sideLength = 18;
+          final ui.Rect rect = ui.Rect.fromLTWH(
+            row.isEven
+                ? (column * 2) * sideLength
+                : (column * 2 + 1) * sideLength,
+            row * sideLength,
+            sideLength,
+            sideLength,
+          );
+          canvas.drawRect(rect, CkPaint()..color = const ui.Color(0xffff0000));
+        }
+      }
+      final CkPicture checkerboard = recorder.endRecording();
+
+      final LayerSceneBuilder builder = LayerSceneBuilder();
+      builder.pushOffset(50, 50);
+
+      // Paint with zero offset
+      builder.pushOffset(0, 0);
+      builder.addPicture(ui.Offset.zero, checkerboard);
+      builder.pop();
+
+      // Paint with non-zero offset
+      builder.pushOffset(150, 0);
+      builder.addPicture(ui.Offset.zero, checkerboard);
+      builder.pop();
+
+      // Paint with identity transform
+      builder.pushOffset(300, 0);
+      builder.pushTransform(Matrix4.identity().debugToFloat64List());
+      builder.addPicture(ui.Offset.zero, checkerboard);
+      builder.pop();
+      builder.pop();
+
+      // Paint with 2D translation transform
+      builder.pushOffset(450, 0);
+      builder.pushTransform(Matrix4.translationValues(1, 20, 0).debugToFloat64List());
+      builder.addPicture(ui.Offset.zero, checkerboard);
+      builder.pop();
+      builder.pop();
+
+      // Paint with general transform
+      builder.pushOffset(600, 0);
+      builder.pushTransform(Matrix4.rotationZ(0.2).debugToFloat64List());
+      builder.addPicture(ui.Offset.zero, checkerboard);
+      builder.pop();
+      builder.pop();
+
+      builder.pop();
+      EnginePlatformDispatcher.instance.rasterizer!.draw(builder.build().layerTree);
+      await matchGoldenFile('canvaskit_transform_layers.png', region: region);
     });
   });
 }

--- a/lib/web_ui/test/engine/util_test.dart
+++ b/lib/web_ui/test/engine/util_test.dart
@@ -28,10 +28,10 @@ void testMain() {
     expect(transformKindOf(zTranslation), TransformKind.complex);
     expect(isIdentityFloat32ListTransform(zTranslation), isFalse);
 
-    expect(transformKindOf(xTranslation), TransformKind.transform2d);
+    expect(transformKindOf(xTranslation), TransformKind.translation2d);
     expect(isIdentityFloat32ListTransform(xTranslation), isFalse);
 
-    expect(transformKindOf(yTranslation), TransformKind.transform2d);
+    expect(transformKindOf(yTranslation), TransformKind.translation2d);
     expect(isIdentityFloat32ListTransform(yTranslation), isFalse);
 
     expect(transformKindOf(scaleAndTranslate2d), TransformKind.transform2d);


### PR DESCRIPTION
Specializes the `OffsetEngineLayer` and `TransformEngineLayer` in CanvasKit mode. Random usage of the Gallery app shows that ~97% of all transforms are covered by identity and translation specializations.

Two specializations are introduced:

* **Identity**: for the case where the transform is a noop no extra work is required in either preroll or paint. In this case, the layer simply prerolls and paints its children. No matrices are created, and in the paint phase save/restore are eliminated.
* **Translation**: for the case when the transform is a translation along x and/or y, `SkCanvas.translate` is used, which only passes 2 on-stack floats (8 bytes) instead of a 4x4 on-heap matrix (64 bytes).

**BEFORE**: `OffsetEngineLayer` has been delegating to `TransformEngineLayer`, which in turn treated every transform as a general transform needing a full 4x4 matrix. We use float32 matrices, so each matrix needs 64 bytes to store transformation data. Copying that data from Dart to C++ has been showing up in profiles reported by a Google customer.

**AFTER**: the specializations cover 100% of `OffsetEngineLayer` needs. For `TransformEngineLayer`, clicking and scrolling randomly around the Gallery app, ~26% is covered by identity, and ~31% is covered by translation. Only ~42% need the full 4x4 matrix. Additionally, ~93% of all transforms are expressed using `OffsetEngineLayer`. So the two specializations cover ~97% of all transforms in the app. For more numbers, see [this spreadsheet](https://docs.google.com/spreadsheets/d/1YsLvPwclspLbYBNZGRmmLYl5_JSJCAskbOsCKMeK52w/edit?usp=sharing).
