### PR TITLE
enable download of Android dependencies on Apple Silicon

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -61,7 +61,7 @@ vars = {
   'download_dart_sdk': True,
 
   # Checkout Android dependencies only on platforms where we build for Android targets.
-  'download_android_deps': 'host_cpu == "x64" and (host_os == "mac" or host_os == "linux")',
+  'download_android_deps': 'host_os == "mac" or host_os == "linux"',
 
   # Checkout Windows dependencies only if we are building on Windows.
   'download_windows_deps' : 'host_os == "win"',


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/108240

The building of an Android engine part is not finished on Apple Silicon, but all of the DEPS should now be available so we no longer need to block their download in DEPS.