### PR TITLE
GLFW Example with dirty region management

### DIFF
--- a/examples/glfw/BUILD.gn
+++ b/examples/glfw/BUILD.gn
@@ -14,5 +14,9 @@ if (build_embedder_examples) {
       "//flutter/shell/platform/embedder:embedder",
       "//third_party/glfw",
     ]
+
+    libs = [
+      "EGL",
+    ]
   }
 }

--- a/examples/glfw/BUILD.gn
+++ b/examples/glfw/BUILD.gn
@@ -15,8 +15,6 @@ if (build_embedder_examples) {
       "//third_party/glfw",
     ]
 
-    libs = [
-      "EGL",
-    ]
+    libs = [ "EGL" ]
   }
 }

--- a/examples/glfw/CMakeLists.txt
+++ b/examples/glfw/CMakeLists.txt
@@ -11,8 +11,10 @@ option(GLFW_BUILD_EXAMPLES "" OFF)
 option(GLFW_BUILD_TESTS "" OFF)
 option(GLFW_BUILD_DOCS "" OFF)
 option(GLFW_INSTALL "" OFF)
+find_package(OpenGL REQUIRED COMPONENTS EGL)
+include_directories(${OPENGL_INCLUDE_DIRS})
 add_subdirectory(${CMAKE_SOURCE_DIR}/../../../third_party/glfw glfw)
-target_link_libraries(flutter_glfw glfw)
+target_link_libraries(flutter_glfw glfw OpenGL::EGL)
 include_directories(${CMAKE_SOURCE_DIR}/../../../third_party/glfw/include)
 
 ############################################################

--- a/examples/glfw/FlutterEmbedderGLFW.cc
+++ b/examples/glfw/FlutterEmbedderGLFW.cc
@@ -6,13 +6,26 @@
 #include <chrono>
 #include <iostream>
 
+#define GLFW_EXPOSE_NATIVE_EGL
+#define GLFW_INCLUDE_GLEXT
+
+#include <array>
+#include <list>
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
 #include "GLFW/glfw3.h"
+#include "GLFW/glfw3native.h"
 #include "embedder.h"
 
 // This value is calculated after the window is created.
 static double g_pixelRatio = 1.0;
 static const size_t kInitialWindowWidth = 800;
 static const size_t kInitialWindowHeight = 600;
+// Maximum damage history - for triple buffering we need to store damage for
+// last two frames; Some Android devices (Pixel 4) use quad buffering.
+static const int kMaxHistorySize = 10;
+
+std::list<FlutterRect> damage_history_;
 
 static_assert(FLUTTER_ENGINE_VERSION == 1,
               "This Flutter Embedder was authored against the stable Flutter "
@@ -82,6 +95,24 @@ void GLFWwindowSizeCallback(GLFWwindow* window, int width, int height) {
       &event);
 }
 
