### PR TITLE
[macOS] Do not block main thread during resizing if there is no content

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -439,11 +439,12 @@ static void OnPlatformMessage(const FlutterPlatformMessage* message, FlutterEngi
     _macOSCompositor = std::make_unique<flutter::FlutterMetalCompositor>(
         _viewController, _platformViewController, metalRenderer.device);
     _macOSCompositor->SetPresentCallback([weakSelf](bool has_flutter_content) {
+      FlutterMetalRenderer* metalRenderer =
+          reinterpret_cast<FlutterMetalRenderer*>(weakSelf.renderer);
       if (has_flutter_content) {
-        FlutterMetalRenderer* metalRenderer =
-            reinterpret_cast<FlutterMetalRenderer*>(weakSelf.renderer);
         return [metalRenderer present:0 /*=textureID*/] == YES;
       } else {
+        [metalRenderer presentWithoutContent];
         return true;
       }
     });
@@ -454,11 +455,12 @@ static void OnPlatformMessage(const FlutterPlatformMessage* message, FlutterEngi
                                                                       openGLRenderer.openGLContext);
 
     _macOSCompositor->SetPresentCallback([weakSelf](bool has_flutter_content) {
+      FlutterOpenGLRenderer* openGLRenderer =
+          reinterpret_cast<FlutterOpenGLRenderer*>(weakSelf.renderer);
       if (has_flutter_content) {
-        FlutterOpenGLRenderer* openGLRenderer =
-            reinterpret_cast<FlutterOpenGLRenderer*>(weakSelf.renderer);
         return [openGLRenderer glPresent] == YES;
       } else {
+        [openGLRenderer presentWithoutContent];
         return true;
       }
     });

--- a/shell/platform/darwin/macos/framework/Source/FlutterMetalRenderer.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterMetalRenderer.h
@@ -35,6 +35,11 @@
 - (BOOL)present:(int64_t)textureID;
 
 /**
+ * Tells the renderer that there is no Flutter content available for this frame.
+ */
+- (void)presentWithoutContent;
+
+/**
  * Populates the texture registry with the provided metalTexture.
  */
 - (BOOL)populateTextureWithIdentifier:(int64_t)textureID

--- a/shell/platform/darwin/macos/framework/Source/FlutterMetalRenderer.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterMetalRenderer.mm
@@ -107,6 +107,10 @@ static bool OnAcquireExternalTexture(FlutterEngine* engine,
   return YES;
 }
 
+- (void)presentWithoutContent {
+  [_flutterView presentWithoutContent];
+}
+
 #pragma mark - FlutterTextureRegistrar methods.
 
 - (BOOL)populateTextureWithIdentifier:(int64_t)textureID

--- a/shell/platform/darwin/macos/framework/Source/FlutterOpenGLRenderer.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterOpenGLRenderer.h
@@ -40,6 +40,11 @@
 - (BOOL)glPresent;
 
 /**
+ * Tells the renderer that there is no Flutter content available for this frame.
+ */
+- (void)presentWithoutContent;
+
+/**
  * Called by the engine when framebuffer object ID is requested.
  */
 - (uint32_t)fboForFrameInfo:(nonnull const FlutterFrameInfo*)info;

--- a/shell/platform/darwin/macos/framework/Source/FlutterOpenGLRenderer.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterOpenGLRenderer.mm
@@ -96,6 +96,10 @@ static bool OnAcquireExternalTexture(FlutterEngine* engine,
   return true;
 }
 
+- (void)presentWithoutContent {
+  [_flutterView presentWithoutContent];
+}
+
 - (uint32_t)fboForFrameInfo:(const FlutterFrameInfo*)info {
   CGSize size = CGSizeMake(info->size.width, info->size.height);
   FlutterOpenGLRenderBackingStore* backingStore =

--- a/shell/platform/darwin/macos/framework/Source/FlutterResizeSynchronizer.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterResizeSynchronizer.h
@@ -76,6 +76,13 @@
 - (void)requestCommit;
 
 /**
+ * Called from view to notify the synchronizer that there are no Flutter frames
+ * coming. Synchronizer must unblock main thread and not block until another
+ * frame is available.
+ */
+- (void)noFlutterContent;
+
+/**
  * Called when shutting down. Unblocks everything and prevents any further synchronization.
  */
 - (void)shutdown;

--- a/shell/platform/darwin/macos/framework/Source/FlutterView.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterView.h
@@ -51,6 +51,12 @@
 - (void)present;
 
 /**
+ * Called when there is no Flutter content available to render. This must be passed to resize
+ * syncrhonizer.
+ */
+- (void)presentWithoutContent;
+
+/**
  * Ensures that a backing store with requested size exists and returns the descriptor. Expected to
  * be called on raster thread.
  */

--- a/shell/platform/darwin/macos/framework/Source/FlutterView.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterView.h
@@ -52,7 +52,7 @@
 
 /**
  * Called when there is no Flutter content available to render. This must be passed to resize
- * syncrhonizer.
+ * synchronizer.
  */
 - (void)presentWithoutContent;
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterView.mm
@@ -72,6 +72,10 @@
   [_resizeSynchronizer requestCommit];
 }
 
+- (void)presentWithoutContent {
+  [_resizeSynchronizer noFlutterContent];
+}
+
 - (void)reshaped {
   CGSize scaledSize = [self convertSizeToBacking:self.bounds.size];
   [_resizeSynchronizer beginResize:scaledSize


### PR DESCRIPTION
Fixes: https://github.com/flutter/flutter/issues/92673


*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
