### PR TITLE
Always use fml::TaskRunnerAffineWeakPtr for SnapshotDelegate

### DIFF
--- a/lib/ui/compositing/scene.cc
+++ b/lib/ui/compositing/scene.cc
@@ -95,7 +95,7 @@ static sk_sp<DlImage> CreateDeferredImage(
     std::shared_ptr<LayerTree> layer_tree,
     uint32_t width,
     uint32_t height,
-    fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
+    fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate,
     fml::RefPtr<fml::TaskRunner> raster_task_runner,
     fml::RefPtr<SkiaUnrefQueue> unref_queue) {
 #if IMPELLER_SUPPORTS_RENDERING

--- a/lib/ui/painting/display_list_deferred_image_gpu_impeller.cc
+++ b/lib/ui/painting/display_list_deferred_image_gpu_impeller.cc
@@ -10,7 +10,7 @@ namespace flutter {
 sk_sp<DlDeferredImageGPUImpeller> DlDeferredImageGPUImpeller::Make(
     std::shared_ptr<LayerTree> layer_tree,
     const SkISize& size,
-    fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
+    fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate,
     fml::RefPtr<fml::TaskRunner> raster_task_runner) {
   return sk_sp<DlDeferredImageGPUImpeller>(new DlDeferredImageGPUImpeller(
       DlDeferredImageGPUImpeller::ImageWrapper::Make(
@@ -21,7 +21,7 @@ sk_sp<DlDeferredImageGPUImpeller> DlDeferredImageGPUImpeller::Make(
 sk_sp<DlDeferredImageGPUImpeller> DlDeferredImageGPUImpeller::Make(
     sk_sp<DisplayList> display_list,
     const SkISize& size,
-    fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
+    fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate,
     fml::RefPtr<fml::TaskRunner> raster_task_runner) {
   return sk_sp<DlDeferredImageGPUImpeller>(new DlDeferredImageGPUImpeller(
       DlDeferredImageGPUImpeller::ImageWrapper::Make(
@@ -88,7 +88,7 @@ std::shared_ptr<DlDeferredImageGPUImpeller::ImageWrapper>
 DlDeferredImageGPUImpeller::ImageWrapper::Make(
     sk_sp<DisplayList> display_list,
     const SkISize& size,
-    fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
+    fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate,
     fml::RefPtr<fml::TaskRunner> raster_task_runner) {
   auto wrapper = std::shared_ptr<ImageWrapper>(new ImageWrapper(
       std::move(display_list), size, std::move(snapshot_delegate),
@@ -101,7 +101,7 @@ std::shared_ptr<DlDeferredImageGPUImpeller::ImageWrapper>
 DlDeferredImageGPUImpeller::ImageWrapper::Make(
     std::shared_ptr<LayerTree> layer_tree,
     const SkISize& size,
-    fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
+    fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate,
     fml::RefPtr<fml::TaskRunner> raster_task_runner) {
   auto wrapper = std::shared_ptr<ImageWrapper>(
       new ImageWrapper(nullptr, size, std::move(snapshot_delegate),
@@ -113,7 +113,7 @@ DlDeferredImageGPUImpeller::ImageWrapper::Make(
 DlDeferredImageGPUImpeller::ImageWrapper::ImageWrapper(
     sk_sp<DisplayList> display_list,
     const SkISize& size,
-    fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
+    fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate,
     fml::RefPtr<fml::TaskRunner> raster_task_runner)
     : size_(size),
       display_list_(std::move(display_list)),

--- a/lib/ui/painting/display_list_deferred_image_gpu_impeller.h
+++ b/lib/ui/painting/display_list_deferred_image_gpu_impeller.h
@@ -20,13 +20,13 @@ class DlDeferredImageGPUImpeller final : public DlImage {
   static sk_sp<DlDeferredImageGPUImpeller> Make(
       std::shared_ptr<LayerTree> layer_tree,
       const SkISize& size,
-      fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
+      fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate,
       fml::RefPtr<fml::TaskRunner> raster_task_runner);
 
   static sk_sp<DlDeferredImageGPUImpeller> Make(
       sk_sp<DisplayList> display_list,
       const SkISize& size,
-      fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
+      fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate,
       fml::RefPtr<fml::TaskRunner> raster_task_runner);
 
   // |DlImage|
@@ -59,13 +59,13 @@ class DlDeferredImageGPUImpeller final : public DlImage {
     static std::shared_ptr<ImageWrapper> Make(
         sk_sp<DisplayList> display_list,
         const SkISize& size,
-        fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
+        fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate,
         fml::RefPtr<fml::TaskRunner> raster_task_runner);
 
     static std::shared_ptr<ImageWrapper> Make(
         std::shared_ptr<LayerTree> layer_tree,
         const SkISize& size,
-        fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
+        fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate,
         fml::RefPtr<fml::TaskRunner> raster_task_runner);
 
     bool isTextureBacked() const;
@@ -82,17 +82,18 @@ class DlDeferredImageGPUImpeller final : public DlImage {
     SkISize size_;
     sk_sp<DisplayList> display_list_;
     std::shared_ptr<impeller::Texture> texture_;
-    fml::WeakPtr<SnapshotDelegate> snapshot_delegate_;
+    fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate_;
     fml::RefPtr<fml::TaskRunner> raster_task_runner_;
     std::shared_ptr<TextureRegistry> texture_registry_;
 
     mutable std::mutex error_mutex_;
     std::optional<std::string> error_;
 
-    ImageWrapper(sk_sp<DisplayList> display_list,
-                 const SkISize& size,
-                 fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
-                 fml::RefPtr<fml::TaskRunner> raster_task_runner);
+    ImageWrapper(
+        sk_sp<DisplayList> display_list,
+        const SkISize& size,
+        fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate,
+        fml::RefPtr<fml::TaskRunner> raster_task_runner);
 
     // If a layer tree is provided, it will be flattened during the raster
     // thread task spwaned by this method. After being flattened into a display

--- a/lib/ui/painting/display_list_deferred_image_gpu_skia.cc
+++ b/lib/ui/painting/display_list_deferred_image_gpu_skia.cc
@@ -11,7 +11,7 @@ namespace flutter {
 sk_sp<DlDeferredImageGPUSkia> DlDeferredImageGPUSkia::Make(
     const SkImageInfo& image_info,
     sk_sp<DisplayList> display_list,
-    fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
+    fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate,
     const fml::RefPtr<fml::TaskRunner>& raster_task_runner,
     fml::RefPtr<SkiaUnrefQueue> unref_queue) {
   return sk_sp<DlDeferredImageGPUSkia>(new DlDeferredImageGPUSkia(
@@ -24,7 +24,7 @@ sk_sp<DlDeferredImageGPUSkia> DlDeferredImageGPUSkia::Make(
 sk_sp<DlDeferredImageGPUSkia> DlDeferredImageGPUSkia::MakeFromLayerTree(
     const SkImageInfo& image_info,
     std::shared_ptr<LayerTree> layer_tree,
-    fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
+    fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate,
     const fml::RefPtr<fml::TaskRunner>& raster_task_runner,
     fml::RefPtr<SkiaUnrefQueue> unref_queue) {
   return sk_sp<DlDeferredImageGPUSkia>(new DlDeferredImageGPUSkia(
@@ -94,7 +94,7 @@ std::shared_ptr<DlDeferredImageGPUSkia::ImageWrapper>
 DlDeferredImageGPUSkia::ImageWrapper::Make(
     const SkImageInfo& image_info,
     sk_sp<DisplayList> display_list,
-    fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
+    fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate,
     fml::RefPtr<fml::TaskRunner> raster_task_runner,
     fml::RefPtr<SkiaUnrefQueue> unref_queue) {
   auto wrapper = std::shared_ptr<ImageWrapper>(new ImageWrapper(
@@ -108,7 +108,7 @@ std::shared_ptr<DlDeferredImageGPUSkia::ImageWrapper>
 DlDeferredImageGPUSkia::ImageWrapper::MakeFromLayerTree(
     const SkImageInfo& image_info,
     std::shared_ptr<LayerTree> layer_tree,
-    fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
+    fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate,
     fml::RefPtr<fml::TaskRunner> raster_task_runner,
     fml::RefPtr<SkiaUnrefQueue> unref_queue) {
   auto wrapper = std::shared_ptr<ImageWrapper>(
@@ -121,7 +121,7 @@ DlDeferredImageGPUSkia::ImageWrapper::MakeFromLayerTree(
 DlDeferredImageGPUSkia::ImageWrapper::ImageWrapper(
     const SkImageInfo& image_info,
     sk_sp<DisplayList> display_list,
-    fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
+    fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate,
     fml::RefPtr<fml::TaskRunner> raster_task_runner,
     fml::RefPtr<SkiaUnrefQueue> unref_queue)
     : image_info_(image_info),

--- a/lib/ui/painting/display_list_deferred_image_gpu_skia.h
+++ b/lib/ui/painting/display_list_deferred_image_gpu_skia.h
@@ -25,14 +25,14 @@ class DlDeferredImageGPUSkia final : public DlImage {
   static sk_sp<DlDeferredImageGPUSkia> Make(
       const SkImageInfo& image_info,
       sk_sp<DisplayList> display_list,
-      fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
+      fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate,
       const fml::RefPtr<fml::TaskRunner>& raster_task_runner,
       fml::RefPtr<SkiaUnrefQueue> unref_queue);
 
   static sk_sp<DlDeferredImageGPUSkia> MakeFromLayerTree(
       const SkImageInfo& image_info,
       std::shared_ptr<LayerTree> layer_tree,
-      fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
+      fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate,
       const fml::RefPtr<fml::TaskRunner>& raster_task_runner,
       fml::RefPtr<SkiaUnrefQueue> unref_queue);
 
@@ -77,14 +77,14 @@ class DlDeferredImageGPUSkia final : public DlImage {
     static std::shared_ptr<ImageWrapper> Make(
         const SkImageInfo& image_info,
         sk_sp<DisplayList> display_list,
-        fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
+        fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate,
         fml::RefPtr<fml::TaskRunner> raster_task_runner,
         fml::RefPtr<SkiaUnrefQueue> unref_queue);
 
     static std::shared_ptr<ImageWrapper> MakeFromLayerTree(
         const SkImageInfo& image_info,
         std::shared_ptr<LayerTree> layer_tree,
-        fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
+        fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate,
         fml::RefPtr<fml::TaskRunner> raster_task_runner,
         fml::RefPtr<SkiaUnrefQueue> unref_queue);
 
@@ -99,7 +99,7 @@ class DlDeferredImageGPUSkia final : public DlImage {
    private:
     const SkImageInfo image_info_;
     sk_sp<DisplayList> display_list_;
-    fml::WeakPtr<SnapshotDelegate> snapshot_delegate_;
+    fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate_;
     fml::RefPtr<fml::TaskRunner> raster_task_runner_;
     fml::RefPtr<SkiaUnrefQueue> unref_queue_;
     std::shared_ptr<TextureRegistry> texture_registry_;
@@ -112,11 +112,12 @@ class DlDeferredImageGPUSkia final : public DlImage {
     // May be used if this image is not texture backed.
     sk_sp<SkImage> image_;
 
-    ImageWrapper(const SkImageInfo& image_info,
-                 sk_sp<DisplayList> display_list,
-                 fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
-                 fml::RefPtr<fml::TaskRunner> raster_task_runner,
-                 fml::RefPtr<SkiaUnrefQueue> unref_queue);
+    ImageWrapper(
+        const SkImageInfo& image_info,
+        sk_sp<DisplayList> display_list,
+        fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate,
+        fml::RefPtr<fml::TaskRunner> raster_task_runner,
+        fml::RefPtr<SkiaUnrefQueue> unref_queue);
 
     // If a layer tree is provided, it will be flattened during the raster
     // thread task spwaned by this method. After being flattened into a display

--- a/lib/ui/painting/image_encoding.cc
+++ b/lib/ui/painting/image_encoding.cc
@@ -66,7 +66,7 @@ void ConvertImageToRaster(
     const fml::RefPtr<fml::TaskRunner>& raster_task_runner,
     const fml::RefPtr<fml::TaskRunner>& io_task_runner,
     const fml::WeakPtr<GrDirectContext>& resource_context,
-    const fml::WeakPtr<SnapshotDelegate>& snapshot_delegate,
+    const fml::TaskRunnerAffineWeakPtr<SnapshotDelegate>& snapshot_delegate,
     const std::shared_ptr<const fml::SyncSwitch>& is_gpu_disabled_sync_switch) {
   // If the owning_context is kRaster, we can't access it on this task runner.
   if (dl_image->owning_context() != DlImage::OwningContext::kRaster) {
@@ -220,7 +220,7 @@ void EncodeImageAndInvokeDataCallback(
     const fml::RefPtr<fml::TaskRunner>& raster_task_runner,
     const fml::RefPtr<fml::TaskRunner>& io_task_runner,
     const fml::WeakPtr<GrDirectContext>& resource_context,
-    const fml::WeakPtr<SnapshotDelegate>& snapshot_delegate,
+    const fml::TaskRunnerAffineWeakPtr<SnapshotDelegate>& snapshot_delegate,
     const std::shared_ptr<const fml::SyncSwitch>& is_gpu_disabled_sync_switch) {
   auto callback_task = fml::MakeCopyable(
       [callback = std::move(callback)](sk_sp<SkData> encoded) mutable {

--- a/lib/ui/painting/picture.cc
+++ b/lib/ui/painting/picture.cc
@@ -62,7 +62,7 @@ static sk_sp<DlImage> CreateDeferredImage(
     sk_sp<DisplayList> display_list,
     uint32_t width,
     uint32_t height,
-    fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
+    fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate,
     fml::RefPtr<fml::TaskRunner> raster_task_runner,
     fml::RefPtr<SkiaUnrefQueue> unref_queue) {
 #if IMPELLER_SUPPORTS_RENDERING

--- a/lib/ui/ui_dart_state.cc
+++ b/lib/ui/ui_dart_state.cc
@@ -30,7 +30,7 @@ UIDartState::Context::Context(const TaskRunners& task_runners)
 
 UIDartState::Context::Context(
     const TaskRunners& task_runners,
-    fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
+    fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate,
     fml::WeakPtr<IOManager> io_manager,
     fml::RefPtr<SkiaUnrefQueue> unref_queue,
     fml::WeakPtr<ImageDecoder> image_decoder,
@@ -180,7 +180,8 @@ void UIDartState::AddOrRemoveTaskObserver(bool add) {
   }
 }
 
-fml::WeakPtr<SnapshotDelegate> UIDartState::GetSnapshotDelegate() const {
+fml::TaskRunnerAffineWeakPtr<SnapshotDelegate>
+UIDartState::GetSnapshotDelegate() const {
   return context_.snapshot_delegate;
 }
 

--- a/lib/ui/ui_dart_state.h
+++ b/lib/ui/ui_dart_state.h
@@ -46,7 +46,7 @@ class UIDartState : public tonic::DartState {
     explicit Context(const TaskRunners& task_runners);
 
     Context(const TaskRunners& task_runners,
-            fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
+            fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate,
             fml::WeakPtr<IOManager> io_manager,
             fml::RefPtr<SkiaUnrefQueue> unref_queue,
             fml::WeakPtr<ImageDecoder> image_decoder,
@@ -65,7 +65,7 @@ class UIDartState : public tonic::DartState {
     /// The snapshot delegate used by the
     /// isolate to gather raster snapshots
     /// of Flutter view hierarchies.
-    fml::WeakPtr<SnapshotDelegate> snapshot_delegate;
+    fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate;
 
     /// The IO manager used by the isolate for asynchronous texture uploads.
     fml::WeakPtr<IOManager> io_manager;
@@ -135,7 +135,7 @@ class UIDartState : public tonic::DartState {
 
   std::shared_ptr<fml::ConcurrentTaskRunner> GetConcurrentTaskRunner() const;
 
-  fml::WeakPtr<SnapshotDelegate> GetSnapshotDelegate() const;
+  fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> GetSnapshotDelegate() const;
 
   fml::WeakPtr<ImageDecoder> GetImageDecoder() const;
 

--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -55,7 +55,7 @@ std::unique_ptr<RuntimeController> RuntimeController::Spawn(
     fml::WeakPtr<IOManager> io_manager,
     fml::WeakPtr<ImageDecoder> image_decoder,
     fml::WeakPtr<ImageGeneratorRegistry> image_generator_registry,
-    fml::WeakPtr<SnapshotDelegate> snapshot_delegate) const {
+    fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate) const {
   UIDartState::Context spawned_context{
       context_.task_runners,          std::move(snapshot_delegate),
       std::move(io_manager),          context_.unref_queue,

--- a/runtime/runtime_controller.h
+++ b/runtime/runtime_controller.h
@@ -107,7 +107,7 @@ class RuntimeController : public PlatformConfigurationClient {
       fml::WeakPtr<IOManager> io_manager,
       fml::WeakPtr<ImageDecoder> image_decoder,
       fml::WeakPtr<ImageGeneratorRegistry> image_generator_registry,
-      fml::WeakPtr<SnapshotDelegate> snapshot_delegate) const;
+      fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate) const;
 
   // |PlatformConfigurationClient|
   ~RuntimeController() override;
@@ -554,7 +554,8 @@ class RuntimeController : public PlatformConfigurationClient {
     return context_.unref_queue;
   }
 
-  const fml::WeakPtr<SnapshotDelegate>& GetSnapshotDelegate() const {
+  const fml::TaskRunnerAffineWeakPtr<SnapshotDelegate>& GetSnapshotDelegate()
+      const {
     return context_.snapshot_delegate;
   }
 

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -70,7 +70,7 @@ Engine::Engine(Delegate& delegate,
                std::unique_ptr<Animator> animator,
                fml::WeakPtr<IOManager> io_manager,
                fml::RefPtr<SkiaUnrefQueue> unref_queue,
-               fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
+               fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate,
                std::shared_ptr<VolatilePathTracker> volatile_path_tracker)
     : Engine(delegate,
              dispatcher_maker,
@@ -112,7 +112,7 @@ std::unique_ptr<Engine> Engine::Spawn(
     std::unique_ptr<Animator> animator,
     const std::string& initial_route,
     const fml::WeakPtr<IOManager>& io_manager,
-    fml::WeakPtr<SnapshotDelegate> snapshot_delegate) const {
+    fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate) const {
   auto result = std::make_unique<Engine>(
       /*delegate=*/delegate,
       /*dispatcher_maker=*/dispatcher_maker,

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -363,7 +363,7 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
          std::unique_ptr<Animator> animator,
          fml::WeakPtr<IOManager> io_manager,
          fml::RefPtr<SkiaUnrefQueue> unref_queue,
-         fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
+         fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate,
          std::shared_ptr<VolatilePathTracker> volatile_path_tracker);
 
   //----------------------------------------------------------------------------
@@ -382,7 +382,7 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
       std::unique_ptr<Animator> animator,
       const std::string& initial_route,
       const fml::WeakPtr<IOManager>& io_manager,
-      fml::WeakPtr<SnapshotDelegate> snapshot_delegate) const;
+      fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate) const;
 
   //----------------------------------------------------------------------------
   /// @brief      Destroys the engine engine. Called by the shell on the UI task

--- a/shell/common/engine_unittests.cc
+++ b/shell/common/engine_unittests.cc
@@ -146,7 +146,7 @@ class EngineTest : public testing::FixtureTest {
   fml::WeakPtr<IOManager> io_manager_;
   std::unique_ptr<RuntimeController> runtime_controller_;
   std::shared_ptr<fml::ConcurrentTaskRunner> image_decoder_task_runner_;
-  fml::WeakPtr<SnapshotDelegate> snapshot_delegate_;
+  fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate_;
 };
 }  // namespace
 

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -53,7 +53,7 @@ std::unique_ptr<Engine> CreateEngine(
     std::unique_ptr<Animator> animator,
     const fml::WeakPtr<IOManager>& io_manager,
     const fml::RefPtr<SkiaUnrefQueue>& unref_queue,
-    const fml::WeakPtr<SnapshotDelegate>& snapshot_delegate,
+    const fml::TaskRunnerAffineWeakPtr<SnapshotDelegate>& snapshot_delegate,
     const std::shared_ptr<VolatilePathTracker>& volatile_path_tracker) {
   return std::make_unique<Engine>(delegate,             //
                                   dispatcher_maker,     //
@@ -189,7 +189,8 @@ std::unique_ptr<Shell> Shell::CreateShellOnPlatformThread(
   // Create the rasterizer on the raster thread.
   std::promise<std::unique_ptr<Rasterizer>> rasterizer_promise;
   auto rasterizer_future = rasterizer_promise.get_future();
-  std::promise<fml::WeakPtr<SnapshotDelegate>> snapshot_delegate_promise;
+  std::promise<fml::TaskRunnerAffineWeakPtr<SnapshotDelegate>>
+      snapshot_delegate_promise;
   auto snapshot_delegate_future = snapshot_delegate_promise.get_future();
   fml::TaskRunner::RunNowOrPostTask(
       task_runners.GetRasterTaskRunner(), [&rasterizer_promise,  //
@@ -533,7 +534,7 @@ std::unique_ptr<Shell> Shell::Spawn(
           const Settings& settings, std::unique_ptr<Animator> animator,
           const fml::WeakPtr<IOManager>& io_manager,
           const fml::RefPtr<SkiaUnrefQueue>& unref_queue,
-          fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
+          fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate,
           const std::shared_ptr<VolatilePathTracker>& volatile_path_tracker) {
         return engine->Spawn(
             /*delegate=*/delegate,

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -125,7 +125,7 @@ class Shell final : public PlatformView::Delegate,
       std::unique_ptr<Animator> animator,
       fml::WeakPtr<IOManager> io_manager,
       fml::RefPtr<SkiaUnrefQueue> unref_queue,
-      fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
+      fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate,
       std::shared_ptr<VolatilePathTracker> volatile_path_tracker)>
       EngineCreateCallback;
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/113437

I hope someone who knows C++ better can explain this to me, I would not have expected this to cause problems (maybe it's related to unopt builds? it can only show up in an unopt build).

What's happening before this patch is that when threads get merged, the checks from `fml::WeakPtr` are getting used instead of `fml::TaskRunnerAffineWeakPtr`, which is what `SnapshotDelegate` is. I don't get why the upcast causes that.

@stuartmorgan fyi