### PR TITLE
[Mac] Add test for AXPlatformNodeCocoa

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -3258,6 +3258,8 @@ ORIGIN: ../../../third_party/icu/scripts/LICENSE
 TYPE: LicenseType.bsd
 FILE: ../../../flutter/third_party/accessibility/ax/ax_tree_data.cc
 FILE: ../../../flutter/third_party/accessibility/ax/ax_tree_data.h
+FILE: ../../../flutter/third_party/accessibility/ax/platform/ax_platform_node_mac_unittest.h
+FILE: ../../../flutter/third_party/accessibility/ax/platform/ax_platform_node_mac_unittest.mm
 FILE: ../../../flutter/third_party/accessibility/ax/platform/ax_platform_node_win.cc
 FILE: ../../../flutter/third_party/accessibility/ax/platform/ax_platform_node_win.h
 FILE: ../../../flutter/third_party/accessibility/ax/platform/ax_platform_node_win_unittest.cc

--- a/third_party/accessibility/BUILD.gn
+++ b/third_party/accessibility/BUILD.gn
@@ -75,6 +75,19 @@ if (enable_unittests) {
         "ax/platform/test_ax_node_wrapper.h",
       ]
 
+      if (is_mac) {
+        sources += [ "ax/platform/ax_platform_node_mac_unittest.mm" ]
+        frameworks = [
+          "AppKit.framework",
+          "CoreFoundation.framework",
+          "CoreGraphics.framework",
+          "CoreText.framework",
+          "IOSurface.framework",
+        ]
+
+        cflags_objcc = flutter_cflags_objcc
+        ldflags = [ "-ObjC" ]
+      }
       if (is_win) {
         sources += [
           "ax/platform/ax_fragment_root_win_unittest.cc",

--- a/third_party/accessibility/ax/platform/ax_platform_node_mac_unittest.h
+++ b/third_party/accessibility/ax/platform/ax_platform_node_mac_unittest.h
@@ -1,0 +1,29 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef UI_ACCESSIBILITY_PLATFORM_AX_PLATFORM_NODE_MAC_UNITTEST_H_
+#define UI_ACCESSIBILITY_PLATFORM_AX_PLATFORM_NODE_MAC_UNITTEST_H_
+
+#include "ax_platform_node_mac.h"
+#include "ax_platform_node_unittest.h"
+
+namespace ui {
+
+// A test fixture that supports accessing the macOS-specific node
+// implementations for the AXTree under test.
+class AXPlatformNodeMacTest : public AXPlatformNodeTest {
+ public:
+  AXPlatformNodeMacTest();
+  ~AXPlatformNodeMacTest() override;
+
+  void SetUp() override;
+  void TearDown() override;
+
+ protected:
+  AXPlatformNode* AXPlatformNodeFromNode(AXNode* node);
+};
+
+}  // namespace ui
+
+#endif  // UI_ACCESSIBILITY_PLATFORM_AX_PLATFORM_NODE_MAC_UNITTEST_H_

--- a/third_party/accessibility/ax/platform/ax_platform_node_mac_unittest.mm
+++ b/third_party/accessibility/ax/platform/ax_platform_node_mac_unittest.mm
@@ -1,0 +1,49 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ax_platform_node_mac_unittest.h"
+
+#include "ax_platform_node_mac.h"
+#include "gtest/gtest.h"
+#include "test_ax_node_wrapper.h"
+#include "third_party/accessibility/ax/ax_node_data.h"
+
+namespace ui {
+
+AXPlatformNodeMacTest::AXPlatformNodeMacTest() = default;
+
+AXPlatformNodeMacTest::~AXPlatformNodeMacTest() = default;
+
+void AXPlatformNodeMacTest::SetUp() {}
+
+void AXPlatformNodeMacTest::TearDown() {
+  // Destroy the tree and make sure we're not leaking any objects.
+  DestroyTree();
+  TestAXNodeWrapper::SetGlobalIsWebContent(false);
+  ASSERT_EQ(0U, AXPlatformNodeBase::GetInstanceCountForTesting());
+}
+
+AXPlatformNode* AXPlatformNodeMacTest::AXPlatformNodeFromNode(AXNode* node) {
+  const TestAXNodeWrapper* wrapper = TestAXNodeWrapper::GetOrCreate(GetTree(), node);
+  return wrapper ? wrapper->ax_platform_node() : nullptr;
+}
+
+// Verify that we can get an AXPlatformNodeMac and AXPlatformNodeCocoa from the tree.
+TEST_F(AXPlatformNodeMacTest, CanGetCocoaPlatformNodeFromTree) {
+  AXNodeData root;
+  root.id = 1;
+  root.relative_bounds.bounds = gfx::RectF(0, 0, 40, 40);
+
+  Init(root);
+  AXNode* root_node = GetRootAsAXNode();
+  ASSERT_TRUE(root_node != nullptr);
+
+  AXPlatformNode* platform_node = AXPlatformNodeFromNode(root_node);
+  ASSERT_TRUE(platform_node != nullptr);
+
+  AXPlatformNodeCocoa* native_root = platform_node->GetNativeViewAccessible();
+  EXPECT_TRUE(native_root != nullptr);
+}
+
+}  // namespace ui


### PR DESCRIPTION
Adds an initial test of looking up the macOS-specific AXPlatformNodeMac
C++ node wrapper and the AXPlatformNodeCocoa Objective-C wrapper, in
addition to the existing platform-agnostic accessibility tests that run
on macOS today.

This is initial test infrastructure to support authoring tests for an
upcoming fix to the issue below.

Related issue: https://github.com/flutter/flutter/issues/102416

Fixes: https://github.com/flutter/flutter/issues/109629

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
