### PR TITLE
Starts a transition to an async FragmentProgram.fromAsset

### DIFF
--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -4049,6 +4049,12 @@ class FragmentProgram extends NativeFieldWrapperClass1 {
     return program;
   }
 
+  // TODO(zra): This is part of a soft transition of the framework to this
+  // API, which pushes the asset load to an asynchronous operation.
+  static Future<FragmentProgram> fromAssetAsync(String assetKey) {
+    return Future<FragmentProgram>.microtask(() => FragmentProgram.fromAsset(assetKey));
+  }
+
   static Map<String, WeakReference<FragmentProgram>> _shaderRegistry =
       <String, WeakReference<FragmentProgram>>{};
 

--- a/lib/web_ui/lib/painting.dart
+++ b/lib/web_ui/lib/painting.dart
@@ -839,6 +839,10 @@ class FragmentProgram {
     throw UnsupportedError('FragmentProgram is not supported for the CanvasKit or HTML renderers.');
   }
 
+  static Future<FragmentProgram> fromAssetAsync(String assetKey) {
+    return Future<FragmentProgram>.microtask(() => FragmentProgram.fromAsset(assetKey));
+  }
+
   FragmentProgram._();
 
   Shader shader({

--- a/testing/dart/observatory/shader_reload_test.dart
+++ b/testing/dart/observatory/shader_reload_test.dart
@@ -14,7 +14,7 @@ void main() {
   test('simple iplr shader can be re-initialized', () async {
     vms.VmService? vmService;
     try {
-      final FragmentProgram program = FragmentProgram.fromAsset(
+      final FragmentProgram program = await FragmentProgram.fromAssetAsync(
         'functions.frag.iplr',
       );
       final Shader shader = program.shader(


### PR DESCRIPTION
Stemming from the discussion on https://github.com/flutter/flutter/pull/107963, `fromAsset` is potentially a big expensive, and would need to be async on web anyway.