### PR TITLE
[Impeller] Avoid unnecessary pre-pass when filtering images

### DIFF
--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -274,8 +274,7 @@ void Canvas::DrawImageRect(std::shared_ptr<Image> image,
     return;
   }
 
-  auto contents = std::make_shared<TextureContents>();
-  contents->SetPath(PathBuilder{}.AddRect(dest).TakePath());
+  auto contents = TextureContents::MakeRect(dest);
   contents->SetTexture(image->GetTexture());
   contents->SetSourceRect(source);
   contents->SetSamplerDescriptor(std::move(sampler));

--- a/impeller/aiks/paint_pass_delegate.cc
+++ b/impeller/aiks/paint_pass_delegate.cc
@@ -34,9 +34,7 @@ bool PaintPassDelegate::CanCollapseIntoParentPass() {
 // |EntityPassDelgate|
 std::shared_ptr<Contents> PaintPassDelegate::CreateContentsForSubpassTarget(
     std::shared_ptr<Texture> target) {
-  auto contents = std::make_shared<TextureContents>();
-  contents->SetPath(
-      PathBuilder{}.AddRect(Rect::MakeSize(target->GetSize())).TakePath());
+  auto contents = TextureContents::MakeRect(Rect::MakeSize(target->GetSize()));
   contents->SetTexture(target);
   contents->SetSourceRect(Rect::MakeSize(target->GetSize()));
   contents->SetOpacity(paint_.color.alpha);

--- a/impeller/entity/contents/filters/filter_contents.cc
+++ b/impeller/entity/contents/filters/filter_contents.cc
@@ -152,9 +152,7 @@ bool FilterContents::Render(const ContentContext& renderer,
 
   // Draw the result texture, respecting the transform and clip stack.
 
-  auto contents = std::make_shared<TextureContents>();
-  contents->SetPath(
-      PathBuilder{}.AddRect(filter_coverage.value()).GetCurrentPath());
+  auto contents = TextureContents::MakeRect(filter_coverage.value());
   contents->SetTexture(snapshot.texture);
   contents->SetSamplerDescriptor(snapshot.sampler_descriptor);
   contents->SetSourceRect(Rect::MakeSize(snapshot.texture->GetSize()));

--- a/impeller/entity/contents/filters/filter_contents.cc
+++ b/impeller/entity/contents/filters/filter_contents.cc
@@ -156,6 +156,7 @@ bool FilterContents::Render(const ContentContext& renderer,
   contents->SetPath(
       PathBuilder{}.AddRect(filter_coverage.value()).GetCurrentPath());
   contents->SetTexture(snapshot.texture);
+  contents->SetSamplerDescriptor(snapshot.sampler_descriptor);
   contents->SetSourceRect(Rect::MakeSize(snapshot.texture->GetSize()));
 
   Entity e;

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -165,12 +165,6 @@ std::optional<Snapshot> DirectionalGaussianBlurFilterContents::RenderFilter(
     frag_info.outer_blur_factor = outer_blur_factor_;
     frag_info.texture_size = Point(input_snapshot->GetCoverage().value().size);
 
-    SamplerDescriptor sampler_desc;
-    sampler_desc.min_filter = MinMagFilter::kLinear;
-    sampler_desc.mag_filter = MinMagFilter::kLinear;
-    auto sampler =
-        renderer.GetContext()->GetSamplerLibrary()->GetSampler(sampler_desc);
-
     Command cmd;
     cmd.label = "Gaussian Blur Filter";
     auto options = OptionsFromPass(pass);
@@ -178,8 +172,14 @@ std::optional<Snapshot> DirectionalGaussianBlurFilterContents::RenderFilter(
     cmd.pipeline = renderer.GetGaussianBlurPipeline(options);
     cmd.BindVertices(vtx_buffer);
 
-    FS::BindTextureSampler(cmd, input_snapshot->texture, sampler);
-    FS::BindAlphaMaskSampler(cmd, source_snapshot->texture, sampler);
+    FS::BindTextureSampler(
+        cmd, input_snapshot->texture,
+        renderer.GetContext()->GetSamplerLibrary()->GetSampler(
+            input_snapshot->sampler_descriptor));
+    FS::BindAlphaMaskSampler(
+        cmd, source_snapshot->texture,
+        renderer.GetContext()->GetSamplerLibrary()->GetSampler(
+            source_snapshot->sampler_descriptor));
     VS::BindFrameInfo(cmd, host_buffer.EmplaceUniform(frame_info));
     FS::BindFragInfo(cmd, host_buffer.EmplaceUniform(frag_info));
 

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -104,6 +104,7 @@ std::optional<Snapshot> DirectionalGaussianBlurFilterContents::RenderFilter(
   if (!input_snapshot.has_value()) {
     return std::nullopt;
   }
+
   auto maybe_input_uvs = input_snapshot->GetCoverageUVs(coverage);
   if (!maybe_input_uvs.has_value()) {
     return std::nullopt;
@@ -191,8 +192,13 @@ std::optional<Snapshot> DirectionalGaussianBlurFilterContents::RenderFilter(
   }
   out_texture->SetLabel("DirectionalGaussianBlurFilter Texture");
 
+  SamplerDescriptor sampler_desc;
+  sampler_desc.min_filter = MinMagFilter::kLinear;
+  sampler_desc.mag_filter = MinMagFilter::kLinear;
+
   return Snapshot{.texture = out_texture,
-                  .transform = Matrix::MakeTranslation(coverage.origin)};
+                  .transform = Matrix::MakeTranslation(coverage.origin),
+                  .sampler_descriptor = sampler_desc};
 }
 
 std::optional<Rect> DirectionalGaussianBlurFilterContents::GetFilterCoverage(

--- a/impeller/entity/contents/texture_contents.cc
+++ b/impeller/entity/contents/texture_contents.cc
@@ -43,6 +43,14 @@ std::optional<Rect> TextureContents::GetCoverage(const Entity& entity) const {
   return path_.GetTransformedBoundingBox(entity.GetTransformation());
 };
 
+std::optional<Snapshot> TextureContents::RenderToSnapshot(
+    const ContentContext& renderer,
+    const Entity& entity) const {
+  return Snapshot{.texture = texture_,
+                  .transform = entity.GetTransformation(),
+                  .sampler_descriptor = sampler_descriptor_};
+}
+
 bool TextureContents::Render(const ContentContext& renderer,
                              const Entity& entity,
                              RenderPass& pass) const {

--- a/impeller/entity/contents/texture_contents.cc
+++ b/impeller/entity/contents/texture_contents.cc
@@ -4,12 +4,14 @@
 
 #include "texture_contents.h"
 
+#include <memory>
 #include <optional>
 
 #include "impeller/entity/contents/content_context.h"
 #include "impeller/entity/entity.h"
 #include "impeller/entity/texture_fill.frag.h"
 #include "impeller/entity/texture_fill.vert.h"
+#include "impeller/geometry/path_builder.h"
 #include "impeller/renderer/render_pass.h"
 #include "impeller/renderer/sampler_library.h"
 #include "impeller/tessellator/tessellator.h"
@@ -20,8 +22,16 @@ TextureContents::TextureContents() = default;
 
 TextureContents::~TextureContents() = default;
 
+std::shared_ptr<TextureContents> TextureContents::MakeRect(Rect destination) {
+  auto contents = std::make_shared<TextureContents>();
+  contents->path_ = PathBuilder{}.AddRect(destination).TakePath();
+  contents->is_rect_ = true;
+  return contents;
+}
+
 void TextureContents::SetPath(Path path) {
   path_ = std::move(path);
+  is_rect_ = false;
 }
 
 void TextureContents::SetTexture(std::shared_ptr<Texture> texture) {
@@ -46,9 +56,17 @@ std::optional<Rect> TextureContents::GetCoverage(const Entity& entity) const {
 std::optional<Snapshot> TextureContents::RenderToSnapshot(
     const ContentContext& renderer,
     const Entity& entity) const {
-  return Snapshot{.texture = texture_,
-                  .transform = entity.GetTransformation(),
-                  .sampler_descriptor = sampler_descriptor_};
+  // Passthrough textures that have simple rectangle paths and complete source
+  // rects.
+  if (is_rect_ && source_rect_ == Rect::MakeSize(texture_->GetSize())) {
+    auto scale =
+        Vector2(path_.GetBoundingBox()->size / Size(texture_->GetSize()));
+    return Snapshot{
+        .texture = texture_,
+        .transform = entity.GetTransformation() * Matrix::MakeScale(scale),
+        .sampler_descriptor = sampler_descriptor_};
+  }
+  return Contents::RenderToSnapshot(renderer, entity);
 }
 
 bool TextureContents::Render(const ContentContext& renderer,

--- a/impeller/entity/contents/texture_contents.h
+++ b/impeller/entity/contents/texture_contents.h
@@ -43,6 +43,10 @@ class TextureContents final : public Contents {
   std::optional<Rect> GetCoverage(const Entity& entity) const override;
 
   // |Contents|
+  std::optional<Snapshot> RenderToSnapshot(const ContentContext& renderer,
+                                           const Entity& entity) const override;
+
+  // |Contents|
   bool Render(const ContentContext& renderer,
               const Entity& entity,
               RenderPass& pass) const override;

--- a/impeller/entity/contents/texture_contents.h
+++ b/impeller/entity/contents/texture_contents.h
@@ -23,6 +23,11 @@ class TextureContents final : public Contents {
 
   ~TextureContents() override;
 
+  /// @brief  A common case factory that marks the texture contents as having a
+  ///         destination rectangle. In this situation, a subpass can be avoided
+  ///         when image filters are applied.
+  static std::shared_ptr<TextureContents> MakeRect(Rect destination);
+
   void SetPath(Path path);
 
   void SetTexture(std::shared_ptr<Texture> texture);
@@ -53,6 +58,7 @@ class TextureContents final : public Contents {
 
  public:
   Path path_;
+  bool is_rect_ = false;
 
   std::shared_ptr<Texture> texture_;
   SamplerDescriptor sampler_descriptor_ = {};

--- a/impeller/entity/contents/texture_contents.h
+++ b/impeller/entity/contents/texture_contents.h
@@ -56,7 +56,7 @@ class TextureContents final : public Contents {
               const Entity& entity,
               RenderPass& pass) const override;
 
- public:
+ private:
   Path path_;
   bool is_rect_ = false;
 

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -161,8 +161,7 @@ bool EntityPass::Render(ContentContext& renderer,
 
     {
       auto size_rect = Rect::MakeSize(offscreen_target.GetRenderTargetSize());
-      auto contents = std::make_shared<TextureContents>();
-      contents->SetPath(PathBuilder{}.AddRect(size_rect).TakePath());
+      auto contents = TextureContents::MakeRect(size_rect);
       contents->SetTexture(offscreen_target.GetRenderTargetTexture());
       contents->SetSourceRect(size_rect);
 

--- a/impeller/renderer/snapshot.h
+++ b/impeller/renderer/snapshot.h
@@ -11,6 +11,7 @@
 #include "flutter/fml/macros.h"
 #include "impeller/geometry/matrix.h"
 #include "impeller/geometry/rect.h"
+#include "impeller/renderer/sampler_descriptor.h"
 #include "impeller/renderer/texture.h"
 
 namespace impeller {
@@ -18,11 +19,13 @@ namespace impeller {
 class ContentContext;
 class Entity;
 
-/// Represents a texture and its intended draw position.
+/// Represents a texture and its intended draw transform/sampler configuration.
 struct Snapshot {
   std::shared_ptr<Texture> texture;
   /// The transform that should be applied to this texture for rendering.
   Matrix transform;
+
+  SamplerDescriptor sampler_descriptor;
 
   std::optional<Rect> GetCoverage() const;
 


### PR DESCRIPTION
Most of the time when filters are applied to textures (including layer textures), pre-rendering the texture is unnecessary. By just returning the texture in RenderToSnapshot with a proper matrix, a subpass is avoided. Filters can already handle arbitrary snapshot transforms and properly map UVs.

This change also adds a sampling configuration to snapshots, which allows filters more control over how the final blit should behave (will be needed for optimizing the Gaussian Blur).