### PR TITLE
Fix crash on ImageFilter.blur with very small sigma

### DIFF
--- a/display_list/display_list_image_filter.h
+++ b/display_list/display_list_image_filter.h
@@ -712,7 +712,11 @@ class DlLocalMatrixImageFilter final : public DlImageFilter {
     if (!image_filter_) {
       return nullptr;
     }
-    return image_filter_->skia_object()->makeWithLocalMatrix(matrix_);
+    sk_sp<SkImageFilter> skia_object = image_filter_->skia_object();
+    if (!skia_object) {
+      return nullptr;
+    }
+    return skia_object->makeWithLocalMatrix(matrix_);
   }
 
  protected:

--- a/display_list/display_list_image_filter_unittests.cc
+++ b/display_list/display_list_image_filter_unittests.cc
@@ -846,6 +846,16 @@ TEST(DisplayListImageFilter, LocalImageFilterBounds) {
   }
 }
 
+TEST(DisplayListImageFilter, LocalImageSkiaNull) {
+  auto blur_filter =
+      std::make_shared<DlBlurImageFilter>(0, 0, DlTileMode::kClamp);
+  DlLocalMatrixImageFilter dl_local_matrix_filter(SkMatrix::RotateDeg(45),
+                                                  blur_filter);
+  // With sigmas set to zero on the blur filter, Skia will return a null filter.
+  // The local matrix filter should return nullptr instead of crashing.
+  ASSERT_EQ(dl_local_matrix_filter.skia_object(), nullptr);
+}
+
 TEST(DisplayListImageFilter, UnknownEquals) {
   sk_sp<SkImageFilter> sk_filter =
       SkImageFilters::Blur(5.0, 6.0, SkTileMode::kRepeat, nullptr);


### PR DESCRIPTION
Seeing a crash in release engine (not in debug build) when using `ImageFilter.blur` with zero or near-zero `sigmaX` and `sigmaY`. 

Introduced in #34837.

<details>
<summary>Stack trace</summary>
```
Exception Type:  EXC_BAD_ACCESS (SIGSEGV)
Exception Subtype: KERN_INVALID_ADDRESS at 0x0000000000000008
Exception Codes: 0x0000000000000001, 0x0000000000000008
VM Region Info: 0x8 is not in any region.  Bytes before following region: 4342644728
      REGION TYPE                 START - END      [ VSIZE] PRT/MAX SHRMOD  REGION DETAIL
      UNUSED SPACE AT START
--->  
      __TEXT                   102d78000-102d98000 [  128K] r-x/r-x SM=COW  ...er.app/Runner
Exception Note:  EXC_CORPSE_NOTIFY
Termination Reason: SIGNAL 11 Segmentation fault: 11
Terminating Process: exc handler [98730]

Triggered by Thread:  5

Thread 0 name:   Dispatch queue: com.apple.main-thread
Thread 0:
0   libobjc.A.dylib               	       0x1dbabcf64 objc_msgSend + 68
1   UIKitCore                     	       0x1c6144078 ____updateTouchesWithDigitizerEventAndDetermineIfShouldSend_block_invoke.50 + 6656
2   UIKitCore                     	       0x1c52f449c _UIEventHIDEnumerateChildren + 176
3   UIKitCore                     	       0x1c52fadd8 __dispatchPreprocessedEventFromEventQueue + 2416
4   UIKitCore                     	       0x1c52f1070 __processEventQueue + 6616
5   UIKitCore                     	       0x1c52f65f0 __eventFetcherSourceCallback + 172
6   CoreFoundation                	       0x1c2dc3414 __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 28
7   CoreFoundation                	       0x1c2dd41a0 __CFRunLoopDoSource0 + 208
8   CoreFoundation                	       0x1c2d0d694 __CFRunLoopDoSources0 + 268
9   CoreFoundation                	       0x1c2d1305c __CFRunLoopRun + 828
10  CoreFoundation                	       0x1c2d26bc8 CFRunLoopRunSpecific + 600
11  GraphicsServices              	       0x1dee92374 GSEventRunModal + 164
12  UIKitCore                     	       0x1c569ab58 -[UIApplication _run] + 1100
13  UIKitCore                     	       0x1c541c090 UIApplicationMain + 364
14  Runner                        	       0x102d7f094 main + 64
15  dyld                          	       0x102f95da4 start + 520

Thread 1:
0   libsystem_pthread.dylib       	       0x233f60e54 start_wqthread + 0

Thread 2:
0   libsystem_pthread.dylib       	       0x233f60e54 start_wqthread + 0

Thread 3 name:  com.apple.uikit.eventfetch-thread
Thread 3:
0   libsystem_kernel.dylib        	       0x1fa83e4a0 mach_msg_trap + 8
1   libsystem_kernel.dylib        	       0x1fa83eae4 mach_msg + 76
2   CoreFoundation                	       0x1c2d0ed30 __CFRunLoopServiceMachPort + 372
3   CoreFoundation                	       0x1c2d131bc __CFRunLoopRun + 1180
4   CoreFoundation                	       0x1c2d26bc8 CFRunLoopRunSpecific + 600
5   Foundation                    	       0x1c4519444 -[NSRunLoop(NSRunLoop) runMode:beforeDate:] + 236
6   Foundation                    	       0x1c455ae0c -[NSRunLoop(NSRunLoop) runUntilDate:] + 92
7   UIKitCore                     	       0x1c5614cc4 -[UIEventFetcher threadMain] + 524
8   Foundation                    	       0x1c456941c __NSThread__start__ + 808
9   libsystem_pthread.dylib       	       0x233f619ac _pthread_start + 148
10  libsystem_pthread.dylib       	       0x233f60e68 thread_start + 8

Thread 4 name:  io.flutter.1.ui
Thread 4:
0   libsystem_kernel.dylib        	       0x1fa83e4a0 mach_msg_trap + 8
1   libsystem_kernel.dylib        	       0x1fa83eae4 mach_msg + 76
2   CoreFoundation                	       0x1c2d0ed30 __CFRunLoopServiceMachPort + 372
3   CoreFoundation                	       0x1c2d131bc __CFRunLoopRun + 1180
4   CoreFoundation                	       0x1c2d26bc8 CFRunLoopRunSpecific + 600
5   Flutter                       	       0x10c869818 fml::MessageLoopDarwin::Run() + 88
6   Flutter                       	       0x10c869200 void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, fml::Thread::Thread(std::__1::function<void (fml::Thread::ThreadConfig const&)> const&, fml::Thread::ThreadConfig const&)::$_0> >(void*) + 208
7   libsystem_pthread.dylib       	       0x233f619ac _pthread_start + 148
8   libsystem_pthread.dylib       	       0x233f60e68 thread_start + 8

Thread 5 name:  io.flutter.1.raster
Thread 5 Crashed:
0   Flutter                       	       0x10ca11110 flutter::DlLocalMatrixImageFilter::skia_object() const + 56
1   Flutter                       	       0x10ca11104 flutter::DlLocalMatrixImageFilter::skia_object() const + 44
2   Flutter                       	       0x10c9f90d4 flutter::Layer::AutoCachePaint::setImageFilter(flutter::DlImageFilter const*) + 40
3   Flutter                       	       0x10c9f8f78 flutter::ImageFilterLayer::Paint(flutter::PaintContext&) const + 80
4   Flutter                       	       0x10c9f62b0 flutter::ContainerLayer::PaintChildren(flutter::PaintContext&) const + 76
5   Flutter                       	       0x10c9f504c flutter::ClipShapeLayer<SkRect>::Paint(flutter::PaintContext&) const + 304
6   Flutter                       	       0x10c9f62b0 flutter::ContainerLayer::PaintChildren(flutter::PaintContext&) const + 76
7   Flutter                       	       0x10c9fd3e8 flutter::TransformLayer::Paint(flutter::PaintContext&) const + 88
8   Flutter                       	       0x10c9f62b0 flutter::ContainerLayer::PaintChildren(flutter::PaintContext&) const + 76
9   Flutter                       	       0x10c9fd3e8 flutter::TransformLayer::Paint(flutter::PaintContext&) const + 88
10  Flutter                       	       0x10c9f62b0 flutter::ContainerLayer::PaintChildren(flutter::PaintContext&) const + 76
11  Flutter                       	       0x10c9f504c flutter::ClipShapeLayer<SkRect>::Paint(flutter::PaintContext&) const + 304
12  Flutter                       	       0x10c9f62b0 flutter::ContainerLayer::PaintChildren(flutter::PaintContext&) const + 76
13  Flutter                       	       0x10c9fd3e8 flutter::TransformLayer::Paint(flutter::PaintContext&) const + 88
14  Flutter                       	       0x10c9f62b0 flutter::ContainerLayer::PaintChildren(flutter::PaintContext&) const + 76
15  Flutter                       	       0x10c9fd3e8 flutter::TransformLayer::Paint(flutter::PaintContext&) const + 88
16  Flutter                       	       0x10c9f62b0 flutter::ContainerLayer::PaintChildren(flutter::PaintContext&) const + 76
17  Flutter                       	       0x10c9fd3e8 flutter::TransformLayer::Paint(flutter::PaintContext&) const + 88
18  Flutter                       	       0x10c9f62b0 flutter::ContainerLayer::PaintChildren(flutter::PaintContext&) const + 76
19  Flutter                       	       0x10c9fd3e8 flutter::TransformLayer::Paint(flutter::PaintContext&) const + 88
20  Flutter                       	       0x10c9f62b0 flutter::ContainerLayer::PaintChildren(flutter::PaintContext&) const + 76
21  Flutter                       	       0x10c9fd3e8 flutter::TransformLayer::Paint(flutter::PaintContext&) const + 88
22  Flutter                       	       0x10c9f62b0 flutter::ContainerLayer::PaintChildren(flutter::PaintContext&) const + 76
23  Flutter                       	       0x10c9f1f24 flutter::CompositorContext::ScopedFrame::Raster(flutter::LayerTree&, bool, flutter::FrameDamage*) + 4200
24  Flutter                       	       0x10c94003c flutter::Rasterizer::DrawToSurfaceUnsafe(flutter::FrameTimingsRecorder&, flutter::LayerTree&) + 880
25  Flutter                       	       0x10c940430 std::__1::__function::__func<flutter::Rasterizer::DrawToSurface(flutter::FrameTimingsRecorder&, flutter::LayerTree&)::$_6, std::__1::allocator<flutter::Rasterizer::DrawToSurface(flutter::FrameTimingsRecorder&, flutter::LayerTree&)::$_6>, void ()>::operator()() + 28
26  Flutter                       	       0x10c867f84 fml::SyncSwitch::Execute(fml::SyncSwitch::Handlers const&) const + 72
27  Flutter                       	       0x10c93fba4 flutter::Rasterizer::DrawToSurface(flutter::FrameTimingsRecorder&, flutter::LayerTree&) + 296
28  Flutter                       	       0x10c941544 std::__1::__function::__func<flutter::Rasterizer::Draw(std::__1::shared_ptr<flutter::Pipeline<flutter::LayerTreeItem> >, std::__1::function<bool (flutter::LayerTree&)>)::$_2, std::__1::allocator<flutter::Rasterizer::Draw(std::__1::shared_ptr<flutter::Pipeline<flutter::LayerTreeItem> >, std::__1::function<bool (flutter::LayerTree&)>)::$_2>, void (std::__1::unique_ptr<flutter::LayerTreeItem, std::__1::default_delete<flutter::LayerTreeItem> >)>::operator()(std::__1::unique_ptr<flutter::LayerTreeItem, std::__1::default_delete<flutter::LayerTreeItem> >&&) + 300
29  Flutter                       	       0x10c940750 flutter::Rasterizer::Draw(std::__1::shared_ptr<flutter::Pipeline<flutter::LayerTreeItem> >, std::__1::function<bool (flutter::LayerTree&)>) + 444
30  Flutter                       	       0x10c9560a4 std::__1::__function::__func<fml::internal::CopyableLambda<flutter::Shell::OnAnimatorDraw(std::__1::shared_ptr<flutter::Pipeline<flutter::LayerTreeItem> >)::$_12>, std::__1::allocator<fml::internal::CopyableLambda<flutter::Shell::OnAnimatorDraw(std::__1::shared_ptr<flutter::Pipeline<flutter::LayerTreeItem> >)::$_12> >, void ()>::operator()() + 152
31  Flutter                       	       0x10c86694c fml::MessageLoopImpl::FlushTasks(fml::FlushType) + 1680
32  Flutter                       	       0x10c86972c fml::MessageLoopDarwin::OnTimerFire(__CFRunLoopTimer*, fml::MessageLoopDarwin*) + 32
33  CoreFoundation                	       0x1c2db6678 __CFRUNLOOP_IS_CALLING_OUT_TO_A_TIMER_CALLBACK_FUNCTION__ + 32
34  CoreFoundation                	       0x1c2d3a654 __CFRunLoopDoTimer + 1064
35  CoreFoundation                	       0x1c2d34e00 __CFRunLoopDoTimers + 320
36  CoreFoundation                	       0x1c2d134b0 __CFRunLoopRun + 1936
37  CoreFoundation                	       0x1c2d26bc8 CFRunLoopRunSpecific + 600
38  Flutter                       	       0x10c869818 fml::MessageLoopDarwin::Run() + 88
39  Flutter                       	       0x10c869200 void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, fml::Thread::Thread(std::__1::function<void (fml::Thread::ThreadConfig const&)> const&, fml::Thread::ThreadConfig const&)::$_0> >(void*) + 208
40  libsystem_pthread.dylib       	       0x233f619ac _pthread_start + 148
41  libsystem_pthread.dylib       	       0x233f60e68 thread_start + 8

Thread 6 name:  io.flutter.1.io
Thread 6:
0   libsystem_kernel.dylib        	       0x1fa83e4a0 mach_msg_trap + 8
1   libsystem_kernel.dylib        	       0x1fa83eae4 mach_msg + 76
2   CoreFoundation                	       0x1c2d0ed30 __CFRunLoopServiceMachPort + 372
3   CoreFoundation                	       0x1c2d131bc __CFRunLoopRun + 1180
4   CoreFoundation                	       0x1c2d26bc8 CFRunLoopRunSpecific + 600
5   Flutter                       	       0x10c869818 fml::MessageLoopDarwin::Run() + 88
6   Flutter                       	       0x10c869200 void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, fml::Thread::Thread(std::__1::function<void (fml::Thread::ThreadConfig const&)> const&, fml::Thread::ThreadConfig const&)::$_0> >(void*) + 208
7   libsystem_pthread.dylib       	       0x233f619ac _pthread_start + 148
8   libsystem_pthread.dylib       	       0x233f60e68 thread_start + 8

Thread 7 name:  io.worker.1
Thread 7:
0   libsystem_kernel.dylib        	       0x1fa83ef24 __psynch_cvwait + 8
1   libsystem_pthread.dylib       	       0x233f68298 _pthread_cond_wait + 1236
2   libc++.1.dylib                	       0x1dbb7128c std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&) + 28
3   Flutter                       	       0x10c863758 void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, fml::ConcurrentMessageLoop::ConcurrentMessageLoop(unsigned long)::$_0> >(void*) + 288
4   libsystem_pthread.dylib       	       0x233f619ac _pthread_start + 148
5   libsystem_pthread.dylib       	       0x233f60e68 thread_start + 8

Thread 8 name:  io.worker.2
Thread 8:
0   libsystem_kernel.dylib        	       0x1fa83ef24 __psynch_cvwait + 8
1   libsystem_pthread.dylib       	       0x233f68298 _pthread_cond_wait + 1236
2   libc++.1.dylib                	       0x1dbb7128c std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&) + 28
3   Flutter                       	       0x10c863758 void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, fml::ConcurrentMessageLoop::ConcurrentMessageLoop(unsigned long)::$_0> >(void*) + 288
4   libsystem_pthread.dylib       	       0x233f619ac _pthread_start + 148
5   libsystem_pthread.dylib       	       0x233f60e68 thread_start + 8

Thread 9 name:  io.worker.3
Thread 9:
0   libsystem_kernel.dylib        	       0x1fa83ef24 __psynch_cvwait + 8
1   libsystem_pthread.dylib       	       0x233f68298 _pthread_cond_wait + 1236
2   libc++.1.dylib                	       0x1dbb7128c std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&) + 28
3   Flutter                       	       0x10c863758 void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, fml::ConcurrentMessageLoop::ConcurrentMessageLoop(unsigned long)::$_0> >(void*) + 288
4   libsystem_pthread.dylib       	       0x233f619ac _pthread_start + 148
5   libsystem_pthread.dylib       	       0x233f60e68 thread_start + 8

Thread 10 name:  io.worker.4
Thread 10:
0   libsystem_kernel.dylib        	       0x1fa83ef24 __psynch_cvwait + 8
1   libsystem_pthread.dylib       	       0x233f68298 _pthread_cond_wait + 1236
2   libc++.1.dylib                	       0x1dbb7128c std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&) + 28
3   Flutter                       	       0x10c863758 void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, fml::ConcurrentMessageLoop::ConcurrentMessageLoop(unsigned long)::$_0> >(void*) + 288
4   libsystem_pthread.dylib       	       0x233f619ac _pthread_start + 148
5   libsystem_pthread.dylib       	       0x233f60e68 thread_start + 8

Thread 11 name:  io.worker.5
Thread 11:
0   libsystem_kernel.dylib        	       0x1fa83ef24 __psynch_cvwait + 8
1   libsystem_pthread.dylib       	       0x233f68298 _pthread_cond_wait + 1236
2   libc++.1.dylib                	       0x1dbb7128c std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&) + 28
3   Flutter                       	       0x10c863758 void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, fml::ConcurrentMessageLoop::ConcurrentMessageLoop(unsigned long)::$_0> >(void*) + 288
4   libsystem_pthread.dylib       	       0x233f619ac _pthread_start + 148
5   libsystem_pthread.dylib       	       0x233f60e68 thread_start + 8

Thread 12 name:  io.worker.6
Thread 12:
0   libsystem_kernel.dylib        	       0x1fa83ef24 __psynch_cvwait + 8
1   libsystem_pthread.dylib       	       0x233f68298 _pthread_cond_wait + 1236
2   libc++.1.dylib                	       0x1dbb7128c std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&) + 28
3   Flutter                       	       0x10c863758 void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, fml::ConcurrentMessageLoop::ConcurrentMessageLoop(unsigned long)::$_0> >(void*) + 288
4   libsystem_pthread.dylib       	       0x233f619ac _pthread_start + 148
5   libsystem_pthread.dylib       	       0x233f60e68 thread_start + 8

Thread 13 name:  dart:io EventHandler
Thread 13:
0   libsystem_kernel.dylib        	       0x1fa83fe18 kevent + 8
1   Flutter                       	       0x10ca45604 dart::bin::EventHandlerImplementation::EventHandlerEntry(unsigned long) + 428
2   Flutter                       	       0x10ca74d40 dart::bin::ThreadStart(void*) + 44
3   libsystem_pthread.dylib       	       0x233f619ac _pthread_start + 148
4   libsystem_pthread.dylib       	       0x233f60e68 thread_start + 8

Thread 14:
0   libsystem_pthread.dylib       	       0x233f60e54 start_wqthread + 0

Thread 15 name:   Dispatch queue: com.apple.network.connections
Thread 15:
0   libobjc.A.dylib               	       0x1dbad9ac0 _setThisThreadIsInitializingClass(objc_class*) + 96
1   libobjc.A.dylib               	       0x1dbad9a80 _setThisThreadIsInitializingClass(objc_class*) + 32
2   libobjc.A.dylib               	       0x1dbac4494 initializeNonMetaClass + 468
3   libobjc.A.dylib               	       0x1dbac8c04 initializeAndMaybeRelock(objc_class*, objc_object*, mutex_tt<false>&, bool) + 184
4   libobjc.A.dylib               	       0x1dbac1d04 lookUpImpOrForward + 912
5   libobjc.A.dylib               	       0x1dbabd3e4 _objc_msgSend_uncached + 68
6   CFNetwork                     	       0x1c3583464 0x1c352b000 + 361572
7   CFNetwork                     	       0x1c358b5b0 0x1c352b000 + 394672
8   CFNetwork                     	       0x1c3539584 0x1c352b000 + 58756
9   CFNetwork                     	       0x1c355f76c 0x1c352b000 + 214892
10  CoreFoundation                	       0x1c2d1c02c _CFRelease + 232
11  CFNetwork                     	       0x1c35a9724 0x1c352b000 + 517924
12  libsystem_blocks.dylib        	       0x233edd804 _Block_release + 192
13  CFNetwork                     	       0x1c353a4bc 0x1c352b000 + 62652
14  CFNetwork                     	       0x1c35a9724 0x1c352b000 + 517924
15  libsystem_blocks.dylib        	       0x233edd804 _Block_release + 192
16  libnetwork.dylib              	       0x1c3ab1c70 nw_proxy_deallocate_options + 32
17  libnetwork.dylib              	       0x1c3b0b230 -[NWConcrete_nw_protocol_options dealloc] + 52
18  libnetwork.dylib              	       0x1c41d0544 nw_array_dispose + 548
19  libnetwork.dylib              	       0x1c3accecc -[OS_nw_array dealloc] + 28
20  libnetwork.dylib              	       0x1c3ab5b0c -[NWConcrete_nw_parameters .cxx_destruct] + 84
21  libobjc.A.dylib               	       0x1dbac3380 object_cxxDestructFromClass(objc_object*, objc_class*) + 116
22  libobjc.A.dylib               	       0x1dbac01b4 objc_destructInstance + 80
23  libobjc.A.dylib               	       0x1dbac9a00 _objc_rootDealloc + 80
24  libnetwork.dylib              	       0x1c3aaf340 -[NWConcrete_nw_parameters dealloc] + 84
25  libobjc.A.dylib               	       0x1dbac3380 object_cxxDestructFromClass(objc_object*, objc_class*) + 116
26  libobjc.A.dylib               	       0x1dbac01b4 objc_destructInstance + 80
27  libobjc.A.dylib               	       0x1dbac9a00 _objc_rootDealloc + 80
28  libnetwork.dylib              	       0x1c3aa5464 -[NWConcrete_nw_path_evaluator dealloc] + 1176
29  libnetwork.dylib              	       0x1c3aa8e98 __nw_association_schedule_deactivation_block_invoke + 1420
30  libdispatch.dylib             	       0x1c2a08a30 _dispatch_client_callout + 20
31  libdispatch.dylib             	       0x1c2a0beec _dispatch_continuation_pop + 500
32  libdispatch.dylib             	       0x1c2a1f13c _dispatch_source_invoke + 1596
33  libdispatch.dylib             	       0x1c2a11f80 _dispatch_workloop_invoke + 1784
34  libdispatch.dylib             	       0x1c2a1b500 _dispatch_workloop_worker_thread + 648
35  libsystem_pthread.dylib       	       0x233f610bc _pthread_wqthread + 288
36  libsystem_pthread.dylib       	       0x233f60e5c start_wqthread + 8

Thread 16 name:  com.google.firebase.crashlytics.MachExceptionServer
Thread 16:
0   libsystem_kernel.dylib        	       0x1fa83feb4 write + 8
1   FirebaseCrashlytics           	       0x1035055b4 FIRCLSSDKFileLog + 316
2   FirebaseCrashlytics           	       0x103507478 FIRCLSMachExceptionServer + 968
3   libsystem_pthread.dylib       	       0x233f619ac _pthread_start + 148
4   libsystem_pthread.dylib       	       0x233f60e68 thread_start + 8

Thread 17 name:  com.apple.NSURLConnectionLoader
Thread 17:
0   libsystem_kernel.dylib        	       0x1fa83e4a0 mach_msg_trap + 8
1   libsystem_kernel.dylib        	       0x1fa83eae4 mach_msg + 76
2   CoreFoundation                	       0x1c2d0ed30 __CFRunLoopServiceMachPort + 372
3   CoreFoundation                	       0x1c2d131bc __CFRunLoopRun + 1180
4   CoreFoundation                	       0x1c2d26bc8 CFRunLoopRunSpecific + 600
5   CFNetwork                     	       0x1c37a31dc 0x1c352b000 + 2589148
6   Foundation                    	       0x1c456941c __NSThread__start__ + 808
7   libsystem_pthread.dylib       	       0x233f619ac _pthread_start + 148
8   libsystem_pthread.dylib       	       0x233f60e68 thread_start + 8

Thread 18 name:  AVAudioSession Notify Thread
Thread 18:
0   libsystem_kernel.dylib        	       0x1fa83e4a0 mach_msg_trap + 8
1   libsystem_kernel.dylib        	       0x1fa83eae4 mach_msg + 76
2   CoreFoundation                	       0x1c2d0ed30 __CFRunLoopServiceMachPort + 372
3   CoreFoundation                	       0x1c2d131bc __CFRunLoopRun + 1180
4   CoreFoundation                	       0x1c2d26bc8 CFRunLoopRunSpecific + 600
5   AudioSession                  	       0x1cc33bf04 CADeprecated::GenericRunLoopThread::Entry(void*) + 164
6   AudioSession                  	       0x1cc3458f0 CADeprecated::CAPThread::Entry(CADeprecated::CAPThread*) + 92
7   libsystem_pthread.dylib       	       0x233f619ac _pthread_start + 148
8   libsystem_pthread.dylib       	       0x233f60e68 thread_start + 8

Thread 19 name:  DartWorker
Thread 19:
0   libsystem_kernel.dylib        	       0x1fa83ef24 __psynch_cvwait + 8
1   libsystem_pthread.dylib       	       0x233f682c4 _pthread_cond_wait + 1280
2   Flutter                       	       0x10cb9f43c dart::Monitor::WaitMicros(long long) + 128
3   Flutter                       	       0x10cbdc608 dart::ThreadPool::Worker::Main(unsigned long) + 668
4   Flutter                       	       0x10cb9ee08 dart::ThreadStart(void*) + 288
5   libsystem_pthread.dylib       	       0x233f619ac _pthread_start + 148
6   libsystem_pthread.dylib       	       0x233f60e68 thread_start + 8

Thread 20 name:  DartWorker
Thread 20:
0   libsystem_kernel.dylib        	       0x1fa83ef24 __psynch_cvwait + 8
1   libsystem_pthread.dylib       	       0x233f682c4 _pthread_cond_wait + 1280
2   Flutter                       	       0x10cb9f43c dart::Monitor::WaitMicros(long long) + 128
3   Flutter                       	       0x10cbdc608 dart::ThreadPool::Worker::Main(unsigned long) + 668
4   Flutter                       	       0x10cb9ee08 dart::ThreadStart(void*) + 288
5   libsystem_pthread.dylib       	       0x233f619ac _pthread_start + 148
6   libsystem_pthread.dylib       	       0x233f60e68 thread_start + 8


Thread 5 crashed with ARM Thread State (64-bit):
    x0: 0x0000000000000000   x1: 0x0000000282f905b8   x2: 0x0000000105315fac   x3: 0x000000016d56b320
    x4: 0x0000000000000000   x5: 0x0000000000000001   x6: 0x0000000104670070   x7: 0x0000000281e91008
    x8: 0x0000000039800000   x9: 0x0000000000000000  x10: 0x0000000000000018  x11: 0x00000000000007bc
   x12: 0x00000000000000b8  x13: 0x00000000fec1d11b  x14: 0x00000000fee1d800  x15: 0x000000000000003b
   x16: 0x0000000080000000  x17: 0x000000007ee00000  x18: 0x0000000000000000  x19: 0x0000000000000000
   x20: 0x0000000282f905c0  x21: 0x0000000282f905b8  x22: 0x0000000000000008  x23: 0x000000000000000c
   x24: 0x000000000000000c  x25: 0x0000000000000001  x26: 0x0000000000000001  x27: 0x00000001045062e8
   x28: 0x00000002828c6ee0   fp: 0x000000016d56b1b0   lr: 0x000000010ca11104
    sp: 0x000000016d56b180   pc: 0x000000010ca11110 cpsr: 0x80000000
   far: 0x0000000000000008  esr: 0x92000006 (Data Abort) byte read Translation fault

Binary Images:
       0x1dbabb000 -        0x1dbaf7fff libobjc.A.dylib arm64e  <f6368be9109b3405b282624040529afd> /usr/lib/libobjc.A.dylib
       0x1c5186000 -        0x1c6a23fff UIKitCore arm64e  <137a95aada6d332cbc01e13bb9b6e317> /System/Library/PrivateFrameworks/UIKitCore.framework/UIKitCore
       0x1c2d08000 -        0x1c315dfff CoreFoundation arm64e  <6b22dd8135853be6bc77ba19810ec0f2> /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation
       0x1dee91000 -        0x1dee99fff GraphicsServices arm64e  <a094e7b51d4037c5902756d86988ec4b> /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices
       0x102d78000 -        0x102d97fff Runner arm64  <0dfe25a946053b878417a8ccc5f22de1> /private/var/containers/Bundle/Application/0FC97315-0A5F-4AC3-912D-A3212285BAB2/Runner.app/Runner
       0x102f7c000 -        0x102fd3fff dyld arm64e  <66e1fb2668f8379ba052eb8b8291b5e1> /usr/lib/dyld
       0x233f60000 -        0x233f6bfff libsystem_pthread.dylib arm64e  <adc41700002e3a2bb4a1eb5fbf575770> /usr/lib/system/libsystem_pthread.dylib
       0x1fa83d000 -        0x1fa872fff libsystem_kernel.dylib arm64e  <1fb39303587b320eaeb8e51a54c8a4a9> /usr/lib/system/libsystem_kernel.dylib
       0x1c4500000 -        0x1c480afff Foundation arm64e  <ee1abaf23d7137fb906715aa79528619> /System/Library/Frameworks/Foundation.framework/Foundation
       0x10c5ac000 -        0x10cd8bfff Flutter arm64  <4c4c443255553144a1d3762364b5eabd> /private/var/containers/Bundle/Application/0FC97315-0A5F-4AC3-912D-A3212285BAB2/Runner.app/Frameworks/Flutter.framework/Flutter
       0x1dbb64000 -        0x1dbbcafff libc++.1.dylib arm64e  <17cea4f6e3933beab8971bf33851a14b> /usr/lib/libc++.1.dylib
       0x1c352b000 -        0x1c39ecfff CFNetwork arm64e  <106410ffdd4f3527ad531980fe8b0ddd> /System/Library/Frameworks/CFNetwork.framework/CFNetwork
       0x233edc000 -        0x233eddfff libsystem_blocks.dylib arm64e  <8684215d9d4131dd9f25fdbc827ba1af> /usr/lib/system/libsystem_blocks.dylib
       0x1c39ed000 -        0x1c4481fff libnetwork.dylib arm64e  <0dbe8d5848823c66b0310239c020ee4c> /usr/lib/libnetwork.dylib
       0x1c2a05000 -        0x1c2a4afff libdispatch.dylib arm64e  <e3ea4f635d11342aaf199f58dbc8e259> /usr/lib/system/libdispatch.dylib
       0x1034ec000 -        0x10352ffff FirebaseCrashlytics arm64  <bc476804f27b356e98431e87c4609c7e> /private/var/containers/Bundle/Application/0FC97315-0A5F-4AC3-912D-A3212285BAB2/Runner.app/Frameworks/FirebaseCrashlytics.framework/FirebaseCrashlytics
       0x1cc335000 -        0x1cc35ffff AudioSession arm64e  <98e4676874ff374c9b70303bffce2d33> /System/Library/PrivateFrameworks/AudioSession.framework/AudioSession
               0x0 - 0xffffffffffffffff ??? unknown-arch  <00000000000000000000000000000000> ???

```
</details>

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
