### PR TITLE
[Windows] Add missing testing namespace

### DIFF
--- a/shell/platform/windows/flutter_windows_unittests.cc
+++ b/shell/platform/windows/flutter_windows_unittests.cc
@@ -9,6 +9,7 @@
 #include "gtest/gtest.h"
 
 namespace flutter {
+namespace testing {
 
 TEST(FlutterWindowsTest, GetTextureRegistrar) {
   FlutterDesktopEngineProperties properties;
@@ -22,4 +23,5 @@ TEST(FlutterWindowsTest, GetTextureRegistrar) {
   FlutterDesktopEngineDestroy(engine);
 }
 
+}  // namespace testing
 }  // namespace flutter

--- a/shell/platform/windows/keyboard_key_embedder_handler_unittests.cc
+++ b/shell/platform/windows/keyboard_key_embedder_handler_unittests.cc
@@ -14,6 +14,7 @@
 #include "gtest/gtest.h"
 
 namespace flutter {
+namespace testing {
 
 namespace {
 
@@ -71,11 +72,6 @@ UINT DefaultMapVkToScan(UINT virtual_key, bool extended) {
                        extended ? MAPVK_VK_TO_VSC_EX : MAPVK_VK_TO_VSC);
 }
 
-}  // namespace
-
-namespace testing {
-
-namespace {
 constexpr uint64_t kScanCodeKeyA = 0x1e;
 constexpr uint64_t kScanCodeAltLeft = 0x38;
 constexpr uint64_t kScanCodeNumpad1 = 0x4f;
@@ -86,8 +82,9 @@ constexpr uint64_t kScanCodeShiftRight = 0x36;
 
 constexpr uint64_t kVirtualKeyA = 0x41;
 
-using namespace ::flutter::testing::keycodes;
 }  // namespace
+
+using namespace ::flutter::testing::keycodes;
 
 TEST(KeyboardKeyEmbedderHandlerTest, ConvertChar32ToUtf8) {
   std::string result;


### PR DESCRIPTION
flutter_windows_unittests.cc had its tests inside the flutter namespace
rather than the flutter:testing namespace. This adds the missing
namespace and makes a namespace-related cleanup in one of the key
event unit tests, and moves a using declaration into the scope where it's
used for clarity, as well.

This is a post-landing cleanup for PR:
https://github.com/flutter/engine/pull/35106

Issue: https://github.com/flutter/flutter/issues/86617


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
