### PR TITLE
Adds artifacts to mac_ios release.

### DIFF
--- a/ci/builders/mac_ios_engine_release.json
+++ b/ci/builders/mac_ios_engine_release.json
@@ -38,7 +38,10 @@
             "name": "ios_release",
             "ninja": {
                 "config": "ios_release",
-                "targets": [],
+                "targets": [
+                    "flutter/shell/platform/darwin/ios:flutter_framework",
+                    "flutter/lib/snapshot:generate_snapshot_bin"
+                ],
                 "tool": "autoninja"
             },
             "tests": []
@@ -69,5 +72,73 @@
             "tests": []
         }
     ],
-    "tests": []
+    "tests": [],
+    "generators": {
+        "tasks": [
+            {
+                "name": "release-FlutterMacOS.framework",
+                "parameters": [
+                    "--dst",
+                    "out/release",
+                    "--arm64-out-dir",
+                    "out/ios_release",
+                    "--simulator-x64-out-dir",
+                    "out/ios_debug_sim",
+                    "--simulator-arm64-out-dir",
+                    "out/ios_debug_sim_arm64",
+                    "--dsym",
+                    "--strip"
+                ],
+                "script": "flutter/sky/tools/create_full_ios_framework.py",
+                "language": "python"
+            },
+            {
+                "name": "release-nobitcode-FlutterMacOS.framework",
+                "parameters": [
+                    "--dst",
+                    "out/release-nobitcode",
+                    "--arm64-out-dir",
+                    "out/ios_release",
+                    "--simulator-x64-out-dir",
+                    "out/ios_debug_sim",
+                    "--simulator-arm64-out-dir",
+                    "out/ios_debug_sim_arm64",
+                    "--strip-bitcode",
+                    "--dsym",
+                    "--strip"
+                ],
+                "script": "flutter/sky/tools/create_full_ios_framework.py",
+                "language": "python"
+            },
+            {
+                "name": "Release-macos-gen-snapshots",
+                "parameters": [
+                    "--dst",
+                    "out/release",
+                    "--arm64-out-dir",
+                    "out/ios_release"
+                ],
+                "script": "flutter/sky/tools/create_macos_gen_snapshots.py",
+                "language": "python"
+            }
+        ]
+    },
+    "archives": [
+        {
+            "source": "out/release/artifacts.zip",
+            "destination": "ios/artifacts.zip"
+        },
+        {
+            "source": "out/release/Flutter.dSYM.zip",
+            "destination": "ios-release/Flutter.dSYM.zip"
+        },
+        {
+            "source": "out/release-nobitcode/artifacts.zip",
+            "destination": "ios-release-nobitcode/artifacts.zip"
+        },
+        {
+            "source": "out/release-nobitcode/Flutter.dSYM.zip",
+            "destination": "ios-release-nobitcode/Flutter.dSYM.zip"
+        }
+    ]
 }

--- a/ci/builders/mac_ios_engine_release.json
+++ b/ci/builders/mac_ios_engine_release.json
@@ -126,7 +126,7 @@
     "archives": [
         {
             "source": "out/release/artifacts.zip",
-            "destination": "ios/artifacts.zip"
+            "destination": "ios-release/artifacts.zip"
         },
         {
             "source": "out/release/Flutter.dSYM.zip",


### PR DESCRIPTION
This change generates and uploads the framework sdk and dsym files for
mac_ios_release.

Bug: https://github.com/flutter/flutter/issues/81855

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
