### PR TITLE
[Impeller] Copy uniforms before appending them to the DisplayList

### DIFF
--- a/display_list/display_list_color_source.cc
+++ b/display_list/display_list_color_source.cc
@@ -133,7 +133,7 @@ std::shared_ptr<DlColorSource> DlColorSource::MakeSweep(
 std::shared_ptr<DlRuntimeEffectColorSource> DlColorSource::MakeRuntimeEffect(
     sk_sp<DlRuntimeEffect> runtime_effect,
     std::vector<std::shared_ptr<DlColorSource>> samplers,
-    sk_sp<SkData> uniform_data) {
+    std::shared_ptr<std::vector<uint8_t>> uniform_data) {
   return std::make_shared<DlRuntimeEffectColorSource>(
       std::move(runtime_effect), std::move(samplers), std::move(uniform_data));
 }

--- a/display_list/display_list_color_source.cc
+++ b/display_list/display_list_color_source.cc
@@ -6,6 +6,7 @@
 
 #include "flutter/display_list/display_list_runtime_effect.h"
 #include "flutter/display_list/display_list_sampling_options.h"
+#include "flutter/fml/logging.h"
 
 namespace flutter {
 
@@ -134,6 +135,7 @@ std::shared_ptr<DlRuntimeEffectColorSource> DlColorSource::MakeRuntimeEffect(
     sk_sp<DlRuntimeEffect> runtime_effect,
     std::vector<std::shared_ptr<DlColorSource>> samplers,
     std::shared_ptr<std::vector<uint8_t>> uniform_data) {
+  FML_DCHECK(uniform_data != nullptr);
   return std::make_shared<DlRuntimeEffectColorSource>(
       std::move(runtime_effect), std::move(samplers), std::move(uniform_data));
 }

--- a/display_list/display_list_color_source_unittests.cc
+++ b/display_list/display_list_color_source_unittests.cc
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <memory>
+#include <vector>
+
 #include "flutter/display_list/display_list_attributes_testing.h"
 #include "flutter/display_list/display_list_builder.h"
 #include "flutter/display_list/display_list_color_source.h"
@@ -942,11 +945,14 @@ TEST(DisplayListColorSource, UnknownNotEquals) {
 
 TEST(DisplayListColorSource, RuntimeEffect) {
   std::shared_ptr<DlRuntimeEffectColorSource> source1 =
-      DlColorSource::MakeRuntimeEffect(kTestRuntimeEffect1, {}, nullptr);
+      DlColorSource::MakeRuntimeEffect(
+          kTestRuntimeEffect1, {}, std::make_shared<std::vector<uint8_t>>());
   std::shared_ptr<DlRuntimeEffectColorSource> source2 =
-      DlColorSource::MakeRuntimeEffect(kTestRuntimeEffect2, {}, nullptr);
+      DlColorSource::MakeRuntimeEffect(
+          kTestRuntimeEffect2, {}, std::make_shared<std::vector<uint8_t>>());
   std::shared_ptr<DlRuntimeEffectColorSource> source3 =
-      DlColorSource::MakeRuntimeEffect(nullptr, {}, nullptr);
+      DlColorSource::MakeRuntimeEffect(
+          nullptr, {}, std::make_shared<std::vector<uint8_t>>());
 
   ASSERT_EQ(source1->type(), DlColorSourceType::kRuntimeEffect);
   ASSERT_EQ(source1->asRuntimeEffect(), source1.get());

--- a/impeller/display_list/display_list_dispatcher.cc
+++ b/impeller/display_list/display_list_dispatcher.cc
@@ -437,8 +437,6 @@ void DisplayListDispatcher::setColorSource(
       auto uniform_data = runtime_effect_color_source->uniform_data();
 
       paint_.color_source = [runtime_stage, uniform_data]() {
-        // TODO(113714): Get rid of the allocation + copy for uniform data.
-
         auto contents = std::make_shared<RuntimeEffectContents>();
         contents->SetRuntimeStage(runtime_stage);
         contents->SetUniformData(uniform_data);

--- a/impeller/display_list/display_list_dispatcher.cc
+++ b/impeller/display_list/display_list_dispatcher.cc
@@ -434,18 +434,14 @@ void DisplayListDispatcher::setColorSource(
           source->asRuntimeEffect();
       auto runtime_stage =
           runtime_effect_color_source->runtime_effect()->runtime_stage();
-      auto uniform_data_sk = runtime_effect_color_source->uniform_data();
+      auto uniform_data = runtime_effect_color_source->uniform_data();
 
-      paint_.color_source = [runtime_stage, uniform_data_sk]() {
+      paint_.color_source = [runtime_stage, uniform_data]() {
         // TODO(113714): Get rid of the allocation + copy for uniform data.
-        std::vector<uint8_t> uniform_data;
-        uniform_data.resize(uniform_data_sk->size());
-        memcpy(uniform_data.data(), uniform_data_sk->bytes(),
-               uniform_data.size());
 
         auto contents = std::make_shared<RuntimeEffectContents>();
         contents->SetRuntimeStage(runtime_stage);
-        contents->SetUniformData(std::move(uniform_data));
+        contents->SetUniformData(uniform_data);
         return contents;
       };
       return;

--- a/impeller/entity/contents/runtime_effect_contents.cc
+++ b/impeller/entity/contents/runtime_effect_contents.cc
@@ -26,7 +26,8 @@ void RuntimeEffectContents::SetRuntimeStage(
   runtime_stage_ = std::move(runtime_stage);
 }
 
-void RuntimeEffectContents::SetUniformData(std::vector<uint8_t> uniform_data) {
+void RuntimeEffectContents::SetUniformData(
+    std::shared_ptr<std::vector<uint8_t>> uniform_data) {
   uniform_data_ = std::move(uniform_data);
 }
 
@@ -143,8 +144,8 @@ bool RuntimeEffectContents::Render(const ContentContext& renderer,
     size_t alignment =
         std::max(uniform.bit_width / 8, DefaultUniformAlignment());
     auto buffer_view = pass.GetTransientsBuffer().Emplace(
-        &uniform_data_[uniform.location * sizeof(float)], uniform.GetSize(),
-        alignment);
+        &uniform_data_.get()[uniform.location * sizeof(float)],
+        uniform.GetSize(), alignment);
 
     ShaderUniformSlot slot;
     slot.name = uniform.name.c_str();

--- a/impeller/entity/contents/runtime_effect_contents.cc
+++ b/impeller/entity/contents/runtime_effect_contents.cc
@@ -144,7 +144,7 @@ bool RuntimeEffectContents::Render(const ContentContext& renderer,
     size_t alignment =
         std::max(uniform.bit_width / 8, DefaultUniformAlignment());
     auto buffer_view = pass.GetTransientsBuffer().Emplace(
-        &uniform_data_.get()[uniform.location * sizeof(float)],
+        uniform_data_->data() + uniform.location * sizeof(float),
         uniform.GetSize(), alignment);
 
     ShaderUniformSlot slot;

--- a/impeller/entity/contents/runtime_effect_contents.h
+++ b/impeller/entity/contents/runtime_effect_contents.h
@@ -14,7 +14,7 @@ class RuntimeEffectContents final : public ColorSourceContents {
  public:
   void SetRuntimeStage(std::shared_ptr<RuntimeStage> runtime_stage);
 
-  void SetUniformData(std::vector<uint8_t> uniform_data);
+  void SetUniformData(std::shared_ptr<std::vector<uint8_t>> uniform_data);
 
   // |Contents|
   bool Render(const ContentContext& renderer,
@@ -23,7 +23,7 @@ class RuntimeEffectContents final : public ColorSourceContents {
 
  private:
   std::shared_ptr<RuntimeStage> runtime_stage_;
-  std::vector<uint8_t> uniform_data_;
+  std::shared_ptr<std::vector<uint8_t>> uniform_data_;
 };
 
 }  // namespace impeller

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -2089,9 +2089,9 @@ TEST_P(EntityTest, RuntimeEffect) {
             fml::TimePoint::Now().ToEpochDelta().ToSecondsF()),
         .iResolution = Vector2(GetWindowSize().width, GetWindowSize().height),
     };
-    std::vector<uint8_t> uniform_data;
-    uniform_data.resize(sizeof(FragUniforms));
-    memcpy(uniform_data.data(), &frag_uniforms, sizeof(FragUniforms));
+    auto uniform_data = std::make_shared<std::vector<uint8_t>>();
+    uniform_data->resize(sizeof(FragUniforms));
+    memcpy(uniform_data->data(), &frag_uniforms, sizeof(FragUniforms));
     contents->SetUniformData(uniform_data);
 
     Entity entity;

--- a/lib/ui/painting/fragment_program.cc
+++ b/lib/ui/painting/fragment_program.cc
@@ -98,10 +98,10 @@ std::string FragmentProgram::initFromAsset(const std::string& asset_name) {
 }
 
 std::shared_ptr<DlColorSource> FragmentProgram::MakeDlColorSource(
-    const sk_sp<SkData>& float_uniforms,
+    std::shared_ptr<std::vector<uint8_t>> float_uniforms,
     const std::vector<std::shared_ptr<DlColorSource>>& children) {
   return DlColorSource::MakeRuntimeEffect(runtime_effect_, children,
-                                          float_uniforms);
+                                          std::move(float_uniforms));
 }
 
 void FragmentProgram::Create(Dart_Handle wrapper) {

--- a/lib/ui/painting/fragment_program.h
+++ b/lib/ui/painting/fragment_program.h
@@ -13,6 +13,7 @@
 #include "third_party/tonic/dart_library_natives.h"
 #include "third_party/tonic/typed_data/typed_list.h"
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -35,7 +36,7 @@ class FragmentProgram : public RefCountedDartWrappable<FragmentProgram> {
                                      Dart_Handle samplers);
 
   std::shared_ptr<DlColorSource> MakeDlColorSource(
-      const sk_sp<SkData>& float_uniforms,
+      std::shared_ptr<std::vector<uint8_t>> float_uniforms,
       const std::vector<std::shared_ptr<DlColorSource>>& children);
 
  private:

--- a/lib/ui/painting/fragment_shader.cc
+++ b/lib/ui/painting/fragment_shader.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include <iostream>
+#include <memory>
 #include <utility>
 
 #include "flutter/lib/ui/painting/fragment_shader.h"
@@ -78,7 +79,14 @@ void ReusableFragmentShader::SetSampler(Dart_Handle index_handle,
 std::shared_ptr<DlColorSource> ReusableFragmentShader::shader(
     DlImageSampling sampling) {
   FML_CHECK(program_);
-  return program_->MakeDlColorSource(uniform_data_, samplers_);
+  auto uniforms =
+      SkData::MakeWithCopy(uniform_data_->data(), uniform_data_->size());
+
+  auto uniform_data = std::make_shared<std::vector<uint8_t>>();
+  uniform_data->resize(uniform_data_->size());
+  memcpy(uniform_data->data(), uniform_data_->bytes(), uniform_data->size());
+
+  return program_->MakeDlColorSource(std::move(uniform_data), samplers_);
 }
 
 void ReusableFragmentShader::Dispose() {

--- a/lib/ui/painting/fragment_shader.cc
+++ b/lib/ui/painting/fragment_shader.cc
@@ -82,6 +82,9 @@ std::shared_ptr<DlColorSource> ReusableFragmentShader::shader(
   auto uniforms =
       SkData::MakeWithCopy(uniform_data_->data(), uniform_data_->size());
 
+  // The lifetime of this object is longer than a frame, and the uniforms can be
+  // continually changed on the UI thread. So we take a copy of the uniforms
+  // before handing it to the DisplayList for consumption on the render thread.
   auto uniform_data = std::make_shared<std::vector<uint8_t>>();
   uniform_data->resize(uniform_data_->size());
   memcpy(uniform_data->data(), uniform_data_->bytes(), uniform_data->size());

--- a/lib/ui/painting/fragment_shader.cc
+++ b/lib/ui/painting/fragment_shader.cc
@@ -79,8 +79,6 @@ void ReusableFragmentShader::SetSampler(Dart_Handle index_handle,
 std::shared_ptr<DlColorSource> ReusableFragmentShader::shader(
     DlImageSampling sampling) {
   FML_CHECK(program_);
-  auto uniforms =
-      SkData::MakeWithCopy(uniform_data_->data(), uniform_data_->size());
 
   // The lifetime of this object is longer than a frame, and the uniforms can be
   // continually changed on the UI thread. So we take a copy of the uniforms


### PR DESCRIPTION
`ReusableFragmentShader` has a lifetime that lasts longer than a frame, and the uniforms can be continually changed on the UI thread. So take a copy (intention immutable) of the uniforms before handing it to the DL for consumption on the render thread.

* Closes https://github.com/flutter/flutter/issues/113714 because the copy in the dispatcher has been removed.
* Fixes this iOS stuttering issue: https://github.com/flutter/engine/pull/36866#issuecomment-1284692335
* Fixes crash when setting a sampler in this example: https://github.com/zanderso/fragment_shader_example/compare/main...bdero:fragment_shader_example:bdero/sampler