### PR TITLE
Use Xcode 14 for all builders

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -56,7 +56,7 @@ platform_properties:
       device_type: none
       cpu: x86
       os: Mac-12
-      xcode: 13a233 # xcode 13.0
+      xcode: 14a5294e # xcode 14.0 beta 5
   windows:
     properties:
       build_host: "false"
@@ -327,7 +327,6 @@ targets:
           "ios-13-0",
           "ios-16-0_14a5294e"
         ]
-      xcode: 14a5294e # xcode 14.0 beta 5
     timeout: 75
 
   - name: Mac Host clang-tidy
@@ -335,7 +334,6 @@ targets:
     properties:
       add_recipes_cq: "true"
       jazzy_version: "0.14.1"
-      xcode: 14a5294e # xcode 14.0 beta 5
       lint_host: "true"
       lint_ios: "false"
     timeout: 75
@@ -345,7 +343,6 @@ targets:
     properties:
       add_recipes_cq: "true"
       jazzy_version: "0.14.1"
-      xcode: 14a5294e # xcode 14.0 beta 5
       lint_host: "false"
       lint_ios: "true"
     timeout: 75


### PR DESCRIPTION
The release builder used to need to run the oldest version of Xcode that the tool supported, because of clang version constraints.  https://github.com/flutter/flutter/issues/107884 removed bitcode from the engine, so all builders should be able to use the latest version of Xcode

Fixes https://github.com/flutter/flutter/issues/112994

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
