### PR TITLE
Add relative directory support to symbols validation script.

### DIFF
--- a/testing/symbols/verify_exported.dart
+++ b/testing/symbols/verify_exported.dart
@@ -120,7 +120,7 @@ int _checkAndroid(String outPath, String nmPath, Iterable<String> builds) {
     final Iterable<NmEntry> entries = NmEntry.parse(nmResult.stdout as String);
     final Map<String, String> entryMap = <String, String>{
       for (final NmEntry entry in entries)
-	entry.name: entry.type,
+        entry.name: entry.type,
     };
     final Map<String, String> expectedSymbols = <String, String>{
       'JNI_OnLoad': 'T',

--- a/testing/symbols/verify_exported.dart
+++ b/testing/symbols/verify_exported.dart
@@ -32,7 +32,8 @@ void main(List<String> arguments) {
   if (p.isRelative(outPath)) {
     /// If path is relative then create a full path starting from the engine checkout
     /// repository.
-    outPath = p.join(p.dirname(Platform.script.toFilePath()), '..', '..', '..', outPath);
+    final String engineCheckoutPath = Platform.environment['ENGINE_CHECKOUT_PATH']!;
+    outPath = p.join(engineCheckoutPath, outPath);
   }
   final String buildToolsPath = arguments.length == 1
       ? p.join(p.dirname(outPath), 'buildtools')

--- a/testing/symbols/verify_exported.dart
+++ b/testing/symbols/verify_exported.dart
@@ -34,7 +34,9 @@ void main(List<String> arguments) {
     /// repository.
     outPath = p.join(p.dirname(Platform.script.toFilePath()), '..', '..', '..', outPath);
   }
-  final String buildToolsPath = arguments.length == 1 ? p.join(p.dirname(outPath), 'buildtools') : arguments[1];
+  final String buildToolsPath = arguments.length == 1
+      ? p.join(p.dirname(outPath), 'buildtools')
+      : arguments[1];
 
   String platform;
   if (Platform.isLinux) {
@@ -50,14 +52,15 @@ void main(List<String> arguments) {
     exit(1);
   }
 
-  final Iterable<String> releaseBuilds = Directory(outPath)
-      .listSync()
+  final Iterable<String> releaseBuilds = Directory(outPath).listSync()
       .whereType<Directory>()
       .map<String>((FileSystemEntity dir) => p.basename(dir.path))
       .where((String s) => s.contains('_release'));
 
-  final Iterable<String> iosReleaseBuilds = releaseBuilds.where((String s) => s.startsWith('ios_'));
-  final Iterable<String> androidReleaseBuilds = releaseBuilds.where((String s) => s.startsWith('android_'));
+  final Iterable<String> iosReleaseBuilds = releaseBuilds
+      .where((String s) => s.startsWith('ios_'));
+  final Iterable<String> androidReleaseBuilds = releaseBuilds
+      .where((String s) => s.startsWith('android_'));
 
   int failures = 0;
   failures += _checkIos(outPath, nmPath, iosReleaseBuilds);
@@ -116,7 +119,8 @@ int _checkAndroid(String outPath, String nmPath, Iterable<String> builds) {
     }
     final Iterable<NmEntry> entries = NmEntry.parse(nmResult.stdout as String);
     final Map<String, String> entryMap = <String, String>{
-      for (final NmEntry entry in entries) entry.name: entry.type,
+      for (final NmEntry entry in entries)
+	entry.name: entry.type,
     };
     final Map<String, String> expectedSymbols = <String, String>{
       'JNI_OnLoad': 'T',

--- a/testing/symbols/verify_exported.dart
+++ b/testing/symbols/verify_exported.dart
@@ -32,6 +32,10 @@ void main(List<String> arguments) {
   if (p.isRelative(outPath)) {
     /// If path is relative then create a full path starting from the engine checkout
     /// repository.
+    if (!Platform.environment.containsKey('ENGINE_CHECKOUT_PATH')) {
+      print('ENGINE_CHECKOUT_PATH env variable is mandatory when using relative destination path');
+      exit(1);
+    }
     final String engineCheckoutPath = Platform.environment['ENGINE_CHECKOUT_PATH']!;
     outPath = p.join(engineCheckoutPath, outPath);
   }


### PR DESCRIPTION
This is to be able to run the validation from the recipes v2.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
