### PR TITLE
Roll to a patched version of libcxxabi that is compatible with the latest Clang Mac/iOS toolchain

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -102,7 +102,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '25e5fd0200ff0bbf4761f3e73cab67a16e928955',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '9639de21458b03a5f7d4e9733eef17330dc6d835',
 
    # Fuchsia compatibility
    #
@@ -120,7 +120,7 @@ deps = {
    Var('llvm_git') + '/llvm-project/libcxx' + '@' + '44079a4cc04cdeffb9cfe8067bfb3c276fb2bab0',
 
   'src/third_party/libcxxabi':
-   Var('llvm_git') + '/llvm-project/libcxxabi' + '@' + '2ce528fb5e0f92e57c97ec3ff53b75359d33af12',
+   Var('flutter_git') + '/third_party/libcxxabi' + '@' + '483f071ff4780a8884f32d97d2d262fbe9f1ae18',
 
   'src/third_party/glfw':
    Var('fuchsia_git') + '/third_party/glfw' + '@' + '78e6a0063d27ed44c2c4805606309744f6fb29fc',

--- a/ci/licenses_golden/licenses_third_party
+++ b/ci/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: 9ed6be1b3790aacd2a3816246733282e
+Signature: 523eb59811ca4e01b0bd2fa5c2961522
 
 UNUSED LICENSES:
 

--- a/testing/symbols/verify_exported.dart
+++ b/testing/symbols/verify_exported.dart
@@ -81,7 +81,9 @@ int _checkIos(String outPath, String nmPath, Iterable<String> builds) {
     final Iterable<NmEntry> unexpectedEntries = NmEntry.parse(nmResult.stdout as String).where((NmEntry entry) {
       return !(((entry.type == '(__DATA,__common)' || entry.type == '(__DATA,__const)') && entry.name.startsWith('_Flutter'))
           || (entry.type == '(__DATA,__objc_data)'
-              && (entry.name.startsWith(r'_OBJC_METACLASS_$_Flutter') || entry.name.startsWith(r'_OBJC_CLASS_$_Flutter'))));
+              && (entry.name.startsWith(r'_OBJC_METACLASS_$_Flutter') || entry.name.startsWith(r'_OBJC_CLASS_$_Flutter')))
+          // TODO(107887): This should not be neccesary after bitcode support is removed from the engine.
+          || (entry.type == '(__TEXT,__text)' && entry.name == '___gxx_personality_v0'));
     });
     if (unexpectedEntries.isNotEmpty) {
       print('ERROR: $libFlutter exports unexpected symbols:');


### PR DESCRIPTION
See https://github.com/flutter/flutter/issues/110140
