### PR TITLE
Add dark mode support to dart:ui diagrams

### DIFF
--- a/lib/ui/geometry.dart
+++ b/lib/ui/geometry.dart
@@ -635,7 +635,7 @@ class Rect {
   /// Construct a rectangle from its left, top, right, and bottom edges.
   ///
   /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/rect_from_ltrb.png#gh-light-mode-only)
-  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/rect_from_ltrb_dark.png#gh-dark-mode-only.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/rect_from_ltrb_dark.png#gh-dark-mode-only)
   @pragma('vm:entry-point')
   const Rect.fromLTRB(this.left, this.top, this.right, this.bottom)
       : assert(left != null),
@@ -650,7 +650,7 @@ class Rect {
   /// rectangle constructor operator `&`. See [Offset.&].
   ///
   /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/rect_from_ltwh.png#gh-light-mode-only)
-  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/rect_from_ltwh_dark.png#gh-dark-mode-only.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/rect_from_ltwh_dark.png#gh-dark-mode-only)
   const Rect.fromLTWH(double left, double top, double width, double height) : this.fromLTRB(left, top, left + width, top + height);
 
   /// Construct a rectangle that bounds the given circle.
@@ -658,7 +658,7 @@ class Rect {
   /// The `center` argument is assumed to be an offset from the origin.
   ///
   /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/rect_from_circle.png#gh-light-mode-only)
-  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/rect_from_circle_dark.png#gh-dark-mode-only.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/rect_from_circle_dark.png#gh-dark-mode-only)
   Rect.fromCircle({ required Offset center, required double radius }) : this.fromCenter(
     center: center,
     width: radius * 2,
@@ -670,7 +670,7 @@ class Rect {
   /// The `center` argument is assumed to be an offset from the origin.
   ///
   /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/rect_from_center.png#gh-light-mode-only)
-  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/rect_from_center_dark.png#gh-dark-mode-only.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/rect_from_center_dark.png#gh-dark-mode-only)
   Rect.fromCenter({ required Offset center, required double width, required double height }) : this.fromLTRB(
     center.dx - width / 2,
     center.dy - height / 2,
@@ -682,7 +682,7 @@ class Rect {
   /// them as vectors from the origin.
   ///
   /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/rect_from_points.png#gh-light-mode-only)
-  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/rect_from_points_dark.png#gh-dark-mode-only.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/rect_from_points_dark.png#gh-dark-mode-only)
   Rect.fromPoints(Offset a, Offset b) : this.fromLTRB(
     math.min(a.dx, b.dx),
     math.min(a.dy, b.dy),
@@ -940,13 +940,13 @@ class Radius {
   /// Constructs a circular radius. [x] and [y] will have the same radius value.
   ///
   /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/radius_circular.png#gh-light-mode-only)
-  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/radius_circular_dark.png#gh-dark-mode-only.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/radius_circular_dark.png#gh-dark-mode-only)
   const Radius.circular(double radius) : this.elliptical(radius, radius);
 
   /// Constructs an elliptical radius with the given radii.
   ///
   /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/radius_elliptical.png#gh-light-mode-only)
-  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/radius_elliptical_dark.png#gh-dark-mode-only.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/radius_elliptical_dark.png#gh-dark-mode-only)
   const Radius.elliptical(this.x, this.y);
 
   /// The radius value on the horizontal axis.

--- a/lib/ui/geometry.dart
+++ b/lib/ui/geometry.dart
@@ -634,7 +634,8 @@ class Size extends OffsetBase {
 class Rect {
   /// Construct a rectangle from its left, top, right, and bottom edges.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/rect_from_ltrb.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/rect_from_ltrb.png#gh-light-mode-only)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/rect_from_ltrb_dark.png#gh-dark-mode-only.png)
   @pragma('vm:entry-point')
   const Rect.fromLTRB(this.left, this.top, this.right, this.bottom)
       : assert(left != null),
@@ -648,14 +649,16 @@ class Rect {
   /// To construct a [Rect] from an [Offset] and a [Size], you can use the
   /// rectangle constructor operator `&`. See [Offset.&].
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/rect_from_ltwh.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/rect_from_ltwh.png#gh-light-mode-only)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/rect_from_ltwh_dark.png#gh-dark-mode-only.png)
   const Rect.fromLTWH(double left, double top, double width, double height) : this.fromLTRB(left, top, left + width, top + height);
 
   /// Construct a rectangle that bounds the given circle.
   ///
   /// The `center` argument is assumed to be an offset from the origin.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/rect_from_circle.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/rect_from_circle.png#gh-light-mode-only)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/rect_from_circle_dark.png#gh-dark-mode-only.png)
   Rect.fromCircle({ required Offset center, required double radius }) : this.fromCenter(
     center: center,
     width: radius * 2,
@@ -666,7 +669,8 @@ class Rect {
   ///
   /// The `center` argument is assumed to be an offset from the origin.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/rect_from_center.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/rect_from_center.png#gh-light-mode-only)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/rect_from_center_dark.png#gh-dark-mode-only.png)
   Rect.fromCenter({ required Offset center, required double width, required double height }) : this.fromLTRB(
     center.dx - width / 2,
     center.dy - height / 2,
@@ -677,7 +681,8 @@ class Rect {
   /// Construct the smallest rectangle that encloses the given offsets, treating
   /// them as vectors from the origin.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/rect_from_points.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/rect_from_points.png#gh-light-mode-only)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/rect_from_points_dark.png#gh-dark-mode-only.png)
   Rect.fromPoints(Offset a, Offset b) : this.fromLTRB(
     math.min(a.dx, b.dx),
     math.min(a.dy, b.dy),
@@ -934,12 +939,14 @@ class Rect {
 class Radius {
   /// Constructs a circular radius. [x] and [y] will have the same radius value.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/radius_circular.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/radius_circular.png#gh-light-mode-only)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/radius_circular_dark.png#gh-dark-mode-only.png)
   const Radius.circular(double radius) : this.elliptical(radius, radius);
 
   /// Constructs an elliptical radius with the given radii.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/radius_elliptical.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/radius_elliptical.png#gh-light-mode-only)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/radius_elliptical_dark.png#gh-dark-mode-only.png)
   const Radius.elliptical(this.x, this.y);
 
   /// The radius value on the horizontal axis.

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -2601,7 +2601,7 @@ class Path extends NativeFieldWrapperClass1 {
   /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/path_add_arc_dark.png#gh-dark-mode-only)
   ///
   /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/path_add_arc_ccw.png#gh-light-mode-only)
-  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/path_add_arc_ccw_dark.png#gh-dark-mode-only.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/path_add_arc_ccw_dark.png#gh-dark-mode-only)
   void addArc(Rect oval, double startAngle, double sweepAngle) {
     assert(_rectIsValid(oval));
     _addArc(oval.left, oval.top, oval.right, oval.bottom, startAngle, sweepAngle);
@@ -4919,7 +4919,7 @@ class Canvas extends NativeFieldWrapperClass1 {
   /// The `p1` and `p2` arguments are interpreted as offsets from the origin.
   ///
   /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/canvas_line.png#gh-light-mode-only)
-  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/canvas_line_dark.png#gh-dark-mode-only.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/canvas_line_dark.png#gh-dark-mode-only)
   void drawLine(Offset p1, Offset p2, Paint paint) {
     assert(_offsetIsValid(p1));
     assert(_offsetIsValid(p2));
@@ -4946,7 +4946,7 @@ class Canvas extends NativeFieldWrapperClass1 {
   /// or stroked (or both) is controlled by [Paint.style].
   ///
   /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/canvas_rect.png#gh-light-mode-only)
-  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/canvas_rect_dark.png#gh-dark-mode-only.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/canvas_rect_dark.png#gh-dark-mode-only)
   void drawRect(Rect rect, Paint paint) {
     assert(_rectIsValid(rect));
     assert(paint != null);
@@ -4960,7 +4960,7 @@ class Canvas extends NativeFieldWrapperClass1 {
   /// filled or stroked (or both) is controlled by [Paint.style].
   ///
   /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/canvas_rrect.png#gh-light-mode-only)
-  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/canvas_rrect_dark.png#gh-dark-mode-only.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/canvas_rrect_dark.png#gh-dark-mode-only)
   void drawRRect(RRect rrect, Paint paint) {
     assert(_rrectIsValid(rrect));
     assert(paint != null);
@@ -4990,7 +4990,7 @@ class Canvas extends NativeFieldWrapperClass1 {
   /// controlled by [Paint.style].
   ///
   /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/canvas_oval.png#gh-light-mode-only)
-  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/canvas_oval_dark.png#gh-dark-mode-only.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/canvas_oval_dark.png#gh-dark-mode-only)
   void drawOval(Rect rect, Paint paint) {
     assert(_rectIsValid(rect));
     assert(paint != null);
@@ -5027,7 +5027,7 @@ class Canvas extends NativeFieldWrapperClass1 {
   /// not closed, forming a circle segment.
   ///
   /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/canvas_draw_arc.png#gh-light-mode-only)
-  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/canvas_draw_arc_dark.png#gh-dark-mode-only.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/canvas_draw_arc_dark.png#gh-dark-mode-only)
   ///
   /// This method is optimized for drawing arcs and should be faster than [Path.arcTo].
   void drawArc(Rect rect, double startAngle, double sweepAngle, bool useCenter, Paint paint) {

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -2430,7 +2430,8 @@ class Path extends NativeFieldWrapperClass1 {
   /// point to the given point (x2,y2), using the control point
   /// (x1,y1).
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/path_quadratic_to.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/path_quadratic_to.png#gh-light-mode-only)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/path_quadratic_to_dark.png#gh-dark-mode-only)
   @FfiNative<Void Function(Pointer<Void>, Float, Float, Float, Float)>('Path::quadraticBezierTo', isLeaf: true)
   external void quadraticBezierTo(double x1, double y1, double x2, double y2);
 
@@ -2446,7 +2447,8 @@ class Path extends NativeFieldWrapperClass1 {
   /// to the given point (x3,y3), using the control points (x1,y1) and
   /// (x2,y2).
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/path_cubic_to.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/path_cubic_to.png#gh-light-mode-only)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/path_cubic_to_dark.png#gh-dark-mode-only)
   @FfiNative<Void Function(Pointer<Void>, Float, Float, Float, Float, Float, Float)>('Path::cubicTo', isLeaf: true)
   external void cubicTo(double x1, double y1, double x2, double y2, double x3, double y3);
 
@@ -2463,7 +2465,8 @@ class Path extends NativeFieldWrapperClass1 {
   /// hyperbola; if the weight equals 1, it's a parabola; and if it is
   /// less than 1, it is an ellipse.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/path_conic_to.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/path_conic_to.png#gh-light-mode-only)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/path_conic_to_dark.png#gh-dark-mode-only)
   @FfiNative<Void Function(Pointer<Void>, Float, Float, Float, Float, Float)>('Path::conicTo', isLeaf: true)
   external void conicTo(double x1, double y1, double x2, double y2, double w);
 
@@ -2594,9 +2597,11 @@ class Path extends NativeFieldWrapperClass1 {
   /// rectangle and with positive angles going clockwise around the
   /// oval.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/path_add_arc.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/path_add_arc.png#gh-light-mode-only)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/path_add_arc_dark.png#gh-dark-mode-only)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/path_add_arc_ccw.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/path_add_arc_ccw.png#gh-light-mode-only)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/path_add_arc_ccw_dark.png#gh-dark-mode-only.png)
   void addArc(Rect oval, double startAngle, double sweepAngle) {
     assert(_rectIsValid(oval));
     _addArc(oval.left, oval.top, oval.right, oval.bottom, startAngle, sweepAngle);
@@ -4913,7 +4918,8 @@ class Canvas extends NativeFieldWrapperClass1 {
   ///
   /// The `p1` and `p2` arguments are interpreted as offsets from the origin.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/canvas_line.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/canvas_line.png#gh-light-mode-only)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/canvas_line_dark.png#gh-dark-mode-only.png)
   void drawLine(Offset p1, Offset p2, Paint paint) {
     assert(_offsetIsValid(p1));
     assert(_offsetIsValid(p2));
@@ -4939,7 +4945,8 @@ class Canvas extends NativeFieldWrapperClass1 {
   /// Draws a rectangle with the given [Paint]. Whether the rectangle is filled
   /// or stroked (or both) is controlled by [Paint.style].
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/canvas_rect.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/canvas_rect.png#gh-light-mode-only)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/canvas_rect_dark.png#gh-dark-mode-only.png)
   void drawRect(Rect rect, Paint paint) {
     assert(_rectIsValid(rect));
     assert(paint != null);
@@ -4952,7 +4959,8 @@ class Canvas extends NativeFieldWrapperClass1 {
   /// Draws a rounded rectangle with the given [Paint]. Whether the rectangle is
   /// filled or stroked (or both) is controlled by [Paint.style].
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/canvas_rrect.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/canvas_rrect.png#gh-light-mode-only)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/canvas_rrect_dark.png#gh-dark-mode-only.png)
   void drawRRect(RRect rrect, Paint paint) {
     assert(_rrectIsValid(rrect));
     assert(paint != null);
@@ -4981,7 +4989,8 @@ class Canvas extends NativeFieldWrapperClass1 {
   /// with the given [Paint]. Whether the oval is filled or stroked (or both) is
   /// controlled by [Paint.style].
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/canvas_oval.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/canvas_oval.png#gh-light-mode-only)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/canvas_oval_dark.png#gh-dark-mode-only.png)
   void drawOval(Rect rect, Paint paint) {
     assert(_rectIsValid(rect));
     assert(paint != null);
@@ -4996,7 +5005,8 @@ class Canvas extends NativeFieldWrapperClass1 {
   /// the third argument. Whether the circle is filled or stroked (or both) is
   /// controlled by [Paint.style].
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/canvas_circle.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/canvas_circle.png#gh-light-mode-only)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/canvas_circle_dark.png#gh-dark-mode-only)
   void drawCircle(Offset c, double radius, Paint paint) {
     assert(_offsetIsValid(c));
     assert(paint != null);
@@ -5016,7 +5026,8 @@ class Canvas extends NativeFieldWrapperClass1 {
   /// closed back to the center, forming a circle sector. Otherwise, the arc is
   /// not closed, forming a circle segment.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/canvas_draw_arc.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/canvas_draw_arc.png#gh-light-mode-only)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/canvas_draw_arc_dark.png#gh-dark-mode-only.png)
   ///
   /// This method is optimized for drawing arcs and should be faster than [Path.arcTo].
   void drawArc(Rect rect, double startAngle, double sweepAngle, bool useCenter, Paint paint) {


### PR DESCRIPTION
Adds dark mode variants of these diagrams merged in https://github.com/flutter/assets-for-api-docs/pull/200, the `#gh-light-mode-only` / `#gh-dark-mode-only` syntax was also added to dartdoc in https://github.com/dart-lang/dartdoc/pull/3182.