### PR TITLE
Fixed visibility of embedded views in safari (google map, video, camera preview etc)

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
@@ -322,6 +322,11 @@ class HtmlViewEmbedder {
           clipView.style.clipPath = '';
           headTransform = Matrix4.identity();
           clipView.style.transform = '';
+          // We need to set width and height for the clipView to cover the
+          // bounds of the path since Safari seem to incorrectly intersect
+          // the  element bounding rect with the clip path.
+          clipView.style.width = '100%';
+          clipView.style.height = '100%';
           if (mutator.rect != null) {
             final ui.Rect rect = mutator.rect!;
             clipView.style.clip = 'rect(${rect.top}px, ${rect.right}px, '

--- a/lib/web_ui/test/canvaskit/embedded_views_test.dart
+++ b/lib/web_ui/test/canvaskit/embedded_views_test.dart
@@ -95,6 +95,22 @@ void testMain() {
             .clipPath,
         'url("#svgClip1")',
       );
+      expect(
+        flutterViewEmbedder.sceneElement!
+            .querySelectorAll('flt-clip')
+            .single
+            .style
+            .width,
+        '100%',
+      );
+      expect(
+        flutterViewEmbedder.sceneElement!
+            .querySelectorAll('flt-clip')
+            .single
+            .style
+            .height,
+        '100%',
+      );
     });
 
     test('correctly transforms platform views', () async {


### PR DESCRIPTION
We need to set width and height for the clipView to cover the bounds of the path since browsers such as Safari and Edge seem to incorrectly intersect the element bounding rect with the clip path. Chrome and Firefox don't perform intersect instead they use the path itself as source of truth.

https://github.com/flutter/flutter/issues/80401#issuecomment-1235806829
https://github.com/flutter/flutter/issues/93241
https://github.com/flutter/flutter/issues/91805

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
