### PR TITLE
[fuchsia][scenic] Fix invalid viewRef error in pointer injection.

### DIFF
--- a/shell/platform/fuchsia/flutter/flatland_platform_view.cc
+++ b/shell/platform/fuchsia/flutter/flatland_platform_view.cc
@@ -154,10 +154,11 @@ void FlatlandPlatformView::OnChildViewViewRef(
     fuchsia::ui::views::ViewRef view_ref) {
   FML_CHECK(child_view_info_.count(content_id) == 1);
 
-  focus_delegate_->OnChildViewViewRef(view_id, std::move(view_ref));
-
   fuchsia::ui::views::ViewRef view_ref_clone;
   fidl::Clone(view_ref, &view_ref_clone);
+
+  focus_delegate_->OnChildViewViewRef(view_id, std::move(view_ref));
+
   pointer_injector_delegate_->OnCreateView(view_id, std::move(view_ref_clone));
   OnChildViewConnected(content_id);
 }


### PR DESCRIPTION
This CL fixes the bug in pointer injector delegate where the viewRef is incorrectly cloned in the flatland platform view, causing an invalid viewRef to be passed in the Fidl request.

Test: flutter-embedder-test
