### PR TITLE
[Impeller] Fix transform in TextureContents::RenderToSnaphot passthrough path

### DIFF
--- a/impeller/entity/contents/texture_contents.cc
+++ b/impeller/entity/contents/texture_contents.cc
@@ -56,15 +56,20 @@ std::optional<Rect> TextureContents::GetCoverage(const Entity& entity) const {
 std::optional<Snapshot> TextureContents::RenderToSnapshot(
     const ContentContext& renderer,
     const Entity& entity) const {
+  auto bounds = path_.GetBoundingBox();
+  if (!bounds.has_value()) {
+    return std::nullopt;
+  }
+
   // Passthrough textures that have simple rectangle paths and complete source
   // rects.
   if (is_rect_ && source_rect_ == Rect::MakeSize(texture_->GetSize())) {
-    auto scale =
-        Vector2(path_.GetBoundingBox()->size / Size(texture_->GetSize()));
-    return Snapshot{
-        .texture = texture_,
-        .transform = entity.GetTransformation() * Matrix::MakeScale(scale),
-        .sampler_descriptor = sampler_descriptor_};
+    auto scale = Vector2(bounds->size / Size(texture_->GetSize()));
+    return Snapshot{.texture = texture_,
+                    .transform = entity.GetTransformation() *
+                                 Matrix::MakeTranslation(bounds->origin) *
+                                 Matrix::MakeScale(scale),
+                    .sampler_descriptor = sampler_descriptor_};
   }
   return Contents::RenderToSnapshot(renderer, entity);
 }


### PR DESCRIPTION
This fixes a bug introduced by one of the pass elimination patches I landed recently. The path origin was inadvertently getting dropped in the case where `TextureContents` is able to build snapshots using the texture directly.

I added parameters to control the path rect in the `GaussianBlurFilter` playground to make smoke testing this aspect possible.

https://user-images.githubusercontent.com/919017/185067669-5a50ab6a-9244-4673-9412-4da1604cf2a0.mov