### PR TITLE
Announce alerts through SemanticsService on Windows

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -3059,9 +3059,13 @@ FILE: ../../../flutter/shell/platform/linux/public/flutter_linux/fl_texture_regi
 FILE: ../../../flutter/shell/platform/linux/public/flutter_linux/fl_value.h
 FILE: ../../../flutter/shell/platform/linux/public/flutter_linux/fl_view.h
 FILE: ../../../flutter/shell/platform/linux/public/flutter_linux/flutter_linux.h
+FILE: ../../../flutter/shell/platform/windows/accessibility_alert.cc
+FILE: ../../../flutter/shell/platform/windows/accessibility_alert.h
 FILE: ../../../flutter/shell/platform/windows/accessibility_bridge_delegate_windows.cc
 FILE: ../../../flutter/shell/platform/windows/accessibility_bridge_delegate_windows.h
 FILE: ../../../flutter/shell/platform/windows/accessibility_bridge_delegate_windows_unittests.cc
+FILE: ../../../flutter/shell/platform/windows/accessibility_root_node.cc
+FILE: ../../../flutter/shell/platform/windows/accessibility_root_node.h
 FILE: ../../../flutter/shell/platform/windows/angle_surface_manager.cc
 FILE: ../../../flutter/shell/platform/windows/angle_surface_manager.h
 FILE: ../../../flutter/shell/platform/windows/client_wrapper/dart_project_unittests.cc

