### PR TITLE
[web] Clean up duplicate golden methods

### DIFF
--- a/lib/web_ui/test/canvaskit/color_filter_golden_test.dart
+++ b/lib/web_ui/test/canvaskit/color_filter_golden_test.dart
@@ -7,8 +7,6 @@ import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' as ui;
 
-import 'package:web_engine_tester/golden_tester.dart';
-
 import 'common.dart';
 
 void main() {
@@ -16,11 +14,6 @@ void main() {
 }
 
 const ui.Rect region = ui.Rect.fromLTRB(0, 0, 500, 250);
-
-Future<void> matchSceneGolden(String goldenFile, LayerScene scene) async {
-  CanvasKitRenderer.instance.rasterizer.draw(scene.layerTree);
-  await matchGoldenFile(goldenFile, region: region);
-}
 
 void testMain() {
   group('ColorFilter', () {
@@ -66,7 +59,7 @@ void testMain() {
 
       builder.addPicture(ui.Offset.zero, greyCircle);
 
-      await matchSceneGolden('canvaskit_colorfilter.png', builder.build());
+      await matchSceneGolden('canvaskit_colorfilter.png', builder.build(), region: region);
     });
 
     test('invertColors inverts the colors', () async {
@@ -102,7 +95,7 @@ void testMain() {
 
       builder.addPicture(ui.Offset.zero, invertedCircle);
 
-      await matchSceneGolden('canvaskit_invertcolors.png', builder.build());
+      await matchSceneGolden('canvaskit_invertcolors.png', builder.build(), region: region);
     });
 
     test('ColorFilter.matrix works for inverse matrix', () async {
@@ -131,7 +124,7 @@ void testMain() {
 
       builder.addPicture(ui.Offset.zero, invertedSquares);
 
-      await matchSceneGolden('canvaskit_inverse_colormatrix.png', builder.build());
+      await matchSceneGolden('canvaskit_inverse_colormatrix.png', builder.build(), region: region);
     });
     // TODO(hterkelsen): https://github.com/flutter/flutter/issues/71520
   }, skip: isSafari || isFirefox);

--- a/lib/web_ui/test/canvaskit/common.dart
+++ b/lib/web_ui/test/canvaskit/common.dart
@@ -175,6 +175,13 @@ class TestCollector implements Collector {
   }
 }
 
+Future<void> matchSceneGolden(String goldenFile, LayerScene scene, {
+  required ui.Rect region,
+}) async {
+  CanvasKitRenderer.instance.rasterizer.draw(scene.layerTree);
+  await matchGoldenFile(goldenFile, region: region);
+}
+
 /// Checks that a [picture] matches the [goldenFile].
 ///
 /// The picture is drawn onto the UI at [ui.Offset.zero] with no additional

--- a/lib/web_ui/test/canvaskit/linear_gradient_golden_test.dart
+++ b/lib/web_ui/test/canvaskit/linear_gradient_golden_test.dart
@@ -9,8 +9,6 @@ import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' as ui;
 
-import 'package:web_engine_tester/golden_tester.dart';
-
 import 'common.dart';
 
 void main() {
@@ -18,14 +16,6 @@ void main() {
 }
 
 const ui.Rect region = ui.Rect.fromLTRB(0, 0, 500, 250);
-
-Future<void> matchPictureGolden(String goldenFile, CkPicture picture) async {
-  final LayerSceneBuilder sb = LayerSceneBuilder();
-  sb.pushOffset(0, 0);
-  sb.addPicture(ui.Offset.zero, picture);
-  CanvasKitRenderer.instance.rasterizer.draw(sb.build().layerTree);
-  await matchGoldenFile(goldenFile, region: region);
-}
 
 void testMain() {
   group('Linear', () {
@@ -62,6 +52,7 @@ void testMain() {
       await matchPictureGolden(
         'canvaskit_linear_gradient.png',
         recorder.endRecording(),
+        region: region,
       );
     });
 
@@ -96,6 +87,7 @@ void testMain() {
       await matchPictureGolden(
         'canvaskit_linear_gradient_rotated.png',
         recorder.endRecording(),
+        region: region,
       );
     });
     // TODO(hterkelsen): https://github.com/flutter/flutter/issues/71520

--- a/lib/web_ui/test/canvaskit/shader_mask_golden_test.dart
+++ b/lib/web_ui/test/canvaskit/shader_mask_golden_test.dart
@@ -8,8 +8,6 @@ import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' as ui;
 
-import 'package:web_engine_tester/golden_tester.dart';
-
 import 'common.dart';
 
 void main() {
@@ -17,11 +15,6 @@ void main() {
 }
 
 const ui.Rect region = ui.Rect.fromLTRB(0, 0, 500, 250);
-
-Future<void> matchSceneGolden(String goldenFile, LayerScene scene) async {
-  CanvasKitRenderer.instance.rasterizer.draw(scene.layerTree);
-  await matchGoldenFile(goldenFile, region: region);
-}
 
 void testMain() {
   group('ShaderMask', () {
@@ -87,8 +80,11 @@ void testMain() {
 
       builder.addPicture(ui.Offset.zero, sweepCircle);
 
-      await matchSceneGolden('canvaskit_shadermask_linear.png',
-          builder.build());
+      await matchSceneGolden(
+        'canvaskit_shadermask_linear.png',
+        builder.build(),
+        region: region,
+      );
     });
 
     /// Regression test for https://github.com/flutter/flutter/issues/78959
@@ -152,8 +148,11 @@ void testMain() {
 
       builder.addPicture(ui.Offset.zero, sweepCircle);
 
-      await matchSceneGolden('canvaskit_shadermask_linear_translated.png',
-          builder.build());
+      await matchSceneGolden(
+        'canvaskit_shadermask_linear_translated.png',
+        builder.build(),
+        region: region,
+      );
     });
     // TODO(hterkelsen): https://github.com/flutter/flutter/issues/71520
   }, skip: isSafari || isFirefox);

--- a/lib/web_ui/test/canvaskit/sweep_gradient_golden_test.dart
+++ b/lib/web_ui/test/canvaskit/sweep_gradient_golden_test.dart
@@ -9,8 +9,6 @@ import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' as ui;
 
-import 'package:web_engine_tester/golden_tester.dart';
-
 import 'common.dart';
 
 void main() {
@@ -18,14 +16,6 @@ void main() {
 }
 
 const ui.Rect region = ui.Rect.fromLTRB(0, 0, 500, 250);
-
-Future<void> matchPictureGolden(String goldenFile, CkPicture picture) async {
-  final LayerSceneBuilder sb = LayerSceneBuilder();
-  sb.pushOffset(0, 0);
-  sb.addPicture(ui.Offset.zero, picture);
-  CanvasKitRenderer.instance.rasterizer.draw(sb.build().layerTree);
-  await matchGoldenFile(goldenFile, region: region);
-}
 
 void testMain() {
   group('SweepGradient', () {
@@ -63,6 +53,7 @@ void testMain() {
       await matchPictureGolden(
         'canvaskit_sweep_gradient.png',
         recorder.endRecording(),
+        region: region,
       );
     });
     // TODO(hterkelsen): https://github.com/flutter/flutter/issues/71520

--- a/lib/web_ui/test/engine/recording_canvas_test.dart
+++ b/lib/web_ui/test/engine/recording_canvas_test.dart
@@ -7,7 +7,7 @@ import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart';
 
-import '../html/paragraph/text_scuba.dart';
+import '../html/screenshot.dart';
 import '../mock_engine_canvas.dart';
 
 void main() {

--- a/lib/web_ui/test/html/canvas_clip_path_golden_test.dart
+++ b/lib/web_ui/test/html/canvas_clip_path_golden_test.dart
@@ -16,10 +16,6 @@ void main() {
 }
 
 Future<void> testMain() async {
-  const double screenWidth = 500.0;
-  const double screenHeight = 500.0;
-  const Rect screenRect = Rect.fromLTWH(0, 0, screenWidth, screenHeight);
-
   setUpAll(() async {
     debugEmulateFlutterTesterEnvironment = true;
     await webOnlyInitializePlatform();
@@ -42,8 +38,7 @@ Future<void> testMain() async {
     rc.drawImageRect(testImage, Rect.fromLTRB(0, 0, testWidth, testHeight),
         Rect.fromLTWH(100, 30, testWidth, testHeight), engine.SurfacePaint());
     rc.restore();
-    await canvasScreenshot(rc, 'image_clipped_by_oval',
-      region: screenRect);
+    await canvasScreenshot(rc, 'image_clipped_by_oval');
   });
 
   // Regression test for https://github.com/flutter/flutter/issues/48683
@@ -67,8 +62,7 @@ Future<void> testMain() async {
           ..color = const Color(0xFF00FF00)
           ..style = PaintingStyle.fill);
     rc.restore();
-    await canvasScreenshot(rc, 'triangle_clipped_by_oval',
-      region: screenRect);
+    await canvasScreenshot(rc, 'triangle_clipped_by_oval');
   });
 
   // Regression test for https://github.com/flutter/flutter/issues/78782
@@ -96,7 +90,8 @@ Future<void> testMain() async {
     rc.drawImageRect(createTestImage(), const Rect.fromLTRB(0, 0, testWidth, testHeight),
         const Rect.fromLTWH(-50, 0, testWidth, testHeight), engine.SurfacePaint());
     rc.restore();
-    await canvasScreenshot(rc, 'image_clipped_by_triangle_off_screen');
+    await canvasScreenshot(rc, 'image_clipped_by_triangle_off_screen',
+        region: const Rect.fromLTWH(0, 0, 600, 800));
   });
 
   // Tests oval clipping using border radius 50%.
@@ -121,7 +116,8 @@ Future<void> testMain() async {
     rc.drawImageRect(createTestImage(), const Rect.fromLTRB(0, 0, testWidth, testHeight),
         const Rect.fromLTWH(-50, 0, testWidth, testHeight), engine.SurfacePaint());
     rc.restore();
-    await canvasScreenshot(rc, 'image_clipped_by_oval_path');
+    await canvasScreenshot(rc, 'image_clipped_by_oval_path',
+        region: const Rect.fromLTWH(0, 0, 600, 800));
   });
 }
 

--- a/lib/web_ui/test/html/canvas_context_golden_test.dart
+++ b/lib/web_ui/test/html/canvas_context_golden_test.dart
@@ -5,10 +5,9 @@
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart' as engine;
-import 'package:ui/src/engine/browser_detection.dart';
 import 'package:ui/ui.dart' hide TextStyle;
 
-import 'package:web_engine_tester/golden_tester.dart';
+import 'screenshot.dart';
 
 void main() {
   internalBootstrapBrowserTest(() => testMain);
@@ -19,36 +18,6 @@ Future<void> testMain() async {
   const double screenWidth = 600.0;
   const double screenHeight = 800.0;
   const Rect screenRect = Rect.fromLTWH(0, 0, screenWidth, screenHeight);
-
-  // Commit a recording canvas to a bitmap, and compare with the expected
-  Future<void> checkScreenshot(engine.RecordingCanvas rc, String fileName,
-      {Rect region = const Rect.fromLTWH(0, 0, 500, 500)}) async {
-    final engine.EngineCanvas engineCanvas = engine.BitmapCanvas(screenRect,
-        engine.RenderStrategy());
-
-    rc.endRecording();
-    rc.apply(engineCanvas, screenRect);
-
-    // Wrap in <flt-scene> so that our CSS selectors kick in.
-    final engine.DomElement sceneElement = engine.createDomElement('flt-scene');
-    if (isIosSafari) {
-      // Shrink to fit on the iPhone screen.
-      sceneElement.style.position = 'absolute';
-      sceneElement.style.transformOrigin = '0 0 0';
-      sceneElement.style.transform = 'scale(0.3)';
-    }
-
-    try {
-      sceneElement.append(engineCanvas.rootElement);
-      engine.domDocument.body!.append(sceneElement);
-      // TODO(yjbanov): 10% diff rate is excessive. Update goldens.
-      await matchGoldenFile('$fileName.png', region: region);
-    } finally {
-      // The page is reused across tests, so remove the element after taking the
-      // Scuba screenshot.
-      sceneElement.remove();
-    }
-  }
 
   setUpAll(() async {
     debugEmulateFlutterTesterEnvironment = true;
@@ -83,7 +52,7 @@ Future<void> testMain() async {
     // The rectangle should paint without clipping since we restored
     // context.
     rc.drawRect(const Rect.fromLTWH(0, 0, 4, 200), paint);
-    await checkScreenshot(rc, 'context_save_restore_transform');
+    await canvasScreenshot(rc, 'context_save_restore_transform', canvasRect: screenRect);
   });
 
   test('Should restore clip path', () async {
@@ -108,6 +77,6 @@ Future<void> testMain() async {
     // The rectangle should paint without clipping since we restored
     // context.
     rc.drawRect(const Rect.fromLTWH(0, 0, 200, 200), goodPaint as engine.SurfacePaint);
-    await checkScreenshot(rc, 'context_save_restore_clip');
+    await canvasScreenshot(rc, 'context_save_restore_clip', canvasRect: screenRect);
   });
 }

--- a/lib/web_ui/test/html/compositing/canvas_blend_golden_test.dart
+++ b/lib/web_ui/test/html/compositing/canvas_blend_golden_test.dart
@@ -58,7 +58,6 @@ Future<void> testMain() async {
     rc.restore();
 
     await canvasScreenshot(rc, 'canvas_blend_circle_diff_color',
-        region: const Rect.fromLTWH(0, 0, 500, 500),
         maxDiffRatePercent: operatingSystem == OperatingSystem.macOs ? 2.95 :
             operatingSystem == OperatingSystem.iOs ? 1.0 : 0);
   });
@@ -97,7 +96,6 @@ Future<void> testMain() async {
         SurfacePaint()..blendMode = BlendMode.multiply);
     rc.restore();
     await canvasScreenshot(rc, 'canvas_blend_image_multiply',
-        region: const Rect.fromLTWH(0, 0, 500, 500),
         maxDiffRatePercent: operatingSystem == OperatingSystem.macOs ? 2.95 :
         operatingSystem == OperatingSystem.iOs ? 2.0 : 0);
   });

--- a/lib/web_ui/test/html/compositing/canvas_image_blend_mode_golden_test.dart
+++ b/lib/web_ui/test/html/compositing/canvas_image_blend_mode_golden_test.dart
@@ -17,10 +17,6 @@ void main() {
 SurfacePaint makePaint() => Paint() as SurfacePaint;
 
 Future<void> testMain() async {
-  const double screenWidth = 500.0;
-  const double screenHeight = 500.0;
-  const Rect screenRect = Rect.fromLTWH(0, 0, screenWidth, screenHeight);
-
   setUpAll(() async {
     debugEmulateFlutterTesterEnvironment = true;
     await webOnlyInitializePlatform();
@@ -90,7 +86,7 @@ Future<void> testMain() async {
       }
       rc.restore();
       await canvasScreenshot(rc, 'canvas_image_blend_group$blendGroup',
-          maxDiffRatePercent: 8.0, region: screenRect);
+          maxDiffRatePercent: 8.0);
     },
         skip: isSafari);
   }
@@ -115,7 +111,7 @@ Future<void> testMain() async {
 
     rc.restore();
     await canvasScreenshot(rc, 'canvas_image_blend_and_text',
-        maxDiffRatePercent: 8.0, region: screenRect);
+        maxDiffRatePercent: 8.0);
   });
 }
 

--- a/lib/web_ui/test/html/compositing/dom_mask_filter_golden_test.dart
+++ b/lib/web_ui/test/html/compositing/dom_mask_filter_golden_test.dart
@@ -13,10 +13,6 @@ void main() {
 }
 
 Future<void> testMain() async {
-  const double screenWidth = 500.0;
-  const double screenHeight = 500.0;
-  const Rect screenRect = Rect.fromLTWH(0, 0, screenWidth, screenHeight);
-
   setUp(() async {
     debugEmulateFlutterTesterEnvironment = true;
     await webOnlyInitializePlatform();
@@ -34,7 +30,6 @@ Future<void> testMain() async {
       rc.drawRect(Rect.fromLTWH(15.0, 15.0 + blurSigma * 40, 200, 20), paint);
     }
     await canvasScreenshot(rc, 'dom_mask_filter_blur',
-        region: screenRect,
         maxDiffRatePercent: 0.01);
   });
 }

--- a/lib/web_ui/test/html/drawing/canvas_draw_image_golden_test.dart
+++ b/lib/web_ui/test/html/drawing/canvas_draw_image_golden_test.dart
@@ -34,8 +34,7 @@ Future<void> testMain() async {
     rc.save();
     rc.drawImage(createTestImage(), Offset.zero, SurfacePaint());
     rc.restore();
-    await canvasScreenshot(rc, 'draw_image',
-        region: const Rect.fromLTWH(0, 0, 500, 500));
+    await canvasScreenshot(rc, 'draw_image');
   });
 
   test('Images from raw data are composited when picture is roundtripped through toImage', () async {
@@ -68,8 +67,7 @@ Future<void> testMain() async {
     rc.rotate(math.pi / 4.0);
     rc.drawImage(createTestImage(), Offset.zero, SurfacePaint());
     rc.restore();
-    await canvasScreenshot(rc, 'draw_image_with_transform',
-        region: const Rect.fromLTWH(0, 0, 500, 500));
+    await canvasScreenshot(rc, 'draw_image_with_transform');
   });
 
   test('Paints image with transform and offset', () async {
@@ -80,8 +78,7 @@ Future<void> testMain() async {
     rc.rotate(math.pi / 4.0);
     rc.drawImage(createTestImage(), const Offset(30, 20), SurfacePaint());
     rc.restore();
-    await canvasScreenshot(rc, 'draw_image_with_transform_and_offset',
-        region: const Rect.fromLTWH(0, 0, 500, 500));
+    await canvasScreenshot(rc, 'draw_image_with_transform_and_offset');
   });
 
   test('Paints image with transform using destination', () async {
@@ -96,8 +93,7 @@ Future<void> testMain() async {
     rc.drawImageRect(testImage, Rect.fromLTRB(0, 0, testWidth, testHeight),
         Rect.fromLTRB(100, 30, 2 * testWidth, 2 * testHeight), SurfacePaint());
     rc.restore();
-    await canvasScreenshot(rc, 'draw_image_rect_with_transform',
-        region: const Rect.fromLTWH(0, 0, 500, 500));
+    await canvasScreenshot(rc, 'draw_image_rect_with_transform');
   });
 
   test('Paints image with source and destination', () async {
@@ -113,8 +109,7 @@ Future<void> testMain() async {
         Rect.fromLTRB(100, 30, 2 * testWidth, 2 * testHeight),
         SurfacePaint());
     rc.restore();
-    await canvasScreenshot(rc, 'draw_image_rect_with_source',
-        region: const Rect.fromLTWH(0, 0, 500, 500));
+    await canvasScreenshot(rc, 'draw_image_rect_with_source');
   });
 
   test('Paints image with source and destination and round clip', () async {
@@ -132,8 +127,7 @@ Future<void> testMain() async {
         Rect.fromLTRB(100, 30, 2 * testWidth, 2 * testHeight),
         SurfacePaint());
     rc.restore();
-    await canvasScreenshot(rc, 'draw_image_rect_with_source_and_clip',
-        region: const Rect.fromLTWH(0, 0, 500, 500));
+    await canvasScreenshot(rc, 'draw_image_rect_with_source_and_clip');
   });
 
   test('Paints image with transform using source and destination', () async {
@@ -151,8 +145,7 @@ Future<void> testMain() async {
         Rect.fromLTRB(100, 30, 2 * testWidth, 2 * testHeight),
         SurfacePaint());
     rc.restore();
-    await canvasScreenshot(rc, 'draw_image_rect_with_transform_source',
-        region: const Rect.fromLTWH(0, 0, 500, 500));
+    await canvasScreenshot(rc, 'draw_image_rect_with_transform_source');
   });
 
   // Regression test for https://github.com/flutter/flutter/issues/44845
@@ -173,8 +166,7 @@ Future<void> testMain() async {
           ..strokeWidth = 3
           ..color = const Color.fromARGB(128, 0, 0, 0));
     rc.restore();
-    await canvasScreenshot(rc, 'draw_circle_on_image',
-        region: const Rect.fromLTWH(0, 0, 500, 500));
+    await canvasScreenshot(rc, 'draw_circle_on_image');
   });
 
   // Regression test for https://github.com/flutter/flutter/issues/44845
@@ -195,8 +187,7 @@ Future<void> testMain() async {
     rc.drawImageRect(testImage, Rect.fromLTRB(0, 0, testWidth, testHeight),
         Rect.fromLTRB(100, 30, 2 * testWidth, 2 * testHeight), SurfacePaint());
     rc.restore();
-    await canvasScreenshot(rc, 'draw_circle_below_image',
-        region: const Rect.fromLTWH(0, 0, 500, 500));
+    await canvasScreenshot(rc, 'draw_circle_below_image');
   });
 
   // Regression test for https://github.com/flutter/flutter/issues/44845
@@ -218,8 +209,7 @@ Future<void> testMain() async {
           ..strokeWidth = 3
           ..color = const Color.fromARGB(128, 0, 0, 0));
     rc.restore();
-    await canvasScreenshot(rc, 'draw_circle_on_image_clip_rect',
-        region: const Rect.fromLTWH(0, 0, 500, 500));
+    await canvasScreenshot(rc, 'draw_circle_on_image_clip_rect');
   });
 
   // Regression test for https://github.com/flutter/flutter/issues/44845
