### PR TITLE
[Impeller] Draw previous MSAA resolve texture to subsequent passes. Never store/load MSAA textures.

### DIFF
--- a/impeller/entity/contents/texture_contents.cc
+++ b/impeller/entity/contents/texture_contents.cc
@@ -29,6 +29,10 @@ std::shared_ptr<TextureContents> TextureContents::MakeRect(Rect destination) {
   return contents;
 }
 
+void TextureContents::SetLabel(std::string label) {
+  label_ = label;
+}
+
 void TextureContents::SetPath(Path path) {
   path_ = std::move(path);
   is_rect_ = false;
@@ -141,7 +145,10 @@ bool TextureContents::Render(const ContentContext& renderer,
   frag_info.alpha = opacity_;
 
   Command cmd;
-  cmd.label = "TextureFill";
+  cmd.label = "Texture Fill";
+  if (!label_.empty()) {
+    cmd.label += ": " + label_;
+  }
   cmd.pipeline =
       renderer.GetTexturePipeline(OptionsFromPassAndEntity(pass, entity));
   cmd.stencil_reference = entity.GetStencilDepth();

--- a/impeller/entity/contents/texture_contents.cc
+++ b/impeller/entity/contents/texture_contents.cc
@@ -12,6 +12,7 @@
 #include "impeller/entity/texture_fill.frag.h"
 #include "impeller/entity/texture_fill.vert.h"
 #include "impeller/geometry/path_builder.h"
+#include "impeller/renderer/formats.h"
 #include "impeller/renderer/render_pass.h"
 #include "impeller/renderer/sampler_library.h"
 #include "impeller/tessellator/tessellator.h"
@@ -48,6 +49,10 @@ std::shared_ptr<Texture> TextureContents::GetTexture() const {
 
 void TextureContents::SetOpacity(Scalar opacity) {
   opacity_ = opacity;
+}
+
+void TextureContents::SetStencilEnabled(bool enabled) {
+  stencil_enabled_ = enabled;
 }
 
 std::optional<Rect> TextureContents::GetCoverage(const Entity& entity) const {
@@ -149,8 +154,12 @@ bool TextureContents::Render(const ContentContext& renderer,
   if (!label_.empty()) {
     cmd.label += ": " + label_;
   }
-  cmd.pipeline =
-      renderer.GetTexturePipeline(OptionsFromPassAndEntity(pass, entity));
+
+  auto pipeline_options = OptionsFromPassAndEntity(pass, entity);
+  if (!stencil_enabled_) {
+    pipeline_options.stencil_compare = CompareFunction::kAlways;
+  }
+  cmd.pipeline = renderer.GetTexturePipeline(pipeline_options);
   cmd.stencil_reference = entity.GetStencilDepth();
   cmd.BindVertices(vertex_builder.CreateVertexBuffer(host_buffer));
   VS::BindVertInfo(cmd, host_buffer.EmplaceUniform(vert_info));

--- a/impeller/entity/contents/texture_contents.h
+++ b/impeller/entity/contents/texture_contents.h
@@ -28,6 +28,8 @@ class TextureContents final : public Contents {
   ///         when image filters are applied.
   static std::shared_ptr<TextureContents> MakeRect(Rect destination);
 
+  void SetLabel(std::string label);
+
   void SetPath(Path path);
 
   void SetTexture(std::shared_ptr<Texture> texture);
@@ -57,6 +59,8 @@ class TextureContents final : public Contents {
               RenderPass& pass) const override;
 
  private:
+  std::string label_;
+
   Path path_;
   bool is_rect_ = false;
 

--- a/impeller/entity/contents/texture_contents.h
+++ b/impeller/entity/contents/texture_contents.h
@@ -46,6 +46,8 @@ class TextureContents final : public Contents {
 
   void SetOpacity(Scalar opacity);
 
+  void SetStencilEnabled(bool enabled);
+
   // |Contents|
   std::optional<Rect> GetCoverage(const Entity& entity) const override;
 
@@ -63,6 +65,7 @@ class TextureContents final : public Contents {
 
   Path path_;
   bool is_rect_ = false;
+  bool stencil_enabled_ = true;
 
   std::shared_ptr<Texture> texture_;
   SamplerDescriptor sampler_descriptor_ = {};

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -153,14 +153,13 @@ static RenderTarget CreateRenderTarget(ContentContext& renderer,
 
   if (context->SupportsOffscreenMSAA()) {
     return RenderTarget::CreateOffscreenMSAA(
-        *context,      // context
-        size,          // size
-        "EntityPass",  // label
-        readable ? StorageMode::kDevicePrivate
-                 : StorageMode::kDeviceTransient,  // color_storage_mode
-        StorageMode::kDevicePrivate,               // color_resolve_storage_mode
-        LoadAction::kDontCare,                     // color_load_action
-        StoreAction::kDontCare,                    // color_store_action
+        *context,                       // context
+        size,                           // size
+        "EntityPass",                   // label
+        StorageMode::kDeviceTransient,  // color_storage_mode
+        StorageMode::kDevicePrivate,    // color_resolve_storage_mode
+        LoadAction::kDontCare,          // color_load_action
+        StoreAction::kDontCare,         // color_store_action
         readable ? StorageMode::kDevicePrivate
                  : StorageMode::kDeviceTransient,  // stencil_storage_mode
         LoadAction::kDontCare,                     // stencil_load_action
@@ -391,20 +390,38 @@ bool EntityPass::OnRender(ContentContext& renderer,
 
   auto render_element = [&stencil_depth_floor, &pass_context, &pass_depth,
                          &renderer](Entity& element_entity) {
-    element_entity.SetStencilDepth(element_entity.GetStencilDepth() -
-                                   stencil_depth_floor);
+    auto result = pass_context.GetRenderPass(pass_depth);
 
-    auto pass = pass_context.GetRenderPass(pass_depth);
-
-    if (!pass) {
+    if (!result.pass) {
       return false;
     }
 
-    if (!element_entity.ShouldRender(pass->GetRenderTargetSize())) {
+    if (!element_entity.ShouldRender(result.pass->GetRenderTargetSize())) {
       return true;  // Nothing to render.
     }
 
-    if (!element_entity.Render(renderer, *pass)) {
+    // If the pass context returns a texture, we need to draw it to the current
+    // pass. We do this because it's faster and takes significantly less memory
+    // than storing/loading large MSAA textures.
+    if (result.previous_pass_texture) {
+      auto size_rect = Rect::MakeSize(result.pass->GetRenderTargetSize());
+      auto msaa_backdrop_contents = TextureContents::MakeRect(size_rect);
+      msaa_backdrop_contents->SetLabel("MSAA backdrop");
+      msaa_backdrop_contents->SetSourceRect(size_rect);
+      msaa_backdrop_contents->SetTexture(result.previous_pass_texture);
+
+      Entity msaa_backdrop_entity;
+      msaa_backdrop_entity.SetStencilDepth(element_entity.GetStencilDepth() -
+                                           stencil_depth_floor);
+      msaa_backdrop_entity.SetContents(std::move(msaa_backdrop_contents));
+      if (!msaa_backdrop_entity.Render(renderer, *result.pass)) {
+        return false;
+      }
+    }
+
+    element_entity.SetStencilDepth(element_entity.GetStencilDepth() -
+                                   stencil_depth_floor);
+    if (!element_entity.Render(renderer, *result.pass)) {
       return false;
     }
     return true;

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -403,16 +403,15 @@ bool EntityPass::OnRender(ContentContext& renderer,
     // If the pass context returns a texture, we need to draw it to the current
     // pass. We do this because it's faster and takes significantly less memory
     // than storing/loading large MSAA textures.
-    if (result.previous_pass_texture) {
+    if (result.backdrop_texture) {
       auto size_rect = Rect::MakeSize(result.pass->GetRenderTargetSize());
       auto msaa_backdrop_contents = TextureContents::MakeRect(size_rect);
+      msaa_backdrop_contents->SetStencilEnabled(false);
       msaa_backdrop_contents->SetLabel("MSAA backdrop");
       msaa_backdrop_contents->SetSourceRect(size_rect);
-      msaa_backdrop_contents->SetTexture(result.previous_pass_texture);
+      msaa_backdrop_contents->SetTexture(result.backdrop_texture);
 
       Entity msaa_backdrop_entity;
-      msaa_backdrop_entity.SetStencilDepth(element_entity.GetStencilDepth() -
-                                           stencil_depth_floor);
       msaa_backdrop_entity.SetContents(std::move(msaa_backdrop_contents));
       if (!msaa_backdrop_entity.Render(renderer, *result.pass)) {
         return false;

--- a/impeller/entity/inline_pass_context.cc
+++ b/impeller/entity/inline_pass_context.cc
@@ -7,6 +7,7 @@
 #include "impeller/base/validation.h"
 #include "impeller/renderer/command_buffer.h"
 #include "impeller/renderer/formats.h"
+#include "impeller/renderer/texture_descriptor.h"
 
 namespace impeller {
 
@@ -59,10 +60,10 @@ const RenderTarget& InlinePassContext::GetRenderTarget() const {
   return render_target_;
 }
 
-std::shared_ptr<RenderPass> InlinePassContext::GetRenderPass(
+InlinePassContext::RenderPassResult InlinePassContext::GetRenderPass(
     uint32_t pass_depth) {
   if (IsActive()) {
-    return pass_;
+    return {.pass = pass_};
   }
 
   /// Create a new render pass if one isn't active. This path will run the first
@@ -72,13 +73,13 @@ std::shared_ptr<RenderPass> InlinePassContext::GetRenderPass(
   command_buffer_ = context_->CreateCommandBuffer();
   if (!command_buffer_) {
     VALIDATION_LOG << "Could not create command buffer.";
-    return nullptr;
+    return {};
   }
 
   if (render_target_.GetColorAttachments().empty()) {
     VALIDATION_LOG << "Color attachment unexpectedly missing from the "
                       "EntityPass render target.";
-    return nullptr;
+    return {};
   }
   auto color0 = render_target_.GetColorAttachments().find(0)->second;
 
@@ -86,27 +87,49 @@ std::shared_ptr<RenderPass> InlinePassContext::GetRenderPass(
   if (!stencil.has_value()) {
     VALIDATION_LOG << "Stencil attachment unexpectedly missing from the "
                       "EntityPass render target.";
-    return nullptr;
+    return {};
   }
 
   command_buffer_->SetLabel(
       "EntityPass Command Buffer: Depth=" + std::to_string(pass_depth) +
       " Count=" + std::to_string(pass_count_));
 
-  // Only clear the color and stencil if this is the very first pass of the
-  // layer.
-  color0.load_action = pass_count_ > 0 ? LoadAction::kLoad : LoadAction::kClear;
-  stencil->load_action = color0.load_action;
+  RenderPassResult result;
 
-  // If we're on the last pass of the layer, there's no need to store the
-  // multisample texture or stencil because nothing needs to read it.
-  if (color0.resolve_texture) {
-    color0.store_action = pass_count_ == total_pass_reads_
-                              ? StoreAction::kMultisampleResolve
-                              : StoreAction::kStoreAndMultisampleResolve;
-  } else {
-    color0.store_action = StoreAction::kStore;
+  if (pass_count_ > 0 && color0.resolve_texture) {
+    result.previous_pass_texture = color0.resolve_texture;
+
+    /*
+        TextureDescriptor color0_resolve_tex_desc;
+        color0_resolve_tex_desc.format = PixelFormat::kDefaultColor;
+        color0_resolve_tex_desc.size = render_target_.GetRenderTargetSize();
+        color0_resolve_tex_desc.usage =
+            static_cast<uint64_t>(TextureUsage::kRenderTarget) |
+            static_cast<uint64_t>(TextureUsage::kShaderRead);
+
+        color0.resolve_texture =
+       context_->GetResourceAllocator()->CreateTexture(
+            StorageMode::kDevicePrivate, color0_resolve_tex_desc);
+        if (!color0.resolve_texture) {
+          VALIDATION_LOG << "Could not create color texture.";
+          return {};
+        }
+        color0.resolve_texture->SetLabel(
+            SPrintF("EntityPass Color Texture: Count=%d", pass_count_));
+            */
   }
+
+  color0.load_action = LoadAction::kClear;
+  color0.store_action = color0.resolve_texture
+                            ? StoreAction::kMultisampleResolve
+                            : StoreAction::kStore;
+
+  // Only clear the stencil if this is the very first pass of the
+  // layer.
+  stencil->load_action =
+      pass_count_ > 0 ? LoadAction::kLoad : LoadAction::kClear;
+  // If we're on the last pass of the layer, there's no need to store the
+  // stencil because nothing needs to read it.
   stencil->store_action = pass_count_ == total_pass_reads_
                               ? StoreAction::kDontCare
                               : StoreAction::kStore;
@@ -117,7 +140,7 @@ std::shared_ptr<RenderPass> InlinePassContext::GetRenderPass(
   pass_ = command_buffer_->CreateRenderPass(render_target_);
   if (!pass_) {
     VALIDATION_LOG << "Could not create render pass.";
-    return nullptr;
+    return {};
   }
 
   pass_->SetLabel(
@@ -126,7 +149,12 @@ std::shared_ptr<RenderPass> InlinePassContext::GetRenderPass(
 
   ++pass_count_;
 
-  return pass_;
+  result.pass = pass_;
+  return result;
+}
+
+uint32_t InlinePassContext::GetPassCount() const {
+  return pass_count_;
 }
 
 }  // namespace impeller

--- a/impeller/entity/inline_pass_context.cc
+++ b/impeller/entity/inline_pass_context.cc
@@ -97,32 +97,17 @@ InlinePassContext::RenderPassResult InlinePassContext::GetRenderPass(
   RenderPassResult result;
 
   if (pass_count_ > 0 && color0.resolve_texture) {
-    result.previous_pass_texture = color0.resolve_texture;
-
-    /*
-        TextureDescriptor color0_resolve_tex_desc;
-        color0_resolve_tex_desc.format = PixelFormat::kDefaultColor;
-        color0_resolve_tex_desc.size = render_target_.GetRenderTargetSize();
-        color0_resolve_tex_desc.usage =
-            static_cast<uint64_t>(TextureUsage::kRenderTarget) |
-            static_cast<uint64_t>(TextureUsage::kShaderRead);
-
-        color0.resolve_texture =
-       context_->GetResourceAllocator()->CreateTexture(
-            StorageMode::kDevicePrivate, color0_resolve_tex_desc);
-        if (!color0.resolve_texture) {
-          VALIDATION_LOG << "Could not create color texture.";
-          return {};
-        }
-        color0.resolve_texture->SetLabel(
-            SPrintF("EntityPass Color Texture: Count=%d", pass_count_));
-            */
+    result.backdrop_texture = color0.resolve_texture;
   }
 
-  color0.load_action = LoadAction::kClear;
-  color0.store_action = color0.resolve_texture
-                            ? StoreAction::kMultisampleResolve
-                            : StoreAction::kStore;
+  if (color0.resolve_texture) {
+    color0.load_action =
+        pass_count_ > 0 ? LoadAction::kDontCare : LoadAction::kClear;
+    color0.store_action = StoreAction::kMultisampleResolve;
+  } else {
+    color0.load_action = LoadAction::kClear;
+    color0.store_action = StoreAction::kStore;
+  }
 
   // Only clear the stencil if this is the very first pass of the
   // layer.

--- a/impeller/entity/inline_pass_context.h
+++ b/impeller/entity/inline_pass_context.h
@@ -14,7 +14,7 @@ class InlinePassContext {
  public:
   struct RenderPassResult {
     std::shared_ptr<RenderPass> pass;
-    std::shared_ptr<Texture> previous_pass_texture;
+    std::shared_ptr<Texture> backdrop_texture;
   };
 
   InlinePassContext(std::shared_ptr<Context> context,

--- a/impeller/entity/inline_pass_context.h
+++ b/impeller/entity/inline_pass_context.h
@@ -12,6 +12,11 @@ namespace impeller {
 
 class InlinePassContext {
  public:
+  struct RenderPassResult {
+    std::shared_ptr<RenderPass> pass;
+    std::shared_ptr<Texture> previous_pass_texture;
+  };
+
   InlinePassContext(std::shared_ptr<Context> context,
                     RenderTarget render_target,
                     uint32_t pass_texture_reads);
@@ -22,8 +27,9 @@ class InlinePassContext {
   std::shared_ptr<Texture> GetTexture();
   bool EndPass();
   const RenderTarget& GetRenderTarget() const;
+  uint32_t GetPassCount() const;
 
-  std::shared_ptr<RenderPass> GetRenderPass(uint32_t pass_depth);
+  RenderPassResult GetRenderPass(uint32_t pass_depth);
 
  private:
   std::shared_ptr<Context> context_;

--- a/impeller/renderer/render_target.cc
+++ b/impeller/renderer/render_target.cc
@@ -258,8 +258,7 @@ RenderTarget RenderTarget::CreateOffscreenMSAA(
   color0_tex_desc.sample_count = SampleCount::kCount4;
   color0_tex_desc.format = PixelFormat::kDefaultColor;
   color0_tex_desc.size = size;
-  color0_tex_desc.usage = static_cast<uint64_t>(TextureUsage::kRenderTarget) |
-                          static_cast<uint64_t>(TextureUsage::kShaderRead);
+  color0_tex_desc.usage = static_cast<uint64_t>(TextureUsage::kRenderTarget);
 
   auto color0_msaa_tex =
       context.GetResourceAllocator()->CreateTexture(color0_tex_desc);


### PR DESCRIPTION
Reduces vram usage by over 30% and GPU frame time by almost 40% on trouble screens in the app we're testing.