### PR TITLE
Fix kPointerDataFieldCount reference

### DIFF
--- a/lib/ui/window/pointer_data.h
+++ b/lib/ui/window/pointer_data.h
@@ -9,7 +9,8 @@
 
 namespace flutter {
 
-// If this value changes, update the pointer data unpacking code in platform_dispatcher.dart.
+// If this value changes, update the pointer data unpacking code in
+// platform_dispatcher.dart.
 static constexpr int kPointerDataFieldCount = 35;
 static constexpr int kBytesPerField = sizeof(int64_t);
 // Must match the button constants in events.dart.

--- a/lib/ui/window/pointer_data.h
+++ b/lib/ui/window/pointer_data.h
@@ -9,7 +9,7 @@
 
 namespace flutter {
 
-// If this value changes, update the pointer data unpacking code in hooks.dart.
+// If this value changes, update the pointer data unpacking code in platform_dispatcher.dart.
 static constexpr int kPointerDataFieldCount = 35;
 static constexpr int kBytesPerField = sizeof(int64_t);
 // Must match the button constants in events.dart.


### PR DESCRIPTION
The code referenced by the comment lives here now (and no longer in `hooks.dart`): https://github.com/flutter/engine/blob/04bd25bcb0b6b267ea6f927f94465bc2fb699d5a/lib/ui/platform_dispatcher.dart#L374

That move happened in https://github.com/flutter/engine/pull/21932, but this reference wasn't updated.