### PR TITLE
[lint] Update local variable names in flow

### DIFF
--- a/flow/instrumentation.cc
+++ b/flow/instrumentation.cc
@@ -58,11 +58,11 @@ double Stopwatch::UnitFrameInterval(double raster_time_ms) const {
 
 double Stopwatch::UnitHeight(double raster_time_ms,
                              double max_unit_interval) const {
-  double unitHeight = UnitFrameInterval(raster_time_ms) / max_unit_interval;
-  if (unitHeight > 1.0) {
-    unitHeight = 1.0;
+  double unit_height = UnitFrameInterval(raster_time_ms) / max_unit_interval;
+  if (unit_height > 1.0) {
+    unit_height = 1.0;
   }
-  return unitHeight;
+  return unit_height;
 }
 
 fml::TimeDelta Stopwatch::MaxDelta() const {

--- a/flow/layers/clip_path_layer_unittests.cc
+++ b/flow/layers/clip_path_layer_unittests.cc
@@ -306,20 +306,20 @@ TEST_F(ClipPathLayerTest, OpacityInheritance) {
 
   {
     // ClipRectLayer(aa with saveLayer) will always be compatible
-    auto clip_path_saveLayer = std::make_shared<ClipPathLayer>(
+    auto clip_path_savelayer = std::make_shared<ClipPathLayer>(
         layer_clip, Clip::antiAliasWithSaveLayer);
-    clip_path_saveLayer->Add(mock1);
-    clip_path_saveLayer->Add(mock2);
+    clip_path_savelayer->Add(mock1);
+    clip_path_savelayer->Add(mock2);
 
     // Double check first two children are compatible and non-overlapping
     context->subtree_can_inherit_opacity = false;
-    clip_path_saveLayer->Preroll(context, SkMatrix::I());
+    clip_path_savelayer->Preroll(context, SkMatrix::I());
     EXPECT_TRUE(context->subtree_can_inherit_opacity);
 
     // Now add the overlapping child and test again, should still be compatible
-    clip_path_saveLayer->Add(mock3);
+    clip_path_savelayer->Add(mock3);
     context->subtree_can_inherit_opacity = false;
-    clip_path_saveLayer->Preroll(context, SkMatrix::I());
+    clip_path_savelayer->Preroll(context, SkMatrix::I());
     EXPECT_TRUE(context->subtree_can_inherit_opacity);
   }
 
@@ -350,20 +350,20 @@ TEST_F(ClipPathLayerTest, OpacityInheritance) {
 
   {
     // ClipRectLayer(aa with saveLayer) will always be compatible
-    auto clip_path_saveLayer_bad_child = std::make_shared<ClipPathLayer>(
+    auto clip_path_savelayer_bad_child = std::make_shared<ClipPathLayer>(
         layer_clip, Clip::antiAliasWithSaveLayer);
-    clip_path_saveLayer_bad_child->Add(mock1);
-    clip_path_saveLayer_bad_child->Add(mock2);
+    clip_path_savelayer_bad_child->Add(mock1);
+    clip_path_savelayer_bad_child->Add(mock2);
 
     // Double check first two children are compatible and non-overlapping
     context->subtree_can_inherit_opacity = false;
-    clip_path_saveLayer_bad_child->Preroll(context, SkMatrix::I());
+    clip_path_savelayer_bad_child->Preroll(context, SkMatrix::I());
     EXPECT_TRUE(context->subtree_can_inherit_opacity);
 
     // Now add the incompatible child and test again, should still be compatible
-    clip_path_saveLayer_bad_child->Add(mock4);
+    clip_path_savelayer_bad_child->Add(mock4);
     context->subtree_can_inherit_opacity = false;
-    clip_path_saveLayer_bad_child->Preroll(context, SkMatrix::I());
+    clip_path_savelayer_bad_child->Preroll(context, SkMatrix::I());
     EXPECT_TRUE(context->subtree_can_inherit_opacity);
   }
 }

--- a/flow/layers/clip_rect_layer_unittests.cc
+++ b/flow/layers/clip_rect_layer_unittests.cc
@@ -299,20 +299,20 @@ TEST_F(ClipRectLayerTest, OpacityInheritance) {
 
   {
     // ClipRectLayer(aa with saveLayer) will always be compatible
-    auto clip_rect_saveLayer = std::make_shared<ClipRectLayer>(
+    auto clip_path_savelayer = std::make_shared<ClipRectLayer>(
         clip_rect, Clip::antiAliasWithSaveLayer);
-    clip_rect_saveLayer->Add(mock1);
-    clip_rect_saveLayer->Add(mock2);
+    clip_path_savelayer->Add(mock1);
+    clip_path_savelayer->Add(mock2);
 
     // Double check first two children are compatible and non-overlapping
     context->subtree_can_inherit_opacity = false;
-    clip_rect_saveLayer->Preroll(context, SkMatrix::I());
+    clip_path_savelayer->Preroll(context, SkMatrix::I());
     EXPECT_TRUE(context->subtree_can_inherit_opacity);
 
     // Now add the overlapping child and test again, should still be compatible
-    clip_rect_saveLayer->Add(mock3);
+    clip_path_savelayer->Add(mock3);
     context->subtree_can_inherit_opacity = false;
-    clip_rect_saveLayer->Preroll(context, SkMatrix::I());
+    clip_path_savelayer->Preroll(context, SkMatrix::I());
     EXPECT_TRUE(context->subtree_can_inherit_opacity);
   }
 
@@ -343,20 +343,20 @@ TEST_F(ClipRectLayerTest, OpacityInheritance) {
 
   {
     // ClipRectLayer(aa with saveLayer) will always be compatible
-    auto clip_rect_saveLayer_bad_child = std::make_shared<ClipRectLayer>(
+    auto clip_path_savelayer_bad_child = std::make_shared<ClipRectLayer>(
         clip_rect, Clip::antiAliasWithSaveLayer);
-    clip_rect_saveLayer_bad_child->Add(mock1);
-    clip_rect_saveLayer_bad_child->Add(mock2);
+    clip_path_savelayer_bad_child->Add(mock1);
+    clip_path_savelayer_bad_child->Add(mock2);
 
     // Double check first two children are compatible and non-overlapping
     context->subtree_can_inherit_opacity = false;
-    clip_rect_saveLayer_bad_child->Preroll(context, SkMatrix::I());
+    clip_path_savelayer_bad_child->Preroll(context, SkMatrix::I());
     EXPECT_TRUE(context->subtree_can_inherit_opacity);
 
     // Now add the incompatible child and test again, should still be compatible
-    clip_rect_saveLayer_bad_child->Add(mock4);
+    clip_path_savelayer_bad_child->Add(mock4);
     context->subtree_can_inherit_opacity = false;
-    clip_rect_saveLayer_bad_child->Preroll(context, SkMatrix::I());
+    clip_path_savelayer_bad_child->Preroll(context, SkMatrix::I());
     EXPECT_TRUE(context->subtree_can_inherit_opacity);
   }
 }

--- a/flow/layers/clip_rrect_layer_unittests.cc
+++ b/flow/layers/clip_rrect_layer_unittests.cc
@@ -272,53 +272,53 @@ TEST_F(ClipRRectLayerTest, OpacityInheritance) {
   auto path1 = SkPath().addRect({10, 10, 30, 30});
   auto mock1 = MockLayer::MakeOpacityCompatible(path1);
   SkRect clip_rect = SkRect::MakeWH(500, 500);
-  SkRRect clip_r_rect = SkRRect::MakeRectXY(clip_rect, 20, 20);
-  auto clip_r_rect_layer =
-      std::make_shared<ClipRRectLayer>(clip_r_rect, Clip::hardEdge);
-  clip_r_rect_layer->Add(mock1);
+  SkRRect clip_rrect = SkRRect::MakeRectXY(clip_rect, 20, 20);
+  auto clip_rrect_layer =
+      std::make_shared<ClipRRectLayer>(clip_rrect, Clip::hardEdge);
+  clip_rrect_layer->Add(mock1);
 
   // ClipRectLayer will pass through compatibility from a compatible child
   PrerollContext* context = preroll_context();
   context->subtree_can_inherit_opacity = false;
-  clip_r_rect_layer->Preroll(context, SkMatrix::I());
+  clip_rrect_layer->Preroll(context, SkMatrix::I());
   EXPECT_TRUE(context->subtree_can_inherit_opacity);
 
   auto path2 = SkPath().addRect({40, 40, 50, 50});
   auto mock2 = MockLayer::MakeOpacityCompatible(path2);
-  clip_r_rect_layer->Add(mock2);
+  clip_rrect_layer->Add(mock2);
 
   // ClipRectLayer will pass through compatibility from multiple
   // non-overlapping compatible children
   context->subtree_can_inherit_opacity = false;
-  clip_r_rect_layer->Preroll(context, SkMatrix::I());
+  clip_rrect_layer->Preroll(context, SkMatrix::I());
   EXPECT_TRUE(context->subtree_can_inherit_opacity);
 
   auto path3 = SkPath().addRect({20, 20, 40, 40});
   auto mock3 = MockLayer::MakeOpacityCompatible(path3);
-  clip_r_rect_layer->Add(mock3);
+  clip_rrect_layer->Add(mock3);
 
   // ClipRectLayer will not pass through compatibility from multiple
   // overlapping children even if they are individually compatible
   context->subtree_can_inherit_opacity = false;
-  clip_r_rect_layer->Preroll(context, SkMatrix::I());
+  clip_rrect_layer->Preroll(context, SkMatrix::I());
   EXPECT_FALSE(context->subtree_can_inherit_opacity);
 
   {
     // ClipRectLayer(aa with saveLayer) will always be compatible
-    auto clip_r_rect_saveLayer = std::make_shared<ClipRRectLayer>(
-        clip_r_rect, Clip::antiAliasWithSaveLayer);
-    clip_r_rect_saveLayer->Add(mock1);
-    clip_r_rect_saveLayer->Add(mock2);
+    auto clip_rrect_savelayer = std::make_shared<ClipRRectLayer>(
+        clip_rrect, Clip::antiAliasWithSaveLayer);
+    clip_rrect_savelayer->Add(mock1);
+    clip_rrect_savelayer->Add(mock2);
 
     // Double check first two children are compatible and non-overlapping
     context->subtree_can_inherit_opacity = false;
-    clip_r_rect_saveLayer->Preroll(context, SkMatrix::I());
+    clip_rrect_savelayer->Preroll(context, SkMatrix::I());
     EXPECT_TRUE(context->subtree_can_inherit_opacity);
 
     // Now add the overlapping child and test again, should still be compatible
-    clip_r_rect_saveLayer->Add(mock3);
+    clip_rrect_savelayer->Add(mock3);
     context->subtree_can_inherit_opacity = false;
-    clip_r_rect_saveLayer->Preroll(context, SkMatrix::I());
+    clip_rrect_savelayer->Preroll(context, SkMatrix::I());
     EXPECT_TRUE(context->subtree_can_inherit_opacity);
   }
 
@@ -328,41 +328,41 @@ TEST_F(ClipRRectLayerTest, OpacityInheritance) {
 
   {
     // ClipRectLayer with incompatible child will not be compatible
-    auto clip_r_rect_bad_child =
-        std::make_shared<ClipRRectLayer>(clip_r_rect, Clip::hardEdge);
-    clip_r_rect_bad_child->Add(mock1);
-    clip_r_rect_bad_child->Add(mock2);
+    auto clip_rrect_bad_child =
+        std::make_shared<ClipRRectLayer>(clip_rrect, Clip::hardEdge);
+    clip_rrect_bad_child->Add(mock1);
+    clip_rrect_bad_child->Add(mock2);
 
     // Double check first two children are compatible and non-overlapping
     context->subtree_can_inherit_opacity = false;
-    clip_r_rect_bad_child->Preroll(context, SkMatrix::I());
+    clip_rrect_bad_child->Preroll(context, SkMatrix::I());
     EXPECT_TRUE(context->subtree_can_inherit_opacity);
 
-    clip_r_rect_bad_child->Add(mock4);
+    clip_rrect_bad_child->Add(mock4);
 
     // The third child is non-overlapping, but not compatible so the
     // TransformLayer should end up incompatible
     context->subtree_can_inherit_opacity = false;
-    clip_r_rect_bad_child->Preroll(context, SkMatrix::I());
+    clip_rrect_bad_child->Preroll(context, SkMatrix::I());
     EXPECT_FALSE(context->subtree_can_inherit_opacity);
   }
 
   {
     // ClipRectLayer(aa with saveLayer) will always be compatible
-    auto clip_r_rect_saveLayer_bad_child = std::make_shared<ClipRRectLayer>(
-        clip_r_rect, Clip::antiAliasWithSaveLayer);
-    clip_r_rect_saveLayer_bad_child->Add(mock1);
-    clip_r_rect_saveLayer_bad_child->Add(mock2);
+    auto clip_rrect_savelayer_bad_child = std::make_shared<ClipRRectLayer>(
+        clip_rrect, Clip::antiAliasWithSaveLayer);
+    clip_rrect_savelayer_bad_child->Add(mock1);
+    clip_rrect_savelayer_bad_child->Add(mock2);
 
     // Double check first two children are compatible and non-overlapping
     context->subtree_can_inherit_opacity = false;
-    clip_r_rect_saveLayer_bad_child->Preroll(context, SkMatrix::I());
+    clip_rrect_savelayer_bad_child->Preroll(context, SkMatrix::I());
     EXPECT_TRUE(context->subtree_can_inherit_opacity);
 
     // Now add the incompatible child and test again, should still be compatible
-    clip_r_rect_saveLayer_bad_child->Add(mock4);
+    clip_rrect_savelayer_bad_child->Add(mock4);
     context->subtree_can_inherit_opacity = false;
-    clip_r_rect_saveLayer_bad_child->Preroll(context, SkMatrix::I());
+    clip_rrect_savelayer_bad_child->Preroll(context, SkMatrix::I());
     EXPECT_TRUE(context->subtree_can_inherit_opacity);
   }
 }
@@ -373,9 +373,9 @@ TEST_F(ClipRRectLayerTest, OpacityInheritancePainting) {
   auto path2 = SkPath().addRect({40, 40, 50, 50});
   auto mock2 = MockLayer::MakeOpacityCompatible(path2);
   SkRect clip_rect = SkRect::MakeWH(500, 500);
-  SkRRect clip_r_rect = SkRRect::MakeRectXY(clip_rect, 20, 20);
+  SkRRect clip_rrect = SkRRect::MakeRectXY(clip_rect, 20, 20);
   auto clip_rect_layer =
-      std::make_shared<ClipRRectLayer>(clip_r_rect, Clip::antiAlias);
+      std::make_shared<ClipRRectLayer>(clip_rrect, Clip::antiAlias);
   clip_rect_layer->Add(mock1);
   clip_rect_layer->Add(mock2);
 
@@ -401,7 +401,7 @@ TEST_F(ClipRRectLayerTest, OpacityInheritancePainting) {
       expected_builder.translate(offset.fX, offset.fY);
       /* ClipRectLayer::Paint() */ {
         expected_builder.save();
-        expected_builder.clipRRect(clip_r_rect, SkClipOp::kIntersect, true);
+        expected_builder.clipRRect(clip_rrect, SkClipOp::kIntersect, true);
         /* child layer1 paint */ {
           expected_builder.setColor(opacity_alpha << 24);
           expected_builder.saveLayer(&path1.getBounds(), true);
@@ -438,23 +438,23 @@ TEST_F(ClipRRectLayerTest, OpacityInheritanceSaveLayerPainting) {
   auto children_bounds = path1.getBounds();
   children_bounds.join(path2.getBounds());
   SkRect clip_rect = SkRect::MakeWH(500, 500);
-  SkRRect clip_r_rect = SkRRect::MakeRectXY(clip_rect, 20, 20);
-  auto clip_r_rect_layer = std::make_shared<ClipRRectLayer>(
-      clip_r_rect, Clip::antiAliasWithSaveLayer);
-  clip_r_rect_layer->Add(mock1);
-  clip_r_rect_layer->Add(mock2);
+  SkRRect clip_rrect = SkRRect::MakeRectXY(clip_rect, 20, 20);
+  auto clip_rrect_layer = std::make_shared<ClipRRectLayer>(
+      clip_rrect, Clip::antiAliasWithSaveLayer);
+  clip_rrect_layer->Add(mock1);
+  clip_rrect_layer->Add(mock2);
 
   // ClipRectLayer will pass through compatibility from multiple
   // non-overlapping compatible children
   PrerollContext* context = preroll_context();
   context->subtree_can_inherit_opacity = false;
-  clip_r_rect_layer->Preroll(context, SkMatrix::I());
+  clip_rrect_layer->Preroll(context, SkMatrix::I());
   EXPECT_TRUE(context->subtree_can_inherit_opacity);
 
   int opacity_alpha = 0x7F;
   SkPoint offset = SkPoint::Make(10, 10);
   auto opacity_layer = std::make_shared<OpacityLayer>(opacity_alpha, offset);
-  opacity_layer->Add(clip_r_rect_layer);
+  opacity_layer->Add(clip_rrect_layer);
   context->subtree_can_inherit_opacity = false;
   opacity_layer->Preroll(context, SkMatrix::I());
   EXPECT_TRUE(opacity_layer->children_can_accept_opacity());
@@ -466,7 +466,7 @@ TEST_F(ClipRRectLayerTest, OpacityInheritanceSaveLayerPainting) {
       expected_builder.translate(offset.fX, offset.fY);
       /* ClipRectLayer::Paint() */ {
         expected_builder.save();
-        expected_builder.clipRRect(clip_r_rect, SkClipOp::kIntersect, true);
+        expected_builder.clipRRect(clip_rrect, SkClipOp::kIntersect, true);
         expected_builder.setColor(opacity_alpha << 24);
         expected_builder.saveLayer(&children_bounds, true);
         /* child layer1 paint */ {
@@ -491,8 +491,8 @@ TEST_F(ClipRRectLayerTest, LayerCached) {
   SkPaint paint = SkPaint();
   auto mock1 = MockLayer::MakeOpacityCompatible(path1);
   SkRect clip_rect = SkRect::MakeWH(500, 500);
-  SkRRect clip_r_rect = SkRRect::MakeRectXY(clip_rect, 20, 20);
-  auto layer = std::make_shared<ClipRRectLayer>(clip_r_rect,
+  SkRRect clip_rrect = SkRRect::MakeRectXY(clip_rect, 20, 20);
+  auto layer = std::make_shared<ClipRRectLayer>(clip_rrect,
                                                 Clip::antiAliasWithSaveLayer);
   layer->Add(mock1);
 
@@ -530,8 +530,8 @@ TEST_F(ClipRRectLayerTest, NoSaveLayerShouldNotCache) {
 
   auto mock1 = MockLayer::MakeOpacityCompatible(path1);
   SkRect clip_rect = SkRect::MakeWH(500, 500);
-  SkRRect clip_r_rect = SkRRect::MakeRectXY(clip_rect, 20, 20);
-  auto layer = std::make_shared<ClipRRectLayer>(clip_r_rect, Clip::antiAlias);
+  SkRRect clip_rrect = SkRRect::MakeRectXY(clip_rect, 20, 20);
+  auto layer = std::make_shared<ClipRRectLayer>(clip_rrect, Clip::antiAlias);
   layer->Add(mock1);
 
   auto initial_transform = SkMatrix::Translate(50.0, 25.5);

--- a/flow/layers/layer.cc
+++ b/flow/layers/layer.cc
@@ -18,10 +18,10 @@ Layer::Layer()
 Layer::~Layer() = default;
 
 uint64_t Layer::NextUniqueID() {
-  static std::atomic<uint64_t> nextID(1);
+  static std::atomic<uint64_t> next_id(1);
   uint64_t id;
   do {
-    id = nextID.fetch_add(1);
+    id = next_id.fetch_add(1);
   } while (id == 0);  // 0 is reserved for an invalid id.
   return id;
 }

--- a/flow/layers/opacity_layer.cc
+++ b/flow/layers/opacity_layer.cc
@@ -113,21 +113,21 @@ void OpacityLayer::Paint(PaintContext& context) const {
     return;
   }
 
-  // Skia may clip the content with saveLayerBounds (although it's not a
-  // guaranteed clip). So we have to provide a big enough saveLayerBounds. To do
-  // so, we first remove the offset from paint bounds since it's already in the
-  // matrix. Then we round out the bounds.
+  // Skia may clip the content with save_layer_bounds (although it's not a
+  // guaranteed clip). So we have to provide a big enough save_layer_bounds. To
+  // do so, we first remove the offset from paint bounds since it's already in
+  // the matrix. Then we round out the bounds.
   //
   // Note that the following lines are only accessible when the raster cache is
   // not available (e.g., when we're using the software backend in golden
   // tests).
-  SkRect saveLayerBounds;
+  SkRect save_layer_bounds;
   paint_bounds()
       .makeOffset(-offset_.fX, -offset_.fY)
-      .roundOut(&saveLayerBounds);
+      .roundOut(&save_layer_bounds);
 
   Layer::AutoSaveLayer save_layer =
-      Layer::AutoSaveLayer::Create(context, saveLayerBounds, &paint);
+      Layer::AutoSaveLayer::Create(context, save_layer_bounds, &paint);
   context.inherited_opacity = SK_Scalar1;
   PaintChildren(context);
   context.inherited_opacity = inherited_opacity;

--- a/flow/layers/opacity_layer_unittests.cc
+++ b/flow/layers/opacity_layer_unittests.cc
@@ -173,10 +173,10 @@ TEST_F(OpacityLayerTest, CacheChildren) {
 
 TEST_F(OpacityLayerTest, ShouldNotCacheChildren) {
   SkPaint paint;
-  auto opacityLayer =
+  auto opacity_layer =
       std::make_shared<OpacityLayer>(128, SkPoint::Make(20, 20));
-  auto mockLayer = MockLayer::MakeOpacityCompatible(SkPath());
-  opacityLayer->Add(mockLayer);
+  auto mock_layer = MockLayer::MakeOpacityCompatible(SkPath());
+  opacity_layer->Add(mock_layer);
 
   PrerollContext* context = preroll_context();
   context->subtree_can_inherit_opacity = false;
@@ -185,17 +185,17 @@ TEST_F(OpacityLayerTest, ShouldNotCacheChildren) {
 
   EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)0);
 
-  const auto* cacheable_opacity_item = opacityLayer->raster_cache_item();
+  const auto* cacheable_opacity_item = opacity_layer->raster_cache_item();
 
   EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)0);
   EXPECT_EQ(cacheable_opacity_item->cache_state(),
             RasterCacheItem::CacheState::kNone);
   EXPECT_FALSE(cacheable_opacity_item->GetId().has_value());
 
-  opacityLayer->Preroll(preroll_context(), SkMatrix::I());
+  opacity_layer->Preroll(preroll_context(), SkMatrix::I());
 
   EXPECT_TRUE(context->subtree_can_inherit_opacity);
-  EXPECT_TRUE(opacityLayer->children_can_accept_opacity());
+  EXPECT_TRUE(opacity_layer->children_can_accept_opacity());
   LayerTree::TryToRasterCache(cacheable_items(), &paint_context());
   EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)0);
   EXPECT_EQ(cacheable_opacity_item->cache_state(),
@@ -447,131 +447,131 @@ TEST_F(OpacityLayerTest, Readback) {
 }
 
 TEST_F(OpacityLayerTest, CullRectIsTransformed) {
-  auto clipRectLayer = std::make_shared<ClipRectLayer>(
+  auto clip_rect_layer = std::make_shared<ClipRectLayer>(
       SkRect::MakeLTRB(0, 0, 10, 10), flutter::hardEdge);
-  auto opacityLayer =
+  auto opacity_layer =
       std::make_shared<OpacityLayer>(128, SkPoint::Make(20, 20));
-  auto mockLayer = std::make_shared<MockLayer>(SkPath());
-  clipRectLayer->Add(opacityLayer);
-  opacityLayer->Add(mockLayer);
-  clipRectLayer->Preroll(preroll_context(), SkMatrix::I());
-  EXPECT_EQ(mockLayer->parent_cull_rect().fLeft, -20);
-  EXPECT_EQ(mockLayer->parent_cull_rect().fTop, -20);
+  auto mock_layer = std::make_shared<MockLayer>(SkPath());
+  clip_rect_layer->Add(opacity_layer);
+  opacity_layer->Add(mock_layer);
+  clip_rect_layer->Preroll(preroll_context(), SkMatrix::I());
+  EXPECT_EQ(mock_layer->parent_cull_rect().fLeft, -20);
+  EXPECT_EQ(mock_layer->parent_cull_rect().fTop, -20);
 }
 
 TEST_F(OpacityLayerTest, OpacityInheritanceCompatibleChild) {
-  auto opacityLayer =
+  auto opacity_layer =
       std::make_shared<OpacityLayer>(128, SkPoint::Make(20, 20));
-  auto mockLayer = MockLayer::MakeOpacityCompatible(SkPath());
-  opacityLayer->Add(mockLayer);
+  auto mock_layer = MockLayer::MakeOpacityCompatible(SkPath());
+  opacity_layer->Add(mock_layer);
 
   PrerollContext* context = preroll_context();
   context->subtree_can_inherit_opacity = false;
-  opacityLayer->Preroll(context, SkMatrix::I());
+  opacity_layer->Preroll(context, SkMatrix::I());
   EXPECT_TRUE(context->subtree_can_inherit_opacity);
-  EXPECT_TRUE(opacityLayer->children_can_accept_opacity());
+  EXPECT_TRUE(opacity_layer->children_can_accept_opacity());
 }
 
 TEST_F(OpacityLayerTest, OpacityInheritanceIncompatibleChild) {
-  auto opacityLayer =
+  auto opacity_layer =
       std::make_shared<OpacityLayer>(128, SkPoint::Make(20, 20));
-  auto mockLayer = MockLayer::Make(SkPath());
-  opacityLayer->Add(mockLayer);
+  auto mock_layer = MockLayer::Make(SkPath());
+  opacity_layer->Add(mock_layer);
 
   PrerollContext* context = preroll_context();
   context->subtree_can_inherit_opacity = false;
-  opacityLayer->Preroll(context, SkMatrix::I());
+  opacity_layer->Preroll(context, SkMatrix::I());
   EXPECT_TRUE(context->subtree_can_inherit_opacity);
-  EXPECT_FALSE(opacityLayer->children_can_accept_opacity());
+  EXPECT_FALSE(opacity_layer->children_can_accept_opacity());
 }
 
 TEST_F(OpacityLayerTest, OpacityInheritanceThroughContainer) {
-  auto opacityLayer =
+  auto opacity_layer =
       std::make_shared<OpacityLayer>(128, SkPoint::Make(20, 20));
-  auto containerLayer = std::make_shared<ContainerLayer>();
-  auto mockLayer = MockLayer::MakeOpacityCompatible(SkPath());
-  containerLayer->Add(mockLayer);
-  opacityLayer->Add(containerLayer);
+  auto container_layer = std::make_shared<ContainerLayer>();
+  auto mock_layer = MockLayer::MakeOpacityCompatible(SkPath());
+  container_layer->Add(mock_layer);
+  opacity_layer->Add(container_layer);
 
   PrerollContext* context = preroll_context();
   context->subtree_can_inherit_opacity = false;
-  opacityLayer->Preroll(context, SkMatrix::I());
+  opacity_layer->Preroll(context, SkMatrix::I());
   EXPECT_TRUE(context->subtree_can_inherit_opacity);
   // By default a container layer will not pass opacity through to
   // its children - specific subclasses will have to enable this
   // pass through by setting the flag to true themselves before
   // calling their super method ContainerLayer::Preroll().
-  EXPECT_FALSE(opacityLayer->children_can_accept_opacity());
+  EXPECT_FALSE(opacity_layer->children_can_accept_opacity());
 }
 
 TEST_F(OpacityLayerTest, OpacityInheritanceThroughTransform) {
-  auto opacityLayer =
+  auto opacity_layer =
       std::make_shared<OpacityLayer>(128, SkPoint::Make(20, 20));
   auto transformLayer = std::make_shared<TransformLayer>(SkMatrix::Scale(2, 2));
-  auto mockLayer = MockLayer::MakeOpacityCompatible(SkPath());
-  transformLayer->Add(mockLayer);
-  opacityLayer->Add(transformLayer);
+  auto mock_layer = MockLayer::MakeOpacityCompatible(SkPath());
+  transformLayer->Add(mock_layer);
+  opacity_layer->Add(transformLayer);
 
   PrerollContext* context = preroll_context();
   context->subtree_can_inherit_opacity = false;
-  opacityLayer->Preroll(context, SkMatrix::I());
+  opacity_layer->Preroll(context, SkMatrix::I());
   EXPECT_TRUE(context->subtree_can_inherit_opacity);
-  EXPECT_TRUE(opacityLayer->children_can_accept_opacity());
+  EXPECT_TRUE(opacity_layer->children_can_accept_opacity());
 }
 
 TEST_F(OpacityLayerTest, OpacityInheritanceThroughImageFilter) {
-  auto opacityLayer =
+  auto opacity_layer =
       std::make_shared<OpacityLayer>(128, SkPoint::Make(20, 20));
-  auto filterLayer = std::make_shared<ImageFilterLayer>(
+  auto filter_layer = std::make_shared<ImageFilterLayer>(
       std::make_shared<DlBlurImageFilter>(5.0, 5.0, DlTileMode::kClamp));
-  auto mockLayer = MockLayer::MakeOpacityCompatible(SkPath());
-  filterLayer->Add(mockLayer);
-  opacityLayer->Add(filterLayer);
+  auto mock_layer = MockLayer::MakeOpacityCompatible(SkPath());
+  filter_layer->Add(mock_layer);
+  opacity_layer->Add(filter_layer);
 
   PrerollContext* context = preroll_context();
   context->subtree_can_inherit_opacity = false;
-  opacityLayer->Preroll(context, SkMatrix::I());
+  opacity_layer->Preroll(context, SkMatrix::I());
   EXPECT_TRUE(context->subtree_can_inherit_opacity);
-  EXPECT_TRUE(opacityLayer->children_can_accept_opacity());
+  EXPECT_TRUE(opacity_layer->children_can_accept_opacity());
 }
 
 TEST_F(OpacityLayerTest, OpacityInheritanceNestedWithCompatibleChild) {
   SkPoint offset1 = SkPoint::Make(10, 20);
   SkPoint offset2 = SkPoint::Make(20, 10);
-  SkPath mockPath = SkPath::Rect({10, 10, 20, 20});
-  auto opacityLayer1 = std::make_shared<OpacityLayer>(128, offset1);
-  auto opacityLayer2 = std::make_shared<OpacityLayer>(64, offset2);
-  auto mockLayer = MockLayer::MakeOpacityCompatible(mockPath);
-  opacityLayer2->Add(mockLayer);
-  opacityLayer1->Add(opacityLayer2);
+  SkPath mock_path = SkPath::Rect({10, 10, 20, 20});
+  auto opacity_layer_1 = std::make_shared<OpacityLayer>(128, offset1);
+  auto opacity_layer_2 = std::make_shared<OpacityLayer>(64, offset2);
+  auto mock_layer = MockLayer::MakeOpacityCompatible(mock_path);
+  opacity_layer_2->Add(mock_layer);
+  opacity_layer_1->Add(opacity_layer_2);
 
   PrerollContext* context = preroll_context();
   context->subtree_can_inherit_opacity = false;
-  opacityLayer1->Preroll(context, SkMatrix::I());
+  opacity_layer_1->Preroll(context, SkMatrix::I());
   EXPECT_TRUE(context->subtree_can_inherit_opacity);
-  EXPECT_TRUE(opacityLayer1->children_can_accept_opacity());
-  EXPECT_TRUE(opacityLayer2->children_can_accept_opacity());
+  EXPECT_TRUE(opacity_layer_1->children_can_accept_opacity());
+  EXPECT_TRUE(opacity_layer_2->children_can_accept_opacity());
 
-  SkPaint saveLayerPaint;
-  SkScalar inheritedOpacity = 128 * 1.0 / SK_AlphaOPAQUE;
-  inheritedOpacity *= 64 * 1.0 / SK_AlphaOPAQUE;
-  saveLayerPaint.setAlphaf(inheritedOpacity);
+  SkPaint savelayer_paint;
+  SkScalar inherited_opacity = 128 * 1.0 / SK_AlphaOPAQUE;
+  inherited_opacity *= 64 * 1.0 / SK_AlphaOPAQUE;
+  savelayer_paint.setAlphaf(inherited_opacity);
 
   DisplayListBuilder expected_builder;
-  /* opacityLayer1::Paint */ {
+  /* opacity_layer_1::Paint */ {
     expected_builder.save();
     {
       expected_builder.translate(offset1.fX, offset1.fY);
-      /* opacityLayer2::Paint */ {
+      /* opacity_layer_2::Paint */ {
         expected_builder.save();
         {
           expected_builder.translate(offset2.fX, offset2.fY);
-          /* mockLayer::Paint */ {
-            expected_builder.setColor(saveLayerPaint.getAlpha() << 24);
-            expected_builder.saveLayer(&mockPath.getBounds(), true);
+          /* mock_layer::Paint */ {
+            expected_builder.setColor(savelayer_paint.getAlpha() << 24);
+            expected_builder.saveLayer(&mock_path.getBounds(), true);
             {
               expected_builder.setColor(0xFF000000);
-              expected_builder.drawPath(mockPath);
+              expected_builder.drawPath(mock_path);
             }
             expected_builder.restore();
           }
@@ -582,46 +582,46 @@ TEST_F(OpacityLayerTest, OpacityInheritanceNestedWithCompatibleChild) {
     expected_builder.restore();
   }
 
-  opacityLayer1->Paint(display_list_paint_context());
+  opacity_layer_1->Paint(display_list_paint_context());
   EXPECT_TRUE(DisplayListsEQ_Verbose(expected_builder.Build(), display_list()));
 }
 
 TEST_F(OpacityLayerTest, OpacityInheritanceNestedWithIncompatibleChild) {
   SkPoint offset1 = SkPoint::Make(10, 20);
   SkPoint offset2 = SkPoint::Make(20, 10);
-  SkPath mockPath = SkPath::Rect({10, 10, 20, 20});
-  auto opacityLayer1 = std::make_shared<OpacityLayer>(128, offset1);
-  auto opacityLayer2 = std::make_shared<OpacityLayer>(64, offset2);
-  auto mockLayer = MockLayer::Make(mockPath);
-  opacityLayer2->Add(mockLayer);
-  opacityLayer1->Add(opacityLayer2);
+  SkPath mock_path = SkPath::Rect({10, 10, 20, 20});
+  auto opacity_layer_1 = std::make_shared<OpacityLayer>(128, offset1);
+  auto opacity_layer_2 = std::make_shared<OpacityLayer>(64, offset2);
+  auto mock_layer = MockLayer::Make(mock_path);
+  opacity_layer_2->Add(mock_layer);
+  opacity_layer_1->Add(opacity_layer_2);
 
   PrerollContext* context = preroll_context();
   context->subtree_can_inherit_opacity = false;
-  opacityLayer1->Preroll(context, SkMatrix::I());
+  opacity_layer_1->Preroll(context, SkMatrix::I());
   EXPECT_TRUE(context->subtree_can_inherit_opacity);
-  EXPECT_TRUE(opacityLayer1->children_can_accept_opacity());
-  EXPECT_FALSE(opacityLayer2->children_can_accept_opacity());
+  EXPECT_TRUE(opacity_layer_1->children_can_accept_opacity());
+  EXPECT_FALSE(opacity_layer_2->children_can_accept_opacity());
 
-  SkPaint saveLayerPaint;
-  SkScalar inheritedOpacity = 128 * 1.0 / SK_AlphaOPAQUE;
-  inheritedOpacity *= 64 * 1.0 / SK_AlphaOPAQUE;
-  saveLayerPaint.setAlphaf(inheritedOpacity);
+  SkPaint savelayer_paint;
+  SkScalar inherited_opacity = 128 * 1.0 / SK_AlphaOPAQUE;
+  inherited_opacity *= 64 * 1.0 / SK_AlphaOPAQUE;
+  savelayer_paint.setAlphaf(inherited_opacity);
 
   DisplayListBuilder expected_builder;
-  /* opacityLayer1::Paint */ {
+  /* opacity_layer_1::Paint */ {
     expected_builder.save();
     {
       expected_builder.translate(offset1.fX, offset1.fY);
-      /* opacityLayer2::Paint */ {
+      /* opacity_layer_2::Paint */ {
         expected_builder.save();
         {
           expected_builder.translate(offset2.fX, offset2.fY);
-          expected_builder.setColor(saveLayerPaint.getAlpha() << 24);
-          expected_builder.saveLayer(&mockLayer->paint_bounds(), true);
-          /* mockLayer::Paint */ {
+          expected_builder.setColor(savelayer_paint.getAlpha() << 24);
+          expected_builder.saveLayer(&mock_layer->paint_bounds(), true);
+          /* mock_layer::Paint */ {
             expected_builder.setColor(0xFF000000);
-            expected_builder.drawPath(mockPath);
+            expected_builder.drawPath(mock_path);
           }
         }
         expected_builder.restore();
@@ -630,7 +630,7 @@ TEST_F(OpacityLayerTest, OpacityInheritanceNestedWithIncompatibleChild) {
     expected_builder.restore();
   }
 
-  opacityLayer1->Paint(display_list_paint_context());
+  opacity_layer_1->Paint(display_list_paint_context());
   EXPECT_TRUE(DisplayListsEQ_Verbose(expected_builder.Build(), display_list()));
 }
 

--- a/flow/layers/performance_overlay_layer_unittests.cc
+++ b/flow/layers/performance_overlay_layer_unittests.cc
@@ -58,7 +58,7 @@ static void TestPerformanceOverlayLayerGold(int refresh_rate) {
 
   ASSERT_TRUE(surface != nullptr);
 
-  flutter::PaintContext paintContext = {
+  flutter::PaintContext paint_context = {
       // clang-format off
       .internal_nodes_canvas         = nullptr,
       .leaf_nodes_canvas             = surface->getCanvas(),
@@ -83,7 +83,7 @@ static void TestPerformanceOverlayLayerGold(int refresh_rate) {
       flutter::GetFontFile().c_str());
   layer.set_paint_bounds(SkRect::MakeWH(1000, 400));
   surface->getCanvas()->clear(SK_ColorTRANSPARENT);
-  layer.Paint(paintContext);
+  layer.Paint(paint_context);
 
   sk_sp<SkImage> snapshot = surface->makeImageSnapshot();
   sk_sp<SkData> snapshot_data = snapshot->encodeToData();
@@ -200,8 +200,8 @@ TEST_F(PerformanceOverlayLayerTest, MarkAsDirtyWhenResized) {
   layer->Preroll(preroll_context(), SkMatrix());
   layer->Paint(paint_context());
   auto data = mock_canvas().draw_calls().front().data;
-  auto imageData = std::get<MockCanvas::DrawImageDataNoPaint>(data);
-  auto first_draw_width = imageData.image->width();
+  auto image_data = std::get<MockCanvas::DrawImageDataNoPaint>(data);
+  auto first_draw_width = image_data.image->width();
 
   // Create a second PerformanceOverlayLayer with different bounds.
   layer = std::make_shared<PerformanceOverlayLayer>(overlay_opts);
@@ -209,8 +209,8 @@ TEST_F(PerformanceOverlayLayerTest, MarkAsDirtyWhenResized) {
   layer->Preroll(preroll_context(), SkMatrix());
   layer->Paint(paint_context());
   data = mock_canvas().draw_calls().back().data;
-  imageData = std::get<MockCanvas::DrawImageDataNoPaint>(data);
-  auto refreshed_draw_width = imageData.image->width();
+  image_data = std::get<MockCanvas::DrawImageDataNoPaint>(data);
+  auto refreshed_draw_width = image_data.image->width();
 
   EXPECT_NE(first_draw_width, refreshed_draw_width);
 }

--- a/flow/layers/physical_shape_layer.cc
+++ b/flow/layers/physical_shape_layer.cc
@@ -94,7 +94,7 @@ void PhysicalShapeLayer::Paint(PaintContext& context) const {
     context.leaf_nodes_canvas->drawPath(path_, paint);
   }
 
-  int saveCount = context.internal_nodes_canvas->save();
+  int save_count = context.internal_nodes_canvas->save();
   switch (clip_behavior_) {
     case Clip::hardEdge:
       context.internal_nodes_canvas->clipPath(path_, false);
@@ -121,7 +121,7 @@ void PhysicalShapeLayer::Paint(PaintContext& context) const {
 
   PaintChildren(context);
 
-  context.internal_nodes_canvas->restoreToCount(saveCount);
+  context.internal_nodes_canvas->restoreToCount(save_count);
 
   if (UsesSaveLayer()) {
     if (context.checkerboard_offscreen_layers) {

--- a/flow/layers/physical_shape_layer_unittests.cc
+++ b/flow/layers/physical_shape_layer_unittests.cc
@@ -278,10 +278,10 @@ TEST_F(PhysicalShapeLayerTest, ShadowNotDependsCtm) {
     SkRect baseline_bounds = DisplayListCanvasDispatcher::ComputeShadowBounds(
         path, elevation, 1.0f, SkMatrix());
     for (SkScalar scale : scales) {
-      for (SkScalar translateX : translates) {
-        for (SkScalar translateY : translates) {
+      for (SkScalar translate_x : translates) {
+        for (SkScalar translate_y : translates) {
           SkMatrix ctm;
-          ctm.setScaleTranslate(scale, scale, translateX, translateY);
+          ctm.setScaleTranslate(scale, scale, translate_x, translate_y);
           SkRect bounds = DisplayListCanvasDispatcher::ComputeShadowBounds(
               path, elevation, scale, ctm);
           EXPECT_FLOAT_EQ(bounds.fLeft, baseline_bounds.fLeft);

--- a/flow/layers/transform_layer.cc
+++ b/flow/layers/transform_layer.cc
@@ -47,11 +47,11 @@ void TransformLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   child_matrix.setConcat(matrix, transform_);
   context->mutators_stack.PushTransform(transform_);
   SkRect previous_cull_rect = context->cull_rect;
-  SkMatrix inverse_transform_;
+  SkMatrix inverse_transform;
   // Perspective projections don't produce rectangles that are useful for
   // culling for some reason.
-  if (!transform_.hasPerspective() && transform_.invert(&inverse_transform_)) {
-    inverse_transform_.mapRect(&context->cull_rect);
+  if (!transform_.hasPerspective() && transform_.invert(&inverse_transform)) {
+    inverse_transform.mapRect(&context->cull_rect);
   } else {
     context->cull_rect = kGiantRect;
   }

--- a/flow/mutators_stack_unittests.cc
+++ b/flow/mutators_stack_unittests.cc
@@ -166,22 +166,22 @@ TEST(MutatorsStack, Equality) {
   auto filter = std::make_shared<DlBlurImageFilter>(5, 5, DlTileMode::kClamp);
   stack.PushBackdropFilter(filter);
 
-  MutatorsStack stackOther;
-  SkMatrix matrixOther = SkMatrix::Scale(1, 1);
-  stackOther.PushTransform(matrixOther);
-  SkRect rectOther = SkRect::MakeEmpty();
-  stackOther.PushClipRect(rectOther);
-  SkRRect rrectOther = SkRRect::MakeEmpty();
-  stackOther.PushClipRRect(rrectOther);
-  SkPath otherPath;
-  stackOther.PushClipPath(otherPath);
-  int otherAlpha = 240;
-  stackOther.PushOpacity(otherAlpha);
-  auto otherFilter =
+  MutatorsStack stack_other;
+  SkMatrix matrix_other = SkMatrix::Scale(1, 1);
+  stack_other.PushTransform(matrix_other);
+  SkRect rect_other = SkRect::MakeEmpty();
+  stack_other.PushClipRect(rect_other);
+  SkRRect rrect_other = SkRRect::MakeEmpty();
+  stack_other.PushClipRRect(rrect_other);
+  SkPath other_path;
+  stack_other.PushClipPath(other_path);
+  int other_alpha = 240;
+  stack_other.PushOpacity(other_alpha);
+  auto other_filter =
       std::make_shared<DlBlurImageFilter>(5, 5, DlTileMode::kClamp);
-  stackOther.PushBackdropFilter(otherFilter);
+  stack_other.PushBackdropFilter(other_filter);
 
-  ASSERT_TRUE(stack == stackOther);
+  ASSERT_TRUE(stack == stack_other);
 }
 
 TEST(Mutator, Initialization) {
@@ -253,33 +253,33 @@ TEST(Mutator, Equality) {
   SkMatrix matrix;
   matrix.setIdentity();
   Mutator mutator = Mutator(matrix);
-  Mutator otherMutator = Mutator(matrix);
-  ASSERT_TRUE(mutator == otherMutator);
+  Mutator other_mutator = Mutator(matrix);
+  ASSERT_TRUE(mutator == other_mutator);
 
   SkRect rect = SkRect::MakeEmpty();
   Mutator mutator2 = Mutator(rect);
-  Mutator otherMutator2 = Mutator(rect);
-  ASSERT_TRUE(mutator2 == otherMutator2);
+  Mutator other_mutator2 = Mutator(rect);
+  ASSERT_TRUE(mutator2 == other_mutator2);
 
   SkRRect rrect = SkRRect::MakeEmpty();
   Mutator mutator3 = Mutator(rrect);
-  Mutator otherMutator3 = Mutator(rrect);
-  ASSERT_TRUE(mutator3 == otherMutator3);
+  Mutator other_mutator3 = Mutator(rrect);
+  ASSERT_TRUE(mutator3 == other_mutator3);
 
   SkPath path;
   flutter::Mutator mutator4 = flutter::Mutator(path);
-  flutter::Mutator otherMutator4 = flutter::Mutator(path);
-  ASSERT_TRUE(mutator4 == otherMutator4);
+  flutter::Mutator other_mutator4 = flutter::Mutator(path);
+  ASSERT_TRUE(mutator4 == other_mutator4);
   ASSERT_FALSE(mutator2 == mutator);
   int alpha = 240;
   Mutator mutator5 = Mutator(alpha);
-  Mutator otherMutator5 = Mutator(alpha);
-  ASSERT_TRUE(mutator5 == otherMutator5);
+  Mutator other_mutator5 = Mutator(alpha);
+  ASSERT_TRUE(mutator5 == other_mutator5);
 
   auto filter = std::make_shared<DlBlurImageFilter>(5, 5, DlTileMode::kClamp);
   Mutator mutator6 = Mutator(filter);
-  Mutator otherMutator6 = Mutator(filter);
-  ASSERT_TRUE(mutator6 == otherMutator6);
+  Mutator other_mutator6 = Mutator(filter);
+  ASSERT_TRUE(mutator6 == other_mutator6);
 }
 
 TEST(Mutator, UnEquality) {
@@ -287,21 +287,21 @@ TEST(Mutator, UnEquality) {
   Mutator mutator = Mutator(rect);
   SkMatrix matrix;
   matrix.setIdentity();
-  Mutator notEqualMutator = Mutator(matrix);
-  ASSERT_TRUE(notEqualMutator != mutator);
+  Mutator not_equal_mutator = Mutator(matrix);
+  ASSERT_TRUE(not_equal_mutator != mutator);
 
   int alpha = 240;
   int alpha2 = 241;
   Mutator mutator2 = Mutator(alpha);
-  Mutator otherMutator2 = Mutator(alpha2);
-  ASSERT_TRUE(mutator2 != otherMutator2);
+  Mutator other_mutator2 = Mutator(alpha2);
+  ASSERT_TRUE(mutator2 != other_mutator2);
 
   auto filter = std::make_shared<DlBlurImageFilter>(5, 5, DlTileMode::kClamp);
   auto filter2 =
       std::make_shared<DlBlurImageFilter>(10, 10, DlTileMode::kClamp);
   Mutator mutator3 = Mutator(filter);
-  Mutator otherMutator3 = Mutator(filter2);
-  ASSERT_TRUE(mutator3 != otherMutator3);
+  Mutator other_mutator3 = Mutator(filter2);
+  ASSERT_TRUE(mutator3 != other_mutator3);
 }
 
 }  // namespace testing

--- a/flow/paint_utils.cc
+++ b/flow/paint_utils.cc
@@ -47,11 +47,11 @@ void DrawCheckerboard(SkCanvas* canvas, const SkRect& rect) {
   canvas->restore();
 
   // Stroke the drawn area
-  SkPaint debugPaint;
-  debugPaint.setStrokeWidth(8);
-  debugPaint.setColor(SkColorSetA(checkerboard_color, 255));
-  debugPaint.setStyle(SkPaint::kStroke_Style);
-  canvas->drawRect(rect, debugPaint);
+  SkPaint debug_paint;
+  debug_paint.setStrokeWidth(8);
+  debug_paint.setColor(SkColorSetA(checkerboard_color, 255));
+  debug_paint.setStyle(SkPaint::kStroke_Style);
+  canvas->drawRect(rect, debug_paint);
 }
 
 }  // namespace flutter

--- a/flow/raster_cache_unittests.cc
+++ b/flow/raster_cache_unittests.cc
@@ -573,7 +573,7 @@ TEST(RasterCache, DisplayListWithSingularMatrixIsNotCached) {
       SkMatrix::Scale(1, 0),
       SkMatrix::Skew(1, 1),
   };
-  int matrixCount = sizeof(matrices) / sizeof(matrices[0]);
+  int matrix_count = sizeof(matrices) / sizeof(matrices[0]);
 
   auto display_list = GetSampleDisplayList();
 
@@ -596,13 +596,13 @@ TEST(RasterCache, DisplayListWithSingularMatrixIsNotCached) {
   for (int i = 0; i < 10; i++) {
     cache.BeginFrame();
 
-    for (int j = 0; j < matrixCount; j++) {
+    for (int j = 0; j < matrix_count; j++) {
       display_list_item.set_matrix(matrices[j]);
       ASSERT_FALSE(RasterCacheItemPrerollAndTryToRasterCache(
           display_list_item, preroll_context, paint_context, matrices[j]));
     }
 
-    for (int j = 0; j < matrixCount; j++) {
+    for (int j = 0; j < matrix_count; j++) {
       dummy_canvas.setMatrix(matrices[j]);
       ASSERT_FALSE(
           display_list_item.Draw(paint_context, &dummy_canvas, &paint));

--- a/flow/skia_gpu_object_unittests.cc
+++ b/flow/skia_gpu_object_unittests.cc
@@ -57,15 +57,15 @@ class SkiaGpuObjectTest : public ThreadTest {
     // The unref queues must be created in the same thread of the
     // unref_task_runner so the queue can access the same-thread-only WeakPtr of
     // the GrContext constructed during the creation.
-    std::promise<bool> queuesCreated;
-    unref_task_runner_->PostTask([this, &queuesCreated]() {
+    std::promise<bool> queues_created;
+    unref_task_runner_->PostTask([this, &queues_created]() {
       unref_queue_ = fml::MakeRefCounted<SkiaUnrefQueue>(
           unref_task_runner(), fml::TimeDelta::FromSeconds(0));
       delayed_unref_queue_ = fml::MakeRefCounted<SkiaUnrefQueue>(
           unref_task_runner(), fml::TimeDelta::FromSeconds(3));
-      queuesCreated.set_value(true);
+      queues_created.set_value(true);
     });
-    queuesCreated.get_future().wait();
+    queues_created.get_future().wait();
     ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   }
 


### PR DESCRIPTION
This updates local variable names to use clang `lower_case` style in the flow directory. This is one of several patches to update our variable names to a consistent style before enabling enforcement in our clang-tidy rules.

This is a formatting-only change with no intended semantic change.


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
