### PR TITLE
Change the time unit of 'DisplayListBuilderBenchmarks' to 'kMicrosecond'

### DIFF
--- a/display_list/display_list_builder_benchmarks.cc
+++ b/display_list/display_list_builder_benchmarks.cc
@@ -133,103 +133,103 @@ static void BM_DisplayListBuilderWithSaveLayerAndImageFilter(
 BENCHMARK_CAPTURE(BM_DisplayListBuilderDefault,
                   kDefault,
                   DisplayListBuilderBenchmarkType::kDefault)
-    ->Unit(benchmark::kMillisecond);
+    ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_DisplayListBuilderDefault,
                   kBounds,
                   DisplayListBuilderBenchmarkType::kBounds)
-    ->Unit(benchmark::kMillisecond);
+    ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_DisplayListBuilderDefault,
                   kRtree,
                   DisplayListBuilderBenchmarkType::kRtree)
-    ->Unit(benchmark::kMillisecond);
+    ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_DisplayListBuilderDefault,
                   kBoundsAndRtree,
                   DisplayListBuilderBenchmarkType::kBoundsAndRtree)
-    ->Unit(benchmark::kMillisecond);
+    ->Unit(benchmark::kMicrosecond);
 
 BENCHMARK_CAPTURE(BM_DisplayListBuilderWithScaleAndTranslate,
                   kDefault,
                   DisplayListBuilderBenchmarkType::kDefault)
-    ->Unit(benchmark::kMillisecond);
+    ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_DisplayListBuilderWithScaleAndTranslate,
                   kBounds,
                   DisplayListBuilderBenchmarkType::kBounds)
-    ->Unit(benchmark::kMillisecond);
+    ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_DisplayListBuilderWithScaleAndTranslate,
                   kRtree,
                   DisplayListBuilderBenchmarkType::kRtree)
-    ->Unit(benchmark::kMillisecond);
+    ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_DisplayListBuilderWithScaleAndTranslate,
                   kBoundsAndRtree,
                   DisplayListBuilderBenchmarkType::kBoundsAndRtree)
-    ->Unit(benchmark::kMillisecond);
+    ->Unit(benchmark::kMicrosecond);
 
 BENCHMARK_CAPTURE(BM_DisplayListBuilderWithPerspective,
                   kDefault,
                   DisplayListBuilderBenchmarkType::kDefault)
-    ->Unit(benchmark::kMillisecond);
+    ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_DisplayListBuilderWithPerspective,
                   kBounds,
                   DisplayListBuilderBenchmarkType::kBounds)
-    ->Unit(benchmark::kMillisecond);
+    ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_DisplayListBuilderWithPerspective,
                   kRtree,
                   DisplayListBuilderBenchmarkType::kRtree)
-    ->Unit(benchmark::kMillisecond);
+    ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_DisplayListBuilderWithPerspective,
                   kBoundsAndRtree,
                   DisplayListBuilderBenchmarkType::kBoundsAndRtree)
-    ->Unit(benchmark::kMillisecond);
+    ->Unit(benchmark::kMicrosecond);
 
 BENCHMARK_CAPTURE(BM_DisplayListBuilderWithClipRect,
                   kDefault,
                   DisplayListBuilderBenchmarkType::kDefault)
-    ->Unit(benchmark::kMillisecond);
+    ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_DisplayListBuilderWithClipRect,
                   kBounds,
                   DisplayListBuilderBenchmarkType::kBounds)
-    ->Unit(benchmark::kMillisecond);
+    ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_DisplayListBuilderWithClipRect,
                   kRtree,
                   DisplayListBuilderBenchmarkType::kRtree)
-    ->Unit(benchmark::kMillisecond);
+    ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_DisplayListBuilderWithClipRect,
                   kBoundsAndRtree,
                   DisplayListBuilderBenchmarkType::kBoundsAndRtree)
-    ->Unit(benchmark::kMillisecond);
+    ->Unit(benchmark::kMicrosecond);
 
 BENCHMARK_CAPTURE(BM_DisplayListBuilderWithSaveLayer,
                   kDefault,
                   DisplayListBuilderBenchmarkType::kDefault)
