### PR TITLE
Fix TextField performing both new line and input action

### DIFF
--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -1376,6 +1376,10 @@ abstract class DefaultTextEditingStrategy with CompositionAwareMixin implements 
       final DomKeyboardEvent event = e as DomKeyboardEvent;
       if (event.keyCode == _kReturnKeyCode) {
         onAction!(inputConfiguration.inputAction);
+        // Prevent the browser from inserting a new line when it's not a multiline input.
+        if (inputConfiguration.inputType is! MultilineInputType) {
+          event.preventDefault();
+        }
       }
     }
   }

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -390,6 +390,28 @@ Future<void> testMain() async {
       expect(event.defaultPrevented, isFalse);
     });
 
+    test('Triggers input action and prevent new line key event for single line field', () {
+      // Regression test for https://github.com/flutter/flutter/issues/113559
+      final InputConfiguration config = InputConfiguration();
+      editingStrategy!.enable(
+        config,
+        onChange: trackEditingState,
+        onAction: trackInputAction,
+      );
+
+      // No input action so far.
+      expect(lastInputAction, isNull);
+
+      final DomKeyboardEvent event = dispatchKeyboardEvent(
+        editingStrategy!.domElement!,
+        'keydown',
+        keyCode: _kReturnKeyCode,
+      );
+      expect(lastInputAction, 'TextInputAction.done');
+      // And default behavior of keyboard event should have been prevented.
+      expect(event.defaultPrevented, isTrue);
+    });
+
     test('globally positions and sizes its DOM element', () {
       editingStrategy!.enable(
         singlelineConfig,


### PR DESCRIPTION
## Description

This PR prevents new line key event from being dispatched when `TextField.textInputAction` is not `TextInputAction.newline` and the text field is not multiline.

## Related Issue

Fixes https://github.com/flutter/flutter/issues/113559

## Implementation choice

Since https://github.com/flutter/engine/pull/33428, web engine does not prevent new line key events.
~~Here, I choose to prevent it whether the field is multiline or not.~~

For a **single line field** (the default text input action is `TextInputAction.done`):
- before this PR, the action is performed and the keyboard event is not prevented. If the action changes focus to another field (`TextInputAction.next` for instance), the newly focused field inserts the new line (see https://github.com/flutter/flutter/issues/113559).
- after this PR, the action is performed and the keyboard event is prevented.

For a **multiline field**, the default text input action is `TextInputAction.newline`.
If the developer sets text input action to another value:
- before this PR, the action is performed and a new line is added.
- ~~after this PR, the action is performed but no new line is added~~.
- Edit: after this PR, same as before.

@mdebbar For multiline text fields, it seems that it was expected to always insert a new line. ~~I think that it should not when the user choose to set the input action to something else than `TextInputAction.newline`~~.
Edit: I have tested on Linux and MacOS and on both platforms a new line is inserted and the action is performed. So it is probably better to do the same on Web for the moment.

## Tests

Adds 2 tests, updates 2 tests.
