### PR TITLE
Roll buildroot to use Fuchsia toolchain for iOS arm simulator

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -33,7 +33,7 @@ config("export_dynamic_symbols") {
   if (is_linux || is_fuchsia) {
     inputs = [ "//flutter/common/exported_symbols.sym" ]
     ldflags = [ "-Wl,--dynamic-list=" + rebase_path(inputs[0], root_build_dir) ]
-  } else if (is_mac && !use_xcode) {
+  } else if (is_mac) {
     inputs = [ "//flutter/common/exported_symbols_mac.sym" ]
     ldflags = [
       "-Xlinker",

--- a/DEPS
+++ b/DEPS
@@ -109,7 +109,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '6c65790a359a1fd24da736f54fe97236d0f1e249',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '2fd45de1f80de6b535163573463924b4be68def0',
 
    # Fuchsia compatibility
    #


### PR DESCRIPTION
Pick up https://github.com/flutter/buildroot/pull/636. Remove `use_xcode` usage.

https://github.com/flutter/flutter/issues/112992