### PR TITLE
[macOS] Fix mouse cursor being replaced by AppKit

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterView.mm
@@ -110,6 +110,15 @@
   return YES;
 }
 
+- (void)cursorUpdate:(NSEvent*)event {
+  // When adding/removing views AppKit will schedule call to current hittest view
+  // cursorUpdate: at the end of frame to determine possible cursor change. If
+  // the view doesn't implement cursorUpdate: AppKit will set the default (arrow) cursor
+  // instead. This would replace the cursor set by FlutterMouseCursorPlugin.
+  // Empty cursorUpdate: implementation prevents this behavior.
+  // https://github.com/flutter/flutter/issues/111425
+}
+
 - (void)viewDidChangeBackingProperties {
   [super viewDidChangeBackingProperties];
   // Force redraw

--- a/shell/platform/darwin/macos/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterView.mm
@@ -111,7 +111,7 @@
 }
 
 - (void)cursorUpdate:(NSEvent*)event {
-  // When adding/removing views AppKit will schedule call to current hittest view
+  // When adding/removing views AppKit will schedule call to current hit-test view
   // cursorUpdate: at the end of frame to determine possible cursor change. If
   // the view doesn't implement cursorUpdate: AppKit will set the default (arrow) cursor
   // instead. This would replace the cursor set by FlutterMouseCursorPlugin.


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/111425

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
