### PR TITLE
Exclude dart/benchmarks*/ folders from license check

### DIFF
--- a/ci/licenses_golden/licenses_third_party
+++ b/ci/licenses_golden/licenses_third_party
@@ -10165,84 +10165,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ====================================================================================================
 LIBRARY: dart
-LIBRARY: double-conversion
-LIBRARY: icu
-ORIGIN: ../../../third_party/dart/benchmarks/Richards/dart/Richards.dart
-TYPE: LicenseType.bsd
-FILE: ../../../third_party/dart/benchmarks/Richards/dart/Richards.dart
-FILE: ../../../third_party/dart/benchmarks/Richards/dart2/Richards.dart
-FILE: ../../../third_party/dart/benchmarks/Richards/javascript/Richards.js
-FILE: ../../../third_party/dart/runtime/third_party/double-conversion/src/cached-powers.cc
-FILE: ../../../third_party/icu/source/i18n/double-conversion-cached-powers.cpp
-----------------------------------------------------------------------------------------------------
-Copyright 2006-2008 the V8 project authors. All rights reserved.
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      disclaimer in the documentation and/or other materials provided
-      with the distribution.
-    * Neither the name of Google Inc. nor the names of its
-      contributors may be used to endorse or promote products derived
-      from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-====================================================================================================
-
-====================================================================================================
-LIBRARY: dart
 ORIGIN: ../../../third_party/dart/LICENSE
 TYPE: LicenseType.bsd
 FILE: ../../../third_party/dart/.gitconfig
 FILE: ../../../third_party/dart/.style.yapf
 FILE: ../../../third_party/dart/.vpython
 FILE: ../../../third_party/dart/PATENT_GRANT
-FILE: ../../../third_party/dart/benchmarks/IsolateJson/dart/sample.json
-FILE: ../../../third_party/dart/benchmarks/IsolateJson/dart2/sample.json
-FILE: ../../../third_party/dart/benchmarks/IsolateSpawn/dart/helloworld.dart
-FILE: ../../../third_party/dart/benchmarks/IsolateSpawn/dart2/helloworld.dart
-FILE: ../../../third_party/dart/benchmarks/IsolateSpawnMemory/dart/helloworld.dart
-FILE: ../../../third_party/dart/benchmarks/IsolateSpawnMemory/dart2/helloworld.dart
-FILE: ../../../third_party/dart/benchmarks/SoundSplayTreeSieve/dart/iterable.dart
-FILE: ../../../third_party/dart/benchmarks/SoundSplayTreeSieve/dart2/iterable.dart
-FILE: ../../../third_party/dart/benchmarks/Utf8Decode/dart/datext_latin1_10k.dart
-FILE: ../../../third_party/dart/benchmarks/Utf8Decode/dart/entext_ascii_10k.dart
-FILE: ../../../third_party/dart/benchmarks/Utf8Decode/dart/netext_3_10k.dart
-FILE: ../../../third_party/dart/benchmarks/Utf8Decode/dart/rutext_2_10k.dart
-FILE: ../../../third_party/dart/benchmarks/Utf8Decode/dart/sktext_10k.dart
-FILE: ../../../third_party/dart/benchmarks/Utf8Decode/dart/zhtext_10k.dart
-FILE: ../../../third_party/dart/benchmarks/Utf8Decode/dart2/datext_latin1_10k.dart
-FILE: ../../../third_party/dart/benchmarks/Utf8Decode/dart2/entext_ascii_10k.dart
-FILE: ../../../third_party/dart/benchmarks/Utf8Decode/dart2/netext_3_10k.dart
-FILE: ../../../third_party/dart/benchmarks/Utf8Decode/dart2/rutext_2_10k.dart
-FILE: ../../../third_party/dart/benchmarks/Utf8Decode/dart2/sktext_10k.dart
-FILE: ../../../third_party/dart/benchmarks/Utf8Decode/dart2/zhtext_10k.dart
-FILE: ../../../third_party/dart/benchmarks/Utf8Encode/dart/datext_latin1_10k.dart
-FILE: ../../../third_party/dart/benchmarks/Utf8Encode/dart/entext_ascii_10k.dart
-FILE: ../../../third_party/dart/benchmarks/Utf8Encode/dart/netext_3_10k.dart
-FILE: ../../../third_party/dart/benchmarks/Utf8Encode/dart/rutext_2_10k.dart
-FILE: ../../../third_party/dart/benchmarks/Utf8Encode/dart/sktext_10k.dart
-FILE: ../../../third_party/dart/benchmarks/Utf8Encode/dart/zhtext_10k.dart
-FILE: ../../../third_party/dart/benchmarks/Utf8Encode/dart2/datext_latin1_10k.dart
-FILE: ../../../third_party/dart/benchmarks/Utf8Encode/dart2/entext_ascii_10k.dart
-FILE: ../../../third_party/dart/benchmarks/Utf8Encode/dart2/netext_3_10k.dart
-FILE: ../../../third_party/dart/benchmarks/Utf8Encode/dart2/rutext_2_10k.dart
-FILE: ../../../third_party/dart/benchmarks/Utf8Encode/dart2/sktext_10k.dart
-FILE: ../../../third_party/dart/benchmarks/Utf8Encode/dart2/zhtext_10k.dart
 FILE: ../../../third_party/dart/runtime/.clang-tidy
 FILE: ../../../third_party/dart/runtime/CPPLINT.cfg
 FILE: ../../../third_party/dart/runtime/bin/ffi_test/clobber_arm.S
@@ -10711,359 +10639,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ====================================================================================================
 LIBRARY: dart
-ORIGIN: ../../../third_party/dart/benchmarks/AsyncLiveVars/dart/AsyncLiveVars.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/abstract_socket_test.cc + ../../../third_party/dart/LICENSE
 TYPE: LicenseType.bsd
