### PR TITLE
[Impeller] Don't do texture passthrough when opacity needs to be applied

### DIFF
--- a/impeller/entity/contents/texture_contents.cc
+++ b/impeller/entity/contents/texture_contents.cc
@@ -11,6 +11,7 @@
 #include "impeller/entity/entity.h"
 #include "impeller/entity/texture_fill.frag.h"
 #include "impeller/entity/texture_fill.vert.h"
+#include "impeller/geometry/constants.h"
 #include "impeller/geometry/path_builder.h"
 #include "impeller/renderer/formats.h"
 #include "impeller/renderer/render_pass.h"
@@ -72,7 +73,8 @@ std::optional<Snapshot> TextureContents::RenderToSnapshot(
 
   // Passthrough textures that have simple rectangle paths and complete source
   // rects.
-  if (is_rect_ && source_rect_ == Rect::MakeSize(texture_->GetSize())) {
+  if (is_rect_ && source_rect_ == Rect::MakeSize(texture_->GetSize()) &&
+      opacity_ >= 1 - kEhCloseEnough) {
     auto scale = Vector2(bounds->size / Size(texture_->GetSize()));
     return Snapshot{.texture = texture_,
                     .transform = entity.GetTransformation() *


### PR DESCRIPTION
It's unfortunately still hard to test properly outside of the playground because it requires uploading images + graphics context to be running in the non-passthrough path.

Before

https://user-images.githubusercontent.com/919017/191629871-903063c0-748e-4051-b2ce-1a29c08ce0b5.mov


After

https://user-images.githubusercontent.com/919017/191629856-9c1f4e41-4d2e-4513-b826-fe6e7bd0e12f.mov

