### PR TITLE
[impeller] forward paint opacity to draw atlas

### DIFF
--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -346,6 +346,7 @@ void Canvas::DrawAtlas(std::shared_ptr<Image> atlas,
   contents->SetTexture(atlas->GetTexture());
   contents->SetSamplerDescriptor(std::move(sampler));
   contents->SetBlendMode(blend_mode);
+  contents->SetAlpha(paint.color.alpha);
   // TODO(jonahwilliams): set cull rect.
 
   Entity entity;

--- a/impeller/entity/contents/atlas_contents.cc
+++ b/impeller/entity/contents/atlas_contents.cc
@@ -41,6 +41,10 @@ void AtlasContents::SetColors(std::vector<Color> colors) {
   colors_ = colors;
 }
 
+void AtlasContents::SetAlpha(Scalar alpha) {
+  alpha_ = alpha;
+}
+
 void AtlasContents::SetBlendMode(Entity::BlendMode blend_mode) {
   // TODO(jonahwilliams): blending of colors with texture.
   blend_mode_ = blend_mode;
@@ -116,7 +120,8 @@ bool AtlasContents::Render(const ContentContext& renderer,
 
   FS::FragInfo frag_info;
   frag_info.texture_sampler_y_coord_scale = texture_->GetYCoordScale();
-  frag_info.has_color = colors_.size() > 0 ? 1.0 : 0.0;
+  frag_info.has_vertex_color = colors_.size() > 0 ? 1.0 : 0.0;
+  frag_info.alpha = alpha_;
 
   Command cmd;
   cmd.label = "DrawAtlas";

--- a/impeller/entity/contents/atlas_contents.h
+++ b/impeller/entity/contents/atlas_contents.h
@@ -35,6 +35,8 @@ class AtlasContents final : public Contents {
 
   void SetSamplerDescriptor(SamplerDescriptor desc);
 
+  void SetAlpha(Scalar alpha);
+
   const SamplerDescriptor& GetSamplerDescriptor() const;
 
   // |Contents|
@@ -51,6 +53,7 @@ class AtlasContents final : public Contents {
   std::vector<Color> colors_;
   std::vector<Matrix> transforms_;
   Entity::BlendMode blend_mode_;
+  Scalar alpha_ = 1.0;
   SamplerDescriptor sampler_descriptor_ = {};
 
   FML_DISALLOW_COPY_AND_ASSIGN(AtlasContents);

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -1159,6 +1159,41 @@ TEST_P(EntityTest, DrawAtlasWithColor) {
   ASSERT_TRUE(OpenPlaygroundHere(e));
 }
 
+TEST_P(EntityTest, DrawAtlasWithOpacity) {
+  // Draws the image as four squares stiched together slightly
+  // opaque
+  auto atlas = CreateTextureForFixture("bay_bridge.jpg");
+  auto size = atlas->GetSize();
+  // Divide image into four quadrants.
+  Scalar half_width = size.width / 2;
+  Scalar half_height = size.height / 2;
+  std::vector<Rect> texture_coordinates = {
+      Rect::MakeLTRB(0, 0, half_width, half_height),
+      Rect::MakeLTRB(half_width, 0, size.width, half_height),
+      Rect::MakeLTRB(0, half_height, half_width, size.height),
+      Rect::MakeLTRB(half_width, half_height, size.width, size.height)};
+  // Position quadrants adjacent to eachother.
+  std::vector<Matrix> transforms = {
+      Matrix::MakeTranslation({0, 0, 0}),
+      Matrix::MakeTranslation({half_width, 0, 0}),
+      Matrix::MakeTranslation({0, half_height, 0}),
+      Matrix::MakeTranslation({half_width, half_height, 0})};
+
+  std::shared_ptr<AtlasContents> contents = std::make_shared<AtlasContents>();
+
+  contents->SetTransforms(std::move(transforms));
+  contents->SetTextureCoordinates(std::move(texture_coordinates));
+  contents->SetTexture(atlas);
+  contents->SetAlpha(0.5);
+  contents->SetBlendMode(Entity::BlendMode::kSource);
+
+  Entity e;
+  e.SetTransformation(Matrix::MakeScale(GetContentScale()));
+  e.SetContents(contents);
+
+  ASSERT_TRUE(OpenPlaygroundHere(e));
+}
+
 TEST_P(EntityTest, DrawAtlasNoColorFullSize) {
   auto atlas = CreateTextureForFixture("bay_bridge.jpg");
   auto size = atlas->GetSize();

--- a/impeller/entity/shaders/atlas_fill.frag
+++ b/impeller/entity/shaders/atlas_fill.frag
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 #include <impeller/texture.glsl>
-#include <impeller/blending.glsl>
 
 uniform sampler2D texture_sampler;
 

--- a/impeller/entity/shaders/atlas_fill.frag
+++ b/impeller/entity/shaders/atlas_fill.frag
@@ -3,12 +3,14 @@
 // found in the LICENSE file.
 
 #include <impeller/texture.glsl>
+#include <impeller/blending.glsl>
 
 uniform sampler2D texture_sampler;
 
 uniform FragInfo {
   float texture_sampler_y_coord_scale;
-  float has_color;
+  float has_vertex_color;
+  float alpha;
 }
 frag_info;
 
@@ -20,9 +22,9 @@ out vec4 frag_color;
 void main() {
   vec4 sampled = IPSample(texture_sampler, v_texture_coords,
                           frag_info.texture_sampler_y_coord_scale);
-  if (frag_info.has_color == 1.0) {
-    frag_color = sampled.aaaa * v_color;
+  if (frag_info.has_vertex_color == 1.0) {
+    frag_color = sampled.aaaa * v_color * frag_info.alpha;
   } else {
-    frag_color = sampled;
+    frag_color = sampled * frag_info.alpha;
   }
 }


### PR DESCRIPTION
From local testing, the Skia backend will use the opacity of the provided paint color. 