### PR TITLE
Revert "[Impeller] add support for COLR fonts and bitmap emojis"

### DIFF
--- a/impeller/entity/contents/text_contents.cc
+++ b/impeller/entity/contents/text_contents.cc
@@ -4,7 +4,6 @@
 
 #include "impeller/entity/contents/text_contents.h"
 
-#include <iostream>
 #include <optional>
 
 #include "impeller/entity/contents/content_context.h"
@@ -90,18 +89,15 @@ bool TextContents::Render(const ContentContext& renderer,
   VS::FrameInfo frame_info;
   frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
                    entity.GetTransformation();
+  frame_info.atlas_size =
+      Point{static_cast<Scalar>(atlas->GetTexture()->GetSize().width),
+            static_cast<Scalar>(atlas->GetTexture()->GetSize().height)};
+  frame_info.text_color = ToVector(color_.Premultiply());
   VS::BindFrameInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frame_info));
 
   SamplerDescriptor sampler_desc;
   sampler_desc.min_filter = MinMagFilter::kLinear;
   sampler_desc.mag_filter = MinMagFilter::kLinear;
-
-  FS::FragInfo frag_info;
-  frag_info.text_color = ToVector(color_.Premultiply());
-  frag_info.atlas_size =
-      Point{static_cast<Scalar>(atlas->GetTexture()->GetSize().width),
-            static_cast<Scalar>(atlas->GetTexture()->GetSize().height)};
-  FS::BindFragInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frag_info));
 
   // Common fragment uniforms for all glyphs.
   FS::BindGlyphAtlasSampler(
@@ -127,13 +123,11 @@ bool TextContents::Render(const ContentContext& renderer,
     auto font = run.GetFont();
     auto glyph_size = ISize::Ceil(font.GetMetrics().GetBoundingBox().size);
     for (const auto& glyph_position : run.GetGlyphPositions()) {
-      FontGlyphPair font_glyph_pair{font, glyph_position.glyph};
-      auto color_glyph =
-          atlas->IsColorFontGlyphPair(font_glyph_pair) ? 1.0 : 0.0;
       for (const auto& point : unit_vertex_points) {
         VS::PerVertexData vtx;
         vtx.unit_vertex = point;
 
+        FontGlyphPair font_glyph_pair{font, glyph_position.glyph};
         auto atlas_glyph_pos = atlas->FindFontGlyphPosition(font_glyph_pair);
         if (!atlas_glyph_pos.has_value()) {
           VALIDATION_LOG << "Could not find glyph position in the atlas.";
@@ -149,7 +143,6 @@ bool TextContents::Render(const ContentContext& renderer,
                                             1 / atlas_glyph_pos->size.height};
         vtx.atlas_glyph_size =
             Point{atlas_glyph_pos->size.width, atlas_glyph_pos->size.height};
-        vtx.color_glyph = color_glyph;
         vertex_builder.AppendVertex(std::move(vtx));
       }
     }

--- a/impeller/entity/shaders/glyph_atlas.frag
+++ b/impeller/entity/shaders/glyph_atlas.frag
@@ -4,31 +4,20 @@
 
 uniform sampler2D glyph_atlas_sampler;
 
-uniform FragInfo {
-  vec2 atlas_size;
-  vec4 text_color;
-  float font_has_color;
-} frag_info;
-
 in vec2 v_unit_vertex;
 in vec2 v_atlas_position;
 in vec2 v_atlas_glyph_size;
-in float v_color_glyph;
+in vec2 v_atlas_size;
+in vec4 v_text_color;
 
 out vec4 frag_color;
 
 void main() {
-  vec2 scale_perspective = v_atlas_glyph_size / frag_info.atlas_size;
-  vec2 offset = v_atlas_position / frag_info.atlas_size;
-  if (v_color_glyph == 1.0) {
-    frag_color = texture(
-      glyph_atlas_sampler,
-      v_unit_vertex * scale_perspective + offset
-    );
-  } else {
-    frag_color = texture(
-      glyph_atlas_sampler,
-      v_unit_vertex * scale_perspective + offset
-    ).aaaa * frag_info.text_color;
-  }
+  vec2 scale_perspective = v_atlas_glyph_size / v_atlas_size;
+  vec2 offset = v_atlas_position / v_atlas_size;
+
+  frag_color = texture(
+    glyph_atlas_sampler,
+    v_unit_vertex * scale_perspective + offset
+  ).aaaa * v_text_color;
 }

--- a/impeller/entity/shaders/glyph_atlas.vert
+++ b/impeller/entity/shaders/glyph_atlas.vert
@@ -4,6 +4,8 @@
 
 uniform FrameInfo {
   mat4 mvp;
+  vec2 atlas_size;
+  vec4 text_color;
 } frame_info;
 
 in vec2 unit_vertex;
@@ -11,12 +13,12 @@ in vec2 glyph_position;
 in vec2 glyph_size;
 in vec2 atlas_position;
 in vec2 atlas_glyph_size;
-in float color_glyph;
 
 out vec2 v_unit_vertex;
 out vec2 v_atlas_position;
 out vec2 v_atlas_glyph_size;
-out float v_color_glyph;
+out vec2 v_atlas_size;
+out vec4 v_text_color;
 
 void main() {
   vec4 translate = frame_info.mvp[0] * glyph_position.x
@@ -38,5 +40,6 @@ void main() {
   v_unit_vertex = unit_vertex;
   v_atlas_position = atlas_position;
   v_atlas_glyph_size = atlas_glyph_size;
-  v_color_glyph = color_glyph;
+  v_atlas_size = frame_info.atlas_size;
+  v_text_color = frame_info.text_color;
 }

--- a/impeller/typographer/backends/skia/text_render_context_skia.cc
+++ b/impeller/typographer/backends/skia/text_render_context_skia.cc
@@ -15,9 +15,8 @@
 #include "third_party/skia/include/core/SkFontMetrics.h"
 #include "third_party/skia/include/core/SkRSXform.h"
 #include "third_party/skia/include/core/SkSurface.h"
-#include "third_party/skia/src/core/SkIPoint16.h"    //nogncheck
-#include "third_party/skia/src/core/SkStrikeSpec.h"  // nogncheck
-#include "third_party/skia/src/gpu/GrRectanizer.h"   //nogncheck
+#include "third_party/skia/src/core/SkIPoint16.h"   //nogncheck
+#include "third_party/skia/src/gpu/GrRectanizer.h"  //nogncheck
 
 namespace impeller {
 
@@ -108,9 +107,7 @@ static std::shared_ptr<SkBitmap> CreateAtlasBitmap(const GlyphAtlas& atlas,
                                                    size_t atlas_size) {
   TRACE_EVENT0("impeller", __FUNCTION__);
   auto bitmap = std::make_shared<SkBitmap>();
-  auto image_info = atlas.ContainsColorGlyph()
-                        ? SkImageInfo::MakeN32Premul(atlas_size, atlas_size)
-                        : SkImageInfo::MakeA8(atlas_size, atlas_size);
+  auto image_info = SkImageInfo::MakeA8(atlas_size, atlas_size);
   if (!bitmap->tryAllocPixels(image_info)) {
     return nullptr;
   }
@@ -125,21 +122,24 @@ static std::shared_ptr<SkBitmap> CreateAtlasBitmap(const GlyphAtlas& atlas,
 
   atlas.IterateGlyphs([canvas](const FontGlyphPair& font_glyph,
                                const Rect& location) -> bool {
-    const auto& metrics = font_glyph.font.GetMetrics();
-    const auto position = SkPoint::Make(location.origin.x / metrics.scale,
-                                        location.origin.y / metrics.scale);
+    const auto position =
+        SkPoint::Make(location.origin.x / font_glyph.font.GetMetrics().scale,
+                      location.origin.y / font_glyph.font.GetMetrics().scale);
     SkGlyphID glyph_id = font_glyph.glyph.index;
 
     SkFont sk_font(
         TypefaceSkia::Cast(*font_glyph.font.GetTypeface()).GetSkiaTypeface(),
-        metrics.point_size);
+        font_glyph.font.GetMetrics().point_size);
+
+    const auto& metrics = font_glyph.font.GetMetrics();
 
     auto glyph_color = SK_ColorWHITE;
 
     SkPaint glyph_paint;
     glyph_paint.setColor(glyph_color);
     canvas->resetMatrix();
-    canvas->scale(metrics.scale, metrics.scale);
+    canvas->scale(font_glyph.font.GetMetrics().scale,
+                  font_glyph.font.GetMetrics().scale);
     canvas->drawGlyphs(1u,         // count
                        &glyph_id,  // glyphs
                        &position,  // positions
@@ -157,8 +157,7 @@ static std::shared_ptr<SkBitmap> CreateAtlasBitmap(const GlyphAtlas& atlas,
 static std::shared_ptr<Texture> UploadGlyphTextureAtlas(
     std::shared_ptr<Allocator> allocator,
     std::shared_ptr<SkBitmap> bitmap,
-    size_t atlas_size,
-    PixelFormat format) {
+    size_t atlas_size) {
   TRACE_EVENT0("impeller", __FUNCTION__);
   if (!allocator) {
     return nullptr;
@@ -169,7 +168,7 @@ static std::shared_ptr<Texture> UploadGlyphTextureAtlas(
 
   TextureDescriptor texture_descriptor;
   texture_descriptor.storage_mode = StorageMode::kHostVisible;
-  texture_descriptor.format = format;
+  texture_descriptor.format = PixelFormat::kA8UNormInt;
   texture_descriptor.size = ISize::MakeWH(atlas_size, atlas_size);
 
   if (pixmap.rowBytes() * pixmap.height() !=
@@ -203,16 +202,6 @@ std::shared_ptr<GlyphAtlas> TextRenderContextSkia::CreateGlyphAtlas(
   }
 
   auto glyph_atlas = std::make_shared<GlyphAtlas>();
-  glyph_atlas->SetFontColorCallback([](const FontGlyphPair& font_glyph) {
-    // TODO(jonahwilliams): ask Skia for a public API to look this up.
-    SkFont sk_font(
-        TypefaceSkia::Cast(*font_glyph.font.GetTypeface()).GetSkiaTypeface(),
-        font_glyph.font.GetMetrics().point_size);
-
-    SkStrikeSpec strikeSpec = SkStrikeSpec::MakeWithNoDevice(sk_font);
-    SkBulkGlyphMetricsAndPaths paths{strikeSpec};
-    return paths.glyph(font_glyph.glyph.index)->isColor();
-  });
 
   // ---------------------------------------------------------------------------
   // Step 1: Collect unique font-glyph pairs in the frame.
@@ -262,11 +251,8 @@ std::shared_ptr<GlyphAtlas> TextRenderContextSkia::CreateGlyphAtlas(
   // ---------------------------------------------------------------------------
   // Step 6: Upload the atlas as a texture.
   // ---------------------------------------------------------------------------
-  auto format = glyph_atlas->ContainsColorGlyph()
-                    ? PixelFormat::kR8G8B8A8UNormInt
-                    : PixelFormat::kA8UNormInt;
   auto texture = UploadGlyphTextureAtlas(GetContext()->GetResourceAllocator(),
-                                         bitmap, atlas_size, format);
+                                         bitmap, atlas_size);
   if (!texture) {
     return nullptr;
   }

--- a/impeller/typographer/glyph_atlas.cc
+++ b/impeller/typographer/glyph_atlas.cc
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 #include "impeller/typographer/glyph_atlas.h"
-#include <iostream>
 
 namespace impeller {
 
@@ -15,10 +14,6 @@ bool GlyphAtlas::IsValid() const {
   return !!texture_;
 }
 
-bool GlyphAtlas::ContainsColorGlyph() const {
-  return has_color_glyph;
-}
-
 const std::shared_ptr<Texture>& GlyphAtlas::GetTexture() const {
   return texture_;
 }
@@ -28,26 +23,7 @@ void GlyphAtlas::SetTexture(std::shared_ptr<Texture> texture) {
 }
 
 void GlyphAtlas::AddTypefaceGlyphPosition(FontGlyphPair pair, Rect rect) {
-  if (callback_.has_value()) {
-    auto has_color = callback_.value()(pair);
-    has_color_glyph |= has_color;
-    colors_[pair] = has_color;
-  }
-
   positions_[pair] = rect;
-}
-
-void GlyphAtlas::SetFontColorCallback(
-    std::function<bool(const FontGlyphPair& pair)> callback) {
-  callback_ = std::move(callback);
-}
-
-bool GlyphAtlas::IsColorFontGlyphPair(const FontGlyphPair& pair) const {
-  auto found = colors_.find(pair);
-  if (found == colors_.end()) {
-    return false;
-  }
-  return found->second;
 }
 
 std::optional<Rect> GlyphAtlas::FindFontGlyphPosition(

--- a/impeller/typographer/glyph_atlas.h
+++ b/impeller/typographer/glyph_atlas.h
@@ -33,30 +33,11 @@ class GlyphAtlas {
   bool IsValid() const;
 
   //----------------------------------------------------------------------------
-  /// @brief   Whether at least one font-glyph pair has colors.
-  ///
-  bool ContainsColorGlyph() const;
-
-  //----------------------------------------------------------------------------
   /// @brief      Set the texture for the glyph atlas.
   ///
   /// @param[in]  texture  The texture
   ///
   void SetTexture(std::shared_ptr<Texture> texture);
-
-  //----------------------------------------------------------------------------
-  /// @brief      Set a callback that determines if a glyph-font pair
-  ///             has color.
-  ///
-  /// @param[in]  callback  The callback
-  ///
-  void SetFontColorCallback(
-      std::function<bool(const FontGlyphPair& pair)> callback);
-
-  //----------------------------------------------------------------------------
-  /// @brief      Whether the provided glyph-font pair contains color.
-  ///
-  bool IsColorFontGlyphPair(const FontGlyphPair& pair) const;
 
   //----------------------------------------------------------------------------
   /// @brief      Get the texture for the glyph atlas.
@@ -105,20 +86,12 @@ class GlyphAtlas {
 
  private:
   std::shared_ptr<Texture> texture_;
-  std::optional<std::function<bool(const FontGlyphPair& pair)>> callback_;
-  bool has_color_glyph = false;
 
   std::unordered_map<FontGlyphPair,
                      Rect,
                      FontGlyphPair::Hash,
                      FontGlyphPair::Equal>
       positions_;
-
-  std::unordered_map<FontGlyphPair,
-                     bool,
-                     FontGlyphPair::Hash,
-                     FontGlyphPair::Equal>
-      colors_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(GlyphAtlas);
 };

--- a/impeller/typographer/typographer_unittests.cc
+++ b/impeller/typographer/typographer_unittests.cc
@@ -40,7 +40,6 @@ TEST_P(TypographerTest, CanCreateGlyphAtlas) {
   ASSERT_TRUE(blob);
   auto atlas = context->CreateGlyphAtlas(TextFrameFromTextBlob(blob));
   ASSERT_NE(atlas, nullptr);
-  ASSERT_FALSE(atlas->ContainsColorGlyph());
   OpenPlaygroundHere([](RenderTarget&) { return true; });
 }
 


### PR DESCRIPTION
Reverts flutter/engine#36161

This is failing on Android:

```
[list_text_layout_impeller_perf__e2e_summary] [STDOUT] stderr: [ +243 ms] VMServiceFlutterDriver: Isolate found with number: 2165495372400231
[list_text_layout_impeller_perf__e2e_summary] [STDOUT] stderr: [  +68 ms] VMServiceFlutterDriver: Isolate is paused at start.
[list_text_layout_impeller_perf__e2e_summary] [STDOUT] stderr: [        ] VMServiceFlutterDriver: Attempting to resume isolate
[list_text_layout_impeller_perf__e2e_summary] [STDOUT] stdout: [  +10 ms] I/flutter (17000): 00:00 +0: list_text_layout
[list_text_layout_impeller_perf__e2e_summary] [STDOUT] stdout: [  +25 ms] E/flutter (17000): [ERROR:flutter/impeller/base/validation.cc(27)] Location for uniform member not known: FRAGINFO.FONTHASCOLOR
[list_text_layout_impeller_perf__e2e_summary] [STDOUT] stdout: [   +3 ms] E/flutter (17000): [ERROR:flutter/impeller/base/validation.cc(38)] Break on ImpellerValidationBreak to inspect point of failure.
[list_text_layout_impeller_perf__e2e_summary] [STDOUT] stdout: [        ] F/flutter (17000): [FATAL:flutter/impeller/renderer/backend/gles/render_pass_gles.cc(516)] Check failed: result. Must be able to encode GL commands without error.
[list_text_layout_impeller_perf__e2e_summary] [STDOUT] stdout: [        ] F/libc    (17000): Fatal signal 6 (SIGABRT), code -6 in tid 17018 (1.raster)
[list_text_layout_impeller_perf__e2e_summary] [STDOUT] stdout: [  +72 ms] *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
[list_text_layout_impeller_perf__e2e_summary] [STDOUT] stdout: [        ] Build fingerprint: 'motorola/athene_amz/athene:7.0/NPJS25.93-14-4/4:user/release-keys'
[list_text_layout_impeller_perf__e2e_summary] [STDOUT] stdout: [        ] Revision: 'p2a0'
[list_text_layout_impeller_perf__e2e_summary] [STDOUT] stdout: [        ] ABI: 'arm'
[list_text_layout_impeller_perf__e2e_summary] [STDOUT] stdout: [        ] pid: 17000, tid: 17018, name: 1.raster  >>> com.example.macrobenchmarks <<<
[list_text_layout_impeller_perf__e2e_summary] [STDOUT] stdout: [        ] signal 6 (SIGABRT), code -6 (SI_TKILL), fault addr --------
[list_text_layout_impeller_perf__e2e_summary] [STDOUT] stdout: [        ] Abort message: '[FATAL:flutter/impeller/renderer/backend/gles/render_pass_gles.cc(516)] Check failed: result. Must be able to encode GL commands without error.
[list_text_layout_impeller_perf__e2e_summary] [STDOUT] stdout: [        ] '
[list_text_layout_impeller_perf__e2e_summary] [STDOUT] stdout: [        ]     r0 00000000  r1 0000427a  r2 00000006  r3 00000008
[list_text_layout_impeller_perf__e2e_summary] [STDOUT] stdout: [        ]     r4 90e58978  r5 00000006  r6 90e58920  r7 0000010c
[list_text_layout_impeller_perf__e2e_summary] [STDOUT] stdout: [        ]     r8 90e576b8  r9 9e78b6cc  sl a0a7f000  fp 8dabf7b0
[list_text_layout_impeller_perf__e2e_summary] [STDOUT] stdout: [        ]     ip 00000000  sp 90e57528  lr ac64d3e7  pc ac64fc44  cpsr 20070010
[list_text_layout_impeller_perf__e2e_summary] [STDOUT] stdout: [   +3 ms] backtrace:
[list_text_layout_impeller_perf__e2e_summary] [STDOUT] stdout: [        ]     #00 pc 00049c44  /system/lib/libc.so (tgkill+12)
[list_text_layout_impeller_perf__e2e_summary] [STDOUT] stdout: [        ]     #01 pc 000473e3  /system/lib/libc.so (pthread_kill+34)
[list_text_layout_impeller_perf__e2e_summary] [STDOUT] stdout: [        ]     #02 pc 0001d535  /system/lib/libc.so (raise+10)
[list_text_layout_impeller_perf__e2e_summary] [STDOUT] stdout: [        ]     #03 pc 00019081  /system/lib/libc.so (__libc_android_abort+34)
[list_text_layout_impeller_perf__e2e_summary] [STDOUT] stdout: [        ]     #04 pc 000170e4  /system/lib/libc.so (abort+4)
[list_text_layout_impeller_perf__e2e_summary] [STDOUT] stdout: [        ]     #05 pc 00011eb3  /data/app/com.example.macrobenchmarks-1/lib/arm/libflutter.so (offset 0x525000)
[list_text_layout_impeller_perf__e2e_summary] [STDOUT] stderr: [+4937 ms] VMServiceFlutterDriver: Flutter Driver extension is taking a long time to become available. Ensure your test app (often "lib/main.dart") imports "package:flutter_driver/driver_extension.dart" and calls enableFlutterDriverExtension() as the first call in main().
[list_text_layout_impeller_perf__e2e_summary] [STDOUT] stdout: [  +27 ms] executing: /opt/s/w/ir/cache/android/sdk/platform-tools/adb -s ZY223CL8VK shell am force-stop com.example.macrobenchmarks
[list_text_layout_impeller_perf__e2e_summary] [STDOUT] stdout: [ +906 ms] executing: /opt/s/w/ir/cache/android/sdk/platform-tools/adb -s ZY223CL8VK uninstall com.example.macrobenchmarks
[list_text_layout_impeller_perf__e2e_summary] [STDOUT] stdout: [ +367 ms] Success
```