### PR TITLE
Use the frame size to cull

### DIFF
--- a/flow/surface_frame.cc
+++ b/flow/surface_frame.cc
@@ -6,7 +6,6 @@
 
 #include <limits>
 
-#include "flutter/flow/layers/layer.h"
 #include "flutter/fml/logging.h"
 #include "flutter/fml/trace_event.h"
 #include "third_party/skia/include/utils/SkNWayCanvas.h"
@@ -16,6 +15,7 @@ namespace flutter {
 SurfaceFrame::SurfaceFrame(sk_sp<SkSurface> surface,
                            FramebufferInfo framebuffer_info,
                            const SubmitCallback& submit_callback,
+                           SkISize frame_size,
                            std::unique_ptr<GLContextResult> context_result,
                            bool display_list_fallback)
     : surface_(surface),
@@ -26,7 +26,9 @@ SurfaceFrame::SurfaceFrame(sk_sp<SkSurface> surface,
   if (surface_) {
     canvas_ = surface_->getCanvas();
   } else if (display_list_fallback) {
-    dl_recorder_ = sk_make_sp<DisplayListCanvasRecorder>(kGiantRect);
+    FML_DCHECK(!frame_size.isEmpty());
+    dl_recorder_ =
+        sk_make_sp<DisplayListCanvasRecorder>(SkRect::Make(frame_size));
     canvas_ = dl_recorder_.get();
   }
 }

--- a/flow/surface_frame.h
+++ b/flow/surface_frame.h
@@ -57,6 +57,7 @@ class SurfaceFrame {
   SurfaceFrame(sk_sp<SkSurface> surface,
                FramebufferInfo framebuffer_info,
                const SubmitCallback& submit_callback,
+               SkISize frame_size,
                std::unique_ptr<GLContextResult> context_result = nullptr,
                bool display_list_fallback = false);
 

--- a/flow/surface_frame_unittests.cc
+++ b/flow/surface_frame_unittests.cc
@@ -13,10 +13,12 @@ TEST(FlowTest, SurfaceFrameDoesNotSubmitInDtor) {
   SurfaceFrame::FramebufferInfo framebuffer_info;
   auto surface_frame = std::make_unique<SurfaceFrame>(
       /*surface=*/nullptr, framebuffer_info,
-      /*submit_callback=*/[](const SurfaceFrame&, SkCanvas*) {
+      /*submit_callback=*/
+      [](const SurfaceFrame&, SkCanvas*) {
         EXPECT_FALSE(true);
         return true;
-      });
+      },
+      SkISize::Make(800, 600));
   surface_frame.reset();
 }
 
@@ -25,9 +27,11 @@ TEST(FlowTest, SurfaceFrameDoesNotHaveEmptyCanvas) {
   SurfaceFrame frame(
       /*surface=*/nullptr, framebuffer_info,
       /*submit_callback=*/[](const SurfaceFrame&, SkCanvas*) { return true; },
+      /*frame_size=*/SkISize::Make(800, 600),
       /*context_result=*/nullptr, /*display_list_fallback=*/true);
 
-  EXPECT_FALSE(frame.SkiaCanvas()->getLocalClipBounds().isEmpty());
+  EXPECT_EQ(frame.SkiaCanvas()->getLocalClipBounds().width(), 800);
+  EXPECT_EQ(frame.SkiaCanvas()->getLocalClipBounds().height(), 600);
   EXPECT_FALSE(
       frame.SkiaCanvas()->quickReject(SkRect::MakeLTRB(10, 10, 50, 50)));
 }

--- a/flow/surface_frame_unittests.cc
+++ b/flow/surface_frame_unittests.cc
@@ -30,8 +30,7 @@ TEST(FlowTest, SurfaceFrameDoesNotHaveEmptyCanvas) {
       /*frame_size=*/SkISize::Make(800, 600),
       /*context_result=*/nullptr, /*display_list_fallback=*/true);
 
-  EXPECT_EQ(frame.SkiaCanvas()->getLocalClipBounds().width(), 800);
-  EXPECT_EQ(frame.SkiaCanvas()->getLocalClipBounds().height(), 600);
+  EXPECT_FALSE(frame.SkiaCanvas()->getLocalClipBounds().isEmpty());
   EXPECT_FALSE(
       frame.SkiaCanvas()->quickReject(SkRect::MakeLTRB(10, 10, 50, 50)));
 }

