### PR TITLE
Make deadline of `NotifyIdle` configurable, allowing `flutter_smooth` to get 60FPS, even if GC needs to run for 14ms per 16.67ms

### DIFF
--- a/lib/ui/dart_ui.cc
+++ b/lib/ui/dart_ui.cc
@@ -95,6 +95,7 @@ typedef CanvasPath Path;
   V(PlatformConfigurationNativeApi::Render, 1)                        \
   V(PlatformConfigurationNativeApi::UpdateSemantics, 1)               \
   V(PlatformConfigurationNativeApi::SetNeedsReportTimings, 1)         \
+  V(PlatformConfigurationNativeApi::SetAfterFrameNotifyIdleExtra, 1)  \
   V(PlatformConfigurationNativeApi::SetIsolateDebugName, 1)           \
   V(PlatformConfigurationNativeApi::RequestDartPerformanceMode, 1)    \
   V(PlatformConfigurationNativeApi::GetPersistentIsolateData, 0)      \

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -523,6 +523,11 @@ class PlatformDispatcher {
   @FfiNative<Void Function(Bool)>('PlatformConfigurationNativeApi::SetNeedsReportTimings')
   external static void __nativeSetNeedsReportTimings(bool value);
 
+  void setAfterFrameNotifyIdle(Duration delta) => _setAfterFrameNotifyIdle(delta.inMicroseconds);
+
+  @FfiNative<Void Function(Int64)>('PlatformConfigurationNativeApi::SetAfterFrameNotifyIdleExtra')
+  external static void _setAfterFrameNotifyIdle(int delta);
+
   // Called from the engine, via hooks.dart
   void _reportTimings(List<int> timings) {
     assert(timings.length % FrameTiming._dataLength == 0);

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -523,10 +523,10 @@ class PlatformDispatcher {
   @FfiNative<Void Function(Bool)>('PlatformConfigurationNativeApi::SetNeedsReportTimings')
   external static void __nativeSetNeedsReportTimings(bool value);
 
-  void setAfterFrameNotifyIdle(Duration delta) => _setAfterFrameNotifyIdle(delta.inMicroseconds);
+  void setAfterFrameNotifyIdleExtra(Duration delta) => _setAfterFrameNotifyIdleExtra(delta.inMicroseconds);
 
   @FfiNative<Void Function(Int64)>('PlatformConfigurationNativeApi::SetAfterFrameNotifyIdleExtra')
-  external static void _setAfterFrameNotifyIdle(int delta);
+  external static void _setAfterFrameNotifyIdleExtra(int delta);
 
   // Called from the engine, via hooks.dart
   void _reportTimings(List<int> timings) {

--- a/lib/ui/window/platform_configuration.cc
+++ b/lib/ui/window/platform_configuration.cc
@@ -285,6 +285,15 @@ void PlatformConfigurationNativeApi::SetNeedsReportTimings(bool value) {
       ->SetNeedsReportTimings(value);
 }
 
+void PlatformConfigurationNativeApi::SetAfterFrameNotifyIdleExtra(
+    int64_t delta) {
+  UIDartState::ThrowIfUIOperationsProhibited();
+  UIDartState::Current()
+      ->platform_configuration()
+      ->client()
+      ->SetAfterFrameNotifyIdleExtra(fml::TimeDelta::FromMicroseconds(delta));
+}
+
 namespace {
 Dart_Handle HandlePlatformMessage(
     UIDartState* dart_state,

--- a/lib/ui/window/platform_configuration.h
+++ b/lib/ui/window/platform_configuration.h
@@ -150,6 +150,12 @@ class PlatformConfigurationClient {
   virtual void SetNeedsReportTimings(bool value) = 0;
 
   //--------------------------------------------------------------------------
+  /// @brief      When the system wants to NotifyIdle after frame ends,
+  ///             it will report that it plan to be idle not only until the
+  ///             next vsync, but also adding `delta` time.
+  virtual void SetAfterFrameNotifyIdleExtra(fml::TimeDelta delta) = 0;
+
+  //--------------------------------------------------------------------------
   /// @brief      The embedder can specify data that the isolate can request
   ///             synchronously on launch. This accessor fetches that data.
   ///
@@ -478,6 +484,8 @@ class PlatformConfigurationNativeApi {
   static void UpdateSemantics(SemanticsUpdate* update);
 
   static void SetNeedsReportTimings(bool value);
+
+  static void SetAfterFrameNotifyIdleExtra(int64_t delta);
 
   static Dart_Handle GetPersistentIsolateData();
 

--- a/lib/web_ui/lib/platform_dispatcher.dart
+++ b/lib/web_ui/lib/platform_dispatcher.dart
@@ -51,6 +51,9 @@ abstract class PlatformDispatcher {
   TimingsCallback? get onReportTimings;
   set onReportTimings(TimingsCallback? callback);
 
+  // no-op on web
+  void setAfterFrameNotifyIdleExtra(Duration delta) {}
+
   void sendPlatformMessage(
       String name,
       ByteData? data,

--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -321,6 +321,11 @@ void RuntimeController::SetNeedsReportTimings(bool value) {
 }
 
 // |PlatformConfigurationClient|
+void RuntimeController::SetAfterFrameNotifyIdleExtra(fml::TimeDelta delta) {
+  client_.SetAfterFrameNotifyIdleExtra(delta);
+}
+
+// |PlatformConfigurationClient|
 std::shared_ptr<const fml::Mapping>
 RuntimeController::GetPersistentIsolateData() {
   return persistent_isolate_data_;

--- a/runtime/runtime_controller.h
+++ b/runtime/runtime_controller.h
@@ -628,6 +628,9 @@ class RuntimeController : public PlatformConfigurationClient {
   void SetNeedsReportTimings(bool value) override;
 
   // |PlatformConfigurationClient|
+  void SetAfterFrameNotifyIdleExtra(fml::TimeDelta delta) override;
+
+  // |PlatformConfigurationClient|
   std::unique_ptr<std::vector<std::string>> ComputePlatformResolvedLocale(
       const std::vector<std::string>& supported_locale_data) override;
 

--- a/runtime/runtime_delegate.h
+++ b/runtime/runtime_delegate.h
@@ -44,6 +44,8 @@ class RuntimeDelegate {
 
   virtual void SetNeedsReportTimings(bool value) = 0;
 
+  virtual void SetAfterFrameNotifyIdleExtra(fml::TimeDelta delta) = 0;
+
   virtual std::unique_ptr<std::vector<std::string>>
   ComputePlatformResolvedLocale(
       const std::vector<std::string>& supported_locale_data) = 0;

--- a/shell/common/animator.cc
+++ b/shell/common/animator.cc
@@ -250,7 +250,7 @@ void Animator::AwaitVSync() {
         }
       });
   if (has_rendered_) {
-    delegate_.OnAnimatorNotifyIdle(dart_frame_deadline_ + TODO);
+    delegate_.OnAnimatorNotifyIdle(dart_frame_deadline_);
   }
 }
 

--- a/shell/common/animator.cc
+++ b/shell/common/animator.cc
@@ -250,7 +250,7 @@ void Animator::AwaitVSync() {
         }
       });
   if (has_rendered_) {
-    delegate_.OnAnimatorNotifyIdle(dart_frame_deadline_);
+    delegate_.OnAnimatorNotifyIdle(dart_frame_deadline_ + TODO);
   }
 }
 

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -486,6 +486,10 @@ void Engine::SetNeedsReportTimings(bool needs_reporting) {
   delegate_.SetNeedsReportTimings(needs_reporting);
 }
 
+void Engine::SetAfterFrameNotifyIdleExtra(fml::TimeDelta delta) {
+  delegate_.SetAfterFrameNotifyIdleExtra(delta);
+}
+
 FontCollection& Engine::GetFontCollection() {
   return *font_collection_;
 }

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -244,6 +244,12 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
     virtual void SetNeedsReportTimings(bool needs_reporting) = 0;
 
     //--------------------------------------------------------------------------
+    /// @brief      When the system wants to NotifyIdle after frame ends,
+    ///             it will report that it plan to be idle not only until the
+    ///             next vsync, but also adding `delta` time.
+    virtual void SetAfterFrameNotifyIdleExtra(fml::TimeDelta delta) = 0;
+
+    //--------------------------------------------------------------------------
     /// @brief      Directly invokes platform-specific APIs to compute the
     ///             locale the platform would have natively resolved to.
     ///
@@ -913,6 +919,8 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
       const override;
 
   void SetNeedsReportTimings(bool value) override;
+
+  void SetAfterFrameNotifyIdleExtra(fml::TimeDelta delta) override;
 
   bool HandleLifecyclePlatformMessage(PlatformMessage* message);
 

--- a/shell/common/engine_unittests.cc
+++ b/shell/common/engine_unittests.cc
@@ -31,6 +31,7 @@ class MockDelegate : public Engine::Delegate {
   MOCK_METHOD0(OnRootIsolateCreated, void());
   MOCK_METHOD2(UpdateIsolateDescription, void(const std::string, int64_t));
   MOCK_METHOD1(SetNeedsReportTimings, void(bool));
+  MOCK_METHOD1(SetAfterFrameNotifyIdleExtra, void(fml::TimeDelta));
   MOCK_METHOD1(ComputePlatformResolvedLocale,
                std::unique_ptr<std::vector<std::string>>(
                    const std::vector<std::string>&));
@@ -59,6 +60,7 @@ class MockRuntimeDelegate : public RuntimeDelegate {
   MOCK_METHOD0(OnRootIsolateCreated, void());
   MOCK_METHOD2(UpdateIsolateDescription, void(const std::string, int64_t));
   MOCK_METHOD1(SetNeedsReportTimings, void(bool));
+  MOCK_METHOD1(SetAfterFrameNotifyIdleExtra, void(fml::TimeDelta));
   MOCK_METHOD1(ComputePlatformResolvedLocale,
                std::unique_ptr<std::vector<std::string>>(
                    const std::vector<std::string>&));

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -1130,7 +1130,7 @@ void Shell::OnAnimatorNotifyIdle(fml::TimePoint deadline) {
   FML_DCHECK(task_runners_.GetUITaskRunner()->RunsTasksOnCurrentThread());
 
   if (engine_) {
-    engine_->NotifyIdle(deadline);
+    engine_->NotifyIdle(deadline + animator_notify_idle_extra_);
     volatile_path_tracker_->OnFrame();
   }
 }
@@ -1352,6 +1352,10 @@ void Shell::UpdateIsolateDescription(const std::string isolate_name,
 
 void Shell::SetNeedsReportTimings(bool value) {
   needs_report_timings_ = value;
+}
+
+void Shell::SetAfterFrameNotifyIdleExtra(fml::TimeDelta delta) {
+  animator_notify_idle_extra_ = delta;
 }
 
 // |Engine::Delegate|

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -451,6 +451,8 @@ class Shell final : public PlatformView::Delegate,
   // atomic.
   std::atomic<bool> needs_report_timings_{false};
 
+  std::atomic<fml::TimeDelta> animator_notify_idle_extra_{};
+
   // Whether there's a task scheduled to report the timings to Dart through
   // ui.Window.onReportTimings.
   bool frame_timings_report_scheduled_ = false;
@@ -627,6 +629,9 @@ class Shell final : public PlatformView::Delegate,
 
   // |Engine::Delegate|
   void SetNeedsReportTimings(bool value) override;
+
+  // |Engine::Delegate|
+  void SetAfterFrameNotifyIdleExtra(fml::TimeDelta delta) override;
 
   // |Engine::Delegate|
   std::unique_ptr<std::vector<std::string>> ComputePlatformResolvedLocale(


### PR DESCRIPTION
1. I will finish code details, refine code, add tests, make tests pass, etc, after a code review that thinks the *rough idea* is acceptable. It is because, from my past experience, reviews may request changing a lot. If the general idea is to be changed, all detailed implementation efforts are wasted :)
2. The PR has an already-working counterpart, and it produces ~60FPS smooth experimental results. The benchmark results and detailed analysis is in chapter https://cjycode.com/flutter_smooth/benchmark/. All the source code is in  https://github.com/fzyzcjy/engine/tree/flutter-smooth and https://github.com/fzyzcjy/flutter/tree/flutter-smooth.
3. Possibly useful as a context to this PR, there is a whole chapter discussing the internals - how flutter_smooth is implemented. (Link: https://cjycode.com/flutter_smooth/design/)

---


This PR is similar to https://github.com/flutter/engine/pull/36797. However, it addresses another portion of the GC-caused-jank problem.

Consider the following case: For each frame, UI thread needs to run for 16.00ms. Then:

**Without this PR and without flutter_smooth**: We know NotifyIdle will be called after the frame ends (more specifically, at AwaitVSync), and the "deadline" argument of NotifyIdle is set to "next_vsync_time - current_time". In other words, it is 16.67-16=0.67ms in our scenario. When DartVM receives this NotifyIdle call, it estimates how long a young GC needs, and realize it needs more than 0.67ms, so it do not call any young GC here. Therefore, garbage starts to accumulate. Finally, at one time, (young) GC must happen because the heap is full. At that time, Dart VM will stop the world for (e.g.) 10ms. Given that the UI thread needs 16.00ms to compute the content of one frame, the 10ms stop-the-world means it must miss at least one deadline. Thus, it janks whenever GC comes.

**With this PR and flutter_smooth**: No such problem at all. Let's consider one specific frame. Suppose the UI thread runs from 0.00-16.00ms and finished computing the content. Then, when calling NotifyIdle, I will deliberately set the "deadline" to be "next_vsync_time - current_time + 14ms". In other words, DartVM is now notified that, it has 14.67ms (instead of 0.67ms as before). Given this loose deadline, Dart VM happily executes a young GC (when it feels needed) using (e.g.) 10ms. Now we are at 26.00ms and the next frame begins. Given that we are using flutter_smooth, we can easily deliver an extra smooth frame when needed near 33.33ms, even though the plain-old frame needs 16.00ms to compute. Therefore, GC is triggered at proper time that does not cause any jank. And since NotifyIdle is triggered per 16.67ms with sufficient deadline (>14ms deadline duration), Dart VM will do GC at these period, so there will be no GC mentioned in the previous case which happens at random location causing UI to jank.

In conslusion, this PR allows `flutter_smooth` to get 60FPS, even if GC needs to run for (e.g.) 14ms per 16.67ms.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on ------ I deliberately do not add any tests yet, because the test are trivial and I want to listen to some feedbacks first (e.g. changing the PR). After feedbacks I will definitely add tests, no worries :)
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
