### PR TITLE
Remove duplicated _ from Android's test methods' name

### DIFF
--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentActivityTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentActivityTest.java
@@ -65,13 +65,13 @@ public class FlutterFragmentActivityTest {
   }
 
   @Test
-  public void createFlutterFragment__defaultRenderModeSurface() {
+  public void createFlutterFragment_defaultRenderModeSurface() {
     final FlutterFragmentActivity activity = new FakeFlutterFragmentActivity();
     assertEquals(activity.createFlutterFragment().getRenderMode(), RenderMode.surface);
   }
 
   @Test
-  public void createFlutterFragment__defaultRenderModeTexture() {
+  public void createFlutterFragment_defaultRenderModeTexture() {
     final FlutterFragmentActivity activity =
         new FakeFlutterFragmentActivity() {
           @Override
@@ -83,7 +83,7 @@ public class FlutterFragmentActivityTest {
   }
 
   @Test
-  public void createFlutterFragment__customRenderMode() {
+  public void createFlutterFragment_customRenderMode() {
     final FlutterFragmentActivity activity =
         new FakeFlutterFragmentActivity() {
           @Override
@@ -95,7 +95,7 @@ public class FlutterFragmentActivityTest {
   }
 
   @Test
-  public void createFlutterFragment__customDartEntrypointLibraryUri() {
+  public void createFlutterFragment_customDartEntrypointLibraryUri() {
     final FlutterFragmentActivity activity =
         new FakeFlutterFragmentActivity() {
           @Override

--- a/shell/platform/android/test/io/flutter/embedding/engine/FlutterJNITest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/FlutterJNITest.java
@@ -150,7 +150,7 @@ public class FlutterJNITest {
     assertEquals(result[2], "");
   }
 
-  public void onDisplayPlatformView__callsPlatformViewsController() {
+  public void onDisplayPlatformView_callsPlatformViewsController() {
     PlatformViewsController platformViewsController = mock(PlatformViewsController.class);
 
     FlutterJNI flutterJNI = new FlutterJNI();
@@ -181,7 +181,7 @@ public class FlutterJNITest {
   }
 
   @Test
-  public void onDisplayOverlaySurface__callsPlatformViewsController() {
+  public void onDisplayOverlaySurface_callsPlatformViewsController() {
     PlatformViewsController platformViewsController = mock(PlatformViewsController.class);
 
     FlutterJNI flutterJNI = new FlutterJNI();
@@ -197,7 +197,7 @@ public class FlutterJNITest {
   }
 
   @Test
-  public void onBeginFrame__callsPlatformViewsController() {
+  public void onBeginFrame_callsPlatformViewsController() {
     PlatformViewsController platformViewsController = mock(PlatformViewsController.class);
 
     // --- Test Setup ---
@@ -212,7 +212,7 @@ public class FlutterJNITest {
   }
 
   @Test
-  public void onEndFrame__callsPlatformViewsController() {
+  public void onEndFrame_callsPlatformViewsController() {
     PlatformViewsController platformViewsController = mock(PlatformViewsController.class);
 
     // --- Test Setup ---
@@ -227,7 +227,7 @@ public class FlutterJNITest {
   }
 
   @Test
-  public void createOverlaySurface__callsPlatformViewsController() {
+  public void createOverlaySurface_callsPlatformViewsController() {
     PlatformViewsController platformViewsController = mock(PlatformViewsController.class);
 
     FlutterJNI flutterJNI = new FlutterJNI();
@@ -241,14 +241,14 @@ public class FlutterJNITest {
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void invokePlatformMessageResponseCallback__wantsDirectBuffer() {
+  public void invokePlatformMessageResponseCallback_wantsDirectBuffer() {
     FlutterJNI flutterJNI = new FlutterJNI();
     ByteBuffer buffer = ByteBuffer.allocate(4);
     flutterJNI.invokePlatformMessageResponseCallback(0, buffer, buffer.position());
   }
 
   @Test
-  public void setRefreshRateFPS__callsUpdateRefreshRate() {
+  public void setRefreshRateFPS_callsUpdateRefreshRate() {
     FlutterJNI flutterJNI = spy(new FlutterJNI());
     // --- Execute Test ---
     flutterJNI.setRefreshRateFPS(120.0f);

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
@@ -268,7 +268,7 @@ public class PlatformViewsControllerTest {
 
   @Test
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
-  public void getPlatformViewById__hybridComposition() {
+  public void getPlatformViewById_hybridComposition() {
     PlatformViewsController platformViewsController = new PlatformViewsController();
 
     int platformViewId = 0;
@@ -296,7 +296,7 @@ public class PlatformViewsControllerTest {
 
   @Test
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
-  public void createPlatformViewMessage__initializesAndroidView() {
+  public void createPlatformViewMessage_initializesAndroidView() {
     PlatformViewsController platformViewsController = new PlatformViewsController();
 
     int platformViewId = 0;
@@ -318,7 +318,7 @@ public class PlatformViewsControllerTest {
 
   @Test
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
-  public void createPlatformViewMessage__wrapsContextForVirtualDisplay() {
+  public void createPlatformViewMessage_wrapsContextForVirtualDisplay() {
     PlatformViewsController platformViewsController = new PlatformViewsController();
 
     int platformViewId = 0;
@@ -343,7 +343,7 @@ public class PlatformViewsControllerTest {
 
   @Test
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
-  public void createPlatformViewMessage__doesNotWrapContextForHybrid() {
+  public void createPlatformViewMessage_doesNotWrapContextForHybrid() {
     PlatformViewsController platformViewsController = new PlatformViewsController();
 
     int platformViewId = 0;
@@ -367,7 +367,7 @@ public class PlatformViewsControllerTest {
 
   @Test
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
-  public void createPlatformViewMessage__setsAndroidViewLayoutDirection() {
+  public void createPlatformViewMessage_setsAndroidViewLayoutDirection() {
     PlatformViewsController platformViewsController = new PlatformViewsController();
     platformViewsController.setSoftwareRendering(true);
 
@@ -393,7 +393,7 @@ public class PlatformViewsControllerTest {
 
   @Test
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
-  public void createPlatformViewMessage__setsAndroidViewSize() {
+  public void createPlatformViewMessage_setsAndroidViewSize() {
     PlatformViewsController platformViewsController = new PlatformViewsController();
     platformViewsController.setSoftwareRendering(true);
 
@@ -426,7 +426,7 @@ public class PlatformViewsControllerTest {
 
   @Test
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
-  public void createPlatformViewMessage__disablesAccessibility() {
+  public void createPlatformViewMessage_disablesAccessibility() {
     PlatformViewsController platformViewsController = new PlatformViewsController();
     platformViewsController.setSoftwareRendering(true);
 
@@ -453,7 +453,7 @@ public class PlatformViewsControllerTest {
 
   @Test
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
-  public void createPlatformViewMessage__throwsIfViewIsNull() {
+  public void createPlatformViewMessage_throwsIfViewIsNull() {
     PlatformViewsController platformViewsController = new PlatformViewsController();
 
     int platformViewId = 0;
@@ -482,7 +482,7 @@ public class PlatformViewsControllerTest {
 
   @Test
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
-  public void createHybridPlatformViewMessage__throwsIfViewIsNull() {
+  public void createHybridPlatformViewMessage_throwsIfViewIsNull() {
     PlatformViewsController platformViewsController = new PlatformViewsController();
 
     int platformViewId = 0;
@@ -574,7 +574,7 @@ public class PlatformViewsControllerTest {
 
   @Test
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
-  public void createPlatformViewMessage__throwsIfViewHasParent() {
+  public void createPlatformViewMessage_throwsIfViewHasParent() {
     PlatformViewsController platformViewsController = new PlatformViewsController();
 
     int platformViewId = 0;
@@ -605,7 +605,7 @@ public class PlatformViewsControllerTest {
 
   @Test
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
-  public void createHybridPlatformViewMessage__throwsIfViewHasParent() {
+  public void createHybridPlatformViewMessage_throwsIfViewHasParent() {
     PlatformViewsController platformViewsController = new PlatformViewsController();
 
     int platformViewId = 0;
@@ -635,7 +635,7 @@ public class PlatformViewsControllerTest {
 
   @Test
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
-  public void setPlatformViewDirection__throwIfPlatformViewNotFound() {
+  public void setPlatformViewDirection_throwIfPlatformViewNotFound() {
     PlatformViewsController platformViewsController = new PlatformViewsController();
 
     int platformViewId = 0;
@@ -706,7 +706,7 @@ public class PlatformViewsControllerTest {
 
   @Test
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
-  public void disposeAndroidView__hybridComposition() {
+  public void disposeAndroidView_hybridComposition() {
     PlatformViewsController platformViewsController = new PlatformViewsController();
 
     int platformViewId = 0;
@@ -803,7 +803,7 @@ public class PlatformViewsControllerTest {
         ShadowFlutterJNI.class,
         ShadowPlatformTaskQueue.class
       })
-  public void onEndFrame__destroysOverlaySurfaceAfterFrameOnFlutterSurfaceView() {
+  public void onEndFrame_destroysOverlaySurfaceAfterFrameOnFlutterSurfaceView() {
     final PlatformViewsController platformViewsController = new PlatformViewsController();
 
     final int platformViewId = 0;
@@ -862,7 +862,7 @@ public class PlatformViewsControllerTest {
 
   @Test
   @Config(shadows = {ShadowFlutterSurfaceView.class, ShadowFlutterJNI.class})
-  public void onEndFrame__removesPlatformView() {
+  public void onEndFrame_removesPlatformView() {
     final PlatformViewsController platformViewsController = new PlatformViewsController();
 
     final int platformViewId = 0;
@@ -903,7 +903,7 @@ public class PlatformViewsControllerTest {
         ShadowFlutterJNI.class,
         ShadowPlatformTaskQueue.class
       })
-  public void onEndFrame__removesPlatformViewParent() {
+  public void onEndFrame_removesPlatformViewParent() {
     final PlatformViewsController platformViewsController = new PlatformViewsController();
 
     final int platformViewId = 0;
@@ -946,7 +946,7 @@ public class PlatformViewsControllerTest {
         ShadowFlutterJNI.class,
         ShadowPlatformTaskQueue.class
       })
-  public void detach__destroysOverlaySurfaces() {
+  public void detach_destroysOverlaySurfaces() {
     final PlatformViewsController platformViewsController = new PlatformViewsController();
 
     final int platformViewId = 0;
@@ -997,7 +997,7 @@ public class PlatformViewsControllerTest {
 
   @Test
   @Config(shadows = {ShadowFlutterSurfaceView.class, ShadowFlutterJNI.class})
-  public void detachFromView__removesAndDestroysOverlayViews() {
+  public void detachFromView_removesAndDestroysOverlayViews() {
     final PlatformViewsController platformViewsController = new PlatformViewsController();
 
     final int platformViewId = 0;
@@ -1035,7 +1035,7 @@ public class PlatformViewsControllerTest {
 
   @Test
   @Config(shadows = {ShadowFlutterSurfaceView.class, ShadowFlutterJNI.class})
-  public void destroyOverlaySurfaces__doesNotThrowIfFlutterViewIsDetached() {
+  public void destroyOverlaySurfaces_doesNotThrowIfFlutterViewIsDetached() {
     final PlatformViewsController platformViewsController = new PlatformViewsController();
 
     final int platformViewId = 0;
@@ -1073,7 +1073,7 @@ public class PlatformViewsControllerTest {
 
   @Test
   @Config(shadows = {ShadowFlutterSurfaceView.class, ShadowFlutterJNI.class})
-  public void destroyOverlaySurfaces__doesNotRemoveOverlayView() {
+  public void destroyOverlaySurfaces_doesNotRemoveOverlayView() {
     final PlatformViewsController platformViewsController = new PlatformViewsController();
 
     final int platformViewId = 0;
@@ -1107,7 +1107,7 @@ public class PlatformViewsControllerTest {
   }
 
   @Test
-  public void checkInputConnectionProxy__falseIfViewIsNull() {
+  public void checkInputConnectionProxy_falseIfViewIsNull() {
     final PlatformViewsController platformViewsController = new PlatformViewsController();
     boolean shouldProxying = platformViewsController.checkInputConnectionProxy(null);
     assertFalse(shouldProxying);


### PR DESCRIPTION
Remove duplicated _ from Android's test methods' name. It's a minor cleanup PR.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
