### PR TITLE
[web] Remove the 'write' parameter from golden methods

### DIFF
--- a/lib/web_ui/dev/test_platform.dart
+++ b/lib/web_ui/dev/test_platform.dart
@@ -329,7 +329,6 @@ class BrowserPlatform extends PlatformPlugin {
       return shelf.Response.ok(json.encode('OK'));
     }
 
-    final bool write = requestData['write'] as bool;
     final double maxDiffRate = requestData.containsKey('maxdiffrate')
         ? (requestData['maxdiffrate'] as num)
             .toDouble() // can be parsed as either int or double
@@ -341,22 +340,17 @@ class BrowserPlatform extends PlatformPlugin {
             value.toString() == requestData['pixelComparison']);
     final bool isCanvaskitTest = requestData['isCanvaskitTest'] as bool;
     final String result = await _diffScreenshot(
-        filename, write, maxDiffRate, region, pixelComparison, isCanvaskitTest);
+        filename, maxDiffRate, region, pixelComparison, isCanvaskitTest);
     return shelf.Response.ok(json.encode(result));
   }
 
   Future<String> _diffScreenshot(
     String filename,
-    bool write,
     double maxDiffRateFailure,
     Map<String, dynamic> region,
     PixelComparison pixelComparison,
     bool isCanvaskitTest,
   ) async {
-    if (doUpdateScreenshotGoldens) {
-      write = true;
-    }
-
     final Rectangle<num> regionAsRectange = Rectangle<num>(
       region['x'] as num,
       region['y'] as num,

--- a/lib/web_ui/test/canvaskit/canvas_golden_test.dart
+++ b/lib/web_ui/test/canvaskit/canvas_golden_test.dart
@@ -817,8 +817,7 @@ void testMain() {
 }
 
 Future<void> testSampleText(String language, String text,
-    {ui.TextDirection textDirection = ui.TextDirection.ltr,
-    bool write = false}) async {
+    {ui.TextDirection textDirection = ui.TextDirection.ltr}) async {
   const double testWidth = 300;
   double paragraphHeight = 0;
   final CkPicture picture = await generatePictureWhenFontsStable(() {
@@ -840,7 +839,6 @@ Future<void> testSampleText(String language, String text,
       'canvaskit_sample_text_$language.png',
       picture,
       region: ui.Rect.fromLTRB(0, 0, testWidth, paragraphHeight + 20),
-      write: write,
     );
   }
 }
@@ -1176,13 +1174,10 @@ CkImage generateTestImage() {
 /// well as in the golden file name. Avoid special characters. Spaces are OK;
 /// they are replaced by "_" in the file name.
 ///
-/// Set [write] to true to overwrite the golden file.
-///
 /// Use [layoutWidth] to customize the width of the paragraph constraints.
 Future<void> testTextStyle(
   // Test properties
   String name, {
-  bool write = false,
   double? layoutWidth,
   // Top-level text where only paragraph style applies
   String outerText = 'Hello ',
@@ -1324,7 +1319,6 @@ Future<void> testTextStyle(
     'canvaskit_text_styles_${name.replaceAll(' ', '_')}.png',
     picture,
     region: region,
-    write: write,
   );
   expect(notoDownloadQueue.debugIsLoadingFonts, isFalse);
   expect(notoDownloadQueue.pendingFonts, isEmpty);

--- a/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
+++ b/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
@@ -1571,7 +1571,6 @@ void _paragraphTests() {
         'paragraph_kitchen_sink.png',
         region: const ui.Rect.fromLTRB(0, 0, 400, 160),
         maxDiffRatePercent: 0.0,
-        write: true,
       );
     }
 

--- a/lib/web_ui/test/canvaskit/color_filter_golden_test.dart
+++ b/lib/web_ui/test/canvaskit/color_filter_golden_test.dart
@@ -17,10 +17,9 @@ void main() {
 
 const ui.Rect region = ui.Rect.fromLTRB(0, 0, 500, 250);
 
-Future<void> matchSceneGolden(String goldenFile, LayerScene scene,
-    {bool write = false}) async {
+Future<void> matchSceneGolden(String goldenFile, LayerScene scene) async {
   CanvasKitRenderer.instance.rasterizer.draw(scene.layerTree);
-  await matchGoldenFile(goldenFile, region: region, write: write);
+  await matchGoldenFile(goldenFile, region: region);
 }
 
 void testMain() {
@@ -132,7 +131,7 @@ void testMain() {
 
       builder.addPicture(ui.Offset.zero, invertedSquares);
 
-      await matchSceneGolden('canvaskit_inverse_colormatrix.png', builder.build(), write: true);
+      await matchSceneGolden('canvaskit_inverse_colormatrix.png', builder.build());
     });
     // TODO(hterkelsen): https://github.com/flutter/flutter/issues/71520
   }, skip: isSafari || isFirefox);

--- a/lib/web_ui/test/canvaskit/common.dart
+++ b/lib/web_ui/test/canvaskit/common.dart
@@ -180,13 +180,12 @@ class TestCollector implements Collector {
 /// The picture is drawn onto the UI at [ui.Offset.zero] with no additional
 /// layers.
 Future<void> matchPictureGolden(String goldenFile, CkPicture picture,
-    {required ui.Rect region, bool write = false}) async {
+    {required ui.Rect region}) async {
   final LayerSceneBuilder sb = LayerSceneBuilder();
   sb.pushOffset(0, 0);
   sb.addPicture(ui.Offset.zero, picture);
   CanvasKitRenderer.instance.rasterizer.draw(sb.build().layerTree);
-  await matchGoldenFile(goldenFile,
-      region: region, maxDiffRatePercent: 0.0, write: write);
+  await matchGoldenFile(goldenFile, region: region, maxDiffRatePercent: 0.0);
 }
 
 /// Sends a platform message to create a Platform View with the given id and viewType.

--- a/lib/web_ui/test/canvaskit/linear_gradient_golden_test.dart
+++ b/lib/web_ui/test/canvaskit/linear_gradient_golden_test.dart
@@ -19,13 +19,12 @@ void main() {
 
 const ui.Rect region = ui.Rect.fromLTRB(0, 0, 500, 250);
 
-Future<void> matchPictureGolden(String goldenFile, CkPicture picture,
-    {bool write = false}) async {
+Future<void> matchPictureGolden(String goldenFile, CkPicture picture) async {
   final LayerSceneBuilder sb = LayerSceneBuilder();
   sb.pushOffset(0, 0);
   sb.addPicture(ui.Offset.zero, picture);
   CanvasKitRenderer.instance.rasterizer.draw(sb.build().layerTree);
-  await matchGoldenFile(goldenFile, region: region, write: write);
+  await matchGoldenFile(goldenFile, region: region);
 }
 
 void testMain() {

--- a/lib/web_ui/test/canvaskit/shader_mask_golden_test.dart
+++ b/lib/web_ui/test/canvaskit/shader_mask_golden_test.dart
@@ -18,10 +18,9 @@ void main() {
 
 const ui.Rect region = ui.Rect.fromLTRB(0, 0, 500, 250);
 
-Future<void> matchSceneGolden(String goldenFile, LayerScene scene,
-    {bool write = false}) async {
+Future<void> matchSceneGolden(String goldenFile, LayerScene scene) async {
   CanvasKitRenderer.instance.rasterizer.draw(scene.layerTree);
-  await matchGoldenFile(goldenFile, region: region, write: write);
+  await matchGoldenFile(goldenFile, region: region);
 }
 
 void testMain() {

--- a/lib/web_ui/test/canvaskit/sweep_gradient_golden_test.dart
+++ b/lib/web_ui/test/canvaskit/sweep_gradient_golden_test.dart
@@ -19,13 +19,12 @@ void main() {
 
 const ui.Rect region = ui.Rect.fromLTRB(0, 0, 500, 250);
 
-Future<void> matchPictureGolden(String goldenFile, CkPicture picture,
-    {bool write = false}) async {
+Future<void> matchPictureGolden(String goldenFile, CkPicture picture) async {
   final LayerSceneBuilder sb = LayerSceneBuilder();
   sb.pushOffset(0, 0);
   sb.addPicture(ui.Offset.zero, picture);
   CanvasKitRenderer.instance.rasterizer.draw(sb.build().layerTree);
-  await matchGoldenFile(goldenFile, region: region, write: write);
+  await matchGoldenFile(goldenFile, region: region);
 }
 
 void testMain() {

--- a/lib/web_ui/test/html/drawing/draw_vertices_golden_test.dart
+++ b/lib/web_ui/test/html/drawing/draw_vertices_golden_test.dart
@@ -25,8 +25,7 @@ Future<void> testMain() async {
   // Commit a recording canvas to a bitmap, and compare with the expected
   Future<void> checkScreenshot(RecordingCanvas rc, String fileName,
       {Rect region = const Rect.fromLTWH(0, 0, 500, 500),
-      double maxDiffRatePercent = 0.0,
-      bool write = false}) async {
+      double maxDiffRatePercent = 0.0}) async {
     final EngineCanvas engineCanvas =
         BitmapCanvas(screenRect, RenderStrategy());
     rc.endRecording();
@@ -47,7 +46,6 @@ Future<void> testMain() async {
       await matchGoldenFile(
         '$fileName.png',
         region: region,
-        write: write,
         maxDiffRatePercent: maxDiffRatePercent,
       );
     } finally {
@@ -70,13 +68,12 @@ Future<void> testMain() async {
   });
 
   Future<void> testVertices(
-      String fileName, Vertices vertices, BlendMode blendMode, Paint paint,
-      {bool write = false}) async {
+      String fileName, Vertices vertices, BlendMode blendMode, Paint paint) async {
     final RecordingCanvas rc =
         RecordingCanvas(const Rect.fromLTRB(0, 0, 500, 500));
     rc.drawVertices(
         vertices as SurfaceVertices, blendMode, paint as SurfacePaint);
-    await checkScreenshot(rc, fileName, write: write);
+    await checkScreenshot(rc, fileName);
   }
 
   test('Should draw green hairline triangles when colors array is null.',

--- a/lib/web_ui/test/html/paragraph/helper.dart
+++ b/lib/web_ui/test/html/paragraph/helper.dart
@@ -46,7 +46,6 @@ Future<void> takeScreenshot(
   EngineCanvas canvas,
   Rect region,
   String fileName, {
-  bool write = false,
   double? maxDiffRatePercent,
 }) async {
   final DomElement sceneElement = createDomElement('flt-scene');
@@ -63,7 +62,6 @@ Future<void> takeScreenshot(
       '$fileName.png',
       region: region,
       maxDiffRatePercent: maxDiffRatePercent,
-      write: write,
     );
   } finally {
     // The page is reused across tests, so remove the element after taking the

--- a/lib/web_ui/test/html/paragraph/text_scuba.dart
+++ b/lib/web_ui/test/html/paragraph/text_scuba.dart
@@ -43,13 +43,11 @@ class EngineScubaTester {
     String fileName, {
     ui.Rect? region,
     double? maxDiffRatePercent,
-    bool write = false,
   }) async {
     await matchGoldenFile(
       '$fileName.png',
       region: region ?? viewportRegion,
       maxDiffRatePercent: maxDiffRatePercent,
-      write: write,
     );
   }
 
@@ -62,7 +60,6 @@ class EngineScubaTester {
     String fileName, {
     ui.Rect? region,
     double? maxDiffRatePercent,
-    bool write = false,
   }) async {
     // Wrap in <flt-scene> so that our CSS selectors kick in.
     final DomElement sceneElement = createDomElement('flt-scene');
@@ -83,7 +80,6 @@ class EngineScubaTester {
         screenshotName,
         region: region,
         maxDiffRatePercent: maxDiffRatePercent,
-        write: write,
       );
     } finally {
       // The page is reused across tests, so remove the element after taking the

--- a/lib/web_ui/test/html/path_to_svg_golden_test.dart
+++ b/lib/web_ui/test/html/path_to_svg_golden_test.dart
@@ -27,7 +27,6 @@ Future<void> testMain() async {
   Future<void> testPath(Path path, String scubaFileName,
       {SurfacePaint? paint,
       double? maxDiffRatePercent,
-      bool write = false,
       PaintMode mode = PaintMode.kStrokeAndFill}) async {
     const Rect canvasBounds = Rect.fromLTWH(0, 0, 600, 400);
     final BitmapCanvas bitmapCanvas =
@@ -75,7 +74,7 @@ Future<void> testMain() async {
     sceneElement.append(svgElement);
 
     await matchGoldenFile('$scubaFileName.png',
-        region: region, maxDiffRatePercent: maxDiffRatePercent, write: write);
+        region: region, maxDiffRatePercent: maxDiffRatePercent);
 
     bitmapCanvas.rootElement.remove();
     svgElement.remove();

--- a/lib/web_ui/test/html/recording_canvas_golden_test.dart
+++ b/lib/web_ui/test/html/recording_canvas_golden_test.dart
@@ -32,8 +32,7 @@ Future<void> testMain() async {
 
   // Commit a recording canvas to a bitmap, and compare with the expected
   Future<void> checkScreenshot(RecordingCanvas rc, String fileName,
-      { Rect region = const Rect.fromLTWH(0, 0, 500, 500),
-        bool write = false }) async {
+      { Rect region = const Rect.fromLTWH(0, 0, 500, 500) }) async {
 
     final EngineCanvas engineCanvas = BitmapCanvas(screenRect,
         RenderStrategy());
@@ -63,8 +62,7 @@ Future<void> testMain() async {
     try {
       sceneElement.append(engineCanvas.rootElement);
       domDocument.body!.append(sceneElement);
-      await matchGoldenFile('paint_bounds_for_$fileName.png', region: region,
-        write: write);
+      await matchGoldenFile('paint_bounds_for_$fileName.png', region: region);
     } finally {
       // The page is reused across tests, so remove the element after taking the
       // Scuba screenshot.

--- a/lib/web_ui/test/html/screenshot.dart
+++ b/lib/web_ui/test/html/screenshot.dart
@@ -11,8 +11,7 @@ import 'package:web_engine_tester/golden_tester.dart';
 /// Commit a recording canvas to a bitmap, and compare with the expected.
 Future<void> canvasScreenshot(RecordingCanvas rc, String fileName,
     {ui.Rect region = const ui.Rect.fromLTWH(0, 0, 600, 800),
-      double maxDiffRatePercent = 0.0, bool setupPerspective = false,
-      bool write = false}) async {
+      double maxDiffRatePercent = 0.0, bool setupPerspective = false}) async {
   final EngineCanvas engineCanvas = BitmapCanvas(region,
       RenderStrategy());
 
@@ -38,7 +37,7 @@ Future<void> canvasScreenshot(RecordingCanvas rc, String fileName,
     sceneElement.append(engineCanvas.rootElement);
     domDocument.body!.append(sceneElement);
     await matchGoldenFile('$fileName.png',
-        region: region, maxDiffRatePercent: maxDiffRatePercent, write: write);
+        region: region, maxDiffRatePercent: maxDiffRatePercent);
   } finally {
     // The page is reused across tests, so remove the element after taking the
     // Scuba screenshot.
@@ -48,7 +47,7 @@ Future<void> canvasScreenshot(RecordingCanvas rc, String fileName,
 
 Future<void> sceneScreenshot(SurfaceSceneBuilder sceneBuilder, String fileName,
     {ui.Rect region = const ui.Rect.fromLTWH(0, 0, 600, 800),
-    double maxDiffRatePercent = 0.0, bool write = false}) async {
+    double maxDiffRatePercent = 0.0}) async {
   DomElement? sceneElement;
   try {
     sceneElement = sceneBuilder
@@ -56,7 +55,7 @@ Future<void> sceneScreenshot(SurfaceSceneBuilder sceneBuilder, String fileName,
         .webOnlyRootElement;
     domDocument.body!.append(sceneElement!);
     await matchGoldenFile('$fileName.png',
-        region: region, maxDiffRatePercent: maxDiffRatePercent, write: write);
+        region: region, maxDiffRatePercent: maxDiffRatePercent);
   } finally {
     // The page is reused across tests, so remove the element after taking the
     // Scuba screenshot.

--- a/lib/web_ui/test/html/shaders/gradient_golden_test.dart
+++ b/lib/web_ui/test/html/shaders/gradient_golden_test.dart
@@ -30,7 +30,7 @@ Future<void> testMain() async {
   // Commit a recording canvas to a bitmap, and compare with the expected
   Future<void> checkScreenshot(RecordingCanvas rc, String fileName,
       {Rect region = const Rect.fromLTWH(0, 0, 500, 240),
-        double maxDiffRatePercent = 0.0, bool write = false}) async {
+        double maxDiffRatePercent = 0.0}) async {
     final EngineCanvas engineCanvas = BitmapCanvas(screenRect,
         RenderStrategy());
 
@@ -49,7 +49,7 @@ Future<void> testMain() async {
       sceneElement.append(engineCanvas.rootElement);
       domDocument.body!.append(sceneElement);
       await matchGoldenFile('$fileName.png',
-          region: region, maxDiffRatePercent: maxDiffRatePercent, write: write);
+          region: region, maxDiffRatePercent: maxDiffRatePercent);
     } finally {
       // The page is reused across tests, so remove the element after taking the
       // Scuba screenshot.

--- a/lib/web_ui/test/html/shaders/radial_gradient_golden_test.dart
+++ b/lib/web_ui/test/html/shaders/radial_gradient_golden_test.dart
@@ -24,7 +24,6 @@ Future<void> testMain() async {
   Future<void> testGradient(String fileName, Shader shader,
       {Rect paintRect = const Rect.fromLTRB(50, 50, 300, 300),
       Rect shaderRect = const Rect.fromLTRB(50, 50, 300, 300),
-      bool write = false,
       double maxDiffRatePercent = 0,
       Rect region = const Rect.fromLTWH(0, 0, 500, 500)}) async {
     final RecordingCanvas rc = RecordingCanvas(region);
@@ -32,7 +31,7 @@ Future<void> testMain() async {
     final Path path = Path();
     path.addRect(paintRect);
     rc.drawPath(path, paint);
-    await canvasScreenshot(rc, fileName, write: write, region: region,
+    await canvasScreenshot(rc, fileName, region: region,
         maxDiffRatePercent: maxDiffRatePercent);
   }
 

--- a/web_sdk/web_engine_tester/lib/golden_tester.dart
+++ b/web_sdk/web_engine_tester/lib/golden_tester.dart
@@ -38,9 +38,6 @@ enum PixelComparison {
 
 /// Attempts to match the current browser state with the screenshot [filename].
 ///
-/// If [write] is true, will overwrite the golden file and fail the test. Use
-/// it to update golden files.
-///
 /// If [region] is not null, the golden will only include the part contained by
 /// the rectangle.
 ///
@@ -51,10 +48,9 @@ enum PixelComparison {
 /// [pixelComparison] determines the algorithm used to compare pixels. Uses
 /// fuzzy comparison by default.
 Future<void> matchGoldenFile(String filename,
-    {bool write = false, Rect? region, double? maxDiffRatePercent, PixelComparison pixelComparison = PixelComparison.fuzzy}) async {
+    {Rect? region, double? maxDiffRatePercent, PixelComparison pixelComparison = PixelComparison.fuzzy}) async {
   final Map<String, dynamic> serverParams = <String, dynamic>{
     'filename': filename,
-    'write': write,
     'region': region == null
         ? null
         : <String, dynamic>{


### PR DESCRIPTION
The `write` parameter is a remnant from the old way we used to do golden tests. It is used to selectively "update" a golden.

We are removing it in favor of the (already existent) `update-screenshot-goldens` flag that updates all goldens at once. 

The flag and the `write` parameter are currently no-ops because we moved to Skia Gold which stores and updates goldens in post-submit. That said, we will likely re-introduce local golden testing, and for that we need these flags.