### PR TITLE
[Impeller] Implement drawPoints in Impeller

### DIFF
--- a/impeller/display_list/display_list_dispatcher.cc
+++ b/impeller/display_list/display_list_dispatcher.cc
@@ -767,6 +767,9 @@ void DisplayListDispatcher::drawPoints(SkCanvas::PointMode mode,
   paint.style = Paint::Style::kStroke;
   switch (mode) {
     case SkCanvas::kPoints_PointMode:
+      if (paint.stroke_cap == SolidStrokeContents::Cap::kButt) {
+        paint.stroke_cap = SolidStrokeContents::Cap::kSquare;
+      }
       for (uint32_t i = 0; i < count; i++) {
         SkPoint p0 = points[i];
         SkPoint p1 = points[i] + SkPoint{0.0001, 0.0};

--- a/impeller/display_list/display_list_dispatcher.cc
+++ b/impeller/display_list/display_list_dispatcher.cc
@@ -772,7 +772,10 @@ void DisplayListDispatcher::drawPoints(SkCanvas::PointMode mode,
       }
       for (uint32_t i = 0; i < count; i++) {
         SkPoint p0 = points[i];
-        SkPoint p1 = points[i] + SkPoint{0.0001, 0.0};
+        // kEhCloseEnough works around a bug where Impeller does not draw
+        // anything for zero-length lines.
+        // See: https://github.com/flutter/flutter/issues/109077
+        SkPoint p1 = points[i] + SkPoint{kEhCloseEnough, 0.0};
         auto path = PathBuilder{}.AddLine(ToPoint(p0), ToPoint(p1)).TakePath();
         canvas_.DrawPath(std::move(path), paint);
       }

--- a/impeller/display_list/display_list_dispatcher.cc
+++ b/impeller/display_list/display_list_dispatcher.cc
@@ -776,7 +776,7 @@ void DisplayListDispatcher::drawPoints(SkCanvas::PointMode mode,
       break;
     case SkCanvas::kLines_PointMode:
       for (uint32_t i = 1; i < count; i += 2) {
-        SkPoint p0 = points[i-1];
+        SkPoint p0 = points[i - 1];
         SkPoint p1 = points[i];
         auto path = PathBuilder{}.AddLine(ToPoint(p0), ToPoint(p1)).TakePath();
         canvas_.DrawPath(std::move(path), paint);
@@ -784,7 +784,7 @@ void DisplayListDispatcher::drawPoints(SkCanvas::PointMode mode,
       break;
     case SkCanvas::kPolygon_PointMode:
       for (uint32_t i = 1; i < count; i++) {
-        SkPoint p0 = points[i-1];
+        SkPoint p0 = points[i - 1];
         SkPoint p1 = points[i];
         auto path = PathBuilder{}.AddLine(ToPoint(p0), ToPoint(p1)).TakePath();
         canvas_.DrawPath(std::move(path), paint);

--- a/impeller/display_list/display_list_dispatcher.cc
+++ b/impeller/display_list/display_list_dispatcher.cc
@@ -762,7 +762,35 @@ void DisplayListDispatcher::drawArc(const SkRect& oval_bounds,
 void DisplayListDispatcher::drawPoints(SkCanvas::PointMode mode,
                                        uint32_t count,
                                        const SkPoint points[]) {
-  UNIMPLEMENTED;
+  // auto path = PathBuilder{}.AddLine(ToPoint(p0), ToPoint(p1)).TakePath();
+  Paint paint = paint_;
+  paint.style = Paint::Style::kStroke;
+  switch (mode) {
+    case SkCanvas::kPoints_PointMode:
+      for (uint32_t i = 0; i < count; i++) {
+        SkPoint p0 = points[i];
+        SkPoint p1 = points[i] + SkPoint{0.0001, 0.0};
+        auto path = PathBuilder{}.AddLine(ToPoint(p0), ToPoint(p1)).TakePath();
+        canvas_.DrawPath(std::move(path), paint);
+      }
+      break;
+    case SkCanvas::kLines_PointMode:
+      for (uint32_t i = 1; i < count; i += 2) {
+        SkPoint p0 = points[i-1];
+        SkPoint p1 = points[i];
+        auto path = PathBuilder{}.AddLine(ToPoint(p0), ToPoint(p1)).TakePath();
+        canvas_.DrawPath(std::move(path), paint);
+      }
+      break;
+    case SkCanvas::kPolygon_PointMode:
+      for (uint32_t i = 1; i < count; i++) {
+        SkPoint p0 = points[i-1];
+        SkPoint p1 = points[i];
+        auto path = PathBuilder{}.AddLine(ToPoint(p0), ToPoint(p1)).TakePath();
+        canvas_.DrawPath(std::move(path), paint);
+      }
+      break;
+  }
 }
 
 // |flutter::Dispatcher|

--- a/impeller/display_list/display_list_unittests.cc
+++ b/impeller/display_list/display_list_unittests.cc
@@ -433,5 +433,38 @@ TEST_P(DisplayListTest, CanDrawNinePatchImageCornersScaledDown) {
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
 
+TEST_P(DisplayListTest, CanDrawPoints) {
+  flutter::DisplayListBuilder builder;
+  SkPoint points[7] = {
+      {0, 0},      //
+      {100, 100},  //
+      {100, 0},    //
+      {0, 100},    //
+      {0, 0},      //
+      {48, 48},    //
+      {52, 52},    //
+  };
+  std::vector<flutter::DlStrokeCap> caps = {
+      flutter::DlStrokeCap::kButt,
+      flutter::DlStrokeCap::kRound,
+      flutter::DlStrokeCap::kSquare,
+  };
+  flutter::DlPaint paint = flutter::DlPaint().setStrokeWidth(20);
+  builder.translate(50, 50);
+  for (auto cap : caps) {
+    paint.setStrokeCap(cap);
+    paint.setColor(flutter::DlColor::kYellow().withAlpha(127));
+    builder.save();
+    builder.drawPoints(SkCanvas::kPoints_PointMode, 7, points, paint);
+    builder.translate(150, 0);
+    builder.drawPoints(SkCanvas::kLines_PointMode, 5, points, paint);
+    builder.translate(150, 0);
+    builder.drawPoints(SkCanvas::kPolygon_PointMode, 5, points, paint);
+    builder.restore();
+    builder.translate(0, 150);
+  }
+  ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
+}
+
 }  // namespace testing
 }  // namespace impeller


### PR DESCRIPTION
It may seem like this is a broken implementation calling drawLine on individual paths, but that is actually the semantics of the call. We could do these in parallel for performance, but they must behave as if they are individual calls to drawLine - complete with Polygon mode not connecting with joins and all of the individual lines/points/polygon segments over-drawing at their overlap points. The following test case helps show the behavior and shows the same behavior with and without Impeller.

<details>
<summary>DrawPoints interactive app</summary>

```
import 'dart:typed_data';
import 'dart:math' as math;
import 'dart:ui' as ui;

import 'package:flutter/material.dart';

void main() {
  runApp(MyApp());
}

class MyApp extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      title: 'Flutter Demo',
      theme: ThemeData(
        primarySwatch: Colors.blue,
      ),
      home: MyHomePage(title: 'Flutter Demo Home Page'),
    );
  }
}

class MyHomePage extends StatefulWidget {
  MyHomePage({Key? key, required this.title}) : super(key: key);

  final String title;

  @override
  _MyHomePageState createState() => _MyHomePageState();
}

class MobilePoint {
  static math.Random generator = math.Random();

  MobilePoint.random(this.size) {
    x = generator.nextDouble() * size.width;
    y = generator.nextDouble() * size.height;
    dx = (generator.nextDouble() - 0.5) * size.width / 100;
    dy = (generator.nextDouble() - 0.5) * size.height / 100;
  }

  void bump() {
    x += dx;
    if (x > size.width) {
      x = size.width * 2 - x;
      dx = -dx;
    } else if (x < 0) {
      x = -x;
      dx = -dx;
    }
    y += dy;
    if (y > size.height) {
      y = size.height * 2 - y;
      dy = -dy;
    } else if (y < 0) {
      y = -y;
      dy = -dy;
    }
  }

  Size size;
  double x = 0, y = 0;
  double dx = 0, dy = 0;
}

class _MyHomePageState extends State<MyHomePage> with SingleTickerProviderStateMixin {
  static Size pointFieldSize = Size(200, 200);
  List<MobilePoint> points = List<MobilePoint>.generate(100, (index) => MobilePoint.random(pointFieldSize));
  late AnimationController controller;

  @override
  void initState() {
    super.initState();
    controller = AnimationController(vsync: this);
    controller.repeat(period: Duration(seconds: 10));
  }

  @override
  void dispose() {
    controller.stop();
    controller.dispose();
    super.dispose();
  }

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(
        title: Text(widget.title),
      ),
      body: Center(
        child: AnimatedBuilder(
          animation: controller,
          builder: (context, child) {
            final Float32List pointList = Float32List(points.length * 2);
            for (int i = 0; i < points.length; i++) {
              points[i].bump();
              pointList[i * 2] = points[i].x;
              pointList[i * 2 + 1] = points[i].y;
            }
            return Column(
              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
              crossAxisAlignment: CrossAxisAlignment.center,
              children: <Widget>[
                Row(
                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                  children: <Widget>[
                    CustomPaint(
                      size: pointFieldSize,
                      painter: PointPainter(pointList, ui.PointMode.points),
                    ),
                    CustomPaint(
                      size: pointFieldSize,
                      painter: PointPainter(pointList, ui.PointMode.lines),
                    ),
                  ],
                ),
                Row(
                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                  children: <Widget>[
                    CustomPaint(
                      size: pointFieldSize,
                      painter: PointPainter(pointList, ui.PointMode.polygon),
                    ),
                    CustomPaint(
                      size: pointFieldSize,
                      painter: PathPainter(points),
                    ),
                  ],
                ),
              ],
            );
          },
        ),
      ),
    );
  }
}

class PointPainter extends CustomPainter {
  PointPainter(this.list, this.mode);

  final ui.PointMode mode;
  final Float32List list;

  @override
  void paint(Canvas canvas, Size size) {
    Paint paint = Paint()
      ..color = Colors.blue.withAlpha(64)
      ..strokeWidth = 4.0
      ..strokeJoin = StrokeJoin.miter
      ..strokeCap = StrokeCap.square;
    canvas.drawRawPoints(mode, list, paint);
  }

  @override
  bool shouldRepaint(CustomPainter oldDelegate) => true;
}

class PathPainter extends CustomPainter {
  PathPainter(this.list);

  final List<MobilePoint> list;

  @override
  void paint(Canvas canvas, Size size) {
    Paint paint = Paint()
      ..color = Colors.blue.withAlpha(64)
      ..style = PaintingStyle.stroke
      ..strokeWidth = 4.0
      ..strokeJoin = StrokeJoin.miter
      ..strokeCap = StrokeCap.square;
    Path path = Path();
    path.moveTo(list[0].x, list[1].y);
    for (int i = 1; i < list.length; i++) {
      path.lineTo(list[i].x, list[i].y);
    }
    canvas.drawPath(path, paint);
  }

  @override
  bool shouldRepaint(CustomPainter oldDelegate) => true;
}
```
</details>