### PR TITLE
[macOS] Make the default background color black.

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.mm
@@ -47,7 +47,6 @@
   if (self) {
     _delegate = delegate;
     self.layer.opaque = opaque;
-    self.layer.backgroundColor = NSColor.black;
   }
 
   return self;

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.mm
@@ -47,6 +47,7 @@
   if (self) {
     _delegate = delegate;
     self.layer.opaque = opaque;
+    self.layer.backgroundColor = NSColor.black;
   }
 
   return self;

--- a/shell/platform/darwin/macos/framework/Headers/FlutterViewController.h
+++ b/shell/platform/darwin/macos/framework/Headers/FlutterViewController.h
@@ -102,7 +102,7 @@ FLUTTER_DARWIN_EXPORT
  *     // If the `FlutterView`'s color is not set via `FlutterViewController.setBackgroundColor`
  *     // it's default will be black.
  *     self.backgroundColor = NSColor.clear
- *     flutterViewController.setBackgroundColor(NSColor.white)
+ *     flutterViewController.backgroundColor = NSColor.clear
  *
  *     let windowFrame = self.frame
  *     self.contentViewController = flutterViewController
@@ -115,6 +115,6 @@ FLUTTER_DARWIN_EXPORT
  * }
  * ```
  */
-- (void)setBackgroundColor:(nonnull NSColor*)color;
+@property(readwrite, nonatomic, nullable) NSColor* backgroundColor;
 
 @end

--- a/shell/platform/darwin/macos/framework/Headers/FlutterViewController.h
+++ b/shell/platform/darwin/macos/framework/Headers/FlutterViewController.h
@@ -73,4 +73,48 @@ FLUTTER_DARWIN_EXPORT
  */
 - (void)onPreEngineRestart;
 
+/**
+ * The contentView (FlutterView)'s background color is set to black during
+ * its instantiation.
+ *
+ * The containing layer's color can be set to the NSColor provided to this method.
+ *
+ * For example, the background may be set after the FlutterViewController
+ * is instantiated in MainFlutterWindow.swift in the Flutter project.
+ * ```swift
+ * import Cocoa
+ * import FlutterMacOS
+ *
+ * class MainFlutterWindow: NSWindow {
+ *   override func awakeFromNib() {
+ *     let flutterViewController = FlutterViewController.init()
+ *
+ *     // The background color of the window and `FlutterViewController`
+ *     // are retained separately.
+ *     //
+ *     // In this example, both the MainFlutterWindow and FlutterViewController's
+ *     // FlutterView's backgroundColor are set to clear to achieve a fully
+ *     // transparent effect.
+ *     //
+ *     // If the window's background color is not set, it will use the system
+ *     // default.
+ *     //
+ *     // If the `FlutterView`'s color is not set via `FlutterViewController.setBackgroundColor`
+ *     // it's default will be black.
+ *     self.backgroundColor = NSColor.clear
+ *     flutterViewController.setBackgroundColor(NSColor.white)
+ *
+ *     let windowFrame = self.frame
+ *     self.contentViewController = flutterViewController
+ *     self.setFrame(windowFrame, display: true)
+ *
+ *     RegisterGeneratedPlugins(registry: flutterViewController)
+ *
+ *     super.awakeFromNib()
+ *   }
+ * }
+ * ```
+ */
+- (void)setBackgroundColor:(nonnull NSColor*)color;
+
 @end

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
@@ -101,6 +101,36 @@ TEST_F(FlutterEngineTest, CanLogToStdout) {
   EXPECT_TRUE(logs.find("Hello logging") != std::string::npos);
 }
 
+TEST_F(FlutterEngineTest, BackgroundIsBlack) {
+  // Launch the test entrypoint.
+  FlutterEngine* engine = GetFlutterEngine();
+  EXPECT_TRUE([engine runWithEntrypoint:@"backgroundTest"]);
+  EXPECT_TRUE(engine.running);
+
+  NSString* fixtures = @(flutter::testing::GetFixturesPath());
+  FlutterDartProject* project = [[FlutterDartProject alloc]
+      initWithAssetsPath:fixtures
+             ICUDataPath:[fixtures stringByAppendingString:@"/icudtl.dat"]];
+  FlutterViewController* viewController = [[FlutterViewController alloc] initWithProject:project];
+  [viewController loadView];
+  viewController.flutterView.frame = CGRectMake(0, 0, 800, 600);
+  [engine setViewController:viewController];
+
+  // Latch to ensure the entire layer tree has been generated and presented.
+  fml::AutoResetWaitableEvent latch;
+  AddNativeCallback("SignalNativeTest", CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
+                      CALayer* rootLayer = engine.viewController.flutterView.layer;
+                      EXPECT_TRUE(rootLayer.backgroundColor != nil);
+                      if (rootLayer.backgroundColor != nil) {
+                        NSColor* actualBackgroundColor =
+                            [NSColor colorWithCGColor:rootLayer.backgroundColor];
+                        EXPECT_EQ(actualBackgroundColor, [NSColor blackColor]);
+                      }
+                      latch.Signal();
+                    }));
+  latch.Wait();
+}
+
 TEST_F(FlutterEngineTest, CanToggleAccessibility) {
   FlutterEngine* engine = GetFlutterEngine();
   // Capture the update callbacks before the embedder API initializes.

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
@@ -145,7 +145,7 @@ TEST_F(FlutterEngineTest, CanOverrideBackgroundColor) {
   [viewController loadView];
   viewController.flutterView.frame = CGRectMake(0, 0, 800, 600);
   [engine setViewController:viewController];
-  [viewController setBackgroundColor:[NSColor whiteColor]];
+  viewController.flutterView.backgroundColor = [NSColor whiteColor];
 
   // Latch to ensure the entire layer tree has been generated and presented.
   fml::AutoResetWaitableEvent latch;

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
@@ -131,6 +131,37 @@ TEST_F(FlutterEngineTest, BackgroundIsBlack) {
   latch.Wait();
 }
 
+TEST_F(FlutterEngineTest, CanOverrideBackgroundColor) {
+  // Launch the test entrypoint.
+  FlutterEngine* engine = GetFlutterEngine();
+  EXPECT_TRUE([engine runWithEntrypoint:@"backgroundTest"]);
+  EXPECT_TRUE(engine.running);
+
+  NSString* fixtures = @(flutter::testing::GetFixturesPath());
+  FlutterDartProject* project = [[FlutterDartProject alloc]
+      initWithAssetsPath:fixtures
+             ICUDataPath:[fixtures stringByAppendingString:@"/icudtl.dat"]];
+  FlutterViewController* viewController = [[FlutterViewController alloc] initWithProject:project];
+  [viewController loadView];
+  viewController.flutterView.frame = CGRectMake(0, 0, 800, 600);
+  [engine setViewController:viewController];
+  [viewController setBackgroundColor:[NSColor whiteColor]];
+
+  // Latch to ensure the entire layer tree has been generated and presented.
+  fml::AutoResetWaitableEvent latch;
+  AddNativeCallback("SignalNativeTest", CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
+                      CALayer* rootLayer = engine.viewController.flutterView.layer;
+                      EXPECT_TRUE(rootLayer.backgroundColor != nil);
+                      if (rootLayer.backgroundColor != nil) {
+                        NSColor* actualBackgroundColor =
+                            [NSColor colorWithCGColor:rootLayer.backgroundColor];
+                        EXPECT_EQ(actualBackgroundColor, [NSColor whiteColor]);
+                      }
+                      latch.Signal();
+                    }));
+  latch.Wait();
+}
+
 TEST_F(FlutterEngineTest, CanToggleAccessibility) {
   FlutterEngine* engine = GetFlutterEngine();
   // Capture the update callbacks before the embedder API initializes.

--- a/shell/platform/darwin/macos/framework/Source/FlutterView.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterView.h
@@ -68,4 +68,13 @@
  */
 - (void)shutdown;
 
+/**
+ * By default, the `FlutterSurfaceManager` creates two layers to manage Flutter
+ * content, the content layer and containing layer. To set the native background
+ * color, onto which the Flutter content is drawn, call this method with the
+ * NSColor which you would like to override the default, black background color
+ * with.
+ */
+- (void)setBackgroundColor:(nonnull NSColor*)color;
+
 @end

--- a/shell/platform/darwin/macos/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterView.mm
@@ -28,6 +28,7 @@
   self = [super initWithFrame:NSZeroRect];
   if (self) {
     [self setWantsLayer:YES];
+    [self setBackgroundColor:[NSColor blackColor]];
     [self setLayerContentsRedrawPolicy:NSViewLayerContentsRedrawDuringViewResize];
     _reshapeListener = reshapeListener;
     _resizableBackingStoreProvider =
@@ -51,6 +52,7 @@
   self = [super initWithFrame:frame];
   if (self) {
     [self setWantsLayer:YES];
+    [self setBackgroundColor:[NSColor blackColor]];
     _reshapeListener = reshapeListener;
     _resizableBackingStoreProvider =
         [[FlutterOpenGLResizableBackingStoreProvider alloc] initWithMainContext:mainContext
@@ -82,6 +84,11 @@
                             notify:^{
                               [_reshapeListener viewDidReshape:self];
                             }];
+}
+
+- (void)setBackgroundColor:(NSColor*)color {
+  [self setWantsLayer:YES];
+  self.layer.backgroundColor = color.CGColor;
 }
 
 #pragma mark - NSView overrides

--- a/shell/platform/darwin/macos/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterView.mm
@@ -87,7 +87,6 @@
 }
 
 - (void)setBackgroundColor:(NSColor*)color {
-  [self setWantsLayer:YES];
   self.layer.backgroundColor = color.CGColor;
 }
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -382,6 +382,9 @@ static void CommonInit(FlutterViewController* controller) {
     }
     flutterView = [[FlutterView alloc] initWithMainContext:mainContext reshapeListener:self];
   }
+  if (_backgroundColor != nil) {
+    [flutterView setBackgroundColor:_backgroundColor];
+  }
   FlutterViewWrapper* wrapperView = [[FlutterViewWrapper alloc] initWithFlutterView:flutterView];
   self.view = wrapperView;
   _flutterView = flutterView;
@@ -426,7 +429,7 @@ static void CommonInit(FlutterViewController* controller) {
 
 - (void)setBackgroundColor:(NSColor*)color {
   _backgroundColor = color;
-  [(FlutterViewWrapper*)[self view] setBackgroundColor:_backgroundColor];
+  [_flutterView setBackgroundColor:_backgroundColor];
 }
 
 - (void)onPreEngineRestart {

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -159,6 +159,8 @@ NSData* currentKeyboardLayoutData() {
  */
 @interface FlutterViewWrapper : NSView
 
+- (void)setBackgroundColor:(NSColor*)color;
+
 @end
 
 /**
@@ -264,6 +266,10 @@ void OnKeyboardLayoutChanged(CFNotificationCenterRef center,
     [self addSubview:view];
   }
   return self;
+}
+
+- (void)setBackgroundColor:(NSColor*)color {
+  [_flutterView setBackgroundColor:color];
 }
 
 - (NSArray*)accessibilityChildren {
@@ -416,6 +422,10 @@ static void CommonInit(FlutterViewController* controller) {
   }
   _mouseTrackingMode = mode;
   [self configureTrackingArea];
+}
+
+- (void)setBackgroundColor:(NSColor*)color {
+  [(FlutterViewWrapper*)[self view] setBackgroundColor:color];
 }
 
 - (void)onPreEngineRestart {

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -425,7 +425,8 @@ static void CommonInit(FlutterViewController* controller) {
 }
 
 - (void)setBackgroundColor:(NSColor*)color {
-  [(FlutterViewWrapper*)[self view] setBackgroundColor:color];
+  _backgroundColor = color;
+  [(FlutterViewWrapper*)[self view] setBackgroundColor:_backgroundColor];
 }
 
 - (void)onPreEngineRestart {

--- a/shell/platform/darwin/macos/framework/Source/fixtures/flutter_desktop_test.dart
+++ b/shell/platform/darwin/macos/framework/Source/fixtures/flutter_desktop_test.dart
@@ -57,3 +57,9 @@ Picture _createSimplePicture() {
 void nativeCallback() {
   signalNativeTest();
 }
+
+@pragma('vm:entry-point')
+void backgroundTest() {
+  PlatformDispatcher.instance.views.first.render(SceneBuilder().build());
+  signalNativeTest(); // should look black
+}


### PR DESCRIPTION
The background color of a macOS application defaults to the system's window default. This patch makes the default color black. More discussion is required to engineer an API that is suitable for clients that need to override this default behavior.

## Fixes https://github.com/flutter/flutter/issues/113975

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
