### PR TITLE
[Windows] Don't crash if GetPointerType is unsupported

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -2486,6 +2486,8 @@ FILE: ../../../flutter/shell/platform/windows/window_proc_delegate_manager.h
 FILE: ../../../flutter/shell/platform/windows/window_proc_delegate_manager_unittests.cc
 FILE: ../../../flutter/shell/platform/windows/window_state.h
 FILE: ../../../flutter/shell/platform/windows/window_unittests.cc
+FILE: ../../../flutter/shell/platform/windows/windows_proc_table.cc
+FILE: ../../../flutter/shell/platform/windows/windows_proc_table.h
 FILE: ../../../flutter/shell/profiling/sampling_profiler.cc
 FILE: ../../../flutter/shell/profiling/sampling_profiler.h
 FILE: ../../../flutter/shell/profiling/sampling_profiler_unittest.cc

--- a/shell/platform/windows/BUILD.gn
+++ b/shell/platform/windows/BUILD.gn
@@ -103,6 +103,8 @@ source_set("flutter_windows_source") {
     "window_proc_delegate_manager.cc",
     "window_proc_delegate_manager.h",
     "window_state.h",
+    "windows_proc_table.cc",
+    "windows_proc_table.h",
   ]
 
   libs = [
@@ -189,6 +191,7 @@ executable("flutter_windows_unittests") {
     "testing/engine_modifier.h",
     "testing/flutter_window_test.cc",
     "testing/flutter_window_test.h",
+    "testing/mock_direct_manipulation.h",
     "testing/mock_gl_functions.h",
     "testing/mock_text_input_manager.cc",
     "testing/mock_text_input_manager.h",
@@ -196,6 +199,7 @@ executable("flutter_windows_unittests") {
     "testing/mock_window.h",
     "testing/mock_window_binding_handler.cc",
     "testing/mock_window_binding_handler.h",
+    "testing/mock_windows_proc_table.h",
     "testing/test_keyboard.cc",
     "testing/test_keyboard.h",
     "testing/test_keyboard_unittests.cc",

--- a/shell/platform/windows/direct_manipulation.h
+++ b/shell/platform/windows/direct_manipulation.h
@@ -22,6 +22,7 @@ class DirectManipulationEventHandler;
 class DirectManipulationOwner {
  public:
   explicit DirectManipulationOwner(Window* window);
+  virtual ~DirectManipulationOwner() = default;
   // Initialize a DirectManipulation viewport with specified width and height.
   // These should match the width and height of the application window.
   int Init(unsigned int width, unsigned int height);
@@ -34,7 +35,7 @@ class DirectManipulationOwner {
       WindowBindingHandlerDelegate* binding_handler_delegate);
   // Called when DM_POINTERHITTEST occurs with an acceptable pointer type. Will
   // start DirectManipulation for that interaction.
-  void SetContact(UINT contactId);
+  virtual void SetContact(UINT contactId);
   // Called to get updates from DirectManipulation. Should be called frequently
   // to provide smooth updates.
   void Update();

--- a/shell/platform/windows/direct_manipulation.h
+++ b/shell/platform/windows/direct_manipulation.h
@@ -58,6 +58,8 @@ class DirectManipulationOwner {
   Microsoft::WRL::ComPtr<IDirectManipulationViewport> viewport_;
   // Child needed for operation of the DirectManipulation API.
   fml::RefPtr<DirectManipulationEventHandler> handler_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(DirectManipulationOwner);
 };
 
 // Implements DirectManipulation event handling interfaces, receives calls from

--- a/shell/platform/windows/testing/mock_direct_manipulation.h
+++ b/shell/platform/windows/testing/mock_direct_manipulation.h
@@ -1,0 +1,30 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_DIRECT_MANIPULATION_H_
+#define FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_DIRECT_MANIPULATION_H_
+
+#include "flutter/shell/platform/windows/direct_manipulation.h"
+#include "gmock/gmock.h"
+
+namespace flutter {
+namespace testing {
+
+/// Mock for the |DirectManipulationOwner| base class.
+class MockDirectManipulationOwner : public DirectManipulationOwner {
+ public:
+  MockDirectManipulationOwner(Window* window)
+      : DirectManipulationOwner(window){};
+  virtual ~MockDirectManipulationOwner() = default;
+
+  MOCK_METHOD1(SetContact, void(UINT contactId));
+
+ private:
+  FML_DISALLOW_COPY_AND_ASSIGN(MockDirectManipulationOwner);
+};
+
+}  // namespace testing
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_DIRECT_MANIPULATION_H_

--- a/shell/platform/windows/testing/mock_direct_manipulation.h
+++ b/shell/platform/windows/testing/mock_direct_manipulation.h
@@ -14,7 +14,7 @@ namespace testing {
 /// Mock for the |DirectManipulationOwner| base class.
 class MockDirectManipulationOwner : public DirectManipulationOwner {
  public:
-  MockDirectManipulationOwner(Window* window)
+  explicit MockDirectManipulationOwner(Window* window)
       : DirectManipulationOwner(window){};
   virtual ~MockDirectManipulationOwner() = default;
 

--- a/shell/platform/windows/testing/mock_direct_manipulation.h
+++ b/shell/platform/windows/testing/mock_direct_manipulation.h
@@ -18,7 +18,7 @@ class MockDirectManipulationOwner : public DirectManipulationOwner {
       : DirectManipulationOwner(window){};
   virtual ~MockDirectManipulationOwner() = default;
 
-  MOCK_METHOD1(SetContact, void(UINT contactId));
+  MOCK_METHOD1(SetContact, void(UINT contact_id));
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(MockDirectManipulationOwner);

--- a/shell/platform/windows/testing/mock_window.cc
+++ b/shell/platform/windows/testing/mock_window.cc
@@ -7,8 +7,9 @@
 namespace flutter {
 namespace testing {
 MockWindow::MockWindow() : Window(){};
-MockWindow::MockWindow(std::unique_ptr<TextInputManager> text_input_manager)
-    : Window(std::move(text_input_manager)){};
+MockWindow::MockWindow(std::unique_ptr<WindowsProcTable> window_proc_table,
+                       std::unique_ptr<TextInputManager> text_input_manager)
+    : Window(std::move(window_proc_table), std::move(text_input_manager)){};
 
 MockWindow::~MockWindow() = default;
 
@@ -21,6 +22,11 @@ LRESULT MockWindow::Win32DefWindowProc(HWND hWnd,
                                        WPARAM wParam,
                                        LPARAM lParam) {
   return kWmResultDefault;
+}
+
+void MockWindow::SetDirectManipulationOwner(
+    std::unique_ptr<DirectManipulationOwner> owner) {
+  direct_manipulation_owner_ = std::move(owner);
 }
 
 LRESULT MockWindow::InjectWindowMessage(UINT const message,

--- a/shell/platform/windows/testing/mock_window.h
+++ b/shell/platform/windows/testing/mock_window.h
@@ -18,7 +18,8 @@ namespace testing {
 class MockWindow : public Window {
  public:
   MockWindow();
-  MockWindow(std::unique_ptr<TextInputManager> text_input_manager);
+  MockWindow(std::unique_ptr<WindowsProcTable> windows_proc_table,
+             std::unique_ptr<TextInputManager> text_input_manager);
   virtual ~MockWindow();
 
   // Prevent copying.
@@ -27,6 +28,10 @@ class MockWindow : public Window {
 
   // Wrapper for GetCurrentDPI() which is a protected method.
   UINT GetDpi();
+
+  // Set the Direct Manipulation owner for testing purposes.
+  void SetDirectManipulationOwner(
+      std::unique_ptr<DirectManipulationOwner> owner);
 
   // Simulates a WindowProc message from the OS.
   LRESULT InjectWindowMessage(UINT const message,

--- a/shell/platform/windows/testing/mock_windows_proc_table.h
+++ b/shell/platform/windows/testing/mock_windows_proc_table.h
@@ -1,0 +1,30 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_WINDOWS_PROC_TABLE_H_
+#define FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_WINDOWS_PROC_TABLE_H_
+
+#include "flutter/shell/platform/windows/windows_proc_table.h"
+#include "gmock/gmock.h"
+
+namespace flutter {
+namespace testing {
+
+/// Mock for the |WindowsProcTable| base class.
+class MockWindowsProcTable : public WindowsProcTable {
+ public:
+  MockWindowsProcTable() = default;
+  virtual ~MockWindowsProcTable() = default;
+
+  MOCK_METHOD2(GetPointerType,
+               BOOL(UINT32 pointer_id, POINTER_INPUT_TYPE* pointer_type));
+
+ private:
+  FML_DISALLOW_COPY_AND_ASSIGN(MockWindowsProcTable);
+};
+
+}  // namespace testing
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_WINDOWS_PROC_TABLE_H_

--- a/shell/platform/windows/window.h
+++ b/shell/platform/windows/window.h
@@ -18,6 +18,7 @@
 #include "flutter/shell/platform/windows/keyboard_manager.h"
 #include "flutter/shell/platform/windows/sequential_id_generator.h"
 #include "flutter/shell/platform/windows/text_input_manager.h"
+#include "flutter/shell/platform/windows/windows_proc_table.h"
 #include "flutter/third_party/accessibility/gfx/native_widget_types.h"
 
 namespace flutter {
@@ -28,7 +29,8 @@ namespace flutter {
 class Window : public KeyboardManager::WindowDelegate {
  public:
   Window();
-  Window(std::unique_ptr<TextInputManager> text_input_manager);
+  Window(std::unique_ptr<WindowsProcTable> windows_proc_table,
+         std::unique_ptr<TextInputManager> text_input_manager);
   virtual ~Window();
 
   // Initializes as a child window with size using |width| and |height| and
@@ -265,6 +267,10 @@ class Window : public KeyboardManager::WindowDelegate {
   // Keeps track of the last mouse coordinates by a WM_MOUSEMOVE message.
   double mouse_x_ = 0;
   double mouse_y_ = 0;
+
+  // Abstracts Windows APIs that may not be available on all supported versions
+  // of Windows.
+  std::unique_ptr<WindowsProcTable> windows_proc_table_;
 
   // Manages IME state.
   std::unique_ptr<TextInputManager> text_input_manager_;

--- a/shell/platform/windows/window_unittests.cc
+++ b/shell/platform/windows/window_unittests.cc
@@ -4,11 +4,15 @@
 
 #include <array>
 
+#include "flutter/shell/platform/windows/testing/mock_direct_manipulation.h"
 #include "flutter/shell/platform/windows/testing/mock_text_input_manager.h"
 #include "flutter/shell/platform/windows/testing/mock_window.h"
+#include "flutter/shell/platform/windows/testing/mock_windows_proc_table.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 using testing::_;
+using testing::Eq;
 using testing::InSequence;
 using testing::Invoke;
 using testing::Return;
@@ -39,9 +43,11 @@ TEST(MockWindow, VerticalScroll) {
 }
 
 TEST(MockWindow, OnImeCompositionCompose) {
-  MockTextInputManager* text_input_manager = new MockTextInputManager();
+  auto windows_proc_table = std::make_unique<MockWindowsProcTable>();
+  auto* text_input_manager = new MockTextInputManager();
   std::unique_ptr<TextInputManager> text_input_manager_ptr(text_input_manager);
-  MockWindow window(std::move(text_input_manager_ptr));
+  MockWindow window(std::move(windows_proc_table),
+                    std::move(text_input_manager_ptr));
   EXPECT_CALL(*text_input_manager, GetComposingString())
       .WillRepeatedly(
           Return(std::optional<std::u16string>(std::u16string(u"nihao"))));
@@ -63,9 +69,11 @@ TEST(MockWindow, OnImeCompositionCompose) {
 }
 
 TEST(MockWindow, OnImeCompositionResult) {
-  MockTextInputManager* text_input_manager = new MockTextInputManager();
+  auto windows_proc_table = std::make_unique<MockWindowsProcTable>();
+  auto* text_input_manager = new MockTextInputManager();
   std::unique_ptr<TextInputManager> text_input_manager_ptr(text_input_manager);
-  MockWindow window(std::move(text_input_manager_ptr));
+  MockWindow window(std::move(windows_proc_table),
+                    std::move(text_input_manager_ptr));
   EXPECT_CALL(*text_input_manager, GetComposingString())
       .WillRepeatedly(
           Return(std::optional<std::u16string>(std::u16string(u"nihao"))));
@@ -87,9 +95,11 @@ TEST(MockWindow, OnImeCompositionResult) {
 }
 
 TEST(MockWindow, OnImeCompositionResultAndCompose) {
-  MockTextInputManager* text_input_manager = new MockTextInputManager();
+  auto windows_proc_table = std::make_unique<MockWindowsProcTable>();
+  auto* text_input_manager = new MockTextInputManager();
   std::unique_ptr<TextInputManager> text_input_manager_ptr(text_input_manager);
-  MockWindow window(std::move(text_input_manager_ptr));
+  MockWindow window(std::move(windows_proc_table),
+                    std::move(text_input_manager_ptr));
 
   // This situation is that Google Japanese Input finished composing "今日" in
   // "今日は" but is still composing "は".
@@ -123,9 +133,11 @@ TEST(MockWindow, OnImeCompositionResultAndCompose) {
 }
 
 TEST(MockWindow, OnImeCompositionClearChange) {
-  MockTextInputManager* text_input_manager = new MockTextInputManager();
+  auto windows_proc_table = std::make_unique<MockWindowsProcTable>();
+  auto* text_input_manager = new MockTextInputManager();
   std::unique_ptr<TextInputManager> text_input_manager_ptr(text_input_manager);
-  MockWindow window(std::move(text_input_manager_ptr));
+  MockWindow window(std::move(windows_proc_table),
+                    std::move(text_input_manager_ptr));
   EXPECT_CALL(window, OnComposeChange(std::u16string(u""), 0)).Times(1);
   EXPECT_CALL(window, OnComposeCommit()).Times(1);
   ON_CALL(window, OnImeComposition)
@@ -270,6 +282,79 @@ TEST(MockWindow, Paint) {
   MockWindow window;
   EXPECT_CALL(window, OnPaint()).Times(1);
   window.InjectWindowMessage(WM_PAINT, 0, 0);
+}
+
+TEST(MockWindow, PointerHitTest) {
+  auto* windows_proc_table = new MockWindowsProcTable();
+  auto text_input_manager = std::make_unique<MockTextInputManager>();
+
+  MockWindow window(std::unique_ptr<MockWindowsProcTable>(windows_proc_table),
+                    std::move(text_input_manager));
+
+  auto direct_manipulation = new MockDirectManipulationOwner(&window);
+  window.SetDirectManipulationOwner(
+      std::unique_ptr<MockDirectManipulationOwner>(direct_manipulation));
+
+  UINT32 pointer_id = 123;
+
+  EXPECT_CALL(*windows_proc_table, GetPointerType(Eq(pointer_id), _))
+      .Times(1)
+      .WillOnce([](UINT32 pointer_id, POINTER_INPUT_TYPE* type) {
+        *type = PT_POINTER;
+        return TRUE;
+      });
+
+  EXPECT_CALL(*direct_manipulation, SetContact).Times(0);
+
+  window.InjectWindowMessage(DM_POINTERHITTEST, MAKEWPARAM(pointer_id, 0), 0);
+}
+
+TEST(MockWindow, TouchPadHitTest) {
+  auto* windows_proc_table = new MockWindowsProcTable();
+  auto text_input_manager = std::make_unique<MockTextInputManager>();
+
+  MockWindow window(std::unique_ptr<MockWindowsProcTable>(windows_proc_table),
+                    std::move(text_input_manager));
+
+  auto direct_manipulation = new MockDirectManipulationOwner(&window);
+  window.SetDirectManipulationOwner(
+      std::unique_ptr<MockDirectManipulationOwner>(direct_manipulation));
+
+  UINT32 pointer_id = 123;
+
+  EXPECT_CALL(*windows_proc_table, GetPointerType(Eq(pointer_id), _))
+      .Times(1)
+      .WillOnce([](UINT32 pointer_id, POINTER_INPUT_TYPE* type) {
+        *type = PT_TOUCHPAD;
+        return TRUE;
+      });
+
+  EXPECT_CALL(*direct_manipulation, SetContact(Eq(pointer_id))).Times(1);
+
+  window.InjectWindowMessage(DM_POINTERHITTEST, MAKEWPARAM(pointer_id, 0), 0);
+}
+
+TEST(MockWindow, UnknownPointerTypeSkipsDirectManipulation) {
+  auto* windows_proc_table = new MockWindowsProcTable();
+  auto text_input_manager = std::make_unique<MockTextInputManager>();
+
+  MockWindow window(std::unique_ptr<MockWindowsProcTable>(windows_proc_table),
+                    std::move(text_input_manager));
+
+  auto direct_manipulation = new MockDirectManipulationOwner(&window);
+  window.SetDirectManipulationOwner(
+      std::unique_ptr<MockDirectManipulationOwner>(direct_manipulation));
+
+  UINT32 pointer_id = 123;
+
+  EXPECT_CALL(*windows_proc_table, GetPointerType(Eq(pointer_id), _))
+      .Times(1)
+      .WillOnce(
+          [](UINT32 pointer_id, POINTER_INPUT_TYPE* type) { return FALSE; });
+
+  EXPECT_CALL(*direct_manipulation, SetContact).Times(0);
+
+  window.InjectWindowMessage(DM_POINTERHITTEST, MAKEWPARAM(pointer_id, 0), 0);
 }
 
 }  // namespace testing

--- a/shell/platform/windows/window_unittests.cc
+++ b/shell/platform/windows/window_unittests.cc
@@ -289,7 +289,7 @@ TEST(MockWindow, PointerHitTest) {
   auto windows_proc_table = std::make_unique<MockWindowsProcTable>();
   auto text_input_manager = std::make_unique<MockTextInputManager>();
 
-  EXPECT_CALL(*windows_proc_table.get(), GetPointerType(Eq(pointer_id), _))
+  EXPECT_CALL(*windows_proc_table, GetPointerType(Eq(pointer_id), _))
       .Times(1)
       .WillOnce([](UINT32 pointer_id, POINTER_INPUT_TYPE* type) {
         *type = PT_POINTER;
@@ -302,7 +302,7 @@ TEST(MockWindow, PointerHitTest) {
   auto direct_manipulation =
       std::make_unique<MockDirectManipulationOwner>(&window);
 
-  EXPECT_CALL(*direct_manipulation.get(), SetContact).Times(0);
+  EXPECT_CALL(*direct_manipulation, SetContact).Times(0);
 
   window.SetDirectManipulationOwner(std::move(direct_manipulation));
   window.InjectWindowMessage(DM_POINTERHITTEST, MAKEWPARAM(pointer_id, 0), 0);
@@ -313,7 +313,7 @@ TEST(MockWindow, TouchPadHitTest) {
   auto windows_proc_table = std::make_unique<MockWindowsProcTable>();
   auto text_input_manager = std::make_unique<MockTextInputManager>();
 
-  EXPECT_CALL(*windows_proc_table.get(), GetPointerType(Eq(pointer_id), _))
+  EXPECT_CALL(*windows_proc_table, GetPointerType(Eq(pointer_id), _))
       .Times(1)
       .WillOnce([](UINT32 pointer_id, POINTER_INPUT_TYPE* type) {
         *type = PT_TOUCHPAD;
@@ -326,7 +326,7 @@ TEST(MockWindow, TouchPadHitTest) {
   auto direct_manipulation =
       std::make_unique<MockDirectManipulationOwner>(&window);
 
-  EXPECT_CALL(*direct_manipulation.get(), SetContact(Eq(pointer_id))).Times(1);
+  EXPECT_CALL(*direct_manipulation, SetContact(Eq(pointer_id))).Times(1);
 
   window.SetDirectManipulationOwner(std::move(direct_manipulation));
   window.InjectWindowMessage(DM_POINTERHITTEST, MAKEWPARAM(pointer_id, 0), 0);
@@ -337,7 +337,7 @@ TEST(MockWindow, UnknownPointerTypeSkipsDirectManipulation) {
   auto windows_proc_table = std::make_unique<MockWindowsProcTable>();
   auto text_input_manager = std::make_unique<MockTextInputManager>();
 
-  EXPECT_CALL(*windows_proc_table.get(), GetPointerType(Eq(pointer_id), _))
+  EXPECT_CALL(*windows_proc_table, GetPointerType(Eq(pointer_id), _))
       .Times(1)
       .WillOnce(
           [](UINT32 pointer_id, POINTER_INPUT_TYPE* type) { return FALSE; });
@@ -348,7 +348,7 @@ TEST(MockWindow, UnknownPointerTypeSkipsDirectManipulation) {
   auto direct_manipulation =
       std::make_unique<MockDirectManipulationOwner>(&window);
 
-  EXPECT_CALL(*direct_manipulation.get(), SetContact).Times(0);
+  EXPECT_CALL(*direct_manipulation, SetContact).Times(0);
 
   window.SetDirectManipulationOwner(std::move(direct_manipulation));
   window.InjectWindowMessage(DM_POINTERHITTEST, MAKEWPARAM(pointer_id, 0), 0);

--- a/shell/platform/windows/window_unittests.cc
+++ b/shell/platform/windows/window_unittests.cc
@@ -285,75 +285,72 @@ TEST(MockWindow, Paint) {
 }
 
 TEST(MockWindow, PointerHitTest) {
-  auto* windows_proc_table = new MockWindowsProcTable();
+  UINT32 pointer_id = 123;
+  auto windows_proc_table = std::make_unique<MockWindowsProcTable>();
   auto text_input_manager = std::make_unique<MockTextInputManager>();
 
-  MockWindow window(std::unique_ptr<MockWindowsProcTable>(windows_proc_table),
-                    std::move(text_input_manager));
-
-  auto direct_manipulation = new MockDirectManipulationOwner(&window);
-  window.SetDirectManipulationOwner(
-      std::unique_ptr<MockDirectManipulationOwner>(direct_manipulation));
-
-  UINT32 pointer_id = 123;
-
-  EXPECT_CALL(*windows_proc_table, GetPointerType(Eq(pointer_id), _))
+  EXPECT_CALL(*windows_proc_table.get(), GetPointerType(Eq(pointer_id), _))
       .Times(1)
       .WillOnce([](UINT32 pointer_id, POINTER_INPUT_TYPE* type) {
         *type = PT_POINTER;
         return TRUE;
       });
 
-  EXPECT_CALL(*direct_manipulation, SetContact).Times(0);
+  MockWindow window(std::move(windows_proc_table),
+                    std::move(text_input_manager));
 
+  auto direct_manipulation =
+      std::make_unique<MockDirectManipulationOwner>(&window);
+
+  EXPECT_CALL(*direct_manipulation.get(), SetContact).Times(0);
+
+  window.SetDirectManipulationOwner(std::move(direct_manipulation));
   window.InjectWindowMessage(DM_POINTERHITTEST, MAKEWPARAM(pointer_id, 0), 0);
 }
 
 TEST(MockWindow, TouchPadHitTest) {
-  auto* windows_proc_table = new MockWindowsProcTable();
+  UINT32 pointer_id = 123;
+  auto windows_proc_table = std::make_unique<MockWindowsProcTable>();
   auto text_input_manager = std::make_unique<MockTextInputManager>();
 
-  MockWindow window(std::unique_ptr<MockWindowsProcTable>(windows_proc_table),
-                    std::move(text_input_manager));
-
-  auto direct_manipulation = new MockDirectManipulationOwner(&window);
-  window.SetDirectManipulationOwner(
-      std::unique_ptr<MockDirectManipulationOwner>(direct_manipulation));
-
-  UINT32 pointer_id = 123;
-
-  EXPECT_CALL(*windows_proc_table, GetPointerType(Eq(pointer_id), _))
+  EXPECT_CALL(*windows_proc_table.get(), GetPointerType(Eq(pointer_id), _))
       .Times(1)
       .WillOnce([](UINT32 pointer_id, POINTER_INPUT_TYPE* type) {
         *type = PT_TOUCHPAD;
         return TRUE;
       });
 
-  EXPECT_CALL(*direct_manipulation, SetContact(Eq(pointer_id))).Times(1);
+  MockWindow window(std::move(windows_proc_table),
+                    std::move(text_input_manager));
 
+  auto direct_manipulation =
+      std::make_unique<MockDirectManipulationOwner>(&window);
+
+  EXPECT_CALL(*direct_manipulation.get(), SetContact(Eq(pointer_id))).Times(1);
+
+  window.SetDirectManipulationOwner(std::move(direct_manipulation));
   window.InjectWindowMessage(DM_POINTERHITTEST, MAKEWPARAM(pointer_id, 0), 0);
 }
 
 TEST(MockWindow, UnknownPointerTypeSkipsDirectManipulation) {
-  auto* windows_proc_table = new MockWindowsProcTable();
+  UINT32 pointer_id = 123;
+  auto windows_proc_table = std::make_unique<MockWindowsProcTable>();
   auto text_input_manager = std::make_unique<MockTextInputManager>();
 
-  MockWindow window(std::unique_ptr<MockWindowsProcTable>(windows_proc_table),
-                    std::move(text_input_manager));
-
-  auto direct_manipulation = new MockDirectManipulationOwner(&window);
-  window.SetDirectManipulationOwner(
-      std::unique_ptr<MockDirectManipulationOwner>(direct_manipulation));
-
-  UINT32 pointer_id = 123;
-
-  EXPECT_CALL(*windows_proc_table, GetPointerType(Eq(pointer_id), _))
+  EXPECT_CALL(*windows_proc_table.get(), GetPointerType(Eq(pointer_id), _))
       .Times(1)
       .WillOnce(
           [](UINT32 pointer_id, POINTER_INPUT_TYPE* type) { return FALSE; });
 
-  EXPECT_CALL(*direct_manipulation, SetContact).Times(0);
+  MockWindow window(std::move(windows_proc_table),
+                    std::move(text_input_manager));
 
+  auto direct_manipulation =
+      std::make_unique<MockDirectManipulationOwner>(&window);
+
+  EXPECT_CALL(*direct_manipulation.get(), SetContact).Times(0);
+
+  window.SetDirectManipulationOwner(std::move(direct_manipulation));
   window.InjectWindowMessage(DM_POINTERHITTEST, MAKEWPARAM(pointer_id, 0), 0);
 }
 

--- a/shell/platform/windows/window_unittests.cc
+++ b/shell/platform/windows/window_unittests.cc
@@ -337,6 +337,7 @@ TEST(MockWindow, TouchPadHitTest) {
 // Verify direct manipulation isn't notified of unknown hit tests.
 // This can happen if determining the pointer type fails, for example,
 // if GetPointerType is unsupported by the current Windows version.
+// See: https://github.com/flutter/flutter/issues/109412
 TEST(MockWindow, UnknownPointerTypeSkipsDirectManipulation) {
   UINT32 pointer_id = 123;
   auto windows_proc_table = std::make_unique<MockWindowsProcTable>();

--- a/shell/platform/windows/window_unittests.cc
+++ b/shell/platform/windows/window_unittests.cc
@@ -284,6 +284,7 @@ TEST(MockWindow, Paint) {
   window.InjectWindowMessage(WM_PAINT, 0, 0);
 }
 
+// Verify direct manipulation isn't notified of pointer hit tests.
 TEST(MockWindow, PointerHitTest) {
   UINT32 pointer_id = 123;
   auto windows_proc_table = std::make_unique<MockWindowsProcTable>();
@@ -308,6 +309,7 @@ TEST(MockWindow, PointerHitTest) {
   window.InjectWindowMessage(DM_POINTERHITTEST, MAKEWPARAM(pointer_id, 0), 0);
 }
 
+// Verify direct manipulation is notified of touchpad hit tests.
 TEST(MockWindow, TouchPadHitTest) {
   UINT32 pointer_id = 123;
   auto windows_proc_table = std::make_unique<MockWindowsProcTable>();
@@ -332,6 +334,9 @@ TEST(MockWindow, TouchPadHitTest) {
   window.InjectWindowMessage(DM_POINTERHITTEST, MAKEWPARAM(pointer_id, 0), 0);
 }
 
+// Verify direct manipulation isn't notified of unknown hit tests.
+// This can happen if determining the pointer type fails, for example,
+// if GetPointerType is unsupported by the current Windows version.
 TEST(MockWindow, UnknownPointerTypeSkipsDirectManipulation) {
   UINT32 pointer_id = 123;
   auto windows_proc_table = std::make_unique<MockWindowsProcTable>();

--- a/shell/platform/windows/windows_proc_table.cc
+++ b/shell/platform/windows/windows_proc_table.cc
@@ -1,0 +1,28 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/windows/windows_proc_table.h"
+
+namespace flutter {
+
+WindowsProcTable::WindowsProcTable() {
+  user32_ = fml::NativeLibrary::Create("user32.dll");
+  get_pointer_type_ =
+      user32_->ResolveFunction<GetPointerType_*>("GetPointerType");
+}
+
+WindowsProcTable::~WindowsProcTable() {
+  user32_ = nullptr;
+}
+
+BOOL WindowsProcTable::GetPointerType(UINT32 pointer_id,
+                                      POINTER_INPUT_TYPE* pointer_type) {
+  if (!get_pointer_type_.has_value()) {
+    return FALSE;
+  }
+
+  return get_pointer_type_.value()(pointer_id, pointer_type);
+}
+
+}  // namespace flutter

--- a/shell/platform/windows/windows_proc_table.h
+++ b/shell/platform/windows/windows_proc_table.h
@@ -1,0 +1,42 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_WINDOWS_PROC_TABLE_H_
+#define FLUTTER_SHELL_PLATFORM_WINDOWS_WINDOWS_PROC_TABLE_H_
+
+#include "flutter/fml/native_library.h"
+
+#include <optional>
+
+namespace flutter {
+
+// Lookup table for Windows APIs that aren't available on all versions of
+// Windows.
+class WindowsProcTable {
+ public:
+  WindowsProcTable();
+  virtual ~WindowsProcTable();
+
+  // Retrieves the pointer type for a specified pointer.
+  //
+  // Used to react differently to touch or pen inputs. Returns zero on failure.
+  // Available in Windows 8 and newer, otherwise returns zero.
+  virtual BOOL GetPointerType(UINT32 pointer_id,
+                              POINTER_INPUT_TYPE* pointer_type);
+
+ private:
+  using GetPointerType_ = BOOL __stdcall(UINT32 pointerId,
+                                         POINTER_INPUT_TYPE* pointerType);
+
+  // The User32.dll library, used to resolve functions at runtime.
+  fml::RefPtr<fml::NativeLibrary> user32_;
+
+  std::optional<GetPointerType_*> get_pointer_type_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(WindowsProcTable);
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_WINDOWS_PROC_TABLE_H_

--- a/shell/platform/windows/windows_proc_table.h
+++ b/shell/platform/windows/windows_proc_table.h
@@ -20,8 +20,8 @@ class WindowsProcTable {
 
   // Retrieves the pointer type for a specified pointer.
   //
-  // Used to react differently to touch or pen inputs. Returns zero on failure.
-  // Available in Windows 8 and newer, otherwise returns zero.
+  // Used to react differently to touch or pen inputs. Returns false on failure.
+  // Available in Windows 8 and newer, otherwise returns false.
   virtual BOOL GetPointerType(UINT32 pointer_id,
                               POINTER_INPUT_TYPE* pointer_type);
 


### PR DESCRIPTION
The engine's `Window` [references `GetPointerType`](https://github.com/flutter/engine/pull/31594/files#diff-25694b69c70103b6c4807eff1744dcaace40a2fe05d7acf61a97bd1f565051b0R475), which is [supported only on Windows 8 and after](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getpointertype). This causes Flutter apps to crash immediately on Windows 7.

This introduces `WindowsProcTable` to look up Windows APIs dynamically.

This bug was introduced in: https://github.com/flutter/engine/pull/31594

Fixes https://github.com/flutter/flutter/issues/109412

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
