### PR TITLE
Revert "Deprecate single semantics tree assumption from platform dispatcher"

### DIFF
--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -758,14 +758,6 @@ class PlatformDispatcher {
   ///
   /// In either case, this function disposes the given update, which means the
   /// semantics update cannot be used further.
-  @Deprecated('''
-    In a multi-view world, the platform dispatcher can no longer provide apis
-    to update semantics since each view will host its own semantics tree.
-
-    Semantics updates must be passed to an individual [FlutterView]. To update
-    semantics, use PlatformDispatcher.instance.views to get a [FlutterView] and
-    call `updateSemantics`.
-  ''')
   void updateSemantics(SemanticsUpdate update) => _updateSemantics(update);
 
   @FfiNative<Void Function(Pointer<Void>)>('PlatformConfigurationNativeApi::UpdateSemantics')

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -266,19 +266,6 @@ abstract class FlutterView {
 
   @FfiNative<Void Function(Pointer<Void>)>('PlatformConfigurationNativeApi::Render')
   external static void _render(Scene scene);
-
-  /// Change the retained semantics data about this [FlutterView].
-  ///
-  /// If [PlatformDispatcher.semanticsEnabled] is true, the user has requested that this function
-  /// be called whenever the semantic content of this [FlutterView]
-  /// changes.
-  ///
-  /// This function disposes the given update, which means the semantics update
-  /// cannot be used further.
-  void updateSemantics(SemanticsUpdate update) => _updateSemantics(update);
-
-  @FfiNative<Void Function(Pointer<Void>)>('PlatformConfigurationNativeApi::UpdateSemantics')
-  external static void _updateSemantics(SemanticsUpdate update);
 }
 
 /// A top-level platform window displaying a Flutter layer tree drawn from a
@@ -733,6 +720,17 @@ class SingletonFlutterWindow extends FlutterWindow {
   set onAccessibilityFeaturesChanged(VoidCallback? callback) {
     platformDispatcher.onAccessibilityFeaturesChanged = callback;
   }
+
+  /// Change the retained semantics data about this window.
+  ///
+  /// {@macro dart.ui.window.functionForwardWarning}
+  ///
+  /// If [semanticsEnabled] is true, the user has requested that this function
+  /// be called whenever the semantic content of this window changes.
+  ///
+  /// In either case, this function disposes the given update, which means the
+  /// semantics update cannot be used further.
+  void updateSemantics(SemanticsUpdate update) => platformDispatcher.updateSemantics(update);
 
   /// Sends a message to a platform-specific plugin.
   ///

--- a/lib/web_ui/lib/platform_dispatcher.dart
+++ b/lib/web_ui/lib/platform_dispatcher.dart
@@ -83,14 +83,6 @@ abstract class PlatformDispatcher {
   VoidCallback? get onAccessibilityFeaturesChanged;
   set onAccessibilityFeaturesChanged(VoidCallback? callback);
 
-  @Deprecated('''
-    In a multi-view world, the platform dispatcher can no longer provide apis
-    to update semantics since each view will host its own semantics tree.
-
-    Semantics updates must be passed to an individual [FlutterView]. To update
-    semantics, use PlatformDispatcher.instance.views to get a [FlutterView] and
-    call `updateSemantics`.
-  ''')
   void updateSemantics(SemanticsUpdate update);
 
   Locale get locale;

--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -698,14 +698,6 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
   /// In either case, this function disposes the given update, which means the
   /// semantics update cannot be used further.
   @override
-  @Deprecated('''
-    In a multi-view world, the platform dispatcher can no longer provide apis
-    to update semantics since each view will host its own semantics tree.
-
-    Semantics updates must be passed to an individual [FlutterView]. To update
-    semantics, use PlatformDispatcher.instance.views to get a [FlutterView] and
-    call `updateSemantics`.
-  ''')
   void updateSemantics(ui.SemanticsUpdate update) {
     EngineSemanticsOwner.instance.updateSemantics(update);
   }

--- a/lib/web_ui/lib/window.dart
+++ b/lib/web_ui/lib/window.dart
@@ -16,7 +16,6 @@ abstract class FlutterView {
   WindowPadding get padding => viewConfiguration.padding;
   List<DisplayFeature> get displayFeatures => viewConfiguration.displayFeatures;
   void render(Scene scene) => platformDispatcher.render(scene, this);
-  void updateSemantics(SemanticsUpdate update) => platformDispatcher.updateSemantics(update);
 }
 
 abstract class FlutterWindow extends FlutterView {
@@ -130,6 +129,8 @@ abstract class SingletonFlutterWindow extends FlutterWindow {
   set onAccessibilityFeaturesChanged(VoidCallback? callback) {
     platformDispatcher.onAccessibilityFeaturesChanged = callback;
   }
+
+  void updateSemantics(SemanticsUpdate update) => platformDispatcher.updateSemantics(update);
 
   void sendPlatformMessage(
     String name,

--- a/shell/platform/embedder/fixtures/main.dart
+++ b/shell/platform/embedder/fixtures/main.dart
@@ -264,9 +264,7 @@ void a11y_main() async {
       label: 'Archive',
       hint: 'archive message',
     );
-
-  PlatformDispatcher.instance.views.first.updateSemantics(builder.build());
-
+  PlatformDispatcher.instance.updateSemantics(builder.build());
   signalNativeTest();
 
   // Await semantics action from embedder.

--- a/testing/scenario_app/lib/src/locale_initialization.dart
+++ b/testing/scenario_app/lib/src/locale_initialization.dart
@@ -43,8 +43,8 @@ class LocaleInitialization extends Scenario {
     // On the first frame, pretend that it drew a text field. Send the
     // corresponding semantics tree comprised of 1 node with the locale data
     // as the label.
-    final SemanticsUpdateBuilder semanticsUpdateBuilder =
-      SemanticsUpdateBuilder()..updateNode(
+    window.updateSemantics((SemanticsUpdateBuilder()
+      ..updateNode(
         id: 0,
         // SemanticsFlag.isTextField.
         flags: 16,
@@ -79,11 +79,8 @@ class LocaleInitialization extends Scenario {
         childrenInTraversalOrder: Int32List(0),
         childrenInHitTestOrder: Int32List(0),
         additionalActions: Int32List(0),
-      );
-
-    final SemanticsUpdate semanticsUpdate = semanticsUpdateBuilder.build();
-
-    dispatcher.views.first.updateSemantics(semanticsUpdate);
+      )).build()
+    );
   }
 
   /// Handle taps.
@@ -101,8 +98,8 @@ class LocaleInitialization extends Scenario {
       // Expand for other test cases.
     }
 
-    final SemanticsUpdateBuilder semanticsUpdateBuilder =
-      SemanticsUpdateBuilder()..updateNode(
+    window.updateSemantics((SemanticsUpdateBuilder()
+      ..updateNode(
         id: 0,
         // SemanticsFlag.isTextField.
         flags: 16,
@@ -137,12 +134,8 @@ class LocaleInitialization extends Scenario {
         childrenInTraversalOrder: Int32List(0),
         childrenInHitTestOrder: Int32List(0),
         additionalActions: Int32List(0),
-      );
-
-    final SemanticsUpdate semanticsUpdate = semanticsUpdateBuilder.build();
-
-    dispatcher.views.first.updateSemantics(semanticsUpdate);
-
+      )).build()
+    );
     _tapCount++;
   }
 }


### PR DESCRIPTION
Reverts flutter/engine#36675

Failing to roll into the framework. https://ci.chromium.org/ui/p/flutter/builders/try/Linux%20analyze/42857/overview