### PR TITLE
[web] remove references to IE11 and old Edge; treat Samsung browser as Blink

### DIFF
--- a/lib/web_ui/lib/src/engine/browser_detection.dart
+++ b/lib/web_ui/lib/src/engine/browser_detection.dart
@@ -16,6 +16,9 @@ bool get _workAroundBug91333 => operatingSystem == OperatingSystem.iOs;
 enum BrowserEngine {
   /// The engine that powers Chrome, Samsung Internet Browser, UC Browser,
   /// Microsoft Edge, Opera, and others.
+  ///
+  /// Blink is assumed in case when a more precise browser engine wasn't
+  /// detected.
   blink,
 
   /// The engine that powers Safari.
@@ -23,18 +26,6 @@ enum BrowserEngine {
 
   /// The engine that powers Firefox.
   firefox,
-
-  /// The engine that powers Edge.
-  edge,
-
-  /// The engine that powers Internet Explorer 11.
-  ie11,
-
-  /// The engine that powers Samsung stock browser. It is based on blink.
-  samsung,
-
-  /// We were unable to detect the current browser engine.
-  unknown,
 }
 
 /// html webgl version qualifier constants.
@@ -70,51 +61,28 @@ BrowserEngine _detectBrowserEngine() {
   return detectBrowserEngineByVendorAgent(vendor, agent);
 }
 
-/// Detects samsung blink variants.
-///
-///  Example patterns:
-///    Note 2 : GT-N7100
-///    Note 3 : SM-N900T
-///    Tab 4 : SM-T330NU
-///    Galaxy S4: SHV-E330S
-///    Galaxy Note2: SHV-E250L
-///    Note: SAMSUNG-SGH-I717
-///    SPH/SCH are very old Palm models.
-bool _isSamsungBrowser(String agent) {
-  final RegExp exp = RegExp(
-      r'SAMSUNG|SGH-[I|N|T]|GT-[I|N]|SM-[A|N|P|T|Z]|SHV-E|SCH-[I|J|R|S]|SPH-L');
-  return exp.hasMatch(agent.toUpperCase());
-}
-
 /// Detects browser engine for a given vendor and agent string.
 ///
 /// Used for testing this library.
 @visibleForTesting
 BrowserEngine detectBrowserEngineByVendorAgent(String vendor, String agent) {
   if (vendor == 'Google Inc.') {
-    // Samsung browser is based on blink, check for variant.
-    if (_isSamsungBrowser(agent)) {
-      return BrowserEngine.samsung;
-    }
     return BrowserEngine.blink;
   } else if (vendor == 'Apple Computer, Inc.') {
     return BrowserEngine.webkit;
-  } else if (agent.contains('edge/')) {
-    return BrowserEngine.edge;
   } else if (agent.contains('Edg/')) {
     // Chromium based Microsoft Edge has `Edg` in the user-agent.
     // https://docs.microsoft.com/en-us/microsoft-edge/web-platform/user-agent-string
     return BrowserEngine.blink;
-  } else if (agent.contains('trident/7.0')) {
-    return BrowserEngine.ie11;
   } else if (vendor == '' && agent.contains('firefox')) {
     // An empty string means firefox:
     // https://developer.mozilla.org/en-US/docs/Web/API/Navigator/vendor
     return BrowserEngine.firefox;
   }
-  // Assume unknown otherwise, but issue a warning.
+
+  // Assume Blink otherwise, but issue a warning.
   print('WARNING: failed to detect current browser engine.');
-  return BrowserEngine.unknown;
+  return BrowserEngine.blink;
 }
 
 /// Operating system where the current browser runs.

--- a/lib/web_ui/lib/src/engine/browser_detection.dart
+++ b/lib/web_ui/lib/src/engine/browser_detection.dart
@@ -81,7 +81,7 @@ BrowserEngine detectBrowserEngineByVendorAgent(String vendor, String agent) {
   }
 
   // Assume Blink otherwise, but issue a warning.
-  print('WARNING: failed to detect current browser engine.');
+  print('WARNING: failed to detect current browser engine. Assuming this is a Chromium-compatible browser.');
   return BrowserEngine.blink;
 }
 

