### PR TITLE
[Window, Keyboard] Fix repeat events of modifier keys

### DIFF
--- a/shell/platform/windows/keyboard_key_embedder_handler.cc
+++ b/shell/platform/windows/keyboard_key_embedder_handler.cc
@@ -186,6 +186,7 @@ void KeyboardKeyEmbedderHandler::KeyboardHookImpl(
 
   const bool is_event_down = action == WM_KEYDOWN || action == WM_SYSKEYDOWN;
 
+  bool event_key_can_be_repeat = true;
   UpdateLastSeenCritialKey(key, physical_key, sequence_logical_key);
   // Synchronize the toggled states of critical keys (such as whether CapsLocks
   // is enabled). Toggled states can only be changed upon a down event, so if
@@ -197,14 +198,14 @@ void KeyboardKeyEmbedderHandler::KeyboardHookImpl(
   // updated to the true state, while the critical keys whose toggled state have
   // been changed will be pressed regardless of their true pressed state.
   // Updating the pressed state will be done by SynchronizeCritialPressedStates.
-  SynchronizeCritialToggledStates(key, is_event_down);
+  SynchronizeCritialToggledStates(key, is_event_down, &event_key_can_be_repeat);
   // Synchronize the pressed states of critical keys (such as whether CapsLocks
   // is pressed).
   //
   // After this function, all critical keys except for the target key will have
   // their toggled state and pressed state matched with their true states. The
   // target key's pressed state will be updated immediately after this.
-  SynchronizeCritialPressedStates(key, physical_key, is_event_down);
+  SynchronizeCritialPressedStates(key, physical_key, is_event_down, event_key_can_be_repeat);
 
   // The resulting event's `type`.
   FlutterKeyEventType type;
@@ -340,7 +341,8 @@ void KeyboardKeyEmbedderHandler::UpdateLastSeenCritialKey(
 
 void KeyboardKeyEmbedderHandler::SynchronizeCritialToggledStates(
     int event_virtual_key,
-    bool is_event_down) {
+    bool is_event_down,
+    bool* event_key_can_be_repeat) {
   //    NowState ---------------->  PreEventState --------------> TrueState
   //              Synchronization                      Event
   for (auto& kv : critical_keys_) {
@@ -364,6 +366,7 @@ void KeyboardKeyEmbedderHandler::SynchronizeCritialToggledStates(
       // Pressed   0          1          0         1
       // Toggled   0          1          1         0
       const bool true_toggled = get_key_state_(virtual_key) & kStateMaskToggled;
+      const bool true_pressed = get_key_state_(virtual_key) & kStateMaskPressed;
       bool pre_event_toggled = true_toggled;
       // Check if the main event's key is the key being checked. If it's the
       // non-repeat down event, toggle the state.
@@ -385,6 +388,7 @@ void KeyboardKeyEmbedderHandler::SynchronizeCritialToggledStates(
                                         key_info.physical_key,
                                         key_info.logical_key, empty_character),
                   nullptr, nullptr);
+        *event_key_can_be_repeat = false;
       }
       key_info.toggled_on = true_toggled;
     }
@@ -394,7 +398,8 @@ void KeyboardKeyEmbedderHandler::SynchronizeCritialToggledStates(
 void KeyboardKeyEmbedderHandler::SynchronizeCritialPressedStates(
     int event_virtual_key,
     int event_physical_key,
-    bool is_event_down) {
+    bool is_event_down,
+    bool event_key_can_be_repeat) {
   // During an incoming event, there might be a synthesized Flutter event for
   // each key of each pressing goal, followed by an eventual main Flutter
   // event.
@@ -424,8 +429,17 @@ void KeyboardKeyEmbedderHandler::SynchronizeCritialPressedStates(
       if (is_event_down) {
         // For down events, this key is the event key if they have the same
         // virtual key, because virtual key represents "functionality."
+        //
+        // In that case, normally Flutter should synthesize nothing since the
+        // resulting event can be a down or a repeat depending on the current
+        // state. However, in certain cases (when Flutter has just synchronized
+        // the key's toggling state) the event must not be a repeat event.
         if (virtual_key == event_virtual_key) {
-          pre_event_pressed = false;
+          if (event_key_can_be_repeat) {
+            continue;
+          } else {
+            pre_event_pressed = false;
+          }
         }
       } else {
         // For up events, this key is the event key if they have the same

--- a/shell/platform/windows/keyboard_key_embedder_handler.cc
+++ b/shell/platform/windows/keyboard_key_embedder_handler.cc
@@ -430,9 +430,10 @@ void KeyboardKeyEmbedderHandler::SynchronizeCritialPressedStates(
         // virtual key, because virtual key represents "functionality."
         //
         // In that case, normally Flutter should synthesize nothing since the
-        // resulting event can be a down or a repeat depending on the current
-        // state. However, in certain cases (when Flutter has just synchronized
-        // the key's toggling state) the event must not be a repeat event.
+        // resulting event can adapt to the current state by flexing between a
+        // down and a repeat event. However, in certain cases (when Flutter has
+        // just synchronized the key's toggling state) the event must not be a
+        // repeat event.
         if (virtual_key == event_virtual_key) {
           if (event_key_can_be_repeat) {
             continue;

--- a/shell/platform/windows/keyboard_key_embedder_handler.cc
+++ b/shell/platform/windows/keyboard_key_embedder_handler.cc
@@ -366,7 +366,6 @@ void KeyboardKeyEmbedderHandler::SynchronizeCritialToggledStates(
       // Pressed   0          1          0         1
       // Toggled   0          1          1         0
       const bool true_toggled = get_key_state_(virtual_key) & kStateMaskToggled;
-      const bool true_pressed = get_key_state_(virtual_key) & kStateMaskPressed;
       bool pre_event_toggled = true_toggled;
       // Check if the main event's key is the key being checked. If it's the
       // non-repeat down event, toggle the state.

--- a/shell/platform/windows/keyboard_key_embedder_handler.cc
+++ b/shell/platform/windows/keyboard_key_embedder_handler.cc
@@ -431,8 +431,8 @@ void KeyboardKeyEmbedderHandler::SynchronizeCritialPressedStates(
         // virtual key, because virtual key represents "functionality."
         //
         // In that case, normally Flutter should synthesize nothing since the
-        // resulting event can adapt to the current state by flexing between a
-        // down and a repeat event. However, in certain cases (when Flutter has
+        // resulting event can adapt to the current state by dispatching either
+        // a down or a repeat event. However, in certain cases (when Flutter has
         // just synchronized the key's toggling state) the event must not be a
         // repeat event.
         if (virtual_key == event_virtual_key) {

--- a/shell/platform/windows/keyboard_key_embedder_handler.cc
+++ b/shell/platform/windows/keyboard_key_embedder_handler.cc
@@ -205,7 +205,8 @@ void KeyboardKeyEmbedderHandler::KeyboardHookImpl(
   // After this function, all critical keys except for the target key will have
   // their toggled state and pressed state matched with their true states. The
   // target key's pressed state will be updated immediately after this.
-  SynchronizeCritialPressedStates(key, physical_key, is_event_down, event_key_can_be_repeat);
+  SynchronizeCritialPressedStates(key, physical_key, is_event_down,
+                                  event_key_can_be_repeat);
 
   // The resulting event's `type`.
   FlutterKeyEventType type;

--- a/shell/platform/windows/keyboard_key_embedder_handler.h
+++ b/shell/platform/windows/keyboard_key_embedder_handler.h
@@ -115,12 +115,14 @@ class KeyboardKeyEmbedderHandler
   // Check each key's state from |get_key_state_| and synthesize events
   // if their toggling states have been desynchronized.
   void SynchronizeCritialToggledStates(int event_virtual_key,
-                                       bool is_event_down);
+                                       bool is_event_down,
+                                       bool* event_key_can_be_repeat);
   // Check each key's state from |get_key_state_| and synthesize events
   // if their pressing states have been desynchronized.
   void SynchronizeCritialPressedStates(int event_virtual_key,
                                        int event_physical_key,
-                                       bool is_event_down);
+                                       bool is_event_down,
+                                       bool event_key_can_be_repeat);
 
   // Wraps perform_send_event_ with state tracking. Use this instead of
   // |perform_send_event_| to send events to the framework.

--- a/shell/platform/windows/keyboard_unittests.cc
+++ b/shell/platform/windows/keyboard_unittests.cc
@@ -696,6 +696,18 @@ TEST(KeyboardTest, ShiftLeftUnhandled) {
   clear_key_calls();
   EXPECT_EQ(tester.RedispatchedMessageCountAndClear(), 1);
 
+  // Hold ShiftLeft
+  tester.InjectKeyboardChanges(std::vector<KeyboardChange>{
+      WmKeyDownInfo{VK_SHIFT, kScanCodeShiftLeft, kNotExtended, kWasDown}.Build(
+          kWmResultZero)});
+
+  EXPECT_EQ(key_calls.size(), 1);
+  EXPECT_CALL_IS_EVENT(key_calls[0], kFlutterKeyEventTypeRepeat,
+                       kPhysicalShiftLeft, kLogicalShiftLeft, "",
+                       kNotSynthesized);
+  clear_key_calls();
+  EXPECT_EQ(tester.RedispatchedMessageCountAndClear(), 1);
+
   // Release ShiftLeft
   tester.InjectKeyboardChanges(std::vector<KeyboardChange>{
       KeyStateChange{VK_LSHIFT, false, true},


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/108646 .

The synchronization logic revised in https://github.com/flutter/engine/pull/33746 always synchronizes the pre-event state of a modifier key to be "released". This is problematic since it disallows repeat events. With this PR, pressing synchronization no longer handles down events of the event key except in one scenario where the event key's toggling state has just been synchronized. However, this exception is not trivial and requires communication between the two synchronization function. The approach adopted by this PR is a little ugly, but it works. Maybe one day we will hate it and find a better way.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
