### PR TITLE
Fix typo in ColorFilter docs

### DIFF
--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -3162,7 +3162,7 @@ class ColorFilter implements ImageFilter {
   /// Construct a color filter that transforms a color by a 5x5 matrix, where
   /// the fifth row is implicitly added in an identity configuration.
   ///
-  /// Every pixel's color value, repsented as an `[R, G, B, A]`, is matrix
+  /// Every pixel's color value, represented as an `[R, G, B, A]`, is matrix
   /// multiplied to create a new color:
   ///
   ///     | R' |   | a00 a01 a02 a03 a04 |   | R |

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -3166,9 +3166,9 @@ class ColorFilter implements ImageFilter {
   /// multiplied to create a new color:
   ///
   ///     | R' |   | a00 a01 a02 a03 a04 |   | R |
-  ///     | G' |   | a10 a11 a22 a33 a44 |   | G |
-  ///     | B' | = | a20 a21 a22 a33 a44 | * | B |
-  ///     | A' |   | a30 a31 a22 a33 a44 |   | A |
+  ///     | G' |   | a10 a11 a12 a13 a14 |   | G |
+  ///     | B' | = | a20 a21 a22 a23 a24 | * | B |
+  ///     | A' |   | a30 a31 a32 a33 a34 |   | A |
   ///     | 1  |   |  0   0   0   0   1  |   | 1 |
   ///
   /// The matrix is in row-major order and the translation column is specified

--- a/lib/web_ui/lib/src/engine/color_filter.dart
+++ b/lib/web_ui/lib/src/engine/color_filter.dart
@@ -28,7 +28,7 @@ class EngineColorFilter implements ui.ColorFilter {
   /// Construct a color filter that transforms a color by a 5x5 matrix, where
   /// the fifth row is implicitly added in an identity configuration.
   ///
-  /// Every pixel's color value, repsented as an `[R, G, B, A]`, is matrix
+  /// Every pixel's color value, represented as an `[R, G, B, A]`, is matrix
   /// multiplied to create a new color:
   ///
   /// ```text

--- a/lib/web_ui/lib/src/engine/color_filter.dart
+++ b/lib/web_ui/lib/src/engine/color_filter.dart
@@ -33,9 +33,9 @@ class EngineColorFilter implements ui.ColorFilter {
   ///
   /// ```text
   /// | R' |   | a00 a01 a02 a03 a04 |   | R |
-  /// | G' |   | a10 a11 a22 a33 a44 |   | G |
-  /// | B' | = | a20 a21 a22 a33 a44 | * | B |
-  /// | A' |   | a30 a31 a22 a33 a44 |   | A |
+  /// | G' |   | a10 a11 a12 a13 a14 |   | G |
+  /// | B' | = | a20 a21 a22 a23 a24 | * | B |
+  /// | A' |   | a30 a31 a32 a33 a34 |   | A |
   /// | 1  |   |  0   0   0   0   1  |   | 1 |
   /// ```
   ///


### PR DESCRIPTION
Just fixing a typo I noticed while looking through `ColorFilter` docs: https://api.flutter.dev/flutter/dart-ui/ColorFilter/ColorFilter.matrix.html

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
