### PR TITLE
Move task running to UI thread for loadDartDefferredLibrary.

### DIFF
--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -544,7 +544,6 @@ void Engine::LoadDartDeferredLibrary(
     intptr_t loading_unit_id,
     std::unique_ptr<const fml::Mapping> snapshot_data,
     std::unique_ptr<const fml::Mapping> snapshot_instructions) {
-  FML_DCHECK(task_runners_.GetUITaskRunner()->RunsTasksOnCurrentThread());
   if (runtime_controller_->IsRootIsolateRunning()) {
     runtime_controller_->LoadDartDeferredLibrary(
         loading_unit_id, std::move(snapshot_data),
@@ -558,7 +557,6 @@ void Engine::LoadDartDeferredLibrary(
 void Engine::LoadDartDeferredLibraryError(intptr_t loading_unit_id,
                                           const std::string error_message,
                                           bool transient) {
-  FML_DCHECK(task_runners_.GetUITaskRunner()->RunsTasksOnCurrentThread());
   if (runtime_controller_->IsRootIsolateRunning()) {
     runtime_controller_->LoadDartDeferredLibraryError(loading_unit_id,
                                                       error_message, transient);

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -544,6 +544,7 @@ void Engine::LoadDartDeferredLibrary(
     intptr_t loading_unit_id,
     std::unique_ptr<const fml::Mapping> snapshot_data,
     std::unique_ptr<const fml::Mapping> snapshot_instructions) {
+  FML_DCHECK(task_runners_.GetUITaskRunner()->RunsTasksOnCurrentThread());
   if (runtime_controller_->IsRootIsolateRunning()) {
     runtime_controller_->LoadDartDeferredLibrary(
         loading_unit_id, std::move(snapshot_data),
@@ -557,6 +558,7 @@ void Engine::LoadDartDeferredLibrary(
 void Engine::LoadDartDeferredLibraryError(intptr_t loading_unit_id,
                                           const std::string error_message,
                                           bool transient) {
+  FML_DCHECK(task_runners_.GetUITaskRunner()->RunsTasksOnCurrentThread());
   if (runtime_controller_->IsRootIsolateRunning()) {
     runtime_controller_->LoadDartDeferredLibraryError(loading_unit_id,
                                                       error_message, transient);

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -1371,15 +1371,29 @@ void Shell::LoadDartDeferredLibrary(
 void Shell::LoadDartDeferredLibraryError(intptr_t loading_unit_id,
                                          const std::string error_message,
                                          bool transient) {
-  engine_->LoadDartDeferredLibraryError(loading_unit_id, error_message,
-                                        transient);
+  fml::TaskRunner::RunNowOrPostTask(
+      task_runners_.GetPlatformTaskRunner(),
+      [engine = weak_engine_, loading_unit_id, error_message, transient] {
+        if (engine) {
+          engine->LoadDartDeferredLibraryError(loading_unit_id, error_message,
+                                               transient);
+        }
+      });
 }
 
 void Shell::UpdateAssetResolverByType(
     std::unique_ptr<AssetResolver> updated_asset_resolver,
     AssetResolver::AssetResolverType type) {
-  engine_->GetAssetManager()->UpdateResolverByType(
-      std::move(updated_asset_resolver), type);
+  fml::TaskRunner::RunNowOrPostTask(
+      task_runners_.GetPlatformTaskRunner(),
+      fml::MakeCopyable(
+          [engine = weak_engine_, type,
+           asset_resolver = std::move(updated_asset_resolver)]() mutable {
+            if (engine) {
+              engine->GetAssetManager()->UpdateResolverByType(
+                  std::move(asset_resolver), type);
+            }
+          }));
 }
 
 // |Engine::Delegate|

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -1372,7 +1372,7 @@ void Shell::LoadDartDeferredLibraryError(intptr_t loading_unit_id,
                                          const std::string error_message,
                                          bool transient) {
   fml::TaskRunner::RunNowOrPostTask(
-      task_runners_.GetPlatformTaskRunner(),
+      task_runners_.GetUITaskRunner(),
       [engine = weak_engine_, loading_unit_id, error_message, transient] {
         if (engine) {
           engine->LoadDartDeferredLibraryError(loading_unit_id, error_message,
@@ -1385,7 +1385,7 @@ void Shell::UpdateAssetResolverByType(
     std::unique_ptr<AssetResolver> updated_asset_resolver,
     AssetResolver::AssetResolverType type) {
   fml::TaskRunner::RunNowOrPostTask(
-      task_runners_.GetPlatformTaskRunner(),
+      task_runners_.GetUITaskRunner(),
       fml::MakeCopyable(
           [engine = weak_engine_, type,
            asset_resolver = std::move(updated_asset_resolver)]() mutable {

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -1371,26 +1371,15 @@ void Shell::LoadDartDeferredLibrary(
 void Shell::LoadDartDeferredLibraryError(intptr_t loading_unit_id,
                                          const std::string error_message,
                                          bool transient) {
-  task_runners_.GetUITaskRunner()->PostTask(
-      [engine = weak_engine_, loading_unit_id, error_message, transient] {
-        if (engine) {
-          engine->LoadDartDeferredLibraryError(loading_unit_id, error_message,
-                                               transient);
-        }
-      });
+  engine_->LoadDartDeferredLibraryError(loading_unit_id, error_message,
+                                        transient);
 }
 
 void Shell::UpdateAssetResolverByType(
     std::unique_ptr<AssetResolver> updated_asset_resolver,
     AssetResolver::AssetResolverType type) {
-  task_runners_.GetUITaskRunner()->PostTask(fml::MakeCopyable(
-      [engine = engine_->GetWeakPtr(), type,
-       asset_resolver = std::move(updated_asset_resolver)]() mutable {
-        if (engine) {
-          engine->GetAssetManager()->UpdateResolverByType(
-              std::move(asset_resolver), type);
-        }
-      }));
+  engine_->GetAssetManager()->UpdateResolverByType(
+      std::move(updated_asset_resolver), type);
 }
 
 // |Engine::Delegate|

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -1371,15 +1371,26 @@ void Shell::LoadDartDeferredLibrary(
 void Shell::LoadDartDeferredLibraryError(intptr_t loading_unit_id,
                                          const std::string error_message,
                                          bool transient) {
-  engine_->LoadDartDeferredLibraryError(loading_unit_id, error_message,
-                                        transient);
+  task_runners_.GetUITaskRunner()->PostTask(
+      [engine = weak_engine_, loading_unit_id, error_message, transient] {
+        if (engine) {
+          engine->LoadDartDeferredLibraryError(loading_unit_id, error_message,
+                                               transient);
+        }
+      });
 }
 
 void Shell::UpdateAssetResolverByType(
     std::unique_ptr<AssetResolver> updated_asset_resolver,
     AssetResolver::AssetResolverType type) {
-  engine_->GetAssetManager()->UpdateResolverByType(
-      std::move(updated_asset_resolver), type);
+  task_runners_.GetUITaskRunner()->PostTask(fml::MakeCopyable(
+      [engine = engine_->GetWeakPtr(), type,
+       asset_resolver = std::move(updated_asset_resolver)]() mutable {
+        if (engine) {
+          engine->GetAssetManager()->UpdateResolverByType(
+              std::move(asset_resolver), type);
+        }
+      }));
 }
 
 // |Engine::Delegate|

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -3339,9 +3339,9 @@ TEST_F(ShellTest, ImageGeneratorRegistryNotNullAfterParentShellDestroyed) {
 TEST_F(ShellTest, UpdateAssetResolverByTypeReplaces) {
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
   Settings settings = CreateSettingsForFixture();
-  ThreadHost thread_host("io.flutter.test." + GetCurrentTestName() + ".",
-                         ThreadHost::Type::Platform);
-  auto task_runner = thread_host.platform_thread->GetTaskRunner();
+
+  fml::MessageLoop::EnsureInitializedForCurrentThread();
+  auto task_runner = fml::MessageLoop::GetCurrent().GetTaskRunner();
   TaskRunners task_runners("test", task_runner, task_runner, task_runner,
                            task_runner);
   auto shell = CreateShell(std::move(settings), task_runners);
@@ -3351,7 +3351,10 @@ TEST_F(ShellTest, UpdateAssetResolverByTypeReplaces) {
   auto configuration = RunConfiguration::InferFromSettings(settings);
   configuration.SetEntrypoint("emptyMain");
   auto asset_manager = configuration.GetAssetManager();
-  RunEngine(shell.get(), std::move(configuration));
+
+  shell->RunEngine(std::move(configuration), [&](auto result) {
+    ASSERT_EQ(result, Engine::RunStatus::Success);
+  });
 
   auto platform_view =
       std::make_unique<PlatformView>(*shell.get(), std::move(task_runners));
@@ -3381,9 +3384,9 @@ TEST_F(ShellTest, UpdateAssetResolverByTypeReplaces) {
 TEST_F(ShellTest, UpdateAssetResolverByTypeAppends) {
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
   Settings settings = CreateSettingsForFixture();
-  ThreadHost thread_host("io.flutter.test." + GetCurrentTestName() + ".",
-                         ThreadHost::Type::Platform);
-  auto task_runner = thread_host.platform_thread->GetTaskRunner();
+
+  fml::MessageLoop::EnsureInitializedForCurrentThread();
+  auto task_runner = fml::MessageLoop::GetCurrent().GetTaskRunner();
   TaskRunners task_runners("test", task_runner, task_runner, task_runner,
                            task_runner);
   auto shell = CreateShell(std::move(settings), task_runners);
@@ -3393,7 +3396,10 @@ TEST_F(ShellTest, UpdateAssetResolverByTypeAppends) {
   auto configuration = RunConfiguration::InferFromSettings(settings);
   configuration.SetEntrypoint("emptyMain");
   auto asset_manager = configuration.GetAssetManager();
-  RunEngine(shell.get(), std::move(configuration));
+
+  shell->RunEngine(std::move(configuration), [&](auto result) {
+    ASSERT_EQ(result, Engine::RunStatus::Success);
+  });
 
   auto platform_view =
       std::make_unique<PlatformView>(*shell.get(), std::move(task_runners));
@@ -3456,10 +3462,9 @@ TEST_F(ShellTest, UpdateAssetResolverByTypeNull) {
 TEST_F(ShellTest, UpdateAssetResolverByTypeDoesNotReplaceMismatchType) {
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
   Settings settings = CreateSettingsForFixture();
-  ThreadHost thread_host(ThreadHost::ThreadHostConfig(
-      "io.flutter.test." + GetCurrentTestName() + ".",
-      ThreadHost::Type::Platform));
-  auto task_runner = thread_host.platform_thread->GetTaskRunner();
+
+  fml::MessageLoop::EnsureInitializedForCurrentThread();
+  auto task_runner = fml::MessageLoop::GetCurrent().GetTaskRunner();
   TaskRunners task_runners("test", task_runner, task_runner, task_runner,
                            task_runner);
   auto shell = CreateShell(std::move(settings), task_runners);
@@ -3469,7 +3474,10 @@ TEST_F(ShellTest, UpdateAssetResolverByTypeDoesNotReplaceMismatchType) {
   auto configuration = RunConfiguration::InferFromSettings(settings);
   configuration.SetEntrypoint("emptyMain");
   auto asset_manager = configuration.GetAssetManager();
-  RunEngine(shell.get(), std::move(configuration));
+
+  shell->RunEngine(std::move(configuration), [&](auto result) {
+    ASSERT_EQ(result, Engine::RunStatus::Success);
+  });
 
   auto platform_view =
       std::make_unique<PlatformView>(*shell.get(), std::move(task_runners));

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -3339,7 +3339,12 @@ TEST_F(ShellTest, ImageGeneratorRegistryNotNullAfterParentShellDestroyed) {
 TEST_F(ShellTest, UpdateAssetResolverByTypeReplaces) {
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
   Settings settings = CreateSettingsForFixture();
-  auto shell = CreateShell(std::move(settings));
+  ThreadHost thread_host("io.flutter.test." + GetCurrentTestName() + ".",
+                         ThreadHost::Type::Platform);
+  auto task_runner = thread_host.platform_thread->GetTaskRunner();
+  TaskRunners task_runners("test", task_runner, task_runner, task_runner,
+                           task_runner);
+  auto shell = CreateShell(std::move(settings), task_runners);
   ASSERT_TRUE(DartVMRef::IsInstanceRunning());
   ASSERT_TRUE(ValidateShell(shell.get()));
 
@@ -3348,36 +3353,40 @@ TEST_F(ShellTest, UpdateAssetResolverByTypeReplaces) {
   auto asset_manager = configuration.GetAssetManager();
   RunEngine(shell.get(), std::move(configuration));
 
+  auto platform_view =
+      std::make_unique<PlatformView>(*shell.get(), std::move(task_runners));
+
   auto old_resolver = std::make_unique<TestAssetResolver>(
       true, AssetResolver::AssetResolverType::kApkAssetProvider);
   ASSERT_TRUE(old_resolver->IsValid());
   asset_manager->PushBack(std::move(old_resolver));
+
   auto updated_resolver = std::make_unique<TestAssetResolver>(
       false, AssetResolver::AssetResolverType::kApkAssetProvider);
   ASSERT_FALSE(updated_resolver->IsValidAfterAssetManagerChange());
+  platform_view->UpdateAssetResolverByType(
+      std::move(updated_resolver),
+      AssetResolver::AssetResolverType::kApkAssetProvider);
 
-  PostSync(shell->GetTaskRunners().GetPlatformTaskRunner(),
-           [&shell, &updated_resolver]() {
-             shell->GetPlatformView()->UpdateAssetResolverByType(
-                 std::move(updated_resolver),
-                 AssetResolver::AssetResolverType::kApkAssetProvider);
-           });
+  auto resolvers = asset_manager->TakeResolvers();
+  ASSERT_EQ(resolvers.size(), 2ull);
+  ASSERT_TRUE(resolvers[0]->IsValidAfterAssetManagerChange());
 
-  PostSync(shell->GetTaskRunners().GetUITaskRunner(), [&shell]() {
-    auto resolvers = shell->GetEngine()->GetAssetManager()->TakeResolvers();
-    ASSERT_EQ(resolvers.size(), 2ull);
-    ASSERT_TRUE(resolvers[0]->IsValidAfterAssetManagerChange());
-    ASSERT_FALSE(resolvers[1]->IsValidAfterAssetManagerChange());
-  });
+  ASSERT_FALSE(resolvers[1]->IsValidAfterAssetManagerChange());
 
-  DestroyShell(std::move(shell));
+  DestroyShell(std::move(shell), std::move(task_runners));
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
 }
 
 TEST_F(ShellTest, UpdateAssetResolverByTypeAppends) {
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
   Settings settings = CreateSettingsForFixture();
-  auto shell = CreateShell(std::move(settings));
+  ThreadHost thread_host("io.flutter.test." + GetCurrentTestName() + ".",
+                         ThreadHost::Type::Platform);
+  auto task_runner = thread_host.platform_thread->GetTaskRunner();
+  TaskRunners task_runners("test", task_runner, task_runner, task_runner,
+                           task_runner);
+  auto shell = CreateShell(std::move(settings), task_runners);
   ASSERT_TRUE(DartVMRef::IsInstanceRunning());
   ASSERT_TRUE(ValidateShell(shell.get()));
 
@@ -3386,31 +3395,36 @@ TEST_F(ShellTest, UpdateAssetResolverByTypeAppends) {
   auto asset_manager = configuration.GetAssetManager();
   RunEngine(shell.get(), std::move(configuration));
 
+  auto platform_view =
+      std::make_unique<PlatformView>(*shell.get(), std::move(task_runners));
+
   auto updated_resolver = std::make_unique<TestAssetResolver>(
       false, AssetResolver::AssetResolverType::kApkAssetProvider);
   ASSERT_FALSE(updated_resolver->IsValidAfterAssetManagerChange());
-  PostSync(shell->GetTaskRunners().GetPlatformTaskRunner(),
-           [&shell, &updated_resolver]() {
-             shell->GetPlatformView()->UpdateAssetResolverByType(
-                 std::move(updated_resolver),
-                 AssetResolver::AssetResolverType::kApkAssetProvider);
-           });
+  platform_view->UpdateAssetResolverByType(
+      std::move(updated_resolver),
+      AssetResolver::AssetResolverType::kApkAssetProvider);
 
-  PostSync(shell->GetTaskRunners().GetUITaskRunner(), [&shell]() {
-    auto resolvers = shell->GetEngine()->GetAssetManager()->TakeResolvers();
-    ASSERT_EQ(resolvers.size(), 2ull);
-    ASSERT_TRUE(resolvers[0]->IsValidAfterAssetManagerChange());
-    ASSERT_FALSE(resolvers[1]->IsValidAfterAssetManagerChange());
-  });
+  auto resolvers = asset_manager->TakeResolvers();
+  ASSERT_EQ(resolvers.size(), 2ull);
+  ASSERT_TRUE(resolvers[0]->IsValidAfterAssetManagerChange());
 
-  DestroyShell(std::move(shell));
+  ASSERT_FALSE(resolvers[1]->IsValidAfterAssetManagerChange());
+
+  DestroyShell(std::move(shell), std::move(task_runners));
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
 }
 
 TEST_F(ShellTest, UpdateAssetResolverByTypeNull) {
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
   Settings settings = CreateSettingsForFixture();
-  auto shell = CreateShell(std::move(settings));
+  ThreadHost thread_host(ThreadHost::ThreadHostConfig(
+      "io.flutter.test." + GetCurrentTestName() + ".",
+      ThreadHost::Type::Platform));
+  auto task_runner = thread_host.platform_thread->GetTaskRunner();
+  TaskRunners task_runners("test", task_runner, task_runner, task_runner,
+                           task_runner);
+  auto shell = CreateShell(std::move(settings), task_runners);
   ASSERT_TRUE(DartVMRef::IsInstanceRunning());
   ASSERT_TRUE(ValidateShell(shell.get()));
 
@@ -3418,33 +3432,37 @@ TEST_F(ShellTest, UpdateAssetResolverByTypeNull) {
   configuration.SetEntrypoint("emptyMain");
   auto asset_manager = configuration.GetAssetManager();
   RunEngine(shell.get(), std::move(configuration));
+
+  auto platform_view =
+      std::make_unique<PlatformView>(*shell.get(), std::move(task_runners));
 
   auto old_resolver = std::make_unique<TestAssetResolver>(
       true, AssetResolver::AssetResolverType::kApkAssetProvider);
   ASSERT_TRUE(old_resolver->IsValid());
   asset_manager->PushBack(std::move(old_resolver));
 
-  PostSync(shell->GetTaskRunners().GetPlatformTaskRunner(), [&shell]() {
-    shell->GetPlatformView()->UpdateAssetResolverByType(
-        std::move(nullptr),
-        AssetResolver::AssetResolverType::kApkAssetProvider);
-  });
+  platform_view->UpdateAssetResolverByType(
+      std::move(nullptr), AssetResolver::AssetResolverType::kApkAssetProvider);
 
-  PostSync(shell->GetTaskRunners().GetUITaskRunner(), [&shell]() {
-    auto resolvers = shell->GetEngine()->GetAssetManager()->TakeResolvers();
-    ASSERT_EQ(resolvers.size(), 2ull);
-    ASSERT_TRUE(resolvers[0]->IsValidAfterAssetManagerChange());
-    ASSERT_TRUE(resolvers[1]->IsValidAfterAssetManagerChange());
-  });
+  auto resolvers = asset_manager->TakeResolvers();
+  ASSERT_EQ(resolvers.size(), 2ull);
+  ASSERT_TRUE(resolvers[0]->IsValidAfterAssetManagerChange());
+  ASSERT_TRUE(resolvers[1]->IsValidAfterAssetManagerChange());
 
-  DestroyShell(std::move(shell));
+  DestroyShell(std::move(shell), std::move(task_runners));
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
 }
 
 TEST_F(ShellTest, UpdateAssetResolverByTypeDoesNotReplaceMismatchType) {
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
   Settings settings = CreateSettingsForFixture();
-  auto shell = CreateShell(std::move(settings));
+  ThreadHost thread_host(ThreadHost::ThreadHostConfig(
+      "io.flutter.test." + GetCurrentTestName() + ".",
+      ThreadHost::Type::Platform));
+  auto task_runner = thread_host.platform_thread->GetTaskRunner();
+  TaskRunners task_runners("test", task_runner, task_runner, task_runner,
+                           task_runner);
+  auto shell = CreateShell(std::move(settings), task_runners);
   ASSERT_TRUE(DartVMRef::IsInstanceRunning());
   ASSERT_TRUE(ValidateShell(shell.get()));
 
@@ -3452,6 +3470,9 @@ TEST_F(ShellTest, UpdateAssetResolverByTypeDoesNotReplaceMismatchType) {
   configuration.SetEntrypoint("emptyMain");
   auto asset_manager = configuration.GetAssetManager();
   RunEngine(shell.get(), std::move(configuration));
+
+  auto platform_view =
+      std::make_unique<PlatformView>(*shell.get(), std::move(task_runners));
 
   auto old_resolver = std::make_unique<TestAssetResolver>(
       true, AssetResolver::AssetResolverType::kAssetManager);
@@ -3461,23 +3482,19 @@ TEST_F(ShellTest, UpdateAssetResolverByTypeDoesNotReplaceMismatchType) {
   auto updated_resolver = std::make_unique<TestAssetResolver>(
       false, AssetResolver::AssetResolverType::kApkAssetProvider);
   ASSERT_FALSE(updated_resolver->IsValidAfterAssetManagerChange());
+  platform_view->UpdateAssetResolverByType(
+      std::move(updated_resolver),
+      AssetResolver::AssetResolverType::kApkAssetProvider);
 
-  PostSync(shell->GetTaskRunners().GetPlatformTaskRunner(),
-           [&shell, &updated_resolver]() {
-             shell->GetPlatformView()->UpdateAssetResolverByType(
-                 std::move(updated_resolver),
-                 AssetResolver::AssetResolverType::kApkAssetProvider);
-           });
+  auto resolvers = asset_manager->TakeResolvers();
+  ASSERT_EQ(resolvers.size(), 3ull);
+  ASSERT_TRUE(resolvers[0]->IsValidAfterAssetManagerChange());
 
-  PostSync(shell->GetTaskRunners().GetUITaskRunner(), [&shell]() {
-    auto resolvers = shell->GetEngine()->GetAssetManager()->TakeResolvers();
-    ASSERT_EQ(resolvers.size(), 3ull);
-    ASSERT_TRUE(resolvers[0]->IsValidAfterAssetManagerChange());
-    ASSERT_TRUE(resolvers[1]->IsValidAfterAssetManagerChange());
-    ASSERT_FALSE(resolvers[2]->IsValidAfterAssetManagerChange());
-  });
+  ASSERT_TRUE(resolvers[1]->IsValidAfterAssetManagerChange());
 
-  DestroyShell(std::move(shell));
+  ASSERT_FALSE(resolvers[2]->IsValidAfterAssetManagerChange());
+
+  DestroyShell(std::move(shell), std::move(task_runners));
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
 }
 


### PR DESCRIPTION
func LoadDartDeferredLibraryError() and UpdateAssetResolverByType in shell.cc should be post to run in UI thread.

Fixed the issue https://github.com/flutter/flutter/issues/109762

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
