### PR TITLE
Adds direction to SemanticsFlag that ensures `flutter_test` is up to date with the latest flags

### DIFF
--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -285,7 +285,9 @@ class SemanticsAction {
 //
 // When changes are made to this class, the equivalent APIs in
 // `lib/ui/semantics/semantics_node.h` and in each of the embedders *must* be
-// updated.
+// updated. If the change affects the visibility of a [SemanticsNode] to
+// accessibility services, `flutter_test/controller.dart#SemanticsController._importantFlags`
+// must be updated as well.
 class SemanticsFlag {
   const SemanticsFlag._(this.index) : assert(index != null);
 
@@ -324,7 +326,10 @@ class SemanticsFlag {
   // value in testing/dart/semantics_test.dart, or tests will fail. Also,
   // please update the Flag enum in
   // flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java,
-  // and the SemanticsFlag class in lib/web_ui/lib/semantics.dart.
+  // and the SemanticsFlag class in lib/web_ui/lib/semantics.dart. If the new flag
+  // affects the visibility of a [SemanticsNode] to accessibility services,
+  // `flutter_test/controller.dart#SemanticsController._importantFlags`
+  // must be updated as well.
 
   /// The semantics node has the quality of either being "checked" or "unchecked".
   ///


### PR DESCRIPTION
As part of [flutter/flutter #107866](https://github.com/flutter/flutter/issues/107866), more functionality for testing semantics was added. Part of this was `simulatedAccessibilityTraversal`, which is dependent on knowing what flags are important for accessibility. The comments noting what need to be updated when SemanticsFlags are changed now include the relevant field to update for tests to remain accurate as well.

Relates to [flutter/flutter #107866](https://github.com/flutter/flutter/issues/107866)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.