### PR TITLE
[impellerc] Adds an --iplr flag

### DIFF
--- a/impeller/compiler/impellerc_main.cc
+++ b/impeller/compiler/impellerc_main.cc
@@ -85,7 +85,7 @@ bool Main(const fml::CommandLine& command_line) {
   if (TargetPlatformNeedsSL(options.target_platform)) {
     auto sl_file_name = std::filesystem::absolute(
         std::filesystem::current_path() / switches.sl_file_name);
-    const bool is_runtime_stage_data = HasSuffix(switches.sl_file_name, "iplr");
+    const bool is_runtime_stage_data = switches.iplr;
     if (is_runtime_stage_data) {
       auto reflector = compiler.GetReflector();
       if (reflector == nullptr) {

--- a/impeller/compiler/switches.cc
+++ b/impeller/compiler/switches.cc
@@ -52,6 +52,8 @@ void Switches::PrintHelp(std::ostream& stream) {
   stream << "}" << std::endl;
   stream << "--sl=<sl_output_file>" << std::endl;
   stream << "--spirv=<spirv_output_file>" << std::endl;
+  stream << "[optional] --iplr (causes --sl file to be emitted in iplr format)"
+         << std::endl;
   stream << "[optional] --reflection-json=<reflection_json_file>" << std::endl;
   stream << "[optional] --reflection-header=<reflection_header_file>"
          << std::endl;
@@ -103,6 +105,7 @@ Switches::Switches(const fml::CommandLine& command_line)
       source_file_name(command_line.GetOptionValueWithDefault("input", "")),
       input_type(SourceTypeFromCommandLine(command_line)),
       sl_file_name(command_line.GetOptionValueWithDefault("sl", "")),
+      iplr(command_line.HasOption("iplr")),
       spirv_file_name(command_line.GetOptionValueWithDefault("spirv", "")),
       reflection_json_name(
           command_line.GetOptionValueWithDefault("reflection-json", "")),

--- a/impeller/compiler/switches.h
+++ b/impeller/compiler/switches.h
@@ -24,6 +24,7 @@ struct Switches {
   std::string source_file_name;
   SourceType input_type;
   std::string sl_file_name;
+  bool iplr;
   std::string spirv_file_name;
   std::string reflection_json_name;
   std::string reflection_header_name;

--- a/impeller/fixtures/BUILD.gn
+++ b/impeller/fixtures/BUILD.gn
@@ -26,6 +26,7 @@ impellerc("runtime_stages") {
   shaders = [ "ink_sparkle.frag" ]
   sl_file_extension = "iplr"
   shader_target_flag = "--runtime-stage-metal"
+  iplr = true
 }
 
 test_fixtures("file_fixtures") {

--- a/impeller/tools/impeller.gni
+++ b/impeller/tools/impeller.gni
@@ -248,7 +248,18 @@ template("impellerc") {
         defined(invoker.sl_file_extension),
         "The extension of the SL file must be specified (metal, glsl, etc..).")
   }
+  iplr = false
+  if (defined(invoker.iplr) && invoker.iplr) {
+    iplr = invoker.iplr
+  }
 
+  # Not needed on every path.
+  not_needed([
+               "iplr",
+               "sksl",
+             ])
+
+  # Optional: invoker.iplr Causes --sl output to be in iplr format.
   # Optional: invoker.defines specifies a list of valueless macro definitions.
   # Optional: invoker.intermediates_subdir specifies the subdirectory in which
   #           to put intermediates.
@@ -281,7 +292,6 @@ template("impellerc") {
     ]
 
     if (flutter_spirv) {
-      not_needed([ "sksl" ])
       args += [ "--spirv=$spirv_intermediate_path" ]
       outputs = [ spirv_intermediate ]
     } else if (sksl) {
@@ -292,6 +302,9 @@ template("impellerc") {
         "--sl=$sl_intermediate_path",
         "--spirv=$spirv_intermediate_path",
       ]
+      if (iplr) {
+        args += [ "--iplr" ]
+      }
 
       outputs = [ sl_intermediate ]
     } else {
@@ -316,6 +329,9 @@ template("impellerc") {
         "--reflection-header=$reflection_header_path",
         "--reflection-cc=$reflection_cc_path",
       ]
+      if (iplr) {
+        args += [ "--iplr" ]
+      }
 
       outputs = [
         sl_intermediate,

--- a/lib/spirv/test/BUILD.gn
+++ b/lib/spirv/test/BUILD.gn
@@ -51,6 +51,7 @@ if (enable_unittests) {
     shader_target_flag = "--sksl"
     intermediates_subdir = "iplr"
     sl_file_extension = "iplr"
+    iplr = true
   }
 
   test_fixtures("fixtures") {

--- a/lib/spirv/test/general_shaders/BUILD.gn
+++ b/lib/spirv/test/general_shaders/BUILD.gn
@@ -44,6 +44,7 @@ if (enable_unittests) {
     shader_target_flag = "--sksl"
     intermediates_subdir = "iplr"
     sl_file_extension = "iplr"
+    iplr = true
   }
 
   test_fixtures("fixtures") {

--- a/lib/spirv/test/supported_glsl_op_shaders/BUILD.gn
+++ b/lib/spirv/test/supported_glsl_op_shaders/BUILD.gn
@@ -70,6 +70,7 @@ if (enable_unittests) {
     shader_target_flag = "--sksl"
     intermediates_subdir = "iplr"
     sl_file_extension = "iplr"
+    iplr = true
   }
 
   test_fixtures("fixtures") {

--- a/lib/spirv/test/supported_op_shaders/BUILD.gn
+++ b/lib/spirv/test/supported_op_shaders/BUILD.gn
@@ -66,6 +66,7 @@ if (enable_unittests) {
     shader_target_flag = "--sksl"
     intermediates_subdir = "iplr"
     sl_file_extension = "iplr"
+    iplr = true
   }
 
   test_fixtures("fixtures") {


### PR DESCRIPTION
This PR adds a flag `--iplr` to `impellerc` that controls whether the output file specified by the `--sl` flag is encoded in the `iplr` format. Previously this was controlled by the extension of the file given by the `--sl` flag. This change will make it easier to land https://github.com/flutter/flutter/pull/108071 and roll it internally.