### PR TITLE
[Impeller] Fix matrix printing

### DIFF
--- a/impeller/geometry/geometry_unittests.cc
+++ b/impeller/geometry/geometry_unittests.cc
@@ -5,6 +5,7 @@
 #include "impeller/geometry/geometry_unittests.h"
 
 #include <limits>
+#include <sstream>
 
 #include "flutter/testing/testing.h"
 #include "impeller/geometry/constants.h"
@@ -1328,6 +1329,35 @@ TEST(GeometryTest, VerticesConstructorAndGetters) {
   ASSERT_EQ(vertices.GetIndices(), indices);
   ASSERT_EQ(vertices.GetColors(), colors);
   ASSERT_EQ(vertices.GetMode(), VertexMode::kTriangle);
+}
+
+TEST(GeometryTest, MatrixPrinting) {
+  std::stringstream stream;
+
+  Matrix m;
+
+  stream << m;
+
+  ASSERT_EQ(stream.str(), R"((
+       1.000000,       0.000000,       0.000000,       0.000000,
+       0.000000,       1.000000,       0.000000,       0.000000,
+       0.000000,       0.000000,       1.000000,       0.000000,
+       0.000000,       0.000000,       0.000000,       1.000000,
+))");
+
+  stream.str("");
+  stream.clear();
+
+  m = Matrix::MakeTranslation(Vector3(10, 20, 30));
+
+  stream << m;
+
+  ASSERT_EQ(stream.str(), R"((
+       1.000000,       0.000000,       0.000000,      10.000000,
+       0.000000,       1.000000,       0.000000,      20.000000,
+       0.000000,       0.000000,       1.000000,      30.000000,
+       0.000000,       0.000000,       0.000000,       1.000000,
+))");
 }
 
 }  // namespace testing

--- a/impeller/geometry/matrix.h
+++ b/impeller/geometry/matrix.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cmath>
+#include <iomanip>
 #include <optional>
 #include <ostream>
 #include <utility>
@@ -374,10 +375,10 @@ static_assert(sizeof(struct Matrix) == sizeof(Scalar) * 16,
 
 namespace std {
 inline std::ostream& operator<<(std::ostream& out, const impeller::Matrix& m) {
-  out << "(";
+  out << "(" << std::endl << std::fixed;
   for (size_t i = 0; i < 4u; i++) {
     for (size_t j = 0; j < 4u; j++) {
-      out << m.e[i][j] << ",";
+      out << std::setw(15) << m.e[j][i] << ",";
     }
     out << std::endl;
   }


### PR DESCRIPTION
Makes matrix printing a bit prettier and fixes issue about ordering of rows/columns (before this change, the translation values were printed out in the fourth row instead of the fourth column).