### PR TITLE
Revert "Roll buildroot (#35714)"

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -102,7 +102,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'cc91a2aba655499dccddb1fbb03720d27617fa2e',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '25e5fd0200ff0bbf4761f3e73cab67a16e928955',
 
    # Fuchsia compatibility
    #


### PR DESCRIPTION
This reverts commit 3aa2be5b5ef65462b3788b7f86ad578c6a115159.

The build was failing for some iOS targets that use LTO
