### PR TITLE
Fix the issue that PrerollContext.has_texture_layer is sticky.

### DIFF
--- a/flow/layers/container_layer.cc
+++ b/flow/layers/container_layer.cc
@@ -134,15 +134,19 @@ void ContainerLayer::PrerollChildren(PrerollContext* context,
   // Platform views have no children, so context->has_platform_view should
   // always be false.
   FML_DCHECK(!context->has_platform_view);
+  FML_DCHECK(!context->has_texture_layer);
+
   bool child_has_platform_view = false;
   bool child_has_texture_layer = false;
   bool subtree_can_inherit_opacity = context->subtree_can_inherit_opacity;
 
   for (auto& layer : layers_) {
-    // Reset context->has_platform_view to false so that layers aren't treated
-    // as if they have a platform view based on one being previously found in a
-    // sibling tree.
+    // Reset context->has_platform_view and context->has_texture_layer to false
+    // so that layers aren't treated as if they have a platform view or texture
+    // layer based on one being previously found in a sibling tree.
     context->has_platform_view = false;
+    context->has_texture_layer = false;
+
     // Initialize the "inherit opacity" flag to false and allow the layer to
     // override the answer during its |Preroll|
     context->subtree_can_inherit_opacity = false;

--- a/flow/layers/container_layer_unittests.cc
+++ b/flow/layers/container_layer_unittests.cc
@@ -29,6 +29,14 @@ TEST_F(ContainerLayerTest, LayerWithParentHasPlatformView) {
                             "!context->has_platform_view");
 }
 
+TEST_F(ContainerLayerTest, LayerWithParentHasTextureLayer) {
+  auto layer = std::make_shared<ContainerLayer>();
+
+  preroll_context()->has_texture_layer = true;
+  EXPECT_DEATH_IF_SUPPORTED(layer->Preroll(preroll_context(), SkMatrix()),
+                            "!context->has_texture_layer");
+}
+
 TEST_F(ContainerLayerTest, PaintingEmptyLayerDies) {
   auto layer = std::make_shared<ContainerLayer>();
 
@@ -54,6 +62,34 @@ TEST_F(ContainerLayerTest, PaintBeforePrerollDies) {
                             "needs_painting\\(context\\)");
 }
 #endif
+
+TEST_F(ContainerLayerTest, LayerWithParentHasTextureLayerNeedsResetFlag) {
+  SkPath child_path1;
+  child_path1.addRect(5.0f, 6.0f, 20.5f, 21.5f);
+  SkPath child_path2;
+  child_path2.addRect(8.0f, 2.0f, 16.5f, 14.5f);
+  SkPaint child_paint1(SkColors::kGray);
+  SkPaint child_paint2(SkColors::kGreen);
+
+  auto mock_layer1 = std::make_shared<MockLayer>(
+      child_path1, child_paint1, false /* fake_has_platform_view */, false,
+      false, true /* fake_has_texture_layer */);
+  auto mock_layer2 = std::make_shared<MockLayer>(child_path2, child_paint2);
+
+  auto root = std::make_shared<ContainerLayer>();
+  auto container_layer1 = std::make_shared<ContainerLayer>();
+  auto container_layer2 = std::make_shared<ContainerLayer>();
+  root->Add(container_layer1);
+  root->Add(container_layer2);
+  container_layer1->Add(mock_layer1);
+  container_layer1->Add(mock_layer2);
+
+  EXPECT_EQ(preroll_context()->has_texture_layer, false);
+  root->Preroll(preroll_context(), SkMatrix());
+  EXPECT_EQ(preroll_context()->has_texture_layer, true);
+  // The flag for holding texture layer from parent needs to be clear
+  EXPECT_EQ(mock_layer2->parent_has_texture_layer(), false);
+}
 
 TEST_F(ContainerLayerTest, Simple) {
   SkPath child_path;

--- a/flow/layers/container_layer_unittests.cc
+++ b/flow/layers/container_layer_unittests.cc
@@ -82,7 +82,7 @@ TEST_F(ContainerLayerTest, LayerWithParentHasTextureLayerNeedsResetFlag) {
   root->Add(container_layer1);
   root->Add(container_layer2);
   container_layer1->Add(mock_layer1);
-  container_layer1->Add(mock_layer2);
+  container_layer2->Add(mock_layer2);
 
   EXPECT_EQ(preroll_context()->has_texture_layer, false);
   root->Preroll(preroll_context(), SkMatrix());

--- a/flow/testing/mock_layer.cc
+++ b/flow/testing/mock_layer.cc
@@ -14,12 +14,14 @@ MockLayer::MockLayer(SkPath path,
                      SkPaint paint,
                      bool fake_has_platform_view,
                      bool fake_reads_surface,
-                     bool fake_opacity_compatible)
+                     bool fake_opacity_compatible,
+                     bool fake_has_texture_layer)
     : fake_paint_path_(path),
       fake_paint_(paint),
       fake_has_platform_view_(fake_has_platform_view),
       fake_reads_surface_(fake_reads_surface),
-      fake_opacity_compatible_(fake_opacity_compatible) {}
+      fake_opacity_compatible_(fake_opacity_compatible),
+      fake_has_texture_layer_(fake_has_texture_layer) {}
 
 bool MockLayer::IsReplacing(DiffContext* context, const Layer* layer) const {
   // Similar to PictureLayer, only return true for identical mock layers;
@@ -41,8 +43,10 @@ void MockLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   parent_matrix_ = matrix;
   parent_cull_rect_ = context->cull_rect;
   parent_has_platform_view_ = context->has_platform_view;
+  parent_has_texture_layer_ = context->has_texture_layer;
 
   context->has_platform_view = fake_has_platform_view_;
+  context->has_texture_layer = fake_has_texture_layer_;
   set_paint_bounds(fake_paint_path_.getBounds());
   if (fake_reads_surface_) {
     context->surface_needs_readback = true;

--- a/flow/testing/mock_layer.h
+++ b/flow/testing/mock_layer.h
@@ -28,7 +28,8 @@ class MockLayer : public Layer {
                      SkPaint paint = SkPaint(),
                      bool fake_has_platform_view = false,
                      bool fake_reads_surface = false,
-                     bool fake_opacity_compatible_ = false);
+                     bool fake_opacity_compatible_ = false,
+                     bool fake_has_texture_layer = false);
 
   static std::shared_ptr<MockLayer> Make(SkPath path,
                                          SkPaint paint = SkPaint()) {
@@ -46,6 +47,7 @@ class MockLayer : public Layer {
   const SkMatrix& parent_matrix() { return parent_matrix_; }
   const SkRect& parent_cull_rect() { return parent_cull_rect_; }
   bool parent_has_platform_view() { return parent_has_platform_view_; }
+  bool parent_has_texture_layer() { return parent_has_texture_layer_; }
 
   bool IsReplacing(DiffContext* context, const Layer* layer) const override;
   void Diff(DiffContext* context, const Layer* old_layer) override;
@@ -58,9 +60,11 @@ class MockLayer : public Layer {
   SkPath fake_paint_path_;
   SkPaint fake_paint_;
   bool parent_has_platform_view_ = false;
+  bool parent_has_texture_layer_ = false;
   bool fake_has_platform_view_ = false;
   bool fake_reads_surface_ = false;
   bool fake_opacity_compatible_ = false;
+  bool fake_has_texture_layer_ = false;
 
   FML_DISALLOW_COPY_AND_ASSIGN(MockLayer);
 };


### PR DESCRIPTION
Fix the issue for PrerollContext.has_texture_layer is sticky and impacts layers unrelated to the TextureLayer, link as below:
https://github.com/flutter/flutter/issues/103013

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

