### PR TITLE
[Impeller] Account for the backend-dependent space of rendered textures in gaussian blur

### DIFF
--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -138,6 +138,10 @@ bool DirectionalGaussianBlurFilterContents::RenderFilter(
   frame_info.mvp = Matrix::MakeOrthographic(ISize(1, 1));
 
   FS::FragInfo frag_info;
+  frag_info.texture_sampler_y_coord_scale =
+      input_snapshot->texture->GetYCoordScale();
+  frag_info.alpha_mask_sampler_y_coord_scale =
+      source_snapshot->texture->GetYCoordScale();
   frag_info.blur_sigma = transformed_blur.GetLength();
   frag_info.blur_radius = Radius{Sigma{frag_info.blur_sigma}}.radius;
   frag_info.blur_direction = input_snapshot->transform.Invert()

--- a/impeller/entity/shaders/gaussian_blur.frag
+++ b/impeller/entity/shaders/gaussian_blur.frag
@@ -20,6 +20,9 @@ uniform sampler2D texture_sampler;
 uniform sampler2D alpha_mask_sampler;
 
 uniform FragInfo {
+  float texture_sampler_y_coord_scale;
+  float alpha_mask_sampler_y_coord_scale;
+
   vec2 texture_size;
   vec2 blur_direction;
 
@@ -59,21 +62,21 @@ void main() {
     total_color +=
         gaussian *
         IPSampleWithTileMode(
-            texture_sampler,                        // sampler
-            v_texture_coords + blur_uv_offset * i,  // texture coordinates
-            1.0,                                    // y coordinate scale
-            frag_info.tile_mode                     // tile mode
+            texture_sampler,                          // sampler
+            v_texture_coords + blur_uv_offset * i,    // texture coordinates
+            frag_info.texture_sampler_y_coord_scale,  // y coordinate scale
+            frag_info.tile_mode                       // tile mode
         );
   }
 
   vec4 blur_color = total_color / gaussian_integral;
 
-  vec4 src_color =
-      IPSampleWithTileMode(alpha_mask_sampler,    // sampler
-                           v_src_texture_coords,  // texture coordinates
-                           1.0,                   // y coordinate scale
-                           frag_info.tile_mode    // tile mode
-      );
+  vec4 src_color = IPSampleWithTileMode(
+      alpha_mask_sampler,                          // sampler
+      v_src_texture_coords,                        // texture coordinates
+      frag_info.alpha_mask_sampler_y_coord_scale,  // y coordinate scale
+      frag_info.tile_mode                          // tile mode
+  );
   float blur_factor = frag_info.inner_blur_factor * float(src_color.a > 0) +
                       frag_info.outer_blur_factor * float(src_color.a == 0);
 


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/105053.

The issue isn't visible in the regular 2 pass blur, so I added a 1 pass (directional) mode to the playground. However, this also fixes a less common bug in the 2 pass gaussian: Since the alpha mask in the second pass will be inverted, blur inputs with a non-symmetrical alpha mask in the Y direction didn't render correctly prior to this change.

Before:
![image](https://user-images.githubusercontent.com/919017/183570736-e559ddc8-2ecd-4ffd-bf06-a28fdcf9b393.png)


After:
![image](https://user-images.githubusercontent.com/919017/183570882-4e83be82-8500-4581-a357-d2db2b169f06.png)

