### PR TITLE
[flow] fix RasterCache to round out device bounds

### DIFF
--- a/flow/raster_cache_unittests.cc
+++ b/flow/raster_cache_unittests.cc
@@ -454,6 +454,35 @@ TEST(RasterCache, DeviceRectRoundOutForDisplayList) {
   ASSERT_TRUE(display_list_item.Draw(paint_context, &canvas, &paint));
 }
 
+TEST(RasterCache, DeviceRectRoundOutRasterize) {
+  flutter::RasterCache cache(1);
+  FixedRefreshRateStopwatch raster_time;
+  FixedRefreshRateStopwatch ui_time;
+  PaintContextHolder paint_context_holder =
+      GetSamplePaintContextHolder(&cache, &raster_time, &ui_time);
+  auto& paint_context = paint_context_holder.paint_context;
+  int surface_width = -1;
+  int surface_height = -1;
+  auto dummy_draw_function = [&](SkCanvas* canvas) {
+    SkSurface* surface = canvas->getSurface();
+    surface_width = surface->width();
+    surface_height = surface->height();
+  };
+  RasterCache::Context r_context = {
+      // clang-format off
+        .gr_context         = paint_context.gr_context,
+        .dst_color_space    = paint_context.dst_color_space,
+        .matrix             = SkMatrix::I(),
+        .logical_rect       = SkRect::MakeLTRB(-52.1, -19.5, 878.6, 457.5),
+        .flow_type          = "RasterCacheFlow::DisplayList",
+      // clang-format on
+  };
+
+  cache.Rasterize(r_context, dummy_draw_function, nullptr);
+  ASSERT_EQ(surface_width, 932);
+  ASSERT_EQ(surface_height, 478);
+}
+
 TEST(RasterCache, NestedOpCountMetricUsedForDisplayList) {
   size_t threshold = 1;
   flutter::RasterCache cache(threshold);


### PR DESCRIPTION
With fractional coordinates, it's not enough to round up device bounds
width and height. Round out to get a large enough integer-size texture.

Fixes: flutter/flutter#107733
Fixes: flutter/flutter#107921
Fixes: flutter/flutter#109608

### Before
https://user-images.githubusercontent.com/140617/185625854-4bfc8a30-a820-4e4c-bd44-3ab1533430ec.mp4

### After
https://user-images.githubusercontent.com/140617/185625870-3949695d-67f7-4222-a016-fbdf85a5f431.mp4

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
