### PR TITLE
Scroll inertia cancel for iPadOS

### DIFF
--- a/testing/scenario_app/ios/Scenarios/ScenariosUITests/StatusBarTest.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosUITests/StatusBarTest.m
@@ -31,14 +31,18 @@
   }
 
   XCUIElement* addTextField =
-      self.application.textFields[@"0,PointerChange.add,device=0,buttons=0"];
+      self.application
+          .textFields[@"0,PointerChange.add,device=0,buttons=0,signalKind=PointerSignalKind.none"];
   BOOL exists = [addTextField waitForExistenceWithTimeout:1];
   XCTAssertTrue(exists, @"");
   XCUIElement* downTextField =
-      self.application.textFields[@"1,PointerChange.down,device=0,buttons=0"];
+      self.application
+          .textFields[@"1,PointerChange.down,device=0,buttons=0,signalKind=PointerSignalKind.none"];
   exists = [downTextField waitForExistenceWithTimeout:1];
   XCTAssertTrue(exists, @"");
-  XCUIElement* upTextField = self.application.textFields[@"2,PointerChange.up,device=0,buttons=0"];
+  XCUIElement* upTextField =
+      self.application
+          .textFields[@"2,PointerChange.up,device=0,buttons=0,signalKind=PointerSignalKind.none"];
   exists = [upTextField waitForExistenceWithTimeout:1];
   XCTAssertTrue(exists, @"");
 }

--- a/testing/scenario_app/lib/src/touches_scenario.dart
+++ b/testing/scenario_app/lib/src/touches_scenario.dart
@@ -32,7 +32,7 @@ class TouchesScenario extends Scenario {
         dispatcher: dispatcher,
         channel: 'display_data',
         json: <String, dynamic>{
-          'data': '$_sequenceNo,${datum.change},device=$deviceId,buttons=${datum.buttons}',
+          'data': '$_sequenceNo,${datum.change},device=$deviceId,buttons=${datum.buttons},signalKind=${datum.signalKind}',
         },
       );
       _sequenceNo++;


### PR DESCRIPTION
Send a `PointerScrollInertiaCancel` event when the user touches the trackpad. Done in two ways, as one only works on real iPad devices, and the other only works when in emulation on an Apple Silicon Mac. 

Part of https://github.com/flutter/flutter/issues/106979

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
