### PR TITLE
Paragraph.GetWordBoundary respects text affinity

### DIFF
--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -2830,7 +2830,16 @@ class Paragraph extends NativeFieldWrapperClass1 {
   /// [offset, offset+1]. Word boundaries are defined more precisely in Unicode
   /// Standard Annex #29 http://www.unicode.org/reports/tr29/#Word_Boundaries
   TextRange getWordBoundary(TextPosition position) {
-    final List<int> boundary = _getWordBoundary(position.offset);
+    final int characterPosition;
+    switch (position.affinity) {
+      case TextAffinity.upstream:
+        characterPosition = position.offset - 1;
+        break;
+      case TextAffinity.downstream:
+        characterPosition = position.offset;
+        break;
+    }
+    final List<int> boundary = _getWordBoundary(characterPosition);
     return TextRange(start: boundary[0], end: boundary[1]);
   }
 

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -2833,7 +2833,7 @@ class Paragraph extends NativeFieldWrapperClass1 {
   /// is used to determine which charater this position points to. For example,
   /// the word boundary at `TextPosition(offset: 5, affinity: TextPosition.upstream)`
   /// of the `string = 'Hello word'` will return range (0, 5) because the position
-  /// points to the charater 'o' instead of the space.
+  /// points to the character 'o' instead of the space.
   TextRange getWordBoundary(TextPosition position) {
     final int characterPosition;
     switch (position.affinity) {

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -2238,13 +2238,12 @@ enum TextAffinity {
 
 /// A position in a string of text.
 ///
-/// A TextPosition can be used to locate a position in a string in code (using
-/// the [offset] property), and it can also be used to locate the same position
-/// visually in a rendered string of text (using [offset] and, when needed to
-/// resolve ambiguity, [affinity]).
+/// A TextPosition can be used to describe a caret position in between
+/// characters. The [offset] points to the position between `offset - 1` and
+/// `offset` characters of the string, and the [affinity] is used to describe
+/// which character this position affiliates with.
 ///
-/// The location of an offset in a rendered string is ambiguous in two cases.
-/// One happens when rendered text is forced to wrap. In this case, the offset
+/// One use case is when rendered text is forced to wrap. In this case, the offset
 /// where the wrap occurs could visually appear either at the end of the first
 /// line or the beginning of the second line. The second way is with
 /// bidirectional text.  An offset at the interface between two different text
@@ -2829,6 +2828,12 @@ class Paragraph extends NativeFieldWrapperClass1 {
   /// have word breaks on both sides. In such cases, this method will return
   /// [offset, offset+1]. Word boundaries are defined more precisely in Unicode
   /// Standard Annex #29 http://www.unicode.org/reports/tr29/#Word_Boundaries
+  ///
+  /// The [TextPosition] is treated as caret position, its [TextPosition.affinity]
+  /// is used to determine which charater this position points to. For example,
+  /// the word boundary at `TextPosition(offset: 5, affinity: TextPosition.upstream)`
+  /// of the `string = 'Hello word'` will return range (0, 5) because the position
+  /// points to the charater 'o' instead of the space.
   TextRange getWordBoundary(TextPosition position) {
     final int characterPosition;
     switch (position.affinity) {

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -2830,7 +2830,7 @@ class Paragraph extends NativeFieldWrapperClass1 {
   /// Standard Annex #29 http://www.unicode.org/reports/tr29/#Word_Boundaries
   ///
   /// The [TextPosition] is treated as caret position, its [TextPosition.affinity]
-  /// is used to determine which charater this position points to. For example,
+  /// is used to determine which character this position points to. For example,
   /// the word boundary at `TextPosition(offset: 5, affinity: TextPosition.upstream)`
   /// of the `string = 'Hello word'` will return range (0, 5) because the position
   /// points to the character 'o' instead of the space.

--- a/lib/web_ui/lib/src/engine/canvaskit/text.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/text.dart
@@ -775,7 +775,16 @@ class CkParagraph extends SkiaObject<SkParagraph> implements ui.Paragraph {
   @override
   ui.TextRange getWordBoundary(ui.TextPosition position) {
     final SkParagraph paragraph = _ensureInitialized(_lastLayoutConstraints!);
-    final SkTextRange skRange = paragraph.getWordBoundary(position.offset);
+    final int characterPosition;
+    switch (position.affinity) {
+      case ui.TextAffinity.upstream:
+        characterPosition = position.offset - 1;
+        break;
+      case ui.TextAffinity.downstream:
+        characterPosition = position.offset;
+        break;
+    }
+    final SkTextRange skRange = paragraph.getWordBoundary(characterPosition);
     return ui.TextRange(start: skRange.start, end: skRange.end);
   }
 

--- a/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
+++ b/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
@@ -1342,6 +1342,22 @@ void _canvasTests() {
     );
   });
 
+  test('Paragraph converts caret position to charactor position', () {
+    final CkParagraphBuilder builder = CkParagraphBuilder(
+      CkParagraphStyle(),
+    );
+    builder.addText('Hello there');
+    final CkParagraph paragraph = builder.build();
+    paragraph.layout(const ui.ParagraphConstraints(width: 100));
+    ui.TextRange range = paragraph.getWordBoundary(const ui.TextPosition(offset: 5, affinity: ui.TextAffinity.upstream));
+    expect(range.start, 0);
+    expect(range.end, 5);
+
+    range = paragraph.getWordBoundary(const ui.TextPosition(offset: 5));
+    expect(range.start, 5);
+    expect(range.end, 6);
+  });
+
   test('Paragraph dispose', () {
     final CkParagraphBuilder builder = CkParagraphBuilder(
       CkParagraphStyle(),

--- a/testing/dart/text_test.dart
+++ b/testing/dart/text_test.dart
@@ -288,6 +288,29 @@ void testFontVariation() {
   });
 }
 
+void testGetWordBoundary() {
+  test('GetWordBoundary', () async {
+    final Uint8List fontData = await readFile('RobotoSlab-VariableFont_wght.ttf');
+    await loadFontFromList(fontData, fontFamily: 'RobotoSerif');
+
+    final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle(
+      fontFamily: 'RobotoSerif',
+      fontSize: 40.0,
+    ));
+    builder.addText('Hello team');
+    final Paragraph paragraph = builder.build();
+    paragraph.layout(const ParagraphConstraints(width: double.infinity));
+
+    TextRange range = paragraph.getWordBoundary(const TextPosition(offset: 5, affinity: TextAffinity.upstream));
+    expect(range.start, 0);
+    expect(range.end, 5);
+
+    range = paragraph.getWordBoundary(const TextPosition(offset: 5));
+    expect(range.start, 5);
+    expect(range.end, 6);
+  });
+}
+
 void main() {
   testFontWeight();
   testParagraphStyle();
@@ -297,4 +320,5 @@ void main() {
   testLoadFontFromList();
   testFontFeatureClass();
   testFontVariation();
+  testGetWordBoundary();
 }


### PR DESCRIPTION
The GetWordBoundary always assume affinity is downstream. This PR fixes it

related https://github.com/flutter/flutter/pull/110367

https://github.com/flutter/flutter/issues/111751

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
