### PR TITLE
Add necessary #includes for SkCodecAnimation.h

### DIFF
--- a/lib/ui/painting/image_generator.h
+++ b/lib/ui/painting/image_generator.h
@@ -7,6 +7,7 @@
 
 #include <optional>
 #include "flutter/fml/macros.h"
+#include "third_party/skia/include/codec/SkCodecAnimation.h"
 #include "third_party/skia/include/core/SkImageInfo.h"
 #include "third_party/skia/src/codec/SkCodecImageGenerator.h"
 

--- a/lib/ui/painting/image_generator_registry_unittests.cc
+++ b/lib/ui/painting/image_generator_registry_unittests.cc
@@ -8,6 +8,8 @@
 #include "flutter/shell/common/shell_test.h"
 #include "flutter/testing/testing.h"
 
+#include "third_party/skia/include/codec/SkCodecAnimation.h"
+
 namespace flutter {
 namespace testing {
 

--- a/lib/ui/painting/multi_frame_codec.cc
+++ b/lib/ui/painting/multi_frame_codec.cc
@@ -12,6 +12,7 @@
 #include "flutter/lib/ui/painting/image_decoder_impeller.h"
 #endif  // IMPELLER_SUPPORTS_RENDERING
 #include "third_party/dart/runtime/include/dart_api.h"
+#include "third_party/skia/include/codec/SkCodecAnimation.h"
 #include "third_party/skia/include/core/SkPixelRef.h"
 #include "third_party/tonic/logging/dart_invoke.h"
 

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -37,6 +37,7 @@
 #include "flutter/testing/testing.h"
 #include "gmock/gmock.h"
 #include "third_party/rapidjson/include/rapidjson/writer.h"
+#include "third_party/skia/include/codec/SkCodecAnimation.h"
 #include "third_party/skia/include/core/SkPictureRecorder.h"
 #include "third_party/tonic/converter/dart_converter.h"
 

--- a/shell/platform/android/android_image_generator.cc
+++ b/shell/platform/android/android_image_generator.cc
@@ -11,6 +11,8 @@
 
 #include "flutter/fml/platform/android/jni_util.h"
 
+#include "third_party/skia/include/codec/SkCodecAnimation.h"
+
 namespace flutter {
 
 static fml::jni::ScopedJavaGlobalRef<jclass>* g_flutter_jni_class = nullptr;


### PR DESCRIPTION
The Skia team is cleaning up the #includes inside our public headers. These changes keep Flutter Engine from depending on transitive dependencies that are being removed.

## Pre-launch Checklist

- [ x ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ x ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ x ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ x ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ x ] I updated/added relevant documentation (doc comments with `///`).
- [ x ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].