### PR TITLE
Reland: Adds a reusable FragmentShader

### DIFF
--- a/lib/ui/dart_ui.cc
+++ b/lib/ui/dart_ui.cc
@@ -18,6 +18,7 @@
 #include "flutter/lib/ui/painting/color_filter.h"
 #include "flutter/lib/ui/painting/engine_layer.h"
 #include "flutter/lib/ui/painting/fragment_program.h"
+#include "flutter/lib/ui/painting/fragment_shader.h"
 #include "flutter/lib/ui/painting/gradient.h"
 #include "flutter/lib/ui/painting/image.h"
 #include "flutter/lib/ui/painting/image_descriptor.h"
@@ -67,6 +68,7 @@ typedef CanvasPath Path;
   V(Canvas::Create, 6)                                                \
   V(ColorFilter::Create, 1)                                           \
   V(FragmentProgram::Create, 1)                                       \
+  V(ReusableFragmentShader::Create, 4)                                \
   V(Gradient::Create, 1)                                              \
   V(ImageFilter::Create, 1)                                           \
   V(ImageShader::Create, 1)                                           \
@@ -167,6 +169,8 @@ typedef CanvasPath Path;
   V(EngineLayer, dispose, 1)                           \
   V(FragmentProgram, initFromAsset, 2)                 \
   V(FragmentProgram, shader, 4)                        \
+  V(ReusableFragmentShader, Dispose, 1)                \
+  V(ReusableFragmentShader, SetSampler, 3)             \
   V(Gradient, initLinear, 6)                           \
   V(Gradient, initRadial, 8)                           \
   V(Gradient, initSweep, 9)                            \

--- a/lib/ui/painting/fragment_program.cc
+++ b/lib/ui/painting/fragment_program.cc
@@ -133,6 +133,13 @@ fml::RefPtr<FragmentShader> FragmentProgram::shader(Dart_Handle shader,
                                        std::move(uniform_data)));
 }
 
