### PR TITLE
Revert "Add support for relative paths in mac os gen_snapshot."

### DIFF
--- a/sky/tools/create_macos_gen_snapshots.py
+++ b/sky/tools/create_macos_gen_snapshots.py
@@ -9,10 +9,6 @@ import subprocess
 import sys
 import os
 
-buildroot_dir = os.path.abspath(
-    os.path.join(os.path.realpath(__file__), '..', '..', '..', '..')
-)
-
 
 def main():
   parser = argparse.ArgumentParser(
@@ -23,29 +19,25 @@ def main():
   parser.add_argument('--clang-dir', type=str, default='clang_x64')
   parser.add_argument('--x64-out-dir', type=str)
   parser.add_argument('--arm64-out-dir', type=str)
+  parser.add_argument('--armv7-out-dir', type=str)
 
   args = parser.parse_args()
 
-  dst = (
-      args.dst
-      if os.path.isabs(args.dst) else os.path.join(buildroot_dir, args.dst)
-  )
-
   if args.x64_out_dir:
-    x64_out_dir = (
-        args.x64_out_dir if os.path.isabs(args.x64_out_dir) else
-        os.path.join(buildroot_dir, args.x64_out_dir)
+    generate_gen_snapshot(
+        args.x64_out_dir, os.path.join(args.dst, 'gen_snapshot_x64')
     )
-    generate_gen_snapshot(x64_out_dir, os.path.join(dst, 'gen_snapshot_x64'))
 
   if args.arm64_out_dir:
-    arm64_out_dir = (
-        args.arm64_out_dir if os.path.isabs(args.arm64_out_dir) else
-        os.path.join(buildroot_dir, args.arm64_out_dir)
-    )
     generate_gen_snapshot(
-        os.path.join(arm64_out_dir, args.clang_dir),
-        os.path.join(dst, 'gen_snapshot_arm64')
+        os.path.join(args.arm64_out_dir, args.clang_dir),
+        os.path.join(args.dst, 'gen_snapshot_arm64')
+    )
+
+  if args.armv7_out_dir:
+    generate_gen_snapshot(
+        os.path.join(args.armv7_out_dir, args.clang_dir),
+        os.path.join(args.dst, 'gen_snapshot_armv7')
     )
 
 


### PR DESCRIPTION
Reverts flutter/engine#35324

These errors are now generated on local builds:

```
FAILED: clang_arm64/gen_snapshot_armv7 
vpython3 ../../flutter/sky/tools/create_macos_gen_snapshots.py --dst /Users/jimgraham/Development/engine/src/out/android_profile/clang_arm64 --clang-dir clang_arm64 --armv7-out-dir /Users/jimgraham/Development/engine/src/out/android_profile
usage: create_macos_gen_snapshots.py [-h] --dst DST [--clang-dir CLANG_DIR]
                                     [--x64-out-dir X64_OUT_DIR]
                                     [--arm64-out-dir ARM64_OUT_DIR]
create_macos_gen_snapshots.py: error: unrecognized arguments: --armv7-out-dir /Users/jimgraham/Development/engine/src/out/android_profile
```

That tool is called in more than one way, other calling sequences, some of which do not think that armv7 is obsolete, must be updated for this to work.