### PR TITLE
Undo custom serialization of spell check results on Android

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/SpellCheckChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/SpellCheckChannel.java
@@ -25,9 +25,8 @@ import java.util.ArrayList;
  *
  * <p>Once the spell check results are received by the {@link
  * io.flutter.plugin.editing.SpellCheckPlugin}, it will send back to the framework the {@code
- * ArrayList<String>} of encoded spell check results (see {@link
- * io.flutter.plugin.editing.SpellCheckPlugin#onGetSentenceSuggestions} for details). For example,
- * the argument may look like: {@code {"7.11.world\nword\nold"}}. The {@link
+ * ArrayList<HashMap<String,Object>>} of spell check results (see {@link
+ * io.flutter.plugin.editing.SpellCheckPlugin#onGetSentenceSuggestions} for details). The {@link
  * io.flutter.plugin.editing.SpellCheckPlugin} only handles one request to fetch spell check results
  * at a time; see {@link io.flutter.plugin.editing.SpellCheckPlugin#initiateSpellCheck} for details.
  *

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/SpellCheckChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/SpellCheckChannel.java
@@ -8,9 +8,10 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import io.flutter.Log;
 import io.flutter.embedding.engine.dart.DartExecutor;
-import io.flutter.plugin.common.JSONMethodCodec;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
+import io.flutter.plugin.common.StandardMethodCodec;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 
@@ -75,7 +76,7 @@ public class SpellCheckChannel {
       };
 
   public SpellCheckChannel(@NonNull DartExecutor dartExecutor) {
-    channel = new MethodChannel(dartExecutor, "flutter/spellcheck", JSONMethodCodec.INSTANCE);
+    channel = new MethodChannel(dartExecutor, "flutter/spellcheck", StandardMethodCodec.INSTANCE);
     channel.setMethodCallHandler(parsingMethodHandler);
   }
 

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/SpellCheckChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/SpellCheckChannel.java
@@ -11,9 +11,7 @@ import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.StandardMethodCodec;
-
-import org.json.JSONArray;
-import org.json.JSONException;
+import java.util.ArrayList;
 
 /**
  * {@link SpellCheckChannel} is a platform channel that is used by the framework to initiate spell
@@ -60,11 +58,11 @@ public class SpellCheckChannel {
           switch (method) {
             case "SpellCheck.initiateSpellCheck":
               try {
-                final JSONArray argumentList = (JSONArray) args;
-                String locale = argumentList.getString(0);
-                String text = argumentList.getString(1);
+                final ArrayList<String> argumentList = (ArrayList<String>) args;
+                String locale = argumentList.get(0);
+                String text = argumentList.get(1);
                 spellCheckMethodHandler.initiateSpellCheck(locale, text, result);
-              } catch (JSONException exception) {
+              } catch (IllegalStateException exception) {
                 result.error("error", exception.getMessage(), null);
               }
               break;

--- a/shell/platform/android/io/flutter/plugin/editing/SpellCheckPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/SpellCheckPlugin.java
@@ -15,6 +15,7 @@ import io.flutter.embedding.engine.systemchannels.SpellCheckChannel;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.localization.LocalizationPlugin;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Locale;
 
 /**
@@ -117,7 +118,8 @@ public class SpellCheckPlugin
       return;
     }
 
-    ArrayList<String> spellCheckerSuggestionSpans = new ArrayList<String>();
+    ArrayList<HashMap<String, Object>> spellCheckerSuggestionSpans =
+        new ArrayList<HashMap<String, Object>>();
     SentenceSuggestionsInfo spellCheckResults = results[0];
 
     for (int i = 0; i < spellCheckResults.getSuggestionsCount(); i++) {
@@ -128,19 +130,20 @@ public class SpellCheckPlugin
         continue;
       }
 
-      String spellCheckerSuggestionSpan = "";
+      HashMap<String, Object> spellCheckerSuggestionSpan = new HashMap<String, Object>();
       int start = spellCheckResults.getOffsetAt(i);
-      int end = start + spellCheckResults.getLengthAt(i) - 1;
+      int end = start + spellCheckResults.getLengthAt(i);
 
-      spellCheckerSuggestionSpan += String.valueOf(start) + ".";
-      spellCheckerSuggestionSpan += String.valueOf(end) + ".";
+      spellCheckerSuggestionSpan.put("start", start);
+      spellCheckerSuggestionSpan.put("end", end);
 
+      ArrayList<String> suggestions = new ArrayList<String>();
       for (int j = 0; j < suggestionsCount; j++) {
-        spellCheckerSuggestionSpan += suggestionsInfo.getSuggestionAt(j) + "\n";
+        suggestions.add(suggestionsInfo.getSuggestionAt(j));
       }
 
-      spellCheckerSuggestionSpans.add(
-          spellCheckerSuggestionSpan.substring(0, spellCheckerSuggestionSpan.length() - 1));
+      spellCheckerSuggestionSpan.put("suggestions", suggestions);
+      spellCheckerSuggestionSpans.add(spellCheckerSuggestionSpan);
     }
 
     pendingResult.success(spellCheckerSuggestionSpans);

--- a/shell/platform/android/io/flutter/plugin/editing/SpellCheckPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/SpellCheckPlugin.java
@@ -35,6 +35,10 @@ public class SpellCheckPlugin
   private final TextServicesManager mTextServicesManager;
   private SpellCheckerSession mSpellCheckerSession;
 
+  public static final String START_INDEX_KEY = "startIndex";
+  public static final String END_INDEX_KEY = "endIndex";
+  public static final String SUGGESTIONS_KEY = "suggestions";
+
   @VisibleForTesting MethodChannel.Result pendingResult;
 
   // The maximum number of suggestions that the Android spell check service is allowed to provide
@@ -142,15 +146,15 @@ public class SpellCheckPlugin
       int start = spellCheckResults.getOffsetAt(i);
       int end = start + spellCheckResults.getLengthAt(i);
 
-      spellCheckerSuggestionSpan.put("startIndex", start);
-      spellCheckerSuggestionSpan.put("endIndex", end);
+      spellCheckerSuggestionSpan.put(START_INDEX_KEY, start);
+      spellCheckerSuggestionSpan.put(END_INDEX_KEY, end);
 
       ArrayList<String> suggestions = new ArrayList<String>();
       for (int j = 0; j < suggestionsCount; j++) {
         suggestions.add(suggestionsInfo.getSuggestionAt(j));
       }
 
-      spellCheckerSuggestionSpan.put("suggestions", suggestions);
+      spellCheckerSuggestionSpan.put(SUGGESTIONS_KEY, suggestions);
       spellCheckerSuggestionSpans.add(spellCheckerSuggestionSpan);
     }
 

--- a/shell/platform/android/io/flutter/plugin/editing/SpellCheckPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/SpellCheckPlugin.java
@@ -106,14 +106,22 @@ public class SpellCheckPlugin
    * Callback for Android spell check API that decomposes results and send results through the
    * {@link SpellCheckChannel}.
    *
-   * <p>Spell check results will be encoded as a string representing the span of that result, with
-   * the format "start_index.end_index.suggestion_1/nsuggestion_2/nsuggestion_3", where there may be
-   * up to 5 suggestions.
+   * <p>Spell check results are encoded as dictionaries with a format that looks like
+   *
+   * <pre>{@code
+   * {
+   *   startIndex: 0,
+   *   endIndex: 5,
+   *   suggestions: [hello, ...]
+   * }
+   * }</pre>
+   *
+   * where there may be up to 5 suggestions.
    */
   @Override
   public void onGetSentenceSuggestions(SentenceSuggestionsInfo[] results) {
     if (results.length == 0) {
-      pendingResult.success(new ArrayList<String>());
+      pendingResult.success(new ArrayList<HashMap<String, Object>>());
       pendingResult = null;
       return;
     }
@@ -134,8 +142,8 @@ public class SpellCheckPlugin
       int start = spellCheckResults.getOffsetAt(i);
       int end = start + spellCheckResults.getLengthAt(i);
 
-      spellCheckerSuggestionSpan.put("start", start);
-      spellCheckerSuggestionSpan.put("end", end);
+      spellCheckerSuggestionSpan.put("startIndex", start);
+      spellCheckerSuggestionSpan.put("endIndex", end);
 
       ArrayList<String> suggestions = new ArrayList<String>();
       for (int j = 0; j < suggestionsCount; j++) {

--- a/shell/platform/android/test/io/flutter/plugin/editing/SpellCheckPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/SpellCheckPluginTest.java
@@ -21,12 +21,13 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.embedding.engine.systemchannels.SpellCheckChannel;
 import io.flutter.plugin.common.BinaryMessenger;
-import io.flutter.plugin.common.JSONMethodCodec;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
+import io.flutter.plugin.common.StandardMethodCodec;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Locale;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -38,7 +39,7 @@ public class SpellCheckPluginTest {
   private static void sendToBinaryMessageHandler(
       BinaryMessenger.BinaryMessageHandler binaryMessageHandler, String method, Object args) {
     MethodCall methodCall = new MethodCall(method, args);
-    ByteBuffer encodedMethodCall = JSONMethodCodec.INSTANCE.encodeMethodCall(methodCall);
+    ByteBuffer encodedMethodCall = StandardMethodCodec.INSTANCE.encodeMethodCall(methodCall);
     binaryMessageHandler.onMessage(
         (ByteBuffer) encodedMethodCall.flip(), mock(BinaryMessenger.BinaryReply.class));
   }
@@ -185,7 +186,7 @@ public class SpellCheckPluginTest {
 
     spellCheckPlugin.onGetSentenceSuggestions(new SentenceSuggestionsInfo[] {});
 
-    verify(mockResult).success(new ArrayList<String>());
+    verify(mockResult).success(new ArrayList<HashMap<String, Object>>());
   }
 
   @Test
@@ -209,6 +210,14 @@ public class SpellCheckPluginTest {
               new int[] {5})
         });
 
-    verify(mockResult).success(new ArrayList<String>(Arrays.asList("7.11.world\nword\nold")));
+    ArrayList<HashMap<String, Object>> expectedResults = new ArrayList<HashMap<String, Object>>();
+    HashMap<String, Object> expectedResult = new HashMap<String, Object>();
+
+    expectedResult.put("startIndex", 7);
+    expectedResult.put("endIndex", 12);
+    expectedResult.put("suggestions", new ArrayList<String>(Arrays.asList("world", "word", "old")));
+    expectedResults.add(expectedResult);
+
+    verify(mockResult).success(expectedResults);
   }
 }

--- a/shell/platform/android/test/io/flutter/plugin/editing/SpellCheckPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/SpellCheckPluginTest.java
@@ -213,9 +213,11 @@ public class SpellCheckPluginTest {
     ArrayList<HashMap<String, Object>> expectedResults = new ArrayList<HashMap<String, Object>>();
     HashMap<String, Object> expectedResult = new HashMap<String, Object>();
 
-    expectedResult.put("startIndex", 7);
-    expectedResult.put("endIndex", 12);
-    expectedResult.put("suggestions", new ArrayList<String>(Arrays.asList("world", "word", "old")));
+    expectedResult.put(SpellCheckPlugin.START_INDEX_KEY, 7);
+    expectedResult.put(SpellCheckPlugin.END_INDEX_KEY, 12);
+    expectedResult.put(
+        SpellCheckPlugin.SUGGESTIONS_KEY,
+        new ArrayList<String>(Arrays.asList("world", "word", "old")));
     expectedResults.add(expectedResult);
 
     verify(mockResult).success(expectedResults);


### PR DESCRIPTION
Undoes custom serialization of spell check results on Android as discussed [here](https://github.com/flutter/engine/pull/34356#discussion_r909074738) and changes codec to `StandardMethodCodec` to match iOS.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
