### PR TITLE
Implemented threadsafe platform channel replies on windows

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -3099,6 +3099,7 @@ FILE: ../../../flutter/shell/platform/windows/external_texture_d3d.cc
 FILE: ../../../flutter/shell/platform/windows/external_texture_d3d.h
 FILE: ../../../flutter/shell/platform/windows/external_texture_pixelbuffer.cc
 FILE: ../../../flutter/shell/platform/windows/external_texture_pixelbuffer.h
+FILE: ../../../flutter/shell/platform/windows/flutter_desktop_messenger.h
 FILE: ../../../flutter/shell/platform/windows/flutter_key_map.g.cc
 FILE: ../../../flutter/shell/platform/windows/flutter_platform_node_delegate_windows.cc
 FILE: ../../../flutter/shell/platform/windows/flutter_platform_node_delegate_windows.h

--- a/shell/platform/common/client_wrapper/core_implementations.cc
+++ b/shell/platform/common/client_wrapper/core_implementations.cc
@@ -42,6 +42,7 @@ void ForwardToHandler(FlutterDesktopMessengerRef messenger,
   BinaryReply reply_handler = [messenger_ptr, response_handle](
                                   const uint8_t* reply,
                                   size_t reply_size) mutable {
+    // Note: This can be called on any thread.
     auto lock = std::unique_ptr<FlutterDesktopMessenger,
                                 decltype(&FlutterDesktopMessengerUnlock)>(
         FlutterDesktopMessengerLock(messenger_ptr.get()),

--- a/shell/platform/common/client_wrapper/core_implementations.cc
+++ b/shell/platform/common/client_wrapper/core_implementations.cc
@@ -52,9 +52,7 @@ void ForwardToHandler(FlutterDesktopMessengerRef messenger,
         FlutterDesktopMessengerLock(messenger_ptr.get()),
         &FlutterDesktopMessengerUnlock);
     if (!FlutterDesktopMessengerIsAvailable(messenger_ptr.get())) {
-      std::cerr << "Error: Responding to platform channel after the engine has"
-                   "been deleted."
-                << std::endl;
+      // Drop reply if it comes in after the engine is destroyed.
       return;
     }
     if (!response_handle) {

--- a/shell/platform/common/client_wrapper/testing/stub_flutter_api.cc
+++ b/shell/platform/common/client_wrapper/testing/stub_flutter_api.cc
@@ -4,6 +4,8 @@
 
 #include "flutter/shell/platform/common/client_wrapper/testing/stub_flutter_api.h"
 
+#include <cassert>
+
 static flutter::testing::StubFlutterApi* s_stub_implementation;
 
 namespace flutter {
@@ -91,6 +93,31 @@ void FlutterDesktopMessengerSetCallback(FlutterDesktopMessengerRef messenger,
   if (s_stub_implementation) {
     s_stub_implementation->MessengerSetCallback(channel, callback, user_data);
   }
+}
+
+FlutterDesktopMessengerRef FlutterDesktopMessengerAddRef(
+    FlutterDesktopMessengerRef messenger) {
+  assert(false);  // not implemented
+  return nullptr;
+}
+
+void FlutterDesktopMessengerRelease(FlutterDesktopMessengerRef messenger) {
+  assert(false);  // not implemented
+}
+
+bool FlutterDesktopMessengerIsAvailable(FlutterDesktopMessengerRef messenger) {
+  assert(false);  // not implemented
+  return false;
+}
+
+FlutterDesktopMessengerRef FlutterDesktopMessengerLock(
+    FlutterDesktopMessengerRef messenger) {
+  assert(false);  // not implemented
+  return nullptr;
+}
+
+void FlutterDesktopMessengerUnlock(FlutterDesktopMessengerRef messenger) {
+  assert(false);  // not implemented
 }
 
 FlutterDesktopTextureRegistrarRef FlutterDesktopRegistrarGetTextureRegistrar(

--- a/shell/platform/common/public/flutter_messenger.h
+++ b/shell/platform/common/public/flutter_messenger.h
@@ -88,18 +88,44 @@ FLUTTER_EXPORT void FlutterDesktopMessengerSetCallback(
     FlutterDesktopMessageCallback callback,
     void* user_data);
 
+// Increments the reference count for the |messenger|.
+//
+// See also: |FlutterDesktopMessengerRelease|
 FLUTTER_EXPORT FlutterDesktopMessengerRef
 FlutterDesktopMessengerAddRef(FlutterDesktopMessengerRef messenger);
 
+// Decrements the reference count for the |messenger|.
+//
+// The reference count starts at zero so it is valid to call
+// FlutterDesktopMessengerRelease without having called
+// FlutterDesktopMessengerAddRef.
+//
+// See also: |FlutterDesktopMessengerAddRef|
 FLUTTER_EXPORT void FlutterDesktopMessengerRelease(
     FlutterDesktopMessengerRef messenger);
 
+// Returns `true` if the |FlutterDesktopMessengerRef| still references a running
+// engine.
+//
+// This check should be made inside of a |FlutterDesktopMessengerLock| and
+// before any other calls are made to the FlutterDesktopMessengerRef when using
+// it from a thread other than the platform thread.
 FLUTTER_EXPORT bool FlutterDesktopMessengerIsAvailable(
     FlutterDesktopMessengerRef messenger);
 
+// Locks the `FlutterDesktopMessengerRef` ensuring that
+// |FlutterDesktopMessengerIsAvailable| does not change while locked.
+//
+// All calls to the FlutterDesktopMessengerRef from threads other than the
+// platform thread should happen inside of a lock.
+//
+// See also: |FlutterDesktopMessengerUnlock|
 FLUTTER_EXPORT FlutterDesktopMessengerRef
 FlutterDesktopMessengerLock(FlutterDesktopMessengerRef messenger);
 
+// Unlocks the `FlutterDesktopMessengerRef`.
+//
+// See also: |FlutterDesktopMessengerLock|
 FLUTTER_EXPORT void FlutterDesktopMessengerUnlock(
     FlutterDesktopMessengerRef messenger);
 

--- a/shell/platform/common/public/flutter_messenger.h
+++ b/shell/platform/common/public/flutter_messenger.h
@@ -90,15 +90,15 @@ FLUTTER_EXPORT void FlutterDesktopMessengerSetCallback(
 
 // Increments the reference count for the |messenger|.
 //
+// Operation is thread-safe.
+//
 // See also: |FlutterDesktopMessengerRelease|
 FLUTTER_EXPORT FlutterDesktopMessengerRef
 FlutterDesktopMessengerAddRef(FlutterDesktopMessengerRef messenger);
 
 // Decrements the reference count for the |messenger|.
 //
-// The reference count starts at zero so it is valid to call
-// FlutterDesktopMessengerRelease without having called
-// FlutterDesktopMessengerAddRef.
+// Operation is thread-safe.
 //
 // See also: |FlutterDesktopMessengerAddRef|
 FLUTTER_EXPORT void FlutterDesktopMessengerRelease(
@@ -119,11 +119,17 @@ FLUTTER_EXPORT bool FlutterDesktopMessengerIsAvailable(
 // All calls to the FlutterDesktopMessengerRef from threads other than the
 // platform thread should happen inside of a lock.
 //
+// Operation is thread-safe.
+//
+// Returns the |messenger| value.
+//
 // See also: |FlutterDesktopMessengerUnlock|
 FLUTTER_EXPORT FlutterDesktopMessengerRef
 FlutterDesktopMessengerLock(FlutterDesktopMessengerRef messenger);
 
 // Unlocks the `FlutterDesktopMessengerRef`.
+//
+// Operation is thread-safe.
 //
 // See also: |FlutterDesktopMessengerLock|
 FLUTTER_EXPORT void FlutterDesktopMessengerUnlock(

--- a/shell/platform/common/public/flutter_messenger.h
+++ b/shell/platform/common/public/flutter_messenger.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_SHELL_PLATFORM_COMMON_PUBLIC_FLUTTER_MESSENGER_H_
 #define FLUTTER_SHELL_PLATFORM_COMMON_PUBLIC_FLUTTER_MESSENGER_H_
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -86,6 +87,21 @@ FLUTTER_EXPORT void FlutterDesktopMessengerSetCallback(
     const char* channel,
     FlutterDesktopMessageCallback callback,
     void* user_data);
+
+FLUTTER_EXPORT FlutterDesktopMessengerRef
+FlutterDesktopMessengerAddRef(FlutterDesktopMessengerRef messenger);
+
+FLUTTER_EXPORT void FlutterDesktopMessengerRelease(
+    FlutterDesktopMessengerRef messenger);
+
+FLUTTER_EXPORT bool FlutterDesktopMessengerIsAvailable(
+    FlutterDesktopMessengerRef messenger);
+
+FLUTTER_EXPORT FlutterDesktopMessengerRef
+FlutterDesktopMessengerLock(FlutterDesktopMessengerRef messenger);
+
+FLUTTER_EXPORT void FlutterDesktopMessengerUnlock(
+    FlutterDesktopMessengerRef messenger);
 
 #if defined(__cplusplus)
 }  // extern "C"

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -2325,12 +2325,12 @@ FlutterEngineResult FlutterPlatformMessageReleaseResponseHandle(
   return kSuccess;
 }
 
+// Note: This can execute on any thread.
 FlutterEngineResult FlutterEngineSendPlatformMessageResponse(
     FLUTTER_API_SYMBOL(FlutterEngine) engine,
     const FlutterPlatformMessageResponseHandle* handle,
     const uint8_t* data,
     size_t data_length) {
-  // Note: This can execute on any thread.
   if (data_length != 0 && data == nullptr) {
     return LOG_EMBEDDER_ERROR(
         kInvalidArguments,

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -2330,6 +2330,7 @@ FlutterEngineResult FlutterEngineSendPlatformMessageResponse(
     const FlutterPlatformMessageResponseHandle* handle,
     const uint8_t* data,
     size_t data_length) {
+  // Note: This can execute on any thread.
   if (data_length != 0 && data == nullptr) {
     return LOG_EMBEDDER_ERROR(
         kInvalidArguments,

--- a/shell/platform/glfw/flutter_glfw.cc
+++ b/shell/platform/glfw/flutter_glfw.cc
@@ -149,6 +149,8 @@ struct FlutterDesktopPluginRegistrar {
 
 // State associated with the messenger used to communicate with the engine.
 struct FlutterDesktopMessenger {
+  FlutterDesktopMessenger() = default;
+
   void AddRef() { ref_count_.fetch_add(1); }
 
   void Release() {
@@ -167,6 +169,7 @@ struct FlutterDesktopMessenger {
   std::mutex& GetMutex() { return mutex_; }
 
  private:
+  FML_DISALLOW_COPY_AND_ASSIGN(FlutterDesktopMessenger);
   // The engine that backs this messenger.
   FlutterDesktopEngineState* engine_;
   std::atomic<int32_t> ref_count_ = 0;

--- a/shell/platform/glfw/flutter_glfw.cc
+++ b/shell/platform/glfw/flutter_glfw.cc
@@ -169,7 +169,9 @@ struct FlutterDesktopMessenger {
   std::mutex& GetMutex() { return mutex_; }
 
  private:
-  FML_DISALLOW_COPY_AND_ASSIGN(FlutterDesktopMessenger);
+  FlutterDesktopMessenger(const FlutterDesktopMessenger& value) = delete;
+  FlutterDesktopMessenger& operator=(const FlutterDesktopMessenger& value) =
+      delete;
   // The engine that backs this messenger.
   FlutterDesktopEngineState* engine_;
   std::atomic<int32_t> ref_count_ = 0;

--- a/shell/platform/glfw/flutter_glfw.cc
+++ b/shell/platform/glfw/flutter_glfw.cc
@@ -1096,6 +1096,31 @@ void FlutterDesktopMessengerSetCallback(FlutterDesktopMessengerRef messenger,
                                                             user_data);
 }
 
+FlutterDesktopMessengerRef FlutterDesktopMessengerAddRef(
+    FlutterDesktopMessengerRef messenger) {
+  assert(false);  // not implemented
+  return nullptr;
+}
+
+void FlutterDesktopMessengerRelease(FlutterDesktopMessengerRef messenger) {
+  assert(false);  // not implemented
+}
+
+bool FlutterDesktopMessengerIsAvailable(FlutterDesktopMessengerRef messenger) {
+  assert(false);  // not implemented
+  return false;
+}
+
+FlutterDesktopMessengerRef FlutterDesktopMessengerLock(
+    FlutterDesktopMessengerRef messenger) {
+  assert(false);  // not implemented
+  return nullptr;
+}
+
+void FlutterDesktopMessengerUnlock(FlutterDesktopMessengerRef messenger) {
+  assert(false);  // not implemented
+}
+
 FlutterDesktopTextureRegistrarRef FlutterDesktopRegistrarGetTextureRegistrar(
     FlutterDesktopPluginRegistrarRef registrar) {
   std::cerr << "GLFW Texture support is not implemented yet." << std::endl;

--- a/shell/platform/glfw/flutter_glfw.cc
+++ b/shell/platform/glfw/flutter_glfw.cc
@@ -116,7 +116,7 @@ struct FlutterDesktopEngineState {
   std::unique_ptr<flutter::EventLoop> event_loop;
 
   // The plugin messenger handle given to API clients.
-  std::unique_ptr<FlutterDesktopMessenger> messenger;
+  std::shared_ptr<FlutterDesktopMessenger> messenger;
 
   // Message dispatch manager for messages from the Flutter engine.
   std::unique_ptr<flutter::IncomingMessageDispatcher> message_dispatcher;
@@ -149,9 +149,53 @@ struct FlutterDesktopPluginRegistrar {
 
 // State associated with the messenger used to communicate with the engine.
 struct FlutterDesktopMessenger {
+  void AddRef() { ref_count_.fetch_add(1); }
+
+  void Release() {
+    int32_t old_count = ref_count_.fetch_sub(1);
+    if (old_count <= 1) {
+      delete this;
+    }
+  }
+
+  FlutterDesktopEngineState* GetEngine() const { return engine_; }
+  void SetEngine(FlutterDesktopEngineState* engine) {
+    std::scoped_lock lock(mutex_);
+    engine_ = engine;
+  }
+
+  std::mutex& GetMutex() { return mutex_; }
+
+ private:
   // The engine that backs this messenger.
-  FlutterDesktopEngineState* engine;
+  FlutterDesktopEngineState* engine_;
+  std::atomic<int32_t> ref_count_ = 0;
+  std::mutex mutex_;
 };
+
+FlutterDesktopMessengerRef FlutterDesktopMessengerAddRef(
+    FlutterDesktopMessengerRef messenger) {
+  messenger->AddRef();
+  return messenger;
+}
+
+void FlutterDesktopMessengerRelease(FlutterDesktopMessengerRef messenger) {
+  messenger->Release();
+}
+
+bool FlutterDesktopMessengerIsAvailable(FlutterDesktopMessengerRef messenger) {
+  return messenger->GetEngine() != nullptr;
+}
+
+FlutterDesktopMessengerRef FlutterDesktopMessengerLock(
+    FlutterDesktopMessengerRef messenger) {
+  messenger->GetMutex().lock();
+  return messenger;
+}
+
+void FlutterDesktopMessengerUnlock(FlutterDesktopMessengerRef messenger) {
+  messenger->GetMutex().unlock();
+}
 
 // Retrieves state bag for the window in question from the GLFWWindow.
 static FlutterDesktopWindowControllerState* GetWindowController(
@@ -743,8 +787,10 @@ static void SetUpLocales(FlutterDesktopEngineState* state) {
 static void SetUpCommonEngineState(FlutterDesktopEngineState* state,
                                    GLFWwindow* window) {
   // Messaging.
-  state->messenger = std::make_unique<FlutterDesktopMessenger>();
-  state->messenger->engine = state;
+  state->messenger = std::shared_ptr<FlutterDesktopMessenger>(
+      FlutterDesktopMessengerAddRef(new FlutterDesktopMessenger()),
+      &FlutterDesktopMessengerRelease);
+  state->messenger->SetEngine(state);
   state->message_dispatcher =
       std::make_unique<flutter::IncomingMessageDispatcher>(
           state->messenger.get());
@@ -846,6 +892,7 @@ FlutterDesktopWindowControllerRef FlutterDesktopCreateWindow(
 }
 
 void FlutterDesktopDestroyWindow(FlutterDesktopWindowControllerRef controller) {
+  controller->engine->messenger->SetEngine(nullptr);
   FlutterDesktopPluginRegistrarRef registrar =
       controller->engine->plugin_registrar.get();
   if (registrar->destruction_handler) {
@@ -1045,7 +1092,8 @@ bool FlutterDesktopMessengerSendWithReply(FlutterDesktopMessengerRef messenger,
   FlutterPlatformMessageResponseHandle* response_handle = nullptr;
   if (reply != nullptr && user_data != nullptr) {
     FlutterEngineResult result = FlutterPlatformMessageCreateResponseHandle(
-        messenger->engine->flutter_engine, reply, user_data, &response_handle);
+        messenger->GetEngine()->flutter_engine, reply, user_data,
+        &response_handle);
     if (result != kSuccess) {
       std::cout << "Failed to create response handle\n";
       return false;
@@ -1061,11 +1109,11 @@ bool FlutterDesktopMessengerSendWithReply(FlutterDesktopMessengerRef messenger,
   };
 
   FlutterEngineResult message_result = FlutterEngineSendPlatformMessage(
-      messenger->engine->flutter_engine, &platform_message);
+      messenger->GetEngine()->flutter_engine, &platform_message);
 
   if (response_handle != nullptr) {
     FlutterPlatformMessageReleaseResponseHandle(
-        messenger->engine->flutter_engine, response_handle);
+        messenger->GetEngine()->flutter_engine, response_handle);
   }
 
   return message_result == kSuccess;
@@ -1084,41 +1132,16 @@ void FlutterDesktopMessengerSendResponse(
     const FlutterDesktopMessageResponseHandle* handle,
     const uint8_t* data,
     size_t data_length) {
-  FlutterEngineSendPlatformMessageResponse(messenger->engine->flutter_engine,
-                                           handle, data, data_length);
+  FlutterEngineSendPlatformMessageResponse(
+      messenger->GetEngine()->flutter_engine, handle, data, data_length);
 }
 
 void FlutterDesktopMessengerSetCallback(FlutterDesktopMessengerRef messenger,
                                         const char* channel,
                                         FlutterDesktopMessageCallback callback,
                                         void* user_data) {
-  messenger->engine->message_dispatcher->SetMessageCallback(channel, callback,
-                                                            user_data);
-}
-
-FlutterDesktopMessengerRef FlutterDesktopMessengerAddRef(
-    FlutterDesktopMessengerRef messenger) {
-  assert(false);  // not implemented
-  return nullptr;
-}
-
-void FlutterDesktopMessengerRelease(FlutterDesktopMessengerRef messenger) {
-  assert(false);  // not implemented
-}
-
-bool FlutterDesktopMessengerIsAvailable(FlutterDesktopMessengerRef messenger) {
-  assert(false);  // not implemented
-  return false;
-}
-
-FlutterDesktopMessengerRef FlutterDesktopMessengerLock(
-    FlutterDesktopMessengerRef messenger) {
-  assert(false);  // not implemented
-  return nullptr;
-}
-
-void FlutterDesktopMessengerUnlock(FlutterDesktopMessengerRef messenger) {
-  assert(false);  // not implemented
+  messenger->GetEngine()->message_dispatcher->SetMessageCallback(
+      channel, callback, user_data);
 }
 
 FlutterDesktopTextureRegistrarRef FlutterDesktopRegistrarGetTextureRegistrar(

--- a/shell/platform/windows/flutter_desktop_messenger.h
+++ b/shell/platform/windows/flutter_desktop_messenger.h
@@ -1,0 +1,78 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_FLUTTER_DESKTOP_MESSENGER_H_
+#define FLUTTER_SHELL_PLATFORM_WINDOWS_FLUTTER_DESKTOP_MESSENGER_H_
+
+#include <atomic>
+#include <mutex>
+
+#include "flutter/shell/platform/common/public/flutter_messenger.h"
+
+namespace flutter {
+
+class FlutterWindowsEngine;
+
+class FlutterDesktopMessenger {
+ public:
+  FlutterDesktopMessenger() = default;
+
+  /// Convert to FlutterDesktopMessengerRef.
+  FlutterDesktopMessengerRef ToRef() {
+    return reinterpret_cast<FlutterDesktopMessengerRef>(this);
+  }
+
+  /// Convert from FlutterDesktopMessengerRef.
+  static FlutterDesktopMessenger* FromRef(FlutterDesktopMessengerRef ref) {
+    return reinterpret_cast<FlutterDesktopMessenger*>(ref);
+  }
+
+  /// Getter for the engine field.
+  flutter::FlutterWindowsEngine* GetEngine() const { return engine; }
+
+  /// Setter for the engine field.
+  /// Thread-safe.
+  void SetEngine(flutter::FlutterWindowsEngine* arg_engine) {
+    std::scoped_lock lock(mutex_);
+    engine = arg_engine;
+  }
+
+  /// Increments the reference count.
+  ///
+  /// Thread-safe.
+  FlutterDesktopMessenger* AddRef() {
+    ref_count_.fetch_add(1);
+    return this;
+  }
+
+  /// Decrements the reference count and deletes the object if the count has
+  /// gone to zero.
+  ///
+  /// Thread-safe.
+  void Release() {
+    int32_t old_count = ref_count_.fetch_sub(1);
+    if (old_count <= 1) {
+      delete this;
+    }
+  }
+
+  /// Returns the mutex associated with the |FlutterDesktopMessenger|.
+  ///
+  /// This mutex is used to synchronize reading or writing state inside the
+  /// |FlutterDesktopMessenger| (ie |engine|).
+  std::mutex& GetMutex() { return mutex_; }
+
+  FlutterDesktopMessenger(const FlutterDesktopMessenger& value) = delete;
+  FlutterDesktopMessenger& operator=(const FlutterDesktopMessenger& value) =
+      delete;
+
+ private:
+  // The engine that owns this state object.
+  flutter::FlutterWindowsEngine* engine = nullptr;
+  std::mutex mutex_;
+  std::atomic<int32_t> ref_count_ = 0;
+};
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_FLUTTER_WINDOW_STATE_H_

--- a/shell/platform/windows/flutter_desktop_messenger.h
+++ b/shell/platform/windows/flutter_desktop_messenger.h
@@ -14,6 +14,11 @@ namespace flutter {
 
 class FlutterWindowsEngine;
 
+/// A messenger object used to invoke platform messages.
+///
+/// On Windows, the message handler is essentially the |FlutterWindowsEngine|,
+/// this allows a handle to the |FlutterWindowsEngine| that will become
+/// invalidated if the |FlutterWindowsEngine| is destroyed.
 class FlutterDesktopMessenger {
  public:
   FlutterDesktopMessenger() = default;

--- a/shell/platform/windows/flutter_windows.cc
+++ b/shell/platform/windows/flutter_windows.cc
@@ -262,8 +262,8 @@ bool FlutterDesktopMessengerSendWithReply(FlutterDesktopMessengerRef messenger,
                                           const size_t message_size,
                                           const FlutterDesktopBinaryReply reply,
                                           void* user_data) {
-  return messenger->engine->SendPlatformMessage(channel, message, message_size,
-                                                reply, user_data);
+  return messenger->GetEngine()->SendPlatformMessage(
+      channel, message, message_size, reply, user_data);
 }
 
 bool FlutterDesktopMessengerSend(FlutterDesktopMessengerRef messenger,
@@ -279,15 +279,39 @@ void FlutterDesktopMessengerSendResponse(
     const FlutterDesktopMessageResponseHandle* handle,
     const uint8_t* data,
     size_t data_length) {
-  messenger->engine->SendPlatformMessageResponse(handle, data, data_length);
+  messenger->GetEngine()->SendPlatformMessageResponse(handle, data,
+                                                      data_length);
 }
 
 void FlutterDesktopMessengerSetCallback(FlutterDesktopMessengerRef messenger,
                                         const char* channel,
                                         FlutterDesktopMessageCallback callback,
                                         void* user_data) {
-  messenger->engine->message_dispatcher()->SetMessageCallback(channel, callback,
-                                                              user_data);
+  messenger->GetEngine()->message_dispatcher()->SetMessageCallback(
+      channel, callback, user_data);
+}
+
+FlutterDesktopMessengerRef FlutterDesktopMessengerAddRef(
+    FlutterDesktopMessengerRef messenger) {
+  return messenger->AddRef();
+}
+
+void FlutterDesktopMessengerRelease(FlutterDesktopMessengerRef messenger) {
+  messenger->Release();
+}
+
+bool FlutterDesktopMessengerIsAvailable(FlutterDesktopMessengerRef messenger) {
+  return messenger->GetEngine() != nullptr;
+}
+
+FlutterDesktopMessengerRef FlutterDesktopMessengerLock(
+    FlutterDesktopMessengerRef messenger) {
+  messenger->GetMutex().lock();
+  return messenger;
+}
+
+void FlutterDesktopMessengerUnlock(FlutterDesktopMessengerRef messenger) {
+  messenger->GetMutex().unlock();
 }
 
 FlutterDesktopTextureRegistrarRef FlutterDesktopRegistrarGetTextureRegistrar(

--- a/shell/platform/windows/flutter_windows.cc
+++ b/shell/platform/windows/flutter_windows.cc
@@ -262,8 +262,9 @@ bool FlutterDesktopMessengerSendWithReply(FlutterDesktopMessengerRef messenger,
                                           const size_t message_size,
                                           const FlutterDesktopBinaryReply reply,
                                           void* user_data) {
-  return messenger->GetEngine()->SendPlatformMessage(
-      channel, message, message_size, reply, user_data);
+  return flutter::FlutterDesktopMessenger::FromRef(messenger)
+      ->GetEngine()
+      ->SendPlatformMessage(channel, message, message_size, reply, user_data);
 }
 
 bool FlutterDesktopMessengerSend(FlutterDesktopMessengerRef messenger,
@@ -279,39 +280,45 @@ void FlutterDesktopMessengerSendResponse(
     const FlutterDesktopMessageResponseHandle* handle,
     const uint8_t* data,
     size_t data_length) {
-  messenger->GetEngine()->SendPlatformMessageResponse(handle, data,
-                                                      data_length);
+  flutter::FlutterDesktopMessenger::FromRef(messenger)
+      ->GetEngine()
+      ->SendPlatformMessageResponse(handle, data, data_length);
 }
 
 void FlutterDesktopMessengerSetCallback(FlutterDesktopMessengerRef messenger,
                                         const char* channel,
                                         FlutterDesktopMessageCallback callback,
                                         void* user_data) {
-  messenger->GetEngine()->message_dispatcher()->SetMessageCallback(
-      channel, callback, user_data);
+  flutter::FlutterDesktopMessenger::FromRef(messenger)
+      ->GetEngine()
+      ->message_dispatcher()
+      ->SetMessageCallback(channel, callback, user_data);
 }
 
 FlutterDesktopMessengerRef FlutterDesktopMessengerAddRef(
     FlutterDesktopMessengerRef messenger) {
-  return messenger->AddRef();
+  return flutter::FlutterDesktopMessenger::FromRef(messenger)
+      ->AddRef()
+      ->ToRef();
 }
 
 void FlutterDesktopMessengerRelease(FlutterDesktopMessengerRef messenger) {
-  messenger->Release();
+  flutter::FlutterDesktopMessenger::FromRef(messenger)->Release();
 }
 
 bool FlutterDesktopMessengerIsAvailable(FlutterDesktopMessengerRef messenger) {
-  return messenger->GetEngine() != nullptr;
+  return flutter::FlutterDesktopMessenger::FromRef(messenger)->GetEngine() !=
+         nullptr;
 }
 
 FlutterDesktopMessengerRef FlutterDesktopMessengerLock(
     FlutterDesktopMessengerRef messenger) {
-  messenger->GetMutex().lock();
+  flutter::FlutterDesktopMessenger::FromRef(messenger)->GetMutex().lock();
   return messenger;
 }
 
 void FlutterDesktopMessengerUnlock(FlutterDesktopMessengerRef messenger) {
-  messenger->GetMutex().unlock();
+  flutter::FlutterDesktopMessenger::FromRef(messenger)->GetMutex().unlock();
 }
 
 FlutterDesktopTextureRegistrarRef FlutterDesktopRegistrarGetTextureRegistrar(

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -185,9 +185,10 @@ FlutterWindowsEngine::FlutterWindowsEngine(
   plugin_registrar_ = std::make_unique<FlutterDesktopPluginRegistrar>();
   plugin_registrar_->engine = this;
 
-  messenger_wrapper_ = std::make_unique<BinaryMessengerImpl>(messenger_.get());
+  messenger_wrapper_ =
+      std::make_unique<BinaryMessengerImpl>(messenger_->ToRef());
   message_dispatcher_ =
-      std::make_unique<IncomingMessageDispatcher>(messenger_.get());
+      std::make_unique<IncomingMessageDispatcher>(messenger_->ToRef());
   message_dispatcher_->SetMessageCallback(
       kAccessibilityChannelName,
       [](FlutterDesktopMessengerRef messenger,

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -179,8 +179,9 @@ FlutterWindowsEngine::FlutterWindowsEngine(
           });
 
   // Set up the legacy structs backing the API handles.
-  messenger_ = std::make_unique<FlutterDesktopMessenger>();
-  messenger_->engine = this;
+  messenger_ =
+      fml::RefPtr<FlutterDesktopMessenger>(new FlutterDesktopMessenger());
+  messenger_->SetEngine(this);
   plugin_registrar_ = std::make_unique<FlutterDesktopPluginRegistrar>();
   plugin_registrar_->engine = this;
 
@@ -210,6 +211,7 @@ FlutterWindowsEngine::FlutterWindowsEngine(
 }
 
 FlutterWindowsEngine::~FlutterWindowsEngine() {
+  messenger_->SetEngine(nullptr);
   Stop();
 }
 

--- a/shell/platform/windows/flutter_windows_engine.h
+++ b/shell/platform/windows/flutter_windows_engine.h
@@ -20,6 +20,7 @@
 #include "flutter/shell/platform/common/incoming_message_dispatcher.h"
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/windows/angle_surface_manager.h"
+#include "flutter/shell/platform/windows/flutter_desktop_messenger.h"
 #include "flutter/shell/platform/windows/flutter_project_bundle.h"
 #include "flutter/shell/platform/windows/flutter_windows_texture_registrar.h"
 #include "flutter/shell/platform/windows/public/flutter_windows.h"
@@ -124,7 +125,7 @@ class FlutterWindowsEngine {
   // Sets switches member to the given switches.
   void SetSwitches(const std::vector<std::string>& switches);
 
-  FlutterDesktopMessengerRef messenger() { return messenger_.get(); }
+  FlutterDesktopMessengerRef messenger() { return messenger_->ToRef(); }
 
   IncomingMessageDispatcher* message_dispatcher() {
     return message_dispatcher_.get();
@@ -283,7 +284,7 @@ class FlutterWindowsEngine {
   std::unique_ptr<TaskRunner> task_runner_;
 
   // The plugin messenger handle given to API clients.
-  fml::RefPtr<FlutterDesktopMessenger> messenger_;
+  fml::RefPtr<flutter::FlutterDesktopMessenger> messenger_;
 
   // A wrapper around messenger_ for interacting with client_wrapper-level APIs.
   std::unique_ptr<BinaryMessengerImpl> messenger_wrapper_;

--- a/shell/platform/windows/flutter_windows_engine.h
+++ b/shell/platform/windows/flutter_windows_engine.h
@@ -283,7 +283,7 @@ class FlutterWindowsEngine {
   std::unique_ptr<TaskRunner> task_runner_;
 
   // The plugin messenger handle given to API clients.
-  std::unique_ptr<FlutterDesktopMessenger> messenger_;
+  fml::RefPtr<FlutterDesktopMessenger> messenger_;
 
   // A wrapper around messenger_ for interacting with client_wrapper-level APIs.
   std::unique_ptr<BinaryMessengerImpl> messenger_wrapper_;

--- a/shell/platform/windows/public/flutter_windows.h
+++ b/shell/platform/windows/public/flutter_windows.h
@@ -181,6 +181,8 @@ FlutterDesktopEngineGetPluginRegistrar(FlutterDesktopEngineRef engine,
                                        const char* plugin_name);
 
 // Returns the messenger associated with the engine.
+//
+// This does not effect the reference count of the FlutterDesktopMessenger.
 FLUTTER_EXPORT FlutterDesktopMessengerRef
 FlutterDesktopEngineGetMessenger(FlutterDesktopEngineRef engine);
 

--- a/shell/platform/windows/public/flutter_windows.h
+++ b/shell/platform/windows/public/flutter_windows.h
@@ -182,7 +182,11 @@ FlutterDesktopEngineGetPluginRegistrar(FlutterDesktopEngineRef engine,
 
 // Returns the messenger associated with the engine.
 //
-// This does not effect the reference count of the FlutterDesktopMessenger.
+// This does not provide an owning reference, so should *not* be balanced with a
+// call to |FlutterDesktopMessengerRelease|.
+//
+// Callers should use |FlutterDesktopMessengerAddRef| if the returned pointer
+// will potentially outlive 'engine', such as when passing it to another thread.
 FLUTTER_EXPORT FlutterDesktopMessengerRef
 FlutterDesktopEngineGetMessenger(FlutterDesktopEngineRef engine);
 

--- a/shell/platform/windows/window_state.h
+++ b/shell/platform/windows/window_state.h
@@ -5,6 +5,8 @@
 #ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_FLUTTER_WINDOW_STATE_H_
 #define FLUTTER_SHELL_PLATFORM_WINDOWS_FLUTTER_WINDOW_STATE_H_
 
+#include <mutex>
+
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/plugin_registrar.h"
 #include "flutter/shell/platform/common/incoming_message_dispatcher.h"
 #include "flutter/shell/platform/embedder/embedder.h"
@@ -36,8 +38,31 @@ struct FlutterDesktopPluginRegistrar {
 // Wrapper to distinguish the messenger ref from the engine ref given out
 // in the C API.
 struct FlutterDesktopMessenger {
+ public:
+  FlutterDesktopMessenger() = default;
+  flutter::FlutterWindowsEngine* GetEngine() const { return engine; }
+  void SetEngine(flutter::FlutterWindowsEngine* arg_engine) {
+    std::scoped_lock lock(mutex_);
+    engine = arg_engine;
+  }
+  FlutterDesktopMessenger* AddRef() {
+    ref_count_.fetch_add(1);
+    return this;
+  }
+  void Release() {
+    int32_t old_count = ref_count_.fetch_sub(1);
+    if (old_count <= 1) {
+      delete this;
+    }
+  }
+  std::mutex& GetMutex() { return mutex_; }
+
+ private:
+  FML_DISALLOW_COPY_AND_ASSIGN(FlutterDesktopMessenger);
   // The engine that owns this state object.
   flutter::FlutterWindowsEngine* engine = nullptr;
+  std::mutex mutex_;
+  std::atomic<int32_t> ref_count_ = 0;
 };
 
 #endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_FLUTTER_WINDOW_STATE_H_

--- a/shell/platform/windows/window_state.h
+++ b/shell/platform/windows/window_state.h
@@ -5,8 +5,6 @@
 #ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_FLUTTER_WINDOW_STATE_H_
 #define FLUTTER_SHELL_PLATFORM_WINDOWS_FLUTTER_WINDOW_STATE_H_
 
-#include <mutex>
-
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/plugin_registrar.h"
 #include "flutter/shell/platform/common/incoming_message_dispatcher.h"
 #include "flutter/shell/platform/embedder/embedder.h"
@@ -37,54 +35,6 @@ struct FlutterDesktopPluginRegistrar {
 
 // Wrapper to distinguish the messenger ref from the engine ref given out
 // in the C API.
-struct FlutterDesktopMessenger {
- public:
-  FlutterDesktopMessenger() = default;
-
-  /// Getter for the engine field.
-  flutter::FlutterWindowsEngine* GetEngine() const { return engine; }
-
-  /// Setter for the engine field.
-  /// Thread-safe.
-  void SetEngine(flutter::FlutterWindowsEngine* arg_engine) {
-    std::scoped_lock lock(mutex_);
-    engine = arg_engine;
-  }
-
-  /// Increments the reference count.
-  ///
-  /// Thread-safe.
-  FlutterDesktopMessenger* AddRef() {
-    ref_count_.fetch_add(1);
-    return this;
-  }
-
-  /// Decrements the reference count and deletes the object if the count has
-  /// gone to zero.
-  ///
-  /// Thread-safe.
-  void Release() {
-    int32_t old_count = ref_count_.fetch_sub(1);
-    if (old_count <= 1) {
-      delete this;
-    }
-  }
-
-  /// Returns the mutex associated with the |FlutterDesktopMessenger|.
-  ///
-  /// This mutex is used to synchronize reading or writing state inside the
-  /// |FlutterDesktopMessenger| (ie |engine|).
-  std::mutex& GetMutex() { return mutex_; }
-
-  FlutterDesktopMessenger(const FlutterDesktopMessenger& value) = delete;
-  FlutterDesktopMessenger& operator=(const FlutterDesktopMessenger& value) =
-      delete;
-
- private:
-  // The engine that owns this state object.
-  flutter::FlutterWindowsEngine* engine = nullptr;
-  std::mutex mutex_;
-  std::atomic<int32_t> ref_count_ = 0;
-};
+struct FlutterDesktopMessenger {};
 
 #endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_FLUTTER_WINDOW_STATE_H_

--- a/shell/platform/windows/window_state.h
+++ b/shell/platform/windows/window_state.h
@@ -33,8 +33,4 @@ struct FlutterDesktopPluginRegistrar {
   flutter::FlutterWindowsEngine* engine = nullptr;
 };
 
-// Wrapper to distinguish the messenger ref from the engine ref given out
-// in the C API.
-struct FlutterDesktopMessenger {};
-
 #endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_FLUTTER_WINDOW_STATE_H_

--- a/shell/platform/windows/window_state.h
+++ b/shell/platform/windows/window_state.h
@@ -40,25 +40,47 @@ struct FlutterDesktopPluginRegistrar {
 struct FlutterDesktopMessenger {
  public:
   FlutterDesktopMessenger() = default;
+
+  /// Getter for the engine field.
   flutter::FlutterWindowsEngine* GetEngine() const { return engine; }
+
+  /// Setter for the engine field.
+  /// Thread-safe.
   void SetEngine(flutter::FlutterWindowsEngine* arg_engine) {
     std::scoped_lock lock(mutex_);
     engine = arg_engine;
   }
+
+  /// Increments the reference count.
+  ///
+  /// Thread-safe.
   FlutterDesktopMessenger* AddRef() {
     ref_count_.fetch_add(1);
     return this;
   }
+
+  /// Decrements the reference count and deletes the object if the count has
+  /// gone to zero.
+  ///
+  /// Thread-safe.
   void Release() {
     int32_t old_count = ref_count_.fetch_sub(1);
     if (old_count <= 1) {
       delete this;
     }
   }
+
+  /// Returns the mutex associated with the |FlutterDesktopMessenger|.
+  ///
+  /// This mutex is used to synchronize reading or writing state inside the
+  /// |FlutterDesktopMessenger| (ie |engine|).
   std::mutex& GetMutex() { return mutex_; }
 
+  FlutterDesktopMessenger(const FlutterDesktopMessenger& value) = delete;
+  FlutterDesktopMessenger& operator=(const FlutterDesktopMessenger& value) =
+      delete;
+
  private:
-  FML_DISALLOW_COPY_AND_ASSIGN(FlutterDesktopMessenger);
   // The engine that owns this state object.
   flutter::FlutterWindowsEngine* engine = nullptr;
   std::mutex mutex_;


### PR DESCRIPTION
This makes it so platform message handlers on Windows can invoke their replies from any thread.  The reason this is possible is:
* There is little actual work that is happening on the thread invoking the reply.  It has mostly to do with manipulating resources uniquely assigned to the message and thread hopping to the ui thread.
* We've introduced a lock that makes sure the dispatcher used to handle messages isn't deleted while the background thread is invoking the reply.
* We decoupled the FlutterDesktopMessenger from the Engine so that the FlutterDesktopMessenger can outlive the Engine but be in an invalid state.  (This surfaced a bug that already existed in the implementation since a reply could always have outlasted an engine).

issue: https://github.com/flutter/flutter/issues/93945

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
