### PR TITLE
let uniform float count / sampler count be reset

### DIFF
--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -4155,10 +4155,10 @@ class FragmentProgram extends NativeFieldWrapperClass1 {
   }
 
   @pragma('vm:entry-point')
-  late final int _uniformFloatCount;
+  late int _uniformFloatCount;
 
   @pragma('vm:entry-point')
-  late final int _samplerCount;
+  late int _samplerCount;
 
   @FfiNative<Void Function(Handle)>('FragmentProgram::Create')
   external void _constructor();

--- a/testing/dart/fragment_shader_test.dart
+++ b/testing/dart/fragment_shader_test.dart
@@ -4,15 +4,12 @@
 
 import 'dart:async';
 import 'dart:collection';
-import 'dart:developer' as developer;
 import 'dart:io';
 import 'dart:typed_data';
 import 'dart:ui';
 
 import 'package:litetest/litetest.dart';
 import 'package:path/path.dart' as path;
-import 'package:vm_service/vm_service.dart' as vms;
-import 'package:vm_service/vm_service_io.dart';
 
 import 'shader_test_file_utils.dart';
 
@@ -65,38 +62,6 @@ void main() {
       floatUniforms: Float32List.fromList(<double>[1]),
     );
     _expectShaderRendersGreen(shader);
-  });
-
-  test('simple iplr shader can be re-initialized', () async {
-    final FragmentProgram program = FragmentProgram.fromAsset(
-      'functions.frag.iplr',
-    );
-    final Shader shader = program.shader(
-      floatUniforms: Float32List.fromList(<double>[1]),
-    );
-
-    final developer.ServiceProtocolInfo info = await developer.Service.getInfo();
-
-    if (info.serverUri == null) {
-      fail('This test must not be run with --disable-observatory.');
-    }
-
-    final vms.VmService vmService = await vmServiceConnectUri(
-      'ws://localhost:${info.serverUri!.port}${info.serverUri!.path}ws',
-    );
-    final vms.VM vm = await vmService.getVM();
-
-    expect(vm.isolates!.isNotEmpty, true);
-    for (final vms.IsolateRef isolateRef in vm.isolates!) {
-      final vms.Response response = await vmService.callServiceExtension(
-        'ext.ui.window.reinitializeShader',
-        isolateId: isolateRef.id,
-        args: <String, Object>{
-          'assetKey': 'functions.frag.iplr',
-        },
-      );
-      expect(response.type == 'Success', true);
-    }
   });
 
   test('blue-green image renders green', () async {

--- a/testing/dart/fragment_shader_test.dart
+++ b/testing/dart/fragment_shader_test.dart
@@ -4,12 +4,15 @@
 
 import 'dart:async';
 import 'dart:collection';
+import 'dart:developer' as developer;
 import 'dart:io';
 import 'dart:typed_data';
 import 'dart:ui';
 
 import 'package:litetest/litetest.dart';
 import 'package:path/path.dart' as path;
+import 'package:vm_service/vm_service.dart' as vms;
+import 'package:vm_service/vm_service_io.dart';
 
 import 'shader_test_file_utils.dart';
 
@@ -62,6 +65,38 @@ void main() {
       floatUniforms: Float32List.fromList(<double>[1]),
     );
     _expectShaderRendersGreen(shader);
+  });
+
+  test('simple iplr shader can be re-initialized', () async {
+    final FragmentProgram program = FragmentProgram.fromAsset(
+      'functions.frag.iplr',
+    );
+    final Shader shader = program.shader(
+      floatUniforms: Float32List.fromList(<double>[1]),
+    );
+
+    final developer.ServiceProtocolInfo info = await developer.Service.getInfo();
+
+    if (info.serverUri == null) {
+      fail('This test must not be run with --disable-observatory.');
+    }
+
+    final vms.VmService vmService = await vmServiceConnectUri(
+      'ws://localhost:${info.serverUri!.port}${info.serverUri!.path}ws',
+    );
+    final vms.VM vm = await vmService.getVM();
+
+    expect(vm.isolates!.isNotEmpty, true);
+    for (final vms.IsolateRef isolateRef in vm.isolates!) {
+      final vms.Response response = await vmService.callServiceExtension(
+        'ext.ui.window.reinitializeShader',
+        isolateId: isolateRef.id,
+        args: <String, Object>{
+          'assetKey': 'functions.frag.iplr',
+        },
+      );
+      expect(response.type == 'Success', true);
+    }
   });
 
   test('blue-green image renders green', () async {

--- a/testing/dart/observatory/BUILD.gn
+++ b/testing/dart/observatory/BUILD.gn
@@ -7,6 +7,7 @@ import("//flutter/testing/dart/compile_test.gni")
 tests = [
   "skp_test.dart",
   "tracing_test.dart",
+  "shader_reload_test.dart",
 ]
 
 foreach(test, tests) {

--- a/testing/dart/observatory/shader_reload_test.dart
+++ b/testing/dart/observatory/shader_reload_test.dart
@@ -1,0 +1,45 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:developer' as developer;
+import 'dart:typed_data';
+import 'dart:ui';
+
+import 'package:litetest/litetest.dart';
+import 'package:vm_service/vm_service.dart' as vms;
+import 'package:vm_service/vm_service_io.dart';
+
+void main() {
+  test('simple iplr shader can be re-initialized', () async {
+    final FragmentProgram program = FragmentProgram.fromAsset(
+      'functions.frag.iplr',
+    );
+    final Shader shader = program.shader(
+      floatUniforms: Float32List.fromList(<double>[1]),
+    );
+
+    final developer.ServiceProtocolInfo info = await developer.Service.getInfo();
+
+    if (info.serverUri == null) {
+      fail('This test must not be run with --disable-observatory.');
+    }
+
+    final vms.VmService vmService = await vmServiceConnectUri(
+      'ws://localhost:${info.serverUri!.port}${info.serverUri!.path}ws',
+    );
+    final vms.VM vm = await vmService.getVM();
+
+    expect(vm.isolates!.isNotEmpty, true);
+    for (final vms.IsolateRef isolateRef in vm.isolates!) {
+      final vms.Response response = await vmService.callServiceExtension(
+        'ext.ui.window.reinitializeShader',
+        isolateId: isolateRef.id,
+        args: <String, Object>{
+          'assetKey': 'functions.frag.iplr',
+        },
+      );
+      expect(response.type == 'Success', true);
+    }
+  });
+}


### PR DESCRIPTION
Since these are final, re-setting them during shader reinitialization on hot reload crashes:

```
ext.ui.window.reinitializeShader: (-32000) Server error
LateInitializationError: Field '_samplerCount@15065589' has already been initialized.
#0      LateError._throwFieldAlreadyInitialized (dart:_internal-patch/internal_patch.dart:194:5)
#1      FragmentProgram._samplerCount= (dart:ui/painting.dart:4161:18)
#2      FfiTrampoline___initFromAsset$FfiNative$Ptr (dart:ffi)
#3      FragmentProgram._initFromAsset (dart:ui/painting.dart:4170:19)
#4      FragmentProgram._reinitializeShader (dart:ui/painting.dart:4151:28)
#5      _reinitializeShader (dart:ui/natives.dart:67:21)
#6      _runExtension (dart:developer-patch/developer.dart:87:23)
```

The best way to test this is probably the eventual integration test for shader hot reload in the flutter framework. Otherwise the alternative would be to pull in package:vmservice, and write a test that connects to its own vm service to invoke the method and assert that it doesn't crash