### PR TITLE
Prevent stack corruption when using C++ `EventChannel`

### DIFF
--- a/shell/platform/common/client_wrapper/event_channel_unittests.cc
+++ b/shell/platform/common/client_wrapper/event_channel_unittests.cc
@@ -226,8 +226,8 @@ TEST(EventChannelTest, ReRegistration) {
   EXPECT_EQ(on_listen_called, true);
 }
 
-// Test that the handler's lifetime can exceed its event channel.
-TEST(EventChannelTest, HandlerCanOutliveEventChannel) {
+// Test that the handler is called even if the event channel is destroyed.
+TEST(EventChannelTest, HandlerOutlivesEventChannel) {
   TestBinaryMessenger messenger;
   const std::string channel_name("some_channel");
   const StandardMethodCodec& codec = StandardMethodCodec::GetInstance();

--- a/shell/platform/common/client_wrapper/event_channel_unittests.cc
+++ b/shell/platform/common/client_wrapper/event_channel_unittests.cc
@@ -251,7 +251,10 @@ TEST(EventChannelTest, HandlerOutlivesEventChannel) {
     channel.SetStreamHandler(std::move(handler));
   }
 
-  // The event channel is now destroyed.
+  // The event channel was destroyed but the handler should still be alive.
+  EXPECT_EQ(messenger.last_message_handler_channel(), channel_name);
+  EXPECT_NE(messenger.last_message_handler(), nullptr);
+
   // Send test listen message.
   MethodCall<> call_listen("listen", nullptr);
   auto message = codec.EncodeMethodCall(call_listen);

--- a/shell/platform/common/client_wrapper/event_channel_unittests.cc
+++ b/shell/platform/common/client_wrapper/event_channel_unittests.cc
@@ -33,7 +33,7 @@ class TestBinaryMessenger : public BinaryMessenger {
     return last_message_handler_channel_;
   }
 
-  BinaryMessageHandler last_message_handler() { return last_message_handler_; }
+  BinaryMessageHandler& last_message_handler() { return last_message_handler_; }
 
  private:
   std::string last_message_handler_channel_;
@@ -64,7 +64,7 @@ TEST(EventChannelTest, Registration) {
   EXPECT_EQ(messenger.last_message_handler_channel(), channel_name);
   EXPECT_NE(messenger.last_message_handler(), nullptr);
 
-  // Send dummy listen message.
+  // Send test listen message.
   MethodCall<> call("listen", nullptr);
   auto message = codec.EncodeMethodCall(call);
   messenger.last_message_handler()(
@@ -121,7 +121,7 @@ TEST(EventChannelTest, Cancel) {
   EXPECT_EQ(messenger.last_message_handler_channel(), channel_name);
   EXPECT_NE(messenger.last_message_handler(), nullptr);
 
-  // Send dummy listen message.
+  // Send test listen message.
   MethodCall<> call_listen("listen", nullptr);
   auto message = codec.EncodeMethodCall(call_listen);
   messenger.last_message_handler()(
@@ -129,7 +129,7 @@ TEST(EventChannelTest, Cancel) {
       [](const uint8_t* reply, const size_t reply_size) {});
   EXPECT_EQ(on_listen_called, true);
 
-  // Send dummy cancel message.
+  // Send test cancel message.
   MethodCall<> call_cancel("cancel", nullptr);
   message = codec.EncodeMethodCall(call_cancel);
   messenger.last_message_handler()(
@@ -165,7 +165,7 @@ TEST(EventChannelTest, ListenNotCancel) {
   EXPECT_EQ(messenger.last_message_handler_channel(), channel_name);
   EXPECT_NE(messenger.last_message_handler(), nullptr);
 
-  // Send dummy listen message.
+  // Send test listen message.
   MethodCall<> call_listen("listen", nullptr);
   auto message = codec.EncodeMethodCall(call_listen);
   messenger.last_message_handler()(
@@ -205,7 +205,7 @@ TEST(EventChannelTest, ReRegistration) {
   EXPECT_EQ(messenger.last_message_handler_channel(), channel_name);
   EXPECT_NE(messenger.last_message_handler(), nullptr);
 
-  // Send dummy listen message.
+  // Send test listen message.
   MethodCall<> call("listen", nullptr);
   auto message = codec.EncodeMethodCall(call);
   messenger.last_message_handler()(
@@ -213,7 +213,7 @@ TEST(EventChannelTest, ReRegistration) {
       [](const uint8_t* reply, const size_t reply_size) {});
   EXPECT_EQ(on_listen_called, true);
 
-  // Send second dummy message to test StreamHandler's OnCancel
+  // Send second test message to test StreamHandler's OnCancel
   // method is called before OnListen method is called.
   on_listen_called = false;
   message = codec.EncodeMethodCall(call);
@@ -224,6 +224,49 @@ TEST(EventChannelTest, ReRegistration) {
   // Check results.
   EXPECT_EQ(on_cancel_called, true);
   EXPECT_EQ(on_listen_called, true);
+}
+
+// Test that the handler's lifetime can exceed its event channel.
+TEST(EventChannelTest, HandlerCanOutliveEventChannel) {
+  TestBinaryMessenger messenger;
+  const std::string channel_name("some_channel");
+  const StandardMethodCodec& codec = StandardMethodCodec::GetInstance();
+
+  bool on_listen_called = false;
+  bool on_cancel_called = false;
+  {
+    EventChannel channel(&messenger, channel_name, &codec);
+    auto handler = std::make_unique<StreamHandlerFunctions<>>(
+        [&on_listen_called](const EncodableValue* arguments,
+                            std::unique_ptr<EventSink<>>&& events)
+            -> std::unique_ptr<StreamHandlerError<>> {
+          on_listen_called = true;
+          return nullptr;
+        },
+        [&on_cancel_called](const EncodableValue* arguments)
+            -> std::unique_ptr<StreamHandlerError<>> {
+          on_cancel_called = true;
+          return nullptr;
+        });
+    channel.SetStreamHandler(std::move(handler));
+  }
+
+  // The event channel is now destroyed.
+  // Send test listen message.
+  MethodCall<> call_listen("listen", nullptr);
+  auto message = codec.EncodeMethodCall(call_listen);
+  messenger.last_message_handler()(
+      message->data(), message->size(),
+      [](const uint8_t* reply, const size_t reply_size) {});
+  EXPECT_EQ(on_listen_called, true);
+
+  // Send test cancel message.
+  MethodCall<> call_cancel("cancel", nullptr);
+  message = codec.EncodeMethodCall(call_cancel);
+  messenger.last_message_handler()(
+      message->data(), message->size(),
+      [](const uint8_t* reply, const size_t reply_size) {});
+  EXPECT_EQ(on_cancel_called, true);
 }
 
 }  // namespace flutter

--- a/shell/platform/common/client_wrapper/event_channel_unittests.cc
+++ b/shell/platform/common/client_wrapper/event_channel_unittests.cc
@@ -33,7 +33,9 @@ class TestBinaryMessenger : public BinaryMessenger {
     return last_message_handler_channel_;
   }
 
-  BinaryMessageHandler& last_message_handler() { return last_message_handler_; }
+  const BinaryMessageHandler& last_message_handler() {
+    return last_message_handler_;
+  }
 
  private:
   std::string last_message_handler_channel_;

--- a/shell/platform/common/client_wrapper/include/flutter/event_channel.h
+++ b/shell/platform/common/client_wrapper/include/flutter/event_channel.h
@@ -47,6 +47,10 @@ class EventChannel {
   // Registers a stream handler on this channel.
   // If no handler has been registered, any incoming stream setup requests will
   // be handled silently by providing an empty stream.
+  //
+  // Note that the EventChannel does not own the handler and will not
+  // unregister it on destruction. The caller is responsible for unregistering
+  // the handler if it should no longer be called.
   void SetStreamHandler(std::unique_ptr<StreamHandler<T>> handler) {
     if (!handler) {
       messenger_->SetMessageHandler(name_, nullptr);

--- a/shell/platform/common/client_wrapper/include/flutter/event_channel.h
+++ b/shell/platform/common/client_wrapper/include/flutter/event_channel.h
@@ -64,70 +64,75 @@ class EventChannel {
     const MethodCodec<T>* codec = codec_;
     const std::string channel_name = name_;
     const BinaryMessenger* messenger = messenger_;
-    std::shared_ptr<bool> is_listening = std::make_shared<bool>(false);
-    BinaryMessageHandler binary_handler = [shared_handler, codec, channel_name,
-                                           messenger, is_listening](
-                                              const uint8_t* message,
-                                              const size_t message_size,
-                                              BinaryReply reply) {
-      constexpr char kOnListenMethod[] = "listen";
-      constexpr char kOnCancelMethod[] = "cancel";
+    BinaryMessageHandler binary_handler =
+        [shared_handler, codec, channel_name, messenger,
+         // Mutable state to track the handler's listening status.
+         is_listening = bool(false)](const uint8_t* message,
+                                     const size_t message_size,
+                                     BinaryReply reply) mutable {
+          constexpr char kOnListenMethod[] = "listen";
+          constexpr char kOnCancelMethod[] = "cancel";
 
-      std::unique_ptr<MethodCall<T>> method_call =
-          codec->DecodeMethodCall(message, message_size);
-      if (!method_call) {
-        std::cerr << "Unable to construct method call from message on channel: "
-                  << channel_name << std::endl;
-        reply(nullptr, 0);
-        return;
-      }
-
-      const std::string& method = method_call->method_name();
-      if (method.compare(kOnListenMethod) == 0) {
-        if (*is_listening) {
-          std::unique_ptr<StreamHandlerError<T>> error =
-              shared_handler->OnCancel(nullptr);
-          if (error) {
-            std::cerr << "Failed to cancel existing stream: "
-                      << (error->error_code) << ", " << (error->error_message)
-                      << ", " << (error->error_details);
+          std::unique_ptr<MethodCall<T>> method_call =
+              codec->DecodeMethodCall(message, message_size);
+          if (!method_call) {
+            std::cerr
+                << "Unable to construct method call from message on channel: "
+                << channel_name << std::endl;
+            reply(nullptr, 0);
+            return;
           }
-        }
-        *is_listening = true;
 
-        std::unique_ptr<std::vector<uint8_t>> result;
-        auto sink = std::make_unique<EventSinkImplementation>(
-            messenger, channel_name, codec);
-        std::unique_ptr<StreamHandlerError<T>> error =
-            shared_handler->OnListen(method_call->arguments(), std::move(sink));
-        if (error) {
-          result = codec->EncodeErrorEnvelope(
-              error->error_code, error->error_message, error->error_details);
-        } else {
-          result = codec->EncodeSuccessEnvelope();
-        }
-        reply(result->data(), result->size());
-      } else if (method.compare(kOnCancelMethod) == 0) {
-        std::unique_ptr<std::vector<uint8_t>> result;
-        if (*is_listening) {
-          std::unique_ptr<StreamHandlerError<T>> error =
-              shared_handler->OnCancel(method_call->arguments());
-          if (error) {
-            result = codec->EncodeErrorEnvelope(
-                error->error_code, error->error_message, error->error_details);
+          const std::string& method = method_call->method_name();
+          if (method.compare(kOnListenMethod) == 0) {
+            if (is_listening) {
+              std::unique_ptr<StreamHandlerError<T>> error =
+                  shared_handler->OnCancel(nullptr);
+              if (error) {
+                std::cerr << "Failed to cancel existing stream: "
+                          << (error->error_code) << ", "
+                          << (error->error_message) << ", "
+                          << (error->error_details);
+              }
+            }
+            is_listening = true;
+
+            std::unique_ptr<std::vector<uint8_t>> result;
+            auto sink = std::make_unique<EventSinkImplementation>(
+                messenger, channel_name, codec);
+            std::unique_ptr<StreamHandlerError<T>> error =
+                shared_handler->OnListen(method_call->arguments(),
+                                         std::move(sink));
+            if (error) {
+              result = codec->EncodeErrorEnvelope(error->error_code,
+                                                  error->error_message,
+                                                  error->error_details);
+            } else {
+              result = codec->EncodeSuccessEnvelope();
+            }
+            reply(result->data(), result->size());
+          } else if (method.compare(kOnCancelMethod) == 0) {
+            std::unique_ptr<std::vector<uint8_t>> result;
+            if (is_listening) {
+              std::unique_ptr<StreamHandlerError<T>> error =
+                  shared_handler->OnCancel(method_call->arguments());
+              if (error) {
+                result = codec->EncodeErrorEnvelope(error->error_code,
+                                                    error->error_message,
+                                                    error->error_details);
+              } else {
+                result = codec->EncodeSuccessEnvelope();
+              }
+              is_listening = false;
+            } else {
+              result = codec->EncodeErrorEnvelope(
+                  "error", "No active stream to cancel", nullptr);
+            }
+            reply(result->data(), result->size());
           } else {
-            result = codec->EncodeSuccessEnvelope();
+            reply(nullptr, 0);
           }
-          *is_listening = false;
-        } else {
-          result = codec->EncodeErrorEnvelope(
-              "error", "No active stream to cancel", nullptr);
-        }
-        reply(result->data(), result->size());
-      } else {
-        reply(nullptr, 0);
-      }
-    };
+        };
     messenger_->SetMessageHandler(name_, std::move(binary_handler));
   }
 


### PR DESCRIPTION
## Background

Updating the engine to Visual Studio 2019 was reverted as it [broke the framework tree](https://ci.chromium.org/ui/p/flutter/builders/prod/Windows%20platform_channel_sample_test_windows/1804/overview). The root cause is that the `EventChannel`'s handler [stores](https://github.com/flutter/engine/blob/7d18d7007affdb9e6063076f4616bbaa124ad6b5/shell/platform/common/client_wrapper/include/flutter/event_channel.h#L168) and [mutates](https://github.com/flutter/engine/blob/7d18d7007affdb9e6063076f4616bbaa124ad6b5/shell/platform/common/client_wrapper/include/flutter/event_channel.h#L92) data on the `EventChannel` itself. This is problematic as the `EventChannel`'s and the handler's lifetimes are decoupled (the `EventChannel` does not own its handler). If the `EventChannel` is destroyed, the handler reads/mutates deallocated memory.  See this comment for more info: https://github.com/flutter/flutter/pull/113135#issuecomment-1272208785

This change decouples the lifetimes of the `EventChannel` and its handler by making the handler own its own state.

Addresses https://github.com/flutter/flutter/issues/113728

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
