### PR TITLE
[Impeller] Make kHostVisible DeviceBuffers actually be host visible.

### DIFF
--- a/impeller/renderer/allocator.cc
+++ b/impeller/renderer/allocator.cc
@@ -58,4 +58,8 @@ std::shared_ptr<Texture> Allocator::CreateTexture(
   return OnCreateTexture(desc);
 }
 
+uint16_t Allocator::MinimumBytesPerRow(PixelFormat format) const {
+  return BytesPerPixelForPixelFormat(format);
+}
+
 }  // namespace impeller

--- a/impeller/renderer/allocator.h
+++ b/impeller/renderer/allocator.h
@@ -31,6 +31,12 @@ class Allocator {
 
   std::shared_ptr<Texture> CreateTexture(const TextureDescriptor& desc);
 
+  //------------------------------------------------------------------------------
+  /// @brief      Minimum value for `row_bytes` on a Texture. The row
+  ///             bytes parameter of that method must be aligned to this value.
+  ///
+  virtual uint16_t MinimumBytesPerRow(PixelFormat format) const;
+
   std::shared_ptr<DeviceBuffer> CreateBufferWithCopy(const uint8_t* buffer,
                                                      size_t length);
 

--- a/impeller/renderer/backend/gles/device_buffer_gles.cc
+++ b/impeller/renderer/backend/gles/device_buffer_gles.cc
@@ -31,6 +31,14 @@ DeviceBufferGLES::~DeviceBufferGLES() {
 }
 
 // |DeviceBuffer|
+uint8_t* DeviceBufferGLES::OnGetContents() const {
+  if (!reactor_) {
+    return nullptr;
+  }
+  return backing_store_->GetBuffer();
+}
+
+// |DeviceBuffer|
 bool DeviceBufferGLES::OnCopyHostBuffer(const uint8_t* source,
                                         Range source_range,
                                         size_t offset) {

--- a/impeller/renderer/backend/gles/device_buffer_gles.h
+++ b/impeller/renderer/backend/gles/device_buffer_gles.h
@@ -42,6 +42,9 @@ class DeviceBufferGLES final
   mutable uint32_t upload_generation_ = 0;
 
   // |DeviceBuffer|
+  uint8_t* OnGetContents() const override;
+
+  // |DeviceBuffer|
   bool OnCopyHostBuffer(const uint8_t* source,
                         Range source_range,
                         size_t offset) override;

--- a/impeller/renderer/backend/metal/allocator_mtl.h
+++ b/impeller/renderer/backend/metal/allocator_mtl.h
@@ -42,6 +42,9 @@ class AllocatorMTL final : public Allocator {
       const TextureDescriptor& desc) override;
 
   // |Allocator|
+  uint16_t MinimumBytesPerRow(PixelFormat format) const override;
+
+  // |Allocator|
   ISize GetMaxTextureSizeSupported() const override;
 
   FML_DISALLOW_COPY_AND_ASSIGN(AllocatorMTL);

--- a/impeller/renderer/backend/metal/allocator_mtl.mm
+++ b/impeller/renderer/backend/metal/allocator_mtl.mm
@@ -201,6 +201,11 @@ std::shared_ptr<Texture> AllocatorMTL::OnCreateTexture(
   return std::make_shared<TextureMTL>(desc, texture);
 }
 
+uint16_t AllocatorMTL::MinimumBytesPerRow(PixelFormat format) const {
+  return static_cast<uint16_t>([device_
+      minimumLinearTextureAlignmentForPixelFormat:ToMTLPixelFormat(format)]);
+}
+
 ISize AllocatorMTL::GetMaxTextureSizeSupported() const {
   return max_texture_supported_;
 }

--- a/impeller/renderer/backend/metal/device_buffer_mtl.h
+++ b/impeller/renderer/backend/metal/device_buffer_mtl.h
@@ -34,6 +34,14 @@ class DeviceBufferMTL final
                   MTLStorageMode storage_mode);
 
   // |DeviceBuffer|
+  uint8_t* OnGetContents() const override;
+
+  // |DeviceBuffer|
+  std::shared_ptr<Texture> AsTexture(Allocator& allocator,
+                                     const TextureDescriptor& descriptor,
+                                     uint16_t row_bytes) const override;
+
+  // |DeviceBuffer|
   bool OnCopyHostBuffer(const uint8_t* source,
                         Range source_range,
                         size_t offset) override;

--- a/impeller/renderer/backend/metal/device_buffer_mtl.mm
+++ b/impeller/renderer/backend/metal/device_buffer_mtl.mm
@@ -22,6 +22,33 @@ id<MTLBuffer> DeviceBufferMTL::GetMTLBuffer() const {
   return buffer_;
 }
 
+uint8_t* DeviceBufferMTL::OnGetContents() const {
+  if (storage_mode_ != MTLStorageModeShared) {
+    return nullptr;
+  }
+  return reinterpret_cast<uint8_t*>(buffer_.contents);
+}
+
+std::shared_ptr<Texture> DeviceBufferMTL::AsTexture(
+    Allocator& allocator,
+    const TextureDescriptor& descriptor,
+    uint16_t row_bytes) const {
+  auto mtl_texture_desc = ToMTLTextureDescriptor(descriptor);
+
+  if (!mtl_texture_desc) {
+    VALIDATION_LOG << "Texture descriptor was invalid.";
+    return nullptr;
+  }
+
+  auto texture = [buffer_ newTextureWithDescriptor:mtl_texture_desc
+                                            offset:0
+                                       bytesPerRow:row_bytes];
+  if (!texture) {
+    return nullptr;
+  }
+  return std::make_shared<TextureMTL>(descriptor, texture);
+}
+
 [[nodiscard]] bool DeviceBufferMTL::OnCopyHostBuffer(const uint8_t* source,
                                                      Range source_range,
                                                      size_t offset) {

--- a/impeller/renderer/backend/vulkan/device_buffer_vk.cc
+++ b/impeller/renderer/backend/vulkan/device_buffer_vk.cc
@@ -46,7 +46,7 @@ DeviceBufferVK::DeviceBufferVK(
 DeviceBufferVK::~DeviceBufferVK() = default;
 
 uint8_t* DeviceBufferVK::OnGetContents() const {
-  return reinterpret_cast<uint8_t*>(allocation_info_.pMappedData);
+  return reinterpret_cast<uint8_t*>(device_allocation_->GetMapping());
 }
 
 bool DeviceBufferVK::OnCopyHostBuffer(const uint8_t* source,

--- a/impeller/renderer/backend/vulkan/device_buffer_vk.cc
+++ b/impeller/renderer/backend/vulkan/device_buffer_vk.cc
@@ -45,6 +45,10 @@ DeviceBufferVK::DeviceBufferVK(
 
 DeviceBufferVK::~DeviceBufferVK() = default;
 
+uint8_t* DeviceBufferVK::OnGetContents() const {
+  return reinterpret_cast<uint8_t*>(allocation_info_.pMappedData);
+}
+
 bool DeviceBufferVK::OnCopyHostBuffer(const uint8_t* source,
                                       Range source_range,
                                       size_t offset) {

--- a/impeller/renderer/backend/vulkan/device_buffer_vk.h
+++ b/impeller/renderer/backend/vulkan/device_buffer_vk.h
@@ -54,6 +54,9 @@ class DeviceBufferVK final : public DeviceBuffer,
   std::unique_ptr<DeviceBufferAllocationVK> device_allocation_;
 
   // |DeviceBuffer|
+  uint8_t* OnGetContents() const override;
+
+  // |DeviceBuffer|
   bool OnCopyHostBuffer(const uint8_t* source,
                         Range source_range,
                         size_t offset) override;

--- a/impeller/renderer/buffer_view.h
+++ b/impeller/renderer/buffer_view.h
@@ -12,6 +12,7 @@ namespace impeller {
 
 struct BufferView {
   std::shared_ptr<const Buffer> buffer;
+  uint8_t* contents;
   Range range;
 
   constexpr operator bool() const { return static_cast<bool>(buffer); }

--- a/impeller/renderer/device_buffer.cc
+++ b/impeller/renderer/device_buffer.cc
@@ -19,8 +19,24 @@ std::shared_ptr<const DeviceBuffer> DeviceBuffer::GetDeviceBuffer(
 BufferView DeviceBuffer::AsBufferView() const {
   BufferView view;
   view.buffer = shared_from_this();
+  view.contents = OnGetContents();
   view.range = {0u, desc_.size};
   return view;
+}
+
+std::shared_ptr<Texture> DeviceBuffer::AsTexture(
+    Allocator& allocator,
+    const TextureDescriptor& descriptor,
+    uint16_t row_bytes) const {
+  auto texture = allocator.CreateTexture(descriptor);
+  if (!texture) {
+    return nullptr;
+  }
+  if (!texture->SetContents(std::make_shared<fml::NonOwnedMapping>(
+          OnGetContents(), desc_.size))) {
+    return nullptr;
+  }
+  return texture;
 }
 
 [[nodiscard]] bool DeviceBuffer::CopyHostBuffer(const uint8_t* source,

--- a/impeller/renderer/device_buffer.h
+++ b/impeller/renderer/device_buffer.h
@@ -32,6 +32,11 @@ class DeviceBuffer : public Buffer,
 
   BufferView AsBufferView() const;
 
+  virtual std::shared_ptr<Texture> AsTexture(
+      Allocator& allocator,
+      const TextureDescriptor& descriptor,
+      uint16_t row_bytes) const;
+
   // |Buffer|
   std::shared_ptr<const DeviceBuffer> GetDeviceBuffer(
       Allocator& allocator) const;
@@ -40,6 +45,8 @@ class DeviceBuffer : public Buffer,
   const DeviceBufferDescriptor desc_;
 
   explicit DeviceBuffer(DeviceBufferDescriptor desc);
+
+  virtual uint8_t* OnGetContents() const = 0;
 
   virtual bool OnCopyHostBuffer(const uint8_t* source,
                                 Range source_range,

--- a/impeller/renderer/host_buffer.cc
+++ b/impeller/renderer/host_buffer.cc
@@ -53,7 +53,7 @@ BufferView HostBuffer::Emplace(const void* buffer, size_t length) {
   if (buffer) {
     ::memmove(GetBuffer() + old_length, buffer, length);
   }
-  return BufferView{shared_from_this(), Range{old_length, length}};
+  return BufferView{shared_from_this(), GetBuffer(), Range{old_length, length}};
 }
 
 std::shared_ptr<const DeviceBuffer> HostBuffer::GetDeviceBuffer(

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -841,5 +841,42 @@ TEST_P(RendererTest, InactiveUniforms) {
   OpenPlaygroundHere(callback);
 }
 
+TEST_P(RendererTest, CanCreateCPUBackedTexture) {
+  if (GetParam() != PlaygroundBackend::kMetal) {
+    GTEST_SKIP_("CPU backed textures only supported on Metal right now.");
+  }
+
+  auto context = GetContext();
+  auto allocator = context->GetResourceAllocator();
+  size_t dimension = 2;
+
+  do {
+    ISize size(dimension, dimension);
+    TextureDescriptor texture_descriptor;
+    texture_descriptor.storage_mode = StorageMode::kHostVisible;
+    texture_descriptor.format = PixelFormat::kR8G8B8A8UNormInt;
+    texture_descriptor.size = size;
+    auto row_bytes =
+        std::max(static_cast<uint16_t>(size.width * 4),
+                 allocator->MinimumBytesPerRow(texture_descriptor.format));
+    auto buffer_size = size.height * row_bytes;
+
+    DeviceBufferDescriptor buffer_descriptor;
+    buffer_descriptor.storage_mode = StorageMode::kHostVisible;
+    buffer_descriptor.size = buffer_size;
+
+    auto buffer = allocator->CreateBuffer(buffer_descriptor);
+
+    ASSERT_TRUE(buffer);
+
+    auto texture = buffer->AsTexture(*allocator, texture_descriptor, row_bytes);
+
+    ASSERT_TRUE(texture);
+    ASSERT_TRUE(texture->IsValid());
+
+    dimension *= 2;
+  } while (dimension <= 8192);
+}
+
 }  // namespace testing
 }  // namespace impeller


### PR DESCRIPTION
This is pulled out from work related to compute and glyph atlases - this makes sense as its own PR and shouldn't get reverted if either of those patches have to get reverted.

Adds a way to view the buffer on `BufferView`. If a `DeviceBuffer` is `StorageMode::kHostVisible`, fills that with the appropriate pointer - otherwise it's nullptr. 

This is useful for reading back data from compute or for having a faster path to send CPU allocated data as a texture to the GPU in some cases (fewer copies).