### PR TITLE
Fix incorrect size for message.Release()

### DIFF
--- a/shell/platform/android/platform_view_android_jni_impl.cc
+++ b/shell/platform/android/platform_view_android_jni_impl.cc
@@ -1160,7 +1160,7 @@ void PlatformViewAndroidJNIImpl::FlutterViewHandlePlatformMessage(
     fml::MallocMapping mapping = message->releaseData();
     env->CallVoidMethod(java_object.obj(), g_handle_platform_message_method,
                         java_channel.obj(), message_array.obj(), responseId,
-                        mapping.Release());
+                        reinterpret_cast<jlong>(mapping.Release()));
   } else {
     env->CallVoidMethod(java_object.obj(), g_handle_platform_message_method,
                         java_channel.obj(), nullptr, responseId, nullptr);


### PR DESCRIPTION
My C skills are a bit lacking so let me know if something here is wrong. The following is tested on arm32 Android.

`message.Release()` is a `uint8_t*`. This is 4 bytes on arm32. However, it is passed as a `long` (`J` in the JNI signature) in Java, which is 8 bytes. 

https://github.com/flutter/engine/blob/5dcaeae6561b37b8f9db97828d33011850445f5c/shell/platform/android/platform_view_android_jni_impl.cc#L858-L860

https://github.com/flutter/engine/blob/5dcaeae6561b37b8f9db97828d33011850445f5c/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java#L984-L988

I don't completely understand why it's not an error today, but when I change the code to pass an `int` right after `response_id` (and making corresponding changes in the method signature to `(Ljava/lang/String;Ljava/nio/ByteBuffer;IIJ)V` and the Java method, this value will be corrupted when read in Java, leading to a crash when it is used as an argument to [`free`](https://github.com/jiahaog/flutter-engine/blob/bb440c6209378c602f45a328d94c05aa0ba3643e/shell/platform/android/platform_view_android_jni_impl.cc#L438).

Thanks to @glencbz for looking into this with me.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
