### PR TITLE
[canvaskit] Don't bundle an embedded font

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -610,7 +610,8 @@ def to_gn_wasm_args(args, gn_args):
   gn_args['skia_use_libheif'] = False
   gn_args['skia_enable_fontmgr_custom_directory'] = False
   gn_args['skia_enable_fontmgr_custom_embedded'] = True
-  gn_args['skia_enable_fontmgr_custom_empty'] = False
+  gn_args['skia_enable_fontmgr_custom_empty'] = True
+  gn_args['skia_fontmgr_factory'] = "//third_party/skia:fontmgr_custom_empty_factory"
   gn_args['skia_enable_skshaper'] = True
   gn_args['skia_enable_skparagraph'] = True
   gn_args['skia_canvaskit_force_tracing'] = False

--- a/tools/gn
+++ b/tools/gn
@@ -626,7 +626,7 @@ def to_gn_wasm_args(args, gn_args):
   gn_args['skia_canvaskit_enable_matrix_helper'] = False
   gn_args['skia_canvaskit_enable_canvas_bindings'] = False
   gn_args['skia_canvaskit_enable_font'] = True
-  gn_args['skia_canvaskit_enable_embedded_font'] = True
+  gn_args['skia_canvaskit_enable_embedded_font'] = False
   gn_args['skia_canvaskit_enable_alias_font'] = True
   gn_args['skia_canvaskit_legacy_draw_vertices_blend_mode'] = False
   gn_args['skia_canvaskit_enable_debugger'] = False

--- a/tools/gn
+++ b/tools/gn
@@ -612,7 +612,7 @@ def to_gn_wasm_args(args, gn_args):
   gn_args['skia_enable_fontmgr_custom_embedded'] = True
   gn_args['skia_enable_fontmgr_custom_empty'] = True
   gn_args['skia_fontmgr_factory'
-         ] = "//third_party/skia:fontmgr_custom_empty_factory"
+         ] = '//third_party/skia:fontmgr_custom_empty_factory'
   gn_args['skia_enable_skshaper'] = True
   gn_args['skia_enable_skparagraph'] = True
   gn_args['skia_canvaskit_force_tracing'] = False

--- a/tools/gn
+++ b/tools/gn
@@ -611,7 +611,8 @@ def to_gn_wasm_args(args, gn_args):
   gn_args['skia_enable_fontmgr_custom_directory'] = False
   gn_args['skia_enable_fontmgr_custom_embedded'] = True
   gn_args['skia_enable_fontmgr_custom_empty'] = True
-  gn_args['skia_fontmgr_factory'] = "//third_party/skia:fontmgr_custom_empty_factory"
+  gn_args['skia_fontmgr_factory'
+         ] = "//third_party/skia:fontmgr_custom_empty_factory"
   gn_args['skia_enable_skshaper'] = True
   gn_args['skia_enable_skparagraph'] = True
   gn_args['skia_canvaskit_force_tracing'] = False


### PR DESCRIPTION
This removes the embedded font in CanvasKit. Since we always provide Roboto font, this is not required.

With this change, we remove 69.9 kb from the gzipped canvaskit.wasm (from 2296455 bytes to 2224892 bytes).

Fixes https://github.com/flutter/flutter/issues/112397

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
