### PR TITLE
[fuchsia] Disable flaking shell test on Fuchsia.

### DIFF
--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -773,6 +773,11 @@ TEST_F(ShellTest, ExternalEmbedderNoThreadMerger) {
 }
 
 TEST_F(ShellTest, PushBackdropFilterToVisitedPlatformViews) {
+#if defined(OS_FUCHSIA)
+  GTEST_SKIP() << "RasterThreadMerger flakes on Fuchsia. "
+                  "https://github.com/flutter/flutter/issues/59816 ";
+#endif
+
   auto settings = CreateSettingsForFixture();
 
   std::shared_ptr<ShellTestExternalViewEmbedder> external_view_embedder;
@@ -839,12 +844,12 @@ TEST_F(ShellTest, PushBackdropFilterToVisitedPlatformViews) {
 
 // TODO(https://github.com/flutter/flutter/issues/59816): Enable on fuchsia.
 TEST_F(ShellTest,
+       ExternalEmbedderEndFrameIsCalledWhenPostPrerollResultIsResubmit) {
 #if defined(OS_FUCHSIA)
-       DISABLED_ExternalEmbedderEndFrameIsCalledWhenPostPrerollResultIsResubmit
-#else
-       ExternalEmbedderEndFrameIsCalledWhenPostPrerollResultIsResubmit
+  GTEST_SKIP() << "RasterThreadMerger flakes on Fuchsia. "
+                  "https://github.com/flutter/flutter/issues/59816 ";
 #endif
-) {
+
   auto settings = CreateSettingsForFixture();
   fml::AutoResetWaitableEvent end_frame_latch;
   bool end_frame_called = false;
@@ -888,15 +893,12 @@ TEST_F(ShellTest,
   DestroyShell(std::move(shell));
 }
 
-TEST_F(ShellTest,
+TEST_F(ShellTest, OnPlatformViewDestroyDisablesThreadMerger) {
 #if defined(OS_FUCHSIA)
-       // TODO(dworsham): https://github.com/flutter/flutter/issues/59816
-       // TODO(cbracken): https://github.com/flutter/flutter/issues/90481
-       DISABLED_OnPlatformViewDestroyDisablesThreadMerger
-#else
-       OnPlatformViewDestroyDisablesThreadMerger
+  GTEST_SKIP() << "RasterThreadMerger flakes on Fuchsia. "
+                  "https://github.com/flutter/flutter/issues/59816 ";
 #endif
-) {
+
   auto settings = CreateSettingsForFixture();
   fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger;
   auto end_frame_callback =
@@ -946,14 +948,12 @@ TEST_F(ShellTest,
   DestroyShell(std::move(shell));
 }
 
-// TODO(https://github.com/flutter/flutter/issues/59816): Enable on fuchsia.
-TEST_F(ShellTest,
+TEST_F(ShellTest, OnPlatformViewDestroyAfterMergingThreads) {
 #if defined(OS_FUCHSIA)
-       DISABLED_OnPlatformViewDestroyAfterMergingThreads
-#else
-       OnPlatformViewDestroyAfterMergingThreads
+  GTEST_SKIP() << "RasterThreadMerger flakes on Fuchsia. "
+                  "https://github.com/flutter/flutter/issues/59816 ";
 #endif
-) {
+
   const int ThreadMergingLease = 10;
   auto settings = CreateSettingsForFixture();
   fml::AutoResetWaitableEvent end_frame_latch;
@@ -1022,14 +1022,12 @@ TEST_F(ShellTest,
   DestroyShell(std::move(shell));
 }
 
-// TODO(https://github.com/flutter/flutter/issues/59816): Enable on fuchsia.
-TEST_F(ShellTest,
+TEST_F(ShellTest, OnPlatformViewDestroyWhenThreadsAreMerging) {
 #if defined(OS_FUCHSIA)
-       DISABLED_OnPlatformViewDestroyWhenThreadsAreMerging
-#else
-       OnPlatformViewDestroyWhenThreadsAreMerging
+  GTEST_SKIP() << "RasterThreadMerger flakes on Fuchsia. "
+                  "https://github.com/flutter/flutter/issues/59816 ";
 #endif
-) {
+
   const int kThreadMergingLease = 10;
   auto settings = CreateSettingsForFixture();
   fml::AutoResetWaitableEvent end_frame_latch;
@@ -1099,14 +1097,13 @@ TEST_F(ShellTest,
   DestroyShell(std::move(shell));
 }
 
-// TODO(https://github.com/flutter/flutter/issues/59816): Enable on fuchsia.
 TEST_F(ShellTest,
+       OnPlatformViewDestroyWithThreadMergerWhileThreadsAreUnmerged) {
 #if defined(OS_FUCHSIA)
-       DISABLED_OnPlatformViewDestroyWithThreadMergerWhileThreadsAreUnmerged
-#else
-       OnPlatformViewDestroyWithThreadMergerWhileThreadsAreUnmerged
+  GTEST_SKIP() << "RasterThreadMerger flakes on Fuchsia. "
+                  "https://github.com/flutter/flutter/issues/59816 ";
 #endif
-) {
+
   auto settings = CreateSettingsForFixture();
   fml::AutoResetWaitableEvent end_frame_latch;
   auto end_frame_callback =
@@ -1201,13 +1198,12 @@ TEST_F(ShellTest, OnPlatformViewDestroyWithoutRasterThreadMerger) {
 }
 
 // TODO(https://github.com/flutter/flutter/issues/59816): Enable on fuchsia.
-TEST_F(ShellTest,
+TEST_F(ShellTest, OnPlatformViewDestroyWithStaticThreadMerging) {
 #if defined(OS_FUCHSIA)
-       DISABLED_OnPlatformViewDestroyWithStaticThreadMerging
-#else
-       OnPlatformViewDestroyWithStaticThreadMerging
+  GTEST_SKIP() << "RasterThreadMerger flakes on Fuchsia. "
+                  "https://github.com/flutter/flutter/issues/59816 ";
 #endif
-) {
+
   auto settings = CreateSettingsForFixture();
   fml::AutoResetWaitableEvent end_frame_latch;
   auto end_frame_callback =
@@ -1304,16 +1300,14 @@ TEST_F(ShellTest, GetUsedThisFrameShouldBeSetBeforeEndFrame) {
   DestroyShell(std::move(shell));
 }
 
-// TODO(https://github.com/flutter/flutter/issues/59816): Enable on fuchsia.
 // TODO(https://github.com/flutter/flutter/issues/66056): Deflake on all other
 // platforms
-TEST_F(ShellTest,
+TEST_F(ShellTest, DISABLED_SkipAndSubmitFrame) {
 #if defined(OS_FUCHSIA)
-       DISABLED_SkipAndSubmitFrame
-#else
-       DISABLED_SkipAndSubmitFrame
+  GTEST_SKIP() << "RasterThreadMerger flakes on Fuchsia. "
+                  "https://github.com/flutter/flutter/issues/59816 ";
 #endif
-) {
+
   auto settings = CreateSettingsForFixture();
   fml::AutoResetWaitableEvent end_frame_latch;
   std::shared_ptr<ShellTestExternalViewEmbedder> external_view_embedder;


### PR DESCRIPTION
This is caused by https://github.com/flutter/flutter/issues/59816 which has disabled a number of adjacent tests.

[#112017](https://github.com/flutter/flutter/issues/112017)