### PR TITLE
[Linux][FlView] guard against disconnecting a disconnected signal

### DIFF
--- a/shell/platform/linux/fl_view.cc
+++ b/shell/platform/linux/fl_view.cc
@@ -606,7 +606,10 @@ static void fl_view_dispose(GObject* object) {
   g_clear_object(&self->engine);
   g_clear_object(&self->accessibility_plugin);
   g_clear_object(&self->keyboard_manager);
-  g_signal_handler_disconnect(self->keymap, self->keymap_keys_changed_cb_id);
+  if (self->keymap_keys_changed_cb_id != 0) {
+    g_signal_handler_disconnect(self->keymap, self->keymap_keys_changed_cb_id);
+    self->keymap_keys_changed_cb_id = 0;
+  }
   g_clear_object(&self->mouse_cursor_plugin);
   g_clear_object(&self->platform_plugin);
   g_list_free_full(self->gl_area_list, g_object_unref);


### PR DESCRIPTION
GObject's dispose() method [may be called multiple times](https://docs.gtk.org/gobject/concepts.html#reference-counts-and-cycles).

> This explains one of the rules about the dispose() handler stated earlier: the dispose() handler can be invoked multiple times.

Guard FlView against trying to disconnect the same signal multiple times by clearing the ID to avoid warnings when closing the window.

```
(bug:74019): GLib-GObject-WARNING **: 11:15:08.697: ../../../gobject/gsignal.c:2731: instance '0x55e1c3ea0200' has no handler with id '255'
```