### PR TITLE
[macOS] Fix redundancy in VoiceOver announcements for groups with `IconButton`.

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
@@ -178,7 +178,9 @@ TEST_F(FlutterEngineTest, CanToggleAccessibility) {
   EXPECT_EQ([engine.viewController.flutterView.accessibilityChildren count], 1u);
   NSAccessibilityElement* native_root = engine.viewController.flutterView.accessibilityChildren[0];
   std::string root_label = [native_root.accessibilityLabel UTF8String];
-  EXPECT_TRUE(root_label == "root");
+  EXPECT_TRUE(root_label == "");
+  std::string root_title = [native_root.accessibilityTitle UTF8String];
+  EXPECT_TRUE(root_title == "root");
   EXPECT_EQ(native_root.accessibilityRole, NSAccessibilityGroupRole);
   EXPECT_EQ([native_root.accessibilityChildren count], 1u);
   NSAccessibilityElement* native_child1 = native_root.accessibilityChildren[0];

--- a/third_party/accessibility/ax/platform/ax_platform_node_mac.mm
+++ b/third_party/accessibility/ax/platform/ax_platform_node_mac.mm
@@ -767,7 +767,7 @@ bool AlsoUseShowMenuActionForDefaultAction(const ui::AXNodeData& data) {
   // and accessibilityTitle is "the title of the accessibility element"; at
   // least in Chromium, the title usually is a short description of the element,
   // so it also functions as a label.
-  return [self AXTitleInternal];
+  return @"";
 }
 
 - (NSString*)accessibilityTitle {


### PR DESCRIPTION
## This patch is different than https://github.com/flutter/engine/pull/36599 as it returns an empty string.

[VoiceOver repeats same text or label property text of Semantics Widget on MacOS 12.5.1](https://github.com/flutter/flutter/issues/111094) when `AXTitleInternal` is called twice from `accessibilityTitle` and `accessibilityLabel`. 

**Demo**

https://user-images.githubusercontent.com/44445638/193924691-1e74891b-4999-4fda-bde1-a69438fb2de9.mov

#### Fixes https://github.com/flutter/flutter/issues/111094

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.