### PR TITLE
Enable cross compile of Linux GTK embedder

### DIFF
--- a/shell/platform/linux/fl_accessible_node.h
+++ b/shell/platform/linux/fl_accessible_node.h
@@ -5,16 +5,19 @@
 #ifndef FLUTTER_SHELL_PLATFORM_LINUX_FL_ACCESSIBLE_NODE_H_
 #define FLUTTER_SHELL_PLATFORM_LINUX_FL_ACCESSIBLE_NODE_H_
 
-#include <gtk/gtk.h>
+#include <atk/atk.h>
+#include <gio/gio.h>
 
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_engine.h"
 
 G_BEGIN_DECLS
 
-// ATK doesn't have the g_autoptr macros, so add them manually.
+// ATK g_autoptr macros weren't added until 2.37. Add them manually.
 // https://gitlab.gnome.org/GNOME/atk/-/issues/10
+#if !ATK_CHECK_VERSION(2, 37, 0)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(AtkObject, g_object_unref)
+#endif
 
 #define FL_TYPE_ACCESSIBLE_NODE fl_accessible_node_get_type()
 G_DECLARE_DERIVABLE_TYPE(FlAccessibleNode,


### PR DESCRIPTION
Signed-off-by: Joel Winarske <joel.winarske@gmail.com>

Cross compiling the Linux GTK embedder is not possible on GCC 11.3 without this change.

This PR fixes https://github.com/flutter/flutter/issues/111221

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
