### PR TITLE
Remove noisy log from startup

### DIFF
--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -132,12 +132,6 @@ static bool IsOpenGLRendererConfigValid(const FlutterRendererConfig* config) {
     return false;
   }
 
-  if (!SAFE_EXISTS(open_gl_config, populate_existing_damage)) {
-    FML_LOG(INFO) << "populate_existing_damage was not defined, disabling "
-                     "partial repaint. If you wish to enable partial repaint, "
-                     "please define this callback.";
-  }
-
   return true;
 }
 

--- a/shell/platform/windows/flutter_windows_unittests.cc
+++ b/shell/platform/windows/flutter_windows_unittests.cc
@@ -38,6 +38,32 @@ TEST_F(WindowsTest, LaunchMain) {
   ASSERT_NE(controller, nullptr);
 }
 
+// Verify there is no unexpected output from launching main.
+TEST_F(WindowsTest, LaunchMainHasNoOutput) {
+  // Replace stdout & stderr stream buffers with our own.
+  std::stringstream cout_buffer;
+  std::stringstream cerr_buffer;
+  std::streambuf* old_cout_buffer = std::cout.rdbuf();
+  std::streambuf* old_cerr_buffer = std::cerr.rdbuf();
+  std::cout.rdbuf(cout_buffer.rdbuf());
+  std::cerr.rdbuf(cerr_buffer.rdbuf());
+
+  auto& context = GetContext();
+  WindowsConfigBuilder builder(context);
+  ViewControllerPtr controller{builder.Run()};
+  ASSERT_NE(controller, nullptr);
+
+  // Restore original stdout & stderr stream buffer.
+  std::cout.rdbuf(old_cout_buffer);
+  std::cerr.rdbuf(old_cerr_buffer);
+
+  // Verify stdout & stderr have no output.
+  std::string cout = cout_buffer.str();
+  std::string cerr = cerr_buffer.str();
+  EXPECT_TRUE(cout.empty());
+  EXPECT_TRUE(cerr.empty());
+}
+
 // Verify we can successfully launch a custom entry point.
 TEST_F(WindowsTest, LaunchCustomEntrypoint) {
   auto& context = GetContext();


### PR DESCRIPTION
This removes a noisy log from the startup path. Normally INFO logs are skipped by default, however, this particular log is sent before the verbosity level has been set.

This also adds a test to verify that a default Flutter Windows app does not output anything to stdout or stderr.

/cc @betrevisan 

Fixes https://github.com/flutter/flutter/issues/110231

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
