### PR TITLE
Remove unused top and left margins from `PlatformViewRequest`

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformViewsChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformViewsChannel.java
@@ -95,10 +95,8 @@ public class PlatformViewsChannel {
                   new PlatformViewCreationRequest(
                       (int) createArgs.get("id"),
                       (String) createArgs.get("viewType"),
-                      0,
-                      0,
-                      0,
-                      0,
+                      0.0,
+                      0.0,
                       (int) createArgs.get("direction"),
                       PlatformViewCreationRequest.RequestedDisplayMode.HYBRID_ONLY,
                       additionalParams);
@@ -118,8 +116,6 @@ public class PlatformViewsChannel {
                   new PlatformViewCreationRequest(
                       (int) createArgs.get("id"),
                       (String) createArgs.get("viewType"),
-                      createArgs.containsKey("top") ? (double) createArgs.get("top") : 0.0,
-                      createArgs.containsKey("left") ? (double) createArgs.get("left") : 0.0,
                       (double) createArgs.get("width"),
                       (double) createArgs.get("height"),
                       (int) createArgs.get("direction"),
@@ -387,12 +383,6 @@ public class PlatformViewsChannel {
     /** The density independent height to display the platform view. */
     public final double logicalHeight;
 
-    /** The density independent top position to display the platform view. */
-    public final double logicalTop;
-
-    /** The density independent left position to display the platform view. */
-    public final double logicalLeft;
-
     /**
      * The layout direction of the new platform view.
      *
@@ -410,8 +400,6 @@ public class PlatformViewsChannel {
     public PlatformViewCreationRequest(
         int viewId,
         @NonNull String viewType,
-        double logicalTop,
-        double logicalLeft,
         double logicalWidth,
         double logicalHeight,
         int direction,
@@ -419,8 +407,6 @@ public class PlatformViewsChannel {
       this(
           viewId,
           viewType,
-          logicalTop,
-          logicalLeft,
           logicalWidth,
           logicalHeight,
           direction,
@@ -432,8 +418,6 @@ public class PlatformViewsChannel {
     public PlatformViewCreationRequest(
         int viewId,
         @NonNull String viewType,
-        double logicalTop,
-        double logicalLeft,
         double logicalWidth,
         double logicalHeight,
         int direction,
@@ -441,8 +425,6 @@ public class PlatformViewsChannel {
         @Nullable ByteBuffer params) {
       this.viewId = viewId;
       this.viewType = viewType;
-      this.logicalTop = logicalTop;
-      this.logicalLeft = logicalLeft;
       this.logicalWidth = logicalWidth;
       this.logicalHeight = logicalHeight;
       this.direction = direction;

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -607,8 +607,8 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
               new FrameLayout.LayoutParams(physicalWidth, physicalHeight);
 
           // Size and position the view wrapper.
-          final int physicalTop = 0; //toPhysicalPixels(request.logicalTop);
-          final int physicalLeft = 0; //toPhysicalPixels(request.logicalLeft);
+          final int physicalTop = 0; // toPhysicalPixels(request.logicalTop);
+          final int physicalLeft = 0; // toPhysicalPixels(request.logicalLeft);
           viewWrapperLayoutParams.topMargin = physicalTop;
           viewWrapperLayoutParams.leftMargin = physicalLeft;
           viewWrapper.setLayoutParams(viewWrapperLayoutParams);

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -304,6 +304,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
           layoutParams.topMargin = physicalTop;
           layoutParams.leftMargin = physicalLeft;
           viewWrapper.setLayoutParams(layoutParams);
+          viewWrapper.setVisibility(View.VISIBLE);
         }
 
         @Override
@@ -606,8 +607,8 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
               new FrameLayout.LayoutParams(physicalWidth, physicalHeight);
 
           // Size and position the view wrapper.
-          final int physicalTop = toPhysicalPixels(request.logicalTop);
-          final int physicalLeft = toPhysicalPixels(request.logicalLeft);
+          final int physicalTop = 0; //toPhysicalPixels(request.logicalTop);
+          final int physicalLeft = 0; //toPhysicalPixels(request.logicalLeft);
           viewWrapperLayoutParams.topMargin = physicalTop;
           viewWrapperLayoutParams.leftMargin = physicalLeft;
           viewWrapper.setLayoutParams(viewWrapperLayoutParams);
@@ -639,6 +640,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
                   textInputPlugin.clearPlatformViewClient(request.viewId);
                 }
               });
+          viewWrapper.setVisibility(View.INVISIBLE);
           flutterView.addView(viewWrapper);
           viewWrappers.append(request.viewId, viewWrapper);
           return textureId;


### PR DESCRIPTION
Looking at the framework code in the link below, there is never any `top` or `left` parameters passed to Android when creating a platform view.

https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/services/platform_views.dart#L1186

For TLHC (Texture Layer Hybrid Composition), this makes the Android View hierarchy think the PlatformView is onscreen at `(0,0)` for the [initial render](https://github.com/flutter/engine/blob/25133f15440dc71d596efbd3b1d7fff54d0213d8/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java#L578) since it is added to the FlutterView (but not drawn). Note that later a PlatformViewsChannel call is made to the [offset method](https://github.com/flutter/engine/blob/25133f15440dc71d596efbd3b1d7fff54d0213d8/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java#L283) to set the top and left margin positions. 

This PR removes the unused margins in the creation request and ....

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
