### PR TITLE
Windows: Cleanup: Eliminate ExternalTexturePixelBufferState

### DIFF
--- a/shell/platform/windows/external_texture_d3d.cc
+++ b/shell/platform/windows/external_texture_d3d.cc
@@ -4,9 +4,6 @@
 
 #include "flutter/shell/platform/windows/external_texture_d3d.h"
 
-#include <EGL/egl.h>
-#include <EGL/eglext.h>
-
 #include "flutter/fml/logging.h"
 #include "flutter/shell/platform/embedder/embedder_struct_macros.h"
 

--- a/shell/platform/windows/external_texture_d3d.h
+++ b/shell/platform/windows/external_texture_d3d.h
@@ -5,11 +5,6 @@
 #ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_EXTERNAL_TEXTURE_D3D_H_
 #define FLUTTER_SHELL_PLATFORM_WINDOWS_EXTERNAL_TEXTURE_D3D_H_
 
-#include <stdint.h>
-
-#include <memory>
-
-#include "flutter/shell/platform/common/public/flutter_texture_registrar.h"
 #include "flutter/shell/platform/windows/angle_surface_manager.h"
 #include "flutter/shell/platform/windows/external_texture.h"
 

--- a/shell/platform/windows/external_texture_pixelbuffer.h
+++ b/shell/platform/windows/external_texture_pixelbuffer.h
@@ -5,12 +5,7 @@
 #ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_EXTERNAL_TEXTURE_PIXELBUFFER_H_
 #define FLUTTER_SHELL_PLATFORM_WINDOWS_EXTERNAL_TEXTURE_PIXELBUFFER_H_
 
-#include <stdint.h>
-
-#include <memory>
-
 #include "flutter/shell/platform/common/public/flutter_texture_registrar.h"
-
 #include "flutter/shell/platform/windows/external_texture.h"
 
 namespace flutter {

--- a/shell/platform/windows/external_texture_pixelbuffer.h
+++ b/shell/platform/windows/external_texture_pixelbuffer.h
@@ -15,13 +15,11 @@
 
 namespace flutter {
 
-typedef struct ExternalTexturePixelBufferState ExternalTexturePixelBufferState;
-
 // An abstraction of an pixel-buffer based texture.
 class ExternalTexturePixelBuffer : public ExternalTexture {
  public:
   ExternalTexturePixelBuffer(
-      FlutterDesktopPixelBufferTextureCallback texture_callback,
+      const FlutterDesktopPixelBufferTextureCallback texture_callback,
       void* user_data,
       const GlProcs& gl_procs);
 
@@ -41,10 +39,10 @@ class ExternalTexturePixelBuffer : public ExternalTexture {
   // by |texture_callback_| was invalid.
   bool CopyPixelBuffer(size_t& width, size_t& height);
 
-  std::unique_ptr<ExternalTexturePixelBufferState> state_;
-  FlutterDesktopPixelBufferTextureCallback texture_callback_ = nullptr;
+  const FlutterDesktopPixelBufferTextureCallback texture_callback_ = nullptr;
   void* const user_data_ = nullptr;
   const GlProcs& gl_;
+  GLuint gl_texture_ = 0;
 };
 
 }  // namespace flutter


### PR DESCRIPTION
Improves data locality by eliminating `ExternalTexturePixelBufferState` and making `gl_texture` a member of `ExternaTexturePixelBuffer` itself.

No semantic changes.