### PR TITLE
[Impeller] Generate descriptor set layout bindings in generated C++ headers.

### DIFF
--- a/impeller/compiler/code_gen_template.h
+++ b/impeller/compiler/code_gen_template.h
@@ -147,6 +147,34 @@ std::move({{ arg.argument_name }}){% if not loop.is_last %}, {% endif %}
 
 {% endfor %}
 
+  // ===========================================================================
+  // Metadata for Vulkan =======================================================
+  // ===========================================================================
+
+{% if length(buffers)+length(sampled_images) > 0 %}
+  static constexpr std::array<VkDescriptorSetLayoutBinding,{{length(buffers)+length(sampled_images)}}> kDescriptorSetLayouts{
+{% for buffer in buffers %}
+    VkDescriptorSetLayoutBinding{
+      {{buffer.binding}} , // binding = {{buffer.binding}}
+      6, // descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER
+      1, // descriptorCount = 1
+      {{to_vk_shader_stage_flag_bits(shader_stage)}}, // stageFlags = {{to_shader_stage(shader_stage)}}
+      nullptr, // pImmutableSamplers = NULL
+    },
+{% endfor %}
+{% for sampled_image in sampled_images %}
+    VkDescriptorSetLayoutBinding{
+      {{sampled_image.binding}} , // binding = {{sampled_image.binding}}
+      2, // descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE
+      1, // descriptorCount = 1
+      {{to_vk_shader_stage_flag_bits(shader_stage)}},// stageFlags = {{to_shader_stage(shader_stage)}}
+      nullptr, // pImmutableSamplers = NULL
+    },
+{% endfor %}
+  };
+{% endif %}
+
+
 };  // struct {{camel_case(shader_name)}}{{camel_case(shader_stage)}}Shader
 
 }  // namespace impeller

--- a/impeller/compiler/code_gen_template.h
+++ b/impeller/compiler/code_gen_template.h
@@ -150,13 +150,13 @@ std::move({{ arg.argument_name }}){% if not loop.is_last %}, {% endif %}
   // ===========================================================================
   // Metadata for Vulkan =======================================================
   // ===========================================================================
