### PR TITLE
iPhone floating cursor selection

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h
@@ -100,6 +100,10 @@ typedef NS_ENUM(NSInteger, FlutterScribbleInteractionStatus) {
 
 + (instancetype)selectionRectWithRect:(CGRect)rect position:(NSUInteger)position;
 
++ (instancetype)selectionRectWithRect:(CGRect)rect
+                             position:(NSUInteger)position
+                     writingDirection:(NSWritingDirection)writingDirection;
+
 - (instancetype)initWithRectAndInfo:(CGRect)rect
                            position:(NSUInteger)position
                    writingDirection:(NSWritingDirection)writingDirection

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h
@@ -114,6 +114,8 @@ typedef NS_ENUM(NSInteger, FlutterScribbleInteractionStatus) {
                          isVertical:(BOOL)isVertical;
 
 - (instancetype)init NS_UNAVAILABLE;
+
+- (BOOL)isRTL;
 @end
 
 API_AVAILABLE(ios(13.0)) @interface FlutterTextPlaceholder : UITextPlaceholder

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h
@@ -63,9 +63,11 @@ typedef NS_ENUM(NSInteger, FlutterScribbleInteractionStatus) {
 @interface FlutterTextPosition : UITextPosition
 
 @property(nonatomic, readonly) NSUInteger index;
+@property(nonatomic, readonly) UITextStorageDirection affinity;
 
 + (instancetype)positionWithIndex:(NSUInteger)index;
-- (instancetype)initWithIndex:(NSUInteger)index;
++ (instancetype)positionWithIndex:(NSUInteger)index affinity:(UITextStorageDirection)affinity;
+- (instancetype)initWithIndex:(NSUInteger)index affinity:(UITextStorageDirection)affinity;
 
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -440,7 +440,8 @@ static BOOL IsSelectionRectCloserToPoint(CGPoint point,
                                          BOOL selectionRectIsRTL,
                                          CGRect otherSelectionRect,
                                          BOOL otherSelectionRectIsRTL,
-                                         BOOL checkFarBoundary) {
+                                         BOOL checkFarBoundary,
+                                         CGFloat verticalPrecision) {
   if (CGRectContainsPoint(
           CGRectMake(
               selectionRect.origin.x +
@@ -465,8 +466,8 @@ static BOOL IsSelectionRectCloserToPoint(CGPoint point,
   // This serves a similar purpose to IsApproximatelyEqual, allowing a little buffer before
   // declaring something closer vertically to account for the small variations in size and position
   // of SelectionRects, especially when dealing with emoji.
-  BOOL isCloserVertically = yDist < yDistOther - 1;
-  BOOL isEqualVertically = IsApproximatelyEqual(yDist, yDistOther, 1);
+  BOOL isCloserVertically = yDist < yDistOther - verticalPrecision;
+  BOOL isEqualVertically = IsApproximatelyEqual(yDist, yDistOther, verticalPrecision);
   BOOL isAboveBottomOfLine = point.y <= selectionRect.origin.y + selectionRect.size.height;
   BOOL isCloserHorizontally = xDist <= xDistOther;
   BOOL isBelowBottomOfLine = point.y > selectionRect.origin.y + selectionRect.size.height;
@@ -750,6 +751,7 @@ static BOOL IsSelectionRectCloserToPoint(CGPoint point,
   // becomes the first responder. Typically set to false
   // when the app shows its own in-flutter keyboard.
   bool _isSystemKeyboardEnabled;
+  bool _isFloatingCursorActive;
   CGPoint _floatingCursorOffset;
   bool _enableInteractiveSelection;
   UITextInteraction* _textInteraction API_AVAILABLE(ios(13.0));
@@ -1729,6 +1731,10 @@ static BOOL IsSelectionRectCloserToPoint(CGPoint point,
   NSUInteger start = ((FlutterTextPosition*)range.start).index;
   NSUInteger end = ((FlutterTextPosition*)range.end).index;
 
+  // Selecting text using the floating cursor is not as precise as the pencil.
+  // Allow further vertical deviation and base more of the decision on horizontal comparison.
+  CGFloat verticalPrecision = _isFloatingCursorActive ? 10 : 1;
+
   BOOL isFirst = YES;
   CGRect _closestRect = CGRectZero;
   BOOL _closestRectIsRTL = NO;
@@ -1740,7 +1746,7 @@ static BOOL IsSelectionRectCloserToPoint(CGPoint point,
                          point, _selectionRects[i].rect,
                          _selectionRects[i].writingDirection == NSWritingDirectionRightToLeft,
                          _closestRect, _closestRectIsRTL,
-                         /*checkFarBoundary=*/NO)) {
+                         /*checkFarBoundary=*/NO, verticalPrecision)) {
         isFirst = NO;
         _closestRect = _selectionRects[i].rect;
         _closestRectIsRTL = _selectionRects[i].writingDirection == NSWritingDirectionRightToLeft;
@@ -1756,7 +1762,7 @@ static BOOL IsSelectionRectCloserToPoint(CGPoint point,
               point, _selectionRects[i].rect,
               _selectionRects[i].writingDirection == NSWritingDirectionRightToLeft, _closestRect,
               _closestRectIsRTL,
-              /*checkFarBoundary=*/YES)) {
+              /*checkFarBoundary=*/YES, verticalPrecision)) {
         _closestPosition = position;
       }
     }
@@ -1786,6 +1792,7 @@ static BOOL IsSelectionRectCloserToPoint(CGPoint point,
   // It seems impossible to use a negative "width" or "height", as the "convertRect"
   // call always turns a CGRect's negative dimensions into non-negative values, e.g.,
   // (1, 2, -3, -4) would become (-2, -2, 3, 4).
+  _isFloatingCursorActive = YES;
   _floatingCursorOffset = point;
   [self.textInputDelegate flutterTextInputView:self
                           updateFloatingCursor:FlutterFloatingCursorDragStateStart
@@ -1804,6 +1811,7 @@ static BOOL IsSelectionRectCloserToPoint(CGPoint point,
 }
 
 - (void)endFloatingCursor {
+  _isFloatingCursorActive = NO;
   [self.textInputDelegate flutterTextInputView:self
                           updateFloatingCursor:FlutterFloatingCursorDragStateEnd
                                     withClient:_textInputClient

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -1665,11 +1665,15 @@ static BOOL IsSelectionRectCloserToPoint(CGPoint point,
   NSInteger index = ((FlutterTextPosition*)position).index;
   UITextStorageDirection affinity = ((FlutterTextPosition*)position).affinity;
   // Get the bounds of the characters before and after the requested caret position.
-  NSArray<UITextSelectionRect*>* rects =
-      [self selectionRectsForRange:[FlutterTextRange
-                                       rangeWithNSRange:fml::RangeForCharactersInRange(
-                                                            self.text,
-                                                            NSMakeRange(MAX(0, index - 1), 2))]];
+  NSArray<UITextSelectionRect*>* rects = [self
+      selectionRectsForRange:[FlutterTextRange
+                                 rangeWithNSRange:fml::RangeForCharactersInRange(
+                                                      self.text,
+                                                      NSMakeRange(
+                                                          MAX(0, index - 1),
+                                                          (index >= (NSInteger)self.text.length)
+                                                              ? 1
+                                                              : 2))]];
   if (rects.count == 0) {
     return CGRectZero;
   }
@@ -1743,7 +1747,8 @@ static BOOL IsSelectionRectCloserToPoint(CGPoint point,
   NSMutableArray* rects = [[NSMutableArray alloc] init];
   for (NSUInteger i = 0; i < [_selectionRects count]; i++) {
     if (_selectionRects[i].position >= start &&
-        (_selectionRects[i].position < end || start == end)) {
+        (_selectionRects[i].position < end ||
+         (start == end && _selectionRects[i].position <= end))) {
       float width = _selectionRects[i].rect.size.width;
       if (start == end) {
         width = 0;

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -1636,36 +1636,36 @@ static BOOL IsSelectionRectCloserToPoint(CGPoint point,
     // There is no character before the caret, so this will be the bounds of the character after the
     // caret position.
     CGRect characterAfterCaret = rects[0].rect;
-    // Return a zero-width rectangle 30% in from the left edge of the character after the caret
+    // Return a zero-width rectangle along the upstream edge of the character after the caret
     // position.
     if ([self isRTLAtPosition:index]) {
-      return CGRectMake(characterAfterCaret.origin.x + 0.7 * characterAfterCaret.size.width,
+      return CGRectMake(characterAfterCaret.origin.x + characterAfterCaret.size.width,
                         characterAfterCaret.origin.y, 0, characterAfterCaret.size.height);
     } else {
-      return CGRectMake(characterAfterCaret.origin.x + 0.3 * characterAfterCaret.size.width,
-                        characterAfterCaret.origin.y, 0, characterAfterCaret.size.height);
+      return CGRectMake(characterAfterCaret.origin.x, characterAfterCaret.origin.y, 0,
+                        characterAfterCaret.size.height);
     }
   } else if (rects.count == 2 && _selectionAffinity == kTextAffinityDownstream) {
     // It's better to use the character after the caret.
     CGRect characterAfterCaret = rects[1].rect;
-    // Return a zero-width rectangle 30% in from the left edge of the character after the caret
+    // Return a zero-width rectangle along the upstream edge of the character after the caret
     // position.
     if ([self isRTLAtPosition:index]) {
-      return CGRectMake(characterAfterCaret.origin.x + 0.7 * characterAfterCaret.size.width,
+      return CGRectMake(characterAfterCaret.origin.x + characterAfterCaret.size.width,
                         characterAfterCaret.origin.y, 0, characterAfterCaret.size.height);
     } else {
-      return CGRectMake(characterAfterCaret.origin.x + 0.3 * characterAfterCaret.size.width,
-                        characterAfterCaret.origin.y, 0, characterAfterCaret.size.height);
+      return CGRectMake(characterAfterCaret.origin.x, characterAfterCaret.origin.y, 0,
+                        characterAfterCaret.size.height);
     }
   }
   CGRect characterBeforeCaret = rects[0].rect;
-  // Return a zero-width rectangle 30% in from the right edge of the character before the caret
+  // Return a zero-width rectangle along the downstream edge of the character before the caret
   // position.
   if ([self isRTLAtPosition:index - 1]) {
-    return CGRectMake(characterBeforeCaret.origin.x + 0.3 * characterBeforeCaret.size.width,
-                      characterBeforeCaret.origin.y, 0, characterBeforeCaret.size.height);
+    return CGRectMake(characterBeforeCaret.origin.x, characterBeforeCaret.origin.y, 0,
+                      characterBeforeCaret.size.height);
   } else {
-    return CGRectMake(characterBeforeCaret.origin.x + 0.7 * characterBeforeCaret.size.width,
+    return CGRectMake(characterBeforeCaret.origin.x + characterBeforeCaret.size.width,
                       characterBeforeCaret.origin.y, 0, characterBeforeCaret.size.height);
   }
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -1592,6 +1592,7 @@ static BOOL IsSelectionRectCloserToPoint(CGPoint point,
 
 - (CGRect)caretRectForPosition:(UITextPosition*)position {
   NSInteger index = ((FlutterTextPosition*)position).index;
+  // Get the bounds of the characters before and after the requested caret position.
   NSArray<UITextSelectionRect*>* rects =
       [self selectionRectsForRange:[FlutterTextRange
                                        rangeWithNSRange:fml::RangeForCharactersInRange(
@@ -1601,10 +1602,17 @@ static BOOL IsSelectionRectCloserToPoint(CGPoint point,
     return CGRectZero;
   }
   if (index == 0) {
-    return CGRectMake(rects[0].rect.origin.x, rects[0].rect.origin.y, 0, rects[0].rect.size.height);
+    // There is no character before the caret, so this will be the bounds of the character after the
+    // caret position.
+    CGRect characterAfterCaret = rects[0].rect;
+    // Return a zero-width rectangle along the left edge of the character after the caret position.
+    return CGRectMake(characterAfterCaret.origin.x, characterAfterCaret.origin.y, 0,
+                      characterAfterCaret.size.height);
   }
-  return CGRectMake(rects[0].rect.origin.x + rects[0].rect.size.width, rects[0].rect.origin.y, 0,
-                    rects[0].rect.size.height);
+  CGRect characterBeforeCaret = rects[0].rect;
+  // Return a zero-width rectangle along the right edge of the character before the caret position.
+  return CGRectMake(characterBeforeCaret.origin.x + characterBeforeCaret.size.width,
+                    characterBeforeCaret.origin.y, 0, characterBeforeCaret.size.height);
 }
 
 - (UITextPosition*)closestPositionToPoint:(CGPoint)point {
@@ -1724,7 +1732,7 @@ static BOOL IsSelectionRectCloserToPoint(CGPoint point,
   [self.textInputDelegate flutterTextInputView:self
                           updateFloatingCursor:FlutterFloatingCursorDragStateStart
                                     withClient:_textInputClient
-                                  withPosition:@{@"X" : @(0), @"Y" : @(0)}];
+                                  withPosition:@{@"X" : @0, @"Y" : @0}];
 }
 
 - (void)updateFloatingCursorAtPoint:(CGPoint)point {
@@ -1743,7 +1751,7 @@ static BOOL IsSelectionRectCloserToPoint(CGPoint point,
   [self.textInputDelegate flutterTextInputView:self
                           updateFloatingCursor:FlutterFloatingCursorDragStateEnd
                                     withClient:_textInputClient
-                                  withPosition:@{@"X" : @(0), @"Y" : @(0)}];
+                                  withPosition:@{@"X" : @0, @"Y" : @0}];
 }
 
 #pragma mark - UIKeyInput Overrides

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -1366,6 +1366,8 @@ FLUTTER_ASSERT_ARC
   ]];
   CGPoint point = CGPointMake(150, 150);
   XCTAssertEqual(2U, ((FlutterTextPosition*)[inputView closestPositionToPoint:point]).index);
+  XCTAssertEqual(UITextStorageDirectionBackward,
+                 ((FlutterTextPosition*)[inputView closestPositionToPoint:point]).affinity);
 
   // Then, if the point is above the bottom of the closest rects vertically, get the closest x
   // origin
@@ -1378,6 +1380,8 @@ FLUTTER_ASSERT_ARC
   ]];
   point = CGPointMake(125, 150);
   XCTAssertEqual(2U, ((FlutterTextPosition*)[inputView closestPositionToPoint:point]).index);
+  XCTAssertEqual(UITextStorageDirectionForward,
+                 ((FlutterTextPosition*)[inputView closestPositionToPoint:point]).affinity);
 
   // However, if the point is below the bottom of the closest rects vertically, get the position
   // farthest to the right
@@ -1390,6 +1394,8 @@ FLUTTER_ASSERT_ARC
   ]];
   point = CGPointMake(125, 201);
   XCTAssertEqual(4U, ((FlutterTextPosition*)[inputView closestPositionToPoint:point]).index);
+  XCTAssertEqual(UITextStorageDirectionBackward,
+                 ((FlutterTextPosition*)[inputView closestPositionToPoint:point]).affinity);
 
   // Also check a point at the right edge of the last selection rect
   [inputView setSelectionRects:@[
@@ -1400,6 +1406,8 @@ FLUTTER_ASSERT_ARC
   ]];
   point = CGPointMake(125, 250);
   XCTAssertEqual(4U, ((FlutterTextPosition*)[inputView closestPositionToPoint:point]).index);
+  XCTAssertEqual(UITextStorageDirectionBackward,
+                 ((FlutterTextPosition*)[inputView closestPositionToPoint:point]).affinity);
 
   // Minimize vertical distance if the difference is more than 1 point.
   [inputView setSelectionRects:@[
@@ -1409,11 +1417,15 @@ FLUTTER_ASSERT_ARC
   ]];
   point = CGPointMake(110, 50);
   XCTAssertEqual(2U, ((FlutterTextPosition*)[inputView closestPositionToPoint:point]).index);
+  XCTAssertEqual(UITextStorageDirectionForward,
+                 ((FlutterTextPosition*)[inputView closestPositionToPoint:point]).affinity);
 
   // In floating cursor mode, the vertical difference is allowed to be 10 points.
   // The closest horizontal position will now win.
   [inputView beginFloatingCursorAtPoint:CGPointZero];
   XCTAssertEqual(1U, ((FlutterTextPosition*)[inputView closestPositionToPoint:point]).index);
+  XCTAssertEqual(UITextStorageDirectionForward,
+                 ((FlutterTextPosition*)[inputView closestPositionToPoint:point]).affinity);
   [inputView endFloatingCursor];
 }
 
@@ -1435,20 +1447,28 @@ FLUTTER_ASSERT_ARC
                                            position:3U
                                    writingDirection:NSWritingDirectionRightToLeft],
   ]];
-  XCTAssertEqual(
-      0U, ((FlutterTextPosition*)[inputView closestPositionToPoint:CGPointMake(275, 50)]).index);
-  XCTAssertEqual(
-      1U, ((FlutterTextPosition*)[inputView closestPositionToPoint:CGPointMake(225, 50)]).index);
-  XCTAssertEqual(
-      1U, ((FlutterTextPosition*)[inputView closestPositionToPoint:CGPointMake(175, 50)]).index);
-  XCTAssertEqual(
-      2U, ((FlutterTextPosition*)[inputView closestPositionToPoint:CGPointMake(125, 50)]).index);
-  XCTAssertEqual(
-      2U, ((FlutterTextPosition*)[inputView closestPositionToPoint:CGPointMake(75, 50)]).index);
-  XCTAssertEqual(
-      3U, ((FlutterTextPosition*)[inputView closestPositionToPoint:CGPointMake(25, 50)]).index);
-  XCTAssertEqual(
-      3U, ((FlutterTextPosition*)[inputView closestPositionToPoint:CGPointMake(-25, 50)]).index);
+  FlutterTextPosition* position =
+      (FlutterTextPosition*)[inputView closestPositionToPoint:CGPointMake(275, 50)];
+  XCTAssertEqual(0U, position.index);
+  XCTAssertEqual(UITextStorageDirectionForward, position.affinity);
+  position = (FlutterTextPosition*)[inputView closestPositionToPoint:CGPointMake(225, 50)];
+  XCTAssertEqual(1U, position.index);
+  XCTAssertEqual(UITextStorageDirectionBackward, position.affinity);
+  position = (FlutterTextPosition*)[inputView closestPositionToPoint:CGPointMake(175, 50)];
+  XCTAssertEqual(1U, position.index);
+  XCTAssertEqual(UITextStorageDirectionForward, position.affinity);
+  position = (FlutterTextPosition*)[inputView closestPositionToPoint:CGPointMake(125, 50)];
+  XCTAssertEqual(2U, position.index);
+  XCTAssertEqual(UITextStorageDirectionBackward, position.affinity);
+  position = (FlutterTextPosition*)[inputView closestPositionToPoint:CGPointMake(75, 50)];
+  XCTAssertEqual(2U, position.index);
+  XCTAssertEqual(UITextStorageDirectionForward, position.affinity);
+  position = (FlutterTextPosition*)[inputView closestPositionToPoint:CGPointMake(25, 50)];
+  XCTAssertEqual(3U, position.index);
+  XCTAssertEqual(UITextStorageDirectionBackward, position.affinity);
+  position = (FlutterTextPosition*)[inputView closestPositionToPoint:CGPointMake(-25, 50)];
+  XCTAssertEqual(3U, position.index);
+  XCTAssertEqual(UITextStorageDirectionBackward, position.affinity);
 }
 
 - (void)testSelectionRectsForRange {
@@ -1494,6 +1514,9 @@ FLUTTER_ASSERT_ARC
   FlutterTextRange* range = [[FlutterTextRange rangeWithNSRange:NSMakeRange(3, 2)] copy];
   XCTAssertEqual(
       3U, ((FlutterTextPosition*)[inputView closestPositionToPoint:point withinRange:range]).index);
+  XCTAssertEqual(
+      UITextStorageDirectionForward,
+      ((FlutterTextPosition*)[inputView closestPositionToPoint:point withinRange:range]).affinity);
 
   // Do not return a position after the end of the range
   [inputView setSelectionRects:@[
@@ -1507,6 +1530,9 @@ FLUTTER_ASSERT_ARC
   range = [[FlutterTextRange rangeWithNSRange:NSMakeRange(0, 1)] copy];
   XCTAssertEqual(
       1U, ((FlutterTextPosition*)[inputView closestPositionToPoint:point withinRange:range]).index);
+  XCTAssertEqual(
+      UITextStorageDirectionForward,
+      ((FlutterTextPosition*)[inputView closestPositionToPoint:point withinRange:range]).affinity);
 }
 
 #pragma mark - Floating Cursor - Tests

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -1528,23 +1528,23 @@ FLUTTER_ASSERT_ARC
   // Verify zeroth caret rect is based on left edge of first character.
   XCTAssertTrue(
       CGRectEqualToRect([inputView caretRectForPosition:[FlutterTextPosition positionWithIndex:0]],
-                        CGRectMake(30, 0, 0, 100)));
+                        CGRectMake(0, 0, 0, 100)));
   // Since the textAffinity is downstream, the caret rect will be based on the
   // left edge of the succeeding character.
   XCTAssertTrue(
       CGRectEqualToRect([inputView caretRectForPosition:[FlutterTextPosition positionWithIndex:1]],
-                        CGRectMake(130, 100, 0, 100)));
+                        CGRectMake(100, 100, 0, 100)));
   XCTAssertTrue(
       CGRectEqualToRect([inputView caretRectForPosition:[FlutterTextPosition positionWithIndex:2]],
-                        CGRectMake(230, 200, 0, 100)));
+                        CGRectMake(200, 200, 0, 100)));
   XCTAssertTrue(
       CGRectEqualToRect([inputView caretRectForPosition:[FlutterTextPosition positionWithIndex:3]],
-                        CGRectMake(330, 300, 0, 100)));
+                        CGRectMake(300, 300, 0, 100)));
   // There is no subsequent character for the last position, so the caret rect
   // will be based on the right edge of the preceding character.
   XCTAssertTrue(
       CGRectEqualToRect([inputView caretRectForPosition:[FlutterTextPosition positionWithIndex:4]],
-                        CGRectMake(370, 300, 0, 100)));
+                        CGRectMake(400, 300, 0, 100)));
   // Verify no caret rect for out-of-range character.
   XCTAssertTrue(CGRectEqualToRect(
       [inputView caretRectForPosition:[FlutterTextPosition positionWithIndex:5]], CGRectZero));
@@ -1559,21 +1559,21 @@ FLUTTER_ASSERT_ARC
   // Verify zeroth caret rect is based on left edge of first character.
   XCTAssertTrue(
       CGRectEqualToRect([inputView caretRectForPosition:[FlutterTextPosition positionWithIndex:0]],
-                        CGRectMake(30, 0, 0, 100)));
+                        CGRectMake(0, 0, 0, 100)));
   // Since the textAffinity is upstream, all below caret rects will be based on
   // the right edge of the preceding character.
   XCTAssertTrue(
       CGRectEqualToRect([inputView caretRectForPosition:[FlutterTextPosition positionWithIndex:1]],
-                        CGRectMake(70, 0, 0, 100)));
+                        CGRectMake(100, 0, 0, 100)));
   XCTAssertTrue(
       CGRectEqualToRect([inputView caretRectForPosition:[FlutterTextPosition positionWithIndex:2]],
-                        CGRectMake(170, 100, 0, 100)));
+                        CGRectMake(200, 100, 0, 100)));
   XCTAssertTrue(
       CGRectEqualToRect([inputView caretRectForPosition:[FlutterTextPosition positionWithIndex:3]],
-                        CGRectMake(270, 200, 0, 100)));
+                        CGRectMake(300, 200, 0, 100)));
   XCTAssertTrue(
       CGRectEqualToRect([inputView caretRectForPosition:[FlutterTextPosition positionWithIndex:4]],
-                        CGRectMake(370, 300, 0, 100)));
+                        CGRectMake(400, 300, 0, 100)));
   // Verify no caret rect for out-of-range character.
   XCTAssertTrue(CGRectEqualToRect(
       [inputView caretRectForPosition:[FlutterTextPosition positionWithIndex:5]], CGRectZero));

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -389,8 +389,8 @@ FLUTTER_ASSERT_ARC
 
 - (void)testTextRangeFromPositionMatchesUITextViewBehavior {
   FlutterTextInputView* inputView = [[FlutterTextInputView alloc] initWithOwner:textInputPlugin];
-  FlutterTextPosition* fromPosition = [[FlutterTextPosition alloc] initWithIndex:2];
-  FlutterTextPosition* toPosition = [[FlutterTextPosition alloc] initWithIndex:0];
+  FlutterTextPosition* fromPosition = [FlutterTextPosition positionWithIndex:2];
+  FlutterTextPosition* toPosition = [FlutterTextPosition positionWithIndex:0];
 
   FlutterTextRange* flutterRange = (FlutterTextRange*)[inputView textRangeFromPosition:fromPosition
                                                                             toPosition:toPosition];
@@ -1527,7 +1527,6 @@ FLUTTER_ASSERT_ARC
     @"text" : @"test",
     @"selectionBase" : @1,
     @"selectionExtent" : @1,
-    @"selectionAffinity" : @"TextAffinity.downstream"
   }];
 
   FlutterTextSelectionRect* first =
