### PR TITLE
[canvaskit] Make the context current before disposing it

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/surface.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/surface.dart
@@ -180,13 +180,10 @@ class Surface {
 
       // If we have a surface, send a dummy command to its canvas to make its context
       // current or else disposing the context could fail below.
-      //_surface?.getCanvas().clear(const ui.Color(0x00000000));
+      _surface?.getCanvas().clear(const ui.Color(0x00000000));
       _surface?.dispose();
       _surface = null;
       _addedToScene = false;
-      if (_grContext != null) {
-        print('ABOUT TO RELEASE GRCONTEXT!');
-      }
       _grContext?.releaseResourcesAndAbandonContext();
       _grContext?.delete();
       _grContext = null;

--- a/lib/web_ui/lib/src/engine/canvaskit/surface.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/surface.dart
@@ -178,9 +178,15 @@ class Surface {
       // new canvas larger than required to avoid many canvas creations.
       final ui.Size newSize = previousCanvasSize == null ? size : size * 1.4;
 
+      // If we have a surface, send a dummy command to its canvas to make its context
+      // current or else disposing the context could fail below.
+      //_surface?.getCanvas().clear(const ui.Color(0x00000000));
       _surface?.dispose();
       _surface = null;
       _addedToScene = false;
+      if (_grContext != null) {
+        print('ABOUT TO RELEASE GRCONTEXT!');
+      }
       _grContext?.releaseResourcesAndAbandonContext();
       _grContext?.delete();
       _grContext = null;

--- a/lib/web_ui/test/canvaskit/embedded_views_test.dart
+++ b/lib/web_ui/test/canvaskit/embedded_views_test.dart
@@ -662,8 +662,8 @@ void testMain() {
 
       window.webOnlyDebugPhysicalSizeOverride = null;
       window.debugForceResize();
-    // ImageDecoder is not supported in Safari.
-    }, skip: isSafari);
+    // ImageDecoder is not supported in Safari or Firefox.
+    }, skip: isSafari || isFirefox);
 
     test('removed the DOM node of an unrendered platform view', () async {
       final Rasterizer rasterizer = CanvasKitRenderer.instance.rasterizer;

--- a/lib/web_ui/test/canvaskit/embedded_views_test.dart
+++ b/lib/web_ui/test/canvaskit/embedded_views_test.dart
@@ -662,7 +662,8 @@ void testMain() {
 
       window.webOnlyDebugPhysicalSizeOverride = null;
       window.debugForceResize();
-    });
+    // ImageDecoder is not supported in Safari.
+    }, skip: isSafari);
 
     test('removed the DOM node of an unrendered platform view', () async {
       final Rasterizer rasterizer = CanvasKitRenderer.instance.rasterizer;

--- a/lib/web_ui/test/canvaskit/embedded_views_test.dart
+++ b/lib/web_ui/test/canvaskit/embedded_views_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:typed_data';
 
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';

--- a/lib/web_ui/test/canvaskit/embedded_views_test.dart
+++ b/lib/web_ui/test/canvaskit/embedded_views_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
@@ -641,14 +642,6 @@ void testMain() {
       final CkPicture picture = recorder.endRecording();
       sb.addPicture(ui.Offset.zero, picture);
       sb.addPlatformView(0, width: 10, height: 10);
-
-      final CkPictureRecorder recorder2 = CkPictureRecorder();
-      final CkCanvas canvas2 = recorder.beginRecording(ui.Rect.largest);
-      canvas.drawRect(const ui.Rect.fromLTRB(0, 0, 50, 50), CkPaint()..color = const ui.Color(0xffff0000));
-      final CkPicture picture2 = recorder.endRecording();
-      sb.addPicture(ui.Offset.zero, picture2);
-
-
 
       window.webOnlyDebugPhysicalSizeOverride = const ui.Size(100, 100);
       window.debugForceResize();

--- a/lib/web_ui/test/canvaskit/embedded_views_test.dart
+++ b/lib/web_ui/test/canvaskit/embedded_views_test.dart
@@ -10,6 +10,7 @@ import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' as ui;
 
 import 'common.dart';
+import 'test_data.dart';
 
 void main() {
   internalBootstrapBrowserTest(() => testMain);
@@ -616,6 +617,59 @@ void testMain() {
             .querySelector('flt-platform-view'),
         isNull,
       );
+    });
+
+    test('does not crash when resizing the window after textures have been registered', () async {
+      ui.platformViewRegistry.registerViewFactory(
+        'test-platform-view',
+        (int viewId) => createDomHTMLDivElement()..id = 'view-0',
+      );
+      await createPlatformView(0, 'test-platform-view');
+
+      final CkBrowserImageDecoder image = await CkBrowserImageDecoder.create(
+        data: kAnimatedGif,
+        debugSource: 'test',
+      );
+      final ui.FrameInfo frame = await image.getNextFrame();
+      final CkImage ckImage = frame.image as CkImage;
+
+      final LayerSceneBuilder sb = LayerSceneBuilder();
+      sb.pushOffset(0, 0);
+      final CkPictureRecorder recorder = CkPictureRecorder();
+      final CkCanvas canvas = recorder.beginRecording(ui.Rect.largest);
+      canvas.drawImage(ckImage, ui.Offset.zero, CkPaint());
+      final CkPicture picture = recorder.endRecording();
+      sb.addPicture(ui.Offset.zero, picture);
+      sb.addPlatformView(0, width: 10, height: 10);
+
+      final CkPictureRecorder recorder2 = CkPictureRecorder();
+      final CkCanvas canvas2 = recorder.beginRecording(ui.Rect.largest);
+      canvas.drawRect(const ui.Rect.fromLTRB(0, 0, 50, 50), CkPaint()..color = const ui.Color(0xffff0000));
+      final CkPicture picture2 = recorder.endRecording();
+      sb.addPicture(ui.Offset.zero, picture2);
+
+
+
+      window.webOnlyDebugPhysicalSizeOverride = const ui.Size(100, 100);
+      window.debugForceResize();
+      CanvasKitRenderer.instance.rasterizer.draw(sb.build().layerTree);
+      _expectSceneMatches(<_EmbeddedViewMarker>[
+        _overlay,
+        _platformView,
+        _overlay,
+      ]);
+
+      window.webOnlyDebugPhysicalSizeOverride = const ui.Size(200, 200);
+      window.debugForceResize();
+      CanvasKitRenderer.instance.rasterizer.draw(sb.build().layerTree);
+      _expectSceneMatches(<_EmbeddedViewMarker>[
+        _overlay,
+        _platformView,
+        _overlay,
+      ]);
+
+      window.webOnlyDebugPhysicalSizeOverride = null;
+      window.debugForceResize();
     });
 
     test('removed the DOM node of an unrendered platform view', () async {


### PR DESCRIPTION
When we delete a Surface context (for example because it has resized) we must make sure that it is the current context or Skia might throw an exception while deleting resources associated with that context.

Fixes https://github.com/flutter/flutter/issues/91881

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
