### PR TITLE
Avoid object creation during each frame

### DIFF
--- a/shell/platform/android/io/flutter/view/VsyncWaiter.java
+++ b/shell/platform/android/io/flutter/view/VsyncWaiter.java
@@ -90,8 +90,6 @@ public class VsyncWaiter {
 
     private long cookie;
 
-    FrameCallback() {}
-
     FrameCallback(long cookie) {
       this.cookie = cookie;
     }

--- a/shell/platform/android/io/flutter/view/VsyncWaiter.java
+++ b/shell/platform/android/io/flutter/view/VsyncWaiter.java
@@ -47,6 +47,7 @@ public class VsyncWaiter {
   private static DisplayListener listener;
   private long refreshPeriodNanos = -1;
   private FlutterJNI flutterJNI;
+  private FrameCallback frameCallback = new FrameCallback(0);
 
   @NonNull
   public static VsyncWaiter getInstance(float fps, @NonNull FlutterJNI flutterJNI) {
@@ -85,22 +86,43 @@ public class VsyncWaiter {
     listener = null;
   }
 
+  private class FrameCallback implements Choreographer.FrameCallback {
+
+    private long cookie;
+
+    FrameCallback() {}
+
+    FrameCallback(long cookie) {
+      this.cookie = cookie;
+    }
+
+    @Override
+    public void doFrame(long frameTimeNanos) {
+      long delay = System.nanoTime() - frameTimeNanos;
+      if (delay < 0) {
+        delay = 0;
+      }
+      flutterJNI.onVsync(delay, refreshPeriodNanos, cookie);
+      frameCallback = this;
+    }
+  }
+
   private final FlutterJNI.AsyncWaitForVsyncDelegate asyncWaitForVsyncDelegate =
       new FlutterJNI.AsyncWaitForVsyncDelegate() {
+
+        private Choreographer.FrameCallback obtainFrameCallback(final long cookie) {
+          if (frameCallback != null) {
+            frameCallback.cookie = cookie;
+            FrameCallback ret = frameCallback;
+            frameCallback = null;
+            return ret;
+          }
+          return new FrameCallback(cookie);
+        }
+
         @Override
         public void asyncWaitForVsync(long cookie) {
-          Choreographer.getInstance()
-              .postFrameCallback(
-                  new Choreographer.FrameCallback() {
-                    @Override
-                    public void doFrame(long frameTimeNanos) {
-                      long delay = System.nanoTime() - frameTimeNanos;
-                      if (delay < 0) {
-                        delay = 0;
-                      }
-                      flutterJNI.onVsync(delay, refreshPeriodNanos, cookie);
-                    }
-                  });
+          Choreographer.getInstance().postFrameCallback(obtainFrameCallback(cookie));
         }
       };
 


### PR DESCRIPTION
`Choreographer.FrameCallback` will  be called each frame

We should avoid create new object here

There is no need to consider thread safety, it is guaranteed  [here](https://github.com/flutter/engine/blob/492cf91f28541be014be308c1e385d5da3cb9f30/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java#L152) and [here](https://github.com/flutter/engine/blob/266d3360a7babfb5f20d5e9f8ea84772b2a247dc/shell/platform/android/vsync_waiter_android.cc#L44)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
