### PR TITLE
[iOS] Eliminate framework bitcode stripping flag

### DIFF
--- a/ci/builders/mac_ios_engine_release.json
+++ b/ci/builders/mac_ios_engine_release.json
@@ -102,7 +102,6 @@
                     "out/ios_debug_sim",
                     "--simulator-arm64-out-dir",
                     "out/ios_debug_sim_arm64",
-                    "--strip-bitcode",
                     "--dsym",
                     "--strip"
                 ],

--- a/sky/tools/create_full_ios_framework.py
+++ b/sky/tools/create_full_ios_framework.py
@@ -41,12 +41,6 @@ def main():
   parser.add_argument('--simulator-arm64-out-dir', type=str, required=False)
   parser.add_argument('--strip', action="store_true", default=False)
   parser.add_argument('--dsym', action="store_true", default=False)
-  parser.add_argument(
-      '--strip-bitcode',
-      dest='strip_bitcode',
-      action="store_true",
-      default=False
-  )
 
   args = parser.parse_args()
 
@@ -201,11 +195,6 @@ def zip_archive(dst):
 
 
 def process_framework(args, dst, framework, framework_binary):
-  if args.strip_bitcode:
-    subprocess.check_call([
-        'xcrun', 'bitcode_strip', '-r', framework_binary, '-o', framework_binary
-    ])
-
   if args.dsym:
     dsym_out = os.path.splitext(framework)[0] + '.dSYM'
     subprocess.check_call([DSYMUTIL, '-o', dsym_out, framework_binary])

--- a/sky/tools/create_ios_framework.py
+++ b/sky/tools/create_ios_framework.py
@@ -33,12 +33,6 @@ def main():
   parser.add_argument('--simulator-arm64-out-dir', type=str, required=False)
   parser.add_argument('--strip', action="store_true", default=False)
   parser.add_argument('--dsym', action="store_true", default=False)
-  parser.add_argument(
-      '--strip-bitcode',
-      dest='strip_bitcode',
-      action="store_true",
-      default=False
-  )
 
   args = parser.parse_args()
 
@@ -113,11 +107,6 @@ def main():
 
 
 def process_framework(args, framework, framework_binary):
-  if args.strip_bitcode:
-    subprocess.check_call([
-        'xcrun', 'bitcode_strip', '-r', framework_binary, '-o', framework_binary
-    ])
-
   if args.dsym:
     dsym_out = os.path.splitext(framework)[0] + '.dSYM'
     subprocess.check_call([DSYMUTIL, '-o', dsym_out, framework_binary])


### PR DESCRIPTION
Eliminates the `--strip-bitcode` flag from the `create_ios_framework.py` and `create_full_ios_framework.py` scripts.

Issue: https://github.com/flutter/flutter/issues/107884


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
