### PR TITLE
Let `_debugCheckNotUsedAsOldLayer` provide hashcode in addition to runtime type

### DIFF
--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -108,7 +108,7 @@ abstract class _EngineLayerWrapper implements EngineLayer {
   bool _debugCheckNotUsedAsOldLayer() {
     assert(
         !_debugWasUsedAsOldLayer,
-        'Layer ${describeIdentity(this)} was previously used as oldLayer.\n'
+        'Layer $runtimeType#${hashCode.toUnsigned(20).toRadixString(16).padLeft(5, '0')} was previously used as oldLayer.\n'
         'Once a layer is used as oldLayer, it may not be used again. Instead, '
         'after calling one of the SceneBuilder.push* methods and passing an oldLayer '
         'to it, use the layer returned by the method as oldLayer in subsequent '

--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -106,6 +106,7 @@ abstract class _EngineLayerWrapper implements EngineLayer {
   bool _debugWasUsedAsOldLayer = false;
 
   bool _debugCheckNotUsedAsOldLayer() {
+    // The hashCode formatting should match shortHash in the framework
     assert(
         !_debugWasUsedAsOldLayer,
         'Layer $runtimeType#${hashCode.toUnsigned(20).toRadixString(16).padLeft(5, '0')} was previously used as oldLayer.\n'

--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -108,7 +108,7 @@ abstract class _EngineLayerWrapper implements EngineLayer {
   bool _debugCheckNotUsedAsOldLayer() {
     assert(
         !_debugWasUsedAsOldLayer,
-        'Layer $runtimeType was previously used as oldLayer.\n'
+        'Layer ${describeIdentity(this)} was previously used as oldLayer.\n'
         'Once a layer is used as oldLayer, it may not be used again. Instead, '
         'after calling one of the SceneBuilder.push* methods and passing an oldLayer '
         'to it, use the layer returned by the method as oldLayer in subsequent '


### PR DESCRIPTION
I see this assert fail when working on my own app today (unrelated to flutter_smooth; work on stable channel). With identity hashcode, we can surely know more about which layer violates.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [
- x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
