### PR TITLE
[lint] Update local variable names in display_list

### DIFF
--- a/display_list/display_list.cc
+++ b/display_list/display_list.cc
@@ -41,9 +41,9 @@ DisplayList::DisplayList(uint8_t* ptr,
       bounds_({0, 0, -1, -1}),
       bounds_cull_(cull_rect),
       can_apply_group_opacity_(can_apply_group_opacity) {
-  static std::atomic<uint32_t> nextID{1};
+  static std::atomic<uint32_t> next_id{1};
   do {
-    unique_id_ = nextID.fetch_add(+1, std::memory_order_relaxed);
+    unique_id_ = next_id.fetch_add(+1, std::memory_order_relaxed);
   } while (unique_id_ == 0);
 }
 
@@ -128,8 +128,8 @@ static bool CompareOps(uint8_t* ptrA,
   // These conditions are checked by the caller...
   FML_DCHECK((endA - ptrA) == (endB - ptrB));
   FML_DCHECK(ptrA != ptrB);
-  uint8_t* bulkStartA = ptrA;
-  uint8_t* bulkStartB = ptrB;
+  uint8_t* bulk_start_a = ptrA;
+  uint8_t* bulk_start_b = ptrB;
   while (ptrA < endA && ptrB < endB) {
     auto opA = reinterpret_cast<const DLOp*>(ptrA);
     auto opB = reinterpret_cast<const DLOp*>(ptrB);
@@ -164,23 +164,23 @@ static bool CompareOps(uint8_t* ptrA,
       case DisplayListCompare::kEqual:
         // Check if we have a backlog of bytes to bulk compare and then
         // reset the bulk compare pointers to the address following this op
-        auto bulkBytes = reinterpret_cast<const uint8_t*>(opA) - bulkStartA;
-        if (bulkBytes > 0) {
-          if (memcmp(bulkStartA, bulkStartB, bulkBytes) != 0) {
+        auto bulk_bytes = reinterpret_cast<const uint8_t*>(opA) - bulk_start_a;
+        if (bulk_bytes > 0) {
+          if (memcmp(bulk_start_a, bulk_start_b, bulk_bytes) != 0) {
             return false;
           }
         }
-        bulkStartA = ptrA;
-        bulkStartB = ptrB;
+        bulk_start_a = ptrA;
+        bulk_start_b = ptrB;
         break;
     }
   }
   if (ptrA != endA || ptrB != endB) {
     return false;
   }
-  if (bulkStartA < ptrA) {
+  if (bulk_start_a < ptrA) {
     // Perform a final bulk compare if we have remaining bytes waiting
-    if (memcmp(bulkStartA, bulkStartB, ptrA - bulkStartA) != 0) {
+    if (memcmp(bulk_start_a, bulk_start_b, ptrA - bulk_start_a) != 0) {
       return false;
     }
   }

--- a/display_list/display_list_builder.cc
+++ b/display_list/display_list_builder.cc
@@ -695,17 +695,17 @@ void DisplayListBuilder::clipPath(const SkPath& path,
   }
 }
 void DisplayListBuilder::intersect(const SkRect& rect) {
-  SkRect devClipBounds = getTransform().mapRect(rect);
-  if (!current_layer_->clip_bounds.intersect(devClipBounds)) {
+  SkRect dev_clip_bounds = getTransform().mapRect(rect);
+  if (!current_layer_->clip_bounds.intersect(dev_clip_bounds)) {
     current_layer_->clip_bounds.setEmpty();
   }
 }
 SkRect DisplayListBuilder::getLocalClipBounds() {
   SkM44 inverse;
   if (current_layer_->matrix.invert(&inverse)) {
-    SkRect devBounds;
-    current_layer_->clip_bounds.roundOut(&devBounds);
-    return inverse.asM33().mapRect(devBounds);
+    SkRect dev_bounds;
+    current_layer_->clip_bounds.roundOut(&dev_bounds);
+    return inverse.asM33().mapRect(dev_bounds);
   }
   return kMaxCullRect_;
 }
@@ -962,21 +962,21 @@ void DisplayListBuilder::drawImageLattice(const sk_sp<DlImage> image,
                                           const SkRect& dst,
                                           DlFilterMode filter,
                                           bool render_with_attributes) {
-  int xDivCount = lattice.fXCount;
-  int yDivCount = lattice.fYCount;
+  int x_div_count = lattice.fXCount;
+  int y_div_count = lattice.fYCount;
   FML_DCHECK((lattice.fRectTypes == nullptr) || (lattice.fColors != nullptr));
-  int cellCount = lattice.fRectTypes && lattice.fColors
-                      ? (xDivCount + 1) * (yDivCount + 1)
-                      : 0;
+  int cell_count = lattice.fRectTypes && lattice.fColors
+                       ? (x_div_count + 1) * (y_div_count + 1)
+                       : 0;
   size_t bytes =
-      (xDivCount + yDivCount) * sizeof(int) +
-      cellCount * (sizeof(SkColor) + sizeof(SkCanvas::Lattice::RectType));
+      (x_div_count + y_div_count) * sizeof(int) +
+      cell_count * (sizeof(SkColor) + sizeof(SkCanvas::Lattice::RectType));
   SkIRect src = lattice.fBounds ? *lattice.fBounds : image->bounds();
   void* pod = this->Push<DrawImageLatticeOp>(
-      bytes, 1, std::move(image), xDivCount, yDivCount, cellCount, src, dst,
-      filter, render_with_attributes);
-  CopyV(pod, lattice.fXDivs, xDivCount, lattice.fYDivs, yDivCount,
-        lattice.fColors, cellCount, lattice.fRectTypes, cellCount);
+      bytes, 1, std::move(image), x_div_count, y_div_count, cell_count, src,
+      dst, filter, render_with_attributes);
+  CopyV(pod, lattice.fXDivs, x_div_count, lattice.fYDivs, y_div_count,
+        lattice.fColors, cell_count, lattice.fRectTypes, cell_count);
   CheckLayerOpacityCompatibility(render_with_attributes);
 }
 void DisplayListBuilder::drawAtlas(const sk_sp<DlImage> atlas,

--- a/display_list/display_list_canvas_dispatcher.cc
+++ b/display_list/display_list_canvas_dispatcher.cc
@@ -308,15 +308,15 @@ void DisplayListCanvasDispatcher::DrawShadow(SkCanvas* canvas,
                        ? SkShadowFlags::kTransparentOccluder_ShadowFlag
                        : SkShadowFlags::kNone_ShadowFlag;
   flags |= SkShadowFlags::kDirectionalLight_ShadowFlag;
-  SkColor inAmbient = SkColorSetA(color, kAmbientAlpha * SkColorGetA(color));
-  SkColor inSpot = SkColorSetA(color, kSpotAlpha * SkColorGetA(color));
-  SkColor ambientColor, spotColor;
-  SkShadowUtils::ComputeTonalColors(inAmbient, inSpot, &ambientColor,
-                                    &spotColor);
+  SkColor in_ambient = SkColorSetA(color, kAmbientAlpha * SkColorGetA(color));
+  SkColor in_spot = SkColorSetA(color, kSpotAlpha * SkColorGetA(color));
+  SkColor ambient_color, spot_color;
+  SkShadowUtils::ComputeTonalColors(in_ambient, in_spot, &ambient_color,
+                                    &spot_color);
   SkShadowUtils::DrawShadow(canvas, path, SkPoint3::Make(0, 0, dpr * elevation),
                             SkPoint3::Make(0, -1, 1),
-                            kLightRadius / kLightHeight, ambientColor,
-                            spotColor, flags);
+                            kLightRadius / kLightHeight, ambient_color,
+                            spot_color, flags);
 }
 
 void DisplayListCanvasDispatcher::drawShadow(const SkPath& path,

--- a/display_list/display_list_canvas_unittests.cc
+++ b/display_list/display_list_canvas_unittests.cc
@@ -205,12 +205,12 @@ class BoundsTolerance {
       allowed.setEmpty();
     }
     SkIRect rounded = allowed.roundOut();
-    int padLeft = std::max(0, pix_bounds.fLeft - rounded.fLeft);
-    int padTop = std::max(0, pix_bounds.fTop - rounded.fTop);
-    int padRight = std::max(0, pix_bounds.fRight - rounded.fRight);
-    int padBottom = std::max(0, pix_bounds.fBottom - rounded.fBottom);
-    int allowed_pad_x = std::max(padLeft, padRight);
-    int allowed_pad_y = std::max(padTop, padBottom);
+    int pad_left = std::max(0, pix_bounds.fLeft - rounded.fLeft);
+    int pad_top = std::max(0, pix_bounds.fTop - rounded.fTop);
+    int pad_right = std::max(0, pix_bounds.fRight - rounded.fRight);
+    int pad_bottom = std::max(0, pix_bounds.fBottom - rounded.fBottom);
+    int allowed_pad_x = std::max(pad_left, pad_right);
+    int allowed_pad_y = std::max(pad_top, pad_bottom);
     if (worst_bounds_pad_x > allowed_pad_x ||
         worst_bounds_pad_y > allowed_pad_y) {
       FML_LOG(ERROR) << "allowed pad: "  //
@@ -496,23 +496,23 @@ class TestParameters {
     if (adjust == 0) {
       return tolerance;
     }
-    SkScalar hTolerance;
-    SkScalar vTolerance;
+    SkScalar h_tolerance;
+    SkScalar v_tolerance;
     if (is_horizontal_line()) {
       FML_DCHECK(!is_vertical_line());
-      hTolerance = adjust;
-      vTolerance = 0;
+      h_tolerance = adjust;
+      v_tolerance = 0;
     } else if (is_vertical_line()) {
-      hTolerance = 0;
-      vTolerance = adjust;
+      h_tolerance = 0;
+      v_tolerance = adjust;
     } else {
       // The perpendicular miters just do not impact the bounds of
       // diagonal lines at all as they are aimed in the wrong direction
       // to matter. So allow tolerance in both axes.
-      hTolerance = vTolerance = adjust;
+      h_tolerance = v_tolerance = adjust;
     }
     BoundsTolerance new_tolerance =
-        tolerance.addBoundsPadding(hTolerance, vTolerance);
+        tolerance.addBoundsPadding(h_tolerance, v_tolerance);
     return new_tolerance;
   }
 
@@ -1085,7 +1085,7 @@ class CanvasCompareTester {
 
     {
       // half opaque cyan
-      DlColor blendableColor = DlColor::kCyan().withAlpha(0x7f);
+      DlColor blendable_color = DlColor::kCyan().withAlpha(0x7f);
       DlColor bg = DlColor::kWhite();
 
       RenderWith(testP, env, tolerance,
@@ -1093,11 +1093,11 @@ class CanvasCompareTester {
                      "Blend == SrcIn",
                      [=](SkCanvas*, SkPaint& p) {
                        p.setBlendMode(SkBlendMode::kSrcIn);
-                       p.setColor(blendableColor);
+                       p.setColor(blendable_color);
                      },
                      [=](DisplayListBuilder& b) {
                        b.setBlendMode(DlBlendMode::kSrcIn);
-                       b.setColor(blendableColor);
+                       b.setColor(blendable_color);
                      })
                      .with_bg(bg));
       RenderWith(testP, env, tolerance,
@@ -1105,11 +1105,11 @@ class CanvasCompareTester {
                      "Blend == DstIn",
                      [=](SkCanvas*, SkPaint& p) {
                        p.setBlendMode(SkBlendMode::kDstIn);
-                       p.setColor(blendableColor);
+                       p.setColor(blendable_color);
                      },
                      [=](DisplayListBuilder& b) {
                        b.setBlendMode(DlBlendMode::kDstIn);
-                       b.setColor(blendableColor);
+                       b.setColor(blendable_color);
                      })
                      .with_bg(bg));
     }
@@ -1151,9 +1151,9 @@ class CanvasCompareTester {
       };
       blur_env.init_ref(cv_blur_setup, testP.cv_renderer(), dl_blur_setup);
       DlBlurImageFilter filter_decal_5(5.0, 5.0, DlTileMode::kDecal);
-      BoundsTolerance blur5Tolerance = tolerance.addBoundsPadding(4, 4);
+      BoundsTolerance blur_5_tolerance = tolerance.addBoundsPadding(4, 4);
       {
-        RenderWith(testP, blur_env, blur5Tolerance,
+        RenderWith(testP, blur_env, blur_5_tolerance,
                    CaseParameters(
                        "ImageFilter == Decal Blur 5",
                        [=](SkCanvas* cv, SkPaint& p) {
@@ -1167,7 +1167,7 @@ class CanvasCompareTester {
       }
       DlBlurImageFilter filter_clamp_5(5.0, 5.0, DlTileMode::kClamp);
       {
-        RenderWith(testP, blur_env, blur5Tolerance,
+        RenderWith(testP, blur_env, blur_5_tolerance,
                    CaseParameters(
                        "ImageFilter == Clamp Blur 5",
                        [=](SkCanvas* cv, SkPaint& p) {
@@ -1352,10 +1352,10 @@ class CanvasCompareTester {
 
     {
       const DlBlurMaskFilter filter(kNormal_SkBlurStyle, 5.0);
-      BoundsTolerance blur5Tolerance = tolerance.addBoundsPadding(4, 4);
+      BoundsTolerance blur_5_tolerance = tolerance.addBoundsPadding(4, 4);
       {
         // Stroked primitives need some non-trivial stroke size to be blurred
-        RenderWith(testP, env, blur5Tolerance,
+        RenderWith(testP, env, blur_5_tolerance,
                    CaseParameters(
                        "MaskFilter == Blur 5",
                        [=](SkCanvas*, SkPaint& p) {
@@ -1561,9 +1561,9 @@ class CanvasCompareTester {
                    }));
 
     {
-      const SkScalar TestDashes1[] = {29.0, 2.0};
-      const SkScalar TestDashes2[] = {17.0, 1.5};
-      auto effect = DlDashPathEffect::Make(TestDashes1, 2, 0.0f);
+      const SkScalar test_dashes_1[] = {29.0, 2.0};
+      const SkScalar test_dashes_2[] = {17.0, 1.5};
+      auto effect = DlDashPathEffect::Make(test_dashes_1, 2, 0.0f);
       {
         RenderWith(testP, stroke_base_env, tolerance,
                    CaseParameters(
@@ -1583,7 +1583,7 @@ class CanvasCompareTester {
                          b.setPathEffect(effect.get());
                        }));
       }
-      effect = DlDashPathEffect::Make(TestDashes2, 2, 0.0f);
+      effect = DlDashPathEffect::Make(test_dashes_2, 2, 0.0f);
       {
         RenderWith(testP, stroke_base_env, tolerance,
                    CaseParameters(
@@ -1898,9 +1898,9 @@ class CanvasCompareTester {
       // renders both back under a transform (scale(2x)) to see if their
       // rendering is affected differently by a change of matrix between
       // recording time and rendering time.
-      const int TestWidth2 = kTestWidth * 2;
-      const int TestHeight2 = kTestHeight * 2;
-      const SkScalar TestScale = 2.0;
+      const int test_width_2 = kTestWidth * 2;
+      const int test_height_2 = kTestHeight * 2;
+      const SkScalar test_scale = 2.0;
 
       SkPictureRecorder sk_x2_recorder;
       SkCanvas* ref_canvas = sk_x2_recorder.beginRecording(kTestBounds);
@@ -1909,27 +1909,27 @@ class CanvasCompareTester {
       sk_sp<SkPicture> ref_x2_picture =
           sk_x2_recorder.finishRecordingAsPicture();
       std::unique_ptr<RenderSurface> ref_x2_surface =
-          env.MakeSurface(bg, TestWidth2, TestHeight2);
+          env.MakeSurface(bg, test_width_2, test_height_2);
       SkCanvas* ref_x2_canvas = ref_x2_surface->canvas();
-      ref_x2_canvas->scale(TestScale, TestScale);
+      ref_x2_canvas->scale(test_scale, test_scale);
       ref_x2_picture->playback(ref_x2_canvas);
       const SkPixmap* ref_x2_pixels = ref_x2_surface->pixmap();
-      ASSERT_EQ(ref_x2_pixels->width(), TestWidth2) << info;
-      ASSERT_EQ(ref_x2_pixels->height(), TestHeight2) << info;
+      ASSERT_EQ(ref_x2_pixels->width(), test_width_2) << info;
+      ASSERT_EQ(ref_x2_pixels->height(), test_height_2) << info;
       ASSERT_EQ(ref_x2_pixels->info().bytesPerPixel(), 4) << info;
 
       DisplayListBuilder builder_x2(kTestBounds);
       caseP.render_to(builder_x2, testP);
       sk_sp<DisplayList> display_list_x2 = builder_x2.Build();
       std::unique_ptr<RenderSurface> test_x2_surface =
-          env.MakeSurface(bg, TestWidth2, TestHeight2);
+          env.MakeSurface(bg, test_width_2, test_height_2);
       SkCanvas* test_x2_canvas = test_x2_surface->canvas();
-      test_x2_canvas->scale(TestScale, TestScale);
+      test_x2_canvas->scale(test_scale, test_scale);
       display_list_x2->RenderTo(test_x2_canvas);
       compareToReference(test_x2_surface->pixmap(), ref_x2_pixels,
                          info + " (Both rendered scaled 2x)", nullptr, nullptr,
                          bg, caseP.fuzzy_compare_components(),  //
-                         TestWidth2, TestHeight2, false);
+                         test_width_2, test_height_2, false);
     }
   }
 
@@ -2068,26 +2068,26 @@ class CanvasCompareTester {
 
     int pixels_different = 0;
     int pixels_oob = 0;
-    int minX = width;
-    int minY = height;
-    int maxX = 0;
-    int maxY = 0;
+    int min_x = width;
+    int min_y = height;
+    int max_x = 0;
+    int max_y = 0;
     for (int y = 0; y < height; y++) {
       const uint32_t* ref_row = ref_pixels->addr32(0, y);
       const uint32_t* test_row = test_pixels->addr32(0, y);
       for (int x = 0; x < width; x++) {
         if (bounds && test_row[x] != untouched) {
-          if (minX > x) {
-            minX = x;
+          if (min_x > x) {
+            min_x = x;
           }
-          if (minY > y) {
-            minY = y;
+          if (min_y > y) {
+            min_y = y;
           }
-          if (maxX <= x) {
-            maxX = x + 1;
+          if (max_x <= x) {
+            max_x = x + 1;
           }
-          if (maxY <= y) {
-            maxY = y + 1;
+          if (max_y <= y) {
+            max_y = y + 1;
           }
           if (!i_bounds.contains(x, y)) {
             pixels_oob++;
@@ -2107,15 +2107,15 @@ class CanvasCompareTester {
     }
     if (pixels_oob > 0) {
       FML_LOG(ERROR) << "pix bounds["  //
-                     << minX << ", " << minY << " => " << maxX << ", " << maxY
-                     << "]";
+                     << min_x << ", " << min_y << " => " << max_x << ", "
+                     << max_y << "]";
       FML_LOG(ERROR) << "dl_bounds["                               //
                      << bounds->fLeft << ", " << bounds->fTop      //
                      << " => "                                     //
                      << bounds->fRight << ", " << bounds->fBottom  //
                      << "]";
     } else if (bounds) {
-      showBoundsOverflow(info, i_bounds, tolerance, minX, minY, maxX, maxY);
+      showBoundsOverflow(info, i_bounds, tolerance, min_x, min_y, max_x, max_y);
     }
     ASSERT_EQ(pixels_oob, 0) << info;
     ASSERT_EQ(pixels_different, 0) << info;
@@ -2135,8 +2135,8 @@ class CanvasCompareTester {
     SkIRect pix_bounds =
         SkIRect::MakeLTRB(pixLeft, pixTop, pixRight, pixBottom);
     SkISize pix_size = pix_bounds.size();
-    int pixWidth = pix_size.width();
-    int pixHeight = pix_size.height();
+    int pix_width = pix_size.width();
+    int pix_height = pix_size.height();
     int worst_pad_x = std::max(pad_left, pad_right);
     int worst_pad_y = std::max(pad_top, pad_bottom);
     if (tolerance->overflows(pix_bounds, worst_pad_x, worst_pad_y)) {
@@ -2150,10 +2150,10 @@ class CanvasCompareTester {
                      << " => "                                   //
                      << bounds.fRight << ", " << bounds.fBottom  //
                      << "]";
-      FML_LOG(ERROR) << "Bounds overflowed by up to "             //
-                     << worst_pad_x << ", " << worst_pad_y        //
-                     << " (" << (worst_pad_x * 100.0 / pixWidth)  //
-                     << "%, " << (worst_pad_y * 100.0 / pixHeight) << "%)";
+      FML_LOG(ERROR) << "Bounds overflowed by up to "              //
+                     << worst_pad_x << ", " << worst_pad_y         //
+                     << " (" << (worst_pad_x * 100.0 / pix_width)  //
+                     << "%, " << (worst_pad_y * 100.0 / pix_height) << "%)";
       int pix_area = pix_size.area();
       int dl_area = bounds.width() * bounds.height();
       FML_LOG(ERROR) << "Total overflow area: " << (dl_area - pix_area)  //
@@ -2368,8 +2368,8 @@ TEST_F(DisplayListCanvas, DrawRRect) {
 TEST_F(DisplayListCanvas, DrawDRRect) {
   SkRRect outer = SkRRect::MakeRectXY(kRenderBounds, kRenderCornerRadius,
                                       kRenderCornerRadius);
-  SkRect innerBounds = kRenderBounds.makeInset(30.0, 30.0);
-  SkRRect inner = SkRRect::MakeRectXY(innerBounds, kRenderCornerRadius,
+  SkRect inner_bounds = kRenderBounds.makeInset(30.0, 30.0);
+  SkRRect inner = SkRRect::MakeRectXY(inner_bounds, kRenderCornerRadius,
                                       kRenderCornerRadius);
   CanvasCompareTester::RenderAll(  //
       TestParameters(
@@ -2825,18 +2825,18 @@ TEST_F(DisplayListCanvas, DrawImageNineLinear) {
 
 TEST_F(DisplayListCanvas, DrawImageLatticeNearest) {
   const SkRect dst = kRenderBounds.makeInset(10.5, 10.5);
-  const int divX[] = {
+  const int div_x[] = {
       kRenderWidth * 1 / 4,
       kRenderWidth * 2 / 4,
       kRenderWidth * 3 / 4,
   };
-  const int divY[] = {
+  const int div_y[] = {
       kRenderHeight * 1 / 4,
       kRenderHeight * 2 / 4,
       kRenderHeight * 3 / 4,
   };
   SkCanvas::Lattice lattice = {
-      divX, divY, nullptr, 3, 3, nullptr, nullptr,
+      div_x, div_y, nullptr, 3, 3, nullptr, nullptr,
   };
   sk_sp<SkImage> image = CanvasCompareTester::kTestImage;
   CanvasCompareTester::RenderAll(  //
@@ -2854,18 +2854,18 @@ TEST_F(DisplayListCanvas, DrawImageLatticeNearest) {
 
 TEST_F(DisplayListCanvas, DrawImageLatticeNearestNoPaint) {
   const SkRect dst = kRenderBounds.makeInset(10.5, 10.5);
-  const int divX[] = {
+  const int div_x[] = {
       kRenderWidth * 1 / 4,
       kRenderWidth * 2 / 4,
       kRenderWidth * 3 / 4,
   };
-  const int divY[] = {
+  const int div_y[] = {
       kRenderHeight * 1 / 4,
       kRenderHeight * 2 / 4,
       kRenderHeight * 3 / 4,
   };
   SkCanvas::Lattice lattice = {
-      divX, divY, nullptr, 3, 3, nullptr, nullptr,
+      div_x, div_y, nullptr, 3, 3, nullptr, nullptr,
   };
   sk_sp<SkImage> image = CanvasCompareTester::kTestImage;
   CanvasCompareTester::RenderAll(  //
@@ -2883,18 +2883,18 @@ TEST_F(DisplayListCanvas, DrawImageLatticeNearestNoPaint) {
 
 TEST_F(DisplayListCanvas, DrawImageLatticeLinear) {
   const SkRect dst = kRenderBounds.makeInset(10.5, 10.5);
-  const int divX[] = {
+  const int div_x[] = {
       kRenderWidth / 4,
       kRenderWidth / 2,
       kRenderWidth * 3 / 4,
   };
-  const int divY[] = {
+  const int div_y[] = {
       kRenderHeight / 4,
       kRenderHeight / 2,
       kRenderHeight * 3 / 4,
   };
   SkCanvas::Lattice lattice = {
-      divX, divY, nullptr, 3, 3, nullptr, nullptr,
+      div_x, div_y, nullptr, 3, 3, nullptr, nullptr,
   };
   sk_sp<SkImage> image = CanvasCompareTester::kTestImage;
   CanvasCompareTester::RenderAll(  //
@@ -3130,18 +3130,18 @@ TEST_F(DisplayListCanvas, DrawTextBlob) {
 #endif  // OS_FUCHSIA
   sk_sp<SkTextBlob> blob =
       CanvasCompareTester::MakeTextBlob("Testing", kRenderHeight * 0.33f);
-  SkScalar RenderY1_3 = kRenderTop + kRenderHeight * 0.3;
-  SkScalar RenderY2_3 = kRenderTop + kRenderHeight * 0.6;
+  SkScalar render_y_1_3 = kRenderTop + kRenderHeight * 0.3;
+  SkScalar render_y_2_3 = kRenderTop + kRenderHeight * 0.6;
   CanvasCompareTester::RenderAll(  //
       TestParameters(
           [=](SkCanvas* canvas, const SkPaint& paint) {  //
-            canvas->drawTextBlob(blob, kRenderLeft, RenderY1_3, paint);
-            canvas->drawTextBlob(blob, kRenderLeft, RenderY2_3, paint);
+            canvas->drawTextBlob(blob, kRenderLeft, render_y_1_3, paint);
+            canvas->drawTextBlob(blob, kRenderLeft, render_y_2_3, paint);
             canvas->drawTextBlob(blob, kRenderLeft, kRenderBottom, paint);
           },
           [=](DisplayListBuilder& builder) {  //
-            builder.drawTextBlob(blob, kRenderLeft, RenderY1_3);
-            builder.drawTextBlob(blob, kRenderLeft, RenderY2_3);
+            builder.drawTextBlob(blob, kRenderLeft, render_y_1_3);
+            builder.drawTextBlob(blob, kRenderLeft, render_y_2_3);
             builder.drawTextBlob(blob, kRenderLeft, kRenderBottom);
           },
           kDrawTextBlobFlags)

--- a/display_list/display_list_color_filter_unittests.cc
+++ b/display_list/display_list_color_filter_unittests.cc
@@ -81,12 +81,12 @@ TEST(DisplayListColorFilter, FromSkiaLinearToSrgbFilter) {
 }
 
 TEST(DisplayListColorFilter, FromSkiaUnrecognizedFilter) {
-  sk_sp<SkColorFilter> sk_inputA =
+  sk_sp<SkColorFilter> sk_input_a =
       SkColorFilters::Blend(SK_ColorRED, SkBlendMode::kOverlay);
-  sk_sp<SkColorFilter> sk_inputB =
+  sk_sp<SkColorFilter> sk_input_b =
       SkColorFilters::Blend(SK_ColorBLUE, SkBlendMode::kScreen);
   sk_sp<SkColorFilter> sk_filter =
-      SkColorFilters::Compose(sk_inputA, sk_inputB);
+      SkColorFilters::Compose(sk_input_a, sk_input_b);
   std::shared_ptr<DlColorFilter> filter = DlColorFilter::From(sk_filter);
   ASSERT_EQ(filter->type(), DlColorFilterType::kUnknown);
   ASSERT_EQ(filter->skia_object(), sk_filter);
@@ -153,25 +153,25 @@ TEST(DisplayListColorFilter, MatrixAsMatrix) {
 }
 
 TEST(DisplayListColorFilter, MatrixContents) {
-  float matrix_[20];
-  memcpy(matrix_, kMatrix, sizeof(matrix_));
-  DlMatrixColorFilter filter(matrix_);
+  float matrix[20];
+  memcpy(matrix, kMatrix, sizeof(matrix));
+  DlMatrixColorFilter filter(matrix);
 
   // Test deref operator []
   for (int i = 0; i < 20; i++) {
-    ASSERT_EQ(filter[i], matrix_[i]);
+    ASSERT_EQ(filter[i], matrix[i]);
   }
 
   // Test get_matrix
   float matrix2[20];
   filter.get_matrix(matrix2);
   for (int i = 0; i < 20; i++) {
-    ASSERT_EQ(matrix2[i], matrix_[i]);
+    ASSERT_EQ(matrix2[i], matrix[i]);
   }
 
   // Test perturbing original array does not affect filter
-  float original_value = matrix_[4];
-  matrix_[4] += 101;
+  float original_value = matrix[4];
+  matrix[4] += 101;
   ASSERT_EQ(filter[4], original_value);
 }
 
@@ -182,11 +182,11 @@ TEST(DisplayListColorFilter, MatrixEquals) {
 }
 
 TEST(DisplayListColorFilter, MatrixNotEquals) {
-  float matrix_[20];
-  memcpy(matrix_, kMatrix, sizeof(matrix_));
-  DlMatrixColorFilter filter1(matrix_);
-  matrix_[4] += 101;
-  DlMatrixColorFilter filter2(matrix_);
+  float matrix[20];
+  memcpy(matrix, kMatrix, sizeof(matrix));
+  DlMatrixColorFilter filter1(matrix);
+  matrix[4] += 101;
+  DlMatrixColorFilter filter2(matrix);
   TestNotEquals(filter1, filter2, "Matrix differs");
 }
 

--- a/display_list/display_list_complexity_unittests.cc
+++ b/display_list/display_list_complexity_unittests.cc
@@ -140,35 +140,35 @@ TEST(DisplayListComplexity, SaveLayers) {
 
 TEST(DisplayListComplexity, DrawPath) {
   DisplayListBuilder builder_line;
-  SkPath linePath;
-  linePath.moveTo(SkPoint::Make(0, 0));
-  linePath.lineTo(SkPoint::Make(10, 10));
-  linePath.close();
-  builder_line.drawPath(linePath);
+  SkPath line_path;
+  line_path.moveTo(SkPoint::Make(0, 0));
+  line_path.lineTo(SkPoint::Make(10, 10));
+  line_path.close();
+  builder_line.drawPath(line_path);
   auto display_list_line = builder_line.Build();
 
   DisplayListBuilder builder_quad;
-  SkPath quadPath;
-  quadPath.moveTo(SkPoint::Make(0, 0));
-  quadPath.quadTo(SkPoint::Make(10, 10), SkPoint::Make(10, 20));
-  quadPath.close();
-  builder_quad.drawPath(quadPath);
+  SkPath quad_path;
+  quad_path.moveTo(SkPoint::Make(0, 0));
+  quad_path.quadTo(SkPoint::Make(10, 10), SkPoint::Make(10, 20));
+  quad_path.close();
+  builder_quad.drawPath(quad_path);
   auto display_list_quad = builder_quad.Build();
 
   DisplayListBuilder builder_conic;
-  SkPath conicPath;
-  conicPath.moveTo(SkPoint::Make(0, 0));
-  conicPath.conicTo(SkPoint::Make(10, 10), SkPoint::Make(10, 20), 1.5f);
-  conicPath.close();
-  builder_conic.drawPath(conicPath);
+  SkPath conic_path;
+  conic_path.moveTo(SkPoint::Make(0, 0));
+  conic_path.conicTo(SkPoint::Make(10, 10), SkPoint::Make(10, 20), 1.5f);
+  conic_path.close();
+  builder_conic.drawPath(conic_path);
   auto display_list_conic = builder_conic.Build();
 
   DisplayListBuilder builder_cubic;
-  SkPath cubicPath;
-  cubicPath.moveTo(SkPoint::Make(0, 0));
-  cubicPath.cubicTo(SkPoint::Make(10, 10), SkPoint::Make(10, 20),
-                    SkPoint::Make(20, 20));
-  builder_cubic.drawPath(cubicPath);
+  SkPath cubic_path;
+  cubic_path.moveTo(SkPoint::Make(0, 0));
+  cubic_path.cubicTo(SkPoint::Make(10, 10), SkPoint::Make(10, 20),
+                     SkPoint::Make(20, 20));
+  builder_cubic.drawPath(cubic_path);
   auto display_list_cubic = builder_cubic.Build();
 
   auto calculators = AccumulatorCalculators();
@@ -182,35 +182,35 @@ TEST(DisplayListComplexity, DrawPath) {
 
 TEST(DisplayListComplexity, DrawShadow) {
   DisplayListBuilder builder_line;
-  SkPath linePath;
-  linePath.moveTo(SkPoint::Make(0, 0));
-  linePath.lineTo(SkPoint::Make(10, 10));
-  linePath.close();
-  builder_line.drawShadow(linePath, SK_ColorRED, 10.0f, false, 1.0f);
+  SkPath line_path;
+  line_path.moveTo(SkPoint::Make(0, 0));
+  line_path.lineTo(SkPoint::Make(10, 10));
+  line_path.close();
+  builder_line.drawShadow(line_path, SK_ColorRED, 10.0f, false, 1.0f);
   auto display_list_line = builder_line.Build();
 
   DisplayListBuilder builder_quad;
-  SkPath quadPath;
-  quadPath.moveTo(SkPoint::Make(0, 0));
-  quadPath.quadTo(SkPoint::Make(10, 10), SkPoint::Make(10, 20));
-  quadPath.close();
-  builder_quad.drawShadow(quadPath, SK_ColorRED, 10.0f, false, 1.0f);
+  SkPath quad_path;
+  quad_path.moveTo(SkPoint::Make(0, 0));
+  quad_path.quadTo(SkPoint::Make(10, 10), SkPoint::Make(10, 20));
+  quad_path.close();
+  builder_quad.drawShadow(quad_path, SK_ColorRED, 10.0f, false, 1.0f);
   auto display_list_quad = builder_quad.Build();
 
   DisplayListBuilder builder_conic;
-  SkPath conicPath;
-  conicPath.moveTo(SkPoint::Make(0, 0));
-  conicPath.conicTo(SkPoint::Make(10, 10), SkPoint::Make(10, 20), 1.5f);
-  conicPath.close();
-  builder_conic.drawShadow(conicPath, SK_ColorRED, 10.0f, false, 1.0f);
+  SkPath conic_path;
+  conic_path.moveTo(SkPoint::Make(0, 0));
+  conic_path.conicTo(SkPoint::Make(10, 10), SkPoint::Make(10, 20), 1.5f);
+  conic_path.close();
+  builder_conic.drawShadow(conic_path, SK_ColorRED, 10.0f, false, 1.0f);
   auto display_list_conic = builder_conic.Build();
 
   DisplayListBuilder builder_cubic;
-  SkPath cubicPath;
-  cubicPath.moveTo(SkPoint::Make(0, 0));
-  cubicPath.cubicTo(SkPoint::Make(10, 10), SkPoint::Make(10, 20),
-                    SkPoint::Make(20, 20));
-  builder_cubic.drawShadow(cubicPath, SK_ColorRED, 10.0f, false, 1.0f);
+  SkPath cubic_path;
+  cubic_path.moveTo(SkPoint::Make(0, 0));
+  cubic_path.cubicTo(SkPoint::Make(10, 10), SkPoint::Make(10, 20),
+                     SkPoint::Make(20, 20));
+  builder_cubic.drawShadow(cubic_path, SK_ColorRED, 10.0f, false, 1.0f);
   auto display_list_cubic = builder_cubic.Build();
 
   auto calculators = AccumulatorCalculators();

--- a/display_list/display_list_image_filter_unittests.cc
+++ b/display_list/display_list_image_filter_unittests.cc
@@ -183,7 +183,7 @@ static bool containsInclusive(const SkIRect rect, const SkRect bounds) {
           bounds.fBottom <= rect.fBottom + 1E-9);
 }
 
-// Used to verify that the expected output bounds and revers engineered
+// Used to verify that the expected output bounds and reverse-engineered
 // "input bounds for output bounds" rectangles are included in the rectangle
 // returned from the various bounds computation methods under the specified
 // matrix.
@@ -191,44 +191,44 @@ static void TestBoundsWithMatrix(const DlImageFilter& filter,
                                  const SkMatrix& matrix,
                                  const SkRect& sourceBounds,
                                  const SkPoint expectedLocalOutputQuad[4]) {
-  SkRect deviceInputBounds = matrix.mapRect(sourceBounds);
-  SkPoint expectedDeviceOutputQuad[4];
-  matrix.mapPoints(expectedDeviceOutputQuad, expectedLocalOutputQuad, 4);
+  SkRect device_input_bounds = matrix.mapRect(sourceBounds);
+  SkPoint expected_output_quad[4];
+  matrix.mapPoints(expected_output_quad, expectedLocalOutputQuad, 4);
 
-  SkIRect deviceFilterIBounds;
-  ASSERT_EQ(filter.map_device_bounds(deviceInputBounds.roundOut(), matrix,
-                                     deviceFilterIBounds),
-            &deviceFilterIBounds);
-  ASSERT_TRUE(containsInclusive(deviceFilterIBounds, expectedDeviceOutputQuad));
+  SkIRect device_filter_ibounds;
+  ASSERT_EQ(filter.map_device_bounds(device_input_bounds.roundOut(), matrix,
+                                     device_filter_ibounds),
+            &device_filter_ibounds);
+  ASSERT_TRUE(containsInclusive(device_filter_ibounds, expected_output_quad));
 
-  SkIRect reverseInputIBounds;
-  ASSERT_EQ(filter.get_input_device_bounds(deviceFilterIBounds, matrix,
-                                           reverseInputIBounds),
-            &reverseInputIBounds);
-  ASSERT_TRUE(containsInclusive(reverseInputIBounds, deviceInputBounds));
+  SkIRect reverse_input_ibounds;
+  ASSERT_EQ(filter.get_input_device_bounds(device_filter_ibounds, matrix,
+                                           reverse_input_ibounds),
+            &reverse_input_ibounds);
+  ASSERT_TRUE(containsInclusive(reverse_input_ibounds, device_input_bounds));
 }
 
 static void TestInvalidBounds(const DlImageFilter& filter,
                               const SkMatrix& matrix,
                               const SkRect& localInputBounds) {
-  SkIRect deviceInputBounds = matrix.mapRect(localInputBounds).roundOut();
+  SkIRect device_input_bounds = matrix.mapRect(localInputBounds).roundOut();
 
-  SkRect localFilterBounds;
-  ASSERT_EQ(filter.map_local_bounds(localInputBounds, localFilterBounds),
+  SkRect local_filter_bounds;
+  ASSERT_EQ(filter.map_local_bounds(localInputBounds, local_filter_bounds),
             nullptr);
-  ASSERT_EQ(localFilterBounds, localInputBounds);
+  ASSERT_EQ(local_filter_bounds, localInputBounds);
 
-  SkIRect deviceFilterIBounds;
-  ASSERT_EQ(
-      filter.map_device_bounds(deviceInputBounds, matrix, deviceFilterIBounds),
-      nullptr);
-  ASSERT_EQ(deviceFilterIBounds, deviceInputBounds);
-
-  SkIRect reverseInputIBounds;
-  ASSERT_EQ(filter.get_input_device_bounds(deviceInputBounds, matrix,
-                                           reverseInputIBounds),
+  SkIRect device_filter_ibounds;
+  ASSERT_EQ(filter.map_device_bounds(device_input_bounds, matrix,
+                                     device_filter_ibounds),
             nullptr);
-  ASSERT_EQ(reverseInputIBounds, deviceInputBounds);
+  ASSERT_EQ(device_filter_ibounds, device_input_bounds);
+
+  SkIRect reverse_input_ibounds;
+  ASSERT_EQ(filter.get_input_device_bounds(device_input_bounds, matrix,
+                                           reverse_input_ibounds),
+            nullptr);
+  ASSERT_EQ(reverse_input_ibounds, device_input_bounds);
 }
 
 // localInputBounds is a sample bounds for testing as input to the filter.
@@ -242,10 +242,10 @@ static void TestInvalidBounds(const DlImageFilter& filter,
 static void TestBounds(const DlImageFilter& filter,
                        const SkRect& sourceBounds,
                        const SkPoint expectedLocalOutputQuad[4]) {
-  SkRect localFilterBounds;
-  ASSERT_EQ(filter.map_local_bounds(sourceBounds, localFilterBounds),
-            &localFilterBounds);
-  ASSERT_TRUE(containsInclusive(localFilterBounds, expectedLocalOutputQuad));
+  SkRect local_filter_bounds;
+  ASSERT_EQ(filter.map_local_bounds(sourceBounds, local_filter_bounds),
+            &local_filter_bounds);
+  ASSERT_TRUE(containsInclusive(local_filter_bounds, expectedLocalOutputQuad));
 
   for (int scale = 1; scale <= 4; scale++) {
     for (int skew = 0; skew < 8; skew++) {
@@ -270,9 +270,9 @@ static void TestBounds(const DlImageFilter& filter,
 static void TestBounds(const DlImageFilter& filter,
                        const SkRect& sourceBounds,
                        const SkRect& expectedLocalOutputBounds) {
-  SkPoint expectedLocalOutputQuad[4];
-  expectedLocalOutputBounds.toQuad(expectedLocalOutputQuad);
-  TestBounds(filter, sourceBounds, expectedLocalOutputQuad);
+  SkPoint expected_local_output_quad[4];
+  expectedLocalOutputBounds.toQuad(expected_local_output_quad);
+  TestBounds(filter, sourceBounds, expected_local_output_quad);
 }
 
 TEST(DisplayListImageFilter, BlurConstructor) {
@@ -321,10 +321,9 @@ TEST(DisplayListImageFilter, BlurNotEquals) {
 
 TEST(DisplayListImageFilter, BlurBounds) {
   DlBlurImageFilter filter = DlBlurImageFilter(5, 10, DlTileMode::kDecal);
-  SkRect inputBounds = SkRect::MakeLTRB(20, 20, 80, 80);
-  SkRect expectOutputBounds = inputBounds.makeOutset(15, 30);
-  // SkRect expectInputBounds = expectOutputBounds.makeOutset(15, 30);
-  TestBounds(filter, inputBounds, expectOutputBounds);
+  SkRect input_bounds = SkRect::MakeLTRB(20, 20, 80, 80);
+  SkRect expected_output_bounds = input_bounds.makeOutset(15, 30);
+  TestBounds(filter, input_bounds, expected_output_bounds);
 }
 
 TEST(DisplayListImageFilter, DilateConstructor) {
@@ -370,9 +369,9 @@ TEST(DisplayListImageFilter, DilateNotEquals) {
 
 TEST(DisplayListImageFilter, DilateBounds) {
   DlDilateImageFilter filter = DlDilateImageFilter(5, 10);
-  SkRect inputBounds = SkRect::MakeLTRB(20, 20, 80, 80);
-  SkRect expectOutputBounds = inputBounds.makeOutset(5, 10);
-  TestBounds(filter, inputBounds, expectOutputBounds);
+  SkRect input_bounds = SkRect::MakeLTRB(20, 20, 80, 80);
+  SkRect expected_output_bounds = input_bounds.makeOutset(5, 10);
+  TestBounds(filter, input_bounds, expected_output_bounds);
 }
 
 TEST(DisplayListImageFilter, ErodeConstructor) {
@@ -418,9 +417,9 @@ TEST(DisplayListImageFilter, ErodeNotEquals) {
 
 TEST(DisplayListImageFilter, ErodeBounds) {
   DlErodeImageFilter filter = DlErodeImageFilter(5, 10);
-  SkRect inputBounds = SkRect::MakeLTRB(20, 20, 80, 80);
-  SkRect expectOutputBounds = inputBounds.makeInset(5, 10);
-  TestBounds(filter, inputBounds, expectOutputBounds);
+  SkRect input_bounds = SkRect::MakeLTRB(20, 20, 80, 80);
+  SkRect expected_output_bounds = input_bounds.makeInset(5, 10);
+  TestBounds(filter, input_bounds, expected_output_bounds);
 }
 
 TEST(DisplayListImageFilter, MatrixConstructor) {
@@ -492,14 +491,14 @@ TEST(DisplayListImageFilter, MatrixBounds) {
   SkMatrix inverse;
   ASSERT_TRUE(matrix.invert(&inverse));
   DlMatrixImageFilter filter(matrix, DlImageSampling::kLinear);
-  SkRect inputBounds = SkRect::MakeLTRB(20, 20, 80, 80);
+  SkRect input_bounds = SkRect::MakeLTRB(20, 20, 80, 80);
   SkPoint expectedOutputQuad[4] = {
       {50, 77},    // (20,20) => (20*2 + 10, 20/2 + 20*3 + 7) == (50, 77)
       {50, 257},   // (20,80) => (20*2 + 10, 20/2 + 80*3 + 7) == (50, 257)
       {170, 287},  // (80,80) => (80*2 + 10, 80/2 + 80*3 + 7) == (170, 287)
       {170, 107},  // (80,20) => (80*2 + 10, 80/2 + 20*3 + 7) == (170, 107)
   };
-  TestBounds(filter, inputBounds, expectedOutputQuad);
+  TestBounds(filter, input_bounds, expectedOutputQuad);
 }
 
 TEST(DisplayListImageFilter, ComposeConstructor) {
@@ -590,9 +589,10 @@ TEST(DisplayListImageFilter, ComposeBounds) {
   DlDilateImageFilter outer = DlDilateImageFilter(5, 10);
   DlBlurImageFilter inner = DlBlurImageFilter(12, 5, DlTileMode::kDecal);
   DlComposeImageFilter filter = DlComposeImageFilter(outer, inner);
-  SkRect inputBounds = SkRect::MakeLTRB(20, 20, 80, 80);
-  SkRect expectOutputBounds = inputBounds.makeOutset(36, 15).makeOutset(5, 10);
-  TestBounds(filter, inputBounds, expectOutputBounds);
+  SkRect input_bounds = SkRect::MakeLTRB(20, 20, 80, 80);
+  SkRect expected_output_bounds =
+      input_bounds.makeOutset(36, 15).makeOutset(5, 10);
+  TestBounds(filter, input_bounds, expected_output_bounds);
 }
 
 static void TestUnboundedBounds(DlImageFilter& filter,
@@ -616,32 +616,32 @@ static void TestUnboundedBounds(DlImageFilter& filter,
 }
 
 TEST(DisplayListImageFilter, ComposeBoundsWithUnboundedInner) {
-  auto inputBounds = SkRect::MakeLTRB(20, 20, 80, 80);
-  auto expectedBounds = SkRect::MakeLTRB(5, 2, 95, 98);
+  auto input_bounds = SkRect::MakeLTRB(20, 20, 80, 80);
+  auto expected_bounds = SkRect::MakeLTRB(5, 2, 95, 98);
 
   DlBlendColorFilter color_filter(DlColor::kRed(), DlBlendMode::kSrcOver);
   auto outer = DlBlurImageFilter(5.0, 6.0, DlTileMode::kRepeat);
   auto inner = DlColorFilterImageFilter(color_filter.shared());
   auto composed = DlComposeImageFilter(outer.shared(), inner.shared());
 
-  TestUnboundedBounds(composed, inputBounds, expectedBounds, expectedBounds);
+  TestUnboundedBounds(composed, input_bounds, expected_bounds, expected_bounds);
 }
 
 TEST(DisplayListImageFilter, ComposeBoundsWithUnboundedOuter) {
-  auto inputBounds = SkRect::MakeLTRB(20, 20, 80, 80);
-  auto expectedBounds = SkRect::MakeLTRB(5, 2, 95, 98);
+  auto input_bounds = SkRect::MakeLTRB(20, 20, 80, 80);
+  auto expected_bounds = SkRect::MakeLTRB(5, 2, 95, 98);
 
   DlBlendColorFilter color_filter(DlColor::kRed(), DlBlendMode::kSrcOver);
   auto outer = DlColorFilterImageFilter(color_filter.shared());
   auto inner = DlBlurImageFilter(5.0, 6.0, DlTileMode::kRepeat);
   auto composed = DlComposeImageFilter(outer.shared(), inner.shared());
 
-  TestUnboundedBounds(composed, inputBounds, expectedBounds, expectedBounds);
+  TestUnboundedBounds(composed, input_bounds, expected_bounds, expected_bounds);
 }
 
 TEST(DisplayListImageFilter, ComposeBoundsWithUnboundedInnerAndOuter) {
-  auto inputBounds = SkRect::MakeLTRB(20, 20, 80, 80);
-  auto expectedBounds = inputBounds;
+  auto input_bounds = SkRect::MakeLTRB(20, 20, 80, 80);
+  auto expected_bounds = input_bounds;
 
   DlBlendColorFilter color_filter1(DlColor::kRed(), DlBlendMode::kSrcOver);
   DlBlendColorFilter color_filter2(DlColor::kBlue(), DlBlendMode::kSrcOver);
@@ -649,12 +649,12 @@ TEST(DisplayListImageFilter, ComposeBoundsWithUnboundedInnerAndOuter) {
   auto inner = DlColorFilterImageFilter(color_filter2.shared());
   auto composed = DlComposeImageFilter(outer.shared(), inner.shared());
 
-  TestUnboundedBounds(composed, inputBounds, expectedBounds, expectedBounds);
+  TestUnboundedBounds(composed, input_bounds, expected_bounds, expected_bounds);
 }
 
 // See https://github.com/flutter/flutter/issues/108433
 TEST(DisplayListImageFilter, Issue_108433) {
-  auto inputBounds = SkIRect::MakeLTRB(20, 20, 80, 80);
+  auto input_bounds = SkIRect::MakeLTRB(20, 20, 80, 80);
 
   auto sk_filter = SkColorFilters::Blend(SK_ColorRED, SkBlendMode::kSrcOver);
   auto sk_outer = SkImageFilters::Blur(5.0, 6.0, SkTileMode::kRepeat, nullptr);
@@ -667,12 +667,13 @@ TEST(DisplayListImageFilter, Issue_108433) {
   auto dl_compose = DlComposeImageFilter(dl_outer, dl_inner);
 
   auto sk_bounds = sk_compose->filterBounds(
-      inputBounds, SkMatrix::I(),
+      input_bounds, SkMatrix::I(),
       SkImageFilter::MapDirection::kForward_MapDirection);
 
   SkIRect dl_bounds;
-  EXPECT_EQ(dl_compose.map_device_bounds(inputBounds, SkMatrix::I(), dl_bounds),
-            nullptr);
+  EXPECT_EQ(
+      dl_compose.map_device_bounds(input_bounds, SkMatrix::I(), dl_bounds),
+      nullptr);
   ASSERT_EQ(dl_bounds, sk_bounds);
 }
 
@@ -730,15 +731,15 @@ TEST(DisplayListImageFilter, ColorFilterNotEquals) {
 TEST(DisplayListImageFilter, ColorFilterBounds) {
   DlBlendColorFilter dl_color_filter(DlColor::kRed(), DlBlendMode::kSrcIn);
   DlColorFilterImageFilter filter(dl_color_filter);
-  SkRect inputBounds = SkRect::MakeLTRB(20, 20, 80, 80);
-  TestBounds(filter, inputBounds, inputBounds);
+  SkRect input_bounds = SkRect::MakeLTRB(20, 20, 80, 80);
+  TestBounds(filter, input_bounds, input_bounds);
 }
 
 TEST(DisplayListImageFilter, ColorFilterModifiesTransparencyBounds) {
   DlBlendColorFilter dl_color_filter(DlColor::kRed(), DlBlendMode::kSrcOver);
   DlColorFilterImageFilter filter(dl_color_filter);
-  SkRect inputBounds = SkRect::MakeLTRB(20, 20, 80, 80);
-  TestInvalidBounds(filter, SkMatrix::I(), inputBounds);
+  SkRect input_bounds = SkRect::MakeLTRB(20, 20, 80, 80);
+  TestInvalidBounds(filter, SkMatrix::I(), input_bounds);
 }
 
 TEST(DisplayListImageFilter, UnknownConstructor) {
@@ -814,12 +815,12 @@ TEST(DisplayListImageFilter, LocalImageFilterBounds) {
           continue;
         }
         {
-          auto inputBounds = SkIRect::MakeLTRB(20, 20, 80, 80);
+          auto input_bounds = SkIRect::MakeLTRB(20, 20, 80, 80);
           SkIRect sk_rect, dl_rect;
           sk_rect = sk_local_filter->filterBounds(
-              inputBounds, bounds_matrix,
+              input_bounds, bounds_matrix,
               SkImageFilter::MapDirection::kForward_MapDirection);
-          dl_local_filter->map_device_bounds(inputBounds, bounds_matrix,
+          dl_local_filter->map_device_bounds(input_bounds, bounds_matrix,
                                              dl_rect);
           ASSERT_EQ(sk_rect, dl_rect);
         }
@@ -832,12 +833,12 @@ TEST(DisplayListImageFilter, LocalImageFilterBounds) {
           if (i == 2 || i == 3) {
             continue;
           }
-          auto outsetBounds = SkIRect::MakeLTRB(20, 20, 80, 80);
+          auto outset_bounds = SkIRect::MakeLTRB(20, 20, 80, 80);
           SkIRect sk_rect, dl_rect;
           sk_rect = sk_local_filter->filterBounds(
-              outsetBounds, bounds_matrix,
+              outset_bounds, bounds_matrix,
               SkImageFilter::MapDirection::kReverse_MapDirection);
-          dl_local_filter->get_input_device_bounds(outsetBounds, bounds_matrix,
+          dl_local_filter->get_input_device_bounds(outset_bounds, bounds_matrix,
                                                    dl_rect);
           ASSERT_EQ(sk_rect, dl_rect);
         }

--- a/display_list/display_list_paint_unittests.cc
+++ b/display_list/display_list_paint_unittests.cc
@@ -51,41 +51,41 @@ TEST(DisplayListPaint, ConstructorDefaults) {
   EXPECT_NE(paint, DlPaint().setStrokeWidth(6));
   EXPECT_NE(paint, DlPaint().setStrokeMiter(7));
 
-  DlColorColorSource colorSource(DlColor::kMagenta());
-  EXPECT_NE(paint, DlPaint().setColorSource(colorSource.shared()));
+  DlColorColorSource color_source(DlColor::kMagenta());
+  EXPECT_NE(paint, DlPaint().setColorSource(color_source.shared()));
 
-  DlBlendColorFilter colorFilter(DlColor::kYellow(), DlBlendMode::kDstIn);
-  EXPECT_NE(paint, DlPaint().setColorFilter(colorFilter.shared()));
+  DlBlendColorFilter color_filter(DlColor::kYellow(), DlBlendMode::kDstIn);
+  EXPECT_NE(paint, DlPaint().setColorFilter(color_filter.shared()));
 
-  DlBlurImageFilter imageFilter(1.3, 4.7, DlTileMode::kClamp);
-  EXPECT_NE(paint, DlPaint().setImageFilter(imageFilter.shared()));
+  DlBlurImageFilter image_filter(1.3, 4.7, DlTileMode::kClamp);
+  EXPECT_NE(paint, DlPaint().setImageFilter(image_filter.shared()));
 
-  DlBlurMaskFilter maskFilter(SkBlurStyle::kInner_SkBlurStyle, 3.14);
-  EXPECT_NE(paint, DlPaint().setMaskFilter(maskFilter.shared()));
+  DlBlurMaskFilter mask_filter(SkBlurStyle::kInner_SkBlurStyle, 3.14);
+  EXPECT_NE(paint, DlPaint().setMaskFilter(mask_filter.shared()));
 }
 
 TEST(DisplayListPaint, NullPointerSetGet) {
-  DlColorSource* nullColorSource = nullptr;
-  DlColorFilter* nullColorFilter = nullptr;
-  DlImageFilter* nullImageFilter = nullptr;
-  DlMaskFilter* nullMaskFilter = nullptr;
+  DlColorSource* null_color_source = nullptr;
+  DlColorFilter* null_color_filter = nullptr;
+  DlImageFilter* null_image_filter = nullptr;
+  DlMaskFilter* null_mask_filter = nullptr;
   DlPaint paint;
-  EXPECT_EQ(paint.setColorSource(nullColorSource).getColorSource(), nullptr);
-  EXPECT_EQ(paint.setColorFilter(nullColorFilter).getColorFilter(), nullptr);
-  EXPECT_EQ(paint.setImageFilter(nullImageFilter).getImageFilter(), nullptr);
-  EXPECT_EQ(paint.setMaskFilter(nullMaskFilter).getMaskFilter(), nullptr);
+  EXPECT_EQ(paint.setColorSource(null_color_source).getColorSource(), nullptr);
+  EXPECT_EQ(paint.setColorFilter(null_color_filter).getColorFilter(), nullptr);
+  EXPECT_EQ(paint.setImageFilter(null_image_filter).getImageFilter(), nullptr);
+  EXPECT_EQ(paint.setMaskFilter(null_mask_filter).getMaskFilter(), nullptr);
 }
 
 TEST(DisplayListPaint, NullSharedPointerSetGet) {
-  std::shared_ptr<DlColorSource> nullColorSource;
-  std::shared_ptr<DlColorFilter> nullColorFilter;
-  std::shared_ptr<DlImageFilter> nullImageFilter;
-  std::shared_ptr<DlMaskFilter> nullMaskFilter;
+  std::shared_ptr<DlColorSource> null_color_source;
+  std::shared_ptr<DlColorFilter> null_color_filter;
+  std::shared_ptr<DlImageFilter> null_image_filter;
+  std::shared_ptr<DlMaskFilter> null_mask_filter;
   DlPaint paint;
-  EXPECT_EQ(paint.setColorSource(nullColorSource).getColorSource(), nullptr);
-  EXPECT_EQ(paint.setColorFilter(nullColorFilter).getColorFilter(), nullptr);
-  EXPECT_EQ(paint.setImageFilter(nullImageFilter).getImageFilter(), nullptr);
-  EXPECT_EQ(paint.setMaskFilter(nullMaskFilter).getMaskFilter(), nullptr);
+  EXPECT_EQ(paint.setColorSource(null_color_source).getColorSource(), nullptr);
+  EXPECT_EQ(paint.setColorFilter(null_color_filter).getColorFilter(), nullptr);
+  EXPECT_EQ(paint.setImageFilter(null_image_filter).getImageFilter(), nullptr);
+  EXPECT_EQ(paint.setMaskFilter(null_mask_filter).getMaskFilter(), nullptr);
 }
 
 TEST(DisplayListPaint, ChainingConstructor) {

--- a/display_list/display_list_path_effect_unittests.cc
+++ b/display_list/display_list_path_effect_unittests.cc
@@ -14,8 +14,8 @@ namespace flutter {
 namespace testing {
 
 TEST(DisplayListPathEffect, BuilderSetGet) {
-  const SkScalar TestDashes1[] = {4.0, 2.0};
-  auto dash_path_effect = DlDashPathEffect::Make(TestDashes1, 2, 0.0);
+  const SkScalar test_dashes[] = {4.0, 2.0};
+  auto dash_path_effect = DlDashPathEffect::Make(test_dashes, 2, 0.0);
   DisplayListBuilder builder;
   ASSERT_EQ(builder.getPathEffect(), nullptr);
   builder.setPathEffect(dash_path_effect.get());
@@ -65,15 +65,15 @@ TEST(DisplayListPathEffect, DashEffectEquals) {
 }
 
 TEST(DisplayListPathEffect, CheckEffectProperties) {
-  const SkScalar TestDashes1[] = {4.0, 2.0};
+  const SkScalar test_dashes[] = {4.0, 2.0};
   const SkScalar TestDashes2[] = {5.0, 2.0};
   const SkScalar TestDashes3[] = {4.0, 3.0};
   const SkScalar TestDashes4[] = {4.0, 2.0, 6.0};
-  auto effect1 = DlDashPathEffect::Make(TestDashes1, 2, 0.0);
+  auto effect1 = DlDashPathEffect::Make(test_dashes, 2, 0.0);
   auto effect2 = DlDashPathEffect::Make(TestDashes2, 2, 0.0);
   auto effect3 = DlDashPathEffect::Make(TestDashes3, 2, 0.0);
   auto effect4 = DlDashPathEffect::Make(TestDashes4, 3, 0.0);
-  auto effect5 = DlDashPathEffect::Make(TestDashes1, 2, 1.0);
+  auto effect5 = DlDashPathEffect::Make(test_dashes, 2, 1.0);
 
   TestNotEquals(*effect1, *effect2, "Interval 1 differs");
   TestNotEquals(*effect1, *effect3, "Interval 2 differs");
@@ -82,40 +82,40 @@ TEST(DisplayListPathEffect, CheckEffectProperties) {
 }
 
 TEST(DisplayListPathEffect, UnknownConstructor) {
-  const SkScalar TestDashes1[] = {4.0, 2.0};
-  DlUnknownPathEffect path_effect(SkDashPathEffect::Make(TestDashes1, 2, 0.0));
+  const SkScalar test_dashes[] = {4.0, 2.0};
+  DlUnknownPathEffect path_effect(SkDashPathEffect::Make(test_dashes, 2, 0.0));
 }
 
 TEST(DisplayListPathEffect, UnknownShared) {
-  const SkScalar TestDashes1[] = {4.0, 2.0};
-  DlUnknownPathEffect path_effect(SkDashPathEffect::Make(TestDashes1, 2, 0.0));
+  const SkScalar test_dashes[] = {4.0, 2.0};
+  DlUnknownPathEffect path_effect(SkDashPathEffect::Make(test_dashes, 2, 0.0));
   ASSERT_NE(path_effect.shared().get(), &path_effect);
   ASSERT_EQ(*path_effect.shared(), path_effect);
 }
 
 TEST(DisplayListPathEffect, UnknownContents) {
-  const SkScalar TestDashes1[] = {4.0, 2.0};
-  sk_sp<SkPathEffect> sk_effect = SkDashPathEffect::Make(TestDashes1, 2, 0.0);
+  const SkScalar test_dashes[] = {4.0, 2.0};
+  sk_sp<SkPathEffect> sk_effect = SkDashPathEffect::Make(test_dashes, 2, 0.0);
   DlUnknownPathEffect effect(sk_effect);
   ASSERT_EQ(effect.skia_object(), sk_effect);
   ASSERT_EQ(effect.skia_object().get(), sk_effect.get());
 }
 
 TEST(DisplayListPathEffect, UnknownEquals) {
-  const SkScalar TestDashes1[] = {4.0, 2.0};
-  sk_sp<SkPathEffect> sk_effect = SkDashPathEffect::Make(TestDashes1, 2, 0.0);
+  const SkScalar test_dashes[] = {4.0, 2.0};
+  sk_sp<SkPathEffect> sk_effect = SkDashPathEffect::Make(test_dashes, 2, 0.0);
   DlUnknownPathEffect effect1(sk_effect);
   DlUnknownPathEffect effect2(sk_effect);
   TestEquals(effect1, effect1);
 }
 
 TEST(DisplayListPathEffect, UnknownNotEquals) {
-  const SkScalar TestDashes1[] = {4.0, 2.0};
+  const SkScalar test_dashes[] = {4.0, 2.0};
   // Even though the effect is the same, it is a different instance
   // and we cannot currently tell them apart because the Skia
   // DashEffect::Make objects do not implement ==
-  DlUnknownPathEffect path_effect1(SkDashPathEffect::Make(TestDashes1, 2, 0.0));
-  DlUnknownPathEffect path_effect2(SkDashPathEffect::Make(TestDashes1, 2, 0.0));
+  DlUnknownPathEffect path_effect1(SkDashPathEffect::Make(test_dashes, 2, 0.0));
+  DlUnknownPathEffect path_effect2(SkDashPathEffect::Make(test_dashes, 2, 0.0));
   TestNotEquals(path_effect1, path_effect2,
                 "SkDashPathEffect instance differs");
 }

--- a/display_list/display_list_test_utils.cc
+++ b/display_list/display_list_test_utils.cc
@@ -988,9 +988,9 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
             [](DisplayListBuilder& b) {
               static SkRSXform xforms[] = {{1, 0, 0, 0}, {0, 1, 0, 0}};
               static SkRect texs[] = {{10, 10, 20, 20}, {20, 20, 30, 30}};
-              static SkRect cullRect = {0, 0, 200, 200};
+              static SkRect cull_rect = {0, 0, 200, 200};
               b.drawAtlas(TestImage2, xforms, texs, nullptr, 2,
-                          DlBlendMode::kSrcIn, kNearestSampling, &cullRect,
+                          DlBlendMode::kSrcIn, kNearestSampling, &cull_rect,
                           false);
             }},
            {1, 48 + 32 + 8 + 8, -1, 48 + 32 + 32 + 8,
@@ -1007,9 +1007,9 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
               static SkRSXform xforms[] = {{1, 0, 0, 0}, {0, 1, 0, 0}};
               static SkRect texs[] = {{10, 10, 20, 20}, {20, 20, 30, 30}};
               static DlColor colors[] = {DlColor::kBlue(), DlColor::kGreen()};
-              static SkRect cullRect = {0, 0, 200, 200};
+              static SkRect cull_rect = {0, 0, 200, 200};
               b.drawAtlas(TestImage1, xforms, texs, colors, 2,
-                          DlBlendMode::kSrcIn, kNearestSampling, &cullRect,
+                          DlBlendMode::kSrcIn, kNearestSampling, &cull_rect,
                           false);
             }},
        }},
@@ -1099,19 +1099,20 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
 
 std::vector<DisplayListInvocationGroup> CreateAllGroups() {
   std::vector<DisplayListInvocationGroup> result;
-  auto allAttributesOps = CreateAllAttributesOps();
-  std::move(allAttributesOps.begin(), allAttributesOps.end(),
+  auto all_attribute_ops = CreateAllAttributesOps();
+  std::move(all_attribute_ops.begin(), all_attribute_ops.end(),
             std::back_inserter(result));
-  auto allSaveRestoreOps = CreateAllSaveRestoreOps();
-  std::move(allSaveRestoreOps.begin(), allSaveRestoreOps.end(),
+  auto all_save_restore_ops = CreateAllSaveRestoreOps();
+  std::move(all_save_restore_ops.begin(), all_save_restore_ops.end(),
             std::back_inserter(result));
-  auto allTransformOps = CreateAllTransformOps();
-  std::move(allTransformOps.begin(), allTransformOps.end(),
+  auto all_transform_ops = CreateAllTransformOps();
+  std::move(all_transform_ops.begin(), all_transform_ops.end(),
             std::back_inserter(result));
-  auto allClipOps = CreateAllClipOps();
-  std::move(allClipOps.begin(), allClipOps.end(), std::back_inserter(result));
-  auto allRenderingOps = CreateAllRenderingOps();
-  std::move(allRenderingOps.begin(), allRenderingOps.end(),
+  auto all_clip_ops = CreateAllClipOps();
+  std::move(all_clip_ops.begin(), all_clip_ops.end(),
+            std::back_inserter(result));
+  auto all_rendering_ops = CreateAllRenderingOps();
+  std::move(all_rendering_ops.begin(), all_rendering_ops.end(),
             std::back_inserter(result));
   return result;
 }

--- a/display_list/display_list_unittests.cc
+++ b/display_list/display_list_unittests.cc
@@ -129,17 +129,17 @@ TEST(DisplayList, SingleOpDisplayListsRecapturedViaSkCanvasAreEqual) {
 
 TEST(DisplayList, SingleOpDisplayListsCompareToEachOther) {
   for (auto& group : allGroups) {
-    std::vector<sk_sp<DisplayList>> listsA;
-    std::vector<sk_sp<DisplayList>> listsB;
+    std::vector<sk_sp<DisplayList>> lists_a;
+    std::vector<sk_sp<DisplayList>> lists_b;
     for (size_t i = 0; i < group.variants.size(); i++) {
-      listsA.push_back(group.variants[i].Build());
-      listsB.push_back(group.variants[i].Build());
+      lists_a.push_back(group.variants[i].Build());
+      lists_b.push_back(group.variants[i].Build());
     }
 
-    for (size_t i = 0; i < listsA.size(); i++) {
-      sk_sp<DisplayList> listA = listsA[i];
-      for (size_t j = 0; j < listsB.size(); j++) {
-        sk_sp<DisplayList> listB = listsB[j];
+    for (size_t i = 0; i < lists_a.size(); i++) {
+      sk_sp<DisplayList> listA = lists_a[i];
+      for (size_t j = 0; j < lists_b.size(); j++) {
+        sk_sp<DisplayList> listB = lists_b[j];
         auto desc = group.op_name + "(variant " + std::to_string(i + 1) +
                     " ==? variant " + std::to_string(j + 1) + ")";
         if (i == j ||
@@ -1113,17 +1113,17 @@ TEST(DisplayList, TranslateAffectsCurrentTransform) {
   builder.translate(12.3, 14.5);
   SkMatrix matrix = SkMatrix::Translate(12.3, 14.5);
   SkM44 m44 = SkM44(matrix);
-  SkM44 curM44 = builder.getTransformFullPerspective();
-  SkMatrix curMatrix = builder.getTransform();
-  ASSERT_EQ(curM44, m44);
-  ASSERT_EQ(curMatrix, matrix);
+  SkM44 cur_m44 = builder.getTransformFullPerspective();
+  SkMatrix cur_matrix = builder.getTransform();
+  ASSERT_EQ(cur_m44, m44);
+  ASSERT_EQ(cur_matrix, matrix);
   builder.translate(10, 10);
   // CurrentTransform has changed
   ASSERT_NE(builder.getTransformFullPerspective(), m44);
-  ASSERT_NE(builder.getTransform(), curMatrix);
+  ASSERT_NE(builder.getTransform(), cur_matrix);
   // Previous return values have not
-  ASSERT_EQ(curM44, m44);
-  ASSERT_EQ(curMatrix, matrix);
+  ASSERT_EQ(cur_m44, m44);
+  ASSERT_EQ(cur_matrix, matrix);
 }
 
 TEST(DisplayList, ScaleAffectsCurrentTransform) {
@@ -1131,17 +1131,17 @@ TEST(DisplayList, ScaleAffectsCurrentTransform) {
   builder.scale(12.3, 14.5);
   SkMatrix matrix = SkMatrix::Scale(12.3, 14.5);
   SkM44 m44 = SkM44(matrix);
-  SkM44 curM44 = builder.getTransformFullPerspective();
-  SkMatrix curMatrix = builder.getTransform();
-  ASSERT_EQ(curM44, m44);
-  ASSERT_EQ(curMatrix, matrix);
+  SkM44 cur_m44 = builder.getTransformFullPerspective();
+  SkMatrix cur_matrix = builder.getTransform();
+  ASSERT_EQ(cur_m44, m44);
+  ASSERT_EQ(cur_matrix, matrix);
   builder.translate(10, 10);
   // CurrentTransform has changed
   ASSERT_NE(builder.getTransformFullPerspective(), m44);
-  ASSERT_NE(builder.getTransform(), curMatrix);
+  ASSERT_NE(builder.getTransform(), cur_matrix);
   // Previous return values have not
-  ASSERT_EQ(curM44, m44);
-  ASSERT_EQ(curMatrix, matrix);
+  ASSERT_EQ(cur_m44, m44);
+  ASSERT_EQ(cur_matrix, matrix);
 }
 
 TEST(DisplayList, RotateAffectsCurrentTransform) {
@@ -1149,17 +1149,17 @@ TEST(DisplayList, RotateAffectsCurrentTransform) {
   builder.rotate(12.3);
   SkMatrix matrix = SkMatrix::RotateDeg(12.3);
   SkM44 m44 = SkM44(matrix);
-  SkM44 curM44 = builder.getTransformFullPerspective();
-  SkMatrix curMatrix = builder.getTransform();
-  ASSERT_EQ(curM44, m44);
-  ASSERT_EQ(curMatrix, matrix);
+  SkM44 cur_m44 = builder.getTransformFullPerspective();
+  SkMatrix cur_matrix = builder.getTransform();
+  ASSERT_EQ(cur_m44, m44);
+  ASSERT_EQ(cur_matrix, matrix);
   builder.translate(10, 10);
   // CurrentTransform has changed
   ASSERT_NE(builder.getTransformFullPerspective(), m44);
-  ASSERT_NE(builder.getTransform(), curMatrix);
+  ASSERT_NE(builder.getTransform(), cur_matrix);
   // Previous return values have not
-  ASSERT_EQ(curM44, m44);
-  ASSERT_EQ(curMatrix, matrix);
+  ASSERT_EQ(cur_m44, m44);
+  ASSERT_EQ(cur_matrix, matrix);
 }
 
 TEST(DisplayList, SkewAffectsCurrentTransform) {
@@ -1167,17 +1167,17 @@ TEST(DisplayList, SkewAffectsCurrentTransform) {
   builder.skew(12.3, 14.5);
   SkMatrix matrix = SkMatrix::Skew(12.3, 14.5);
   SkM44 m44 = SkM44(matrix);
-  SkM44 curM44 = builder.getTransformFullPerspective();
-  SkMatrix curMatrix = builder.getTransform();
-  ASSERT_EQ(curM44, m44);
-  ASSERT_EQ(curMatrix, matrix);
+  SkM44 cur_m44 = builder.getTransformFullPerspective();
+  SkMatrix cur_matrix = builder.getTransform();
+  ASSERT_EQ(cur_m44, m44);
+  ASSERT_EQ(cur_matrix, matrix);
   builder.translate(10, 10);
   // CurrentTransform has changed
   ASSERT_NE(builder.getTransformFullPerspective(), m44);
-  ASSERT_NE(builder.getTransform(), curMatrix);
+  ASSERT_NE(builder.getTransform(), cur_matrix);
   // Previous return values have not
-  ASSERT_EQ(curM44, m44);
-  ASSERT_EQ(curMatrix, matrix);
+  ASSERT_EQ(cur_m44, m44);
+  ASSERT_EQ(cur_matrix, matrix);
 }
 
 TEST(DisplayList, TransformAffectsCurrentTransform) {
@@ -1188,17 +1188,17 @@ TEST(DisplayList, TransformAffectsCurrentTransform) {
                                       1, 5, 14.5,  //
                                       0, 0, 1);
   SkM44 m44 = SkM44(matrix);
-  SkM44 curM44 = builder.getTransformFullPerspective();
-  SkMatrix curMatrix = builder.getTransform();
-  ASSERT_EQ(curM44, m44);
-  ASSERT_EQ(curMatrix, matrix);
+  SkM44 cur_m44 = builder.getTransformFullPerspective();
+  SkMatrix cur_matrix = builder.getTransform();
+  ASSERT_EQ(cur_m44, m44);
+  ASSERT_EQ(cur_matrix, matrix);
   builder.translate(10, 10);
   // CurrentTransform has changed
   ASSERT_NE(builder.getTransformFullPerspective(), m44);
-  ASSERT_NE(builder.getTransform(), curMatrix);
+  ASSERT_NE(builder.getTransform(), cur_matrix);
   // Previous return values have not
-  ASSERT_EQ(curM44, m44);
-  ASSERT_EQ(curMatrix, matrix);
+  ASSERT_EQ(cur_m44, m44);
+  ASSERT_EQ(cur_matrix, matrix);
 }
 
 TEST(DisplayList, FullTransformAffectsCurrentTransform) {
@@ -1214,123 +1214,123 @@ TEST(DisplayList, FullTransformAffectsCurrentTransform) {
                     1, 5, 3, 14.5,  //
                     0, 0, 7, 16.2,  //
                     0, 0, 0, 1);
-  SkM44 curM44 = builder.getTransformFullPerspective();
-  SkMatrix curMatrix = builder.getTransform();
-  ASSERT_EQ(curM44, m44);
-  ASSERT_EQ(curMatrix, matrix);
+  SkM44 cur_m44 = builder.getTransformFullPerspective();
+  SkMatrix cur_matrix = builder.getTransform();
+  ASSERT_EQ(cur_m44, m44);
+  ASSERT_EQ(cur_matrix, matrix);
   builder.translate(10, 10);
   // CurrentTransform has changed
   ASSERT_NE(builder.getTransformFullPerspective(), m44);
-  ASSERT_NE(builder.getTransform(), curMatrix);
+  ASSERT_NE(builder.getTransform(), cur_matrix);
   // Previous return values have not
-  ASSERT_EQ(curM44, m44);
-  ASSERT_EQ(curMatrix, matrix);
+  ASSERT_EQ(cur_m44, m44);
+  ASSERT_EQ(cur_matrix, matrix);
 }
 
 TEST(DisplayList, ClipRectAffectsClipBounds) {
   DisplayListBuilder builder;
-  SkRect clipBounds = SkRect::MakeLTRB(10.2, 11.3, 20.4, 25.7);
-  SkRect clipExpandedBounds = SkRect::MakeLTRB(10, 11, 21, 26);
-  builder.clipRect(clipBounds, SkClipOp::kIntersect, false);
+  SkRect clip_bounds = SkRect::MakeLTRB(10.2, 11.3, 20.4, 25.7);
+  SkRect clip_expanded_bounds = SkRect::MakeLTRB(10, 11, 21, 26);
+  builder.clipRect(clip_bounds, SkClipOp::kIntersect, false);
 
   // Save initial return values for testing restored values
-  SkRect initialLocalBounds = builder.getLocalClipBounds();
-  SkRect initialDestinationBounds = builder.getDestinationClipBounds();
-  ASSERT_EQ(initialLocalBounds, clipExpandedBounds);
-  ASSERT_EQ(initialDestinationBounds, clipBounds);
+  SkRect initial_local_bounds = builder.getLocalClipBounds();
+  SkRect initial_destination_bounds = builder.getDestinationClipBounds();
+  ASSERT_EQ(initial_local_bounds, clip_expanded_bounds);
+  ASSERT_EQ(initial_destination_bounds, clip_bounds);
 
   builder.save();
   builder.clipRect({0, 0, 15, 15}, SkClipOp::kIntersect, false);
   // Both clip bounds have changed
-  ASSERT_NE(builder.getLocalClipBounds(), clipExpandedBounds);
-  ASSERT_NE(builder.getDestinationClipBounds(), clipBounds);
+  ASSERT_NE(builder.getLocalClipBounds(), clip_expanded_bounds);
+  ASSERT_NE(builder.getDestinationClipBounds(), clip_bounds);
   // Previous return values have not changed
-  ASSERT_EQ(initialLocalBounds, clipExpandedBounds);
-  ASSERT_EQ(initialDestinationBounds, clipBounds);
+  ASSERT_EQ(initial_local_bounds, clip_expanded_bounds);
+  ASSERT_EQ(initial_destination_bounds, clip_bounds);
   builder.restore();
 
   // save/restore returned the values to their original values
-  ASSERT_EQ(builder.getLocalClipBounds(), initialLocalBounds);
-  ASSERT_EQ(builder.getDestinationClipBounds(), initialDestinationBounds);
+  ASSERT_EQ(builder.getLocalClipBounds(), initial_local_bounds);
+  ASSERT_EQ(builder.getDestinationClipBounds(), initial_destination_bounds);
 
   builder.save();
   builder.scale(2, 2);
-  SkRect scaledExpandedBounds = SkRect::MakeLTRB(5, 5.5, 10.5, 13);
-  ASSERT_EQ(builder.getLocalClipBounds(), scaledExpandedBounds);
+  SkRect scaled_expanded_bounds = SkRect::MakeLTRB(5, 5.5, 10.5, 13);
+  ASSERT_EQ(builder.getLocalClipBounds(), scaled_expanded_bounds);
   // Destination bounds are unaffected by transform
-  ASSERT_EQ(builder.getDestinationClipBounds(), clipBounds);
+  ASSERT_EQ(builder.getDestinationClipBounds(), clip_bounds);
   builder.restore();
 
   // save/restore returned the values to their original values
-  ASSERT_EQ(builder.getLocalClipBounds(), initialLocalBounds);
-  ASSERT_EQ(builder.getDestinationClipBounds(), initialDestinationBounds);
+  ASSERT_EQ(builder.getLocalClipBounds(), initial_local_bounds);
+  ASSERT_EQ(builder.getDestinationClipBounds(), initial_destination_bounds);
 }
 
 TEST(DisplayList, ClipRectAffectsClipBoundsWithMatrix) {
   DisplayListBuilder builder;
-  SkRect clipBounds1 = SkRect::MakeLTRB(0, 0, 10, 10);
-  SkRect clipBounds2 = SkRect::MakeLTRB(10, 10, 20, 20);
+  SkRect clip_bounds_1 = SkRect::MakeLTRB(0, 0, 10, 10);
+  SkRect clip_bounds_2 = SkRect::MakeLTRB(10, 10, 20, 20);
   builder.save();
-  builder.clipRect(clipBounds1, SkClipOp::kIntersect, false);
+  builder.clipRect(clip_bounds_1, SkClipOp::kIntersect, false);
   builder.translate(10, 0);
-  builder.clipRect(clipBounds1, SkClipOp::kIntersect, false);
+  builder.clipRect(clip_bounds_1, SkClipOp::kIntersect, false);
   ASSERT_TRUE(builder.getDestinationClipBounds().isEmpty());
   builder.restore();
 
   builder.save();
-  builder.clipRect(clipBounds1, SkClipOp::kIntersect, false);
+  builder.clipRect(clip_bounds_1, SkClipOp::kIntersect, false);
   builder.translate(-10, -10);
-  builder.clipRect(clipBounds2, SkClipOp::kIntersect, false);
-  ASSERT_EQ(builder.getDestinationClipBounds(), clipBounds1);
+  builder.clipRect(clip_bounds_2, SkClipOp::kIntersect, false);
+  ASSERT_EQ(builder.getDestinationClipBounds(), clip_bounds_1);
   builder.restore();
 }
 
 TEST(DisplayList, ClipRRectAffectsClipBounds) {
   DisplayListBuilder builder;
-  SkRect clipBounds = SkRect::MakeLTRB(10.2, 11.3, 20.4, 25.7);
-  SkRect clipExpandedBounds = SkRect::MakeLTRB(10, 11, 21, 26);
-  SkRRect clip = SkRRect::MakeRectXY(clipBounds, 3, 2);
+  SkRect clip_bounds = SkRect::MakeLTRB(10.2, 11.3, 20.4, 25.7);
+  SkRect clip_expanded_bounds = SkRect::MakeLTRB(10, 11, 21, 26);
+  SkRRect clip = SkRRect::MakeRectXY(clip_bounds, 3, 2);
   builder.clipRRect(clip, SkClipOp::kIntersect, false);
 
   // Save initial return values for testing restored values
-  SkRect initialLocalBounds = builder.getLocalClipBounds();
-  SkRect initialDestinationBounds = builder.getDestinationClipBounds();
-  ASSERT_EQ(initialLocalBounds, clipExpandedBounds);
-  ASSERT_EQ(initialDestinationBounds, clipBounds);
+  SkRect initial_local_bounds = builder.getLocalClipBounds();
+  SkRect initial_destination_bounds = builder.getDestinationClipBounds();
+  ASSERT_EQ(initial_local_bounds, clip_expanded_bounds);
+  ASSERT_EQ(initial_destination_bounds, clip_bounds);
 
   builder.save();
   builder.clipRect({0, 0, 15, 15}, SkClipOp::kIntersect, false);
   // Both clip bounds have changed
-  ASSERT_NE(builder.getLocalClipBounds(), clipExpandedBounds);
-  ASSERT_NE(builder.getDestinationClipBounds(), clipBounds);
+  ASSERT_NE(builder.getLocalClipBounds(), clip_expanded_bounds);
+  ASSERT_NE(builder.getDestinationClipBounds(), clip_bounds);
   // Previous return values have not changed
-  ASSERT_EQ(initialLocalBounds, clipExpandedBounds);
-  ASSERT_EQ(initialDestinationBounds, clipBounds);
+  ASSERT_EQ(initial_local_bounds, clip_expanded_bounds);
+  ASSERT_EQ(initial_destination_bounds, clip_bounds);
   builder.restore();
 
   // save/restore returned the values to their original values
-  ASSERT_EQ(builder.getLocalClipBounds(), initialLocalBounds);
-  ASSERT_EQ(builder.getDestinationClipBounds(), initialDestinationBounds);
+  ASSERT_EQ(builder.getLocalClipBounds(), initial_local_bounds);
+  ASSERT_EQ(builder.getDestinationClipBounds(), initial_destination_bounds);
 
   builder.save();
   builder.scale(2, 2);
-  SkRect scaledExpandedBounds = SkRect::MakeLTRB(5, 5.5, 10.5, 13);
-  ASSERT_EQ(builder.getLocalClipBounds(), scaledExpandedBounds);
+  SkRect scaled_expanded_bounds = SkRect::MakeLTRB(5, 5.5, 10.5, 13);
+  ASSERT_EQ(builder.getLocalClipBounds(), scaled_expanded_bounds);
   // Destination bounds are unaffected by transform
-  ASSERT_EQ(builder.getDestinationClipBounds(), clipBounds);
+  ASSERT_EQ(builder.getDestinationClipBounds(), clip_bounds);
   builder.restore();
 
   // save/restore returned the values to their original values
-  ASSERT_EQ(builder.getLocalClipBounds(), initialLocalBounds);
-  ASSERT_EQ(builder.getDestinationClipBounds(), initialDestinationBounds);
+  ASSERT_EQ(builder.getLocalClipBounds(), initial_local_bounds);
+  ASSERT_EQ(builder.getDestinationClipBounds(), initial_destination_bounds);
 }
 
 TEST(DisplayList, ClipRRectAffectsClipBoundsWithMatrix) {
   DisplayListBuilder builder;
-  SkRect clipBounds1 = SkRect::MakeLTRB(0, 0, 10, 10);
-  SkRect clipBounds2 = SkRect::MakeLTRB(10, 10, 20, 20);
-  SkRRect clip1 = SkRRect::MakeRectXY(clipBounds1, 3, 2);
-  SkRRect clip2 = SkRRect::MakeRectXY(clipBounds2, 3, 2);
+  SkRect clip_bounds_1 = SkRect::MakeLTRB(0, 0, 10, 10);
+  SkRect clip_bounds_2 = SkRect::MakeLTRB(10, 10, 20, 20);
+  SkRRect clip1 = SkRRect::MakeRectXY(clip_bounds_1, 3, 2);
+  SkRRect clip2 = SkRRect::MakeRectXY(clip_bounds_2, 3, 2);
 
   builder.save();
   builder.clipRRect(clip1, SkClipOp::kIntersect, false);
@@ -1343,53 +1343,53 @@ TEST(DisplayList, ClipRRectAffectsClipBoundsWithMatrix) {
   builder.clipRRect(clip1, SkClipOp::kIntersect, false);
   builder.translate(-10, -10);
   builder.clipRRect(clip2, SkClipOp::kIntersect, false);
-  ASSERT_EQ(builder.getDestinationClipBounds(), clipBounds1);
+  ASSERT_EQ(builder.getDestinationClipBounds(), clip_bounds_1);
   builder.restore();
 }
 
 TEST(DisplayList, ClipPathAffectsClipBounds) {
   DisplayListBuilder builder;
   SkPath clip = SkPath().addCircle(10.2, 11.3, 2).addCircle(20.4, 25.7, 2);
-  SkRect clipBounds = SkRect::MakeLTRB(8.2, 9.3, 22.4, 27.7);
-  SkRect clipExpandedBounds = SkRect::MakeLTRB(8, 9, 23, 28);
+  SkRect clip_bounds = SkRect::MakeLTRB(8.2, 9.3, 22.4, 27.7);
+  SkRect clip_expanded_bounds = SkRect::MakeLTRB(8, 9, 23, 28);
   builder.clipPath(clip, SkClipOp::kIntersect, false);
 
   // Save initial return values for testing restored values
-  SkRect initialLocalBounds = builder.getLocalClipBounds();
-  SkRect initialDestinationBounds = builder.getDestinationClipBounds();
-  ASSERT_EQ(initialLocalBounds, clipExpandedBounds);
-  ASSERT_EQ(initialDestinationBounds, clipBounds);
+  SkRect initial_local_bounds = builder.getLocalClipBounds();
+  SkRect initial_destination_bounds = builder.getDestinationClipBounds();
+  ASSERT_EQ(initial_local_bounds, clip_expanded_bounds);
+  ASSERT_EQ(initial_destination_bounds, clip_bounds);
 
   builder.save();
   builder.clipRect({0, 0, 15, 15}, SkClipOp::kIntersect, false);
   // Both clip bounds have changed
-  ASSERT_NE(builder.getLocalClipBounds(), clipExpandedBounds);
-  ASSERT_NE(builder.getDestinationClipBounds(), clipBounds);
+  ASSERT_NE(builder.getLocalClipBounds(), clip_expanded_bounds);
+  ASSERT_NE(builder.getDestinationClipBounds(), clip_bounds);
   // Previous return values have not changed
-  ASSERT_EQ(initialLocalBounds, clipExpandedBounds);
-  ASSERT_EQ(initialDestinationBounds, clipBounds);
+  ASSERT_EQ(initial_local_bounds, clip_expanded_bounds);
+  ASSERT_EQ(initial_destination_bounds, clip_bounds);
   builder.restore();
 
   // save/restore returned the values to their original values
-  ASSERT_EQ(builder.getLocalClipBounds(), initialLocalBounds);
-  ASSERT_EQ(builder.getDestinationClipBounds(), initialDestinationBounds);
+  ASSERT_EQ(builder.getLocalClipBounds(), initial_local_bounds);
+  ASSERT_EQ(builder.getDestinationClipBounds(), initial_destination_bounds);
 
   builder.save();
   builder.scale(2, 2);
-  SkRect scaledExpandedBounds = SkRect::MakeLTRB(4, 4.5, 11.5, 14);
-  ASSERT_EQ(builder.getLocalClipBounds(), scaledExpandedBounds);
+  SkRect scaled_expanded_bounds = SkRect::MakeLTRB(4, 4.5, 11.5, 14);
+  ASSERT_EQ(builder.getLocalClipBounds(), scaled_expanded_bounds);
   // Destination bounds are unaffected by transform
-  ASSERT_EQ(builder.getDestinationClipBounds(), clipBounds);
+  ASSERT_EQ(builder.getDestinationClipBounds(), clip_bounds);
   builder.restore();
 
   // save/restore returned the values to their original values
-  ASSERT_EQ(builder.getLocalClipBounds(), initialLocalBounds);
-  ASSERT_EQ(builder.getDestinationClipBounds(), initialDestinationBounds);
+  ASSERT_EQ(builder.getLocalClipBounds(), initial_local_bounds);
+  ASSERT_EQ(builder.getDestinationClipBounds(), initial_destination_bounds);
 }
 
 TEST(DisplayList, ClipPathAffectsClipBoundsWithMatrix) {
   DisplayListBuilder builder;
-  SkRect clipBounds = SkRect::MakeLTRB(0, 0, 10, 10);
+  SkRect clip_bounds = SkRect::MakeLTRB(0, 0, 10, 10);
   SkPath clip1 = SkPath().addCircle(2.5, 2.5, 2.5).addCircle(7.5, 7.5, 2.5);
   SkPath clip2 = SkPath().addCircle(12.5, 12.5, 2.5).addCircle(17.5, 17.5, 2.5);
 
@@ -1404,64 +1404,64 @@ TEST(DisplayList, ClipPathAffectsClipBoundsWithMatrix) {
   builder.clipPath(clip1, SkClipOp::kIntersect, false);
   builder.translate(-10, -10);
   builder.clipPath(clip2, SkClipOp::kIntersect, false);
-  ASSERT_EQ(builder.getDestinationClipBounds(), clipBounds);
+  ASSERT_EQ(builder.getDestinationClipBounds(), clip_bounds);
   builder.restore();
 }
 
 TEST(DisplayList, DiffClipRectDoesNotAffectClipBounds) {
   DisplayListBuilder builder;
   SkRect diff_clip = SkRect::MakeLTRB(0, 0, 15, 15);
-  SkRect clipBounds = SkRect::MakeLTRB(10.2, 11.3, 20.4, 25.7);
-  SkRect clipExpandedBounds = SkRect::MakeLTRB(10, 11, 21, 26);
-  builder.clipRect(clipBounds, SkClipOp::kIntersect, false);
+  SkRect clip_bounds = SkRect::MakeLTRB(10.2, 11.3, 20.4, 25.7);
+  SkRect clip_expanded_bounds = SkRect::MakeLTRB(10, 11, 21, 26);
+  builder.clipRect(clip_bounds, SkClipOp::kIntersect, false);
 
   // Save initial return values for testing after kDifference clip
-  SkRect initialLocalBounds = builder.getLocalClipBounds();
-  SkRect initialDestinationBounds = builder.getDestinationClipBounds();
-  ASSERT_EQ(initialLocalBounds, clipExpandedBounds);
-  ASSERT_EQ(initialDestinationBounds, clipBounds);
+  SkRect initial_local_bounds = builder.getLocalClipBounds();
+  SkRect initial_destination_bounds = builder.getDestinationClipBounds();
+  ASSERT_EQ(initial_local_bounds, clip_expanded_bounds);
+  ASSERT_EQ(initial_destination_bounds, clip_bounds);
 
   builder.clipRect(diff_clip, SkClipOp::kDifference, false);
-  ASSERT_EQ(builder.getLocalClipBounds(), initialLocalBounds);
-  ASSERT_EQ(builder.getDestinationClipBounds(), initialDestinationBounds);
+  ASSERT_EQ(builder.getLocalClipBounds(), initial_local_bounds);
+  ASSERT_EQ(builder.getDestinationClipBounds(), initial_destination_bounds);
 }
 
 TEST(DisplayList, DiffClipRRectDoesNotAffectClipBounds) {
   DisplayListBuilder builder;
   SkRRect diff_clip = SkRRect::MakeRectXY({0, 0, 15, 15}, 1, 1);
-  SkRect clipBounds = SkRect::MakeLTRB(10.2, 11.3, 20.4, 25.7);
-  SkRect clipExpandedBounds = SkRect::MakeLTRB(10, 11, 21, 26);
+  SkRect clip_bounds = SkRect::MakeLTRB(10.2, 11.3, 20.4, 25.7);
+  SkRect clip_expanded_bounds = SkRect::MakeLTRB(10, 11, 21, 26);
   SkRRect clip = SkRRect::MakeRectXY({10.2, 11.3, 20.4, 25.7}, 3, 2);
   builder.clipRRect(clip, SkClipOp::kIntersect, false);
 
   // Save initial return values for testing after kDifference clip
-  SkRect initialLocalBounds = builder.getLocalClipBounds();
-  SkRect initialDestinationBounds = builder.getDestinationClipBounds();
-  ASSERT_EQ(initialLocalBounds, clipExpandedBounds);
-  ASSERT_EQ(initialDestinationBounds, clipBounds);
+  SkRect initial_local_bounds = builder.getLocalClipBounds();
+  SkRect initial_destination_bounds = builder.getDestinationClipBounds();
+  ASSERT_EQ(initial_local_bounds, clip_expanded_bounds);
+  ASSERT_EQ(initial_destination_bounds, clip_bounds);
 
   builder.clipRRect(diff_clip, SkClipOp::kDifference, false);
-  ASSERT_EQ(builder.getLocalClipBounds(), initialLocalBounds);
-  ASSERT_EQ(builder.getDestinationClipBounds(), initialDestinationBounds);
+  ASSERT_EQ(builder.getLocalClipBounds(), initial_local_bounds);
+  ASSERT_EQ(builder.getDestinationClipBounds(), initial_destination_bounds);
 }
 
 TEST(DisplayList, DiffClipPathDoesNotAffectClipBounds) {
   DisplayListBuilder builder;
   SkPath diff_clip = SkPath().addRect({0, 0, 15, 15});
   SkPath clip = SkPath().addCircle(10.2, 11.3, 2).addCircle(20.4, 25.7, 2);
-  SkRect clipBounds = SkRect::MakeLTRB(8.2, 9.3, 22.4, 27.7);
-  SkRect clipExpandedBounds = SkRect::MakeLTRB(8, 9, 23, 28);
+  SkRect clip_bounds = SkRect::MakeLTRB(8.2, 9.3, 22.4, 27.7);
+  SkRect clip_expanded_bounds = SkRect::MakeLTRB(8, 9, 23, 28);
   builder.clipPath(clip, SkClipOp::kIntersect, false);
 
   // Save initial return values for testing after kDifference clip
-  SkRect initialLocalBounds = builder.getLocalClipBounds();
-  SkRect initialDestinationBounds = builder.getDestinationClipBounds();
-  ASSERT_EQ(initialLocalBounds, clipExpandedBounds);
-  ASSERT_EQ(initialDestinationBounds, clipBounds);
+  SkRect initial_local_bounds = builder.getLocalClipBounds();
+  SkRect initial_destination_bounds = builder.getDestinationClipBounds();
+  ASSERT_EQ(initial_local_bounds, clip_expanded_bounds);
+  ASSERT_EQ(initial_destination_bounds, clip_bounds);
 
   builder.clipPath(diff_clip, SkClipOp::kDifference, false);
-  ASSERT_EQ(builder.getLocalClipBounds(), initialLocalBounds);
-  ASSERT_EQ(builder.getDestinationClipBounds(), initialDestinationBounds);
+  ASSERT_EQ(builder.getLocalClipBounds(), initial_local_bounds);
+  ASSERT_EQ(builder.getDestinationClipBounds(), initial_destination_bounds);
 }
 
 TEST(DisplayList, ClipPathWithInvertFillTypeDoesNotAffectClipBounds) {

--- a/display_list/display_list_utils.cc
+++ b/display_list/display_list_utils.cc
@@ -212,20 +212,20 @@ void ClipBoundsDispatchHelper::clipPath(const SkPath& path,
   }
 }
 void ClipBoundsDispatchHelper::intersect(const SkRect& rect, bool is_aa) {
-  SkRect devClipBounds = matrix().mapRect(rect);
+  SkRect dev_clip_bounds = matrix().mapRect(rect);
   if (is_aa) {
-    devClipBounds.roundOut(&devClipBounds);
+    dev_clip_bounds.roundOut(&dev_clip_bounds);
   }
   if (has_clip_) {
-    if (!bounds_.intersect(devClipBounds)) {
+    if (!bounds_.intersect(dev_clip_bounds)) {
       bounds_.setEmpty();
     }
   } else {
     has_clip_ = true;
-    if (devClipBounds.isEmpty()) {
+    if (dev_clip_bounds.isEmpty()) {
       bounds_.setEmpty();
     } else {
-      bounds_ = devClipBounds;
+      bounds_ = dev_clip_bounds;
     }
   }
 }
@@ -559,11 +559,11 @@ void DisplayListBoundsCalculator::drawPoints(SkCanvas::PointMode mode,
                                              uint32_t count,
                                              const SkPoint pts[]) {
   if (count > 0) {
-    RectBoundsAccumulator ptBounds;
+    RectBoundsAccumulator pt_bounds;
     for (size_t i = 0; i < count; i++) {
-      ptBounds.accumulate(pts[i]);
+      pt_bounds.accumulate(pts[i]);
     }
-    SkRect point_bounds = ptBounds.bounds();
+    SkRect point_bounds = pt_bounds.bounds();
     switch (mode) {
       case SkCanvas::kPoints_PointMode:
         AccumulateOpBounds(point_bounds, kDrawPointsAsPointsFlags);
@@ -640,19 +640,19 @@ void DisplayListBoundsCalculator::drawAtlas(const sk_sp<DlImage> atlas,
                                             const SkRect* cullRect,
                                             bool render_with_attributes) {
   SkPoint quad[4];
-  RectBoundsAccumulator atlasBounds;
+  RectBoundsAccumulator atlas_bounds;
   for (int i = 0; i < count; i++) {
     const SkRect& src = tex[i];
     xform[i].toQuad(src.width(), src.height(), quad);
     for (int j = 0; j < 4; j++) {
-      atlasBounds.accumulate(quad[j]);
+      atlas_bounds.accumulate(quad[j]);
     }
   }
-  if (atlasBounds.is_not_empty()) {
+  if (atlas_bounds.is_not_empty()) {
     DisplayListAttributeFlags flags = render_with_attributes  //
                                           ? kDrawAtlasWithPaintFlags
                                           : kDrawAtlasFlags;
-    AccumulateOpBounds(atlasBounds.bounds(), flags);
+    AccumulateOpBounds(atlas_bounds.bounds(), flags);
   }
 }
 void DisplayListBoundsCalculator::drawPicture(const sk_sp<SkPicture> picture,


### PR DESCRIPTION
This updates local variable names to use clang `lower_case` style in the display_list directory. This is one of several patches to update our variable names to a consistent style before enabling enforcement in our clang-tidy rules.

This is a formatting-only change with no intended semantic change.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
