### PR TITLE
[CP] Workaround iOS text input crash for emoji+Korean text

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -7,6 +7,8 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
+#include "unicode/uchar.h"
+
 #include "flutter/fml/logging.h"
 #include "flutter/fml/platform/darwin/string_range_sanitization.h"
 
@@ -1896,6 +1898,22 @@ static BOOL IsSelectionRectCloserToPoint(CGPoint point,
     NSRange oldRange = ((FlutterTextRange*)oldSelectedRange).range;
     if (oldRange.location > 0) {
       NSRange newRange = NSMakeRange(oldRange.location - 1, 1);
+
+      // We should check if the last character is a part of emoji.
+      // If so, we must delete the entire emoji to prevent the text from being malformed.
+      NSRange charRange = fml::RangeForCharacterAtIndex(self.text, oldRange.location - 1);
+      UChar32 codePoint;
+      BOOL gotCodePoint = [self.text getBytes:&codePoint
+                                    maxLength:sizeof(codePoint)
+                                   usedLength:NULL
+                                     encoding:NSUTF32StringEncoding
+                                      options:kNilOptions
+                                        range:charRange
+                               remainingRange:NULL];
+      if (gotCodePoint && u_hasBinaryProperty(codePoint, UCHAR_EMOJI)) {
+        newRange = NSMakeRange(charRange.location, oldRange.location - charRange.location);
+      }
+
       _selectedTextRange = [[FlutterTextRange rangeWithNSRange:newRange] copy];
       [oldSelectedRange release];
     }

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -406,6 +406,41 @@ FLUTTER_ASSERT_ARC
   XCTAssertEqualObjects(substring, @"bbbbaaaabbbbaaaa");
 }
 
+- (void)testDeletingBackward {
+  NSDictionary* config = self.mutableTemplateCopy;
+  [self setClientId:123 configuration:config];
+  NSArray<FlutterTextInputView*>* inputFields = self.installedInputViews;
+  FlutterTextInputView* inputView = inputFields[0];
+
+  [inputView insertText:@"ឹ😀 text 🥰👨‍👩‍👧‍👦🇺🇳ดี "];
+  [inputView deleteBackward];
+  [inputView deleteBackward];
+
+  // Thai vowel is removed.
+  XCTAssertEqualObjects(inputView.text, @"ឹ😀 text 🥰👨‍👩‍👧‍👦🇺🇳ด");
+  [inputView deleteBackward];
+  XCTAssertEqualObjects(inputView.text, @"ឹ😀 text 🥰👨‍👩‍👧‍👦🇺🇳");
+  [inputView deleteBackward];
+  XCTAssertEqualObjects(inputView.text, @"ឹ😀 text 🥰👨‍👩‍👧‍👦");
+  [inputView deleteBackward];
+  XCTAssertEqualObjects(inputView.text, @"ឹ😀 text 🥰");
+  [inputView deleteBackward];
+
+  XCTAssertEqualObjects(inputView.text, @"ឹ😀 text ");
+  [inputView deleteBackward];
+  [inputView deleteBackward];
+  [inputView deleteBackward];
+  [inputView deleteBackward];
+  [inputView deleteBackward];
+  [inputView deleteBackward];
+
+  XCTAssertEqualObjects(inputView.text, @"ឹ😀");
+  [inputView deleteBackward];
+  XCTAssertEqualObjects(inputView.text, @"ឹ");
+  [inputView deleteBackward];
+  XCTAssertEqualObjects(inputView.text, @"");
+}
+
 - (void)testPastingNonTextDisallowed {
   NSDictionary* config = self.mutableTemplateCopy;
   [self setClientId:123 configuration:config];

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -441,6 +441,65 @@ FLUTTER_ASSERT_ARC
   XCTAssertEqualObjects(inputView.text, @"");
 }
 
+// This tests the workaround to fix an iOS 16 bug
+// See: https://github.com/flutter/flutter/issues/111494
+- (void)testSystemOnlyAddingPartialComposedCharacter {
+  NSDictionary* config = self.mutableTemplateCopy;
+  [self setClientId:123 configuration:config];
+  NSArray<FlutterTextInputView*>* inputFields = self.installedInputViews;
+  FlutterTextInputView* inputView = inputFields[0];
+
+  [inputView insertText:@"👨‍👩‍👧‍👦"];
+  [inputView deleteBackward];
+
+  // Insert the first unichar in the emoji.
+  [inputView insertText:[@"👨‍👩‍👧‍👦" substringWithRange:NSMakeRange(0, 1)]];
+  [inputView insertText:@"아"];
+
+  XCTAssertEqualObjects(inputView.text, @"👨‍👩‍👧‍👦아");
+
+  // Deleting 아.
+  [inputView deleteBackward];
+  // 👨‍👩‍👧‍👦 should be the current string.
+
+  [inputView insertText:@"😀"];
+  [inputView deleteBackward];
+  // Insert the first unichar in the emoji.
+  [inputView insertText:[@"😀" substringWithRange:NSMakeRange(0, 1)]];
+  [inputView insertText:@"아"];
+  XCTAssertEqualObjects(inputView.text, @"👨‍👩‍👧‍👦😀아");
+
+  // Deleting 아.
+  [inputView deleteBackward];
+  // 👨‍👩‍👧‍👦😀 should be the current string.
+
+  [inputView deleteBackward];
+  // Insert the first unichar in the emoji.
+  [inputView insertText:[@"😀" substringWithRange:NSMakeRange(0, 1)]];
+  [inputView insertText:@"아"];
+
+  XCTAssertEqualObjects(inputView.text, @"👨‍👩‍👧‍👦😀아");
+}
+
+- (void)testCachedComposedCharacterClearedAtKeyboardInteraction {
+  NSDictionary* config = self.mutableTemplateCopy;
+  [self setClientId:123 configuration:config];
+  NSArray<FlutterTextInputView*>* inputFields = self.installedInputViews;
+  FlutterTextInputView* inputView = inputFields[0];
+
+  [inputView insertText:@"👨‍👩‍👧‍👦"];
+  [inputView deleteBackward];
+  [inputView shouldChangeTextInRange:OCMClassMock([UITextRange class]) replacementText:@""];
+
+  // Insert the first unichar in the emoji.
+  NSString* brokenEmoji = [@"👨‍👩‍👧‍👦" substringWithRange:NSMakeRange(0, 1)];
+  [inputView insertText:brokenEmoji];
+  [inputView insertText:@"아"];
+
+  NSString* finalText = [NSString stringWithFormat:@"%@아", brokenEmoji];
+  XCTAssertEqualObjects(inputView.text, finalText);
+}
+
 - (void)testPastingNonTextDisallowed {
   NSDictionary* config = self.mutableTemplateCopy;
   [self setClientId:123 configuration:config];

--- a/testing/ios/IosUnitTests/IosUnitTests.xcodeproj/xcshareddata/xcschemes/IosUnitTests.xcscheme
+++ b/testing/ios/IosUnitTests/IosUnitTests.xcodeproj/xcshareddata/xcschemes/IosUnitTests.xcscheme
@@ -78,6 +78,12 @@
             ReferencedContainer = "container:IosUnitTests.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "--icu-data-file-path=Frameworks/Flutter.framework/icudtl.dat"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
Hot fixing: https://github.com/flutter/flutter/issues/111494
PR: https://github.com/flutter/engine/pull/36295 and #34508

CP issue: https://github.com/flutter/flutter/issues/112963

https://github.com/flutter/engine/pull/36621 plus cherry pick #34508

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
