### PR TITLE
[Impeller] [vulkan] reland binding offset for vulkan

### DIFF
--- a/impeller/compiler/code_gen_template.h
+++ b/impeller/compiler/code_gen_template.h
@@ -152,7 +152,6 @@ std::move({{ arg.argument_name }}){% if not loop.is_last %}, {% endif %}
   // ===========================================================================
   // Metadata for Vulkan =======================================================
   // ===========================================================================
-{% if length(buffers)+length(sampled_images) > 0 %}
   static constexpr std::array<DescriptorSetLayout,{{length(buffers)+length(sampled_images)}}> kDescriptorSetLayouts{
 {% for buffer in buffers %}
     DescriptorSetLayout{
@@ -171,7 +170,6 @@ std::move({{ arg.argument_name }}){% if not loop.is_last %}, {% endif %}
     },
 {% endfor %}
   };
-{% endif %}
 
 };  // struct {{camel_case(shader_name)}}{{camel_case(shader_stage)}}Shader
 

--- a/impeller/compiler/compiler.cc
+++ b/impeller/compiler/compiler.cc
@@ -14,9 +14,14 @@
 #include "impeller/compiler/compiler_backend.h"
 #include "impeller/compiler/includer.h"
 #include "impeller/compiler/logger.h"
+#include "impeller/compiler/types.h"
 
 namespace impeller {
 namespace compiler {
+
+const uint32_t kFragBindingBase = 128;
+const size_t kNumUniformKinds =
+    int(shaderc_uniform_kind::shaderc_uniform_kind_buffer) + 1;
 
 static CompilerBackend CreateMSLCompiler(const spirv_cross::ParsedIR& ir,
                                          const SourceOptions& source_options) {
@@ -223,6 +228,15 @@ static void SetLimitations(shaderc::CompileOptions& compiler_opts) {
   }
 }
 
+void Compiler::SetBindingBase(shaderc::CompileOptions& compiler_opts) const {
+  for (size_t uniform_kind = 0; uniform_kind < kNumUniformKinds;
+       uniform_kind++) {
+    compiler_opts.SetBindingBaseForStage(
+        ToShaderCShaderKind(SourceType::kFragmentShader),
+        static_cast<shaderc_uniform_kind>(uniform_kind), kFragBindingBase);
+  }
+}
+
 Compiler::Compiler(const fml::Mapping& source_mapping,
                    SourceOptions source_options,
                    Reflector::Options reflector_options)
@@ -333,6 +347,9 @@ Compiler::Compiler(const fml::Mapping& source_mapping,
   }
 
   spirv_options.SetAutoBindUniforms(true);
+#ifdef IMPELLER_ENABLE_VULKAN
+  SetBindingBase(spirv_options);
+#endif
   spirv_options.SetAutoMapLocations(true);
 
   std::vector<std::string> included_file_names;

--- a/impeller/compiler/compiler.h
+++ b/impeller/compiler/compiler.h
@@ -57,6 +57,8 @@ class Compiler {
 
   std::string GetDependencyNames(std::string separator) const;
 
+  void SetBindingBase(shaderc::CompileOptions& compiler_opts) const;
+
   FML_DISALLOW_COPY_AND_ASSIGN(Compiler);
 };
 

--- a/impeller/compiler/compiler_test.cc
+++ b/impeller/compiler/compiler_test.cc
@@ -89,6 +89,13 @@ bool CompilerTest::ValidateDepfileEscaped(const char* fixture_name) const {
   return true;
 }
 
+std::unique_ptr<fml::FileMapping> CompilerTest::GetReflectionJson(
+    const char* fixture_name) const {
+  auto filename = ReflectionJSONName(fixture_name);
+  auto fd = fml::OpenFileReadOnly(intermediates_directory_, filename.c_str());
+  return fml::FileMapping::CreateReadOnly(fd);
+}
+
 bool CompilerTest::CanCompileAndReflect(const char* fixture_name,
                                         SourceType source_type) const {
   auto fixture = flutter::testing::OpenFixtureAsMapping(fixture_name);

--- a/impeller/compiler/compiler_test.h
+++ b/impeller/compiler/compiler_test.h
@@ -21,6 +21,9 @@ class CompilerTest : public ::testing::TestWithParam<TargetPlatform> {
 
   ~CompilerTest();
 
+  std::unique_ptr<fml::FileMapping> GetReflectionJson(
+      const char* fixture_name) const;
+
   bool CanCompileAndReflect(
       const char* fixture_name,
       SourceType source_type = SourceType::kUnknown) const;

--- a/impeller/compiler/compiler_unittests.cc
+++ b/impeller/compiler/compiler_unittests.cc
@@ -70,6 +70,27 @@ TEST_P(CompilerTest, ShaderWithSpecialCharactersHasEscapedDepfile) {
   ASSERT_TRUE(ValidateDepfileEscaped("sa\%m#ple.vert"));
 }
 
+TEST_P(CompilerTest, BindingBaseForFragShader) {
+  if (GetParam() == TargetPlatform::kFlutterSPIRV) {
+    // This is a failure of reflection which this target doesn't perform.
+    GTEST_SKIP();
+  }
+
+  ASSERT_TRUE(CanCompileAndReflect("sample.vert", SourceType::kVertexShader));
+  ASSERT_TRUE(CanCompileAndReflect("sample.frag", SourceType::kFragmentShader));
+
+  auto get_binding = [&](const char* fixture) -> uint32_t {
+    auto json_fd = GetReflectionJson(fixture);
+    nlohmann::json shader_json = nlohmann::json::parse(json_fd->GetMapping());
+    return shader_json["buffers"][0]["binding"].get<uint32_t>();
+  };
+
+  auto vert_uniform_binding = get_binding("sample.vert");
+  auto frag_uniform_binding = get_binding("sample.frag");
+
+  ASSERT_GT(frag_uniform_binding, vert_uniform_binding);
+}
+
 #define INSTANTIATE_TARGET_PLATFORM_TEST_SUITE_P(suite_name)              \
   INSTANTIATE_TEST_SUITE_P(                                               \
       suite_name, CompilerTest,                                           \

--- a/impeller/compiler/compiler_unittests.cc
+++ b/impeller/compiler/compiler_unittests.cc
@@ -76,6 +76,10 @@ TEST_P(CompilerTest, BindingBaseForFragShader) {
     GTEST_SKIP();
   }
 
+#ifndef IMPELLER_ENABLE_VULKAN
+  GTEST_SKIP();
+#endif
+
   ASSERT_TRUE(CanCompileAndReflect("sample.vert", SourceType::kVertexShader));
   ASSERT_TRUE(CanCompileAndReflect("sample.frag", SourceType::kFragmentShader));
 

--- a/impeller/fixtures/BUILD.gn
+++ b/impeller/fixtures/BUILD.gn
@@ -44,6 +44,7 @@ test_fixtures("file_fixtures") {
     "kalimba.jpg",
     "resources_limit.vert",
     "sample.comp",
+    "sample.frag",
     "sample.tesc",
     "sample.tese",
     "sample.vert",

--- a/impeller/fixtures/sample.frag
+++ b/impeller/fixtures/sample.frag
@@ -1,0 +1,14 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+uniform FragInfo {
+  vec4 color;
+}
+frag_info;
+
+out vec4 frag_color;
+
+void main() {
+  frag_color = frag_info.color;
+}

--- a/impeller/renderer/pipeline_builder.h
+++ b/impeller/renderer/pipeline_builder.h
@@ -100,6 +100,15 @@ struct PipelineBuilder {
                        << VertexShader::kLabel << "'.";
         return false;
       }
+
+      if (!vertex_descriptor->SetDescriptorSetLayouts(
+              FragmentShader::kDescriptorSetLayouts)) {
+        VALIDATION_LOG << "Cound not configure vertex descriptor set layout for"
+                          " pipeline named '"
+                       << VertexShader::kLabel << "'.";
+        return false;
+      }
+
       desc.SetVertexDescriptor(std::move(vertex_descriptor));
     }
 


### PR DESCRIPTION
The binding offsets are enabled only for vulkan, as they are causing problems in OpenGL.
