### PR TITLE
[Windows] Replace memset with C++ alternatives

### DIFF
--- a/shell/platform/windows/flutter_window.cc
+++ b/shell/platform/windows/flutter_window.cc
@@ -250,8 +250,7 @@ bool FlutterWindow::OnBitmapSurfaceUpdated(const void* allocation,
                                            size_t row_bytes,
                                            size_t height) {
   HDC dc = ::GetDC(GetWindowHandle());
-  BITMAPINFO bmi;
-  memset(&bmi, 0, sizeof(bmi));
+  BITMAPINFO bmi = {};
   bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
   bmi.bmiHeader.biWidth = row_bytes / 4;
   bmi.bmiHeader.biHeight = -height;

--- a/shell/platform/windows/flutter_windows_unittests.cc
+++ b/shell/platform/windows/flutter_windows_unittests.cc
@@ -4,7 +4,6 @@
 
 #include "flutter/shell/platform/windows/public/flutter_windows.h"
 
-#include <cstring>
 #include <thread>
 
 #include "flutter/shell/platform/windows/testing/windows_test.h"
@@ -16,8 +15,7 @@ namespace flutter {
 namespace testing {
 
 TEST(WindowsNoFixtureTest, GetTextureRegistrar) {
-  FlutterDesktopEngineProperties properties;
-  memset(&properties, 0, sizeof(FlutterDesktopEngineProperties));
+  FlutterDesktopEngineProperties properties = {};
   properties.assets_path = L"";
   properties.icu_data_path = L"icudtl.dat";
   auto engine = FlutterDesktopEngineCreate(&properties);

--- a/shell/platform/windows/window_unittests.cc
+++ b/shell/platform/windows/window_unittests.cc
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <array>
+
 #include "flutter/shell/platform/windows/testing/mock_text_input_manager.h"
 #include "flutter/shell/platform/windows/testing/mock_window.h"
 #include "gtest/gtest.h"
@@ -207,19 +209,19 @@ TEST(MockWindow, KeyDownPrintable) {
       .Times(1)
       .WillOnce(respond_false);
   EXPECT_CALL(window, OnText(_)).Times(1);
-  Win32Message messages[] = {{WM_KEYDOWN, 65, lparam, kWmResultDontCheck},
-                             {WM_CHAR, 65, lparam, kWmResultDontCheck}};
-  window.InjectMessageList(2, messages);
+  std::array<Win32Message, 2> messages = {
+      Win32Message{WM_KEYDOWN, 65, lparam, kWmResultDontCheck},
+      Win32Message{WM_CHAR, 65, lparam, kWmResultDontCheck}};
+  window.InjectMessageList(2, messages.data());
 }
 
 TEST(MockWindow, KeyDownWithCtrl) {
   MockWindow window;
 
   // Simulate CONTROL pressed
-  BYTE keyboard_state[256];
-  memset(keyboard_state, 0, 256);
+  std::array<BYTE, 256> keyboard_state;
   keyboard_state[VK_CONTROL] = -1;
-  SetKeyboardState(keyboard_state);
+  SetKeyboardState(keyboard_state.data());
 
   LPARAM lparam = CreateKeyEventLparam(30, false, false);
 
@@ -230,8 +232,8 @@ TEST(MockWindow, KeyDownWithCtrl) {
 
   window.InjectWindowMessage(WM_KEYDOWN, 65, lparam);
 
-  memset(keyboard_state, 0, 256);
-  SetKeyboardState(keyboard_state);
+  keyboard_state.fill(0);
+  SetKeyboardState(keyboard_state.data());
 }
 
 TEST(MockWindow, KeyDownWithCtrlToggled) {
@@ -244,10 +246,9 @@ TEST(MockWindow, KeyDownWithCtrlToggled) {
   };
 
   // Simulate CONTROL toggled
-  BYTE keyboard_state[256];
-  memset(keyboard_state, 0, 256);
+  std::array<BYTE, 256> keyboard_state;
   keyboard_state[VK_CONTROL] = 1;
-  SetKeyboardState(keyboard_state);
+  SetKeyboardState(keyboard_state.data());
 
   LPARAM lparam = CreateKeyEventLparam(30, false, false);
 
@@ -261,8 +262,8 @@ TEST(MockWindow, KeyDownWithCtrlToggled) {
                              {WM_CHAR, 65, lparam, kWmResultDontCheck}};
   window.InjectMessageList(2, messages);
 
-  memset(keyboard_state, 0, 256);
-  SetKeyboardState(keyboard_state);
+  keyboard_state.fill(0);
+  SetKeyboardState(keyboard_state.data());
 }
 
 TEST(MockWindow, Paint) {


### PR DESCRIPTION
Eliminate a few uses of memset in the code, replacing them with C++
alternatives, like using initialiser list syntax and std::array + fill.
This avoids some double-hardcoding of array length in the code.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
