### PR TITLE
Modify assert keyboard condition on Windows to account for violation of invariant

### DIFF
--- a/shell/platform/windows/keyboard_key_embedder_handler.cc
+++ b/shell/platform/windows/keyboard_key_embedder_handler.cc
@@ -265,7 +265,7 @@ void KeyboardKeyEmbedderHandler::KeyboardHookImpl(
   } else {
     auto record_iter = pressingRecords_.find(physical_key);
     // Critical keys can be unset before this poitn if get_key_state_ finds they are not
-    // currently pressed. If a the physical key of a keyup event is not in pressingRecords_,
+    // currently pressed. If the physical key of a keyup event is not in pressingRecords_,
     // only assert that it is a critical key.
     if (record_iter == pressingRecords_.end()) {
       assert(critical_keys_.find(key) != critical_keys_.end());

--- a/shell/platform/windows/keyboard_key_embedder_handler.cc
+++ b/shell/platform/windows/keyboard_key_embedder_handler.cc
@@ -270,6 +270,8 @@ void KeyboardKeyEmbedderHandler::KeyboardHookImpl(
     // key is currently recorded as pressed.
     if (record_iter != pressingRecords_.end()) {
       pressingRecords_.erase(record_iter);
+    } else {
+      assert(false);
     }
   }
 

--- a/shell/platform/windows/keyboard_key_embedder_handler.cc
+++ b/shell/platform/windows/keyboard_key_embedder_handler.cc
@@ -212,8 +212,7 @@ void KeyboardKeyEmbedderHandler::KeyboardHookImpl(
   // by the above synchronization methods.
   last_logical_record_iter = pressingRecords_.find(physical_key);
   had_record = last_logical_record_iter != pressingRecords_.end();
-  last_logical_record =
-      had_record ? last_logical_record_iter->second : 0;
+  last_logical_record = had_record ? last_logical_record_iter->second : 0;
 
   // The resulting event's `type`.
   FlutterKeyEventType type;

--- a/shell/platform/windows/keyboard_key_embedder_handler.cc
+++ b/shell/platform/windows/keyboard_key_embedder_handler.cc
@@ -264,8 +264,12 @@ void KeyboardKeyEmbedderHandler::KeyboardHookImpl(
     pressingRecords_[physical_key] = eventual_logical_record;
   } else {
     auto record_iter = pressingRecords_.find(physical_key);
-    assert(record_iter != pressingRecords_.end());
-    pressingRecords_.erase(record_iter);
+    if (record_iter == pressingRecords_.end()) {
+      auto critical_iter = critical_keys_.find(key);
+      assert(critical_iter != critical_keys_.end());
+    } else {
+      pressingRecords_.erase(record_iter);
+    }
   }
 
   FlutterKeyEvent key_data{

--- a/shell/platform/windows/keyboard_key_embedder_handler.cc
+++ b/shell/platform/windows/keyboard_key_embedder_handler.cc
@@ -270,10 +270,9 @@ void KeyboardKeyEmbedderHandler::KeyboardHookImpl(
     pressingRecords_[physical_key] = eventual_logical_record;
   } else {
     auto record_iter = pressingRecords_.find(physical_key);
-    // Synthesized keyup events can be handled causing the
-    // key state to be released before the keyup event is
-    // received. Therefore, only erase the record if the
-    // key is currently recorded as pressed.
+    // Assert this in debug mode. But in cases that it doesn't satisfy
+    // (such as due to a bug), make sure the `erase` is only called 
+    // with a valid value to avoid crashing.
     if (record_iter != pressingRecords_.end()) {
       pressingRecords_.erase(record_iter);
     } else {

--- a/shell/platform/windows/keyboard_key_embedder_handler.cc
+++ b/shell/platform/windows/keyboard_key_embedder_handler.cc
@@ -164,8 +164,8 @@ void KeyboardKeyEmbedderHandler::KeyboardHookImpl(
          action == WM_SYSKEYDOWN || action == WM_SYSKEYUP);
 
   auto last_logical_record_iter = pressingRecords_.find(physical_key);
-  const bool had_record = last_logical_record_iter != pressingRecords_.end();
-  const uint64_t last_logical_record =
+  bool had_record = last_logical_record_iter != pressingRecords_.end();
+  uint64_t last_logical_record =
       had_record ? last_logical_record_iter->second : 0;
 
   // The logical key for the current "tap sequence".
@@ -207,6 +207,13 @@ void KeyboardKeyEmbedderHandler::KeyboardHookImpl(
   // target key's pressed state will be updated immediately after this.
   SynchronizeCritialPressedStates(key, physical_key, is_event_down,
                                   event_key_can_be_repeat);
+
+  // Reassess the last logical record in case pressingRecords_ was modified
+  // by the above synchronization methods.
+  last_logical_record_iter = pressingRecords_.find(physical_key);
+  had_record = last_logical_record_iter != pressingRecords_.end();
+  last_logical_record =
+      had_record ? last_logical_record_iter->second : 0;
 
   // The resulting event's `type`.
   FlutterKeyEventType type;

--- a/shell/platform/windows/keyboard_key_embedder_handler.cc
+++ b/shell/platform/windows/keyboard_key_embedder_handler.cc
@@ -264,7 +264,7 @@ void KeyboardKeyEmbedderHandler::KeyboardHookImpl(
     pressingRecords_[physical_key] = eventual_logical_record;
   } else {
     auto record_iter = pressingRecords_.find(physical_key);
-    // Critical keys can be unset before this poitn if get_key_state_ finds they
+    // Critical keys can be unset before this point if get_key_state_ finds they
     // are not currently pressed. If the physical key of a keyup event is not in
     // pressingRecords_, only assert that it is a critical key.
     // This can occur when caps lock is double pressed with Windows Narrator

--- a/shell/platform/windows/keyboard_key_embedder_handler.cc
+++ b/shell/platform/windows/keyboard_key_embedder_handler.cc
@@ -260,13 +260,8 @@ void KeyboardKeyEmbedderHandler::KeyboardHookImpl(
     }
   }
 
-  auto new_record = pressingRecords_.end();
   if (eventual_logical_record != 0) {
-    auto this_record = pressingRecords_.insert(
-      std::pair<uint64_t, uint64_t>{physical_key, eventual_logical_record}).first;
-    if (!(get_key_state_(key) & kStateMaskPressed) && !event_key_can_be_repeat) {
-      new_record = this_record;
-    }
+    pressingRecords_[physical_key] = eventual_logical_record;
   } else {
     auto record_iter = pressingRecords_.find(physical_key);
     // Synthesized keyup events can be handled causing the
@@ -310,10 +305,8 @@ void KeyboardKeyEmbedderHandler::KeyboardHookImpl(
   SendEvent(key_data, KeyboardKeyEmbedderHandler::HandleResponse,
             reinterpret_cast<void*>(pending_responses_[response_id].get()));
 
-  if (new_record != pressingRecords_.end()) {
-    SendEvent(SynthesizeSimpleEvent(kFlutterKeyEventTypeUp, physical_key, logical_key, ""),
-      nullptr, nullptr);
-  }
+  SynchronizeCritialPressedStates(key, physical_key, is_event_down,
+                                  event_key_can_be_repeat);
 }
 
 void KeyboardKeyEmbedderHandler::KeyboardHook(

--- a/shell/platform/windows/keyboard_key_embedder_handler.cc
+++ b/shell/platform/windows/keyboard_key_embedder_handler.cc
@@ -264,15 +264,11 @@ void KeyboardKeyEmbedderHandler::KeyboardHookImpl(
     pressingRecords_[physical_key] = eventual_logical_record;
   } else {
     auto record_iter = pressingRecords_.find(physical_key);
-    // Critical keys can be unset before this point if get_key_state_ finds they
-    // are not currently pressed. If the physical key of a keyup event is not in
-    // pressingRecords_, only assert that it is a critical key.
-    // This can occur when caps lock is double pressed with Windows Narrator
-    // running, as key events with wparam 0x14 (caps lock) but with scancode
-    // 0x00 are issued.
-    if (record_iter == pressingRecords_.end()) {
-      assert(critical_keys_.find(key) != critical_keys_.end());
-    } else {
+    // Synthesized keyup events can be handled causing the
+    // key state to be released before the keyup event is
+    // received. Therefore, only erase the record if the
+    // key is currently recorded as pressed.
+    if (record_iter != pressingRecords_.end()) {
       pressingRecords_.erase(record_iter);
     }
   }

--- a/shell/platform/windows/keyboard_key_embedder_handler.cc
+++ b/shell/platform/windows/keyboard_key_embedder_handler.cc
@@ -312,6 +312,10 @@ void KeyboardKeyEmbedderHandler::KeyboardHookImpl(
   SendEvent(key_data, KeyboardKeyEmbedderHandler::HandleResponse,
             reinterpret_cast<void*>(pending_responses_[response_id].get()));
 
+  // Post-event synchronization. It is useful in cases where the true pressing state
+  // does not match the event type. For example, a CapsLock down event is received
+  // despite that GetKeyState says that CapsLock is not pressed. In such case, post-
+  // event synchronization will synthesize a CapsLock up event after the main event.
   SynchronizeCritialPressedStates(key, physical_key, is_event_down,
                                   event_key_can_be_repeat);
 }

--- a/shell/platform/windows/keyboard_key_embedder_handler.cc
+++ b/shell/platform/windows/keyboard_key_embedder_handler.cc
@@ -264,9 +264,11 @@ void KeyboardKeyEmbedderHandler::KeyboardHookImpl(
     pressingRecords_[physical_key] = eventual_logical_record;
   } else {
     auto record_iter = pressingRecords_.find(physical_key);
+    // Critical keys can be unset before this poitn if get_key_state_ finds they are not
+    // currently pressed. If a the physical key of a keyup event is not in pressingRecords_,
+    // only assert that it is a critical key.
     if (record_iter == pressingRecords_.end()) {
-      auto critical_iter = critical_keys_.find(key);
-      assert(critical_iter != critical_keys_.end());
+      assert(critical_keys_.find(key) != critical_keys_.end());
     } else {
       pressingRecords_.erase(record_iter);
     }

--- a/shell/platform/windows/keyboard_key_embedder_handler.cc
+++ b/shell/platform/windows/keyboard_key_embedder_handler.cc
@@ -264,9 +264,12 @@ void KeyboardKeyEmbedderHandler::KeyboardHookImpl(
     pressingRecords_[physical_key] = eventual_logical_record;
   } else {
     auto record_iter = pressingRecords_.find(physical_key);
-    // Critical keys can be unset before this poitn if get_key_state_ finds they are not
-    // currently pressed. If the physical key of a keyup event is not in pressingRecords_,
-    // only assert that it is a critical key.
+    // Critical keys can be unset before this poitn if get_key_state_ finds they
+    // are not currently pressed. If the physical key of a keyup event is not in
+    // pressingRecords_, only assert that it is a critical key.
+    // This can occur when caps lock is double pressed with Windows Narrator
+    // running, as key events with wparam 0x14 (caps lock) but with scancode
+    // 0x00 are issued.
     if (record_iter == pressingRecords_.end()) {
       assert(critical_keys_.find(key) != critical_keys_.end());
     } else {

--- a/shell/platform/windows/keyboard_key_embedder_handler.cc
+++ b/shell/platform/windows/keyboard_key_embedder_handler.cc
@@ -271,7 +271,7 @@ void KeyboardKeyEmbedderHandler::KeyboardHookImpl(
   } else {
     auto record_iter = pressingRecords_.find(physical_key);
     // Assert this in debug mode. But in cases that it doesn't satisfy
-    // (such as due to a bug), make sure the `erase` is only called 
+    // (such as due to a bug), make sure the `erase` is only called
     // with a valid value to avoid crashing.
     if (record_iter != pressingRecords_.end()) {
       pressingRecords_.erase(record_iter);

--- a/shell/platform/windows/keyboard_key_embedder_handler.cc
+++ b/shell/platform/windows/keyboard_key_embedder_handler.cc
@@ -312,10 +312,11 @@ void KeyboardKeyEmbedderHandler::KeyboardHookImpl(
   SendEvent(key_data, KeyboardKeyEmbedderHandler::HandleResponse,
             reinterpret_cast<void*>(pending_responses_[response_id].get()));
 
-  // Post-event synchronization. It is useful in cases where the true pressing state
-  // does not match the event type. For example, a CapsLock down event is received
-  // despite that GetKeyState says that CapsLock is not pressed. In such case, post-
-  // event synchronization will synthesize a CapsLock up event after the main event.
+  // Post-event synchronization. It is useful in cases where the true pressing
+  // state does not match the event type. For example, a CapsLock down event is
+  // received despite that GetKeyState says that CapsLock is not pressed. In
+  // such case, post-event synchronization will synthesize a CapsLock up event
+  // after the main event.
   SynchronizeCritialPressedStates(key, physical_key, is_event_down,
                                   event_key_can_be_repeat);
 }

--- a/shell/platform/windows/keyboard_key_embedder_handler_unittests.cc
+++ b/shell/platform/windows/keyboard_key_embedder_handler_unittests.cc
@@ -942,6 +942,9 @@ TEST(KeyboardKeyEmbedderHandlerTest,
       VK_NUMLOCK, kScanCodeNumLock, WM_KEYDOWN, 0, true, false,
       [&last_handled](bool handled) { last_handled = handled; });
   EXPECT_EQ(last_handled, false);
+  // 4 total events should be fired:
+  // Pre-synchronization toggle, pre-sync press,
+  // main event, and post-sync press.
   EXPECT_EQ(results.size(), 4);
   event = &results[0];
   EXPECT_EQ(event->type, kFlutterKeyEventTypeDown);

--- a/shell/platform/windows/keyboard_key_embedder_handler_unittests.cc
+++ b/shell/platform/windows/keyboard_key_embedder_handler_unittests.cc
@@ -942,7 +942,7 @@ TEST(KeyboardKeyEmbedderHandlerTest,
       VK_NUMLOCK, kScanCodeNumLock, WM_KEYDOWN, 0, true, false,
       [&last_handled](bool handled) { last_handled = handled; });
   EXPECT_EQ(last_handled, false);
-  EXPECT_EQ(results.size(), 3);
+  EXPECT_EQ(results.size(), 4);
   event = &results[0];
   EXPECT_EQ(event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(event->physical, kPhysicalNumLock);

--- a/shell/platform/windows/keyboard_unittests.cc
+++ b/shell/platform/windows/keyboard_unittests.cc
@@ -2375,7 +2375,7 @@ TEST(KeyboardTest, VietnameseTelexAddDiacriticWithSlowTrueResponse) {
 }
 
 // Ensure that the scancode-less key events issued by Narrator
-// when toggling caps lock do violate assert statements.
+// when toggling caps lock don't violate assert statements.
 TEST(KeyboardTest, DoubleCapsLock) {
   KeyboardTester tester;
   tester.Responding(false);

--- a/shell/platform/windows/keyboard_unittests.cc
+++ b/shell/platform/windows/keyboard_unittests.cc
@@ -2374,5 +2374,20 @@ TEST(KeyboardTest, VietnameseTelexAddDiacriticWithSlowTrueResponse) {
   VietnameseTelexAddDiacriticWithSlowResponse(true);
 }
 
+// Ensure that the scancode-less key events issued by Narrator
+// when toggling caps lock do violate assert statements.
+TEST(KeyboardTest, DoubleCapsLock) {
+  KeyboardTester tester;
+  tester.Responding(false);
+
+  tester.InjectKeyboardChanges(std::vector<KeyboardChange>{
+    WmKeyDownInfo{VK_CAPITAL, 0, kNotExtended}.Build(),
+    WmKeyUpInfo{VK_CAPITAL, 0, kNotExtended}.Build()
+  });
+
+  clear_key_calls();
+  
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/shell/platform/windows/keyboard_unittests.cc
+++ b/shell/platform/windows/keyboard_unittests.cc
@@ -2385,7 +2385,6 @@ TEST(KeyboardTest, DoubleCapsLock) {
       WmKeyUpInfo{VK_CAPITAL, 0, kNotExtended}.Build()});
 
   clear_key_calls();
-  
 }
 
 }  // namespace testing

--- a/shell/platform/windows/keyboard_unittests.cc
+++ b/shell/platform/windows/keyboard_unittests.cc
@@ -2381,9 +2381,8 @@ TEST(KeyboardTest, DoubleCapsLock) {
   tester.Responding(false);
 
   tester.InjectKeyboardChanges(std::vector<KeyboardChange>{
-    WmKeyDownInfo{VK_CAPITAL, 0, kNotExtended}.Build(),
-    WmKeyUpInfo{VK_CAPITAL, 0, kNotExtended}.Build()
-  });
+      WmKeyDownInfo{VK_CAPITAL, 0, kNotExtended}.Build(),
+      WmKeyUpInfo{VK_CAPITAL, 0, kNotExtended}.Build()});
 
   clear_key_calls();
   


### PR DESCRIPTION
There is at least one edge case where an assert statement in the keyboard handler for Windows would fail in debug mode, and an absent entry in a `map` would be erased in release, causing a segfault.

When CAPS is pressed twice quickly while Narrator is open, it sends a keydown and keyup event consecutively to the window, but because the `get_key_state_` handler cannot account for this simulated key event, it would be cleared from the record of pressed physical keys twice.

This change checks that a key record is present before attempting to erase it, and asserts that only critical keys (including caps lock) may be absent, as only these keys can be erased prematurely.

Addresses [#flutter/flutter/108731](https://github.com/flutter/flutter/issues/108731)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
