### PR TITLE
Delete dead/obsolete spirv transpiler rules

### DIFF
--- a/ci/analyze.sh
+++ b/ci/analyze.sh
@@ -48,8 +48,6 @@ echo ""
 
 "$DART" analyze --fatal-infos --fatal-warnings "$FLUTTER_DIR/lib/ui"
 
-"$DART" analyze --fatal-infos --fatal-warnings "$FLUTTER_DIR/lib/spirv"
-
 "$DART" analyze --fatal-infos --fatal-warnings "$FLUTTER_DIR/ci"
 
 "$DART" analyze --fatal-infos --fatal-warnings "$FLUTTER_DIR/flutter_frontend_server"

--- a/lib/spirv/test/exception_shaders/BUILD.gn
+++ b/lib/spirv/test/exception_shaders/BUILD.gn
@@ -1,6 +1,0 @@
-# Copyright 2013 The Flutter Authors. All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be
-# found in the LICENSE file.
-
-group("spirv_compile_exception_shaders") {
-}

--- a/lib/ui/fixtures/shaders/BUILD.gn
+++ b/lib/ui/fixtures/shaders/BUILD.gn
@@ -10,10 +10,6 @@ if (enable_unittests) {
     testonly = true
     deps = [
       ":fixtures",
-
-      # TODO(zra): Remove this when it is no longer referenced in the
-      # recipe.
-      "//flutter/lib/spirv/test/exception_shaders:spirv_compile_exception_shaders",
       "//flutter/lib/ui/fixtures/shaders/general_shaders",
       "//flutter/lib/ui/fixtures/shaders/supported_glsl_op_shaders",
       "//flutter/lib/ui/fixtures/shaders/supported_op_shaders",


### PR DESCRIPTION
These rules are no longer used or needed.