### PR TITLE
[Impeller] Refactor blend filter to avoid creating passes unnecessarily

### DIFF
--- a/impeller/entity/contents/contents.cc
+++ b/impeller/entity/contents/contents.cc
@@ -32,19 +32,19 @@ Contents::~Contents() = default;
 std::optional<Snapshot> Contents::RenderToSnapshot(
     const ContentContext& renderer,
     const Entity& entity) const {
-  auto bounds = GetCoverage(entity);
-  if (!bounds.has_value()) {
+  auto coverage = GetCoverage(entity);
+  if (!coverage.has_value()) {
     return std::nullopt;
   }
 
   auto texture = renderer.MakeSubpass(
-      ISize::Ceil(bounds->size),
-      [&contents = *this, &entity, &bounds](const ContentContext& renderer,
-                                            RenderPass& pass) -> bool {
+      ISize::Ceil(coverage->size),
+      [&contents = *this, &entity, &coverage](const ContentContext& renderer,
+                                              RenderPass& pass) -> bool {
         Entity sub_entity;
         sub_entity.SetBlendMode(Entity::BlendMode::kSourceOver);
         sub_entity.SetTransformation(
-            Matrix::MakeTranslation(Vector3(-bounds->origin)) *
+            Matrix::MakeTranslation(Vector3(-coverage->origin)) *
             entity.GetTransformation());
         return contents.Render(renderer, sub_entity, pass);
       });
@@ -54,7 +54,7 @@ std::optional<Snapshot> Contents::RenderToSnapshot(
   }
 
   return Snapshot{.texture = texture,
-                  .transform = Matrix::MakeTranslation(bounds->origin)};
+                  .transform = Matrix::MakeTranslation(coverage->origin)};
 }
 
 bool Contents::ShouldRender(const Entity& entity,

--- a/impeller/entity/contents/filters/blend_filter_contents.cc
+++ b/impeller/entity/contents/filters/blend_filter_contents.cc
@@ -28,29 +28,33 @@ using PipelineProc =
     std::shared_ptr<Pipeline> (ContentContext::*)(ContentContextOptions) const;
 
 template <typename TPipeline>
-static bool AdvancedBlend(const FilterInput::Vector& inputs,
-                          const ContentContext& renderer,
-                          const Entity& entity,
-                          RenderPass& pass,
-                          const Rect& coverage,
-                          std::optional<Color> foreground_color,
-                          PipelineProc pipeline_proc) {
+static std::optional<Snapshot> AdvancedBlend(
+    const FilterInput::Vector& inputs,
+    const ContentContext& renderer,
+    const Entity& entity,
+    const Rect& coverage,
+    std::optional<Color> foreground_color,
+    PipelineProc pipeline_proc) {
   using VS = typename TPipeline::VertexShader;
   using FS = typename TPipeline::FragmentShader;
+
+  //----------------------------------------------------------------------------
+  /// Handle inputs.
+  ///
 
   const size_t total_inputs =
       inputs.size() + (foreground_color.has_value() ? 1 : 0);
   if (total_inputs < 2) {
-    return false;
+    return std::nullopt;
   }
 
   auto dst_snapshot = inputs[0]->GetSnapshot(renderer, entity);
   if (!dst_snapshot.has_value()) {
-    return true;
+    return std::nullopt;
   }
   auto maybe_dst_uvs = dst_snapshot->GetCoverageUVs(coverage);
   if (!maybe_dst_uvs.has_value()) {
-    return true;
+    return std::nullopt;
   }
   auto dst_uvs = maybe_dst_uvs.value();
 
@@ -59,175 +63,208 @@ static bool AdvancedBlend(const FilterInput::Vector& inputs,
   if (!foreground_color.has_value()) {
     src_snapshot = inputs[1]->GetSnapshot(renderer, entity);
     if (!src_snapshot.has_value()) {
-      return true;
+      return std::nullopt;
     }
     auto maybe_src_uvs = src_snapshot->GetCoverageUVs(coverage);
     if (!maybe_src_uvs.has_value()) {
-      return true;
+      return std::nullopt;
     }
     src_uvs = maybe_src_uvs.value();
   }
 
-  auto& host_buffer = pass.GetTransientsBuffer();
+  //----------------------------------------------------------------------------
+  /// Render to texture.
+  ///
 
-  auto size = pass.GetRenderTargetSize();
-  VertexBufferBuilder<typename VS::PerVertexData> vtx_builder;
-  vtx_builder.AddVertices({
-      {Point(0, 0), dst_uvs[0], src_uvs[0]},
-      {Point(size.width, 0), dst_uvs[1], src_uvs[1]},
-      {Point(size.width, size.height), dst_uvs[3], src_uvs[3]},
-      {Point(0, 0), dst_uvs[0], src_uvs[0]},
-      {Point(size.width, size.height), dst_uvs[3], src_uvs[3]},
-      {Point(0, size.height), dst_uvs[2], src_uvs[2]},
-  });
-  auto vtx_buffer = vtx_builder.CreateVertexBuffer(host_buffer);
+  ContentContext::SubpassCallback callback = [&](const ContentContext& renderer,
+                                                 RenderPass& pass) {
+    auto& host_buffer = pass.GetTransientsBuffer();
 
-  auto options = OptionsFromPassAndEntity(pass, entity);
-  std::shared_ptr<Pipeline> pipeline =
-      std::invoke(pipeline_proc, renderer, options);
-
-  Command cmd;
-  cmd.label = "Advanced Blend Filter";
-  cmd.BindVertices(vtx_buffer);
-  cmd.pipeline = std::move(pipeline);
-
-  typename FS::BlendInfo blend_info;
-
-  auto sampler = renderer.GetContext()->GetSamplerLibrary()->GetSampler({});
-  FS::BindTextureSamplerDst(cmd, dst_snapshot->texture, sampler);
-  blend_info.dst_y_coord_scale = dst_snapshot->texture->GetYCoordScale();
-
-  if (foreground_color.has_value()) {
-    blend_info.color_factor = 1;
-    blend_info.color = foreground_color.value();
-    // This texture will not be sampled from due to the color factor. But this
-    // is present so that validation doesn't trip on a missing binding.
-    FS::BindTextureSamplerSrc(cmd, dst_snapshot->texture, sampler);
-  } else {
-    blend_info.color_factor = 0;
-    FS::BindTextureSamplerSrc(cmd, src_snapshot->texture, sampler);
-    blend_info.src_y_coord_scale = src_snapshot->texture->GetYCoordScale();
-  }
-  auto blend_uniform = host_buffer.EmplaceUniform(blend_info);
-  FS::BindBlendInfo(cmd, blend_uniform);
-
-  typename VS::FrameInfo frame_info;
-  frame_info.mvp = Matrix::MakeOrthographic(size);
-
-  auto uniform_view = host_buffer.EmplaceUniform(frame_info);
-  VS::BindFrameInfo(cmd, uniform_view);
-  pass.AddCommand(cmd);
-
-  return true;
-}
-
-static bool PipelineBlend(const FilterInput::Vector& inputs,
-                          const ContentContext& renderer,
-                          const Entity& entity,
-                          RenderPass& pass,
-                          const Rect& coverage,
-                          Entity::BlendMode pipeline_blend,
-                          std::optional<Color> foreground_color) {
-  using VS = BlendPipeline::VertexShader;
-  using FS = BlendPipeline::FragmentShader;
-
-  auto& host_buffer = pass.GetTransientsBuffer();
-
-  auto sampler = renderer.GetContext()->GetSamplerLibrary()->GetSampler({});
-
-  Command cmd;
-  cmd.label = "Pipeline Blend Filter";
-  auto options = OptionsFromPass(pass);
-
-  auto add_blend_command = [&](std::optional<Snapshot> input) {
-    if (!input.has_value()) {
-      return false;
-    }
-    auto input_coverage = input->GetCoverage();
-    if (!input_coverage.has_value()) {
-      return false;
-    }
-
-    FS::BindTextureSamplerSrc(cmd, input->texture, sampler);
-
-    auto size = input->texture->GetSize();
-    VertexBufferBuilder<VS::PerVertexData> vtx_builder;
+    auto size = pass.GetRenderTargetSize();
+    VertexBufferBuilder<typename VS::PerVertexData> vtx_builder;
     vtx_builder.AddVertices({
-        {Point(0, 0), Point(0, 0)},
-        {Point(size.width, 0), Point(1, 0)},
-        {Point(size.width, size.height), Point(1, 1)},
-        {Point(0, 0), Point(0, 0)},
-        {Point(size.width, size.height), Point(1, 1)},
-        {Point(0, size.height), Point(0, 1)},
+        {Point(0, 0), dst_uvs[0], src_uvs[0]},
+        {Point(size.width, 0), dst_uvs[1], src_uvs[1]},
+        {Point(size.width, size.height), dst_uvs[3], src_uvs[3]},
+        {Point(0, 0), dst_uvs[0], src_uvs[0]},
+        {Point(size.width, size.height), dst_uvs[3], src_uvs[3]},
+        {Point(0, size.height), dst_uvs[2], src_uvs[2]},
     });
     auto vtx_buffer = vtx_builder.CreateVertexBuffer(host_buffer);
-    cmd.BindVertices(vtx_buffer);
 
-    VS::FrameInfo frame_info;
-    frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                     Matrix::MakeTranslation(-coverage.origin) *
-                     input->transform;
+    auto options = OptionsFromPassAndEntity(pass, entity);
+    std::shared_ptr<Pipeline> pipeline =
+        std::invoke(pipeline_proc, renderer, options);
+
+    Command cmd;
+    cmd.label = "Advanced Blend Filter";
+    cmd.BindVertices(vtx_buffer);
+    cmd.pipeline = std::move(pipeline);
+
+    typename FS::BlendInfo blend_info;
+
+    auto sampler = renderer.GetContext()->GetSamplerLibrary()->GetSampler({});
+    FS::BindTextureSamplerDst(cmd, dst_snapshot->texture, sampler);
+    blend_info.dst_y_coord_scale = dst_snapshot->texture->GetYCoordScale();
+
+    if (foreground_color.has_value()) {
+      blend_info.color_factor = 1;
+      blend_info.color = foreground_color.value();
+      // This texture will not be sampled from due to the color factor. But
+      // this is present so that validation doesn't trip on a missing
+      // binding.
+      FS::BindTextureSamplerSrc(cmd, dst_snapshot->texture, sampler);
+    } else {
+      blend_info.color_factor = 0;
+      FS::BindTextureSamplerSrc(cmd, src_snapshot->texture, sampler);
+      blend_info.src_y_coord_scale = src_snapshot->texture->GetYCoordScale();
+    }
+    auto blend_uniform = host_buffer.EmplaceUniform(blend_info);
+    FS::BindBlendInfo(cmd, blend_uniform);
+
+    typename VS::FrameInfo frame_info;
+    frame_info.mvp = Matrix::MakeOrthographic(size);
 
     auto uniform_view = host_buffer.EmplaceUniform(frame_info);
     VS::BindFrameInfo(cmd, uniform_view);
-
     pass.AddCommand(cmd);
+
     return true;
   };
 
-  // Draw the first texture using kSource.
-
-  options.blend_mode = Entity::BlendMode::kSource;
-  cmd.pipeline = renderer.GetBlendPipeline(options);
-  if (!add_blend_command(inputs[0]->GetSnapshot(renderer, entity))) {
-    return true;
+  auto out_texture = renderer.MakeSubpass(ISize(coverage.size), callback);
+  if (!out_texture) {
+    return std::nullopt;
   }
+  out_texture->SetLabel("Advanced Blend Filter Texture");
 
-  // Write subsequent textures using the selected blend mode.
-
-  if (inputs.size() >= 2) {
-    options.blend_mode = pipeline_blend;
-    cmd.pipeline = renderer.GetBlendPipeline(options);
-
-    for (auto texture_i = inputs.begin() + 1; texture_i < inputs.end();
-         texture_i++) {
-      auto input = texture_i->get()->GetSnapshot(renderer, entity);
-      if (!add_blend_command(input)) {
-        return true;
-      }
-    }
-  }
-
-  // If a foreground color is set, blend it in.
-
-  if (foreground_color.has_value()) {
-    auto contents = std::make_shared<SolidColorContents>();
-    contents->SetPath(PathBuilder{}
-                          .AddRect(Rect::MakeSize(pass.GetRenderTargetSize()))
-                          .TakePath());
-    contents->SetColor(foreground_color.value());
-
-    Entity foreground_entity;
-    foreground_entity.SetBlendMode(pipeline_blend);
-    foreground_entity.SetContents(contents);
-    if (!foreground_entity.Render(renderer, pass)) {
-      return false;
-    }
-  }
-
-  return true;
+  return Snapshot{.texture = out_texture,
+                  .transform = Matrix::MakeTranslation(coverage.origin),
+                  .sampler_descriptor = dst_snapshot->sampler_descriptor};
 }
 
-#define BLEND_CASE(mode)                                                      \
-  case Entity::BlendMode::k##mode:                                            \
-    advanced_blend_proc_ =                                                    \
-        [](const FilterInput::Vector& inputs, const ContentContext& renderer, \
-           const Entity& entity, RenderPass& pass, const Rect& coverage,      \
-           std::optional<Color> fg_color) {                                   \
-          PipelineProc p = &ContentContext::GetBlend##mode##Pipeline;         \
-          return AdvancedBlend<BlendScreenPipeline>(                          \
-              inputs, renderer, entity, pass, coverage, fg_color, p);         \
-        };                                                                    \
+static std::optional<Snapshot> PipelineBlend(
+    const FilterInput::Vector& inputs,
+    const ContentContext& renderer,
+    const Entity& entity,
+    const Rect& coverage,
+    Entity::BlendMode pipeline_blend,
+    std::optional<Color> foreground_color) {
+  using VS = BlendPipeline::VertexShader;
+  using FS = BlendPipeline::FragmentShader;
+
+  ContentContext::SubpassCallback callback = [&](const ContentContext& renderer,
+                                                 RenderPass& pass) {
+    auto& host_buffer = pass.GetTransientsBuffer();
+
+    auto sampler = renderer.GetContext()->GetSamplerLibrary()->GetSampler({});
+
+    Command cmd;
+    cmd.label = "Pipeline Blend Filter";
+    auto options = OptionsFromPass(pass);
+
+    auto add_blend_command = [&](std::optional<Snapshot> input) {
+      if (!input.has_value()) {
+        return false;
+      }
+      auto input_coverage = input->GetCoverage();
+      if (!input_coverage.has_value()) {
+        return false;
+      }
+
+      FS::BindTextureSamplerSrc(cmd, input->texture, sampler);
+
+      auto size = input->texture->GetSize();
+      VertexBufferBuilder<VS::PerVertexData> vtx_builder;
+      vtx_builder.AddVertices({
+          {Point(0, 0), Point(0, 0)},
+          {Point(size.width, 0), Point(1, 0)},
+          {Point(size.width, size.height), Point(1, 1)},
+          {Point(0, 0), Point(0, 0)},
+          {Point(size.width, size.height), Point(1, 1)},
+          {Point(0, size.height), Point(0, 1)},
+      });
+      auto vtx_buffer = vtx_builder.CreateVertexBuffer(host_buffer);
+      cmd.BindVertices(vtx_buffer);
+
+      VS::FrameInfo frame_info;
+      frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
+                       Matrix::MakeTranslation(-coverage.origin) *
+                       input->transform;
+
+      auto uniform_view = host_buffer.EmplaceUniform(frame_info);
+      VS::BindFrameInfo(cmd, uniform_view);
+
+      pass.AddCommand(cmd);
+      return true;
+    };
+
+    // Draw the first texture using kSource.
+
+    options.blend_mode = Entity::BlendMode::kSource;
+    cmd.pipeline = renderer.GetBlendPipeline(options);
+    if (!add_blend_command(inputs[0]->GetSnapshot(renderer, entity))) {
+      return true;
+    }
+
+    // Write subsequent textures using the selected blend mode.
+
+    if (inputs.size() >= 2) {
+      options.blend_mode = pipeline_blend;
+      cmd.pipeline = renderer.GetBlendPipeline(options);
+
+      for (auto texture_i = inputs.begin() + 1; texture_i < inputs.end();
+           texture_i++) {
+        auto input = texture_i->get()->GetSnapshot(renderer, entity);
+        if (!add_blend_command(input)) {
+          return true;
+        }
+      }
+    }
+
+    // If a foreground color is set, blend it in.
+
+    if (foreground_color.has_value()) {
+      auto contents = std::make_shared<SolidColorContents>();
+      contents->SetPath(PathBuilder{}
+                            .AddRect(Rect::MakeSize(pass.GetRenderTargetSize()))
+                            .TakePath());
+      contents->SetColor(foreground_color.value());
+
+      Entity foreground_entity;
+      foreground_entity.SetBlendMode(pipeline_blend);
+      foreground_entity.SetContents(contents);
+      if (!foreground_entity.Render(renderer, pass)) {
+        return false;
+      }
+    }
+
+    return true;
+  };
+
+  auto out_texture = renderer.MakeSubpass(ISize(coverage.size), callback);
+  if (!out_texture) {
+    return std::nullopt;
+  }
+  out_texture->SetLabel("Pipeline Blend Filter Texture");
+
+  return Snapshot{
+      .texture = out_texture,
+      .transform = Matrix::MakeTranslation(coverage.origin),
+      .sampler_descriptor =
+          inputs[0]->GetSnapshot(renderer, entity)->sampler_descriptor};
+}
+
+#define BLEND_CASE(mode)                                                  \
+  case Entity::BlendMode::k##mode:                                        \
+    advanced_blend_proc_ = [](const FilterInput::Vector& inputs,          \
+                              const ContentContext& renderer,             \
+                              const Entity& entity, const Rect& coverage, \
+                              std::optional<Color> fg_color) {            \
+      PipelineProc p = &ContentContext::GetBlend##mode##Pipeline;         \
+      return AdvancedBlend<BlendScreenPipeline>(inputs, renderer, entity, \
+                                                coverage, fg_color, p);   \
+    };                                                                    \
     break;
 
 void BlendFilterContents::SetBlendMode(Entity::BlendMode blend_mode) {
@@ -277,34 +314,22 @@ std::optional<Snapshot> BlendFilterContents::RenderFilter(
     return std::nullopt;
   }
 
-  ContentContext::SubpassCallback callback = [&](const ContentContext& renderer,
-                                                 RenderPass& pass) {
-    if (inputs.size() == 1 && !foreground_color_.has_value()) {
-      // Nothing to blend.
-      return PipelineBlend(inputs, renderer, entity, pass, coverage,
-                           Entity::BlendMode::kSource, std::nullopt);
-    }
-
-    if (blend_mode_ <= Entity::BlendMode::kLastPipelineBlendMode) {
-      return PipelineBlend(inputs, renderer, entity, pass, coverage,
-                           blend_mode_, foreground_color_);
-    }
-
-    if (blend_mode_ <= Entity::BlendMode::kLastAdvancedBlendMode) {
-      return advanced_blend_proc_(inputs, renderer, entity, pass, coverage,
-                                  foreground_color_);
-    }
-    FML_UNREACHABLE();
-  };
-
-  auto out_texture = renderer.MakeSubpass(ISize(coverage.size), callback);
-  if (!out_texture) {
-    return std::nullopt;
+  if (inputs.size() == 1 && !foreground_color_.has_value()) {
+    // Nothing to blend.
+    return PipelineBlend(inputs, renderer, entity, coverage,
+                         Entity::BlendMode::kSource, std::nullopt);
   }
-  out_texture->SetLabel("BlendFilter Texture");
 
-  return Snapshot{.texture = out_texture,
-                  .transform = Matrix::MakeTranslation(coverage.origin)};
+  if (blend_mode_ <= Entity::BlendMode::kLastPipelineBlendMode) {
+    return PipelineBlend(inputs, renderer, entity, coverage, blend_mode_,
+                         foreground_color_);
+  }
+
+  if (blend_mode_ <= Entity::BlendMode::kLastAdvancedBlendMode) {
+    return advanced_blend_proc_(inputs, renderer, entity, coverage,
+                                foreground_color_);
+  }
+  FML_UNREACHABLE();
 }
 
 }  // namespace impeller

--- a/impeller/entity/contents/filters/blend_filter_contents.h
+++ b/impeller/entity/contents/filters/blend_filter_contents.h
@@ -11,13 +11,12 @@ namespace impeller {
 
 class BlendFilterContents : public FilterContents {
  public:
-  using AdvancedBlendProc =
-      std::function<bool(const FilterInput::Vector& inputs,
-                         const ContentContext& renderer,
-                         const Entity& entity,
-                         RenderPass& pass,
-                         const Rect& coverage,
-                         std::optional<Color> foreground_color)>;
+  using AdvancedBlendProc = std::function<std::optional<Snapshot>(
+      const FilterInput::Vector& inputs,
+      const ContentContext& renderer,
+      const Entity& entity,
+      const Rect& coverage,
+      std::optional<Color> foreground_color)>;
 
   BlendFilterContents();
 


### PR DESCRIPTION
Moves the pass creation into the blend routines for advanced/pipeline blends and ducks out early whenever inputs can't be resolved or have no coverage.

Also makes the texture labels more specific.