### PR TITLE
Remove unnecessary include of private Skia header

### DIFF
--- a/lib/ui/painting/image_generator_registry.cc
+++ b/lib/ui/painting/image_generator_registry.cc
@@ -7,7 +7,6 @@
 #include "flutter/lib/ui/painting/image_generator_registry.h"
 #include "third_party/skia/include/codec/SkCodec.h"
 #include "third_party/skia/include/core/SkImageGenerator.h"
-#include "third_party/skia/src/codec/SkCodecImageGenerator.h"
 #ifdef FML_OS_MACOSX
 #include "third_party/skia/include/ports/SkImageGeneratorCG.h"
 #elif FML_OS_WIN


### PR DESCRIPTION
`src/codec/SkCodecImageGenerator.h` is a private Skia header and should not be directly included. It appears this include is innocuous, as the private types are not (no longer?) used. However, this include may cause an issue when flutter_engine is rolled into G3.

## Pre-launch Checklist

- [ x ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ x ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ x ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ x ] I signed the [CLA].
- [ ] All existing and new tests are passing.