-FILE: ../../../third_party/dart/benchmarks/AsyncLiveVars/dart/AsyncLiveVars.dart
-FILE: ../../../third_party/dart/benchmarks/AsyncLiveVars/dart2/AsyncLiveVars.dart
-FILE: ../../../third_party/dart/benchmarks/InstantiateTypeArgs/dart/InstantiateTypeArgs.dart
-FILE: ../../../third_party/dart/benchmarks/InstantiateTypeArgs/dart2/InstantiateTypeArgs.dart
-FILE: ../../../third_party/dart/benchmarks/InstantiateTypeArgs/generate.dart
-FILE: ../../../third_party/dart/benchmarks/IsolateBaseOverhead/dart/IsolateBaseOverhead.dart
-FILE: ../../../third_party/dart/benchmarks/IsolateBaseOverhead/dart2/IsolateBaseOverhead.dart
-FILE: ../../../third_party/dart/benchmarks/IsolateSendExitLatency/dart/IsolateSendExitLatency.dart
-FILE: ../../../third_party/dart/benchmarks/IsolateSendExitLatency/dart2/IsolateSendExitLatency.dart
-FILE: ../../../third_party/dart/benchmarks/Iterators/dart/Iterators.dart
-FILE: ../../../third_party/dart/benchmarks/Iterators/dart/data.dart
-FILE: ../../../third_party/dart/benchmarks/Iterators/dart2/Iterators.dart
-FILE: ../../../third_party/dart/benchmarks/Startup/dart/Startup.dart
-FILE: ../../../third_party/dart/benchmarks/Startup/dart2/Startup.dart
-FILE: ../../../third_party/dart/benchmarks/TypeLiteral/dart/TypeLiteral.dart
-FILE: ../../../third_party/dart/runtime/bin/snapshot_utils_test.cc
-FILE: ../../../third_party/dart/runtime/bin/test_utils.cc
-FILE: ../../../third_party/dart/runtime/bin/test_utils.h
-FILE: ../../../third_party/dart/runtime/bin/thread_absl.cc
-FILE: ../../../third_party/dart/runtime/bin/thread_absl.h
-FILE: ../../../third_party/dart/runtime/platform/mach_o.h
-FILE: ../../../third_party/dart/runtime/platform/pe.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/backend/il_serializer.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/backend/il_serializer.h
-FILE: ../../../third_party/dart/runtime/vm/heap/gc_shared.cc
-FILE: ../../../third_party/dart/runtime/vm/heap/gc_shared.h
-FILE: ../../../third_party/dart/runtime/vm/instructions.cc
-FILE: ../../../third_party/dart/runtime/vm/malloc_hooks_riscv.cc
-FILE: ../../../third_party/dart/runtime/vm/os_thread_absl.cc
-FILE: ../../../third_party/dart/runtime/vm/os_thread_absl.h
-FILE: ../../../third_party/dart/runtime/vm/simulator_x64.cc
-FILE: ../../../third_party/dart/runtime/vm/simulator_x64.h
-FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/js_names.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/runtime_metrics.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/js_shared/lib/js_util_patch.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/js_shared/lib/synced/embedded_names.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_native_finalizer_patch.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/finalizer_patch.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/hash_factories.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/async_patch.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/bool.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/class_id.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/core_patch.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/date_patch.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/developer.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/double.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/errors_patch.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/expando_patch.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/function.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/growable_list.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/hash_factories.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/identical_patch.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/int.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/internal_patch.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/isolate_patch.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/js_helper.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/js_patch.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/js_util_patch.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/list.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/math_patch.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/object_patch.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/patch.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/print_patch.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/regexp_helper.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/regexp_patch.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/stack_trace_patch.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/stopwatch_patch.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/string_buffer_patch.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/string_patch.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/symbol_patch.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/timer_patch.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/type.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/uri_patch.dart
-FILE: ../../../third_party/dart/sdk/lib/ffi/c_type.dart
-FILE: ../../../third_party/dart/sdk/lib/ffi/native_finalizer.dart
-FILE: ../../../third_party/dart/sdk/lib/js/js_wasm.dart
-FILE: ../../../third_party/dart/sdk/lib/js_util/js_util_wasm.dart
-FILE: ../../../third_party/dart/sdk/lib/wasm/wasm_types.dart
-----------------------------------------------------------------------------------------------------
-Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
-for details. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      disclaimer in the documentation and/or other materials provided
-      with the distribution.
-    * Neither the name of Google LLC nor the names of its
-      contributors may be used to endorse or promote products derived
-      from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-====================================================================================================
-
-====================================================================================================
-LIBRARY: dart
-ORIGIN: ../../../third_party/dart/benchmarks/BigIntParsePrint/dart/BigIntParsePrint.dart + ../../../third_party/dart/LICENSE
-TYPE: LicenseType.bsd
-FILE: ../../../third_party/dart/benchmarks/BigIntParsePrint/dart/BigIntParsePrint.dart
-FILE: ../../../third_party/dart/benchmarks/BigIntParsePrint/dart/native_version.dart
-FILE: ../../../third_party/dart/benchmarks/BigIntParsePrint/dart/native_version_dummy.dart
-FILE: ../../../third_party/dart/benchmarks/BigIntParsePrint/dart/native_version_javascript.dart
-FILE: ../../../third_party/dart/benchmarks/BigIntParsePrint/dart2/BigIntParsePrint.dart
-FILE: ../../../third_party/dart/benchmarks/BigIntParsePrint/dart2/native_version.dart
-FILE: ../../../third_party/dart/benchmarks/BigIntParsePrint/dart2/native_version_dummy.dart
-FILE: ../../../third_party/dart/benchmarks/BigIntParsePrint/dart2/native_version_javascript.dart
-FILE: ../../../third_party/dart/benchmarks/Calls/dart/Calls.dart
-FILE: ../../../third_party/dart/benchmarks/Calls/dart2/Calls.dart
-FILE: ../../../third_party/dart/benchmarks/Example/dart/Example.dart
-FILE: ../../../third_party/dart/benchmarks/Example/dart2/Example.dart
-FILE: ../../../third_party/dart/benchmarks/FfiBoringssl/dart/FfiBoringssl.dart
-FILE: ../../../third_party/dart/benchmarks/FfiBoringssl/dart/digest.dart
-FILE: ../../../third_party/dart/benchmarks/FfiBoringssl/dart/dlopen_helper.dart
-FILE: ../../../third_party/dart/benchmarks/FfiBoringssl/dart/types.dart
-FILE: ../../../third_party/dart/benchmarks/FfiBoringssl/dart2/FfiBoringssl.dart
-FILE: ../../../third_party/dart/benchmarks/FfiBoringssl/dart2/digest.dart
-FILE: ../../../third_party/dart/benchmarks/FfiBoringssl/dart2/dlopen_helper.dart
-FILE: ../../../third_party/dart/benchmarks/FfiBoringssl/dart2/types.dart
-FILE: ../../../third_party/dart/benchmarks/FfiCall/dart/FfiCall.dart
-FILE: ../../../third_party/dart/benchmarks/FfiCall/dart/dlopen_helper.dart
-FILE: ../../../third_party/dart/benchmarks/FfiCall/dart2/FfiCall.dart
-FILE: ../../../third_party/dart/benchmarks/FfiCall/dart2/dlopen_helper.dart
-FILE: ../../../third_party/dart/benchmarks/FfiCall/native/native_functions.c
-FILE: ../../../third_party/dart/benchmarks/FfiMemory/dart/FfiMemory.dart
-FILE: ../../../third_party/dart/benchmarks/FfiMemory/dart2/FfiMemory.dart
-FILE: ../../../third_party/dart/benchmarks/FfiStruct/dart/FfiStruct.dart
-FILE: ../../../third_party/dart/benchmarks/FfiStruct/dart2/FfiStruct.dart
-FILE: ../../../third_party/dart/benchmarks/Isolate/dart/Isolate.dart
-FILE: ../../../third_party/dart/benchmarks/Isolate/dart2/Isolate.dart
-FILE: ../../../third_party/dart/benchmarks/IsolateJson/dart/IsolateJson.dart
-FILE: ../../../third_party/dart/benchmarks/IsolateJson/dart2/IsolateJson.dart
-FILE: ../../../third_party/dart/benchmarks/IsolateSpawn/dart/IsolateSpawn.dart
-FILE: ../../../third_party/dart/benchmarks/IsolateSpawn/dart2/IsolateSpawn.dart
-FILE: ../../../third_party/dart/benchmarks/IsolateSpawnMemory/dart/IsolateSpawnMemory.dart
-FILE: ../../../third_party/dart/benchmarks/IsolateSpawnMemory/dart2/IsolateSpawnMemory.dart
-FILE: ../../../third_party/dart/benchmarks/SoundSplayTreeSieve/dart/SoundSplayTreeSieve.dart
-FILE: ../../../third_party/dart/benchmarks/SoundSplayTreeSieve/dart/sound_splay_tree.dart
-FILE: ../../../third_party/dart/benchmarks/SoundSplayTreeSieve/dart2/SoundSplayTreeSieve.dart
-FILE: ../../../third_party/dart/benchmarks/SoundSplayTreeSieve/dart2/sound_splay_tree.dart
-FILE: ../../../third_party/dart/runtime/bin/elf_loader.cc
-FILE: ../../../third_party/dart/runtime/bin/elf_loader.h
-FILE: ../../../third_party/dart/runtime/bin/entrypoints_verification_test.cc
-FILE: ../../../third_party/dart/runtime/bin/ffi_test/ffi_test_dynamic_library.cc
-FILE: ../../../third_party/dart/runtime/bin/ffi_test/ffi_test_functions.cc
-FILE: ../../../third_party/dart/runtime/bin/ffi_test/ffi_test_functions_vmspecific.cc
-FILE: ../../../third_party/dart/runtime/bin/ifaddrs-android.cc
-FILE: ../../../third_party/dart/runtime/bin/ifaddrs-android.h
-FILE: ../../../third_party/dart/runtime/bin/namespace_fuchsia.h
-FILE: ../../../third_party/dart/runtime/bin/socket_base_android.cc
-FILE: ../../../third_party/dart/runtime/lib/ffi.cc
-FILE: ../../../third_party/dart/runtime/lib/ffi_dynamic_library.cc
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/tree_map.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/isolate_group.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/isolate_group.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/isolate_group.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/timeline_base.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/tree_map.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/isolate_group.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/isolate_group.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/isolate_group.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/timeline_base.dart
-FILE: ../../../third_party/dart/runtime/platform/elf.h
-FILE: ../../../third_party/dart/runtime/platform/thread_sanitizer.h
-FILE: ../../../third_party/dart/runtime/tools/dartfuzz/dartfuzz_api_table.dart
-FILE: ../../../third_party/dart/runtime/tools/dartfuzz/dartfuzz_ffi_api.dart
-FILE: ../../../third_party/dart/runtime/tools/dartfuzz/dartfuzz_type_table.dart
-FILE: ../../../third_party/dart/runtime/tools/dartfuzz/gen_api_table.dart
-FILE: ../../../third_party/dart/runtime/tools/dartfuzz/gen_type_table.dart
-FILE: ../../../third_party/dart/runtime/tools/dartfuzz/gen_util.dart
-FILE: ../../../third_party/dart/runtime/tools/ffi/sdk_lib_ffi_generator.dart
-FILE: ../../../third_party/dart/runtime/tools/graphexplorer/graphexplorer.html
-FILE: ../../../third_party/dart/runtime/tools/graphexplorer/graphexplorer.js
-FILE: ../../../third_party/dart/runtime/tools/run_clang_tidy.dart
-FILE: ../../../third_party/dart/runtime/vm/bss_relocs.cc
-FILE: ../../../third_party/dart/runtime/vm/bss_relocs.h
-FILE: ../../../third_party/dart/runtime/vm/catch_entry_moves_test.cc
-FILE: ../../../third_party/dart/runtime/vm/class_id.h
-FILE: ../../../third_party/dart/runtime/vm/code_comments.cc
-FILE: ../../../third_party/dart/runtime/vm/code_comments.h
-FILE: ../../../third_party/dart/runtime/vm/code_entry_kind.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/asm_intrinsifier.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/asm_intrinsifier.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/asm_intrinsifier_arm.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/asm_intrinsifier_arm64.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/asm_intrinsifier_ia32.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/asm_intrinsifier_x64.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/backend/bce_test.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/backend/block_builder.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/backend/evaluator.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/backend/evaluator.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/backend/flow_graph_checker.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/backend/flow_graph_checker.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/backend/il_test_helper.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/backend/il_test_helper.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/backend/inliner_test.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/backend/slot_test.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/backend/type_propagator_test.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/backend/typed_data_aot_test.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/backend/yield_position_test.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/graph_intrinsifier.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/graph_intrinsifier.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/offsets_extractor.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/recognized_methods_list.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/relocation.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/runtime_api.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/runtime_api.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/runtime_offsets_extracted.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/runtime_offsets_list.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/stub_code_compiler.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/stub_code_compiler_arm.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/stub_code_compiler_arm64.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/stub_code_compiler_ia32.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/stub_code_compiler_x64.cc
-FILE: ../../../third_party/dart/runtime/vm/constants_arm.cc
-FILE: ../../../third_party/dart/runtime/vm/constants_arm64.cc
-FILE: ../../../third_party/dart/runtime/vm/constants_ia32.cc
-FILE: ../../../third_party/dart/runtime/vm/constants_x64.cc
-FILE: ../../../third_party/dart/runtime/vm/elf.cc
-FILE: ../../../third_party/dart/runtime/vm/elf.h
-FILE: ../../../third_party/dart/runtime/vm/ffi_callback_trampolines.cc
-FILE: ../../../third_party/dart/runtime/vm/ffi_callback_trampolines.h
-FILE: ../../../third_party/dart/runtime/vm/frame_layout.h
-FILE: ../../../third_party/dart/runtime/vm/intrusive_dlist.h
-FILE: ../../../third_party/dart/runtime/vm/intrusive_dlist_test.cc
-FILE: ../../../third_party/dart/runtime/vm/libfuzzer/dart_libfuzzer.cc
-FILE: ../../../third_party/dart/runtime/vm/longjump.h
-FILE: ../../../third_party/dart/runtime/vm/pointer_tagging.h
-FILE: ../../../third_party/dart/runtime/vm/splay-tree.h
-FILE: ../../../third_party/dart/runtime/vm/static_type_exactness_state.h
-FILE: ../../../third_party/dart/runtime/vm/stub_code_list.h
-FILE: ../../../third_party/dart/runtime/vm/thread_stack_resource.cc
-FILE: ../../../third_party/dart/runtime/vm/thread_stack_resource.h
-FILE: ../../../third_party/dart/runtime/vm/thread_state.cc
-FILE: ../../../third_party/dart/runtime/vm/thread_state.h
-FILE: ../../../third_party/dart/samples/ffi/coordinate.dart
-FILE: ../../../third_party/dart/samples/ffi/dylib_utils.dart
-FILE: ../../../third_party/dart/samples/ffi/resource_management/arena_isolate_shutdown_sample.dart
-FILE: ../../../third_party/dart/samples/ffi/resource_management/arena_sample.dart
-FILE: ../../../third_party/dart/samples/ffi/resource_management/arena_zoned_sample.dart
-FILE: ../../../third_party/dart/samples/ffi/resource_management/resource_management_test.dart
-FILE: ../../../third_party/dart/samples/ffi/resource_management/unmanaged_sample.dart
-FILE: ../../../third_party/dart/samples/ffi/sample_ffi_bitfield.dart
-FILE: ../../../third_party/dart/samples/ffi/sample_ffi_data.dart
-FILE: ../../../third_party/dart/samples/ffi/sample_ffi_dynamic_library.dart
-FILE: ../../../third_party/dart/samples/ffi/sample_ffi_functions.dart
-FILE: ../../../third_party/dart/samples/ffi/sample_ffi_functions_callbacks.dart
-FILE: ../../../third_party/dart/samples/ffi/sample_ffi_functions_structs.dart
-FILE: ../../../third_party/dart/samples/ffi/sample_ffi_structs.dart
-FILE: ../../../third_party/dart/samples/ffi/samples_test.dart
-FILE: ../../../third_party/dart/samples/ffi/sqlite/example/main.dart
-FILE: ../../../third_party/dart/samples/ffi/sqlite/lib/sqlite.dart
-FILE: ../../../third_party/dart/samples/ffi/sqlite/lib/src/bindings/bindings.dart
-FILE: ../../../third_party/dart/samples/ffi/sqlite/lib/src/bindings/constants.dart
-FILE: ../../../third_party/dart/samples/ffi/sqlite/lib/src/bindings/signatures.dart
-FILE: ../../../third_party/dart/samples/ffi/sqlite/lib/src/bindings/types.dart
-FILE: ../../../third_party/dart/samples/ffi/sqlite/lib/src/collections/closable_iterator.dart
-FILE: ../../../third_party/dart/samples/ffi/sqlite/lib/src/database.dart
-FILE: ../../../third_party/dart/samples/ffi/sqlite/lib/src/ffi/dylib_utils.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/js_shared/lib/rti.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/js_shared/lib/synced/recipe_syntax.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_dynamic_library_patch.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_native_type_patch.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_patch.dart
-FILE: ../../../third_party/dart/sdk/lib/ffi/annotations.dart
-FILE: ../../../third_party/dart/sdk/lib/ffi/dynamic_library.dart
-FILE: ../../../third_party/dart/sdk/lib/ffi/ffi.dart
-FILE: ../../../third_party/dart/sdk/lib/ffi/native_type.dart
-FILE: ../../../third_party/dart/sdk/lib/ffi/struct.dart
-FILE: ../../../third_party/dart/sdk/lib/internal/errors.dart
-----------------------------------------------------------------------------------------------------
-Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
-for details. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      disclaimer in the documentation and/or other materials provided
-      with the distribution.
-    * Neither the name of Google LLC nor the names of its
-      contributors may be used to endorse or promote products derived
-      from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-====================================================================================================
-
-====================================================================================================
-LIBRARY: dart
-ORIGIN: ../../../third_party/dart/benchmarks/DartCLIStartup/dart/DartCLIStartup.dart + ../../../third_party/dart/LICENSE
-TYPE: LicenseType.bsd
-FILE: ../../../third_party/dart/benchmarks/DartCLIStartup/dart/DartCLIStartup.dart
-FILE: ../../../third_party/dart/benchmarks/DartCLIStartup/dart2/DartCLIStartup.dart
-FILE: ../../../third_party/dart/benchmarks/EventLoopLatencyRegexp/dart/EventLoopLatencyRegexp.dart
-FILE: ../../../third_party/dart/benchmarks/EventLoopLatencyRegexp/dart/regexp_benchmark.dart
-FILE: ../../../third_party/dart/benchmarks/EventLoopLatencyRegexp/dart2/regexp_benchmark.dart
-FILE: ../../../third_party/dart/benchmarks/FfiAsTypedList/dart/FfiAsTypedList.dart
-FILE: ../../../third_party/dart/benchmarks/FfiAsTypedList/dart2/FfiAsTypedList.dart
-FILE: ../../../third_party/dart/benchmarks/IsolateFibonacci/dart/IsolateFibonacci.dart
-FILE: ../../../third_party/dart/benchmarks/IsolateFibonacci/dart2/IsolateFibonacci.dart
-FILE: ../../../third_party/dart/benchmarks/MapCopy/dart/MapCopy.dart
-FILE: ../../../third_party/dart/benchmarks/MapCopy/dart2/MapCopy.dart
-FILE: ../../../third_party/dart/benchmarks/MapLookup/dart/MapLookup.dart
-FILE: ../../../third_party/dart/benchmarks/MapLookup/dart/maps.dart
-FILE: ../../../third_party/dart/benchmarks/MapLookup/dart2/MapLookup.dart
-FILE: ../../../third_party/dart/benchmarks/MapLookup/dart2/maps.dart
-FILE: ../../../third_party/dart/benchmarks/MapLookup/generate_maps.dart
-FILE: ../../../third_party/dart/benchmarks/NativeCall/dart/NativeCall.dart
-FILE: ../../../third_party/dart/benchmarks/NativeCall/dart/dlopen_helper.dart
-FILE: ../../../third_party/dart/benchmarks/NativeCall/dart2/NativeCall.dart
-FILE: ../../../third_party/dart/benchmarks/NativeCall/dart2/dlopen_helper.dart
-FILE: ../../../third_party/dart/benchmarks/NativeCall/native/native_functions.c
-FILE: ../../../third_party/dart/benchmarks/ObjectHash/dart/ObjectHash.dart
-FILE: ../../../third_party/dart/benchmarks/ObjectHash/dart2/ObjectHash.dart
-FILE: ../../../third_party/dart/benchmarks/SDKArtifactSizes/dart/SDKArtifactSizes.dart
-FILE: ../../../third_party/dart/benchmarks/SDKArtifactSizes/dart2/SDKArtifactSizes.dart
-FILE: ../../../third_party/dart/benchmarks/SendPort/dart/SendPort.dart
-FILE: ../../../third_party/dart/benchmarks/SendPort/dart2/SendPort.dart
-FILE: ../../../third_party/dart/benchmarks/StringPool/dart/StringPool.dart
-FILE: ../../../third_party/dart/benchmarks/StringPool/dart/StringPool100.dart
-FILE: ../../../third_party/dart/benchmarks/StringPool/dart/version1a.dart
-FILE: ../../../third_party/dart/benchmarks/StringPool/dart/version1b.dart
-FILE: ../../../third_party/dart/benchmarks/StringPool/dart/version2.dart
-FILE: ../../../third_party/dart/benchmarks/StringPool/dart2/StringPool.dart
-FILE: ../../../third_party/dart/benchmarks/StringPool/dart2/StringPool100.dart
 FILE: ../../../third_party/dart/runtime/bin/abstract_socket_test.cc
 FILE: ../../../third_party/dart/runtime/bin/analyze_snapshot.cc
 FILE: ../../../third_party/dart/runtime/bin/platform_macos_cocoa.h
