### PR TITLE
Partial revert of fractional translation changes to raster cache

### DIFF
--- a/flow/layer_snapshot_store.cc
+++ b/flow/layer_snapshot_store.cc
@@ -12,7 +12,7 @@ namespace flutter {
 LayerSnapshotData::LayerSnapshotData(int64_t layer_unique_id,
                                      const fml::TimeDelta& duration,
                                      const sk_sp<SkData>& snapshot,
-                                     const SkRect& bounds)
+                                     const SkIRect& bounds)
     : layer_unique_id_(layer_unique_id),
       duration_(duration),
       snapshot_(snapshot),

--- a/flow/layer_snapshot_store.h
+++ b/flow/layer_snapshot_store.h
@@ -26,7 +26,7 @@ class LayerSnapshotData {
   LayerSnapshotData(int64_t layer_unique_id,
                     const fml::TimeDelta& duration,
                     const sk_sp<SkData>& snapshot,
-                    const SkRect& bounds);
+                    const SkIRect& bounds);
 
   ~LayerSnapshotData() = default;
 
@@ -36,13 +36,13 @@ class LayerSnapshotData {
 
   sk_sp<SkData> GetSnapshot() const { return snapshot_; }
 
-  SkRect GetBounds() const { return bounds_; }
+  SkIRect GetBounds() const { return bounds_; }
 
  private:
   const int64_t layer_unique_id_;
   const fml::TimeDelta duration_;
   const sk_sp<SkData> snapshot_;
-  const SkRect bounds_;
+  const SkIRect bounds_;
 };
 
 /// Collects snapshots of layers during frame rasterization.

