### PR TITLE
Move extension to TypefaceFontProvider instead of SkFontMgr

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -2110,7 +2110,7 @@ class TypefaceFontProvider extends SkFontMgr {
   external factory TypefaceFontProvider();
 }
 
-extension TypefaceFontProviderExtension on SkFontMgr {
+extension TypefaceFontProviderExtension on TypefaceFontProvider {
   external void registerFont(Uint8List font, String family);
 }
 


### PR DESCRIPTION
This extension should belong on TypefaceFontProvider instead of the parent class. The only usage is in lib/web_ui/lib/src/engine/canvaskit/fonts.dart, and both usages are on a variable typed as TypefaceFontProvider. In the future, multiple extensions on the same `@staticInterop` type will be an error (https://github.com/dart-lang/sdk/issues/49350), so this must be migrated.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [NO - need test exemption/test is unneeded because this should not build if the extension is on the wrong class] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