--- a/lib/web_ui/lib/src/engine/html_image_codec.dart
+++ b/lib/web_ui/lib/src/engine/html_image_codec.dart
@@ -56,9 +56,7 @@ class HtmlCodec implements ui.Codec {
         int naturalWidth = imgElement.naturalWidth;
         int naturalHeight = imgElement.naturalHeight;
         // Workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=700533.
-        if (naturalWidth == 0 && naturalHeight == 0 && (
-            browserEngine == BrowserEngine.firefox ||
-                browserEngine == BrowserEngine.ie11)) {
+        if (naturalWidth == 0 && naturalHeight == 0 && browserEngine == BrowserEngine.firefox) {
           const int kDefaultImageSizeFallback = 300;
           naturalWidth = kDefaultImageSizeFallback;
           naturalHeight = kDefaultImageSizeFallback;

--- a/lib/web_ui/lib/src/engine/semantics/text_field.dart
+++ b/lib/web_ui/lib/src/engine/semantics/text_field.dart
@@ -252,11 +252,7 @@ class TextField extends RoleManager {
 
     switch (browserEngine) {
       case BrowserEngine.blink:
-      case BrowserEngine.samsung:
-      case BrowserEngine.edge:
-      case BrowserEngine.ie11:
       case BrowserEngine.firefox:
-      case BrowserEngine.unknown:
         _initializeForBlink();
         break;
       case BrowserEngine.webkit:

--- a/lib/web_ui/lib/src/engine/text/font_collection.dart
+++ b/lib/web_ui/lib/src/engine/text/font_collection.dart
@@ -259,8 +259,7 @@ class _PolyfillFontManager extends FontManager {
     paragraph.style.position = 'absolute';
     paragraph.style.visibility = 'hidden';
     paragraph.style.fontSize = '72px';
-    final String fallbackFontName =
-        browserEngine == BrowserEngine.ie11 ? 'Times New Roman' : 'sans-serif';
+    const String fallbackFontName = 'sans-serif';
     paragraph.style.fontFamily = fallbackFontName;
     if (descriptors['style'] != null) {
       paragraph.style.fontStyle = descriptors['style']!;

--- a/lib/web_ui/lib/src/engine/text/font_collection.dart
+++ b/lib/web_ui/lib/src/engine/text/font_collection.dart
@@ -9,7 +9,6 @@ import 'dart:typed_data';
 import 'package:ui/src/engine/fonts.dart';
 
 import '../assets.dart';
-import '../browser_detection.dart';
 import '../dom.dart';
 import '../safe_browser_api.dart';
 import '../util.dart';

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -37,7 +37,6 @@ const int _kReturnKeyCode = 13;
 /// is autofilled.
 bool browserHasAutofillOverlay() =>
     browserEngine == BrowserEngine.blink ||
-    browserEngine == BrowserEngine.samsung ||
     browserEngine == BrowserEngine.webkit;
 
 /// `transparentTextEditing` class is configured to make the autofill overlay

--- a/lib/web_ui/test/browser_detect_test.dart
+++ b/lib/web_ui/test/browser_detect_test.dart
@@ -37,15 +37,6 @@ void testMain() {
               '(khtml, like gecko) version/14.0.3 safari/605.1.15');
       expect(browserEngine, BrowserEngine.webkit);
     });
-
-    test('Should detect Samsung browser', () {
-      // Samsung 13.2.1.70 on Galaxy Tab S6.
-      final BrowserEngine browserEngine = detectBrowserEngineByVendorAgent(
-          'Google Inc.',
-          'mozilla/5.0 (x11; linux x86_64) applewebkit/537.36 (khtml, like gecko)'
-              ' samsungbrowser/13.2 chrome/83.0.4103.106 safari/537.36');
-      expect(browserEngine, BrowserEngine.samsung);
-    });
   });
 
   group('detectOperatingSystem', () {

--- a/lib/web_ui/test/embedder_test.dart
+++ b/lib/web_ui/test/embedder_test.dart
@@ -40,9 +40,7 @@ void testMain() {
     embedder.reset();
   },
       // TODO(ferhat): https://github.com/flutter/flutter/issues/46638
-      // TODO(ferhat): https://github.com/flutter/flutter/issues/50828
-      skip: browserEngine == BrowserEngine.firefox ||
-          browserEngine == BrowserEngine.edge);
+      skip: browserEngine == BrowserEngine.firefox);
 
   test('accesibility placeholder is attached after creation', () {
     final FlutterViewEmbedder embedder = FlutterViewEmbedder();

--- a/lib/web_ui/test/engine/history_test.dart
+++ b/lib/web_ui/test/engine/history_test.dart
@@ -117,9 +117,7 @@ void testMain() {
 
       // The flutter entry is the current entry.
       expect(strategy.currentEntry, flutterEntry);
-    },
-        // TODO(mdebbar): https://github.com/flutter/flutter/issues/50836
-        skip: browserEngine == BrowserEngine.edge);
+    });
 
     test('disposes of its listener without touching history', () async {
       const String unwrappedOriginState = 'initial state';
@@ -216,9 +214,7 @@ void testMain() {
       // The url of the current entry (flutter entry) should go back to /home.
       expect(strategy.currentEntry.state, flutterState);
       expect(strategy.currentEntry.url, '/home');
-    },
-        // TODO(mdebbar): https://github.com/flutter/flutter/issues/50836
-        skip: browserEngine == BrowserEngine.edge);
+    });
 
     test('multiple browser back clicks', () async {
       final TestUrlStrategy strategy = TestUrlStrategy.fromEntry(
@@ -284,10 +280,7 @@ void testMain() {
       // 3. The active entry doesn't belong to our history anymore because we
       // navigated past it.
       expect(originalStrategy.currentEntryIndex, -1);
-    },
-        // TODO(mdebbar): https://github.com/flutter/flutter/issues/50836
-        skip: browserEngine == BrowserEngine.edge ||
-            browserEngine == BrowserEngine.webkit);
+    }, skip: browserEngine == BrowserEngine.webkit);
 
     test('handle user-provided url', () async {
       final TestUrlStrategy strategy = TestUrlStrategy.fromEntry(
@@ -328,9 +321,7 @@ void testMain() {
       expect(strategy.currentEntryIndex, 1);
       expect(strategy.currentEntry.state, flutterState);
       expect(strategy.currentEntry.url, '/home');
-    },
-        // TODO(mdebbar): https://github.com/flutter/flutter/issues/50836
-        skip: browserEngine == BrowserEngine.edge);
+    });
 
     test('user types unknown url', () async {
       final TestUrlStrategy strategy = TestUrlStrategy.fromEntry(
@@ -354,9 +345,7 @@ void testMain() {
       expect(strategy.currentEntryIndex, 1);
       expect(strategy.currentEntry.state, flutterState);
       expect(strategy.currentEntry.url, '/home');
-    },
-        // TODO(mdebbar): https://github.com/flutter/flutter/issues/50836
-        skip: browserEngine == BrowserEngine.edge);
+    });
   });
 
   group('$MultiEntriesBrowserHistory', () {
@@ -384,9 +373,7 @@ void testMain() {
       final TestHistoryEntry taggedOriginEntry = strategy.history[0];
       expect(taggedOriginEntry.state, _tagStateWithSerialCount('initial state', 0));
       expect(taggedOriginEntry.url, '/initial');
-    },
-        // TODO(mdebbar): https://github.com/flutter/flutter/issues/50836
-        skip: browserEngine == BrowserEngine.edge);
+    });
 
     test('disposes of its listener without touching history', () async {
       const String untaggedState = 'initial state';
@@ -481,9 +468,7 @@ void testMain() {
       expect(strategy.currentEntryIndex, 0);
       expect(strategy.currentEntry.state, _tagStateWithSerialCount('initial state', 0));
       expect(strategy.currentEntry.url, '/home');
-    },
-        // TODO(mdebbar): https://github.com/flutter/flutter/issues/50836
-        skip: browserEngine == BrowserEngine.edge);
+    });
 
     test('multiple browser back clicks', () async {
       final TestUrlStrategy strategy = TestUrlStrategy.fromEntry(
@@ -532,10 +517,7 @@ void testMain() {
       expect(strategy.currentEntryIndex, 0);
       expect(strategy.currentEntry.state, _tagStateWithSerialCount('initial state', 0));
       expect(strategy.currentEntry.url, '/home');
-    },
-        // TODO(mdebbar): https://github.com/flutter/flutter/issues/50836
-        skip: browserEngine == BrowserEngine.edge ||
-            browserEngine == BrowserEngine.webkit);
+    }, skip: browserEngine == BrowserEngine.webkit);
 
     test('handle user-provided url', () async {
       final TestUrlStrategy strategy = TestUrlStrategy.fromEntry(
@@ -578,9 +560,7 @@ void testMain() {
       expect(strategy.currentEntryIndex, 0);
       expect(strategy.currentEntry.state, _tagStateWithSerialCount('initial state', 0));
       expect(strategy.currentEntry.url, '/home');
-    },
-        // TODO(mdebbar): https://github.com/flutter/flutter/issues/50836
-        skip: browserEngine == BrowserEngine.edge);
+    });
 
     test('forward button works', () async {
       final TestUrlStrategy strategy = TestUrlStrategy.fromEntry(
@@ -630,9 +610,7 @@ void testMain() {
       expect(strategy.currentEntryIndex, 2);
       expect(strategy.currentEntry.state, _tagStateWithSerialCount('page2 state', 2));
       expect(strategy.currentEntry.url, '/page2');
-    },
-        // TODO(mdebbar): https://github.com/flutter/flutter/issues/50836
-        skip: browserEngine == BrowserEngine.edge);
+    });
   });
 
   group('$HashUrlStrategy', () {

--- a/lib/web_ui/test/engine/image/html_image_codec_test.dart
+++ b/lib/web_ui/test/engine/image/html_image_codec_test.dart
@@ -81,7 +81,7 @@ Future<void> testMain() async {
       expect(buffer.toString(), '0/100,100/100,');
     });
 
-    /// Regression test for Firefox/ie11
+    /// Regression test for Firefox
     /// https://github.com/flutter/flutter/issues/66412
     test('Returns nonzero natural width/height', () async {
       final HtmlCodec codec = HtmlCodec(

--- a/lib/web_ui/test/engine/semantics/semantics_tester.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_tester.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:test/test.dart';
-import 'package:ui/src/engine/browser_detection.dart';
 import 'package:ui/src/engine/dom.dart';
 import 'package:ui/src/engine/embedder.dart';
 import 'package:ui/src/engine/host_node.dart';
@@ -28,9 +27,7 @@ HostNode get appHostNode => flutterViewEmbedder.glassPaneShadow!;
 /// CSS style applied to the root of the semantics tree.
 // TODO(yjbanov): this should be handled internally by [expectSemanticsTree].
 //                No need for every test to inject it.
-final String rootSemanticStyle = browserEngine != BrowserEngine.edge
-  ? 'filter: opacity(0%); color: rgba(0, 0, 0, 0)'
-  : 'color: rgba(0, 0, 0, 0); filter: opacity(0%)';
+const String rootSemanticStyle = 'filter: opacity(0%); color: rgba(0, 0, 0, 0)';
 
 /// A convenience wrapper of the semantics API for building and inspecting the
 /// semantics tree in unit tests.

--- a/lib/web_ui/test/engine/semantics/text_field_test.dart
+++ b/lib/web_ui/test/engine/semantics/text_field_test.dart
@@ -400,9 +400,7 @@ void testMain() {
 
       semantics().semanticsEnabled = false;
     });
-  },
-  // TODO(mdebbar): https://github.com/flutter/flutter/issues/50769
-  skip: browserEngine == BrowserEngine.edge);
+  });
 }
 
 SemanticsObject createTextFieldSemantics({

--- a/lib/web_ui/test/keyboard_test.dart
+++ b/lib/web_ui/test/keyboard_test.dart
@@ -8,7 +8,6 @@ import 'dart:typed_data';
 import 'package:quiver/testing/async.dart';
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
-import 'package:ui/src/engine/browser_detection.dart';
 import 'package:ui/src/engine/dom.dart';
 import 'package:ui/src/engine/keyboard.dart';
 import 'package:ui/src/engine/services.dart';

--- a/lib/web_ui/test/keyboard_test.dart
+++ b/lib/web_ui/test/keyboard_test.dart
@@ -68,9 +68,7 @@ void testMain() {
       });
 
       Keyboard.instance!.dispose();
-    },
-        // TODO(mdebbar): https://github.com/flutter/flutter/issues/50815
-        skip: browserEngine == BrowserEngine.edge);
+    });
 
     test('dispatches keydown to flutter/keyevent channel', () {
       Keyboard.initialize();
@@ -101,9 +99,7 @@ void testMain() {
       expect(event.defaultPrevented, isFalse);
 
       Keyboard.instance!.dispose();
-    },
-        // TODO(mdebbar): https://github.com/flutter/flutter/issues/50815
-        skip: browserEngine == BrowserEngine.edge);
+    });
 
     test('dispatches correct meta state', () {
       Keyboard.initialize();
@@ -155,9 +151,7 @@ void testMain() {
       });
 
       Keyboard.instance!.dispose();
-    },
-        // TODO(mdebbar): https://github.com/flutter/flutter/issues/50815
-        skip: browserEngine == BrowserEngine.edge);
+    });
 
     test('dispatches repeat events', () {
       Keyboard.initialize();
@@ -210,9 +204,7 @@ void testMain() {
       ]);
 
       Keyboard.instance!.dispose();
-    },
-        // TODO(mdebbar): https://github.com/flutter/flutter/issues/50815
-        skip: browserEngine == BrowserEngine.edge);
+    });
 
     test('stops dispatching events after dispose', () {
       Keyboard.initialize();

--- a/lib/web_ui/test/text/canvas_paragraph_builder_test.dart
+++ b/lib/web_ui/test/text/canvas_paragraph_builder_test.dart
@@ -22,7 +22,6 @@ String fontFamilyToAttribute(String fontFamily) {
   if (browserEngine == BrowserEngine.firefox) {
     return fontFamily.replaceAll('"', '&quot;');
   } else if (browserEngine == BrowserEngine.blink ||
-      browserEngine == BrowserEngine.samsung ||
       browserEngine == BrowserEngine.webkit) {
     return fontFamily.replaceAll('"', '');
   }

--- a/lib/web_ui/test/text/font_collection_test.dart
+++ b/lib/web_ui/test/text/font_collection_test.dart
@@ -39,9 +39,7 @@ void testMain() {
 
         expect(fontFamilyList.length, equals(1));
         expect(fontFamilyList.first, 'Ahem');
-      },
-          // TODO(mdebbar): https://github.com/flutter/flutter/issues/50770
-          skip: browserEngine == BrowserEngine.edge);
+      });
 
       test('Register Asset with white space in the family name', () async {
         const String testFontFamily = 'Ahem ahem ahem';
@@ -58,10 +56,8 @@ void testMain() {
         expect(fontFamilyList.length, equals(1));
         expect(fontFamilyList.first, 'Ahem ahem ahem');
       },
-          // TODO(mdebbar): https://github.com/flutter/flutter/issues/50770
           // TODO(mdebbar): https://github.com/flutter/flutter/issues/51142
-          skip: browserEngine == BrowserEngine.edge ||
-              browserEngine == BrowserEngine.webkit);
+          skip: browserEngine == BrowserEngine.webkit);
 
       test('Register Asset with capital case letters', () async {
         const String testFontFamily = 'AhEm';
@@ -77,9 +73,7 @@ void testMain() {
 
         expect(fontFamilyList.length, equals(1));
         expect(fontFamilyList.first, 'AhEm');
-      },
-          // TODO(mdebbar): https://github.com/flutter/flutter/issues/50770
-          skip: browserEngine == BrowserEngine.edge);
+      });
     });
 
     group('fonts with special characters', () {
@@ -104,10 +98,8 @@ void testMain() {
           expect(fontFamilyList.first, '"/Ahem"');
         }
       },
-          // TODO(mdebbar): https://github.com/flutter/flutter/issues/50770
           // TODO(mdebbar): https://github.com/flutter/flutter/issues/51142
-          skip: browserEngine == BrowserEngine.edge ||
-              browserEngine == BrowserEngine.webkit);
+          skip: browserEngine == BrowserEngine.webkit);
 
       test('Register Asset twice with exclamation mark', () async {
         const String testFontFamily = 'Ahem!!ahem';
@@ -130,10 +122,8 @@ void testMain() {
           expect(fontFamilyList.first, '"Ahem!!ahem"');
         }
       },
-          // TODO(mdebbar): https://github.com/flutter/flutter/issues/50770
           // TODO(mdebbar): https://github.com/flutter/flutter/issues/51142
-          skip: browserEngine == BrowserEngine.edge ||
-              browserEngine == BrowserEngine.webkit);
+          skip: browserEngine == BrowserEngine.webkit);
 
       test('Register Asset twice with comma', () async {
         const String testFontFamily = 'Ahem ,ahem';
@@ -156,10 +146,8 @@ void testMain() {
           expect(fontFamilyList.first, '"Ahem ,ahem"');
         }
       },
-          // TODO(mdebbar): https://github.com/flutter/flutter/issues/50770
           // TODO(mdebbar): https://github.com/flutter/flutter/issues/51142
-          skip: browserEngine == BrowserEngine.edge ||
-              browserEngine == BrowserEngine.webkit);
+          skip: browserEngine == BrowserEngine.webkit);
 
       test('Register Asset twice with a digit at the start of a token',
           () async {
@@ -183,10 +171,8 @@ void testMain() {
           expect(fontFamilyList.first, '"Ahem 1998"');
         }
       },
-          // TODO(mdebbar): https://github.com/flutter/flutter/issues/50770
           // TODO(mdebbar): https://github.com/flutter/flutter/issues/51142
-          skip: browserEngine == BrowserEngine.edge ||
-              browserEngine == BrowserEngine.webkit);
+          skip: browserEngine == BrowserEngine.webkit);
     });
   });
 }

