### PR TITLE
[Impeller] Add DlRuntimeEffect, pipe RuntimeStage through the DL

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -709,6 +709,8 @@ FILE: ../../../flutter/display_list/display_list_path_effect.h
 FILE: ../../../flutter/display_list/display_list_path_effect_unittests.cc
 FILE: ../../../flutter/display_list/display_list_rtree.cc
 FILE: ../../../flutter/display_list/display_list_rtree.h
+FILE: ../../../flutter/display_list/display_list_runtime_effect.cc
+FILE: ../../../flutter/display_list/display_list_runtime_effect.h
 FILE: ../../../flutter/display_list/display_list_sampling_options.h
 FILE: ../../../flutter/display_list/display_list_test_utils.cc
 FILE: ../../../flutter/display_list/display_list_test_utils.h

--- a/display_list/BUILD.gn
+++ b/display_list/BUILD.gn
@@ -53,6 +53,8 @@ source_set("display_list") {
     "display_list_path_effect.h",
     "display_list_rtree.cc",
     "display_list_rtree.h",
+    "display_list_runtime_effect.cc",
+    "display_list_runtime_effect.h",
     "display_list_sampling_options.h",
     "display_list_tile_mode.h",
     "display_list_utils.cc",
@@ -64,6 +66,7 @@ source_set("display_list") {
 
   public_deps = [
     "//flutter/fml",
+    "//flutter/impeller/runtime_stage",
     "//third_party/skia",
   ]
 }

--- a/display_list/display_list_color_source.cc
+++ b/display_list/display_list_color_source.cc
@@ -3,7 +3,8 @@
 // found in the LICENSE file.
 
 #include "flutter/display_list/display_list_color_source.h"
-#include "display_list_color_source.h"
+
+#include "flutter/display_list/display_list_runtime_effect.h"
 #include "flutter/display_list/display_list_sampling_options.h"
 
 namespace flutter {
@@ -130,7 +131,7 @@ std::shared_ptr<DlColorSource> DlColorSource::MakeSweep(
 }
 
 std::shared_ptr<DlRuntimeEffectColorSource> DlColorSource::MakeRuntimeEffect(
-    sk_sp<SkRuntimeEffect> runtime_effect,
+    sk_sp<DlRuntimeEffect> runtime_effect,
     std::vector<std::shared_ptr<DlColorSource>> samplers,
     sk_sp<SkData> uniform_data) {
   return std::make_shared<DlRuntimeEffectColorSource>(

--- a/display_list/display_list_color_source_unittests.cc
+++ b/display_list/display_list_color_source_unittests.cc
@@ -2,11 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "display_list/display_list_runtime_effect.h"
 #include "flutter/display_list/display_list_attributes_testing.h"
 #include "flutter/display_list/display_list_builder.h"
 #include "flutter/display_list/display_list_color_source.h"
 #include "flutter/display_list/display_list_image.h"
+#include "flutter/display_list/display_list_runtime_effect.h"
 #include "flutter/display_list/display_list_sampling_options.h"
 #include "flutter/display_list/types.h"
 #include "third_party/skia/include/core/SkString.h"

--- a/display_list/display_list_color_source_unittests.cc
+++ b/display_list/display_list_color_source_unittests.cc
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "display_list/display_list_runtime_effect.h"
 #include "flutter/display_list/display_list_attributes_testing.h"
 #include "flutter/display_list/display_list_builder.h"
 #include "flutter/display_list/display_list_color_source.h"
@@ -28,14 +29,16 @@ static sk_sp<DlImage> MakeTestImage(int w, int h, SkColor color) {
   return DlImage::Make(surface->makeImageSnapshot());
 }
 
-static const sk_sp<SkRuntimeEffect> kTestRuntimeEffect1 =
-    SkRuntimeEffect::MakeForShader(
-        SkString("vec4 main(vec2 p) { return vec4(0); }"))
-        .effect;
-static const sk_sp<SkRuntimeEffect> kTestRuntimeEffect2 =
-    SkRuntimeEffect::MakeForShader(
-        SkString("vec4 main(vec2 p) { return vec4(1); }"))
-        .effect;
+static const sk_sp<DlRuntimeEffect> kTestRuntimeEffect1 =
+    DlRuntimeEffect::MakeSkia(
+        SkRuntimeEffect::MakeForShader(
+            SkString("vec4 main(vec2 p) { return vec4(0); }"))
+            .effect);
+static const sk_sp<DlRuntimeEffect> kTestRuntimeEffect2 =
+    DlRuntimeEffect::MakeSkia(
+        SkRuntimeEffect::MakeForShader(
+            SkString("vec4 main(vec2 p) { return vec4(1); }"))
+            .effect);
 
 static const sk_sp<DlImage> kTestImage1 = MakeTestImage(10, 10, SK_ColorGREEN);
 static const sk_sp<DlImage> kTestAlphaImage1 =

--- a/display_list/display_list_runtime_effect.cc
+++ b/display_list/display_list_runtime_effect.cc
@@ -1,0 +1,66 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/display_list/display_list_runtime_effect.h"
+
+#include "third_party/skia/include/core/SkRefCnt.h"
+
+namespace flutter {
+
+//------------------------------------------------------------------------------
+/// DlRuntimeEffect
+///
+
+DlRuntimeEffect::DlRuntimeEffect() = default;
+DlRuntimeEffect::~DlRuntimeEffect() = default;
+
+sk_sp<DlRuntimeEffect> DlRuntimeEffect::MakeSkia(
+    const sk_sp<SkRuntimeEffect>& runtime_effect) {
+  return sk_make_sp<DlRuntimeEffectSkia>(runtime_effect);
+}
+
+sk_sp<DlRuntimeEffect> DlRuntimeEffect::MakeImpeller(
+    std::shared_ptr<impeller::RuntimeStage> runtime_stage) {
+  return sk_make_sp<DlRuntimeEffectImpeller>(std::move(runtime_stage));
+}
+
+//------------------------------------------------------------------------------
+/// DlRuntimeEffectSkia
+///
+
+DlRuntimeEffectSkia::~DlRuntimeEffectSkia() = default;
+
+DlRuntimeEffectSkia::DlRuntimeEffectSkia(
+    const sk_sp<SkRuntimeEffect>& runtime_effect)
+    : skia_runtime_effect_(runtime_effect) {}
+
+sk_sp<SkRuntimeEffect> DlRuntimeEffectSkia::skia_runtime_effect() const {
+  return skia_runtime_effect_;
+}
+
+std::shared_ptr<impeller::RuntimeStage> DlRuntimeEffectSkia::runtime_stage()
+    const {
+  return nullptr;
+}
+
+//------------------------------------------------------------------------------
+/// DlRuntimeEffectImpeller
+///
+
+DlRuntimeEffectImpeller::~DlRuntimeEffectImpeller() = default;
+
+DlRuntimeEffectImpeller::DlRuntimeEffectImpeller(
+    std::shared_ptr<impeller::RuntimeStage> runtime_stage)
+    : runtime_stage_(std::move(runtime_stage)){};
+
+sk_sp<SkRuntimeEffect> DlRuntimeEffectImpeller::skia_runtime_effect() const {
+  return nullptr;
+}
+
+std::shared_ptr<impeller::RuntimeStage> DlRuntimeEffectImpeller::runtime_stage()
+    const {
+  return runtime_stage_;
+}
+
+}  // namespace flutter

--- a/display_list/display_list_runtime_effect.h
+++ b/display_list/display_list_runtime_effect.h
@@ -1,0 +1,85 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_DISPLAY_LIST_RUNTIME_EFFECT_H_
+#define FLUTTER_DISPLAY_LIST_RUNTIME_EFFECT_H_
+
+#include <memory>
+
+#include "flutter/fml/macros.h"
+#include "flutter/impeller/runtime_stage/runtime_stage.h"
+
+#include "third_party/skia/include/core/SkRefCnt.h"
+#include "third_party/skia/include/effects/SkRuntimeEffect.h"
+
+namespace flutter {
+
+class DlRuntimeEffect : public SkRefCnt {
+ public:
+  static sk_sp<DlRuntimeEffect> MakeSkia(
+      const sk_sp<SkRuntimeEffect>& runtime_effect);
+
+  static sk_sp<DlRuntimeEffect> MakeImpeller(
+      std::shared_ptr<impeller::RuntimeStage> runtime_stage);
+
+  virtual sk_sp<SkRuntimeEffect> skia_runtime_effect() const = 0;
+
+  virtual std::shared_ptr<impeller::RuntimeStage> runtime_stage() const = 0;
+
+ protected:
+  DlRuntimeEffect();
+  virtual ~DlRuntimeEffect();
+
+ private:
+  FML_DISALLOW_COPY_AND_ASSIGN(DlRuntimeEffect);
+};
+
+class DlRuntimeEffectSkia final : public DlRuntimeEffect {
+ public:
+  explicit DlRuntimeEffectSkia(const sk_sp<SkRuntimeEffect>& runtime_effect);
+
+  // |DlRuntimeEffect|
+  sk_sp<SkRuntimeEffect> skia_runtime_effect() const override;
+
+  // |DlRuntimeEffect|
+  std::shared_ptr<impeller::RuntimeStage> runtime_stage() const override;
+
+ private:
+  DlRuntimeEffectSkia() = delete;
+  // |DlRuntimeEffect|
+  ~DlRuntimeEffectSkia() override;
+
+  sk_sp<SkRuntimeEffect> skia_runtime_effect_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(DlRuntimeEffectSkia);
+
+  friend DlRuntimeEffect;
+};
+
+class DlRuntimeEffectImpeller final : public DlRuntimeEffect {
+ public:
+  explicit DlRuntimeEffectImpeller(
+      std::shared_ptr<impeller::RuntimeStage> runtime_stage);
+
+  // |DlRuntimeEffect|
+  sk_sp<SkRuntimeEffect> skia_runtime_effect() const override;
+
+  // |DlRuntimeEffect|
+  std::shared_ptr<impeller::RuntimeStage> runtime_stage() const override;
+
+ private:
+  DlRuntimeEffectImpeller() = delete;
+  // |DlRuntimeEffect|
+  ~DlRuntimeEffectImpeller() override;
+
+  std::shared_ptr<impeller::RuntimeStage> runtime_stage_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(DlRuntimeEffectImpeller);
+
+  friend DlRuntimeEffect;
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_DISPLAY_LIST_RUNTIME_EFFECT_H_

--- a/impeller/runtime_stage/runtime_stage.cc
+++ b/impeller/runtime_stage/runtime_stage.cc
@@ -100,6 +100,8 @@ RuntimeStage::RuntimeStage(std::shared_ptr<fml::Mapping> payload)
 }
 
 RuntimeStage::~RuntimeStage() = default;
+RuntimeStage::RuntimeStage(RuntimeStage&&) = default;
+RuntimeStage& RuntimeStage::operator=(RuntimeStage&&) = default;
 
 bool RuntimeStage::IsValid() const {
   return is_valid_;

--- a/impeller/runtime_stage/runtime_stage.h
+++ b/impeller/runtime_stage/runtime_stage.h
@@ -9,7 +9,8 @@
 
 #include "flutter/fml/macros.h"
 #include "flutter/fml/mapping.h"
-#include "impeller/runtime_stage/runtime_types.h"
+
+#include "flutter/impeller/runtime_stage/runtime_types.h"
 
 namespace impeller {
 
@@ -18,6 +19,8 @@ class RuntimeStage {
   explicit RuntimeStage(std::shared_ptr<fml::Mapping> payload);
 
   ~RuntimeStage();
+  RuntimeStage(RuntimeStage&&);
+  RuntimeStage& operator=(RuntimeStage&&);
 
   bool IsValid() const;
 

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -4188,7 +4188,7 @@ class FragmentProgram extends NativeFieldWrapperClass1 {
       <String, WeakReference<FragmentProgram>>{};
 
   static void _reinitializeShader(String assetKey) {
-    // If a shader for the assert isn't already registered, then there's no
+    // If a shader for the asset isn't already registered, then there's no
     // need to reinitialize it. The new shader will be loaded and initialized
     // the next time the program access it.
     final WeakReference<FragmentProgram>? programRef = _shaderRegistry == null

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -4188,7 +4188,7 @@ class FragmentProgram extends NativeFieldWrapperClass1 {
       <String, WeakReference<FragmentProgram>>{};
 
   static void _reinitializeShader(String assetKey) {
-    // If a shader for the assent isn't already registered, then there's no
+    // If a shader for the assert isn't already registered, then there's no
     // need to reinitialize it. The new shader will be loaded and initialized
     // the next time the program access it.
     final WeakReference<FragmentProgram>? programRef = _shaderRegistry == null

--- a/lib/ui/painting/fragment_program.h
+++ b/lib/ui/painting/fragment_program.h
@@ -5,10 +5,11 @@
 #ifndef FLUTTER_LIB_UI_PAINTING_FRAGMENT_PROGRAM_H_
 #define FLUTTER_LIB_UI_PAINTING_FRAGMENT_PROGRAM_H_
 
+#include "flutter/display_list/display_list_runtime_effect.h"
 #include "flutter/lib/ui/dart_wrapper.h"
 #include "flutter/lib/ui/painting/fragment_shader.h"
 #include "flutter/lib/ui/painting/shader.h"
-#include "third_party/skia/include/effects/SkRuntimeEffect.h"
+
 #include "third_party/tonic/dart_library_natives.h"
 #include "third_party/tonic/typed_data/typed_list.h"
 
@@ -34,12 +35,12 @@ class FragmentProgram : public RefCountedDartWrappable<FragmentProgram> {
                                      Dart_Handle samplers);
 
   std::shared_ptr<DlColorSource> MakeDlColorSource(
-      sk_sp<SkData> float_uniforms,
+      const sk_sp<SkData>& float_uniforms,
       const std::vector<std::shared_ptr<DlColorSource>>& children);
 
  private:
   FragmentProgram();
-  sk_sp<SkRuntimeEffect> runtime_effect_;
+  sk_sp<DlRuntimeEffect> runtime_effect_;
 };
 
 }  // namespace flutter


### PR DESCRIPTION
This change gets the `impeller::RuntimeStage` accessible from the Impeller dispatcher.

I'm gonna land the actual `ColorSourceContents` impl in a separate patch. There is some complexity to work through with sampler uniforms mapping to color sources. I plan to land an initial version with partial support for `DlImageColorSource` inputs only (ignoring the effect matrix). We'll also need to provide a standard way for users to handle stuff like the y flip in their shaders such that it doesn't disrupt the Skia shaders -- I have some ideas for abstracting some of this complexity away from users.