### PR TITLE
Add skip-remove-buckets parameter

### DIFF
--- a/tools/fuchsia/build_fuchsia_artifacts.py
+++ b/tools/fuchsia/build_fuchsia_artifacts.py
@@ -444,12 +444,14 @@ def main():
       'and copy two debug builds, one with ASAN and one without.'
   )
 
+  # TODO(http://fxb/110639): Deprecate this in favor of multiple runtime parameters
   parser.add_argument(
       '--skip-remove-buckets',
       action='store_true',
       default=False,
-      help='If set, will skip over the removal of existing artifacts in the '
-      'default bucket directory (which is the default behavior).'
+      help='This allows for multiple runtimes to exist in the default bucket directory. If '
+      'set, will skip over the removal of existing artifacts in the bucket directory '
+      '(which is the default behavior).'
   )
 
   args = parser.parse_args()

--- a/tools/fuchsia/build_fuchsia_artifacts.py
+++ b/tools/fuchsia/build_fuchsia_artifacts.py
@@ -25,6 +25,8 @@ _src_root_dir = os.path.join(_script_dir, '..', '..', '..')
 _out_dir = os.path.join(_src_root_dir, 'out')
 _bucket_directory = os.path.join(_out_dir, 'fuchsia_bucket')
 
+print('OUT DIR: ', _out_dir)
+
 
 def IsLinux():
   return platform.system() == 'Linux'
@@ -444,9 +446,18 @@ def main():
       'and copy two debug builds, one with ASAN and one without.'
   )
 
+  parser.add_argument(
+    '--skip-remove-buckets',
+    action='store_true',
+    default=False,
+    help='If set, will skip over the removal of existing artifacts in the '
+    'default bucket directory (which is the default behavior).'
+  )
+
   args = parser.parse_args()
-  RemoveDirectoryIfExists(_bucket_directory)
   build_mode = args.runtime_mode
+  if (not args.skip_remove_buckets):
+    RemoveDirectoryIfExists(_bucket_directory)
 
   archs = ['x64', 'arm64'] if args.archs == 'all' else [args.archs]
   runtime_modes = ['debug', 'profile', 'release']

--- a/tools/fuchsia/build_fuchsia_artifacts.py
+++ b/tools/fuchsia/build_fuchsia_artifacts.py
@@ -25,8 +25,6 @@ _src_root_dir = os.path.join(_script_dir, '..', '..', '..')
 _out_dir = os.path.join(_src_root_dir, 'out')
 _bucket_directory = os.path.join(_out_dir, 'fuchsia_bucket')
 
-print('OUT DIR: ', _out_dir)
-
 
 def IsLinux():
   return platform.system() == 'Linux'

--- a/tools/fuchsia/build_fuchsia_artifacts.py
+++ b/tools/fuchsia/build_fuchsia_artifacts.py
@@ -447,11 +447,11 @@ def main():
   )
 
   parser.add_argument(
-    '--skip-remove-buckets',
-    action='store_true',
-    default=False,
-    help='If set, will skip over the removal of existing artifacts in the '
-    'default bucket directory (which is the default behavior).'
+      '--skip-remove-buckets',
+      action='store_true',
+      default=False,
+      help='If set, will skip over the removal of existing artifacts in the '
+      'default bucket directory (which is the default behavior).'
   )
 
   args = parser.parse_args()


### PR DESCRIPTION
The `--skip-remove-buckets` parameter allows for scenarios where multiple runtimes need to exist in the default bucket directory. This wasn't possible with the previous workflow, which cleaned the bucket if the script was run.

This allows for both debug/JIT and profile/AOT to be built in the [flutter recipes](https://flutter.googlesource.com/recipes/+/refs/heads/main/recipes/engine/femu_test.py#76) without needing to build all runtimes (eg. passing in `all` to the `--runtime-mode` argument)