### PR TITLE
[Impeller] Do not terminate on performance related validation failures

### DIFF
--- a/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/impeller/renderer/backend/vulkan/context_vk.cc
@@ -310,9 +310,16 @@ ContextVK::ContextVK(
            VkDebugUtilsMessageTypeFlagsEXT type,
            const VkDebugUtilsMessengerCallbackDataEXT* data,
            void* user_data) -> VkBool32 {
-      FML_DCHECK(false)
-          << vk::to_string(vk::DebugUtilsMessageSeverityFlagBitsEXT{severity})
-          << ": " << data->pMessage;
+      if (type == VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT) {
+        // do not terminate on performance warnings.
+        FML_LOG(ERROR)
+            << vk::to_string(vk::DebugUtilsMessageSeverityFlagBitsEXT{severity})
+            << ": " << data->pMessage;
+      } else {
+        FML_DCHECK(false)
+            << vk::to_string(vk::DebugUtilsMessageSeverityFlagBitsEXT{severity})
+            << ": " << data->pMessage;
+      }
       return true;
     };
 


### PR DESCRIPTION
Example:

```
Warning: Validation Performance Warning: [ UNASSIGNED-CoreValidation-Shader-OutputNotConsumed ] Object 0: handle = 0x980b0000000002e, type = VK_OBJECT_TYPE_SHADER_MODULE; | MessageID = 0x609a13b | vertex shader writes to output location 1.0 which is not consumed by fragment shader. Enable VK_KHR_maintenance4 device extension to allow relaxed interface matching between input and output vectors.
```

In cases like these where SPIRV-Cross optimizes away unused uniforms in fragment shaders, there isn't an easy way to detect and not drop these. Current constraints mean that `VK_KHR_maintenance4` can not be guaranteed to be available. So we log and continue.