@@ -11119,178 +10696,6 @@ FILE: ../../../third_party/dart/sdk/lib/ffi/allocation.dart
 FILE: ../../../third_party/dart/sdk/lib/ffi/union.dart
 ----------------------------------------------------------------------------------------------------
 Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
-for details. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      disclaimer in the documentation and/or other materials provided
-      with the distribution.
-    * Neither the name of Google LLC nor the names of its
-      contributors may be used to endorse or promote products derived
-      from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-====================================================================================================
-
-====================================================================================================
-LIBRARY: dart
-ORIGIN: ../../../third_party/dart/benchmarks/Dynamic/dart/Dynamic.dart + ../../../third_party/dart/LICENSE
-TYPE: LicenseType.bsd
-FILE: ../../../third_party/dart/benchmarks/Dynamic/dart/Dynamic.dart
-FILE: ../../../third_party/dart/benchmarks/Dynamic/dart2/Dynamic.dart
-FILE: ../../../third_party/dart/benchmarks/EventLoopLatencyJson/dart/EventLoopLatencyJson.dart
-FILE: ../../../third_party/dart/benchmarks/EventLoopLatencyJson/dart/json_benchmark.dart
-FILE: ../../../third_party/dart/benchmarks/EventLoopLatencyJson/dart/latency.dart
-FILE: ../../../third_party/dart/benchmarks/EventLoopLatencyJson/dart2/EventLoopLatencyJson.dart
-FILE: ../../../third_party/dart/benchmarks/EventLoopLatencyJson/dart2/json_benchmark.dart
-FILE: ../../../third_party/dart/benchmarks/EventLoopLatencyJson/dart2/latency.dart
-FILE: ../../../third_party/dart/benchmarks/EventLoopLatencyJson350KB/dart/EventLoopLatencyJson350KB.dart
-FILE: ../../../third_party/dart/benchmarks/EventLoopLatencyJson350KB/dart/json_benchmark.dart
-FILE: ../../../third_party/dart/benchmarks/EventLoopLatencyJson350KB/dart/latency.dart
-FILE: ../../../third_party/dart/benchmarks/EventLoopLatencyJson350KB/dart2/EventLoopLatencyJson350KB.dart
-FILE: ../../../third_party/dart/benchmarks/EventLoopLatencyJson350KB/dart2/json_benchmark.dart
-FILE: ../../../third_party/dart/benchmarks/EventLoopLatencyJson350KB/dart2/latency.dart
-FILE: ../../../third_party/dart/benchmarks/EventLoopLatencyRegexp/dart/latency.dart
-FILE: ../../../third_party/dart/benchmarks/EventLoopLatencyRegexp/dart2/EventLoopLatencyRegexp.dart
-FILE: ../../../third_party/dart/benchmarks/EventLoopLatencyRegexp/dart2/latency.dart
-FILE: ../../../third_party/dart/benchmarks/IsolateSendExitLatency/dart/latency.dart
-FILE: ../../../third_party/dart/benchmarks/IsolateSendExitLatency/dart2/latency.dart
-FILE: ../../../third_party/dart/benchmarks/ListCopy/dart/ListCopy.dart
-FILE: ../../../third_party/dart/benchmarks/ListCopy/dart2/ListCopy.dart
-FILE: ../../../third_party/dart/benchmarks/MD5/dart/md5.dart
-FILE: ../../../third_party/dart/benchmarks/MD5/dart2/md5.dart
-FILE: ../../../third_party/dart/benchmarks/Omnibus/dart/Omnibus.dart
-FILE: ../../../third_party/dart/benchmarks/Omnibus/dart2/Omnibus.dart
-FILE: ../../../third_party/dart/benchmarks/OmnibusDeferred/dart/OmnibusDeferred.dart
-FILE: ../../../third_party/dart/benchmarks/OmnibusDeferred/dart2/OmnibusDeferred.dart
-FILE: ../../../third_party/dart/benchmarks/RuntimeType/dart/RuntimeType.dart
-FILE: ../../../third_party/dart/benchmarks/RuntimeType/dart2/RuntimeType.dart
-FILE: ../../../third_party/dart/benchmarks/SHA1/dart/sha1.dart
-FILE: ../../../third_party/dart/benchmarks/SHA1/dart2/sha1.dart
-FILE: ../../../third_party/dart/benchmarks/SHA256/dart/sha256.dart
-FILE: ../../../third_party/dart/benchmarks/SHA256/dart2/sha256.dart
-FILE: ../../../third_party/dart/benchmarks/SkeletalAnimation/dart/SkeletalAnimation.dart
-FILE: ../../../third_party/dart/benchmarks/SkeletalAnimation/dart2/SkeletalAnimation.dart
-FILE: ../../../third_party/dart/benchmarks/SkeletalAnimationSIMD/dart/SkeletalAnimationSIMD.dart
-FILE: ../../../third_party/dart/benchmarks/SkeletalAnimationSIMD/dart2/SkeletalAnimationSIMD.dart
-FILE: ../../../third_party/dart/benchmarks/TypedDataDuplicate/dart/TypedDataDuplicate.dart
-FILE: ../../../third_party/dart/benchmarks/TypedDataDuplicate/dart2/TypedDataDuplicate.dart
-FILE: ../../../third_party/dart/benchmarks/Utf8Decode/dart/Utf8Decode.dart
-FILE: ../../../third_party/dart/benchmarks/Utf8Decode/dart2/Utf8Decode.dart
-FILE: ../../../third_party/dart/benchmarks/Utf8Encode/dart/Utf8Encode.dart
-FILE: ../../../third_party/dart/benchmarks/Utf8Encode/dart2/Utf8Encode.dart
-FILE: ../../../third_party/dart/runtime/bin/dartdev_isolate.cc
-FILE: ../../../third_party/dart/runtime/bin/dartdev_isolate.h
-FILE: ../../../third_party/dart/runtime/bin/exe_utils.cc
-FILE: ../../../third_party/dart/runtime/bin/exe_utils.h
-FILE: ../../../third_party/dart/runtime/bin/ffi_test/ffi_test_functions_generated.cc
-FILE: ../../../third_party/dart/runtime/bin/ffi_unit_test/run_ffi_unit_tests.cc
-FILE: ../../../third_party/dart/runtime/bin/file_win.h
-FILE: ../../../third_party/dart/runtime/bin/platform_macos.h
-FILE: ../../../third_party/dart/runtime/bin/priority_heap_test.cc
-FILE: ../../../third_party/dart/runtime/include/dart_api_dl.c
-FILE: ../../../third_party/dart/runtime/include/dart_api_dl.h
-FILE: ../../../third_party/dart/runtime/include/dart_version.h
-FILE: ../../../third_party/dart/runtime/include/internal/dart_api_dl_impl.h
-FILE: ../../../third_party/dart/runtime/observatory/bin/heap_snapshot.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/process_snapshot.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/bin/heap_snapshot.dart
-FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/process_snapshot.dart
-FILE: ../../../third_party/dart/runtime/platform/allocation.cc
-FILE: ../../../third_party/dart/runtime/platform/leak_sanitizer.h
-FILE: ../../../third_party/dart/runtime/platform/priority_queue.h
-FILE: ../../../third_party/dart/runtime/platform/unaligned.h
-FILE: ../../../third_party/dart/runtime/platform/undefined_behavior_sanitizer.h
-FILE: ../../../third_party/dart/runtime/tools/wiki/xref_extractor/bin/main.dart
-FILE: ../../../third_party/dart/runtime/tools/wiki/xref_extractor/lib/cquery_driver.dart
-FILE: ../../../third_party/dart/runtime/tools/wiki/xref_extractor/lib/xref_extractor.dart
-FILE: ../../../third_party/dart/runtime/vm/canonical_tables.cc
-FILE: ../../../third_party/dart/runtime/vm/closure_functions_cache.cc
-FILE: ../../../third_party/dart/runtime/vm/closure_functions_cache.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/aot/dispatch_table_generator.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/aot/dispatch_table_generator.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/aot/precompiler_tracer.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/aot/precompiler_tracer.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/api/deopt_id.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/api/print_filter.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/api/print_filter.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/api/type_check_mode.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_base.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/backend/constant_propagator_test.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/backend/reachability_fence_test.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/abi.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/abi.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/call.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/call.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/callback.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/callback.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/frame_rebase.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/frame_rebase.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/marshaller.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/marshaller.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/native_calling_convention.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/native_calling_convention.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/native_calling_convention_test.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/native_location.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/native_location.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/native_location_test.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/native_type.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/native_type.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/native_type_test.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/native_type_vm_test.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/recognized_method.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/recognized_method.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/unit_test.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/unit_test.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/unit_test_custom_zone.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/unit_test_custom_zone.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/kernel_binary_flowgraph_test.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/stub_code_compiler.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/write_barrier_elimination.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/write_barrier_elimination.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/write_barrier_elimination_test.cc
-FILE: ../../../third_party/dart/runtime/vm/constants_base.h
-FILE: ../../../third_party/dart/runtime/vm/datastream_test.cc
-FILE: ../../../third_party/dart/runtime/vm/dispatch_table.cc
-FILE: ../../../third_party/dart/runtime/vm/dispatch_table.h
-FILE: ../../../third_party/dart/runtime/vm/experimental_features.cc
-FILE: ../../../third_party/dart/runtime/vm/experimental_features.h
-FILE: ../../../third_party/dart/runtime/vm/field_table.cc
-FILE: ../../../third_party/dart/runtime/vm/field_table.h
-FILE: ../../../third_party/dart/runtime/vm/heap/become_test.cc
-FILE: ../../../third_party/dart/runtime/vm/heap/weak_table_test.cc
-FILE: ../../../third_party/dart/runtime/vm/port_set.h
-FILE: ../../../third_party/dart/runtime/vm/stub_code_test.cc
-FILE: ../../../third_party/dart/runtime/vm/tagged_pointer.h
-FILE: ../../../third_party/dart/runtime/vm/timeline_macos.cc
-FILE: ../../../third_party/dart/runtime/vm/type_testing_stubs_test.cc
-FILE: ../../../third_party/dart/runtime/vm/visitor.cc
-FILE: ../../../third_party/dart/samples/ffi/async/async_test.dart
-FILE: ../../../third_party/dart/samples/ffi/async/sample_async_callback.dart
-FILE: ../../../third_party/dart/samples/ffi/async/sample_native_port_call.dart
-FILE: ../../../third_party/dart/samples/ffi/sample_ffi_functions_callbacks_closures.dart
-FILE: ../../../third_party/dart/sdk/lib/_http/embedder_config.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/patch/js_patch.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/js_patch.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_struct_patch.dart
-FILE: ../../../third_party/dart/sdk/lib/internal/lowering.dart
-----------------------------------------------------------------------------------------------------
-Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
 for details. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -13002,6 +12407,299 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ====================================================================================================
 LIBRARY: dart
