### PR TITLE
[Impeller] Fix Metal playgrounds for Apple Silicon

### DIFF
--- a/impeller/playground/backend/metal/playground_impl_mtl.mm
+++ b/impeller/playground/backend/metal/playground_impl_mtl.mm
@@ -70,6 +70,7 @@ PlaygroundImplMTL::PlaygroundImplMTL()
   data_->metal_layer.device = ContextMTL::Cast(*context).GetMTLDevice();
   // This pixel format is one of the documented supported formats.
   data_->metal_layer.pixelFormat = ToMTLPixelFormat(PixelFormat::kDefaultColor);
+  data_->metal_layer.framebufferOnly = NO;
   cocoa_window.contentView.layer = data_->metal_layer;
   cocoa_window.contentView.wantsLayer = YES;
 

--- a/impeller/playground/imgui/imgui_impl_impeller.cc
+++ b/impeller/playground/imgui/imgui_impl_impeller.cc
@@ -93,7 +93,6 @@ bool ImGui_ImplImpeller_Init(std::shared_ptr<impeller::Context> context) {
     auto desc = impeller::PipelineBuilder<impeller::ImguiRasterVertexShader,
                                           impeller::ImguiRasterFragmentShader>::
         MakeDefaultPipelineDescriptor(*context);
-    desc->SetSampleCount(impeller::SampleCount::kCount4);
     auto stencil = desc->GetFrontStencilAttachmentDescriptor();
     if (stencil.has_value()) {
       stencil->stencil_compare = impeller::CompareFunction::kAlways;


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/109658.
Fixes https://github.com/flutter/flutter/issues/110800.

On M1 macs, the root MSAA texture is transient and can't be loaded by the subsequent ImGui pass. This change modifies the ImGui pass to just load the resolve texture (which must always be stored for the surface anyway) and switches the ImGui pipeline to be single sample.