### PR TITLE
Communicate switch status to semantics on Windows

### DIFF
--- a/shell/platform/common/accessibility_bridge.cc
+++ b/shell/platform/common/accessibility_bridge.cc
@@ -385,6 +385,13 @@ void AccessibilityBridge::SetIntAttributesFromFlutterUpdate(
             : flags & FlutterSemanticsFlag::kFlutterSemanticsFlagIsChecked
                 ? ax::mojom::CheckedState::kTrue
                 : ax::mojom::CheckedState::kFalse));
+  } else if (node_data.role == ax::mojom::Role::kToggleButton) {
+    node_data.AddIntAttribute(
+        ax::mojom::IntAttribute::kCheckedState,
+        static_cast<int32_t>(
+            flags & FlutterSemanticsFlag::kFlutterSemanticsFlagIsToggled
+                ? ax::mojom::CheckedState::kTrue
+                : ax::mojom::CheckedState::kFalse));
   }
 }
 

--- a/shell/platform/windows/flutter_windows_view_unittests.cc
+++ b/shell/platform/windows/flutter_windows_view_unittests.cc
@@ -685,7 +685,7 @@ TEST(FlutterWindowsViewTest, CheckboxNativeState) {
     VARIANT varchild = {};
     varchild.vt = VT_I4;
 
-    // Verify the checkbox is checked.
+    // Verify the checkbox is unchecked.
     varchild.lVal = CHILDID_SELF;
     VARIANT native_state = {};
     ASSERT_TRUE(SUCCEEDED(native_view->get_accState(varchild, &native_state)));
@@ -716,11 +716,102 @@ TEST(FlutterWindowsViewTest, CheckboxNativeState) {
     VARIANT varchild = {};
     varchild.vt = VT_I4;
 
-    // Verify the checkbox is checked.
+    // Verify the checkbox is mixed.
     varchild.lVal = CHILDID_SELF;
     VARIANT native_state = {};
     ASSERT_TRUE(SUCCEEDED(native_view->get_accState(varchild, &native_state)));
     EXPECT_TRUE(native_state.lVal & STATE_SYSTEM_MIXED);
+  }
+}
+
+// Ensure that switches have their toggle status set apropriately
+TEST(FlutterWindowsViewTest, SwitchNativeState) {
+  std::unique_ptr<FlutterWindowsEngine> engine = GetTestEngine();
+  EngineModifier modifier(engine.get());
+  modifier.embedder_api().UpdateSemanticsEnabled =
+      [](FLUTTER_API_SYMBOL(FlutterEngine) engine, bool enabled) {
+        return kSuccess;
+      };
+
+  auto window_binding_handler =
+      std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();
+  FlutterWindowsView view(std::move(window_binding_handler));
+  view.SetEngine(std::move(engine));
+
+  // Enable semantics to instantiate accessibility bridge.
+  view.OnUpdateSemanticsEnabled(true);
+
+  auto bridge = view.GetEngine()->accessibility_bridge().lock();
+  ASSERT_TRUE(bridge);
+
+  FlutterSemanticsNode root{sizeof(FlutterSemanticsNode), 0};
+  root.id = 0;
+  root.label = "root";
+  root.hint = "";
+  root.value = "";
+  root.increased_value = "";
+  root.decreased_value = "";
+  root.child_count = 0;
+  root.custom_accessibility_actions_count = 0;
+  root.flags = static_cast<FlutterSemanticsFlag>(
+      FlutterSemanticsFlag::kFlutterSemanticsFlagHasToggledState |
+      FlutterSemanticsFlag::kFlutterSemanticsFlagIsToggled);
+  bridge->AddFlutterSemanticsNodeUpdate(&root);
+
+  bridge->CommitUpdates();
+
+  {
+    auto root_node = bridge
+                         ->GetFlutterPlatformNodeDelegateFromID(
+                             AccessibilityBridge::kRootNodeId)
+                         .lock();
+    EXPECT_EQ(root_node->GetData().role, ax::mojom::Role::kToggleButton);
+    EXPECT_EQ(root_node->GetData().GetCheckedState(),
+              ax::mojom::CheckedState::kTrue);
+
+    // Get the IAccessible for the root node.
+    IAccessible* native_view = root_node->GetNativeViewAccessible();
+    ASSERT_TRUE(native_view != nullptr);
+
+    // Look up against the node itself (not one of its children).
+    VARIANT varchild = {};
+    varchild.vt = VT_I4;
+
+    // Verify the switch is pressed.
+    varchild.lVal = CHILDID_SELF;
+    VARIANT native_state = {};
+    ASSERT_TRUE(SUCCEEDED(native_view->get_accState(varchild, &native_state)));
+    EXPECT_TRUE(native_state.lVal & STATE_SYSTEM_PRESSED);
+  }
+
+  // Test unpressed too.
+  root.flags = static_cast<FlutterSemanticsFlag>(
+      FlutterSemanticsFlag::kFlutterSemanticsFlagHasToggledState);
+  bridge->AddFlutterSemanticsNodeUpdate(&root);
+  bridge->CommitUpdates();
+
+  {
+    auto root_node = bridge
+                         ->GetFlutterPlatformNodeDelegateFromID(
+                             AccessibilityBridge::kRootNodeId)
+                         .lock();
+    EXPECT_EQ(root_node->GetData().role, ax::mojom::Role::kToggleButton);
+    EXPECT_EQ(root_node->GetData().GetCheckedState(),
+              ax::mojom::CheckedState::kFalse);
+
+    // Get the IAccessible for the root node.
+    IAccessible* native_view = root_node->GetNativeViewAccessible();
+    ASSERT_TRUE(native_view != nullptr);
+
+    // Look up against the node itself (not one of its children).
+    VARIANT varchild = {};
+    varchild.vt = VT_I4;
+
+    // Verify the switch is not pressed.
+    varchild.lVal = CHILDID_SELF;
+    VARIANT native_state = {};
+    ASSERT_TRUE(SUCCEEDED(native_view->get_accState(varchild, &native_state)));
+    EXPECT_FALSE(native_state.lVal & STATE_SYSTEM_PRESSED);
   }
 }
 

