### PR TITLE
[Linux] remove AtkText stub implementation

### DIFF
--- a/shell/platform/linux/fl_accessible_node.cc
+++ b/shell/platform/linux/fl_accessible_node.cc
@@ -89,7 +89,6 @@ enum { kProp0, kPropEngine, kPropId, kPropLast };
 static void fl_accessible_node_component_interface_init(
     AtkComponentIface* iface);
 static void fl_accessible_node_action_interface_init(AtkActionIface* iface);
-static void fl_accessible_node_text_interface_init(AtkTextIface* iface);
 
 G_DEFINE_TYPE_WITH_CODE(
     FlAccessibleNode,
@@ -99,9 +98,7 @@ G_DEFINE_TYPE_WITH_CODE(
         G_IMPLEMENT_INTERFACE(ATK_TYPE_COMPONENT,
                               fl_accessible_node_component_interface_init)
             G_IMPLEMENT_INTERFACE(ATK_TYPE_ACTION,
-                                  fl_accessible_node_action_interface_init)
-                G_IMPLEMENT_INTERFACE(ATK_TYPE_TEXT,
-                                      fl_accessible_node_text_interface_init))
+                                  fl_accessible_node_action_interface_init))
 
 // Returns TRUE if [flag] has changed between [old_flags] and [flags].
 static gboolean flag_is_changed(FlutterSemanticsFlag old_flags,
@@ -338,13 +335,6 @@ static const gchar* fl_accessible_node_get_name(AtkAction* action, gint i) {
   return data->name;
 }
 
-// Implements AtkText::get_text.
-static gchar* fl_accessible_node_get_text(AtkText* text,
-                                          gint start_offset,
-                                          gint end_offset) {
-  return nullptr;
-}
-
 // Implements FlAccessibleNode::set_name.
 static void fl_accessible_node_set_name_impl(FlAccessibleNode* self,
                                              const gchar* name) {
@@ -473,10 +463,6 @@ static void fl_accessible_node_action_interface_init(AtkActionIface* iface) {
   iface->do_action = fl_accessible_node_do_action;
   iface->get_n_actions = fl_accessible_node_get_n_actions;
   iface->get_name = fl_accessible_node_get_name;
-}
-
-static void fl_accessible_node_text_interface_init(AtkTextIface* iface) {
-  iface->get_text = fl_accessible_node_get_text;
 }
 
 static void fl_accessible_node_init(FlAccessibleNode* self) {


### PR DESCRIPTION
This PR fixes a minor issue that came up here: https://github.com/flutter/flutter/issues/95230#issuecomment-1192246394

When Orca has "Speak object under mouse" enabled, it tries to get the text range extents for any object that implements the AtkText interface and gets a bit confused by the AtkText stub implementation that merely returns null for `get_text`.

The screen reader works, but the following warning gets printed whenever moving the mouse cursor over a text label:

> Atk-CRITICAL **: atk_text_get_range_extents: assertion 'start_offset >= 0 && start_offset < end_offset' failed

Removing the stub implementation helps to avoid the issue that Orca would try to call `atk_text_get_range_extents()` with `start_offset=0` and `end_offset=0`:

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