@@ -245,8 +235,7 @@ Future<void> testMain() async {
           ..strokeWidth = 3
           ..color = const Color.fromARGB(128, 0, 0, 0));
     rc.restore();
-    await canvasScreenshot(rc, 'draw_circle_on_image_clip_rect_with_transform',
-        region: const Rect.fromLTWH(0, 0, 500, 500));
+    await canvasScreenshot(rc, 'draw_circle_on_image_clip_rect_with_transform');
   });
 
   // Regression test for https://github.com/flutter/flutter/issues/44845
@@ -274,8 +263,7 @@ Future<void> testMain() async {
           ..color = const Color.fromARGB(128, 0, 0, 0));
     rc.restore();
     rc.restore();
-    await canvasScreenshot(rc, 'draw_circle_on_image_clip_rect_with_stack',
-        region: const Rect.fromLTWH(0, 0, 500, 500));
+    await canvasScreenshot(rc, 'draw_circle_on_image_clip_rect_with_stack');
   });
 
   // Regression test for https://github.com/flutter/flutter/issues/44845
@@ -297,8 +285,7 @@ Future<void> testMain() async {
           ..strokeWidth = 3
           ..color = const Color.fromARGB(128, 0, 0, 0));
     rc.restore();
-    await canvasScreenshot(rc, 'draw_circle_on_image_clip_rrect',
-        region: const Rect.fromLTWH(0, 0, 500, 500));
+    await canvasScreenshot(rc, 'draw_circle_on_image_clip_rrect');
   });
 
   // Regression test for https://github.com/flutter/flutter/issues/44845
