### PR TITLE
[macOS] Unify FlutterRenderers' presenting callbacks

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -438,33 +438,20 @@ static void OnPlatformMessage(const FlutterPlatformMessage* message, FlutterEngi
     FlutterMetalRenderer* metalRenderer = reinterpret_cast<FlutterMetalRenderer*>(_renderer);
     _macOSCompositor = std::make_unique<flutter::FlutterMetalCompositor>(
         _viewController, _platformViewController, metalRenderer.device);
-    _macOSCompositor->SetPresentCallback([weakSelf](bool has_flutter_content) {
-      FlutterMetalRenderer* metalRenderer =
-          reinterpret_cast<FlutterMetalRenderer*>(weakSelf.renderer);
-      if (has_flutter_content) {
-        return [metalRenderer present:0 /*=textureID*/] == YES;
-      } else {
-        [metalRenderer presentWithoutContent];
-        return true;
-      }
-    });
   } else {
     FlutterOpenGLRenderer* openGLRenderer = reinterpret_cast<FlutterOpenGLRenderer*>(_renderer);
     [openGLRenderer.openGLContext makeCurrentContext];
     _macOSCompositor = std::make_unique<flutter::FlutterGLCompositor>(_viewController,
                                                                       openGLRenderer.openGLContext);
-
-    _macOSCompositor->SetPresentCallback([weakSelf](bool has_flutter_content) {
-      FlutterOpenGLRenderer* openGLRenderer =
-          reinterpret_cast<FlutterOpenGLRenderer*>(weakSelf.renderer);
-      if (has_flutter_content) {
-        return [openGLRenderer glPresent] == YES;
-      } else {
-        [openGLRenderer presentWithoutContent];
-        return true;
-      }
-    });
   }
+  _macOSCompositor->SetPresentCallback([weakSelf](bool has_flutter_content) {
+    if (has_flutter_content) {
+      return [weakSelf.renderer present] == YES;
+    } else {
+      [weakSelf.renderer presentWithoutContent];
+      return true;
+    }
+  });
 
   _compositor = {};
   _compositor.struct_size = sizeof(FlutterCompositor);

--- a/shell/platform/darwin/macos/framework/Source/FlutterMetalRenderer.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterMetalRenderer.h
@@ -30,16 +30,6 @@
 - (FlutterMetalTexture)createTextureForSize:(CGSize)size;
 
 /**
- * Presents the texture specified by the texture id.
- */
-- (BOOL)present:(int64_t)textureID;
-
-/**
- * Tells the renderer that there is no Flutter content available for this frame.
- */
-- (void)presentWithoutContent;
-
-/**
  * Populates the texture registry with the provided metalTexture.
  */
 - (BOOL)populateTextureWithIdentifier:(int64_t)textureID

