### PR TITLE
[Impeller] Remove pendown trick for solid strokes

### DIFF
--- a/impeller/entity/contents/solid_stroke_contents.cc
+++ b/impeller/entity/contents/solid_stroke_contents.cc
@@ -121,7 +121,6 @@ static VertexBuffer CreateSolidStrokeVertices(
       // and the beginning of the new contour.
       vtx.position = polyline.points[contour_start_point_i - 1];
       vtx.normal = {};
-      vtx.pen_down = 0.0;
       // Append two transparent vertices when "picking up" the pen so that the
       // triangle drawn when moving to the beginning of the new contour will
       // have zero volume. This is necessary because strokes with a transparent
@@ -134,7 +133,6 @@ static VertexBuffer CreateSolidStrokeVertices(
       // so that the next appended vertex will create a triangle with zero
       // volume.
       vtx_builder.AppendVertex(vtx);
-      vtx.pen_down = 1.0;
       vtx_builder.AppendVertex(vtx);
     }
 
@@ -150,7 +148,6 @@ static VertexBuffer CreateSolidStrokeVertices(
       if (point_i > contour_start_point_i) {
         // Generate line rect.
         vtx.position = polyline.points[point_i - 1];
-        vtx.pen_down = 1.0;
         vtx.normal = normal;
         vtx_builder.AppendVertex(vtx);
         vtx.normal = -normal;
@@ -271,7 +268,6 @@ void SolidStrokeContents::SetStrokeCap(Cap cap) {
                      const SmoothingApproximation& smoothing) {
         SolidStrokeVertexShader::PerVertexData vtx;
         vtx.position = position;
-        vtx.pen_down = 1.0;
 
         Point forward(normal.y, -normal.x);
 
@@ -299,7 +295,6 @@ void SolidStrokeContents::SetStrokeCap(Cap cap) {
                      const SmoothingApproximation& smoothing) {
         SolidStrokeVertexShader::PerVertexData vtx;
         vtx.position = position;
-        vtx.pen_down = 1.0;
 
         Point forward(normal.y, -normal.x);
 
@@ -327,7 +322,6 @@ static Scalar CreateBevelAndGetDirection(
     const Point& end_normal) {
   SolidStrokeVertexShader::PerVertexData vtx;
   vtx.position = position;
-  vtx.pen_down = 1.0;
   vtx.normal = {};
   vtx_builder.AppendVertex(vtx);
 
@@ -377,7 +371,6 @@ void SolidStrokeContents::SetStrokeJoin(Join join) {
         // Outer miter point.
         SolidStrokeVertexShader::PerVertexData vtx;
         vtx.position = position;
-        vtx.pen_down = 1.0;
         vtx.normal = miter_point * dir;
         vtx_builder.AppendVertex(vtx);
       };
@@ -411,7 +404,6 @@ void SolidStrokeContents::SetStrokeJoin(Join join) {
 
         SolidStrokeVertexShader::PerVertexData vtx;
         vtx.position = position;
-        vtx.pen_down = 1.0;
         for (const auto& point : arc_points) {
           vtx.normal = point * dir;
           vtx_builder.AppendVertex(vtx);

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -203,13 +203,22 @@ TEST_P(EntityTest, ThreeStrokesInOnePath) {
 
 TEST_P(EntityTest, TriangleInsideASquare) {
   auto callback = [&](ContentContext& context, RenderPass& pass) {
-    Point a = IMPELLER_PLAYGROUND_POINT(Point(10, 10), 20, Color::White());
-    Point b = IMPELLER_PLAYGROUND_POINT(Point(210, 10), 20, Color::White());
-    Point c = IMPELLER_PLAYGROUND_POINT(Point(210, 210), 20, Color::White());
-    Point d = IMPELLER_PLAYGROUND_POINT(Point(10, 210), 20, Color::White());
-    Point e = IMPELLER_PLAYGROUND_POINT(Point(50, 50), 20, Color::White());
-    Point f = IMPELLER_PLAYGROUND_POINT(Point(100, 50), 20, Color::White());
-    Point g = IMPELLER_PLAYGROUND_POINT(Point(50, 150), 20, Color::White());
+    Point offset(100, 100);
+
+    Point a =
+        IMPELLER_PLAYGROUND_POINT(Point(10, 10) + offset, 20, Color::White());
+    Point b =
+        IMPELLER_PLAYGROUND_POINT(Point(210, 10) + offset, 20, Color::White());
+    Point c =
+        IMPELLER_PLAYGROUND_POINT(Point(210, 210) + offset, 20, Color::White());
+    Point d =
+        IMPELLER_PLAYGROUND_POINT(Point(10, 210) + offset, 20, Color::White());
+    Point e =
+        IMPELLER_PLAYGROUND_POINT(Point(50, 50) + offset, 20, Color::White());
+    Point f =
+        IMPELLER_PLAYGROUND_POINT(Point(100, 50) + offset, 20, Color::White());
+    Point g =
+        IMPELLER_PLAYGROUND_POINT(Point(50, 150) + offset, 20, Color::White());
     Path path = PathBuilder{}
                     .MoveTo(a)
                     .LineTo(b)

--- a/impeller/entity/shaders/solid_stroke.frag
+++ b/impeller/entity/shaders/solid_stroke.frag
@@ -7,10 +7,8 @@ uniform FragInfo {
 }
 frag_info;
 
-in float v_pen_down;
-
 out vec4 frag_color;
 
 void main() {
-  frag_color = frag_info.color * floor(v_pen_down);
+  frag_color = frag_info.color;
 }

--- a/impeller/entity/shaders/solid_stroke.vert
+++ b/impeller/entity/shaders/solid_stroke.vert
@@ -10,13 +10,9 @@ vert_info;
 
 in vec2 position;
 in vec2 normal;
-in float pen_down;
-
-out float v_pen_down;
 
 void main() {
   // Push one vertex by the half stroke size along the normal vector.
   vec2 offset = normal * vec2(vert_info.size * 0.5);
   gl_Position = vert_info.mvp * vec4(position + offset, 0.0, 1.0);
-  v_pen_down = pen_down;
 }


### PR DESCRIPTION
Remove special "pen down" attribute from the solid generator algorithm. The triangle created between contours already has zero area. We already rely on zero area triangles getting discarded by the rasterizer for the overdraw prevention technique we use.

Part of preparing solid strokes for the deferred geometry refactor. See also https://flutter.dev/go/impeller-geometry#heading=h.fymtgh4bhdl2 for a detailed explanation.