### PR TITLE
Eliminates Dart->Host response copy for large buffers

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1100,6 +1100,7 @@ FILE: ../../../flutter/lib/ui/window/platform_message_response.cc
 FILE: ../../../flutter/lib/ui/window/platform_message_response.h
 FILE: ../../../flutter/lib/ui/window/platform_message_response_dart.cc
 FILE: ../../../flutter/lib/ui/window/platform_message_response_dart.h
+FILE: ../../../flutter/lib/ui/window/platform_message_response_dart_unittests.cc
 FILE: ../../../flutter/lib/ui/window/pointer_data.cc
 FILE: ../../../flutter/lib/ui/window/pointer_data.h
 FILE: ../../../flutter/lib/ui/window/pointer_data_packet.cc

--- a/lib/ui/BUILD.gn
+++ b/lib/ui/BUILD.gn
@@ -231,6 +231,7 @@ if (enable_unittests) {
       "painting/vertices_unittests.cc",
       "semantics/semantics_update_builder_unittests.cc",
       "window/platform_configuration_unittests.cc",
+      "window/platform_message_response_dart_unittests.cc",
       "window/pointer_data_packet_converter_unittests.cc",
     ]
 

--- a/lib/ui/fixtures/ui_test.dart
+++ b/lib/ui/fixtures/ui_test.dart
@@ -229,6 +229,21 @@ void frameCallback(_Image, int) {
 }
 
 @pragma('vm:entry-point')
+void platformMessageResponseTest() {
+  _callPlatformMessageResponseDart((ByteData? result) {
+    if (result is UnmodifiableByteDataView &&
+        result.lengthInBytes == 100) {
+      _finishCallResponse(true);
+    } else {
+      _finishCallResponse(false);
+    }
+  });
+}
+
+void _callPlatformMessageResponseDart(void Function(ByteData? result) callback) native 'CallPlatformMessageResponseDart';
+void _finishCallResponse(bool didPass) native 'FinishCallResponse';
+
+@pragma('vm:entry-point')
 void messageCallback(dynamic data) {}
 
 @pragma('vm:entry-point')

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -69,6 +69,10 @@ const double _kUnsetGestureSetting = -1.0;
 // See embedder.cc::kFlutterKeyDataChannel for more information.
 const String _kFlutterKeyDataChannel = 'flutter/keydata';
 
+@pragma('vm:entry-point')
+ByteData? _wrapUnmodifiableByteData(ByteData? byteData) =>
+    byteData == null ? null : UnmodifiableByteDataView(byteData);
+
 /// Platform event dispatcher singleton.
 ///
 /// The most basic interface to the host operating system's interface.

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -69,10 +69,6 @@ const double _kUnsetGestureSetting = -1.0;
 // See embedder.cc::kFlutterKeyDataChannel for more information.
 const String _kFlutterKeyDataChannel = 'flutter/keydata';
 
-@pragma('vm:entry-point')
-ByteData? _wrapUnmodifiableByteData(ByteData? byteData) =>
-    byteData == null ? null : UnmodifiableByteDataView(byteData);
-
 /// Platform event dispatcher singleton.
 ///
 /// The most basic interface to the host operating system's interface.

