### PR TITLE
Fixed race in incorrect windows platform channel test.

### DIFF
--- a/shell/platform/windows/fixtures/main.dart
+++ b/shell/platform/windows/fixtures/main.dart
@@ -32,7 +32,7 @@ void hiPlatformChannels() {
       ui.PlatformDispatcher.instance
           .sendPlatformMessage('hi', reply, (ByteData? reply) {});
     });
-    callback(null);
+    callback(data);
   });
 }
 

--- a/shell/platform/windows/flutter_windows_engine_unittests.cc
+++ b/shell/platform/windows/flutter_windows_engine_unittests.cc
@@ -295,12 +295,12 @@ TEST_F(FlutterWindowsEngineTest, PlatformMessageRoundTrip) {
   binary_messenger->Send(
       channel, reinterpret_cast<uint8_t*>(payload), 5,
       [&did_call_reply](const uint8_t* reply, size_t reply_size) {
-        EXPECT_EQ(reply_size, 3);
-        EXPECT_EQ(reply[0], static_cast<uint8_t>('b'));
+        EXPECT_EQ(reply_size, 5);
+        EXPECT_EQ(reply[0], static_cast<uint8_t>('h'));
         did_call_reply = true;
       });
   // Rely on timeout mechanism in CI.
-  while (!did_call_callback && !did_call_reply && !did_call_dart_reply) {
+  while (!did_call_callback || !did_call_reply || !did_call_dart_reply) {
     engine->task_runner()->ProcessTasks();
   }
 }


### PR DESCRIPTION
alternative to https://github.com/flutter/engine/pull/37010

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
