### PR TITLE
Display list multiplexer

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -55,6 +55,8 @@ FILE: ../../../flutter/display_list/display_list_blend_mode.cc
 FILE: ../../../flutter/display_list/display_list_blend_mode.h
 FILE: ../../../flutter/display_list/display_list_builder.cc
 FILE: ../../../flutter/display_list/display_list_builder.h
+FILE: ../../../flutter/display_list/display_list_builder_multiplexer.cc
+FILE: ../../../flutter/display_list/display_list_builder_multiplexer.h
 FILE: ../../../flutter/display_list/display_list_builder_benchmarks.cc
 FILE: ../../../flutter/display_list/display_list_canvas_dispatcher.cc
 FILE: ../../../flutter/display_list/display_list_canvas_dispatcher.h

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -55,9 +55,9 @@ FILE: ../../../flutter/display_list/display_list_blend_mode.cc
 FILE: ../../../flutter/display_list/display_list_blend_mode.h
 FILE: ../../../flutter/display_list/display_list_builder.cc
 FILE: ../../../flutter/display_list/display_list_builder.h
+FILE: ../../../flutter/display_list/display_list_builder_benchmarks.cc
 FILE: ../../../flutter/display_list/display_list_builder_multiplexer.cc
 FILE: ../../../flutter/display_list/display_list_builder_multiplexer.h
-FILE: ../../../flutter/display_list/display_list_builder_benchmarks.cc
 FILE: ../../../flutter/display_list/display_list_canvas_dispatcher.cc
 FILE: ../../../flutter/display_list/display_list_canvas_dispatcher.h
 FILE: ../../../flutter/display_list/display_list_canvas_recorder.cc

