### PR TITLE
[Impeller] Eliminate unused shader output

### DIFF
--- a/impeller/entity/shaders/position.vert
+++ b/impeller/entity/shaders/position.vert
@@ -12,10 +12,8 @@ uniform VertInfo {
 in vec2 position;
 
 out vec4 v_color;
-out vec2 v_position;
 
 void main() {
   gl_Position = vert_info.mvp * vec4(position, 0.0, 1.0);
   v_color = vert_info.color;
-  v_position = IPVec2TransformPosition(vert_info.mvp, position);
 }

--- a/impeller/entity/shaders/position_color.vert
+++ b/impeller/entity/shaders/position_color.vert
@@ -12,10 +12,8 @@ in vec2 position;
 in vec4 color;
 
 out vec4 v_color;
-out vec2 v_position;
 
 void main() {
   gl_Position = vert_info.mvp * vec4(position, 0.0, 1.0);
   v_color = color;
-  v_position = IPVec2TransformPosition(vert_info.mvp, position);
 }

--- a/impeller/renderer/backend/vulkan/pipeline_library_vk.cc
+++ b/impeller/renderer/backend/vulkan/pipeline_library_vk.cc
@@ -387,7 +387,8 @@ std::unique_ptr<PipelineCreateInfoVK> PipelineLibraryVK::CreatePipeline(
   auto pipeline =
       device_.createGraphicsPipelineUnique(cache_.get(), pipeline_info);
   if (pipeline.result != vk::Result::eSuccess) {
-    VALIDATION_LOG << "Could not create graphics pipeline: " << desc.GetLabel();
+    VALIDATION_LOG << "Could not create graphics pipeline - " << desc.GetLabel()
+                   << ": " << vk::to_string(pipeline.result);
     return nullptr;
   }
 


### PR DESCRIPTION
This eliminates the `v_position` output for `position.vert` and `position_color.vert`.
