### PR TITLE
Fix reversed macOS trackpad rotation

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -611,7 +611,7 @@ static void CommonInit(FlutterViewController* controller) {
     } else if (event.type == NSEventTypeMagnify) {
       _mouseState.scale += event.magnification;
     } else if (event.type == NSEventTypeRotate) {
-      _mouseState.rotation += event.rotation * (M_PI / 180.0);
+      _mouseState.rotation += event.rotation * (-M_PI / 180.0);
     }
     flutterEvent.pan_x = _mouseState.delta_x;
     flutterEvent.pan_y = _mouseState.delta_y;


### PR DESCRIPTION
macOS rotation values increase counterclockwise rather than the expected clockwise. So they have been inverted in polarity.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