+ORIGIN: ../../../third_party/dart/runtime/bin/ffi_test/ffi_test_dynamic_library.cc + ../../../third_party/dart/LICENSE
+TYPE: LicenseType.bsd
+FILE: ../../../third_party/dart/runtime/bin/elf_loader.cc
+FILE: ../../../third_party/dart/runtime/bin/elf_loader.h
+FILE: ../../../third_party/dart/runtime/bin/entrypoints_verification_test.cc
+FILE: ../../../third_party/dart/runtime/bin/ffi_test/ffi_test_dynamic_library.cc
+FILE: ../../../third_party/dart/runtime/bin/ffi_test/ffi_test_functions.cc
+FILE: ../../../third_party/dart/runtime/bin/ffi_test/ffi_test_functions_vmspecific.cc
+FILE: ../../../third_party/dart/runtime/bin/ifaddrs-android.cc
+FILE: ../../../third_party/dart/runtime/bin/ifaddrs-android.h
+FILE: ../../../third_party/dart/runtime/bin/namespace_fuchsia.h
+FILE: ../../../third_party/dart/runtime/bin/socket_base_android.cc
+FILE: ../../../third_party/dart/runtime/lib/ffi.cc
+FILE: ../../../third_party/dart/runtime/lib/ffi_dynamic_library.cc
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/tree_map.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/isolate_group.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/isolate_group.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/isolate_group.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/timeline_base.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/tree_map.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/isolate_group.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/isolate_group.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/isolate_group.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/timeline_base.dart
+FILE: ../../../third_party/dart/runtime/platform/elf.h
+FILE: ../../../third_party/dart/runtime/platform/thread_sanitizer.h
+FILE: ../../../third_party/dart/runtime/tools/dartfuzz/dartfuzz_api_table.dart
+FILE: ../../../third_party/dart/runtime/tools/dartfuzz/dartfuzz_ffi_api.dart
+FILE: ../../../third_party/dart/runtime/tools/dartfuzz/dartfuzz_type_table.dart
+FILE: ../../../third_party/dart/runtime/tools/dartfuzz/gen_api_table.dart
+FILE: ../../../third_party/dart/runtime/tools/dartfuzz/gen_type_table.dart
+FILE: ../../../third_party/dart/runtime/tools/dartfuzz/gen_util.dart
+FILE: ../../../third_party/dart/runtime/tools/ffi/sdk_lib_ffi_generator.dart
+FILE: ../../../third_party/dart/runtime/tools/graphexplorer/graphexplorer.html
+FILE: ../../../third_party/dart/runtime/tools/graphexplorer/graphexplorer.js
+FILE: ../../../third_party/dart/runtime/tools/run_clang_tidy.dart
+FILE: ../../../third_party/dart/runtime/vm/bss_relocs.cc
+FILE: ../../../third_party/dart/runtime/vm/bss_relocs.h
+FILE: ../../../third_party/dart/runtime/vm/catch_entry_moves_test.cc
+FILE: ../../../third_party/dart/runtime/vm/class_id.h
+FILE: ../../../third_party/dart/runtime/vm/code_comments.cc
+FILE: ../../../third_party/dart/runtime/vm/code_comments.h
+FILE: ../../../third_party/dart/runtime/vm/code_entry_kind.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/asm_intrinsifier.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/asm_intrinsifier.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/asm_intrinsifier_arm.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/asm_intrinsifier_arm64.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/asm_intrinsifier_ia32.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/asm_intrinsifier_x64.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/bce_test.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/block_builder.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/evaluator.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/evaluator.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/flow_graph_checker.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/flow_graph_checker.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/il_test_helper.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/il_test_helper.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/inliner_test.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/slot_test.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/type_propagator_test.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/typed_data_aot_test.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/yield_position_test.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/graph_intrinsifier.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/graph_intrinsifier.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/offsets_extractor.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/recognized_methods_list.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/relocation.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/runtime_api.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/runtime_api.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/runtime_offsets_extracted.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/runtime_offsets_list.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/stub_code_compiler.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/stub_code_compiler_arm.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/stub_code_compiler_arm64.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/stub_code_compiler_ia32.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/stub_code_compiler_x64.cc
+FILE: ../../../third_party/dart/runtime/vm/constants_arm.cc
+FILE: ../../../third_party/dart/runtime/vm/constants_arm64.cc
+FILE: ../../../third_party/dart/runtime/vm/constants_ia32.cc
+FILE: ../../../third_party/dart/runtime/vm/constants_x64.cc
+FILE: ../../../third_party/dart/runtime/vm/elf.cc
+FILE: ../../../third_party/dart/runtime/vm/elf.h
+FILE: ../../../third_party/dart/runtime/vm/ffi_callback_trampolines.cc
+FILE: ../../../third_party/dart/runtime/vm/ffi_callback_trampolines.h
+FILE: ../../../third_party/dart/runtime/vm/frame_layout.h
+FILE: ../../../third_party/dart/runtime/vm/intrusive_dlist.h
+FILE: ../../../third_party/dart/runtime/vm/intrusive_dlist_test.cc
+FILE: ../../../third_party/dart/runtime/vm/libfuzzer/dart_libfuzzer.cc
+FILE: ../../../third_party/dart/runtime/vm/longjump.h
+FILE: ../../../third_party/dart/runtime/vm/pointer_tagging.h
+FILE: ../../../third_party/dart/runtime/vm/splay-tree.h
+FILE: ../../../third_party/dart/runtime/vm/static_type_exactness_state.h
+FILE: ../../../third_party/dart/runtime/vm/stub_code_list.h
+FILE: ../../../third_party/dart/runtime/vm/thread_stack_resource.cc
+FILE: ../../../third_party/dart/runtime/vm/thread_stack_resource.h
+FILE: ../../../third_party/dart/runtime/vm/thread_state.cc
+FILE: ../../../third_party/dart/runtime/vm/thread_state.h
+FILE: ../../../third_party/dart/samples/ffi/coordinate.dart
+FILE: ../../../third_party/dart/samples/ffi/dylib_utils.dart
+FILE: ../../../third_party/dart/samples/ffi/resource_management/arena_isolate_shutdown_sample.dart
+FILE: ../../../third_party/dart/samples/ffi/resource_management/arena_sample.dart
+FILE: ../../../third_party/dart/samples/ffi/resource_management/arena_zoned_sample.dart
+FILE: ../../../third_party/dart/samples/ffi/resource_management/resource_management_test.dart
+FILE: ../../../third_party/dart/samples/ffi/resource_management/unmanaged_sample.dart
+FILE: ../../../third_party/dart/samples/ffi/sample_ffi_bitfield.dart
+FILE: ../../../third_party/dart/samples/ffi/sample_ffi_data.dart
+FILE: ../../../third_party/dart/samples/ffi/sample_ffi_dynamic_library.dart
+FILE: ../../../third_party/dart/samples/ffi/sample_ffi_functions.dart
+FILE: ../../../third_party/dart/samples/ffi/sample_ffi_functions_callbacks.dart
+FILE: ../../../third_party/dart/samples/ffi/sample_ffi_functions_structs.dart
+FILE: ../../../third_party/dart/samples/ffi/sample_ffi_structs.dart
+FILE: ../../../third_party/dart/samples/ffi/samples_test.dart
+FILE: ../../../third_party/dart/samples/ffi/sqlite/example/main.dart
+FILE: ../../../third_party/dart/samples/ffi/sqlite/lib/sqlite.dart
+FILE: ../../../third_party/dart/samples/ffi/sqlite/lib/src/bindings/bindings.dart
+FILE: ../../../third_party/dart/samples/ffi/sqlite/lib/src/bindings/constants.dart
+FILE: ../../../third_party/dart/samples/ffi/sqlite/lib/src/bindings/signatures.dart
+FILE: ../../../third_party/dart/samples/ffi/sqlite/lib/src/bindings/types.dart
+FILE: ../../../third_party/dart/samples/ffi/sqlite/lib/src/collections/closable_iterator.dart
+FILE: ../../../third_party/dart/samples/ffi/sqlite/lib/src/database.dart
+FILE: ../../../third_party/dart/samples/ffi/sqlite/lib/src/ffi/dylib_utils.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_shared/lib/rti.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_shared/lib/synced/recipe_syntax.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_dynamic_library_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_native_type_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/ffi/annotations.dart
+FILE: ../../../third_party/dart/sdk/lib/ffi/dynamic_library.dart
+FILE: ../../../third_party/dart/sdk/lib/ffi/ffi.dart
+FILE: ../../../third_party/dart/sdk/lib/ffi/native_type.dart
+FILE: ../../../third_party/dart/sdk/lib/ffi/struct.dart
+FILE: ../../../third_party/dart/sdk/lib/internal/errors.dart
+----------------------------------------------------------------------------------------------------
+Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+for details. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google LLC nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: dart
+ORIGIN: ../../../third_party/dart/runtime/bin/ffi_test/ffi_test_functions_generated.cc + ../../../third_party/dart/LICENSE
+TYPE: LicenseType.bsd
+FILE: ../../../third_party/dart/runtime/bin/dartdev_isolate.cc
+FILE: ../../../third_party/dart/runtime/bin/dartdev_isolate.h
+FILE: ../../../third_party/dart/runtime/bin/exe_utils.cc
+FILE: ../../../third_party/dart/runtime/bin/exe_utils.h
+FILE: ../../../third_party/dart/runtime/bin/ffi_test/ffi_test_functions_generated.cc
+FILE: ../../../third_party/dart/runtime/bin/ffi_unit_test/run_ffi_unit_tests.cc
+FILE: ../../../third_party/dart/runtime/bin/file_win.h
+FILE: ../../../third_party/dart/runtime/bin/platform_macos.h
+FILE: ../../../third_party/dart/runtime/bin/priority_heap_test.cc
+FILE: ../../../third_party/dart/runtime/include/dart_api_dl.c
+FILE: ../../../third_party/dart/runtime/include/dart_api_dl.h
+FILE: ../../../third_party/dart/runtime/include/dart_version.h
+FILE: ../../../third_party/dart/runtime/include/internal/dart_api_dl_impl.h
+FILE: ../../../third_party/dart/runtime/observatory/bin/heap_snapshot.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/process_snapshot.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/bin/heap_snapshot.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/process_snapshot.dart
+FILE: ../../../third_party/dart/runtime/platform/allocation.cc
+FILE: ../../../third_party/dart/runtime/platform/leak_sanitizer.h
+FILE: ../../../third_party/dart/runtime/platform/priority_queue.h
+FILE: ../../../third_party/dart/runtime/platform/unaligned.h
+FILE: ../../../third_party/dart/runtime/platform/undefined_behavior_sanitizer.h
+FILE: ../../../third_party/dart/runtime/tools/wiki/xref_extractor/bin/main.dart
+FILE: ../../../third_party/dart/runtime/tools/wiki/xref_extractor/lib/cquery_driver.dart
+FILE: ../../../third_party/dart/runtime/tools/wiki/xref_extractor/lib/xref_extractor.dart
+FILE: ../../../third_party/dart/runtime/vm/canonical_tables.cc
+FILE: ../../../third_party/dart/runtime/vm/closure_functions_cache.cc
+FILE: ../../../third_party/dart/runtime/vm/closure_functions_cache.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/aot/dispatch_table_generator.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/aot/dispatch_table_generator.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/aot/precompiler_tracer.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/aot/precompiler_tracer.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/api/deopt_id.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/api/print_filter.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/api/print_filter.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/api/type_check_mode.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_base.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/constant_propagator_test.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/reachability_fence_test.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/abi.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/abi.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/call.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/call.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/callback.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/callback.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/frame_rebase.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/frame_rebase.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/marshaller.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/marshaller.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/native_calling_convention.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/native_calling_convention.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/native_calling_convention_test.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/native_location.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/native_location.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/native_location_test.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/native_type.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/native_type.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/native_type_test.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/native_type_vm_test.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/recognized_method.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/recognized_method.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/unit_test.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/unit_test.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/unit_test_custom_zone.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/unit_test_custom_zone.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/kernel_binary_flowgraph_test.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/stub_code_compiler.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/write_barrier_elimination.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/write_barrier_elimination.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/write_barrier_elimination_test.cc
+FILE: ../../../third_party/dart/runtime/vm/constants_base.h
+FILE: ../../../third_party/dart/runtime/vm/datastream_test.cc
+FILE: ../../../third_party/dart/runtime/vm/dispatch_table.cc
+FILE: ../../../third_party/dart/runtime/vm/dispatch_table.h
+FILE: ../../../third_party/dart/runtime/vm/experimental_features.cc
+FILE: ../../../third_party/dart/runtime/vm/experimental_features.h
+FILE: ../../../third_party/dart/runtime/vm/field_table.cc
+FILE: ../../../third_party/dart/runtime/vm/field_table.h
+FILE: ../../../third_party/dart/runtime/vm/heap/become_test.cc
+FILE: ../../../third_party/dart/runtime/vm/heap/weak_table_test.cc
+FILE: ../../../third_party/dart/runtime/vm/port_set.h
+FILE: ../../../third_party/dart/runtime/vm/stub_code_test.cc
+FILE: ../../../third_party/dart/runtime/vm/tagged_pointer.h
+FILE: ../../../third_party/dart/runtime/vm/timeline_macos.cc
+FILE: ../../../third_party/dart/runtime/vm/type_testing_stubs_test.cc
+FILE: ../../../third_party/dart/runtime/vm/visitor.cc
+FILE: ../../../third_party/dart/samples/ffi/async/async_test.dart
+FILE: ../../../third_party/dart/samples/ffi/async/sample_async_callback.dart
+FILE: ../../../third_party/dart/samples/ffi/async/sample_native_port_call.dart
+FILE: ../../../third_party/dart/samples/ffi/sample_ffi_functions_callbacks_closures.dart
+FILE: ../../../third_party/dart/sdk/lib/_http/embedder_config.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/patch/js_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/js_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_struct_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/internal/lowering.dart
+----------------------------------------------------------------------------------------------------
+Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+for details. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google LLC nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: dart
 ORIGIN: ../../../third_party/dart/runtime/bin/process_test.cc + ../../../third_party/dart/LICENSE
 TYPE: LicenseType.bsd
 FILE: ../../../third_party/dart/runtime/bin/process_test.cc
