### PR TITLE
Enable a frame to be scheduled immediately

### DIFF
--- a/lib/ui/dart_ui.cc
+++ b/lib/ui/dart_ui.cc
@@ -91,7 +91,7 @@ typedef CanvasPath Path;
   V(NativeStringAttribute::initLocaleStringAttribute, 4)              \
   V(NativeStringAttribute::initSpellOutStringAttribute, 3)            \
   V(PlatformConfigurationNativeApi::DefaultRouteName, 0)              \
-  V(PlatformConfigurationNativeApi::ScheduleFrame, 0)                 \
+  V(PlatformConfigurationNativeApi::ScheduleFrame, 1)                 \
   V(PlatformConfigurationNativeApi::Render, 1)                        \
   V(PlatformConfigurationNativeApi::UpdateSemantics, 1)               \
   V(PlatformConfigurationNativeApi::SetNeedsReportTimings, 1)         \

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -715,10 +715,13 @@ class PlatformDispatcher {
   ///
   ///  * [SchedulerBinding], the Flutter framework class which manages the
   ///    scheduling of frames.
-  void scheduleFrame() => _scheduleFrame();
+  void scheduleFrame({Duration? forceDirectlyCallNextVsyncTargetTime}) =>
+      _scheduleFrame(forceDirectlyCallNextVsyncTargetTime == null
+          ? -1
+          : forceDirectlyCallNextVsyncTargetTime.inMicroseconds);
 
-  @FfiNative<Void Function()>('PlatformConfigurationNativeApi::ScheduleFrame')
-  external static void _scheduleFrame();
+  @FfiNative<Void Function(Int64)>('PlatformConfigurationNativeApi::ScheduleFrame')
+  external static void _scheduleFrame(int forceDirectlyCallNextVsyncTargetTime);
 
   /// Additional accessibility features that may be enabled by the platform.
   AccessibilityFeatures get accessibilityFeatures => configuration.accessibilityFeatures;

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -674,7 +674,9 @@ class SingletonFlutterWindow extends FlutterWindow {
   ///
   /// * [SchedulerBinding], the Flutter framework class which manages the
   ///   scheduling of frames.
-  void scheduleFrame() => platformDispatcher.scheduleFrame();
+  void scheduleFrame({Duration? forceDirectlyCallNextVsyncTargetTime}) =>
+      platformDispatcher.scheduleFrame(
+          forceDirectlyCallNextVsyncTargetTime: forceDirectlyCallNextVsyncTargetTime);
 
   /// Whether the user has requested that [updateSemantics] be called when
   /// the semantic contents of window changes.

--- a/lib/ui/window/platform_configuration.cc
+++ b/lib/ui/window/platform_configuration.cc
@@ -392,9 +392,18 @@ Dart_Handle PlatformConfigurationNativeApi::GetPersistentIsolateData() {
                                      persistent_isolate_data->GetSize());
 }
 
-void PlatformConfigurationNativeApi::ScheduleFrame() {
+void PlatformConfigurationNativeApi::ScheduleFrame(
+    int64_t force_directly_call_next_vsync_target_time_microseconds) {
+  std::optional<fml::TimePoint> force_directly_call_next_vsync_target_time =
+      force_directly_call_next_vsync_target_time_microseconds <= 0
+          ? std::nullopt
+          : std::optional(fml::TimePoint::FromTicks(
+                force_directly_call_next_vsync_target_time_microseconds *
+                1000));
+
   UIDartState::ThrowIfUIOperationsProhibited();
-  UIDartState::Current()->platform_configuration()->client()->ScheduleFrame();
+  UIDartState::Current()->platform_configuration()->client()->ScheduleFrame(
+      force_directly_call_next_vsync_target_time);
 }
 
 void PlatformConfigurationNativeApi::UpdateSemantics(SemanticsUpdate* update) {

--- a/lib/ui/window/platform_configuration.h
+++ b/lib/ui/window/platform_configuration.h
@@ -62,7 +62,9 @@ class PlatformConfigurationClient {
   /// @brief      Requests that, at the next appropriate opportunity, a new
   ///             frame be scheduled for rendering.
   ///
-  virtual void ScheduleFrame() = 0;
+  virtual void ScheduleFrame(
+      std::optional<fml::TimePoint>
+          force_directly_call_next_vsync_target_time) = 0;
 
   //--------------------------------------------------------------------------
   /// @brief      Updates the client's rendering on the GPU with the newly
@@ -471,7 +473,8 @@ class PlatformConfigurationNativeApi {
  public:
   static std::string DefaultRouteName();
 
-  static void ScheduleFrame();
+  static void ScheduleFrame(
+      int64_t force_directly_call_next_vsync_target_time_microseconds);
 
   static void Render(Scene* scene);
 

--- a/lib/web_ui/lib/platform_dispatcher.dart
+++ b/lib/web_ui/lib/platform_dispatcher.dart
@@ -74,7 +74,7 @@ abstract class PlatformDispatcher {
 
   ByteData? getPersistentIsolateData() => null;
 
-  void scheduleFrame();
+  void scheduleFrame({Duration? forceDirectlyCallNextVsyncTargetTime});
 
   void render(Scene scene, [FlutterView view]);
 

--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -627,7 +627,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
   ///  * [SchedulerBinding], the Flutter framework class which manages the
   ///    scheduling of frames.
   @override
-  void scheduleFrame() {
+  void scheduleFrame({Duration? forceDirectlyCallNextVsyncTargetTime}) {
     if (scheduleFrameCallback == null) {
       throw Exception('scheduleFrameCallback must be initialized first.');
     }

--- a/lib/web_ui/lib/window.dart
+++ b/lib/web_ui/lib/window.dart
@@ -101,7 +101,8 @@ abstract class SingletonFlutterWindow extends FlutterWindow {
 
   String get defaultRouteName => platformDispatcher.defaultRouteName;
 
-  void scheduleFrame() => platformDispatcher.scheduleFrame();
+  void scheduleFrame({Duration? forceDirectlyCallNextVsyncTargetTime}) =>
+      platformDispatcher.scheduleFrame(forceDirectlyCallNextVsyncTargetTime: forceDirectlyCallNextVsyncTargetTime);
 
   @override
   void render(Scene scene) => platformDispatcher.render(scene, this);

--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -277,8 +277,9 @@ std::string RuntimeController::DefaultRouteName() {
 }
 
 // |PlatformConfigurationClient|
-void RuntimeController::ScheduleFrame() {
-  client_.ScheduleFrame();
+void RuntimeController::ScheduleFrame(
+    std::optional<fml::TimePoint> force_directly_call_next_vsync_target_time) {
+  client_.ScheduleFrame(true, force_directly_call_next_vsync_target_time);
 }
 
 // |PlatformConfigurationClient|

--- a/runtime/runtime_controller.h
+++ b/runtime/runtime_controller.h
@@ -603,7 +603,8 @@ class RuntimeController : public PlatformConfigurationClient {
   std::string DefaultRouteName() override;
 
   // |PlatformConfigurationClient|
-  void ScheduleFrame() override;
+  void ScheduleFrame(std::optional<fml::TimePoint>
+                         force_directly_call_next_vsync_target_time) override;
 
   // |PlatformConfigurationClient|
   void Render(Scene* scene) override;

--- a/runtime/runtime_delegate.h
+++ b/runtime/runtime_delegate.h
@@ -23,7 +23,10 @@ class RuntimeDelegate {
  public:
   virtual std::string DefaultRouteName() = 0;
 
-  virtual void ScheduleFrame(bool regenerate_layer_tree = true) = 0;
+  virtual void ScheduleFrame(
+      bool regenerate_layer_tree = true,
+      std::optional<fml::TimePoint> force_directly_call_next_vsync_target_time =
+          std::nullopt) = 0;
 
   virtual void Render(std::shared_ptr<flutter::LayerTree> layer_tree) = 0;
 

--- a/shell/common/animator.h
+++ b/shell/common/animator.h
@@ -52,7 +52,10 @@ class Animator final {
 
   ~Animator();
 
-  void RequestFrame(bool regenerate_layer_tree = true);
+  void RequestFrame(
+      bool regenerate_layer_tree = true,
+      std::optional<fml::TimePoint> force_directly_call_next_vsync_target_time =
+          std::nullopt);
 
   void Render(std::shared_ptr<flutter::LayerTree> layer_tree);
 
@@ -89,7 +92,9 @@ class Animator final {
   void DrawLastLayerTree(
       std::unique_ptr<FrameTimingsRecorder> frame_timings_recorder);
 
-  void AwaitVSync();
+  void AwaitVSync(
+      std::optional<fml::TimePoint> force_directly_call_next_vsync_target_time,
+      int curr_await_vsync_id);
 
   // Clear |trace_flow_ids_| if |frame_scheduled_| is false.
   void ScheduleMaybeClearTraceFlowIds();
@@ -110,6 +115,8 @@ class Animator final {
   SkISize last_layer_tree_size_ = {0, 0};
   std::deque<uint64_t> trace_flow_ids_;
   bool has_rendered_ = false;
+  std::atomic<std::optional<int>> pending_await_vsync_id_{std::nullopt};
+  std::atomic<int> next_await_vsync_id_{0};
 
   fml::WeakPtrFactory<Animator> weak_factory_;
 

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -437,8 +437,11 @@ std::string Engine::DefaultRouteName() {
   return "/";
 }
 
-void Engine::ScheduleFrame(bool regenerate_layer_tree) {
-  animator_->RequestFrame(regenerate_layer_tree);
+void Engine::ScheduleFrame(
+    bool regenerate_layer_tree,
+    std::optional<fml::TimePoint> force_directly_call_next_vsync_target_time) {
+  animator_->RequestFrame(regenerate_layer_tree,
+                          force_directly_call_next_vsync_target_time);
 }
 
 void Engine::Render(std::shared_ptr<flutter::LayerTree> layer_tree) {

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -753,7 +753,10 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
   void SetAccessibilityFeatures(int32_t flags);
 
   // |RuntimeDelegate|
-  void ScheduleFrame(bool regenerate_layer_tree) override;
+  void ScheduleFrame(
+      bool regenerate_layer_tree,
+      std::optional<fml::TimePoint> force_directly_call_next_vsync_target_time =
+          std::nullopt) override;
 
   /// Schedule a frame with the default parameter of regenerating the layer
   /// tree.


### PR DESCRIPTION
1. I will finish code details, refine code, add tests, make tests pass, etc, after a code review that thinks the *rough idea* is acceptable. It is because, from my past experience, reviews may request changing a lot. If the general idea is to be changed, all detailed implementation efforts are wasted :)
2. The PR has an already-working counterpart, and it produces ~60FPS smooth experimental results. The benchmark results and detailed analysis is in chapter https://cjycode.com/flutter_smooth/benchmark/. All the source code is in  https://github.com/fzyzcjy/engine/tree/flutter-smooth and https://github.com/fzyzcjy/flutter/tree/flutter-smooth.
3. Possibly useful as a context to this PR, there is a whole chapter discussing the internals - how flutter_smooth is implemented. (Link: https://cjycode.com/flutter_smooth/design/)

---


This PR depends on the merging of https://github.com/flutter/engine/pull/36911.

This PR is needed by flutter_smooth, because of the "Brake" mechanism discussed in https://github.com/fzyzcjy/flutter_smooth/blob/feat%2Fdoc-insight/website/docs/design/infra/brake/intro.md (TODO@fzyzcjy: post website link when it is published). In short, for that mechanism to work without jank, a frame must be able to be started immediately instead of waiting for the next vsync (otherwise we must have a jank).

More specifically, let's analyze the figure in the Brake mechanism. The red arrow points where we need this PR. If this PR is not there, the frame cannot start at time=2.6, but have to start at time=3. Then, even though we have preempt render mechanism, we are not able to produce scene and rasterizer quick enough before time=4, so we will have a jank.

![image](https://user-images.githubusercontent.com/5236035/197199138-74d1c21a-0839-4c21-94bb-2e0774b8b22e.png)


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on 
writing and running engine tests. -- see above
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
