### PR TITLE
Move subprocess.run to popen.

### DIFF
--- a/sky/tools/create_macos_gen_snapshots.py
+++ b/sky/tools/create_macos_gen_snapshots.py
@@ -82,10 +82,16 @@ def generate_gen_snapshot(directory, destination):
     print('Cannot find gen_snapshot at %s' % gen_snapshot_dir)
     sys.exit(1)
 
-  result = subprocess.run([
+  command = [
       'xcrun', 'bitcode_strip', '-r', gen_snapshot_dir, '-o', destination
-  ])
-  if result.returncode != 0:
+  ]
+  process = subprocess.Popen(
+      command, stderr=subprocess.STDOUT, stdout=subprocess.PIPE
+  )
+  stdout, stderr = process.communicate()
+  exit_status = process.wait()
+
+  if exit_status != 0:
     print(
         'Error processing command with stdout[%s] and stderr[%s]' %
         (result.stdout, result.stderr)

--- a/sky/tools/create_macos_gen_snapshots.py
+++ b/sky/tools/create_macos_gen_snapshots.py
@@ -94,7 +94,7 @@ def generate_gen_snapshot(directory, destination):
   if exit_status != 0:
     print(
         'Error processing command with stdout[%s] and stderr[%s]' %
-        (result.stdout, result.stderr)
+        (stdout, stderr)
     )
     return 1
 


### PR DESCRIPTION
Turns out subprocess.run is available only after 3.5 and it is failing in our bots.

Bug: https://github.com/flutter/flutter/issues/81855


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
