### PR TITLE
Reimplement ForceRedraw() using the ScheduleFrame embedder API

### DIFF
--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -475,6 +475,10 @@ void FlutterWindowsEngine::ReloadSystemFonts() {
   embedder_api_.ReloadSystemFonts(engine_);
 }
 
+void FlutterWindowsEngine::ScheduleFrame() {
+  embedder_api_.ScheduleFrame(engine_);
+}
+
 void FlutterWindowsEngine::SendSystemLocales() {
   std::vector<LanguageInfo> languages = GetPreferredLanguageInfo();
   std::vector<FlutterLocale> flutter_locales;

--- a/shell/platform/windows/flutter_windows_engine.h
+++ b/shell/platform/windows/flutter_windows_engine.h
@@ -160,6 +160,9 @@ class FlutterWindowsEngine {
   // Informs the engine that the system font list has changed.
   void ReloadSystemFonts();
 
+  // Informs the engine that a new frame is needed to redraw the content.
+  void ScheduleFrame();
+
   // Attempts to register the texture with the given |texture_id|.
   bool RegisterExternalTexture(int64_t texture_id);
 

--- a/shell/platform/windows/flutter_windows_engine_unittests.cc
+++ b/shell/platform/windows/flutter_windows_engine_unittests.cc
@@ -374,5 +374,20 @@ TEST(FlutterWindowsEngine, AddPluginRegistrarDestructionCallback) {
   EXPECT_EQ(result2, 2);
 }
 
+TEST(FlutterWindowsEngine, ScheduleFrame) {
+  std::unique_ptr<FlutterWindowsEngine> engine = GetTestEngine();
+  EngineModifier modifier(engine.get());
+
+  bool called = false;
+  modifier.embedder_api().ScheduleFrame =
+      MOCK_ENGINE_PROC(ScheduleFrame, ([&called](auto engine) {
+                         called = true;
+                         return kSuccess;
+                       }));
+
+  engine->ScheduleFrame();
+  EXPECT_TRUE(called);
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -117,11 +117,8 @@ uint32_t FlutterWindowsView::GetFrameBufferId(size_t width, size_t height) {
 
 void FlutterWindowsView::ForceRedraw() {
   if (resize_status_ == ResizeState::kDone) {
-    // Request new frame
-    // TODO(knopp): Replace with more specific call once there is API for it
-    // https://github.com/flutter/flutter/issues/69716
-    SendWindowMetrics(resize_target_width_, resize_target_height_,
-                      binding_handler_->GetDpiScale());
+    // Request new frame.
+    engine_->ScheduleFrame();
   }
 }
 

--- a/shell/platform/windows/flutter_windows_view_unittests.cc
+++ b/shell/platform/windows/flutter_windows_view_unittests.cc
@@ -587,23 +587,15 @@ TEST(FlutterWindowsViewTest, WindowRepaintTests) {
   view.SetEngine(std::move(engine));
   view.CreateRenderSurface();
 
-  bool send_window_metrics_event_called = false;
-  size_t width = 0;
-  size_t height = 0;
-  modifier.embedder_api().SendWindowMetricsEvent = MOCK_ENGINE_PROC(
-      SendWindowMetricsEvent,
-      ([&send_window_metrics_event_called, &width, &height](
-           auto engine, const FlutterWindowMetricsEvent* event) {
-        send_window_metrics_event_called = true;
-        width = event->width;
-        height = event->height;
-        return kSuccess;
-      }));
+  bool schedule_frame_called = false;
+  modifier.embedder_api().ScheduleFrame =
+      MOCK_ENGINE_PROC(ScheduleFrame, ([&schedule_frame_called](auto engine) {
+                         schedule_frame_called = true;
+                         return kSuccess;
+                       }));
 
   view.OnWindowRepaint();
-  EXPECT_TRUE(send_window_metrics_event_called);
-  EXPECT_EQ(width, 100);
-  EXPECT_EQ(height, 100);
+  EXPECT_TRUE(schedule_frame_called);
 }
 
 }  // namespace testing


### PR DESCRIPTION
Need to reimplement FlutterWindowsView::ForceRedraw(), since we have added an embedder.h API for requesting a redraw.

See: https://github.com/flutter/flutter/issues/69716

*List which issues are fixed by this PR. You must list at least one issue.*
https://github.com/flutter/flutter/issues/107623

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
