### PR TITLE
[fuchsia] Fix debug symbol registration.

### DIFF
--- a/tools/fuchsia/devshell/build_and_copy_to_fuchsia.sh
+++ b/tools/fuchsia/devshell/build_and_copy_to_fuchsia.sh
@@ -109,7 +109,10 @@ engine-info "Copying the patched SDK (dart:ui, dart:zircon, dart:fuchsia) to Fuc
 cp -ra "${fuchsia_out_dir}"/flutter_runner_patched_sdk/* "$FUCHSIA_DIR"/prebuilt/third_party/flutter/"${fuchsia_cpu}"/release/aot/flutter_runner_patched_sdk/
 
 engine-info "Registering debug symbols..."
-"$ENGINE_DIR"/fuchsia/sdk/linux/tools/x64/symbol-index add "${fuchsia_out_dir}"/.build-id "${fuchsia_out_dir}"
+# .jiri_root/bin/ffx needs to run from $FUCHSIA_DIR.
+pushd $FUCHSIA_DIR
+"$FUCHSIA_DIR"/.jiri_root/bin/ffx debug symbol-index add "${fuchsia_out_dir}"/.build-id --build-dir "${fuchsia_out_dir}"
+popd  # $FUCHSIA_DIR
 
 if [[ "${runtime_mode}" == release ]]
 then

--- a/tools/fuchsia/devshell/run_integration_test.sh
+++ b/tools/fuchsia/devshell/run_integration_test.sh
@@ -164,10 +164,11 @@ do
   rm -r "${far_debug_dir}"
 done
 
-engine-info "Registering debug symbols..."
-"$ENGINE_DIR"/fuchsia/sdk/linux/tools/x64/symbol-index add "${fuchsia_out_dir}"/.build-id "${fuchsia_out_dir}"
-
+# .jiri_root/bin/ffx needs to run from $FUCHSIA_DIR.
 pushd $FUCHSIA_DIR
+
+engine-info "Registering debug symbols..."
+"$FUCHSIA_DIR"/.jiri_root/bin/ffx debug symbol-index add "${fuchsia_out_dir}"/.build-id --build-dir "${fuchsia_out_dir}"
 
 if [[ "$skip_fuchsia_build" -eq 0 ]]
 then

--- a/tools/fuchsia/devshell/run_unit_tests.sh
+++ b/tools/fuchsia/devshell/run_unit_tests.sh
@@ -80,7 +80,10 @@ engine-info "Building ${fuchsia_out_dir_name}..."
 ${ninja_cmd} -C "${fuchsia_out_dir}" fuchsia_tests
 
 engine-info "Registering debug symbols..."
-"${ENGINE_DIR}"/fuchsia/sdk/linux/tools/x64/symbol-index add "${fuchsia_out_dir}"/.build-id "${fuchsia_out_dir}"
+# .jiri_root/bin/ffx needs to run from $FUCHSIA_DIR.
+pushd $FUCHSIA_DIR
+"$FUCHSIA_DIR"/.jiri_root/bin/ffx debug symbol-index add "${fuchsia_out_dir}"/.build-id --build-dir "${fuchsia_out_dir}"
+popd  # $FUCHSIA_DIR
 
 test_packages="$(find ${fuchsia_out_dir} -name "${package_filter}")"
 

--- a/tools/fuchsia/gn-sdk/symbol_index.gni
+++ b/tools/fuchsia/gn-sdk/symbol_index.gni
@@ -4,6 +4,11 @@
 
 import("config/config.gni")
 
+# TODO(akbiggs): Delete this, symbol-index no longer exists, it has been
+# replaced with ffx debug symbol-index. I don't think this build rule is being
+# used because it would be failing if it was, so it can probably be removed
+# safely.
+#
 # Template for running the symbol-index tool for registering symbols with the symbolizer.
 #
 # Parameters


### PR DESCRIPTION
The standalone symbol-index tool was deprecated and replaced with an ffx tool.