--- a/flow/layers/display_list_layer.cc
+++ b/flow/layers/display_list_layer.cc
@@ -141,7 +141,7 @@ void DisplayListLayer::Paint(PaintContext& context) const {
     const fml::TimeDelta offscreen_render_time =
         fml::TimePoint::Now() - start_time;
 
-    const SkRect device_bounds =
+    const SkIRect device_bounds =
         RasterCacheUtil::GetDeviceBounds(paint_bounds(), ctm);
     sk_sp<SkData> raster_data = offscreen_surface->GetRasterData(true);
     LayerSnapshotData snapshot_data(unique_id(), offscreen_render_time,

--- a/flow/raster_cache_util.h
+++ b/flow/raster_cache_util.h
@@ -53,8 +53,24 @@ struct RasterCacheUtil {
     SkRect device_rect;
     ctm.mapRect(&device_rect, rect);
     SkIRect bounds;
-    device_rect.roundOut(&bounds);
+    // Rather than roundOut, we first subtract the fractional portion of fLeft
+    // and fTop from fRight and fBottom. This ensures that we are more likely to
+    // round up to the nearest physical pixel in each direction instead of potentially
+    // two physical pixels in each direction.
+    auto fractionalLeft = bounds.fLeft - SkScalarFloorToInt(bounds.fLeft);
+    auto fractionalTop = bounds.fTop - SkScalarFloorToInt(bounds.fTop);
+    auto adjustedBottom = SkScalarCeilToInt(bounds.fBottom - fractionalTop);
+    auto adjustedRight = SkScalarCeilToInt(bounds.fRight - fractionalLeft);
+    bounds.setLTRB(SkScalarFloorToInt(bounds.fLeft),
+                   SkScalarFloorToInt(bounds.fTop), adjustedRight,
+                   adjustedBottom);
     return bounds;
+  }
+
+  static SkRect GetRawDeviceBounds(const SkRect& rect, const SkMatrix& ctm) {
+    SkRect device_rect;
+    ctm.mapRect(&device_rect, rect);
+    return device_rect;
   }
 };
 

--- a/flow/raster_cache_util.h
+++ b/flow/raster_cache_util.h
@@ -55,8 +55,8 @@ struct RasterCacheUtil {
     SkIRect bounds;
     // Rather than roundOut, we first subtract the fractional portion of fLeft
     // and fTop from fRight and fBottom. This ensures that we are more likely to
-    // round up to the nearest physical pixel in each direction instead of potentially
-    // two physical pixels in each direction.
+    // round up to the nearest physical pixel in each direction instead o
+    // potentially two physical pixels in each direction.
     auto fractionalLeft = bounds.fLeft - SkScalarFloorToInt(bounds.fLeft);
     auto fractionalTop = bounds.fTop - SkScalarFloorToInt(bounds.fTop);
     auto adjustedBottom = SkScalarCeilToInt(bounds.fBottom - fractionalTop);

--- a/flow/raster_cache_util.h
+++ b/flow/raster_cache_util.h
@@ -49,10 +49,12 @@ struct RasterCacheUtil {
     return true;
   }
 
-  static SkRect GetDeviceBounds(const SkRect& rect, const SkMatrix& ctm) {
+  static SkIRect GetDeviceBounds(const SkRect& rect, const SkMatrix& ctm) {
     SkRect device_rect;
     ctm.mapRect(&device_rect, rect);
-    return device_rect;
+    SkIRect bounds;
+    device_rect.roundOut(&bounds);
+    return bounds;
   }
 };
 

--- a/flow/testing/mock_raster_cache.cc
+++ b/flow/testing/mock_raster_cache.cc
@@ -16,7 +16,7 @@
 namespace flutter {
 namespace testing {
 
-MockRasterCacheResult::MockRasterCacheResult(SkRect device_rect)
+MockRasterCacheResult::MockRasterCacheResult(SkIRect device_rect)
     : RasterCacheResult(nullptr, SkRect::MakeEmpty(), "RasterCacheFlow::test"),
       device_rect_(device_rect) {}
 
@@ -40,7 +40,7 @@ void MockRasterCache::AddMockLayer(int width, int height) {
   UpdateCacheEntry(
       RasterCacheKeyID(layer.unique_id(), RasterCacheKeyType::kLayer),
       r_context, [&](SkCanvas* canvas) {
-        SkRect cache_rect = RasterCacheUtil::GetDeviceBounds(
+        SkIRect cache_rect = RasterCacheUtil::GetDeviceBounds(
             r_context.logical_rect, r_context.matrix);
         return std::make_unique<MockRasterCacheResult>(cache_rect);
       });
@@ -78,7 +78,7 @@ void MockRasterCache::AddMockPicture(int width, int height) {
   UpdateCacheEntry(RasterCacheKeyID(display_list->unique_id(),
                                     RasterCacheKeyType::kDisplayList),
                    r_context, [&](SkCanvas* canvas) {
-                     SkRect cache_rect = RasterCacheUtil::GetDeviceBounds(
+                     SkIRect cache_rect = RasterCacheUtil::GetDeviceBounds(
                          r_context.logical_rect, r_context.matrix);
                      return std::make_unique<MockRasterCacheResult>(cache_rect);
                    });

--- a/flow/testing/mock_raster_cache.h
+++ b/flow/testing/mock_raster_cache.h
@@ -29,7 +29,7 @@ namespace testing {
  */
 class MockRasterCacheResult : public RasterCacheResult {
  public:
-  explicit MockRasterCacheResult(SkRect device_rect);
+  explicit MockRasterCacheResult(SkIRect device_rect);
 
   void draw(SkCanvas& canvas, const SkPaint* paint = nullptr) const override{};
 
@@ -43,7 +43,7 @@ class MockRasterCacheResult : public RasterCacheResult {
   }
 
  private:
-  SkRect device_rect_;
+  SkIRect device_rect_;
 };
 
 static std::vector<RasterCacheItem*> raster_cache_items_;

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -1840,7 +1840,7 @@ static rapidjson::Value SerializeLayerSnapshot(
   result.AddMember("duration_micros", snapshot.GetDuration().ToMicroseconds(),
                    allocator);
 
-  const SkRect bounds = snapshot.GetBounds();
+  const SkIRect bounds = snapshot.GetBounds();
   result.AddMember("top", bounds.top(), allocator);
   result.AddMember("left", bounds.left(), allocator);
   result.AddMember("width", bounds.width(), allocator);


### PR DESCRIPTION
Revert changes to raster cache entries, which must be SkiRect to accurately represent texture size

https://github.com/flutter/flutter/issues/110957