### PR TITLE
Fix create macos framework.

### DIFF
--- a/sky/tools/create_macos_framework.py
+++ b/sky/tools/create_macos_framework.py
@@ -87,15 +87,19 @@ def main():
   )
 
   # Create the arm64/x64 fat framework.
-  result = subprocess.run([
+  print('Command: %s ' % (['lipo', arm64_dylib, x64_dylib, '-create', '-output', fat_framework_binary]) )
+  subprocess.check_call([
       'lipo', arm64_dylib, x64_dylib, '-create', '-output', fat_framework_binary
   ])
-  if result.returncode != 0:
-    print(
-        'Error processing command with stdout[%s] and stderr[%s]' %
-        (result.stdout, result.stderr)
-    )
-    return 1
+  #result = subprocess.run([
+  #    'lipo', arm64_dylib, x64_dylib, '-create', '-output', fat_framework_binary
+  #])
+  #if result.returncode != 0:
+  #  print(
+  #      'Error processing command with stdout[%s] and stderr[%s]' %
+  #      (result.stdout, result.stderr)
+  #  )
+  #  return 1
   process_framework(dst, args, fat_framework, fat_framework_binary)
 
 

--- a/sky/tools/create_macos_framework.py
+++ b/sky/tools/create_macos_framework.py
@@ -104,15 +104,15 @@ def regenerate_symlinks(fat_framework):
     return
   shutil.rmtree(os.path.join(fat_framework, 'FlutterMacOS'), True)
   shutil.rmtree(os.path.join(fat_framework, 'Headers'), True)
-  shutil.rmtree(os.path.join(fat_framework, 'Modukles'), True)
+  shutil.rmtree(os.path.join(fat_framework, 'Modules'), True)
   shutil.rmtree(os.path.join(fat_framework, 'Resources'), True)
   current_version_path = os.path.join(fat_framework, 'Versions', 'Current')
   shutil.rmtree(current_version_path, True)
   os.symlink('A', current_version_path)
-  os.symlink('FlutterMacOS', os.path.join(current_version_path, 'FlutterMacOS'))
-  os.symlink('Headers', os.path.join(current_version_path, 'Headers'))
-  os.symlink('Modules', os.path.join(current_version_path, 'Modules'))
-  os.symlink('Resources', os.path.join(current_version_path, 'Resources'))
+  os.symlink('FlutterMacOS', os.path.join(fat_framework, 'FlutterMacOS'))
+  os.symlink('Headers', os.path.join(fat_framework, 'Headers'))
+  os.symlink('Modules', os.path.join(fat_framework, 'Modules'))
+  os.symlink('Resources', os.path.join(fat_framework, 'Resources'))
 
 
 def process_framework(dst, args, fat_framework, fat_framework_binary):

--- a/sky/tools/create_macos_framework.py
+++ b/sky/tools/create_macos_framework.py
@@ -108,11 +108,11 @@ def regenerate_symlinks(fat_framework):
   shutil.rmtree(os.path.join(fat_framework, 'Resources'), True)
   current_version_path = os.path.join(fat_framework, 'Versions', 'Current')
   shutil.rmtree(current_version_path, True)
+  os.symlink('A', current_version_path)
   os.symlink('FlutterMacOS', os.path.join(current_version_path, 'FlutterMacOS'))
   os.symlink('Headers', os.path.join(current_version_path, 'Headers'))
   os.symlink('Modules', os.path.join(current_version_path, 'Modules'))
   os.symlink('Resources', os.path.join(current_version_path, 'Resources'))
-  os.symlink('A', current_version_path)
 
 
 def process_framework(dst, args, fat_framework, fat_framework_binary):

--- a/sky/tools/create_macos_framework.py
+++ b/sky/tools/create_macos_framework.py
@@ -87,19 +87,9 @@ def main():
   )
 
   # Create the arm64/x64 fat framework.
-  print('Command: %s ' % (['lipo', arm64_dylib, x64_dylib, '-create', '-output', fat_framework_binary]) )
   subprocess.check_call([
       'lipo', arm64_dylib, x64_dylib, '-create', '-output', fat_framework_binary
   ])
-  #result = subprocess.run([
-  #    'lipo', arm64_dylib, x64_dylib, '-create', '-output', fat_framework_binary
-  #])
-  #if result.returncode != 0:
-  #  print(
-  #      'Error processing command with stdout[%s] and stderr[%s]' %
-  #      (result.stdout, result.stderr)
-  #  )
-  #  return 1
   process_framework(dst, args, fat_framework, fat_framework_binary)
 
 

--- a/sky/tools/create_macos_framework.py
+++ b/sky/tools/create_macos_framework.py
@@ -102,7 +102,7 @@ def regenerate_symlinks(fat_framework):
   """
   if os.path.islink(os.path.join(fat_framework, 'FlutterMacOS')):
     return
-  shutil.rmtree(os.path.join(fat_framework, 'FlutterMacOS'), True)
+  os.remove(os.path.join(fat_framework, 'FlutterMacOS'))
   shutil.rmtree(os.path.join(fat_framework, 'Headers'), True)
   shutil.rmtree(os.path.join(fat_framework, 'Modules'), True)
   shutil.rmtree(os.path.join(fat_framework, 'Resources'), True)


### PR DESCRIPTION
Subprocess.run does not work properly with the python version installed in the bots.

Bug: https://github.com/flutter/flutter/issues/81855

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