-
+#ifdef IMPELLER_ENABLE_VULKAN_REFLECTION
 {% if length(buffers)+length(sampled_images) > 0 %}
   static constexpr std::array<VkDescriptorSetLayoutBinding,{{length(buffers)+length(sampled_images)}}> kDescriptorSetLayouts{
 {% for buffer in buffers %}
     VkDescriptorSetLayoutBinding{
-      {{buffer.binding}} , // binding = {{buffer.binding}}
-      6, // descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER
+      {{buffer.binding}}, // binding = {{buffer.binding}}
+      VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, // descriptorType = Uniform Buffer
       1, // descriptorCount = 1
       {{to_vk_shader_stage_flag_bits(shader_stage)}}, // stageFlags = {{to_shader_stage(shader_stage)}}
       nullptr, // pImmutableSamplers = NULL
@@ -164,8 +164,8 @@ std::move({{ arg.argument_name }}){% if not loop.is_last %}, {% endif %}
 {% endfor %}
 {% for sampled_image in sampled_images %}
     VkDescriptorSetLayoutBinding{
-      {{sampled_image.binding}} , // binding = {{sampled_image.binding}}
-      2, // descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE
+      {{sampled_image.binding}}, // binding = {{sampled_image.binding}}
+      VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, // descriptorType = Sampled Image
       1, // descriptorCount = 1
       {{to_vk_shader_stage_flag_bits(shader_stage)}},// stageFlags = {{to_shader_stage(shader_stage)}}
       nullptr, // pImmutableSamplers = NULL
@@ -173,7 +173,7 @@ std::move({{ arg.argument_name }}){% if not loop.is_last %}, {% endif %}
 {% endfor %}
   };
 {% endif %}
-
+#endif
 
 };  // struct {{camel_case(shader_name)}}{{camel_case(shader_stage)}}Shader
 

--- a/impeller/compiler/reflector.cc
+++ b/impeller/compiler/reflector.cc
@@ -108,6 +108,28 @@ static std::string StringToShaderStage(std::string str) {
   return "ShaderStage::kUnknown";
 }
 
+static std::string StringToVkShaderStage(std::string str){
+  if (str == "vertex") {
+    return "0x00000001";
+  }
+  if (str == "fragment") {
+    return "0x00000010";
+  }
+
+  if (str == "tessellation_control") {
+    return "0x00000002";
+  }
+
+  if (str == "tessellation_evaluation") {
+    return "0x00000004";
+  }
+
+  if (str == "compute") {
+    return "0x00000020";
+  }
+  return "0x0000001f"; // VK_SHADER_STAGE_ALL_GRAPHICS
+}
+
 Reflector::Reflector(Options options,
                      std::shared_ptr<const spirv_cross::ParsedIR> ir,
                      std::shared_ptr<fml::Mapping> shader_data,
@@ -366,6 +388,9 @@ std::shared_ptr<fml::Mapping> Reflector::InflateTemplate(
                    [type = compiler_.GetType()](inja::Arguments& args) {
                      return ToString(type);
                    });
+  env.add_callback("to_vk_shader_stage_flag_bits",1u,[](inja::Arguments& args){
+                      return StringToVkShaderStage(args.at(0u)->get<std::string>());
+                  });
 
   auto inflated_template =
       std::make_shared<std::string>(env.render(tmpl, *template_arguments_));

--- a/impeller/compiler/reflector.cc
+++ b/impeller/compiler/reflector.cc
@@ -108,7 +108,7 @@ static std::string StringToShaderStage(std::string str) {
   return "ShaderStage::kUnknown";
 }
 
-static std::string StringToVkShaderStage(std::string str){
+static std::string StringToVkShaderStage(std::string str) {
   if (str == "vertex") {
     return "0x00000001";
   }
@@ -127,7 +127,7 @@ static std::string StringToVkShaderStage(std::string str){
   if (str == "compute") {
     return "0x00000020";
   }
-  return "0x0000001f"; // VK_SHADER_STAGE_ALL_GRAPHICS
+  return "0x0000001f";  // VK_SHADER_STAGE_ALL_GRAPHICS
 }
 
 Reflector::Reflector(Options options,
@@ -388,9 +388,10 @@ std::shared_ptr<fml::Mapping> Reflector::InflateTemplate(
                    [type = compiler_.GetType()](inja::Arguments& args) {
                      return ToString(type);
                    });
-  env.add_callback("to_vk_shader_stage_flag_bits",1u,[](inja::Arguments& args){
-                      return StringToVkShaderStage(args.at(0u)->get<std::string>());
-                  });
+  env.add_callback(
+      "to_vk_shader_stage_flag_bits", 1u, [](inja::Arguments& args) {
+        return StringToVkShaderStage(args.at(0u)->get<std::string>());
+      });
 
   auto inflated_template =
       std::make_shared<std::string>(env.render(tmpl, *template_arguments_));

--- a/impeller/compiler/reflector.cc
+++ b/impeller/compiler/reflector.cc
@@ -110,24 +110,24 @@ static std::string StringToShaderStage(std::string str) {
 
 static std::string StringToVkShaderStage(std::string str) {
   if (str == "vertex") {
-    return "0x00000001";
+    return "VK_SHADER_STAGE_VERTEX_BIT";
   }
   if (str == "fragment") {
-    return "0x00000010";
+    return "VK_SHADER_STAGE_FRAGMENT_BIT";
   }
 
   if (str == "tessellation_control") {
-    return "0x00000002";
+    return "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT";
   }
 
   if (str == "tessellation_evaluation") {
-    return "0x00000004";
+    return "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT";
   }
 
   if (str == "compute") {
-    return "0x00000020";
+    return "VK_SHADER_STAGE_COMPUTE_BIT";
   }
-  return "0x0000001f";  // VK_SHADER_STAGE_ALL_GRAPHICS
+  return "VK_SHADER_STAGE_ALL_GRAPHICS";
 }
 
 Reflector::Reflector(Options options,

--- a/impeller/renderer/shader_types.h
+++ b/impeller/renderer/shader_types.h
@@ -98,6 +98,14 @@ struct SampledImageSlot {
   constexpr bool HasSampler() const { return sampler_index < 32u; }
 };
 
+struct VkDescriptorSetLayoutBinding {
+  uint32_t   binding = 0;
+  uint32_t   descriptorType = 0;
+  uint32_t   descriptorCount = 1;
+  uint32_t   stageFlags = 0;
+  void*      pImmutableSamplers = nullptr;
+};
+
 template <size_t Size>
 struct Padding {
  private:

--- a/impeller/renderer/shader_types.h
+++ b/impeller/renderer/shader_types.h
@@ -98,14 +98,6 @@ struct SampledImageSlot {
   constexpr bool HasSampler() const { return sampler_index < 32u; }
 };
 
-struct VkDescriptorSetLayoutBinding {
-  uint32_t binding = 0;
-  uint32_t descriptorType = 0;
-  uint32_t descriptorCount = 1;
-  uint32_t stageFlags = 0;
-  void* pImmutableSamplers = nullptr;
-};
-
 template <size_t Size>
 struct Padding {
  private:

--- a/impeller/renderer/shader_types.h
+++ b/impeller/renderer/shader_types.h
@@ -99,11 +99,11 @@ struct SampledImageSlot {
 };
 
 struct VkDescriptorSetLayoutBinding {
-  uint32_t   binding = 0;
-  uint32_t   descriptorType = 0;
-  uint32_t   descriptorCount = 1;
-  uint32_t   stageFlags = 0;
-  void*      pImmutableSamplers = nullptr;
+  uint32_t binding = 0;
+  uint32_t descriptorType = 0;
+  uint32_t descriptorCount = 1;
+  uint32_t stageFlags = 0;
+  void* pImmutableSamplers = nullptr;
 };
 
 template <size_t Size>


### PR DESCRIPTION
Fix https://github.com/flutter/flutter/issues/106377
This pr generates descriptor set layout bindings in generated C++ headers for vulkan backend.
example:
```cpp
  // ===========================================================================
  // Metadata for Vulkan =======================================================
  // ===========================================================================
#ifdef IMPELLER_ENABLE_VULKAN_REFLECTION
  static constexpr std::array<VkDescriptorSetLayoutBinding,3> kDescriptorSetLayouts{
    VkDescriptorSetLayoutBinding{
      0, // binding = 0
      VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, // descriptorType = Uniform Buffer
      1, // descriptorCount = 1
      VK_SHADER_STAGE_FRAGMENT_BIT, // stageFlags = ShaderStage::kFragment
      nullptr, // pImmutableSamplers = NULL
    },
    VkDescriptorSetLayoutBinding{
      1, // binding = 1
      VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, // descriptorType = Sampled Image
      1, // descriptorCount = 1
      VK_SHADER_STAGE_FRAGMENT_BIT,// stageFlags = ShaderStage::kFragment
      nullptr, // pImmutableSamplers = NULL
    },
    VkDescriptorSetLayoutBinding{
      2, // binding = 2
      VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, // descriptorType = Sampled Image
      1, // descriptorCount = 1
      VK_SHADER_STAGE_FRAGMENT_BIT,// stageFlags = ShaderStage::kFragment
      nullptr, // pImmutableSamplers = NULL
    },
  };
#endif
```

I didn't include any test because I wonder how I should implement it, I checked the compiler_unittests.cc and found that all tests in it didn't check the content in the headers. I wonder if I should add checks to that.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