+std::array<EGLint, 4> static RectToInts(EGLDisplay display,
+                                        EGLSurface surface,
+                                        const FlutterRect rect) {
+  EGLint height;
+  eglQuerySurface(display, surface, EGL_HEIGHT, &height);
+
+  std::array<EGLint, 4> res{static_cast<int>(rect.left), height - static_cast<int>(rect.bottom), static_cast<int>(rect.right) - static_cast<int>(rect.left),
+                            static_cast<int>(rect.bottom) - static_cast<int>(rect.top)};
+  return res;
+}
+
+void JoinFlutterRect(FlutterRect* rect, FlutterRect additional_rect) {
+  rect->left = std::min(rect->left, additional_rect.left);
+  rect->top = std::min(rect->top, additional_rect.top);
+  rect->right = std::max(rect->right, additional_rect.right);
+  rect->bottom = std::max(rect->bottom, additional_rect.bottom);
+}
+
 bool RunFlutter(GLFWwindow* window,
                 const std::string& project_path,
                 const std::string& icudtl_path) {
@@ -96,16 +127,79 @@ bool RunFlutter(GLFWwindow* window,
     glfwMakeContextCurrent(nullptr);  // is this even a thing?
     return true;
   };
-  config.open_gl.present = [](void* userdata) -> bool {
-    glfwSwapBuffers(static_cast<GLFWwindow*>(userdata));
+  config.open_gl.present_with_info = [](void* userdata, const FlutterPresentInfo* info) -> bool {
+    PFNEGLSETDAMAGEREGIONKHRPROC set_damage_region_ =
+          reinterpret_cast<PFNEGLSETDAMAGEREGIONKHRPROC>(
+              eglGetProcAddress("eglSetDamageRegionKHR"));
+    PFNEGLSWAPBUFFERSWITHDAMAGEEXTPROC swap_buffers_with_damage_ =
+          reinterpret_cast<PFNEGLSWAPBUFFERSWITHDAMAGEEXTPROC>(
+              eglGetProcAddress("eglSwapBuffersWithDamageKHR"));
+
+    GLFWwindow* window = static_cast<GLFWwindow*>(userdata);
+    EGLDisplay display = glfwGetEGLDisplay();
+    EGLSurface surface = glfwGetEGLSurface(window);
+
+    auto buffer_rects = RectToInts(display, surface, {0, 0, kInitialWindowWidth, kInitialWindowHeight});
+    set_damage_region_(display, surface, buffer_rects.data(), 1);
+
+    // Swap buffers with frame damage
+    auto frame_rects = RectToInts(display, surface, info->frame_damage.damage);
+    swap_buffers_with_damage_(display, surface, frame_rects.data(), 1);
+
+    // Add frame damage to damage history
+    damage_history_.push_back(info->frame_damage.damage);
+    if (damage_history_.size() > kMaxHistorySize) {
+      damage_history_.pop_front();
+    }
+    std::cout << "Buffer Damage: " << info->buffer_damage.damage.left << ", " << info->buffer_damage.damage.top << ", " << info->buffer_damage.damage.right << ", " << info->buffer_damage.damage.bottom << std::endl;
+    std::cout << "Frame Damage: " << info->frame_damage.damage.left << ", " << info->frame_damage.damage.top << ", " << info->frame_damage.damage.right << ", " << info->frame_damage.damage.bottom << std::endl;
     return true;
   };
-  config.open_gl.fbo_callback = [](void*) -> uint32_t {
-    return 0;  // FBO0
+  config.open_gl.fbo_with_frame_info_callback = [](void* userdata, const FlutterFrameInfo* info) -> uint32_t {
+    // Given the FBO age, create existing damage region by joining all frame
+    // damages since FBO was last used
+    GLFWwindow* window = static_cast<GLFWwindow*>(userdata);
+    EGLDisplay display = glfwGetEGLDisplay();
+    EGLSurface surface = glfwGetEGLSurface(window);
+
+    EGLint age;
+    if (glfwExtensionSupported("GL_EXT_buffer_age") == GLFW_TRUE) {
+      eglQuerySurface(display, surface, EGL_BUFFER_AGE_EXT, &age);
+    } else {
+      age = 4;  // Virtually no driver should have a swapchain length > 4.
+    }
+    std::cout << "Buffer age: " << age << std::endl;
+
+    FlutterDamage existing_damage;
+    existing_damage.damage = {0, 0, kInitialWindowWidth, kInitialWindowHeight};
+
+    if (age > 1) {
+      --age;
+      // join up to (age - 1) last rects from damage history
+      for (auto i = damage_history_.rbegin();
+           i != damage_history_.rend() && age > 0; ++i, --age) {
+        std::cout << "Damage in history: " << i->left << ", " << i->top << ", " << i->right << ", " << i->bottom << std::endl;
+        if (i == damage_history_.rbegin()) {
+          if (i != damage_history_.rend()) {
+           existing_damage.damage = {i->left, i->top, i->right, i->bottom};
+          }
+        } else {
+          JoinFlutterRect(&(existing_damage.damage), *i);
+        }
+      }
+    }
+
+    FlutterFrameInfo* info_copy = const_cast<FlutterFrameInfo*>(info);
+    info_copy->fbo_id = 0; // FBO0
+    info_copy->existing_damage = std::move(existing_damage);
+    std::cout << "Existing Damage: " << info->existing_damage.damage.left << ", " << info->existing_damage.damage.top << ", " << info->existing_damage.damage.right << ", " << info->existing_damage.damage.bottom << std::endl;
+    return info->fbo_id;
   };
   config.open_gl.gl_proc_resolver = [](void*, const char* name) -> void* {
     return reinterpret_cast<void*>(glfwGetProcAddress(name));
   };
+
+  config.open_gl.fbo_reset_after_present = true;
 
   // This directory is generated by `flutter build bundle`.
   std::string assets_path = project_path + "/build/flutter_assets";

--- a/examples/glfw/main.dart
+++ b/examples/glfw/main.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart'
     show debugDefaultTargetPlatformOverride;
+import 'package:flutter_spinkit/flutter_spinkit.dart';
 
 void main() {
   // This is a hack to make Flutter think you are running on Google Fuchsia,
@@ -55,18 +56,6 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -85,38 +74,10 @@ class _MyHomePageState extends State<MyHomePage> {
       body: Center(
         // Center is a layout widget. It takes a single child and positions it
         // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Invoke "debug painting" (press "p" in the console, choose the
-          // "Toggle Debug Paint" action from the Flutter Inspector in Android
-          // Studio, or the "Toggle Debug Paint" command in Visual Studio Code)
-          // to see the wireframe for each widget.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            Text(
-              'You have pushed the button this many times:',
-            ),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headline4,
-            ),
-          ],
+        child: RepaintBoundary(
+          child: SpinKitRotatingCircle(color: Colors.blue, size: 50.0),
         ),
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
     );
   }
 }

--- a/shell/common/shell_test_platform_view_gl.cc
+++ b/shell/common/shell_test_platform_view_gl.cc
@@ -69,8 +69,10 @@ bool ShellTestPlatformViewGL::GLContextPresent(
 }
 
 // |GPUSurfaceGLDelegate|
