### PR TITLE
Keep the fuchsia build from trying to build the dart sdk

### DIFF
--- a/build/dart/BUILD.gn
+++ b/build/dart/BUILD.gn
@@ -31,7 +31,7 @@ if (flutter_prebuilt_dart_sdk) {
   }
 }
 
-if (!is_fuchsia) {
+if (build_engine_artifacts) {
   group("dart_sdk") {
     if (flutter_prebuilt_dart_sdk) {
       public_deps = [ ":copy_dart_sdk" ]

--- a/build/dart/BUILD.gn
+++ b/build/dart/BUILD.gn
@@ -31,10 +31,12 @@ if (flutter_prebuilt_dart_sdk) {
   }
 }
 
-group("dart_sdk") {
-  if (flutter_prebuilt_dart_sdk) {
-    public_deps = [ ":copy_dart_sdk" ]
-  } else {
-    public_deps = [ "//third_party/dart:create_sdk" ]
+if (!is_fuchsia) {
+  group("dart_sdk") {
+    if (flutter_prebuilt_dart_sdk) {
+      public_deps = [ ":copy_dart_sdk" ]
+    } else {
+      public_deps = [ "//third_party/dart:create_sdk" ]
+    }
   }
 }


### PR DESCRIPTION
Keep the fuchsia build from trying to build the dart sdk when it imports `//flutter/build/dart/BUILD.gn`.

This fixes the broken hhh builds: https://ci.chromium.org/p/dart/g/flutter-hhh-web/console