### PR TITLE
Write link content rather than source path

### DIFF
--- a/build/zip.py
+++ b/build/zip.py
@@ -19,8 +19,8 @@ def _zip_dir(path, zip_file, prefix):
       if os.path.islink(os.path.join(root, directory)):
         add_symlink(
             zip_file,
-            os.path.join(root, '%s/' % directory),
-            os.path.join(root.replace(path, prefix), directory),
+            os.path.join(root, directory, ''),
+            os.path.join(root.replace(path, prefix), directory, ''),
         )
     for file in files:
       if os.path.islink(os.path.join(root, file)):

--- a/build/zip.py
+++ b/build/zip.py
@@ -20,7 +20,7 @@ def _zip_dir(path, zip_file, prefix):
         add_symlink(
             zip_file,
             os.path.join(root, directory, ''),
-            os.path.join(root.replace(path, prefix), directory, ''),
+            os.path.join(root.replace(path, prefix), directory),
         )
     for file in files:
       if os.path.islink(os.path.join(root, file)):

--- a/build/zip.py
+++ b/build/zip.py
@@ -6,10 +6,10 @@
 
 import argparse
 import json
-import zipfile
 import os
 import stat
 import sys
+import zipfile
 
 
 def _zip_dir(path, zip_file, prefix):
@@ -19,7 +19,7 @@ def _zip_dir(path, zip_file, prefix):
       if os.path.islink(os.path.join(root, directory)):
         add_symlink(
             zip_file,
-            os.path.join(root, directory, ''),
+            os.path.join(root, directory),
             os.path.join(root.replace(path, prefix), directory),
         )
     for file in files:
@@ -50,7 +50,7 @@ def add_symlink(zip_file, source, target):
       | stat.S_IWGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IWOTH | stat.S_IXOTH
   )
   zip_info.external_attr = unix_st_mode << 16
-  zip_file.writestr(zip_info, source)
+  zip_file.writestr(zip_info, os.readlink(source))
 
 
 def main(args):


### PR DESCRIPTION
zip.py was not creating symlinks correctly because instead of reading the symlink content and writing to the zip file we were providing the path to the source file. The source to the file was translated to a full path using the build machine directory instead of the relative path to the extraction folder. 

Bug: https://github.com/flutter/flutter/issues/81855

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