-intptr_t ShellTestPlatformViewGL::GLContextFBO(GLFrameInfo frame_info) const {
-  return gl_surface_.GetFramebuffer(frame_info.width, frame_info.height);
+GLFBOInfo ShellTestPlatformViewGL::GLContextFBO(GLFrameInfo frame_info) const {
+  return GLFBOInfo{
+    .fbo_id = gl_surface_.GetFramebuffer(frame_info.width, frame_info.height),
+  };
 }
 
 // |GPUSurfaceGLDelegate|

--- a/shell/common/shell_test_platform_view_gl.cc
+++ b/shell/common/shell_test_platform_view_gl.cc
@@ -71,7 +71,7 @@ bool ShellTestPlatformViewGL::GLContextPresent(
 // |GPUSurfaceGLDelegate|
 GLFBOInfo ShellTestPlatformViewGL::GLContextFBO(GLFrameInfo frame_info) const {
   return GLFBOInfo{
-    .fbo_id = gl_surface_.GetFramebuffer(frame_info.width, frame_info.height),
+      .fbo_id = gl_surface_.GetFramebuffer(frame_info.width, frame_info.height),
   };
 }
 

--- a/shell/common/shell_test_platform_view_gl.h
+++ b/shell/common/shell_test_platform_view_gl.h
@@ -61,7 +61,7 @@ class ShellTestPlatformViewGL : public ShellTestPlatformView,
   bool GLContextPresent(const GLPresentInfo& present_info) override;
 
   // |GPUSurfaceGLDelegate|
-  intptr_t GLContextFBO(GLFrameInfo frame_info) const override;
+  GLFBOInfo GLContextFBO(GLFrameInfo frame_info) const override;
 
   // |GPUSurfaceGLDelegate|
   GLProcResolver GetGLProcResolver() const override;

--- a/shell/gpu/gpu_surface_gl_delegate.h
+++ b/shell/gpu/gpu_surface_gl_delegate.h
@@ -22,6 +22,15 @@ struct GLFrameInfo {
   uint32_t height;
 };
 
+// A structure to represent the frame buffer information which is returned to
+// the embedder after requesting a frame buffer object.
+struct GLFBOInfo {
+  // The frame buffer's ID.
+  uint32_t fbo_id;
+  // The frame buffer's existing damage (i.e. damage since it was last used).
+  const SkIRect existing_damage;
+};
+
 // Information passed during presentation of a frame.
 struct GLPresentInfo {
   uint32_t fbo_id;

--- a/shell/gpu/gpu_surface_gl_delegate.h
+++ b/shell/gpu/gpu_surface_gl_delegate.h
@@ -68,7 +68,7 @@ class GPUSurfaceGLDelegate {
   virtual bool GLContextPresent(const GLPresentInfo& present_info) = 0;
 
   // The ID of the main window bound framebuffer. Typically FBO0.
-  virtual intptr_t GLContextFBO(GLFrameInfo frame_info) const = 0;
+  virtual GLFBOInfo GLContextFBO(GLFrameInfo frame_info) const = 0;
 
   // The rendering subsystem assumes that the ID of the main window bound
   // framebuffer remains constant throughout. If this assumption in incorrect,

--- a/shell/gpu/gpu_surface_gl_delegate.h
+++ b/shell/gpu/gpu_surface_gl_delegate.h
@@ -35,13 +35,17 @@ struct GLFBOInfo {
 struct GLPresentInfo {
   uint32_t fbo_id;
 
-  // Damage is a hint to compositor telling it which parts of front buffer
-  // need to be updated
-  const std::optional<SkIRect>& damage;
+  // The frame damage is a hint to compositor telling it which parts of front
+  // buffer need to be updated.
+  const std::optional<SkIRect>& frame_damage;
 
   // Time at which this frame is scheduled to be presented. This is a hint
   // that can be passed to the platform to drop queued frames.
   std::optional<fml::TimePoint> presentation_time = std::nullopt;
+
+  // The buffer damage refers to the region that needs to be set as damaged
+  // within the frame buffer being presented.
+  const std::optional<SkIRect>& buffer_damage;
 };
 
 class GPUSurfaceGLDelegate {

--- a/shell/gpu/gpu_surface_gl_impeller.cc
+++ b/shell/gpu/gpu_surface_gl_impeller.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "flutter/shell/gpu/gpu_surface_gl_impeller.h"
+#include <optional>
 
 #include "flutter/fml/make_copyable.h"
 #include "flutter/impeller/display_list/display_list_dispatcher.h"
@@ -62,10 +63,11 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceGLImpeller::AcquireFrame(
     if (weak) {
       GLPresentInfo present_info = {
           .fbo_id = 0,
-          .damage = std::nullopt,
+          .frame_damage = std::nullopt,
           // TODO (https://github.com/flutter/flutter/issues/105597): wire-up
           // presentation time to impeller backend.
           .presentation_time = std::nullopt,
+          .buffer_damage = std::nullopt,
       };
       delegate->GLContextPresent(present_info);
     }

--- a/shell/gpu/gpu_surface_gl_skia.cc
+++ b/shell/gpu/gpu_surface_gl_skia.cc
@@ -181,10 +181,10 @@ bool GPUSurfaceGLSkia::CreateOrUpdateSurfaces(const SkISize& size) {
 
   GLFrameInfo frame_info = {static_cast<uint32_t>(size.width()),
                             static_cast<uint32_t>(size.height())};
-  const uint32_t fbo_id = delegate_->GLContextFBO(frame_info);
+  const GLFBOInfo fbo_info = delegate_->GLContextFBO(frame_info);
   onscreen_surface = WrapOnscreenSurface(context_.get(),  // GL context
                                          size,            // root surface size
-                                         fbo_id           // window FBO ID
+                                         fbo_info.fbo_id  // window FBO ID
   );
 
   if (onscreen_surface == nullptr) {
@@ -195,7 +195,8 @@ bool GPUSurfaceGLSkia::CreateOrUpdateSurfaces(const SkISize& size) {
   }
 
   onscreen_surface_ = std::move(onscreen_surface);
-  fbo_id_ = fbo_id;
+  fbo_id_ = fbo_info.fbo_id;
+  existing_damage_ = fbo_info.existing_damage;
 
   return true;
 }
@@ -248,6 +249,9 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceGLSkia::AcquireFrame(
       };
 
   framebuffer_info = delegate_->GLContextFramebufferInfo();
+  // Partial repaint is enabled by default
+  framebuffer_info.supports_partial_repaint = true;
+  framebuffer_info.existing_damage = existing_damage_;
   return std::make_unique<SurfaceFrame>(surface, std::move(framebuffer_info),
                                         submit_callback,
                                         std::move(context_switch));
@@ -268,8 +272,9 @@ bool GPUSurfaceGLSkia::PresentSurface(const SurfaceFrame& frame,
 
   GLPresentInfo present_info = {
       .fbo_id = fbo_id_,
-      .damage = frame.submit_info().frame_damage,
+      .frame_damage = frame.submit_info().frame_damage,
       .presentation_time = frame.submit_info().presentation_time,
+      .buffer_damage = frame.submit_info().buffer_damage,
   };
   if (!delegate_->GLContextPresent(present_info)) {
     return false;
@@ -284,11 +289,11 @@ bool GPUSurfaceGLSkia::PresentSurface(const SurfaceFrame& frame,
 
     // The FBO has changed, ask the delegate for the new FBO and do a surface
     // re-wrap.
-    const uint32_t fbo_id = delegate_->GLContextFBO(frame_info);
+    const GLFBOInfo fbo_info = delegate_->GLContextFBO(frame_info);
     auto new_onscreen_surface =
         WrapOnscreenSurface(context_.get(),  // GL context
                             current_size,    // root surface size
-                            fbo_id           // window FBO ID
+                            fbo_info.fbo_id  // window FBO ID
         );
 
     if (!new_onscreen_surface) {
@@ -296,7 +301,8 @@ bool GPUSurfaceGLSkia::PresentSurface(const SurfaceFrame& frame,
     }
 
     onscreen_surface_ = std::move(new_onscreen_surface);
-    fbo_id_ = fbo_id;
+    fbo_id_ = fbo_info.fbo_id;
+    existing_damage_ = fbo_info.existing_damage;
   }
 
   return true;

--- a/shell/gpu/gpu_surface_gl_skia.h
+++ b/shell/gpu/gpu_surface_gl_skia.h
@@ -67,6 +67,8 @@ class GPUSurfaceGLSkia : public Surface {
   sk_sp<SkSurface> onscreen_surface_;
   /// FBO backing the current `onscreen_surface_`.
   uint32_t fbo_id_ = 0;
+  /// Private variable used to keep track of the current FBO's existing damage.
+  SkIRect existing_damage_ = SkIRect::MakeEmpty();
   bool context_owner_ = false;
   // TODO(38466): Refactor GPU surface APIs take into account the fact that an
   // external view embedder may want to render to the root surface. This is a

--- a/shell/platform/android/android_surface_gl_impeller.cc
+++ b/shell/platform/android/android_surface_gl_impeller.cc
@@ -298,7 +298,7 @@ bool AndroidSurfaceGLImpeller::GLContextPresent(
 GLFBOInfo AndroidSurfaceGLImpeller::GLContextFBO(GLFrameInfo frame_info) const {
   // FBO0 is the default window bound framebuffer in EGL environments.
   return GLFBOInfo{
-    .fbo_id = 0,
+      .fbo_id = 0,
   };
 }
 

--- a/shell/platform/android/android_surface_gl_impeller.cc
+++ b/shell/platform/android/android_surface_gl_impeller.cc
@@ -295,9 +295,11 @@ bool AndroidSurfaceGLImpeller::GLContextPresent(
 }
 
 // |GPUSurfaceGLDelegate|
-intptr_t AndroidSurfaceGLImpeller::GLContextFBO(GLFrameInfo frame_info) const {
+GLFBOInfo AndroidSurfaceGLImpeller::GLContextFBO(GLFrameInfo frame_info) const {
   // FBO0 is the default window bound framebuffer in EGL environments.
-  return 0;
+  return GLFBOInfo{
+    .fbo_id = 0,
+  };
 }
 
 // |GPUSurfaceGLDelegate|

--- a/shell/platform/android/android_surface_gl_impeller.h
+++ b/shell/platform/android/android_surface_gl_impeller.h
@@ -68,7 +68,7 @@ class AndroidSurfaceGLImpeller final : public GPUSurfaceGLDelegate,
   bool GLContextPresent(const GLPresentInfo& present_info) override;
 
   // |GPUSurfaceGLDelegate|
-  intptr_t GLContextFBO(GLFrameInfo frame_info) const override;
+  GLFBOInfo GLContextFBO(GLFrameInfo frame_info) const override;
 
   // |GPUSurfaceGLDelegate|
   sk_sp<const GrGLInterface> GetGLInterface() const override;

--- a/shell/platform/android/android_surface_gl_skia.cc
+++ b/shell/platform/android/android_surface_gl_skia.cc
@@ -159,7 +159,7 @@ bool AndroidSurfaceGLSkia::GLContextPresent(const GLPresentInfo& present_info) {
   if (present_info.presentation_time) {
     onscreen_surface_->SetPresentationTime(*present_info.presentation_time);
   }
-  return onscreen_surface_->SwapBuffers(present_info.damage);
+  return onscreen_surface_->SwapBuffers(present_info.frame_damage);
 }
 
 GLFBOInfo AndroidSurfaceGLSkia::GLContextFBO(GLFrameInfo frame_info) const {

--- a/shell/platform/android/android_surface_gl_skia.cc
+++ b/shell/platform/android/android_surface_gl_skia.cc
@@ -166,7 +166,7 @@ GLFBOInfo AndroidSurfaceGLSkia::GLContextFBO(GLFrameInfo frame_info) const {
   FML_DCHECK(IsValid());
   // The default window bound framebuffer on Android.
   return GLFBOInfo{
-    .fbo_id = 0,
+      .fbo_id = 0,
   };
 }
 

--- a/shell/platform/android/android_surface_gl_skia.cc
+++ b/shell/platform/android/android_surface_gl_skia.cc
@@ -162,10 +162,12 @@ bool AndroidSurfaceGLSkia::GLContextPresent(const GLPresentInfo& present_info) {
   return onscreen_surface_->SwapBuffers(present_info.damage);
 }
 
-intptr_t AndroidSurfaceGLSkia::GLContextFBO(GLFrameInfo frame_info) const {
+GLFBOInfo AndroidSurfaceGLSkia::GLContextFBO(GLFrameInfo frame_info) const {
   FML_DCHECK(IsValid());
   // The default window bound framebuffer on Android.
-  return 0;
+  return GLFBOInfo{
+    .fbo_id = 0,
+  };
 }
 
 // |GPUSurfaceGLDelegate|

--- a/shell/platform/android/android_surface_gl_skia.h
+++ b/shell/platform/android/android_surface_gl_skia.h
@@ -10,6 +10,7 @@
 #include <memory>
 
 #include "flutter/fml/macros.h"
+#include "flutter/shell/gpu/gpu_surface_gl_delegate.h"
 #include "flutter/shell/gpu/gpu_surface_gl_skia.h"
 #include "flutter/shell/platform/android/android_context_gl_skia.h"
 #include "flutter/shell/platform/android/android_environment_gl.h"
@@ -67,7 +68,7 @@ class AndroidSurfaceGLSkia final : public GPUSurfaceGLDelegate,
   bool GLContextPresent(const GLPresentInfo& present_info) override;
 
   // |GPUSurfaceGLDelegate|
-  intptr_t GLContextFBO(GLFrameInfo frame_info) const override;
+  GLFBOInfo GLContextFBO(GLFrameInfo frame_info) const override;
 
   // |GPUSurfaceGLDelegate|
   sk_sp<const GrGLInterface> GetGLInterface() const override;

--- a/shell/platform/android/surface/android_surface_mock.cc
+++ b/shell/platform/android/surface/android_surface_mock.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "flutter/shell/platform/android/surface/android_surface_mock.h"
+#include "shell/gpu/gpu_surface_gl_delegate.h"
 
 namespace flutter {
 
@@ -22,8 +23,10 @@ bool AndroidSurfaceMock::GLContextPresent(const GLPresentInfo& present_info) {
   return true;
 }
 
-intptr_t AndroidSurfaceMock::GLContextFBO(GLFrameInfo frame_info) const {
-  return 0;
+GLFBOInfo AndroidSurfaceMock::GLContextFBO(GLFrameInfo frame_info) const {
+  return GLFBOInfo {
+    .fbo_id = 0,
+  };
 }
 
 }  // namespace flutter

--- a/shell/platform/android/surface/android_surface_mock.cc
+++ b/shell/platform/android/surface/android_surface_mock.cc
@@ -24,8 +24,8 @@ bool AndroidSurfaceMock::GLContextPresent(const GLPresentInfo& present_info) {
 }
 
 GLFBOInfo AndroidSurfaceMock::GLContextFBO(GLFrameInfo frame_info) const {
-  return GLFBOInfo {
-    .fbo_id = 0,
+  return GLFBOInfo{
+      .fbo_id = 0,
   };
 }
 

--- a/shell/platform/android/surface/android_surface_mock.h
+++ b/shell/platform/android/surface/android_surface_mock.h
@@ -8,6 +8,7 @@
 #include "flutter/shell/gpu/gpu_surface_gl_skia.h"
 #include "flutter/shell/platform/android/surface/android_surface.h"
 #include "gmock/gmock.h"
+#include "shell/gpu/gpu_surface_gl_delegate.h"
 
 namespace flutter {
 
@@ -51,7 +52,7 @@ class AndroidSurfaceMock final : public GPUSurfaceGLDelegate,
   bool GLContextPresent(const GLPresentInfo& present_info) override;
 
   // |GPUSurfaceGLDelegate|
-  intptr_t GLContextFBO(GLFrameInfo frame_info) const override;
+  GLFBOInfo GLContextFBO(GLFrameInfo frame_info) const override;
 };
 
 }  // namespace flutter

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "include/core/SkRect.h"
-#include "shell/gpu/gpu_surface_gl_delegate.h"
 #define FML_USED_ON_EMBEDDER
 #define RAPIDJSON_HAS_STDSTRING 1
 

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -271,22 +271,22 @@ InferOpenGLPlatformViewCreationCallback(
       return present(user_data);
     } else {
       /// Format the frame and buffer damages accordingly.
-      FlutterDamage frame_damage {
-        .struct_size = sizeof(FlutterDamage),
-        .damage_kind = kFlutterSingleRectDamage,
-        .damage = SkIRectToFlutterRect(*(gl_present_info.frame_damage)),
+      FlutterDamage frame_damage{
+          .struct_size = sizeof(FlutterDamage),
+          .damage_kind = kFlutterSingleRectDamage,
+          .damage = SkIRectToFlutterRect(*(gl_present_info.frame_damage)),
       };
-      FlutterDamage buffer_damage {
-        .struct_size = sizeof(FlutterDamage),
-        .damage_kind = kFlutterSingleRectDamage,
-        .damage = SkIRectToFlutterRect(*(gl_present_info.buffer_damage)),
+      FlutterDamage buffer_damage{
+          .struct_size = sizeof(FlutterDamage),
+          .damage_kind = kFlutterSingleRectDamage,
+          .damage = SkIRectToFlutterRect(*(gl_present_info.buffer_damage)),
       };
 
       FlutterPresentInfo present_info = {
-        .struct_size = sizeof(FlutterPresentInfo),
-        .fbo_id = gl_present_info.fbo_id,
-        .frame_damage = frame_damage,
-        .buffer_damage = buffer_damage,
+          .struct_size = sizeof(FlutterPresentInfo),
+          .fbo_id = gl_present_info.fbo_id,
+          .frame_damage = frame_damage,
+          .buffer_damage = buffer_damage,
       };
 
       return present_with_info(user_data, &present_info);
@@ -300,28 +300,29 @@ InferOpenGLPlatformViewCreationCallback(
        user_data](flutter::GLFrameInfo gl_frame_info) -> flutter::GLFBOInfo {
     if (fbo_callback) {
       flutter::GLFBOInfo gl_fbo = {
-        .fbo_id = fbo_callback(user_data),
-        .existing_damage = SkIRect::MakeEmpty(),
+          .fbo_id = fbo_callback(user_data),
+          .existing_damage = SkIRect::MakeEmpty(),
       };
 
       return gl_fbo;
     } else {
       FlutterDamage existing_damage = {
-        .struct_size = sizeof(FlutterDamage),
-        .damage_kind = kFlutterSingleRectDamage,
-        .damage = {0, 0, 0, 0},
+          .struct_size = sizeof(FlutterDamage),
+          .damage_kind = kFlutterSingleRectDamage,
+          .damage = {0, 0, 0, 0},
       };
 
       FlutterFrameInfo frame_info = {
-        .struct_size = sizeof(FlutterFrameInfo),
-        .size = {gl_frame_info.width, gl_frame_info.height},
-        .fbo_id = 0,
-        .existing_damage = existing_damage,
+          .struct_size = sizeof(FlutterFrameInfo),
+          .size = {gl_frame_info.width, gl_frame_info.height},
+          .fbo_id = 0,
+          .existing_damage = existing_damage,
       };
 
       flutter::GLFBOInfo gl_fbo = {
-        .fbo_id = fbo_with_frame_info_callback(user_data, &frame_info),
-        .existing_damage = FlutterRectToSkIRect(frame_info.existing_damage.damage),
+          .fbo_id = fbo_with_frame_info_callback(user_data, &frame_info),
+          .existing_damage =
+              FlutterRectToSkIRect(frame_info.existing_damage.damage),
       };
 
       return gl_fbo;

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -277,8 +277,10 @@ InferOpenGLPlatformViewCreationCallback(
       /// Format the frame and buffer damages accordingly.
       FlutterDamage frame_damage;
       FlutterDamage buffer_damage;
-      frame_damage.damage = SkIRectToFlutterRect(*(gl_present_info.frame_damage));
-      buffer_damage.damage = SkIRectToFlutterRect(*(gl_present_info.buffer_damage));
+      frame_damage.damage =
+          SkIRectToFlutterRect(*(gl_present_info.frame_damage));
+      buffer_damage.damage =
+          SkIRectToFlutterRect(*(gl_present_info.buffer_damage));
       present_info.frame_damage = frame_damage;
       present_info.buffer_damage = buffer_damage;
 
@@ -298,13 +300,17 @@ InferOpenGLPlatformViewCreationCallback(
       FlutterFrameInfo frame_info = {};
       frame_info.struct_size = sizeof(FlutterFrameInfo);
       frame_info.size = {gl_frame_info.width, gl_frame_info.height};
-      return flutter::GLFBOInfo{fbo_with_frame_info_callback(user_data, &frame_info), SkIRect::MakeEmpty()};
+      return flutter::GLFBOInfo{
+          fbo_with_frame_info_callback(user_data, &frame_info),
+          SkIRect::MakeEmpty()};
     } else {
       FlutterFrameInfo frame_info = {};
       frame_info.struct_size = sizeof(FlutterFrameInfo);
       frame_info.size = {gl_frame_info.width, gl_frame_info.height};
       FlutterFrameBuffer fbo = fbo_with_damage_callback(user_data, &frame_info);
-      return flutter::GLFBOInfo{static_cast<uint32_t>(fbo.fbo_id), FlutterRectToSkIRect(fbo.existing_damage.damage)};
+      return flutter::GLFBOInfo{
+          static_cast<uint32_t>(fbo.fbo_id),
+          FlutterRectToSkIRect(fbo.existing_damage.damage)};
     }
   };
 

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -222,6 +222,16 @@ static void* DefaultGLProcResolver(const char* name) {
 }
 #endif  // FML_OS_LINUX || FML_OS_WIN
 
+/// Auxiliar function used to translate rectangles of type SkIRect to
+/// FlutterRect.
+FlutterRect SkIRectToFlutterRect(const SkIRect sk_rect) {
+  FlutterRect flutter_rect = {static_cast<double>(sk_rect.fLeft),
+                              static_cast<double>(sk_rect.fTop),
+                              static_cast<double>(sk_rect.fRight),
+                              static_cast<double>(sk_rect.fBottom)};
+  return flutter_rect;
+}
+
 static flutter::Shell::CreateCallback<flutter::PlatformView>
 InferOpenGLPlatformViewCreationCallback(
     const FlutterRendererConfig* config,

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -466,6 +466,18 @@ typedef uint32_t (*UIntFrameInfoCallback)(
     void* /* user data */,
     const FlutterFrameInfo* /* frame info */);
 
+/// This information is passed from the user to the embedder upon request of a
+/// new frame buffer. This is used for partial repaint, which requries a
+/// flexible surface size (contrasting with \ref FlutterFrameInfo).
+typedef struct {
+  /// The size of this struct. Must be sizeof(FlutterFrameBuffer).
+  size_t struct_size;
+  /// The frame buffer's ID.
+  intptr_t fbo_id;
+  /// The frame buffer's existing damage (i.e. damage since it was last used).
+  FlutterDamage existing_damage;
+} FlutterFrameBuffer;
+
 /// This information is passed to the embedder when a surface is presented.
 ///
 /// See: \ref FlutterOpenGLRendererConfig.present_with_info.

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -478,6 +478,11 @@ typedef struct {
   FlutterDamage existing_damage;
 } FlutterFrameBuffer;
 
+/// Callback for when a frame buffer object is requested with partial repaint.
+typedef FlutterFrameBuffer (*FlutterFrameBufferFrameInfoCallback)(
+    void* /* user data */,
+    const FlutterFrameInfo* /* frame info */);
+
 /// This information is passed to the embedder when a surface is presented.
 ///
 /// See: \ref FlutterOpenGLRendererConfig.present_with_info.
@@ -502,11 +507,11 @@ typedef struct {
   /// required. Specifying both is an error and engine initialization will be
   /// terminated. The return value indicates success of the present call.
   BoolCallback present;
-  /// Specifying one (and only one) of the `fbo_callback` or
-  /// `fbo_with_frame_info_callback` is required. Specifying both is an error
-  /// and engine intialization will be terminated. The return value indicates
-  /// the id of the frame buffer object that flutter will obtain the gl surface
-  /// from.
+  /// Specifying one (and only one) of the `fbo_callback`,
+  /// `fbo_with_frame_info_callback`, or `fbo_with_damage_callback` is required.
+  /// Specifying more than one is an error and engine intialization will be
+  /// terminated. The return value indicates the id of the frame buffer object
+  /// that flutter will obtain the gl surface from.
   UIntCallback fbo_callback;
   /// This is an optional callback. Flutter will ask the emebdder to create a GL
   /// context current on a background thread. If the embedder is able to do so,
@@ -537,13 +542,13 @@ typedef struct {
   /// that external texture details can be supplied to the engine for subsequent
   /// composition.
   TextureFrameCallback gl_external_texture_frame_callback;
-  /// Specifying one (and only one) of the `fbo_callback` or
-  /// `fbo_with_frame_info_callback` is required. Specifying both is an error
-  /// and engine intialization will be terminated. The return value indicates
-  /// the id of the frame buffer object (fbo) that flutter will obtain the gl
-  /// surface from. When using this variant, the embedder is passed a
-  /// `FlutterFrameInfo` struct that indicates the properties of the surface
-  /// that flutter will acquire from the returned fbo.
+  /// Specifying one (and only one) of the `fbo_callback`,
+  /// `fbo_with_frame_info_callback`, or `fbo_with_damage_callback` is required.
+  /// Specifying more than one is an error and engine intialization will be
+  /// terminated. The return value indicates the id of the frame buffer object
+  /// that flutter will obtain the gl surface from. When using this variant, the
+  /// embedder is passed a `FlutterFrameInfo` struct that indicates the
+  /// properties of the surface that flutter will acquire from the returned fbo.
   UIntFrameInfoCallback fbo_with_frame_info_callback;
   /// Specifying one (and only one) of `present` or `present_with_info` is
   /// required. Specifying both is an error and engine initialization will be
@@ -551,6 +556,15 @@ typedef struct {
   /// `FlutterPresentInfo` struct that the embedder can use to release any
   /// resources. The return value indicates success of the present call.
   BoolPresentInfoCallback present_with_info;
+  /// Specifying one (and only one) of the `fbo_callback`,
+  /// `fbo_with_frame_info_callback`, or `fbo_with_damage_callback` is required.
+  /// Specifying more than one is an error and engine intialization will be
+  /// terminated. The return value indicates the a struct containing both the id
+  /// of the frame buffer object that flutter will obtain the gl surface from
+  /// and the existing damage to it. When using this variant, the embedder can
+  /// also pass a `FlutterFrameInfo` struct that indicates the properties of the
+  /// surface that flutter will acquire from the returned fbo.
+  FlutterFrameBufferFrameInfoCallback fbo_with_damage_callback;
 } FlutterOpenGLRendererConfig;
 
 /// Alias for id<MTLDevice>.

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -491,6 +491,10 @@ typedef struct {
   size_t struct_size;
   /// Id of the fbo backing the surface that was presented.
   uint32_t fbo_id;
+  /// Damage representing the area that the compositor needs to render.
+  FlutterDamage frame_damage;
+  /// Damage used to set the buffer's damage region.
+  FlutterDamage buffer_damage;
 } FlutterPresentInfo;
 
 /// Callback for when a surface is presented.

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -433,6 +433,23 @@ typedef struct {
   FlutterSize lower_left_corner_radius;
 } FlutterRoundedRect;
 
+/// The type of damage used.
+typedef enum {
+  kFlutterSingleRectDamage = 1,
+} FlutterDamageKind;
+
+/// A structure to represent a damage region.
+typedef struct {
+  /// The size of this struct. Must be sizeof(FlutterDamage).
+  size_t struct_size;
+  // The type of damage used. Allows for future multi-damage modes.
+  FlutterDamageKind damage_kind;
+  // The actual damage region(s) in question.
+  union {
+    FlutterRect damage;
+  };
+} FlutterDamage;
+
 /// This information is passed to the embedder when requesting a frame buffer
 /// object.
 ///

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -459,27 +459,14 @@ typedef struct {
   size_t struct_size;
   /// The size of the surface that will be backed by the fbo.
   FlutterUIntSize size;
-} FlutterFrameInfo;
-
-/// Callback for when a frame buffer object is requested.
-typedef uint32_t (*UIntFrameInfoCallback)(
-    void* /* user data */,
-    const FlutterFrameInfo* /* frame info */);
-
-/// This information is passed from the user to the embedder upon request of a
-/// new frame buffer. This is used for partial repaint, which requries a
-/// flexible surface size (contrasting with \ref FlutterFrameInfo).
-typedef struct {
-  /// The size of this struct. Must be sizeof(FlutterFrameBuffer).
-  size_t struct_size;
   /// The frame buffer's ID.
   intptr_t fbo_id;
   /// The frame buffer's existing damage (i.e. damage since it was last used).
   FlutterDamage existing_damage;
-} FlutterFrameBuffer;
+} FlutterFrameInfo;
 
-/// Callback for when a frame buffer object is requested with partial repaint.
-typedef FlutterFrameBuffer (*FlutterFrameBufferFrameInfoCallback)(
+/// Callback for when a frame buffer object is requested.
+typedef uint32_t (*UIntFrameInfoCallback)(
     void* /* user data */,
     const FlutterFrameInfo* /* frame info */);
 
@@ -511,11 +498,11 @@ typedef struct {
   /// required. Specifying both is an error and engine initialization will be
   /// terminated. The return value indicates success of the present call.
   BoolCallback present;
-  /// Specifying one (and only one) of the `fbo_callback`,
-  /// `fbo_with_frame_info_callback`, or `fbo_with_damage_callback` is required.
-  /// Specifying more than one is an error and engine intialization will be
-  /// terminated. The return value indicates the id of the frame buffer object
-  /// that flutter will obtain the gl surface from.
+  /// Specifying one (and only one) of the `fbo_callback` or
+  /// `fbo_with_frame_info_callback` is required. Specifying both is an error
+  /// and engine intialization will be terminated. The return value indicates
+  /// the id of the frame buffer object that flutter will obtain the gl surface
+  /// from.
   UIntCallback fbo_callback;
   /// This is an optional callback. Flutter will ask the emebdder to create a GL
   /// context current on a background thread. If the embedder is able to do so,
@@ -546,13 +533,16 @@ typedef struct {
   /// that external texture details can be supplied to the engine for subsequent
   /// composition.
   TextureFrameCallback gl_external_texture_frame_callback;
-  /// Specifying one (and only one) of the `fbo_callback`,
-  /// `fbo_with_frame_info_callback`, or `fbo_with_damage_callback` is required.
-  /// Specifying more than one is an error and engine intialization will be
-  /// terminated. The return value indicates the id of the frame buffer object
-  /// that flutter will obtain the gl surface from. When using this variant, the
-  /// embedder is passed a `FlutterFrameInfo` struct that indicates the
-  /// properties of the surface that flutter will acquire from the returned fbo.
+  /// Specifying one (and only one) of the `fbo_callback` or
+  /// `fbo_with_frame_info_callback` is required. Specifying both is an error
+  /// and engine intialization will be terminated. The return value indicates
+  /// the id of the frame buffer object (fbo) that flutter will obtain the gl
+  /// surface from. When using this variant, the embedder is passed a
+  /// `FlutterFrameInfo` struct that indicates the properties of the surface
+  /// that flutter will acquire from the returned fbo. When performing partial
+  /// repaint, this callback is responsible for also filling in the values of
+  /// the frame_info that is passed to it by reference such as buffer existing
+  /// damage and buffer id.
   UIntFrameInfoCallback fbo_with_frame_info_callback;
   /// Specifying one (and only one) of `present` or `present_with_info` is
   /// required. Specifying both is an error and engine initialization will be
@@ -560,15 +550,6 @@ typedef struct {
   /// `FlutterPresentInfo` struct that the embedder can use to release any
   /// resources. The return value indicates success of the present call.
   BoolPresentInfoCallback present_with_info;
-  /// Specifying one (and only one) of the `fbo_callback`,
-  /// `fbo_with_frame_info_callback`, or `fbo_with_damage_callback` is required.
-  /// Specifying more than one is an error and engine intialization will be
-  /// terminated. The return value indicates the a struct containing both the id
-  /// of the frame buffer object that flutter will obtain the gl surface from
-  /// and the existing damage to it. When using this variant, the embedder can
-  /// also pass a `FlutterFrameInfo` struct that indicates the properties of the
-  /// surface that flutter will acquire from the returned fbo.
-  FlutterFrameBufferFrameInfoCallback fbo_with_damage_callback;
 } FlutterOpenGLRendererConfig;
 
 /// Alias for id<MTLDevice>.

--- a/shell/platform/embedder/embedder_surface_gl.cc
+++ b/shell/platform/embedder/embedder_surface_gl.cc
@@ -46,11 +46,11 @@ bool EmbedderSurfaceGL::GLContextClearCurrent() {
 
 // |GPUSurfaceGLDelegate|
 bool EmbedderSurfaceGL::GLContextPresent(const GLPresentInfo& present_info) {
-  return gl_dispatch_table_.gl_present_callback(present_info.fbo_id);
+  return gl_dispatch_table_.gl_present_callback(present_info);
 }
 
 // |GPUSurfaceGLDelegate|
-intptr_t EmbedderSurfaceGL::GLContextFBO(GLFrameInfo frame_info) const {
+GLFBOInfo EmbedderSurfaceGL::GLContextFBO(GLFrameInfo frame_info) const {
   return gl_dispatch_table_.gl_fbo_callback(frame_info);
 }
 

--- a/shell/platform/embedder/embedder_surface_gl.h
+++ b/shell/platform/embedder/embedder_surface_gl.h
@@ -9,6 +9,7 @@
 #include "flutter/shell/gpu/gpu_surface_gl_skia.h"
 #include "flutter/shell/platform/embedder/embedder_external_view_embedder.h"
 #include "flutter/shell/platform/embedder/embedder_surface.h"
+#include "shell/gpu/gpu_surface_gl_delegate.h"
 
 namespace flutter {
 
@@ -16,14 +17,14 @@ class EmbedderSurfaceGL final : public EmbedderSurface,
                                 public GPUSurfaceGLDelegate {
  public:
   struct GLDispatchTable {
-    std::function<bool(void)> gl_make_current_callback;           // required
-    std::function<bool(void)> gl_clear_current_callback;          // required
-    std::function<bool(uint32_t)> gl_present_callback;            // required
-    std::function<intptr_t(GLFrameInfo)> gl_fbo_callback;         // required
-    std::function<bool(void)> gl_make_resource_current_callback;  // optional
+    std::function<bool(void)> gl_make_current_callback;              // required
+    std::function<bool(void)> gl_clear_current_callback;             // required
+    std::function<bool(GLPresentInfo)> gl_present_callback;          // required
+    std::function<GLFBOInfo(GLFrameInfo)> gl_fbo_callback;           // required
+    std::function<bool(void)> gl_make_resource_current_callback;     // optional
     std::function<SkMatrix(void)>
-        gl_surface_transformation_callback;              // optional
-    std::function<void*(const char*)> gl_proc_resolver;  // optional
+        gl_surface_transformation_callback;                          // optional
+    std::function<void*(const char*)> gl_proc_resolver;              // optional
   };
 
   EmbedderSurfaceGL(
@@ -59,7 +60,7 @@ class EmbedderSurfaceGL final : public EmbedderSurface,
   bool GLContextPresent(const GLPresentInfo& present_info) override;
 
   // |GPUSurfaceGLDelegate|
-  intptr_t GLContextFBO(GLFrameInfo frame_info) const override;
+  GLFBOInfo GLContextFBO(GLFrameInfo frame_info) const override;
 
   // |GPUSurfaceGLDelegate|
   bool GLContextFBOResetAfterPresent() const override;

--- a/shell/platform/embedder/embedder_surface_gl.h
+++ b/shell/platform/embedder/embedder_surface_gl.h
@@ -9,7 +9,6 @@
 #include "flutter/shell/gpu/gpu_surface_gl_skia.h"
 #include "flutter/shell/platform/embedder/embedder_external_view_embedder.h"
 #include "flutter/shell/platform/embedder/embedder_surface.h"
-#include "shell/gpu/gpu_surface_gl_delegate.h"
 
 namespace flutter {
 

--- a/shell/platform/embedder/embedder_surface_gl.h
+++ b/shell/platform/embedder/embedder_surface_gl.h
@@ -17,14 +17,14 @@ class EmbedderSurfaceGL final : public EmbedderSurface,
                                 public GPUSurfaceGLDelegate {
  public:
   struct GLDispatchTable {
-    std::function<bool(void)> gl_make_current_callback;              // required
-    std::function<bool(void)> gl_clear_current_callback;             // required
-    std::function<bool(GLPresentInfo)> gl_present_callback;          // required
-    std::function<GLFBOInfo(GLFrameInfo)> gl_fbo_callback;           // required
-    std::function<bool(void)> gl_make_resource_current_callback;     // optional
+    std::function<bool(void)> gl_make_current_callback;           // required
+    std::function<bool(void)> gl_clear_current_callback;          // required
+    std::function<bool(GLPresentInfo)> gl_present_callback;       // required
+    std::function<GLFBOInfo(GLFrameInfo)> gl_fbo_callback;        // required
+    std::function<bool(void)> gl_make_resource_current_callback;  // optional
     std::function<SkMatrix(void)>
-        gl_surface_transformation_callback;                          // optional
-    std::function<void*(const char*)> gl_proc_resolver;              // optional
+        gl_surface_transformation_callback;              // optional
+    std::function<void*(const char*)> gl_proc_resolver;  // optional
   };
 
   EmbedderSurfaceGL(


### PR DESCRIPTION
The changes proposed in this PR update the GLFW example to support dirty region management. It updates the example to a loading spinner in the center of the screen and adjusts the user-defined embedder callbacks to manage the information necessary for partial repaint. The goal of this example is also to serve as a local benchmark for dirty region management within the Embedder API.

*List which issues are fixed by this PR. You must list at least one issue.*

*Add tests*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.