### PR TITLE
Support new package dependency in flutter_frontend_server

### DIFF
--- a/flutter_frontend_server/pubspec.yaml
+++ b/flutter_frontend_server/pubspec.yaml
@@ -105,5 +105,7 @@ dependency_overrides:
     path: ../../third_party/dart/pkg/vm
   vm_service:
     path: ../../third_party/dart/pkg/vm_service
+  vm_snapshot_analysis:
+    path: ../../third_party/dart/pkg/vm_snapshot_analysis
   yaml:
     path: ../../third_party/dart/third_party/pkg/yaml


### PR DESCRIPTION
Package dart2js_info added a dependency on vm_snapshot_analysis.
Both packages are inside the Dart SDK source checkout.

The relative path to the new package must be added to
dependency_overrides in the pubspec.yaml.

## Pre-launch Checklist

- [x ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x ] I signed the [CLA].
- [x ] All existing and new tests are passing.