--- a/shell/common/rasterizer_unittests.cc
+++ b/shell/common/rasterizer_unittests.cc
@@ -158,7 +158,8 @@ TEST(RasterizerTest,
 
   auto surface_frame = std::make_unique<SurfaceFrame>(
       /*surface=*/nullptr, framebuffer_info,
-      /*submit_callback=*/[](const SurfaceFrame&, SkCanvas*) { return true; });
+      /*submit_callback=*/[](const SurfaceFrame&, SkCanvas*) { return true; },
+      /*frame_size=*/SkISize::Make(800, 600));
   EXPECT_CALL(*surface, AllowsDrawingWhenGpuDisabled()).WillOnce(Return(true));
   EXPECT_CALL(*surface, AcquireFrame(SkISize()))
       .WillOnce(Return(ByMove(std::move(surface_frame))));
@@ -226,7 +227,8 @@ TEST(
   framebuffer_info.supports_readback = true;
   auto surface_frame = std::make_unique<SurfaceFrame>(
       /*surface=*/nullptr, framebuffer_info,
-      /*submit_callback=*/[](const SurfaceFrame&, SkCanvas*) { return true; });
+      /*submit_callback=*/[](const SurfaceFrame&, SkCanvas*) { return true; },
+      /*frame_size=*/SkISize::Make(800, 600));
   EXPECT_CALL(*surface, AllowsDrawingWhenGpuDisabled()).WillOnce(Return(true));
   EXPECT_CALL(*surface, AcquireFrame(SkISize()))
       .WillOnce(Return(ByMove(std::move(surface_frame))));
@@ -295,7 +297,8 @@ TEST(
 
   auto surface_frame = std::make_unique<SurfaceFrame>(
       /*surface=*/nullptr, framebuffer_info,
-      /*submit_callback=*/[](const SurfaceFrame&, SkCanvas*) { return true; });
+      /*submit_callback=*/[](const SurfaceFrame&, SkCanvas*) { return true; },
+      /*frame_size=*/SkISize::Make(800, 600));
   EXPECT_CALL(*surface, AllowsDrawingWhenGpuDisabled()).WillOnce(Return(true));
   EXPECT_CALL(*surface, AcquireFrame(SkISize()))
       .WillOnce(Return(ByMove(std::move(surface_frame))));
@@ -361,10 +364,12 @@ TEST(RasterizerTest,
 
   auto surface_frame1 = std::make_unique<SurfaceFrame>(
       /*surface=*/nullptr, framebuffer_info,
-      /*submit_callback=*/[](const SurfaceFrame&, SkCanvas*) { return true; });
+      /*submit_callback=*/[](const SurfaceFrame&, SkCanvas*) { return true; },
+      /*frame_size=*/SkISize::Make(800, 600));
   auto surface_frame2 = std::make_unique<SurfaceFrame>(
       /*surface=*/nullptr, framebuffer_info,
-      /*submit_callback=*/[](const SurfaceFrame&, SkCanvas*) { return true; });
+      /*submit_callback=*/[](const SurfaceFrame&, SkCanvas*) { return true; },
+      /*frame_size=*/SkISize::Make(800, 600));
   EXPECT_CALL(*surface, AllowsDrawingWhenGpuDisabled())
       .WillRepeatedly(Return(true));
   // Prepare two frames for Draw() and DrawLastLayerTree().
