### PR TITLE
Only install Xcode on Mac builders that use it

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -24,7 +24,6 @@ platform_properties:
       ios_debug: "false"
       ios_profile: "false"
       ios_release: "false"
-      no_bitcode: "false"
       # CIPD flutter_internal/java/openjdk/$platform
       dependencies: >-
         [
@@ -47,7 +46,6 @@ platform_properties:
       ios_debug: "false"
       ios_profile: "false"
       ios_release: "false"
-      no_bitcode: "false"
       # CIPD flutter_internal/java/openjdk/$platform
       dependencies: >-
         [
@@ -56,7 +54,6 @@ platform_properties:
       device_type: none
       cpu: x86
       os: Mac-12
-      xcode: 14a5294e # xcode 14.0 beta 5
   windows:
     properties:
       build_host: "false"
@@ -70,7 +67,6 @@ platform_properties:
       ios_debug: "false"
       ios_profile: "false"
       ios_release: "false"
-      no_bitcode: "false"
       # CIPD flutter_internal/java/openjdk/$platform
       dependencies: >-
         [
@@ -336,7 +332,6 @@ targets:
       android_sdk_license: \n24333f8a63b6825ea9c5514f83c2829b004d1fee
       android_sdk_preview_license: \n84831b9409646a918e30573bab4c9c91346d8abd
       build_android_aot: "true"
-      jazzy_version: "0.14.1"
     timeout: 60
 
   - name: Mac Host Engine
@@ -346,7 +341,7 @@ targets:
         {"download_emsdk": true}
       add_recipes_cq: "true"
       build_host: "true"
-      jazzy_version: "0.14.1"
+      xcode: 14a5294e # xcode 14.0 beta 5
     timeout: 75
 
   - name: Mac mac_android_aot_engine
@@ -370,11 +365,11 @@ targets:
     recipe: engine/engine_unopt
     properties:
       add_recipes_cq: "true"
-      jazzy_version: "0.14.1"
       runtime_versions: >-
         [
           "ios-16-0_14a5294e"
         ]
+      xcode: 14a5294e # xcode 14.0 beta 5
     timeout: 75
 
   - name: Mac Host clang-tidy
@@ -382,7 +377,6 @@ targets:
     properties:
       add_recipes_cq: "true"
       cores: "12"
-      jazzy_version: "0.14.1"
       lint_host: "true"
       lint_ios: "false"
     timeout: 75
@@ -404,7 +398,6 @@ targets:
     recipe: engine/engine_lint
     properties:
       add_recipes_cq: "true"
-      jazzy_version: "0.14.1"
       lint_host: "false"
       lint_ios: "true"
     timeout: 75
@@ -428,7 +421,7 @@ targets:
       add_recipes_cq: "true"
       build_ios: "true"
       ios_debug: "true"
-      jazzy_version: "0.14.1"
+      xcode: 14a5294e # xcode 14.0 beta 5
     timeout: 60
 
   - name: Mac Web Engine
@@ -464,6 +457,7 @@ targets:
         [
           {"dependency": "jazzy", "version": "0.14.1"}
         ]
+      xcode: 14a5294e # xcode 14.0 beta 5
 
   - name:  Mac mac_ios_engine_profile
     recipe: engine_v2/engine_v2
@@ -472,6 +466,7 @@ targets:
       config_name: mac_ios_engine_profile
       $flutter/osx_sdk : >-
         { "sdk_version": "14a5294e" }
+      xcode: 14a5294e # xcode 14.0 beta 5
 
   - name:  Mac mac_ios_engine_release
     recipe: engine_v2/engine_v2
@@ -480,6 +475,7 @@ targets:
       config_name: mac_ios_engine_release
       $flutter/osx_sdk : >-
         { "sdk_version": "14a5294e" }
+      xcode: 14a5294e # xcode 14.0 beta 5
 
   - name: Windows Android AOT Engine
     recipe: engine/engine
@@ -548,7 +544,7 @@ targets:
     properties:
       build_ios: "true"
       ios_profile: "true"
-      jazzy_version: "0.14.1"
+      xcode: 14a5294e # xcode 14.0 beta 5
     timeout: 90
     runIf:
       - DEPS
@@ -560,7 +556,7 @@ targets:
     properties:
       build_ios: "true"
       ios_release: "true"
-      jazzy_version: "0.14.1"
+      xcode: 14a5294e # xcode 14.0 beta 5
     timeout: 90
     runIf:
       - DEPS


### PR DESCRIPTION
Do not install Xcode on builders that do not use it.  On an Xcode cache hit this only adds about a second, but on a cache miss it can be an additional ~10 minutes.  Also reduce noise in the task step list.

Clean up other unused properties.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
