### PR TITLE
Remove reduntant call to _getLineBoundary

### DIFF
--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -2865,8 +2865,7 @@ class Paragraph extends NativeFieldWrapperClass1 {
 
     final List<int> nextBoundary = _getLineBoundary(position.offset + 1);
     final TextRange nextLine = TextRange(start: nextBoundary[0], end: nextBoundary[1]);
-    // If there is no next line, because we're at the end of the field, return
-    // line.
+    // If there is no next line, because we're at the end of the field, return line.
     if (!nextLine.isValid) {
       return line;
     }
@@ -2876,7 +2875,6 @@ class Paragraph extends NativeFieldWrapperClass1 {
     // word wrap (downstream), we need to return the line for the next offset.
     if (position.affinity == TextAffinity.downstream && line != nextLine
         && position.offset == line.end && line.end == nextLine.start) {
-      final List<int> nextBoundary = _getLineBoundary(position.offset + 1);
       return TextRange(start: nextBoundary[0], end: nextBoundary[1]);
     }
     return line;


### PR DESCRIPTION
This PR removes the reduntant call to `_getLineBoundary()` in `getLineBoundary()`.

test-exempt: removed redundant call.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
