### PR TITLE
Roll ANGLE, vulkan-deps, and shaderc

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -142,10 +142,10 @@ deps = {
    Var('fuchsia_git') + '/third_party/glfw' + '@' + '78e6a0063d27ed44c2c4805606309744f6fb29fc',
 
   'src/third_party/shaderc':
-   Var('github_git') + '/google/shaderc.git' + '@' + '948660cccfbbc303d2590c7f44a4cee40b66fdd6',
+   Var('github_git') + '/google/shaderc.git' + '@' + '7ea834ecc59258a5c13c3d3e6fa0582bdde7c543',
 
   'src/third_party/vulkan-deps':
-   Var('chromium_git') + '/vulkan-deps' + '@' + '9bb79e503dd5f60d14d46712d51bda9c9dd8f2d3',
+   Var('chromium_git') + '/vulkan-deps' + '@' + 'afc444a0f49a09f67b3dc63ddcd14e2031466ffa',
 
   'src/third_party/flatbuffers':
    Var('github_git') + '/google/flatbuffers.git' + '@' + '0a80646371179f8a7a5c1f42c31ee1d44dcf6709',
@@ -474,7 +474,7 @@ deps = {
    Var('swiftshader_git') + '/SwiftShader.git' + '@' + 'bea8d2471bd912220ba59032e0738f3364632657',
 
    'src/third_party/angle':
-   Var('chromium_git') + '/angle/angle.git' + '@' + '3faaded8234b31dea24c929e40e33089a34a9aa5',
+   Var('chromium_git') + '/angle/angle.git' + '@' + '094b49db60cb48ee932a875898b57accbfa656de',
 
    'src/third_party/vulkan_memory_allocator':
    Var('chromium_git') + '/external/github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator' + '@' + '7de5cc00de50e71a3aab22dea52fbb7ff4efceb6',

--- a/ci/licenses_golden/licenses_third_party
+++ b/ci/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: 13f254f7438eedf72d1e436bc270fb5c
+Signature: 415d338edcb980960efe1fe9e47ab370
 
 UNUSED LICENSES:
 
@@ -1327,10 +1327,7 @@ FILE: ../../../third_party/angle/include/GLES/egl.h
 FILE: ../../../third_party/angle/include/GLES/glplatform.h
 FILE: ../../../third_party/angle/include/GLES2/gl2platform.h
 FILE: ../../../third_party/angle/include/GLES3/gl3platform.h
-FILE: ../../../third_party/angle/scripts/cl.xml
-FILE: ../../../third_party/angle/scripts/egl.xml
 FILE: ../../../third_party/angle/scripts/gl.xml
-FILE: ../../../third_party/angle/scripts/wgl.xml
 FILE: ../../../third_party/angle/src/android_system_settings/res/layout/fragment.xml
 FILE: ../../../third_party/angle/src/android_system_settings/res/values-af/strings.xml
 FILE: ../../../third_party/angle/src/android_system_settings/res/values-am/strings.xml
@@ -2220,6 +2217,7 @@ FILE: ../../../third_party/vulkan-deps/vulkan-headers/src/include/vulkan/vulkan_
 FILE: ../../../third_party/vulkan-deps/vulkan-headers/src/include/vulkan/vulkan_raii.hpp
 FILE: ../../../third_party/vulkan-deps/vulkan-headers/src/include/vulkan/vulkan_screen.h
 FILE: ../../../third_party/vulkan-deps/vulkan-headers/src/include/vulkan/vulkan_structs.hpp
+FILE: ../../../third_party/vulkan-deps/vulkan-headers/src/include/vulkan/vulkan_to_string.hpp
 FILE: ../../../third_party/vulkan-deps/vulkan-headers/src/include/vulkan/vulkan_vi.h
 FILE: ../../../third_party/vulkan-deps/vulkan-headers/src/include/vulkan/vulkan_wayland.h
 FILE: ../../../third_party/vulkan-deps/vulkan-headers/src/include/vulkan/vulkan_win32.h
@@ -18724,8 +18722,9 @@ FILE: ../../../third_party/angle/src/libANGLE/renderer/vulkan/ProgramPipelineVk.
 FILE: ../../../third_party/angle/src/libANGLE/renderer/vulkan/ProgramPipelineVk.h
 FILE: ../../../third_party/angle/src/libANGLE/renderer/vulkan/ResourceVk.cpp
 FILE: ../../../third_party/angle/src/libANGLE/renderer/vulkan/ResourceVk.h
-FILE: ../../../third_party/angle/src/libGL/proc_table_wgl.h
 FILE: ../../../third_party/angle/src/libGLESv2/proc_table_egl.h
+FILE: ../../../third_party/angle/src/libGLESv2/proc_table_glx.h
+FILE: ../../../third_party/angle/src/libGLESv2/proc_table_wgl.h
 ----------------------------------------------------------------------------------------------------
 Copyright 2017 The ANGLE Project Authors. All rights reserved.
 
@@ -19160,8 +19159,6 @@ FILE: ../../../third_party/angle/src/libANGLE/renderer/vulkan/shaders/src/Overla
 FILE: ../../../third_party/angle/src/libANGLE/renderer/vulkan/vk_mandatory_format_support_data.json
 FILE: ../../../third_party/angle/src/libEGL/libEGL.rc
 FILE: ../../../third_party/angle/src/libEGL/resource.h
-FILE: ../../../third_party/angle/src/libGL/libGL.rc
-FILE: ../../../third_party/angle/src/libGL/resource.h
 FILE: ../../../third_party/angle/src/libGLESv1_CM/libGLESv1_CM.def
 FILE: ../../../third_party/angle/src/libGLESv1_CM/libGLESv1_CM.rc
 FILE: ../../../third_party/angle/src/libGLESv1_CM/resource.h
@@ -19757,10 +19754,11 @@ FILE: ../../../third_party/angle/src/libANGLE/validationGL1.cpp
 FILE: ../../../third_party/angle/src/libANGLE/validationGL2.cpp
 FILE: ../../../third_party/angle/src/libANGLE/validationGL3.cpp
 FILE: ../../../third_party/angle/src/libANGLE/validationGL4.cpp
-FILE: ../../../third_party/angle/src/libGL/entry_points_wgl.cpp
-FILE: ../../../third_party/angle/src/libGL/entry_points_wgl.h
-FILE: ../../../third_party/angle/src/libGL/proc_table_wgl_autogen.cpp
+FILE: ../../../third_party/angle/src/libGLESv2/entry_points_wgl.cpp
+FILE: ../../../third_party/angle/src/libGLESv2/entry_points_wgl.h
 FILE: ../../../third_party/angle/src/libGLESv2/proc_table_egl_autogen.cpp
+FILE: ../../../third_party/angle/src/libGLESv2/proc_table_glx_autogen.cpp
+FILE: ../../../third_party/angle/src/libGLESv2/proc_table_wgl_autogen.cpp
 FILE: ../../../third_party/angle/util/Timer.cpp
 FILE: ../../../third_party/angle/util/Timer.h
 FILE: ../../../third_party/angle/util/fuchsia/ScenicWindow.cpp
@@ -20054,8 +20052,6 @@ FILE: ../../../third_party/angle/src/compiler/translator/tree_ops/RemoveAtomicCo
 FILE: ../../../third_party/angle/src/compiler/translator/tree_ops/RemoveAtomicCounterBuiltins.h
 FILE: ../../../third_party/angle/src/compiler/translator/tree_ops/d3d/RecordUniformBlocksWithLargeArrayMember.cpp
 FILE: ../../../third_party/angle/src/compiler/translator/tree_ops/d3d/RecordUniformBlocksWithLargeArrayMember.h
-FILE: ../../../third_party/angle/src/compiler/translator/tree_ops/vulkan/EarlyFragmentTestsOptimization.cpp
-FILE: ../../../third_party/angle/src/compiler/translator/tree_ops/vulkan/EarlyFragmentTestsOptimization.h
 FILE: ../../../third_party/angle/src/compiler/translator/tree_ops/vulkan/FlagSamplersWithTexelFetch.cpp
 FILE: ../../../third_party/angle/src/compiler/translator/tree_ops/vulkan/FlagSamplersWithTexelFetch.h
 FILE: ../../../third_party/angle/src/compiler/translator/tree_ops/vulkan/ReplaceForShaderFramebufferFetch.cpp
@@ -20099,6 +20095,14 @@ FILE: ../../../third_party/angle/src/libANGLE/InfoLog.h
 FILE: ../../../third_party/angle/src/libANGLE/ProgramExecutable.cpp
 FILE: ../../../third_party/angle/src/libANGLE/ProgramExecutable.h
 FILE: ../../../third_party/angle/src/libANGLE/angletypes_unittest.cpp
+FILE: ../../../third_party/angle/src/libANGLE/capture/capture_gl_1_autogen.cpp
+FILE: ../../../third_party/angle/src/libANGLE/capture/capture_gl_1_autogen.h
+FILE: ../../../third_party/angle/src/libANGLE/capture/capture_gl_2_autogen.cpp
+FILE: ../../../third_party/angle/src/libANGLE/capture/capture_gl_2_autogen.h
+FILE: ../../../third_party/angle/src/libANGLE/capture/capture_gl_3_autogen.cpp
+FILE: ../../../third_party/angle/src/libANGLE/capture/capture_gl_3_autogen.h
+FILE: ../../../third_party/angle/src/libANGLE/capture/capture_gl_4_autogen.cpp
+FILE: ../../../third_party/angle/src/libANGLE/capture/capture_gl_4_autogen.h
 FILE: ../../../third_party/angle/src/libANGLE/capture/capture_gles_1_0_autogen.cpp
 FILE: ../../../third_party/angle/src/libANGLE/capture/capture_gles_1_0_autogen.h
 FILE: ../../../third_party/angle/src/libANGLE/capture/capture_gles_2_0_autogen.cpp
@@ -20122,7 +20126,6 @@ FILE: ../../../third_party/angle/src/libANGLE/renderer/EGLReusableSync.h
 FILE: ../../../third_party/angle/src/libANGLE/renderer/EGLSyncImpl.cpp
 FILE: ../../../third_party/angle/src/libANGLE/renderer/FormatID_autogen.h
 FILE: ../../../third_party/angle/src/libANGLE/renderer/Format_table_autogen.cpp
-FILE: ../../../third_party/angle/src/libANGLE/renderer/ProgramPipelineImpl.cpp
 FILE: ../../../third_party/angle/src/libANGLE/renderer/d3d/driver_utils_d3d.cpp
 FILE: ../../../third_party/angle/src/libANGLE/renderer/d3d/driver_utils_d3d.h
 FILE: ../../../third_party/angle/src/libANGLE/renderer/d3d_format.cpp
@@ -20215,16 +20218,6 @@ FILE: ../../../third_party/angle/src/libANGLE/validationGL46_autogen.h
 FILE: ../../../third_party/angle/src/libANGLE/validationGL4_autogen.h
 FILE: ../../../third_party/angle/src/libEGL/libEGL_autogen.cpp
 FILE: ../../../third_party/angle/src/libEGL/libEGL_autogen.def
-FILE: ../../../third_party/angle/src/libGL/entry_points_gl_1_autogen.cpp
-FILE: ../../../third_party/angle/src/libGL/entry_points_gl_1_autogen.h
-FILE: ../../../third_party/angle/src/libGL/entry_points_gl_2_autogen.cpp
-FILE: ../../../third_party/angle/src/libGL/entry_points_gl_2_autogen.h
-FILE: ../../../third_party/angle/src/libGL/entry_points_gl_3_autogen.cpp
-FILE: ../../../third_party/angle/src/libGL/entry_points_gl_3_autogen.h
-FILE: ../../../third_party/angle/src/libGL/entry_points_gl_4_autogen.cpp
-FILE: ../../../third_party/angle/src/libGL/entry_points_gl_4_autogen.h
-FILE: ../../../third_party/angle/src/libGL/libGL_autogen.cpp
-FILE: ../../../third_party/angle/src/libGL/libGL_autogen.def
 FILE: ../../../third_party/angle/src/libGLESv2/egl_ext_stubs.cpp
 FILE: ../../../third_party/angle/src/libGLESv2/egl_ext_stubs_autogen.h
 FILE: ../../../third_party/angle/src/libGLESv2/egl_get_labeled_object_data.json
@@ -20236,6 +20229,14 @@ FILE: ../../../third_party/angle/src/libGLESv2/entry_points_egl_autogen.cpp
 FILE: ../../../third_party/angle/src/libGLESv2/entry_points_egl_autogen.h
 FILE: ../../../third_party/angle/src/libGLESv2/entry_points_egl_ext_autogen.cpp
 FILE: ../../../third_party/angle/src/libGLESv2/entry_points_egl_ext_autogen.h
+FILE: ../../../third_party/angle/src/libGLESv2/entry_points_gl_1_autogen.cpp
+FILE: ../../../third_party/angle/src/libGLESv2/entry_points_gl_1_autogen.h
+FILE: ../../../third_party/angle/src/libGLESv2/entry_points_gl_2_autogen.cpp
+FILE: ../../../third_party/angle/src/libGLESv2/entry_points_gl_2_autogen.h
+FILE: ../../../third_party/angle/src/libGLESv2/entry_points_gl_3_autogen.cpp
+FILE: ../../../third_party/angle/src/libGLESv2/entry_points_gl_3_autogen.h
+FILE: ../../../third_party/angle/src/libGLESv2/entry_points_gl_4_autogen.cpp
+FILE: ../../../third_party/angle/src/libGLESv2/entry_points_gl_4_autogen.h
 FILE: ../../../third_party/angle/src/libGLESv2/entry_points_gles_1_0_autogen.cpp
 FILE: ../../../third_party/angle/src/libGLESv2/entry_points_gles_1_0_autogen.h
 FILE: ../../../third_party/angle/src/libGLESv2/entry_points_gles_2_0_autogen.cpp
@@ -20252,6 +20253,8 @@ FILE: ../../../third_party/angle/src/libGLESv2/libGLESv2_autogen.cpp
 FILE: ../../../third_party/angle/src/libGLESv2/libGLESv2_autogen.def
 FILE: ../../../third_party/angle/src/libGLESv2/libGLESv2_no_capture_autogen.def
 FILE: ../../../third_party/angle/src/libGLESv2/libGLESv2_with_capture_autogen.def
+FILE: ../../../third_party/angle/src/libGLESv2/opengl32_autogen.def
+FILE: ../../../third_party/angle/src/libGLESv2/opengl32_with_wgl_autogen.def
 FILE: ../../../third_party/angle/src/libOpenCL/libOpenCL_autogen.cpp
 FILE: ../../../third_party/angle/util/capture/angle_trace_gl.h
 FILE: ../../../third_party/angle/util/capture/frame_capture_test_utils.h
@@ -20737,10 +20740,15 @@ FILE: ../../../third_party/angle/include/platform/frontend_features.json
 FILE: ../../../third_party/angle/include/platform/gl_features.json
 FILE: ../../../third_party/angle/include/platform/mtl_features.json
 FILE: ../../../third_party/angle/include/platform/vk_features.json
+FILE: ../../../third_party/angle/samples/hello_triangle_gl/HelloTriangleGL.cpp
+FILE: ../../../third_party/angle/scripts/angle_android_codegen.go
+FILE: ../../../third_party/angle/src/common/apple_platform_utils.mm
 FILE: ../../../third_party/angle/src/compiler/translator/BaseTypes.cpp
 FILE: ../../../third_party/angle/src/compiler/translator/TranslatorMetalConstantNames.cpp
 FILE: ../../../third_party/angle/src/compiler/translator/TranslatorMetalDirect/GuardFragDepthWrite.cpp
 FILE: ../../../third_party/angle/src/compiler/translator/TranslatorMetalDirect/GuardFragDepthWrite.h
+FILE: ../../../third_party/angle/src/compiler/translator/tree_ops/RewritePixelLocalStorage.cpp
+FILE: ../../../third_party/angle/src/compiler/translator/tree_ops/RewritePixelLocalStorage.h
 FILE: ../../../third_party/angle/src/compiler/translator/tree_ops/d3d/AggregateAssignArraysInSSBOs.cpp
 FILE: ../../../third_party/angle/src/compiler/translator/tree_ops/d3d/AggregateAssignArraysInSSBOs.h
 FILE: ../../../third_party/angle/src/compiler/translator/tree_ops/d3d/AggregateAssignStructsInSSBOs.cpp
@@ -20751,14 +20759,33 @@ FILE: ../../../third_party/angle/src/compiler/translator/tree_ops/vulkan/Emulate
 FILE: ../../../third_party/angle/src/compiler/translator/tree_ops/vulkan/EmulateDithering.h
 FILE: ../../../third_party/angle/src/compiler/translator/tree_ops/vulkan/EmulateYUVBuiltIns.cpp
 FILE: ../../../third_party/angle/src/compiler/translator/tree_ops/vulkan/EmulateYUVBuiltIns.h
+FILE: ../../../third_party/angle/src/image_util/loadimage_astc.cpp
+FILE: ../../../third_party/angle/src/libANGLE/MemoryShaderCache.cpp
+FILE: ../../../third_party/angle/src/libANGLE/MemoryShaderCache.h
 FILE: ../../../third_party/angle/src/libANGLE/Overlay_font_autogen.cpp
 FILE: ../../../third_party/angle/src/libANGLE/Overlay_font_autogen.h
+FILE: ../../../third_party/angle/src/libANGLE/PixelLocalStorage.cpp
+FILE: ../../../third_party/angle/src/libANGLE/PixelLocalStorage.h
 FILE: ../../../third_party/angle/src/libANGLE/capture/capture_egl.cpp
 FILE: ../../../third_party/angle/src/libANGLE/capture/capture_egl.h
+FILE: ../../../third_party/angle/src/libANGLE/capture/capture_gl_1_params.cpp
+FILE: ../../../third_party/angle/src/libANGLE/capture/capture_gl_2_params.cpp
+FILE: ../../../third_party/angle/src/libANGLE/capture/capture_gl_3_params.cpp
+FILE: ../../../third_party/angle/src/libANGLE/capture/capture_gl_4_params.cpp
+FILE: ../../../third_party/angle/src/libANGLE/renderer/FramebufferImpl.cpp
+FILE: ../../../third_party/angle/src/libANGLE/renderer/ProgramImpl.cpp
+FILE: ../../../third_party/angle/src/libANGLE/renderer/ProgramPipelineImpl.cpp
+FILE: ../../../third_party/angle/src/libANGLE/renderer/RenderbufferImpl.cpp
+FILE: ../../../third_party/angle/src/libANGLE/renderer/TransformFeedbackImpl.cpp
+FILE: ../../../third_party/angle/src/libANGLE/renderer/VertexArrayImpl.cpp
+FILE: ../../../third_party/angle/src/libANGLE/renderer/vulkan/Suballocation.cpp
+FILE: ../../../third_party/angle/src/libANGLE/renderer/vulkan/Suballocation.h
 FILE: ../../../third_party/angle/src/libANGLE/renderer/vulkan/linux/gbm/DisplayVkGbm.cpp
 FILE: ../../../third_party/angle/src/libANGLE/renderer/vulkan/linux/gbm/DisplayVkGbm.h
 FILE: ../../../third_party/angle/src/libANGLE/renderer/vulkan/shaders/src/OverlayDraw.frag
 FILE: ../../../third_party/angle/src/libANGLE/renderer/vulkan/shaders/src/OverlayDraw.vert
+FILE: ../../../third_party/angle/src/libGLESv2/entry_points_glx.cpp
+FILE: ../../../third_party/angle/src/libGLESv2/entry_points_glx.h
 FILE: ../../../third_party/angle/util/angle_features_autogen.cpp
 FILE: ../../../third_party/angle/util/angle_features_autogen.h
 FILE: ../../../third_party/angle/util/linux/LinuxWindow.cpp
@@ -24712,6 +24739,7 @@ FILE: ../../../third_party/angle/include/GLES2/gl2ext.h
 FILE: ../../../third_party/angle/include/GLES3/gl3.h
 FILE: ../../../third_party/angle/include/GLES3/gl31.h
 FILE: ../../../third_party/angle/include/GLES3/gl32.h
+FILE: ../../../third_party/angle/include/GLX/glxext.h
 FILE: ../../../third_party/json/include/nlohmann/adl_serializer.hpp
 FILE: ../../../third_party/json/include/nlohmann/byte_container_with_subtype.hpp
 FILE: ../../../third_party/json/include/nlohmann/detail/abi_macros.hpp

--- a/ci/licenses_golden/tool_signature
+++ b/ci/licenses_golden/tool_signature
@@ -1,2 +1,2 @@
-Signature: ebfee4cf8fc59213ae6efbc0c13dc6c8
+Signature: 960c777bbc4aed25629fa86a8d7bf10b
 

--- a/tools/gn
+++ b/tools/gn
@@ -335,11 +335,16 @@ def to_gn_args(args):
     gn_args['host_cpu'] = cpu
     gn_args['target_cpu'] = cpu
 
-  # macOS host builds (whether x64 or arm64) must currently be built under
-  # Rosetta on Apple Silicon Macs.
-  # TODO(cbracken): https://github.com/flutter/flutter/issues/103386
   if is_host_build(args) and gn_args['host_os'] == 'mac':
+    # macOS host builds (whether x64 or arm64) must currently be built under
+    # Rosetta on Apple Silicon Macs.
+    # TODO(cbracken): https://github.com/flutter/flutter/issues/103386
     gn_args['host_cpu'] = 'x64'
+
+    # macOS unit tests include Vulkan headers which reference Metal types
+    # introduced in macOS 10.14.
+    gn_args['mac_sdk_min'] = '10.14'
+    gn_args['mac_deployment_target'] = '10.14.0'
 
   # macOS target builds (whether x64 or arm64) must currently be built under
   # Rosetta on Apple Silicon Macs.
@@ -554,11 +559,13 @@ def to_gn_args(args):
                              get_host_os() == 'win'):
     # Do not build unnecessary parts of the ANGLE tree.
     gn_args['angle_build_all'] = False
+    gn_args['angle_has_astc_encoder'] = False
     # Force ANGLE context checks on Windows to prevent crashes.
     # TODO(loic-sharma): Remove this once ANGLE crashes have been fixed.
     # https://github.com/flutter/flutter/issues/114107
     if get_host_os() == 'win':
       gn_args['angle_force_context_check_every_call'] = True
+
     # Requires RTTI. We may want to build this in debug modes, punting on that
     # for now.
     gn_args['angle_enable_vulkan_validation_layers'] = False

--- a/tools/licenses/lib/patterns.dart
+++ b/tools/licenses/lib/patterns.dart
@@ -1649,7 +1649,7 @@ final List<RegExp> csLicenses = <RegExp>[
     r'^(?:\1\2)?GNU General Public License for more details.\n'
     r'^(?:\1\2)?\n*'
     r'^(?:\1\2)?You should have received a copy of the GNU General Public License\n'
-    r'^(?:\1\2)?along with this program.  If not, see <http://www.gnu.org/licenses/>.  \*/\n'
+    r'^(?:\1\2)?along with this program.  If not, see <https?://www.gnu.org/licenses/>.  \*/\n'
     r'^(?:\1\2)?\n*' +
     kIndent +
     r'As a special exception, you may create a larger work that contains\n'


### PR DESCRIPTION
This change updates ANGLE to a version that contains [angle#3906325](https://chromium-review.googlesource.com/c/angle/angle/+/3906325), which fixes the COM error reported in  https://github.com/flutter/flutter/issues/110948. This also updates vulkan-deps and shaderc as these are dependencies of ANGLE.

Part of https://github.com/flutter/flutter/issues/110948

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
