### PR TITLE
[Impeller] Improved rounded rect shadow approximation

### DIFF
--- a/impeller/compiler/shader_lib/impeller/gaussian.glsl
+++ b/impeller/compiler/shader_lib/impeller/gaussian.glsl
@@ -7,6 +7,7 @@
 
 #include <impeller/constants.glsl>
 
+/// Gaussian distribution function.
 float IPGaussian(float x, float sigma) {
   float variance = sigma * sigma;
   return exp(-0.5 * x * x / variance) / (kSqrtTwoPi * sigma);
@@ -20,8 +21,12 @@ float IPErf(float x) {
   return sign(x) * (1 - 1 / (b * b * b * b));
 }
 
+/// Vec2 variation for the Abramowitz and Stegun erf approximation.
 vec2 IPVec2Erf(vec2 x) {
-  return vec2(IPErf(x.x), IPErf(x.y));
+  vec2 a = abs(x);
+  // 0.278393*x + 0.230389*x^2 + 0.078108*x^4 + 1
+  vec2 b = (0.278393 + (0.230389 + 0.078108 * a * a) * a) * a + 1.0;
+  return sign(x) * (1 - 1 / (b * b * b * b));
 }
 
 /// Indefinite integral of the Gaussian function (with constant range 0->1).
@@ -30,6 +35,20 @@ float IPGaussianIntegral(float x, float sigma) {
   // Because this sigmoid is always > 1, we remap it (n * 1.07 - 0.07)
   // so that it always fades to zero before it reaches the blur radius.
   return 0.535 * IPErf(x * (kHalfSqrtTwo / sigma)) + 0.465;
+}
+
+/// Vec2 variation for the indefinite integral of the Gaussian function (with
+/// constant range 0->1).
+vec2 IPVec2GaussianIntegral(vec2 x, float sigma) {
+  // ( 1 + erf( x * (sqrt(2) / (2 * sigma) ) ) / 2
+  // Because this sigmoid is always > 1, we remap it (n * 1.07 - 0.07)
+  // so that it always fades to zero before it reaches the blur radius.
+  return 0.535 * IPVec2Erf(x * (kHalfSqrtTwo / sigma)) + 0.465;
+}
+
+/// Simple logistic sigmoid with a domain of [-1, 1] and range of [0, 1].
+float IPSigmoid(float x) {
+  return 1.03731472073 / (1 + exp(-4 * x)) - 0.0186573603638;
 }
 
 #endif

--- a/impeller/entity/contents/rrect_shadow_contents.cc
+++ b/impeller/entity/contents/rrect_shadow_contents.cc
@@ -94,7 +94,7 @@ bool RRectShadowContents::Render(const ContentContext& renderer,
 
   FS::FragInfo frag_info;
   frag_info.color = color_;
-  frag_info.blur_radius = blur_radius;
+  frag_info.blur_sigma = sigma_.sigma;
   frag_info.rect_size = Point(positive_rect.size);
   frag_info.corner_radius =
       std::min(corner_radius_, std::min(positive_rect.size.width / 2.0f,

--- a/impeller/entity/shaders/rrect_blur.frag
+++ b/impeller/entity/shaders/rrect_blur.frag
@@ -2,9 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <impeller/gaussian.glsl>
+
 uniform FragInfo {
   vec4 color;
-  float blur_radius;
+  float blur_sigma;
   vec2 rect_size;
   float corner_radius;
 }
@@ -14,21 +16,61 @@ in vec2 v_position;
 
 out vec4 frag_color;
 
-// Simple logistic sigmoid with a domain of [-1, 1] and range of [0, 1].
-float Sigmoid(float x) {
-  return 1.03731472073 / (1 + exp(-4 * x)) - 0.0186573603638;
-}
+const int kSamples = 5;
 
-float RRectDistance(vec2 sample_position, vec2 rect_size, float corner_radius) {
-  vec2 space = abs(sample_position) - rect_size + corner_radius;
+float RRectDistance(vec2 sample_position, vec2 half_size, float corner_radius) {
+  vec2 space = abs(sample_position) - half_size + corner_radius;
   return length(max(space, 0.0)) + min(max(space.x, space.y), 0.0) -
          corner_radius;
 }
 
+/// Closed form unidirectional rounded rect blur mask solution using the
+/// analytical Gaussian integral (with approximated erf).
+float RRectShadowX(float x, float y, vec2 half_size) {
+  // Compute the X direction distance field (not incorporating the Y distance)
+  // for the rounded rect.
+  float space = min(0, half_size.y - frag_info.corner_radius - abs(y));
+  float rrect_distance =
+      half_size.x - frag_info.corner_radius +
+      sqrt(max(0, frag_info.corner_radius * frag_info.corner_radius -
+                      space * space));
+
+  // Map the linear distance field to the analytical Gaussian integral.
+  vec2 integral = IPVec2GaussianIntegral(
+      x + vec2(-rrect_distance, rrect_distance), frag_info.blur_sigma);
+  return integral.y - integral.x;
+}
+
+float RRectShadow(vec2 sample_position, vec2 half_size) {
+  // Limit the sampling range to 3 standard deviations in the Y direction from
+  // the kernel center to incorporate 99.7% of the color contribution.
+  float half_sampling_range = frag_info.blur_sigma * 3;
+
+  float begin_y = max(-half_sampling_range, sample_position.y - half_size.y);
+  float end_y = min(half_sampling_range, sample_position.y + half_size.y);
+  float interval = (end_y - begin_y) / kSamples;
+
+  float result = 0;
+  for (int sample_i = 0; sample_i < kSamples; sample_i++) {
+    float y = begin_y + interval * (sample_i + 0.5);
+    result +=
+        RRectShadowX(sample_position.x, sample_position.y - y, half_size) *
+        IPGaussian(y, frag_info.blur_sigma) * interval;
+  }
+
+  return result;
+}
+
 void main() {
-  vec2 center = v_position - frag_info.rect_size / 2.0;
-  float dist =
-      RRectDistance(center, frag_info.rect_size / 2.0, frag_info.corner_radius);
-  float shadow_mask = Sigmoid(-dist / frag_info.blur_radius);
-  frag_color = frag_info.color * shadow_mask;
+  frag_color = frag_info.color;
+
+  vec2 half_size = frag_info.rect_size * 0.5;
+  vec2 sample_position = v_position - half_size;
+
+  if (frag_info.blur_sigma > 0) {
+    frag_color *= RRectShadow(sample_position, half_size);
+  } else {
+    frag_color *=
+        -RRectDistance(sample_position, half_size, frag_info.corner_radius);
+  }
 }


### PR DESCRIPTION
This switches the rounded rect blur approximation from using only a distance field to a hybrid sampling approach.
1. The X direction blur is computed by taking the X-only distance field and mapping it through the analytical Gaussian integral (which uses an erf approximation).
2. Step 1 is sampled with 5 evenly spaced samples over a 3*sigma kernel size in the Y direction.

This makes the rounded rect shadows nearly indistinguishable from the fully numerical Gaussian blur in most cases, while keeping the per-fragment overhead constant.

This was largely inspired by the ideas in this article: https://madebyevan.com/shaders/fast-rounded-rectangle-shadows/

Future work:
* Remove the slight discontinuity around the edges by adjusting either the radius per sigma ratio or the Gaussian integral.
* Still need to investigate why circles are missing the fast path.

https://user-images.githubusercontent.com/919017/198249151-4d610bab-d00f-4116-a9d3-392ea6e32c52.mov

Before:

![Screen Shot 2022-10-27 at 2 41 45 AM](https://user-images.githubusercontent.com/919017/198250786-41259631-1f88-498b-a4c6-88a4efec90d3.png)


After:

![Screen Shot 2022-10-27 at 2 40 37 AM](https://user-images.githubusercontent.com/919017/198250630-2d62b01c-82c4-4506-b597-e793e53b3f32.png)
