### PR TITLE
Include checkbox in check state update

### DIFF
--- a/shell/platform/common/accessibility_bridge.cc
+++ b/shell/platform/common/accessibility_bridge.cc
@@ -375,7 +375,8 @@ void AccessibilityBridge::SetIntAttributesFromFlutterUpdate(
   node_data.AddIntAttribute(ax::mojom::IntAttribute::kTextSelStart, sel_start);
   node_data.AddIntAttribute(ax::mojom::IntAttribute::kTextSelEnd, sel_end);
 
-  if (node_data.role == ax::mojom::Role::kRadioButton) {
+  if (node_data.role == ax::mojom::Role::kRadioButton ||
+      node_data.role == ax::mojom::Role::kCheckBox) {
     node_data.AddIntAttribute(
         ax::mojom::IntAttribute::kCheckedState,
         static_cast<int32_t>(

--- a/shell/platform/common/accessibility_bridge_unittests.cc
+++ b/shell/platform/common/accessibility_bridge_unittests.cc
@@ -337,7 +337,12 @@ TEST(AccessibilityBridgeTest, SliderHasSliderRole) {
   EXPECT_EQ(root_node->GetData().role, ax::mojom::Role::kSlider);
 }
 
-TEST(AccessibilityBridgeTest, canSetCheckboxChecked) {
+// Ensure that checkboxes have their checked status set apropriately
+// Previously, only Radios could have this flag updated
+// Resulted in the issue seen at
+// https://github.com/flutter/flutter/issues/96218
+// As this fix involved code run on all platforms, it is included here
+TEST(AccessibilityBridgeTest, CanSetCheckboxChecked) {
   std::shared_ptr<AccessibilityBridge> bridge =
       std::make_shared<AccessibilityBridge>(
           std::make_unique<TestAccessibilityBridgeDelegate>());
@@ -359,7 +364,8 @@ TEST(AccessibilityBridgeTest, canSetCheckboxChecked) {
 
   auto root_node = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
   EXPECT_EQ(root_node->GetData().role, ax::mojom::Role::kCheckBox);
-  EXPECT_EQ(root_node->GetData().GetCheckedState(), ax::mojom::CheckedState::kTrue);
+  EXPECT_EQ(
+      root_node->GetData().GetCheckedState(), ax::mojom::CheckedState::kTrue);
 }
 
 }  // namespace testing

--- a/shell/platform/common/accessibility_bridge_unittests.cc
+++ b/shell/platform/common/accessibility_bridge_unittests.cc
@@ -364,8 +364,8 @@ TEST(AccessibilityBridgeTest, CanSetCheckboxChecked) {
 
   auto root_node = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
   EXPECT_EQ(root_node->GetData().role, ax::mojom::Role::kCheckBox);
-  EXPECT_EQ(
-      root_node->GetData().GetCheckedState(), ax::mojom::CheckedState::kTrue);
+  EXPECT_EQ(root_node->GetData().GetCheckedState(),
+            ax::mojom::CheckedState::kTrue);
 }
 
 }  // namespace testing

--- a/shell/platform/common/accessibility_bridge_unittests.cc
+++ b/shell/platform/common/accessibility_bridge_unittests.cc
@@ -341,7 +341,7 @@ TEST(AccessibilityBridgeTest, SliderHasSliderRole) {
 // Previously, only Radios could have this flag updated
 // Resulted in the issue seen at
 // https://github.com/flutter/flutter/issues/96218
-// As this fix involved code run on all platforms, it is included here
+// As this fix involved code run on all platforms, it is included here.
 TEST(AccessibilityBridgeTest, CanSetCheckboxChecked) {
   std::shared_ptr<AccessibilityBridge> bridge =
       std::make_shared<AccessibilityBridge>(

--- a/shell/platform/common/accessibility_bridge_unittests.cc
+++ b/shell/platform/common/accessibility_bridge_unittests.cc
@@ -337,5 +337,30 @@ TEST(AccessibilityBridgeTest, SliderHasSliderRole) {
   EXPECT_EQ(root_node->GetData().role, ax::mojom::Role::kSlider);
 }
 
+TEST(AccessibilityBridgeTest, canSetCheckboxChecked) {
+  std::shared_ptr<AccessibilityBridge> bridge =
+      std::make_shared<AccessibilityBridge>(
+          std::make_unique<TestAccessibilityBridgeDelegate>());
+  FlutterSemanticsNode root;
+  root.id = 0;
+  root.label = "root";
+  root.hint = "";
+  root.value = "";
+  root.increased_value = "";
+  root.decreased_value = "";
+  root.child_count = 0;
+  root.custom_accessibility_actions_count = 0;
+  root.flags = static_cast<FlutterSemanticsFlag>(
+      FlutterSemanticsFlag::kFlutterSemanticsFlagHasCheckedState |
+      FlutterSemanticsFlag::kFlutterSemanticsFlagIsChecked);
+  bridge->AddFlutterSemanticsNodeUpdate(&root);
+
+  bridge->CommitUpdates();
+
+  auto root_node = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
+  EXPECT_EQ(root_node->GetData().role, ax::mojom::Role::kCheckBox);
+  EXPECT_EQ(root_node->GetData().GetCheckedState(), ax::mojom::CheckedState::kTrue);
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/shell/platform/windows/flutter_windows_view_unittests.cc
+++ b/shell/platform/windows/flutter_windows_view_unittests.cc
@@ -638,10 +638,13 @@ TEST(FlutterWindowsViewTest, CheckboxNativeState) {
 
   bridge->CommitUpdates();
 
-  auto root_node = bridge->GetFlutterPlatformNodeDelegateFromID(AccessibilityBridge::kRootNodeId).lock();
+  auto root_node = bridge
+                       ->GetFlutterPlatformNodeDelegateFromID(
+                           AccessibilityBridge::kRootNodeId)
+                       .lock();
   EXPECT_EQ(root_node->GetData().role, ax::mojom::Role::kCheckBox);
-  EXPECT_EQ(
-      root_node->GetData().GetCheckedState(), ax::mojom::CheckedState::kTrue);
+  EXPECT_EQ(root_node->GetData().GetCheckedState(),
+            ax::mojom::CheckedState::kTrue);
 
   // Get the IAccessible for the root node.
   IAccessible* native_view = root_node->GetNativeViewAccessible();
@@ -664,8 +667,8 @@ TEST(FlutterWindowsViewTest, CheckboxNativeState) {
   bridge->CommitUpdates();
   root_node = bridge->GetFlutterPlatformNodeDelegateFromID(AccessibilityBridge::kRootNodeId).lock();
   EXPECT_EQ(root_node->GetData().role, ax::mojom::Role::kCheckBox);
-  EXPECT_EQ(
-      root_node->GetData().GetCheckedState(), ax::mojom::CheckedState::kFalse);
+  EXPECT_EQ(root_node->GetData().GetCheckedState(),
+            ax::mojom::CheckedState::kFalse);
 
   // Get the IAccessible for the root node.
   native_view = root_node->GetNativeViewAccessible();

--- a/shell/platform/windows/flutter_windows_view_unittests.cc
+++ b/shell/platform/windows/flutter_windows_view_unittests.cc
@@ -597,5 +597,89 @@ TEST(FlutterWindowsViewTest, WindowRepaintTests) {
   EXPECT_TRUE(schedule_frame_called);
 }
 
+// Ensure that checkboxes have their checked status set apropriately
+// Previously, only Radios could have this flag updated
+// Resulted in the issue seen at
+// https://github.com/flutter/flutter/issues/96218
+// This test ensures that the native state of Checkboxes on Windows,
+// specifically, is updated as desired
+TEST(FlutterWindowsViewTest, CheckboxNativeState) {
+  std::unique_ptr<FlutterWindowsEngine> engine = GetTestEngine();
+  EngineModifier modifier(engine.get());
+  modifier.embedder_api().UpdateSemanticsEnabled =
+      [](FLUTTER_API_SYMBOL(FlutterEngine) engine, bool enabled) {
+        return kSuccess;
+      };
+
+  auto window_binding_handler =
+      std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();
+  FlutterWindowsView view(std::move(window_binding_handler));
+  view.SetEngine(std::move(engine));
+
+  // Enable semantics to instantiate accessibility bridge.
+  view.OnUpdateSemanticsEnabled(true);
+
+  auto bridge = view.GetEngine()->accessibility_bridge().lock();
+  ASSERT_TRUE(bridge);
+
+  FlutterSemanticsNode root{sizeof(FlutterSemanticsNode), 0};
+  root.id = 0;
+  root.label = "root";
+  root.hint = "";
+  root.value = "";
+  root.increased_value = "";
+  root.decreased_value = "";
+  root.child_count = 0;
+  root.custom_accessibility_actions_count = 0;
+  root.flags = static_cast<FlutterSemanticsFlag>(
+      FlutterSemanticsFlag::kFlutterSemanticsFlagHasCheckedState |
+      FlutterSemanticsFlag::kFlutterSemanticsFlagIsChecked);
+  bridge->AddFlutterSemanticsNodeUpdate(&root);
+
+  bridge->CommitUpdates();
+
+  auto root_node = bridge->GetFlutterPlatformNodeDelegateFromID(AccessibilityBridge::kRootNodeId).lock();
+  EXPECT_EQ(root_node->GetData().role, ax::mojom::Role::kCheckBox);
+  EXPECT_EQ(
+      root_node->GetData().GetCheckedState(), ax::mojom::CheckedState::kTrue);
+
+  // Get the IAccessible for the root node.
+  IAccessible* native_view = root_node->GetNativeViewAccessible();
+  ASSERT_TRUE(native_view != nullptr);
+
+  // Look up against the node itself (not one of its children)
+  VARIANT varchild = {};
+  varchild.vt = VT_I4;
+
+  // Verify the checkbox is checked.
+  varchild.lVal = CHILDID_SELF;
+  VARIANT native_state = {};
+  ASSERT_TRUE(SUCCEEDED(native_view->get_accState(varchild, &native_state)));
+  EXPECT_TRUE(native_state.lVal & STATE_SYSTEM_CHECKED);
+
+  // Test unchecked too
+  root.flags = static_cast<FlutterSemanticsFlag>(
+      FlutterSemanticsFlag::kFlutterSemanticsFlagHasCheckedState);
+  bridge->AddFlutterSemanticsNodeUpdate(&root);
+  bridge->CommitUpdates();
+  root_node = bridge->GetFlutterPlatformNodeDelegateFromID(AccessibilityBridge::kRootNodeId).lock();
+  EXPECT_EQ(root_node->GetData().role, ax::mojom::Role::kCheckBox);
+  EXPECT_EQ(
+      root_node->GetData().GetCheckedState(), ax::mojom::CheckedState::kFalse);
+
+  // Get the IAccessible for the root node.
+  native_view = root_node->GetNativeViewAccessible();
+
+  // Look up against the node itself (not one of its children)
+  varchild = {};
+  varchild.vt = VT_I4;
+
+  // Verify the checkbox is checked.
+  varchild.lVal = CHILDID_SELF;
+  native_state = {};
+  ASSERT_TRUE(SUCCEEDED(native_view->get_accState(varchild, &native_state)));
+  EXPECT_FALSE(native_state.lVal & STATE_SYSTEM_CHECKED);
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/shell/platform/windows/flutter_windows_view_unittests.cc
+++ b/shell/platform/windows/flutter_windows_view_unittests.cc
@@ -665,7 +665,10 @@ TEST(FlutterWindowsViewTest, CheckboxNativeState) {
       FlutterSemanticsFlag::kFlutterSemanticsFlagHasCheckedState);
   bridge->AddFlutterSemanticsNodeUpdate(&root);
   bridge->CommitUpdates();
-  root_node = bridge->GetFlutterPlatformNodeDelegateFromID(AccessibilityBridge::kRootNodeId).lock();
+  root_node = bridge
+                  ->GetFlutterPlatformNodeDelegateFromID(
+                      AccessibilityBridge::kRootNodeId)
+                  .lock();
   EXPECT_EQ(root_node->GetData().role, ax::mojom::Role::kCheckBox);
   EXPECT_EQ(root_node->GetData().GetCheckedState(),
             ax::mojom::CheckedState::kFalse);

--- a/shell/platform/windows/flutter_windows_view_unittests.cc
+++ b/shell/platform/windows/flutter_windows_view_unittests.cc
@@ -602,7 +602,7 @@ TEST(FlutterWindowsViewTest, WindowRepaintTests) {
 // Resulted in the issue seen at
 // https://github.com/flutter/flutter/issues/96218
 // This test ensures that the native state of Checkboxes on Windows,
-// specifically, is updated as desired
+// specifically, is updated as desired.
 TEST(FlutterWindowsViewTest, CheckboxNativeState) {
   std::unique_ptr<FlutterWindowsEngine> engine = GetTestEngine();
   EngineModifier modifier(engine.get());


### PR DESCRIPTION
Previously, the accessibility semantics for Checkboxes on Windows platform applications did not update when the state (checked/unchecked) of the widget changed. It seems to me that this was the result of an overly-restrictive check that only propagated updates to this status for Radio widgets, excluding Checkboxes. That is fixed in this PR and a unit test is added to ensure that state changes to Checkboxes are properly reflected.

Addresses issue #96218 in the Flutter repo.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
