### PR TITLE
Retain a reference to the CFRunLoop until MessageLoopDarwin::Terminate exits

### DIFF
--- a/fml/platform/darwin/message_loop_darwin.mm
+++ b/fml/platform/darwin/message_loop_darwin.mm
@@ -63,7 +63,12 @@ void MessageLoopDarwin::Run() {
 
 void MessageLoopDarwin::Terminate() {
   running_ = false;
-  CFRunLoopStop(loop_);
+
+  // Ensure that the CFRunLoop remains alive through the end of this function
+  // even if the loop's thread exits and drops its reference to the loop.
+  CFRef<CFRunLoopRef> local_loop(loop_);
+
+  CFRunLoopStop(local_loop);
 }
 
 void MessageLoopDarwin::WakeUp(fml::TimePoint time_point) {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/106588
