### PR TITLE
[Windows] Fix system theme integration.

### DIFF
--- a/shell/platform/windows/settings_plugin.cc
+++ b/shell/platform/windows/settings_plugin.cc
@@ -34,9 +34,18 @@ SettingsPlugin::SettingsPlugin(BinaryMessenger* messenger,
           messenger,
           kChannelName,
           &JsonMessageCodec::GetInstance())),
-      task_runner_(task_runner) {}
+      task_runner_(task_runner) {
+  RegOpenKeyEx(HKEY_CURRENT_USER, kGetPreferredBrightnessRegKey,
+               RRF_RT_REG_DWORD, KEY_NOTIFY, &preferred_brightness_reg_hkey_);
+  RegOpenKeyEx(HKEY_CURRENT_USER, kGetTextScaleFactorRegKey, RRF_RT_REG_DWORD,
+               KEY_NOTIFY, &text_scale_factor_reg_hkey_);
+}
 
-SettingsPlugin::~SettingsPlugin() = default;
+SettingsPlugin::~SettingsPlugin() {
+  StopWatching();
+  RegCloseKey(preferred_brightness_reg_hkey_);
+  RegCloseKey(text_scale_factor_reg_hkey_);
+}
 
 void SettingsPlugin::SendSettings() {
   rapidjson::Document settings(rapidjson::kObjectType);

--- a/shell/platform/windows/settings_plugin.cc
+++ b/shell/platform/windows/settings_plugin.cc
@@ -34,17 +34,10 @@ SettingsPlugin::SettingsPlugin(BinaryMessenger* messenger,
           messenger,
           kChannelName,
           &JsonMessageCodec::GetInstance())),
-      task_runner_(task_runner) {
-  RegOpenKeyEx(HKEY_CURRENT_USER, kGetPreferredBrightnessRegKey,
-               RRF_RT_REG_DWORD, KEY_NOTIFY, &preferred_brightness_reg_hkey_);
-  RegOpenKeyEx(HKEY_CURRENT_USER, kGetTextScaleFactorRegKey, RRF_RT_REG_DWORD,
-               KEY_NOTIFY, &text_scale_factor_reg_hkey_);
-}
+      task_runner_(task_runner) {}
 
 SettingsPlugin::~SettingsPlugin() {
   StopWatching();
-  RegCloseKey(preferred_brightness_reg_hkey_);
-  RegCloseKey(text_scale_factor_reg_hkey_);
 }
 
 void SettingsPlugin::SendSettings() {
@@ -64,6 +57,12 @@ void SettingsPlugin::SendSettings() {
 }
 
 void SettingsPlugin::StartWatching() {
+  RegOpenKeyEx(HKEY_CURRENT_USER, kGetPreferredBrightnessRegKey,
+               RRF_RT_REG_DWORD, KEY_NOTIFY, &preferred_brightness_reg_hkey_);
+  RegOpenKeyEx(HKEY_CURRENT_USER, kGetTextScaleFactorRegKey, RRF_RT_REG_DWORD,
+               KEY_NOTIFY, &text_scale_factor_reg_hkey_);
+
+  // Start watching when the keys exist.
   if (preferred_brightness_reg_hkey_ != nullptr) {
     WatchPreferredBrightnessChanged();
   }
@@ -75,6 +74,13 @@ void SettingsPlugin::StartWatching() {
 void SettingsPlugin::StopWatching() {
   preferred_brightness_changed_watcher_ = nullptr;
   text_scale_factor_changed_watcher_ = nullptr;
+
+  if (preferred_brightness_reg_hkey_ != nullptr) {
+    RegCloseKey(preferred_brightness_reg_hkey_);
+  }
+  if (text_scale_factor_reg_hkey_ != nullptr) {
+    RegCloseKey(text_scale_factor_reg_hkey_);
+  }
 }
 
 bool SettingsPlugin::GetAlwaysUse24HourFormat() {

--- a/shell/platform/windows/settings_plugin.h
+++ b/shell/platform/windows/settings_plugin.h
@@ -49,11 +49,14 @@ class SettingsPlugin {
   // Returns the user-preferred brightness.
   virtual PlatformBrightness GetPreferredBrightness();
 
+  // Starts watching brightness changes.
+  virtual void WatchPreferredBrightnessChanged();
+
+  // Starts watching text scale factor changes.
+  virtual void WatchTextScaleFactorChanged();
+
  private:
   std::unique_ptr<BasicMessageChannel<rapidjson::Document>> channel_;
-
-  void WatchPreferredBrightnessChanged();
-  void WatchTextScaleFactorChanged();
 
   HKEY preferred_brightness_reg_hkey_ = nullptr;
   HKEY text_scale_factor_reg_hkey_ = nullptr;

--- a/shell/platform/windows/settings_plugin_unittests.cc
+++ b/shell/platform/windows/settings_plugin_unittests.cc
@@ -22,12 +22,12 @@ class MockSettingsPlugin : public SettingsPlugin {
   virtual ~MockSettingsPlugin() = default;
 
   // |SettingsPlugin|
-  MOCK_METHOD0(StartWatching, void());
-  MOCK_METHOD0(StopWatching, void());
-
   MOCK_METHOD0(GetAlwaysUse24HourFormat, bool());
   MOCK_METHOD0(GetTextScaleFactor, float());
   MOCK_METHOD0(GetPreferredBrightness, PlatformBrightness());
+
+  MOCK_METHOD0(WatchPreferredBrightnessChanged, void());
+  MOCK_METHOD0(WatchTextScaleFactorChanged, void());
 };
 
 }  // namespace
@@ -56,6 +56,18 @@ TEST(SettingsPluginTest, SendSettingsGetsSettings) {
   EXPECT_CALL(settings_plugin, GetPreferredBrightness).Times(1);
 
   settings_plugin.SendSettings();
+}
+
+TEST(SettingsPluginTest, StartWatchingStartsWatchingChanges) {
+  TestBinaryMessenger messenger([](const std::string& channel,
+                                   const uint8_t* message, size_t message_size,
+                                   BinaryReply reply) {});
+  ::testing::NiceMock<MockSettingsPlugin> settings_plugin(&messenger, nullptr);
+
+  EXPECT_CALL(settings_plugin, WatchPreferredBrightnessChanged).Times(1);
+  EXPECT_CALL(settings_plugin, WatchTextScaleFactorChanged).Times(1);
+
+  settings_plugin.StartWatching();
 }
 
 }  // namespace testing


### PR DESCRIPTION
The #35019 didn't merge [SettingsPluginWin32's constructor and destructor](https://github.com/flutter/engine/blob/c4f583d1baaadaa3a65502382c4e3745d5e937d4/shell/platform/windows/settings_plugin_win32.cc#L24-L34). This PR adds them and fix SettingsPlugin to re-enable it to watch the theme changes.

This PR is part of flutter/flutter#110700.

No changes in the [flutter/tests] repo.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