@@ -1541,57 +1540,82 @@ FLUTTER_ASSERT_ARC
   [inputView setSelectionRects:@[ first, second, third, fourth ]];
 
   // Verify zeroth caret rect is based on left edge of first character.
-  XCTAssertTrue(
-      CGRectEqualToRect([inputView caretRectForPosition:[FlutterTextPosition positionWithIndex:0]],
-                        CGRectMake(0, 0, 0, 100)));
+  XCTAssertTrue(CGRectEqualToRect(
+      [inputView caretRectForPosition:[FlutterTextPosition
+                                          positionWithIndex:0
+                                                   affinity:UITextStorageDirectionForward]],
+      CGRectMake(0, 0, 0, 100)));
   // Since the textAffinity is downstream, the caret rect will be based on the
   // left edge of the succeeding character.
-  XCTAssertTrue(
-      CGRectEqualToRect([inputView caretRectForPosition:[FlutterTextPosition positionWithIndex:1]],
-                        CGRectMake(100, 100, 0, 100)));
-  XCTAssertTrue(
-      CGRectEqualToRect([inputView caretRectForPosition:[FlutterTextPosition positionWithIndex:2]],
-                        CGRectMake(200, 200, 0, 100)));
-  XCTAssertTrue(
-      CGRectEqualToRect([inputView caretRectForPosition:[FlutterTextPosition positionWithIndex:3]],
-                        CGRectMake(300, 300, 0, 100)));
+  XCTAssertTrue(CGRectEqualToRect(
+      [inputView caretRectForPosition:[FlutterTextPosition
+                                          positionWithIndex:1
+                                                   affinity:UITextStorageDirectionForward]],
+      CGRectMake(100, 100, 0, 100)));
+  XCTAssertTrue(CGRectEqualToRect(
+      [inputView caretRectForPosition:[FlutterTextPosition
+                                          positionWithIndex:2
+                                                   affinity:UITextStorageDirectionForward]],
+      CGRectMake(200, 200, 0, 100)));
+  XCTAssertTrue(CGRectEqualToRect(
+      [inputView caretRectForPosition:[FlutterTextPosition
+                                          positionWithIndex:3
+                                                   affinity:UITextStorageDirectionForward]],
+      CGRectMake(300, 300, 0, 100)));
   // There is no subsequent character for the last position, so the caret rect
   // will be based on the right edge of the preceding character.
