### PR TITLE
Deprecate single semantics tree assumption from platform dispatcher

### DIFF
--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -758,6 +758,14 @@ class PlatformDispatcher {
   ///
   /// In either case, this function disposes the given update, which means the
   /// semantics update cannot be used further.
+  @Deprecated('''
+  In a multi-view world, the platform dispatcher can no longer provide apis
+  to update semantics since each view will host its own semantics tree.
+
+  Semantics updates must be passed to an individual flutter view. To update
+  semantics, use PlatformDispatcher.instance.views to get a flutter view and
+  call `updateSemantics`.
+  ''')
   void updateSemantics(SemanticsUpdate update) => _updateSemantics(update);
 
   @FfiNative<Void Function(Pointer<Void>)>('PlatformConfigurationNativeApi::UpdateSemantics')

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -759,12 +759,12 @@ class PlatformDispatcher {
   /// In either case, this function disposes the given update, which means the
   /// semantics update cannot be used further.
   @Deprecated('''
-  In a multi-view world, the platform dispatcher can no longer provide apis
-  to update semantics since each view will host its own semantics tree.
+    In a multi-view world, the platform dispatcher can no longer provide apis
+    to update semantics since each view will host its own semantics tree.
 
-  Semantics updates must be passed to an individual flutter view. To update
-  semantics, use PlatformDispatcher.instance.views to get a flutter view and
-  call `updateSemantics`.
+    Semantics updates must be passed to an individual [FlutterView]. To update
+    semantics, use PlatformDispatcher.instance.views to get a [FlutterView] and
+    call `updateSemantics`.
   ''')
   void updateSemantics(SemanticsUpdate update) => _updateSemantics(update);
 

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -266,6 +266,19 @@ abstract class FlutterView {
 
   @FfiNative<Void Function(Pointer<Void>)>('PlatformConfigurationNativeApi::Render')
   external static void _render(Scene scene);
+
+  /// Change the retained semantics data about this platform dispatcher.
+  ///
+  /// If [semanticsEnabled] is true, the user has requested that this function
+  /// be called whenever the semantic content of this platform dispatcher
+  /// changes.
+  ///
+  /// In either case, this function disposes the given update, which means the
+  /// semantics update cannot be used further.
+  void updateSemantics(SemanticsUpdate update) => _updateSemantics(update);
+
+  @FfiNative<Void Function(Pointer<Void>)>('PlatformConfigurationNativeApi::UpdateSemantics')
+  external static void _updateSemantics(SemanticsUpdate update);
 }
 
 /// A top-level platform window displaying a Flutter layer tree drawn from a
@@ -730,6 +743,13 @@ class SingletonFlutterWindow extends FlutterWindow {
   ///
   /// In either case, this function disposes the given update, which means the
   /// semantics update cannot be used further.
+  @override
+  @Deprecated('''
+  A singleton flutter window no longer manages semantics trees. In a multi-view
+  world, each flutter view must manage its own semantics tree.
+
+  Call updateSemantics() from FlutterView instead.
+  ''')
   void updateSemantics(SemanticsUpdate update) => platformDispatcher.updateSemantics(update);
 
   /// Sends a message to a platform-specific plugin.

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -267,14 +267,14 @@ abstract class FlutterView {
   @FfiNative<Void Function(Pointer<Void>)>('PlatformConfigurationNativeApi::Render')
   external static void _render(Scene scene);
 
-  /// Change the retained semantics data about this platform dispatcher.
+  /// Change the retained semantics data about this [FlutterView].
   ///
-  /// If [semanticsEnabled] is true, the user has requested that this function
-  /// be called whenever the semantic content of this platform dispatcher
+  /// If [PlatformDispatcher.semanticsEnabled] is true, the user has requested that this function
+  /// be called whenever the semantic content of this [FlutterView]
   /// changes.
   ///
-  /// In either case, this function disposes the given update, which means the
-  /// semantics update cannot be used further.
+  /// This function disposes the given update, which means the semantics update
+  /// cannot be used further.
   void updateSemantics(SemanticsUpdate update) => _updateSemantics(update);
 
   @FfiNative<Void Function(Pointer<Void>)>('PlatformConfigurationNativeApi::UpdateSemantics')
@@ -733,24 +733,6 @@ class SingletonFlutterWindow extends FlutterWindow {
   set onAccessibilityFeaturesChanged(VoidCallback? callback) {
     platformDispatcher.onAccessibilityFeaturesChanged = callback;
   }
-
-  /// Change the retained semantics data about this window.
-  ///
-  /// {@macro dart.ui.window.functionForwardWarning}
-  ///
-  /// If [semanticsEnabled] is true, the user has requested that this function
-  /// be called whenever the semantic content of this window changes.
-  ///
-  /// In either case, this function disposes the given update, which means the
-  /// semantics update cannot be used further.
-  @override
-  @Deprecated('''
-  A singleton flutter window no longer manages semantics trees. In a multi-view
-  world, each flutter view must manage its own semantics tree.
-
-  Call updateSemantics() from FlutterView instead.
-  ''')
-  void updateSemantics(SemanticsUpdate update) => platformDispatcher.updateSemantics(update);
 
   /// Sends a message to a platform-specific plugin.
   ///

--- a/lib/web_ui/lib/platform_dispatcher.dart
+++ b/lib/web_ui/lib/platform_dispatcher.dart
@@ -84,12 +84,12 @@ abstract class PlatformDispatcher {
   set onAccessibilityFeaturesChanged(VoidCallback? callback);
 
   @Deprecated('''
-  In a multi-view world, the platform dispatcher can no longer provide apis
-  to update semantics since each view will host its own semantics tree.
+    In a multi-view world, the platform dispatcher can no longer provide apis
+    to update semantics since each view will host its own semantics tree.
 
-  Semantics updates must be passed to an individual flutter view. To update
-  semantics, use PlatformDispatcher.instance.views to get a flutter view and
-  call `updateSemantics`.
+    Semantics updates must be passed to an individual flutter view. To update
+    semantics, use PlatformDispatcher.instance.views to get a flutter view and
+    call `updateSemantics`.
   ''')
   void updateSemantics(SemanticsUpdate update);
 

--- a/lib/web_ui/lib/platform_dispatcher.dart
+++ b/lib/web_ui/lib/platform_dispatcher.dart
@@ -87,8 +87,8 @@ abstract class PlatformDispatcher {
     In a multi-view world, the platform dispatcher can no longer provide apis
     to update semantics since each view will host its own semantics tree.
 
-    Semantics updates must be passed to an individual flutter view. To update
-    semantics, use PlatformDispatcher.instance.views to get a flutter view and
+    Semantics updates must be passed to an individual [FlutterView]. To update
+    semantics, use PlatformDispatcher.instance.views to get a [FlutterView] and
     call `updateSemantics`.
   ''')
   void updateSemantics(SemanticsUpdate update);

--- a/lib/web_ui/lib/platform_dispatcher.dart
+++ b/lib/web_ui/lib/platform_dispatcher.dart
@@ -83,6 +83,14 @@ abstract class PlatformDispatcher {
   VoidCallback? get onAccessibilityFeaturesChanged;
   set onAccessibilityFeaturesChanged(VoidCallback? callback);
 
+  @Deprecated('''
+  In a multi-view world, the platform dispatcher can no longer provide apis
+  to update semantics since each view will host its own semantics tree.
+
+  Semantics updates must be passed to an individual flutter view. To update
+  semantics, use PlatformDispatcher.instance.views to get a flutter view and
+  call `updateSemantics`.
+  ''')
   void updateSemantics(SemanticsUpdate update);
 
   Locale get locale;

--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -698,6 +698,14 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
   /// In either case, this function disposes the given update, which means the
   /// semantics update cannot be used further.
   @override
+  @Deprecated('''
+  In a multi-view world, the platform dispatcher can no longer provide apis
+  to update semantics since each view will host its own semantics tree.
+
+  Semantics updates must be passed to an individual flutter view. To update
+  semantics, use PlatformDispatcher.instance.views to get a flutter view and
+  call `updateSemantics`.
+  ''')
   void updateSemantics(ui.SemanticsUpdate update) {
     EngineSemanticsOwner.instance.updateSemantics(update);
   }

--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -699,12 +699,12 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
   /// semantics update cannot be used further.
   @override
   @Deprecated('''
-  In a multi-view world, the platform dispatcher can no longer provide apis
-  to update semantics since each view will host its own semantics tree.
+    In a multi-view world, the platform dispatcher can no longer provide apis
+    to update semantics since each view will host its own semantics tree.
 
-  Semantics updates must be passed to an individual flutter view. To update
-  semantics, use PlatformDispatcher.instance.views to get a flutter view and
-  call `updateSemantics`.
+    Semantics updates must be passed to an individual [FlutterView]. To update
+    semantics, use PlatformDispatcher.instance.views to get a [FlutterView] and
+    call `updateSemantics`.
   ''')
   void updateSemantics(ui.SemanticsUpdate update) {
     EngineSemanticsOwner.instance.updateSemantics(update);

--- a/lib/web_ui/lib/window.dart
+++ b/lib/web_ui/lib/window.dart
@@ -131,15 +131,6 @@ abstract class SingletonFlutterWindow extends FlutterWindow {
     platformDispatcher.onAccessibilityFeaturesChanged = callback;
   }
 
-  @override
-  @Deprecated('''
-  A singleton flutter window no longer manages semantics trees. In a multi-view
-  world, each flutter view must manage its own semantics tree.
-
-  Call updateSemantics() from FlutterView instead.
-  ''')
-  void updateSemantics(SemanticsUpdate update) => platformDispatcher.updateSemantics(update);
-
   void sendPlatformMessage(
     String name,
     ByteData? data,

--- a/lib/web_ui/lib/window.dart
+++ b/lib/web_ui/lib/window.dart
@@ -16,6 +16,7 @@ abstract class FlutterView {
   WindowPadding get padding => viewConfiguration.padding;
   List<DisplayFeature> get displayFeatures => viewConfiguration.displayFeatures;
   void render(Scene scene) => platformDispatcher.render(scene, this);
+  void updateSemantics(SemanticsUpdate update) => platformDispatcher.updateSemantics(update);
 }
 
 abstract class FlutterWindow extends FlutterView {
@@ -130,6 +131,13 @@ abstract class SingletonFlutterWindow extends FlutterWindow {
     platformDispatcher.onAccessibilityFeaturesChanged = callback;
   }
 
+  @override
+  @Deprecated('''
+  A singleton flutter window no longer manages semantics trees. In a multi-view
+  world, each flutter view must manage its own semantics tree.
+
+  Call updateSemantics() from FlutterView instead.
+  ''')
   void updateSemantics(SemanticsUpdate update) => platformDispatcher.updateSemantics(update);
 
   void sendPlatformMessage(

--- a/shell/platform/embedder/fixtures/main.dart
+++ b/shell/platform/embedder/fixtures/main.dart
@@ -264,7 +264,9 @@ void a11y_main() async {
       label: 'Archive',
       hint: 'archive message',
     );
-  PlatformDispatcher.instance.updateSemantics(builder.build());
+
+  PlatformDispatcher.instance.views.first.updateSemantics(builder.build());
+
   signalNativeTest();
 
   // Await semantics action from embedder.

--- a/testing/scenario_app/lib/src/locale_initialization.dart
+++ b/testing/scenario_app/lib/src/locale_initialization.dart
@@ -43,8 +43,8 @@ class LocaleInitialization extends Scenario {
     // On the first frame, pretend that it drew a text field. Send the
     // corresponding semantics tree comprised of 1 node with the locale data
     // as the label.
-    window.updateSemantics((SemanticsUpdateBuilder()
-      ..updateNode(
+    final SemanticsUpdateBuilder semanticsUpdateBuilder =
+      SemanticsUpdateBuilder()..updateNode(
         id: 0,
         // SemanticsFlag.isTextField.
         flags: 16,
@@ -79,8 +79,11 @@ class LocaleInitialization extends Scenario {
         childrenInTraversalOrder: Int32List(0),
         childrenInHitTestOrder: Int32List(0),
         additionalActions: Int32List(0),
-      )).build()
-    );
+      );
+
+    final SemanticsUpdate semanticsUpdate = semanticsUpdateBuilder.build();
+
+    dispatcher.views.first.updateSemantics(semanticsUpdate);
   }
 
   /// Handle taps.
@@ -98,8 +101,8 @@ class LocaleInitialization extends Scenario {
       // Expand for other test cases.
     }
 
-    window.updateSemantics((SemanticsUpdateBuilder()
-      ..updateNode(
+    final SemanticsUpdateBuilder semanticsUpdateBuilder =
+      SemanticsUpdateBuilder()..updateNode(
         id: 0,
         // SemanticsFlag.isTextField.
         flags: 16,
@@ -134,8 +137,12 @@ class LocaleInitialization extends Scenario {
         childrenInTraversalOrder: Int32List(0),
         childrenInHitTestOrder: Int32List(0),
         additionalActions: Int32List(0),
-      )).build()
-    );
+      );
+
+    final SemanticsUpdate semanticsUpdate = semanticsUpdateBuilder.build();
+
+    dispatcher.views.first.updateSemantics(semanticsUpdate);
+
     _tapCount++;
   }
 }


### PR DESCRIPTION
In an effort to move from a single-rooted flutter view to multiple views in a flutter app, `dart::ui` should be able to dispatch semantics tree updates to selected views. This PR deprecates semantics APIs that assume one flutter view per app. 

This patch will be succeeded by framework changes that migrate from the deprecated APIs. After, the deprecated APIs will be removed in a subsequent PR.

This is a partial fix to https://github.com/flutter/flutter/issues/112221. that issue will be fully fixed when all 3 PRs are landed.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
