### PR TITLE
Updates accessible_navigation trigger in Android

### DIFF
--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -257,8 +257,9 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
 
   @Nullable private OnAccessibilityChangeListener onAccessibilityChangeListener;
 
-  // The widget within Flutter that currently sits beneath a cursor, e.g,
-  // beneath a stylus or mouse cursor.
+  // Whether there is assitive technology[s] running.
+  //
+  // Use the setter to update this property if needed.
   @VisibleForTesting public boolean hasAssistiveTechnology = false;
 
   private void setHasAssistiveTechnology(boolean value) {

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -257,17 +257,23 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
 
   @Nullable private OnAccessibilityChangeListener onAccessibilityChangeListener;
 
-  // Whether there is assitive technology[s] running.
+  // Whether the users are using assistive technologies to interact with the devices.
   //
-  // Use the setter to update this property if needed.
-  @VisibleForTesting public boolean hasAssistiveTechnology = false;
+  // The getter returns true when at least one of the assistive technologies is running:
+  // TalkBack, SwitchAccess, or VoiceAccess.
+  @VisibleForTesting
+  public boolean getAccessibleNavigation() {
+    return accessibleNavigation;
+  }
 
-  private void setHasAssistiveTechnology(boolean value) {
-    if (hasAssistiveTechnology == value) {
+  private boolean accessibleNavigation = false;
+
+  private void setAccessibleNavigation(boolean value) {
+    if (accessibleNavigation == value) {
       return;
     }
-    hasAssistiveTechnology = value;
-    if (hasAssistiveTechnology) {
+    accessibleNavigation = value;
+    if (accessibleNavigation) {
       accessibilityFeatureFlags |= AccessibilityFeature.ACCESSIBLE_NAVIGATION.value;
     } else {
       accessibilityFeatureFlags &= ~AccessibilityFeature.ACCESSIBLE_NAVIGATION.value;
@@ -349,7 +355,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
                 accessibilityChannel.setAccessibilityMessageHandler(accessibilityMessageHandler);
                 accessibilityChannel.onAndroidAccessibilityEnabled();
               } else {
-                setHasAssistiveTechnology(false);
+                setAccessibleNavigation(false);
                 accessibilityChannel.setAccessibilityMessageHandler(null);
                 accessibilityChannel.onAndroidAccessibilityDisabled();
               }
@@ -444,7 +450,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
                 return;
               }
               if (!isTouchExplorationEnabled) {
-                setHasAssistiveTechnology(false);
+                setAccessibleNavigation(false);
                 onTouchExplorationExit();
               }
 
@@ -566,7 +572,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
   // Suppressing Lint warning for new API, as we are version guarding all calls to newer APIs
   @SuppressLint("NewApi")
   public AccessibilityNodeInfo createAccessibilityNodeInfo(int virtualViewId) {
-    setHasAssistiveTechnology(true);
+    setAccessibleNavigation(true);
     if (virtualViewId >= MIN_ENGINE_GENERATED_NODE_ID) {
       // The node is in the engine generated range, and is provided by the accessibility view
       // embedder.

--- a/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -125,6 +125,44 @@ public class AccessibilityBridgeTest {
   }
 
   @Test
+  public void itSetsHasAssistiveTechnology() {
+    AccessibilityChannel mockChannel = mock(AccessibilityChannel.class);
+    AccessibilityViewEmbedder mockViewEmbedder = mock(AccessibilityViewEmbedder.class);
+    AccessibilityManager mockManager = mock(AccessibilityManager.class);
+    View mockRootView = mock(View.class);
+    Context context = mock(Context.class);
+    when(mockRootView.getContext()).thenReturn(context);
+    when(context.getPackageName()).thenReturn("test");
+    when(mockManager.isTouchExplorationEnabled()).thenReturn(false);
+    AccessibilityBridge accessibilityBridge =
+        setUpBridge(
+            /*rootAccessibilityView=*/ mockRootView,
+            /*accessibilityChannel=*/ mockChannel,
+            /*accessibilityManager=*/ mockManager,
+            /*contentResolver=*/ null,
+            /*accessibilityViewEmbedder=*/ mockViewEmbedder,
+            /*platformViewsAccessibilityDelegate=*/ null);
+    ArgumentCaptor<AccessibilityManager.TouchExplorationStateChangeListener> listenerCaptor =
+        ArgumentCaptor.forClass(AccessibilityManager.TouchExplorationStateChangeListener.class);
+    verify(mockManager).addTouchExplorationStateChangeListener(listenerCaptor.capture());
+
+    assertEquals(accessibilityBridge.hasAssistiveTechnology, false);
+    verify(mockChannel).setAccessibilityFeatures(0);
+    reset(mockChannel);
+
+    // Simulate assistive technology accessing accessibility tree.
+    accessibilityBridge.createAccessibilityNodeInfo(0);
+    verify(mockChannel).setAccessibilityFeatures(1);
+    assertEquals(accessibilityBridge.hasAssistiveTechnology, true);
+
+    // Simulate turning of talkback.
+    reset(mockChannel);
+    listenerCaptor.getValue().onTouchExplorationStateChanged(false);
+    verify(mockChannel).setAccessibilityFeatures(0);
+    assertEquals(accessibilityBridge.hasAssistiveTechnology, false);
+  }
+
+  @Test
   public void itDoesNotContainADescriptionIfScopesRoute() {
     AccessibilityBridge accessibilityBridge = setUpBridge();
 

--- a/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -155,7 +155,7 @@ public class AccessibilityBridgeTest {
     verify(mockChannel).setAccessibilityFeatures(1);
     assertEquals(accessibilityBridge.hasAssistiveTechnology, true);
 
-    // Simulate turning of talkback.
+    // Simulate turning off TalkBack.
     reset(mockChannel);
     listenerCaptor.getValue().onTouchExplorationStateChanged(false);
     verify(mockChannel).setAccessibilityFeatures(0);

--- a/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -125,7 +125,7 @@ public class AccessibilityBridgeTest {
   }
 
   @Test
-  public void itSetsHasAssistiveTechnology() {
+  public void itSetsAccessibleNavigation() {
     AccessibilityChannel mockChannel = mock(AccessibilityChannel.class);
     AccessibilityViewEmbedder mockViewEmbedder = mock(AccessibilityViewEmbedder.class);
     AccessibilityManager mockManager = mock(AccessibilityManager.class);
@@ -146,20 +146,20 @@ public class AccessibilityBridgeTest {
         ArgumentCaptor.forClass(AccessibilityManager.TouchExplorationStateChangeListener.class);
     verify(mockManager).addTouchExplorationStateChangeListener(listenerCaptor.capture());
 
-    assertEquals(accessibilityBridge.hasAssistiveTechnology, false);
+    assertEquals(accessibilityBridge.getAccessibleNavigation(), false);
     verify(mockChannel).setAccessibilityFeatures(0);
     reset(mockChannel);
 
     // Simulate assistive technology accessing accessibility tree.
     accessibilityBridge.createAccessibilityNodeInfo(0);
     verify(mockChannel).setAccessibilityFeatures(1);
-    assertEquals(accessibilityBridge.hasAssistiveTechnology, true);
+    assertEquals(accessibilityBridge.getAccessibleNavigation(), true);
 
     // Simulate turning off TalkBack.
     reset(mockChannel);
     listenerCaptor.getValue().onTouchExplorationStateChanged(false);
     verify(mockChannel).setAccessibilityFeatures(0);
-    assertEquals(accessibilityBridge.hasAssistiveTechnology, false);
+    assertEquals(accessibilityBridge.getAccessibleNavigation(), false);
   }
 
   @Test


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/109521

There isn't an API to detect whether voice access and switch access is running. Android team also shift away the strategy from exposing the state of assistive technology. Their strategies are exposing API that targets specific use case. For example, most app need to know whether assistive technologies are running to decide modal fadeout durations. So Android team expose adhoc getRecommendedTimeoutMillis for this use case. Unfortunately we can't use these adhoc API due to the reason mentioned in https://github.com/flutter/flutter/issues/109521#issuecomment-1218465190. Therefore, I implement this pr to workaround the issue.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
