### PR TITLE
Macos re-enable TestSetMenu

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterMenuPluginTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterMenuPluginTest.mm
@@ -25,6 +25,11 @@
 @implementation FlutterMenuPluginTestObjc
 
 - (bool)testSetMenu {
+  // Workaround to deflake the test.
+  // See: https://github.com/flutter/flutter/issues/104748#issuecomment-1159336728
+  NSView* view = [[NSView alloc] initWithFrame:NSZeroRect];
+  view.wantsLayer = YES;
+
   // Build a simulation of the default main menu.
   NSMenu* mainMenu = [[NSMenu alloc] init];
   NSMenuItem* appNameMenu = [[NSMenuItem alloc] initWithTitle:@"APP_NAME"
@@ -175,9 +180,7 @@
 @end
 
 namespace flutter::testing {
-// TODO(gspencergoog): Re-enabled when deflaked
-// https://github.com/flutter/flutter/issues/106589
-TEST(FlutterMenuPluginTest, DISABLED_TestSetMenu) {
+TEST(FlutterMenuPluginTest, TestSetMenu) {
   ASSERT_TRUE([[FlutterMenuPluginTestObjc alloc] testSetMenu]);
 }
 }  // namespace flutter::testing


### PR DESCRIPTION
Re-enables the TestSetMenu test.
The workaround in https://github.com/flutter/flutter/issues/104748#issuecomment-1159336728 is applied in this PR.

Fixes https://github.com/flutter/flutter/issues/104748

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
