### PR TITLE
Use Goma in the CanvasKit build

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -245,7 +245,6 @@ def to_gn_args(args):
                                         '0') == '1':
       gn_args['create_xcode_symlinks'] = True
 
-
   # If building for WASM, set the GN args using 'to_gn_wasm_args' as most
   # of the Flutter SDK specific arguments are unused.
   if args.target_os == 'wasm':

--- a/tools/gn
+++ b/tools/gn
@@ -213,6 +213,39 @@ def to_gn_args(args):
 
   gn_args['is_debug'] = args.unoptimized
 
+  goma_dir = os.environ.get('GOMA_DIR')
+  goma_home_dir = os.path.join(os.getenv('HOME', ''), 'goma')
+  depot_tools_bin_dir = os.path.join(args.depot_tools, '.cipd_bin')
+
+  # GOMA has a different default (home) path on gWindows.
+  if not os.path.exists(goma_home_dir) and sys.platform.startswith(
+      ('cygwin', 'win')):
+    goma_home_dir = os.path.join('c:\\', 'src', 'goma', 'goma-win64')
+
+  if args.goma and goma_dir:
+    gn_args['use_goma'] = True
+    gn_args['goma_dir'] = goma_dir
+  elif args.goma and os.path.exists(goma_home_dir):
+    gn_args['use_goma'] = True
+    gn_args['goma_dir'] = goma_home_dir
+  elif args.goma and os.path.exists(depot_tools_bin_dir):
+    gn_args['use_goma'] = True
+    gn_args['goma_dir'] = depot_tools_bin_dir
+  else:
+    if args.goma:
+      print(
+          "GOMA usage was specified but can't be found, falling back to local "
+          'builds. Set the GOMA_DIR environment variable to fix GOMA.'
+      )
+    gn_args['use_goma'] = False
+    gn_args['goma_dir'] = None
+
+  if gn_args['use_goma']:
+    if args.xcode_symlinks or os.getenv('FLUTTER_GOMA_CREATE_XCODE_SYMLINKS',
+                                        '0') == '1':
+      gn_args['create_xcode_symlinks'] = True
+
+
   # If building for WASM, set the GN args using 'to_gn_wasm_args' as most
   # of the Flutter SDK specific arguments are unused.
   if args.target_os == 'wasm':
@@ -370,38 +403,6 @@ def to_gn_args(args):
 
   if args.target_triple:
     gn_args['custom_target_triple'] = args.target_triple
-
-  goma_dir = os.environ.get('GOMA_DIR')
-  goma_home_dir = os.path.join(os.getenv('HOME', ''), 'goma')
-  depot_tools_bin_dir = os.path.join(args.depot_tools, '.cipd_bin')
-
-  # GOMA has a different default (home) path on gWindows.
-  if not os.path.exists(goma_home_dir) and sys.platform.startswith(
-      ('cygwin', 'win')):
-    goma_home_dir = os.path.join('c:\\', 'src', 'goma', 'goma-win64')
-
-  if args.goma and goma_dir:
-    gn_args['use_goma'] = True
-    gn_args['goma_dir'] = goma_dir
-  elif args.goma and os.path.exists(goma_home_dir):
-    gn_args['use_goma'] = True
-    gn_args['goma_dir'] = goma_home_dir
-  elif args.goma and os.path.exists(depot_tools_bin_dir):
-    gn_args['use_goma'] = True
-    gn_args['goma_dir'] = depot_tools_bin_dir
-  else:
-    if args.goma:
-      print(
-          "GOMA usage was specified but can't be found, falling back to local "
-          'builds. Set the GOMA_DIR environment variable to fix GOMA.'
-      )
-    gn_args['use_goma'] = False
-    gn_args['goma_dir'] = None
-
-  if gn_args['use_goma']:
-    if args.xcode_symlinks or os.getenv('FLUTTER_GOMA_CREATE_XCODE_SYMLINKS',
-                                        '0') == '1':
-      gn_args['create_xcode_symlinks'] = True
 
   # Enable Metal on iOS builds.
   if args.target_os == 'ios':


### PR DESCRIPTION
This change causes the WASM build to use Goma. Hopefully this will speed up the builds on LUCI.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
