### PR TITLE
[Impeller] More aggressively downscale gaussian blur textures

### DIFF
--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -226,14 +226,13 @@ std::optional<Snapshot> DirectionalGaussianBlurFilterContents::RenderFilter(
   };
 
   Vector2 scale;
+  auto scale_curve = [](Scalar radius) { return std::min(1.0, 2.0 / radius); };
   {
-    scale.x =
-        1.0 /
-        std::ceil(std::log2(std::max(2.0f, transformed_blur_radius_length)));
+    scale.x = scale_curve(transformed_blur_radius_length);
 
     Scalar y_radius = std::abs(pass_transform.GetDirectionScale(Vector2(
         0, source_override_ ? Radius{secondary_blur_sigma_}.radius : 1)));
-    scale.y = 1.0 / std::ceil(std::log2(std::max(2.0f, y_radius)));
+    scale.y = scale_curve(y_radius);
   }
 
   Vector2 scaled_size = pass_texture_rect.size * scale;

--- a/impeller/geometry/geometry_unittests.cc
+++ b/impeller/geometry/geometry_unittests.cc
@@ -229,7 +229,7 @@ TEST(GeometryTest, MatrixTransformDirection) {
   }
 
   {
-    auto matrix = Matrix::MakeTranslation({100, 100, 100}) *
+    auto matrix = Matrix::MakeTranslation({0, -0.4, 100}) *
                   Matrix::MakeRotationZ(Radians{kPiOver2}) *
                   Matrix::MakeScale({2.0, 2.0, 2.0});
     auto vector = Point(10, 20);

--- a/impeller/geometry/matrix.h
+++ b/impeller/geometry/matrix.h
@@ -249,7 +249,7 @@ struct Matrix {
   }
 
   constexpr Scalar GetDirectionScale(Vector3 direction) const {
-    return 1.0 / (this->Invert() * direction.Normalize()).Length() *
+    return 1.0 / (this->Basis().Invert() * direction.Normalize()).Length() *
            direction.Length();
   }
 


### PR DESCRIPTION
Just changing it to a simpler linear curve saves more than half the execution time for the max blur in Wonders, and there doesn't seem to be any visible color jitter as the texture size changes gradually. Making the curve any steeper results in visible banding.
I'm experimenting with some optimizations that are heavier on the information loss side, but this adjustment is pretty safe and is getting me much better frame times.

I don't think this is the final curve we'll use when the blur radius is extremely high (like when the blur radius is getting to be larger than the dimensions of the input texture). I think we'll want a 2nd order asymptotic falloff.