--- a/lib/web_ui/test/text/font_loading_test.dart
+++ b/lib/web_ui/test/text/font_loading_test.dart
@@ -30,9 +30,7 @@ Future<void> testMain() async {
           throwsA(const TypeMatcher<Exception>()));
     },
         // TODO(hterkelsen): https://github.com/flutter/flutter/issues/56702
-        // TODO(hterkelsen): https://github.com/flutter/flutter/issues/50770
-        skip: browserEngine == BrowserEngine.edge ||
-            browserEngine == BrowserEngine.webkit);
+        skip: browserEngine == BrowserEngine.webkit);
 
     test('loads Blehm font from buffer', () async {
       expect(_containsFontFamily('Blehm'), isFalse);
@@ -46,9 +44,7 @@ Future<void> testMain() async {
       expect(_containsFontFamily('Blehm'), isTrue);
     },
         // TODO(hterkelsen): https://github.com/flutter/flutter/issues/56702
-        // TODO(hterkelsen): https://github.com/flutter/flutter/issues/50770
-        skip: browserEngine == BrowserEngine.edge ||
-            browserEngine == BrowserEngine.webkit);
+        skip: browserEngine == BrowserEngine.webkit);
 
     test('loading font should clear measurement caches', () async {
       final EngineParagraphStyle style = EngineParagraphStyle();
@@ -74,9 +70,7 @@ Future<void> testMain() async {
       expect(Spanometer.rulers.length, 0);
     },
         // TODO(hterkelsen): https://github.com/flutter/flutter/issues/56702
-        // TODO(hterkelsen): https://github.com/flutter/flutter/issues/50770
-        skip: browserEngine == BrowserEngine.edge ||
-            browserEngine == BrowserEngine.webkit);
+        skip: browserEngine == BrowserEngine.webkit);
 
     test('loading font should send font change message', () async {
       final ui.PlatformMessageCallback? oldHandler = ui.window.onPlatformMessage;
@@ -103,9 +97,7 @@ Future<void> testMain() async {
       expect(message, '{"type":"fontsChange"}');
     },
         // TODO(hterkelsen): https://github.com/flutter/flutter/issues/56702
-        // TODO(hterkelsen): https://github.com/flutter/flutter/issues/50770
-        skip: browserEngine == BrowserEngine.edge ||
-            browserEngine == BrowserEngine.webkit);
+        skip: browserEngine == BrowserEngine.webkit);
   });
 }
 

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -342,9 +342,7 @@ Future<void> testMain() async {
         keyCode: _kReturnKeyCode,
       );
       expect(lastInputAction, 'TextInputAction.done');
