### PR TITLE
[Impeller] Skip all playground tests if SHIFT, SUPER, or CTRL is held.

### DIFF
--- a/impeller/playground/playground.cc
+++ b/impeller/playground/playground.cc
@@ -126,12 +126,21 @@ void Playground::TeardownWindow() {
   impl_.reset();
 }
 
+static std::atomic_bool gShouldOpenNewPlaygrounds = true;
+
+bool Playground::ShouldOpenNewPlaygrounds() {
+  return gShouldOpenNewPlaygrounds;
+}
+
 static void PlaygroundKeyCallback(GLFWwindow* window,
                                   int key,
                                   int scancode,
                                   int action,
                                   int mods) {
   if ((key == GLFW_KEY_ESCAPE || key == GLFW_KEY_Q) && action == GLFW_RELEASE) {
+    if (mods & (GLFW_MOD_CONTROL | GLFW_MOD_SUPER | GLFW_MOD_SHIFT)) {
+      gShouldOpenNewPlaygrounds = false;
+    }
     ::glfwSetWindowShouldClose(window, GLFW_TRUE);
   }
 }

--- a/impeller/playground/playground.h
+++ b/impeller/playground/playground.h
@@ -34,6 +34,8 @@ class Playground {
 
   static constexpr bool is_enabled() { return is_enabled_; }
 
+  static bool ShouldOpenNewPlaygrounds();
+
   void SetupWindow(PlaygroundBackend backend);
 
   void TeardownWindow();

--- a/impeller/playground/playground_test.cc
+++ b/impeller/playground/playground_test.cc
@@ -16,6 +16,11 @@ void PlaygroundTest::SetUp() {
     return;
   }
 
+  if (!Playground::ShouldOpenNewPlaygrounds()) {
+    GTEST_SKIP_("Skipping due to user action.");
+    return;
+  }
+
   SetupWindow(GetParam());
 }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/109269.

Notably, this doesn't work with CMD keys on Mac even though these
are supposed to be modifiers.