### PR TITLE
[CP] [Windows] Don't crash if GetPointerType is unsupported

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -2397,6 +2397,8 @@ FILE: ../../../flutter/shell/platform/windows/window_state.h
 FILE: ../../../flutter/shell/platform/windows/window_win32.cc
 FILE: ../../../flutter/shell/platform/windows/window_win32.h
 FILE: ../../../flutter/shell/platform/windows/window_win32_unittests.cc
+FILE: ../../../flutter/shell/platform/windows/windows_proc_table.cc
+FILE: ../../../flutter/shell/platform/windows/windows_proc_table.h
 FILE: ../../../flutter/shell/profiling/sampling_profiler.cc
 FILE: ../../../flutter/shell/profiling/sampling_profiler.h
 FILE: ../../../flutter/shell/profiling/sampling_profiler_unittest.cc

--- a/shell/platform/windows/BUILD.gn
+++ b/shell/platform/windows/BUILD.gn
@@ -110,6 +110,8 @@ source_set("flutter_windows_source") {
     "window_state.h",
     "window_win32.cc",
     "window_win32.h",
+    "windows_proc_table.cc",
+    "windows_proc_table.h",
   ]
 
   libs = [
@@ -195,6 +197,7 @@ executable("flutter_windows_unittests") {
     "testing/engine_modifier.h",
     "testing/flutter_window_win32_test.cc",
     "testing/flutter_window_win32_test.h",
+    "testing/mock_direct_manipulation.h",
     "testing/mock_gl_functions.h",
     "testing/mock_text_input_manager_win32.cc",
     "testing/mock_text_input_manager_win32.h",
@@ -202,6 +205,7 @@ executable("flutter_windows_unittests") {
     "testing/mock_window_binding_handler.h",
     "testing/mock_window_win32.cc",
     "testing/mock_window_win32.h",
+    "testing/mock_windows_proc_table.h",
     "testing/test_keyboard.cc",
     "testing/test_keyboard.h",
     "testing/test_keyboard_unittests.cc",

--- a/shell/platform/windows/direct_manipulation.h
+++ b/shell/platform/windows/direct_manipulation.h
@@ -22,6 +22,7 @@ class DirectManipulationEventHandler;
 class DirectManipulationOwner {
  public:
   explicit DirectManipulationOwner(WindowWin32* window);
+  virtual ~DirectManipulationOwner() = default;
   // Initialize a DirectManipulation viewport with specified width and height.
   // These should match the width and height of the application window.
   int Init(unsigned int width, unsigned int height);
@@ -34,7 +35,7 @@ class DirectManipulationOwner {
       WindowBindingHandlerDelegate* binding_handler_delegate);
   // Called when DM_POINTERHITTEST occurs with an acceptable pointer type. Will
   // start DirectManipulation for that interaction.
-  void SetContact(UINT contactId);
+  virtual void SetContact(UINT contactId);
   // Called to get updates from DirectManipulation. Should be called frequently
   // to provide smooth updates.
   void Update();
@@ -57,6 +58,8 @@ class DirectManipulationOwner {
   Microsoft::WRL::ComPtr<IDirectManipulationViewport> viewport_;
   // Child needed for operation of the DirectManipulation API.
   fml::RefPtr<DirectManipulationEventHandler> handler_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(DirectManipulationOwner);
 };
 
 // Implements DirectManipulation event handling interfaces, receives calls from

--- a/shell/platform/windows/testing/mock_direct_manipulation.h
+++ b/shell/platform/windows/testing/mock_direct_manipulation.h
@@ -1,0 +1,30 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_DIRECT_MANIPULATION_H_
+#define FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_DIRECT_MANIPULATION_H_
+
+#include "flutter/shell/platform/windows/direct_manipulation.h"
+#include "gmock/gmock.h"
+
+namespace flutter {
+namespace testing {
+
+/// Mock for the |DirectManipulationOwner| base class.
+class MockDirectManipulationOwner : public DirectManipulationOwner {
+ public:
+  explicit MockDirectManipulationOwner(WindowWin32* window)
+      : DirectManipulationOwner(window){};
+  virtual ~MockDirectManipulationOwner() = default;
+
+  MOCK_METHOD1(SetContact, void(UINT contact_id));
+
+ private:
+  FML_DISALLOW_COPY_AND_ASSIGN(MockDirectManipulationOwner);
+};
+
+}  // namespace testing
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_DIRECT_MANIPULATION_H_

--- a/shell/platform/windows/testing/mock_window_win32.cc
+++ b/shell/platform/windows/testing/mock_window_win32.cc
@@ -8,8 +8,10 @@ namespace flutter {
 namespace testing {
 MockWin32Window::MockWin32Window() : WindowWin32(){};
 MockWin32Window::MockWin32Window(
+    std::unique_ptr<WindowsProcTable> window_proc_table,
     std::unique_ptr<TextInputManagerWin32> text_input_manager)
-    : WindowWin32(std::move(text_input_manager)){};
+    : WindowWin32(std::move(window_proc_table),
+                  std::move(text_input_manager)){};
 
 MockWin32Window::~MockWin32Window() = default;
 
@@ -22,6 +24,11 @@ LRESULT MockWin32Window::Win32DefWindowProc(HWND hWnd,
                                             WPARAM wParam,
                                             LPARAM lParam) {
   return kWmResultDefault;
+}
+
+void MockWin32Window::SetDirectManipulationOwner(
+    std::unique_ptr<DirectManipulationOwner> owner) {
+  direct_manipulation_owner_ = std::move(owner);
 }
 
 LRESULT MockWin32Window::InjectWindowMessage(UINT const message,

--- a/shell/platform/windows/testing/mock_window_win32.h
+++ b/shell/platform/windows/testing/mock_window_win32.h
@@ -18,7 +18,8 @@ namespace testing {
 class MockWin32Window : public WindowWin32 {
  public:
   MockWin32Window();
-  MockWin32Window(std::unique_ptr<TextInputManagerWin32> text_input_manager);
+  MockWin32Window(std::unique_ptr<WindowsProcTable> windows_proc_table,
+                  std::unique_ptr<TextInputManagerWin32> text_input_manager);
   virtual ~MockWin32Window();
 
   // Prevent copying.
@@ -27,6 +28,10 @@ class MockWin32Window : public WindowWin32 {
 
   // Wrapper for GetCurrentDPI() which is a protected method.
   UINT GetDpi();
+
+  // Set the Direct Manipulation owner for testing purposes.
+  void SetDirectManipulationOwner(
+      std::unique_ptr<DirectManipulationOwner> owner);
 
   // Simulates a WindowProc message from the OS.
   LRESULT InjectWindowMessage(UINT const message,

--- a/shell/platform/windows/testing/mock_windows_proc_table.h
+++ b/shell/platform/windows/testing/mock_windows_proc_table.h
@@ -1,0 +1,30 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_WINDOWS_PROC_TABLE_H_
+#define FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_WINDOWS_PROC_TABLE_H_
+
+#include "flutter/shell/platform/windows/windows_proc_table.h"
+#include "gmock/gmock.h"
+
+namespace flutter {
+namespace testing {
+
+/// Mock for the |WindowsProcTable| base class.
+class MockWindowsProcTable : public WindowsProcTable {
+ public:
+  MockWindowsProcTable() = default;
+  virtual ~MockWindowsProcTable() = default;
+
+  MOCK_METHOD2(GetPointerType,
+               BOOL(UINT32 pointer_id, POINTER_INPUT_TYPE* pointer_type));
+
+ private:
+  FML_DISALLOW_COPY_AND_ASSIGN(MockWindowsProcTable);
+};
+
+}  // namespace testing
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_WINDOWS_PROC_TABLE_H_

--- a/shell/platform/windows/window_win32.cc
+++ b/shell/platform/windows/window_win32.cc
@@ -51,16 +51,22 @@ static const int kMaxTouchDeviceId = 128;
 
 }  // namespace
 
-WindowWin32::WindowWin32() : WindowWin32(nullptr) {}
+WindowWin32::WindowWin32() : WindowWin32(nullptr, nullptr) {}
 
 WindowWin32::WindowWin32(
+    std::unique_ptr<WindowsProcTable> windows_proc_table,
     std::unique_ptr<TextInputManagerWin32> text_input_manager)
     : touch_id_generator_(kMinTouchDeviceId, kMaxTouchDeviceId),
+      windows_proc_table_(std::move(windows_proc_table)),
       text_input_manager_(std::move(text_input_manager)) {
   // Get the DPI of the primary monitor as the initial DPI. If Per-Monitor V2 is
   // supported, |current_dpi_| should be updated in the
   // kWmDpiChangedBeforeParent message.
   current_dpi_ = GetDpiForHWND(nullptr);
+
+  if (windows_proc_table_ == nullptr) {
+    windows_proc_table_ = std::make_unique<WindowsProcTable>();
+  }
   if (text_input_manager_ == nullptr) {
     text_input_manager_ = std::make_unique<TextInputManagerWin32>();
   }
@@ -473,11 +479,11 @@ WindowWin32::HandleMessage(UINT const message,
       break;
     case DM_POINTERHITTEST: {
       if (direct_manipulation_owner_) {
-        UINT contactId = GET_POINTERID_WPARAM(wparam);
-        POINTER_INPUT_TYPE pointerType;
-        if (GetPointerType(contactId, &pointerType) &&
-            pointerType == PT_TOUCHPAD) {
-          direct_manipulation_owner_->SetContact(contactId);
+        UINT contact_id = GET_POINTERID_WPARAM(wparam);
+        POINTER_INPUT_TYPE pointer_type;
+        if (windows_proc_table_->GetPointerType(contact_id, &pointer_type) &&
+            pointer_type == PT_TOUCHPAD) {
+          direct_manipulation_owner_->SetContact(contact_id);
         }
       }
       break;

--- a/shell/platform/windows/window_win32.h
+++ b/shell/platform/windows/window_win32.h
@@ -18,6 +18,7 @@
 #include "flutter/shell/platform/windows/keyboard_manager_win32.h"
 #include "flutter/shell/platform/windows/sequential_id_generator.h"
 #include "flutter/shell/platform/windows/text_input_manager_win32.h"
+#include "flutter/shell/platform/windows/windows_proc_table.h"
 #include "flutter/third_party/accessibility/gfx/native_widget_types.h"
 
 namespace flutter {
@@ -28,7 +29,8 @@ namespace flutter {
 class WindowWin32 : public KeyboardManagerWin32::WindowDelegate {
  public:
   WindowWin32();
-  WindowWin32(std::unique_ptr<TextInputManagerWin32> text_input_manager);
+  WindowWin32(std::unique_ptr<WindowsProcTable> windows_proc_table,
+              std::unique_ptr<TextInputManagerWin32> text_input_manager);
   virtual ~WindowWin32();
 
   // Initializes as a child window with size using |width| and |height| and
@@ -253,6 +255,10 @@ class WindowWin32 : public KeyboardManagerWin32::WindowDelegate {
   // Keeps track of the last mouse coordinates by a WM_MOUSEMOVE message.
   double mouse_x_ = 0;
   double mouse_y_ = 0;
+
+  // Abstracts Windows APIs that may not be available on all supported versions
+  // of Windows.
+  std::unique_ptr<WindowsProcTable> windows_proc_table_;
 
   // Manages IME state.
   std::unique_ptr<TextInputManagerWin32> text_input_manager_;

--- a/shell/platform/windows/windows_proc_table.cc
+++ b/shell/platform/windows/windows_proc_table.cc
@@ -1,0 +1,28 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/windows/windows_proc_table.h"
+
+namespace flutter {
+
+WindowsProcTable::WindowsProcTable() {
+  user32_ = fml::NativeLibrary::Create("user32.dll");
+  get_pointer_type_ =
+      user32_->ResolveFunction<GetPointerType_*>("GetPointerType");
+}
+
+WindowsProcTable::~WindowsProcTable() {
+  user32_ = nullptr;
+}
+
+BOOL WindowsProcTable::GetPointerType(UINT32 pointer_id,
+                                      POINTER_INPUT_TYPE* pointer_type) {
+  if (!get_pointer_type_.has_value()) {
+    return FALSE;
+  }
+
+  return get_pointer_type_.value()(pointer_id, pointer_type);
+}
+
+}  // namespace flutter

--- a/shell/platform/windows/windows_proc_table.h
+++ b/shell/platform/windows/windows_proc_table.h
@@ -1,0 +1,42 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_WINDOWS_PROC_TABLE_H_
+#define FLUTTER_SHELL_PLATFORM_WINDOWS_WINDOWS_PROC_TABLE_H_
+
+#include "flutter/fml/native_library.h"
+
+#include <optional>
+
+namespace flutter {
+
+// Lookup table for Windows APIs that aren't available on all versions of
+// Windows.
+class WindowsProcTable {
+ public:
+  WindowsProcTable();
+  virtual ~WindowsProcTable();
+
+  // Retrieves the pointer type for a specified pointer.
+  //
+  // Used to react differently to touch or pen inputs. Returns false on failure.
+  // Available in Windows 8 and newer, otherwise returns false.
+  virtual BOOL GetPointerType(UINT32 pointer_id,
+                              POINTER_INPUT_TYPE* pointer_type);
+
+ private:
+  using GetPointerType_ = BOOL __stdcall(UINT32 pointerId,
+                                         POINTER_INPUT_TYPE* pointerType);
+
+  // The User32.dll library, used to resolve functions at runtime.
+  fml::RefPtr<fml::NativeLibrary> user32_;
+
+  std::optional<GetPointerType_*> get_pointer_type_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(WindowsProcTable);
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_WINDOWS_PROC_TABLE_H_


### PR DESCRIPTION
Cherry pick of https://github.com/flutter/engine/pull/35442 into [`flutter-3.2-candidate.5`](https://github.com/flutter/engine/tree/flutter-3.2-candidate.5)
Cherry pick issue: https://github.com/flutter/flutter/issues/109742

The engine's `Window` [references `GetPointerType`](https://github.com/flutter/engine/pull/31594/files#diff-25694b69c70103b6c4807eff1744dcaace40a2fe05d7acf61a97bd1f565051b0R475), which is [supported only on Windows 8 and after](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getpointertype). This causes Flutter apps to crash immediately on Windows 7.

This introduces `WindowsProcTable` to look up Windows APIs dynamically.

This bug was introduced in: https://github.com/flutter/engine/pull/31594

Fixes https://github.com/flutter/flutter/issues/109412

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
