### PR TITLE
[Impeller] Unify tiling functionality in shader lib

### DIFF
--- a/impeller/compiler/shader_lib/impeller/constants.glsl
+++ b/impeller/compiler/shader_lib/impeller/constants.glsl
@@ -6,6 +6,11 @@
 #define CONSTANTS_GLSL_
 
 const float kEhCloseEnough = 0.000001;
+
+// 1 / (2 * pi)
 const float k1Over2Pi = 0.1591549430918;
+
+// sqrt(2 * pi)
+const float kSqrtTwoPi = 2.50662827463;
 
 #endif

--- a/impeller/entity/shaders/blending/advanced_blend.glsl
+++ b/impeller/entity/shaders/blending/advanced_blend.glsl
@@ -21,12 +21,13 @@ in vec2 v_src_texture_coords;
 out vec4 frag_color;
 
 void main() {
-  vec4 dst = IPUnpremultiply(
-      IPSampleClampToBorder(texture_sampler_dst, v_dst_texture_coords));
-  vec4 src = blend_info.color_factor > 0
-                 ? blend_info.color
-                 : IPUnpremultiply(IPSampleClampToBorder(texture_sampler_src,
-                                                         v_src_texture_coords));
+  vec4 dst = IPUnpremultiply(IPSampleWithTileMode(
+      texture_sampler_dst, v_dst_texture_coords, kTileModeDecal));
+  vec4 src =
+      blend_info.color_factor > 0
+          ? blend_info.color
+          : IPUnpremultiply(IPSampleWithTileMode(
+                texture_sampler_src, v_src_texture_coords, kTileModeDecal));
 
   vec3 blended = Blend(dst.rgb, src.rgb);
 

--- a/impeller/entity/shaders/gradient_fill.frag
+++ b/impeller/entity/shaders/gradient_fill.frag
@@ -28,6 +28,6 @@ void main() {
     return;
   }
 
-  t = IPTileTextureCoords(t, gradient_info.tile_mode);
+  t = IPFloatTile(t, gradient_info.tile_mode);
   frag_color = mix(gradient_info.start_color, gradient_info.end_color, t);
 }

--- a/impeller/entity/shaders/radial_gradient_fill.frag
+++ b/impeller/entity/shaders/radial_gradient_fill.frag
@@ -24,6 +24,6 @@ void main() {
     return;
   }
 
-  t = IPTileTextureCoords(t, gradient_info.tile_mode);
+  t = IPFloatTile(t, gradient_info.tile_mode);
   frag_color = mix(gradient_info.center_color, gradient_info.edge_color, t);
 }

--- a/impeller/entity/shaders/sweep_gradient_fill.frag
+++ b/impeller/entity/shaders/sweep_gradient_fill.frag
@@ -28,6 +28,6 @@ void main() {
     return;
   }
 
-  t = IPTileTextureCoords(t, gradient_info.tile_mode);
+  t = IPFloatTile(t, gradient_info.tile_mode);
   frag_color = mix(gradient_info.start_color, gradient_info.end_color, t);
 }


### PR DESCRIPTION
Replaces `IPSampleClampToBorder` with a more flexible `IPSampleWithTileMode` to set us up for easy emulation of tiling modes when we can't rely on sampler features.

Cleaned up naming and doc strings for consistency.