### PR TITLE
Only run clang-tidy warning checks reported as errors

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,29 +7,15 @@ clang-diagnostic-*,\
 google-*,\
 modernize-use-default-member-init,\
 readability-identifier-naming,\
+-google-build-using-namespace,\
+-google-default-arguments,\
 -google-objc-global-variable-declaration,\
 -google-objc-avoid-throwing-exception,\
+-google-readability-casting,\
 -clang-analyzer-nullability.NullPassedToNonnull,\
 -clang-analyzer-nullability.NullablePassedToNonnull,\
 -clang-analyzer-nullability.NullReturnedFromNonnull,\
 -clang-analyzer-nullability.NullableReturnedFromNonnull,\
-performance-move-const-arg,\
-performance-unnecessary-value-param"
-
-# Only warnings treated as errors are reported
-# in the "ci/lint.sh" script and pre-push git hook.
-# Add checks when all warnings are fixed
-# to prevent new warnings being introduced.
-# https://github.com/flutter/flutter/issues/93279
-# Note: There are platform specific warnings as errors in
-# //ci/lint.sh
-WarningsAsErrors: "bugprone-use-after-move,\
-clang-analyzer-*,\
-readability-identifier-naming,\
-clang-diagnostic-*,\
-google-objc-*,\
-google-explicit-constructor,\
-google-readability-avoid-underscore-in-googletest-name,\
 performance-move-const-arg,\
 performance-unnecessary-value-param"
 

--- a/tools/clang_tidy/lib/src/command.dart
+++ b/tools/clang_tidy/lib/src/command.dart
@@ -134,8 +134,7 @@ class Command {
   WorkerJob createLintJob(Options options) {
     final List<String> args = <String>[
       filePath,
-      if (options.warningsAsErrors != null)
-        '--warnings-as-errors=${options.warningsAsErrors}',
+      '--warnings-as-errors=${options.warningsAsErrors ?? '*'}',
       if (options.checks != null)
         options.checks!,
       if (options.fix) ...<String>[

--- a/tools/clang_tidy/test/clang_tidy_test.dart
+++ b/tools/clang_tidy/test/clang_tidy_test.dart
@@ -379,19 +379,21 @@ Future<int> main(List<String> args) async {
     final WorkerJob jobNoFix = command.createLintJob(noFixOptions);
     expect(jobNoFix.command[0], endsWith('../../buildtools/mac-x64/clang/bin/clang-tidy'));
     expect(jobNoFix.command[1], endsWith(filePath.replaceAll('/', io.Platform.pathSeparator)));
-    expect(jobNoFix.command[2], '--');
-    expect(jobNoFix.command[3], '');
-    expect(jobNoFix.command[4], endsWith(filePath));
+    expect(jobNoFix.command[2], '--warnings-as-errors=*');
+    expect(jobNoFix.command[3], '--');
+    expect(jobNoFix.command[4], '');
+    expect(jobNoFix.command[5], endsWith(filePath));
 
     final Options fixOptions = Options(buildCommandsPath: io.File('.'), fix: true);
     final WorkerJob jobWithFix = command.createLintJob(fixOptions);
     expect(jobWithFix.command[0], endsWith('../../buildtools/mac-x64/clang/bin/clang-tidy'));
     expect(jobWithFix.command[1], endsWith(filePath.replaceAll('/', io.Platform.pathSeparator)));
-    expect(jobWithFix.command[2], '--fix');
-    expect(jobWithFix.command[3], '--format-style=file');
-    expect(jobWithFix.command[4], '--');
-    expect(jobWithFix.command[5], '');
-    expect(jobWithFix.command[6], endsWith(filePath));
+    expect(jobWithFix.command[2], '--warnings-as-errors=*');
+    expect(jobWithFix.command[3], '--fix');
+    expect(jobWithFix.command[4], '--format-style=file');
+    expect(jobWithFix.command[5], '--');
+    expect(jobWithFix.command[6], '');
+    expect(jobWithFix.command[7], endsWith(filePath));
   });
 
   test('Command getLintAction flags third_party files', () async {


### PR DESCRIPTION
`lint.sh` was running `clang-tidy` but only failing on the warnings explicitly treated as errors.  That means it was running more checks than it was reporting, but not giving any additional information.

Treat all clang-tidy warnings as errors.  This will also prevent checks being added that aren't _really_ being reported. 

Remove `performance-move-const-arg` and `performance-unnecessary-value-param` checks because they produce errors that were never surfaced and would need to be fixed before these checks are re-added.

It looks like this improved `Mac Host clang-tidy` time, but the rest are about the same.

- [Linux Android clang-tidy](https://ci.chromium.org/p/flutter/builders/try/Linux%20Android%20clang-tidy)
- [Linux Host clang-tidy](https://ci.chromium.org/p/flutter/builders/try/Linux%20Host%20clang-tidy)
- [Mac iOS clang-tidy](https://ci.chromium.org/p/flutter/builders/try/Mac%20iOS%20clang-tidy)
- [Mac Host clang-tidy](https://ci.chromium.org/p/flutter/builders/try/Mac%20Host%20clang-tidy)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