@@ -13095,6 +12793,103 @@ FILE: ../../../third_party/dart/sdk/lib/internal/sort.dart
 FILE: ../../../third_party/dart/utils/peg/pegparser.dart
 ----------------------------------------------------------------------------------------------------
 Copyright (c) 2011, the Dart project authors.  Please see the AUTHORS file
+for details. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google LLC nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: dart
+ORIGIN: ../../../third_party/dart/runtime/bin/snapshot_utils_test.cc + ../../../third_party/dart/LICENSE
+TYPE: LicenseType.bsd
+FILE: ../../../third_party/dart/runtime/bin/snapshot_utils_test.cc
+FILE: ../../../third_party/dart/runtime/bin/test_utils.cc
+FILE: ../../../third_party/dart/runtime/bin/test_utils.h
+FILE: ../../../third_party/dart/runtime/bin/thread_absl.cc
+FILE: ../../../third_party/dart/runtime/bin/thread_absl.h
+FILE: ../../../third_party/dart/runtime/platform/mach_o.h
+FILE: ../../../third_party/dart/runtime/platform/pe.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/il_serializer.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/il_serializer.h
+FILE: ../../../third_party/dart/runtime/vm/heap/gc_shared.cc
+FILE: ../../../third_party/dart/runtime/vm/heap/gc_shared.h
+FILE: ../../../third_party/dart/runtime/vm/instructions.cc
+FILE: ../../../third_party/dart/runtime/vm/malloc_hooks_riscv.cc
+FILE: ../../../third_party/dart/runtime/vm/os_thread_absl.cc
+FILE: ../../../third_party/dart/runtime/vm/os_thread_absl.h
+FILE: ../../../third_party/dart/runtime/vm/simulator_x64.cc
+FILE: ../../../third_party/dart/runtime/vm/simulator_x64.h
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/js_names.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/runtime_metrics.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_shared/lib/js_util_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_shared/lib/synced/embedded_names.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_native_finalizer_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/finalizer_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/hash_factories.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/async_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/bool.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/class_id.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/core_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/date_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/developer.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/double.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/errors_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/expando_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/function.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/growable_list.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/hash_factories.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/identical_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/int.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/internal_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/isolate_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/js_helper.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/js_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/js_util_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/list.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/math_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/object_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/print_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/regexp_helper.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/regexp_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/stack_trace_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/stopwatch_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/string_buffer_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/string_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/symbol_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/timer_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/type.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/uri_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/ffi/c_type.dart
+FILE: ../../../third_party/dart/sdk/lib/ffi/native_finalizer.dart
+FILE: ../../../third_party/dart/sdk/lib/js/js_wasm.dart
+FILE: ../../../third_party/dart/sdk/lib/js_util/js_util_wasm.dart
+FILE: ../../../third_party/dart/sdk/lib/wasm/wasm_types.dart
+----------------------------------------------------------------------------------------------------
+Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
 for details. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -13469,6 +13264,42 @@ FILE: ../../../third_party/icu/source/i18n/double-conversion-strtod.h
 FILE: ../../../third_party/icu/source/i18n/double-conversion-utils.h
 ----------------------------------------------------------------------------------------------------
 Copyright 2010 the V8 project authors. All rights reserved.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google Inc. nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: double-conversion
