### PR TITLE
Fix wrong use of fl_method_call_respond arguments in documentation

### DIFF
--- a/shell/platform/linux/public/flutter_linux/fl_method_channel.h
+++ b/shell/platform/linux/public/flutter_linux/fl_method_channel.h
@@ -54,7 +54,7 @@ G_DECLARE_FINAL_TYPE(FlMethodChannel,
  * (fl_method_not_implemented_response_new ());
  *
  *   g_autoptr(GError) error = NULL;
- *   if (!fl_method_call_respond(method_call, response))
+ *   if (!fl_method_call_respond(method_call, response, &error))
  *     g_warning ("Failed to send response: %s", error->message);
  * }
  *


### PR DESCRIPTION
Fix wrong use of fl_method_call_respond arguments in documentation

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
