### PR TITLE
Adds a --lint-head flag to the clang-tidy script

### DIFF
--- a/tools/clang_tidy/lib/clang_tidy.dart
+++ b/tools/clang_tidy/lib/clang_tidy.dart
@@ -47,6 +47,7 @@ class ClangTidy {
     required io.File buildCommandsPath,
     String checksArg = '',
     bool lintAll = false,
+    bool lintHead = false,
     bool fix = false,
     StringSink? outSink,
     StringSink? errSink,
@@ -55,6 +56,7 @@ class ClangTidy {
       buildCommandsPath: buildCommandsPath,
       checksArg: checksArg,
       lintAll: lintAll,
+      lintHead: lintHead,
       fix: fix,
       errSink: errSink,
     ),
@@ -159,7 +161,15 @@ class ClangTidy {
         .whereType<io.File>()
         .toList();
     }
-    return GitRepo(options.repoPath).changedFiles;
+
+    final GitRepo repo = GitRepo(
+      options.repoPath,
+      verbose: options.verbose,
+    );
+    if (options.lintHead) {
+      return repo.changedFilesAtHead;
+    }
+    return repo.changedFiles;
   }
 
   /// Given a build commands json file, and the files with local changes,

--- a/tools/clang_tidy/lib/src/git_repo.dart
+++ b/tools/clang_tidy/lib/src/git_repo.dart
@@ -78,7 +78,7 @@ class GitRepo {
         'diff-tree',
         '--no-commit-id',
         '--name-only',
-        '--diff-filter=ACMRT', # Added, copied, modified, renamed, or type-changed.
+        '--diff-filter=ACMRT', // Added, copied, modified, renamed, or type-changed.
         '-r',
         'HEAD',
       ],

--- a/tools/clang_tidy/lib/src/git_repo.dart
+++ b/tools/clang_tidy/lib/src/git_repo.dart
@@ -78,7 +78,7 @@ class GitRepo {
         'diff-tree',
         '--no-commit-id',
         '--name-only',
-        '--diff-filter=ACMRT',
+        '--diff-filter=ACMRT', # Added, copied, modified, renamed, or type-changed.
         '-r',
         'HEAD',
       ],

