### PR TITLE
Add discrete scale pointer signal

### DIFF
--- a/lib/ui/pointer.dart
+++ b/lib/ui/pointer.dart
@@ -130,6 +130,9 @@ enum PointerSignalKind {
   /// A pointer-generated scroll-inertia cancel.
   scrollInertiaCancel,
 
+  /// A pointer-generated scale event (e.g. trackpad pinch).
+  scale,
+
   /// An unknown pointer signal kind.
   unknown
 }

--- a/lib/ui/window/pointer_data.h
+++ b/lib/ui/window/pointer_data.h
@@ -61,6 +61,7 @@ struct alignas(8) PointerData {
     kNone,
     kScroll,
     kScrollInertiaCancel,
+    kScale,
   };
 
   int64_t embedder_id;

--- a/lib/ui/window/pointer_data_packet_converter.cc
+++ b/lib/ui/window/pointer_data_packet_converter.cc
@@ -298,7 +298,8 @@ void PointerDataPacketConverter::ConvertPointerData(
   } else {
     switch (pointer_data.signal_kind) {
       case PointerData::SignalKind::kScroll:
-      case PointerData::SignalKind::kScrollInertiaCancel: {
+      case PointerData::SignalKind::kScrollInertiaCancel:
+      case PointerData::SignalKind::kScale: {
         // Makes sure we have an existing pointer
         auto iter = states_.find(pointer_data.device);
         PointerState state;

--- a/lib/ui/window/pointer_data_packet_converter_unittests.cc
+++ b/lib/ui/window/pointer_data_packet_converter_unittests.cc
@@ -558,6 +558,7 @@ TEST(PointerDataPacketConverterTest, CanConvertPointerSignals) {
   PointerData::SignalKind signal_kinds[] = {
       PointerData::SignalKind::kScroll,
       PointerData::SignalKind::kScrollInertiaCancel,
+      PointerData::SignalKind::kScale,
   };
   for (const PointerData::SignalKind& kind : signal_kinds) {
     PointerDataPacketConverter converter;

--- a/lib/web_ui/lib/pointer.dart
+++ b/lib/web_ui/lib/pointer.dart
@@ -30,6 +30,7 @@ enum PointerSignalKind {
   none,
   scroll,
   scrollInertiaCancel,
+  scale,
   unknown
 }
 

--- a/lib/web_ui/lib/src/engine/pointer_converter.dart
+++ b/lib/web_ui/lib/src/engine/pointer_converter.dart
@@ -624,6 +624,7 @@ class PointerDataConverter {
       switch (signalKind) {
         case ui.PointerSignalKind.scroll:
         case ui.PointerSignalKind.scrollInertiaCancel:
+        case ui.PointerSignalKind.scale:
           final bool alreadyAdded = _pointers.containsKey(device);
           _ensureStateForPointer(device, physicalX, physicalY);
           if (!alreadyAdded) {

--- a/shell/platform/android/io/flutter/embedding/android/AndroidTouchProcessor.java
+++ b/shell/platform/android/io/flutter/embedding/android/AndroidTouchProcessor.java
@@ -65,13 +65,15 @@ public class AndroidTouchProcessor {
     PointerSignalKind.NONE,
     PointerSignalKind.SCROLL,
     PointerSignalKind.SCROLL_INERTIA_CANCEL,
+    PointerSignalKind.SCALE,
     PointerSignalKind.UNKNOWN
   })
   public @interface PointerSignalKind {
     int NONE = 0;
     int SCROLL = 1;
     int SCROLL_INERTIA_CANCEL = 2;
-    int UNKNOWN = 3;
+    int SCALE = 3;
+    int UNKNOWN = 4;
   }
 
   // Must match the unpacking code in hooks.dart.

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -1924,6 +1924,8 @@ inline flutter::PointerData::SignalKind ToPointerDataSignalKind(
       return flutter::PointerData::SignalKind::kScroll;
     case kFlutterPointerSignalKindScrollInertiaCancel:
       return flutter::PointerData::SignalKind::kScrollInertiaCancel;
+    case kFlutterPointerSignalKindScale:
+      return flutter::PointerData::SignalKind::kScale;
   }
   return flutter::PointerData::SignalKind::kNone;
 }

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -875,6 +875,7 @@ typedef enum {
   kFlutterPointerSignalKindNone,
   kFlutterPointerSignalKindScroll,
   kFlutterPointerSignalKindScrollInertiaCancel,
+  kFlutterPointerSignalKindScale,
 } FlutterPointerSignalKind;
 
 typedef struct {


### PR DESCRIPTION
Add a new discrete event type to represent a one-time zoom/scale, not as part of a wider gesture. Needed to support pinch-to-zoom on web as we cannot determine the start and end of a pinch, so it can't use `PointerPanZoom` system.

Part of https://github.com/flutter/flutter/issues/112103

## Sequence

1. https://github.com/flutter/flutter/pull/112170
2. This PR
3. https://github.com/flutter/flutter/pull/112172
4. https://github.com/flutter/engine/pull/36348

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
