### PR TITLE
[Impeller] Fix Gaussian blur jittering.

### DIFF
--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -112,6 +112,11 @@ std::optional<Snapshot> DirectionalGaussianBlurFilterContents::RenderFilter(
 
   auto transformed_blur_radius_length = transformed_blur_radius.GetLength();
 
+  // If the radius length is < .5, the shader will take no samples.
+  if (transformed_blur_radius_length < .5) {
+    return input_snapshot.value();  // No blur to render.
+  }
+
   // A matrix that rotates the snapshot space such that the blur direction is
   // +X.
   auto texture_rotate = Matrix::MakeRotationZ(
@@ -216,11 +221,11 @@ std::optional<Snapshot> DirectionalGaussianBlurFilterContents::RenderFilter(
   };
 
   Scalar x_scale =
-      std::min(1.0, 1.0 / std::ceil(std::log2(transformed_blur_radius_length)));
-  auto out_texture =
-      renderer.MakeSubpass(ISize(pass_texture_rect.size.width * x_scale,
-                                 pass_texture_rect.size.height),
-                           callback);
+      1.0 /
+      std::ceil(std::log2(std::max(2.0f, transformed_blur_radius_length)));
+  auto scaled_texture_width = pass_texture_rect.size.width * x_scale;
+  auto out_texture = renderer.MakeSubpass(
+      ISize(scaled_texture_width, pass_texture_rect.size.height), callback);
   if (!out_texture) {
     return std::nullopt;
   }
@@ -234,7 +239,10 @@ std::optional<Snapshot> DirectionalGaussianBlurFilterContents::RenderFilter(
       .texture = out_texture,
       .transform = texture_rotate.Invert() *
                    Matrix::MakeTranslation(pass_texture_rect.origin) *
-                   Matrix::MakeScale(Vector2(1 / x_scale, 1)),
+                   Matrix::MakeScale(Vector2(
+                       (1 / x_scale) * (scaled_texture_width /
+                                        std::floor(scaled_texture_width)),
+                       1)),
       .sampler_descriptor = sampler_desc};
 }
 

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -112,7 +112,8 @@ std::optional<Snapshot> DirectionalGaussianBlurFilterContents::RenderFilter(
 
   auto transformed_blur_radius_length = transformed_blur_radius.GetLength();
 
-  // If the radius length is < .5, the shader will take no samples.
+  // If the radius length is < .5, the shader will take at most 1 sample,
+  // resulting in no blur.
   if (transformed_blur_radius_length < .5) {
     return input_snapshot.value();  // No blur to render.
   }

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -864,7 +864,7 @@ TEST_P(EntityTest, GaussianBlurFilter) {
     static Color input_color = Color::Black();
     static int selected_blur_type = 0;
     static int selected_pass_variation = 0;
-    static float blur_amount[2] = {20, 20};
+    static float blur_amount[2] = {10, 10};
     static int selected_blur_style = 0;
     static int selected_tile_mode = 3;
     static Color cover_color(1, 0, 0, 0.2);
@@ -894,7 +894,7 @@ TEST_P(EntityTest, GaussianBlurFilter) {
                      pass_variation_names,
                      sizeof(pass_variation_names) / sizeof(char*));
       }
-      ImGui::SliderFloat2("Sigma", blur_amount, 0, 200);
+      ImGui::SliderFloat2("Sigma", blur_amount, 0, 10);
       ImGui::Combo("Blur style", &selected_blur_style, blur_style_names,
                    sizeof(blur_style_names) / sizeof(char*));
       ImGui::Combo("Tile mode", &selected_tile_mode, tile_mode_names,


### PR DESCRIPTION
Converting the scaled texutre width to an ISize snaps it down. This accounts
for the extra snapping in the scale transform.

Also fixes a bug where small blur radius values which would result in a
single turn of the shader sampling would produce no output.

Updates an existing test to use smaller sigma range to make jitter
more apparent on changing the imgui slider.
