### PR TITLE
[Impeller] Give filters full responsibility over commands

### DIFF
--- a/impeller/entity/contents/filters/blend_filter_contents.cc
+++ b/impeller/entity/contents/filters/blend_filter_contents.cc
@@ -268,32 +268,43 @@ void BlendFilterContents::SetForegroundColor(std::optional<Color> color) {
   foreground_color_ = color;
 }
 
-bool BlendFilterContents::RenderFilter(const FilterInput::Vector& inputs,
-                                       const ContentContext& renderer,
-                                       const Entity& entity,
-                                       RenderPass& pass,
-                                       const Rect& coverage) const {
+std::optional<Snapshot> BlendFilterContents::RenderFilter(
+    const FilterInput::Vector& inputs,
+    const ContentContext& renderer,
+    const Entity& entity,
+    const Rect& coverage) const {
   if (inputs.empty()) {
-    return true;
+    return std::nullopt;
   }
 
-  if (inputs.size() == 1 && !foreground_color_.has_value()) {
-    // Nothing to blend.
-    return PipelineBlend(inputs, renderer, entity, pass, coverage,
-                         Entity::BlendMode::kSource, std::nullopt);
-  }
+  ContentContext::SubpassCallback callback = [&](const ContentContext& renderer,
+                                                 RenderPass& pass) {
+    if (inputs.size() == 1 && !foreground_color_.has_value()) {
+      // Nothing to blend.
+      return PipelineBlend(inputs, renderer, entity, pass, coverage,
+                           Entity::BlendMode::kSource, std::nullopt);
+    }
 
-  if (blend_mode_ <= Entity::BlendMode::kLastPipelineBlendMode) {
-    return PipelineBlend(inputs, renderer, entity, pass, coverage, blend_mode_,
-                         foreground_color_);
-  }
+    if (blend_mode_ <= Entity::BlendMode::kLastPipelineBlendMode) {
+      return PipelineBlend(inputs, renderer, entity, pass, coverage,
+                           blend_mode_, foreground_color_);
+    }
 
-  if (blend_mode_ <= Entity::BlendMode::kLastAdvancedBlendMode) {
-    return advanced_blend_proc_(inputs, renderer, entity, pass, coverage,
-                                foreground_color_);
-  }
+    if (blend_mode_ <= Entity::BlendMode::kLastAdvancedBlendMode) {
+      return advanced_blend_proc_(inputs, renderer, entity, pass, coverage,
+                                  foreground_color_);
+    }
+    FML_UNREACHABLE();
+  };
 
-  FML_UNREACHABLE();
+  auto out_texture = renderer.MakeSubpass(ISize(coverage.size), callback);
+  if (!out_texture) {
+    return std::nullopt;
+  }
+  out_texture->SetLabel("BlendFilter Texture");
+
+  return Snapshot{.texture = out_texture,
+                  .transform = Matrix::MakeTranslation(coverage.origin)};
 }
 
 }  // namespace impeller

