### PR TITLE
round_out certain cache bounds

### DIFF
--- a/flow/layers/display_list_raster_cache_item.cc
+++ b/flow/layers/display_list_raster_cache_item.cc
@@ -162,7 +162,7 @@ bool DisplayListRasterCacheItem::TryToPrepareRasterCache(
       // clang-format on
   };
   return context.raster_cache->UpdateCacheEntry(
-      GetId().value(), r_context,
+      GetId().value(), true, r_context,
       [display_list = display_list_](SkCanvas* canvas) {
         display_list->RenderTo(canvas);
       });

--- a/flow/layers/layer_raster_cache_item.cc
+++ b/flow/layers/layer_raster_cache_item.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "flutter/flow/layers/layer_raster_cache_item.h"
+#include <iostream>
 #include "flutter/flow/layers/container_layer.h"
 #include "flutter/flow/raster_cache_item.h"
 

--- a/flow/layers/layer_raster_cache_item.cc
+++ b/flow/layers/layer_raster_cache_item.cc
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 #include "flutter/flow/layers/layer_raster_cache_item.h"
-#include <iostream>
 #include "flutter/flow/layers/container_layer.h"
 #include "flutter/flow/raster_cache_item.h"
 

--- a/flow/layers/layer_raster_cache_item.cc
+++ b/flow/layers/layer_raster_cache_item.cc
@@ -156,7 +156,7 @@ bool LayerRasterCacheItem::TryToPrepareRasterCache(const PaintContext& context,
           // clang-format on
       };
       return context.raster_cache->UpdateCacheEntry(
-          GetId().value(), r_context,
+          GetId().value(), false, r_context,
           [ctx = context, cache_state = cache_state_,
            layer = layer_](SkCanvas* canvas) {
             Rasterize(cache_state, layer, ctx, canvas);

--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -35,9 +35,10 @@ void RasterCacheResult::draw(SkCanvas& canvas, const SkPaint* paint) const {
   SkIRect rounded_bounds = RasterCacheUtil::GetRoundedOutDeviceBounds(
       logical_rect_, canvas.getTotalMatrix());
 #ifndef NDEBUG
-  FML_DCHECK(
-      std::abs(bounds.size().width() - image_->dimensions().width()) <= 1 &&
-      std::abs(bounds.size().height() - image_->dimensions().height()) <= 1);
+  FML_DCHECK(std::abs(rounded_bounds.size().width() -
+                      image_->dimensions().width()) <= 1 &&
+             std::abs(rounded_bounds.size().height() -
+                      image_->dimensions().height()) <= 1);
 #endif
   canvas.resetMatrix();
   flow_.Step();

--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -65,7 +65,7 @@ void RasterCacheResult::draw(SkCanvas& canvas, const SkPaint* paint) const {
       canvas.clipRect(SkRect::Make(raw_bounds.roundOut()));
     }
     canvas.drawImage(image_, raw_bounds.fLeft, raw_bounds.fTop,
-                     SkSamplingOptions(SkFilterMode::kNearest), paint);
+                     SkSamplingOptions(), paint);
 
     if (exceeds_bounds) {
       canvas.restore();

--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -34,6 +34,8 @@ void RasterCacheResult::draw(SkCanvas& canvas, const SkPaint* paint) const {
 
   SkRect bounds =
       RasterCacheUtil::GetDeviceBounds(logical_rect_, canvas.getTotalMatrix());
+  SkIRect rounded_bounds = RasterCacheUtil::GetRoundedOutDeviceBounds(
+      logical_rect_, canvas.getTotalMatrix());
 #ifndef NDEBUG
   // The image dimensions should always be larger than the device bounds and
   // smaller than the device bounds plus one pixel, at the same time, we must
@@ -59,8 +61,8 @@ void RasterCacheResult::draw(SkCanvas& canvas, const SkPaint* paint) const {
     canvas.save();
     canvas.clipRect(SkRect::Make(bounds.roundOut()));
   }
-  canvas.drawImage(image_, bounds.fLeft, bounds.fTop, SkSamplingOptions(),
-                   paint);
+  canvas.drawImage(image_, rounded_bounds.fLeft, rounded_bounds.fTop,
+                   SkSamplingOptions(), paint);
   if (exceeds_bounds) {
     canvas.restore();
   }
@@ -82,8 +84,6 @@ std::unique_ptr<RasterCacheResult> RasterCache::Rasterize(
 
   SkIRect dest_rect = RasterCacheUtil::GetRoundedOutDeviceBounds(
       context.logical_rect, context.matrix);
-  ;
-
   const SkImageInfo image_info =
       SkImageInfo::MakeN32Premul(dest_rect.width(), dest_rect.height(),
                                  sk_ref_sp(context.dst_color_space));

--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -80,14 +80,13 @@ std::unique_ptr<RasterCacheResult> RasterCache::Rasterize(
     const {
   TRACE_EVENT0("flutter", "RasterCachePopulate");
 
-  SkRect dest_rect =
-      RasterCacheUtil::GetDeviceBounds(context.logical_rect, context.matrix);
-  // we always round out here so that the texture is integer sized.
-  int width = SkScalarCeilToInt(dest_rect.width());
-  int height = SkScalarCeilToInt(dest_rect.height());
+  SkIRect dest_rect = RasterCacheUtil::GetRoundedOutDeviceBounds(
+      context.logical_rect, context.matrix);
+  ;
 
-  const SkImageInfo image_info = SkImageInfo::MakeN32Premul(
-      width, height, sk_ref_sp(context.dst_color_space));
+  const SkImageInfo image_info =
+      SkImageInfo::MakeN32Premul(dest_rect.width(), dest_rect.height(),
+                                 sk_ref_sp(context.dst_color_space));
 
   sk_sp<SkSurface> surface =
       context.gr_context ? SkSurface::MakeRenderTarget(

--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -35,16 +35,8 @@ void RasterCacheResult::draw(SkCanvas& canvas, const SkPaint* paint) const {
   SkIRect rounded_bounds = RasterCacheUtil::GetRoundedOutDeviceBounds(
       logical_rect_, canvas.getTotalMatrix());
 #ifndef NDEBUG
-  // The image dimensions should always be larger than the device bounds and
-  // smaller than the device bounds plus one pixel, at the same time, we must
-  // introduce epsilon to solve the round-off error. The value of epsilon is
-  // 1/512, which represents half of an AA sample.
-  float epsilon = 1 / 512.0;
-  FML_DCHECK(
-      image_->dimensions().width() - rounded_bounds.width() > -epsilon &&
-      image_->dimensions().height() - rounded_bounds.height() > -epsilon &&
-      image_->dimensions().width() - rounded_bounds.width() < 1 + epsilon &&
-      image_->dimensions().height() - rounded_bounds.height() < 1 + epsilon);
+  FML_DCHECK(image_->dimensions().width() == rounded_bounds.width() &&
+             image_->dimensions().height() == rounded_bounds.height());
 #endif
   canvas.resetMatrix();
   flow_.Step();

--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -35,8 +35,9 @@ void RasterCacheResult::draw(SkCanvas& canvas, const SkPaint* paint) const {
   SkIRect rounded_bounds = RasterCacheUtil::GetRoundedOutDeviceBounds(
       logical_rect_, canvas.getTotalMatrix());
 #ifndef NDEBUG
-  FML_DCHECK(image_->dimensions().width() == rounded_bounds.width() &&
-             image_->dimensions().height() == rounded_bounds.height());
+  FML_DCHECK(
+      std::abs(bounds.size().width() - image_->dimensions().width()) <= 1 &&
+      std::abs(bounds.size().height() - image_->dimensions().height()) <= 1);
 #endif
   canvas.resetMatrix();
   flow_.Step();

--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -49,23 +49,8 @@ void RasterCacheResult::draw(SkCanvas& canvas, const SkPaint* paint) const {
   canvas.resetMatrix();
   flow_.Step();
 
-  bool exceeds_bounds = rounded_bounds.fLeft + image_->dimensions().width() >
-                            SkScalarCeilToScalar(rounded_bounds.fRight) ||
-                        rounded_bounds.fTop + image_->dimensions().height() >
-                            SkScalarCeilToScalar(rounded_bounds.fBottom);
-
-  // Make sure raster cache doesn't bleed to physical pixels outside of
-  // original bounds. https://github.com/flutter/flutter/issues/110002
-  if (exceeds_bounds) {
-    canvas.save();
-    canvas.clipRect(SkRect::Make(rounded_bounds));
-  }
-
   canvas.drawImage(image_, rounded_bounds.fLeft, rounded_bounds.fTop,
                    SkSamplingOptions(), paint);
-  if (exceeds_bounds) {
-    canvas.restore();
-  }
 }
 
 RasterCache::RasterCache(size_t access_threshold,

--- a/flow/raster_cache.h
+++ b/flow/raster_cache.h
@@ -31,6 +31,7 @@ class RasterCacheResult {
  public:
   RasterCacheResult(sk_sp<SkImage> image,
                     const SkRect& logical_rect,
+                    const SkPoint& texture_edge,
                     const char* type);
 
   virtual ~RasterCacheResult() = default;
@@ -48,6 +49,8 @@ class RasterCacheResult {
  private:
   sk_sp<SkImage> image_;
   SkRect logical_rect_;
+  // TBD: what to do with this. Find example where texture still jumps
+  SkPoint texture_edge_;
   fml::tracing::TraceFlow flow_;
 };
 

--- a/flow/raster_cache.h
+++ b/flow/raster_cache.h
@@ -31,7 +31,6 @@ class RasterCacheResult {
  public:
   RasterCacheResult(sk_sp<SkImage> image,
                     const SkRect& logical_rect,
-                    const SkPoint& texture_edge,
                     const char* type);
 
   virtual ~RasterCacheResult() = default;
@@ -49,8 +48,6 @@ class RasterCacheResult {
  private:
   sk_sp<SkImage> image_;
   SkRect logical_rect_;
-  // TBD: what to do with this. Find example where texture still jumps
-  SkPoint texture_edge_;
   fml::tracing::TraceFlow flow_;
 };
 

--- a/flow/raster_cache.h
+++ b/flow/raster_cache.h
@@ -31,6 +31,7 @@ class RasterCacheResult {
  public:
   RasterCacheResult(sk_sp<SkImage> image,
                     const SkRect& logical_rect,
+                    bool align_image,
                     const char* type);
 
   virtual ~RasterCacheResult() = default;
@@ -48,6 +49,7 @@ class RasterCacheResult {
  private:
   sk_sp<SkImage> image_;
   SkRect logical_rect_;
+  bool align_image_;
   fml::tracing::TraceFlow flow_;
 };
 
@@ -124,6 +126,7 @@ class RasterCache {
 
   std::unique_ptr<RasterCacheResult> Rasterize(
       const RasterCache::Context& context,
+      bool align_image,
       const std::function<void(SkCanvas*)>& draw_function,
       const std::function<void(SkCanvas*, const SkRect& rect)>&
           draw_checkerboard) const;
@@ -233,6 +236,7 @@ class RasterCache {
 
   bool UpdateCacheEntry(
       const RasterCacheKeyID& id,
+      bool align_image,
       const Context& raster_cache_context,
       const std::function<void(SkCanvas*)>& render_function) const;
 

--- a/flow/raster_cache_unittests.cc
+++ b/flow/raster_cache_unittests.cc
@@ -159,11 +159,11 @@ TEST(RasterCache, SetCheckboardCacheImages) {
   };
 
   cache.SetCheckboardCacheImages(false);
-  cache.Rasterize(r_context, dummy_draw_function, draw_checkerboard);
+  cache.Rasterize(r_context, true, dummy_draw_function, draw_checkerboard);
   ASSERT_FALSE(did_draw_checkerboard);
 
   cache.SetCheckboardCacheImages(true);
-  cache.Rasterize(r_context, dummy_draw_function, draw_checkerboard);
+  cache.Rasterize(r_context, true, dummy_draw_function, draw_checkerboard);
   ASSERT_TRUE(did_draw_checkerboard);
 }
 
@@ -797,8 +797,8 @@ TEST_F(RasterCacheTest, RasterCacheBleedingNoClipNeeded) {
   canvas.setMatrix(SkMatrix::Scale(2, 2));
   // Drawing cached image does not exceeds physical pixels of the original
   // bounds and does not need to be clipped.
-  auto cache_result =
-      RasterCacheResult(image, SkRect::MakeXYWH(100.3, 100.3, 20, 20), "");
+  auto cache_result = RasterCacheResult(
+      image, SkRect::MakeXYWH(100.3, 100.3, 20, 20), true, "");
   auto paint = SkPaint();
   cache_result.draw(canvas, &paint);
 
@@ -824,8 +824,8 @@ TEST_F(RasterCacheTest, RasterCacheBleedingClipStillNotNeeded) {
   auto canvas = MockCanvas();
   canvas.setMatrix(SkMatrix::Scale(2, 2));
 
-  auto cache_result =
-      RasterCacheResult(image, SkRect::MakeXYWH(100.3, 100.3, 19.6, 19.6), "");
+  auto cache_result = RasterCacheResult(
+      image, SkRect::MakeXYWH(100.3, 100.3, 19.6, 19.6), true, "");
   auto paint = SkPaint();
   cache_result.draw(canvas, &paint);
 

--- a/flow/raster_cache_unittests.cc
+++ b/flow/raster_cache_unittests.cc
@@ -797,8 +797,8 @@ TEST_F(RasterCacheTest, RasterCacheBleedingNoClipNeeded) {
   canvas.setMatrix(SkMatrix::Scale(2, 2));
   // Drawing cached image does not exceeds physical pixels of the original
   // bounds and does not need to be clipped.
-  auto cache_result =
-      RasterCacheResult(image, SkRect::MakeXYWH(100.3, 100.3, 20, 20), "");
+  auto cache_result = RasterCacheResult(
+      image, SkRect::MakeXYWH(100.3, 100.3, 20, 20), SkPoint::Make(0, 0), "");
   auto paint = SkPaint();
   cache_result.draw(canvas, &paint);
 
@@ -825,7 +825,8 @@ TEST_F(RasterCacheTest, RasterCacheBleedingClipNeeded) {
   canvas.setMatrix(SkMatrix::Scale(2, 2));
 
   auto cache_result =
-      RasterCacheResult(image, SkRect::MakeXYWH(100.3, 100.3, 19.6, 19.6), "");
+      RasterCacheResult(image, SkRect::MakeXYWH(100.3, 100.3, 19.6, 19.6),
+                        SkPoint::Make(0, 0), "");
   auto paint = SkPaint();
   cache_result.draw(canvas, &paint);
 

--- a/flow/raster_cache_unittests.cc
+++ b/flow/raster_cache_unittests.cc
@@ -797,8 +797,8 @@ TEST_F(RasterCacheTest, RasterCacheBleedingNoClipNeeded) {
   canvas.setMatrix(SkMatrix::Scale(2, 2));
   // Drawing cached image does not exceeds physical pixels of the original
   // bounds and does not need to be clipped.
-  auto cache_result = RasterCacheResult(
-      image, SkRect::MakeXYWH(100.3, 100.3, 20, 20), SkPoint::Make(0, 0), "");
+  auto cache_result =
+      RasterCacheResult(image, SkRect::MakeXYWH(100.3, 100.3, 20, 20), "");
   auto paint = SkPaint();
   cache_result.draw(canvas, &paint);
 
@@ -825,8 +825,7 @@ TEST_F(RasterCacheTest, RasterCacheBleedingClipNeeded) {
   canvas.setMatrix(SkMatrix::Scale(2, 2));
 
   auto cache_result =
-      RasterCacheResult(image, SkRect::MakeXYWH(100.3, 100.3, 19.6, 19.6),
-                        SkPoint::Make(0, 0), "");
+      RasterCacheResult(image, SkRect::MakeXYWH(100.3, 100.3, 19.6, 19.6), "");
   auto paint = SkPaint();
   cache_result.draw(canvas, &paint);
 

--- a/flow/raster_cache_unittests.cc
+++ b/flow/raster_cache_unittests.cc
@@ -809,13 +809,13 @@ TEST_F(RasterCacheTest, RasterCacheBleedingNoClipNeeded) {
                 MockCanvas::DrawCall{0, MockCanvas::SaveData{1}},
                 MockCanvas::DrawCall{1, MockCanvas::SetMatrixData{SkM44()}},
                 MockCanvas::DrawCall{
-                    1, MockCanvas::DrawImageData{image, 200.6, 200.6,
+                    1, MockCanvas::DrawImageData{image, 200, 200,
                                                  SkSamplingOptions(), paint}},
                 MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}},
             }));
 }
 
-TEST_F(RasterCacheTest, RasterCacheBleedingClipNeeded) {
+TEST_F(RasterCacheTest, RasterCacheBleedingClipStillNotNeeded) {
   SkImageInfo info =
       SkImageInfo::MakeN32(40, 40, SkAlphaType::kOpaque_SkAlphaType);
 
@@ -829,24 +829,17 @@ TEST_F(RasterCacheTest, RasterCacheBleedingClipNeeded) {
   auto paint = SkPaint();
   cache_result.draw(canvas, &paint);
 
-  EXPECT_EQ(
-      canvas.draw_calls(),
-      std::vector({
-          MockCanvas::DrawCall{0,
-                               MockCanvas::SetMatrixData{SkM44::Scale(2, 2)}},
-          MockCanvas::DrawCall{0, MockCanvas::SaveData{1}},
-          MockCanvas::DrawCall{1, MockCanvas::SetMatrixData{SkM44()}},
-          MockCanvas::DrawCall{1, MockCanvas::SaveData{2}},
-          MockCanvas::DrawCall{
-              2, MockCanvas::ClipRectData{SkRect::MakeLTRB(200, 200, 240, 240),
-                                          SkClipOp::kIntersect,
-                                          MockCanvas::kHard_ClipEdgeStyle}},
-          MockCanvas::DrawCall{
-              2, MockCanvas::DrawImageData{image, 200.6, 200.6,
-                                           SkSamplingOptions(), paint}},
-          MockCanvas::DrawCall{2, MockCanvas::RestoreData{1}},
-          MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}},
-      }));
+  EXPECT_EQ(canvas.draw_calls(),
+            std::vector({
+                MockCanvas::DrawCall{
+                    0, MockCanvas::SetMatrixData{SkM44::Scale(2, 2)}},
+                MockCanvas::DrawCall{0, MockCanvas::SaveData{1}},
+                MockCanvas::DrawCall{1, MockCanvas::SetMatrixData{SkM44()}},
+                MockCanvas::DrawCall{
+                    1, MockCanvas::DrawImageData{image, 200, 200,
+                                                 SkSamplingOptions(), paint}},
+                MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}},
+            }));
 }
 
 }  // namespace testing

--- a/flow/raster_cache_util.h
+++ b/flow/raster_cache_util.h
@@ -54,6 +54,24 @@ struct RasterCacheUtil {
     ctm.mapRect(&device_rect, rect);
     return device_rect;
   }
+
+  static SkIRect GetRoundedOutDeviceBounds(const SkRect& rect, const SkMatrix& ctm) {
+    SkRect device_rect;
+    ctm.mapRect(&device_rect, rect);
+    SkIRect bounds;
+    // Rather than roundOut, we first subtract the fractional portion of fLeft
+    // and fTop from fRight and fBottom. This ensures that we are more likely to
+    // round up to the nearest physical pixel in each direction instead o
+    // potentially two physical pixels in each direction.
+    auto fractionalLeft = bounds.fLeft - SkScalarFloorToInt(bounds.fLeft);
+    auto fractionalTop = bounds.fTop - SkScalarFloorToInt(bounds.fTop);
+    auto adjustedBottom = SkScalarCeilToInt(bounds.fBottom - fractionalTop);
+    auto adjustedRight = SkScalarCeilToInt(bounds.fRight - fractionalLeft);
+    bounds.setLTRB(SkScalarFloorToInt(bounds.fLeft),
+                   SkScalarFloorToInt(bounds.fTop), adjustedRight,
+                   adjustedBottom);
+    return bounds;
+  }
 };
 
 }  // namespace flutter

--- a/flow/raster_cache_util.h
+++ b/flow/raster_cache_util.h
@@ -63,6 +63,27 @@ struct RasterCacheUtil {
     device_rect.roundOut(&bounds);
     return bounds;
   }
+
+  /**
+   * @brief Snap the translation components of the matrix to integers.
+   *
+   * The snapping will only happen if the matrix only has scale and translation
+   * transformations.
+   *
+   * @param ctm the current transformation matrix.
+   * @return SkMatrix the snapped transformation matrix.
+   */
+  static SkMatrix GetIntegralTransCTM(const SkMatrix& ctm) {
+    // Avoid integral snapping if the matrix has complex transformation to avoid
+    // the artifact observed in https://github.com/flutter/flutter/issues/41654.
+    if (!ctm.isScaleTranslate()) {
+      return ctm;
+    }
+    SkMatrix result = ctm;
+    result[SkMatrix::kMTransX] = SkScalarRoundToScalar(ctm.getTranslateX());
+    result[SkMatrix::kMTransY] = SkScalarRoundToScalar(ctm.getTranslateY());
+    return result;
+  }
 };
 
 }  // namespace flutter

--- a/flow/raster_cache_util.h
+++ b/flow/raster_cache_util.h
@@ -55,21 +55,12 @@ struct RasterCacheUtil {
     return device_rect;
   }
 
-  static SkIRect GetRoundedOutDeviceBounds(const SkRect& rect, const SkMatrix& ctm) {
+  static SkIRect GetRoundedOutDeviceBounds(const SkRect& rect,
+                                           const SkMatrix& ctm) {
     SkRect device_rect;
     ctm.mapRect(&device_rect, rect);
     SkIRect bounds;
-    // Rather than roundOut, we first subtract the fractional portion of fLeft
-    // and fTop from fRight and fBottom. This ensures that we are more likely to
-    // round up to the nearest physical pixel in each direction instead o
-    // potentially two physical pixels in each direction.
-    auto fractionalLeft = bounds.fLeft - SkScalarFloorToInt(bounds.fLeft);
-    auto fractionalTop = bounds.fTop - SkScalarFloorToInt(bounds.fTop);
-    auto adjustedBottom = SkScalarCeilToInt(bounds.fBottom - fractionalTop);
-    auto adjustedRight = SkScalarCeilToInt(bounds.fRight - fractionalLeft);
-    bounds.setLTRB(SkScalarFloorToInt(bounds.fLeft),
-                   SkScalarFloorToInt(bounds.fTop), adjustedRight,
-                   adjustedBottom);
+    device_rect.roundOut(&bounds);
     return bounds;
   }
 };

--- a/flow/testing/mock_raster_cache.cc
+++ b/flow/testing/mock_raster_cache.cc
@@ -17,7 +17,10 @@ namespace flutter {
 namespace testing {
 
 MockRasterCacheResult::MockRasterCacheResult(SkRect device_rect)
-    : RasterCacheResult(nullptr, SkRect::MakeEmpty(), "RasterCacheFlow::test"),
+    : RasterCacheResult(nullptr,
+                        SkRect::MakeEmpty(),
+                        false,
+                        "RasterCacheFlow::test"),
       device_rect_(device_rect) {}
 
 void MockRasterCache::AddMockLayer(int width, int height) {
@@ -39,7 +42,7 @@ void MockRasterCache::AddMockLayer(int width, int height) {
   };
   UpdateCacheEntry(
       RasterCacheKeyID(layer.unique_id(), RasterCacheKeyType::kLayer),
-      r_context, [&](SkCanvas* canvas) {
+      false, r_context, [&](SkCanvas* canvas) {
         SkRect cache_rect = RasterCacheUtil::GetDeviceBounds(
             r_context.logical_rect, r_context.matrix);
         return std::make_unique<MockRasterCacheResult>(cache_rect);
@@ -77,7 +80,7 @@ void MockRasterCache::AddMockPicture(int width, int height) {
   };
   UpdateCacheEntry(RasterCacheKeyID(display_list->unique_id(),
                                     RasterCacheKeyType::kDisplayList),
-                   r_context, [&](SkCanvas* canvas) {
+                   false, r_context, [&](SkCanvas* canvas) {
                      SkRect cache_rect = RasterCacheUtil::GetDeviceBounds(
                          r_context.logical_rect, r_context.matrix);
                      return std::make_unique<MockRasterCacheResult>(cache_rect);

--- a/flow/testing/mock_raster_cache.cc
+++ b/flow/testing/mock_raster_cache.cc
@@ -17,7 +17,10 @@ namespace flutter {
 namespace testing {
 
 MockRasterCacheResult::MockRasterCacheResult(SkRect device_rect)
-    : RasterCacheResult(nullptr, SkRect::MakeEmpty(), "RasterCacheFlow::test"),
+    : RasterCacheResult(nullptr,
+                        SkRect::MakeEmpty(),
+                        SkPoint::Make(0, 0),
+                        "RasterCacheFlow::test"),
       device_rect_(device_rect) {}
 
 void MockRasterCache::AddMockLayer(int width, int height) {

--- a/flow/testing/mock_raster_cache.cc
+++ b/flow/testing/mock_raster_cache.cc
@@ -17,10 +17,7 @@ namespace flutter {
 namespace testing {
 
 MockRasterCacheResult::MockRasterCacheResult(SkRect device_rect)
-    : RasterCacheResult(nullptr,
-                        SkRect::MakeEmpty(),
-                        SkPoint::Make(0, 0),
-                        "RasterCacheFlow::test"),
+    : RasterCacheResult(nullptr, SkRect::MakeEmpty(), "RasterCacheFlow::test"),
       device_rect_(device_rect) {}
 
 void MockRasterCache::AddMockLayer(int width, int height) {


### PR DESCRIPTION
This fixes the worst of the pixel jumping issues, though issues with raster cached/animated display list layers are still present.

Fixes https://github.com/flutter/flutter/issues/110959
Fixes https://github.com/flutter/flutter/issues/110957

Previously I computed the bounds using the logical rect, and rounded up to get a texture size. To create the texture for the raster cache entry, we first appended a translation which attempted to position the origin of the display_list/layer at (0,0). This led to a number of issues I did not anticipate, and had difficulty observing on mobile devices with high device pixel ratios.

For display list raster cache entries, this would lead to the raster cached entry being drawn differently than the non-raster cached entry. This is fixed by this PR, by rounding out the bounds.

This does not appear to fix the issue with layer raster caching.