### PR TITLE
[Impeller] Fix element padding for unknown types in reflector

### DIFF
--- a/impeller/compiler/reflector.cc
+++ b/impeller/compiler/reflector.cc
@@ -731,7 +731,7 @@ std::vector<StructMember> Reflector::ReadStructMembers(
           size,                                  // size
           stride * array_elements,               // byte_length
           array_elements,                        // array_elements
-          0,                                     // element_padding
+          element_padding,                       // element_padding
       });
       current_byte_offset += stride * array_elements;
       continue;


### PR DESCRIPTION
I don't think we support any types in our backends at runtime that can hit this branch right now.