### PR TITLE
[Impeller] Support uniform struct arrays

### DIFF
--- a/impeller/compiler/code_gen_template.h
+++ b/impeller/compiler/code_gen_template.h
@@ -50,7 +50,7 @@ struct {{camel_case(shader_name)}}{{camel_case(shader_stage)}}Shader {
 {% for def in struct_definitions %}
   struct {{def.name}} {
 {% for member in def.members %}
-    {{member.type}} {{member.name}}; // (offset {{member.offset}}, size {{member.byte_length}})
+    {{member.type}} {{member.name}}{% if member.array_elements > 1 %}[{{member.array_elements}}]{% endif %}; // (offset {{member.offset}}, size {{member.byte_length}})
 {% endfor %}
   }; // struct {{def.name}} (size {{def.byte_length}})
 {% endfor %}
@@ -205,10 +205,11 @@ ShaderMetadata Shader::kMetadata{{camel_case(buffer.name)}} = {
   std::vector<ShaderStructMemberMetadata> {
     {% for member in buffer.type.members %}
       ShaderStructMemberMetadata {
-        {{ member.base_type }}, // type
-        "{{ member.name }}",    // name
-        {{ member.offset }},    // offset
-        {{ member.size }},      // size
+        {{ member.base_type }},      // type
+        "{{ member.name }}",         // name
+        {{ member.offset }},         // offset
+        {{ member.size }},           // size
+        {{ member.array_elements }}, // array_elements
       },
     {% endfor %}
   } // members

--- a/impeller/compiler/code_gen_template.h
+++ b/impeller/compiler/code_gen_template.h
@@ -50,7 +50,7 @@ struct {{camel_case(shader_name)}}{{camel_case(shader_stage)}}Shader {
 {% for def in struct_definitions %}
   struct {{def.name}} {
 {% for member in def.members %}
-    {{member.type}} {{member.name}}{% if member.array_elements > 1 %}[{{member.array_elements}}]{% endif %}; // (offset {{member.offset}}, size {{member.byte_length}})
+{% if member.element_padding > 0 %}Padded<{{member.type}}, {{member.element_padding}}>{% else %}{{member.type}}{% endif %} {{" " + member.name}}{% if member.array_elements > 1 %}[{{member.array_elements}}]{% endif %}; // (offset {{member.offset}}, size {{member.byte_length}})
 {% endfor %}
   }; // struct {{def.name}} (size {{def.byte_length}})
 {% endfor %}

--- a/impeller/compiler/code_gen_template.h
+++ b/impeller/compiler/code_gen_template.h
@@ -209,6 +209,7 @@ ShaderMetadata Shader::kMetadata{{camel_case(buffer.name)}} = {
         "{{ member.name }}",         // name
         {{ member.offset }},         // offset
         {{ member.size }},           // size
+        {{ member.byte_length }},    // byte_length
         {{ member.array_elements }}, // array_elements
       },
     {% endfor %}

--- a/impeller/compiler/reflector.h
+++ b/impeller/compiler/reflector.h
@@ -23,6 +23,7 @@ struct StructMember {
   std::string base_type;
   std::string name;
   size_t offset = 0u;
+  size_t size = 0u;
   size_t byte_length = 0u;
   size_t array_elements = 1u;
   size_t element_padding = 0u;
@@ -31,6 +32,7 @@ struct StructMember {
                std::string p_base_type,
                std::string p_name,
                size_t p_offset,
+               size_t p_size,
                size_t p_byte_length,
                size_t p_array_elements,
                size_t p_element_padding)
@@ -38,6 +40,7 @@ struct StructMember {
         base_type(std::move(p_base_type)),
         name(std::move(p_name)),
         offset(p_offset),
+        size(p_size),
         byte_length(p_byte_length),
         array_elements(p_array_elements),
         element_padding(p_element_padding) {}

--- a/impeller/compiler/reflector.h
+++ b/impeller/compiler/reflector.h
@@ -25,19 +25,22 @@ struct StructMember {
   size_t offset = 0u;
   size_t byte_length = 0u;
   size_t array_elements = 1u;
+  size_t element_padding = 0u;
 
   StructMember(std::string p_type,
                std::string p_base_type,
                std::string p_name,
                size_t p_offset,
                size_t p_byte_length,
-               size_t p_array_elements)
+               size_t p_array_elements,
+               size_t p_element_padding)
       : type(std::move(p_type)),
         base_type(std::move(p_base_type)),
         name(std::move(p_name)),
         offset(p_offset),
         byte_length(p_byte_length),
-        array_elements(p_array_elements) {}
+        array_elements(p_array_elements),
+        element_padding(p_element_padding) {}
 };
 
 class Reflector {
@@ -144,6 +147,17 @@ class Reflector {
       const spirv_cross::TypeID& type_id) const;
 
   uint32_t GetArrayElements(const spirv_cross::SPIRType& type) const;
+
+  template <uint32_t Size>
+  uint32_t GetArrayStride(const spirv_cross::SPIRType& struct_type,
+                          const spirv_cross::SPIRType& member_type,
+                          uint32_t index) const {
+    auto element_count = GetArrayElements(member_type);
+    if (element_count <= 1) {
+      return Size;
+    }
+    return compiler_->type_struct_member_array_stride(struct_type, index);
+  };
 
   FML_DISALLOW_COPY_AND_ASSIGN(Reflector);
 };

--- a/impeller/compiler/reflector.h
+++ b/impeller/compiler/reflector.h
@@ -24,17 +24,20 @@ struct StructMember {
   std::string name;
   size_t offset = 0u;
   size_t byte_length = 0u;
+  size_t array_elements = 1u;
 
   StructMember(std::string p_type,
                std::string p_base_type,
                std::string p_name,
                size_t p_offset,
-               size_t p_byte_length)
+               size_t p_byte_length,
+               size_t p_array_elements)
       : type(std::move(p_type)),
         base_type(std::move(p_base_type)),
         name(std::move(p_name)),
         offset(p_offset),
-        byte_length(p_byte_length) {}
+        byte_length(p_byte_length),
+        array_elements(p_array_elements) {}
 };
 
 class Reflector {

--- a/impeller/docs/ubo_gles2.md
+++ b/impeller/docs/ubo_gles2.md
@@ -31,6 +31,7 @@ struct ShaderStructMemberMetadata {
   std::string name; // the uniform member name "frame_info.mvp"
   size_t offset;
   size_t size;
+  size_t array_elements;
 };
 ```
 

--- a/impeller/fixtures/BUILD.gn
+++ b/impeller/fixtures/BUILD.gn
@@ -8,6 +8,8 @@ import("//flutter/testing/testing.gni")
 impeller_shaders("shader_fixtures") {
   name = "fixtures"
   shaders = [
+    "array.frag",
+    "array.vert",
     "box_fade.frag",
     "box_fade.vert",
     "colors.vert",

--- a/impeller/fixtures/array.frag
+++ b/impeller/fixtures/array.frag
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 uniform FragInfo {
-  vec4 circle_positions[4];
+  vec2 circle_positions[4];
   vec4 colors[4];
 }
 frag_info;

--- a/impeller/fixtures/array.frag
+++ b/impeller/fixtures/array.frag
@@ -1,0 +1,27 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+uniform FragInfo {
+  vec4 circle_positions[4];
+  vec4 colors[4];
+}
+frag_info;
+
+in vec2 v_position;
+
+out vec4 frag_color;
+
+float SphereDistance(vec2 position, float radius) {
+  return length(v_position - position) - radius;
+}
+
+void main() {
+  for (int i = 0; i < 4; i++) {
+    if (SphereDistance(frag_info.circle_positions[i].xy, 20) <= 0) {
+      frag_color = frag_info.colors[i];
+      return;
+    }
+  }
+  frag_color = vec4(0);
+}

--- a/impeller/fixtures/array.vert
+++ b/impeller/fixtures/array.vert
@@ -1,0 +1,17 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+uniform VertInfo {
+  mat4 mvp;
+}
+vert_info;
+
+in vec2 position;
+
+out vec2 v_position;
+
+void main() {
+  gl_Position = vert_info.mvp * vec4(position, 0.0, 1.0);
+  v_position = position;
+}

--- a/impeller/geometry/color.h
+++ b/impeller/geometry/color.h
@@ -41,10 +41,15 @@ struct Color {
 
   constexpr Color() {}
 
-  Color(const ColorHSB& hsbColor);
+  explicit Color(const ColorHSB& hsbColor);
 
   constexpr Color(Scalar r, Scalar g, Scalar b, Scalar a)
       : red(r), green(g), blue(b), alpha(a) {}
+
+  static constexpr Color MakeRGBA8(uint8_t r, uint8_t g, uint8_t b, uint8_t a) {
+    return Color(static_cast<Scalar>(r) / 255, static_cast<Scalar>(g) / 255,
+                 static_cast<Scalar>(b) / 255, static_cast<Scalar>(a) / 255);
+  }
 
   constexpr bool operator==(const Color& c) const {
     return red == c.red && green == c.green && blue == c.blue &&

--- a/impeller/geometry/geometry_unittests.cc
+++ b/impeller/geometry/geometry_unittests.cc
@@ -964,6 +964,26 @@ TEST(GeometryTest, ColorLerp) {
   }
 }
 
+TEST(GeometryTest, ColorMakeRGBA8) {
+  {
+    Color a = Color::MakeRGBA8(0, 0, 0, 0);
+    Color b = Color::BlackTransparent();
+    ASSERT_COLOR_NEAR(a, b);
+  }
+
+  {
+    Color a = Color::MakeRGBA8(255, 255, 255, 255);
+    Color b = Color::White();
+    ASSERT_COLOR_NEAR(a, b);
+  }
+
+  {
+    Color a = Color::MakeRGBA8(63, 127, 191, 127);
+    Color b(0.247059, 0.498039, 0.74902, 0.498039);
+    ASSERT_COLOR_NEAR(a, b);
+  }
+}
+
 TEST(GeometryTest, CanConvertBetweenDegressAndRadians) {
   {
     auto deg = Degrees{90.0};

--- a/impeller/renderer/backend/gles/buffer_bindings_gles.cc
+++ b/impeller/renderer/backend/gles/buffer_bindings_gles.cc
@@ -224,18 +224,21 @@ bool BufferBindingsGLES::BindUniformBuffer(const ProcTableGLES& gl,
     auto* buffer_data =
         reinterpret_cast<const GLfloat*>(buffer_ptr + member.offset);
 
-    std::vector<uint8_t> buffer;
+    std::vector<uint8_t> array_element_buffer;
     if (member.array_elements > 1) {
       // When binding uniform arrays, the elements must be contiguous. Copy the
       // uniforms to a temp buffer to eliminate any padding needed by the other
       // backends.
-      buffer.reserve(member.size * member.array_elements);
+      array_element_buffer.resize(member.size * member.array_elements);
       for (size_t element_i = 0; element_i < member.array_elements;
            element_i++) {
-        std::memcpy(buffer.data(), buffer_data + element_i * element_stride,
+        std::memcpy(array_element_buffer.data() + element_i * member.size,
+                    reinterpret_cast<const char*>(buffer_data) +
+                        element_i * element_stride,
                     member.size);
       }
-      buffer_data = reinterpret_cast<const GLfloat*>(buffer.data());
+      buffer_data =
+          reinterpret_cast<const GLfloat*>(array_element_buffer.data());
     }
 
     switch (member.type) {

--- a/impeller/renderer/backend/gles/buffer_bindings_gles.cc
+++ b/impeller/renderer/backend/gles/buffer_bindings_gles.cc
@@ -70,9 +70,13 @@ static std::string NormalizeUniformKey(const std::string& key) {
 }
 
 static std::string CreateUnifiormMemberKey(const std::string& struct_name,
-                                           const std::string& member) {
+                                           const std::string& member,
+                                           bool is_array) {
   std::stringstream stream;
   stream << struct_name << "." << member;
+  if (is_array) {
+    stream << "[0]";
+  }
   return NormalizeUniformKey(stream.str());
 }
 
@@ -112,10 +116,6 @@ bool BufferBindingsGLES::ReadUniformsBindings(const ProcTableGLES& gl,
     }
     if (written_count <= 0) {
       VALIDATION_LOG << "Uniform name could not be read for active uniform.";
-      return false;
-    }
-    if (uniform_var_size != 1) {
-      VALIDATION_LOG << "Array uniform types are not supported.";
       return false;
     }
     uniform_locations_[NormalizeUniformKey(std::string{
@@ -208,51 +208,51 @@ bool BufferBindingsGLES::BindUniformBuffer(const ProcTableGLES& gl,
       // mappings for these. Keep going.
       continue;
     }
-    const auto member_key =
-        CreateUnifiormMemberKey(metadata->name, member.name);
+
+    const auto member_key = CreateUnifiormMemberKey(metadata->name, member.name,
+                                                    member.array_elements > 1);
     const auto location = uniform_locations_.find(member_key);
     if (location == uniform_locations_.end()) {
       VALIDATION_LOG << "Location for uniform member not known: " << member_key;
       return false;
     }
 
+    size_t element_size = member.size / member.array_elements;
+    auto* buffer_data =
+        reinterpret_cast<const GLfloat*>(buffer_ptr + member.offset);
+
     switch (member.type) {
       case ShaderType::kFloat:
-        switch (member.size) {
+        switch (element_size) {
           case sizeof(Matrix):
-            gl.UniformMatrix4fv(location->second,  // location
-                                1u,                // count
-                                GL_FALSE,          // normalize
-                                reinterpret_cast<const GLfloat*>(
-                                    buffer_ptr + member.offset)  // data
+            gl.UniformMatrix4fv(location->second,       // location
+                                member.array_elements,  // count
+                                GL_FALSE,               // normalize
+                                buffer_data             // data
             );
             continue;
           case sizeof(Vector4):
-            gl.Uniform4fv(location->second,  // location
-                          1u,                // count
-                          reinterpret_cast<const GLfloat*>(
-                              buffer_ptr + member.offset)  // data
+            gl.Uniform4fv(location->second,       // location
+                          member.array_elements,  // count
+                          buffer_data             // data
             );
             continue;
           case sizeof(Vector3):
-            gl.Uniform3fv(location->second,  // location
-                          1u,                // count
-                          reinterpret_cast<const GLfloat*>(
-                              buffer_ptr + member.offset)  // data
+            gl.Uniform3fv(location->second,       // location
+                          member.array_elements,  // count
+                          buffer_data             // data
             );
             continue;
           case sizeof(Vector2):
-            gl.Uniform2fv(location->second,  // location
-                          1u,                // count
-                          reinterpret_cast<const GLfloat*>(
-                              buffer_ptr + member.offset)  // data
+            gl.Uniform2fv(location->second,       // location
+                          member.array_elements,  // count
+                          buffer_data             // data
             );
             continue;
           case sizeof(Scalar):
-            gl.Uniform1fv(location->second,  // location
-                          1u,                // count
-                          reinterpret_cast<const GLfloat*>(
-                              buffer_ptr + member.offset)  // data
+            gl.Uniform1fv(location->second,       // location
+                          member.array_elements,  // count
+                          buffer_data             // data
             );
             continue;
         }

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -5,6 +5,8 @@
 #include "flutter/fml/time/time_point.h"
 #include "flutter/testing/testing.h"
 #include "impeller/base/strings.h"
+#include "impeller/fixtures/array.frag.h"
+#include "impeller/fixtures/array.vert.h"
 #include "impeller/fixtures/box_fade.frag.h"
 #include "impeller/fixtures/box_fade.vert.h"
 #include "impeller/fixtures/colors.frag.h"
@@ -729,6 +731,64 @@ TEST_P(RendererTest, TheImpeller) {
                      pass.GetTransientsBuffer().EmplaceUniform(fs_uniform));
     FS::BindBlueNoise(cmd, blue_noise, noise_sampler);
     FS::BindCubeMap(cmd, cube_map, cube_map_sampler);
+
+    pass.AddCommand(cmd);
+    return true;
+  };
+  OpenPlaygroundHere(callback);
+}
+
+TEST_P(RendererTest, ArrayUniforms) {
+  using VS = ArrayVertexShader;
+  using FS = ArrayFragmentShader;
+
+  auto context = GetContext();
+  auto pipeline_descriptor =
+      PipelineBuilder<VS, FS>::MakeDefaultPipelineDescriptor(*context);
+  ASSERT_TRUE(pipeline_descriptor.has_value());
+  pipeline_descriptor->SetSampleCount(SampleCount::kCount4);
+  auto pipeline =
+      context->GetPipelineLibrary()->GetPipeline(pipeline_descriptor).get();
+  ASSERT_TRUE(pipeline && pipeline->IsValid());
+
+  SinglePassCallback callback = [&](RenderPass& pass) {
+    auto size = pass.GetRenderTargetSize();
+
+    Command cmd;
+    cmd.pipeline = pipeline;
+    cmd.label = "Google Dots";
+    VertexBufferBuilder<VS::PerVertexData> builder;
+    builder.AddVertices({{Point()},
+                         {Point(0, size.height)},
+                         {Point(size.width, 0)},
+                         {Point(size.width, 0)},
+                         {Point(0, size.height)},
+                         {Point(size.width, size.height)}});
+    cmd.BindVertices(builder.CreateVertexBuffer(pass.GetTransientsBuffer()));
+
+    VS::VertInfo vs_uniform;
+    vs_uniform.mvp =
+        Matrix::MakeOrthographic(size) * Matrix::MakeScale(GetContentScale());
+    VS::BindVertInfo(cmd,
+                     pass.GetTransientsBuffer().EmplaceUniform(vs_uniform));
+
+    auto time = fml::TimePoint::Now().ToEpochDelta().ToSecondsF();
+    auto y_pos = [&time](float x) {
+      return 400 + 10 * std::cos(time * 5 + x / 6);
+    };
+
+    FS::FragInfo fs_uniform = {
+        .circle_positions = {Vector4(430, y_pos(0), 0, 0),
+                             Vector4(480, y_pos(1), 0, 0),
+                             Vector4(530, y_pos(2), 0, 0),
+                             Vector4(580, y_pos(3), 0, 0)},
+        .colors = {Color::MakeRGBA8(66, 133, 244, 255),
+                   Color::MakeRGBA8(219, 68, 55, 255),
+                   Color::MakeRGBA8(244, 180, 0, 255),
+                   Color::MakeRGBA8(15, 157, 88, 255)},
+    };
+    FS::BindFragInfo(cmd,
+                     pass.GetTransientsBuffer().EmplaceUniform(fs_uniform));
 
     pass.AddCommand(cmd);
     return true;

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -778,10 +778,8 @@ TEST_P(RendererTest, ArrayUniforms) {
     };
 
     FS::FragInfo fs_uniform = {
-        .circle_positions = {Vector4(430, y_pos(0), 0, 0),
-                             Vector4(480, y_pos(1), 0, 0),
-                             Vector4(530, y_pos(2), 0, 0),
-                             Vector4(580, y_pos(3), 0, 0)},
+        .circle_positions = {Point(430, y_pos(0)), Point(480, y_pos(1)),
+                             Point(530, y_pos(2)), Point(580, y_pos(3))},
         .colors = {Color::MakeRGBA8(66, 133, 244, 255),
                    Color::MakeRGBA8(219, 68, 55, 255),
                    Color::MakeRGBA8(244, 180, 0, 255),

--- a/impeller/renderer/shader_types.h
+++ b/impeller/renderer/shader_types.h
@@ -123,6 +123,17 @@ struct Padding {
   uint8_t pad_[Size];
 };
 
+/// @brief Struct used for padding uniform buffer array elements.
+template <typename T,
+          size_t Size,
+          class = std::enable_if_t<std::is_standard_layout_v<T>>>
+struct Padded {
+  T value;
+  Padding<Size> _PADDING_;
+
+  Padded(T p_value) : value(p_value){};  // NOLINT(google-explicit-constructor)
+};
+
 inline constexpr Vector4 ToVector(Color color) {
   return {color.red, color.green, color.blue, color.alpha};
 }

--- a/impeller/renderer/shader_types.h
+++ b/impeller/renderer/shader_types.h
@@ -67,6 +67,7 @@ struct ShaderStructMemberMetadata {
   std::string name;
   size_t offset;
   size_t size;
+  size_t array_elements;
 };
 
 struct ShaderMetadata {

--- a/impeller/renderer/shader_types.h
+++ b/impeller/renderer/shader_types.h
@@ -67,6 +67,7 @@ struct ShaderStructMemberMetadata {
   std::string name;
   size_t offset;
   size_t size;
+  size_t byte_length;
   size_t array_elements;
 };
 


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/110514.

The individual array elements need to be aligned for Metal -- this is done through a new `Padded` struct template. For GLES, the data needs to be contiguous, so the array elements are just copied to a temp buffer prior to binding.

https://user-images.githubusercontent.com/919017/190632260-40e6b262-f24c-4266-8879-b5b7ee1d53e3.mov

