### PR TITLE
[Impeller] Add additional trace around acquisition of next Metal drawable.

### DIFF
--- a/impeller/renderer/backend/metal/surface_mtl.mm
+++ b/impeller/renderer/backend/metal/surface_mtl.mm
@@ -24,7 +24,11 @@ std::unique_ptr<Surface> SurfaceMTL::WrapCurrentMetalLayerDrawable(
     return nullptr;
   }
 
-  auto current_drawable = [layer nextDrawable];
+  id<CAMetalDrawable> current_drawable = nil;
+  {
+    TRACE_EVENT0("impeller", "WaitForNextDrawable");
+    current_drawable = [layer nextDrawable];
+  }
 
   if (!current_drawable) {
     VALIDATION_LOG << "Could not acquire current drawable.";


### PR DESCRIPTION
Extremely minor patch to separately trace the time it takes to acquire the next metal drawable. Delays here mean that a GPU trace needs to be collected.