### PR TITLE
[Impeller] Set stencil attachment on root FBO render target in GLES

### DIFF
--- a/impeller/renderer/backend/gles/surface_gles.cc
+++ b/impeller/renderer/backend/gles/surface_gles.cc
@@ -58,6 +58,7 @@ std::unique_ptr<Surface> SurfaceGLES::WrapFBO(std::shared_ptr<Context> context,
   RenderTarget render_target_desc;
 
   render_target_desc.SetColorAttachment(color0, 0u);
+  render_target_desc.SetStencilAttachment(stencil0);
 
   return std::unique_ptr<SurfaceGLES>(
       new SurfaceGLES(std::move(swap_callback), std::move(render_target_desc)));


### PR DESCRIPTION
Fixes Aiks/DisplayList GLES playgrounds. Turns out the attachment was was getting filled out but not handed to the target! The root render target is more for bookkeeping than anything, so this probably doesn't impact rendering in practice.