@@ -580,7 +585,8 @@ TEST(RasterizerTest,
   framebuffer_info.supports_readback = true;
   auto surface_frame = std::make_unique<SurfaceFrame>(
       /*surface=*/nullptr, /*framebuffer_info=*/framebuffer_info,
-      /*submit_callback=*/[](const SurfaceFrame&, SkCanvas*) { return true; });
+      /*submit_callback=*/[](const SurfaceFrame&, SkCanvas*) { return true; },
+      /*frame_size=*/SkISize::Make(800, 600));
   EXPECT_CALL(*surface, AllowsDrawingWhenGpuDisabled()).WillOnce(Return(true));
   ON_CALL(delegate, GetIsGpuDisabledSyncSwitch())
       .WillByDefault(Return(is_gpu_disabled_sync_switch));
@@ -636,7 +642,8 @@ TEST(
 
   auto surface_frame = std::make_unique<SurfaceFrame>(
       /*surface=*/nullptr, /*framebuffer_info=*/framebuffer_info,
-      /*submit_callback=*/[](const SurfaceFrame&, SkCanvas*) { return true; });
+      /*submit_callback=*/[](const SurfaceFrame&, SkCanvas*) { return true; },
+      /*frame_size=*/SkISize::Make(800, 600));
   EXPECT_CALL(*surface, AllowsDrawingWhenGpuDisabled()).WillOnce(Return(true));
   ON_CALL(delegate, GetIsGpuDisabledSyncSwitch())
       .WillByDefault(Return(is_gpu_disabled_sync_switch));
@@ -693,7 +700,8 @@ TEST(
 
   auto surface_frame = std::make_unique<SurfaceFrame>(
       /*surface=*/nullptr, /*framebuffer_info=*/framebuffer_info,
-      /*submit_callback=*/[](const SurfaceFrame&, SkCanvas*) { return true; });
+      /*submit_callback=*/[](const SurfaceFrame&, SkCanvas*) { return true; },
+      /*frame_size=*/SkISize::Make(800, 600));
   EXPECT_CALL(*surface, AllowsDrawingWhenGpuDisabled()).WillOnce(Return(false));
   EXPECT_CALL(delegate, GetIsGpuDisabledSyncSwitch())
       .WillOnce(Return(is_gpu_disabled_sync_switch));
@@ -749,7 +757,8 @@ TEST(
 
   auto surface_frame = std::make_unique<SurfaceFrame>(
       /*surface=*/nullptr, /*framebuffer_info=*/framebuffer_info,
-      /*submit_callback=*/[](const SurfaceFrame&, SkCanvas*) { return true; });
+      /*submit_callback=*/[](const SurfaceFrame&, SkCanvas*) { return true; },
+      /*frame_size=*/SkISize::Make(800, 600));
   EXPECT_CALL(*surface, AllowsDrawingWhenGpuDisabled()).WillOnce(Return(false));
   EXPECT_CALL(delegate, GetIsGpuDisabledSyncSwitch())
       .WillOnce(Return(is_gpu_disabled_sync_switch));
@@ -809,9 +818,9 @@ TEST(RasterizerTest,
         framebuffer_info.supports_readback = true;
         return std::make_unique<SurfaceFrame>(
             /*surface=*/nullptr, framebuffer_info,
-            /*submit_callback=*/[](const SurfaceFrame& frame, SkCanvas*) {
-              return true;
-            });
+            /*submit_callback=*/
+            [](const SurfaceFrame& frame, SkCanvas*) { return true; },
+            /*frame_size=*/SkISize::Make(800, 600));
       }));
   ON_CALL(*surface, MakeRenderContextCurrent())
       .WillByDefault(::testing::Invoke(
@@ -987,7 +996,8 @@ TEST(RasterizerTest, presentationTimeSetWhenVsyncTargetInFuture) {
         framebuffer_info.supports_readback = true;
         return std::make_unique<SurfaceFrame>(
             /*surface=*/nullptr, framebuffer_info,
-            /*submit_callback=*/[&](const SurfaceFrame& frame, SkCanvas*) {
+            /*submit_callback=*/
+            [&](const SurfaceFrame& frame, SkCanvas*) {
               const auto pres_time = *frame.submit_info().presentation_time;
               const auto diff = pres_time - first_timestamp;
               int num_frames_submitted = frames_submitted++;
@@ -995,7 +1005,8 @@ TEST(RasterizerTest, presentationTimeSetWhenVsyncTargetInFuture) {
                         num_frames_submitted * millis_16.ToMilliseconds());
               submit_latch.CountDown();
               return true;
-            });
+            },
+            /*frame_size=*/SkISize::Make(800, 600));
       }));
 
   ON_CALL(*surface, MakeRenderContextCurrent())
