### PR TITLE
Manual roll of Clang Mac from 60d276923902 to 41d4067d0b7c

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -606,7 +606,7 @@ deps = {
     'packages': [
       {
         'package': 'fuchsia/third_party/clang/mac-amd64',
-        'version': 'git_revision:60d276923902051192eba692e5312e605c9d9f65'
+        'version': 'git_revision:41d4067d0b7c3c955b8b6cda328bcb46e268bd6a'
       }
     ],
     'condition': 'host_os == "mac"',


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/110140
