### PR TITLE
Prevent leaking inputViews between iOS unit tests

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -1137,6 +1137,7 @@ FLUTTER_ASSERT_ARC
       @"composingExtent" : @3
     }];
     OCMVerify([mockInputView setInputDelegate:[OCMArg isNotNil]]);
+    [inputView removeFromSuperview];
   }
 }
 


### PR DESCRIPTION
`-[FlutterViewControllerTest testkeyboardWillChangeFrameWillStartKeyboardAnimation]` was failing when `-[FlutterTextInputPluginTest testInputViewsHasNonNilInputDelegate]` was run first.  The latter test was adding a `FlutterTextInputView` to the app, testing it, but not removing it when it was complete.  Remove it from the view hierarchy at the end of the test.

I still need to investigate why this test was passing on iOS 15 but fails on iOS 16.

Fixes https://github.com/flutter/flutter/issues/109655

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
