### PR TITLE
optimized IncomingMessageDispatcher::HandleMessage a bit

### DIFF
--- a/shell/platform/common/incoming_message_dispatcher.cc
+++ b/shell/platform/common/incoming_message_dispatcher.cc
@@ -17,7 +17,7 @@ void IncomingMessageDispatcher::HandleMessage(
     const FlutterDesktopMessage& message,
     const std::function<void(void)>& input_block_cb,
     const std::function<void(void)>& input_unblock_cb) {
-  const std::string& channel = message.channel;
+  std::string channel(message.channel);
 
   auto callback_iterator = callbacks_.find(channel);
   // Find the handler for the channel; if there isn't one, report the failure.

--- a/shell/platform/common/incoming_message_dispatcher.cc
+++ b/shell/platform/common/incoming_message_dispatcher.cc
@@ -17,16 +17,17 @@ void IncomingMessageDispatcher::HandleMessage(
     const FlutterDesktopMessage& message,
     const std::function<void(void)>& input_block_cb,
     const std::function<void(void)>& input_unblock_cb) {
-  std::string channel(message.channel);
+  const std::string& channel = message.channel;
 
+  auto callback_iterator = callbacks_.find(channel);
   // Find the handler for the channel; if there isn't one, report the failure.
-  if (callbacks_.find(channel) == callbacks_.end()) {
+  if (callback_iterator == callbacks_.end()) {
     FlutterDesktopMessengerSendResponse(messenger_, message.response_handle,
                                         nullptr, 0);
     return;
   }
-  auto& callback_info = callbacks_[channel];
-  FlutterDesktopMessageCallback message_callback = callback_info.first;
+  auto& callback_info = callback_iterator->second;
+  const FlutterDesktopMessageCallback& message_callback = callback_info.first;
 
   // Process the call, handling input blocking if requested.
   bool block_input = input_blocking_channels_.count(channel) > 0;


### PR DESCRIPTION
I noticed a few simple optimizations while reading through the desktop code:

1) One lookup into `callbacks_` instead of 2
1) ~~Removed copy of the channel name~~
1) Removed copy of the callback closure

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
