### PR TITLE
Clean up some optional Dart lints

### DIFF
--- a/testing/dart/assets_test.dart
+++ b/testing/dart/assets_test.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 import 'dart:typed_data';
 import 'dart:ui';
 

--- a/testing/dart/codec_test.dart
+++ b/testing/dart/codec_test.dart
@@ -87,7 +87,7 @@ void main() {
   });
 
   test('disposed decoded image', () async {
-    Uint8List data = await _getSkiaResource('flutter_logo.jpg').readAsBytes();
+    final Uint8List data = await _getSkiaResource('flutter_logo.jpg').readAsBytes();
     final ui.Codec codec = await ui.instantiateImageCodec(data);
     final ui.FrameInfo frameInfo = await codec.getNextFrame();
     expect(frameInfo.image, isNotNull);

--- a/testing/dart/compositing_test.dart
+++ b/testing/dart/compositing_test.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:typed_data' show Float64List, Uint32List, ByteData;
+import 'dart:typed_data' show Float64List, ByteData;
 import 'dart:ui';
 
 import 'package:litetest/litetest.dart';

--- a/testing/dart/image_shader_test.dart
+++ b/testing/dart/image_shader_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:typed_data';
 import 'dart:ui';
 

--- a/testing/dart/paragraph_test.dart
+++ b/testing/dart/paragraph_test.dart
@@ -70,12 +70,12 @@ void main() {
     ));
     builder.addText('Test Ahem');
     final Paragraph paragraph = builder.build();
-    paragraph.layout(ParagraphConstraints(width: fontSize * 5.0));
+    paragraph.layout(const ParagraphConstraints(width: fontSize * 5.0));
 
     // Wraps to two lines.
     expect(paragraph.height, closeTo(fontSize * 2.0, 0.001));
 
-    final TextPosition wrapPositionDown = TextPosition(
+    const TextPosition wrapPositionDown = TextPosition(
       offset: 5,
       affinity: TextAffinity.downstream,
     );
@@ -83,7 +83,7 @@ void main() {
     expect(line.start, 5);
     expect(line.end, 9);
 
-    final TextPosition wrapPositionUp = TextPosition(
+    const TextPosition wrapPositionUp = TextPosition(
       offset: 5,
       affinity: TextAffinity.upstream,
     );
@@ -91,7 +91,7 @@ void main() {
     expect(line.start, 0);
     expect(line.end, 5);
 
-    final TextPosition wrapPositionStart = TextPosition(
+    const TextPosition wrapPositionStart = TextPosition(
       offset: 0,
       affinity: TextAffinity.downstream,
     );
@@ -99,7 +99,7 @@ void main() {
     expect(line.start, 0);
     expect(line.end, 5);
 
-    final TextPosition wrapPositionEnd = TextPosition(
+    const TextPosition wrapPositionEnd = TextPosition(
       offset: 9,
       affinity: TextAffinity.downstream,
     );
@@ -119,12 +119,12 @@ void main() {
     ));
     builder.addText('القاهرةالقاهرة');
     final Paragraph paragraph = builder.build();
-    paragraph.layout(ParagraphConstraints(width: fontSize * 5.0));
+    paragraph.layout(const ParagraphConstraints(width: fontSize * 5.0));
 
     // Wraps to three lines.
     expect(paragraph.height, closeTo(fontSize * 3.0, 0.001));
 
-    final TextPosition wrapPositionDown = TextPosition(
+    const TextPosition wrapPositionDown = TextPosition(
       offset: 5,
       affinity: TextAffinity.downstream,
     );
@@ -132,7 +132,7 @@ void main() {
     expect(line.start, 5);
     expect(line.end, 10);
 
-    final TextPosition wrapPositionUp = TextPosition(
+    const TextPosition wrapPositionUp = TextPosition(
       offset: 5,
       affinity: TextAffinity.upstream,
     );
@@ -140,7 +140,7 @@ void main() {
     expect(line.start, 0);
     expect(line.end, 5);
 
-    final TextPosition wrapPositionStart = TextPosition(
+    const TextPosition wrapPositionStart = TextPosition(
       offset: 0,
       affinity: TextAffinity.downstream,
     );
@@ -148,7 +148,7 @@ void main() {
     expect(line.start, 0);
     expect(line.end, 5);
 
-    final TextPosition wrapPositionEnd = TextPosition(
+    const TextPosition wrapPositionEnd = TextPosition(
       offset: 9,
       affinity: TextAffinity.downstream,
     );
@@ -168,12 +168,12 @@ void main() {
     ));
     builder.addText('Test\n\nAhem');
     final Paragraph paragraph = builder.build();
-    paragraph.layout(ParagraphConstraints(width: fontSize * 5.0));
+    paragraph.layout(const ParagraphConstraints(width: fontSize * 5.0));
 
     // Three lines due to line breaks, with the middle line being empty.
     expect(paragraph.height, closeTo(fontSize * 3.0, 0.001));
 
-    final TextPosition emptyLinePosition = TextPosition(
+    const TextPosition emptyLinePosition = TextPosition(
       offset: 5,
       affinity: TextAffinity.downstream,
     );
@@ -182,7 +182,7 @@ void main() {
     expect(line.end, 5);
 
     // Since these are hard newlines, TextAffinity has no effect here.
-    final TextPosition emptyLinePositionUpstream = TextPosition(
+    const TextPosition emptyLinePositionUpstream = TextPosition(
       offset: 5,
       affinity: TextAffinity.upstream,
     );
@@ -190,7 +190,7 @@ void main() {
     expect(line.start, 5);
     expect(line.end, 5);
 
-    final TextPosition endOfFirstLinePosition = TextPosition(
+    const TextPosition endOfFirstLinePosition = TextPosition(
       offset: 4,
       affinity: TextAffinity.downstream,
     );
@@ -198,7 +198,7 @@ void main() {
     expect(line.start, 0);
     expect(line.end, 4);
 
-    final TextPosition startOfLastLinePosition = TextPosition(
+    const TextPosition startOfLastLinePosition = TextPosition(
       offset: 6,
       affinity: TextAffinity.downstream,
     );

--- a/testing/dart/serial_gc_test.dart
+++ b/testing/dart/serial_gc_test.dart
@@ -6,11 +6,16 @@
 
 import 'package:litetest/litetest.dart';
 
+int use(List<int> a) {
+  return a[0];
+}
+
 void main() {
   test('Serial GC option test ', () async {
-    bool threw = false;
+    const bool threw = false;
     for (int i = 0; i < 100; i++) {
-      var a = <int>[100];
+      final List<int> a = <int>[100];
+      use(a);
     }
     expect(threw, false);
   });

--- a/testing/dart/text_test.dart
+++ b/testing/dart/text_test.dart
@@ -252,7 +252,7 @@ void testFontVariation() {
     ));
     baseBuilder.addText('Hello');
     final Paragraph baseParagraph = baseBuilder.build();
-    baseParagraph.layout(ParagraphConstraints(width: double.infinity));
+    baseParagraph.layout(const ParagraphConstraints(width: double.infinity));
     final double baseWidth = baseParagraph.minIntrinsicWidth;
 
     final ParagraphBuilder wideBuilder = ParagraphBuilder(ParagraphStyle(
@@ -262,11 +262,11 @@ void testFontVariation() {
     wideBuilder.pushStyle(TextStyle(
       fontFamily: 'RobotoSerif',
       fontSize: 40.0,
-      fontVariations: <FontVariation>[FontVariation('wght', 900.0)]
+      fontVariations: <FontVariation>[const FontVariation('wght', 900.0)],
     ));
     wideBuilder.addText('Hello');
     final Paragraph wideParagraph = wideBuilder.build();
-    wideParagraph.layout(ParagraphConstraints(width: double.infinity));
+    wideParagraph.layout(const ParagraphConstraints(width: double.infinity));
     final double wideWidth = wideParagraph.minIntrinsicWidth;
 
     expect(wideWidth, greaterThan(baseWidth));


### PR DESCRIPTION
I don't think we want to enforce being clean w.r.t. the optional lints, but the big list of these was making it tricky to see an actual error in a PR I was working on.