### PR TITLE
[engine v2 + codesign] add include paths for global generators

### DIFF
--- a/ci/builders/mac_host_engine.json
+++ b/ci/builders/mac_host_engine.json
@@ -269,9 +269,6 @@
                     "--strip",
                     "--zip"
                 ],
-                "include_paths": [
-                    "out/release/framework/FlutterMacOS.framework.zip"
-                ],
                 "script": "flutter/sky/tools/create_macos_framework.py"
             },
             {
@@ -285,9 +282,6 @@
                     "out/host_debug",
                     "--zip"
                 ],
-                "include_paths": [
-                    "out/debug/framework/FlutterMacOS.framework.zip"
-                ],
                 "script": "flutter/sky/tools/create_macos_framework.py"
             },
             {
@@ -300,9 +294,6 @@
                     "--x64-out-dir",
                     "out/host_profile",
                     "--zip"
-                ],
-                "include_paths": [
-                    "out/profile/framework/FlutterMacOS.framework.zip"
                 ],
                 "script": "flutter/sky/tools/create_macos_framework.py"
             },
@@ -325,9 +316,6 @@
                     "out/host_debug",
                     "--zip"
                 ],
-                "include_paths": [
-                    "out/debug/snapshot/gen_snapshot.zip"
-                ],
                 "script": "flutter/sky/tools/create_macos_gen_snapshots.py"
             },
             {
@@ -341,9 +329,6 @@
                     "out/host_profile",
                     "--zip"
                 ],
-                "include_paths": [
-                    "out/profile/snapshot/gen_snapshot.zip"
-                ],
                 "script": "flutter/sky/tools/create_macos_gen_snapshots.py"
             },
             {
@@ -356,9 +341,6 @@
                     "--x64-out-dir",
                     "out/host_release",
                     "--zip"
-                ],
-                "include_paths": [
-                    "out/release/snapshot/gen_snapshot.zip"
                 ],
                 "script": "flutter/sky/tools/create_macos_gen_snapshots.py"
             }

--- a/ci/builders/mac_host_engine.json
+++ b/ci/builders/mac_host_engine.json
@@ -349,31 +349,38 @@
     "archives": [
         {
             "source": "out/release/framework/FlutterMacOS.dSYM.zip",
-            "destination": "darwin-x64-release/FlutterMacOS.dSYM.zip"
+            "destination": "darwin-x64-release/FlutterMacOS.dSYM.zip",
+            "mac_codesign": false
         },
         {
             "source": "out/debug/framework/FlutterMacOS.framework.zip",
-            "destination": "darwin-x64/FlutterMacOS.framework.zip"
+            "destination": "darwin-x64/FlutterMacOS.framework.zip",
+            "mac_codesign": true
         },
         {
             "source": "out/profile/framework/FlutterMacOS.framework.zip",
-            "destination": "darwin-x64-profile/FlutterMacOS.framework.zip"
+            "destination": "darwin-x64-profile/FlutterMacOS.framework.zip",
+            "mac_codesign": true
         },
         {
             "source": "out/release/framework/FlutterMacOS.framework.zip",
-            "destination": "darwin-x64-release/FlutterMacOS.framework.zip"
+            "destination": "darwin-x64-release/FlutterMacOS.framework.zip",
+            "mac_codesign": true
         },
         {
             "source": "out/debug/snapshot/gen_snapshot.zip",
-            "destination": "darwin-x64/gen_snapshot.zip"
+            "destination": "darwin-x64/gen_snapshot.zip",
+            "mac_codesign": true
         },
         {
             "source": "out/profile/snapshot/gen_snapshot.zip",
-            "destination": "darwin-x64-profile/gen_snapshot.zip"
+            "destination": "darwin-x64-profile/gen_snapshot.zip",
+            "mac_codesign": true
         },
         {
             "source": "out/release/snapshot/gen_snapshot.zip",
-            "destination": "darwin-x64-release/gen_snapshot.zip"
+            "destination": "darwin-x64-release/gen_snapshot.zip",
+            "mac_codesign": true
         }
     ]
 }

--- a/ci/builders/mac_host_engine.json
+++ b/ci/builders/mac_host_engine.json
@@ -269,6 +269,9 @@
                     "--strip",
                     "--zip"
                 ],
