### PR TITLE
[Impeller] Copy user indices directly into buffer for DrawVertices

### DIFF
--- a/display_list/display_list_vertices.h
+++ b/display_list/display_list_vertices.h
@@ -108,7 +108,7 @@ class DlVertices {
     ///
     /// Vertices are always required. Optional texture coordinates
     /// and optional colors are reserved depending on the |Flags|.
-    /// Optional indices will be reserved iff the index_count is
+    /// Optional indices will be reserved if the index_count is
     /// positive (>0).
     ///
     /// The caller must provide all data that is promised by the

--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -306,11 +306,12 @@ void Canvas::DrawTextFrame(TextFrame text_frame, Point position, Paint paint) {
 }
 
 void Canvas::DrawVertices(Vertices vertices,
-                          Entity::BlendMode mode,
+                          Entity::BlendMode blend_mode,
                           Paint paint) {
   std::shared_ptr<VerticesContents> contents =
       std::make_shared<VerticesContents>(std::move(vertices));
   contents->SetColor(paint.color);
+  contents->SetBlendMode(blend_mode);
   Entity entity;
   entity.SetTransformation(GetCurrentTransformation());
   entity.SetStencilDepth(GetStencilDepth());

--- a/impeller/aiks/canvas.h
+++ b/impeller/aiks/canvas.h
@@ -93,7 +93,9 @@ class Canvas {
 
   void DrawTextFrame(TextFrame text_frame, Point position, Paint paint);
 
-  void DrawVertices(Vertices vertices, Entity::BlendMode mode, Paint paint);
+  void DrawVertices(Vertices vertices,
+                    Entity::BlendMode blend_mode,
+                    Paint paint);
 
   Picture EndRecordingAsPicture();
 

--- a/impeller/entity/contents/vertices_contents.h
+++ b/impeller/entity/contents/vertices_contents.h
@@ -10,6 +10,7 @@
 
 #include "flutter/fml/macros.h"
 #include "impeller/entity/contents/contents.h"
+#include "impeller/entity/entity.h"
 #include "impeller/geometry/color.h"
 #include "impeller/geometry/path.h"
 #include "impeller/geometry/point.h"
@@ -26,6 +27,8 @@ class VerticesContents final : public Contents {
 
   void SetColor(Color color);
 
+  void SetBlendMode(Entity::BlendMode blend_mode);
+
   // |Contents|
   std::optional<Rect> GetCoverage(const Entity& entity) const override;
 
@@ -37,6 +40,7 @@ class VerticesContents final : public Contents {
  public:
   Vertices vertices_;
   Color color_;
+  Entity::BlendMode blend_mode_ = Entity::BlendMode::kSource;
 
   FML_DISALLOW_COPY_AND_ASSIGN(VerticesContents);
 };

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -1055,14 +1055,31 @@ TEST_P(EntityTest, BorderMaskBlurCoverageIsCorrect) {
   }
 }
 
-TEST_P(EntityTest, DrawVerticesSolidColorTrianglesWithoutIndex) {
-  std::vector<Point> points = {Point(100, 300), Point(200, 100),
-                               Point(300, 300)};
-  std::vector<uint16_t> indexes;
+TEST_P(EntityTest, DrawVerticesSolidColorTrianglesWithoutIndices) {
+  std::vector<Point> positions = {Point(100, 300), Point(200, 100),
+                                  Point(300, 300)};
   std::vector<Color> colors = {Color::White(), Color::White(), Color::White()};
 
-  Vertices vertices = Vertices(points, indexes, colors, VertexMode::kTriangle,
-                               Rect(100, 100, 300, 300));
+  Vertices vertices = Vertices(positions, {} /* indices */, colors,
+                               VertexMode::kTriangle, Rect(100, 100, 300, 300));
+
+  std::shared_ptr<VerticesContents> contents =
+      std::make_shared<VerticesContents>(vertices);
+  contents->SetColor(Color::White());
+  Entity e;
+  e.SetTransformation(Matrix::MakeScale(GetContentScale()));
+  e.SetContents(contents);
+
+  ASSERT_TRUE(OpenPlaygroundHere(e));
+}
+
+TEST_P(EntityTest, DrawVerticesSolidColorTrianglesWithIndices) {
+  std::vector<Point> positions = {Point(100, 300), Point(200, 100),
+                                  Point(300, 300), Point(200, 500)};
+  std::vector<uint16_t> indices = {0, 1, 2, 0, 2, 3};
+
+  Vertices vertices = Vertices(positions, indices, {} /* colors */,
+                               VertexMode::kTriangle, Rect(100, 100, 300, 300));
 
   std::shared_ptr<VerticesContents> contents =
       std::make_shared<VerticesContents>(vertices);

--- a/impeller/entity/shaders/vertices.frag
+++ b/impeller/entity/shaders/vertices.frag
@@ -2,10 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-in vec4 color;
+in vec4 v_color;
 
 out vec4 frag_color;
 
 void main() {
-  frag_color = color;
+  frag_color = v_color;
 }

--- a/impeller/entity/shaders/vertices.vert
+++ b/impeller/entity/shaders/vertices.vert
@@ -6,12 +6,12 @@ uniform FrameInfo {
   mat4 mvp;
 } frame_info;
 
-in vec2 point;
-in vec4 vertex_color;
+in vec2 position;
+in vec4 color;
 
-out vec4 color;
+out vec4 v_color;
 
 void main() {
-  gl_Position = frame_info.mvp * vec4(point, 0.0, 1.0);
-  color = vertex_color;
+  gl_Position = frame_info.mvp * vec4(position, 0.0, 1.0);
+  v_color = color;
 }

--- a/impeller/geometry/geometry_unittests.cc
+++ b/impeller/geometry/geometry_unittests.cc
@@ -1233,7 +1233,7 @@ TEST(GeometryTest, VerticesConstructorAndGetters) {
                                Rect(0, 0, 4, 4));
 
   ASSERT_EQ(vertices.GetBoundingBox().value(), Rect(0, 0, 4, 4));
-  ASSERT_EQ(vertices.GetPoints(), points);
+  ASSERT_EQ(vertices.GetPositions(), points);
   ASSERT_EQ(vertices.GetIndices(), indices);
   ASSERT_EQ(vertices.GetColors(), colors);
   ASSERT_EQ(vertices.GetMode(), VertexMode::kTriangle);

--- a/impeller/geometry/vertices.cc
+++ b/impeller/geometry/vertices.cc
@@ -11,13 +11,30 @@ Vertices::Vertices(std::vector<Point> points,
                    std::vector<Color> colors,
                    VertexMode vertex_mode,
                    Rect bounds)
-    : points_(std::move(points)),
+    : positions_(std::move(points)),
       indices_(std::move(indices)),
       colors_(std::move(colors)),
       vertex_mode_(vertex_mode),
-      bounds_(bounds){};
+      bounds_(bounds) {
+  NormalizeIndices();
+}
 
 Vertices::~Vertices() = default;
+
+bool Vertices::IsValid() const {
+  size_t points_size = positions_.size();
+  size_t colors_size = colors_.size();
+
+  if (colors_size > 0 && colors_size != points_size) {
+    return false;
+  }
+
+  return true;
+}
+
+std::optional<Rect> Vertices::GetBoundingBox() const {
+  return bounds_;
+};
 
 std::optional<Rect> Vertices::GetTransformedBoundingBox(
     const Matrix& transform) const {
@@ -27,5 +44,30 @@ std::optional<Rect> Vertices::GetTransformedBoundingBox(
   }
   return bounds->TransformBounds(transform);
 };
+
+const std::vector<Point>& Vertices::GetPositions() const {
+  return positions_;
+}
+
+const std::vector<uint16_t>& Vertices::GetIndices() const {
+  return indices_;
+}
+
+const std::vector<Color>& Vertices::GetColors() const {
+  return colors_;
+}
+
+VertexMode Vertices::GetMode() const {
+  return vertex_mode_;
+}
+
+void Vertices::NormalizeIndices() {
+  if (indices_.size() != 0 || positions_.size() == 0) {
+    return;
+  }
+  for (size_t i = 0; i < positions_.size(); i++) {
+    indices_.push_back(i);
+  }
+}
 
 }  // namespace impeller

--- a/impeller/geometry/vertices.h
+++ b/impeller/geometry/vertices.h
@@ -20,7 +20,7 @@ enum class VertexMode {
 
 class Vertices {
  public:
-  Vertices(std::vector<Point> points,
+  Vertices(std::vector<Point> positions,
            std::vector<uint16_t> indices,
            std::vector<Color> colors,
            VertexMode vertex_mode,
@@ -28,24 +28,28 @@ class Vertices {
 
   ~Vertices();
 
-  std::optional<Rect> GetBoundingBox() const { return bounds_; };
+  bool IsValid() const;
+
+  std::optional<Rect> GetBoundingBox() const;
 
   std::optional<Rect> GetTransformedBoundingBox(const Matrix& transform) const;
 
-  const std::vector<Point>& GetPoints() const { return points_; }
+  const std::vector<Point>& GetPositions() const;
 
-  const std::vector<uint16_t>& GetIndices() const { return indices_; }
+  const std::vector<uint16_t>& GetIndices() const;
 
-  const std::vector<Color>& GetColors() const { return colors_; }
+  const std::vector<Color>& GetColors() const;
 
-  VertexMode GetMode() const { return vertex_mode_; }
+  VertexMode GetMode() const;
 
  private:
-  std::vector<Point> points_;
+  std::vector<Point> positions_;
   std::vector<uint16_t> indices_;
   std::vector<Color> colors_;
   VertexMode vertex_mode_;
   Rect bounds_;
+
+  void NormalizeIndices();
 };
 
 }  // namespace impeller


### PR DESCRIPTION
* Copy user supplied indices directly into buffer for DrawVertices.
* Populate optional vertex colors when available... These colors still need to be blended (see inline comment and bullet below).
* Add the blend mode field -- will be used once we add host-side blends: flutter/flutter#108047
* Did the same consistency cleanup that I'm currently doing against all contents/shaders (as in https://github.com/flutter/engine/pull/34739)