### PR TITLE
Image shader dispose

### DIFF
--- a/lib/ui/dart_ui.cc
+++ b/lib/ui/dart_ui.cc
@@ -185,6 +185,7 @@ typedef CanvasPath Path;
   V(ImageFilter, initColorFilter, 2)                   \
   V(ImageFilter, initComposeFilter, 3)                 \
   V(ImageFilter, initMatrix, 3)                        \
+  V(ImageShader, dispose, 1)                           \
   V(ImageShader, initWithImage, 6)                     \
   V(ImmutableBuffer, dispose, 1)                       \
   V(ImmutableBuffer, length, 1)                        \

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -4050,6 +4050,41 @@ class ImageShader extends Shader {
 
   @FfiNative<Handle Function(Pointer<Void>, Pointer<Void>, Int32, Int32, Int32, Handle)>('ImageShader::initWithImage')
   external String? _initWithImage(_Image image, int tmx, int tmy, int filterQualityIndex, Float64List matrix4);
+
+  bool _debugDisposed = false;
+
+  /// Whether [dispose] has been called.
+  ///
+  /// This must only be used when asserts are enabled. Otherwise, it will throw.
+  bool get debugDisposed {
+    late bool disposed;
+    assert(() {
+      disposed = _debugDisposed;
+      return true;
+    }());
+    return disposed;
+  }
+
+  /// Release the resources used by this object. The object is no longer usable
+  /// after this method is called.
+  ///
+  /// The underlying memory allocated by this object will be retained beyond
+  /// this call if it is still needed by another object that has not been
+  /// disposed. For example, an [Picture] that has not been disposed that
+  /// refers to this [ImageShader] may keep its underlying resources alive.
+  void dispose() {
+    assert(() {
+      assert(!_debugDisposed);
+      _debugDisposed = true;
+      return true;
+    }());
+    _dispose();
+  }
+
+  /// This can't be a leaf call because the native function calls Dart API
+  /// (Dart_SetNativeInstanceField).
+  @FfiNative<Void Function(Pointer<Void>)>('ImageShader::dispose')
+  external void _dispose();
 }
 
 /// An instance of [FragmentProgram] creates [Shader] objects (as used by [Paint.shader]) that run SPIR-V code.

--- a/lib/ui/painting/image_shader.cc
+++ b/lib/ui/painting/image_shader.cc
@@ -69,6 +69,11 @@ int ImageShader::height() {
   return image_->height();
 }
 
+void ImageShader::dispose() {
+  image_.reset();
+  ClearDartWrapper();
+}
+
 ImageShader::ImageShader() = default;
 
 ImageShader::~ImageShader() = default;

