### PR TITLE
Fix HTML renderer does not render border

### DIFF
--- a/lib/web_ui/lib/src/engine/html/recording_canvas.dart
+++ b/lib/web_ui/lib/src/engine/html/recording_canvas.dart
@@ -496,6 +496,20 @@ class RecordingCanvas {
         drawRRect(rrect, paint);
         return;
       }
+      // Use drawRect for straight line paths painted with a zero strokeWidth
+      final ui.Rect? line = sPath.toStraightLine();
+      if (line != null && paint.strokeWidth == 0) {
+        final double left = math.min(line.left, line.right);
+        final double top = math.min(line.top, line.bottom);
+        final double width = line.width.abs();
+        final double height = line.height.abs();
+        final double inflatedHeight = line.height == 0 ? 1 : height;
+        final double inflatedWidth = line.width == 0 ? 1 : width;
+        final ui.Size inflatedSize = ui.Size(inflatedWidth, inflatedHeight);
+        paint.style = ui.PaintingStyle.fill;
+        drawRect(ui.Offset(left, top) & inflatedSize, paint);
+        return;
+      }
     }
     final SurfacePath sPath = path as SurfacePath;
     if (!sPath.pathRef.isEmpty) {


### PR DESCRIPTION
## Description

This PRs fixes an issue where the HTML renderer was not able to draw straight lines when stroke width is zero (For more information see the demo here: https://github.com/flutter/flutter/issues/46339#issuecomment-1188719650).
The implementation choice is to draw a filled rectangle with a 1 width or a 1 height. This choice is done for optimization purposes (compared to relying on drawing the line on an Web canvas). 

## Related Issue

Fixes https://github.com/flutter/flutter/issues/46339

## Tests

Adds 1 test.
