### PR TITLE
[Impeller] Adds FragmentProgram.fromAsset

### DIFF
--- a/impeller/compiler/reflector.cc
+++ b/impeller/compiler/reflector.cc
@@ -331,6 +331,7 @@ std::shared_ptr<RuntimeStageData> Reflector::GenerateRuntimeStageData() const {
         uniform_description.type = spir_type.basetype;
         uniform_description.rows = spir_type.vecsize;
         uniform_description.columns = spir_type.columns;
+        uniform_description.bit_width = spir_type.width;
         data->AddUniformDescription(std::move(uniform_description));
       });
   return data;

--- a/impeller/compiler/runtime_stage_data.cc
+++ b/impeller/compiler/runtime_stage_data.cc
@@ -55,11 +55,12 @@ static std::optional<fb::TargetPlatform> ToTargetPlatform(
     case TargetPlatform::kMetalDesktop:
     case TargetPlatform::kMetalIOS:
     case TargetPlatform::kFlutterSPIRV:
-    case TargetPlatform::kSkSL:
     case TargetPlatform::kOpenGLES:
     case TargetPlatform::kOpenGLDesktop:
     case TargetPlatform::kVulkan:
       return std::nullopt;
+    case TargetPlatform::kSkSL:
+      return fb::TargetPlatform::kSkSL;
     case TargetPlatform::kRuntimeStageMetal:
       return fb::TargetPlatform::kMetal;
     case TargetPlatform::kRuntimeStageGLES:
@@ -155,6 +156,7 @@ std::shared_ptr<fml::Mapping> RuntimeStageData::CreateMapping() const {
       return nullptr;
     }
     desc->type = uniform_type.value();
+    desc->bit_width = uniform.bit_width;
 
     runtime_stage.uniforms.emplace_back(std::move(desc));
   }

--- a/impeller/compiler/runtime_stage_data.h
+++ b/impeller/compiler/runtime_stage_data.h
@@ -21,6 +21,7 @@ struct UniformDescription {
   spirv_cross::SPIRType::BaseType type = spirv_cross::SPIRType::BaseType::Float;
   size_t rows = 0u;
   size_t columns = 0u;
+  size_t bit_width = 0u;
 };
 
 class RuntimeStageData {

--- a/impeller/runtime_stage/runtime_stage.cc
+++ b/impeller/runtime_stage/runtime_stage.cc
@@ -85,7 +85,9 @@ RuntimeStage::RuntimeStage(std::shared_ptr<fml::Mapping> payload)
     desc.name = i->name()->str();
     desc.location = i->location();
     desc.type = ToType(i->type());
-    desc.dimensions = RuntimeUniformDimensions{i->rows(), i->columns()};
+    desc.dimensions = RuntimeUniformDimensions{
+        static_cast<size_t>(i->rows()), static_cast<size_t>(i->columns())};
+    desc.bit_width = i->bit_width();
     uniforms_.emplace_back(std::move(desc));
   }
 

