### PR TITLE
Add ImmutableBuffer.fromFilePath

### DIFF
--- a/lib/ui/dart_ui.cc
+++ b/lib/ui/dart_ui.cc
@@ -83,6 +83,7 @@ typedef CanvasPath Path;
   V(ImageDescriptor::initEncoded, 3)                                  \
   V(ImmutableBuffer::init, 3)                                         \
   V(ImmutableBuffer::initFromAsset, 3)                                \
+  V(ImmutableBuffer::initFromFile, 3)                                 \
   V(ImageDescriptor::initRaw, 6)                                      \
   V(IsolateNameServerNatives::LookupPortByName, 1)                    \
   V(IsolateNameServerNatives::RegisterPortWithName, 2)                \

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -6104,7 +6104,12 @@ class ImmutableBuffer extends NativeFieldWrapperClass1 {
     final ImmutableBuffer instance = ImmutableBuffer._(0);
     return _futurize((_Callback<int> callback) {
       return instance._initFromFile(path, callback);
-    }).then((int length) => instance.._length = length);
+    }).then((int length) {
+      if (length == -1) {
+        throw Exception('Could not load file at $path.');
+      }
+      return instance.._length = length;
+    });
   }
 
   @FfiNative<Handle Function(Handle, Handle, Handle)>('ImmutableBuffer::init')

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -6097,11 +6097,24 @@ class ImmutableBuffer extends NativeFieldWrapperClass1 {
     }).then((int length) => instance.._length = length);
   }
 
+  /// Create a buffer from the file with [path].
+  ///
+  /// Throws an [Exception] if the asset does not exist.
+  static Future<ImmutableBuffer> fromFilePath(String path) {
+    final ImmutableBuffer instance = ImmutableBuffer._(0);
+    return _futurize((_Callback<int> callback) {
+      return instance._initFromFile(path, callback);
+    }).then((int length) => instance.._length = length);
+  }
+
   @FfiNative<Handle Function(Handle, Handle, Handle)>('ImmutableBuffer::init')
   external String? _init(Uint8List list, _Callback<void> callback);
 
   @FfiNative<Handle Function(Handle, Handle, Handle)>('ImmutableBuffer::initFromAsset')
   external String? _initFromAsset(String assetKey, _Callback<int> callback);
+
+  @FfiNative<Handle Function(Handle, Handle, Handle)>('ImmutableBuffer::initFromFile')
+  external String? _initFromFile(String assetKey, _Callback<int> callback);
 
   /// The length, in bytes, of the underlying data.
   int get length => _length;

--- a/lib/ui/painting/immutable_buffer.cc
+++ b/lib/ui/painting/immutable_buffer.cc
@@ -6,11 +6,14 @@
 
 #include <cstring>
 
+#include "flutter/fml/file.h"
+#include "flutter/fml/make_copyable.h"
 #include "flutter/lib/ui/ui_dart_state.h"
 #include "flutter/lib/ui/window/platform_configuration.h"
 #include "third_party/tonic/converter/dart_converter.h"
 #include "third_party/tonic/dart_args.h"
 #include "third_party/tonic/dart_binding_macros.h"
+#include "third_party/tonic/dart_persistent_value.h"
 
 #if FML_OS_ANDROID
 #include <sys/mman.h>
