### PR TITLE
[WIP] Optimize the SaveLayer operation

### DIFF
--- a/display_list/display_list.cc
+++ b/display_list/display_list.cc
@@ -8,6 +8,7 @@
 #include "flutter/display_list/display_list_canvas_dispatcher.h"
 #include "flutter/display_list/display_list_ops.h"
 #include "flutter/display_list/display_list_utils.h"
+#include "flutter/display_list/display_list_paint.h"
 #include "flutter/fml/trace_event.h"
 
 namespace flutter {
@@ -194,6 +195,11 @@ void DisplayList::RenderTo(DisplayListBuilder* builder,
     return;
   }
   Dispatch(*builder);
+}
+
+bool DisplayList::is_compatible(const DlPaint *paint) const {
+  // TODO(JsouLiang)
+  return true;
 }
 
 void DisplayList::RenderTo(SkCanvas* canvas, SkScalar opacity) const {

--- a/display_list/display_list.cc
+++ b/display_list/display_list.cc
@@ -7,8 +7,8 @@
 #include "flutter/display_list/display_list.h"
 #include "flutter/display_list/display_list_canvas_dispatcher.h"
 #include "flutter/display_list/display_list_ops.h"
-#include "flutter/display_list/display_list_utils.h"
 #include "flutter/display_list/display_list_paint.h"
+#include "flutter/display_list/display_list_utils.h"
 #include "flutter/fml/trace_event.h"
 
 namespace flutter {
@@ -197,7 +197,7 @@ void DisplayList::RenderTo(DisplayListBuilder* builder,
   Dispatch(*builder);
 }
 
-bool DisplayList::is_compatible(const DlPaint *paint) const {
+bool DisplayList::is_compatible(const DlPaint* paint) const {
   // TODO(JsouLiang)
   return true;
 }

--- a/display_list/display_list.cc
+++ b/display_list/display_list.cc
@@ -198,7 +198,15 @@ void DisplayList::RenderTo(DisplayListBuilder* builder,
 }
 
 bool DisplayList::is_compatible(const DlPaint* paint) const {
-  // TODO(JsouLiang)
+  // if we set the opacity then we check can we compatible the alpha
+  if (paint->attribute_is_setted(DlPaintAttribute::kAlpha)) {
+    return can_apply_group_opacity_;
+  }
+  // if we set the colorFilter then we check can we compatible the color_filter
+  if (paint->attribute_is_setted(DlPaintAttribute::kColorFilter)) {
+    // return can_apply_color_filter_;
+  }
+  // check image_filter
   return true;
 }
 

--- a/display_list/display_list.h
+++ b/display_list/display_list.h
@@ -163,6 +163,7 @@ enum class DisplayListOpType { FOR_EACH_DISPLAY_LIST_OP(DL_OP_TO_ENUM_VALUE) };
 
 class Dispatcher;
 class DisplayListBuilder;
+class DlPaint;
 
 class SaveLayerOptions {
  public:
@@ -272,6 +273,8 @@ class DisplayList : public SkRefCnt {
   bool can_apply_group_opacity() { return can_apply_group_opacity_; }
 
   static void DisposeOps(uint8_t* ptr, uint8_t* end);
+
+  bool is_compatible(const DlPaint* paint) const;
 
  private:
   DisplayList(uint8_t* ptr,

--- a/display_list/display_list_builder.cc
+++ b/display_list/display_list_builder.cc
@@ -459,9 +459,9 @@ void DisplayListBuilder::restore() {
       // For regular save() ops there was no protecting layer so we have to
       // accumulate the values into the enclosing layer.
       if (layer_info.cannot_inherit_opacity) {
-        current_layer_->mark_incompatible();
-      } else if (layer_info.has_compatible_op) {
-        current_layer_->add_compatible_op();
+        current_layer_->mark_opacity_incompatible();
+      } else if (layer_info.has_opacity_compatible_op) {
+        current_layer_->mark_opacity_incompatible();
       }
     }
   }

--- a/display_list/display_list_builder.cc
+++ b/display_list/display_list_builder.cc
@@ -352,10 +352,9 @@ void DisplayListBuilder::setAttributesFromDlPaint(
   if (flags.applies_image_filter()) {
     setImageFilter(paint.getImageFilter().get());
   }
-  // Waiting for https://github.com/flutter/engine/pull/32159
-  // if (flags.applies_path_effect()) {
-  //   setPathEffect(sk_ref_sp(paint.getPathEffect()));
-  // }
+  if (flags.applies_path_effect()) {
+    setPathEffect(paint.getPathEffect().get());
+  }
   if (flags.applies_mask_filter()) {
     setMaskFilter(paint.getMaskFilter().get());
   }

--- a/display_list/display_list_builder.h
+++ b/display_list/display_list_builder.h
@@ -413,7 +413,9 @@ class DisplayListBuilder final : public virtual Dispatcher,
 
     void mark_opacity_incompatible() { cannot_inherit_opacity = true; }
 
-    void mark_color_filter_incompatible() { cannot_inherit_color_filter = true; }
+    void mark_color_filter_incompatible() {
+      cannot_inherit_color_filter = true;
+    }
 
     // For now this only allows a single compatible op to mark the
     // layer as being compatible with group opacity. If we start
@@ -471,10 +473,10 @@ class DisplayListBuilder final : public virtual Dispatcher,
 
   void UpdateCurrentColorFilterCompatibility() {
     // TODO:(Jsouliang) check the filter compatiblity is right?
-    current_opacity_compatibility_ = 
-        current_.getAlpha() == 1.0 && // not set alpha
-        !current_.isInvertColors() && 
-        IsOpacityCompatible(current_.getBlendMode()); 
+    current_opacity_compatibility_ =
+        current_.getAlpha() == 1.0 &&  // not set alpha
+        !current_.isInvertColors() &&
+        IsOpacityCompatible(current_.getBlendMode());
   }
 
   // Update the opacity compatibility flags of the current layer for an op

--- a/display_list/display_list_builder.h
+++ b/display_list/display_list_builder.h
@@ -507,7 +507,10 @@ class DisplayListBuilder final : public virtual Dispatcher,
                                     current_opacity_compatibility_);
   }
 
-  void CheckLayerColorFilterCompatiblity() {}
+  void CheckLayerColorFilterCompatiblity(bool uses_blend_attribute = true) {
+    UpdateLayerColorFilterCompatiblity(!uses_blend_attribute ||
+                                       current_color_filter_compatibility_);
+  }
 
   void CheckLayerOpacityHairlineCompatibility() {
     UpdateLayerOpacityCompatibility(

--- a/display_list/display_list_paint.h
+++ b/display_list/display_list_paint.h
@@ -279,7 +279,7 @@ class DlPaint {
   bool operator==(DlPaint const& other) const;
   bool operator!=(DlPaint const& other) const { return !(*this == other); }
 
-  bool attribute_is_setted(DlPaintAttribute attribute) {
+  bool attribute_is_setted(DlPaintAttribute attribute) const {
     return setted_attributed_ & attribute;
   }
 

--- a/display_list/display_list_paint_unittests.cc
+++ b/display_list/display_list_paint_unittests.cc
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "flutter/display_list/display_list.h"
 #include "flutter/display_list/display_list_paint.h"
 
 #include "flutter/display_list/display_list_comparable.h"
@@ -130,6 +131,20 @@ TEST(DisplayListPaint, ChainingConstructor) {
             DlBlurMaskFilter(SkBlurStyle::kInner_SkBlurStyle, 3.14));
 
   EXPECT_NE(paint, DlPaint());
+}
+
+TEST(DisplayListPaint, AttributeSetted) {
+  DlPaint dl_paint;
+  dl_paint.setColorFilter(
+      DlBlendColorFilter(DlColor::kYellow(), DlBlendMode::kDstIn).shared());
+  dl_paint.setAlpha(0x7F);
+  EXPECT_EQ(dl_paint.attribute_is_setted(DlPaintAttribute::kColorFilter), true);
+  EXPECT_EQ(dl_paint.attribute_is_setted(DlPaintAttribute::kAlpha), true);
+  // clean color filter
+  dl_paint.setColorFilter(nullptr);
+  EXPECT_EQ(dl_paint.attribute_is_setted(DlPaintAttribute::kColorFilter),
+            false);
+  EXPECT_EQ(dl_paint.attribute_is_setted(DlPaintAttribute::kAlpha), true);
 }
 
 }  // namespace testing

--- a/flow/BUILD.gn
+++ b/flow/BUILD.gn
@@ -51,6 +51,8 @@ source_set("flow") {
     "layers/offscreen_surface.h",
     "layers/opacity_layer.cc",
     "layers/opacity_layer.h",
+    "layers/paint_node.cc",
+    "layers/paint_node.h",
     "layers/performance_overlay_layer.cc",
     "layers/performance_overlay_layer.h",
     "layers/physical_shape_layer.cc",

--- a/flow/layers/backdrop_filter_layer.cc
+++ b/flow/layers/backdrop_filter_layer.cc
@@ -47,6 +47,11 @@ void BackdropFilterLayer::Preroll(PrerollContext* context,
     context->view_embedder->PushFilterToVisitedPlatformViews(filter_);
   }
   SkRect child_paint_bounds = SkRect::MakeEmpty();
+  
+  context->paint = context->paint->SetBackdropFilter(blend_mode_, filter_.get());
+  BindPaintNode(context->paint);
+
+
   PrerollChildren(context, matrix, &child_paint_bounds);
   child_paint_bounds.join(context->cull_rect);
   set_paint_bounds(child_paint_bounds);

--- a/flow/layers/backdrop_filter_layer.cc
+++ b/flow/layers/backdrop_filter_layer.cc
@@ -47,10 +47,10 @@ void BackdropFilterLayer::Preroll(PrerollContext* context,
     context->view_embedder->PushFilterToVisitedPlatformViews(filter_);
   }
   SkRect child_paint_bounds = SkRect::MakeEmpty();
-  
-  context->paint = context->paint->SetBackdropFilter(blend_mode_, filter_.get());
-  BindPaintNode(context->paint);
 
+  context->paint =
+      context->paint->SetBackdropFilter(blend_mode_, filter_.get());
+  BindPaintNode(context->paint);
 
   PrerollChildren(context, matrix, &child_paint_bounds);
   child_paint_bounds.join(context->cull_rect);
@@ -65,13 +65,13 @@ void BackdropFilterLayer::Paint(PaintContext& context) const {
   AutoCachePaint save_paint(context);
   save_paint.setBlendMode(blend_mode_);
   if (context.leaf_nodes_builder) {
-
     // // Note that we perform a saveLayer directly on the
     // // leaf_nodes_builder here similar to how the SkCanvas
     // // path specifies the kLeafNodesCanvas below.
     // // See https:://flutter.dev/go/backdrop-filter-with-overlay-canvas
     // context.leaf_nodes_builder->saveLayer(&paint_bounds(),
-    //                                       save_paint.dl_paint(), filter_.get());
+    //                                       save_paint.dl_paint(),
+    //                                       filter_.get());
     context.paint =
         context.paint->SetBackdropFilter(blend_mode_, filter_.get());
 

--- a/flow/layers/backdrop_filter_layer.cc
+++ b/flow/layers/backdrop_filter_layer.cc
@@ -60,12 +60,15 @@ void BackdropFilterLayer::Paint(PaintContext& context) const {
   AutoCachePaint save_paint(context);
   save_paint.setBlendMode(blend_mode_);
   if (context.leaf_nodes_builder) {
-    // Note that we perform a saveLayer directly on the
-    // leaf_nodes_builder here similar to how the SkCanvas
-    // path specifies the kLeafNodesCanvas below.
-    // See https:://flutter.dev/go/backdrop-filter-with-overlay-canvas
-    context.leaf_nodes_builder->saveLayer(&paint_bounds(),
-                                          save_paint.dl_paint(), filter_.get());
+
+    // // Note that we perform a saveLayer directly on the
+    // // leaf_nodes_builder here similar to how the SkCanvas
+    // // path specifies the kLeafNodesCanvas below.
+    // // See https:://flutter.dev/go/backdrop-filter-with-overlay-canvas
+    // context.leaf_nodes_builder->saveLayer(&paint_bounds(),
+    //                                       save_paint.dl_paint(), filter_.get());
+    context.paint =
+        context.paint->SetBackdropFilter(blend_mode_, filter_.get());
 
     PaintChildren(context);
 

--- a/flow/layers/backdrop_filter_layer.cc
+++ b/flow/layers/backdrop_filter_layer.cc
@@ -48,9 +48,9 @@ void BackdropFilterLayer::Preroll(PrerollContext* context,
   }
   SkRect child_paint_bounds = SkRect::MakeEmpty();
 
-  context->paint =
-      context->paint->SetBackdropFilter(blend_mode_, filter_.get());
-  BindPaintNode(context->paint);
+  // context->paint =
+  //     context->paint->SetBackdropFilter(blend_mode_, filter_.get());
+  // BindPaintNode(context->paint);
 
   PrerollChildren(context, matrix, &child_paint_bounds);
   child_paint_bounds.join(context->cull_rect);
@@ -65,15 +65,12 @@ void BackdropFilterLayer::Paint(PaintContext& context) const {
   AutoCachePaint save_paint(context);
   save_paint.setBlendMode(blend_mode_);
   if (context.leaf_nodes_builder) {
-    // // Note that we perform a saveLayer directly on the
-    // // leaf_nodes_builder here similar to how the SkCanvas
-    // // path specifies the kLeafNodesCanvas below.
-    // // See https:://flutter.dev/go/backdrop-filter-with-overlay-canvas
-    // context.leaf_nodes_builder->saveLayer(&paint_bounds(),
-    //                                       save_paint.dl_paint(),
-    //                                       filter_.get());
-    context.paint =
-        context.paint->SetBackdropFilter(blend_mode_, filter_.get());
+    // Note that we perform a saveLayer directly on the
+    // leaf_nodes_builder here similar to how the SkCanvas
+    // path specifies the kLeafNodesCanvas below.
+    // See https:://flutter.dev/go/backdrop-filter-with-overlay-canvas
+    context.leaf_nodes_builder->saveLayer(&paint_bounds(),
+                                          save_paint.dl_paint(), filter_.get());
 
     PaintChildren(context);
 

--- a/flow/layers/color_filter_layer.cc
+++ b/flow/layers/color_filter_layer.cc
@@ -36,7 +36,7 @@ void ColorFilterLayer::Preroll(PrerollContext* context,
                                const SkMatrix& matrix) {
   Layer::AutoPrerollSaveLayerState save =
       Layer::AutoPrerollSaveLayerState::Create(context);
-      
+
   context->paint = context->paint->SetColorFilter(filter_.get());
   BindPaintNode(context->paint);
 

--- a/flow/layers/color_filter_layer.cc
+++ b/flow/layers/color_filter_layer.cc
@@ -61,9 +61,13 @@ void ColorFilterLayer::Paint(PaintContext& context) const {
   AutoCachePaint cache_paint(context);
   cache_paint.setColorFilter(filter_.get());
   if (context.leaf_nodes_builder) {
+
     FML_DCHECK(context.builder_multiplexer);
     context.builder_multiplexer->saveLayer(&paint_bounds(),
                                            cache_paint.dl_paint());
+
+    context.paint = context.paint->SetColorFilter(filter_.get());
+
     PaintChildren(context);
     context.builder_multiplexer->restore();
   } else {

--- a/flow/layers/color_filter_layer.cc
+++ b/flow/layers/color_filter_layer.cc
@@ -36,6 +36,10 @@ void ColorFilterLayer::Preroll(PrerollContext* context,
                                const SkMatrix& matrix) {
   Layer::AutoPrerollSaveLayerState save =
       Layer::AutoPrerollSaveLayerState::Create(context);
+      
+  context->paint = context->paint->SetColorFilter(filter_.get());
+  BindPaintNode(context->paint);
+
   AutoCache cache = AutoCache(layer_raster_cache_item_.get(), context, matrix);
 
   ContainerLayer::Preroll(context, matrix);
@@ -61,7 +65,6 @@ void ColorFilterLayer::Paint(PaintContext& context) const {
   AutoCachePaint cache_paint(context);
   cache_paint.setColorFilter(filter_.get());
   if (context.leaf_nodes_builder) {
-
     FML_DCHECK(context.builder_multiplexer);
     context.builder_multiplexer->saveLayer(&paint_bounds(),
                                            cache_paint.dl_paint());

--- a/flow/layers/color_filter_layer.cc
+++ b/flow/layers/color_filter_layer.cc
@@ -66,13 +66,13 @@ void ColorFilterLayer::Paint(PaintContext& context) const {
   cache_paint.setColorFilter(filter_.get());
   if (context.leaf_nodes_builder) {
     FML_DCHECK(context.builder_multiplexer);
-    context.builder_multiplexer->saveLayer(&paint_bounds(),
-                                           cache_paint.dl_paint());
+    // context.builder_multiplexer->saveLayer(&paint_bounds(),
+    //                                        cache_paint.dl_paint());
 
-    context.paint = context.paint->SetColorFilter(filter_.get());
+    // context.paint = context.paint->SetColorFilter(filter_.get());
 
     PaintChildren(context);
-    context.builder_multiplexer->restore();
+    // context.builder_multiplexer->restore();
   } else {
     Layer::AutoSaveLayer save = Layer::AutoSaveLayer::Create(
         context, paint_bounds(), cache_paint.sk_paint());

--- a/flow/layers/display_list_layer.cc
+++ b/flow/layers/display_list_layer.cc
@@ -150,8 +150,13 @@ void DisplayListLayer::Paint(PaintContext& context) const {
   }
 
   if (context.leaf_nodes_builder) {
-    AutoCachePaint save_paint(context);
+    DlPaint paint;
+    // we get all paints which need saveLayer
+    auto paint_nodes = context.paint->SaveLayerAttributePaintNodes();
+    AutoCachePaint save_paint(paint_nodes, context);
+
     int restore_count = context.leaf_nodes_builder->getSaveCount();
+
     if (save_paint.dl_paint() != nullptr) {
       context.leaf_nodes_builder->saveLayer(&paint_bounds(),
                                             save_paint.dl_paint());

--- a/flow/layers/display_list_layer.cc
+++ b/flow/layers/display_list_layer.cc
@@ -98,6 +98,7 @@ void DisplayListLayer::Preroll(PrerollContext* context,
 
   AutoCache cache =
       AutoCache(display_list_raster_cache_item_.get(), context, matrix);
+  BindPaintNode(context->paint);
   if (disp_list->can_apply_group_opacity()) {
     context->subtree_can_inherit_opacity = true;
   }
@@ -152,7 +153,7 @@ void DisplayListLayer::Paint(PaintContext& context) const {
   if (context.leaf_nodes_builder) {
     DlPaint paint;
     // we get all paints which need saveLayer
-    auto paint_nodes = context.paint->SaveLayerAttributePaintNodes();
+    auto paint_nodes = paint_node()->SaveLayerAttributePaintNodes();
     AutoCachePaint save_paint(paint_nodes, context);
 
     int restore_count = context.leaf_nodes_builder->getSaveCount();

--- a/flow/layers/display_list_layer_unittests.cc
+++ b/flow/layers/display_list_layer_unittests.cc
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "flutter/display_list/display_list_paint.h"
 #define FML_USED_ON_EMBEDDER
 
 #include "flutter/flow/layers/display_list_layer.h"
@@ -137,8 +138,8 @@ TEST_F(DisplayListLayerTest, SimpleDisplayListOpacityInheritance) {
         expected_builder.save();
         {
           expected_builder.translate(layer_offset.fX, layer_offset.fY);
-          expected_builder.setColor(opacity_alpha << 24);
-          expected_builder.saveLayer(&save_layer_bounds, true);
+          auto dl_paint = DlPaint().setColor(opacity_alpha << 24);
+          expected_builder.saveLayer(&save_layer_bounds, &dl_paint);
           /* display_list contents */ {  //
             expected_builder.drawDisplayList(child_display_list);
           }
@@ -196,8 +197,8 @@ TEST_F(DisplayListLayerTest, IncompatibleDisplayListOpacityInheritance) {
     expected_builder.save();
     {
       expected_builder.translate(opacity_offset.fX, opacity_offset.fY);
-      expected_builder.setColor(opacity_alpha << 24);
-      expected_builder.saveLayer(&save_layer_bounds, true);
+      auto dl_paint = DlPaint().setColor(opacity_alpha << 24);
+      expected_builder.saveLayer(&save_layer_bounds, &dl_paint);
       {
         /* display_list_layer::Paint() */ {
           expected_builder.save();

--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -414,6 +414,14 @@ class Layer {
   }
   virtual const testing::MockLayer* as_mock_layer() const { return nullptr; }
 
+  void BindPaintNode(DlPaintNode* paint_node) {
+    paint_node_ = paint_node;
+  }
+
+  const DlPaintNode* paint_node() const {
+    return paint_node_;
+  }
+
  private:
   SkRect paint_bounds_;
   uint64_t unique_id_;
@@ -421,6 +429,8 @@ class Layer {
   bool subtree_has_platform_view_;
 
   static uint64_t NextUniqueID();
+
+  DlPaintNode* paint_node_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(Layer);
 };

--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -414,13 +414,9 @@ class Layer {
   }
   virtual const testing::MockLayer* as_mock_layer() const { return nullptr; }
 
-  void BindPaintNode(DlPaintNode* paint_node) {
-    paint_node_ = paint_node;
-  }
+  void BindPaintNode(DlPaintNode* paint_node) { paint_node_ = paint_node; }
 
-  const DlPaintNode* paint_node() const {
-    return paint_node_;
-  }
+  const DlPaintNode* paint_node() const { return paint_node_; }
 
  private:
   SkRect paint_bounds_;

--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -234,8 +234,11 @@ class Layer {
     explicit AutoCachePaint(std::vector<DlPaintNode*>& paint_nodes,
                             PaintContext& context)
         : context_(context) {
-      for (auto* paint_node : paint_nodes) {
-        paint_node->SetSaveLayerAttribute(&dl_paint_);
+      if (paint_nodes.size() > 1) {
+        needs_paint_ = true;
+        for (auto* paint_node : paint_nodes) {
+          paint_node->SetSaveLayerAttribute(&dl_paint_);
+        }
       }
     }
 
@@ -416,7 +419,7 @@ class Layer {
 
   void BindPaintNode(DlPaintNode* paint_node) { paint_node_ = paint_node; }
 
-  const DlPaintNode* paint_node() const { return paint_node_; }
+  DlPaintNode* paint_node() const { return paint_node_; }
 
  private:
   SkRect paint_bounds_;

--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -49,7 +49,9 @@ bool LayerTree::Preroll(CompositorContext::ScopedFrame& frame,
   RasterCache* cache =
       ignore_raster_cache ? nullptr : &frame.context().raster_cache();
   raster_cache_items_.clear();
+  
   paint_tree_root_ = std::make_unique<DlPaintNode>();
+  root_layer_->BindPaintNode(paint_tree_root_.get());
 
   PrerollContext context = {
       // clang-format off

--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "flutter/flow/layers/layer_tree.h"
+#include <memory>
 
 #include "flutter/flow/embedded_views.h"
 #include "flutter/flow/frame_timings.h"
@@ -48,6 +49,7 @@ bool LayerTree::Preroll(CompositorContext::ScopedFrame& frame,
   RasterCache* cache =
       ignore_raster_cache ? nullptr : &frame.context().raster_cache();
   raster_cache_items_.clear();
+  paint_tree_root_ = std::make_unique<DlPaintNode>();
 
   PrerollContext context = {
       // clang-format off
@@ -65,6 +67,7 @@ bool LayerTree::Preroll(CompositorContext::ScopedFrame& frame,
       .frame_device_pixel_ratio      = device_pixel_ratio_,
       .raster_cached_entries         = &raster_cache_items_,
       .display_list_enabled          = frame.display_list_builder() != nullptr,
+      .paint                         = paint_tree_root_.get(),
       // clang-format on
   };
 
@@ -158,6 +161,7 @@ void LayerTree::Paint(CompositorContext::ScopedFrame& frame,
       .inherited_opacity             = SK_Scalar1,
       .leaf_nodes_builder            = builder,
       .builder_multiplexer           = builder ? &builder_multiplexer : nullptr,
+      .paint                         = paint_tree_root_.get(),
       // clang-format on
   };
 

--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -49,7 +49,7 @@ bool LayerTree::Preroll(CompositorContext::ScopedFrame& frame,
   RasterCache* cache =
       ignore_raster_cache ? nullptr : &frame.context().raster_cache();
   raster_cache_items_.clear();
-  
+
   paint_tree_root_ = std::make_unique<DlPaintNode>();
   root_layer_->BindPaintNode(paint_tree_root_.get());
 

--- a/flow/layers/layer_tree.h
+++ b/flow/layers/layer_tree.h
@@ -7,6 +7,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <vector>
 
 #include "flutter/flow/compositor_context.h"
 #include "flutter/flow/layers/layer.h"
@@ -98,6 +99,10 @@ class LayerTree {
   PaintRegionMap paint_region_map_;
 
   std::vector<RasterCacheItem*> raster_cache_items_;
+
+  std::unique_ptr<DlPaint> dl_paint_;
+
+  std::unique_ptr<DlPaintNode> paint_tree_root_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(LayerTree);
 };

--- a/flow/layers/opacity_layer.cc
+++ b/flow/layers/opacity_layer.cc
@@ -89,6 +89,9 @@ void OpacityLayer::Paint(PaintContext& context) const {
   SkScalar inherited_opacity = context.inherited_opacity;
   SkScalar subtree_opacity = opacity() * inherited_opacity;
 
+  auto* subtree_paint_node = context.paint->SetAlpha(subtree_opacity);
+  context.paint = subtree_paint_node;
+
   if (children_can_accept_opacity()) {
     context.inherited_opacity = subtree_opacity;
     PaintChildren(context);

--- a/flow/layers/opacity_layer.cc
+++ b/flow/layers/opacity_layer.cc
@@ -46,6 +46,9 @@ void OpacityLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
       SkMatrix::Translate(offset_.fX, offset_.fY));
   context->mutators_stack.PushOpacity(alpha_);
 
+  context->paint = context->paint->SetAlpha(alpha_);
+  BindPaintNode(context->paint);
+
   AutoCache auto_cache =
       AutoCache(layer_raster_cache_item_.get(), context, matrix);
   Layer::AutoPrerollSaveLayerState save =

--- a/flow/layers/opacity_layer.cc
+++ b/flow/layers/opacity_layer.cc
@@ -92,15 +92,14 @@ void OpacityLayer::Paint(PaintContext& context) const {
   SkScalar inherited_opacity = context.inherited_opacity;
   SkScalar subtree_opacity = opacity() * inherited_opacity;
 
-  auto* subtree_paint_node = context.paint->SetAlpha(subtree_opacity);
-  context.paint = subtree_paint_node;
-
   if (children_can_accept_opacity()) {
     context.inherited_opacity = subtree_opacity;
     PaintChildren(context);
     context.inherited_opacity = inherited_opacity;
     return;
   }
+
+  paint_node()->incompatible();
 
   SkPaint paint;
   paint.setAlphaf(subtree_opacity);

--- a/flow/layers/paint_node.cc
+++ b/flow/layers/paint_node.cc
@@ -1,0 +1,48 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/flow/layers/paint_node.h"
+#include <memory>
+#include <utility>
+
+namespace flutter {
+
+DlPaintNode* DlPaintNode::SetAlpha(uint8_t alpha) {
+  auto child = std::make_unique<OpacityPaintNode>(alpha);
+  child->parent_ = this;
+  child->depth_++;
+  children_.emplace_back(std::move(child));
+  return children_.back().get();
+}
+
+DlPaintNode* DlPaintNode::SetColorFilter(const DlColorFilter* color_filter) {
+  auto child = std::make_unique<ColorFilterPaintNode>(color_filter);
+  child->parent_ = this;
+  child->depth_++;
+  children_.emplace_back(std::move(child));
+  return children_.back().get();
+}
+
+DlPaintNode* DlPaintNode::SetBackdropFilter(DlBlendMode blend_mode,
+                                            const DlImageFilter* filter) {
+  auto child = std::make_unique<BackdropFilterPaintNode>(blend_mode, filter);
+  child->parent_ = this;
+  child->depth_++;
+  children_.emplace_back(std::move(child));
+  return children_.back().get();
+}
+
+void BackdropFilterPaintNode::SetSaveLayerAttribute(DlPaint* paint) {
+  paint->setBlendMode(blend_mode_);
+}
+
+void OpacityPaintNode::SetSaveLayerAttribute(DlPaint* paint) {
+  paint->setAlpha(alpha_);
+}
+
+void ColorFilterPaintNode::SetSaveLayerAttribute(DlPaint* paint) {
+  paint->setColorFilter(color_filter_);
+}
+
+}  // namespace flutter

--- a/flow/layers/paint_node.cc
+++ b/flow/layers/paint_node.cc
@@ -35,6 +35,7 @@ DlPaintNode* DlPaintNode::SetBackdropFilter(DlBlendMode blend_mode,
 
 void BackdropFilterPaintNode::SetSaveLayerAttribute(DlPaint* paint) {
   paint->setBlendMode(blend_mode_);
+  paint->setImageFilter(filter_);
 }
 
 void OpacityPaintNode::SetSaveLayerAttribute(DlPaint* paint) {

--- a/flow/layers/paint_node.cc
+++ b/flow/layers/paint_node.cc
@@ -34,16 +34,22 @@ DlPaintNode* DlPaintNode::SetBackdropFilter(DlBlendMode blend_mode,
 }
 
 void BackdropFilterPaintNode::SetSaveLayerAttribute(DlPaint* paint) {
-  paint->setBlendMode(blend_mode_);
-  paint->setImageFilter(filter_);
+  if (compatibility) {
+    paint->setBlendMode(blend_mode_);
+    paint->setImageFilter(filter_);
+  }
 }
 
 void OpacityPaintNode::SetSaveLayerAttribute(DlPaint* paint) {
-  paint->setAlpha(alpha_);
+  if (compatibility) {
+    paint->setAlpha(alpha_);
+  }
 }
 
 void ColorFilterPaintNode::SetSaveLayerAttribute(DlPaint* paint) {
-  paint->setColorFilter(color_filter_);
+  if (compatibility) {
+    paint->setColorFilter(color_filter_);
+  }
 }
 
 }  // namespace flutter

--- a/flow/layers/paint_node.h
+++ b/flow/layers/paint_node.h
@@ -1,0 +1,99 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_FLOW_LAYERS_PAINT_NODE_H_
+#define FLUTTER_FLOW_LAYERS_PAINT_NODE_H_
+
+#include <iterator>
+#include <vector>
+#include "flutter/display_list/display_list.h"
+#include "flutter/display_list/display_list_blend_mode.h"
+#include "flutter/display_list/display_list_builder.h"
+#include "flutter/display_list/display_list_color_filter.h"
+#include "flutter/display_list/display_list_paint.h"
+
+namespace flutter {
+
+class DlPaintNode {
+ public:
+  explicit DlPaintNode() {}
+  virtual ~DlPaintNode() = default;
+
+  virtual void SetSaveLayerAttribute(DlPaint*){};
+
+  DlPaintNode* SetAlpha(uint8_t alpha);
+
+  DlPaintNode* SetColorFilter(const DlColorFilter* color_filter);
+
+  DlPaintNode* SetBackdropFilter(DlBlendMode blend_mode,
+                                 const DlImageFilter* filter);
+
+  const DlPaintNode* parent() const { return parent_; }
+
+  bool hasNext() const { return current_index_ >= children_.size(); }
+
+  DlPaintNode* next() {
+    if (current_index_ < children_.size()) {
+      return children_[current_index_++].get();
+    }
+    return nullptr;
+  }
+
+  std::vector<DlPaintNode*> SaveLayerAttributePaintNodes() {
+    DlPaintNode* nodes[depth_];
+    auto* current = this;
+    auto index = depth_ - 1;
+    while (current) {
+      nodes[index--] = current;
+      current = current->parent_;
+    }
+    std::vector<DlPaintNode*> a(nodes, nodes + depth_ - 1);
+    return a;
+  }
+
+ protected:
+  std::vector<std::unique_ptr<DlPaintNode>> children_;
+  DlPaintNode* parent_;
+
+  unsigned current_index_ = 0;
+  unsigned depth_ = 1;
+};
+
+class OpacityPaintNode : public DlPaintNode {
+ public:
+  explicit OpacityPaintNode(uint8_t alpha) : alpha_(alpha) {}
+
+  void SetSaveLayerAttribute(DlPaint*) override;
+
+ private:
+  uint8_t alpha_;
+};
+
+class BackdropFilterPaintNode : public DlPaintNode {
+ public:
+  explicit BackdropFilterPaintNode(DlBlendMode blend_mode,
+                                   const DlImageFilter* filter)
+      : blend_mode_(blend_mode), filter_(filter) {}
+
+  void SetSaveLayerAttribute(DlPaint*) override;
+
+ private:
+  DlBlendMode blend_mode_;
+  const DlImageFilter* filter_;
+};
+
+class ColorFilterPaintNode : public DlPaintNode {
+ public:
+  explicit ColorFilterPaintNode(const DlColorFilter* color_filter)
+      : color_filter_(color_filter) {}
+
+  void SetSaveLayerAttribute(DlPaint*) override;
+
+ private:
+  const DlColorFilter* color_filter_;
+};
+
+}  // namespace flutter
+
+#endif /* FLUTTER_FLOW_LAYERS_PAINT_NODE_H_ */

--- a/flow/layers/paint_node.h
+++ b/flow/layers/paint_node.h
@@ -33,6 +33,8 @@ class DlPaintNode {
 
   bool hasNext() const { return current_index_ >= children_.size(); }
 
+  void incompatible() { compatibility = false; }
+
   DlPaintNode* next() {
     if (current_index_ < children_.size()) {
       return children_[current_index_++].get();
@@ -43,18 +45,22 @@ class DlPaintNode {
   std::vector<DlPaintNode*> SaveLayerAttributePaintNodes() {
     DlPaintNode* nodes[depth_];
     auto* current = this;
-    auto index = depth_ - 1;
+    int index = depth_ - 1;
     while (current) {
+      if (!current->compatibility) {
+        break;
+      }
       nodes[index--] = current;
       current = current->parent_;
     }
-    std::vector<DlPaintNode*> a(nodes, nodes + depth_ - 1);
-    return a;
+    auto length = depth_ - (index + 1);
+    return {nodes, nodes + length};
   }
 
  protected:
-  std::vector<std::unique_ptr<DlPaintNode>> children_;
-  DlPaintNode* parent_;
+  std::vector<std::unique_ptr<DlPaintNode>> children_ = {};
+  DlPaintNode* parent_ = nullptr;
+  bool compatibility = true;
 
   unsigned current_index_ = 0;
   unsigned depth_ = 1;

--- a/flow/testing/layer_test.h
+++ b/flow/testing/layer_test.h
@@ -8,11 +8,13 @@
 #include "flutter/flow/layer_snapshot_store.h"
 #include "flutter/flow/layers/layer.h"
 
+#include <memory>
 #include <optional>
 #include <utility>
 #include <vector>
 
 #include "flutter/display_list/display_list_builder_multiplexer.h"
+#include "flutter/flow/layers/paint_node.h"
 #include "flutter/flow/testing/mock_raster_cache.h"
 #include "flutter/fml/macros.h"
 #include "flutter/testing/canvas_test.h"
@@ -46,6 +48,7 @@ class LayerTestBase : public CanvasTestBase<BaseT> {
  public:
   LayerTestBase()
       : texture_registry_(std::make_shared<TextureRegistry>()),
+        paint_node_(std::make_unique<DlPaintNode>()),
         preroll_context_{
             // clang-format off
             .raster_cache                  = nullptr,
@@ -62,6 +65,7 @@ class LayerTestBase : public CanvasTestBase<BaseT> {
             .frame_device_pixel_ratio      = 1.0f,
             .has_platform_view             = false,
             .raster_cached_entries         = &cacheable_items_,
+            .paint                         = paint_node_.get()
             // clang-format on
         },
         paint_context_{
@@ -76,6 +80,7 @@ class LayerTestBase : public CanvasTestBase<BaseT> {
             .raster_cache                  = nullptr,
             .checkerboard_offscreen_layers = false,
             .frame_device_pixel_ratio      = 1.0f,
+            .paint                         = paint_node_.get()
             // clang-format on
         },
         display_list_recorder_(kDlBounds),
@@ -94,6 +99,7 @@ class LayerTestBase : public CanvasTestBase<BaseT> {
             .frame_device_pixel_ratio      = 1.0f,
             .leaf_nodes_builder            = display_list_recorder_.builder().get(),
             .builder_multiplexer           = &display_list_multiplexer_,
+            .paint                         = paint_node_.get()
             // clang-format on
         },
         check_board_context_{
@@ -213,9 +219,11 @@ class LayerTestBase : public CanvasTestBase<BaseT> {
   FixedRefreshRateStopwatch raster_time_;
   FixedRefreshRateStopwatch ui_time_;
   MutatorsStack mutators_stack_;
-  std::shared_ptr<TextureRegistry> texture_registry_;
 
+  std::shared_ptr<TextureRegistry> texture_registry_;
+  std::unique_ptr<DlPaintNode> paint_node_;
   std::unique_ptr<RasterCache> raster_cache_;
+
   PrerollContext preroll_context_;
   PaintContext paint_context_;
   DisplayListCanvasRecorder display_list_recorder_;


### PR DESCRIPTION
Description:
1. Create a PaintTree during the traversal tree phase, the PaintTree node is the AttributeLayer which set the paint attribute and it needs to `saveLayer`
2. In the DisplayListLayer we can get all the PaintTree nodes, and to compress  the `saveLayer` op
3. In the AttributeLayer, we don't do the `saveLayer` op, instead, we create a PaintTree node and insert the node to the PaintTree.

- [x] Recording the attribute in a DlPaint
- [ ] Quick check which attribute is set in DlPaint
- [ ] Check if DlPaint is compatible with DLLayer's display_list



cc @flar 