### PR TITLE
[Impeller] Avoid using the major and minor variable names.

### DIFF
--- a/impeller/base/version.cc
+++ b/impeller/base/version.cc
@@ -26,7 +26,7 @@ std::optional<Version> Version::FromVector(const std::vector<size_t>& version) {
 
 std::string Version::ToString() const {
   std::stringstream stream;
-  stream << major << "." << minor << "." << patch;
+  stream << major_version << "." << minor_version << "." << patch_version;
   return stream.str();
 }
 

--- a/impeller/base/version.h
+++ b/impeller/base/version.h
@@ -14,18 +14,21 @@ namespace impeller {
 
 struct Version {
  public:
-  size_t major;
-  size_t minor;
-  size_t patch;
+  size_t major_version;
+  size_t minor_version;
+  size_t patch_version;
 
   constexpr Version(size_t p_major = 0, size_t p_minor = 0, size_t p_patch = 0)
-      : major(p_major), minor(p_minor), patch(p_patch) {}
+      : major_version(p_major),
+        minor_version(p_minor),
+        patch_version(p_patch) {}
 
   static std::optional<Version> FromVector(const std::vector<size_t>& version);
 
   constexpr bool IsAtLeast(const Version& other) {
-    return std::tie(major, minor, patch) >=
-           std::tie(other.major, other.minor, other.patch);
+    return std::tie(major_version, minor_version, patch_version) >=
+           std::tie(other.major_version, other.minor_version,
+                    other.patch_version);
   }
 
   std::string ToString() const;


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/110936

In some versions of GNU libc, these are macros. The man page says "major(), and minor() functions are not specified in POSIX.1, but are present on many other systems". Just so happens that its not on any systems we build on in CI.

We could do complicated macro management using scopes or undefining these the right spot. I just renamed them to avoid collisions.

The most useful resource I found on this subject was https://stackoverflow.com/a/22253389/38070.