### PR TITLE
Remove unnecessary exceptions from analysis_options.yaml

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -9,14 +9,6 @@ analyzer:
     strict-casts: true
     strict-raw-types: true
   errors:
-    # treat missing required parameters as a warning (not a hint)
-    missing_required_param: warning
-    # treat missing returns as a warning (not a hint)
-    missing_return: warning
-    # allow having TODO comments in the code
-    todo: ignore
-    # allow dart:ui to import dart:_internal
-    import_internal_library: ignore # DIFFERENT FROM FLUTTER/FLUTTER
     # allow self-reference to deprecated members (we do this because otherwise we have
     # to annotate every member in every test, assert, etc, when we deprecate something)
     deprecated_member_use_from_same_package: ignore
@@ -150,7 +142,7 @@ linter:
     # - prefer_double_quotes # opposite of prefer_single_quotes
     - prefer_equal_for_default_values
     # - prefer_expression_function_bodies # conflicts with https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#consider-using--for-short-functions-and-methods
-    # - prefer_final_fields # DIFFERENT FROM FLUTTER/FLUTTER (we do weird things with private fields, especially on the PlatformDispatcher object)
+    - prefer_final_fields
     - prefer_final_in_for_each
     - prefer_final_locals
     # - prefer_final_parameters # we should enable this one day when it can be auto-fixed (https://github.com/dart-lang/linter/issues/3104), see also parameter_assignments
@@ -185,7 +177,7 @@ linter:
     # - sized_box_shrink_expand # not yet tested
     - slash_for_doc_comments
     - sort_child_properties_last
-    # - sort_constructors_first # DIFFERENT FROM FLUTTER/FLUTTER (we have private fake constructors)
+    - sort_constructors_first
     # - sort_pub_dependencies # prevents separating pinned transitive dependencies
     - sort_unnamed_constructors_first
     - test_types_in_equals