--- a/lib/ui/window/platform_message_response_dart.cc
+++ b/lib/ui/window/platform_message_response_dart.cc
@@ -17,6 +17,11 @@ static std::atomic<uint64_t> platform_message_counter = 1;
 
 namespace flutter {
 namespace {
+
+void MappingFinalizer(void* isolate_callback_data, void* peer) {
+  delete static_cast<fml::Mapping*>(peer);
+}
+
 template <typename Callback, typename TaskRunner, typename Result>
 void PostCompletion(Callback&& callback,
                     const TaskRunner& ui_task_runner,
@@ -63,11 +68,38 @@ PlatformMessageResponseDart::~PlatformMessageResponseDart() {
 }
 
 void PlatformMessageResponseDart::Complete(std::unique_ptr<fml::Mapping> data) {
-  PostCompletion(std::move(callback_), ui_task_runner_, &is_complete_, channel_,
-                 [data = std::move(data)] {
-                   return tonic::DartByteData::Create(data->GetMapping(),
-                                                      data->GetSize());
-                 });
+  PostCompletion(
+      std::move(callback_), ui_task_runner_, &is_complete_, channel_,
+      [data = std::move(data)]() mutable {
+        Dart_Handle byte_buffer;
+        intptr_t size = data->GetSize();
+        if (data->GetSize() > tonic::DartByteData::kExternalSizeThreshold) {
+          // The ByteData will be wrapped with an
+          // UnmodifiableByteDataView below to protect constness in
+          // Dart.
+          void* mapping = const_cast<uint8_t*>(data->GetMapping());
+          byte_buffer = Dart_NewExternalTypedDataWithFinalizer(
+              /*type=*/Dart_TypedData_kByteData,
+              /*data=*/mapping,
+              /*length=*/size,
+              /*peer=*/data.release(),
+              /*external_allocation_size=*/size,
+              /*callback=*/MappingFinalizer);
+        } else {
+          byte_buffer =
+              tonic::DartByteData::Create(data->GetMapping(), data->GetSize());
+        }
+        Dart_Handle ui_lib = Dart_LookupLibrary(
+            tonic::DartConverter<std::string>().ToDart("dart:ui"));
+        FML_DCHECK(!(Dart_IsNull(ui_lib) || Dart_IsError(ui_lib)));
+        Dart_Handle result =
+            Dart_Invoke(ui_lib,
+                        tonic::DartConverter<std::string>().ToDart(
+                            "_wrapUnmodifiableByteData"),
+                        1, &byte_buffer);
+        FML_DCHECK(!(Dart_IsNull(result) || Dart_IsError(result)));
+        return result;
+      });
 }
 
 void PlatformMessageResponseDart::CompleteEmpty() {

--- a/lib/ui/window/platform_message_response_dart.cc
+++ b/lib/ui/window/platform_message_response_dart.cc
@@ -83,9 +83,18 @@ void PlatformMessageResponseDart::Complete(std::unique_ptr<fml::Mapping> data) {
               /*external_allocation_size=*/size,
               /*callback=*/MappingFinalizer);
         } else {
-          byte_buffer =
+          Dart_Handle mutable_byte_buffer =
               tonic::DartByteData::Create(data->GetMapping(), data->GetSize());
+          Dart_Handle ui_lib = Dart_LookupLibrary(
+              tonic::DartConverter<std::string>().ToDart("dart:ui"));
+          FML_DCHECK(!(Dart_IsNull(ui_lib) || Dart_IsError(ui_lib)));
+          byte_buffer = Dart_Invoke(ui_lib,
+                                    tonic::DartConverter<std::string>().ToDart(
+                                        "_wrapUnmodifiableByteData"),
+                                    1, &mutable_byte_buffer);
+          FML_DCHECK(!(Dart_IsNull(byte_buffer) || Dart_IsError(byte_buffer)));
         }
+
         return byte_buffer;
       });
 }

--- a/lib/ui/window/platform_message_response_dart_unittests.cc
+++ b/lib/ui/window/platform_message_response_dart_unittests.cc
@@ -1,0 +1,73 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/common/task_runners.h"
+#include "flutter/fml/mapping.h"
+#include "flutter/fml/synchronization/waitable_event.h"
+#include "flutter/lib/ui/window/platform_message_response_dart.h"
+#include "flutter/runtime/dart_vm.h"
+#include "flutter/shell/common/shell_test.h"
+#include "flutter/shell/common/thread_host.h"
+#include "flutter/testing/testing.h"
+
+namespace flutter {
+namespace testing {
+
+TEST_F(ShellTest, PlatformMessageResponseDart) {
+  bool did_pass = false;
+  auto message_latch = std::make_shared<fml::AutoResetWaitableEvent>();
+  TaskRunners task_runners("test",                  // label
+                           GetCurrentTaskRunner(),  // platform
+                           CreateNewThread(),       // raster
+                           CreateNewThread(),       // ui
+                           CreateNewThread()        // io
+  );
+
+  auto nativeCallPlatformMessageResponseDart =
+      [ui_task_runner =
+           task_runners.GetUITaskRunner()](Dart_NativeArguments args) {
+        auto dart_state = std::make_shared<tonic::DartState>();
+        auto response = fml::MakeRefCounted<PlatformMessageResponseDart>(
+            tonic::DartPersistentValue(tonic::DartState::Current(),
+                                       Dart_GetNativeArgument(args, 0)),
+            ui_task_runner, "foobar");
+        uint8_t* data = static_cast<uint8_t*>(malloc(100));
+        auto mapping = std::make_unique<fml::MallocMapping>(data, 100);
+        response->Complete(std::move(mapping));
+      };
+
+  AddNativeCallback("CallPlatformMessageResponseDart",
+                    CREATE_NATIVE_ENTRY(nativeCallPlatformMessageResponseDart));
+
+  auto nativeFinishCallResponse = [message_latch,
+                                   &did_pass](Dart_NativeArguments args) {
+    did_pass =
+        tonic::DartConverter<bool>::FromDart(Dart_GetNativeArgument(args, 0));
+    message_latch->Signal();
+  };
+
+  AddNativeCallback("FinishCallResponse",
+                    CREATE_NATIVE_ENTRY(nativeFinishCallResponse));
+
+  Settings settings = CreateSettingsForFixture();
+
+  std::unique_ptr<Shell> shell =
+      CreateShell(std::move(settings), std::move(task_runners));
+
+  ASSERT_TRUE(shell->IsSetup());
+  auto configuration = RunConfiguration::InferFromSettings(settings);
+  configuration.SetEntrypoint("platformMessageResponseTest");
+
+  shell->RunEngine(std::move(configuration), [](auto result) {
+    ASSERT_EQ(result, Engine::RunStatus::Success);
+  });
+
+  message_latch->Wait();
+
+  ASSERT_TRUE(did_pass);
+  DestroyShell(std::move(shell), std::move(task_runners));
+}
+
+}  // namespace testing
+}  // namespace flutter

