### PR TITLE
[Impeller] Implement support for RuntimeEffect samplers

### DIFF
--- a/impeller/entity/contents/runtime_effect_contents.h
+++ b/impeller/entity/contents/runtime_effect_contents.h
@@ -4,17 +4,26 @@
 
 #include <functional>
 #include <memory>
+#include <vector>
 
 #include "impeller/entity/contents/color_source_contents.h"
+#include "impeller/renderer/sampler_descriptor.h"
 #include "impeller/runtime_stage/runtime_stage.h"
 
 namespace impeller {
 
 class RuntimeEffectContents final : public ColorSourceContents {
  public:
+  struct TextureInput {
+    SamplerDescriptor sampler_descriptor;
+    std::shared_ptr<Texture> texture;
+  };
+
   void SetRuntimeStage(std::shared_ptr<RuntimeStage> runtime_stage);
 
   void SetUniformData(std::shared_ptr<std::vector<uint8_t>> uniform_data);
+
+  void SetTextureInputs(std::vector<TextureInput> texture_inputs);
 
   // |Contents|
   bool Render(const ContentContext& renderer,
@@ -24,6 +33,7 @@ class RuntimeEffectContents final : public ColorSourceContents {
  private:
   std::shared_ptr<RuntimeStage> runtime_stage_;
   std::shared_ptr<std::vector<uint8_t>> uniform_data_;
+  std::vector<TextureInput> texture_inputs_;
 };
 
 }  // namespace impeller


### PR DESCRIPTION
This gets image samplers working by simply pulling the image and sampling info directly out of the color source, but we can add a path that supports properly rendering color source inputs quite easily later depending on what we end up deciding to do with the API.