### PR TITLE
[Impeller] move Geometry methods only used in VerticesContents to VerticesGeometry

### DIFF
--- a/impeller/entity/contents/vertices_contents.cc
+++ b/impeller/entity/contents/vertices_contents.cc
@@ -25,7 +25,7 @@ std::optional<Rect> VerticesContents::GetCoverage(const Entity& entity) const {
   return geometry_->GetCoverage(entity.GetTransformation());
 };
 
-void VerticesContents::SetGeometry(std::unique_ptr<Geometry> geometry) {
+void VerticesContents::SetGeometry(std::unique_ptr<VerticesGeometry> geometry) {
   geometry_ = std::move(geometry);
 }
 

--- a/impeller/entity/contents/vertices_contents.h
+++ b/impeller/entity/contents/vertices_contents.h
@@ -26,7 +26,7 @@ class VerticesContents final : public Contents {
 
   ~VerticesContents() override;
 
-  void SetGeometry(std::unique_ptr<Geometry> geometry);
+  void SetGeometry(std::unique_ptr<VerticesGeometry> geometry);
 
   void SetColor(Color color);
 
@@ -42,7 +42,7 @@ class VerticesContents final : public Contents {
 
  public:
   Color color_;
-  std::unique_ptr<Geometry> geometry_;
+  std::unique_ptr<VerticesGeometry> geometry_;
   BlendMode blend_mode_ = BlendMode::kSource;
 
   FML_DISALLOW_COPY_AND_ASSIGN(VerticesContents);

--- a/impeller/entity/geometry.cc
+++ b/impeller/entity/geometry.cc
@@ -17,7 +17,7 @@ Geometry::Geometry() = default;
 Geometry::~Geometry() = default;
 
 // static
-std::unique_ptr<Geometry> Geometry::MakeVertices(Vertices vertices) {
+std::unique_ptr<VerticesGeometry> Geometry::MakeVertices(Vertices vertices) {
   return std::make_unique<VerticesGeometry>(std::move(vertices));
 }
 
@@ -171,7 +171,8 @@ GeometryResult VerticesGeometry::GetPositionUVBuffer(
     const ContentContext& renderer,
     const Entity& entity,
     RenderPass& pass) {
-  // TODO(jonahwilliams): support texture coordinates in vertices.
+  // TODO(jonahwilliams): support texture coordinates in vertices
+  // https://github.com/flutter/flutter/issues/109956
   return {};
 }
 
@@ -220,24 +221,6 @@ GeometryResult FillPathGeometry::GetPositionBuffer(
       .vertex_buffer = vertex_buffer,
       .prevent_overdraw = false,
   };
-}
-
-GeometryResult FillPathGeometry::GetPositionColorBuffer(
-    const ContentContext& renderer,
-    const Entity& entity,
-    RenderPass& pass,
-    Color paint_color,
-    BlendMode blend_mode) {
-  // TODO(jonahwilliams): support per-color vertex in path geometry.
-  return {};
-}
-
-GeometryResult FillPathGeometry::GetPositionUVBuffer(
-    const ContentContext& renderer,
-    const Entity& entity,
-    RenderPass& pass) {
-  // TODO(jonahwilliams): support texture coordinates in path geometry.
-  return {};
 }
 
 GeometryVertexType FillPathGeometry::GetVertexType() const {
@@ -593,24 +576,6 @@ GeometryResult StrokePathGeometry::GetPositionBuffer(
   };
 }
 
-GeometryResult StrokePathGeometry::GetPositionColorBuffer(
-    const ContentContext& renderer,
-    const Entity& entity,
-    RenderPass& pass,
-    Color paint_color,
-    BlendMode blend_mode) {
-  // TODO(jonahwilliams): support per-color vertex in path geometry.
-  return {};
-}
-
-GeometryResult StrokePathGeometry::GetPositionUVBuffer(
-    const ContentContext& renderer,
-    const Entity& entity,
-    RenderPass& pass) {
-  // TODO(jonahwilliams): support texture coordinates in path geometry.
-  return {};
-}
-
 GeometryVertexType StrokePathGeometry::GetVertexType() const {
   return GeometryVertexType::kPosition;
 }
@@ -667,24 +632,6 @@ GeometryResult CoverGeometry::GetPositionBuffer(const ContentContext& renderer,
                         .index_type = IndexType::k16bit},
       .prevent_overdraw = false,
   };
-}
-
-GeometryResult CoverGeometry::GetPositionColorBuffer(
-    const ContentContext& renderer,
-    const Entity& entity,
-    RenderPass& pass,
-    Color paint_color,
-    BlendMode blend_mode) {
-  // TODO(jonahwilliams): support per-color vertex in cover geometry.
-  return {};
-}
-
-GeometryResult CoverGeometry::GetPositionUVBuffer(
-    const ContentContext& renderer,
-    const Entity& entity,
-    RenderPass& pass) {
-  // TODO(jonahwilliams): support texture coordinates in cover geometry.
-  return {};
 }
 
 GeometryVertexType CoverGeometry::GetVertexType() const {

--- a/impeller/entity/geometry.cc
+++ b/impeller/entity/geometry.cc
@@ -671,23 +671,6 @@ GeometryResult RectGeometry::GetPositionBuffer(const ContentContext& renderer,
   };
 }
 
-GeometryResult RectGeometry::GetPositionColorBuffer(
-    const ContentContext& renderer,
-    const Entity& entity,
-    RenderPass& pass,
-    Color paint_color,
-    BlendMode blend_mode) {
-  // TODO(jonahwilliams): support per-color vertex in rect geometry.
-  return {};
-}
-
-GeometryResult RectGeometry::GetPositionUVBuffer(const ContentContext& renderer,
-                                                 const Entity& entity,
-                                                 RenderPass& pass) {
-  // TODO(jonahwilliams): support texture coordinates in rect geometry.
-  return {};
-}
-
 GeometryVertexType RectGeometry::GetVertexType() const {
   return GeometryVertexType::kPosition;
 }

--- a/impeller/entity/geometry.h
+++ b/impeller/entity/geometry.h
@@ -241,18 +241,6 @@ class RectGeometry : public Geometry {
                                    RenderPass& pass) override;
 
   // |Geometry|
-  GeometryResult GetPositionColorBuffer(const ContentContext& renderer,
-                                        const Entity& entity,
-                                        RenderPass& pass,
-                                        Color paint_color,
-                                        BlendMode blend_mode) override;
-
-  // |Geometry|
-  GeometryResult GetPositionUVBuffer(const ContentContext& renderer,
-                                     const Entity& entity,
-                                     RenderPass& pass) override;
-
-  // |Geometry|
   GeometryVertexType GetVertexType() const override;
 
   // |Geometry|

--- a/impeller/entity/geometry.h
+++ b/impeller/entity/geometry.h
@@ -42,13 +42,15 @@ enum class Join {
   kBevel,
 };
 
+class VerticesGeometry;
+
 class Geometry {
  public:
   Geometry();
 
   virtual ~Geometry();
 
-  static std::unique_ptr<Geometry> MakeVertices(Vertices vertices);
+  static std::unique_ptr<VerticesGeometry> MakeVertices(Vertices vertices);
 
   static std::unique_ptr<Geometry> MakeFillPath(Path path);
 
@@ -65,16 +67,6 @@ class Geometry {
                                            const Entity& entity,
                                            RenderPass& pass) = 0;
 
-  virtual GeometryResult GetPositionColorBuffer(const ContentContext& renderer,
-                                                const Entity& entity,
-                                                RenderPass& pass,
-                                                Color paint_color,
-                                                BlendMode blend_mode) = 0;
-
-  virtual GeometryResult GetPositionUVBuffer(const ContentContext& renderer,
-                                             const Entity& entity,
-                                             RenderPass& pass) = 0;
-
   virtual GeometryVertexType GetVertexType() const = 0;
 
   virtual std::optional<Rect> GetCoverage(const Matrix& transform) const = 0;
@@ -87,30 +79,28 @@ class VerticesGeometry : public Geometry {
 
   ~VerticesGeometry();
 
- private:
+  GeometryResult GetPositionColorBuffer(const ContentContext& renderer,
+                                        const Entity& entity,
+                                        RenderPass& pass,
+                                        Color paint_color,
+                                        BlendMode blend_mode);
+
+  GeometryResult GetPositionUVBuffer(const ContentContext& renderer,
+                                     const Entity& entity,
+                                     RenderPass& pass);
+
   // |Geometry|
   GeometryResult GetPositionBuffer(const ContentContext& renderer,
                                    const Entity& entity,
                                    RenderPass& pass) override;
 
   // |Geometry|
-  GeometryResult GetPositionColorBuffer(const ContentContext& renderer,
-                                        const Entity& entity,
-                                        RenderPass& pass,
-                                        Color paint_color,
-                                        BlendMode blend_mode) override;
-
-  // |Geometry|
-  GeometryResult GetPositionUVBuffer(const ContentContext& renderer,
-                                     const Entity& entity,
-                                     RenderPass& pass) override;
+  std::optional<Rect> GetCoverage(const Matrix& transform) const override;
 
   // |Geometry|
   GeometryVertexType GetVertexType() const override;
 
-  // |Geometry|
-  std::optional<Rect> GetCoverage(const Matrix& transform) const override;
-
+ private:
   Vertices vertices_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(VerticesGeometry);
@@ -128,18 +118,6 @@ class FillPathGeometry : public Geometry {
   GeometryResult GetPositionBuffer(const ContentContext& renderer,
                                    const Entity& entity,
                                    RenderPass& pass) override;
-
-  // |Geometry|
-  GeometryResult GetPositionColorBuffer(const ContentContext& renderer,
-                                        const Entity& entity,
-                                        RenderPass& pass,
-                                        Color paint_color,
-                                        BlendMode blend_mode) override;
-
-  // |Geometry|
-  GeometryResult GetPositionUVBuffer(const ContentContext& renderer,
-                                     const Entity& entity,
-                                     RenderPass& pass) override;
 
   // |Geometry|
   GeometryVertexType GetVertexType() const override;
@@ -193,18 +171,6 @@ class StrokePathGeometry : public Geometry {
                                    RenderPass& pass) override;
 
   // |Geometry|
-  GeometryResult GetPositionColorBuffer(const ContentContext& renderer,
-                                        const Entity& entity,
-                                        RenderPass& pass,
-                                        Color paint_color,
-                                        BlendMode blend_mode) override;
-
-  // |Geometry|
-  GeometryResult GetPositionUVBuffer(const ContentContext& renderer,
-                                     const Entity& entity,
-                                     RenderPass& pass) override;
-
-  // |Geometry|
   GeometryVertexType GetVertexType() const override;
 
   // |Geometry|
@@ -250,18 +216,6 @@ class CoverGeometry : public Geometry {
   GeometryResult GetPositionBuffer(const ContentContext& renderer,
                                    const Entity& entity,
                                    RenderPass& pass) override;
-
-  // |Geometry|
-  GeometryResult GetPositionColorBuffer(const ContentContext& renderer,
-                                        const Entity& entity,
-                                        RenderPass& pass,
-                                        Color paint_color,
-                                        BlendMode blend_mode) override;
-
-  // |Geometry|
-  GeometryResult GetPositionUVBuffer(const ContentContext& renderer,
-                                     const Entity& entity,
-                                     RenderPass& pass) override;
 
   // |Geometry|
   GeometryVertexType GetVertexType() const override;


### PR DESCRIPTION
As @dnfield notes in https://github.com/flutter/engine/pull/36914/files/02e0643cad37becd84e03f21e9ca6f431de6f1ed#r1002228848 , we're picking up a lot of TODOs from me in this file. most of these methods aren't really useful, except for the special case of vertices geometry. While we might find a use for them in the future, for now lets move them to the subclass?
