### PR TITLE
[web] Use TrustedTypes to load canvaskit (where available)

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -2652,7 +2652,7 @@ Future<void> _downloadCanvasKitJs() {
   final String canvasKitJavaScriptUrl = canvasKitJavaScriptBindingsUrl;
 
   final DomHTMLScriptElement canvasKitScript = createDomHTMLScriptElement();
-  canvasKitScript.src = canvasKitJavaScriptUrl;
+  canvasKitScript.src = createTrustedScriptUrl(canvasKitJavaScriptUrl);
 
   final Completer<void> canvasKitLoadCompleter = Completer<void>();
   late DomEventListener callback;

--- a/lib/web_ui/lib/src/engine/dom.dart
+++ b/lib/web_ui/lib/src/engine/dom.dart
@@ -1482,11 +1482,9 @@ abstract class DomTrustedTypePolicyOptions {
   });
 }
 
-/// Type of the function to configure createScriptURL.
+/// Type of the function used to configure createScriptURL.
 typedef DomCreateScriptUrlOptionFn = String? Function(String input);
 
-/// Dart binding of a JavaScript TrustedTypePolicy instance.
-///
 /// A TrustedTypePolicy defines a group of functions which create TrustedType
 /// objects.
 ///
@@ -1506,8 +1504,6 @@ extension DomTrustedTypePolicyExtension on DomTrustedTypePolicy {
   external DomTrustedScriptURL createScriptURL(String input);
 }
 
-/// Dart binding of a JavaScript TrustedScriptURL instance.
-///
 /// Represents a string that a developer can insert into an _injection sink_
 /// that will parse it as an external script.
 ///
@@ -1553,10 +1549,8 @@ final DomTrustedTypePolicy _ttPolicy = domWindow.trustedTypes!.createPolicy(
   ),
 );
 
-/// Converts a String `url` into a [DomTrustedScriptURL] object, when the
-/// Trusted Types API is available.
-///
-/// Else returns the unmodified `url`.
+/// Converts a String `url` into a [DomTrustedScriptURL] object when the
+/// Trusted Types API is available, else returns the unmodified `url`.
 Object createTrustedScriptUrl(String url) {
   if (domWindow.trustedTypes != null) {
     // Pass `url` through Flutter Engine's TrustedType policy.

--- a/lib/web_ui/lib/src/engine/dom.dart
+++ b/lib/web_ui/lib/src/engine/dom.dart
@@ -1533,19 +1533,19 @@ const Set<String> _expectedFilesForTT = <String>{
 
 // The definition of the `flutter-engine` TrustedType policy.
 // Only accessible if the Trusted Types API is available.
-final DomTrustedTypePolicy _ttPolicy = domWindow
-  .trustedTypes!
-  .createPolicy('flutter-engine',
-    DomTrustedTypePolicyOptions(
-      // Validates the given [url].
-      createScriptURL: allowInterop((String url) {
+final DomTrustedTypePolicy _ttPolicy = domWindow.trustedTypes!.createPolicy(
+  'flutter-engine',
+  DomTrustedTypePolicyOptions(
+    // Validates the given [url].
+    createScriptURL: allowInterop(
+      (String url) {
         final Uri uri = Uri.parse(url);
         if (_expectedFilesForTT.contains(uri.pathSegments.last)) {
           return uri.toString();
         }
-        domWindow.console.error(
-          'URL rejected by TrustedTypes policy flutter-engine: $url'
-          '(download prevented)');
+        domWindow.console
+            .error('URL rejected by TrustedTypes policy flutter-engine: $url'
+                '(download prevented)');
 
         return null;
       },
@@ -1561,10 +1561,10 @@ Object createTrustedScriptUrl(String url) {
   if (domWindow.trustedTypes != null) {
     // Pass `url` through Flutter Engine's TrustedType policy.
     final DomTrustedScriptURL trustedCanvasKitUrl =
-      _ttPolicy.createScriptURL(url);
+        _ttPolicy.createScriptURL(url);
 
     assert(trustedCanvasKitUrl.url != '',
-      'URL: $url rejected by TrustedTypePolicy');
+        'URL: $url rejected by TrustedTypePolicy');
 
     return trustedCanvasKitUrl;
   }

--- a/lib/web_ui/test/canvaskit/canvaskit_api_tt_on_test.dart
+++ b/lib/web_ui/test/canvaskit/canvaskit_api_tt_on_test.dart
@@ -1,0 +1,38 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:js/js_util.dart' as js_util;
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+import 'package:ui/src/engine.dart';
+
+import '../matchers.dart';
+import 'canvaskit_api_test.dart';
+
+// These tests need to happen in a separate file, because a Content Security
+// Policy cannot be relaxed once set, only made more strict.
+void main() {
+  enableTrustedTypes();
+  internalBootstrapBrowserTest(() => () {
+    // Run all standard canvaskit tests, with TT on...
+    testMain();
+
+    test('rejects wrong canvaskit.js URL', () async {
+      expect(() {
+        createTrustedScriptUrl('https://www.unpkg.com/soemthing/not-canvaskit.js');
+      }, throwsAssertionError);
+    });
+  });
+}
+
+/// Enables Trusted Types by setting the appropriate meta tag in the DOM:
+/// <meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script'">
+void enableTrustedTypes() {
+  print('Enabling TrustedTypes in browser window...');
+  final DomHTMLMetaElement enableTTMeta = createDomHTMLMetaElement()
+    ..setAttribute('http-equiv', 'Content-Security-Policy')
+    ..content = "require-trusted-types-for 'script'";
+  domDocument.head!.append(enableTTMeta);
+}

--- a/lib/web_ui/test/canvaskit/canvaskit_api_tt_on_test.dart
+++ b/lib/web_ui/test/canvaskit/canvaskit_api_tt_on_test.dart
@@ -23,7 +23,7 @@ void main() {
       expect(() {
         createTrustedScriptUrl('https://www.unpkg.com/soemthing/not-canvaskit.js');
       }, throwsAssertionError);
-    });
+    }, skip: isSafari || isFirefox);
   });
 }
 

--- a/lib/web_ui/test/canvaskit/canvaskit_api_tt_on_test.dart
+++ b/lib/web_ui/test/canvaskit/canvaskit_api_tt_on_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:js/js_util.dart' as js_util;
-
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';


### PR DESCRIPTION
Adds a small JS-Interop layer to use the TrustedTypes API from the flutter/engine code, and use it to download the CanvasKit JS.

Adds a test that runs the canvaskit_api tests with TT enabled.

Fixes https://github.com/flutter/flutter/issues/112654

### Testing

* Unit test included
* Deployed test app: https://dit-tests.web.app

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
