### PR TITLE
Null check uniforms in runtime stage

### DIFF
--- a/impeller/runtime_stage/runtime_stage.cc
+++ b/impeller/runtime_stage/runtime_stage.cc
@@ -75,17 +75,18 @@ RuntimeStage::RuntimeStage(std::shared_ptr<fml::Mapping> payload)
   stage_ = ToShaderStage(runtime_stage->stage());
   entrypoint_ = runtime_stage->entrypoint()->str();
 
-  for (auto i = runtime_stage->uniforms()->begin(),
-            end = runtime_stage->uniforms()->end();
-       i != end; i++) {
-    RuntimeUniformDescription desc;
-    desc.name = i->name()->str();
-    desc.location = i->location();
-    desc.type = ToType(i->type());
-    desc.dimensions = RuntimeUniformDimensions{
-        static_cast<size_t>(i->rows()), static_cast<size_t>(i->columns())};
-    desc.bit_width = i->bit_width();
-    uniforms_.emplace_back(std::move(desc));
+  auto* uniforms = runtime_stage->uniforms();
+  if (uniforms) {
+    for (auto i = uniforms->begin(), end = uniforms->end(); i != end; i++) {
+      RuntimeUniformDescription desc;
+      desc.name = i->name()->str();
+      desc.location = i->location();
+      desc.type = ToType(i->type());
+      desc.dimensions = RuntimeUniformDimensions{
+          static_cast<size_t>(i->rows()), static_cast<size_t>(i->columns())};
+      desc.bit_width = i->bit_width();
+      uniforms_.emplace_back(std::move(desc));
+    }
   }
 
   code_mapping_ = std::make_shared<fml::NonOwnedMapping>(

--- a/lib/spirv/test/general_shaders/BUILD.gn
+++ b/lib/spirv/test/general_shaders/BUILD.gn
@@ -11,6 +11,7 @@ if (enable_unittests) {
     "blue_green_sampler.frag",
     "children_and_uniforms.frag",
     "functions.frag",
+    "no_uniforms.frag",
     "simple.frag",
     "uniforms.frag",
     "uniforms_sorted.frag",

--- a/lib/spirv/test/general_shaders/no_uniforms.frag
+++ b/lib/spirv/test/general_shaders/no_uniforms.frag
@@ -1,0 +1,13 @@
+#version 320 es
+
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+precision highp float;
+
+layout(location = 0) out vec4 fragColor;
+
+void main() {
+    fragColor = vec4(0.0, 1.0, 0.0, 1.0);
+}

--- a/testing/dart/fragment_shader_test.dart
+++ b/testing/dart/fragment_shader_test.dart
@@ -319,6 +319,14 @@ void main() {
     expect(throws, equals(true));
   });
 
+  test('iplr accepts a shader with no uniforms', () async {
+    final FragmentProgram program = FragmentProgram.fromAsset(
+      'no_uniforms.frag.iplr',
+    );
+    final Shader shader = program.shader();
+    await _expectShaderRendersGreen(shader);
+  });
+
   // Test all supported GLSL ops. See lib/spirv/lib/src/constants.dart
   final Map<String, ByteBuffer> supportedGLSLOpShaders = _loadShaders(
     path.join('supported_glsl_op_shaders', 'spirv'),


### PR DESCRIPTION
This prevents a crash if a shader doesn't declare any uniforms.

Related https://github.com/flutter/flutter/issues/108077