-    },
-        // TODO(mdebbar): https://github.com/flutter/flutter/issues/50769
-        skip: browserEngine == BrowserEngine.edge);
+    });
 
     test('Triggers input action in multi-line mode', () {
       final InputConfiguration config = InputConfiguration(
@@ -666,9 +664,7 @@ Future<void> testMain() async {
       // DOM element still keeps the focus.
       expect(defaultTextEditingRoot.activeElement,
           textEditing!.strategy.domElement);
-    },
-        // TODO(mdebbar): https://github.com/flutter/flutter/issues/50769
-        skip: browserEngine == BrowserEngine.edge);
+    });
 
     test('focus and disconnection with delaying blur in iOS', () async {
       final MethodCall setClient = MethodCall(
@@ -767,9 +763,7 @@ Future<void> testMain() async {
       spy.messages.clear();
       // Input element is removed from DOM.
       expect(defaultTextEditingRoot.querySelectorAll('input'), hasLength(0));
-    },
-        // TODO(mdebbar): https://github.com/flutter/flutter/issues/50769
-        skip: browserEngine == BrowserEngine.edge);
+    });
 
     test('finishAutofillContext removes form from DOM', () async {
       // Create a configuration with an AutofillGroup of four text fields.
@@ -825,9 +819,7 @@ Future<void> testMain() async {
       // Form element is removed from DOM.
       expect(defaultTextEditingRoot.querySelectorAll('form'), isEmpty);
       expect(formsOnTheDom, hasLength(0));
-    },
-        // TODO(nurhan): https://github.com/flutter/flutter/issues/50769
-        skip: browserEngine == BrowserEngine.edge);
+    });
 
     test('finishAutofillContext with save submits forms', () async {
       // Create a configuration with an AutofillGroup of four text fields.
@@ -880,9 +872,7 @@ Future<void> testMain() async {
 
       // `submit` action is called on form.
       await expectLater(await submittedForm.future, isTrue);
-    },
-        // TODO(mdebbar): https://github.com/flutter/flutter/issues/50769
-        skip: browserEngine == BrowserEngine.edge);
+    });
 
     test('forms submits for focused input', () async {
       // Create a configuration with an AutofillGroup of four text fields.
@@ -941,9 +931,7 @@ Future<void> testMain() async {
       // Form element is removed from DOM.
       expect(defaultTextEditingRoot.querySelectorAll('form'), hasLength(0));
       expect(formsOnTheDom, hasLength(0));
-    },
-        // TODO(mdebbar): https://github.com/flutter/flutter/issues/50769
-        skip: browserEngine == BrowserEngine.edge);
+    });
 
     test('setClient, setEditingState, show, setClient', () {
       final MethodCall setClient = MethodCall(
@@ -1388,7 +1376,6 @@ Future<void> testMain() async {
 
       // For `blink` and `webkit` browser engines the overlay would be hidden.
       if (browserEngine == BrowserEngine.blink ||
-          browserEngine == BrowserEngine.samsung ||
           browserEngine == BrowserEngine.webkit) {
         expect(textEditing!.strategy.domElement!.classList.contains('transparentTextEditing'),
             isTrue);
@@ -1914,9 +1901,7 @@ Future<void> testMain() async {
         spy.messages[0].methodArguments,
         <dynamic>[clientId, 'TextInputAction.next'],
       );
-    },
-        // TODO(mdebbar): https://github.com/flutter/flutter/issues/50769
-        skip: browserEngine == BrowserEngine.edge);
+    });
 
     test('sends input action in multi-line mode', () {
       showKeyboard(
@@ -1997,7 +1982,6 @@ Future<void> testMain() async {
 
       // For `blink` and `webkit` browser engines the overlay would be hidden.
       if (browserEngine == BrowserEngine.blink ||
-          browserEngine == BrowserEngine.samsung ||
           browserEngine == BrowserEngine.webkit) {
         expect(firstElement.classList.contains('transparentTextEditing'), isTrue);
       } else {

--- a/lib/web_ui/test/text_test.dart
+++ b/lib/web_ui/test/text_test.dart
@@ -231,10 +231,8 @@ Future<void> testMain() async {
     // The nested span here should not set it's family to default sans-serif.
     expect(spans[1].style.fontFamily, 'Ahem, $fallback, sans-serif');
   },
-      // TODO(mdebbar): https://github.com/flutter/flutter/issues/50771
       // TODO(mdebbar): https://github.com/flutter/flutter/issues/46638
-      skip: browserEngine == BrowserEngine.firefox ||
-          browserEngine == BrowserEngine.edge);
+      skip: browserEngine == BrowserEngine.firefox);
 
   test('adds Arial and sans-serif as fallback fonts', () {
     // Set this to false so it doesn't default to 'Ahem' font.
@@ -251,10 +249,8 @@ Future<void> testMain() async {
 
     debugEmulateFlutterTesterEnvironment = true;
   },
-      // TODO(mdebbar): https://github.com/flutter/flutter/issues/50771
       // TODO(mdebbar): https://github.com/flutter/flutter/issues/46638
-      skip: browserEngine == BrowserEngine.firefox ||
-          browserEngine == BrowserEngine.edge);
+      skip: browserEngine == BrowserEngine.firefox);
 
   test('does not add fallback fonts to generic families', () {
     // Set this to false so it doesn't default to 'Ahem' font.
@@ -285,9 +281,7 @@ Future<void> testMain() async {
         '"MyFont 2000", $fallback, sans-serif');
 
     debugEmulateFlutterTesterEnvironment = true;
-  },
-      // TODO(mdebbar): https://github.com/flutter/flutter/issues/50771
-      skip: browserEngine == BrowserEngine.edge);
+  });
 
   group('TextRange', () {
     test('empty ranges are correct', () {

--- a/lib/web_ui/test/window_test.dart
+++ b/lib/web_ui/test/window_test.dart
@@ -378,7 +378,7 @@ void testMain() {
     // should've been correctly set to "/bar".
     expect(window.browserHistory.urlStrategy, isNot(isNull));
     expect(window.browserHistory.urlStrategy!.getPath(), '/bar');
-  }, skip: true); // https://github.com/flutter/flutter/issues/50836
+  });
 
   test('initialize browser history with default url strategy (multiple)', () async {
     // On purpose, we don't initialize history on the window. We want to let the
@@ -406,7 +406,7 @@ void testMain() {
     // should've been correctly set to "/baz".
     expect(window.browserHistory.urlStrategy, isNot(isNull));
     expect(window.browserHistory.urlStrategy!.getPath(), '/baz');
-  }, skip: true); // https://github.com/flutter/flutter/issues/50836
+  });
 
   test('can disable location strategy', () async {
     // Disable URL strategy.

--- a/lib/web_ui/test/window_test.dart
+++ b/lib/web_ui/test/window_test.dart
@@ -378,7 +378,7 @@ void testMain() {
     // should've been correctly set to "/bar".
     expect(window.browserHistory.urlStrategy, isNot(isNull));
     expect(window.browserHistory.urlStrategy!.getPath(), '/bar');
-  });
+  }, skip: true); // https://github.com/flutter/flutter/issues/50836
 
   test('initialize browser history with default url strategy (multiple)', () async {
     // On purpose, we don't initialize history on the window. We want to let the
@@ -406,7 +406,7 @@ void testMain() {
     // should've been correctly set to "/baz".
     expect(window.browserHistory.urlStrategy, isNot(isNull));
     expect(window.browserHistory.urlStrategy!.getPath(), '/baz');
-  });
+  }, skip: true); // https://github.com/flutter/flutter/issues/50836
 
   test('can disable location strategy', () async {
     // Disable URL strategy.


### PR DESCRIPTION
Remove references to IE11 and old Edge (this change is not breaking as Flutter Web never really worked on these); treat Samsung browser as Blink.

Fixes https://github.com/flutter/flutter/issues/108999.
Potentially also fixes the issue https://github.com/flutter/flutter/issues/107786, but if our regex was busted then perhaps we never detected Samsung browser and so never tried applying the non-mobile version of the text field.