### PR TITLE
Added integration test for platform channels on windows.

### DIFF
--- a/shell/platform/windows/fixtures/main.dart
+++ b/shell/platform/windows/fixtures/main.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:io' as io;
+import 'dart:typed_data' show ByteData;
 import 'dart:ui' as ui;
 
 // Signals a waiting latch in the native test.
@@ -20,12 +21,23 @@ bool signalBoolReturn() native 'SignalBoolReturn';
 // Notify the native test that the first frame has been scheduled.
 void notifyFirstFrameScheduled() native 'NotifyFirstFrameScheduled';
 
-void main() {
+void main() {}
+
+@pragma('vm:entry-point')
+void hiPlatformChannels() {
+  ui.channelBuffers.setListener('hi',
+      (ByteData? data, ui.PlatformMessageResponseCallback callback) async {
+    ui.PlatformDispatcher.instance.sendPlatformMessage('hi', data,
+        (ByteData? reply) {
+      ui.PlatformDispatcher.instance
+          .sendPlatformMessage('hi', reply, (ByteData? reply) {});
+    });
+    callback(null);
+  });
 }
 
 @pragma('vm:entry-point')
-void customEntrypoint() {
-}
+void customEntrypoint() {}
 
 @pragma('vm:entry-point')
 void verifyNativeFunction() {
@@ -51,8 +63,8 @@ void readPlatformExecutable() {
 @pragma('vm:entry-point')
 void drawHelloWorld() {
   ui.PlatformDispatcher.instance.onBeginFrame = (Duration duration) {
-    final ui.ParagraphBuilder paragraphBuilder = ui.ParagraphBuilder(ui.ParagraphStyle())
-      ..addText('Hello world');
+    final ui.ParagraphBuilder paragraphBuilder =
+        ui.ParagraphBuilder(ui.ParagraphStyle())..addText('Hello world');
     final ui.Paragraph paragraph = paragraphBuilder.build();
 
     paragraph.layout(const ui.ParagraphConstraints(width: 800.0));


### PR DESCRIPTION
Adds an integration test for windows platform channels.  This is preliminary groundwork to implementing background platform channels for windows.

issue: https://github.com/flutter/flutter/issues/91635

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
