### PR TITLE
dont throw on null view embedder

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/layer.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/layer.dart
@@ -591,6 +591,9 @@ class PlatformViewLayer extends Layer {
   @override
   void preroll(PrerollContext prerollContext, Matrix4 matrix) {
     paintBounds = ui.Rect.fromLTWH(offset.dx, offset.dy, width, height);
+
+    /// ViewEmbedder is set to null when screenshotting. Therefore, skip 
+    /// rendering
     prerollContext.viewEmbedder?.prerollCompositeEmbeddedView(
       viewId,
       EmbeddedViewParams(

--- a/lib/web_ui/lib/src/engine/canvaskit/layer.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/layer.dart
@@ -592,7 +592,7 @@ class PlatformViewLayer extends Layer {
   void preroll(PrerollContext prerollContext, Matrix4 matrix) {
     paintBounds = ui.Rect.fromLTWH(offset.dx, offset.dy, width, height);
 
-    /// ViewEmbedder is set to null when screenshotting. Therefore, skip 
+    /// ViewEmbedder is set to null when screenshotting. Therefore, skip
     /// rendering
     prerollContext.viewEmbedder?.prerollCompositeEmbeddedView(
       viewId,

--- a/lib/web_ui/lib/src/engine/canvaskit/layer.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/layer.dart
@@ -591,7 +591,7 @@ class PlatformViewLayer extends Layer {
   @override
   void preroll(PrerollContext prerollContext, Matrix4 matrix) {
     paintBounds = ui.Rect.fromLTWH(offset.dx, offset.dy, width, height);
-    prerollContext.viewEmbedder!.prerollCompositeEmbeddedView(
+    prerollContext.viewEmbedder?.prerollCompositeEmbeddedView(
       viewId,
       EmbeddedViewParams(
         offset,
@@ -604,7 +604,7 @@ class PlatformViewLayer extends Layer {
   @override
   void paint(PaintContext paintContext) {
     final CkCanvas? canvas =
-        paintContext.viewEmbedder!.compositeEmbeddedView(viewId);
+        paintContext.viewEmbedder?.compositeEmbeddedView(viewId);
     if (canvas != null) {
       paintContext.leafNodesCanvas = canvas;
     }

--- a/lib/web_ui/test/canvaskit/layer_test.dart
+++ b/lib/web_ui/test/canvaskit/layer_test.dart
@@ -65,7 +65,6 @@ void testMain() {
 
       final CkPictureRecorder recorder = CkPictureRecorder();
       final CkCanvas canvas = recorder.beginRecording(kDefaultRegion);
-  
       canvas.drawImage(testImage as CkImage, ui.Offset.zero, CkPaint());
       await matchPictureGolden(
         'canvaskit_picture.png',

--- a/lib/web_ui/test/canvaskit/layer_test.dart
+++ b/lib/web_ui/test/canvaskit/layer_test.dart
@@ -61,7 +61,7 @@ void testMain() {
       sb.addPlatformView(0, width: 10, height: 10);
       sb.pushOffset(0, 0);
       final LayerScene layerScene = sb.build();
-      final testImage = await layerScene.toImage(100, 100);
+      final ui.Image testImage = await layerScene.toImage(100, 100);
 
       final CkPictureRecorder recorder = CkPictureRecorder();
       final CkCanvas canvas = recorder.beginRecording(kDefaultRegion);

--- a/lib/web_ui/test/canvaskit/layer_test.dart
+++ b/lib/web_ui/test/canvaskit/layer_test.dart
@@ -52,5 +52,15 @@ void testMain() {
       recorder.beginRecording(ui.Rect.zero);
       LayerSceneBuilder().addPicture(ui.Offset.zero, recorder.endRecording());
     });
+
+    test('null ViewEmbedder with PlatformView', () async {
+      final LayerSceneBuilder sb = LayerSceneBuilder();
+      await createPlatformView(0, 'test-platform-view');
+      sb.pushOffset(0, 0);
+      sb.addPlatformView(0, width: 10, height: 10);
+      sb.pushOffset(0, 0);
+      final LayerScene layerScene = sb.build();
+      await layerScene.toImage(100, 100);
+    });
   });
 }

--- a/lib/web_ui/test/canvaskit/layer_test.dart
+++ b/lib/web_ui/test/canvaskit/layer_test.dart
@@ -55,12 +55,23 @@ void testMain() {
 
     test('null ViewEmbedder with PlatformView', () async {
       final LayerSceneBuilder sb = LayerSceneBuilder();
+      const ui.Rect kDefaultRegion = ui.Rect.fromLTRB(0, 0, 200, 200);
       await createPlatformView(0, 'test-platform-view');
       sb.pushOffset(0, 0);
       sb.addPlatformView(0, width: 10, height: 10);
       sb.pushOffset(0, 0);
       final LayerScene layerScene = sb.build();
-      await layerScene.toImage(100, 100);
+      final testImage = await layerScene.toImage(100, 100);
+
+      final CkPictureRecorder recorder = CkPictureRecorder();
+      final CkCanvas canvas = recorder.beginRecording(kDefaultRegion);
+  
+      canvas.drawImage(testImage as CkImage, ui.Offset.zero, CkPaint());
+      await matchPictureGolden(
+        'canvaskit_picture.png',
+        recorder.endRecording(),
+        region: kDefaultRegion,
+      );
     });
   });
 }

--- a/lib/web_ui/test/canvaskit/layer_test.dart
+++ b/lib/web_ui/test/canvaskit/layer_test.dart
@@ -71,6 +71,7 @@ void testMain() {
         recorder.endRecording(),
         region: kDefaultRegion,
       );
-    });
+      //https://github.com/flutter/flutter/issues/109265
+    }, skip: isFirefox || isSafari);
   });
 }


### PR DESCRIPTION
viewEmbedder is null when screenshotting. Fixed by not rendering the platform view when screenshotting. 

fixes https://github.com/flutter/flutter/issues/101720

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.


