### PR TITLE
[impeller] Fix linkage issue when `impeller_enable_vulkan = true`

### DIFF
--- a/display_list/BUILD.gn
+++ b/display_list/BUILD.gn
@@ -4,6 +4,7 @@
 
 import("//build/fuchsia/sdk.gni")
 import("//flutter/common/config.gni")
+import("//flutter/impeller/tools/impeller.gni")
 import("//flutter/testing/testing.gni")
 
 source_set("display_list") {
@@ -197,7 +198,16 @@ source_set("display_list_benchmarks_source") {
   }
 
   # iOS and Fuchsia don't support OpenGL
-  if (!is_fuchsia && !is_ios) {
+  _enable_gl_benchmarks = !is_fuchsia && !is_ios
+
+  # TODO (https://github.com/flutter/flutter/issues/107357):
+  # impeller_enable_vulkan currently requires skia to not use VMA, which inturn
+  # causes linkage problems with swiftshader.
+  if (impeller_enable_vulkan) {
+    _enable_gl_benchmarks = false
+  }
+
+  if (_enable_gl_benchmarks) {
     defines += [ "ENABLE_OPENGL_BENCHMARKS" ]
     sources += [
       "display_list_benchmarks_gl.cc",

--- a/tools/gn
+++ b/tools/gn
@@ -526,6 +526,11 @@ def to_gn_args(args):
   if args.prebuilt_impellerc is not None:
     gn_args['impeller_use_prebuilt_impellerc'] = args.prebuilt_impellerc
 
+  # Vulkan support is WIP, see: https://github.com/flutter/flutter/issues/107357
+  if args.enable_impeller_vulkan:
+    gn_args['impeller_enable_vulkan'] = True
+    gn_args['skia_use_vma'] = False
+
   # ANGLE is exclusively used for:
   #  - Windows at runtime
   #  - Non-fuchsia host unit tests (is_host_build evaluates to false).
@@ -848,6 +853,13 @@ def parse_args(args):
       type=str,
       help='Absolute path to a prebuilt impellerc. ' +
       'Do not use this outside of CI or with impellerc from a different engine version.'
+  )
+  parser.add_argument(
+      '--enable-impeller-vulkan',
+      default=False,
+      action='store_true',
+      help='Enables WIP impeller support for vulkan. ' +
+      'https://github.com/flutter/flutter/issues/107357'
   )
 
   # Sanitizers.


### PR DESCRIPTION
Also adds `--enable-impeller-vulkan` flutter/tools/gn flag for CI
