### PR TITLE
[Impeller] Add missing Vector3 arithmetic ops

### DIFF
--- a/impeller/geometry/geometry_unittests.cc
+++ b/impeller/geometry/geometry_unittests.cc
@@ -891,11 +891,97 @@ TEST(GeometryTest, CanUseVector3AssignmentOperators) {
   }
 
   {
+    Vector3 p(1, 2, 3);
+    p *= 2;
+    ASSERT_EQ(p.x, 2u);
+    ASSERT_EQ(p.y, 4u);
+    ASSERT_EQ(p.z, 6u);
+  }
+
+  {
     Vector3 p(2, 6, 12);
     p /= Vector3(2, 3, 4);
     ASSERT_EQ(p.x, 1u);
     ASSERT_EQ(p.y, 2u);
     ASSERT_EQ(p.z, 3u);
+  }
+
+  {
+    Vector3 p(2, 6, 12);
+    p /= 2;
+    ASSERT_EQ(p.x, 1u);
+    ASSERT_EQ(p.y, 3u);
+    ASSERT_EQ(p.z, 6u);
+  }
+}
+
+TEST(GeometryTest, CanPerformAlgebraicVector3Ops) {
+  {
+    Vector3 p1(1, 2, 3);
+    Vector3 p2 = p1 + Vector3(1, 2, 3);
+    ASSERT_EQ(p2.x, 2u);
+    ASSERT_EQ(p2.y, 4u);
+    ASSERT_EQ(p2.z, 6u);
+  }
+
+  {
+    Vector3 p1(3, 6, 9);
+    Vector3 p2 = p1 - Vector3(1, 2, 3);
+    ASSERT_EQ(p2.x, 2u);
+    ASSERT_EQ(p2.y, 4u);
+    ASSERT_EQ(p2.z, 6u);
+  }
+
+  {
+    Vector3 p1(1, 2, 3);
+    Vector3 p2 = p1 * Vector3(2, 3, 4);
+    ASSERT_EQ(p2.x, 2u);
+    ASSERT_EQ(p2.y, 6u);
+    ASSERT_EQ(p2.z, 12u);
+  }
+
+  {
+    Vector3 p1(2, 6, 12);
+    Vector3 p2 = p1 / Vector3(2, 3, 4);
+    ASSERT_EQ(p2.x, 1u);
+    ASSERT_EQ(p2.y, 2u);
+    ASSERT_EQ(p2.z, 3u);
+  }
+}
+
+TEST(GeometryTest, CanPerformAlgebraicVector3OpsWithArithmeticTypes) {
+  // LHS
+  {
+    Vector3 p1(1, 2, 3);
+    Vector3 p2 = p1 * 2.0f;
+    ASSERT_EQ(p2.x, 2u);
+    ASSERT_EQ(p2.y, 4u);
+    ASSERT_EQ(p2.z, 6u);
+  }
+
+  {
+    Vector3 p1(2, 6, 12);
+    Vector3 p2 = p1 / 2.0f;
+    ASSERT_EQ(p2.x, 1u);
+    ASSERT_EQ(p2.y, 3u);
+    ASSERT_EQ(p2.z, 6u);
+  }
+
+  // RHS
+  {
+    Vector3 p1(1, 2, 3);
+    Vector3 p2 = 2.0f * p1;
+    ASSERT_EQ(p2.x, 2u);
+    ASSERT_EQ(p2.y, 4u);
+    ASSERT_EQ(p2.z, 6u);
+  }
+
+  {
+    Vector3 p1(2, 6, 12);
+    Vector3 p2 = 12.0f / p1;
+    ASSERT_EQ(p2.x, 6u);
+    ASSERT_EQ(p2.y, 2u);
+    ASSERT_EQ(p2.z, 1u);
   }
 }
 

--- a/impeller/geometry/vector.h
+++ b/impeller/geometry/vector.h
@@ -89,10 +89,26 @@ struct Vector3 {
     return *this;
   }
 
+  template <class U, class = std::enable_if_t<std::is_arithmetic_v<U>>>
+  constexpr Vector3 operator*=(U scale) {
+    x *= scale;
+    y *= scale;
+    z *= scale;
+    return *this;
+  }
+
   constexpr Vector3 operator/=(const Vector3& p) {
     x /= p.x;
     y /= p.y;
     z /= p.z;
+    return *this;
+  }
+
+  template <class U, class = std::enable_if_t<std::is_arithmetic_v<U>>>
+  constexpr Vector3 operator/=(U scale) {
+    x /= scale;
+    y /= scale;
+    z /= scale;
     return *this;
   }
 
@@ -104,6 +120,24 @@ struct Vector3 {
 
   constexpr Vector3 operator-(const Vector3& v) const {
     return Vector3(x - v.x, y - v.y, z - v.z);
+  }
+
+  constexpr Vector3 operator*(const Vector3& v) const {
+    return Vector3(x * v.x, y * v.y, z * v.z);
+  }
+
+  template <class U, class = std::enable_if_t<std::is_arithmetic_v<U>>>
+  constexpr Vector3 operator*(U scale) const {
+    return Vector3(x * scale, y * scale, z * scale);
+  }
+
+  constexpr Vector3 operator/(const Vector3& v) const {
+    return Vector3(x / v.x, y / v.y, z / v.z);
+  }
+
+  template <class U, class = std::enable_if_t<std::is_arithmetic_v<U>>>
+  constexpr Vector3 operator/(U scale) const {
+    return Vector3(x / scale, y / scale, z / scale);
   }
 
   /**
@@ -139,7 +173,11 @@ constexpr Vector3 operator*(U s, const Vector3& p) {
 
 template <class U, class = std::enable_if_t<std::is_arithmetic_v<U>>>
 constexpr Vector3 operator/(U s, const Vector3& p) {
-  return {static_cast<Scalar>(s) / p.x, static_cast<Scalar>(s) / p.y};
+  return {
+      static_cast<Scalar>(s) / p.x,
+      static_cast<Scalar>(s) / p.y,
+      static_cast<Scalar>(s) / p.z,
+  };
 }
 
 struct Vector4 {


### PR DESCRIPTION
* Adds `Vector3 *= scale`, `Vector3 /= scale`, `Vector3 * Vector3`, `Vector3 * scale`, `Vector3 / Vector3`, `Vector3 / scale`.
* Covers all existing/new arithmetic ops in tests.
* Fixes bug in `scale / Vector3`.