### PR TITLE
[fuchsia] Use root-ssl-certificates in v2 runner manifests

### DIFF
--- a/shell/platform/fuchsia/flutter/meta/common.shard.cml
+++ b/shell/platform/fuchsia/flutter/meta/common.shard.cml
@@ -7,10 +7,44 @@
         // Copied from inspect/client.shard.cml because out-of-tree doesn't
         // have support for CML includes from the SDK.
         {
-            
             directory: "diagnostics",
             rights: [ "connect" ],
             path: "/diagnostics",
+        },
+    ],
+    use: [
+        {
+            directory: "config-data",
+            rights: [ "r*" ],
+            path: "/config/data",
+        },
+        {
+            directory: "root-ssl-certificates",
+            rights: [ "r*" ],
+            path: "/config/ssl",
+        },
+        {
+            protocol: [
+                "fuchsia.accessibility.semantics.SemanticsManager",
+                "fuchsia.device.NameProvider",
+                "fuchsia.feedback.CrashReporter",
+                "fuchsia.fonts.Provider",
+                "fuchsia.intl.PropertyProvider",
+                "fuchsia.logger.LogSink", // Copied from syslog/client.shard.cml.
+                "fuchsia.memorypressure.Provider",
+                "fuchsia.net.name.Lookup",
+                "fuchsia.posix.socket.Provider",
+                "fuchsia.sysmem.Allocator",
+                "fuchsia.timezone.Timezone", // Copied from vulkan/client.shard.cml.
+                "fuchsia.tracing.provider.Registry", // Copied from vulkan/client.shard.cml.
+                "fuchsia.ui.composition.Allocator",
+                "fuchsia.ui.composition.Flatland",
+                "fuchsia.ui.input.ImeService",
+                "fuchsia.ui.input3.Keyboard",
+                "fuchsia.ui.pointerinjector.Registry",
+                "fuchsia.ui.scenic.Scenic",
+                "fuchsia.vulkan.loader.Loader", // Copied from vulkan/client.shard.cml.
+            ],
         },
     ],
     expose: [
@@ -23,34 +57,4 @@
             to: "framework",
         },
     ],
-    use: [
-        {
-            directory: "config-data",
-            rights: [ "r*" ],
-            path: "/config/data",
-        },
-        {
-            protocol: [
-                "fuchsia.accessibility.semantics.SemanticsManager",
-                "fuchsia.device.NameProvider",
-                "fuchsia.feedback.CrashReporter",
-                "fuchsia.fonts.Provider",
-                "fuchsia.intl.PropertyProvider",
-                "fuchsia.logger.LogSink",  // Copied from syslog/client.shard.cml.
-                "fuchsia.memorypressure.Provider",
-                "fuchsia.net.name.Lookup",
-                "fuchsia.posix.socket.Provider",
-                "fuchsia.sysmem.Allocator",
-                "fuchsia.timezone.Timezone",  // Copied from vulkan/client.shard.cml.
-                "fuchsia.tracing.provider.Registry",  // Copied from vulkan/client.shard.cml.
-                "fuchsia.ui.composition.Allocator",
-                "fuchsia.ui.composition.Flatland",
-                "fuchsia.ui.input.ImeService",
-                "fuchsia.ui.input3.Keyboard",
-                "fuchsia.ui.scenic.Scenic",
-                "fuchsia.ui.pointerinjector.Registry",
-                "fuchsia.vulkan.loader.Loader"  // Copied from vulkan/client.shard.cml.
-            ]
-        }
-    ]
 }


### PR DESCRIPTION
* Add a `use` for the `root-ssl-certificates` to ensure BoringSSL can read the certificates at /config/ssl
* Reformat manifest with `cmc format`

Fixes `HandshakeException`s when establishing a secure connection:

```
HandshakeException: Handshake error in client (OS Error:
        CERTIFICATE_VERIFY_FAILED: unable to get local issuer certificate(handshake.cc:393))
<asynchronous suspension>
```

Depends on changes that offer this directory to the runners, e.g. https://fxrev.dev/737597

Bug: https://fxbug.dev/111712