--- a/tools/clang_tidy/lib/src/git_repo.dart
+++ b/tools/clang_tidy/lib/src/git_repo.dart
@@ -10,7 +10,12 @@ import 'package:process_runner/process_runner.dart';
 /// Utility methods for working with a git repo.
 class GitRepo {
   /// The git repository rooted at `root`.
-  GitRepo(this.root);
+  GitRepo(this.root, {
+    this.verbose = false,
+  });
+
+  /// Whether to produce verbose log output.
+  final bool verbose;
 
   /// The root of the git repo.
   final io.Directory root;
@@ -26,23 +31,18 @@ class GitRepo {
   Future<List<io.File>> get changedFiles async =>
     _changedFiles ??= await _getChangedFiles();
 
+  List<io.File>? _changedFilesAtHead;
+
+  /// Returns a list of non-deleted files which differ between the HEAD
+  /// commit and its parent.
+  Future<List<io.File>> get changedFilesAtHead async =>
+    _changedFilesAtHead ??= await _getChangedFilesAtHead();
+
   Future<List<io.File>> _getChangedFiles() async {
     final ProcessRunner processRunner = ProcessRunner(
       defaultWorkingDirectory: root,
     );
-    final ProcessRunnerResult fetchResult = await processRunner.runProcess(
-      <String>['git', 'fetch', 'upstream', 'main'],
-      failOk: true,
-    );
-    if (fetchResult.exitCode != 0) {
-      await processRunner.runProcess(<String>[
-        'git',
-        'fetch',
-        'origin',
-        'main',
-      ]);
-    }
-    final Set<String> result = <String>{};
+    await _fetch(processRunner);
     ProcessRunnerResult mergeBaseResult = await processRunner.runProcess(
       <String>['git', 'merge-base', '--fork-point', 'FETCH_HEAD', 'HEAD'],
       failOk: true,
@@ -64,10 +64,53 @@ class GitRepo {
       '--diff-filter=ACMRT',
       mergeBase,
     ]);
-    result.addAll(masterResult.stdout.split('\n').where(
+    return _gitOutputToList(masterResult);
+  }
+
+  Future<List<io.File>> _getChangedFilesAtHead() async {
+    final ProcessRunner processRunner = ProcessRunner(
+      defaultWorkingDirectory: root,
+    );
+    await _fetch(processRunner);
+    final ProcessRunnerResult diffTreeResult = await processRunner.runProcess(
+      <String>[
+        'git',
+        'diff-tree',
+        '--no-commit-id',
+        '--name-only',
+        '--diff-filter=ACMRT',
+        '-r',
+        'HEAD',
+      ],
+    );
+    return _gitOutputToList(diffTreeResult);
+  }
+
+  Future<void> _fetch(ProcessRunner processRunner) async {
+    final ProcessRunnerResult fetchResult = await processRunner.runProcess(
+      <String>['git', 'fetch', 'upstream', 'main'],
+      failOk: true,
+    );
+    if (fetchResult.exitCode != 0) {
+      await processRunner.runProcess(<String>[
+        'git',
+        'fetch',
+        'origin',
+        'main',
+      ]);
+    }
+  }
+
+  List<io.File> _gitOutputToList(ProcessRunnerResult result) {
+    final String diffOutput = result.stdout.trim();
+    if (verbose) {
+      print('git diff output:\n$diffOutput');
+    }
+    final Set<String> resultMap = <String>{};
+    resultMap.addAll(diffOutput.split('\n').where(
       (String str) => str.isNotEmpty,
     ));
-    return result.map<io.File>(
+    return resultMap.map<io.File>(
       (String filePath) => io.File(path.join(root.path, filePath)),
     ).toList();
   }

--- a/tools/clang_tidy/lib/src/options.dart
+++ b/tools/clang_tidy/lib/src/options.dart
@@ -20,6 +20,7 @@ class Options {
     this.verbose = false,
     this.checksArg = '',
     this.lintAll = false,
+    this.lintHead = false,
     this.fix = false,
     this.errorMessage,
     StringSink? errSink,
@@ -60,6 +61,7 @@ class Options {
       checksArg: options.wasParsed('checks') ? options['checks'] as String : '',
       lintAll: io.Platform.environment['FLUTTER_LINT_ALL'] != null ||
                options['lint-all'] as bool,
+      lintHead: options['lint-head'] as bool,
       fix: options['fix'] as bool,
       errSink: errSink,
     );
@@ -104,7 +106,11 @@ class Options {
     )
     ..addFlag(
       'lint-all',
-      help: 'lint all of the sources, regardless of FLUTTER_NOLINT.',
+      help: 'Lint all of the sources, regardless of FLUTTER_NOLINT.',
+    )
+    ..addFlag(
+      'lint-head',
+      help: 'Lint files changed in the tip-of-tree commit.',
     )
     ..addFlag(
       'fix',
@@ -163,6 +169,9 @@ class Options {
   /// Whether all files should be linted.
   final bool lintAll;
 
+  /// Whether to lint only files changed in the tip-of-tree commit.
+  final bool lintHead;
+
   /// Whether checks should apply available fix-ups to the working copy.
   final bool fix;
 
@@ -178,7 +187,8 @@ class Options {
       _errSink.writeln(message);
     }
     _errSink.writeln(
-      'Usage: bin/main.dart [--help] [--lint-all] [--fix] [--verbose] [--diff-branch] [--target-variant variant] [--src-dir path/to/engine/src]',
+      'Usage: bin/main.dart [--help] [--lint-all] [--lint-head] [--fix] [--verbose] '
+      '[--diff-branch] [--target-variant variant] [--src-dir path/to/engine/src]',
     );
     _errSink.writeln(_argParser.usage);
   }
@@ -196,6 +206,10 @@ class Options {
 
     if (compileCommandsParsed && argResults.wasParsed('src-dir')) {
       return 'ERROR: --compile-commands option cannot be used with --src-dir.';
+    }
+
+    if (argResults.wasParsed('lint-all') && argResults.wasParsed('lint-head')) {
+      return 'ERROR: At most one of --lint-all and --lint-head can be passed.';
     }
 
     if (!buildCommandsPath.existsSync()) {

--- a/tools/clang_tidy/test/clang_tidy_test.dart
+++ b/tools/clang_tidy/test/clang_tidy_test.dart
@@ -128,6 +128,29 @@ Future<int> main(List<String> args) async {
     ));
   });
 
+  test('Error when --lint-all and --lint-head are used together', () async {
+    final StringBuffer outBuffer = StringBuffer();
+    final StringBuffer errBuffer = StringBuffer();
+    final ClangTidy clangTidy = ClangTidy.fromCommandLine(
+      <String>[
+        '--compile-commands',
+        '/unused',
+        '--lint-all',
+        '--lint-head',
+      ],
+      outSink: outBuffer,
+      errSink: errBuffer,
+    );
+
+    final int result = await clangTidy.run();
+
+    expect(clangTidy.options.help, isFalse);
+    expect(result, equals(1));
+    expect(errBuffer.toString(), contains(
+      'ERROR: At most one of --lint-all and --lint-head can be passed.',
+    ));
+  });
+
   test('lintAll=true checks all files', () async {
     final StringBuffer outBuffer = StringBuffer();
     final StringBuffer errBuffer = StringBuffer();


### PR DESCRIPTION
This PR adds a flag to the clang-tidy wrapper script that causes it to lint the files that are changed in the HEAD commit. This will let us avoid linting every file on every commit on prod CI.

In particular, in presubmit, we'll be able to remove the `--lint-all` flag. In post-submit, we'll remove the `lint-all` flag, and use the `--lint-head` flag instead, and only when certain files are changed, like the `DEPS` file, we'll continue passing `--lint-all`.

Related: https://github.com/flutter/flutter/issues/105068