-    ->Unit(benchmark::kMillisecond);
+    ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_DisplayListBuilderWithSaveLayer,
                   kBounds,
                   DisplayListBuilderBenchmarkType::kBounds)
-    ->Unit(benchmark::kMillisecond);
+    ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_DisplayListBuilderWithSaveLayer,
                   kRtree,
                   DisplayListBuilderBenchmarkType::kRtree)
-    ->Unit(benchmark::kMillisecond);
+    ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_DisplayListBuilderWithSaveLayer,
                   kBoundsAndRtree,
                   DisplayListBuilderBenchmarkType::kBoundsAndRtree)
-    ->Unit(benchmark::kMillisecond);
+    ->Unit(benchmark::kMicrosecond);
 
 BENCHMARK_CAPTURE(BM_DisplayListBuilderWithSaveLayerAndImageFilter,
                   kDefault,
                   DisplayListBuilderBenchmarkType::kDefault)
-    ->Unit(benchmark::kMillisecond);
+    ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_DisplayListBuilderWithSaveLayerAndImageFilter,
                   kBounds,
                   DisplayListBuilderBenchmarkType::kBounds)
-    ->Unit(benchmark::kMillisecond);
+    ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_DisplayListBuilderWithSaveLayerAndImageFilter,
                   kRtree,
                   DisplayListBuilderBenchmarkType::kRtree)
-    ->Unit(benchmark::kMillisecond);
+    ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_DisplayListBuilderWithSaveLayerAndImageFilter,
                   kBoundsAndRtree,
                   DisplayListBuilderBenchmarkType::kBoundsAndRtree)
-    ->Unit(benchmark::kMillisecond);
+    ->Unit(benchmark::kMicrosecond);
 
 }  // namespace flutter


### PR DESCRIPTION
When I ran `testing/run_tests.py --type=benchmarks --variant=host_release`, I found that the time unit here should use microseconds.

## Before Change
<pre>
Run on (10 X 2400 MHz CPU s)
CPU Caches:
  L1 Data 64 KiB (x10)
  L1 Instruction 128 KiB (x10)
  L2 Unified 4096 KiB (x5)
Load Average: 7.32, 8.71, 8.24
-----------------------------------------------------------------------------------------------------------
Benchmark                                                                 Time             CPU   Iterations
-----------------------------------------------------------------------------------------------------------
BM_DisplayListBuilderDefault/kDefault                                 0.003 ms        0.003 ms       226823
BM_DisplayListBuilderDefault/kBounds                                  0.006 ms        0.006 ms       117925
BM_DisplayListBuilderDefault/kRtree                                   0.014 ms        0.014 ms        49793
BM_DisplayListBuilderDefault/kBoundsAndRtree                          0.017 ms        0.017 ms        41255
BM_DisplayListBuilderWithScaleAndTranslate/kDefault                   0.003 ms        0.003 ms       222748
BM_DisplayListBuilderWithScaleAndTranslate/kBounds                    0.006 ms        0.006 ms       115704
BM_DisplayListBuilderWithScaleAndTranslate/kRtree                     0.014 ms        0.014 ms        48913
BM_DisplayListBuilderWithScaleAndTranslate/kBoundsAndRtree            0.017 ms        0.017 ms        40779
BM_DisplayListBuilderWithPerspective/kDefault                         0.003 ms        0.003 ms       221655
BM_DisplayListBuilderWithPerspective/kBounds                          0.071 ms        0.071 ms         9766
BM_DisplayListBuilderWithPerspective/kRtree                           0.079 ms        0.079 ms         8741
BM_DisplayListBuilderWithPerspective/kBoundsAndRtree                  0.147 ms        0.147 ms         4698
BM_DisplayListBuilderWithClipRect/kDefault                            0.003 ms        0.003 ms       230961
BM_DisplayListBuilderWithClipRect/kBounds                             0.006 ms        0.006 ms       117332
BM_DisplayListBuilderWithClipRect/kRtree                              0.014 ms        0.014 ms        49652
BM_DisplayListBuilderWithClipRect/kBoundsAndRtree                     0.017 ms        0.017 ms        41497
BM_DisplayListBuilderWithSaveLayer/kDefault                           0.004 ms        0.004 ms       162753
BM_DisplayListBuilderWithSaveLayer/kBounds                            0.014 ms        0.014 ms        48509
BM_DisplayListBuilderWithSaveLayer/kRtree                             0.022 ms        0.022 ms        31366
BM_DisplayListBuilderWithSaveLayer/kBoundsAndRtree                    0.033 ms        0.033 ms        21445
BM_DisplayListBuilderWithSaveLayerAndImageFilter/kDefault             0.007 ms        0.007 ms       105895
BM_DisplayListBuilderWithSaveLayerAndImageFilter/kBounds              0.027 ms        0.027 ms        26274
BM_DisplayListBuilderWithSaveLayerAndImageFilter/kRtree               0.035 ms        0.035 ms        20320
BM_DisplayListBuilderWithSaveLayerAndImageFilter/kBoundsAndRtree      0.055 ms        0.055 ms        12631
</pre>

