### PR TITLE
Android: Add ability to add report Java exceptions to Dart

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/RestorationChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/RestorationChannel.java
@@ -112,6 +112,11 @@ public class RestorationChannel {
             }
 
             @Override
+            public void errorWithException(String errorCode, Exception exception, Object errorDetails) {
+              // Unused.
+            }
+
+            @Override
             public void notImplemented() {
               // Nothing to do.
             }

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/RestorationChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/RestorationChannel.java
@@ -112,7 +112,8 @@ public class RestorationChannel {
             }
 
             @Override
-            public void errorWithException(String errorCode, Exception exception, Object errorDetails) {
+            public void errorWithException(
+                String errorCode, Exception exception, Object errorDetails) {
               // Unused.
             }
 

--- a/shell/platform/android/io/flutter/plugin/common/ErrorLogResult.java
+++ b/shell/platform/android/io/flutter/plugin/common/ErrorLogResult.java
@@ -4,6 +4,7 @@
 
 package io.flutter.plugin.common;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import io.flutter.BuildConfig;
 import io.flutter.Log;

--- a/shell/platform/android/io/flutter/plugin/common/ErrorLogResult.java
+++ b/shell/platform/android/io/flutter/plugin/common/ErrorLogResult.java
@@ -37,6 +37,15 @@ public class ErrorLogResult implements MethodChannel.Result {
   }
 
   @Override
+  public void errorWithException(
+      String errorCode, @NonNull Exception exception, @Nullable Object errorDetails) {
+    String details = (errorDetails != null) ? " details: " + errorDetails : "";
+    if (level >= Log.WARN || BuildConfig.DEBUG) {
+      Log.println(level, tag, exception.getMessage() + details);
+    }
+  }
+
+  @Override
   public void notImplemented() {
     if (level >= Log.WARN || BuildConfig.DEBUG) {
       Log.println(level, tag, "method not implemented");

--- a/shell/platform/android/io/flutter/plugin/common/MethodChannel.java
+++ b/shell/platform/android/io/flutter/plugin/common/MethodChannel.java
@@ -217,6 +217,25 @@ public class MethodChannel {
     void error(
         @NonNull String errorCode, @Nullable String errorMessage, @Nullable Object errorDetails);
 
+    /**
+     * Handles an error result.
+     *
+     * @param errorCode An error code String.
+     * @param exception The exception which is responsible for this erroneous result.
+     *     The exception message will be reported in the 
+     *     <a href="https://api.flutter.dev/flutter/services/PlatformException/message.html">
+     *     PlatformException.message</a> field on the Dart side.
+     *     The stack trace will be reported in the <a href="https://api.flutter.dev/flutter/services/PlatformException/stacktrace.html">
+     *     PlatformException.stacktrace</a> field on the Dart side.
+     * @param errorDetails Error details, possibly null. The details must be an Object type
+     *     supported by the codec. For instance, if you are using {@link StandardMessageCodec}
+     *     (default), please see its documentation on what types are supported.
+     */
+    void errorWithException(
+        @NonNull String errorCode,
+        @Nullable Exception exception,
+        @Nullable Object errorDetails);
+
     /** Handles a call to an unimplemented method. */
     void notImplemented();
   }
@@ -270,6 +289,13 @@ public class MethodChannel {
               @Override
               public void error(String errorCode, String errorMessage, Object errorDetails) {
                 reply.reply(codec.encodeErrorEnvelope(errorCode, errorMessage, errorDetails));
+              }
+
+              @Override
+              public void errorWithException(String errorCode, Exception exception, Object errorDetails) {
+                reply.reply(
+                    codec.encodeErrorEnvelopeWithStacktrace(
+                      errorCode, exception.getMessage(), errorDetails, getStackTrace(exception)));
               }
 
               @Override

--- a/shell/platform/android/io/flutter/plugin/common/MethodChannel.java
+++ b/shell/platform/android/io/flutter/plugin/common/MethodChannel.java
@@ -233,7 +233,7 @@ public class MethodChannel {
      */
     void errorWithException(
         @NonNull String errorCode,
-        @Nullable Exception exception,
+        @NonNull Exception exception,
         @Nullable Object errorDetails);
 
     /** Handles a call to an unimplemented method. */

--- a/shell/platform/android/io/flutter/plugin/common/MethodChannel.java
+++ b/shell/platform/android/io/flutter/plugin/common/MethodChannel.java
@@ -221,20 +221,18 @@ public class MethodChannel {
      * Handles an error result.
      *
      * @param errorCode An error code String.
-     * @param exception The exception which is responsible for this erroneous result.
-     *     The exception message will be reported in the 
-     *     <a href="https://api.flutter.dev/flutter/services/PlatformException/message.html">
-     *     PlatformException.message</a> field on the Dart side.
-     *     The stack trace will be reported in the <a href="https://api.flutter.dev/flutter/services/PlatformException/stacktrace.html">
+     * @param exception The exception which is responsible for this erroneous result. The exception
+     *     message will be reported in the <a
+     *     href="https://api.flutter.dev/flutter/services/PlatformException/message.html">
+     *     PlatformException.message</a> field on the Dart side. The stack trace will be reported in
+     *     the <a href="https://api.flutter.dev/flutter/services/PlatformException/stacktrace.html">
      *     PlatformException.stacktrace</a> field on the Dart side.
      * @param errorDetails Error details, possibly null. The details must be an Object type
      *     supported by the codec. For instance, if you are using {@link StandardMessageCodec}
      *     (default), please see its documentation on what types are supported.
      */
     void errorWithException(
-        @NonNull String errorCode,
-        @NonNull Exception exception,
-        @Nullable Object errorDetails);
+        @NonNull String errorCode, @NonNull Exception exception, @Nullable Object errorDetails);
 
     /** Handles a call to an unimplemented method. */
     void notImplemented();
@@ -292,10 +290,11 @@ public class MethodChannel {
               }
 
               @Override
-              public void errorWithException(String errorCode, Exception exception, Object errorDetails) {
+              public void errorWithException(
+                  String errorCode, Exception exception, Object errorDetails) {
                 reply.reply(
                     codec.encodeErrorEnvelopeWithStacktrace(
-                      errorCode, exception.getMessage(), errorDetails, getStackTrace(exception)));
+                        errorCode, exception.getMessage(), errorDetails, getStackTrace(exception)));
               }
 
               @Override

--- a/shell/platform/android/test/io/flutter/plugin/mouse/MouseCursorPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/mouse/MouseCursorPluginTest.java
@@ -68,5 +68,8 @@ class StoredResult implements MethodChannel.Result {
   public void error(String errorCode, String errorMessage, Object errorDetails) {}
 
   @Override
+  public void errorWithException(String errorCode, Exception exception, Object errorDetails) {}
+
+  @Override
   public void notImplemented() {}
 }


### PR DESCRIPTION
This PR adds the ability to send native exceptions to Dart. This enables error monitoring tools like Sentry, DataDog, Crashlytics, etc to make use of the [PlatformException.stacktrace](https://api.flutter.dev/flutter/services/PlatformException/stacktrace.html) field in more use cases.

Until now, exceptions had to be swallowed on the native side or passed in an unstructured way to the Dart side. Both solutions aren't optimal. Another solution, would be to report the native exception on the native side, but that would only work for code you control and not for third party code.

Example:
```kt
MethodChannel(binaryMessenger, "channel_name").setMethodCallHandler {
        call, result ->
      when (call.method) {
        "throw_new" -> {
          // as proposed by this PR
          // StackTrace ends up in Dart's PlatformException.stackTrace
          resul.errorWithException("code", new Exception(), null);
        }
        "throw_old" -> {
          // before this PR
          // StackTrace does not ends up in Dart's PlatformException.stackTrace
          Exception e = new Exception()
          resul.error("code", e.getMessage(), e.getStackTrace().toString());
        }
        else -> {
          result.notImplemented()
        }
      }
      result.notImplemented()
    }
  }
```

*List which issues are fixed by this PR. You must list at least one issue.*
https://github.com/flutter/flutter/issues/107392

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

If this gets accepted, I'll try to follow up with documentation updates for [PlatformException.stacktrace](https://master-api.flutter.dev/flutter/services/PlatformException/stacktrace.html) and the [plugin guide](https://docs.flutter.dev/development/packages-and-plugins/developing-packages) if necessary.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
