### PR TITLE
Adds a release_candidate variable to DEPS.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -408,7 +408,7 @@ deps = {
       }
     ],
     'dep_type': 'cipd',
-    'condition': 'host_os == "win" and download_dart_sdk and not release_candidate_build'
+    'condition': 'host_os == "win" and download_dart_sdk and not release_candidate'
   },
 
   'src/third_party/colorama/src':

--- a/DEPS
+++ b/DEPS
@@ -30,6 +30,11 @@ vars = {
   # for the web engine.
   'download_emsdk': False,
 
+  # For experimental features some dependencies may only be avaialable in the master/main
+  # channels. This variable is being set when CI is checking out the repository.
+  'release_candidate': False,
+
+
   # As Dart does, we use Fuchsia's GN and Clang toolchain. These revision
   # should be kept up to date with the revisions pulled by Dart.
   # The list of revisions for these tools comes from Fuchsia, here:
@@ -403,7 +408,7 @@ deps = {
       }
     ],
     'dep_type': 'cipd',
-    'condition': 'host_os == "win" and download_dart_sdk'
+    'condition': 'host_os == "win" and download_dart_sdk and not release_candidate_build'
   },
 
   'src/third_party/colorama/src':


### PR DESCRIPTION
This is used to avoid trying to download experimental dependencies as part of the release candidate branches.

Bug: https://github.com/flutter/flutter/issues/113931

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
