### PR TITLE
Make the filter_ in mutator shared_ptr

### DIFF
--- a/flow/embedded_views.cc
+++ b/flow/embedded_views.cc
@@ -36,7 +36,8 @@ void MutatorsStack::PushOpacity(const int& alpha) {
   vector_.push_back(element);
 };
 
-void MutatorsStack::PushBackdropFilter(const DlImageFilter& filter) {
+void MutatorsStack::PushBackdropFilter(
+    std::shared_ptr<const DlImageFilter> filter) {
   std::shared_ptr<Mutator> element = std::make_shared<Mutator>(filter);
   vector_.push_back(element);
 };

--- a/flow/embedded_views.h
+++ b/flow/embedded_views.h
@@ -98,7 +98,7 @@ class Mutator {
       case kOpacity:
         return alpha_ == other.alpha_;
       case kBackdropFilter:
-        return *filter_ == *other.filter_->shared();
+        return *filter_ == *other.filter_;
     }
 
     return false;

--- a/flow/embedded_views.h
+++ b/flow/embedded_views.h
@@ -56,7 +56,7 @@ class Mutator {
         alpha_ = other.alpha_;
         break;
       case kBackdropFilter:
-        filter_ = other.filter_;
+        filter_ = other.filter_->shared();
         break;
       default:
         break;
@@ -71,7 +71,7 @@ class Mutator {
       : type_(kTransform), matrix_(matrix) {}
   explicit Mutator(const int& alpha) : type_(kOpacity), alpha_(alpha) {}
   explicit Mutator(const DlImageFilter& filter)
-      : type_(kBackdropFilter), filter_(&filter) {}
+      : type_(kBackdropFilter), filter_(filter.shared()) {}
 
   const MutatorType& GetType() const { return type_; }
   const SkRect& GetRect() const { return rect_; }
@@ -98,7 +98,7 @@ class Mutator {
       case kOpacity:
         return alpha_ == other.alpha_;
       case kBackdropFilter:
-        return *filter_ == *other.filter_;
+        return *filter_ == *other.filter_->shared();
     }
 
     return false;
@@ -119,14 +119,17 @@ class Mutator {
  private:
   MutatorType type_;
 
+  // TODO(cyanglaz): Remove union.
+  //  https://github.com/flutter/flutter/issues/108470
   union {
     SkRect rect_;
     SkRRect rrect_;
     SkMatrix matrix_;
     SkPath* path_;
     int alpha_;
-    const DlImageFilter* filter_;
   };
+
+  std::shared_ptr<const DlImageFilter> filter_;
 
 };  // Mutator
 

--- a/flow/embedded_views.h
+++ b/flow/embedded_views.h
@@ -56,7 +56,7 @@ class Mutator {
         alpha_ = other.alpha_;
         break;
       case kBackdropFilter:
-        filter_ = other.filter_->shared();
+        filter_ = other.filter_;
         break;
       default:
         break;
@@ -70,8 +70,8 @@ class Mutator {
   explicit Mutator(const SkMatrix& matrix)
       : type_(kTransform), matrix_(matrix) {}
   explicit Mutator(const int& alpha) : type_(kOpacity), alpha_(alpha) {}
-  explicit Mutator(const DlImageFilter& filter)
-      : type_(kBackdropFilter), filter_(filter.shared()) {}
+  explicit Mutator(std::shared_ptr<const DlImageFilter> filter)
+      : type_(kBackdropFilter), filter_(filter) {}
 
   const MutatorType& GetType() const { return type_; }
   const SkRect& GetRect() const { return rect_; }
@@ -151,7 +151,7 @@ class MutatorsStack {
   void PushClipPath(const SkPath& path);
   void PushTransform(const SkMatrix& matrix);
   void PushOpacity(const int& alpha);
-  void PushBackdropFilter(const DlImageFilter& filter);
+  void PushBackdropFilter(std::shared_ptr<const DlImageFilter> filter);
 
   // Removes the `Mutator` on the top of the stack
   // and destroys it.

--- a/flow/mutators_stack_unittests.cc
+++ b/flow/mutators_stack_unittests.cc
@@ -91,7 +91,8 @@ TEST(MutatorsStack, PushOpacity) {
 
 TEST(MutatorsStack, PushBackdropFilter) {
   MutatorsStack stack;
-  for (int i = 0; i < 10; i++) {
+  const int num_of_mutators = 10;
+  for (int i = 0; i < num_of_mutators; i++) {
     auto filter = std::make_shared<DlBlurImageFilter>(i, 5, DlTileMode::kClamp);
     stack.PushBackdropFilter(filter);
   }
@@ -99,11 +100,12 @@ TEST(MutatorsStack, PushBackdropFilter) {
   auto iter = stack.Begin();
   int i = 0;
   while (iter != stack.End()) {
-    ASSERT_TRUE(iter->get()->GetType() == MutatorType::kBackdropFilter);
+    ASSERT_EQ(iter->get()->GetType(), MutatorType::kBackdropFilter);
     ASSERT_EQ(iter->get()->GetFilter().asBlur()->sigma_x(), i);
     ++iter;
     ++i;
   }
+  ASSERT_EQ(i, num_of_mutators);
 }
 
 TEST(MutatorsStack, Pop) {

--- a/flow/mutators_stack_unittests.cc
+++ b/flow/mutators_stack_unittests.cc
@@ -91,11 +91,19 @@ TEST(MutatorsStack, PushOpacity) {
 
 TEST(MutatorsStack, PushBackdropFilter) {
   MutatorsStack stack;
-  auto filter = DlBlurImageFilter(5, 5, DlTileMode::kClamp);
-  stack.PushBackdropFilter(filter);
-  auto iter = stack.Bottom();
+  auto filter1 = DlBlurImageFilter(5, 5, DlTileMode::kClamp);
+  auto filter2 = DlBlurImageFilter(6, 5, DlTileMode::kClamp);
+  stack.PushBackdropFilter(filter1);
+  stack.PushBackdropFilter(filter2);
+
+  auto iter = stack.Begin();
   ASSERT_TRUE(iter->get()->GetType() == MutatorType::kBackdropFilter);
-  ASSERT_TRUE(iter->get()->GetFilter() == filter);
+  ASSERT_TRUE(iter->get()->GetFilter() == filter1);
+  ASSERT_EQ(iter->get()->GetFilter().asBlur()->sigma_x(), 5);
+  ++iter;
+  ASSERT_TRUE(iter->get()->GetType() == MutatorType::kBackdropFilter);
+  ASSERT_TRUE(iter->get()->GetFilter() == filter2);
+  ASSERT_EQ(iter->get()->GetFilter().asBlur()->sigma_x(), 6);
 }
 
 TEST(MutatorsStack, Pop) {

--- a/flow/mutators_stack_unittests.cc
+++ b/flow/mutators_stack_unittests.cc
@@ -91,19 +91,19 @@ TEST(MutatorsStack, PushOpacity) {
 
 TEST(MutatorsStack, PushBackdropFilter) {
   MutatorsStack stack;
-  auto filter1 = DlBlurImageFilter(5, 5, DlTileMode::kClamp);
-  auto filter2 = DlBlurImageFilter(6, 5, DlTileMode::kClamp);
-  stack.PushBackdropFilter(filter1);
-  stack.PushBackdropFilter(filter2);
+  for (int i = 0; i < 10; i++) {
+    auto filter = std::make_shared<DlBlurImageFilter>(i, 5, DlTileMode::kClamp);
+    stack.PushBackdropFilter(filter);
+  }
 
   auto iter = stack.Begin();
-  ASSERT_TRUE(iter->get()->GetType() == MutatorType::kBackdropFilter);
-  ASSERT_TRUE(iter->get()->GetFilter() == filter1);
-  ASSERT_EQ(iter->get()->GetFilter().asBlur()->sigma_x(), 5);
-  ++iter;
-  ASSERT_TRUE(iter->get()->GetType() == MutatorType::kBackdropFilter);
-  ASSERT_TRUE(iter->get()->GetFilter() == filter2);
-  ASSERT_EQ(iter->get()->GetFilter().asBlur()->sigma_x(), 6);
+  int i = 0;
+  while (iter != stack.End()) {
+    ASSERT_TRUE(iter->get()->GetType() == MutatorType::kBackdropFilter);
+    ASSERT_EQ(iter->get()->GetFilter().asBlur()->sigma_x(), i);
+    ++iter;
+    ++i;
+  }
 }
 
 TEST(MutatorsStack, Pop) {


### PR DESCRIPTION
Storing raw filter_ pointers of DlImageFilter in union caused some issue where all the pointers are pointing to the same address in the stack. 

This PR moves the filter_ object out of union so we can simply making the filter_ a shared_ptr.
This is to unblock https://github.com/flutter/flutter/issues/43902
The real fix for Mutators should be: https://github.com/flutter/flutter/issues/108470

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
