### PR TITLE
[Impeller] Use the ES profile for shaderc ingestion

### DIFF
--- a/impeller/compiler/compiler.cc
+++ b/impeller/compiler/compiler.cc
@@ -252,12 +252,12 @@ Compiler::Compiler(const fml::Mapping& source_mapping,
   // here are irrelevant and get in the way of generating reflection code.
   spirv_options.SetGenerateDebugInfo();
 
-  // Expects GLSL 4.60 (Core Profile).
-  // https://www.khronos.org/registry/OpenGL/specs/gl/GLSLangSpec.4.60.pdf
+  // Expects GLSL ES 3.20.
+  // https://registry.khronos.org/OpenGL/specs/es/3.2/GLSL_ES_Specification_3.20.pdf
   spirv_options.SetSourceLanguage(
       shaderc_source_language::shaderc_source_language_glsl);
-  spirv_options.SetForcedVersionProfile(460,
-                                        shaderc_profile::shaderc_profile_core);
+  spirv_options.SetForcedVersionProfile(320,
+                                        shaderc_profile::shaderc_profile_es);
   SetLimitations(spirv_options);
 
   switch (source_options.target_platform) {

--- a/impeller/compiler/shader_lib/impeller/blending.glsl
+++ b/impeller/compiler/shader_lib/impeller/blending.glsl
@@ -24,11 +24,11 @@ vec3 IPClipColor(vec3 color) {
   float mx = max(max(color.r, color.g), color.b);
   // `lum - mn` and `mx - lum` will always be >= 0 in the following conditions,
   // so adding a tiny value is enough to make these divisions safe.
-  if (mn < 0) {
+  if (mn < 0.0) {
     color = lum + (((color - lum) * lum) / (lum - mn + kEhCloseEnough));
   }
-  if (mx > 1) {
-    color = lum + (((color - lum) * (1 - lum)) / (mx - lum + kEhCloseEnough));
+  if (mx > 1.0) {
+    color = lum + (((color - lum) * (1.0 - lum)) / (mx - lum + kEhCloseEnough));
   }
   return color;
 }
@@ -65,7 +65,8 @@ vec3 IPBlendScreen(vec3 dst, vec3 src) {
 
 vec3 IPBlendHardLight(vec3 dst, vec3 src) {
   // https://www.w3.org/TR/compositing-1/#blendinghardlight
-  return IPVec3Choose(dst * (2 * src), IPBlendScreen(dst, 2 * src - 1), src);
+  return IPVec3Choose(dst * (2.0 * src), IPBlendScreen(dst, 2.0 * src - 1.0),
+                      src);
 }
 
 vec3 IPBlendOverlay(vec3 dst, vec3 src) {
@@ -87,26 +88,26 @@ vec3 IPBlendLighten(vec3 dst, vec3 src) {
 vec3 IPBlendColorDodge(vec3 dst, vec3 src) {
   // https://www.w3.org/TR/compositing-1/#blendingcolordodge
 
-  vec3 color = min(vec3(1), dst / (1 - src));
+  vec3 color = min(vec3(1.0), dst / (1.0 - src));
 
   if (dst.r < kEhCloseEnough) {
-    color.r = 0;
+    color.r = 0.0;
   }
   if (dst.g < kEhCloseEnough) {
-    color.g = 0;
+    color.g = 0.0;
   }
   if (dst.b < kEhCloseEnough) {
-    color.b = 0;
+    color.b = 0.0;
   }
 
-  if (1 - src.r < kEhCloseEnough) {
-    color.r = 1;
+  if (1.0 - src.r < kEhCloseEnough) {
+    color.r = 1.0;
   }
-  if (1 - src.g < kEhCloseEnough) {
-    color.g = 1;
+  if (1.0 - src.g < kEhCloseEnough) {
+    color.g = 1.0;
   }
-  if (1 - src.b < kEhCloseEnough) {
-    color.b = 1;
+  if (1.0 - src.b < kEhCloseEnough) {
+    color.b = 1.0;
   }
 
   return color;
@@ -115,26 +116,26 @@ vec3 IPBlendColorDodge(vec3 dst, vec3 src) {
 vec3 IPBlendColorBurn(vec3 dst, vec3 src) {
   // https://www.w3.org/TR/compositing-1/#blendingcolorburn
 
-  vec3 color = 1 - min(vec3(1), (1 - dst) / src);
+  vec3 color = 1.0 - min(vec3(1.0), (1.0 - dst) / src);
 
-  if (1 - dst.r < kEhCloseEnough) {
-    color.r = 1;
+  if (1.0 - dst.r < kEhCloseEnough) {
+    color.r = 1.0;
   }
-  if (1 - dst.g < kEhCloseEnough) {
-    color.g = 1;
+  if (1.0 - dst.g < kEhCloseEnough) {
+    color.g = 1.0;
   }
-  if (1 - dst.b < kEhCloseEnough) {
-    color.b = 1;
+  if (1.0 - dst.b < kEhCloseEnough) {
+    color.b = 1.0;
   }
 
   if (src.r < kEhCloseEnough) {
-    color.r = 0;
+    color.r = 0.0;
   }
   if (src.g < kEhCloseEnough) {
-    color.g = 0;
+    color.g = 0.0;
   }
   if (src.b < kEhCloseEnough) {
-    color.b = 0;
+    color.b = 0.0;
   }
 
   return color;
@@ -143,13 +144,13 @@ vec3 IPBlendColorBurn(vec3 dst, vec3 src) {
 vec3 IPBlendSoftLight(vec3 dst, vec3 src) {
   // https://www.w3.org/TR/compositing-1/#blendingsoftlight
 
-  vec3 D = IPVec3ChooseCutoff(((16 * dst - 12) * dst + 4) * dst,  //
-                              sqrt(dst),                          //
-                              dst,                                //
+  vec3 D = IPVec3ChooseCutoff(((16.0 * dst - 12.0) * dst + 4.0) * dst,  //
+                              sqrt(dst),                                //
+                              dst,                                      //
                               0.25);
 
-  return IPVec3Choose(dst - (1 - 2 * src) * dst * (1 - dst),  //
-                      dst + (2 * src - 1) * (D - dst),        //
+  return IPVec3Choose(dst - (1.0 - 2.0 * src) * dst * (1.0 - dst),  //
+                      dst + (2.0 * src - 1.0) * (D - dst),          //
                       src);
 }
 
@@ -160,7 +161,7 @@ vec3 IPBlendDifference(vec3 dst, vec3 src) {
 
 vec3 IPBlendExclusion(vec3 dst, vec3 src) {
   // https://www.w3.org/TR/compositing-1/#blendingexclusion
-  return dst + src - 2 * dst * src;
+  return dst + src - 2.0 * dst * src;
 }
 
 vec3 IPBlendMultiply(vec3 dst, vec3 src) {

--- a/impeller/compiler/shader_lib/impeller/branching.glsl
+++ b/impeller/compiler/shader_lib/impeller/branching.glsl
@@ -22,21 +22,21 @@ BoolV3 IPVec3IsEqual(vec3 x, float y) {
 ///
 /// Returns 1.0 if x > y, otherwise 0.0.
 BoolF IPFloatIsGreaterThan(float x, float y) {
-  return max(sign(x - y), 0);
+  return max(sign(x - y), 0.0);
 }
 
 /// Perform a branchless greater than check for each vec3 component.
 ///
 /// Returns 1.0 if x > y, otherwise 0.0.
 BoolV3 IPVec3IsGreaterThan(vec3 x, vec3 y) {
-  return max(sign(x - y), 0);
+  return max(sign(x - y), 0.0);
 }
 
 /// Perform a branchless less than check.
 ///
 /// Returns 1.0 if x < y, otherwise 0.0.
 BoolF IPFloatIsLessThan(float x, float y) {
-  return max(sign(y - x), 0);
+  return max(sign(y - x), 0.0);
 }
 
 /// For each vec3 component, if value > cutoff, return b, otherwise return a.

--- a/impeller/compiler/shader_lib/impeller/color.glsl
+++ b/impeller/compiler/shader_lib/impeller/color.glsl
@@ -12,8 +12,8 @@
 ///
 /// Returns (0, 0, 0, 0) if the alpha component is 0.
 vec4 IPUnpremultiply(vec4 color) {
-  if (color.a == 0) {
-    return vec4(0);
+  if (color.a == 0.0) {
+    return vec4(0.0);
   }
   return vec4(color.rgb / color.a, color.a);
 }

--- a/impeller/compiler/shader_lib/impeller/constants.glsl
+++ b/impeller/compiler/shader_lib/impeller/constants.glsl
@@ -5,12 +5,12 @@
 #ifndef CONSTANTS_GLSL_
 #define CONSTANTS_GLSL_
 
-const float kEhCloseEnough = 0.000001;
+const mediump float kEhCloseEnough = 0.000001;
 
 // 1 / (2 * pi)
-const float k1Over2Pi = 0.1591549430918;
+const mediump float k1Over2Pi = 0.1591549430918;
 
 // sqrt(2 * pi)
-const float kSqrtTwoPi = 2.50662827463;
+const mediump float kSqrtTwoPi = 2.50662827463;
 
 #endif

--- a/impeller/compiler/shader_lib/impeller/texture.glsl
+++ b/impeller/compiler/shader_lib/impeller/texture.glsl
@@ -21,10 +21,10 @@ vec4 IPSample(sampler2D texture_sampler, vec2 coords, float y_coord_scale) {
 
 // These values must correspond to the order of the items in the
 // 'Entity::TileMode' enum class.
-const float kTileModeClamp = 0;
-const float kTileModeRepeat = 1;
-const float kTileModeMirror = 2;
-const float kTileModeDecal = 3;
+const float kTileModeClamp = 0.0;
+const float kTileModeRepeat = 1.0;
+const float kTileModeMirror = 2.0;
+const float kTileModeDecal = 3.0;
 
 /// Remap a float using a tiling mode.
 ///
@@ -38,8 +38,8 @@ float IPFloatTile(float t, float tile_mode) {
   } else if (tile_mode == kTileModeRepeat) {
     t = fract(t);
   } else if (tile_mode == kTileModeMirror) {
-    float t1 = t - 1;
-    float t2 = t1 - 2 * floor(t1 * 0.5) - 1;
+    float t1 = t - 1.0;
+    float t2 = t1 - 2.0 * floor(t1 * 0.5) - 1.0;
     t = abs(t2);
   }
   return t;
@@ -61,9 +61,9 @@ vec4 IPSampleWithTileMode(sampler2D tex,
                           vec2 coords,
                           float y_coord_scale,
                           float tile_mode) {
-  if (tile_mode == kTileModeDecal &&
-      (coords.x < 0 || coords.y < 0 || coords.x >= 1 || coords.y >= 1)) {
-    return vec4(0);
+  if (tile_mode == kTileModeDecal && (coords.x < 0.0 || coords.y < 0.0 ||
+                                      coords.x >= 1.0 || coords.y >= 1.0)) {
+    return vec4(0.0);
   }
 
   return IPSample(tex, IPVec2Tile(coords, tile_mode), y_coord_scale);

--- a/impeller/entity/shaders/atlas_fill.frag
+++ b/impeller/entity/shaders/atlas_fill.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/texture.glsl>
 
 uniform sampler2D texture_sampler;

--- a/impeller/entity/shaders/blending/advanced_blend.glsl
+++ b/impeller/entity/shaders/blending/advanced_blend.glsl
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 #include <impeller/color.glsl>
 #include <impeller/texture.glsl>
@@ -29,7 +31,7 @@ void main() {
       blend_info.dst_y_coord_scale,  // y coordinate scale
       kTileModeDecal                 // tile mode
       ));
-  vec4 src = blend_info.color_factor > 0
+  vec4 src = blend_info.color_factor > 0.0
                  ? blend_info.color
                  : IPUnpremultiply(IPSampleWithTileMode(
                        texture_sampler_src,           // sampler

--- a/impeller/entity/shaders/blending/advanced_blend_color.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_color.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 
 vec3 Blend(vec3 dst, vec3 src) {

--- a/impeller/entity/shaders/blending/advanced_blend_colorburn.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_colorburn.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 
 vec3 Blend(vec3 dst, vec3 src) {

--- a/impeller/entity/shaders/blending/advanced_blend_colordodge.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_colordodge.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 
 vec3 Blend(vec3 dst, vec3 src) {

--- a/impeller/entity/shaders/blending/advanced_blend_darken.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_darken.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 
 vec3 Blend(vec3 dst, vec3 src) {

--- a/impeller/entity/shaders/blending/advanced_blend_difference.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_difference.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 
 vec3 Blend(vec3 dst, vec3 src) {

--- a/impeller/entity/shaders/blending/advanced_blend_exclusion.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_exclusion.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 
 vec3 Blend(vec3 dst, vec3 src) {

--- a/impeller/entity/shaders/blending/advanced_blend_hardlight.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_hardlight.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 
 vec3 Blend(vec3 dst, vec3 src) {

--- a/impeller/entity/shaders/blending/advanced_blend_hue.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_hue.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 
 vec3 Blend(vec3 dst, vec3 src) {

--- a/impeller/entity/shaders/blending/advanced_blend_lighten.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_lighten.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 
 vec3 Blend(vec3 dst, vec3 src) {

--- a/impeller/entity/shaders/blending/advanced_blend_luminosity.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_luminosity.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 
 vec3 Blend(vec3 dst, vec3 src) {

--- a/impeller/entity/shaders/blending/advanced_blend_multiply.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_multiply.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 
 vec3 Blend(vec3 dst, vec3 src) {

--- a/impeller/entity/shaders/blending/advanced_blend_overlay.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_overlay.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 
 vec3 Blend(vec3 dst, vec3 src) {

--- a/impeller/entity/shaders/blending/advanced_blend_saturation.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_saturation.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 
 vec3 Blend(vec3 dst, vec3 src) {

--- a/impeller/entity/shaders/blending/advanced_blend_screen.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_screen.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 
 vec3 Blend(vec3 dst, vec3 src) {

--- a/impeller/entity/shaders/blending/advanced_blend_softlight.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_softlight.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 
 vec3 Blend(vec3 dst, vec3 src) {

--- a/impeller/entity/shaders/blending/blend.frag
+++ b/impeller/entity/shaders/blending/blend.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 uniform sampler2D texture_sampler_src;
 
 in vec2 v_texture_coords;

--- a/impeller/entity/shaders/border_mask_blur.frag
+++ b/impeller/entity/shaders/border_mask_blur.frag
@@ -11,6 +11,8 @@
 // integral (using an erf approximation) to the 4 edges of the UV rectangle and
 // multiplying them.
 
+precision mediump float;
+
 uniform sampler2D texture_sampler;
 
 in vec2 v_texture_coords;
@@ -26,7 +28,7 @@ float erf(float x) {
   float a = abs(x);
   // 0.278393*x + 0.230389*x^2 + 0.078108*x^4 + 1
   float b = (0.278393 + (0.230389 + 0.078108 * a * a) * a) * a + 1.0;
-  return sign(x) * (1 - 1 / (b * b * b * b));
+  return sign(x) * (1.0 - 1.0 / (b * b * b * b));
 }
 
 const float kHalfSqrtTwo = 0.70710678118;
@@ -41,10 +43,10 @@ float GaussianIntegral(float x, float sigma) {
 
 float BoxBlurMask(vec2 uv) {
   // LTRB
-  return GaussianIntegral(uv.x, v_sigma_uv.x) *      //
-         GaussianIntegral(uv.y, v_sigma_uv.y) *      //
-         GaussianIntegral(1 - uv.x, v_sigma_uv.x) *  //
-         GaussianIntegral(1 - uv.y, v_sigma_uv.y);
+  return GaussianIntegral(uv.x, v_sigma_uv.x) *        //
+         GaussianIntegral(uv.y, v_sigma_uv.y) *        //
+         GaussianIntegral(1.0 - uv.x, v_sigma_uv.x) *  //
+         GaussianIntegral(1.0 - uv.y, v_sigma_uv.y);
 }
 
 void main() {
@@ -52,11 +54,12 @@ void main() {
   float blur_factor = BoxBlurMask(v_texture_coords);
 
   float within_bounds =
-      float(v_texture_coords.x >= 0 && v_texture_coords.y >= 0 &&
-            v_texture_coords.x < 1 && v_texture_coords.y < 1);
+      float(v_texture_coords.x >= 0.0 && v_texture_coords.y >= 0.0 &&
+            v_texture_coords.x < 1.0 && v_texture_coords.y < 1.0);
   float inner_factor =
       (v_inner_blur_factor * blur_factor + v_src_factor) * within_bounds;
-  float outer_factor = v_outer_blur_factor * blur_factor * (1 - within_bounds);
+  float outer_factor =
+      v_outer_blur_factor * blur_factor * (1.0 - within_bounds);
 
   float mask_factor = inner_factor + outer_factor;
   frag_color = image_color * mask_factor;

--- a/impeller/entity/shaders/gaussian_blur.frag
+++ b/impeller/entity/shaders/gaussian_blur.frag
@@ -13,6 +13,8 @@
 //     reduced in the first pass by sampling the source textures with a mip
 //     level of log2(min_radius).
 
+precision mediump float;
+
 #include <impeller/constants.glsl>
 #include <impeller/texture.glsl>
 
@@ -49,8 +51,8 @@ float Gaussian(float x) {
 }
 
 void main() {
-  vec4 total_color = vec4(0);
-  float gaussian_integral = 0;
+  vec4 total_color = vec4(0.0);
+  float gaussian_integral = 0.0;
   vec2 blur_uv_offset = frag_info.blur_direction / frag_info.texture_size;
 
   for (float i = -frag_info.blur_radius; i <= frag_info.blur_radius; i++) {
@@ -74,8 +76,8 @@ void main() {
                            1.0,                   // y coordinate scale
                            frag_info.tile_mode    // tile mode
       );
-  float blur_factor = frag_info.inner_blur_factor * float(src_color.a > 0) +
-                      frag_info.outer_blur_factor * float(src_color.a == 0);
+  float blur_factor = frag_info.inner_blur_factor * float(src_color.a > 0.0) +
+                      frag_info.outer_blur_factor * float(src_color.a == 0.0);
 
   frag_color = blur_color * blur_factor + src_color * frag_info.src_factor;
 }

--- a/impeller/entity/shaders/glyph_atlas.frag
+++ b/impeller/entity/shaders/glyph_atlas.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 uniform sampler2D glyph_atlas_sampler;
 
 in vec2 v_unit_vertex;

--- a/impeller/entity/shaders/gradient_fill.frag
+++ b/impeller/entity/shaders/gradient_fill.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/texture.glsl>
 
 uniform GradientInfo {

--- a/impeller/entity/shaders/radial_gradient_fill.frag
+++ b/impeller/entity/shaders/radial_gradient_fill.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/texture.glsl>
 
 uniform GradientInfo {

--- a/impeller/entity/shaders/rrect_blur.frag
+++ b/impeller/entity/shaders/rrect_blur.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 uniform FragInfo {
   vec4 color;
   float blur_radius;
@@ -16,7 +18,7 @@ out vec4 frag_color;
 
 // Simple logistic sigmoid with a domain of [-1, 1] and range of [0, 1].
 float Sigmoid(float x) {
-  return 1.03731472073 / (1 + exp(-4 * x)) - 0.0186573603638;
+  return 1.03731472073 / (1.0 + exp(-4.0 * x)) - 0.0186573603638;
 }
 
 float RRectDistance(vec2 sample_position, vec2 rect_size, float corner_radius) {

--- a/impeller/entity/shaders/solid_fill.frag
+++ b/impeller/entity/shaders/solid_fill.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 uniform FragInfo {
   vec4 color;
 }

--- a/impeller/entity/shaders/solid_stroke.frag
+++ b/impeller/entity/shaders/solid_stroke.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 uniform FragInfo {
   vec4 color;
 }

--- a/impeller/entity/shaders/sweep_gradient_fill.frag
+++ b/impeller/entity/shaders/sweep_gradient_fill.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/constants.glsl>
 #include <impeller/texture.glsl>
 

--- a/impeller/entity/shaders/texture_fill.frag
+++ b/impeller/entity/shaders/texture_fill.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/texture.glsl>
 
 uniform sampler2D texture_sampler;

--- a/impeller/entity/shaders/vertices.frag
+++ b/impeller/entity/shaders/vertices.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 in vec4 v_color;
 
 out vec4 frag_color;

--- a/impeller/fixtures/box_fade.frag
+++ b/impeller/fixtures/box_fade.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 uniform FrameInfo {
   float current_time;
   vec2 cursor_position;

--- a/impeller/fixtures/colors.frag
+++ b/impeller/fixtures/colors.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 in vec4 v_color;
 
 out vec4 frag_color;

--- a/impeller/fixtures/impeller.frag
+++ b/impeller/fixtures/impeller.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 uniform samplerCube cube_map;
 uniform sampler2D blue_noise;
 

--- a/impeller/fixtures/instanced_draw.frag
+++ b/impeller/fixtures/instanced_draw.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 in vec4 v_color;
 
 out vec4 frag_color;

--- a/impeller/fixtures/instanced_draw.vert
+++ b/impeller/fixtures/instanced_draw.vert
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
 #ifdef IMPELLER_TARGET_OPENGLES
 
 void main() {
@@ -13,22 +12,22 @@ void main() {
 
 uniform FrameInfo {
   mat4 mvp;
-} frame_info;
+}
+frame_info;
 
 readonly buffer InstanceInfo {
   vec4 colors[];
-} instance_info;
+}
+instance_info;
 
 in vec2 vtx;
 
 out vec4 v_color;
 
-void main () {
-  gl_Position = frame_info.mvp *
-    vec4(vtx.x + 105.0 * gl_InstanceIndex,
-         vtx.y + 105.0 * gl_InstanceIndex,
-         0.0,
-         1.0);
+void main() {
+  gl_Position =
+      frame_info.mvp * vec4(vtx.x + 105.0 * float(gl_InstanceIndex),
+                            vtx.y + 105.0 * float(gl_InstanceIndex), 0.0, 1.0);
   v_color = instance_info.colors[gl_InstanceIndex];
 }
 

--- a/impeller/fixtures/mipmaps.frag
+++ b/impeller/fixtures/mipmaps.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 uniform FragInfo {
   float lod;
 }

--- a/impeller/fixtures/test_texture.frag
+++ b/impeller/fixtures/test_texture.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 out vec4 frag_color;
 
 void main() {

--- a/impeller/playground/imgui/imgui_raster.frag
+++ b/impeller/playground/imgui/imgui_raster.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 in vec2 frag_texture_coordinates;
 in vec4 frag_vertex_color;
 


### PR DESCRIPTION
This is a step towards being able to control floating point precision. The GLSL 4.6 spec ignores precision (and so does glslang in this mode). The compiler is still not emitting half precision on Metal, so something else probably needs to be adjusted (perhaps the shaderc_env or spirv_target) since it appears to have support for doing so internally.

All of the shaders needed to be modified because explicitly specifying precision (and explicitly specifying conversions between different precisions) is mandatory for GLSL ES 3.2. If we end up needing to reverse this change for some reason, none of the shaders will need to be changed to do so, as all of the changes are also compatible with GLSL 4.6