### PR TITLE
[fuchsia][scenic] Fix logical size in flatland platform view.

### DIFF
--- a/shell/platform/fuchsia/flutter/flatland_platform_view.cc
+++ b/shell/platform/fuchsia/flutter/flatland_platform_view.cc
@@ -84,25 +84,27 @@ void FlatlandPlatformView::OnGetLayout(
   }
 
   SetViewportMetrics({
-      pixel_ratio,                    // device_pixel_ratio
-      view_logical_size_.value()[0],  // physical_width
-      view_logical_size_.value()[1],  // physical_height
-      0.0f,                           // physical_padding_top
-      0.0f,                           // physical_padding_right
-      0.0f,                           // physical_padding_bottom
-      0.0f,                           // physical_padding_left
-      0.0f,                           // physical_view_inset_top
-      0.0f,                           // physical_view_inset_right
-      0.0f,                           // physical_view_inset_bottom
-      0.0f,                           // physical_view_inset_left
-      0.0f,                           // p_physical_system_gesture_inset_top
-      0.0f,                           // p_physical_system_gesture_inset_right
-      0.0f,                           // p_physical_system_gesture_inset_bottom
-      0.0f,                           // p_physical_system_gesture_inset_left,
-      -1.0,                           // p_physical_touch_slop,
-      {},                             // p_physical_display_features_bounds
-      {},                             // p_physical_display_features_type
-      {},                             // p_physical_display_features_state
+      pixel_ratio,  // device_pixel_ratio
+      std::round(view_logical_size_.value()[0] *
+                 pixel_ratio),  // physical_width
+      std::round(view_logical_size_.value()[1] *
+                 pixel_ratio),  // physical_height
+      0.0f,                     // physical_padding_top
+      0.0f,                     // physical_padding_right
+      0.0f,                     // physical_padding_bottom
+      0.0f,                     // physical_padding_left
+      0.0f,                     // physical_view_inset_top
+      0.0f,                     // physical_view_inset_right
+      0.0f,                     // physical_view_inset_bottom
+      0.0f,                     // physical_view_inset_left
+      0.0f,                     // p_physical_system_gesture_inset_top
+      0.0f,                     // p_physical_system_gesture_inset_right
+      0.0f,                     // p_physical_system_gesture_inset_bottom
+      0.0f,                     // p_physical_system_gesture_inset_left,
+      -1.0,                     // p_physical_touch_slop,
+      {},                       // p_physical_display_features_bounds
+      {},                       // p_physical_display_features_type
+      {},                       // p_physical_display_features_state
   });
 
   parent_viewport_watcher_->GetLayout(

--- a/shell/platform/fuchsia/flutter/tests/flatland_platform_view_unittest.cc
+++ b/shell/platform/fuchsia/flutter/tests/flatland_platform_view_unittest.cc
@@ -672,7 +672,8 @@ TEST_F(FlatlandPlatformViewTests, SetViewportMetrics) {
   watcher.SetLayout(width, height, kDPR);
   RunLoopUntilIdle();
   EXPECT_EQ(delegate.metrics(),
-            flutter::ViewportMetrics(kDPR, width, height, -1.0));
+            flutter::ViewportMetrics(kDPR, std::round(width * kDPR),
+                                     std::round(height * kDPR), -1.0));
 }
 
 // This test makes sure that the PlatformView correctly registers semantics


### PR DESCRIPTION
This PR fixes a bug identified after DPR feature was added in flatland where currently we do not multiple the logical size of the view by the pixel ratio.

This change is getting tested in input tests like mouse-input-test, touch-input-test

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
