### PR TITLE
[Impeller] Factor destination alpha into advanced blend output

### DIFF
--- a/impeller/entity/entity.cc
+++ b/impeller/entity/entity.cc
@@ -16,9 +16,6 @@
 
 namespace impeller {
 
-const BlendMode Entity::kLastPipelineBlendMode = BlendMode::kModulate;
-const BlendMode Entity::kLastAdvancedBlendMode = BlendMode::kLuminosity;
-
 Entity::Entity() = default;
 
 Entity::~Entity() = default;

--- a/impeller/entity/entity.h
+++ b/impeller/entity/entity.h
@@ -19,8 +19,8 @@ class RenderPass;
 
 class Entity {
  public:
-  static const BlendMode kLastPipelineBlendMode;
-  static const BlendMode kLastAdvancedBlendMode;
+  static constexpr BlendMode kLastPipelineBlendMode = BlendMode::kModulate;
+  static constexpr BlendMode kLastAdvancedBlendMode = BlendMode::kLuminosity;
 
   /// An enum to define how to repeat, fold, or omit colors outside of the
   /// typically defined range of the source of the colors (such as the

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -666,6 +666,7 @@ TEST_P(EntityTest, BlendingModeOptions) {
     static_assert(b == BlendMode::kClear);  // Ensure the first item in
                                             // the switch is the first
                                             // item in the enum.
+    static_assert(Entity::kLastPipelineBlendMode == BlendMode::kModulate);
     switch (b) {
       case BlendMode::kClear:
         blend_mode_names.push_back("Clear");

--- a/impeller/entity/shaders/blending/advanced_blend.glsl
+++ b/impeller/entity/shaders/blending/advanced_blend.glsl
@@ -40,5 +40,5 @@ void main() {
 
   vec3 blended = Blend(dst.rgb, src.rgb);
 
-  frag_color = vec4(blended * src.a, src.a);
+  frag_color = vec4(blended, 1) * src.a * dst.a;
 }


### PR DESCRIPTION
https://github.com/gskinnerTeam/flutter-wonderous-app/issues/34

For advanced blends, the destination alpha needs to be factored into the output color.

Before:
![image](https://user-images.githubusercontent.com/919017/191635717-e29f48f6-2679-41b9-9bb6-2d71d058ceac.png)


After:
![image](https://user-images.githubusercontent.com/919017/191635575-fef01611-c9e6-4fbb-bb54-566001e7737a.png)
