### PR TITLE
Detect high contrast mode on Windows

### DIFF
--- a/shell/platform/windows/flutter_window.cc
+++ b/shell/platform/windows/flutter_window.cc
@@ -282,7 +282,7 @@ PointerLocation FlutterWindow::GetPrimaryPointerLocation() {
 }
 
 void FlutterWindow::OnThemeChange() {
-  HIGHCONTRAST high_contrast = { .cbSize = sizeof(HIGHCONTRAST) };
+  HIGHCONTRAST high_contrast = {.cbSize = sizeof(HIGHCONTRAST)};
   // API call is only supported on Windows 8+
   if (SystemParametersInfoW(SPI_GETHIGHCONTRAST, sizeof(HIGHCONTRAST),
                             &high_contrast, 0)) {
@@ -290,9 +290,8 @@ void FlutterWindow::OnThemeChange() {
     // Currently, only FlutterWindowsView should be used as delegate on Windows
     binding_handler_delegate_->UpdateHighContrastEnabled(hc_on);
   } else {
-    FML_LOG(INFO)
-        << "Failed to get status of high contrast feature,"
-        << "support only for Windows 8 + ";
+    FML_LOG(INFO) << "Failed to get status of high contrast feature,"
+                  << "support only for Windows 8 + ";
   }
 }
 

--- a/shell/platform/windows/flutter_window.cc
+++ b/shell/platform/windows/flutter_window.cc
@@ -6,6 +6,7 @@
 
 #include <WinUser.h>
 #include <dwmapi.h>
+
 #include <chrono>
 #include <map>
 
@@ -282,16 +283,7 @@ PointerLocation FlutterWindow::GetPrimaryPointerLocation() {
 }
 
 void FlutterWindow::OnThemeChange() {
-  HIGHCONTRAST high_contrast = {.cbSize = sizeof(HIGHCONTRAST)};
-  // API call is only supported on Windows 8+
-  if (SystemParametersInfoW(SPI_GETHIGHCONTRAST, sizeof(HIGHCONTRAST),
-                            &high_contrast, 0)) {
-    BOOL hc_on = high_contrast.dwFlags & HCF_HIGHCONTRASTON;
-    binding_handler_delegate_->UpdateHighContrastEnabled(hc_on);
-  } else {
-    FML_LOG(INFO) << "Failed to get status of high contrast feature,"
-                  << "support only for Windows 8 + ";
-  }
+  binding_handler_delegate_->UpdateHighContrastEnabled(GetHighContrastEnabled());
 }
 
 void FlutterWindow::SendInitialAccessibilityFeatures() {

--- a/shell/platform/windows/flutter_window.cc
+++ b/shell/platform/windows/flutter_window.cc
@@ -283,18 +283,15 @@ PointerLocation FlutterWindow::GetPrimaryPointerLocation() {
 
 void FlutterWindow::OnThemeChange() {
   HIGHCONTRAST high_contrast = {sizeof(HIGHCONTRAST)};
-  if (SystemParametersInfoW(SPI_GETHIGHCONTRAST,
-      sizeof(HIGHCONTRAST), &high_contrast, 0)) {
+  if (SystemParametersInfoW(SPI_GETHIGHCONTRAST, sizeof(HIGHCONTRAST),
+                            &high_contrast, 0)) {
     BOOL hc_on = high_contrast.dwFlags & HCF_HIGHCONTRASTON;
     // Currently, only FlutterWindowsView should be used as delegate on Windows
     FlutterWindowsView* view =
         reinterpret_cast<FlutterWindowsView*>(binding_handler_delegate_);
-    else {
-      FlutterWindowsEngine* engine = view->GetEngine();
-      engine->UpdateHighContrastEnabled(hc_on);
-    }
-  }
-  else {
+    FlutterWindowsEngine* engine = view->GetEngine();
+    engine->UpdateHighContrastEnabled(hc_on);
+  } else {
     FML_LOG(ERROR) << "Failed to get status of high contrast feature";
   }
 }

--- a/shell/platform/windows/flutter_window.cc
+++ b/shell/platform/windows/flutter_window.cc
@@ -4,10 +4,10 @@
 
 #include "flutter/shell/platform/windows/flutter_window.h"
 
+#include <WinUser.h>
 #include <dwmapi.h>
 #include <chrono>
 #include <map>
-#include <WinUser.h>
 
 #include "flutter/fml/logging.h"
 #include "flutter/shell/platform/embedder/embedder.h"

--- a/shell/platform/windows/flutter_window.cc
+++ b/shell/platform/windows/flutter_window.cc
@@ -287,7 +287,6 @@ void FlutterWindow::OnThemeChange() {
   if (SystemParametersInfoW(SPI_GETHIGHCONTRAST, sizeof(HIGHCONTRAST),
                             &high_contrast, 0)) {
     BOOL hc_on = high_contrast.dwFlags & HCF_HIGHCONTRASTON;
-    // Currently, only FlutterWindowsView should be used as delegate on Windows
     binding_handler_delegate_->UpdateHighContrastEnabled(hc_on);
   } else {
     FML_LOG(INFO) << "Failed to get status of high contrast feature,"
@@ -295,7 +294,7 @@ void FlutterWindow::OnThemeChange() {
   }
 }
 
-void FlutterWindow::UpdateInitialAccessibilityFeatures() {
+void FlutterWindow::SendInitialAccessibilityFeatures() {
   OnThemeChange();
 }
 

--- a/shell/platform/windows/flutter_window.cc
+++ b/shell/platform/windows/flutter_window.cc
@@ -7,8 +7,12 @@
 #include <dwmapi.h>
 #include <chrono>
 #include <map>
+#include <WinUser.h>
 
 #include "flutter/fml/logging.h"
+#include "flutter/shell/platform/embedder/embedder.h"
+#include "flutter/shell/platform/windows/flutter_windows_engine.h"
+#include "flutter/shell/platform/windows/flutter_windows_view.h"
 
 namespace flutter {
 
@@ -275,6 +279,26 @@ PointerLocation FlutterWindow::GetPrimaryPointerLocation() {
   GetCursorPos(&point);
   ScreenToClient(GetWindowHandle(), &point);
   return {(size_t)point.x, (size_t)point.y};
+}
+
+void FlutterWindow::OnThemeChange() {
+  FML_LOG(ERROR) << "THEME CHANGE!!";
+  HIGHCONTRAST high_contrast = {sizeof(HIGHCONTRAST)};
+  if (SystemParametersInfoW(SPI_GETHIGHCONTRAST, sizeof(HIGHCONTRAST), &high_contrast, 0)) {
+    BOOL hc_on = high_contrast.dwFlags & HCF_HIGHCONTRASTON;
+    FML_LOG(ERROR) << "HIGH CONTRAST IS ON? " << hc_on;
+    FlutterWindowsView* view = reinterpret_cast<FlutterWindowsView*>(binding_handler_delegate_);
+    if (view == nullptr) {
+      FML_LOG(ERROR) << "Binding handler delegate is not a FlutterWindowsView";
+    }
+    else {
+      FlutterWindowsEngine* engine = view->GetEngine();
+      FlutterEngineUpdateAccessibilityFeatures(*engine, FlutterAccessibilityFeature::kFlutterAccessibilityFeatureHighContrast);
+    }
+  }
+  else {
+    FML_LOG(ERROR) << "FAILED TO GET HIGH CONTRAST!";
+  }
 }
 
 }  // namespace flutter

--- a/shell/platform/windows/flutter_window.cc
+++ b/shell/platform/windows/flutter_window.cc
@@ -283,12 +283,12 @@ PointerLocation FlutterWindow::GetPrimaryPointerLocation() {
 
 void FlutterWindow::OnThemeChange() {
   HIGHCONTRAST high_contrast = {sizeof(HIGHCONTRAST)};
-  if (SystemParametersInfoW(SPI_GETHIGHCONTRAST, sizeof(HIGHCONTRAST), &high_contrast, 0)) {
+  if (SystemParametersInfoW(SPI_GETHIGHCONTRAST,
+      sizeof(HIGHCONTRAST), &high_contrast, 0)) {
     BOOL hc_on = high_contrast.dwFlags & HCF_HIGHCONTRASTON;
-    FlutterWindowsView* view = reinterpret_cast<FlutterWindowsView*>(binding_handler_delegate_);
-    if (view == nullptr) {
-      FML_LOG(ERROR) << "Binding handler delegate is not a FlutterWindowsView";
-    }
+    // Currently, only FlutterWindowsView should be used as delegate on Windows
+    FlutterWindowsView* view =
+        reinterpret_cast<FlutterWindowsView*>(binding_handler_delegate_);
     else {
       FlutterWindowsEngine* engine = view->GetEngine();
       engine->UpdateHighContrastEnabled(hc_on);

--- a/shell/platform/windows/flutter_window.cc
+++ b/shell/platform/windows/flutter_window.cc
@@ -282,23 +282,25 @@ PointerLocation FlutterWindow::GetPrimaryPointerLocation() {
 }
 
 void FlutterWindow::OnThemeChange() {
-  FML_LOG(ERROR) << "THEME CHANGE!!";
   HIGHCONTRAST high_contrast = {sizeof(HIGHCONTRAST)};
   if (SystemParametersInfoW(SPI_GETHIGHCONTRAST, sizeof(HIGHCONTRAST), &high_contrast, 0)) {
     BOOL hc_on = high_contrast.dwFlags & HCF_HIGHCONTRASTON;
-    FML_LOG(ERROR) << "HIGH CONTRAST IS ON? " << hc_on;
     FlutterWindowsView* view = reinterpret_cast<FlutterWindowsView*>(binding_handler_delegate_);
     if (view == nullptr) {
       FML_LOG(ERROR) << "Binding handler delegate is not a FlutterWindowsView";
     }
     else {
       FlutterWindowsEngine* engine = view->GetEngine();
-      FlutterEngineUpdateAccessibilityFeatures(*engine, FlutterAccessibilityFeature::kFlutterAccessibilityFeatureHighContrast);
+      engine->UpdateHighContrastEnabled(hc_on);
     }
   }
   else {
-    FML_LOG(ERROR) << "FAILED TO GET HIGH CONTRAST!";
+    FML_LOG(ERROR) << "Failed to get status of high contrast feature";
   }
+}
+
+void FlutterWindow::AfterEngineSet() {
+  OnThemeChange();
 }
 
 }  // namespace flutter

--- a/shell/platform/windows/flutter_window.cc
+++ b/shell/platform/windows/flutter_window.cc
@@ -283,7 +283,8 @@ PointerLocation FlutterWindow::GetPrimaryPointerLocation() {
 }
 
 void FlutterWindow::OnThemeChange() {
-  binding_handler_delegate_->UpdateHighContrastEnabled(GetHighContrastEnabled());
+  binding_handler_delegate_->UpdateHighContrastEnabled(
+      GetHighContrastEnabled());
 }
 
 void FlutterWindow::SendInitialAccessibilityFeatures() {

--- a/shell/platform/windows/flutter_window.cc
+++ b/shell/platform/windows/flutter_window.cc
@@ -282,21 +282,21 @@ PointerLocation FlutterWindow::GetPrimaryPointerLocation() {
 }
 
 void FlutterWindow::OnThemeChange() {
-  HIGHCONTRAST high_contrast = {sizeof(HIGHCONTRAST)};
+  HIGHCONTRAST high_contrast = { .cbSize = sizeof(HIGHCONTRAST) };
+  // API call is only supported on Windows 8+
   if (SystemParametersInfoW(SPI_GETHIGHCONTRAST, sizeof(HIGHCONTRAST),
                             &high_contrast, 0)) {
     BOOL hc_on = high_contrast.dwFlags & HCF_HIGHCONTRASTON;
     // Currently, only FlutterWindowsView should be used as delegate on Windows
-    FlutterWindowsView* view =
-        reinterpret_cast<FlutterWindowsView*>(binding_handler_delegate_);
-    FlutterWindowsEngine* engine = view->GetEngine();
-    engine->UpdateHighContrastEnabled(hc_on);
+    binding_handler_delegate_->UpdateHighContrastEnabled(hc_on);
   } else {
-    FML_LOG(ERROR) << "Failed to get status of high contrast feature";
+    FML_LOG(INFO)
+        << "Failed to get status of high contrast feature,"
+        << "support only for Windows 8 + ";
   }
 }
 
-void FlutterWindow::AfterEngineSet() {
+void FlutterWindow::UpdateInitialAccessibilityFeatures() {
   OnThemeChange();
 }
 

--- a/shell/platform/windows/flutter_window.h
+++ b/shell/platform/windows/flutter_window.h
@@ -145,6 +145,9 @@ class FlutterWindow : public Window, public WindowBindingHandler {
   // |Window|
   void OnThemeChange() override;
 
+  // |WindowBindingHandler|
+  void AfterEngineSet() override;
+
  private:
   // A pointer to a FlutterWindowsView that can be used to update engine
   // windowing and input state.

--- a/shell/platform/windows/flutter_window.h
+++ b/shell/platform/windows/flutter_window.h
@@ -142,6 +142,9 @@ class FlutterWindow : public Window, public WindowBindingHandler {
   // |FlutterWindowBindingHandler|
   PointerLocation GetPrimaryPointerLocation() override;
 
+  // |Window|
+  void OnThemeChange() override;
+
  private:
   // A pointer to a FlutterWindowsView that can be used to update engine
   // windowing and input state.

--- a/shell/platform/windows/flutter_window.h
+++ b/shell/platform/windows/flutter_window.h
@@ -146,7 +146,7 @@ class FlutterWindow : public Window, public WindowBindingHandler {
   void OnThemeChange() override;
 
   // |WindowBindingHandler|
-  void UpdateInitialAccessibilityFeatures() override;
+  void SendInitialAccessibilityFeatures() override;
 
  private:
   // A pointer to a FlutterWindowsView that can be used to update engine

--- a/shell/platform/windows/flutter_window.h
+++ b/shell/platform/windows/flutter_window.h
@@ -146,7 +146,7 @@ class FlutterWindow : public Window, public WindowBindingHandler {
   void OnThemeChange() override;
 
   // |WindowBindingHandler|
-  void AfterEngineSet() override;
+  void UpdateInitialAccessibilityFeatures() override;
 
  private:
   // A pointer to a FlutterWindowsView that can be used to update engine

--- a/shell/platform/windows/flutter_window_unittests.cc
+++ b/shell/platform/windows/flutter_window_unittests.cc
@@ -384,7 +384,6 @@ TEST(FlutterWindowTest, OnThemeChange) {
   win32window.SetView(&delegate);
 
   ON_CALL(win32window, GetHighContrastEnabled()).WillByDefault(Return(true));
-  EXPECT_CALL(win32window, GetHighContrastEnabled()).Times(1);
   EXPECT_CALL(delegate, UpdateHighContrastEnabled(true)).Times(1);
 
   win32window.InjectWindowMessage(WM_THEMECHANGED, 0, 0);

--- a/shell/platform/windows/flutter_window_unittests.cc
+++ b/shell/platform/windows/flutter_window_unittests.cc
@@ -128,6 +128,7 @@ class MockFlutterWindow : public FlutterWindow {
                void(double, double, FlutterPointerDeviceKind, int32_t));
   MOCK_METHOD0(OnSetCursor, void());
   MOCK_METHOD0(GetScrollOffsetMultiplier, float());
+  MOCK_METHOD0(GetHighContrastEnabled, bool());
   MOCK_METHOD0(GetDpiScale, float());
   MOCK_METHOD0(IsVisible, bool());
   MOCK_METHOD1(UpdateCursorRect, void(const Rect&));
@@ -375,6 +376,19 @@ TEST(FlutterWindowTest, OnWindowRepaint) {
   EXPECT_CALL(delegate, OnWindowRepaint()).Times(1);
 
   win32window.InjectWindowMessage(WM_PAINT, 0, 0);
+}
+
+TEST(FlutterWindowTest, OnThemeChange) {
+  MockFlutterWindow win32window;
+  MockWindowBindingHandlerDelegate delegate;
+  win32window.SetView(&delegate);
+
+  ON_CALL(win32window, GetHighContrastEnabled())
+      .WillByDefault(Return(true));
+  EXPECT_CALL(win32window, GetHighContrastEnabled()).Times(1);
+  EXPECT_CALL(delegate, UpdateHighContrastEnabled(true)).Times(1);
+
+  win32window.InjectWindowMessage(WM_THEMECHANGED, 0, 0);
 }
 
 }  // namespace testing

--- a/shell/platform/windows/flutter_window_unittests.cc
+++ b/shell/platform/windows/flutter_window_unittests.cc
@@ -383,8 +383,7 @@ TEST(FlutterWindowTest, OnThemeChange) {
   MockWindowBindingHandlerDelegate delegate;
   win32window.SetView(&delegate);
 
-  ON_CALL(win32window, GetHighContrastEnabled())
-      .WillByDefault(Return(true));
+  ON_CALL(win32window, GetHighContrastEnabled()).WillByDefault(Return(true));
   EXPECT_CALL(win32window, GetHighContrastEnabled()).Times(1);
   EXPECT_CALL(delegate, UpdateHighContrastEnabled(true)).Times(1);
 

--- a/shell/platform/windows/flutter_window_unittests.cc
+++ b/shell/platform/windows/flutter_window_unittests.cc
@@ -389,5 +389,16 @@ TEST(FlutterWindowTest, OnThemeChange) {
   win32window.InjectWindowMessage(WM_THEMECHANGED, 0, 0);
 }
 
+TEST(FlutterWindowTest, InitialAccessibilityFeatures) {
+  MockFlutterWindow win32window;
+  MockWindowBindingHandlerDelegate delegate;
+  win32window.SetView(&delegate);
+
+  ON_CALL(win32window, GetHighContrastEnabled()).WillByDefault(Return(true));
+  EXPECT_CALL(delegate, UpdateHighContrastEnabled(true)).Times(1);
+
+  win32window.SendInitialAccessibilityFeatures();
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/shell/platform/windows/flutter_windows.cc
+++ b/shell/platform/windows/flutter_windows.cc
@@ -85,6 +85,7 @@ FlutterDesktopViewControllerRef FlutterDesktopViewControllerCreate(
 
   // Must happen after engine is running.
   state->view->SendInitialBounds();
+  state->view->SendInitialAccessibilityFeatures();
   return state.release();
 }
 

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -620,6 +620,7 @@ void FlutterWindowsEngine::UpdateAccessibilityFeatures(
 }
 
 void FlutterWindowsEngine::UpdateHighContrastEnabled(bool enabled) {
+  high_contrast_enabled_ = enabled;
   int flags = EnabledAccessibilityFeatures();
   if (enabled) {
     flags |= FlutterAccessibilityFeature::kFlutterAccessibilityFeatureHighContrast;

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -346,6 +346,8 @@ bool FlutterWindowsEngine::Run(std::string_view entrypoint) {
     return false;
   }
 
+  UpdateAccessibilityFeatures(queued_flags_);
+
   // Configure device frame rate displayed via devtools.
   FlutterEngineDisplay display = {};
   display.struct_size = sizeof(FlutterEngineDisplay);
@@ -605,6 +607,38 @@ std::string FlutterWindowsEngine::GetExecutableName() const {
     return executable_path.substr(last_separator + 1);
   }
   return "Flutter";
+}
+
+void FlutterWindowsEngine::UpdateAccessibilityFeatures(
+    FlutterAccessibilityFeature flags) {
+  if (!engine_) {
+    // Queue the accessibility flags to set them once the engine is available
+    queued_flags_ = flags;
+    return;
+  }
+  embedder_api_.UpdateAccessibilityFeatures(engine_, flags);
+}
+
+void FlutterWindowsEngine::UpdateHighContrastEnabled(bool enabled) {
+  int flags = EnabledAccessibilityFeatures();
+  if (enabled) {
+    flags |= FlutterAccessibilityFeature::kFlutterAccessibilityFeatureHighContrast;
+  }
+  else {
+    flags &= ~FlutterAccessibilityFeature::kFlutterAccessibilityFeatureHighContrast;
+  }
+  UpdateAccessibilityFeatures(static_cast<FlutterAccessibilityFeature>(flags));
+}
+
+int FlutterWindowsEngine::EnabledAccessibilityFeatures() const {
+  int flags = 0;
+  if (high_contrast_enabled()) {
+    flags |=
+        FlutterAccessibilityFeature::kFlutterAccessibilityFeatureHighContrast;
+  }
+  // As more accessibility features are enabled for Windows,
+  // the corresponding checks and flags should be added here.
+  return flags;
 }
 
 }  // namespace flutter

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -346,8 +346,6 @@ bool FlutterWindowsEngine::Run(std::string_view entrypoint) {
     return false;
   }
 
-  UpdateAccessibilityFeatures(queued_flags_);
-
   // Configure device frame rate displayed via devtools.
   FlutterEngineDisplay display = {};
   display.struct_size = sizeof(FlutterEngineDisplay);
@@ -611,12 +609,9 @@ std::string FlutterWindowsEngine::GetExecutableName() const {
 
 void FlutterWindowsEngine::UpdateAccessibilityFeatures(
     FlutterAccessibilityFeature flags) {
-  if (!engine_) {
-    // Queue the accessibility flags to set them once the engine is available
-    queued_flags_ = flags;
-    return;
+  if (engine_) {
+    embedder_api_.UpdateAccessibilityFeatures(engine_, flags);
   }
-  embedder_api_.UpdateAccessibilityFeatures(engine_, flags);
 }
 
 void FlutterWindowsEngine::UpdateHighContrastEnabled(bool enabled) {

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -609,9 +609,7 @@ std::string FlutterWindowsEngine::GetExecutableName() const {
 
 void FlutterWindowsEngine::UpdateAccessibilityFeatures(
     FlutterAccessibilityFeature flags) {
-  if (engine_) {
-    embedder_api_.UpdateAccessibilityFeatures(engine_, flags);
-  }
+  embedder_api_.UpdateAccessibilityFeatures(engine_, flags);
 }
 
 void FlutterWindowsEngine::UpdateHighContrastEnabled(bool enabled) {

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -623,10 +623,11 @@ void FlutterWindowsEngine::UpdateHighContrastEnabled(bool enabled) {
   high_contrast_enabled_ = enabled;
   int flags = EnabledAccessibilityFeatures();
   if (enabled) {
-    flags |= FlutterAccessibilityFeature::kFlutterAccessibilityFeatureHighContrast;
-  }
-  else {
-    flags &= ~FlutterAccessibilityFeature::kFlutterAccessibilityFeatureHighContrast;
+    flags |=
+        FlutterAccessibilityFeature::kFlutterAccessibilityFeatureHighContrast;
+  } else {
+    flags &=
+        ~FlutterAccessibilityFeature::kFlutterAccessibilityFeatureHighContrast;
   }
   UpdateAccessibilityFeatures(static_cast<FlutterAccessibilityFeature>(flags));
 }

--- a/shell/platform/windows/flutter_windows_engine.h
+++ b/shell/platform/windows/flutter_windows_engine.h
@@ -318,7 +318,8 @@ class FlutterWindowsEngine {
   // The on frame drawn callback.
   fml::closure next_frame_callback_;
 
-  FlutterAccessibilityFeature queued_flags_ = static_cast<FlutterAccessibilityFeature>(0);
+  FlutterAccessibilityFeature queued_flags_ =
+      static_cast<FlutterAccessibilityFeature>(0);
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/flutter_windows_engine.h
+++ b/shell/platform/windows/flutter_windows_engine.h
@@ -317,9 +317,6 @@ class FlutterWindowsEngine {
 
   // The on frame drawn callback.
   fml::closure next_frame_callback_;
-
-  FlutterAccessibilityFeature queued_flags_ =
-      static_cast<FlutterAccessibilityFeature>(0);
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/flutter_windows_engine.h
+++ b/shell/platform/windows/flutter_windows_engine.h
@@ -204,6 +204,15 @@ class FlutterWindowsEngine {
   // Returns true if the semantics tree is enabled.
   bool semantics_enabled() const { return semantics_enabled_; }
 
+  // Update the high contrast feature state.
+  void UpdateHighContrastEnabled(bool enabled);
+
+  // Returns the flags for all currently enabled accessibility features
+  int EnabledAccessibilityFeatures() const;
+
+  // Returns true if the high contrast feature is enabled.
+  bool high_contrast_enabled() const { return high_contrast_enabled_; }
+
   // Returns the native accessibility node with the given id.
   gfx::NativeViewAccessible GetNativeAccessibleFromId(AccessibilityNodeId id);
 
@@ -222,6 +231,9 @@ class FlutterWindowsEngine {
 
   // Returns the executable name for this process or "Flutter" if unknown.
   std::string GetExecutableName() const;
+
+  // Updates accessibility, e.g. switch to high contrast mode
+  void UpdateAccessibilityFeatures(FlutterAccessibilityFeature flags);
 
  private:
   // Allows swapping out embedder_api_ calls in tests.
@@ -293,6 +305,8 @@ class FlutterWindowsEngine {
 
   bool semantics_enabled_ = false;
 
+  bool high_contrast_enabled_ = false;
+
   std::shared_ptr<AccessibilityBridge> accessibility_bridge_;
 
   // The manager for WindowProc delegate registration and callbacks.
@@ -303,6 +317,8 @@ class FlutterWindowsEngine {
 
   // The on frame drawn callback.
   fml::closure next_frame_callback_;
+
+  FlutterAccessibilityFeature queued_flags_ = static_cast<FlutterAccessibilityFeature>(0);
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/flutter_windows_engine_unittests.cc
+++ b/shell/platform/windows/flutter_windows_engine_unittests.cc
@@ -76,6 +76,12 @@ TEST(FlutterWindowsEngine, RunDoesExpectedInitialization) {
                   THREAD_PRIORITY_ABOVE_NORMAL);
         return kSuccess;
       }));
+  // Accessibility updates must do nothing when the embedder engine is mocked
+  modifier.embedder_api().UpdateAccessibilityFeatures = MOCK_ENGINE_PROC(
+      UpdateAccessibilityFeatures, [](FLUTTER_API_SYMBOL(FlutterEngine) engine,
+         FlutterAccessibilityFeature flags) {
+        return kSuccess;
+      });
 
   // It should send locale info.
   bool update_locales_called = false;
@@ -193,6 +199,12 @@ TEST(FlutterWindowsEngine, RunWithoutANGLEUsesSoftware) {
         EXPECT_EQ(config->type, kSoftware);
         return kSuccess;
       }));
+  // Accessibility updates must do nothing when the embedder engine is mocked
+  modifier.embedder_api().UpdateAccessibilityFeatures = MOCK_ENGINE_PROC(
+      UpdateAccessibilityFeatures, [](FLUTTER_API_SYMBOL(FlutterEngine) engine,
+         FlutterAccessibilityFeature flags) {
+        return kSuccess;
+      });
 
   // Stub out UpdateLocales and SendPlatformMessage as we don't have a fully
   // initialized engine instance.
@@ -407,6 +419,22 @@ TEST(FlutterWindowsEngine, SetNextFrameCallback) {
 TEST(FlutterWindowsEngine, GetExecutableName) {
   std::unique_ptr<FlutterWindowsEngine> engine = GetTestEngine();
   EXPECT_EQ(engine->GetExecutableName(), "flutter_windows_unittests.exe");
+}
+
+// Ensure that after setting or resetting the high contrast feature,
+// the corresponding status flag can be retrieved from the engine.
+TEST(FlutterWindowsEngine, UpdateHighContrastFeature) {
+  std::unique_ptr<FlutterWindowsEngine> engine = GetTestEngine();
+
+  engine->UpdateHighContrastEnabled(true);
+  EXPECT_TRUE(engine->EnabledAccessibilityFeatures() &
+      FlutterAccessibilityFeature::kFlutterAccessibilityFeatureHighContrast);
+  EXPECT_TRUE(engine->high_contrast_enabled());
+
+  engine->UpdateHighContrastEnabled(false);
+  EXPECT_FALSE(engine->EnabledAccessibilityFeatures() &
+      FlutterAccessibilityFeature::kFlutterAccessibilityFeatureHighContrast);
+  EXPECT_FALSE(engine->high_contrast_enabled());
 }
 
 }  // namespace testing

--- a/shell/platform/windows/flutter_windows_engine_unittests.cc
+++ b/shell/platform/windows/flutter_windows_engine_unittests.cc
@@ -425,22 +425,6 @@ TEST(FlutterWindowsEngine, UpdateHighContrastFeature) {
   std::unique_ptr<FlutterWindowsEngine> engine = GetTestEngine();
   EngineModifier modifier(engine.get());
 
-  modifier.embedder_api().Run = MOCK_ENGINE_PROC(
-      Run, ([](auto version, auto config, auto args, auto user_data,
-               FLUTTER_API_SYMBOL(FlutterEngine) * engine_out) {
-        *engine_out = reinterpret_cast<FLUTTER_API_SYMBOL(FlutterEngine)>(1);
-        return kSuccess;
-      }));
-  modifier.embedder_api().NotifyDisplayUpdate = MOCK_ENGINE_PROC(
-      NotifyDisplayUpdate,
-      ([](auto engine, auto type, auto data, auto size) { return kSuccess; }));
-  modifier.embedder_api().UpdateLocales = MOCK_ENGINE_PROC(
-      UpdateLocales, ([](auto engine, const FlutterLocale** locales,
-                         size_t locales_count) { return kSuccess; }));
-  modifier.embedder_api().SendPlatformMessage =
-      MOCK_ENGINE_PROC(SendPlatformMessage,
-                       ([](auto engine, auto message) { return kSuccess; }));
-
   bool called = false;
   modifier.embedder_api().UpdateAccessibilityFeatures = MOCK_ENGINE_PROC(
       UpdateAccessibilityFeatures, ([&called](auto engine, auto flags) {
@@ -448,7 +432,6 @@ TEST(FlutterWindowsEngine, UpdateHighContrastFeature) {
         return kSuccess;
       }));
 
-  engine->Run();
   engine->UpdateHighContrastEnabled(true);
   EXPECT_TRUE(
       engine->EnabledAccessibilityFeatures() &
@@ -461,8 +444,6 @@ TEST(FlutterWindowsEngine, UpdateHighContrastFeature) {
       engine->EnabledAccessibilityFeatures() &
       FlutterAccessibilityFeature::kFlutterAccessibilityFeatureHighContrast);
   EXPECT_FALSE(engine->high_contrast_enabled());
-
-  modifier.embedder_api().Shutdown = [](auto engine) { return kSuccess; };
 }
 
 }  // namespace testing

--- a/shell/platform/windows/flutter_windows_engine_unittests.cc
+++ b/shell/platform/windows/flutter_windows_engine_unittests.cc
@@ -78,10 +78,9 @@ TEST(FlutterWindowsEngine, RunDoesExpectedInitialization) {
       }));
   // Accessibility updates must do nothing when the embedder engine is mocked
   modifier.embedder_api().UpdateAccessibilityFeatures = MOCK_ENGINE_PROC(
-      UpdateAccessibilityFeatures, [](FLUTTER_API_SYMBOL(FlutterEngine) engine,
-         FlutterAccessibilityFeature flags) {
-        return kSuccess;
-      });
+      UpdateAccessibilityFeatures,
+      [](FLUTTER_API_SYMBOL(FlutterEngine) engine,
+         FlutterAccessibilityFeature flags) { return kSuccess; });
 
   // It should send locale info.
   bool update_locales_called = false;
@@ -427,12 +426,14 @@ TEST(FlutterWindowsEngine, UpdateHighContrastFeature) {
   std::unique_ptr<FlutterWindowsEngine> engine = GetTestEngine();
 
   engine->UpdateHighContrastEnabled(true);
-  EXPECT_TRUE(engine->EnabledAccessibilityFeatures() &
+  EXPECT_TRUE(
+      engine->EnabledAccessibilityFeatures() &
       FlutterAccessibilityFeature::kFlutterAccessibilityFeatureHighContrast);
   EXPECT_TRUE(engine->high_contrast_enabled());
 
   engine->UpdateHighContrastEnabled(false);
-  EXPECT_FALSE(engine->EnabledAccessibilityFeatures() &
+  EXPECT_FALSE(
+      engine->EnabledAccessibilityFeatures() &
       FlutterAccessibilityFeature::kFlutterAccessibilityFeatureHighContrast);
   EXPECT_FALSE(engine->high_contrast_enabled());
 }

--- a/shell/platform/windows/flutter_windows_engine_unittests.cc
+++ b/shell/platform/windows/flutter_windows_engine_unittests.cc
@@ -200,10 +200,9 @@ TEST(FlutterWindowsEngine, RunWithoutANGLEUsesSoftware) {
       }));
   // Accessibility updates must do nothing when the embedder engine is mocked
   modifier.embedder_api().UpdateAccessibilityFeatures = MOCK_ENGINE_PROC(
-      UpdateAccessibilityFeatures, [](FLUTTER_API_SYMBOL(FlutterEngine) engine,
-         FlutterAccessibilityFeature flags) {
-        return kSuccess;
-      });
+      UpdateAccessibilityFeatures,
+      [](FLUTTER_API_SYMBOL(FlutterEngine) engine,
+         FlutterAccessibilityFeature flags) { return kSuccess; });
 
   // Stub out UpdateLocales and SendPlatformMessage as we don't have a fully
   // initialized engine instance.

--- a/shell/platform/windows/flutter_windows_engine_unittests.cc
+++ b/shell/platform/windows/flutter_windows_engine_unittests.cc
@@ -426,27 +426,20 @@ TEST(FlutterWindowsEngine, UpdateHighContrastFeature) {
   EngineModifier modifier(engine.get());
 
   modifier.embedder_api().Run = MOCK_ENGINE_PROC(
-      Run, ([](auto version, auto config,
-               auto args, auto user_data,
+      Run, ([](auto version, auto config, auto args, auto user_data,
                FLUTTER_API_SYMBOL(FlutterEngine) * engine_out) {
         *engine_out = reinterpret_cast<FLUTTER_API_SYMBOL(FlutterEngine)>(1);
         return kSuccess;
       }));
   modifier.embedder_api().NotifyDisplayUpdate = MOCK_ENGINE_PROC(
-      NotifyDisplayUpdate, ([](auto engine, auto type, auto data, auto size) {
-        return kSuccess;
-      }));
+      NotifyDisplayUpdate,
+      ([](auto engine, auto type, auto data, auto size) { return kSuccess; }));
   modifier.embedder_api().UpdateLocales = MOCK_ENGINE_PROC(
-      UpdateLocales,
-      ([](auto engine, const FlutterLocale** locales,
-                                size_t locales_count) {
-        return kSuccess;
-      }));
-  modifier.embedder_api().SendPlatformMessage = MOCK_ENGINE_PROC(
-      SendPlatformMessage,
-      ([](auto engine, auto message) {
-        return kSuccess;
-      }));
+      UpdateLocales, ([](auto engine, const FlutterLocale** locales,
+                         size_t locales_count) { return kSuccess; }));
+  modifier.embedder_api().SendPlatformMessage =
+      MOCK_ENGINE_PROC(SendPlatformMessage,
+                       ([](auto engine, auto message) { return kSuccess; }));
 
   bool called = false;
   modifier.embedder_api().UpdateAccessibilityFeatures = MOCK_ENGINE_PROC(

--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -56,6 +56,7 @@ void FlutterWindowsView::SetEngine(
   engine_ = std::move(engine);
 
   engine_->SetView(this);
+  binding_handler_->AfterEngineSet();
 
   internal_plugin_registrar_ =
       std::make_unique<PluginRegistrar>(engine_->GetRegistrar());

--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -617,7 +617,7 @@ void FlutterWindowsView::DestroyRenderSurface() {
 }
 
 void FlutterWindowsView::SendInitialAccessibilityFeatures() {
-  binding_handler_->UpdateInitialAccessibilityFeatures();
+  binding_handler_->SendInitialAccessibilityFeatures();
 }
 
 void FlutterWindowsView::UpdateHighContrastEnabled(bool enabled) {

--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -56,7 +56,6 @@ void FlutterWindowsView::SetEngine(
   engine_ = std::move(engine);
 
   engine_->SetView(this);
-  binding_handler_->AfterEngineSet();
 
   internal_plugin_registrar_ =
       std::make_unique<PluginRegistrar>(engine_->GetRegistrar());
@@ -615,6 +614,14 @@ void FlutterWindowsView::DestroyRenderSurface() {
   if (engine_ && engine_->surface_manager()) {
     engine_->surface_manager()->DestroySurface();
   }
+}
+
+void FlutterWindowsView::SendInitialAccessibilityFeatures() {
+  binding_handler_->UpdateInitialAccessibilityFeatures();
+}
+
+void FlutterWindowsView::UpdateHighContrastEnabled(bool enabled) {
+  engine_->UpdateHighContrastEnabled(enabled);
 }
 
 WindowsRenderTarget* FlutterWindowsView::GetRenderTarget() const {

--- a/shell/platform/windows/flutter_windows_view.h
+++ b/shell/platform/windows/flutter_windows_view.h
@@ -87,6 +87,12 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate,
   // Send initial bounds to embedder.  Must occur after engine has initialized.
   void SendInitialBounds();
 
+  // Send the initial accessibility features to the window
+  void SendInitialAccessibilityFeatures();
+
+  // |WindowBindingHandlerDelegate|
+  void UpdateHighContrastEnabled(bool enabled) override;
+
   // Returns the frame buffer id for the engine to render to.
   uint32_t GetFrameBufferId(size_t width, size_t height);
 

--- a/shell/platform/windows/testing/mock_window.h
+++ b/shell/platform/windows/testing/mock_window.h
@@ -65,6 +65,8 @@ class MockWindow : public Window {
   MOCK_METHOD2(OnComposeChange, void(const std::u16string&, int));
   MOCK_METHOD3(OnImeComposition, void(UINT const, WPARAM const, LPARAM const));
 
+  MOCK_METHOD0(OnThemeChange, void());
+
   void CallOnImeComposition(UINT const message,
                             WPARAM const wparam,
                             LPARAM const lparam);

--- a/shell/platform/windows/testing/mock_window_binding_handler.h
+++ b/shell/platform/windows/testing/mock_window_binding_handler.h
@@ -36,7 +36,7 @@ class MockWindowBindingHandler : public WindowBindingHandler {
   MOCK_METHOD3(OnBitmapSurfaceUpdated,
                bool(const void* allocation, size_t row_bytes, size_t height));
   MOCK_METHOD0(GetPrimaryPointerLocation, PointerLocation());
-  MOCK_METHOD0(UpdateInitialAccessibilityFeatures, void());
+  MOCK_METHOD0(SendInitialAccessibilityFeatures, void());
 };
 
 }  // namespace testing

--- a/shell/platform/windows/testing/mock_window_binding_handler.h
+++ b/shell/platform/windows/testing/mock_window_binding_handler.h
@@ -36,6 +36,7 @@ class MockWindowBindingHandler : public WindowBindingHandler {
   MOCK_METHOD3(OnBitmapSurfaceUpdated,
                bool(const void* allocation, size_t row_bytes, size_t height));
   MOCK_METHOD0(GetPrimaryPointerLocation, PointerLocation());
+  MOCK_METHOD0(AfterEngineSet, void());
 };
 
 }  // namespace testing

--- a/shell/platform/windows/testing/mock_window_binding_handler.h
+++ b/shell/platform/windows/testing/mock_window_binding_handler.h
@@ -36,7 +36,7 @@ class MockWindowBindingHandler : public WindowBindingHandler {
   MOCK_METHOD3(OnBitmapSurfaceUpdated,
                bool(const void* allocation, size_t row_bytes, size_t height));
   MOCK_METHOD0(GetPrimaryPointerLocation, PointerLocation());
-  MOCK_METHOD0(AfterEngineSet, void());
+  MOCK_METHOD0(UpdateInitialAccessibilityFeatures, void());
 };
 
 }  // namespace testing

--- a/shell/platform/windows/testing/mock_window_binding_handler_delegate.h
+++ b/shell/platform/windows/testing/mock_window_binding_handler_delegate.h
@@ -61,6 +61,7 @@ class MockWindowBindingHandlerDelegate : public WindowBindingHandlerDelegate {
                     FlutterPointerDeviceKind,
                     int32_t));
   MOCK_METHOD0(OnPlatformBrightnessChanged, void());
+  MOCK_METHOD1(UpdateHighContrastEnabled, void(bool enabled));
 };
 
 }  // namespace testing

--- a/shell/platform/windows/testing/test_keyboard.cc
+++ b/shell/platform/windows/testing/test_keyboard.cc
@@ -180,6 +180,14 @@ void MockEmbedderApiForKeyboard(
 
         return kSuccess;
       };
+  // Any time the associated EmbedderEngine will be mocked, such as here,
+  // the Update accessibility features must not attempt to actually push the
+  // update
+  modifier.embedder_api().UpdateAccessibilityFeatures =
+      [](FLUTTER_API_SYMBOL(FlutterEngine) engine,
+         FlutterAccessibilityFeature flags) {
+        return kSuccess;
+      };
   modifier.embedder_api().UpdateLocales =
       [](auto engine, const FlutterLocale** locales, size_t locales_count) {
         return kSuccess;

--- a/shell/platform/windows/testing/test_keyboard.cc
+++ b/shell/platform/windows/testing/test_keyboard.cc
@@ -185,9 +185,7 @@ void MockEmbedderApiForKeyboard(
   // update
   modifier.embedder_api().UpdateAccessibilityFeatures =
       [](FLUTTER_API_SYMBOL(FlutterEngine) engine,
-         FlutterAccessibilityFeature flags) {
-        return kSuccess;
-      };
+         FlutterAccessibilityFeature flags) { return kSuccess; };
   modifier.embedder_api().UpdateLocales =
       [](auto engine, const FlutterLocale** locales, size_t locales_count) {
         return kSuccess;

--- a/shell/platform/windows/window.cc
+++ b/shell/platform/windows/window.cc
@@ -537,6 +537,9 @@ Window::HandleMessage(UINT const message,
       // DefWindowProc will send WM_CHAR for this WM_UNICHAR.
       break;
     }
+    case WM_THEMECHANGED:
+      OnThemeChange();
+      break;
     case WM_DEADCHAR:
     case WM_SYSDEADCHAR:
     case WM_CHAR:

--- a/shell/platform/windows/window.cc
+++ b/shell/platform/windows/window.cc
@@ -635,4 +635,17 @@ UINT Window::Win32DispatchMessage(UINT Msg, WPARAM wParam, LPARAM lParam) {
   return ::SendMessage(window_handle_, Msg, wParam, lParam);
 }
 
+bool Window::GetHighContrastEnabled() {
+  HIGHCONTRAST high_contrast = {.cbSize = sizeof(HIGHCONTRAST)};
+  // API call is only supported on Windows 8+
+  if (SystemParametersInfoW(SPI_GETHIGHCONTRAST, sizeof(HIGHCONTRAST),
+                            &high_contrast, 0)) {
+    return high_contrast.dwFlags & HCF_HIGHCONTRASTON;
+  } else {
+    FML_LOG(INFO) << "Failed to get status of high contrast feature,"
+                  << "support only for Windows 8 + ";
+    return false;
+  }
+}
+
 }  // namespace flutter

--- a/shell/platform/windows/window.h
+++ b/shell/platform/windows/window.h
@@ -207,6 +207,9 @@ class Window : public KeyboardManager::WindowDelegate {
   // Returns the current pixel per scroll tick value.
   virtual float GetScrollOffsetMultiplier();
 
+  // Check if the high contrast feature is enabled on the OS
+  virtual bool GetHighContrastEnabled();
+
  protected:
   // Win32's DefWindowProc.
   //

--- a/shell/platform/windows/window.h
+++ b/shell/platform/windows/window.h
@@ -224,6 +224,9 @@ class Window : public KeyboardManager::WindowDelegate {
   // gestures.
   std::unique_ptr<DirectManipulationOwner> direct_manipulation_owner_;
 
+  // Called when a theme change message is issued
+  virtual void OnThemeChange() = 0;
+
  private:
   // Release OS resources associated with window.
   void Destroy();

--- a/shell/platform/windows/window_binding_handler.h
+++ b/shell/platform/windows/window_binding_handler.h
@@ -90,7 +90,8 @@ class WindowBindingHandler {
   // coordinates.
   virtual PointerLocation GetPrimaryPointerLocation() = 0;
 
-  virtual void AfterEngineSet() = 0;
+  // Called to set the initial state of accessibility features
+  virtual void UpdateInitialAccessibilityFeatures() = 0;
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/window_binding_handler.h
+++ b/shell/platform/windows/window_binding_handler.h
@@ -91,7 +91,7 @@ class WindowBindingHandler {
   virtual PointerLocation GetPrimaryPointerLocation() = 0;
 
   // Called to set the initial state of accessibility features
-  virtual void UpdateInitialAccessibilityFeatures() = 0;
+  virtual void SendInitialAccessibilityFeatures() = 0;
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/window_binding_handler.h
+++ b/shell/platform/windows/window_binding_handler.h
@@ -89,6 +89,8 @@ class WindowBindingHandler {
   // Returns the last known position of the primary pointer in window
   // coordinates.
   virtual PointerLocation GetPrimaryPointerLocation() = 0;
+
+  virtual void AfterEngineSet() = 0;
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/window_binding_handler_delegate.h
+++ b/shell/platform/windows/window_binding_handler_delegate.h
@@ -128,6 +128,9 @@ class WindowBindingHandlerDelegate {
 
   // Returns the root view accessibility node, or nullptr if none.
   virtual gfx::NativeViewAccessible GetNativeViewAccessible() = 0;
+
+  // Update the status of the high contrast feature
+  virtual void UpdateHighContrastEnabled(bool enabled) = 0;
 };
 
 }  // namespace flutter


### PR DESCRIPTION
Flutter supports separate `Theme`s for when High-contrast mode is enabled. Previously, on Windows, the status of the OS' high contrast feature was not detected, so these themes were not put to use on Windows applications. These changes detect when high contrast mode is enabled while the application is running and changes the used theme accordingly, and also checks the status of high contrast mode when the application starts up.

Issue #109802

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
