### PR TITLE
Fix inertia cancel event on macOS Ventura

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -843,8 +843,8 @@ static void CommonInit(FlutterViewController* controller) {
 - (void)touchesBeganWithEvent:(NSEvent*)event {
   NSTouch* touch = event.allTouches.anyObject;
   if (touch != nil) {
-    if ((event.timestamp - _mouseState.last_scroll_momentum_changed_time) < 0.010) {
-      // The trackpad has been touched within 10 ms following a scroll momentum event.
+    if ((event.timestamp - _mouseState.last_scroll_momentum_changed_time) < 0.050) {
+      // The trackpad has been touched within 50 ms following a scroll momentum event.
       // A scroll inertia cancel message should be sent to the framework.
       NSPoint locationInView = [self.flutterView convertPoint:event.locationInWindow fromView:nil];
       NSPoint locationInBackingCoordinates =


### PR DESCRIPTION
In macOS Ventura, the momentum end event is received before the `touchesBegan:`, so the old method doesn't function. Now we store the time of momentum change events and check upon `touchesBegan:` if one happened recently, this will handle both Ventura and older macOS versions. It also handles an issue seen in low power mode where the event sequence was different.

Fixes [#112333](https://github.com/flutter/flutter/issues/112333)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
