### PR TITLE
[Impeller] Implement local matrix filter

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -586,6 +586,8 @@ FILE: ../../../flutter/impeller/entity/contents/filters/inputs/texture_filter_in
 FILE: ../../../flutter/impeller/entity/contents/filters/inputs/texture_filter_input.h
 FILE: ../../../flutter/impeller/entity/contents/filters/linear_to_srgb_filter_contents.cc
 FILE: ../../../flutter/impeller/entity/contents/filters/linear_to_srgb_filter_contents.h
+FILE: ../../../flutter/impeller/entity/contents/filters/local_matrix_filter_contents.cc
+FILE: ../../../flutter/impeller/entity/contents/filters/local_matrix_filter_contents.h
 FILE: ../../../flutter/impeller/entity/contents/filters/matrix_filter_contents.cc
 FILE: ../../../flutter/impeller/entity/contents/filters/matrix_filter_contents.h
 FILE: ../../../flutter/impeller/entity/contents/filters/morphology_filter_contents.cc

--- a/display_list/display_list_image_filter.h
+++ b/display_list/display_list_image_filter.h
@@ -669,6 +669,10 @@ class DlLocalMatrixImageFilter final : public DlImageFilter {
 
   const SkMatrix& matrix() const { return matrix_; }
 
+  const std::shared_ptr<DlImageFilter> image_filter() const {
+    return image_filter_;
+  }
+
   const DlLocalMatrixImageFilter* asLocalMatrix() const override {
     return this;
   }

--- a/impeller/display_list/display_list_dispatcher.cc
+++ b/impeller/display_list/display_list_dispatcher.cc
@@ -620,7 +620,28 @@ static std::optional<Paint::ImageFilterProc> ToImageFilterProc(
       };
       break;
     }
-    case flutter::DlImageFilterType::kLocalMatrixFilter:
+    case flutter::DlImageFilterType::kLocalMatrixFilter: {
+      auto local_matrix_filter = filter->asLocalMatrix();
+      FML_DCHECK(local_matrix_filter);
+      auto internal_filter = local_matrix_filter->image_filter();
+      FML_DCHECK(internal_filter);
+
+      auto image_filter_proc = ToImageFilterProc(internal_filter.get());
+      if (!image_filter_proc.has_value()) {
+        return std::nullopt;
+      }
+
+      auto matrix = ToMatrix(local_matrix_filter->matrix());
+
+      return [matrix, filter_proc = image_filter_proc.value()](
+                 FilterInput::Ref input, const Matrix& effect_transform) {
+        std::shared_ptr<FilterContents> filter =
+            filter_proc(input, effect_transform);
+        return FilterContents::MakeLocalMatrixFilter(FilterInput::Make(filter),
+                                                     matrix);
+      };
+      break;
+    }
     case flutter::DlImageFilterType::kUnknown:
       return std::nullopt;
   }
