### PR TITLE
[impeller] Add 'ColorSourceProc' for creating color source contents

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -299,8 +299,15 @@ TEST_P(AiksTest, CanRenderDifferentShapesWithSameColorSource) {
     contents->SetTileMode(Entity::TileMode::kRepeat);
     return contents;
   };
-  canvas.DrawRect({100, 100, 200, 200}, paint);
-  canvas.DrawCircle({200, 500}, 100, paint);
+  canvas.Save();
+  canvas.Translate({100, 100, 0});
+  canvas.DrawRect({0, 0, 200, 200}, paint);
+  canvas.Restore();
+
+  canvas.Save();
+  canvas.Translate({100, 400, 0});
+  canvas.DrawCircle({100, 100}, 100, paint);
+  canvas.Restore();
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 

--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -10,6 +10,7 @@
 #include "impeller/aiks/aiks_playground.h"
 #include "impeller/aiks/canvas.h"
 #include "impeller/aiks/image.h"
+#include "impeller/entity/entity.h"
 #include "impeller/geometry/color.h"
 #include "impeller/geometry/geometry_unittests.h"
 #include "impeller/geometry/path_builder.h"
@@ -214,13 +215,16 @@ TEST_P(AiksTest, CanRenderLinearGradient) {
   for (int i = 0; i < 4; i++) {
     canvas.Save();
     canvas.Translate(offsets[i]);
-    auto contents = std::make_shared<LinearGradientContents>();
-    contents->SetEndPoints({0, 0}, {100, 100});
-    std::vector<Color> colors = {Color{0.9568, 0.2627, 0.2118, 1.0},
-                                 Color{0.1294, 0.5882, 0.9529, 1.0}};
-    contents->SetColors(std::move(colors));
-    contents->SetTileMode(tile_modes[i]);
-    paint.contents = contents;
+    Entity::TileMode tile_mode = tile_modes[i];
+    paint.color_source = [tile_mode]() {
+      auto contents = std::make_shared<LinearGradientContents>();
+      contents->SetEndPoints({0, 0}, {100, 100});
+      std::vector<Color> colors = {Color{0.9568, 0.2627, 0.2118, 1.0},
+                                   Color{0.1294, 0.5882, 0.9529, 1.0}};
+      contents->SetColors(std::move(colors));
+      contents->SetTileMode(tile_mode);
+      return contents;
+    };
     canvas.DrawRect({0, 0, 200, 200}, paint);
     canvas.Restore();
   }
@@ -238,13 +242,16 @@ TEST_P(AiksTest, CanRenderRadialGradient) {
   for (int i = 0; i < 4; i++) {
     canvas.Save();
     canvas.Translate(offsets[i]);
-    auto contents = std::make_shared<RadialGradientContents>();
-    contents->SetCenterAndRadius({50, 50}, 50);
-    std::vector<Color> colors = {Color{0.9568, 0.2627, 0.2118, 1.0},
-                                 Color{0.1294, 0.5882, 0.9529, 1.0}};
-    contents->SetColors(std::move(colors));
-    contents->SetTileMode(tile_modes[i]);
-    paint.contents = contents;
+    Entity::TileMode tile_mode = tile_modes[i];
+    paint.color_source = [tile_mode]() {
+      auto contents = std::make_shared<RadialGradientContents>();
+      contents->SetCenterAndRadius({50, 50}, 50);
+      std::vector<Color> colors = {Color{0.9568, 0.2627, 0.2118, 1.0},
+                                   Color{0.1294, 0.5882, 0.9529, 1.0}};
+      contents->SetColors(std::move(colors));
+      contents->SetTileMode(tile_mode);
+      return contents;
+    };
     canvas.DrawRect({0, 0, 200, 200}, paint);
     canvas.Restore();
   }
@@ -263,17 +270,37 @@ TEST_P(AiksTest, CanRenderSweepGradient) {
   for (int i = 0; i < 4; i++) {
     canvas.Save();
     canvas.Translate(offsets[i]);
-    auto contents = std::make_shared<SweepGradientContents>();
-    contents->SetCenterAndAngles({50, 50}, Degrees(45), Degrees(135));
-    std::vector<Color> colors = {Color{0.9568, 0.2627, 0.2118, 1.0},
-                                 Color{0.1294, 0.5882, 0.9529, 1.0}};
-    contents->SetColors(std::move(colors));
-    contents->SetTileMode(tile_modes[i]);
-    paint.contents = contents;
+    Entity::TileMode tile_mode = tile_modes[i];
+    paint.color_source = [tile_mode]() {
+      auto contents = std::make_shared<SweepGradientContents>();
+      contents->SetCenterAndAngles({50, 50}, Degrees(45), Degrees(135));
+      std::vector<Color> colors = {Color{0.9568, 0.2627, 0.2118, 1.0},
+                                   Color{0.1294, 0.5882, 0.9529, 1.0}};
+      contents->SetColors(std::move(colors));
+      contents->SetTileMode(tile_mode);
+      return contents;
+    };
     canvas.DrawRect({0, 0, 200, 200}, paint);
     canvas.Restore();
   }
 
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
+TEST_P(AiksTest, CanRenderDifferentShapesWithSameColorSource) {
+  Canvas canvas;
+  Paint paint;
+  paint.color_source = []() {
+    auto contents = std::make_shared<LinearGradientContents>();
+    contents->SetEndPoints({0, 0}, {100, 100});
+    std::vector<Color> colors = {Color{0.9568, 0.2627, 0.2118, 1.0},
+                                 Color{0.1294, 0.5882, 0.9529, 1.0}};
+    contents->SetColors(std::move(colors));
+    contents->SetTileMode(Entity::TileMode::kRepeat);
+    return contents;
+  };
+  canvas.DrawRect({100, 100, 200, 200}, paint);
+  canvas.DrawCircle({200, 500}, 100, paint);
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 

--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -10,7 +10,6 @@
 #include "impeller/aiks/aiks_playground.h"
 #include "impeller/aiks/canvas.h"
 #include "impeller/aiks/image.h"
-#include "impeller/entity/entity.h"
 #include "impeller/geometry/color.h"
 #include "impeller/geometry/geometry_unittests.h"
 #include "impeller/geometry/path_builder.h"

--- a/impeller/aiks/paint.cc
+++ b/impeller/aiks/paint.cc
@@ -10,7 +10,9 @@ namespace impeller {
 
 std::shared_ptr<Contents> Paint::CreateContentsForEntity(Path path,
                                                          bool cover) const {
-  if (contents) {
+  if (color_source.has_value()) {
+    auto& source = color_source.value();
+    auto contents = source();
     contents->SetPath(std::move(path));
     return contents;
   }
@@ -41,7 +43,7 @@ std::shared_ptr<Contents> Paint::CreateContentsForEntity(Path path,
 std::shared_ptr<Contents> Paint::WithFilters(
     std::shared_ptr<Contents> input,
     std::optional<bool> is_solid_color) const {
-  bool is_solid_color_val = is_solid_color.value_or(!contents);
+  bool is_solid_color_val = is_solid_color.value_or(!color_source);
 
   if (mask_blur_descriptor.has_value()) {
     input = mask_blur_descriptor->CreateMaskBlur(FilterInput::Make(input),

--- a/impeller/aiks/paint.h
+++ b/impeller/aiks/paint.h
@@ -10,6 +10,7 @@
 #include "impeller/entity/contents/contents.h"
 #include "impeller/entity/contents/filters/filter_contents.h"
 #include "impeller/entity/contents/linear_gradient_contents.h"
+#include "impeller/entity/contents/path_contents.h"
 #include "impeller/entity/contents/radial_gradient_contents.h"
 #include "impeller/entity/contents/solid_stroke_contents.h"
 #include "impeller/entity/contents/sweep_gradient_contents.h"
@@ -25,6 +26,7 @@ struct Paint {
   using MaskFilterProc =
       std::function<std::shared_ptr<FilterContents>(FilterInput::Ref,
                                                     bool is_solid_color)>;
+  using ColorSourceProc = std::function<std::shared_ptr<PathContents>()>;
 
   enum class Style {
     kFill,
@@ -40,7 +42,7 @@ struct Paint {
   };
 
   Color color = Color::Black();
-  std::shared_ptr<PathContents> contents;
+  std::optional<ColorSourceProc> color_source;
 
   Scalar stroke_width = 0.0;
   SolidStrokeContents::Cap stroke_cap = SolidStrokeContents::Cap::kButt;

--- a/impeller/aiks/paint.h
+++ b/impeller/aiks/paint.h
@@ -10,7 +10,6 @@
 #include "impeller/entity/contents/contents.h"
 #include "impeller/entity/contents/filters/filter_contents.h"
 #include "impeller/entity/contents/linear_gradient_contents.h"
-#include "impeller/entity/contents/path_contents.h"
 #include "impeller/entity/contents/radial_gradient_contents.h"
 #include "impeller/entity/contents/solid_stroke_contents.h"
 #include "impeller/entity/contents/sweep_gradient_contents.h"

--- a/impeller/display_list/display_list_dispatcher.cc
+++ b/impeller/display_list/display_list_dispatcher.cc
@@ -260,7 +260,8 @@ void DisplayListDispatcher::setColorSource(
         colors.emplace_back(ToColor(linear->colors()[i]));
       }
       auto tile_mode = ToTileMode(linear->tile_mode());
-      paint_.color_source = [start_point, end_point, colors, tile_mode]() {
+      paint_.color_source = [start_point, end_point, colors = std::move(colors),
+                             tile_mode]() {
         auto contents = std::make_shared<LinearGradientContents>();
         contents->SetEndPoints(start_point, end_point);
         contents->SetColors(std::move(colors));
@@ -280,7 +281,8 @@ void DisplayListDispatcher::setColorSource(
         colors.emplace_back(ToColor(radialGradient->colors()[i]));
       }
       auto tile_mode = ToTileMode(radialGradient->tile_mode());
-      paint_.color_source = [center, radius, colors, tile_mode]() {
+      paint_.color_source = [center, radius, colors = std::move(colors),
+                             tile_mode]() {
         auto contents = std::make_shared<RadialGradientContents>();
         contents->SetCenterAndRadius(center, radius),
             contents->SetColors(std::move(colors));
@@ -302,8 +304,8 @@ void DisplayListDispatcher::setColorSource(
         colors.emplace_back(ToColor(sweepGradient->colors()[i]));
       }
       auto tile_mode = ToTileMode(sweepGradient->tile_mode());
-      paint_.color_source = [center, start_angle, end_angle, colors,
-                             tile_mode]() {
+      paint_.color_source = [center, start_angle, end_angle,
+                             colors = std::move(colors), tile_mode]() {
         auto contents = std::make_shared<SweepGradientContents>();
         contents->SetCenterAndAngles(center, start_angle, end_angle);
         contents->SetColors(std::move(colors));

--- a/impeller/display_list/display_list_dispatcher.cc
+++ b/impeller/display_list/display_list_dispatcher.cc
@@ -237,14 +237,14 @@ static std::vector<Matrix> ToRSXForms(const SkRSXform xform[], int count) {
 void DisplayListDispatcher::setColorSource(
     const flutter::DlColorSource* source) {
   if (!source) {
-    paint_.contents = nullptr;
+    paint_.color_source = std::nullopt;
     return;
   }
 
   switch (source->type()) {
     case flutter::DlColorSourceType::kColor: {
       const flutter::DlColorColorSource* color = source->asColor();
-      paint_.contents = nullptr;
+      paint_.color_source = std::nullopt;
       setColor(color->color());
       FML_DCHECK(color);
       return;
@@ -253,49 +253,63 @@ void DisplayListDispatcher::setColorSource(
       const flutter::DlLinearGradientColorSource* linear =
           source->asLinearGradient();
       FML_DCHECK(linear);
-      auto contents = std::make_shared<LinearGradientContents>();
-      contents->SetEndPoints(ToPoint(linear->start_point()),
-                             ToPoint(linear->end_point()));
+      auto start_point = ToPoint(linear->start_point());
+      auto end_point = ToPoint(linear->end_point());
       std::vector<Color> colors;
       for (auto i = 0; i < linear->stop_count(); i++) {
         colors.emplace_back(ToColor(linear->colors()[i]));
       }
-      contents->SetColors(std::move(colors));
-      contents->SetTileMode(ToTileMode(linear->tile_mode()));
-      paint_.contents = std::move(contents);
+      auto tile_mode = ToTileMode(linear->tile_mode());
+      paint_.color_source = [start_point, end_point, colors, tile_mode]() {
+        auto contents = std::make_shared<LinearGradientContents>();
+        contents->SetEndPoints(start_point, end_point);
+        contents->SetColors(std::move(colors));
+        contents->SetTileMode(tile_mode);
+        return contents;
+      };
       return;
     }
     case flutter::DlColorSourceType::kRadialGradient: {
       const flutter::DlRadialGradientColorSource* radialGradient =
           source->asRadialGradient();
       FML_DCHECK(radialGradient);
-      auto contents = std::make_shared<RadialGradientContents>();
-      contents->SetCenterAndRadius(ToPoint(radialGradient->center()),
-                                   radialGradient->radius());
+      auto center = ToPoint(radialGradient->center());
+      auto radius = radialGradient->radius();
       std::vector<Color> colors;
       for (auto i = 0; i < radialGradient->stop_count(); i++) {
         colors.emplace_back(ToColor(radialGradient->colors()[i]));
       }
-      contents->SetColors(std::move(colors));
-      contents->SetTileMode(ToTileMode(radialGradient->tile_mode()));
-      paint_.contents = std::move(contents);
+      auto tile_mode = ToTileMode(radialGradient->tile_mode());
+      paint_.color_source = [center, radius, colors, tile_mode]() {
+        auto contents = std::make_shared<RadialGradientContents>();
+        contents->SetCenterAndRadius(center, radius),
+            contents->SetColors(std::move(colors));
+        contents->SetTileMode(tile_mode);
+        return contents;
+      };
       return;
     }
     case flutter::DlColorSourceType::kSweepGradient: {
       const flutter::DlSweepGradientColorSource* sweepGradient =
           source->asSweepGradient();
       FML_DCHECK(sweepGradient);
-      auto contents = std::make_shared<SweepGradientContents>();
-      contents->SetCenterAndAngles(ToPoint(sweepGradient->center()),
-                                   Degrees(sweepGradient->start()),
-                                   Degrees(sweepGradient->end()));
+
+      auto center = ToPoint(sweepGradient->center());
+      auto start_angle = Degrees(sweepGradient->start());
+      auto end_angle = Degrees(sweepGradient->end());
       std::vector<Color> colors;
       for (auto i = 0; i < sweepGradient->stop_count(); i++) {
         colors.emplace_back(ToColor(sweepGradient->colors()[i]));
       }
-      contents->SetColors(std::move(colors));
-      contents->SetTileMode(ToTileMode(sweepGradient->tile_mode()));
-      paint_.contents = std::move(contents);
+      auto tile_mode = ToTileMode(sweepGradient->tile_mode());
+      paint_.color_source = [center, start_angle, end_angle, colors,
+                             tile_mode]() {
+        auto contents = std::make_shared<SweepGradientContents>();
+        contents->SetCenterAndAngles(center, start_angle, end_angle);
+        contents->SetColors(std::move(colors));
+        contents->SetTileMode(tile_mode);
+        return contents;
+      };
       return;
     }
     case flutter::DlColorSourceType::kImage:


### PR DESCRIPTION
In the current implementation, use the same paint with a linear gradient to draw a Rect and a Circle, two Circles will appear on the screen.

fix https://github.com/flutter/flutter/issues/109293

## test
```
TEST_P(AiksTest, CanRenderDifferentShapesWithSameColorSource) {
  Canvas canvas;
  Paint paint;
  paint.color_source = []() {
    auto contents = std::make_shared<LinearGradientContents>();
    contents->SetEndPoints({0, 0}, {100, 100});
    std::vector<Color> colors = {Color{0.9568, 0.2627, 0.2118, 1.0},
                                 Color{0.1294, 0.5882, 0.9529, 1.0}};
    contents->SetColors(std::move(colors));
    contents->SetTileMode(Entity::TileMode::kRepeat);
    return contents;
  };
  canvas.Save();
  canvas.Translate({100, 100, 0});
  canvas.DrawRect({0, 0, 200, 200}, paint);
  canvas.Restore();

  canvas.Save();
  canvas.Translate({100, 400, 0});
  canvas.DrawCircle({100, 100}, 100, paint);
  canvas.Restore();
  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
}
```


## before change
![ivwlV3Gfg6](https://user-images.githubusercontent.com/31977171/183837769-a7f52d0b-7b4f-49fa-a2ce-92ad83891869.jpg)



## after change 

![sWcqptVTeY](https://user-images.githubusercontent.com/31977171/183836843-e553cc33-f34b-4fde-81bb-4ad5811961d3.jpg)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.


