### PR TITLE
[Impeller] Make Picture::RenderToTexture antialiased 

### DIFF
--- a/impeller/aiks/picture.cc
+++ b/impeller/aiks/picture.cc
@@ -52,12 +52,12 @@ std::shared_ptr<Texture> Picture::RenderToTexture(
 
   // This texture isn't host visible, but we might want to add host visible
   // features to Image someday.
-  auto impeller_context = *context.GetContext();
+  auto impeller_context = context.GetContext();
   RenderTarget target;
   if (impeller_context->SupportsOffscreenMSAA()) {
-    target = RenderTarget::CreateOffscreenMSAA(impeller_context, size);
+    target = RenderTarget::CreateOffscreenMSAA(*impeller_context, size);
   } else {
-    target = RenderTarget::CreateOffscreen(impeller_context, size);
+    target = RenderTarget::CreateOffscreen(*impeller_context, size);
   }
   if (!target.IsValid()) {
     VALIDATION_LOG << "Could not create valid RenderTarget.";

--- a/impeller/aiks/picture.cc
+++ b/impeller/aiks/picture.cc
@@ -52,7 +52,7 @@ std::shared_ptr<Texture> Picture::RenderToTexture(
 
   // This texture isn't host visible, but we might want to add host visible
   // features to Image someday.
-  auto target = RenderTarget::CreateOffscreen(*context.GetContext(), size);
+  auto target = RenderTarget::CreateOffscreenMSAA(*context.GetContext(), size);
   if (!target.IsValid()) {
     VALIDATION_LOG << "Could not create valid RenderTarget.";
     return nullptr;

--- a/impeller/aiks/picture.cc
+++ b/impeller/aiks/picture.cc
@@ -52,7 +52,13 @@ std::shared_ptr<Texture> Picture::RenderToTexture(
 
   // This texture isn't host visible, but we might want to add host visible
   // features to Image someday.
-  auto target = RenderTarget::CreateOffscreenMSAA(*context.GetContext(), size);
+  auto impeller_context = *context.GetContext();
+  RenderTarget target;
+  if (impeller_context->SupportsOffscreenMSAA()) {
+    target = RenderTarget::CreateOffscreenMSAA(impeller_context, size);
+  } else {
+    target = RenderTarget::CreateOffscreen(impeller_context, size);
+  }
   if (!target.IsValid()) {
     VALIDATION_LOG << "Could not create valid RenderTarget.";
     return nullptr;


### PR DESCRIPTION
Right now the textures aren't getting MSAA and so look aliased when drawing into a scene.
