### PR TITLE
[fuchsia][scenic] Add input shield flag support in Flatland.

### DIFF
--- a/shell/platform/fuchsia/flutter/flatland_external_view_embedder.cc
+++ b/shell/platform/fuchsia/flutter/flatland_external_view_embedder.cc
@@ -36,6 +36,24 @@ FlatlandExternalViewEmbedder::FlatlandExternalViewEmbedder(
   root_transform_id_ = flatland_->NextTransformId();
   flatland_->flatland()->CreateTransform(root_transform_id_);
   flatland_->flatland()->SetRootTransform(root_transform_id_);
+
+  if (intercept_all_input) {
+    input_interceptor_transform_ = flatland_->NextTransformId();
+    flatland_->flatland()->CreateTransform(*input_interceptor_transform_);
+
+    flatland_->flatland()->AddChild(root_transform_id_,
+                                    *input_interceptor_transform_);
+    child_transforms_.emplace_back(*input_interceptor_transform_);
+
+    // Attach full-screen hit testing shield. Note that since the hit-region
+    // may be transformed (translated, rotated), we do not want to set
+    // width/height to FLT_MAX. This will cause a numeric overflow.
+    flatland_->flatland()->SetHitRegions(
+        *input_interceptor_transform_,
+        {{{0, 0, kMaxHitRegionSize, kMaxHitRegionSize},
+          fuchsia::ui::composition::HitTestInteraction::
+              SEMANTICALLY_INVISIBLE}});
+  }
 }
 
 FlatlandExternalViewEmbedder::~FlatlandExternalViewEmbedder() = default;
@@ -335,6 +353,18 @@ void FlatlandExternalViewEmbedder::SubmitFrame(
 
       // Reset for the next pass:
       flatland_layer_index++;
+    }
+
+    // TODO(fxbug.dev/104956): Setting per-layer overlay hit region for Flatland
+    // external view embedder should match with what is being done in GFX
+    // external view embedder.
+    // Set up the input interceptor at the top of the
+    // scene, if applicable.  It will capture all input, and any unwanted input
+    // will be reinjected into embedded views.
+    if (input_interceptor_transform_.has_value()) {
+      flatland_->flatland()->AddChild(root_transform_id_,
+                                      *input_interceptor_transform_);
+      child_transforms_.emplace_back(*input_interceptor_transform_);
     }
   }
 

--- a/shell/platform/fuchsia/flutter/flatland_external_view_embedder.h
+++ b/shell/platform/fuchsia/flutter/flatland_external_view_embedder.h
@@ -192,6 +192,11 @@ class FlatlandExternalViewEmbedder final
   SkISize frame_size_ = SkISize::Make(0, 0);
   float frame_dpr_ = 1.f;
 
+  // TransformId for the input interceptor node when input shield is turned on,
+  // std::nullptr otherwise.
+  std::optional<fuchsia::ui::composition::TransformId>
+      input_interceptor_transform_;
+
   FML_DISALLOW_COPY_AND_ASSIGN(FlatlandExternalViewEmbedder);
 };
 


### PR DESCRIPTION
This CL adds support for "intercept_all_input" flag in flutter_runner_config for flatland.

Test: This code path will be tested once the flatland config is enabled for flutter embedder tests. This patch is a prereq for the test to roll.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
