### PR TITLE
[Impeller] Remove redundant GN flags.

### DIFF
--- a/impeller/BUILD.gn
+++ b/impeller/BUILD.gn
@@ -9,10 +9,6 @@ config("impeller_public_config") {
 
   defines = []
 
-  if (impeller_supports_platform) {
-    defines += [ "IMPELLER_SUPPORTS_PLATFORM=1" ]
-  }
-
   if (impeller_supports_rendering) {
     defines += [ "IMPELLER_SUPPORTS_RENDERING=1" ]
   }

--- a/impeller/tools/impeller.gni
+++ b/impeller/tools/impeller.gni
@@ -10,9 +10,6 @@ declare_args() {
   # Whether playgrounds are enabled for unit tests.
   impeller_enable_playground = false
 
-  # Whether Impeller is supported on the platform.
-  impeller_supports_platform = true
-
   # Whether the Metal backend is enabled.
   impeller_enable_metal = is_mac || is_ios
 
@@ -36,11 +33,6 @@ declare_args() {
 }
 
 declare_args() {
-  # Whether Impeller shaders are supported on the platform.
-  impeller_shaders_supports_platform =
-      impeller_enable_metal || impeller_enable_opengles ||
-      impeller_enable_vulkan
-
   # Whether Impeller supports rendering on the platform.
   impeller_supports_rendering =
       impeller_enable_metal || impeller_enable_opengles ||
@@ -61,7 +53,7 @@ template("impeller_component") {
     group(target_name) {
       not_needed(invoker, "*")
     }
-  } else if (impeller_supports_platform) {
+  } else {
     target_type = "source_set"
     if (defined(invoker.target_type)) {
       target_type = invoker.target_type
@@ -95,10 +87,6 @@ template("impeller_component") {
       if (is_ios || is_mac) {
         cflags_objcc += flutter_cflags_objcc_arc
       }
-    }
-  } else {
-    group(target_name) {
-      not_needed(invoker, "*")
     }
   }
 }
@@ -586,7 +574,7 @@ template("impeller_shaders") {
     }
   }
 
-  if (!impeller_shaders_supports_platform) {
+  if (!impeller_supports_rendering) {
     not_needed(invoker, "*")
   }
 

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -10,14 +10,10 @@
 #include "flutter/fml/synchronization/waitable_event.h"
 #include "flutter/shell/common/shell_io_manager.h"
 #include "flutter/shell/gpu/gpu_surface_gl_delegate.h"
-#if IMPELLER_SUPPORTS_PLATFORM
 #include "flutter/shell/platform/android/android_context_gl_impeller.h"
-#endif
 #include "flutter/shell/platform/android/android_context_gl_skia.h"
 #include "flutter/shell/platform/android/android_external_texture_gl.h"
-#if IMPELLER_SUPPORTS_PLATFORM
 #include "flutter/shell/platform/android/android_surface_gl_impeller.h"
-#endif
 #include "flutter/shell/platform/android/android_surface_gl_skia.h"
 #include "flutter/shell/platform/android/android_surface_software.h"
 #include "flutter/shell/platform/android/context/android_context.h"
@@ -46,17 +42,13 @@ std::unique_ptr<AndroidSurface> AndroidSurfaceFactoryImpl::CreateSurface() {
       return std::make_unique<AndroidSurfaceSoftware>(android_context_,
                                                       jni_facade_);
     case AndroidRenderingAPI::kOpenGLES:
-#if IMPELLER_SUPPORTS_PLATFORM
       if (enable_impeller_) {
         return std::make_unique<AndroidSurfaceGLImpeller>(android_context_,
                                                           jni_facade_);
       } else {
-#endif
         return std::make_unique<AndroidSurfaceGLSkia>(android_context_,
                                                       jni_facade_);
-#if IMPELLER_SUPPORTS_PLATFORM
       }
-#endif
     default:
       FML_DCHECK(false);
       return nullptr;
@@ -71,11 +63,9 @@ static std::shared_ptr<flutter::AndroidContext> CreateAndroidContext(
   if (use_software_rendering) {
     return std::make_shared<AndroidContext>(AndroidRenderingAPI::kSoftware);
   }
-#if IMPELLER_SUPPORTS_PLATFORM
   if (enable_impeller) {
     return std::make_unique<AndroidContextGLImpeller>();
   }
-#endif
   return std::make_unique<AndroidContextGLSkia>(
       AndroidRenderingAPI::kOpenGLES,               //
       fml::MakeRefCounted<AndroidEnvironmentGL>(),  //


### PR DESCRIPTION
These were added to conditionally compile stuff when Impeller only had Metal on
Darwin implementation. These are no longer used.