### PR TITLE
Add global generator processing for mac_ios builds.

### DIFF
--- a/ci/builders/mac_ios_engine.json
+++ b/ci/builders/mac_ios_engine.json
@@ -48,8 +48,7 @@
             "archives": [
                 {
                     "base_path": "out/ios_debug/zip_archives/",
-                    "include_paths": [
-                    ],
+                    "include_paths": [],
                     "name": "ios_debug"
                 }
             ],
@@ -64,23 +63,51 @@
                 "--runtime-mode",
                 "debug"
             ],
-            "generators": {
-                "tasks": [
-                    {
-                        "name": "BuildObjcDoc",
-                        "scripts": [
-                            "flutter/tools/gen_objcdoc.sh"
-                        ]
-                    }
-                ]
-            },
             "name": "ios_debug",
             "ninja": {
                 "config": "ios_debug",
-                "targets": []
+                "targets": [
+                    "flutter/shell/platform/darwin/ios:flutter_framework"
+                ]
             },
             "tests": []
         }
     ],
-    "tests": []
+    "tests": [],
+    "generators": {
+        "tasks": [
+            {
+                "name": "Debug-FlutterMacOS.framework",
+                "parameters": [
+                    "--dst",
+                    "out/debug",
+                    "--arm64-out-dir",
+                    "out/ios_debug",
+                    "--simulator-x64-out-dir",
+                    "out/ios_debug_sim",
+                    "--simulator-arm64-out-dir",
+                    "out/ios_debug_sim_arm64"
+                ],
+                "script": "flutter/sky/tools/create_full_ios_framework.py",
+                "language": "python"
+            },
+            {
+                "name": "obj-c-doc",
+                "parameters": [
+                    "out/debug"
+                ],
+                "script": "flutter/tools/gen_objcdoc.sh"
+            }
+        ]
+    },
+    "archives": [
+        {
+            "source": "out/debug/artifacts.zip",
+            "destination": "ios/artifacts.zip"
+        },
+        {
+            "source": "out/debug/ios-objcdoc.zip",
+            "destination": "ios-objcdoc.zip"
+        }
+    ]
 }

--- a/ci/builders/mac_ios_engine_profile.json
+++ b/ci/builders/mac_ios_engine_profile.json
@@ -61,10 +61,38 @@
             "name": "ios_profile",
             "ninja": {
                 "config": "ios_profile",
-                "targets": []
+                "targets": [
+                    "flutter/shell/platform/darwin/ios:flutter_framework",
+                    "flutter/lib/snapshot:generate_snapshot_bin"
+                ]
             },
             "tests": []
         }
     ],
-    "tests": []
+    "tests": [],
+    "generators": {
+        "tasks": [
+            {
+                "name": "Profile-FlutterMacOS.framework",
+                "parameters": [
+                    "--dst",
+                    "out/profile",
+                    "--arm64-out-dir",
+                    "out/ios_profile",
+                    "--simulator-x64-out-dir",
+                    "out/ios_debug_sim",
+                    "--simulator-arm64-out-dir",
+                    "out/ios_debug_sim_arm64"
+                ],
+                "script": "flutter/sky/tools/create_full_ios_framework.py",
+                "language": "python"
+            }
+        ]
+    },
+    "archives": [
+        {
+            "source": "out/profile/artifacts.zip",
+            "destination": "ios-profile/artifacts.zip"
+        }
+    ]
 }


### PR DESCRIPTION
Objectc docs and framework sdk need to be generated using multiple
subbuild artifacts. This functionality is called global generators and
framework sdk processing and objectc docs generation is being added to
the recipes v2 build.

Bug: https://github.com/flutter/flutter/issues/81855

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
