### PR TITLE
[gn] Mac entitlement config for font subset

### DIFF
--- a/tools/font-subset/BUILD.gn
+++ b/tools/font-subset/BUILD.gn
@@ -22,6 +22,10 @@ executable("_font-subset") {
       "CoreText.framework",
     ]
   }
+
+  metadata = {
+    font_subset_without_entitlement = [ "font-subset" ]
+  }
 }
 
 generated_file("_font-subset-license") {
@@ -38,6 +42,14 @@ generated_file("_font-subset-license") {
     "Source code for this tool: [flutter/engine/$source_path]($git_url/$source_path).",
     "License for this tool: [flutter/engine/sky/packages/sky_engine/LICENSE]($git_url/$license_path).",
   ]
+}
+
+generated_file("font_entitlement_config") {
+  outputs = [ "$target_gen_dir/font_subset_without_entitlements.txt" ]
+
+  data_keys = [ "font_subset_without_entitlement" ]
+
+  deps = [ ":_font-subset" ]
 }
 
 zip_bundle("font-subset") {
@@ -74,4 +86,13 @@ zip_bundle("font-subset") {
     ":_font-subset-license",
     "//flutter/tools/const_finder",
   ]
+  if (is_mac) {
+    deps += [ ":font_entitlement_config" ]
+    files += [
+      {
+        source = "$target_gen_dir/font_subset_without_entitlements.txt"
+        destination = "without_entitlements.txt"
+      },
+    ]
+  }
 }


### PR DESCRIPTION
This commit adds the Mac code sign entitlement configuration file for darwin-x64/font-subset.zip.