### PR TITLE
Revert "Make ShaderMaskLayer code builder aware"

### DIFF
--- a/flow/layers/shader_mask_layer.cc
+++ b/flow/layers/shader_mask_layer.cc
@@ -54,32 +54,19 @@ void ShaderMaskLayer::Paint(PaintContext& context) const {
       return;
     }
   }
-  auto shader_rect = SkRect::MakeWH(mask_rect_.width(), mask_rect_.height());
 
-  if (context.leaf_nodes_builder) {
-    context.builder_multiplexer->saveLayer(&paint_bounds(),
-                                           cache_paint.dl_paint());
-    PaintChildren(context);
+  Layer::AutoSaveLayer save = Layer::AutoSaveLayer::Create(
+      context, paint_bounds(), cache_paint.sk_paint());
+  PaintChildren(context);
 
-    DlPaint dl_paint;
-    dl_paint.setBlendMode(blend_mode_);
-    if (shader_) {
-      dl_paint.setColorSource(shader_.get());
-    }
-    context.leaf_nodes_builder->translate(mask_rect_.left(), mask_rect_.top());
-    context.leaf_nodes_builder->drawRect(shader_rect, dl_paint);
-  } else {
-    Layer::AutoSaveLayer save = Layer::AutoSaveLayer::Create(
-        context, paint_bounds(), cache_paint.sk_paint());
-    PaintChildren(context);
-    SkPaint paint;
-    paint.setBlendMode(ToSk(blend_mode_));
-    if (shader_) {
-      paint.setShader(shader_->skia_object());
-    }
-    context.leaf_nodes_canvas->translate(mask_rect_.left(), mask_rect_.top());
-    context.leaf_nodes_canvas->drawRect(shader_rect, paint);
+  SkPaint paint;
+  paint.setBlendMode(ToSk(blend_mode_));
+  if (shader_) {
+    paint.setShader(shader_->skia_object());
   }
+  context.leaf_nodes_canvas->translate(mask_rect_.left(), mask_rect_.top());
+  context.leaf_nodes_canvas->drawRect(
+      SkRect::MakeWH(mask_rect_.width(), mask_rect_.height()), paint);
 }
 
 }  // namespace flutter

--- a/flow/layers/shader_mask_layer_unittests.cc
+++ b/flow/layers/shader_mask_layer_unittests.cc
@@ -373,18 +373,17 @@ TEST_F(ShaderMaskLayerTest, OpacityInheritance) {
     {
       expected_builder.translate(offset.fX, offset.fY);
       /* ShaderMaskLayer::Paint() */ {
-        DlPaint sl_paint;
-        sl_paint.setColor(opacity_alpha << 24);
-        expected_builder.saveLayer(&child_path.getBounds(), &sl_paint);
+        expected_builder.setColor(opacity_alpha << 24);
+        expected_builder.saveLayer(&child_path.getBounds(), true);
         {
           /* child layer paint */ {
-            expected_builder.drawPath(child_path,
-                                      DlPaint().setColor(0xFF000000));
+            expected_builder.setColor(0xFF000000);
+            expected_builder.drawPath(child_path);
           }
           expected_builder.translate(mask_rect.fLeft, mask_rect.fTop);
+          expected_builder.setBlendMode(DlBlendMode::kSrc);
           expected_builder.drawRect(
-              SkRect::MakeWH(mask_rect.width(), mask_rect.height()),
-              DlPaint().setBlendMode(DlBlendMode::kSrc));
+              SkRect::MakeWH(mask_rect.width(), mask_rect.height()));
         }
         expected_builder.restore();
       }


### PR DESCRIPTION
Reverts flutter/engine#35534

This broke Google tests. Googlers, see b/243217201 before relanding.

This caused visual regressions in what I believe are related to transitions between screens, but I defer to a @flar and @dnfield to root cause this.