### PR TITLE
Updates objectc script to accept relative paths.

### DIFF
--- a/tools/gen_objcdoc.sh
+++ b/tools/gen_objcdoc.sh
@@ -22,6 +22,7 @@ if [[ $# -eq 0 ]]; then
 fi
 
 OUTPUT_DIR="$1"
+ZIP_DESTINATION="$1"
 if [ "${OUTPUT_DIR:0:1}" != "/" ]
 then
   cwd=$('pwd')

--- a/tools/gen_objcdoc.sh
+++ b/tools/gen_objcdoc.sh
@@ -17,7 +17,6 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 pushd "$SCRIPT_DIR/../../flutter"
 
 FLUTTER_UMBRELLA_HEADER=$(find ../out -maxdepth 4 -type f -name Flutter.h | grep 'ios_' | head -n 1)
-echo "$(pwd)"
 if [[ ! -f "$FLUTTER_UMBRELLA_HEADER" ]]
   then
       echo "Error: This script must be run at the root of the Flutter source tree with at least one built Flutter.framework in ../out/ios*/Flutter.framework."
@@ -25,7 +24,7 @@ if [[ ! -f "$FLUTTER_UMBRELLA_HEADER" ]]
       exit 1
 fi
 
-OUTPUT_DIR="$1"
+OUTPUT_DIR="$1/objectc_docs"
 ZIP_DESTINATION="$1"
 if [ "${OUTPUT_DIR:0:1}" != "/" ]
 then

--- a/tools/gen_objcdoc.sh
+++ b/tools/gen_objcdoc.sh
@@ -21,6 +21,7 @@ echo "$(pwd)"
 if [[ ! -f "$FLUTTER_UMBRELLA_HEADER" ]]
   then
       echo "Error: This script must be run at the root of the Flutter source tree with at least one built Flutter.framework in ../out/ios*/Flutter.framework."
+      echo "Running from: $(pwd)"
       exit 1
 fi
 

--- a/tools/gen_objcdoc.sh
+++ b/tools/gen_objcdoc.sh
@@ -14,9 +14,10 @@ fi
 
 # Move to the flutter checkout
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-pushd "$SCRIPT_DIR/../"
+pushd "$SCRIPT_DIR/../../flutter"
 
 FLUTTER_UMBRELLA_HEADER=$(find ../out -maxdepth 4 -type f -name Flutter.h | grep 'ios_' | head -n 1)
+echo "$(pwd)"
 if [[ ! -f "$FLUTTER_UMBRELLA_HEADER" ]]
   then
       echo "Error: This script must be run at the root of the Flutter source tree with at least one built Flutter.framework in ../out/ios*/Flutter.framework."

--- a/tools/gen_objcdoc.sh
+++ b/tools/gen_objcdoc.sh
@@ -15,19 +15,18 @@ if [[ ! -f "$FLUTTER_UMBRELLA_HEADER" ]]
 fi
 
 
-# If the script is running from within LUCI we use the LUCI_WORKDIR, if not we force the caller of the script
-# to pass an output directory as the first parameter.
-OUTPUT_DIR=""
 
-if [[ -z "$LUCI_CI" ]]; then
-  if [[ $# -eq 0 ]]; then
-    echo "Error: Argument specifying output directory required."
-    exit 1
-  else
-    OUTPUT_DIR="$1"
-  fi
-else
-  OUTPUT_DIR="$LUCI_WORKDIR/objectc_docs"
+if [[ $# -eq 0 ]]; then
+   echo "Error: Argument specifying output directory required."
+   exit 1
+fi
+
+OUTPUT_DIR="$1"
+if [ "${OUTPUT_DIR:0:1}" != "/" ]
+then
+  cwd=$('pwd')
+  ZIP_DESTINATION="$cwd/../$1"
+  OUTPUT_DIR="$ZIP_DESTINATION/objectc_docs"
 fi
 
 # If GEM_HOME is set, prefer using its copy of jazzy.
@@ -83,3 +82,8 @@ if [[ $EXPECTED_CLASSES != $ACTUAL_CLASSES ]]; then
   diff <(echo "$EXPECTED_CLASSES") <(echo "$ACTUAL_CLASSES")
   exit -1
 fi
+
+# Create the final zip file.
+pushd $OUTPUT_DIR
+zip -r "$ZIP_DESTINATION/ios-objcdoc.zip" .
+popd

--- a/tools/gen_objcdoc.sh
+++ b/tools/gen_objcdoc.sh
@@ -7,6 +7,15 @@
 
 set -e
 
+if [[ $# -eq 0 ]]; then
+   echo "Error: Argument specifying output directory required."
+   exit 1
+fi
+
+# Move to the flutter checkout
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+pushd "$SCRIPT_DIR/../"
+
 FLUTTER_UMBRELLA_HEADER=$(find ../out -maxdepth 4 -type f -name Flutter.h | grep 'ios_' | head -n 1)
 if [[ ! -f "$FLUTTER_UMBRELLA_HEADER" ]]
   then
@@ -14,19 +23,11 @@ if [[ ! -f "$FLUTTER_UMBRELLA_HEADER" ]]
       exit 1
 fi
 
-
-
-if [[ $# -eq 0 ]]; then
-   echo "Error: Argument specifying output directory required."
-   exit 1
-fi
-
 OUTPUT_DIR="$1"
 ZIP_DESTINATION="$1"
 if [ "${OUTPUT_DIR:0:1}" != "/" ]
 then
-  cwd=$('pwd')
-  ZIP_DESTINATION="$cwd/../$1"
+  ZIP_DESTINATION="$SCRIPT_DIR/../../$1"
   OUTPUT_DIR="$ZIP_DESTINATION/objectc_docs"
 fi
 


### PR DESCRIPTION
Recipes v2 do not know the final paths in advance to be provided in the
configurations. The support of relative paths allow to calculate full
paths at runtime.

This change is also moving the creation of zips to the script to
simplify the recipes.

Bug: https://github.com/flutter/flutter/issues/81855

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
