### PR TITLE
[Impeller] Cleanup the build dependency graph.

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -898,6 +898,7 @@ FILE: ../../../flutter/impeller/runtime_stage/runtime_stage.h
 FILE: ../../../flutter/impeller/runtime_stage/runtime_stage_playground.cc
 FILE: ../../../flutter/impeller/runtime_stage/runtime_stage_playground.h
 FILE: ../../../flutter/impeller/runtime_stage/runtime_stage_unittests.cc
+FILE: ../../../flutter/impeller/runtime_stage/runtime_types.h
 FILE: ../../../flutter/impeller/tessellator/c/tessellator.cc
 FILE: ../../../flutter/impeller/tessellator/c/tessellator.h
 FILE: ../../../flutter/impeller/tessellator/dart/lib/tessellator.dart

--- a/impeller/renderer/BUILD.gn
+++ b/impeller/renderer/BUILD.gn
@@ -81,6 +81,7 @@ impeller_component("renderer") {
     "../base",
     "../geometry",
     "../image",
+    "../runtime_stage",
     "../tessellator",
   ]
 

--- a/impeller/renderer/shader_types.h
+++ b/impeller/renderer/shader_types.h
@@ -9,7 +9,9 @@
 #include <vector>
 
 #include "flutter/fml/hash_combine.h"
+#include "flutter/fml/logging.h"
 #include "impeller/geometry/matrix.h"
