### PR TITLE
[Impeller] Don't emit double underscores in SkSL backend.

### DIFF
--- a/impeller/compiler/spirv_sksl.cc
+++ b/impeller/compiler/spirv_sksl.cc
@@ -68,7 +68,7 @@ std::string CompilerSkSL::compile() {
   statement("half4 main(float2 iFragCoord)");
   begin_scope();
   statement("  flutter_FragCoord = float4(iFragCoord, 0, 0);");
-  statement("  __main();");
+  statement("  FLT_main();");
   statement("  return " + output_name_ + ";");
   end_scope();
 
@@ -76,7 +76,7 @@ std::string CompilerSkSL::compile() {
 }
 
 void CompilerSkSL::fixup_user_functions() {
-  const std::string prefix = "__flutter_local_";
+  const std::string prefix = "FLT_flutter_local_";
   ir.for_each_typed_id<SPIRFunction>([&](uint32_t, const SPIRFunction& func) {
     const auto& original_name = get_name(func.self);
     // Just in case. Don't add the prefix a second time.
@@ -381,8 +381,8 @@ void CompilerSkSL::emit_function_prototype(SPIRFunction& func,
 
   // If this is the entrypoint of a fragment shader, then GLSL requires the
   // prototype to be "void main()", and so it is safe to rewrite as
-  // "void __main()".
-  statement("void __main()");
+  // "void FLT_main()".
+  statement("void FLT_main()");
 }
 
 std::string CompilerSkSL::image_type_glsl(const SPIRType& type, uint32_t id) {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/111379. Identifiers with double-underscore in them are reserved in SkSL, but it looks like this is only enforced when targeting an Android emulator.