### PR TITLE
Update the language version used by Fuchsia's wrapper for the Dart args package

### DIFF
--- a/shell/platform/fuchsia/dart/BUILD.gn
+++ b/shell/platform/fuchsia/dart/BUILD.gn
@@ -127,7 +127,7 @@ dart_library("args") {
   package_root = "//third_party/dart/third_party/pkg/args"
   package_name = "args"
 
-  language_version = "2.12"
+  language_version = "2.18"
 
   deps = []
 


### PR DESCRIPTION
The latest version of args is using Dart 2.18 language features.

See https://github.com/flutter/flutter/issues/113943
