### PR TITLE
Fix HTML renderer does not render non zeroed width borders

### DIFF
--- a/lib/web_ui/lib/src/engine/html/path/path_ref.dart
+++ b/lib/web_ui/lib/src/engine/html/path/path_ref.dart
@@ -247,7 +247,9 @@ class PathRef {
     if ((x2 - x3) != width || (y3 - y0) != height) {
       return null;
     }
-    return ui.Rect.fromLTWH(x0, y0, width, height);
+    final double x = math.min(x0, x1);
+    final double y = math.min(y0, y2);
+    return ui.Rect.fromLTWH(x, y, width.abs(), height.abs());
   }
 
   /// Returns horizontal/vertical line bounds or null if not a line.

--- a/lib/web_ui/test/html/path_ref_test.dart
+++ b/lib/web_ui/test/html/path_ref_test.dart
@@ -65,6 +65,30 @@ void testMain() {
     expect(path.toRect(), rrect.outerRect);
   });
 
+  test('PathRef.getRect returns a Rect from a valid Path and null otherwise', () {
+    final SurfacePath path = SurfacePath();
+    // Draw a line
+    path.moveTo(0,0);
+    path.lineTo(10,0);
+    expect(path.pathRef.getRect(), isNull);
+    // Draw two other lines to get a valid rectangle
+    path.lineTo(10,10);
+    path.lineTo(0,10);
+    expect(path.pathRef.getRect(), const Rect.fromLTWH(0, 0, 10, 10));
+  });
+
+  // Regression test for https://github.com/flutter/flutter/issues/111750
+  test('PathRef.getRect returns Rect with positive width and height', () {
+    final SurfacePath path = SurfacePath();
+    // Draw a rectangle starting from bottom right corner
+    path.moveTo(10,10);
+    path.lineTo(0,10);
+    path.lineTo(0,0);
+    path.lineTo(10,0);
+    // pathRef.getRect() should return a rectangle with positive height and width
+    expect(path.pathRef.getRect(), const Rect.fromLTWH(0, 0, 10, 10));
+  });
+
   // This test demonstrates the issue with attempting to reconstruct an RRect
   // with imprecision introduced by comparing double values. We should fix this
   // by removing the need to reconstruct rrects:


### PR DESCRIPTION
## Description

Before this PR, the HTML renderer does not render properly borders when `width > 0`.
(FYI, rendering zeroed width borders was fixed in https://github.com/flutter/engine/pull/34812).

When `width > 0`, the border is rendered by calling `RecordingCanvas.drawRect`. The `Rect` is computed by `PathRef._detectRect` which might return a `Rect` with negative width and/or height, this leads to wrong computations when clipping (and the border being not visible).

This PR fixed `PathRef._detectRect` to return a `Rect` with positive width and height.

## Related Issue

Fixes https://github.com/flutter/flutter/issues/111750

## Tests

Adds 2 tests.
