### PR TITLE
Fix inverted setSystemUIChangeCallback

### DIFF
--- a/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
@@ -239,12 +239,12 @@ public class PlatformPlugin {
                     // controls. Another common action is to set a timer to dismiss
                     // the system bars and restore the fullscreen mode that was
                     // previously enabled.
-                    platformChannel.systemChromeChanged(false);
+                    platformChannel.systemChromeChanged(true);
                   } else {
                     // The system bars are NOT visible. Make any desired adjustments
                     // to your UI, such as hiding the action bar or other
                     // navigational controls.
-                    platformChannel.systemChromeChanged(true);
+                    platformChannel.systemChromeChanged(false);
                   }
                 });
           }


### PR DESCRIPTION
The signature of `systemChromeChanged` is 

```java
public void systemChromeChanged(boolean overlaysAreVisible);
```

But the wrong value of `overlaysAreVisible` is propagated, resulting in the incorrect value received by `setSystemUIChangeCallback`.

*List which issues are fixed by this PR. You must list at least one issue.*

Fix https://github.com/flutter/flutter/issues/111618

`setSystemUIChangeCallback` isn't used internally, but I also patched this change and ran an internal presubmit to double check. Since there are no failing tests, this isn't a breaking change.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
