### PR TITLE
[Windows] Set Platform.executable on engine start

### DIFF
--- a/shell/platform/windows/fixtures/main.dart
+++ b/shell/platform/windows/fixtures/main.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io' as io;
 import 'dart:ui' as ui;
 
 // Signals a waiting latch in the native test.
@@ -9,6 +10,9 @@ void signal() native 'Signal';
 
 // Signals a waiting latch in the native test, passing a boolean value.
 void signalBoolValue(bool value) native 'SignalBoolValue';
+
+// Signals a waiting latch in the native test, passing a string value.
+void signalStringValue(String value) native 'SignalStringValue';
 
 // Signals a waiting latch in the native test, which returns a value to the fixture.
 bool signalBoolReturn() native 'SignalBoolReturn';
@@ -37,6 +41,11 @@ void verifyNativeFunctionWithParameters() {
 void verifyNativeFunctionWithReturn() {
   bool value = signalBoolReturn();
   signalBoolValue(value);
+}
+
+@pragma('vm:entry-point')
+void readPlatformExecutable() {
+  signalStringValue(io.Platform.executable);
 }
 
 @pragma('vm:entry-point')

--- a/shell/platform/windows/flutter_windows_engine.h
+++ b/shell/platform/windows/flutter_windows_engine.h
@@ -220,6 +220,9 @@ class FlutterWindowsEngine {
     root_isolate_create_callback_ = callback;
   }
 
+  // Returns the executable name for this process or "Flutter" if unknown.
+  std::string GetExecutableName() const;
+
  private:
   // Allows swapping out embedder_api_ calls in tests.
   friend class EngineModifier;

--- a/shell/platform/windows/flutter_windows_engine_unittests.cc
+++ b/shell/platform/windows/flutter_windows_engine_unittests.cc
@@ -404,5 +404,10 @@ TEST(FlutterWindowsEngine, SetNextFrameCallback) {
   EXPECT_TRUE(called);
 }
 
+TEST(FlutterWindowsEngine, GetExecutableName) {
+  std::unique_ptr<FlutterWindowsEngine> engine = GetTestEngine();
+  EXPECT_EQ(engine->GetExecutableName(), "flutter_windows_unittests.exe");
+}
+
 }  // namespace testing
 }  // namespace flutter


### PR DESCRIPTION
When setting `FlutterProjectArgs.command_line_argv` prior to launching the
engine, we were previously setting a placeholder value rather than the
executable name. This resulted in `Platform.executable` (from dart:io)
returning "placeholder" in application code.

This updates the Windows implementation for consistency with macOS and
guarantees that Platform.executable will return a reasonable value in
Dart code.

Note that this does not affect `Platform.resolvedExecutable`, which returns
a full, resolved path, and is implemented in the Dart runtime itself.
Previously the code:
```dart
print(Platform.executable);
print(Platform.resolvedExecutable);
```
resulted in the following output on Windows:
```
flutter: placeholder
flutter: C:\path\to\project\build\windows\runner\Debug\project.exe
```
after this patch, it results in:
```
flutter: project.exe
flutter: C:\path\to\project\build\windows\runner\Debug\project.exe
```

Issue: https://github.com/flutter/flutter/issues/83921


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
