### PR TITLE
[gn + generator ] add codesign configs for generator tasks in ios/artifacts.zip

### DIFF
--- a/sky/tools/create_full_ios_framework.py
+++ b/sky/tools/create_full_ios_framework.py
@@ -164,18 +164,25 @@ def create_framework(
 
 
 def zip_archive(dst):
-  entitlement_config = open( dst + '/entitlements.txt', 'w')
-  entitlement_config.write( 'gen_snapshot_arm64\n', 'w')
+  entitlement_config = open(dst + '/entitlements.txt', 'w')
+  entitlement_config.write('gen_snapshot_arm64\n')
   entitlement_config.close()
 
-  without_entitlement_config = open( dst + '/without_entitlements.txt', 'w')
-  without_entitlement_config.writelines( 'Flutter.xcframework/ios-arm64/Flutter.framework/Flutter',
-      'Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter',)
+  without_entitlement_config = open(dst + '/without_entitlements.txt', 'w')
+  without_entitlement_config.writelines([
+      'Flutter.xcframework/ios-arm64/Flutter.framework/Flutter\n',
+      'Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter\n'
+  ])
   without_entitlement_config.close()
 
   subprocess.check_call([
-      'zip', '-r', 'artifacts.zip', 'gen_snapshot_arm64', 'Flutter.xcframework',
-      'entitlements.txt', 'without_entitlements.txt',
+      'zip',
+      '-r',
+      'artifacts.zip',
+      'gen_snapshot_arm64',
+      'Flutter.xcframework',
+      'entitlements.txt',
+      'without_entitlements.txt',
   ],
                         cwd=dst)
 

--- a/sky/tools/create_full_ios_framework.py
+++ b/sky/tools/create_full_ios_framework.py
@@ -164,8 +164,18 @@ def create_framework(
 
 
 def zip_archive(dst):
+  entitlement_config = open( dst + '/entitlements.txt', 'w')
+  entitlement_config.write( 'gen_snapshot_arm64\n', 'w')
+  entitlement_config.close()
+
+  without_entitlement_config = open( dst + '/without_entitlements.txt', 'w')
+  without_entitlement_config.writelines( 'Flutter.xcframework/ios-arm64/Flutter.framework/Flutter',
+      'Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter',)
+  without_entitlement_config.close()
+
   subprocess.check_call([
-      'zip', '-r', 'artifacts.zip', 'gen_snapshot_arm64', 'Flutter.xcframework'
+      'zip', '-r', 'artifacts.zip', 'gen_snapshot_arm64', 'Flutter.xcframework',
+      'entitlements.txt', 'without_entitlements.txt',
   ],
                         cwd=dst)
 

--- a/sky/tools/create_full_ios_framework.py
+++ b/sky/tools/create_full_ios_framework.py
@@ -169,15 +169,18 @@ def embed_codesign_configuration(config_path, contents):
 
 
 def zip_archive(dst):
+  ios_file_with_entitlements = ['gen_snapshot_arm64\n']
+  ios_file_without_entitlements = [
+      'Flutter.xcframework/ios-arm64/Flutter.framework/Flutter\n',
+      'Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter\n'
+  ]
   embed_codesign_configuration(
-      os.path.join(dst, 'entitlements.txt'), ['gen_snapshot_arm64\n']
+      os.path.join(dst, 'entitlements.txt'), ios_file_with_entitlements
   )
 
   embed_codesign_configuration(
-      os.path.join(dst, 'without_entitlements.txt'), [
-          'Flutter.xcframework/ios-arm64/Flutter.framework/Flutter\n',
-          'Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter\n'
-      ]
+      os.path.join(dst, 'without_entitlements.txt'),
+      ios_file_without_entitlements
   )
 
   subprocess.check_call([

--- a/sky/tools/create_full_ios_framework.py
+++ b/sky/tools/create_full_ios_framework.py
@@ -163,17 +163,22 @@ def create_framework(
   ])
 
 
-def zip_archive(dst):
-  entitlement_config = open(dst + '/entitlements.txt', 'w')
-  entitlement_config.write('gen_snapshot_arm64\n')
-  entitlement_config.close()
+def embed_codesign_configuration(config_path, contents):
+  with open(config_path, 'w') as f:
+    f.writelines(contents)
 
-  without_entitlement_config = open(dst + '/without_entitlements.txt', 'w')
-  without_entitlement_config.writelines([
-      'Flutter.xcframework/ios-arm64/Flutter.framework/Flutter\n',
-      'Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter\n'
-  ])
-  without_entitlement_config.close()
+
+def zip_archive(dst):
+  embed_codesign_configuration(
+      os.path.join(dst, 'entitlements.txt'), ['gen_snapshot_arm64\n']
+  )
+
+  embed_codesign_configuration(
+      os.path.join(dst, 'without_entitlements.txt'), [
+          'Flutter.xcframework/ios-arm64/Flutter.framework/Flutter\n',
+          'Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter\n'
+      ]
+  )
 
   subprocess.check_call([
       'zip',


### PR DESCRIPTION
context: This change is based on recent changes related to generators: https://flutter-review.googlesource.com/c/recipes/+/32501, https://flutter-review.googlesource.com/c/recipes/+/32500, https://flutter-review.googlesource.com/c/recipes/+/32380,
https://flutter-review.googlesource.com/c/recipes/+/32280.

This commit adds Mac codesign configuration files into ios/artifacts.zip. Since ios/artifacts.zip is produced through global generators, the configuration is embedded into generator script.
