### PR TITLE
[Impeller] Fix gles binding locations

### DIFF
--- a/impeller/compiler/compiler_backend.cc
+++ b/impeller/compiler/compiler_backend.cc
@@ -42,7 +42,7 @@ uint32_t CompilerBackend::GetExtendedMSLResourceBinding(
     }
   }
   if (auto compiler = GetGLSLCompiler()) {
-    return compiler->get_decoration(id, spv::Decoration::DecorationLocation);
+    return compiler->get_decoration(id, spv::Decoration::DecorationBinding);
   }
   const auto kOOBIndex = static_cast<uint32_t>(-1);
   return kOOBIndex;


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/105156.

In Impeller's Playground tests on MacOS, we import the impeller reflection headers that were generated for Metal, which have good binding locations. However, the GLES headers have all 0 for their binding locations. The result was that the binding map would only ever get populated with 1 item when using the binding utilities in the header. Ran into this in impeller-cmake on Windows.

Not sure what the best way to test this is... one option that comes to mind is checking the fields in the output metadata with nlohmann/json?