### PR TITLE
Reland "Avoid vsync scheduling delay"

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1648,6 +1648,7 @@ FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/platform/Platfor
 FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/platform/SingleViewPresentation.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java
+FILE: ../../../flutter/shell/platform/android/io/flutter/util/HandlerCompat.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/util/PathUtils.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/util/Preconditions.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/util/Predicate.java

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -289,6 +289,7 @@ android_java_sources = [
   "io/flutter/plugin/platform/PlatformViewsController.java",
   "io/flutter/plugin/platform/SingleViewPresentation.java",
   "io/flutter/plugin/platform/VirtualDisplayController.java",
+  "io/flutter/util/HandlerCompat.java",
   "io/flutter/util/PathUtils.java",
   "io/flutter/util/Preconditions.java",
   "io/flutter/util/Predicate.java",

--- a/shell/platform/android/io/flutter/embedding/engine/dart/PlatformTaskQueue.java
+++ b/shell/platform/android/io/flutter/embedding/engine/dart/PlatformTaskQueue.java
@@ -7,10 +7,13 @@ package io.flutter.embedding.engine.dart;
 import android.os.Handler;
 import android.os.Looper;
 import androidx.annotation.NonNull;
+import io.flutter.util.HandlerCompat;
 
 /** A BinaryMessenger.TaskQueue that posts to the platform thread (aka main thread). */
 public class PlatformTaskQueue implements DartMessenger.DartMessengerTaskQueue {
-  @NonNull private final Handler handler = new Handler(Looper.getMainLooper());
+  // Use an async handler because the default is subject to vsync synchronization and can result
+  // in delays when dispatching tasks.
+  @NonNull private final Handler handler = HandlerCompat.createAsyncHandler(Looper.getMainLooper());
 
   @Override
   public void dispatch(@NonNull Runnable runnable) {

--- a/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
@@ -23,6 +23,7 @@ import io.flutter.BuildConfig;
 import io.flutter.FlutterInjector;
 import io.flutter.Log;
 import io.flutter.embedding.engine.FlutterJNI;
+import io.flutter.util.HandlerCompat;
 import io.flutter.util.PathUtils;
 import io.flutter.util.TraceSection;
 import io.flutter.view.VsyncWaiter;
@@ -385,7 +386,7 @@ public class FlutterLoader {
             Log.e(TAG, "Flutter initialization failed.", e);
             throw new RuntimeException(e);
           }
-          new Handler(Looper.getMainLooper())
+          HandlerCompat.createAsyncHandler(Looper.getMainLooper())
               .post(
                   () -> {
                     ensureInitializationComplete(applicationContext.getApplicationContext(), args);

--- a/shell/platform/android/io/flutter/util/HandlerCompat.java
+++ b/shell/platform/android/io/flutter/util/HandlerCompat.java
@@ -1,0 +1,35 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.util;
+
+import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
+
+/** Compatability wrapper over {@link Handler}. */
+public final class HandlerCompat {
+  /**
+   * Create a new Handler whose posted messages and runnables are not subject to synchronization
+   * barriers such as display vsync.
+   *
+   * <p>Messages sent to an async handler are guaranteed to be ordered with respect to one another,
+   * but not necessarily with respect to messages from other Handlers. Compatibility behavior:
+   *
+   * <ul>
+   *   <li>SDK 28 and above, this method matches platform behavior.
+   *   <li>Otherwise, returns a synchronous handler instance.
+   * </ul>
+   *
+   * @param looper the Looper that the new Handler should be bound to
+   * @return a new async Handler instance
+   * @see Handler#createAsync(Looper)
+   */
+  public static Handler createAsyncHandler(Looper looper) {
+    if (Build.VERSION.SDK_INT >= 28) {
+      return Handler.createAsync(looper);
+    }
+    return new Handler(looper);
+  }
+}

--- a/shell/platform/android/test/io/flutter/util/HandlerCompatTest.java
+++ b/shell/platform/android/test/io/flutter/util/HandlerCompatTest.java
@@ -1,0 +1,29 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.util;
+
+import static org.junit.Assert.assertTrue;
+
+import android.os.Handler;
+import android.os.Looper;
+import android.os.Message;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+public class HandlerCompatTest {
+  @Test
+  @Config(sdk = 28)
+  public void createAsync_createsAnAsyncHandler() {
+    Handler handler = Handler.createAsync(Looper.getMainLooper());
+
+    Message message = Message.obtain();
+    handler.sendMessageAtTime(message, 0);
+
+    assertTrue(message.isAsynchronous());
+  }
+}

--- a/tools/android_lint/project.xml
+++ b/tools/android_lint/project.xml
@@ -23,6 +23,7 @@
     <src file="../../../flutter/shell/platform/android/io/flutter/util/Predicate.java" />
     <src file="../../../flutter/shell/platform/android/io/flutter/util/TraceSection.java" />
     <src file="../../../flutter/shell/platform/android/io/flutter/util/PathUtils.java" />
+    <src file="../../../flutter/shell/platform/android/io/flutter/util/HandlerCompat.java" />
     <src file="../../../flutter/shell/platform/android/io/flutter/embedding/android/KeyboardMap.java" />
     <src file="../../../flutter/shell/platform/android/io/flutter/embedding/android/KeyboardManager.java" />
     <src file="../../../flutter/shell/platform/android/io/flutter/embedding/android/AndroidTouchProcessor.java" />


### PR DESCRIPTION
Relands https://github.com/flutter/engine/pull/34363 which was reverted in https://github.com/flutter/engine/pull/36091 with fix.

Fix https://github.com/flutter/flutter/issues/110867. The fix is in https://github.com/flutter/engine/pull/36197/commits/6cf54943025806b91b27f8558217d414ee0d4ff0; the parent commit is a pure revert of the revert.

## Explanation of https://github.com/flutter/flutter/issues/110867

Some user might write Dart code like the following to keep the app in full screen mode even after this might be changed in response to certain user actions. There is no built in time out or gesture that will restore the full screen mode the app was in. (Thanks to @Piinks for helping me understand this offline)

```dart
SystemChrome.setSystemUIChangeCallback((systemOverlaysAreVisible) async {
  SystemChrome.restoreSystemUIOverlays();
});
```

This is what happens:

1. User swipes up or does some gesture which causes the system UI mode to change
1. `OnSystemUiVisibilityChangeListener` receives a notification of the change
1. It propagates a platform message to Dart; the Dart callback defined in `setSystemUIChangeCallback` (above) is called
1. `SystemChrome.restoreSystemUIOverlays()` is called in the callback, sending a platform message to the host
1. Platform message is scheduled on the host; resulting in a call to `setSystemUiVisibility`. 
 
**1-5 all occur in the same frame**. Because of this, `OnSystemUiVisibilityChangeListener` will silently stop responding to future system UI notifications.

#34363 introduces the behaviour in bold; previously using `new Handler` instead of `Handler.createAsync` will always cause platform messages to be scheduled in the next frame, such as in (5).

This PR causes (3) to be scheduled in a subsequent frame, avoiding the issue.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].
