### PR TITLE
[Impeller] Add WSI support for Vulkan on Linux and Windows

### DIFF
--- a/fml/string_conversion.cc
+++ b/fml/string_conversion.cc
@@ -6,6 +6,7 @@
 
 #include <codecvt>
 #include <locale>
+#include <sstream>
 #include <string>
 
 #include "flutter/fml/build_config.h"
@@ -21,6 +22,17 @@ namespace fml {
 
 using Utf16StringConverter =
     std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>;
+
+std::string Join(const std::vector<std::string>& vec, const char* delim) {
+  std::stringstream res;
+  for (size_t i = 0; i < vec.size(); ++i) {
+    res << vec[i];
+    if (i < vec.size() - 1) {
+      res << delim;
+    }
+  }
+  return res.str();
+}
 
 std::string Utf16ToUtf8(const std::u16string_view string) {
   Utf16StringConverter converter;

--- a/fml/string_conversion.h
+++ b/fml/string_conversion.h
@@ -6,8 +6,12 @@
 #define FLUTTER_FML_STRING_CONVERSION_H_
 
 #include <string>
+#include <vector>
 
 namespace fml {
+
+// Returns a string joined by the given delimiter.
+std::string Join(const std::vector<std::string>& vec, const char* delimiter);
 
 // Returns a UTF-8 encoded equivalent of a UTF-16 encoded input string.
 std::string Utf16ToUtf8(const std::u16string_view string);

--- a/impeller/playground/backend/vulkan/playground_impl_vk.cc
+++ b/impeller/playground/backend/vulkan/playground_impl_vk.cc
@@ -87,7 +87,13 @@ void PlaygroundImplVK::SetupSwapchain() {
   auto window = reinterpret_cast<GLFWwindow*>(handle_.get());
   vk::Instance instance = context_vk->GetInstance();
   VkSurfaceKHR surface_tmp;
-  ::glfwCreateWindowSurface(instance, window, nullptr, &surface_tmp);
+  auto res = vk::Result{
+      ::glfwCreateWindowSurface(instance, window, nullptr, &surface_tmp)};
+  if (res != vk::Result::eSuccess) {
+    VALIDATION_LOG << "Could not create surface for GLFW window: "
+                   << vk::to_string(res);
+    return;
+  }
   vk::UniqueSurfaceKHR surface{surface_tmp, instance};
   context_vk->SetupSwapchain(std::move(surface));
 }


### PR DESCRIPTION
There are additional instance extensions that need to be enabled for this. Having any one of them is sufficient on each of these platforms. There were also some `VALIDATION_LOG`s that would fail in the process of picking a valid physical device, this would incorrectly exit early when there were multiple devices and a latter device is valid.

Also improves logging for playground when glfw fails to get a surface.