### PR TITLE
[impellerc] Namespace user functions in SkSL output

### DIFF
--- a/impeller/compiler/spirv_sksl.h
+++ b/impeller/compiler/spirv_sksl.h
@@ -38,6 +38,8 @@ class CompilerSkSL : public spirv_cross::CompilerGLSL {
 
   void emit_uniform(const spirv_cross::SPIRVariable& var) override;
 
+  void fixup_user_functions();
+
   void detect_unsupported_resources();
   bool emit_constant_resources();
   bool emit_struct_resources();

--- a/lib/ui/fixtures/shaders/general_shaders/BUILD.gn
+++ b/lib/ui/fixtures/shaders/general_shaders/BUILD.gn
@@ -11,6 +11,7 @@ if (enable_unittests) {
     "blue_green_sampler.frag",
     "children_and_uniforms.frag",
     "functions.frag",
+    "no_builtin_redefinition.frag",
     "no_uniforms.frag",
     "simple.frag",
     "uniforms.frag",

--- a/lib/ui/fixtures/shaders/general_shaders/no_builtin_redefinition.frag
+++ b/lib/ui/fixtures/shaders/general_shaders/no_builtin_redefinition.frag
@@ -1,0 +1,38 @@
+#version 320 es
+
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+precision highp float;
+
+layout ( location = 0 ) out vec4 oColor;
+
+layout ( location = 0 ) uniform float a;  // should be 1.0
+
+float saturate(float x) {
+  return clamp(x, 0.0, 1.0);
+}
+
+float addA(float x) {
+  return x + a;
+}
+
+vec2 pairWithA(float x) {
+  return vec2(x, a);
+}
+
+vec3 composedFunction(float x) {
+  return vec3(addA(x), pairWithA(x));
+}
+
+float multiParam(float x, float y, float z) {
+  return x * y * z * a;
+}
+
+void main() {
+  float x = saturate(addA(0.0)); // x = 0 + 1;
+  vec3 v3 = composedFunction(x); // v3 = vec3(2, 1, 1);
+  x = multiParam(v3.x, v3.y, v3.z); // x = 2 * 1 * 1 * 1;
+  oColor = vec4(0.0, x / 2.0, 0.0, 1.0); // vec4(0, 1, 0, 1);
+}

--- a/testing/dart/fragment_shader_test.dart
+++ b/testing/dart/fragment_shader_test.dart
@@ -118,6 +118,16 @@ void main() async {
     expect(throws, equals(true));
   });
 
+  test('user defined functions do not redefine builtins', () async {
+    final FragmentProgram program = await FragmentProgram.fromAsset(
+      'no_builtin_redefinition.frag.iplr',
+    );
+    final Shader shader = program.shader(
+      floatUniforms: Float32List.fromList(<double>[1.0]),
+    );
+    await _expectShaderRendersGreen(shader);
+  });
+
   test('fromAsset accepts a shader with no uniforms', () async {
     final FragmentProgram program = await FragmentProgram.fromAsset(
       'no_uniforms.frag.iplr',


### PR DESCRIPTION
A recent change made redefinition of builtin functions forbidden in SkSL. To ensure that impellerc's SPIRV to SkSL translator is always generating valid SkSL, this change prefixes user defined functions with a distinctive string. Then, if the name of a user defined function is the same as an SkSL builtin in the input, the prefix added by impellerc in the output will disambiguate from the builtin.