### PR TITLE
MacOS framework was simplified to remove an internal zip.

### DIFF
--- a/build/archives/BUILD.gn
+++ b/build/archives/BUILD.gn
@@ -246,12 +246,6 @@ if (is_mac) {
     deps = [ "//flutter/lib/snapshot:create_macos_gen_snapshots" ]
   }
 
-  group("macos_flutter_framework") {
-    deps = [
-      "//flutter/shell/platform/darwin/macos:macos_flutter_framework_archive",
-    ]
-  }
-
   zip_bundle("archive_gen_snapshot") {
     deps = [
       ":snapshot_entitlement_config",

--- a/build/zip.py
+++ b/build/zip.py
@@ -14,7 +14,13 @@ import sys
 
 def _zip_dir(path, zip_file, prefix):
   path = path.rstrip('/\\')
-  for root, _, files in os.walk(path):
+  for root, directories, files in os.walk(path):
+    for directory in directories:
+      if os.path.islink(os.path.join(root, directory)):
+        add_symlink(
+            zip_file, os.path.join(root, directory),
+            os.path.join(root.replace(path, prefix), directory)
+        )
     for file in files:
       if os.path.islink(os.path.join(root, file)):
         add_symlink(

--- a/build/zip.py
+++ b/build/zip.py
@@ -18,8 +18,9 @@ def _zip_dir(path, zip_file, prefix):
     for directory in directories:
       if os.path.islink(os.path.join(root, directory)):
         add_symlink(
-            zip_file, os.path.join(root, directory),
-            os.path.join(root.replace(path, prefix), directory)
+            zip_file,
+            os.path.join(root, '%s/' % directory),
+            os.path.join(root.replace(path, prefix), directory),
         )
     for file in files:
       if os.path.islink(os.path.join(root, file)):

--- a/shell/platform/darwin/macos/BUILD.gn
+++ b/shell/platform/darwin/macos/BUILD.gn
@@ -325,8 +325,15 @@ if (build_glfw_shell) {
 }
 
 zip_bundle("zip_macos_flutter_framework") {
-  deps = [ ":_generate_symlinks" ]
-  output = "tmp/FlutterMacOS.framework.zip"
+  deps = [
+    ":_generate_symlinks",
+    ":macos_framework_without_entitlement_config",
+  ]
+  prefix = "$full_platform_name-$flutter_runtime_mode/"
+  if (flutter_runtime_mode == "debug") {
+    prefix = "$full_platform_name/"
+  }
+  output = "${prefix}FlutterMacOS.framework.zip"
   visibility = [ ":*" ]
   files = [
     {
@@ -342,26 +349,4 @@ generated_file("macos_framework_without_entitlement_config") {
   data_keys = [ "macos_framework_without_entitlement" ]
 
   deps = [ ":_generate_symlinks" ]
-}
-
-zip_bundle("macos_flutter_framework_archive") {
-  deps = [
-    ":macos_framework_without_entitlement_config",
-    ":zip_macos_flutter_framework",
-  ]
-  prefix = "$full_platform_name-$flutter_runtime_mode/"
-  if (flutter_runtime_mode == "debug") {
-    prefix = "$full_platform_name/"
-  }
-  output = "${prefix}FlutterMacOS.framework.zip"
-  files = [
-    {
-      source = "$root_out_dir/zip_archives/tmp/FlutterMacOS.framework.zip"
-      destination = "FlutterMacOS.framework.zip"
-    },
-    {
-      source = "$target_gen_dir/framework_without_entitlements.txt"
-      destination = "without_entitlements.txt"
-    },
-  ]
 }


### PR DESCRIPTION
This PR is removing the nested zip file and removing all the boilerplate
GN used to generate the zip within the zip.

Bug: https://github.com/flutter/flutter/issues/81855

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
