### PR TITLE
Workaround iOS text input crash for emoji+Korean text

### DIFF
--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -174,7 +174,6 @@ source_set("flutter_framework_source") {
   frameworks = [
     "AudioToolbox.framework",
     "CoreMedia.framework",
-    "CoreText.framework",
     "CoreVideo.framework",
     "QuartzCore.framework",
     "UIKit.framework",

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -174,6 +174,7 @@ source_set("flutter_framework_source") {
   frameworks = [
     "AudioToolbox.framework",
     "CoreMedia.framework",
+    "CoreText.framework",
     "CoreVideo.framework",
     "QuartzCore.framework",
     "UIKit.framework",


### PR DESCRIPTION
This is what iOS 16 does when transforming 2 Korean characters into 1 (for example ㅇ ㅏ) right after a unicode composed character (emoji etc):
1. The keyboard deletes the emoji.
2. The keyboard API inserts the composed character back.
3. The keyboard API inserts the transformed Korean character. 

However, in iOS 16.0, there is a bug that in step 2, only the first unicode is inserted, which creates an incomplete or different composed character. 

To workaround this issue, this PR:

1. Cache the deleted composed character.
5. Detects when iOS only adds the first unicode of the composed character, then replaced the first unicode with the cached input.

The issue is caused by an iOS bug and this PR only provides a workaround, we should revert this workaround when the issue is fixed by iOS.

fixes https://github.com/flutter/flutter/issues/111494

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
