### PR TITLE
Bundle impeller only on debug version of artifacts.

### DIFF
--- a/build/archives/BUILD.gn
+++ b/build/archives/BUILD.gn
@@ -76,14 +76,18 @@ if (build_engine_artifacts) {
         destination = "flutter_tester$exe"
       },
       {
-        source = "$root_out_dir/impellerc$exe"
-        destination = "impellerc$exe"
-      },
-      {
         source = "$root_out_dir/libtessellator$dll"
         destination = "libtessellator$dll"
       },
     ]
+    if (flutter_runtime_mode == "debug") {
+      files += [
+        {
+          source = "$root_out_dir/impellerc$exe"
+          destination = "impellerc$exe"
+        },
+      ]
+    }
     if (host_os == "mac") {
       deps += [ ":artifacts_entitlement_config" ]
       files += [


### PR DESCRIPTION
Impeller was bundled in release, profile and debug version of artifacts when only the debug version is expected.

Bug: https://github.com/flutter/flutter/issues/81855

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