-  XCTAssertTrue(
-      CGRectEqualToRect([inputView caretRectForPosition:[FlutterTextPosition positionWithIndex:4]],
-                        CGRectMake(400, 300, 0, 100)));
+  XCTAssertTrue(CGRectEqualToRect(
+      [inputView caretRectForPosition:[FlutterTextPosition
+                                          positionWithIndex:4
+                                                   affinity:UITextStorageDirectionForward]],
+      CGRectMake(400, 300, 0, 100)));
   // Verify no caret rect for out-of-range character.
   XCTAssertTrue(CGRectEqualToRect(
-      [inputView caretRectForPosition:[FlutterTextPosition positionWithIndex:5]], CGRectZero));
+      [inputView caretRectForPosition:[FlutterTextPosition
+                                          positionWithIndex:5
+                                                   affinity:UITextStorageDirectionForward]],
+      CGRectZero));
 
   // Check caret rects again again when text affinity is upstream.
   [inputView setTextInputState:@{
     @"text" : @"test",
     @"selectionBase" : @2,
     @"selectionExtent" : @2,
-    @"selectionAffinity" : @"TextAffinity.upstream"
   }];
   // Verify zeroth caret rect is based on left edge of first character.
-  XCTAssertTrue(
-      CGRectEqualToRect([inputView caretRectForPosition:[FlutterTextPosition positionWithIndex:0]],
-                        CGRectMake(0, 0, 0, 100)));
+  XCTAssertTrue(CGRectEqualToRect(
+      [inputView caretRectForPosition:[FlutterTextPosition
+                                          positionWithIndex:0
+                                                   affinity:UITextStorageDirectionBackward]],
+      CGRectMake(0, 0, 0, 100)));
   // Since the textAffinity is upstream, all below caret rects will be based on
   // the right edge of the preceding character.
