### PR TITLE
Honor mixed state of tristate Checkbox in Semantics

### DIFF
--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -351,7 +351,11 @@ class SemanticsFlag {
 
   /// Whether a tristate checkbox is in its mixed state.
   ///
-  /// Should only be true when the checkbox has [tristate] = true.
+  /// If this is true, the check box this semantics node represents
+  /// is in a mixed state.
+  /// 
+  /// For example, a [Checkbox] with [Checkbox.tristate] set to true
+  /// can have checked,  unchecked, or mixed state.
   ///
   /// Should be false when the checkbox is either checked or unchecked.
   ///

--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -357,8 +357,7 @@ class SemanticsFlag {
   /// For example, a [Checkbox] with [Checkbox.tristate] set to true
   /// can have checked,  unchecked, or mixed state.
   ///
-  /// Should be false when the checkbox is either checked or unchecked.
-  ///
+  /// Must be false when the checkbox is either checked or unchecked.
   static const SemanticsFlag isCheckStateMixed = SemanticsFlag._(_kIsCheckStateMixedIndex);
 
 

--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -319,6 +319,7 @@ class SemanticsFlag {
   static const int _kIsLinkIndex = 1 << 22;
   static const int _kIsSliderIndex = 1 << 23;
   static const int _kIsKeyboardKeyIndex = 1 << 24;
+  static const int _kIsMixedCheckIndex = 1 << 25;
   // READ THIS: if you add a flag here, you MUST update the numSemanticsFlags
   // value in testing/dart/semantics_test.dart, or tests will fail. Also,
   // please update the Flag enum in
@@ -347,6 +348,14 @@ class SemanticsFlag {
   ///
   ///   * [SemanticsFlag.hasCheckedState], which enables a checked state.
   static const SemanticsFlag isChecked = SemanticsFlag._(_kIsCheckedIndex);
+
+  /// Whether a tristate checkbox is in its mixed state.
+  ///
+  /// Should only be true when the checkbox has [tristate] = true.
+  ///
+  /// Should be false when the checkbox is either checked or unchecked.
+  ///
+  static const SemanticsFlag isMixedCheck = SemanticsFlag._(_kIsMixedCheckIndex);
 
 
   /// Whether a semantics node is selected.
@@ -578,6 +587,7 @@ class SemanticsFlag {
     _kIsLinkIndex: isLink,
     _kIsSliderIndex: isSlider,
     _kIsKeyboardKeyIndex: isKeyboardKey,
+    _kIsMixedCheckIndex: isMixedCheck,
   };
 
   @override
@@ -633,6 +643,8 @@ class SemanticsFlag {
         return 'SemanticsFlag.isSlider';
       case _kIsKeyboardKeyIndex:
         return 'SemanticsFlag.isKeyboardKey';
+      case _kIsMixedCheckIndex:
+        return 'SemanticsFlag.isMixedChck';
     }
     assert(false, 'Unhandled index: $index (0x${index.toRadixString(8).padLeft(4, "0")})');
     return '';

--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -353,7 +353,7 @@ class SemanticsFlag {
   ///
   /// If this is true, the check box this semantics node represents
   /// is in a mixed state.
-  /// 
+  ///
   /// For example, a [Checkbox] with [Checkbox.tristate] set to true
   /// can have checked,  unchecked, or mixed state.
   ///

--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -644,7 +644,7 @@ class SemanticsFlag {
       case _kIsKeyboardKeyIndex:
         return 'SemanticsFlag.isKeyboardKey';
       case _kIsMixedCheckIndex:
-        return 'SemanticsFlag.isMixedChck';
+        return 'SemanticsFlag.isMixedCheck';
     }
     assert(false, 'Unhandled index: $index (0x${index.toRadixString(8).padLeft(4, "0")})');
     return '';

--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -319,7 +319,7 @@ class SemanticsFlag {
   static const int _kIsLinkIndex = 1 << 22;
   static const int _kIsSliderIndex = 1 << 23;
   static const int _kIsKeyboardKeyIndex = 1 << 24;
-  static const int _kIsMixedCheckIndex = 1 << 25;
+  static const int _kIsCheckStateMixedIndex = 1 << 25;
   // READ THIS: if you add a flag here, you MUST update the numSemanticsFlags
   // value in testing/dart/semantics_test.dart, or tests will fail. Also,
   // please update the Flag enum in
@@ -355,7 +355,7 @@ class SemanticsFlag {
   ///
   /// Should be false when the checkbox is either checked or unchecked.
   ///
-  static const SemanticsFlag isMixedCheck = SemanticsFlag._(_kIsMixedCheckIndex);
+  static const SemanticsFlag isCheckStateMixed = SemanticsFlag._(_kIsCheckStateMixedIndex);
 
 
   /// Whether a semantics node is selected.
@@ -587,7 +587,7 @@ class SemanticsFlag {
     _kIsLinkIndex: isLink,
     _kIsSliderIndex: isSlider,
     _kIsKeyboardKeyIndex: isKeyboardKey,
-    _kIsMixedCheckIndex: isMixedCheck,
+    _kIsCheckStateMixedIndex: isCheckStateMixed,
   };
 
   @override
@@ -643,8 +643,8 @@ class SemanticsFlag {
         return 'SemanticsFlag.isSlider';
       case _kIsKeyboardKeyIndex:
         return 'SemanticsFlag.isKeyboardKey';
-      case _kIsMixedCheckIndex:
-        return 'SemanticsFlag.isMixedCheck';
+      case _kIsCheckStateMixedIndex:
+        return 'SemanticsFlag.isCheckStateMixed';
     }
     assert(false, 'Unhandled index: $index (0x${index.toRadixString(8).padLeft(4, "0")})');
     return '';

--- a/lib/ui/semantics/semantics_node.h
+++ b/lib/ui/semantics/semantics_node.h
@@ -87,6 +87,7 @@ enum class SemanticsFlags : int32_t {
   kIsLink = 1 << 22,
   kIsSlider = 1 << 23,
   kIsKeyboardKey = 1 << 24,
+  kIsMixedCheck = 1 << 25,
 };
 
 const int kScrollableSemanticsFlags =

--- a/lib/ui/semantics/semantics_node.h
+++ b/lib/ui/semantics/semantics_node.h
@@ -87,7 +87,7 @@ enum class SemanticsFlags : int32_t {
   kIsLink = 1 << 22,
   kIsSlider = 1 << 23,
   kIsKeyboardKey = 1 << 24,
-  kIsMixedCheck = 1 << 25,
+  kIsCheckStateMixed = 1 << 25,
 };
 
 const int kScrollableSemanticsFlags =

--- a/lib/web_ui/lib/semantics.dart
+++ b/lib/web_ui/lib/semantics.dart
@@ -163,6 +163,7 @@ class SemanticsFlag {
   static const int _kIsLinkIndex = 1 << 22;
   static const int _kIsSliderIndex = 1 << 23;
   static const int _kIsKeyboardKeyIndex = 1 << 24;
+  static const int _kIsMixedCheckIndex = 1 << 25;
 
   static const SemanticsFlag hasCheckedState = SemanticsFlag._(_kHasCheckedStateIndex);
   static const SemanticsFlag isChecked = SemanticsFlag._(_kIsCheckedIndex);
@@ -189,6 +190,7 @@ class SemanticsFlag {
   static const SemanticsFlag hasToggledState = SemanticsFlag._(_kHasToggledStateIndex);
   static const SemanticsFlag isToggled = SemanticsFlag._(_kIsToggledIndex);
   static const SemanticsFlag hasImplicitScrolling = SemanticsFlag._(_kHasImplicitScrollingIndex);
+  static const SemanticsFlag isMixedCheck = SemanticsFlag._(_kIsMixedCheckIndex);
 
   static const Map<int, SemanticsFlag> values = <int, SemanticsFlag>{
     _kHasCheckedStateIndex: hasCheckedState,
@@ -216,6 +218,7 @@ class SemanticsFlag {
     _kIsLinkIndex: isLink,
     _kIsSliderIndex: isSlider,
     _kIsKeyboardKeyIndex: isKeyboardKey,
+    _kIsMixedCheckIndex: isMixedCheck,
   };
 
   @override
@@ -271,6 +274,8 @@ class SemanticsFlag {
         return 'SemanticsFlag.isSlider';
       case _kIsKeyboardKeyIndex:
         return 'SemanticsFlag.isKeyboardKey';
+      case _kIsMixedCheckIndex:
+        return 'SemanticsFlag.isMixedCheck';
     }
     assert(false, 'Unhandled index: $index (0x${index.toRadixString(8).padLeft(4, "0")})');
     return '';

--- a/lib/web_ui/lib/semantics.dart
+++ b/lib/web_ui/lib/semantics.dart
@@ -163,7 +163,7 @@ class SemanticsFlag {
   static const int _kIsLinkIndex = 1 << 22;
   static const int _kIsSliderIndex = 1 << 23;
   static const int _kIsKeyboardKeyIndex = 1 << 24;
-  static const int _kIsMixedCheckIndex = 1 << 25;
+  static const int _kIsCheckStateMixedIndex = 1 << 25;
 
   static const SemanticsFlag hasCheckedState = SemanticsFlag._(_kHasCheckedStateIndex);
   static const SemanticsFlag isChecked = SemanticsFlag._(_kIsCheckedIndex);
@@ -190,7 +190,7 @@ class SemanticsFlag {
   static const SemanticsFlag hasToggledState = SemanticsFlag._(_kHasToggledStateIndex);
   static const SemanticsFlag isToggled = SemanticsFlag._(_kIsToggledIndex);
   static const SemanticsFlag hasImplicitScrolling = SemanticsFlag._(_kHasImplicitScrollingIndex);
-  static const SemanticsFlag isMixedCheck = SemanticsFlag._(_kIsMixedCheckIndex);
+  static const SemanticsFlag isCheckStateMixed = SemanticsFlag._(_kIsCheckStateMixedIndex);
 
   static const Map<int, SemanticsFlag> values = <int, SemanticsFlag>{
     _kHasCheckedStateIndex: hasCheckedState,
@@ -218,7 +218,7 @@ class SemanticsFlag {
     _kIsLinkIndex: isLink,
     _kIsSliderIndex: isSlider,
     _kIsKeyboardKeyIndex: isKeyboardKey,
-    _kIsMixedCheckIndex: isMixedCheck,
+    _kIsCheckStateMixedIndex: isCheckStateMixed,
   };
 
   @override
@@ -274,8 +274,8 @@ class SemanticsFlag {
         return 'SemanticsFlag.isSlider';
       case _kIsKeyboardKeyIndex:
         return 'SemanticsFlag.isKeyboardKey';
-      case _kIsMixedCheckIndex:
-        return 'SemanticsFlag.isMixedCheck';
+      case _kIsCheckStateMixedIndex:
+        return 'SemanticsFlag.isCheckStateMixed';
     }
     assert(false, 'Unhandled index: $index (0x${index.toRadixString(8).padLeft(4, "0")})');
     return '';

--- a/lib/web_ui/test/engine/semantics/semantics_api_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_api_test.dart
@@ -17,7 +17,7 @@ void main() {
 
 void testMain() {
   // This must match the number of flags in lib/ui/semantics.dart
-  const int numSemanticsFlags = 25;
+  const int numSemanticsFlags = 26;
   test('SemanticsFlag.values refers to all flags.', () async {
     expect(SemanticsFlag.values.length, equals(numSemanticsFlags));
     for (int index = 0; index < numSemanticsFlags; ++index) {

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -2131,7 +2131,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
     IS_FOCUSABLE(1 << 21),
     IS_LINK(1 << 22),
     IS_SLIDER(1 << 23),
-    IS_KEYBOARD_KEY(1 << 24);
+    IS_KEYBOARD_KEY(1 << 24),
     IS_MIXED_CHECK(1 << 25);
 
     final int value;

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -2132,6 +2132,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
     IS_LINK(1 << 22),
     IS_SLIDER(1 << 23),
     IS_KEYBOARD_KEY(1 << 24);
+    IS_MIXED_CHECK(1 << 25);
 
     final int value;
 

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -2132,7 +2132,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
     IS_LINK(1 << 22),
     IS_SLIDER(1 << 23),
     IS_KEYBOARD_KEY(1 << 24),
-    IS_MIXED_CHECK(1 << 25);
+    IS_CHECK_STATE_MIXED(1 << 25);
 
     final int value;
 

--- a/shell/platform/common/accessibility_bridge.cc
+++ b/shell/platform/common/accessibility_bridge.cc
@@ -380,7 +380,7 @@ void AccessibilityBridge::SetIntAttributesFromFlutterUpdate(
     node_data.AddIntAttribute(
         ax::mojom::IntAttribute::kCheckedState,
         static_cast<int32_t>(
-            flags & FlutterSemanticsFlag::kFlutterSemanticsFlagIsMixedCheck
+            flags & FlutterSemanticsFlag::kFlutterSemanticsFlagIsCheckStateMixed
                 ? ax::mojom::CheckedState::kMixed
             : flags & FlutterSemanticsFlag::kFlutterSemanticsFlagIsChecked
                 ? ax::mojom::CheckedState::kTrue

--- a/shell/platform/common/accessibility_bridge.cc
+++ b/shell/platform/common/accessibility_bridge.cc
@@ -380,7 +380,9 @@ void AccessibilityBridge::SetIntAttributesFromFlutterUpdate(
     node_data.AddIntAttribute(
         ax::mojom::IntAttribute::kCheckedState,
         static_cast<int32_t>(
-            flags & FlutterSemanticsFlag::kFlutterSemanticsFlagIsChecked
+            flags & FlutterSemanticsFlag::kFlutterSemanticsFlagIsMixedCheck
+                ? ax::mojom::CheckedState::kMixed
+                : flags & FlutterSemanticsFlag::kFlutterSemanticsFlagIsChecked
                 ? ax::mojom::CheckedState::kTrue
                 : ax::mojom::CheckedState::kFalse));
   }

--- a/shell/platform/common/accessibility_bridge.cc
+++ b/shell/platform/common/accessibility_bridge.cc
@@ -382,7 +382,7 @@ void AccessibilityBridge::SetIntAttributesFromFlutterUpdate(
         static_cast<int32_t>(
             flags & FlutterSemanticsFlag::kFlutterSemanticsFlagIsMixedCheck
                 ? ax::mojom::CheckedState::kMixed
-                : flags & FlutterSemanticsFlag::kFlutterSemanticsFlagIsChecked
+            : flags & FlutterSemanticsFlag::kFlutterSemanticsFlagIsChecked
                 ? ax::mojom::CheckedState::kTrue
                 : ax::mojom::CheckedState::kFalse));
   }

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -227,6 +227,8 @@ typedef enum {
   kFlutterSemanticsFlagIsSlider = 1 << 23,
   /// Whether the semantics node represents a keyboard key.
   kFlutterSemanticsFlagIsKeyboardKey = 1 << 24,
+  /// Whether the semantics node represents a tristate checkbox in mixed state.
+  kFlutterSemanticsFlagIsMixedCheck = 1 << 25,
 } FlutterSemanticsFlag;
 
 typedef enum {

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -228,7 +228,7 @@ typedef enum {
   /// Whether the semantics node represents a keyboard key.
   kFlutterSemanticsFlagIsKeyboardKey = 1 << 24,
   /// Whether the semantics node represents a tristate checkbox in mixed state.
-  kFlutterSemanticsFlagIsMixedCheck = 1 << 25,
+  kFlutterSemanticsFlagIsCheckStateMixed = 1 << 25,
 } FlutterSemanticsFlag;
 
 typedef enum {

--- a/shell/platform/windows/flutter_windows_view_unittests.cc
+++ b/shell/platform/windows/flutter_windows_view_unittests.cc
@@ -651,7 +651,7 @@ TEST(FlutterWindowsViewTest, CheckboxNativeState) {
     IAccessible* native_view = root_node->GetNativeViewAccessible();
     ASSERT_TRUE(native_view != nullptr);
 
-    // Look up against the node itself (not one of its children)
+    // Look up against the node itself (not one of its children).
     VARIANT varchild = {};
     varchild.vt = VT_I4;
 
@@ -662,7 +662,7 @@ TEST(FlutterWindowsViewTest, CheckboxNativeState) {
     EXPECT_TRUE(native_state.lVal & STATE_SYSTEM_CHECKED);
   }
 
-  // Test unchecked too
+  // Test unchecked too.
   root.flags = static_cast<FlutterSemanticsFlag>(
       FlutterSemanticsFlag::kFlutterSemanticsFlagHasCheckedState);
   bridge->AddFlutterSemanticsNodeUpdate(&root);
@@ -681,7 +681,7 @@ TEST(FlutterWindowsViewTest, CheckboxNativeState) {
     IAccessible* native_view = root_node->GetNativeViewAccessible();
     ASSERT_TRUE(native_view != nullptr);
 
-    // Look up against the node itself (not one of its children)
+    // Look up against the node itself (not one of its children).
     VARIANT varchild = {};
     varchild.vt = VT_I4;
 
@@ -692,7 +692,7 @@ TEST(FlutterWindowsViewTest, CheckboxNativeState) {
     EXPECT_FALSE(native_state.lVal & STATE_SYSTEM_CHECKED);
   }
 
-  // Now check mixed state
+  // Now check mixed state.
   root.flags = static_cast<FlutterSemanticsFlag>(
       FlutterSemanticsFlag::kFlutterSemanticsFlagHasCheckedState |
       FlutterSemanticsFlag::kFlutterSemanticsFlagIsCheckStateMixed);
@@ -712,7 +712,7 @@ TEST(FlutterWindowsViewTest, CheckboxNativeState) {
     IAccessible* native_view = root_node->GetNativeViewAccessible();
     ASSERT_TRUE(native_view != nullptr);
 
-    // Look up against the node itself (not one of its children)
+    // Look up against the node itself (not one of its children).
     VARIANT varchild = {};
     varchild.vt = VT_I4;
 

--- a/shell/platform/windows/flutter_windows_view_unittests.cc
+++ b/shell/platform/windows/flutter_windows_view_unittests.cc
@@ -695,7 +695,7 @@ TEST(FlutterWindowsViewTest, CheckboxNativeState) {
   // Now check mixed state
   root.flags = static_cast<FlutterSemanticsFlag>(
       FlutterSemanticsFlag::kFlutterSemanticsFlagHasCheckedState |
-      FlutterSemanticsFlag::kFlutterSemanticsFlagIsMixedCheck);
+      FlutterSemanticsFlag::kFlutterSemanticsFlagIsCheckStateMixed);
   bridge->AddFlutterSemanticsNodeUpdate(&root);
   bridge->CommitUpdates();
 

--- a/shell/platform/windows/flutter_windows_view_unittests.cc
+++ b/shell/platform/windows/flutter_windows_view_unittests.cc
@@ -638,27 +638,29 @@ TEST(FlutterWindowsViewTest, CheckboxNativeState) {
 
   bridge->CommitUpdates();
 
-  auto root_node = bridge
-                       ->GetFlutterPlatformNodeDelegateFromID(
-                           AccessibilityBridge::kRootNodeId)
-                       .lock();
-  EXPECT_EQ(root_node->GetData().role, ax::mojom::Role::kCheckBox);
-  EXPECT_EQ(root_node->GetData().GetCheckedState(),
-            ax::mojom::CheckedState::kTrue);
+  {
+    auto root_node = bridge
+                         ->GetFlutterPlatformNodeDelegateFromID(
+                             AccessibilityBridge::kRootNodeId)
+                         .lock();
+    EXPECT_EQ(root_node->GetData().role, ax::mojom::Role::kCheckBox);
+    EXPECT_EQ(root_node->GetData().GetCheckedState(),
+              ax::mojom::CheckedState::kTrue);
 
-  // Get the IAccessible for the root node.
-  IAccessible* native_view = root_node->GetNativeViewAccessible();
-  ASSERT_TRUE(native_view != nullptr);
+    // Get the IAccessible for the root node.
+    IAccessible* native_view = root_node->GetNativeViewAccessible();
+    ASSERT_TRUE(native_view != nullptr);
 
-  // Look up against the node itself (not one of its children)
-  VARIANT varchild = {};
-  varchild.vt = VT_I4;
+    // Look up against the node itself (not one of its children)
+    VARIANT varchild = {};
+    varchild.vt = VT_I4;
 
-  // Verify the checkbox is checked.
-  varchild.lVal = CHILDID_SELF;
-  VARIANT native_state = {};
-  ASSERT_TRUE(SUCCEEDED(native_view->get_accState(varchild, &native_state)));
-  EXPECT_TRUE(native_state.lVal & STATE_SYSTEM_CHECKED);
+    // Verify the checkbox is checked.
+    varchild.lVal = CHILDID_SELF;
+    VARIANT native_state = {};
+    ASSERT_TRUE(SUCCEEDED(native_view->get_accState(varchild, &native_state)));
+    EXPECT_TRUE(native_state.lVal & STATE_SYSTEM_CHECKED);
+  }
 
   // Test unchecked too
   root.flags = static_cast<FlutterSemanticsFlag>(
@@ -666,19 +668,29 @@ TEST(FlutterWindowsViewTest, CheckboxNativeState) {
   bridge->AddFlutterSemanticsNodeUpdate(&root);
   bridge->CommitUpdates();
 
-  EXPECT_EQ(root_node->GetData().role, ax::mojom::Role::kCheckBox);
-  EXPECT_EQ(root_node->GetData().GetCheckedState(),
-            ax::mojom::CheckedState::kFalse);
+  {
+    auto root_node = bridge
+                         ->GetFlutterPlatformNodeDelegateFromID(
+                             AccessibilityBridge::kRootNodeId)
+                         .lock();
+    EXPECT_EQ(root_node->GetData().role, ax::mojom::Role::kCheckBox);
+    EXPECT_EQ(root_node->GetData().GetCheckedState(),
+              ax::mojom::CheckedState::kFalse);
 
-  // Look up against the node itself (not one of its children)
-  varchild = {};
-  varchild.vt = VT_I4;
+    // Get the IAccessible for the root node.
+    IAccessible* native_view = root_node->GetNativeViewAccessible();
+    ASSERT_TRUE(native_view != nullptr);
 
-  // Verify the checkbox is checked.
-  varchild.lVal = CHILDID_SELF;
-  native_state = {};
-  ASSERT_TRUE(SUCCEEDED(native_view->get_accState(varchild, &native_state)));
-  EXPECT_FALSE(native_state.lVal & STATE_SYSTEM_CHECKED);
+    // Look up against the node itself (not one of its children)
+    VARIANT varchild = {};
+    varchild.vt = VT_I4;
+
+    // Verify the checkbox is checked.
+    varchild.lVal = CHILDID_SELF;
+    VARIANT native_state = {};
+    ASSERT_TRUE(SUCCEEDED(native_view->get_accState(varchild, &native_state)));
+    EXPECT_FALSE(native_state.lVal & STATE_SYSTEM_CHECKED);
+  }
 
   // Now check mixed state
   root.flags = static_cast<FlutterSemanticsFlag>(
@@ -687,19 +699,29 @@ TEST(FlutterWindowsViewTest, CheckboxNativeState) {
   bridge->AddFlutterSemanticsNodeUpdate(&root);
   bridge->CommitUpdates();
 
-  EXPECT_EQ(root_node->GetData().role, ax::mojom::Role::kCheckBox);
-  EXPECT_EQ(root_node->GetData().GetCheckedState(),
-            ax::mojom::CheckedState::kMixed);
+  {
+    auto root_node = bridge
+                         ->GetFlutterPlatformNodeDelegateFromID(
+                             AccessibilityBridge::kRootNodeId)
+                         .lock();
+    EXPECT_EQ(root_node->GetData().role, ax::mojom::Role::kCheckBox);
+    EXPECT_EQ(root_node->GetData().GetCheckedState(),
+              ax::mojom::CheckedState::kMixed);
 
-  // Look up against the node itself (not one of its children)
-  varchild = {};
-  varchild.vt = VT_I4;
+    // Get the IAccessible for the root node.
+    IAccessible* native_view = root_node->GetNativeViewAccessible();
+    ASSERT_TRUE(native_view != nullptr);
 
-  // Verify the checkbox is checked.
-  varchild.lVal = CHILDID_SELF;
-  native_state = {};
-  ASSERT_TRUE(SUCCEEDED(native_view->get_accState(varchild, &native_state)));
-  EXPECT_TRUE(native_state.lVal & STATE_SYSTEM_MIXED);
+    // Look up against the node itself (not one of its children)
+    VARIANT varchild = {};
+    varchild.vt = VT_I4;
+
+    // Verify the checkbox is checked.
+    varchild.lVal = CHILDID_SELF;
+    VARIANT native_state = {};
+    ASSERT_TRUE(SUCCEEDED(native_view->get_accState(varchild, &native_state)));
+    EXPECT_TRUE(native_state.lVal & STATE_SYSTEM_MIXED);
+  }
 }
 
 }  // namespace testing

--- a/testing/dart/semantics_test.dart
+++ b/testing/dart/semantics_test.dart
@@ -11,7 +11,7 @@ import 'package:litetest/litetest.dart';
 
 void main() {
   // This must match the number of flags in lib/ui/semantics.dart
-  const int numSemanticsFlags = 25;
+  const int numSemanticsFlags = 26;
   test('SemanticsFlag.values refers to all flags.', () async {
     expect(SemanticsFlag.values.length, equals(numSemanticsFlags));
     for (int index = 0; index < numSemanticsFlags; ++index) {


### PR DESCRIPTION
Flutter already supports tristate checkboxes that can have a mixed or half-checked state, but the semantics do not. Where the checked/unchecked state of a checkbox is passed to the Semantics node, a mixed state is not. This adds support for the mixed-state semantics flag to the engine. In conjunction with a PR to Flutter, we will be able to support the mixed state in semantics for checkboxes.

Addresses [flutter/flutter#110107](https://github.com/flutter/flutter/issues/110107)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