@@ -719,7 +740,8 @@ void DisplayListDispatcher::transformFullPerspective(SkScalar mxx,
                                                      SkScalar mwy,
                                                      SkScalar mwz,
                                                      SkScalar mwt) {
-  // The order of arguments is row-major but Impeller matrices are column-major.
+  // The order of arguments is row-major but Impeller matrices are
+  // column-major.
   // clang-format off
   auto xformation = Matrix{
     mxx, myx, mzx, mwx,

--- a/impeller/display_list/display_list_unittests.cc
+++ b/impeller/display_list/display_list_unittests.cc
@@ -634,6 +634,9 @@ TEST_P(DisplayListTest, CanDrawWithMatrixFilter) {
       ImGui::SetNextWindowPos({10, 10});
     }
 
+    static int selected_matrix_type = 0;
+    const char* matrix_type_names[] = {"Matrix", "Local Matrix"};
+
     static float ctm_translation[2] = {200, 200};
     static float ctm_scale[2] = {0.65, 0.65};
     static float ctm_skew[2] = {0, 0};
@@ -647,14 +650,20 @@ TEST_P(DisplayListTest, CanDrawWithMatrixFilter) {
 
     ImGui::Begin("Controls", nullptr, ImGuiWindowFlags_AlwaysAutoResize);
     {
+      ImGui::Combo("Filter type", &selected_matrix_type, matrix_type_names,
+                   sizeof(matrix_type_names) / sizeof(char*));
+
       ImGui::TextWrapped("Current Transform");
       ImGui::SliderFloat2("CTM Translation", ctm_translation, 0, 1000);
       ImGui::SliderFloat2("CTM Scale", ctm_scale, 0, 3);
       ImGui::SliderFloat2("CTM Skew", ctm_skew, -3, 3);
 
       ImGui::TextWrapped(
-          "The MatrixFilter applies a matrix in world space as opposed to "
-          "local filter space.");
+          "MatrixFilter and LocalMatrixFilter modify the CTM in the same way. "
+          "The only difference is that MatrixFilter doesn't affect the effect "
+          "transform, whereas LocalMatrixFilter does.");
+      // Note: See this behavior in:
+      //       https://fiddle.skia.org/c/6cbb551ab36d06f163db8693972be954
       ImGui::Checkbox("Enable", &enable);
       ImGui::SliderFloat2("Filter Translation", translation, 0, 1000);
       ImGui::SliderFloat2("Filter Scale", scale, 0, 3);
@@ -670,7 +679,9 @@ TEST_P(DisplayListTest, CanDrawWithMatrixFilter) {
 
     flutter::DisplayListBuilder builder;
     SkPaint paint;
-    builder.saveLayer(nullptr, nullptr);
+    if (enable_savelayer) {
+      builder.saveLayer(nullptr, nullptr);
+    }
     {
       auto content_scale = GetContentScale();
       builder.scale(content_scale.x, content_scale.y);
@@ -687,17 +698,34 @@ TEST_P(DisplayListTest, CanDrawWithMatrixFilter) {
           SkMatrix::MakeAll(scale[0], skew[0], translation[0],  //
                             skew[1], scale[1], translation[1],  //
                             0, 0, 1);
-      auto filter = flutter::DlMatrixImageFilter(
-          filter_matrix, flutter::DlImageSampling::kLinear);
+
       if (enable) {
-        builder.setImageFilter(&filter);
+        switch (selected_matrix_type) {
+          case 0: {
+            auto filter = flutter::DlMatrixImageFilter(
+                filter_matrix, flutter::DlImageSampling::kLinear);
+            builder.setImageFilter(&filter);
+            break;
+          }
+          case 1: {
+            auto internal_filter =
+                flutter::DlBlurImageFilter(10, 10, flutter::DlTileMode::kDecal)
+                    .shared();
+            auto filter = flutter::DlLocalMatrixImageFilter(filter_matrix,
+                                                            internal_filter);
+            builder.setImageFilter(&filter);
+            break;
+          }
+        }
       }
 
       builder.drawImage(DlImageImpeller::Make(boston), {},
                         flutter::DlImageSampling::kLinear, true);
-
+    }
+    if (enable_savelayer) {
       builder.restore();
     }
+
     return builder.Build();
   };
 

--- a/impeller/entity/BUILD.gn
+++ b/impeller/entity/BUILD.gn
@@ -93,6 +93,8 @@ impeller_component("entity") {
     "contents/filters/inputs/texture_filter_input.h",
     "contents/filters/linear_to_srgb_filter_contents.cc",
     "contents/filters/linear_to_srgb_filter_contents.h",
+    "contents/filters/local_matrix_filter_contents.cc",
+    "contents/filters/local_matrix_filter_contents.h",
     "contents/filters/matrix_filter_contents.cc",
     "contents/filters/matrix_filter_contents.h",
     "contents/filters/morphology_filter_contents.cc",

--- a/impeller/entity/contents/filters/filter_contents.cc
+++ b/impeller/entity/contents/filters/filter_contents.cc
@@ -20,6 +20,7 @@
 #include "impeller/entity/contents/filters/gaussian_blur_filter_contents.h"
 #include "impeller/entity/contents/filters/inputs/filter_input.h"
 #include "impeller/entity/contents/filters/linear_to_srgb_filter_contents.h"
+#include "impeller/entity/contents/filters/local_matrix_filter_contents.h"
 #include "impeller/entity/contents/filters/matrix_filter_contents.h"
 #include "impeller/entity/contents/filters/morphology_filter_contents.h"
 #include "impeller/entity/contents/filters/srgb_to_linear_filter_contents.h"
@@ -180,6 +181,15 @@ std::shared_ptr<FilterContents> FilterContents::MakeMatrixFilter(
     FilterInput::Ref input,
     const Matrix& matrix) {
   auto filter = std::make_shared<MatrixFilterContents>();
+  filter->SetInputs({input});
+  filter->SetMatrix(matrix);
+  return filter;
+}
+
+std::shared_ptr<FilterContents> FilterContents::MakeLocalMatrixFilter(
+    FilterInput::Ref input,
+    const Matrix& matrix) {
+  auto filter = std::make_shared<LocalMatrixFilterContents>();
   filter->SetInputs({input});
   filter->SetMatrix(matrix);
   return filter;

--- a/impeller/entity/contents/filters/filter_contents.h
+++ b/impeller/entity/contents/filters/filter_contents.h
@@ -94,6 +94,10 @@ class FilterContents : public Contents {
       FilterInput::Ref input,
       const Matrix& matrix);
 
+  static std::shared_ptr<FilterContents> MakeLocalMatrixFilter(
+      FilterInput::Ref input,
+      const Matrix& matrix);
+
   FilterContents();
 
   ~FilterContents() override;

--- a/impeller/entity/contents/filters/local_matrix_filter_contents.cc
+++ b/impeller/entity/contents/filters/local_matrix_filter_contents.cc
@@ -1,0 +1,31 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/entity/contents/filters/local_matrix_filter_contents.h"
+
+namespace impeller {
+
+LocalMatrixFilterContents::LocalMatrixFilterContents() = default;
+
+LocalMatrixFilterContents::~LocalMatrixFilterContents() = default;
+
+void LocalMatrixFilterContents::SetMatrix(Matrix matrix) {
+  matrix_ = matrix;
+}
+
+Matrix LocalMatrixFilterContents::GetLocalTransform(
+    const Matrix& parent_transform) const {
+  return matrix_;
+}
+
+std::optional<Snapshot> LocalMatrixFilterContents::RenderFilter(
+    const FilterInput::Vector& inputs,
+    const ContentContext& renderer,
+    const Entity& entity,
+    const Matrix& effect_transform,
+    const Rect& coverage) const {
+  return inputs[0]->GetSnapshot(renderer, entity);
+}
+
+}  // namespace impeller

--- a/impeller/entity/contents/filters/local_matrix_filter_contents.h
+++ b/impeller/entity/contents/filters/local_matrix_filter_contents.h
@@ -1,0 +1,37 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#pragma once
+
+#include "impeller/entity/contents/filters/filter_contents.h"
+#include "impeller/entity/contents/filters/inputs/filter_input.h"
+
+namespace impeller {
+
+class LocalMatrixFilterContents final : public FilterContents {
+ public:
+  LocalMatrixFilterContents();
+
+  ~LocalMatrixFilterContents() override;
+
+  void SetMatrix(Matrix matrix);
+
+  // |FilterContents|
+  Matrix GetLocalTransform(const Matrix& parent_transform) const override;
+
+ private:
+  // |FilterContents|
+  std::optional<Snapshot> RenderFilter(
+      const FilterInput::Vector& input_textures,
+      const ContentContext& renderer,
+      const Entity& entity,
+      const Matrix& effect_transform,
+      const Rect& coverage) const override;
+
+  Matrix matrix_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(LocalMatrixFilterContents);
+};
+
+}  // namespace impeller


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/109733

The local matrix filter just appends to the CTM and renders the child Contents. The matrix filter essentially does the same thing, except it doesn't impact the effect transform.

See also: https://fiddle.skia.org/c/6cbb551ab36d06f163db8693972be954