### PR TITLE
[web] Compile tests with sound null safety

### DIFF
--- a/lib/web_ui/dev/steps/compile_tests_step.dart
+++ b/lib/web_ui/dev/steps/compile_tests_step.dart
@@ -285,7 +285,6 @@ Future<bool> compileUnitTest(FilePath input, {required bool forCanvasKit, requir
     '--no-minify',
     '--disable-inlining',
     '--enable-asserts',
-    '--no-sound-null-safety',
 
     // We do not want to auto-select a renderer in tests. As of today, tests
     // are designed to run in one specific mode. So instead, we specify the


### PR DESCRIPTION
For some reason, we still compile our tests with the `--no-sound-null-safety` flag that disables sound null safety. This flag was added in https://github.com/flutter/engine/pull/20390 in 2020 (IIRC, that was before we fully migrated to null safety, so the flag made sense).

Now that all of our code and tests are migrated to null safety, let's remove this flag and let Dart compile our tests with sound null safety.

This PR gets rid of the warning:
```
Info: Compiling without sound null safety ⚠️
Dart 3 will only support sound null safety, see https://dart.dev/null-safety
```