### PR TITLE
[Linux] Set Platform.executable on startup

### DIFF
--- a/shell/platform/linux/BUILD.gn
+++ b/shell/platform/linux/BUILD.gn
@@ -158,6 +158,7 @@ source_set("flutter_linux_sources") {
   ]
 
   deps = [
+    "//flutter/fml",
     "//flutter/shell/platform/common:common_cpp_input",
     "//flutter/shell/platform/common:common_cpp_switches",
     "//flutter/shell/platform/embedder:embedder_headers",

--- a/shell/platform/linux/fl_engine.cc
+++ b/shell/platform/linux/fl_engine.cc
@@ -8,6 +8,7 @@
 
 #include <cstring>
 
+#include "flutter/fml/paths.h"
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/linux/fl_binary_messenger_private.h"
 #include "flutter/shell/platform/linux/fl_dart_project_private.h"
@@ -483,10 +484,11 @@ gboolean fl_engine_start(FlEngine* self, GError** error) {
 
   g_autoptr(GPtrArray) command_line_args =
       fl_dart_project_get_switches(self->project);
-  // FlutterProjectArgs expects a full argv, so when processing it for flags
-  // the first item is treated as the executable and ignored. Add a dummy value
-  // so that all switches are used.
-  g_ptr_array_insert(command_line_args, 0, g_strdup("flutter"));
+  auto executable_path = fml::paths::GetExecutablePath();
+  std::string executable_path_str =
+      executable_path.first ? executable_path.second : "Flutter";
+  g_ptr_array_insert(command_line_args, 0,
+                     g_strdup(executable_path_str.c_str()));
 
   gchar** dart_entrypoint_args =
       fl_dart_project_get_dart_entrypoint_arguments(self->project);


### PR DESCRIPTION
**Note: this is WIP. Pushing so I don't forget to pick this up on Monday.**

When setting `FlutterProjectArgs.command_line_argv` prior to launching the
engine, we were previously setting a placeholder value rather than the
executable name. This resulted in `Platform.executable` (from dart:io)
returning "placeholder" in application code.

This updates the Linux implementation for consistency with macOS and
Windows and guarantees that Platform.executable will return a reasonable
value in Dart code.

Note that this does not affect `Platform.resolvedExecutable`, which returns
a full, resolved path, and is implemented in the Dart runtime itself.

Previously the code:
```dart
print(Platform.executable);
print(Platform.resolvedExecutable);
```
resulted in the following output on Linux:
```
flutter: flutter
flutter: /path/to/project/build/linux/runner/Debug/project
```

after this patch, it results in:
```
flutter: /path/to/project/build/linux/runner/Debug/project
flutter: /path/to/project/build/linux/runner/Debug/project
```

This is a follow-up to: https://github.com/flutter/engine/pull/33127

Issue: https://github.com/flutter/flutter/issues/83921

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