+#include "impeller/runtime_stage/runtime_types.h"
 
 namespace impeller {
 
@@ -21,6 +23,22 @@ enum class ShaderStage {
   kTessellationEvaluation,
   kCompute,
 };
+
+constexpr ShaderStage ToShaderStage(RuntimeShaderStage stage) {
+  switch (stage) {
+    case RuntimeShaderStage::kVertex:
+      return ShaderStage::kVertex;
+    case RuntimeShaderStage::kFragment:
+      return ShaderStage::kFragment;
+    case RuntimeShaderStage::kCompute:
+      return ShaderStage::kCompute;
+    case RuntimeShaderStage::kTessellationControl:
+      return ShaderStage::kTessellationControl;
+    case RuntimeShaderStage::kTessellationEvaluation:
+      return ShaderStage::kTessellationEvaluation;
+  }
+  FML_UNREACHABLE();
+}
 
 enum class ShaderType {
   kUnknown,

--- a/impeller/runtime_stage/BUILD.gn
+++ b/impeller/runtime_stage/BUILD.gn
@@ -20,11 +20,11 @@ impeller_component("runtime_stage") {
   sources = [
     "runtime_stage.cc",
     "runtime_stage.h",
+    "runtime_types.h",
   ]
   public_deps = [
     ":runtime_stage_flatbuffers",
     "../base",
-    "../renderer",
     "//flutter/fml",
   ]
 }

--- a/impeller/runtime_stage/runtime_stage.cc
+++ b/impeller/runtime_stage/runtime_stage.cc
@@ -43,18 +43,18 @@ static RuntimeUniformType ToType(fb::UniformDataType type) {
   FML_UNREACHABLE();
 }
 
-static ShaderStage ToShaderStage(fb::Stage stage) {
+static RuntimeShaderStage ToShaderStage(fb::Stage stage) {
   switch (stage) {
     case fb::Stage::kVertex:
-      return ShaderStage::kVertex;
+      return RuntimeShaderStage::kVertex;
     case fb::Stage::kFragment:
-      return ShaderStage::kFragment;
+      return RuntimeShaderStage::kFragment;
     case fb::Stage::kCompute:
-      return ShaderStage::kCompute;
+      return RuntimeShaderStage::kCompute;
     case fb::Stage::kTessellationControl:
-      return ShaderStage::kTessellationControl;
+      return RuntimeShaderStage::kTessellationControl;
     case fb::Stage::kTessellationEvaluation:
-      return ShaderStage::kTessellationEvaluation;
+      return RuntimeShaderStage::kTessellationEvaluation;
   }
   FML_UNREACHABLE();
 }
@@ -128,7 +128,7 @@ const std::string& RuntimeStage::GetEntrypoint() const {
   return entrypoint_;
 }
 
-ShaderStage RuntimeStage::GetShaderStage() const {
+RuntimeShaderStage RuntimeStage::GetShaderStage() const {
   return stage_;
 }
 

--- a/impeller/runtime_stage/runtime_stage.h
+++ b/impeller/runtime_stage/runtime_stage.h
@@ -9,52 +9,19 @@
 
 #include "flutter/fml/macros.h"
 #include "flutter/fml/mapping.h"
-#include "impeller/renderer/shader_function.h"
-#include "impeller/renderer/shader_types.h"
+#include "impeller/runtime_stage/runtime_types.h"
 
 namespace impeller {
 
-enum RuntimeUniformType {
-  kBoolean,
-  kSignedByte,
-  kUnsignedByte,
-  kSignedShort,
-  kUnsignedShort,
-  kSignedInt,
-  kUnsignedInt,
-  kSignedInt64,
-  kUnsignedInt64,
-  kHalfFloat,
-  kFloat,
-  kDouble,
-  kSampledImage,
-};
-
-struct RuntimeUniformDimensions {
-  size_t rows = 0;
-  size_t cols = 0;
-};
-
-struct RuntimeUniformDescription {
-  std::string name;
-  size_t location = 0u;
-  RuntimeUniformType type = kFloat;
-  RuntimeUniformDimensions dimensions;
-  size_t bit_width;
-  size_t array_elements;
-};
-
-size_t SizeOfRuntimeUniformType(RuntimeUniformType type);
-
 class RuntimeStage {
  public:
-  RuntimeStage(std::shared_ptr<fml::Mapping> payload);
+  explicit RuntimeStage(std::shared_ptr<fml::Mapping> payload);
 
   ~RuntimeStage();
 
   bool IsValid() const;
 
-  ShaderStage GetShaderStage() const;
+  RuntimeShaderStage GetShaderStage() const;
 
   const std::vector<RuntimeUniformDescription>& GetUniforms() const;
 
@@ -65,7 +32,7 @@ class RuntimeStage {
   const std::shared_ptr<fml::Mapping>& GetCodeMapping() const;
 
  private:
-  ShaderStage stage_ = ShaderStage::kUnknown;
+  RuntimeShaderStage stage_ = RuntimeShaderStage::kVertex;
   std::shared_ptr<fml::Mapping> payload_;
   std::string entrypoint_;
   std::shared_ptr<fml::Mapping> code_mapping_;

--- a/impeller/runtime_stage/runtime_stage_playground.cc
+++ b/impeller/runtime_stage/runtime_stage_playground.cc
@@ -9,6 +9,7 @@
 #include "flutter/fml/make_copyable.h"
 #include "flutter/testing/testing.h"
 #include "impeller/renderer/shader_library.h"
+#include "impeller/renderer/shader_types.h"
 
 namespace impeller {
 
@@ -34,7 +35,8 @@ bool RuntimeStagePlayground::RegisterStage(const RuntimeStage& stage) {
   auto future = registration.get_future();
   auto library = GetContext()->GetShaderLibrary();
   GetContext()->GetShaderLibrary()->RegisterFunction(
-      stage.GetEntrypoint(), stage.GetShaderStage(), stage.GetCodeMapping(),
+      stage.GetEntrypoint(), ToShaderStage(stage.GetShaderStage()),
+      stage.GetCodeMapping(),
       fml::MakeCopyable([reg = std::move(registration)](bool result) mutable {
         reg.set_value(result);
       }));

--- a/impeller/runtime_stage/runtime_stage_unittests.cc
+++ b/impeller/runtime_stage/runtime_stage_unittests.cc
@@ -13,6 +13,7 @@
 #include "impeller/renderer/pipeline_descriptor.h"
 #include "impeller/renderer/pipeline_library.h"
 #include "impeller/renderer/shader_library.h"
+#include "impeller/renderer/shader_types.h"
 #include "impeller/runtime_stage/runtime_stage.h"
 #include "impeller/runtime_stage/runtime_stage_playground.h"
 
@@ -29,7 +30,7 @@ TEST(RuntimeStageTest, CanReadValidBlob) {
   ASSERT_GT(fixture->GetSize(), 0u);
   RuntimeStage stage(std::move(fixture));
   ASSERT_TRUE(stage.IsValid());
-  ASSERT_EQ(stage.GetShaderStage(), ShaderStage::kFragment);
+  ASSERT_EQ(stage.GetShaderStage(), RuntimeShaderStage::kFragment);
 }
 
 TEST(RuntimeStageTest, CanRejectInvalidBlob) {
@@ -199,9 +200,9 @@ TEST_P(RuntimeStageTest, CanRegisterStage) {
   auto future = registration.get_future();
   auto library = GetContext()->GetShaderLibrary();
   library->RegisterFunction(
-      stage.GetEntrypoint(),   //
-      stage.GetShaderStage(),  //
-      stage.GetCodeMapping(),  //
+      stage.GetEntrypoint(),                  //
+      ToShaderStage(stage.GetShaderStage()),  //
+      stage.GetCodeMapping(),                 //
       fml::MakeCopyable([reg = std::move(registration)](bool result) mutable {
         reg.set_value(result);
       }));

--- a/impeller/runtime_stage/runtime_types.h
+++ b/impeller/runtime_stage/runtime_types.h
@@ -1,0 +1,50 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+namespace impeller {
+
+enum RuntimeUniformType {
+  kBoolean,
+  kSignedByte,
+  kUnsignedByte,
+  kSignedShort,
+  kUnsignedShort,
+  kSignedInt,
+  kUnsignedInt,
+  kSignedInt64,
+  kUnsignedInt64,
+  kHalfFloat,
+  kFloat,
+  kDouble,
+  kSampledImage,
+};
+
+enum class RuntimeShaderStage {
+  kVertex,
+  kFragment,
+  kCompute,
+  kTessellationControl,
+  kTessellationEvaluation,
+};
+
+struct RuntimeUniformDimensions {
+  size_t rows = 0;
+  size_t cols = 0;
+};
+
+struct RuntimeUniformDescription {
+  std::string name;
+  size_t location = 0u;
+  RuntimeUniformType type = RuntimeUniformType::kFloat;
+  RuntimeUniformDimensions dimensions;
+  size_t bit_width;
+  size_t array_elements;
+};
+
+}  // namespace impeller


### PR DESCRIPTION
This was a recent observation that slowed down local development on Impeller.

Making small changes to `//impeller/renderer` and re-building would seemingly
build all Impeller related targets (~650 actions). Even with Goma, this was
getting annoying. Turns out that `//impeller/compiler` was including
`//impeller/runtime_stage` that pulled in `//impeller/renderer`. It did so only for
a couple of headers.

The downside of this dependency is that a compiler invalidation rebuilds all
shaders and also the targets containing the generated C++ headers with shader
metadata. This causes the huge number of actions invocations.

Another downside is that the compiler was pulling in the renderer making it
larger and taking longer to link. Hilariously, it also pulled in Skia because of
the SkParagraph shaper used for text layout.

This patch reworks the dependency so that runtime stage enums are separate and
inverts the runtime_stage dependency on the compiler and renderer.

Now, editing and invalidating a `//impeller/renderer` or related target only
invokes < 5 actions instead of the ~650 earlier.