### PR TITLE
Make sure disposed image shaders are safe to use on paint, asser that they are not used

### DIFF
--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -1398,6 +1398,12 @@ class Paint {
     return _objects?[_kShaderIndex] as Shader?;
   }
   set shader(Shader? value) {
+    assert(() {
+      if (value is ImageShader) {
+        assert(!value.debugDisposed, 'Attempted to set a disposed shader to $this');
+      }
+      return true;
+    }());
     _ensureObjectsInitialized()[_kShaderIndex] = value;
   }
 
@@ -4031,6 +4037,7 @@ class ImageShader extends Shader {
     FilterQuality? filterQuality,
   }) :
     assert(image != null), // image is checked on the engine side
+    assert(!image.debugDisposed),
     assert(tmx != null),
     assert(tmy != null),
     assert(matrix4 != null),

--- a/lib/ui/painting/image_shader.cc
+++ b/lib/ui/painting/image_shader.cc
@@ -70,6 +70,7 @@ int ImageShader::height() {
 }
 
 void ImageShader::dispose() {
+  cached_shader_.reset();
   image_.reset();
   ClearDartWrapper();
 }

--- a/testing/dart/image_shader_test.dart
+++ b/testing/dart/image_shader_test.dart
@@ -18,7 +18,7 @@ void main() {
   test('Construct an ImageShader', () async {
     final Image image = await createImage(50, 50);
     final ImageShader shader = ImageShader(image, TileMode.clamp, TileMode.clamp, Float64List(16));
-    final Paint paint = Paint()..shader=shader;
+    final Paint paint = Paint()..shader = shader;
     const Rect rect = Rect.fromLTRB(0, 0, 100, 100);
     testCanvas((Canvas canvas) => canvas.drawRect(rect, paint));
 
@@ -31,6 +31,40 @@ void main() {
     }
 
     image.dispose();
+  });
+
+  test('ImageShader with disposed image', () async {
+    final Image image = await createImage(50, 50);
+    image.dispose();
+
+    if (assertsEnabled) {
+      expectAssertion(() => ImageShader(image, TileMode.clamp, TileMode.clamp, Float64List(16)));
+      return;
+    }
+
+    final ImageShader shader = ImageShader(image, TileMode.clamp, TileMode.clamp, Float64List(16));
+
+    final Paint paint = Paint()..shader = shader;
+    const Rect rect = Rect.fromLTRB(0, 0, 100, 100);
+    testCanvas((Canvas canvas) => canvas.drawRect(rect, paint));
+    shader.dispose();
+
+  });
+
+  test('Disposed image shader in a paint', () async {
+    final Image image = await createImage(50, 50);
+    final ImageShader shader = ImageShader(image, TileMode.clamp, TileMode.clamp, Float64List(16));
+    shader.dispose();
+
+    if (assertsEnabled) {
+      expectAssertion(() => Paint()..shader = shader);
+      return;
+    }
+    final Paint paint = Paint()..shader = shader;
+    const Rect rect = Rect.fromLTRB(0, 0, 100, 100);
+    testCanvas((Canvas canvas) => canvas.drawRect(rect, paint));
+    image.dispose();
+
   });
 
   test('Construct an ImageShader - GPU image', () async {

--- a/testing/dart/image_shader_test.dart
+++ b/testing/dart/image_shader_test.dart
@@ -39,16 +39,9 @@ void main() {
 
     if (assertsEnabled) {
       expectAssertion(() => ImageShader(image, TileMode.clamp, TileMode.clamp, Float64List(16)));
-      return;
+    } else {
+      throwsException(() => ImageShader(image, TileMode.clamp, TileMode.clamp, Float64List(16)));
     }
-
-    final ImageShader shader = ImageShader(image, TileMode.clamp, TileMode.clamp, Float64List(16));
-
-    final Paint paint = Paint()..shader = shader;
-    const Rect rect = Rect.fromLTRB(0, 0, 100, 100);
-    testCanvas((Canvas canvas) => canvas.drawRect(rect, paint));
-    shader.dispose();
-
   });
 
   test('Disposed image shader in a paint', () async {


### PR DESCRIPTION
Follow up on https://github.com/flutter/engine/pull/35640

In current state, trying to do a canvas operation with a paint that contains a disposed image shader will cause a segfault.

This patch fixes that - it makes using a disposed shader a no-op when asserts are disabled and an assertion error when enabled.