### PR TITLE
[Impeller] Cleanup Context API.

### DIFF
--- a/impeller/entity/contents/content_context.cc
+++ b/impeller/entity/contents/content_context.cc
@@ -243,7 +243,7 @@ std::shared_ptr<Texture> ContentContext::MakeSubpass(
     return nullptr;
   }
 
-  auto sub_command_buffer = context->CreateRenderCommandBuffer();
+  auto sub_command_buffer = context->CreateCommandBuffer();
   sub_command_buffer->SetLabel("Offscreen Contents Command Buffer");
   if (!sub_command_buffer) {
     return nullptr;
@@ -259,7 +259,7 @@ std::shared_ptr<Texture> ContentContext::MakeSubpass(
     return nullptr;
   }
 
-  if (!sub_renderpass->EncodeCommands(context->GetTransientsAllocator())) {
+  if (!sub_renderpass->EncodeCommands(context->GetResourceAllocator())) {
     return nullptr;
   }
 

--- a/impeller/entity/contents/vertices_contents.cc
+++ b/impeller/entity/contents/vertices_contents.cc
@@ -80,7 +80,7 @@ bool VerticesContents::Render(const ContentContext& renderer,
   size_t total_vtx_bytes = vertex_data.size() * sizeof(VS::PerVertexData);
   size_t total_idx_bytes = vertices_.GetIndices().size() * sizeof(uint16_t);
 
-  auto buffer = renderer.GetContext()->GetTransientsAllocator()->CreateBuffer(
+  auto buffer = renderer.GetContext()->GetResourceAllocator()->CreateBuffer(
       StorageMode::kHostVisible, total_vtx_bytes + total_idx_bytes);
 
   if (!buffer->CopyHostBuffer(reinterpret_cast<uint8_t*>(vertex_data.data()),

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -154,7 +154,7 @@ bool EntityPass::Render(ContentContext& renderer,
       return false;
     }
 
-    auto command_buffer = renderer.GetContext()->CreateRenderCommandBuffer();
+    auto command_buffer = renderer.GetContext()->CreateCommandBuffer();
     command_buffer->SetLabel("EntityPass Root Command Buffer");
     auto render_pass = command_buffer->CreateRenderPass(render_target);
     render_pass->SetLabel("EntityPass Root Render Pass");
@@ -174,7 +174,7 @@ bool EntityPass::Render(ContentContext& renderer,
     }
 
     if (!render_pass->EncodeCommands(
-            renderer.GetContext()->GetTransientsAllocator())) {
+            renderer.GetContext()->GetResourceAllocator())) {
       return false;
     }
     if (!command_buffer->SubmitCommands()) {

--- a/impeller/entity/inline_pass_context.cc
+++ b/impeller/entity/inline_pass_context.cc
@@ -37,7 +37,7 @@ bool InlinePassContext::EndPass() {
     return true;
   }
 
-  if (!pass_->EncodeCommands(context_->GetTransientsAllocator())) {
+  if (!pass_->EncodeCommands(context_->GetResourceAllocator())) {
     return false;
   }
 
@@ -59,7 +59,7 @@ std::shared_ptr<RenderPass> InlinePassContext::GetRenderPass(
     uint32_t pass_depth) {
   // Create a new render pass if one isn't active.
   if (!IsActive()) {
-    command_buffer_ = context_->CreateRenderCommandBuffer();
+    command_buffer_ = context_->CreateCommandBuffer();
     if (!command_buffer_) {
       return nullptr;
     }

--- a/impeller/playground/imgui/imgui_impl_impeller.cc
+++ b/impeller/playground/imgui/imgui_impl_impeller.cc
@@ -74,7 +74,7 @@ bool ImGui_ImplImpeller_Init(std::shared_ptr<impeller::Context> context) {
     texture_descriptor.size = {width, height};
     texture_descriptor.mip_count = 1u;
 
-    bd->font_texture = context->GetPermanentsAllocator()->CreateTexture(
+    bd->font_texture = context->GetResourceAllocator()->CreateTexture(
         impeller::StorageMode::kHostVisible, texture_descriptor);
     IM_ASSERT(bd->font_texture != nullptr &&
               "Could not allocate ImGui font texture.");
@@ -136,7 +136,7 @@ void ImGui_ImplImpeller_RenderDrawData(ImDrawData* draw_data,
   }
 
   // Allocate buffer for vertices + indices.
-  auto buffer = bd->context->GetTransientsAllocator()->CreateBuffer(
+  auto buffer = bd->context->GetResourceAllocator()->CreateBuffer(
       impeller::StorageMode::kHostVisible, total_vtx_bytes + total_idx_bytes);
   buffer->SetLabel(impeller::SPrintF("ImGui vertex+index buffer"));
 

--- a/impeller/playground/playground.cc
+++ b/impeller/playground/playground.cc
@@ -224,7 +224,7 @@ bool Playground::OpenPlaygroundHere(Renderer::RenderCallback render_callback) {
 
       // Render ImGui overlay.
       {
-        auto buffer = renderer->GetContext()->CreateRenderCommandBuffer();
+        auto buffer = renderer->GetContext()->CreateCommandBuffer();
         if (!buffer) {
           return false;
         }
@@ -244,7 +244,7 @@ bool Playground::OpenPlaygroundHere(Renderer::RenderCallback render_callback) {
 
         ImGui_ImplImpeller_RenderDrawData(ImGui::GetDrawData(), *pass);
 
-        pass->EncodeCommands(renderer->GetContext()->GetTransientsAllocator());
+        pass->EncodeCommands(renderer->GetContext()->GetResourceAllocator());
         if (!buffer->SubmitCommands()) {
           return false;
         }
@@ -268,7 +268,7 @@ bool Playground::OpenPlaygroundHere(Renderer::RenderCallback render_callback) {
 bool Playground::OpenPlaygroundHere(SinglePassCallback pass_callback) {
   return OpenPlaygroundHere(
       [context = GetContext(), &pass_callback](RenderTarget& render_target) {
-        auto buffer = context->CreateRenderCommandBuffer();
+        auto buffer = context->CreateCommandBuffer();
         if (!buffer) {
           return false;
         }
@@ -284,7 +284,7 @@ bool Playground::OpenPlaygroundHere(SinglePassCallback pass_callback) {
           return false;
         }
 
-        pass->EncodeCommands(context->GetTransientsAllocator());
+        pass->EncodeCommands(context->GetResourceAllocator());
         if (!buffer->SubmitCommands()) {
           return false;
         }
@@ -332,9 +332,8 @@ std::shared_ptr<Texture> Playground::CreateTextureForFixture(
   texture_descriptor.mip_count =
       enable_mipmapping ? image->GetSize().MipCount() : 1u;
 
-  auto texture =
-      renderer_->GetContext()->GetPermanentsAllocator()->CreateTexture(
-          StorageMode::kHostVisible, texture_descriptor);
+  auto texture = renderer_->GetContext()->GetResourceAllocator()->CreateTexture(
+      StorageMode::kHostVisible, texture_descriptor);
   if (!texture) {
     VALIDATION_LOG << "Could not allocate texture for fixture " << fixture_name;
     return nullptr;
@@ -367,9 +366,8 @@ std::shared_ptr<Texture> Playground::CreateTextureCubeForFixture(
   texture_descriptor.size = images[0].GetSize();
   texture_descriptor.mip_count = 1u;
 
-  auto texture =
-      renderer_->GetContext()->GetPermanentsAllocator()->CreateTexture(
-          StorageMode::kHostVisible, texture_descriptor);
+  auto texture = renderer_->GetContext()->GetResourceAllocator()->CreateTexture(
+      StorageMode::kHostVisible, texture_descriptor);
   if (!texture) {
     VALIDATION_LOG << "Could not allocate texture cube.";
     return nullptr;

--- a/impeller/renderer/backend/gles/context_gles.cc
+++ b/impeller/renderer/backend/gles/context_gles.cc
@@ -42,19 +42,12 @@ ContextGLES::ContextGLES(
         std::shared_ptr<PipelineLibraryGLES>(new PipelineLibraryGLES(reactor_));
   }
 
-  // Create all allocators.
+  // Create allocators.
   {
-    permanents_allocator_ =
+    resource_allocator_ =
         std::shared_ptr<AllocatorGLES>(new AllocatorGLES(reactor_));
-    if (!permanents_allocator_->IsValid()) {
-      VALIDATION_LOG << "Could not create permanents allocator.";
-      return;
-    }
-
-    transients_allocator_ =
-        std::shared_ptr<AllocatorGLES>(new AllocatorGLES(reactor_));
-    if (!transients_allocator_->IsValid()) {
-      VALIDATION_LOG << "Could not create transients allocator.";
+    if (!resource_allocator_->IsValid()) {
+      VALIDATION_LOG << "Could not create a resource allocator.";
       return;
     }
   }
@@ -93,12 +86,8 @@ bool ContextGLES::IsValid() const {
   return is_valid_;
 }
 
-std::shared_ptr<Allocator> ContextGLES::GetPermanentsAllocator() const {
-  return permanents_allocator_;
-}
-
-std::shared_ptr<Allocator> ContextGLES::GetTransientsAllocator() const {
-  return transients_allocator_;
+std::shared_ptr<Allocator> ContextGLES::GetResourceAllocator() const {
+  return resource_allocator_;
 }
 
 std::shared_ptr<ShaderLibrary> ContextGLES::GetShaderLibrary() const {
@@ -113,14 +102,8 @@ std::shared_ptr<PipelineLibrary> ContextGLES::GetPipelineLibrary() const {
   return pipeline_library_;
 }
 
-std::shared_ptr<CommandBuffer> ContextGLES::CreateRenderCommandBuffer() const {
+std::shared_ptr<CommandBuffer> ContextGLES::CreateCommandBuffer() const {
   return std::shared_ptr<CommandBufferGLES>(new CommandBufferGLES(reactor_));
-}
-
-std::shared_ptr<CommandBuffer> ContextGLES::CreateTransferCommandBuffer()
-    const {
-  // There is no such concept. Just use a render command buffer.
-  return CreateRenderCommandBuffer();
 }
 
 // |Context|

--- a/impeller/renderer/backend/gles/context_gles.h
+++ b/impeller/renderer/backend/gles/context_gles.h
@@ -38,8 +38,7 @@ class ContextGLES final : public Context,
   std::shared_ptr<ShaderLibraryGLES> shader_library_;
   std::shared_ptr<PipelineLibraryGLES> pipeline_library_;
   std::shared_ptr<SamplerLibraryGLES> sampler_library_;
-  std::shared_ptr<AllocatorGLES> permanents_allocator_;
-  std::shared_ptr<AllocatorGLES> transients_allocator_;
+  std::shared_ptr<AllocatorGLES> resource_allocator_;
   bool is_valid_ = false;
 
   ContextGLES(std::unique_ptr<ProcTableGLES> gl,
@@ -49,10 +48,7 @@ class ContextGLES final : public Context,
   bool IsValid() const override;
 
   // |Context|
-  std::shared_ptr<Allocator> GetPermanentsAllocator() const override;
-
-  // |Context|
-  std::shared_ptr<Allocator> GetTransientsAllocator() const override;
+  std::shared_ptr<Allocator> GetResourceAllocator() const override;
 
   // |Context|
   std::shared_ptr<ShaderLibrary> GetShaderLibrary() const override;
@@ -64,10 +60,7 @@ class ContextGLES final : public Context,
   std::shared_ptr<PipelineLibrary> GetPipelineLibrary() const override;
 
   // |Context|
-  std::shared_ptr<CommandBuffer> CreateRenderCommandBuffer() const override;
-
-  // |Context|
-  std::shared_ptr<CommandBuffer> CreateTransferCommandBuffer() const override;
+  std::shared_ptr<CommandBuffer> CreateCommandBuffer() const override;
 
   // |Context|
   bool HasThreadingRestrictions() const override;

--- a/impeller/renderer/backend/metal/context_mtl.h
+++ b/impeller/renderer/backend/metal/context_mtl.h
@@ -37,13 +37,11 @@ class ContextMTL final : public Context,
 
  private:
   id<MTLDevice> device_ = nullptr;
-  id<MTLCommandQueue> render_queue_ = nullptr;
-  id<MTLCommandQueue> transfer_queue_ = nullptr;
+  id<MTLCommandQueue> command_queue_ = nullptr;
   std::shared_ptr<ShaderLibraryMTL> shader_library_;
   std::shared_ptr<PipelineLibraryMTL> pipeline_library_;
   std::shared_ptr<SamplerLibrary> sampler_library_;
-  std::shared_ptr<AllocatorMTL> permanents_allocator_;
-  std::shared_ptr<AllocatorMTL> transients_allocator_;
+  std::shared_ptr<AllocatorMTL> resource_allocator_;
   bool is_valid_ = false;
 
   ContextMTL(id<MTLDevice> device, NSArray<id<MTLLibrary>>* shader_libraries);
@@ -52,10 +50,7 @@ class ContextMTL final : public Context,
   bool IsValid() const override;
 
   // |Context|
-  std::shared_ptr<Allocator> GetPermanentsAllocator() const override;
-
-  // |Context|
-  std::shared_ptr<Allocator> GetTransientsAllocator() const override;
+  std::shared_ptr<Allocator> GetResourceAllocator() const override;
 
   // |Context|
   std::shared_ptr<ShaderLibrary> GetShaderLibrary() const override;
@@ -67,10 +62,7 @@ class ContextMTL final : public Context,
   std::shared_ptr<PipelineLibrary> GetPipelineLibrary() const override;
 
   // |Context|
-  std::shared_ptr<CommandBuffer> CreateRenderCommandBuffer() const override;
-
-  // |Context|
-  std::shared_ptr<CommandBuffer> CreateTransferCommandBuffer() const override;
+  std::shared_ptr<CommandBuffer> CreateCommandBuffer() const override;
 
   std::shared_ptr<CommandBuffer> CreateCommandBufferInQueue(
       id<MTLCommandQueue> queue) const;

--- a/impeller/renderer/backend/metal/context_mtl.mm
+++ b/impeller/renderer/backend/metal/context_mtl.mm
@@ -41,15 +41,13 @@ ContextMTL::ContextMTL(id<MTLDevice> device,
   }
 
   // Setup command queues.
-  render_queue_ = device_.newCommandQueue;
-  transfer_queue_ = device_.newCommandQueue;
+  command_queue_ = device_.newCommandQueue;
 
-  if (!render_queue_ || !transfer_queue_) {
+  if (!command_queue_) {
     return;
   }
 
-  render_queue_.label = @"Impeller Render Queue";
-  transfer_queue_.label = @"Impeller Transfer Queue";
+  command_queue_.label = @"Impeller Command Queue";
 
   // Setup the pipeline library.
   {  //
@@ -64,15 +62,9 @@ ContextMTL::ContextMTL(id<MTLDevice> device,
   }
 
   {
-    transients_allocator_ = std::shared_ptr<AllocatorMTL>(
-        new AllocatorMTL(device_, "Impeller Transients Allocator"));
-    if (!transients_allocator_) {
-      return;
-    }
-
-    permanents_allocator_ = std::shared_ptr<AllocatorMTL>(
+    resource_allocator_ = std::shared_ptr<AllocatorMTL>(
         new AllocatorMTL(device_, "Impeller Permanents Allocator"));
-    if (!permanents_allocator_) {
+    if (!resource_allocator_) {
       return;
     }
   }
@@ -191,12 +183,8 @@ std::shared_ptr<SamplerLibrary> ContextMTL::GetSamplerLibrary() const {
   return sampler_library_;
 }
 
-std::shared_ptr<CommandBuffer> ContextMTL::CreateRenderCommandBuffer() const {
-  return CreateCommandBufferInQueue(render_queue_);
-}
-
-std::shared_ptr<CommandBuffer> ContextMTL::CreateTransferCommandBuffer() const {
-  return CreateCommandBufferInQueue(transfer_queue_);
+std::shared_ptr<CommandBuffer> ContextMTL::CreateCommandBuffer() const {
+  return CreateCommandBufferInQueue(command_queue_);
 }
 
 std::shared_ptr<CommandBuffer> ContextMTL::CreateCommandBufferInQueue(
@@ -212,12 +200,8 @@ std::shared_ptr<CommandBuffer> ContextMTL::CreateCommandBufferInQueue(
   return buffer;
 }
 
-std::shared_ptr<Allocator> ContextMTL::GetPermanentsAllocator() const {
-  return permanents_allocator_;
-}
-
-std::shared_ptr<Allocator> ContextMTL::GetTransientsAllocator() const {
-  return transients_allocator_;
+std::shared_ptr<Allocator> ContextMTL::GetResourceAllocator() const {
+  return resource_allocator_;
 }
 
 id<MTLDevice> ContextMTL::GetMTLDevice() const {

--- a/impeller/renderer/backend/metal/surface_mtl.mm
+++ b/impeller/renderer/backend/metal/surface_mtl.mm
@@ -52,7 +52,7 @@ std::unique_ptr<Surface> SurfaceMTL::WrapCurrentMetalLayerDrawable(
       static_cast<ISize::Type>(current_drawable.texture.height)};
   color0_tex_desc.usage = static_cast<uint64_t>(TextureUsage::kRenderTarget);
 
-  auto msaa_tex = context->GetPermanentsAllocator()->CreateTexture(
+  auto msaa_tex = context->GetResourceAllocator()->CreateTexture(
       StorageMode::kDeviceTransient, color0_tex_desc);
   if (!msaa_tex) {
     VALIDATION_LOG << "Could not allocate MSAA resolve texture.";
@@ -82,7 +82,7 @@ std::unique_ptr<Surface> SurfaceMTL::WrapCurrentMetalLayerDrawable(
   stencil0_tex.size = color0_tex_desc.size;
   stencil0_tex.usage =
       static_cast<TextureUsageMask>(TextureUsage::kRenderTarget);
-  auto stencil_texture = context->GetPermanentsAllocator()->CreateTexture(
+  auto stencil_texture = context->GetResourceAllocator()->CreateTexture(
       StorageMode::kDeviceTransient, stencil0_tex);
 
   if (!stencil_texture) {

--- a/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/impeller/renderer/backend/vulkan/context_vk.cc
@@ -410,11 +410,7 @@ bool ContextVK::IsValid() const {
   return is_valid_;
 }
 
-std::shared_ptr<Allocator> ContextVK::GetPermanentsAllocator() const {
-  return allocator_;
-}
-
-std::shared_ptr<Allocator> ContextVK::GetTransientsAllocator() const {
+std::shared_ptr<Allocator> ContextVK::GetResourceAllocator() const {
   return allocator_;
 }
 
@@ -430,11 +426,7 @@ std::shared_ptr<PipelineLibrary> ContextVK::GetPipelineLibrary() const {
   return pipeline_library_;
 }
 
-std::shared_ptr<CommandBuffer> ContextVK::CreateRenderCommandBuffer() const {
-  FML_UNREACHABLE();
-}
-
-std::shared_ptr<CommandBuffer> ContextVK::CreateTransferCommandBuffer() const {
+std::shared_ptr<CommandBuffer> ContextVK::CreateCommandBuffer() const {
   FML_UNREACHABLE();
 }
 

--- a/impeller/renderer/backend/vulkan/context_vk.h
+++ b/impeller/renderer/backend/vulkan/context_vk.h
@@ -83,10 +83,7 @@ class ContextVK final : public Context, public BackendCast<ContextVK, Context> {
       const std::string& label);
 
   // |Context|
-  std::shared_ptr<Allocator> GetPermanentsAllocator() const override;
-
-  // |Context|
-  std::shared_ptr<Allocator> GetTransientsAllocator() const override;
+  std::shared_ptr<Allocator> GetResourceAllocator() const override;
 
   // |Context|
   std::shared_ptr<ShaderLibrary> GetShaderLibrary() const override;
@@ -98,10 +95,7 @@ class ContextVK final : public Context, public BackendCast<ContextVK, Context> {
   std::shared_ptr<PipelineLibrary> GetPipelineLibrary() const override;
 
   // |Context|
-  std::shared_ptr<CommandBuffer> CreateRenderCommandBuffer() const override;
-
-  // |Context|
-  std::shared_ptr<CommandBuffer> CreateTransferCommandBuffer() const override;
+  std::shared_ptr<CommandBuffer> CreateCommandBuffer() const override;
 
   FML_DISALLOW_COPY_AND_ASSIGN(ContextVK);
 };

--- a/impeller/renderer/context.h
+++ b/impeller/renderer/context.h
@@ -24,16 +24,9 @@ class Context {
   virtual bool IsValid() const = 0;
 
   //----------------------------------------------------------------------------
-  /// @return     An allocator suitable for allocations that persist between
-  ///             frames.
+  /// @return     A resource allocator.
   ///
-  virtual std::shared_ptr<Allocator> GetPermanentsAllocator() const = 0;
-
-  //----------------------------------------------------------------------------
-  /// @return     An allocator suitable for allocations that used only for one
-  ///             frame or render pass.
-  ///
-  virtual std::shared_ptr<Allocator> GetTransientsAllocator() const = 0;
+  virtual std::shared_ptr<Allocator> GetResourceAllocator() const = 0;
 
   virtual std::shared_ptr<ShaderLibrary> GetShaderLibrary() const = 0;
 
@@ -41,10 +34,7 @@ class Context {
 
   virtual std::shared_ptr<PipelineLibrary> GetPipelineLibrary() const = 0;
 
-  virtual std::shared_ptr<CommandBuffer> CreateRenderCommandBuffer() const = 0;
-
-  virtual std::shared_ptr<CommandBuffer> CreateTransferCommandBuffer()
-      const = 0;
+  virtual std::shared_ptr<CommandBuffer> CreateCommandBuffer() const = 0;
 
   virtual bool HasThreadingRestrictions() const;
 

--- a/impeller/renderer/render_target.cc
+++ b/impeller/renderer/render_target.cc
@@ -204,7 +204,7 @@ RenderTarget RenderTarget::CreateOffscreen(const Context& context,
   color0.clear_color = Color::BlackTransparent();
   color0.load_action = color_load_action;
   color0.store_action = color_store_action;
-  color0.texture = context.GetPermanentsAllocator()->CreateTexture(
+  color0.texture = context.GetResourceAllocator()->CreateTexture(
       color_storage_mode, color_tex0);
 
   if (!color0.texture) {
@@ -217,7 +217,7 @@ RenderTarget RenderTarget::CreateOffscreen(const Context& context,
   stencil0.load_action = stencil_load_action;
   stencil0.store_action = stencil_store_action;
   stencil0.clear_stencil = 0u;
-  stencil0.texture = context.GetPermanentsAllocator()->CreateTexture(
+  stencil0.texture = context.GetResourceAllocator()->CreateTexture(
       stencil_storage_mode, stencil_tex0);
 
   if (!stencil0.texture) {

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -66,7 +66,7 @@ TEST_P(RendererTest, CanCreateBoxPrimitive) {
       {{100, 800, 0.0}, {0.0, 1.0}},  // 4
   });
   auto vertex_buffer =
-      vertex_builder.CreateVertexBuffer(*context->GetPermanentsAllocator());
+      vertex_builder.CreateVertexBuffer(*context->GetResourceAllocator());
   ASSERT_TRUE(vertex_buffer);
 
   auto bridge = CreateTextureForFixture("bay_bridge.jpg");
@@ -145,9 +145,8 @@ TEST_P(RendererTest, CanRenderPerspectiveCube) {
 
   VertexBuffer vertex_buffer;
   {
-    auto device_buffer =
-        context->GetPermanentsAllocator()->CreateBufferWithCopy(
-            reinterpret_cast<uint8_t*>(&cube), sizeof(cube));
+    auto device_buffer = context->GetResourceAllocator()->CreateBufferWithCopy(
+        reinterpret_cast<uint8_t*>(&cube), sizeof(cube));
     vertex_buffer.vertex_buffer = {
         .buffer = device_buffer,
         .range = Range(offsetof(Cube, vertices), sizeof(Cube::vertices))};
@@ -231,7 +230,7 @@ TEST_P(RendererTest, CanRenderMultiplePrimitives) {
       {{100, 800, 0.0}, {0.0, 1.0}},  // 4
   });
   auto vertex_buffer =
-      vertex_builder.CreateVertexBuffer(*context->GetPermanentsAllocator());
+      vertex_builder.CreateVertexBuffer(*context->GetResourceAllocator());
   ASSERT_TRUE(vertex_buffer);
 
   auto bridge = CreateTextureForFixture("bay_bridge.jpg");
@@ -303,7 +302,7 @@ TEST_P(RendererTest, CanRenderToTexture) {
       {{100, 800, 0.0}, {0.0, 1.0}},  // 4
   });
   auto vertex_buffer =
-      vertex_builder.CreateVertexBuffer(*context->GetPermanentsAllocator());
+      vertex_builder.CreateVertexBuffer(*context->GetResourceAllocator());
   ASSERT_TRUE(vertex_buffer);
 
   auto bridge = CreateTextureForFixture("bay_bridge.jpg");
@@ -328,7 +327,7 @@ TEST_P(RendererTest, CanRenderToTexture) {
     texture_descriptor.usage =
         static_cast<TextureUsageMask>(TextureUsage::kRenderTarget);
 
-    color0.texture = context->GetPermanentsAllocator()->CreateTexture(
+    color0.texture = context->GetResourceAllocator()->CreateTexture(
         StorageMode::kHostVisible, texture_descriptor);
 
     ASSERT_TRUE(color0);
@@ -343,13 +342,13 @@ TEST_P(RendererTest, CanRenderToTexture) {
     stencil_texture_desc.format = PixelFormat::kS8UInt;
     stencil_texture_desc.usage =
         static_cast<TextureUsageMask>(TextureUsage::kRenderTarget);
-    stencil0.texture = context->GetPermanentsAllocator()->CreateTexture(
+    stencil0.texture = context->GetResourceAllocator()->CreateTexture(
         StorageMode::kDeviceTransient, stencil_texture_desc);
 
     RenderTarget r2t_desc;
     r2t_desc.SetColorAttachment(color0, 0u);
     r2t_desc.SetStencilAttachment(stencil0);
-    auto cmd_buffer = context->CreateRenderCommandBuffer();
+    auto cmd_buffer = context->CreateCommandBuffer();
     r2t_pass = cmd_buffer->CreateRenderPass(r2t_desc);
     ASSERT_TRUE(r2t_pass && r2t_pass->IsValid());
   }
@@ -379,7 +378,7 @@ TEST_P(RendererTest, CanRenderToTexture) {
   VS::BindUniformBuffer(
       cmd, r2t_pass->GetTransientsBuffer().EmplaceUniform(uniforms));
   ASSERT_TRUE(r2t_pass->AddCommand(std::move(cmd)));
-  ASSERT_TRUE(r2t_pass->EncodeCommands(context->GetTransientsAllocator()));
+  ASSERT_TRUE(r2t_pass->EncodeCommands(context->GetResourceAllocator()));
 }
 
 #if IMPELLER_ENABLE_METAL
@@ -465,7 +464,7 @@ TEST_P(RendererTest, CanBlitTextureToTexture) {
   texture_desc.usage =
       static_cast<TextureUsageMask>(TextureUsage::kRenderTarget) |
       static_cast<TextureUsageMask>(TextureUsage::kShaderRead);
-  auto texture = context->GetPermanentsAllocator()->CreateTexture(
+  auto texture = context->GetResourceAllocator()->CreateTexture(
       StorageMode::kHostVisible, texture_desc);
   ASSERT_TRUE(texture);
 
@@ -488,11 +487,11 @@ TEST_P(RendererTest, CanBlitTextureToTexture) {
       {{0, size.y}, {0.0, 1.0}},       // 4
   });
   auto vertex_buffer =
-      vertex_builder.CreateVertexBuffer(*context->GetTransientsAllocator());
+      vertex_builder.CreateVertexBuffer(*context->GetResourceAllocator());
   ASSERT_TRUE(vertex_buffer);
 
   Renderer::RenderCallback callback = [&](RenderTarget& render_target) {
-    auto buffer = context->CreateRenderCommandBuffer();
+    auto buffer = context->CreateCommandBuffer();
     if (!buffer) {
       return false;
     }
@@ -512,7 +511,7 @@ TEST_P(RendererTest, CanBlitTextureToTexture) {
       // Blit `bridge` to the top left corner of the texture.
       pass->AddCopy(bridge, texture);
 
-      pass->EncodeCommands(context->GetTransientsAllocator());
+      pass->EncodeCommands(context->GetResourceAllocator());
     }
 
     {
@@ -544,7 +543,7 @@ TEST_P(RendererTest, CanBlitTextureToTexture) {
 
         pass->AddCommand(std::move(cmd));
       }
-      pass->EncodeCommands(context->GetTransientsAllocator());
+      pass->EncodeCommands(context->GetResourceAllocator());
     }
 
     if (!buffer->SubmitCommands()) {
@@ -584,7 +583,7 @@ TEST_P(RendererTest, CanGenerateMipmaps) {
       {{0, size.y}, {0.0, 1.0}},       // 4
   });
   auto vertex_buffer =
-      vertex_builder.CreateVertexBuffer(*context->GetPermanentsAllocator());
+      vertex_builder.CreateVertexBuffer(*context->GetResourceAllocator());
   ASSERT_TRUE(vertex_buffer);
 
   bool first_frame = true;
@@ -613,7 +612,7 @@ TEST_P(RendererTest, CanGenerateMipmaps) {
     ImGui::SliderFloat("LOD", &lod, 0, boston->GetMipCount() - 1);
     ImGui::End();
 
-    auto buffer = context->CreateRenderCommandBuffer();
+    auto buffer = context->CreateCommandBuffer();
     if (!buffer) {
       return false;
     }
@@ -628,7 +627,7 @@ TEST_P(RendererTest, CanGenerateMipmaps) {
 
       pass->GenerateMipmap(boston, "Boston Mipmap");
 
-      pass->EncodeCommands(context->GetTransientsAllocator());
+      pass->EncodeCommands(context->GetResourceAllocator());
     }
 
     first_frame = false;
@@ -665,7 +664,7 @@ TEST_P(RendererTest, CanGenerateMipmaps) {
 
         pass->AddCommand(std::move(cmd));
       }
-      pass->EncodeCommands(context->GetTransientsAllocator());
+      pass->EncodeCommands(context->GetResourceAllocator());
     }
 
     if (!buffer->SubmitCommands()) {

--- a/impeller/typographer/backends/skia/text_render_context_skia.cc
+++ b/impeller/typographer/backends/skia/text_render_context_skia.cc
@@ -248,7 +248,7 @@ std::shared_ptr<GlyphAtlas> TextRenderContextSkia::CreateGlyphAtlas(
   // ---------------------------------------------------------------------------
   // Step 6: Upload the atlas as a texture.
   // ---------------------------------------------------------------------------
-  auto texture = UploadGlyphTextureAtlas(GetContext()->GetTransientsAllocator(),
+  auto texture = UploadGlyphTextureAtlas(GetContext()->GetResourceAllocator(),
                                          bitmap, atlas_size);
   if (!texture) {
     return nullptr;

--- a/lib/ui/painting/image_decoder_impeller.cc
+++ b/lib/ui/painting/image_decoder_impeller.cc
@@ -149,7 +149,7 @@ static sk_sp<DlImage> UploadTexture(std::shared_ptr<impeller::Context> context,
   texture_descriptor.format = pixel_format.value();
   texture_descriptor.size = {image_info.width(), image_info.height()};
 
-  auto texture = context->GetPermanentsAllocator()->CreateTexture(
+  auto texture = context->GetResourceAllocator()->CreateTexture(
       impeller::StorageMode::kHostVisible, texture_descriptor);
   if (!texture) {
     FML_DLOG(ERROR) << "Could not create Impeller texture.";


### PR DESCRIPTION
The concept of separate allocators and queues was used early on in the
prototype. Cleanup the unused API variants and make impeller::Context simpler.