### PR TITLE
Creates dst folder if it does not exist.

### DIFF
--- a/sky/tools/create_macos_gen_snapshots.py
+++ b/sky/tools/create_macos_gen_snapshots.py
@@ -33,6 +33,10 @@ def main():
       if os.path.isabs(args.dst) else os.path.join(buildroot_dir, args.dst)
   )
 
+  # if dst folder does not exist create it.
+  if not os.path.exists(dst):
+    os.makedirs(dst)
+
   if args.x64_out_dir:
     x64_out_dir = (
         args.x64_out_dir if os.path.isabs(args.x64_out_dir) else


### PR DESCRIPTION
In order to separate the files that are being zipped from all the other files in out/debug we added a new directory to the output in recipes v2 but the builder is failing to copy files to the folder because it does not exist yet.

Bug: https://github.com/flutter/flutter/issues/81855


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
