### PR TITLE
don't report GPU image size

### DIFF
--- a/lib/ui/painting/display_list_deferred_image_gpu.cc
+++ b/lib/ui/painting/display_list_deferred_image_gpu.cc
@@ -64,10 +64,9 @@ SkISize DlDeferredImageGPU::dimensions() const {
 
 // |DlImage|
 size_t DlDeferredImageGPU::GetApproximateByteSize() const {
-  // We don't actually want Dart's GC to use the size of this object to make GC
-  // decisions, as it is generally both created and disposed in the framework.
-  // This is similar to why we do not report the sizes of engine layers.
-  return sizeof(this);
+  return sizeof(this) + (image_wrapper_
+                             ? image_wrapper_->image_info().computeMinByteSize()
+                             : 0);
 }
 
 std::optional<std::string> DlDeferredImageGPU::get_error() const {

--- a/lib/ui/painting/display_list_deferred_image_gpu.cc
+++ b/lib/ui/painting/display_list_deferred_image_gpu.cc
@@ -64,9 +64,10 @@ SkISize DlDeferredImageGPU::dimensions() const {
 
 // |DlImage|
 size_t DlDeferredImageGPU::GetApproximateByteSize() const {
-  return sizeof(this) + (image_wrapper_
-                             ? image_wrapper_->image_info().computeMinByteSize()
-                             : 0);
+  // We don't actually want Dart's GC to use the size of this object to make GC
+  // decisions, as it is generally both created and disposed in the framework.
+  // This is similar to why we do not report the sizes of engine layers.
+  return sizeof(this);
 }
 
 std::optional<std::string> DlDeferredImageGPU::get_error() const {

--- a/lib/ui/painting/image.cc
+++ b/lib/ui/painting/image.cc
@@ -42,7 +42,7 @@ void CanvasImage::dispose() {
 size_t CanvasImage::GetAllocationSize() const {
   // We don't actually want Dart's GC to use the size of this object to make GC
   // decisions, as it is generally both created and disposed in the framework.
-  // This is similar to why we do not report the sizes of engine
+  // This is similar to why we do not report the sizes of engine layers.
   return sizeof(this);
 }
 }  // namespace flutter

--- a/lib/ui/painting/image.cc
+++ b/lib/ui/painting/image.cc
@@ -43,6 +43,6 @@ size_t CanvasImage::GetAllocationSize() const {
   // We don't actually want Dart's GC to use the size of this object to make GC
   // decisions, as it is generally both created and disposed in the framework.
   // This is similar to why we do not report the sizes of engine layers.
-  return sizeof(this);
+  return sizeof(*this);
 }
 }  // namespace flutter

--- a/lib/ui/painting/image.cc
+++ b/lib/ui/painting/image.cc
@@ -40,15 +40,9 @@ void CanvasImage::dispose() {
 }
 
 size_t CanvasImage::GetAllocationSize() const {
-  auto size = sizeof(this);
-  if (image_) {
-    size += image_->GetApproximateByteSize();
-  }
-  // The VM will assert if we set a value larger than or close to
-  // std::numeric_limits<intptr_t>::max().
-  // https://github.com/dart-lang/sdk/issues/49332
-  return std::clamp(
-      size, static_cast<size_t>(0),
-      static_cast<size_t>(std::numeric_limits<intptr_t>::max() / 10));
+  // We don't actually want Dart's GC to use the size of this object to make GC
+  // decisions, as it is generally both created and disposed in the framework.
+  // This is similar to why we do not report the sizes of engine
+  return sizeof(this);
 }
 }  // namespace flutter

--- a/lib/ui/painting/image_encoding_unittests.cc
+++ b/lib/ui/painting/image_encoding_unittests.cc
@@ -125,6 +125,7 @@ TEST_F(ShellTest, EncodeImageAccessesSyncSwitch) {
         image_handle, tonic::DartWrappable::kPeerIndex, &peer);
     ASSERT_FALSE(Dart_IsError(result));
     CanvasImage* canvas_image = reinterpret_cast<CanvasImage*>(peer);
+    ASSERT_EQ(canvas_image->GetAllocationSize(), sizeof(canvas_image));
 
     int64_t format = -1;
     result = Dart_IntegerToInt64(format_handle, &format);

--- a/lib/ui/painting/image_encoding_unittests.cc
+++ b/lib/ui/painting/image_encoding_unittests.cc
@@ -125,7 +125,7 @@ TEST_F(ShellTest, EncodeImageAccessesSyncSwitch) {
         image_handle, tonic::DartWrappable::kPeerIndex, &peer);
     ASSERT_FALSE(Dart_IsError(result));
     CanvasImage* canvas_image = reinterpret_cast<CanvasImage*>(peer);
-    ASSERT_EQ(canvas_image->GetAllocationSize(), sizeof(canvas_image));
+    ASSERT_EQ(canvas_image->GetAllocationSize(), sizeof(*canvas_image));
 
     int64_t format = -1;
     result = Dart_IntegerToInt64(format_handle, &format);


### PR DESCRIPTION
 We don't actually want Dart's GC to use the size of this object to make GC decisions, as it is generally both created and disposed in the framework. This is similar to why we do not report the sizes of engine layers.
 
 FYI @iskakaushik , if you use the zoom page transition as an example you'll have to revert this change after we land it.