@@ -325,8 +312,7 @@ Future<void> testMain() async {
           ..strokeWidth = 3
           ..color = const Color.fromARGB(128, 0, 0, 0));
     rc.restore();
-    await canvasScreenshot(rc, 'draw_circle_on_image_clip_path',
-        region: const Rect.fromLTWH(0, 0, 500, 500));
+    await canvasScreenshot(rc, 'draw_circle_on_image_clip_path');
   });
 
   // Regression test for https://github.com/flutter/flutter/issues/53078

--- a/lib/web_ui/test/html/drawing/canvas_draw_image_golden_test.dart
+++ b/lib/web_ui/test/html/drawing/canvas_draw_image_golden_test.dart
@@ -55,8 +55,7 @@ Future<void> testMain() async {
     rc.save();
     rc.drawImage(image, Offset.zero, SurfacePaint());
     rc.restore();
-    await canvasScreenshot(rc, 'draw_raw_image',
-      region: const Rect.fromLTWH(0, 0, 500, 500));
+    await canvasScreenshot(rc, 'draw_raw_image');
   });
 
   test('Paints image with transform', () async {

--- a/lib/web_ui/test/html/drawing/canvas_rrect_golden_test.dart
+++ b/lib/web_ui/test/html/drawing/canvas_rrect_golden_test.dart
@@ -7,28 +7,19 @@ import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart';
 
-import 'package:web_engine_tester/golden_tester.dart';
+import '../screenshot.dart';
 
 void main() {
   internalBootstrapBrowserTest(() => testMain);
 }
 
 Future<void> testMain() async {
-  late BitmapCanvas canvas;
-
-  Future<void> checkScreenshot(String goldenFileName, Rect region) async {
-    if (isIosSafari) {
-      canvas.rootElement.style
-        ..transformOrigin = '0 0 0'
-        ..transform = 'scale(0.3)';
-    }
-    domDocument.body!.append(canvas.rootElement);
-    await matchGoldenFile(goldenFileName, region: region);
-  }
+  late RecordingCanvas rc;
+  const Rect screenRect = Rect.fromLTWH(0, 0, 500, 500);
 
   const Rect region = Rect.fromLTWH(8, 8, 500, 100); // Compensate for old scuba tester padding
 
-  final SurfacePaintData niceRRectPaint = SurfacePaintData()
+  final SurfacePaint niceRRectPaint = SurfacePaint()
     ..color = const Color.fromRGBO(250, 186, 218, 1.0) // #fabada
     ..style = PaintingStyle.fill;
 
@@ -38,35 +29,30 @@ Future<void> testMain() async {
   const Radius someFixedRadius = Radius.circular(10);
 
   setUp(() {
-    canvas = BitmapCanvas(const Rect.fromLTWH(0, 0, 500, 100),
-        RenderStrategy());
-    canvas.translate(10, 10); // Center
-  });
-
-  tearDown(() {
-    canvas.rootElement.remove();
+    rc = RecordingCanvas(const Rect.fromLTWH(0, 0, 500, 100));
+    rc.translate(10, 10); // Center
   });
 
   test('round square with big (equal) radius ends up as a circle', () async {
     for (int i = 0; i < 5; i++) {
-      canvas.drawRRect(
+      rc.drawRRect(
           RRect.fromRectAndRadius(Rect.fromLTWH(100 * i.toDouble(), 0, 80, 80),
               Radius.circular(rRectRadii[i])),
           niceRRectPaint);
     }
-    await checkScreenshot('canvas_rrect_round_square.png', region);
+    await canvasScreenshot(rc, 'canvas_rrect_round_square.png', canvasRect: screenRect, region: region);
   });
 
   /// Regression test for https://github.com/flutter/flutter/issues/62631
   test('round square with flipped left/right coordinates', () async {
-    canvas.translate(35, 320);
-    canvas.drawRRect(
+    rc.translate(35, 320);
+    rc.drawRRect(
       RRect.fromRectAndRadius(
           const Rect.fromLTRB(-30, -100, 30, -300),
           const Radius.circular(30)),
       niceRRectPaint);
-    canvas.drawPath(Path()..moveTo(0, 0)..lineTo(20, 0), niceRRectPaint);
-    await checkScreenshot('canvas_rrect_flipped.png', const Rect.fromLTWH(0, 0, 100, 200));
+    rc.drawPath(Path()..moveTo(0, 0)..lineTo(20, 0), niceRRectPaint);
+    await canvasScreenshot(rc, 'canvas_rrect_flipped.png', canvasRect: screenRect, region: const Rect.fromLTWH(0, 0, 100, 200));
   });
 
   test('round rect with big radius scale down smaller radius', () async {
@@ -78,9 +64,9 @@ Future<void> testMain() async {
           topRight: growingRadius,
           bottomLeft: growingRadius);
 
-      canvas.drawRRect(rrect, niceRRectPaint);
+      rc.drawRRect(rrect, niceRRectPaint);
     }
-    await checkScreenshot('canvas_rrect_overlapping_radius.png', region);
+    await canvasScreenshot(rc, 'canvas_rrect_overlapping_radius.png', canvasRect: screenRect, region: region);
   });
 
   test('diff round rect with big radius scale down smaller radius', () async {
@@ -99,9 +85,9 @@ Future<void> testMain() async {
           topRight: growingRadius / 2,
           bottomLeft: growingRadius / 2);
 
-      canvas.drawDRRect(outerRRect, innerRRect, niceRRectPaint);
+      rc.drawDRRect(outerRRect, innerRRect, niceRRectPaint);
     }
 
-    await checkScreenshot('canvas_drrect_overlapping_radius.png', region);
+    await canvasScreenshot(rc, 'canvas_drrect_overlapping_radius.png', canvasRect: screenRect, region: region);
   });
 }

--- a/lib/web_ui/test/html/drawing/canvas_rrect_golden_test.dart
+++ b/lib/web_ui/test/html/drawing/canvas_rrect_golden_test.dart
@@ -40,7 +40,7 @@ Future<void> testMain() async {
               Radius.circular(rRectRadii[i])),
           niceRRectPaint);
     }
-    await canvasScreenshot(rc, 'canvas_rrect_round_square.png', canvasRect: screenRect, region: region);
+    await canvasScreenshot(rc, 'canvas_rrect_round_square', canvasRect: screenRect, region: region);
   });
 
   /// Regression test for https://github.com/flutter/flutter/issues/62631