-  XCTAssertTrue(
-      CGRectEqualToRect([inputView caretRectForPosition:[FlutterTextPosition positionWithIndex:1]],
-                        CGRectMake(100, 0, 0, 100)));
-  XCTAssertTrue(
-      CGRectEqualToRect([inputView caretRectForPosition:[FlutterTextPosition positionWithIndex:2]],
-                        CGRectMake(200, 100, 0, 100)));
-  XCTAssertTrue(
-      CGRectEqualToRect([inputView caretRectForPosition:[FlutterTextPosition positionWithIndex:3]],
-                        CGRectMake(300, 200, 0, 100)));
-  XCTAssertTrue(
-      CGRectEqualToRect([inputView caretRectForPosition:[FlutterTextPosition positionWithIndex:4]],
-                        CGRectMake(400, 300, 0, 100)));
+  XCTAssertTrue(CGRectEqualToRect(
+      [inputView caretRectForPosition:[FlutterTextPosition
+                                          positionWithIndex:1
+                                                   affinity:UITextStorageDirectionBackward]],
+      CGRectMake(100, 0, 0, 100)));
+  XCTAssertTrue(CGRectEqualToRect(
+      [inputView caretRectForPosition:[FlutterTextPosition
+                                          positionWithIndex:2
+                                                   affinity:UITextStorageDirectionBackward]],
+      CGRectMake(200, 100, 0, 100)));
+  XCTAssertTrue(CGRectEqualToRect(
+      [inputView caretRectForPosition:[FlutterTextPosition
+                                          positionWithIndex:3
+                                                   affinity:UITextStorageDirectionBackward]],
+      CGRectMake(300, 200, 0, 100)));
+  XCTAssertTrue(CGRectEqualToRect(
+      [inputView caretRectForPosition:[FlutterTextPosition
+                                          positionWithIndex:4
+                                                   affinity:UITextStorageDirectionBackward]],
+      CGRectMake(400, 300, 0, 100)));
   // Verify no caret rect for out-of-range character.
   XCTAssertTrue(CGRectEqualToRect(
-      [inputView caretRectForPosition:[FlutterTextPosition positionWithIndex:5]], CGRectZero));
+      [inputView caretRectForPosition:[FlutterTextPosition
+                                          positionWithIndex:5
+                                                   affinity:UITextStorageDirectionBackward]],
+      CGRectZero));
 
   // Verify floating cursor updates are relative to original position, and that there is no bounds
   // change.

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -1465,7 +1465,7 @@ FLUTTER_ASSERT_ARC
   ]];
 
   // Returns the matching rects within a range
