### PR TITLE
[Impeller] Use ascent/descent rather than deprecated top/bottom for glyph bounds

### DIFF
--- a/impeller/entity/contents/text_contents.cc
+++ b/impeller/entity/contents/text_contents.cc
@@ -138,7 +138,9 @@ bool TextContents::Render(const ContentContext& renderer,
             Point{font.GetMetrics().min_extent.x, font.GetMetrics().ascent};
         vtx.glyph_size = Point{static_cast<Scalar>(glyph_size.width),
                                static_cast<Scalar>(glyph_size.height)};
-        vtx.atlas_position = atlas_glyph_pos->origin;
+        vtx.atlas_position =
+            atlas_glyph_pos->origin + Point{1 / atlas_glyph_pos->size.width,
+                                            1 / atlas_glyph_pos->size.height};
         vtx.atlas_glyph_size =
             Point{atlas_glyph_pos->size.width, atlas_glyph_pos->size.height};
         vertex_builder.AppendVertex(std::move(vtx));

--- a/impeller/typographer/backends/skia/text_frame_skia.cc
+++ b/impeller/typographer/backends/skia/text_frame_skia.cc
@@ -23,8 +23,8 @@ static Font ToFont(const SkFont& font, Scalar scale) {
   metrics.point_size = font.getSize();
   metrics.ascent = sk_metrics.fAscent;
   metrics.descent = sk_metrics.fDescent;
-  metrics.min_extent = {sk_metrics.fXMin, sk_metrics.fTop};
-  metrics.max_extent = {sk_metrics.fXMax, sk_metrics.fBottom};
+  metrics.min_extent = {sk_metrics.fXMin, sk_metrics.fAscent};
+  metrics.max_extent = {sk_metrics.fXMax, sk_metrics.fDescent};
 
   return Font{std::move(typeface), std::move(metrics)};
 }

--- a/impeller/typographer/backends/skia/text_render_context_skia.cc
+++ b/impeller/typographer/backends/skia/text_render_context_skia.cc
@@ -122,13 +122,14 @@ static std::shared_ptr<SkBitmap> CreateAtlasBitmap(const GlyphAtlas& atlas,
 
   atlas.IterateGlyphs([canvas](const FontGlyphPair& font_glyph,
                                const Rect& location) -> bool {
-    const auto position = SkPoint::Make(location.origin.x, location.origin.y);
+    const auto position =
+        SkPoint::Make(location.origin.x / font_glyph.font.GetMetrics().scale,
+                      location.origin.y / font_glyph.font.GetMetrics().scale);
     SkGlyphID glyph_id = font_glyph.glyph.index;
 
     SkFont sk_font(
         TypefaceSkia::Cast(*font_glyph.font.GetTypeface()).GetSkiaTypeface(),
-        font_glyph.font.GetMetrics().point_size *
-            font_glyph.font.GetMetrics().scale);
+        font_glyph.font.GetMetrics().point_size);
 
     const auto& metrics = font_glyph.font.GetMetrics();
 
@@ -136,14 +137,16 @@ static std::shared_ptr<SkBitmap> CreateAtlasBitmap(const GlyphAtlas& atlas,
 
     SkPaint glyph_paint;
     glyph_paint.setColor(glyph_color);
-    canvas->drawGlyphs(
-        1u,         // count
-        &glyph_id,  // glyphs
-        &position,  // positions
-        SkPoint::Make(-metrics.min_extent.x * metrics.scale,
-                      -metrics.ascent * metrics.scale),  // origin
-        sk_font,                                         // font
-        glyph_paint                                      // paint
+    canvas->resetMatrix();
+    canvas->scale(font_glyph.font.GetMetrics().scale,
+                  font_glyph.font.GetMetrics().scale);
+    canvas->drawGlyphs(1u,         // count
+                       &glyph_id,  // glyphs
+                       &position,  // positions
+                       SkPoint::Make(-metrics.min_extent.x,
+                                     -metrics.ascent),  // origin
+                       sk_font,                         // font
+                       glyph_paint                      // paint
     );
     return true;
   });


### PR DESCRIPTION
https://github.com/gskinnerTeam/flutter-wonderous-app/issues/11.

This change fixes both issues I described in the corresponding bug (and seems to solve other text quality problems as well!)

The bounds bug turned out to be usage of the deprecated top/bottom bounds values -- this doesn't correspond to actual pixel coverage of some glyphs (including all of the Chinese glyphs in this particular typeface). The safe way to determine the max onscreen coverage glyphs seems to be the ascend/descend values. We were also already using the baseline ascend for positioning glyphs in the scene, so this also corrects the positioning, which was off by a couple of pixels.

Additionally, for the atlas generation I switched from scaling the point value directly to scaling Skia's CTM. I don't think this changes anything in this typeface, but it's more correct and may fix problems in other typefaces we haven't seen yet.

![image](https://user-images.githubusercontent.com/919017/188794675-80b676c4-a775-4c49-9ff4-b3910658691e.png)

I don't think we have typefaces with Chinese glyphs in the repo, but the existing text playgrounds continue to work/look good (and the English version of the Wondrous app seems to have fewer text artifacts).
