### PR TITLE
add missing break statements in makeWithLocalMatrix

### DIFF
--- a/display_list/display_list_image_filter.cc
+++ b/display_list/display_list_image_filter.cc
@@ -39,12 +39,14 @@ std::shared_ptr<DlImageFilter> DlImageFilter::makeWithLocalMatrix(
         // Nothing we can do at this point
         return nullptr;
       }
+      break;
     }
     case MatrixCapability::kScaleTranslate: {
       if (!matrix.isScaleTranslate()) {
         // Nothing we can do at this point
         return nullptr;
       }
+      break;
     }
     default:
       break;


### PR DESCRIPTION
These were missed in the original code review, but by luck the missing break statements wouldn't actually cause an issue because the code just works without them anyway. No tests because there is no change in behavior when you add the break statements so there is no programmatic way to know if they are present or missing.