### PR TITLE
[Impeller] Add TSize type param to TRect::MakeSize

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -459,10 +459,8 @@ TEST_P(AiksTest, CanRenderItalicizedText) {
 
 TEST_P(AiksTest, CanRenderEmojiTextFrame) {
   Canvas canvas;
-  ASSERT_TRUE(RenderTextInCanvas(
-      GetContext(), canvas,
-      "😀 😃 😄 😁 😆 😅 😂 🤣 🥲 ☺️ 😊",
-      "NotoColorEmoji.ttf"));
+  ASSERT_TRUE(RenderTextInCanvas(GetContext(), canvas, "😀 😃 😄 😁 😆 😅 😂 🤣 🥲 ☺️ 😊",
+                                 "NotoColorEmoji.ttf"));
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
@@ -839,8 +837,9 @@ TEST_P(AiksTest, DrawRectStrokesRenderCorrectly) {
   paint.stroke_width = 10;
 
   canvas.Translate({100, 100});
-  canvas.DrawPath(PathBuilder{}.AddRect(Rect::MakeSize({100, 100})).TakePath(),
-                  {paint});
+  canvas.DrawPath(
+      PathBuilder{}.AddRect(Rect::MakeSize(Size{100, 100})).TakePath(),
+      {paint});
 
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
@@ -912,11 +911,11 @@ TEST_P(AiksTest, CanRenderClippedLayers) {
     canvas.SaveLayer({}, Rect::MakeXYWH(50, 50, 100, 100));
 
     // Fill the layer with white.
-    canvas.DrawRect(Rect::MakeSize({400, 400}), {.color = Color::White()});
+    canvas.DrawRect(Rect::MakeSize(Size{400, 400}), {.color = Color::White()});
     // Fill the layer with green, but do so with a color blend that can't be
     // collapsed into the parent pass.
     canvas.DrawRect(
-        Rect::MakeSize({400, 400}),
+        Rect::MakeSize(Size{400, 400}),
         {.color = Color::Green(), .blend_mode = Entity::BlendMode::kColorBurn});
   }
 

--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -208,7 +208,7 @@ void Canvas::DrawImage(std::shared_ptr<Image> image,
     return;
   }
 
-  const auto source = Rect::MakeSize(Size(image->GetSize()));
+  const auto source = Rect::MakeSize(image->GetSize());
   const auto dest =
       Rect::MakeXYWH(offset.x, offset.y, source.size.width, source.size.height);
 

--- a/impeller/aiks/paint_pass_delegate.cc
+++ b/impeller/aiks/paint_pass_delegate.cc
@@ -35,11 +35,10 @@ bool PaintPassDelegate::CanCollapseIntoParentPass() {
 std::shared_ptr<Contents> PaintPassDelegate::CreateContentsForSubpassTarget(
     std::shared_ptr<Texture> target) {
   auto contents = std::make_shared<TextureContents>();
-  contents->SetPath(PathBuilder{}
-                        .AddRect(Rect::MakeSize(Size(target->GetSize())))
-                        .TakePath());
+  contents->SetPath(
+      PathBuilder{}.AddRect(Rect::MakeSize(target->GetSize())).TakePath());
   contents->SetTexture(target);
-  contents->SetSourceRect(Rect::MakeSize(Size(target->GetSize())));
+  contents->SetSourceRect(Rect::MakeSize(target->GetSize()));
   contents->SetOpacity(paint_.color.alpha);
   return contents;
 }

--- a/impeller/entity/contents/filters/blend_filter_contents.cc
+++ b/impeller/entity/contents/filters/blend_filter_contents.cc
@@ -199,10 +199,9 @@ static bool PipelineBlend(const FilterInput::Vector& inputs,
 
   if (foreground_color.has_value()) {
     auto contents = std::make_shared<SolidColorContents>();
-    contents->SetPath(
-        PathBuilder{}
-            .AddRect(Rect::MakeSize(Size(pass.GetRenderTargetSize())))
-            .TakePath());
+    contents->SetPath(PathBuilder{}
+                          .AddRect(Rect::MakeSize(pass.GetRenderTargetSize()))
+                          .TakePath());
     contents->SetColor(foreground_color.value());
 
     Entity foreground_entity;

--- a/impeller/entity/contents/filters/filter_contents.cc
+++ b/impeller/entity/contents/filters/filter_contents.cc
@@ -142,7 +142,7 @@ bool FilterContents::Render(const ContentContext& renderer,
   contents->SetPath(
       PathBuilder{}.AddRect(filter_coverage.value()).GetCurrentPath());
   contents->SetTexture(snapshot.texture);
-  contents->SetSourceRect(Rect::MakeSize(Size(snapshot.texture->GetSize())));
+  contents->SetSourceRect(Rect::MakeSize(snapshot.texture->GetSize()));
 
   Entity e;
   e.SetBlendMode(entity.GetBlendMode());

--- a/impeller/entity/contents/filters/inputs/texture_filter_input.cc
+++ b/impeller/entity/contents/filters/inputs/texture_filter_input.cc
@@ -24,7 +24,7 @@ std::optional<Snapshot> TextureFilterInput::GetSnapshot(
 
 std::optional<Rect> TextureFilterInput::GetCoverage(
     const Entity& entity) const {
-  return Rect::MakeSize(Size(texture_->GetSize()))
+  return Rect::MakeSize(texture_->GetSize())
       .TransformBounds(GetTransform(entity));
 }
 

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -160,8 +160,7 @@ bool EntityPass::Render(ContentContext& renderer,
     render_pass->SetLabel("EntityPass Root Render Pass");
 
     {
-      auto size_rect =
-          Rect::MakeSize(Size(offscreen_target.GetRenderTargetSize()));
+      auto size_rect = Rect::MakeSize(offscreen_target.GetRenderTargetSize());
       auto contents = std::make_shared<TextureContents>();
       contents->SetPath(PathBuilder{}.AddRect(size_rect).TakePath());
       contents->SetTexture(offscreen_target.GetRenderTargetTexture());
@@ -252,7 +251,7 @@ EntityPass::EntityResult EntityPass::GetEntityForElement(
     }
 
     auto subpass_coverage =
-        GetSubpassCoverage(*subpass, Rect::MakeSize(Size(root_pass_size)));
+        GetSubpassCoverage(*subpass, Rect::MakeSize(root_pass_size));
 
     if (backdrop_contents) {
       auto backdrop_coverage = backdrop_contents->GetCoverage(Entity{});
@@ -269,7 +268,7 @@ EntityPass::EntityResult EntityPass::GetEntityForElement(
 
     if (subpass_coverage.has_value()) {
       subpass_coverage =
-          subpass_coverage->Intersection(Rect::MakeSize(Size(root_pass_size)));
+          subpass_coverage->Intersection(Rect::MakeSize(root_pass_size));
     }
 
     if (!subpass_coverage.has_value()) {

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -139,7 +139,7 @@ TEST_P(EntityTest, FilterCoverageRespectsCropRect) {
   // Without the crop rect (default behavior).
   {
     auto actual = filter->GetCoverage({});
-    auto expected = Rect::MakeSize(Size(image->GetSize()));
+    auto expected = Rect::MakeSize(image->GetSize());
 
     ASSERT_TRUE(actual.has_value());
     ASSERT_RECT_NEAR(actual.value(), expected);
@@ -887,7 +887,7 @@ TEST_P(EntityTest, GaussianBlurFilter) {
 
     if (selected_input_type == 0) {
       auto texture = std::make_shared<TextureContents>();
-      auto input_rect = Rect::MakeSize(Size(boston->GetSize()));
+      auto input_rect = Rect::MakeSize(boston->GetSize());
       texture->SetSourceRect(input_rect);
       texture->SetPath(PathBuilder{}.AddRect(input_rect).TakePath());
       texture->SetTexture(boston);
@@ -897,7 +897,7 @@ TEST_P(EntityTest, GaussianBlurFilter) {
       input_size = input_rect.size;
     } else {
       auto fill = std::make_shared<SolidColorContents>();
-      auto input_rect = Rect::MakeSize(Size(boston->GetSize()));
+      auto input_rect = Rect::MakeSize(boston->GetSize());
       fill->SetColor(input_color);
       fill->SetPath(PathBuilder{}.AddRect(input_rect).TakePath());
 
@@ -934,7 +934,7 @@ TEST_P(EntityTest, GaussianBlurFilter) {
     // unfiltered input.
     Entity cover_entity;
     cover_entity.SetContents(SolidColorContents::Make(
-        PathBuilder{}.AddRect(Rect::MakeSize(Size(input_size))).TakePath(),
+        PathBuilder{}.AddRect(Rect::MakeSize(input_size)).TakePath(),
         cover_color));
     cover_entity.SetTransformation(ctm);
 

--- a/impeller/geometry/geometry_unittests.cc
+++ b/impeller/geometry/geometry_unittests.cc
@@ -837,6 +837,36 @@ TEST(GeometryTest, CanConvertBetweenDegressAndRadians) {
   }
 }
 
+TEST(GeometryTest, RectMakeSize) {
+  {
+    Size s(100, 200);
+    Rect r = Rect::MakeSize(s);
+    Rect expected = Rect::MakeLTRB(0, 0, 100, 200);
+    ASSERT_RECT_NEAR(r, expected);
+  }
+
+  {
+    ISize s(100, 200);
+    Rect r = Rect::MakeSize(s);
+    Rect expected = Rect::MakeLTRB(0, 0, 100, 200);
+    ASSERT_RECT_NEAR(r, expected);
+  }
+
+  {
+    Size s(100, 200);
+    IRect r = IRect::MakeSize(s);
+    IRect expected = IRect::MakeLTRB(0, 0, 100, 200);
+    ASSERT_EQ(r, expected);
+  }
+
+  {
+    ISize s(100, 200);
+    IRect r = IRect::MakeSize(s);
+    IRect expected = IRect::MakeLTRB(0, 0, 100, 200);
+    ASSERT_EQ(r, expected);
+  }
+}
+
 TEST(GeometryTest, RectUnion) {
   {
     Rect a(100, 100, 100, 100);

--- a/impeller/geometry/rect.h
+++ b/impeller/geometry/rect.h
@@ -48,7 +48,8 @@ struct TRect {
     return TRect(x, y, width, height);
   }
 
-  constexpr static TRect MakeSize(const TSize<Type>& size) {
+  template <class U>
+  constexpr static TRect MakeSize(const TSize<U>& size) {
     return TRect(0.0, 0.0, size.width, size.height);
   }
 

--- a/impeller/playground/imgui/imgui_impl_impeller.cc
+++ b/impeller/playground/imgui/imgui_impl_impeller.cc
@@ -224,8 +224,8 @@ void ImGui_ImplImpeller_RenderDrawData(ImDrawData* draw_data,
         {
           // Clamp the clip to ensure it never goes outside of the render
           // target.
-          auto visible_clip = clip_rect.Intersection(impeller::Rect::MakeSize(
-              impeller::Size(render_pass.GetRenderTargetSize())));
+          auto visible_clip = clip_rect.Intersection(
+              impeller::Rect::MakeSize(render_pass.GetRenderTargetSize()));
           if (!visible_clip.has_value()) {
             continue;  // Nothing to render.
           }

--- a/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -473,7 +473,7 @@ bool RenderPassGLES::EncodeCommands(
 
   auto pass_data = std::make_shared<RenderPassData>();
   pass_data->label = label_;
-  pass_data->viewport.rect = Rect::MakeSize(Size(GetRenderTargetSize()));
+  pass_data->viewport.rect = Rect::MakeSize(GetRenderTargetSize());
 
   //----------------------------------------------------------------------------
   /// Setup color data.

--- a/impeller/renderer/backend/metal/render_pass_mtl.mm
+++ b/impeller/renderer/backend/metal/render_pass_mtl.mm
@@ -431,7 +431,7 @@ bool RenderPassMTL::EncodeCommands(const std::shared_ptr<Allocator>& allocator,
     [encoder setStencilReferenceValue:command.stencil_reference];
 
     auto v = command.viewport.value_or<Viewport>(
-        {.rect = Rect::MakeSize(Size(GetRenderTargetSize()))});
+        {.rect = Rect::MakeSize(GetRenderTargetSize())});
     MTLViewport viewport = {
         .originX = v.rect.origin.x,
         .originY = v.rect.origin.y,


### PR DESCRIPTION
Friction fix for a redundant conversion that bugs me whenever I run across it.