### PR TITLE
Disable clang-tidy pre-push hook by default

### DIFF
--- a/tools/githooks/lib/githooks.dart
+++ b/tools/githooks/lib/githooks.dart
@@ -19,6 +19,10 @@ Future<int> run(List<String> args) async {
 
   // Add top-level arguments.
   runner.argParser
+    ..addFlag(
+      'enable-clang-tidy',
+      help: 'Enable running clang-tidy on changed files.',
+    )
     ..addOption(
       'flutter',
       abbr: 'f',

--- a/tools/githooks/lib/src/pre_push_command.dart
+++ b/tools/githooks/lib/src/pre_push_command.dart
@@ -20,10 +20,18 @@ class PrePushCommand extends Command<bool> {
   Future<bool> run() async {
     final Stopwatch sw = Stopwatch()..start();
     final bool verbose = globalResults!['verbose']! as bool;
+    final bool enableClangTidy = globalResults!['enable-clang-tidy']! as bool;
     final String flutterRoot = globalResults!['flutter']! as String;
+
+    if (!enableClangTidy) {
+      print('The clang-tidy check is disabled. To enable set the environment '
+            'variable PRE_PUSH_CLANG_TIDY to any value.');
+    }
+
     final List<bool> checkResults = <bool>[
       await _runFormatter(flutterRoot, verbose),
-      await _runClangTidy(flutterRoot, verbose),
+      if (enableClangTidy)
+        await _runClangTidy(flutterRoot, verbose),
     ];
     sw.stop();
     io.stdout.writeln('pre-push checks finished in ${sw.elapsed}');
@@ -51,7 +59,8 @@ class PrePushCommand extends Command<bool> {
         'compile_commands.json',
       ));
       if (!compileCommands.existsSync()) {
-        io.stderr.writeln('clang-tidy requires a fully built host_debug or host_debug_unopt build directory');
+        io.stderr.writeln('clang-tidy requires a fully built host_debug or '
+                          'host_debug_unopt build directory');
         return false;
       }
     }

--- a/tools/githooks/pre-push
+++ b/tools/githooks/pre-push
@@ -15,15 +15,24 @@ import sys
 SRC_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 FLUTTER_DIR = os.path.join(SRC_ROOT, 'flutter')
 DART_BIN = os.path.join(SRC_ROOT, 'third_party', 'dart', 'tools', 'sdks', 'dart-sdk', 'bin')
-
+ENABLE_CLANG_TIDY = os.environ.get('PRE_PUSH_CLANG_TIDY')
 
 def Main(argv):
+  githook_args = [
+    '--flutter',
+    FLUTTER_DIR,
+  ]
+
+  if ENABLE_CLANG_TIDY is not None:
+    githook_args += [
+      '--enable-clang-tidy',
+    ]
+
   result = subprocess.run([
     os.path.join(DART_BIN, 'dart'),
     '--disable-dart-dev',
     os.path.join(FLUTTER_DIR, 'tools', 'githooks', 'bin', 'main.dart'),
-    '--flutter',
-    FLUTTER_DIR,
+  ] + githook_args + [
     'pre-push',
   ], cwd=SRC_ROOT)
   return result.returncode


### PR DESCRIPTION
`clang-tidy` has been taking so long to run during the pre-push hook that folks are just disabling it with the `--no-verify` flag to `git push` out of annoyance. This has the downside of also disabling the formatting checks that are in the pre-push hook. This change makes the clang-tidy check optional behind an environment variable.

The clang-tidy checks will still run in presubmit after a change is pushed to a branch/PR.