### PR TITLE
[Impeller] Frustum culling

### DIFF
--- a/impeller/entity/contents/clip_contents.cc
+++ b/impeller/entity/contents/clip_contents.cc
@@ -33,8 +33,13 @@ void ClipContents::SetClipOperation(Entity::ClipOperation clip_op) {
 }
 
 std::optional<Rect> ClipContents::GetCoverage(const Entity& entity) const {
-  return path_.GetTransformedBoundingBox(entity.GetTransformation());
+  return std::nullopt;
 };
+
+bool ClipContents::ShouldRender(const Entity& entity,
+                                const RenderPass& pass) const {
+  return true;
+}
 
 bool ClipContents::Render(const ContentContext& renderer,
                           const Entity& entity,
@@ -108,6 +113,11 @@ std::optional<Rect> ClipRestoreContents::GetCoverage(
     const Entity& entity) const {
   return std::nullopt;
 };
+
+bool ClipRestoreContents::ShouldRender(const Entity& entity,
+                                       const RenderPass& pass) const {
+  return true;
+}
 
 bool ClipRestoreContents::Render(const ContentContext& renderer,
                                  const Entity& entity,

--- a/impeller/entity/contents/clip_contents.h
+++ b/impeller/entity/contents/clip_contents.h
@@ -28,6 +28,10 @@ class ClipContents final : public Contents {
   std::optional<Rect> GetCoverage(const Entity& entity) const override;
 
   // |Contents|
+  bool ShouldRender(const Entity& entity,
+                    const RenderPass& pass) const override;
+
+  // |Contents|
   bool Render(const ContentContext& renderer,
               const Entity& entity,
               RenderPass& pass) const override;
@@ -47,6 +51,10 @@ class ClipRestoreContents final : public Contents {
 
   // |Contents|
   std::optional<Rect> GetCoverage(const Entity& entity) const override;
+
+  // |Contents|
+  bool ShouldRender(const Entity& entity,
+                    const RenderPass& pass) const override;
 
   // |Contents|
   bool Render(const ContentContext& renderer,

--- a/impeller/entity/contents/contents.cc
+++ b/impeller/entity/contents/contents.cc
@@ -57,4 +57,12 @@ std::optional<Snapshot> Contents::RenderToSnapshot(
                   .transform = Matrix::MakeTranslation(bounds->origin)};
 }
 
+bool Contents::ShouldRender(const Entity& entity,
+                            const RenderPass& pass) const {
+  auto coverage = GetCoverage(entity);
+  return coverage.has_value() &&
+         Rect::MakeSize(Size(pass.GetRenderTargetSize()))
+             .IntersectsWithRect(coverage.value());
+}
+
 }  // namespace impeller

--- a/impeller/entity/contents/contents.h
+++ b/impeller/entity/contents/contents.h
@@ -47,6 +47,8 @@ class Contents {
       const ContentContext& renderer,
       const Entity& entity) const;
 
+  virtual bool ShouldRender(const Entity& entity, const RenderPass& pass) const;
+
  protected:
 
  private:

--- a/impeller/entity/entity.cc
+++ b/impeller/entity/entity.cc
@@ -41,6 +41,10 @@ std::optional<Rect> Entity::GetCoverage() const {
   return contents_->GetCoverage(*this);
 }
 
+bool Entity::ShouldRender(const RenderPass& pass) const {
+  return contents_->ShouldRender(*this, pass);
+}
+
 void Entity::SetContents(std::shared_ptr<Contents> contents) {
   contents_ = std::move(contents);
 }

--- a/impeller/entity/entity.cc
+++ b/impeller/entity/entity.cc
@@ -33,16 +33,12 @@ bool Entity::AddsToCoverage() const {
   return adds_to_coverage_;
 }
 
-std::optional<Rect> Entity::GetCoverage(bool use_cache) const {
+std::optional<Rect> Entity::GetCoverage() const {
   if (!adds_to_coverage_ || !contents_) {
     return std::nullopt;
   }
 
-  if (!use_cache || !coverage_cache_.has_value()) {
-    coverage_cache_ = contents_->GetCoverage(*this);
-  }
-
-  return coverage_cache_.value();
+  return contents_->GetCoverage(*this);
 }
 
 void Entity::SetContents(std::shared_ptr<Contents> contents) {

--- a/impeller/entity/entity.cc
+++ b/impeller/entity/entity.cc
@@ -33,12 +33,16 @@ bool Entity::AddsToCoverage() const {
   return adds_to_coverage_;
 }
 
-std::optional<Rect> Entity::GetCoverage() const {
+std::optional<Rect> Entity::GetCoverage(bool use_cache) const {
   if (!adds_to_coverage_ || !contents_) {
     return std::nullopt;
   }
 
-  return contents_->GetCoverage(*this);
+  if (!use_cache || !coverage_cache_.has_value()) {
+    coverage_cache_ = contents_->GetCoverage(*this);
+  }
+
+  return coverage_cache_.value();
 }
 
 void Entity::SetContents(std::shared_ptr<Contents> contents) {

--- a/impeller/entity/entity.h
+++ b/impeller/entity/entity.h
@@ -81,6 +81,8 @@ class Entity {
 
   std::optional<Rect> GetCoverage() const;
 
+  bool ShouldRender(const RenderPass& pass) const;
+
   void SetContents(std::shared_ptr<Contents> contents);
 
   const std::shared_ptr<Contents>& GetContents() const;

--- a/impeller/entity/entity.h
+++ b/impeller/entity/entity.h
@@ -79,7 +79,14 @@ class Entity {
 
   bool AddsToCoverage() const;
 
-  std::optional<Rect> GetCoverage() const;
+  /// @brief      Get the screen space bounding rectangle that this entity will
+  ///             affect when rendered.
+  /// @param[in]  use_cache  When `false`, always compute the coverage (and
+  ///                        overwrite the cached coverage). When `true`, return
+  ///                        the cached coverage if populated. Coverage is
+  ///                        always computed if the cache has not yet been
+  ///                        populated.
+  std::optional<Rect> GetCoverage(bool use_cache = false) const;
 
   void SetContents(std::shared_ptr<Contents> contents);
 
@@ -103,6 +110,7 @@ class Entity {
   BlendMode blend_mode_ = BlendMode::kSourceOver;
   uint32_t stencil_depth_ = 0u;
   bool adds_to_coverage_ = true;
+  mutable std::optional<std::optional<Rect>> coverage_cache_;
 };
 
 }  // namespace impeller

--- a/impeller/entity/entity.h
+++ b/impeller/entity/entity.h
@@ -79,14 +79,7 @@ class Entity {
 
   bool AddsToCoverage() const;
 
-  /// @brief      Get the screen space bounding rectangle that this entity will
-  ///             affect when rendered.
-  /// @param[in]  use_cache  When `false`, always compute the coverage (and
-  ///                        overwrite the cached coverage). When `true`, return
-  ///                        the cached coverage if populated. Coverage is
-  ///                        always computed if the cache has not yet been
-  ///                        populated.
-  std::optional<Rect> GetCoverage(bool use_cache = false) const;
+  std::optional<Rect> GetCoverage() const;
 
   void SetContents(std::shared_ptr<Contents> contents);
 
@@ -110,7 +103,6 @@ class Entity {
   BlendMode blend_mode_ = BlendMode::kSourceOver;
   uint32_t stencil_depth_ = 0u;
   bool adds_to_coverage_ = true;
-  mutable std::optional<std::optional<Rect>> coverage_cache_;
 };
 
 }  // namespace impeller

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -359,11 +359,18 @@ bool EntityPass::OnRender(ContentContext& renderer,
   }
 
   auto render_element = [&stencil_depth_floor, &pass_context, &pass_depth,
-                         &renderer](Entity element_entity) {
+                         &renderer](Entity& element_entity) {
+    auto pass = pass_context.GetRenderPass(pass_depth);
+
+    auto coverage = element_entity.GetCoverage(true);
+    if (!coverage.has_value() ||
+        !Rect::MakeSize(Size(pass->GetRenderTargetSize()))
+             .IntersectsWithRect(coverage.value())) {
+      return true;  // Nothing to render.
+    }
+
     element_entity.SetStencilDepth(element_entity.GetStencilDepth() -
                                    stencil_depth_floor);
-
-    auto pass = pass_context.GetRenderPass(pass_depth);
     if (!element_entity.Render(renderer, *pass)) {
       return false;
     }

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -362,7 +362,7 @@ bool EntityPass::OnRender(ContentContext& renderer,
                          &renderer](Entity& element_entity) {
     auto pass = pass_context.GetRenderPass(pass_depth);
 
-    auto coverage = element_entity.GetCoverage(true);
+    auto coverage = element_entity.GetCoverage();
     if (!coverage.has_value() ||
         !Rect::MakeSize(Size(pass->GetRenderTargetSize()))
              .IntersectsWithRect(coverage.value())) {

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -360,17 +360,14 @@ bool EntityPass::OnRender(ContentContext& renderer,
 
   auto render_element = [&stencil_depth_floor, &pass_context, &pass_depth,
                          &renderer](Entity& element_entity) {
-    auto pass = pass_context.GetRenderPass(pass_depth);
+    element_entity.SetStencilDepth(element_entity.GetStencilDepth() -
+                                   stencil_depth_floor);
 
-    auto coverage = element_entity.GetCoverage();
-    if (!coverage.has_value() ||
-        !Rect::MakeSize(Size(pass->GetRenderTargetSize()))
-             .IntersectsWithRect(coverage.value())) {
+    auto pass = pass_context.GetRenderPass(pass_depth);
+    if (!element_entity.ShouldRender(*pass)) {
       return true;  // Nothing to render.
     }
 
-    element_entity.SetStencilDepth(element_entity.GetStencilDepth() -
-                                   stencil_depth_floor);
     if (!element_entity.Render(renderer, *pass)) {
       return false;
     }

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -131,44 +131,6 @@ TEST_P(EntityTest, EntityPassCoverageRespectsCoverageLimit) {
   }
 }
 
-TEST_P(EntityTest, EntityCoverageCachingWorks) {
-  auto make_fill = [](Rect rect) {
-    return SolidColorContents::Make(PathBuilder{}.AddRect(rect).TakePath(),
-                                    Color::White());
-  };
-
-  Entity entity;
-  entity.SetContents(make_fill({0, 0, 100, 100}));
-  {
-    auto coverage = entity.GetCoverage();
-    auto expected = Rect(0, 0, 100, 100);
-    ASSERT_TRUE(coverage.has_value());
-    ASSERT_RECT_NEAR(coverage.value(), expected);
-  }
-
-  entity.SetContents(make_fill({0, 0, 200, 200}));
-  // When true, the coverage is not recomputed.
-  {
-    auto coverage = entity.GetCoverage(true);
-    auto expected = Rect(0, 0, 100, 100);
-    ASSERT_TRUE(coverage.has_value());
-    ASSERT_RECT_NEAR(coverage.value(), expected);
-  }
-  // When false, coverage is computed and the cached coverage is overridden.
-  {
-    auto coverage = entity.GetCoverage();
-    auto expected = Rect(0, 0, 200, 200);
-    ASSERT_TRUE(coverage.has_value());
-    ASSERT_RECT_NEAR(coverage.value(), expected);
-  }
-  {
-    auto coverage = entity.GetCoverage(true);
-    auto expected = Rect(0, 0, 200, 200);
-    ASSERT_TRUE(coverage.has_value());
-    ASSERT_RECT_NEAR(coverage.value(), expected);
-  }
-}
-
 TEST_P(EntityTest, FilterCoverageRespectsCropRect) {
   auto image = CreateTextureForFixture("boston.jpg");
   auto filter = FilterContents::MakeBlend(Entity::BlendMode::kSoftLight,

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -131,6 +131,44 @@ TEST_P(EntityTest, EntityPassCoverageRespectsCoverageLimit) {
   }
 }
 
+TEST_P(EntityTest, EntityCoverageCachingWorks) {
+  auto make_fill = [](Rect rect) {
+    return SolidColorContents::Make(PathBuilder{}.AddRect(rect).TakePath(),
+                                    Color::White());
+  };
+
+  Entity entity;
+  entity.SetContents(make_fill({0, 0, 100, 100}));
+  {
+    auto coverage = entity.GetCoverage();
+    auto expected = Rect(0, 0, 100, 100);
+    ASSERT_TRUE(coverage.has_value());
+    ASSERT_RECT_NEAR(coverage.value(), expected);
+  }
+
+  entity.SetContents(make_fill({0, 0, 200, 200}));
+  // When true, the coverage is not recomputed.
+  {
+    auto coverage = entity.GetCoverage(true);
+    auto expected = Rect(0, 0, 100, 100);
+    ASSERT_TRUE(coverage.has_value());
+    ASSERT_RECT_NEAR(coverage.value(), expected);
+  }
+  // When false, coverage is computed and the cached coverage is overridden.
+  {
+    auto coverage = entity.GetCoverage();
+    auto expected = Rect(0, 0, 200, 200);
+    ASSERT_TRUE(coverage.has_value());
+    ASSERT_RECT_NEAR(coverage.value(), expected);
+  }
+  {
+    auto coverage = entity.GetCoverage(true);
+    auto expected = Rect(0, 0, 200, 200);
+    ASSERT_TRUE(coverage.has_value());
+    ASSERT_RECT_NEAR(coverage.value(), expected);
+  }
+}
+
 TEST_P(EntityTest, FilterCoverageRespectsCropRect) {
   auto image = CreateTextureForFixture("boston.jpg");
   auto filter = FilterContents::MakeBlend(Entity::BlendMode::kSoftLight,


### PR DESCRIPTION
Don't render entities that lie entirely outside the subpass render target. Adds light opt-in entity coverage memoization to avoid computing coverage for all entities in the pass multiple times.