### PR TITLE
Include raster cache when flattening layer tree

### DIFF
--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -174,7 +174,8 @@ void LayerTree::Paint(CompositorContext::ScopedFrame& frame,
 sk_sp<DisplayList> LayerTree::Flatten(
     const SkRect& bounds,
     std::shared_ptr<TextureRegistry> texture_registry,
-    GrDirectContext* gr_context) {
+    GrDirectContext* gr_context,
+    RasterCache* cache) {
   TRACE_EVENT0("flutter", "LayerTree::Flatten");
 
   DisplayListCanvasRecorder builder(bounds);
@@ -188,7 +189,7 @@ sk_sp<DisplayList> LayerTree::Flatten(
 
   PrerollContext preroll_context{
       // clang-format off
-      .raster_cache                  = nullptr,
+      .raster_cache                  = cache,
       .gr_context                    = gr_context,
       .view_embedder                 = nullptr,
       .mutators_stack                = unused_stack,
@@ -219,7 +220,7 @@ sk_sp<DisplayList> LayerTree::Flatten(
       .raster_time                   = unused_stopwatch,
       .ui_time                       = unused_stopwatch,
       .texture_registry              = texture_registry,
-      .raster_cache                  = nullptr,
+      .raster_cache                  = cache,
       .checkerboard_offscreen_layers = false,
       .frame_device_pixel_ratio      = device_pixel_ratio_,
       .layer_snapshot_store          = nullptr,

--- a/flow/layers/layer_tree.h
+++ b/flow/layers/layer_tree.h
@@ -45,7 +45,8 @@ class LayerTree {
   sk_sp<DisplayList> Flatten(
       const SkRect& bounds,
       std::shared_ptr<TextureRegistry> texture_registry = nullptr,
-      GrDirectContext* gr_context = nullptr);
+      GrDirectContext* gr_context = nullptr,
+      RasterCache* cache = nullptr);
 
   Layer* root_layer() const { return root_layer_.get(); }
 

--- a/flow/surface.h
+++ b/flow/surface.h
@@ -10,6 +10,7 @@
 #include "flutter/common/graphics/gl_context_switch.h"
 #include "flutter/flow/embedded_views.h"
 #include "flutter/flow/surface_frame.h"
+#include "flutter/flow/raster_cache.h"
 #include "flutter/fml/macros.h"
 
 namespace flutter {

--- a/lib/ui/painting/display_list_deferred_image_gpu.cc
+++ b/lib/ui/painting/display_list_deferred_image_gpu.cc
@@ -172,11 +172,12 @@ void DlDeferredImageGPU::ImageWrapper::SnapshotDisplayList(
           return;
         }
         if (layer_tree) {
-          auto display_list =
-              layer_tree->Flatten(SkRect::MakeWH(wrapper->image_info_.width(),
-                                                 wrapper->image_info_.height()),
-                                  snapshot_delegate->GetTextureRegistry(),
-                                  snapshot_delegate->GetGrContext());
+          auto* raster_cache = &snapshot_delegate->GetRasterCache();
+          auto display_list = layer_tree->Flatten(
+              SkRect::MakeWH(wrapper->image_info_.width(),
+                             wrapper->image_info_.height()),
+              snapshot_delegate->GetTextureRegistry(),
+              snapshot_delegate->GetGrContext(), raster_cache);
           wrapper->display_list_ = std::move(display_list);
         }
         auto result = snapshot_delegate->MakeGpuImage(wrapper->display_list_,

--- a/lib/ui/painting/picture.cc
+++ b/lib/ui/painting/picture.cc
@@ -173,10 +173,12 @@ Dart_Handle Picture::RasterizeToImage(
        ui_task, layer_tree = std::move(layer_tree)] {
         sk_sp<SkImage> raster_image;
         if (layer_tree) {
+          auto* raster_cache = &snapshot_delegate->GetRasterCache();
           auto display_list = layer_tree->Flatten(
               SkRect::MakeWH(picture_bounds.width(), picture_bounds.height()),
               snapshot_delegate->GetTextureRegistry(),
-              snapshot_delegate->GetGrContext());
+              snapshot_delegate->GetGrContext(),
+              raster_cache);
 
           raster_image = snapshot_delegate->MakeRasterSnapshot(
               [display_list](SkCanvas* canvas) {

--- a/lib/ui/snapshot_delegate.h
+++ b/lib/ui/snapshot_delegate.h
@@ -9,6 +9,7 @@
 
 #include "flutter/common/graphics/texture.h"
 #include "flutter/display_list/display_list.h"
+#include "flutter/flow/raster_cache.h"
 #include "third_party/skia/include/core/SkImage.h"
 #include "third_party/skia/include/core/SkPicture.h"
 #include "third_party/skia/include/core/SkPromiseImageTexture.h"
@@ -54,6 +55,8 @@ class SnapshotDelegate {
   virtual std::shared_ptr<TextureRegistry> GetTextureRegistry() = 0;
 
   virtual GrDirectContext* GetGrContext() = 0;
+
+  virtual RasterCache& GetRasterCache() = 0;
 
   virtual std::unique_ptr<GpuImageResult> MakeGpuImage(
       sk_sp<DisplayList> display_list,

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -149,6 +149,10 @@ GrDirectContext* Rasterizer::GetGrContext() {
   return surface_ ? surface_->GetContext() : nullptr;
 }
 
+RasterCache& Rasterizer::GetRasterCache() {
+  return compositor_context_->raster_cache();
+}
+
 flutter::LayerTree* Rasterizer::GetLastLayerTree() {
   return last_layer_tree_.get();
 }

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -216,6 +216,9 @@ class Rasterizer final : public SnapshotDelegate,
   // |SnapshotDelegate|
   GrDirectContext* GetGrContext() override;
 
+  // |SnapshotDelegate|
+  RasterCache& GetRasterCache() override;
+
   std::shared_ptr<flutter::TextureRegistry> GetTextureRegistry() override;
 
   using LayerTreeDiscardCallback = std::function<bool(flutter::LayerTree&)>;


### PR DESCRIPTION
In theory this improves throughput of the zoom page transition by re-using anything that was cached on the exiting screen.

Fixes https://github.com/flutter/flutter/issues/107584