### PR TITLE
Add more dart:ui diagrams

### DIFF
--- a/lib/ui/geometry.dart
+++ b/lib/ui/geometry.dart
@@ -633,6 +633,8 @@ class Size extends OffsetBase {
 /// ```
 class Rect {
   /// Construct a rectangle from its left, top, right, and bottom edges.
+  ///
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/rect_from_ltrb.png)
   @pragma('vm:entry-point')
   const Rect.fromLTRB(this.left, this.top, this.right, this.bottom)
       : assert(left != null),
@@ -645,11 +647,15 @@ class Rect {
   ///
   /// To construct a [Rect] from an [Offset] and a [Size], you can use the
   /// rectangle constructor operator `&`. See [Offset.&].
+  ///
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/rect_from_ltwh.png)
   const Rect.fromLTWH(double left, double top, double width, double height) : this.fromLTRB(left, top, left + width, top + height);
 
   /// Construct a rectangle that bounds the given circle.
   ///
   /// The `center` argument is assumed to be an offset from the origin.
+  ///
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/rect_from_circle.png)
   Rect.fromCircle({ required Offset center, required double radius }) : this.fromCenter(
     center: center,
     width: radius * 2,
@@ -659,6 +665,8 @@ class Rect {
   /// Constructs a rectangle from its center point, width, and height.
   ///
   /// The `center` argument is assumed to be an offset from the origin.
+  ///
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/rect_from_center.png)
   Rect.fromCenter({ required Offset center, required double width, required double height }) : this.fromLTRB(
     center.dx - width / 2,
     center.dy - height / 2,
@@ -668,6 +676,8 @@ class Rect {
 
   /// Construct the smallest rectangle that encloses the given offsets, treating
   /// them as vectors from the origin.
+  ///
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/rect_from_points.png)
   Rect.fromPoints(Offset a, Offset b) : this.fromLTRB(
     math.min(a.dx, b.dx),
     math.min(a.dy, b.dy),
@@ -923,9 +933,13 @@ class Rect {
 /// A radius for either circular or elliptical shapes.
 class Radius {
   /// Constructs a circular radius. [x] and [y] will have the same radius value.
+  ///
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/radius_circular.png)
   const Radius.circular(double radius) : this.elliptical(radius, radius);
 
   /// Constructs an elliptical radius with the given radii.
+  ///
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/radius_elliptical.png)
   const Radius.elliptical(this.x, this.y);
 
   /// The radius value on the horizontal axis.

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -2429,6 +2429,8 @@ class Path extends NativeFieldWrapperClass1 {
   /// Adds a quadratic bezier segment that curves from the current
   /// point to the given point (x2,y2), using the control point
   /// (x1,y1).
+  ///
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/path_quadratic_to.png)
   @FfiNative<Void Function(Pointer<Void>, Float, Float, Float, Float)>('Path::quadraticBezierTo', isLeaf: true)
   external void quadraticBezierTo(double x1, double y1, double x2, double y2);
 
@@ -2443,6 +2445,8 @@ class Path extends NativeFieldWrapperClass1 {
   /// Adds a cubic bezier segment that curves from the current point
   /// to the given point (x3,y3), using the control points (x1,y1) and
   /// (x2,y2).
+  ///
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/path_cubic_to.png)
   @FfiNative<Void Function(Pointer<Void>, Float, Float, Float, Float, Float, Float)>('Path::cubicTo', isLeaf: true)
   external void cubicTo(double x1, double y1, double x2, double y2, double x3, double y3);
 
@@ -2458,6 +2462,8 @@ class Path extends NativeFieldWrapperClass1 {
   /// weight w. If the weight is greater than 1, then the curve is a
   /// hyperbola; if the weight equals 1, it's a parabola; and if it is
   /// less than 1, it is an ellipse.
+  ///
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/path_conic_to.png)
   @FfiNative<Void Function(Pointer<Void>, Float, Float, Float, Float, Float)>('Path::conicTo', isLeaf: true)
   external void conicTo(double x1, double y1, double x2, double y2, double w);
 
@@ -4863,6 +4869,8 @@ class Canvas extends NativeFieldWrapperClass1 {
   /// Reduces the clip region to the intersection of the current clip and the
   /// given rectangle.
   ///
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/clip_rect.png)
+  ///
   /// If [doAntiAlias] is true, then the clip will be anti-aliased.
   ///
   /// If multiple draw commands intersect with the clip boundary, this can result
@@ -4884,6 +4892,8 @@ class Canvas extends NativeFieldWrapperClass1 {
   /// Reduces the clip region to the intersection of the current clip and the
   /// given rounded rectangle.
   ///
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/clip_rrect.png)
+  ///
   /// If [doAntiAlias] is true, then the clip will be anti-aliased.
   ///
   /// If multiple draw commands intersect with the clip boundary, this can result
@@ -4900,6 +4910,8 @@ class Canvas extends NativeFieldWrapperClass1 {
 
   /// Reduces the clip region to the intersection of the current clip and the
   /// given [Path].
+  ///
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/clip_path.png)
   ///
   /// If [doAntiAlias] is true, then the clip will be anti-aliased.
   ///
@@ -5015,6 +5027,8 @@ class Canvas extends NativeFieldWrapperClass1 {
   /// stroked, the value of the [Paint.style] is ignored for this call.
   ///
   /// The `p1` and `p2` arguments are interpreted as offsets from the origin.
+  ///
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/canvas_line.png)
   void drawLine(Offset p1, Offset p2, Paint paint) {
     assert(_offsetIsValid(p1));
     assert(_offsetIsValid(p2));
@@ -5039,6 +5053,8 @@ class Canvas extends NativeFieldWrapperClass1 {
 
   /// Draws a rectangle with the given [Paint]. Whether the rectangle is filled
   /// or stroked (or both) is controlled by [Paint.style].
+  ///
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/canvas_rect.png)
   void drawRect(Rect rect, Paint paint) {
     assert(_rectIsValid(rect));
     assert(paint != null);
@@ -5050,6 +5066,8 @@ class Canvas extends NativeFieldWrapperClass1 {
 
   /// Draws a rounded rectangle with the given [Paint]. Whether the rectangle is
   /// filled or stroked (or both) is controlled by [Paint.style].
+  ///
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/canvas_rrect.png)
   void drawRRect(RRect rrect, Paint paint) {
     assert(_rrectIsValid(rrect));
     assert(paint != null);
@@ -5077,6 +5095,8 @@ class Canvas extends NativeFieldWrapperClass1 {
   /// Draws an axis-aligned oval that fills the given axis-aligned rectangle
   /// with the given [Paint]. Whether the oval is filled or stroked (or both) is
   /// controlled by [Paint.style].
+  ///
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/canvas_oval.png)
   void drawOval(Rect rect, Paint paint) {
     assert(_rectIsValid(rect));
     assert(paint != null);
@@ -5090,6 +5110,8 @@ class Canvas extends NativeFieldWrapperClass1 {
   /// that has the radius given by the second argument, with the [Paint] given in
   /// the third argument. Whether the circle is filled or stroked (or both) is
   /// controlled by [Paint.style].
+  ///
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/canvas_circle.png)
   void drawCircle(Offset c, double radius, Paint paint) {
     assert(_offsetIsValid(c));
     assert(paint != null);


### PR DESCRIPTION
This PR just updates docs to include diagrams merged in https://github.com/flutter/assets-for-api-docs/pull/198