### PR TITLE
[Impeller] Add implementations for concurrent work-queues.

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -450,6 +450,8 @@ FILE: ../../../flutter/impeller/base/base_unittests.cc
 FILE: ../../../flutter/impeller/base/comparable.cc
 FILE: ../../../flutter/impeller/base/comparable.h
 FILE: ../../../flutter/impeller/base/config.h
+FILE: ../../../flutter/impeller/base/platform/darwin/work_queue_darwin.cc
+FILE: ../../../flutter/impeller/base/platform/darwin/work_queue_darwin.h
 FILE: ../../../flutter/impeller/base/promise.cc
 FILE: ../../../flutter/impeller/base/promise.h
 FILE: ../../../flutter/impeller/base/strings.cc
@@ -462,6 +464,10 @@ FILE: ../../../flutter/impeller/base/validation.cc
 FILE: ../../../flutter/impeller/base/validation.h
 FILE: ../../../flutter/impeller/base/version.cc
 FILE: ../../../flutter/impeller/base/version.h
+FILE: ../../../flutter/impeller/base/work_queue.cc
+FILE: ../../../flutter/impeller/base/work_queue.h
+FILE: ../../../flutter/impeller/base/work_queue_common.cc
+FILE: ../../../flutter/impeller/base/work_queue_common.h
 FILE: ../../../flutter/impeller/blobcat/blob.cc
 FILE: ../../../flutter/impeller/blobcat/blob.h
 FILE: ../../../flutter/impeller/blobcat/blob_library.cc

--- a/impeller/base/BUILD.gn
+++ b/impeller/base/BUILD.gn
@@ -24,7 +24,18 @@ impeller_component("base") {
     "validation.h",
     "version.cc",
     "version.h",
+    "work_queue.cc",
+    "work_queue.h",
+    "work_queue_common.cc",
+    "work_queue_common.h",
   ]
+
+  if (is_ios || is_mac) {
+    sources += [
+      "platform/darwin/work_queue_darwin.cc",
+      "platform/darwin/work_queue_darwin.h",
+    ]
+  }
 
   deps = [ "//flutter/fml" ]
 }

--- a/impeller/base/platform/darwin/work_queue_darwin.cc
+++ b/impeller/base/platform/darwin/work_queue_darwin.cc
@@ -1,0 +1,38 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/base/platform/darwin/work_queue_darwin.h"
+
+namespace impeller {
+
+std::shared_ptr<WorkQueueDarwin> WorkQueueDarwin::Create() {
+  auto queue = std::shared_ptr<WorkQueueDarwin>(new WorkQueueDarwin());
+  if (!queue->IsValid()) {
+    return nullptr;
+  }
+  return queue;
+}
+
+WorkQueueDarwin::WorkQueueDarwin()
+    : queue_(::dispatch_queue_create(
+          "io.flutter.impeller.wq",
+          ::dispatch_queue_attr_make_with_qos_class(
+              DISPATCH_QUEUE_CONCURRENT_WITH_AUTORELEASE_POOL,
+              QOS_CLASS_USER_INITIATED,
+              -1))) {}
+
+WorkQueueDarwin::~WorkQueueDarwin() = default;
+
+bool WorkQueueDarwin::IsValid() const {
+  return queue_ != NULL;
+}
+
+// |WorkQueue|
+void WorkQueueDarwin::PostTask(fml::closure task) {
+  dispatch_async(queue_, ^() {
+    task();
+  });
+}
+
+}  // namespace impeller

--- a/impeller/base/platform/darwin/work_queue_darwin.h
+++ b/impeller/base/platform/darwin/work_queue_darwin.h
@@ -1,0 +1,36 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#pragma once
+
+#include <dispatch/dispatch.h>
+
+#include <memory>
+
+#include "flutter/fml/macros.h"
+#include "impeller/base/work_queue.h"
+
+namespace impeller {
+
+class WorkQueueDarwin final : public WorkQueue {
+ public:
+  static std::shared_ptr<WorkQueueDarwin> Create();
+
+  // |WorkQueue|
+  ~WorkQueueDarwin();
+
+  bool IsValid() const;
+
+ private:
+  dispatch_queue_t queue_ = NULL;
+
+  WorkQueueDarwin();
+
+  // |WorkQueue|
+  void PostTask(fml::closure task) override;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(WorkQueueDarwin);
+};
+
+}  // namespace impeller

--- a/impeller/base/work_queue.cc
+++ b/impeller/base/work_queue.cc
@@ -1,0 +1,13 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/impeller/base/work_queue.h"
+
+namespace impeller {
+
+WorkQueue::WorkQueue() = default;
+
+WorkQueue::~WorkQueue() = default;
+
+}  // namespace impeller

--- a/impeller/base/work_queue.h
+++ b/impeller/base/work_queue.h
@@ -1,0 +1,27 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#pragma once
+
+#include <memory>
+
+#include "flutter/fml/closure.h"
+#include "flutter/fml/macros.h"
+
+namespace impeller {
+
+class WorkQueue : public std::enable_shared_from_this<WorkQueue> {
+ public:
+  virtual ~WorkQueue();
+
+  virtual void PostTask(fml::closure task) = 0;
+
+ protected:
+  WorkQueue();
+
+ private:
+  FML_DISALLOW_COPY_AND_ASSIGN(WorkQueue);
+};
+
+}  // namespace impeller

