### PR TITLE
[Impeller] Add rounded rect SDF blur

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -570,6 +570,8 @@ FILE: ../../../flutter/impeller/entity/contents/path_contents.cc
 FILE: ../../../flutter/impeller/entity/contents/path_contents.h
 FILE: ../../../flutter/impeller/entity/contents/radial_gradient_contents.cc
 FILE: ../../../flutter/impeller/entity/contents/radial_gradient_contents.h
+FILE: ../../../flutter/impeller/entity/contents/rrect_shadow_contents.cc
+FILE: ../../../flutter/impeller/entity/contents/rrect_shadow_contents.h
 FILE: ../../../flutter/impeller/entity/contents/solid_color_contents.cc
 FILE: ../../../flutter/impeller/entity/contents/solid_color_contents.h
 FILE: ../../../flutter/impeller/entity/contents/solid_stroke_contents.cc
@@ -621,6 +623,8 @@ FILE: ../../../flutter/impeller/entity/shaders/gradient_fill.frag
 FILE: ../../../flutter/impeller/entity/shaders/gradient_fill.vert
 FILE: ../../../flutter/impeller/entity/shaders/radial_gradient_fill.frag
 FILE: ../../../flutter/impeller/entity/shaders/radial_gradient_fill.vert
+FILE: ../../../flutter/impeller/entity/shaders/rrect_blur.frag
+FILE: ../../../flutter/impeller/entity/shaders/rrect_blur.vert
 FILE: ../../../flutter/impeller/entity/shaders/solid_fill.frag
 FILE: ../../../flutter/impeller/entity/shaders/solid_fill.vert
 FILE: ../../../flutter/impeller/entity/shaders/solid_stroke.frag

--- a/impeller/entity/BUILD.gn
+++ b/impeller/entity/BUILD.gn
@@ -34,6 +34,10 @@ impeller_shaders("entity_shaders") {
     "shaders/glyph_atlas.vert",
     "shaders/gradient_fill.frag",
     "shaders/gradient_fill.vert",
+    "shaders/radial_gradient_fill.vert",
+    "shaders/radial_gradient_fill.frag",
+    "shaders/rrect_blur.vert",
+    "shaders/rrect_blur.frag",
     "shaders/solid_fill.frag",
     "shaders/solid_fill.vert",
     "shaders/solid_stroke.frag",
@@ -42,8 +46,6 @@ impeller_shaders("entity_shaders") {
     "shaders/texture_fill.vert",
     "shaders/vertices.vert",
     "shaders/vertices.frag",
-    "shaders/radial_gradient_fill.vert",
-    "shaders/radial_gradient_fill.frag",
   ]
 }
 