-  FlutterTextRange* range = [FlutterTextRange rangeWithNSRange:NSMakeRange(1, 1)];
+  FlutterTextRange* range = [FlutterTextRange rangeWithNSRange:NSMakeRange(1, 2)];
   XCTAssertTrue(CGRectEqualToRect(testRect0, [inputView selectionRectsForRange:range][0].rect));
   XCTAssertTrue(CGRectEqualToRect(testRect1, [inputView selectionRectsForRange:range][1].rect));
   XCTAssertEqual(2U, [[inputView selectionRectsForRange:range] count]);

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -1365,7 +1365,7 @@ FLUTTER_ASSERT_ARC
     [FlutterTextSelectionRect selectionRectWithRect:CGRectMake(0, 200, 100, 100) position:2U],
   ]];
   CGPoint point = CGPointMake(150, 150);
-  XCTAssertEqual(1U, ((FlutterTextPosition*)[inputView closestPositionToPoint:point]).index);
+  XCTAssertEqual(2U, ((FlutterTextPosition*)[inputView closestPositionToPoint:point]).index);
 
   // Then, if the point is above the bottom of the closest rects vertically, get the closest x
   // origin
@@ -1389,7 +1389,7 @@ FLUTTER_ASSERT_ARC
     [FlutterTextSelectionRect selectionRectWithRect:CGRectMake(0, 300, 100, 100) position:4U],
   ]];
   point = CGPointMake(125, 201);