--- a/lib/ui/painting/image_shader.h
+++ b/lib/ui/painting/image_shader.h
@@ -35,6 +35,8 @@ class ImageShader : public Shader {
   int width();
   int height();
 
+  void dispose();
+
  private:
   ImageShader();
 

--- a/lib/web_ui/lib/painting.dart
+++ b/lib/web_ui/lib/painting.dart
@@ -751,7 +751,9 @@ abstract class ImageShader extends Shader {
       ? engine.CkImageShader(image, tmx, tmy, matrix4, filterQuality)
       : engine.EngineImageShader(image, tmx, tmy, matrix4, filterQuality);
 
-  abstract void dispose();
+  void dispose();
+
+  bool get debugDisposed;
 }
 
 class ImmutableBuffer {

--- a/lib/web_ui/lib/painting.dart
+++ b/lib/web_ui/lib/painting.dart
@@ -744,12 +744,14 @@ class Shadow {
   String toString() => 'TextShadow($color, $offset, $blurRadius)';
 }
 
-class ImageShader extends Shader {
+abstract class ImageShader extends Shader {
   factory ImageShader(Image image, TileMode tmx, TileMode tmy, Float64List matrix4, {
     FilterQuality? filterQuality,
   }) => engine.useCanvasKit
       ? engine.CkImageShader(image, tmx, tmy, matrix4, filterQuality)
       : engine.EngineImageShader(image, tmx, tmy, matrix4, filterQuality);
+
+  abstract void dispose();
 }
 
 class ImmutableBuffer {

--- a/lib/web_ui/lib/src/engine/canvaskit/shader.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/shader.dart
@@ -224,4 +224,9 @@ class CkImageShader extends CkShader implements ui.ImageShader {
   void delete() {
     rawSkiaObject?.delete();
   }
+
+  @override
+  void dispose() {
+    _image.dispose();
+  }
 }

--- a/lib/web_ui/lib/src/engine/canvaskit/shader.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/shader.dart
@@ -225,8 +225,24 @@ class CkImageShader extends CkShader implements ui.ImageShader {
     rawSkiaObject?.delete();
   }
 
+  bool _disposed = false;
+
+  @override
+  bool get debugDisposed {
+    late bool disposed;
+    assert(() {
+      disposed = _disposed;
+      return true;
+    }());
+    return disposed;
+  }
+
   @override
   void dispose() {
+    assert(() {
+      _disposed = true;
+      return true;
+    }());
     _image.dispose();
   }
 }

--- a/lib/web_ui/lib/src/engine/html/shaders/image_shader.dart
+++ b/lib/web_ui/lib/src/engine/html/shaders/image_shader.dart
@@ -265,4 +265,9 @@ class EngineImageShader implements ui.ImageShader {
     gl.bindElementArrayBuffer(null);
     return context!.createPattern(bitmapImage!, 'no-repeat')!;
   }
+
+  @override
+  void dispose() {
+    image.dispose();
+  }
 }

--- a/lib/web_ui/lib/src/engine/html/shaders/image_shader.dart
+++ b/lib/web_ui/lib/src/engine/html/shaders/image_shader.dart
@@ -266,8 +266,24 @@ class EngineImageShader implements ui.ImageShader {
     return context!.createPattern(bitmapImage!, 'no-repeat')!;
   }
 
+  bool _disposed = false;
+
+  @override
+  bool get debugDisposed {
+    late bool disposed;
+    assert(() {
+      disposed = _disposed;
+      return true;
+    }());
+    return disposed;
+  }
+
   @override
   void dispose() {
-    image.dispose();
+    assert(() {
+      _disposed = true;
+      return true;
+    }());
+      image.dispose();
   }
 }

--- a/lib/web_ui/test/canvaskit/shader_test.dart
+++ b/lib/web_ui/test/canvaskit/shader_test.dart
@@ -70,6 +70,10 @@ void testMain() {
         Float64List.fromList(Matrix4.diagonal3Values(1, 2, 3).storage),
       ) as CkImageShader;
       expect(imageShader, isA<CkImageShader>());
+
+      expect(imageShader.debugDisposed, false);
+      imageShader.dispose();
+      expect(imageShader.debugDisposed, true);
     });
   });
 }

--- a/lib/web_ui/test/html/drawing/draw_vertices_golden_test.dart
+++ b/lib/web_ui/test/html/drawing/draw_vertices_golden_test.dart
@@ -393,6 +393,10 @@ Future<void> testMain() async {
 
     rc.drawVertices(vertices as SurfaceVertices, BlendMode.srcOver, paint);
     await checkScreenshot(rc, filename, maxDiffRatePercent: 1.0);
+
+    expect(imgShader.debugDisposed, false);
+    imgShader.dispose();
+    expect(imgShader.debugDisposed, true);
   }
 
   test('Should draw triangle with texture and indices', () async {

--- a/testing/dart/image_shader_test.dart
+++ b/testing/dart/image_shader_test.dart
@@ -9,12 +9,28 @@ import 'package:litetest/litetest.dart';
 import 'canvas_test.dart' show createImage, testCanvas;
 
 void main() {
+  bool assertsEnabled = false;
+  assert(() {
+    assertsEnabled = true;
+    return true;
+  }());
+
   test('Construct an ImageShader', () async {
     final Image image = await createImage(50, 50);
     final ImageShader shader = ImageShader(image, TileMode.clamp, TileMode.clamp, Float64List(16));
     final Paint paint = Paint()..shader=shader;
     const Rect rect = Rect.fromLTRB(0, 0, 100, 100);
     testCanvas((Canvas canvas) => canvas.drawRect(rect, paint));
+
+    if (assertsEnabled) {
+      expect(shader.debugDisposed, false);
+    }
+    shader.dispose();
+    if (assertsEnabled) {
+      expect(shader.debugDisposed, true);
+    }
+
+    image.dispose();
   });
 
   test('Construct an ImageShader - GPU image', () async {
@@ -29,5 +45,15 @@ void main() {
     final Paint paint = Paint()..shader=shader;
     const Rect rect = Rect.fromLTRB(0, 0, 100, 100);
     testCanvas((Canvas canvas) => canvas.drawRect(rect, paint));
+
+    if (assertsEnabled) {
+      expect(shader.debugDisposed, false);
+    }
+    shader.dispose();
+    if (assertsEnabled) {
+      expect(shader.debugDisposed, true);
+    }
+
+    image.dispose();
   });
 }


### PR DESCRIPTION
Image shaders can contain images and should be disposed.

Fixes https://github.com/flutter/flutter/issues/82832

Once this lands we should update vector_graphics to dispose the image shaders it creates.