### PR TITLE
Add a missing include to FlutterSurfaceManager.mm

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm
@@ -7,6 +7,8 @@
 #import <Metal/Metal.h>
 #import <OpenGL/gl.h>
 
+#include <algorithm>
+
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterFrameBufferProvider.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterIOSurfaceHolder.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/MacOSGLContextSwitch.h"


### PR DESCRIPTION
The missing header caused an issue when building with an updated libcxx.
