### PR TITLE
[Windows] Fix incorrect public C API argument type

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -2393,6 +2393,7 @@ FILE: ../../../flutter/shell/platform/windows/flutter_windows_engine_unittests.c
 FILE: ../../../flutter/shell/platform/windows/flutter_windows_texture_registrar.cc
 FILE: ../../../flutter/shell/platform/windows/flutter_windows_texture_registrar.h
 FILE: ../../../flutter/shell/platform/windows/flutter_windows_texture_registrar_unittests.cc
+FILE: ../../../flutter/shell/platform/windows/flutter_windows_unittests.cc
 FILE: ../../../flutter/shell/platform/windows/flutter_windows_view.cc
 FILE: ../../../flutter/shell/platform/windows/flutter_windows_view.h
 FILE: ../../../flutter/shell/platform/windows/flutter_windows_view_unittests.cc

--- a/shell/platform/windows/BUILD.gn
+++ b/shell/platform/windows/BUILD.gn
@@ -173,6 +173,7 @@ executable("flutter_windows_unittests") {
     "flutter_window_unittests.cc",
     "flutter_windows_engine_unittests.cc",
     "flutter_windows_texture_registrar_unittests.cc",
+    "flutter_windows_unittests.cc",
     "flutter_windows_view_unittests.cc",
     "keyboard_key_channel_handler_unittests.cc",
     "keyboard_key_embedder_handler_unittests.cc",

--- a/shell/platform/windows/flutter_windows_unittests.cc
+++ b/shell/platform/windows/flutter_windows_unittests.cc
@@ -1,0 +1,25 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/windows/public/flutter_windows.h"
+
+#include <cstring>
+
+#include "gtest/gtest.h"
+
+namespace flutter {
+
+TEST(FlutterWindowsTest, GetTextureRegistrar) {
+  FlutterDesktopEngineProperties properties;
+  memset(&properties, 0, sizeof(FlutterDesktopEngineProperties));
+  properties.assets_path = L"";
+  properties.icu_data_path = L"icudtl.dat";
+  auto engine = FlutterDesktopEngineCreate(&properties);
+  ASSERT_NE(engine, nullptr);
+  auto texture_registrar = FlutterDesktopEngineGetTextureRegistrar(engine);
+  EXPECT_NE(texture_registrar, nullptr);
+  FlutterDesktopEngineDestroy(engine);
+}
+
+}  // namespace flutter

--- a/shell/platform/windows/public/flutter_windows.h
+++ b/shell/platform/windows/public/flutter_windows.h
@@ -169,8 +169,7 @@ FlutterDesktopEngineGetMessenger(FlutterDesktopEngineRef engine);
 
 // Returns the texture registrar associated with the engine.
 FLUTTER_EXPORT FlutterDesktopTextureRegistrarRef
-FlutterDesktopEngineGetTextureRegistrar(
-    FlutterDesktopTextureRegistrarRef texture_registrar);
+FlutterDesktopEngineGetTextureRegistrar(FlutterDesktopEngineRef engine);
 
 // ========== View ==========
 


### PR DESCRIPTION
FlutterDesktopEngineGetTextureRegistrar is used to get the texture
registrar associated with an engine object and therefore should take a
FlutterDesktopEngineRef parameter.

This bug was initially identified and fixed by @knopp in:
https://github.com/flutter/engine/pull/27522

This patch replaces that one and adds the simplest possible unit test to
get it landed.

This also adds an initial unit test for the public Windows C API used to
implement the C++ client wrapper. In order to fully test this API, we'll
want to support test fixtures similar to what we do in the embedder API
tests. See: https://github.com/flutter/flutter/issues/87299

Fixes: https://github.com/flutter/flutter/issues/86617

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
