### PR TITLE
Run clang-tidy and Mac Unopt on Xcode beta

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -318,7 +318,7 @@ targets:
       runtime_versions: >-
         [
           "ios-13-0",
-          "ios-16-0"
+          "ios-16-0_14a5294e"
         ]
       xcode: 14a5294e # xcode 14.0 beta 5
     timeout: 75

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -318,8 +318,9 @@ targets:
       runtime_versions: >-
         [
           "ios-13-0",
-          "ios-15-0"
+          "ios-16-0"
         ]
+      xcode: 14a5294e # xcode 14.0 beta 5
     timeout: 75
 
   - name: Mac clang-tidy
@@ -327,6 +328,7 @@ targets:
     properties:
       add_recipes_cq: "true"
       jazzy_version: "0.14.1"
+      xcode: 14a5294e # xcode 14.0 beta 5
     timeout: 75
 
   - name: Mac iOS Engine


### PR DESCRIPTION
In preparation for iOS 16 / macOS Ventura September (likely) release, start running tests on Xcode 14 beta 5 and the iOS 16 beta simulator.

https://github.com/flutter/flutter/issues/108566

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
