### PR TITLE
Avoid using non-UTF-8 encoded argv more often

### DIFF
--- a/benchmarking/benchmarking.cc
+++ b/benchmarking/benchmarking.cc
@@ -14,7 +14,7 @@ namespace benchmarking {
 int Main(int argc, char** argv) {
   fml::InstallCrashHandler();
 #if !defined(FML_OS_ANDROID)
-  fml::CommandLine cmd = fml::CommandLineFromArgcArgv(argc, argv);
+  fml::CommandLine cmd = fml::CommandLineFromPlatformOrArgcArgv(argc, argv);
   std::string icudtl_path =
       cmd.GetOptionValueWithDefault("icu-data-file-path", "icudtl.dat");
   fml::icu::InitializeICU(icudtl_path);

--- a/flow/flow_run_all_unittests.cc
+++ b/flow/flow_run_all_unittests.cc
@@ -13,7 +13,7 @@
 int main(int argc, char** argv) {
   fml::InstallCrashHandler();
   testing::InitGoogleTest(&argc, argv);
-  fml::CommandLine cmd = fml::CommandLineFromArgcArgv(argc, argv);
+  fml::CommandLine cmd = fml::CommandLineFromPlatformOrArgcArgv(argc, argv);
 
 #if defined(OS_FUCHSIA)
   flutter::SetGoldenDir(cmd.GetOptionValueWithDefault(

--- a/fml/command_line.h
+++ b/fml/command_line.h
@@ -223,7 +223,14 @@ inline CommandLine CommandLineFromIteratorsWithArgv0(const std::string& argv0,
 }
 
 // Builds a |CommandLine| from the usual argc/argv.
+//
+// First checks if CommandLineFromPlatform returns a value, to avoid using an
+// argv that is not provided as UTF-8.
 inline CommandLine CommandLineFromArgcArgv(int argc, const char* const* argv) {
+  auto command_line = CommandLineFromPlatform();
+  if (command_line.has_value()) {
+    return *command_line;
+  }
   return CommandLineFromIterators(argv, argv + argc);
 }
 

--- a/fml/command_line.h
+++ b/fml/command_line.h
@@ -222,16 +222,30 @@ inline CommandLine CommandLineFromIteratorsWithArgv0(const std::string& argv0,
   return builder.Build();
 }
 
-// Builds a |CommandLine| from the usual argc/argv.
+// Builds a |CommandLine| by obtaining the arguments of the process using host
+// platform APIs. The resulting |CommandLine| will be encoded in UTF-8.
+// Returns an empty optional if this is not supported on the host platform.
 //
-// First checks if CommandLineFromPlatform returns a value, to avoid using an
-// argv that is not provided as UTF-8.
+// This can be useful on platforms where argv may not be provided as UTF-8.
+std::optional<CommandLine> CommandLineFromPlatform();
+
+// Builds a |CommandLine| from the usual argc/argv.
 inline CommandLine CommandLineFromArgcArgv(int argc, const char* const* argv) {
+  return CommandLineFromIterators(argv, argv + argc);
+}
+
+// Builds a |CommandLine| by first trying the platform specific implementation,
+// and then falling back to the argc/argv.
+//
+// If the platform provides a special way of getting arguments, this method may
+// discard the values passed in to argc/argv.
+inline CommandLine CommandLineFromPlatformOrArgcArgv(int argc,
+                                                     const char* const* argv) {
   auto command_line = CommandLineFromPlatform();
   if (command_line.has_value()) {
     return *command_line;
   }
-  return CommandLineFromIterators(argv, argv + argc);
+  return CommandLineFromArgcArgv(argc, argv);
 }
 
 // Builds a |CommandLine| from an initializer list of |std::string|s or things
@@ -246,13 +260,6 @@ inline CommandLine CommandLineFromInitializerList(
 // |CommandLine| into a vector of argument strings according to the rules
 // outlined at the top of this file.
 std::vector<std::string> CommandLineToArgv(const CommandLine& command_line);
-
-// Builds a |CommandLine| by obtaining the arguments of the process using host
-// platform APIs. The resulting |CommandLine| will be encoded in UTF-8.
-// Returns an empty optional if this is not supported on the host platform.
-//
-// This can be useful on platforms where argv may not be provided as UTF-8.
-std::optional<CommandLine> CommandLineFromPlatform();
 
 }  // namespace fml
 

--- a/impeller/blobcat/blobcat_main.cc
+++ b/impeller/blobcat/blobcat_main.cc
@@ -49,7 +49,7 @@ bool Main(const fml::CommandLine& command_line) {
 }  // namespace impeller
 
 int main(int argc, char const* argv[]) {
-  return impeller::Main(fml::CommandLineFromArgcArgv(argc, argv))
+  return impeller::Main(fml::CommandLineFromPlatformOrArgcArgv(argc, argv))
              ? EXIT_SUCCESS
              : EXIT_FAILURE;
 }

--- a/impeller/compiler/impellerc_main.cc
+++ b/impeller/compiler/impellerc_main.cc
@@ -226,7 +226,8 @@ bool Main(const fml::CommandLine& command_line) {
 }  // namespace impeller
 
 int main(int argc, char const* argv[]) {
-  return impeller::compiler::Main(fml::CommandLineFromArgcArgv(argc, argv))
+  return impeller::compiler::Main(
+             fml::CommandLineFromPlatformOrArgcArgv(argc, argv))
              ? EXIT_SUCCESS
              : EXIT_FAILURE;
 }

--- a/impeller/compiler/impellerc_main.cc
+++ b/impeller/compiler/impellerc_main.cc
@@ -226,9 +226,7 @@ bool Main(const fml::CommandLine& command_line) {
 }  // namespace impeller
 
 int main(int argc, char const* argv[]) {
-  std::optional<fml::CommandLine> command_line = fml::CommandLineFromPlatform();
-  if (!command_line) {
-    command_line = fml::CommandLineFromArgcArgv(argc, argv);
-  }
-  return impeller::compiler::Main(*command_line) ? EXIT_SUCCESS : EXIT_FAILURE;
+  return impeller::compiler::Main(fml::CommandLineFromArgcArgv(argc, argv))
+             ? EXIT_SUCCESS
+             : EXIT_FAILURE;
 }

--- a/shell/testing/tester_main.cc
+++ b/shell/testing/tester_main.cc
@@ -372,7 +372,7 @@ int main(int argc, char* argv[]) {
   dart::bin::SetExecutableName(argv[0]);
   dart::bin::SetExecutableArguments(argc - 1, argv);
 
-  auto command_line = fml::CommandLineFromArgcArgv(argc, argv);
+  auto command_line = fml::CommandLineFromPlatformOrArgcArgv(argc, argv);
 
   if (command_line.HasOption(flutter::FlagForSwitch(flutter::Switch::Help))) {
     flutter::PrintUsage("flutter_tester");

--- a/testing/run_all_unittests.cc
+++ b/testing/run_all_unittests.cc
@@ -18,7 +18,7 @@
 #endif  // FML_OS_IOS
 
 std::optional<fml::TimeDelta> GetTestTimeoutFromArgs(int argc, char** argv) {
-  const auto command_line = fml::CommandLineFromArgcArgv(argc, argv);
+  const auto command_line = fml::CommandLineFromPlatformOrArgcArgv(argc, argv);
 
   std::string timeout_seconds;
   if (!command_line.GetOptionValue("timeout", &timeout_seconds)) {

--- a/third_party/txt/benchmarks/txt_run_all_benchmarks.cc
+++ b/third_party/txt/benchmarks/txt_run_all_benchmarks.cc
@@ -23,7 +23,7 @@
 // We will use a custom main to allow custom font directories for consistency.
 int main(int argc, char** argv) {
   ::benchmark::Initialize(&argc, argv);
-  fml::CommandLine cmd = fml::CommandLineFromArgcArgv(argc, argv);
+  fml::CommandLine cmd = fml::CommandLineFromPlatformOrArgcArgv(argc, argv);
   txt::SetCommandLine(cmd);
   txt::SetFontDir(flutter::testing::GetFixturesPath());
   if (txt::GetFontDir().length() <= 0) {

--- a/third_party/txt/tests/txt_run_all_unittests.cc
+++ b/third_party/txt/tests/txt_run_all_unittests.cc
@@ -26,7 +26,7 @@
 
 int main(int argc, char** argv) {
   fml::InstallCrashHandler();
-  fml::CommandLine cmd = fml::CommandLineFromArgcArgv(argc, argv);
+  fml::CommandLine cmd = fml::CommandLineFromPlatformOrArgcArgv(argc, argv);
   txt::SetCommandLine(cmd);
   txt::SetFontDir(flutter::testing::GetFixturesPath());
   if (txt::GetFontDir().length() <= 0) {


### PR DESCRIPTION
Should fix https://github.com/flutter/flutter/issues/112819

I have not tested this on a windows machine though. @sealesj would you be able to kick off a LED run with this patched in for one of your failing windows tests?