### PR TITLE
[Impeller] Account for the backend-dependent space of rendered textures in advanced blends

### DIFF
--- a/impeller/compiler/shader_lib/impeller/texture.glsl
+++ b/impeller/compiler/shader_lib/impeller/texture.glsl
@@ -48,21 +48,25 @@ float IPFloatTile(float t, float tile_mode) {
 /// Remap a vec2 using a tiling mode.
 ///
 /// Runs each component of the vec2 through `IPFloatTile`.
-vec2 IPVec2Tile(vec2 uv, float tile_mode) {
-  return vec2(IPFloatTile(uv.x, tile_mode), IPFloatTile(uv.y, tile_mode));
+vec2 IPVec2Tile(vec2 coords, float tile_mode) {
+  return vec2(IPFloatTile(coords.x, tile_mode),
+              IPFloatTile(coords.y, tile_mode));
 }
 
 /// Sample a texture, emulating a specific tile mode.
 ///
 /// This is useful for Impeller graphics backend that don't have native support
 /// for Decal.
-vec4 IPSampleWithTileMode(sampler2D tex, vec2 uv, float tile_mode) {
+vec4 IPSampleWithTileMode(sampler2D tex,
+                          vec2 coords,
+                          float y_coord_scale,
+                          float tile_mode) {
   if (tile_mode == kTileModeDecal &&
-      (uv.x < 0 || uv.y < 0 || uv.x >= 1 || uv.y >= 1)) {
+      (coords.x < 0 || coords.y < 0 || coords.x >= 1 || coords.y >= 1)) {
     return vec4(0);
   }
 
-  return texture(tex, IPVec2Tile(uv, tile_mode));
+  return IPSample(tex, IPVec2Tile(coords, tile_mode), y_coord_scale);
 }
 
 #endif

--- a/impeller/entity/contents/filters/blend_filter_contents.cc
+++ b/impeller/entity/contents/filters/blend_filter_contents.cc
@@ -91,10 +91,12 @@ static bool AdvancedBlend(const FilterInput::Vector& inputs,
   cmd.BindVertices(vtx_buffer);
   cmd.pipeline = std::move(pipeline);
 
+  typename FS::BlendInfo blend_info;
+
   auto sampler = renderer.GetContext()->GetSamplerLibrary()->GetSampler({});
   FS::BindTextureSamplerDst(cmd, dst_snapshot->texture, sampler);
+  blend_info.dst_y_coord_scale = dst_snapshot->texture->GetYCoordScale();
 
-  typename FS::BlendInfo blend_info;
   if (foreground_color.has_value()) {
     blend_info.color_factor = 1;
     blend_info.color = foreground_color.value();
@@ -104,6 +106,7 @@ static bool AdvancedBlend(const FilterInput::Vector& inputs,
   } else {
     blend_info.color_factor = 0;
     FS::BindTextureSamplerSrc(cmd, src_snapshot->texture, sampler);
+    blend_info.src_y_coord_scale = src_snapshot->texture->GetYCoordScale();
   }
   auto blend_uniform = host_buffer.EmplaceUniform(blend_info);
   FS::BindBlendInfo(cmd, blend_uniform);

--- a/impeller/entity/shaders/blending/advanced_blend.glsl
+++ b/impeller/entity/shaders/blending/advanced_blend.glsl
@@ -7,6 +7,8 @@
 #include <impeller/texture.glsl>
 
 uniform BlendInfo {
+  float dst_y_coord_scale;
+  float src_y_coord_scale;
   float color_factor;
   vec4 color;  // This color input is expected to be unpremultiplied.
 }
@@ -22,12 +24,19 @@ out vec4 frag_color;
 
 void main() {
   vec4 dst = IPUnpremultiply(IPSampleWithTileMode(
-      texture_sampler_dst, v_dst_texture_coords, kTileModeDecal));
-  vec4 src =
-      blend_info.color_factor > 0
-          ? blend_info.color
-          : IPUnpremultiply(IPSampleWithTileMode(
-                texture_sampler_src, v_src_texture_coords, kTileModeDecal));
+      texture_sampler_dst,           // sampler
+      v_dst_texture_coords,          // texture coordinates
+      blend_info.dst_y_coord_scale,  // y coordinate scale
+      kTileModeDecal                 // tile mode
+      ));
+  vec4 src = blend_info.color_factor > 0
+                 ? blend_info.color
+                 : IPUnpremultiply(IPSampleWithTileMode(
+                       texture_sampler_src,           // sampler
+                       v_src_texture_coords,          // texture coordinates
+                       blend_info.src_y_coord_scale,  // y coordinate scale
+                       kTileModeDecal                 // tile mode
+                       ));
 
   vec3 blended = Blend(dst.rgb, src.rgb);
 

--- a/impeller/entity/shaders/gaussian_blur.frag
+++ b/impeller/entity/shaders/gaussian_blur.frag
@@ -57,15 +57,23 @@ void main() {
     float gaussian = Gaussian(i);
     gaussian_integral += gaussian;
     total_color +=
-        gaussian * IPSampleWithTileMode(texture_sampler,
-                                        v_texture_coords + blur_uv_offset * i,
-                                        frag_info.tile_mode);
+        gaussian *
+        IPSampleWithTileMode(
+            texture_sampler,                        // sampler
+            v_texture_coords + blur_uv_offset * i,  // texture coordinates
+            1.0,                                    // y coordinate scale
+            frag_info.tile_mode                     // tile mode
+        );
   }
 
   vec4 blur_color = total_color / gaussian_integral;
 
-  vec4 src_color = IPSampleWithTileMode(
-      alpha_mask_sampler, v_src_texture_coords, frag_info.tile_mode);
+  vec4 src_color =
+      IPSampleWithTileMode(alpha_mask_sampler,    // sampler
+                           v_src_texture_coords,  // texture coordinates
+                           1.0,                   // y coordinate scale
+                           frag_info.tile_mode    // tile mode
+      );
   float blur_factor = frag_info.inner_blur_factor * float(src_color.a > 0) +
                       frag_info.outer_blur_factor * float(src_color.a == 0);
 


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/105053 -- affects OpenGL fidelity.

Before:

https://user-images.githubusercontent.com/919017/183541735-6cb3d767-de66-4fcc-86e8-5df2190e2c24.mov


After:

https://user-images.githubusercontent.com/919017/183541621-f609248c-7c52-4ae7-98af-19db795eb2b4.mov


