### PR TITLE
[Impeller] Apply effects to layers

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -1227,5 +1227,31 @@ TEST_P(AiksTest, CanRenderClippedLayers) {
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
+TEST_P(AiksTest, SaveLayerFiltersScaleWithTransform) {
+  Canvas canvas;
+  canvas.Scale(GetContentScale());
+  canvas.Translate(Vector2(100, 100));
+
+  auto texture = std::make_shared<Image>(CreateTextureForFixture("boston.jpg"));
+  auto draw_image_layer = [&canvas, &texture](Paint paint) {
+    canvas.SaveLayer(paint);
+    canvas.DrawImage(texture, {}, Paint{});
+    canvas.Restore();
+  };
+
+  Paint effect_paint;
+  effect_paint.mask_blur_descriptor = Paint::MaskBlurDescriptor{
+      .style = FilterContents::BlurStyle::kNormal,
+      .sigma = Sigma{6},
+  };
+  draw_image_layer(effect_paint);
+
+  canvas.Translate(Vector2(300, 300));
+  canvas.Scale(Vector2(3, 3));
+  draw_image_layer(effect_paint);
+
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/impeller/aiks/paint.cc
+++ b/impeller/aiks/paint.cc
@@ -42,17 +42,18 @@ std::shared_ptr<Contents> Paint::CreateContentsForEntity(Path path,
 
 std::shared_ptr<Contents> Paint::WithFilters(
     std::shared_ptr<Contents> input,
-    std::optional<bool> is_solid_color) const {
+    std::optional<bool> is_solid_color,
+    const Matrix& effect_transform) const {
   bool is_solid_color_val = is_solid_color.value_or(!color_source);
 
   if (mask_blur_descriptor.has_value()) {
-    input = mask_blur_descriptor->CreateMaskBlur(FilterInput::Make(input),
-                                                 is_solid_color_val);
+    input = mask_blur_descriptor->CreateMaskBlur(
+        FilterInput::Make(input), is_solid_color_val, effect_transform);
   }
 
   if (image_filter.has_value()) {
     const ImageFilterProc& filter = image_filter.value();
-    input = filter(FilterInput::Make(input));
+    input = filter(FilterInput::Make(input), effect_transform);
   }
 
   if (color_filter.has_value()) {
@@ -65,12 +66,14 @@ std::shared_ptr<Contents> Paint::WithFilters(
 
 std::shared_ptr<FilterContents> Paint::MaskBlurDescriptor::CreateMaskBlur(
     FilterInput::Ref input,
-    bool is_solid_color) const {
+    bool is_solid_color,
+    const Matrix& effect_transform) const {
   if (is_solid_color) {
-    return FilterContents::MakeGaussianBlur(input, sigma, sigma, style,
-                                            Entity::TileMode::kDecal);
+    return FilterContents::MakeGaussianBlur(
+        input, sigma, sigma, style, Entity::TileMode::kDecal, effect_transform);
   }
-  return FilterContents::MakeBorderMaskBlur(input, sigma, sigma, style);
+  return FilterContents::MakeBorderMaskBlur(input, sigma, sigma, style,
+                                            effect_transform);
 }
 
 }  // namespace impeller

--- a/impeller/aiks/paint.h
+++ b/impeller/aiks/paint.h
@@ -19,12 +19,15 @@
 namespace impeller {
 
 struct Paint {
-  using ImageFilterProc =
+  using ImageFilterProc = std::function<std::shared_ptr<FilterContents>(
+      FilterInput::Ref,
+      const Matrix& effect_transform)>;
+  using ColorFilterProc =
       std::function<std::shared_ptr<FilterContents>(FilterInput::Ref)>;
-  using ColorFilterProc = ImageFilterProc;
-  using MaskFilterProc =
-      std::function<std::shared_ptr<FilterContents>(FilterInput::Ref,
-                                                    bool is_solid_color)>;
+  using MaskFilterProc = std::function<std::shared_ptr<FilterContents>(
+      FilterInput::Ref,
+      bool is_solid_color,
+      const Matrix& effect_transform)>;
   using ColorSourceProc = std::function<std::shared_ptr<ColorSourceContents>()>;
 
   enum class Style {
@@ -36,8 +39,10 @@ struct Paint {
     FilterContents::BlurStyle style;
     Sigma sigma;
 
-    std::shared_ptr<FilterContents> CreateMaskBlur(FilterInput::Ref input,
-                                                   bool is_solid_color) const;
+    std::shared_ptr<FilterContents> CreateMaskBlur(
+        FilterInput::Ref input,
+        bool is_solid_color,
+        const Matrix& effect_matrix) const;
   };
 
   Color color = Color::Black();
@@ -67,7 +72,8 @@ struct Paint {
   ///             original contents is returned.
   std::shared_ptr<Contents> WithFilters(
       std::shared_ptr<Contents> input,
-      std::optional<bool> is_solid_color = std::nullopt) const;
+      std::optional<bool> is_solid_color = std::nullopt,
+      const Matrix& effect_transform = Matrix()) const;
 
   std::shared_ptr<Contents> CreateContentsForEntity(Path path = {},
                                                     bool cover = false) const;

--- a/impeller/aiks/paint_pass_delegate.cc
+++ b/impeller/aiks/paint_pass_delegate.cc
@@ -33,12 +33,14 @@ bool PaintPassDelegate::CanCollapseIntoParentPass() {
 
 // |EntityPassDelgate|
 std::shared_ptr<Contents> PaintPassDelegate::CreateContentsForSubpassTarget(
-    std::shared_ptr<Texture> target) {
+    std::shared_ptr<Texture> target,
+    const Matrix& effect_transform) {
   auto contents = TextureContents::MakeRect(Rect::MakeSize(target->GetSize()));
   contents->SetTexture(target);
   contents->SetSourceRect(Rect::MakeSize(target->GetSize()));
   contents->SetOpacity(paint_.color.alpha);
-  return contents;
+
+  return paint_.WithFilters(std::move(contents), false, effect_transform);
 }
 
 }  // namespace impeller

--- a/impeller/aiks/paint_pass_delegate.h
+++ b/impeller/aiks/paint_pass_delegate.h
@@ -30,7 +30,8 @@ class PaintPassDelegate final : public EntityPassDelegate {
 
   // |EntityPassDelgate|
   std::shared_ptr<Contents> CreateContentsForSubpassTarget(
-      std::shared_ptr<Texture> target) override;
+      std::shared_ptr<Texture> target,
+      const Matrix& effect_transform) override;
 
  private:
   const Paint paint_;

--- a/impeller/entity/contents/filters/blend_filter_contents.cc
+++ b/impeller/entity/contents/filters/blend_filter_contents.cc
@@ -309,6 +309,7 @@ std::optional<Snapshot> BlendFilterContents::RenderFilter(
     const FilterInput::Vector& inputs,
     const ContentContext& renderer,
     const Entity& entity,
+    const Matrix& effect_transform,
     const Rect& coverage) const {
   if (inputs.empty()) {
     return std::nullopt;

--- a/impeller/entity/contents/filters/blend_filter_contents.h
+++ b/impeller/entity/contents/filters/blend_filter_contents.h
@@ -33,6 +33,7 @@ class BlendFilterContents : public FilterContents {
   std::optional<Snapshot> RenderFilter(const FilterInput::Vector& inputs,
                                        const ContentContext& renderer,
                                        const Entity& entity,
+                                       const Matrix& effect_transform,
                                        const Rect& coverage) const override;
 
   Entity::BlendMode blend_mode_ = Entity::BlendMode::kSourceOver;

--- a/impeller/entity/contents/filters/border_mask_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/border_mask_blur_filter_contents.cc
@@ -102,8 +102,9 @@ std::optional<Snapshot> BorderMaskBlurFilterContents::RenderFilter(
 
     VS::FrameInfo frame_info;
     frame_info.mvp = Matrix::MakeOrthographic(ISize(1, 1));
-    frame_info.sigma_uv = Vector2(sigma_x_.sigma, sigma_y_.sigma).Abs() /
-                          input_snapshot->texture->GetSize();
+
+    auto sigma = effect_transform * Vector2(sigma_x_.sigma, sigma_y_.sigma);
+    frame_info.sigma_uv = sigma.Abs() / input_snapshot->texture->GetSize();
     frame_info.src_factor = src_color_factor_;
     frame_info.inner_blur_factor = inner_blur_factor_;
     frame_info.outer_blur_factor = outer_blur_factor_;
@@ -138,7 +139,7 @@ std::optional<Rect> BorderMaskBlurFilterContents::GetFilterCoverage(
   if (!coverage.has_value()) {
     return std::nullopt;
   }
-  auto transform = inputs[0]->GetTransform(entity);
+  auto transform = inputs[0]->GetTransform(entity) * effect_transform;
   auto transformed_blur_vector =
       transform.TransformDirection(Vector2(Radius{sigma_x_}.radius, 0)).Abs() +
       transform.TransformDirection(Vector2(0, Radius{sigma_y_}.radius)).Abs();

--- a/impeller/entity/contents/filters/border_mask_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/border_mask_blur_filter_contents.cc
@@ -51,6 +51,7 @@ std::optional<Snapshot> BorderMaskBlurFilterContents::RenderFilter(
     const FilterInput::Vector& inputs,
     const ContentContext& renderer,
     const Entity& entity,
+    const Matrix& effect_transform,
     const Rect& coverage) const {
   using VS = BorderMaskBlurPipeline::VertexShader;
   using FS = BorderMaskBlurPipeline::FragmentShader;
@@ -127,7 +128,8 @@ std::optional<Snapshot> BorderMaskBlurFilterContents::RenderFilter(
 
 std::optional<Rect> BorderMaskBlurFilterContents::GetFilterCoverage(
     const FilterInput::Vector& inputs,
-    const Entity& entity) const {
+    const Entity& entity,
+    const Matrix& effect_transform) const {
   if (inputs.empty()) {
     return std::nullopt;
   }

--- a/impeller/entity/contents/filters/border_mask_blur_filter_contents.h
+++ b/impeller/entity/contents/filters/border_mask_blur_filter_contents.h
@@ -22,8 +22,10 @@ class BorderMaskBlurFilterContents final : public FilterContents {
   void SetBlurStyle(BlurStyle blur_style);
 
   // |FilterContents|
-  std::optional<Rect> GetFilterCoverage(const FilterInput::Vector& inputs,
-                                        const Entity& entity) const override;
+  std::optional<Rect> GetFilterCoverage(
+      const FilterInput::Vector& inputs,
+      const Entity& entity,
+      const Matrix& effect_transform) const override;
 
  private:
   // |FilterContents|
@@ -31,6 +33,7 @@ class BorderMaskBlurFilterContents final : public FilterContents {
       const FilterInput::Vector& input_textures,
       const ContentContext& renderer,
       const Entity& entity,
+      const Matrix& effect_transform,
       const Rect& coverage) const override;
 
   Sigma sigma_x_;

--- a/impeller/entity/contents/filters/color_matrix_filter_contents.cc
+++ b/impeller/entity/contents/filters/color_matrix_filter_contents.cc
@@ -27,6 +27,7 @@ std::optional<Snapshot> ColorMatrixFilterContents::RenderFilter(
     const FilterInput::Vector& inputs,
     const ContentContext& renderer,
     const Entity& entity,
+    const Matrix& effect_transform,
     const Rect& coverage) const {
   using VS = ColorMatrixColorFilterPipeline::VertexShader;
   using FS = ColorMatrixColorFilterPipeline::FragmentShader;

--- a/impeller/entity/contents/filters/color_matrix_filter_contents.h
+++ b/impeller/entity/contents/filters/color_matrix_filter_contents.h
@@ -28,6 +28,7 @@ class ColorMatrixFilterContents final : public FilterContents {
       const FilterInput::Vector& input_textures,
       const ContentContext& renderer,
       const Entity& entity,
+      const Matrix& effect_transform,
       const Rect& coverage) const override;
 
   ColorMatrix matrix_;

--- a/impeller/entity/contents/filters/filter_contents.cc
+++ b/impeller/entity/contents/filters/filter_contents.cc
@@ -78,7 +78,8 @@ std::shared_ptr<FilterContents> FilterContents::MakeDirectionalGaussianBlur(
     Vector2 direction,
     BlurStyle blur_style,
     Entity::TileMode tile_mode,
-    FilterInput::Ref source_override) {
+    FilterInput::Ref source_override,
+    const Matrix& effect_transform) {
   auto blur = std::make_shared<DirectionalGaussianBlurFilterContents>();
   blur->SetInputs({input});
   blur->SetSigma(sigma);
@@ -86,6 +87,7 @@ std::shared_ptr<FilterContents> FilterContents::MakeDirectionalGaussianBlur(
   blur->SetBlurStyle(blur_style);
   blur->SetTileMode(tile_mode);
   blur->SetSourceOverride(source_override);
+  blur->SetEffectTransform(effect_transform);
   return blur;
 }
 
@@ -94,12 +96,14 @@ std::shared_ptr<FilterContents> FilterContents::MakeGaussianBlur(
     Sigma sigma_x,
     Sigma sigma_y,
     BlurStyle blur_style,
-    Entity::TileMode tile_mode) {
+    Entity::TileMode tile_mode,
+    const Matrix& effect_transform) {
   auto x_blur = MakeDirectionalGaussianBlur(input, sigma_x, Point(1, 0),
-                                            BlurStyle::kNormal, tile_mode);
-  auto y_blur =
-      MakeDirectionalGaussianBlur(FilterInput::Make(x_blur), sigma_y,
-                                  Point(0, 1), blur_style, tile_mode, input);
+                                            BlurStyle::kNormal, tile_mode,
+                                            nullptr, effect_transform);
+  auto y_blur = MakeDirectionalGaussianBlur(FilterInput::Make(x_blur), sigma_y,
+                                            Point(0, 1), blur_style, tile_mode,
+                                            input, effect_transform);
   return y_blur;
 }
 
@@ -107,11 +111,13 @@ std::shared_ptr<FilterContents> FilterContents::MakeBorderMaskBlur(
     FilterInput::Ref input,
     Sigma sigma_x,
     Sigma sigma_y,
-    BlurStyle blur_style) {
+    BlurStyle blur_style,
+    const Matrix& effect_transform) {
   auto filter = std::make_shared<BorderMaskBlurFilterContents>();
   filter->SetInputs({input});
   filter->SetSigma(sigma_x, sigma_y);
   filter->SetBlurStyle(blur_style);
+  filter->SetEffectTransform(effect_transform);
   return filter;
 }
 
@@ -150,6 +156,10 @@ void FilterContents::SetCoverageCrop(std::optional<Rect> coverage_crop) {
   coverage_crop_ = coverage_crop;
 }
 
+void FilterContents::SetEffectTransform(Matrix effect_transform) {
+  effect_transform_ = effect_transform.Basis();
+}
+
 bool FilterContents::Render(const ContentContext& renderer,
                             const Entity& entity,
                             RenderPass& pass) const {
@@ -183,7 +193,7 @@ bool FilterContents::Render(const ContentContext& renderer,
 
 std::optional<Rect> FilterContents::GetLocalCoverage(
     const Entity& local_entity) const {
-  auto coverage = GetFilterCoverage(inputs_, local_entity);
+  auto coverage = GetFilterCoverage(inputs_, local_entity, effect_transform_);
   if (coverage_crop_.has_value() && coverage.has_value()) {
     coverage = coverage->Intersection(coverage_crop_.value());
   }
@@ -201,7 +211,8 @@ std::optional<Rect> FilterContents::GetCoverage(const Entity& entity) const {
 
 std::optional<Rect> FilterContents::GetFilterCoverage(
     const FilterInput::Vector& inputs,
-    const Entity& entity) const {
+    const Entity& entity,
+    const Matrix& effect_transform) const {
   // The default coverage of FilterContents is just the union of its inputs'
   // coverage. FilterContents implementations may choose to adjust this
   // coverage depending on the use case.
@@ -238,7 +249,7 @@ std::optional<Snapshot> FilterContents::RenderToSnapshot(
   }
 
   return RenderFilter(inputs_, renderer, entity_with_local_transform,
-                      coverage.value());
+                      effect_transform_, coverage.value());
 }
 
 Matrix FilterContents::GetLocalTransform() const {

--- a/impeller/entity/contents/filters/filter_contents.h
+++ b/impeller/entity/contents/filters/filter_contents.h
@@ -47,20 +47,23 @@ class FilterContents : public Contents {
       Vector2 direction,
       BlurStyle blur_style = BlurStyle::kNormal,
       Entity::TileMode tile_mode = Entity::TileMode::kDecal,
-      FilterInput::Ref alpha_mask = nullptr);
+      FilterInput::Ref alpha_mask = nullptr,
+      const Matrix& effect_transform = Matrix());
 
   static std::shared_ptr<FilterContents> MakeGaussianBlur(
       FilterInput::Ref input,
       Sigma sigma_x,
       Sigma sigma_y,
       BlurStyle blur_style = BlurStyle::kNormal,
-      Entity::TileMode tile_mode = Entity::TileMode::kDecal);
+      Entity::TileMode tile_mode = Entity::TileMode::kDecal,
+      const Matrix& effect_transform = Matrix());
 
   static std::shared_ptr<FilterContents> MakeBorderMaskBlur(
       FilterInput::Ref input,
       Sigma sigma_x,
       Sigma sigma_y,
-      BlurStyle blur_style = BlurStyle::kNormal);
+      BlurStyle blur_style = BlurStyle::kNormal,
+      const Matrix& effect_transform = Matrix());
 
   static std::shared_ptr<FilterContents> MakeColorMatrix(
       FilterInput::Ref input,
@@ -86,6 +89,10 @@ class FilterContents : public Contents {
   /// @brief  Screen space bounds to use for cropping the filter output.
   void SetCoverageCrop(std::optional<Rect> coverage_crop);
 
+  /// @brief  Sets the transform which gets appended to the effect of this
+  ///         filter. Note that this is in addition to the entity's transform.
+  void SetEffectTransform(Matrix effect_transform);
+
   // |Contents|
   bool Render(const ContentContext& renderer,
               const Entity& entity,
@@ -105,19 +112,22 @@ class FilterContents : public Contents {
  private:
   virtual std::optional<Rect> GetFilterCoverage(
       const FilterInput::Vector& inputs,
-      const Entity& entity) const;
+      const Entity& entity,
+      const Matrix& effect_transform) const;
 
   /// @brief  Converts zero or more filter inputs into a new texture.
   virtual std::optional<Snapshot> RenderFilter(
       const FilterInput::Vector& inputs,
       const ContentContext& renderer,
       const Entity& entity,
+      const Matrix& effect_transform,
       const Rect& coverage) const = 0;
 
   std::optional<Rect> GetLocalCoverage(const Entity& local_entity) const;
 
   FilterInput::Vector inputs_;
   std::optional<Rect> coverage_crop_;
+  Matrix effect_transform_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(FilterContents);
 };

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.h
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.h
@@ -28,8 +28,10 @@ class DirectionalGaussianBlurFilterContents final : public FilterContents {
   void SetSourceOverride(FilterInput::Ref alpha_mask);
 
   // |FilterContents|
-  std::optional<Rect> GetFilterCoverage(const FilterInput::Vector& inputs,
-                                        const Entity& entity) const override;
+  std::optional<Rect> GetFilterCoverage(
+      const FilterInput::Vector& inputs,
+      const Entity& entity,
+      const Matrix& effect_transform) const override;
 
  private:
   // |FilterContents|
@@ -37,6 +39,7 @@ class DirectionalGaussianBlurFilterContents final : public FilterContents {
       const FilterInput::Vector& input_textures,
       const ContentContext& renderer,
       const Entity& entity,
+      const Matrix& effect_transform,
       const Rect& coverage) const override;
   Sigma blur_sigma_;
   Vector2 blur_direction_;

--- a/impeller/entity/contents/filters/linear_to_srgb_filter_contents.cc
+++ b/impeller/entity/contents/filters/linear_to_srgb_filter_contents.cc
@@ -21,6 +21,7 @@ std::optional<Snapshot> LinearToSrgbFilterContents::RenderFilter(
     const FilterInput::Vector& inputs,
     const ContentContext& renderer,
     const Entity& entity,
+    const Matrix& effect_transform,
     const Rect& coverage) const {
   if (inputs.empty()) {
     return std::nullopt;

--- a/impeller/entity/contents/filters/linear_to_srgb_filter_contents.h
+++ b/impeller/entity/contents/filters/linear_to_srgb_filter_contents.h
@@ -21,6 +21,7 @@ class LinearToSrgbFilterContents final : public FilterContents {
       const FilterInput::Vector& input_textures,
       const ContentContext& renderer,
       const Entity& entity,
+      const Matrix& effect_transform,
       const Rect& coverage) const override;
 
   FML_DISALLOW_COPY_AND_ASSIGN(LinearToSrgbFilterContents);

--- a/impeller/entity/contents/filters/srgb_to_linear_filter_contents.cc
+++ b/impeller/entity/contents/filters/srgb_to_linear_filter_contents.cc
@@ -21,6 +21,7 @@ std::optional<Snapshot> SrgbToLinearFilterContents::RenderFilter(
     const FilterInput::Vector& inputs,
     const ContentContext& renderer,
     const Entity& entity,
+    const Matrix& effect_transform,
     const Rect& coverage) const {
   if (inputs.empty()) {
     return std::nullopt;

--- a/impeller/entity/contents/filters/srgb_to_linear_filter_contents.h
+++ b/impeller/entity/contents/filters/srgb_to_linear_filter_contents.h
@@ -21,6 +21,7 @@ class SrgbToLinearFilterContents final : public FilterContents {
       const FilterInput::Vector& input_textures,
       const ContentContext& renderer,
       const Entity& entity,
+      const Matrix& effect_transform,
       const Rect& coverage) const override;
 
   FML_DISALLOW_COPY_AND_ASSIGN(SrgbToLinearFilterContents);

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -240,7 +240,8 @@ EntityPass::EntityResult EntityPass::GetEntityForElement(
       auto texture = pass_context.GetTexture();
       // Render the backdrop texture before any of the pass elements.
       const auto& proc = subpass->backdrop_filter_proc_.value();
-      backdrop_contents = proc(FilterInput::Make(std::move(texture)));
+      backdrop_contents =
+          proc(FilterInput::Make(std::move(texture)), subpass->xformation_);
 
       // The subpass will need to read from the current pass texture when
       // rendering the backdrop, so if there's an active pass, end it prior to
@@ -304,7 +305,8 @@ EntityPass::EntityResult EntityPass::GetEntityForElement(
     }
 
     auto offscreen_texture_contents =
-        subpass->delegate_->CreateContentsForSubpassTarget(subpass_texture);
+        subpass->delegate_->CreateContentsForSubpassTarget(
+            subpass_texture, subpass->xformation_);
 
     if (!offscreen_texture_contents) {
       // This is an error because the subpass delegate said the pass couldn't
@@ -329,10 +331,6 @@ EntityPass::EntityResult EntityPass::GetEntityForElement(
     element_entity.SetContents(std::move(offscreen_texture_contents));
     element_entity.SetStencilDepth(subpass->stencil_depth_);
     element_entity.SetBlendMode(subpass->blend_mode_);
-    // Once we have filters being applied for SaveLayer, some special sauce
-    // may be needed here (or in PaintPassDelegate) to ensure the filter
-    // parameters are transformed by the `xformation_` matrix, while
-    // continuing to apply only the subpass offset to the offscreen texture.
     element_entity.SetTransformation(
         Matrix::MakeTranslation(Vector3(subpass_coverage->origin - position)));
   } else {

--- a/impeller/entity/entity_pass.h
+++ b/impeller/entity/entity_pass.h
@@ -25,8 +25,9 @@ class ContentContext;
 class EntityPass {
  public:
   using Element = std::variant<Entity, std::unique_ptr<EntityPass>>;
-  using BackdropFilterProc =
-      std::function<std::shared_ptr<FilterContents>(FilterInput::Ref)>;
+  using BackdropFilterProc = std::function<std::shared_ptr<FilterContents>(
+      FilterInput::Ref,
+      const Matrix& effect_transform)>;
 
   EntityPass();
 

--- a/impeller/entity/entity_pass_delegate.cc
+++ b/impeller/entity/entity_pass_delegate.cc
@@ -28,7 +28,8 @@ class DefaultEntityPassDelegate final : public EntityPassDelegate {
 
   // |EntityPassDelegate|
   std::shared_ptr<Contents> CreateContentsForSubpassTarget(
-      std::shared_ptr<Texture> target) override {
+      std::shared_ptr<Texture> target,
+      const Matrix& effect_transform) override {
     // Not possible since this pass always collapses into its parent.
     FML_UNREACHABLE();
   }

--- a/impeller/entity/entity_pass_delegate.h
+++ b/impeller/entity/entity_pass_delegate.h
@@ -27,7 +27,8 @@ class EntityPassDelegate {
   virtual bool CanCollapseIntoParentPass() = 0;
 
   virtual std::shared_ptr<Contents> CreateContentsForSubpassTarget(
-      std::shared_ptr<Texture> target) = 0;
+      std::shared_ptr<Texture> target,
+      const Matrix& effect_transform) = 0;
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(EntityPassDelegate);

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -61,7 +61,8 @@ class TestPassDelegate final : public EntityPassDelegate {
 
   // |EntityPassDelgate|
   std::shared_ptr<Contents> CreateContentsForSubpassTarget(
-      std::shared_ptr<Texture> target) override {
+      std::shared_ptr<Texture> target,
+      const Matrix& transform) override {
     return nullptr;
   }
 


### PR DESCRIPTION
Adds a separate matrix parameter to image filters to allow for transforming image effects in EntityPass.
Removes a hack to scale scale the backdrop filter sigma by the current transform

<img width="1136" alt="Screen Shot 2022-08-22 at 3 17 18 PM" src="https://user-images.githubusercontent.com/919017/186028798-a1880390-96e8-4b6b-8066-9da75664ff95.png">