--- a/impeller/base/work_queue_common.cc
+++ b/impeller/base/work_queue_common.cc
@@ -1,0 +1,25 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/base/work_queue_common.h"
+
+namespace impeller {
+
+std::shared_ptr<WorkQueueCommon> WorkQueueCommon::Create() {
+  return std::shared_ptr<WorkQueueCommon>(new WorkQueueCommon());
+}
+
+WorkQueueCommon::WorkQueueCommon()
+    : loop_(fml::ConcurrentMessageLoop::Create(2u)) {}
+
+WorkQueueCommon::~WorkQueueCommon() {
+  loop_->Terminate();
+}
+
+// |WorkQueue|
+void WorkQueueCommon::PostTask(fml::closure task) {
+  loop_->GetTaskRunner()->PostTask(std::move(task));
+}
+
+}  // namespace impeller

--- a/impeller/base/work_queue_common.h
+++ b/impeller/base/work_queue_common.h
@@ -1,0 +1,33 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#pragma once
+
+#include <memory>
+
+#include "flutter/fml/concurrent_message_loop.h"
+#include "flutter/fml/macros.h"
+#include "impeller/base/work_queue.h"
+
+namespace impeller {
+
+class WorkQueueCommon : public WorkQueue {
+ public:
+  static std::shared_ptr<WorkQueueCommon> Create();
+
+  // |WorkQueue|
+  ~WorkQueueCommon();
+
+ private:
+  std::shared_ptr<fml::ConcurrentMessageLoop> loop_;
+
+  WorkQueueCommon();
+
+  // |WorkQueue|
+  void PostTask(fml::closure task) override;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(WorkQueueCommon);
+};
+
+}  // namespace impeller

--- a/impeller/renderer/backend/gles/context_gles.cc
+++ b/impeller/renderer/backend/gles/context_gles.cc
@@ -6,6 +6,7 @@
 
 #include "impeller/base/config.h"
 #include "impeller/base/validation.h"
+#include "impeller/base/work_queue_common.h"
 
 namespace impeller {
 
@@ -52,10 +53,19 @@ ContextGLES::ContextGLES(
     }
   }
 
-  // Create the sampler library
+  // Create the sampler library.
   {
     sampler_library_ =
         std::shared_ptr<SamplerLibraryGLES>(new SamplerLibraryGLES());
+  }
+
+  // Create the work queue.
+  {
+    work_queue_ = WorkQueueCommon::Create();
+    if (!work_queue_) {
+      VALIDATION_LOG << "Could not create work queue.";
+      return;
+    }
   }
 
   is_valid_ = true;
@@ -86,25 +96,35 @@ bool ContextGLES::IsValid() const {
   return is_valid_;
 }
 
+// |Context|
 std::shared_ptr<Allocator> ContextGLES::GetResourceAllocator() const {
   return resource_allocator_;
 }
 
+// |Context|
 std::shared_ptr<ShaderLibrary> ContextGLES::GetShaderLibrary() const {
   return shader_library_;
 }
 
+// |Context|
 std::shared_ptr<SamplerLibrary> ContextGLES::GetSamplerLibrary() const {
   return sampler_library_;
 }
 
+// |Context|
 std::shared_ptr<PipelineLibrary> ContextGLES::GetPipelineLibrary() const {
   return pipeline_library_;
 }
 
+// |Context|
 std::shared_ptr<CommandBuffer> ContextGLES::CreateCommandBuffer() const {
   return std::shared_ptr<CommandBufferGLES>(
       new CommandBufferGLES(weak_from_this(), reactor_));
+}
+
+// |Context|
+std::shared_ptr<WorkQueue> ContextGLES::GetWorkQueue() const {
+  return work_queue_;
 }
 
 // |Context|

--- a/impeller/renderer/backend/gles/context_gles.h
+++ b/impeller/renderer/backend/gles/context_gles.h
@@ -38,6 +38,7 @@ class ContextGLES final : public Context,
   std::shared_ptr<ShaderLibraryGLES> shader_library_;
   std::shared_ptr<PipelineLibraryGLES> pipeline_library_;
   std::shared_ptr<SamplerLibraryGLES> sampler_library_;
+  std::shared_ptr<WorkQueue> work_queue_;
   std::shared_ptr<AllocatorGLES> resource_allocator_;
   bool is_valid_ = false;
 
@@ -61,6 +62,9 @@ class ContextGLES final : public Context,
 
   // |Context|
   std::shared_ptr<CommandBuffer> CreateCommandBuffer() const override;
+
+  // |Context|
+  std::shared_ptr<WorkQueue> GetWorkQueue() const override;
 
   // |Context|
   bool HasThreadingRestrictions() const override;

