### PR TITLE
download fonts concurrently with wasm

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/font_fallbacks.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/font_fallbacks.dart
@@ -447,12 +447,7 @@ class FallbackFontDownloadQueue {
       final Uint8List bytes = downloadedData[url]!;
       FontFallbackData.instance.registerFallbackFont(font.name, bytes);
       if (pendingFonts.isEmpty) {
-        _fontsLoading = renderer.fontCollection.ensureFontsLoaded();
-        try {
-          await _fontsLoading;
-        } finally {
-          _fontsLoading = null;
-        }
+        renderer.fontCollection.registerDownloadedFonts();
         sendFontChangeMessage();
       }
     }

--- a/lib/web_ui/lib/src/engine/canvaskit/fonts.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/fonts.dart
@@ -83,7 +83,7 @@ class SkiaFontCollection implements FontCollection {
         canvasKit.Typeface.MakeFreeTypeFaceFromData(list.buffer);
     if (typeface != null) {
       _registeredFonts.add(RegisteredFont(list, fontFamily, typeface));
-      registerDownloadedFonts();
+      _registerWithFontProvider();
     } else {
       printWarning('Failed to parse font family "$fontFamily"');
       return;
@@ -135,7 +135,12 @@ class SkiaFontCollection implements FontCollection {
     }
 
     final List<UnregisteredFont?> completedPendingFonts = await Future.wait(pendingFonts);
-    _unregisteredFonts.addAll(completedPendingFonts.whereType<UnregisteredFont>());
+    for (final UnregisteredFont? unregFont in completedPendingFonts) {
+      if (unregFont != null) {
+        _unregisteredFonts.add(unregFont);
+      }
+    }
+    //_unregisteredFonts.addAll(completedPendingFonts.whereType<UnregisteredFont>());
   }
 
   @override
@@ -151,10 +156,6 @@ class SkiaFontCollection implements FontCollection {
         printWarning('Verify that $url contains a valid font.');
         return null;
       }
-    }
-
-    if (_unregisteredFonts.isEmpty) {
-      return;
     }
 
     for (final UnregisteredFont unregisteredFont in _unregisteredFonts) {

--- a/lib/web_ui/lib/src/engine/canvaskit/fonts.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/fonts.dart
@@ -23,42 +23,29 @@ const String _robotoUrl =
 
 /// Manages the fonts used in the Skia-based backend.
 class SkiaFontCollection implements FontCollection {
-  final Set<String> _registeredFontFamilies = <String>{};
+  final Set<String> _downloadedFontFamilies = <String>{};
 
-  /// Fonts that started the download process.
+  /// Fonts that started the download process, but are not yet registered.
   ///
-  /// Once downloaded successfully, this map is cleared and the resulting
-  /// [RegisteredFont]s are added to [_downloadedFonts].
-  final List<Future<RegisteredFont?>> _pendingFonts = <Future<RegisteredFont?>>[];
+  /// /// Once downloaded successfully, this map is cleared and the resulting
+  /// [UnregisteredFont]s are added to [_registeredFonts].
+  final List<UnregisteredFont> _unregisteredFonts = <UnregisteredFont>[];
 
-  /// Fonts that have been downloaded and parsed into [SkTypeface].
-  ///
-  /// These fonts may not yet have been registered with the [fontProvider]. This
-  /// happens after [ensureFontsLoaded] completes.
-  final List<RegisteredFont> _downloadedFonts = <RegisteredFont>[];
+  final List<RegisteredFont> _registeredFonts = <RegisteredFont>[];
 
-  /// Font ByteBuffer information and corresponding url and family are
-  /// temporarily stored here while waiting for canvaskit field to be initialized.
-  final List<List<dynamic>> _pendingFontInfo = List<List<dynamic>>.empty(
-    growable: true
-  );
-
-  /// Returns fonts that have been downloaded and parsed.
+  /// Returns fonts that have been downloaded, registered, and parsed.
   ///
   /// This should only be used in tests.
-  List<RegisteredFont>? get debugDownloadedFonts {
+  List<RegisteredFont>? get debugRegisteredFonts {
     if (!assertionsEnabled) {
       return null;
     }
-    return _downloadedFonts;
+    return _registeredFonts;
   }
 
   final Map<String, List<SkFont>> familyToFontMap = <String, List<SkFont>>{};
 
-  @override
-  Future<void> ensureFontsLoaded() async {
-    await _loadFonts();
-
+  void _registerWithFontProvider() {
     if (fontProvider != null) {
       fontProvider!.delete();
       fontProvider = null;
@@ -66,7 +53,7 @@ class SkiaFontCollection implements FontCollection {
     fontProvider = canvasKit.TypefaceFontProvider.Make();
     familyToFontMap.clear();
 
-    for (final RegisteredFont font in _downloadedFonts) {
+    for (final RegisteredFont font in _registeredFonts) {
       fontProvider!.registerFont(font.bytes, font.family);
       familyToFontMap
           .putIfAbsent(font.family, () => <SkFont>[])
@@ -82,21 +69,6 @@ class SkiaFontCollection implements FontCollection {
     }
   }
 
-  /// Loads all of the unloaded fonts in [_pendingFonts] and adds them
-  /// to [_downloadedFonts].
-  Future<void> _loadFonts() async {
-    if (_pendingFonts.isEmpty) {
-      return;
-    }
-    final List<RegisteredFont?> loadedFonts = await Future.wait(_pendingFonts);
-    for (final RegisteredFont? font in loadedFonts) {
-      if (font != null) {
-        _downloadedFonts.add(font);
-      }
-    }
-    _pendingFonts.clear();
-  }
-
   @override
   Future<void> loadFontFromList(Uint8List list, {String? fontFamily}) async {
     if (fontFamily == null) {
@@ -110,8 +82,8 @@ class SkiaFontCollection implements FontCollection {
     final SkTypeface? typeface =
         canvasKit.Typeface.MakeFreeTypeFaceFromData(list.buffer);
     if (typeface != null) {
-      _downloadedFonts.add(RegisteredFont(list, fontFamily, typeface));
-      await ensureFontsLoaded();
+      _registeredFonts.add(RegisteredFont(list, fontFamily, typeface));
+      registerDownloadedFonts();
     } else {
       printWarning('Failed to parse font family "$fontFamily"');
       return;
@@ -120,7 +92,7 @@ class SkiaFontCollection implements FontCollection {
 
   /// Loads fonts from `FontManifest.json`.
   @override
-  Future<void> registerFonts(AssetManager assetManager) async {
+  Future<void> downloadAssetFonts(AssetManager assetManager) async {
     ByteData byteData;
 
     try {
@@ -141,6 +113,8 @@ class SkiaFontCollection implements FontCollection {
           'There was a problem trying to load FontManifest.json');
     }
 
+    final List<Future<UnregisteredFont?>> pendingFonts = <Future<UnregisteredFont?>>[];
+
     for (final Map<String, dynamic> fontFamily
         in fontManifest.cast<Map<String, dynamic>>()) {
       final String family = fontFamily.readString('family');
@@ -148,24 +122,25 @@ class SkiaFontCollection implements FontCollection {
       for (final dynamic fontAssetItem in fontAssets) {
         final Map<String, dynamic> fontAsset = fontAssetItem as Map<String, dynamic>;
         final String asset = fontAsset.readString('asset');
-        unawaited(_registerFont(assetManager.getAssetUrl(asset), family));
+        _downloadFont(pendingFonts, assetManager.getAssetUrl(asset), family);
       }
     }
 
     /// We need a default fallback font for CanvasKit, in order to
     /// avoid crashing while laying out text with an unregistered font. We chose
     /// Roboto to match Android.
-    if (!_isFontFamilyRegistered('Roboto')) {
+    if (!_isFontFamilyDownloaded('Roboto')) {
       // Download Roboto and add it to the font buffers.
-      unawaited(_registerFont(_robotoUrl, 'Roboto'));
+      _downloadFont(pendingFonts, _robotoUrl, 'Roboto');
     }
+
+    final List<UnregisteredFont?> completedPendingFonts = await Future.wait(pendingFonts);
+    _unregisteredFonts.addAll(completedPendingFonts.whereType<UnregisteredFont>());
   }
 
-  /// Make typefaces for each font and if successful, adds them to pendingFonts
-  /// to be resolved in _loadFonts.
   @override
-  Future<void> addPendingFonts() async {
-    Future<RegisteredFont?> addFont(ByteBuffer buffer, String url, String family) async {
+  void registerDownloadedFonts() {
+    RegisteredFont? makeRegisterFont(ByteBuffer buffer, String url, String family) {
       final Uint8List bytes = buffer.asUint8List();
       final SkTypeface? typeface =
           canvasKit.Typeface.MakeFreeTypeFaceFromData(bytes.buffer);
@@ -178,51 +153,67 @@ class SkiaFontCollection implements FontCollection {
       }
     }
 
-    for (final List<dynamic> fontInfo in _pendingFontInfo) {
-      final ByteBuffer buffer = fontInfo[0] as ByteBuffer;
-      final String url = fontInfo[1] as String;
-      final String family = fontInfo[2] as String;
-      if (buffer != null) {
-        _pendingFonts.add(addFont(buffer, url, family));
-      }
+    if (_unregisteredFonts.isEmpty) {
+      return;
     }
-    _pendingFontInfo.clear();
+
+    for (final UnregisteredFont unregisteredFont in _unregisteredFonts) {
+      final RegisteredFont? registeredFont = makeRegisterFont(
+        unregisteredFont.bytes,
+        unregisteredFont.url,
+        unregisteredFont.family
+      );
+        if (registeredFont != null) {
+          _registeredFonts.add(registeredFont);
+        }
+    }
+
+    _unregisteredFonts.clear();
+    _registerWithFontProvider();
   }
 
   /// Whether the [fontFamily] was registered and/or loaded.
-  bool _isFontFamilyRegistered(String fontFamily) {
-    return _registeredFontFamilies.contains(fontFamily);
+  bool _isFontFamilyDownloaded(String fontFamily) {
+    return _downloadedFontFamilies.contains(fontFamily);
   }
 
   /// Loads the Ahem font, unless it's already been loaded using
-  /// `FontManifest.json` (see [registerFonts]).
+  /// `FontManifest.json` (see [downloadAssetFonts]).
   ///
   /// `FontManifest.json` has higher priority than the default test font URLs.
   /// This allows customizing test environments where fonts are loaded from
   /// different URLs.
   @override
-  void debugRegisterTestFonts() {
-    if (!_isFontFamilyRegistered(ahemFontFamily)) {
-      _registerFont(ahemFontUrl, ahemFontFamily);
+  Future<void> debugDownloadTestFonts() async {
+    final List<Future<UnregisteredFont?>> pendingFonts = <Future<UnregisteredFont?>>[];
+    if (!_isFontFamilyDownloaded(ahemFontFamily)) {
+      _downloadFont(pendingFonts, ahemFontUrl, ahemFontFamily);
     }
-    if (!_isFontFamilyRegistered(robotoFontFamily)) {
-      _registerFont(robotoTestFontUrl, robotoFontFamily);
+    if (!_isFontFamilyDownloaded(robotoFontFamily)) {
+      _downloadFont(pendingFonts, robotoTestFontUrl, robotoFontFamily);
     }
-    if (!_isFontFamilyRegistered(robotoVariableFontFamily)) {
-      _registerFont(robotoVariableTestFontUrl, robotoVariableFontFamily);
+    if (!_isFontFamilyDownloaded(robotoVariableFontFamily)) {
+      _downloadFont(pendingFonts, robotoVariableTestFontUrl, robotoVariableFontFamily);
     }
+
+    final List<UnregisteredFont?> completedPendingFonts = await Future.wait(pendingFonts);
+    _unregisteredFonts.addAll(completedPendingFonts.whereType<UnregisteredFont>());
 
     // Ahem must be added to font fallbacks list regardless of where it was
     // downloaded from.
     FontFallbackData.instance.globalFontFallbacks.add(ahemFontFamily);
   }
 
-  Future<void> _registerFont(String url, String family) async {
-    Future<ByteBuffer?> downloadFont() async {
+  void _downloadFont(
+    List<Future<UnregisteredFont?>> waitUnregisteredFonts,
+    String url,
+    String family
+  ) {
+    Future<UnregisteredFont?> downloadFont() async {
       ByteBuffer buffer;
       try {
         buffer = await httpFetch(url).then(_getArrayBuffer);
-        return buffer;
+        return UnregisteredFont(buffer, url, family);
       } catch (e) {
         printWarning('Failed to load font $family at $url');
         printWarning(e.toString());
@@ -230,9 +221,8 @@ class SkiaFontCollection implements FontCollection {
       }
     }
 
-    _registeredFontFamilies.add(family);
-    final ByteBuffer? finishedLoadedFont = await downloadFont();
-    _pendingFontInfo.add(<dynamic>[finishedLoadedFont, url, family]);
+    _downloadedFontFamilies.add(family);
+    waitUnregisteredFonts.add(downloadFont());
   }
 
 
@@ -274,4 +264,12 @@ class RegisteredFont {
   ///
   /// This is used to determine which code points are supported by this font.
   final SkTypeface typeface;
+}
+
+/// Represents a font that has been downloaded but not registered.
+class UnregisteredFont {
+  const UnregisteredFont(this.bytes, this.url, this.family);
+  final ByteBuffer bytes;
+  final String url;
+  final String family;
 }

--- a/lib/web_ui/lib/src/engine/canvaskit/fonts.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/fonts.dart
@@ -135,12 +135,7 @@ class SkiaFontCollection implements FontCollection {
     }
 
     final List<UnregisteredFont?> completedPendingFonts = await Future.wait(pendingFonts);
-    for (final UnregisteredFont? unregFont in completedPendingFonts) {
-      if (unregFont != null) {
-        _unregisteredFonts.add(unregFont);
-      }
-    }
-    //_unregisteredFonts.addAll(completedPendingFonts.whereType<UnregisteredFont>());
+    _unregisteredFonts.addAll(completedPendingFonts.whereType<UnregisteredFont>());
   }
 
   @override

--- a/lib/web_ui/lib/src/engine/canvaskit/fonts.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/fonts.dart
@@ -163,9 +163,9 @@ class SkiaFontCollection implements FontCollection {
         unregisteredFont.url,
         unregisteredFont.family
       );
-        if (registeredFont != null) {
-          _registeredFonts.add(registeredFont);
-        }
+      if (registeredFont != null) {
+        _registeredFonts.add(registeredFont);
+      }
     }
 
     _unregisteredFonts.clear();

--- a/lib/web_ui/lib/src/engine/fonts.dart
+++ b/lib/web_ui/lib/src/engine/fonts.dart
@@ -10,6 +10,7 @@ abstract class FontCollection {
   Future<void> loadFontFromList(Uint8List list, {String? fontFamily});
   Future<void> ensureFontsLoaded();
   Future<void> registerFonts(AssetManager assetManager);
+  Future<void> addPendingFonts();
   void debugRegisterTestFonts();
   void clear();
 }

--- a/lib/web_ui/lib/src/engine/fonts.dart
+++ b/lib/web_ui/lib/src/engine/fonts.dart
@@ -2,15 +2,15 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:typed_data';
 
 import 'assets.dart';
 
 abstract class FontCollection {
   Future<void> loadFontFromList(Uint8List list, {String? fontFamily});
-  Future<void> ensureFontsLoaded();
-  Future<void> registerFonts(AssetManager assetManager);
-  Future<void> addPendingFonts();
-  void debugRegisterTestFonts();
+  Future<void> downloadAssetFonts(AssetManager assetManager);
+  void registerDownloadedFonts();
+  FutureOr<void> debugDownloadTestFonts();
   void clear();
 }

--- a/lib/web_ui/lib/src/engine/fonts.dart
+++ b/lib/web_ui/lib/src/engine/fonts.dart
@@ -9,7 +9,15 @@ import 'assets.dart';
 
 abstract class FontCollection {
   Future<void> loadFontFromList(Uint8List list, {String? fontFamily});
+
+  /// Completes when fonts from FontManifest.json have been downloaded.
   Future<void> downloadAssetFonts(AssetManager assetManager);
+
+  /// Registeres fonts that have been downloaded but not yet registered with the
+  /// TypefaceFontProvider.
+  ///
+  /// downloading of fonts happens separately from registering of fonts so that
+  /// the download step can happen concurrently with the download of wasm.
   void registerDownloadedFonts();
   FutureOr<void> debugDownloadTestFonts();
   void clear();

--- a/lib/web_ui/lib/src/engine/fonts.dart
+++ b/lib/web_ui/lib/src/engine/fonts.dart
@@ -8,16 +8,26 @@ import 'dart:typed_data';
 import 'assets.dart';
 
 abstract class FontCollection {
+
+  /// Fonts loaded with [loadFontFromList] do not need to be registered
+  /// with [registerDownloadedFonts]. Fonts are both downloaded and registered
+  /// with [loadFontFromList] calls.
   Future<void> loadFontFromList(Uint8List list, {String? fontFamily});
 
   /// Completes when fonts from FontManifest.json have been downloaded.
   Future<void> downloadAssetFonts(AssetManager assetManager);
 
-  /// Registeres fonts that have been downloaded but not yet registered with the
-  /// TypefaceFontProvider.
+  /// Registers both downloaded fonts and fallback fonts with the TypefaceFontProvider.
   ///
-  /// downloading of fonts happens separately from registering of fonts so that
-  /// the download step can happen concurrently with the download of wasm.
+  /// Downloading of fonts happens separately from registering of fonts so that
+  /// the download step can happen concurrently with the initalization of the renderer.
+  ///
+  /// The correct order of calls to register downloaded fonts:
+  /// 1) [downloadAssetFonts]
+  /// 2) [registerDownloadedFonts]
+  ///
+  /// For fallbackFonts, call registerFallbackFont (see font_fallbacks.dart)
+  /// for each fallback font before calling [registerDownloadedFonts]
   void registerDownloadedFonts();
   FutureOr<void> debugDownloadTestFonts();
   void clear();

--- a/lib/web_ui/lib/src/engine/initialization.dart
+++ b/lib/web_ui/lib/src/engine/initialization.dart
@@ -208,7 +208,7 @@ Future<void> initializeEngineServices({
   _setAssetManager(assetManager);
 
   Future<void> initializeRendererCallback () async => renderer.initialize();
-  await Future.wait<void>(<Future<void>>[initializeRendererCallback(), _downloadAssetFonts(assetManager)]);
+  await Future.wait<void>(<Future<void>>[initializeRendererCallback(), _downloadAssetFonts()]);
   renderer.fontCollection.registerDownloadedFonts();
   _initializationState = DebugEngineInitializationState.initializedServices;
 }
@@ -253,11 +253,11 @@ void _setAssetManager(AssetManager assetManager) {
   _assetManager = assetManager;
 }
 
-Future<void> _downloadAssetFonts(AssetManager assetManager) async {
+Future<void> _downloadAssetFonts() async {
   renderer.fontCollection.clear();
 
   if (_assetManager != null) {
-    await renderer.fontCollection.downloadAssetFonts(assetManager);
+    await renderer.fontCollection.downloadAssetFonts(_assetManager!);
   }
 
   if (ui.debugEmulateFlutterTesterEnvironment) {

--- a/lib/web_ui/lib/src/engine/initialization.dart
+++ b/lib/web_ui/lib/src/engine/initialization.dart
@@ -205,10 +205,11 @@ Future<void> initializeEngineServices({
   };
 
   assetManager ??= const AssetManager();
-  Future<void> rendererCallback () async => renderer.initialize();
-  await Future.wait<void>(<Future<void>>[rendererCallback(), _setAssetManager(assetManager)]);
-  await renderer.fontCollection.addPendingFonts();
-  await renderer.fontCollection.ensureFontsLoaded();
+  _setAssetManager(assetManager);
+
+  Future<void> initializeRendererCallback () async => renderer.initialize();
+  await Future.wait<void>(<Future<void>>[initializeRendererCallback(), _downloadAssetFonts(assetManager)]);
+  renderer.fontCollection.registerDownloadedFonts();
   _initializationState = DebugEngineInitializationState.initializedServices;
 }
 
@@ -243,22 +244,24 @@ Future<void> initializeEngineUi() async {
 AssetManager get assetManager => _assetManager!;
 AssetManager? _assetManager;
 
-Future<void> _setAssetManager(AssetManager assetManager) async {
+void _setAssetManager(AssetManager assetManager) {
   assert(assetManager != null, 'Cannot set assetManager to null');
   if (assetManager == _assetManager) {
     return;
   }
 
   _assetManager = assetManager;
+}
 
+Future<void> _downloadAssetFonts(AssetManager assetManager) async {
   renderer.fontCollection.clear();
 
   if (_assetManager != null) {
-    await renderer.fontCollection.registerFonts(assetManager);
+    await renderer.fontCollection.downloadAssetFonts(assetManager);
   }
 
   if (ui.debugEmulateFlutterTesterEnvironment) {
-    renderer.fontCollection.debugRegisterTestFonts();
+    await renderer.fontCollection.debugDownloadTestFonts();
   }
 }
 

--- a/lib/web_ui/lib/src/engine/initialization.dart
+++ b/lib/web_ui/lib/src/engine/initialization.dart
@@ -204,10 +204,10 @@ Future<void> initializeEngineServices({
     }
   };
 
-  await renderer.initialize();
-
   assetManager ??= const AssetManager();
-  await _setAssetManager(assetManager);
+  Future<void> rendererCallback () async => renderer.initialize();
+  await Future.wait<void>(<Future<void>>[rendererCallback(), _setAssetManager(assetManager)]);
+  await renderer.fontCollection.addPendingFonts();
   await renderer.fontCollection.ensureFontsLoaded();
   _initializationState = DebugEngineInitializationState.initializedServices;
 }

--- a/lib/web_ui/lib/src/engine/text/font_collection.dart
+++ b/lib/web_ui/lib/src/engine/text/font_collection.dart
@@ -266,6 +266,9 @@ class _PolyfillFontManager extends FontManager {
   }
 
   @override
+  void registerDownloadedFonts() {}
+
+  @override
   void downloadAsset(
     String family,
     String asset,

--- a/lib/web_ui/lib/src/engine/text/font_collection.dart
+++ b/lib/web_ui/lib/src/engine/text/font_collection.dart
@@ -110,6 +110,11 @@ class HtmlFontCollection implements FontCollection {
       domDocument.fonts!.clear();
     }
   }
+
+  @override
+  Future<void> addPendingFonts() async {
+    return;
+  }
 }
 
 /// Manages a collection of fonts and ensures they are loaded.

--- a/lib/web_ui/lib/src/engine/text/font_collection.dart
+++ b/lib/web_ui/lib/src/engine/text/font_collection.dart
@@ -113,11 +113,6 @@ class HtmlFontCollection implements FontCollection {
       domDocument.fonts!.clear();
     }
   }
-
-  @override
-  Future<void> addPendingFonts() async {
-    return;
-  }
 }
 
 /// Manages a collection of fonts and ensures they are loaded.

--- a/lib/web_ui/lib/src/engine/text/font_collection.dart
+++ b/lib/web_ui/lib/src/engine/text/font_collection.dart
@@ -71,9 +71,7 @@ class HtmlFontCollection implements FontCollection {
             family!, 'url(${assetManager.getAssetUrl(asset)})', descriptors);
       }
     }
-
-    final List<DomFontFace?> loadedFonts = await Future.wait(_assetFontManager!._fontLoadingFutures);
-    _assetFontManager!._downloadedFonts.addAll(loadedFonts.whereType<DomFontFace>());
+    await _assetFontManager!.downloadAllFonts();
   }
 
   @override
@@ -94,8 +92,7 @@ class HtmlFontCollection implements FontCollection {
         'url($robotoTestFontUrl)', const <String, String>{});
     _testFontManager!.downloadAsset(robotoVariableFontFamily,
         'url($robotoVariableTestFontUrl)', const <String, String>{});
-    final List<DomFontFace?> loadedFonts = await Future.wait(_testFontManager!._fontLoadingFutures);
-    _testFontManager!._downloadedFonts.addAll(loadedFonts.whereType<DomFontFace>());
+    await _testFontManager!.downloadAllFonts();
   }
 
   @override
@@ -221,7 +218,7 @@ class FontManager {
   }
 
 
-  Future<void> fillDownloadedFonts() async {
+  Future<void> downloadAllFonts() async {
     final List<DomFontFace?> loadedFonts = await Future.wait(_fontLoadingFutures);
     _downloadedFonts.addAll(loadedFonts.whereType<DomFontFace>());
   }
@@ -264,7 +261,7 @@ class _PolyfillFontManager extends FontManager {
   final List<Future<void>> _completerFutures = <Future<void>>[];
 
   @override
-  Future<void> fillDownloadedFonts() async {
+  Future<void> downloadAllFonts() async {
     await Future.wait(_completerFutures);
   }
 

--- a/lib/web_ui/lib/src/engine/text/font_collection.dart
+++ b/lib/web_ui/lib/src/engine/text/font_collection.dart
@@ -197,7 +197,8 @@ class FontManager {
   ) {
     Future<DomFontFace?> fontFaceLoad(DomFontFace fontFace) async {
       try {
-        return fontFace.load();
+        final DomFontFace loadedFontFace = await fontFace.load();
+        return loadedFontFace;
       } catch (e) {
         printWarning('Error while trying to load font family "$family":\n$e');
         return null;

--- a/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
+++ b/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
@@ -1465,8 +1465,8 @@ void _textStyleTests() {
 
 void _paragraphTests() {
   setUpAll(() async {
-    CanvasKitRenderer.instance.fontCollection.debugRegisterTestFonts();
-    await CanvasKitRenderer.instance.fontCollection.ensureFontsLoaded();
+    await CanvasKitRenderer.instance.fontCollection.debugDownloadTestFonts();
+    CanvasKitRenderer.instance.fontCollection.registerDownloadedFonts();
   });
 
   // This test is just a kitchen sink that blasts CanvasKit with all paragraph

--- a/lib/web_ui/test/canvaskit/skia_font_collection_test.dart
+++ b/lib/web_ui/test/canvaskit/skia_font_collection_test.dart
@@ -35,12 +35,13 @@ void testMain() {
       warnings.clear();
     });
 
-    test('logs no warnings with the default mock asset manager', () {
+    test('logs no warnings with the default mock asset manager', () async {
       final SkiaFontCollection fontCollection = SkiaFontCollection();
       final WebOnlyMockAssetManager mockAssetManager =
           WebOnlyMockAssetManager();
-      expect(fontCollection.registerFonts(mockAssetManager), completes);
-      expect(fontCollection.ensureFontsLoaded(), completes);
+      await fontCollection.downloadAssetFonts(mockAssetManager);
+      fontCollection.registerDownloadedFonts();
+
       expect(warnings, isEmpty);
     });
 
@@ -61,8 +62,8 @@ void testMain() {
   ]
       ''';
       // It should complete without error, but emit a warning about BrokenFont.
-      await fontCollection.registerFonts(mockAssetManager);
-      await fontCollection.ensureFontsLoaded();
+      await fontCollection.downloadAssetFonts(mockAssetManager);
+      fontCollection.registerDownloadedFonts();
       expect(
         warnings,
         containsAllInOrder(
@@ -89,13 +90,13 @@ void testMain() {
 
       final ByteBuffer robotoData = (await (await httpFetch('/assets/fonts/Roboto-Regular.ttf')).arrayBuffer())! as ByteBuffer;
 
-      await fontCollection.registerFonts(mockAssetManager);
-      fontCollection.debugRegisterTestFonts();
-      await fontCollection.ensureFontsLoaded();
+      await fontCollection.downloadAssetFonts(mockAssetManager);
+      await fontCollection.debugDownloadTestFonts();
+      fontCollection.registerDownloadedFonts();
       expect(warnings, isEmpty);
 
       // Use `singleWhere` to make sure only one version of 'Ahem' is loaded.
-      final RegisteredFont ahem = fontCollection.debugDownloadedFonts!
+      final RegisteredFont ahem = fontCollection.debugRegisteredFonts!
         .singleWhere((RegisteredFont font) => font.family == 'Ahem');
 
       // Check that the contents of 'Ahem' is actually Roboto, because that's
@@ -111,18 +112,32 @@ void testMain() {
 
       final ByteBuffer ahemData = (await (await httpFetch('/assets/fonts/ahem.ttf')).arrayBuffer())! as ByteBuffer;
 
-      await fontCollection.registerFonts(mockAssetManager);
-      fontCollection.debugRegisterTestFonts();
-      await fontCollection.ensureFontsLoaded();
+      await fontCollection.downloadAssetFonts(mockAssetManager);
+      await fontCollection.debugDownloadTestFonts();
+      fontCollection.registerDownloadedFonts();
       expect(warnings, isEmpty);
 
       // Use `singleWhere` to make sure only one version of 'Ahem' is loaded.
-      final RegisteredFont ahem = fontCollection.debugDownloadedFonts!
+      final RegisteredFont ahem = fontCollection.debugRegisteredFonts!
         .singleWhere((RegisteredFont font) => font.family == 'Ahem');
 
       // Check that the contents of 'Ahem' is actually Roboto, because that's
       // what's specified in the manifest, and the manifest takes precedence.
       expect(ahem.bytes.length, ahemData.lengthInBytes);
+    });
+
+    test('download fonts separately from registering', () async {
+      final SkiaFontCollection fontCollection = SkiaFontCollection();
+
+      await fontCollection.debugDownloadTestFonts();
+      /// Fonts should have been downloaded, but not yet registered
+      expect(fontCollection.debugRegisteredFonts, isEmpty);
+
+      fontCollection.registerDownloadedFonts();
+      /// Fonts should now be registered and _registeredFonts should be filled
+      expect(fontCollection.debugRegisteredFonts, isNotEmpty);
+      expect(warnings, isEmpty);
+
     });
   });
 }

--- a/lib/web_ui/test/canvaskit/skia_font_collection_test.dart
+++ b/lib/web_ui/test/canvaskit/skia_font_collection_test.dart
@@ -137,7 +137,6 @@ void testMain() {
       /// Fonts should now be registered and _registeredFonts should be filled
       expect(fontCollection.debugRegisteredFonts, isNotEmpty);
       expect(warnings, isEmpty);
-
     });
   });
 }

--- a/lib/web_ui/test/engine/image_to_byte_data_test.dart
+++ b/lib/web_ui/test/engine/image_to_byte_data_test.dart
@@ -16,8 +16,8 @@ void main() {
 Future<void> testMain() async {
   setUpAll(() async {
     await webOnlyInitializePlatform();
-    renderer.fontCollection.debugRegisterTestFonts();
-    await renderer.fontCollection.ensureFontsLoaded();
+    await renderer.fontCollection.debugDownloadTestFonts();
+    renderer.fontCollection.registerDownloadedFonts();
   });
 
   Future<Image> createTestImageByColor(Color color) async {

--- a/lib/web_ui/test/html/canvas_clip_path_golden_test.dart
+++ b/lib/web_ui/test/html/canvas_clip_path_golden_test.dart
@@ -19,8 +19,8 @@ Future<void> testMain() async {
   setUpAll(() async {
     debugEmulateFlutterTesterEnvironment = true;
     await webOnlyInitializePlatform();
-    engine.renderer.fontCollection.debugRegisterTestFonts();
-    await engine.renderer.fontCollection.ensureFontsLoaded();
+    await engine.renderer.fontCollection.debugDownloadTestFonts();
+    engine.renderer.fontCollection.registerDownloadedFonts();
   });
 
   // Regression test for https://github.com/flutter/flutter/issues/48683

--- a/lib/web_ui/test/html/canvas_context_golden_test.dart
+++ b/lib/web_ui/test/html/canvas_context_golden_test.dart
@@ -22,8 +22,8 @@ Future<void> testMain() async {
   setUpAll(() async {
     debugEmulateFlutterTesterEnvironment = true;
     await webOnlyInitializePlatform();
-    engine.renderer.fontCollection.debugRegisterTestFonts();
-    await engine.renderer.fontCollection.ensureFontsLoaded();
+    await engine.renderer.fontCollection.debugDownloadTestFonts();
+    engine.renderer.fontCollection.registerDownloadedFonts();
   });
 
   // Regression test for https://github.com/flutter/flutter/issues/49429

--- a/lib/web_ui/test/html/canvas_reuse_golden_test.dart
+++ b/lib/web_ui/test/html/canvas_reuse_golden_test.dart
@@ -25,8 +25,8 @@ Future<void> testMain() async {
   setUp(() async {
     debugEmulateFlutterTesterEnvironment = true;
     await webOnlyInitializePlatform();
-    renderer.fontCollection.debugRegisterTestFonts();
-    await renderer.fontCollection.ensureFontsLoaded();
+    await renderer.fontCollection.debugDownloadTestFonts();
+    renderer.fontCollection.registerDownloadedFonts();
   });
 
   // Regression test for https://github.com/flutter/flutter/issues/51514

--- a/lib/web_ui/test/html/compositing/backdrop_filter_golden_test.dart
+++ b/lib/web_ui/test/html/compositing/backdrop_filter_golden_test.dart
@@ -16,8 +16,8 @@ void main() {
 Future<void> testMain() async {
   setUpAll(() async {
     await webOnlyInitializePlatform();
-    renderer.fontCollection.debugRegisterTestFonts();
-    await renderer.fontCollection.ensureFontsLoaded();
+    await renderer.fontCollection.debugDownloadTestFonts();
+    renderer.fontCollection.registerDownloadedFonts();
   });
 
   setUp(() async {

--- a/lib/web_ui/test/html/compositing/canvas_blend_golden_test.dart
+++ b/lib/web_ui/test/html/compositing/canvas_blend_golden_test.dart
@@ -20,8 +20,8 @@ Future<void> testMain() async {
   setUpAll(() async {
     debugEmulateFlutterTesterEnvironment = true;
     await webOnlyInitializePlatform();
-    renderer.fontCollection.debugRegisterTestFonts();
-    await renderer.fontCollection.ensureFontsLoaded();
+    await renderer.fontCollection.debugDownloadTestFonts();
+    renderer.fontCollection.registerDownloadedFonts();
   });
 
   test('Blend circles with difference and color', () async {

--- a/lib/web_ui/test/html/compositing/canvas_image_blend_mode_golden_test.dart
+++ b/lib/web_ui/test/html/compositing/canvas_image_blend_mode_golden_test.dart
@@ -20,8 +20,8 @@ Future<void> testMain() async {
   setUpAll(() async {
     debugEmulateFlutterTesterEnvironment = true;
     await webOnlyInitializePlatform();
-    renderer.fontCollection.debugRegisterTestFonts();
-    await renderer.fontCollection.ensureFontsLoaded();
+    await renderer.fontCollection.debugDownloadTestFonts();
+    renderer.fontCollection.registerDownloadedFonts();
   });
 
   const Color red = Color(0xFFFF0000);

--- a/lib/web_ui/test/html/compositing/canvas_mask_filter_golden_test.dart
+++ b/lib/web_ui/test/html/compositing/canvas_mask_filter_golden_test.dart
@@ -20,8 +20,8 @@ Future<void> testMain() async {
   setUpAll(() async {
     ui.debugEmulateFlutterTesterEnvironment = true;
     await ui.webOnlyInitializePlatform();
-    renderer.fontCollection.debugRegisterTestFonts();
-    await renderer.fontCollection.ensureFontsLoaded();
+    await renderer.fontCollection.debugDownloadTestFonts();
+    renderer.fontCollection.registerDownloadedFonts();
   });
 
   tearDown(() {

--- a/lib/web_ui/test/html/compositing/color_filter_golden_test.dart
+++ b/lib/web_ui/test/html/compositing/color_filter_golden_test.dart
@@ -20,8 +20,8 @@ void main() {
 Future<void> testMain() async {
   setUpAll(() async {
     await webOnlyInitializePlatform();
-    renderer.fontCollection.debugRegisterTestFonts();
-    await renderer.fontCollection.ensureFontsLoaded();
+    await renderer.fontCollection.debugDownloadTestFonts();
+    renderer.fontCollection.registerDownloadedFonts();
   });
 
   setUp(() async {

--- a/lib/web_ui/test/html/compositing/compositing_golden_test.dart
+++ b/lib/web_ui/test/html/compositing/compositing_golden_test.dart
@@ -21,8 +21,8 @@ void main() {
 Future<void> testMain() async {
   setUpAll(() async {
     await ui.webOnlyInitializePlatform();
-    renderer.fontCollection.debugRegisterTestFonts();
-    await renderer.fontCollection.ensureFontsLoaded();
+    await renderer.fontCollection.debugDownloadTestFonts();
+    renderer.fontCollection.registerDownloadedFonts();
   });
 
   setUp(() async {

--- a/lib/web_ui/test/html/compositing/dom_mask_filter_golden_test.dart
+++ b/lib/web_ui/test/html/compositing/dom_mask_filter_golden_test.dart
@@ -16,8 +16,8 @@ Future<void> testMain() async {
   setUp(() async {
     debugEmulateFlutterTesterEnvironment = true;
     await webOnlyInitializePlatform();
-    renderer.fontCollection.debugRegisterTestFonts();
-    await renderer.fontCollection.ensureFontsLoaded();
+    await renderer.fontCollection.debugDownloadTestFonts();
+    renderer.fontCollection.registerDownloadedFonts();
   });
 
   test('Should blur rectangles based on sigma.', () async {

--- a/lib/web_ui/test/html/drawing/canvas_draw_color_golden_test.dart
+++ b/lib/web_ui/test/html/drawing/canvas_draw_color_golden_test.dart
@@ -18,8 +18,8 @@ Future<void> testMain() async {
     debugShowClipLayers = true;
     SurfaceSceneBuilder.debugForgetFrameScene();
     await webOnlyInitializePlatform();
-    renderer.fontCollection.debugRegisterTestFonts();
-    await renderer.fontCollection.ensureFontsLoaded();
+    await renderer.fontCollection.debugDownloadTestFonts();
+    renderer.fontCollection.registerDownloadedFonts();
   });
 
   tearDown(() {

--- a/lib/web_ui/test/html/drawing/canvas_draw_picture_golden_test.dart
+++ b/lib/web_ui/test/html/drawing/canvas_draw_picture_golden_test.dart
@@ -21,8 +21,8 @@ Future<void> testMain() async {
   setUpAll(() async {
     debugShowClipLayers = true;
     await webOnlyInitializePlatform();
-    renderer.fontCollection.debugRegisterTestFonts();
-    await renderer.fontCollection.ensureFontsLoaded();
+    await renderer.fontCollection.debugDownloadTestFonts();
+    renderer.fontCollection.registerDownloadedFonts();
   });
 
   setUp(() async {

--- a/lib/web_ui/test/html/drawing/draw_vertices_golden_test.dart
+++ b/lib/web_ui/test/html/drawing/draw_vertices_golden_test.dart
@@ -25,8 +25,8 @@ Future<void> testMain() async {
   setUpAll(() async {
     debugEmulateFlutterTesterEnvironment = true;
     await webOnlyInitializePlatform();
-    renderer.fontCollection.debugRegisterTestFonts();
-    await renderer.fontCollection.ensureFontsLoaded();
+    await renderer.fontCollection.debugDownloadTestFonts();
+    renderer.fontCollection.registerDownloadedFonts();
   });
 
   setUp(() {

--- a/lib/web_ui/test/html/path_metrics_golden_test.dart
+++ b/lib/web_ui/test/html/path_metrics_golden_test.dart
@@ -25,7 +25,7 @@ Future<void> testMain() async {
   setUpAll(() async {
     debugEmulateFlutterTesterEnvironment = true;
     await webOnlyInitializePlatform();
-    renderer.fontCollection.debugDownloadTestFonts();
+    await renderer.fontCollection.debugDownloadTestFonts();
     renderer.fontCollection.registerDownloadedFonts();
   });
 

--- a/lib/web_ui/test/html/path_metrics_golden_test.dart
+++ b/lib/web_ui/test/html/path_metrics_golden_test.dart
@@ -25,8 +25,8 @@ Future<void> testMain() async {
   setUpAll(() async {
     debugEmulateFlutterTesterEnvironment = true;
     await webOnlyInitializePlatform();
-    renderer.fontCollection.debugRegisterTestFonts();
-    await renderer.fontCollection.ensureFontsLoaded();
+    renderer.fontCollection.debugDownloadTestFonts();
+    renderer.fontCollection.registerDownloadedFonts();
   });
 
   test('Should calculate tangent on line', () async {

--- a/lib/web_ui/test/html/path_transform_golden_test.dart
+++ b/lib/web_ui/test/html/path_transform_golden_test.dart
@@ -23,8 +23,8 @@ Future<void> testMain() async {
   setUpAll(() async {
     debugEmulateFlutterTesterEnvironment = true;
     await webOnlyInitializePlatform();
-    renderer.fontCollection.debugRegisterTestFonts();
-    await renderer.fontCollection.ensureFontsLoaded();
+    await renderer.fontCollection.debugDownloadTestFonts();
+    renderer.fontCollection.registerDownloadedFonts();
   });
 
   test('Should draw transformed line.', () async {

--- a/lib/web_ui/test/html/screenshot.dart
+++ b/lib/web_ui/test/html/screenshot.dart
@@ -77,7 +77,7 @@ Future<void> sceneScreenshot(SurfaceSceneBuilder sceneBuilder, String fileName,
 void setUpStableTestFonts() {
   setUpAll(() async {
     await ui.webOnlyInitializePlatform();
-    renderer.fontCollection.debugRegisterTestFonts();
-    await renderer.fontCollection.ensureFontsLoaded();
+    await renderer.fontCollection.debugDownloadTestFonts();
+    renderer.fontCollection.registerDownloadedFonts();
   });
 }

--- a/lib/web_ui/test/html/shaders/image_shader_golden_test.dart
+++ b/lib/web_ui/test/html/shaders/image_shader_golden_test.dart
@@ -27,8 +27,8 @@ Future<void> testMain() async {
   setUpAll(() async {
     debugEmulateFlutterTesterEnvironment = true;
     await webOnlyInitializePlatform();
-    renderer.fontCollection.debugRegisterTestFonts();
-    await renderer.fontCollection.ensureFontsLoaded();
+    await renderer.fontCollection.debugDownloadTestFonts();
+    renderer.fontCollection.registerDownloadedFonts();
   });
 
   void drawShapes(RecordingCanvas rc, SurfacePaint paint, Rect shaderRect) {

--- a/lib/web_ui/test/html/shaders/linear_gradient_golden_test.dart
+++ b/lib/web_ui/test/html/shaders/linear_gradient_golden_test.dart
@@ -21,8 +21,8 @@ Future<void> testMain() async {
   setUpAll(() async {
     debugEmulateFlutterTesterEnvironment = true;
     await webOnlyInitializePlatform();
-    renderer.fontCollection.debugRegisterTestFonts();
-    await renderer.fontCollection.ensureFontsLoaded();
+    await renderer.fontCollection.debugDownloadTestFonts();
+    renderer.fontCollection.registerDownloadedFonts();
   });
 
   test('Should draw linear gradient using rectangle.', () async {

--- a/lib/web_ui/test/html/shaders/radial_gradient_golden_test.dart
+++ b/lib/web_ui/test/html/shaders/radial_gradient_golden_test.dart
@@ -17,8 +17,8 @@ Future<void> testMain() async {
   setUpAll(() async {
     debugEmulateFlutterTesterEnvironment = true;
     await webOnlyInitializePlatform();
-    renderer.fontCollection.debugRegisterTestFonts();
-    await renderer.fontCollection.ensureFontsLoaded();
+    await renderer.fontCollection.debugDownloadTestFonts();
+    renderer.fontCollection.registerDownloadedFonts();
   });
 
   Future<void> testGradient(String fileName, Shader shader,

--- a/lib/web_ui/test/html/shaders/shader_mask_golden_test.dart
+++ b/lib/web_ui/test/html/shaders/shader_mask_golden_test.dart
@@ -41,8 +41,8 @@ Future<void> testMain() async {
       scene.remove();
     }
     initWebGl();
-    renderer.fontCollection.debugRegisterTestFonts();
-    await renderer.fontCollection.ensureFontsLoaded();
+    await renderer.fontCollection.debugDownloadTestFonts();
+    renderer.fontCollection.registerDownloadedFonts();
   });
 
   /// Should render the picture unmodified.

--- a/lib/web_ui/test/text/font_collection_test.dart
+++ b/lib/web_ui/test/text/font_collection_test.dart
@@ -31,7 +31,7 @@ void testMain() {
 
         fontManager.downloadAsset(
             testFontFamily, 'url($testFontUrl)', const <String, String>{});
-        await fontManager.fillDownloadedFonts();
+        await fontManager.downloadAllFonts();
         fontManager.registerDownloadedFonts();
         domDocument.fonts!
             .forEach(allowInterop((DomFontFace f, DomFontFace f2, DomFontFaceSet s) {
@@ -48,7 +48,7 @@ void testMain() {
 
         fontManager.downloadAsset(
             testFontFamily, 'url($testFontUrl)', const <String, String>{});
-        await fontManager.fillDownloadedFonts();
+        await fontManager.downloadAllFonts();
         fontManager.registerDownloadedFonts();
         domDocument.fonts!
             .forEach(allowInterop((DomFontFace f, DomFontFace f2, DomFontFaceSet s) {
@@ -67,7 +67,7 @@ void testMain() {
 
         fontManager.downloadAsset(
             testFontFamily, 'url($testFontUrl)', const <String, String>{});
-        await fontManager.fillDownloadedFonts();
+        await fontManager.downloadAllFonts();
         fontManager.registerDownloadedFonts();
         domDocument.fonts!
             .forEach(allowInterop((DomFontFace f, DomFontFace f2, DomFontFaceSet s) {
@@ -86,7 +86,7 @@ void testMain() {
 
         fontManager.downloadAsset(
             testFontFamily, 'url($testFontUrl)', const <String, String>{});
-        await fontManager.fillDownloadedFonts();
+        await fontManager.downloadAllFonts();
         fontManager.registerDownloadedFonts();
         domDocument.fonts!
             .forEach(allowInterop((DomFontFace f, DomFontFace f2, DomFontFaceSet s) {
@@ -111,7 +111,7 @@ void testMain() {
 
         fontManager.downloadAsset(
             testFontFamily, 'url($testFontUrl)', const <String, String>{});
-        await fontManager.fillDownloadedFonts();
+        await fontManager.downloadAllFonts();
         fontManager.registerDownloadedFonts();
         domDocument.fonts!
             .forEach(allowInterop((DomFontFace f, DomFontFace f2, DomFontFaceSet s) {
@@ -136,7 +136,7 @@ void testMain() {
 
         fontManager.downloadAsset(
             testFontFamily, 'url($testFontUrl)', const <String, String>{});
-        await fontManager.fillDownloadedFonts();
+        await fontManager.downloadAllFonts();
         fontManager.registerDownloadedFonts();
         domDocument.fonts!
             .forEach(allowInterop((DomFontFace f, DomFontFace f2, DomFontFaceSet s) {
@@ -162,7 +162,7 @@ void testMain() {
 
         fontManager.downloadAsset(
             testFontFamily, 'url($testFontUrl)', const <String, String>{});
-        await fontManager.fillDownloadedFonts();
+        await fontManager.downloadAllFonts();
         fontManager.registerDownloadedFonts();
         domDocument.fonts!
             .forEach(allowInterop((DomFontFace f, DomFontFace f2, DomFontFaceSet s) {

--- a/lib/web_ui/test/text/font_collection_test.dart
+++ b/lib/web_ui/test/text/font_collection_test.dart
@@ -31,7 +31,7 @@ void testMain() {
 
        fontManager.downloadAsset(
             testFontFamily, 'url($testFontUrl)', const <String, String>{});
-        await fontManager.testFillDownloadedFonts();
+        await fontManager.fillDownloadedFonts();
         fontManager.registerDownloadedFonts();
         domDocument.fonts!
             .forEach(allowInterop((DomFontFace f, DomFontFace f2, DomFontFaceSet s) {
@@ -48,7 +48,7 @@ void testMain() {
 
        fontManager.downloadAsset(
             testFontFamily, 'url($testFontUrl)', const <String, String>{});
-        await fontManager.testFillDownloadedFonts();
+        await fontManager.fillDownloadedFonts();
         fontManager.registerDownloadedFonts();
         domDocument.fonts!
             .forEach(allowInterop((DomFontFace f, DomFontFace f2, DomFontFaceSet s) {
@@ -67,7 +67,7 @@ void testMain() {
 
        fontManager.downloadAsset(
             testFontFamily, 'url($testFontUrl)', const <String, String>{});
-        await fontManager.testFillDownloadedFonts();
+        await fontManager.fillDownloadedFonts();
         fontManager.registerDownloadedFonts();
         domDocument.fonts!
             .forEach(allowInterop((DomFontFace f, DomFontFace f2, DomFontFaceSet s) {
@@ -86,7 +86,7 @@ void testMain() {
 
        fontManager.downloadAsset(
             testFontFamily, 'url($testFontUrl)', const <String, String>{});
-        await fontManager.testFillDownloadedFonts();
+        await fontManager.fillDownloadedFonts();
         fontManager.registerDownloadedFonts();
         domDocument.fonts!
             .forEach(allowInterop((DomFontFace f, DomFontFace f2, DomFontFaceSet s) {
@@ -111,7 +111,7 @@ void testMain() {
 
        fontManager.downloadAsset(
             testFontFamily, 'url($testFontUrl)', const <String, String>{});
-        await fontManager.testFillDownloadedFonts();
+        await fontManager.fillDownloadedFonts();
         fontManager.registerDownloadedFonts();
         domDocument.fonts!
             .forEach(allowInterop((DomFontFace f, DomFontFace f2, DomFontFaceSet s) {
@@ -136,7 +136,7 @@ void testMain() {
 
        fontManager.downloadAsset(
             testFontFamily, 'url($testFontUrl)', const <String, String>{});
-        await fontManager.testFillDownloadedFonts();
+        await fontManager.fillDownloadedFonts();
         fontManager.registerDownloadedFonts();
         domDocument.fonts!
             .forEach(allowInterop((DomFontFace f, DomFontFace f2, DomFontFaceSet s) {
@@ -162,7 +162,7 @@ void testMain() {
 
        fontManager.downloadAsset(
             testFontFamily, 'url($testFontUrl)', const <String, String>{});
-        await fontManager.testFillDownloadedFonts();
+        await fontManager.fillDownloadedFonts();
         fontManager.registerDownloadedFonts();
         domDocument.fonts!
             .forEach(allowInterop((DomFontFace f, DomFontFace f2, DomFontFaceSet s) {

--- a/lib/web_ui/test/text/font_collection_test.dart
+++ b/lib/web_ui/test/text/font_collection_test.dart
@@ -29,7 +29,7 @@ void testMain() {
         const String testFontFamily = 'Ahem';
         final List<String> fontFamilyList = <String>[];
 
-       fontManager.downloadAsset(
+        fontManager.downloadAsset(
             testFontFamily, 'url($testFontUrl)', const <String, String>{});
         await fontManager.fillDownloadedFonts();
         fontManager.registerDownloadedFonts();
@@ -46,7 +46,7 @@ void testMain() {
         const String testFontFamily = 'Ahem ahem ahem';
         final List<String> fontFamilyList = <String>[];
 
-       fontManager.downloadAsset(
+        fontManager.downloadAsset(
             testFontFamily, 'url($testFontUrl)', const <String, String>{});
         await fontManager.fillDownloadedFonts();
         fontManager.registerDownloadedFonts();
@@ -65,7 +65,7 @@ void testMain() {
         const String testFontFamily = 'AhEm';
         final List<String> fontFamilyList = <String>[];
 
-       fontManager.downloadAsset(
+        fontManager.downloadAsset(
             testFontFamily, 'url($testFontUrl)', const <String, String>{});
         await fontManager.fillDownloadedFonts();
         fontManager.registerDownloadedFonts();
@@ -84,7 +84,7 @@ void testMain() {
         const String testFontFamily = '/Ahem';
         final List<String> fontFamilyList = <String>[];
 
-       fontManager.downloadAsset(
+        fontManager.downloadAsset(
             testFontFamily, 'url($testFontUrl)', const <String, String>{});
         await fontManager.fillDownloadedFonts();
         fontManager.registerDownloadedFonts();
@@ -109,7 +109,7 @@ void testMain() {
         const String testFontFamily = 'Ahem!!ahem';
         final List<String> fontFamilyList = <String>[];
 
-       fontManager.downloadAsset(
+        fontManager.downloadAsset(
             testFontFamily, 'url($testFontUrl)', const <String, String>{});
         await fontManager.fillDownloadedFonts();
         fontManager.registerDownloadedFonts();
@@ -134,7 +134,7 @@ void testMain() {
         const String testFontFamily = 'Ahem ,ahem';
         final List<String> fontFamilyList = <String>[];
 
-       fontManager.downloadAsset(
+        fontManager.downloadAsset(
             testFontFamily, 'url($testFontUrl)', const <String, String>{});
         await fontManager.fillDownloadedFonts();
         fontManager.registerDownloadedFonts();
@@ -160,7 +160,7 @@ void testMain() {
         const String testFontFamily = 'Ahem 1998';
         final List<String> fontFamilyList = <String>[];
 
-       fontManager.downloadAsset(
+        fontManager.downloadAsset(
             testFontFamily, 'url($testFontUrl)', const <String, String>{});
         await fontManager.fillDownloadedFonts();
         fontManager.registerDownloadedFonts();

--- a/lib/web_ui/test/text/font_collection_test.dart
+++ b/lib/web_ui/test/text/font_collection_test.dart
@@ -29,9 +29,10 @@ void testMain() {
         const String testFontFamily = 'Ahem';
         final List<String> fontFamilyList = <String>[];
 
-        fontManager.registerAsset(
+       fontManager.downloadAsset(
             testFontFamily, 'url($testFontUrl)', const <String, String>{});
-        await fontManager.ensureFontsLoaded();
+        await fontManager.testFillDownloadedFonts();
+        fontManager.registerDownloadedFonts();
         domDocument.fonts!
             .forEach(allowInterop((DomFontFace f, DomFontFace f2, DomFontFaceSet s) {
           fontFamilyList.add(f.family!);
@@ -45,9 +46,10 @@ void testMain() {
         const String testFontFamily = 'Ahem ahem ahem';
         final List<String> fontFamilyList = <String>[];
 
-        fontManager.registerAsset(
+       fontManager.downloadAsset(
             testFontFamily, 'url($testFontUrl)', const <String, String>{});
-        await fontManager.ensureFontsLoaded();
+        await fontManager.testFillDownloadedFonts();
+        fontManager.registerDownloadedFonts();
         domDocument.fonts!
             .forEach(allowInterop((DomFontFace f, DomFontFace f2, DomFontFaceSet s) {
           fontFamilyList.add(f.family!);
@@ -63,9 +65,10 @@ void testMain() {
         const String testFontFamily = 'AhEm';
         final List<String> fontFamilyList = <String>[];
 
-        fontManager.registerAsset(
+       fontManager.downloadAsset(
             testFontFamily, 'url($testFontUrl)', const <String, String>{});
-        await fontManager.ensureFontsLoaded();
+        await fontManager.testFillDownloadedFonts();
+        fontManager.registerDownloadedFonts();
         domDocument.fonts!
             .forEach(allowInterop((DomFontFace f, DomFontFace f2, DomFontFaceSet s) {
           fontFamilyList.add(f.family!);
@@ -81,9 +84,10 @@ void testMain() {
         const String testFontFamily = '/Ahem';
         final List<String> fontFamilyList = <String>[];
 
-        fontManager.registerAsset(
+       fontManager.downloadAsset(
             testFontFamily, 'url($testFontUrl)', const <String, String>{});
-        await fontManager.ensureFontsLoaded();
+        await fontManager.testFillDownloadedFonts();
+        fontManager.registerDownloadedFonts();
         domDocument.fonts!
             .forEach(allowInterop((DomFontFace f, DomFontFace f2, DomFontFaceSet s) {
           fontFamilyList.add(f.family!);
@@ -105,9 +109,10 @@ void testMain() {
         const String testFontFamily = 'Ahem!!ahem';
         final List<String> fontFamilyList = <String>[];
 
-        fontManager.registerAsset(
+       fontManager.downloadAsset(
             testFontFamily, 'url($testFontUrl)', const <String, String>{});
-        await fontManager.ensureFontsLoaded();
+        await fontManager.testFillDownloadedFonts();
+        fontManager.registerDownloadedFonts();
         domDocument.fonts!
             .forEach(allowInterop((DomFontFace f, DomFontFace f2, DomFontFaceSet s) {
           fontFamilyList.add(f.family!);
@@ -129,9 +134,10 @@ void testMain() {
         const String testFontFamily = 'Ahem ,ahem';
         final List<String> fontFamilyList = <String>[];
 
-        fontManager.registerAsset(
+       fontManager.downloadAsset(
             testFontFamily, 'url($testFontUrl)', const <String, String>{});
-        await fontManager.ensureFontsLoaded();
+        await fontManager.testFillDownloadedFonts();
+        fontManager.registerDownloadedFonts();
         domDocument.fonts!
             .forEach(allowInterop((DomFontFace f, DomFontFace f2, DomFontFaceSet s) {
           fontFamilyList.add(f.family!);
@@ -154,9 +160,10 @@ void testMain() {
         const String testFontFamily = 'Ahem 1998';
         final List<String> fontFamilyList = <String>[];
 
-        fontManager.registerAsset(
+       fontManager.downloadAsset(
             testFontFamily, 'url($testFontUrl)', const <String, String>{});
-        await fontManager.ensureFontsLoaded();
+        await fontManager.testFillDownloadedFonts();
+        fontManager.registerDownloadedFonts();
         domDocument.fonts!
             .forEach(allowInterop((DomFontFace f, DomFontFace f2, DomFontFaceSet s) {
           fontFamilyList.add(f.family!);


### PR DESCRIPTION
refactored `FontCollection` for both canvaskit and html. 

With the refactor, it becomes possible to download fonts concurrently with wasm, resolving issue: https://github.com/flutter/flutter/issues/105929

### fontCollection refactor

Each font needs to be 1) downloaded and 2) registered before it can be used. 

Previously, this process was done in one function call: `registerFonts()`

Now, downloading fonts happens in two separate function calls:
1) `downloadAsetFonts(AssetManager assetmanager)` to download fonts
2) `registerDownloadedFonts()` to register fonts 

Breaking the previous `registerFonts()` into the two aforementioned steps allows the following functions to be called concurrently:
1) download fonts with `downloadAsetFonts(AssetManager assetmanager)`
2) download wasm with `canvaskit = await downloadCanvasKit()`

All affected tests were refactored as well. 

Before: 
![173461040-d1724d8b-4134-43f2-a523-daa95449ecc8](https://user-images.githubusercontent.com/50225138/196283464-60dee4a2-22df-4361-9e8e-d086455f432d.png)

After: 
<img width="1632" alt="Screen Shot 2022-10-17 at 1 59 14 PM" src="https://user-images.githubusercontent.com/50225138/196283646-fe109aa9-67df-4c36-847c-61c2a1c2aade.png">


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.