### PR TITLE
[Impeller] Clean up fill shaders

### DIFF
--- a/impeller/entity/contents/clip_contents.cc
+++ b/impeller/entity/contents/clip_contents.cc
@@ -45,12 +45,17 @@ bool ClipContents::Render(const ContentContext& renderer,
                           const Entity& entity,
                           RenderPass& pass) const {
   using VS = ClipPipeline::VertexShader;
+  using FS = ClipPipeline::FragmentShader;
 
-  VS::FrameInfo info;
-  // The color really doesn't matter.
-  info.color = Color::SkyBlue();
+  VS::VertInfo info;
 
   Command cmd;
+
+  FS::FragInfo frag_info;
+  // The color really doesn't matter.
+  frag_info.color = Color::SkyBlue();
+  FS::BindFragInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frag_info));
+
   auto options = OptionsFromPassAndEntity(pass, entity);
   cmd.stencil_reference = entity.GetStencilDepth();
   options.stencil_compare = CompareFunction::kEqual;
@@ -69,7 +74,7 @@ bool ClipContents::Render(const ContentContext& renderer,
       cmd.BindVertices(std::move(vertices));
 
       info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize());
-      VS::BindFrameInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(info));
+      VS::BindVertInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(info));
 
       cmd.pipeline = renderer.GetClipPipeline(options);
       pass.AddCommand(cmd);
@@ -95,7 +100,7 @@ bool ClipContents::Render(const ContentContext& renderer,
 
   info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
              entity.GetTransformation();
-  VS::BindFrameInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(info));
+  VS::BindVertInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(info));
 
   pass.AddCommand(std::move(cmd));
   return true;
@@ -123,6 +128,7 @@ bool ClipRestoreContents::Render(const ContentContext& renderer,
                                  const Entity& entity,
                                  RenderPass& pass) const {
   using VS = ClipPipeline::VertexShader;
+  using FS = ClipPipeline::FragmentShader;
 
   Command cmd;
   cmd.label = "Restore Clip";
@@ -145,12 +151,14 @@ bool ClipRestoreContents::Render(const ContentContext& renderer,
   });
   cmd.BindVertices(vtx_builder.CreateVertexBuffer(pass.GetTransientsBuffer()));
 
-  VS::FrameInfo info;
-  // The color really doesn't matter.
-  info.color = Color::SkyBlue();
+  VS::VertInfo info;
   info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize());
+  VS::BindVertInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(info));
 
-  VS::BindFrameInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(info));
+  FS::FragInfo frag_info;
+  // The color really doesn't matter.
+  frag_info.color = Color::SkyBlue();
+  FS::BindFragInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frag_info));
 
   pass.AddCommand(std::move(cmd));
   return true;

