### PR TITLE
[Impeller] Render on Simulator

### DIFF
--- a/flow/surface_frame.cc
+++ b/flow/surface_frame.cc
@@ -6,6 +6,7 @@
 
 #include <limits>
 
+#include "flutter/flow/layers/layer.h"
 #include "flutter/fml/logging.h"
 #include "flutter/fml/trace_event.h"
 #include "third_party/skia/include/utils/SkNWayCanvas.h"
@@ -25,9 +26,7 @@ SurfaceFrame::SurfaceFrame(sk_sp<SkSurface> surface,
   if (surface_) {
     canvas_ = surface_->getCanvas();
   } else if (display_list_fallback) {
-    dl_recorder_ = sk_make_sp<DisplayListCanvasRecorder>(
-        SkRect::MakeWH(std::numeric_limits<SkScalar>::max(),
-                       std::numeric_limits<SkScalar>::max()));
+    dl_recorder_ = sk_make_sp<DisplayListCanvasRecorder>(kGiantRect);
     canvas_ = dl_recorder_.get();
   }
 }

--- a/flow/surface_frame_unittests.cc
+++ b/flow/surface_frame_unittests.cc
@@ -20,4 +20,16 @@ TEST(FlowTest, SurfaceFrameDoesNotSubmitInDtor) {
   surface_frame.reset();
 }
 
+TEST(FlowTest, SurfaceFrameDoesNotHaveEmptyCanvas) {
+  SurfaceFrame::FramebufferInfo framebuffer_info;
+  SurfaceFrame frame(
+      /*surface=*/nullptr, framebuffer_info,
+      /*submit_callback=*/[](const SurfaceFrame&, SkCanvas*) { return true; },
+      /*context_result=*/nullptr, /*display_list_fallback=*/true);
+
+  EXPECT_FALSE(frame.SkiaCanvas()->getLocalClipBounds().isEmpty());
+  EXPECT_FALSE(
+      frame.SkiaCanvas()->quickReject(SkRect::MakeLTRB(10, 10, 50, 50)));
+}
+
 }  // namespace flutter

--- a/impeller/renderer/backend/metal/render_pass_mtl.mm
+++ b/impeller/renderer/backend/metal/render_pass_mtl.mm
@@ -493,18 +493,31 @@ bool RenderPassMTL::EncodeCommands(const std::shared_ptr<Allocator>& allocator,
     if (!mtl_index_buffer) {
       return false;
     }
+
     FML_DCHECK(command.index_count *
                    (command.index_type == IndexType::k16bit ? 2 : 4) ==
                command.index_buffer.range.length);
-    // Returns void. All error checking must be done by this point.
-    [encoder drawIndexedPrimitives:ToMTLPrimitiveType(command.primitive_type)
-                        indexCount:command.index_count
-                         indexType:ToMTLIndexType(command.index_type)
-                       indexBuffer:mtl_index_buffer
-                 indexBufferOffset:command.index_buffer.range.offset
-                     instanceCount:command.instance_count
-                        baseVertex:command.base_vertex
-                      baseInstance:0u];
+
+    if (command.instance_count != 1u) {
+#if TARGET_OS_SIMULATOR
+      VALIDATION_LOG << "iOS Simulator does not support instanced rendering.";
+      return false;
+#endif
+      [encoder drawIndexedPrimitives:ToMTLPrimitiveType(command.primitive_type)
+                          indexCount:command.index_count
+                           indexType:ToMTLIndexType(command.index_type)
+                         indexBuffer:mtl_index_buffer
+                   indexBufferOffset:command.index_buffer.range.offset
+                       instanceCount:command.instance_count
+                          baseVertex:command.base_vertex
+                        baseInstance:0u];
+    } else {
+      [encoder drawIndexedPrimitives:ToMTLPrimitiveType(command.primitive_type)
+                          indexCount:command.index_count
+                           indexType:ToMTLIndexType(command.index_type)
+                         indexBuffer:mtl_index_buffer
+                   indexBufferOffset:command.index_buffer.range.offset];
+    }
   }
   return true;
 }

--- a/impeller/renderer/platform.h
+++ b/impeller/renderer/platform.h
@@ -12,7 +12,7 @@
 namespace impeller {
 
 constexpr size_t DefaultUniformAlignment() {
-#if FML_OS_IOS
+#if FML_OS_IOS && !TARGET_OS_SIMULATOR
   return 16u;
 #elif FML_OS_MACOSX
   return 256u;


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/104743

Simulator more or less restricts to [Apple2](https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf). That means no instanced rendering. It's not clear to me if some of the sampling stuff would break either, but it isn't breaking currently on the test apps I'm looking at. Also means that we have to use the same uniform alignment as for macOS. I thought we couldn't use memoryless textures but that seems to be working.

The `SurfaceFrame` change is because using `SK_ScalarMax` overflows an `int32_t`, and Skia internally treats the clip as empty if you try to create an SkCanvas that overflows `int32_t`. I'm not quite sure why this works on iPhones, but I'm going to bed now :)

I've tested this patch on an Intel MBP, don't have access to an M1 at the moment to see what's going on there.

@jonahwilliams @zanderso @flar fyi