### PR TITLE
Get user's preferred languages from registry

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -2538,6 +2538,8 @@ FILE: ../../../flutter/shell/platform/windows/window_state.h
 FILE: ../../../flutter/shell/platform/windows/window_unittests.cc
 FILE: ../../../flutter/shell/platform/windows/windows_proc_table.cc
 FILE: ../../../flutter/shell/platform/windows/windows_proc_table.h
+FILE: ../../../flutter/shell/platform/windows/windows_registry.cc
+FILE: ../../../flutter/shell/platform/windows/windows_registry.h
 FILE: ../../../flutter/shell/profiling/sampling_profiler.cc
 FILE: ../../../flutter/shell/profiling/sampling_profiler.h
 FILE: ../../../flutter/shell/profiling/sampling_profiler_unittest.cc

--- a/shell/platform/windows/BUILD.gn
+++ b/shell/platform/windows/BUILD.gn
@@ -105,6 +105,8 @@ source_set("flutter_windows_source") {
     "window_state.h",
     "windows_proc_table.cc",
     "windows_proc_table.h",
+    "windows_registry.cc",
+    "windows_registry.h",
   ]
 
   libs = [

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -155,7 +155,7 @@ FlutterLocale CovertToFlutterLocale(const LanguageInfo& info) {
 FlutterWindowsEngine::FlutterWindowsEngine(const FlutterProjectBundle& project)
     : project_(std::make_unique<FlutterProjectBundle>(project)),
       aot_data_(nullptr, nullptr),
-      registry_(std::make_unique<WindowsRegistry>()) {
+      windows_registry_(std::make_unique<WindowsRegistry>()) {
   embedder_api_.struct_size = sizeof(FlutterEngineProcTable);
   FlutterEngineGetProcAddresses(&embedder_api_);
 
@@ -527,7 +527,7 @@ void FlutterWindowsEngine::SetNextFrameCallback(fml::closure callback) {
 
 void FlutterWindowsEngine::SendSystemLocales() {
   std::vector<LanguageInfo> languages =
-      GetPreferredLanguageInfo(*registry_);
+      GetPreferredLanguageInfo(*windows_registry_);
   std::vector<FlutterLocale> flutter_locales;
   flutter_locales.reserve(languages.size());
   for (const auto& info : languages) {

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -658,9 +658,4 @@ int FlutterWindowsEngine::EnabledAccessibilityFeatures() const {
   return flags;
 }
 
-void FlutterWindowsEngine::SetWindowsRegistry(
-    const WindowsRegistry& windows_registry) {
-  windows_registry_ = std::make_unique<WindowsRegistry>(windows_registry);
-}
-
 }  // namespace flutter

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -526,7 +526,7 @@ void FlutterWindowsEngine::SetNextFrameCallback(fml::closure callback) {
 }
 
 void FlutterWindowsEngine::SendSystemLocales() {
-  std::vector<LanguageInfo> languages = GetPreferredLanguageInfo();
+  std::vector<LanguageInfo> languages = GetPreferredLanguageInfo(*windows_registry_);
   std::vector<FlutterLocale> flutter_locales;
   flutter_locales.reserve(languages.size());
   for (const auto& info : languages) {

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -152,10 +152,12 @@ FlutterLocale CovertToFlutterLocale(const LanguageInfo& info) {
 
 }  // namespace
 
-FlutterWindowsEngine::FlutterWindowsEngine(const FlutterProjectBundle& project)
+FlutterWindowsEngine::FlutterWindowsEngine(
+    const FlutterProjectBundle& project,
+    std::unique_ptr<WindowsRegistry> registry)
     : project_(std::make_unique<FlutterProjectBundle>(project)),
       aot_data_(nullptr, nullptr),
-      windows_registry_(std::make_unique<WindowsRegistry>()) {
+      windows_registry_(std::move(registry)) {
   embedder_api_.struct_size = sizeof(FlutterEngineProcTable);
   FlutterEngineGetProcAddresses(&embedder_api_);
 

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -526,7 +526,8 @@ void FlutterWindowsEngine::SetNextFrameCallback(fml::closure callback) {
 }
 
 void FlutterWindowsEngine::SendSystemLocales() {
-  std::vector<LanguageInfo> languages = GetPreferredLanguageInfo(*windows_registry_);
+  std::vector<LanguageInfo> languages =
+      GetPreferredLanguageInfo(*windows_registry_);
   std::vector<FlutterLocale> flutter_locales;
   flutter_locales.reserve(languages.size());
   for (const auto& info : languages) {
@@ -657,7 +658,8 @@ int FlutterWindowsEngine::EnabledAccessibilityFeatures() const {
   return flags;
 }
 
-void FlutterWindowsEngine::SetWindowsRegistry(const WindowsRegistry& windows_registry) {
+void FlutterWindowsEngine::SetWindowsRegistry(
+    const WindowsRegistry& windows_registry) {
   windows_registry_ = std::make_unique<WindowsRegistry>(windows_registry);
 }
 

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -154,7 +154,8 @@ FlutterLocale CovertToFlutterLocale(const LanguageInfo& info) {
 
 FlutterWindowsEngine::FlutterWindowsEngine(const FlutterProjectBundle& project)
     : project_(std::make_unique<FlutterProjectBundle>(project)),
-      aot_data_(nullptr, nullptr) {
+      aot_data_(nullptr, nullptr),
+      windows_registry_(std::make_unique<WindowsRegistry>()) {
   embedder_api_.struct_size = sizeof(FlutterEngineProcTable);
   FlutterEngineGetProcAddresses(&embedder_api_);
 
@@ -654,6 +655,10 @@ int FlutterWindowsEngine::EnabledAccessibilityFeatures() const {
   // As more accessibility features are enabled for Windows,
   // the corresponding checks and flags should be added here.
   return flags;
+}
+
+void FlutterWindowsEngine::SetWindowsRegistry(const WindowsRegistry& windows_registry) {
+  windows_registry_ = std::make_unique<WindowsRegistry>(windows_registry);
 }
 
 }  // namespace flutter

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -155,7 +155,7 @@ FlutterLocale CovertToFlutterLocale(const LanguageInfo& info) {
 FlutterWindowsEngine::FlutterWindowsEngine(const FlutterProjectBundle& project)
     : project_(std::make_unique<FlutterProjectBundle>(project)),
       aot_data_(nullptr, nullptr),
-      windows_registry_(std::make_unique<WindowsRegistry>()) {
+      registry_(std::make_unique<WindowsRegistry>()) {
   embedder_api_.struct_size = sizeof(FlutterEngineProcTable);
   FlutterEngineGetProcAddresses(&embedder_api_);
 
@@ -527,7 +527,7 @@ void FlutterWindowsEngine::SetNextFrameCallback(fml::closure callback) {
 
 void FlutterWindowsEngine::SendSystemLocales() {
   std::vector<LanguageInfo> languages =
-      GetPreferredLanguageInfo(*windows_registry_);
+      GetPreferredLanguageInfo(*registry_);
   std::vector<FlutterLocale> flutter_locales;
   flutter_locales.reserve(languages.size());
   for (const auto& info : languages) {

--- a/shell/platform/windows/flutter_windows_engine.h
+++ b/shell/platform/windows/flutter_windows_engine.h
@@ -323,7 +323,7 @@ class FlutterWindowsEngine {
   fml::closure next_frame_callback_;
 
   // A handle to a registry for registry values
-  std::unique_ptr<WindowsRegistry> windows_registry_;
+  std::unique_ptr<WindowsRegistry> registry_;
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/flutter_windows_engine.h
+++ b/shell/platform/windows/flutter_windows_engine.h
@@ -239,9 +239,6 @@ class FlutterWindowsEngine {
   // Updates accessibility, e.g. switch to high contrast mode
   void UpdateAccessibilityFeatures(FlutterAccessibilityFeature flags);
 
-  // Allow setting the Windows Registry
-  void SetWindowsRegistry(const WindowsRegistry& windows_registry);
-
  private:
   // Allows swapping out embedder_api_ calls in tests.
   friend class EngineModifier;

--- a/shell/platform/windows/flutter_windows_engine.h
+++ b/shell/platform/windows/flutter_windows_engine.h
@@ -67,8 +67,14 @@ static void WindowsPlatformThreadPrioritySetter(
 // run in headless mode.
 class FlutterWindowsEngine {
  public:
+  // Creates a new Flutter engine with an injectible windows registry.
+  FlutterWindowsEngine(
+      const FlutterProjectBundle& project,
+      std::unique_ptr<WindowsRegistry> windows_registry);
+
   // Creates a new Flutter engine object configured to run |project|.
-  explicit FlutterWindowsEngine(const FlutterProjectBundle& project);
+  explicit FlutterWindowsEngine(const FlutterProjectBundle& project)
+      : FlutterWindowsEngine(project, std::make_unique<WindowsRegistry>()) {}
 
   virtual ~FlutterWindowsEngine();
 

--- a/shell/platform/windows/flutter_windows_engine.h
+++ b/shell/platform/windows/flutter_windows_engine.h
@@ -27,6 +27,7 @@
 #include "flutter/shell/platform/windows/task_runner.h"
 #include "flutter/shell/platform/windows/window_proc_delegate_manager.h"
 #include "flutter/shell/platform/windows/window_state.h"
+#include "flutter/shell/platform/windows/windows_registry.h"
 #include "third_party/rapidjson/include/rapidjson/document.h"
 
 namespace flutter {
@@ -238,6 +239,9 @@ class FlutterWindowsEngine {
   // Updates accessibility, e.g. switch to high contrast mode
   void UpdateAccessibilityFeatures(FlutterAccessibilityFeature flags);
 
+  // Allow setting the Windows Registry
+  void SetWindowsRegistry(const WindowsRegistry& windows_registry);
+
  private:
   // Allows swapping out embedder_api_ calls in tests.
   friend class EngineModifier;
@@ -320,6 +324,9 @@ class FlutterWindowsEngine {
 
   // The on frame drawn callback.
   fml::closure next_frame_callback_;
+
+  // A handle to a registry for registry values
+  std::unique_ptr<WindowsRegistry> windows_registry_;
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/flutter_windows_engine.h
+++ b/shell/platform/windows/flutter_windows_engine.h
@@ -322,8 +322,8 @@ class FlutterWindowsEngine {
   // The on frame drawn callback.
   fml::closure next_frame_callback_;
 
-  // A handle to a registry for registry values
-  std::unique_ptr<WindowsRegistry> registry_;
+  // Wrapper providing Windows registry access.
+  std::unique_ptr<WindowsRegistry> windows_registry_;
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/flutter_windows_engine.h
+++ b/shell/platform/windows/flutter_windows_engine.h
@@ -68,9 +68,8 @@ static void WindowsPlatformThreadPrioritySetter(
 class FlutterWindowsEngine {
  public:
   // Creates a new Flutter engine with an injectible windows registry.
-  FlutterWindowsEngine(
-      const FlutterProjectBundle& project,
-      std::unique_ptr<WindowsRegistry> windows_registry);
+  FlutterWindowsEngine(const FlutterProjectBundle& project,
+                       std::unique_ptr<WindowsRegistry> windows_registry);
 
   // Creates a new Flutter engine object configured to run |project|.
   explicit FlutterWindowsEngine(const FlutterProjectBundle& project)

--- a/shell/platform/windows/flutter_windows_engine_unittests.cc
+++ b/shell/platform/windows/flutter_windows_engine_unittests.cc
@@ -4,13 +4,10 @@
 
 #include "flutter/shell/platform/windows/flutter_windows_engine.h"
 
-#include <string>
-
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/embedder/test_utils/proc_table_replacement.h"
 #include "flutter/shell/platform/windows/testing/engine_modifier.h"
 #include "flutter/shell/platform/windows/testing/test_keyboard.h"
-#include "flutter/shell/platform/windows/windows_registry.h"
 #include "gtest/gtest.h"
 
 // winbase.h defines GetCurrentTime as a macro.

--- a/shell/platform/windows/flutter_windows_engine_unittests.cc
+++ b/shell/platform/windows/flutter_windows_engine_unittests.cc
@@ -4,10 +4,13 @@
 
 #include "flutter/shell/platform/windows/flutter_windows_engine.h"
 
+#include <string>
+
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/embedder/test_utils/proc_table_replacement.h"
 #include "flutter/shell/platform/windows/testing/engine_modifier.h"
 #include "flutter/shell/platform/windows/testing/test_keyboard.h"
+#include "flutter/shell/platform/windows/windows_registry.h"
 #include "gtest/gtest.h"
 
 // winbase.h defines GetCurrentTime as a macro.
@@ -17,6 +20,7 @@ namespace flutter {
 namespace testing {
 
 namespace {
+
 // Returns an engine instance configured with dummy project path values.
 std::unique_ptr<FlutterWindowsEngine> GetTestEngine() {
   FlutterDesktopEngineProperties properties = {};

--- a/shell/platform/windows/system_utils.cc
+++ b/shell/platform/windows/system_utils.cc
@@ -34,8 +34,8 @@ std::vector<std::wstring> GetPreferredLanguages(
 
   // Determine where languages are defined and get buffer length
   if (registry.GetRegistryValue(HKEY_CURRENT_USER,
-                                L"Control panel\\International\\User Profile",
-                                L"Languages", RRF_RT_REG_MULTI_SZ, NULL, NULL,
+                                WIN_REG_I18N_PROFILE,
+                                WIN_REG_LANGUAGES, RRF_RT_REG_MULTI_SZ, NULL, NULL,
                                 &buffer_size) != ERROR_SUCCESS) {
     languages_from_registry = FALSE;
     if (!::GetThreadPreferredUILanguages(flags, &count, nullptr,
@@ -57,8 +57,8 @@ std::vector<std::wstring> GetPreferredLanguages(
   std::wstring buffer(buffer_size, '\0');
   if (languages_from_registry) {
     if (registry.GetRegistryValue(
-            HKEY_CURRENT_USER, L"Control panel\\International\\User Profile",
-            L"Languages", RRF_RT_REG_MULTI_SZ, NULL, buffer.data(),
+            HKEY_CURRENT_USER, WIN_REG_I18N_PROFILE,
+            WIN_REG_LANGUAGES, RRF_RT_REG_MULTI_SZ, NULL, buffer.data(),
             &buffer_size) != ERROR_SUCCESS) {
       return languages;
     }

--- a/shell/platform/windows/system_utils.cc
+++ b/shell/platform/windows/system_utils.cc
@@ -32,9 +32,9 @@ std::vector<std::wstring> GetPreferredLanguages() {
   DWORD flags = MUI_LANGUAGE_NAME | MUI_UI_FALLBACK;
 
   // Determine where languages are defined and get buffer length
-  if(RegGetValueA(HKEY_CURRENT_USER,
-                  "Control panel\\International\\User Profile", "Languages",
-                  RRF_RT_REG_MULTI_SZ, NULL, NULL, &buffer_size) != S_OK) {
+  if (RegGetValueA(HKEY_CURRENT_USER,
+                   "Control panel\\International\\User Profile", "Languages",
+                   RRF_RT_REG_MULTI_SZ, NULL, NULL, &buffer_size) != S_OK) {
     languages_from_registry = FALSE;
     if (!::GetThreadPreferredUILanguages(flags, &count, nullptr,
                                          &buffer_size)) {
@@ -52,9 +52,9 @@ std::vector<std::wstring> GetPreferredLanguages() {
   std::wstring buffer(buffer_size, '\0');
   if (languages_from_registry) {
     std::string str_buffer(buffer_size, '\0');
-    if(RegGetValueA(HKEY_CURRENT_USER,
-                    "Control panel\\International\\User Profile", "Languages",
-                    RRF_RT_REG_MULTI_SZ, NULL, str_buffer.data(),
+    if (RegGetValueA(HKEY_CURRENT_USER,
+                     "Control panel\\International\\User Profile", "Languages",
+                     RRF_RT_REG_MULTI_SZ, NULL, str_buffer.data(),
                     &buffer_size) != S_OK) {
       return languages;
     }

--- a/shell/platform/windows/system_utils.cc
+++ b/shell/platform/windows/system_utils.cc
@@ -33,10 +33,9 @@ std::vector<std::wstring> GetPreferredLanguages(
   DWORD flags = MUI_LANGUAGE_NAME | MUI_UI_FALLBACK;
 
   // Determine where languages are defined and get buffer length
-  if (registry.GetRegistryValue(HKEY_CURRENT_USER,
-                                WIN_REG_I18N_PROFILE,
-                                WIN_REG_LANGUAGES, RRF_RT_REG_MULTI_SZ, NULL, NULL,
-                                &buffer_size) != ERROR_SUCCESS) {
+  if (registry.GetRegistryValue(HKEY_CURRENT_USER, WIN_REG_I18N_PROFILE,
+                                WIN_REG_LANGUAGES, RRF_RT_REG_MULTI_SZ, NULL,
+                                NULL, &buffer_size) != ERROR_SUCCESS) {
     languages_from_registry = FALSE;
     if (!::GetThreadPreferredUILanguages(flags, &count, nullptr,
                                          &buffer_size)) {
@@ -56,10 +55,10 @@ std::vector<std::wstring> GetPreferredLanguages(
   // Initialize the buffer
   std::wstring buffer(buffer_size, '\0');
   if (languages_from_registry) {
-    if (registry.GetRegistryValue(
-            HKEY_CURRENT_USER, WIN_REG_I18N_PROFILE,
-            WIN_REG_LANGUAGES, RRF_RT_REG_MULTI_SZ, NULL, buffer.data(),
-            &buffer_size) != ERROR_SUCCESS) {
+    if (registry.GetRegistryValue(HKEY_CURRENT_USER, WIN_REG_I18N_PROFILE,
+                                  WIN_REG_LANGUAGES, RRF_RT_REG_MULTI_SZ, NULL,
+                                  buffer.data(),
+                                  &buffer_size) != ERROR_SUCCESS) {
       return languages;
     }
   } else {

--- a/shell/platform/windows/system_utils.cc
+++ b/shell/platform/windows/system_utils.cc
@@ -43,7 +43,9 @@ std::vector<std::wstring> GetPreferredLanguages() {
   }
 
   // Mutli-string must be at least 3-long if non-empty,
-  // as a mulit-string is terminated with 2 nulls.
+  // as a multi-string is terminated with 2 nulls.
+  //
+  // See: https://learn.microsoft.com/en-us/windows/win32/sysinfo/registry-value-types
   if (buffer_size < 3) {
     languages_from_registry = FALSE;
   }

--- a/shell/platform/windows/system_utils.cc
+++ b/shell/platform/windows/system_utils.cc
@@ -34,8 +34,9 @@ std::vector<std::wstring> GetPreferredLanguages(
 
   // Determine where languages are defined and get buffer length
   if (registry.GetRegistryValue(HKEY_CURRENT_USER, kGetPreferredLanguageRegKey,
-                                kGetPreferredLanguageRegValue, RRF_RT_REG_MULTI_SZ, NULL,
-                                NULL, &buffer_size) != ERROR_SUCCESS) {
+                                kGetPreferredLanguageRegValue,
+                                RRF_RT_REG_MULTI_SZ, NULL, NULL,
+                                &buffer_size) != ERROR_SUCCESS) {
     languages_from_registry = FALSE;
     if (!::GetThreadPreferredUILanguages(flags, &count, nullptr,
                                          &buffer_size)) {
@@ -55,10 +56,10 @@ std::vector<std::wstring> GetPreferredLanguages(
   // Initialize the buffer
   std::wstring buffer(buffer_size, '\0');
   if (languages_from_registry) {
-    if (registry.GetRegistryValue(HKEY_CURRENT_USER, kGetPreferredLanguageRegKey,
-                                  kGetPreferredLanguageRegValue, RRF_RT_REG_MULTI_SZ, NULL,
-                                  buffer.data(),
-                                  &buffer_size) != ERROR_SUCCESS) {
+    if (registry.GetRegistryValue(
+            HKEY_CURRENT_USER, kGetPreferredLanguageRegKey,
+            kGetPreferredLanguageRegValue, RRF_RT_REG_MULTI_SZ, NULL,
+            buffer.data(), &buffer_size) != ERROR_SUCCESS) {
       return languages;
     }
   } else {

--- a/shell/platform/windows/system_utils.cc
+++ b/shell/platform/windows/system_utils.cc
@@ -33,8 +33,8 @@ std::vector<std::wstring> GetPreferredLanguages(
   DWORD flags = MUI_LANGUAGE_NAME | MUI_UI_FALLBACK;
 
   // Determine where languages are defined and get buffer length
-  if (registry.GetRegistryValue(HKEY_CURRENT_USER, WIN_REG_I18N_PROFILE,
-                                WIN_REG_LANGUAGES, RRF_RT_REG_MULTI_SZ, NULL,
+  if (registry.GetRegistryValue(HKEY_CURRENT_USER, kGetPreferredLanguageRegKey,
+                                kGetPreferredLanguageRegValue, RRF_RT_REG_MULTI_SZ, NULL,
                                 NULL, &buffer_size) != ERROR_SUCCESS) {
     languages_from_registry = FALSE;
     if (!::GetThreadPreferredUILanguages(flags, &count, nullptr,
@@ -55,8 +55,8 @@ std::vector<std::wstring> GetPreferredLanguages(
   // Initialize the buffer
   std::wstring buffer(buffer_size, '\0');
   if (languages_from_registry) {
-    if (registry.GetRegistryValue(HKEY_CURRENT_USER, WIN_REG_I18N_PROFILE,
-                                  WIN_REG_LANGUAGES, RRF_RT_REG_MULTI_SZ, NULL,
+    if (registry.GetRegistryValue(HKEY_CURRENT_USER, kGetPreferredLanguageRegKey,
+                                  kGetPreferredLanguageRegValue, RRF_RT_REG_MULTI_SZ, NULL,
                                   buffer.data(),
                                   &buffer_size) != ERROR_SUCCESS) {
       return languages;

--- a/shell/platform/windows/system_utils.cc
+++ b/shell/platform/windows/system_utils.cc
@@ -24,8 +24,8 @@ std::vector<LanguageInfo> GetPreferredLanguageInfo(
   return language_info;
 }
 
-std::wstring GetPreferredLanguagesFromRegistry(
-    const WindowsRegistry& registry, ULONG buffer_size) {
+std::wstring GetPreferredLanguagesFromRegistry(const WindowsRegistry& registry,
+                                               ULONG buffer_size) {
   std::wstring buffer(buffer_size, '\0');
   if (registry.GetRegistryValue(HKEY_CURRENT_USER, kGetPreferredLanguageRegKey,
                                 kGetPreferredLanguageRegValue,
@@ -44,7 +44,8 @@ std::wstring GetPreferredLanguagesFromMUI() {
     return std::wstring();
   }
   std::wstring buffer(buffer_size, '\0');
-  if (!GetThreadPreferredUILanguages(flags, &count, buffer.data(), &buffer_size)) {
+  if (!GetThreadPreferredUILanguages(flags, &count, buffer.data(),
+                                     &buffer_size)) {
     return std::wstring();
   }
   return buffer;
@@ -77,8 +78,9 @@ std::vector<std::wstring> GetPreferredLanguages(
 
   // Initialize the buffer
   std::wstring buffer =
-      languages_from_registry ? GetPreferredLanguagesFromRegistry(registry, buffer_size) :
-      GetPreferredLanguagesFromMUI();
+      languages_from_registry
+          ? GetPreferredLanguagesFromRegistry(registry, buffer_size)
+          : GetPreferredLanguagesFromMUI();
 
   // Extract the individual languages from the buffer.
   size_t start = 0;

--- a/shell/platform/windows/system_utils.cc
+++ b/shell/platform/windows/system_utils.cc
@@ -33,12 +33,11 @@ std::vector<std::wstring> GetPreferredLanguages() {
 
   // Determine where languages are defined and get buffer length
   if(RegGetValueA(HKEY_CURRENT_USER,
-      "Control panel\\International\\User Profile",
-      "Languages", RRF_RT_REG_MULTI_SZ, NULL,
-      NULL, &buffer_size) != S_OK) {
+                  "Control panel\\International\\User Profile", "Languages",
+                  RRF_RT_REG_MULTI_SZ, NULL, NULL, &buffer_size) != S_OK) {
     languages_from_registry = FALSE;
-    if (!::GetThreadPreferredUILanguages(flags, &count,
-        nullptr, &buffer_size)) {
+    if (!::GetThreadPreferredUILanguages(flags, &count, nullptr,
+                                         &buffer_size)) {
       return languages;
     }
   }
@@ -54,17 +53,15 @@ std::vector<std::wstring> GetPreferredLanguages() {
   if (languages_from_registry) {
     std::string str_buffer(buffer_size, '\0');
     if(RegGetValueA(HKEY_CURRENT_USER,
-        "Control panel\\International\\User Profile",
-        "Languages",
-        RRF_RT_REG_MULTI_SZ, NULL, str_buffer.data(),
-        &buffer_size) != S_OK) {
+                    "Control panel\\International\\User Profile", "Languages",
+                    RRF_RT_REG_MULTI_SZ, NULL, str_buffer.data(),
+                    &buffer_size) != S_OK) {
       return languages;
     }
     for (int i = 0; i < buffer_size; i++) {
       buffer[i] = str_buffer[i];
     }
-  }
-  else {
+  } else {
     if (!::GetThreadPreferredUILanguages(flags, &count, buffer.data(),
                                          &buffer_size)) {
       return languages;

--- a/shell/platform/windows/system_utils.cc
+++ b/shell/platform/windows/system_utils.cc
@@ -5,11 +5,11 @@
 #include "flutter/shell/platform/windows/system_utils.h"
 
 #include <Windows.h>
-#include <winreg.h>
 
 #include <sstream>
 
 #include "flutter/fml/platform/win/wstring_conversion.h"
+#include "flutter/fml/logging.h"
 
 namespace flutter {
 
@@ -45,7 +45,8 @@ std::vector<std::wstring> GetPreferredLanguages() {
   // Mutli-string must be at least 3-long if non-empty,
   // as a multi-string is terminated with 2 nulls.
   //
-  // See: https://learn.microsoft.com/en-us/windows/win32/sysinfo/registry-value-types
+  // See:
+  // https://learn.microsoft.com/en-us/windows/win32/sysinfo/registry-value-types
   if (buffer_size < 3) {
     languages_from_registry = FALSE;
   }
@@ -86,6 +87,7 @@ std::vector<std::wstring> GetPreferredLanguages() {
     // Skip past that language and its terminating null in the buffer.
     start += language.size() + 1;
   }
+  FML_LOG(ERROR) << "Leaving func";
   return languages;
 }
 

--- a/shell/platform/windows/system_utils.cc
+++ b/shell/platform/windows/system_utils.cc
@@ -32,18 +32,32 @@ std::vector<std::wstring> GetPreferredLanguages() {
   DWORD flags = MUI_LANGUAGE_NAME | MUI_UI_FALLBACK;
 
   // Determine where languages are defined and get buffer length
-  if(RegGetValueA(HKEY_CURRENT_USER, "Control panel\\International\\User Profile", "Languages", RRF_RT_REG_MULTI_SZ, NULL, NULL, &buffer_size) != S_OK) {
+  if(RegGetValueA(HKEY_CURRENT_USER,
+      "Control panel\\International\\User Profile",
+      "Languages", RRF_RT_REG_MULTI_SZ, NULL,
+      NULL, &buffer_size) != S_OK) {
     languages_from_registry = FALSE;
-    if (!::GetThreadPreferredUILanguages(flags, &count, nullptr, &buffer_size)) {
+    if (!::GetThreadPreferredUILanguages(flags, &count,
+        nullptr, &buffer_size)) {
       return languages;
     }
+  }
+
+  // Mutli-string must be at least 3-long if non-empty,
+  // as a mulit-string is terminated with 2 nulls.
+  if (buffer_size < 3) {
+    languages_from_registry = FALSE;
   }
 
   // Initialize the buffer
   std::wstring buffer(buffer_size, '\0');
   if (languages_from_registry) {
     std::string str_buffer(buffer_size, '\0');
-    if(RegGetValueA(HKEY_CURRENT_USER, "Control panel\\International\\User Profile", "Languages", RRF_RT_REG_MULTI_SZ, NULL, str_buffer.data(), &buffer_size) != S_OK) {
+    if(RegGetValueA(HKEY_CURRENT_USER,
+        "Control panel\\International\\User Profile",
+        "Languages",
+        RRF_RT_REG_MULTI_SZ, NULL, str_buffer.data(),
+        &buffer_size) != S_OK) {
       return languages;
     }
     for (int i = 0; i < buffer_size; i++) {

--- a/shell/platform/windows/system_utils.cc
+++ b/shell/platform/windows/system_utils.cc
@@ -12,7 +12,8 @@
 
 namespace flutter {
 
-std::vector<LanguageInfo> GetPreferredLanguageInfo(const WindowsRegistry& registry) {
+std::vector<LanguageInfo> GetPreferredLanguageInfo(
+    const WindowsRegistry& registry) {
   std::vector<std::wstring> languages = GetPreferredLanguages(registry);
   std::vector<LanguageInfo> language_info;
   language_info.reserve(languages.size());
@@ -23,7 +24,8 @@ std::vector<LanguageInfo> GetPreferredLanguageInfo(const WindowsRegistry& regist
   return language_info;
 }
 
-std::vector<std::wstring> GetPreferredLanguages(const WindowsRegistry& registry) {
+std::vector<std::wstring> GetPreferredLanguages(
+    const WindowsRegistry& registry) {
   std::vector<std::wstring> languages;
   BOOL languages_from_registry = TRUE;
   ULONG buffer_size = 0;
@@ -32,8 +34,9 @@ std::vector<std::wstring> GetPreferredLanguages(const WindowsRegistry& registry)
 
   // Determine where languages are defined and get buffer length
   if (registry.GetRegistryValue(HKEY_CURRENT_USER,
-                   L"Control panel\\International\\User Profile", L"Languages",
-                   RRF_RT_REG_MULTI_SZ, NULL, NULL, &buffer_size) != ERROR_SUCCESS) {
+                                L"Control panel\\International\\User Profile",
+                                L"Languages", RRF_RT_REG_MULTI_SZ, NULL, NULL,
+                                &buffer_size) != ERROR_SUCCESS) {
     languages_from_registry = FALSE;
     if (!::GetThreadPreferredUILanguages(flags, &count, nullptr,
                                          &buffer_size)) {
@@ -53,10 +56,10 @@ std::vector<std::wstring> GetPreferredLanguages(const WindowsRegistry& registry)
   // Initialize the buffer
   std::wstring buffer(buffer_size, '\0');
   if (languages_from_registry) {
-    if (registry.GetRegistryValue(HKEY_CURRENT_USER,
-                     L"Control panel\\International\\User Profile", L"Languages",
-                     RRF_RT_REG_MULTI_SZ, NULL, buffer.data(),
-                     &buffer_size) != ERROR_SUCCESS) {
+    if (registry.GetRegistryValue(
+            HKEY_CURRENT_USER, L"Control panel\\International\\User Profile",
+            L"Languages", RRF_RT_REG_MULTI_SZ, NULL, buffer.data(),
+            &buffer_size) != ERROR_SUCCESS) {
       return languages;
     }
   } else {

--- a/shell/platform/windows/system_utils.cc
+++ b/shell/platform/windows/system_utils.cc
@@ -55,7 +55,7 @@ std::vector<std::wstring> GetPreferredLanguages() {
     if (RegGetValueA(HKEY_CURRENT_USER,
                      "Control panel\\International\\User Profile", "Languages",
                      RRF_RT_REG_MULTI_SZ, NULL, str_buffer.data(),
-                    &buffer_size) != S_OK) {
+                     &buffer_size) != S_OK) {
       return languages;
     }
     for (int i = 0; i < buffer_size; i++) {

--- a/shell/platform/windows/system_utils.h
+++ b/shell/platform/windows/system_utils.h
@@ -31,6 +31,13 @@ struct LanguageInfo {
 std::vector<LanguageInfo> GetPreferredLanguageInfo(
     const WindowsRegistry& registry);
 
+// Retrieve the preferred languages from the registry.
+std::wstring GetPreferredLanguagesFromRegistry(
+    const WindowsRegistry& registry, ULONG buffer_size);
+
+// Retrieve the preferred languages from the MUI API.
+std::wstring GetPreferredLanguagesFromMUI();
+
 // Returns the list of user-preferred languages, in preference order.
 // The language names are as described at:
 // https://docs.microsoft.com/en-us/windows/win32/intl/language-names

--- a/shell/platform/windows/system_utils.h
+++ b/shell/platform/windows/system_utils.h
@@ -32,8 +32,8 @@ std::vector<LanguageInfo> GetPreferredLanguageInfo(
     const WindowsRegistry& registry);
 
 // Retrieve the preferred languages from the registry.
-std::wstring GetPreferredLanguagesFromRegistry(
-    const WindowsRegistry& registry, ULONG buffer_size);
+std::wstring GetPreferredLanguagesFromRegistry(const WindowsRegistry& registry,
+                                               ULONG buffer_size);
 
 // Retrieve the preferred languages from the MUI API.
 std::wstring GetPreferredLanguagesFromMUI();

--- a/shell/platform/windows/system_utils.h
+++ b/shell/platform/windows/system_utils.h
@@ -14,7 +14,7 @@
 
 // Registry key for user-preferred languages.
 constexpr const wchar_t kGetPreferredLanguageRegKey[] =
-  L"Control panel\\International\\User Profile";
+    L"Control panel\\International\\User Profile";
 constexpr const wchar_t kGetPreferredLanguageRegValue[] = L"Languages";
 
 namespace flutter {

--- a/shell/platform/windows/system_utils.h
+++ b/shell/platform/windows/system_utils.h
@@ -12,8 +12,10 @@
 
 #include "flutter/shell/platform/windows/windows_registry.h"
 
-#define WIN_REG_I18N_PROFILE L"Control panel\\International\\User Profile"
-#define WIN_REG_LANGUAGES L"Languages"
+// Registry key for user-preferred languages.
+constexpr const wchar_t kGetPreferredLanguageRegKey[] =
+  L"Control panel\\International\\User Profile";
+constexpr const wchar_t kGetPreferredLanguageRegValue[] = L"Languages";
 
 namespace flutter {
 

--- a/shell/platform/windows/system_utils.h
+++ b/shell/platform/windows/system_utils.h
@@ -10,6 +10,8 @@
 #include <string>
 #include <vector>
 
+#include "flutter/shell/platform/windows/windows_registry.h"
+
 namespace flutter {
 
 // Components of a system language/locale.

--- a/shell/platform/windows/system_utils.h
+++ b/shell/platform/windows/system_utils.h
@@ -23,12 +23,12 @@ struct LanguageInfo {
 
 // Returns the list of user-preferred languages, in preference order,
 // parsed into LanguageInfo structures.
-std::vector<LanguageInfo> GetPreferredLanguageInfo();
+std::vector<LanguageInfo> GetPreferredLanguageInfo(const WindowsRegistry& registry);
 
 // Returns the list of user-preferred languages, in preference order.
 // The language names are as described at:
 // https://docs.microsoft.com/en-us/windows/win32/intl/language-names
-std::vector<std::wstring> GetPreferredLanguages();
+std::vector<std::wstring> GetPreferredLanguages(const WindowsRegistry& registry);
 
 // Parses a Windows language name into its components.
 LanguageInfo ParseLanguageName(std::wstring language_name);

--- a/shell/platform/windows/system_utils.h
+++ b/shell/platform/windows/system_utils.h
@@ -12,6 +12,9 @@
 
 #include "flutter/shell/platform/windows/windows_registry.h"
 
+#define WIN_REG_I18N_PROFILE L"Control panel\\International\\User Profile"
+#define WIN_REG_LANGUAGES L"Languages"
+
 namespace flutter {
 
 // Components of a system language/locale.

--- a/shell/platform/windows/system_utils.h
+++ b/shell/platform/windows/system_utils.h
@@ -12,12 +12,12 @@
 
 #include "flutter/shell/platform/windows/windows_registry.h"
 
+namespace flutter {
+
 // Registry key for user-preferred languages.
 constexpr const wchar_t kGetPreferredLanguageRegKey[] =
     L"Control panel\\International\\User Profile";
 constexpr const wchar_t kGetPreferredLanguageRegValue[] = L"Languages";
-
-namespace flutter {
 
 // Components of a system language/locale.
 struct LanguageInfo {

--- a/shell/platform/windows/system_utils.h
+++ b/shell/platform/windows/system_utils.h
@@ -23,12 +23,14 @@ struct LanguageInfo {
 
 // Returns the list of user-preferred languages, in preference order,
 // parsed into LanguageInfo structures.
-std::vector<LanguageInfo> GetPreferredLanguageInfo(const WindowsRegistry& registry);
+std::vector<LanguageInfo> GetPreferredLanguageInfo(
+    const WindowsRegistry& registry);
 
 // Returns the list of user-preferred languages, in preference order.
 // The language names are as described at:
 // https://docs.microsoft.com/en-us/windows/win32/intl/language-names
-std::vector<std::wstring> GetPreferredLanguages(const WindowsRegistry& registry);
+std::vector<std::wstring> GetPreferredLanguages(
+    const WindowsRegistry& registry);
 
 // Parses a Windows language name into its components.
 LanguageInfo ParseLanguageName(std::wstring language_name);

--- a/shell/platform/windows/system_utils_unittests.cc
+++ b/shell/platform/windows/system_utils_unittests.cc
@@ -12,23 +12,30 @@ namespace flutter {
 namespace testing {
 
 class MockWindowsRegistry : public WindowsRegistry {
-  public:
-    virtual ~MockWindowsRegistry() {}
+public:
+  virtual ~MockWindowsRegistry() {}
 
-    virtual LSTATUS GetRegistryValue(HKEY hkey, LPCWSTR key, LPCWSTR value, DWORD flags, LPDWORD type, PVOID data, LPDWORD sizeData) const {
-      static const wchar_t* locales = L"en-US\0zh-Hans-CN\0ja\0zh-Hant-TW\0he\0\0";
-      static DWORD locales_len = 35;
-      if (data != NULL) {
-        if (*sizeData < locales_len) {
-          return ERROR_MORE_DATA;
-        }
-        memcpy(data, locales, locales_len * sizeof(wchar_t));
-        *sizeData = locales_len * sizeof(wchar_t);
-      } else if (sizeData != NULL) {
-        *sizeData = locales_len * sizeof(wchar_t);
+  virtual LSTATUS GetRegistryValue(HKEY hkey,
+                                   LPCWSTR key,
+                                   LPCWSTR value,
+                                   DWORD flags,
+                                   LPDWORD type,
+                                   PVOID data,
+                                   LPDWORD sizeData) const {
+    static const wchar_t* locales =
+        L"en-US\0zh-Hans-CN\0ja\0zh-Hant-TW\0he\0\0";
+    static DWORD locales_len = 35;
+    if (data != NULL) {
+      if (*sizeData < locales_len) {
+        return ERROR_MORE_DATA;
       }
-      return ERROR_SUCCESS;
+      memcpy(data, locales, locales_len * sizeof(wchar_t));
+      *sizeData = locales_len * sizeof(wchar_t);
+    } else if (sizeData != NULL) {
+      *sizeData = locales_len * sizeof(wchar_t);
     }
+    return ERROR_SUCCESS;
+  }
 };
 
 TEST(SystemUtils, GetPreferredLanguageInfo) {

--- a/shell/platform/windows/system_utils_unittests.cc
+++ b/shell/platform/windows/system_utils_unittests.cc
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <cstring>
 #include <cwchar>
 
 #include "flutter/shell/platform/windows/system_utils.h"
@@ -20,18 +21,19 @@ class MockWindowsRegistry : public WindowsRegistry {
                                    DWORD flags,
                                    LPDWORD type,
                                    PVOID data,
-                                   LPDWORD sizeData) const {
-    static const wchar_t* locales =
-        L"en-US\0zh-Hans-CN\0ja\0zh-Hant-TW\0he\0\0";
-    static DWORD locales_len = 35;
+                                   LPDWORD data_size) const {
+    using namespace std::string_literals;
+    static const std::wstring locales =
+        L"en-US\0zh-Hans-CN\0ja\0zh-Hant-TW\0he\0\0"s;
+    static DWORD locales_len = locales.size() * sizeof(wchar_t);
     if (data != nullptr) {
-      if (*sizeData < locales_len) {
+      if (*data_size < locales_len) {
         return ERROR_MORE_DATA;
       }
-      memcpy(data, locales, locales_len * sizeof(wchar_t));
-      *sizeData = locales_len * sizeof(wchar_t);
-    } else if (sizeData != NULL) {
-      *sizeData = locales_len * sizeof(wchar_t);
+      std::memcpy(data, locales.data(), locales_len);
+      *data_size = locales_len;
+    } else if (data_size != NULL) {
+      *data_size = locales_len;
     }
     return ERROR_SUCCESS;
   }

--- a/shell/platform/windows/system_utils_unittests.cc
+++ b/shell/platform/windows/system_utils_unittests.cc
@@ -4,7 +4,6 @@
 
 #include <cwchar>
 
-#include "flutter/fml/platform/win/wstring_conversion.h"
 #include "flutter/shell/platform/windows/system_utils.h"
 #include "gtest/gtest.h"
 

--- a/shell/platform/windows/system_utils_unittests.cc
+++ b/shell/platform/windows/system_utils_unittests.cc
@@ -58,7 +58,8 @@ TEST(SystemUtils, GetPreferredLanguages) {
   EXPECT_EQ(languages[0].size(), wcslen(languages[0].c_str()));
 
   // Test mock results
-  languages = GetPreferredLanguages(MockWindowsRegistry());
+  MockWindowsRegistry mock_registry;
+  languages = GetPreferredLanguages(mock_registry);
   ASSERT_EQ(languages.size(), 5);
   ASSERT_EQ(languages[0], std::wstring(L"en-US"));
   ASSERT_EQ(languages[1], std::wstring(L"zh-Hans-CN"));

--- a/shell/platform/windows/system_utils_unittests.cc
+++ b/shell/platform/windows/system_utils_unittests.cc
@@ -24,7 +24,7 @@ class MockWindowsRegistry : public WindowsRegistry {
     static const wchar_t* locales =
         L"en-US\0zh-Hans-CN\0ja\0zh-Hant-TW\0he\0\0";
     static DWORD locales_len = 35;
-    if (data != NULL) {
+    if (data != nullptr) {
       if (*sizeData < locales_len) {
         return ERROR_MORE_DATA;
       }

--- a/shell/platform/windows/system_utils_unittests.cc
+++ b/shell/platform/windows/system_utils_unittests.cc
@@ -12,7 +12,7 @@ namespace flutter {
 namespace testing {
 
 class MockWindowsRegistry : public WindowsRegistry {
-public:
+ public:
   virtual ~MockWindowsRegistry() {}
 
   virtual LSTATUS GetRegistryValue(HKEY hkey,

--- a/shell/platform/windows/windows_registry.cc
+++ b/shell/platform/windows/windows_registry.cc
@@ -6,7 +6,13 @@
 
 namespace flutter {
 
-LSTATUS WindowsRegistry::GetRegistryValue(HKEY hkey, LPCWSTR key, LPCWSTR value, DWORD flags, LPDWORD type, PVOID data, LPDWORD dataSize) const {
+LSTATUS WindowsRegistry::GetRegistryValue(HKEY hkey,
+                                          LPCWSTR key,
+                                          LPCWSTR value,
+                                          DWORD flags,
+                                          LPDWORD type,
+                                          PVOID data,
+                                          LPDWORD dataSize) const {
   return RegGetValue(hkey, key, value, flags, type, data, dataSize);
 }
 

--- a/shell/platform/windows/windows_registry.cc
+++ b/shell/platform/windows/windows_registry.cc
@@ -6,6 +6,8 @@
 
 namespace flutter {
 
+WindowsRegistry::WindowsRegistry() {}
+
 LSTATUS WindowsRegistry::GetRegistryValue(HKEY hkey,
                                           LPCWSTR key,
                                           LPCWSTR value,

--- a/shell/platform/windows/windows_registry.cc
+++ b/shell/platform/windows/windows_registry.cc
@@ -18,4 +18,4 @@ LSTATUS WindowsRegistry::GetRegistryValue(HKEY hkey,
 
 WindowsRegistry::~WindowsRegistry() {}
 
-}
+}  // namespace flutter

--- a/shell/platform/windows/windows_registry.cc
+++ b/shell/platform/windows/windows_registry.cc
@@ -1,0 +1,15 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/windows/windows_registry.h"
+
+namespace flutter {
+
+LSTATUS WindowsRegistry::GetRegistryValue(HKEY hkey, LPCSTR key, LPCSTR value, DWORD flags, LPDWORD type, PVOID data, LPDWORD dataSize) const {
+  return RegGetValueA(hkey, key, value, flags, type, data, dataSize);
+}
+
+WindowsRegistry::~WindowsRegistry() {}
+
+}

--- a/shell/platform/windows/windows_registry.cc
+++ b/shell/platform/windows/windows_registry.cc
@@ -6,8 +6,8 @@
 
 namespace flutter {
 
-LSTATUS WindowsRegistry::GetRegistryValue(HKEY hkey, LPCSTR key, LPCSTR value, DWORD flags, LPDWORD type, PVOID data, LPDWORD dataSize) const {
-  return RegGetValueA(hkey, key, value, flags, type, data, dataSize);
+LSTATUS WindowsRegistry::GetRegistryValue(HKEY hkey, LPCWSTR key, LPCWSTR value, DWORD flags, LPDWORD type, PVOID data, LPDWORD dataSize) const {
+  return RegGetValue(hkey, key, value, flags, type, data, dataSize);
 }
 
 WindowsRegistry::~WindowsRegistry() {}

--- a/shell/platform/windows/windows_registry.cc
+++ b/shell/platform/windows/windows_registry.cc
@@ -6,18 +6,14 @@
 
 namespace flutter {
 
-WindowsRegistry::WindowsRegistry() {}
-
 LSTATUS WindowsRegistry::GetRegistryValue(HKEY hkey,
                                           LPCWSTR key,
                                           LPCWSTR value,
                                           DWORD flags,
                                           LPDWORD type,
                                           PVOID data,
-                                          LPDWORD dataSize) const {
-  return RegGetValue(hkey, key, value, flags, type, data, dataSize);
+                                          LPDWORD data_size) const {
+  return RegGetValue(hkey, key, value, flags, type, data, data_size);
 }
-
-WindowsRegistry::~WindowsRegistry() {}
 
 }  // namespace flutter

--- a/shell/platform/windows/windows_registry.h
+++ b/shell/platform/windows/windows_registry.h
@@ -16,7 +16,7 @@ class WindowsRegistry {
   public:
     virtual ~WindowsRegistry();
 
-    virtual LSTATUS GetRegistryValue(HKEY hkey, LPCSTR key, LPCSTR value, DWORD flags, LPDWORD type, PVOID data, LPDWORD sizeData) const;
+    virtual LSTATUS GetRegistryValue(HKEY hkey, LPCWSTR key, LPCWSTR value, DWORD flags, LPDWORD type, PVOID data, LPDWORD sizeData) const;
   private:
 };
 

--- a/shell/platform/windows/windows_registry.h
+++ b/shell/platform/windows/windows_registry.h
@@ -13,7 +13,7 @@
 namespace flutter {
 
 class WindowsRegistry {
-public:
+ public:
   virtual ~WindowsRegistry();
 
   virtual LSTATUS GetRegistryValue(HKEY hkey,
@@ -23,9 +23,10 @@ public:
                                    LPDWORD type,
                                    PVOID data,
                                    LPDWORD sizeData) const;
-private:
+
+ private:
 };
 
-}
+}  // namespace flutter
 
 #endif

--- a/shell/platform/windows/windows_registry.h
+++ b/shell/platform/windows/windows_registry.h
@@ -1,0 +1,25 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_WINDOWS_REGISTRY_H_
+#define FLUTTER_SHELL_PLATFORM_WINDOWS_WINDOWS_REGISTRY_H_
+
+#include <Windows.h>
+
+#include <string>
+#include <vector>
+
+namespace flutter {
+
+class WindowsRegistry {
+  public:
+    virtual ~WindowsRegistry();
+
+    virtual LSTATUS GetRegistryValue(HKEY hkey, LPCSTR key, LPCSTR value, DWORD flags, LPDWORD type, PVOID data, LPDWORD sizeData) const;
+  private:
+};
+
+}
+
+#endif

--- a/shell/platform/windows/windows_registry.h
+++ b/shell/platform/windows/windows_registry.h
@@ -36,4 +36,4 @@ class WindowsRegistry {
 
 }  // namespace flutter
 
-#endif
+#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_WINDOWS_REGISTRY_H_

--- a/shell/platform/windows/windows_registry.h
+++ b/shell/platform/windows/windows_registry.h
@@ -13,11 +13,17 @@
 namespace flutter {
 
 class WindowsRegistry {
-  public:
-    virtual ~WindowsRegistry();
+public:
+  virtual ~WindowsRegistry();
 
-    virtual LSTATUS GetRegistryValue(HKEY hkey, LPCWSTR key, LPCWSTR value, DWORD flags, LPDWORD type, PVOID data, LPDWORD sizeData) const;
-  private:
+  virtual LSTATUS GetRegistryValue(HKEY hkey,
+                                   LPCWSTR key,
+                                   LPCWSTR value,
+                                   DWORD flags,
+                                   LPDWORD type,
+                                   PVOID data,
+                                   LPDWORD sizeData) const;
+private:
 };
 
 }

--- a/shell/platform/windows/windows_registry.h
+++ b/shell/platform/windows/windows_registry.h
@@ -7,13 +7,13 @@
 
 #include <Windows.h>
 
-#include <string>
-#include <vector>
+#include "flutter/fml/macros.h"
 
 namespace flutter {
 
 class WindowsRegistry {
  public:
+  explicit WindowsRegistry();
   virtual ~WindowsRegistry();
 
   virtual LSTATUS GetRegistryValue(HKEY hkey,
@@ -25,6 +25,7 @@ class WindowsRegistry {
                                    LPDWORD sizeData) const;
 
  private:
+  FML_DISALLOW_COPY_AND_ASSIGN(WindowsRegistry);
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/windows_registry.h
+++ b/shell/platform/windows/windows_registry.h
@@ -11,18 +11,24 @@
 
 namespace flutter {
 
+/// A utility class to encapsulate interaction with the Windows registry.
+/// By encapsulating this in a class, we can mock out this functionality
+/// for unit testing.
 class WindowsRegistry {
  public:
-  explicit WindowsRegistry();
-  virtual ~WindowsRegistry();
+  WindowsRegistry() = default;
+  virtual ~WindowsRegistry() = default;
 
+  // Parameters and return values of this method match those of RegGetValue
+  // See:
+  // https://learn.microsoft.com/windows/win32/api/winreg/nf-winreg-reggetvaluew
   virtual LSTATUS GetRegistryValue(HKEY hkey,
                                    LPCWSTR key,
                                    LPCWSTR value,
                                    DWORD flags,
                                    LPDWORD type,
                                    PVOID data,
-                                   LPDWORD sizeData) const;
+                                   LPDWORD data_size) const;
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(WindowsRegistry);


### PR DESCRIPTION
The function currently used in `GetPreferredLanguages` on Windows does not necessarily return all the languages included in the list of preferred languages set in the user's settings. By attempting to get these values from the registry first, we can obtain all these languages in order. These are eventually parsed and used as the `PlatformConfiguration`'s locales.

[flutter/flutter#112717](https://github.com/flutter/flutter/issues/112717)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
