### PR TITLE
Use PorterDuff blend mode when below Android 29

### DIFF
--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewWrapper.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewWrapper.java
@@ -170,11 +170,7 @@ class PlatformViewWrapper extends FrameLayout {
     // to the user until the platform view draws its first frame.
     final Canvas canvas = surface.lockHardwareCanvas();
     try {
-      if (Build.VERSION.SDK_INT >= 29) {
-        canvas.drawColor(Color.TRANSPARENT, BlendMode.CLEAR);
-      } else {
-        canvas.drawColor(Color.TRANSPARENT);
-      }
+      canvas.drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR);
       onFrameProduced();
     } finally {
       surface.unlockCanvasAndPost(canvas);
@@ -306,11 +302,7 @@ class PlatformViewWrapper extends FrameLayout {
       try {
         // Clear the current pixels in the canvas.
         // This helps when a WebView renders an HTML document with transparent background.
-        if (Build.VERSION.SDK_INT >= 29) {
-          surfaceCanvas.drawColor(Color.TRANSPARENT, BlendMode.CLEAR);
-        } else {
-          surfaceCanvas.drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR);
-        }
+        surfaceCanvas.drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR);
         super.draw(surfaceCanvas);
         onFrameProduced();
       } finally {

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewWrapper.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewWrapper.java
@@ -31,6 +31,7 @@ import io.flutter.embedding.android.AndroidTouchProcessor;
 import io.flutter.util.ViewUtils;
 import io.flutter.view.TextureRegistry;
 import java.util.concurrent.atomic.AtomicLong;
+import android.graphics.PorterDuff;
 
 /**
  * Wraps a platform view to intercept gestures and project this view onto a {@link SurfaceTexture}.
@@ -308,7 +309,7 @@ class PlatformViewWrapper extends FrameLayout {
         if (Build.VERSION.SDK_INT >= 29) {
           surfaceCanvas.drawColor(Color.TRANSPARENT, BlendMode.CLEAR);
         } else {
-          surfaceCanvas.drawColor(Color.TRANSPARENT);
+          surfaceCanvas.drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR);
         }
         super.draw(surfaceCanvas);
         onFrameProduced();

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewWrapper.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewWrapper.java
@@ -13,6 +13,7 @@ import android.graphics.BlendMode;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Matrix;
+import android.graphics.PorterDuff;
 import android.graphics.Rect;
 import android.graphics.SurfaceTexture;
 import android.os.Build;
@@ -31,7 +32,6 @@ import io.flutter.embedding.android.AndroidTouchProcessor;
 import io.flutter.util.ViewUtils;
 import io.flutter.view.TextureRegistry;
 import java.util.concurrent.atomic.AtomicLong;
-import android.graphics.PorterDuff;
 
 /**
  * Wraps a platform view to intercept gestures and project this view onto a {@link SurfaceTexture}.

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewWrapper.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewWrapper.java
@@ -9,7 +9,6 @@ import static android.content.ComponentCallbacks2.TRIM_MEMORY_COMPLETE;
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.content.Context;
-import android.graphics.BlendMode;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Matrix;

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewWrapperTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewWrapperTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import android.annotation.TargetApi;
 import android.content.Context;
 import android.graphics.BlendMode;
 import android.graphics.Canvas;
@@ -26,6 +27,7 @@ import org.robolectric.annotation.Config;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+@TargetApi(31)
 @RunWith(AndroidJUnit4.class)
 public class PlatformViewWrapperTest {
   private final Context ctx = ApplicationProvider.getApplicationContext();
@@ -64,7 +66,7 @@ public class PlatformViewWrapperTest {
     // Verify.
     verify(surface, times(1)).lockHardwareCanvas();
     verify(surface, times(1)).unlockCanvasAndPost(canvas);
-    verify(canvas, times(1)).drawColor(Color.TRANSPARENT, BlendMode.CLEAR);
+    verify(canvas, times(1)).drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR);
     verifyNoMoreInteractions(surface);
     verifyNoMoreInteractions(canvas);
   }
@@ -111,56 +113,12 @@ public class PlatformViewWrapperTest {
     wrapper.draw(new Canvas());
 
     // Verify.
-    verify(canvas, times(1)).drawColor(Color.TRANSPARENT, BlendMode.CLEAR);
+    verify(canvas, times(1)).drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR);
     verify(surface, times(1)).isValid();
     verify(surface, times(1)).lockHardwareCanvas();
     verify(surface, times(1)).unlockCanvasAndPost(canvas);
     verifyNoMoreInteractions(surface);
     verifyNoMoreInteractions(canvas);
-  }
-
-  @Config(sdk = 28)
-  @Test
-  public void draw_clearsCanvasWithClearModeOnAndroidVersionsBelow29() {
-    final Surface surface = mock(Surface.class);
-    final PlatformViewWrapper wrapper =
-        new PlatformViewWrapper(ctx) {
-          @Override
-          protected Surface createSurface(@NonNull SurfaceTexture tx) {
-            return surface;
-          }
-        };
-
-    wrapper.addView(
-        new View(ctx) {
-          @Override
-          public void draw(Canvas canvas) {
-            super.draw(canvas);
-            canvas.drawColor(Color.RED);
-          }
-        });
-
-    final int size = 100;
-    wrapper.measure(size, size);
-    wrapper.layout(0, 0, size, size);
-
-    final SurfaceTexture tx = mock(SurfaceTexture.class);
-    when(tx.isReleased()).thenReturn(false);
-
-    when(surface.lockHardwareCanvas()).thenReturn(mock(Canvas.class));
-
-    wrapper.setTexture(tx);
-
-    final Canvas canvas = mock(Canvas.class);
-    when(surface.lockHardwareCanvas()).thenReturn(canvas);
-    when(surface.isValid()).thenReturn(true);
-
-    // Test.
-    wrapper.invalidate();
-    wrapper.draw(new Canvas());
-
-    // Verify.
-    verify(canvas, times(1)).drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR);
   }
 
   @Test

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewWrapperTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewWrapperTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.*;
 
 import android.annotation.TargetApi;
 import android.content.Context;
-import android.graphics.BlendMode;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.PorterDuff;


### PR DESCRIPTION
Engine fix for https://github.com/flutter/flutter/issues/104686.

As of now, this is solved at the plugin level by switching to Hybrid Composition when the view has a transparent/translucent background:  https://github.com/flutter/plugins/pull/6063

This should hopefully remove the need to do this. I tested it locally and the previous rendering issue was fixed when this flag was used.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
