### PR TITLE
[web] roll CanvasKit 0.37.0

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -22,7 +22,7 @@ vars = {
 
   # WARNING: DO NOT EDIT canvaskit_cipd_instance MANUALLY
   # See `lib/web_ui/README.md` for how to roll CanvasKit to a new version.
-  'canvaskit_cipd_instance': '8wh6J7ZXGCgo1vvCQIqkmskYQZfjhcXQG1YCKFNrzRUC',
+  'canvaskit_cipd_instance': 'C478RsheZD4Fqp1fStMPwFWnSz7nfhh7LMFsrU8M4dQC',
 
   # Do not download the Emscripten SDK by default.
   # This prevents us from downloading the Emscripten toolchain for builds

--- a/lib/web_ui/dev/canvaskit_lock.yaml
+++ b/lib/web_ui/dev/canvaskit_lock.yaml
@@ -1,4 +1,4 @@
 # Specifies the version of CanvasKit to use for Flutter Web apps.
 #
 # See `lib/web_ui/README.md` for how to update this file.
-canvaskit_version: "0.36.1"
+canvaskit_version: "0.37.0"

--- a/lib/web_ui/lib/src/engine/configuration.dart
+++ b/lib/web_ui/lib/src/engine/configuration.dart
@@ -32,7 +32,7 @@ import 'package:js/js.dart';
 /// The version of CanvasKit used by the web engine by default.
 // DO NOT EDIT THE NEXT LINE OF CODE MANUALLY
 // See `lib/web_ui/README.md` for how to roll CanvasKit to a new version.
-const String _canvaskitVersion = '0.36.1';
+const String _canvaskitVersion = '0.37.0';
 
 /// The Web Engine configuration for the current application.
 FlutterConfiguration get configuration => _configuration ??= FlutterConfiguration(_jsConfiguration);


### PR DESCRIPTION
Roll CanvasKit to 0.37.0. This version contains a change that speculatively may fix the flaky perspective text golden tests (https://github.com/flutter/flutter/issues/110785).