### PR TITLE
Revert "[Windows] Move to Visual Studio 2019"

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -109,7 +109,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '24bd842dde44696462562fb02f9e2226f9297d92',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '64d07cbd3d9fa0c15f06c8e24c3bdbf5a9a06329',
 
    # Fuchsia compatibility
    #

--- a/shell/platform/windows/window_proc_delegate_manager_unittests.cc
+++ b/shell/platform/windows/window_proc_delegate_manager_unittests.cc
@@ -10,18 +10,11 @@ namespace testing {
 
 namespace {
 
-#ifdef _WIN32
-#define FLUTTER_NOINLINE __declspec(noinline)
-#else
-#define FLUTTER_NOINLINE __attribute__((noinline))
-#endif
-
 using TestWindowProcDelegate = std::function<std::optional<
     LRESULT>(HWND hwnd, UINT message, WPARAM wparam, LPARAM lparam)>;
 
 // A FlutterDesktopWindowProcCallback that forwards to a std::function provided
 // as user_data.
-FLUTTER_NOINLINE
 bool TestWindowProcCallback(HWND hwnd,
                             UINT message,
                             WPARAM wparam,

--- a/tools/dia_dll.py
+++ b/tools/dia_dll.py
@@ -44,7 +44,7 @@ def GetDiaDll():
   msvs_version = vs_toolchain.GetVisualStudioVersion()
 
   if bool(int(os.environ.get('DEPOT_TOOLS_WIN_TOOLCHAIN', '1'))):
-    dia_path = os.path.join(win_sdk_dir, '..', '..', 'DIA SDK', 'bin', 'amd64')
+    dia_path = os.path.join(win_sdk_dir, '..', 'DIA SDK', 'bin', 'amd64')
   else:
     if 'GYP_MSVS_OVERRIDE_PATH' in os.environ:
       vs_path = os.environ['GYP_MSVS_OVERRIDE_PATH']


### PR DESCRIPTION
Reverts flutter/engine#36538
as it appears to have broken the tree: https://discord.com/channels/608014603317936148/613398423093116959/1026995839278792754

Failure:
1. https://ci.chromium.org/ui/p/flutter/builders/prod/Windows%20platform_channel_sample_test_windows/1804/overview
2. https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8801195816777587809/+/u/run_platform_channel_sample_test_windows/test_stdout

<details>
<summary>Logs...</summary>

```
[platform_channel_sample_test_windows] [STDOUT] stdout: [ +127 ms] executing: C:\b\s\w\ir\x\w\recipe_cleanup\tmpr1awka7t\flutter sdk\bin\cache\dart-sdk\bin\dart.exe C:\b\s\w\ir\x\w\recipe_cleanup\tmpr1awka7t\flutter sdk\examples\platform_channel\test_driver\button_tap_test.dart -rexpanded
[platform_channel_sample_test_windows] [STDOUT] stdout: [+3014 ms] 00:00 [32m+0[0m: button tap test (setUpAll)[0m
[platform_channel_sample_test_windows] [STDOUT] stderr: [  +31 ms] VMServiceFlutterDriver: Connecting to Flutter application at http://127.0.0.1:52673/c6-w7zT5-Qw=/
[platform_channel_sample_test_windows] [STDOUT] stderr: [ +179 ms] VMServiceFlutterDriver: Isolate found with number: 3990082986865311
[platform_channel_sample_test_windows] [STDOUT] stderr: [  +50 ms] VMServiceFlutterDriver: Isolate is paused at start.
[platform_channel_sample_test_windows] [STDOUT] stderr: [        ] VMServiceFlutterDriver: Attempting to resume isolate
[platform_channel_sample_test_windows] [STDOUT] stdout: [+1207 ms] 00:01 [32m+0[0m[31m -1[0m: button tap test (setUpAll) [1m[31m[E][0m[0m
[platform_channel_sample_test_windows] [STDOUT] stdout: [   +2 ms]   DriverError: Failed to fulfill GetHealth due to remote error
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   Original error: ext.flutter.driver: (112) Service has disappeared
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   Original stack trace:
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   #0      new _OutstandingRequest (package:vm_service/src/vm_service.dart:1746:45)
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   #1      VmService._call (package:vm_service/src/vm_service.dart:2262:21)
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   #2      VmService.callServiceExtension (package:vm_service/src/vm_service.dart:2233:14)
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   #3      VMServiceFlutterDriver.sendCommand (package:flutter_driver/src/driver/vmservice_driver.dart:306:66)
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   #4      FlutterDriver.checkHealth (package:flutter_driver/src/driver/driver.dart:197:34)
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   #5      VMServiceFlutterDriver.connect (package:flutter_driver/src/driver/vmservice_driver.dart:229:40)
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   <asynchronous suspension>
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   #6      main.<anonymous closure>.<anonymous closure> (file:///C:/b/s/w/ir/x/w/recipe_cleanup/tmpr1awka7t/flutter%20sdk/examples/platform_channel/test_driver/button_tap_test.dart:13:16)
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   <asynchronous suspension>
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   #7      _CustomZone.bindUnaryCallbackGuarded.<anonymous closure> (dart:async/zone.dart:1253:12)
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   <asynchronous suspension>
[platform_channel_sample_test_windows] [STDOUT] stdout: [  +14 ms]   package:flutter_driver/src/driver/vmservice_driver.dart 318:7   VMServiceFlutterDriver.sendCommand
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   ===== asynchronous gap ===========================
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   package:flutter_driver/src/driver/driver.dart 197:28            FlutterDriver.checkHealth
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   ===== asynchronous gap ===========================
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   package:flutter_driver/src/driver/vmservice_driver.dart 229:27  VMServiceFlutterDriver.connect
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   ===== asynchronous gap ===========================
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   test_driver\button_tap_test.dart 13:16                          main.<fn>.<fn>
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   ===== asynchronous gap ===========================
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   dart:async/zone.dart 1253:12                                    _CustomZone.bindUnaryCallbackGuarded.<fn>
[platform_channel_sample_test_windows] [STDOUT] stdout: [  +10 ms] 00:01 [32m+0[0m[31m -1[0m: button tap test (tearDownAll)[0m
[platform_channel_sample_test_windows] [STDOUT] stdout: [   +3 ms] 00:01 [32m+0[0m[31m -2[0m: button tap test (tearDownAll) [1m[31m[E][0m[0m
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   LateInitializationError: Local 'driver' has not been initialized.
[platform_channel_sample_test_windows] [STDOUT] stdout: [   +3 ms]   dart:_internal-patch/internal_patch.dart 209:5     LateError._throwLocalNotInitialized
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   test_driver\button_tap_test.dart 17:7              main.<fn>.<fn>
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   dart:async/future.dart 302:31                      new Future.sync
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   package:test_api/src/backend/invoker.dart 236:18   Invoker.runTearDowns.<fn>.<fn>
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   package:test_api/src/backend/invoker.dart 257:15   Invoker._waitForOutstandingCallbacks.<fn>
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   dart:async/zone.dart 1398:13                       _rootRun
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   dart:async/zone.dart 1300:19                       _CustomZone.run
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   dart:async/zone.dart 1803:10                       _runZoned
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   dart:async/zone.dart 1746:10                       runZoned
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   package:test_api/src/backend/invoker.dart 254:5    Invoker._waitForOutstandingCallbacks
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   package:test_api/src/backend/invoker.dart 235:9    Invoker.runTearDowns.<fn>
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   dart:async/zone.dart 1398:13                       _rootRun
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   dart:async/zone.dart 1300:19                       _CustomZone.run
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   dart:async/zone.dart 1803:10                       _runZoned
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   dart:async/zone.dart 1746:10                       runZoned
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   package:test_api/src/backend/invoker.dart 230:12   Invoker.runTearDowns
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   package:test_api/src/backend/declarer.dart 378:46  Declarer._tearDownAll.<fn>.<fn>
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   dart:async/zone.dart 1398:13                       _rootRun
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   dart:async/zone.dart 1300:19                       _CustomZone.run
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   dart:async/zone.dart 1803:10                       _runZoned
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   dart:async/zone.dart 1746:10                       runZoned
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   package:test_api/src/backend/declarer.dart 378:14  Declarer._tearDownAll.<fn>
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   package:test_api/src/backend/invoker.dart 257:15   Invoker._waitForOutstandingCallbacks.<fn>
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   dart:async/zone.dart 1398:13                       _rootRun
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   dart:async/zone.dart 1300:19                       _CustomZone.run
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   dart:async/zone.dart 1803:10                       _runZoned
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   dart:async/zone.dart 1746:10                       runZoned
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   package:test_api/src/backend/invoker.dart 254:5    Invoker._waitForOutstandingCallbacks
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ]   package:test_api/src/backend/invoker.dart 391:17   Invoker._onRun.<fn>.<fn>.<fn>
[platform_channel_sample_test_windows] [STDOUT] stdout: [  +11 ms] 00:01 [32m+0[0m[31m -2[0m: [31mSome tests failed.[0m
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ] Consider enabling the flag chain-stack-traces to receive more detailed exceptions.
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ] For example, 'dart test --chain-stack-traces'.
[platform_channel_sample_test_windows] [STDOUT] stderr: [   +1 ms] Unhandled exception:
[platform_channel_sample_test_windows] [STDOUT] stderr: [        ] Dummy exception to set exit code.
[platform_channel_sample_test_windows] [STDOUT] stdout: [+1044 ms] "flutter drive" took 22,339ms.
[platform_channel_sample_test_windows] [STDOUT] stderr: [   +6 ms] 
[platform_channel_sample_test_windows] [STDOUT] stderr:            #0      throwToolExit (package:flutter_tools/src/base/common.dart:10:3)
[platform_channel_sample_test_windows] [STDOUT] stderr:            #1      DriveCommand.runCommand (package:flutter_tools/src/commands/drive.dart:304:9)
[platform_channel_sample_test_windows] [STDOUT] stderr:            <asynchronous suspension>
[platform_channel_sample_test_windows] [STDOUT] stderr:            #2      FlutterCommand.run.<anonymous closure> (package:flutter_tools/src/runner/flutter_command.dart:1244:27)
[platform_channel_sample_test_windows] [STDOUT] stderr:            <asynchronous suspension>
[platform_channel_sample_test_windows] [STDOUT] stderr:            #3      AppContext.run.<anonymous closure> (package:flutter_tools/src/base/context.dart:150:19)
[platform_channel_sample_test_windows] [STDOUT] stderr:            <asynchronous suspension>
[platform_channel_sample_test_windows] [STDOUT] stderr:            #4      CommandRunner.runCommand (package:args/command_runner.dart:209:13)
[platform_channel_sample_test_windows] [STDOUT] stderr:            <asynchronous suspension>
[platform_channel_sample_test_windows] [STDOUT] stderr:            #5      FlutterCommandRunner.runCommand.<anonymous closure> (package:flutter_tools/src/runner/flutter_command_runner.dart:283:9)
[platform_channel_sample_test_windows] [STDOUT] stderr:            <asynchronous suspension>
[platform_channel_sample_test_windows] [STDOUT] stderr:            #6      AppContext.run.<anonymous closure> (package:flutter_tools/src/base/context.dart:150:19)
[platform_channel_sample_test_windows] [STDOUT] stderr:            <asynchronous suspension>
[platform_channel_sample_test_windows] [STDOUT] stderr:            #7      FlutterCommandRunner.runCommand (package:flutter_tools/src/runner/flutter_command_runner.dart:229:5)
[platform_channel_sample_test_windows] [STDOUT] stderr:            <asynchronous suspension>
[platform_channel_sample_test_windows] [STDOUT] stderr:            #8      run.<anonymous closure>.<anonymous closure> (package:flutter_tools/runner.dart:63:9)
[platform_channel_sample_test_windows] [STDOUT] stderr:            <asynchronous suspension>
[platform_channel_sample_test_windows] [STDOUT] stderr:            #9      AppContext.run.<anonymous closure> (package:flutter_tools/src/base/context.dart:150:19)
[platform_channel_sample_test_windows] [STDOUT] stderr:            <asynchronous suspension>
[platform_channel_sample_test_windows] [STDOUT] stderr:            #10     main (package:flutter_tools/executable.dart:91:3)
[platform_channel_sample_test_windows] [STDOUT] stderr:            <asynchronous suspension>
[platform_channel_sample_test_windows] [STDOUT] stderr: 
[platform_channel_sample_test_windows] [STDOUT] stderr: 
[platform_channel_sample_test_windows] [STDOUT] stdout: [   +1 ms] ensureAnalyticsSent: 0ms
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ] Running 0 shutdown hooks
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ] Shutdown hooks complete
[platform_channel_sample_test_windows] [STDOUT] stdout: [        ] exiting with code 1
[platform_channel_sample_test_windows] [STDOUT] Checking for reboot
[platform_channel_sample_test_windows] Process terminated with exit code 0.
```

</details>