### PR TITLE
[Impeller] Make stroke round cap/join smoothing way less aggressive

### DIFF
--- a/impeller/entity/contents/solid_stroke_contents.cc
+++ b/impeller/entity/contents/solid_stroke_contents.cc
@@ -10,7 +10,6 @@
 #include "impeller/entity/contents/content_context.h"
 #include "impeller/entity/entity.h"
 #include "impeller/geometry/path_builder.h"
-#include "impeller/renderer/formats.h"
 #include "impeller/renderer/render_pass.h"
 
 namespace impeller {

--- a/impeller/entity/contents/solid_stroke_contents.cc
+++ b/impeller/entity/contents/solid_stroke_contents.cc
@@ -212,7 +212,6 @@ bool SolidStrokeContents::Render(const ContentContext& renderer,
   }
   cmd.pipeline = renderer.GetSolidStrokePipeline(options);
   cmd.stencil_reference = entity.GetStencilDepth();
-  cmd.primitive_type = PrimitiveType::kLineStrip;
 
   auto smoothing = SmoothingApproximation(
       60.0 / (stroke_size_ * entity.GetTransformation().GetMaxBasisLength()),

--- a/impeller/entity/contents/solid_stroke_contents.cc
+++ b/impeller/entity/contents/solid_stroke_contents.cc
@@ -10,6 +10,7 @@
 #include "impeller/entity/contents/content_context.h"
 #include "impeller/entity/entity.h"
 #include "impeller/geometry/path_builder.h"
+#include "impeller/renderer/formats.h"
 #include "impeller/renderer/render_pass.h"
 
 namespace impeller {
@@ -211,9 +212,10 @@ bool SolidStrokeContents::Render(const ContentContext& renderer,
   }
   cmd.pipeline = renderer.GetSolidStrokePipeline(options);
   cmd.stencil_reference = entity.GetStencilDepth();
+  cmd.primitive_type = PrimitiveType::kLineStrip;
 
   auto smoothing = SmoothingApproximation(
-      5.0 / (stroke_size_ * entity.GetTransformation().GetMaxBasisLength()),
+      60.0 / (stroke_size_ * entity.GetTransformation().GetMaxBasisLength()),
       0.0, 0.0);
 
   Scalar min_size = 1.0f / sqrt(std::abs(determinant));


### PR DESCRIPTION
I noticed the geometry was extremely dense in a frame capture.

Videos of the new round cap smoothing behavior:

https://user-images.githubusercontent.com/919017/194152274-128b2bb8-a322-4b67-8269-29dc1890cd58.mov

https://user-images.githubusercontent.com/919017/194152289-3f276b08-64bc-4c38-b8fa-eacc8ff02f29.mov

