### PR TITLE
Support basic back navigation in Android 13/API 33

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -538,13 +538,15 @@ public class FlutterActivity extends Activity
     }
   }
 
-  private final OnBackInvokedCallback onBackInvokedCallback = Build.VERSION.SDK_INT >= 33 ?
-      new OnBackInvokedCallback() {
-        @Override
-        public void onBackInvoked() {
-          onBackPressed();
-        }
-      } : null;
+  private final OnBackInvokedCallback onBackInvokedCallback =
+      Build.VERSION.SDK_INT >= 33
+          ? new OnBackInvokedCallback() {
+            @Override
+            public void onBackInvoked() {
+              onBackPressed();
+            }
+          }
+          : null;
 
   /**
    * Switches themes for this {@code Activity} from the theme used to launch this {@code Activity}

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -538,13 +538,13 @@ public class FlutterActivity extends Activity
     }
   }
 
-  private final OnBackInvokedCallback onBackInvokedCallback =
+  private final OnBackInvokedCallback onBackInvokedCallback = Build.VERSION.SDK_INT >= 33 ?
       new OnBackInvokedCallback() {
         @Override
         public void onBackInvoked() {
           onBackPressed();
         }
-      };
+      } : null;
 
   /**
    * Switches themes for this {@code Activity} from the theme used to launch this {@code Activity}

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -494,7 +494,7 @@ public class FlutterActivity extends ComponentActivity
     delegate.onAttach(this);
     delegate.onRestoreInstanceState(savedInstanceState);
 
-    getLifecycle().handleLifecycleEvent(Lifecycle.Event.ON_CREATE);
+    getLifecycleRegistry().handleLifecycleEvent(Lifecycle.Event.ON_CREATE);
 
     registerOnBackInvokedCallback();
 
@@ -664,7 +664,7 @@ public class FlutterActivity extends ComponentActivity
   @Override
   protected void onStart() {
     super.onStart();
-    getLifecycle().handleLifecycleEvent(Lifecycle.Event.ON_START);
+    getLifecycleRegistry().handleLifecycleEvent(Lifecycle.Event.ON_START);
     if (stillAttachedForEvent("onStart")) {
       delegate.onStart();
     }
@@ -673,7 +673,7 @@ public class FlutterActivity extends ComponentActivity
   @Override
   protected void onResume() {
     super.onResume();
-    getLifecycle().handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
+    getLifecycleRegistry().handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
     if (stillAttachedForEvent("onResume")) {
       delegate.onResume();
     }
@@ -693,7 +693,7 @@ public class FlutterActivity extends ComponentActivity
     if (stillAttachedForEvent("onPause")) {
       delegate.onPause();
     }
-    getLifecycle().handleLifecycleEvent(Lifecycle.Event.ON_PAUSE);
+    getLifecycleRegistry().handleLifecycleEvent(Lifecycle.Event.ON_PAUSE);
   }
 
   @Override
@@ -702,7 +702,7 @@ public class FlutterActivity extends ComponentActivity
     if (stillAttachedForEvent("onStop")) {
       delegate.onStop();
     }
-    getLifecycle().handleLifecycleEvent(Lifecycle.Event.ON_STOP);
+    getLifecycleRegistry().handleLifecycleEvent(Lifecycle.Event.ON_STOP);
   }
 
   @Override
@@ -755,7 +755,7 @@ public class FlutterActivity extends ComponentActivity
       delegate.onDetach();
     }
     release();
-    getLifecycle().handleLifecycleEvent(Lifecycle.Event.ON_DESTROY);
+    getLifecycleRegistry().handleLifecycleEvent(Lifecycle.Event.ON_DESTROY);
   }
 
   @Override
@@ -838,6 +838,10 @@ public class FlutterActivity extends ComponentActivity
       lifecycle = new LifecycleRegistry(this);
     }
     return lifecycle;
+  }
+
+  private LifecycleRegistry getLifecycleRegistry() {
+    return (LifecycleRegistry) lifecycle;
   }
 
   /**

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -505,6 +505,16 @@ public class FlutterActivity extends ComponentActivity
     configureStatusBarForFullscreenFlutterExperience();
   }
 
+  /**
+   * Registers the callback with OnBackInvokedDispatcher to capture back navigation
+   * gestures and pass them to the framework.
+   *
+   * This replaces the deprecated onBackPressed method override in order to support
+   * API 33's predictive back navigation feature.
+   *
+   * The callback must be unregistered in order to prevent unpredictable behavior
+   * once outside the Flutter app.
+   */
   @VisibleForTesting
   public void registerOnBackInvokedCallback() {
     if (Build.VERSION.SDK_INT >= 33) {
@@ -514,6 +524,12 @@ public class FlutterActivity extends ComponentActivity
     }
   }
 
