### PR TITLE
[Windows] Migrate error logging to FML_LOG

### DIFF
--- a/shell/platform/windows/angle_surface_manager.cc
+++ b/shell/platform/windows/angle_surface_manager.cc
@@ -4,15 +4,16 @@
 
 #include "flutter/shell/platform/windows/angle_surface_manager.h"
 
-#include <iostream>
 #include <vector>
+
+#include "flutter/fml/logging.h"
 
 // Logs an EGL error to stderr. This automatically calls eglGetError()
 // and logs the error code.
 static void LogEglError(std::string message) {
   EGLint error = eglGetError();
-  std::cerr << "EGL: " << message << std::endl;
-  std::cerr << "EGL: eglGetError returned " << error << std::endl;
+  FML_LOG(ERROR) << "EGL: " << message;
+  FML_LOG(ERROR) << "EGL: eglGetError returned " << error;
 }
 
 namespace flutter {
@@ -245,8 +246,8 @@ void AngleSurfaceManager::ResizeSurface(WindowsRenderTarget* render_target,
     ClearContext();
     DestroySurface();
     if (!CreateSurface(render_target, width, height)) {
-      std::cerr << "AngleSurfaceManager::ResizeSurface failed to create surface"
-                << std::endl;
+      FML_LOG(ERROR)
+          << "AngleSurfaceManager::ResizeSurface failed to create surface";
     }
   }
 }

--- a/shell/platform/windows/external_texture_d3d.cc
+++ b/shell/platform/windows/external_texture_d3d.cc
@@ -6,8 +6,8 @@
 
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
-#include <iostream>
 
