### PR TITLE
[Impeller] fix quadradic behavior in polyline creation

### DIFF
--- a/impeller/geometry/path.cc
+++ b/impeller/geometry/path.cc
@@ -232,8 +232,6 @@ Path::Polyline Path::CreatePolyline(
       return;
     }
 
-    polyline.points.reserve(polyline.points.size() + collection.size());
-
     for (const auto& point : collection) {
       if (previous_contour_point.has_value() &&
           previous_contour_point.value() == point) {


### PR DESCRIPTION
Incrementally reserving vector capacity leads to quadradic behavior in polyline creation. I think that reserve only ensures that vector has the specified capacity, it doesn't trigger the normal doubling of the storage space. Each time a polyline component is converted and we request the vector to reserve . Because it won't have resized more than the prior component required, we force the existing vector to copy all of the previous components to allocate the backing memory. This is roughly N2 in the number of components.

By removing this reserve and letting the normal vector allocation strategy run, we get the expected linear-ish behavior.


With fix, this frame takes ~20ms to render. Without the fix, it takes ~180ms. Adding too many more rects and it won't finish.

Example app:

```dart
// Copyright 2014 The Flutter Authors. All rights reserved.
// Use of this source code is governed by a BSD-style license that can be
// found in the LICENSE file.

import 'dart:math' as math;
import 'package:flutter/material.dart';

void main() {
  runApp(
    const MaterialApp(
      home: Scaffold(
        body: Center(
          child: Benchmark(),
        )
      ),
    )
  );
}

class Benchmark extends StatefulWidget {
  const Benchmark({super.key});

  @override
  State<Benchmark> createState() => _BenchmarkState();
}

class _BenchmarkState extends State<Benchmark> {
  bool showQR = false;

  @override
  Widget build(BuildContext context) {
    if (!showQR) {
      return TextButton(
        key: const ValueKey<String>('Button'),
        onPressed: () {
          setState(() {
            showQR = true;
          });
        },
        child: const Text('Start Bench'),
      );
    }
    return CustomPaint(
      key: const ValueKey<String>('Painter'),
      painter: QRPainter(),
      size: const Size(800, 800),
    );
  }
}

class QRPainter extends CustomPainter {

  @override
  void paint(Canvas canvas, Size size) {
    final double boxWidth = size.width / 50.0;
    final double boxHeight = size.height / 50.0;
    var pathA = Path();
    for (int i = 0; i < 50; i++) {
      for (int j = 0; j < 50; j++) {
        final Rect rect = Rect.fromLTWH(i * boxWidth, j * boxHeight, boxWidth, boxHeight);
        pathA.addRect(rect);
      }
    }
    var paint =  Paint()
            ..style = PaintingStyle.fill
            ..color = Colors.red;
    canvas.drawPath(pathA, paint);
  }

  @override
  bool shouldRepaint(covariant CustomPainter oldDelegate) {
    return false;
  }
}
```