@@ -52,7 +52,7 @@ Future<void> testMain() async {
           const Radius.circular(30)),
       niceRRectPaint);
     rc.drawPath(Path()..moveTo(0, 0)..lineTo(20, 0), niceRRectPaint);
-    await canvasScreenshot(rc, 'canvas_rrect_flipped.png', canvasRect: screenRect, region: const Rect.fromLTWH(0, 0, 100, 200));
+    await canvasScreenshot(rc, 'canvas_rrect_flipped', canvasRect: screenRect, region: const Rect.fromLTWH(0, 0, 100, 200));
   });
 
   test('round rect with big radius scale down smaller radius', () async {
@@ -66,7 +66,7 @@ Future<void> testMain() async {
 
       rc.drawRRect(rrect, niceRRectPaint);
     }
-    await canvasScreenshot(rc, 'canvas_rrect_overlapping_radius.png', canvasRect: screenRect, region: region);
+    await canvasScreenshot(rc, 'canvas_rrect_overlapping_radius', canvasRect: screenRect, region: region);
   });
 
   test('diff round rect with big radius scale down smaller radius', () async {
@@ -88,6 +88,6 @@ Future<void> testMain() async {
       rc.drawDRRect(outerRRect, innerRRect, niceRRectPaint);
     }
 
-    await canvasScreenshot(rc, 'canvas_drrect_overlapping_radius.png', canvasRect: screenRect, region: region);
+    await canvasScreenshot(rc, 'canvas_drrect_overlapping_radius', canvasRect: screenRect, region: region);
   });
 }

