### PR TITLE
Add entrypoint annotations to FragmentProgram fields

### DIFF
--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -4154,7 +4154,10 @@ class FragmentProgram extends NativeFieldWrapperClass1 {
     }
   }
 
+  @pragma('vm:entry-point')
   late final int _uniformFloatCount;
+
+  @pragma('vm:entry-point')
   late final int _samplerCount;
 
   @FfiNative<Void Function(Handle)>('FragmentProgram::Create')


### PR DESCRIPTION
These are written from `FragmentProgram.initFromAsset` in the C++ code.