### PR TITLE
Support custom entrypoints in public Windows API

### DIFF
--- a/shell/platform/windows/accessibility_bridge_delegate_windows_unittests.cc
+++ b/shell/platform/windows/accessibility_bridge_delegate_windows_unittests.cc
@@ -86,7 +86,7 @@ std::unique_ptr<FlutterWindowsEngine> GetTestEngine() {
   MockEmbedderApiForKeyboard(modifier,
                              std::make_shared<MockKeyResponseController>());
 
-  engine->RunWithEntrypoint(nullptr);
+  engine->Run();
   return engine;
 }
 

--- a/shell/platform/windows/client_wrapper/flutter_engine.cc
+++ b/shell/platform/windows/client_wrapper/flutter_engine.cc
@@ -16,6 +16,7 @@ FlutterEngine::FlutterEngine(const DartProject& project) {
   c_engine_properties.assets_path = project.assets_path().c_str();
   c_engine_properties.icu_data_path = project.icu_data_path().c_str();
   c_engine_properties.aot_library_path = project.aot_library_path().c_str();
+  c_engine_properties.dart_entrypoint = project.dart_entrypoint().c_str();
 
   const std::vector<std::string>& entrypoint_args =
       project.dart_entrypoint_arguments();
@@ -38,6 +39,10 @@ FlutterEngine::FlutterEngine(const DartProject& project) {
 
 FlutterEngine::~FlutterEngine() {
   ShutDown();
+}
+
+bool FlutterEngine::Run() {
+  return Run(nullptr);
 }
 
 bool FlutterEngine::Run(const char* entry_point) {

--- a/shell/platform/windows/client_wrapper/flutter_engine_unittests.cc
+++ b/shell/platform/windows/client_wrapper/flutter_engine_unittests.cc
@@ -86,6 +86,23 @@ TEST(FlutterEngineTest, CreateDestroy) {
   EXPECT_EQ(test_api->destroy_called(), true);
 }
 
+TEST(FlutterEngineTest, CreateDestroyWithCustomEntrypoint) {
+  testing::ScopedStubFlutterWindowsApi scoped_api_stub(
+      std::make_unique<TestFlutterWindowsApi>());
+  auto test_api = static_cast<TestFlutterWindowsApi*>(scoped_api_stub.stub());
+  {
+    DartProject project(L"fake/project/path");
+    project.set_dart_entrypoint("customEntrypoint");
+    FlutterEngine engine(project);
+    engine.Run();
+    EXPECT_EQ(test_api->create_called(), true);
+    EXPECT_EQ(test_api->run_called(), true);
+    EXPECT_EQ(test_api->destroy_called(), false);
+  }
+  // Destroying should implicitly shut down if it hasn't been done manually.
+  EXPECT_EQ(test_api->destroy_called(), true);
+}
+
 TEST(FlutterEngineTest, ExplicitShutDown) {
   testing::ScopedStubFlutterWindowsApi scoped_api_stub(
       std::make_unique<TestFlutterWindowsApi>());

--- a/shell/platform/windows/client_wrapper/include/flutter/dart_project.h
+++ b/shell/platform/windows/client_wrapper/include/flutter/dart_project.h
@@ -45,6 +45,20 @@ class DartProject {
 
   ~DartProject() = default;
 
+  // Sets the Dart entrypoint to the specified value.
+  //
+  // If not set, the default entrypoint (main) is used. Custom Dart entrypoints
+  // must be decorated with `@pragma('vm:entry-point')`.
+  void set_dart_entrypoint(const std::string& entrypoint) {
+    if (entrypoint.empty()) {
+      return;
+    }
+    dart_entrypoint_ = entrypoint;
+  }
+
+  // Returns the Dart entrypoint.
+  const std::string& dart_entrypoint() const { return dart_entrypoint_; }
+
   // Sets the command line arguments that should be passed to the Dart
   // entrypoint.
   void set_dart_entrypoint_arguments(std::vector<std::string> arguments) {
@@ -77,6 +91,8 @@ class DartProject {
   // The path to the AOT library. This will always return a path, but non-AOT
   // builds will not be expected to actually have a library at that path.
   std::wstring aot_library_path_;
+  // The Dart entrypoint to launch.
+  std::string dart_entrypoint_;
   // The list of arguments to pass through to the Dart entrypoint.
   std::vector<std::string> dart_entrypoint_arguments_;
 };

--- a/shell/platform/windows/client_wrapper/include/flutter/flutter_engine.h
+++ b/shell/platform/windows/client_wrapper/include/flutter/flutter_engine.h
@@ -35,13 +35,17 @@ class FlutterEngine : public PluginRegistry {
   FlutterEngine(FlutterEngine const&) = delete;
   FlutterEngine& operator=(FlutterEngine const&) = delete;
 
+  // Starts running the engine at the entrypoint function specified in the
+  // DartProject used to configure the engine, or main() by default.
+  bool Run();
+
   // Starts running the engine, with an optional entry point.
   //
   // If provided, entry_point must be the name of a top-level function from the
   // same Dart library that contains the app's main() function, and must be
   // decorated with `@pragma(vm:entry-point)` to ensure the method is not
   // tree-shaken by the Dart compiler. If not provided, defaults to main().
-  bool Run(const char* entry_point = nullptr);
+  bool Run(const char* entry_point);
 
   // Terminates the running engine.
   void ShutDown();

--- a/shell/platform/windows/fixtures/main.dart
+++ b/shell/platform/windows/fixtures/main.dart
@@ -3,5 +3,10 @@
 // found in the LICENSE file.
 
 void main() {
-  print('Hello windows engine test!');
+  print('Hello windows engine test main!');
+}
+
+@pragma('vm:entry-point')
+void customEntrypoint() {
+  print('Hello windows engine test customEntrypoint!');
 }

--- a/shell/platform/windows/flutter_project_bundle.cc
+++ b/shell/platform/windows/flutter_project_bundle.cc
@@ -20,6 +20,10 @@ FlutterProjectBundle::FlutterProjectBundle(
     aot_library_path_ = std::filesystem::path(properties.aot_library_path);
   }
 
+  if (properties.dart_entrypoint && properties.dart_entrypoint[0] != '\0') {
+    dart_entrypoint_ = properties.dart_entrypoint;
+  }
+
   for (int i = 0; i < properties.dart_entrypoint_argc; i++) {
     dart_entrypoint_arguments_.push_back(
         std::string(properties.dart_entrypoint_argv[i]));

--- a/shell/platform/windows/flutter_project_bundle.h
+++ b/shell/platform/windows/flutter_project_bundle.h
@@ -50,6 +50,9 @@ class FlutterProjectBundle {
   // Logs and returns nullptr on failure.
   UniqueAotDataPtr LoadAotData(const FlutterEngineProcTable& engine_procs);
 
+  // Returns the Dart entrypoint.
+  const std::string& dart_entrypoint() const { return dart_entrypoint_; }
+
   // Returns the command line arguments to be passed through to the Dart
   // entrypoint.
   const std::vector<std::string>& dart_entrypoint_arguments() const {
@@ -62,6 +65,9 @@ class FlutterProjectBundle {
 
   // Path to the AOT library file, if any.
   std::filesystem::path aot_library_path_;
+
+  // The Dart entrypoint to launch.
+  std::string dart_entrypoint_;
 
   // Dart entrypoint arguments.
   std::vector<std::string> dart_entrypoint_arguments_;

--- a/shell/platform/windows/flutter_windows.cc
+++ b/shell/platform/windows/flutter_windows.cc
@@ -78,7 +78,7 @@ FlutterDesktopViewControllerRef FlutterDesktopViewControllerCreate(
       std::unique_ptr<flutter::FlutterWindowsEngine>(EngineFromHandle(engine)));
   state->view->CreateRenderSurface();
   if (!state->view->GetEngine()->running()) {
-    if (!state->view->GetEngine()->RunWithEntrypoint(nullptr)) {
+    if (!state->view->GetEngine()->Run()) {
       return nullptr;
     }
   }
@@ -144,7 +144,7 @@ bool FlutterDesktopEngineDestroy(FlutterDesktopEngineRef engine_ref) {
 
 bool FlutterDesktopEngineRun(FlutterDesktopEngineRef engine,
                              const char* entry_point) {
-  return EngineFromHandle(engine)->RunWithEntrypoint(entry_point);
+  return EngineFromHandle(engine)->Run(entry_point);
 }
 
 uint64_t FlutterDesktopEngineProcessMessages(FlutterDesktopEngineRef engine) {

--- a/shell/platform/windows/flutter_windows_engine.h
+++ b/shell/platform/windows/flutter_windows_engine.h
@@ -9,6 +9,8 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <string>
+#include <string_view>
 #include <vector>
 
 #include "flutter/shell/platform/common/accessibility_bridge.h"
@@ -72,11 +74,22 @@ class FlutterWindowsEngine {
   FlutterWindowsEngine(FlutterWindowsEngine const&) = delete;
   FlutterWindowsEngine& operator=(FlutterWindowsEngine const&) = delete;
 
-  // Starts running the engine with the given entrypoint. If null, defaults to
-  // main().
+  // Starts running the entrypoint function specifed in the project bundle. If
+  // unspecified, defaults to main().
   //
   // Returns false if the engine couldn't be started.
-  bool RunWithEntrypoint(const char* entrypoint);
+  bool Run();
+
+  // Starts running the engine with the given entrypoint. If the empty string
+  // is specified, defaults to the entrypoint function specified in the project
+  // bundle, or main() if both are unspecified.
+  //
+  // Returns false if the engine couldn't be started or if conflicting,
+  // non-default values are passed here and in the project bundle..
+  //
+  // DEPRECATED: Prefer setting the entrypoint in the FlutterProjectBundle
+  // passed to the constructor and calling the no-parameter overload.
+  bool Run(std::string_view entrypoint);
 
   // Returns true if the engine is currently running.
   bool running() { return engine_ != nullptr; }

--- a/shell/platform/windows/flutter_windows_engine_unittests.cc
+++ b/shell/platform/windows/flutter_windows_engine_unittests.cc
@@ -129,7 +129,7 @@ TEST(FlutterWindowsEngine, RunDoesExpectedInitialization) {
   // Set the AngleSurfaceManager to !nullptr to test ANGLE rendering.
   modifier.SetSurfaceManager(reinterpret_cast<AngleSurfaceManager*>(1));
 
-  engine->RunWithEntrypoint(nullptr);
+  engine->Run();
 
   EXPECT_TRUE(run_called);
   EXPECT_TRUE(update_locales_called);
@@ -206,7 +206,7 @@ TEST(FlutterWindowsEngine, RunWithoutANGLEUsesSoftware) {
   // Set the AngleSurfaceManager to nullptr to test software fallback path.
   modifier.SetSurfaceManager(nullptr);
 
-  engine->RunWithEntrypoint(nullptr);
+  engine->Run();
 
   EXPECT_TRUE(run_called);
 
@@ -351,7 +351,7 @@ TEST(FlutterWindowsEngine, AddPluginRegistrarDestructionCallback) {
   MockEmbedderApiForKeyboard(modifier,
                              std::make_shared<MockKeyResponseController>());
 
-  engine->RunWithEntrypoint(nullptr);
+  engine->Run();
 
   // Verify that destruction handlers don't overwrite each other.
   int result1 = 0;

--- a/shell/platform/windows/flutter_windows_view_unittests.cc
+++ b/shell/platform/windows/flutter_windows_view_unittests.cc
@@ -90,7 +90,7 @@ std::unique_ptr<FlutterWindowsEngine> GetTestEngine() {
 
   MockEmbedderApiForKeyboard(modifier, key_response_controller);
 
-  engine->RunWithEntrypoint(nullptr);
+  engine->Run();
   return engine;
 }
 

--- a/shell/platform/windows/keyboard_unittests.cc
+++ b/shell/platform/windows/keyboard_unittests.cc
@@ -524,7 +524,7 @@ class KeyboardTester {
 
     MockEmbedderApiForKeyboard(modifier, key_response_controller);
 
-    engine->RunWithEntrypoint(nullptr);
+    engine->Run();
     return engine;
   }
 

--- a/shell/platform/windows/public/flutter_windows.h
+++ b/shell/platform/windows/public/flutter_windows.h
@@ -47,6 +47,14 @@ typedef struct {
   // it will be ignored in that case.
   const wchar_t* aot_library_path;
 
+  // The name of the top-level Dart entrypoint function. If null or the empty
+  // string, 'main' is assumed. If a custom entrypoint is used, this parameter
+  // must specifiy the name of a top-level function in the same Dart library as
+  // the app's main() function. Custom entrypoint functions must be decorated
+  // with `@pragma('vm:entry-point')` to ensure the method is not tree-shaken
+  // by the Dart compiler.
+  const char* dart_entrypoint;
+
   // Number of elements in the array passed in as dart_entrypoint_argv.
   int dart_entrypoint_argc;
 
@@ -129,13 +137,19 @@ FLUTTER_EXPORT FlutterDesktopEngineRef FlutterDesktopEngineCreate(
 // |engine| is no longer valid after this call.
 FLUTTER_EXPORT bool FlutterDesktopEngineDestroy(FlutterDesktopEngineRef engine);
 
-// Starts running the given engine instance and optional entry point in the Dart
-// project. If the entry point is null, defaults to main().
+// Starts running the given engine instance.
 //
-// If provided, entry_point must be the name of a top-level function from the
+// The entry_point parameter is deprecated but preserved for
+// backward-compatibility. If desired, a custom Dart entrypoint function can be
+// set in the dart_entrypoint field of the FlutterDesktopEngineProperties
+// struct passed to FlutterDesktopEngineCreate.
+//
+// If sprecified, entry_point must be the name of a top-level function from the
 // same Dart library that contains the app's main() function, and must be
 // decorated with `@pragma(vm:entry-point)` to ensure the method is not
-// tree-shaken by the Dart compiler.
+// tree-shaken by the Dart compiler. If conflicting non-null values are passed
+// to this function and via the FlutterDesktopEngineProperties struct, the run
+// will fail.
 //
 // Returns false if running the engine failed.
 FLUTTER_EXPORT bool FlutterDesktopEngineRun(FlutterDesktopEngineRef engine,

--- a/shell/platform/windows/testing/windows_test_config_builder.h
+++ b/shell/platform/windows/testing/windows_test_config_builder.h
@@ -52,22 +52,29 @@ class WindowsConfigBuilder {
   // Returns the desktop engine properties configured for this test.
   FlutterDesktopEngineProperties GetEngineProperties() const;
 
+  // Sets the Dart entrypoint to the specified value.
+  //
+  // If not set, the default entrypoint (main) is used. Custom Dart entrypoints
+  // must be decorated with `@pragma('vm:entry-point')`.
+  void SetDartEntrypoint(std::string_view entrypoint);
+
   // Adds an argument to the Dart entrypoint arguments List<String>.
   void AddDartEntrypointArgument(std::string_view arg);
 
+  // Returns a configured and initialized engine.
+  EnginePtr InitializeEngine() const;
+
   // Returns a configured and initialized view controller running the default
   // Dart entrypoint.
-  ViewControllerPtr LaunchEngine() const;
+  ViewControllerPtr Run() const;
 
  private:
   // Initialize COM, so that it is available for use in the library and/or
   // plugins.
   void InitializeCOM() const;
 
-  // Returns a configured and initialized engine.
-  EnginePtr InitializeEngine() const;
-
   WindowsTestContext& context_;
+  std::string dart_entrypoint_;
   std::vector<std::string> dart_entrypoint_arguments_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(WindowsConfigBuilder);


### PR DESCRIPTION
This adds a `dart_entrypoint` field to `FlutterDesktopEngineProperties` in
the public C Windows API, which mirrors that in the embedder API.

When a null or empty entrypoint is specified, a default entrypoint of
'main' is assumed. Otherwise, the app is launched at the top-level
function specified, which must be annotated with
`@pragma('vm:entry-point')` in the Dart source.

This change is backward-compatible for existing users of the Windows C API
and the C++ client wrapper API. To avoid breaking backward compatibility,
this patch preserves the `entry_point` parameter to `FlutterDesktopEngineRun`
in the public Windows C API as well as in the `FlutterEngine::Run` method
in the C++ client wrapper API. The entrypoint can be specified in either
the engine properties struct or via the parameter, but if conflicting
non-empty values are specified, the engine launch will intentionally fail
with an error message.

This change has no effect on existing Flutter Windows desktop apps and no
migration is required, because our app templates never specify a custom
entrypoint, nor was the option to specify one via the old method
particularly feasible, because the `FlutterViewController` class constructor
[immediately invokes](https://github.com/flutter/engine/blob/75e17f1a6f19ef96a9badf07b7b6c5527d867187/shell/platform/windows/client_wrapper/flutter_view_controller.cc#L16) `FlutterViewControllerCreate` which
[immediately launches](https://github.com/flutter/engine/blob/75e17f1a6f19ef96a9badf07b7b6c5527d867187/shell/platform/windows/flutter_windows.cc#L80-L83) the engine passed to it with a null entrypoint
argument, so long as the engine is not already running. However, running the
engine without a view controller previously resulted in errors due to failure to
create a rendering surface.

This is a followup patch to https://github.com/flutter/engine/pull/35273
which added support for running Dart fixture tests with a live Windows
embedder engine.

Fixes: https://github.com/flutter/flutter/issues/93537
Related: https://github.com/flutter/flutter/issues/87299

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
