### PR TITLE
[Impeller] Render Gaussian blurs into smaller textures and scale up with linear sampling

### DIFF
--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -90,7 +90,7 @@ std::optional<Snapshot> DirectionalGaussianBlurFilterContents::RenderFilter(
     return std::nullopt;
   }
 
-  // Input 0 snapshot and UV mapping.
+  // Input 0 snapshot.
 
   auto input_snapshot = inputs[0]->GetSnapshot(renderer, entity);
   if (!input_snapshot.has_value()) {
@@ -101,24 +101,51 @@ std::optional<Snapshot> DirectionalGaussianBlurFilterContents::RenderFilter(
     return input_snapshot.value();  // No blur to render.
   }
 
-  auto maybe_input_uvs = input_snapshot->GetCoverageUVs(coverage);
-  if (!maybe_input_uvs.has_value()) {
-    return std::nullopt;
-  }
-  auto input_uvs = maybe_input_uvs.value();
+  auto radius = Radius{blur_sigma_}.radius;
 
-  // Source override snapshot and UV mapping.
+  auto transformed_blur_radius =
+      entity.GetTransformation().TransformDirection(blur_direction_ * radius);
+
+  auto transformed_blur_radius_length = transformed_blur_radius.GetLength();
+
+  // A matrix that rotates the snapshot space such that the blur direction is
+  // +X.
+  auto texture_rotate = Matrix::MakeRotationZ(
+      transformed_blur_radius.Normalize().AngleTo({1, 0}));
+
+  // Converts local pass space to screen space. This is just the snapshot space
+  // rotated such that the blur direction is +X.
+  auto pass_transform = texture_rotate * input_snapshot->transform;
+
+  // The pass texture coverage, but rotated such that the blur is in the +X
+  // direction, and expanded to include the blur radius. This is used for UV
+  // projection and as a source for the pass size. Note that it doesn't matter
+  // which direction the space is rotated in when grabbing the pass size.
+  auto pass_texture_rect = Rect::MakeSize(input_snapshot->texture->GetSize())
+                               .TransformBounds(pass_transform);
+  pass_texture_rect.origin.x -= transformed_blur_radius_length;
+  pass_texture_rect.size.width += transformed_blur_radius_length * 2;
+
+  // Source override snapshot.
 
   auto source = source_override_ ? source_override_ : inputs[0];
   auto source_snapshot = source->GetSnapshot(renderer, entity);
   if (!source_snapshot.has_value()) {
     return std::nullopt;
   }
-  auto maybe_source_uvs = source_snapshot->GetCoverageUVs(coverage);
-  if (!maybe_source_uvs.has_value()) {
-    return std::nullopt;
-  }
-  auto source_uvs = maybe_source_uvs.value();
+
+  // UV mapping.
+
+  auto pass_uv_project = [&texture_rotate,
+                          &pass_texture_rect](Snapshot& input) {
+    auto uv_matrix = Matrix::MakeScale(1 / Vector2(input.texture->GetSize())) *
+                     (texture_rotate * input.transform).Invert();
+    return pass_texture_rect.GetTransformedPoints(uv_matrix);
+  };
+
+  auto input_uvs = pass_uv_project(input_snapshot.value());
+
+  auto source_uvs = pass_uv_project(source_snapshot.value());
 
   //----------------------------------------------------------------------------
   /// Render to texture.
@@ -139,9 +166,6 @@ std::optional<Snapshot> DirectionalGaussianBlurFilterContents::RenderFilter(
     });
     auto vtx_buffer = vtx_builder.CreateVertexBuffer(host_buffer);
 
-    auto transformed_blur = entity.GetTransformation().TransformDirection(
-        blur_direction_ * blur_sigma_.sigma);
-
     VS::FrameInfo frame_info;
     frame_info.mvp = Matrix::MakeOrthographic(ISize(1, 1));
 