--- a/display_list/BUILD.gn
+++ b/display_list/BUILD.gn
@@ -16,6 +16,8 @@ source_set("display_list") {
     "display_list_blend_mode.h",
     "display_list_builder.cc",
     "display_list_builder.h",
+    "display_list_builder_multiplexer.cc",
+    "display_list_builder_multiplexer.h",
     "display_list_canvas_dispatcher.cc",
     "display_list_canvas_dispatcher.h",
     "display_list_canvas_recorder.cc",

--- a/display_list/display_list_builder_multiplexer.cc
+++ b/display_list/display_list_builder_multiplexer.cc
@@ -1,0 +1,28 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/display_list/display_list_builder_multiplexer.h"
+
+namespace flutter {
+
+void DisplayListBuilderMultiplexer::addBuilder(DisplayListBuilder* builder) {
+  builders_.push_back(builder);
+}
+
+void DisplayListBuilderMultiplexer::saveLayer(
+    const SkRect* bounds,
+    const DlPaint* paint,
+    const DlImageFilter* backdrop_filter) {
+  for (auto builder : builders_) {
+    builder->saveLayer(bounds, paint, backdrop_filter);
+  }
+}
+
+void DisplayListBuilderMultiplexer::restore() {
+  for (auto builder : builders_) {
+    builder->restore();
+  }
+}
+
+}  // namespace flutter

--- a/display_list/display_list_builder_multiplexer.cc
+++ b/display_list/display_list_builder_multiplexer.cc
@@ -14,13 +14,13 @@ void DisplayListBuilderMultiplexer::saveLayer(
     const SkRect* bounds,
     const DlPaint* paint,
     const DlImageFilter* backdrop_filter) {
-  for (auto builder : builders_) {
+  for (auto* builder : builders_) {
     builder->saveLayer(bounds, paint, backdrop_filter);
   }
 }
 
 void DisplayListBuilderMultiplexer::restore() {
-  for (auto builder : builders_) {
+  for (auto* builder : builders_) {
     builder->restore();
   }
 }

--- a/display_list/display_list_builder_multiplexer.h
+++ b/display_list/display_list_builder_multiplexer.h
@@ -1,0 +1,35 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_DISPLAY_LIST_DISPLAY_LIST_BUILDER_MULTIPLEXER_H_
+#define FLUTTER_DISPLAY_LIST_DISPLAY_LIST_BUILDER_MULTIPLEXER_H_
+
+#include "flutter/display_list/display_list_builder.h"
+#include "flutter/display_list/display_list_image_filter.h"
+#include "flutter/display_list/display_list_paint.h"
+#include "flutter/fml/macros.h"
+
+namespace flutter {
+
+/// A class that mutiplexes some of the DisplayListBuilder calls to multiple
+/// other builders. For now it only implements saveLayer and restore as those
+/// are needed to create a replacement for PaintContext::internal_nodes_canvas.
+class DisplayListBuilderMultiplexer {
+ public:
+  DisplayListBuilderMultiplexer() = default;
+
+  void addBuilder(DisplayListBuilder* builder);
+
+  void saveLayer(const SkRect* bounds, const DlPaint* paint,
+                 const DlImageFilter* backdrop_filter = nullptr);
+
+  void restore();
+
+ private:
+  std::vector<DisplayListBuilder*> builders_;
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_DISPLAY_LIST_DISPLAY_LIST_BUILDER_MULTIPLEXER_H_

--- a/display_list/display_list_builder_multiplexer.h
+++ b/display_list/display_list_builder_multiplexer.h
@@ -21,7 +21,8 @@ class DisplayListBuilderMultiplexer {
 
   void addBuilder(DisplayListBuilder* builder);
 
-  void saveLayer(const SkRect* bounds, const DlPaint* paint,
+  void saveLayer(const SkRect* bounds,
+                 const DlPaint* paint,
                  const DlImageFilter* backdrop_filter = nullptr);
 
   void restore();

--- a/flow/embedded_views.h
+++ b/flow/embedded_views.h
@@ -7,6 +7,7 @@
 
 #include <vector>
 
+#include "flutter/display_list/display_list_builder.h"
 #include "flutter/flow/rtree.h"
 #include "flutter/flow/surface_frame.h"
 #include "flutter/fml/memory/ref_counted.h"
@@ -393,6 +394,7 @@ class ExternalViewEmbedder {
   }
 
   virtual std::vector<SkCanvas*> GetCurrentCanvases() = 0;
+  virtual std::vector<DisplayListBuilder*> GetCurrentBuilders() = 0;
 
   // Must be called on the UI thread.
   virtual EmbedderPaintContext CompositeEmbeddedView(int view_id) = 0;

--- a/flow/layers/backdrop_filter_layer.cc
+++ b/flow/layers/backdrop_filter_layer.cc
@@ -60,6 +60,10 @@ void BackdropFilterLayer::Paint(PaintContext& context) const {
   AutoCachePaint save_paint(context);
   save_paint.setBlendMode(blend_mode_);
   if (context.leaf_nodes_builder) {
+    // Note that we perform a saveLayer directly on the
+    // leaf_nodes_builder here similar to how the SkCanvas
+    // path specifies the kLeafNodesCanvas below.
+    // See https:://flutter.dev/go/backdrop-filter-with-overlay-canvas
     context.leaf_nodes_builder->saveLayer(&paint_bounds(),
                                           save_paint.dl_paint(), filter_.get());
 

--- a/flow/layers/color_filter_layer.cc
+++ b/flow/layers/color_filter_layer.cc
@@ -61,10 +61,11 @@ void ColorFilterLayer::Paint(PaintContext& context) const {
   AutoCachePaint cache_paint(context);
   cache_paint.setColorFilter(filter_.get());
   if (context.leaf_nodes_builder) {
-    context.leaf_nodes_builder->saveLayer(&paint_bounds(),
-                                          cache_paint.dl_paint());
+    FML_DCHECK(context.builder_multiplexer);
+    context.builder_multiplexer->saveLayer(&paint_bounds(),
+                                           cache_paint.dl_paint());
     PaintChildren(context);
-    context.leaf_nodes_builder->restore();
+    context.builder_multiplexer->restore();
   } else {
     Layer::AutoSaveLayer save = Layer::AutoSaveLayer::Create(
         context, paint_bounds(), cache_paint.sk_paint());

--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "flutter/common/graphics/texture.h"
+#include "flutter/display_list/display_list_builder_multiplexer.h"
 #include "flutter/flow/diff_context.h"
 #include "flutter/flow/embedded_views.h"
 #include "flutter/flow/instrumentation.h"
@@ -29,7 +30,9 @@
 #include "third_party/skia/include/core/SkRRect.h"
 #include "third_party/skia/include/core/SkRect.h"
 #include "third_party/skia/include/utils/SkNWayCanvas.h"
+
 namespace flutter {
+
 namespace testing {
 class MockLayer;
 }  // namespace testing
@@ -150,6 +153,7 @@ struct PaintContext {
   // a |kSrcOver| blend mode.
   SkScalar inherited_opacity = SK_Scalar1;
   DisplayListBuilder* leaf_nodes_builder = nullptr;
+  DisplayListBuilderMultiplexer* builder_multiplexer = nullptr;
 };
 
 // Represents a single composited layer. Created on the UI thread but then

--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -124,7 +124,7 @@ void LayerTree::Paint(CompositorContext::ScopedFrame& frame,
   if (builder) {
     builder_multiplexer.addBuilder(builder);
     if (frame.view_embedder()) {
-      for (auto view_builder : frame.view_embedder()->GetCurrentBuilders()) {
+      for (auto* view_builder : frame.view_embedder()->GetCurrentBuilders()) {
         builder_multiplexer.addBuilder(view_builder);
       }
     }

--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -119,6 +119,16 @@ void LayerTree::Paint(CompositorContext::ScopedFrame& frame,
       internal_nodes_canvas.addCanvas(overlay_canvases[i]);
     }
   }
+  DisplayListBuilder* builder = frame.display_list_builder();
+  DisplayListBuilderMultiplexer builder_multiplexer;
+  if (builder) {
+    builder_multiplexer.addBuilder(builder);
+    if (frame.view_embedder()) {
+      for (auto view_builder : frame.view_embedder()->GetCurrentBuilders()) {
+        builder_multiplexer.addBuilder(view_builder);
+      }
+    }
+  }
 
   // clear the previous snapshots.
   LayerSnapshotStore* snapshot_store = nullptr;
@@ -146,7 +156,8 @@ void LayerTree::Paint(CompositorContext::ScopedFrame& frame,
       .layer_snapshot_store          = snapshot_store,
       .enable_leaf_layer_tracing     = enable_leaf_layer_tracing_,
       .inherited_opacity             = SK_Scalar1,
-      .leaf_nodes_builder            = frame.display_list_builder(),
+      .leaf_nodes_builder            = builder,
+      .builder_multiplexer           = builder ? &builder_multiplexer : nullptr,
       // clang-format on
   };
 

--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -202,6 +202,8 @@ sk_sp<DisplayList> LayerTree::Flatten(const SkRect& bounds) {
   SkISize canvas_size = builder.getBaseLayerSize();
   SkNWayCanvas internal_nodes_canvas(canvas_size.width(), canvas_size.height());
   internal_nodes_canvas.addCanvas(&builder);
+  DisplayListBuilderMultiplexer multiplexer;
+  multiplexer.addBuilder(builder.builder().get());
 
   PaintContext paint_context = {
       // clang-format off
@@ -219,6 +221,7 @@ sk_sp<DisplayList> LayerTree::Flatten(const SkRect& bounds) {
       .layer_snapshot_store          = nullptr,
       .enable_leaf_layer_tracing     = false,
       .leaf_nodes_builder            = builder.builder().get(),
+      .builder_multiplexer           = &multiplexer,
       // clang-format on
   };
 

--- a/flow/layers/layer_tree_unittests.cc
+++ b/flow/layers/layer_tree_unittests.cc
@@ -256,6 +256,7 @@ TEST_F(LayerTreeTest, PaintContextInitialization) {
 
     EXPECT_EQ(context.inherited_opacity, SK_Scalar1);
     EXPECT_EQ(context.leaf_nodes_builder, nullptr);
+    EXPECT_EQ(context.builder_multiplexer, nullptr);
   };
 
   // These 4 initializers are required because they are handled by reference

--- a/flow/testing/layer_test.h
+++ b/flow/testing/layer_test.h
@@ -12,6 +12,7 @@
 #include <utility>
 #include <vector>
 
+#include "flutter/display_list/display_list_builder_multiplexer.h"
 #include "flutter/flow/testing/mock_raster_cache.h"
 #include "flutter/fml/macros.h"
 #include "flutter/testing/canvas_test.h"
@@ -92,6 +93,7 @@ class LayerTestBase : public CanvasTestBase<BaseT> {
             .checkerboard_offscreen_layers = false,
             .frame_device_pixel_ratio      = 1.0f,
             .leaf_nodes_builder            = display_list_recorder_.builder().get(),
+            .builder_multiplexer           = &display_list_multiplexer_,
             // clang-format on
         },
         check_board_context_{
@@ -109,6 +111,8 @@ class LayerTestBase : public CanvasTestBase<BaseT> {
             // clang-format on
         } {
     internal_display_list_canvas_.addCanvas(&display_list_recorder_);
+    display_list_multiplexer_.addBuilder(
+        display_list_recorder_.builder().get());
     use_null_raster_cache();
   }
 
@@ -214,6 +218,7 @@ class LayerTestBase : public CanvasTestBase<BaseT> {
   PrerollContext preroll_context_;
   PaintContext paint_context_;
   DisplayListCanvasRecorder display_list_recorder_;
+  DisplayListBuilderMultiplexer display_list_multiplexer_;
   sk_sp<DisplayList> display_list_;
   SkNWayCanvas internal_display_list_canvas_;
   PaintContext display_list_paint_context_;

--- a/flow/testing/layer_test.h
+++ b/flow/testing/layer_test.h
@@ -187,6 +187,7 @@ class LayerTestBase : public CanvasTestBase<BaseT> {
       display_list_paint_context_.leaf_nodes_canvas = nullptr;
       display_list_paint_context_.internal_nodes_canvas = nullptr;
       display_list_paint_context_.leaf_nodes_builder = nullptr;
+      display_list_paint_context_.builder_multiplexer = nullptr;
     }
     return display_list_;
   }

--- a/flow/testing/mock_embedder.cc
+++ b/flow/testing/mock_embedder.cc
@@ -37,6 +37,11 @@ std::vector<SkCanvas*> MockViewEmbedder::GetCurrentCanvases() {
 }
 
 // |ExternalViewEmbedder|
+std::vector<DisplayListBuilder*> MockViewEmbedder::GetCurrentBuilders() {
+  return std::vector<DisplayListBuilder*>({});
+}
+
+// |ExternalViewEmbedder|
 EmbedderPaintContext MockViewEmbedder::CompositeEmbeddedView(int view_id) {
   return {nullptr, nullptr};
 }

--- a/flow/testing/mock_embedder.h
+++ b/flow/testing/mock_embedder.h
@@ -38,6 +38,9 @@ class MockViewEmbedder : public ExternalViewEmbedder {
   std::vector<SkCanvas*> GetCurrentCanvases() override;
 
   // |ExternalViewEmbedder|
+  std::vector<DisplayListBuilder*> GetCurrentBuilders() override;
+
+  // |ExternalViewEmbedder|
   EmbedderPaintContext CompositeEmbeddedView(int view_id) override;
 };
 

--- a/shell/common/rasterizer_unittests.cc
+++ b/shell/common/rasterizer_unittests.cc
@@ -66,6 +66,7 @@ class MockExternalViewEmbedder : public ExternalViewEmbedder {
                PostPrerollResult(
                    fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger));
   MOCK_METHOD0(GetCurrentCanvases, std::vector<SkCanvas*>());
+  MOCK_METHOD0(GetCurrentBuilders, std::vector<DisplayListBuilder*>());
   MOCK_METHOD1(CompositeEmbeddedView, EmbedderPaintContext(int view_id));
   MOCK_METHOD2(SubmitFrame,
                void(GrDirectContext* context,

--- a/shell/common/shell_test_external_view_embedder.cc
+++ b/shell/common/shell_test_external_view_embedder.cc
@@ -73,6 +73,12 @@ std::vector<SkCanvas*> ShellTestExternalViewEmbedder::GetCurrentCanvases() {
 }
 
 // |ExternalViewEmbedder|
+std::vector<DisplayListBuilder*>
+ShellTestExternalViewEmbedder::GetCurrentBuilders() {
+  return {};
+}
+
+// |ExternalViewEmbedder|
 void ShellTestExternalViewEmbedder::PushVisitedPlatformView(int64_t view_id) {
   visited_platform_views_.push_back(view_id);
 }

--- a/shell/common/shell_test_external_view_embedder.h
+++ b/shell/common/shell_test_external_view_embedder.h
@@ -66,6 +66,9 @@ class ShellTestExternalViewEmbedder final : public ExternalViewEmbedder {
   std::vector<SkCanvas*> GetCurrentCanvases() override;
 
   // |ExternalViewEmbedder|
+  std::vector<DisplayListBuilder*> GetCurrentBuilders() override;
+
+  // |ExternalViewEmbedder|
   EmbedderPaintContext CompositeEmbeddedView(int view_id) override;
 
   // |ExternalViewEmbedder|

--- a/shell/platform/android/external_view_embedder/external_view_embedder.cc
+++ b/shell/platform/android/external_view_embedder/external_view_embedder.cc
@@ -69,6 +69,19 @@ std::vector<SkCanvas*> AndroidExternalViewEmbedder::GetCurrentCanvases() {
   return canvases;
 }
 
+// |ExternalViewEmbedder|
+std::vector<DisplayListBuilder*>
+AndroidExternalViewEmbedder::GetCurrentBuilders() {
+  std::vector<DisplayListBuilder*> builders;
+  for (size_t i = 0; i < composition_order_.size(); i++) {
+    int64_t view_id = composition_order_[i];
+    if (slices_.count(view_id) == 1) {
+      builders.push_back(slices_.at(view_id)->builder());
+    }
+  }
+  return builders;
+}
+
 SkRect AndroidExternalViewEmbedder::GetViewRect(int view_id) const {
   const EmbeddedViewParams& params = view_params_.at(view_id);
   // TODO(egarciad): The rect should be computed from the mutator stack.

--- a/shell/platform/android/external_view_embedder/external_view_embedder.h
+++ b/shell/platform/android/external_view_embedder/external_view_embedder.h
@@ -48,6 +48,9 @@ class AndroidExternalViewEmbedder final : public ExternalViewEmbedder {
   std::vector<SkCanvas*> GetCurrentCanvases() override;
 
   // |ExternalViewEmbedder|
+  // Similar call to GetCurrentCanvases but will return the array of
+  // builders being used by PlatformViews on platforms that provide
+  // optional DisplayListBuilder objects for rendering.
   std::vector<DisplayListBuilder*> GetCurrentBuilders() override;
 
   // |ExternalViewEmbedder|

--- a/shell/platform/android/external_view_embedder/external_view_embedder.h
+++ b/shell/platform/android/external_view_embedder/external_view_embedder.h
@@ -48,6 +48,9 @@ class AndroidExternalViewEmbedder final : public ExternalViewEmbedder {
   std::vector<SkCanvas*> GetCurrentCanvases() override;
 
   // |ExternalViewEmbedder|
+  std::vector<DisplayListBuilder*> GetCurrentBuilders() override;
+
+  // |ExternalViewEmbedder|
   void SubmitFrame(GrDirectContext* context,
                    std::unique_ptr<SurfaceFrame> frame) override;
 

--- a/shell/platform/android/external_view_embedder/external_view_embedder_unittests.cc
+++ b/shell/platform/android/external_view_embedder/external_view_embedder_unittests.cc
@@ -124,6 +124,9 @@ TEST(AndroidExternalViewEmbedder, GetCurrentCanvases) {
   ASSERT_EQ(2UL, canvases.size());
   ASSERT_EQ(SkISize::Make(10, 20), canvases[0]->getBaseLayerSize());
   ASSERT_EQ(SkISize::Make(10, 20), canvases[1]->getBaseLayerSize());
+
+  auto builders = embedder->GetCurrentBuilders();
+  ASSERT_EQ(2UL, builders.size());
 }
 
 TEST(AndroidExternalViewEmbedder, GetCurrentCanvasesCompositeOrder) {
@@ -149,6 +152,9 @@ TEST(AndroidExternalViewEmbedder, GetCurrentCanvasesCompositeOrder) {
   ASSERT_EQ(2UL, canvases.size());
   ASSERT_EQ(embedder->CompositeEmbeddedView(0).canvas, canvases[0]);
   ASSERT_EQ(embedder->CompositeEmbeddedView(1).canvas, canvases[1]);
+
+  auto builders = embedder->GetCurrentBuilders();
+  ASSERT_EQ(2UL, builders.size());
 }
 
 TEST(AndroidExternalViewEmbedder, CompositeEmbeddedView) {
@@ -178,6 +184,9 @@ TEST(AndroidExternalViewEmbedder, CancelFrame) {
 
   auto canvases = embedder->GetCurrentCanvases();
   ASSERT_EQ(0UL, canvases.size());
+
+  auto builders = embedder->GetCurrentBuilders();
+  ASSERT_EQ(0UL, builders.size());
 }
 
 TEST(AndroidExternalViewEmbedder, RasterizerRunsOnPlatformThread) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -379,6 +379,15 @@ std::vector<SkCanvas*> FlutterPlatformViewsController::GetCurrentCanvases() {
   return canvases;
 }
 
+std::vector<DisplayListBuilder*> FlutterPlatformViewsController::GetCurrentBuilders() {
+  std::vector<DisplayListBuilder*> builders;
+  for (size_t i = 0; i < composition_order_.size(); i++) {
+    int64_t view_id = composition_order_[i];
+    builders.push_back(slices_[view_id]->builder());
+  }
+  return builders;
+}
+
 int FlutterPlatformViewsController::CountClips(const MutatorsStack& mutators_stack) {
   std::vector<std::shared_ptr<Mutator>>::const_reverse_iterator iter = mutators_stack.Bottom();
   int clipCount = 0;

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -1076,16 +1076,19 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   flutterPlatformViewsController->PrerollCompositeEmbeddedView(0, std::move(embeddedViewParams1));
   flutterPlatformViewsController->CompositeEmbeddedView(0);
   XCTAssertEqual(flutterPlatformViewsController->GetCurrentCanvases().size(), 1UL);
+  XCTAssertEqual(flutterPlatformViewsController->GetCurrentBuilders().size(), 1UL);
 
   // Second frame, |GetCurrentCanvases| should be empty at the start
   flutterPlatformViewsController->BeginFrame(SkISize::Make(300, 300));
   XCTAssertTrue(flutterPlatformViewsController->GetCurrentCanvases().empty());
+  XCTAssertTrue(flutterPlatformViewsController->GetCurrentBuilders().empty());
 
   auto embeddedViewParams2 =
       std::make_unique<flutter::EmbeddedViewParams>(finalMatrix, SkSize::Make(300, 300), stack);
   flutterPlatformViewsController->PrerollCompositeEmbeddedView(0, std::move(embeddedViewParams2));
   flutterPlatformViewsController->CompositeEmbeddedView(0);
   XCTAssertEqual(flutterPlatformViewsController->GetCurrentCanvases().size(), 1UL);
+  XCTAssertEqual(flutterPlatformViewsController->GetCurrentBuilders().size(), 1UL);
 }
 
 - (void)testThreadMergeAtEndFrame {

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -165,6 +165,8 @@ class FlutterPlatformViewsController {
 
   std::vector<SkCanvas*> GetCurrentCanvases();
 
+  std::vector<DisplayListBuilder*> GetCurrentBuilders();
+
   EmbedderPaintContext CompositeEmbeddedView(int view_id);
 
   // The rect of the platform view at index view_id. This rect has been translated into the

--- a/shell/platform/darwin/ios/ios_external_view_embedder.h
+++ b/shell/platform/darwin/ios/ios_external_view_embedder.h
@@ -50,6 +50,9 @@ class IOSExternalViewEmbedder : public ExternalViewEmbedder {
   std::vector<SkCanvas*> GetCurrentCanvases() override;
 
   // |ExternalViewEmbedder|
+  std::vector<DisplayListBuilder*> GetCurrentBuilders() override;
+
+  // |ExternalViewEmbedder|
   EmbedderPaintContext CompositeEmbeddedView(int view_id) override;
 
   // |ExternalViewEmbedder|

--- a/shell/platform/darwin/ios/ios_external_view_embedder.mm
+++ b/shell/platform/darwin/ios/ios_external_view_embedder.mm
@@ -65,6 +65,12 @@ std::vector<SkCanvas*> IOSExternalViewEmbedder::GetCurrentCanvases() {
 }
 
 // |ExternalViewEmbedder|
+std::vector<SkCanvas*> IOSExternalViewEmbedder::GetCurrentBuilders() {
+  FML_CHECK(platform_views_controller_);
+  return platform_views_controller_->GetCurentBuilders();
+}
+
+// |ExternalViewEmbedder|
 EmbedderPaintContext IOSExternalViewEmbedder::CompositeEmbeddedView(int view_id) {
   TRACE_EVENT0("flutter", "IOSExternalViewEmbedder::CompositeEmbeddedView");
   FML_CHECK(platform_views_controller_);

--- a/shell/platform/darwin/ios/ios_external_view_embedder.mm
+++ b/shell/platform/darwin/ios/ios_external_view_embedder.mm
@@ -65,9 +65,9 @@ std::vector<SkCanvas*> IOSExternalViewEmbedder::GetCurrentCanvases() {
 }
 
 // |ExternalViewEmbedder|
-std::vector<SkCanvas*> IOSExternalViewEmbedder::GetCurrentBuilders() {
+std::vector<DisplayListBuilder*> IOSExternalViewEmbedder::GetCurrentBuilders() {
   FML_CHECK(platform_views_controller_);
-  return platform_views_controller_->GetCurentBuilders();
+  return platform_views_controller_->GetCurrentBuilders();
 }
 
 // |ExternalViewEmbedder|

--- a/shell/platform/embedder/embedder_external_view_embedder.cc
+++ b/shell/platform/embedder/embedder_external_view_embedder.cc
@@ -111,6 +111,12 @@ std::vector<SkCanvas*> EmbedderExternalViewEmbedder::GetCurrentCanvases() {
 }
 
 // |ExternalViewEmbedder|
+std::vector<DisplayListBuilder*>
+EmbedderExternalViewEmbedder::GetCurrentBuilders() {
+  return std::vector<DisplayListBuilder*>({});
+}
+
+// |ExternalViewEmbedder|
 EmbedderPaintContext EmbedderExternalViewEmbedder::CompositeEmbeddedView(
     int view_id) {
   auto vid = EmbedderExternalView::ViewIdentifier(view_id);

--- a/shell/platform/embedder/embedder_external_view_embedder.h
+++ b/shell/platform/embedder/embedder_external_view_embedder.h
@@ -94,6 +94,9 @@ class EmbedderExternalViewEmbedder final : public ExternalViewEmbedder {
   std::vector<SkCanvas*> GetCurrentCanvases() override;
 
   // |ExternalViewEmbedder|
+  std::vector<DisplayListBuilder*> GetCurrentBuilders() override;
+
+  // |ExternalViewEmbedder|
   EmbedderPaintContext CompositeEmbeddedView(int view_id) override;
 
   // |ExternalViewEmbedder|

--- a/shell/platform/fuchsia/flutter/flatland_external_view_embedder.cc
+++ b/shell/platform/fuchsia/flutter/flatland_external_view_embedder.cc
@@ -56,6 +56,10 @@ std::vector<SkCanvas*> FlatlandExternalViewEmbedder::GetCurrentCanvases() {
   return canvases;
 }
 
+std::vector<SkCanvas*> FlatlandExternalViewEmbedder::GetCurrentBuilders() {
+  return std::vector<DisplayListBuilder*>();
+}
+
 void FlatlandExternalViewEmbedder::PrerollCompositeEmbeddedView(
     int view_id,
     std::unique_ptr<flutter::EmbeddedViewParams> params) {

--- a/shell/platform/fuchsia/flutter/flatland_external_view_embedder.cc
+++ b/shell/platform/fuchsia/flutter/flatland_external_view_embedder.cc
@@ -56,8 +56,9 @@ std::vector<SkCanvas*> FlatlandExternalViewEmbedder::GetCurrentCanvases() {
   return canvases;
 }
 
-std::vector<SkCanvas*> FlatlandExternalViewEmbedder::GetCurrentBuilders() {
-  return std::vector<DisplayListBuilder*>();
+std::vector<flutter::DisplayListBuilder*>
+FlatlandExternalViewEmbedder::GetCurrentBuilders() {
+  return std::vector<flutter::DisplayListBuilder*>();
 }
 
 void FlatlandExternalViewEmbedder::PrerollCompositeEmbeddedView(

--- a/shell/platform/fuchsia/flutter/flatland_external_view_embedder.h
+++ b/shell/platform/fuchsia/flutter/flatland_external_view_embedder.h
@@ -16,6 +16,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "flutter/display_list/display_list_builder_multiplexer.h"
 #include "flutter/flow/embedded_views.h"
 #include "flutter/fml/logging.h"
 #include "flutter/fml/macros.h"

--- a/shell/platform/fuchsia/flutter/flatland_external_view_embedder.h
+++ b/shell/platform/fuchsia/flutter/flatland_external_view_embedder.h
@@ -16,7 +16,6 @@
 #include <unordered_map>
 #include <vector>
 
-#include "flutter/display_list/display_list_builder_multiplexer.h"
 #include "flutter/flow/embedded_views.h"
 #include "flutter/fml/logging.h"
 #include "flutter/fml/macros.h"
@@ -66,7 +65,7 @@ class FlatlandExternalViewEmbedder final
   std::vector<SkCanvas*> GetCurrentCanvases() override;
 
   // |ExternalViewEmbedder|
-  std::vector<DisplayListBuilder*> GetCurrentBuilders() override;
+  std::vector<flutter::DisplayListBuilder*> GetCurrentBuilders() override;
 
   // |ExternalViewEmbedder|
   void PrerollCompositeEmbeddedView(

--- a/shell/platform/fuchsia/flutter/flatland_external_view_embedder.h
+++ b/shell/platform/fuchsia/flutter/flatland_external_view_embedder.h
@@ -65,6 +65,9 @@ class FlatlandExternalViewEmbedder final
   std::vector<SkCanvas*> GetCurrentCanvases() override;
 
   // |ExternalViewEmbedder|
+  std::vector<DisplayListBuilder*> GetCurrentBuilders() override;
+
+  // |ExternalViewEmbedder|
   void PrerollCompositeEmbeddedView(
       int view_id,
       std::unique_ptr<flutter::EmbeddedViewParams> params) override;

--- a/shell/platform/fuchsia/flutter/gfx_external_view_embedder.cc
+++ b/shell/platform/fuchsia/flutter/gfx_external_view_embedder.cc
@@ -166,7 +166,7 @@ std::vector<SkCanvas*> GfxExternalViewEmbedder::GetCurrentCanvases() {
 
 std::vector<flutter::DisplayListBuilder*>
 GfxExternalViewEmbedder::GetCurrentBuilders() {
-  return std::vector<DisplayListBuilder*>({});
+  return std::vector<flutter::DisplayListBuilder*>({});
 }
 
 void GfxExternalViewEmbedder::PrerollCompositeEmbeddedView(

--- a/shell/platform/fuchsia/flutter/gfx_external_view_embedder.cc
+++ b/shell/platform/fuchsia/flutter/gfx_external_view_embedder.cc
@@ -164,6 +164,11 @@ std::vector<SkCanvas*> GfxExternalViewEmbedder::GetCurrentCanvases() {
   return canvases;
 }
 
+std::vector<flutter::DisplayListBuilder*>
+GfxExternalViewEmbedder::GetCurrentBuilders() {
+  return std::vector<DisplayListBuilder*>({});
+}
+
 void GfxExternalViewEmbedder::PrerollCompositeEmbeddedView(
     int view_id,
     std::unique_ptr<flutter::EmbeddedViewParams> params) {

--- a/shell/platform/fuchsia/flutter/gfx_external_view_embedder.h
+++ b/shell/platform/fuchsia/flutter/gfx_external_view_embedder.h
@@ -88,6 +88,9 @@ class GfxExternalViewEmbedder final : public flutter::ExternalViewEmbedder {
   std::vector<SkCanvas*> GetCurrentCanvases() override;
 
   // |ExternalViewEmbedder|
+  std::vector<flutter::DisplayListBuilder*> GetCurrentBuilders() override;
+
+  // |ExternalViewEmbedder|
   void PrerollCompositeEmbeddedView(
       int view_id,
       std::unique_ptr<flutter::EmbeddedViewParams> params) override;

--- a/shell/platform/fuchsia/flutter/platform_view_unittest.cc
+++ b/shell/platform/fuchsia/flutter/platform_view_unittest.cc
@@ -48,6 +48,9 @@ class MockExternalViewEmbedder : public flutter::ExternalViewEmbedder {
   std::vector<SkCanvas*> GetCurrentCanvases() override {
     return std::vector<SkCanvas*>();
   }
+  std::vector<flutter::DisplayListBuilder*> GetCurrentBuilders() override {
+    return std::vector<flutter::DisplayListBuilder*>();
+  }
 
   void CancelFrame() override {}
   void BeginFrame(

--- a/shell/platform/fuchsia/flutter/tests/flatland_platform_view_unittest.cc
+++ b/shell/platform/fuchsia/flutter/tests/flatland_platform_view_unittest.cc
@@ -47,6 +47,9 @@ class MockExternalViewEmbedder : public flutter::ExternalViewEmbedder {
   std::vector<SkCanvas*> GetCurrentCanvases() override {
     return std::vector<SkCanvas*>();
   }
+  std::vector<flutter::DisplayListBuilder*> GetCurrentBuilders() override {
+    return std::vector<flutter::DisplayListBuilder*>();
+  }
 
   void CancelFrame() override {}
   void BeginFrame(

--- a/shell/testing/tester_main.cc
+++ b/shell/testing/tester_main.cc
@@ -60,6 +60,9 @@ class TesterExternalViewEmbedder : public ExternalViewEmbedder {
   std::vector<SkCanvas*> GetCurrentCanvases() override { return {&canvas_}; }
 
   // |ExternalViewEmbedder|
+  std::vector<DisplayListBuilder*> GetCurrentBuilders() override { return {}; }
+
+  // |ExternalViewEmbedder|
   EmbedderPaintContext CompositeEmbeddedView(int view_id) override {
     return {&canvas_, nullptr};
   }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/109579

This small utility class should enable us to continue embracing the `PaintContext::leaf_nodes_builder` class in subclasses that require access to saveLayer on `PaintContext::internal_nodes_canvas`.