### PR TITLE
Try to deflake service isolate startup

### DIFF
--- a/runtime/dart_service_isolate.cc
+++ b/runtime/dart_service_isolate.cc
@@ -157,18 +157,6 @@ bool DartServiceIsolate::Startup(std::string server_ip,
   result = Dart_SetNativeResolver(library, GetNativeFunction, GetSymbol);
   SHUTDOWN_ON_ERROR(result);
 
-  // Make runnable.
-  Dart_ExitScope();
-  Dart_ExitIsolate();
-  *error = Dart_IsolateMakeRunnable(isolate);
-  if (*error) {
-    Dart_EnterIsolate(isolate);
-    Dart_ShutdownIsolate();
-    return false;
-  }
-  Dart_EnterIsolate(isolate);
-  Dart_EnterScope();
-
   library = Dart_RootLibrary();
   SHUTDOWN_ON_ERROR(library);
 
@@ -202,6 +190,19 @@ bool DartServiceIsolate::Startup(std::string server_ip,
       library, Dart_NewStringFromCString("_enableServicePortFallback"),
       Dart_NewBoolean(enable_service_port_fallback));
   SHUTDOWN_ON_ERROR(result);
+
+  // Make runnable.
+  Dart_ExitScope();
+  Dart_ExitIsolate();
+  *error = Dart_IsolateMakeRunnable(isolate);
+  if (*error) {
+    Dart_EnterIsolate(isolate);
+    Dart_ShutdownIsolate();
+    return false;
+  }
+  Dart_EnterIsolate(isolate);
+  Dart_EnterScope();
+
   return true;
 }
 


### PR DESCRIPTION
Speculative fix for https://github.com/flutter/flutter/issues/106753

Re-orders the call to making the isolate runnable to the end, after we set the private fields.

Tested this locally and it seems to work fine, but I had not reproduced the flake locally.