+  /**
+   * Unregisters the callback from OnBackInvokedDispatcher.
+   *
+   * This should be called when the activity is no longer in use to prevent unpredictable
+   * behavior such as being stuck and unable to press back.
+   */
   @VisibleForTesting
   public void unregisterOnBackInvokedCallback() {
     if (Build.VERSION.SDK_INT >= 33) {

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -512,7 +512,7 @@ public class FlutterActivity extends ComponentActivity
    * <p>This replaces the deprecated onBackPressed method override in order to support API 33's
    * predictive back navigation feature.
    *
-   * The callback must be unregistered in order to prevent unpredictable behavior once outside
+   * <p>The callback must be unregistered in order to prevent unpredictable behavior once outside
    * the Flutter app.
    */
   @VisibleForTesting

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -496,17 +496,29 @@ public class FlutterActivity extends ComponentActivity
 
     lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE);
 
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.T) {
-      getOnBackInvokedDispatcher()
-          .registerOnBackInvokedCallback(
-              OnBackInvokedDispatcher.PRIORITY_DEFAULT, onBackInvokedCallback);
-    }
+    registerOnBackInvokedCallback();
 
     configureWindowForTransparency();
 
     setContentView(createFlutterView());
 
     configureStatusBarForFullscreenFlutterExperience();
+  }
+
+  @VisibleForTesting
+  public void registerOnBackInvokedCallback() {
+    if (Build.VERSION.SDK_INT >= 33) {
+      getOnBackInvokedDispatcher()
+          .registerOnBackInvokedCallback(
+              OnBackInvokedDispatcher.PRIORITY_DEFAULT, onBackInvokedCallback);
+    }
+  }
+
+  @VisibleForTesting
+  public void unregisterOnBackInvokedCallback() {
+    if (Build.VERSION.SDK_INT >= 33) {
+      getOnBackInvokedDispatcher().unregisterOnBackInvokedCallback(onBackInvokedCallback);
+    }
   }
 
   private final OnBackInvokedCallback onBackInvokedCallback =
@@ -671,9 +683,6 @@ public class FlutterActivity extends ComponentActivity
   @Override
   protected void onStop() {
     super.onStop();
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.T) {
-      getOnBackInvokedDispatcher().unregisterOnBackInvokedCallback(onBackInvokedCallback);
-    }
     if (stillAttachedForEvent("onStop")) {
       delegate.onStop();
     }