@@ -1066,13 +1077,15 @@ TEST(RasterizerTest, presentationTimeNotSetWhenVsyncTargetInPast) {
         framebuffer_info.supports_readback = true;
         return std::make_unique<SurfaceFrame>(
             /*surface=*/nullptr, framebuffer_info,
-            /*submit_callback=*/[&](const SurfaceFrame& frame, SkCanvas*) {
+            /*submit_callback=*/
+            [&](const SurfaceFrame& frame, SkCanvas*) {
               const std::optional<fml::TimePoint> pres_time =
                   frame.submit_info().presentation_time;
               EXPECT_EQ(pres_time, std::nullopt);
               submit_latch.CountDown();
               return true;
-            });
+            },
+            /*frame_size=*/SkISize::Make(800, 600));
       }));
 
   ON_CALL(*surface, MakeRenderContextCurrent())

--- a/shell/common/shell_test_platform_view_vulkan.cc
+++ b/shell/common/shell_test_platform_view_vulkan.cc
@@ -193,7 +193,8 @@ ShellTestPlatformViewVulkan::OffScreenSurface::AcquireFrame(
   framebuffer_info.supports_readback = true;
 
   return std::make_unique<SurfaceFrame>(
-      std::move(surface), std::move(framebuffer_info), std::move(callback));
+      std::move(surface), std::move(framebuffer_info), std::move(callback),
+      /*frame_size=*/SkISize::Make(800, 600));
 }
 
 GrDirectContext* ShellTestPlatformViewVulkan::OffScreenSurface::GetContext() {

--- a/shell/gpu/gpu_surface_gl_impeller.cc
+++ b/shell/gpu/gpu_surface_gl_impeller.cc
@@ -120,6 +120,7 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceGLImpeller::AcquireFrame(
       nullptr,                          // surface
       SurfaceFrame::FramebufferInfo{},  // framebuffer info
       submit_callback,                  // submit callback
+      size,                             // frame size
       std::move(context_switch),        // context result
       true                              // display list fallback
   );

--- a/shell/gpu/gpu_surface_gl_skia.cc
+++ b/shell/gpu/gpu_surface_gl_skia.cc
@@ -229,7 +229,8 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceGLSkia::AcquireFrame(
         nullptr, std::move(framebuffer_info),
         [](const SurfaceFrame& surface_frame, SkCanvas* canvas) {
           return true;
-        });
+        },
+        size);
   }
 
   const auto root_surface_transformation = GetRootTransformation();
@@ -253,7 +254,7 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceGLSkia::AcquireFrame(
     framebuffer_info.existing_damage = existing_damage_;
   }
   return std::make_unique<SurfaceFrame>(surface, std::move(framebuffer_info),
-                                        submit_callback,
+                                        submit_callback, size,
                                         std::move(context_switch));
 }
 

