### PR TITLE
[Impeller] Passes and command buffers hold weak handles to the context.

### DIFF
--- a/impeller/entity/contents/content_context.cc
+++ b/impeller/entity/contents/content_context.cc
@@ -263,7 +263,7 @@ std::shared_ptr<Texture> ContentContext::MakeSubpass(
     return nullptr;
   }
 
-  if (!sub_renderpass->EncodeCommands(context->GetResourceAllocator())) {
+  if (!sub_renderpass->EncodeCommands()) {
     return nullptr;
   }
 

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -173,8 +173,7 @@ bool EntityPass::Render(ContentContext& renderer,
       entity.Render(renderer, *render_pass);
     }
 
-    if (!render_pass->EncodeCommands(
-            renderer.GetContext()->GetResourceAllocator())) {
+    if (!render_pass->EncodeCommands()) {
       return false;
     }
     if (!command_buffer->SubmitCommands()) {

--- a/impeller/entity/inline_pass_context.cc
+++ b/impeller/entity/inline_pass_context.cc
@@ -37,7 +37,7 @@ bool InlinePassContext::EndPass() {
     return true;
   }
 
-  if (!pass_->EncodeCommands(context_->GetResourceAllocator())) {
+  if (!pass_->EncodeCommands()) {
     return false;
   }
 

--- a/impeller/playground/playground.cc
+++ b/impeller/playground/playground.cc
@@ -244,7 +244,7 @@ bool Playground::OpenPlaygroundHere(Renderer::RenderCallback render_callback) {
 
         ImGui_ImplImpeller_RenderDrawData(ImGui::GetDrawData(), *pass);
 
-        pass->EncodeCommands(renderer->GetContext()->GetResourceAllocator());
+        pass->EncodeCommands();
         if (!buffer->SubmitCommands()) {
           return false;
         }
@@ -284,7 +284,7 @@ bool Playground::OpenPlaygroundHere(SinglePassCallback pass_callback) {
           return false;
         }
 
-        pass->EncodeCommands(context->GetResourceAllocator());
+        pass->EncodeCommands();
         if (!buffer->SubmitCommands()) {
           return false;
         }

--- a/impeller/renderer/backend/gles/command_buffer_gles.h
+++ b/impeller/renderer/backend/gles/command_buffer_gles.h
@@ -22,7 +22,8 @@ class CommandBufferGLES final : public CommandBuffer {
   ReactorGLES::Ref reactor_;
   bool is_valid_ = false;
 
-  CommandBufferGLES(ReactorGLES::Ref reactor);
+  CommandBufferGLES(std::weak_ptr<const Context> context,
+                    ReactorGLES::Ref reactor);
 
   // |CommandBuffer|
   void SetLabel(const std::string& label) const override;
@@ -31,7 +32,7 @@ class CommandBufferGLES final : public CommandBuffer {
   bool IsValid() const override;
 
   // |CommandBuffer|
-  bool SubmitCommands(CompletionCallback callback) override;
+  bool OnSubmitCommands(CompletionCallback callback) override;
 
   // |CommandBuffer|
   std::shared_ptr<RenderPass> OnCreateRenderPass(

--- a/impeller/renderer/backend/gles/context_gles.cc
+++ b/impeller/renderer/backend/gles/context_gles.cc
@@ -103,7 +103,8 @@ std::shared_ptr<PipelineLibrary> ContextGLES::GetPipelineLibrary() const {
 }
 
 std::shared_ptr<CommandBuffer> ContextGLES::CreateCommandBuffer() const {
-  return std::shared_ptr<CommandBufferGLES>(new CommandBufferGLES(reactor_));
+  return std::shared_ptr<CommandBufferGLES>(
+      new CommandBufferGLES(weak_from_this(), reactor_));
 }
 
 // |Context|

--- a/impeller/renderer/backend/gles/render_pass_gles.h
+++ b/impeller/renderer/backend/gles/render_pass_gles.h
@@ -22,7 +22,9 @@ class RenderPassGLES final : public RenderPass {
   std::string label_;
   bool is_valid_ = false;
 
-  RenderPassGLES(RenderTarget target, ReactorGLES::Ref reactor);
+  RenderPassGLES(std::weak_ptr<const Context> context,
+                 RenderTarget target,
+                 ReactorGLES::Ref reactor);
 
   // |RenderPass|
   bool IsValid() const override;
@@ -31,8 +33,7 @@ class RenderPassGLES final : public RenderPass {
   void OnSetLabel(std::string label) override;
 
   // |RenderPass|
-  bool EncodeCommands(
-      const std::shared_ptr<Allocator>& transients_allocator) const override;
+  bool OnEncodeCommands(const Context& context) const override;
 
   FML_DISALLOW_COPY_AND_ASSIGN(RenderPassGLES);
 };

--- a/impeller/renderer/backend/metal/command_buffer_mtl.h
+++ b/impeller/renderer/backend/metal/command_buffer_mtl.h
@@ -13,8 +13,6 @@ namespace impeller {
 
 class CommandBufferMTL final : public CommandBuffer {
  public:
-  CommandBufferMTL();
-
   // |CommandBuffer|
   ~CommandBufferMTL() override;
 
@@ -23,7 +21,8 @@ class CommandBufferMTL final : public CommandBuffer {
 
   id<MTLCommandBuffer> buffer_ = nullptr;
 
-  CommandBufferMTL(id<MTLCommandQueue> queue);
+  CommandBufferMTL(const std::weak_ptr<const Context> context,
+                   id<MTLCommandQueue> queue);
 
   // |CommandBuffer|
   void SetLabel(const std::string& label) const override;
@@ -32,7 +31,7 @@ class CommandBufferMTL final : public CommandBuffer {
   bool IsValid() const override;
 
   // |CommandBuffer|
-  bool SubmitCommands(CompletionCallback callback) override;
+  bool OnSubmitCommands(CompletionCallback callback) override;
 
   // |CommandBuffer|
   std::shared_ptr<RenderPass> OnCreateRenderPass(

--- a/impeller/renderer/backend/metal/command_buffer_mtl.mm
+++ b/impeller/renderer/backend/metal/command_buffer_mtl.mm
@@ -137,8 +137,9 @@ id<MTLCommandBuffer> CreateCommandBuffer(id<MTLCommandQueue> queue) {
   return [queue commandBuffer];
 }
 
-CommandBufferMTL::CommandBufferMTL(id<MTLCommandQueue> queue)
-    : buffer_(CreateCommandBuffer(queue)) {}
+CommandBufferMTL::CommandBufferMTL(const std::weak_ptr<const Context> context,
+                                   id<MTLCommandQueue> queue)
+    : CommandBuffer(std::move(context)), buffer_(CreateCommandBuffer(queue)) {}
 
 CommandBufferMTL::~CommandBufferMTL() = default;
 
@@ -166,15 +167,7 @@ static CommandBuffer::Status ToCommitResult(MTLCommandBufferStatus status) {
   return CommandBufferMTL::Status::kError;
 }
 
-bool CommandBufferMTL::SubmitCommands(CompletionCallback callback) {
-  if (!IsValid()) {
-    // Already committed or was never valid. Either way, this is caller error.
-    if (callback) {
-      callback(Status::kError);
-    }
-    return false;
-  }
-
+bool CommandBufferMTL::OnSubmitCommands(CompletionCallback callback) {
   if (callback) {
     [buffer_ addCompletedHandler:^(id<MTLCommandBuffer> buffer) {
       LogMTLCommandBufferErrorIfPresent(buffer);
@@ -195,7 +188,7 @@ std::shared_ptr<RenderPass> CommandBufferMTL::OnCreateRenderPass(
   }
 
   auto pass = std::shared_ptr<RenderPassMTL>(
-      new RenderPassMTL(buffer_, std::move(target)));
+      new RenderPassMTL(context_, std::move(target), buffer_));
   if (!pass->IsValid()) {
     return nullptr;
   }

--- a/impeller/renderer/backend/metal/context_mtl.mm
+++ b/impeller/renderer/backend/metal/context_mtl.mm
@@ -193,7 +193,8 @@ std::shared_ptr<CommandBuffer> ContextMTL::CreateCommandBufferInQueue(
     return nullptr;
   }
 
-  auto buffer = std::shared_ptr<CommandBufferMTL>(new CommandBufferMTL(queue));
+  auto buffer = std::shared_ptr<CommandBufferMTL>(
+      new CommandBufferMTL(weak_from_this(), queue));
   if (!buffer->IsValid()) {
     return nullptr;
   }

--- a/impeller/renderer/backend/metal/render_pass_mtl.h
+++ b/impeller/renderer/backend/metal/render_pass_mtl.h
@@ -25,7 +25,9 @@ class RenderPassMTL final : public RenderPass {
   std::string label_;
   bool is_valid_ = false;
 
-  RenderPassMTL(id<MTLCommandBuffer> buffer, RenderTarget target);
+  RenderPassMTL(std::weak_ptr<const Context> context,
+                RenderTarget target,
+                id<MTLCommandBuffer> buffer);
 
   // |RenderPass|
   bool IsValid() const override;
@@ -34,8 +36,7 @@ class RenderPassMTL final : public RenderPass {
   void OnSetLabel(std::string label) override;
 
   // |RenderPass|
-  bool EncodeCommands(
-      const std::shared_ptr<Allocator>& transients_allocator) const override;
+  bool OnEncodeCommands(const Context& context) const override;
 
   bool EncodeCommands(const std::shared_ptr<Allocator>& transients_allocator,
                       id<MTLRenderCommandEncoder> pass) const;

--- a/impeller/renderer/backend/vulkan/command_buffer_vk.cc
+++ b/impeller/renderer/backend/vulkan/command_buffer_vk.cc
@@ -9,7 +9,8 @@
 
 namespace impeller {
 
-CommandBufferVK::CommandBufferVK() = default;
+CommandBufferVK::CommandBufferVK(std::weak_ptr<const Context> context)
+    : CommandBuffer(std::move(context)) {}
 
 CommandBufferVK::~CommandBufferVK() = default;
 
@@ -21,7 +22,7 @@ bool CommandBufferVK::IsValid() const {
   FML_UNREACHABLE();
 }
 
-bool CommandBufferVK::SubmitCommands(CompletionCallback callback) {
+bool CommandBufferVK::OnSubmitCommands(CompletionCallback callback) {
   FML_UNREACHABLE();
 }
 

--- a/impeller/renderer/backend/vulkan/command_buffer_vk.h
+++ b/impeller/renderer/backend/vulkan/command_buffer_vk.h
@@ -17,7 +17,7 @@ class CommandBufferVK final : public CommandBuffer {
  private:
   friend class ContextMTL;
 
-  CommandBufferVK();
+  explicit CommandBufferVK(std::weak_ptr<const Context> context);
 
   // |CommandBuffer|
   void SetLabel(const std::string& label) const override;
@@ -26,7 +26,7 @@ class CommandBufferVK final : public CommandBuffer {
   bool IsValid() const override;
 
   // |CommandBuffer|
-  bool SubmitCommands(CompletionCallback callback) override;
+  bool OnSubmitCommands(CompletionCallback callback) override;
 
   // |CommandBuffer|
   std::shared_ptr<RenderPass> OnCreateRenderPass(

--- a/impeller/renderer/backend/vulkan/render_pass_vk.h
+++ b/impeller/renderer/backend/vulkan/render_pass_vk.h
@@ -27,8 +27,7 @@ class RenderPassVK final : public RenderPass {
   void OnSetLabel(std::string label) override;
 
   // |RenderPass|
-  bool EncodeCommands(
-      const std::shared_ptr<Allocator>& transients_allocator) const override;
+  bool OnEncodeCommands(const Context& context) const override;
 
   FML_DISALLOW_COPY_AND_ASSIGN(RenderPassVK);
 };

--- a/impeller/renderer/command_buffer.cc
+++ b/impeller/renderer/command_buffer.cc
@@ -4,14 +4,28 @@
 
 #include "impeller/renderer/command_buffer.h"
 
+#include "flutter/fml/trace_event.h"
 #include "impeller/renderer/render_pass.h"
 #include "impeller/renderer/render_target.h"
 
 namespace impeller {
 
-CommandBuffer::CommandBuffer() = default;
+CommandBuffer::CommandBuffer(std::weak_ptr<const Context> context)
+    : context_(std::move(context)) {}
 
 CommandBuffer::~CommandBuffer() = default;
+
+bool CommandBuffer::SubmitCommands(CompletionCallback callback) {
+  TRACE_EVENT0("impeller", "CommandBuffer::SubmitCommands");
+  if (!IsValid()) {
+    // Already committed or was never valid. Either way, this is caller error.
+    if (callback) {
+      callback(Status::kError);
+    }
+    return false;
+  }
+  return OnSubmitCommands(callback);
+}
 
 bool CommandBuffer::SubmitCommands() {
   return SubmitCommands(nullptr);

--- a/impeller/renderer/command_buffer.h
+++ b/impeller/renderer/command_buffer.h
@@ -59,7 +59,7 @@ class CommandBuffer {
   ///
   /// @param[in]  callback  The completion callback.
   ///
-  [[nodiscard]] virtual bool SubmitCommands(CompletionCallback callback) = 0;
+  [[nodiscard]] bool SubmitCommands(CompletionCallback callback);
 
   [[nodiscard]] bool SubmitCommands();
 
@@ -82,12 +82,16 @@ class CommandBuffer {
   std::shared_ptr<BlitPass> CreateBlitPass() const;
 
  protected:
-  CommandBuffer();
+  std::weak_ptr<const Context> context_;
+
+  explicit CommandBuffer(std::weak_ptr<const Context> context);
 
   virtual std::shared_ptr<RenderPass> OnCreateRenderPass(
       RenderTarget render_target) const = 0;
 
   virtual std::shared_ptr<BlitPass> OnCreateBlitPass() const = 0;
+
+  [[nodiscard]] virtual bool OnSubmitCommands(CompletionCallback callback) = 0;
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(CommandBuffer);

--- a/impeller/renderer/context.h
+++ b/impeller/renderer/context.h
@@ -17,7 +17,7 @@ class CommandBuffer;
 class PipelineLibrary;
 class Allocator;
 
-class Context {
+class Context : public std::enable_shared_from_this<Context> {
  public:
   virtual ~Context();
 

--- a/impeller/renderer/render_pass.h
+++ b/impeller/renderer/render_pass.h
@@ -51,22 +51,22 @@ class RenderPass {
   //----------------------------------------------------------------------------
   /// @brief      Encode the recorded commands to the underlying command buffer.
   ///
-  /// @param      transients_allocator  The transients allocator.
-  ///
   /// @return     If the commands were encoded to the underlying command
   ///             buffer.
   ///
-  virtual bool EncodeCommands(
-      const std::shared_ptr<Allocator>& transients_allocator) const = 0;
+  bool EncodeCommands() const;
 
  protected:
+  const std::weak_ptr<const Context> context_;
   const RenderTarget render_target_;
   std::shared_ptr<HostBuffer> transients_buffer_;
   std::vector<Command> commands_;
 
-  RenderPass(RenderTarget target);
+  RenderPass(std::weak_ptr<const Context> context, RenderTarget target);
 
   virtual void OnSetLabel(std::string label) = 0;
+
+  virtual bool OnEncodeCommands(const Context& context) const = 0;
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(RenderPass);

--- a/impeller/renderer/renderer.cc
+++ b/impeller/renderer/renderer.cc
@@ -53,8 +53,11 @@ bool Renderer::Render(std::unique_ptr<Surface> surface,
     return false;
   }
 
+  const auto present_result = surface->Present();
+
   frames_in_flight_sema_->Signal();
-  return surface->Present();
+
+  return present_result;
 }
 
 std::shared_ptr<Context> Renderer::GetContext() const {

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -378,7 +378,7 @@ TEST_P(RendererTest, CanRenderToTexture) {
   VS::BindUniformBuffer(
       cmd, r2t_pass->GetTransientsBuffer().EmplaceUniform(uniforms));
   ASSERT_TRUE(r2t_pass->AddCommand(std::move(cmd)));
-  ASSERT_TRUE(r2t_pass->EncodeCommands(context->GetResourceAllocator()));
+  ASSERT_TRUE(r2t_pass->EncodeCommands());
 }
 
 #if IMPELLER_ENABLE_METAL
@@ -543,7 +543,7 @@ TEST_P(RendererTest, CanBlitTextureToTexture) {
 
         pass->AddCommand(std::move(cmd));
       }
-      pass->EncodeCommands(context->GetResourceAllocator());
+      pass->EncodeCommands();
     }
 
     if (!buffer->SubmitCommands()) {
@@ -664,7 +664,7 @@ TEST_P(RendererTest, CanGenerateMipmaps) {
 
         pass->AddCommand(std::move(cmd));
       }
-      pass->EncodeCommands(context->GetResourceAllocator());
+      pass->EncodeCommands();
     }
 
     if (!buffer->SubmitCommands()) {


### PR DESCRIPTION
This makes the submission simpler as the allocators can be acquired from the
pass itself.

Also makes command buffer submission go through a common method that performs
error checking before dispatch to the backend.