### PR TITLE
Don't insist on modules when attempting to include the Flutter umbrella header.

### DIFF
--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -381,11 +381,7 @@ copy("copy_license") {
 shared_library("copy_and_verify_framework_module") {
   framework_search_path = rebase_path("$root_out_dir")
   visibility = [ ":*" ]
-  cflags_objc = [
-    "-F$framework_search_path",
-    "-fmodules",
-    "-Wnon-modular-include-in-framework-module",
-  ]
+  cflags_objc = [ "-F$framework_search_path" ]
 
   sources = [ "framework/Source/FlutterUmbrellaImport.m" ]
   deps = [


### PR DESCRIPTION
This fixes local engine builds on Mac. The `copy_and_verify_framework_module`
exists to ensure that the umbrella header can be cleanly imported from an ObjC
TU. However, the compile flags insist on module support being enabled. It isn't
clear how this used to work earlier since no modules were provided. Likely, this
was a race. Remove the insistence on modules because that wasn't the intent of
creating the target in the first place.

The issue fixed is the following:

```
/Users/chinmaygarde/VersionControlled/depot_tools/.cipd_bin/gomacc  ../../buildtools/mac-x64/clang/bin/clang++ -MD -MF obj/flutter/shell/platform/darwin/ios/framework/Source/libcopy_and_verify_framework_module.FlutterUmbrellaImport.o.d -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D_FORTIFY_SOURCE=2 -D_LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS -D_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS -D_DEBUG -I../.. -Igen -isysroot /Users/chinmaygarde/VersionControlled/engine/src/out/ios_debug_unopt/gen/SDKs/iPhoneOS15.5.sdk -miphoneos-version-min=11.0 -fno-strict-aliasing -arch arm64 -fcolor-diagnostics -Wall -Wextra -Wendif-labels -Werror -Wno-missing-field-initializers -Wno-unused-parameter -Wno-unused-but-set-parameter -Wno-unused-but-set-variable -Wno-implicit-int-float-conversion -Wno-c99-designator -Wno-deprecated-copy -Wno-psabi -Wno-unqualified-std-cast-call -Wno-non-c-typedef-for-linkage -Wno-range-loop-construct -Wunguarded-availability -Wno-deprecated-declarations -fvisibility=hidden -stdlib=libc++ -Wstring-conversion -Wnewline-eof -O0 -g2  -F/Users/chinmaygarde/VersionControlled/engine/src/out/ios_debug_unopt -fmodules -Wnon-modular-include-in-framework-module  -c ../../flutter/shell/platform/darwin/ios/framework/Source/FlutterUmbrellaImport.m -o obj/flutter/shell/platform/darwin/ios/framework/Source/libcopy_and_verify_framework_module.FlutterUmbrellaImport.o
../../flutter/shell/platform/darwin/ios/framework/Source/FlutterUmbrellaImport.m:11:9: fatal error: module 'Flutter' is needed but has not been provided, and implicit use of module files is disabled
        ^
1 error generated.
```