### PR TITLE
[Impeller] Fix modulate blend mode

### DIFF
--- a/impeller/entity/contents/content_context.cc
+++ b/impeller/entity/contents/content_context.cc
@@ -110,8 +110,7 @@ void ContentContextOptions::ApplyToPipelineDescriptor(
       color0.src_color_blend_factor = BlendFactor::kOne;
       break;
     case BlendMode::kModulate:
-      // kSourceColor and kDestinationColor override the alpha blend factor.
-      color0.dst_alpha_blend_factor = BlendFactor::kZero;
+      color0.dst_alpha_blend_factor = BlendFactor::kSourceAlpha;
       color0.dst_color_blend_factor = BlendFactor::kSourceColor;
       color0.src_alpha_blend_factor = BlendFactor::kZero;
       color0.src_color_blend_factor = BlendFactor::kZero;


### PR DESCRIPTION
Before, modulate was just clearing out the pass due to the zero alpha factors. The color is `src * dst`, which is correct. This patch sets the alpha to also be `src * dst`.

Skia on left, Impeller on right:
![Screen Shot 2022-10-07 at 4 45 09 AM](https://user-images.githubusercontent.com/919017/194545714-bc0ac139-a1e0-4d3c-9a42-fedcf3ee16a5.png)
