### PR TITLE
feat: add custom cursor interface on windows

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -3110,6 +3110,7 @@ FILE: ../../../flutter/shell/platform/windows/client_wrapper/include/flutter/plu
 FILE: ../../../flutter/shell/platform/windows/client_wrapper/plugin_registrar_windows_unittests.cc
 FILE: ../../../flutter/shell/platform/windows/cursor_handler.cc
 FILE: ../../../flutter/shell/platform/windows/cursor_handler.h
+FILE: ../../../flutter/shell/platform/windows/cursor_handler_unittests.cc
 FILE: ../../../flutter/shell/platform/windows/direct_manipulation.cc
 FILE: ../../../flutter/shell/platform/windows/direct_manipulation.h
 FILE: ../../../flutter/shell/platform/windows/direct_manipulation_unittests.cc

--- a/shell/platform/windows/BUILD.gn
+++ b/shell/platform/windows/BUILD.gn
@@ -176,8 +176,8 @@ executable("flutter_windows_unittests") {
   # Common Windows test sources.
   sources = [
     "accessibility_bridge_windows_unittests.cc",
-    "direct_manipulation_unittests.cc",
     "cursor_handler_unittests.cc",
+    "direct_manipulation_unittests.cc",
     "dpi_utils_unittests.cc",
     "flutter_project_bundle_unittests.cc",
     "flutter_window_unittests.cc",

--- a/shell/platform/windows/BUILD.gn
+++ b/shell/platform/windows/BUILD.gn
@@ -177,6 +177,7 @@ executable("flutter_windows_unittests") {
   sources = [
     "accessibility_bridge_windows_unittests.cc",
     "direct_manipulation_unittests.cc",
+    "cursor_handler_unittests.cc",
     "dpi_utils_unittests.cc",
     "flutter_project_bundle_unittests.cc",
     "flutter_window_unittests.cc",

--- a/shell/platform/windows/cursor_handler.cc
+++ b/shell/platform/windows/cursor_handler.cc
@@ -141,19 +141,13 @@ HCURSOR GetCursorFromBuffer(const std::vector<uint8_t>& buffer,
   HBITMAP bitmap =
       CreateDIBSection(display_dc, &bmi, DIB_RGB_COLORS, (void**)&pixels, 0, 0);
   ReleaseDC(0, display_dc);
-  if (!bitmap) {
-    return nullptr;
-  }
-  if (!pixels) {
+  if (!bitmap || !pixels) {
     return nullptr;
   }
   int bytes_per_line = width * 4;
   for (int y = 0; y < height; ++y) {
     memcpy(pixels + y * bytes_per_line, &buffer[bytes_per_line * y],
            bytes_per_line);
-  }
-  if (bitmap == nullptr) {
-    return nullptr;
   }
   HBITMAP mask;
   GetMaskBitmaps(bitmap, mask);

--- a/shell/platform/windows/cursor_handler.cc
+++ b/shell/platform/windows/cursor_handler.cc
@@ -124,7 +124,8 @@ void CursorHandler::HandleMethodCall(
     }
     // push the cursor into the cache vector of this handler.
     custom_cursors_.emplace_back(std::move(cursor));
-    result->Success(flutter::EncodableValue(custom_cursors_.size() - 1));
+    int64_t key = custom_cursors_.size() - 1;
+    result->Success(flutter::EncodableValue(key));
   } else if (method.compare(kSetCustomCursorMethod) == 0) {
     const auto& arguments = std::get<EncodableMap>(*method_call.arguments());
     auto key_iter =
@@ -134,7 +135,7 @@ void CursorHandler::HandleMethodCall(
                     "Missing argument key while trying to set a custom cursor");
       return;
     }
-    auto key = std::get<int>(key_iter->second);
+    auto key = std::get<int64_t>(key_iter->second);
     if (key < 0 || key >= custom_cursors_.size()) {
       result->Error("Argument error", "The argument key must be valid");
       return;
@@ -152,7 +153,7 @@ void CursorHandler::HandleMethodCall(
           "Missing argument key while trying to delete a custom cursor");
       return;
     }
-    auto key = std::get<int>(key_iter->second);
+    auto key = std::get<int64_t>(key_iter->second);
     if (key < 0 || key >= custom_cursors_.size()) {
       result->Error("Argument error", "The argument key must be valid");
       return;

--- a/shell/platform/windows/cursor_handler.cc
+++ b/shell/platform/windows/cursor_handler.cc
@@ -99,7 +99,7 @@ void CursorHandler::HandleMethodCall(
           "Missing argument width while trying to customize system cursor");
       return;
     }
-    auto width = std::get<int>(arguments.at(width_iter->second));
+    auto width = std::get<int>(width_iter->second);
     auto height_iter =
         arguments.find(EncodableValue(std::string(kCustomCursorHeightKey)));
     if (height_iter == arguments.end()) {

--- a/shell/platform/windows/cursor_handler.cc
+++ b/shell/platform/windows/cursor_handler.cc
@@ -14,7 +14,7 @@ static constexpr char kActivateSystemCursorMethod[] = "activateSystemCursor";
 static constexpr char kKindKey[] = "kind";
 
 // This method allows creating a custom cursor with rawBGRA buffer, returns a
-// unique int key to identify the cursor.
+// unique int64_t key to identify the cursor.
 static constexpr char kCreateCustomCursorMethod[] =
     "createCustomCursor/windows";
 // A list of bytes, the custom cursor's rawBGRA buffer.
@@ -29,13 +29,13 @@ static constexpr char kCustomCursorWidthKey[] = "width";
 // An int value for the height of the custom cursor.
 static constexpr char kCustomCursorHeightKey[] = "height";
 
-// This method allows setting a custom cursor with a unique key of the custom
-// cursor.
+// This method allows setting a custom cursor with a unique int64_t key of the
+// custom cursor.
 static constexpr char kSetCustomCursorMethod[] = "setCustomCursor/windows";
 // An int64_t value for the key of the custom cursor.
 static constexpr char kCustomCursorKey[] = "key";
 
-// This method allows deleting a custom cursor with a unique key.
+// This method allows deleting a custom cursor with a unique int64_t key.
 static constexpr char kDeleteCustomCursorMethod[] =
     "deleteCustomCursor/windows";
 

--- a/shell/platform/windows/cursor_handler.cc
+++ b/shell/platform/windows/cursor_handler.cc
@@ -53,39 +53,50 @@ void CursorHandler::HandleMethodCall(
     result->Success();
   } else if (method.compare(kSetSystemCursorMethod) == 0) {
     const auto& arguments = std::get<EncodableMap>(*method_call.arguments());
-    auto buffer_iter = arguments.find(EncodableValue(std::string(kCustomCursorBufferKey)));
+    auto buffer_iter =
+        arguments.find(EncodableValue(std::string(kCustomCursorBufferKey)));
     if (buffer_iter == arguments.end()) {
-      result->Error("Argument error",
-                    "Missing argument buffer while trying to customize system cursor");
+      result->Error(
+          "Argument error",
+          "Missing argument buffer while trying to customize system cursor");
       return;
     }
     auto buffer = std::get<std::vector<uint8_t>>(
         arguments.at(flutter::EncodableValue("buffer")));
-    auto width_iter = arguments.find(EncodableValue(std::string(kCustomCursorWidthKey)));
+    auto width_iter =
+        arguments.find(EncodableValue(std::string(kCustomCursorWidthKey)));
     if (width_iter == arguments.end()) {
-      result->Error("Argument error",
-                    "Missing argument width while trying to customize system cursor");
+      result->Error(
+          "Argument error",
+          "Missing argument width while trying to customize system cursor");
       return;
     }
     auto width = std::get<int>(arguments.at(flutter::EncodableValue("width")));
-    auto height_iter = arguments.find(EncodableValue(std::string(kCustomCursorHeightKey)));
+    auto height_iter =
+        arguments.find(EncodableValue(std::string(kCustomCursorHeightKey)));
     if (height_iter == arguments.end()) {
-      result->Error("Argument error",
-                    "Missing argument height while trying to customize system cursor");
+      result->Error(
+          "Argument error",
+          "Missing argument height while trying to customize system cursor");
       return;
     }
-    auto height = std::get<int>(arguments.at(flutter::EncodableValue("height")));
-    auto hotx_iter = arguments.find(EncodableValue(std::string(kCustomCursorHotxKey)));
+    auto height =
+        std::get<int>(arguments.at(flutter::EncodableValue("height")));
+    auto hotx_iter =
+        arguments.find(EncodableValue(std::string(kCustomCursorHotxKey)));
     if (hotx_iter == arguments.end()) {
-      result->Error("Argument error",
-                    "Missing argument hotx while trying to customize system cursor");
+      result->Error(
+          "Argument error",
+          "Missing argument hotx while trying to customize system cursor");
       return;
     }
     auto hotx = std::get<double>(arguments.at(flutter::EncodableValue("hotx")));
-    auto hoty_iter = arguments.find(EncodableValue(std::string(kCustomCursorHotyKey)));
+    auto hoty_iter =
+        arguments.find(EncodableValue(std::string(kCustomCursorHotyKey)));
     if (hoty_iter == arguments.end()) {
-      result->Error("Argument error",
-                    "Missing argument hoty while trying to customize system cursor");
+      result->Error(
+          "Argument error",
+          "Missing argument hoty while trying to customize system cursor");
       return;
     }
     auto hoty = std::get<double>(arguments.at(flutter::EncodableValue("hoty")));
@@ -93,7 +104,8 @@ void CursorHandler::HandleMethodCall(
     // Flutter returns rawRgba, which has 8bits*4channels
     auto bitmap = CreateBitmap(width, height, 1, 32, &buffer[0]);
     if (bitmap == nullptr) {
-      result->Error("Argument error", "Argument buffer must contain valid rawRgba bitmap");
+      result->Error("Argument error",
+                    "Argument buffer must contain valid rawRgba bitmap");
       return;
     }
     ICONINFO icon_info;
@@ -105,7 +117,9 @@ void CursorHandler::HandleMethodCall(
     cursor = CreateIconIndirect(&icon_info);
     DeleteObject(bitmap);
     if (cursor == nullptr) {
-      result->Error("Argument error", "Create Icon failed, argument buffer must contain valid rawRgba bitmap");
+      result->Error("Argument error",
+                    "Create Icon failed, argument buffer must contain valid "
+                    "rawRgba bitmap");
       return;
     }
     delegate_->SetFlutterCursor(cursor);

--- a/shell/platform/windows/cursor_handler.cc
+++ b/shell/platform/windows/cursor_handler.cc
@@ -11,13 +11,19 @@
 static constexpr char kChannelName[] = "flutter/mousecursor";
 
 static constexpr char kActivateSystemCursorMethod[] = "activateSystemCursor";
-static constexpr char kSetCustomCursorMethod[] = "setCustomCursor";
-
 static constexpr char kKindKey[] = "kind";
+
+// [kSetCustomCursorMethod] allows developers to set a custom cursor with rawRGBA buffer.
+static constexpr char kSetCustomCursorMethod[] = "setCustomCursor";
+// std::vector<uint8_t> value for custom cursor rawRGBA buffer.
 static constexpr char kCustomCursorBufferKey[] = "buffer";
+// double value for the hotx value of custom cursor.
 static constexpr char kCustomCursorHotxKey[] = "hotx";
+// double value for the hoty value of custom cursor.
 static constexpr char kCustomCursorHotyKey[] = "hoty";
+// int value for the width of custom cursor.
 static constexpr char kCustomCursorWidthKey[] = "width";
+// int value for the height of custom cursor.
 static constexpr char kCustomCursorHeightKey[] = "height";
 
 namespace flutter {

--- a/shell/platform/windows/cursor_handler.cc
+++ b/shell/platform/windows/cursor_handler.cc
@@ -105,8 +105,7 @@ void CursorHandler::HandleMethodCall(
       return;
     }
     auto hoty = std::get<double>(hoty_iter->second);
-    HCURSOR cursor =
-        GetCursorFromBuffer(std::move(buffer), hotx, hoty, width, height);
+    HCURSOR cursor = GetCursorFromBuffer(buffer, hotx, hoty, width, height);
     if (cursor == nullptr) {
       result->Error("Argument error",
                     "Argument must contain valid rawRgba bitmap");
@@ -119,7 +118,7 @@ void CursorHandler::HandleMethodCall(
   }
 }
 
-HCURSOR GetCursorFromBuffer(std::vector<uint8_t> buffer,
+HCURSOR GetCursorFromBuffer(const std::vector<uint8_t>& buffer,
                             double hotx,
                             double hoty,
                             int width,

--- a/shell/platform/windows/cursor_handler.cc
+++ b/shell/platform/windows/cursor_handler.cc
@@ -13,15 +13,15 @@ static constexpr char kChannelName[] = "flutter/mousecursor";
 static constexpr char kActivateSystemCursorMethod[] = "activateSystemCursor";
 static constexpr char kKindKey[] = "kind";
 
-// [kSetCustomCursorMethod] allows developers to set a custom cursor with
-// rawRGBA buffer.
-static constexpr char kSetCustomCursorMethod[] = "setCustomCursor";
-// std::vector<uint8_t> value for custom cursor rawRGBA buffer.
+// This method allows setting a custom cursor with rawRGBA buffer.
+static constexpr char kSetCustomCursorMethod[] = "setCustomCursor/windows";
+// A list of bytes, the custom cursor's rawRGBA buffer.
 static constexpr char kCustomCursorBufferKey[] = "buffer";
-// double value for the hotx value of custom cursor.
-static constexpr char kCustomCursorHotxKey[] = "hotx";
-// double value for the hoty value of custom cursor.
-static constexpr char kCustomCursorHotyKey[] = "hoty";
+// A double, the x coordinate of the custom cursor's hotspot, starting from
+// left.
+static constexpr char kCustomCursorHotXKey[] = "hotX";
+// A double, the y coordinate of the custom cursor's hotspot, starting from top.
+static constexpr char kCustomCursorHotYKey[] = "hotY";
 // int value for the width of custom cursor.
 static constexpr char kCustomCursorWidthKey[] = "width";
 // int value for the height of custom cursor.
@@ -87,25 +87,25 @@ void CursorHandler::HandleMethodCall(
       return;
     }
     auto height = std::get<int>(height_iter->second);
-    auto hotx_iter =
-        arguments.find(EncodableValue(std::string(kCustomCursorHotxKey)));
-    if (hotx_iter == arguments.end()) {
+    auto hot_x_iter =
+        arguments.find(EncodableValue(std::string(kCustomCursorHotXKey)));
+    if (hot_x_iter == arguments.end()) {
       result->Error(
           "Argument error",
-          "Missing argument hotx while trying to customize system cursor");
+          "Missing argument hotX while trying to customize system cursor");
       return;
     }
-    auto hotx = std::get<double>(hotx_iter->second);
-    auto hoty_iter =
-        arguments.find(EncodableValue(std::string(kCustomCursorHotyKey)));
-    if (hoty_iter == arguments.end()) {
+    auto hot_x = std::get<double>(hot_x_iter->second);
+    auto hot_y_iter =
+        arguments.find(EncodableValue(std::string(kCustomCursorHotYKey)));
+    if (hot_y_iter == arguments.end()) {
       result->Error(
           "Argument error",
-          "Missing argument hoty while trying to customize system cursor");
+          "Missing argument hotY while trying to customize system cursor");
       return;
     }
-    auto hoty = std::get<double>(hoty_iter->second);
-    HCURSOR cursor = GetCursorFromBuffer(buffer, hotx, hoty, width, height);
+    auto hot_y = std::get<double>(hot_y_iter->second);
+    HCURSOR cursor = GetCursorFromBuffer(buffer, hot_x, hot_y, width, height);
     if (cursor == nullptr) {
       result->Error("Argument error",
                     "Argument must contain valid rawRgba bitmap");
@@ -119,20 +119,20 @@ void CursorHandler::HandleMethodCall(
 }
 
 HCURSOR GetCursorFromBuffer(const std::vector<uint8_t>& buffer,
-                            double hotx,
-                            double hoty,
+                            double hot_x,
+                            double hot_y,
                             int width,
                             int height) {
   HCURSOR cursor = nullptr;
-  // Flutter returns rawRgba, which has 8bits * 4channels
+  // Flutter returns rawRgba, which has 8bits * 4channels.
   auto bitmap = CreateBitmap(width, height, 1, 32, &buffer[0]);
   if (bitmap == nullptr) {
     return nullptr;
   }
   ICONINFO icon_info;
   icon_info.fIcon = 0;
-  icon_info.xHotspot = hotx;
-  icon_info.yHotspot = hoty;
+  icon_info.xHotspot = hot_x;
+  icon_info.yHotspot = hot_y;
   icon_info.hbmMask = bitmap;
   icon_info.hbmColor = bitmap;
   cursor = CreateIconIndirect(&icon_info);

--- a/shell/platform/windows/cursor_handler.cc
+++ b/shell/platform/windows/cursor_handler.cc
@@ -137,35 +137,35 @@ void CursorHandler::HandleMethodCall(
     result->Success(flutter::EncodableValue(std::move(name)));
   } else if (method.compare(kSetCustomCursorMethod) == 0) {
     const auto& arguments = std::get<EncodableMap>(*method_call.arguments());
-    auto key_iter =
+    auto name_iter =
         arguments.find(EncodableValue(std::string(kCustomCursorNameKey)));
-    if (key_iter == arguments.end()) {
+    if (name_iter == arguments.end()) {
       result->Error("Argument error",
                     "Missing argument key while trying to set a custom cursor");
       return;
     }
-    auto key = std::get<std::string>(key_iter->second);
-    if (custom_cursors_.find(key) == custom_cursors_.end()) {
+    auto name = std::get<std::string>(name_iter->second);
+    if (custom_cursors_.find(name) == custom_cursors_.end()) {
       result->Error(
           "Argument error",
           "The custom cursor identified by the argument key cannot be found");
       return;
     }
-    HCURSOR cursor = custom_cursors_[key];
+    HCURSOR cursor = custom_cursors_[name];
     delegate_->SetFlutterCursor(cursor);
     result->Success();
   } else if (method.compare(kDeleteCustomCursorMethod) == 0) {
     const auto& arguments = std::get<EncodableMap>(*method_call.arguments());
-    auto key_iter =
+    auto name_iter =
         arguments.find(EncodableValue(std::string(kCustomCursorNameKey)));
-    if (key_iter == arguments.end()) {
+    if (name_iter == arguments.end()) {
       result->Error(
           "Argument error",
           "Missing argument key while trying to delete a custom cursor");
       return;
     }
-    auto key = std::get<std::string>(key_iter->second);
-    auto it = custom_cursors_.find(key);
+    auto name = std::get<std::string>(name_iter->second);
+    auto it = custom_cursors_.find(name);
     // if the cursor identified by key cannot be found, it's ok for deleting
     // operations
     if (it != custom_cursors_.end()) {

--- a/shell/platform/windows/cursor_handler.cc
+++ b/shell/platform/windows/cursor_handler.cc
@@ -11,6 +11,7 @@
 static constexpr char kChannelName[] = "flutter/mousecursor";
 
 static constexpr char kActivateSystemCursorMethod[] = "activateSystemCursor";
+static constexpr char kSetSystemCursorMethod[] = "setSystemCursor";
 
 static constexpr char kKindKey[] = "kind";
 
@@ -44,6 +45,31 @@ void CursorHandler::HandleMethodCall(
     }
     const auto& kind = std::get<std::string>(kind_iter->second);
     delegate_->UpdateFlutterCursor(kind);
+    result->Success();
+  } else if (method.compare(kSetSystemCursorMethod) == 0) {
+    const auto& map = std::get<EncodableMap>(*method_call.arguments());
+    auto buffer = std::get<std::vector<uint8_t>>(
+        map.at(flutter::EncodableValue("buffer")));
+    auto width = std::get<int>(map.at(flutter::EncodableValue("width")));
+    auto height = std::get<int>(map.at(flutter::EncodableValue("height")));
+    auto hotx = std::get<double>(map.at(flutter::EncodableValue("hotx")));
+    auto hoty = std::get<double>(map.at(flutter::EncodableValue("hoty")));
+    HCURSOR cursor = nullptr;
+    // Flutter returns rawRgba, which has 8bits*4channels
+    auto bitmap = CreateBitmap(width, height, 1, 32, &buffer[0]);
+    if (bitmap == nullptr) {
+      result->Error("Argument error", "Invalid rawRgba bitmap from flutter");
+      return;
+    }
+    ICONINFO icon_info;
+    icon_info.fIcon = 0;
+    icon_info.xHotspot = hotx;
+    icon_info.yHotspot = hoty;
+    icon_info.hbmMask = bitmap;
+    icon_info.hbmColor = bitmap;
+    cursor = CreateIconIndirect(&icon_info);
+    DeleteObject(bitmap);
+    delegate_->SetFlutterCursor(cursor);
     result->Success();
   } else {
     result->NotImplemented();

--- a/shell/platform/windows/cursor_handler.cc
+++ b/shell/platform/windows/cursor_handler.cc
@@ -22,9 +22,9 @@ static constexpr char kCustomCursorBufferKey[] = "buffer";
 static constexpr char kCustomCursorHotXKey[] = "hotX";
 // A double, the y coordinate of the custom cursor's hotspot, starting from top.
 static constexpr char kCustomCursorHotYKey[] = "hotY";
-// int value for the width of custom cursor.
+// An int value for the width of custom cursor.
 static constexpr char kCustomCursorWidthKey[] = "width";
-// int value for the height of custom cursor.
+// An int value for the height of custom cursor.
 static constexpr char kCustomCursorHeightKey[] = "height";
 
 namespace flutter {

--- a/shell/platform/windows/cursor_handler.cc
+++ b/shell/platform/windows/cursor_handler.cc
@@ -31,11 +31,12 @@ static constexpr char kCustomCursorWidthKey[] = "width";
 // An int value for the height of the custom cursor.
 static constexpr char kCustomCursorHeightKey[] = "height";
 
-// This method allows setting a custom cursor with a unique int64_t key of the
-// custom cursor.
+// This method also has an argument `kCustomCursorNameKey` for the name
+// of the cursor to activate.
 static constexpr char kSetCustomCursorMethod[] = "setCustomCursor/windows";
 
-// This method allows deleting a custom cursor with a string key.
+// This method also has an argument `kCustomCursorNameKey` for the name
+// of the cursor to delete.
 static constexpr char kDeleteCustomCursorMethod[] =
     "deleteCustomCursor/windows";
 
@@ -132,7 +133,7 @@ void CursorHandler::HandleMethodCall(
                     "Argument must contains a valid rawBGRA bitmap");
       return;
     }
-    // push the cursor into the cache vector of this handler.
+    // Push the cursor into the cache map.
     custom_cursors_.emplace(name, std::move(cursor));
     result->Success(flutter::EncodableValue(std::move(name)));
   } else if (method.compare(kSetCustomCursorMethod) == 0) {
@@ -166,8 +167,8 @@ void CursorHandler::HandleMethodCall(
     }
     auto name = std::get<std::string>(name_iter->second);
     auto it = custom_cursors_.find(name);
-    // if the cursor identified by key cannot be found, it's ok for deleting
-    // operations
+    // If the specified cursor name is not found, the deletion is a noop and
+    // returns success.
     if (it != custom_cursors_.end()) {
       DeleteObject(it->second);
       custom_cursors_.erase(it);

--- a/shell/platform/windows/cursor_handler.cc
+++ b/shell/platform/windows/cursor_handler.cc
@@ -13,9 +13,9 @@ static constexpr char kChannelName[] = "flutter/mousecursor";
 static constexpr char kActivateSystemCursorMethod[] = "activateSystemCursor";
 static constexpr char kKindKey[] = "kind";
 
-// This method allows setting a custom cursor with rawRGBA buffer.
+// This method allows setting a custom cursor with rawBGRA buffer.
 static constexpr char kSetCustomCursorMethod[] = "setCustomCursor/windows";
-// A list of bytes, the custom cursor's rawRGBA buffer.
+// A list of bytes, the custom cursor's rawBGRA buffer.
 static constexpr char kCustomCursorBufferKey[] = "buffer";
 // A double, the x coordinate of the custom cursor's hotspot, starting from
 // left.
@@ -108,7 +108,7 @@ void CursorHandler::HandleMethodCall(
     HCURSOR cursor = GetCursorFromBuffer(buffer, hot_x, hot_y, width, height);
     if (cursor == nullptr) {
       result->Error("Argument error",
-                    "Argument must contain valid rawRgba bitmap");
+                    "Argument must contain valid rawBGRA bitmap");
       return;
     }
     delegate_->SetFlutterCursor(cursor);
@@ -124,7 +124,7 @@ HCURSOR GetCursorFromBuffer(const std::vector<uint8_t>& buffer,
                             int width,
                             int height) {
   HCURSOR cursor = nullptr;
-  // Flutter returns rawRgba, which has 8bits * 4channels.
+  // Flutter returns rawRGRA, which has 8bits * 4channels.
   auto bitmap = CreateBitmap(width, height, 1, 32, &buffer[0]);
   if (bitmap == nullptr) {
     return nullptr;

--- a/shell/platform/windows/cursor_handler.cc
+++ b/shell/platform/windows/cursor_handler.cc
@@ -11,7 +11,7 @@
 static constexpr char kChannelName[] = "flutter/mousecursor";
 
 static constexpr char kActivateSystemCursorMethod[] = "activateSystemCursor";
-static constexpr char kSetSystemCursorMethod[] = "setSystemCursor";
+static constexpr char kSetCustomCursorMethod[] = "setCustomCursor";
 
 static constexpr char kKindKey[] = "kind";
 static constexpr char kCustomCursorBufferKey[] = "buffer";
@@ -51,7 +51,7 @@ void CursorHandler::HandleMethodCall(
     const auto& kind = std::get<std::string>(kind_iter->second);
     delegate_->UpdateFlutterCursor(kind);
     result->Success();
-  } else if (method.compare(kSetSystemCursorMethod) == 0) {
+  } else if (method.compare(kSetCustomCursorMethod) == 0) {
     const auto& arguments = std::get<EncodableMap>(*method_call.arguments());
     auto buffer_iter =
         arguments.find(EncodableValue(std::string(kCustomCursorBufferKey)));
@@ -61,8 +61,7 @@ void CursorHandler::HandleMethodCall(
           "Missing argument buffer while trying to customize system cursor");
       return;
     }
-    auto buffer = std::get<std::vector<uint8_t>>(
-        arguments.at(flutter::EncodableValue("buffer")));
+    auto buffer = std::get<std::vector<uint8_t>>(buffer_iter->second);
     auto width_iter =
         arguments.find(EncodableValue(std::string(kCustomCursorWidthKey)));
     if (width_iter == arguments.end()) {
@@ -71,7 +70,7 @@ void CursorHandler::HandleMethodCall(
           "Missing argument width while trying to customize system cursor");
       return;
     }
-    auto width = std::get<int>(arguments.at(flutter::EncodableValue("width")));
+    auto width = std::get<int>(arguments.at(width_iter->second));
     auto height_iter =
         arguments.find(EncodableValue(std::string(kCustomCursorHeightKey)));
     if (height_iter == arguments.end()) {
@@ -81,7 +80,7 @@ void CursorHandler::HandleMethodCall(
       return;
     }
     auto height =
-        std::get<int>(arguments.at(flutter::EncodableValue("height")));
+        std::get<int>(height_iter->second);
     auto hotx_iter =
         arguments.find(EncodableValue(std::string(kCustomCursorHotxKey)));
     if (hotx_iter == arguments.end()) {
@@ -90,7 +89,7 @@ void CursorHandler::HandleMethodCall(
           "Missing argument hotx while trying to customize system cursor");
       return;
     }
-    auto hotx = std::get<double>(arguments.at(flutter::EncodableValue("hotx")));
+    auto hotx = std::get<double>(hotx_iter->second);
     auto hoty_iter =
         arguments.find(EncodableValue(std::string(kCustomCursorHotyKey)));
     if (hoty_iter == arguments.end()) {
@@ -99,7 +98,7 @@ void CursorHandler::HandleMethodCall(
           "Missing argument hoty while trying to customize system cursor");
       return;
     }
-    auto hoty = std::get<double>(arguments.at(flutter::EncodableValue("hoty")));
+    auto hoty = std::get<double>(hoty_iter->second);
     HCURSOR cursor = nullptr;
     // Flutter returns rawRgba, which has 8bits*4channels
     auto bitmap = CreateBitmap(width, height, 1, 32, &buffer[0]);

--- a/shell/platform/windows/cursor_handler.cc
+++ b/shell/platform/windows/cursor_handler.cc
@@ -24,14 +24,15 @@ static constexpr char kCustomCursorBufferKey[] = "buffer";
 static constexpr char kCustomCursorHotXKey[] = "hotX";
 // A double, the y coordinate of the custom cursor's hotspot, starting from top.
 static constexpr char kCustomCursorHotYKey[] = "hotY";
-// An int value for the width of custom cursor.
+// An int value for the width of the custom cursor.
 static constexpr char kCustomCursorWidthKey[] = "width";
-// An int value for the height of custom cursor.
+// An int value for the height of the custom cursor.
 static constexpr char kCustomCursorHeightKey[] = "height";
 
 // This method allows setting a custom cursor with a unique key of the custom
 // cursor.
 static constexpr char kSetCustomCursorMethod[] = "setCustomCursor/windows";
+// And int64_t value for the key of the custom cursor.
 static constexpr char kCustomCursorKey[] = "key";
 
 // This method allows deleting a custom cursor with a unique key.

--- a/shell/platform/windows/cursor_handler.cc
+++ b/shell/platform/windows/cursor_handler.cc
@@ -34,8 +34,6 @@ static constexpr char kCustomCursorHeightKey[] = "height";
 // This method allows setting a custom cursor with a unique int64_t key of the
 // custom cursor.
 static constexpr char kSetCustomCursorMethod[] = "setCustomCursor/windows";
-// A string value for the key of the custom cursor.
-static constexpr char kCustomCursorKey[] = "key";
 
 // This method allows deleting a custom cursor with a string key.
 static constexpr char kDeleteCustomCursorMethod[] =
@@ -140,7 +138,7 @@ void CursorHandler::HandleMethodCall(
   } else if (method.compare(kSetCustomCursorMethod) == 0) {
     const auto& arguments = std::get<EncodableMap>(*method_call.arguments());
     auto key_iter =
-        arguments.find(EncodableValue(std::string(kCustomCursorKey)));
+        arguments.find(EncodableValue(std::string(kCustomCursorNameKey)));
     if (key_iter == arguments.end()) {
       result->Error("Argument error",
                     "Missing argument key while trying to set a custom cursor");
@@ -159,7 +157,7 @@ void CursorHandler::HandleMethodCall(
   } else if (method.compare(kDeleteCustomCursorMethod) == 0) {
     const auto& arguments = std::get<EncodableMap>(*method_call.arguments());
     auto key_iter =
-        arguments.find(EncodableValue(std::string(kCustomCursorKey)));
+        arguments.find(EncodableValue(std::string(kCustomCursorNameKey)));
     if (key_iter == arguments.end()) {
       result->Error(
           "Argument error",

--- a/shell/platform/windows/cursor_handler.cc
+++ b/shell/platform/windows/cursor_handler.cc
@@ -13,7 +13,8 @@ static constexpr char kChannelName[] = "flutter/mousecursor";
 static constexpr char kActivateSystemCursorMethod[] = "activateSystemCursor";
 static constexpr char kKindKey[] = "kind";
 
-// [kSetCustomCursorMethod] allows developers to set a custom cursor with rawRGBA buffer.
+// [kSetCustomCursorMethod] allows developers to set a custom cursor with
+// rawRGBA buffer.
 static constexpr char kSetCustomCursorMethod[] = "setCustomCursor";
 // std::vector<uint8_t> value for custom cursor rawRGBA buffer.
 static constexpr char kCustomCursorBufferKey[] = "buffer";
@@ -85,8 +86,7 @@ void CursorHandler::HandleMethodCall(
           "Missing argument height while trying to customize system cursor");
       return;
     }
-    auto height =
-        std::get<int>(height_iter->second);
+    auto height = std::get<int>(height_iter->second);
     auto hotx_iter =
         arguments.find(EncodableValue(std::string(kCustomCursorHotxKey)));
     if (hotx_iter == arguments.end()) {

--- a/shell/platform/windows/cursor_handler.cc
+++ b/shell/platform/windows/cursor_handler.cc
@@ -32,7 +32,7 @@ static constexpr char kCustomCursorHeightKey[] = "height";
 // This method allows setting a custom cursor with a unique key of the custom
 // cursor.
 static constexpr char kSetCustomCursorMethod[] = "setCustomCursor/windows";
-// And int64_t value for the key of the custom cursor.
+// An int64_t value for the key of the custom cursor.
 static constexpr char kCustomCursorKey[] = "key";
 
 // This method allows deleting a custom cursor with a unique key.

--- a/shell/platform/windows/cursor_handler.cc
+++ b/shell/platform/windows/cursor_handler.cc
@@ -14,6 +14,11 @@ static constexpr char kActivateSystemCursorMethod[] = "activateSystemCursor";
 static constexpr char kSetSystemCursorMethod[] = "setSystemCursor";
 
 static constexpr char kKindKey[] = "kind";
+static constexpr char kCustomCursorBufferKey[] = "buffer";
+static constexpr char kCustomCursorHotxKey[] = "hotx";
+static constexpr char kCustomCursorHotyKey[] = "hoty";
+static constexpr char kCustomCursorWidthKey[] = "width";
+static constexpr char kCustomCursorHeightKey[] = "height";
 
 namespace flutter {
 
@@ -47,18 +52,48 @@ void CursorHandler::HandleMethodCall(
     delegate_->UpdateFlutterCursor(kind);
     result->Success();
   } else if (method.compare(kSetSystemCursorMethod) == 0) {
-    const auto& map = std::get<EncodableMap>(*method_call.arguments());
+    const auto& arguments = std::get<EncodableMap>(*method_call.arguments());
+    auto buffer_iter = arguments.find(EncodableValue(std::string(kCustomCursorBufferKey)));
+    if (buffer_iter == arguments.end()) {
+      result->Error("Argument error",
+                    "Missing argument buffer while trying to customize system cursor");
+      return;
+    }
     auto buffer = std::get<std::vector<uint8_t>>(
-        map.at(flutter::EncodableValue("buffer")));
-    auto width = std::get<int>(map.at(flutter::EncodableValue("width")));
-    auto height = std::get<int>(map.at(flutter::EncodableValue("height")));
-    auto hotx = std::get<double>(map.at(flutter::EncodableValue("hotx")));
-    auto hoty = std::get<double>(map.at(flutter::EncodableValue("hoty")));
+        arguments.at(flutter::EncodableValue("buffer")));
+    auto width_iter = arguments.find(EncodableValue(std::string(kCustomCursorWidthKey)));
+    if (width_iter == arguments.end()) {
+      result->Error("Argument error",
+                    "Missing argument width while trying to customize system cursor");
+      return;
+    }
+    auto width = std::get<int>(arguments.at(flutter::EncodableValue("width")));
+    auto height_iter = arguments.find(EncodableValue(std::string(kCustomCursorHeightKey)));
+    if (height_iter == arguments.end()) {
+      result->Error("Argument error",
+                    "Missing argument height while trying to customize system cursor");
+      return;
+    }
+    auto height = std::get<int>(arguments.at(flutter::EncodableValue("height")));
+    auto hotx_iter = arguments.find(EncodableValue(std::string(kCustomCursorHotxKey)));
+    if (hotx_iter == arguments.end()) {
+      result->Error("Argument error",
+                    "Missing argument hotx while trying to customize system cursor");
+      return;
+    }
+    auto hotx = std::get<double>(arguments.at(flutter::EncodableValue("hotx")));
+    auto hoty_iter = arguments.find(EncodableValue(std::string(kCustomCursorHotyKey)));
+    if (hoty_iter == arguments.end()) {
+      result->Error("Argument error",
+                    "Missing argument hoty while trying to customize system cursor");
+      return;
+    }
+    auto hoty = std::get<double>(arguments.at(flutter::EncodableValue("hoty")));
     HCURSOR cursor = nullptr;
     // Flutter returns rawRgba, which has 8bits*4channels
     auto bitmap = CreateBitmap(width, height, 1, 32, &buffer[0]);
     if (bitmap == nullptr) {
-      result->Error("Argument error", "Invalid rawRgba bitmap from flutter");
+      result->Error("Argument error", "Argument buffer must contain valid rawRgba bitmap");
       return;
     }
     ICONINFO icon_info;
@@ -69,6 +104,10 @@ void CursorHandler::HandleMethodCall(
     icon_info.hbmColor = bitmap;
     cursor = CreateIconIndirect(&icon_info);
     DeleteObject(bitmap);
+    if (cursor == nullptr) {
+      result->Error("Argument error", "Create Icon failed, argument buffer must contain valid rawRgba bitmap");
+      return;
+    }
     delegate_->SetFlutterCursor(cursor);
     result->Success();
   } else {

--- a/shell/platform/windows/cursor_handler.h
+++ b/shell/platform/windows/cursor_handler.h
@@ -33,7 +33,7 @@ class CursorHandler {
 };
 
 // Create cursor from buffer and cursor info
-inline HCURSOR GetCursorFromBuffer(std::vector<uint8_t> buffer,
+inline HCURSOR GetCursorFromBuffer(const std::vector<uint8_t>& buffer,
                                    double hotx,
                                    double hoty,
                                    int width,

--- a/shell/platform/windows/cursor_handler.h
+++ b/shell/platform/windows/cursor_handler.h
@@ -39,6 +39,9 @@ HCURSOR GetCursorFromBuffer(const std::vector<uint8_t>& buffer,
                             int width,
                             int height);
 
+// Get the corresponding mask bitmap from the source bitmap.
+void GetMaskBitmaps(HBITMAP bitmap, HBITMAP& mask_bitmap);
+
 }  // namespace flutter
 
 #endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_CURSOR_HANDLER_H_

--- a/shell/platform/windows/cursor_handler.h
+++ b/shell/platform/windows/cursor_handler.h
@@ -5,7 +5,7 @@
 #ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_CURSOR_HANDLER_H_
 #define FLUTTER_SHELL_PLATFORM_WINDOWS_CURSOR_HANDLER_H_
 
-#include <vector>
+#include <unordered_map>
 
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/binary_messenger.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/encodable_value.h"
@@ -33,8 +33,8 @@ class CursorHandler {
   // The delegate for cursor updates.
   WindowBindingHandler* delegate_;
 
-  // The cache for custom cursors.
-  std::vector<HCURSOR> custom_cursors_;
+  // The cache map for custom cursors. 
+  std::unordered_map<std::string, HCURSOR> custom_cursors_;
 };
 
 // Create a cursor from a rawBGRA buffer and the cursor info.

--- a/shell/platform/windows/cursor_handler.h
+++ b/shell/platform/windows/cursor_handler.h
@@ -32,10 +32,10 @@ class CursorHandler {
   WindowBindingHandler* delegate_;
 };
 
-// Create cursor from buffer and cursor info
+// Create a cursor from buffer and cursor info.
 HCURSOR GetCursorFromBuffer(const std::vector<uint8_t>& buffer,
-                            double hotx,
-                            double hoty,
+                            double hot_x,
+                            double hot_y,
                             int width,
                             int height);
 

--- a/shell/platform/windows/cursor_handler.h
+++ b/shell/platform/windows/cursor_handler.h
@@ -32,7 +32,7 @@ class CursorHandler {
   WindowBindingHandler* delegate_;
 };
 
-// Create a cursor from buffer and cursor info.
+// Create a cursor from a rawBGRA buffer and the cursor info.
 HCURSOR GetCursorFromBuffer(const std::vector<uint8_t>& buffer,
                             double hot_x,
                             double hot_y,

--- a/shell/platform/windows/cursor_handler.h
+++ b/shell/platform/windows/cursor_handler.h
@@ -33,7 +33,7 @@ class CursorHandler {
 };
 
 // Create cursor from buffer and cursor info
-inline HCURSOR GetCursorFromBuffer(const std::vector<uint8_t>& buffer,
+HCURSOR GetCursorFromBuffer(const std::vector<uint8_t>& buffer,
                                    double hotx,
                                    double hoty,
                                    int width,

--- a/shell/platform/windows/cursor_handler.h
+++ b/shell/platform/windows/cursor_handler.h
@@ -34,10 +34,10 @@ class CursorHandler {
 
 // Create cursor from buffer and cursor info
 HCURSOR GetCursorFromBuffer(const std::vector<uint8_t>& buffer,
-                                   double hotx,
-                                   double hoty,
-                                   int width,
-                                   int height);
+                            double hotx,
+                            double hoty,
+                            int width,
+                            int height);
 
 }  // namespace flutter
 

--- a/shell/platform/windows/cursor_handler.h
+++ b/shell/platform/windows/cursor_handler.h
@@ -5,6 +5,8 @@
 #ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_CURSOR_HANDLER_H_
 #define FLUTTER_SHELL_PLATFORM_WINDOWS_CURSOR_HANDLER_H_
 
+#include <vector>
+
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/binary_messenger.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/encodable_value.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/method_channel.h"
@@ -30,6 +32,9 @@ class CursorHandler {
 
   // The delegate for cursor updates.
   WindowBindingHandler* delegate_;
+
+  // The cache for custom cursors.
+  std::vector<HCURSOR> custom_cursors_;
 };
 
 // Create a cursor from a rawBGRA buffer and the cursor info.

--- a/shell/platform/windows/cursor_handler.h
+++ b/shell/platform/windows/cursor_handler.h
@@ -32,6 +32,13 @@ class CursorHandler {
   WindowBindingHandler* delegate_;
 };
 
+// Create cursor from buffer and cursor info
+inline HCURSOR GetCursorFromBuffer(std::vector<uint8_t> buffer,
+                                   double hotx,
+                                   double hoty,
+                                   int width,
+                                   int height);
+
 }  // namespace flutter
 
 #endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_CURSOR_HANDLER_H_

--- a/shell/platform/windows/cursor_handler.h
+++ b/shell/platform/windows/cursor_handler.h
@@ -33,7 +33,7 @@ class CursorHandler {
   // The delegate for cursor updates.
   WindowBindingHandler* delegate_;
 
-  // The cache map for custom cursors. 
+  // The cache map for custom cursors.
   std::unordered_map<std::string, HCURSOR> custom_cursors_;
 };
 

--- a/shell/platform/windows/cursor_handler_unittests.cc
+++ b/shell/platform/windows/cursor_handler_unittests.cc
@@ -18,7 +18,7 @@ TEST(CursorHandlerTest, CreateDummyCursor) {
     buffer.push_back(0);
   }
   // get cursor
-  auto cursor = GetCursorFromBuffer(buffer, 0, 0, 4, 4);
+  auto cursor = GetCursorFromBuffer(buffer, 0.0, 0.0, 4, 4);
   // expect cursor is not null
   EXPECT_NE(cursor, nullptr);
 }

--- a/shell/platform/windows/cursor_handler_unittests.cc
+++ b/shell/platform/windows/cursor_handler_unittests.cc
@@ -12,14 +12,14 @@
 namespace flutter {
 namespace testing {
 TEST(CursorHandlerTest, CreateDummyCursor) {
-  // create a 4x4 rawBGRA dummy cursor buffer.
+  // Create a 4x4 rawBGRA dummy cursor buffer.
   std::vector<uint8_t> buffer;
   for (int i = 0; i < 4 * 4 * 4; i++) {
     buffer.push_back(0);
   }
-  // create the cursor from buffer provided above.
+  // Create the cursor from buffer provided above.
   auto cursor = GetCursorFromBuffer(buffer, 0.0, 0.0, 4, 4);
-  // expect cursor is not null.
+  // Expect cursor is not null.
   EXPECT_NE(cursor, nullptr);
 }
 

--- a/shell/platform/windows/cursor_handler_unittests.cc
+++ b/shell/platform/windows/cursor_handler_unittests.cc
@@ -12,12 +12,14 @@
 namespace flutter {
 namespace testing {
 TEST(CursorHandlerTest, CreateDummyCursor) {
-  // create 4x4 rawRGBA dummy cursor arguments
+  // create 4x4 rawRGBA dummy cursor buffer
   std::vector<uint8_t> buffer;
   for (int i = 0; i < 4 * 4 * 4; i++) {
     buffer.push_back(0);
   }
+  // get cursor
   auto cursor = GetCursorFromBuffer(buffer, 0, 0, 4, 4);
+  // expect cursor is not null
   EXPECT_NE(cursor, nullptr);
 }
 

--- a/shell/platform/windows/cursor_handler_unittests.cc
+++ b/shell/platform/windows/cursor_handler_unittests.cc
@@ -12,14 +12,14 @@
 namespace flutter {
 namespace testing {
 TEST(CursorHandlerTest, CreateDummyCursor) {
-  // create 4x4 rawRGBA dummy cursor buffer
+  // create a 4x4 rawRGBA dummy cursor buffer.
   std::vector<uint8_t> buffer;
   for (int i = 0; i < 4 * 4 * 4; i++) {
     buffer.push_back(0);
   }
-  // get cursor
+  // create the cursor from buffer provided above.
   auto cursor = GetCursorFromBuffer(buffer, 0.0, 0.0, 4, 4);
-  // expect cursor is not null
+  // expect cursor is not null.
   EXPECT_NE(cursor, nullptr);
 }
 

--- a/shell/platform/windows/cursor_handler_unittests.cc
+++ b/shell/platform/windows/cursor_handler_unittests.cc
@@ -1,0 +1,25 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+#include "flutter/shell/platform/windows/cursor_handler.h"
+
+#include <memory>
+#include <vector>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace flutter {
+namespace testing {
+TEST(CursorHandlerTest, CreateDummyCursor) {
+  // create 4x4 rawRGBA dummy cursor arguments
+  std::vector<uint8_t> buffer;
+  for (int i = 0; i < 4 * 4 * 4; i++) {
+    buffer.push_back(0);
+  }
+  auto cursor = GetCursorFromBuffer(std::move(buffer), 0, 0, 4, 4);
+  EXPECT_NE(cursor, nullptr);
+}
+
+}  // namespace testing
+}  // namespace flutter

--- a/shell/platform/windows/cursor_handler_unittests.cc
+++ b/shell/platform/windows/cursor_handler_unittests.cc
@@ -17,7 +17,7 @@ TEST(CursorHandlerTest, CreateDummyCursor) {
   for (int i = 0; i < 4 * 4 * 4; i++) {
     buffer.push_back(0);
   }
-  auto cursor = GetCursorFromBuffer(std::move(buffer), 0, 0, 4, 4);
+  auto cursor = GetCursorFromBuffer(buffer, 0, 0, 4, 4);
   EXPECT_NE(cursor, nullptr);
 }
 

--- a/shell/platform/windows/cursor_handler_unittests.cc
+++ b/shell/platform/windows/cursor_handler_unittests.cc
@@ -12,7 +12,7 @@
 namespace flutter {
 namespace testing {
 TEST(CursorHandlerTest, CreateDummyCursor) {
-  // create a 4x4 rawRGBA dummy cursor buffer.
+  // create a 4x4 rawBGRA dummy cursor buffer.
   std::vector<uint8_t> buffer;
   for (int i = 0; i < 4 * 4 * 4; i++) {
     buffer.push_back(0);

--- a/shell/platform/windows/flutter_window.cc
+++ b/shell/platform/windows/flutter_window.cc
@@ -107,6 +107,7 @@ void FlutterWindow::UpdateFlutterCursor(const std::string& cursor_name) {
 
 void FlutterWindow::SetFlutterCursor(HCURSOR cursor) {
   current_cursor_ = cursor;
+  ::SetCursor(current_cursor_);
 }
 
 void FlutterWindow::OnWindowResized() {

--- a/shell/platform/windows/flutter_window.cc
+++ b/shell/platform/windows/flutter_window.cc
@@ -105,6 +105,10 @@ void FlutterWindow::UpdateFlutterCursor(const std::string& cursor_name) {
   current_cursor_ = GetCursorByName(cursor_name);
 }
 
+void FlutterWindow::SetFlutterCursor(HCURSOR cursor) {
+  current_cursor_ = cursor;
+}
+
 void FlutterWindow::OnWindowResized() {
   // Blocking the raster thread until DWM flushes alleviates glitches where
   // previous size surface is stretched over current size view.

--- a/shell/platform/windows/flutter_window.h
+++ b/shell/platform/windows/flutter_window.h
@@ -132,6 +132,9 @@ class FlutterWindow : public Window, public WindowBindingHandler {
   void UpdateFlutterCursor(const std::string& cursor_name) override;
 
   // |FlutterWindowBindingHandler|
+  void SetFlutterCursor(HCURSOR cursor) override;
+
+  // |FlutterWindowBindingHandler|
   void OnWindowResized() override;
 
   // |FlutterWindowBindingHandler|

--- a/shell/platform/windows/testing/mock_window_binding_handler.h
+++ b/shell/platform/windows/testing/mock_window_binding_handler.h
@@ -31,6 +31,7 @@ class MockWindowBindingHandler : public WindowBindingHandler {
   MOCK_METHOD0(OnWindowResized, void());
   MOCK_METHOD0(GetPhysicalWindowBounds, PhysicalWindowBounds());
   MOCK_METHOD1(UpdateFlutterCursor, void(const std::string& cursor_name));
+  MOCK_METHOD1(SetFlutterCursor, void(HCURSOR cursor_name));
   MOCK_METHOD1(OnCursorRectUpdated, void(const Rect& rect));
   MOCK_METHOD0(OnResetImeComposing, void());
   MOCK_METHOD3(OnBitmapSurfaceUpdated,

--- a/shell/platform/windows/window_binding_handler.h
+++ b/shell/platform/windows/window_binding_handler.h
@@ -72,6 +72,9 @@ class WindowBindingHandler {
   // content. See mouse_cursor.dart for the values and meanings of cursor_name.
   virtual void UpdateFlutterCursor(const std::string& cursor_name) = 0;
 
+  // Sets the cursor directly from cursor
+  virtual void SetFlutterCursor(HCURSOR cursor) = 0;
+
   // Invoked when the cursor/composing rect has been updated in the framework.
   virtual void OnCursorRectUpdated(const Rect& rect) = 0;
 

--- a/shell/platform/windows/window_binding_handler.h
+++ b/shell/platform/windows/window_binding_handler.h
@@ -72,7 +72,7 @@ class WindowBindingHandler {
   // content. See mouse_cursor.dart for the values and meanings of cursor_name.
   virtual void UpdateFlutterCursor(const std::string& cursor_name) = 0;
 
-  // Sets the cursor directly from cursor
+  // Sets the cursor directly from a cursor handle.
   virtual void SetFlutterCursor(HCURSOR cursor) = 0;
 
   // Invoked when the cursor/composing rect has been updated in the framework.


### PR DESCRIPTION
This PR adds an additional interface to set custom cursor on windows, which fixes issues mentioned below.

Currently,  Customizing `MouseCursor` on windows is not working, the customed mouse will restore to arrow once it moves. See https://github.com/flutter/flutter/issues/31952#issuecomment-1056115014 
https://github.com/flutter/flutter/issues/99484
for details. Variable `current_cursor_` in `cursor handler` will not update when we set our custom cursors, and we cannot change this field to prevent the cursor from restoring due to lacking of interface.

The reason is that cursor handler on windows has no interface to change current cursor to custom cursor, only support setting windows self-contained icons.  

Changes:
- add new function handled by method channel of `SystemCursors.mousecursors`, which can change `current_cursor_`, make possible to handle custom cursor on windows correctly.

![Screenshot_20220914_183105](https://user-images.githubusercontent.com/39793325/190131253-8ee3d739-ec64-43b8-9ac3-70d507df34c3.png)

We have successfully tested this interface in https://github.com/Kingtous/rustdesk_flutter_custom_cursor/blob/8f3be4ac68b4fb20d05b8d30df4c13d8fd77f9c4/lib/flutter_custom_cursor.dart#L113, which works perfectly on windows.

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