@@ -77,6 +79,8 @@ impeller_component("entity") {
     "contents/path_contents.h",
     "contents/radial_gradient_contents.cc",
     "contents/radial_gradient_contents.h",
+    "contents/rrect_shadow_contents.cc",
+    "contents/rrect_shadow_contents.h",
     "contents/solid_color_contents.cc",
     "contents/solid_color_contents.h",
     "contents/solid_stroke_contents.cc",

--- a/impeller/entity/contents/content_context.cc
+++ b/impeller/entity/contents/content_context.cc
@@ -155,6 +155,8 @@ ContentContext::ContentContext(std::shared_ptr<Context> context)
       CreateDefaultPipeline<SolidFillPipeline>(*context_);
   radial_gradient_fill_pipelines_[{}] =
       CreateDefaultPipeline<RadialGradientFillPipeline>(*context_);
+  rrect_blur_pipelines_[{}] =
+      CreateDefaultPipeline<RRectBlurPipeline>(*context_);
   texture_blend_pipelines_[{}] =
       CreateDefaultPipeline<BlendPipeline>(*context_);
   blend_color_pipelines_[{}] =

--- a/impeller/entity/contents/content_context.h
+++ b/impeller/entity/contents/content_context.h
@@ -40,6 +40,8 @@
 #include "impeller/entity/gradient_fill.vert.h"
 #include "impeller/entity/radial_gradient_fill.frag.h"
 #include "impeller/entity/radial_gradient_fill.vert.h"
+#include "impeller/entity/rrect_blur.frag.h"
+#include "impeller/entity/rrect_blur.vert.h"
 #include "impeller/entity/solid_fill.frag.h"
 #include "impeller/entity/solid_fill.vert.h"
 #include "impeller/entity/solid_stroke.frag.h"
@@ -58,6 +60,9 @@ using SolidFillPipeline =
     PipelineT<SolidFillVertexShader, SolidFillFragmentShader>;
 using RadialGradientFillPipeline =
     PipelineT<RadialGradientFillVertexShader, RadialGradientFillFragmentShader>;
+using BlendPipeline = PipelineT<BlendVertexShader, BlendFragmentShader>;
+using RRectBlurPipeline =
+    PipelineT<RrectBlurVertexShader, RrectBlurFragmentShader>;
 using BlendPipeline = PipelineT<BlendVertexShader, BlendFragmentShader>;
 using BlendColorPipeline =
     PipelineT<AdvancedBlendVertexShader, AdvancedBlendColorFragmentShader>;
@@ -146,6 +151,10 @@ class ContentContext {
   std::shared_ptr<Pipeline> GetRadialGradientFillPipeline(
       ContentContextOptions opts) const {
     return GetPipeline(radial_gradient_fill_pipelines_, opts);
+  }
+  std::shared_ptr<Pipeline> GetRRectBlurPipeline(
+      ContentContextOptions opts) const {
+    return GetPipeline(rrect_blur_pipelines_, opts);
   }
 
   std::shared_ptr<Pipeline> GetSolidFillPipeline(
@@ -293,6 +302,7 @@ class ContentContext {
   mutable Variants<GradientFillPipeline> gradient_fill_pipelines_;
   mutable Variants<SolidFillPipeline> solid_fill_pipelines_;
   mutable Variants<RadialGradientFillPipeline> radial_gradient_fill_pipelines_;
+  mutable Variants<RRectBlurPipeline> rrect_blur_pipelines_;
   mutable Variants<BlendPipeline> texture_blend_pipelines_;
   mutable Variants<TexturePipeline> texture_pipelines_;
   mutable Variants<GaussianBlurPipeline> gaussian_blur_pipelines_;

--- a/impeller/entity/contents/rrect_shadow_contents.cc
+++ b/impeller/entity/contents/rrect_shadow_contents.cc
@@ -1,0 +1,148 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/entity/contents/rrect_shadow_contents.h"
+#include <optional>
+
+#include "impeller/entity/contents/content_context.h"
+#include "impeller/entity/entity.h"
+#include "impeller/geometry/path.h"
+#include "impeller/geometry/path_builder.h"
+#include "impeller/renderer/render_pass.h"
+#include "impeller/tessellator/tessellator.h"
+
+namespace impeller {
+
+RRectShadowContents::RRectShadowContents() = default;
+
+RRectShadowContents::~RRectShadowContents() = default;
+
+void RRectShadowContents::SetRect(std::optional<Rect> rect) {
+  rect_ = rect;
+}
+
+void RRectShadowContents::SetSigma(FilterContents::Sigma sigma) {
+  sigma_ = sigma;
+}
+
+void RRectShadowContents::SetColor(Color color) {
+  color_ = color.Premultiply();
+}
+
+std::optional<Rect> RRectShadowContents::GetCoverage(
+    const Entity& entity) const {
+  if (!rect_.has_value()) {
+    return std::nullopt;
+  }
+
+  Scalar border = FilterContents::Radius{sigma_}.radius;
+  Rect bounds =
+      Rect::MakeLTRB(rect_->GetLeft() - border, rect_->GetTop() - border,
+                     rect_->GetRight() + border, rect_->GetBottom() + border);
+  return bounds.TransformBounds(entity.GetTransformation());
+};
+
+/// The box shadow consists of 9 quads built from 16 vertices; 4 inner vertices
+/// and 12 outset border vertices.
+///
+///   04---05----06---07
+///   |    |      |    |
+///   15---00----01---08
+///   |    |      |    |
+///   |    |      |    |
+///   14---03----02---09
+///   |    |      |    |
+///   13---12----11---10
+///
+const static size_t kIndexCount = 9 * 6;
+const static uint16_t kIndices[kIndexCount] = {
+    4,  5, 0,  4,  0,  15,  // Top left
+    5,  6, 1,  5,  1,  0,   // Top middle
+    6,  7, 8,  6,  8,  1,   // Top right
+    15, 0, 3,  15, 3,  14,  // Middle left
+    0,  1, 2,  1,  2,  3,   // Middle middle
+    1,  8, 9,  1,  9,  2,   // Middle right
+    14, 3, 12, 14, 12, 13,  // Bottom left
+    3,  2, 11, 3,  11, 12,  // Bottom middle
+    2,  9, 10, 2,  10, 11,  // Bottom right
+};
+
+bool RRectShadowContents::Render(const ContentContext& renderer,
+                                 const Entity& entity,
+                                 RenderPass& pass) const {
+  if (!rect_.has_value()) {
+    return true;
+  }
+
+  if (color_.IsTransparent()) {
+    return true;
+  }
+
+  using VS = RRectBlurPipeline::VertexShader;
+  using FS = RRectBlurPipeline::FragmentShader;
+
+  auto radius = FilterContents::Radius{sigma_}.radius;
+  auto box = rect_->GetPoints();
+  VS::PerVertexData vertices[16] = {
+      // Middle box
+      {box[0], Point()},
+      {box[1], Point()},
+      {box[3], Point()},
+      {box[2], Point()},
+
+      // Outset border
+      {box[0] + Point(-radius, -radius), Point(1, 1)},
+      {box[0] + Point(0, -radius), Point(0, 1)},
+      {box[1] + Point(0, -radius), Point(0, 1)},
+
+      {box[1] + Point(radius, -radius), Point(1, 1)},
+      {box[1] + Point(radius, 0), Point(1, 0)},
+      {box[2] + Point(radius, 0), Point(1, 0)},
+
+      {box[3] + Point(radius, radius), Point(1, 1)},
+      {box[3] + Point(0, radius), Point(0, 1)},
+      {box[2] + Point(0, radius), Point(0, 1)},
+
+      {box[2] + Point(-radius, radius), Point(1, 1)},
+      {box[2] + Point(-radius, 0), Point(1, 0)},
+      {box[0] + Point(-radius, 0), Point(1, 0)},
+  };
+
+  VertexBuffer vertex_buffer = {
+      .vertex_buffer = pass.GetTransientsBuffer().Emplace(
+          &vertices, sizeof(vertices), alignof(VS::PerVertexData)),
+      .index_buffer = pass.GetTransientsBuffer().Emplace(
+          &kIndices, sizeof(kIndices), alignof(uint16_t)),
+      .index_count = kIndexCount,
+      .index_type = IndexType::k16bit,
+  };
+
+  Command cmd;
+  cmd.label = "Box Shadow";
+  cmd.pipeline =
+      renderer.GetRRectBlurPipeline(OptionsFromPassAndEntity(pass, entity));
+  cmd.stencil_reference = entity.GetStencilDepth();
+
+  cmd.primitive_type = PrimitiveType::kTriangle;
+  cmd.BindVertices(vertex_buffer);
+
+  VS::VertexInfo vertex_info;
+  vertex_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
+                    entity.GetTransformation();
+  VS::BindVertexInfo(cmd,
+                     pass.GetTransientsBuffer().EmplaceUniform(vertex_info));
+
+  FS::FragmentInfo fragment_info;
+  fragment_info.color = color_;
+  FS::BindFragmentInfo(
+      cmd, pass.GetTransientsBuffer().EmplaceUniform(fragment_info));
+
+  if (!pass.AddCommand(std::move(cmd))) {
+    return false;
+  }
+
+  return true;
+}
+
+}  // namespace impeller

--- a/impeller/entity/contents/rrect_shadow_contents.cc
+++ b/impeller/entity/contents/rrect_shadow_contents.cc
@@ -99,7 +99,6 @@ bool RRectShadowContents::Render(const ContentContext& renderer,
   frag_info.corner_radius =
       std::min(corner_radius_, std::min(positive_rect.size.width / 2.0f,
                                         positive_rect.size.height / 2.0f));
-  ;
   FS::BindFragInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frag_info));
 
   if (!pass.AddCommand(std::move(cmd))) {

--- a/impeller/entity/contents/rrect_shadow_contents.cc
+++ b/impeller/entity/contents/rrect_shadow_contents.cc
@@ -41,8 +41,9 @@ std::optional<Rect> RRectShadowContents::GetCoverage(
 
   Scalar radius = Radius{sigma_}.radius;
 
-  Rect bounds = Rect::MakeLTRB(-radius, -radius, rect_->size.width + radius,
-                               rect_->size.height + radius);
+  auto ltrb = rect_->GetLTRB();
+  Rect bounds = Rect::MakeLTRB(ltrb[0] - radius, ltrb[1] - radius,
+                               ltrb[2] + radius, ltrb[3] + radius);
   return bounds.TransformBounds(entity.GetTransformation());
 };
 

--- a/impeller/entity/contents/rrect_shadow_contents.cc
+++ b/impeller/entity/contents/rrect_shadow_contents.cc
@@ -78,7 +78,7 @@ bool RRectShadowContents::Render(const ContentContext& renderer,
   }
 
   Command cmd;
-  cmd.label = "Box Shadow";
+  cmd.label = "RRect Shadow";
   cmd.pipeline =
       renderer.GetRRectBlurPipeline(OptionsFromPassAndEntity(pass, entity));
   cmd.stencil_reference = entity.GetStencilDepth();

--- a/impeller/entity/contents/rrect_shadow_contents.h
+++ b/impeller/entity/contents/rrect_shadow_contents.h
@@ -24,9 +24,9 @@ class RRectShadowContents final : public Contents {
 
   ~RRectShadowContents() override;
 
-  void SetRect(std::optional<Rect> rect);
+  void SetRRect(std::optional<Rect> rect, Scalar corner_radius = 0);
 
-  void SetSigma(FilterContents::Sigma sigma);
+  void SetSigma(Sigma sigma);
 
   void SetColor(Color color);
 
@@ -40,7 +40,8 @@ class RRectShadowContents final : public Contents {
 
  private:
   std::optional<Rect> rect_;
-  FilterContents::Sigma sigma_;
+  Scalar corner_radius_;
+  Sigma sigma_;
 
   Color color_;
 

--- a/impeller/entity/contents/rrect_shadow_contents.h
+++ b/impeller/entity/contents/rrect_shadow_contents.h
@@ -1,0 +1,50 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <vector>
+
+#include "impeller/entity/contents/contents.h"
+#include "impeller/entity/contents/filters/filter_contents.h"
+#include "impeller/geometry/color.h"
+
+namespace impeller {
+
+class Path;
+class HostBuffer;
+struct VertexBuffer;
+
+class RRectShadowContents final : public Contents {
+ public:
+  RRectShadowContents();
+
+  ~RRectShadowContents() override;
+
+  void SetRect(std::optional<Rect> rect);
+
+  void SetSigma(FilterContents::Sigma sigma);
+
+  void SetColor(Color color);
+
+  // |Contents|
+  std::optional<Rect> GetCoverage(const Entity& entity) const override;
+
+  // |Contents|
+  bool Render(const ContentContext& renderer,
+              const Entity& entity,
+              RenderPass& pass) const override;
+
+ private:
+  std::optional<Rect> rect_;
+  FilterContents::Sigma sigma_;
+
+  Color color_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(RRectShadowContents);
+};
+
+}  // namespace impeller

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -10,6 +10,7 @@
 #include "impeller/entity/contents/filters/blend_filter_contents.h"
 #include "impeller/entity/contents/filters/filter_contents.h"
 #include "impeller/entity/contents/filters/inputs/filter_input.h"
+#include "impeller/entity/contents/rrect_shadow_contents.h"
 #include "impeller/entity/contents/solid_color_contents.h"
 #include "impeller/entity/contents/solid_stroke_contents.h"
 #include "impeller/entity/contents/texture_contents.h"
@@ -1172,6 +1173,62 @@ TEST_P(EntityTest, ClipContentsShouldRenderIsCorrect) {
     auto restore = std::make_shared<ClipRestoreContents>();
     ASSERT_TRUE(restore->ShouldRender(Entity{}, {100, 100}));
   }
+}
+
+TEST_P(EntityTest, RRectShadowTest) {
+  bool first_frame = true;
+  auto callback = [&](ContentContext& context, RenderPass& pass) {
+    if (first_frame) {
+      first_frame = false;
+      ImGui::SetNextWindowPos({10, 10});
+    }
+
+    static Color color = Color::Red();
+    static float corner_radius = 10;
+    static float blur_radius = 10;
+    static bool show_coverage = false;
+    static Color coverage_color = Color::Green().WithAlpha(0.2);
+
+    ImGui::Begin("Controls", nullptr, ImGuiWindowFlags_AlwaysAutoResize);
+    ImGui::SliderFloat("Corner radius", &corner_radius, 0, 100);
+    ImGui::SliderFloat("Blur radius", &blur_radius, 0, 100);
+    ImGui::ColorEdit4("Color", reinterpret_cast<Scalar*>(&color));
+    ImGui::Checkbox("Show coverage", &show_coverage);
+    if (show_coverage) {
+      ImGui::ColorEdit4("Coverage color",
+                        reinterpret_cast<Scalar*>(&coverage_color));
+    }
+    ImGui::End();
+
+    auto [top_left, bottom_right] = IMPELLER_PLAYGROUND_LINE(
+        Point(200, 200), Point(600, 400), 30, Color::Black(), Color::White());
+    auto rect =
+        Rect::MakeLTRB(top_left.x, top_left.y, bottom_right.x, bottom_right.y);
+
+    auto contents = std::make_unique<RRectShadowContents>();
+    contents->SetRRect(rect, corner_radius);
+    contents->SetColor(color);
+    contents->SetSigma(Radius(blur_radius));
+
+    Entity entity;
+    entity.SetTransformation(Matrix::MakeScale(GetContentScale()));
+    entity.SetContents(std::move(contents));
+    entity.Render(context, pass);
+
+    auto coverage = entity.GetCoverage();
+    if (show_coverage && coverage.has_value()) {
+      auto bounds_contents = std::make_unique<SolidColorContents>();
+      bounds_contents->SetPath(
+          PathBuilder{}.AddRect(entity.GetCoverage().value()).TakePath());
+      bounds_contents->SetColor(coverage_color.Premultiply());
+      Entity bounds_entity;
+      bounds_entity.SetContents(std::move(bounds_contents));
+      bounds_entity.Render(context, pass);
+    }
+
+    return true;
+  };
+  ASSERT_TRUE(OpenPlaygroundHere(callback));
 }
 
 }  // namespace testing

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -1201,7 +1201,7 @@ TEST_P(EntityTest, RRectShadowTest) {
     ImGui::End();
 
     auto [top_left, bottom_right] = IMPELLER_PLAYGROUND_LINE(
-        Point(200, 200), Point(600, 400), 30, Color::Black(), Color::White());
+        Point(200, 200), Point(600, 400), 30, Color::White(), Color::White());
     auto rect =
         Rect::MakeLTRB(top_left.x, top_left.y, bottom_right.x, bottom_right.y);
 

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -1184,14 +1184,14 @@ TEST_P(EntityTest, RRectShadowTest) {
     }
 
     static Color color = Color::Red();
-    static float corner_radius = 10;
-    static float blur_radius = 10;
+    static float corner_radius = 100;
+    static float blur_radius = 100;
     static bool show_coverage = false;
     static Color coverage_color = Color::Green().WithAlpha(0.2);
 
     ImGui::Begin("Controls", nullptr, ImGuiWindowFlags_AlwaysAutoResize);
-    ImGui::SliderFloat("Corner radius", &corner_radius, 0, 100);
-    ImGui::SliderFloat("Blur radius", &blur_radius, 0, 100);
+    ImGui::SliderFloat("Corner radius", &corner_radius, 0, 300);
+    ImGui::SliderFloat("Blur radius", &blur_radius, 0, 300);
     ImGui::ColorEdit4("Color", reinterpret_cast<Scalar*>(&color));
     ImGui::Checkbox("Show coverage", &show_coverage);
     if (show_coverage) {

--- a/impeller/entity/shaders/rrect_blur.frag
+++ b/impeller/entity/shaders/rrect_blur.frag
@@ -2,21 +2,50 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-uniform FragmentInfo {
+uniform FragInfo {
   vec4 color;
+  float blur_radius;
+  vec2 rect_size;
+  float corner_radius;
 }
-fragment_info;
+frag_info;
 
-in vec2 v_border;
+in vec2 v_position;
 
 out vec4 frag_color;
 
-// Simple logistic sigmoid with a domain and range of [0 to 1].
+// Simple logistic sigmoid with a domain of [-1, 1] and range of [0, 1].
 float Sigmoid(float x) {
-  return 1.03597241992 / (1 + exp(-8 * x + 4)) - 0.0179862099621;
+  return 1.03731472073 / (1 + exp(-4 * x)) - 0.0186573603638;
+}
+
+float CircleDistance(vec2 sample_position,
+                     vec2 sphere_position,
+                     float sphere_size) {
+  return length(sample_position - sphere_position) - sphere_size;
+}
+
+float RectDistance(vec2 sample_position, vec2 rect_size) {
+  vec2 space = abs(sample_position) - rect_size;
+  return length(max(space, 0.0)) + min(max(space.x, space.y), 0.0);
+}
+
+float RRectDistance(vec2 sample_position, vec2 rect_size, float corner_radius) {
+  vec2 space = abs(sample_position) - rect_size + corner_radius;
+  return length(max(space, 0.0)) + min(max(space.x, space.y), 0.0) -
+         corner_radius;
+}
+
+float SquircleDistance(vec2 sample_position, float n) {
+  return pow(pow(abs(sample_position.x), n) + pow(abs(sample_position.y), n),
+             1.0 / n) -
+         1.0;
 }
 
 void main() {
-  float shadow_mask = Sigmoid(max(0.0, 1.0 - length(v_border)));
-  frag_color = fragment_info.color * shadow_mask;
+  float dist = RRectDistance(v_position - frag_info.rect_size / 2.0,
+                             frag_info.rect_size, frag_info.corner_radius);
+  float shadow_mask =
+      Sigmoid(clamp(1.0 - length(dist / frag_info.corner_radius), 0.0, 1.0));
+  frag_color = frag_info.color * shadow_mask;
 }

--- a/impeller/entity/shaders/rrect_blur.frag
+++ b/impeller/entity/shaders/rrect_blur.frag
@@ -1,0 +1,22 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+uniform FragmentInfo {
+  vec4 color;
+}
+fragment_info;
+
+in vec2 v_border;
+
+out vec4 frag_color;
+
+// Simple logistic sigmoid with a domain and range of [0 to 1].
+float Sigmoid(float x) {
+  return 1.03597241992 / (1 + exp(-8 * x + 4)) - 0.0179862099621;
+}
+
+void main() {
+  float shadow_mask = Sigmoid(max(0.0, 1.0 - length(v_border)));
+  frag_color = fragment_info.color * shadow_mask;
+}

--- a/impeller/entity/shaders/rrect_blur.frag
+++ b/impeller/entity/shaders/rrect_blur.frag
@@ -19,27 +19,10 @@ float Sigmoid(float x) {
   return 1.03731472073 / (1 + exp(-4 * x)) - 0.0186573603638;
 }
 
-float CircleDistance(vec2 sample_position,
-                     vec2 sphere_position,
-                     float sphere_size) {
-  return length(sample_position - sphere_position) - sphere_size;
-}
-
-float RectDistance(vec2 sample_position, vec2 rect_size) {
-  vec2 space = abs(sample_position) - rect_size;
-  return length(max(space, 0.0)) + min(max(space.x, space.y), 0.0);
-}
-
 float RRectDistance(vec2 sample_position, vec2 rect_size, float corner_radius) {
   vec2 space = abs(sample_position) - rect_size + corner_radius;
   return length(max(space, 0.0)) + min(max(space.x, space.y), 0.0) -
          corner_radius;
-}
-
-float SquircleDistance(vec2 sample_position, float n) {
-  return pow(pow(abs(sample_position.x), n) + pow(abs(sample_position.y), n),
-             1.0 / n) -
-         1.0;
 }
 
 void main() {

--- a/impeller/entity/shaders/rrect_blur.frag
+++ b/impeller/entity/shaders/rrect_blur.frag
@@ -43,9 +43,9 @@ float SquircleDistance(vec2 sample_position, float n) {
 }
 
 void main() {
-  float dist = RRectDistance(v_position - frag_info.rect_size / 2.0,
-                             frag_info.rect_size, frag_info.corner_radius);
-  float shadow_mask =
-      Sigmoid(clamp(1.0 - length(dist / frag_info.corner_radius), 0.0, 1.0));
+  vec2 center = v_position - frag_info.rect_size / 2.0;
+  float dist =
+      RRectDistance(center, frag_info.rect_size / 2.0, frag_info.corner_radius);
+  float shadow_mask = Sigmoid(-dist / frag_info.blur_radius);
   frag_color = frag_info.color * shadow_mask;
 }

--- a/impeller/entity/shaders/rrect_blur.vert
+++ b/impeller/entity/shaders/rrect_blur.vert
@@ -1,0 +1,18 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+uniform VertexInfo {
+  mat4 mvp;
+}
+vertex_info;
+
+in vec2 position;
+in vec2 border;
+
+out vec2 v_border;
+
+void main() {
+  gl_Position = vertex_info.mvp * vec4(position, 0.0, 1.0);
+  v_border = border;
+}

--- a/impeller/entity/shaders/rrect_blur.vert
+++ b/impeller/entity/shaders/rrect_blur.vert
@@ -2,17 +2,17 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-uniform VertexInfo {
+uniform VertInfo {
   mat4 mvp;
 }
-vertex_info;
+vert_info;
 
 in vec2 position;
-in vec2 border;
 
-out vec2 v_border;
+out vec2 v_position;
 
 void main() {
-  gl_Position = vertex_info.mvp * vec4(position, 0.0, 1.0);
-  v_border = border;
+  gl_Position = vert_info.mvp * vec4(position, 0.0, 1.0);
+  // The fragment stage uses local coordinates to compute the blur.
+  v_position = position;
 }

--- a/impeller/tools/build_metal_library.py
+++ b/impeller/tools/build_metal_library.py
@@ -93,6 +93,11 @@ def main():
     command += [
         '--std=macos-metal1.2',
     ]
+  elif args.platform == 'ios':
+    command += [
+        '--std=ios-metal1.2',
+        '-mios-version-min=10.0',
+    ]
 
   if args.optimize:
     command += [

--- a/impeller/tools/build_metal_library.py
+++ b/impeller/tools/build_metal_library.py
@@ -93,11 +93,6 @@ def main():
     command += [
         '--std=macos-metal1.2',
     ]
-  elif args.platform == 'ios':
-    command += [
-        '--std=ios-metal1.2',
-        '-mios-version-min=10.0',
-    ]
 
   if args.optimize:
     command += [


### PR DESCRIPTION
Adds an SDF blur that can be used for rects,  rounded rects, and circles.

Uses https://github.com/flutter/engine/pull/35083.

Right now there are visible corner artifacts when the blur radius is larger than the corner radius due to gradient discontinuities. I'm experimenting with a couple of promising solutions for this (one that samples the field a few times and one that interpolates with another field), but I figured I'd land this initial implementation since everything else is in place.

Will probably move some of the utilities into the shader lib depending on what the final solution ends up needing.

https://user-images.githubusercontent.com/919017/182367317-4a857924-749d-4fe6-b910-ad6f9468fe33.mov


