### PR TITLE
[testing/scenario_app] fix no-op interpolated toStrings()

### DIFF
--- a/testing/scenario_app/bin/android_integration_tests.dart
+++ b/testing/scenario_app/bin/android_integration_tests.dart
@@ -71,7 +71,7 @@ void main(List<String> args) async {
         try {
           goldenFile = File(join(screenshotPath, fileName))..writeAsBytesSync(fileContent, flush: true);
         } on FileSystemException catch (err) {
-          panic(<String>['failed to create screenshot $fileName: ${err.toString()}']);
+          panic(<String>['failed to create screenshot $fileName: $err']);
         }
         log('wrote ${goldenFile.absolute.path}');
         if (isSkiaGoldClientAvailable) {
@@ -79,13 +79,13 @@ void main(List<String> args) async {
             .addImg(fileName, goldenFile,
                     screenshotSize: screenshot.pixelCount)
             .catchError((dynamic err) {
-              panic(<String>['skia gold comparison failed: ${err.toString()}']);
+              panic(<String>['skia gold comparison failed: $err']);
             });
           pendingComparisons.add(comparison);
         }
       },
       onError: (dynamic err) {
-        panic(<String>['error while receiving bytes: ${err.toString()}']);
+        panic(<String>['error while receiving bytes: $err']);
       },
       cancelOnError: true);
     });


### PR DESCRIPTION
Fix diagnostics that will get flagged in the next Dart SDK roll.

See breakage:

https://logs.chromium.org/logs/dart/buildbucket/cr-buildbucket/8806813421665614129/+/u/analyze_dart_ui/stdout

Source Linter DEP bump: https://dart-review.googlesource.com/c/sdk/+/253501

/cc @a14n @srawlins 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
