### PR TITLE
Fix redefinition error of glib_autoptr_clear_AtkObject

### DIFF
--- a/shell/platform/linux/fl_accessible_node.h
+++ b/shell/platform/linux/fl_accessible_node.h
@@ -14,7 +14,9 @@ G_BEGIN_DECLS
 
 // ATK doesn't have the g_autoptr macros, so add them manually.
 // https://gitlab.gnome.org/GNOME/atk/-/issues/10
+#if !ATK_CHECK_VERSION(2, 38, 0)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(AtkObject, g_object_unref)
+#endif
 
 #define FL_TYPE_ACCESSIBLE_NODE fl_accessible_node_get_type()
 G_DECLARE_DERIVABLE_TYPE(FlAccessibleNode,


### PR DESCRIPTION
Fixes the following build error when compiling on Fedora-36:

 In file included from ../../flutter/shell/platform/linux/fl_view_accessible.cc:6:
 ../../flutter/shell/platform/linux/fl_accessible_node.h:17:1: error: redefinition of 'glib_autoptr_clear_AtkObject'
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(AtkObject, g_object_unref)
 ^
 /usr/include/glib-2.0/glib/gmacros.h:1228:3: note: expanded from macro 'G_DEFINE_AUTOPTR_CLEANUP_FUNC'
   _GLIB_DEFINE_AUTOPTR_CLEANUP_FUNCS(TypeName, TypeName, func)
   ^
 /usr/include/glib-2.0/glib/gmacros.h:1211:36: note: expanded from macro '_GLIB_DEFINE_AUTOPTR_CLEANUP_FUNCS'
   static G_GNUC_UNUSED inline void _GLIB_AUTOPTR_CLEAR_FUNC_NAME(TypeName) (TypeName *_ptr)                     \
                                    ^
 /usr/include/glib-2.0/glib/gmacros.h:1195:49: note: expanded from macro '_GLIB_AUTOPTR_CLEAR_FUNC_NAME'
 #define _GLIB_AUTOPTR_CLEAR_FUNC_NAME(TypeName) glib_autoptr_clear_##TypeName
                                                 ^
 <scratch space>:65:1: note: expanded from here
 glib_autoptr_clear_AtkObject
 ^
 /usr/include/atk-1.0/atk/atk-autocleanups.h:38:1: note: previous definition is here
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (AtkObject, g_object_unref)
 ^

 The 'atk' header already provides such a cleanup function:
   $ sed -n 38p /usr/include/atk-1.0/atk/atk-autocleanups.h
   G_DEFINE_AUTOPTR_CLEANUP_FUNC (AtkObject, g_object_unref)

 Tested with 'atk' version:
   $ rpm -qf /usr/include/atk-1.0/atk/atk-autocleanups.h
   atk-devel-2.38.0-1.fc36.x86_64

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>
