### PR TITLE
[Impeller] Make 'MorphologyFilterContents' use 'effect_transform'

### DIFF
--- a/impeller/display_list/display_list_dispatcher.cc
+++ b/impeller/display_list/display_list_dispatcher.cc
@@ -546,7 +546,8 @@ static std::optional<Paint::ImageFilterProc> ToImageFilterProc(
       return [radius_x, radius_y](FilterInput::Ref input,
                                   const Matrix& effect_transform) {
         return FilterContents::MakeMorphology(
-            input, radius_x, radius_y, FilterContents::MorphType::kDilate);
+            input, radius_x, radius_y, FilterContents::MorphType::kDilate,
+            effect_transform);
       };
       break;
     }
@@ -560,8 +561,9 @@ static std::optional<Paint::ImageFilterProc> ToImageFilterProc(
       auto radius_y = Radius(erode->radius_y());
       return [radius_x, radius_y](FilterInput::Ref input,
                                   const Matrix& effect_transform) {
-        return FilterContents::MakeMorphology(
-            input, radius_x, radius_y, FilterContents::MorphType::kErode);
+        return FilterContents::MakeMorphology(input, radius_x, radius_y,
+                                              FilterContents::MorphType::kErode,
+                                              effect_transform);
       };
       break;
     }

--- a/impeller/entity/contents/filters/filter_contents.cc
+++ b/impeller/entity/contents/filters/filter_contents.cc
@@ -128,12 +128,14 @@ std::shared_ptr<FilterContents> FilterContents::MakeDirectionalMorphology(
     FilterInput::Ref input,
     Radius radius,
     Vector2 direction,
-    MorphType morph_type) {
+    MorphType morph_type,
+    const Matrix& effect_transform) {
   auto filter = std::make_shared<DirectionalMorphologyFilterContents>();
   filter->SetInputs({input});
   filter->SetRadius(radius);
   filter->SetDirection(direction);
   filter->SetMorphType(morph_type);
+  filter->SetEffectTransform(effect_transform);
   return filter;
 }
 
@@ -141,11 +143,13 @@ std::shared_ptr<FilterContents> FilterContents::MakeMorphology(
     FilterInput::Ref input,
     Radius radius_x,
     Radius radius_y,
-    MorphType morph_type) {
-  auto x_morphology =
-      MakeDirectionalMorphology(input, radius_x, Point(1, 0), morph_type);
-  auto y_morphology = MakeDirectionalMorphology(
-      FilterInput::Make(x_morphology), radius_y, Point(0, 1), morph_type);
+    MorphType morph_type,
+    const Matrix& effect_transform) {
+  auto x_morphology = MakeDirectionalMorphology(input, radius_x, Point(1, 0),
+                                                morph_type, effect_transform);
+  auto y_morphology =
+      MakeDirectionalMorphology(FilterInput::Make(x_morphology), radius_y,
+                                Point(0, 1), morph_type, effect_transform);
   return y_morphology;
 }
 

--- a/impeller/entity/contents/filters/filter_contents.h
+++ b/impeller/entity/contents/filters/filter_contents.h
@@ -70,12 +70,15 @@ class FilterContents : public Contents {
       FilterInput::Ref input,
       Radius radius,
       Vector2 direction,
-      MorphType morph_type);
+      MorphType morph_type,
+      const Matrix& effect_transform = Matrix());
 
-  static std::shared_ptr<FilterContents> MakeMorphology(FilterInput::Ref input,
-                                                        Radius radius_x,
-                                                        Radius radius_y,
-                                                        MorphType morph_type);
+  static std::shared_ptr<FilterContents> MakeMorphology(
+      FilterInput::Ref input,
+      Radius radius_x,
+      Radius radius_y,
+      MorphType morph_type,
+      const Matrix& effect_transform = Matrix());
 
   static std::shared_ptr<FilterContents> MakeColorMatrix(
       FilterInput::Ref input,

--- a/impeller/entity/contents/filters/morphology_filter_contents.cc
+++ b/impeller/entity/contents/filters/morphology_filter_contents.cc
@@ -88,9 +88,9 @@ std::optional<Snapshot> DirectionalMorphologyFilterContents::RenderFilter(
 
     VS::FrameInfo frame_info;
     frame_info.mvp = Matrix::MakeOrthographic(ISize(1, 1));
-
-    auto transformed_radius = entity.GetTransformation().TransformDirection(
-        direction_ * radius_.radius);
+    auto transform = entity.GetTransformation() * effect_transform;
+    auto transformed_radius =
+        transform.TransformDirection(direction_ * radius_.radius);
     auto transformed_texture_vertices =
         Rect(Size(input_snapshot->texture->GetSize()))
             .GetTransformedPoints(input_snapshot->transform);
@@ -156,11 +156,9 @@ std::optional<Rect> DirectionalMorphologyFilterContents::GetFilterCoverage(
   if (!coverage.has_value()) {
     return std::nullopt;
   }
-
-  auto transformed_vector = inputs[0]
-                                ->GetTransform(entity)
-                                .TransformDirection(direction_ * radius_.radius)
-                                .Abs();
+  auto transform = inputs[0]->GetTransform(entity) * effect_transform;
+  auto transformed_vector =
+      transform.TransformDirection(direction_ * radius_.radius).Abs();
 
   auto extent = coverage->size + transformed_vector * 2;
   return Rect(coverage->origin - transformed_vector, Size(extent.x, extent.y));

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -1018,6 +1018,7 @@ TEST_P(EntityTest, MorphologyFilter) {
     static float path_rect[4] = {0, 0,
                                  static_cast<float>(boston->GetSize().width),
                                  static_cast<float>(boston->GetSize().height)};
+    static float effect_transform_scale = 1;
 
     ImGui::Begin("Controls", nullptr, ImGuiWindowFlags_AlwaysAutoResize);
     {
@@ -1035,6 +1036,8 @@ TEST_P(EntityTest, MorphologyFilter) {
       ImGui::SliderFloat2("Scale", scale, 0, 3);
       ImGui::SliderFloat2("Skew", skew, -3, 3);
       ImGui::SliderFloat4("Path XYWH", path_rect, -1000, 1000);
+      ImGui::SliderFloat("Effect transform scale", &effect_transform_scale, 0,
+                         3);
     }
     ImGui::End();
 
@@ -1052,9 +1055,12 @@ TEST_P(EntityTest, MorphologyFilter) {
     input = texture;
     input_size = input_rect.size;
 
+    auto effect_transform = Matrix::MakeScale(
+        Vector2{effect_transform_scale, effect_transform_scale});
+
     auto contents = FilterContents::MakeMorphology(
         FilterInput::Make(input), Radius{radius[0]}, Radius{radius[1]},
-        morphology_types[selected_morphology_type]);
+        morphology_types[selected_morphology_type], effect_transform);
 
     auto ctm = Matrix::MakeScale(GetContentScale()) *
                Matrix::MakeTranslation(Vector3(offset[0], offset[1])) *


### PR DESCRIPTION
Like 'GaussianBlurContents', 'MorphologyFilterContents' also needs to use 'effect_transform', otherwise the result of 'transformed_radius' will be calculated incorrectly


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