+LIBRARY: icu
+ORIGIN: ../../../third_party/dart/runtime/third_party/double-conversion/src/cached-powers.cc
+TYPE: LicenseType.bsd
+FILE: ../../../third_party/dart/runtime/third_party/double-conversion/src/cached-powers.cc
+FILE: ../../../third_party/icu/source/i18n/double-conversion-cached-powers.cpp
+----------------------------------------------------------------------------------------------------
+Copyright 2006-2008 the V8 project authors. All rights reserved.
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
 met:

--- a/ci/licenses_golden/licenses_third_party
+++ b/ci/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: 640372296da717028e5e5f51b5e8f529
+Signature: 6fe4ae17b3d11dfba99dc18dbeeac1a3
 
 UNUSED LICENSES:
 

--- a/ci/licenses_golden/tool_signature
+++ b/ci/licenses_golden/tool_signature
@@ -1,2 +1,2 @@
-Signature: 647326c44237e255694c24deb9896c68
+Signature: 2fb519822786fbfd8d72d8cf704caafd
 

--- a/tools/licenses/lib/main.dart
+++ b/tools/licenses/lib/main.dart
@@ -2382,6 +2382,8 @@ class _RepositoryDartDirectory extends _RepositoryDirectory {
         && entry.name != 'build' // not shipped in binary
         && entry.name != 'tools' // not shipped in binary
         && entry.name != 'samples-dev' // not shipped in binary
+        && entry.name != 'benchmarks' // not shipped in binary
+        && entry.name != 'benchmarks-internal' // not shipped in binary
         && super.shouldRecurse(entry);
   }
 


### PR DESCRIPTION
Exclude those folders since they are not included into flutter distro.