--- a/shell/platform/darwin/macos/framework/Source/FlutterMetalRenderer.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterMetalRenderer.mm
@@ -20,8 +20,7 @@ static FlutterMetalTexture OnGetNextDrawable(FlutterEngine* engine,
 }
 
 static bool OnPresentDrawable(FlutterEngine* engine, const FlutterMetalTexture* texture) {
-  FlutterMetalRenderer* metalRenderer = reinterpret_cast<FlutterMetalRenderer*>(engine.renderer);
-  return [metalRenderer present:texture->texture_id];
+  return [engine.renderer present];
 }
 
 static bool OnAcquireExternalTexture(FlutterEngine* engine,
@@ -36,8 +35,6 @@ static bool OnAcquireExternalTexture(FlutterEngine* engine,
 #pragma mark - FlutterMetalRenderer implementation
 
 @implementation FlutterMetalRenderer {
-  __weak FlutterEngine* _engine;
-
   FlutterView* _flutterView;
 
   FlutterDarwinContextMetal* _darwinMetalContext;
@@ -46,8 +43,6 @@ static bool OnAcquireExternalTexture(FlutterEngine* engine,
 - (instancetype)initWithFlutterEngine:(nonnull FlutterEngine*)flutterEngine {
   self = [super initWithDelegate:self engine:flutterEngine];
   if (self) {
-    _engine = flutterEngine;
-
     _device = MTLCreateSystemDefaultDevice();
     if (!_device) {
       NSLog(@"Could not acquire Metal device.");
@@ -99,7 +94,7 @@ static bool OnAcquireExternalTexture(FlutterEngine* engine,
   return embedderTexture;
 }
 
-- (BOOL)present:(int64_t)textureID {
+- (BOOL)present {
   if (!_flutterView) {
     return NO;
   }
@@ -108,6 +103,9 @@ static bool OnAcquireExternalTexture(FlutterEngine* engine,
 }
 
 - (void)presentWithoutContent {
+  if (!_flutterView) {
+    return;
+  }
   [_flutterView presentWithoutContent];
 }
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterMetalRendererTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterMetalRendererTest.mm
@@ -30,9 +30,9 @@ TEST(FlutterMetalRenderer, PresentDelegatesToFlutterView) {
   FlutterEngine* engine = CreateTestEngine();
   FlutterMetalRenderer* renderer = [[FlutterMetalRenderer alloc] initWithFlutterEngine:engine];
   id mockFlutterView = OCMClassMock([FlutterView class]);
-  [[mockFlutterView expect] present];
+  [(FlutterView*)[mockFlutterView expect] present];
   [renderer setFlutterView:mockFlutterView];
-  [renderer present:1];
+  [renderer present];
 }
 
 TEST(FlutterMetalRenderer, TextureReturnedByFlutterView) {

--- a/shell/platform/darwin/macos/framework/Source/FlutterOpenGLRenderer.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterOpenGLRenderer.h
@@ -35,16 +35,6 @@
 - (BOOL)clearCurrent;
 
 /**
- * Called by the engine when the context's buffers should be swapped.
- */
-- (BOOL)glPresent;
-
-/**
- * Tells the renderer that there is no Flutter content available for this frame.
- */
-- (void)presentWithoutContent;
-
-/**
  * Called by the engine when framebuffer object ID is requested.
  */
 - (uint32_t)fboForFrameInfo:(nonnull const FlutterFrameInfo*)info;

--- a/shell/platform/darwin/macos/framework/Source/FlutterOpenGLRenderer.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterOpenGLRenderer.mm
@@ -20,8 +20,7 @@ static bool OnClearCurrent(FlutterEngine* engine) {
 }
 
 static bool OnPresent(FlutterEngine* engine) {
-  FlutterOpenGLRenderer* openGLRenderer = reinterpret_cast<FlutterOpenGLRenderer*>(engine.renderer);
-  return [openGLRenderer glPresent];
+  return [engine.renderer present];
 }
 
 static uint32_t OnFBO(FlutterEngine* engine, const FlutterFrameInfo* info) {
@@ -88,15 +87,18 @@ static bool OnAcquireExternalTexture(FlutterEngine* engine,
   return true;
 }
 
-- (BOOL)glPresent {
-  if (!_openGLContext) {
-    return false;
+- (BOOL)present {
+  if (!_openGLContext || !_flutterView) {
+    return NO;
   }
   [_flutterView present];
-  return true;
+  return YES;
 }
 
 - (void)presentWithoutContent {
+  if (!_flutterView) {
+    return;
+  }
   [_flutterView presentWithoutContent];
 }
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterOpenGLRenderer.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterOpenGLRenderer.mm
@@ -55,15 +55,10 @@ static bool OnAcquireExternalTexture(FlutterEngine* engine,
 
   // The context provided to the Flutter engine for resource loading.
   NSOpenGLContext* _resourceContext;
-
-  __weak FlutterEngine* _flutterEngine;
 }
 
 - (instancetype)initWithFlutterEngine:(FlutterEngine*)flutterEngine {
   self = [super initWithDelegate:self engine:flutterEngine];
-  if (self) {
-    _flutterEngine = flutterEngine;
-  }
   return self;
 }
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterOpenGLRendererTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterOpenGLRendererTest.mm
@@ -113,10 +113,10 @@ TEST(FlutterOpenGLRenderer, PresetDelegatesToFlutterView) {
   FlutterEngine* engine = [[TestOpenGLEngine alloc] initWithGLRenderer];
   FlutterOpenGLRenderer* renderer = [[FlutterOpenGLRenderer alloc] initWithFlutterEngine:engine];
   id mockFlutterView = OCMClassMock([FlutterView class]);
-  [[mockFlutterView expect] present];
+  [(FlutterView*)[mockFlutterView expect] present];
   [renderer setFlutterView:mockFlutterView];
   [renderer openGLContext];
-  [renderer glPresent];
+  [renderer present];
 }
 
 TEST(FlutterOpenGLRenderer, FBOReturnedByFlutterView) {

--- a/shell/platform/darwin/macos/framework/Source/FlutterRenderer.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterRenderer.h
@@ -29,4 +29,14 @@
  */
 - (FlutterRendererConfig)createRendererConfig;
 
+/**
+ * Called by the engine when the context's buffers should be swapped.
+ */
+- (BOOL)present;
+
+/**
+ * Tells the renderer that there is no Flutter content available for this frame.
+ */
+- (void)presentWithoutContent;
+
 @end


### PR DESCRIPTION
This PR refactors `FlutterMetalRenderer` and `FlutterOpenGLRenderer` by extracting the presenting methods to the base class, `FlutterRenderer`.

Part of [the multiwindow project](https://github.com/flutter/flutter/issues/30701): This change removes redundant design and makes it easier to adapt renderers to multiple view controllers, paving the road to multi-window.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
