### PR TITLE
[Impeller] Don't make playgrounds implicitly be test fixtures.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -102,7 +102,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'fd6e9d332eed84b2a9d2a0f790c24089bbc0a093',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'cd444824e34d8f735a351f680776bc0479f20677',
 
    # Fuchsia compatibility
    #

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -410,6 +410,8 @@ FILE: ../../../flutter/impeller/aiks/aiks_context.cc
 FILE: ../../../flutter/impeller/aiks/aiks_context.h
 FILE: ../../../flutter/impeller/aiks/aiks_playground.cc
 FILE: ../../../flutter/impeller/aiks/aiks_playground.h
+FILE: ../../../flutter/impeller/aiks/aiks_playground_test.cc
+FILE: ../../../flutter/impeller/aiks/aiks_playground_test.h
 FILE: ../../../flutter/impeller/aiks/aiks_unittests.cc
 FILE: ../../../flutter/impeller/aiks/canvas.cc
 FILE: ../../../flutter/impeller/aiks/canvas.h

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -410,8 +410,6 @@ FILE: ../../../flutter/impeller/aiks/aiks_context.cc
 FILE: ../../../flutter/impeller/aiks/aiks_context.h
 FILE: ../../../flutter/impeller/aiks/aiks_playground.cc
 FILE: ../../../flutter/impeller/aiks/aiks_playground.h
-FILE: ../../../flutter/impeller/aiks/aiks_playground_test.cc
-FILE: ../../../flutter/impeller/aiks/aiks_playground_test.h
 FILE: ../../../flutter/impeller/aiks/aiks_unittests.cc
 FILE: ../../../flutter/impeller/aiks/canvas.cc
 FILE: ../../../flutter/impeller/aiks/canvas.h

--- a/impeller/aiks/BUILD.gn
+++ b/impeller/aiks/BUILD.gn
@@ -41,7 +41,7 @@ impeller_component("aiks_unittests") {
   deps = [
     ":aiks",
     "../geometry:geometry_unittests",
-    "../playground",
+    "../playground:playground_test",
     "//flutter/testing",
   ]
 }

--- a/impeller/aiks/aiks_playground.h
+++ b/impeller/aiks/aiks_playground.h
@@ -7,11 +7,11 @@
 #include "flutter/fml/macros.h"
 #include "impeller/aiks/aiks_context.h"
 #include "impeller/aiks/picture.h"