## After Change
<pre>
Run on (10 X 2400 MHz CPU s)
CPU Caches:
  L1 Data 64 KiB (x10)
  L1 Instruction 128 KiB (x10)
  L2 Unified 4096 KiB (x5)
Load Average: 2.90, 2.81, 4.73
-----------------------------------------------------------------------------------------------------------
Benchmark                                                                 Time             CPU   Iterations
-----------------------------------------------------------------------------------------------------------
BM_DisplayListBuilderDefault/kDefault                                  2.98 us         2.98 us       234046
BM_DisplayListBuilderDefault/kBounds                                   6.01 us         6.01 us       117202
BM_DisplayListBuilderDefault/kRtree                                    14.2 us         14.2 us        49206
BM_DisplayListBuilderDefault/kBoundsAndRtree                           17.0 us         17.0 us        41048
BM_DisplayListBuilderWithScaleAndTranslate/kDefault                    3.12 us         3.12 us       225619
BM_DisplayListBuilderWithScaleAndTranslate/kBounds                     6.16 us         6.16 us       112874
BM_DisplayListBuilderWithScaleAndTranslate/kRtree                      14.3 us         14.3 us        48725
BM_DisplayListBuilderWithScaleAndTranslate/kBoundsAndRtree             17.3 us         17.3 us        40446
BM_DisplayListBuilderWithPerspective/kDefault                          3.05 us         3.05 us       229715
BM_DisplayListBuilderWithPerspective/kBounds                           71.4 us         71.4 us         9727
BM_DisplayListBuilderWithPerspective/kRtree                            79.8 us         79.8 us         8660
BM_DisplayListBuilderWithPerspective/kBoundsAndRtree                    149 us          149 us         4670
BM_DisplayListBuilderWithClipRect/kDefault                             3.07 us         3.07 us       224331
BM_DisplayListBuilderWithClipRect/kBounds                              6.00 us         6.00 us       116364
BM_DisplayListBuilderWithClipRect/kRtree                               14.1 us         14.1 us        49528
BM_DisplayListBuilderWithClipRect/kBoundsAndRtree                      16.9 us         16.9 us        41146
BM_DisplayListBuilderWithSaveLayer/kDefault                            4.27 us         4.27 us       164400
BM_DisplayListBuilderWithSaveLayer/kBounds                             14.8 us         14.8 us        46948
BM_DisplayListBuilderWithSaveLayer/kRtree                              22.8 us         22.8 us        30887
BM_DisplayListBuilderWithSaveLayer/kBoundsAndRtree                     33.4 us         33.4 us        20971
BM_DisplayListBuilderWithSaveLayerAndImageFilter/kDefault              6.60 us         6.60 us       105184
BM_DisplayListBuilderWithSaveLayerAndImageFilter/kBounds               26.7 us         26.7 us        26133
BM_DisplayListBuilderWithSaveLayerAndImageFilter/kRtree                34.7 us         34.7 us        20112
BM_DisplayListBuilderWithSaveLayerAndImageFilter/kBoundsAndRtree       54.9 us         54.9 us        12636
</pre>


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
