### PR TITLE
clang-tidy: Added an environment variable that allows fix to print the     generated diff.

### DIFF
--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -36,6 +36,15 @@ DART="${DART_BIN}/dart"
 # to have this as an error.
 MAC_HOST_WARNINGS_AS_ERRORS="performance-move-const-arg,performance-unnecessary-value-param"
 
+# FLUTTER_LINT_PRINT_FIX will make it so that fix is executed and the generated
+# diff is printed to stdout if clang-tidy fails. This is helpful for enabling
+# new lints.
+if [[ -z "${FLUTTER_LINT_PRINT_FIX}" ]]; then
+  fix_flag=""
+else
+  fix_flag="--fix"
+fi
+
 COMPILE_COMMANDS="$SRC_DIR/out/host_debug/compile_commands.json"
 if [ ! -f "$COMPILE_COMMANDS" ]; then
   (cd "$SRC_DIR"; ./flutter/tools/gn)
@@ -47,7 +56,18 @@ cd "$SCRIPT_DIR"
   "$SRC_DIR/flutter/tools/clang_tidy/bin/main.dart" \
   --src-dir="$SRC_DIR" \
   --mac-host-warnings-as-errors="$MAC_HOST_WARNINGS_AS_ERRORS" \
-  "$@"
+  $fix_flag \
+  "$@" && true # errors ignored
+clang_tidy_return=$?
+if [ $clang_tidy_return -ne 0 ]; then
+  if [ -n "$fix_flag" ]; then
+    echo "###################################################"
+    echo "# Attempted to fix issues with the following patch:"
+    echo "###################################################"
+    git --no-pager diff
+  fi
+  exit $clang_tidy_return
+fi
 
 cd "$FLUTTER_DIR"
 pylint-2.7 --rcfile=.pylintrc \


### PR DESCRIPTION
This helps with migrating new linter checks that have fixes implemented.  Turning this on allows the bots to print out the diff that can be patched locally across all platform CI checks.

issue: https://github.com/flutter/flutter/issues/113848

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
