### PR TITLE
[Impeller] Avoid soon to be deprecated MTLRenderPipelineDescriptor.sampleCount.

### DIFF
--- a/impeller/renderer/backend/metal/pipeline_library_mtl.mm
+++ b/impeller/renderer/backend/metal/pipeline_library_mtl.mm
@@ -23,7 +23,7 @@ static MTLRenderPipelineDescriptor* GetMTLRenderPipelineDescriptor(
     const PipelineDescriptor& desc) {
   auto descriptor = [[MTLRenderPipelineDescriptor alloc] init];
   descriptor.label = @(desc.GetLabel().c_str());
-  descriptor.sampleCount = static_cast<NSUInteger>(desc.GetSampleCount());
+  descriptor.rasterSampleCount = static_cast<NSUInteger>(desc.GetSampleCount());
 
   for (const auto& entry : desc.GetStageEntrypoints()) {
     if (entry.first == ShaderStage::kVertex) {


### PR DESCRIPTION
This is deprecated in iOS 16.0 with new annotations added in newer SDKs. See:

```
@property (readwrite, nonatomic) NSUInteger sampleCount
API_DEPRECATED_WITH_REPLACEMENT("rasterSampleCount", macos(10.11, 13.0), ios(8.0, 16.0));
```