### PR TITLE
Revert "DiffContext: Remove transform_override"

### DIFF
--- a/flow/diff_context.cc
+++ b/flow/diff_context.cc
@@ -24,6 +24,10 @@ void DiffContext::BeginSubtree() {
   state_.rect_index_ = rects_->size();
   state_.has_filter_bounds_adjustment = false;
   state_.has_texture = false;
+  if (state_.transform_override) {
+    state_.transform = *state_.transform_override;
+    state_.transform_override = std::nullopt;
+  }
 }
 
 void DiffContext::EndSubtree() {
@@ -47,7 +51,7 @@ void DiffContext::PushTransform(const SkMatrix& transform) {
 }
 
 void DiffContext::SetTransform(const SkMatrix& transform) {
-  state_.transform = transform;
+  state_.transform_override = transform;
 }
 
 void DiffContext::PushFilterBoundsAdjustment(FilterBoundsAdjustment filter) {
@@ -155,8 +159,16 @@ void DiffContext::MarkSubtreeDirty(const SkRect& previous_paint_region) {
 }
 
 void DiffContext::AddLayerBounds(const SkRect& rect) {
-  auto paint_rect = ApplyFilterBoundsAdjustment(state_.transform.mapRect(rect));
-  if (paint_rect.intersects(state_.cull_rect)) {
+  // During painting we cull based on non-overriden transform and then
+  // override the transform right before paint. Do the same thing here to get
+  // identical paint rect.
+  auto transformed_rect =
+      ApplyFilterBoundsAdjustment(state_.transform.mapRect(rect));
+  if (transformed_rect.intersects(state_.cull_rect)) {
+    auto paint_rect = state_.transform_override
+                          ? ApplyFilterBoundsAdjustment(
+                                state_.transform_override->mapRect(rect))
+                          : transformed_rect;
     rects_->push_back(paint_rect);
     if (IsSubtreeDirty()) {
       AddDamage(paint_rect);

--- a/flow/diff_context.h
+++ b/flow/diff_context.h
@@ -203,7 +203,16 @@ class DiffContext {
     bool dirty;
     SkRect cull_rect;  // in screen coordinates
 
+    // In order to replicate paint process closely, we need both the original
+    // transform, and the overriden transform (set for layers that need to paint
+    // on integer coordinates). The reason for this is that during paint the
+    // transform matrix is overriden only after layer passes the cull check
+    // first (with original transform). So to cull layer we use transform, but
+    // to get paint coordinates we use transform_override. Child layers are
+    // painted after transform override, so if set we use transform_override as
+    // base when diffing child layers.
     SkMatrix transform;
+    std::optional<SkMatrix> transform_override;
     size_t rect_index_;
 
     // Whether this subtree has filter bounds adjustment function. If so,


### PR DESCRIPTION
Reverts flutter/engine#35601

We added back pixel snapping. This isn't in the stable though