### PR TITLE
fix noop toString() diagnostics

### DIFF
--- a/lib/web_ui/dev/create_simulator.dart
+++ b/lib/web_ui/dev/create_simulator.dart
@@ -27,7 +27,7 @@ class CreateSimulatorCommand extends Command<bool> with ArgUtils<bool> {
         lock.minorVersion,
         lock.device,
       );
-      print('INFO: Simulator created ${simulator.toString()}');
+      print('INFO: Simulator created $simulator');
     } catch (e) {
       throw Exception('Error creating requested simulator. You can use Xcode '
           'to install more versions: XCode > Preferences > Components.'

--- a/lib/web_ui/dev/utils.dart
+++ b/lib/web_ui/dev/utils.dart
@@ -276,7 +276,7 @@ Future<void> runFlutter(
   if (exitCode != 0) {
     throw ToolExit(
       'ERROR: Failed to run $executable with '
-      'arguments ${arguments.toString()}. Exited with exit code $exitCode',
+      'arguments $arguments. Exited with exit code $exitCode',
       exitCode: exitCode,
     );
   }

--- a/lib/web_ui/test/text/line_breaker_test.dart
+++ b/lib/web_ui/test/text/line_breaker_test.dart
@@ -263,7 +263,7 @@ void testMain() {
               result.index,
               i,
               reason: 'Failed at test case number $t:\n'
-                  '${testCase.toString()}\n'
+                  '$testCase\n'
                   '"$text"\n'
                   '\nExpected line break at {$lastLineBreak - $i} but found line break at {$lastLineBreak - ${result.index}}.',
             );
@@ -283,7 +283,7 @@ void testMain() {
               result.index,
               greaterThan(i),
               reason: 'Failed at test case number $t:\n'
-                  '${testCase.toString()}\n'
+                  '$testCase\n'
                   '"$text"\n'
                   '\nUnexpected line break found at {$lastLineBreak - ${result.index}}.',
             );


### PR DESCRIPTION
Fix diagnostics that will get flagged in the next Dart SDK roll.

See breakage:

https://logs.chromium.org/logs/dart/buildbucket/cr-buildbucket/8806923775196938273/+/u/analyze_flutter_engine/stdout

Source Linter DEP bump: https://dart-review.googlesource.com/c/sdk/+/253501

/cc @a14n @srawlins 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
