### PR TITLE
[Impeller] Allow skipping of inactive uniforms in GLES

### DIFF
--- a/impeller/fixtures/BUILD.gn
+++ b/impeller/fixtures/BUILD.gn
@@ -16,6 +16,8 @@ impeller_shaders("shader_fixtures") {
     "colors.frag",
     "impeller.frag",
     "impeller.vert",
+    "inactive_uniforms.frag",
+    "inactive_uniforms.vert",
     "instanced_draw.frag",
     "instanced_draw.vert",
     "mipmaps.frag",

--- a/impeller/fixtures/inactive_uniforms.frag
+++ b/impeller/fixtures/inactive_uniforms.frag
@@ -1,0 +1,21 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+uniform FragInfo {
+  vec4 unused_color;
+  vec4 color;
+}
+frag_info;
+
+in vec2 v_position;
+
+out vec4 frag_color;
+
+float SphereDistance(vec2 position, float radius) {
+  return length(v_position - position) - radius;
+}
+
+void main() {
+  frag_color = frag_info.color;
+}

--- a/impeller/fixtures/inactive_uniforms.vert
+++ b/impeller/fixtures/inactive_uniforms.vert
@@ -1,0 +1,17 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+uniform VertInfo {
+  mat4 mvp;
+}
+vert_info;
+
+in vec2 position;
+
+out vec2 v_position;
+
+void main() {
+  gl_Position = vert_info.mvp * vec4(position, 0.0, 1.0);
+  v_position = position;
+}

--- a/impeller/renderer/backend/gles/buffer_bindings_gles.cc
+++ b/impeller/renderer/backend/gles/buffer_bindings_gles.cc
@@ -218,8 +218,9 @@ bool BufferBindingsGLES::BindUniformBuffer(const ProcTableGLES& gl,
                                                     member.array_elements > 1);
     const auto location = uniform_locations_.find(member_key);
     if (location == uniform_locations_.end()) {
-      FML_DLOG(WARNING) << "Location for uniform member not known: "
-                        << member_key;
+      // The list of uniform locations only contains "active" uniforms that are
+      // not optimized out. So this situation is expected to happen when unused
+      // uniforms are present in the shader.
       continue;
     }
 

--- a/impeller/renderer/backend/gles/buffer_bindings_gles.cc
+++ b/impeller/renderer/backend/gles/buffer_bindings_gles.cc
@@ -103,6 +103,9 @@ bool BufferBindingsGLES::ReadUniformsBindings(const ProcTableGLES& gl,
     GLsizei written_count = 0u;
     GLint uniform_var_size = 0u;
     GLenum uniform_type = GL_FLOAT;
+    // Note: Active uniforms are defined as uniforms that may have an impact on
+    //       the output of the shader. Drivers are allowed to (and often do)
+    //       optimize out unused uniforms.
     gl.GetActiveUniform(program,            // program
                         i,                  // index
                         max_name_size,      // buffer_size
@@ -215,8 +218,9 @@ bool BufferBindingsGLES::BindUniformBuffer(const ProcTableGLES& gl,
                                                     member.array_elements > 1);
     const auto location = uniform_locations_.find(member_key);
     if (location == uniform_locations_.end()) {
-      VALIDATION_LOG << "Location for uniform member not known: " << member_key;
-      return false;
+      FML_DLOG(WARNING) << "Location for uniform member not known: "
+                        << member_key;
+      continue;
     }
 
     size_t element_stride = member.byte_length / member.array_elements;


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/109966.

It turns out that "active" uniforms are defined as uniforms that contribute to the shader's output. So many (most?) drivers eliminate unused uniforms while compiling shaders anyhow. There doesn't seem to be a way to detect "inactive" uniforms that were eliminated, which means that making ImpellerC not eliminate the uniforms won't get us any closer to properly sanity checking the bindings (while also making the driver do slightly more work).

This lack of predictability in the final uniform layout is one of the reasons looking up the uniform locations is necessary in the first place.