### PR TITLE
[web] Remove unnecessary code from sdk_rewriter

### DIFF
--- a/web_sdk/sdk_rewriter.dart
+++ b/web_sdk/sdk_rewriter.dart
@@ -211,14 +211,7 @@ String validateApiFile(String apiFilePath, String apiFileCode, String libraryNam
 }
 
 String preprocessPartFile(String source, String libraryName) {
-  if (source.startsWith('part of $libraryName;') || source.contains('\npart of $libraryName;')) {
-    // The file hasn't been migrated yet.
-    // Do nothing.
-  } else {
-    // Insert the part directive at the beginning of the file.
-    source = 'part of $libraryName;\n$source';
-  }
-  return source;
+  return 'part of $libraryName;\n$source';
 }
 
 /// Responsible for performing string replacements.

--- a/web_sdk/test/sdk_rewriter_test.dart
+++ b/web_sdk/test/sdk_rewriter_test.dart
@@ -125,29 +125,4 @@ void printSomething() {
     );
     expect(result, expected);
   });
-
-  test('does not insert an extra part directive', () {
-    const String source = '''
-part of engine;
-
-void printSomething() {
-  print('something');
-}
-''';
-
-    const String expected = '''
-part of dart._engine;
-
-void printSomething() {
-  print('something');
-}
-''';
-
-    final String result = processSource(
-      source,
-      (String source) => preprocessPartFile(source, 'engine'),
-      generatePartsPatterns('engine'),
-    );
-    expect(result, expected);
-  });
 }


### PR DESCRIPTION
Remove a conditional that was put in place as a temporary workaround during the librarification of the web engine. Now that the engine is fully librarified, the conditional is no longer necessary.