### PR TITLE
[fuchsia][scenic] Call GetViewRef once per view in flatland platform view.

### DIFF
--- a/shell/platform/fuchsia/flutter/flatland_platform_view.cc
+++ b/shell/platform/fuchsia/flutter/flatland_platform_view.cc
@@ -154,13 +154,6 @@ void FlatlandPlatformView::OnChildViewViewRef(
   fidl::Clone(view_ref, &view_ref_clone);
   pointer_injector_delegate_->OnCreateView(view_id, std::move(view_ref_clone));
   OnChildViewConnected(content_id);
-
-  // TODO(http://fxbug.dev/109948): Remove the following GetViewRef call.
-  child_view_info_.at(content_id)
-      .child_view_watcher->GetViewRef(
-          [this, content_id, view_id](fuchsia::ui::views::ViewRef view_ref) {
-            this->OnChildViewViewRef(content_id, view_id, std::move(view_ref));
-          });
 }
 
 void FlatlandPlatformView::OnCreateView(ViewCallback on_view_created,

--- a/shell/platform/fuchsia/flutter/tests/flatland_platform_view_unittest.cc
+++ b/shell/platform/fuchsia/flutter/tests/flatland_platform_view_unittest.cc
@@ -247,9 +247,7 @@ class MockChildViewWatcher
   // |fuchsia::ui::composition::ChildViewWatcher|
   void GetViewRef(GetViewRefCallback callback) override {
     // GetViewRef only returns once as per flatland.fidl comments
-    if (control_ref_.reference) {
-      return;
-    }
+    ASSERT_FALSE(control_ref_.reference);
     auto pair = scenic::ViewRefPair::New();
     control_ref_ = std::move(pair.control_ref);
     callback(std::move(pair.view_ref));


### PR DESCRIPTION
Currently flatland platform view recursively calls GetViewRef to watch for ViewRef changes. Since re-linking of views will not be supported by flatland, GetViewRef should be called only once per view.

Test: ffx test run "fuchsia-pkg://fuchsia.com/flutter_runner_tests#meta/flutter_runner_tests.cm"

Bug: https://bugs.fuchsia.dev/p/fuchsia/issues/detail?id=109948

Manual testing
---------------

1) Launched and closed terminal on workstation
2) Launched Chrome, played vids on YT, closed chrome
3) Launched and closed spinning square 