@@ -150,11 +174,15 @@ std::optional<Snapshot> DirectionalGaussianBlurFilterContents::RenderFilter(
         input_snapshot->texture->GetYCoordScale();
     frag_info.alpha_mask_sampler_y_coord_scale =
         source_snapshot->texture->GetYCoordScale();
-    frag_info.blur_sigma = transformed_blur.GetLength();
-    frag_info.blur_radius = Radius{Sigma{frag_info.blur_sigma}}.radius;
-    frag_info.blur_direction = input_snapshot->transform.Invert()
-                                   .TransformDirection(transformed_blur)
-                                   .Normalize();
+
+    auto radius = Radius{transformed_blur_radius_length};
+    frag_info.blur_sigma = Sigma{radius}.sigma;
+    frag_info.blur_radius = radius.radius;
+
+    // The blur direction is in input UV space.
+    frag_info.blur_direction =
+        pass_transform.Invert().TransformDirection(Vector2(1, 0)).Normalize();
+
     frag_info.tile_mode = static_cast<Scalar>(tile_mode_);
     frag_info.src_factor = src_color_factor_;
     frag_info.inner_blur_factor = inner_blur_factor_;
@@ -182,7 +210,8 @@ std::optional<Snapshot> DirectionalGaussianBlurFilterContents::RenderFilter(
     return pass.AddCommand(cmd);
   };
 
-  auto out_texture = renderer.MakeSubpass(ISize(coverage.size), callback);
+  auto out_texture =
+      renderer.MakeSubpass(ISize(pass_texture_rect.size), callback);
   if (!out_texture) {
     return std::nullopt;
   }
@@ -192,9 +221,11 @@ std::optional<Snapshot> DirectionalGaussianBlurFilterContents::RenderFilter(
   sampler_desc.min_filter = MinMagFilter::kLinear;
   sampler_desc.mag_filter = MinMagFilter::kLinear;
 
-  return Snapshot{.texture = out_texture,
-                  .transform = Matrix::MakeTranslation(coverage.origin),
-                  .sampler_descriptor = sampler_desc};
+  return Snapshot{
+      .texture = out_texture,
+      .transform = texture_rotate.Invert() *
+                   Matrix::MakeTranslation(pass_texture_rect.origin),
+      .sampler_descriptor = sampler_desc};
 }
 
 std::optional<Rect> DirectionalGaussianBlurFilterContents::GetFilterCoverage(

--- a/impeller/geometry/geometry_unittests.cc
+++ b/impeller/geometry/geometry_unittests.cc
@@ -773,6 +773,35 @@ TEST(GeometryTest, PointAbs) {
   ASSERT_POINT_NEAR(a_abs, expected);
 }
 
+TEST(GeometryTest, PointAngleTo) {
+  // Negative result in the CCW (with up = -Y) direction.
+  {
+    Point a(1, 1);
+    Point b(1, -1);
+    Radians actual = a.AngleTo(b);
+    Radians expected = Radians{-kPi / 2};
+    ASSERT_FLOAT_EQ(actual.radians, expected.radians);
+  }
+
+  // Check the other direction to ensure the result is signed correctly.
+  {
+    Point a(1, -1);
+    Point b(1, 1);
+    Radians actual = a.AngleTo(b);
+    Radians expected = Radians{kPi / 2};
+    ASSERT_FLOAT_EQ(actual.radians, expected.radians);
+  }
+
+  // Differences in magnitude should have no impact on the result.
+  {
+    Point a(100, -100);
+    Point b(0.01, 0.01);
+    Radians actual = a.AngleTo(b);
+    Radians expected = Radians{kPi / 2};
+    ASSERT_FLOAT_EQ(actual.radians, expected.radians);
+  }
+}
+
 TEST(GeometryTest, CanUseVector3AssignmentOperators) {
   {
     Vector3 p(1, 2, 4);

--- a/impeller/geometry/point.h
+++ b/impeller/geometry/point.h
@@ -204,6 +204,10 @@ struct TPoint {
     return *this - axis * this->Dot(axis) * 2;
   }
 
+  constexpr Radians AngleTo(const TPoint& p) const {
+    return Radians{std::atan2(this->Cross(p), this->Dot(p))};
+  }
+
   constexpr bool IsZero() const { return x == 0 && y == 0; }
 };
 

--- a/impeller/geometry/point.h
+++ b/impeller/geometry/point.h
@@ -200,6 +200,10 @@ struct TPoint {
 
   constexpr Type Dot(const TPoint& p) const { return (x * p.x) + (y * p.y); }
 
+  constexpr Radians AngleTo(const TPoint& p) const {
+    return Radians{std::atan2(this->Cross(p), this->Dot(p))};
+  }
+
   constexpr TPoint Reflect(const TPoint& axis) const {
     return *this - axis * this->Dot(axis) * 2;
   }

--- a/impeller/geometry/point.h
+++ b/impeller/geometry/point.h
@@ -200,10 +200,6 @@ struct TPoint {
 
   constexpr Type Dot(const TPoint& p) const { return (x * p.x) + (y * p.y); }
 
-  constexpr Radians AngleTo(const TPoint& p) const {
-    return Radians{std::atan2(this->Cross(p), this->Dot(p))};
-  }
-
   constexpr TPoint Reflect(const TPoint& axis) const {
     return *this - axis * this->Dot(axis) * 2;
   }


### PR DESCRIPTION
This reduces blur cost by ~80% on the apps we're testing with virtually no difference in quality. We can still easily do a lot better than this -- I'm working on other improvements that I plan to land in follow-ups.

https://user-images.githubusercontent.com/919017/185361703-2c81ce93-e4e6-4572-9d5a-290cddc9efb6.mov