### PR TITLE
[Impeller] Add Rect::GetPositive

### DIFF
--- a/impeller/geometry/geometry_unittests.cc
+++ b/impeller/geometry/geometry_unittests.cc
@@ -1049,6 +1049,20 @@ TEST(GeometryTest, RectMakePointBounds) {
   }
 }
 
+TEST(GeometryTest, RectGetPositive) {
+  {
+    Rect r{100, 200, 300, 400};
+    auto actual = r.GetPositive();
+    ASSERT_RECT_NEAR(r, actual);
+  }
+  {
+    Rect r{100, 200, -100, -100};
+    auto actual = r.GetPositive();
+    Rect expected(0, 100, 100, 100);
+    ASSERT_RECT_NEAR(expected, actual);
+  }
+}
+
 TEST(GeometryTest, CubicPathComponentPolylineDoesNotIncludePointOne) {
   CubicPathComponent component({10, 10}, {20, 35}, {35, 20}, {40, 40});
   SmoothingApproximation approximation;

--- a/impeller/geometry/rect.h
+++ b/impeller/geometry/rect.h
@@ -146,7 +146,7 @@ struct TRect {
   }
 
   /// @brief  Get the points that represent the 4 corners of this rectangle. The
-  ///         order is: Top left, top right, bottom left, bottom right.=
+  ///         order is: Top left, top right, bottom left, bottom right.
   constexpr std::array<TPoint<T>, 4> GetPoints() const {
     auto [left, top, right, bottom] = GetLTRB();
     return {TPoint(left, top), TPoint(right, top), TPoint(left, bottom),

--- a/impeller/geometry/rect.h
+++ b/impeller/geometry/rect.h
@@ -139,6 +139,14 @@ struct TRect {
     return {left, top, right, bottom};
   }
 
+  /// @brief  Get a version of this rectangle that has a non-negative size.
+  constexpr TRect GetPositive() const {
+    auto ltrb = GetLTRB();
+    return MakeLTRB(ltrb[0], ltrb[1], ltrb[2], ltrb[3]);
+  }
+
+  /// @brief  Get the points that represent the 4 corners of this rectangle. The
+  ///         order is: Top left, top right, bottom left, bottom right.=
   constexpr std::array<TPoint<T>, 4> GetPoints() const {
     auto [left, top, right, bottom] = GetLTRB();
     return {TPoint(left, top), TPoint(right, top), TPoint(left, bottom),


### PR DESCRIPTION
Most of the time I've implicitly done this using GetLTRB. This makes the conversion less implicit/easier to read when breaking out the LTRB isn't necessary. Used in the new RRect blur.