### PR TITLE
[Impeller] lift calculations out of per vertex iteration, use index buffer

### DIFF
--- a/impeller/entity/contents/text_contents.cc
+++ b/impeller/entity/contents/text_contents.cc
@@ -108,13 +108,13 @@ static bool CommonRender(const ContentContext& renderer,
   for (const auto& run : frame.GetRuns()) {
     count += run.GetGlyphPositions().size();
   }
-  
+
   vertex_builder.Reserve(count * 4);
   vertex_builder.ReserveIndices(count * 6);
 
   uint32_t offset = 0u;
   for (auto i = 0u; i < count; i++) {
-    for (const auto& index: indices) {
+    for (const auto& index : indices) {
       vertex_builder.AppendIndex(index + offset);
     }
     offset += 4;

--- a/impeller/entity/contents/text_contents.cc
+++ b/impeller/entity/contents/text_contents.cc
@@ -99,35 +99,57 @@ static bool CommonRender(const ContentContext& renderer,
   // sample from the glyph atlas.
 
   const std::vector<Point> unit_vertex_points = {
-      {0, 0}, {1, 0}, {0, 1}, {1, 0}, {0, 1}, {1, 1},
-  };
+      {0, 0}, {1, 0}, {0, 1}, {1, 1}};
+  const std::vector<uint32_t> indices = {0, 1, 2, 1, 2, 3};
 
   VertexBufferBuilder<typename VS::PerVertexData> vertex_builder;
+
+  size_t count = 0;
+  for (const auto& run : frame.GetRuns()) {
+    count += run.GetGlyphPositions().size();
+  }
+  
+  vertex_builder.Reserve(count * 4);
+  vertex_builder.ReserveIndices(count * 6);
+
+  uint32_t offset = 0u;
+  for (auto i = 0u; i < count; i++) {
+    for (const auto& index: indices) {
+      vertex_builder.AppendIndex(index + offset);
+    }
+    offset += 4;
+  }
+
   for (const auto& run : frame.GetRuns()) {
     auto font = run.GetFont();
-    auto glyph_size = ISize::Ceil(font.GetMetrics().GetBoundingBox().size);
+    auto glyph_size_ = ISize::Ceil(font.GetMetrics().GetBoundingBox().size);
+    auto glyph_size = Point{static_cast<Scalar>(glyph_size_.width),
+                            static_cast<Scalar>(glyph_size_.height)};
+    auto metrics_offset =
+        Point{font.GetMetrics().min_extent.x, font.GetMetrics().ascent};
+
     for (const auto& glyph_position : run.GetGlyphPositions()) {
       FontGlyphPair font_glyph_pair{font, glyph_position.glyph};
+      auto atlas_glyph_pos = atlas->FindFontGlyphPosition(font_glyph_pair);
+      if (!atlas_glyph_pos.has_value()) {
+        VALIDATION_LOG << "Could not find glyph position in the atlas.";
+        return false;
+      }
+
+      auto atlas_position =
+          atlas_glyph_pos->origin + Point{1 / atlas_glyph_pos->size.width,
+                                          1 / atlas_glyph_pos->size.height};
+      auto atlas_glyph_size =
+          Point{atlas_glyph_pos->size.width, atlas_glyph_pos->size.height};
+      auto offset_glyph_position = glyph_position.position + metrics_offset;
 
       for (const auto& point : unit_vertex_points) {
         typename VS::PerVertexData vtx;
         vtx.unit_vertex = point;
-
-        auto atlas_glyph_pos = atlas->FindFontGlyphPosition(font_glyph_pair);
-        if (!atlas_glyph_pos.has_value()) {
-          VALIDATION_LOG << "Could not find glyph position in the atlas.";
-          return false;
-        }
-        vtx.glyph_position =
-            glyph_position.position +
-            Point{font.GetMetrics().min_extent.x, font.GetMetrics().ascent};
-        vtx.glyph_size = Point{static_cast<Scalar>(glyph_size.width),
-                               static_cast<Scalar>(glyph_size.height)};
-        vtx.atlas_position =
-            atlas_glyph_pos->origin + Point{1 / atlas_glyph_pos->size.width,
-                                            1 / atlas_glyph_pos->size.height};
-        vtx.atlas_glyph_size =
-            Point{atlas_glyph_pos->size.width, atlas_glyph_pos->size.height};
+        vtx.glyph_position = offset_glyph_position;
+        vtx.glyph_size = glyph_size;
+        vtx.atlas_position = atlas_position;
+        vtx.atlas_glyph_size = atlas_glyph_size;
         if constexpr (std::is_same_v<TPipeline, GlyphAtlasPipeline>) {
           vtx.color_glyph =
               glyph_position.glyph.type == Glyph::Type::kBitmap ? 1.0 : 0.0;
@@ -178,7 +200,7 @@ bool TextContents::Render(const ContentContext& renderer,
   }
 
   // This TextContents may be for a frame that doesn't have color, but the
-  // lazy atlas for this scene alraedy does have color.
+  // lazy atlas for this scene already does have color.
   // Benchmarks currently show that creating two atlases per pass regresses
   // render time. This should get re-evaluated if we start caching atlases
   // between frames or get significantly faster at creating atlases, because

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -878,5 +878,27 @@ TEST_P(RendererTest, CanCreateCPUBackedTexture) {
   } while (dimension <= 8192);
 }
 
+TEST_P(RendererTest, VertexBufferBuilder) {
+  // Does not create index buffer if one is provided.
+  using VS = BoxFadeVertexShader;
+  VertexBufferBuilder<VS::PerVertexData> vertex_builder;
+  vertex_builder.SetLabel("Box");
+  vertex_builder.AddVertices({
+      {{100, 100, 0.0}, {0.0, 0.0}},  // 1
+      {{800, 100, 0.0}, {1.0, 0.0}},  // 2
+      {{800, 800, 0.0}, {1.0, 1.0}},  // 3
+      {{100, 800, 0.0}, {0.0, 1.0}},  // 4
+  });
+  vertex_builder.AppendIndex(0);
+  vertex_builder.AppendIndex(1);
+  vertex_builder.AppendIndex(2);
+  vertex_builder.AppendIndex(1);
+  vertex_builder.AppendIndex(2);
+  vertex_builder.AppendIndex(3);
+
+  ASSERT_EQ(vertex_builder.GetIndexCount(), 6u);
+  ASSERT_EQ(vertex_builder.GetVertexCount(), 4u);
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/impeller/renderer/vertex_buffer_builder.h
+++ b/impeller/renderer/vertex_buffer_builder.h
@@ -43,9 +43,15 @@ class VertexBufferBuilder {
 
   void Reserve(size_t count) { return vertices_.reserve(count); }
 
+  void ReserveIndices(size_t count) { return indices_.reserve(count); }
+
   bool HasVertices() const { return !vertices_.empty(); }
 
   size_t GetVertexCount() const { return vertices_.size(); }
+
+  size_t GetIndexCount() const {
+    return indices_.size() > 0 ? indices_.size() : vertices_.size();
+  }
 
   VertexBufferBuilder& AppendVertex(VertexType_ vertex) {
     vertices_.emplace_back(std::move(vertex));
@@ -58,6 +64,11 @@ class VertexBufferBuilder {
     for (auto& vertex : vertices) {
       vertices_.emplace_back(std::move(vertex));
     }
+    return *this;
+  }
+
+  VertexBufferBuilder& AppendIndex(IndexType_ index) {
+    indices_.emplace_back(index);
     return *this;
   }
 
@@ -81,9 +92,8 @@ class VertexBufferBuilder {
   };
 
  private:
-  // This is a placeholder till vertex de-duplication can be implemented. The
-  // current implementation is a very dumb placeholder.
   std::vector<VertexType> vertices_;
+  std::vector<IndexType> indices_;
   std::string label_;
 
   BufferView CreateVertexBufferView(HostBuffer& buffer) const {
@@ -106,6 +116,10 @@ class VertexBufferBuilder {
   }
 
   std::vector<IndexType> CreateIndexBuffer() const {
+    if (indices_.size() > 0) {
+      return indices_;
+    }
+
     // So dumb! We don't actually need an index buffer right now. But we will
     // once de-duplication is done. So assume this is always done.
     std::vector<IndexType> index_buffer;
@@ -135,8 +149,6 @@ class VertexBufferBuilder {
     }
     return buffer->AsBufferView();
   }
-
-  size_t GetIndexCount() const { return vertices_.size(); }
 };
 
 }  // namespace impeller


### PR DESCRIPTION
Attempt to reduce the amount of working being done during text drawing by lifting up per vertex calculations out of the inner loop. Additionally reduce the size of this buffer by using an index buffer.

https://github.com/flutter/flutter/issues/109949