### PR TITLE
Only run clang-tidy in presubmit when C, C++, ObjC, or ObjC++ files change

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -194,6 +194,13 @@ targets:
       lint_android: "false"
       lint_host: "true"
     timeout: 60
+    runIf:
+      - DEPS
+      - .ci.yaml
+      - tools/**
+      - ci/**
+      - "**.c"
+      - "**.cc"
 
   - name: Linux Android clang-tidy
     recipe: engine/engine_lint
@@ -203,6 +210,13 @@ targets:
       lint_android: "true"
       lint_host: "false"
     timeout: 60
+    runIf:
+      - DEPS
+      - .ci.yaml
+      - tools/**
+      - ci/**
+      - "**.c"
+      - "**.cc"
 
   - name: Linux Arm Host Engine
     recipe: engine/engine_arm
@@ -336,6 +350,11 @@ targets:
       lint_host: "true"
       lint_ios: "false"
     timeout: 75
+    runIf:
+      - "**.c"
+      - "**.cc"
+      - "**.m"
+      - "**.mm"
 
   - name: Mac iOS clang-tidy
     recipe: engine/engine_lint
@@ -345,6 +364,15 @@ targets:
       lint_host: "false"
       lint_ios: "true"
     timeout: 75
+    runIf:
+      - DEPS
+      - .ci.yaml
+      - tools/**
+      - ci/**
+      - "**.c"
+      - "**.cc"
+      - "**.m"
+      - "**.mm"
 
   - name: Mac iOS Engine
     recipe: engine/engine

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -202,6 +202,9 @@ targets:
       - "**.h"
       - "**.c"
       - "**.cc"
+      - "**.fbs"
+      - "**.frag"
+      - "**.vert"
 
   - name: Linux Android clang-tidy
     recipe: engine/engine_lint
@@ -219,6 +222,9 @@ targets:
       - "**.h"
       - "**.c"
       - "**.cc"
+      - "**.fbs"
+      - "**.frag"
+      - "**.vert"
       - "**.py" # Run pylint on the fastest clang-tidy builder.
 
   - name: Linux Arm Host Engine
@@ -361,6 +367,9 @@ targets:
       - "**.h"
       - "**.c"
       - "**.cc"
+      - "**.fbs"
+      - "**.frag"
+      - "**.vert"
       - "**.m"
       - "**.mm"
 
@@ -380,6 +389,9 @@ targets:
       - "**.h"
       - "**.c"
       - "**.cc"
+      - "**.fbs"
+      - "**.frag"
+      - "**.vert"
       - "**.m"
       - "**.mm"
 

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -199,6 +199,7 @@ targets:
       - .ci.yaml
       - tools/**
       - ci/**
+      - "**.h"
       - "**.c"
       - "**.cc"
 
@@ -215,6 +216,7 @@ targets:
       - .ci.yaml
       - tools/**
       - ci/**
+      - "**.h"
       - "**.c"
       - "**.cc"
       - "**.py" # Run pylint on the fastest clang-tidy builder.
@@ -356,6 +358,7 @@ targets:
       - .ci.yaml
       - tools/**
       - ci/**
+      - "**.h"
       - "**.c"
       - "**.cc"
       - "**.m"
@@ -374,6 +377,7 @@ targets:
       - .ci.yaml
       - tools/**
       - ci/**
+      - "**.h"
       - "**.c"
       - "**.cc"
       - "**.m"

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -351,6 +351,10 @@ targets:
       lint_ios: "false"
     timeout: 75
     runIf:
+      - DEPS
+      - .ci.yaml
+      - tools/**
+      - ci/**
       - "**.c"
       - "**.cc"
       - "**.m"

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -217,6 +217,7 @@ targets:
       - ci/**
       - "**.c"
       - "**.cc"
+      - "**.py" # Run pylint on the fastest clang-tidy builder.
 
   - name: Linux Arm Host Engine
     recipe: engine/engine_arm

--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -41,6 +41,8 @@ if [ ! -f "$COMPILE_COMMANDS" ]; then
   (cd "$SRC_DIR"; ./flutter/tools/gn)
 fi
 
+echo "$(date +%T) Running clang_tidy"
+
 cd "$SCRIPT_DIR"
 "$DART" \
   --disable-dart-dev \
@@ -49,9 +51,13 @@ cd "$SCRIPT_DIR"
   --mac-host-warnings-as-errors="$MAC_HOST_WARNINGS_AS_ERRORS" \
   "$@"
 
+echo "$(date +%T) Running pylint"
+
 cd "$FLUTTER_DIR"
 pylint-2.7 --rcfile=.pylintrc \
   "build/" \
   "ci/" \
   "impeller/" \
   "tools/gn"
+
+echo "$(date +%T) Linting complete"

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -18,6 +18,8 @@
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h"
 #import "flutter/shell/platform/embedder/embedder.h"
 
+// Add comment to trigger build.
+
 FLUTTER_ASSERT_ARC
 
 @interface FlutterEngine ()

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -18,8 +18,6 @@
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h"
 #import "flutter/shell/platform/embedder/embedder.h"
 
-// Add comment to trigger build.
-
 FLUTTER_ASSERT_ARC
 
 @interface FlutterEngine ()


### PR DESCRIPTION
Only run clang-tidy builders in presubmit when C, C++, ObjC, or ObjC++ files change.  Also run if the `DEPS` or CI files change.  Run on `Linux Android clang-tidy` if any python files change, since that's the shortest-running builder.  All builds will always run in post-submit.

To test the globs, the first commit https://github.com/flutter/engine/pull/36887/commits/586b9e16b8518a499e1b1c05e8a1ef2a7f2cc5f8 added a comment to a `.mm` file, and `Mac Host clang-tidy` did not include `.ci.yaml`.  It was correctly scheduled just because of the extension: 
https://ci.chromium.org/p/flutter/builders/try/Mac%20Host%20clang-tidy/760

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
