### PR TITLE
Roll Clang Mac from 60d276923902 to 41d4067d0b7c

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -56,7 +56,7 @@ platform_properties:
       device_type: none
       cpu: x86
       os: Mac-12
-      xcode: 13a233 # xcode 13.0
+      xcode: 13f17a # xcode 13.4
   windows:
     properties:
       build_host: "false"
@@ -448,6 +448,7 @@ targets:
       build_ios: "true"
       ios_release: "true"
       jazzy_version: "0.14.1"
+      xcode: 13a233 # Xcode 13.0 for bitcode support
     timeout: 90
 
   - name: Linux ci_yaml engine roller

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -56,7 +56,7 @@ platform_properties:
       device_type: none
       cpu: x86
       os: Mac-12
-      xcode: 13f17a # xcode 13.4
+      xcode: 14a5294e # xcode 14.0 beta 5
   windows:
     properties:
       build_host: "false"

--- a/DEPS
+++ b/DEPS
@@ -606,7 +606,7 @@ deps = {
     'packages': [
       {
         'package': 'fuchsia/third_party/clang/mac-amd64',
-        'version': 'git_revision:60d276923902051192eba692e5312e605c9d9f65'
+        'version': 'git_revision:41d4067d0b7c3c955b8b6cda328bcb46e268bd6a'
       }
     ],
     'condition': 'host_os == "mac"',


### PR DESCRIPTION
https://github.com/flutter/engine/pull/35653 plus Xcode bump on non-release Mac builders that use fuchsia toolchain version of clang to see if the newer headers work.
