### PR TITLE
[gn] mac entitlement config when dart sdk is non prebuilt 

### DIFF
--- a/build/archives/BUILD.gn
+++ b/build/archives/BUILD.gn
@@ -172,17 +172,24 @@ if (build_engine_artifacts && !flutter_prebuilt_dart_sdk) {
   zip_bundle_from_file("dart_sdk_archive") {
     deps = [ "//third_party/dart:create_sdk" ]
     output = "dart-sdk-$full_target_platform_name.zip"
-    if (is_mac) {
-      # Mac artifacts sometimes use mac and sometimes darwin. Standardizing the
-      # names will require changes in the list of artifacts the tool is downloading.
-      output = "dart-sdk-darwin-$target_cpu.zip"
-    }
     files = [
       {
         source = rebase_path("$root_build_dir/dart-sdk")
         destination = "dart-sdk"
       },
     ]
+    if (is_mac) {
+      # Mac artifacts sometimes use mac and sometimes darwin. Standardizing the
+      # names will require changes in the list of artifacts the tool is downloading.
+      output = "dart-sdk-darwin-$target_cpu.zip"
+      deps += [ ":dart_sdk_entitlement_config" ]
+      files += [
+        {
+          source = "$target_gen_dir/dart_sdk_entitlements.txt"
+          destination = "entitlements.txt"
+        },
+      ]
+    }
   }
 }
 

--- a/build/archives/BUILD.gn
+++ b/build/archives/BUILD.gn
@@ -179,8 +179,6 @@ if (build_engine_artifacts && !flutter_prebuilt_dart_sdk) {
       },
     ]
     if (is_mac) {
-      # Mac artifacts sometimes use mac and sometimes darwin. Standardizing the
-      # names will require changes in the list of artifacts the tool is downloading.
       output = "dart-sdk-darwin-$target_cpu.zip"
       deps += [ ":dart_sdk_entitlement_config" ]
       files += [


### PR DESCRIPTION
a followup from https://github.com/flutter/engine/pull/34605, to add mac entitlement config when dart sdk is not prebuilt.