### PR TITLE
Revert "Use git exec candidate list on all platforms for build"

### DIFF
--- a/build/git_revision.py
+++ b/build/git_revision.py
@@ -10,7 +10,11 @@ import sys
 import subprocess
 import os
 import argparse
-from shutil import which  # Natively supported since python 3.3
+
+
+def is_windows():
+  os_id = sys.platform
+  return os_id.startswith('win32') or os_id.startswith('cygwin')
 
 
 def get_repository_version(repository):
@@ -18,12 +22,9 @@ def get_repository_version(repository):
   if not os.path.exists(repository):
     raise IOError('path does not exist')
 
-  git_candidates = ['git', 'git.sh', 'git.bat']
-  git = next(filter(which, git_candidates), None)
-  if git is None:
-    candidates = "', '".join(git_candidates)
-    raise IOError(f"Looks like GIT is not on the path. Tried '{candidates}'")
-
+  git = 'git'
+  if is_windows():
+    git = 'git.bat'
   version = subprocess.check_output([
       git,
       '-C',

--- a/tools/githooks/setup.py
+++ b/tools/githooks/setup.py
@@ -10,7 +10,6 @@ Sets up githooks.
 import os
 import subprocess
 import sys
-from shutil import which  # Natively supported since python 3.3
 
 SRC_ROOT = os.path.dirname(
     os.path.dirname(
@@ -20,13 +19,17 @@ SRC_ROOT = os.path.dirname(
 FLUTTER_DIR = os.path.join(SRC_ROOT, 'flutter')
 
 
+def IsWindows():
+  os_id = sys.platform
+  return os_id.startswith('win32') or os_id.startswith('cygwin')
+
+
 def Main(argv):
+  git = 'git'
   githooks = os.path.join(FLUTTER_DIR, 'tools', 'githooks')
-  git_candidates = ['git', 'git.sh', 'git.bat']
-  git = next(filter(which, git_candidates), None)
-  if git is None:
-    candidates = "', '".join(git_candidates)
-    raise IOError(f"Looks like GIT is not on the path. Tried '{candidates}'")
+  if IsWindows():
+    git = 'git.bat'
+    githooks = os.path.join(githooks, 'windows')
   result = subprocess.run([
       git,
       'config',


### PR DESCRIPTION
Reverts flutter/engine#34294 to fix https://github.com/flutter/flutter/issues/108122.

This change incorrectly moves the pre-push githook to the non-Windows hook, thereby breaking `git push` on Windows.

/cc @mtolmacs 