### PR TITLE
[Windows] Shut down VM on shutdown of last engine

### DIFF
--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -254,6 +254,7 @@ bool FlutterWindowsEngine::RunWithEntrypoint(const char* entrypoint) {
 
   FlutterProjectArgs args = {};
   args.struct_size = sizeof(FlutterProjectArgs);
+  args.shutdown_dart_vm_when_done = true;
   args.assets_path = assets_path_string.c_str();
   args.icu_data_path = icu_path_string.c_str();
   args.command_line_argc = static_cast<int>(argv.size());


### PR DESCRIPTION
All Flutter engines in the same process share a common Dart VM, which is
launched with the start of the first engine in the process and should be
terminated when the last engine in the process has been deallocated.

Formerly, it was not possible to cleanly shut down and restart the VM in
a process, but this was resolved in the Dart SDK and a flag exposed in
flutter/engine#10652. Since some custom embedders may take advantage of
the fact that the VM remains running after engine shutdown, this flag is
not enabled by default, however it should be enabled for the Windows
embedder, which we control.

No tests added since this is not testable via any API to which the
Windows embedder has access. The behaviour of this flag is tested in the
embedder API tests in `EmbedderTest.VMShutsDownWhenNoEnginesInProcess`
in [shell/platform/embedder/tests/embedder_unittests.cc](https://github.com/flutter/engine/blob/6c14fb339fe10af4ee87dd891912ca7fcc595de3/shell/platform/embedder/tests/embedder_unittests.cc#L546-L565).

Issue: https://github.com/flutter/flutter/issues/109191


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
