### PR TITLE
[Windows] Fix dllimport issue in unit tests

### DIFF
--- a/shell/platform/windows/BUILD.gn
+++ b/shell/platform/windows/BUILD.gn
@@ -205,6 +205,9 @@ executable("flutter_windows_unittests") {
     "window_unittests.cc",
   ]
 
+  configs +=
+      [ "//flutter/shell/platform/common:desktop_library_implementation" ]
+
   public_configs = [ "//flutter:config" ]
 
   deps = [


### PR DESCRIPTION
In flutter/engine#35106, I landed a parameter type fix for the
declaration of FlutterDesktopEngineGetTextureRegistrar in our public
Windows C API. I also added a unit test that called this function.

That function (and all others) in our public Windows API is marked
FLUTTER_EXPORT, which resolves to __declspec(dllexport) or
__declspec(dllimport) depending on whether FLUTTER_DESKTOP_LIBRARY is
defined. It can be defined by adding the following build config:
//flutter/shell/platform/common:desktop_library_implementation

If the function is marked as an import, we get linker warnings that
we're importing a function that's defined in the same executable image.
This patch resolves this by marking the functions as export.

An alternative fix would be to support a third macro resolution that
resolves to nothing in the presence of some definition like
FLUTTER_NO_EXPORT; however, since flutter_export.h is a public header,
I'd prefer not to complicate it further, and this is a unit test that
can't be linked against either way.

Issue: https://github.com/flutter/flutter/issues/109184
Original issue: https://github.com/flutter/flutter/issues/86617

See: https://github.com/flutter/engine/blob/main/shell/platform/common/public/flutter_export.h
See: https://github.com/flutter/engine/blob/a51c7638e702b086dffaae3ce92f52130a2c23ff/shell/platform/common/BUILD.gn#L8-L10

No new tests since this simply fixes a link warning message in unit tests.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
