### PR TITLE
[fuchsia] Enable dart null-safety for Fuchsia .dart files

### DIFF
--- a/shell/platform/fuchsia/dart/compiler.dart
+++ b/shell/platform/fuchsia/dart/compiler.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.9
-
 import 'dart:async';
 import 'dart:io';
 

--- a/shell/platform/fuchsia/runtime/dart/profiler_symbols/dart_profiler_symbols.dart
+++ b/shell/platform/fuchsia/runtime/dart/profiler_symbols/dart_profiler_symbols.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.9
-
 // On Fuchsia, in lieu of the ELF dynamic symbol table consumed through dladdr,
 // the Dart VM profiler consumes symbols produced by this tool, which have the
 // format
@@ -42,11 +40,11 @@ Options:
 ${parser.usage};
 """;
 
-  String buildIdDir;
-  String buildIdScript;
-  String nm;
-  String binary;
-  String output;
+  String? buildIdDir;
+  String? buildIdScript;
+  String? nm;
+  String? binary;
+  String? output;
 
   try {
     final options = parser.parse(args);
@@ -82,9 +80,11 @@ class Symbol {
   int offset;
   int size;
   String name;
+
+  Symbol({required this.offset, required this.size, required this.name});
 }
 
-Future<void> run(String buildIdDir, String buildIdScript, String nm,
+Future<void> run(String? buildIdDir, String? buildIdScript, String nm,
   String binary, String output) async {
   final unstrippedFile = binary;
   final args = ["--demangle", "--numeric-sort", "--print-size", unstrippedFile];
@@ -95,7 +95,7 @@ Future<void> run(String buildIdDir, String buildIdScript, String nm,
     throw "Command failed: $nm $args";
   }
 
-  var symbols = new List();
+  var symbols = [];
 
   var regex = new RegExp("([0-9A-Za-z]+) ([0-9A-Za-z]+) (t|T|w|W) (.*)");
   for (final line in result.stdout.split("\n")) {
@@ -104,12 +104,10 @@ Future<void> run(String buildIdDir, String buildIdScript, String nm,
       continue; // Ignore non-text symbols.
     }
 
-    final symbol = new Symbol();
-
     // Note that capture groups start at 1.
-    symbol.offset = int.parse(match[1], radix: 16);
-    symbol.size = int.parse(match[2], radix: 16);
-    symbol.name = match[4].split("(")[0];
+    final symbol = new Symbol(offset: int.parse(match[1]!, radix: 16),
+                              size: int.parse(match[2]!, radix: 16),
+                              name: match[4]!.split("(")[0]);
 
     if (symbol.name.startsWith("\$")) {
       continue; // Ignore compiler/assembler temps.

--- a/shell/platform/fuchsia/runtime/dart/profiler_symbols/pubspec.yaml
+++ b/shell/platform/fuchsia/runtime/dart/profiler_symbols/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: profiler_symbols
 environment:
-  sdk: '>=2.11.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 version: 0
 description: Extracts a minimal symbols table for the Dart VM profiler
 author: Dart Team <misc@dartlang.org>


### PR DESCRIPTION
Enables null safety in compiler.dart and dart_profiler_symbols.dart
Contributes to [#110020](https://github.com/flutter/flutter/is)

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
