### PR TITLE
upload the output of the DisplayList builder benchmarks

### DIFF
--- a/testing/benchmark/upload_metrics.sh
+++ b/testing/benchmark/upload_metrics.sh
@@ -44,3 +44,5 @@ cd "$SCRIPT_DIR"
   --json ../../../out/host_release/shell_benchmarks.json "$@"
 "$DART" --disable-dart-dev bin/parse_and_send.dart \
   --json ../../../out/host_release/ui_benchmarks.json "$@"
+"$DART" --disable-dart-dev bin/parse_and_send.dart \
+  --json ../../../out/host_release/display_list_builder_benchmarks.json "$@"


### PR DESCRIPTION
The benchmarks are generated by the generate script, but there was no line to upload them in the upload script.