--- a/impeller/renderer/backend/metal/context_mtl.h
+++ b/impeller/renderer/backend/metal/context_mtl.h
@@ -42,6 +42,7 @@ class ContextMTL final : public Context,
   std::shared_ptr<PipelineLibraryMTL> pipeline_library_;
   std::shared_ptr<SamplerLibrary> sampler_library_;
   std::shared_ptr<AllocatorMTL> resource_allocator_;
+  std::shared_ptr<WorkQueue> work_queue_;
   bool is_valid_ = false;
 
   ContextMTL(id<MTLDevice> device, NSArray<id<MTLLibrary>>* shader_libraries);
@@ -63,6 +64,9 @@ class ContextMTL final : public Context,
 
   // |Context|
   std::shared_ptr<CommandBuffer> CreateCommandBuffer() const override;
+
+  // |Context|
+  std::shared_ptr<WorkQueue> GetWorkQueue() const override;
 
   std::shared_ptr<CommandBuffer> CreateCommandBufferInQueue(
       id<MTLCommandQueue> queue) const;

--- a/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/impeller/renderer/backend/vulkan/context_vk.cc
@@ -12,6 +12,7 @@
 #include "flutter/fml/build_config.h"
 #include "flutter/fml/trace_event.h"
 #include "impeller/base/validation.h"
+#include "impeller/base/work_queue_common.h"
 #include "impeller/renderer/backend/vulkan/allocator_vk.h"
 #include "impeller/renderer/backend/vulkan/capabilities_vk.h"
 #include "impeller/renderer/backend/vulkan/surface_producer_vk.h"
@@ -407,6 +408,13 @@ ContextVK::ContextVK(
     return;
   }
 
+  auto work_queue = WorkQueueCommon::Create();
+
+  if (!work_queue) {
+    VALIDATION_LOG << "Could not create workqueue.";
+    return;
+  }
+
   instance_ = std::move(instance.value);
   debug_messenger_ = std::move(debug_messenger);
   device_ = std::move(device.value);
@@ -414,6 +422,7 @@ ContextVK::ContextVK(
   shader_library_ = std::move(shader_library);
   sampler_library_ = std::move(sampler_library);
   pipeline_library_ = std::move(pipeline_library);
+  work_queue_ = std::move(work_queue);
   graphics_queue_ =
       device_->getQueue(graphics_queue->family, graphics_queue->index);
   compute_queue_ =
@@ -445,6 +454,11 @@ std::shared_ptr<SamplerLibrary> ContextVK::GetSamplerLibrary() const {
 
 std::shared_ptr<PipelineLibrary> ContextVK::GetPipelineLibrary() const {
   return pipeline_library_;
+}
+
+// |Context|
+std::shared_ptr<WorkQueue> ContextVK::GetWorkQueue() const {
+  return work_queue_;
 }
 
 std::shared_ptr<CommandBuffer> ContextVK::CreateCommandBuffer() const {

--- a/impeller/renderer/backend/vulkan/context_vk.h
+++ b/impeller/renderer/backend/vulkan/context_vk.h
@@ -78,6 +78,7 @@ class ContextVK final : public Context, public BackendCast<ContextVK, Context> {
   std::unique_ptr<SwapchainVK> swapchain_;
   std::unique_ptr<CommandPoolVK> graphics_command_pool_;
   std::unique_ptr<SurfaceProducerVK> surface_producer_;
+  std::shared_ptr<WorkQueue> work_queue_;
   bool is_valid_ = false;
 
   ContextVK(
@@ -101,6 +102,9 @@ class ContextVK final : public Context, public BackendCast<ContextVK, Context> {
 
   // |Context|
   std::shared_ptr<CommandBuffer> CreateCommandBuffer() const override;
+
+  // |Context|
+  std::shared_ptr<WorkQueue> GetWorkQueue() const override;
 
   FML_DISALLOW_COPY_AND_ASSIGN(ContextVK);
 };

--- a/impeller/renderer/context.h
+++ b/impeller/renderer/context.h
@@ -16,6 +16,7 @@ class SamplerLibrary;
 class CommandBuffer;
 class PipelineLibrary;
 class Allocator;
+class WorkQueue;
 
 class Context : public std::enable_shared_from_this<Context> {
  public:
@@ -35,6 +36,8 @@ class Context : public std::enable_shared_from_this<Context> {
   virtual std::shared_ptr<PipelineLibrary> GetPipelineLibrary() const = 0;
 
   virtual std::shared_ptr<CommandBuffer> CreateCommandBuffer() const = 0;
+
+  virtual std::shared_ptr<WorkQueue> GetWorkQueue() const = 0;
 
   virtual bool HasThreadingRestrictions() const;
 


### PR DESCRIPTION
These workers are owned by Impeller and not shared with the IO pool because we
don't want long running tasks such as image decompression getting in the way of
these Impeller render tasks. Impeller will still use the work pool provided by
the shell for image decompression as before.

This patch just adds the queues but doesn't use them.

We can make the common work queues better later. These are just placeholders
for now to provide some workers for GLES and Vulkan. The Darwin stuff sets up
the right pools with QOS classes.