### PR TITLE
[Impeller] Don't store textures that aren't read (most of the time)

### DIFF
--- a/impeller/aiks/canvas.h
+++ b/impeller/aiks/canvas.h
@@ -124,7 +124,9 @@ class Canvas {
   size_t GetStencilDepth() const;
 
   void Save(bool create_subpass,
-            Entity::BlendMode = Entity::BlendMode::kSourceOver);
+            Entity::BlendMode = Entity::BlendMode::kSourceOver,
+            std::optional<EntityPass::BackdropFilterProc> backdrop_filter =
+                std::nullopt);
 
   void RestoreClip();
 

--- a/impeller/entity/entity_pass.h
+++ b/impeller/entity/entity_pass.h
@@ -122,7 +122,7 @@ class EntityPass {
   /// the following scenarios:
   ///   1. An entity with an "advanced blend" is added to the pass.
   ///   2. A subpass with a backdrop filter is added to the pass.
-  unsigned int reads_from_pass_texture_ = 0;
+  uint32_t reads_from_pass_texture_ = 0;
 
   std::optional<BackdropFilterProc> backdrop_filter_proc_ = std::nullopt;
 

--- a/impeller/entity/entity_pass.h
+++ b/impeller/entity/entity_pass.h
@@ -116,12 +116,13 @@ class EntityPass {
   size_t stencil_depth_ = 0u;
   Entity::BlendMode blend_mode_ = Entity::BlendMode::kSourceOver;
   bool cover_whole_screen = false;
-  /// This flag is set to `true` whenever an entity is added to the pass that
-  /// requires reading the pass texture during rendering. This can happen in the
-  /// following scenarios:
+
+  /// This value is incremented whenever something is added to the pass that
+  /// requires reading from the backdrop texture. Currently, this can happen in
+  /// the following scenarios:
   ///   1. An entity with an "advanced blend" is added to the pass.
   ///   2. A subpass with a backdrop filter is added to the pass.
-  bool reads_from_pass_texture_ = false;
+  unsigned int reads_from_pass_texture_ = 0;
 
   std::optional<BackdropFilterProc> backdrop_filter_proc_ = std::nullopt;
 

--- a/impeller/entity/inline_pass_context.cc
+++ b/impeller/entity/inline_pass_context.cc
@@ -12,7 +12,7 @@ namespace impeller {
 
 InlinePassContext::InlinePassContext(std::shared_ptr<Context> context,
                                      RenderTarget render_target,
-                                     unsigned int pass_texture_reads)
+                                     uint32_t pass_texture_reads)
     : context_(context),
       render_target_(render_target),
       total_pass_reads_(pass_texture_reads) {}

--- a/impeller/entity/inline_pass_context.cc
+++ b/impeller/entity/inline_pass_context.cc
@@ -6,12 +6,16 @@
 
 #include "impeller/base/validation.h"
 #include "impeller/renderer/command_buffer.h"
+#include "impeller/renderer/formats.h"
 
 namespace impeller {
 
 InlinePassContext::InlinePassContext(std::shared_ptr<Context> context,
-                                     RenderTarget render_target)
-    : context_(context), render_target_(render_target) {}
+                                     RenderTarget render_target,
+                                     unsigned int pass_texture_reads)
+    : context_(context),
+      render_target_(render_target),
+      total_pass_reads_(pass_texture_reads) {}
 
 InlinePassContext::~InlinePassContext() {
   EndPass();
@@ -57,45 +61,66 @@ const RenderTarget& InlinePassContext::GetRenderTarget() const {
 
 std::shared_ptr<RenderPass> InlinePassContext::GetRenderPass(
     uint32_t pass_depth) {
-  // Create a new render pass if one isn't active.
-  if (!IsActive()) {
-    command_buffer_ = context_->CreateCommandBuffer();
-    if (!command_buffer_) {
-      VALIDATION_LOG << "Could not create command buffer.";
-      return nullptr;
-    }
-
-    command_buffer_->SetLabel(
-        "EntityPass Command Buffer: Depth=" + std::to_string(pass_depth) +
-        " Count=" + std::to_string(pass_count_));
-
-    // Never clear the texture for subsequent passes.
-    if (pass_count_ > 0) {
-      if (!render_target_.GetColorAttachments().empty()) {
-        auto color0 = render_target_.GetColorAttachments().find(0)->second;
-        color0.load_action = LoadAction::kLoad;
-        render_target_.SetColorAttachment(color0, 0);
-      }
-
-      if (auto stencil = render_target_.GetStencilAttachment();
-          stencil.has_value()) {
-        stencil->load_action = LoadAction::kLoad;
-        render_target_.SetStencilAttachment(stencil.value());
-      }
-    }
-
-    pass_ = command_buffer_->CreateRenderPass(render_target_);
-    if (!pass_) {
-      VALIDATION_LOG << "Could not create render pass.";
-      return nullptr;
-    }
-
-    pass_->SetLabel(
-        "EntityPass Render Pass: Depth=" + std::to_string(pass_depth) +
-        " Count=" + std::to_string(pass_count_));
-
-    ++pass_count_;
+  if (IsActive()) {
+    return pass_;
   }
+
+  /// Create a new render pass if one isn't active. This path will run the first
+  /// time this method is called, but it'll also run if the pass has been
+  /// previously ended via `EndPass`.
+
+  command_buffer_ = context_->CreateCommandBuffer();
+  if (!command_buffer_) {
+    VALIDATION_LOG << "Could not create command buffer.";
+    return nullptr;
+  }
+
+  if (render_target_.GetColorAttachments().empty()) {
+    VALIDATION_LOG << "Color attachment unexpectedly missing from the "
+                      "EntityPass render target.";
+    return nullptr;
+  }
+  auto color0 = render_target_.GetColorAttachments().find(0)->second;
+
+  auto stencil = render_target_.GetStencilAttachment();
+  if (!stencil.has_value()) {
+    VALIDATION_LOG << "Stencil attachment unexpectedly missing from the "
+                      "EntityPass render target.";
+    return nullptr;
+  }
+
+  command_buffer_->SetLabel(
+      "EntityPass Command Buffer: Depth=" + std::to_string(pass_depth) +
+      " Count=" + std::to_string(pass_count_));
+
+  // Only clear the color and stencil if this is the very first pass of the
+  // layer.
+  color0.load_action = pass_count_ > 0 ? LoadAction::kLoad : LoadAction::kClear;
+  stencil->load_action = color0.load_action;
+
+  // If we're on the last pass of the layer, there's no need to store the
+  // multisample texture or stencil because nothing needs to read it.
+  color0.store_action = pass_count_ == total_pass_reads_
+                            ? StoreAction::kMultisampleResolve
+                            : StoreAction::kStoreAndMultisampleResolve;
+  stencil->store_action = pass_count_ == total_pass_reads_
+                              ? StoreAction::kDontCare
+                              : StoreAction::kStore;
+
+  render_target_.SetColorAttachment(color0, 0);
+  render_target_.SetStencilAttachment(stencil.value());
+
+  pass_ = command_buffer_->CreateRenderPass(render_target_);
+  if (!pass_) {
+    VALIDATION_LOG << "Could not create render pass.";
+    return nullptr;
+  }
+
+  pass_->SetLabel(
+      "EntityPass Render Pass: Depth=" + std::to_string(pass_depth) +
+      " Count=" + std::to_string(pass_count_));
+
+  ++pass_count_;
 
   return pass_;
 }

--- a/impeller/entity/inline_pass_context.h
+++ b/impeller/entity/inline_pass_context.h
@@ -13,7 +13,8 @@ namespace impeller {
 class InlinePassContext {
  public:
   InlinePassContext(std::shared_ptr<Context> context,
-                    RenderTarget render_target);
+                    RenderTarget render_target,
+                    unsigned int pass_texture_reads);
   ~InlinePassContext();
 
   bool IsValid() const;
@@ -30,6 +31,7 @@ class InlinePassContext {
   std::shared_ptr<CommandBuffer> command_buffer_;
   std::shared_ptr<RenderPass> pass_;
   uint32_t pass_count_ = 0;
+  unsigned int total_pass_reads_ = 0;
 
   FML_DISALLOW_COPY_AND_ASSIGN(InlinePassContext);
 };

--- a/impeller/entity/inline_pass_context.h
+++ b/impeller/entity/inline_pass_context.h
@@ -14,7 +14,7 @@ class InlinePassContext {
  public:
   InlinePassContext(std::shared_ptr<Context> context,
                     RenderTarget render_target,
-                    unsigned int pass_texture_reads);
+                    uint32_t pass_texture_reads);
   ~InlinePassContext();
 
   bool IsValid() const;
@@ -31,7 +31,7 @@ class InlinePassContext {
   std::shared_ptr<CommandBuffer> command_buffer_;
   std::shared_ptr<RenderPass> pass_;
   uint32_t pass_count_ = 0;
-  unsigned int total_pass_reads_ = 0;
+  uint32_t total_pass_reads_ = 0;
 
   FML_DISALLOW_COPY_AND_ASSIGN(InlinePassContext);
 };


### PR DESCRIPTION
This changes `InlinePassContext` to always declare the load/store rules for attachments when creating a new pass based on simple rules. This eliminates almost all cases where a multisample texture or stencil is being stored unnecessarily.

Follow-up work:
* Skipped subpasses and entities aren't being incorporated yet, so if a skipped entity would have otherwise rendered with an advanced blend, the last pass in the layer will still store unnecessarily. This is an easy fix but I need to step away at the moment.
* After fixing the above problem, we'll still have the problem of the texture being non-transient in this case unnecessarily. This is less trivial to solve since it requires us to know which passes/entities are going to get eliminated before the texture is created. We'll probably be in a better position to address this issue after we land a rewrite to stop using command buffers as a hack for GPU synchronization.