### PR TITLE
Fix the best guess results from DlComposeImageFilter with unbounded children

### DIFF
--- a/display_list/display_list_image_filter.cc
+++ b/display_list/display_list_image_filter.cc
@@ -27,4 +27,67 @@ std::shared_ptr<DlImageFilter> DlImageFilter::From(
   return std::make_shared<DlUnknownImageFilter>(sk_ref_sp(sk_filter));
 }
 
+SkRect* DlComposeImageFilter::map_local_bounds(const SkRect& input_bounds,
+                                               SkRect& output_bounds) const {
+  SkRect cur_bounds = input_bounds;
+  SkRect* ret = &output_bounds;
+  // We set this result in case neither filter is present.
+  output_bounds = input_bounds;
+  if (inner_) {
+    if (!inner_->map_local_bounds(cur_bounds, output_bounds)) {
+      ret = nullptr;
+    }
+    cur_bounds = output_bounds;
+  }
+  if (outer_) {
+    if (!outer_->map_local_bounds(cur_bounds, output_bounds)) {
+      ret = nullptr;
+    }
+  }
+  return ret;
+}
+
+SkIRect* DlComposeImageFilter::map_device_bounds(const SkIRect& input_bounds,
+                                                 const SkMatrix& ctm,
+                                                 SkIRect& output_bounds) const {
+  SkIRect cur_bounds = input_bounds;
+  SkIRect* ret = &output_bounds;
+  // We set this result in case neither filter is present.
+  output_bounds = input_bounds;
+  if (inner_) {
+    if (!inner_->map_device_bounds(cur_bounds, ctm, output_bounds)) {
+      ret = nullptr;
+    }
+    cur_bounds = output_bounds;
+  }
+  if (outer_) {
+    if (!outer_->map_device_bounds(cur_bounds, ctm, output_bounds)) {
+      ret = nullptr;
+    }
+  }
+  return ret;
+}
+
+SkIRect* DlComposeImageFilter::get_input_device_bounds(
+    const SkIRect& output_bounds,
+    const SkMatrix& ctm,
+    SkIRect& input_bounds) const {
+  SkIRect cur_bounds = output_bounds;
+  SkIRect* ret = &input_bounds;
+  // We set this result in case neither filter is present.
+  input_bounds = output_bounds;
+  if (outer_) {
+    if (!outer_->get_input_device_bounds(cur_bounds, ctm, input_bounds)) {
+      ret = nullptr;
+    }
+    cur_bounds = input_bounds;
+  }
+  if (inner_) {
+    if (!inner_->get_input_device_bounds(cur_bounds, ctm, input_bounds)) {
+      ret = nullptr;
+    }
+  }
+  return ret;
+}
+
 }  // namespace flutter

--- a/display_list/display_list_image_filter.h
+++ b/display_list/display_list_image_filter.h
@@ -519,63 +519,15 @@ class DlComposeImageFilter final : public DlImageFilter {
   }
 
   SkRect* map_local_bounds(const SkRect& input_bounds,
-                           SkRect& output_bounds) const override {
-    SkRect cur_bounds = input_bounds;
-    // We set this result in case neither filter is present.
-    output_bounds = input_bounds;
-    if (inner_) {
-      if (!inner_->map_local_bounds(cur_bounds, output_bounds)) {
-        return nullptr;
-      }
-      cur_bounds = output_bounds;
-    }
-    if (outer_) {
-      if (!outer_->map_local_bounds(cur_bounds, output_bounds)) {
-        return nullptr;
-      }
-    }
-    return &output_bounds;
-  }
+                           SkRect& output_bounds) const override;
 
   SkIRect* map_device_bounds(const SkIRect& input_bounds,
                              const SkMatrix& ctm,
-                             SkIRect& output_bounds) const override {
-    SkIRect cur_bounds = input_bounds;
-    // We set this result in case neither filter is present.
-    output_bounds = input_bounds;
-    if (inner_) {
-      if (!inner_->map_device_bounds(cur_bounds, ctm, output_bounds)) {
-        return nullptr;
-      }
-      cur_bounds = output_bounds;
-    }
-    if (outer_) {
-      if (!outer_->map_device_bounds(cur_bounds, ctm, output_bounds)) {
-        return nullptr;
-      }
-    }
-    return &output_bounds;
-  }
+                             SkIRect& output_bounds) const override;
 
   SkIRect* get_input_device_bounds(const SkIRect& output_bounds,
                                    const SkMatrix& ctm,
-                                   SkIRect& input_bounds) const override {
-    SkIRect cur_bounds = output_bounds;
-    // We set this result in case neither filter is present.
-    input_bounds = output_bounds;
-    if (outer_) {
-      if (!outer_->get_input_device_bounds(cur_bounds, ctm, input_bounds)) {
-        return nullptr;
-      }
-      cur_bounds = output_bounds;
-    }
-    if (inner_) {
-      if (!inner_->get_input_device_bounds(cur_bounds, ctm, input_bounds)) {
-        return nullptr;
-      }
-    }
-    return &input_bounds;
-  }
+                                   SkIRect& input_bounds) const override;
 
   sk_sp<SkImageFilter> skia_object() const override {
     return SkImageFilters::Compose(outer_->skia_object(),


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/108433

Along with fixing the test case in that issue, I discovered a chaining issue in the implementation of get_input_device_bounds - we were forwarding the output bounds as the input to the next element in the composition instead of the input_bounds.

I also took the liberty of moving these non-trivial methods to the .cc file where they should have been in the first place.