+#include "flutter/fml/logging.h"
 #include "flutter/shell/platform/embedder/embedder_struct_macros.h"
 
 namespace flutter {
@@ -107,7 +107,7 @@ bool ExternalTextureD3d::CreateOrUpdateTexture(
     if (egl_surface_ == EGL_NO_SURFACE ||
         eglBindTexImage(surface_manager_->egl_display(), egl_surface_,
                         EGL_BACK_BUFFER) == EGL_FALSE) {
-      std::cerr << "Binding D3D surface failed." << std::endl;
+      FML_LOG(ERROR) << "Binding D3D surface failed.";
     }
     last_surface_handle_ = handle;
   }

--- a/shell/platform/windows/flutter_project_bundle.cc
+++ b/shell/platform/windows/flutter_project_bundle.cc
@@ -5,8 +5,8 @@
 #include "flutter/shell/platform/windows/flutter_project_bundle.h"
 
 #include <filesystem>
-#include <iostream>
 
+#include "flutter/fml/logging.h"
 #include "flutter/shell/platform/common/engine_switches.h"  // nogncheck
 #include "flutter/shell/platform/common/path_utils.h"
 
@@ -34,9 +34,8 @@ FlutterProjectBundle::FlutterProjectBundle(
       (!aot_library_path_.empty() && aot_library_path_.is_relative())) {
     std::filesystem::path executable_location = GetExecutableDirectory();
     if (executable_location.empty()) {
-      std::cerr
-          << "Unable to find executable location to resolve resource paths."
-          << std::endl;
+      FML_LOG(ERROR)
+          << "Unable to find executable location to resolve resource paths.";
       assets_path_ = std::filesystem::path();
       icu_path_ = std::filesystem::path();
     } else {
@@ -59,14 +58,13 @@ bool FlutterProjectBundle::HasValidPaths() {
 UniqueAotDataPtr FlutterProjectBundle::LoadAotData(
     const FlutterEngineProcTable& engine_procs) {
   if (aot_library_path_.empty()) {
-    std::cerr
-        << "Attempted to load AOT data, but no aot_library_path was provided."
-        << std::endl;
+    FML_LOG(ERROR)
+        << "Attempted to load AOT data, but no aot_library_path was provided.";
     return UniqueAotDataPtr(nullptr, nullptr);
   }
   if (!std::filesystem::exists(aot_library_path_)) {
-    std::cerr << "Can't load AOT data from " << aot_library_path_.u8string()
-              << "; no such file." << std::endl;
+    FML_LOG(ERROR) << "Can't load AOT data from "
+                   << aot_library_path_.u8string() << "; no such file.";
     return UniqueAotDataPtr(nullptr, nullptr);
   }
   std::string path_string = aot_library_path_.u8string();
@@ -76,7 +74,7 @@ UniqueAotDataPtr FlutterProjectBundle::LoadAotData(
   FlutterEngineAOTData data = nullptr;
   auto result = engine_procs.CreateAOTData(&source, &data);
   if (result != kSuccess) {
-    std::cerr << "Failed to load AOT data from: " << path_string << std::endl;
+    FML_LOG(ERROR) << "Failed to load AOT data from: " << path_string;
     return UniqueAotDataPtr(nullptr, nullptr);
   }
   return UniqueAotDataPtr(data, engine_procs.CollectAOTData);

--- a/shell/platform/windows/flutter_window.cc
+++ b/shell/platform/windows/flutter_window.cc
@@ -8,6 +8,8 @@
 #include <chrono>
 #include <map>
 
+#include "flutter/fml/logging.h"
+
 namespace flutter {
 
 namespace {
@@ -121,7 +123,7 @@ static uint64_t ConvertWinButtonToFlutterButton(UINT button) {
     case XBUTTON2:
       return kFlutterPointerButtonMouseForward;
   }
-  std::cerr << "Mouse button not recognized: " << button << std::endl;
+  FML_LOG(WARNING) << "Mouse button not recognized: " << button;
   return 0;
 }
 

--- a/shell/platform/windows/flutter_windows_texture_registrar.cc
+++ b/shell/platform/windows/flutter_windows_texture_registrar.cc
@@ -4,9 +4,9 @@
 
 #include "flutter/shell/platform/windows/flutter_windows_texture_registrar.h"
 
-#include <iostream>
 #include <mutex>
 
+#include "flutter/fml/logging.h"
 #include "flutter/shell/platform/embedder/embedder_struct_macros.h"
 #include "flutter/shell/platform/windows/external_texture_d3d.h"
 #include "flutter/shell/platform/windows/external_texture_pixelbuffer.h"
@@ -31,7 +31,7 @@ int64_t FlutterWindowsTextureRegistrar::RegisterTexture(
 
   if (texture_info->type == kFlutterDesktopPixelBufferTexture) {
     if (!texture_info->pixel_buffer_config.callback) {
-      std::cerr << "Invalid pixel buffer texture callback." << std::endl;
+      FML_LOG(ERROR) << "Invalid pixel buffer texture callback.";
       return kInvalidTexture;
     }
 
@@ -47,7 +47,7 @@ int64_t FlutterWindowsTextureRegistrar::RegisterTexture(
         surface_type == kFlutterDesktopGpuSurfaceTypeD3d11Texture2D) {
       auto callback = SAFE_ACCESS(gpu_surface_config, callback, nullptr);
       if (!callback) {
-        std::cerr << "Invalid GPU surface descriptor callback." << std::endl;
+        FML_LOG(ERROR) << "Invalid GPU surface descriptor callback.";
         return kInvalidTexture;
       }
 
@@ -58,7 +58,7 @@ int64_t FlutterWindowsTextureRegistrar::RegisterTexture(
     }
   }
 
-  std::cerr << "Attempted to register texture of unsupport type." << std::endl;
+  FML_LOG(ERROR) << "Attempted to register texture of unsupport type.";
   return kInvalidTexture;
 }
 

--- a/shell/platform/windows/keyboard_key_channel_handler.cc
+++ b/shell/platform/windows/keyboard_key_channel_handler.cc
@@ -6,8 +6,7 @@
 
 #include <windows.h>
 
-#include <iostream>
-
+#include "flutter/fml/logging.h"
 #include "flutter/shell/platform/common/json_message_codec.h"
 #include "flutter/shell/platform/windows/keyboard_utils.h"
 
@@ -139,7 +138,7 @@ void KeyboardKeyChannelHandler::KeyboardHook(
       event.AddMember(kTypeKey, kKeyUp, allocator);
       break;
     default:
-      std::cerr << "Unknown key event action: " << action << std::endl;
+      FML_LOG(WARNING) << "Unknown key event action: " << action;
       callback(false);
       return;
   }

--- a/shell/platform/windows/keyboard_key_handler.cc
+++ b/shell/platform/windows/keyboard_key_handler.cc
@@ -6,8 +6,7 @@
 
 #include <windows.h>
 
-#include <iostream>
-
+#include "flutter/fml/logging.h"
 #include "flutter/shell/platform/windows/keyboard_utils.h"
 
 namespace flutter {
@@ -48,10 +47,10 @@ void KeyboardKeyHandler::KeyboardHook(int key,
   incoming->callback = std::move(callback);
 
   if (pending_responds_.size() > kMaxPendingEvents) {
-    std::cerr
+    FML_LOG(ERROR)
         << "There are " << pending_responds_.size()
         << " keyboard events that have not yet received a response from the "
-        << "framework. Are responses being sent?" << std::endl;
+        << "framework. Are responses being sent?";
   }
   pending_responds_.push_back(std::move(incoming));
 

--- a/shell/platform/windows/keyboard_manager.cc
+++ b/shell/platform/windows/keyboard_manager.cc
@@ -3,10 +3,10 @@
 // found in the LICENSE file.
 
 #include <assert.h>
-#include <iostream>
 #include <memory>
 #include <string>
 
+#include "flutter/fml/logging.h"
 #include "flutter/shell/platform/windows/keyboard_manager.h"
 #include "flutter/shell/platform/windows/keyboard_utils.h"
 
@@ -120,15 +120,14 @@ void KeyboardManager::RedispatchEvent(std::unique_ptr<PendingEvent> event) {
     UINT result = window_delegate_->Win32DispatchMessage(
         message.action, message.wparam, message.lparam);
     if (result != 0) {
-      std::cerr << "Unable to synthesize event for keyboard event."
-                << std::endl;
+      FML_LOG(ERROR) << "Unable to synthesize event for keyboard event.";
     }
   }
   if (pending_redispatches_.size() > kMaxPendingEvents) {
-    std::cerr
+    FML_LOG(ERROR)
         << "There are " << pending_redispatches_.size()
         << " keyboard events that have not yet received a response from the "
-        << "framework. Are responses being sent?" << std::endl;
+        << "framework. Are responses being sent?";
   }
 }
 

--- a/shell/platform/windows/platform_handler.cc
+++ b/shell/platform/windows/platform_handler.cc
@@ -7,9 +7,9 @@
 #include <windows.h>
 
 #include <cstring>
-#include <iostream>
 #include <optional>
 
+#include "flutter/fml/logging.h"
 #include "flutter/fml/platform/win/wstring_conversion.h"
 #include "flutter/shell/platform/common/json_method_codec.h"
 #include "flutter/shell/platform/windows/flutter_windows_view.h"
@@ -41,14 +41,16 @@ class ScopedGlobalMemory {
   ScopedGlobalMemory(unsigned int flags, size_t bytes) {
     memory_ = ::GlobalAlloc(flags, bytes);
     if (!memory_) {
-      std::cerr << "Unable to allocate global memory: " << ::GetLastError();
+      FML_LOG(ERROR) << "Unable to allocate global memory: "
+                     << ::GetLastError();
     }
   }
 
   ~ScopedGlobalMemory() {
     if (memory_) {
       if (::GlobalFree(memory_) != nullptr) {
-        std::cerr << "Failed to free global allocation: " << ::GetLastError();
+        FML_LOG(ERROR) << "Failed to free global allocation: "
+                       << ::GetLastError();
       }
     }
   }
@@ -79,7 +81,7 @@ class ScopedGlobalLock {
     if (memory) {
       locked_memory_ = ::GlobalLock(memory);
       if (!locked_memory_) {
-        std::cerr << "Unable to acquire global lock: " << ::GetLastError();
+        FML_LOG(ERROR) << "Unable to acquire global lock: " << ::GetLastError();
       }
     }
   }
@@ -89,7 +91,8 @@ class ScopedGlobalLock {
       if (!::GlobalUnlock(source_)) {
         DWORD error = ::GetLastError();
         if (error != NO_ERROR) {
-          std::cerr << "Unable to release global lock: " << ::GetLastError();
+          FML_LOG(ERROR) << "Unable to release global lock: "
+                         << ::GetLastError();
         }
       }
     }

--- a/shell/platform/windows/task_runner_window.cc
+++ b/shell/platform/windows/task_runner_window.cc
@@ -5,7 +5,8 @@
 #include "flutter/shell/platform/windows/task_runner_window.h"
 
 #include <algorithm>
-#include <iostream>
+
+#include "flutter/fml/logging.h"
 
 namespace flutter {
 
@@ -52,7 +53,7 @@ std::shared_ptr<TaskRunnerWindow> TaskRunnerWindow::GetSharedInstance() {
 
 void TaskRunnerWindow::WakeUp() {
   if (!PostMessage(window_handle_, WM_NULL, 0, 0)) {
-    std::cerr << "Failed to post message to main thread." << std::endl;
+    FML_LOG(ERROR) << "Failed to post message to main thread.";
   }
 }
 


### PR DESCRIPTION
Migrates error logging from logging directly to stderr to using the
FML_LOG macro with a specified log level.

No additional tests since there is no semantic change to the logging
(FML_LOG simply [writes to stderr](https://github.com/flutter/engine/blob/643742e4fb97900e39b27c704e71bfbab8cce58b/fml/logging.cc#L125-L126) on desktop).

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
