### PR TITLE
Remove fx_logger_config_t.console_fd

### DIFF
--- a/fml/logging_unittests.cc
+++ b/fml/logging_unittests.cc
@@ -55,7 +55,6 @@ class LoggingSocketTest : public ::testing::Test {
 
     fx_logger_config_t config = {
         .min_severity = FX_LOG_INFO,
-        .console_fd = -1,
         .log_sink_socket = local.release(),
         .tags = nullptr,
         .num_tags = 0,


### PR DESCRIPTION
This was deprecated in https://fxrev.dev/708606.

@arbreng 