-#include "impeller/playground/playground.h"
+#include "impeller/playground/playground_test.h"
 
 namespace impeller {
 
-class AiksPlayground : public Playground {
+class AiksPlayground : public PlaygroundTest {
  public:
   using AiksPlaygroundCallback =
       std::function<bool(AiksContext& renderer, RenderTarget& render_target)>;

--- a/impeller/display_list/BUILD.gn
+++ b/impeller/display_list/BUILD.gn
@@ -31,6 +31,6 @@ impeller_component("display_list_unittests") {
 
   deps = [
     ":display_list",
-    "../playground",
+    "../playground:playground_test",
   ]
 }

--- a/impeller/display_list/display_list_playground.h
+++ b/impeller/display_list/display_list_playground.h
@@ -7,12 +7,12 @@
 #include "flutter/display_list/display_list.h"
 #include "flutter/display_list/display_list_builder.h"
 #include "flutter/fml/macros.h"
-#include "impeller/playground/playground.h"
+#include "impeller/playground/playground_test.h"
 #include "third_party/skia/include/core/SkFont.h"
 
 namespace impeller {
 
-class DisplayListPlayground : public Playground {
+class DisplayListPlayground : public PlaygroundTest {
  public:
   using DisplayListPlaygroundCallback =
       std::function<sk_sp<flutter::DisplayList>()>;

--- a/impeller/display_list/display_list_unittests.cc
+++ b/impeller/display_list/display_list_unittests.cc
@@ -8,12 +8,6 @@
 #include "display_list/display_list_image_filter.h"
 #include "display_list/display_list_paint.h"
 #include "display_list/display_list_tile_mode.h"
-#include "gtest/gtest.h"
-#include "third_party/imgui/imgui.h"
-#include "third_party/skia/include/core/SkClipOp.h"
-#include "third_party/skia/include/core/SkColor.h"
-#include "third_party/skia/include/core/SkPathBuilder.h"
-
 #include "flutter/display_list/display_list_builder.h"
 #include "flutter/display_list/display_list_mask_filter.h"
 #include "flutter/display_list/types.h"
@@ -22,6 +16,10 @@
 #include "impeller/display_list/display_list_playground.h"
 #include "impeller/geometry/point.h"
 #include "impeller/playground/widgets.h"
+#include "third_party/imgui/imgui.h"
+#include "third_party/skia/include/core/SkClipOp.h"
+#include "third_party/skia/include/core/SkColor.h"
+#include "third_party/skia/include/core/SkPathBuilder.h"
 
 namespace impeller {
 namespace testing {

--- a/impeller/entity/BUILD.gn
+++ b/impeller/entity/BUILD.gn
@@ -121,6 +121,6 @@ impeller_component("entity_unittests") {
   deps = [
     ":entity",
     "../geometry:geometry_unittests",
-    "../playground",
+    "../playground:playground_test",
   ]
 }

--- a/impeller/entity/entity_playground.h
+++ b/impeller/entity/entity_playground.h
@@ -7,11 +7,11 @@
 #include "flutter/fml/macros.h"
 #include "impeller/entity/contents/content_context.h"
 #include "impeller/entity/entity.h"
-#include "impeller/playground/playground.h"
+#include "impeller/playground/playground_test.h"
 
 namespace impeller {
 
-class EntityPlayground : public Playground {
+class EntityPlayground : public PlaygroundTest {
  public:
   using EntityPlaygroundCallback =
       std::function<bool(ContentContext& context, RenderPass& pass)>;

--- a/impeller/playground/BUILD.gn
+++ b/impeller/playground/BUILD.gn
@@ -6,8 +6,6 @@ import("//flutter/impeller/tools/impeller.gni")
 import("//flutter/testing/testing.gni")
 
 impeller_component("playground") {
-  testonly = true
-
   sources = [
     "playground.cc",
     "playground.h",
@@ -45,7 +43,6 @@ impeller_component("playground") {
     "../fixtures:shader_fixtures",
     "../renderer",
     "imgui:imgui_impeller_backend",
-    "//flutter/testing",
     "//third_party/glfw",
     "//third_party/imgui:imgui_glfw",
   ]
@@ -58,6 +55,20 @@ impeller_component("playground") {
       "QuartzCore.framework",
     ]
   }
+}
+
+impeller_component("playground_test") {
+  testonly = true
+
+  sources = [
+    "playground_test.cc",
+    "playground_test.h",
+  ]
+
+  public_deps = [
+    ":playground",
+    "//flutter/testing",
+  ]
 }
 
 config("playground_config") {

--- a/impeller/playground/BUILD.gn
+++ b/impeller/playground/BUILD.gn
@@ -43,6 +43,7 @@ impeller_component("playground") {
     "../fixtures:shader_fixtures",
     "../renderer",
     "imgui:imgui_impeller_backend",
+    "//flutter/fml",
     "//third_party/glfw",
     "//third_party/imgui:imgui_glfw",
   ]

--- a/impeller/playground/imgui/BUILD.gn
+++ b/impeller/playground/imgui/BUILD.gn
@@ -12,9 +12,7 @@ impeller_shaders("imgui_shaders") {
   ]
 }
 
-source_set("imgui_impeller_backend") {
-  testonly = true
-
+impeller_component("imgui_impeller_backend") {
   public_deps = [
     ":imgui_shaders",
     "//third_party/imgui",

--- a/impeller/playground/playground.cc
+++ b/impeller/playground/playground.cc
@@ -75,10 +75,6 @@ Playground::Playground()
 
 Playground::~Playground() = default;
 
-PlaygroundBackend Playground::GetBackend() const {
-  return backend_;
-}
-
 std::shared_ptr<Context> Playground::GetContext() const {
   return renderer_ ? renderer_->GetContext() : nullptr;
 }

--- a/impeller/playground/playground.cc
+++ b/impeller/playground/playground.cc
@@ -14,7 +14,6 @@
 #include "third_party/glfw/include/GLFW/glfw3.h"
 
 #include "flutter/fml/paths.h"
-#include "flutter/testing/testing.h"
 #include "impeller/base/validation.h"
 #include "impeller/image/compressed_image.h"
 #include "impeller/playground/imgui/imgui_impl_impeller.h"
@@ -77,14 +76,14 @@ Playground::Playground()
 Playground::~Playground() = default;
 
 PlaygroundBackend Playground::GetBackend() const {
-  return GetParam();
+  return backend_;
 }
 
 std::shared_ptr<Context> Playground::GetContext() const {
   return renderer_ ? renderer_->GetContext() : nullptr;
 }
 
-static constexpr bool PlatformSupportsBackend(PlaygroundBackend backend) {
+bool Playground::SupportsBackend(PlaygroundBackend backend) {
   switch (backend) {
     case PlaygroundBackend::kMetal:
 #if IMPELLER_ENABLE_METAL
@@ -108,12 +107,10 @@ static constexpr bool PlatformSupportsBackend(PlaygroundBackend backend) {
   FML_UNREACHABLE();
 }
 
-void Playground::SetUp() {
-  if (!PlatformSupportsBackend(GetBackend())) {
-    GTEST_SKIP_("This backend is disabled or isn't supported on this platform");
-  }
+void Playground::SetupWindow(PlaygroundBackend backend) {
+  FML_CHECK(SupportsBackend(backend));
 
-  impl_ = PlaygroundImpl::Create(GetParam());
+  impl_ = PlaygroundImpl::Create(backend);
   if (!impl_) {
     return;
   }
@@ -128,7 +125,7 @@ void Playground::SetUp() {
   renderer_ = std::move(renderer);
 }
 
-void Playground::TearDown() {
+void Playground::TeardownWindow() {
   renderer_.reset();
   impl_.reset();
 }
@@ -141,13 +138,6 @@ static void PlaygroundKeyCallback(GLFWwindow* window,
   if ((key == GLFW_KEY_ESCAPE || key == GLFW_KEY_Q) && action == GLFW_RELEASE) {
     ::glfwSetWindowShouldClose(window, GLFW_TRUE);
   }
-}
-
-static std::string GetWindowTitle(const std::string& test_name) {
-  std::stringstream stream;
-  stream << "Impeller Playground for '" << test_name
-         << "' (Press ESC or 'q' to quit)";
-  return stream.str();
 }
 
 Point Playground::GetCursorPosition() const {
@@ -190,8 +180,7 @@ bool Playground::OpenPlaygroundHere(Renderer::RenderCallback render_callback) {
   if (!window) {
     return false;
   }
-  ::glfwSetWindowTitle(
-      window, GetWindowTitle(flutter::testing::GetCurrentTestName()).c_str());
+  ::glfwSetWindowTitle(window, GetWindowTitle().c_str());
   ::glfwSetWindowUserPointer(window, this);
   ::glfwSetWindowSizeCallback(
       window, [](GLFWwindow* window, int width, int height) -> void {
@@ -309,12 +298,12 @@ bool Playground::OpenPlaygroundHere(SinglePassCallback pass_callback) {
 
 std::optional<DecompressedImage> Playground::LoadFixtureImageRGBA(
     const char* fixture_name) const {
-  if (!renderer_) {
+  if (!renderer_ || fixture_name == nullptr) {
     return std::nullopt;
   }
 
-  auto compressed_image = CompressedImage::Create(
-      flutter::testing::OpenFixtureAsMapping(fixture_name));
+  auto compressed_image =
+      CompressedImage::Create(OpenAssetAsMapping(fixture_name));
   if (!compressed_image) {
     VALIDATION_LOG << "Could not create compressed image.";
     return std::nullopt;

--- a/impeller/playground/playground.h
+++ b/impeller/playground/playground.h
@@ -38,8 +38,6 @@ class Playground {
 
   void TeardownWindow();
 
-  PlaygroundBackend GetBackend() const;
-
   Point GetCursorPosition() const;
 
   ISize GetWindowSize() const;
@@ -76,7 +74,6 @@ class Playground {
 #endif  // IMPELLER_ENABLE_PLAYGROUND
 
   struct GLFWInitializer;
-  PlaygroundBackend backend_;
   std::unique_ptr<GLFWInitializer> glfw_initializer_;
   std::unique_ptr<PlaygroundImpl> impl_;
   std::unique_ptr<Renderer> renderer_;

--- a/impeller/playground/playground_test.cc
+++ b/impeller/playground/playground_test.cc
@@ -1,0 +1,44 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/playground/playground_test.h"
+
+namespace impeller {
+
+PlaygroundTest::PlaygroundTest() = default;
+
+PlaygroundTest::~PlaygroundTest() = default;
+
+void PlaygroundTest::SetUp() {
+  if (!Playground::SupportsBackend(GetParam())) {
+    GTEST_SKIP_("Playground doesn't support this backend type.");
+    return;
+  }
+
+  SetupWindow(GetParam());
+}
+
+void PlaygroundTest::TearDown() {
+  TeardownWindow();
+}
+
+// |Playground|
+std::unique_ptr<fml::Mapping> PlaygroundTest::OpenAssetAsMapping(
+    std::string asset_name) const {
+  return flutter::testing::OpenFixtureAsMapping(asset_name);
+}
+
+static std::string FormatWindowTitle(const std::string& test_name) {
+  std::stringstream stream;
+  stream << "Impeller Playground for '" << test_name
+         << "' (Press ESC or 'q' to quit)";
+  return stream.str();
+}
+
+// |Playground|
+std::string PlaygroundTest::GetWindowTitle() const {
+  return FormatWindowTitle(flutter::testing::GetCurrentTestName());
+}
+
+}  // namespace impeller

--- a/impeller/playground/playground_test.h
+++ b/impeller/playground/playground_test.h
@@ -1,0 +1,47 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#pragma once
+
+#include <memory>
+
+#include "flutter/fml/macros.h"
+#include "flutter/testing/testing.h"
+#include "impeller/playground/playground.h"
+
+namespace impeller {
+
+class PlaygroundTest : public Playground,
+                       public ::testing::TestWithParam<PlaygroundBackend> {
+ public:
+  PlaygroundTest();
+
+  virtual ~PlaygroundTest();
+
+  void SetUp() override;
+
+  void TearDown() override;
+
+  // |Playground|
+  std::unique_ptr<fml::Mapping> OpenAssetAsMapping(
+      std::string asset_name) const override;
+
+  // |Playground|
+  std::string GetWindowTitle() const override;
+
+ private:
+  FML_DISALLOW_COPY_AND_ASSIGN(PlaygroundTest);
+};
+
+#define INSTANTIATE_PLAYGROUND_SUITE(playground)                            \
+  INSTANTIATE_TEST_SUITE_P(                                                 \
+      Play, playground,                                                     \
+      ::testing::Values(PlaygroundBackend::kMetal,                          \
+                        PlaygroundBackend::kOpenGLES,                       \
+                        PlaygroundBackend::kVulkan),                        \
+      [](const ::testing::TestParamInfo<PlaygroundTest::ParamType>& info) { \
+        return PlaygroundBackendToString(info.param);                       \
+      });
+
+}  // namespace impeller

--- a/impeller/renderer/BUILD.gn
+++ b/impeller/renderer/BUILD.gn
@@ -94,7 +94,7 @@ impeller_component("renderer_unittests") {
   deps = [
     ":renderer",
     "../fixtures",
-    "../playground",
+    "../playground:playground_test",
     "//flutter/testing:testing_lib",
   ]
 }

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -381,7 +381,7 @@ TEST_P(RendererTest, CanRenderToTexture) {
 
 #if IMPELLER_ENABLE_METAL
 TEST_P(RendererTest, CanRenderInstanced) {
-  if (GetBackend() != PlaygroundBackend::kMetal) {
+  if (GetParam() != PlaygroundBackend::kMetal) {
     GTEST_SKIP_("Instancing is only supported on Metal.");
   }
   using VS = InstancedDrawVertexShader;

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -17,7 +17,7 @@
 #include "impeller/geometry/path_builder.h"
 #include "impeller/image/compressed_image.h"
 #include "impeller/image/decompressed_image.h"
-#include "impeller/playground/playground.h"
+#include "impeller/playground/playground_test.h"
 #include "impeller/renderer/command.h"
 #include "impeller/renderer/command_buffer.h"
 #include "impeller/renderer/formats.h"
@@ -35,7 +35,7 @@
 namespace impeller {
 namespace testing {
 
-using RendererTest = Playground;
+using RendererTest = PlaygroundTest;
 INSTANTIATE_PLAYGROUND_SUITE(RendererTest);
 
 TEST_P(RendererTest, CanCreateBoxPrimitive) {

--- a/impeller/runtime_stage/BUILD.gn
+++ b/impeller/runtime_stage/BUILD.gn
@@ -39,7 +39,7 @@ impeller_component("runtime_stage_unittests") {
   ]
   deps = [
     ":runtime_stage",
-    "../playground",
+    "../playground:playground_test",
     "//flutter/testing",
   ]
 }

--- a/impeller/runtime_stage/runtime_stage_playground.h
+++ b/impeller/runtime_stage/runtime_stage_playground.h
@@ -5,12 +5,12 @@
 #pragma once
 
 #include "flutter/fml/macros.h"
-#include "impeller/playground/playground.h"
+#include "impeller/playground/playground_test.h"
 #include "impeller/runtime_stage/runtime_stage.h"
 
 namespace impeller {
 
-class RuntimeStagePlayground : public Playground {
+class RuntimeStagePlayground : public PlaygroundTest {
  public:
   RuntimeStagePlayground();
 

--- a/impeller/runtime_stage/runtime_stage_unittests.cc
+++ b/impeller/runtime_stage/runtime_stage_unittests.cc
@@ -186,7 +186,7 @@ TEST(RuntimeStageTest, CanReadUniforms) {
 }
 
 TEST_P(RuntimeStageTest, CanRegisterStage) {
-  if (GetBackend() != PlaygroundBackend::kMetal) {
+  if (GetParam() != PlaygroundBackend::kMetal) {
     GTEST_SKIP_("Skipped: https://github.com/flutter/flutter/issues/105538");
   }
   auto fixture =
@@ -212,7 +212,7 @@ TEST_P(RuntimeStageTest, CanRegisterStage) {
 }
 
 TEST_P(RuntimeStageTest, CanCreatePipelineFromRuntimeStage) {
-  if (GetBackend() != PlaygroundBackend::kMetal) {
+  if (GetParam() != PlaygroundBackend::kMetal) {
     GTEST_SKIP_("Skipped: https://github.com/flutter/flutter/issues/105538");
   }
   auto stage = CreateStageFromFixture("ink_sparkle.frag.iplr");

--- a/impeller/typographer/BUILD.gn
+++ b/impeller/typographer/BUILD.gn
@@ -49,6 +49,6 @@ impeller_component("typographer_unittests") {
 
   deps = [
     ":typographer",
-    "../playground",
+    "../playground:playground_test",
   ]
 }

--- a/impeller/typographer/typographer_unittests.cc
+++ b/impeller/typographer/typographer_unittests.cc
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 #include "flutter/testing/testing.h"
-#include "impeller/playground/playground.h"
+#include "impeller/playground/playground_test.h"
 #include "impeller/typographer/backends/skia/text_frame_skia.h"
 #include "impeller/typographer/backends/skia/text_render_context_skia.h"
 #include "third_party/skia/include/core/SkTextBlob.h"
@@ -11,7 +11,7 @@
 namespace impeller {
 namespace testing {
 
-using TypographerTest = Playground;
+using TypographerTest = PlaygroundTest;
 INSTANTIATE_PLAYGROUND_SUITE(TypographerTest);
 
 TEST_P(TypographerTest, CanConvertTextBlob) {


### PR DESCRIPTION
Playgrounds are ideal for prototyping Impeller targets but they also assume that
the user is a Google Test. This separates playgrounds into a base library that
can be used outside of tests as well as a playground_test target that is
specifically used by Google Test cases.

No change in functionality.

Needs buildroot patch https://github.com/flutter/buildroot/pull/596