### PR TITLE
[Impeller] Fix bug where the intermediary root pass is getting created even when nothing reads from it

### DIFF
--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -531,7 +531,7 @@ void EntityPass::SetBlendMode(Entity::BlendMode blend_mode) {
 
 void EntityPass::SetBackdropFilter(std::optional<BackdropFilterProc> proc) {
   backdrop_filter_proc_ = proc;
-  if (superpass_) {
+  if (proc.has_value() && superpass_) {
     superpass_->reads_from_pass_texture_ = true;
   }
 }


### PR DESCRIPTION
Reduces vram by like 40% on home screen of the app we're testing by eliminating a shader driven full screen blit.