### PR TITLE
Warn if we have not built CanvasKit and requested --use-local-canvaskit

### DIFF
--- a/lib/web_ui/dev/steps/compile_tests_step.dart
+++ b/lib/web_ui/dev/steps/compile_tests_step.dart
@@ -132,10 +132,9 @@ Future<void> copyCanvasKitFiles({bool useLocalCanvasKit = false}) async {
   ));
   final bool builtLocalCanvasKit = localCanvasKitWasm.existsSync();
   if (useLocalCanvasKit && !builtLocalCanvasKit) {
-    print('WARNING: Requested to use local CanvasKit but could not find the '
+    throw ArgumentError('Requested to use local CanvasKit but could not find the '
         'built CanvasKit at ${localCanvasKitWasm.path}. Falling back to '
         'CanvasKit from CIPD.');
-    useLocalCanvasKit = false;
   }
 
   final io.Directory targetDir = io.Directory(pathlib.join(

--- a/lib/web_ui/dev/steps/compile_tests_step.dart
+++ b/lib/web_ui/dev/steps/compile_tests_step.dart
@@ -130,14 +130,20 @@ Future<void> copyCanvasKitFiles({bool useLocalCanvasKit = false}) async {
     environment.wasmReleaseOutDir.path,
     'canvaskit.wasm',
   ));
-  final bool builtLocalCanvasKit = localCanvasKitWasm.existsSync() && useLocalCanvasKit;
+  final bool builtLocalCanvasKit = localCanvasKitWasm.existsSync();
+  if (useLocalCanvasKit && !builtLocalCanvasKit) {
+    print('WARNING: Requested to use local CanvasKit but could not find the '
+        'built CanvasKit at ${localCanvasKitWasm.path}. Falling back to '
+        'CanvasKit from CIPD.');
+    useLocalCanvasKit = false;
+  }
 
   final io.Directory targetDir = io.Directory(pathlib.join(
     environment.webUiBuildDir.path,
     'canvaskit',
   ));
 
-  if (builtLocalCanvasKit) {
+  if (useLocalCanvasKit) {
     final List<io.File> canvasKitFiles = <io.File>[
       localCanvasKitWasm,
       io.File(pathlib.join(


### PR DESCRIPTION
This is to give extra confidence that we are actually testing against the locally built CanvasKit on LUCI.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
