### PR TITLE
[lint] Enforce kCamelCase for global constants

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -31,6 +31,8 @@ CheckOptions:
     value:  'CamelCase'
   - key:    readability-identifier-naming.EnumConstantPrefix
     value:  'k'
+  - key:    readability-identifier-naming.GlobalConstantCase
+    value:  'CamelCase'
   - key:    readability-identifier-naming.GlobalConstantPrefix
     value:  'k'
   - key:    readability-identifier-naming.PrivateMemberCase

--- a/lib/ui/painting/fragment_shader.cc
+++ b/lib/ui/painting/fragment_shader.cc
@@ -20,12 +20,12 @@ namespace flutter {
 
 // Since _FragmentShader is a private class, we can't use
 // IMPLEMENT_WRAPPERTYPEINFO
-static const tonic::DartWrapperInfo kDartWrapperInfo_ui_FragmentShader = {
+static const tonic::DartWrapperInfo kDartWrapperInfoUIFragmentShader = {
     "ui",
     "_FragmentShader",
 };
 const tonic::DartWrapperInfo& FragmentShader::dart_wrapper_info_ =
-    kDartWrapperInfo_ui_FragmentShader;
+    kDartWrapperInfoUIFragmentShader;
 
 std::shared_ptr<DlColorSource> FragmentShader::shader(
     DlImageSampling sampling) {

--- a/lib/ui/painting/image.cc
+++ b/lib/ui/painting/image.cc
@@ -18,12 +18,12 @@ namespace flutter {
 typedef CanvasImage Image;
 
 // Since _Image is a private class, we can't use IMPLEMENT_WRAPPERTYPEINFO
-static const tonic::DartWrapperInfo kDartWrapperInfo_ui_Image = {
+static const tonic::DartWrapperInfo kDartWrapperInfoUIImage = {
     "ui",
     "_Image",
 };
 const tonic::DartWrapperInfo& Image::dart_wrapper_info_ =
-    kDartWrapperInfo_ui_Image;
+    kDartWrapperInfoUIImage;
 
 CanvasImage::CanvasImage() = default;
 


### PR DESCRIPTION
This updates global constants to use clang `CamelCase` style and enforce this in a lint.

This is a formatting-only change with no intended semantic change.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
