### PR TITLE
[Windows] Move to Visual Studio 2019

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -109,7 +109,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '64d07cbd3d9fa0c15f06c8e24c3bdbf5a9a06329',
+  'src': 'https://github.com/loic-sharma/flutter-buildroot.git' + '@' + '5aab65c80488a2b59193d0661bed63e419c645ff',
 
    # Fuchsia compatibility
    #

--- a/DEPS
+++ b/DEPS
@@ -109,7 +109,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/loic-sharma/flutter-buildroot.git' + '@' + '5aab65c80488a2b59193d0661bed63e419c645ff',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '24bd842dde44696462562fb02f9e2226f9297d92',
 
    # Fuchsia compatibility
    #

--- a/shell/platform/windows/window_proc_delegate_manager_unittests.cc
+++ b/shell/platform/windows/window_proc_delegate_manager_unittests.cc
@@ -10,11 +10,18 @@ namespace testing {
 
 namespace {
 
+#ifdef _WIN32
+#define FLUTTER_NOINLINE __declspec(noinline)
+#else
+#define FLUTTER_NOINLINE __attribute__((noinline))
+#endif
+
 using TestWindowProcDelegate = std::function<std::optional<
     LRESULT>(HWND hwnd, UINT message, WPARAM wparam, LPARAM lparam)>;
 
 // A FlutterDesktopWindowProcCallback that forwards to a std::function provided
 // as user_data.
+FLUTTER_NOINLINE
 bool TestWindowProcCallback(HWND hwnd,
                             UINT message,
                             WPARAM wparam,

--- a/tools/dia_dll.py
+++ b/tools/dia_dll.py
@@ -44,7 +44,7 @@ def GetDiaDll():
   msvs_version = vs_toolchain.GetVisualStudioVersion()
 
   if bool(int(os.environ.get('DEPOT_TOOLS_WIN_TOOLCHAIN', '1'))):
-    dia_path = os.path.join(win_sdk_dir, '..', 'DIA SDK', 'bin', 'amd64')
+    dia_path = os.path.join(win_sdk_dir, '..', '..', 'DIA SDK', 'bin', 'amd64')
   else:
     if 'GYP_MSVS_OVERRIDE_PATH' in os.environ:
       vs_path = os.environ['GYP_MSVS_OVERRIDE_PATH']


### PR DESCRIPTION
Use Visual Studio 2019 to build the engine.

This is a requirement to roll ANGLE as it is affected by an STL bug if built using Visual Studio 2017: [angleproject#7693](https://bugs.chromium.org/p/angleproject/issues/detail?id=7693)

Depends on: https://github.com/flutter/buildroot/pull/632

Part of: https://github.com/flutter/flutter/issues/110948

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
