### PR TITLE
[Impeller] Premultiply gradient alpha after the gradient LUT is generated

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -336,7 +336,7 @@ TEST_P(AiksTest, CanRenderLinearGradient) {
     auto tile_mode = tile_modes[selected_tile_mode];
     paint.color_source = [tile_mode]() {
       std::vector<Color> colors = {Color{0.9568, 0.2627, 0.2118, 1.0},
-                                   Color{0.1294, 0.5882, 0.9529, 1.0}};
+                                   Color{0.1294, 0.5882, 0.9529, 0.0}};
       std::vector<Scalar> stops = {0.0, 1.0};
 
       auto contents = std::make_shared<LinearGradientContents>();

--- a/impeller/entity/shaders/linear_gradient_fill.frag
+++ b/impeller/entity/shaders/linear_gradient_fill.frag
@@ -30,4 +30,5 @@ void main() {
     gradient_info.texture_sampler_y_coord_scale,
     gradient_info.tile_mode,
     gradient_info.tile_mode);
+  frag_color = vec4(frag_color.xyz * frag_color.a, frag_color.a);
 }

--- a/impeller/entity/shaders/radial_gradient_fill.frag
+++ b/impeller/entity/shaders/radial_gradient_fill.frag
@@ -26,4 +26,5 @@ void main() {
     gradient_info.texture_sampler_y_coord_scale,
     gradient_info.tile_mode,
     gradient_info.tile_mode);
+  frag_color = vec4(frag_color.xyz * frag_color.a, frag_color.a);
 }

--- a/impeller/entity/shaders/sweep_gradient_fill.frag
+++ b/impeller/entity/shaders/sweep_gradient_fill.frag
@@ -30,4 +30,5 @@ void main() {
     gradient_info.texture_sampler_y_coord_scale,
     gradient_info.tile_mode,
     gradient_info.tile_mode);
+  frag_color = vec4(frag_color.xyz * frag_color.a, frag_color.a);
 }

--- a/impeller/geometry/gradient.cc
+++ b/impeller/geometry/gradient.cc
@@ -9,7 +9,7 @@
 namespace impeller {
 
 static void AppendColor(const Color& color, std::vector<uint8_t>* colors) {
-  auto converted = color.Premultiply().ToR8G8B8A8();
+  auto converted = color.ToR8G8B8A8();
   colors->push_back(converted[0]);
   colors->push_back(converted[1]);
   colors->push_back(converted[2]);


### PR DESCRIPTION
All output from the fragment stage must be premultiplied.

It looks like somewhere along the way we lost the premultiply for the gradients.