--- a/shell/gpu/gpu_surface_metal_impeller.mm
+++ b/shell/gpu/gpu_surface_metal_impeller.mm
@@ -88,6 +88,7 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetalImpeller::AcquireFrame(const SkISiz
   return std::make_unique<SurfaceFrame>(nullptr,                          // surface
                                         SurfaceFrame::FramebufferInfo{},  // framebuffer info
                                         submit_callback,                  // submit callback
+                                        frame_info,                       // frame size
                                         nullptr,                          // context result
                                         true                              // display list fallback
   );

--- a/shell/gpu/gpu_surface_metal_skia.mm
+++ b/shell/gpu/gpu_surface_metal_skia.mm
@@ -95,7 +95,7 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetalSkia::AcquireFrame(const SkISize& f
   if (!render_to_surface_) {
     return std::make_unique<SurfaceFrame>(
         nullptr, SurfaceFrame::FramebufferInfo(),
-        [](const SurfaceFrame& surface_frame, SkCanvas* canvas) { return true; });
+        [](const SurfaceFrame& surface_frame, SkCanvas* canvas) { return true; }, frame_size);
   }
 
   PrecompileKnownSkSLsIfNecessary();
@@ -187,7 +187,8 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetalSkia::AcquireFrameFromCAMetalLayer(
     framebuffer_info.supports_partial_repaint = true;
   }
 
-  return std::make_unique<SurfaceFrame>(std::move(surface), framebuffer_info, submit_callback);
+  return std::make_unique<SurfaceFrame>(std::move(surface), framebuffer_info, submit_callback,
+                                        frame_info);
 }
 
 std::unique_ptr<SurfaceFrame> GPUSurfaceMetalSkia::AcquireFrameFromMTLTexture(
@@ -229,7 +230,7 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetalSkia::AcquireFrameFromMTLTexture(
   framebuffer_info.supports_readback = true;
 
   return std::make_unique<SurfaceFrame>(std::move(surface), std::move(framebuffer_info),
-                                        submit_callback);
+                                        submit_callback, frame_info);
 }
 
 // |Surface|

--- a/shell/gpu/gpu_surface_software.cc
+++ b/shell/gpu/gpu_surface_software.cc
@@ -35,7 +35,8 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceSoftware::AcquireFrame(
         nullptr, std::move(framebuffer_info),
         [](const SurfaceFrame& surface_frame, SkCanvas* canvas) {
           return true;
-        });
+        },
+        logical_size);
   }
 
   if (!IsValid()) {
@@ -73,8 +74,8 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceSoftware::AcquireFrame(
     return self->delegate_->PresentBackingStore(surface_frame.SkiaSurface());
   };
 
-  return std::make_unique<SurfaceFrame>(backing_store,
-                                        std::move(framebuffer_info), on_submit);
+  return std::make_unique<SurfaceFrame>(
+      backing_store, std::move(framebuffer_info), on_submit, logical_size);
 }
 
 // |Surface|

--- a/shell/gpu/gpu_surface_vulkan.cc
+++ b/shell/gpu/gpu_surface_vulkan.cc
@@ -43,7 +43,8 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceVulkan::AcquireFrame(
         nullptr, SurfaceFrame::FramebufferInfo(),
         [](const SurfaceFrame& surface_frame, SkCanvas* canvas) {
           return true;
-        });
+        },
+        frame_size);
   }
 
   FlutterVulkanImage image = delegate_->AcquireImage(frame_size);
@@ -77,8 +78,9 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceVulkan::AcquireFrame(
 
   SurfaceFrame::FramebufferInfo framebuffer_info{.supports_readback = true};
 
-  return std::make_unique<SurfaceFrame>(
-      std::move(surface), std::move(framebuffer_info), std::move(callback));
+  return std::make_unique<SurfaceFrame>(std::move(surface),
+                                        std::move(framebuffer_info),
+                                        std::move(callback), frame_size);
 }
 
 SkMatrix GPUSurfaceVulkan::GetRootTransformation() const {

--- a/shell/platform/android/external_view_embedder/external_view_embedder_unittests.cc
+++ b/shell/platform/android/external_view_embedder/external_view_embedder_unittests.cc
@@ -326,12 +326,14 @@ TEST(AndroidExternalViewEmbedder, SubmitFrame) {
             SkSurface::MakeNull(1000, 1000), framebuffer_info,
             [](const SurfaceFrame& surface_frame, SkCanvas* canvas) {
               return true;
-            });
+            },
+            /*frame_size=*/SkISize::Make(800, 600));
         auto surface_frame_2 = std::make_unique<SurfaceFrame>(
             SkSurface::MakeNull(1000, 1000), framebuffer_info,
             [](const SurfaceFrame& surface_frame, SkCanvas* canvas) {
               return true;
-            });
+            },
+            /*frame_size=*/SkISize::Make(800, 600));
 
         auto surface_mock = std::make_unique<SurfaceMock>();
         EXPECT_CALL(*surface_mock, AcquireFrame(frame_size))
