### PR TITLE
Drop unnecessary @dart annotations

### DIFF
--- a/lib/ui/annotations.dart
+++ b/lib/ui/annotations.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
-// @dart = 2.14
 part of dart.ui;
 
 // TODO(dnfield): Update this if/when we default this to on in the tool,

--- a/lib/ui/channel_buffers.dart
+++ b/lib/ui/channel_buffers.dart
@@ -4,8 +4,6 @@
 
 
 // KEEP THIS SYNCHRONIZED WITH ../web_ui/lib/channel_buffers.dart
-
-// @dart = 2.14
 part of dart.ui;
 
 /// Signature for [ChannelBuffers.drain]'s `callback` argument.

--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -1,8 +1,6 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-
-// @dart = 2.14
 part of dart.ui;
 
 /// An opaque object representing a composited scene.

--- a/lib/ui/geometry.dart
+++ b/lib/ui/geometry.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
-// @dart = 2.14
 part of dart.ui;
 
 /// Base class for [Size] and [Offset], which are both ways to describe

--- a/lib/ui/hash_codes.dart
+++ b/lib/ui/hash_codes.dart
@@ -1,8 +1,6 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-
-// @dart = 2.14
 part of dart.ui;
 
 class _HashEnd { const _HashEnd(); }

--- a/lib/ui/hooks.dart
+++ b/lib/ui/hooks.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
-// @dart = 2.14
 part of dart.ui;
 
 @pragma('vm:entry-point')

--- a/lib/ui/isolate_name_server.dart
+++ b/lib/ui/isolate_name_server.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
-// @dart = 2.14
 part of dart.ui;
 
 /// Static methods to allow for simple sharing of [SendPort]s across [Isolate]s.

--- a/lib/ui/key.dart
+++ b/lib/ui/key.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.14
-
 part of dart.ui;
 
 /// The type of a key event.

--- a/lib/ui/lerp.dart
+++ b/lib/ui/lerp.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
-// @dart = 2.14
 part of dart.ui;
 
 /// Linearly interpolate between two numbers, `a` and `b`, by an extrapolation

--- a/lib/ui/natives.dart
+++ b/lib/ui/natives.dart
@@ -1,8 +1,6 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-
-// @dart = 2.14
 part of dart.ui;
 
 // ignore_for_file: avoid_classes_with_only_static_members

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -1,8 +1,6 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-
-// @dart = 2.14
 part of dart.ui;
 
 // Some methods in this file assert that their arguments are not null. These

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -1,8 +1,6 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-
-// @dart = 2.14
 part of dart.ui;
 
 /// Signature of callbacks that have no arguments and return no data.

--- a/lib/ui/plugins.dart
+++ b/lib/ui/plugins.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
-// @dart = 2.14
 part of dart.ui;
 
 /// A wrapper for a raw callback handle.

--- a/lib/ui/pointer.dart
+++ b/lib/ui/pointer.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
-// @dart = 2.14
 part of dart.ui;
 
 /// How the pointer has changed since the last report.

--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
-// @dart = 2.14
 part of dart.ui;
 
 /// The possible actions that can be conveyed from the operating system

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -1,8 +1,6 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-
-// @dart = 2.14
 part of dart.ui;
 
 /// Whether to slant the glyphs in the font

--- a/lib/ui/ui.dart
+++ b/lib/ui/ui.dart
@@ -9,7 +9,6 @@
 /// This library exposes the lowest-level services that Flutter frameworks use
 /// to bootstrap applications, such as classes for driving the input, graphics
 /// text, layout, and rendering subsystems.
-// @dart = 2.14
 library dart.ui;
 
 import 'dart:_spirv' as spv;

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -1,8 +1,6 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-
-// @dart = 2.14
 part of dart.ui;
 
 /// A view into which a Flutter [Scene] is drawn.

--- a/testing/litetest/lib/litetest.dart
+++ b/testing/litetest/lib/litetest.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
-
 import 'package:async_helper/async_minitest.dart'; // ignore: unused_import
 import 'package:expect/expect.dart'; // ignore: unused_import
 

--- a/testing/litetest/lib/src/matchers.dart
+++ b/testing/litetest/lib/src/matchers.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
-
 import 'package:async_helper/async_minitest.dart';
 import 'package:expect/expect.dart';
 

--- a/testing/litetest/lib/src/test.dart
+++ b/testing/litetest/lib/src/test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
-
 import 'dart:async';
 import 'dart:io' show stdout;
 import 'dart:isolate';

--- a/testing/litetest/lib/src/test_suite.dart
+++ b/testing/litetest/lib/src/test_suite.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
-
 import 'dart:async';
 import 'dart:collection';
 import 'dart:io' show stdout;

--- a/testing/litetest/test/litetest_test.dart
+++ b/testing/litetest/test/litetest_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
-
 import 'dart:async';
 import 'dart:collection';
 

--- a/tools/api_check/lib/apicheck.dart
+++ b/tools/api_check/lib/apicheck.dart
@@ -165,7 +165,7 @@ List<String> _getBlockStartingWith({
 void visitUIUnits(String flutterRoot, AstVisitor<void> visitor) {
   String uiRoot = '$flutterRoot/lib/ui';
   final FeatureSet analyzerFeatures = FeatureSet.fromEnableFlags2(
-    sdkLanguageVersion: Version.parse('2.12.0'),
+    sdkLanguageVersion: Version.parse('2.17.0'),
     flags: <String>['non-nullable'],
   );
   final ParseStringResult uiResult = parseFile(path: '$uiRoot/ui.dart', featureSet: analyzerFeatures);

--- a/tools/clang_tidy/bin/main.dart
+++ b/tools/clang_tidy/bin/main.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
-
 // Runs clang-tidy on files with changes.
 //
 // Basic Usage:

--- a/tools/githooks/bin/main.dart
+++ b/tools/githooks/bin/main.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
-
 import 'dart:io' as io;
 
 import 'package:githooks/githooks.dart';

--- a/tools/githooks/lib/githooks.dart
+++ b/tools/githooks/lib/githooks.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
-
 import 'dart:io' as io;
 
 import 'package:args/args.dart';

--- a/tools/githooks/lib/src/pre_push_command.dart
+++ b/tools/githooks/lib/src/pre_push_command.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
-
 import 'dart:io' as io;
 
 import 'package:args/command_runner.dart';

--- a/tools/githooks/test/githooks_test.dart
+++ b/tools/githooks/test/githooks_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
-
 import 'dart:io' as io;
 
 import 'package:githooks/githooks.dart';

--- a/web_sdk/test/api_conform_test.dart
+++ b/web_sdk/test/api_conform_test.dart
@@ -19,7 +19,7 @@ const Set<String> _kObjectMembers = <String>{
 
 CompilationUnit _parseAndCheckDart(String path) {
   final FeatureSet analyzerFeatures = FeatureSet.fromEnableFlags2(
-    sdkLanguageVersion: Version.parse('2.12.0'),
+    sdkLanguageVersion: Version.parse('2.17.0'),
     flags: <String>['non-nullable'],
   );
   if (!analyzerFeatures.isEnabled(Feature.non_nullable)) {


### PR DESCRIPTION
Drops all `@dart` annotations >= 2.12.

These are remnants of the null safety incremental migration.

There are still a few libraries in the engine that have < 2.12 - some are in `//shell/platform/fuchsia`, and two others are in the benchmark uploading script and the verify_exported_symbols package - those will require null safety migration.