### PR TITLE
[gn + artifacts] dart-sdk mac entitlement configs

### DIFF
--- a/build/archives/BUILD.gn
+++ b/build/archives/BUILD.gn
@@ -127,23 +127,41 @@ zip_bundle("flutter_patched_sdk") {
   ]
 }
 
+generated_file("dart_sdk_entitlement_config") {
+  outputs = [ "$target_gen_dir/dart_sdk_entitlements.txt" ]
+
+  contents = [
+    "dart-sdk/bin/dart",
+    "dart-sdk/bin/dartaotruntime",
+    "dart-sdk/bin/utils/gen_snapshot",
+  ]
+
+  deps = []
+}
+
 # Flutter consumes the dart sdk as a prebuilt. Rather than regenerating
 # the zip file we are just copying the original file to the artifacts location.
 if (build_engine_artifacts && flutter_prebuilt_dart_sdk) {
   zip_bundle("dart_sdk_archive") {
-    deps = []
+    deps = [ ":dart_sdk_entitlement_config" ]
     output = "dart-sdk-$full_target_platform_name.zip"
-    if (is_mac) {
-      # Mac artifacts sometimes use mac and sometimes darwin. Standardizing the
-      # names will require changes in the list of artifacts the tool is downloading.
-      output = "dart-sdk-darwin-$target_cpu.zip"
-    }
     files = [
       {
         source = prebuilt_dart_sdk
         destination = "dart-sdk"
       },
     ]
+    if (is_mac) {
+      # Mac artifacts sometimes use mac and sometimes darwin. Standardizing the
+      # names will require changes in the list of artifacts the tool is downloading.
+      output = "dart-sdk-darwin-$target_cpu.zip"
+      files += [
+        {
+          source = "$target_gen_dir/dart_sdk_entitlements.txt"
+          destination = "entitlements.txt"
+        },
+      ]
+    }
   }
 }
 

--- a/build/archives/BUILD.gn
+++ b/build/archives/BUILD.gn
@@ -130,6 +130,8 @@ zip_bundle("flutter_patched_sdk") {
 generated_file("dart_sdk_entitlement_config") {
   outputs = [ "$target_gen_dir/dart_sdk_entitlements.txt" ]
 
+  # Dart SDK is a prebuilt archive. The rule for building
+  # Dart SDK is https://github.com/flutter/engine/blob/main/BUILD.gn#L61
   contents = [
     "dart-sdk/bin/dart",
     "dart-sdk/bin/dartaotruntime",


### PR DESCRIPTION
This is the mac entitlement config file to be embedded in dart-sdk-darwin-arm64.zip and dart-sdk-darwin-x64.zip. 

dart-sdk is built by copying prebuilt_dart_sdk, which points to files under `prebuilts/`. But prebuilts is a generated folder and it looks like it doesn't have a BUILD.gn file. In this case I am not sure what the leaf node targets would be. So I added them as `contents`(as opposed to `data_keys`) at the parent level (as opposed to at the leaf level). This might not be the correct approach, would be great if the experts could help take a look. Thank you!
