### PR TITLE
[macOS] Fix redundancy in VoiceOver announcements for groups with `IconButton`.

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
@@ -178,7 +178,9 @@ TEST_F(FlutterEngineTest, CanToggleAccessibility) {
   EXPECT_EQ([engine.viewController.flutterView.accessibilityChildren count], 1u);
   NSAccessibilityElement* native_root = engine.viewController.flutterView.accessibilityChildren[0];
   std::string root_label = [native_root.accessibilityLabel UTF8String];
-  EXPECT_TRUE(root_label == "root");
+  EXPECT_TRUE(root_label == "");
+  std::string root_title = [native_root.accessibilityTitle UTF8String];
+  EXPECT_TRUE(root_title == "root");
   EXPECT_EQ(native_root.accessibilityRole, NSAccessibilityGroupRole);
   EXPECT_EQ([native_root.accessibilityChildren count], 1u);
   NSAccessibilityElement* native_child1 = native_root.accessibilityChildren[0];

--- a/third_party/accessibility/ax/platform/ax_platform_node_base.cc
+++ b/third_party/accessibility/ax/platform/ax_platform_node_base.cc
@@ -901,6 +901,18 @@ bool AXPlatformNodeBase::IsChildOfLeaf() const {
   return delegate_ && delegate_->IsChildOfLeaf();
 }
 
+ax::mojom::NameFrom AXPlatformNodeBase::GetNameFrom() const {
+  if (!delegate_)
+    return ax::mojom::NameFrom::kNone;
+  return delegate_->GetNameFrom();
+}
+
+bool AXPlatformNodeBase::HasNameFromOtherElement() const {
+  ax::mojom::NameFrom nameFrom = GetNameFrom();
+  return nameFrom == ax::mojom::NameFrom::kCaption ||
+         nameFrom == ax::mojom::NameFrom::kRelatedElement;
+}
+
 bool AXPlatformNodeBase::IsInvisibleOrIgnored() const {
   return GetData().IsInvisibleOrIgnored();
 }

--- a/third_party/accessibility/ax/platform/ax_platform_node_base.h
+++ b/third_party/accessibility/ax/platform/ax_platform_node_base.h
@@ -146,6 +146,10 @@ class AX_EXPORT AXPlatformNodeBase : public AXPlatformNode {
   bool GetIntListAttribute(ax::mojom::IntListAttribute attribute,
                            std::vector<int32_t>* value) const;
 
+  ax::mojom::NameFrom GetNameFrom() const;
+
+  bool HasNameFromOtherElement() const;
+
   // Returns the selection container if inside one.
   AXPlatformNodeBase* GetSelectionContainer() const;
 

--- a/third_party/accessibility/ax/platform/ax_platform_node_delegate.h
+++ b/third_party/accessibility/ax/platform/ax_platform_node_delegate.h
@@ -168,6 +168,7 @@ class AX_EXPORT AXPlatformNodeDelegate {
 
   // Returns the accessible name for the node.
   virtual std::string GetName() const = 0;
+  virtual ax::mojom::NameFrom GetNameFrom() const = 0;
 
   // Returns the text of this node and represent the text of descendant nodes
   // with a special character in place of every embedded object. This represents

--- a/third_party/accessibility/ax/platform/ax_platform_node_delegate_base.cc
+++ b/third_party/accessibility/ax/platform/ax_platform_node_delegate_base.cc
@@ -242,6 +242,10 @@ std::string AXPlatformNodeDelegateBase::GetName() const {
   return GetData().GetStringAttribute(ax::mojom::StringAttribute::kName);
 }
 
+ax::mojom::NameFrom AXPlatformNodeDelegateBase::GetNameFrom() const {
+  return GetData().GetNameFrom();
+}
+
 std::u16string AXPlatformNodeDelegateBase::GetHypertext() const {
   return std::u16string();
 }

--- a/third_party/accessibility/ax/platform/ax_platform_node_delegate_base.h
+++ b/third_party/accessibility/ax/platform/ax_platform_node_delegate_base.h
@@ -99,6 +99,7 @@ class AX_EXPORT AXPlatformNodeDelegateBase : public AXPlatformNodeDelegate {
   std::unique_ptr<AXPlatformNodeDelegate::ChildIterator> ChildrenEnd() override;
 
   std::string GetName() const override;
+  ax::mojom::NameFrom GetNameFrom() const override;
   std::u16string GetHypertext() const override;
   bool SetHypertextSelection(int start_offset, int end_offset) override;
   TextAttributeMap ComputeTextAttributeMap(


### PR DESCRIPTION
[VoiceOver repeats same text or label property text of Semantics Widget on MacOS 12.5.1](https://github.com/flutter/flutter/issues/111094) when `AXTitleInternal` is called twice from `accessibilityTitle` and `accessibilityLabel`. 

**Demo**

https://user-images.githubusercontent.com/44445638/193924691-1e74891b-4999-4fda-bde1-a69438fb2de9.mov

_Before patch_
```obj-c
- (NSString*)accessibilityLabel {
  // accessibilityLabel is "a short description of the accessibility element",
  // and accessibilityTitle is "the title of the accessibility element"; at
  // least in Chromium, the title usually is a short description of the element,
  // so it also functions as a label.
  return [self AXTitleInternal];
}

- (NSString*)accessibilityTitle {
  return [self AXTitleInternal];
}
```

Note that this particular issue can be solved by returning an empty string from `accessibilityLabel` like so.
```obj-c
- (NSString*)accessibilityLabel {
  return @"";
}
```

Neither break the existing unit tests. The ladder is a much less complicated PR.

_I'm wondering which approach we should go with._

#### Fixes https://github.com/flutter/flutter/issues/111094

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.