### PR TITLE
[iOS] Not log callback cache info if cache is empty

### DIFF
--- a/lib/ui/plugins/callback_cache.cc
+++ b/lib/ui/plugins/callback_cache.cc
@@ -127,6 +127,9 @@ void DartCallbackCache::LoadCacheFromDisk() {
   }
   std::string cache_contents{std::istreambuf_iterator<char>(input),
                              std::istreambuf_iterator<char>()};
+  if (cache_contents.empty()) {
+    return;
+  }
   Document d;
   d.Parse(cache_contents.c_str());
   if (d.HasParseError() || !d.IsArray()) {

--- a/lib/ui/plugins/callback_cache.cc
+++ b/lib/ui/plugins/callback_cache.cc
@@ -127,14 +127,9 @@ void DartCallbackCache::LoadCacheFromDisk() {
   }
   std::string cache_contents{std::istreambuf_iterator<char>(input),
                              std::istreambuf_iterator<char>()};
-  if (cache_contents.empty()) {
-    return;
-  }
   Document d;
   d.Parse(cache_contents.c_str());
   if (d.HasParseError() || !d.IsArray()) {
-    FML_LOG(INFO) << "Could not parse callback cache, aborting restore";
-    // TODO(bkonyi): log and bail (delete cache?)
     return;
   }
   const auto entries = d.GetArray();

--- a/lib/ui/plugins/callback_cache.cc
+++ b/lib/ui/plugins/callback_cache.cc
@@ -130,6 +130,7 @@ void DartCallbackCache::LoadCacheFromDisk() {
   Document d;
   d.Parse(cache_contents.c_str());
   if (d.HasParseError() || !d.IsArray()) {
+    // Could not parse callback cache, aborting restore.
     return;
   }
   const auto entries = d.GetArray();


### PR DESCRIPTION
If we don't use callback cache, every time we start the app, the log prints "Runner[667:97662] [VERBOSE0:callback_cache.cc(136)] Could not parse callback cache, aborting restore", which may lead to misleading.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
