### PR TITLE
[Impeller] Make validation errors fatal in non-release builds.

### DIFF
--- a/impeller/base/validation.cc
+++ b/impeller/base/validation.cc
@@ -24,8 +24,12 @@ ValidationLog::ValidationLog() = default;
 
 ValidationLog::~ValidationLog() {
   if (sValidationLogsDisabledCount <= 0) {
+#if (FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_RELEASE)
     FML_LOG(ERROR) << stream_.str();
     ImpellerValidationBreak();
+#else
+    FML_LOG(FATAL) << stream_.str();
+#endif
   }
 }
 


### PR DESCRIPTION
This ensures that the scenario tests with Impeller enabled will fail when there are validation errors like the ones fixed by https://github.com/flutter/engine/pull/36809