### PR TITLE
[Impeller] Refactor compute unit tests to own TU

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -867,6 +867,7 @@ FILE: ../../../flutter/impeller/renderer/compute_pipeline_builder.cc
 FILE: ../../../flutter/impeller/renderer/compute_pipeline_builder.h
 FILE: ../../../flutter/impeller/renderer/compute_pipeline_descriptor.cc
 FILE: ../../../flutter/impeller/renderer/compute_pipeline_descriptor.h
+FILE: ../../../flutter/impeller/renderer/compute_unittests.cc
 FILE: ../../../flutter/impeller/renderer/context.cc
 FILE: ../../../flutter/impeller/renderer/context.h
 FILE: ../../../flutter/impeller/renderer/descriptor_set_layout.h

--- a/impeller/renderer/BUILD.gn
+++ b/impeller/renderer/BUILD.gn
@@ -107,6 +107,10 @@ impeller_component("renderer_unittests") {
     "renderer_unittests.cc",
   ]
 
+  if (impeller_enable_metal || impeller_enable_vulkan) {
+    sources += [ "compute_unittests.cc" ]
+  }
+
   deps = [
     ":renderer",
     "../fixtures",

--- a/impeller/renderer/compute_unittests.cc
+++ b/impeller/renderer/compute_unittests.cc
@@ -1,0 +1,66 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/fml/time/time_point.h"
+#include "flutter/testing/testing.h"
+#include "impeller/base/strings.h"
+#include "impeller/fixtures/sample.comp.h"
+#include "impeller/playground/playground_test.h"
+#include "impeller/renderer/command_buffer.h"
+#include "impeller/renderer/compute_command.h"
+#include "impeller/renderer/compute_pipeline_builder.h"
+#include "impeller/renderer/formats.h"
+#include "impeller/renderer/pipeline_library.h"
+
+namespace impeller {
+namespace testing {
+
+using ComputeTest = PlaygroundTest;
+INSTANTIATE_PLAYGROUND_SUITE(ComputeTest);
+
+TEST_P(ComputeTest, CanCreateComputePass) {
+  if (GetParam() == PlaygroundBackend::kOpenGLES) {
+    GTEST_SKIP_("Compute is not supported on GL.");
+  }
+  if (GetParam() == PlaygroundBackend::kVulkan) {
+    GTEST_SKIP_("Compute is not supported on Vulkan yet.");
+  }
+
+  using CS = SampleComputeShader;
+  auto context = GetContext();
+  ASSERT_TRUE(context);
+  using SamplePipelineBuilder = ComputePipelineBuilder<CS>;
+  auto pipeline_desc =
+      SamplePipelineBuilder::MakeDefaultPipelineDescriptor(*context);
+  ASSERT_TRUE(pipeline_desc.has_value());
+  auto compute_pipeline =
+      context->GetPipelineLibrary()->GetPipeline(pipeline_desc).get();
+  ASSERT_TRUE(compute_pipeline);
+
+  auto cmd_buffer = context->CreateCommandBuffer();
+  auto pass = cmd_buffer->CreateComputePass();
+  ASSERT_TRUE(pass && pass->IsValid());
+
+  ComputeCommand cmd;
+  cmd.label = "Compute";
+  cmd.pipeline = compute_pipeline;
+
+  std::vector<CS::Input0> input_0;
+  std::vector<CS::Input1> input_1;
+  input_0.push_back(CS::Input0{Vector4(2.0, 3.0, 4.0, 5.0)});
+  input_1.push_back(CS::Input1{Vector4(6.0, 7.0, 8.0, 9.0)});
+
+  std::vector<CS::Output> output(5);
+  CS::BindInput0(cmd,
+                 pass->GetTransientsBuffer().EmplaceStorageBuffer(input_0));
+  CS::BindInput1(cmd,
+                 pass->GetTransientsBuffer().EmplaceStorageBuffer(input_1));
+  CS::BindOutput(cmd, pass->GetTransientsBuffer().EmplaceStorageBuffer(output));
+
+  ASSERT_TRUE(pass->AddCommand(std::move(cmd)));
+  ASSERT_TRUE(pass->EncodeCommands());
+}
+
+}  // namespace testing
+}  // namespace impeller

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -15,9 +15,6 @@
 #include "impeller/fixtures/instanced_draw.vert.h"
 #include "impeller/fixtures/mipmaps.frag.h"
 #include "impeller/fixtures/mipmaps.vert.h"
-#if IMPELLER_ENABLE_METAL || IMPELLER_ENABLE_VULKAN
-#include "impeller/fixtures/sample.comp.h"
-#endif
 #include "impeller/fixtures/test_texture.frag.h"
 #include "impeller/fixtures/test_texture.vert.h"
 #include "impeller/geometry/path_builder.h"
@@ -738,51 +735,6 @@ TEST_P(RendererTest, TheImpeller) {
   };
   OpenPlaygroundHere(callback);
 }
-
-#if IMPELLER_ENABLE_METAL || IMPELLER_ENABLE_VULKAN
-TEST_P(RendererTest, CanCreateComputePass) {
-  if (GetParam() == PlaygroundBackend::kOpenGLES) {
-    GTEST_SKIP_("Compute is not supported on GL.");
-  }
-  if (GetParam() == PlaygroundBackend::kVulkan) {
-    GTEST_SKIP_("Compute is not supported on Vulkan yet.");
-  }
-
-  using CS = SampleComputeShader;
-  auto context = GetContext();
-  ASSERT_TRUE(context);
-  using SamplePipelineBuilder = ComputePipelineBuilder<CS>;
-  auto pipeline_desc =
-      SamplePipelineBuilder::MakeDefaultPipelineDescriptor(*context);
-  ASSERT_TRUE(pipeline_desc.has_value());
-  auto compute_pipeline =
-      context->GetPipelineLibrary()->GetPipeline(pipeline_desc).get();
-  ASSERT_TRUE(compute_pipeline);
-
-  auto cmd_buffer = context->CreateCommandBuffer();
-  auto pass = cmd_buffer->CreateComputePass();
-  ASSERT_TRUE(pass && pass->IsValid());
-
-  ComputeCommand cmd;
-  cmd.label = "Compute";
-  cmd.pipeline = compute_pipeline;
-
-  std::vector<CS::Input0> input_0;
-  std::vector<CS::Input1> input_1;
-  input_0.push_back(CS::Input0{Vector4(2.0, 3.0, 4.0, 5.0)});
-  input_1.push_back(CS::Input1{Vector4(6.0, 7.0, 8.0, 9.0)});
-
-  std::vector<CS::Output> output(5);
-  CS::BindInput0(cmd,
-                 pass->GetTransientsBuffer().EmplaceStorageBuffer(input_0));
-  CS::BindInput1(cmd,
-                 pass->GetTransientsBuffer().EmplaceStorageBuffer(input_1));
-  CS::BindOutput(cmd, pass->GetTransientsBuffer().EmplaceStorageBuffer(output));
-
-  ASSERT_TRUE(pass->AddCommand(std::move(cmd)));
-  ASSERT_TRUE(pass->EncodeCommands());
-}
-#endif
 
 }  // namespace testing
 }  // namespace impeller


### PR DESCRIPTION
Trivial refactor. I'm going to be adding more tests and want to avoid bloating renderer_unittests.cc