--- a/impeller/entity/contents/filters/blend_filter_contents.h
+++ b/impeller/entity/contents/filters/blend_filter_contents.h
@@ -31,11 +31,10 @@ class BlendFilterContents : public FilterContents {
 
  private:
   // |FilterContents|
-  bool RenderFilter(const FilterInput::Vector& inputs,
-                    const ContentContext& renderer,
-                    const Entity& entity,
-                    RenderPass& pass,
-                    const Rect& coverage) const override;
+  std::optional<Snapshot> RenderFilter(const FilterInput::Vector& inputs,
+                                       const ContentContext& renderer,
+                                       const Entity& entity,
+                                       const Rect& coverage) const override;
 
   Entity::BlendMode blend_mode_ = Entity::BlendMode::kSourceOver;
   AdvancedBlendProc advanced_blend_proc_;

--- a/impeller/entity/contents/filters/border_mask_blur_filter_contents.h
+++ b/impeller/entity/contents/filters/border_mask_blur_filter_contents.h
@@ -27,11 +27,11 @@ class BorderMaskBlurFilterContents final : public FilterContents {
 
  private:
   // |FilterContents|
-  bool RenderFilter(const FilterInput::Vector& input_textures,
-                    const ContentContext& renderer,
-                    const Entity& entity,
-                    RenderPass& pass,
-                    const Rect& coverage) const override;
+  std::optional<Snapshot> RenderFilter(
+      const FilterInput::Vector& input_textures,
+      const ContentContext& renderer,
+      const Entity& entity,
+      const Rect& coverage) const override;
 
   Sigma sigma_x_;
   Sigma sigma_y_;

--- a/impeller/entity/contents/filters/color_matrix_filter_contents.h
+++ b/impeller/entity/contents/filters/color_matrix_filter_contents.h
@@ -24,11 +24,11 @@ class ColorMatrixFilterContents final : public FilterContents {
 
  private:
   // |FilterContents|
-  bool RenderFilter(const FilterInput::Vector& input_textures,
-                    const ContentContext& renderer,
-                    const Entity& entity,
-                    RenderPass& pass,
-                    const Rect& coverage) const override;
+  std::optional<Snapshot> RenderFilter(
+      const FilterInput::Vector& input_textures,
+      const ContentContext& renderer,
+      const Entity& entity,
+      const Rect& coverage) const override;
 
   ColorMatrix matrix_;
 

--- a/impeller/entity/contents/filters/filter_contents.cc
+++ b/impeller/entity/contents/filters/filter_contents.cc
@@ -220,20 +220,8 @@ std::optional<Snapshot> FilterContents::RenderToSnapshot(
     return std::nullopt;
   }
 
-  // Render the filter into a new texture.
-  auto texture = renderer.MakeSubpass(
-      ISize(coverage->size),
-      [=](const ContentContext& renderer, RenderPass& pass) -> bool {
-        return RenderFilter(inputs_, renderer, entity_with_local_transform,
-                            pass, coverage.value());
-      });
-
-  if (!texture) {
-    return std::nullopt;
-  }
-
-  return Snapshot{.texture = texture,
-                  .transform = Matrix::MakeTranslation(coverage->origin)};
+  return RenderFilter(inputs_, renderer, entity_with_local_transform,
+                      coverage.value());
 }
 
 Matrix FilterContents::GetLocalTransform() const {

--- a/impeller/entity/contents/filters/filter_contents.h
+++ b/impeller/entity/contents/filters/filter_contents.h
@@ -101,13 +101,12 @@ class FilterContents : public Contents {
       const FilterInput::Vector& inputs,
       const Entity& entity) const;
 
-  /// @brief  Takes a set of zero or more input textures and writes to an output
-  ///         texture.
-  virtual bool RenderFilter(const FilterInput::Vector& inputs,
-                            const ContentContext& renderer,
-                            const Entity& entity,
-                            RenderPass& pass,
-                            const Rect& coverage) const = 0;
+  /// @brief  Converts zero or more filter inputs into a new texture.
+  virtual std::optional<Snapshot> RenderFilter(
+      const FilterInput::Vector& inputs,
+      const ContentContext& renderer,
+      const Entity& entity,
+      const Rect& coverage) const = 0;
 
   std::optional<Rect> GetLocalCoverage(const Entity& local_entity) const;
 

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.h
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.h
@@ -33,11 +33,11 @@ class DirectionalGaussianBlurFilterContents final : public FilterContents {
 
  private:
   // |FilterContents|
-  bool RenderFilter(const FilterInput::Vector& input_textures,
-                    const ContentContext& renderer,
-                    const Entity& entity,
-                    RenderPass& pass,
-                    const Rect& coverage) const override;
+  std::optional<Snapshot> RenderFilter(
+      const FilterInput::Vector& input_textures,
+      const ContentContext& renderer,
+      const Entity& entity,
+      const Rect& coverage) const override;
   Sigma blur_sigma_;
   Vector2 blur_direction_;
   BlurStyle blur_style_ = BlurStyle::kNormal;


### PR DESCRIPTION
No semantic change beyond debug labels and resource creation order. This just moves filter pass creation down the stack from `FilterContents::RenderToSnapshot` to `virtual FilterContents::RenderFilter`

- Filters now create their own render passes and return a snapshot.
- Most filters now resolve their inputs before creating their own textures/render passes.
- Textures now have labels.

This allows filters to:
- Avoid creating textures when not necessary.
- Passthrough inputs.
- Do arbitrary pass encoding (blit passes,  multiple render passes, etc.)