### PR TITLE
[web] Allow tests to run with multiple renderers

### DIFF
--- a/lib/web_ui/dev/steps/compile_tests_step.dart
+++ b/lib/web_ui/dev/steps/compile_tests_step.dart
@@ -257,13 +257,13 @@ Future<bool> compileUnitTest(FilePath input, {required Renderer renderer}) async
   // to run the same test in multiple renderers.
   final String targetFileName = pathlib.join(
     environment.webUiBuildDir.path,
-    buildDirForRenderer(renderer),
+    getBuildDirForRenderer(renderer),
     '${input.relativeToWebUi}.browser_test.dart.js',
   );
 
   final io.Directory directoryToTarget = io.Directory(pathlib.join(
       environment.webUiBuildDir.path,
-      buildDirForRenderer(renderer),
+      getBuildDirForRenderer(renderer),
       pathlib.dirname(input.relativeToWebUi)));
 
   if (!directoryToTarget.existsSync()) {

--- a/lib/web_ui/dev/steps/compile_tests_step.dart
+++ b/lib/web_ui/dev/steps/compile_tests_step.dart
@@ -203,10 +203,6 @@ Future<void> compileTests(List<FilePath> testFiles) async {
       _compileTestsInParallel(targets: sortedTests.canvasKitTests, renderer: Renderer.canvasKit),
     if (sortedTests.skwasmTests.isNotEmpty)
       _compileTestsInParallel(targets: sortedTests.skwasmTests, renderer: Renderer.skwasm),
-    if (sortedTests.uiTests.isNotEmpty)
-      _compileTestsInParallel(targets: sortedTests.uiTests),
-    if (sortedTests.uiTests.isNotEmpty)
-      _compileTestsInParallel(targets: sortedTests.uiTests, renderer: Renderer.canvasKit),
   ]);
 
   stopwatch.stop();

