### PR TITLE
improve modelity of multi finger move

### DIFF
--- a/lib/ui/window/pointer_data_packet_converter.cc
+++ b/lib/ui/window/pointer_data_packet_converter.cc
@@ -83,7 +83,9 @@ void PointerDataPacketConverter::ConvertPointerData(
       case PointerData::Change::kRemove: {
         // Makes sure we have an existing pointer
         auto iter = states_.find(pointer_data.device);
-        FML_DCHECK(iter != states_.end());
+        if (iter == states_.end()) {
+          break;
+        }
         PointerState state = iter->second;
 
         if (state.is_down) {
@@ -147,7 +149,7 @@ void PointerDataPacketConverter::ConvertPointerData(
           state = EnsurePointerState(synthesized_add_event);
           converted_pointers.push_back(synthesized_add_event);
         } else {
-          state = iter->second;
+          return;
         }
 
         FML_DCHECK(!state.is_down);
@@ -185,7 +187,9 @@ void PointerDataPacketConverter::ConvertPointerData(
       case PointerData::Change::kUp: {
         // Makes sure we have an existing pointer in down state
         auto iter = states_.find(pointer_data.device);
-        FML_DCHECK(iter != states_.end());
+        if (iter == states_.end()) {
+          break;
+        }
         PointerState state = iter->second;
         FML_DCHECK(state.is_down);
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -1120,7 +1120,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 }
 
 - (void)touchesMoved:(NSSet*)touches withEvent:(UIEvent*)event {
-  [self dispatchTouches:touches pointerDataChangeOverride:nullptr event:event];
+  [self dispatchTouches:event.allTouches pointerDataChangeOverride:nullptr event:event];
 }
 
 - (void)touchesEnded:(NSSet*)touches withEvent:(UIEvent*)event {


### PR DESCRIPTION
@dkwingsmt @goderbauer 

Sorry for the late comments.

This is about the issues : [Improve fidelity of multi-pointer drag gestures](https://github.com/flutter/flutter/pull/106552) and [this](https://github.com/flutter/flutter/pull/108340).

In iOS, we can use `event.allTouches` to replace `touches` in the function: 
<img width="877" alt="image" src="https://user-images.githubusercontent.com/35736246/197330467-7a64adf0-a9c4-41f7-ac7e-98210b70ec8c.png">
in [FlutterViewControll.mm Line 1122](https://github.com/flutter/engine/blob/main/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm#:~:text=%2D%20(void)touchesMoved,%7D).

If we do this, we can easly process the multi fingers' move not using endOfBatch ([proposed in this](https://github.com/flutter/flutter/pull/108340)). But the code of the flutter/engine need to modify firstly. 

Why we need to modify `FML_DCHECK` to `if` statement?
When we use `event.allTouches`, the events' phase may be different. For example, the p1 down and p2 down firstly, if p1 move now, sometimes the event.allTouches phases are "p1 move and p2 move" and sometimes they are "p1 move and p2 down"(two fingers down together and move fast together, maybe but not must appear, you need try some times). That means p2 down event will triger twice! ( I do not know why, maybe a bug in ios? ). Please refer to the stack trace below.

<img width="1285" alt="wecom-temp-ab7c893082b4b7fbd3d64afc05237fd3" src="https://user-images.githubusercontent.com/35736246/197331159-6701e22e-5a07-4cca-80ec-d1b9edb6080f.png">

Pay attention to the phase. 0 means down and 1 means move. And it happend to touchesEnd too. So I modify the `FML_DCHECK` in  `PointerData::Change::kRemove`, `PointerData::Change::kDown` and `PointerData::Change::kUp`.

After this merged, I will open the [Improve fidelity of multi-pointer drag gestures](https://github.com/flutter/flutter/pull/106552) again. 
What are your opions?
