### PR TITLE
Make analyzer hints and warnings fatal

### DIFF
--- a/ci/analyze.sh
+++ b/ci/analyze.sh
@@ -46,31 +46,31 @@ echo "Using dart from $DART_BIN"
 "$DART" --version
 echo ""
 
-"$DART" analyze "$FLUTTER_DIR/lib/ui"
+"$DART" analyze --fatal-infos --fatal-warnings "$FLUTTER_DIR/lib/ui"
 
-"$DART" analyze "$FLUTTER_DIR/lib/spirv"
+"$DART" analyze --fatal-infos --fatal-warnings "$FLUTTER_DIR/lib/spirv"
 
-"$DART" analyze "$FLUTTER_DIR/ci"
+"$DART" analyze --fatal-infos --fatal-warnings "$FLUTTER_DIR/ci"
 
-"$DART" analyze "$FLUTTER_DIR/flutter_frontend_server"
+"$DART" analyze --fatal-infos --fatal-warnings "$FLUTTER_DIR/flutter_frontend_server"
 
-"$DART" analyze "$FLUTTER_DIR/tools/licenses"
+"$DART" analyze --fatal-infos --fatal-warnings "$FLUTTER_DIR/tools/licenses"
 
-"$DART" analyze "$FLUTTER_DIR/testing/litetest"
+"$DART" analyze --fatal-infos --fatal-warnings "$FLUTTER_DIR/testing/litetest"
 
-"$DART" analyze "$FLUTTER_DIR/testing/benchmark"
+"$DART" analyze --fatal-infos --fatal-warnings "$FLUTTER_DIR/testing/benchmark"
 
-"$DART" analyze "$FLUTTER_DIR/testing/smoke_test_failure"
+"$DART" analyze --fatal-infos --fatal-warnings "$FLUTTER_DIR/testing/smoke_test_failure"
 
-"$DART" analyze "$FLUTTER_DIR/testing/dart"
+"$DART" analyze --fatal-infos --fatal-warnings "$FLUTTER_DIR/testing/dart"
 
-"$DART" analyze "$FLUTTER_DIR/testing/scenario_app"
+"$DART" analyze --fatal-infos --fatal-warnings "$FLUTTER_DIR/testing/scenario_app"
 
-"$DART" analyze "$FLUTTER_DIR/testing/symbols"
+"$DART" analyze --fatal-infos --fatal-warnings "$FLUTTER_DIR/testing/symbols"
 
-"$DART" analyze "$FLUTTER_DIR/tools/githooks"
+"$DART" analyze --fatal-infos --fatal-warnings "$FLUTTER_DIR/tools/githooks"
 
-"$DART" analyze "$FLUTTER_DIR/tools/clang_tidy"
+"$DART" analyze --fatal-infos --fatal-warnings "$FLUTTER_DIR/tools/clang_tidy"
 
 echo ""
 

--- a/testing/scenario_app/lib/src/platform_view.dart
+++ b/testing/scenario_app/lib/src/platform_view.dart
@@ -701,8 +701,13 @@ class PlatformViewForTouchIOSScenario extends Scenario
 
   late void Function() _nextFrame;
 
+  /// Whether gestures should be accepted or rejected.
   final bool accept;
+
+  /// The platform view identifier.
   final int id;
+
+  /// Whether touches should be rejected until the gesture ends.
   final bool rejectUntilTouchesEnded;
 
   @override


### PR DESCRIPTION
This matches how we treat them in the flutter/flutter repo.

The engine repo was hints and warnings free with one minor exception that's fixed in this PR.