--- a/lib/web_ui/dev/steps/compile_tests_step.dart
+++ b/lib/web_ui/dev/steps/compile_tests_step.dart
@@ -194,24 +194,24 @@ Future<void> copyCanvasKitFiles({bool useLocalCanvasKit = false}) async {
 Future<void> compileTests(List<FilePath> testFiles) async {
   final Stopwatch stopwatch = Stopwatch()..start();
 
-  final TestsByRenderer testsByRenderer = organizeTestsByRenderer(testFiles);
+  final TestsByRenderer sortedTests = sortTestsByRenderer(testFiles);
 
   await Future.wait(<Future<void>>[
-    if (testsByRenderer.htmlTests.isNotEmpty)
-      _compileTestsInParallel(targets: testsByRenderer.htmlTests),
-    if (testsByRenderer.canvasKitTests.isNotEmpty)
-      _compileTestsInParallel(targets: testsByRenderer.canvasKitTests, renderer: Renderer.canvasKit),
-    if (testsByRenderer.skwasmTests.isNotEmpty)
-      _compileTestsInParallel(targets: testsByRenderer.skwasmTests, renderer: Renderer.skwasm),
-    if (testsByRenderer.uiTests.isNotEmpty)
-      _compileTestsInParallel(targets: testsByRenderer.uiTests),
-    if (testsByRenderer.uiTests.isNotEmpty)
-      _compileTestsInParallel(targets: testsByRenderer.uiTests, renderer: Renderer.canvasKit),
+    if (sortedTests.htmlTests.isNotEmpty)
+      _compileTestsInParallel(targets: sortedTests.htmlTests),
+    if (sortedTests.canvasKitTests.isNotEmpty)
+      _compileTestsInParallel(targets: sortedTests.canvasKitTests, renderer: Renderer.canvasKit),
+    if (sortedTests.skwasmTests.isNotEmpty)
+      _compileTestsInParallel(targets: sortedTests.skwasmTests, renderer: Renderer.skwasm),
+    if (sortedTests.uiTests.isNotEmpty)
+      _compileTestsInParallel(targets: sortedTests.uiTests),
+    if (sortedTests.uiTests.isNotEmpty)
+      _compileTestsInParallel(targets: sortedTests.uiTests, renderer: Renderer.canvasKit),
   ]);
 
   stopwatch.stop();
 
-  final int targetCount = testsByRenderer.numTargetsToCompile;
+  final int targetCount = sortedTests.numTargetsToCompile;
   print(
     'Built $targetCount tests in ${stopwatch.elapsedMilliseconds ~/ 1000} '
     'seconds using $_dart2jsConcurrency concurrent dart2js processes.',

--- a/lib/web_ui/dev/steps/run_tests_step.dart
+++ b/lib/web_ui/dev/steps/run_tests_step.dart
@@ -68,11 +68,11 @@ class RunTestsStep implements PipelineStep {
     final SkiaGoldClient? skiaClient = await _createSkiaClient();
     final List<FilePath> testFiles = this.testFiles ?? findAllTests();
 
-    final TestsByRenderer testsByRenderer = organizeTestsByRenderer(testFiles);
+    final TestsByRenderer sortedTests = sortTestsByRenderer(testFiles);
 
-    if (testsByRenderer.htmlTests.isNotEmpty || testsByRenderer.uiTests.isNotEmpty) {
+    if (sortedTests.htmlTests.isNotEmpty || sortedTests.uiTests.isNotEmpty) {
       await _runTestBatch(
-        testFiles: testsByRenderer.htmlTests + testsByRenderer.uiTests,
+        testFiles: sortedTests.htmlTests + sortedTests.uiTests,
         renderer: Renderer.html,
         browserEnvironment: browserEnvironment,
         expectFailure: false,
@@ -83,9 +83,9 @@ class RunTestsStep implements PipelineStep {
       );
     }
 
-    if (testsByRenderer.canvasKitTests.isNotEmpty || testsByRenderer.uiTests.isNotEmpty) {
+    if (sortedTests.canvasKitTests.isNotEmpty || sortedTests.uiTests.isNotEmpty) {
       await _runTestBatch(
-        testFiles: testsByRenderer.canvasKitTests + testsByRenderer.uiTests,
+        testFiles: sortedTests.canvasKitTests + sortedTests.uiTests,
         renderer: Renderer.canvasKit,
         browserEnvironment: browserEnvironment,
         expectFailure: false,
@@ -96,9 +96,9 @@ class RunTestsStep implements PipelineStep {
       );
     }
 
-    if (testsByRenderer.skwasmTests.isNotEmpty) {
+    if (sortedTests.skwasmTests.isNotEmpty) {
       await _runTestBatch(
-        testFiles: testsByRenderer.skwasmTests,
+        testFiles: sortedTests.skwasmTests,
         renderer: Renderer.skwasm,
         browserEnvironment: browserEnvironment,
         expectFailure: false,

--- a/lib/web_ui/dev/steps/run_tests_step.dart
+++ b/lib/web_ui/dev/steps/run_tests_step.dart
@@ -70,9 +70,9 @@ class RunTestsStep implements PipelineStep {
 
     final TestsByRenderer sortedTests = sortTestsByRenderer(testFiles);
 
-    if (sortedTests.htmlTests.isNotEmpty || sortedTests.uiTests.isNotEmpty) {
+    if (sortedTests.htmlTests.isNotEmpty) {
       await _runTestBatch(
-        testFiles: sortedTests.htmlTests + sortedTests.uiTests,
+        testFiles: sortedTests.htmlTests,
         renderer: Renderer.html,
         browserEnvironment: browserEnvironment,
         expectFailure: false,
@@ -83,9 +83,9 @@ class RunTestsStep implements PipelineStep {
       );
     }
 
-    if (sortedTests.canvasKitTests.isNotEmpty || sortedTests.uiTests.isNotEmpty) {
+    if (sortedTests.canvasKitTests.isNotEmpty) {
       await _runTestBatch(
-        testFiles: sortedTests.canvasKitTests + sortedTests.uiTests,
+        testFiles: sortedTests.canvasKitTests,
         renderer: Renderer.canvasKit,
         browserEnvironment: browserEnvironment,
         expectFailure: false,
@@ -188,7 +188,7 @@ Future<void> _runTestBatch({
   );
   final String precompiledBuildDir = pathlib.join(
     environment.webUiBuildDir.path,
-    buildDirForRenderer(renderer),
+    getBuildDirForRenderer(renderer),
   );
   final List<String> testArgs = <String>[
     ...<String>['-r', 'compact'],

--- a/lib/web_ui/dev/steps/run_tests_step.dart
+++ b/lib/web_ui/dev/steps/run_tests_step.dart
@@ -68,15 +68,46 @@ class RunTestsStep implements PipelineStep {
     final SkiaGoldClient? skiaClient = await _createSkiaClient();
     final List<FilePath> testFiles = this.testFiles ?? findAllTests();
 
-    await _runTestBatch(
-      testFiles: testFiles,
-      browserEnvironment: browserEnvironment,
-      expectFailure: false,
-      isDebug: isDebug,
-      doUpdateScreenshotGoldens: doUpdateScreenshotGoldens,
-      skiaClient: skiaClient,
-      overridePathToCanvasKit: overridePathToCanvasKit,
-    );
+    final TestsByRenderer testsByRenderer = organizeTestsByRenderer(testFiles);
+
+    if (testsByRenderer.htmlTests.isNotEmpty || testsByRenderer.uiTests.isNotEmpty) {
+      await _runTestBatch(
+        testFiles: testsByRenderer.htmlTests + testsByRenderer.uiTests,
+        renderer: Renderer.html,
+        browserEnvironment: browserEnvironment,
+        expectFailure: false,
+        isDebug: isDebug,
+        doUpdateScreenshotGoldens: doUpdateScreenshotGoldens,
+        skiaClient: skiaClient,
+        overridePathToCanvasKit: overridePathToCanvasKit,
+      );
+    }
+
+    if (testsByRenderer.canvasKitTests.isNotEmpty || testsByRenderer.uiTests.isNotEmpty) {
+      await _runTestBatch(
+        testFiles: testsByRenderer.canvasKitTests + testsByRenderer.uiTests,
+        renderer: Renderer.canvasKit,
+        browserEnvironment: browserEnvironment,
+        expectFailure: false,
+        isDebug: isDebug,
+        doUpdateScreenshotGoldens: doUpdateScreenshotGoldens,
+        skiaClient: skiaClient,
+        overridePathToCanvasKit: overridePathToCanvasKit,
+      );
+    }
+
+    if (testsByRenderer.skwasmTests.isNotEmpty) {
+      await _runTestBatch(
+        testFiles: testsByRenderer.skwasmTests,
+        renderer: Renderer.skwasm,
+        browserEnvironment: browserEnvironment,
+        expectFailure: false,
+        isDebug: isDebug,
+        doUpdateScreenshotGoldens: doUpdateScreenshotGoldens,
+        skiaClient: skiaClient,
+        overridePathToCanvasKit: overridePathToCanvasKit,
+      );
+    }
 
     await browserEnvironment.cleanup();
 
@@ -143,6 +174,7 @@ Future<void> _prepareTestResultsDirectory() async {
 /// value if any tests fail.
 Future<void> _runTestBatch({
   required List<FilePath> testFiles,
+  required Renderer renderer,
   required bool isDebug,
   required BrowserEnvironment browserEnvironment,
   required bool doUpdateScreenshotGoldens,
@@ -154,6 +186,10 @@ Future<void> _runTestBatch({
     environment.webUiRootDir.path,
     browserEnvironment.packageTestConfigurationYamlFile,
   );
+  final String precompiledBuildDir = pathlib.join(
+    environment.webUiBuildDir.path,
+    buildDirForRenderer(renderer),
+  );
   final List<String> testArgs = <String>[
     ...<String>['-r', 'compact'],
     // Disable concurrency. Running with concurrency proved to be flaky.
@@ -163,7 +199,7 @@ Future<void> _runTestBatch({
     if (expectFailure)
       '--reporter=name-only',
     '--platform=${browserEnvironment.packageTestRuntime.identifier}',
-    '--precompiled=${environment.webUiBuildDir.path}',
+    '--precompiled=$precompiledBuildDir',
     '--configuration=$configurationFilePath',
     '--',
     ...testFiles.map((FilePath f) => f.relativeToWebUi),
@@ -183,6 +219,7 @@ Future<void> _runTestBatch({
   ], () {
     return BrowserPlatform.start(
       browserEnvironment: browserEnvironment,
+      renderer: renderer,
       // It doesn't make sense to update a screenshot for a test that is
       // expected to fail.
       doUpdateScreenshotGoldens: !expectFailure && doUpdateScreenshotGoldens,

--- a/lib/web_ui/dev/test_platform.dart
+++ b/lib/web_ui/dev/test_platform.dart
@@ -401,7 +401,7 @@ class BrowserPlatform extends PlatformPlugin {
     if (!fileInBuild.existsSync()) {
       fileInBuild = File(p.join(
         env.environment.webUiBuildDir.path,
-        buildDirForRenderer(renderer),
+        getBuildDirForRenderer(renderer),
         request.url.path,
       ));
     }
@@ -870,7 +870,7 @@ class BrowserManager {
         final String pathToTest = p.dirname(path);
 
         final String mapPath = p.join(env.environment.webUiRootDir.path,
-            'build', buildDirForRenderer(_renderer), pathToTest, sourceMapFileName);
+            'build', getBuildDirForRenderer(_renderer), pathToTest, sourceMapFileName);
 
         final Map<String, Uri> packageMap = <String, Uri>{
           for (Package p in packageConfig.packages) p.name: p.packageUriRoot

--- a/lib/web_ui/dev/test_platform.dart
+++ b/lib/web_ui/dev/test_platform.dart
@@ -38,12 +38,14 @@ import 'package:web_test_utils/image_compare.dart';
 
 import 'browser.dart';
 import 'environment.dart' as env;
+import 'utils.dart';
 
 /// Custom test platform that serves web engine unit tests.
 class BrowserPlatform extends PlatformPlugin {
   BrowserPlatform._({
     required this.browserEnvironment,
     required this.server,
+    required this.renderer,
     required this.isDebug,
     required this.doUpdateScreenshotGoldens,
     required this.packageConfig,
@@ -100,6 +102,7 @@ class BrowserPlatform extends PlatformPlugin {
   /// instead of failing the test on screenshot mismatches.
   static Future<BrowserPlatform> start({
     required BrowserEnvironment browserEnvironment,
+    required Renderer renderer,
     required bool doUpdateScreenshotGoldens,
     required SkiaGoldClient? skiaClient,
     required String? overridePathToCanvasKit,
@@ -108,6 +111,7 @@ class BrowserPlatform extends PlatformPlugin {
         shelf_io.IOServer(await HttpMultiServer.loopback(0));
     return BrowserPlatform._(
       browserEnvironment: browserEnvironment,
+      renderer: renderer,
       server: server,
       isDebug: Configuration.current.pauseAfterLoad,
       doUpdateScreenshotGoldens: doUpdateScreenshotGoldens,
@@ -127,6 +131,9 @@ class BrowserPlatform extends PlatformPlugin {
 
   /// Provides the environment for the browser running tests.
   final BrowserEnvironment browserEnvironment;
+
+  /// The renderer that tests are running under.
+  final Renderer renderer;
 
   /// The URL for this server.
   Uri get url => server.url.resolve('/');
@@ -384,10 +391,18 @@ class BrowserPlatform extends PlatformPlugin {
   ///
   /// This is used for trivial use-cases, such as `favicon.ico`, host pages, etc.
   shelf.Response buildDirectoryHandler(shelf.Request request) {
-    final File fileInBuild = File(p.join(
+    File fileInBuild = File(p.join(
       env.environment.webUiBuildDir.path,
       request.url.path,
     ));
+
+    if (!fileInBuild.existsSync()) {
+      fileInBuild = File(p.join(
+        env.environment.webUiBuildDir.path,
+        buildDirForRenderer(renderer),
+        request.url.path,
+      ));
+    }
 
     if (!fileInBuild.existsSync()) {
       return shelf.Response.notFound('File not found: ${request.url.path}');
@@ -517,6 +532,7 @@ class BrowserPlatform extends PlatformPlugin {
       future: completer.future,
       packageConfig: packageConfig,
       debug: isDebug,
+      renderer: renderer,
     );
 
     // Store null values for browsers that error out so we know not to load them
@@ -612,7 +628,7 @@ class BrowserManager {
   /// Creates a new BrowserManager that communicates with the browser over
   /// [webSocket].
   BrowserManager._(this.packageConfig, this._browser, this._browserEnvironment,
-      WebSocketChannel webSocket) {
+      this._renderer, WebSocketChannel webSocket) {
     // The duration should be short enough that the debugging console is open as
     // soon as the user is done setting breakpoints, but long enough that a test
     // doing a lot of synchronous work doesn't trigger a false positive.
@@ -657,6 +673,9 @@ class BrowserManager {
 
   /// The browser environment for this test.
   final BrowserEnvironment _browserEnvironment;
+
+  /// The renderer for this test.
+  final Renderer _renderer;
 
   /// The channel used to communicate with the browser.
   ///
@@ -722,6 +741,7 @@ class BrowserManager {
     required Uri url,
     required Future<WebSocketChannel> future,
     required PackageConfig packageConfig,
+    required Renderer renderer,
     bool debug = false,
   }) async {
     final Browser browser =
@@ -732,6 +752,7 @@ class BrowserManager {
         future: future,
         packageConfig: packageConfig,
         browser: browser,
+        renderer: renderer,
         debug: debug);
   }
 
@@ -741,6 +762,7 @@ class BrowserManager {
     required Future<WebSocketChannel> future,
     required PackageConfig packageConfig,
     required Browser browser,
+    required Renderer renderer,
     bool debug = false,
   }) {
     final Completer<BrowserManager> completer = Completer<BrowserManager>();
@@ -762,7 +784,7 @@ class BrowserManager {
         return;
       }
       completer.complete(BrowserManager._(
-          packageConfig, browser, browserEnvironment, webSocket));
+          packageConfig, browser, browserEnvironment, renderer, webSocket));
     }).catchError((Object error, StackTrace stackTrace) {
       browser.close();
       if (completer.isCompleted) {
@@ -846,7 +868,7 @@ class BrowserManager {
         final String pathToTest = p.dirname(path);
 
         final String mapPath = p.join(env.environment.webUiRootDir.path,
-            'build', pathToTest, sourceMapFileName);
+            'build', buildDirForRenderer(_renderer), pathToTest, sourceMapFileName);
 
         final Map<String, Uri> packageMap = <String, Uri>{
           for (Package p in packageConfig.packages) p.name: p.packageUriRoot

--- a/lib/web_ui/dev/test_platform.dart
+++ b/lib/web_ui/dev/test_platform.dart
@@ -396,6 +396,8 @@ class BrowserPlatform extends PlatformPlugin {
       request.url.path,
     ));
 
+    // If we can't find the file in the top-level `build` directory, then it
+    // may be in the renderer-specific `build` subdirectory.
     if (!fileInBuild.existsSync()) {
       fileInBuild = File(p.join(
         env.environment.webUiBuildDir.path,

--- a/lib/web_ui/dev/utils.dart
+++ b/lib/web_ui/dev/utils.dart
@@ -389,7 +389,7 @@ enum Renderer {
 
 /// The `FilePath`s for all the tests, organized by renderer.
 class TestsByRenderer {
-  TestsByRenderer(this.htmlTests, this.canvasKitTests, this.skwasmTests, this.uiTests);
+  TestsByRenderer(this.htmlTests, this.canvasKitTests, this.skwasmTests);
 
   /// Tests which should be run with the HTML renderer.
   final List<FilePath> htmlTests;
@@ -400,14 +400,11 @@ class TestsByRenderer {
   /// Tests which should be run with the Skwasm renderer.
   final List<FilePath> skwasmTests;
 
-  /// Renderer-agnostic tests. These should only use `dart:ui` APIs.
-  final List<FilePath> uiTests;
-
   /// The total number of targets to compile.
   ///
   /// The number of uiTests is doubled since they are compiled twice: once for
   /// the HTML renderer and once for the CanvasKit renderer.
-  int get numTargetsToCompile => htmlTests.length + canvasKitTests.length + skwasmTests.length + 2 * uiTests.length;
+  int get numTargetsToCompile => htmlTests.length + canvasKitTests.length + skwasmTests.length;
 }
 
 /// Given a list of test files, organizes them by which renderer should run them.
@@ -415,7 +412,6 @@ TestsByRenderer sortTestsByRenderer(List<FilePath> testFiles) {
   final List<FilePath> htmlTargets = <FilePath>[];
   final List<FilePath> canvasKitTargets = <FilePath>[];
   final List<FilePath> skwasmTargets = <FilePath>[];
-  final List<FilePath> uiTargets = <FilePath>[];
   final String canvasKitTestDirectory =
       path.join(environment.webUiTestDir.path, 'canvaskit');
   final String skwasmTestDirectory =
@@ -428,16 +424,17 @@ TestsByRenderer sortTestsByRenderer(List<FilePath> testFiles) {
     } else if (path.isWithin(skwasmTestDirectory, testFile.absolute)) {
       skwasmTargets.add(testFile);
     } else if (path.isWithin(uiTestDirectory, testFile.absolute)) {
-      uiTargets.add(testFile);
+      htmlTargets.add(testFile);
+      canvasKitTargets.add(testFile);
     } else {
       htmlTargets.add(testFile);
     }
   }
-  return TestsByRenderer(htmlTargets, canvasKitTargets, skwasmTargets, uiTargets);
+  return TestsByRenderer(htmlTargets, canvasKitTargets, skwasmTargets);
 }
 
 /// The build directory to compile a test into given the renderer.
-String buildDirForRenderer(Renderer renderer) {
+String getBuildDirForRenderer(Renderer renderer) {
   switch (renderer) {
     case Renderer.html:
       return 'html_tests';

--- a/lib/web_ui/dev/utils.dart
+++ b/lib/web_ui/dev/utils.dart
@@ -379,3 +379,71 @@ List<FilePath> findAllTests() {
           path.relative(f.path, from: environment.webUiRootDir.path)))
       .toList();
 }
+
+/// The renderer used to run the test.
+enum Renderer {
+  html,
+  canvasKit,
+  skwasm,
+}
+
+/// The `FilePath`s for all the tests, organized by renderer.
+class TestsByRenderer {
+  TestsByRenderer(this.htmlTests, this.canvasKitTests, this.skwasmTests, this.uiTests);
+
+  /// Tests which should be run with the HTML renderer.
+  final List<FilePath> htmlTests;
+
+  /// Tests which should be run with the CanvasKit renderer.
+  final List<FilePath> canvasKitTests;
+
+  /// Tests which should be run with the Skwasm renderer.
+  final List<FilePath> skwasmTests;
+
+  /// Renderer-agnostic tests. These should only use `dart:ui` APIs.
+  final List<FilePath> uiTests;
+
+  /// The total number of targets to compile.
+  ///
+  /// The number of uiTests is doubled since they are compiled twice: once for
+  /// the HTML renderer and once for the CanvasKit renderer.
+  int get numTargetsToCompile => htmlTests.length + canvasKitTests.length + skwasmTests.length + 2 * uiTests.length;
+}
+
+/// Given a list of test files, organizes them by which renderer should run them.
+TestsByRenderer organizeTestsByRenderer(List<FilePath> testFiles) {
+  final List<FilePath> htmlTargets = <FilePath>[];
+  final List<FilePath> canvasKitTargets = <FilePath>[];
+  final List<FilePath> skwasmTargets = <FilePath>[];
+  final List<FilePath> uiTargets = <FilePath>[];
+  final String canvasKitTestDirectory =
+      path.join(environment.webUiTestDir.path, 'canvaskit');
+  final String skwasmTestDirectory =
+      path.join(environment.webUiTestDir.path, 'skwasm');
+  final String uiTestDirectory =
+      path.join(environment.webUiTestDir.path, 'ui');
+  for (final FilePath testFile in testFiles) {
+    if (path.isWithin(canvasKitTestDirectory, testFile.absolute)) {
+      canvasKitTargets.add(testFile);
+    } else if (path.isWithin(skwasmTestDirectory, testFile.absolute)) {
+      skwasmTargets.add(testFile);
+    } else if (path.isWithin(uiTestDirectory, testFile.absolute)) {
+      uiTargets.add(testFile);
+    } else {
+      htmlTargets.add(testFile);
+    }
+  }
+  return TestsByRenderer(htmlTargets, canvasKitTargets, skwasmTargets, uiTargets);
+}
+
+/// The build directory to compile a test into given the renderer.
+String buildDirForRenderer(Renderer renderer) {
+  switch (renderer) {
+    case Renderer.html:
+      return 'html_tests';
+    case Renderer.canvasKit:
+      return 'canvaskit_tests';
+    case Renderer.skwasm:
+      return 'skwasm_tests';
+  }
+}

--- a/lib/web_ui/dev/utils.dart
+++ b/lib/web_ui/dev/utils.dart
@@ -411,7 +411,7 @@ class TestsByRenderer {
 }
 
 /// Given a list of test files, organizes them by which renderer should run them.
-TestsByRenderer organizeTestsByRenderer(List<FilePath> testFiles) {
+TestsByRenderer sortTestsByRenderer(List<FilePath> testFiles) {
   final List<FilePath> htmlTargets = <FilePath>[];
   final List<FilePath> canvasKitTargets = <FilePath>[];
   final List<FilePath> skwasmTargets = <FilePath>[];

--- a/lib/web_ui/lib/src/engine/canvaskit/painting.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/painting.dart
@@ -108,7 +108,8 @@ class CkPaint extends ManagedSkiaObject<SkPaint> implements ui.Paint {
     if (_color == value) {
       return;
     }
-    _color = value;
+    _color =
+        value.runtimeType == ui.Color ? value : ui.Color(value.value);
     skiaObject.setColorInt(value.value);
   }
 

--- a/lib/web_ui/test/ui/color_test.dart
+++ b/lib/web_ui/test/ui/color_test.dart
@@ -6,6 +6,8 @@ import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/ui.dart';
 
+import 'utils.dart';
+
 void main() {
   internalBootstrapBrowserTest(() => testMain);
 }
@@ -15,6 +17,8 @@ class NotAColor extends Color {
 }
 
 void testMain() {
+  setUpUiTest();
+
   test('color accessors should work', () {
     const Color foo = Color(0x12345678);
     expect(foo.alpha, equals(0x12));

--- a/lib/web_ui/test/ui/utils.dart
+++ b/lib/web_ui/test/ui/utils.dart
@@ -1,0 +1,14 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:ui/src/engine.dart';
+
+import '../canvaskit/common.dart';
+
+/// Initializes the renderer for this test.
+void setUpUiTest() {
+  if (renderer is CanvasKitRenderer) {
+    setUpCanvasKitTest();
+  }
+}


### PR DESCRIPTION
This change creates the 'ui' test subdirectory, which is for tests using pure `dart:ui` API which we want to test with all renderers.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
