### PR TITLE
[macos] expose runWithEngine constructor in FlutterViewController (#7…

### DIFF
--- a/shell/platform/darwin/macos/framework/Headers/FlutterViewController.h
+++ b/shell/platform/darwin/macos/framework/Headers/FlutterViewController.h
@@ -53,7 +53,18 @@ FLUTTER_DARWIN_EXPORT
                                  bundle:(nullable NSBundle*)nibBundleOrNil
     NS_DESIGNATED_INITIALIZER;
 - (nonnull instancetype)initWithCoder:(nonnull NSCoder*)nibNameOrNil NS_DESIGNATED_INITIALIZER;
-
+/**
+ * Initializes this FlutterViewController with the specified `FlutterEngine`.
+ *
+ * The initialized viewcontroller will attach itself to the engine as part of this process.
+ *
+ * @param engine The `FlutterEngine` instance to attach to. Cannot be nil.
+ * @param nibName The NIB name to initialize this controller with.
+ * @param nibBundle The NIB bundle.
+ */
+- (nonnull instancetype)initWithEngine:(nonnull FlutterEngine*)engine
+                               nibName:(nullable NSString*)nibName
+                                bundle:(nullable NSBundle*)nibBundle NS_DESIGNATED_INITIALIZER;
 /**
  * Invoked by the engine right before the engine is restarted.
  *

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -340,7 +340,6 @@ static void CommonInit(FlutterViewController* controller) {
     }
     _engine = engine;
     CommonInit(self);
-    [engine setViewController:self];
   }
 
   return self;

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
@@ -242,6 +242,16 @@ TEST(FlutterViewControllerTest, testViewWillAppearCalledMultipleTimes) {
   return true;
 }
 
+- (bool)testFlutterViewIsConfigured {
+  id engineMock = OCMClassMock([FlutterEngine class]);
+  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engineMock
+                                                                                nibName:@""
+                                                                                 bundle:nil];
+  [viewControllerMock loadView];
+  id renderer = [engineMock renderer];
+  // TODO check that render.flutterView is not nil
+}
+
 - (bool)testFlagsChangedEventsArePropagatedIfNotHandled {
   id engineMock = OCMClassMock([FlutterEngine class]);
   id binaryMessengerMock = OCMProtocolMock(@protocol(FlutterBinaryMessenger));

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h
@@ -19,19 +19,6 @@
 @property(nonatomic, readonly, nonnull) FlutterTextInputPlugin* textInputPlugin;
 
 /**
- * Initializes this FlutterViewController with the specified `FlutterEngine`.
- *
- * The initialized viewcontroller will attach itself to the engine as part of this process.
- *
- * @param engine The `FlutterEngine` instance to attach to. Cannot be nil.
- * @param nibName The NIB name to initialize this controller with.
- * @param nibBundle The NIB bundle.
- */
-- (nonnull instancetype)initWithEngine:(nonnull FlutterEngine*)engine
-                               nibName:(nullable NSString*)nibName
-                                bundle:(nullable NSBundle*)nibBundle NS_DESIGNATED_INITIALIZER;
-
-/**
  * Returns YES if provided event is being currently redispatched by keyboard manager.
  */
 - (BOOL)isDispatchingKeyEvent:(nonnull NSEvent*)event;


### PR DESCRIPTION
…4735)

Exposes `runWithEngine` in `FlutterViewController` as suggested by [jmagman](https://github.com/jmagman) in #74735
Fixes: #74735

Removing `[engine setViewController:self];` because `view` is not loaded, but in that function controller is saved. Later, when the view is loaded (`loadView`) passed as an argument controller is checked against the saved controller and since they match, the `nil` view is not replaced with a new view. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