--- a/lib/web_ui/test/html/drawing/canvas_rrect_golden_test.dart
+++ b/lib/web_ui/test/html/drawing/canvas_rrect_golden_test.dart
@@ -15,7 +15,7 @@ void main() {
 
 Future<void> testMain() async {
   late RecordingCanvas rc;
-  const Rect screenRect = Rect.fromLTWH(0, 0, 500, 500);
+  const Rect canvasRect = Rect.fromLTWH(0, 0, 500, 100);
 
   const Rect region = Rect.fromLTWH(8, 8, 500, 100); // Compensate for old scuba tester padding
 
@@ -40,7 +40,7 @@ Future<void> testMain() async {
               Radius.circular(rRectRadii[i])),
           niceRRectPaint);
     }
-    await canvasScreenshot(rc, 'canvas_rrect_round_square', canvasRect: screenRect, region: region);
+    await canvasScreenshot(rc, 'canvas_rrect_round_square', canvasRect: canvasRect, region: region);
   });
 
   /// Regression test for https://github.com/flutter/flutter/issues/62631
@@ -52,7 +52,7 @@ Future<void> testMain() async {
           const Radius.circular(30)),
       niceRRectPaint);
     rc.drawPath(Path()..moveTo(0, 0)..lineTo(20, 0), niceRRectPaint);
-    await canvasScreenshot(rc, 'canvas_rrect_flipped', canvasRect: screenRect, region: const Rect.fromLTWH(0, 0, 100, 200));
+    await canvasScreenshot(rc, 'canvas_rrect_flipped', canvasRect: canvasRect, region: const Rect.fromLTWH(0, 0, 100, 200));
   });
 
   test('round rect with big radius scale down smaller radius', () async {
@@ -66,7 +66,7 @@ Future<void> testMain() async {
 
       rc.drawRRect(rrect, niceRRectPaint);
     }
-    await canvasScreenshot(rc, 'canvas_rrect_overlapping_radius', canvasRect: screenRect, region: region);
+    await canvasScreenshot(rc, 'canvas_rrect_overlapping_radius', canvasRect: canvasRect, region: region);
   });
 
   test('diff round rect with big radius scale down smaller radius', () async {
@@ -88,6 +88,6 @@ Future<void> testMain() async {
       rc.drawDRRect(outerRRect, innerRRect, niceRRectPaint);
     }
 
-    await canvasScreenshot(rc, 'canvas_drrect_overlapping_radius', canvasRect: screenRect, region: region);
+    await canvasScreenshot(rc, 'canvas_drrect_overlapping_radius', canvasRect: canvasRect, region: region);
   });
 }

--- a/lib/web_ui/test/html/paragraph/bidi_golden_test.dart
+++ b/lib/web_ui/test/html/paragraph/bidi_golden_test.dart
@@ -9,8 +9,8 @@ import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' hide window;
 
+import '../screenshot.dart';
 import 'helper.dart';
-import 'text_scuba.dart';
 
 typedef CanvasTest = FutureOr<void> Function(EngineCanvas canvas);
 

--- a/lib/web_ui/test/html/paragraph/general_golden_test.dart
+++ b/lib/web_ui/test/html/paragraph/general_golden_test.dart
@@ -10,8 +10,8 @@ import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' hide window;
 
+import '../screenshot.dart';
 import 'helper.dart';
-import 'text_scuba.dart';
 
 typedef CanvasTest = FutureOr<void> Function(EngineCanvas canvas);
 

--- a/lib/web_ui/test/html/paragraph/justify_golden_test.dart
+++ b/lib/web_ui/test/html/paragraph/justify_golden_test.dart
@@ -9,8 +9,8 @@ import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' hide window;
 
+import '../screenshot.dart';
 import 'helper.dart';
