### PR TITLE
[Impeller] Fix failure case for advanced blend when source snapshot has no coverage

### DIFF
--- a/impeller/entity/contents/filters/blend_filter_contents.cc
+++ b/impeller/entity/contents/filters/blend_filter_contents.cc
@@ -64,11 +64,11 @@ static std::optional<Snapshot> AdvancedBlend(
   if (!foreground_color.has_value()) {
     src_snapshot = inputs[1]->GetSnapshot(renderer, entity);
     if (!src_snapshot.has_value()) {
-      return std::nullopt;
+      return dst_snapshot;
     }
     auto maybe_src_uvs = src_snapshot->GetCoverageUVs(coverage);
     if (!maybe_src_uvs.has_value()) {
-      return std::nullopt;
+      return dst_snapshot;
     }
     src_uvs = maybe_src_uvs.value();
   }


### PR DESCRIPTION
Fix frame failure for advanced blends when there's no source snapshot available.

This is currently causing the ColorWheel playground to fail when the source alpha is set to 0 for the savelayer because invisible images have no coverage (which is from an optimization I landed a while back for Wondrous). The correct behavior is to just forward the destination color along.
