### PR TITLE
Enable avoid_returning_null & native_function_body_in_non_sdk_code

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -16,7 +16,6 @@ analyzer:
     missing_required_param: warning
     # treat missing returns as a warning (not a hint)
     missing_return: warning
-    native_function_body_in_non_sdk_code: ignore # DIFFERENT FROM FLUTTER/FLUTTER
     # allow having TODO comments in the code
     todo: ignore
     # allow dart:ui to import dart:_internal
@@ -65,7 +64,7 @@ linter:
     - avoid_relative_lib_imports
     - avoid_renaming_method_parameters
     - avoid_return_types_on_setters
-    # - avoid_returning_null # still violated by some pre-nnbd code that we haven't yet migrated
+    - avoid_returning_null
     - avoid_returning_null_for_future
     - avoid_returning_null_for_void
     # - avoid_returning_this # there are enough valid reasons to return `this` that this lint ends up with too many false positives


### PR DESCRIPTION
The code base is clean and these warnings can be turned on now.