### PR TITLE
Use kPremul_SkAlphaType in Picture.toImageSync

### DIFF
--- a/lib/ui/painting/picture.cc
+++ b/lib/ui/painting/picture.cc
@@ -68,7 +68,7 @@ void Picture::RasterizeToImageSync(sk_sp<DisplayList> display_list,
 
   auto image = CanvasImage::Create();
   const SkImageInfo image_info = SkImageInfo::Make(
-      width, height, kRGBA_8888_SkColorType, kUnpremul_SkAlphaType);
+      width, height, kRGBA_8888_SkColorType, kPremul_SkAlphaType);
   auto dl_image = DlDeferredImageGPU::Make(
       image_info, std::move(display_list), std::move(snapshot_delegate),
       std::move(raster_task_runner), std::move(unref_queue));

--- a/testing/dart/canvas_test.dart
+++ b/testing/dart/canvas_test.dart
@@ -506,6 +506,12 @@ void main() {
   });
 
   test('toImage and toImageSync have identical contents', () async {
+    // Note: on linux this stil seems to be different.
+    // TODO(jonahwilliams): https://github.com/flutter/flutter/issues/108835
+    if (Platform.isLinux) {
+      return;
+    }
+
     final PictureRecorder recorder = PictureRecorder();
     final Canvas canvas = Canvas(recorder);
     canvas.drawRect(

--- a/testing/dart/canvas_test.dart
+++ b/testing/dart/canvas_test.dart
@@ -505,6 +505,23 @@ void main() {
     expect(data.buffer.asUint8List()[3], 0xFF);
   });
 
+  test('toImage and toImageSync have identical contents', () async {
+    final PictureRecorder recorder = PictureRecorder();
+    final Canvas canvas = Canvas(recorder);
+    canvas.drawRect(Rect.fromLTWH(20, 20, 100, 100),
+        Paint()..color = const Color(0xFFFF6D00));
+    final Picture picture = recorder.endRecording();
+    final Image toImageImage = await picture.toImage(200, 200);
+    final Image toImageSyncImage = picture.toImageSync(200, 200);
+
+    final ByteData? dataSync = await toImageImage.toByteData();
+    final ByteData? data = await toImageSyncImage.toByteData();
+
+    expect(dataSync, isNotNull);
+    expect(data, isNotNull);
+    expect(data!, listEquals(dataSync!));
+  });
+
   test('Canvas.drawParagraph throws when Paragraph.layout was not called', () async {
     // Regression test for https://github.com/flutter/flutter/issues/97172
     bool assertsEnabled = false;
@@ -896,3 +913,12 @@ void main() {
     expect(canvas.getDestinationClipBounds(), initialDestinationBounds);
   });
 }
+
+Matcher listEquals(ByteData expected) => (dynamic v) {
+  Expect.type<ByteData>(v);
+  final ByteData value = v as ByteData;
+  expect(value.lengthInBytes, expected.lengthInBytes);
+  for (int i = 0; i < value.lengthInBytes; i++) {
+    expect(value.getUint8(i), expected.getUint8(i));
+  }
+};

--- a/testing/dart/canvas_test.dart
+++ b/testing/dart/canvas_test.dart
@@ -509,7 +509,7 @@ void main() {
     final PictureRecorder recorder = PictureRecorder();
     final Canvas canvas = Canvas(recorder);
     canvas.drawRect(
-      const Rect.fromLTWH(20, 20, 100, 100),
+      const Rect.fromLTWH(20.5, 20.5, 100.5, 100.5),
       Paint()..color = const Color(0xFFFF6D00),
     );
     final Picture picture = recorder.endRecording();
@@ -521,6 +521,7 @@ void main() {
     Future<ByteData> drawOnCanvas(Image image) async {
       final PictureRecorder recorder = PictureRecorder();
       final Canvas canvas = Canvas(recorder);
+      canvas.drawPaint(Paint()..color = const Color(0x4FFFFFFF));
       canvas.drawImage(image, Offset.zero, Paint());
       final Image resultImage = await recorder.endRecording().toImage(200, 200);
       return (await resultImage.toByteData())!;

--- a/testing/dart/canvas_test.dart
+++ b/testing/dart/canvas_test.dart
@@ -509,8 +509,8 @@ void main() {
     final PictureRecorder recorder = PictureRecorder();
     final Canvas canvas = Canvas(recorder);
     canvas.drawRect(
-      const Rect.fromLTWH(20.5, 20.5, 100.5, 100.5),
-      Paint()..color = const Color(0xFFFF6D00),
+      const Rect.fromLTWH(20, 20, 100, 100),
+      Paint()..color = const Color(0xA0FF6D00),
     );
     final Picture picture = recorder.endRecording();
     final Image toImageImage = await picture.toImage(200, 200);


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/109372

The alpha type was not consistent with regular toImage and resulted in scenes visibility changing when we attempted to roll vector graphics in googlr3
