### PR TITLE
Reland "Support basic back navigation in Android 13/API 33 #35678"

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -541,6 +541,9 @@ public class FlutterActivity extends Activity
   private final OnBackInvokedCallback onBackInvokedCallback =
       Build.VERSION.SDK_INT >= 33
           ? new OnBackInvokedCallback() {
+            // TODO(garyq): Remove SuppressWarnings annotation. This was added to workaround
+            // a google3 bug where the linter is not properly running against API 33, causing
+            // a failure here. See b/243609613
             @SuppressWarnings("Override")
             @Override
             public void onBackInvoked() {

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -541,6 +541,7 @@ public class FlutterActivity extends Activity
   private final OnBackInvokedCallback onBackInvokedCallback =
       Build.VERSION.SDK_INT >= 33
           ? new OnBackInvokedCallback() {
+            @SuppressWarnings("Override")
             @Override
             public void onBackInvoked() {
               onBackPressed();

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -543,7 +543,7 @@ public class FlutterActivity extends Activity
           ? new OnBackInvokedCallback() {
             // TODO(garyq): Remove SuppressWarnings annotation. This was added to workaround
             // a google3 bug where the linter is not properly running against API 33, causing
-            // a failure here. See b/243609613
+            // a failure here. See b/243609613 and https://github.com/flutter/flutter/issues/111295
             @SuppressWarnings("Override")
             @Override
             public void onBackInvoked() {

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
@@ -88,6 +88,36 @@ public class FlutterActivityTest {
     assertTrue(activity.findViewById(FlutterActivity.FLUTTER_VIEW_ID) instanceof FlutterView);
   }
 
+  // TODO(garyq): Robolectric does not yet support android api 33 yet. Switch to a robolectric
+  // test that directly exercises the OnBackInvoked APIs when API 33 is supported.
+  @Test
+  @TargetApi(33)
+  public void itRegistersOnBackInvokedCallbackOnCreate() {
+    Intent intent = FlutterActivityWithReportFullyDrawn.createDefaultIntent(ctx);
+    ActivityController<FlutterActivityWithReportFullyDrawn> activityController =
+        Robolectric.buildActivity(FlutterActivityWithReportFullyDrawn.class, intent);
+    FlutterActivityWithReportFullyDrawn activity = spy(activityController.get());
+
+    activity.onCreate(null);
+
+    verify(activity, times(1)).registerOnBackInvokedCallback();
+  }
+
+  // TODO(garyq): Robolectric does not yet support android api 33 yet. Switch to a robolectric
+  // test that directly exercises the OnBackInvoked APIs when API 33 is supported.
+  @Test
+  @TargetApi(33)
+  public void itUnregistersOnBackInvokedCallbackOnRelease() {
+    Intent intent = FlutterActivityWithReportFullyDrawn.createDefaultIntent(ctx);
+    ActivityController<FlutterActivityWithReportFullyDrawn> activityController =
+        Robolectric.buildActivity(FlutterActivityWithReportFullyDrawn.class, intent);
+    FlutterActivityWithReportFullyDrawn activity = spy(activityController.get());
+
+    activity.release();
+
+    verify(activity, times(1)).unregisterOnBackInvokedCallback();
+  }
+
   @Test
   public void itCreatesDefaultIntentWithExpectedDefaults() {
     Intent intent = FlutterActivity.createDefaultIntent(ctx);
@@ -594,6 +624,14 @@ public class FlutterActivityTest {
     public void resetFullyDrawn() {
       fullyDrawn = false;
     }
+  }
+
+  private class FlutterActivityWithMockBackInvokedHandling extends FlutterActivity {
+    @Override
+    public void registerOnBackInvokedCallback() {}
+
+    @Override
+    public void unregisterOnBackInvokedCallback() {}
   }
 
   private static final class FakeFlutterPlugin

--- a/shell/platform/android/test_runner/build.gradle
+++ b/shell/platform/android/test_runner/build.gradle
@@ -71,10 +71,10 @@ android {
     testImplementation "com.google.android.play:core:1.8.0"
     testImplementation "com.ibm.icu:icu4j:69.1"
     testImplementation "org.robolectric:robolectric:4.7.3"
-    testImplementation "junit:junit:4.13"
-    testImplementation "androidx.test.ext:junit:1.1.3"
+    testImplementation "junit:junit:4.13.2"
+    testImplementation "androidx.test.ext:junit:1.1.4-alpha07"
 
-    def mockitoVersion = "4.1.0"
+    def mockitoVersion = "4.7.0"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.mockito:mockito-inline:$mockitoVersion"
     testImplementation "org.mockito:mockito-android:$mockitoVersion"


### PR DESCRIPTION
This was reverted due to Google3 linter not properly running against API 33. This workaround is from https://b.corp.google.com/issues/243609613