### PR TITLE
[iOS] Remove deprecated metal texture cache and commandqueue

### DIFF
--- a/shell/platform/darwin/ios/ios_context_metal_skia.h
+++ b/shell/platform/darwin/ios/ios_context_metal_skia.h
@@ -34,8 +34,6 @@ class IOSContextMetalSkia final : public IOSContext {
 
  private:
   fml::scoped_nsobject<FlutterDarwinContextMetal> darwin_context_metal_;
-  fml::scoped_nsprotocol<id<MTLCommandQueue>> main_command_queue_;
-  fml::CFRef<CVMetalTextureCacheRef> texture_cache_;
 
   // |IOSContext|
   sk_sp<GrDirectContext> CreateResourceContext() override;

--- a/shell/platform/darwin/ios/ios_context_metal_skia.mm
+++ b/shell/platform/darwin/ios/ios_context_metal_skia.mm
@@ -15,25 +15,6 @@ namespace flutter {
 IOSContextMetalSkia::IOSContextMetalSkia(MsaaSampleCount msaa_samples) : IOSContext(msaa_samples) {
   darwin_context_metal_ = fml::scoped_nsobject<FlutterDarwinContextMetal>{
       [[FlutterDarwinContextMetal alloc] initWithDefaultMTLDevice]};
-
-  if (!darwin_context_metal_) {
-    return;
-  }
-
-  main_command_queue_.reset([darwin_context_metal_.get().commandQueue retain]);
-
-  CVMetalTextureCacheRef texture_cache_raw = NULL;
-  auto cv_return = CVMetalTextureCacheCreate(kCFAllocatorDefault,  // allocator
-                                             NULL,  // cache attributes (NULL default)
-                                             darwin_context_metal_.get().device,  // metal device
-                                             NULL,  // texture attributes (NULL default)
-                                             &texture_cache_raw  // [out] cache
-  );
-  if (cv_return != kCVReturnSuccess) {
-    FML_DLOG(ERROR) << "Could not create Metal texture cache.";
-    return;
-  }
-  texture_cache_.Reset(texture_cache_raw);
 }
 
 IOSContextMetalSkia::~IOSContextMetalSkia() = default;


### PR DESCRIPTION
Remove the deprecated metal texture cache and commandqueue, we do that all in `FlutterDarwinContextMetal`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
