### PR TITLE
[Impeller] Fix Vulkan build issues.

### DIFF
--- a/impeller/renderer/backend/vulkan/vk.h
+++ b/impeller/renderer/backend/vulkan/vk.h
@@ -8,7 +8,14 @@
 #include "impeller/base/validation.h"
 
 #define VK_NO_PROTOTYPES
+
+#if !defined(NDEBUG)
 #define VULKAN_HPP_ASSERT FML_CHECK
+#else
+#define VULKAN_HPP_ASSERT(ignored) \
+  {}
+#endif
+
 #define VULKAN_HPP_NAMESPACE impeller::vk
 #define VULKAN_HPP_ASSERT_ON_RESULT(ignored) \
   { [[maybe_unused]] auto res = (ignored); }

--- a/tools/gn
+++ b/tools/gn
@@ -528,6 +528,7 @@ def to_gn_args(args):
 
   # Vulkan support is WIP, see: https://github.com/flutter/flutter/issues/107357
   if args.enable_impeller_vulkan:
+    gn_args['impeller_enable_opengles'] = False
     gn_args['impeller_enable_vulkan'] = True
     gn_args['skia_use_vma'] = False
 


### PR DESCRIPTION
1. Do not build gles and vulkan at the same time

error seen:

```
ERROR at //build/compiled_action.gni:142:3: Duplicate output file.
  action_foreach(target_name) {
  ^----------------------------
Two or more targets generate the same output:
  gen/flutter/impeller/entity/advanced_blend.vert.h

This is can often be fixed by changing one of the target names, or by
setting an output_name on one of them.

Collisions:
  //flutter/impeller/entity:impellerc_gles_entity_shaders(//build/toolchain/linux:clang_x64)
  //flutter/impeller/entity:impellerc_vk_entity_shaders(//build/toolchain/linux:clang_x64)

See //build/compiled_action.gni:142:3: Collision.
  action_foreach(target_name) {
  ^----------------------------
```

2. Do not enable `VULAN_HPP_ASSERT` when `NDEBUG` is enabled.

This is because: `getVkHeaderVersion` is not defined in `NDEBUG`.
See: https://github.com/KhronosGroup/Vulkan-Hpp/blob/master/VulkanHppGenerator.cpp#L14611
