### PR TITLE
Rtree from displaylist

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -100,6 +100,8 @@ FILE: ../../../flutter/display_list/display_list_paint_unittests.cc
 FILE: ../../../flutter/display_list/display_list_path_effect.cc
 FILE: ../../../flutter/display_list/display_list_path_effect.h
 FILE: ../../../flutter/display_list/display_list_path_effect_unittests.cc
+FILE: ../../../flutter/display_list/display_list_rtree.cc
+FILE: ../../../flutter/display_list/display_list_rtree.h
 FILE: ../../../flutter/display_list/display_list_sampling_options.h
 FILE: ../../../flutter/display_list/display_list_test_utils.cc
 FILE: ../../../flutter/display_list/display_list_test_utils.h

--- a/display_list/BUILD.gn
+++ b/display_list/BUILD.gn
@@ -48,6 +48,8 @@ source_set("display_list") {
     "display_list_paint.h",
     "display_list_path_effect.cc",
     "display_list_path_effect.h",
+    "display_list_rtree.cc",
+    "display_list_rtree.h",
     "display_list_sampling_options.h",
     "display_list_tile_mode.h",
     "display_list_utils.cc",

--- a/display_list/display_list.cc
+++ b/display_list/display_list.cc
@@ -53,9 +53,23 @@ DisplayList::~DisplayList() {
 }
 
 void DisplayList::ComputeBounds() {
-  DisplayListBoundsCalculator calculator(&bounds_cull_);
+  RectBoundsAccumulator accumulator;
+  DisplayListBoundsCalculator calculator(accumulator, &bounds_cull_);
   Dispatch(calculator);
-  bounds_ = calculator.bounds();
+  if (calculator.is_unbounded()) {
+    FML_LOG(INFO) << "returning partial bounds for unbounded DisplayList";
+  }
+  bounds_ = accumulator.bounds();
+}
+
+void DisplayList::ComputeRTree() {
+  RTreeBoundsAccumulator accumulator;
+  DisplayListBoundsCalculator calculator(accumulator, &bounds_cull_);
+  Dispatch(calculator);
+  if (calculator.is_unbounded()) {
+    FML_LOG(INFO) << "returning partial rtree for unbounded DisplayList";
+  }
+  rtree_ = accumulator.rtree();
 }
 
 void DisplayList::Dispatch(Dispatcher& dispatcher,

--- a/display_list/display_list.h
+++ b/display_list/display_list.h
@@ -5,8 +5,10 @@
 #ifndef FLUTTER_DISPLAY_LIST_DISPLAY_LIST_H_
 #define FLUTTER_DISPLAY_LIST_DISPLAY_LIST_H_
 
+#include <memory>
 #include <optional>
 
+#include "flutter/display_list/display_list_rtree.h"
 #include "flutter/display_list/display_list_sampling_options.h"
 #include "flutter/display_list/types.h"
 #include "flutter/fml/logging.h"
@@ -254,6 +256,13 @@ class DisplayList : public SkRefCnt {
     return bounds_;
   }
 
+  sk_sp<const DlRTree> rtree() {
+    if (!rtree_) {
+      ComputeRTree();
+    }
+    return rtree_;
+  }
+
   bool Equals(const DisplayList* other) const;
   bool Equals(const DisplayList& other) const { return Equals(&other); }
   bool Equals(sk_sp<const DisplayList> other) const {
@@ -282,6 +291,7 @@ class DisplayList : public SkRefCnt {
 
   uint32_t unique_id_;
   SkRect bounds_;
+  sk_sp<const DlRTree> rtree_;
 
   // Only used for drawPaint() and drawColor()
   SkRect bounds_cull_;
@@ -289,6 +299,7 @@ class DisplayList : public SkRefCnt {
   bool can_apply_group_opacity_;
 
   void ComputeBounds();
+  void ComputeRTree();
   void Dispatch(Dispatcher& ctx, uint8_t* ptr, uint8_t* end) const;
 
   friend class DisplayListBuilder;

--- a/display_list/display_list_rtree.cc
+++ b/display_list/display_list_rtree.cc
@@ -1,0 +1,97 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/display_list/display_list_rtree.h"
+
+#include "flutter/fml/logging.h"
+
+namespace flutter {
+
+DlRTree::DlRTree() : bbh_{SkRTreeFactory{}()}, all_ops_count_(0) {}
+
+void DlRTree::insert(const SkRect boundsArray[],
+                     const SkBBoxHierarchy::Metadata metadata[],
+                     int N) {
+  FML_DCHECK(0 == all_ops_count_);
+  bbh_->insert(boundsArray, metadata, N);
+  for (int i = 0; i < N; i++) {
+    if (metadata == nullptr || metadata[i].isDraw) {
+      draw_op_[i] = boundsArray[i];
+    }
+  }
+  all_ops_count_ = N;
+}
+
+void DlRTree::insert(const SkRect boundsArray[], int N) {
+  insert(boundsArray, nullptr, N);
+}
+
+void DlRTree::search(const SkRect& query, std::vector<int>* results) const {
+  bbh_->search(query, results);
+}
+
+std::list<SkRect> DlRTree::searchNonOverlappingDrawnRects(
+    const SkRect& query) const {
+  // Get the indexes for the operations that intersect with the query rect.
+  std::vector<int> intermediary_results;
+  search(query, &intermediary_results);
+
+  std::list<SkRect> final_results;
+  for (int index : intermediary_results) {
+    auto draw_op = draw_op_.find(index);
+    // Ignore records that don't draw anything.
+    if (draw_op == draw_op_.end()) {
+      continue;
+    }
+    auto current_record_rect = draw_op->second;
+    auto replaced_existing_rect = false;
+    // // If the current record rect intersects with any of the rects in the
+    // // result list, then join them, and update the rect in final_results.
+    std::list<SkRect>::iterator curr_rect_itr = final_results.begin();
+    std::list<SkRect>::iterator first_intersecting_rect_itr;
+    while (!replaced_existing_rect && curr_rect_itr != final_results.end()) {
+      if (SkRect::Intersects(*curr_rect_itr, current_record_rect)) {
+        replaced_existing_rect = true;
+        first_intersecting_rect_itr = curr_rect_itr;
+        curr_rect_itr->join(current_record_rect);
+      }
+      curr_rect_itr++;
+    }
+    // It's possible that the result contains duplicated rects at this point.
+    // For example, consider a result list that contains rects A, B. If a
+    // new rect C is a superset of A and B, then A and B are the same set after
+    // the merge. As a result, find such cases and remove them from the result
+    // list.
+    while (replaced_existing_rect && curr_rect_itr != final_results.end()) {
+      if (SkRect::Intersects(*curr_rect_itr, *first_intersecting_rect_itr)) {
+        first_intersecting_rect_itr->join(*curr_rect_itr);
+        curr_rect_itr = final_results.erase(curr_rect_itr);
+      } else {
+        curr_rect_itr++;
+      }
+    }
+    if (!replaced_existing_rect) {
+      final_results.push_back(current_record_rect);
+    }
+  }
+  return final_results;
+}
+
+size_t DlRTree::bytesUsed() const {
+  return bbh_->bytesUsed();
+}
+
+DlRTreeFactory::DlRTreeFactory() {
+  r_tree_ = sk_make_sp<DlRTree>();
+}
+
+sk_sp<DlRTree> DlRTreeFactory::getInstance() {
+  return r_tree_;
+}
+
+sk_sp<SkBBoxHierarchy> DlRTreeFactory::operator()() const {
+  return r_tree_;
+}
+
+}  // namespace flutter

--- a/display_list/display_list_rtree.h
+++ b/display_list/display_list_rtree.h
@@ -1,0 +1,68 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_DISPLAY_LIST_RTREE_H_
+#define FLUTTER_DISPLAY_LIST_RTREE_H_
+
+#include <list>
+#include <map>
+
+#include "third_party/skia/include/core/SkRect.h"
+#include "third_party/skia/include/core/SkBBHFactory.h"
+
+namespace flutter {
+
+/**
+ * An R-Tree implementation that forwards calls to an SkRTree. This is just
+ * a copy of flow/rtree.h/cc until we can figure out where these utilities
+ * can live with appropriate linking visibility.
+ *
+ * This implementation provides a searchNonOverlappingDrawnRects method,
+ * which can be used to query the rects for the operations recorded in the tree.
+ */
+class DlRTree : public SkBBoxHierarchy {
+ public:
+  DlRTree();
+
+  void insert(const SkRect[],
+              const SkBBoxHierarchy::Metadata[],
+              int N) override;
+  void insert(const SkRect[], int N) override;
+  void search(const SkRect& query, std::vector<int>* results) const override;
+  size_t bytesUsed() const override;
+
+  // Finds the rects in the tree that represent drawing operations and intersect
+  // with the query rect.
+  //
+  // When two rects intersect with each other, they are joined into a single
+  // rect which also intersects with the query rect. In other words, the bounds
+  // of each rect in the result list are mutually exclusive.
+  std::list<SkRect> searchNonOverlappingDrawnRects(const SkRect& query) const;
+
+  // Insertion count (not overall node count, which may be greater).
+  int getCount() const { return all_ops_count_; }
+
+ private:
+  // A map containing the draw operation rects keyed off the operation index
+  // in the insert call.
+  std::map<int, SkRect> draw_op_;
+  sk_sp<SkBBoxHierarchy> bbh_;
+  int all_ops_count_;
+};
+
+class DlRTreeFactory : public SkBBHFactory {
+ public:
+  DlRTreeFactory();
+
+  // Gets the instance to the R-tree.
+  sk_sp<DlRTree> getInstance();
+  sk_sp<SkBBoxHierarchy> operator()() const override;
+
+ private:
+  sk_sp<DlRTree> r_tree_;
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_DISPLAY_LIST_RTREE_H_

--- a/display_list/display_list_rtree.h
+++ b/display_list/display_list_rtree.h
@@ -8,8 +8,8 @@
 #include <list>
 #include <map>
 
-#include "third_party/skia/include/core/SkRect.h"
 #include "third_party/skia/include/core/SkBBHFactory.h"
+#include "third_party/skia/include/core/SkRect.h"
 
 namespace flutter {
 

--- a/display_list/display_list_unittests.cc
+++ b/display_list/display_list_unittests.cc
@@ -3,10 +3,12 @@
 // found in the LICENSE file.
 
 #include <memory>
+
 #include "flutter/display_list/display_list.h"
 #include "flutter/display_list/display_list_blend_mode.h"
 #include "flutter/display_list/display_list_builder.h"
 #include "flutter/display_list/display_list_canvas_recorder.h"
+#include "flutter/display_list/display_list_rtree.h"
 #include "flutter/display_list/display_list_utils.h"
 #include "flutter/fml/math.h"
 #include "flutter/testing/display_list_testing.h"
@@ -2301,6 +2303,50 @@ TEST(DisplayList, FlatDrawPointsProducesBounds) {
     EXPECT_TRUE(bounds.contains(10, 10));
     EXPECT_EQ(bounds, SkRect::MakeLTRB(9, 9, 11, 11));
   }
+}
+
+static void test_rtree(sk_sp<const DlRTree> rtree,
+                       const SkRect& query,
+                       std::vector<SkRect> expected_rects,
+                       std::vector<int> expected_indices) {
+  std::vector<int> indices;
+  rtree->search(query, &indices);
+  EXPECT_EQ(indices, expected_indices);
+  EXPECT_EQ(indices.size(), expected_indices.size());
+  std::list<SkRect> rects = rtree->searchNonOverlappingDrawnRects(query);
+  // ASSERT_EQ(rects.size(), expected_indices.size());
+  auto iterator = rects.cbegin();
+  for (int i : expected_indices) {
+    EXPECT_TRUE(iterator != rects.cend());
+    EXPECT_EQ(*iterator++, expected_rects[i]);
+  }
+}
+
+TEST(DisplayList, RTreeOfSimpleScene) {
+  DisplayListBuilder builder;
+  builder.drawRect({10, 10, 20, 20});
+  builder.drawRect({50, 50, 60, 60});
+  auto display_list = builder.Build();
+  auto rtree = display_list->rtree();
+  std::vector<SkRect> rects = {
+      {10, 10, 20, 20},
+      {50, 50, 60, 60},
+  };
+
+  // Missing all drawRect calls
+  test_rtree(rtree, {5, 5, 10, 10}, rects, {});
+  test_rtree(rtree, {20, 20, 25, 25}, rects, {});
+  test_rtree(rtree, {45, 45, 50, 50}, rects, {});
+  test_rtree(rtree, {60, 60, 65, 65}, rects, {});
+
+  // Hitting just 1 of the drawRects
+  test_rtree(rtree, {5, 5, 11, 11}, rects, {0});
+  test_rtree(rtree, {19, 19, 25, 25}, rects, {0});
+  test_rtree(rtree, {45, 45, 51, 51}, rects, {1});
+  test_rtree(rtree, {59, 59, 65, 65}, rects, {1});
+
+  // Hitting both drawRect calls
+  test_rtree(rtree, {19, 19, 51, 51}, rects, {0, 1});
 }
 
 }  // namespace testing

--- a/display_list/display_list_utils.cc
+++ b/display_list/display_list_utils.cc
@@ -258,11 +258,143 @@ void ClipBoundsDispatchHelper::reset(const SkRect* cull_rect) {
   }
 }
 
+void RectBoundsAccumulator::accumulate(const SkRect& r) {
+  if (r.fLeft < r.fRight && r.fTop < r.fBottom) {
+    rect_.accumulate(r.fLeft, r.fTop);
+    rect_.accumulate(r.fRight, r.fBottom);
+  }
+}
+
+void RectBoundsAccumulator::save() {
+  saved_rects_.emplace_back(rect_);
+  rect_ = AccumulationRect();
+}
+void RectBoundsAccumulator::restore(const SkRect* clip) {
+  if (!saved_rects_.empty()) {
+    SkRect layer_bounds = rect_.bounds();
+    pop_and_accumulate(layer_bounds, clip);
+  }
+}
+bool RectBoundsAccumulator::restore(
+    std::function<bool(const SkRect&, SkRect&)> mapper,
+    const SkRect* clip) {
+  bool success = true;
+  if (!saved_rects_.empty()) {
+    SkRect layer_bounds = rect_.bounds();
+    success = mapper(layer_bounds, layer_bounds);
+    pop_and_accumulate(layer_bounds, clip);
+  }
+  return success;
+}
+void RectBoundsAccumulator::pop_and_accumulate(SkRect& layer_bounds,
+                                               const SkRect* clip) {
+  FML_DCHECK(!saved_rects_.empty());
+
+  rect_ = saved_rects_.back();
+  saved_rects_.pop_back();
+
+  if (clip == nullptr || layer_bounds.intersect(*clip)) {
+    accumulate(layer_bounds);
+  }
+}
+
+RectBoundsAccumulator::AccumulationRect::AccumulationRect() {
+  min_x_ = std::numeric_limits<SkScalar>::infinity();
+  min_y_ = std::numeric_limits<SkScalar>::infinity();
+  max_x_ = -std::numeric_limits<SkScalar>::infinity();
+  max_y_ = -std::numeric_limits<SkScalar>::infinity();
+}
+void RectBoundsAccumulator::AccumulationRect::accumulate(SkScalar x,
+                                                         SkScalar y) {
+  if (min_x_ > x) {
+    min_x_ = x;
+  }
+  if (min_y_ > y) {
+    min_y_ = y;
+  }
+  if (max_x_ < x) {
+    max_x_ = x;
+  }
+  if (max_y_ < y) {
+    max_y_ = y;
+  }
+}
+SkRect RectBoundsAccumulator::AccumulationRect::bounds() const {
+  return (max_x_ >= min_x_ && max_y_ >= min_y_)
+             ? SkRect::MakeLTRB(min_x_, min_y_, max_x_, max_y_)
+             : SkRect::MakeEmpty();
+}
+
+void RTreeBoundsAccumulator::accumulate(const SkRect& r) {
+  if (r.fLeft < r.fRight && r.fTop < r.fBottom) {
+    rects_.push_back(r);
+  }
+}
+bool RTreeBoundsAccumulator::is_empty() const {
+  return rects_.empty();
+}
+bool RTreeBoundsAccumulator::is_not_empty() const {
+  return !rects_.empty();
+}
+void RTreeBoundsAccumulator::save() {
+  saved_offsets_.push_back(rects_.size());
+}
+void RTreeBoundsAccumulator::restore(const SkRect* clip) {
+  if (saved_offsets_.empty()) {
+    return;
+  }
+
+  size_t previous_size = saved_offsets_.back();
+  saved_offsets_.pop_back();
+
+  if (clip) {
+    for (size_t i = previous_size; i < saved_offsets_.size(); i++) {
+      SkRect original = rects_[i];
+      if (original.intersect(*clip)) {
+        rects_[previous_size++] = original;
+      }
+    }
+    rects_.resize(previous_size);
+  }
+}
+bool RTreeBoundsAccumulator::restore(
+    std::function<bool(const SkRect& original, SkRect& modified)> map,
+    const SkRect* clip) {
+  if (saved_offsets_.empty()) {
+    return true;
+  }
+
+  size_t previous_size = saved_offsets_.back();
+  saved_offsets_.pop_back();
+
+  bool success = true;
+  if (clip) {
+    for (size_t i = previous_size; i < saved_offsets_.size(); i++) {
+      SkRect original = rects_[i];
+      if (!map(original, original)) {
+        success = false;
+      }
+      if (original.intersect(*clip)) {
+        rects_[previous_size++] = original;
+      }
+    }
+    rects_.resize(previous_size);
+  }
+  return success;
+}
+sk_sp<DlRTree> RTreeBoundsAccumulator::rtree() const {
+  FML_DCHECK(saved_offsets_.empty());
+  DlRTreeFactory factory;
+  sk_sp<DlRTree> rtree = factory.getInstance();
+  rtree->insert(rects_.data(), rects_.size());
+  return rtree;
+}
+
 DisplayListBoundsCalculator::DisplayListBoundsCalculator(
+    BoundsAccumulator& accumulator,
     const SkRect* cull_rect)
-    : ClipBoundsDispatchHelper(cull_rect) {
+    : ClipBoundsDispatchHelper(cull_rect), accumulator_(accumulator) {
   layer_infos_.emplace_back(std::make_unique<LayerData>(nullptr));
-  accumulator_ = layer_infos_.back()->layer_accumulator();
 }
 void DisplayListBoundsCalculator::setStrokeCap(DlStrokeCap cap) {
   cap_is_square_ = (cap == DlStrokeCap::kSquare);
@@ -307,8 +439,8 @@ void DisplayListBoundsCalculator::setMaskFilter(const DlMaskFilter* filter) {
 void DisplayListBoundsCalculator::save() {
   SkMatrixDispatchHelper::save();
   ClipBoundsDispatchHelper::save();
-  layer_infos_.emplace_back(std::make_unique<LayerData>(accumulator_));
-  accumulator_ = layer_infos_.back()->layer_accumulator();
+  layer_infos_.emplace_back(std::make_unique<LayerData>(nullptr));
+  accumulator_.save();
 }
 void DisplayListBoundsCalculator::saveLayer(const SkRect* bounds,
                                             const SaveLayerOptions options,
@@ -325,14 +457,12 @@ void DisplayListBoundsCalculator::saveLayer(const SkRect* bounds,
       AccumulateUnbounded();
     }
 
-    layer_infos_.emplace_back(
-        std::make_unique<LayerData>(accumulator_, image_filter_));
+    layer_infos_.emplace_back(std::make_unique<LayerData>(image_filter_));
   } else {
-    layer_infos_.emplace_back(
-        std::make_unique<LayerData>(accumulator_, nullptr));
+    layer_infos_.emplace_back(std::make_unique<LayerData>(nullptr));
   }
 
-  accumulator_ = layer_infos_.back()->layer_accumulator();
+  accumulator_.save();
 
   // Even though Skia claims that the bounds are only a hint, they actually
   // use them as the temporary layer bounds during rendering the layer, so
@@ -353,47 +483,34 @@ void DisplayListBoundsCalculator::restore() {
     // Remember a few pieces of information from the current layer info
     // for later processing.
     LayerData* layer_info = layer_infos_.back().get();
-    BoundsAccumulator* outer_accumulator = layer_info->restore_accumulator();
     bool is_unbounded = layer_info->is_unbounded();
 
     // Before we pop_back we will get the current layer bounds from the
     // current accumulator and adjust ot as required based on the filter.
-    SkRect layer_bounds = accumulator_->bounds();
+    // SkRect layer_bounds = accumulator_->bounds();
     std::shared_ptr<DlImageFilter> filter = layer_info->filter();
+    const SkRect* clip = has_clip() ? &clip_bounds() : nullptr;
     if (filter) {
-      SkIRect filter_bounds;
-      if (filter->map_device_bounds(layer_bounds.roundOut(), matrix(),
-                                    filter_bounds)) {
-        layer_bounds.set(filter_bounds);
-
-        // We could leave the clipping to the code below that will
-        // finally accumulate the layer bounds, but the bounds do
-        // not normally need clipping unless they were modified by
-        // entering this filtering code path.
-        if (has_clip() && !layer_bounds.intersect(clip_bounds())) {
-          layer_bounds.setEmpty();
-        }
-      } else {
-        // If the filter cannot compute bounds then it might take an
-        // unbounded amount of space. This can sometimes happen if it
-        // modifies transparent black which means its affect will not
-        // be bounded by the transparent pixels outside of the layer
-        // drawable.
+      if (!accumulator_.restore(
+              [filter = filter, matrix = matrix()](const SkRect& input,
+                                                   SkRect& output) {
+                SkIRect output_bounds;
+                bool ret = filter->map_device_bounds(input.roundOut(), matrix,
+                                                     output_bounds);
+                output.set(output_bounds);
+                return ret;
+              },
+              clip)) {
         is_unbounded = true;
       }
+    } else {
+      accumulator_.restore(clip);
     }
 
     // Restore the accumulator before popping the LayerInfo so that
     // it nevers points to an out of scope instance.
-    accumulator_ = outer_accumulator;
     layer_infos_.pop_back();
 
-    // Finally accumulate the impact of the layer into the new scope.
-    // Note that the bounds were already accumulated in device pixels
-    // and clipped to any clips involved so we do not need to go
-    // through any transforms or clips to accuulate them into this
-    // layer.
-    accumulator_->accumulate(layer_bounds);
     if (is_unbounded) {
       AccumulateUnbounded();
     }
@@ -456,7 +573,7 @@ void DisplayListBoundsCalculator::drawPoints(SkCanvas::PointMode mode,
                                              uint32_t count,
                                              const SkPoint pts[]) {
   if (count > 0) {
-    BoundsAccumulator ptBounds;
+    RectBoundsAccumulator ptBounds;
     for (size_t i = 0; i < count; i++) {
       ptBounds.accumulate(pts[i]);
     }
@@ -537,7 +654,7 @@ void DisplayListBoundsCalculator::drawAtlas(const sk_sp<DlImage> atlas,
                                             const SkRect* cullRect,
                                             bool render_with_attributes) {
   SkPoint quad[4];
-  BoundsAccumulator atlasBounds;
+  RectBoundsAccumulator atlasBounds;
   for (int i = 0; i < count; i++) {
     const SkRect& src = tex[i];
     xform[i].toQuad(src.width(), src.height(), quad);
@@ -655,7 +772,7 @@ bool DisplayListBoundsCalculator::AdjustBoundsForPaint(
 
 void DisplayListBoundsCalculator::AccumulateUnbounded() {
   if (has_clip()) {
-    accumulator_->accumulate(clip_bounds());
+    accumulator_.accumulate(clip_bounds());
   } else {
     layer_infos_.back()->set_unbounded();
   }
@@ -672,7 +789,7 @@ void DisplayListBoundsCalculator::AccumulateOpBounds(
 void DisplayListBoundsCalculator::AccumulateBounds(SkRect& bounds) {
   matrix().mapRect(&bounds);
   if (!has_clip() || bounds.intersect(clip_bounds())) {
-    accumulator_->accumulate(bounds);
+    accumulator_.accumulate(bounds);
   }
 }
 

--- a/display_list/display_list_utils.cc
+++ b/display_list/display_list_utils.cc
@@ -487,7 +487,6 @@ void DisplayListBoundsCalculator::restore() {
 
     // Before we pop_back we will get the current layer bounds from the
     // current accumulator and adjust ot as required based on the filter.
-    // SkRect layer_bounds = accumulator_->bounds();
     std::shared_ptr<DlImageFilter> filter = layer_info->filter();
     const SkRect* clip = has_clip() ? &clip_bounds() : nullptr;
     if (filter) {

--- a/display_list/display_list_utils.h
+++ b/display_list/display_list_utils.h
@@ -586,10 +586,6 @@ class DisplayListBoundsCalculator final
    public:
     // Construct a LayerData to push on the save stack for a |save|
     // or |saveLayer| call.
-    // The |outer| parameter is the |BoundsAccumulator| that was
-    // in use by the stream before this layer was pushed on the
-    // stack and should be returned when this layer is popped off
-    // the stack.
     // Some saveLayer calls will process their bounds by a
     // |DlImageFilter| when they are restored, but for most
     // saveLayer (and all save) calls the filter will be null.

--- a/display_list/display_list_utils.h
+++ b/display_list/display_list_utils.h
@@ -10,6 +10,7 @@
 #include "flutter/display_list/display_list.h"
 #include "flutter/display_list/display_list_blend_mode.h"
 #include "flutter/display_list/display_list_builder.h"
+#include "flutter/display_list/display_list_rtree.h"
 #include "flutter/fml/logging.h"
 #include "flutter/fml/macros.h"
 #include "third_party/skia/include/core/SkMaskFilter.h"
@@ -338,42 +339,130 @@ class ClipBoundsDispatchHelper : public virtual Dispatcher,
 
 class BoundsAccumulator {
  public:
-  void accumulate(const SkPoint& p) { accumulate(p.fX, p.fY); }
-  void accumulate(SkScalar x, SkScalar y) {
-    if (min_x_ > x) {
-      min_x_ = x;
-    }
-    if (min_y_ > y) {
-      min_y_ = y;
-    }
-    if (max_x_ < x) {
-      max_x_ = x;
-    }
-    if (max_y_ < y) {
-      max_y_ = y;
-    }
-  }
-  void accumulate(const SkRect& r) {
-    if (r.fLeft < r.fRight && r.fTop < r.fBottom) {
-      accumulate(r.fLeft, r.fTop);
-      accumulate(r.fRight, r.fBottom);
-    }
-  }
+  /// function definition for modifying the bounds of a rectangle
+  /// during a restore operation. The function is used primarily
+  /// to account for the bounds impact of an ImageFilter on a
+  /// saveLayer on a per-rect basis. The implementation may apply
+  /// this function at whatever granularity it can manage easily
+  /// (for example, a Rect accumulator might apply it to the entire
+  /// local bounds being restored, whereas an RTree accumulator might
+  /// apply it individually to each element in the local RTree).
+  ///
+  /// The function will do a best faith attempt at determining the
+  /// modified bounds and store the results in the supplied |dest|
+  /// rectangle and return true. If the function is unable to
+  /// accurately determine the modifed bounds, it will set the
+  /// |dest| rectangle to a copy of the input bounds (or a best
+  /// guess) and return false to indicate that the bounds should not
+  /// be trusted.
+  typedef bool BoundsModifier(const SkRect& original, SkRect* dest);
 
-  bool is_empty() const { return min_x_ >= max_x_ || min_y_ >= max_y_; }
-  bool is_not_empty() const { return min_x_ < max_x_ && min_y_ < max_y_; }
+  virtual void accumulate(const SkRect& r) = 0;
+
+  virtual bool is_empty() const = 0;
+  virtual bool is_not_empty() const = 0;
+
+  /// Save aside the rects/bounds currently being accumulated and start
+  /// accumulating a new set of rects/bounds. When restore is called,
+  /// some additional modifications may be applied to these new bounds
+  /// before they are accumulated back into the surrounding bounds.
+  virtual void save() = 0;
+
+  /// Restore the previous set of accumulation rects/bounds and accumulate
+  /// the current rects/bounds that were accumulated since the most recent
+  /// call to |save| into them, optionally clipping them to the specified
+  /// clip if it is not null.
+  ///
+  /// If there are no saved accumulations to restore to, this method will
+  /// NOP even if a clip is provided.
+  virtual void restore(const SkRect* clip = nullptr) = 0;
+
+  /// Restore the previous set of accumulation rects/bounds and accumulate
+  /// the current rects/bounds that were accumulated since the most recent
+  /// call to |save| into them with modifications specified by the |map|
+  /// parameter and clipping to the clip parameter if it is not null.
+  ///
+  /// The indicated map function is applied to the various rects and bounds
+  /// that have been accumulated in this save/restore cycle before they
+  /// are then accumulated into the previous accumulations. The granularity
+  /// of the application of the map function to the rectangles that were
+  /// accumulated during the save period is left up to the implementation.
+  ///
+  /// This method will return true if the map function returned true on
+  /// every single invocation. A false return value means that the
+  /// bounds accumulated during this restore may not be trusted (as
+  /// determined by the map function).
+  ///
+  /// If there are no saved accumulations to restore to, this method will
+  /// NOP ignoring the map function and the optional clip entirely.
+  virtual bool restore(
+      std::function<bool(const SkRect& original, SkRect& modified)> map,
+      const SkRect* clip = nullptr) = 0;
+};
+
+class RectBoundsAccumulator final : public virtual BoundsAccumulator {
+ public:
+  void accumulate(SkScalar x, SkScalar y) { rect_.accumulate(x, y); }
+  void accumulate(const SkPoint& p) { rect_.accumulate(p.fX, p.fY); }
+  void accumulate(const SkRect& r) override;
+
+  bool is_empty() const override { return rect_.is_empty(); }
+  bool is_not_empty() const override { return rect_.is_not_empty(); }
+
+  void save() override;
+  void restore(const SkRect* clip) override;
+  bool restore(std::function<bool(const SkRect&, SkRect&)> mapper,
+               const SkRect* clip) override;
 
   SkRect bounds() const {
-    return (max_x_ >= min_x_ && max_y_ >= min_y_)
-               ? SkRect::MakeLTRB(min_x_, min_y_, max_x_, max_y_)
-               : SkRect::MakeEmpty();
+    FML_DCHECK(saved_rects_.empty());
+    return rect_.bounds();
   }
 
  private:
-  SkScalar min_x_ = std::numeric_limits<SkScalar>::infinity();
-  SkScalar min_y_ = std::numeric_limits<SkScalar>::infinity();
-  SkScalar max_x_ = -std::numeric_limits<SkScalar>::infinity();
-  SkScalar max_y_ = -std::numeric_limits<SkScalar>::infinity();
+  class AccumulationRect {
+   public:
+    AccumulationRect();
+
+    void accumulate(SkScalar x, SkScalar y);
+
+    bool is_empty() const { return min_x_ >= max_x_ || min_y_ >= max_y_; }
+    bool is_not_empty() const { return min_x_ < max_x_ && min_y_ < max_y_; }
+
+    SkRect bounds() const;
+
+   private:
+    SkScalar min_x_;
+    SkScalar min_y_;
+    SkScalar max_x_;
+    SkScalar max_y_;
+  };
+
+  void pop_and_accumulate(SkRect& layer_bounds, const SkRect* clip);
+
+  AccumulationRect rect_;
+  std::vector<AccumulationRect> saved_rects_;
+};
+
+class RTreeBoundsAccumulator final : public virtual BoundsAccumulator {
+ public:
+  void accumulate(const SkRect& r) override;
+
+  bool is_empty() const override;
+  bool is_not_empty() const override;
+
+  void save() override;
+  void restore(const SkRect* clip = nullptr) override;
+
+  bool restore(
+      std::function<bool(const SkRect& original, SkRect& modified)> map,
+      const SkRect* clip = nullptr) override;
+
+  sk_sp<DlRTree> rtree() const;
+
+ private:
+  std::vector<SkRect> rects_;
+  std::vector<size_t> saved_offsets_;
 };
 
 // This class implements all rendering methods and computes a liberal
@@ -394,7 +483,8 @@ class DisplayListBoundsCalculator final
   // queried using |isUnbounded| if an alternate plan is available
   // for such cases.
   // The flag should never be set if a cull_rect is provided.
-  explicit DisplayListBoundsCalculator(const SkRect* cull_rect = nullptr);
+  explicit DisplayListBoundsCalculator(BoundsAccumulator& accumulator,
+                                       const SkRect* cull_rect = nullptr);
 
   void setStrokeCap(DlStrokeCap cap) override;
   void setStrokeJoin(DlStrokeJoin join) override;
@@ -489,17 +579,8 @@ class DisplayListBoundsCalculator final
     return layer_infos_.front()->is_unbounded();
   }
 
-  SkRect bounds() const {
-    FML_DCHECK(layer_infos_.size() == 1);
-    if (is_unbounded()) {
-      FML_LOG(INFO) << "returning partial bounds for unbounded DisplayList";
-    }
-    return accumulator_->bounds();
-  }
-
  private:
-  // current accumulator based on saveLayer history
-  BoundsAccumulator* accumulator_;
+  BoundsAccumulator& accumulator_;
 
   // A class that remembers the information kept for a single
   // |save| or |saveLayer|.
@@ -517,18 +598,9 @@ class DisplayListBoundsCalculator final
     // Some saveLayer calls will process their bounds by a
     // |DlImageFilter| when they are restored, but for most
     // saveLayer (and all save) calls the filter will be null.
-    explicit LayerData(BoundsAccumulator* outer,
-                       std::shared_ptr<DlImageFilter> filter = nullptr)
-        : outer_(outer), filter_(filter), is_unbounded_(false) {}
+    explicit LayerData(std::shared_ptr<DlImageFilter> filter = nullptr)
+        : filter_(filter), is_unbounded_(false) {}
     ~LayerData() = default;
-
-    // The accumulator to use while this layer is put in play by
-    // a |save| or |saveLayer|
-    BoundsAccumulator* layer_accumulator() { return &layer_accumulator_; }
-
-    // The accumulator to use after this layer is removed from play
-    // via |restore|
-    BoundsAccumulator* restore_accumulator() { return outer_; }
 
     // The filter to apply to the layer bounds when it is restored
     std::shared_ptr<DlImageFilter> filter() { return filter_; }
@@ -563,9 +635,12 @@ class DisplayListBoundsCalculator final
     // the layer will have one last chance to flag an unbounded state.
     bool is_unbounded() const { return is_unbounded_; }
 
+    bool map_bounds(const SkRect& input, SkRect* output) {
+      *output = input;
+      return true;
+    }
+
    private:
-    BoundsAccumulator layer_accumulator_;
-    BoundsAccumulator* outer_;
     std::shared_ptr<DlImageFilter> filter_;
     bool is_unbounded_;
 

--- a/display_list/display_list_utils.h
+++ b/display_list/display_list_utils.h
@@ -368,14 +368,9 @@ class BoundsAccumulator {
   /// before they are accumulated back into the surrounding bounds.
   virtual void save() = 0;
 
-  /// Restore the previous set of accumulation rects/bounds and accumulate
-  /// the current rects/bounds that were accumulated since the most recent
-  /// call to |save| into them, optionally clipping them to the specified
-  /// clip if it is not null.
-  ///
-  /// If there are no saved accumulations to restore to, this method will
-  /// NOP even if a clip is provided.
-  virtual void restore(const SkRect* clip = nullptr) = 0;
+  /// Restore to the previous accumulation and incorporate the bounds of
+  /// the primitives that were recorded since the last save (if needed).
+  virtual void restore() = 0;
 
   /// Restore the previous set of accumulation rects/bounds and accumulate
   /// the current rects/bounds that were accumulated since the most recent
@@ -410,7 +405,7 @@ class RectBoundsAccumulator final : public virtual BoundsAccumulator {
   bool is_not_empty() const override { return rect_.is_not_empty(); }
 
   void save() override;
-  void restore(const SkRect* clip) override;
+  void restore() override;
   bool restore(std::function<bool(const SkRect&, SkRect&)> mapper,
                const SkRect* clip) override;
 
@@ -452,7 +447,7 @@ class RTreeBoundsAccumulator final : public virtual BoundsAccumulator {
   bool is_not_empty() const override;
 
   void save() override;
-  void restore(const SkRect* clip = nullptr) override;
+  void restore() override;
 
   bool restore(
       std::function<bool(const SkRect& original, SkRect& modified)> map,

--- a/display_list/display_list_vertices.cc
+++ b/display_list/display_list_vertices.cc
@@ -86,7 +86,7 @@ size_t DlVertices::size() const {
 }
 
 static SkRect compute_bounds(const SkPoint* points, int count) {
-  BoundsAccumulator accumulator;
+  RectBoundsAccumulator accumulator;
   for (int i = 0; i < count; i++) {
     accumulator.accumulate(points[i]);
   }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/108083

This PR simply adds a new rtree() method on DisplayList that will return an RTree implementation representing its contents, primarily for use in PlatformView embedders. No other optimizations are added that leverage the RTree.