### PR TITLE
Clang-tidy: cleaned up the output.

### DIFF
--- a/tools/clang_tidy/lib/clang_tidy.dart
+++ b/tools/clang_tidy/lib/clang_tidy.dart
@@ -228,7 +228,7 @@ class ClangTidy {
     return _ComputeJobsResult(jobs, sawMalformed);
   }
 
-  Iterable<String> _trimGenerator(String output) sync* {
+  static Iterable<String> _trimGenerator(String output) sync* {
     const LineSplitter splitter = LineSplitter();
     final List<String> lines = splitter.convert(output);
     bool isPrintingError = false;
@@ -244,7 +244,8 @@ class ClangTidy {
     }
   }
 
-  String _trimOutput(String output) => _trimGenerator(output).join('\n');
+  @visibleForTesting
+  static String trimOutput(String output) => _trimGenerator(output).join('\n');
 
   Future<int> _runJobs(List<WorkerJob> jobs) async {
     int result = 0;
@@ -257,9 +258,9 @@ class ClangTidy {
       if (!job.printOutput) {
         final Exception? exception = job.exception;
         if (exception != null) {
-          _errSink.writeln(_trimOutput(exception.toString()));
+          _errSink.writeln(trimOutput(exception.toString()));
         } else {
-          _errSink.writeln(_trimOutput(job.result.stdout));
+          _errSink.writeln(trimOutput(job.result.stdout));
         }
       }
       result = 1;

--- a/tools/clang_tidy/lib/clang_tidy.dart
+++ b/tools/clang_tidy/lib/clang_tidy.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:convert' show jsonDecode, LineSplitter;
+import 'dart:convert' show LineSplitter, jsonDecode;
 import 'dart:io' as io show File, stderr, stdout;
 
 import 'package:meta/meta.dart';
@@ -244,6 +244,8 @@ class ClangTidy {
     }
   }
 
+  /// Visible for testing.
+  /// Function for trimming raw clang-tidy output.
   @visibleForTesting
   static String trimOutput(String output) => _trimGenerator(output).join('\n');
 

--- a/tools/clang_tidy/test/clang_tidy_test.dart
+++ b/tools/clang_tidy/test/clang_tidy_test.dart
@@ -10,6 +10,34 @@ import 'package:clang_tidy/src/options.dart';
 import 'package:litetest/litetest.dart';
 import 'package:process_runner/process_runner.dart';
 
+// Recorded locally from clang-tidy.
+const String _tidyOutput = '''
+/runtime.dart_isolate.o" in /Users/aaclarke/dev/engine/src/out/host_debug exited with code 1
+3467 warnings generated.
+/Users/aaclarke/dev/engine/src/flutter/runtime/dart_isolate.cc:167:32: error: std::move of the const variable 'dart_entrypoint_args' has no effect; remove std::move() or make the variable non-const [performance-move-const-arg,-warnings-as-errors]
+                               std::move(dart_entrypoint_args))) {
+                               ^~~~~~~~~~                    ~
+Suppressed 3474 warnings (3466 in non-user code, 8 NOLINT).
+Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
+1 warning treated as error
+:
+3467 warnings generated.
+Suppressed 3474 warnings (3466 in non-user code, 8 NOLINT).
+Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
+1 warning treated as error
+
+
+
+''';
+
+const String _tidyTrimmedOutput = '''
+/Users/aaclarke/dev/engine/src/flutter/runtime/dart_isolate.cc:167:32: error: std::move of the const variable 'dart_entrypoint_args' has no effect; remove std::move() or make the variable non-const [performance-move-const-arg,-warnings-as-errors]
+                               std::move(dart_entrypoint_args))) {
+                               ^~~~~~~~~~                    ~
+Suppressed 3474 warnings (3466 in non-user code, 8 NOLINT).
+Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
+1 warning treated as error''';
+
 Future<int> main(List<String> args) async {
   if (args.isEmpty) {
     io.stderr.writeln(
@@ -35,6 +63,10 @@ Future<int> main(List<String> args) async {
     expect(clangTidy.options.help, isTrue);
     expect(result, equals(0));
     expect(errBuffer.toString(), contains('Usage: '));
+  });
+
+  test('trimmed clang-tidy output', () {
+    expect(_tidyTrimmedOutput, equals(ClangTidy.trimOutput(_tidyOutput)));
   });
 
   test('Error when --compile-commands and --target-variant are used together', () async {


### PR DESCRIPTION
Previously we would print out errors twice (or thrice if you had `--verbose`).  Also we were printing out the invocation which isn't necessary now that the `--verbose` flag does that.  Users want to know the filename and a quick description of the errors.

issue: https://github.com/flutter/flutter/issues/113848

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
