### PR TITLE
Add support for assertive announcements in aria-live

### DIFF
--- a/lib/web_ui/lib/src/engine/semantics/accessibility.dart
+++ b/lib/web_ui/lib/src/engine/semantics/accessibility.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:typed_data';
 
-import '../../engine.dart'  show registerHotRestartListener;
+import '../../engine.dart' show registerHotRestartListener;
 import '../dom.dart';
 import '../services.dart';
 import '../util.dart';
@@ -63,15 +63,18 @@ class AccessibilityAnnouncements {
     final Map<dynamic, dynamic> dataMap = inputMap.readDynamicJson('data');
     final String? message = dataMap.tryString('message');
     if (message != null && message.isNotEmpty) {
-      _initLiveRegion(message);
+      final bool? assertiveAnnouncement = dataMap.tryBool('assertiveAnnouncement');
+      _initLiveRegion(message, assertiveAnnouncement : assertiveAnnouncement);
       _removeElementTimer = Timer(durationA11yMessageIsOnDom, () {
         _element!.remove();
       });
     }
   }
 
-  void _initLiveRegion(String message) {
-    _domElement.setAttribute('aria-live', 'polite');
+  void _initLiveRegion(String message, {bool? assertiveAnnouncement = true}) {
+    //The default is assertive. If assertiveAnnouncement is set to false, the mode will be polite.
+    final String assertiveLevel = (assertiveAnnouncement == null || assertiveAnnouncement)? 'assertive' : 'polite';
+    _domElement.setAttribute('aria-live', assertiveLevel);
     _domElement.text = message;
     domDocument.body!.append(_domElement);
   }

--- a/lib/web_ui/test/engine/semantics/accessibility_test.dart
+++ b/lib/web_ui/test/engine/semantics/accessibility_test.dart
@@ -46,7 +46,7 @@ void testMain() {
       );
       final DomHTMLLabelElement input =
           domDocument.getElementById('accessibility-element')! as DomHTMLLabelElement;
-      expect(input.getAttribute('aria-live'), equals('polite'));
+      expect(input.getAttribute('aria-live'), equals('assertive'));
       expect(input.text, testMessage);
 
       // The element should have been removed after the duration.
@@ -54,6 +54,38 @@ void testMain() {
           accessibilityAnnouncements.durationA11yMessageIsOnDom,
           () =>
               expect(domDocument.getElementById('accessibility-element'), isNull));
+    });
+
+    test('Default value of aria-live is assertive when assertiveAnnouncement is not specified', () {
+      const Map<dynamic, dynamic> testInput = <dynamic, dynamic>{'data': <dynamic, dynamic>{'message': 'message'}};
+      accessibilityAnnouncements.handleMessage(codec, codec.encodeMessage(testInput));
+      final DomHTMLLabelElement input = domDocument.getElementById('accessibility-element')! as DomHTMLLabelElement;
+
+      expect(input.getAttribute('aria-live'), equals('assertive'));
+    });
+
+     test('aria-live is assertive when assertiveAnnouncement is set to true', () {
+      const Map<dynamic, dynamic> testInput = <dynamic, dynamic>{'data': <dynamic, dynamic>{'message': 'message', 'assertiveAnnouncement': true}};
+      accessibilityAnnouncements.handleMessage(codec, codec.encodeMessage(testInput));
+      final DomHTMLLabelElement input = domDocument.getElementById('accessibility-element')! as DomHTMLLabelElement;
+
+      expect(input.getAttribute('aria-live'), equals('assertive'));
+    });
+
+    test('aria-live is assertive when assertiveAnnouncement is null', () {
+      const Map<dynamic, dynamic> testInput = <dynamic, dynamic>{'data': <dynamic, dynamic>{'message': 'message', 'assertiveAnnouncement': null}};
+      accessibilityAnnouncements.handleMessage(codec, codec.encodeMessage(testInput));
+      final DomHTMLLabelElement input = domDocument.getElementById('accessibility-element')! as DomHTMLLabelElement;
+
+      expect(input.getAttribute('aria-live'), equals('assertive'));
+    });
+
+    test('aria-live is polite when assertiveAnnouncement is set to false', () {
+      const Map<dynamic, dynamic> testInput = <dynamic, dynamic>{'data': <dynamic, dynamic>{'message': 'message', 'assertiveAnnouncement': false}};
+      accessibilityAnnouncements.handleMessage(codec, codec.encodeMessage(testInput));
+      final DomHTMLLabelElement input = domDocument.getElementById('accessibility-element')! as DomHTMLLabelElement;
+
+      expect(input.getAttribute('aria-live'), equals('polite'));
     });
   });
 }


### PR DESCRIPTION
Add support for two different modes of aria announcements: polite/assertive.
This PR makes the default to be `assertive` and provides an optional flag to set the mode to `polite`
Fixes flutter/flutter#104109


## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
