### PR TITLE
[macos] expose runWithEngine constructor in FlutterViewController (#7…

### DIFF
--- a/shell/platform/darwin/macos/framework/Headers/FlutterViewController.h
+++ b/shell/platform/darwin/macos/framework/Headers/FlutterViewController.h
@@ -53,7 +53,18 @@ FLUTTER_DARWIN_EXPORT
                                  bundle:(nullable NSBundle*)nibBundleOrNil
     NS_DESIGNATED_INITIALIZER;
 - (nonnull instancetype)initWithCoder:(nonnull NSCoder*)nibNameOrNil NS_DESIGNATED_INITIALIZER;
-
+/**
+ * Initializes this FlutterViewController with the specified `FlutterEngine`.
+ *
+ * The initialized viewcontroller will attach itself to the engine as part of this process.
+ *
+ * @param engine The `FlutterEngine` instance to attach to. Cannot be nil.
+ * @param nibName The NIB name to initialize this controller with.
+ * @param nibBundle The NIB bundle.
+ */
+- (nonnull instancetype)initWithEngine:(nonnull FlutterEngine*)engine
+                               nibName:(nullable NSString*)nibName
+                                bundle:(nullable NSBundle*)nibBundle NS_DESIGNATED_INITIALIZER;
 /**
  * Invoked by the engine right before the engine is restarted.
  *

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -340,7 +340,11 @@ static void CommonInit(FlutterViewController* controller) {
     }
     _engine = engine;
     CommonInit(self);
-    [engine setViewController:self];
+    if (engine.running) {
+      [self loadView];
+      engine.viewController = self;
+      [self initializeKeyboard];
+    }
   }
 
   return self;

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -329,15 +329,14 @@ static void CommonInit(FlutterViewController* controller) {
                        nibName:(nullable NSString*)nibName
                         bundle:(nullable NSBundle*)nibBundle {
   NSAssert(engine != nil, @"Engine is required");
+  NSAssert(engine.viewController == nil,
+           @"The supplied FlutterEngine is already used with FlutterViewController "
+            "instance. One instance of the FlutterEngine can only be attached to one "
+            "FlutterViewController at a time. Set FlutterEngine.viewController "
+            "to nil before attaching it to another FlutterViewController.");
+
   self = [super initWithNibName:nibName bundle:nibBundle];
   if (self) {
-    if (engine.viewController) {
-      NSLog(@"The supplied FlutterEngine %@ is already used with FlutterViewController "
-             "instance %@. One instance of the FlutterEngine can only be attached to one "
-             "FlutterViewController at a time. Set FlutterEngine.viewController "
-             "to nil before attaching it to another FlutterViewController.",
-            [engine description], [engine.viewController description]);
-    }
     _engine = engine;
     CommonInit(self);
     if (engine.running) {

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
@@ -23,6 +23,7 @@
 - (bool)testKeyboardIsRestartedOnEngineRestart;
 - (bool)testTrackpadGesturesAreSentToFramework;
 - (bool)testViewWillAppearCalledMultipleTimes;
+- (bool)testFlutterViewIsConfigured;
 
 + (void)respondFalseForSendEvent:(const FlutterKeyEvent&)event
                         callback:(nullable FlutterKeyEventCallback)callback
@@ -145,6 +146,10 @@ TEST(FlutterViewControllerTest, testViewWillAppearCalledMultipleTimes) {
   ASSERT_TRUE([[FlutterViewControllerTestObjC alloc] testViewWillAppearCalledMultipleTimes]);
 }
 
+TEST(FlutterViewControllerTest, testFlutterViewIsConfigured) {
+  ASSERT_TRUE([[FlutterViewControllerTestObjC alloc] testFlutterViewIsConfigured]);
+}
+
 }  // namespace flutter::testing
 
 @implementation FlutterViewControllerTestObjC
@@ -239,6 +244,27 @@ TEST(FlutterViewControllerTest, testViewWillAppearCalledMultipleTimes) {
   } @catch (...) {
     return false;
   }
+  return true;
+}
+
+- (bool)testFlutterViewIsConfigured {
+  id engineMock = OCMClassMock([FlutterEngine class]);
+
+  id renderer_ = [[FlutterMetalRenderer alloc] initWithFlutterEngine:engineMock];
+  OCMStub([engineMock renderer]).andReturn(renderer_);
+
+  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engineMock
+                                                                                nibName:@""
+                                                                                 bundle:nil];
+  [viewController loadView];
+
+  @try {
+    // Make sure "renderer" was called during "loadView", which means "flutterView" is created
+    OCMVerify([engineMock renderer]);
+  } @catch (...) {
+    return false;
+  }
+
   return true;
 }
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h
@@ -19,19 +19,6 @@
 @property(nonatomic, readonly, nonnull) FlutterTextInputPlugin* textInputPlugin;
 
 /**
- * Initializes this FlutterViewController with the specified `FlutterEngine`.
- *
- * The initialized viewcontroller will attach itself to the engine as part of this process.
- *
- * @param engine The `FlutterEngine` instance to attach to. Cannot be nil.
- * @param nibName The NIB name to initialize this controller with.
- * @param nibBundle The NIB bundle.
- */
-- (nonnull instancetype)initWithEngine:(nonnull FlutterEngine*)engine
-                               nibName:(nullable NSString*)nibName
-                                bundle:(nullable NSBundle*)nibBundle NS_DESIGNATED_INITIALIZER;
-
-/**
  * Returns YES if provided event is being currently redispatched by keyboard manager.
  */
 - (BOOL)isDispatchingKeyEvent:(nonnull NSEvent*)event;


### PR DESCRIPTION
…4735)

Exposes runWithEngine in FlutterViewController as suggested by [jmagman](https://github.com/jmagman) in #74735
Fixes: https://github.com/flutter/flutter/issues/74735

Removing `[engine setViewController:self];` because view is not loaded, but in that function controller is saved. Later, when the view is loaded (`loadView`) passed as an argument controller is checked against the saved controller and since they match, the `nil` view is not replaced with a new view.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

