### PR TITLE
[Impeller] Improvements for SSBO codegen

### DIFF
--- a/impeller/compiler/code_gen_template.h
+++ b/impeller/compiler/code_gen_template.h
@@ -48,9 +48,13 @@ struct {{camel_case(shader_name)}}{{camel_case(shader_stage)}}Shader {
   // Struct Definitions ========================================================
   // ===========================================================================
 {% for def in struct_definitions %}
+
+{% if last(def.members).array_elements == 0 %}
+  template <size_t FlexCount>
+{% endif %}
   struct {{def.name}} {
 {% for member in def.members %}
-{% if member.element_padding > 0 %}Padded<{{member.type}}, {{member.element_padding}}>{% else %}{{member.type}}{% endif %} {{" " + member.name}}{% if member.array_elements > 1 %}[{{member.array_elements}}]{% endif %}; // (offset {{member.offset}}, size {{member.byte_length}})
+{{"    "}}{% if member.element_padding > 0 %}Padded<{{member.type}}, {{member.element_padding}}>{% else %}{{member.type}}{% endif %}{{" " + member.name}}{% if member.array_elements != "std::nullopt" %}[{% if member.array_elements == 0 %}FlexCount{% else %}{{member.array_elements}}{% endif %}]{% endif %}; // (offset {{member.offset}}, size {{member.byte_length}})
 {% endfor %}
   }; // struct {{def.name}} (size {{def.byte_length}})
 {% endfor %}
@@ -196,11 +200,19 @@ using Shader = {{camel_case(shader_name)}}{{camel_case(shader_stage)}}Shader;
 
 {% for def in struct_definitions %}
 // Sanity checks for {{def.name}}
+{% if last(def.members).array_elements == 0 %}
+static_assert(std::is_standard_layout_v<Shader::{{def.name}}<0>>);
+static_assert(sizeof(Shader::{{def.name}}<0>) == {{def.byte_length}});
+{% for member in def.members %}
+static_assert(offsetof(Shader::{{def.name}}<0>, {{member.name}}) == {{member.offset}});
+{% endfor %}
+{% else %}
 static_assert(std::is_standard_layout_v<Shader::{{def.name}}>);
 static_assert(sizeof(Shader::{{def.name}}) == {{def.byte_length}});
 {% for member in def.members %}
 static_assert(offsetof(Shader::{{def.name}}, {{member.name}}) == {{member.offset}});
 {% endfor %}
+{% endif %}
 {% endfor %}
 
 {% for buffer in buffers %}

--- a/impeller/compiler/reflector.h
+++ b/impeller/compiler/reflector.h
@@ -25,7 +25,7 @@ struct StructMember {
   size_t offset = 0u;
   size_t size = 0u;
   size_t byte_length = 0u;
-  size_t array_elements = 1u;
+  std::optional<size_t> array_elements = std::nullopt;
   size_t element_padding = 0u;
 
   StructMember(std::string p_type,
@@ -34,7 +34,7 @@ struct StructMember {
                size_t p_offset,
                size_t p_size,
                size_t p_byte_length,
-               size_t p_array_elements,
+               std::optional<size_t> p_array_elements,
                size_t p_element_padding)
       : type(std::move(p_type)),
         base_type(std::move(p_base_type)),
@@ -149,13 +149,14 @@ class Reflector {
   std::vector<StructMember> ReadStructMembers(
       const spirv_cross::TypeID& type_id) const;
 
-  uint32_t GetArrayElements(const spirv_cross::SPIRType& type) const;
+  std::optional<uint32_t> GetArrayElements(
+      const spirv_cross::SPIRType& type) const;
 
   template <uint32_t Size>
   uint32_t GetArrayStride(const spirv_cross::SPIRType& struct_type,
                           const spirv_cross::SPIRType& member_type,
                           uint32_t index) const {
-    auto element_count = GetArrayElements(member_type);
+    auto element_count = GetArrayElements(member_type).value_or(1);
     if (element_count <= 1) {
       return Size;
     }

--- a/impeller/compiler/runtime_stage_data.cc
+++ b/impeller/compiler/runtime_stage_data.cc
@@ -156,7 +156,9 @@ std::shared_ptr<fml::Mapping> RuntimeStageData::CreateMapping() const {
     }
     desc->type = uniform_type.value();
     desc->bit_width = uniform.bit_width;
-    desc->array_elements = uniform.array_elements;
+    if (uniform.array_elements.has_value()) {
+      desc->array_elements = uniform.array_elements.value();
+    }
 
     runtime_stage.uniforms.emplace_back(std::move(desc));
   }

--- a/impeller/compiler/runtime_stage_data.h
+++ b/impeller/compiler/runtime_stage_data.h
@@ -22,7 +22,7 @@ struct UniformDescription {
   size_t rows = 0u;
   size_t columns = 0u;
   size_t bit_width = 0u;
-  size_t array_elements = 0u;
+  std::optional<size_t> array_elements = std::nullopt;
 };
 
 class RuntimeStageData {

--- a/impeller/fixtures/sample.comp
+++ b/impeller/fixtures/sample.comp
@@ -6,10 +6,13 @@ layout(binding = 0) writeonly buffer Output {
 } output_data;
 
 layout(binding = 1) readonly buffer Input0 {
+  int some_int;
+  ivec2 fixed_array[3];
   vec4 elements[];
 } input_data0;
 
 layout(binding = 2) readonly buffer Input1 {
+  uvec2 fixed_array[4];
   vec4 elements[];
 } input_data1;
 
@@ -27,4 +30,7 @@ void main()
   }
 
   output_data.elements[ident] = input_data0.elements[ident] * input_data1.elements[ident];
+  output_data.elements[ident].x += input_data0.fixed_array[1].x;
+  output_data.elements[ident].y += input_data1.fixed_array[0].y;
+  output_data.elements[ident].z += input_data0.some_int;
 }

--- a/impeller/geometry/point.h
+++ b/impeller/geometry/point.h
@@ -293,6 +293,8 @@ constexpr TPoint<T> operator/(const TSize<U>& s, const TPoint<T>& p) {
 
 using Point = TPoint<Scalar>;
 using IPoint = TPoint<int64_t>;
+using IPoint32 = TPoint<int32_t>;
+using UintPoint32 = TPoint<uint32_t>;
 using Vector2 = Point;
 
 }  // namespace impeller

--- a/impeller/renderer/backend/gles/buffer_bindings_gles.cc
+++ b/impeller/renderer/backend/gles/buffer_bindings_gles.cc
@@ -214,8 +214,8 @@ bool BufferBindingsGLES::BindUniformBuffer(const ProcTableGLES& gl,
       continue;
     }
 
-    const auto member_key = CreateUnifiormMemberKey(metadata->name, member.name,
-                                                    member.array_elements > 1);
+    const auto member_key = CreateUnifiormMemberKey(
+        metadata->name, member.name, member.array_elements.value_or(1) > 1);
     const auto location = uniform_locations_.find(member_key);
     if (location == uniform_locations_.end()) {
       // The list of uniform locations only contains "active" uniforms that are
@@ -224,17 +224,18 @@ bool BufferBindingsGLES::BindUniformBuffer(const ProcTableGLES& gl,
       continue;
     }
 
-    size_t element_stride = member.byte_length / member.array_elements;
+    size_t element_stride =
+        member.byte_length / member.array_elements.value_or(1);
 
     auto* buffer_data =
         reinterpret_cast<const GLfloat*>(buffer_ptr + member.offset);
 
     std::vector<uint8_t> array_element_buffer;
-    if (member.array_elements > 1) {
+    if (member.array_elements.value_or(1) > 1) {
       // When binding uniform arrays, the elements must be contiguous. Copy the
       // uniforms to a temp buffer to eliminate any padding needed by the other
       // backends.
-      array_element_buffer.resize(member.size * member.array_elements);
+      array_element_buffer.resize(member.size * member.array_elements.value());
       for (size_t element_i = 0; element_i < member.array_elements;
            element_i++) {
         std::memcpy(array_element_buffer.data() + element_i * member.size,
@@ -250,34 +251,34 @@ bool BufferBindingsGLES::BindUniformBuffer(const ProcTableGLES& gl,
       case ShaderType::kFloat:
         switch (member.size) {
           case sizeof(Matrix):
-            gl.UniformMatrix4fv(location->second,       // location
-                                member.array_elements,  // count
-                                GL_FALSE,               // normalize
-                                buffer_data             // data
+            gl.UniformMatrix4fv(location->second,               // location
+                                member.array_elements.value(),  // count
+                                GL_FALSE,                       // normalize
+                                buffer_data                     // data
             );
             continue;
           case sizeof(Vector4):
-            gl.Uniform4fv(location->second,       // location
-                          member.array_elements,  // count
-                          buffer_data             // data
+            gl.Uniform4fv(location->second,               // location
+                          member.array_elements.value(),  // count
+                          buffer_data                     // data
             );
             continue;
           case sizeof(Vector3):
-            gl.Uniform3fv(location->second,       // location
-                          member.array_elements,  // count
-                          buffer_data             // data
+            gl.Uniform3fv(location->second,               // location
+                          member.array_elements.value(),  // count
+                          buffer_data                     // data
             );
             continue;
           case sizeof(Vector2):
-            gl.Uniform2fv(location->second,       // location
-                          member.array_elements,  // count
-                          buffer_data             // data
+            gl.Uniform2fv(location->second,               // location
+                          member.array_elements.value(),  // count
+                          buffer_data                     // data
             );
             continue;
           case sizeof(Scalar):
-            gl.Uniform1fv(location->second,       // location
-                          member.array_elements,  // count
-                          buffer_data             // data
+            gl.Uniform1fv(location->second,               // location
+                          member.array_elements.value(),  // count
+                          buffer_data                     // data
             );
             continue;
         }

--- a/impeller/renderer/backend/gles/buffer_bindings_gles.cc
+++ b/impeller/renderer/backend/gles/buffer_bindings_gles.cc
@@ -214,8 +214,10 @@ bool BufferBindingsGLES::BindUniformBuffer(const ProcTableGLES& gl,
       continue;
     }
 
-    const auto member_key = CreateUnifiormMemberKey(
-        metadata->name, member.name, member.array_elements.value_or(1) > 1);
+    size_t element_count = member.array_elements.value_or(1);
+
+    const auto member_key =
+        CreateUnifiormMemberKey(metadata->name, member.name, element_count > 1);
     const auto location = uniform_locations_.find(member_key);
     if (location == uniform_locations_.end()) {
       // The list of uniform locations only contains "active" uniforms that are
@@ -224,20 +226,18 @@ bool BufferBindingsGLES::BindUniformBuffer(const ProcTableGLES& gl,
       continue;
     }
 
-    size_t element_stride =
-        member.byte_length / member.array_elements.value_or(1);
+    size_t element_stride = member.byte_length / element_count;
 
     auto* buffer_data =
         reinterpret_cast<const GLfloat*>(buffer_ptr + member.offset);
 
     std::vector<uint8_t> array_element_buffer;
-    if (member.array_elements.value_or(1) > 1) {
+    if (element_count > 1) {
       // When binding uniform arrays, the elements must be contiguous. Copy the
       // uniforms to a temp buffer to eliminate any padding needed by the other
       // backends.
-      array_element_buffer.resize(member.size * member.array_elements.value());
-      for (size_t element_i = 0; element_i < member.array_elements;
-           element_i++) {
+      array_element_buffer.resize(member.size * element_count);
+      for (size_t element_i = 0; element_i < element_count; element_i++) {
         std::memcpy(array_element_buffer.data() + element_i * member.size,
                     reinterpret_cast<const char*>(buffer_data) +
                         element_i * element_stride,
@@ -251,34 +251,34 @@ bool BufferBindingsGLES::BindUniformBuffer(const ProcTableGLES& gl,
       case ShaderType::kFloat:
         switch (member.size) {
           case sizeof(Matrix):
-            gl.UniformMatrix4fv(location->second,               // location
-                                member.array_elements.value(),  // count
-                                GL_FALSE,                       // normalize
-                                buffer_data                     // data
+            gl.UniformMatrix4fv(location->second,  // location
+                                element_count,     // count
+                                GL_FALSE,          // normalize
+                                buffer_data        // data
             );
             continue;
           case sizeof(Vector4):
-            gl.Uniform4fv(location->second,               // location
-                          member.array_elements.value(),  // count
-                          buffer_data                     // data
+            gl.Uniform4fv(location->second,  // location
+                          element_count,     // count
+                          buffer_data        // data
             );
             continue;
           case sizeof(Vector3):
-            gl.Uniform3fv(location->second,               // location
-                          member.array_elements.value(),  // count
-                          buffer_data                     // data
+            gl.Uniform3fv(location->second,  // location
+                          element_count,     // count
+                          buffer_data        // data
             );
             continue;
           case sizeof(Vector2):
-            gl.Uniform2fv(location->second,               // location
-                          member.array_elements.value(),  // count
-                          buffer_data                     // data
+            gl.Uniform2fv(location->second,  // location
+                          element_count,     // count
+                          buffer_data        // data
             );
             continue;
           case sizeof(Scalar):
-            gl.Uniform1fv(location->second,               // location
-                          member.array_elements.value(),  // count
-                          buffer_data                     // data
+            gl.Uniform1fv(location->second,  // location
+                          element_count,     // count
+                          buffer_data        // data
             );
             continue;
         }

--- a/impeller/renderer/backend/metal/compute_pass_mtl.h
+++ b/impeller/renderer/backend/metal/compute_pass_mtl.h
@@ -33,10 +33,14 @@ class ComputePassMTL final : public ComputePass {
   void OnSetLabel(std::string label) override;
 
   // |ComputePass|
-  bool OnEncodeCommands(const Context& context) const override;
+  bool OnEncodeCommands(const Context& context,
+                        const ISize& grid_size,
+                        const ISize& thread_group_size) const override;
 
   bool EncodeCommands(const std::shared_ptr<Allocator>& allocator,
-                      id<MTLComputeCommandEncoder> pass) const;
+                      id<MTLComputeCommandEncoder> pass,
+                      const ISize& grid_size,
+                      const ISize& thread_group_size) const;
 
   FML_DISALLOW_COPY_AND_ASSIGN(ComputePassMTL);
 };

--- a/impeller/renderer/compute_pass.cc
+++ b/impeller/renderer/compute_pass.cc
@@ -28,6 +28,14 @@ void ComputePass::SetLabel(std::string label) {
   OnSetLabel(std::move(label));
 }
 
+void ComputePass::SetGridSize(const ISize& size) {
+  grid_size_ = size;
+}
+
+void ComputePass::SetThreadGroupSize(const ISize& size) {
+  thread_group_size_ = size;
+}
+
 bool ComputePass::AddCommand(ComputeCommand command) {
   if (!command) {
     VALIDATION_LOG << "Attempted to add an invalid command to the render pass.";
@@ -44,7 +52,7 @@ bool ComputePass::EncodeCommands() const {
   if (!context) {
     return false;
   }
-  return OnEncodeCommands(*context);
+  return OnEncodeCommands(*context, grid_size_, thread_group_size_);
 }
 
 }  // namespace impeller

--- a/impeller/renderer/compute_pass.h
+++ b/impeller/renderer/compute_pass.h
@@ -31,6 +31,10 @@ class ComputePass {
 
   void SetLabel(std::string label);
 
+  void SetGridSize(const ISize& size);
+
+  void SetThreadGroupSize(const ISize& size);
+
   HostBuffer& GetTransientsBuffer();
 
   //----------------------------------------------------------------------------
@@ -56,6 +60,8 @@ class ComputePass {
 
  protected:
   const std::weak_ptr<const Context> context_;
+  ISize grid_size_ = ISize(32, 32);
+  ISize thread_group_size_ = ISize(32, 32);
   std::shared_ptr<HostBuffer> transients_buffer_;
   std::vector<ComputeCommand> commands_;
 
@@ -63,7 +69,9 @@ class ComputePass {
 
   virtual void OnSetLabel(std::string label) = 0;
 
-  virtual bool OnEncodeCommands(const Context& context) const = 0;
+  virtual bool OnEncodeCommands(const Context& context,
+                                const ISize& grid_size,
+                                const ISize& thread_group_size) const = 0;
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(ComputePass);

--- a/impeller/renderer/compute_unittests.cc
+++ b/impeller/renderer/compute_unittests.cc
@@ -43,11 +43,15 @@ TEST_P(ComputeTest, CanCreateComputePass) {
   auto pass = cmd_buffer->CreateComputePass();
   ASSERT_TRUE(pass && pass->IsValid());
 
+  static constexpr size_t kCount = 5;
+
+  pass->SetGridSize(ISize(kCount, 1));
+  pass->SetThreadGroupSize(ISize(kCount, 1));
+
   ComputeCommand cmd;
   cmd.label = "Compute";
   cmd.pipeline = compute_pipeline;
 
-  static constexpr size_t kCount = 5;
   CS::Info info{.count = kCount};
   CS::Input0<kCount> input_0;
   CS::Input1<kCount> input_1;
@@ -85,7 +89,7 @@ TEST_P(ComputeTest, CanCreateComputePass) {
         EXPECT_EQ(status, CommandBuffer::Status::kCompleted);
 
         auto view = output_buffer->AsBufferView();
-        EXPECT_EQ(view.range.length, 80lu);
+        EXPECT_EQ(view.range.length, sizeof(CS::Output<kCount>));
 
         CS::Output<kCount>* output =
             reinterpret_cast<CS::Output<kCount>*>(view.contents);

--- a/impeller/renderer/compute_unittests.cc
+++ b/impeller/renderer/compute_unittests.cc
@@ -47,10 +47,11 @@ TEST_P(ComputeTest, CanCreateComputePass) {
   cmd.label = "Compute";
   cmd.pipeline = compute_pipeline;
 
-  CS::Info info{.count = 5};
-  CS::Input0<5> input_0;
-  CS::Input1<5> input_1;
-  for (uint i = 0; i < 5; i++) {
+  static constexpr size_t kCount = 5;
+  CS::Info info{.count = kCount};
+  CS::Input0<kCount> input_0;
+  CS::Input1<kCount> input_1;
+  for (uint i = 0; i < kCount; i++) {
     input_0.elements[i] = Vector4(2.0 + i, 3.0 + i, 4.0 + i, 5.0 * i);
     input_1.elements[i] = Vector4(6.0, 7.0, 8.0, 9.0);
   }
@@ -61,7 +62,7 @@ TEST_P(ComputeTest, CanCreateComputePass) {
 
   DeviceBufferDescriptor buffer_desc;
   buffer_desc.storage_mode = StorageMode::kHostVisible;
-  buffer_desc.size = sizeof(CS::Output<5>);
+  buffer_desc.size = sizeof(CS::Output<kCount>);
 
   auto output_buffer =
       context->GetResourceAllocator()->CreateBuffer(buffer_desc);
@@ -86,9 +87,10 @@ TEST_P(ComputeTest, CanCreateComputePass) {
         auto view = output_buffer->AsBufferView();
         EXPECT_EQ(view.range.length, 80lu);
 
-        CS::Output<5>* output = reinterpret_cast<CS::Output<5>*>(view.contents);
+        CS::Output<kCount>* output =
+            reinterpret_cast<CS::Output<kCount>*>(view.contents);
         EXPECT_TRUE(output);
-        for (size_t i = 0; i < 5; i++) {
+        for (size_t i = 0; i < kCount; i++) {
           Vector4 vector = output->elements[i];
           Vector4 computed = input_0.elements[i] * input_1.elements[i];
           EXPECT_EQ(vector, Vector4(computed.x + 2, computed.y + 3,

--- a/impeller/renderer/compute_unittests.cc
+++ b/impeller/renderer/compute_unittests.cc
@@ -48,16 +48,20 @@ TEST_P(ComputeTest, CanCreateComputePass) {
   cmd.pipeline = compute_pipeline;
 
   CS::Info info{.count = 5};
-  std::vector<CS::Input0> input_0;
-  std::vector<CS::Input1> input_1;
+  CS::Input0<5> input_0;
+  CS::Input1<5> input_1;
   for (uint i = 0; i < 5; i++) {
-    input_0.push_back(CS::Input0{Vector4(2.0 + i, 3.0 + i, 4.0 + i, 5.0 * i)});
-    input_1.push_back(CS::Input1{Vector4(6.0, 7.0, 8.0, 9.0)});
+    input_0.elements[i] = Vector4(2.0 + i, 3.0 + i, 4.0 + i, 5.0 * i);
+    input_1.elements[i] = Vector4(6.0, 7.0, 8.0, 9.0);
   }
+
+  input_0.fixed_array[1] = IPoint32(2, 2);
+  input_1.fixed_array[0] = UintPoint32(3, 3);
+  input_0.some_int = 5;
 
   DeviceBufferDescriptor buffer_desc;
   buffer_desc.storage_mode = StorageMode::kHostVisible;
-  buffer_desc.size = sizeof(CS::Output) * 5;
+  buffer_desc.size = sizeof(CS::Output<5>);
 
   auto output_buffer =
       context->GetResourceAllocator()->CreateBuffer(buffer_desc);
@@ -82,11 +86,13 @@ TEST_P(ComputeTest, CanCreateComputePass) {
         auto view = output_buffer->AsBufferView();
         EXPECT_EQ(view.range.length, 80lu);
 
-        for (size_t i = 0; i < input_0.size() - 1; i++) {
-          Vector4 output = reinterpret_cast<CS::Output*>(view.contents +
-                                                         i * sizeof(CS::Output))
-                               ->elements;
-          EXPECT_EQ(output, input_0[i].elements * input_1[i].elements);
+        CS::Output<5>* output = reinterpret_cast<CS::Output<5>*>(view.contents);
+        EXPECT_TRUE(output);
+        for (size_t i = 0; i < 5; i++) {
+          Vector4 vector = output->elements[i];
+          Vector4 computed = input_0.elements[i] * input_1.elements[i];
+          EXPECT_EQ(vector, Vector4(computed.x + 2, computed.y + 3,
+                                    computed.z + 5, computed.w));
         }
         latch.Signal();
       }));

--- a/impeller/renderer/host_buffer.h
+++ b/impeller/renderer/host_buffer.h
@@ -63,12 +63,12 @@ class HostBuffer final : public std::enable_shared_from_this<HostBuffer>,
       class StorageBufferType,
       class = std::enable_if_t<std::is_standard_layout_v<StorageBufferType>>>
   [[nodiscard]] BufferView EmplaceStorageBuffer(
-      const std::vector<StorageBufferType>& buffer) {
+      const StorageBufferType& buffer) {
     const auto alignment =
         std::max(alignof(StorageBufferType), DefaultUniformAlignment());
-    return Emplace(buffer.data(),                              // buffer
-                   buffer.size() * sizeof(StorageBufferType),  // size
-                   alignment                                   // alignment
+    return Emplace(&buffer,                    // buffer
+                   sizeof(StorageBufferType),  // size
+                   alignment                   // alignment
     );
   }
 

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -425,11 +425,9 @@ TEST_P(RendererTest, CanRenderInstanced) {
   cmd.label = "InstancedDraw";
 
   static constexpr size_t kInstancesCount = 5u;
-  std::vector<VS::InstanceInfo> instances;
+  VS::InstanceInfo<kInstancesCount> instances;
   for (size_t i = 0; i < kInstancesCount; i++) {
-    VS::InstanceInfo info;
-    info.colors = Color::Random();
-    instances.emplace_back(info);
+    instances.colors[i] = Color::Random();
   }
 
   ASSERT_TRUE(OpenPlaygroundHere([&](RenderPass& pass) -> bool {

--- a/impeller/renderer/shader_types.h
+++ b/impeller/renderer/shader_types.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstddef>
+#include <optional>
 #include <string_view>
 #include <vector>
 
@@ -68,7 +69,7 @@ struct ShaderStructMemberMetadata {
   size_t offset;
   size_t size;
   size_t byte_length;
-  size_t array_elements;
+  std::optional<size_t> array_elements;
 };
 
 struct ShaderMetadata {

--- a/impeller/runtime_stage/runtime_types.h
+++ b/impeller/runtime_stage/runtime_types.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstddef>
+#include <optional>
 #include <string>
 
 namespace impeller {
@@ -44,7 +45,7 @@ struct RuntimeUniformDescription {
   RuntimeUniformType type = RuntimeUniformType::kFloat;
   RuntimeUniformDimensions dimensions;
   size_t bit_width;
-  size_t array_elements;
+  std::optional<size_t> array_elements;
 };
 
 }  // namespace impeller

--- a/lib/ui/fixtures/shaders/general_shaders/uniform_arrays.frag
+++ b/lib/ui/fixtures/shaders/general_shaders/uniform_arrays.frag
@@ -12,7 +12,6 @@ layout ( location = 1 ) uniform float floatArray[2];
 layout ( location = 3 ) uniform vec2 vec2Array[2];
 layout ( location = 7 ) uniform vec3 vec3Array[2];
 layout ( location = 13 ) uniform mat2 mat2Array[2];
-layout ( location = 21 ) uniform float float2dArray[2][2];
 
 void main() {
   vec4 badColor = vec4(1.0, 0, 0, 1.0);
@@ -39,11 +38,7 @@ void main() {
       mat2Array[0][1][1] >= mat2Array[1][0][0] ||
       mat2Array[1][0][0] >= mat2Array[1][0][1] ||
       mat2Array[1][0][1] >= mat2Array[1][1][0] ||
-      mat2Array[1][1][0] >= mat2Array[1][1][1] ||
-      mat2Array[1][1][1] >= float2dArray[0][0] ||
-      float2dArray[0][0] >= float2dArray[0][1] ||
-      float2dArray[0][1] >= float2dArray[1][0] ||
-      float2dArray[1][0] >= float2dArray[1][1]) {
+      mat2Array[1][1][0] >= mat2Array[1][1][1]) {
     oColor = badColor;
   } else {
     oColor = goodColor;

--- a/lib/ui/painting/fragment_program.cc
+++ b/lib/ui/painting/fragment_program.cc
@@ -65,8 +65,8 @@ std::string FragmentProgram::initFromAsset(const std::string& asset_name) {
       size_t size = uniform_description.dimensions.rows *
                     uniform_description.dimensions.cols *
                     uniform_description.bit_width / 8u;
-      if (uniform_description.array_elements > 0) {
-        size *= uniform_description.array_elements;
+      if (uniform_description.array_elements.value_or(0) > 0) {
+        size *= uniform_description.array_elements.value();
       }
       other_uniforms_bytes += size;
     }

--- a/testing/dart/fragment_shader_test.dart
+++ b/testing/dart/fragment_shader_test.dart
@@ -226,7 +226,7 @@ void main() async {
     );
 
     final FragmentShader shader = program.fragmentShader();
-    for (int i = 0; i < 24; i++) {
+    for (int i = 0; i < 20; i++) {
       shader.setFloat(i, i.toDouble());
     }
 


### PR DESCRIPTION
This PR does a few things:

- Adds a UintPoint32 and a IPoint32 to handle uvec2/ivec2 members, and updates the reflector to know about these.
- Turns structs that have dynamically sized arrays (aka flexible arrays) into template classes that take a size parameter.
  - This allows for stack allocation instead of forcing heap allocation.
  - This allows for structs that have more than just the array member in GLSL.
  - This requires updating `HostBuffer::EmplaceStorageBuffer`
- Turns the array_elements member of the struct definition into an optional so that callsites can decide what to do if there's no array elements instead of forcing them to always think there's at least 1.
- Updates the compute test/sample.comp to use these features.
- Updates a bug in the way we handled array sizes. Previously we would have taken a multi-dimensional array and flattened it out as if single dimensional. Impellerc will now enforce that you don't use multi-dimensional arrays in GLSL, since it's not supported everywhere we need (SkSL, GLES 2.0 for example).

Fixes https://github.com/flutter/flutter/issues/110618
Addresses part of the concerns in https://github.com/flutter/flutter/issues/112683