--- a/impeller/runtime_stage/runtime_stage.fbs
+++ b/impeller/runtime_stage/runtime_stage.fbs
@@ -15,6 +15,7 @@ enum Stage:byte {
 enum TargetPlatform:byte {
   kMetal,
   kOpenGLES,
+  kSkSL,
 }
 
 enum UniformDataType:uint32 {
@@ -37,6 +38,7 @@ table UniformDescription {
   name: string;
   location: uint64;
   type: UniformDataType;
+  bit_width: uint64;
   rows: uint64;
   columns: uint64;
 }

--- a/impeller/runtime_stage/runtime_stage.h
+++ b/impeller/runtime_stage/runtime_stage.h
@@ -40,7 +40,10 @@ struct RuntimeUniformDescription {
   size_t location = 0u;
   RuntimeUniformType type = kFloat;
   RuntimeUniformDimensions dimensions;
+  size_t bit_width;
 };
+
+size_t SizeOfRuntimeUniformType(RuntimeUniformType type);
 
 class RuntimeStage {
  public:

--- a/lib/spirv/test/BUILD.gn
+++ b/lib/spirv/test/BUILD.gn
@@ -21,7 +21,9 @@ if (enable_unittests) {
   }
 
   group("test") {
+    testonly = true
     deps = [
+      ":fixtures",
       ":sksl_ink_sparkle",
       ":spirv_ink_sparkle",
       "//flutter/lib/spirv/test/exception_shaders:spirv_compile_exception_shaders",
@@ -42,5 +44,18 @@ if (enable_unittests) {
     shader_target_flag = "--sksl"
     intermediates_subdir = "sksl"
     sl_file_extension = "sksl"
+  }
+
+  impellerc("iplr_ink_sparkle") {
+    shaders = [ "//flutter/impeller/fixtures/ink_sparkle.frag" ]
+    shader_target_flag = "--sksl"
+    intermediates_subdir = "iplr"
+    sl_file_extension = "iplr"
+  }
+
+  test_fixtures("fixtures") {
+    deps = [ ":iplr_ink_sparkle" ]
+    fixtures = get_target_outputs(":iplr_ink_sparkle")
+    dest = "$root_gen_dir/flutter/lib/ui"
   }
 }

--- a/lib/spirv/test/general_shaders/BUILD.gn
+++ b/lib/spirv/test/general_shaders/BUILD.gn
@@ -17,7 +17,9 @@ if (enable_unittests) {
   ]
 
   group("general_shaders") {
+    testonly = true
     deps = [
+      ":fixtures",
       ":sksl_compile_general_shaders",
       ":spirv_compile_general_shaders",
     ]
@@ -34,5 +36,18 @@ if (enable_unittests) {
     shader_target_flag = "--sksl"
     intermediates_subdir = "sksl"
     sl_file_extension = "sksl"
+  }
+
+  impellerc("sksl_compile_general_shaders_iplr") {
+    shaders = test_shaders
+    shader_target_flag = "--sksl"
+    intermediates_subdir = "iplr"
+    sl_file_extension = "iplr"
+  }
+
+  test_fixtures("fixtures") {
+    deps = [ ":sksl_compile_general_shaders_iplr" ]
+    fixtures = get_target_outputs(":sksl_compile_general_shaders_iplr")
+    dest = "$root_gen_dir/flutter/lib/ui"
   }
 }

--- a/lib/spirv/test/supported_glsl_op_shaders/BUILD.gn
+++ b/lib/spirv/test/supported_glsl_op_shaders/BUILD.gn
@@ -44,7 +44,9 @@ if (enable_unittests) {
   ]
 
   group("supported_glsl_op_shaders") {
+    testonly = true
     deps = [
+      ":fixtures",
       ":sksl_compile_supported_glsl_shaders",
       ":spirv_compile_supported_glsl_shaders",
     ]
@@ -61,5 +63,18 @@ if (enable_unittests) {
     shader_target_flag = "--sksl"
     intermediates_subdir = "sksl"
     sl_file_extension = "sksl"
+  }
+
+  impellerc("iplr_compile_supported_glsl_shaders") {
+    shaders = test_shaders
+    shader_target_flag = "--sksl"
+    intermediates_subdir = "iplr"
+    sl_file_extension = "iplr"
+  }
+
+  test_fixtures("fixtures") {
+    deps = [ ":iplr_compile_supported_glsl_shaders" ]
+    fixtures = get_target_outputs(":iplr_compile_supported_glsl_shaders")
+    dest = "$root_gen_dir/flutter/lib/ui"
   }
 }

--- a/lib/spirv/test/supported_op_shaders/BUILD.gn
+++ b/lib/spirv/test/supported_op_shaders/BUILD.gn
@@ -40,7 +40,9 @@ if (enable_unittests) {
   ]
 
   group("supported_op_shaders") {
+    testonly = true
     deps = [
+      ":fixtures",
       ":sksl_compile_supported_op_shaders",
       ":spirv_compile_supported_op_shaders",
     ]
@@ -57,5 +59,18 @@ if (enable_unittests) {
     shader_target_flag = "--sksl"
     intermediates_subdir = "sksl"
     sl_file_extension = "sksl"
+  }
+
+  impellerc("iplr_compile_supported_op_shaders") {
+    shaders = test_shaders
+    shader_target_flag = "--sksl"
+    intermediates_subdir = "iplr"
+    sl_file_extension = "iplr"
+  }
+
+  test_fixtures("fixtures") {
+    deps = [ ":iplr_compile_supported_op_shaders" ]
+    fixtures = get_target_outputs(":iplr_compile_supported_op_shaders")
+    dest = "$root_gen_dir/flutter/lib/ui"
   }
 }

--- a/lib/ui/BUILD.gn
+++ b/lib/ui/BUILD.gn
@@ -148,6 +148,7 @@ source_set("ui") {
     "//flutter/common",
     "//flutter/display_list",
     "//flutter/fml",
+    "//flutter/impeller/runtime_stage",
     "//flutter/runtime:dart_plugin_registrant",
     "//flutter/runtime:test_font",
     "//flutter/third_party/tonic",

--- a/lib/ui/dart_ui.cc
+++ b/lib/ui/dart_ui.cc
@@ -162,6 +162,7 @@ typedef CanvasPath Path;
   V(ColorFilter, initSrgbToLinearGamma, 1)             \
   V(EngineLayer, dispose, 1)                           \
   V(FragmentProgram, init, 3)                          \
+  V(FragmentProgram, initFromAsset, 2)                 \
   V(FragmentProgram, shader, 4)                        \
   V(Gradient, initLinear, 6)                           \
   V(Gradient, initRadial, 8)                           \

--- a/lib/ui/natives.dart
+++ b/lib/ui/natives.dart
@@ -47,11 +47,26 @@ const Endian _kFakeHostEndian = Endian.little;
 // A service protocol extension to schedule a frame to be rendered into the
 // window.
 Future<developer.ServiceExtensionResponse> _scheduleFrame(
-    String method,
-    Map<String, String> parameters
-    ) async {
+  String method,
+  Map<String, String> parameters,
+) async {
   // Schedule the frame.
   PlatformDispatcher.instance.scheduleFrame();
+  // Always succeed.
+  return developer.ServiceExtensionResponse.result(json.encode(<String, String>{
+    'type': 'Success',
+  }));
+}
+
+Future<developer.ServiceExtensionResponse> _reinitializeShader(
+  String method,
+  Map<String, String> parameters,
+) async {
+  final String? assetKey = parameters['assetKey'];
+  if (assetKey != null) {
+    FragmentProgram._reinitializeShader(assetKey);
+  }
+
   // Always succeed.
   return developer.ServiceExtensionResponse.result(json.encode(<String, String>{
     'type': 'Success',
@@ -63,6 +78,12 @@ void _setupHooks() {
   assert(() {
     // In debug mode, register the schedule frame extension.
     developer.registerExtension('ext.ui.window.scheduleFrame', _scheduleFrame);
+
+    // In debug mode, allow shaders to be reinitialized.
+    developer.registerExtension(
+      'ext.ui.window.reinitializeShader',
+      _reinitializeShader,
+    );
     return true;
   }());
 }

--- a/lib/ui/painting/fragment_program.h
+++ b/lib/ui/painting/fragment_program.h
@@ -24,6 +24,8 @@ class FragmentProgram : public RefCountedDartWrappable<FragmentProgram> {
   ~FragmentProgram() override;
   static void Create(Dart_Handle wrapper);
 
+  void initFromAsset(std::string asset_name);
+
   void init(std::string sksl, bool debugPrintSksl);
 
   fml::RefPtr<FragmentShader> shader(Dart_Handle shader,

--- a/lib/ui/painting/image_decoder.cc
+++ b/lib/ui/painting/image_decoder.cc
@@ -6,9 +6,9 @@
 
 #include "flutter/lib/ui/painting/image_decoder_skia.h"
 
-#if IMPELLER_SUPPORTS_PLATFORM
+#if IMPELLER_SUPPORTS_RENDERING
 #include "flutter/lib/ui/painting/image_decoder_impeller.h"
-#endif  // IMPELLER_SUPPORTS_PLATFORM
+#endif  // IMPELLER_SUPPORTS_RENDERING
 
 namespace flutter {
 
@@ -17,7 +17,7 @@ std::unique_ptr<ImageDecoder> ImageDecoder::Make(
     TaskRunners runners,
     std::shared_ptr<fml::ConcurrentTaskRunner> concurrent_task_runner,
     fml::WeakPtr<IOManager> io_manager) {
-#if IMPELLER_SUPPORTS_PLATFORM
+#if IMPELLER_SUPPORTS_RENDERING
   if (settings.enable_impeller) {
     return std::make_unique<ImageDecoderImpeller>(
         std::move(runners),                 //
@@ -25,7 +25,7 @@ std::unique_ptr<ImageDecoder> ImageDecoder::Make(
         std::move(io_manager)               //
     );
   }
-#endif  // IMPELLER_SUPPORTS_PLATFORM
+#endif  // IMPELLER_SUPPORTS_RENDERING
   return std::make_unique<ImageDecoderSkia>(
       std::move(runners),                 //
       std::move(concurrent_task_runner),  //

--- a/lib/web_ui/lib/painting.dart
+++ b/lib/web_ui/lib/painting.dart
@@ -845,6 +845,10 @@ class FragmentProgram {
     throw UnsupportedError('FragmentProgram is not supported for the CanvasKit or HTML renderers.');
   }
 
+  static FragmentProgram fromAsset(String assetKey) {
+    throw UnsupportedError('FragmentProgram is not supported for the CanvasKit or HTML renderers.');
+  }
+
   FragmentProgram._();
 
   Shader shader({

--- a/testing/testing.gni
+++ b/testing/testing.gni
@@ -246,10 +246,19 @@ template("dart_snapshot") {
 # Arguments:
 #
 #     fixtures (required): The list of fixtures to copy.
+#
+#     dest (optional): When specified, the fixtures are placed under an
+#                      'assets' subdirectory of this path rather than an
+#                      'assets' subdirectory of target_gen_dir.
 template("copy_fixtures") {
   testonly = true
 
   assert(defined(invoker.fixtures), "The test fixtures must be specified.")
+
+  dest = target_gen_dir
+  if (defined(invoker.dest)) {
+    dest = invoker.dest
+  }
 
   has_fixtures = false
   foreach(fixture, invoker.fixtures) {
@@ -259,7 +268,7 @@ template("copy_fixtures") {
   if (has_fixtures) {
     copy(target_name) {
       sources = invoker.fixtures
-      outputs = [ "$target_gen_dir/assets/{{source_file_part}}" ]
+      outputs = [ "$dest/assets/{{source_file_part}}" ]
       forward_variables_from(invoker, [ "deps" ])
     }
   } else {
@@ -289,8 +298,21 @@ template("copy_fixtures") {
 #     dart_main (optional): The path to the main Dart file. If specified, it is
 #                           snapshotted.
 #
-#     use_target_as_artifact_prefix(optional): If true, adds the target name as prefix of the kernel and AOT ELF snapshot filename.
+#     use_target_as_artifact_prefix(optional): If true, adds the target name as
+#         prefix of the kernel and AOT ELF snapshot filename.
+#
+#     dest (optional): When specified, the fixtures are placed under an
+#                      'assets' subdirectory of this path rather than an
+#                      'assets' subdirectory of target_gen_dir.
 template("test_fixtures") {
+  dest = target_gen_dir
+  if (defined(invoker.dest)) {
+    dest = invoker.dest
+  }
+
+  # Not all paths use 'dest'
+  not_needed([ "dest" ])
+
   # Even if no fixtures are present, the location of the fixtures directory
   # must always be known to tests.
   fixtures_location_target_name = "_fl_$target_name"
@@ -298,7 +320,7 @@ template("test_fixtures") {
     if (is_fuchsia) {
       assets_dir = "/pkg/data/assets"
     } else {
-      assets_dir = "$target_gen_dir/assets"
+      assets_dir = "$dest/assets"
     }
   }
   test_deps = [ ":$fixtures_location_target_name" ]
@@ -309,6 +331,7 @@ template("test_fixtures") {
     copy_fixtures_target_name = "_cf_$target_name"
     copy_fixtures(copy_fixtures_target_name) {
       fixtures = invoker.fixtures
+      dest = dest
       forward_variables_from(invoker, [ "deps" ])
     }
     test_public_deps += [ ":$copy_fixtures_target_name" ]


### PR DESCRIPTION
This PR adds the API `FragmentProgram.fromAsset`, which loads a shader in `.iplr` format as output by `impellerc` directly from a bundled asset into a `FragmentProgram` object. Since `impellerc` has already compiled the shader into the correct target-specific format, there is no need for the shader to transit the Dart heap or to be transpiled by the Engine's SPIR-V -> SkSL transpiler.