### PR TITLE
Engine startup event timed after VM initializes

### DIFF
--- a/common/settings.h
+++ b/common/settings.h
@@ -301,11 +301,6 @@ struct Settings {
   // Max bytes threshold of resource cache, or 0 for unlimited.
   size_t resource_cache_max_bytes_threshold = 0;
 
-  /// A timestamp representing when the engine started. The value is based
-  /// on the clock used by the Dart timeline APIs. This timestamp is used
-  /// to log a timeline event that tracks the latency of engine startup.
-  std::chrono::microseconds engine_start_timestamp = {};
-
   /// The minimum number of samples to require in multipsampled anti-aliasing.
   ///
   /// Setting this value to 0 or 1 disables MSAA.

--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -467,8 +467,10 @@ DartVM::DartVM(std::shared_ptr<const DartVMData> vm_data,
     // Send the earliest available timestamp in the application lifecycle to
     // timeline. The difference between this timestamp and the time we render
     // the very first frame gives us a good idea about Flutter's startup time.
-    // Use a duration event so about:tracing will consider this event when
-    // deciding the earliest event to use as time 0.
+    // Use an instant event because the call to Dart_TimelineGetMicros
+    // may behave differently before and after the Dart VM is initialized.
+    // As this call is immediately after initialization of the Dart VM,
+    // we are interested in only one timestamp.
     if (settings_.engine_start_timestamp.count()) {
       int64_t micros = Dart_TimelineGetMicros();
       Dart_TimelineEvent("FlutterEngineMainEnter",     // label

--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -471,17 +471,15 @@ DartVM::DartVM(std::shared_ptr<const DartVMData> vm_data,
     // may behave differently before and after the Dart VM is initialized.
     // As this call is immediately after initialization of the Dart VM,
     // we are interested in only one timestamp.
-    if (settings_.engine_start_timestamp.count()) {
-      int64_t micros = Dart_TimelineGetMicros();
-      Dart_TimelineEvent("FlutterEngineMainEnter",     // label
-                         micros,                       // timestamp0
-                         micros,                       // timestamp1_or_async_id
-                         Dart_Timeline_Event_Instant,  // event type
-                         0,                            // argument_count
-                         nullptr,                      // argument_names
-                         nullptr                       // argument_values
-      );
-    }
+    int64_t micros = Dart_TimelineGetMicros();
+    Dart_TimelineEvent("FlutterEngineMainEnter",     // label
+                        micros,                       // timestamp0
+                        micros,                       // timestamp1_or_async_id
+                        Dart_Timeline_Event_Instant,  // event type
+                        0,                            // argument_count
+                        nullptr,                      // argument_names
+                        nullptr                       // argument_values
+    );
   }
 
   Dart_SetFileModifiedCallback(&DartFileModifiedCallback);

--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -470,11 +470,12 @@ DartVM::DartVM(std::shared_ptr<const DartVMData> vm_data,
     // Use a duration event so about:tracing will consider this event when
     // deciding the earliest event to use as time 0.
     if (settings_.engine_start_timestamp.count()) {
+      int64_t micros = Dart_TimelineGetMicros();
       Dart_TimelineEvent(
           "FlutterEngineMainEnter",                  // label
-          settings_.engine_start_timestamp.count(),  // timestamp0
-          Dart_TimelineGetMicros(),                  // timestamp1_or_async_id
-          Dart_Timeline_Event_Duration,              // event type
+          micros,                  // timestamp0
+          micros,                  // timestamp1_or_async_id
+          Dart_Timeline_Event_Instant,              // event type
           0,                                         // argument_count
           nullptr,                                   // argument_names
           nullptr                                    // argument_values

--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -471,14 +471,13 @@ DartVM::DartVM(std::shared_ptr<const DartVMData> vm_data,
     // deciding the earliest event to use as time 0.
     if (settings_.engine_start_timestamp.count()) {
       int64_t micros = Dart_TimelineGetMicros();
-      Dart_TimelineEvent(
-          "FlutterEngineMainEnter",                  // label
-          micros,                  // timestamp0
-          micros,                  // timestamp1_or_async_id
-          Dart_Timeline_Event_Instant,              // event type
-          0,                                         // argument_count
-          nullptr,                                   // argument_names
-          nullptr                                    // argument_values
+      Dart_TimelineEvent("FlutterEngineMainEnter",     // label
+                         micros,                       // timestamp0
+                         micros,                       // timestamp1_or_async_id
+                         Dart_Timeline_Event_Instant,  // event type
+                         0,                            // argument_count
+                         nullptr,                      // argument_names
+                         nullptr                       // argument_values
       );
     }
   }

--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -473,12 +473,12 @@ DartVM::DartVM(std::shared_ptr<const DartVMData> vm_data,
     // we are interested in only one timestamp.
     int64_t micros = Dart_TimelineGetMicros();
     Dart_TimelineEvent("FlutterEngineMainEnter",     // label
-                        micros,                       // timestamp0
-                        micros,                       // timestamp1_or_async_id
-                        Dart_Timeline_Event_Instant,  // event type
-                        0,                            // argument_count
-                        nullptr,                      // argument_names
-                        nullptr                       // argument_values
+                       micros,                       // timestamp0
+                       micros,                       // timestamp1_or_async_id
+                       Dart_Timeline_Event_Instant,  // event type
+                       0,                            // argument_count
+                       nullptr,                      // argument_names
+                       nullptr                       // argument_values
     );
   }
 

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -84,11 +84,6 @@ void PerformInitializationTasks(Settings& settings) {
 
   static std::once_flag gShellSettingsInitialization = {};
   std::call_once(gShellSettingsInitialization, [&settings] {
-    if (settings.engine_start_timestamp.count() == 0) {
-      settings.engine_start_timestamp =
-          std::chrono::microseconds(Dart_TimelineGetMicros());
-    }
-
     tonic::SetLogHandler(
         [](const char* message) { FML_LOG(ERROR) << message; });
 

--- a/shell/platform/android/flutter_main.cc
+++ b/shell/platform/android/flutter_main.cc
@@ -112,8 +112,6 @@ void FlutterMain::Init(JNIEnv* env,
 #endif  // FLUTTER_RELEASE
 
   int64_t init_time_micros = initTimeMillis * 1000;
-  settings.engine_start_timestamp =
-      std::chrono::microseconds(Dart_TimelineGetMicros() - init_time_micros);
 
   // Restore the callback cache.
   // TODO(chinmaygarde): Route all cache file access through FML and remove this

--- a/shell/platform/android/flutter_main.cc
+++ b/shell/platform/android/flutter_main.cc
@@ -111,8 +111,6 @@ void FlutterMain::Init(JNIEnv* env,
   settings.enable_timeline_event_handler = settings.trace_systrace;
 #endif  // FLUTTER_RELEASE
 
-  int64_t init_time_micros = initTimeMillis * 1000;
-
   // Restore the callback cache.
   // TODO(chinmaygarde): Route all cache file access through FML and remove this
   // setter.


### PR DESCRIPTION
The Flutter Engine uses a function exposed by the Dart SDK to get a timestamp in microseconds. However, depending on the platform, this `Dart_TimelineGetMicros` function can return timestamps in different forms depending on whether or not `Dart::Initialize` has yet been called. On Windows, when the Dart VM is not yet initialized, such as when setting the `engine_start_timestamp`, the timestamp is given in microseconds since the Unix Epoch. After the Dart VM has been initialized, such as when the time is queried for all later timeline events, the timetsamp on Windows is in QPC, which, according to Microsoft's documentation, cannot be sycned to any standard format such as UTC or Epoch time. This means that the starting timestamp for the `FlutterEngineMainEnter` timeline event previously was in a different format than the timestamp of all later events. By changing the timestamp0 of this event to a timestamp obtained after initializing the Dart VM, all events now have consistent timestamp forms.

As far as I can tell, this `FlutterEngineMainEnter` event that is affected is only used by the tracing code in Flutter used in startup tests to calculate the time between the engine startup and the first frame being built. Previously, this value would be reported as roughly -16 quadrillion on Windows because of this inconsistency.

Addresses flutter/flutter#109859 in Flutter.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
