### PR TITLE
[Android] Add the method 'Log.getStackTraceString'

### DIFF
--- a/shell/platform/android/io/flutter/Log.java
+++ b/shell/platform/android/io/flutter/Log.java
@@ -95,4 +95,9 @@ public class Log {
   public static void wtf(@NonNull String tag, @NonNull String message, @NonNull Throwable tr) {
     android.util.Log.wtf(tag, message, tr);
   }
+
+  @NonNull
+  public static String getStackTraceString(@Nullable Throwable tr) {
+    return android.util.Log.getStackTraceString(tr);
+  }
 }

--- a/shell/platform/android/io/flutter/Log.java
+++ b/shell/platform/android/io/flutter/Log.java
@@ -5,6 +5,7 @@
 package io.flutter;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * Port of {@link android.util.Log} that only logs in {@link io.flutter.BuildConfig#DEBUG} mode and

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformViewsChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformViewsChannel.java
@@ -11,8 +11,6 @@ import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.StandardMethodCodec;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.List;
@@ -38,10 +36,7 @@ public class PlatformViewsChannel {
   }
 
   private static String detailedExceptionString(Exception exception) {
-    StringWriter stringWriter = new StringWriter();
-    PrintWriter printWriter = new PrintWriter(stringWriter);
-    exception.printStackTrace(printWriter);
-    return stringWriter.toString();
+    return Log.getStackTraceString(exception);
   }
 
   private final MethodChannel.MethodCallHandler parsingHandler =

--- a/shell/platform/android/io/flutter/plugin/common/MethodChannel.java
+++ b/shell/platform/android/io/flutter/plugin/common/MethodChannel.java
@@ -11,9 +11,6 @@ import io.flutter.BuildConfig;
 import io.flutter.Log;
 import io.flutter.plugin.common.BinaryMessenger.BinaryMessageHandler;
 import io.flutter.plugin.common.BinaryMessenger.BinaryReply;
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.io.Writer;
 import java.nio.ByteBuffer;
 
 /**
@@ -280,14 +277,8 @@ public class MethodChannel {
         Log.e(TAG + name, "Failed to handle method call", e);
         reply.reply(
             codec.encodeErrorEnvelopeWithStacktrace(
-                "error", e.getMessage(), null, getStackTrace(e)));
+                "error", e.getMessage(), null, Log.getStackTraceString(e)));
       }
-    }
-
-    private String getStackTrace(Exception e) {
-      Writer result = new StringWriter();
-      e.printStackTrace(new PrintWriter(result));
-      return result.toString();
     }
   }
 }

--- a/shell/platform/android/io/flutter/plugin/common/StandardMethodCodec.java
+++ b/shell/platform/android/io/flutter/plugin/common/StandardMethodCodec.java
@@ -5,6 +5,7 @@
 package io.flutter.plugin.common;
 
 import androidx.annotation.NonNull;
+import io.flutter.Log;
 import io.flutter.plugin.common.StandardMessageCodec.ExposedByteArrayOutputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;

--- a/shell/platform/android/io/flutter/plugin/common/StandardMethodCodec.java
+++ b/shell/platform/android/io/flutter/plugin/common/StandardMethodCodec.java
@@ -6,9 +6,6 @@ package io.flutter.plugin.common;
 
 import androidx.annotation.NonNull;
 import io.flutter.plugin.common.StandardMessageCodec.ExposedByteArrayOutputStream;
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.io.Writer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
@@ -75,7 +72,7 @@ public final class StandardMethodCodec implements MethodCodec {
     messageCodec.writeValue(stream, errorCode);
     messageCodec.writeValue(stream, errorMessage);
     if (errorDetails instanceof Throwable) {
-      messageCodec.writeValue(stream, getStackTrace((Throwable) errorDetails));
+      messageCodec.writeValue(stream, Log.getStackTraceString((Throwable) errorDetails));
     } else {
       messageCodec.writeValue(stream, errorDetails);
     }
@@ -96,7 +93,7 @@ public final class StandardMethodCodec implements MethodCodec {
     messageCodec.writeValue(stream, errorCode);
     messageCodec.writeValue(stream, errorMessage);
     if (errorDetails instanceof Throwable) {
-      messageCodec.writeValue(stream, getStackTrace((Throwable) errorDetails));
+      messageCodec.writeValue(stream, Log.getStackTraceString((Throwable) errorDetails));
     } else {
       messageCodec.writeValue(stream, errorDetails);
     }
@@ -133,12 +130,5 @@ public final class StandardMethodCodec implements MethodCodec {
         }
     }
     throw new IllegalArgumentException("Envelope corrupted");
-  }
-
-  @NonNull
-  private static String getStackTrace(@NonNull Throwable t) {
-    Writer result = new StringWriter();
-    t.printStackTrace(new PrintWriter(result));
-    return result.toString();
   }
 }

--- a/shell/platform/android/test/io/flutter/LogTest.java
+++ b/shell/platform/android/test/io/flutter/LogTest.java
@@ -19,7 +19,7 @@ public class LogTest {
 
   @Test
   public void canGetStacktraceString() {
-    RuntimeException exception = new RuntimeException("foo");
+    Exception exception = new Exception();
     String str = Log.getStackTraceString(exception);
 
     StringWriter stringWriter = new StringWriter();

--- a/shell/platform/android/test/io/flutter/LogTest.java
+++ b/shell/platform/android/test/io/flutter/LogTest.java
@@ -1,0 +1,32 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@Config(manifest = Config.NONE)
+@RunWith(RobolectricTestRunner.class)
+public class LogTest {
+
+  @Test
+  public void canGetStacktraceString() {
+    RuntimeException exception = new RuntimeException("foo");
+    String str = Log.getStackTraceString(exception);
+
+    StringWriter stringWriter = new StringWriter();
+    PrintWriter printWriter = new PrintWriter(stringWriter);
+    exception.printStackTrace(printWriter);
+    String expectStr = stringWriter.toString();
+
+    assertEquals(str, expectStr);
+  }
+}


### PR DESCRIPTION
fix https://github.com/flutter/flutter/issues/110856

I found that `Log.getStackTraceString` is not exposed. I think it's very helpful to be able to get stack trace string from `Throwable` or `Exception`.

In fact, there are many codes in flutter that need to use this capability. In the current implementation, each place is implemented separately.

This PR proposes to expose `Log.getStackTraceString` to simplify the codes and for similar scenarios in the future.

c.f.
https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/util/Log.java#371

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.


