### PR TITLE
Provide fallback vsync target time for `window.render`

### DIFF
--- a/lib/ui/dart_ui.cc
+++ b/lib/ui/dart_ui.cc
@@ -92,7 +92,7 @@ typedef CanvasPath Path;
   V(NativeStringAttribute::initSpellOutStringAttribute, 3)            \
   V(PlatformConfigurationNativeApi::DefaultRouteName, 0)              \
   V(PlatformConfigurationNativeApi::ScheduleFrame, 0)                 \
-  V(PlatformConfigurationNativeApi::Render, 1)                        \
+  V(PlatformConfigurationNativeApi::Render, 2)                        \
   V(PlatformConfigurationNativeApi::UpdateSemantics, 1)               \
   V(PlatformConfigurationNativeApi::SetNeedsReportTimings, 1)         \
   V(PlatformConfigurationNativeApi::SetIsolateDebugName, 1)           \

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -262,10 +262,11 @@ abstract class FlutterView {
   ///   scheduling of frames.
   /// * [RendererBinding], the Flutter framework class which manages layout and
   ///   painting.
-  void render(Scene scene) => _render(scene);
+  void render(Scene scene, {Duration? fallbackVsyncTargetTime}) => _render(scene,
+      fallbackVsyncTargetTime == null ? -1 : (fallbackVsyncTargetTime.inMicroseconds * 1000));
 
-  @FfiNative<Void Function(Pointer<Void>)>('PlatformConfigurationNativeApi::Render')
-  external static void _render(Scene scene);
+  @FfiNative<Void Function(Pointer<Void>, Int64)>('PlatformConfigurationNativeApi::Render')
+  external static void _render(Scene scene, int fallbackVsyncTargetTime);
 
   /// Change the retained semantics data about this [FlutterView].
   ///

--- a/lib/ui/window/platform_configuration.cc
+++ b/lib/ui/window/platform_configuration.cc
@@ -272,9 +272,18 @@ void PlatformConfiguration::CompletePlatformMessageResponse(
   response->Complete(std::make_unique<fml::DataMapping>(std::move(data)));
 }
 
-void PlatformConfigurationNativeApi::Render(Scene* scene) {
+void PlatformConfigurationNativeApi::Render(
+    Scene* scene,
+    int64_t fallback_vsync_target_time) {
   UIDartState::ThrowIfUIOperationsProhibited();
-  UIDartState::Current()->platform_configuration()->client()->Render(scene);
+
+  std::optional<fml::TimePoint> fallback_vsync_target_time_converted =
+      fallback_vsync_target_time <= 0 ? std::nullopt
+                                      : std::optional(fml::TimePoint::FromTicks(
+                                            fallback_vsync_target_time));
+
+  UIDartState::Current()->platform_configuration()->client()->Render(
+      scene, fallback_vsync_target_time_converted);
 }
 
 void PlatformConfigurationNativeApi::SetNeedsReportTimings(bool value) {

--- a/lib/ui/window/platform_configuration.h
+++ b/lib/ui/window/platform_configuration.h
@@ -68,7 +68,9 @@ class PlatformConfigurationClient {
   /// @brief      Updates the client's rendering on the GPU with the newly
   ///             provided Scene.
   ///
-  virtual void Render(Scene* scene) = 0;
+  virtual void Render(
+      Scene* scene,
+      std::optional<fml::TimePoint> fallback_vsync_target_time) = 0;
 
   //--------------------------------------------------------------------------
   /// @brief      Receives a updated semantics tree from the Framework.
@@ -473,7 +475,7 @@ class PlatformConfigurationNativeApi {
 
   static void ScheduleFrame();
 
-  static void Render(Scene* scene);
+  static void Render(Scene* scene, int64_t fallback_vsync_target_time);
 
   static void UpdateSemantics(SemanticsUpdate* update);
 

--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -282,8 +282,10 @@ void RuntimeController::ScheduleFrame() {
 }
 
 // |PlatformConfigurationClient|
-void RuntimeController::Render(Scene* scene) {
-  client_.Render(scene->takeLayerTree());
+void RuntimeController::Render(
+    Scene* scene,
+    std::optional<fml::TimePoint> fallback_vsync_target_time) {
+  client_.Render(scene->takeLayerTree(), fallback_vsync_target_time);
 }
 
 // |PlatformConfigurationClient|

--- a/runtime/runtime_controller.h
+++ b/runtime/runtime_controller.h
@@ -606,7 +606,9 @@ class RuntimeController : public PlatformConfigurationClient {
   void ScheduleFrame() override;
 
   // |PlatformConfigurationClient|
-  void Render(Scene* scene) override;
+  void Render(
+      Scene* scene,
+      std::optional<fml::TimePoint> fallback_vsync_target_time) override;
 
   // |PlatformConfigurationClient|
   void UpdateSemantics(SemanticsUpdate* update) override;

--- a/runtime/runtime_delegate.h
+++ b/runtime/runtime_delegate.h
@@ -25,7 +25,9 @@ class RuntimeDelegate {
 
   virtual void ScheduleFrame(bool regenerate_layer_tree = true) = 0;
 
-  virtual void Render(std::shared_ptr<flutter::LayerTree> layer_tree) = 0;
+  virtual void Render(
+      std::shared_ptr<flutter::LayerTree> layer_tree,
+      std::optional<fml::TimePoint> fallback_vsync_target_time) = 0;
 
   virtual void UpdateSemantics(SemanticsNodeUpdates update,
                                CustomAccessibilityActionUpdates actions) = 0;

--- a/runtime/runtime_delegate.h
+++ b/runtime/runtime_delegate.h
@@ -25,9 +25,9 @@ class RuntimeDelegate {
 
   virtual void ScheduleFrame(bool regenerate_layer_tree = true) = 0;
 
-  virtual void Render(
-      std::shared_ptr<flutter::LayerTree> layer_tree,
-      std::optional<fml::TimePoint> fallback_vsync_target_time) = 0;
+  virtual void Render(std::shared_ptr<flutter::LayerTree> layer_tree,
+                      std::optional<fml::TimePoint> fallback_vsync_target_time =
+                          std::nullopt) = 0;
 
   virtual void UpdateSemantics(SemanticsNodeUpdates update,
                                CustomAccessibilityActionUpdates actions) = 0;

--- a/shell/common/animator.h
+++ b/shell/common/animator.h
@@ -54,7 +54,8 @@ class Animator final {
 
   void RequestFrame(bool regenerate_layer_tree = true);
 
-  void Render(std::shared_ptr<flutter::LayerTree> layer_tree);
+  void Render(std::shared_ptr<flutter::LayerTree> layer_tree,
+              std::optional<fml::TimePoint> fallback_vsync_target_time);
 
   const std::weak_ptr<VsyncWaiter> GetVsyncWaiter() const;
 

--- a/shell/common/animator.h
+++ b/shell/common/animator.h
@@ -54,8 +54,9 @@ class Animator final {
 
   void RequestFrame(bool regenerate_layer_tree = true);
 
-  void Render(std::shared_ptr<flutter::LayerTree> layer_tree,
-              std::optional<fml::TimePoint> fallback_vsync_target_time);
+  void Render(
+      std::shared_ptr<flutter::LayerTree> layer_tree,
+      std::optional<fml::TimePoint> fallback_vsync_target_time = std::nullopt);
 
   const std::weak_ptr<VsyncWaiter> GetVsyncWaiter() const;
 

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -441,7 +441,8 @@ void Engine::ScheduleFrame(bool regenerate_layer_tree) {
   animator_->RequestFrame(regenerate_layer_tree);
 }
 
-void Engine::Render(std::shared_ptr<flutter::LayerTree> layer_tree) {
+void Engine::Render(std::shared_ptr<flutter::LayerTree> layer_tree,
+                    std::optional<fml::TimePoint> fallback_vsync_target_time) {
   if (!layer_tree) {
     return;
   }
@@ -452,7 +453,7 @@ void Engine::Render(std::shared_ptr<flutter::LayerTree> layer_tree) {
     return;
   }
 
-  animator_->Render(std::move(layer_tree));
+  animator_->Render(std::move(layer_tree), fallback_vsync_target_time);
 }
 
 void Engine::UpdateSemantics(SemanticsNodeUpdates update,

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -885,7 +885,9 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
   std::string DefaultRouteName() override;
 
   // |RuntimeDelegate|
-  void Render(std::shared_ptr<flutter::LayerTree> layer_tree) override;
+  void Render(
+      std::shared_ptr<flutter::LayerTree> layer_tree,
+      std::optional<fml::TimePoint> fallback_vsync_target_time) override;
 
   // |RuntimeDelegate|
   void UpdateSemantics(SemanticsNodeUpdates update,

--- a/shell/common/engine_unittests.cc
+++ b/shell/common/engine_unittests.cc
@@ -50,7 +50,9 @@ class MockRuntimeDelegate : public RuntimeDelegate {
  public:
   MOCK_METHOD0(DefaultRouteName, std::string());
   MOCK_METHOD1(ScheduleFrame, void(bool));
-  MOCK_METHOD1(Render, void(std::shared_ptr<flutter::LayerTree>));
+  MOCK_METHOD2(Render,
+               void(std::shared_ptr<flutter::LayerTree>,
+                    std::optional<fml::TimePoint>));
   MOCK_METHOD2(UpdateSemantics,
                void(SemanticsNodeUpdates, CustomAccessibilityActionUpdates));
   MOCK_METHOD1(HandlePlatformMessage, void(std::unique_ptr<PlatformMessage>));


### PR DESCRIPTION

1. I will finish code details, refine code, add tests, make tests pass, etc, after a code review that thinks the *rough idea* is acceptable. It is because, from my past experience, reviews may request changing a lot. If the general idea is to be changed, all detailed implementation efforts are wasted :)
2. The PR has an already-working counterpart, and it produces ~60FPS smooth experimental results. The benchmark results and detailed analysis is in chapter https://cjycode.com/flutter_smooth/benchmark/. All the source code is in  https://github.com/fzyzcjy/engine/tree/flutter-smooth and https://github.com/fzyzcjy/flutter/tree/flutter-smooth.
3. Possibly useful as a context to this PR, there is a whole chapter discussing the internals - how flutter_smooth is implemented. (Link: https://cjycode.com/flutter_smooth/design/)

---


This works together with a few other PRs: https://github.com/flutter/engine/pull/36438 (to support multi render), https://github.com/flutter/engine/pull/36837 (which consumes vsync tagret time).

In order to make https://github.com/flutter/engine/pull/36837 and other Flutter logic work, we need to provide the correct vsync target time. However, currently the fallback target time is filled as the current time, which is surely incorrect and caused bugs for things like https://github.com/flutter/engine/pull/36837.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests. -- see above
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
