### PR TITLE
Null check for the activity intent in FlutterEngineConnectionRegistry.attachToActivityInternal

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngineConnectionRegistry.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngineConnectionRegistry.java
@@ -331,9 +331,11 @@ import java.util.Set;
     this.activityPluginBinding = new FlutterEngineActivityPluginBinding(activity, lifecycle);
 
     final boolean useSoftwareRendering =
-        activity
-            .getIntent()
-            .getBooleanExtra(FlutterShellArgs.ARG_KEY_ENABLE_SOFTWARE_RENDERING, false);
+        activity.getIntent() != null
+            ? activity
+                .getIntent()
+                .getBooleanExtra(FlutterShellArgs.ARG_KEY_ENABLE_SOFTWARE_RENDERING, false)
+            : false;
     flutterEngine.getPlatformViewsController().setSoftwareRendering(useSoftwareRendering);
 
     // Activate the PlatformViewsController. This must happen before any plugins attempt

--- a/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineConnectionRegistryTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineConnectionRegistryTest.java
@@ -127,15 +127,18 @@ public class FlutterEngineConnectionRegistryTest {
     Activity activity = mock(Activity.class);
     when(appComponent.getAppComponent()).thenReturn(activity);
 
+    // Test attachToActivity with an Activity that has no Intent.
+    FlutterEngineConnectionRegistry registry =
+        new FlutterEngineConnectionRegistry(context, flutterEngine, flutterLoader);
+    registry.attachToActivity(appComponent, mock(Lifecycle.class));
+    verify(platformViewsController).setSoftwareRendering(false);
+
     Intent intent = mock(Intent.class);
     when(intent.getBooleanExtra("enable-software-rendering", false)).thenReturn(false);
     when(activity.getIntent()).thenReturn(intent);
 
-    FlutterEngineConnectionRegistry registry =
-        new FlutterEngineConnectionRegistry(context, flutterEngine, flutterLoader);
-
     registry.attachToActivity(appComponent, mock(Lifecycle.class));
-    verify(platformViewsController).setSoftwareRendering(false);
+    verify(platformViewsController, times(2)).setSoftwareRendering(false);
 
     when(intent.getBooleanExtra("enable-software-rendering", false)).thenReturn(true);
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/109364