### PR TITLE
Skip test that crashes platform

### DIFF
--- a/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenariosui/PlatformViewWithSurfaceViewUiTest.java
+++ b/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenariosui/PlatformViewWithSurfaceViewUiTest.java
@@ -12,6 +12,7 @@ import androidx.test.rule.ActivityTestRule;
 import androidx.test.runner.AndroidJUnit4;
 import dev.flutter.scenarios.PlatformViewsActivity;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -124,9 +125,12 @@ public class PlatformViewWithSurfaceViewUiTest {
         goldName("testPlatformViewWithoutOverlayIntersection"));
   }
 
+  // TODO(dnfield): This is not safe until https://github.com/flutter/flutter/issues/31990
+  // is resolved.
+  @Ignore
   @Test
   public void testPlatformViewLargerThanDisplaySize() throws Exception {
-    // Regression test for https://github.com/flutter/flutter/issues/2897.
+    // Regression test for https://github.com/flutter/flutter/issues/28978.
     intent.putExtra("scenario_name", "platform_view_larger_than_display_size");
     ScreenshotUtil.capture(
         activityRule.launchActivity(intent), goldName("testPlatformViewLargerThanDisplaySize"));

--- a/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenariosui/PlatformViewWithSurfaceViewUiTest.java
+++ b/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenariosui/PlatformViewWithSurfaceViewUiTest.java
@@ -127,7 +127,7 @@ public class PlatformViewWithSurfaceViewUiTest {
 
   // TODO(dnfield): This is not safe until https://github.com/flutter/flutter/issues/31990
   // is resolved.
-  @Ignore
+  @Ignore("not safe until https://github.com/flutter/flutter/issues/31990 is resolved")
   @Test
   public void testPlatformViewLargerThanDisplaySize() throws Exception {
     // Regression test for https://github.com/flutter/flutter/issues/28978.

--- a/testing/scenario_app/lib/src/platform_view.dart
+++ b/testing/scenario_app/lib/src/platform_view.dart
@@ -117,7 +117,7 @@ class PlatformViewNoOverlayIntersectionScenario extends Scenario
 
 /// A platform view that is larger than the display size.
 /// This is only applicable on Android while using virtual displays.
-/// Related issue: https://github.com/flutter/flutter/issues/2897.
+/// Related issue: https://github.com/flutter/flutter/issues/28978.
 class PlatformViewLargerThanDisplaySize extends Scenario
     with _BasePlatformViewScenarioMixin {
   /// Creates the PlatformView scenario.


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/107667

Skips test that intentionally creates a vastly oversized platform view using the Virtual Display backend, which causes a crash.

This test was made flaky by https://github.com/flutter/engine/pull/34414

We can't safely run it until the underlying issue is fixed - the suggestion I gave @blasten turned out to cause unintended regressions.