--- a/third_party/tonic/typed_data/dart_byte_data.cc
+++ b/third_party/tonic/typed_data/dart_byte_data.cc
@@ -12,15 +12,15 @@ namespace tonic {
 
 namespace {
 
-// For large objects it is more efficient to use an external typed data object
-// with a buffer allocated outside the Dart heap.
-const int kExternalSizeThreshold = 1000;
-
 void FreeFinalizer(void* isolate_callback_data, void* peer) {
   free(peer);
 }
 
 }  // anonymous namespace
+
+// For large objects it is more efficient to use an external typed data object
+// with a buffer allocated outside the Dart heap.
+const size_t DartByteData::kExternalSizeThreshold = 1000;
 
 Dart_Handle DartByteData::Create(const void* data, size_t length) {
   if (length < kExternalSizeThreshold) {

--- a/third_party/tonic/typed_data/dart_byte_data.h
+++ b/third_party/tonic/typed_data/dart_byte_data.h
@@ -14,6 +14,7 @@ namespace tonic {
 
 class DartByteData {
  public:
+  static const size_t kExternalSizeThreshold;
   static Dart_Handle Create(const void* data, size_t length);
 
   explicit DartByteData(Dart_Handle list);


### PR DESCRIPTION
## description
This constitutes a 30% reduction in the [1MB test](https://github.com/flutter/flutter/blob/master/dev/benchmarks/platform_channels_benchmarks/lib/main.dart) and little change in the other tests.

This will affect platform channel communications, including loading assets from the asset directory.

This is an alternative to the PR that eliminates copies if we have a modifiable buffer: https://github.com/flutter/engine/pull/34018

## breaking change notice

This can break users at runtime in the following cases:
 1) usage of a BinaryCodec that edits the ByteData returned from platform message calls
 2) custom implementations of MessageCodec that edit the ByteData returned from platform message calls

It isn't technically a breaking change since it doesn't appear to break any existing tests.

## local testing results
Local iOS platform channel benchmark results with the framework pr https://github.com/flutter/flutter/pull/109707:
```
## before ##
BasicMessageChannel/StandardMessageCodec/Flutter->Host/Small: 47.8 µs
BasicMessageChannel/StandardMessageCodec/Flutter->Host/Large: 647.6 µs
BasicMessageChannel/BinaryCodec/Flutter->Host/Large: 52.8 µs
BasicMessageChannel/BinaryCodec/Flutter->Host/1MB: 485.9 µs
BasicMessageChannel/StandardMessageCodec/Flutter->Host/SmallParallel3: 25.5 µs
BasicMessageChannel/StandardMessageCodec/Flutter->Host (background)/Small: 39.2 µs
BasicMessageChannel/StandardMessageCodec/Flutter->Host (background)/SmallParallel3: 22.5 µs

## after ##
BasicMessageChannel/StandardMessageCodec/Flutter->Host/Small: 43.0 µs
BasicMessageChannel/StandardMessageCodec/Flutter->Host/Large: 660.3 µs
BasicMessageChannel/BinaryCodec/Flutter->Host/Large: 47.9 µs
BasicMessageChannel/BinaryCodec/Flutter->Host/1MB: 342.4 µs
BasicMessageChannel/StandardMessageCodec/Flutter->Host/SmallParallel3: 26.4 µs
BasicMessageChannel/StandardMessageCodec/Flutter->Host (background)/Small: 38.6 µs
BasicMessageChannel/StandardMessageCodec/Flutter->Host (background)/SmallParallel3: 21.4 µs
```


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
