### PR TITLE
Prevent Gradients from creating textures of size 0 when stops overlap

### DIFF
--- a/impeller/geometry/geometry_unittests.cc
+++ b/impeller/geometry/geometry_unittests.cc
@@ -1499,9 +1499,9 @@ TEST(GeometryTest, Gradient) {
     // Gradient size is capped at 1024.
     std::vector<Color> colors = {};
     std::vector<Scalar> stops = {};
-    for (auto i = 0u; i < 2000; i++) {
+    for (auto i = 0u; i < 1025; i++) {
       colors.push_back(Color::Blue());
-      stops.push_back(i / 2000.0);
+      stops.push_back(i / 1025.0);
     }
     stops[1999] = 1.0;
 

--- a/impeller/geometry/geometry_unittests.cc
+++ b/impeller/geometry/geometry_unittests.cc
@@ -1452,6 +1452,17 @@ TEST(GeometryTest, Gradient) {
   }
 
   {
+    // Gradient with duplicate stops does not create an empty texture.
+    std::vector<Color> colors = {Color::Red(), Color::Yellow(), Color::Black(),
+                                 Color::Blue()};
+    std::vector<Scalar> stops = {0.0, 0.25, 0.25, 1.0};
+    uint32_t texture_size;
+
+    auto gradient = CreateGradientBuffer(colors, stops, &texture_size);
+    ASSERT_EQ(texture_size, 5u);
+  }
+
+  {
     // Simple N color gradient produces color buffer containing exactly those
     // values.
     std::vector<Color> colors = {Color::Red(), Color::Blue(), Color::Green(),

--- a/impeller/geometry/gradient.cc
+++ b/impeller/geometry/gradient.cc
@@ -25,7 +25,7 @@ std::vector<uint8_t> CreateGradientBuffer(const std::vector<Color>& colors,
   if (stops.size() == 2) {
     texture_size = 2;
   } else {
-    auto minimum_delta = 1.0; 
+    auto minimum_delta = 1.0;
     for (size_t i = 1; i < stops.size(); i++) {
       auto value = stops[i] - stops[i - 1];
       if (value < kEhCloseEnough) {

--- a/impeller/geometry/gradient.cc
+++ b/impeller/geometry/gradient.cc
@@ -28,7 +28,8 @@ std::vector<uint8_t> CreateGradientBuffer(const std::vector<Color>& colors,
     auto minimum_delta = 1.0;
     for (size_t i = 1; i < stops.size(); i++) {
       auto value = stops[i] - stops[i - 1];
-      if (value < kEhCloseEnough) {
+      // Smaller than kEhCloseEnough
+      if (value < 0.0001) {
         continue;
       }
       if (value < minimum_delta) {

--- a/impeller/geometry/gradient.cc
+++ b/impeller/geometry/gradient.cc
@@ -22,14 +22,15 @@ std::vector<uint8_t> CreateGradientBuffer(const std::vector<Color>& colors,
   uint32_t texture_size;
   // TODO(jonahwilliams): we should add a display list flag to check if the
   // stops were provided or not, then we can skip this step.
-  // TODO(jonahwilliams): Skia has a check for stop sizes below a certain
-  // threshold, we should make sure that we behave reasonably with them.
   if (stops.size() == 2) {
     texture_size = 2;
   } else {
-    auto minimum_delta = 1.0;
+    auto minimum_delta = 1.0; 
     for (size_t i = 1; i < stops.size(); i++) {
       auto value = stops[i] - stops[i - 1];
+      if (value < kEhCloseEnough) {
+        continue;
+      }
       if (value < minimum_delta) {
         minimum_delta = value;
       }
@@ -41,7 +42,6 @@ std::vector<uint8_t> CreateGradientBuffer(const std::vector<Color>& colors,
     texture_size =
         std::min((uint32_t)std::round(1.0 / minimum_delta) + 1, 1024u);
   }
-
   *out_texture_size = texture_size;
   std::vector<uint8_t> color_stop_channels;
   color_stop_channels.reserve(texture_size * 4);


### PR DESCRIPTION
TIL this is a valid gradient, but it is used for the overflow indicator.

This is only a stopgap, to fix this for real we'd need to fallback to an entirely different approach for these gradients. Additionally, we may need to insert and beginning and end stop if the color stops do not already contain them.
