### PR TITLE
[Impeller] Remove CommandT.

### DIFF
--- a/impeller/renderer/command.h
+++ b/impeller/renderer/command.h
@@ -190,41 +190,4 @@ struct Command {
   constexpr operator bool() const { return pipeline && pipeline->IsValid(); }
 };
 
-template <class VertexShader_, class FragmentShader_>
-struct CommandT {
-  using VertexShader = VertexShader_;
-  using FragmentShader = FragmentShader_;
-  using VertexBufferBuilder =
-      VertexBufferBuilder<typename VertexShader_::PerVertexData>;
-  using Pipeline = PipelineT<VertexShader_, FragmentShader_>;
-
-  CommandT(PipelineT<VertexShader, FragmentShader>& pipeline) {
-    command_.label = VertexShader::kLabel;
-
-    // This could be moved to the accessor to delay the wait.
-    command_.pipeline = pipeline.WaitAndGet();
-  }
-
-  static VertexBufferBuilder CreateVertexBuilder() {
-    VertexBufferBuilder builder;
-    builder.SetLabel(std::string{VertexShader::kLabel});
-    return builder;
-  }
-
-  Command& Get() { return command_; }
-
-  operator Command&() { return Get(); }
-
-  bool BindVertices(VertexBufferBuilder builder, HostBuffer& buffer) {
-    return command_.BindVertices(builder.CreateVertexBuffer(buffer));
-  }
-
-  bool BindVerticesDynamic(const VertexBuffer& buffer) {
-    return command_.BindVertices(buffer);
-  }
-
- private:
-  Command command_;
-};
-
 }  // namespace impeller


### PR DESCRIPTION
This is dead code and was part of earlier prototype for typed commands. While
the concept is somewhat safer, we didn't end up using it since there were gaps
in the implementation and just restricting the typing to pipeline generation was
sufficient for our use cases.