### PR TITLE
Generate mac os framework with a global generator.

### DIFF
--- a/ci/builders/mac_host_engine.json
+++ b/ci/builders/mac_host_engine.json
@@ -6,7 +6,6 @@
                     "base_path": "out/host_debug/zip_archives/",
                     "type": "gcs",
                     "include_paths": [
-                        "out/host_debug/zip_archives/darwin-x64/FlutterMacOS.framework.zip",
                         "out/host_debug/zip_archives/darwin-x64/gen_snapshot.zip",
                         "out/host_debug/zip_archives/darwin-x64/artifacts.zip",
                         "out/host_debug/zip_archives/darwin-x64/FlutterEmbedder.framework.zip",
@@ -52,7 +51,6 @@
                     "base_path": "out/host_profile/zip_archives/",
                     "type": "gcs",
                     "include_paths": [
-                        "out/host_profile/zip_archives/darwin-x64-profile/FlutterMacOS.framework.zip",
                         "out/host_profile/zip_archives/darwin-x64-profile/gen_snapshot.zip",
                         "out/host_profile/zip_archives/darwin-x64-profile/artifacts.zip"
                     ],
@@ -106,7 +104,6 @@
                     "base_path": "out/host_release/zip_archives/",
                     "type": "gcs",
                     "include_paths": [
-                        "out/host_release/zip_archives/darwin-x64-release/FlutterMacOS.framework.zip",
                         "out/host_release/zip_archives/darwin-x64-release/gen_snapshot.zip",
                         "out/host_release/zip_archives/darwin-x64-release/artifacts.zip",
                         "out/host_release/zip_archives/darwin-x64/font-subset.zip"
@@ -275,6 +272,30 @@
                     "--strip"
                 ],
                 "script": "flutter/sky/tools/create_macos_framework.py"
+            },
+            {
+                "name": "Debug-FlutterMacOS.framework",
+                "parameters": [
+                    "--dst",
+                    "out/debug",
+                    "--arm64-out-dir",
+                    "out/mac_debug_arm64",
+                    "--x64-out-dir",
+                    "out/host_debug"
+                ],
+                "script": "flutter/sky/tools/create_macos_framework.py"
+            },
+            {
+                "name": "Profile-FlutterMacOS.framework",
+                "parameters": [
+                    "--dst",
+                    "out/profile",
+                    "--arm64-out-dir",
+                    "out/mac_profile_arm64",
+                    "--x64-out-dir",
+                    "out/host_profile"
+                ],
+                "script": "flutter/sky/tools/create_macos_framework.py"
             }
         ]
     },
@@ -282,6 +303,18 @@
         {
             "source": "out/release/FlutterMacOS.dSYM.zip",
             "destination": "darwin-x64-release/FlutterMacOS.dSYM.zip"
+        },
+        {
+            "source": "out/debug/FlutterMacOS.framework.zip",
+            "destination": "darwin-x64/FlutterMacOS.framework.zip"
+        },
+        {
+            "source": "out/profile/FlutterMacOS.framework.zip",
+            "destination": "darwin-x64-profile/FlutterMacOS.framework.zip"
+        },
+        {
+            "source": "out/release/FlutterMacOS.framework.zip",
+            "destination": "darwin-x64-release/FlutterMacOS.framework.zip"
         }
     ]
 }

--- a/ci/builders/mac_host_engine.json
+++ b/ci/builders/mac_host_engine.json
@@ -269,7 +269,8 @@
                     "--x64-out-dir",
                     "out/host_release",
                     "--dsym",
-                    "--strip"
+                    "--strip",
+                    "--zip"
                 ],
                 "script": "flutter/sky/tools/create_macos_framework.py"
             },
@@ -281,7 +282,8 @@
                     "--arm64-out-dir",
                     "out/mac_debug_arm64",
                     "--x64-out-dir",
-                    "out/host_debug"
+                    "out/host_debug",
+                    "--zip"
                 ],
                 "script": "flutter/sky/tools/create_macos_framework.py"
             },
@@ -293,7 +295,8 @@
                     "--arm64-out-dir",
                     "out/mac_profile_arm64",
                     "--x64-out-dir",
-                    "out/host_profile"
+                    "out/host_profile",
+                    "--zip"
                 ],
                 "script": "flutter/sky/tools/create_macos_framework.py"
             }


### PR DESCRIPTION
Previously we were generating mac os framework in the host_debug
subbuild but that was only updating the x64 architecture but the
expection is to include x64 and arm64. As those builds are generated
separately we need to create the FAT binaries in the orchestrator rather
than the subbuilds.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