@@ -366,7 +368,8 @@ TEST(AndroidExternalViewEmbedder, SubmitFrame) {
             did_submit_frame = true;
           }
           return true;
-        });
+        },
+        /*frame_size=*/SkISize::Make(800, 600));
 
     embedder->SubmitFrame(gr_context.get(), std::move(surface_frame));
     // Submits frame if no Android view in the current frame.
@@ -433,7 +436,8 @@ TEST(AndroidExternalViewEmbedder, SubmitFrame) {
             did_submit_frame = true;
           }
           return true;
-        });
+        },
+        /*frame_size=*/SkISize::Make(800, 600));
 
     embedder->SubmitFrame(gr_context.get(), std::move(surface_frame));
     // Doesn't submit frame if there aren't Android views in the previous frame.
@@ -498,7 +502,8 @@ TEST(AndroidExternalViewEmbedder, SubmitFrame) {
             did_submit_frame = true;
           }
           return true;
-        });
+        },
+        /*frame_size=*/SkISize::Make(800, 600));
     embedder->SubmitFrame(gr_context.get(), std::move(surface_frame));
     // Submits frame if there are Android views in the previous frame.
     EXPECT_TRUE(did_submit_frame);
@@ -526,7 +531,8 @@ TEST(AndroidExternalViewEmbedder, SubmitFrameOverlayComposition) {
             SkSurface::MakeNull(1000, 1000), framebuffer_info,
             [](const SurfaceFrame& surface_frame, SkCanvas* canvas) {
               return true;
-            });
+            },
+            /*frame_size=*/SkISize::Make(800, 600));
 
         auto surface_mock = std::make_unique<SurfaceMock>();
         EXPECT_CALL(*surface_mock, AcquireFrame(frame_size))
@@ -605,7 +611,8 @@ TEST(AndroidExternalViewEmbedder, SubmitFrameOverlayComposition) {
       SkSurface::MakeNull(1000, 1000), framebuffer_info,
       [](const SurfaceFrame& surface_frame, SkCanvas* canvas) mutable {
         return true;
-      });
+      },
+      /*frame_size=*/SkISize::Make(800, 600));
 
   embedder->SubmitFrame(gr_context.get(), std::move(surface_frame));
 
@@ -628,7 +635,8 @@ TEST(AndroidExternalViewEmbedder, SubmitFramePlatformViewWithoutAnyOverlay) {
             SkSurface::MakeNull(1000, 1000), framebuffer_info,
             [](const SurfaceFrame& surface_frame, SkCanvas* canvas) {
               return true;
-            });
+            },
+            /*frame_size=*/SkISize::Make(800, 600));
 
         auto surface_mock = std::make_unique<SurfaceMock>();
         EXPECT_CALL(*surface_mock, AcquireFrame(frame_size))
@@ -672,7 +680,8 @@ TEST(AndroidExternalViewEmbedder, SubmitFramePlatformViewWithoutAnyOverlay) {
       SkSurface::MakeNull(1000, 1000), framebuffer_info,
       [](const SurfaceFrame& surface_frame, SkCanvas* canvas) mutable {
         return true;
-      });
+      },
+      /*frame_size=*/SkISize::Make(800, 600));
 
   embedder->SubmitFrame(gr_context.get(), std::move(surface_frame));
 
@@ -715,7 +724,8 @@ TEST(AndroidExternalViewEmbedder, DestroyOverlayLayersOnSizeChange) {
             SkSurface::MakeNull(1000, 1000), framebuffer_info,
             [](const SurfaceFrame& surface_frame, SkCanvas* canvas) {
               return true;
-            });
+            },
+            /*frame_size=*/SkISize::Make(800, 600));
 
         auto surface_mock = std::make_unique<SurfaceMock>();
         EXPECT_CALL(*surface_mock, AcquireFrame(frame_size))
