### PR TITLE
Reland Add support for relative paths in mac os gen_snapshot.

### DIFF
--- a/sky/tools/create_macos_gen_snapshots.py
+++ b/sky/tools/create_macos_gen_snapshots.py
@@ -9,6 +9,10 @@ import subprocess
 import sys
 import os
 
+buildroot_dir = os.path.abspath(
+    os.path.join(os.path.realpath(__file__), '..', '..', '..', '..')
+)
+
 
 def main():
   parser = argparse.ArgumentParser(
@@ -23,21 +27,36 @@ def main():
 
   args = parser.parse_args()
 
+  dst = (
+      args.dst
+      if os.path.isabs(args.dst) else os.path.join(buildroot_dir, args.dst)
+  )
+
   if args.x64_out_dir:
-    generate_gen_snapshot(
-        args.x64_out_dir, os.path.join(args.dst, 'gen_snapshot_x64')
+    x64_out_dir = (
+        args.x64_out_dir if os.path.isabs(args.x64_out_dir) else
+        os.path.join(buildroot_dir, args.x64_out_dir)
     )
+    generate_gen_snapshot(x64_out_dir, os.path.join(dst, 'gen_snapshot_x64'))
 
   if args.arm64_out_dir:
+    arm64_out_dir = (
+        args.arm64_out_dir if os.path.isabs(args.arm64_out_dir) else
+        os.path.join(buildroot_dir, args.arm64_out_dir)
+    )
     generate_gen_snapshot(
-        os.path.join(args.arm64_out_dir, args.clang_dir),
-        os.path.join(args.dst, 'gen_snapshot_arm64')
+        os.path.join(arm64_out_dir, args.clang_dir),
+        os.path.join(dst, 'gen_snapshot_arm64')
     )
 
   if args.armv7_out_dir:
+    armv7_out_dir = (
+        args.armv7_out_dir if os.path.isabs(args.armv7_out_dir) else
+        os.path.join(buildroot_dir, args.armv7_out_dir)
+    )
     generate_gen_snapshot(
-        os.path.join(args.armv7_out_dir, args.clang_dir),
-        os.path.join(args.dst, 'gen_snapshot_armv7')
+        os.path.join(armv7_out_dir, args.clang_dir),
+        os.path.join(dst, 'gen_snapshot_armv7')
     )
 
 


### PR DESCRIPTION
Relative paths are required for engine v2 builds where we don't know the
full path in advance.

Armv7 flags were added back to prevent local builds from failing.

Bug: flutter/flutter#81855

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
