### PR TITLE
Revert "Roll Clang from 039b969b32b6 to f85c1f3b7c0b"

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -35,7 +35,7 @@ vars = {
   # The list of revisions for these tools comes from Fuchsia, here:
   # https://fuchsia.googlesource.com/integration/+/HEAD/toolchain
   # If there are problems with the toolchain, contact fuchsia-toolchain@.
-  'clang_version': 'git_revision:f85c1f3b7c0bda64aef12201e2f5bbad6028582d',
+  'clang_version': 'git_revision:039b969b32b64b64123dce30dd28ec4e343d893f',
 
   # When updating the Dart revision, ensure that all entries that are
   # dependencies of Dart are also updated to match the entries in the


### PR DESCRIPTION
Reverts flutter/engine#36739

This is causing the flutter tree to break. A longer term fix will need to be employed, but this is to return the tree to green for now while a longer term fix is implemented.

https://ci.chromium.org/p/flutter/builders/prod/Linux_android%20list_text_layout_impeller_perf__e2e_summary/1728