### PR TITLE
[web:a11y] fix group vs label relationship

### DIFF
--- a/lib/web_ui/lib/src/engine/semantics/label_and_value.dart
+++ b/lib/web_ui/lib/src/engine/semantics/label_and_value.dart
@@ -97,9 +97,7 @@ class LabelAndValue extends RoleManager {
 
   void _cleanUpDom() {
     semanticsObject.element.removeAttribute('aria-label');
-    semanticsObject.setAriaRole('heading', false);
-    semanticsObject.setAriaRole('text', false);
-    semanticsObject.setAriaRole('group', false);
+    semanticsObject.clearAriaRole();
   }
 
   @override

--- a/lib/web_ui/lib/src/engine/semantics/label_and_value.dart
+++ b/lib/web_ui/lib/src/engine/semantics/label_and_value.dart
@@ -4,49 +4,32 @@
 
 import 'package:ui/ui.dart' as ui;
 
-import '../configuration.dart';
 import '../dom.dart';
 import 'semantics.dart';
 
-/// Renders [_label] and [_value] to the semantics DOM.
+/// Renders [SemanticsObject.label] and/or [SemanticsObject.value] to the semantics DOM.
 ///
-/// The rendering method is browser-dependent. There is no explicit ARIA
-/// attribute to express "value". Instead, you are expected to render the
-/// value as text content of HTML.
+/// VoiceOver supports "aria-label" but only in conjunction with an ARIA role.
+/// Setting "aria-label" on an empty element without a role causes VoiceOver to
+/// treat element as if it does not exist. VoiceOver supports role "text", which
+/// is a proprietary role not supported by other browsers. Flutter Web still
+/// uses it because it provides the best user experience for plain text nodes.
 ///
-/// VoiceOver only supports "aria-label" for certain ARIA roles. For plain
-/// text it expects that the label is part of the text content of the element.
-/// The strategy for VoiceOver is to combine [_label] and [_value] and stamp
-/// out a single child element that contains the value.
+/// TalkBack supports standalone "aria-label" attribute, but does not support
+/// role "text". This leads to TalkBack reading "group" or "empty group" on
+/// plain text elements, but that's still better than other alternatives
+/// considered.
 ///
-/// TalkBack supports the "aria-label" attribute. However, when present,
-/// TalkBack ignores the text content. Therefore, we cannot split [_label]
-/// and [_value] between "aria-label" and text content. The strategy for
-/// TalkBack is to combine [_label] and [_value] into a single "aria-label".
-///
-/// The [_value] is not always rendered. Some semantics nodes correspond to
+/// The value is not always rendered. Some semantics nodes correspond to
 /// interactive controls, such as an `<input>` element. In such case the value
 /// is reported via that element's `value` attribute rather than rendering it
 /// separately.
 ///
-/// Aria role image is not managed by this role manager. Img role and label
-/// describes the visual are added in [ImageRoleManager].
+/// This role manager does not manage images and text fields. See
+/// [ImageRoleManager] and [TextField].
 class LabelAndValue extends RoleManager {
   LabelAndValue(SemanticsObject semanticsObject)
       : super(Role.labelAndValue, semanticsObject);
-
-  /// Supplements the "aria-label" that renders the combination of [_label] and
-  /// [_value] to semantics as text content.
-  ///
-  /// This extra element is needed for the following reasons:
-  ///
-  /// - VoiceOver on iOS Safari does not recognize standalone "aria-label". It
-  ///   only works for specific roles.
-  /// - TalkBack does support "aria-label". However, if an element has children
-  ///   its label is not reachable via accessibility focus. This happens, for
-  ///   example in popup dialogs, such as the alert dialog. The text of the
-  ///   alert is supplied as a label on the parent node.
-  DomElement? _auxiliaryValueElement;
 
   @override
   void update() {
@@ -84,42 +67,39 @@ class LabelAndValue extends RoleManager {
     semanticsObject.element
         .setAttribute('aria-label', combinedValue.toString());
 
-    if (semanticsObject.hasFlag(ui.SemanticsFlag.isHeader)) {
+    // Assign one of three roles to the element: heading, group, text.
+    //
+    // - "group" is used when the node has children, irrespective of whether the
+    //   node is marked as a header or not. This is because marking a group
+    //   as a "heading" will prevent the AT from reaching its children.
+    // - "heading" is used when the framework explicitly marks the node as a
+    //   heading and the node does not have children.
+    // - "text" is used by default.
+    //
+    // As of October 24, 2022, "text" only has effect on Safari. Other browsers
+    // ignore it. Setting role="text" prevents Safari from treating the element
+    // as a "group" or "empty group". Other browsers still announce it as
+    // "group" or "empty group". However, other options considered produced even
+    // worse results, such as:
+    //
+    // - Ignore the size of the element and size the focus ring to the text
+    //   content, which is wrong. The HTML text size is irrelevant because
+    //   Flutter renders into canvas, so the focus ring looks wrong.
+    // - Read out the same label multiple times.
+    if (semanticsObject.hasChildren) {
+      semanticsObject.setAriaRole('group', true);
+    } else if (semanticsObject.hasFlag(ui.SemanticsFlag.isHeader)) {
       semanticsObject.setAriaRole('heading', true);
+    } else {
+      semanticsObject.setAriaRole('text', true);
     }
-
-    if (_auxiliaryValueElement == null) {
-      _auxiliaryValueElement = domDocument.createElement('flt-semantics-value');
-      // Absolute positioning and sizing of leaf text elements confuses
-      // VoiceOver. So we let the browser size the value node. The node will
-      // still have a bigger tap area. However, if the node is a parent to other
-      // nodes, then VoiceOver behaves as expected with absolute positioning and
-      // sizing.
-      if (semanticsObject.hasChildren) {
-        _auxiliaryValueElement!.style
-          ..position = 'absolute'
-          ..top = '0'
-          ..left = '0'
-          ..width = '${semanticsObject.rect!.width}px'
-          ..height = '${semanticsObject.rect!.height}px';
-      }
-
-      // Normally use a small font size so that text doesn't leave the scope
-      // of the semantics node. When debugging semantics, use a font size
-      // that's reasonably visible.
-      _auxiliaryValueElement!.style.fontSize = configuration.debugShowSemanticsNodes ? '12px' : '6px';
-      semanticsObject.element.append(_auxiliaryValueElement!);
-    }
-    _auxiliaryValueElement!.text = combinedValue.toString();
   }
 
   void _cleanUpDom() {
-    if (_auxiliaryValueElement != null) {
-      _auxiliaryValueElement!.remove();
-      _auxiliaryValueElement = null;
-    }
     semanticsObject.element.removeAttribute('aria-label');
     semanticsObject.setAriaRole('heading', false);
+    semanticsObject.setAriaRole('text', false);
+    semanticsObject.setAriaRole('group', false);
   }
 
   @override

--- a/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -1221,6 +1221,11 @@ class SemanticsObject {
     }
   }
 
+  /// Removes the `role` HTML attribue, if any.
+  void clearAriaRole() {
+    element.removeAttribute('role');
+  }
+
   /// Role managers.
   ///
   /// The [_roleManagers] map needs to have a stable order for easier debugging

--- a/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -78,6 +78,9 @@ void runSemanticsTests() {
   group('accessibility builder', () {
     _testEngineAccessibilityBuilder();
   });
+  group('group', () {
+    _testGroup();
+  });
 }
 
 void _testEngineAccessibilityBuilder() {
@@ -310,9 +313,7 @@ void _testEngineSemanticsOwner() {
     expectSemanticsTree('''
 <sem style="$rootSemanticStyle">
   <sem-c>
-    <sem aria-label="Hello">
-      <sem-v>Hello</sem-v>
-    </sem>
+    <sem aria-label="Hello"></sem>
   </sem-c>
 </sem>''');
 
@@ -322,9 +323,7 @@ void _testEngineSemanticsOwner() {
     expectSemanticsTree('''
 <sem style="$rootSemanticStyle">
   <sem-c>
-    <sem aria-label="World">
-      <sem-v>World</sem-v>
-    </sem>
+    <sem aria-label="World"></sem>
   </sem-c>
 </sem>''');
 
@@ -357,9 +356,7 @@ void _testEngineSemanticsOwner() {
     expectSemanticsTree('''
 <sem style="$rootSemanticStyle">
   <sem-c>
-    <sem aria-label="tooltip">
-      <sem-v>tooltip</sem-v>
-    </sem>
+    <sem aria-label="tooltip"></sem>
   </sem-c>
 </sem>''');
 
@@ -369,9 +366,7 @@ void _testEngineSemanticsOwner() {
     expectSemanticsTree('''
 <sem style="$rootSemanticStyle">
   <sem-c>
-    <sem aria-label="tooltip\nHello">
-      <sem-v>tooltip\nHello</sem-v>
-    </sem>
+    <sem aria-label="tooltip\nHello"></sem>
   </sem-c>
 </sem>''');
 
@@ -486,9 +481,43 @@ void _testHeader() {
 
     semantics().updateSemantics(builder.build());
     expectSemanticsTree('''
-<sem role="heading" aria-label="Header of the page" style="$rootSemanticStyle">
-  <sem-v>Header of the page</sem-v>
-</sem>
+<sem role="heading" aria-label="Header of the page" style="$rootSemanticStyle"></sem>
+''');
+
+    semantics().semanticsEnabled = false;
+  });
+
+  // When a header has child elements, role="heading" prevents AT from reaching
+  // child elements. To fix that role="group" is used, even though that causes
+  // the heading to not be announced as a heading. If the app really needs the
+  // heading to be announced as a heading, the developer can restructure the UI
+  // such that the heading is not a parent node, but a side-note, e.g. preceding
+  // the child list.
+  test('uses group role for headers when children are present', () {
+    semantics()
+      ..debugOverrideTimestampFunction(() => _testTime)
+      ..semanticsEnabled = true;
+
+    final ui.SemanticsUpdateBuilder builder = ui.SemanticsUpdateBuilder();
+    updateNode(
+      builder,
+      flags: 0 | ui.SemanticsFlag.isHeader.index,
+      label: 'Header of the page',
+      transform: Matrix4.identity().toFloat64(),
+      rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
+      childrenInHitTestOrder: Int32List.fromList(<int>[1]),
+      childrenInTraversalOrder: Int32List.fromList(<int>[1]),
+    );
+    updateNode(
+      builder,
+      id: 1,
+      transform: Matrix4.identity().toFloat64(),
+      rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
+    );
+
+    semantics().updateSemantics(builder.build());
+    expectSemanticsTree('''
+<sem role="group" aria-label="Header of the page" style="$rootSemanticStyle"><sem-c><sem></sem></sem-c></sem>
 ''');
 
     semantics().semanticsEnabled = false;
@@ -1731,7 +1760,7 @@ void _testLiveRegion() {
     semantics().updateSemantics(builder.build());
 
     expectSemanticsTree('''
-<sem aria-label="This is a snackbar" aria-live="polite" style="$rootSemanticStyle"><sem-v>This is a snackbar</sem-v></sem>
+<sem aria-label="This is a snackbar" aria-live="polite" style="$rootSemanticStyle"></sem>
 ''');
 
     semantics().semanticsEnabled = false;
@@ -1933,6 +1962,37 @@ void _testPlatformView() {
 
     // Hit test child 3
     expect(shadowRoot.elementFromPoint(10, 50), child3);
+
+    semantics().semanticsEnabled = false;
+  });
+}
+
+void _testGroup() {
+  test('nodes with children and labels use group role with aria label', () {
+    semantics()
+      ..debugOverrideTimestampFunction(() => _testTime)
+      ..semanticsEnabled = true;
+
+    final ui.SemanticsUpdateBuilder builder = ui.SemanticsUpdateBuilder();
+    updateNode(
+      builder,
+      label: 'this is a label for a group of elements',
+      transform: Matrix4.identity().toFloat64(),
+      rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
+      childrenInHitTestOrder: Int32List.fromList(<int>[1]),
+      childrenInTraversalOrder: Int32List.fromList(<int>[1]),
+    );
+    updateNode(
+      builder,
+      id: 1,
+      transform: Matrix4.identity().toFloat64(),
+      rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
+    );
+
+    semantics().updateSemantics(builder.build());
+    expectSemanticsTree('''
+<sem role="group" aria-label="this is a label for a group of elements" style="$rootSemanticStyle"><sem-c><sem></sem></sem-c></sem>
+''');
 
     semantics().semanticsEnabled = false;
   });

--- a/lib/web_ui/test/matchers.dart
+++ b/lib/web_ui/test/matchers.dart
@@ -289,9 +289,6 @@ String canonicalizeHtml(
       case 'flt-semantics-container':
         replacementTag = 'sem-c';
         break;
-      case 'flt-semantics-value':
-        replacementTag = 'sem-v';
-        break;
       case 'flt-semantics-img':
         replacementTag = 'sem-img';
         break;


### PR DESCRIPTION
This fixes the following issues with ARIA labels, groups, and heading:

- Replace `<flt-semantics-value>` with `role="text"`. The text role works better in Safari, and the extra element causes the AT to read the same label multiple times. (fixes https://github.com/flutter/flutter/issues/91914)
- Use explicit `role="group"` for nodes with children. This communicates the label to the user as a group of elements, enabling enter/exit group gestures.
- Do not use `role="heading"` for nodes with children, because that prevents the AT from reaching child nodes.

This change does not fix the issue with Chrome reading "group" or "empty group" on text labels. I could not find a way to simultaneously control the positioning/sizing of an element _and_ have it be treated as text. Using actual text in HTML causes the browser to size the focus ring to just the text itself rather than the element. Adding `aria-label` fixes the sizing but "group"/"empty group" reappear.
