### PR TITLE
[fuchsia][scenic] Accept Uint64 values in timestamp for pointerinjector.

### DIFF
--- a/shell/platform/fuchsia/flutter/pointer_injector_delegate.cc
+++ b/shell/platform/fuchsia/flutter/pointer_injector_delegate.cc
@@ -129,7 +129,7 @@ bool PointerInjectorDelegate::HandlePlatformMessage(
     }
 
     auto timestamp = args.FindMember("timestamp");
-    if (!timestamp->value.IsInt()) {
+    if (!timestamp->value.IsInt() && !timestamp->value.IsUint64()) {
       FML_LOG(ERROR) << "Argument 'timestamp' is not a int";
       return false;
     }


### PR DESCRIPTION
Uint64 type values should be acceptable in the timestamp field of the
platform message for pointerinjector.

Test: ffx test run "fuchsia-pkg://fuchsia.com/flutter_runner_tests#meta/flutter_runner_tests.cm"

Manual Testing
Deployed changes on Smart display (estelle)
Manually verified youtube was working through swipe and taps
Manually verified Duo is working through swipe and taps