### PR TITLE
[Windows] Fix GDI resource leaks in the software fallback path

### DIFF
--- a/shell/platform/windows/flutter_window_win32.cc
+++ b/shell/platform/windows/flutter_window_win32.cc
@@ -249,7 +249,7 @@ void FlutterWindowWin32::OnResetImeComposing() {
 bool FlutterWindowWin32::OnBitmapSurfaceUpdated(const void* allocation,
                                                 size_t row_bytes,
                                                 size_t height) {
-  HDC dc = ::GetDC(std::get<HWND>(GetRenderTarget()));
+  HDC dc = ::GetDC(GetWindowHandle());
   BITMAPINFO bmi;
   memset(&bmi, 0, sizeof(bmi));
   bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
@@ -261,6 +261,7 @@ bool FlutterWindowWin32::OnBitmapSurfaceUpdated(const void* allocation,
   bmi.bmiHeader.biSizeImage = 0;
   int ret = SetDIBitsToDevice(dc, 0, 0, row_bytes / 4, height, 0, 0, 0, height,
                               allocation, &bmi, DIB_RGB_COLORS);
+  ::ReleaseDC(GetWindowHandle(), dc);
   return ret != 0;
 }
 

--- a/shell/platform/windows/flutter_window_win32_unittests.cc
+++ b/shell/platform/windows/flutter_window_win32_unittests.cc
@@ -211,6 +211,20 @@ TEST(FlutterWindowWin32Test, CreateDestroy) {
   ASSERT_TRUE(TRUE);
 }
 
+TEST(FlutterWindowWin32Test, OnBitmapSurfaceUpdated) {
+  FlutterWindowWin32 win32window(100, 100);
+  int old_handle_count = GetGuiResources(GetCurrentProcess(), GR_GDIOBJECTS);
+
+  constexpr size_t row_bytes = 100 * 4;
+  constexpr size_t height = 100;
+  std::array<char, row_bytes * height> allocation;
+  win32window.OnBitmapSurfaceUpdated(allocation.data(), row_bytes, height);
+
+  int new_handle_count = GetGuiResources(GetCurrentProcess(), GR_GDIOBJECTS);
+  // Check GDI resources leak
+  EXPECT_EQ(old_handle_count, new_handle_count);
+}
+
 // Tests that composing rect updates are transformed from Flutter logical
 // coordinates to device coordinates and passed to the text input manager
 // when the DPI scale is 100% (96 DPI).


### PR DESCRIPTION
In [FlutterWindowWin32::OnBitmapSurfaceUpdated()](https://github.com/flutter/engine/blob/6c321db6885fdbc33a79ced39571341c06ab2383/shell/platform/windows/flutter_window_win32.cc#L247), the ReleaseDC function is not called to release the DC.
The ReleaseDC function must be called to release the DC.


This PR will fix issue: https://github.com/flutter/flutter/issues/107368

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

