### PR TITLE
Fix DartPerformanceMode enum mismatch

### DIFF
--- a/lib/web_ui/lib/platform_dispatcher.dart
+++ b/lib/web_ui/lib/platform_dispatcher.dart
@@ -549,4 +549,7 @@ class Locale {
 
 enum DartPerformanceMode {
   balanced,
+  latency,
+  throughput,
+  memory,
 }


### PR DESCRIPTION
See: https://github.com/flutter/flutter/issues/110605
