### PR TITLE
NNBD migration for //testing

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -476,7 +476,7 @@ deps = {
   Var('github_git') + '/google/file.dart.git' + '@' + '427bb20ccc852425d67f2880da2a9b4707c266b4', # 6.1.0
 
   'src/third_party/pkg/flutter_packages':
-  Var('github_git') + '/flutter/packages.git' + '@' + 'a19eca7fe2660c71acf5928a275deda1da318c50', # various
+  Var('github_git') + '/flutter/packages.git' + '@' + '26990a2f75ab2028c3c77ffc869db11d6d866d18', # various
 
   'src/third_party/pkg/gcloud':
   Var('github_git') + '/dart-lang/gcloud.git' + '@' + 'a5276b85c4714378e84b1fb478b8feeeb686ac26', # 0.8.6-dev

--- a/DEPS
+++ b/DEPS
@@ -479,7 +479,7 @@ deps = {
   Var('github_git') + '/flutter/packages.git' + '@' + 'a19eca7fe2660c71acf5928a275deda1da318c50', # various
 
   'src/third_party/pkg/gcloud':
-  Var('github_git') + '/dart-lang/gcloud.git' + '@' + '92a33a9d95ea94a4354b052a28b98088d660e0e7', # 0.8.0-dev
+  Var('github_git') + '/dart-lang/gcloud.git' + '@' + 'a5276b85c4714378e84b1fb478b8feeeb686ac26', # 0.8.6-dev
 
   'src/third_party/pkg/googleapis':
   Var('github_git') + '/google/googleapis.dart.git' + '@' + '07f01b7aa6985e4cafd0fd4b98724841bc9e85a1', # various

--- a/testing/benchmark/bin/parse_and_send.dart
+++ b/testing/benchmark/bin/parse_and_send.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.6
-
 import 'dart:convert';
 import 'dart:io';
 
@@ -13,7 +11,7 @@ import 'package:path/path.dart' as p;
 
 Future<ProcessResult> runGit(
   List<String> args, {
-  String processWorkingDir,
+  String? processWorkingDir,
 }) async {
   return Process.run(
     'git',
@@ -54,8 +52,8 @@ Future<PointsAndDate> parse(String jsonFileName) async {
   final List<FlutterEngineMetricPoint> points = <FlutterEngineMetricPoint>[];
   for (final MetricPoint rawPoint in rawPoints) {
     points.add(FlutterEngineMetricPoint(
-      rawPoint.tags[kNameKey],
-      rawPoint.value,
+      rawPoint.tags[kNameKey]!,
+      rawPoint.value!,
       gitRevision,
       moreTags: rawPoint.tags,
     ));
@@ -70,13 +68,13 @@ Future<FlutterDestination> connectFlutterDestination() async {
   final bool isTesting = env['IS_TESTING'] == 'true';
   if (env.containsKey(kTokenPath) && env.containsKey(kGcpProject)) {
     return FlutterDestination.makeFromAccessToken(
-      File(env[kTokenPath]).readAsStringSync(),
-      env[kGcpProject],
+      File(env[kTokenPath]!).readAsStringSync(),
+      env[kGcpProject]!,
       isTesting: isTesting,
     );
   }
   return FlutterDestination.makeFromCredentialsJson(
-    jsonDecode(Platform.environment['BENCHMARK_GCP_CREDENTIALS'])
+    jsonDecode(Platform.environment['BENCHMARK_GCP_CREDENTIALS']!)
         as Map<String, dynamic>,
     isTesting: isTesting,
   );

--- a/testing/benchmark/test/parse_and_send_test.dart
+++ b/testing/benchmark/test/parse_and_send_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.6
-
 import 'dart:io';
 
 import 'package:litetest/litetest.dart';
@@ -27,8 +25,7 @@ void main() {
     expect(sha1re.hasMatch(gitLog[0]), true);
 
     // Check that gitLog[1] is an int
-    final int secondsSinceEpoch = int.tryParse(gitLog[1]);
-    expect(secondsSinceEpoch, isNotNull);
+    final int secondsSinceEpoch = int.parse(gitLog[1]);
 
     // Check that gitLog[1] is a sensible Unix Epoch
     final int millisecondsSinceEpoch = secondsSinceEpoch * 1000;

--- a/testing/symbols/verify_exported.dart
+++ b/testing/symbols/verify_exported.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.6
 import 'dart:convert';
 import 'dart:io';
 


### PR DESCRIPTION
Addresses two of the items in https://github.com/flutter/flutter/issues/71507

verify_exported seems to "just work." Unfortunately, I don't think it will be run in CI until post submit and I may not have covered all the cases exercised there in my quick local test.

The parse_and_send stuff was relatively trivial to migrate. The fallout if there is anything bad there is we may not get benchmark data showing up.