### PR TITLE
Properly throw Dart error from PluginUtilities.getCallbackHandle FFI

### DIFF
--- a/lib/ui/dart_runtime_hooks.cc
+++ b/lib/ui/dart_runtime_hooks.cc
@@ -259,7 +259,9 @@ Dart_Handle DartRuntimeHooks::GetCallbackHandle(Dart_Handle func) {
 }
 
 Dart_Handle DartRuntimeHooks::GetCallbackFromHandle(int64_t handle) {
-  return DartCallbackCache::GetCallback(handle);
+  Dart_Handle result = DartCallbackCache::GetCallback(handle);
+  PropagateIfError(result);
+  return result;
 }
 
 void DartPluginRegistrant_EnsureInitialized() {

--- a/testing/dart/plugin_utilities_test.dart
+++ b/testing/dart/plugin_utilities_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:isolate';
 import 'dart:ui';
 
 import 'package:litetest/litetest.dart';
@@ -18,6 +19,34 @@ class Foo {
 }
 
 const Foo foo = Foo();
+
+@pragma('vm:entry-point')
+Future<void> included() async {
+
+}
+
+Future<void> excluded() async {
+
+}
+
+@pragma('vm:entry-point')
+Future<void> runCallback(IsolateParam param) async {
+  try {
+    final Future<dynamic> Function() func = PluginUtilities.getCallbackFromHandle(CallbackHandle.fromRawHandle(param.rawHandle))! as Future<dynamic> Function();
+    await func.call();
+    param.sendPort.send(true);
+  }
+  catch (e) {
+    print(e);
+    param.sendPort.send(false);
+  }
+}
+
+class IsolateParam {
+  const IsolateParam(this.sendPort, this.rawHandle);
+  final SendPort sendPort;
+  final int rawHandle;
+}
 
 void main() {
   test('PluginUtilities Callback Handles', () {
@@ -42,5 +71,19 @@ void main() {
     // Anonymous closures cannot be looked up.
     final Function anon = (int a, int b) => a + b; // ignore: prefer_function_declarations_over_variables
     expect(PluginUtilities.getCallbackHandle(anon), isNull);
+  });
+
+  test('PluginUtilities Callback Handles in Isolate', () async {
+    if (!const bool.fromEnvironment('dart.vm.product')) {
+      return;
+    }
+    ReceivePort port = ReceivePort();
+    await Isolate.spawn(runCallback, IsolateParam(port.sendPort, PluginUtilities.getCallbackHandle(included)!.toRawHandle()));
+    expect(await port.first, true);
+    port.close();
+    port = ReceivePort();
+    await Isolate.spawn(runCallback, IsolateParam(port.sendPort, PluginUtilities.getCallbackHandle(excluded)!.toRawHandle()));
+    expect(await port.first, false);
+    port.close();
   });
 }


### PR DESCRIPTION
Restore dart error propagation which was missing since refactoring for FFI.

Not sure how to test this as the engine dart tests seem to not perform the level of optimizations required to reproduce my failure case (handle to optimized-out function).

Fixes [#111243](https://github.com/flutter/flutter/issues/111243)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

