### PR TITLE
[gn + ci/builders/json] add snapshot for arm64

### DIFF
--- a/ci/builders/mac_host_engine.json
+++ b/ci/builders/mac_host_engine.json
@@ -143,7 +143,8 @@
                 {
                     "base_path": "out/mac_debug_arm64/zip_archives/",
                     "include_paths": [
-                        "out/mac_debug_arm64/zip_archives/dart-sdk-darwin-arm64.zip"
+                        "out/mac_debug_arm64/zip_archives/dart-sdk-darwin-arm64.zip",
+                        "out/mac_debug_arm64/zip_archives/darwin-x64/gen_snapshot.zip"
                     ],
                     "name": "mac_debug_arm64"
                 }
@@ -170,7 +171,8 @@
             "ninja": {
                 "config": "mac_debug_arm64",
                 "targets": [
-                    "flutter/build/archives:dart_sdk_archive"
+                    "flutter/build/archives:dart_sdk_archive",
+                    "flutter/build/archives:archive_gen_snapshot"
                 ]
             },
             "tests": []
@@ -179,7 +181,9 @@
             "archives": [
                 {
                     "base_path": "out/mac_profile_arm64/zip_archives/",
-                    "include_paths": [],
+                    "include_paths": [
+                        "out/mac_profile_arm64/zip_archives/darwin-x64/gen_snapshot.zip"
+                    ],
                     "name": "mac_profile_arm64"
                 }
             ],
@@ -203,7 +207,9 @@
             "name": "mac_profile_arm64",
             "ninja": {
                 "config": "mac_profile_arm64",
-                "targets": []
+                "targets": [
+                    "flutter/build/archives:archive_gen_snapshot"
+                ]
             },
             "tests": []
         },
@@ -211,7 +217,9 @@
             "archives": [
                 {
                     "base_path": "out/mac_release_arm64/zip_archives/",
-                    "include_paths": [],
+                    "include_paths": [
+                        "out/mac_release_arm64/zip_archives/darwin-x64/gen_snapshot.zip"
+                    ],
                     "name": "mac_release_arm64"
                 }
             ],
@@ -235,7 +243,9 @@
             "name": "mac_release_arm64",
             "ninja": {
                 "config": "mac_release_arm64",
-                "targets": []
+                "targets": [
+                    "flutter/build/archives:archive_gen_snapshot" 
+                ]
             },
             "tests": []
         }

--- a/ci/builders/mac_host_engine.json
+++ b/ci/builders/mac_host_engine.json
@@ -244,7 +244,7 @@
             "ninja": {
                 "config": "mac_release_arm64",
                 "targets": [
-                    "flutter/build/archives:archive_gen_snapshot" 
+                    "flutter/build/archives:archive_gen_snapshot"
                 ]
             },
             "tests": []


### PR DESCRIPTION
This PR aims to add gen_snapshot_arm64 to artifacts such as darwin-x64/gen_snapshot.zip, darwin-x64-profile/gen_snapshot.zip and darwin-x64-release/gen_snapshot.zip.

My understanding is that we need the '-mac-cpu=arm64' flag in gn commands to include the arm64 snapshots. However, This implies we would create the arm64 snapshots in a different out directory from the x64 snapshots. For example, without the '-mac-cpu=arm64' flag, the out directory is out/host_debug/zip_archives/. And with the '-mac-cpu=arm64' flag, the directory out/mac_debug_arm64/zip_archives/.

Would be great if the experts could take a look. Thank you!