### PR TITLE
[Impeller] Make render target, texture, and device buffer validation backend agnostic.

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -854,6 +854,8 @@ FILE: ../../../flutter/impeller/renderer/context.h
 FILE: ../../../flutter/impeller/renderer/descriptor_set_layout.h
 FILE: ../../../flutter/impeller/renderer/device_buffer.cc
 FILE: ../../../flutter/impeller/renderer/device_buffer.h
+FILE: ../../../flutter/impeller/renderer/device_buffer_descriptor.cc
+FILE: ../../../flutter/impeller/renderer/device_buffer_descriptor.h
 FILE: ../../../flutter/impeller/renderer/device_buffer_unittests.cc
 FILE: ../../../flutter/impeller/renderer/formats.cc
 FILE: ../../../flutter/impeller/renderer/formats.h

--- a/impeller/entity/contents/vertices_contents.cc
+++ b/impeller/entity/contents/vertices_contents.cc
@@ -80,8 +80,12 @@ bool VerticesContents::Render(const ContentContext& renderer,
   size_t total_vtx_bytes = vertex_data.size() * sizeof(VS::PerVertexData);
   size_t total_idx_bytes = vertices_.GetIndices().size() * sizeof(uint16_t);
 
-  auto buffer = renderer.GetContext()->GetResourceAllocator()->CreateBuffer(
-      StorageMode::kHostVisible, total_vtx_bytes + total_idx_bytes);
+  DeviceBufferDescriptor buffer_desc;
+  buffer_desc.size = total_vtx_bytes + total_idx_bytes;
+  buffer_desc.storage_mode = StorageMode::kHostVisible;
+
+  auto buffer =
+      renderer.GetContext()->GetResourceAllocator()->CreateBuffer(buffer_desc);
 
   if (!buffer->CopyHostBuffer(reinterpret_cast<uint8_t*>(vertex_data.data()),
                               Range{0, total_vtx_bytes}, 0)) {

--- a/impeller/playground/imgui/imgui_impl_impeller.cc
+++ b/impeller/playground/imgui/imgui_impl_impeller.cc
@@ -70,12 +70,13 @@ bool ImGui_ImplImpeller_Init(std::shared_ptr<impeller::Context> context) {
     io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height);
 
     auto texture_descriptor = impeller::TextureDescriptor{};
+    texture_descriptor.storage_mode = impeller::StorageMode::kHostVisible;
     texture_descriptor.format = impeller::PixelFormat::kR8G8B8A8UNormInt;
     texture_descriptor.size = {width, height};
     texture_descriptor.mip_count = 1u;
 
-    bd->font_texture = context->GetResourceAllocator()->CreateTexture(
-        impeller::StorageMode::kHostVisible, texture_descriptor);
+    bd->font_texture =
+        context->GetResourceAllocator()->CreateTexture(texture_descriptor);
     IM_ASSERT(bd->font_texture != nullptr &&
               "Could not allocate ImGui font texture.");
     bd->font_texture->SetLabel("ImGui Font Texture");
@@ -136,8 +137,11 @@ void ImGui_ImplImpeller_RenderDrawData(ImDrawData* draw_data,
   }
 
   // Allocate buffer for vertices + indices.
-  auto buffer = bd->context->GetResourceAllocator()->CreateBuffer(
-      impeller::StorageMode::kHostVisible, total_vtx_bytes + total_idx_bytes);
+  impeller::DeviceBufferDescriptor buffer_desc;
+  buffer_desc.size = total_vtx_bytes + total_idx_bytes;
+  buffer_desc.storage_mode = impeller::StorageMode::kHostVisible;
+
+  auto buffer = bd->context->GetResourceAllocator()->CreateBuffer(buffer_desc);
   buffer->SetLabel(impeller::SPrintF("ImGui vertex+index buffer"));
 
   auto display_rect =

--- a/impeller/playground/playground.cc
+++ b/impeller/playground/playground.cc
@@ -336,13 +336,14 @@ std::shared_ptr<Texture> Playground::CreateTextureForFixture(
   }
 
   auto texture_descriptor = TextureDescriptor{};
+  texture_descriptor.storage_mode = StorageMode::kHostVisible;
   texture_descriptor.format = PixelFormat::kR8G8B8A8UNormInt;
   texture_descriptor.size = image->GetSize();
   texture_descriptor.mip_count =
       enable_mipmapping ? image->GetSize().MipCount() : 1u;
 
   auto texture = renderer_->GetContext()->GetResourceAllocator()->CreateTexture(
-      StorageMode::kHostVisible, texture_descriptor);
+      texture_descriptor);
   if (!texture) {
     VALIDATION_LOG << "Could not allocate texture for fixture " << fixture_name;
     return nullptr;
@@ -370,13 +371,14 @@ std::shared_ptr<Texture> Playground::CreateTextureCubeForFixture(
   }
 
   auto texture_descriptor = TextureDescriptor{};
+  texture_descriptor.storage_mode = StorageMode::kHostVisible;
   texture_descriptor.type = TextureType::kTextureCube;
   texture_descriptor.format = PixelFormat::kR8G8B8A8UNormInt;
   texture_descriptor.size = images[0].GetSize();
   texture_descriptor.mip_count = 1u;
 
   auto texture = renderer_->GetContext()->GetResourceAllocator()->CreateTexture(
-      StorageMode::kHostVisible, texture_descriptor);
+      texture_descriptor);
   if (!texture) {
     VALIDATION_LOG << "Could not allocate texture cube.";
     return nullptr;

--- a/impeller/renderer/BUILD.gn
+++ b/impeller/renderer/BUILD.gn
@@ -25,6 +25,8 @@ impeller_component("renderer") {
     "descriptor_set_layout.h",
     "device_buffer.cc",
     "device_buffer.h",
+    "device_buffer_descriptor.cc",
+    "device_buffer_descriptor.h",
     "formats.cc",
     "formats.h",
     "host_buffer.cc",

--- a/impeller/renderer/allocator.cc
+++ b/impeller/renderer/allocator.cc
@@ -4,6 +4,7 @@
 
 #include "impeller/renderer/allocator.h"
 
+#include "impeller/base/validation.h"
 #include "impeller/renderer/device_buffer.h"
 #include "impeller/renderer/range.h"
 
@@ -16,7 +17,10 @@ Allocator::~Allocator() = default;
 std::shared_ptr<DeviceBuffer> Allocator::CreateBufferWithCopy(
     const uint8_t* buffer,
     size_t length) {
-  auto new_buffer = CreateBuffer(StorageMode::kHostVisible, length);
+  DeviceBufferDescriptor desc;
+  desc.size = length;
+  desc.storage_mode = StorageMode::kHostVisible;
+  auto new_buffer = CreateBuffer(desc);
 
   if (!new_buffer) {
     return nullptr;
@@ -34,6 +38,24 @@ std::shared_ptr<DeviceBuffer> Allocator::CreateBufferWithCopy(
 std::shared_ptr<DeviceBuffer> Allocator::CreateBufferWithCopy(
     const fml::Mapping& mapping) {
   return CreateBufferWithCopy(mapping.GetMapping(), mapping.GetSize());
+}
+
+std::shared_ptr<DeviceBuffer> Allocator::CreateBuffer(
+    const DeviceBufferDescriptor& desc) {
+  return OnCreateBuffer(desc);
+}
+
+std::shared_ptr<Texture> Allocator::CreateTexture(
+    const TextureDescriptor& desc) {
+  const auto max_size = GetMaxTextureSizeSupported();
+  if (desc.size.width > max_size.width || desc.size.height > max_size.height) {
+    VALIDATION_LOG
+        << "Requested texture size exceeds maximum supported size of "
+        << desc.size;
+    return nullptr;
+  }
+
+  return OnCreateTexture(desc);
 }
 
 }  // namespace impeller

--- a/impeller/renderer/allocator.h
+++ b/impeller/renderer/allocator.h
@@ -8,40 +8,10 @@
 
 #include "flutter/fml/macros.h"
 #include "flutter/fml/mapping.h"
+#include "impeller/renderer/device_buffer_descriptor.h"
 #include "impeller/renderer/texture_descriptor.h"
 
 namespace impeller {
-
-//------------------------------------------------------------------------------
-/// @brief      Specified where the allocation resides and how it is used.
-///
-enum class StorageMode {
-  //----------------------------------------------------------------------------
-  /// Allocations can be mapped onto the hosts address space and also be used by
-  /// the device.
-  ///
-  kHostVisible,
-  //----------------------------------------------------------------------------
-  /// Allocations can only be used by the device. This location is optimal for
-  /// use by the device. If the host needs to access these allocations, the
-  /// transfer queue must be used to transfer this allocation onto the a host
-  /// visible buffer.
-  ///
-  kDevicePrivate,
-  //----------------------------------------------------------------------------
-  /// Used by the device for temporary render targets. These allocations cannot
-  /// be transferred from and to other allocations using the transfer queue.
-  /// Render pass cannot initialize the contents of these buffers using load and
-  /// store actions.
-  ///
-  /// These allocations reside in tile memory which has higher bandwidth, lower
-  /// latency and lower power consumption. The total device memory usage is
-  /// also lower as a separate allocation does not need to be created in
-  /// device memory. Prefer using these allocations for intermediates like depth
-  /// and stencil buffers.
-  ///
-  kDeviceTransient,
-};
 
 class Context;
 class DeviceBuffer;
@@ -56,12 +26,10 @@ class Allocator {
 
   bool IsValid() const;
 
-  virtual std::shared_ptr<DeviceBuffer> CreateBuffer(StorageMode mode,
-                                                     size_t length) = 0;
+  std::shared_ptr<DeviceBuffer> CreateBuffer(
+      const DeviceBufferDescriptor& desc);
 
-  virtual std::shared_ptr<Texture> CreateTexture(
-      StorageMode mode,
-      const TextureDescriptor& desc) = 0;
+  std::shared_ptr<Texture> CreateTexture(const TextureDescriptor& desc);
 
   std::shared_ptr<DeviceBuffer> CreateBufferWithCopy(const uint8_t* buffer,
                                                      size_t length);
@@ -73,6 +41,12 @@ class Allocator {
 
  protected:
   Allocator();
+
+  virtual std::shared_ptr<DeviceBuffer> OnCreateBuffer(
+      const DeviceBufferDescriptor& desc) = 0;
+
+  virtual std::shared_ptr<Texture> OnCreateTexture(
+      const TextureDescriptor& desc) = 0;
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(Allocator);

--- a/impeller/renderer/backend/gles/allocator_gles.cc
+++ b/impeller/renderer/backend/gles/allocator_gles.cc
@@ -25,19 +25,20 @@ bool AllocatorGLES::IsValid() const {
 }
 
 // |Allocator|
-std::shared_ptr<DeviceBuffer> AllocatorGLES::CreateBuffer(StorageMode mode,
-                                                          size_t length) {
+std::shared_ptr<DeviceBuffer> AllocatorGLES::OnCreateBuffer(
+    const DeviceBufferDescriptor& desc) {
   auto backing_store = std::make_shared<Allocation>();
-  if (!backing_store->Truncate(length)) {
+  if (!backing_store->Truncate(desc.size)) {
     return nullptr;
   }
-  return std::make_shared<DeviceBufferGLES>(reactor_, std::move(backing_store),
-                                            length, mode);
+  return std::make_shared<DeviceBufferGLES>(desc,                     //
+                                            reactor_,                 //
+                                            std::move(backing_store)  //
+  );
 }
 
 // |Allocator|
-std::shared_ptr<Texture> AllocatorGLES::CreateTexture(
-    StorageMode mode,
+std::shared_ptr<Texture> AllocatorGLES::OnCreateTexture(
     const TextureDescriptor& desc) {
   return std::make_shared<TextureGLES>(reactor_, std::move(desc));
 }

--- a/impeller/renderer/backend/gles/allocator_gles.h
+++ b/impeller/renderer/backend/gles/allocator_gles.h
@@ -27,12 +27,11 @@ class AllocatorGLES final : public Allocator {
   bool IsValid() const;
 
   // |Allocator|
-  std::shared_ptr<DeviceBuffer> CreateBuffer(StorageMode mode,
-                                             size_t length) override;
+  std::shared_ptr<DeviceBuffer> OnCreateBuffer(
+      const DeviceBufferDescriptor& desc) override;
 
   // |Allocator|
-  std::shared_ptr<Texture> CreateTexture(
-      StorageMode mode,
+  std::shared_ptr<Texture> OnCreateTexture(
       const TextureDescriptor& desc) override;
 
   // |Allocator|

--- a/impeller/renderer/backend/gles/device_buffer_gles.cc
+++ b/impeller/renderer/backend/gles/device_buffer_gles.cc
@@ -14,11 +14,10 @@
 
 namespace impeller {
 
-DeviceBufferGLES::DeviceBufferGLES(ReactorGLES::Ref reactor,
-                                   std::shared_ptr<Allocation> backing_store,
-                                   size_t size,
-                                   StorageMode mode)
-    : DeviceBuffer(size, mode),
+DeviceBufferGLES::DeviceBufferGLES(DeviceBufferDescriptor desc,
+                                   ReactorGLES::Ref reactor,
+                                   std::shared_ptr<Allocation> backing_store)
+    : DeviceBuffer(std::move(desc)),
       reactor_(std::move(reactor)),
       handle_(reactor_ ? reactor_->CreateHandle(HandleType::kBuffer)
                        : HandleGLES::DeadHandle()),
@@ -32,20 +31,10 @@ DeviceBufferGLES::~DeviceBufferGLES() {
 }
 
 // |DeviceBuffer|
-bool DeviceBufferGLES::CopyHostBuffer(const uint8_t* source,
-                                      Range source_range,
-                                      size_t offset) {
-  if (mode_ != StorageMode::kHostVisible) {
-    // One of the storage modes where a transfer queue must be used.
-    return false;
-  }
-
+bool DeviceBufferGLES::OnCopyHostBuffer(const uint8_t* source,
+                                        Range source_range,
+                                        size_t offset) {
   if (!reactor_) {
-    return false;
-  }
-
-  if (offset + source_range.length > size_) {
-    // Out of bounds of this buffer.
     return false;
   }
 

--- a/impeller/renderer/backend/gles/device_buffer_gles.h
+++ b/impeller/renderer/backend/gles/device_buffer_gles.h
@@ -18,10 +18,9 @@ class DeviceBufferGLES final
     : public DeviceBuffer,
       public BackendCast<DeviceBufferGLES, DeviceBuffer> {
  public:
-  DeviceBufferGLES(ReactorGLES::Ref reactor,
-                   std::shared_ptr<Allocation> buffer,
-                   size_t size,
-                   StorageMode mode);
+  DeviceBufferGLES(DeviceBufferDescriptor desc,
+                   ReactorGLES::Ref reactor,
+                   std::shared_ptr<Allocation> backing_store);
 
   // |DeviceBuffer|
   ~DeviceBufferGLES() override;
@@ -43,9 +42,9 @@ class DeviceBufferGLES final
   mutable uint32_t upload_generation_ = 0;
 
   // |DeviceBuffer|
-  bool CopyHostBuffer(const uint8_t* source,
-                      Range source_range,
-                      size_t offset) override;
+  bool OnCopyHostBuffer(const uint8_t* source,
+                        Range source_range,
+                        size_t offset) override;
 
   // |DeviceBuffer|
   bool SetLabel(const std::string& label) override;

--- a/impeller/renderer/backend/metal/allocator_mtl.h
+++ b/impeller/renderer/backend/metal/allocator_mtl.h
@@ -34,12 +34,11 @@ class AllocatorMTL final : public Allocator {
   bool IsValid() const;
 
   // |Allocator|
-  std::shared_ptr<DeviceBuffer> CreateBuffer(StorageMode mode,
-                                             size_t length) override;
+  std::shared_ptr<DeviceBuffer> OnCreateBuffer(
+      const DeviceBufferDescriptor& desc) override;
 
   // |Allocator|
-  std::shared_ptr<Texture> CreateTexture(
-      StorageMode mode,
+  std::shared_ptr<Texture> OnCreateTexture(
       const TextureDescriptor& desc) override;
 
   // |Allocator|

--- a/impeller/renderer/backend/metal/allocator_mtl.mm
+++ b/impeller/renderer/backend/metal/allocator_mtl.mm
@@ -161,26 +161,25 @@ static MTLStorageMode ToMTLStorageMode(StorageMode mode,
   FML_UNREACHABLE();
 }
 
-std::shared_ptr<DeviceBuffer> AllocatorMTL::CreateBuffer(StorageMode mode,
-                                                         size_t length) {
-  const auto resource_options =
-      ToMTLResourceOptions(mode, supports_memoryless_targets_, supports_uma_);
-  const auto storage_mode =
-      ToMTLStorageMode(mode, supports_memoryless_targets_, supports_uma_);
+std::shared_ptr<DeviceBuffer> AllocatorMTL::OnCreateBuffer(
+    const DeviceBufferDescriptor& desc) {
+  const auto resource_options = ToMTLResourceOptions(
+      desc.storage_mode, supports_memoryless_targets_, supports_uma_);
+  const auto storage_mode = ToMTLStorageMode(
+      desc.storage_mode, supports_memoryless_targets_, supports_uma_);
 
-  auto buffer = [device_ newBufferWithLength:length options:resource_options];
+  auto buffer = [device_ newBufferWithLength:desc.size
+                                     options:resource_options];
   if (!buffer) {
     return nullptr;
   }
-  return std::shared_ptr<DeviceBufferMTL>(new DeviceBufferMTL(buffer,       //
-                                                              length,       //
-                                                              mode,         //
+  return std::shared_ptr<DeviceBufferMTL>(new DeviceBufferMTL(desc,         //
+                                                              buffer,       //
                                                               storage_mode  //
                                                               ));
 }
 
-std::shared_ptr<Texture> AllocatorMTL::CreateTexture(
-    StorageMode mode,
+std::shared_ptr<Texture> AllocatorMTL::OnCreateTexture(
     const TextureDescriptor& desc) {
   if (!IsValid()) {
     return nullptr;
@@ -193,8 +192,8 @@ std::shared_ptr<Texture> AllocatorMTL::CreateTexture(
     return nullptr;
   }
 
-  mtl_texture_desc.storageMode =
-      ToMTLStorageMode(mode, supports_memoryless_targets_, supports_uma_);
+  mtl_texture_desc.storageMode = ToMTLStorageMode(
+      desc.storage_mode, supports_memoryless_targets_, supports_uma_);
   auto texture = [device_ newTextureWithDescriptor:mtl_texture_desc];
   if (!texture) {
     return nullptr;

--- a/impeller/renderer/backend/metal/command_buffer_mtl.mm
+++ b/impeller/renderer/backend/metal/command_buffer_mtl.mm
@@ -37,8 +37,6 @@ static NSString* MTLCommandBufferErrorToString(MTLCommandBufferError code) {
       return @"timeout";
     case MTLCommandBufferErrorPageFault:
       return @"page fault";
-    case MTLCommandBufferErrorAccessRevoked:
-      return @"access revoked / blacklisted";
     case MTLCommandBufferErrorNotPermitted:
       return @"not permitted";
     case MTLCommandBufferErrorOutOfMemory:
@@ -47,8 +45,6 @@ static NSString* MTLCommandBufferErrorToString(MTLCommandBufferError code) {
       return @"invalid resource";
     case MTLCommandBufferErrorMemoryless:
       return @"memory-less";
-    case MTLCommandBufferErrorStackOverflow:
-      return @"stack overflow";
     default:
       break;
   }

--- a/impeller/renderer/backend/metal/command_buffer_mtl.mm
+++ b/impeller/renderer/backend/metal/command_buffer_mtl.mm
@@ -154,7 +154,8 @@ bool CommandBufferMTL::OnSubmitCommands(CompletionCallback callback) {
   if (callback) {
     [buffer_
         addCompletedHandler:^(id<MTLCommandBuffer> buffer) {
-          auto result = LogMTLCommandBufferErrorIfPresent(buffer);
+          [[maybe_unused]] auto result =
+              LogMTLCommandBufferErrorIfPresent(buffer);
           FML_DCHECK(result)
               << "Must not have errors during command buffer submission.";
           callback(ToCommitResult(buffer.status));

--- a/impeller/renderer/backend/metal/command_buffer_mtl.mm
+++ b/impeller/renderer/backend/metal/command_buffer_mtl.mm
@@ -8,10 +8,9 @@
 #include "impeller/renderer/backend/metal/render_pass_mtl.h"
 
 namespace impeller {
-namespace {
 
 API_AVAILABLE(ios(14.0), macos(11.0))
-NSString* MTLCommandEncoderErrorStateToString(
+static NSString* MTLCommandEncoderErrorStateToString(
     MTLCommandEncoderErrorState state) {
   switch (state) {
     case MTLCommandEncoderErrorStateUnknown:
@@ -27,18 +26,6 @@ NSString* MTLCommandEncoderErrorStateToString(
   }
   return @"unknown";
 }
-
-// NOLINTBEGIN(readability-identifier-naming)
-
-// TODO(dnfield): This can be removed when all bots have been sufficiently
-// upgraded for MAC_OS_VERSION_12_0.
-#if !defined(MAC_OS_VERSION_12_0) || \
-    MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_VERSION_12_0
-constexpr int MTLCommandBufferErrorAccessRevoked = 4;
-constexpr int MTLCommandBufferErrorStackOverflow = 12;
-#endif
-
-// NOLINTEND(readability-identifier-naming)
 
 static NSString* MTLCommandBufferErrorToString(MTLCommandBufferError code) {
   switch (code) {
@@ -69,13 +56,13 @@ static NSString* MTLCommandBufferErrorToString(MTLCommandBufferError code) {
   return [NSString stringWithFormat:@"<unknown> %zu", code];
 }
 
-static void LogMTLCommandBufferErrorIfPresent(id<MTLCommandBuffer> buffer) {
+static bool LogMTLCommandBufferErrorIfPresent(id<MTLCommandBuffer> buffer) {
   if (!buffer) {
-    return;
+    return true;
   }
 
   if (buffer.status == MTLCommandBufferStatusCompleted) {
-    return;
+    return true;
   }
 
   std::stringstream stream;
@@ -123,10 +110,10 @@ static void LogMTLCommandBufferErrorIfPresent(id<MTLCommandBuffer> buffer) {
 
   stream << "<<<<<<<";
   VALIDATION_LOG << stream.str();
+  return false;
 }
-}  // namespace
 
-id<MTLCommandBuffer> CreateCommandBuffer(id<MTLCommandQueue> queue) {
+static id<MTLCommandBuffer> CreateCommandBuffer(id<MTLCommandQueue> queue) {
   if (@available(iOS 14.0, macOS 11.0, *)) {
     auto desc = [[MTLCommandBufferDescriptor alloc] init];
     // Degrades CPU performance slightly but is well worth the cost for typical
@@ -169,10 +156,13 @@ static CommandBuffer::Status ToCommitResult(MTLCommandBufferStatus status) {
 
 bool CommandBufferMTL::OnSubmitCommands(CompletionCallback callback) {
   if (callback) {
-    [buffer_ addCompletedHandler:^(id<MTLCommandBuffer> buffer) {
-      LogMTLCommandBufferErrorIfPresent(buffer);
-      callback(ToCommitResult(buffer.status));
-    }];
+    [buffer_
+        addCompletedHandler:^(id<MTLCommandBuffer> buffer) {
+          auto result = LogMTLCommandBufferErrorIfPresent(buffer);
+          FML_DCHECK(result)
+              << "Must not have errors during command buffer submission.";
+          callback(ToCommitResult(buffer.status));
+        }];
   }
 
   [buffer_ commit];

--- a/impeller/renderer/backend/metal/device_buffer_mtl.h
+++ b/impeller/renderer/backend/metal/device_buffer_mtl.h
@@ -29,15 +29,14 @@ class DeviceBufferMTL final
   const id<MTLBuffer> buffer_;
   const MTLStorageMode storage_mode_;
 
-  DeviceBufferMTL(id<MTLBuffer> buffer,
-                  size_t size,
-                  StorageMode mode,
+  DeviceBufferMTL(DeviceBufferDescriptor desc,
+                  id<MTLBuffer> buffer,
                   MTLStorageMode storage_mode);
 
   // |DeviceBuffer|
-  bool CopyHostBuffer(const uint8_t* source,
-                      Range source_range,
-                      size_t offset) override;
+  bool OnCopyHostBuffer(const uint8_t* source,
+                        Range source_range,
+                        size_t offset) override;
 
   // |DeviceBuffer|
   bool SetLabel(const std::string& label) override;

--- a/impeller/renderer/backend/metal/device_buffer_mtl.mm
+++ b/impeller/renderer/backend/metal/device_buffer_mtl.mm
@@ -11,11 +11,12 @@
 
 namespace impeller {
 
-DeviceBufferMTL::DeviceBufferMTL(id<MTLBuffer> buffer,
-                                 size_t size,
-                                 StorageMode mode,
+DeviceBufferMTL::DeviceBufferMTL(DeviceBufferDescriptor desc,
+                                 id<MTLBuffer> buffer,
                                  MTLStorageMode storage_mode)
-    : DeviceBuffer(size, mode), buffer_(buffer), storage_mode_(storage_mode) {}
+    : DeviceBuffer(std::move(desc)),
+      buffer_(buffer),
+      storage_mode_(storage_mode) {}
 
 DeviceBufferMTL::~DeviceBufferMTL() = default;
 
@@ -23,19 +24,9 @@ id<MTLBuffer> DeviceBufferMTL::GetMTLBuffer() const {
   return buffer_;
 }
 
-[[nodiscard]] bool DeviceBufferMTL::CopyHostBuffer(const uint8_t* source,
-                                                   Range source_range,
-                                                   size_t offset) {
-  if (mode_ != StorageMode::kHostVisible) {
-    // One of the storage modes where a transfer queue must be used.
-    return false;
-  }
-
-  if (offset + source_range.length > size_) {
-    // Out of bounds of this buffer.
-    return false;
-  }
-
+[[nodiscard]] bool DeviceBufferMTL::OnCopyHostBuffer(const uint8_t* source,
+                                                     Range source_range,
+                                                     size_t offset) {
   auto dest = static_cast<uint8_t*>(buffer_.contents);
 
   if (!dest) {

--- a/impeller/renderer/backend/metal/surface_mtl.mm
+++ b/impeller/renderer/backend/metal/surface_mtl.mm
@@ -44,6 +44,7 @@ std::unique_ptr<Surface> SurfaceMTL::WrapCurrentMetalLayerDrawable(
   }
 
   TextureDescriptor color0_tex_desc;
+  color0_tex_desc.storage_mode = StorageMode::kDeviceTransient;
   color0_tex_desc.type = TextureType::kTexture2DMultisample;
   color0_tex_desc.sample_count = SampleCount::kCount4;
   color0_tex_desc.format = color_format;
@@ -52,8 +53,8 @@ std::unique_ptr<Surface> SurfaceMTL::WrapCurrentMetalLayerDrawable(
       static_cast<ISize::Type>(current_drawable.texture.height)};
   color0_tex_desc.usage = static_cast<uint64_t>(TextureUsage::kRenderTarget);
 
-  auto msaa_tex = context->GetResourceAllocator()->CreateTexture(
-      StorageMode::kDeviceTransient, color0_tex_desc);
+  auto msaa_tex =
+      context->GetResourceAllocator()->CreateTexture(color0_tex_desc);
   if (!msaa_tex) {
     VALIDATION_LOG << "Could not allocate MSAA resolve texture.";
     return nullptr;
@@ -76,14 +77,15 @@ std::unique_ptr<Surface> SurfaceMTL::WrapCurrentMetalLayerDrawable(
       color0_resolve_tex_desc, current_drawable.texture);
 
   TextureDescriptor stencil0_tex;
+  stencil0_tex.storage_mode = StorageMode::kDeviceTransient;
   stencil0_tex.type = TextureType::kTexture2DMultisample;
   stencil0_tex.sample_count = SampleCount::kCount4;
   stencil0_tex.format = PixelFormat::kDefaultStencil;
   stencil0_tex.size = color0_tex_desc.size;
   stencil0_tex.usage =
       static_cast<TextureUsageMask>(TextureUsage::kRenderTarget);
-  auto stencil_texture = context->GetResourceAllocator()->CreateTexture(
-      StorageMode::kDeviceTransient, stencil0_tex);
+  auto stencil_texture =
+      context->GetResourceAllocator()->CreateTexture(stencil0_tex);
 
   if (!stencil_texture) {
     VALIDATION_LOG << "Could not create stencil texture.";

--- a/impeller/renderer/backend/vulkan/allocator_vk.cc
+++ b/impeller/renderer/backend/vulkan/allocator_vk.cc
@@ -60,8 +60,7 @@ bool AllocatorVK::IsValid() const {
 }
 
 // |Allocator|
-std::shared_ptr<Texture> AllocatorVK::CreateTexture(
-    StorageMode mode,
+std::shared_ptr<Texture> AllocatorVK::OnCreateTexture(
     const TextureDescriptor& desc) {
   auto image_create_info = vk::ImageCreateInfo{};
   image_create_info.imageType = vk::ImageType::e2D;
@@ -116,8 +115,8 @@ std::shared_ptr<Texture> AllocatorVK::CreateTexture(
 }
 
 // |Allocator|
-std::shared_ptr<DeviceBuffer> AllocatorVK::CreateBuffer(StorageMode mode,
-                                                        size_t length) {
+std::shared_ptr<DeviceBuffer> AllocatorVK::OnCreateBuffer(
+    const DeviceBufferDescriptor& desc) {
   // TODO (kaushikiska): consider optimizing  the usage flags based on
   // StorageMode.
   auto buffer_create_info = static_cast<vk::BufferCreateInfo::NativeType>(
@@ -125,7 +124,7 @@ std::shared_ptr<DeviceBuffer> AllocatorVK::CreateBuffer(StorageMode mode,
           .setUsage(vk::BufferUsageFlagBits::eStorageBuffer |
                     vk::BufferUsageFlagBits::eTransferSrc |
                     vk::BufferUsageFlagBits::eTransferDst)
-          .setSize(length)
+          .setSize(desc.size)
           .setSharingMode(vk::SharingMode::eExclusive));
 
   VmaAllocationCreateInfo allocCreateInfo = {};
@@ -149,7 +148,7 @@ std::shared_ptr<DeviceBuffer> AllocatorVK::CreateBuffer(StorageMode mode,
   auto device_allocation = std::make_unique<DeviceBufferAllocationVK>(
       allocator_, buffer, buffer_allocation, buffer_allocation_info);
 
-  return std::make_shared<DeviceBufferVK>(length, mode, context_,
+  return std::make_shared<DeviceBufferVK>(desc, context_,
                                           std::move(device_allocation));
 }
 

--- a/impeller/renderer/backend/vulkan/allocator_vk.h
+++ b/impeller/renderer/backend/vulkan/allocator_vk.h
@@ -37,12 +37,11 @@ class AllocatorVK final : public Allocator {
   bool IsValid() const;
 
   // |Allocator|
-  std::shared_ptr<DeviceBuffer> CreateBuffer(StorageMode mode,
-                                             size_t length) override;
+  std::shared_ptr<DeviceBuffer> OnCreateBuffer(
+      const DeviceBufferDescriptor& desc) override;
 
   // |Allocator|
-  std::shared_ptr<Texture> CreateTexture(
-      StorageMode mode,
+  std::shared_ptr<Texture> OnCreateTexture(
       const TextureDescriptor& desc) override;
 
   // |Allocator|

--- a/impeller/renderer/backend/vulkan/device_buffer_vk.cc
+++ b/impeller/renderer/backend/vulkan/device_buffer_vk.cc
@@ -33,29 +33,18 @@ void* DeviceBufferAllocationVK::GetMapping() const {
 }
 
 DeviceBufferVK::DeviceBufferVK(
-    size_t size,
-    StorageMode mode,
+    DeviceBufferDescriptor desc,
     ContextVK& context,
     std::unique_ptr<DeviceBufferAllocationVK> device_allocation)
-    : DeviceBuffer(size, mode),
+    : DeviceBuffer(std::move(desc)),
       context_(context),
       device_allocation_(std::move(device_allocation)) {}
 
 DeviceBufferVK::~DeviceBufferVK() = default;
 
-bool DeviceBufferVK::CopyHostBuffer(const uint8_t* source,
-                                    Range source_range,
-                                    size_t offset) {
-  if (mode_ != StorageMode::kHostVisible) {
-    // One of the storage modes where a transfer queue must be used.
-    return false;
-  }
-
-  if (offset + source_range.length > size_) {
-    // Out of bounds of this buffer.
-    return false;
-  }
-
+bool DeviceBufferVK::OnCopyHostBuffer(const uint8_t* source,
+                                      Range source_range,
+                                      size_t offset) {
   auto dest = static_cast<uint8_t*>(device_allocation_->GetMapping());
 
   if (!dest) {

--- a/impeller/renderer/backend/vulkan/device_buffer_vk.h
+++ b/impeller/renderer/backend/vulkan/device_buffer_vk.h
@@ -38,8 +38,7 @@ class DeviceBufferAllocationVK {
 class DeviceBufferVK final : public DeviceBuffer,
                              public BackendCast<DeviceBufferVK, DeviceBuffer> {
  public:
-  DeviceBufferVK(size_t size,
-                 StorageMode mode,
+  DeviceBufferVK(DeviceBufferDescriptor desc,
                  ContextVK& context,
                  std::unique_ptr<DeviceBufferAllocationVK> device_allocation);
 
@@ -53,9 +52,9 @@ class DeviceBufferVK final : public DeviceBuffer,
   std::unique_ptr<DeviceBufferAllocationVK> device_allocation_;
 
   // |DeviceBuffer|
-  bool CopyHostBuffer(const uint8_t* source,
-                      Range source_range,
-                      size_t offset) override;
+  bool OnCopyHostBuffer(const uint8_t* source,
+                        Range source_range,
+                        size_t offset) override;
 
   // |DeviceBuffer|
   bool SetLabel(const std::string& label) override;

--- a/impeller/renderer/device_buffer.h
+++ b/impeller/renderer/device_buffer.h
@@ -11,6 +11,7 @@
 #include "impeller/renderer/allocator.h"
 #include "impeller/renderer/buffer.h"
 #include "impeller/renderer/buffer_view.h"
+#include "impeller/renderer/device_buffer_descriptor.h"
 #include "impeller/renderer/range.h"
 #include "impeller/renderer/texture.h"
 
@@ -21,9 +22,9 @@ class DeviceBuffer : public Buffer,
  public:
   virtual ~DeviceBuffer();
 
-  [[nodiscard]] virtual bool CopyHostBuffer(const uint8_t* source,
-                                            Range source_range,
-                                            size_t offset = 0u) = 0;
+  [[nodiscard]] bool CopyHostBuffer(const uint8_t* source,
+                                    Range source_range,
+                                    size_t offset = 0u);
 
   virtual bool SetLabel(const std::string& label) = 0;
 
@@ -36,10 +37,13 @@ class DeviceBuffer : public Buffer,
       Allocator& allocator) const;
 
  protected:
-  const size_t size_;
-  const StorageMode mode_;
+  const DeviceBufferDescriptor desc_;
 
-  DeviceBuffer(size_t size, StorageMode mode);
+  explicit DeviceBuffer(DeviceBufferDescriptor desc);
+
+  virtual bool OnCopyHostBuffer(const uint8_t* source,
+                                Range source_range,
+                                size_t offset) = 0;
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(DeviceBuffer);

--- a/impeller/renderer/device_buffer_descriptor.cc
+++ b/impeller/renderer/device_buffer_descriptor.cc
@@ -1,0 +1,11 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/renderer/device_buffer_descriptor.h"
+
+namespace impeller {
+
+//
+
+}  // namespace impeller

--- a/impeller/renderer/device_buffer_descriptor.h
+++ b/impeller/renderer/device_buffer_descriptor.h
@@ -1,0 +1,18 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#pragma once
+
+#include <cstddef>
+
+#include "impeller/renderer/formats.h"
+
+namespace impeller {
+
+struct DeviceBufferDescriptor {
+  StorageMode storage_mode = StorageMode::kDeviceTransient;
+  size_t size = 0u;
+};
+
+}  // namespace impeller

--- a/impeller/renderer/formats.cc
+++ b/impeller/renderer/formats.cc
@@ -4,8 +4,50 @@
 
 #include "impeller/renderer/formats.h"
 
+#include "impeller/base/validation.h"
+#include "impeller/renderer/texture.h"
+
 namespace impeller {
 
-//
+constexpr bool StoreActionNeedsResolveTexture(StoreAction action) {
+  switch (action) {
+    case StoreAction::kDontCare:
+    case StoreAction::kStore:
+      return false;
+    case StoreAction::kMultisampleResolve:
+    case StoreAction::kStoreAndMultisampleResolve:
+      return true;
+  }
+}
+
+bool Attachment::IsValid() const {
+  if (!texture || !texture->IsValid()) {
+    VALIDATION_LOG << "Attachment has no texture.";
+    return false;
+  }
+
+// TODO(110385): Enable attachment validation.
+#if 0
+  if (StoreActionNeedsResolveTexture(store_action)) {
+    if (!resolve_texture || !resolve_texture->IsValid()) {
+      VALIDATION_LOG << "Store action needs resolve but no valid resolve "
+                        "texture specified.";
+      return false;
+    }
+  }
+
+  if (texture->GetTextureDescriptor().storage_mode ==
+      StorageMode::kDeviceTransient) {
+    if (load_action != LoadAction::kDontCare &&
+        store_action != StoreAction::kDontCare) {
+      VALIDATION_LOG
+          << "Load or store actions specified on device transient textures.";
+      return false;
+    }
+  }
+#endif
+
+  return true;
+}
 
 }  // namespace impeller

--- a/impeller/renderer/formats.h
+++ b/impeller/renderer/formats.h
@@ -21,6 +21,37 @@ namespace impeller {
 class Texture;
 
 //------------------------------------------------------------------------------
+/// @brief      Specified where the allocation resides and how it is used.
+///
+enum class StorageMode {
+  //----------------------------------------------------------------------------
+  /// Allocations can be mapped onto the hosts address space and also be used by
+  /// the device.
+  ///
+  kHostVisible,
+  //----------------------------------------------------------------------------
+  /// Allocations can only be used by the device. This location is optimal for
+  /// use by the device. If the host needs to access these allocations, the
+  /// transfer queue must be used to transfer this allocation onto the a host
+  /// visible buffer.
+  ///
+  kDevicePrivate,
+  //----------------------------------------------------------------------------
+  /// Used by the device for temporary render targets. These allocations cannot
+  /// be transferred from and to other allocations using the transfer queue.
+  /// Render pass cannot initialize the contents of these buffers using load and
+  /// store actions.
+  ///
+  /// These allocations reside in tile memory which has higher bandwidth, lower
+  /// latency and lower power consumption. The total device memory usage is
+  /// also lower as a separate allocation does not need to be created in
+  /// device memory. Prefer using these allocations for intermediates like depth
+  /// and stencil buffers.
+  ///
+  kDeviceTransient,
+};
+
+//------------------------------------------------------------------------------
 /// @brief      The Pixel formats supported by Impeller. The naming convention
 ///             denotes the usage of the component, the bit width of that
 ///             component, and then one or more qualifiers to its
@@ -419,7 +450,7 @@ struct Attachment {
   LoadAction load_action = LoadAction::kDontCare;
   StoreAction store_action = StoreAction::kStore;
 
-  constexpr operator bool() const { return static_cast<bool>(texture); }
+  bool IsValid() const;
 };
 
 struct ColorAttachment : public Attachment {

--- a/impeller/renderer/render_target.cc
+++ b/impeller/renderer/render_target.cc
@@ -142,21 +142,21 @@ std::shared_ptr<Texture> RenderTarget::GetRenderTargetTexture() const {
 
 RenderTarget& RenderTarget::SetColorAttachment(ColorAttachment attachment,
                                                size_t index) {
-  if (attachment) {
+  if (attachment.IsValid()) {
     colors_[index] = attachment;
   }
   return *this;
 }
 
 RenderTarget& RenderTarget::SetDepthAttachment(DepthAttachment attachment) {
-  if (attachment) {
+  if (attachment.IsValid()) {
     depth_ = std::move(attachment);
   }
   return *this;
 }
 
 RenderTarget& RenderTarget::SetStencilAttachment(StencilAttachment attachment) {
-  if (attachment) {
+  if (attachment.IsValid()) {
     stencil_ = std::move(attachment);
   }
   return *this;
@@ -190,12 +190,14 @@ RenderTarget RenderTarget::CreateOffscreen(const Context& context,
   }
 
   TextureDescriptor color_tex0;
+  color_tex0.storage_mode = color_storage_mode;
   color_tex0.format = PixelFormat::kDefaultColor;
   color_tex0.size = size;
   color_tex0.usage = static_cast<uint64_t>(TextureUsage::kRenderTarget) |
                      static_cast<uint64_t>(TextureUsage::kShaderRead);
 
   TextureDescriptor stencil_tex0;
+  stencil_tex0.storage_mode = stencil_storage_mode;
   stencil_tex0.format = PixelFormat::kDefaultStencil;
   stencil_tex0.size = size;
   stencil_tex0.usage =
@@ -205,8 +207,7 @@ RenderTarget RenderTarget::CreateOffscreen(const Context& context,
   color0.clear_color = Color::BlackTransparent();
   color0.load_action = color_load_action;
   color0.store_action = color_store_action;
-  color0.texture = context.GetResourceAllocator()->CreateTexture(
-      color_storage_mode, color_tex0);
+  color0.texture = context.GetResourceAllocator()->CreateTexture(color_tex0);
 
   if (!color0.texture) {
     return {};
@@ -218,8 +219,8 @@ RenderTarget RenderTarget::CreateOffscreen(const Context& context,
   stencil0.load_action = stencil_load_action;
   stencil0.store_action = stencil_store_action;
   stencil0.clear_stencil = 0u;
-  stencil0.texture = context.GetResourceAllocator()->CreateTexture(
-      stencil_storage_mode, stencil_tex0);
+  stencil0.texture =
+      context.GetResourceAllocator()->CreateTexture(stencil_tex0);
 
   if (!stencil0.texture) {
     return {};
@@ -252,6 +253,7 @@ RenderTarget RenderTarget::CreateOffscreenMSAA(
   // Create MSAA color texture.
 
   TextureDescriptor color0_tex_desc;
+  color0_tex_desc.storage_mode = color_storage_mode;
   color0_tex_desc.type = TextureType::kTexture2DMultisample;
   color0_tex_desc.sample_count = SampleCount::kCount4;
   color0_tex_desc.format = PixelFormat::kDefaultColor;
@@ -259,8 +261,8 @@ RenderTarget RenderTarget::CreateOffscreenMSAA(
   color0_tex_desc.usage = static_cast<uint64_t>(TextureUsage::kRenderTarget) |
                           static_cast<uint64_t>(TextureUsage::kShaderRead);
 
-  auto color0_msaa_tex = context.GetResourceAllocator()->CreateTexture(
-      color_storage_mode, color0_tex_desc);
+  auto color0_msaa_tex =
+      context.GetResourceAllocator()->CreateTexture(color0_tex_desc);
   if (!color0_msaa_tex) {
     VALIDATION_LOG << "Could not create multisample color texture.";
     return {};
@@ -271,14 +273,15 @@ RenderTarget RenderTarget::CreateOffscreenMSAA(
   // Create color resolve texture.
 
   TextureDescriptor color0_resolve_tex_desc;
+  color0_resolve_tex_desc.storage_mode = color_resolve_storage_mode;
   color0_resolve_tex_desc.format = PixelFormat::kDefaultColor;
   color0_resolve_tex_desc.size = size;
   color0_resolve_tex_desc.usage =
       static_cast<uint64_t>(TextureUsage::kRenderTarget) |
       static_cast<uint64_t>(TextureUsage::kShaderRead);
 
-  auto color0_resolve_tex = context.GetResourceAllocator()->CreateTexture(
-      color_resolve_storage_mode, color0_resolve_tex_desc);
+  auto color0_resolve_tex =
+      context.GetResourceAllocator()->CreateTexture(color0_resolve_tex_desc);
   if (!color0_resolve_tex) {
     VALIDATION_LOG << "Could not create color texture.";
     return {};
@@ -297,6 +300,7 @@ RenderTarget RenderTarget::CreateOffscreenMSAA(
   // Create MSAA stencil texture.
 
   TextureDescriptor stencil_tex0;
+  stencil_tex0.storage_mode = stencil_storage_mode;
   stencil_tex0.type = TextureType::kTexture2DMultisample;
   stencil_tex0.sample_count = SampleCount::kCount4;
   stencil_tex0.format = PixelFormat::kDefaultStencil;
@@ -308,8 +312,8 @@ RenderTarget RenderTarget::CreateOffscreenMSAA(
   stencil0.load_action = stencil_load_action;
   stencil0.store_action = stencil_store_action;
   stencil0.clear_stencil = 0u;
-  stencil0.texture = context.GetResourceAllocator()->CreateTexture(
-      stencil_storage_mode, stencil_tex0);
+  stencil0.texture =
+      context.GetResourceAllocator()->CreateTexture(stencil_tex0);
 
   if (!stencil0.texture) {
     return {};

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -322,15 +322,16 @@ TEST_P(RendererTest, CanRenderToTexture) {
     ASSERT_NE(pipeline_desc->GetColorAttachmentDescriptor(0u), nullptr);
     texture_descriptor.format =
         pipeline_desc->GetColorAttachmentDescriptor(0u)->format;
+    texture_descriptor.storage_mode = StorageMode::kHostVisible;
     texture_descriptor.size = {400, 400};
     texture_descriptor.mip_count = 1u;
     texture_descriptor.usage =
         static_cast<TextureUsageMask>(TextureUsage::kRenderTarget);
 
-    color0.texture = context->GetResourceAllocator()->CreateTexture(
-        StorageMode::kHostVisible, texture_descriptor);
+    color0.texture =
+        context->GetResourceAllocator()->CreateTexture(texture_descriptor);
 
-    ASSERT_TRUE(color0);
+    ASSERT_TRUE(color0.IsValid());
 
     color0.texture->SetLabel("r2t_target");
 
@@ -338,12 +339,13 @@ TEST_P(RendererTest, CanRenderToTexture) {
     stencil0.load_action = LoadAction::kClear;
     stencil0.store_action = StoreAction::kDontCare;
     TextureDescriptor stencil_texture_desc;
+    stencil_texture_desc.storage_mode = StorageMode::kDeviceTransient;
     stencil_texture_desc.size = texture_descriptor.size;
     stencil_texture_desc.format = PixelFormat::kS8UInt;
     stencil_texture_desc.usage =
         static_cast<TextureUsageMask>(TextureUsage::kRenderTarget);
-    stencil0.texture = context->GetResourceAllocator()->CreateTexture(
-        StorageMode::kDeviceTransient, stencil_texture_desc);
+    stencil0.texture =
+        context->GetResourceAllocator()->CreateTexture(stencil_texture_desc);
 
     RenderTarget r2t_desc;
     r2t_desc.SetColorAttachment(color0, 0u);
@@ -458,14 +460,14 @@ TEST_P(RendererTest, CanBlitTextureToTexture) {
   ASSERT_TRUE(mipmaps_pipeline);
 
   TextureDescriptor texture_desc;
+  texture_desc.storage_mode = StorageMode::kHostVisible;
   texture_desc.format = PixelFormat::kR8G8B8A8UNormInt;
   texture_desc.size = {800, 600};
   texture_desc.mip_count = 1u;
   texture_desc.usage =
       static_cast<TextureUsageMask>(TextureUsage::kRenderTarget) |
       static_cast<TextureUsageMask>(TextureUsage::kShaderRead);
-  auto texture = context->GetResourceAllocator()->CreateTexture(
-      StorageMode::kHostVisible, texture_desc);
+  auto texture = context->GetResourceAllocator()->CreateTexture(texture_desc);
   ASSERT_TRUE(texture);
 
   auto bridge = CreateTextureForFixture("bay_bridge.jpg");

--- a/impeller/renderer/texture.h
+++ b/impeller/renderer/texture.h
@@ -40,7 +40,7 @@ class Texture {
   virtual Scalar GetYCoordScale() const;
 
  protected:
-  Texture(TextureDescriptor desc);
+  explicit Texture(TextureDescriptor desc);
 
   [[nodiscard]] virtual bool OnSetContents(const uint8_t* contents,
                                            size_t length,

--- a/impeller/renderer/texture_descriptor.h
+++ b/impeller/renderer/texture_descriptor.h
@@ -17,6 +17,7 @@ namespace impeller {
 ///             that can then used used an allocator to create that texture.
 ///
 struct TextureDescriptor {
+  StorageMode storage_mode = StorageMode::kDeviceTransient;
   TextureType type = TextureType::kTexture2D;
   PixelFormat format = PixelFormat::kUnknown;
   ISize size;

--- a/impeller/typographer/backends/skia/text_render_context_skia.cc
+++ b/impeller/typographer/backends/skia/text_render_context_skia.cc
@@ -164,6 +164,7 @@ static std::shared_ptr<Texture> UploadGlyphTextureAtlas(
   const auto& pixmap = bitmap->pixmap();
 
   TextureDescriptor texture_descriptor;
+  texture_descriptor.storage_mode = StorageMode::kHostVisible;
   texture_descriptor.format = PixelFormat::kA8UNormInt;
   texture_descriptor.size = ISize::MakeWH(atlas_size, atlas_size);
 
@@ -172,8 +173,7 @@ static std::shared_ptr<Texture> UploadGlyphTextureAtlas(
     return nullptr;
   }
 
-  auto texture =
-      allocator->CreateTexture(StorageMode::kHostVisible, texture_descriptor);
+  auto texture = allocator->CreateTexture(texture_descriptor);
   if (!texture || !texture->IsValid()) {
     return nullptr;
   }

--- a/lib/ui/painting/image_decoder_impeller.cc
+++ b/lib/ui/painting/image_decoder_impeller.cc
@@ -151,11 +151,12 @@ static sk_sp<DlImage> UploadTexture(std::shared_ptr<impeller::Context> context,
   }
 
   impeller::TextureDescriptor texture_descriptor;
+  texture_descriptor.storage_mode = impeller::StorageMode::kHostVisible;
   texture_descriptor.format = pixel_format.value();
   texture_descriptor.size = {image_info.width(), image_info.height()};
 
-  auto texture = context->GetResourceAllocator()->CreateTexture(
-      impeller::StorageMode::kHostVisible, texture_descriptor);
+  auto texture =
+      context->GetResourceAllocator()->CreateTexture(texture_descriptor);
   if (!texture) {
     FML_DLOG(ERROR) << "Could not create Impeller texture.";
     return nullptr;


### PR DESCRIPTION
Today, depending on which backend specific validation layers are enabled at
runtime, invalid user configuration of render targets, texture allocations, or
resource copies may go unnoticed.

Moreover, not all configurations are errors in all backends. For instance, there
is no concept of device transient resource types (`MTLStorageModeMemoryless` in
Metal) in a backend such as OpenGLES. This will allow an Impeller user working
on testing just the OpenGL backend create rendering intent that will trip
validation errors (and cause rendering issues) on Metal.

This patch moves all the validation into Impeller itself (pretty cheap with no
increases in algorithmic complexity).