### PR TITLE
Update mac_host_engine to generate snapshot with global generators.

### DIFF
--- a/ci/builders/mac_host_engine.json
+++ b/ci/builders/mac_host_engine.json
@@ -6,7 +6,6 @@
                     "base_path": "out/host_debug/zip_archives/",
                     "type": "gcs",
                     "include_paths": [
-                        "out/host_debug/zip_archives/darwin-x64/gen_snapshot.zip",
                         "out/host_debug/zip_archives/darwin-x64/artifacts.zip",
                         "out/host_debug/zip_archives/darwin-x64/FlutterEmbedder.framework.zip",
                         "out/host_debug/zip_archives/dart-sdk-darwin-x64.zip",
@@ -51,7 +50,6 @@
                     "base_path": "out/host_profile/zip_archives/",
                     "type": "gcs",
                     "include_paths": [
-                        "out/host_profile/zip_archives/darwin-x64-profile/gen_snapshot.zip",
                         "out/host_profile/zip_archives/darwin-x64-profile/artifacts.zip"
                     ],
                     "name": "host_profile"
@@ -104,7 +102,6 @@
                     "base_path": "out/host_release/zip_archives/",
                     "type": "gcs",
                     "include_paths": [
-                        "out/host_release/zip_archives/darwin-x64-release/gen_snapshot.zip",
                         "out/host_release/zip_archives/darwin-x64-release/artifacts.zip",
                         "out/host_release/zip_archives/darwin-x64/font-subset.zip"
                     ],
@@ -144,8 +141,7 @@
                     "base_path": "out/mac_debug_arm64/zip_archives/",
                     "type": "gcs",
                     "include_paths": [
-                        "out/mac_debug_arm64/zip_archives/dart-sdk-darwin-arm64.zip",
-                        "out/mac_debug_arm64/zip_archives/darwin-x64/gen_snapshot.zip"
+                        "out/mac_debug_arm64/zip_archives/dart-sdk-darwin-arm64.zip"
                     ],
                     "name": "mac_debug_arm64"
                 }
@@ -184,9 +180,7 @@
                 {
                     "base_path": "out/mac_profile_arm64/zip_archives/",
                     "type": "gcs",
-                    "include_paths": [
-                        "out/mac_profile_arm64/zip_archives/darwin-x64-profile/gen_snapshot.zip"
-                    ],
+                    "include_paths": [],
                     "name": "mac_profile_arm64"
                 }
             ],
@@ -222,9 +216,7 @@
                 {
                     "base_path": "out/mac_release_arm64/zip_archives/",
                     "type": "gcs",
-                    "include_paths": [
-                        "out/mac_release_arm64/zip_archives/darwin-x64-release/gen_snapshot.zip"
-                    ],
+                    "include_paths": [],
                     "name": "mac_release_arm64"
                 }
             ],
@@ -263,7 +255,7 @@
                 "name": "Release-FlutterMacOS.framework",
                 "parameters": [
                     "--dst",
-                    "out/release",
+                    "out/release/framework",
                     "--arm64-out-dir",
                     "out/mac_release_arm64",
                     "--x64-out-dir",
@@ -278,7 +270,7 @@
                 "name": "Debug-FlutterMacOS.framework",
                 "parameters": [
                     "--dst",
-                    "out/debug",
+                    "out/debug/framework",
                     "--arm64-out-dir",
                     "out/mac_debug_arm64",
                     "--x64-out-dir",
@@ -291,7 +283,7 @@
                 "name": "Profile-FlutterMacOS.framework",
                 "parameters": [
                     "--dst",
-                    "out/profile",
+                    "out/profile/framework",
                     "--arm64-out-dir",
                     "out/mac_profile_arm64",
                     "--x64-out-dir",
@@ -299,25 +291,84 @@
                     "--zip"
                 ],
                 "script": "flutter/sky/tools/create_macos_framework.py"
+            },
+            {
+                "name": "Verify-export-symbols",
+                "parameters": [
+                    "src/out"
+                ],
+                "script": "flutter/testing/symbols/verify_exported.dart",
+                "language": "dart"
+            },
+            {
+                "name": "Debug-gen_snapshots",
+                "parameters": [
+                    "--dst",
+                    "out/debug/snapshot",
+                    "--arm64-out-dir",
+                    "out/mac_debug_arm64",
+                    "--x64-out-dir",
+                    "out/host_debug",
+                    "--zip"
+                ],
+                "script": "flutter/sky/tools/create_macos_gen_snapshots.py"
+            },
+            {
+                "name": "Profile-gen_snapshots",
+                "parameters": [
+                    "--dst",
+                    "out/profile/snapshot",
+                    "--arm64-out-dir",
+                    "out/mac_profile_arm64",
+                    "--x64-out-dir",
+                    "out/host_profile",
+                    "--zip"
+                ],
+                "script": "flutter/sky/tools/create_macos_gen_snapshots.py"
+            },
+            {
+                "name": "Release-gen_snapshots",
+                "parameters": [
+                    "--dst",
+                    "out/release/snapshot",
+                    "--arm64-out-dir",
+                    "out/mac_release_arm64",
+                    "--x64-out-dir",
+                    "out/host_release",
+                    "--zip"
+                ],
+                "script": "flutter/sky/tools/create_macos_gen_snapshots.py"
             }
         ]
     },
     "archives": [
         {
-            "source": "out/release/FlutterMacOS.dSYM.zip",
+            "source": "out/release/framework/FlutterMacOS.dSYM.zip",
             "destination": "darwin-x64-release/FlutterMacOS.dSYM.zip"
         },
         {
-            "source": "out/debug/FlutterMacOS.framework.zip",
+            "source": "out/debug/framework/FlutterMacOS.framework.zip",
             "destination": "darwin-x64/FlutterMacOS.framework.zip"
         },
         {
-            "source": "out/profile/FlutterMacOS.framework.zip",
+            "source": "out/profile/framework/FlutterMacOS.framework.zip",
             "destination": "darwin-x64-profile/FlutterMacOS.framework.zip"
         },
         {
-            "source": "out/release/FlutterMacOS.framework.zip",
+            "source": "out/release/framework/FlutterMacOS.framework.zip",
             "destination": "darwin-x64-release/FlutterMacOS.framework.zip"
+        },
+        {
+            "source": "out/debug/snapshot/gen_snapshot.zip",
+            "destination": "darwin-x64/gen_snapshot.zip"
+        },
+        {
+            "source": "out/profile/snapshot/gen_snapshot.zip",
+            "destination": "darwin-x64-profile/gen_snapshot.zip"
+        },
+        {
+            "source": "out/release/snapshot/gen_snapshot.zip",
+            "destination": "darwin-x64-release/gen_snapshot.zip"
         }
     ]
 }


### PR DESCRIPTION
This is because in mac gen_snapshot artifacts include x64 and target cpu gen_snapshot binaries.

Bug: https://github.com/flutter/flutter/issues/81855

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
