### PR TITLE
[Impeller] remove unused uniform

### DIFF
--- a/impeller/entity/shaders/glyph_atlas.frag
+++ b/impeller/entity/shaders/glyph_atlas.frag
@@ -7,7 +7,6 @@ uniform sampler2D glyph_atlas_sampler;
 uniform FragInfo {
   vec2 atlas_size;
   vec4 text_color;
-  float font_has_color;
 } frag_info;
 
 in vec2 v_unit_vertex;

--- a/impeller/typographer/glyph_atlas.cc
+++ b/impeller/typographer/glyph_atlas.cc
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 #include "impeller/typographer/glyph_atlas.h"
-#include <iostream>
 
 namespace impeller {
 


### PR DESCRIPTION
This is crashing on android, because we optimize out the uniform but not the binding
