### PR TITLE
Expose `vsync` information to developer

### DIFF
--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -338,6 +338,12 @@ class PlatformDispatcher {
     _invoke(onDrawFrame, _onDrawFrameZone);
   }
 
+  /// Read the information of the latest vsync.
+  VsyncInfo lastVsyncInfo() => _lastVsyncInfo();
+
+  @FfiNative<Handle Function()>('PlatformConfigurationNativeApi::LastVsyncInfo')
+  external static VsyncInfo _lastVsyncInfo();
+
   /// A callback that is invoked when pointer data is available.
   ///
   /// The framework invokes this callback in the same zone in which the callback
@@ -2175,4 +2181,16 @@ enum DartPerformanceMode {
   /// Optimize for low memory, at the expensive of throughput and latency by more
   /// frequently performing work.
   memory,
+}
+
+/// Vsync information.
+class VsyncInfo {
+  const VsyncInfo({
+    required this.timeStamp,
+  });
+
+  /// The time of the vsync. It has the same meaning as the time stamp
+  /// passed into [PlatformDispatcher.onBeginFrame] - both mean vsync
+  /// target time.
+  final Duration timeStamp;
 }

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -339,6 +339,11 @@ class PlatformDispatcher {
   }
 
   /// Read the information of the latest vsync.
+  ///
+  /// For example, suppose we are running on a 60FPS device, and the first
+  /// vsync comes at 0ms, the second comes at 16.67ms, and the third comes at
+  /// 33.33ms. Then, if you call [lastVsyncInfo] at 18ms or 25ms or 30ms etc,
+  /// you will get a [VsyncInfo] with information about the second vsync.
   VsyncInfo lastVsyncInfo() => _lastVsyncInfo();
 
   @FfiNative<Handle Function()>('PlatformConfigurationNativeApi::LastVsyncInfo')


### PR DESCRIPTION
This PR tries to expose vsync information to the developer, so they can know when it is proper to call the more un-restricted `window.render` proposed in #36438.

Currently only the API is shown, because IMHO the implementation details is unrelated to thoughts about #36438, and the API (and therefore implementations) are subject to changes. I will continue working on it, once the API is approved.

For detailed design about this API and its implementation, please have a look at "Get last vsync time information" section of https://docs.google.com/document/d/1FuNcBvAPghUyjeqQCOYxSt6lGDAQ1YxsNlOvrUx0Gko/edit.

Sample usage:

```dart
final info = SchedulerBinding.instance.lastVsyncInfo();
```

List of work:

- [x] code the (draft) Dart API
- [ ] discuss whether the API is acceptable
- [ ] implement the C++ part on SDK<=29 Android
- [ ] implement the C++ part on new android, ios, and other platforms
- [ ] create a wrapper function in `flutter/flutter` repo, probably in `SchedulerBinding`

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
