### PR TITLE
Add an //ignore now that we are analyzing the sample code

### DIFF
--- a/lib/ui/hash_codes.dart
+++ b/lib/ui/hash_codes.dart
@@ -4,6 +4,7 @@
 part of dart.ui;
 
 // Examples can assume:
+// // ignore_for_file: deprecated_member_use
 // int foo = 0;
 // int bar = 0;
 // List<int> quux = <int>[];


### PR DESCRIPTION
Otherwise the examples in this file trigger the "but it's deprecated" warning.