### PR TITLE
[lint] Update local variable names in fml (#36136)

### DIFF
--- a/fml/memory/task_runner_checker_unittest.cc
+++ b/fml/memory/task_runner_checker_unittest.cc
@@ -27,7 +27,7 @@ TEST(TaskRunnerCheckerTests, FailsTheCheckIfOnDifferentTaskRunner) {
   EXPECT_EQ(checker.RunsOnCreationTaskRunner(), true);
   fml::MessageLoop* loop = nullptr;
   fml::AutoResetWaitableEvent latch;
-  std::thread anotherThread([&]() {
+  std::thread another_thread([&]() {
     fml::MessageLoop::EnsureInitializedForCurrentThread();
     loop = &fml::MessageLoop::GetCurrent();
     loop->GetTaskRunner()->PostTask([&]() {
@@ -38,7 +38,7 @@ TEST(TaskRunnerCheckerTests, FailsTheCheckIfOnDifferentTaskRunner) {
   });
   latch.Wait();
   loop->Terminate();
-  anotherThread.join();
+  another_thread.join();
   EXPECT_EQ(checker.RunsOnCreationTaskRunner(), true);
 }
 
@@ -56,7 +56,7 @@ TEST(TaskRunnerCheckerTests, RunsOnDifferentThreadsReturnsFalse) {
   fml::MessageLoop& loop1 = fml::MessageLoop::GetCurrent();
   TaskQueueId a = loop1.GetTaskRunner()->GetTaskQueueId();
   fml::AutoResetWaitableEvent latch;
-  std::thread anotherThread([&]() {
+  std::thread another_thread([&]() {
     fml::MessageLoop::EnsureInitializedForCurrentThread();
     fml::MessageLoop& loop2 = fml::MessageLoop::GetCurrent();
     TaskQueueId b = loop2.GetTaskRunner()->GetTaskQueueId();
@@ -64,7 +64,7 @@ TEST(TaskRunnerCheckerTests, RunsOnDifferentThreadsReturnsFalse) {
     latch.Signal();
   });
   latch.Wait();
-  anotherThread.join();
+  another_thread.join();
 }
 
 TEST(TaskRunnerCheckerTests, MergedTaskRunnersRunsOnTheSameThread) {
@@ -92,21 +92,21 @@ TEST(TaskRunnerCheckerTests, MergedTaskRunnersRunsOnTheSameThread) {
   latch2.Wait();
   fml::TaskQueueId qid1 = loop1->GetTaskRunner()->GetTaskQueueId();
   fml::TaskQueueId qid2 = loop2->GetTaskRunner()->GetTaskQueueId();
-  const auto raster_thread_merger_ =
+  const auto raster_thread_merger =
       fml::MakeRefCounted<fml::RasterThreadMerger>(qid1, qid2);
   const size_t kNumFramesMerged = 5;
 
-  raster_thread_merger_->MergeWithLease(kNumFramesMerged);
+  raster_thread_merger->MergeWithLease(kNumFramesMerged);
 
   // merged, running on the same thread
   EXPECT_EQ(TaskRunnerChecker::RunsOnTheSameThread(qid1, qid2), true);
 
   for (size_t i = 0; i < kNumFramesMerged; i++) {
-    ASSERT_TRUE(raster_thread_merger_->IsMerged());
-    raster_thread_merger_->DecrementLease();
+    ASSERT_TRUE(raster_thread_merger->IsMerged());
+    raster_thread_merger->DecrementLease();
   }
 
-  ASSERT_FALSE(raster_thread_merger_->IsMerged());
+  ASSERT_FALSE(raster_thread_merger->IsMerged());
 
   // un-merged, not running on the same thread
   EXPECT_EQ(TaskRunnerChecker::RunsOnTheSameThread(qid1, qid2), false);

--- a/fml/memory/weak_ptr_unittest.cc
+++ b/fml/memory/weak_ptr_unittest.cc
@@ -214,21 +214,21 @@ TEST(TaskRunnerAffineWeakPtrTest, ShouldNotCrashIfRunningOnTheSameTaskRunner) {
   latch2.Wait();
   fml::TaskQueueId qid1 = loop1->GetTaskRunner()->GetTaskQueueId();
   fml::TaskQueueId qid2 = loop2->GetTaskRunner()->GetTaskQueueId();
-  const auto raster_thread_merger_ =
+  const auto raster_thread_merger =
       fml::MakeRefCounted<fml::RasterThreadMerger>(qid1, qid2);
   const size_t kNumFramesMerged = 5;
 
-  raster_thread_merger_->MergeWithLease(kNumFramesMerged);
+  raster_thread_merger->MergeWithLease(kNumFramesMerged);
 
   loop2_task_start_latch.Signal();
   loop2_task_finish_latch.Wait();
 
   for (size_t i = 0; i < kNumFramesMerged; i++) {
-    ASSERT_TRUE(raster_thread_merger_->IsMerged());
-    raster_thread_merger_->DecrementLease();
+    ASSERT_TRUE(raster_thread_merger->IsMerged());
+    raster_thread_merger->DecrementLease();
   }
 
-  ASSERT_FALSE(raster_thread_merger_->IsMerged());
+  ASSERT_FALSE(raster_thread_merger->IsMerged());
   loop2->Terminate();
 
   term1.Signal();

--- a/fml/synchronization/sync_switch_unittest.cc
+++ b/fml/synchronization/sync_switch_unittest.cc
@@ -11,49 +11,49 @@
 using fml::SyncSwitch;
 
 TEST(SyncSwitchTest, Basic) {
-  SyncSwitch syncSwitch;
-  bool switchValue = false;
-  syncSwitch.Execute(SyncSwitch::Handlers()
-                         .SetIfTrue([&] { switchValue = true; })
-                         .SetIfFalse([&] { switchValue = false; }));
-  EXPECT_FALSE(switchValue);
-  syncSwitch.SetSwitch(true);
-  syncSwitch.Execute(SyncSwitch::Handlers()
-                         .SetIfTrue([&] { switchValue = true; })
-                         .SetIfFalse([&] { switchValue = false; }));
-  EXPECT_TRUE(switchValue);
+  SyncSwitch sync_switch;
+  bool switch_value = false;
+  sync_switch.Execute(SyncSwitch::Handlers()
+                          .SetIfTrue([&] { switch_value = true; })
+                          .SetIfFalse([&] { switch_value = false; }));
+  EXPECT_FALSE(switch_value);
+  sync_switch.SetSwitch(true);
+  sync_switch.Execute(SyncSwitch::Handlers()
+                          .SetIfTrue([&] { switch_value = true; })
+                          .SetIfFalse([&] { switch_value = false; }));
+  EXPECT_TRUE(switch_value);
 }
 
 TEST(SyncSwitchTest, NoopIfUndefined) {
-  SyncSwitch syncSwitch;
-  bool switchValue = false;
-  syncSwitch.Execute(SyncSwitch::Handlers());
-  EXPECT_FALSE(switchValue);
+  SyncSwitch sync_switch;
+  bool switch_value = false;
+  sync_switch.Execute(SyncSwitch::Handlers());
+  EXPECT_FALSE(switch_value);
 }
 
 TEST(SyncSwitchTest, SharedLock) {
-  SyncSwitch syncSwitch;
-  syncSwitch.SetSwitch(true);
-  bool switchValue1 = false;
-  bool switchValue2 = false;
+  SyncSwitch sync_switch;
+  sync_switch.SetSwitch(true);
+  bool switch_value1 = false;
+  bool switch_value2 = false;
 
   std::thread thread1([&] {
-    syncSwitch.Execute(
+    sync_switch.Execute(
         SyncSwitch::Handlers()
             .SetIfTrue([&] {
-              switchValue1 = true;
+              switch_value1 = true;
 
               std::thread thread2([&]() {
-                syncSwitch.Execute(
+                sync_switch.Execute(
                     SyncSwitch::Handlers()
-                        .SetIfTrue([&] { switchValue2 = true; })
-                        .SetIfFalse([&] { switchValue2 = false; }));
+                        .SetIfTrue([&] { switch_value2 = true; })
+                        .SetIfFalse([&] { switch_value2 = false; }));
               });
               thread2.join();
             })
-            .SetIfFalse([&] { switchValue1 = false; }));
+            .SetIfFalse([&] { switch_value1 = false; }));
   });
   thread1.join();
-  EXPECT_TRUE(switchValue1);
-  EXPECT_TRUE(switchValue2);
+  EXPECT_TRUE(switch_value1);
+  EXPECT_TRUE(switch_value2);
 }

--- a/fml/trace_event.cc
+++ b/fml/trace_event.cc
@@ -65,8 +65,8 @@ void TraceSetTimelineMicrosSource(TimelineMicrosSource source) {
 }
 
 size_t TraceNonce() {
-  static std::atomic_size_t gLastItem;
-  return ++gLastItem;
+  static std::atomic_size_t last_item;
+  return ++last_item;
 }
 
 void TraceTimelineEvent(TraceArg category_group,


### PR DESCRIPTION
This updates local variable names to use clang `lower_case` style in the fml directory. This is one of several patches to update our variable names to a consistent style before enabling enforcement in our clang-tidy rules.

This is a formatting-only change with no intended semantic change.


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
