### PR TITLE
Fix the `AXPlatformNodeWinTest.IAccessibleHitTest` test

### DIFF
--- a/third_party/accessibility/ax/platform/ax_platform_node_win_unittest.cc
+++ b/third_party/accessibility/ax/platform/ax_platform_node_win_unittest.cc
@@ -271,7 +271,7 @@ void AXPlatformNodeWinTest::TearDown() {
   ax_fragment_root_.reset(nullptr);
   DestroyTree();
   TestAXNodeWrapper::SetGlobalIsWebContent(false);
-  TestAXNodeWrapper::ClearHitTestResult();
+  TestAXNodeWrapper::ClearHitTestResults();
   ASSERT_EQ(0U, AXPlatformNodeBase::GetInstanceCountForTesting());
 }
 

--- a/third_party/accessibility/ax/platform/ax_platform_node_win_unittest.cc
+++ b/third_party/accessibility/ax/platform/ax_platform_node_win_unittest.cc
@@ -446,8 +446,7 @@ TEST_F(AXPlatformNodeWinTest, IAccessibleDetachedObject) {
   EXPECT_EQ(E_FAIL, root_obj->get_accName(SELF, name2.Receive()));
 }
 
-// TODO(cbracken): Flaky https://github.com/flutter/flutter/issues/98302
-TEST_F(AXPlatformNodeWinTest, DISABLED_IAccessibleHitTest) {
+TEST_F(AXPlatformNodeWinTest, IAccessibleHitTest) {
   AXNodeData root;
   root.id = 1;
   root.relative_bounds.bounds = gfx::RectF(0, 0, 40, 40);

--- a/third_party/accessibility/ax/platform/ax_platform_node_win_unittest.cc
+++ b/third_party/accessibility/ax/platform/ax_platform_node_win_unittest.cc
@@ -271,6 +271,7 @@ void AXPlatformNodeWinTest::TearDown() {
   ax_fragment_root_.reset(nullptr);
   DestroyTree();
   TestAXNodeWrapper::SetGlobalIsWebContent(false);
+  TestAXNodeWrapper::ClearHitTestResult();
   ASSERT_EQ(0U, AXPlatformNodeBase::GetInstanceCountForTesting());
 }
 

--- a/third_party/accessibility/ax/platform/test_ax_node_wrapper.cc
+++ b/third_party/accessibility/ax/platform/test_ax_node_wrapper.cc
@@ -119,6 +119,11 @@ void TestAXNodeWrapper::SetHitTestResult(AXNode::AXID src_node_id,
   g_hit_test_result[src_node_id] = dst_node_id;
 }
 
+// static
+void TestAXNodeWrapper::ClearHitTestResult() {
+  g_hit_test_result.clear();
+}
+
 TestAXNodeWrapper::~TestAXNodeWrapper() {
   platform_node_->Destroy();
 }

--- a/third_party/accessibility/ax/platform/test_ax_node_wrapper.cc
+++ b/third_party/accessibility/ax/platform/test_ax_node_wrapper.cc
@@ -120,7 +120,7 @@ void TestAXNodeWrapper::SetHitTestResult(AXNode::AXID src_node_id,
 }
 
 // static
-void TestAXNodeWrapper::ClearHitTestResult() {
+void TestAXNodeWrapper::ClearHitTestResults() {
   g_hit_test_result.clear();
 }
 

--- a/third_party/accessibility/ax/platform/test_ax_node_wrapper.h
+++ b/third_party/accessibility/ax/platform/test_ax_node_wrapper.h
@@ -55,7 +55,9 @@ class TestAXNodeWrapper : public AXPlatformNodeDelegateBase {
   // the result.
   static void SetHitTestResult(AXNode::AXID src_node_id,
                                AXNode::AXID dst_node_id);
-  static void ClearHitTestResult();
+
+  // Remove all hit test overrides added by SetHitTestResult.
+  static void ClearHitTestResults();
 
   ~TestAXNodeWrapper() override;
 

--- a/third_party/accessibility/ax/platform/test_ax_node_wrapper.h
+++ b/third_party/accessibility/ax/platform/test_ax_node_wrapper.h
@@ -55,6 +55,7 @@ class TestAXNodeWrapper : public AXPlatformNodeDelegateBase {
   // the result.
   static void SetHitTestResult(AXNode::AXID src_node_id,
                                AXNode::AXID dst_node_id);
+  static void ClearHitTestResult();
 
   ~TestAXNodeWrapper() override;
 


### PR DESCRIPTION
The accessibility tests use global state to override hit test results. This global state wasn't cleaned in between test runs, causing `IAccessibleHitTest` to have unexpected results whenever it ran after [`IAccessibleHitTestDoesNotLoopForever`](https://github.com/flutter/engine/blob/5fafbc1b3a4a57f029c7b2d74a1498302c0e1ccf/third_party/accessibility/ax/platform/ax_platform_node_win_unittest.cc#L492-L518).

Fixes: https://github.com/flutter/flutter/issues/98302

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