@@ -74,6 +77,71 @@ Dart_Handle ImmutableBuffer::initFromAsset(Dart_Handle buffer_handle,
   auto buffer = fml::MakeRefCounted<ImmutableBuffer>(sk_data);
   buffer->AssociateWithDartWrapper(buffer_handle);
   tonic::DartInvoke(callback_handle, {tonic::ToDart(size)});
+  return Dart_Null();
+}
+
+Dart_Handle ImmutableBuffer::initFromFile(Dart_Handle raw_buffer_handle,
+                                          Dart_Handle file_path_handle,
+                                          Dart_Handle callback_handle) {
+  UIDartState::ThrowIfUIOperationsProhibited();
+  if (!Dart_IsClosure(callback_handle)) {
+    return tonic::ToDart("Callback must be a function");
+  }
+
+  uint8_t* chars = nullptr;
+  intptr_t file_path_length = 0;
+  Dart_Handle result =
+      Dart_StringToUTF8(file_path_handle, &chars, &file_path_length);
+  if (Dart_IsError(result)) {
+    return tonic::ToDart("File path must be valid UTF8");
+  }
+
+  std::string file_path = std::string{reinterpret_cast<const char*>(chars),
+                                      static_cast<size_t>(file_path_length)};
+
+  auto* dart_state = UIDartState::Current();
+  auto ui_task_runner = dart_state->GetTaskRunners().GetUITaskRunner();
+  auto buffer_callback =
+      std::make_unique<tonic::DartPersistentValue>(dart_state, callback_handle);
+  auto buffer_handle = std::make_unique<tonic::DartPersistentValue>(
+      dart_state, raw_buffer_handle);
+
+  auto ui_task =
+      fml::MakeCopyable([buffer_callback = std::move(buffer_callback),
+                         buffer_handle = std::move(buffer_handle)](
+                            sk_sp<SkData> sk_data, size_t buffer_size) mutable {
+        auto dart_state = buffer_callback->dart_state().lock();
+        if (!dart_state) {
+          return;
+        }
+        tonic::DartState::Scope scope(dart_state);
+        if (!sk_data) {
+          tonic::DartInvoke(buffer_callback->Get(), {Dart_Null()});
+          return;
+        }
+        auto buffer = fml::MakeRefCounted<ImmutableBuffer>(sk_data);
+        buffer->AssociateWithDartWrapper(buffer_handle->Get());
+        tonic::DartInvoke(buffer_callback->Get(), {tonic::ToDart(buffer_size)});
+      });
+
+  dart_state->GetConcurrentTaskRunner()->PostTask(
+      [file_path = std::move(file_path),
+       ui_task_runner = std::move(ui_task_runner),
+       ui_task = std::move(ui_task)] {
+        auto mapping = std::make_unique<fml::FileMapping>(fml::OpenFile(
+            file_path.c_str(), false, fml::FilePermission::kRead));
+
+        sk_sp<SkData> sk_data;
+        size_t buffer_size = 0;
+        if (mapping->IsValid()) {
+          buffer_size = mapping->GetSize();
+          const void* bytes = static_cast<const void*>(mapping->GetMapping());
+          sk_data = MakeSkDataWithCopy(bytes, buffer_size);
+        }
+        ui_task_runner->PostTask(
+            [sk_data = std::move(sk_data), ui_task = std::move(ui_task),
+             buffer_size]() { ui_task(sk_data, buffer_size); });
+      });
   return Dart_Null();
 }
 

