### PR TITLE
allows mallocmapping copies of size zero

### DIFF
--- a/fml/mapping.h
+++ b/fml/mapping.h
@@ -160,7 +160,7 @@ class MallocMapping final : public Mapping {
   /// for `uint8_t` and `char`.
   template <typename T>
   static MallocMapping Copy(const T* begin, const T* end) {
-    FML_DCHECK(end > begin);
+    FML_DCHECK(end >= begin);
     size_t length = end - begin;
     return Copy(begin, length);
   }

--- a/fml/mapping_unittests.cc
+++ b/fml/mapping_unittests.cc
@@ -60,4 +60,10 @@ TEST(MallocMapping, IsDontNeedSafe) {
   ASSERT_FALSE(mapping.IsDontNeedSafe());
 }
 
+TEST(MallocMapping, CopySizeZero) {
+  char ch = 'a';
+  MallocMapping mapping = MallocMapping::Copy(&ch, &ch);
+  ASSERT_EQ(0u, mapping.GetSize());
+}
+
 }  // namespace fml


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/110596

This is how things work in release builds today.  It crashed in debug builds so this makes the builds work similarly.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
