### PR TITLE
[Impeller] Move front-face and winding order specification to pipeline.

### DIFF
--- a/impeller/playground/imgui/imgui_impl_impeller.cc
+++ b/impeller/playground/imgui/imgui_impl_impeller.cc
@@ -239,7 +239,6 @@ void ImGui_ImplImpeller_RenderDrawData(ImDrawData* draw_data,
         cmd.viewport = viewport;
         cmd.scissor = impeller::IRect(clip_rect);
 
-        cmd.winding = impeller::WindingOrder::kClockwise;
         cmd.pipeline = bd->pipeline;
         VS::BindUniformBuffer(cmd, vtx_uniforms);
         FS::BindTex(cmd, bd->font_texture, bd->sampler);

--- a/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -319,7 +319,7 @@ struct RenderPassData {
     //--------------------------------------------------------------------------
     /// Setup culling.
     ///
-    switch (command.cull_mode) {
+    switch (pipeline.GetDescriptor().GetCullMode()) {
       case CullMode::kNone:
         gl.Disable(GL_CULL_FACE);
         break;
@@ -335,7 +335,7 @@ struct RenderPassData {
     //--------------------------------------------------------------------------
     /// Setup winding order.
     ///
-    switch (command.winding) {
+    switch (pipeline.GetDescriptor().GetWindingOrder()) {
       case WindingOrder::kClockwise:
         gl.FrontFace(GL_CW);
         break;

--- a/impeller/renderer/backend/metal/render_pass_mtl.mm
+++ b/impeller/renderer/backend/metal/render_pass_mtl.mm
@@ -408,14 +408,13 @@ bool RenderPassMTL::EncodeCommands(const std::shared_ptr<Allocator>& allocator,
       auto_pop_debug_marker.Release();
     }
 
-    if (target_sample_count !=
-        command.pipeline->GetDescriptor().GetSampleCount()) {
+    const auto& pipeline_desc = command.pipeline->GetDescriptor();
+    if (target_sample_count != pipeline_desc.GetSampleCount()) {
       VALIDATION_LOG << "Pipeline for command and the render target disagree "
                         "on sample counts (target was "
                      << static_cast<uint64_t>(target_sample_count)
                      << " but pipeline wanted "
-                     << static_cast<uint64_t>(
-                            command.pipeline->GetDescriptor().GetSampleCount())
+                     << static_cast<uint64_t>(pipeline_desc.GetSampleCount())
                      << ").";
       return false;
     }
@@ -424,10 +423,11 @@ bool RenderPassMTL::EncodeCommands(const std::shared_ptr<Allocator>& allocator,
         PipelineMTL::Cast(*command.pipeline).GetMTLRenderPipelineState());
     pass_bindings.SetDepthStencilState(
         PipelineMTL::Cast(*command.pipeline).GetMTLDepthStencilState());
-    [encoder setFrontFacingWinding:command.winding == WindingOrder::kClockwise
+    [encoder setFrontFacingWinding:pipeline_desc.GetWindingOrder() ==
+                                           WindingOrder::kClockwise
                                        ? MTLWindingClockwise
                                        : MTLWindingCounterClockwise];
-    [encoder setCullMode:ToMTLCullMode(command.cull_mode)];
+    [encoder setCullMode:ToMTLCullMode(pipeline_desc.GetCullMode())];
     [encoder setStencilReferenceValue:command.stencil_reference];
 
     auto v = command.viewport.value_or<Viewport>(

--- a/impeller/renderer/command.h
+++ b/impeller/renderer/command.h
@@ -108,20 +108,6 @@ struct Command {
   ///
   PrimitiveType primitive_type = PrimitiveType::kTriangle;
   //----------------------------------------------------------------------------
-  /// The orientation of vertices of the front-facing polygons. This usually
-  /// matters when culling is enabled.
-  ///
-  /// @see         `cull_mode`
-  ///
-  WindingOrder winding = WindingOrder::kClockwise;
-  //----------------------------------------------------------------------------
-  /// How to control culling of polygons. The orientation of front-facing
-  /// polygons is controlled via the `winding` parameter.
-  ///
-  /// @see         `winding`
-  ///
-  CullMode cull_mode = CullMode::kNone;
-  //----------------------------------------------------------------------------
   /// The reference value to use in stenciling operations. Stencil configuration
   /// is part of pipeline setup and can be read from the pipelines descriptor.
   ///

--- a/impeller/renderer/pipeline_descriptor.cc
+++ b/impeller/renderer/pipeline_descriptor.cc
@@ -38,6 +38,8 @@ std::size_t PipelineDescriptor::GetHash() const {
   fml::HashCombineSeed(seed, depth_attachment_descriptor_);
   fml::HashCombineSeed(seed, front_stencil_attachment_descriptor_);
   fml::HashCombineSeed(seed, back_stencil_attachment_descriptor_);
+  fml::HashCombineSeed(seed, winding_order_);
+  fml::HashCombineSeed(seed, cull_mode_);
   return seed;
 }
 
@@ -53,7 +55,9 @@ bool PipelineDescriptor::IsEqual(const PipelineDescriptor& other) const {
          front_stencil_attachment_descriptor_ ==
              other.front_stencil_attachment_descriptor_ &&
          back_stencil_attachment_descriptor_ ==
-             other.back_stencil_attachment_descriptor_;
+             other.back_stencil_attachment_descriptor_ &&
+         winding_order_ == other.winding_order_ &&
+         cull_mode_ == other.cull_mode_;
 }
 
 PipelineDescriptor& PipelineDescriptor::SetLabel(std::string label) {
@@ -207,6 +211,22 @@ PipelineDescriptor::GetBackStencilAttachmentDescriptor() const {
 bool PipelineDescriptor::HasStencilAttachmentDescriptors() const {
   return front_stencil_attachment_descriptor_.has_value() ||
          back_stencil_attachment_descriptor_.has_value();
+}
+
+void PipelineDescriptor::SetCullMode(CullMode mode) {
+  cull_mode_ = mode;
+}
+
+CullMode PipelineDescriptor::GetCullMode() const {
+  return cull_mode_;
+}
+
+void PipelineDescriptor::SetWindingOrder(WindingOrder order) {
+  winding_order_ = order;
+}
+
+WindingOrder PipelineDescriptor::GetWindingOrder() const {
+  return winding_order_;
 }
 
 }  // namespace impeller

--- a/impeller/renderer/pipeline_descriptor.h
+++ b/impeller/renderer/pipeline_descriptor.h
@@ -18,6 +18,7 @@
 #include "impeller/base/comparable.h"
 #include "impeller/renderer/formats.h"
 #include "impeller/renderer/shader_types.h"
+#include "impeller/tessellator/tessellator.h"
 
 namespace impeller {
 
@@ -105,9 +106,19 @@ class PipelineDescriptor final : public Comparable<PipelineDescriptor> {
 
   void ResetAttachments();
 
+  void SetCullMode(CullMode mode);
+
+  CullMode GetCullMode() const;
+
+  void SetWindingOrder(WindingOrder order);
+
+  WindingOrder GetWindingOrder() const;
+
  private:
   std::string label_;
   SampleCount sample_count_ = SampleCount::kCount1;
+  WindingOrder winding_order_ = WindingOrder::kClockwise;
+  CullMode cull_mode_ = CullMode::kNone;
   std::map<ShaderStage, std::shared_ptr<const ShaderFunction>> entrypoints_;
   std::map<size_t /* index */, ColorAttachmentDescriptor>
       color_attachment_descriptors_;

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -111,6 +111,7 @@ TEST_P(RendererTest, CanRenderPerspectiveCube) {
   ASSERT_TRUE(context);
   auto desc = PipelineBuilder<VS, FS>::MakeDefaultPipelineDescriptor(*context);
   ASSERT_TRUE(desc.has_value());
+  desc->SetCullMode(CullMode::kBackFace);
   desc->SetSampleCount(SampleCount::kCount4);
   auto pipeline =
       context->GetPipelineLibrary()->GetRenderPipeline(std::move(desc)).get();
@@ -194,7 +195,6 @@ TEST_P(RendererTest, CanRenderPerspectiveCube) {
                           pass.GetTransientsBuffer().EmplaceUniform(uniforms));
 
     cmd.primitive_type = PrimitiveType::kTriangle;
-    cmd.cull_mode = CullMode::kBackFace;
     if (!pass.AddCommand(std::move(cmd))) {
       return false;
     }
@@ -483,7 +483,6 @@ TEST_P(RendererTest, TheImpeller) {
                          {Point(0, size.height)},
                          {Point(size.width, size.height)}});
     cmd.BindVertices(builder.CreateVertexBuffer(pass.GetTransientsBuffer()));
-    cmd.cull_mode = CullMode::kNone;
 
     VS::FrameInfo vs_uniform;
     vs_uniform.mvp = Matrix::MakeOrthographic(size);


### PR DESCRIPTION
Impeller doesn't need to specify this on a per command basis and moving
this to the pipeline makes more information available during pipeline
state object creation. This helps for backends like Vulkan.

Fixes https://github.com/flutter/flutter/issues/106380