### PR TITLE
[impeller] move gaussian blur vertex uniforms to fragment uniforms

### DIFF
--- a/impeller/entity/shaders/gaussian_blur.vert
+++ b/impeller/entity/shaders/gaussian_blur.vert
@@ -4,15 +4,6 @@
 
 uniform FrameInfo {
   mat4 mvp;
-  vec2 texture_size;
-
-  vec2 blur_direction;
-  float blur_sigma;
-  float blur_radius;
-
-  float src_factor;
-  float inner_blur_factor;
-  float outer_blur_factor;
 }
 frame_info;
 
@@ -22,23 +13,9 @@ in vec2 src_texture_coords;
 
 out vec2 v_texture_coords;
 out vec2 v_src_texture_coords;
-out vec2 v_texture_size;
-out vec2 v_blur_direction;
-out float v_blur_sigma;
-out float v_blur_radius;
-out float v_src_factor;
-out float v_inner_blur_factor;
-out float v_outer_blur_factor;
 
 void main() {
   gl_Position = frame_info.mvp * vec4(vertices, 0.0, 1.0);
   v_texture_coords = texture_coords;
   v_src_texture_coords = src_texture_coords;
-  v_texture_size = frame_info.texture_size;
-  v_blur_direction = frame_info.blur_direction;
-  v_blur_sigma = frame_info.blur_sigma;
-  v_blur_radius = frame_info.blur_radius;
-  v_src_factor = frame_info.src_factor;
-  v_inner_blur_factor = frame_info.inner_blur_factor;
-  v_outer_blur_factor = frame_info.outer_blur_factor;
 }


### PR DESCRIPTION
The blur shader is currently passing uniforms from the vertex shader through fragment shader inputs. Instead make the fragment shader take these as a uniform - which _I think_ is theoretically faster and cleaner.

From local debugging, this reduces the amount of time spent in WaitForNextDrawable from ~830 ms to ~660 ms in a customer application.

TOT ios_debug

![image](https://user-images.githubusercontent.com/8975114/183218996-5a465077-1a67-43fe-828a-2af742fdc494.png)

With change ios_debug

![image](https://user-images.githubusercontent.com/8975114/183219033-60c5d29e-12cd-4cd7-b840-acfcba176030.png)


Of course, maybe its all just noise!