--- a/shell/platform/windows/flutter_windows_view_unittests.cc
+++ b/shell/platform/windows/flutter_windows_view_unittests.cc
@@ -777,8 +777,14 @@ TEST(FlutterWindowsViewTest, SwitchNativeState) {
     VARIANT varchild = {};
     varchild.vt = VT_I4;
 
-    // Verify the switch is pressed.
     varchild.lVal = CHILDID_SELF;
+    VARIANT varrole = {};
+
+    // Verify the role of the switch is CHECKBUTTON
+    ASSERT_EQ(native_view->get_accRole(varchild, &varrole), S_OK);
+    ASSERT_EQ(varrole.lVal, ROLE_SYSTEM_CHECKBUTTON);
+
+    // Verify the switch is pressed.
     VARIANT native_state = {};
     ASSERT_TRUE(SUCCEEDED(native_view->get_accState(varchild, &native_state)));
     EXPECT_TRUE(native_state.lVal & STATE_SYSTEM_PRESSED);

--- a/third_party/accessibility/ax/platform/ax_platform_node_win.cc
+++ b/third_party/accessibility/ax/platform/ax_platform_node_win.cc
@@ -3421,7 +3421,7 @@ int AXPlatformNodeWin::MSAARole() {
       return ROLE_SYSTEM_TITLEBAR;
 
     case ax::mojom::Role::kToggleButton:
-      return ROLE_SYSTEM_PUSHBUTTON;
+      return ROLE_SYSTEM_CHECKBUTTON;
 
     case ax::mojom::Role::kTextField:
     case ax::mojom::Role::kSearchBox:


### PR DESCRIPTION
Switch widgets used to have the `PUSHBUTTON` role on Windows, which has no associated state. This PR switches it to a `CHECKBUTTON` and associates the `PRESSED` state with its MSAA node when it is toggled. Adds a unit test to verify that the native state reflects the toggle state of the Switch.

Also fixes some typos in comments in the existing checkbox unit test.

Addresses [#flutter/flutter/111525](https://github.com/flutter/flutter/issues/111525)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