@@ -773,7 +783,8 @@ TEST(AndroidExternalViewEmbedder, DestroyOverlayLayersOnSizeChange) {
         SkSurface::MakeNull(1000, 1000), framebuffer_info,
         [](const SurfaceFrame& surface_frame, SkCanvas* canvas) {
           return true;
-        });
+        },
+        /*frame_size=*/SkISize::Make(800, 600));
     embedder->SubmitFrame(gr_context.get(), std::move(surface_frame));
 
     EXPECT_CALL(*jni_mock, FlutterViewEndFrame());
@@ -802,7 +813,8 @@ TEST(AndroidExternalViewEmbedder, DoesNotDestroyOverlayLayersOnSizeChange) {
             SkSurface::MakeNull(1000, 1000), framebuffer_info,
             [](const SurfaceFrame& surface_frame, SkCanvas* canvas) {
               return true;
-            });
+            },
+            /*frame_size=*/SkISize::Make(800, 600));
 
         auto surface_mock = std::make_unique<SurfaceMock>();
         EXPECT_CALL(*surface_mock, AcquireFrame(frame_size))
@@ -859,7 +871,8 @@ TEST(AndroidExternalViewEmbedder, DoesNotDestroyOverlayLayersOnSizeChange) {
         SkSurface::MakeNull(1000, 1000), framebuffer_info,
         [](const SurfaceFrame& surface_frame, SkCanvas* canvas) {
           return true;
-        });
+        },
+        /*frame_size=*/SkISize::Make(800, 600));
     embedder->SubmitFrame(gr_context.get(), std::move(surface_frame));
 
     EXPECT_CALL(*jni_mock, FlutterViewEndFrame());
@@ -926,7 +939,8 @@ TEST(AndroidExternalViewEmbedder, Teardown) {
             SkSurface::MakeNull(1000, 1000), framebuffer_info,
             [](const SurfaceFrame& surface_frame, SkCanvas* canvas) {
               return true;
-            });
+            },
+            /*frame_size=*/SkISize::Make(800, 600));
 
         auto surface_mock = std::make_unique<SurfaceMock>();
         EXPECT_CALL(*surface_mock, AcquireFrame(frame_size))
@@ -969,7 +983,8 @@ TEST(AndroidExternalViewEmbedder, Teardown) {
   SurfaceFrame::FramebufferInfo framebuffer_info;
   auto surface_frame = std::make_unique<SurfaceFrame>(
       SkSurface::MakeNull(1000, 1000), framebuffer_info,
-      [](const SurfaceFrame& surface_frame, SkCanvas* canvas) { return true; });
+      [](const SurfaceFrame& surface_frame, SkCanvas* canvas) { return true; },
+      /*frame_size=*/SkISize::Make(800, 600));
   embedder->SubmitFrame(gr_context.get(), std::move(surface_frame));
 
   embedder->EndFrame(/*should_resubmit_frame=*/false, raster_thread_merger);

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -1851,7 +1851,8 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   flutter::SurfaceFrame::FramebufferInfo framebuffer_info;
   auto mock_surface = std::make_unique<flutter::SurfaceFrame>(
       nullptr, framebuffer_info,
-      [](const flutter::SurfaceFrame& surface_frame, SkCanvas* canvas) { return false; });
+      [](const flutter::SurfaceFrame& surface_frame, SkCanvas* canvas) { return false; },
+      /*frame_size=*/SkISize::Make(800, 600));
   XCTAssertFalse(
       flutterPlatformViewsController->SubmitFrame(nullptr, nullptr, std::move(mock_surface)));
 
@@ -1861,7 +1862,8 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   flutterPlatformViewsController->CompositeEmbeddedView(2);
   auto mock_surface_submit_true = std::make_unique<flutter::SurfaceFrame>(
       nullptr, framebuffer_info,
-      [](const flutter::SurfaceFrame& surface_frame, SkCanvas* canvas) { return true; });
+      [](const flutter::SurfaceFrame& surface_frame, SkCanvas* canvas) { return true; },
+      /*frame_size=*/SkISize::Make(800, 600));
   XCTAssertTrue(flutterPlatformViewsController->SubmitFrame(nullptr, nullptr,
                                                             std::move(mock_surface_submit_true)));
 }

