### PR TITLE
made RootIsolateToken.instance not null for web

### DIFF
--- a/lib/web_ui/lib/platform_dispatcher.dart
+++ b/lib/web_ui/lib/platform_dispatcher.dart
@@ -19,9 +19,10 @@ typedef ErrorCallback = bool Function(Object exception, StackTrace stackTrace);
 // ignore: avoid_classes_with_only_static_members
 /// A token that represents a root isolate.
 class RootIsolateToken {
-  static RootIsolateToken? get instance {
-    throw UnsupportedError('Root isolate not identifiable on web.');
-  }
+  RootIsolateToken._();
+  // There is only a root isolate on web.
+  static final RootIsolateToken _instance = RootIsolateToken._();
+  static RootIsolateToken? get instance => _instance;
 }
 
 abstract class PlatformDispatcher {

--- a/lib/web_ui/test/engine/platform_dispatcher_test.dart
+++ b/lib/web_ui/test/engine/platform_dispatcher_test.dart
@@ -16,6 +16,10 @@ void main() {
 }
 
 void testMain() {
+  test("root isolate not null",() {
+    expect(ui.RootIsolateToken.instance, isNotNull);
+  });
+
   group('PlatformDispatcher', () {
     test('high contrast in accessibilityFeatures has the correct value', () {
       final MockHighContrastSupport mockHighContrast =


### PR DESCRIPTION
Unblocks https://github.com/flutter/flutter/pull/109005 so we don't have to handle exceptions for web.

We use `ui.RootIsolateToken.instance` as a proxy for asking if we are on a root isolate in the framework to decide which binary messenger to use.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
