### PR TITLE
Don't wrap Context for Android Hybrid Composition

### DIFF
--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -161,7 +161,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
           ensureValidAndroidVersion(19);
           ensureValidRequest(request);
 
-          final PlatformView platformView = createPlatformView(request);
+          final PlatformView platformView = createPlatformView(request, false);
 
           configureForHybridComposition(platformView, request);
           // New code should be added to configureForHybridComposition, not here, unless it is
@@ -189,7 +189,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
                     + viewId);
           }
 
-          final PlatformView platformView = createPlatformView(request);
+          final PlatformView platformView = createPlatformView(request, true);
 
           final View embeddedView = platformView.getView();
           if (embeddedView.getParent() != null) {
@@ -477,7 +477,8 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
         // all display modes, and adds it to `platformViews`.
         @TargetApi(19)
         private PlatformView createPlatformView(
-            @NonNull PlatformViewsChannel.PlatformViewCreationRequest request) {
+            @NonNull PlatformViewsChannel.PlatformViewCreationRequest request,
+            boolean wrapContext) {
           final PlatformViewFactory viewFactory = registry.getFactory(request.viewType);
           if (viewFactory == null) {
             throw new IllegalStateException(
@@ -490,7 +491,9 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
           }
 
           // In some display modes, the context needs to be modified during display.
-          final Context mutableContext = new MutableContextWrapper(context);
+          // TODO(stuartmorgan): Make this wrapping unconditional if possible; for context see
+          // https://github.com/flutter/flutter/issues/113449
+          final Context mutableContext = wrapContext ? new MutableContextWrapper(context) : context;
           final PlatformView platformView =
               viewFactory.create(mutableContext, request.viewId, createParams);
 

--- a/shell/platform/android/io/flutter/plugin/platform/SingleViewPresentation.java
+++ b/shell/platform/android/io/flutter/plugin/platform/SingleViewPresentation.java
@@ -176,6 +176,7 @@ class SingleViewPresentation extends Presentation {
 
     View embeddedView = state.platformView.getView();
     if (embeddedView.getContext() instanceof MutableContextWrapper) {
+      Log.e("StuartMorgan", "Updating the context");
       MutableContextWrapper currentContext = (MutableContextWrapper) embeddedView.getContext();
       currentContext.setBaseContext(baseContext);
     } else {

--- a/shell/platform/android/io/flutter/plugin/platform/SingleViewPresentation.java
+++ b/shell/platform/android/io/flutter/plugin/platform/SingleViewPresentation.java
@@ -176,7 +176,6 @@ class SingleViewPresentation extends Presentation {
 
     View embeddedView = state.platformView.getView();
     if (embeddedView.getContext() instanceof MutableContextWrapper) {
-      Log.e("StuartMorgan", "Updating the context");
       MutableContextWrapper currentContext = (MutableContextWrapper) embeddedView.getContext();
       currentContext.setBaseContext(baseContext);
     } else {


### PR DESCRIPTION
Bypasses the step of wrapping the `Context` provided to the platform view factory when Hybrid Composition has been requested (i.e., when using `initExpensiveAndroidView`). This was added to the Hybrid Composition codepath in https://github.com/flutter/engine/pull/35233 when the creation flow was unified; it was intended to be a no-op for HC, but turns out not to have been, as described in https://github.com/flutter/flutter/issues/113449

This effectively reverts just the HC-specific part of https://github.com/flutter/engine/pull/35233 without affecting the other codepaths (so doesn't require reverting other changes built on that for TLHC mode).

Fixes b/249389618
See also https://github.com/flutter/flutter/issues/113449

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