-import 'text_scuba.dart';
 
 void main() {
   internalBootstrapBrowserTest(() => testMain);

--- a/lib/web_ui/test/html/paragraph/overflow_golden_test.dart
+++ b/lib/web_ui/test/html/paragraph/overflow_golden_test.dart
@@ -9,8 +9,8 @@ import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' hide window;
 
+import '../screenshot.dart';
 import 'helper.dart';
-import 'text_scuba.dart';
 
 typedef CanvasTest = FutureOr<void> Function(EngineCanvas canvas);
 

--- a/lib/web_ui/test/html/paragraph/placeholders_golden_test.dart
+++ b/lib/web_ui/test/html/paragraph/placeholders_golden_test.dart
@@ -9,8 +9,8 @@ import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' hide window;
 
+import '../screenshot.dart';
 import 'helper.dart';
-import 'text_scuba.dart';
 
 typedef CanvasTest = FutureOr<void> Function(EngineCanvas canvas);
 

--- a/lib/web_ui/test/html/paragraph/shadows_golden_test.dart
+++ b/lib/web_ui/test/html/paragraph/shadows_golden_test.dart
@@ -7,8 +7,8 @@ import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' hide window;
 
+import '../screenshot.dart';
 import 'helper.dart';
-import 'text_scuba.dart';
 
 const Rect bounds = Rect.fromLTWH(0, 0, 800, 600);
 

--- a/lib/web_ui/test/html/paragraph/text_multiline_clipping_golden_test.dart
+++ b/lib/web_ui/test/html/paragraph/text_multiline_clipping_golden_test.dart
@@ -8,6 +8,7 @@ import 'package:test/bootstrap/browser.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart';
 
+import '../screenshot.dart';
 import 'text_scuba.dart';
 
 typedef PaintTest = void Function(RecordingCanvas recordingCanvas);

--- a/lib/web_ui/test/html/paragraph/text_overflow_golden_test.dart
+++ b/lib/web_ui/test/html/paragraph/text_overflow_golden_test.dart
@@ -8,6 +8,7 @@ import 'package:test/bootstrap/browser.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' hide window;
 
+import '../screenshot.dart';
 import 'text_scuba.dart';
 
 typedef CanvasTest = FutureOr<void> Function(EngineCanvas canvas);

--- a/lib/web_ui/test/html/paragraph/text_placeholders_golden_test.dart
+++ b/lib/web_ui/test/html/paragraph/text_placeholders_golden_test.dart
@@ -6,6 +6,7 @@ import 'package:test/bootstrap/browser.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart';
 
+import '../screenshot.dart';
 import 'text_scuba.dart';
 
 typedef PaintTest = void Function(RecordingCanvas recordingCanvas);

--- a/lib/web_ui/test/html/paragraph/text_scuba.dart
+++ b/lib/web_ui/test/html/paragraph/text_scuba.dart
@@ -124,13 +124,3 @@ CanvasParagraph paragraph(
   paragraph.layout(ui.ParagraphConstraints(width: maxWidth));
   return paragraph;
 }
-
-/// Configures the test to use bundled Roboto and Ahem fonts to avoid golden
-/// screenshot differences due to differences in the preinstalled system fonts.
-void setUpStableTestFonts() {
-  setUpAll(() async {
-    await ui.webOnlyInitializePlatform();
-    renderer.fontCollection.debugRegisterTestFonts();
-    await renderer.fontCollection.ensureFontsLoaded();
-  });
-}

--- a/lib/web_ui/test/html/path_metrics_golden_test.dart
+++ b/lib/web_ui/test/html/path_metrics_golden_test.dart
@@ -6,9 +6,9 @@ import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' hide TextStyle;
-import 'package:web_engine_tester/golden_tester.dart';
 
 import '../matchers.dart';
+import 'screenshot.dart';
 
 void main() {
   internalBootstrapBrowserTest(() => testMain);
@@ -21,33 +21,6 @@ Future<void> testMain() async {
   const Color black12Color = Color(0x1F000000);
   const Color redAccentColor = Color(0xFFFF1744);
   const double kDashLength = 5.0;
-
-  // Commit a recording canvas to a bitmap, and compare with the expected
-  Future<void> checkScreenshot(RecordingCanvas rc, String fileName,
-      {Rect region = const Rect.fromLTWH(0, 0, 500, 500)}) async {
-    final EngineCanvas engineCanvas = BitmapCanvas(screenRect,
-        RenderStrategy());
-    rc.endRecording();
-    rc.apply(engineCanvas, screenRect);
-
-    // Wrap in <flt-scene> so that our CSS selectors kick in.
-    final DomElement sceneElement = createDomElement('flt-scene');
-    if (isIosSafari) {
-      // Shrink to fit on the iPhone screen.
-      sceneElement.style.position = 'absolute';
-      sceneElement.style.transformOrigin = '0 0 0';
-      sceneElement.style.transform = 'scale(0.3)';
-    }
-    try {
-      sceneElement.append(engineCanvas.rootElement);
-      domDocument.body!.append(sceneElement);
-      await matchGoldenFile('$fileName.png', region: region);
-    } finally {
-      // The page is reused across tests, so remove the element after taking the
-      // Scuba screenshot.
-      sceneElement.remove();
-    }
-  }
 
   setUpAll(() async {
     debugEmulateFlutterTesterEnvironment = true;
@@ -150,7 +123,7 @@ Future<void> testMain() async {
       }
     }
     rc.drawPath(dashedPath, redPaint);
-    await checkScreenshot(rc, 'path_dash_quadratic');
+    await canvasScreenshot(rc, 'path_dash_quadratic', canvasRect: screenRect);
   });
 
   // Test for extractPath to draw 5 pixel length dashed line using cubic curve.
@@ -204,6 +177,6 @@ Future<void> testMain() async {
       }
     }
     rc.drawPath(dashedPath, redPaint);
-    await checkScreenshot(rc, 'path_dash_cubic');
+    await canvasScreenshot(rc, 'path_dash_cubic', canvasRect: screenRect);
   });
 }

--- a/lib/web_ui/test/html/path_transform_golden_test.dart
+++ b/lib/web_ui/test/html/path_transform_golden_test.dart
@@ -9,7 +9,7 @@ import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' hide TextStyle;
 
