### PR TITLE
Adds documentation for PathMetric.length

### DIFF
--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -2883,6 +2883,7 @@ class PathMetric {
       contourIndex = _measure.currentContourIndex;
 
   /// Return the total length of the current contour.
+  ///
   /// The length may be calculated from an approximation of the geometry
   /// originally added. For this reason, it is not recommended to rely on
   /// this property for mathematically correct lengths of common shapes.

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -2883,6 +2883,9 @@ class PathMetric {
       contourIndex = _measure.currentContourIndex;
 
   /// Return the total length of the current contour.
+  /// The length may be calculated from an approximation of the geometry
+  /// originally added. For this reason, it is not recommended to rely on
+  /// this property for mathematically correct lengths of common shapes.
   final double length;
 
   /// Whether the contour is closed.


### PR DESCRIPTION
Adds documentation regarding the approximated contour length represented by PathMetric.length.

Following an explanation of the issue presented in flutter/flutter#108130 this pull request proposes an addition to the  `length` documentation of `PathMetric`. The addition should prevent users from using the property for unintended purposes.