### PR TITLE
[impeller] use cullRect for drawAtlas coverage

### DIFF
--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -346,7 +346,7 @@ void Canvas::DrawAtlas(std::shared_ptr<Image> atlas,
   contents->SetTexture(atlas->GetTexture());
   contents->SetSamplerDescriptor(std::move(sampler));
   contents->SetBlendMode(blend_mode);
-  // TODO(jonahwilliams): set cull rect.
+  contents->SetCullRect(cull_rect);
 
   Entity entity;
   entity.SetTransformation(GetCurrentTransformation());

--- a/impeller/entity/contents/atlas_contents.cc
+++ b/impeller/entity/contents/atlas_contents.cc
@@ -46,7 +46,15 @@ void AtlasContents::SetBlendMode(Entity::BlendMode blend_mode) {
   blend_mode_ = blend_mode;
 }
 
+void AtlasContents::SetCullRect(std::optional<Rect> cull_rect) {
+  cull_rect_ = cull_rect;
+}
+
 std::optional<Rect> AtlasContents::GetCoverage(const Entity& entity) const {
+  if (cull_rect_.has_value()) {
+    return cull_rect_.value().TransformBounds(entity.GetTransformation());
+  }
+
   Rect bounding_box = {};
   for (size_t i = 0; i < texture_coords_.size(); i++) {
     auto matrix = transforms_[i];

--- a/impeller/entity/contents/atlas_contents.h
+++ b/impeller/entity/contents/atlas_contents.h
@@ -33,6 +33,8 @@ class AtlasContents final : public Contents {
 
   void SetColors(std::vector<Color> colors);
 
+  void SetCullRect(std::optional<Rect> cull_rect);
+
   void SetSamplerDescriptor(SamplerDescriptor desc);
 
   const SamplerDescriptor& GetSamplerDescriptor() const;
@@ -51,6 +53,7 @@ class AtlasContents final : public Contents {
   std::vector<Color> colors_;
   std::vector<Matrix> transforms_;
   Entity::BlendMode blend_mode_;
+  std::optional<Rect> cull_rect_;
   SamplerDescriptor sampler_descriptor_ = {};
 
   FML_DISALLOW_COPY_AND_ASSIGN(AtlasContents);

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -1159,6 +1159,43 @@ TEST_P(EntityTest, DrawAtlasWithColor) {
   ASSERT_TRUE(OpenPlaygroundHere(e));
 }
 
+TEST_P(EntityTest, DrawAtlasUsesProvidedCullRectForCoverage) {
+  auto atlas = CreateTextureForFixture("bay_bridge.jpg");
+  auto size = atlas->GetSize();
+  Scalar half_width = size.width / 2;
+  Scalar half_height = size.height / 2;
+  std::vector<Rect> texture_coordinates = {
+      Rect::MakeLTRB(0, 0, half_width, half_height),
+      Rect::MakeLTRB(half_width, 0, size.width, half_height),
+      Rect::MakeLTRB(0, half_height, half_width, size.height),
+      Rect::MakeLTRB(half_width, half_height, size.width, size.height)};
+  std::vector<Matrix> transforms = {
+      Matrix::MakeTranslation({0, 0, 0}),
+      Matrix::MakeTranslation({half_width, 0, 0}),
+      Matrix::MakeTranslation({0, half_height, 0}),
+      Matrix::MakeTranslation({half_width, half_height, 0})};
+
+  std::shared_ptr<AtlasContents> contents = std::make_shared<AtlasContents>();
+
+  contents->SetTransforms(std::move(transforms));
+  contents->SetTextureCoordinates(std::move(texture_coordinates));
+  contents->SetTexture(atlas);
+  contents->SetBlendMode(Entity::BlendMode::kSource);
+
+  auto transform = Matrix::MakeScale(GetContentScale());
+  Entity e;
+  e.SetTransformation(transform);
+  e.SetContents(contents);
+
+  ASSERT_EQ(contents->GetCoverage(e).value(),
+            Rect::MakeSize(size).TransformBounds(transform));
+
+  contents->SetCullRect(Rect::MakeLTRB(0, 0, 10, 10));
+
+  ASSERT_EQ(contents->GetCoverage(e).value(),
+            Rect::MakeLTRB(0, 0, 10, 10).TransformBounds(transform));
+}
+
 TEST_P(EntityTest, DrawAtlasNoColorFullSize) {
   auto atlas = CreateTextureForFixture("bay_bridge.jpg");
   auto size = atlas->GetSize();

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -1195,8 +1195,6 @@ TEST_P(EntityTest, DrawAtlasUsesProvidedCullRectForCoverage) {
 
   ASSERT_EQ(contents->GetCoverage(e).value(),
             Rect::MakeLTRB(0, 0, 10, 10).TransformBounds(transform));
-  contents->SetAlpha(0.5);
-  contents->SetBlendMode(Entity::BlendMode::kSource);
 }
 
 TEST_P(EntityTest, DrawAtlasWithOpacity) {
@@ -1225,21 +1223,7 @@ TEST_P(EntityTest, DrawAtlasWithOpacity) {
   contents->SetTextureCoordinates(std::move(texture_coordinates));
   contents->SetTexture(atlas);
   contents->SetBlendMode(Entity::BlendMode::kSource);
-
-  auto transform = Matrix::MakeScale(GetContentScale());
-  Entity e;
-  e.SetTransformation(transform);
-  e.SetContents(contents);
-
-  ASSERT_EQ(contents->GetCoverage(e).value(),
-            Rect::MakeSize(size).TransformBounds(transform));
-
-  contents->SetCullRect(Rect::MakeLTRB(0, 0, 10, 10));
-
-  ASSERT_EQ(contents->GetCoverage(e).value(),
-            Rect::MakeLTRB(0, 0, 10, 10).TransformBounds(transform));
   contents->SetAlpha(0.5);
-  contents->SetBlendMode(Entity::BlendMode::kSource);
 
   Entity e;
   e.SetTransformation(Matrix::MakeScale(GetContentScale()));


### PR DESCRIPTION
Context >

On the cullRect argument to drawAtlas, the documentation states:

"The optional cullRect argument can provide an estimate of the bounds of the coordinates rendered by all components of the atlas to be compared against the clip to quickly reject the operation if it does not intersect."

And from my observed testing, as long as some part of the cull rect would be on screen - everything is drawn. Which makes sense, its not a clip rect. It sounds like a correct implementation for this for impeller would be to use the provided cullRect in place of the computed coverage, if provided.
