### PR TITLE
add enterkeyhint property to web textfields

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1274,6 +1274,7 @@ FILE: ../../../flutter/lib/web_ui/lib/src/engine/text/word_break_properties.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/text/word_breaker.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/text_editing/autofill_hint.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/text_editing/composition_aware_mixin.dart
+FILE: ../../../flutter/lib/web_ui/lib/src/engine/text_editing/input_action.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/text_editing/input_type.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/text_editing/text_capitalization.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart

--- a/lib/web_ui/lib/src/engine.dart
+++ b/lib/web_ui/lib/src/engine.dart
@@ -156,6 +156,7 @@ export 'engine/text/word_break_properties.dart';
 export 'engine/text/word_breaker.dart';
 export 'engine/text_editing/autofill_hint.dart';
 export 'engine/text_editing/composition_aware_mixin.dart';
+export 'engine/text_editing/input_action.dart';
 export 'engine/text_editing/input_type.dart';
 export 'engine/text_editing/text_capitalization.dart';
 export 'engine/text_editing/text_editing.dart';

--- a/lib/web_ui/lib/src/engine/text_editing/input_action.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/input_action.dart
@@ -1,4 +1,4 @@
-// Copyright 2013 The Flutter Authors. All rights reserved.
+// Copyright 2022 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/lib/web_ui/lib/src/engine/text_editing/input_action.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/input_action.dart
@@ -1,4 +1,4 @@
-// Copyright 2022 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
@@ -27,9 +27,9 @@ abstract class EngineInputAction {
       case 'TextInputAction.newline':
         return enter;
       case 'TextInputAction.search':
-      return search;
+        return search;
       case 'TextInputAction.send':
-      return send;
+        return send;
       case 'TextInputAction.emergencyCall':
       case 'TextInputAction.join':
       case 'TextInputAction.none':

--- a/lib/web_ui/lib/src/engine/text_editing/input_action.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/input_action.dart
@@ -1,0 +1,155 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import '../browser_detection.dart';
+import '../dom.dart';
+
+/// Various input action types used in text fields.
+///
+/// These types are coming from Flutter's [TextInputAction]. Currently, the web doesn't
+/// support all the types. We fallback to [EngineInputAction.none] when Flutter
+/// sends a type that isn't supported.
+abstract class EngineInputAction {
+  const EngineInputAction();
+
+  static EngineInputAction fromName(String name) {
+    switch (name) {
+      case 'TextInputAction.continueAction':
+      case 'TextInputAction.next':
+        return next;
+      case 'TextInputAction.previous':
+        return previous;
+      case 'TextInputAction.done':
+        return done;
+      case 'TextInputAction.go':
+        return go;
+      case 'TextInputAction.newline':
+        return enter;
+      case 'TextInputAction.search':
+      return search;
+      case 'TextInputAction.send':
+      return send;
+      case 'TextInputAction.emergencyCall':
+      case 'TextInputAction.join':
+      case 'TextInputAction.none':
+      case 'TextInputAction.route':
+      case 'TextInputAction.unspecified':
+      default:
+        return none;
+    }
+  }
+
+  /// No input action
+  static const NoInputAction none = NoInputAction();
+
+  /// Action to go to next
+  static const NextInputAction next = NextInputAction();
+
+  /// Action to go to previous
+  static const PreviousInputAction previous = PreviousInputAction();
+
+  /// Action to be finished
+  static const DoneInputAction done = DoneInputAction();
+
+  /// Action to Go
+  static const GoInputAction go = GoInputAction();
+
+  /// Action to insert newline
+  static const EnterInputAction enter = EnterInputAction();
+
+  /// Action to search
+  static const SearchInputAction search = SearchInputAction();
+
+  /// Action to send
+  static const SendInputAction send = SendInputAction();
+
+
+  /// The HTML `enterkeyhint` attribute to be set on the DOM element.
+  ///
+  /// This HTML attribute helps the browser decide what kind of keyboard action
+  /// to use for this text field
+  ///
+  /// For various `enterkeyhint` values supported by browsers, see:
+  /// <https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/enterkeyhint>.
+  String? get enterkeyhintAttribute;
+
+  /// Given a [domElement], set attributes that are specific to this input action.
+  void configureInputAction(DomHTMLElement domElement) {
+    if (enterkeyhintAttribute == null) {
+      return;
+    }
+
+    // Only apply `enterkeyhint` in mobile browsers so that the right virtual
+    // keyboard shows up.
+    if (operatingSystem == OperatingSystem.iOs ||
+        operatingSystem == OperatingSystem.android ||
+        enterkeyhintAttribute == EngineInputAction.none.enterkeyhintAttribute) {
+      domElement.setAttribute('enterkeyhint', enterkeyhintAttribute!);
+    }
+  }
+}
+
+/// No action specified
+class NoInputAction extends EngineInputAction {
+  const NoInputAction();
+
+  @override
+  String? get enterkeyhintAttribute => null;
+}
+
+/// Typically inserting a new line.
+class EnterInputAction extends EngineInputAction {
+  const EnterInputAction();
+
+  @override
+  String? get enterkeyhintAttribute => 'enter';
+}
+
+/// Typically meaning there is nothing more to input and the input method editor (IME) will be closed.
+class DoneInputAction extends EngineInputAction {
+  const DoneInputAction();
+
+  @override
+  String? get enterkeyhintAttribute => 'done';
+}
+
+/// Typically meaning to take the user to the target of the text they typed.
+class GoInputAction extends EngineInputAction {
+  const GoInputAction();
+
+  @override
+  String? get enterkeyhintAttribute => 'go';
+}
+
+/// Typically taking the user to the next field that will accept text.
+class NextInputAction extends EngineInputAction {
+  const NextInputAction();
+
+  @override
+  String? get enterkeyhintAttribute => 'next';
+}
+
+/// Typically taking the user to the previous field that will accept text.
+class PreviousInputAction extends EngineInputAction {
+  const PreviousInputAction();
+
+  @override
+  String? get enterkeyhintAttribute => 'previous';
+}
+
+/// Typically taking the user to the results of searching for the text they have typed.
+class SearchInputAction extends EngineInputAction {
+  const SearchInputAction();
+
+  @override
+  String? get enterkeyhintAttribute => 'search';
+}
+
+/// Typically delivering the text to its target.
+class SendInputAction extends EngineInputAction {
+  const SendInputAction();
+
+  @override
+  String? get enterkeyhintAttribute => 'send';
+}

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -1181,7 +1181,7 @@ abstract class DefaultTextEditingStrategy with CompositionAwareMixin implements 
     if (config.inputType == EngineInputType.none) {
       activeDomElement.setAttribute('inputmode', 'none');
     }
-    
+
     final EngineInputAction action = EngineInputAction.fromName(config.inputAction);
     action.configureInputAction(activeDomElement);
 

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -21,6 +21,7 @@ import '../text/paragraph.dart';
 import '../util.dart';
 import 'autofill_hint.dart';
 import 'composition_aware_mixin.dart';
+import 'input_action.dart';
 import 'input_type.dart';
 import 'text_capitalization.dart';
 
@@ -1180,6 +1181,9 @@ abstract class DefaultTextEditingStrategy with CompositionAwareMixin implements 
     if (config.inputType == EngineInputType.none) {
       activeDomElement.setAttribute('inputmode', 'none');
     }
+    
+    final EngineInputAction action = EngineInputAction.fromName(config.inputAction);
+    action.configureInputAction(activeDomElement);
 
     final AutofillInfo? autofill = config.autofill;
     if (autofill != null) {

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -159,6 +159,27 @@ Future<void> testMain() async {
       editingStrategy!.disable();
     });
 
+    test('Knows how to create non-default text actions', () {
+      final InputConfiguration config = InputConfiguration(
+        inputAction: 'TextInputAction.send'
+      );
+      editingStrategy!.enable(
+        config,
+        onChange: trackEditingState,
+        onAction: trackInputAction,
+      );
+      expect(defaultTextEditingRoot.querySelectorAll('input'), hasLength(1));
+      final DomElement input = defaultTextEditingRoot.querySelector('input')!;
+      expect(editingStrategy!.domElement, input);
+      if (operatingSystem == OperatingSystem.iOs || operatingSystem == OperatingSystem.android){
+        expect(input.getAttribute('enterkeyhint'), 'send');
+      } else {
+        expect(input.getAttribute('enterkeyhint'), null);
+      }
+
+      editingStrategy!.disable();
+    });
+
     test('Knows to turn autocorrect off', () {
       final InputConfiguration config = InputConfiguration(
         autocorrect: false,


### PR DESCRIPTION
Adds the enterkeyhint property to web textfields
@mdebbar Can you take a look at this?

*List which issues are fixed by this PR. You must list at least one issue.*
Fixes: https://github.com/flutter/flutter/issues/100708
Fixes: https://github.com/flutter/flutter/issues/73835

Here is the screenshot of the input action button being displayed properly.
![fixed](https://user-images.githubusercontent.com/15617545/184716887-65d6af64-bfcc-4717-86ff-f2d58487c220.png)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