--- a/shell/platform/windows/BUILD.gn
+++ b/shell/platform/windows/BUILD.gn
@@ -176,7 +176,6 @@ executable("flutter_windows_unittests") {
   # Common Windows test sources.
   sources = [
     "accessibility_bridge_delegate_windows_unittests.cc",
-    "accessibility_root_node_unittests.cc",
     "direct_manipulation_unittests.cc",
     "dpi_utils_unittests.cc",
     "flutter_project_bundle_unittests.cc",

--- a/shell/platform/windows/BUILD.gn
+++ b/shell/platform/windows/BUILD.gn
@@ -38,8 +38,12 @@ source_set("flutter_windows_headers") {
 source_set("flutter_windows_source") {
   # Common Windows sources.
   sources = [
+    "accessibility_alert.cc",
+    "accessibility_alert.h",
     "accessibility_bridge_delegate_windows.cc",
     "accessibility_bridge_delegate_windows.h",
+    "accessibility_root_node.cc",
+    "accessibility_root_node.h",
     "angle_surface_manager.cc",
     "angle_surface_manager.h",
     "cursor_handler.cc",
@@ -172,6 +176,7 @@ executable("flutter_windows_unittests") {
   # Common Windows test sources.
   sources = [
     "accessibility_bridge_delegate_windows_unittests.cc",
+    "accessibility_root_node_unittests.cc",
     "direct_manipulation_unittests.cc",
     "dpi_utils_unittests.cc",
     "flutter_project_bundle_unittests.cc",

--- a/shell/platform/windows/accessibility_alert.cc
+++ b/shell/platform/windows/accessibility_alert.cc
@@ -1,0 +1,9 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/windows/accessibility_alert.h"
+
+namespace flutter {
+
+}

--- a/shell/platform/windows/accessibility_alert.cc
+++ b/shell/platform/windows/accessibility_alert.cc
@@ -4,6 +4,157 @@
 
 #include "flutter/shell/platform/windows/accessibility_alert.h"
 
+#include "flutter/shell/platform/windows/accessibility_root_node.h"
+
 namespace flutter {
+
+AccessibilityAlert::AccessibilityAlert() : text_(L""), parent_(nullptr) {}
+
+IFACEMETHODIMP AccessibilityAlert::accHitTest(LONG screen_physical_pixel_x,
+                            LONG screen_physical_pixel_y,
+                            VARIANT* child) {
+  child->vt = VT_EMPTY;
+  return S_FALSE;
+}
+
+// Performs the object's default action.
+IFACEMETHODIMP AccessibilityAlert::accDoDefaultAction(VARIANT var_id) {
+  return E_FAIL;
+}
+
+// Retrieves the specified object's current screen location.
+IFACEMETHODIMP AccessibilityAlert::accLocation(LONG* physical_pixel_left,
+                            LONG* physical_pixel_top,
+                            LONG* width,
+                            LONG* height,
+                            VARIANT var_id) {
+  return E_NOTIMPL;
+}
+
+// Traverses to another UI element and retrieves the object.
+IFACEMETHODIMP AccessibilityAlert::accNavigate(LONG nav_dir,
+                            VARIANT start,
+                            VARIANT* end) {
+  end->vt = VT_EMPTY;
+  return E_NOTIMPL;
+}
+
+// Retrieves an IDispatch interface pointer for the specified child.
+IFACEMETHODIMP AccessibilityAlert::get_accChild(VARIANT var_child,
+                            IDispatch** disp_child) {
+  if (V_VT(&var_child) == VT_I4 && V_I4(&var_child) == CHILDID_SELF) {
+    *disp_child = this;
+    AddRef();
+    return S_OK;
+  }
+  *disp_child = nullptr;
+  return E_FAIL;
+}
+
+// Retrieves the number of accessible children.
+IFACEMETHODIMP AccessibilityAlert::get_accChildCount(LONG* child_count) {
+  *child_count = 0;
+  return S_OK;
+}
+
+// Retrieves a string that describes the object's default action.
+IFACEMETHODIMP AccessibilityAlert::get_accDefaultAction(VARIANT var_id,
+                                    BSTR* default_action) {
+  *default_action = nullptr;
+  return E_NOTIMPL;
+}
+
+// Retrieves the tooltip description.
+IFACEMETHODIMP AccessibilityAlert::get_accDescription(VARIANT var_id, BSTR* desc) {
+  *desc = nullptr;
+  return E_NOTIMPL;
+}
+
+// Retrieves the object that has the keyboard focus.
+IFACEMETHODIMP AccessibilityAlert::get_accFocus(VARIANT* focus_child) {
+  focus_child->vt = VT_EMPTY;
+  return E_NOTIMPL;
+}
+
+// Retrieves the specified object's shortcut.
+IFACEMETHODIMP AccessibilityAlert::get_accKeyboardShortcut(VARIANT var_id,
+                                        BSTR* access_key) {
+  *access_key = nullptr;
+  return E_NOTIMPL;
+}
+
+// Retrieves the name of the specified object.
+IFACEMETHODIMP AccessibilityAlert::get_accName(VARIANT var_id, BSTR* name) {
+  *name = SysAllocString(text_.c_str());
+  return S_OK;
+}
+
+// Retrieves the IDispatch interface of the object's parent.
+IFACEMETHODIMP AccessibilityAlert::get_accParent(IDispatch** disp_parent) {
+  //*disp_parent = parent_;
+  //return S_OK;
+  *disp_parent = nullptr;
+  return E_NOTIMPL;
+}
+
+// Retrieves information describing the role of the specified object.
+IFACEMETHODIMP AccessibilityAlert::get_accRole(VARIANT var_id, VARIANT* role) {
+  *role = {.vt = VT_I4, .lVal = ROLE_SYSTEM_ALERT};
+  return S_OK;
+}
+
+// Retrieves the current state of the specified object.
+IFACEMETHODIMP AccessibilityAlert::get_accState(VARIANT var_id, VARIANT* state) {
+  *state = {.vt = VT_I4, .lVal = STATE_SYSTEM_DEFAULT};
+  return S_OK;
+}
+
+// Gets the help string for the specified object.
+IFACEMETHODIMP AccessibilityAlert::get_accHelp(VARIANT var_id, BSTR* help) {
+  *help = SysAllocString(L"");
+  return S_OK;
+}
+
+// Retrieve or set the string value associated with the specified object.
+// Setting the value is not typically used by screen readers, but it's
+// used frequently by automation software.
+IFACEMETHODIMP AccessibilityAlert::get_accValue(VARIANT var_id, BSTR* value) {
+  *value = SysAllocString(text_.c_str());
+  return S_OK;
+}
+IFACEMETHODIMP AccessibilityAlert::put_accValue(VARIANT var_id, BSTR new_value) {
+  return E_NOTIMPL;
+}
+
+// IAccessible methods not implemented.
+IFACEMETHODIMP AccessibilityAlert::get_accSelection(VARIANT* selected) {
+  selected->vt = VT_EMPTY;
+  return E_NOTIMPL;
+}
+IFACEMETHODIMP AccessibilityAlert::accSelect(LONG flags_sel, VARIANT var_id) {
+  return E_NOTIMPL;
+}
+IFACEMETHODIMP AccessibilityAlert::get_accHelpTopic(BSTR* help_file,
+                                VARIANT var_id,
+                                LONG* topic_id) {
+  if (help_file) {
+    *help_file = nullptr;
+  }
+  if (topic_id) {
+    *topic_id = 0;
+  }
+  return E_NOTIMPL;
+}
+IFACEMETHODIMP AccessibilityAlert::put_accName(VARIANT var_id, BSTR put_name) {
+  return E_NOTIMPL;
+}
+
+void AccessibilityAlert::SetText(const std::wstring& text) {
+  text_ = text;
+}
+
+void AccessibilityAlert::SetParent(AccessibilityRootNode* parent) {
+  parent_ = parent;
+}
 
 }

--- a/shell/platform/windows/accessibility_alert.cc
+++ b/shell/platform/windows/accessibility_alert.cc
@@ -10,6 +10,8 @@ namespace flutter {
 
 AccessibilityAlert::AccessibilityAlert() : text_(L""), parent_(nullptr) {}
 
+// IAccessible methods.
+
 IFACEMETHODIMP AccessibilityAlert::accHitTest(LONG screen_physical_pixel_x,
                                               LONG screen_physical_pixel_y,
                                               VARIANT* child) {
@@ -156,6 +158,8 @@ IFACEMETHODIMP AccessibilityAlert::get_accHelpTopic(BSTR* help_file,
 IFACEMETHODIMP AccessibilityAlert::put_accName(VARIANT var_id, BSTR put_name) {
   return E_NOTIMPL;
 }
+
+// End of IAccessible methods.
 
 void AccessibilityAlert::SetText(const std::wstring& text) {
   text_ = text;

--- a/shell/platform/windows/accessibility_alert.cc
+++ b/shell/platform/windows/accessibility_alert.cc
@@ -66,8 +66,8 @@ IFACEMETHODIMP AccessibilityAlert::get_accDefaultAction(VARIANT var_id,
 
 // Retrieves the tooltip description.
 IFACEMETHODIMP AccessibilityAlert::get_accDescription(VARIANT var_id, BSTR* desc) {
-  *desc = nullptr;
-  return E_NOTIMPL;
+  *desc = SysAllocString(text_.c_str());
+  return S_OK;
 }
 
 // Retrieves the object that has the keyboard focus.
@@ -91,10 +91,13 @@ IFACEMETHODIMP AccessibilityAlert::get_accName(VARIANT var_id, BSTR* name) {
 
 // Retrieves the IDispatch interface of the object's parent.
 IFACEMETHODIMP AccessibilityAlert::get_accParent(IDispatch** disp_parent) {
-  //*disp_parent = parent_;
-  //return S_OK;
-  *disp_parent = nullptr;
-  return E_NOTIMPL;
+  *disp_parent = parent_;
+  if (*disp_parent) {
+    (*disp_parent)->AddRef();
+  }
+  return S_OK;
+  //*disp_parent = nullptr;
+  //return E_NOTIMPL;
 }
 
 // Retrieves information describing the role of the specified object.

--- a/shell/platform/windows/accessibility_alert.cc
+++ b/shell/platform/windows/accessibility_alert.cc
@@ -24,23 +24,6 @@ IFACEMETHODIMP AccessibilityAlert::accDoDefaultAction(VARIANT var_id) {
   return E_FAIL;
 }
 
-// Retrieves the specified object's current screen location.
-IFACEMETHODIMP AccessibilityAlert::accLocation(LONG* physical_pixel_left,
-                                               LONG* physical_pixel_top,
-                                               LONG* width,
-                                               LONG* height,
-                                               VARIANT var_id) {
-  return E_NOTIMPL;
-}
-
-// Traverses to another UI element and retrieves the object.
-IFACEMETHODIMP AccessibilityAlert::accNavigate(LONG nav_dir,
-                                               VARIANT start,
-                                               VARIANT* end) {
-  end->vt = VT_EMPTY;
-  return E_NOTIMPL;
-}
-
 // Retrieves an IDispatch interface pointer for the specified child.
 IFACEMETHODIMP AccessibilityAlert::get_accChild(VARIANT var_child,
                                                 IDispatch** disp_child) {
@@ -59,31 +42,11 @@ IFACEMETHODIMP AccessibilityAlert::get_accChildCount(LONG* child_count) {
   return S_OK;
 }
 
-// Retrieves a string that describes the object's default action.
-IFACEMETHODIMP AccessibilityAlert::get_accDefaultAction(VARIANT var_id,
-                                                        BSTR* default_action) {
-  *default_action = nullptr;
-  return E_NOTIMPL;
-}
-
 // Retrieves the tooltip description.
 IFACEMETHODIMP AccessibilityAlert::get_accDescription(VARIANT var_id,
                                                       BSTR* desc) {
   *desc = SysAllocString(text_.c_str());
   return S_OK;
-}
-
-// Retrieves the object that has the keyboard focus.
-IFACEMETHODIMP AccessibilityAlert::get_accFocus(VARIANT* focus_child) {
-  focus_child->vt = VT_EMPTY;
-  return E_NOTIMPL;
-}
-
-// Retrieves the specified object's shortcut.
-IFACEMETHODIMP AccessibilityAlert::get_accKeyboardShortcut(VARIANT var_id,
-                                                           BSTR* access_key) {
-  *access_key = nullptr;
-  return E_NOTIMPL;
 }
 
 // Retrieves the name of the specified object.
@@ -129,11 +92,6 @@ IFACEMETHODIMP AccessibilityAlert::get_accValue(VARIANT var_id, BSTR* value) {
   return S_OK;
 }
 
-IFACEMETHODIMP AccessibilityAlert::put_accValue(VARIANT var_id,
-                                                BSTR new_value) {
-  return E_NOTIMPL;
-}
-
 // IAccessible methods not implemented.
 IFACEMETHODIMP AccessibilityAlert::get_accSelection(VARIANT* selected) {
   selected->vt = VT_EMPTY;
@@ -141,6 +99,16 @@ IFACEMETHODIMP AccessibilityAlert::get_accSelection(VARIANT* selected) {
 }
 
 IFACEMETHODIMP AccessibilityAlert::accSelect(LONG flags_sel, VARIANT var_id) {
+  return E_NOTIMPL;
+}
+
+IFACEMETHODIMP AccessibilityAlert::put_accValue(VARIANT var_id,
+                                                BSTR new_value) {
+  return E_NOTIMPL;
+}
+
+IFACEMETHODIMP AccessibilityAlert::get_accFocus(VARIANT* focus_child) {
+  focus_child->vt = VT_EMPTY;
   return E_NOTIMPL;
 }
 
@@ -155,7 +123,35 @@ IFACEMETHODIMP AccessibilityAlert::get_accHelpTopic(BSTR* help_file,
   }
   return E_NOTIMPL;
 }
+
 IFACEMETHODIMP AccessibilityAlert::put_accName(VARIANT var_id, BSTR put_name) {
+  return E_NOTIMPL;
+}
+
+IFACEMETHODIMP AccessibilityAlert::get_accKeyboardShortcut(VARIANT var_id,
+                                                           BSTR* access_key) {
+  *access_key = nullptr;
+  return E_NOTIMPL;
+}
+
+IFACEMETHODIMP AccessibilityAlert::accLocation(LONG* physical_pixel_left,
+                                               LONG* physical_pixel_top,
+                                               LONG* width,
+                                               LONG* height,
+                                               VARIANT var_id) {
+  return E_NOTIMPL;
+}
+
+IFACEMETHODIMP AccessibilityAlert::accNavigate(LONG nav_dir,
+                                               VARIANT start,
+                                               VARIANT* end) {
+  end->vt = VT_EMPTY;
+  return E_NOTIMPL;
+}
+
+IFACEMETHODIMP AccessibilityAlert::get_accDefaultAction(VARIANT var_id,
+                                                        BSTR* default_action) {
+  *default_action = nullptr;
   return E_NOTIMPL;
 }
 

--- a/shell/platform/windows/accessibility_alert.cc
+++ b/shell/platform/windows/accessibility_alert.cc
@@ -11,8 +11,8 @@ namespace flutter {
 AccessibilityAlert::AccessibilityAlert() : text_(L""), parent_(nullptr) {}
 
 IFACEMETHODIMP AccessibilityAlert::accHitTest(LONG screen_physical_pixel_x,
-                            LONG screen_physical_pixel_y,
-                            VARIANT* child) {
+                                              LONG screen_physical_pixel_y,
+                                              VARIANT* child) {
   child->vt = VT_EMPTY;
   return S_FALSE;
 }
@@ -24,24 +24,24 @@ IFACEMETHODIMP AccessibilityAlert::accDoDefaultAction(VARIANT var_id) {
 
 // Retrieves the specified object's current screen location.
 IFACEMETHODIMP AccessibilityAlert::accLocation(LONG* physical_pixel_left,
-                            LONG* physical_pixel_top,
-                            LONG* width,
-                            LONG* height,
-                            VARIANT var_id) {
+                                               LONG* physical_pixel_top,
+                                               LONG* width,
+                                               LONG* height,
+                                               VARIANT var_id) {
   return E_NOTIMPL;
 }
 
 // Traverses to another UI element and retrieves the object.
 IFACEMETHODIMP AccessibilityAlert::accNavigate(LONG nav_dir,
-                            VARIANT start,
-                            VARIANT* end) {
+                                               VARIANT start,
+                                               VARIANT* end) {
   end->vt = VT_EMPTY;
   return E_NOTIMPL;
 }
 
 // Retrieves an IDispatch interface pointer for the specified child.
 IFACEMETHODIMP AccessibilityAlert::get_accChild(VARIANT var_child,
-                            IDispatch** disp_child) {
+                                                IDispatch** disp_child) {
   if (V_VT(&var_child) == VT_I4 && V_I4(&var_child) == CHILDID_SELF) {
     *disp_child = this;
     AddRef();
@@ -59,13 +59,14 @@ IFACEMETHODIMP AccessibilityAlert::get_accChildCount(LONG* child_count) {
 
 // Retrieves a string that describes the object's default action.
 IFACEMETHODIMP AccessibilityAlert::get_accDefaultAction(VARIANT var_id,
-                                    BSTR* default_action) {
+                                                        BSTR* default_action) {
   *default_action = nullptr;
   return E_NOTIMPL;
 }
 
 // Retrieves the tooltip description.
-IFACEMETHODIMP AccessibilityAlert::get_accDescription(VARIANT var_id, BSTR* desc) {
+IFACEMETHODIMP AccessibilityAlert::get_accDescription(VARIANT var_id,
+                                                      BSTR* desc) {
   *desc = SysAllocString(text_.c_str());
   return S_OK;
 }
@@ -78,7 +79,7 @@ IFACEMETHODIMP AccessibilityAlert::get_accFocus(VARIANT* focus_child) {
 
 // Retrieves the specified object's shortcut.
 IFACEMETHODIMP AccessibilityAlert::get_accKeyboardShortcut(VARIANT var_id,
-                                        BSTR* access_key) {
+                                                           BSTR* access_key) {
   *access_key = nullptr;
   return E_NOTIMPL;
 }
@@ -97,7 +98,7 @@ IFACEMETHODIMP AccessibilityAlert::get_accParent(IDispatch** disp_parent) {
   }
   return S_OK;
   //*disp_parent = nullptr;
-  //return E_NOTIMPL;
+  // return E_NOTIMPL;
 }
 
 // Retrieves information describing the role of the specified object.
@@ -107,7 +108,8 @@ IFACEMETHODIMP AccessibilityAlert::get_accRole(VARIANT var_id, VARIANT* role) {
 }
 
 // Retrieves the current state of the specified object.
-IFACEMETHODIMP AccessibilityAlert::get_accState(VARIANT var_id, VARIANT* state) {
+IFACEMETHODIMP AccessibilityAlert::get_accState(VARIANT var_id,
+                                                VARIANT* state) {
   *state = {.vt = VT_I4, .lVal = STATE_SYSTEM_DEFAULT};
   return S_OK;
 }
@@ -125,7 +127,8 @@ IFACEMETHODIMP AccessibilityAlert::get_accValue(VARIANT var_id, BSTR* value) {
   *value = SysAllocString(text_.c_str());
   return S_OK;
 }
-IFACEMETHODIMP AccessibilityAlert::put_accValue(VARIANT var_id, BSTR new_value) {
+IFACEMETHODIMP AccessibilityAlert::put_accValue(VARIANT var_id,
+                                                BSTR new_value) {
   return E_NOTIMPL;
 }
 
@@ -138,8 +141,8 @@ IFACEMETHODIMP AccessibilityAlert::accSelect(LONG flags_sel, VARIANT var_id) {
   return E_NOTIMPL;
 }
 IFACEMETHODIMP AccessibilityAlert::get_accHelpTopic(BSTR* help_file,
-                                VARIANT var_id,
-                                LONG* topic_id) {
+                                                    VARIANT var_id,
+                                                    LONG* topic_id) {
   if (help_file) {
     *help_file = nullptr;
   }
@@ -160,4 +163,4 @@ void AccessibilityAlert::SetParent(AccessibilityRootNode* parent) {
   parent_ = parent;
 }
 
-}
+}  // namespace flutter

--- a/shell/platform/windows/accessibility_alert.cc
+++ b/shell/platform/windows/accessibility_alert.cc
@@ -95,10 +95,9 @@ IFACEMETHODIMP AccessibilityAlert::get_accParent(IDispatch** disp_parent) {
   *disp_parent = parent_;
   if (*disp_parent) {
     (*disp_parent)->AddRef();
+    return S_OK;
   }
-  return S_OK;
-  //*disp_parent = nullptr;
-  // return E_NOTIMPL;
+  return S_FALSE;
 }
 
 // Retrieves information describing the role of the specified object.
@@ -127,6 +126,7 @@ IFACEMETHODIMP AccessibilityAlert::get_accValue(VARIANT var_id, BSTR* value) {
   *value = SysAllocString(text_.c_str());
   return S_OK;
 }
+
 IFACEMETHODIMP AccessibilityAlert::put_accValue(VARIANT var_id,
                                                 BSTR new_value) {
   return E_NOTIMPL;
@@ -137,9 +137,11 @@ IFACEMETHODIMP AccessibilityAlert::get_accSelection(VARIANT* selected) {
   selected->vt = VT_EMPTY;
   return E_NOTIMPL;
 }
+
 IFACEMETHODIMP AccessibilityAlert::accSelect(LONG flags_sel, VARIANT var_id) {
   return E_NOTIMPL;
 }
+
 IFACEMETHODIMP AccessibilityAlert::get_accHelpTopic(BSTR* help_file,
                                                     VARIANT var_id,
                                                     LONG* topic_id) {

--- a/shell/platform/windows/accessibility_alert.h
+++ b/shell/platform/windows/accessibility_alert.h
@@ -32,19 +32,6 @@ class AccessibilityAlert : public CComObjectRootEx<CComMultiThreadModel>,
                             VARIANT* child) override;
 
   // Performs the object's default action.
-  IFACEMETHODIMP accDoDefaultAction(VARIANT var_id) override;
-
-  // Retrieves the specified object's current screen location.
-  IFACEMETHODIMP accLocation(LONG* physical_pixel_left,
-                             LONG* physical_pixel_top,
-                             LONG* width,
-                             LONG* height,
-                             VARIANT var_id) override;
-
-  // Traverses to another UI element and retrieves the object.
-  IFACEMETHODIMP accNavigate(LONG nav_dir,
-                             VARIANT start,
-                             VARIANT* end) override;
 
   // Retrieves an IDispatch interface pointer for the specified child.
   IFACEMETHODIMP get_accChild(VARIANT var_child,
@@ -61,11 +48,6 @@ class AccessibilityAlert : public CComObjectRootEx<CComMultiThreadModel>,
   IFACEMETHODIMP get_accDescription(VARIANT var_id, BSTR* desc) override;
 
   // Retrieves the object that has the keyboard focus.
-  IFACEMETHODIMP get_accFocus(VARIANT* focus_child) override;
-
-  // Retrieves the specified object's shortcut.
-  IFACEMETHODIMP get_accKeyboardShortcut(VARIANT var_id,
-                                         BSTR* access_key) override;
 
   // Retrieves the name of the specified object.
   IFACEMETHODIMP get_accName(VARIANT var_id, BSTR* name) override;
@@ -86,15 +68,27 @@ class AccessibilityAlert : public CComObjectRootEx<CComMultiThreadModel>,
   // Setting the value is not typically used by screen readers, but it's
   // used frequently by automation software.
   IFACEMETHODIMP get_accValue(VARIANT var_id, BSTR* value) override;
-  IFACEMETHODIMP put_accValue(VARIANT var_id, BSTR new_value) override;
 
   // IAccessible methods not implemented.
+  IFACEMETHODIMP accLocation(LONG* physical_pixel_left,
+                             LONG* physical_pixel_top,
+                             LONG* width,
+                             LONG* height,
+                             VARIANT var_id) override;
+  IFACEMETHODIMP accNavigate(LONG nav_dir,
+                             VARIANT start,
+                             VARIANT* end) override;
+  IFACEMETHODIMP accDoDefaultAction(VARIANT var_id) override;
+  IFACEMETHODIMP get_accFocus(VARIANT* focus_child) override;
+  IFACEMETHODIMP get_accKeyboardShortcut(VARIANT var_id,
+                                         BSTR* access_key) override;
   IFACEMETHODIMP get_accSelection(VARIANT* selected) override;
   IFACEMETHODIMP accSelect(LONG flags_sel, VARIANT var_id) override;
   IFACEMETHODIMP get_accHelpTopic(BSTR* help_file,
                                   VARIANT var_id,
                                   LONG* topic_id) override;
   IFACEMETHODIMP put_accName(VARIANT var_id, BSTR put_name) override;
+  IFACEMETHODIMP put_accValue(VARIANT var_id, BSTR new_value) override;
 
   AccessibilityAlert();
   ~AccessibilityAlert() = default;

--- a/shell/platform/windows/accessibility_alert.h
+++ b/shell/platform/windows/accessibility_alert.h
@@ -9,14 +9,96 @@
 #include <atlcom.h>
 #include <oleacc.h>
 
+#include <string>
+
 namespace flutter {
 
+// An IAccessible node representing an alert read to the screen reader.
 class AccessibilityAlert : public CComObjectRootEx<CComMultiThreadModel>,
                            public IAccessible {
  public:
   BEGIN_COM_MAP(AccessibilityAlert)
   COM_INTERFACE_ENTRY(IAccessible)
   END_COM_MAP()
+  //
+  // IAccessible methods.
+  //
+
+  // Retrieves the child element or child object at a given point on the screen.
+  IFACEMETHODIMP accHitTest(LONG screen_physical_pixel_x,
+                            LONG screen_physical_pixel_y,
+                            VARIANT* child) override;
+
+  // Performs the object's default action.
+  IFACEMETHODIMP accDoDefaultAction(VARIANT var_id) override;
+
+  // Retrieves the specified object's current screen location.
+  IFACEMETHODIMP accLocation(LONG* physical_pixel_left,
+                             LONG* physical_pixel_top,
+                             LONG* width,
+                             LONG* height,
+                             VARIANT var_id) override;
+
+  // Traverses to another UI element and retrieves the object.
+  IFACEMETHODIMP accNavigate(LONG nav_dir,
+                             VARIANT start,
+                             VARIANT* end) override;
+
+  // Retrieves an IDispatch interface pointer for the specified child.
+  IFACEMETHODIMP get_accChild(VARIANT var_child,
+                              IDispatch** disp_child) override;
+
+  // Retrieves the number of accessible children.
+  IFACEMETHODIMP get_accChildCount(LONG* child_count) override;
+
+  // Retrieves a string that describes the object's default action.
+  IFACEMETHODIMP get_accDefaultAction(VARIANT var_id,
+                                      BSTR* default_action) override;
+
+  // Retrieves the tooltip description.
+  IFACEMETHODIMP get_accDescription(VARIANT var_id, BSTR* desc) override;
+
+  // Retrieves the object that has the keyboard focus.
+  IFACEMETHODIMP get_accFocus(VARIANT* focus_child) override;
+
+  // Retrieves the specified object's shortcut.
+  IFACEMETHODIMP get_accKeyboardShortcut(VARIANT var_id,
+                                         BSTR* access_key) override;
+
+  // Retrieves the name of the specified object.
+  IFACEMETHODIMP get_accName(VARIANT var_id, BSTR* name) override;
+
+  // Retrieves the IDispatch interface of the object's parent.
+  IFACEMETHODIMP get_accParent(IDispatch** disp_parent) override;
+
+  // Retrieves information describing the role of the specified object.
+  IFACEMETHODIMP get_accRole(VARIANT var_id, VARIANT* role) override;
+
+  // Retrieves the current state of the specified object.
+  IFACEMETHODIMP get_accState(VARIANT var_id, VARIANT* state) override;
+
+  // Gets the help string for the specified object.
+  IFACEMETHODIMP get_accHelp(VARIANT var_id, BSTR* help) override;
+
+  // Retrieve or set the string value associated with the specified object.
+  // Setting the value is not typically used by screen readers, but it's
+  // used frequently by automation software.
+  IFACEMETHODIMP get_accValue(VARIANT var_id, BSTR* value) override;
+  IFACEMETHODIMP put_accValue(VARIANT var_id, BSTR new_value) override;
+
+  // IAccessible methods not implemented.
+  IFACEMETHODIMP get_accSelection(VARIANT* selected) override;
+  IFACEMETHODIMP accSelect(LONG flags_sel, VARIANT var_id) override;
+  IFACEMETHODIMP get_accHelpTopic(BSTR* help_file,
+                                  VARIANT var_id,
+                                  LONG* topic_id) override;
+  IFACEMETHODIMP put_accName(VARIANT var_id, BSTR put_name) override;
+
+  // Sets the text of this alert to the provided message.
+  void SetText(const std::u16string& text);
+
+ private:
+  std::u16string text_;
 
 };
 

--- a/shell/platform/windows/accessibility_alert.h
+++ b/shell/platform/windows/accessibility_alert.h
@@ -16,6 +16,11 @@ namespace flutter {
 class AccessibilityRootNode;
 
 // An IAccessible node representing an alert read to the screen reader.
+// When an announcement is requested by the framework, an instance of
+// this class, if none exists already, is created and made a child of
+// the root AccessibilityRootNode node, and is therefore also a sibling
+// of the window's root node.
+// This node is not interactable to the user.
 class AccessibilityAlert : public CComObjectRootEx<CComMultiThreadModel>,
                            public IDispatchImpl<IAccessible> {
  public:
@@ -31,8 +36,6 @@ class AccessibilityAlert : public CComObjectRootEx<CComMultiThreadModel>,
                             LONG screen_physical_pixel_y,
                             VARIANT* child) override;
 
-  // Performs the object's default action.
-
   // Retrieves an IDispatch interface pointer for the specified child.
   IFACEMETHODIMP get_accChild(VARIANT var_child,
                               IDispatch** disp_child) override;
@@ -46,8 +49,6 @@ class AccessibilityAlert : public CComObjectRootEx<CComMultiThreadModel>,
 
   // Retrieves the tooltip description.
   IFACEMETHODIMP get_accDescription(VARIANT var_id, BSTR* desc) override;
-
-  // Retrieves the object that has the keyboard focus.
 
   // Retrieves the name of the specified object.
   IFACEMETHODIMP get_accName(VARIANT var_id, BSTR* name) override;
@@ -64,9 +65,7 @@ class AccessibilityAlert : public CComObjectRootEx<CComMultiThreadModel>,
   // Gets the help string for the specified object.
   IFACEMETHODIMP get_accHelp(VARIANT var_id, BSTR* help) override;
 
-  // Retrieve or set the string value associated with the specified object.
-  // Setting the value is not typically used by screen readers, but it's
-  // used frequently by automation software.
+  // Retrieve the string value associated with the specified object.
   IFACEMETHODIMP get_accValue(VARIANT var_id, BSTR* value) override;
 
   // IAccessible methods not implemented.
@@ -89,6 +88,8 @@ class AccessibilityAlert : public CComObjectRootEx<CComMultiThreadModel>,
                                   LONG* topic_id) override;
   IFACEMETHODIMP put_accName(VARIANT var_id, BSTR put_name) override;
   IFACEMETHODIMP put_accValue(VARIANT var_id, BSTR new_value) override;
+
+  // End of IAccessible methods.
 
   AccessibilityAlert();
   ~AccessibilityAlert() = default;

--- a/shell/platform/windows/accessibility_alert.h
+++ b/shell/platform/windows/accessibility_alert.h
@@ -1,0 +1,25 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_ACCESSIBILITY_ALERT_H_
+#define FLUTTER_SHELL_PLATFORM_WINDOWS_ACCESSIBILITY_ALERT_H_
+
+#include <atlbase.h>
+#include <atlcom.h>
+#include <oleacc.h>
+
+namespace flutter {
+
+class AccessibilityAlert : public CComObjectRootEx<CComMultiThreadModel>,
+                           public IAccessible {
+ public:
+  BEGIN_COM_MAP(AccessibilityAlert)
+  COM_INTERFACE_ENTRY(IAccessible)
+  END_COM_MAP()
+
+};
+
+}
+
+#endif

--- a/shell/platform/windows/accessibility_alert.h
+++ b/shell/platform/windows/accessibility_alert.h
@@ -107,4 +107,4 @@ class AccessibilityAlert : public CComObjectRootEx<CComMultiThreadModel>,
 
 }  // namespace flutter
 
-#endif
+#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_ACCESSIBILITY_ALERT_H_

--- a/shell/platform/windows/accessibility_alert.h
+++ b/shell/platform/windows/accessibility_alert.h
@@ -108,9 +108,8 @@ class AccessibilityAlert : public CComObjectRootEx<CComMultiThreadModel>,
   std::wstring text_;
 
   AccessibilityRootNode* parent_;
-
 };
 
-}
+}  // namespace flutter
 
 #endif

--- a/shell/platform/windows/accessibility_alert.h
+++ b/shell/platform/windows/accessibility_alert.h
@@ -13,9 +13,11 @@
 
 namespace flutter {
 
+class AccessibilityRootNode;
+
 // An IAccessible node representing an alert read to the screen reader.
 class AccessibilityAlert : public CComObjectRootEx<CComMultiThreadModel>,
-                           public IAccessible {
+                           public IDispatchImpl<IAccessible> {
  public:
   BEGIN_COM_MAP(AccessibilityAlert)
   COM_INTERFACE_ENTRY(IAccessible)
@@ -94,11 +96,18 @@ class AccessibilityAlert : public CComObjectRootEx<CComMultiThreadModel>,
                                   LONG* topic_id) override;
   IFACEMETHODIMP put_accName(VARIANT var_id, BSTR put_name) override;
 
+  AccessibilityAlert();
+  ~AccessibilityAlert() = default;
+
   // Sets the text of this alert to the provided message.
-  void SetText(const std::u16string& text);
+  void SetText(const std::wstring& text);
+
+  void SetParent(AccessibilityRootNode* parent);
 
  private:
-  std::u16string text_;
+  std::wstring text_;
+
+  AccessibilityRootNode* parent_;
 
 };
 

--- a/shell/platform/windows/accessibility_root_node.cc
+++ b/shell/platform/windows/accessibility_root_node.cc
@@ -4,6 +4,231 @@
 
 #include "flutter/shell/platform/windows/accessibility_root_node.h"
 
+static constexpr LONG kWindowChildId = 1;
+static constexpr LONG kAlertChildId = 2;
+static constexpr LONG kInvalidChildId = 3;
+
 namespace flutter {
+
+AccessibilityRootNode::~AccessibilityRootNode() {
+  if (alert_accessible_) {
+    alert_accessible_->Release();
+    alert_accessible_ = nullptr;
+  }
+}
+
+IAccessible* AccessibilityRootNode::GetTargetAndChildID(VARIANT* var_id) {
+  LONG& child_id = var_id->lVal;
+  if (V_VT(var_id) != VT_I4) {
+    child_id = kInvalidChildId;
+    return FALSE;
+  }
+  child_id = V_I4(var_id);
+  if (!window_accessible_) {
+    return nullptr;
+  }
+  if (child_id == CHILDID_SELF || child_id == kWindowChildId) {
+    child_id = CHILDID_SELF;
+    return window_accessible_;
+  }
+  if (child_id == kAlertChildId && alert_accessible_) {
+    child_id = CHILDID_SELF;
+    return alert_accessible_;
+  }
+  if (child_id < 0) {
+    return window_accessible_;
+  }
+  return nullptr;
+}
+
+IFACEMETHODIMP AccessibilityRootNode::accHitTest(LONG screen_physical_pixel_x,
+                                                 LONG screen_physical_pixel_y,
+                                                 VARIANT* child) {
+  if (window_accessible_) {
+    return window_accessible_->accHitTest(screen_physical_pixel_x, screen_physical_pixel_y, child);
+  }
+  child->vt = VT_EMPTY;
+  return S_FALSE;
+}
+
+IFACEMETHODIMP AccessibilityRootNode::accDoDefaultAction(VARIANT var_id) {
+  IAccessible* target;
+  if ((target = GetTargetAndChildID(&var_id))) {
+    return target->accDoDefaultAction(var_id);
+  }
+  return E_FAIL;
+}
+
+IFACEMETHODIMP AccessibilityRootNode::accLocation(LONG* physical_pixel_left,
+                                                  LONG* physical_pixel_top,
+                                                  LONG* width,
+                                                  LONG* height,
+                                                  VARIANT var_id) {
+  IAccessible* target;
+  if ((target = GetTargetAndChildID(&var_id))) {
+    return window_accessible_->accLocation(physical_pixel_left, physical_pixel_top, width, height, var_id);
+  }
+  return S_FALSE;
+}
+
+IFACEMETHODIMP AccessibilityRootNode::accNavigate(LONG nav_dir,
+                                                  VARIANT start,
+                                                  VARIANT* end) {
+  IAccessible* target;
+  if ((target = GetTargetAndChildID(&start))) {
+    return window_accessible_->accNavigate(nav_dir, start, end);
+  }
+  return S_FALSE;
+}
+
+IFACEMETHODIMP AccessibilityRootNode::get_accChild(VARIANT var_child,
+                                                   IDispatch** disp_child) {
+  if (V_VT(&var_child) != VT_I4) {
+    return E_FAIL;
+  }
+  LONG child_id = V_I4(&var_child);
+  if (child_id == CHILDID_SELF) {
+    *disp_child = this;
+  } else if (!window_accessible_) {
+    return E_FAIL;
+  } else if (child_id == 1) {
+    *disp_child = window_accessible_;
+  } else if (child_id == 2 && alert_accessible_) {
+    *disp_child = alert_accessible_;
+  } else {
+    return E_FAIL;
+  }
+  (*disp_child)->AddRef();
+  return S_OK;
+}
+
+IFACEMETHODIMP AccessibilityRootNode::get_accChildCount(LONG* child_count) {
+  LONG children = 0;
+  if (window_accessible_) {
+    children++;
+  }
+  if (alert_accessible_) {
+    children++;
+  }
+  *child_count = children;
+  return S_OK;
+}
+
+IFACEMETHODIMP AccessibilityRootNode::get_accDefaultAction(VARIANT var_id,
+                                                           BSTR* def_action) {
+  IAccessible* target;
+  if ((target = GetTargetAndChildID(&var_id))) {
+    return window_accessible_->get_accDefaultAction(var_id, def_action);
+  }
+  *def_action = nullptr;
+  return S_FALSE;
+}
+
+IFACEMETHODIMP AccessibilityRootNode::get_accDescription(VARIANT var_id,
+                                                         BSTR* desc) {
+  IAccessible* target;
+  if ((target = GetTargetAndChildID(&var_id))) {
+    return window_accessible_->get_accDescription(var_id, desc);
+  }
+  return E_FAIL;
+}
+
+IFACEMETHODIMP AccessibilityRootNode::get_accFocus(VARIANT* focus_child) {
+  if (window_accessible_) {
+    return window_accessible_->get_accFocus(focus_child);
+  }
+  focus_child->vt = VT_EMPTY;
+  return S_OK;
+}
+
+IFACEMETHODIMP AccessibilityRootNode::get_accKeyboardShortcut(VARIANT var_id,
+                                                              BSTR* acc_key) {
+  IAccessible* target;
+  if ((target = GetTargetAndChildID(&var_id))) {
+    return window_accessible_->get_accKeyboardShortcut(var_id, acc_key);
+  }
+  return E_FAIL;
+}
+
+IFACEMETHODIMP AccessibilityRootNode::get_accName(VARIANT var_id, BSTR* name_bstr) {
+  IAccessible* target;
+  if ((target = GetTargetAndChildID(&var_id))) {
+    return window_accessible_->get_accName(var_id, name_bstr);
+  }
+  return S_FALSE;
+}
+
+IFACEMETHODIMP AccessibilityRootNode::get_accParent(IDispatch** disp_parent) {
+  return S_FALSE;
+}
+
+IFACEMETHODIMP AccessibilityRootNode::get_accRole(VARIANT var_id, VARIANT* role) {
+  IAccessible* target;
+  if ((target = GetTargetAndChildID(&var_id))) {
+    return window_accessible_->get_accRole(var_id, role);
+  }
+  return E_FAIL;
+}
+
+IFACEMETHODIMP AccessibilityRootNode::get_accState(VARIANT var_id, VARIANT* state) {
+  IAccessible* target;
+  if ((target = GetTargetAndChildID(&var_id))) {
+    return window_accessible_->get_accState(var_id, state);
+  }
+  return E_FAIL;
+}
+
+IFACEMETHODIMP AccessibilityRootNode::get_accHelp(VARIANT var_id, BSTR* help) {
+  if (!help) {
+    return E_INVALIDARG;
+  }
+  *help = {};
+  return S_FALSE;
+}
+
+IFACEMETHODIMP AccessibilityRootNode::get_accValue(VARIANT var_id, BSTR* value) {
+  IAccessible* target;
+  if ((target = GetTargetAndChildID(&var_id))) {
+    return window_accessible_->get_accValue(var_id, value);
+  }
+  return E_FAIL;
+}
+
+IFACEMETHODIMP AccessibilityRootNode::put_accValue(VARIANT var_id, BSTR new_value) {
+  IAccessible* target;
+  if ((target = GetTargetAndChildID(&var_id))) {
+    return window_accessible_->put_accValue(var_id, new_value);
+  }
+  return E_FAIL;
+}
+
+IFACEMETHODIMP AccessibilityRootNode::get_accSelection(VARIANT* selected) {
+  selected->vt = VT_EMPTY;
+  return S_OK;
+}
+
+IFACEMETHODIMP AccessibilityRootNode::accSelect(LONG flagsSelect, VARIANT var_id) {
+  IAccessible* target;
+  if ((target = GetTargetAndChildID(&var_id))) {
+    return window_accessible_->accSelect(flagsSelect, var_id);
+  }
+  return E_FAIL;
+}
+
+IFACEMETHODIMP AccessibilityRootNode::get_accHelpTopic(BSTR* help_file,
+                                                       VARIANT var_id,
+                                                       LONG* topic_id) {
+  if (help_file) {
+    *help_file = nullptr;
+  }
+  if (topic_id) {
+    *topic_id = -1;
+  }
+  return E_NOTIMPL;
+}
+
+IFACEMETHODIMP AccessibilityRootNode::put_accName(VARIANT var_id, BSTR put_name) {
+  return E_NOTIMPL;
+}
 
 }

--- a/shell/platform/windows/accessibility_root_node.cc
+++ b/shell/platform/windows/accessibility_root_node.cc
@@ -103,7 +103,8 @@ IFACEMETHODIMP AccessibilityRootNode::get_accChild(VARIANT var_child,
   } else if (child_id == kAlertChildId && alert_accessible_) {
     *disp_child = alert_accessible_;
   } else if (child_id < 0) {
-    // A negative child ID can be used to refer to an AX node directly by its ID.
+    // A negative child ID can be used to refer to an AX node directly by its
+    // ID.
     return window_accessible_->get_accChild(var_child, disp_child);
   } else {
     return E_FAIL;

--- a/shell/platform/windows/accessibility_root_node.cc
+++ b/shell/platform/windows/accessibility_root_node.cc
@@ -253,6 +253,7 @@ AccessibilityAlert* AccessibilityRootNode::GetOrCreateAlert() {
     if (!SUCCEEDED(hr)) {
       FML_LOG(FATAL) << "Failed to create alert accessible";
     }
+    instance->AddRef();
     instance->SetParent(this);
     alert_accessible_ = instance;
   }

--- a/shell/platform/windows/accessibility_root_node.cc
+++ b/shell/platform/windows/accessibility_root_node.cc
@@ -1,0 +1,9 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/windows/accessibility_root_node.h"
+
+namespace flutter {
+
+}

--- a/shell/platform/windows/accessibility_root_node.cc
+++ b/shell/platform/windows/accessibility_root_node.cc
@@ -5,6 +5,7 @@
 #include "flutter/shell/platform/windows/accessibility_root_node.h"
 
 #include "flutter/fml/logging.h"
+#include "flutter/third_party/accessibility/base/win/atl_module.h"
 
 namespace flutter {
 
@@ -268,6 +269,18 @@ AccessibilityAlert* AccessibilityRootNode::GetOrCreateAlert() {
     alert_accessible_ = instance;
   }
   return alert_accessible_;
+}
+
+// static
+AccessibilityRootNode* AccessibilityRootNode::Create() {
+  ui::win::CreateATLModuleIfNeeded();
+  CComObject<AccessibilityRootNode>* instance = nullptr;
+  HRESULT hr = CComObject<AccessibilityRootNode>::CreateInstance(&instance);
+  if (!SUCCEEDED(hr) || !instance) {
+    FML_LOG(FATAL) << "Failed to create accessibility root node";
+  }
+  instance->AddRef();
+  return instance;
 }
 
 }  // namespace flutter

--- a/shell/platform/windows/accessibility_root_node.cc
+++ b/shell/platform/windows/accessibility_root_node.cc
@@ -11,8 +11,7 @@ namespace flutter {
 static constexpr LONG kWindowChildId = 1;
 static constexpr LONG kInvalidChildId = 3;
 
-AccessibilityRootNode::AccessibilityRootNode() :
-    alert_accessible_(nullptr) {}
+AccessibilityRootNode::AccessibilityRootNode() : alert_accessible_(nullptr) {}
 
 AccessibilityRootNode::~AccessibilityRootNode() {
   if (alert_accessible_) {
@@ -49,7 +48,8 @@ IFACEMETHODIMP AccessibilityRootNode::accHitTest(LONG screen_physical_pixel_x,
                                                  LONG screen_physical_pixel_y,
                                                  VARIANT* child) {
   if (window_accessible_) {
-    return window_accessible_->accHitTest(screen_physical_pixel_x, screen_physical_pixel_y, child);
+    return window_accessible_->accHitTest(screen_physical_pixel_x,
+                                          screen_physical_pixel_y, child);
   }
   child->vt = VT_EMPTY;
   return S_FALSE;
@@ -70,7 +70,8 @@ IFACEMETHODIMP AccessibilityRootNode::accLocation(LONG* physical_pixel_left,
                                                   VARIANT var_id) {
   IAccessible* target;
   if ((target = GetTargetAndChildID(&var_id))) {
-    return target->accLocation(physical_pixel_left, physical_pixel_top, width, height, var_id);
+    return target->accLocation(physical_pixel_left, physical_pixel_top, width,
+                               height, var_id);
   }
   return S_FALSE;
 }
@@ -156,7 +157,8 @@ IFACEMETHODIMP AccessibilityRootNode::get_accKeyboardShortcut(VARIANT var_id,
   return E_FAIL;
 }
 
-IFACEMETHODIMP AccessibilityRootNode::get_accName(VARIANT var_id, BSTR* name_bstr) {
+IFACEMETHODIMP AccessibilityRootNode::get_accName(VARIANT var_id,
+                                                  BSTR* name_bstr) {
   if (V_I4(&var_id) == CHILDID_SELF) {
     std::wstring name = L"ROOT_NODE_VIEW";
     *name_bstr = SysAllocString(name.c_str());
@@ -173,7 +175,8 @@ IFACEMETHODIMP AccessibilityRootNode::get_accParent(IDispatch** disp_parent) {
   return S_FALSE;
 }
 
-IFACEMETHODIMP AccessibilityRootNode::get_accRole(VARIANT var_id, VARIANT* role) {
+IFACEMETHODIMP AccessibilityRootNode::get_accRole(VARIANT var_id,
+                                                  VARIANT* role) {
   IAccessible* target;
   if ((target = GetTargetAndChildID(&var_id))) {
     return target->get_accRole(var_id, role);
@@ -181,7 +184,8 @@ IFACEMETHODIMP AccessibilityRootNode::get_accRole(VARIANT var_id, VARIANT* role)
   return E_FAIL;
 }
 
-IFACEMETHODIMP AccessibilityRootNode::get_accState(VARIANT var_id, VARIANT* state) {
+IFACEMETHODIMP AccessibilityRootNode::get_accState(VARIANT var_id,
+                                                   VARIANT* state) {
   IAccessible* target;
   if ((target = GetTargetAndChildID(&var_id))) {
     return target->get_accState(var_id, state);
@@ -197,7 +201,8 @@ IFACEMETHODIMP AccessibilityRootNode::get_accHelp(VARIANT var_id, BSTR* help) {
   return S_FALSE;
 }
 
-IFACEMETHODIMP AccessibilityRootNode::get_accValue(VARIANT var_id, BSTR* value) {
+IFACEMETHODIMP AccessibilityRootNode::get_accValue(VARIANT var_id,
+                                                   BSTR* value) {
   IAccessible* target;
   if ((target = GetTargetAndChildID(&var_id))) {
     return target->get_accValue(var_id, value);
@@ -205,7 +210,8 @@ IFACEMETHODIMP AccessibilityRootNode::get_accValue(VARIANT var_id, BSTR* value) 
   return E_FAIL;
 }
 
-IFACEMETHODIMP AccessibilityRootNode::put_accValue(VARIANT var_id, BSTR new_value) {
+IFACEMETHODIMP AccessibilityRootNode::put_accValue(VARIANT var_id,
+                                                   BSTR new_value) {
   IAccessible* target;
   if ((target = GetTargetAndChildID(&var_id))) {
     return target->put_accValue(var_id, new_value);
@@ -218,7 +224,8 @@ IFACEMETHODIMP AccessibilityRootNode::get_accSelection(VARIANT* selected) {
   return S_OK;
 }
 
-IFACEMETHODIMP AccessibilityRootNode::accSelect(LONG flagsSelect, VARIANT var_id) {
+IFACEMETHODIMP AccessibilityRootNode::accSelect(LONG flagsSelect,
+                                                VARIANT var_id) {
   IAccessible* target;
   if ((target = GetTargetAndChildID(&var_id))) {
     return target->accSelect(flagsSelect, var_id);
@@ -238,7 +245,8 @@ IFACEMETHODIMP AccessibilityRootNode::get_accHelpTopic(BSTR* help_file,
   return E_NOTIMPL;
 }
 
-IFACEMETHODIMP AccessibilityRootNode::put_accName(VARIANT var_id, BSTR put_name) {
+IFACEMETHODIMP AccessibilityRootNode::put_accName(VARIANT var_id,
+                                                  BSTR put_name) {
   return E_NOTIMPL;
 }
 
@@ -260,4 +268,4 @@ AccessibilityAlert* AccessibilityRootNode::GetOrCreateAlert() {
   return alert_accessible_;
 }
 
-}
+}  // namespace flutter

--- a/shell/platform/windows/accessibility_root_node.cc
+++ b/shell/platform/windows/accessibility_root_node.cc
@@ -24,7 +24,7 @@ IAccessible* AccessibilityRootNode::GetTargetAndChildID(VARIANT* var_id) {
   LONG& child_id = var_id->lVal;
   if (V_VT(var_id) != VT_I4) {
     child_id = kInvalidChildId;
-    return FALSE;
+    return nullptr;
   }
   child_id = V_I4(var_id);
   if (!window_accessible_) {
@@ -38,6 +38,7 @@ IAccessible* AccessibilityRootNode::GetTargetAndChildID(VARIANT* var_id) {
     child_id = CHILDID_SELF;
     return alert_accessible_;
   }
+  // A negative child ID can be used to refer to an AX node directly by its ID.
   if (child_id < 0) {
     return window_accessible_;
   }

--- a/shell/platform/windows/accessibility_root_node.cc
+++ b/shell/platform/windows/accessibility_root_node.cc
@@ -102,6 +102,7 @@ IFACEMETHODIMP AccessibilityRootNode::get_accChild(VARIANT var_child,
   } else if (child_id == kAlertChildId && alert_accessible_) {
     *disp_child = alert_accessible_;
   } else if (child_id < 0) {
+    // A negative child ID can be used to refer to an AX node directly by its ID.
     return window_accessible_->get_accChild(var_child, disp_child);
   } else {
     return E_FAIL;

--- a/shell/platform/windows/accessibility_root_node.cc
+++ b/shell/platform/windows/accessibility_root_node.cc
@@ -170,7 +170,7 @@ IFACEMETHODIMP AccessibilityRootNode::get_accName(VARIANT var_id,
   }
   IAccessible* target;
   if ((target = GetTargetAndChildID(&var_id))) {
-    return window_accessible_->get_accName(var_id, name_bstr);
+    return target->get_accName(var_id, name_bstr);
   }
   return S_FALSE;
 }

--- a/shell/platform/windows/accessibility_root_node.h
+++ b/shell/platform/windows/accessibility_root_node.h
@@ -120,4 +120,4 @@ class AccessibilityRootNode : public CComObjectRootEx<CComMultiThreadModel>,
 
 }  // namespace flutter
 
-#endif
+#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_ACCESSIBILITY_ROOT_NODE_H_

--- a/shell/platform/windows/accessibility_root_node.h
+++ b/shell/platform/windows/accessibility_root_node.h
@@ -99,13 +99,15 @@ class AccessibilityRootNode : public CComObjectRootEx<CComMultiThreadModel>,
   IFACEMETHODIMP put_accName(VARIANT var_id, BSTR put_name) override;
 
   AccessibilityRootNode();
-  ~AccessibilityRootNode();
+  virtual ~AccessibilityRootNode();
 
   void SetWindow(IAccessible* window);
 
   void SetAlert(AccessibilityAlert* alert);
 
   AccessibilityAlert* GetOrCreateAlert();
+
+  static AccessibilityRootNode* Create();
 
  private:
   // Helper method to redirect method calls to the contained window or alert.

--- a/shell/platform/windows/accessibility_root_node.h
+++ b/shell/platform/windows/accessibility_root_node.h
@@ -9,14 +9,110 @@
 #include <atlcom.h>
 #include <oleacc.h>
 
+#include <memory>
+
+#include "flutter/shell/platform/windows/accessibility_alert.h"
+
 namespace flutter {
 
+// A parent node that wraps the window IAccessible node.
 class AccessibilityRootNode : public CComObjectRootEx<CComMultiThreadModel>,
                               public IAccessible {
  public:
   BEGIN_COM_MAP(AccessibilityRootNode)
   COM_INTERFACE_ENTRY(IAccessible)
   END_COM_MAP()
+
+  //
+  // IAccessible methods.
+  //
+
+  // Retrieves the child element or child object at a given point on the screen.
+  IFACEMETHODIMP accHitTest(LONG screen_physical_pixel_x,
+                            LONG screen_physical_pixel_y,
+                            VARIANT* child) override;
+
+  // Performs the object's default action.
+  IFACEMETHODIMP accDoDefaultAction(VARIANT var_id) override;
+
+  // Retrieves the specified object's current screen location.
+  IFACEMETHODIMP accLocation(LONG* physical_pixel_left,
+                             LONG* physical_pixel_top,
+                             LONG* width,
+                             LONG* height,
+                             VARIANT var_id) override;
+
+  // Traverses to another UI element and retrieves the object.
+  IFACEMETHODIMP accNavigate(LONG nav_dir,
+                             VARIANT start,
+                             VARIANT* end) override;
+
+  // Retrieves an IDispatch interface pointer for the specified child.
+  IFACEMETHODIMP get_accChild(VARIANT var_child,
+                              IDispatch** disp_child) override;
+
+  // Retrieves the number of accessible children.
+  IFACEMETHODIMP get_accChildCount(LONG* child_count) override;
+
+  // Retrieves a string that describes the object's default action.
+  IFACEMETHODIMP get_accDefaultAction(VARIANT var_id,
+                                      BSTR* default_action) override;
+
+  // Retrieves the tooltip description.
+  IFACEMETHODIMP get_accDescription(VARIANT var_id, BSTR* desc) override;
+
+  // Retrieves the object that has the keyboard focus.
+  IFACEMETHODIMP get_accFocus(VARIANT* focus_child) override;
+
+  // Retrieves the specified object's shortcut.
+  IFACEMETHODIMP get_accKeyboardShortcut(VARIANT var_id,
+                                         BSTR* access_key) override;
+
+  // Retrieves the name of the specified object.
+  IFACEMETHODIMP get_accName(VARIANT var_id, BSTR* name) override;
+
+  // Retrieves the IDispatch interface of the object's parent.
+  IFACEMETHODIMP get_accParent(IDispatch** disp_parent) override;
+
+  // Retrieves information describing the role of the specified object.
+  IFACEMETHODIMP get_accRole(VARIANT var_id, VARIANT* role) override;
+
+  // Retrieves the current state of the specified object.
+  IFACEMETHODIMP get_accState(VARIANT var_id, VARIANT* state) override;
+
+  // Gets the help string for the specified object.
+  IFACEMETHODIMP get_accHelp(VARIANT var_id, BSTR* help) override;
+
+  // Retrieve or set the string value associated with the specified object.
+  // Setting the value is not typically used by screen readers, but it's
+  // used frequently by automation software.
+  IFACEMETHODIMP get_accValue(VARIANT var_id, BSTR* value) override;
+  IFACEMETHODIMP put_accValue(VARIANT var_id, BSTR new_value) override;
+
+  // IAccessible methods not implemented.
+  IFACEMETHODIMP get_accSelection(VARIANT* selected) override;
+  IFACEMETHODIMP accSelect(LONG flags_sel, VARIANT var_id) override;
+  IFACEMETHODIMP get_accHelpTopic(BSTR* help_file,
+                                  VARIANT var_id,
+                                  LONG* topic_id) override;
+  IFACEMETHODIMP put_accName(VARIANT var_id, BSTR put_name) override;
+
+  AccessibilityRootNode() = default;
+  ~AccessibilityRootNode();
+
+  void SetWindow(IAccessible* window);
+
+  void SetAlert(AccessibilityAlert* alert);
+
+  inline AccessibilityAlert* GetAlert() {return alert_accessible_;}
+
+ private:
+  // Helper method to redirect method calls to the contained window.
+  IAccessible* GetTargetAndChildID(VARIANT* var_id);
+
+  IAccessible* window_accessible_;
+
+  AccessibilityAlert* alert_accessible_;
 
 };
 

--- a/shell/platform/windows/accessibility_root_node.h
+++ b/shell/platform/windows/accessibility_root_node.h
@@ -114,9 +114,8 @@ class AccessibilityRootNode : public CComObjectRootEx<CComMultiThreadModel>,
   IAccessible* window_accessible_;
 
   AccessibilityAlert* alert_accessible_;
-
 };
 
-}
+}  // namespace flutter
 
 #endif

--- a/shell/platform/windows/accessibility_root_node.h
+++ b/shell/platform/windows/accessibility_root_node.h
@@ -17,8 +17,9 @@ namespace flutter {
 
 // A parent node that wraps the window IAccessible node.
 class AccessibilityRootNode : public CComObjectRootEx<CComMultiThreadModel>,
-                              public IAccessible {
+                              public IDispatchImpl<IAccessible> {
  public:
+  static constexpr LONG kAlertChildId = 2;
   BEGIN_COM_MAP(AccessibilityRootNode)
   COM_INTERFACE_ENTRY(IAccessible)
   END_COM_MAP()
@@ -97,14 +98,14 @@ class AccessibilityRootNode : public CComObjectRootEx<CComMultiThreadModel>,
                                   LONG* topic_id) override;
   IFACEMETHODIMP put_accName(VARIANT var_id, BSTR put_name) override;
 
-  AccessibilityRootNode() = default;
+  AccessibilityRootNode();
   ~AccessibilityRootNode();
 
   void SetWindow(IAccessible* window);
 
   void SetAlert(AccessibilityAlert* alert);
 
-  inline AccessibilityAlert* GetAlert() {return alert_accessible_;}
+  AccessibilityAlert* GetOrCreateAlert();
 
  private:
   // Helper method to redirect method calls to the contained window.

--- a/shell/platform/windows/accessibility_root_node.h
+++ b/shell/platform/windows/accessibility_root_node.h
@@ -1,0 +1,25 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_ACCESSIBILITY_ROOT_NODE_H_
+#define FLUTTER_SHELL_PLATFORM_WINDOWS_ACCESSIBILITY_ROOT_NODE_H_
+
+#include <atlbase.h>
+#include <atlcom.h>
+#include <oleacc.h>
+
+namespace flutter {
+
+class AccessibilityRootNode : public CComObjectRootEx<CComMultiThreadModel>,
+                              public IAccessible {
+ public:
+  BEGIN_COM_MAP(AccessibilityRootNode)
+  COM_INTERFACE_ENTRY(IAccessible)
+  END_COM_MAP()
+
+};
+
+}
+
+#endif

--- a/shell/platform/windows/accessibility_root_node.h
+++ b/shell/platform/windows/accessibility_root_node.h
@@ -108,7 +108,7 @@ class AccessibilityRootNode : public CComObjectRootEx<CComMultiThreadModel>,
   AccessibilityAlert* GetOrCreateAlert();
 
  private:
-  // Helper method to redirect method calls to the contained window.
+  // Helper method to redirect method calls to the contained window or alert.
   IAccessible* GetTargetAndChildID(VARIANT* var_id);
 
   IAccessible* window_accessible_;

--- a/shell/platform/windows/fixtures/main.dart
+++ b/shell/platform/windows/fixtures/main.dart
@@ -40,33 +40,37 @@ void hiPlatformChannels() {
 @pragma('vm:entry-point')
 void alertPlatformChannel() async {
   // Serializers for data types are in the framework, so this will be hardcoded.
-  Uint8List data = Uint8List.fromList([
-    13, // _valueMap
+  const int valueMap = 13, valueString = 7;
+  // Corresponds to:
+  // Map<String, Object> data =
+  // {"type": "announce", "data": {"message": ""}};
+  final Uint8List data = Uint8List.fromList([
+    valueMap, // _valueMap
     2, // Size
     // key: "type"
-    7, // _valueString
+    valueString,
     'type'.length,
     ...'type'.codeUnits,
     // value: "announce"
-    7,
+    valueString,
     'announce'.length,
     ...'announce'.codeUnits,
     // key: "data"
-    7, // _valueString
+    valueString,
     'data'.length,
     ...'data'.codeUnits,
     // value: map
-    13, // _valueMap
+    valueMap, // _valueMap
     1, // Size
     // key: "message"
-    7, // _valueString
+    valueString,
     'message'.length,
     ...'message'.codeUnits,
     // value: ""
-    7, // _valueString
-    0
+    valueString,
+    0, // Length of empty string == 0.
   ]);
-  ByteData byteData = data.buffer.asByteData();
+  final ByteData byteData = data.buffer.asByteData();
 
   final Completer<ByteData?> enabled = Completer<ByteData?>();
   ui.PlatformDispatcher.instance.sendPlatformMessage('semantics', ByteData(0), (ByteData? reply){

--- a/shell/platform/windows/flutter_window.cc
+++ b/shell/platform/windows/flutter_window.cc
@@ -291,4 +291,8 @@ void FlutterWindow::SendInitialAccessibilityFeatures() {
   OnThemeChange();
 }
 
+AccessibilityRootNode* FlutterWindow::GetAccessibilityRootNode() {
+  return accessibility_root_;
+}
+
 }  // namespace flutter

--- a/shell/platform/windows/flutter_window.cc
+++ b/shell/platform/windows/flutter_window.cc
@@ -292,6 +292,9 @@ void FlutterWindow::SendInitialAccessibilityFeatures() {
 }
 
 AccessibilityRootNode* FlutterWindow::GetAccessibilityRootNode() {
+  if (!accessibility_root_) {
+    CreateAccessibilityRootNode();
+  }
   return accessibility_root_;
 }
 

--- a/shell/platform/windows/flutter_window.cc
+++ b/shell/platform/windows/flutter_window.cc
@@ -292,6 +292,7 @@ void FlutterWindow::SendInitialAccessibilityFeatures() {
 }
 
 AccessibilityRootNode* FlutterWindow::GetAccessibilityRootNode() {
+  FML_LOG(ERROR) << "Returning accessibility_root_";
   return accessibility_root_;
 }
 

--- a/shell/platform/windows/flutter_window.cc
+++ b/shell/platform/windows/flutter_window.cc
@@ -292,7 +292,6 @@ void FlutterWindow::SendInitialAccessibilityFeatures() {
 }
 
 AccessibilityRootNode* FlutterWindow::GetAccessibilityRootNode() {
-  FML_LOG(ERROR) << "Returning accessibility_root_";
   return accessibility_root_;
 }
 

--- a/shell/platform/windows/flutter_window.h
+++ b/shell/platform/windows/flutter_window.h
@@ -148,6 +148,9 @@ class FlutterWindow : public Window, public WindowBindingHandler {
   // |WindowBindingHandler|
   void SendInitialAccessibilityFeatures() override;
 
+  // |WindowBindingHandler|
+  AccessibilityRootNode* GetAccessibilityRootNode() override;
+
  private:
   // A pointer to a FlutterWindowsView that can be used to update engine
   // windowing and input state.

--- a/shell/platform/windows/flutter_window_unittests.cc
+++ b/shell/platform/windows/flutter_window_unittests.cc
@@ -404,14 +404,16 @@ TEST(FlutterWindowTest, InitialAccessibilityFeatures) {
 // Ensure that announcing the alert propagates the message to the alert node.
 // Different screen readers use different properties for alerts.
 TEST(FlutterWindowTest, AlertNode) {
-  std::unique_ptr<MockFlutterWindow> win32window = std::make_unique<MockFlutterWindow>();;
+  std::unique_ptr<MockFlutterWindow> win32window =
+      std::make_unique<MockFlutterWindow>();
+  ;
   ON_CALL(*win32window, GetPlatformWindow()).WillByDefault(Return(nullptr));
   AccessibilityRootNode* root_node = win32window->GetAccessibilityRootNode();
   TestFlutterWindowsView view(std::move(win32window));
   std::wstring message = L"Test alert";
   view.AnnounceAlert(message);
   IAccessible* alert = root_node->GetOrCreateAlert();
-  VARIANT self{.vt=VT_I4, .lVal=CHILDID_SELF};
+  VARIANT self{.vt = VT_I4, .lVal = CHILDID_SELF};
   BSTR strptr;
   alert->get_accName(self, &strptr);
   EXPECT_EQ(message, strptr);

--- a/shell/platform/windows/flutter_window_unittests.cc
+++ b/shell/platform/windows/flutter_window_unittests.cc
@@ -412,7 +412,10 @@ TEST(FlutterWindowTest, AlertNode) {
   ON_CALL(*win32window, GetPlatformWindow()).WillByDefault(Return(nullptr));
   AccessibilityRootNode* root_node = win32window->GetAccessibilityRootNode();
   TestFlutterWindowsView view(std::move(win32window));
-  EXPECT_CALL(view, NotifyWinEventWrapper(EVENT_SYSTEM_ALERT, nullptr, OBJID_CLIENT, AccessibilityRootNode::kAlertChildId)).Times(1);
+  EXPECT_CALL(view,
+              NotifyWinEventWrapper(EVENT_SYSTEM_ALERT, nullptr, OBJID_CLIENT,
+                                    AccessibilityRootNode::kAlertChildId))
+      .Times(1);
   std::wstring message = L"Test alert";
   view.AnnounceAlert(message);
   IAccessible* alert = root_node->GetOrCreateAlert();

--- a/shell/platform/windows/flutter_window_unittests.cc
+++ b/shell/platform/windows/flutter_window_unittests.cc
@@ -154,9 +154,12 @@ class TestFlutterWindowsView : public FlutterWindowsView {
  public:
   TestFlutterWindowsView(std::unique_ptr<WindowBindingHandler> window_binding)
       : FlutterWindowsView(std::move(window_binding)) {}
+  ~TestFlutterWindowsView() {}
 
   SpyKeyboardKeyHandler* key_event_handler;
   SpyTextInputPlugin* text_input_plugin;
+
+  MOCK_METHOD4(NotifyWinEventWrapper, void(DWORD, HWND, LONG, LONG));
 
  protected:
   std::unique_ptr<KeyboardHandlerBase> CreateKeyboardKeyHandler(
@@ -406,10 +409,10 @@ TEST(FlutterWindowTest, InitialAccessibilityFeatures) {
 TEST(FlutterWindowTest, AlertNode) {
   std::unique_ptr<MockFlutterWindow> win32window =
       std::make_unique<MockFlutterWindow>();
-  ;
   ON_CALL(*win32window, GetPlatformWindow()).WillByDefault(Return(nullptr));
   AccessibilityRootNode* root_node = win32window->GetAccessibilityRootNode();
   TestFlutterWindowsView view(std::move(win32window));
+  EXPECT_CALL(view, NotifyWinEventWrapper(EVENT_SYSTEM_ALERT, nullptr, OBJID_CLIENT, AccessibilityRootNode::kAlertChildId)).Times(1);
   std::wstring message = L"Test alert";
   view.AnnounceAlert(message);
   IAccessible* alert = root_node->GetOrCreateAlert();

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -697,7 +697,7 @@ void FlutterWindowsEngine::HandleAccessibilityMessage(FlutterDesktopMessengerRef
         .tooltip = ""
       };
       accessibility_bridge_->AddFlutterSemanticsNodeUpdate(&announcement);
-      accessibility_bridge_->CommitUpdates();*/
+      accessibility_bridge_->CommitUpdates();
       auto root = std::static_pointer_cast<FlutterPlatformNodeDelegateWindows>(accessibility_bridge_->GetFlutterPlatformNodeDelegateFromID(AccessibilityBridge::kRootNodeId).lock());
       FML_LOG(ERROR) << "Got root? " << (!!root);
       auto root_node = root->GetAXNode();
@@ -712,7 +712,9 @@ void FlutterWindowsEngine::HandleAccessibilityMessage(FlutterDesktopMessengerRef
       int32_t uindex = root_node->GetUnignoredChildCount();
       ui::AXNode* node = new ui::AXNode(owner_tree, root_node, -1, index_in_parent, uindex);
       siblings.push_back(node);
-      root_node->SwapChildren(&siblings);
+      root_node->SwapChildren(&siblings);*/
+      std::wstring wide_text = fml::Utf8ToWideString(text);
+      view_->AnnounceAlert(wide_text);
     }
   }
   SendPlatformMessageResponse(message->response_handle, reinterpret_cast<const uint8_t*>(""), 0);

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -673,46 +673,10 @@ void FlutterWindowsEngine::HandleAccessibilityMessage(FlutterDesktopMessengerRef
   auto data = codec.DecodeMessage(message->message, message->message_size);
   EncodableMap map = std::get<EncodableMap>(*data);
   std::string type = std::get<std::string>(map.at(EncodableValue("type")));
-  FML_LOG(ERROR) << "Handling a11y call of type " << type;
   if (type.compare("announce") == 0) {
     if (semantics_enabled_) {
       EncodableMap data_map = std::get<EncodableMap>(map.at(EncodableValue("data")));
       std::string text = std::get<std::string>(data_map.at(EncodableValue("message")));
-      FML_LOG(ERROR) << "Announcing " << text;
-      /*FlutterSemanticsNode announcement = {
-        .struct_size = sizeof(FlutterSemanticsNode),
-        .id = -1,
-        .flags = static_cast<FlutterSemanticsFlag>(0),
-        .actions = static_cast<FlutterSemanticsAction>(0),
-        .text_selection_base = -1,
-        .text_selection_extent = -1,
-        .label = text.c_str(),
-        .hint = "",
-        .value = "",
-        .increased_value = "",
-        .decreased_value = "",
-        .child_count = 0,
-        .children_in_traversal_order = nullptr,
-        .custom_accessibility_actions_count = 0,
-        .tooltip = ""
-      };
-      accessibility_bridge_->AddFlutterSemanticsNodeUpdate(&announcement);
-      accessibility_bridge_->CommitUpdates();
-      auto root = std::static_pointer_cast<FlutterPlatformNodeDelegateWindows>(accessibility_bridge_->GetFlutterPlatformNodeDelegateFromID(AccessibilityBridge::kRootNodeId).lock());
-      FML_LOG(ERROR) << "Got root? " << (!!root);
-      auto root_node = root->GetAXNode();
-      int32_t root_id = root_node->id();
-      FML_LOG(ERROR) << "Root id = " << root_id;
-      for (auto it = root_node->UnignoredChildrenBegin(); it != root_node->UnignoredChildrenEnd(); ++it) {
-        FML_LOG(ERROR) << "ID of child: " << it->id();
-      }
-      auto owner_tree = root_node->tree();
-      auto siblings = root_node->children();
-      int32_t index_in_parent = siblings.size();
-      int32_t uindex = root_node->GetUnignoredChildCount();
-      ui::AXNode* node = new ui::AXNode(owner_tree, root_node, -1, index_in_parent, uindex);
-      siblings.push_back(node);
-      root_node->SwapChildren(&siblings);*/
       std::wstring wide_text = fml::Utf8ToWideString(text);
       view_->AnnounceAlert(wide_text);
     }

--- a/shell/platform/windows/flutter_windows_engine.h
+++ b/shell/platform/windows/flutter_windows_engine.h
@@ -254,6 +254,8 @@ class FlutterWindowsEngine {
   // system changes.
   void SendSystemLocales();
 
+  void HandleAccessibilityMessage(FlutterDesktopMessengerRef messenger, const FlutterDesktopMessage* message);
+
   // The handle to the embedder.h engine instance.
   FLUTTER_API_SYMBOL(FlutterEngine) engine_ = nullptr;
 

--- a/shell/platform/windows/flutter_windows_engine.h
+++ b/shell/platform/windows/flutter_windows_engine.h
@@ -254,7 +254,8 @@ class FlutterWindowsEngine {
   // system changes.
   void SendSystemLocales();
 
-  void HandleAccessibilityMessage(FlutterDesktopMessengerRef messenger, const FlutterDesktopMessage* message);
+  void HandleAccessibilityMessage(FlutterDesktopMessengerRef messenger,
+                                  const FlutterDesktopMessage* message);
 
   // The handle to the embedder.h engine instance.
   FLUTTER_API_SYMBOL(FlutterEngine) engine_ = nullptr;

--- a/shell/platform/windows/flutter_windows_engine_unittests.cc
+++ b/shell/platform/windows/flutter_windows_engine_unittests.cc
@@ -6,10 +6,13 @@
 
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/embedder/test_utils/proc_table_replacement.h"
+#include "flutter/shell/platform/windows/flutter_windows_view.h"
 #include "flutter/shell/platform/windows/testing/engine_modifier.h"
+#include "flutter/shell/platform/windows/testing/mock_window_binding_handler.h"
 #include "flutter/shell/platform/windows/testing/test_keyboard.h"
 #include "flutter/shell/platform/windows/testing/windows_test.h"
 #include "fml/synchronization/waitable_event.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 // winbase.h defines GetCurrentTime as a macro.
@@ -514,6 +517,58 @@ TEST_F(FlutterWindowsEngineTest, PostRasterThreadTask) {
   engine->PostRasterThreadTask([&called]() { called = true; });
 
   EXPECT_TRUE(called);
+}
+
+class MockFlutterWindowsView : public FlutterWindowsView {
+ public:
+  MockFlutterWindowsView(std::unique_ptr<WindowBindingHandler> wbh) : FlutterWindowsView(std::move(wbh)) {}
+  ~MockFlutterWindowsView() {}
+
+  MOCK_METHOD4(NotifyWinEventWrapper, void(DWORD, HWND, LONG, LONG));
+};
+
+TEST_F(FlutterWindowsEngineTest, AlertPlatformMessage) {
+  FlutterDesktopEngineProperties properties = {};
+  properties.assets_path = GetContext().GetAssetsPath().c_str();
+  properties.icu_data_path = GetContext().GetIcuDataPath().c_str();
+  properties.dart_entrypoint = "alertPlatformChannel";
+
+  FlutterProjectBundle project(properties);
+
+  auto window_binding_handler = std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();
+  AccessibilityRootNode* root_node = AccessibilityRootNode::Create();
+  ON_CALL(*window_binding_handler, GetAccessibilityRootNode).WillByDefault(::testing::Return(root_node));
+  MockFlutterWindowsView view(std::move(window_binding_handler));
+  view.SetEngine(std::make_unique<FlutterWindowsEngine>(project));
+  FlutterWindowsEngine* engine = view.GetEngine();
+
+  EngineModifier modifier(engine);
+  modifier.embedder_api().RunsAOTCompiledDartCode = []() { return false; };
+
+  auto binary_messenger =
+      std::make_unique<BinaryMessengerImpl>(engine->messenger());
+  binary_messenger->SetMessageHandler(
+      "semantics",
+      [&engine](
+          const uint8_t* message, size_t message_size, BinaryReply reply) {
+            engine->UpdateSemanticsEnabled(true);
+            char response[] = "";
+            reply(reinterpret_cast<uint8_t*>(response), 0);
+      });
+
+  bool did_call = false;
+  ON_CALL(view, NotifyWinEventWrapper).WillByDefault([&did_call](DWORD event, HWND hwnd, LONG obj, LONG child) {
+    did_call = true;
+  });
+
+
+  engine->UpdateSemanticsEnabled(true);
+  engine->Run();
+  
+  // Rely on timeout mechanism in CI.
+  while (!did_call) {
+    engine->task_runner()->ProcessTasks();
+  }
 }
 
 }  // namespace testing

--- a/shell/platform/windows/flutter_windows_engine_unittests.cc
+++ b/shell/platform/windows/flutter_windows_engine_unittests.cc
@@ -521,7 +521,8 @@ TEST_F(FlutterWindowsEngineTest, PostRasterThreadTask) {
 
 class MockFlutterWindowsView : public FlutterWindowsView {
  public:
-  MockFlutterWindowsView(std::unique_ptr<WindowBindingHandler> wbh) : FlutterWindowsView(std::move(wbh)) {}
+  MockFlutterWindowsView(std::unique_ptr<WindowBindingHandler> wbh)
+      : FlutterWindowsView(std::move(wbh)) {}
   ~MockFlutterWindowsView() {}
 
   MOCK_METHOD4(NotifyWinEventWrapper, void(DWORD, HWND, LONG, LONG));
@@ -535,9 +536,11 @@ TEST_F(FlutterWindowsEngineTest, AlertPlatformMessage) {
 
   FlutterProjectBundle project(properties);
 
-  auto window_binding_handler = std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();
+  auto window_binding_handler =
+      std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();
   AccessibilityRootNode* root_node = AccessibilityRootNode::Create();
-  ON_CALL(*window_binding_handler, GetAccessibilityRootNode).WillByDefault(::testing::Return(root_node));
+  ON_CALL(*window_binding_handler, GetAccessibilityRootNode)
+      .WillByDefault(::testing::Return(root_node));
   MockFlutterWindowsView view(std::move(window_binding_handler));
   view.SetEngine(std::make_unique<FlutterWindowsEngine>(project));
   FlutterWindowsEngine* engine = view.GetEngine();
@@ -548,23 +551,22 @@ TEST_F(FlutterWindowsEngineTest, AlertPlatformMessage) {
   auto binary_messenger =
       std::make_unique<BinaryMessengerImpl>(engine->messenger());
   binary_messenger->SetMessageHandler(
-      "semantics",
-      [&engine](
-          const uint8_t* message, size_t message_size, BinaryReply reply) {
-            engine->UpdateSemanticsEnabled(true);
-            char response[] = "";
-            reply(reinterpret_cast<uint8_t*>(response), 0);
+      "semantics", [&engine](const uint8_t* message, size_t message_size,
+                             BinaryReply reply) {
+        engine->UpdateSemanticsEnabled(true);
+        char response[] = "";
+        reply(reinterpret_cast<uint8_t*>(response), 0);
       });
 
   bool did_call = false;
-  ON_CALL(view, NotifyWinEventWrapper).WillByDefault([&did_call](DWORD event, HWND hwnd, LONG obj, LONG child) {
-    did_call = true;
-  });
-
+  ON_CALL(view, NotifyWinEventWrapper)
+      .WillByDefault([&did_call](DWORD event, HWND hwnd, LONG obj, LONG child) {
+        did_call = true;
+      });
 
   engine->UpdateSemanticsEnabled(true);
   engine->Run();
-  
+
   // Rely on timeout mechanism in CI.
   while (!did_call) {
     engine->task_runner()->ProcessTasks();

--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -657,6 +657,7 @@ FlutterWindowsEngine* FlutterWindowsView::GetEngine() {
 }
 
 void FlutterWindowsView::AnnounceAlert(const std::wstring& text) {
+  AccessibilityRootNode* root_node = binding_handler_->GetAccessibilityRootNode();
   AccessibilityAlert* alert =
       binding_handler_->GetAccessibilityRootNode()->GetOrCreateAlert();
   alert->SetText(text);

--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -656,4 +656,11 @@ FlutterWindowsEngine* FlutterWindowsView::GetEngine() {
   return engine_.get();
 }
 
+void FlutterWindowsView::AnnounceAlert(const std::wstring& text) {
+  AccessibilityAlert* alert = binding_handler_->GetAccessibilityRootNode()->GetOrCreateAlert();
+  alert->SetText(text);
+  HWND hwnd = GetPlatformWindow();
+  NotifyWinEvent(EVENT_SYSTEM_ALERT, hwnd, OBJID_CLIENT, AccessibilityRootNode::kAlertChildId);
+}
+
 }  // namespace flutter

--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -657,11 +657,13 @@ FlutterWindowsEngine* FlutterWindowsView::GetEngine() {
 }
 
 void FlutterWindowsView::AnnounceAlert(const std::wstring& text) {
-  AccessibilityAlert* alert = binding_handler_->GetAccessibilityRootNode()->GetOrCreateAlert();
+  AccessibilityAlert* alert =
+      binding_handler_->GetAccessibilityRootNode()->GetOrCreateAlert();
   alert->SetText(text);
   HWND hwnd = GetPlatformWindow();
   if (hwnd) {
-    NotifyWinEvent(EVENT_SYSTEM_ALERT, hwnd, OBJID_CLIENT, AccessibilityRootNode::kAlertChildId);
+    NotifyWinEvent(EVENT_SYSTEM_ALERT, hwnd, OBJID_CLIENT,
+                   AccessibilityRootNode::kAlertChildId);
   }
 }
 

--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -661,6 +661,10 @@ void FlutterWindowsView::AnnounceAlert(const std::wstring& text) {
       binding_handler_->GetAccessibilityRootNode()->GetOrCreateAlert();
   alert->SetText(text);
   HWND hwnd = GetPlatformWindow();
+  NotifyWinEventWrapper(EVENT_SYSTEM_ALERT, hwnd, OBJID_CLIENT, AccessibilityRootNode::kAlertChildId);
+}
+
+void FlutterWindowsView::NotifyWinEventWrapper(DWORD event, HWND hwnd, LONG idObject, LONG idChild) {
   if (hwnd) {
     NotifyWinEvent(EVENT_SYSTEM_ALERT, hwnd, OBJID_CLIENT,
                    AccessibilityRootNode::kAlertChildId);

--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -657,15 +657,20 @@ FlutterWindowsEngine* FlutterWindowsView::GetEngine() {
 }
 
 void FlutterWindowsView::AnnounceAlert(const std::wstring& text) {
-  AccessibilityRootNode* root_node = binding_handler_->GetAccessibilityRootNode();
+  AccessibilityRootNode* root_node =
+      binding_handler_->GetAccessibilityRootNode();
   AccessibilityAlert* alert =
       binding_handler_->GetAccessibilityRootNode()->GetOrCreateAlert();
   alert->SetText(text);
   HWND hwnd = GetPlatformWindow();
-  NotifyWinEventWrapper(EVENT_SYSTEM_ALERT, hwnd, OBJID_CLIENT, AccessibilityRootNode::kAlertChildId);
+  NotifyWinEventWrapper(EVENT_SYSTEM_ALERT, hwnd, OBJID_CLIENT,
+                        AccessibilityRootNode::kAlertChildId);
 }
 
-void FlutterWindowsView::NotifyWinEventWrapper(DWORD event, HWND hwnd, LONG idObject, LONG idChild) {
+void FlutterWindowsView::NotifyWinEventWrapper(DWORD event,
+                                               HWND hwnd,
+                                               LONG idObject,
+                                               LONG idChild) {
   if (hwnd) {
     NotifyWinEvent(EVENT_SYSTEM_ALERT, hwnd, OBJID_CLIENT,
                    AccessibilityRootNode::kAlertChildId);

--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -660,7 +660,9 @@ void FlutterWindowsView::AnnounceAlert(const std::wstring& text) {
   AccessibilityAlert* alert = binding_handler_->GetAccessibilityRootNode()->GetOrCreateAlert();
   alert->SetText(text);
   HWND hwnd = GetPlatformWindow();
-  NotifyWinEvent(EVENT_SYSTEM_ALERT, hwnd, OBJID_CLIENT, AccessibilityRootNode::kAlertChildId);
+  if (hwnd) {
+    NotifyWinEvent(EVENT_SYSTEM_ALERT, hwnd, OBJID_CLIENT, AccessibilityRootNode::kAlertChildId);
+  }
 }
 
 }  // namespace flutter

--- a/shell/platform/windows/flutter_windows_view.h
+++ b/shell/platform/windows/flutter_windows_view.h
@@ -214,6 +214,8 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate,
   virtual std::unique_ptr<TextInputPlugin> CreateTextInputPlugin(
       BinaryMessenger* messenger);
 
+  virtual void NotifyWinEventWrapper(DWORD event, HWND hwnd, LONG idObject, LONG idChild);
+
  private:
   // Struct holding the state of an individual pointer. The engine doesn't keep
   // track of which buttons have been pressed, so it's the embedding's

--- a/shell/platform/windows/flutter_windows_view.h
+++ b/shell/platform/windows/flutter_windows_view.h
@@ -90,6 +90,9 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate,
   // Send the initial accessibility features to the window
   void SendInitialAccessibilityFeatures();
 
+  // Set the text of the alert, and create it if it does not yet exist.
+  void AnnounceAlert(const std::wstring& text);
+
   // |WindowBindingHandlerDelegate|
   void UpdateHighContrastEnabled(bool enabled) override;
 

--- a/shell/platform/windows/flutter_windows_view.h
+++ b/shell/platform/windows/flutter_windows_view.h
@@ -214,7 +214,10 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate,
   virtual std::unique_ptr<TextInputPlugin> CreateTextInputPlugin(
       BinaryMessenger* messenger);
 
-  virtual void NotifyWinEventWrapper(DWORD event, HWND hwnd, LONG idObject, LONG idChild);
+  virtual void NotifyWinEventWrapper(DWORD event,
+                                     HWND hwnd,
+                                     LONG idObject,
+                                     LONG idChild);
 
  private:
   // Struct holding the state of an individual pointer. The engine doesn't keep

--- a/shell/platform/windows/testing/mock_window_binding_handler.h
+++ b/shell/platform/windows/testing/mock_window_binding_handler.h
@@ -37,6 +37,7 @@ class MockWindowBindingHandler : public WindowBindingHandler {
                bool(const void* allocation, size_t row_bytes, size_t height));
   MOCK_METHOD0(GetPrimaryPointerLocation, PointerLocation());
   MOCK_METHOD0(SendInitialAccessibilityFeatures, void());
+  MOCK_METHOD0(GetAccessibilityRootNode, AccessibilityRootNode*());
 };
 
 }  // namespace testing

--- a/shell/platform/windows/window.cc
+++ b/shell/platform/windows/window.cc
@@ -666,7 +666,7 @@ void Window::CreateAccessibilityRootNode() {
   ui::win::CreateATLModuleIfNeeded();
   CComObject<AccessibilityRootNode>* instance = nullptr;
   HRESULT hr = CComObject<AccessibilityRootNode>::CreateInstance(&instance);
-  if (!SUCCEEDED(hr)) {
+  if (!SUCCEEDED(hr) || !instance) {
     FML_LOG(FATAL) << "Failed to create accessibility root node";
   }
   instance->AddRef();

--- a/shell/platform/windows/window.cc
+++ b/shell/platform/windows/window.cc
@@ -219,7 +219,6 @@ LRESULT Window::OnGetObject(UINT const message,
     // Microsoft::WRL::ComPtr<IAccessible> root(root_view);
     accessibility_root_->SetWindow(root_view);
     Microsoft::WRL::ComPtr<IAccessible> root(accessibility_root_);
-    // TODO(schectman): wrap returned accessible in AccessibilityRootNode
     LRESULT lresult = LresultFromObject(IID_IAccessible, wparam, root.Get());
     return lresult;
   }

--- a/shell/platform/windows/window.cc
+++ b/shell/platform/windows/window.cc
@@ -214,14 +214,7 @@ LRESULT Window::OnGetObject(UINT const message,
   } else if (is_msaa_request && root_view) {
     // Create the accessibility root if it does not already exist.
     if (!accessibility_root_) {
-      ui::win::CreateATLModuleIfNeeded();
-      CComObject<AccessibilityRootNode>* instance = nullptr;
-      HRESULT hr = CComObject<AccessibilityRootNode>::CreateInstance(&instance);
-      if (!SUCCEEDED(hr)) {
-        FML_LOG(FATAL) << "Failed to create accessibility root node";
-      }
-      instance->AddRef();
-      accessibility_root_ = instance;
+      CreateAccessibilityRootNode();
     }
     // Return the IAccessible for the root view.
     //Microsoft::WRL::ComPtr<IAccessible> root(root_view);
@@ -667,6 +660,17 @@ bool Window::GetHighContrastEnabled() {
                   << "support only for Windows 8 + ";
     return false;
   }
+}
+
+void Window::CreateAccessibilityRootNode() {
+  ui::win::CreateATLModuleIfNeeded();
+  CComObject<AccessibilityRootNode>* instance = nullptr;
+  HRESULT hr = CComObject<AccessibilityRootNode>::CreateInstance(&instance);
+  if (!SUCCEEDED(hr)) {
+    FML_LOG(FATAL) << "Failed to create accessibility root node";
+  }
+  instance->AddRef();
+  accessibility_root_ = instance;
 }
 
 }  // namespace flutter

--- a/shell/platform/windows/window.cc
+++ b/shell/platform/windows/window.cc
@@ -15,7 +15,6 @@
 #include <cstring>
 
 #include "flutter/shell/platform/windows/dpi_utils.h"
-#include "flutter/third_party/accessibility/base/win/atl_module.h"
 
 namespace flutter {
 
@@ -663,14 +662,7 @@ bool Window::GetHighContrastEnabled() {
 }
 
 void Window::CreateAccessibilityRootNode() {
-  ui::win::CreateATLModuleIfNeeded();
-  CComObject<AccessibilityRootNode>* instance = nullptr;
-  HRESULT hr = CComObject<AccessibilityRootNode>::CreateInstance(&instance);
-  if (!SUCCEEDED(hr) || !instance) {
-    FML_LOG(FATAL) << "Failed to create accessibility root node";
-  }
-  instance->AddRef();
-  accessibility_root_ = instance;
+  accessibility_root_ = AccessibilityRootNode::Create();
 }
 
 }  // namespace flutter

--- a/shell/platform/windows/window.cc
+++ b/shell/platform/windows/window.cc
@@ -212,6 +212,7 @@ LRESULT Window::OnGetObject(UINT const message,
   } else if (is_msaa_request && root_view) {
     // Return the IAccessible for the root view.
     Microsoft::WRL::ComPtr<IAccessible> root(root_view);
+    // TODO(schectman): wrap returned accessible in AccessibilityRootNode
     LRESULT lresult = LresultFromObject(IID_IAccessible, wparam, root.Get());
     return lresult;
   }
@@ -594,6 +595,11 @@ void Window::Destroy() {
     text_input_manager_->SetWindowHandle(nullptr);
     DestroyWindow(window_handle_);
     window_handle_ = nullptr;
+  }
+
+  if (accessibility_root_) {
+    accessibility_root_->Release();
+    accessibility_root_ = nullptr;
   }
 
   UnregisterClass(window_class_name_.c_str(), nullptr);

--- a/shell/platform/windows/window.cc
+++ b/shell/platform/windows/window.cc
@@ -222,7 +222,6 @@ LRESULT Window::OnGetObject(UINT const message,
       }
       instance->AddRef();
       accessibility_root_ = instance;
-      FML_LOG(ERROR) << "Creating accessibility root";
     }
     // Return the IAccessible for the root view.
     //Microsoft::WRL::ComPtr<IAccessible> root(root_view);
@@ -614,7 +613,6 @@ void Window::Destroy() {
   }
 
   if (accessibility_root_) {
-    FML_LOG(ERROR) << "Destroying accessibility_root_!!\n";
     accessibility_root_->Release();
     accessibility_root_ = nullptr;
   }

--- a/shell/platform/windows/window.cc
+++ b/shell/platform/windows/window.cc
@@ -217,7 +217,7 @@ LRESULT Window::OnGetObject(UINT const message,
       CreateAccessibilityRootNode();
     }
     // Return the IAccessible for the root view.
-    //Microsoft::WRL::ComPtr<IAccessible> root(root_view);
+    // Microsoft::WRL::ComPtr<IAccessible> root(root_view);
     accessibility_root_->SetWindow(root_view);
     Microsoft::WRL::ComPtr<IAccessible> root(accessibility_root_);
     // TODO(schectman): wrap returned accessible in AccessibilityRootNode

--- a/shell/platform/windows/window.cc
+++ b/shell/platform/windows/window.cc
@@ -662,6 +662,9 @@ bool Window::GetHighContrastEnabled() {
 }
 
 void Window::CreateAccessibilityRootNode() {
+  if (accessibility_root_) {
+    accessibility_root_->Release();
+  }
   accessibility_root_ = AccessibilityRootNode::Create();
 }
 

--- a/shell/platform/windows/window.h
+++ b/shell/platform/windows/window.h
@@ -224,6 +224,9 @@ class Window : public KeyboardManager::WindowDelegate {
   // Returns the root view accessibility node, or nullptr if none.
   virtual gfx::NativeViewAccessible GetNativeViewAccessible() = 0;
 
+  // Create the wrapper node.
+  void CreateAccessibilityRootNode();
+
   // Handles running DirectManipulation on the window to receive trackpad
   // gestures.
   std::unique_ptr<DirectManipulationOwner> direct_manipulation_owner_;

--- a/shell/platform/windows/window.h
+++ b/shell/platform/windows/window.h
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "flutter/shell/platform/embedder/embedder.h"
+#include "flutter/shell/platform/windows/accessibility_root_node.h"
 #include "flutter/shell/platform/windows/direct_manipulation.h"
 #include "flutter/shell/platform/windows/keyboard_manager.h"
 #include "flutter/shell/platform/windows/sequential_id_generator.h"
@@ -229,6 +230,9 @@ class Window : public KeyboardManager::WindowDelegate {
 
   // Called when a theme change message is issued
   virtual void OnThemeChange() = 0;
+
+  // A parent node wrapping the window root, used for siblings.
+  AccessibilityRootNode* accessibility_root_;
 
  private:
   // Release OS resources associated with window.

--- a/shell/platform/windows/window_binding_handler.h
+++ b/shell/platform/windows/window_binding_handler.h
@@ -11,6 +11,7 @@
 #include <variant>
 
 #include "flutter/shell/platform/common/geometry.h"
+#include "flutter/shell/platform/windows/accessibility_root_node.h"
 #include "flutter/shell/platform/windows/public/flutter_windows.h"
 #include "flutter/shell/platform/windows/window_binding_handler_delegate.h"
 
@@ -92,6 +93,9 @@ class WindowBindingHandler {
 
   // Called to set the initial state of accessibility features
   virtual void SendInitialAccessibilityFeatures() = 0;
+
+  // Returns the wrapper parent accessibility node.
+  virtual AccessibilityRootNode* GetAccessibilityRootNode() = 0;
 };
 
 }  // namespace flutter


### PR DESCRIPTION
The platform message used to trigger announcements/alerts by the Framework was previously ignored on Windows, as there was no channel to accept it, nor method to announce it. This PR receives the message to announce a message to the screen reader. The former root node of the Window is now wrapped by a parent node which may also create an alert node as a sibling, and can then notify a `EVENT_SYSTEM_ALERT` event pointing to this alert node to read out an alert.

You may test this by running the code sample in the linked issue with either Windows Narrator or NVDA.

Addresses https://github.com/flutter/flutter/issues/113059

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