--- a/shell/platform/fuchsia/flutter/surface.cc
+++ b/shell/platform/fuchsia/flutter/surface.cc
@@ -37,7 +37,7 @@ std::unique_ptr<flutter::SurfaceFrame> Surface::AcquireFrame(
       [](const flutter::SurfaceFrame& surface_frame, SkCanvas* canvas) {
         return true;
       },
-      /*frame_size=*/SkISize::Make(800, 600));
+      size);
 }
 
 // |flutter::Surface|

--- a/shell/platform/fuchsia/flutter/surface.cc
+++ b/shell/platform/fuchsia/flutter/surface.cc
@@ -36,7 +36,8 @@ std::unique_ptr<flutter::SurfaceFrame> Surface::AcquireFrame(
       nullptr, std::move(framebuffer_info),
       [](const flutter::SurfaceFrame& surface_frame, SkCanvas* canvas) {
         return true;
-      });
+      },
+      /*frame_size=*/SkISize::Make(800, 600));
 }
 
 // |flutter::Surface|

--- a/shell/platform/fuchsia/flutter/tests/flatland_external_view_embedder_unittests.cc
+++ b/shell/platform/fuchsia/flutter/tests/flatland_external_view_embedder_unittests.cc
@@ -288,7 +288,8 @@ void DrawSimpleFrame(FlatlandExternalViewEmbedder& external_view_embedder,
       nullptr, std::make_unique<flutter::SurfaceFrame>(
                    nullptr, std::move(framebuffer_info),
                    [](const flutter::SurfaceFrame& surface_frame,
-                      SkCanvas* canvas) { return true; }));
+                      SkCanvas* canvas) { return true; },
+                   frame_size));
 }
 
 void DrawFrameWithView(FlatlandExternalViewEmbedder& external_view_embedder,
@@ -316,7 +317,8 @@ void DrawFrameWithView(FlatlandExternalViewEmbedder& external_view_embedder,
       nullptr, std::make_unique<flutter::SurfaceFrame>(
                    nullptr, std::move(framebuffer_info),
                    [](const flutter::SurfaceFrame& surface_frame,
-                      SkCanvas* canvas) { return true; }));
+                      SkCanvas* canvas) { return true; },
+                   frame_size));
 }
 
 };  // namespace

--- a/shell/platform/fuchsia/flutter/tests/gfx_external_view_embedder_unittests.cc
+++ b/shell/platform/fuchsia/flutter/tests/gfx_external_view_embedder_unittests.cc
@@ -462,7 +462,8 @@ void DrawSimpleFrame(GfxExternalViewEmbedder& external_view_embedder,
       nullptr, std::make_unique<flutter::SurfaceFrame>(
                    nullptr, framebuffer_info,
                    [](const flutter::SurfaceFrame& surface_frame,
-                      SkCanvas* canvas) { return true; }));
+                      SkCanvas* canvas) { return true; },
+                   frame_size));
 }
 
 void DrawFrameWithView(GfxExternalViewEmbedder& external_view_embedder,
@@ -489,7 +490,8 @@ void DrawFrameWithView(GfxExternalViewEmbedder& external_view_embedder,
       nullptr, std::make_unique<flutter::SurfaceFrame>(
                    nullptr, framebuffer_info,
                    [](const flutter::SurfaceFrame& surface_frame,
-                      SkCanvas* canvas) { return true; }));
+                      SkCanvas* canvas) { return true; },
+                   frame_size));
 }
 
 FramePresentedInfo MakeFramePresentedInfoForOnePresent(


### PR DESCRIPTION
Passes through the frame size parameter from `Surface::AcquireFrame` to `SurfaceFrame`. This primarily helps impeller, which no longer needs to use `kGiantRect` and will be able to more aggressively cull away graphical operations/geometry that fall outside of the frame's bounds.

This is part of a fix for https://github.com/flutter/flutter/issues/110442. We should still do the work @bdero is proposing in #35966, but this will cover cases where clips in the DL/layer tree don't save us.

I still think we could be doing this kind of culling higher up in the stack in the framework (see https://github.com/flutter/flutter/issues/111065).