+std::shared_ptr<DlColorSource> FragmentProgram::MakeDlColorSource(
+    sk_sp<SkData> float_uniforms,
+    const std::vector<std::shared_ptr<DlColorSource>>& children) {
+  return DlColorSource::MakeRuntimeEffect(runtime_effect_, std::move(children),
+                                          std::move(float_uniforms));
+}
+
 void FragmentProgram::Create(Dart_Handle wrapper) {
   auto res = fml::MakeRefCounted<FragmentProgram>();
   res->AssociateWithDartWrapper(wrapper);

--- a/lib/ui/painting/fragment_program.h
+++ b/lib/ui/painting/fragment_program.h
@@ -7,6 +7,7 @@
 
 #include "flutter/lib/ui/dart_wrapper.h"
 #include "flutter/lib/ui/painting/fragment_shader.h"
+#include "flutter/lib/ui/painting/shader.h"
 #include "third_party/skia/include/effects/SkRuntimeEffect.h"
 #include "third_party/tonic/dart_library_natives.h"
 #include "third_party/tonic/typed_data/typed_list.h"
@@ -15,6 +16,8 @@
 #include <vector>
 
 namespace flutter {
+
+class FragmentShader;
 
 class FragmentProgram : public RefCountedDartWrappable<FragmentProgram> {
   DEFINE_WRAPPERTYPEINFO();
@@ -29,6 +32,10 @@ class FragmentProgram : public RefCountedDartWrappable<FragmentProgram> {
   fml::RefPtr<FragmentShader> shader(Dart_Handle shader,
                                      Dart_Handle uniforms_handle,
                                      Dart_Handle samplers);
+
+  std::shared_ptr<DlColorSource> MakeDlColorSource(
+      sk_sp<SkData> float_uniforms,
+      const std::vector<std::shared_ptr<DlColorSource>>& children);
 
  private:
   FragmentProgram();

--- a/lib/ui/painting/fragment_shader.cc
+++ b/lib/ui/painting/fragment_shader.cc
@@ -7,6 +7,7 @@
 #include "flutter/lib/ui/painting/fragment_shader.h"
 
 #include "flutter/lib/ui/dart_wrapper.h"
+#include "flutter/lib/ui/painting/fragment_program.h"
 #include "flutter/lib/ui/ui_dart_state.h"
 #include "third_party/skia/include/core/SkString.h"
 #include "third_party/tonic/converter/dart_converter.h"
@@ -47,5 +48,76 @@ FragmentShader::FragmentShader(
     : source_(std::move(shader)) {}
 
 FragmentShader::~FragmentShader() = default;
+
+IMPLEMENT_WRAPPERTYPEINFO(ui, ReusableFragmentShader);
+
+ReusableFragmentShader::ReusableFragmentShader(
+    fml::RefPtr<FragmentProgram> program,
+    uint64_t float_count,
+    uint64_t sampler_count)
+    : program_(program),
+      uniform_data_(SkData::MakeUninitialized(
+          (float_count + 2 * sampler_count) * sizeof(float))),
+      samplers_(sampler_count),
+      float_count_(float_count) {}
+
+Dart_Handle ReusableFragmentShader::Create(Dart_Handle wrapper,
+                                           Dart_Handle program,
+                                           Dart_Handle float_count_handle,
+                                           Dart_Handle sampler_count_handle) {
+  auto* fragment_program =
+      tonic::DartConverter<FragmentProgram*>::FromDart(program);
+  uint64_t float_count =
+      tonic::DartConverter<uint64_t>::FromDart(float_count_handle);
+  uint64_t sampler_count =
+      tonic::DartConverter<uint64_t>::FromDart(sampler_count_handle);
+
+  auto res = fml::MakeRefCounted<ReusableFragmentShader>(
+      fml::Ref(fragment_program), float_count, sampler_count);
+  res->AssociateWithDartWrapper(wrapper);
+
+  void* raw_uniform_data =
+      reinterpret_cast<void*>(res->uniform_data_->writable_data());
+  return Dart_NewExternalTypedData(Dart_TypedData_kFloat32, raw_uniform_data,
+                                   float_count);
+}
+
+void ReusableFragmentShader::SetSampler(Dart_Handle index_handle,
+                                        Dart_Handle sampler_handle) {
+  uint64_t index = tonic::DartConverter<uint64_t>::FromDart(index_handle);
+  ImageShader* sampler =
+      tonic::DartConverter<ImageShader*>::FromDart(sampler_handle);
+  if (index >= samplers_.size()) {
+    Dart_ThrowException(tonic::ToDart("Sampler index out of bounds"));
+  }
+
+  // ImageShaders can hold a preferred value for sampling options and
+  // developers are encouraged to use that value or the value will be supplied
+  // by "the environment where it is used". The environment here does not
+  // contain a value to be used if the developer did not specify a preference
+  // when they constructed the ImageShader, so we will use kNearest which is
+  // the default filterQuality in a Paint object.
+  DlImageSampling sampling = DlImageSampling::kNearestNeighbor;
+  auto* uniform_floats =
+      reinterpret_cast<float*>(uniform_data_->writable_data());
+  samplers_[index] = sampler->shader(sampling);
+  uniform_floats[float_count_ + 2 * index] = sampler->width();
+  uniform_floats[float_count_ + 2 * index + 1] = sampler->height();
+}
+
+std::shared_ptr<DlColorSource> ReusableFragmentShader::shader(
+    DlImageSampling sampling) {
+  FML_CHECK(program_);
+  return program_->MakeDlColorSource(uniform_data_, samplers_);
+}
+
+void ReusableFragmentShader::Dispose() {
+  uniform_data_.reset();
+  program_ = nullptr;
+  samplers_.clear();
+  ClearDartWrapper();
+}
+
+ReusableFragmentShader::~ReusableFragmentShader() = default;
 
 }  // namespace flutter

--- a/lib/ui/painting/fragment_shader.h
+++ b/lib/ui/painting/fragment_shader.h
@@ -6,6 +6,7 @@
 #define FLUTTER_LIB_UI_PAINTING_FRAGMENT_SHADER_H_
 
 #include "flutter/lib/ui/dart_wrapper.h"
+#include "flutter/lib/ui/painting/fragment_program.h"
 #include "flutter/lib/ui/painting/image.h"
 #include "flutter/lib/ui/painting/image_shader.h"
 #include "flutter/lib/ui/painting/shader.h"
@@ -19,6 +20,8 @@
 
 namespace flutter {
 
+class FragmentProgram;
+
 class FragmentShader : public Shader {
   DEFINE_WRAPPERTYPEINFO();
   FML_FRIEND_MAKE_REF_COUNTED(FragmentShader);
@@ -29,12 +32,43 @@ class FragmentShader : public Shader {
       Dart_Handle dart_handle,
       std::shared_ptr<DlRuntimeEffectColorSource> shader);
 
+  // |Shader|
   std::shared_ptr<DlColorSource> shader(DlImageSampling) override;
 
  private:
   explicit FragmentShader(std::shared_ptr<DlRuntimeEffectColorSource> shader);
 
   std::shared_ptr<DlRuntimeEffectColorSource> source_;
+};
+
+class ReusableFragmentShader : public Shader {
+  DEFINE_WRAPPERTYPEINFO();
+  FML_FRIEND_MAKE_REF_COUNTED(ReusableFragmentShader);
+
+ public:
+  ~ReusableFragmentShader() override;
+
+  static Dart_Handle Create(Dart_Handle wrapper,
+                            Dart_Handle program,
+                            Dart_Handle float_count,
+                            Dart_Handle sampler_count);
+
+  void SetSampler(Dart_Handle index, Dart_Handle sampler);
+
+  void Dispose();
+
+  // |Shader|
+  std::shared_ptr<DlColorSource> shader(DlImageSampling) override;
+
+ private:
+  ReusableFragmentShader(fml::RefPtr<FragmentProgram> program,
+                         uint64_t float_count,
+                         uint64_t sampler_count);
+
+  fml::RefPtr<FragmentProgram> program_;
+  sk_sp<SkData> uniform_data_;
+  std::vector<std::shared_ptr<DlColorSource>> samplers_;
+  size_t float_count_;
 };
 
 }  // namespace flutter

--- a/lib/web_ui/lib/painting.dart
+++ b/lib/web_ui/lib/painting.dart
@@ -270,6 +270,10 @@ abstract class Paint {
 
 abstract class Shader {
   Shader._();
+
+  void dispose();
+
+  bool get debugDisposed;
 }
 
 abstract class Gradient extends Shader {
@@ -700,8 +704,10 @@ abstract class ImageShader extends Shader {
     FilterQuality? filterQuality,
   }) => engine.renderer.createImageShader(image, tmx, tmy, matrix4, filterQuality);
 
+  @override
   void dispose();
 
+  @override
   bool get debugDisposed;
 }
 
@@ -799,12 +805,34 @@ class FragmentProgram {
     throw UnsupportedError('FragmentProgram is not supported for the CanvasKit or HTML renderers.');
   }
 
-  static Future<FragmentProgram> fromAssetAsync(String assetKey) {
-    return Future<FragmentProgram>.microtask(() => FragmentProgram.fromAsset(assetKey));
+  FragmentShader fragmentShader() {
+    throw UnsupportedError('FragmentProgram is not supported for the CanvasKit or HTML renderers.');
   }
 
   Shader shader({
     Float32List? floatUniforms,
     List<ImageShader>? samplerUniforms,
   }) => throw UnsupportedError('FragmentProgram is not supported for the CanvasKit or HTML renderers.');
+}
+
+class FragmentShader extends Shader {
+  FragmentShader._() : super._();
+
+  void setFloat(int index, double value) {
+    throw UnsupportedError('FragmentShader is not supported for the CanvasKit or HTML renderers.');
+  }
+
+  void setSampler(int index, ImageShader sampler) {
+    throw UnsupportedError('FragmentShader is not supported for the CanvasKit or HTML renderers.');
+  }
+
+  @override
+  void dispose() {
+    throw UnsupportedError('FragmentShader is not supported for the CanvasKit or HTML renderers.');
+  }
+
+  @override
+  bool get debugDisposed {
+    throw UnsupportedError('FragmentShader is not supported for the CanvasKit or HTML renderers.');
+  }
 }

--- a/lib/web_ui/lib/src/engine/canvaskit/shader.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/shader.dart
@@ -21,6 +21,26 @@ abstract class CkShader extends ManagedSkiaObject<SkShader>
   void delete() {
     rawSkiaObject?.delete();
   }
+
+  bool _disposed = false;
+
+  @override
+  bool get debugDisposed {
+    late bool disposed;
+    assert(() {
+      disposed = _disposed;
+      return true;
+    }());
+    return disposed;
+  }
+
+  @override
+  void dispose() {
+    assert(() {
+      _disposed = true;
+      return true;
+    }());
+  }
 }
 
 class CkGradientSweep extends CkShader implements ui.Gradient {
@@ -219,24 +239,9 @@ class CkImageShader extends CkShader implements ui.ImageShader {
     rawSkiaObject?.delete();
   }
 
-  bool _disposed = false;
-
-  @override
-  bool get debugDisposed {
-    late bool disposed;
-    assert(() {
-      disposed = _disposed;
-      return true;
-    }());
-    return disposed;
-  }
-
   @override
   void dispose() {
-    assert(() {
-      _disposed = true;
-      return true;
-    }());
+    super.dispose();
     _image.dispose();
   }
 }

--- a/lib/web_ui/lib/src/engine/html/shaders/image_shader.dart
+++ b/lib/web_ui/lib/src/engine/html/shaders/image_shader.dart
@@ -284,6 +284,6 @@ class EngineImageShader implements ui.ImageShader {
       _disposed = true;
       return true;
     }());
-      image.dispose();
+    image.dispose();
   }
 }

--- a/lib/web_ui/lib/src/engine/html/shaders/shader.dart
+++ b/lib/web_ui/lib/src/engine/html/shaders/shader.dart
@@ -54,6 +54,12 @@ abstract class EngineGradient implements ui.Gradient {
   /// Creates a CanvasImageSource to paint gradient.
   Object createImageBitmap(
       ui.Rect? shaderBounds, double density, bool createDataUrl);
+
+  @override
+  bool debugDisposed = false;
+
+  @override
+  void dispose() {}
 }
 
 class GradientSweep extends EngineGradient {


### PR DESCRIPTION
Reland of https://github.com/flutter/engine/pull/35253 with the example code removed, which was failing framework analysis checks. I'll investigate how to land the example code in a separate PR.