-import 'package:web_engine_tester/golden_tester.dart';
+import 'screenshot.dart';
 
 void main() {
   internalBootstrapBrowserTest(() => testMain);
@@ -19,34 +19,6 @@ Future<void> testMain() async {
   const double screenWidth = 600.0;
   const double screenHeight = 800.0;
   const Rect screenRect = Rect.fromLTWH(0, 0, screenWidth, screenHeight);
-
-  // Commit a recording canvas to a bitmap, and compare with the expected
-  Future<void> checkScreenshot(RecordingCanvas rc, String fileName,
-      {Rect region = const Rect.fromLTWH(0, 0, 500, 500),
-      double? maxDiffRatePercent}) async {
-    final EngineCanvas engineCanvas = BitmapCanvas(screenRect,
-        RenderStrategy());
-    rc.endRecording();
-    rc.apply(engineCanvas, screenRect);
-
-    // Wrap in <flt-scene> so that our CSS selectors kick in.
-    final DomElement sceneElement = createDomElement('flt-scene');
-    if (isIosSafari) {
-      // Shrink to fit on the iPhone screen.
-      sceneElement.style.position = 'absolute';
-      sceneElement.style.transformOrigin = '0 0 0';
-      sceneElement.style.transform = 'scale(0.3)';
-    }
-    try {
-      sceneElement.append(engineCanvas.rootElement);
-      domDocument.body!.append(sceneElement);
-      await matchGoldenFile('$fileName.png', region: region, maxDiffRatePercent: maxDiffRatePercent);
-    } finally {
-      // The page is reused across tests, so remove the element after taking the
-      // Scuba screenshot.
-      sceneElement.remove();
-    }
-  }
 
   setUpAll(() async {
     debugEmulateFlutterTesterEnvironment = true;
@@ -78,7 +50,7 @@ Future<void> testMain() async {
           ..style = PaintingStyle.stroke
           ..strokeWidth = 2.0
           ..color = const Color.fromRGBO(0, 128, 255, 1.0));
-    await checkScreenshot(rc, 'path_transform_with_line');
+    await canvasScreenshot(rc, 'path_transform_with_line', canvasRect: screenRect);
   });
 
   test('Should draw transformed line.', () async {
@@ -103,7 +75,7 @@ Future<void> testMain() async {
           ..style = PaintingStyle.stroke
           ..strokeWidth = 2.0
           ..color = const Color.fromRGBO(0, 128, 255, 1.0));
-    await checkScreenshot(rc, 'path_transform_with_rect');
+    await canvasScreenshot(rc, 'path_transform_with_rect', canvasRect: screenRect);
   });
 
   test('Should draw transformed quadratic curve.', () async {
@@ -129,7 +101,7 @@ Future<void> testMain() async {
           ..style = PaintingStyle.stroke
           ..strokeWidth = 2.0
           ..color = const Color.fromRGBO(0, 128, 255, 1.0));
-    await checkScreenshot(rc, 'path_transform_with_quadratic_curve');
+    await canvasScreenshot(rc, 'path_transform_with_quadratic_curve', canvasRect: screenRect);
   });
 
   test('Should draw transformed conic.', () async {
@@ -166,7 +138,7 @@ Future<void> testMain() async {
           ..style = PaintingStyle.stroke
           ..strokeWidth = 2.0
           ..color = const Color.fromRGBO(0, 128, 255, 1.0));
-    await checkScreenshot(rc, 'path_transform_with_conic');
+    await canvasScreenshot(rc, 'path_transform_with_conic', canvasRect: screenRect);
   });
 
   test('Should draw transformed arc.', () async {
@@ -199,8 +171,7 @@ Future<void> testMain() async {
           ..style = PaintingStyle.stroke
           ..strokeWidth = 2.0
           ..color = const Color.fromRGBO(0, 128, 255, 1.0));
-    await checkScreenshot(rc, 'path_transform_with_arc',
-        maxDiffRatePercent: 1.4);
+    await canvasScreenshot(rc, 'path_transform_with_arc', canvasRect: screenRect);
   });
 
   test('Should draw transformed rrect.', () async {
@@ -228,6 +199,6 @@ Future<void> testMain() async {
           ..style = PaintingStyle.stroke
           ..strokeWidth = 2.0
           ..color = const Color.fromRGBO(0, 128, 255, 1.0));
-    await checkScreenshot(rc, 'path_transform_with_rrect');
+    await canvasScreenshot(rc, 'path_transform_with_rrect', canvasRect: screenRect);
   });
 }

--- a/lib/web_ui/test/html/recording_canvas_golden_test.dart
+++ b/lib/web_ui/test/html/recording_canvas_golden_test.dart
@@ -12,7 +12,7 @@ import 'package:ui/ui.dart' hide TextStyle;
 import 'package:web_engine_tester/golden_tester.dart';
 
 import '../matchers.dart';
-import 'paragraph/text_scuba.dart';
+import 'screenshot.dart';
 
 void main() {
   internalBootstrapBrowserTest(() => testMain);

--- a/lib/web_ui/test/html/screenshot.dart
+++ b/lib/web_ui/test/html/screenshot.dart
@@ -9,11 +9,21 @@ import 'package:ui/ui.dart' as ui;
 import 'package:web_engine_tester/golden_tester.dart';
 
 /// Commit a recording canvas to a bitmap, and compare with the expected.
-Future<void> canvasScreenshot(RecordingCanvas rc, String fileName,
-    {ui.Rect region = const ui.Rect.fromLTWH(0, 0, 600, 800),
-      double maxDiffRatePercent = 0.0, bool setupPerspective = false}) async {
-  final EngineCanvas engineCanvas = BitmapCanvas(region,
-      RenderStrategy());
+///
+/// [region] specifies the area of the canvas that will be included in the
+/// golden.
+///
+/// If [canvasRect] is omitted, it defaults to the value of [region].
+Future<void> canvasScreenshot(
+  RecordingCanvas rc,
+  String fileName, {
+  ui.Rect region = const ui.Rect.fromLTWH(0, 0, 500, 500),
+  ui.Rect? canvasRect,
+  double maxDiffRatePercent = 0.0,
+  bool setupPerspective = false,
+}) async {
+  canvasRect ??= region;
+  final EngineCanvas engineCanvas = BitmapCanvas(canvasRect, RenderStrategy());
 
   rc.endRecording();
   rc.apply(engineCanvas, region);

--- a/lib/web_ui/test/html/shaders/gradient_golden_test.dart
+++ b/lib/web_ui/test/html/shaders/gradient_golden_test.dart
@@ -11,9 +11,7 @@ import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart';
 
-import 'package:web_engine_tester/golden_tester.dart';
-
-import '../paragraph/text_scuba.dart';
+import '../screenshot.dart';
 
 // TODO(yjbanov): unskip Firefox tests when Firefox implements WebGL in headless mode.
 // https://github.com/flutter/flutter/issues/86623
@@ -26,36 +24,7 @@ Future<void> testMain() async {
   const double screenWidth = 600.0;
   const double screenHeight = 800.0;
   const Rect screenRect = Rect.fromLTWH(0, 0, screenWidth, screenHeight);
-
-  // Commit a recording canvas to a bitmap, and compare with the expected
-  Future<void> checkScreenshot(RecordingCanvas rc, String fileName,
-      {Rect region = const Rect.fromLTWH(0, 0, 500, 240),
-        double maxDiffRatePercent = 0.0}) async {
-    final EngineCanvas engineCanvas = BitmapCanvas(screenRect,
-        RenderStrategy());
-
-    rc.endRecording();
-    rc.apply(engineCanvas, screenRect);
-
-    // Wrap in <flt-scene> so that our CSS selectors kick in.
-    final DomElement sceneElement = createDomElement('flt-scene');
-    if (isIosSafari) {
-      // Shrink to fit on the iPhone screen.
-      sceneElement.style.position = 'absolute';
-      sceneElement.style.transformOrigin = '0 0 0';
-      sceneElement.style.transform = 'scale(0.3)';
-    }
-    try {
-      sceneElement.append(engineCanvas.rootElement);
-      domDocument.body!.append(sceneElement);
-      await matchGoldenFile('$fileName.png',
-          region: region, maxDiffRatePercent: maxDiffRatePercent);
-    } finally {
-      // The page is reused across tests, so remove the element after taking the
-      // Scuba screenshot.
-      sceneElement.remove();
-    }
-  }
+  const Rect region = Rect.fromLTWH(0, 0, 500, 240);
 
   setUp(() async {
     debugEmulateFlutterTesterEnvironment = true;
@@ -139,7 +108,7 @@ Future<void> testMain() async {
     canvas.drawRect(rectBounds, borderPaint);
 
     canvas.restore();
-    await checkScreenshot(canvas, 'sweep_gradient_rect');
+    await canvasScreenshot(canvas, 'sweep_gradient_rect', canvasRect: screenRect, region: region);
   }, skip: isFirefox);
 
   test('Paints sweep gradient ovals', () async {
@@ -218,7 +187,7 @@ Future<void> testMain() async {
     canvas.drawRect(rectBounds, borderPaint);
 
     canvas.restore();
-    await checkScreenshot(canvas, 'sweep_gradient_oval');
+    await canvasScreenshot(canvas, 'sweep_gradient_oval', canvasRect: screenRect, region: region);
   }, skip: isFirefox);
 
   test('Paints sweep gradient paths', () async {
@@ -302,7 +271,7 @@ Future<void> testMain() async {
     canvas.drawRect(rectBounds, borderPaint);
 
     canvas.restore();
-    await checkScreenshot(canvas, 'sweep_gradient_path');
+    await canvasScreenshot(canvas, 'sweep_gradient_path', canvasRect: screenRect, region: region);
   }, skip: isFirefox);
 
   /// Regression test for https://github.com/flutter/flutter/issues/74137.
@@ -350,7 +319,7 @@ Future<void> testMain() async {
     canvas.drawRect(rectBounds, borderPaint);
 
     canvas.restore();
-    await checkScreenshot(canvas, 'linear_gradient_rect_shifted');
+    await canvasScreenshot(canvas, 'linear_gradient_rect_shifted', canvasRect: screenRect, region: region);
   }, skip: isFirefox);
 
   /// Regression test for https://github.com/flutter/flutter/issues/82748.
@@ -465,7 +434,7 @@ Future<void> testMain() async {
     canvas.drawRect(rectBounds, borderPaint);
 
     canvas.restore();
-    await checkScreenshot(canvas, 'linear_gradient_rect_clamp_rotated');
+    await canvasScreenshot(canvas, 'linear_gradient_rect_clamp_rotated', canvasRect: screenRect, region: region);
   });
 
   test('Paints linear gradient properly when within svg context', () async {
@@ -499,7 +468,7 @@ Future<void> testMain() async {
     canvas.drawRect(rectBounds, borderPaint);
 
     canvas.restore();
-    await checkScreenshot(canvas, 'linear_gradient_in_svg_context');
+    await canvasScreenshot(canvas, 'linear_gradient_in_svg_context', canvasRect: screenRect, region: region);
   });
 }
 

--- a/lib/web_ui/test/html/shaders/linear_gradient_golden_test.dart
+++ b/lib/web_ui/test/html/shaders/linear_gradient_golden_test.dart
@@ -18,10 +18,6 @@ void main() {
 }
 
 Future<void> testMain() async {
-  const double screenWidth = 500.0;
-  const double screenHeight = 500.0;
-  const Rect screenRect = Rect.fromLTWH(0, 0, screenWidth, screenHeight);
-
   setUpAll(() async {
     debugEmulateFlutterTesterEnvironment = true;
     await webOnlyInitializePlatform();
@@ -40,7 +36,6 @@ Future<void> testMain() async {
     rc.drawRect(shaderRect, paint);
     expect(rc.renderStrategy.hasArbitraryPaint, isTrue);
     await canvasScreenshot(rc, 'linear_gradient_rect',
-        region: screenRect,
         maxDiffRatePercent: 0.01);
   });
 
@@ -61,7 +56,6 @@ Future<void> testMain() async {
     rc.drawRect(shaderRect, paint);
     expect(rc.renderStrategy.hasArbitraryPaint, isTrue);
     await canvasScreenshot(rc, 'linear_gradient_rect_alpha',
-        region: screenRect,
         maxDiffRatePercent: 0.01);
   });
 
@@ -94,7 +88,6 @@ Future<void> testMain() async {
     }
     expect(rc.renderStrategy.hasArbitraryPaint, isTrue);
     await canvasScreenshot(rc, 'linear_gradient_oval_matrix',
-        region: screenRect,
         maxDiffRatePercent: 0.2);
   });
 
@@ -110,7 +103,6 @@ Future<void> testMain() async {
     rc.drawRRect(RRect.fromRectAndRadius(shaderRect, const Radius.circular(16)), paint);
     expect(rc.renderStrategy.hasArbitraryPaint, isTrue);
     await canvasScreenshot(rc, 'linear_gradient_rounded_rect',
-        region: screenRect,
         maxDiffRatePercent: 0.1);
   });
 
@@ -137,8 +129,7 @@ Future<void> testMain() async {
       yOffset += 120;
     }
     expect(rc.renderStrategy.hasArbitraryPaint, isTrue);
-    await canvasScreenshot(rc, 'linear_gradient_tiled_repeated_rect',
-        region: screenRect);
+    await canvasScreenshot(rc, 'linear_gradient_tiled_repeated_rect');
   }, skip: isFirefox);
 
   test('Should draw tiled mirrored linear gradient with transform.', () async {
@@ -164,7 +155,6 @@ Future<void> testMain() async {
       yOffset += 120;
     }
     expect(rc.renderStrategy.hasArbitraryPaint, isTrue);
-    await canvasScreenshot(rc, 'linear_gradient_tiled_mirrored_rect',
-        region: screenRect);
+    await canvasScreenshot(rc, 'linear_gradient_tiled_mirrored_rect');
   }, skip: isFirefox);
 }

--- a/lib/web_ui/test/html/shadow_golden_test.dart
+++ b/lib/web_ui/test/html/shadow_golden_test.dart
@@ -9,7 +9,7 @@ import 'package:ui/ui.dart';
 
 import 'package:web_engine_tester/golden_tester.dart';
 
-import 'paragraph/text_scuba.dart';
+import 'screenshot.dart';
 
 const Color _kShadowColor = Color.fromARGB(255, 0, 0, 0);
 


### PR DESCRIPTION
While working on https://github.com/flutter/engine/pull/36095 I realized we have several golden-related helpers that are duplicated throughout our tests. This PR attempts to clean up the duplicates.

* `matchSceneGolden()`
* `matchPictureGolden()`
* `canvasScreenshot()`
* `checkScreenshot()`
* `setUpStableTestFonts()`

As a future effort, we may want to unify some of these helpers.