### PR TITLE
Fix Android embedding lint

### DIFF
--- a/shell/platform/android/io/flutter/app/FlutterFragmentActivity.java
+++ b/shell/platform/android/io/flutter/app/FlutterFragmentActivity.java
@@ -157,6 +157,7 @@ public class FlutterFragmentActivity extends FragmentActivity
 
   @Override
   public void onTrimMemory(int level) {
+    super.onTrimMemory(level);
     eventDelegate.onTrimMemory(level);
   }
 


### PR DESCRIPTION
We should delete this old embedding class, but fixing an urgent issue b/240230736 to unblock Android rolls inside Google
