### PR TITLE
Enable analysis for  all of dart:ui

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -29,6 +29,8 @@ analyzer:
     import_internal_library: ignore
     # Turned off until null-safe rollout is complete.
     unnecessary_null_comparison: ignore
+    # TODO(goderbauer): remove when https://github.com/dart-lang/sdk/issues/49563 is fixed.
+    ffi_native_unexpected_number_of_parameters: ignore
 
 linter:
   rules:

--- a/ci/analyze.sh
+++ b/ci/analyze.sh
@@ -30,7 +30,6 @@ function follow_links() (
 SCRIPT_DIR=$(follow_links "$(dirname -- "${BASH_SOURCE[0]}")")
 SRC_DIR="$(cd "$SCRIPT_DIR/../.."; pwd -P)"
 FLUTTER_DIR="$SRC_DIR/flutter"
-SKY_ENGINE_DIR="$SRC_DIR/out/host_debug_unopt/gen/dart-pkg/sky_engine"
 DART_BIN="$SRC_DIR/out/host_debug_unopt/dart-sdk/bin"
 DART="$DART_BIN/dart"
 
@@ -47,8 +46,7 @@ echo "Using dart from $DART_BIN"
 "$DART" --version
 echo ""
 
-(cd $SKY_ENGINE_DIR && "$DART" pub get --offline)
-"$DART" analyze "$SKY_ENGINE_DIR/lib/ui/ui.dart"
+"$DART" analyze "$FLUTTER_DIR/lib/ui"
 
 "$DART" analyze "$FLUTTER_DIR/lib/spirv"
 

--- a/lib/ui/geometry.dart
+++ b/lib/ui/geometry.dart
@@ -1720,13 +1720,13 @@ class RSTransform {
   /// The `translateX` and `translateY` parameters give the coordinate of the
   /// offset by which to translate.
   ///
-  /// This constructor computes the arguments of the [new RSTransform]
+  /// This constructor computes the arguments of the [RSTransform.new]
   /// constructor and then defers to that constructor to actually create the
   /// object. If many [RSTransform] objects are being created and there is a way
   /// to factor out the computations of the sine and cosine of the rotation
   /// (which are computed each time this constructor is called) and reuse them
   /// over multiple [RSTransform] objects, it may be more efficient to directly
-  /// use the more direct [new RSTransform] constructor instead.
+  /// use the more direct [RSTransform.new] constructor instead.
   factory RSTransform.fromComponents({
     required double rotation,
     required double scale,

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -3519,7 +3519,7 @@ class _ErodeImageFilter implements ImageFilter {
   }
 
   @override
-  int get hashCode => hashValues(radiusX, radiusY);
+  int get hashCode => Object.hash(radiusX, radiusY);
 }
 
 class _ComposeImageFilter implements ImageFilter {
@@ -4039,7 +4039,7 @@ class FragmentProgram extends NativeFieldWrapperClass1 {
   /// compiler. The constructed object should then be reused via the [shader]
   /// method to create [Shader] objects that can be used by [Shader.paint].
   static Future<FragmentProgram> fromAsset(String assetKey) {
-    FragmentProgram? program = _shaderRegistry[assetKey]?.target;
+    final FragmentProgram? program = _shaderRegistry[assetKey]?.target;
     if (program != null) {
       return Future<FragmentProgram>.value(program);
     }
@@ -4057,13 +4057,6 @@ class FragmentProgram extends NativeFieldWrapperClass1 {
   // cache.
   static Map<String, WeakReference<FragmentProgram>> _shaderRegistry =
       <String, WeakReference<FragmentProgram>>{};
-
-  FragmentProgram._() {
-    assert(
-      false,
-      'FragmentProgram should only be initialized via "fromAsset".',
-    );
-  }
 
   @pragma('vm:entry-point')
   FragmentProgram._fromAsset(String assetKey) {
@@ -4090,7 +4083,7 @@ class FragmentProgram extends NativeFieldWrapperClass1 {
       return;
     }
 
-    final result = program._initFromAsset(assetKey);
+    final String result = program._initFromAsset(assetKey);
     if (result.isNotEmpty) {
       throw result;
     }
@@ -4161,9 +4154,7 @@ class FragmentProgram extends NativeFieldWrapperClass1 {
     Float32List? floatUniforms,
     List<ImageShader>? samplerUniforms,
   }) {
-    if (floatUniforms == null) {
-      floatUniforms = Float32List(_uniformFloatCount);
-    }
+    floatUniforms ??= Float32List(_uniformFloatCount);
     if (floatUniforms.length != _uniformFloatCount) {
       throw ArgumentError(
         'floatUniforms size: ${floatUniforms.length} must match given shader '
@@ -4288,7 +4279,7 @@ class Vertices extends NativeFieldWrapperClass1 {
   }
 
   /// Creates a set of vertex data for use with [Canvas.drawVertices], directly
-  /// using the encoding methods of [new Vertices].
+  /// using the encoding methods of [Vertices.new].
   /// Note that this constructor uses raw typed data lists,
   /// so it runs faster than the [Vertices()] constructor
   /// because it doesn't require any conversion from Dart lists.
@@ -5051,8 +5042,8 @@ class Canvas extends NativeFieldWrapperClass1 {
   /// first.
   ///
   /// To align the text, set the `textAlign` on the [ParagraphStyle] object
-  /// passed to the [new ParagraphBuilder] constructor. For more details see
-  /// [TextAlign] and the discussion at [new ParagraphStyle].
+  /// passed to the [ParagraphBuilder.new] constructor. For more details see
+  /// [TextAlign] and the discussion at [ParagraphStyle.new].
   ///
   /// If the text is left aligned or justified, the left margin will be at the
   /// position specified by the `offset` argument's [Offset.dx] coordinate.
@@ -5123,7 +5114,7 @@ class Canvas extends NativeFieldWrapperClass1 {
   /// All parameters must not be null.
   ///
   /// See also:
-  ///   * [new Vertices], which creates a set of vertices to draw on the canvas.
+  ///   * [Vertices.new], which creates a set of vertices to draw on the canvas.
   ///   * [Vertices.raw], which creates the vertices using typed data lists
   ///     rather than unencoded lists.
   ///   * [paint], Image shaders can be used to draw images on a triangular mesh.

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -2384,7 +2384,7 @@ class ParagraphConstraints {
   /// follows).
   ///
   /// The width influences how ellipses are applied. See the discussion at
-  /// [new ParagraphStyle] for more details.
+  /// [ParagraphStyle.new] for more details.
   ///
   /// This width is also used to position glyphs according to the [TextAlign]
   /// alignment described in the [ParagraphStyle] used when building the
@@ -2717,7 +2717,7 @@ class Paragraph extends NativeFieldWrapperClass1 {
   /// constraint.
   ///
   /// See the discussion of the `maxLines` and `ellipsis` arguments at
-  /// [new ParagraphStyle].
+  /// [ParagraphStyle.new].
   @FfiNative<Bool Function(Pointer<Void>)>('Paragraph::didExceedMaxLines', isLeaf: true)
   external bool get didExceedMaxLines;
 
@@ -2886,7 +2886,7 @@ class Paragraph extends NativeFieldWrapperClass1 {
 ///
 /// To set the paragraph's alignment, truncation, and ellipsizing behavior, pass
 /// an appropriately-configured [ParagraphStyle] object to the
-/// [new ParagraphBuilder] constructor.
+/// [ParagraphBuilder.new] constructor.
 ///
 /// Then, call combinations of [pushStyle], [addText], and [pop] to add styled
 /// text to the object.
@@ -3164,6 +3164,7 @@ Future<void> loadFontFromList(Uint8List list, {String? fontFamily}) {
   return _futurize(
     (_Callback<void> callback) {
       _loadFontFromList(list, callback, fontFamily ?? '');
+      return null;
     }
   ).then((_) => _sendFontChangeMessage());
 }


### PR DESCRIPTION
Analysis for all of `dart:ui` was accidentally disabled about a year ago in https://github.com/flutter/engine/pull/28208. After that change, only `ui.dart` was analyzed (ignoring all other files that make up `dart:ui`) and it was analyzed with the default analysis options ignoring our custom `analysis_options.yaml`.

This change re-enables analysis for all of `dart:ui` using our custom `analysis_options.yaml` file and fixes the issues that have been introduced since then.