-  XCTAssertEqual(3U, ((FlutterTextPosition*)[inputView closestPositionToPoint:point]).index);
+  XCTAssertEqual(4U, ((FlutterTextPosition*)[inputView closestPositionToPoint:point]).index);
 
   // Also check a point at the right edge of the last selection rect
   [inputView setSelectionRects:@[
@@ -1400,6 +1400,40 @@ FLUTTER_ASSERT_ARC
   ]];
   point = CGPointMake(125, 250);
   XCTAssertEqual(4U, ((FlutterTextPosition*)[inputView closestPositionToPoint:point]).index);
+}
+
+- (void)testClosestPositionToPointRTL {
+  FlutterTextInputView* inputView = [[FlutterTextInputView alloc] initWithOwner:textInputPlugin];
+  [inputView setTextInputState:@{@"text" : @"COMPOSING"}];
+
+  [inputView setSelectionRects:@[
+    [FlutterTextSelectionRect selectionRectWithRect:CGRectMake(200, 0, 100, 100)
+                                           position:0U
+                                   writingDirection:NSWritingDirectionRightToLeft],
+    [FlutterTextSelectionRect selectionRectWithRect:CGRectMake(100, 0, 100, 100)
+                                           position:1U
+                                   writingDirection:NSWritingDirectionRightToLeft],
+    [FlutterTextSelectionRect selectionRectWithRect:CGRectMake(0, 0, 100, 100)
+                                           position:2U
+                                   writingDirection:NSWritingDirectionRightToLeft],
+    [FlutterTextSelectionRect selectionRectWithRect:CGRectMake(0, 100, 100, 100)
+                                           position:3U
+                                   writingDirection:NSWritingDirectionRightToLeft],
+  ]];
+  XCTAssertEqual(
+      0U, ((FlutterTextPosition*)[inputView closestPositionToPoint:CGPointMake(275, 50)]).index);
+  XCTAssertEqual(
+      1U, ((FlutterTextPosition*)[inputView closestPositionToPoint:CGPointMake(225, 50)]).index);
+  XCTAssertEqual(
+      1U, ((FlutterTextPosition*)[inputView closestPositionToPoint:CGPointMake(175, 50)]).index);
+  XCTAssertEqual(
+      2U, ((FlutterTextPosition*)[inputView closestPositionToPoint:CGPointMake(125, 50)]).index);
+  XCTAssertEqual(
+      2U, ((FlutterTextPosition*)[inputView closestPositionToPoint:CGPointMake(75, 50)]).index);
+  XCTAssertEqual(
+      3U, ((FlutterTextPosition*)[inputView closestPositionToPoint:CGPointMake(25, 50)]).index);
+  XCTAssertEqual(
+      3U, ((FlutterTextPosition*)[inputView closestPositionToPoint:CGPointMake(-25, 50)]).index);
 }
 
 - (void)testSelectionRectsForRange {
@@ -1990,7 +2024,7 @@ FLUTTER_ASSERT_ARC
   XCTAssertEqual(self.installedInputViews.count, 1ul);
   XCTAssertEqual([textInputPlugin.activeView.selectionRects count], 0u);
 
-  NSArray<NSNumber*>* selectionRect = [NSArray arrayWithObjects:@0, @0, @100, @100, @0, nil];
+  NSArray<NSNumber*>* selectionRect = [NSArray arrayWithObjects:@0, @0, @100, @100, @0, @1, nil];
   NSArray* selectionRects = [NSArray arrayWithObjects:selectionRect, nil];
   FlutterMethodCall* methodCall =
       [FlutterMethodCall methodCallWithMethodName:@"Scribble.setSelectionRects"

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -1400,6 +1400,21 @@ FLUTTER_ASSERT_ARC
   ]];
   point = CGPointMake(125, 250);
   XCTAssertEqual(4U, ((FlutterTextPosition*)[inputView closestPositionToPoint:point]).index);