@@ -699,6 +708,7 @@ public class FlutterActivity extends ComponentActivity
    * <p>After calling, this activity should be disposed immediately and not be re-used.
    */
   private void release() {
+    unregisterOnBackInvokedCallback();
     if (delegate != null) {
       delegate.release();
       delegate = null;

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -37,7 +37,6 @@ import android.view.Window;
 import android.view.WindowManager;
 import android.window.OnBackInvokedCallback;
 import android.window.OnBackInvokedDispatcher;
-import androidx.activity.ComponentActivity;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
@@ -211,7 +210,7 @@ import java.util.List;
 // A number of methods in this class have the same implementation as FlutterFragmentActivity. These
 // methods are duplicated for readability purposes. Be sure to replicate any change in this class in
 // FlutterFragmentActivity, too.
-public class FlutterActivity extends ComponentActivity
+public class FlutterActivity extends Activity
     implements FlutterActivityAndFragmentDelegate.Host, LifecycleOwner {
   private static final String TAG = "FlutterActivity";
 
@@ -456,7 +455,9 @@ public class FlutterActivity extends ComponentActivity
 
   @NonNull private LifecycleRegistry lifecycle;
 
-  public FlutterActivity() {}
+  public FlutterActivity() {
+    lifecycle = new LifecycleRegistry(this);
+  }
 
   /**
    * This method exists so that JVM tests can ensure that a delegate exists without putting this
@@ -494,7 +495,7 @@ public class FlutterActivity extends ComponentActivity
     delegate.onAttach(this);
     delegate.onRestoreInstanceState(savedInstanceState);
 
-    getLifecycleRegistry().handleLifecycleEvent(Lifecycle.Event.ON_CREATE);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE);
 
     registerOnBackInvokedCallback();
 
@@ -664,7 +665,7 @@ public class FlutterActivity extends ComponentActivity
   @Override
   protected void onStart() {
     super.onStart();
-    getLifecycleRegistry().handleLifecycleEvent(Lifecycle.Event.ON_START);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START);
     if (stillAttachedForEvent("onStart")) {
       delegate.onStart();
     }
@@ -673,7 +674,7 @@ public class FlutterActivity extends ComponentActivity
   @Override
   protected void onResume() {
     super.onResume();
-    getLifecycleRegistry().handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
     if (stillAttachedForEvent("onResume")) {
       delegate.onResume();
     }
@@ -693,7 +694,7 @@ public class FlutterActivity extends ComponentActivity
     if (stillAttachedForEvent("onPause")) {
       delegate.onPause();
     }
-    getLifecycleRegistry().handleLifecycleEvent(Lifecycle.Event.ON_PAUSE);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE);
   }
 
   @Override
@@ -702,7 +703,7 @@ public class FlutterActivity extends ComponentActivity
     if (stillAttachedForEvent("onStop")) {
       delegate.onStop();
     }
-    getLifecycleRegistry().handleLifecycleEvent(Lifecycle.Event.ON_STOP);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP);
   }
 
   @Override
@@ -755,7 +756,7 @@ public class FlutterActivity extends ComponentActivity
       delegate.onDetach();
     }
     release();
-    getLifecycleRegistry().handleLifecycleEvent(Lifecycle.Event.ON_DESTROY);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY);
   }
 
   @Override
@@ -834,14 +835,7 @@ public class FlutterActivity extends ComponentActivity
   @Override
   @NonNull
   public Lifecycle getLifecycle() {
-    if (lifecycle == null) {
-      lifecycle = new LifecycleRegistry(this);
-    }
     return lifecycle;
-  }
-
-  private LifecycleRegistry getLifecycleRegistry() {
-    return (LifecycleRegistry) lifecycle;
   }
 
   /**

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -723,7 +723,8 @@ public class FlutterActivity extends ComponentActivity
    *
    * <p>After calling, this activity should be disposed immediately and not be re-used.
    */
-  private void release() {
+  @VisibleForTesting
+  public void release() {
     unregisterOnBackInvokedCallback();
     if (delegate != null) {
       delegate.release();

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -494,7 +494,7 @@ public class FlutterActivity extends ComponentActivity
     delegate.onAttach(this);
     delegate.onRestoreInstanceState(savedInstanceState);
 
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE);
+    getLifecycle().handleLifecycleEvent(Lifecycle.Event.ON_CREATE);
 
     registerOnBackInvokedCallback();
 
@@ -664,7 +664,7 @@ public class FlutterActivity extends ComponentActivity
   @Override
   protected void onStart() {
     super.onStart();
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START);
+    getLifecycle().handleLifecycleEvent(Lifecycle.Event.ON_START);
     if (stillAttachedForEvent("onStart")) {
       delegate.onStart();
     }
@@ -673,7 +673,7 @@ public class FlutterActivity extends ComponentActivity
   @Override
   protected void onResume() {
     super.onResume();
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
+    getLifecycle().handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
     if (stillAttachedForEvent("onResume")) {
       delegate.onResume();
     }
@@ -693,7 +693,7 @@ public class FlutterActivity extends ComponentActivity
     if (stillAttachedForEvent("onPause")) {
       delegate.onPause();
     }
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE);
+    getLifecycle().handleLifecycleEvent(Lifecycle.Event.ON_PAUSE);
   }
 
   @Override
@@ -702,7 +702,7 @@ public class FlutterActivity extends ComponentActivity
     if (stillAttachedForEvent("onStop")) {
       delegate.onStop();
     }
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP);
+    getLifecycle().handleLifecycleEvent(Lifecycle.Event.ON_STOP);
   }
 
   @Override
@@ -755,7 +755,7 @@ public class FlutterActivity extends ComponentActivity
       delegate.onDetach();
     }
     release();
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY);
+    getLifecycle().handleLifecycleEvent(Lifecycle.Event.ON_DESTROY);
   }
 
   @Override

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -506,14 +506,14 @@ public class FlutterActivity extends ComponentActivity
   }
 
   /**
-   * Registers the callback with OnBackInvokedDispatcher to capture back navigation
-   * gestures and pass them to the framework.
+   * Registers the callback with OnBackInvokedDispatcher to capture back navigation gestures and
+   * pass them to the framework.
    *
-   * This replaces the deprecated onBackPressed method override in order to support
-   * API 33's predictive back navigation feature.
+   * <p>This replaces the deprecated onBackPressed method override in order to support API 33's
+   * predictive back navigation feature.
    *
-   * The callback must be unregistered in order to prevent unpredictable behavior
-   * once outside the Flutter app.
+   * The callback must be unregistered in order to prevent unpredictable behavior once outside
+   * the Flutter app.
    */
   @VisibleForTesting
   public void registerOnBackInvokedCallback() {
@@ -527,7 +527,7 @@ public class FlutterActivity extends ComponentActivity
   /**
    * Unregisters the callback from OnBackInvokedDispatcher.
    *
-   * This should be called when the activity is no longer in use to prevent unpredictable
+   * <p>This should be called when the activity is no longer in use to prevent unpredictable
    * behavior such as being stuck and unable to press back.
    */
   @VisibleForTesting

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
@@ -103,6 +103,21 @@ public class FlutterActivityTest {
     verify(activity, times(1)).registerOnBackInvokedCallback();
   }
 
+  // TODO(garyq): Robolectric does not yet support android api 33 yet. Switch to a robolectric
+  // test that directly exercises the OnBackInvoked APIs when API 33 is supported.
+  @Test
+  @TargetApi(33)
+  public void itUnregistersOnBackInvokedCallbackOnRelease() {
+    Intent intent = FlutterActivityWithReportFullyDrawn.createDefaultIntent(ctx);
+    ActivityController<FlutterActivityWithReportFullyDrawn> activityController =
+        Robolectric.buildActivity(FlutterActivityWithReportFullyDrawn.class, intent);
+    FlutterActivityWithReportFullyDrawn activity = spy(activityController.get());
+
+    activity.release();
+
+    verify(activity, times(1)).unregisterOnBackInvokedCallback();
+  }
+
   @Test
   public void itCreatesDefaultIntentWithExpectedDefaults() {
     Intent intent = FlutterActivity.createDefaultIntent(ctx);

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
@@ -88,6 +88,21 @@ public class FlutterActivityTest {
     assertTrue(activity.findViewById(FlutterActivity.FLUTTER_VIEW_ID) instanceof FlutterView);
   }
 
+  // TODO(garyq): Robolectric does not yet support android api 33 yet. Switch to a robolectric
+  // test that directly exercises the OnBackInvoked APIs when API 33 is supported.
+  @Test
+  @TargetApi(33)
+  public void itRegistersOnBackInvokedCallbackOnCreate() {
+    Intent intent = FlutterActivityWithReportFullyDrawn.createDefaultIntent(ctx);
+    ActivityController<FlutterActivityWithReportFullyDrawn> activityController =
+        Robolectric.buildActivity(FlutterActivityWithReportFullyDrawn.class, intent);
+    FlutterActivityWithReportFullyDrawn activity = spy(activityController.get());
+
+    activity.onCreate(null);
+
+    verify(activity, times(1)).registerOnBackInvokedCallback();
+  }
+
   @Test
   public void itCreatesDefaultIntentWithExpectedDefaults() {
     Intent intent = FlutterActivity.createDefaultIntent(ctx);
@@ -594,6 +609,14 @@ public class FlutterActivityTest {
     public void resetFullyDrawn() {
       fullyDrawn = false;
     }
+  }
+
+  private class FlutterActivityWithMockBackInvokedHandling extends FlutterActivity {
+    @Override
+    public void registerOnBackInvokedCallback() {}
+
+    @Override
+    public void unregisterOnBackInvokedCallback() {}
   }
 
   private static final class FakeFlutterPlugin

--- a/shell/platform/android/test_runner/build.gradle
+++ b/shell/platform/android/test_runner/build.gradle
@@ -36,7 +36,6 @@ android {
   compileSdkVersion 33
 
   defaultConfig {
-    targetSdkVersion 33
     minSdkVersion 16
   }
 
@@ -71,7 +70,7 @@ android {
     testImplementation "androidx.test:core:1.4.0"
     testImplementation "com.google.android.play:core:1.8.0"
     testImplementation "com.ibm.icu:icu4j:69.1"
-    testImplementation "org.robolectric:robolectric:4.8.2"
+    testImplementation "org.robolectric:robolectric:4.7.3"
     testImplementation "junit:junit:4.13.2"
     testImplementation "androidx.test.ext:junit:1.1.4-alpha07"
 

--- a/shell/platform/android/test_runner/build.gradle
+++ b/shell/platform/android/test_runner/build.gradle
@@ -36,6 +36,7 @@ android {
   compileSdkVersion 33
 
   defaultConfig {
+    targetSdkVersion 33
     minSdkVersion 16
   }
 
@@ -70,11 +71,11 @@ android {
     testImplementation "androidx.test:core:1.4.0"
     testImplementation "com.google.android.play:core:1.8.0"
     testImplementation "com.ibm.icu:icu4j:69.1"
-    testImplementation "org.robolectric:robolectric:4.7.3"
-    testImplementation "junit:junit:4.13"
-    testImplementation "androidx.test.ext:junit:1.1.3"
+    testImplementation "org.robolectric:robolectric:4.8.2"
+    testImplementation "junit:junit:4.13.2"
+    testImplementation "androidx.test.ext:junit:1.1.4-alpha07"
 
-    def mockitoVersion = "4.1.0"
+    def mockitoVersion = "4.7.0"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.mockito:mockito-inline:$mockitoVersion"
     testImplementation "org.mockito:mockito-android:$mockitoVersion"

--- a/shell/platform/android/test_runner/src/main/resources/robolectric.properties
+++ b/shell/platform/android/test_runner/src/main/resources/robolectric.properties
@@ -1,2 +1,2 @@
-sdk=32
+sdk=31
 shadows=io.flutter.CustomShadowContextImpl

--- a/shell/platform/android/test_runner/src/main/resources/robolectric.properties
+++ b/shell/platform/android/test_runner/src/main/resources/robolectric.properties
@@ -1,2 +1,2 @@
-sdk=31
+sdk=32
 shadows=io.flutter.CustomShadowContextImpl


### PR DESCRIPTION
Implements `OnBackInvoked____ in order to provide pre-13 backnavigation behavior when predictive backnav is enabled.

This PR will allow back actions to pop flutter route instead of exiting the app completely.

This also bumps some dependencies to better support API 33.

Partially addresses https://github.com/flutter/flutter/issues/109558 and https://github.com/flutter/flutter/issues/109513