### PR TITLE
[Impeller] update compute unit test to actually read back the data, fix bugs in it

### DIFF
--- a/impeller/fixtures/sample.comp
+++ b/impeller/fixtures/sample.comp
@@ -13,8 +13,18 @@ layout(binding = 2) readonly buffer Input1 {
   vec4 elements[];
 } input_data1;
 
+uniform Info {
+  uint count;
+} info;
+
 void main()
 {
   uint ident = gl_GlobalInvocationID.x;
+  // TODO(dnfield): https://github.com/flutter/flutter/issues/112683
+  // We should be able to use length here instead of an extra arrgument.
+  if (ident >= info.count) {
+    return;
+  }
+
   output_data.elements[ident] = input_data0.elements[ident] * input_data1.elements[ident];
 }

--- a/impeller/geometry/vector.h
+++ b/impeller/geometry/vector.h
@@ -232,6 +232,10 @@ struct Vector4 {
     return Vector4(x * f, y * f, z * f, w * f);
   }
 
+  constexpr Vector4 operator*(const Vector4& v) const {
+    return Vector4(x * v.x, y * v.y, z * v.z, w * v.w);
+  }
+
   constexpr Vector4 Lerp(const Vector4& v, Scalar t) const {
     return *this + (v - *this) * t;
   }

--- a/impeller/renderer/compute_unittests.cc
+++ b/impeller/renderer/compute_unittests.cc
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "flutter/fml/synchronization/waitable_event.h"
 #include "flutter/fml/time/time_point.h"
 #include "flutter/testing/testing.h"
 #include "impeller/base/strings.h"
@@ -46,20 +47,51 @@ TEST_P(ComputeTest, CanCreateComputePass) {
   cmd.label = "Compute";
   cmd.pipeline = compute_pipeline;
 
+  CS::Info info{.count = 5};
   std::vector<CS::Input0> input_0;
   std::vector<CS::Input1> input_1;
-  input_0.push_back(CS::Input0{Vector4(2.0, 3.0, 4.0, 5.0)});
-  input_1.push_back(CS::Input1{Vector4(6.0, 7.0, 8.0, 9.0)});
+  for (uint i = 0; i < 5; i++) {
+    input_0.push_back(CS::Input0{Vector4(2.0 + i, 3.0 + i, 4.0 + i, 5.0 * i)});
+    input_1.push_back(CS::Input1{Vector4(6.0, 7.0, 8.0, 9.0)});
+  }
 
-  std::vector<CS::Output> output(5);
+  DeviceBufferDescriptor buffer_desc;
+  buffer_desc.storage_mode = StorageMode::kHostVisible;
+  buffer_desc.size = sizeof(CS::Output) * 5;
+
+  auto output_buffer =
+      context->GetResourceAllocator()->CreateBuffer(buffer_desc);
+  output_buffer->SetLabel("Output Buffer");
+
+  CS::BindInfo(cmd, pass->GetTransientsBuffer().EmplaceUniform(info));
   CS::BindInput0(cmd,
                  pass->GetTransientsBuffer().EmplaceStorageBuffer(input_0));
   CS::BindInput1(cmd,
                  pass->GetTransientsBuffer().EmplaceStorageBuffer(input_1));
-  CS::BindOutput(cmd, pass->GetTransientsBuffer().EmplaceStorageBuffer(output));
+  CS::BindOutput(cmd, output_buffer->AsBufferView());
 
   ASSERT_TRUE(pass->AddCommand(std::move(cmd)));
   ASSERT_TRUE(pass->EncodeCommands());
+
+  fml::AutoResetWaitableEvent latch;
+  ASSERT_TRUE(
+      cmd_buffer->SubmitCommands([&latch, output_buffer, &input_0,
+                                  &input_1](CommandBuffer::Status status) {
+        EXPECT_EQ(status, CommandBuffer::Status::kCompleted);
+
+        auto view = output_buffer->AsBufferView();
+        EXPECT_EQ(view.range.length, 80lu);
+
+        for (size_t i = 0; i < input_0.size() - 1; i++) {
+          Vector4 output = reinterpret_cast<CS::Output*>(view.contents +
+                                                         i * sizeof(CS::Output))
+                               ->elements;
+          EXPECT_EQ(output, input_0[i].elements * input_1[i].elements);
+        }
+        latch.Signal();
+      }));
+
+  latch.Wait();
 }
 
 }  // namespace testing


### PR DESCRIPTION
This is built on top of changes from https://github.com/flutter/engine/pull/36466

Not ready for review, but updates the compute unit test to actually complete the computation and read its result(s). Fixes some bugs in there.