--- a/lib/ui/painting/immutable_buffer.cc
+++ b/lib/ui/painting/immutable_buffer.cc
@@ -127,8 +127,7 @@ Dart_Handle ImmutableBuffer::initFromFile(Dart_Handle raw_buffer_handle,
 
   dart_state->GetConcurrentTaskRunner()->PostTask(
       [file_path = std::move(file_path),
-       ui_task_runner = std::move(ui_task_runner),
-       ui_task] {
+       ui_task_runner = std::move(ui_task_runner), ui_task] {
         auto mapping = std::make_unique<fml::FileMapping>(fml::OpenFile(
             file_path.c_str(), false, fml::FilePermission::kRead));
 

--- a/lib/ui/painting/immutable_buffer.cc
+++ b/lib/ui/painting/immutable_buffer.cc
@@ -116,7 +116,8 @@ Dart_Handle ImmutableBuffer::initFromFile(Dart_Handle raw_buffer_handle,
         }
         tonic::DartState::Scope scope(dart_state);
         if (!sk_data) {
-          tonic::DartInvoke(buffer_callback->Get(), {Dart_Null()});
+          // -1 is used as a sentinel that the file could not be opened.
+          tonic::DartInvoke(buffer_callback->Get(), {tonic::ToDart(-1)});
           return;
         }
         auto buffer = fml::MakeRefCounted<ImmutableBuffer>(sk_data);

--- a/lib/ui/painting/immutable_buffer.cc
+++ b/lib/ui/painting/immutable_buffer.cc
@@ -106,10 +106,10 @@ Dart_Handle ImmutableBuffer::initFromFile(Dart_Handle raw_buffer_handle,
   auto buffer_handle = std::make_unique<tonic::DartPersistentValue>(
       dart_state, raw_buffer_handle);
 
-  auto ui_task =
-      fml::MakeCopyable([buffer_callback = std::move(buffer_callback),
-                         buffer_handle = std::move(buffer_handle)](
-                            sk_sp<SkData> sk_data, size_t buffer_size) mutable {
+  auto ui_task = fml::MakeCopyable(
+      [buffer_callback = std::move(buffer_callback),
+       buffer_handle = std::move(buffer_handle)](const sk_sp<SkData>& sk_data,
+                                                 size_t buffer_size) mutable {
         auto dart_state = buffer_callback->dart_state().lock();
         if (!dart_state) {
           return;
@@ -128,7 +128,7 @@ Dart_Handle ImmutableBuffer::initFromFile(Dart_Handle raw_buffer_handle,
   dart_state->GetConcurrentTaskRunner()->PostTask(
       [file_path = std::move(file_path),
        ui_task_runner = std::move(ui_task_runner),
-       ui_task = std::move(ui_task)] {
+       ui_task] {
         auto mapping = std::make_unique<fml::FileMapping>(fml::OpenFile(
             file_path.c_str(), false, fml::FilePermission::kRead));
 

--- a/lib/ui/painting/immutable_buffer.h
+++ b/lib/ui/painting/immutable_buffer.h
@@ -56,6 +56,20 @@ class ImmutableBuffer : public RefCountedDartWrappable<ImmutableBuffer> {
                                    Dart_Handle asset_name_handle,
                                    Dart_Handle callback_handle);
 
+  /// Initializes a new ImmutableData from an File path.
+  ///
+  /// The zero indexed argument is the caller that will be registered as the
+  /// Dart peer of the native ImmutableBuffer object.
+  ///
+  /// The first indexed argumented is a String corresponding to the file path
+  /// to load.
+  ///
+  /// The second indexed argument is expected to be a void callback to signal
+  /// when the copy has completed.
+  static Dart_Handle initFromFile(Dart_Handle buffer_handle,
+                                  Dart_Handle file_path_handle,
+                                  Dart_Handle callback_handle);
+
   /// The length of the data in bytes.
   size_t length() const {
     FML_DCHECK(data_);

--- a/lib/ui/ui_dart_state.cc
+++ b/lib/ui/ui_dart_state.cc
@@ -147,7 +147,8 @@ std::shared_ptr<VolatilePathTracker> UIDartState::GetVolatilePathTracker()
   return context_.volatile_path_tracker;
 }
 
-std::shared_ptr<fml::ConcurrentTaskRunner> UIDartState::GetConcurrentTaskRunner() const {
+std::shared_ptr<fml::ConcurrentTaskRunner>
+UIDartState::GetConcurrentTaskRunner() const {
   return context_.concurrent_task_runner;
 }
 

--- a/lib/ui/ui_dart_state.cc
+++ b/lib/ui/ui_dart_state.cc
@@ -38,6 +38,7 @@ UIDartState::Context::Context(
     std::string advisory_script_uri,
     std::string advisory_script_entrypoint,
     std::shared_ptr<VolatilePathTracker> volatile_path_tracker,
+    std::shared_ptr<fml::ConcurrentTaskRunner> concurrent_task_runner,
     bool enable_impeller)
     : task_runners(task_runners),
       snapshot_delegate(std::move(snapshot_delegate)),
@@ -48,6 +49,7 @@ UIDartState::Context::Context(
       advisory_script_uri(std::move(advisory_script_uri)),
       advisory_script_entrypoint(std::move(advisory_script_entrypoint)),
       volatile_path_tracker(std::move(volatile_path_tracker)),
+      concurrent_task_runner(concurrent_task_runner),
       enable_impeller(enable_impeller) {}
 
 UIDartState::UIDartState(
@@ -143,6 +145,10 @@ fml::RefPtr<flutter::SkiaUnrefQueue> UIDartState::GetSkiaUnrefQueue() const {
 std::shared_ptr<VolatilePathTracker> UIDartState::GetVolatilePathTracker()
     const {
   return context_.volatile_path_tracker;
+}
+
+std::shared_ptr<fml::ConcurrentTaskRunner> UIDartState::GetConcurrentTaskRunner() const {
+  return context_.concurrent_task_runner;
 }
 
 void UIDartState::ScheduleMicrotask(Dart_Handle closure) {

--- a/lib/ui/ui_dart_state.h
+++ b/lib/ui/ui_dart_state.h
@@ -54,6 +54,7 @@ class UIDartState : public tonic::DartState {
             std::string advisory_script_uri,
             std::string advisory_script_entrypoint,
             std::shared_ptr<VolatilePathTracker> volatile_path_tracker,
+            std::shared_ptr<fml::ConcurrentTaskRunner> concurrent_task_runner,
             bool enable_impeller);
 
     /// The task runners used by the shell hosting this runtime controller. This
@@ -93,6 +94,10 @@ class UIDartState : public tonic::DartState {
     /// Cache for tracking path volatility.
     std::shared_ptr<VolatilePathTracker> volatile_path_tracker;
 
+    /// The task runner whose tasks may be executed concurrently on a pool
+    /// of shared worker threads.
+    std::shared_ptr<fml::ConcurrentTaskRunner> concurrent_task_runner;
+
     /// Whether Impeller is enabled or not.
     bool enable_impeller = false;
   };
@@ -127,6 +132,8 @@ class UIDartState : public tonic::DartState {
   fml::RefPtr<flutter::SkiaUnrefQueue> GetSkiaUnrefQueue() const;
 
   std::shared_ptr<VolatilePathTracker> GetVolatilePathTracker() const;
+
+  std::shared_ptr<fml::ConcurrentTaskRunner> GetConcurrentTaskRunner() const;
 
   fml::WeakPtr<SnapshotDelegate> GetSnapshotDelegate() const;
 

--- a/lib/web_ui/lib/painting.dart
+++ b/lib/web_ui/lib/painting.dart
@@ -728,6 +728,10 @@ class ImmutableBuffer {
     throw UnsupportedError('ImmutableBuffer.fromAsset is not supported on the web.');
   }
 
+  static Future<ImmutableBuffer> fromFilePath(String path) async {
+    throw UnsupportedError('ImmutableBuffer.fromFilePath is not supported on the web.');
+  }
+
   Uint8List? _list;
 
   int get length => _length;

--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -61,7 +61,8 @@ std::unique_ptr<RuntimeController> RuntimeController::Spawn(
       std::move(io_manager),          context_.unref_queue,
       std::move(image_decoder),       std::move(image_generator_registry),
       std::move(advisory_script_uri), std::move(advisory_script_entrypoint),
-      context_.volatile_path_tracker, context_.enable_impeller};
+      context_.volatile_path_tracker, context_.concurrent_task_runner,
+      context_.enable_impeller};
   auto result =
       std::make_unique<RuntimeController>(p_client,                      //
                                           vm_,                           //

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -100,6 +100,7 @@ Engine::Engine(Delegate& delegate,
           settings_.advisory_script_uri,           // advisory script uri
           settings_.advisory_script_entrypoint,    // advisory script entrypoint
           std::move(volatile_path_tracker),        // volatile path tracker
+          vm.GetConcurrentWorkerTaskRunner(),      // concurrent task runner
           settings_.enable_impeller,               // enable impeller
       });
 }

--- a/testing/dart/assets_test.dart
+++ b/testing/dart/assets_test.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 import 'dart:typed_data';
 import 'dart:ui';
 

--- a/testing/dart/assets_test.dart
+++ b/testing/dart/assets_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 import 'dart:typed_data';
 import 'dart:ui';
 
@@ -39,6 +40,8 @@ void main() {
   });
 
   test('returns the bytes of a file', () async {
+    print("CURRENT:");
+    print(Directory.current);
     final ImmutableBuffer buffer = await ImmutableBuffer.fromFilePath('gen/flutter/lib/ui/assets/DashInNooglerHat.jpg');
 
     expect(buffer.length == 354679, true);

--- a/testing/dart/assets_test.dart
+++ b/testing/dart/assets_test.dart
@@ -21,8 +21,25 @@ void main() {
     expect(error is Exception, true);
   });
 
+  test('Loading a file that does not exist returns null', () async {
+    Object? error;
+    try {
+      await ImmutableBuffer.fromFilePath('ThisDoesNotExist');
+    } catch (err) {
+      error = err;
+    }
+    expect(error, isNotNull);
+    expect(error is Exception, true);
+  });
+
   test('returns the bytes of a bundled asset', () async {
     final ImmutableBuffer buffer = await ImmutableBuffer.fromAsset('DashInNooglerHat.jpg');
+
+    expect(buffer.length == 354679, true);
+  });
+
+  test('returns the bytes of a file', () async {
+    final ImmutableBuffer buffer = await ImmutableBuffer.fromFilePath('assets/DashInNooglerHat.jpg');
 
     expect(buffer.length == 354679, true);
   });

--- a/testing/dart/assets_test.dart
+++ b/testing/dart/assets_test.dart
@@ -40,9 +40,7 @@ void main() {
   });
 
   test('returns the bytes of a file', () async {
-    print("CURRENT:");
-    print(Directory.current);
-    final ImmutableBuffer buffer = await ImmutableBuffer.fromFilePath('gen/flutter/lib/ui/assets/DashInNooglerHat.jpg');
+    final ImmutableBuffer buffer = await ImmutableBuffer.fromFilePath('flutter/lib/ui/fixtures/DashInNooglerHat.jpg');
 
     expect(buffer.length == 354679, true);
   });

--- a/testing/dart/assets_test.dart
+++ b/testing/dart/assets_test.dart
@@ -39,7 +39,7 @@ void main() {
   });
 
   test('returns the bytes of a file', () async {
-    final ImmutableBuffer buffer = await ImmutableBuffer.fromFilePath('assets/DashInNooglerHat.jpg');
+    final ImmutableBuffer buffer = await ImmutableBuffer.fromFilePath('gen/flutter/lib/ui/assets/DashInNooglerHat.jpg');
 
     expect(buffer.length == 354679, true);
   });


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/112958

Loads the file bytes in a background worker, allowing very large files to be loaded without causing visible UI jank. Works around issues where dart:io struggles to load bytes on certain platforms above a given size