+                "include_paths": [
+                    "out/release/framework/FlutterMacOS.framework.zip"
+                ],
                 "script": "flutter/sky/tools/create_macos_framework.py"
             },
             {
@@ -282,6 +285,9 @@
                     "out/host_debug",
                     "--zip"
                 ],
+                "include_paths": [
+                    "out/debug/framework/FlutterMacOS.framework.zip"
+                ],
                 "script": "flutter/sky/tools/create_macos_framework.py"
             },
             {
@@ -294,6 +300,9 @@
                     "--x64-out-dir",
                     "out/host_profile",
                     "--zip"
+                ],
+                "include_paths": [
+                    "out/profile/framework/FlutterMacOS.framework.zip"
                 ],
                 "script": "flutter/sky/tools/create_macos_framework.py"
             },
@@ -316,6 +325,9 @@
                     "out/host_debug",
                     "--zip"
                 ],
+                "include_paths": [
+                    "out/debug/snapshot/gen_snapshot.zip"
+                ],
                 "script": "flutter/sky/tools/create_macos_gen_snapshots.py"
             },
             {
@@ -329,6 +341,9 @@
                     "out/host_profile",
                     "--zip"
                 ],
+                "include_paths": [
+                    "out/profile/snapshot/gen_snapshot.zip"
+                ],
                 "script": "flutter/sky/tools/create_macos_gen_snapshots.py"
             },
             {
@@ -341,6 +356,9 @@
                     "--x64-out-dir",
                     "out/host_release",
                     "--zip"
+                ],
+                "include_paths": [
+                    "out/release/snapshot/gen_snapshot.zip"
                 ],
                 "script": "flutter/sky/tools/create_macos_gen_snapshots.py"
             }

--- a/ci/builders/mac_ios_engine.json
+++ b/ci/builders/mac_ios_engine.json
@@ -102,11 +102,13 @@
     "archives": [
         {
             "source": "out/debug/artifacts.zip",
-            "destination": "ios/artifacts.zip"
+            "destination": "ios/artifacts.zip",
+            "mac_codesign": true
         },
         {
             "source": "out/debug/ios-objcdoc.zip",
-            "destination": "ios-objcdoc.zip"
+            "destination": "ios-objcdoc.zip",
+            "mac_codesign": false
         }
     ]
 }

--- a/ci/builders/mac_ios_engine_profile.json
+++ b/ci/builders/mac_ios_engine_profile.json
@@ -91,7 +91,8 @@
     "archives": [
         {
             "source": "out/profile/artifacts.zip",
-            "destination": "ios-profile/artifacts.zip"
+            "destination": "ios-profile/artifacts.zip",
+            "mac_codesign": true
         }
     ]
 }

--- a/ci/builders/mac_ios_engine_release.json
+++ b/ci/builders/mac_ios_engine_release.json
@@ -124,19 +124,23 @@
     "archives": [
         {
             "source": "out/release/artifacts.zip",
-            "destination": "ios-release/artifacts.zip"
+            "destination": "ios-release/artifacts.zip",
+            "mac_codesign": true
         },
         {
             "source": "out/release/Flutter.dSYM.zip",
-            "destination": "ios-release/Flutter.dSYM.zip"
+            "destination": "ios-release/Flutter.dSYM.zip",
+            "mac_codesign": false
         },
         {
             "source": "out/release-nobitcode/artifacts.zip",
-            "destination": "ios-release-nobitcode/artifacts.zip"
+            "destination": "ios-release-nobitcode/artifacts.zip",
+            "mac_codesign": false
         },
         {
             "source": "out/release-nobitcode/Flutter.dSYM.zip",
-            "destination": "ios-release-nobitcode/Flutter.dSYM.zip"
+            "destination": "ios-release-nobitcode/Flutter.dSYM.zip",
+            "mac_codesign": false
         }
     ]
 }


### PR DESCRIPTION
Adding a code sign attribute for "archives" field in json, so that it can be later parsed and used in recipe.

Revisited recipe today and my understanding is that for global generators, the "archives" fields are what eventually uploaded to the google cloud bucket through the "destination" fields. Therefore I think a code sign luci build should be triggered only after the "upload to google cloud" process is complete (after the "archives" are processed), as opposed to run from the sub tasks in the generator process. umm Given the processing sequence of generators -> archives -> scheduling codesign jobs, I feel like we might have lost the distributed topology for generators? Or maybe it is acceptable.