### PR TITLE
[Impeller] Cast chat8_t* to char* for MSSTL compat

### DIFF
--- a/impeller/compiler/impellerc_main.cc
+++ b/impeller/compiler/impellerc_main.cc
@@ -90,9 +90,10 @@ bool Main(const fml::CommandLine& command_line) {
 
   auto spriv_file_name = std::filesystem::absolute(
       std::filesystem::current_path() / switches.spirv_file_name);
-  if (!fml::WriteAtomically(*switches.working_directory,
-                            spriv_file_name.u8string().c_str(),
-                            *compiler.GetSPIRVAssembly())) {
+  if (!fml::WriteAtomically(
+          *switches.working_directory,
+          reinterpret_cast<const char*>(spriv_file_name.u8string().c_str()),
+          *compiler.GetSPIRVAssembly())) {
     std::cerr << "Could not write file to " << switches.spirv_file_name
               << std::endl;
     return false;
@@ -118,9 +119,10 @@ bool Main(const fml::CommandLine& command_line) {
         std::cerr << "Runtime stage data could not be created." << std::endl;
         return false;
       }
-      if (!fml::WriteAtomically(*switches.working_directory,      //
-                                sl_file_name.u8string().c_str(),  //
-                                *stage_data_mapping               //
+      if (!fml::WriteAtomically(*switches.working_directory,  //
+                                reinterpret_cast<const char*>(
+                                    sl_file_name.u8string().c_str()),  //
+                                *stage_data_mapping                    //
                                 )) {
         std::cerr << "Could not write file to " << switches.sl_file_name
                   << std::endl;
@@ -132,9 +134,10 @@ bool Main(const fml::CommandLine& command_line) {
         return false;
       }
     } else {
-      if (!fml::WriteAtomically(*switches.working_directory,
-                                sl_file_name.u8string().c_str(),
-                                *compiler.GetSLShaderSource())) {
+      if (!fml::WriteAtomically(
+              *switches.working_directory,
+              reinterpret_cast<const char*>(sl_file_name.u8string().c_str()),
+              *compiler.GetSLShaderSource())) {
         std::cerr << "Could not write file to " << switches.sl_file_name
                   << std::endl;
         return false;
@@ -148,7 +151,8 @@ bool Main(const fml::CommandLine& command_line) {
           std::filesystem::current_path() / switches.reflection_json_name);
       if (!fml::WriteAtomically(
               *switches.working_directory,
-              reflection_json_name.u8string().c_str(),
+              reinterpret_cast<const char*>(
+                  reflection_json_name.u8string().c_str()),
               *compiler.GetReflector()->GetReflectionJSON())) {
         std::cerr << "Could not write reflection json to "
                   << switches.reflection_json_name << std::endl;
@@ -162,7 +166,8 @@ bool Main(const fml::CommandLine& command_line) {
                                     switches.reflection_header_name.c_str());
       if (!fml::WriteAtomically(
               *switches.working_directory,
-              reflection_header_name.u8string().c_str(),
+              reinterpret_cast<const char*>(
+                  reflection_header_name.u8string().c_str()),
               *compiler.GetReflector()->GetReflectionHeader())) {
         std::cerr << "Could not write reflection header to "
                   << switches.reflection_header_name << std::endl;
@@ -175,7 +180,8 @@ bool Main(const fml::CommandLine& command_line) {
           std::filesystem::absolute(std::filesystem::current_path() /
                                     switches.reflection_cc_name.c_str());
       if (!fml::WriteAtomically(*switches.working_directory,
-                                reflection_cc_name.u8string().c_str(),
+                                reinterpret_cast<const char*>(
+                                    reflection_cc_name.u8string().c_str()),
                                 *compiler.GetReflector()->GetReflectionCC())) {
         std::cerr << "Could not write reflection CC to "
                   << switches.reflection_cc_name << std::endl;
@@ -204,9 +210,10 @@ bool Main(const fml::CommandLine& command_line) {
     }
     auto depfile_path = std::filesystem::absolute(
         std::filesystem::current_path() / switches.depfile_path.c_str());
-    if (!fml::WriteAtomically(*switches.working_directory,
-                              depfile_path.u8string().c_str(),
-                              *compiler.CreateDepfileContents({result_file}))) {
+    if (!fml::WriteAtomically(
+            *switches.working_directory,
+            reinterpret_cast<const char*>(depfile_path.u8string().c_str()),
+            *compiler.CreateDepfileContents({result_file}))) {
       std::cerr << "Could not write depfile to " << switches.depfile_path
                 << std::endl;
       return false;

--- a/impeller/compiler/utilities.cc
+++ b/impeller/compiler/utilities.cc
@@ -12,7 +12,8 @@ namespace impeller {
 namespace compiler {
 
 std::string InferShaderNameFromPath(std::string_view path) {
-  return std::filesystem::path{path}.stem().u8string();
+  return reinterpret_cast<const char*>(
+      std::filesystem::path{path}.stem().u8string().c_str());
 }
 
 std::string ConvertToCamelCase(std::string_view string) {


### PR DESCRIPTION
Noticed when syncing impeller-cmake.

In MSSTL, `Path::u8string` returns an `std::u8string`, which is spec abiding. However, libcxx returns an `std::string`. Our interfaces use `const char*` and `std::string` for paths, but Clang doesn't do implicit conversions for `char8_t`->`char`. This is a safe cast because the underlying type of `char8_t` is [defined by the spec](https://timsong-cpp.github.io/cppwp/basic.fundamental#9) to be `unsigned char`.