### PR TITLE
[Impeller] Support binding Vector3s in GLES backend

### DIFF
--- a/impeller/renderer/backend/gles/buffer_bindings_gles.cc
+++ b/impeller/renderer/backend/gles/buffer_bindings_gles.cc
@@ -234,6 +234,13 @@ bool BufferBindingsGLES::BindUniformBuffer(const ProcTableGLES& gl,
                               buffer_ptr + member.offset)  // data
             );
             continue;
+          case sizeof(Vector3):
+            gl.Uniform3fv(location->second,  // location
+                          1u,                // count
+                          reinterpret_cast<const GLfloat*>(
+                              buffer_ptr + member.offset)  // data
+            );
+            continue;
           case sizeof(Vector2):
             gl.Uniform2fv(location->second,  // location
                           1u,                // count

--- a/impeller/renderer/backend/gles/proc_table_gles.h
+++ b/impeller/renderer/backend/gles/proc_table_gles.h
@@ -157,6 +157,7 @@ struct GLProc {
   PROC(Uniform1fv);                          \
   PROC(Uniform1i);                           \
   PROC(Uniform2fv);                          \
+  PROC(Uniform3fv);                          \
   PROC(Uniform4fv);                          \
   PROC(UniformMatrix4fv);                    \
   PROC(UseProgram);                          \


### PR DESCRIPTION
Noticed while working on impeller-cmake-example.