### PR TITLE
[impeller] Record final stroke vertex positions directly instead of using a separate normal attribute

### DIFF
--- a/impeller/entity/contents/solid_stroke_contents.h
+++ b/impeller/entity/contents/solid_stroke_contents.h
@@ -34,13 +34,13 @@ class SolidStrokeContents final : public Contents {
   using CapProc = std::function<void(
       VertexBufferBuilder<SolidStrokeVertexShader::PerVertexData>& vtx_builder,
       const Point& position,
-      const Point& normal,
+      const Point& offset,
       const SmoothingApproximation& smoothing)>;
   using JoinProc = std::function<void(
       VertexBufferBuilder<SolidStrokeVertexShader::PerVertexData>& vtx_builder,
       const Point& position,
-      const Point& start_normal,
-      const Point& end_normal,
+      const Point& start_offset,
+      const Point& end_offset,
       Scalar miter_limit,
       const SmoothingApproximation& smoothing)>;
 

--- a/impeller/entity/shaders/solid_stroke.vert
+++ b/impeller/entity/shaders/solid_stroke.vert
@@ -4,15 +4,11 @@
 
 uniform VertInfo {
   mat4 mvp;
-  float size;
 }
 vert_info;
 
 in vec2 position;
-in vec2 normal;
 
 void main() {
-  // Push one vertex by the half stroke size along the normal vector.
-  vec2 offset = normal * vec2(vert_info.size * 0.5);
-  gl_Position = vert_info.mvp * vec4(position + offset, 0.0, 1.0);
+  gl_Position = vert_info.mvp * vec4(position, 0.0, 1.0);
 }


### PR DESCRIPTION
This is another step towards making the stroke path algorithm compatible with the deferred geometry design. (See also https://flutter.dev/go/impeller-geometry#heading=h.fymtgh4bhdl2)

Took some funky screenshots along the way:
![Screen Shot 2022-10-04 at 9 07 39 PM](https://user-images.githubusercontent.com/919017/193984750-2cd219f2-d63f-4bfc-a562-7cc665822545.png)
![Screen Shot 2022-10-04 at 9 32 42 PM](https://user-images.githubusercontent.com/919017/193984758-21933fe4-5164-4b9c-bb10-dd182da34d56.png)
