### PR TITLE
[fuchsia] Convert Gfx PlatformView to use modern TouchSource API, take 2

### DIFF
--- a/shell/platform/fuchsia/flutter/engine.cc
+++ b/shell/platform/fuchsia/flutter/engine.cc
@@ -166,8 +166,8 @@ void Engine::Initialize(
   } else {
     gfx_protocols.set_view_focuser(focuser.NewRequest());
     gfx_protocols.set_view_ref_focused(view_ref_focused.NewRequest());
-    // TODO(fxbug.dev/85125): Enable TouchSource for GFX.
-    // gfx_protocols.set_touch_source(touch_source.NewRequest());
+    gfx_protocols.set_touch_source(touch_source.NewRequest());
+    // GFX used only on products without a mouse.
   }
   scenic->CreateSessionT(std::move(gfx_protocols), [] {});
 

--- a/shell/platform/fuchsia/flutter/platform_view.cc
+++ b/shell/platform/fuchsia/flutter/platform_view.cc
@@ -109,33 +109,31 @@ PlatformView::PlatformView(
   });
 
   // Begin watching for pointer events.
-  if (is_flatland) {  // TODO(fxbug.dev/85125): make unconditional
-    pointer_delegate_->WatchLoop([weak = weak_factory_.GetWeakPtr()](
-                                     std::vector<flutter::PointerData> events) {
-      if (!weak) {
-        FML_LOG(WARNING) << "PlatformView use-after-free attempted. Ignoring.";
-        return;
-      }
+  pointer_delegate_->WatchLoop([weak = weak_factory_.GetWeakPtr()](
+                                   std::vector<flutter::PointerData> events) {
+    if (!weak) {
+      FML_LOG(WARNING) << "PlatformView use-after-free attempted. Ignoring.";
+      return;
+    }
 
-      if (events.size() == 0) {
-        return;  // No work, bounce out.
-      }
+    if (events.empty()) {
+      return;  // No work, bounce out.
+    }
 
-      // If pixel ratio hasn't been set, use a default value of 1.
-      const float pixel_ratio = weak->view_pixel_ratio_.value_or(1.f);
-      auto packet = std::make_unique<flutter::PointerDataPacket>(events.size());
-      for (size_t i = 0; i < events.size(); ++i) {
-        auto& event = events[i];
-        // Translate logical to physical coordinates, as per
-        // flutter::PointerData contract. Done here because pixel ratio comes
-        // from the graphics API.
-        event.physical_x = event.physical_x * pixel_ratio;
-        event.physical_y = event.physical_y * pixel_ratio;
-        packet->SetPointerData(i, event);
-      }
-      weak->DispatchPointerDataPacket(std::move(packet));
-    });
-  }
+    // If pixel ratio hasn't been set, use a default value of 1.
+    const float pixel_ratio = weak->view_pixel_ratio_.value_or(1.f);
+    auto packet = std::make_unique<flutter::PointerDataPacket>(events.size());
+    for (size_t i = 0; i < events.size(); ++i) {
+      auto& event = events[i];
+      // Translate logical to physical coordinates, as per
+      // flutter::PointerData contract. Done here because pixel ratio comes
+      // from the graphics API.
+      event.physical_x = event.physical_x * pixel_ratio;
+      event.physical_y = event.physical_y * pixel_ratio;
+      packet->SetPointerData(i, event);
+    }
+    weak->DispatchPointerDataPacket(std::move(packet));
+  });
 
   // Configure the pointer injector delegate.
   pointer_injector_delegate_ = std::make_unique<PointerInjectorDelegate>(

--- a/shell/platform/fuchsia/flutter/platform_view_unittest.cc
+++ b/shell/platform/fuchsia/flutter/platform_view_unittest.cc
@@ -1394,8 +1394,7 @@ TEST_F(PlatformViewTests, OnShaderWarmup) {
   EXPECT_EQ(expected_result_string, response->result_string);
 }
 
-// TODO(fxbug.dev/85125): Enable when GFX converts to TouchSource.
-TEST_F(PlatformViewTests, DISABLED_TouchSourceLogicalToPhysicalConversion) {
+TEST_F(PlatformViewTests, TouchSourceLogicalToPhysicalConversion) {
   constexpr std::array<std::array<float, 2>, 2> kRect = {{{0, 0}, {20, 20}}};
   constexpr std::array<float, 9> kIdentity = {1, 0, 0, 0, 1, 0, 0, 0, 1};
   constexpr fuchsia::ui::pointer::TouchInteractionId kIxnOne = {

--- a/shell/platform/fuchsia/flutter/pointer_delegate.cc
+++ b/shell/platform/fuchsia/flutter/pointer_delegate.cc
@@ -447,7 +447,9 @@ void PointerDelegate::WatchLoop(
   // Start watching both channels.
   touch_source_->Watch(std::move(touch_responses_), /*copy*/ touch_responder_);
   touch_responses_.clear();
-  mouse_source_->Watch(/*copy*/ mouse_responder_);
+  if (mouse_source_) {
+    mouse_source_->Watch(/*copy*/ mouse_responder_);
+  }
 }
 
 }  // namespace flutter_runner


### PR DESCRIPTION
Original PR: #32877

Revert of #32877: commit 1965c92ea417e1d4114b5bfea03b93e3532cb1f2 (#33471)

*This* patch: Revert of #33471

fxbug.dev/85125

This PR switches the GfxPlatformView code to use the TouchSource/MouseSource API. After this PR, both GFX and Flatland will receive touch and mouse events over the new APIs, instead of the legacy GFX SessionListener API.

https://github.com/flutter/flutter/issues/102412

=Fuchsia testing=
$ fx test //src/ui/tests
(This is what broke the roll last time)

=Flutter testing=
Test re-enabled: PlatformViewTests.TouchSourceLogicalToPhysicalConversion
$ fx shell run fuchsia-pkg://fuchsia.com/flutter_runner_tests#meta/flutter_runner_tests.cmx

=Product testing=
This PR has been manually validated on a nelson device (today, July 29) running stable production code, with the following UI cases:

- ordinary usage of the System UI
- with child view (YouTube), bring up settings (Sys UI)
- with a partial-screen child view (Duo) interrupting another full-screen child view (YT), and both are still responsive to touch
- with and without the new injection2 code path for child views

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
