### PR TITLE
Add analyze_snapshot as a build dependency

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -90,7 +90,7 @@ group("flutter") {
     }
   }
 
-  # If enbaled, compile the SDK / snapshot.
+  # If enabled, compile the SDK / snapshot.
   if (!is_fuchsia) {
     public_deps += [ "//flutter/lib/snapshot:generate_snapshot_bins" ]
 
@@ -103,6 +103,9 @@ group("flutter") {
         # //flutter/lib/snapshot:generate_snapshot_bin will only build
         # gen_snapshot for the host and not the target.
         "//third_party/dart/runtime/bin:gen_snapshot",
+
+        # Built alongside gen_snapshot for 64 bit targets
+        "//third_party/dart/runtime/bin:analyze_snasphot",
 
         # Impeller artifacts - compiler and libtessellator
         "//flutter/impeller/compiler:impellerc",

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -105,7 +105,7 @@ group("flutter") {
         "//third_party/dart/runtime/bin:gen_snapshot",
 
         # Built alongside gen_snapshot for 64 bit targets
-        "//third_party/dart/runtime/bin:analyze_snasphot",
+        "//third_party/dart/runtime/bin:analyze_snapshot",
 
         # Impeller artifacts - compiler and libtessellator
         "//flutter/impeller/compiler:impellerc",


### PR DESCRIPTION
@zanderso 
reference: https://github.com/dart-lang/sdk/issues/47924

Recently added a standalone binary utility that allows for parsing of precompiled AOT snapshots in order to obtain metadata information from them. 

Goal is to get this bundled with Flutter engine distributions and built alongside `gen_snapshot` so that it is compiled with the correct flags in order to correctly parse snapshots.

Tests for the binary itself live inside of the dart-sdk repo, so do not know if a test is needed/what that would like in this repo