### PR TITLE
[Impeller] Keep track of stencil coverage; don't render unused clips

### DIFF
--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -215,7 +215,6 @@ void Canvas::ClipPath(Path path, Entity::ClipOperation clip_op) {
   entity.SetTransformation(GetCurrentTransformation());
   entity.SetContents(std::move(contents));
   entity.SetStencilDepth(GetStencilDepth());
-  entity.SetAddsToCoverage(false);
 
   GetCurrentPass().AddEntity(std::move(entity));
 
@@ -230,7 +229,6 @@ void Canvas::RestoreClip() {
   // takes up the full render target.
   entity.SetContents(std::make_shared<ClipRestoreContents>());
   entity.SetStencilDepth(GetStencilDepth());
-  entity.SetAddsToCoverage(false);
 
   GetCurrentPass().AddEntity(std::move(entity));
 }

--- a/impeller/entity/contents/clip_contents.h
+++ b/impeller/entity/contents/clip_contents.h
@@ -28,8 +28,13 @@ class ClipContents final : public Contents {
   std::optional<Rect> GetCoverage(const Entity& entity) const override;
 
   // |Contents|
+  StencilCoverage GetStencilCoverage(
+      const Entity& entity,
+      const std::optional<Rect>& current_stencil_coverage) const override;
+
+  // |Contents|
   bool ShouldRender(const Entity& entity,
-                    const ISize& target_size) const override;
+                    const std::optional<Rect>& stencil_coverage) const override;
 
   // |Contents|
   bool Render(const ContentContext& renderer,
@@ -53,8 +58,13 @@ class ClipRestoreContents final : public Contents {
   std::optional<Rect> GetCoverage(const Entity& entity) const override;
 
   // |Contents|
+  StencilCoverage GetStencilCoverage(
+      const Entity& entity,
+      const std::optional<Rect>& current_stencil_coverage) const override;
+
+  // |Contents|
   bool ShouldRender(const Entity& entity,
-                    const ISize& target_size) const override;
+                    const std::optional<Rect>& stencil_coverage) const override;
 
   // |Contents|
   bool Render(const ContentContext& renderer,

--- a/impeller/entity/contents/contents.cc
+++ b/impeller/entity/contents/contents.cc
@@ -5,6 +5,7 @@
 #include "impeller/entity/contents/contents.h"
 #include <optional>
 
+#include "fml/logging.h"
 #include "impeller/entity/contents/content_context.h"
 #include "impeller/renderer/command_buffer.h"
 #include "impeller/renderer/render_pass.h"
@@ -67,7 +68,7 @@ std::optional<Snapshot> Contents::RenderToSnapshot(
 bool Contents::ShouldRender(const Entity& entity,
                             const std::optional<Rect>& stencil_coverage) const {
   if (!stencil_coverage.has_value()) {
-    return true;
+    return false;
   }
   if (Entity::BlendModeShouldCoverWholeScreen(entity.GetBlendMode())) {
     return true;
@@ -75,7 +76,7 @@ bool Contents::ShouldRender(const Entity& entity,
 
   auto coverage = GetCoverage(entity);
   if (!coverage.has_value()) {
-    return true;
+    return false;
   }
   return stencil_coverage->IntersectsWithRect(coverage.value());
 }

--- a/impeller/entity/contents/contents.h
+++ b/impeller/entity/contents/contents.h
@@ -32,12 +32,27 @@ class Contents {
 
   virtual ~Contents();
 
+  struct StencilCoverage {
+    enum class Type { kNone, kAppend, kRestore };
+
+    Type type = Type::kNone;
+    std::optional<Rect> coverage = std::nullopt;
+  };
+
   virtual bool Render(const ContentContext& renderer,
                       const Entity& entity,
                       RenderPass& pass) const = 0;
 
   /// @brief Get the screen space bounding rectangle that this contents affects.
   virtual std::optional<Rect> GetCoverage(const Entity& entity) const = 0;
+
+  /// @brief Given the current screen space bounding rectangle of the stencil,
+  ///        return the expected stencil coverage after this draw call. This
+  ///        should only be implemented for contents that may write to the
+  ///        stencil buffer.
+  virtual StencilCoverage GetStencilCoverage(
+      const Entity& entity,
+      const std::optional<Rect>& current_stencil_coverage) const;
 
   /// @brief Render this contents to a snapshot, respecting the entity's
   ///        transform, path, stencil depth, and blend mode.
@@ -48,7 +63,7 @@ class Contents {
       const Entity& entity) const;
 
   virtual bool ShouldRender(const Entity& entity,
-                            const ISize& target_size) const;
+                            const std::optional<Rect>& stencil_coverage) const;
 
  protected:
 

--- a/impeller/entity/contents/solid_color_contents.cc
+++ b/impeller/entity/contents/solid_color_contents.cc
@@ -41,9 +41,13 @@ std::optional<Rect> SolidColorContents::GetCoverage(
   return path_.GetTransformedBoundingBox(entity.GetTransformation());
 };
 
-bool SolidColorContents::ShouldRender(const Entity& entity,
-                                      const ISize& target_size) const {
-  return cover_ || Contents::ShouldRender(entity, target_size);
+bool SolidColorContents::ShouldRender(
+    const Entity& entity,
+    const std::optional<Rect>& stencil_coverage) const {
+  if (!stencil_coverage.has_value()) {
+    return false;
+  }
+  return cover_ || Contents::ShouldRender(entity, stencil_coverage);
 }
 
 VertexBuffer SolidColorContents::CreateSolidFillVertices(const Path& path,

--- a/impeller/entity/contents/solid_color_contents.h
+++ b/impeller/entity/contents/solid_color_contents.h
@@ -43,7 +43,7 @@ class SolidColorContents final : public Contents {
 
   // |Contents|
   bool ShouldRender(const Entity& entity,
-                    const ISize& target_size) const override;
+                    const std::optional<Rect>& stencil_coverage) const override;
 
   // |Contents|
   bool Render(const ContentContext& renderer,

--- a/impeller/entity/entity.cc
+++ b/impeller/entity/entity.cc
@@ -25,27 +25,24 @@ void Entity::SetTransformation(const Matrix& transformation) {
   transformation_ = transformation;
 }
 
-void Entity::SetAddsToCoverage(bool adds) {
-  adds_to_coverage_ = adds;
-}
-
-bool Entity::AddsToCoverage() const {
-  return adds_to_coverage_;
-}
-
 std::optional<Rect> Entity::GetCoverage() const {
-  if (!adds_to_coverage_ || !contents_) {
+  if (!contents_) {
     return std::nullopt;
   }
 
   return contents_->GetCoverage(*this);
 }
 
-bool Entity::ShouldRender(const ISize& target_size) const {
-  if (BlendModeShouldCoverWholeScreen(blend_mode_)) {
-    return true;
+Contents::StencilCoverage Entity::GetStencilCoverage(
+    const std::optional<Rect>& current_stencil_coverage) const {
+  if (!contents_) {
+    return {};
   }
-  return contents_->ShouldRender(*this, target_size);
+  return contents_->GetStencilCoverage(*this, current_stencil_coverage);
+}
+
+bool Entity::ShouldRender(const std::optional<Rect>& stencil_coverage) const {
+  return contents_->ShouldRender(*this, stencil_coverage);
 }
 
 void Entity::SetContents(std::shared_ptr<Contents> contents) {

--- a/impeller/entity/entity.h
+++ b/impeller/entity/entity.h
@@ -97,13 +97,12 @@ class Entity {
 
   void SetTransformation(const Matrix& transformation);
 
-  void SetAddsToCoverage(bool adds);
-
-  bool AddsToCoverage() const;
-
   std::optional<Rect> GetCoverage() const;
 
-  bool ShouldRender(const ISize& target_size) const;
+  Contents::StencilCoverage GetStencilCoverage(
+      const std::optional<Rect>& current_stencil_coverage) const;
+
+  bool ShouldRender(const std::optional<Rect>& stencil_coverage) const;
 
   void SetContents(std::shared_ptr<Contents> contents);
 
@@ -128,7 +127,6 @@ class Entity {
   std::shared_ptr<Contents> contents_;
   BlendMode blend_mode_ = BlendMode::kSourceOver;
   uint32_t stencil_depth_ = 0u;
-  bool adds_to_coverage_ = true;
 };
 
 }  // namespace impeller

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -439,6 +439,7 @@ bool EntityPass::OnRender(
         }
       } break;
       case Contents::StencilCoverage::Type::kRestore: {
+        FML_DCHECK(!stencil_stack.empty());
         stencil_stack.pop_back();
 
         if (!stencil_stack.back().has_value()) {

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -1434,6 +1434,8 @@ TEST_P(EntityTest, SolidFillShouldRenderIsCorrect) {
     auto fill = std::make_shared<SolidColorContents>();
     fill->SetColor(Color::CornflowerBlue());
     ASSERT_FALSE(fill->ShouldRender(Entity{}, Rect::MakeSize(Size{100, 100})));
+    ASSERT_FALSE(
+        fill->ShouldRender(Entity{}, Rect::MakeLTRB(-100, -100, -50, -50)));
   }
 
   // With path.
@@ -1443,6 +1445,8 @@ TEST_P(EntityTest, SolidFillShouldRenderIsCorrect) {
     fill->SetPath(
         PathBuilder{}.AddRect(Rect::MakeLTRB(0, 0, 100, 100)).TakePath());
     ASSERT_TRUE(fill->ShouldRender(Entity{}, Rect::MakeSize(Size{100, 100})));
+    ASSERT_FALSE(
+        fill->ShouldRender(Entity{}, Rect::MakeLTRB(-100, -100, -50, -50)));
   }
 
   // With paint cover.
@@ -1451,10 +1455,14 @@ TEST_P(EntityTest, SolidFillShouldRenderIsCorrect) {
     fill->SetColor(Color::CornflowerBlue());
     fill->SetCover(true);
     ASSERT_TRUE(fill->ShouldRender(Entity{}, Rect::MakeSize(Size{100, 100})));
+    ASSERT_TRUE(
+        fill->ShouldRender(Entity{}, Rect::MakeLTRB(-100, -100, -50, -50)));
   }
 }
 
 TEST_P(EntityTest, ClipContentsShouldRenderIsCorrect) {
+  // For clip ops, `ShouldRender` should always return true.
+
   // Clip.
   {
     auto clip = std::make_shared<ClipContents>();
@@ -1462,6 +1470,8 @@ TEST_P(EntityTest, ClipContentsShouldRenderIsCorrect) {
     clip->SetPath(
         PathBuilder{}.AddRect(Rect::MakeLTRB(0, 0, 100, 100)).TakePath());
     ASSERT_TRUE(clip->ShouldRender(Entity{}, Rect::MakeSize(Size{100, 100})));
+    ASSERT_TRUE(
+        clip->ShouldRender(Entity{}, Rect::MakeLTRB(-100, -100, -50, -50)));
   }
 
   // Clip restore.
@@ -1469,6 +1479,8 @@ TEST_P(EntityTest, ClipContentsShouldRenderIsCorrect) {
     auto restore = std::make_shared<ClipRestoreContents>();
     ASSERT_TRUE(
         restore->ShouldRender(Entity{}, Rect::MakeSize(Size{100, 100})));
+    ASSERT_TRUE(
+        restore->ShouldRender(Entity{}, Rect::MakeLTRB(-100, -100, -50, -50)));
   }
 }
 

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -1433,7 +1433,7 @@ TEST_P(EntityTest, SolidFillShouldRenderIsCorrect) {
   {
     auto fill = std::make_shared<SolidColorContents>();
     fill->SetColor(Color::CornflowerBlue());
-    ASSERT_FALSE(fill->ShouldRender(Entity{}, {100, 100}));
+    ASSERT_FALSE(fill->ShouldRender(Entity{}, Rect::MakeSize(Size{100, 100})));
   }
 
   // With path.
@@ -1442,7 +1442,7 @@ TEST_P(EntityTest, SolidFillShouldRenderIsCorrect) {
     fill->SetColor(Color::CornflowerBlue());
     fill->SetPath(
         PathBuilder{}.AddRect(Rect::MakeLTRB(0, 0, 100, 100)).TakePath());
-    ASSERT_TRUE(fill->ShouldRender(Entity{}, {100, 100}));
+    ASSERT_TRUE(fill->ShouldRender(Entity{}, Rect::MakeSize(Size{100, 100})));
   }
 
   // With paint cover.
@@ -1450,7 +1450,7 @@ TEST_P(EntityTest, SolidFillShouldRenderIsCorrect) {
     auto fill = std::make_shared<SolidColorContents>();
     fill->SetColor(Color::CornflowerBlue());
     fill->SetCover(true);
-    ASSERT_TRUE(fill->ShouldRender(Entity{}, {100, 100}));
+    ASSERT_TRUE(fill->ShouldRender(Entity{}, Rect::MakeSize(Size{100, 100})));
   }
 }
 
@@ -1458,16 +1458,17 @@ TEST_P(EntityTest, ClipContentsShouldRenderIsCorrect) {
   // Clip.
   {
     auto clip = std::make_shared<ClipContents>();
-    ASSERT_TRUE(clip->ShouldRender(Entity{}, {100, 100}));
+    ASSERT_TRUE(clip->ShouldRender(Entity{}, Rect::MakeSize(Size{100, 100})));
     clip->SetPath(
         PathBuilder{}.AddRect(Rect::MakeLTRB(0, 0, 100, 100)).TakePath());
-    ASSERT_TRUE(clip->ShouldRender(Entity{}, {100, 100}));
+    ASSERT_TRUE(clip->ShouldRender(Entity{}, Rect::MakeSize(Size{100, 100})));
   }
 
   // Clip restore.
   {
     auto restore = std::make_shared<ClipRestoreContents>();
-    ASSERT_TRUE(restore->ShouldRender(Entity{}, {100, 100}));
+    ASSERT_TRUE(
+        restore->ShouldRender(Entity{}, Rect::MakeSize(Size{100, 100})));
   }
 }
 

--- a/impeller/geometry/rect.h
+++ b/impeller/geometry/rect.h
@@ -194,6 +194,14 @@ struct TRect {
     return intersection;
   }
 
+  inline constexpr std::optional<TRect<T>> Intersection(
+      const std::optional<TRect>& o) const {
+    if (!o.has_value()) {
+      return std::nullopt;
+    }
+    return Intersection(o.value());
+  }
+
   constexpr bool IntersectsWithRect(const TRect& o) const {
     return Intersection(o).has_value();
   }

--- a/impeller/geometry/rect.h
+++ b/impeller/geometry/rect.h
@@ -194,14 +194,6 @@ struct TRect {
     return intersection;
   }
 
-  inline constexpr std::optional<TRect<T>> Intersection(
-      const std::optional<TRect>& o) const {
-    if (!o.has_value()) {
-      return std::nullopt;
-    }
-    return Intersection(o.value());
-  }
-
   constexpr bool IntersectsWithRect(const TRect& o) const {
     return Intersection(o).has_value();
   }


### PR DESCRIPTION
This should resolve https://github.com/flutter/flutter/issues/110442.

Mainly, this gets rid of excess clips which don't make an on-screen difference.

I also wrote [this change](https://github.com/flutter/engine/commit/79f15edf24fadb7db6f77cf34136ab198501e163) to stash the appended clip and lazily render it, but this stencil coverage diff alone is turning out to be enough.

WIP because I haven't thoroughly tested it against Wondrous and Gallery yet.