--- a/impeller/entity/contents/texture_contents.cc
+++ b/impeller/entity/contents/texture_contents.cc
@@ -78,7 +78,7 @@ bool TextureContents::Render(const ContentContext& renderer,
         path_.GetFillType(), path_.CreatePolyline(),
         [this, &vertex_builder, &coverage_rect, &texture_size](Point vtx) {
           VS::PerVertexData data;
-          data.vertices = vtx;
+          data.position = vtx;
           auto coverage_coords =
               (vtx - coverage_rect->origin) / coverage_rect->size;
           data.texture_coords =
@@ -101,13 +101,13 @@ bool TextureContents::Render(const ContentContext& renderer,
 
   auto& host_buffer = pass.GetTransientsBuffer();
 
-  VS::FrameInfo frame_info;
-  frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransformation();
-  frame_info.alpha = opacity_;
+  VS::VertInfo vert_info;
+  vert_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
+                  entity.GetTransformation();
 
   FS::FragInfo frag_info;
   frag_info.texture_sampler_y_coord_scale = texture_->GetYCoordScale();
+  frag_info.alpha = opacity_;
 
   Command cmd;
   cmd.label = "TextureFill";
@@ -115,7 +115,7 @@ bool TextureContents::Render(const ContentContext& renderer,
       renderer.GetTexturePipeline(OptionsFromPassAndEntity(pass, entity));
   cmd.stencil_reference = entity.GetStencilDepth();
   cmd.BindVertices(vertex_builder.CreateVertexBuffer(host_buffer));
-  VS::BindFrameInfo(cmd, host_buffer.EmplaceUniform(frame_info));
+  VS::BindVertInfo(cmd, host_buffer.EmplaceUniform(vert_info));
   FS::BindFragInfo(cmd, host_buffer.EmplaceUniform(frag_info));
   FS::BindTextureSampler(cmd, texture_,
                          renderer.GetContext()->GetSamplerLibrary()->GetSampler(

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -708,6 +708,8 @@ TEST_P(EntityTest, BlendingModeOptions) {
                          Rect rect, Color color,
                          Entity::BlendMode blend_mode) -> bool {
       using VS = SolidFillPipeline::VertexShader;
+      using FS = SolidFillPipeline::FragmentShader;
+
       VertexBufferBuilder<VS::PerVertexData> vtx_builder;
       {
         auto r = rect.GetLTRB();
@@ -729,12 +731,16 @@ TEST_P(EntityTest, BlendingModeOptions) {
       cmd.BindVertices(
           vtx_builder.CreateVertexBuffer(pass.GetTransientsBuffer()));
 
-      VS::FrameInfo frame_info;
+      VS::VertInfo frame_info;
       frame_info.mvp =
           Matrix::MakeOrthographic(pass.GetRenderTargetSize()) * world_matrix;
-      frame_info.color = color.Premultiply();
-      VS::BindFrameInfo(cmd,
-                        pass.GetTransientsBuffer().EmplaceUniform(frame_info));
+      VS::BindVertInfo(cmd,
+                       pass.GetTransientsBuffer().EmplaceUniform(frame_info));
+
+      FS::FragInfo frag_info;
+      frag_info.color = color.Premultiply();
+      FS::BindFragInfo(cmd,
+                       pass.GetTransientsBuffer().EmplaceUniform(frag_info));
 
       cmd.primitive_type = PrimitiveType::kTriangle;
 

--- a/impeller/entity/shaders/solid_fill.frag
+++ b/impeller/entity/shaders/solid_fill.frag
@@ -4,7 +4,8 @@
 
 uniform FragInfo {
   vec4 color;
-} frag_info;
+}
+frag_info;
 
 out vec4 frag_color;
 

--- a/impeller/entity/shaders/solid_fill.frag
+++ b/impeller/entity/shaders/solid_fill.frag
@@ -2,10 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-in vec4 color;
+uniform FragInfo {
+  vec4 color;
+} frag_info;
 
 out vec4 frag_color;
 
 void main() {
-  frag_color = color;
+  frag_color = frag_info.color;
 }

--- a/impeller/entity/shaders/solid_fill.vert
+++ b/impeller/entity/shaders/solid_fill.vert
@@ -2,16 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-uniform FrameInfo {
+uniform VertInfo {
   mat4 mvp;
-  vec4 color;
-} frame_info;
+} vert_info;
 
-in vec2 vertices;
-
-out vec4 color;
+in vec2 position;
 
 void main() {
-  gl_Position = frame_info.mvp * vec4(vertices, 0.0, 1.0);
-  color = frame_info.color;
+  gl_Position = vert_info.mvp * vec4(position, 0.0, 1.0);
 }

--- a/impeller/entity/shaders/solid_fill.vert
+++ b/impeller/entity/shaders/solid_fill.vert
@@ -4,7 +4,8 @@
 
 uniform VertInfo {
   mat4 mvp;
-} vert_info;
+}
+vert_info;
 
 in vec2 position;
 

--- a/impeller/entity/shaders/solid_stroke.frag
+++ b/impeller/entity/shaders/solid_stroke.frag
@@ -2,11 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-in vec4 stroke_color;
+uniform FragInfo {
+  vec4 color;
+} frag_info;
+
 in float v_pen_down;
 
 out vec4 frag_color;
 
 void main() {
-  frag_color = stroke_color * floor(v_pen_down);
+  frag_color = frag_info.color * floor(v_pen_down);
 }

--- a/impeller/entity/shaders/solid_stroke.frag
+++ b/impeller/entity/shaders/solid_stroke.frag
@@ -4,7 +4,8 @@
 
 uniform FragInfo {
   vec4 color;
-} frag_info;
+}
+frag_info;
 
 in float v_pen_down;
 

--- a/impeller/entity/shaders/solid_stroke.vert
+++ b/impeller/entity/shaders/solid_stroke.vert
@@ -2,23 +2,20 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-uniform FrameInfo {
+uniform VertInfo {
   mat4 mvp;
-  vec4 color;
   float size;
-} frame_info;
+} vert_info;
 
-in vec2 vertex_position;
-in vec2 vertex_normal;
+in vec2 position;
+in vec2 normal;
 in float pen_down;
 
-out vec4 stroke_color;
 out float v_pen_down;
 
 void main() {
   // Push one vertex by the half stroke size along the normal vector.
-  vec2 offset = vertex_normal * vec2(frame_info.size * 0.5);
-  gl_Position = frame_info.mvp * vec4(vertex_position + offset, 0.0, 1.0);
-  stroke_color = frame_info.color;
+  vec2 offset = normal * vec2(vert_info.size * 0.5);
+  gl_Position = vert_info.mvp * vec4(position + offset, 0.0, 1.0);
   v_pen_down = pen_down;
 }

--- a/impeller/entity/shaders/solid_stroke.vert
+++ b/impeller/entity/shaders/solid_stroke.vert
@@ -5,7 +5,8 @@
 uniform VertInfo {
   mat4 mvp;
   float size;
-} vert_info;
+}
+vert_info;
 
 in vec2 position;
 in vec2 normal;

--- a/impeller/entity/shaders/texture_fill.frag
+++ b/impeller/entity/shaders/texture_fill.frag
@@ -5,18 +5,19 @@
 #include <impeller/texture.glsl>
 
 uniform sampler2D texture_sampler;
+
 uniform FragInfo {
   float texture_sampler_y_coord_scale;
+  float alpha;
 }
 frag_info;
 
 in vec2 v_texture_coords;
-in float v_alpha;
 
 out vec4 frag_color;
 
 void main() {
   vec4 sampled = IPSample(texture_sampler, v_texture_coords,
                           frag_info.texture_sampler_y_coord_scale);
-  frag_color = sampled * v_alpha;
+  frag_color = sampled * frag_info.alpha;
 }

--- a/impeller/entity/shaders/texture_fill.vert
+++ b/impeller/entity/shaders/texture_fill.vert
@@ -2,19 +2,17 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-uniform FrameInfo {
+uniform VertInfo {
   mat4 mvp;
-  float alpha;
-} frame_info;
+}
+vert_info;
 
-in vec2 vertices;
+in vec2 position;
 in vec2 texture_coords;
 
 out vec2 v_texture_coords;
-out float v_alpha;
 
 void main() {
-  gl_Position = frame_info.mvp * vec4(vertices, 0.0, 1.0);
+  gl_Position = vert_info.mvp * vec4(position, 0.0, 1.0);
   v_texture_coords = texture_coords;
-  v_alpha = frame_info.alpha;
 }


### PR DESCRIPTION
Doing this clean up of all our older shaders in parts.

Make attribute names not redundant/ambiguous and bind fragment shader uniforms directly rather than interpolating through vertex shaders.