### PR TITLE
[CP] [Android] Fatal crash with `java.lang.AssertionError` when selecting text in `TextField`

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/KeyEmbedderResponder.java
+++ b/shell/platform/android/io/flutter/embedding/android/KeyEmbedderResponder.java
@@ -10,6 +10,7 @@ import androidx.annotation.Nullable;
 import io.flutter.embedding.android.KeyboardMap.PressingGoal;
 import io.flutter.embedding.android.KeyboardMap.TogglingGoal;
 import io.flutter.plugin.common.BinaryMessenger;
+import java.util.ArrayList;
 import java.util.HashMap;
 
 /**
@@ -120,17 +121,25 @@ public class KeyEmbedderResponder implements KeyboardManager.Responder {
   // dispatches synthesized events so that the state of these keys matches the true state taking
   // the current event in consideration.
   //
+  // Events that should be synthesized before the main event are synthesized
+  // immediately, while events that should be syntehsized after the main event are appended to
+  // `postSynchronize`.
+  //
   // Although Android KeyEvent defined bitmasks for sided modifiers (SHIFT_LEFT_ON and
   // SHIFT_RIGHT_ON),
   // this function only uses the unsided modifiers (SHIFT_ON), due to the weird behaviors observed
   // on ChromeOS, where right modifiers produce events with UNSIDED | LEFT_SIDE meta state bits.
   void synchronizePressingKey(
-      PressingGoal goal, boolean truePressed, long eventLogicalKey, KeyEvent event) {
+      PressingGoal goal,
+      boolean truePressed,
+      long eventLogicalKey,
+      KeyEvent event,
+      ArrayList<Runnable> postSynchronize) {
     // During an incoming event, there might be a synthesized Flutter event for each key of each
     // pressing goal, followed by an eventual main Flutter event.
     //
-    //    NowState ---------------->  PreEventState --------------> TrueState
-    //              Synchronization                      Event
+    //    NowState ---------------->  PreEventState --------------> -------------->TrueState
+    //              PreSynchronize                       Event      PostSynchronize
     //
     // The goal of the synchronization algorithm is to derive a pre-event state that can satisfy the
     // true state (`truePressed`) after the event, and that requires as few synthesized events based
@@ -141,6 +150,7 @@ public class KeyEmbedderResponder implements KeyboardManager.Responder {
     // 1. Find the current states of all keys.
     // 2. Derive the pre-event state of the event key (if applicable.)
     for (int keyIdx = 0; keyIdx < goal.keys.length; keyIdx += 1) {
+      final KeyboardMap.KeyPair key = goal.keys[keyIdx];
       nowStates[keyIdx] = pressingRecords.containsKey(goal.keys[keyIdx].physicalKey);
       if (goal.keys[keyIdx].logicalKey == eventLogicalKey) {
         switch (getEventType(event)) {
@@ -148,10 +158,10 @@ public class KeyEmbedderResponder implements KeyboardManager.Responder {
             preEventStates[keyIdx] = false;
             postEventAnyPressed = true;
             if (!truePressed) {
-              throw new AssertionError(
-                  String.format(
-                      "Unexpected metaState 0 for key 0x%x during an ACTION_down event.",
-                      eventLogicalKey));
+              postSynchronize.add(
+                  () ->
+                      synthesizeEvent(
+                          false, key.logicalKey, key.physicalKey, event.getEventTime()));
             }
             break;
           case kUp:
@@ -165,10 +175,10 @@ public class KeyEmbedderResponder implements KeyboardManager.Responder {
             // synthesize a down event here, or there will be a down event *and* a repeat event,
             // both of which have printable characters. Obviously don't synthesize up events either.
             if (!truePressed) {
-              throw new AssertionError(
-                  String.format(
-                      "Unexpected metaState 0 for key 0x%x during an ACTION_down repeat event.",
-                      eventLogicalKey));
+              postSynchronize.add(
+                  () ->
+                      synthesizeEvent(
+                          false, key.logicalKey, key.physicalKey, event.getEventTime()));
             }
             preEventStates[keyIdx] = nowStates[keyIdx];
             postEventAnyPressed = true;
@@ -260,8 +270,10 @@ public class KeyEmbedderResponder implements KeyboardManager.Responder {
     final Long physicalKey = getPhysicalKey(event);
     final Long logicalKey = getLogicalKey(event);
 
+    final ArrayList<Runnable> postSynchronizeEvents = new ArrayList<>();
     for (final PressingGoal goal : KeyboardMap.pressingGoals) {
-      synchronizePressingKey(goal, (event.getMetaState() & goal.mask) != 0, logicalKey, event);
+      synchronizePressingKey(
+          goal, (event.getMetaState() & goal.mask) != 0, logicalKey, event, postSynchronizeEvents);
     }
 
     for (final TogglingGoal goal : togglingGoals.values()) {
@@ -329,6 +341,9 @@ public class KeyEmbedderResponder implements KeyboardManager.Responder {
     output.synthesized = false;
 
     sendKeyEvent(output, onKeyEventHandledCallback);
+    for (final Runnable postSyncEvent : postSynchronizeEvents) {
+      postSyncEvent.run();
+    }
     return true;
   }
 


### PR DESCRIPTION
Cherry picks #34827 and #35924.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
