### PR TITLE
Fix filter null exceptions

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/color_filter.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/color_filter.dart
@@ -81,16 +81,16 @@ class CkBlendModeColorFilter extends CkColorFilter {
   final ui.Color color;
   final ui.BlendMode blendMode;
 
-  static Float32List get _identityMatrix {
+  static Float32List identityTransform() => _identityTransform ?? _computeIdentityTransform();
+  static Float32List? _identityTransform;
+
+  static Float32List _computeIdentityTransform() {
     final Float32List result = Float32List(20);
     const List<int> translationIndices = <int>[0, 6, 12, 18];
-    for (int i = 0; i < 20; i++) {
-      if (translationIndices.contains(i)) {
-        result[i] = 1;
-      } else {
-        result[i] = 0;
-      }
+    for (final int i in translationIndices) {
+      result[i] = 1;
     }
+    _identityTransform = result;
     return result;
   }
 
@@ -99,7 +99,7 @@ class CkBlendModeColorFilter extends CkColorFilter {
     /// Return the identity matrix when the color opacity is 0. Replicates
     /// effect of applying no filter
     if (color.opacity == 0) {
-      return canvasKit.ColorFilter.MakeMatrix(_identityMatrix);
+      return canvasKit.ColorFilter.MakeMatrix(identityTransform());
     }
     final SkColorFilter? filter = canvasKit.ColorFilter.MakeBlend(
       toSharedSkColor1(color),

--- a/lib/web_ui/lib/src/engine/canvaskit/color_filter.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/color_filter.dart
@@ -81,7 +81,7 @@ class CkBlendModeColorFilter extends CkColorFilter {
   final ui.Color color;
   final ui.BlendMode blendMode;
 
-  static Float32List identityTransform() => _identityTransform ?? _computeIdentityTransform();
+  static Float32List get identityTransform => _identityTransform ?? _computeIdentityTransform();
   static Float32List? _identityTransform;
 
   static Float32List _computeIdentityTransform() {
@@ -99,7 +99,7 @@ class CkBlendModeColorFilter extends CkColorFilter {
     /// Return the identity matrix when the color opacity is 0. Replicates
     /// effect of applying no filter
     if (color.opacity == 0) {
-      return canvasKit.ColorFilter.MakeMatrix(identityTransform());
+      return canvasKit.ColorFilter.MakeMatrix(identityTransform);
     }
     final SkColorFilter? filter = canvasKit.ColorFilter.MakeBlend(
       toSharedSkColor1(color),

--- a/lib/web_ui/lib/src/engine/canvaskit/color_filter.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/color_filter.dart
@@ -81,7 +81,7 @@ class CkBlendModeColorFilter extends CkColorFilter {
   final ui.Color color;
   final ui.BlendMode blendMode;
 
-  Float32List get _identityMatrix {
+  static Float32List get _identityMatrix {
     final Float32List result = Float32List(20);
     const List<int> translationIndices = <int>[0, 6, 12, 18];
     for (int i = 0; i < 20; i++) {

--- a/lib/web_ui/lib/src/engine/canvaskit/color_filter.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/color_filter.dart
@@ -96,9 +96,8 @@ class CkBlendModeColorFilter extends CkColorFilter {
 
   @override
   SkColorFilter _initRawColorFilter() {
-
-    /// Return the identity matrix when the color opacity is 0. Mimics behavior
-    /// of a color filter with an "invisible" color 
+    /// Return the identity matrix when the color opacity is 0. Replicates
+    /// effect of applying no filter
     if (color.opacity == 0) {
       return canvasKit.ColorFilter.MakeMatrix(_identityMatrix);
     }

--- a/lib/web_ui/lib/src/engine/canvaskit/color_filter.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/color_filter.dart
@@ -81,8 +81,27 @@ class CkBlendModeColorFilter extends CkColorFilter {
   final ui.Color color;
   final ui.BlendMode blendMode;
 
+  Float32List get _identityMatrix {
+    final Float32List result = Float32List(20);
+    const List<int> translationIndices = <int>[0, 6, 12, 18];
+    for (int i = 0; i < 20; i++) {
+      if (translationIndices.contains(i)) {
+        result[i] = 1;
+      } else {
+        result[i] = 0;
+      }
+    }
+    return result;
+  }
+
   @override
   SkColorFilter _initRawColorFilter() {
+
+    /// Return the identity matrix when the color opacity is 0. Mimics behavior
+    /// of a color filter with an "invisible" color 
+    if (color.opacity == 0) {
+      return canvasKit.ColorFilter.MakeMatrix(_identityMatrix);
+    }
     final SkColorFilter? filter = canvasKit.ColorFilter.MakeBlend(
       toSharedSkColor1(color),
       toSkBlendMode(blendMode),

--- a/lib/web_ui/lib/src/engine/canvaskit/image_filter.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image_filter.dart
@@ -4,7 +4,7 @@
 
 import 'dart:typed_data';
 
-import 'package:ui/src/engine.dart';
+import 'package:ui/src/engine/vector_math.dart';
 import 'package:ui/ui.dart' as ui;
 
 import '../util.dart';

--- a/lib/web_ui/lib/src/engine/canvaskit/image_filter.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image_filter.dart
@@ -4,6 +4,7 @@
 
 import 'dart:typed_data';
 
+import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' as ui;
 
 import '../util.dart';
@@ -104,6 +105,15 @@ class _CkBlurImageFilter extends CkImageFilter {
 
   @override
   SkImageFilter _initSkiaObject() {
+    /// Return the identity matrix when both sigmaX and sigmaY are 0. Replicates
+    /// effect of applying no filter
+    if (sigmaX == 0 && sigmaY == 0) {
+      return canvasKit.ImageFilter.MakeMatrixTransform(
+        toSkMatrixFromFloat64(Matrix4.identity().toFloat64()),
+        toSkFilterOptions(ui.FilterQuality.none),
+        null
+        );
+      }
     return canvasKit.ImageFilter.MakeBlur(
       sigmaX,
       sigmaY,

--- a/lib/web_ui/lib/src/engine/canvaskit/image_filter.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image_filter.dart
@@ -109,11 +109,11 @@ class _CkBlurImageFilter extends CkImageFilter {
     /// effect of applying no filter
     if (sigmaX == 0 && sigmaY == 0) {
       return canvasKit.ImageFilter.MakeMatrixTransform(
-        toSkMatrixFromFloat64(Matrix4.identity().toFloat64()),
+        toSkMatrixFromFloat32(Matrix4.identity().storage),
         toSkFilterOptions(ui.FilterQuality.none),
         null
-        );
-      }
+      );
+    }
     return canvasKit.ImageFilter.MakeBlur(
       sigmaX,
       sigmaY,

--- a/lib/web_ui/test/canvaskit/color_filter_golden_test.dart
+++ b/lib/web_ui/test/canvaskit/color_filter_golden_test.dart
@@ -126,10 +126,7 @@ void testMain() {
 
       await matchSceneGolden('canvaskit_inverse_colormatrix.png', builder.build(), region: region);
     });
-    test('ColorFilter color with zero opacity', () async {
-      // draw a circle, apply ColorFilter with zero opacity color, see that 
-      // the circle is still the same color 
-
+    test('ColorFilter color with 0 opacity', () async {
       final LayerSceneBuilder builder = LayerSceneBuilder();
       builder.pushOffset(0,0);
       final CkPictureRecorder recorder = CkPictureRecorder();
@@ -159,8 +156,6 @@ void testMain() {
       builder.addPicture(ui.Offset.zero, redCircle2);
 
       await matchSceneGolden('canvaskit_translucent_colorfilter.png', builder.build(), region: region);
-
-
     });
     // TODO(hterkelsen): https://github.com/flutter/flutter/issues/71520
   }, skip: isSafari || isFirefox);

--- a/lib/web_ui/test/canvaskit/color_filter_golden_test.dart
+++ b/lib/web_ui/test/canvaskit/color_filter_golden_test.dart
@@ -126,6 +126,42 @@ void testMain() {
 
       await matchSceneGolden('canvaskit_inverse_colormatrix.png', builder.build(), region: region);
     });
+    test('ColorFilter color with zero opacity', () async {
+      // draw a circle, apply ColorFilter with zero opacity color, see that 
+      // the circle is still the same color 
+
+      final LayerSceneBuilder builder = LayerSceneBuilder();
+      builder.pushOffset(0,0);
+      final CkPictureRecorder recorder = CkPictureRecorder();
+      final CkCanvas canvas = recorder.beginRecording(region);
+
+      canvas.drawCircle(
+        const ui.Offset(75, 125),
+        50,
+        CkPaint()..color = const ui.Color.fromARGB(255, 255, 0, 0),
+      );
+      final CkPicture redCircle1 = recorder.endRecording();
+      builder.addPicture(ui.Offset.zero, redCircle1);
+
+      builder.pushColorFilter(ui.ColorFilter.mode(const ui.Color(0x00000000).withOpacity(0), ui.BlendMode.srcOver));
+
+      // Draw another red circle and apply it to the scene.
+      // This one should also be red with the color filter doing nothing
+      final CkPictureRecorder recorder2 = CkPictureRecorder();
+      final CkCanvas canvas2 = recorder2.beginRecording(region);
+      canvas2.drawCircle(
+        const ui.Offset(425, 125),
+        50,
+        CkPaint()..color = const ui.Color.fromARGB(255, 255, 0, 0),
+      );
+      final CkPicture redCircle2 = recorder2.endRecording();
+
+      builder.addPicture(ui.Offset.zero, redCircle2);
+
+      await matchSceneGolden('canvaskit_translucent_colorfilter.png', builder.build(), region: region);
+
+
+    });
     // TODO(hterkelsen): https://github.com/flutter/flutter/issues/71520
   }, skip: isSafari || isFirefox);
 }

--- a/lib/web_ui/test/canvaskit/color_filter_golden_test.dart
+++ b/lib/web_ui/test/canvaskit/color_filter_golden_test.dart
@@ -126,6 +126,7 @@ void testMain() {
 
       await matchSceneGolden('canvaskit_inverse_colormatrix.png', builder.build(), region: region);
     });
+
     test('ColorFilter color with 0 opacity', () async {
       final LayerSceneBuilder builder = LayerSceneBuilder();
       builder.pushOffset(0,0);
@@ -155,7 +156,7 @@ void testMain() {
 
       builder.addPicture(ui.Offset.zero, redCircle2);
 
-      await matchSceneGolden('canvaskit_translucent_colorfilter.png', builder.build(), region: region);
+      await matchSceneGolden('canvaskit_transparent_colorfilter.png', builder.build(), region: region);
     });
     // TODO(hterkelsen): https://github.com/flutter/flutter/issues/71520
   }, skip: isSafari || isFirefox);

--- a/lib/web_ui/test/canvaskit/filter_test.dart
+++ b/lib/web_ui/test/canvaskit/filter_test.dart
@@ -123,7 +123,7 @@ void testMain() {
 
       builder.addPicture(ui.Offset.zero, redCircle2);
 
-      await matchSceneGolden('canvaskit_imageFilter.png', builder.build(), region: region);
+      await matchSceneGolden('canvaskit_zero_sigma_blur.png', builder.build(), region: region);
     });
   });
 

--- a/lib/web_ui/test/canvaskit/filter_test.dart
+++ b/lib/web_ui/test/canvaskit/filter_test.dart
@@ -94,7 +94,7 @@ void testMain() {
       expect(imageFilter, isNotNull);
 
       const ui.Rect region = ui.Rect.fromLTRB(0, 0, 500, 250);
-      
+
       final LayerSceneBuilder builder = LayerSceneBuilder();
       builder.pushOffset(0,0);
       final CkPictureRecorder recorder = CkPictureRecorder();

--- a/lib/web_ui/test/canvaskit/filter_test.dart
+++ b/lib/web_ui/test/canvaskit/filter_test.dart
@@ -89,6 +89,42 @@ void testMain() {
       expect((paint.imageFilter! as ManagedSkiaObject<Object>).skiaObject, same(skiaFilter));
     });
 
+    test('does not throw for both sigmaX and sigmaY set to 0', () async {
+      final CkImageFilter imageFilter = CkImageFilter.blur(sigmaX: 0, sigmaY: 0, tileMode: ui.TileMode.clamp);
+      expect(imageFilter, isNotNull);
+
+      const ui.Rect region = ui.Rect.fromLTRB(0, 0, 500, 250);
+      
+      final LayerSceneBuilder builder = LayerSceneBuilder();
+      builder.pushOffset(0,0);
+      final CkPictureRecorder recorder = CkPictureRecorder();
+      final CkCanvas canvas = recorder.beginRecording(region);
+
+      canvas.drawCircle(
+        const ui.Offset(75, 125),
+        50,
+        CkPaint()..color = const ui.Color.fromARGB(255, 255, 0, 0),
+      );
+      final CkPicture redCircle1 = recorder.endRecording();
+      builder.addPicture(ui.Offset.zero, redCircle1);
+
+      builder.pushImageFilter(imageFilter);
+
+      // Draw another red circle and apply it to the scene.
+      // This one should also be red with the image filter doing nothing
+      final CkPictureRecorder recorder2 = CkPictureRecorder();
+      final CkCanvas canvas2 = recorder2.beginRecording(region);
+      canvas2.drawCircle(
+        const ui.Offset(425, 125),
+        50,
+        CkPaint()..color = const ui.Color.fromARGB(255, 255, 0, 0),
+      );
+      final CkPicture redCircle2 = recorder2.endRecording();
+
+      builder.addPicture(ui.Offset.zero, redCircle2);
+
+      await matchSceneGolden('canvaskit_imageFilter.png', builder.build(), region: region);
+    });
   });
 
   group('MaskFilter', () {


### PR DESCRIPTION
two issues fixed for canvaskit: 

1) ColorFilter.mode with a color opacity of zero would throw 
2) ImageFilter.blur with sigmaX and sigmaY of zero would throw 

fixed by returning the identity matrix in both cases. Mimics NOP behavior, where the filter does nothing. 

This is a temporary fix. Will create a better performing fix to handle the above listed edge cases so that we don't have to do the extra work of returning the identity matrix

see https://github.com/flutter/flutter/issues/89433

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.