### PR TITLE
Add FLUTTER_DEPRECATED macro and flutter_macros.h

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1673,6 +1673,7 @@ FILE: ../../../flutter/shell/platform/common/path_utils.h
 FILE: ../../../flutter/shell/platform/common/path_utils_unittests.cc
 FILE: ../../../flutter/shell/platform/common/platform_provided_menu.h
 FILE: ../../../flutter/shell/platform/common/public/flutter_export.h
+FILE: ../../../flutter/shell/platform/common/public/flutter_macros.h
 FILE: ../../../flutter/shell/platform/common/public/flutter_messenger.h
 FILE: ../../../flutter/shell/platform/common/public/flutter_plugin_registrar.h
 FILE: ../../../flutter/shell/platform/common/public/flutter_texture_registrar.h

--- a/shell/platform/common/BUILD.gn
+++ b/shell/platform/common/BUILD.gn
@@ -11,6 +11,7 @@ config("desktop_library_implementation") {
 
 _public_headers = [
   "public/flutter_export.h",
+  "public/flutter_macros.h",
   "public/flutter_messenger.h",
   "public/flutter_plugin_registrar.h",
   "public/flutter_texture_registrar.h",

--- a/shell/platform/common/public/flutter_macros.h
+++ b/shell/platform/common/public/flutter_macros.h
@@ -1,0 +1,24 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_COMMON_PUBLIC_FLUTTER_MACROS_H_
+#define FLUTTER_SHELL_PLATFORM_COMMON_PUBLIC_FLUTTER_MACROS_H_
+
+#ifdef FLUTTER_DESKTOP_LIBRARY
+
+// Do not add deprecation annotations when building the library.
+#define FLUTTER_DEPRECATED(message)
+
+#else  // FLUTTER_DESKTOP_LIBRARY
+
+// Add deprecation warning for users of the library.
+#ifdef _WIN32
+#define FLUTTER_DEPRECATED(message) __declspec(deprecated(message))
+#else
+#define FLUTTER_DEPRECATED(message) __attribute__((deprecated(message)))
+#endif
+
+#endif  // FLUTTER_DESKTOP_LIBRARY
+
+#endif  // FLUTTER_SHELL_PLATFORM_COMMON_PUBLIC_FLUTTER_MACROS_H_


### PR DESCRIPTION
Adds a new header, flutter_macros.h which includes a FLUTTER_DEPRECATED
macro that can be used to mark deprecated API as such, with a
hopefully-informative message, ideally describing the expected removal
version and any migration tips.

This will need to be #included in flutter_windows.h and flutter_linux.h,
but prior to doing so, we'll need to update the engine recipe to bundle
the new header, here:
https://flutter.googlesource.com/recipes/+/refs/heads/main/recipes/engine/engine.py#1457

No tests since this adds a compiler macro that will be used for future
C/C++ API deprecation once the above recipe change has landed;
specifically: [`FlutterDesktopEngineProcessMessages`](https://github.com/flutter/engine/blob/228c5a84da45559f3281fe186952069e97837af9/shell/platform/windows/public/flutter_windows.h#L144-L154).

Related: https://github.com/flutter/flutter/issues/93537

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
