### PR TITLE
Remove workaround setting target_cpu to x64 in windows.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -102,7 +102,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/godofredoc/buildroot.git' + '@' + '187b85f2a9ad99bb22a71b9e0a1882b58767a944',
+  'src': 'https://github.com/godofredoc/buildroot.git' + '@' + '01f1c8a1ad248e85340757332bb97a8f63bbd037',
 
    # Fuchsia compatibility
    #

--- a/DEPS
+++ b/DEPS
@@ -102,7 +102,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/godofredoc/buildroot.git' + '@' + '0d724b26837825caa99cfe0be9fe6a700d86465b',
+  'src': 'https://github.com/godofredoc/buildroot.git' + '@' + '011756d976592615378a7f65a504fe886171a3cb',
 
    # Fuchsia compatibility
    #

--- a/DEPS
+++ b/DEPS
@@ -102,7 +102,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/godofredoc/buildroot.git' + '@' + '01f1c8a1ad248e85340757332bb97a8f63bbd037',
+  'src': 'https://github.com/godofredoc/buildroot.git' + '@' + '9e082d79aeff3ce012008b0e3c3f52048dee74a0',
 
    # Fuchsia compatibility
    #

--- a/DEPS
+++ b/DEPS
@@ -102,7 +102,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/godofredoc/buildroot.git' + '@' + '9e082d79aeff3ce012008b0e3c3f52048dee74a0',
+  'src': 'https://github.com/godofredoc/buildroot.git' + '@' + '0d724b26837825caa99cfe0be9fe6a700d86465b',
 
    # Fuchsia compatibility
    #

--- a/DEPS
+++ b/DEPS
@@ -102,7 +102,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/godofredoc/buildroot.git' + '@' + '1c2d498ad97cdfe7165d9cc3873db4034ee276cb',
+  'src': 'https://github.com/godofredoc/buildroot.git' + '@' + '187b85f2a9ad99bb22a71b9e0a1882b58767a944',
 
    # Fuchsia compatibility
    #

--- a/DEPS
+++ b/DEPS
@@ -102,7 +102,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/godofredoc/buildroot.git' + '@' + '011756d976592615378a7f65a504fe886171a3cb',
+  'src': 'https://github.com/godofredoc/buildroot.git' + '@' + 'b555e5fe750b4ff570896e863edc6d52a0c97d71',
 
    # Fuchsia compatibility
    #

--- a/DEPS
+++ b/DEPS
@@ -102,7 +102,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '25e5fd0200ff0bbf4761f3e73cab67a16e928955',
+  'src': 'https://github.com/godofredoc/buildroot.git' + '@' + '1c2d498ad97cdfe7165d9cc3873db4034ee276cb',
 
    # Fuchsia compatibility
    #

--- a/DEPS
+++ b/DEPS
@@ -102,7 +102,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/godofredoc/buildroot.git' + '@' + 'b555e5fe750b4ff570896e863edc6d52a0c97d71',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '25e5fd0200ff0bbf4761f3e73cab67a16e928955',
 
    # Fuchsia compatibility
    #

--- a/tools/gn
+++ b/tools/gn
@@ -292,7 +292,7 @@ def to_gn_args(args):
   # matches the bit-width of the target architecture.
   #if sys.platform.startswith(('cygwin', 'win')) and args.target_os != 'win':
   #  gn_args['host_cpu'] = cpu_for_target_arch(gn_args['target_cpu'])
-  gn_args['target_cpu'] = cpu_for_target_arch(gn_args['target_cpu'])
+  #gn_args['target_cpu'] = cpu_for_target_arch(gn_args['target_cpu'])
 
   # macOS host builds (whether x64 or arm64) must currently be built under
   # Rosetta on Apple Silicon Macs.

--- a/tools/gn
+++ b/tools/gn
@@ -292,7 +292,7 @@ def to_gn_args(args):
   # matches the bit-width of the target architecture.
   #if sys.platform.startswith(('cygwin', 'win')) and args.target_os != 'win':
   #  gn_args['host_cpu'] = cpu_for_target_arch(gn_args['target_cpu'])
-  #  gn_args['target_cpu'] = cpu_for_target_arch(gn_args['target_cpu'])
+  gn_args['target_cpu'] = cpu_for_target_arch(gn_args['target_cpu'])
 
   # macOS host builds (whether x64 or arm64) must currently be built under
   # Rosetta on Apple Silicon Macs.

--- a/tools/gn
+++ b/tools/gn
@@ -290,9 +290,9 @@ def to_gn_args(args):
 
   # No cross-compilation on Windows (for now). Use host toolchain that
   # matches the bit-width of the target architecture.
-  if sys.platform.startswith(('cygwin', 'win')) and args.target_os != 'win':
-    gn_args['host_cpu'] = cpu_for_target_arch(gn_args['target_cpu'])
-    gn_args['target_cpu'] = cpu_for_target_arch(gn_args['target_cpu'])
+  #if sys.platform.startswith(('cygwin', 'win')) and args.target_os != 'win':
+  #  gn_args['host_cpu'] = cpu_for_target_arch(gn_args['target_cpu'])
+  #  gn_args['target_cpu'] = cpu_for_target_arch(gn_args['target_cpu'])
 
   # macOS host builds (whether x64 or arm64) must currently be built under
   # Rosetta on Apple Silicon Macs.


### PR DESCRIPTION
Removes the workaround always setting target_cpu to x64 in windows builds. It also passes the responsibility of running the correct ninja target to recipes.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
