### PR TITLE
[Impeller] Implement drawShadow

### DIFF
--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -83,6 +83,10 @@ void Canvas::Concat(const Matrix& xformation) {
   xformation_stack_.back().xformation = GetCurrentTransformation() * xformation;
 }
 
+void Canvas::PreConcat(const Matrix& xformation) {
+  xformation_stack_.back().xformation = xformation * GetCurrentTransformation();
+}
+
 void Canvas::ResetTransform() {
   xformation_stack_.back().xformation = {};
 }
@@ -226,8 +230,6 @@ void Canvas::RestoreClip() {
 
   GetCurrentPass().AddEntity(std::move(entity));
 }
-
-void Canvas::DrawShadow(Path path, Color color, Scalar elevation) {}
 
 void Canvas::DrawPicture(Picture picture) {
   if (!picture.pass) {

--- a/impeller/aiks/canvas.h
+++ b/impeller/aiks/canvas.h
@@ -54,6 +54,8 @@ class Canvas {
 
   void Concat(const Matrix& xformation);
 
+  void PreConcat(const Matrix& xformation);
+
   void Translate(const Vector3& offset);
 
   void Scale(const Vector2& scale);
@@ -88,8 +90,6 @@ class Canvas {
   void ClipPath(
       Path path,
       Entity::ClipOperation clip_op = Entity::ClipOperation::kIntersect);
-
-  void DrawShadow(Path path, Color color, Scalar elevation);
 
   void DrawPicture(Picture picture);
 

--- a/impeller/display_list/display_list_unittests.cc
+++ b/impeller/display_list/display_list_unittests.cc
@@ -16,6 +16,7 @@
 #include "impeller/display_list/display_list_playground.h"
 #include "impeller/geometry/point.h"
 #include "impeller/playground/widgets.h"
+#include "include/core/SkRRect.h"
 #include "third_party/imgui/imgui.h"
 #include "third_party/skia/include/core/SkClipOp.h"
 #include "third_party/skia/include/core/SkColor.h"
@@ -490,6 +491,33 @@ TEST_P(DisplayListTest, CanDrawZeroLengthLine) {
     builder.drawPath(path, paint);
     builder.translate(0, 150);
   }
+  ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
+}
+
+TEST_P(DisplayListTest, CanDrawShadow) {
+  flutter::DisplayListBuilder builder;
+  std::array<SkPath, 3> paths = {
+      SkPath{}.addRect(SkRect::MakeXYWH(0, 0, 200, 100)),
+      SkPath{}.addRRect(
+          SkRRect::MakeRectXY(SkRect::MakeXYWH(0, 0, 200, 100), 30, 30)),
+      SkPath{}.addCircle(100, 50, 50),
+  };
+  builder.setColor(flutter::DlColor::kWhite());
+  builder.drawPaint();
+  builder.setColor(flutter::DlColor::kCyan());
+  builder.translate(100, 100);
+  for (size_t x = 0; x < paths.size(); x++) {
+    builder.save();
+    for (size_t y = 0; y < 5; y++) {
+      builder.drawShadow(paths[x], flutter::DlColor::kBlack(), 3 + y * 5, false,
+                         1);
+      builder.drawPath(paths[x]);
+      builder.translate(0, 200);
+    }
+    builder.restore();
+    builder.translate(300, 0);
+  }
+
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
 


### PR DESCRIPTION
Doesn't include the ambient occlusion part (which has a comparatively tiny impact on the shadow color).
The accuracy of these shadows will improve a bit more when I land improvements to the rrect approximation.

Skia:

![image](https://user-images.githubusercontent.com/919017/184854546-a1fd578d-a31d-4f16-8a7a-1f7d666ab570.png)

Impeller:

![image](https://user-images.githubusercontent.com/919017/184855130-1eb6b02d-cd7f-436e-a282-58beb645e6f2.png)

Fixes https://github.com/flutter/flutter/issues/104715