--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -240,7 +240,7 @@ class SceneBuilder extends NativeFieldWrapperClass1 {
   //
   // The key is the layer used. The value is the description of what the layer
   // is used for, e.g. "pushOpacity" or "addRetained".
-  Map<EngineLayer, String> _usedLayers = <EngineLayer, String>{};
+  final Map<EngineLayer, String> _usedLayers = <EngineLayer, String>{};
 
   // In debug mode checks that the `layer` is only used once in a given scene.
   bool _debugCheckUsedOnce(EngineLayer layer, String usage) {

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -1090,6 +1090,14 @@ enum Clip {
 /// Most APIs on [Canvas] take a [Paint] object to describe the style
 /// to use for that operation.
 class Paint {
+  /// Constructs an empty [Paint] object with all fields initialized to
+  /// their defaults.
+  Paint() {
+    if (enableDithering) {
+      _dither = true;
+    }
+  }
+
   // Paint objects are encoded in two buffers:
   //
   // * _data is binary data in four-byte fields, each of which is either a
@@ -1149,14 +1157,6 @@ class Paint {
   static const int _kColorFilterIndex = 1;
   static const int _kImageFilterIndex = 2;
   static const int _kObjectCount = 3; // Must be one larger than the largest index.
-
-  /// Constructs an empty [Paint] object with all fields initialized to
-  /// their defaults.
-  Paint() {
-    if (enableDithering) {
-      _dither = true;
-    }
-  }
 
   /// Whether to apply anti-aliasing to lines and images drawn on the
   /// canvas.
@@ -1878,7 +1878,7 @@ class _Image extends NativeFieldWrapperClass1 {
   @FfiNative<Void Function(Pointer<Void>)>('Image::dispose')
   external void _dispose();
 
-  Set<Image> _handles = <Image>{};
+  final Set<Image> _handles = <Image>{};
 
   @override
   String toString() => '[$width\u00D7$height]';
@@ -2350,9 +2350,6 @@ class Path extends NativeFieldWrapperClass1 {
   @pragma('vm:entry-point')
   Path() { _constructor(); }
 
-  @FfiNative<Void Function(Handle)>('Path::Create')
-  external void _constructor();
-
   /// Avoids creating a new native backing for the path for methods that will
   /// create it later, such as [Path.from], [shift] and [transform].
   Path._();
@@ -2366,6 +2363,9 @@ class Path extends NativeFieldWrapperClass1 {
     source._clone(clonedPath);
     return clonedPath;
   }
+
+  @FfiNative<Void Function(Handle)>('Path::Create')
+  external void _constructor();
 
   @FfiNative<Void Function(Pointer<Void>, Handle)>('Path::clone')
   external void _clone(Path outPath);
@@ -2848,7 +2848,7 @@ class PathMetricIterator implements Iterator<PathMetric> {
   PathMetricIterator._(this._pathMeasure) : assert(_pathMeasure != null);
 
   PathMetric? _pathMetric;
-  _PathMeasure _pathMeasure;
+  final _PathMeasure _pathMeasure;
 
   @override
   PathMetric get current {
@@ -3576,49 +3576,39 @@ class _ComposeImageFilter implements ImageFilter {
 /// ImageFilter, because we want ImageFilter to be efficiently comparable, so that
 /// widgets can check for ImageFilter equality to avoid repainting.
 class _ImageFilter extends NativeFieldWrapperClass1 {
-  @FfiNative<Void Function(Handle)>('ImageFilter::Create')
-  external void _constructor();
-
   /// Creates an image filter that applies a Gaussian blur.
   _ImageFilter.blur(_GaussianBlurImageFilter filter)
-    : assert(filter != null),
-      creator = filter { // ignore: prefer_initializing_formals
+      : assert(filter != null),
+        creator = filter { // ignore: prefer_initializing_formals
     _constructor();
     _initBlur(filter.sigmaX, filter.sigmaY, filter.tileMode.index);
   }
 
-  @FfiNative<Void Function(Pointer<Void>, Double, Double, Int32)>('ImageFilter::initBlur', isLeaf: true)
-  external void _initBlur(double sigmaX, double sigmaY, int tileMode);
-
   /// Creates an image filter that dilates each input pixel's channel values
   /// to the max value within the given radii along the x and y axes.
   _ImageFilter.dilate(_DilateImageFilter filter)
-    : assert(filter != null),
-      creator = filter {    // ignore: prefer_initializing_formals
+      : assert(filter != null),
+        creator = filter {    // ignore: prefer_initializing_formals
     _constructor();
     _initDilate(filter.radiusX, filter.radiusY);
   }
-  @FfiNative<Void Function(Pointer<Void>, Double, Double)>('ImageFilter::initDilate', isLeaf: true)
-  external void _initDilate(double radiusX, double radiusY);
 
   /// Create a filter that erodes each input pixel's channel values
   /// to the minimum channel value within the given radii along the x and y axes.
   _ImageFilter.erode(_ErodeImageFilter filter)
-    : assert(filter != null),
-      creator = filter {    // ignore: prefer_initializing_formals
+      : assert(filter != null),
+        creator = filter {    // ignore: prefer_initializing_formals
     _constructor();
     _initErode(filter.radiusX, filter.radiusY);
   }
-  @FfiNative<Void Function(Pointer<Void>, Double, Double)>('ImageFilter::initErode', isLeaf: true)
-  external void _initErode(double radiusX, double radiusY);
 
   /// Creates an image filter that applies a matrix transformation.
   ///
   /// For example, applying a positive scale matrix (see [Matrix4.diagonal3])
   /// when used with [BackdropFilter] would magnify the background image.
   _ImageFilter.matrix(_MatrixImageFilter filter)
-    : assert(filter != null),
-      creator = filter { // ignore: prefer_initializing_formals
+      : assert(filter != null),
+        creator = filter { // ignore: prefer_initializing_formals
     if (filter.data.length != 16) {
       throw ArgumentError('"matrix4" must have 16 entries.');
     }
@@ -3626,30 +3616,42 @@ class _ImageFilter extends NativeFieldWrapperClass1 {
     _initMatrix(filter.data, filter.filterQuality.index);
   }
 
-  @FfiNative<Void Function(Pointer<Void>, Handle, Int32)>('ImageFilter::initMatrix')
-  external void _initMatrix(Float64List matrix4, int filterQuality);
-
   /// Converts a color filter to an image filter.
   _ImageFilter.fromColorFilter(ColorFilter filter)
-    : assert(filter != null),
-      creator = filter { // ignore: prefer_initializing_formals
+      : assert(filter != null),
+        creator = filter { // ignore: prefer_initializing_formals
     _constructor();
     final _ColorFilter? nativeFilter = filter._toNativeColorFilter();
     _initColorFilter(nativeFilter);
   }
 
-  @FfiNative<Void Function(Pointer<Void>, Pointer<Void>)>('ImageFilter::initColorFilter')
-  external void _initColorFilter(_ColorFilter? colorFilter);
-
   /// Composes `_innerFilter` with `_outerFilter`.
   _ImageFilter.composed(_ComposeImageFilter filter)
-    : assert(filter != null),
-      creator = filter { // ignore: prefer_initializing_formals
+      : assert(filter != null),
+        creator = filter { // ignore: prefer_initializing_formals
     _constructor();
     final _ImageFilter nativeFilterInner = filter.innerFilter._toNativeImageFilter();
     final _ImageFilter nativeFilterOuter = filter.outerFilter._toNativeImageFilter();
     _initComposed(nativeFilterOuter, nativeFilterInner);
   }
+
+  @FfiNative<Void Function(Handle)>('ImageFilter::Create')
+  external void _constructor();
+
+  @FfiNative<Void Function(Pointer<Void>, Double, Double, Int32)>('ImageFilter::initBlur', isLeaf: true)
+  external void _initBlur(double sigmaX, double sigmaY, int tileMode);
+
+  @FfiNative<Void Function(Pointer<Void>, Double, Double)>('ImageFilter::initDilate', isLeaf: true)
+  external void _initDilate(double radiusX, double radiusY);
+
+  @FfiNative<Void Function(Pointer<Void>, Double, Double)>('ImageFilter::initErode', isLeaf: true)
+  external void _initErode(double radiusX, double radiusY);
+
+  @FfiNative<Void Function(Pointer<Void>, Handle, Int32)>('ImageFilter::initMatrix')
+  external void _initMatrix(Float64List matrix4, int filterQuality);
+
+  @FfiNative<Void Function(Pointer<Void>, Pointer<Void>)>('ImageFilter::initColorFilter')
+  external void _initColorFilter(_ColorFilter? colorFilter);
 
   @FfiNative<Void Function(Pointer<Void>, Pointer<Void>, Pointer<Void>)>('ImageFilter::initComposeFilter')
   external void _initComposed(_ImageFilter outerFilter, _ImageFilter innerFilter);
@@ -3803,9 +3805,6 @@ Float32List _encodeTwoPoints(Offset pointA, Offset pointB) {
 ///  * [Gradient](https://api.flutter.dev/flutter/painting/Gradient-class.html), the class in the [painting] library.
 ///
 class Gradient extends Shader {
-  @FfiNative<Void Function(Handle)>('Gradient::Create')
-  external void _constructor();
-
   /// Creates a linear gradient from `from` to `to`.
   ///
   /// If `colorStops` is provided, `colorStops[i]` is a number from 0.0 to 1.0
@@ -3849,9 +3848,6 @@ class Gradient extends Shader {
     _initLinear(endPointsBuffer, colorsBuffer, colorStopsBuffer, tileMode.index, matrix4);
   }
 
-  @FfiNative<Void Function(Pointer<Void>, Handle, Handle, Handle, Int32, Handle)>('Gradient::initLinear')
-  external void _initLinear(Float32List endPoints, Int32List colors, Float32List? colorStops, int tileMode, Float64List? matrix4);
-
   /// Creates a radial gradient centered at `center` that ends at `radius`
   /// distance from the center.
   ///
@@ -3883,19 +3879,19 @@ class Gradient extends Shader {
   /// provided and not equal to `center`, at least one of the two offsets must
   /// not be equal to [Offset.zero].
   Gradient.radial(
-    Offset center,
-    double radius,
-    List<Color> colors, [
-    List<double>? colorStops,
-    TileMode tileMode = TileMode.clamp,
-    Float64List? matrix4,
-    Offset? focal,
-    double focalRadius = 0.0
-  ]) : assert(_offsetIsValid(center)),
-       assert(colors != null),
-       assert(tileMode != null),
-       assert(matrix4 == null || _matrix4IsValid(matrix4)),
-       super._() {
+      Offset center,
+      double radius,
+      List<Color> colors, [
+        List<double>? colorStops,
+        TileMode tileMode = TileMode.clamp,
+        Float64List? matrix4,
+        Offset? focal,
+        double focalRadius = 0.0
+      ]) : assert(_offsetIsValid(center)),
+        assert(colors != null),
+        assert(tileMode != null),
+        assert(matrix4 == null || _matrix4IsValid(matrix4)),
+        super._() {
     _validateColorStops(colors, colorStops);
     final Int32List colorsBuffer = _encodeColorList(colors);
     final Float32List? colorStopsBuffer = colorStops == null ? null : Float32List.fromList(colorStops);
@@ -3911,30 +3907,6 @@ class Gradient extends Shader {
       _initConical(focal.dx, focal.dy, focalRadius, center.dx, center.dy, radius, colorsBuffer, colorStopsBuffer, tileMode.index, matrix4);
     }
   }
-
-  @FfiNative<Void Function(Pointer<Void>, Double, Double, Double, Handle, Handle, Int32, Handle)>('Gradient::initRadial')
-  external void _initRadial(
-      double centerX,
-      double centerY,
-      double radius,
-      Int32List colors,
-      Float32List? colorStops,
-      int tileMode,
-      Float64List? matrix4);
-
-  @FfiNative<Void Function(Pointer<Void>, Double, Double, Double, Double, Double, Double, Handle, Handle, Int32, Handle)>(
-      'Gradient::initTwoPointConical')
-  external void _initConical(
-      double startX,
-      double startY,
-      double startRadius,
-      double endX,
-      double endY,
-      double endRadius,
-      Int32List colors,
-      Float32List? colorStops,
-      int tileMode,
-      Float64List? matrix4);
 
   /// Creates a sweep gradient centered at `center` that starts at `startAngle`
   /// and ends at `endAngle`.
@@ -3964,27 +3936,57 @@ class Gradient extends Shader {
   /// specified 4x4 matrix relative to the local coordinate system. `matrix4` must
   /// be a column-major matrix packed into a list of 16 values.
   Gradient.sweep(
-    Offset center,
-    List<Color> colors, [
-    List<double>? colorStops,
-    TileMode tileMode = TileMode.clamp,
-    double startAngle = 0.0,
-    double endAngle = math.pi * 2,
-    Float64List? matrix4,
-  ]) : assert(_offsetIsValid(center)),
-       assert(colors != null),
-       assert(tileMode != null),
-       assert(startAngle != null),
-       assert(endAngle != null),
-       assert(startAngle < endAngle),
-       assert(matrix4 == null || _matrix4IsValid(matrix4)),
-       super._() {
+      Offset center,
+      List<Color> colors, [
+        List<double>? colorStops,
+        TileMode tileMode = TileMode.clamp,
+        double startAngle = 0.0,
+        double endAngle = math.pi * 2,
+        Float64List? matrix4,
+      ]) : assert(_offsetIsValid(center)),
+        assert(colors != null),
+        assert(tileMode != null),
+        assert(startAngle != null),
+        assert(endAngle != null),
+        assert(startAngle < endAngle),
+        assert(matrix4 == null || _matrix4IsValid(matrix4)),
+        super._() {
     _validateColorStops(colors, colorStops);
     final Int32List colorsBuffer = _encodeColorList(colors);
     final Float32List? colorStopsBuffer = colorStops == null ? null : Float32List.fromList(colorStops);
     _constructor();
     _initSweep(center.dx, center.dy, colorsBuffer, colorStopsBuffer, tileMode.index, startAngle, endAngle, matrix4);
   }
+
+  @FfiNative<Void Function(Handle)>('Gradient::Create')
+  external void _constructor();
+
+  @FfiNative<Void Function(Pointer<Void>, Handle, Handle, Handle, Int32, Handle)>('Gradient::initLinear')
+  external void _initLinear(Float32List endPoints, Int32List colors, Float32List? colorStops, int tileMode, Float64List? matrix4);
+
+  @FfiNative<Void Function(Pointer<Void>, Double, Double, Double, Handle, Handle, Int32, Handle)>('Gradient::initRadial')
+  external void _initRadial(
+      double centerX,
+      double centerY,
+      double radius,
+      Int32List colors,
+      Float32List? colorStops,
+      int tileMode,
+      Float64List? matrix4);
+
+  @FfiNative<Void Function(Pointer<Void>, Double, Double, Double, Double, Double, Double, Handle, Handle, Int32, Handle)>(
+      'Gradient::initTwoPointConical')
+  external void _initConical(
+      double startX,
+      double startY,
+      double startRadius,
+      double endX,
+      double endY,
+      double endRadius,
+      Int32List colors,
+      Float32List? colorStops,
+      int tileMode,
+      Float64List? matrix4);
 
   @FfiNative<Void Function(Pointer<Void>, Double, Double, Handle, Handle, Int32, Double, Double, Handle)>('Gradient::initSweep')
   external void _initSweep(
@@ -4054,6 +4056,15 @@ class ImageShader extends Shader {
 /// [A current specification of valid SPIR-V is here.](https://github.com/flutter/engine/blob/main/lib/spirv/README.md)
 ///
 class FragmentProgram extends NativeFieldWrapperClass1 {
+  @pragma('vm:entry-point')
+  FragmentProgram._fromAsset(String assetKey) {
+    _constructor();
+    final String result = _initFromAsset(assetKey);
+    if (result.isNotEmpty) {
+      throw result; // ignore: only_throw_errors
+    }
+  }
+
   // TODO(zra): Document custom shaders on the website and add a link to it
   // here. https://github.com/flutter/flutter/issues/107929.
   /// Creates a fragment program from the asset with key [assetKey].
@@ -4078,17 +4089,8 @@ class FragmentProgram extends NativeFieldWrapperClass1 {
   // so that the case where an in-use program is requested again can be fast,
   // but programs that are no longer referenced are not retained because of the
   // cache.
-  static Map<String, WeakReference<FragmentProgram>> _shaderRegistry =
+  static final Map<String, WeakReference<FragmentProgram>> _shaderRegistry =
       <String, WeakReference<FragmentProgram>>{};
-
-  @pragma('vm:entry-point')
-  FragmentProgram._fromAsset(String assetKey) {
-    _constructor();
-    final String result = _initFromAsset(assetKey);
-    if (result.isNotEmpty) {
-      throw result; // ignore: only_throw_errors
-    }
-  }
 
   static void _reinitializeShader(String assetKey) {
     // If a shader for the assent isn't already registered, then there's no
@@ -6010,17 +6012,6 @@ class ImmutableBuffer extends NativeFieldWrapperClass1 {
 class ImageDescriptor extends NativeFieldWrapperClass1 {
   ImageDescriptor._();
 
-  /// Creates an image descriptor from encoded data in a supported format.
-  static Future<ImageDescriptor> encoded(ImmutableBuffer buffer) {
-    final ImageDescriptor descriptor = ImageDescriptor._();
-    return _futurize((_Callback<void> callback) {
-      return descriptor._initEncoded(buffer, callback);
-    }).then((_) => descriptor);
-  }
-
-  @FfiNative<Handle Function(Handle, Pointer<Void>, Handle)>('ImageDescriptor::initEncoded')
-  external String? _initEncoded(ImmutableBuffer buffer, _Callback<void> callback);
-
   /// Creates an image descriptor from raw image pixels.
   ///
   /// The `pixels` parameter is the pixel data. They are packed in bytes in the
@@ -6032,18 +6023,29 @@ class ImageDescriptor extends NativeFieldWrapperClass1 {
   /// by the number of bytes per pixel in the provided `format`.
   // Not async because there's no expensive work to do here.
   ImageDescriptor.raw(
-    ImmutableBuffer buffer, {
-    required int width,
-    required int height,
-    int? rowBytes,
-    required PixelFormat pixelFormat,
-  }) {
+      ImmutableBuffer buffer, {
+        required int width,
+        required int height,
+        int? rowBytes,
+        required PixelFormat pixelFormat,
+      }) {
     _width = width;
     _height = height;
     // We only support 4 byte pixel formats in the PixelFormat enum.
     _bytesPerPixel = 4;
     _initRaw(this, buffer, width, height, rowBytes ?? -1, pixelFormat.index);
   }
+
+  /// Creates an image descriptor from encoded data in a supported format.
+  static Future<ImageDescriptor> encoded(ImmutableBuffer buffer) {
+    final ImageDescriptor descriptor = ImageDescriptor._();
+    return _futurize((_Callback<void> callback) {
+      return descriptor._initEncoded(buffer, callback);
+    }).then((_) => descriptor);
+  }
+
+  @FfiNative<Handle Function(Handle, Pointer<Void>, Handle)>('ImageDescriptor::initEncoded')
+  external String? _initEncoded(ImmutableBuffer buffer, _Callback<void> callback);
 
   @FfiNative<Void Function(Handle, Handle, Int32, Int32, Int32, Int32)>('ImageDescriptor::initRaw')
   external static void _initRaw(ImageDescriptor outDescriptor, ImmutableBuffer buffer, int width, int height, int rowBytes, int pixelFormat);

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -3578,8 +3578,8 @@ class _ComposeImageFilter implements ImageFilter {
 class _ImageFilter extends NativeFieldWrapperClass1 {
   /// Creates an image filter that applies a Gaussian blur.
   _ImageFilter.blur(_GaussianBlurImageFilter filter)
-      : assert(filter != null),
-        creator = filter { // ignore: prefer_initializing_formals
+    : assert(filter != null),
+      creator = filter { // ignore: prefer_initializing_formals
     _constructor();
     _initBlur(filter.sigmaX, filter.sigmaY, filter.tileMode.index);
   }
@@ -3587,8 +3587,8 @@ class _ImageFilter extends NativeFieldWrapperClass1 {
   /// Creates an image filter that dilates each input pixel's channel values
   /// to the max value within the given radii along the x and y axes.
   _ImageFilter.dilate(_DilateImageFilter filter)
-      : assert(filter != null),
-        creator = filter {    // ignore: prefer_initializing_formals
+    : assert(filter != null),
+      creator = filter {    // ignore: prefer_initializing_formals
     _constructor();
     _initDilate(filter.radiusX, filter.radiusY);
   }
@@ -3596,8 +3596,8 @@ class _ImageFilter extends NativeFieldWrapperClass1 {
   /// Create a filter that erodes each input pixel's channel values
   /// to the minimum channel value within the given radii along the x and y axes.
   _ImageFilter.erode(_ErodeImageFilter filter)
-      : assert(filter != null),
-        creator = filter {    // ignore: prefer_initializing_formals
+    : assert(filter != null),
+      creator = filter {    // ignore: prefer_initializing_formals
     _constructor();
     _initErode(filter.radiusX, filter.radiusY);
   }
@@ -3607,8 +3607,8 @@ class _ImageFilter extends NativeFieldWrapperClass1 {
   /// For example, applying a positive scale matrix (see [Matrix4.diagonal3])
   /// when used with [BackdropFilter] would magnify the background image.
   _ImageFilter.matrix(_MatrixImageFilter filter)
-      : assert(filter != null),
-        creator = filter { // ignore: prefer_initializing_formals
+    : assert(filter != null),
+      creator = filter { // ignore: prefer_initializing_formals
     if (filter.data.length != 16) {
       throw ArgumentError('"matrix4" must have 16 entries.');
     }
@@ -3618,8 +3618,8 @@ class _ImageFilter extends NativeFieldWrapperClass1 {
 
   /// Converts a color filter to an image filter.
   _ImageFilter.fromColorFilter(ColorFilter filter)
-      : assert(filter != null),
-        creator = filter { // ignore: prefer_initializing_formals
+    : assert(filter != null),
+      creator = filter { // ignore: prefer_initializing_formals
     _constructor();
     final _ColorFilter? nativeFilter = filter._toNativeColorFilter();
     _initColorFilter(nativeFilter);
@@ -3627,8 +3627,8 @@ class _ImageFilter extends NativeFieldWrapperClass1 {
 
   /// Composes `_innerFilter` with `_outerFilter`.
   _ImageFilter.composed(_ComposeImageFilter filter)
-      : assert(filter != null),
-        creator = filter { // ignore: prefer_initializing_formals
+    : assert(filter != null),
+      creator = filter { // ignore: prefer_initializing_formals
     _constructor();
     final _ImageFilter nativeFilterInner = filter.innerFilter._toNativeImageFilter();
     final _ImageFilter nativeFilterOuter = filter.outerFilter._toNativeImageFilter();
@@ -3879,19 +3879,19 @@ class Gradient extends Shader {
   /// provided and not equal to `center`, at least one of the two offsets must
   /// not be equal to [Offset.zero].
   Gradient.radial(
-      Offset center,
-      double radius,
-      List<Color> colors, [
-        List<double>? colorStops,
-        TileMode tileMode = TileMode.clamp,
-        Float64List? matrix4,
-        Offset? focal,
-        double focalRadius = 0.0
-      ]) : assert(_offsetIsValid(center)),
-        assert(colors != null),
-        assert(tileMode != null),
-        assert(matrix4 == null || _matrix4IsValid(matrix4)),
-        super._() {
+    Offset center,
+    double radius,
+    List<Color> colors, [
+    List<double>? colorStops,
+    TileMode tileMode = TileMode.clamp,
+    Float64List? matrix4,
+    Offset? focal,
+    double focalRadius = 0.0
+  ]) : assert(_offsetIsValid(center)),
+       assert(colors != null),
+       assert(tileMode != null),
+       assert(matrix4 == null || _matrix4IsValid(matrix4)),
+       super._() {
     _validateColorStops(colors, colorStops);
     final Int32List colorsBuffer = _encodeColorList(colors);
     final Float32List? colorStopsBuffer = colorStops == null ? null : Float32List.fromList(colorStops);
@@ -3936,21 +3936,21 @@ class Gradient extends Shader {
   /// specified 4x4 matrix relative to the local coordinate system. `matrix4` must
   /// be a column-major matrix packed into a list of 16 values.
   Gradient.sweep(
-      Offset center,
-      List<Color> colors, [
-        List<double>? colorStops,
-        TileMode tileMode = TileMode.clamp,
-        double startAngle = 0.0,
-        double endAngle = math.pi * 2,
-        Float64List? matrix4,
-      ]) : assert(_offsetIsValid(center)),
-        assert(colors != null),
-        assert(tileMode != null),
-        assert(startAngle != null),
-        assert(endAngle != null),
-        assert(startAngle < endAngle),
-        assert(matrix4 == null || _matrix4IsValid(matrix4)),
-        super._() {
+    Offset center,
+    List<Color> colors, [
+    List<double>? colorStops,
+    TileMode tileMode = TileMode.clamp,
+    double startAngle = 0.0,
+    double endAngle = math.pi * 2,
+    Float64List? matrix4,
+  ]) : assert(_offsetIsValid(center)),
+       assert(colors != null),
+       assert(tileMode != null),
+       assert(startAngle != null),
+       assert(endAngle != null),
+       assert(startAngle < endAngle),
+       assert(matrix4 == null || _matrix4IsValid(matrix4)),
+       super._() {
     _validateColorStops(colors, colorStops);
     final Int32List colorsBuffer = _encodeColorList(colors);
     final Float32List? colorStopsBuffer = colorStops == null ? null : Float32List.fromList(colorStops);
@@ -6023,12 +6023,12 @@ class ImageDescriptor extends NativeFieldWrapperClass1 {
   /// by the number of bytes per pixel in the provided `format`.
   // Not async because there's no expensive work to do here.
   ImageDescriptor.raw(
-      ImmutableBuffer buffer, {
-        required int width,
-        required int height,
-        int? rowBytes,
-        required PixelFormat pixelFormat,
-      }) {
+    ImmutableBuffer buffer, {
+    required int width,
+    required int height,
+    int? rowBytes,
+    required PixelFormat pixelFormat,
+  }) {
     _width = width;
     _height = height;
     // We only support 4 byte pixel formats in the PixelFormat enum.

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -141,10 +141,10 @@ class PlatformDispatcher {
   ///
   /// If any of their configurations change, [onMetricsChanged] will be called.
   Iterable<FlutterView> get views => _views.values;
-  Map<Object, FlutterView> _views = <Object, FlutterView>{};
+  final Map<Object, FlutterView> _views = <Object, FlutterView>{};
 
   // A map of opaque platform view identifiers to view configurations.
-  Map<Object, ViewConfiguration> _viewConfigurations = <Object, ViewConfiguration>{};
+  final Map<Object, ViewConfiguration> _viewConfigurations = <Object, ViewConfiguration>{};
 
   /// A callback that is invoked whenever the [ViewConfiguration] of any of the
   /// [views] changes.
@@ -1454,8 +1454,6 @@ class FrameTiming {
     ]);
   }
 
-  static final int _dataLength = FramePhase.values.length + _FrameTimingInfo.values.length;
-
   /// Construct [FrameTiming] with raw timestamps in microseconds.
   ///
   /// List [timestamps] must have the same number of elements as
@@ -1463,8 +1461,9 @@ class FrameTiming {
   ///
   /// This constructor is usually only called by the Flutter engine, or a test.
   /// To get the [FrameTiming] of your app, see [PlatformDispatcher.onReportTimings].
-  FrameTiming._(this._data)
-      : assert(_data.length == _dataLength);
+  FrameTiming._(this._data) : assert(_data.length == _dataLength);
+
+  static final int _dataLength = FramePhase.values.length + _FrameTimingInfo.values.length;
 
   /// This is a raw timestamp in microseconds from some epoch. The epoch in all
   /// [FrameTiming] is the same, but it may not match [DateTime]'s epoch.

--- a/lib/ui/plugins.dart
+++ b/lib/ui/plugins.dart
@@ -45,9 +45,9 @@ class PluginUtilities {
   // extended directly.
   factory PluginUtilities._() => throw UnsupportedError('Namespace');
 
-  static Map<Function, CallbackHandle?> _forwardCache =
+  static final Map<Function, CallbackHandle?> _forwardCache =
       <Function, CallbackHandle?>{};
-  static Map<CallbackHandle, Function?> _backwardCache =
+  static final Map<CallbackHandle, Function?> _backwardCache =
       <CallbackHandle, Function?>{};
 
   /// Get a handle to a named top-level or static callback function which can

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -2976,7 +2976,7 @@ class ParagraphBuilder extends NativeFieldWrapperClass1 {
 
   /// The scales of the placeholders in the paragraph.
   List<double> get placeholderScales => _placeholderScales;
-  List<double> _placeholderScales = <double>[];
+  final List<double> _placeholderScales = <double>[];
 
   final TextLeadingDistribution _defaultLeadingDistribution;
   /// Applies the given style to the added text until [pop] is called.

--- a/lib/web_ui/analysis_options.yaml
+++ b/lib/web_ui/analysis_options.yaml
@@ -15,5 +15,6 @@ linter:
     no_default_cases: false
     prefer_relative_imports: false
     public_member_api_docs: false
+    sort_constructors_first: false
     unawaited_futures: true
     use_setters_to_change_properties: false

--- a/lib/web_ui/analysis_options.yaml
+++ b/lib/web_ui/analysis_options.yaml
@@ -15,6 +15,5 @@ linter:
     no_default_cases: false
     prefer_relative_imports: false
     public_member_api_docs: false
-    sort_constructors_first: false
     unawaited_futures: true
     use_setters_to_change_properties: false

--- a/lib/web_ui/dev/browser_process.dart
+++ b/lib/web_ui/dev/browser_process.dart
@@ -10,25 +10,6 @@ import 'package:stack_trace/stack_trace.dart';
 import 'package:typed_data/typed_buffers.dart';
 
 class BrowserProcess {
-  /// The underlying process.
-  ///
-  /// This will fire once the process has started successfully.
-  Future<Process> get _process => _processCompleter.future;
-  final Completer<Process> _processCompleter = Completer<Process>();
-
-  /// Whether [close] has been called.
-  bool _closed = false;
-
-  /// A future that completes when the browser exits.
-  ///
-  /// If there's a problem starting or running the browser, this will complete
-  /// with an error.
-  Future<void> get onExit => _onExitCompleter.future;
-  final Completer<void> _onExitCompleter = Completer<void>();
-
-  /// Standard IO streams for the underlying browser process.
-  final List<StreamSubscription<void>> _ioSubscriptions = <StreamSubscription<void>>[];
-
   /// Creates a new browser.
   ///
   /// Clients pass in [startBrowser], which asynchronously returns the browser
@@ -102,6 +83,25 @@ class BrowserProcess {
       );
     });
   }
+
+  /// The underlying process.
+  ///
+  /// This will fire once the process has started successfully.
+  Future<Process> get _process => _processCompleter.future;
+  final Completer<Process> _processCompleter = Completer<Process>();
+
+  /// Whether [close] has been called.
+  bool _closed = false;
+
+  /// A future that completes when the browser exits.
+  ///
+  /// If there's a problem starting or running the browser, this will complete
+  /// with an error.
+  Future<void> get onExit => _onExitCompleter.future;
+  final Completer<void> _onExitCompleter = Completer<void>();
+
+  /// Standard IO streams for the underlying browser process.
+  final List<StreamSubscription<void>> _ioSubscriptions = <StreamSubscription<void>>[];
 
   /// Kills the browser process.
   ///

--- a/lib/web_ui/dev/chrome.dart
+++ b/lib/web_ui/dev/chrome.dart
@@ -58,11 +58,6 @@ class ChromeEnvironment implements BrowserEnvironment {
 ///
 /// Any errors starting or running the process are reported through [onExit].
 class Chrome extends Browser {
-  final BrowserProcess _process;
-
-  @override
-  final Future<Uri> remoteDebuggerUrl;
-
   /// Starts a new instance of Chrome open to the given [url], which may be a
   /// [Uri] or a [String].
   factory Chrome(Uri url, BrowserInstallation installation, {bool debug = false}) {
@@ -121,6 +116,11 @@ class Chrome extends Browser {
   }
 
   Chrome._(this._process, this.remoteDebuggerUrl);
+
+  final BrowserProcess _process;
+
+  @override
+  final Future<Uri> remoteDebuggerUrl;
 
   @override
   Future<void> get onExit => _process.onExit;

--- a/lib/web_ui/dev/chrome_installer.dart
+++ b/lib/web_ui/dev/chrome_installer.dart
@@ -100,16 +100,16 @@ class ChromeInstaller {
     );
   }
 
-  static Future<ChromeInstaller> latest() async {
-    final String latestVersion = await fetchLatestChromeVersion();
-    return ChromeInstaller(version: latestVersion);
-  }
-
   ChromeInstaller._({
     required this.version,
     required this.chromeInstallationDir,
     required this.versionDir,
   });
+
+  static Future<ChromeInstaller> latest() async {
+    final String latestVersion = await fetchLatestChromeVersion();
+    return ChromeInstaller(version: latestVersion);
+  }
 
   /// Chrome version managed by this installer.
   final String version;

--- a/lib/web_ui/dev/edge.dart
+++ b/lib/web_ui/dev/edge.dart
@@ -46,8 +46,6 @@ class EdgeEnvironment implements BrowserEnvironment {
 ///
 /// Any errors starting or running the process are reported through [onExit].
 class Edge extends Browser {
-  final BrowserProcess _process;
-
   /// Starts a new instance of Safari open to the given [url], which may be a
   /// [Uri] or a [String].
   factory Edge(Uri url) {
@@ -74,6 +72,8 @@ class Edge extends Browser {
   }
 
   Edge._(this._process);
+
+  final BrowserProcess _process;
 
   @override
   Future<void> get onExit => _process.onExit;

--- a/lib/web_ui/dev/edge_installation.dart
+++ b/lib/web_ui/dev/edge_installation.dart
@@ -70,6 +70,8 @@ Future<BrowserInstallation> getEdgeInstallation(
 ///
 /// See: https://github.com/MicrosoftEdge/edge-launcher
 class EdgeLauncher {
+  EdgeLauncher();
+
   /// Path to the directory that contains `MicrosoftEdgeLauncher.exe`.
   io.Directory get launcherInstallationDir => io.Directory(
         path.join(environment.webUiDartToolDir.path, 'microsoftedgelauncher',
@@ -89,8 +91,6 @@ class EdgeLauncher {
   /// Only useful in Windows, hence not added to [PlatformBinding].
   String get windowsEdgeLauncherDownloadUrl =>
       'https://github.com/MicrosoftEdge/edge-launcher/releases/download/$version/MicrosoftEdgeLauncher.exe';
-
-  EdgeLauncher();
 
   /// Install the launcher if it does not exist in this system.
   Future<void> install() async {

--- a/lib/web_ui/dev/firefox.dart
+++ b/lib/web_ui/dev/firefox.dart
@@ -54,11 +54,6 @@ class FirefoxEnvironment implements BrowserEnvironment {
 ///
 /// Any errors starting or running the process are reported through [onExit].
 class Firefox extends Browser {
-  final BrowserProcess _process;
-
-  @override
-  final Future<Uri> remoteDebuggerUrl;
-
   /// Starts a new instance of Firefox open to the given [url], which may be a
   /// [Uri] or a [String].
   factory Firefox(Uri url, FirefoxEnvironment firefoxEnvironment, {bool debug = false}) {
@@ -115,6 +110,11 @@ user_pref("dom.max_script_run_time", 0);
   }
 
   Firefox._(this._process, this.remoteDebuggerUrl);
+
+  final BrowserProcess _process;
+
+  @override
+  final Future<Uri> remoteDebuggerUrl;
 
   @override
   Future<void> get onExit => _process.onExit;

--- a/lib/web_ui/dev/firefox_installer.dart
+++ b/lib/web_ui/dev/firefox_installer.dart
@@ -91,18 +91,18 @@ class FirefoxInstaller {
     );
   }
 
+  FirefoxInstaller._({
+    required this.version,
+    required this.firefoxInstallationDir,
+    required this.versionDir,
+  });
+
   static Future<FirefoxInstaller> latest() async {
     final String latestVersion = io.Platform.isLinux
         ? await fetchLatestFirefoxVersionLinux()
         : await fetchLatestFirefoxVersionMacOS();
     return FirefoxInstaller(version: latestVersion);
   }
-
-  FirefoxInstaller._({
-    required this.version,
-    required this.firefoxInstallationDir,
-    required this.versionDir,
-  });
 
   /// Firefox version managed by this installer.
   final String version;

--- a/lib/web_ui/dev/safari_ios.dart
+++ b/lib/web_ui/dev/safari_ios.dart
@@ -22,11 +22,11 @@ import 'utils.dart';
 ///
 /// This is used to properly take screenshots of the browser.
 class SafariScreenInfo {
+  SafariScreenInfo(this.heightOfHeader, this.heightOfFooter, this.scaleFactor);
+
   final int heightOfHeader;
   final int heightOfFooter;
   final double scaleFactor;
-
-  SafariScreenInfo(this.heightOfHeader, this.heightOfFooter, this.scaleFactor);
 }
 
 /// Provides an environment for the mobile variant of Safari running in an iOS
@@ -78,8 +78,6 @@ class SafariIosEnvironment implements BrowserEnvironment {
 ///
 /// Any errors starting or running the process are reported through [onExit].
 class SafariIos extends Browser {
-  final BrowserProcess _process;
-  final SafariScreenInfo _screenInfo;
 
   /// Starts a new instance of Safari open to the given [url], which may be a
   /// [Uri].
@@ -101,6 +99,8 @@ class SafariIos extends Browser {
   }
 
   SafariIos._(this._process, this._screenInfo);
+  final BrowserProcess _process;
+  final SafariScreenInfo _screenInfo;
 
   @override
   Future<void> get onExit => _process.onExit;

--- a/lib/web_ui/dev/test_platform.dart
+++ b/lib/web_ui/dev/test_platform.dart
@@ -629,7 +629,6 @@ class OneOffHandler {
 /// This is in charge of telling the browser which test suites to load and
 /// converting its responses into [Suite] objects.
 class BrowserManager {
-
   /// Creates a new BrowserManager that communicates with the browser over
   /// [webSocket].
   BrowserManager._(this.packageConfig, this._browser, this._browserEnvironment,
@@ -670,6 +669,7 @@ class BrowserManager {
         (dynamic message) => _onMessage(message as Map<dynamic, dynamic>),
         onDone: close);
   }
+
   final PackageConfig packageConfig;
 
   /// The browser instance that this is connected to via [_channel].
@@ -954,9 +954,9 @@ class BrowserManager {
 ///
 /// All methods forward directly to [BrowserManager].
 class _BrowserEnvironment implements Environment {
-
   _BrowserEnvironment(this._manager, this.observatoryUrl,
       this.remoteDebuggerUrl, this.onRestart);
+
   final BrowserManager _manager;
 
   @override

--- a/lib/web_ui/dev/test_platform.dart
+++ b/lib/web_ui/dev/test_platform.dart
@@ -43,6 +43,57 @@ import 'environment.dart' as env;
 
 /// Custom test platform that serves web engine unit tests.
 class BrowserPlatform extends PlatformPlugin {
+  BrowserPlatform._({
+    required this.browserEnvironment,
+    required this.server,
+    required this.isDebug,
+    required this.doUpdateScreenshotGoldens,
+    required this.packageConfig,
+    required this.skiaClient,
+    required this.overridePathToCanvasKit,
+  }) {
+    // The cascade of request handlers.
+    final shelf.Cascade cascade = shelf.Cascade()
+        // The web socket that carries the test channels for running tests and
+        // reporting restuls. See [_browserManagerFor] and [BrowserManager.start]
+        // for details on how the channels are established.
+        .add(_webSocketHandler.handler)
+
+        // Serves /packages/* requests; fetches files and sources from
+        // pubspec dependencies.
+        //
+        // Includes:
+        //  * Requests for Dart sources from source maps
+        //  * Assets that are part of the engine sources, such as Ahem.ttf
+        .add(_packageUrlHandler)
+        .add(_canvasKitOverrideHandler)
+
+        // Serves files from the web_ui/build/ directory at the root (/) URL path.
+        .add(buildDirectoryHandler)
+        .add(_testImageListingHandler)
+
+        // Serves the initial HTML for the test.
+        .add(_testBootstrapHandler)
+
+        // Serves files from the root of web_ui.
+        //
+        // This is needed because sourcemaps refer to local files, i.e. those
+        // that don't come from package dependencies, relative to web_ui/.
+        //
+        // Examples of URLs that this handles:
+        //  * /test/alarm_clock_test.dart
+        //  * /lib/src/engine/alarm_clock.dart
+        .add(createStaticHandler(env.environment.webUiRootDir.path))
+
+        // Serves absolute package URLs (i.e. not /packages/* but /Users/user/*/hosted/pub.dartlang.org/*).
+        // This handler goes last, after all more specific handlers failed to handle the request.
+        .add(_createAbsolutePackageUrlHandler())
+        .add(_screenshotHandler)
+        .add(_fileNotFoundCatcher);
+
+    server.mount(cascade.handler);
+  }
+
   /// Starts the server.
   ///
   /// [browserEnvironment] provides the browser environment to run the test.
@@ -104,57 +155,6 @@ class BrowserPlatform extends PlatformPlugin {
   final SkiaGoldClient? skiaClient;
 
   final String? overridePathToCanvasKit;
-
-  BrowserPlatform._({
-    required this.browserEnvironment,
-    required this.server,
-    required this.isDebug,
-    required this.doUpdateScreenshotGoldens,
-    required this.packageConfig,
-    required this.skiaClient,
-    required this.overridePathToCanvasKit,
-  }) {
-    // The cascade of request handlers.
-    final shelf.Cascade cascade = shelf.Cascade()
-        // The web socket that carries the test channels for running tests and
-        // reporting restuls. See [_browserManagerFor] and [BrowserManager.start]
-        // for details on how the channels are established.
-        .add(_webSocketHandler.handler)
-
-        // Serves /packages/* requests; fetches files and sources from
-        // pubspec dependencies.
-        //
-        // Includes:
-        //  * Requests for Dart sources from source maps
-        //  * Assets that are part of the engine sources, such as Ahem.ttf
-        .add(_packageUrlHandler)
-        .add(_canvasKitOverrideHandler)
-
-        // Serves files from the web_ui/build/ directory at the root (/) URL path.
-        .add(buildDirectoryHandler)
-        .add(_testImageListingHandler)
-
-        // Serves the initial HTML for the test.
-        .add(_testBootstrapHandler)
-
-        // Serves files from the root of web_ui.
-        //
-        // This is needed because sourcemaps refer to local files, i.e. those
-        // that don't come from package dependencies, relative to web_ui/.
-        //
-        // Examples of URLs that this handles:
-        //  * /test/alarm_clock_test.dart
-        //  * /lib/src/engine/alarm_clock.dart
-        .add(createStaticHandler(env.environment.webUiRootDir.path))
-
-        // Serves absolute package URLs (i.e. not /packages/* but /Users/user/*/hosted/pub.dartlang.org/*).
-        // This handler goes last, after all more specific handlers failed to handle the request.
-        .add(_createAbsolutePackageUrlHandler())
-        .add(_screenshotHandler)
-        .add(_fileNotFoundCatcher);
-
-    server.mount(cascade.handler);
-  }
 
   /// If a path to a custom local build of CanvasKit was specified, serve from
   /// there instead of serving the default CanvasKit in the build/ directory.
@@ -629,6 +629,47 @@ class OneOffHandler {
 /// This is in charge of telling the browser which test suites to load and
 /// converting its responses into [Suite] objects.
 class BrowserManager {
+
+  /// Creates a new BrowserManager that communicates with the browser over
+  /// [webSocket].
+  BrowserManager._(this.packageConfig, this._browser, this._browserEnvironment,
+      WebSocketChannel webSocket) {
+    // The duration should be short enough that the debugging console is open as
+    // soon as the user is done setting breakpoints, but long enough that a test
+    // doing a lot of synchronous work doesn't trigger a false positive.
+    //
+    // Start this canceled because we don't want it to start ticking until we
+    // get some response from the iframe.
+    _timer = RestartableTimer(const Duration(seconds: 3), () {
+      for (final RunnerSuiteController controller in _controllers) {
+        controller.setDebugging(true);
+      }
+    })
+      ..cancel();
+
+    // Whenever we get a message, no matter which child channel it's for, we the
+    // know browser is still running code which means the user isn't debugging.
+    _channel = MultiChannel<dynamic>(webSocket
+        .cast<String>()
+        .transform(jsonDocument)
+        .changeStream((Stream<Object?> stream) {
+      return stream.map((Object? message) {
+        if (!_closed) {
+          _timer.reset();
+        }
+        for (final RunnerSuiteController controller in _controllers) {
+          controller.setDebugging(false);
+        }
+
+        return message;
+      });
+    }));
+
+    _environment = _loadBrowserEnvironment();
+    _channel.stream.listen(
+        (dynamic message) => _onMessage(message as Map<dynamic, dynamic>),
+        onDone: close);
+  }
   final PackageConfig packageConfig;
 
   /// The browser instance that this is connected to via [_channel].
@@ -760,47 +801,6 @@ class BrowserManager {
       Uri url, BrowserEnvironment browserEnvironment,
       {bool debug = false}) {
     return browserEnvironment.launchBrowserInstance(url, debug: debug);
-  }
-
-  /// Creates a new BrowserManager that communicates with the browser over
-  /// [webSocket].
-  BrowserManager._(this.packageConfig, this._browser, this._browserEnvironment,
-      WebSocketChannel webSocket) {
-    // The duration should be short enough that the debugging console is open as
-    // soon as the user is done setting breakpoints, but long enough that a test
-    // doing a lot of synchronous work doesn't trigger a false positive.
-    //
-    // Start this canceled because we don't want it to start ticking until we
-    // get some response from the iframe.
-    _timer = RestartableTimer(const Duration(seconds: 3), () {
-      for (final RunnerSuiteController controller in _controllers) {
-        controller.setDebugging(true);
-      }
-    })
-      ..cancel();
-
-    // Whenever we get a message, no matter which child channel it's for, we the
-    // know browser is still running code which means the user isn't debugging.
-    _channel = MultiChannel<dynamic>(webSocket
-        .cast<String>()
-        .transform(jsonDocument)
-        .changeStream((Stream<Object?> stream) {
-      return stream.map((Object? message) {
-        if (!_closed) {
-          _timer.reset();
-        }
-        for (final RunnerSuiteController controller in _controllers) {
-          controller.setDebugging(false);
-        }
-
-        return message;
-      });
-    }));
-
-    _environment = _loadBrowserEnvironment();
-    _channel.stream.listen(
-        (dynamic message) => _onMessage(message as Map<dynamic, dynamic>),
-        onDone: close);
   }
 
   /// Loads [_BrowserEnvironment].
@@ -954,6 +954,9 @@ class BrowserManager {
 ///
 /// All methods forward directly to [BrowserManager].
 class _BrowserEnvironment implements Environment {
+
+  _BrowserEnvironment(this._manager, this.observatoryUrl,
+      this.remoteDebuggerUrl, this.onRestart);
   final BrowserManager _manager;
 
   @override
@@ -967,9 +970,6 @@ class _BrowserEnvironment implements Environment {
 
   @override
   final Stream<dynamic> onRestart;
-
-  _BrowserEnvironment(this._manager, this.observatoryUrl,
-      this.remoteDebuggerUrl, this.onRestart);
 
   @override
   CancelableOperation<void> displayPause() => _manager._displayPause();

--- a/lib/web_ui/dev/webdriver_browser.dart
+++ b/lib/web_ui/dev/webdriver_browser.dart
@@ -79,13 +79,13 @@ abstract class WebDriverBrowserEnvironment extends BrowserEnvironment {
 }
 
 class WebDriverBrowser extends Browser {
-  final WebDriver _driver;
-  final Uri _url;
-  final Completer<void> _onExitCompleter = Completer<void>();
-
   WebDriverBrowser(this._driver, this._url) {
     _driver.get(_url);
   }
+
+  final WebDriver _driver;
+  final Uri _url;
+  final Completer<void> _onExitCompleter = Completer<void>();
 
   @override
   Future<void> close() async {

--- a/lib/web_ui/lib/painting.dart
+++ b/lib/web_ui/lib/painting.dart
@@ -782,17 +782,6 @@ class ImmutableBuffer {
 }
 
 class ImageDescriptor {
-  ImageDescriptor._()
-      : _width = null,
-        _height = null,
-        _rowBytes = null,
-        _format = null;
-  static Future<ImageDescriptor> encoded(ImmutableBuffer buffer) async {
-    final ImageDescriptor descriptor = ImageDescriptor._();
-    descriptor._data = buffer._list;
-    return descriptor;
-  }
-
   // Not async because there's no expensive work to do here.
   ImageDescriptor.raw(
     ImmutableBuffer buffer, {
@@ -805,6 +794,17 @@ class ImageDescriptor {
         _rowBytes = rowBytes,
         _format = pixelFormat {
     _data = buffer._list;
+  }
+
+  ImageDescriptor._()
+      : _width = null,
+        _height = null,
+        _rowBytes = null,
+        _format = null;
+  static Future<ImageDescriptor> encoded(ImmutableBuffer buffer) async {
+    final ImageDescriptor descriptor = ImageDescriptor._();
+    descriptor._data = buffer._list;
+    return descriptor;
   }
 
   Uint8List? _data;
@@ -840,6 +840,8 @@ class ImageDescriptor {
 }
 
 class FragmentProgram {
+  FragmentProgram._();
+  
   static Future<FragmentProgram> fromAsset(String assetKey) {
     throw UnsupportedError('FragmentProgram is not supported for the CanvasKit or HTML renderers.');
   }
@@ -847,8 +849,6 @@ class FragmentProgram {
   static Future<FragmentProgram> fromAssetAsync(String assetKey) {
     return Future<FragmentProgram>.microtask(() => FragmentProgram.fromAsset(assetKey));
   }
-
-  FragmentProgram._();
 
   Shader shader({
     Float32List? floatUniforms,

--- a/lib/web_ui/lib/painting.dart
+++ b/lib/web_ui/lib/painting.dart
@@ -801,6 +801,7 @@ class ImageDescriptor {
         _height = null,
         _rowBytes = null,
         _format = null;
+
   static Future<ImageDescriptor> encoded(ImmutableBuffer buffer) async {
     final ImageDescriptor descriptor = ImageDescriptor._();
     descriptor._data = buffer._list;

--- a/lib/web_ui/lib/painting.dart
+++ b/lib/web_ui/lib/painting.dart
@@ -841,7 +841,7 @@ class ImageDescriptor {
 
 class FragmentProgram {
   FragmentProgram._();
-  
+
   static Future<FragmentProgram> fromAsset(String assetKey) {
     throw UnsupportedError('FragmentProgram is not supported for the CanvasKit or HTML renderers.');
   }

--- a/lib/web_ui/lib/painting.dart
+++ b/lib/web_ui/lib/painting.dart
@@ -768,7 +768,7 @@ class ImmutableBuffer {
   Uint8List? _list;
 
   int get length => _length;
-  int _length;
+  final int _length;
 
   bool get debugDisposed {
     late bool disposed;

--- a/lib/web_ui/lib/platform_dispatcher.dart
+++ b/lib/web_ui/lib/platform_dispatcher.dart
@@ -265,10 +265,10 @@ class FrameTiming {
     ]);
   }
 
-  static final int _dataLength = FramePhase.values.length + _FrameTimingInfo.values.length;
-
   FrameTiming._(this._data)
       : assert(_data.length == _dataLength);
+
+  static final int _dataLength = FramePhase.values.length + _FrameTimingInfo.values.length;
 
   int timestampInMicroseconds(FramePhase phase) => _data[phase.index];
 

--- a/lib/web_ui/lib/src/engine/assets.dart
+++ b/lib/web_ui/lib/src/engine/assets.dart
@@ -14,13 +14,13 @@ import 'util.dart';
 /// The assets are resolved relative to [assetsDir] inside the directory
 /// containing the currently executing JS script.
 class AssetManager {
+  /// Initializes [AssetManager] with path to assets relative to baseUrl.
+  const AssetManager({this.assetsDir = _defaultAssetsDir});
+
   static const String _defaultAssetsDir = 'assets';
 
   /// The directory containing the assets.
   final String assetsDir;
-
-  /// Initializes [AssetManager] with path to assets relative to baseUrl.
-  const AssetManager({this.assetsDir = _defaultAssetsDir});
 
   String? get _baseUrl {
     return domWindow.document
@@ -92,14 +92,14 @@ class AssetManager {
 
 /// Thrown to indicate http failure during asset loading.
 class AssetManagerException implements Exception {
+  /// Initializes exception with request url and http status.
+  AssetManagerException(this.url, this.httpStatus);
+
   /// Http request url for asset.
   final String url;
 
   /// Http status of response.
   final int httpStatus;
-
-  /// Initializes exception with request url and http status.
-  AssetManagerException(this.url, this.httpStatus);
 
   @override
   String toString() => 'Failed to load asset at "$url" ($httpStatus)';

--- a/lib/web_ui/lib/src/engine/canvas_pool.dart
+++ b/lib/web_ui/lib/src/engine/canvas_pool.dart
@@ -607,7 +607,7 @@ class CanvasPool extends _SaveStackTracking {
   }
 
   // Float buffer used for path iteration.
-  static Float32List _runBuffer = Float32List(PathRefIterator.kMaxBufferSize);
+  static final Float32List _runBuffer = Float32List(PathRefIterator.kMaxBufferSize);
 
   /// 'Runs' the given [path] by applying all of its commands to the canvas.
   void _runPath(DomCanvasRenderingContext2D ctx, SurfacePath path) {

--- a/lib/web_ui/lib/src/engine/canvas_pool.dart
+++ b/lib/web_ui/lib/src/engine/canvas_pool.dart
@@ -45,6 +45,10 @@ import 'window.dart';
 /// can be reused, [CanvasPool] will move canvas(s) from pool to reusablePool
 /// to prevent reallocation.
 class CanvasPool extends _SaveStackTracking {
+  /// Initializes canvas pool for target size and dpi.
+  CanvasPool(this._widthInBitmapPixels, this._heightInBitmapPixels,
+      this._density);
+
   DomCanvasRenderingContext2D? _context;
   ContextStateHandle? _contextHandle;
   final int _widthInBitmapPixels, _heightInBitmapPixels;
@@ -58,10 +62,6 @@ class CanvasPool extends _SaveStackTracking {
   DomHTMLElement? _rootElement;
   int _saveContextCount = 0;
   final double _density;
-
-  /// Initializes canvas pool for target size and dpi.
-  CanvasPool(this._widthInBitmapPixels, this._heightInBitmapPixels,
-      this._density);
 
   /// Initializes canvas pool to be hosted on a surface.
   void mount(DomHTMLElement rootElement) {
@@ -872,14 +872,14 @@ class CanvasPool extends _SaveStackTracking {
 /// See https://www.w3.org/TR/2dcontext/ for defaults used in this class
 /// to initialize current values.
 class ContextStateHandle {
+  /// Initializes context state for a [CanvasPool].
+  ContextStateHandle(this._canvasPool, this.context, this.density);
+
   /// Associated canvas element context tracked by this context state.
   final DomCanvasRenderingContext2D context;
   final CanvasPool _canvasPool;
   /// Dpi of context.
   final double density;
-
-  /// Initializes context state for a [CanvasPool].
-  ContextStateHandle(this._canvasPool, this.context, this.density);
   ui.BlendMode? _currentBlendMode = ui.BlendMode.srcOver;
   ui.StrokeCap? _currentStrokeCap = ui.StrokeCap.butt;
   ui.StrokeJoin? _currentStrokeJoin = ui.StrokeJoin.miter;

--- a/lib/web_ui/lib/src/engine/canvaskit/canvas.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvas.dart
@@ -27,14 +27,14 @@ final SkClipOp _clipOpIntersect = canvasKit.ClipOp.Intersect;
 /// This is intentionally not memory-managing the underlying [SkCanvas]. See
 /// the docs on [SkCanvas], which explain the reason.
 class CkCanvas {
+  CkCanvas(this.skCanvas);
+
   // Cubic equation coefficients recommended by Mitchell & Netravali
   // in their paper on cubic interpolation.
   static const double _kMitchellNetravali_B = 1.0 / 3.0;
   static const double _kMitchellNetravali_C = 1.0 / 3.0;
 
   final SkCanvas skCanvas;
-
-  CkCanvas(this.skCanvas);
 
   int? get saveCount => skCanvas.getSaveCount();
 
@@ -654,10 +654,10 @@ class CkRestoreToCountCommand extends CkPaintCommand {
 }
 
 class CkTranslateCommand extends CkPaintCommand {
+  CkTranslateCommand(this.dx, this.dy);
+
   final double dx;
   final double dy;
-
-  CkTranslateCommand(this.dx, this.dy);
 
   @override
   void apply(SkCanvas canvas) {
@@ -666,10 +666,10 @@ class CkTranslateCommand extends CkPaintCommand {
 }
 
 class CkScaleCommand extends CkPaintCommand {
+  CkScaleCommand(this.sx, this.sy);
+
   final double sx;
   final double sy;
-
-  CkScaleCommand(this.sx, this.sy);
 
   @override
   void apply(SkCanvas canvas) {
@@ -678,9 +678,9 @@ class CkScaleCommand extends CkPaintCommand {
 }
 
 class CkRotateCommand extends CkPaintCommand {
-  final double radians;
-
   CkRotateCommand(this.radians);
+
+  final double radians;
 
   @override
   void apply(SkCanvas canvas) {
@@ -689,9 +689,9 @@ class CkRotateCommand extends CkPaintCommand {
 }
 
 class CkTransformCommand extends CkPaintCommand {
-  final Float32List matrix4;
-
   CkTransformCommand(this.matrix4);
+
+  final Float32List matrix4;
 
   @override
   void apply(SkCanvas canvas) {
@@ -700,10 +700,10 @@ class CkTransformCommand extends CkPaintCommand {
 }
 
 class CkSkewCommand extends CkPaintCommand {
+  CkSkewCommand(this.sx, this.sy);
+
   final double sx;
   final double sy;
-
-  CkSkewCommand(this.sx, this.sy);
 
   @override
   void apply(SkCanvas canvas) {
@@ -712,11 +712,11 @@ class CkSkewCommand extends CkPaintCommand {
 }
 
 class CkClipRectCommand extends CkPaintCommand {
+  CkClipRectCommand(this.rect, this.clipOp, this.doAntiAlias);
+
   final ui.Rect rect;
   final ui.ClipOp clipOp;
   final bool doAntiAlias;
-
-  CkClipRectCommand(this.rect, this.clipOp, this.doAntiAlias);
 
   @override
   void apply(SkCanvas canvas) {
@@ -776,10 +776,10 @@ class CkDrawAtlasCommand extends CkPaintCommand {
 }
 
 class CkClipRRectCommand extends CkPaintCommand {
+  CkClipRRectCommand(this.rrect, this.doAntiAlias);
+
   final ui.RRect rrect;
   final bool doAntiAlias;
-
-  CkClipRRectCommand(this.rrect, this.doAntiAlias);
 
   @override
   void apply(SkCanvas canvas) {
@@ -792,10 +792,10 @@ class CkClipRRectCommand extends CkPaintCommand {
 }
 
 class CkClipPathCommand extends CkPaintCommand {
+  CkClipPathCommand(this.path, this.doAntiAlias);
+
   final CkPath path;
   final bool doAntiAlias;
-
-  CkClipPathCommand(this.path, this.doAntiAlias);
 
   @override
   void apply(SkCanvas canvas) {
@@ -808,10 +808,10 @@ class CkClipPathCommand extends CkPaintCommand {
 }
 
 class CkDrawColorCommand extends CkPaintCommand {
+  CkDrawColorCommand(this.color, this.blendMode);
+
   final ui.Color color;
   final ui.BlendMode blendMode;
-
-  CkDrawColorCommand(this.color, this.blendMode);
 
   @override
   void apply(SkCanvas canvas) {
@@ -823,11 +823,11 @@ class CkDrawColorCommand extends CkPaintCommand {
 }
 
 class CkDrawLineCommand extends CkPaintCommand {
+  CkDrawLineCommand(this.p1, this.p2, this.paint);
+
   final ui.Offset p1;
   final ui.Offset p2;
   final CkPaint paint;
-
-  CkDrawLineCommand(this.p1, this.p2, this.paint);
 
   @override
   void apply(SkCanvas canvas) {
@@ -842,9 +842,9 @@ class CkDrawLineCommand extends CkPaintCommand {
 }
 
 class CkDrawPaintCommand extends CkPaintCommand {
-  final CkPaint paint;
-
   CkDrawPaintCommand(this.paint);
+
+  final CkPaint paint;
 
   @override
   void apply(SkCanvas canvas) {
@@ -853,10 +853,11 @@ class CkDrawPaintCommand extends CkPaintCommand {
 }
 
 class CkDrawVerticesCommand extends CkPaintCommand {
+  CkDrawVerticesCommand(this.vertices, this.blendMode, this.paint);
+
   final CkVertices vertices;
   final ui.BlendMode blendMode;
   final CkPaint paint;
-  CkDrawVerticesCommand(this.vertices, this.blendMode, this.paint);
 
   @override
   void apply(SkCanvas canvas) {
@@ -869,10 +870,11 @@ class CkDrawVerticesCommand extends CkPaintCommand {
 }
 
 class CkDrawPointsCommand extends CkPaintCommand {
+  CkDrawPointsCommand(this.pointMode, this.points, this.paint);
+
   final Float32List points;
   final ui.PointMode pointMode;
   final CkPaint paint;
-  CkDrawPointsCommand(this.pointMode, this.points, this.paint);
 
   @override
   void apply(SkCanvas canvas) {
@@ -885,10 +887,10 @@ class CkDrawPointsCommand extends CkPaintCommand {
 }
 
 class CkDrawRectCommand extends CkPaintCommand {
+  CkDrawRectCommand(this.rect, this.paint);
+
   final ui.Rect rect;
   final CkPaint paint;
-
-  CkDrawRectCommand(this.rect, this.paint);
 
   @override
   void apply(SkCanvas canvas) {
@@ -897,10 +899,10 @@ class CkDrawRectCommand extends CkPaintCommand {
 }
 
 class CkDrawRRectCommand extends CkPaintCommand {
+  CkDrawRRectCommand(this.rrect, this.paint);
+
   final ui.RRect rrect;
   final CkPaint paint;
-
-  CkDrawRRectCommand(this.rrect, this.paint);
 
   @override
   void apply(SkCanvas canvas) {
@@ -912,11 +914,11 @@ class CkDrawRRectCommand extends CkPaintCommand {
 }
 
 class CkDrawDRRectCommand extends CkPaintCommand {
+  CkDrawDRRectCommand(this.outer, this.inner, this.paint);
+
   final ui.RRect outer;
   final ui.RRect inner;
   final CkPaint paint;
-
-  CkDrawDRRectCommand(this.outer, this.inner, this.paint);
 
   @override
   void apply(SkCanvas canvas) {
@@ -929,10 +931,10 @@ class CkDrawDRRectCommand extends CkPaintCommand {
 }
 
 class CkDrawOvalCommand extends CkPaintCommand {
+  CkDrawOvalCommand(this.rect, this.paint);
+
   final ui.Rect rect;
   final CkPaint paint;
-
-  CkDrawOvalCommand(this.rect, this.paint);
 
   @override
   void apply(SkCanvas canvas) {
@@ -944,11 +946,11 @@ class CkDrawOvalCommand extends CkPaintCommand {
 }
 
 class CkDrawCircleCommand extends CkPaintCommand {
+  CkDrawCircleCommand(this.c, this.radius, this.paint);
+
   final ui.Offset c;
   final double radius;
   final CkPaint paint;
-
-  CkDrawCircleCommand(this.c, this.radius, this.paint);
 
   @override
   void apply(SkCanvas canvas) {
@@ -962,10 +964,10 @@ class CkDrawCircleCommand extends CkPaintCommand {
 }
 
 class CkDrawPathCommand extends CkPaintCommand {
+  CkDrawPathCommand(this.path, this.paint);
+
   final CkPath path;
   final CkPaint paint;
-
-  CkDrawPathCommand(this.path, this.paint);
 
   @override
   void apply(SkCanvas canvas) {
@@ -990,12 +992,12 @@ class CkDrawShadowCommand extends CkPaintCommand {
 }
 
 class CkDrawImageCommand extends CkPaintCommand {
+  CkDrawImageCommand(CkImage ckImage, this.offset, this.paint)
+      : image = ckImage.clone();
+
   final CkImage image;
   final ui.Offset offset;
   final CkPaint paint;
-
-  CkDrawImageCommand(CkImage ckImage, this.offset, this.paint)
-      : image = ckImage.clone();
 
   @override
   void apply(SkCanvas canvas) {
@@ -1028,13 +1030,13 @@ class CkDrawImageCommand extends CkPaintCommand {
 }
 
 class CkDrawImageRectCommand extends CkPaintCommand {
+  CkDrawImageRectCommand(CkImage ckImage, this.src, this.dst, this.paint)
+      : image = ckImage.clone();
+
   final CkImage image;
   final ui.Rect src;
   final ui.Rect dst;
   final CkPaint paint;
-
-  CkDrawImageRectCommand(CkImage ckImage, this.src, this.dst, this.paint)
-      : image = ckImage.clone();
 
   @override
   void apply(SkCanvas canvas) {
@@ -1093,10 +1095,10 @@ class CkDrawImageNineCommand extends CkPaintCommand {
 }
 
 class CkDrawParagraphCommand extends CkPaintCommand {
+  CkDrawParagraphCommand(this.paragraph, this.offset);
+
   final CkParagraph paragraph;
   final ui.Offset offset;
-
-  CkDrawParagraphCommand(this.paragraph, this.offset);
 
   @override
   void apply(SkCanvas canvas) {

--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_canvas.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_canvas.dart
@@ -21,8 +21,6 @@ import 'vertices.dart';
 
 /// An implementation of [ui.Canvas] that is backed by a CanvasKit canvas.
 class CanvasKitCanvas implements ui.Canvas {
-  final CkCanvas _canvas;
-
   factory CanvasKitCanvas(ui.PictureRecorder recorder, [ui.Rect? cullRect]) {
     assert(recorder != null); // ignore: unnecessary_null_comparison
     if (recorder.isRecording) {
@@ -35,6 +33,8 @@ class CanvasKitCanvas implements ui.Canvas {
   }
 
   CanvasKitCanvas._(this._canvas);
+
+  final CkCanvas _canvas;
 
   @override
   void save() {

--- a/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
@@ -92,10 +92,10 @@ class HtmlViewEmbedder {
   final Set<int> _viewsToRecomposite = <int>{};
 
   /// The list of view ids that should be composited, in order.
-  List<int> _compositionOrder = <int>[];
+  final List<int> _compositionOrder = <int>[];
 
   /// The most recent composition order.
-  List<int> _activeCompositionOrder = <int>[];
+  final List<int> _activeCompositionOrder = <int>[];
 
   /// The size of the frame, in physical pixels.
   ui.Size _frameSize = ui.window.physicalSize;
@@ -398,7 +398,7 @@ class HtmlViewEmbedder {
   DomElement? _svgPathDefs;
 
   /// The nodes containing the SVG clip definitions needed to clip this view.
-  Map<int, Set<String>> _svgClipDefs = <int, Set<String>>{};
+  final Map<int, Set<String>> _svgClipDefs = <int, Set<String>>{};
 
   /// Ensures we add a container of SVG path defs to the DOM so they can
   /// be referred to in clip-path: url(#blah).
@@ -715,7 +715,7 @@ class HtmlViewEmbedder {
 /// * The number of clipping elements used last time the view was composited.
 class ViewClipChain {
   DomElement _root;
-  DomElement _slot;
+  final DomElement _slot;
   int _clipCount = -1;
 
   ViewClipChain({required DomElement view})

--- a/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
@@ -23,10 +23,10 @@ import 'surface_factory.dart';
 
 /// This composites HTML views into the [ui.Scene].
 class HtmlViewEmbedder {
+  HtmlViewEmbedder._();
+
   /// The [HtmlViewEmbedder] singleton.
   static HtmlViewEmbedder instance = HtmlViewEmbedder._();
-
-  HtmlViewEmbedder._();
 
   /// Force the view embedder to disable overlays.
   ///
@@ -714,13 +714,13 @@ class HtmlViewEmbedder {
 /// * The slot view in the stack (the actual contents of the platform view).
 /// * The number of clipping elements used last time the view was composited.
 class ViewClipChain {
-  DomElement _root;
-  final DomElement _slot;
-  int _clipCount = -1;
-
   ViewClipChain({required DomElement view})
       : _root = view,
         _slot = view;
+
+  DomElement _root;
+  final DomElement _slot;
+  int _clipCount = -1;
 
   DomElement get root => _root;
   DomElement get slot => _slot;
@@ -766,6 +766,17 @@ enum MutatorType {
 
 /// Stores mutation information like clipping or transform.
 class Mutator {
+  const Mutator.clipRect(ui.Rect rect)
+      : this._(MutatorType.clipRect, rect, null, null, null, null);
+  const Mutator.clipRRect(ui.RRect rrect)
+      : this._(MutatorType.clipRRect, null, rrect, null, null, null);
+  const Mutator.clipPath(ui.Path path)
+      : this._(MutatorType.clipPath, null, null, path, null, null);
+  const Mutator.transform(Matrix4 matrix)
+      : this._(MutatorType.transform, null, null, null, matrix, null);
+  const Mutator.opacity(int alpha)
+      : this._(MutatorType.opacity, null, null, null, null, alpha);
+
   const Mutator._(
     this.type,
     this.rect,
@@ -781,17 +792,6 @@ class Mutator {
   final ui.Path? path;
   final Matrix4? matrix;
   final int? alpha;
-
-  const Mutator.clipRect(ui.Rect rect)
-      : this._(MutatorType.clipRect, rect, null, null, null, null);
-  const Mutator.clipRRect(ui.RRect rrect)
-      : this._(MutatorType.clipRRect, null, rrect, null, null, null);
-  const Mutator.clipPath(ui.Path path)
-      : this._(MutatorType.clipPath, null, null, path, null, null);
-  const Mutator.transform(Matrix4 matrix)
-      : this._(MutatorType.transform, null, null, null, matrix, null);
-  const Mutator.opacity(int alpha)
-      : this._(MutatorType.opacity, null, null, null, null, alpha);
 
   bool get isClipType =>
       type == MutatorType.clipRect ||

--- a/lib/web_ui/lib/src/engine/canvaskit/embedded_views_diff.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/embedded_views_diff.dart
@@ -5,6 +5,10 @@
 /// The results of diffing the current composition order with the active
 /// composition order.
 class ViewListDiffResult {
+  const ViewListDiffResult(
+      this.viewsToRemove, this.viewsToAdd, this.addToBeginning,
+      {this.viewToInsertBefore});
+
   /// Views which should be removed from the scene.
   final List<int> viewsToRemove;
 
@@ -20,10 +24,6 @@ class ViewListDiffResult {
   ///
   /// `null` if [addToBeginning] is `false`.
   final int? viewToInsertBefore;
-
-  const ViewListDiffResult(
-      this.viewsToRemove, this.viewsToAdd, this.addToBeginning,
-      {this.viewToInsertBefore});
 }
 
 /// Diff the composition order with the active composition order. It is

--- a/lib/web_ui/lib/src/engine/canvaskit/font_fallbacks.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/font_fallbacks.dart
@@ -547,13 +547,13 @@ Set<NotoFont> findMinimumFontsForCodeUnits(
 }
 
 class NotoFont {
+  NotoFont(this.name, this.approximateUnicodeRanges);
+
   final String name;
   final List<CodeunitRange> approximateUnicodeRanges;
 
   Completer<void>? _decodingCompleter;
   _ResolvedNotoFont? resolvedFont;
-
-  NotoFont(this.name, this.approximateUnicodeRanges);
 
   String get googleFontsCssUrl =>
       'https://fonts.googleapis.com/css2?family=${name.replaceAll(' ', '+')}';
@@ -581,10 +581,10 @@ class NotoFont {
 }
 
 class CodeunitRange {
+  const CodeunitRange(this.start, this.end);
+
   final int start;
   final int end;
-
-  const CodeunitRange(this.start, this.end);
 
   bool contains(int codeUnit) {
     return start <= codeUnit && codeUnit <= end;
@@ -607,19 +607,19 @@ class CodeunitRange {
 }
 
 class _ResolvedNotoFont {
+  const _ResolvedNotoFont(this.name, this.subsets, this.tree);
+
   final String name;
   final List<_ResolvedNotoSubset> subsets;
   final IntervalTree<_ResolvedNotoSubset> tree;
-
-  const _ResolvedNotoFont(this.name, this.subsets, this.tree);
 }
 
 class _ResolvedNotoSubset {
+  _ResolvedNotoSubset(this.url, this.family, this.ranges);
+
   final String url;
   final String family;
   final List<CodeunitRange> ranges;
-
-  _ResolvedNotoSubset(this.url, this.family, this.ranges);
 
   @override
   String toString() => '_ResolvedNotoSubset($family, $url)';

--- a/lib/web_ui/lib/src/engine/canvaskit/fonts.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/fonts.dart
@@ -222,6 +222,12 @@ class SkiaFontCollection {
 
 /// Represents a font that has been registered.
 class RegisteredFont {
+  RegisteredFont(this.bytes, this.family, this.typeface) {
+    // This is a hack which causes Skia to cache the decoded font.
+    final SkFont skFont = SkFont(typeface);
+    skFont.getGlyphBounds(<int>[0], null, null);
+  }
+
   /// The font family name for this font.
   final String family;
 
@@ -232,10 +238,4 @@ class RegisteredFont {
   ///
   /// This is used to determine which code points are supported by this font.
   final SkTypeface typeface;
-
-  RegisteredFont(this.bytes, this.family, this.typeface) {
-    // This is a hack which causes Skia to cache the decoded font.
-    final SkFont skFont = SkFont(typeface);
-    skFont.getGlyphBounds(<int>[0], null, null);
-  }
 }

--- a/lib/web_ui/lib/src/engine/canvaskit/image.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image.dart
@@ -345,10 +345,10 @@ class CkImage implements ui.Image, StackTraceDebugger {
 
 /// Data for a single frame of an animated image.
 class AnimatedImageFrameInfo implements ui.FrameInfo {
+  AnimatedImageFrameInfo(this._duration, this._image);
+
   final Duration _duration;
   final CkImage _image;
-
-  AnimatedImageFrameInfo(this._duration, this._image);
 
   @override
   Duration get duration => _duration;

--- a/lib/web_ui/lib/src/engine/canvaskit/image_web_codecs.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image_web_codecs.dart
@@ -42,6 +42,14 @@ void debugRestoreWebDecoderExpireDuration() {
 
 /// Image decoder backed by the browser's `ImageDecoder`.
 class CkBrowserImageDecoder implements ui.Codec {
+  CkBrowserImageDecoder._({
+    required this.contentType,
+    required this.targetWidth,
+    required this.targetHeight,
+    required this.data,
+    required this.debugSource,
+  });
+
   static Future<CkBrowserImageDecoder> create({
     required Uint8List data,
     required String debugSource,
@@ -78,14 +86,6 @@ class CkBrowserImageDecoder implements ui.Codec {
     await decoder._getOrCreateWebDecoder();
     return decoder;
   }
-
-  CkBrowserImageDecoder._({
-    required this.contentType,
-    required this.targetWidth,
-    required this.targetHeight,
-    required this.data,
-    required this.debugSource,
-  });
 
   final String contentType;
   final int? targetWidth;

--- a/lib/web_ui/lib/src/engine/canvaskit/interval_tree.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/interval_tree.dart
@@ -8,9 +8,6 @@ import 'font_fallbacks.dart' show CodeunitRange;
 
 /// A tree which stores a set of intervals that can be queried for intersection.
 class IntervalTree<T> {
-  /// The root node of the interval tree.
-  final IntervalTreeNode<T> root;
-
   IntervalTree._(this.root);
 
   /// Creates an interval tree from a mapping of [T] values to a list of ranges.
@@ -76,6 +73,9 @@ class IntervalTree<T> {
     return IntervalTree<T>._(root);
   }
 
+  /// The root node of the interval tree.
+  final IntervalTreeNode<T> root;
+
   /// Returns the list of objects which have been associated with intervals that
   /// intersect with [x].
   List<T> intersections(int x) {
@@ -91,6 +91,8 @@ class IntervalTree<T> {
 }
 
 class IntervalTreeNode<T> {
+  IntervalTreeNode(this.value, this.low, this.high) : computedHigh = high;
+  
   final T value;
   final int low;
   final int high;
@@ -98,8 +100,6 @@ class IntervalTreeNode<T> {
 
   IntervalTreeNode<T>? left;
   IntervalTreeNode<T>? right;
-
-  IntervalTreeNode(this.value, this.low, this.high) : computedHigh = high;
 
   Iterable<T> enumerateAllElements() sync* {
     if (left != null) {

--- a/lib/web_ui/lib/src/engine/canvaskit/interval_tree.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/interval_tree.dart
@@ -92,7 +92,7 @@ class IntervalTree<T> {
 
 class IntervalTreeNode<T> {
   IntervalTreeNode(this.value, this.low, this.high) : computedHigh = high;
-  
+
   final T value;
   final int low;
   final int high;

--- a/lib/web_ui/lib/src/engine/canvaskit/layer.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/layer.dart
@@ -47,6 +47,8 @@ abstract class Layer implements ui.EngineLayer {
 
 /// A context shared by all layers during the preroll pass.
 class PrerollContext {
+  PrerollContext(this.rasterCache, this.viewEmbedder);
+
   /// A raster cache. Used to register candidates for caching.
   final RasterCache? rasterCache;
 
@@ -54,8 +56,6 @@ class PrerollContext {
   final HtmlViewEmbedder? viewEmbedder;
 
   final MutatorsStack mutatorsStack = MutatorsStack();
-
-  PrerollContext(this.rasterCache, this.viewEmbedder);
 
   ui.Rect get cullRect {
     ui.Rect cullRect = ui.Rect.largest;
@@ -82,6 +82,13 @@ class PrerollContext {
 
 /// A context shared by all layers during the paint pass.
 class PaintContext {
+  PaintContext(
+    this.internalNodesCanvas,
+    this.leafNodesCanvas,
+    this.rasterCache,
+    this.viewEmbedder,
+  );
+
   /// A multi-canvas that applies clips, transforms, and opacity
   /// operations to all canvases (root canvas and overlay canvases for the
   /// platform views).
@@ -95,13 +102,6 @@ class PaintContext {
 
   /// A compositor for embedded HTML views.
   final HtmlViewEmbedder? viewEmbedder;
-
-  PaintContext(
-    this.internalNodesCanvas,
-    this.leafNodesCanvas,
-    this.rasterCache,
-    this.viewEmbedder,
-  );
 }
 
 /// A layer that contains child layers.
@@ -167,10 +167,10 @@ class RootLayer extends ContainerLayer {
 
 class BackdropFilterEngineLayer extends ContainerLayer
     implements ui.BackdropFilterEngineLayer {
+  BackdropFilterEngineLayer(this._filter, this._blendMode);
+
   final ui.ImageFilter _filter;
   final ui.BlendMode _blendMode;
-
-  BackdropFilterEngineLayer(this._filter, this._blendMode);
 
   @override
   void preroll(PrerollContext prerollContext, Matrix4 matrix) {
@@ -194,12 +194,12 @@ class BackdropFilterEngineLayer extends ContainerLayer
 /// A layer that clips its child layers by a given [Path].
 class ClipPathEngineLayer extends ContainerLayer
     implements ui.ClipPathEngineLayer {
+  ClipPathEngineLayer(this._clipPath, this._clipBehavior)
+      : assert(_clipBehavior != ui.Clip.none);
+
   /// The path used to clip child layers.
   final CkPath _clipPath;
   final ui.Clip _clipBehavior;
-
-  ClipPathEngineLayer(this._clipPath, this._clipBehavior)
-      : assert(_clipBehavior != ui.Clip.none);
 
   @override
   void preroll(PrerollContext prerollContext, Matrix4 matrix) {
@@ -234,12 +234,12 @@ class ClipPathEngineLayer extends ContainerLayer
 /// A layer that clips its child layers by a given [Rect].
 class ClipRectEngineLayer extends ContainerLayer
     implements ui.ClipRectEngineLayer {
+  ClipRectEngineLayer(this._clipRect, this._clipBehavior)
+      : assert(_clipBehavior != ui.Clip.none);
+
   /// The rectangle used to clip child layers.
   final ui.Rect _clipRect;
   final ui.Clip _clipBehavior;
-
-  ClipRectEngineLayer(this._clipRect, this._clipBehavior)
-      : assert(_clipBehavior != ui.Clip.none);
 
   @override
   void preroll(PrerollContext prerollContext, Matrix4 matrix) {
@@ -275,12 +275,12 @@ class ClipRectEngineLayer extends ContainerLayer
 /// A layer that clips its child layers by a given [RRect].
 class ClipRRectEngineLayer extends ContainerLayer
     implements ui.ClipRRectEngineLayer {
+  ClipRRectEngineLayer(this._clipRRect, this._clipBehavior)
+      : assert(_clipBehavior != ui.Clip.none);
+
   /// The rounded rectangle used to clip child layers.
   final ui.RRect _clipRRect;
   final ui.Clip? _clipBehavior;
-
-  ClipRRectEngineLayer(this._clipRRect, this._clipBehavior)
-      : assert(_clipBehavior != ui.Clip.none);
 
   @override
   void preroll(PrerollContext prerollContext, Matrix4 matrix) {
@@ -313,10 +313,10 @@ class ClipRRectEngineLayer extends ContainerLayer
 /// A layer that paints its children with the given opacity.
 class OpacityEngineLayer extends ContainerLayer
     implements ui.OpacityEngineLayer {
+  OpacityEngineLayer(this._alpha, this._offset);
+
   final int _alpha;
   final ui.Offset _offset;
-
-  OpacityEngineLayer(this._alpha, this._offset);
 
   @override
   void preroll(PrerollContext prerollContext, Matrix4 matrix) {
@@ -354,10 +354,10 @@ class OpacityEngineLayer extends ContainerLayer
 /// A layer that transforms its child layers by the given transform matrix.
 class TransformEngineLayer extends ContainerLayer
     implements ui.TransformEngineLayer {
+  TransformEngineLayer(this._transform);
+
   /// The matrix with which to transform the child layers.
   final Matrix4 _transform;
-
-  TransformEngineLayer(this._transform);
 
   @override
   void preroll(PrerollContext prerollContext, Matrix4 matrix) {
@@ -447,6 +447,8 @@ class ShaderMaskEngineLayer extends ContainerLayer
 
 /// A layer containing a [Picture].
 class PictureLayer extends Layer {
+  PictureLayer(this.picture, this.offset, this.isComplex, this.willChange);
+
   /// The picture to paint into the canvas.
   final CkPicture picture;
 
@@ -458,8 +460,6 @@ class PictureLayer extends Layer {
 
   /// A hint to the compositor that this picture is likely to change.
   final bool willChange;
-
-  PictureLayer(this.picture, this.offset, this.isComplex, this.willChange);
 
   @override
   void preroll(PrerollContext prerollContext, Matrix4 matrix) {
@@ -485,12 +485,6 @@ class PictureLayer extends Layer {
 /// on the given elevation.
 class PhysicalShapeEngineLayer extends ContainerLayer
     implements ui.PhysicalShapeEngineLayer {
-  final double _elevation;
-  final ui.Color _color;
-  final ui.Color? _shadowColor; // ignore: use_late_for_private_fields_and_variables
-  final CkPath _path;
-  final ui.Clip _clipBehavior;
-
   PhysicalShapeEngineLayer(
     this._elevation,
     this._color,
@@ -498,6 +492,12 @@ class PhysicalShapeEngineLayer extends ContainerLayer
     this._path,
     this._clipBehavior,
   );
+
+  final double _elevation;
+  final ui.Color _color;
+  final ui.Color? _shadowColor; // ignore: use_late_for_private_fields_and_variables
+  final CkPath _path;
+  final ui.Clip _clipBehavior;
 
   @override
   void preroll(PrerollContext prerollContext, Matrix4 matrix) {

--- a/lib/web_ui/lib/src/engine/canvaskit/layer_scene_builder.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/layer_scene_builder.dart
@@ -13,9 +13,9 @@ import 'path.dart';
 import 'picture.dart';
 
 class LayerScene implements ui.Scene {
-  final LayerTree layerTree;
-
   LayerScene(RootLayer rootLayer) : layerTree = LayerTree(rootLayer);
+
+  final LayerTree layerTree;
 
   @override
   void dispose() {}

--- a/lib/web_ui/lib/src/engine/canvaskit/layer_tree.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/layer_tree.dart
@@ -86,6 +86,8 @@ class LayerTree {
 
 /// A single frame to be rendered.
 class Frame {
+  Frame(this.canvas, this.rasterCache, this.viewEmbedder);
+
   /// The canvas to render this frame to.
   final CkCanvas canvas;
 
@@ -94,8 +96,6 @@ class Frame {
 
   /// The platform view embedder.
   final HtmlViewEmbedder? viewEmbedder;
-
-  Frame(this.canvas, this.rasterCache, this.viewEmbedder);
 
   /// Rasterize the given layer tree into this frame.
   bool raster(LayerTree layerTree, {bool ignoreRasterCache = false}) {

--- a/lib/web_ui/lib/src/engine/canvaskit/picture.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/picture.dart
@@ -17,9 +17,6 @@ import 'skia_object_cache.dart';
 /// class may have their Skia counterparts deleted before finalization registry
 /// or [SkiaObjectCache] decide to delete it.
 class CkPicture extends ManagedSkiaObject<SkPicture> implements ui.Picture {
-  final ui.Rect? cullRect;
-  final CkPictureSnapshot? _snapshot;
-
   CkPicture(SkPicture super.picture, this.cullRect, this._snapshot) :
     assert(
       browserSupportsFinalizationRegistry && _snapshot == null ||
@@ -27,6 +24,8 @@ class CkPicture extends ManagedSkiaObject<SkPicture> implements ui.Picture {
       'If the browser does not support FinalizationRegistry (WeakRef), then we must have a picture snapshot to be able to resurrect it.',
     );
 
+  final ui.Rect? cullRect;
+  final CkPictureSnapshot? _snapshot;
 
   @override
   int get approximateBytesUsed => 0;

--- a/lib/web_ui/lib/src/engine/canvaskit/platform_message.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/platform_message.dart
@@ -6,11 +6,11 @@ import 'dart:typed_data';
 
 // TODO(hterkelsen): Delete this once the slots change lands?
 class PlatformMessage {
+  PlatformMessage(this.channel, this.data, this.response);
+
   final String channel;
   final ByteData data;
   final PlatformMessageResponse response;
-
-  PlatformMessage(this.channel, this.data, this.response);
 }
 
 class PlatformMessageResponse {

--- a/lib/web_ui/lib/src/engine/canvaskit/skia_object_cache.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/skia_object_cache.dart
@@ -25,6 +25,10 @@ import 'canvaskit_api.dart';
 /// JS-managed data structure when they are deleted so that when the associated
 /// object is garbage collected, so is the serialized data.
 class SkiaObjectCache {
+  SkiaObjectCache(this.maximumSize)
+      : _itemQueue = DoubleLinkedQueue<SkiaObject<Object>>(),
+        _itemMap = <SkiaObject<Object>, DoubleLinkedQueueEntry<SkiaObject<Object>>>{};
+
   final int maximumSize;
 
   /// A doubly linked list of the objects in the cache.
@@ -37,10 +41,6 @@ class SkiaObjectCache {
   /// This makes it fast to find the node in the queue when we need to
   /// move the object to the front of the queue.
   final Map<SkiaObject<Object>, DoubleLinkedQueueEntry<SkiaObject<Object>>> _itemMap;
-
-  SkiaObjectCache(this.maximumSize)
-      : _itemQueue = DoubleLinkedQueue<SkiaObject<Object>>(),
-        _itemMap = <SkiaObject<Object>, DoubleLinkedQueueEntry<SkiaObject<Object>>>{};
 
   /// The number of objects in the cache.
   int get length => _itemQueue.length;
@@ -90,6 +90,10 @@ class SkiaObjectCache {
 /// Like [SkiaObjectCache] but enforces the [maximumSize] of the cache
 /// synchronously instead of waiting until a post-frame callback.
 class SynchronousSkiaObjectCache {
+  SynchronousSkiaObjectCache(this.maximumSize)
+      : _itemQueue = DoubleLinkedQueue<SkiaObject<Object>>(),
+        _itemMap = <SkiaObject<Object>, DoubleLinkedQueueEntry<SkiaObject<Object>>>{};
+
   /// This cache will never exceed this limit, even temporarily.
   final int maximumSize;
 
@@ -103,10 +107,6 @@ class SynchronousSkiaObjectCache {
   /// This makes it fast to find the node in the queue when we need to
   /// move the object to the front of the queue.
   final Map<SkiaObject<Object>, DoubleLinkedQueueEntry<SkiaObject<Object>>> _itemMap;
-
-  SynchronousSkiaObjectCache(this.maximumSize)
-      : _itemQueue = DoubleLinkedQueue<SkiaObject<Object>>(),
-        _itemMap = <SkiaObject<Object>, DoubleLinkedQueueEntry<SkiaObject<Object>>>{};
 
   /// The number of objects in the cache.
   int get length => _itemQueue.length;

--- a/lib/web_ui/lib/src/engine/canvaskit/surface.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/surface.dart
@@ -26,14 +26,14 @@ typedef SubmitCallback = bool Function(SurfaceFrame, CkCanvas);
 
 /// A frame which contains a canvas to be drawn into.
 class SurfaceFrame {
-  final CkSurface skiaSurface;
-  final SubmitCallback submitCallback;
-  final bool _submitted;
-
   SurfaceFrame(this.skiaSurface, this.submitCallback)
       : _submitted = false,
         assert(skiaSurface != null), // ignore: unnecessary_null_comparison
-        assert(submitCallback != null); // ignore: unnecessary_null_comparison
+        assert(submitCallback != null);
+
+  final CkSurface skiaSurface;
+  final SubmitCallback submitCallback;
+  final bool _submitted; // ignore: unnecessary_null_comparison
 
   /// Submit this frame to be drawn.
   bool submit() {

--- a/lib/web_ui/lib/src/engine/canvaskit/surface.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/surface.dart
@@ -28,7 +28,7 @@ typedef SubmitCallback = bool Function(SurfaceFrame, CkCanvas);
 class SurfaceFrame {
   final CkSurface skiaSurface;
   final SubmitCallback submitCallback;
-  bool _submitted;
+  final bool _submitted;
 
   SurfaceFrame(this.skiaSurface, this.submitCallback)
       : _submitted = false,

--- a/lib/web_ui/lib/src/engine/canvaskit/surface.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/surface.dart
@@ -28,12 +28,12 @@ typedef SubmitCallback = bool Function(SurfaceFrame, CkCanvas);
 class SurfaceFrame {
   SurfaceFrame(this.skiaSurface, this.submitCallback)
       : _submitted = false,
-        assert(skiaSurface != null), // ignore: unnecessary_null_comparison
+        assert(skiaSurface != null),
         assert(submitCallback != null);
 
   final CkSurface skiaSurface;
   final SubmitCallback submitCallback;
-  final bool _submitted; // ignore: unnecessary_null_comparison
+  final bool _submitted;
 
   /// Submit this frame to be drawn.
   bool submit() {

--- a/lib/web_ui/lib/src/engine/canvaskit/surface_factory.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/surface_factory.dart
@@ -9,6 +9,18 @@ import '../../engine.dart';
 
 /// Caches surfaces used to overlay platform views.
 class SurfaceFactory {
+  SurfaceFactory(int maximumSurfaces)
+      : maximumSurfaces = math.max(maximumSurfaces, 1) {
+    if (assertionsEnabled) {
+      if (maximumSurfaces < 1) {
+        printWarning('Attempted to create a $SurfaceFactory with '
+            '$maximumSurfaces maximum surfaces. At least 1 surface is required '
+            'for rendering.');
+      }
+      registerHotRestartListener(debugClear);
+    }
+  }
+
   /// The lazy-initialized singleton surface factory.
   ///
   /// [debugClear] causes this singleton to be reinitialized.
@@ -28,18 +40,6 @@ class SurfaceFactory {
   }
 
   static SurfaceFactory? _instance;
-
-  SurfaceFactory(int maximumSurfaces)
-      : maximumSurfaces = math.max(maximumSurfaces, 1) {
-    if (assertionsEnabled) {
-      if (maximumSurfaces < 1) {
-        printWarning('Attempted to create a $SurfaceFactory with '
-            '$maximumSurfaces maximum surfaces. At least 1 surface is required '
-            'for rendering.');
-      }
-      registerHotRestartListener(debugClear);
-    }
-  }
 
   /// The base surface to paint on. This is the default surface which will be
   /// painted to. If there are no platform views, then this surface will receive

--- a/lib/web_ui/lib/src/engine/canvaskit/text.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/text.dart
@@ -1039,6 +1039,7 @@ class _ParagraphCommand {
       _CkParagraphPlaceholder placeholderStyle)
       : this._(
             _ParagraphCommandType.addPlaceholder, null, null, placeholderStyle);
+
   final _ParagraphCommandType type;
   final String? text;
   final CkTextStyle? style;

--- a/lib/web_ui/lib/src/engine/canvaskit/text.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/text.dart
@@ -835,13 +835,6 @@ class CkLineMetrics implements ui.LineMetrics {
 }
 
 class CkParagraphBuilder implements ui.ParagraphBuilder {
-  final SkParagraphBuilder _paragraphBuilder;
-  final CkParagraphStyle _style;
-  final List<_ParagraphCommand> _commands;
-  int _placeholderCount;
-  final List<double> _placeholderScales;
-  final List<CkTextStyle> _styleStack;
-
   CkParagraphBuilder(ui.ParagraphStyle style)
       : _commands = <_ParagraphCommand>[],
         _style = style as CkParagraphStyle,
@@ -854,6 +847,13 @@ class CkParagraphBuilder implements ui.ParagraphBuilder {
         ) {
     _styleStack.add(_style.getTextStyle());
   }
+
+  final SkParagraphBuilder _paragraphBuilder;
+  final CkParagraphStyle _style;
+  final List<_ParagraphCommand> _commands;
+  int _placeholderCount;
+  final List<double> _placeholderScales;
+  final List<CkTextStyle> _styleStack;
 
   @override
   void addPlaceholder(
@@ -1019,11 +1019,6 @@ class _CkParagraphPlaceholder {
 }
 
 class _ParagraphCommand {
-  final _ParagraphCommandType type;
-  final String? text;
-  final CkTextStyle? style;
-  final _CkParagraphPlaceholder? placeholderStyle;
-
   const _ParagraphCommand._(
     this.type,
     this.text,
@@ -1044,6 +1039,10 @@ class _ParagraphCommand {
       _CkParagraphPlaceholder placeholderStyle)
       : this._(
             _ParagraphCommandType.addPlaceholder, null, null, placeholderStyle);
+  final _ParagraphCommandType type;
+  final String? text;
+  final CkTextStyle? style;
+  final _CkParagraphPlaceholder? placeholderStyle;
 }
 
 enum _ParagraphCommandType {

--- a/lib/web_ui/lib/src/engine/canvaskit/text.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/text.dart
@@ -637,7 +637,7 @@ class CkParagraph extends SkiaObject<SkParagraph> implements ui.Paragraph {
   //                lot of paragraphs are laid out _and_ rendered. To support
   //                this use-case without blowing up memory usage we need this:
   //                https://github.com/flutter/flutter/issues/81224
-  static SynchronousSkiaObjectCache _paragraphCache =
+  static final SynchronousSkiaObjectCache _paragraphCache =
       SynchronousSkiaObjectCache(500);
 
   /// Marks this paragraph as having been used this frame.

--- a/lib/web_ui/lib/src/engine/canvaskit/viewport_metrics.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/viewport_metrics.dart
@@ -3,13 +3,13 @@
 // found in the LICENSE file.
 
 class ViewportMetrics {
-  final double devicePixelRatio;
-  final double physicalWidth;
-  final double physicalHeight;
-
   const ViewportMetrics(
     this.devicePixelRatio,
     this.physicalWidth,
     this.physicalHeight,
   );
+
+  final double devicePixelRatio;
+  final double physicalWidth;
+  final double physicalHeight;
 }

--- a/lib/web_ui/lib/src/engine/dom.dart
+++ b/lib/web_ui/lib/src/engine/dom.dart
@@ -1309,22 +1309,22 @@ extension DomScreenOrientationExtension on DomScreenOrientation {
 // remove the listener. Caller is still responsible for calling [allowInterop]
 // on the listener before creating the subscription.
 class DomSubscription {
-  final String type;
-  final DomEventTarget target;
-  final DomEventListener listener;
-
   DomSubscription(this.target, this.type, this.listener) {
     target.addEventListener(type, listener);
   }
+
+  final String type;
+  final DomEventTarget target;
+  final DomEventListener listener;
 
   void cancel() => target.removeEventListener(type, listener);
 }
 
 class DomPoint {
+  DomPoint(this.x, this.y);
+
   final num x;
   final num y;
-
-  DomPoint(this.x, this.y);
 }
 
 @JS()
@@ -1422,10 +1422,10 @@ extension DomListExtension on _DomList {
 }
 
 class _DomListIterator<T> extends Iterator<T> {
+  _DomListIterator(this.list);
+
   final _DomList list;
   int index = -1;
-
-  _DomListIterator(this.list);
 
   @override
   bool moveNext() {
@@ -1441,9 +1441,9 @@ class _DomListIterator<T> extends Iterator<T> {
 }
 
 class _DomListWrapper<T> extends Iterable<T> {
-  final _DomList list;
-
   _DomListWrapper._(this.list);
+
+  final _DomList list;
 
   @override
   Iterator<T> get iterator => _DomListIterator<T>(list);

--- a/lib/web_ui/lib/src/engine/engine_canvas.dart
+++ b/lib/web_ui/lib/src/engine/engine_canvas.dart
@@ -116,10 +116,6 @@ class SaveStackEntry {
 
 /// Tagged union of clipping parameters used for canvas.
 class SaveClipEntry {
-  final ui.Rect? rect;
-  final ui.RRect? rrect;
-  final ui.Path? path;
-  final Matrix4 currentTransform;
   SaveClipEntry.rect(this.rect, this.currentTransform)
       : rrect = null,
         path = null;
@@ -129,6 +125,11 @@ class SaveClipEntry {
   SaveClipEntry.path(this.path, this.currentTransform)
       : rect = null,
         rrect = null;
+
+  final ui.Rect? rect;
+  final ui.RRect? rrect;
+  final ui.Path? path;
+  final Matrix4 currentTransform;
 }
 
 /// Provides save stack tracking functionality to implementations of

--- a/lib/web_ui/lib/src/engine/frame_reference.dart
+++ b/lib/web_ui/lib/src/engine/frame_reference.dart
@@ -86,9 +86,9 @@ class CrossFrameCache<T> {
 }
 
 class _CrossFrameCacheItem<T> {
+  _CrossFrameCacheItem(this.value, this.evictCallback);
   final T value;
   final CrossFrameCacheEvictCallback<T>? evictCallback;
-  _CrossFrameCacheItem(this.value, this.evictCallback);
   void evict() {
     if (evictCallback != null) {
       evictCallback!(value);

--- a/lib/web_ui/lib/src/engine/host_node.dart
+++ b/lib/web_ui/lib/src/engine/host_node.dart
@@ -86,8 +86,6 @@ abstract class HostNode {
 /// supported in the current environment. In this case, a fallback [ElementHostNode]
 /// should be created instead.
 class ShadowDomHostNode implements HostNode {
-  late DomShadowRoot _shadow;
-
   /// Build a HostNode by attaching a [DomShadowRoot] to the `root` element.
   ///
   /// This also calls [applyGlobalCssRulesToSheet], defined in dom_renderer.
@@ -114,6 +112,8 @@ class ShadowDomHostNode implements HostNode {
       hasAutofillOverlay: browserHasAutofillOverlay(),
     );
   }
+
+  late DomShadowRoot _shadow;
 
   @override
   DomElement? get activeElement => _shadow.activeElement;
@@ -150,13 +150,13 @@ class ShadowDomHostNode implements HostNode {
 /// This is a fallback implementation, in case [ShadowDomHostNode] fails when
 /// being constructed.
 class ElementHostNode implements HostNode {
-  late DomElement _element;
-
   /// Build a HostNode by attaching a child [DomElement] to the `root` element.
   ElementHostNode(DomElement root) {
     _element = domDocument.createElement('flt-element-host-node');
     root.appendChild(_element);
   }
+
+  late DomElement _element;
 
   @override
   DomElement? get activeElement => _element.ownerDocument?.activeElement;

--- a/lib/web_ui/lib/src/engine/html/bitmap_canvas.dart
+++ b/lib/web_ui/lib/src/engine/html/bitmap_canvas.dart
@@ -1036,7 +1036,7 @@ class BitmapCanvas extends EngineCanvas {
   /// Stores paint data used by [drawPoints]. We cannot use the original paint
   /// data object because painting style is determined by [ui.PointMode] and
   /// not by [SurfacePointData.style].
-  static SurfacePaintData _drawPointsPaint = SurfacePaintData()
+  static final SurfacePaintData _drawPointsPaint = SurfacePaintData()
     ..strokeCap = ui.StrokeCap.round
     ..strokeJoin = ui.StrokeJoin.round
     ..blendMode = ui.BlendMode.srcOver;

--- a/lib/web_ui/lib/src/engine/html/bitmap_canvas.dart
+++ b/lib/web_ui/lib/src/engine/html/bitmap_canvas.dart
@@ -31,6 +31,39 @@ import 'shaders/image_shader.dart';
 
 /// A raw HTML canvas that is directly written to.
 class BitmapCanvas extends EngineCanvas {
+  /// Allocates a canvas with enough memory to paint a picture within the given
+  /// [bounds].
+  ///
+  /// This canvas can be reused by pictures with different paint bounds as long
+  /// as the [Rect.size] of the bounds fully fit within the size used to
+  /// initialize this canvas.
+  BitmapCanvas(this._bounds, RenderStrategy renderStrategy,
+      {double density = 1.0})
+      : assert(_bounds != null), // ignore: unnecessary_null_comparison
+        _density = density,
+        _renderStrategy = renderStrategy,
+        widthInBitmapPixels = widthToPhysical(_bounds.width),
+        heightInBitmapPixels = heightToPhysical(_bounds.height),
+        _canvasPool = CanvasPool(widthToPhysical(_bounds.width),
+            heightToPhysical(_bounds.height), density) {
+    rootElement.style.position = 'absolute';
+    // Adds one extra pixel to the requested size. This is to compensate for
+    // _initializeViewport() snapping canvas position to 1 pixel, causing
+    // painting to overflow by at most 1 pixel.
+    _canvasPositionX = _bounds.left.floor() - kPaddingPixels;
+    _canvasPositionY = _bounds.top.floor() - kPaddingPixels;
+    _updateRootElementTransform();
+    _canvasPool.mount(rootElement as DomHTMLElement);
+    _setupInitialTransform();
+  }
+
+  /// Constructs bitmap canvas to capture image data.
+  factory BitmapCanvas.imageData(ui.Rect bounds) {
+    final BitmapCanvas bitmapCanvas = BitmapCanvas(bounds, RenderStrategy());
+    bitmapCanvas._preserveImageData = true;
+    return bitmapCanvas;
+  }
+
   /// The rectangle positioned relative to the parent layer's coordinate
   /// system's origin, within which this canvas paints.
   ///
@@ -135,39 +168,6 @@ class BitmapCanvas extends EngineCanvas {
   final double _density;
 
   final RenderStrategy _renderStrategy;
-
-  /// Allocates a canvas with enough memory to paint a picture within the given
-  /// [bounds].
-  ///
-  /// This canvas can be reused by pictures with different paint bounds as long
-  /// as the [Rect.size] of the bounds fully fit within the size used to
-  /// initialize this canvas.
-  BitmapCanvas(this._bounds, RenderStrategy renderStrategy,
-      {double density = 1.0})
-      : assert(_bounds != null), // ignore: unnecessary_null_comparison
-        _density = density,
-        _renderStrategy = renderStrategy,
-        widthInBitmapPixels = widthToPhysical(_bounds.width),
-        heightInBitmapPixels = heightToPhysical(_bounds.height),
-        _canvasPool = CanvasPool(widthToPhysical(_bounds.width),
-            heightToPhysical(_bounds.height), density) {
-    rootElement.style.position = 'absolute';
-    // Adds one extra pixel to the requested size. This is to compensate for
-    // _initializeViewport() snapping canvas position to 1 pixel, causing
-    // painting to overflow by at most 1 pixel.
-    _canvasPositionX = _bounds.left.floor() - kPaddingPixels;
-    _canvasPositionY = _bounds.top.floor() - kPaddingPixels;
-    _updateRootElementTransform();
-    _canvasPool.mount(rootElement as DomHTMLElement);
-    _setupInitialTransform();
-  }
-
-  /// Constructs bitmap canvas to capture image data.
-  factory BitmapCanvas.imageData(ui.Rect bounds) {
-    final BitmapCanvas bitmapCanvas = BitmapCanvas(bounds, RenderStrategy());
-    bitmapCanvas._preserveImageData = true;
-    return bitmapCanvas;
-  }
 
   /// Setup cache for reusing DOM elements across frames.
   void setElementCache(CrossFrameCache<DomHTMLElement>? cache) {

--- a/lib/web_ui/lib/src/engine/html/canvas.dart
+++ b/lib/web_ui/lib/src/engine/html/canvas.dart
@@ -16,8 +16,6 @@ import 'recording_canvas.dart';
 import 'render_vertices.dart';
 
 class SurfaceCanvas implements ui.Canvas {
-  RecordingCanvas _canvas;
-
   factory SurfaceCanvas(EnginePictureRecorder recorder, [ui.Rect? cullRect]) {
     if (recorder.isRecording) {
       throw ArgumentError(
@@ -28,6 +26,8 @@ class SurfaceCanvas implements ui.Canvas {
   }
 
   SurfaceCanvas._(this._canvas);
+
+  RecordingCanvas _canvas;
 
   @override
   void save() {

--- a/lib/web_ui/lib/src/engine/html/color_filter.dart
+++ b/lib/web_ui/lib/src/engine/html/color_filter.dart
@@ -252,8 +252,6 @@ const int kOperatorArithmetic = 6;
 
 /// Builds an [SvgFilter].
 class SvgFilterBuilder {
-  static int _filterIdCounter = 0;
-
   SvgFilterBuilder() : id = '_fcf${++_filterIdCounter}' {
     filter.id = id;
 
@@ -267,6 +265,8 @@ class SvgFilterBuilder {
     filter.width!.baseVal!.valueAsString = '100%';
     filter.height!.baseVal!.valueAsString = '100%';
   }
+
+  static int _filterIdCounter = 0;
 
   final String id;
   final SVGSVGElement root = kSvgResourceHeader.cloneNode(false) as

--- a/lib/web_ui/lib/src/engine/html/dom_canvas.dart
+++ b/lib/web_ui/lib/src/engine/html/dom_canvas.dart
@@ -22,10 +22,10 @@ import 'shaders/shader.dart';
 
 /// A canvas that renders to DOM elements and CSS properties.
 class DomCanvas extends EngineCanvas with SaveElementStackTracking {
+  DomCanvas(this.rootElement);
+
   @override
   final DomElement rootElement;
-
-  DomCanvas(this.rootElement);
 
   /// Prepare to reuse this canvas by clearing it's current contents.
   @override

--- a/lib/web_ui/lib/src/engine/html/path/conic.dart
+++ b/lib/web_ui/lib/src/engine/html/path/conic.dart
@@ -17,11 +17,11 @@ import 'path_utils.dart';
 /// Skia implementation reference:
 /// https://github.com/google/skia/blob/main/src/core/SkGeometry.cpp
 class Conic {
+  Conic(this.p0x, this.p0y, this.p1x, this.p1y, this.p2x, this.p2y, this.fW);
+
   double p0x, p0y, p1x, p1y, p2x, p2y;
   final double fW;
   static const int _maxSubdivisionCount = 5;
-
-  Conic(this.p0x, this.p0y, this.p1x, this.p1y, this.p2x, this.p2y, this.fW);
 
   /// Returns array of points for the approximation of the conic as quad(s).
   ///

--- a/lib/web_ui/lib/src/engine/html/path/path.dart
+++ b/lib/web_ui/lib/src/engine/html/path/path.dart
@@ -35,35 +35,8 @@ import 'tangent.dart';
 ///   3. if we encounter Move without a preceding Close, and forceClose is true, goto #2
 ///   4. if we encounter Line | Quad | Cubic after Close, cons up a Move
 class SurfacePath implements ui.Path {
-  // Initial valid of last move to index so we can detect if a move to
-  // needs to be inserted after contour closure. See [close].
-  static const int kInitialLastMoveToIndexValue = 0;
-
-  PathRef pathRef;
-  ui.PathFillType _fillType = ui.PathFillType.nonZero;
-  // Skia supports inverse winding as part of path fill type.
-  // For Flutter inverse is always false.
-  final bool _isInverseFillType = false;
-  // Store point index + 1 of last moveTo instruction.
-  // If contour has been closed or path is in initial state, the value is
-  // negated.
-  int fLastMoveToIndex = kInitialLastMoveToIndexValue;
-  int _convexityType = SPathConvexityType.kUnknown;
-  int _firstDirection = SPathDirection.kUnknown;
-
   SurfacePath() : pathRef = PathRef() {
     _resetFields();
-  }
-
-  void _resetFields() {
-    fLastMoveToIndex = kInitialLastMoveToIndexValue;
-    _fillType = ui.PathFillType.nonZero;
-    _resetAfterEdit();
-  }
-
-  void _resetAfterEdit() {
-    _convexityType = SPathConvexityType.kUnknown;
-    _firstDirection = SPathDirection.kUnknown;
   }
 
   /// Creates a copy of another [Path].
@@ -81,6 +54,33 @@ class SurfacePath implements ui.Path {
   SurfacePath.shallowCopy(SurfacePath source)
       : pathRef = PathRef.shallowCopy(source.pathRef) {
     _copyFields(source);
+  }
+
+  // Initial valid of last move to index so we can detect if a move to
+  // needs to be inserted after contour closure. See [close].
+  static const int kInitialLastMoveToIndexValue = 0;
+
+  PathRef pathRef;
+  ui.PathFillType _fillType = ui.PathFillType.nonZero;
+  // Skia supports inverse winding as part of path fill type.
+  // For Flutter inverse is always false.
+  final bool _isInverseFillType = false;
+  // Store point index + 1 of last moveTo instruction.
+  // If contour has been closed or path is in initial state, the value is
+  // negated.
+  int fLastMoveToIndex = kInitialLastMoveToIndexValue;
+  int _convexityType = SPathConvexityType.kUnknown;
+  int _firstDirection = SPathDirection.kUnknown;
+
+  void _resetFields() {
+    fLastMoveToIndex = kInitialLastMoveToIndexValue;
+    _fillType = ui.PathFillType.nonZero;
+    _resetAfterEdit();
+  }
+
+  void _resetAfterEdit() {
+    _convexityType = SPathConvexityType.kUnknown;
+    _firstDirection = SPathDirection.kUnknown;
   }
 
   void _copyFields(SurfacePath source) {

--- a/lib/web_ui/lib/src/engine/html/path/path.dart
+++ b/lib/web_ui/lib/src/engine/html/path/path.dart
@@ -43,7 +43,7 @@ class SurfacePath implements ui.Path {
   ui.PathFillType _fillType = ui.PathFillType.nonZero;
   // Skia supports inverse winding as part of path fill type.
   // For Flutter inverse is always false.
-  bool _isInverseFillType = false;
+  final bool _isInverseFillType = false;
   // Store point index + 1 of last moveTo instruction.
   // If contour has been closed or path is in initial state, the value is
   // negated.

--- a/lib/web_ui/lib/src/engine/html/path/path_metrics.dart
+++ b/lib/web_ui/lib/src/engine/html/path/path_metrics.dart
@@ -52,7 +52,7 @@ class _SurfacePathMeasure {
         _pathIterator = PathIterator(_path, forceClosed);
 
   final PathRef _path;
-  PathIterator _pathIterator;
+  final PathIterator _pathIterator;
   final List<_PathContourMeasure> _contours = <_PathContourMeasure>[];
 
   // If the contour ends with a call to [Path.close] (which may
@@ -494,7 +494,7 @@ class SurfacePathMetricIterator implements Iterator<ui.PathMetric> {
   SurfacePathMetricIterator._(this._pathMeasure);
 
   SurfacePathMetric? _pathMetric;
-  _SurfacePathMeasure _pathMeasure;
+  final _SurfacePathMeasure _pathMeasure;
 
   @override
   SurfacePathMetric get current => _pathMetric!;

--- a/lib/web_ui/lib/src/engine/html/path/path_metrics.dart
+++ b/lib/web_ui/lib/src/engine/html/path/path_metrics.dart
@@ -693,7 +693,6 @@ class _PathSegment {
 
 // Evaluates A * t^3 + B * t^2 + Ct + D = 0 for cubic curve.
 class _SkCubicCoefficients {
-  final double ax, ay, bx, by, cx, cy, dx, dy;
   _SkCubicCoefficients(double x0, double y0, double x1, double y1, double x2,
       double y2, double x3, double y3)
       : ax = x3 + (3 * (x1 - x2)) - x0,
@@ -704,6 +703,8 @@ class _SkCubicCoefficients {
         cy = 3 * (y1 - y0),
         dx = x0,
         dy = y0;
+
+  final double ax, ay, bx, by, cx, cy, dx, dy;
 
   double evalX(double t) => (((ax * t + bx) * t) + cx) * t + dx;
 

--- a/lib/web_ui/lib/src/engine/html/path/path_ref.dart
+++ b/lib/web_ui/lib/src/engine/html/path/path_ref.dart
@@ -27,6 +27,67 @@ class PathRef {
     _resetFields();
   }
 
+  /// Creates a copy of the path by pointing new path to a current
+  /// points,verbs and weights arrays. If original path is mutated by adding
+  /// more verbs, this copy only returns path at the time of copy and shares
+  /// typed arrays of original path.
+  PathRef.shallowCopy(PathRef ref)
+      : fPoints = ref.fPoints,
+        _fVerbs = ref._fVerbs {
+    _fVerbsCapacity = ref._fVerbsCapacity;
+    _fVerbsLength = ref._fVerbsLength;
+
+    _fPointsCapacity = ref._fPointsCapacity;
+    _fPointsLength = ref._fPointsLength;
+
+    _conicWeightsCapacity = ref._conicWeightsCapacity;
+    _conicWeightsLength = ref._conicWeightsLength;
+    _conicWeights = ref._conicWeights;
+    fBoundsIsDirty = ref.fBoundsIsDirty;
+    if (!fBoundsIsDirty) {
+      fBounds = ref.fBounds;
+      cachedBounds = ref.cachedBounds;
+      fIsFinite = ref.fIsFinite;
+    }
+    fSegmentMask = ref.fSegmentMask;
+    fIsOval = ref.fIsOval;
+    fIsRRect = ref.fIsRRect;
+    fIsRect = ref.fIsRect;
+    fRRectOrOvalIsCCW = ref.fRRectOrOvalIsCCW;
+    fRRectOrOvalStartIdx = ref.fRRectOrOvalStartIdx;
+    debugValidate();
+  }
+
+  /// Returns a new path by translating [source] by [offsetX], [offsetY].
+  PathRef.shiftedFrom(PathRef source, double offsetX, double offsetY)
+      : fPoints = _fPointsFromSource(source, offsetX, offsetY),
+        _fVerbs = _fVerbsFromSource(source) {
+    _conicWeightsCapacity = source._conicWeightsCapacity;
+    _conicWeightsLength = source._conicWeightsLength;
+    if (source._conicWeights != null) {
+      _conicWeights = Float32List(_conicWeightsCapacity);
+      _conicWeights!.setAll(0, source._conicWeights!);
+    }
+    _fVerbsCapacity = source._fVerbsCapacity;
+    _fVerbsLength = source._fVerbsLength;
+
+    _fPointsCapacity = source._fPointsCapacity;
+    _fPointsLength = source._fPointsLength;
+    fBoundsIsDirty = source.fBoundsIsDirty;
+    if (!fBoundsIsDirty) {
+      fBounds = source.fBounds!.translate(offsetX, offsetY);
+      cachedBounds = source.cachedBounds?.translate(offsetX, offsetY);
+      fIsFinite = source.fIsFinite;
+    }
+    fSegmentMask = source.fSegmentMask;
+    fIsOval = source.fIsOval;
+    fIsRRect = source.fIsRRect;
+    fIsRect = source.fIsRect;
+    fRRectOrOvalIsCCW = source.fRRectOrOvalIsCCW;
+    fRRectOrOvalStartIdx = source.fRRectOrOvalStartIdx;
+    debugValidate();
+  }
+
   // Value to use to check against to insert move(0,0) when a command
   // is added without moveTo.
   static const int kInitialLastMoveToIndex = -1;
@@ -83,37 +144,6 @@ class PathRef {
     final int index = pointIndex * 2;
     fPoints[index] = x;
     fPoints[index + 1] = y;
-  }
-
-  /// Creates a copy of the path by pointing new path to a current
-  /// points,verbs and weights arrays. If original path is mutated by adding
-  /// more verbs, this copy only returns path at the time of copy and shares
-  /// typed arrays of original path.
-  PathRef.shallowCopy(PathRef ref)
-      : fPoints = ref.fPoints,
-        _fVerbs = ref._fVerbs {
-    _fVerbsCapacity = ref._fVerbsCapacity;
-    _fVerbsLength = ref._fVerbsLength;
-
-    _fPointsCapacity = ref._fPointsCapacity;
-    _fPointsLength = ref._fPointsLength;
-
-    _conicWeightsCapacity = ref._conicWeightsCapacity;
-    _conicWeightsLength = ref._conicWeightsLength;
-    _conicWeights = ref._conicWeights;
-    fBoundsIsDirty = ref.fBoundsIsDirty;
-    if (!fBoundsIsDirty) {
-      fBounds = ref.fBounds;
-      cachedBounds = ref.cachedBounds;
-      fIsFinite = ref.fIsFinite;
-    }
-    fSegmentMask = ref.fSegmentMask;
-    fIsOval = ref.fIsOval;
-    fIsRRect = ref.fIsRRect;
-    fIsRect = ref.fIsRect;
-    fRRectOrOvalIsCCW = ref.fRRectOrOvalIsCCW;
-    fRRectOrOvalStartIdx = ref.fRRectOrOvalStartIdx;
-    debugValidate();
   }
 
   Float32List get points => fPoints;
@@ -393,36 +423,6 @@ class PathRef {
     final Uint8List verbs = Uint8List(source._fVerbsCapacity);
     verbs.setAll(0, source._fVerbs);
     return verbs;
-  }
-
-  /// Returns a new path by translating [source] by [offsetX], [offsetY].
-  PathRef.shiftedFrom(PathRef source, double offsetX, double offsetY)
-      : fPoints = _fPointsFromSource(source, offsetX, offsetY),
-        _fVerbs = _fVerbsFromSource(source) {
-    _conicWeightsCapacity = source._conicWeightsCapacity;
-    _conicWeightsLength = source._conicWeightsLength;
-    if (source._conicWeights != null) {
-      _conicWeights = Float32List(_conicWeightsCapacity);
-      _conicWeights!.setAll(0, source._conicWeights!);
-    }
-    _fVerbsCapacity = source._fVerbsCapacity;
-    _fVerbsLength = source._fVerbsLength;
-
-    _fPointsCapacity = source._fPointsCapacity;
-    _fPointsLength = source._fPointsLength;
-    fBoundsIsDirty = source.fBoundsIsDirty;
-    if (!fBoundsIsDirty) {
-      fBounds = source.fBounds!.translate(offsetX, offsetY);
-      cachedBounds = source.cachedBounds?.translate(offsetX, offsetY);
-      fIsFinite = source.fIsFinite;
-    }
-    fSegmentMask = source.fSegmentMask;
-    fIsOval = source.fIsOval;
-    fIsRRect = source.fIsRRect;
-    fIsRect = source.fIsRect;
-    fRRectOrOvalIsCCW = source.fRRectOrOvalIsCCW;
-    fRRectOrOvalStartIdx = source.fRRectOrOvalStartIdx;
-    debugValidate();
   }
 
   /// Copies contents from a source path [ref].
@@ -948,11 +948,6 @@ class PathRef {
 }
 
 class PathRefIterator {
-  final PathRef pathRef;
-  int _conicWeightIndex = -1;
-  int _verbIndex = 0;
-  int _pointIndex = 0;
-
   PathRefIterator(this.pathRef) {
     _pointIndex = 0;
     if (!pathRef.isFinite) {
@@ -961,6 +956,11 @@ class PathRefIterator {
       _verbIndex = pathRef.countVerbs();
     }
   }
+
+  final PathRef pathRef;
+  int _conicWeightIndex = -1;
+  int _verbIndex = 0;
+  int _pointIndex = 0;
 
   /// Maximum buffer size required for points in [next] calls.
   static const int kMaxBufferSize = 8;

--- a/lib/web_ui/lib/src/engine/html/path/path_utils.dart
+++ b/lib/web_ui/lib/src/engine/html/path/path_utils.dart
@@ -115,10 +115,10 @@ class SPathSegmentState {
 ///    x1 = Q / A
 ///    x2 = C / Q
 class QuadRoots {
+  QuadRoots();
+
   double? root0;
   double? root1;
-
-  QuadRoots();
 
   /// Returns roots as list.
   List<double> get roots => (root0 == null)

--- a/lib/web_ui/lib/src/engine/html/platform_view.dart
+++ b/lib/web_ui/lib/src/engine/html/platform_view.dart
@@ -8,13 +8,13 @@ import 'surface.dart';
 
 /// A surface containing a platform view, which is an HTML element.
 class PersistedPlatformView extends PersistedLeafSurface {
+  PersistedPlatformView(this.viewId, this.dx, this.dy, this.width, this.height);
+
   final int viewId;
   final double dx;
   final double dy;
   final double width;
   final double height;
-
-  PersistedPlatformView(this.viewId, this.dx, this.dy, this.width, this.height);
 
   @override
   DomElement createElement() {

--- a/lib/web_ui/lib/src/engine/html/recording_canvas.dart
+++ b/lib/web_ui/lib/src/engine/html/recording_canvas.dart
@@ -51,7 +51,7 @@ class RawRecordingCanvas extends BitmapCanvas implements ui.PictureRecorder {
 
   late RecordingCanvas _canvas; // ignore: unused_field
 
-  bool _isRecording = true; // ignore: unused_field
+  final bool _isRecording = true; // ignore: unused_field
 
   @override
   bool get isRecording => true;

--- a/lib/web_ui/lib/src/engine/html/recording_canvas.dart
+++ b/lib/web_ui/lib/src/engine/html/recording_canvas.dart
@@ -63,6 +63,9 @@ class RawRecordingCanvas extends BitmapCanvas implements ui.PictureRecorder {
 ///
 /// See [Canvas] for docs for these methods.
 class RecordingCanvas {
+  RecordingCanvas(ui.Rect? bounds)
+      : _paintBounds = _PaintBounds(bounds ?? ui.Rect.largest);
+
   /// Computes [_pictureBounds].
   final _PaintBounds _paintBounds;
 
@@ -90,9 +93,6 @@ class RecordingCanvas {
     }
     throw UnsupportedError('For debugging only.');
   }
-
-  RecordingCanvas(ui.Rect? bounds)
-      : _paintBounds = _PaintBounds(bounds ?? ui.Rect.largest);
 
   final RenderStrategy renderStrategy = RenderStrategy();
 
@@ -770,10 +770,10 @@ class PaintRestore extends PaintCommand {
 }
 
 class PaintTranslate extends PaintCommand {
+  PaintTranslate(this.dx, this.dy);
+
   final double dx;
   final double dy;
-
-  PaintTranslate(this.dx, this.dy);
 
   @override
   void apply(EngineCanvas canvas) {
@@ -791,10 +791,10 @@ class PaintTranslate extends PaintCommand {
 }
 
 class PaintScale extends PaintCommand {
+  PaintScale(this.sx, this.sy);
+
   final double sx;
   final double sy;
-
-  PaintScale(this.sx, this.sy);
 
   @override
   void apply(EngineCanvas canvas) {
@@ -812,9 +812,9 @@ class PaintScale extends PaintCommand {
 }
 
 class PaintRotate extends PaintCommand {
-  final double radians;
-
   PaintRotate(this.radians);
+
+  final double radians;
 
   @override
   void apply(EngineCanvas canvas) {
@@ -832,9 +832,9 @@ class PaintRotate extends PaintCommand {
 }
 
 class PaintTransform extends PaintCommand {
-  final Float32List matrix4;
-
   PaintTransform(this.matrix4);
+
+  final Float32List matrix4;
 
   @override
   void apply(EngineCanvas canvas) {
@@ -852,10 +852,10 @@ class PaintTransform extends PaintCommand {
 }
 
 class PaintSkew extends PaintCommand {
+  PaintSkew(this.sx, this.sy);
+
   final double sx;
   final double sy;
-
-  PaintSkew(this.sx, this.sy);
 
   @override
   void apply(EngineCanvas canvas) {
@@ -873,10 +873,10 @@ class PaintSkew extends PaintCommand {
 }
 
 class PaintClipRect extends DrawCommand {
+  PaintClipRect(this.rect, this.clipOp);
+
   final ui.Rect rect;
   final ui.ClipOp clipOp;
-
-  PaintClipRect(this.rect, this.clipOp);
 
   @override
   void apply(EngineCanvas canvas) {
@@ -894,9 +894,9 @@ class PaintClipRect extends DrawCommand {
 }
 
 class PaintClipRRect extends DrawCommand {
-  final ui.RRect rrect;
-
   PaintClipRRect(this.rrect);
+
+  final ui.RRect rrect;
 
   @override
   void apply(EngineCanvas canvas) {
@@ -914,9 +914,9 @@ class PaintClipRRect extends DrawCommand {
 }
 
 class PaintClipPath extends DrawCommand {
-  final SurfacePath path;
-
   PaintClipPath(this.path);
+
+  final SurfacePath path;
 
   @override
   void apply(EngineCanvas canvas) {
@@ -934,10 +934,10 @@ class PaintClipPath extends DrawCommand {
 }
 
 class PaintDrawColor extends DrawCommand {
+  PaintDrawColor(this.color, this.blendMode);
+
   final ui.Color color;
   final ui.BlendMode blendMode;
-
-  PaintDrawColor(this.color, this.blendMode);
 
   @override
   void apply(EngineCanvas canvas) {
@@ -955,11 +955,11 @@ class PaintDrawColor extends DrawCommand {
 }
 
 class PaintDrawLine extends DrawCommand {
+  PaintDrawLine(this.p1, this.p2, this.paint);
+
   final ui.Offset p1;
   final ui.Offset p2;
   final SurfacePaintData paint;
-
-  PaintDrawLine(this.p1, this.p2, this.paint);
 
   @override
   void apply(EngineCanvas canvas) {
@@ -977,9 +977,9 @@ class PaintDrawLine extends DrawCommand {
 }
 
 class PaintDrawPaint extends DrawCommand {
-  final SurfacePaintData paint;
-
   PaintDrawPaint(this.paint);
+
+  final SurfacePaintData paint;
 
   @override
   void apply(EngineCanvas canvas) {
@@ -997,10 +997,11 @@ class PaintDrawPaint extends DrawCommand {
 }
 
 class PaintDrawVertices extends DrawCommand {
+  PaintDrawVertices(this.vertices, this.blendMode, this.paint);
+
   final ui.Vertices vertices;
   final ui.BlendMode blendMode;
   final SurfacePaintData paint;
-  PaintDrawVertices(this.vertices, this.blendMode, this.paint);
 
   @override
   void apply(EngineCanvas canvas) {
@@ -1018,10 +1019,11 @@ class PaintDrawVertices extends DrawCommand {
 }
 
 class PaintDrawPoints extends DrawCommand {
+  PaintDrawPoints(this.pointMode, this.points, this.paint);
+
   final Float32List points;
   final ui.PointMode pointMode;
   final SurfacePaintData paint;
-  PaintDrawPoints(this.pointMode, this.points, this.paint);
 
   @override
   void apply(EngineCanvas canvas) {
@@ -1039,10 +1041,10 @@ class PaintDrawPoints extends DrawCommand {
 }
 
 class PaintDrawRect extends DrawCommand {
+  PaintDrawRect(this.rect, this.paint);
+
   final ui.Rect rect;
   final SurfacePaintData paint;
-
-  PaintDrawRect(this.rect, this.paint);
 
   @override
   void apply(EngineCanvas canvas) {
@@ -1060,10 +1062,10 @@ class PaintDrawRect extends DrawCommand {
 }
 
 class PaintDrawRRect extends DrawCommand {
+  PaintDrawRRect(this.rrect, this.paint);
+
   final ui.RRect rrect;
   final SurfacePaintData paint;
-
-  PaintDrawRRect(this.rrect, this.paint);
 
   @override
   void apply(EngineCanvas canvas) {
@@ -1081,10 +1083,6 @@ class PaintDrawRRect extends DrawCommand {
 }
 
 class PaintDrawDRRect extends DrawCommand {
-  final ui.RRect outer;
-  final ui.RRect inner;
-  final SurfacePaintData paint;
-  ui.Path? path;
   PaintDrawDRRect(this.outer, this.inner, this.paint) {
     path = ui.Path()
       ..fillType = ui.PathFillType.evenOdd
@@ -1092,6 +1090,11 @@ class PaintDrawDRRect extends DrawCommand {
       ..addRRect(inner)
       ..close();
   }
+
+  final ui.RRect outer;
+  final ui.RRect inner;
+  final SurfacePaintData paint;
+  ui.Path? path;
 
   @override
   void apply(EngineCanvas canvas) {
@@ -1110,10 +1113,10 @@ class PaintDrawDRRect extends DrawCommand {
 }
 
 class PaintDrawOval extends DrawCommand {
+  PaintDrawOval(this.rect, this.paint);
+
   final ui.Rect rect;
   final SurfacePaintData paint;
-
-  PaintDrawOval(this.rect, this.paint);
 
   @override
   void apply(EngineCanvas canvas) {
@@ -1131,11 +1134,11 @@ class PaintDrawOval extends DrawCommand {
 }
 
 class PaintDrawCircle extends DrawCommand {
+  PaintDrawCircle(this.c, this.radius, this.paint);
+
   final ui.Offset c;
   final double radius;
   final SurfacePaintData paint;
-
-  PaintDrawCircle(this.c, this.radius, this.paint);
 
   @override
   void apply(EngineCanvas canvas) {
@@ -1153,10 +1156,10 @@ class PaintDrawCircle extends DrawCommand {
 }
 
 class PaintDrawPath extends DrawCommand {
+  PaintDrawPath(this.path, this.paint);
+
   final SurfacePath path;
   final SurfacePaintData paint;
-
-  PaintDrawPath(this.path, this.paint);
 
   @override
   void apply(EngineCanvas canvas) {
@@ -1198,11 +1201,11 @@ class PaintDrawShadow extends DrawCommand {
 }
 
 class PaintDrawImage extends DrawCommand {
+  PaintDrawImage(this.image, this.offset, this.paint);
+
   final ui.Image image;
   final ui.Offset offset;
   final SurfacePaintData paint;
-
-  PaintDrawImage(this.image, this.offset, this.paint);
 
   @override
   void apply(EngineCanvas canvas) {
@@ -1220,12 +1223,12 @@ class PaintDrawImage extends DrawCommand {
 }
 
 class PaintDrawImageRect extends DrawCommand {
+  PaintDrawImageRect(this.image, this.src, this.dst, this.paint);
+
   final ui.Image image;
   final ui.Rect src;
   final ui.Rect dst;
   final SurfacePaintData paint;
-
-  PaintDrawImageRect(this.image, this.src, this.dst, this.paint);
 
   @override
   void apply(EngineCanvas canvas) {
@@ -1243,10 +1246,10 @@ class PaintDrawImageRect extends DrawCommand {
 }
 
 class PaintDrawParagraph extends DrawCommand {
+  PaintDrawParagraph(this.paragraph, this.offset);
+
   final CanvasParagraph paragraph;
   final ui.Offset offset;
-
-  PaintDrawParagraph(this.paragraph, this.offset);
 
   @override
   void apply(EngineCanvas canvas) {
@@ -1264,14 +1267,14 @@ class PaintDrawParagraph extends DrawCommand {
 }
 
 class Subpath {
+  Subpath(this.startX, this.startY) : commands = <PathCommand>[];
+
   double startX = 0.0;
   double startY = 0.0;
   double currentX = 0.0;
   double currentY = 0.0;
 
   final List<PathCommand> commands;
-
-  Subpath(this.startX, this.startY) : commands = <PathCommand>[];
 
   Subpath shift(ui.Offset offset) {
     final Subpath result = Subpath(startX + offset.dx, startY + offset.dy)
@@ -1310,10 +1313,10 @@ abstract class PathCommand {
 }
 
 class MoveTo extends PathCommand {
+  const MoveTo(this.x, this.y);
+
   final double x;
   final double y;
-
-  const MoveTo(this.x, this.y);
 
   @override
   MoveTo shifted(ui.Offset offset) {
@@ -1337,10 +1340,10 @@ class MoveTo extends PathCommand {
 }
 
 class LineTo extends PathCommand {
+  const LineTo(this.x, this.y);
+
   final double x;
   final double y;
-
-  const LineTo(this.x, this.y);
 
   @override
   LineTo shifted(ui.Offset offset) {
@@ -1364,6 +1367,9 @@ class LineTo extends PathCommand {
 }
 
 class Ellipse extends PathCommand {
+  const Ellipse(this.x, this.y, this.radiusX, this.radiusY, this.rotation,
+      this.startAngle, this.endAngle, this.anticlockwise);
+
   final double x;
   final double y;
   final double radiusX;
@@ -1372,9 +1378,6 @@ class Ellipse extends PathCommand {
   final double startAngle;
   final double endAngle;
   final bool anticlockwise;
-
-  const Ellipse(this.x, this.y, this.radiusX, this.radiusY, this.rotation,
-      this.startAngle, this.endAngle, this.anticlockwise);
 
   @override
   Ellipse shifted(ui.Offset offset) {
@@ -1496,12 +1499,12 @@ class Ellipse extends PathCommand {
 }
 
 class QuadraticCurveTo extends PathCommand {
+  const QuadraticCurveTo(this.x1, this.y1, this.x2, this.y2);
+
   final double x1;
   final double y1;
   final double x2;
   final double y2;
-
-  const QuadraticCurveTo(this.x1, this.y1, this.x2, this.y2);
 
   @override
   QuadraticCurveTo shifted(ui.Offset offset) {
@@ -1536,14 +1539,14 @@ class QuadraticCurveTo extends PathCommand {
 }
 
 class BezierCurveTo extends PathCommand {
+  const BezierCurveTo(this.x1, this.y1, this.x2, this.y2, this.x3, this.y3);
+
   final double x1;
   final double y1;
   final double x2;
   final double y2;
   final double x3;
   final double y3;
-
-  const BezierCurveTo(this.x1, this.y1, this.x2, this.y2, this.x3, this.y3);
 
   @override
   BezierCurveTo shifted(ui.Offset offset) {
@@ -1580,12 +1583,12 @@ class BezierCurveTo extends PathCommand {
 }
 
 class RectCommand extends PathCommand {
+  const RectCommand(this.x, this.y, this.width, this.height);
+
   final double x;
   final double y;
   final double width;
   final double height;
-
-  const RectCommand(this.x, this.y, this.width, this.height);
 
   @override
   RectCommand shifted(ui.Offset offset) {
@@ -1637,9 +1640,9 @@ class RectCommand extends PathCommand {
 }
 
 class RRectCommand extends PathCommand {
-  final ui.RRect rrect;
-
   const RRectCommand(this.rrect);
+
+  final ui.RRect rrect;
 
   @override
   RRectCommand shifted(ui.Offset offset) {
@@ -1685,6 +1688,8 @@ class CloseCommand extends PathCommand {
 }
 
 class _PaintBounds {
+  _PaintBounds(this.maxPaintBounds);
+
   // Bounds of maximum area that is paintable by canvas ops.
   final ui.Rect maxPaintBounds;
 
@@ -1708,8 +1713,6 @@ class _PaintBounds {
       _currentClipTop = 0.0,
       _currentClipRight = 0.0,
       _currentClipBottom = 0.0;
-
-  _PaintBounds(this.maxPaintBounds);
 
   void translate(double dx, double dy) {
     if (dx != 0.0 || dy != 0.0) {
@@ -2045,6 +2048,8 @@ double _getPaintSpread(SurfacePaint paint) {
 /// Contains metrics collected by recording canvas to provide data for
 /// rendering heuristics (canvas use vs DOM).
 class RenderStrategy {
+  RenderStrategy();
+
   /// Whether paint commands contain image elements.
   bool hasImageElements = false;
 
@@ -2063,8 +2068,6 @@ class RenderStrategy {
   /// element tree. When this is set to true, we prevent canvas usage in
   /// bitmap canvas and instead render using dom primitives and svg only.
   bool isInsideSvgFilterTree = false;
-
-  RenderStrategy();
 
   /// Merges render strategy settings from a child recording.
   void merge(RenderStrategy childStrategy) {

--- a/lib/web_ui/lib/src/engine/html/recording_canvas.dart
+++ b/lib/web_ui/lib/src/engine/html/recording_canvas.dart
@@ -14,7 +14,6 @@ import '../shadow.dart';
 import '../text/canvas_paragraph.dart';
 import '../util.dart';
 import '../vector_math.dart';
-import 'bitmap_canvas.dart';
 import 'painting.dart';
 import 'path/path.dart';
 import 'path/path_utils.dart';
@@ -33,30 +32,6 @@ double _measureBorderRadius(double x, double y) {
   final double clampedX = x < 0 ? 0 : x;
   final double clampedY = y < 0 ? 0 : y;
   return clampedX * clampedX + clampedY * clampedY;
-}
-
-class RawRecordingCanvas extends BitmapCanvas implements ui.PictureRecorder {
-  RawRecordingCanvas(ui.Size size)
-      : super(ui.Offset.zero & size, RenderStrategy());
-
-  @override
-  void dispose() {
-    clear();
-  }
-
-  RecordingCanvas beginRecording(ui.Rect bounds) => throw UnsupportedError('');
-
-  @override
-  ui.Picture endRecording() => throw UnsupportedError('');
-
-  late RecordingCanvas _canvas; // ignore: unused_field
-
-  final bool _isRecording = true; // ignore: unused_field
-
-  @override
-  bool get isRecording => true;
-
-  ui.Rect? cullRect;
 }
 
 /// Records canvas commands to be applied to a [EngineCanvas].

--- a/lib/web_ui/lib/src/engine/html/render_vertices.dart
+++ b/lib/web_ui/lib/src/engine/html/render_vertices.dart
@@ -20,7 +20,7 @@ import 'shaders/vertex_shaders.dart';
 
 GlRenderer? glRenderer;
 
-class SurfaceVertices implements ui.Vertices { // ignore: unused_field
+class SurfaceVertices implements ui.Vertices {
   SurfaceVertices(
     this.mode,
     List<ui.Offset> positions, {
@@ -50,7 +50,7 @@ class SurfaceVertices implements ui.Vertices { // ignore: unused_field
   final ui.VertexMode mode;
   final Float32List positions;
   final Int32List? colors;
-  final Uint16List? indices;
+  final Uint16List? indices; // ignore: unused_field
 
   static Int32List _int32ListFromColors(List<ui.Color> colors) {
     final Int32List list = Int32List(colors.length);

--- a/lib/web_ui/lib/src/engine/html/render_vertices.dart
+++ b/lib/web_ui/lib/src/engine/html/render_vertices.dart
@@ -20,12 +20,7 @@ import 'shaders/vertex_shaders.dart';
 
 GlRenderer? glRenderer;
 
-class SurfaceVertices implements ui.Vertices {
-  final ui.VertexMode mode;
-  final Float32List positions;
-  final Int32List? colors;
-  final Uint16List? indices; // ignore: unused_field
-
+class SurfaceVertices implements ui.Vertices { // ignore: unused_field
   SurfaceVertices(
     this.mode,
     List<ui.Offset> positions, {
@@ -51,6 +46,11 @@ class SurfaceVertices implements ui.Vertices {
         assert(positions != null) { // ignore: unnecessary_null_comparison
     initWebGl();
   }
+
+  final ui.VertexMode mode;
+  final Float32List positions;
+  final Int32List? colors;
+  final Uint16List? indices;
 
   static Int32List _int32ListFromColors(List<ui.Color> colors) {
     final Int32List list = Int32List(colors.length);

--- a/lib/web_ui/lib/src/engine/html/shaders/normalized_gradient.dart
+++ b/lib/web_ui/lib/src/engine/html/shaders/normalized_gradient.dart
@@ -22,12 +22,6 @@ import 'shader_builder.dart';
 ///              scale = (c2 - c1) / (t2 - t1)
 ///              bias = c1 - t1 / (t2 - t1) * (c2 - c1)
 class NormalizedGradient {
-  final Float32List _thresholds;
-  final Float32List _bias;
-  final Float32List _scale;
-  final int thresholdCount;
-  final bool isOpaque;
-
   factory NormalizedGradient(List<ui.Color> colors, {List<double>? stops}) {
     // If colorStops is not provided, then only two stops, at 0.0 and 1.0,
     // are implied (and colors must therefore only have two entries).
@@ -101,6 +95,12 @@ class NormalizedGradient {
 
   NormalizedGradient._(
       this.thresholdCount, this._thresholds, this._scale, this._bias, this.isOpaque);
+
+  final Float32List _thresholds;
+  final Float32List _bias;
+  final Float32List _scale;
+  final int thresholdCount;
+  final bool isOpaque;
 
   /// Sets uniforms for threshold, bias and scale for program.
   void setupUniforms(GlContext gl, GlProgram glProgram) {

--- a/lib/web_ui/lib/src/engine/html/shaders/shader_builder.dart
+++ b/lib/web_ui/lib/src/engine/html/shaders/shader_builder.dart
@@ -28,6 +28,13 @@ import '../../util.dart';
 ///  method.addStatement('${u1.name} = vec4(1.0, 1.0, 1.0, 0.0);');
 ///  source = builder.build();
 class ShaderBuilder {
+  ShaderBuilder(this.version) : isWebGl2 = version == WebGLVersion.webgl2,
+        _isFragmentShader = false;
+
+  ShaderBuilder.fragment(this.version) :
+        isWebGl2 = version == WebGLVersion.webgl2,
+        _isFragmentShader = true;
+
   /// WebGL version.
   final int version;
   final List<ShaderDeclaration> declarations = <ShaderDeclaration>[];
@@ -58,13 +65,6 @@ class ShaderBuilder {
 
   /// Lazily allocated fragment color output.
   ShaderDeclaration? _fragmentColorDeclaration;
-
-  ShaderBuilder(this.version) : isWebGl2 = version == WebGLVersion.webgl2,
-        _isFragmentShader = false;
-
-  ShaderBuilder.fragment(this.version) :
-        isWebGl2 = version == WebGLVersion.webgl2,
-        _isFragmentShader = true;
 
   /// Returns fragment color declaration for fragment shader.
   ///
@@ -345,10 +345,6 @@ abstract class ShaderStorageQualifier {
 
 /// Shader variable and constant declaration.
 class ShaderDeclaration {
-  final String name;
-  final int dataType;
-  final int storage;
-  final String constValue;
   ShaderDeclaration(this.name, this.dataType, this.storage)
       : assert(!_isGLSLReservedWord(name)),
         constValue = '';
@@ -356,6 +352,11 @@ class ShaderDeclaration {
   /// Constructs a constant.
   ShaderDeclaration.constant(this.name, this.dataType, this.constValue)
       : storage = ShaderStorageQualifier.kConst;
+
+  final String name;
+  final int dataType;
+  final int storage;
+  final String constValue;
 }
 
 // These are used only in debug mode to assert if used as variable name.

--- a/lib/web_ui/lib/src/engine/html_image_codec.dart
+++ b/lib/web_ui/lib/src/engine/html_image_codec.dart
@@ -25,10 +25,10 @@ typedef WebOnlyImageCodecChunkCallback = void Function(
     int cumulativeBytesLoaded, int expectedTotalBytes);
 
 class HtmlCodec implements ui.Codec {
+  HtmlCodec(this.src, {this.chunkCallback});
+
   final String src;
   final WebOnlyImageCodecChunkCallback? chunkCallback;
-
-  HtmlCodec(this.src, {this.chunkCallback});
 
   @override
   int get frameCount => 1;
@@ -119,9 +119,9 @@ class HtmlCodec implements ui.Codec {
 }
 
 class HtmlBlobCodec extends HtmlCodec {
-  final DomBlob blob;
-
   HtmlBlobCodec(this.blob) : super(domWindow.URL.createObjectURL(blob));
+
+  final DomBlob blob;
 
   @override
   void dispose() {
@@ -140,9 +140,10 @@ class SingleFrameInfo implements ui.FrameInfo {
 }
 
 class HtmlImage implements ui.Image {
+  HtmlImage(this.imgElement, this.width, this.height);
+
   final DomHTMLImageElement imgElement;
   bool _requiresClone = false;
-  HtmlImage(this.imgElement, this.width, this.height);
 
   bool _disposed = false;
   @override

--- a/lib/web_ui/lib/src/engine/keyboard.dart
+++ b/lib/web_ui/lib/src/engine/keyboard.dart
@@ -13,6 +13,21 @@ import 'services.dart';
 
 /// Provides keyboard bindings, such as the `flutter/keyevent` channel.
 class Keyboard {
+  Keyboard._(this._onMacOs) {
+    _keydownListener = allowInterop((DomEvent event) {
+      _handleHtmlEvent(event);
+    });
+    domWindow.addEventListener('keydown', _keydownListener);
+
+    _keyupListener = allowInterop((DomEvent event) {
+      _handleHtmlEvent(event);
+    });
+    domWindow.addEventListener('keyup', _keyupListener);
+    registerHotRestartListener(() {
+      dispose();
+    });
+  }
+
   /// Initializes the [Keyboard] singleton.
   ///
   /// Use the [instance] getter to get the singleton after calling this method.
@@ -32,21 +47,6 @@ class Keyboard {
 
   DomEventListener? _keydownListener;
   DomEventListener? _keyupListener;
-
-  Keyboard._(this._onMacOs) {
-    _keydownListener = allowInterop((DomEvent event) {
-      _handleHtmlEvent(event);
-    });
-    domWindow.addEventListener('keydown', _keydownListener);
-
-    _keyupListener = allowInterop((DomEvent event) {
-      _handleHtmlEvent(event);
-    });
-    domWindow.addEventListener('keyup', _keyupListener);
-    registerHotRestartListener(() {
-      dispose();
-    });
-  }
 
   /// Uninitializes the [Keyboard] singleton.
   ///

--- a/lib/web_ui/lib/src/engine/keyboard.dart
+++ b/lib/web_ui/lib/src/engine/keyboard.dart
@@ -73,7 +73,7 @@ class Keyboard {
   /// Initializing with `0x0` which means no meta keys are pressed.
   int _lastMetaState = 0x0;
 
-  bool _onMacOs;
+  final bool _onMacOs;
 
   // When the user enters a browser/system shortcut (e.g. `cmd+alt+i`) on macOS,
   // the browser doesn't send a keyup for it. This puts the framework in a

--- a/lib/web_ui/lib/src/engine/keyboard_binding.dart
+++ b/lib/web_ui/lib/src/engine/keyboard_binding.dart
@@ -88,6 +88,10 @@ Duration _eventTimeStampToDuration(num milliseconds) {
 }
 
 class KeyboardBinding {
+  KeyboardBinding._(this.glassPaneElement) {
+    _setup();
+  }
+
   /// The singleton instance of this object.
   static KeyboardBinding? get instance => _instance;
   static KeyboardBinding? _instance;
@@ -100,10 +104,6 @@ class KeyboardBinding {
         return true;
       }());
     }
-  }
-
-  KeyboardBinding._(this.glassPaneElement) {
-    _setup();
   }
 
   final DomElement glassPaneElement;

--- a/lib/web_ui/lib/src/engine/mouse_cursor.dart
+++ b/lib/web_ui/lib/src/engine/mouse_cursor.dart
@@ -7,6 +7,8 @@ import 'util.dart';
 
 /// Provides mouse cursor bindings, such as the `flutter/mousecursor` channel.
 class MouseCursor {
+  MouseCursor._();
+
   /// Initializes the [MouseCursor] singleton.
   ///
   /// Use the [instance] getter to get the singleton after calling this method.
@@ -17,8 +19,6 @@ class MouseCursor {
   /// The [MouseCursor] singleton.
   static MouseCursor? get instance => _instance;
   static MouseCursor? _instance;
-
-  MouseCursor._();
 
   // Map from Flutter's kind values to CSS's cursor values.
   //

--- a/lib/web_ui/lib/src/engine/navigation/history.dart
+++ b/lib/web_ui/lib/src/engine/navigation/history.dart
@@ -287,7 +287,7 @@ class SingleEntryBrowserHistory extends BrowserHistory {
     return originState['state'];
   }
 
-  Map<String, bool> _flutterState = <String, bool>{_kFlutterTag: true};
+  final Map<String, bool> _flutterState = <String, bool>{_kFlutterTag: true};
 
   /// The origin entry is the history entry that the Flutter app landed on. It's
   /// created by the browser when the user navigates to the url of the app.

--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -142,14 +142,14 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
   @override
   Iterable<ui.FlutterView> get views => _windows.values;
   Map<Object, ui.FlutterWindow> get windows => _windows;
-  Map<Object, ui.FlutterWindow> _windows = <Object, ui.FlutterWindow>{};
+  final Map<Object, ui.FlutterWindow> _windows = <Object, ui.FlutterWindow>{};
 
   /// A map of opaque platform window identifiers to window configurations.
   ///
   /// This should be considered a protected member, only to be used by
   /// [PlatformDispatcher] subclasses.
   Map<Object, ui.ViewConfiguration> get windowConfigurations => _windowConfigurations;
-  Map<Object, ui.ViewConfiguration> _windowConfigurations =
+  final Map<Object, ui.ViewConfiguration> _windowConfigurations =
       <Object, ui.ViewConfiguration>{};
 
   /// A callback that is invoked whenever the platform's [devicePixelRatio],

--- a/lib/web_ui/lib/src/engine/platform_views/message_handler.dart
+++ b/lib/web_ui/lib/src/engine/platform_views/message_handler.dart
@@ -39,16 +39,15 @@ typedef PlatformViewContentHandler = void Function(DomElement);
 /// some extra cleanup of its internal state, but it can do it automatically. See
 /// [HtmlViewEmbedder.disposeViews]
 class PlatformViewMessageHandler {
-  final MethodCodec _codec = const StandardMethodCodec();
-
-  final PlatformViewManager _contentManager;
-  final PlatformViewContentHandler? _contentHandler;
-
   PlatformViewMessageHandler({
     required PlatformViewManager contentManager,
     PlatformViewContentHandler? contentHandler,
   }) : _contentManager = contentManager,
        _contentHandler = contentHandler;
+
+  final MethodCodec _codec = const StandardMethodCodec();
+  final PlatformViewManager _contentManager;
+  final PlatformViewContentHandler? _contentHandler;
 
   /// Handle a `create` Platform View message.
   ///

--- a/lib/web_ui/lib/src/engine/pointer_binding.dart
+++ b/lib/web_ui/lib/src/engine/pointer_binding.dart
@@ -106,7 +106,7 @@ class PointerBinding {
   final DomElement glassPaneElement;
 
   PointerSupportDetector _detector;
-  PointerDataConverter _pointerDataConverter;
+  final PointerDataConverter _pointerDataConverter;
   late _BaseAdapter _adapter;
 
   /// Should be used in tests to define custom detection of pointer support.
@@ -245,8 +245,8 @@ abstract class _BaseAdapter {
 
   final List<_Listener> _listeners = <_Listener>[];
   final DomElement glassPaneElement;
-  _PointerDataCallback _callback;
-  PointerDataConverter _pointerDataConverter;
+  final _PointerDataCallback _callback;
+  final PointerDataConverter _pointerDataConverter;
 
   /// Each subclass is expected to override this method to attach its own event
   /// listeners and convert events into pointer events.

--- a/lib/web_ui/lib/src/engine/pointer_binding.dart
+++ b/lib/web_ui/lib/src/engine/pointer_binding.dart
@@ -73,6 +73,15 @@ class SafariPointerEventWorkaround {
 }
 
 class PointerBinding {
+  PointerBinding(this.glassPaneElement)
+    : _pointerDataConverter = PointerDataConverter(),
+      _detector = const PointerSupportDetector() {
+    if (isIosSafari) {
+      SafariPointerEventWorkaround.instance.workAroundMissingPointerEvents();
+    }
+    _adapter = _createAdapter();
+  }
+
   /// The singleton instance of this object.
   static PointerBinding? get instance => _instance;
   static PointerBinding? _instance;
@@ -92,15 +101,6 @@ class PointerBinding {
   void dispose() {
     _adapter.clearListeners();
     _pointerDataConverter.clearPointerState();
-  }
-
-  PointerBinding(this.glassPaneElement)
-    : _pointerDataConverter = PointerDataConverter(),
-      _detector = const PointerSupportDetector() {
-    if (isIosSafari) {
-      SafariPointerEventWorkaround.instance.workAroundMissingPointerEvents();
-    }
-    _adapter = _createAdapter();
   }
 
   final DomElement glassPaneElement;

--- a/lib/web_ui/lib/src/engine/rrect_renderer.dart
+++ b/lib/web_ui/lib/src/engine/rrect_renderer.dart
@@ -183,8 +183,8 @@ abstract class RRectRenderer {
 
 /// Renders RRect to a 2d canvas.
 class RRectToCanvasRenderer extends RRectRenderer {
-  final DomCanvasRenderingContext2D context;
   RRectToCanvasRenderer(this.context);
+  final DomCanvasRenderingContext2D context;
   @override
   void beginPath() {
     context.beginPath();
@@ -210,8 +210,8 @@ class RRectToCanvasRenderer extends RRectRenderer {
 
 /// Renders RRect to a path.
 class RRectToPathRenderer extends RRectRenderer {
-  final ui.Path path;
   RRectToPathRenderer(this.path);
+  final ui.Path path;
   @override
   void beginPath() {}
 

--- a/lib/web_ui/lib/src/engine/semantics/accessibility.dart
+++ b/lib/web_ui/lib/src/engine/semantics/accessibility.dart
@@ -27,6 +27,12 @@ final AccessibilityAnnouncements accessibilityAnnouncements =
 /// Attaches accessibility announcements coming from the 'flutter/accessibility'
 /// channel as temporary elements to the DOM.
 class AccessibilityAnnouncements {
+  AccessibilityAnnouncements._() {
+    registerHotRestartListener(() {
+      _removeElementTimer?.cancel();
+    });
+  }
+
   /// Initializes the [AccessibilityAnnouncements] singleton if it is not
   /// already initialized.
   static AccessibilityAnnouncements get instance {
@@ -34,12 +40,6 @@ class AccessibilityAnnouncements {
   }
 
   static AccessibilityAnnouncements? _instance;
-
-  AccessibilityAnnouncements._() {
-    registerHotRestartListener(() {
-      _removeElementTimer?.cancel();
-    });
-  }
 
   /// Timer that times when the accessibility element should be removed from the
   /// DOM.

--- a/lib/web_ui/lib/src/engine/semantics/checkable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/checkable.dart
@@ -50,11 +50,11 @@ _CheckableKind _checkableKindFromSemanticsFlag(
 /// [ui.SemanticsFlag.isInMutuallyExclusiveGroup], [ui.SemanticsFlag.isToggled],
 /// [ui.SemanticsFlag.hasToggledState]
 class Checkable extends RoleManager {
-  final _CheckableKind _kind;
-
   Checkable(SemanticsObject semanticsObject)
       : _kind = _checkableKindFromSemanticsFlag(semanticsObject),
         super(Role.checkable, semanticsObject);
+
+  final _CheckableKind _kind;
 
   @override
   void update() {

--- a/lib/web_ui/lib/src/engine/semantics/incrementable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/incrementable.dart
@@ -19,30 +19,6 @@ import 'semantics.dart';
 /// events. This is to prevent the browser from taking over drag gestures. Drag
 /// gestures must be interpreted by the Flutter framework.
 class Incrementable extends RoleManager {
-  /// The HTML element used to render semantics to the browser.
-  final DomHTMLInputElement _element = createDomHTMLInputElement();
-
-  /// The value used by the input element.
-  ///
-  /// Flutter values are strings, and are not necessarily numbers. In order to
-  /// convey to the browser what the available "range" of values is we
-  /// substitute the framework value with a generated `int` surrogate.
-  /// "aria-valuetext" attribute is used to cause the browser to announce the
-  /// framework value to the user.
-  int _currentSurrogateValue = 1;
-
-  /// Disables the input [_element] when the gesture mode switches to
-  /// [GestureMode.pointerEvents], and enables it when the mode switches back to
-  /// [GestureMode.browserGestures].
-  GestureModeCallback? _gestureModeListener;
-
-  /// Whether we forwarded a semantics action to the framework and awaiting an
-  /// update.
-  ///
-  /// This field is used to determine whether the HTML DOM of the semantics
-  /// tree should be updated.
-  bool _pendingResync = false;
-
   Incrementable(SemanticsObject semanticsObject)
       : super(Role.incrementable, semanticsObject) {
     semanticsObject.element.append(_element);
@@ -73,6 +49,30 @@ class Incrementable extends RoleManager {
     };
     semanticsObject.owner.addGestureModeListener(_gestureModeListener);
   }
+
+  /// The HTML element used to render semantics to the browser.
+  final DomHTMLInputElement _element = createDomHTMLInputElement();
+
+  /// The value used by the input element.
+  ///
+  /// Flutter values are strings, and are not necessarily numbers. In order to
+  /// convey to the browser what the available "range" of values is we
+  /// substitute the framework value with a generated `int` surrogate.
+  /// "aria-valuetext" attribute is used to cause the browser to announce the
+  /// framework value to the user.
+  int _currentSurrogateValue = 1;
+
+  /// Disables the input [_element] when the gesture mode switches to
+  /// [GestureMode.pointerEvents], and enables it when the mode switches back to
+  /// [GestureMode.browserGestures].
+  GestureModeCallback? _gestureModeListener;
+
+  /// Whether we forwarded a semantics action to the framework and awaiting an
+  /// update.
+  ///
+  /// This field is used to determine whether the HTML DOM of the semantics
+  /// tree should be updated.
+  bool _pendingResync = false;
 
   @override
   void update() {

--- a/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -1724,7 +1724,7 @@ class EngineSemanticsOwner {
   /// Callbacks are called synchronously. HTML DOM updates made in a callback
   /// take effect in the current animation frame and/or the current message loop
   /// event.
-  List<GestureModeCallback?> _gestureModeListeners = <GestureModeCallback?>[];
+  final List<GestureModeCallback?> _gestureModeListeners = <GestureModeCallback?>[];
 
   /// Calls the [callback] every time the current [GestureMode] changes.
   ///

--- a/lib/web_ui/lib/src/engine/semantics/text_field.dart
+++ b/lib/web_ui/lib/src/engine/semantics/text_field.dart
@@ -21,6 +21,11 @@ import 'semantics.dart';
 /// This class is still responsible for hooking up the DOM element with the
 /// [HybridTextEditing] instance so that changes are communicated to Flutter.
 class SemanticsTextEditingStrategy extends DefaultTextEditingStrategy {
+  /// Creates a [SemanticsTextEditingStrategy] that eagerly instantiates
+  /// [domElement] so the caller can insert it before calling
+  /// [SemanticsTextEditingStrategy.enable].
+  SemanticsTextEditingStrategy(super.owner);
+
   /// Initializes the [SemanticsTextEditingStrategy] singleton.
   ///
   /// This method must be called prior to accessing [instance].
@@ -34,11 +39,6 @@ class SemanticsTextEditingStrategy extends DefaultTextEditingStrategy {
   /// The [SemanticsTextEditingStrategy] singleton.
   static SemanticsTextEditingStrategy get instance => _instance!;
   static SemanticsTextEditingStrategy? _instance;
-
-  /// Creates a [SemanticsTextEditingStrategy] that eagerly instantiates
-  /// [domElement] so the caller can insert it before calling
-  /// [SemanticsTextEditingStrategy.enable].
-  SemanticsTextEditingStrategy(super.owner);
 
   /// The text field whose DOM element is currently used for editing.
   ///

--- a/lib/web_ui/lib/src/engine/services/buffers.dart
+++ b/lib/web_ui/lib/src/engine/services/buffers.dart
@@ -6,6 +6,10 @@ import 'dart:collection';
 import 'dart:typed_data';
 
 abstract class _TypedDataBuffer<E> extends ListBase<E> {
+  _TypedDataBuffer(List<E> buffer)
+      : _buffer = buffer,
+        _length = buffer.length;
+
   static const int _initialLength = 8;
 
   /// The underlying data buffer.
@@ -19,10 +23,6 @@ abstract class _TypedDataBuffer<E> extends ListBase<E> {
 
   /// The length of the list being built.
   int _length;
-
-  _TypedDataBuffer(List<E> buffer)
-      : _buffer = buffer,
-        _length = buffer.length;
 
   @override
   int get length => _length;

--- a/lib/web_ui/lib/src/engine/services/message_codecs.dart
+++ b/lib/web_ui/lib/src/engine/services/message_codecs.dart
@@ -212,6 +212,9 @@ class JSONMethodCodec implements MethodCodec {
 /// The codec is extensible by subclasses overriding [writeValue] and
 /// [readValueOfType].
 class StandardMessageCodec implements MessageCodec<dynamic> {
+  /// Creates a [MessageCodec] using the Flutter standard binary encoding.
+  const StandardMessageCodec();
+
   // The codec serializes messages as outlined below. This format must
   // match the Android and iOS counterparts.
   //
@@ -263,9 +266,6 @@ class StandardMessageCodec implements MessageCodec<dynamic> {
   static const int _valueFloat64List = 11;
   static const int _valueList = 12;
   static const int _valueMap = 13;
-
-  /// Creates a [MessageCodec] using the Flutter standard binary encoding.
-  const StandardMessageCodec();
 
   @override
   ByteData? encodeMessage(dynamic message) {

--- a/lib/web_ui/lib/src/engine/test_embedding.dart
+++ b/lib/web_ui/lib/src/engine/test_embedding.dart
@@ -37,11 +37,11 @@ Future<void> initializeTestFlutterViewEmbedder({double devicePixelRatio = 3.0}) 
 const bool _debugLogHistoryActions = false;
 
 class TestHistoryEntry {
+  const TestHistoryEntry(this.state, this.title, this.url);
+
   final dynamic state;
   final String? title;
   final String url;
-
-  const TestHistoryEntry(this.state, this.title, this.url);
 
   @override
   String toString() {

--- a/lib/web_ui/lib/src/engine/text/canvas_paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/canvas_paragraph.dart
@@ -567,7 +567,7 @@ class CanvasParagraphBuilder implements ui.ParagraphBuilder {
   final List<ParagraphSpan> _spans = <ParagraphSpan>[];
   final List<StyleNode> _styleStack = <StyleNode>[];
 
-  RootStyleNode _rootStyleNode;
+  final RootStyleNode _rootStyleNode;
   StyleNode get _currentStyleNode => _styleStack.isEmpty
       ? _rootStyleNode
       : _styleStack[_styleStack.length - 1];

--- a/lib/web_ui/lib/src/engine/text/font_collection.dart
+++ b/lib/web_ui/lib/src/engine/text/font_collection.dart
@@ -112,6 +112,16 @@ class FontCollection {
 
 /// Manages a collection of fonts and ensures they are loaded.
 class FontManager {
+  factory FontManager() {
+    if (supportsFontLoadingApi) {
+      return FontManager._();
+    } else {
+      return _PolyfillFontManager();
+    }
+  }
+
+  FontManager._();
+
   final List<Future<void>> _fontLoadingFutures = <Future<void>>[];
 
   // Regular expression to detect a string with no punctuations.
@@ -123,16 +133,6 @@ class FontManager {
   // For example font family 'Goudy Bookletter 1911' falls into this
   // category.
   static final RegExp startWithDigit = RegExp(r'\b\d');
-
-  factory FontManager() {
-    if (supportsFontLoadingApi) {
-      return FontManager._();
-    } else {
-      return _PolyfillFontManager();
-    }
-  }
-
-  FontManager._();
 
   /// Registers assets to Flutter Web Engine.
   ///

--- a/lib/web_ui/lib/src/engine/text/layout_service.dart
+++ b/lib/web_ui/lib/src/engine/text/layout_service.dart
@@ -1582,9 +1582,9 @@ class Spanometer {
   final CanvasParagraph paragraph;
   final DomCanvasRenderingContext2D context;
 
-  static RulerHost _rulerHost = RulerHost();
+  static final RulerHost _rulerHost = RulerHost();
 
-  static Map<TextHeightStyle, TextHeightRuler> _rulers =
+  static final Map<TextHeightStyle, TextHeightRuler> _rulers =
       <TextHeightStyle, TextHeightRuler>{};
 
   @visibleForTesting

--- a/lib/web_ui/lib/src/engine/text/word_breaker.dart
+++ b/lib/web_ui/lib/src/engine/text/word_breaker.dart
@@ -6,10 +6,10 @@ import '../util.dart';
 import 'word_break_properties.dart';
 
 class _FindBreakDirection {
+  const _FindBreakDirection({required this.step});
+
   static const _FindBreakDirection forward = _FindBreakDirection(step: 1);
   static const _FindBreakDirection backward = _FindBreakDirection(step: -1);
-
-  const _FindBreakDirection({required this.step});
 
   final int step;
 }

--- a/lib/web_ui/lib/src/engine/text_editing/autofill_hint.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/autofill_hint.dart
@@ -7,14 +7,6 @@
 /// See: https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/services/autofill.dart
 /// See: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete
 class BrowserAutofillHints {
-  static final BrowserAutofillHints _singletonInstance =
-      BrowserAutofillHints._();
-
-  /// The [BrowserAutofillHints] singleton.
-  static BrowserAutofillHints get instance => _singletonInstance;
-
-  final Map<String, String> _flutterToEngineMap;
-
   BrowserAutofillHints._()
       : _flutterToEngineMap = <String, String>{
           'birthday': 'bday',
@@ -72,6 +64,14 @@ class BrowserAutofillHints {
           'url': 'url',
           'username': 'username',
         };
+
+  static final BrowserAutofillHints _singletonInstance =
+      BrowserAutofillHints._();
+
+  /// The [BrowserAutofillHints] singleton.
+  static BrowserAutofillHints get instance => _singletonInstance;
+
+  final Map<String, String> _flutterToEngineMap;
 
   /// Converts the Flutter AutofillHint to the autofill hint value used by the
   /// browsers.

--- a/lib/web_ui/lib/src/engine/text_editing/text_capitalization.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_capitalization.dart
@@ -32,8 +32,6 @@ enum TextCapitalization {
 /// See: https://developers.google.com/web/updates/2015/04/autocapitalize
 /// https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autocapitalize
 class TextCapitalizationConfig {
-  final TextCapitalization textCapitalization;
-
   const TextCapitalizationConfig.defaultCapitalization()
       : textCapitalization = TextCapitalization.none;
 
@@ -46,6 +44,8 @@ class TextCapitalizationConfig {
                     : inputConfiguration == 'TextCapitalization.sentences'
                         ? TextCapitalization.sentences
                         : TextCapitalization.none;
+
+  final TextCapitalization textCapitalization;
 
   /// Sets `autocapitalize` attribute on input elements.
   ///

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -352,6 +352,24 @@ class AutofillInfo {
     this.placeholder,
   });
 
+  factory AutofillInfo.fromFrameworkMessage(Map<String, dynamic> autofill,
+      {TextCapitalizationConfig textCapitalization =
+          const TextCapitalizationConfig.defaultCapitalization()}) {
+    assert(autofill != null); // ignore: unnecessary_null_comparison
+    final String uniqueIdentifier = autofill.readString('uniqueIdentifier');
+    final List<dynamic>? hintsList = autofill.tryList('hints');
+    final String? firstHint = (hintsList == null || hintsList.isEmpty) ? null : hintsList.first as String;
+    final EditingState editingState =
+        EditingState.fromFrameworkMessage(autofill.readJson('editingValue'));
+    return AutofillInfo(
+      uniqueIdentifier: uniqueIdentifier,
+      autofillHint: (firstHint != null) ? BrowserAutofillHints.instance.flutterToEngine(firstHint) : null,
+      editingState: editingState,
+      placeholder: autofill.tryString('hintText'),
+      textCapitalization: textCapitalization,
+    );
+  }
+
   /// The current text and selection state of a text field.
   final EditingState editingState;
 
@@ -389,24 +407,6 @@ class AutofillInfo {
   /// can be a useful indication to the platform autofill service as to what
   /// information is expected in this field.
   final String? placeholder;
-
-  factory AutofillInfo.fromFrameworkMessage(Map<String, dynamic> autofill,
-      {TextCapitalizationConfig textCapitalization =
-          const TextCapitalizationConfig.defaultCapitalization()}) {
-    assert(autofill != null); // ignore: unnecessary_null_comparison
-    final String uniqueIdentifier = autofill.readString('uniqueIdentifier');
-    final List<dynamic>? hintsList = autofill.tryList('hints');
-    final String? firstHint = (hintsList == null || hintsList.isEmpty) ? null : hintsList.first as String;
-    final EditingState editingState =
-        EditingState.fromFrameworkMessage(autofill.readJson('editingValue'));
-    return AutofillInfo(
-      uniqueIdentifier: uniqueIdentifier,
-      autofillHint: (firstHint != null) ? BrowserAutofillHints.instance.flutterToEngine(firstHint) : null,
-      editingState: editingState,
-      placeholder: autofill.tryString('hintText'),
-      textCapitalization: textCapitalization,
-    );
-  }
 
   void applyToDomElement(DomHTMLElement domElement,
       {bool focusedElement = false}) {
@@ -1084,9 +1084,9 @@ class SafariDesktopTextEditingStrategy extends DefaultTextEditingStrategy {
 /// Unless a formfactor/browser requires specific implementation for a specific
 /// strategy the methods in this class should be used.
 abstract class DefaultTextEditingStrategy with CompositionAwareMixin implements TextEditingStrategy  {
-  final HybridTextEditing owner;
-
   DefaultTextEditingStrategy(this.owner);
+
+  final HybridTextEditing owner;
 
   bool isEnabled = false;
 

--- a/lib/web_ui/lib/src/engine/ulps.dart
+++ b/lib/web_ui/lib/src/engine/ulps.dart
@@ -48,9 +48,6 @@ int twosComplimentToSignBit(int x) {
 }
 
 class _FloatBitConverter {
-  final Float32List float32List;
-  final Int32List int32List;
-
   factory _FloatBitConverter() {
     final Float32List float32List = Float32List(1);
     return _FloatBitConverter._(
@@ -58,6 +55,9 @@ class _FloatBitConverter {
   }
 
   _FloatBitConverter._(this.float32List, this.int32List);
+
+  final Float32List float32List;
+  final Int32List int32List;
 
   int toInt(Float32List source, int index) {
     float32List[0] = source[index];

--- a/lib/web_ui/lib/src/engine/vector_math.dart
+++ b/lib/web_ui/lib/src/engine/vector_math.dart
@@ -8,41 +8,6 @@ import 'dart:typed_data';
 import 'util.dart';
 
 class Matrix4 {
-  final Float32List _m4storage;
-
-  /// The components of the matrix.
-  Float32List get storage => _m4storage;
-
-  /// Returns a matrix that is the inverse of [other] if [other] is invertible,
-  /// otherwise `null`.
-  static Matrix4? tryInvert(Matrix4 other) {
-    final Matrix4 r = Matrix4.zero();
-    final double determinant = r.copyInverse(other);
-    if (determinant == 0.0) {
-      return null;
-    }
-    return r;
-  }
-
-  /// Return index in storage for [row], [col] value.
-  int index(int row, int col) => (col * 4) + row;
-
-  /// Value at [row], [col].
-  double entry(int row, int col) {
-    assert((row >= 0) && (row < dimension));
-    assert((col >= 0) && (col < dimension));
-
-    return _m4storage[index(row, col)];
-  }
-
-  /// Set value at [row], [col] to be [v].
-  void setEntry(int row, int col, double v) {
-    assert((row >= 0) && (row < dimension));
-    assert((col >= 0) && (col < dimension));
-
-    _m4storage[index(row, col)] = v;
-  }
-
   /// Constructs a new mat4.
   factory Matrix4(
           double arg0,
@@ -128,6 +93,41 @@ class Matrix4 {
   /// [offset]. [offset] has to be multiple of [Float32List.bytesPerElement].
   Matrix4.fromBuffer(ByteBuffer buffer, int offset)
       : _m4storage = Float32List.view(buffer, offset, 16);
+
+  final Float32List _m4storage;
+
+  /// The components of the matrix.
+  Float32List get storage => _m4storage;
+
+  /// Returns a matrix that is the inverse of [other] if [other] is invertible,
+  /// otherwise `null`.
+  static Matrix4? tryInvert(Matrix4 other) {
+    final Matrix4 r = Matrix4.zero();
+    final double determinant = r.copyInverse(other);
+    if (determinant == 0.0) {
+      return null;
+    }
+    return r;
+  }
+
+  /// Return index in storage for [row], [col] value.
+  int index(int row, int col) => (col * 4) + row;
+
+  /// Value at [row], [col].
+  double entry(int row, int col) {
+    assert((row >= 0) && (row < dimension));
+    assert((col >= 0) && (col < dimension));
+
+    return _m4storage[index(row, col)];
+  }
+
+  /// Set value at [row], [col] to be [v].
+  void setEntry(int row, int col, double v) {
+    assert((row >= 0) && (row < dimension));
+    assert((col >= 0) && (col < dimension));
+
+    _m4storage[index(row, col)] = v;
+  }
 
   /// Sets the matrix with specified values.
   void setValues(
@@ -1087,6 +1087,34 @@ class Matrix4 {
 
 /// 3D column vector.
 class Vector3 {
+  /// Construct a new vector with the specified values.
+  factory Vector3(double x, double y, double z) =>
+      Vector3.zero()..setValues(x, y, z);
+
+  /// Zero vector.
+  Vector3.zero() : _v3storage = Float32List(3);
+
+  /// Splat [value] into all lanes of the vector.
+  factory Vector3.all(double value) => Vector3.zero()..splat(value);
+
+  /// Copy of [other].
+  factory Vector3.copy(Vector3 other) => Vector3.zero()..setFrom(other);
+
+  /// Constructs Vector3 with given Float32List as [storage].
+  Vector3.fromFloat32List(this._v3storage);
+
+  /// Constructs Vector3 with a [storage] that views given [buffer] starting at
+  /// [offset]. [offset] has to be multiple of [Float32List.bytesPerElement].
+  Vector3.fromBuffer(ByteBuffer buffer, int offset)
+      : _v3storage = Float32List.view(buffer, offset, 3);
+
+  /// Generate random vector in the range (0, 0, 0) to (1, 1, 1). You can
+  /// optionally pass your own random number generator.
+  factory Vector3.random([math.Random? rng]) {
+    rng ??= math.Random();
+    return Vector3(rng.nextDouble(), rng.nextDouble(), rng.nextDouble());
+  }
+
   final Float32List _v3storage;
 
   /// The components of the vector.
@@ -1115,34 +1143,6 @@ class Vector3 {
       ..x = min.x + a * (max.x - min.x)
       ..y = min.y + a * (max.y - min.y)
       ..z = min.z + a * (max.z - min.z);
-  }
-
-  /// Construct a new vector with the specified values.
-  factory Vector3(double x, double y, double z) =>
-      Vector3.zero()..setValues(x, y, z);
-
-  /// Zero vector.
-  Vector3.zero() : _v3storage = Float32List(3);
-
-  /// Splat [value] into all lanes of the vector.
-  factory Vector3.all(double value) => Vector3.zero()..splat(value);
-
-  /// Copy of [other].
-  factory Vector3.copy(Vector3 other) => Vector3.zero()..setFrom(other);
-
-  /// Constructs Vector3 with given Float32List as [storage].
-  Vector3.fromFloat32List(this._v3storage);
-
-  /// Constructs Vector3 with a [storage] that views given [buffer] starting at
-  /// [offset]. [offset] has to be multiple of [Float32List.bytesPerElement].
-  Vector3.fromBuffer(ByteBuffer buffer, int offset)
-      : _v3storage = Float32List.view(buffer, offset, 3);
-
-  /// Generate random vector in the range (0, 0, 0) to (1, 1, 1). You can
-  /// optionally pass your own random number generator.
-  factory Vector3.random([math.Random? rng]) {
-    rng ??= math.Random();
-    return Vector3(rng.nextDouble(), rng.nextDouble(), rng.nextDouble());
   }
 
   /// Set the values of the vector.

--- a/lib/web_ui/test/canvaskit/fallback_fonts_golden_test.dart
+++ b/lib/web_ui/test/canvaskit/fallback_fonts_golden_test.dart
@@ -374,9 +374,9 @@ class TestDownloader extends NotoDownloader {
 }
 
 class LoggingDownloader implements NotoDownloader {
-  final List<String> log = <String>[];
-
   LoggingDownloader(this.delegate);
+
+  final List<String> log = <String>[];
 
   final NotoDownloader delegate;
 

--- a/lib/web_ui/test/canvaskit/skia_objects_cache_test.dart
+++ b/lib/web_ui/test/canvaskit/skia_objects_cache_test.dart
@@ -317,8 +317,6 @@ void _tests() {
 ///
 /// Can be [clone]d such that the clones share the same ref counted box.
 class TestBoxWrapper implements StackTraceDebugger {
-  static int resurrectCount = 0;
-
   TestBoxWrapper() {
     if (assertionsEnabled) {
       _debugStackTrace = StackTrace.current;
@@ -336,6 +334,8 @@ class TestBoxWrapper implements StackTraceDebugger {
     }
     box.ref(this);
   }
+
+  static int resurrectCount = 0;
 
   @override
   StackTrace get debugStackTrace => _debugStackTrace;
@@ -393,13 +393,13 @@ class TestJsConstructor implements JsConstructor {
 }
 
 class TestSkiaObject extends ManagedSkiaObject<SkPaint> {
+  TestSkiaObject({this.isExpensive = false});
+
   int createDefaultCount = 0;
   int resurrectCount = 0;
   int deleteCount = 0;
 
   final bool isExpensive;
-
-  TestSkiaObject({this.isExpensive = false});
 
   @override
   SkPaint createDefault() {

--- a/lib/web_ui/test/engine/frame_reference_test.dart
+++ b/lib/web_ui/test/engine/frame_reference_test.dart
@@ -75,6 +75,6 @@ void testMain() {
 }
 
 class TestItem {
-  final String label;
   TestItem(this.label);
+  final String label;
 }

--- a/lib/web_ui/test/engine/platform_views/message_handler_test.dart
+++ b/lib/web_ui/test/engine/platform_views/message_handler_test.dart
@@ -154,7 +154,7 @@ class _FakePlatformViewManager extends PlatformViewManager {
   _FakePlatformViewManager(void Function(int) clearFunction)
       : _clearPlatformView = clearFunction;
 
-  void Function(int) _clearPlatformView;
+  final void Function(int) _clearPlatformView;
 
   @override
   void clearPlatformView(int viewId) {

--- a/lib/web_ui/test/engine/pointer_binding_test.dart
+++ b/lib/web_ui/test/engine/pointer_binding_test.dart
@@ -2497,7 +2497,7 @@ class _TouchEventContext extends _BasicEventContext
   @override
   bool get hasMouseEvents => false;
 
-  DomEventTarget _target;
+  final DomEventTarget _target;
 
   DomTouch _createTouch({
     int? identifier,

--- a/lib/web_ui/test/engine/semantics/semantics_tester.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_tester.dart
@@ -380,17 +380,6 @@ DomElement? findScrollable() {
 
 /// Logs semantics actions dispatched to [ui.window].
 class SemanticsActionLogger {
-  late StreamController<int> _idLogController;
-  late StreamController<ui.SemanticsAction> _actionLogController;
-
-  /// Semantics object ids that dispatched the actions.
-  Stream<int> get idLog => _idLog;
-  late Stream<int> _idLog;
-
-  /// The actions that were dispatched to [ui.window].
-  Stream<ui.SemanticsAction> get actionLog => _actionLog;
-  late Stream<ui.SemanticsAction> _actionLog;
-
   SemanticsActionLogger() {
     _idLogController = StreamController<int>();
     _actionLogController = StreamController<ui.SemanticsAction>();
@@ -411,4 +400,15 @@ class SemanticsActionLogger {
       });
     };
   }
+
+  late StreamController<int> _idLogController;
+  late StreamController<ui.SemanticsAction> _actionLogController;
+
+  /// Semantics object ids that dispatched the actions.
+  Stream<int> get idLog => _idLog;
+  late Stream<int> _idLog;
+
+  /// The actions that were dispatched to [ui.window].
+  Stream<ui.SemanticsAction> get actionLog => _actionLog;
+  late Stream<ui.SemanticsAction> _actionLog;
 }

--- a/lib/web_ui/test/engine/surface/path/path_winding_test.dart
+++ b/lib/web_ui/test/engine/surface/path/path_winding_test.dart
@@ -442,10 +442,10 @@ void testMain() {
 }
 
 class LineTestCase {
+  LineTestCase(this.pathContent, this.convexity, this.direction);
   final String pathContent;
   final int convexity;
   final int? direction;
-  LineTestCase(this.pathContent, this.convexity, this.direction);
 }
 
 /// Parses a string of the format "mx my lx1 ly1 lx2 ly2..." into a path

--- a/lib/web_ui/test/engine/surface/surface_test.dart
+++ b/lib/web_ui/test/engine/surface/surface_test.dart
@@ -378,9 +378,9 @@ void testMain() {
 }
 
 class _LoggingTestSurface extends PersistedContainerSurface {
-  final List<String> log = <String>[];
-
   _LoggingTestSurface() : super(null);
+
+  final List<String> log = <String>[];
 
   @override
   void build() {

--- a/lib/web_ui/test/html/paragraph/text_scuba.dart
+++ b/lib/web_ui/test/html/paragraph/text_scuba.dart
@@ -14,10 +14,10 @@ import 'package:web_engine_tester/golden_tester.dart';
 ///
 /// (For Googlers: Not really related with internal Scuba anymore)
 class EngineScubaTester {
+  EngineScubaTester(this.viewportSize);
+
   /// The size of the browser window used in this scuba test.
   final ui.Size viewportSize;
-
-  EngineScubaTester(this.viewportSize);
 
   static Future<EngineScubaTester> initialize(
       {ui.Size viewportSize = const ui.Size(2400, 1800)}) async {

--- a/lib/web_ui/test/html/path_to_svg_golden_test.dart
+++ b/lib/web_ui/test/html/path_to_svg_golden_test.dart
@@ -210,13 +210,13 @@ DomElement pathToSvgElement(Path path, Paint paint, bool enableFill) {
 }
 
 class ArcSample {
+  ArcSample(this.offset,
+      {this.largeArc = false, this.clockwise = false, this.distance = 0});
+
   final Offset offset;
   final bool largeArc;
   final bool clockwise;
   final double distance;
-
-  ArcSample(this.offset,
-      {this.largeArc = false, this.clockwise = false, this.distance = 0});
 
   Path createPath() {
     final Offset startP =

--- a/lib/web_ui/test/mock_engine_canvas.dart
+++ b/lib/web_ui/test/mock_engine_canvas.dart
@@ -34,7 +34,7 @@ class MockEngineCanvas implements EngineCanvas {
 
   @override
   DomElement get rootElement => _rootElement;
-  DomElement _rootElement = createDomHTMLDivElement();
+  final DomElement _rootElement = createDomHTMLDivElement();
 
   void _called(String methodName, {dynamic arguments}) {
     methodCallLog.add(MockCanvasCall._(

--- a/testing/scenario_app/lib/src/touches_scenario.dart
+++ b/testing/scenario_app/lib/src/touches_scenario.dart
@@ -11,7 +11,7 @@ import 'scenario.dart';
 class TouchesScenario extends Scenario {
   /// Constructor for `TouchesScenario`.
   TouchesScenario(PlatformDispatcher dispatcher) : super(dispatcher);
-  
+
   final Map<int, int> _knownDevices = <int, int>{};
   int _sequenceNo = 0;
 

--- a/testing/scenario_app/lib/src/touches_scenario.dart
+++ b/testing/scenario_app/lib/src/touches_scenario.dart
@@ -9,11 +9,11 @@ import 'scenario.dart';
 
 /// A scenario that sends back messages when touches are received.
 class TouchesScenario extends Scenario {
-  final Map<int, int> _knownDevices = <int, int>{};
-  int _sequenceNo = 0;
-
   /// Constructor for `TouchesScenario`.
   TouchesScenario(PlatformDispatcher dispatcher) : super(dispatcher);
+  
+  final Map<int, int> _knownDevices = <int, int>{};
+  int _sequenceNo = 0;
 
   @override
   void onBeginFrame(Duration duration) {


### PR DESCRIPTION
Inspired by Dan's comment on https://github.com/flutter/engine/pull/34986 I went through the other declared differences in analyzer options between the `flutter/flutter` and the `flutter/engine` repository. Turns out, some of these exceptions (namely `import_internal_library`, `prefer_final_fields`, and `sort_constructors_first`) are no longer necessary. The stated reason for why they are different from `flutter/flutter` don't appear to apply anymore.

This reduces the effective differences between `flutter/flutter` and `flutter/engine` down to three.

This PR also removes the special treatment of `todo`, `missing_required_param`, and `missing_return` as those are also no longer necessary as explained in https://github.com/flutter/flutter/pull/108747.