### PR TITLE
Set the 'visibility' of 'FlutterView' to the previous one in 'FragmentActivityAndFragment.onStart'

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -87,6 +87,7 @@ import java.util.List;
   private boolean isFlutterUiDisplayed;
   private boolean isFirstFrameRendered;
   private boolean isAttached;
+  private Integer previousVisibility;
 
   @NonNull
   private final FlutterUiDisplayListener flutterUiDisplayListener =
@@ -399,7 +400,9 @@ import java.util.List;
     // screen when unlocked. We can work around this by changing the visibility of FlutterView in
     // onStart and onStop.
     // See https://github.com/flutter/flutter/issues/93276
-    flutterView.setVisibility(View.VISIBLE);
+    if (previousVisibility != null) {
+      flutterView.setVisibility(previousVisibility);
+    }
   }
 
   /**
@@ -599,7 +602,10 @@ import java.util.List;
     // screen when unlocked. We can work around this by changing the visibility of FlutterView in
     // onStart and onStop.
     // See https://github.com/flutter/flutter/issues/93276
-    flutterView.setVisibility(View.GONE);
+    if (flutterView.getVisibility() != View.GONE) {
+      previousVisibility = flutterView.getVisibility();
+      flutterView.setVisibility(View.GONE);
+    }
   }
 
   /**

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -602,10 +602,8 @@ import java.util.List;
     // screen when unlocked. We can work around this by changing the visibility of FlutterView in
     // onStart and onStop.
     // See https://github.com/flutter/flutter/issues/93276
-    if (flutterView.getVisibility() != View.GONE) {
-      previousVisibility = flutterView.getVisibility();
-      flutterView.setVisibility(View.GONE);
-    }
+    previousVisibility = flutterView.getVisibility();
+    flutterView.setVisibility(View.GONE);
   }
 
   /**

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
@@ -1038,11 +1038,27 @@ public class FlutterActivityAndFragmentDelegateTest {
     // Verify that the flutterView is visible.
     assertEquals(View.VISIBLE, delegate.flutterView.getVisibility());
     delegate.onStop();
-    // Verify that the flutterView is not visible.
+    // Verify that the flutterView is gone.
     assertEquals(View.GONE, delegate.flutterView.getVisibility());
     delegate.onStart();
     // Verify that the flutterView is visible.
     assertEquals(View.VISIBLE, delegate.flutterView.getVisibility());
+
+    delegate.flutterView.setVisibility(View.INVISIBLE);
+    delegate.onStop();
+    // Verify that the flutterView is gone.
+    assertEquals(View.GONE, delegate.flutterView.getVisibility());
+    delegate.onStart();
+    // Verify that the flutterView is invisible.
+    assertEquals(View.INVISIBLE, delegate.flutterView.getVisibility());
+
+    delegate.flutterView.setVisibility(View.GONE);
+    delegate.onStop();
+    // Verify that the flutterView is gone.
+    assertEquals(View.GONE, delegate.flutterView.getVisibility());
+    delegate.onStart();
+    // Verify that the flutterView is gone.
+    assertEquals(View.GONE, delegate.flutterView.getVisibility());
   }
 
   @Test


### PR DESCRIPTION
fix https://github.com/flutter/flutter/issues/105203

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.
