### PR TITLE
[fuchsia][scenic] Reset the state of a PointerInjectorEndpoint on channel closure

### DIFF
--- a/shell/platform/fuchsia/flutter/pointer_injector_delegate.cc
+++ b/shell/platform/fuchsia/flutter/pointer_injector_delegate.cc
@@ -305,4 +305,10 @@ void PointerInjectorDelegate::PointerInjectorEndpoint::RegisterInjector(
   registered_ = true;
 }
 
+void PointerInjectorDelegate::PointerInjectorEndpoint::Reset() {
+  injection_in_flight_ = false;
+  registered_ = false;
+  injector_events_ = {};
+}
+
 }  // namespace flutter_runner

--- a/shell/platform/fuchsia/flutter/pointer_injector_delegate.h
+++ b/shell/platform/fuchsia/flutter/pointer_injector_delegate.h
@@ -106,7 +106,11 @@ class PointerInjectorDelegate {
             if (!weak) {
               return;
             }
-            weak->registered_ = false;
+
+            // Clear all the stale pointer events in |injector_events_| and
+            // reset the state of |weak| so that any future calls do not inject
+            // any stale pointer events.
+            weak->Reset();
           });
     }
 
@@ -128,6 +132,12 @@ class PointerInjectorDelegate {
     void DispatchPendingEvents();
 
     void EnqueueEvent(fuchsia::ui::pointerinjector::Event event);
+
+    // Resets |registered_|, |injection_in_flight_| and |injector_events_| so
+    // that |device_| can be re-registered and future calls to
+    // |fuchsia.ui.pointerinjector.Device.Inject| do not include any stale
+    // pointer events.
+    void Reset();
 
     // Set to true if there is a |fuchsia.ui.pointerinjector.Device.Inject| call
     // in progress. If true, the |fuchsia.ui.pointerinjector.Event| is buffered

--- a/shell/platform/fuchsia/flutter/tests/fakes/mock_injector_registry.h
+++ b/shell/platform/fuchsia/flutter/tests/fakes/mock_injector_registry.h
@@ -51,6 +51,8 @@ class MockInjectorRegistry : public fuchsia::ui::pointerinjector::Registry,
     callback();
   }
 
+  void ClearBindings() { bindings_.clear(); }
+
   // Returns the |fuchsia::ui::pointerinjector::Config| received in the last
   // |Register(...)| call.
   const fuchsia::ui::pointerinjector::Config& config() const { return config_; }


### PR DESCRIPTION
This CL resets the state including cleaning up the buffers whenever
a fuchsia.ui.pointerinjector.Device channel closes due to some error.

Test: flutter_runner_tests

