### PR TITLE
[Impeller] Make gradients work as expected

### DIFF
--- a/impeller/entity/contents/linear_gradient_contents.cc
+++ b/impeller/entity/contents/linear_gradient_contents.cc
@@ -81,7 +81,8 @@ bool LinearGradientContents::Render(const ContentContext& renderer,
   gradient_info.texture_sampler_y_coord_scale =
       gradient_texture->GetYCoordScale();
   gradient_info.alpha = GetAlpha();
-  gradient_info.half_texel_width = 0.5 / gradient_texture->GetSize().width;
+  gradient_info.half_texel = Vector2(0.5 / gradient_texture->GetSize().width,
+                                     0.5 / gradient_texture->GetSize().height);
 
   VS::FrameInfo frame_info;
   frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *

--- a/impeller/entity/contents/linear_gradient_contents.cc
+++ b/impeller/entity/contents/linear_gradient_contents.cc
@@ -81,6 +81,7 @@ bool LinearGradientContents::Render(const ContentContext& renderer,
   gradient_info.texture_sampler_y_coord_scale =
       gradient_texture->GetYCoordScale();
   gradient_info.alpha = GetAlpha();
+  gradient_info.half_texel_width = 0.5 / gradient_texture->GetSize().width;
 
   VS::FrameInfo frame_info;
   frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *

--- a/impeller/entity/contents/radial_gradient_contents.cc
+++ b/impeller/entity/contents/radial_gradient_contents.cc
@@ -79,6 +79,7 @@ bool RadialGradientContents::Render(const ContentContext& renderer,
   gradient_info.texture_sampler_y_coord_scale =
       gradient_texture->GetYCoordScale();
   gradient_info.alpha = GetAlpha();
+  gradient_info.half_texel_width = 0.5 / gradient_texture->GetSize().width;
 
   VS::FrameInfo frame_info;
   frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *

--- a/impeller/entity/contents/radial_gradient_contents.cc
+++ b/impeller/entity/contents/radial_gradient_contents.cc
@@ -79,7 +79,8 @@ bool RadialGradientContents::Render(const ContentContext& renderer,
   gradient_info.texture_sampler_y_coord_scale =
       gradient_texture->GetYCoordScale();
   gradient_info.alpha = GetAlpha();
-  gradient_info.half_texel_width = 0.5 / gradient_texture->GetSize().width;
+  gradient_info.half_texel = Vector2(0.5 / gradient_texture->GetSize().width,
+                                     0.5 / gradient_texture->GetSize().height);
 
   VS::FrameInfo frame_info;
   frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *

--- a/impeller/entity/contents/sweep_gradient_contents.cc
+++ b/impeller/entity/contents/sweep_gradient_contents.cc
@@ -87,7 +87,8 @@ bool SweepGradientContents::Render(const ContentContext& renderer,
       gradient_texture->GetYCoordScale();
   gradient_info.tile_mode = static_cast<Scalar>(tile_mode_);
   gradient_info.alpha = GetAlpha();
-  gradient_info.half_texel_width = 0.5 / gradient_texture->GetSize().width;
+  gradient_info.half_texel = Vector2(0.5 / gradient_texture->GetSize().width,
+                                     0.5 / gradient_texture->GetSize().height);
 
   VS::FrameInfo frame_info;
   frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *

--- a/impeller/entity/contents/sweep_gradient_contents.cc
+++ b/impeller/entity/contents/sweep_gradient_contents.cc
@@ -87,6 +87,7 @@ bool SweepGradientContents::Render(const ContentContext& renderer,
       gradient_texture->GetYCoordScale();
   gradient_info.tile_mode = static_cast<Scalar>(tile_mode_);
   gradient_info.alpha = GetAlpha();
+  gradient_info.half_texel_width = 0.5 / gradient_texture->GetSize().width;
 
   VS::FrameInfo frame_info;
   frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *

--- a/impeller/entity/shaders/linear_gradient_fill.frag
+++ b/impeller/entity/shaders/linear_gradient_fill.frag
@@ -12,6 +12,7 @@ uniform GradientInfo {
   float tile_mode;
   float texture_sampler_y_coord_scale;
   float alpha;
+  float half_texel_width;
 } gradient_info;
 
 in vec2 v_position;
@@ -25,11 +26,17 @@ void main() {
     gradient_info.end_point - gradient_info.start_point
   );
   float t = dot / (len * len);
-  frag_color = IPSampleWithTileMode(
+  if ((t < 0.0 || t >= 1.0) && gradient_info.tile_mode == kTileModeDecal) {
+    frag_color = vec4(0);
+    return;
+  }
+
+  t = IPFloatTile(t, gradient_info.tile_mode);
+  float coords_x = mix(gradient_info.half_texel_width, 1 - gradient_info.half_texel_width, t);
+
+  frag_color = IPSample(
     texture_sampler,
-    vec2(t, 0.5),
-    gradient_info.texture_sampler_y_coord_scale,
-    gradient_info.tile_mode,
-    gradient_info.tile_mode);
+    vec2(coords_x, 0.5),
+    gradient_info.texture_sampler_y_coord_scale);
   frag_color = vec4(frag_color.xyz * frag_color.a, frag_color.a) * gradient_info.alpha;
 }

--- a/impeller/entity/shaders/linear_gradient_fill.frag
+++ b/impeller/entity/shaders/linear_gradient_fill.frag
@@ -12,7 +12,7 @@ uniform GradientInfo {
   float tile_mode;
   float texture_sampler_y_coord_scale;
   float alpha;
-  float half_texel_width;
+  vec2 half_texel;
 } gradient_info;
 
 in vec2 v_position;
@@ -26,17 +26,11 @@ void main() {
     gradient_info.end_point - gradient_info.start_point
   );
   float t = dot / (len * len);
-  if ((t < 0.0 || t >= 1.0) && gradient_info.tile_mode == kTileModeDecal) {
-    frag_color = vec4(0);
-    return;
-  }
-
-  t = IPFloatTile(t, gradient_info.tile_mode);
-  float coords_x = mix(gradient_info.half_texel_width, 1 - gradient_info.half_texel_width, t);
-
-  frag_color = IPSample(
+  frag_color = IPSampleLinearWithTileMode(
     texture_sampler,
-    vec2(coords_x, 0.5),
-    gradient_info.texture_sampler_y_coord_scale);
+    vec2(t, 0.5),
+    gradient_info.texture_sampler_y_coord_scale,
+    gradient_info.half_texel,
+    gradient_info.tile_mode);
   frag_color = vec4(frag_color.xyz * frag_color.a, frag_color.a) * gradient_info.alpha;
 }

--- a/impeller/entity/shaders/radial_gradient_fill.frag
+++ b/impeller/entity/shaders/radial_gradient_fill.frag
@@ -12,7 +12,7 @@ uniform GradientInfo {
   float tile_mode;
   float texture_sampler_y_coord_scale;
   float alpha;
-  float half_texel_width;
+  vec2 half_texel;
 } gradient_info;
 
 in vec2 v_position;
@@ -22,17 +22,11 @@ out vec4 frag_color;
 void main() {
   float len = length(v_position - gradient_info.center);
   float t = len / gradient_info.radius;
-  if ((t < 0.0 || t >= 1.0) && gradient_info.tile_mode == kTileModeDecal) {
-    frag_color = vec4(0);
-    return;
-  }
-
-  t = IPFloatTile(t, gradient_info.tile_mode);
-  float coords_x = mix(gradient_info.half_texel_width, 1 - gradient_info.half_texel_width, t);
-
-  frag_color = IPSample(
+  frag_color = IPSampleLinearWithTileMode(
     texture_sampler,
-    vec2(coords_x, 0.5),
-    gradient_info.texture_sampler_y_coord_scale);
+    vec2(t, 0.5),
+    gradient_info.texture_sampler_y_coord_scale,
+    gradient_info.half_texel,
+    gradient_info.tile_mode);
   frag_color = vec4(frag_color.xyz * frag_color.a, frag_color.a) * gradient_info.alpha;
 }

--- a/impeller/entity/shaders/radial_gradient_fill.frag
+++ b/impeller/entity/shaders/radial_gradient_fill.frag
@@ -12,6 +12,7 @@ uniform GradientInfo {
   float tile_mode;
   float texture_sampler_y_coord_scale;
   float alpha;
+  float half_texel_width;
 } gradient_info;
 
 in vec2 v_position;
@@ -21,11 +22,17 @@ out vec4 frag_color;
 void main() {
   float len = length(v_position - gradient_info.center);
   float t = len / gradient_info.radius;
-  frag_color = IPSampleWithTileMode(
+  if ((t < 0.0 || t >= 1.0) && gradient_info.tile_mode == kTileModeDecal) {
+    frag_color = vec4(0);
+    return;
+  }
+
+  t = IPFloatTile(t, gradient_info.tile_mode);
+  float coords_x = mix(gradient_info.half_texel_width, 1 - gradient_info.half_texel_width, t);
+
+  frag_color = IPSample(
     texture_sampler,
-    vec2(t, 0.5),
-    gradient_info.texture_sampler_y_coord_scale,
-    gradient_info.tile_mode,
-    gradient_info.tile_mode);
+    vec2(coords_x, 0.5),
+    gradient_info.texture_sampler_y_coord_scale);
   frag_color = vec4(frag_color.xyz * frag_color.a, frag_color.a) * gradient_info.alpha;
 }

--- a/impeller/entity/shaders/sweep_gradient_fill.frag
+++ b/impeller/entity/shaders/sweep_gradient_fill.frag
@@ -14,7 +14,7 @@ uniform GradientInfo {
   float tile_mode;
   float texture_sampler_y_coord_scale;
   float alpha;
-  float half_texel_width;
+  vec2 half_texel;
 } gradient_info;
 
 in vec2 v_position;
@@ -26,17 +26,11 @@ void main() {
   float angle = atan(-coord.y, -coord.x);
 
   float t = (angle * k1Over2Pi + 0.5 + gradient_info.bias) * gradient_info.scale;
-  if ((t < 0.0 || t >= 1.0) && gradient_info.tile_mode == kTileModeDecal) {
-    frag_color = vec4(0);
-    return;
-  }
-
-  t = IPFloatTile(t, gradient_info.tile_mode);
-  float coords_x = mix(gradient_info.half_texel_width, 1 - gradient_info.half_texel_width, t);
-
-  frag_color = IPSample(
+  frag_color = IPSampleLinearWithTileMode(
     texture_sampler,
-    vec2(coords_x, 0.5),
-    gradient_info.texture_sampler_y_coord_scale);
+    vec2(t, 0.5),
+    gradient_info.texture_sampler_y_coord_scale,
+    gradient_info.half_texel,
+    gradient_info.tile_mode);
   frag_color = vec4(frag_color.xyz * frag_color.a, frag_color.a) * gradient_info.alpha;
 }


### PR DESCRIPTION
fix https://github.com/flutter/flutter/issues/111534

The value of coods x should range from the center of the first texel to the center of the last texel. However, the current implementation goes from the left of the first texel to the right of the last texel.

For example, if the gradient only has start color and end color, the value range of coods x is from 0.25 to 0.75.

cc @jonahwilliams @bdero @dnfield 


It is base on the flowing image
![image](https://user-images.githubusercontent.com/31977171/190082291-0a2658fa-64f6-45dc-8dae-ba06c9e639f9.png)

#### without patch
![jbfdwDQRvz](https://user-images.githubusercontent.com/31977171/190115052-bd3e2069-fad0-4248-94a7-8c04e8e4b3a9.jpg)

#### with patch
![vcNKoRn634](https://user-images.githubusercontent.com/31977171/190115101-b619397c-4f3a-4aae-ad7e-36be97e90ebb.jpg)




## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

