### PR TITLE
Fix _endRecording native return type

### DIFF
--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -5661,7 +5661,7 @@ class PictureRecorder extends NativeFieldWrapperClass1 {
     return picture;
   }
 
-  @FfiNative<Handle Function(Pointer<Void>, Handle)>('PictureRecorder::endRecording')
+  @FfiNative<Void Function(Pointer<Void>, Handle)>('PictureRecorder::endRecording')
   external void _endRecording(Picture outPicture);
 
   Canvas? _canvas;


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/108309

See discussion there -this will be tested on an upcoming dart roll.