+
+  // Minimize vertical distance if the difference is more than 1 point.
+  [inputView setSelectionRects:@[
+    [FlutterTextSelectionRect selectionRectWithRect:CGRectMake(0, 2, 100, 100) position:0U],
+    [FlutterTextSelectionRect selectionRectWithRect:CGRectMake(100, 2, 100, 100) position:1U],
+    [FlutterTextSelectionRect selectionRectWithRect:CGRectMake(200, 0, 100, 100) position:2U],
+  ]];
+  point = CGPointMake(110, 50);
+  XCTAssertEqual(2U, ((FlutterTextPosition*)[inputView closestPositionToPoint:point]).index);
+
+  // In floating cursor mode, the vertical difference is allowed to be 10 points.
+  // The closest horizontal position will now win.
+  [inputView beginFloatingCursorAtPoint:CGPointZero];
+  XCTAssertEqual(1U, ((FlutterTextPosition*)[inputView closestPositionToPoint:point]).index);
+  [inputView endFloatingCursor];
 }
 
 - (void)testClosestPositionToPointRTL {


### PR DESCRIPTION
Floating cursor selection hasn't worked as we haven't been returning a real value for `caretRectForPosition:`. If we have the selection rectangles, we can do so. 

Fixes [#30476](https://github.com/flutter/flutter/issues/30476)

Requires selection rects to be turned on for iPhone (https://github.com/flutter/flutter/pull/113048)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.