### PR TITLE
[Impeller] Support user defined structs in buffers, clean up compute tests

### DIFF
--- a/impeller/compiler/reflector.cc
+++ b/impeller/compiler/reflector.cc
@@ -603,6 +603,29 @@ std::vector<StructMember> Reflector::ReadStructMembers(
 
     FML_CHECK(current_byte_offset == struct_member_offset);
 
+    // A user defined struct.
+    if (member.basetype == spirv_cross::SPIRType::BaseType::Struct) {
+      const size_t size =
+          GetReflectedStructSize(ReadStructMembers(member.self));
+      uint32_t stride = GetArrayStride<0>(struct_type, member, i);
+      if (stride == 0) {
+        stride = size;
+      }
+      uint32_t element_padding = stride - size;
+      result.emplace_back(StructMember{
+          compiler_->get_name(member.self),      // type
+          BaseTypeToString(member.basetype),     // basetype
+          GetMemberNameAtIndex(struct_type, i),  // name
+          struct_member_offset,                  // offset
+          size,                                  // size
+          stride * array_elements.value_or(1),   // byte_length
+          array_elements,                        // array_elements
+          element_padding,                       // element_padding
+      });
+      current_byte_offset += stride * array_elements.value_or(1);
+      continue;
+    }
+
     // Tightly packed 4x4 Matrix is special cased as we know how to work with
     // those.
     if (member.basetype == spirv_cross::SPIRType::BaseType::Float &&  //

--- a/impeller/fixtures/sample.comp
+++ b/impeller/fixtures/sample.comp
@@ -1,6 +1,11 @@
 layout(local_size_x = 128) in;
 layout(std430) buffer;
 
+struct SomeStruct {
+  vec2 vf;
+  uint i;
+};
+
 layout(binding = 0) writeonly buffer Output {
   vec4 elements[];
 } output_data;
@@ -12,6 +17,7 @@ layout(binding = 1) readonly buffer Input0 {
 } input_data0;
 
 layout(binding = 2) readonly buffer Input1 {
+  SomeStruct some_struct;
   uvec2 fixed_array[4];
   vec4 elements[];
 } input_data1;
@@ -30,7 +36,7 @@ void main()
   }
 
   output_data.elements[ident] = input_data0.elements[ident] * input_data1.elements[ident];
-  output_data.elements[ident].x += input_data0.fixed_array[1].x;
-  output_data.elements[ident].y += input_data1.fixed_array[0].y;
-  output_data.elements[ident].z += input_data0.some_int;
+  output_data.elements[ident].x += input_data0.fixed_array[1].x + input_data1.some_struct.i;
+  output_data.elements[ident].y += input_data1.fixed_array[0].y + input_data1.some_struct.vf.x;
+  output_data.elements[ident].z += input_data0.some_int + input_data1.some_struct.vf.y;
 }

--- a/impeller/playground/BUILD.gn
+++ b/impeller/playground/BUILD.gn
@@ -62,6 +62,8 @@ impeller_component("playground_test") {
   testonly = true
 
   sources = [
+    "compute_playground_test.cc",
+    "compute_playground_test.h",
     "playground_test.cc",
     "playground_test.h",
   ]

--- a/impeller/playground/compute_playground_test.cc
+++ b/impeller/playground/compute_playground_test.cc
@@ -4,15 +4,15 @@
 
 #include "flutter/fml/time/time_point.h"
 
-#include "impeller/playground/playground_test.h"
+#include "impeller/playground/compute_playground_test.h"
 
 namespace impeller {
 
-PlaygroundTest::PlaygroundTest() = default;
+ComputePlaygroundTest::ComputePlaygroundTest() = default;
 
-PlaygroundTest::~PlaygroundTest() = default;
+ComputePlaygroundTest::~ComputePlaygroundTest() = default;
 
-void PlaygroundTest::SetUp() {
+void ComputePlaygroundTest::SetUp() {
   if (!Playground::SupportsBackend(GetParam())) {
     GTEST_SKIP_("Playground doesn't support this backend type.");
     return;
@@ -24,22 +24,21 @@ void PlaygroundTest::SetUp() {
   }
 
   SetupContext(GetParam());
-  SetupWindow();
 
   start_time_ = fml::TimePoint::Now().ToEpochDelta();
 }
 
-void PlaygroundTest::TearDown() {
+void ComputePlaygroundTest::TearDown() {
   TeardownWindow();
 }
 
 // |Playground|
-std::unique_ptr<fml::Mapping> PlaygroundTest::OpenAssetAsMapping(
+std::unique_ptr<fml::Mapping> ComputePlaygroundTest::OpenAssetAsMapping(
     std::string asset_name) const {
   return flutter::testing::OpenFixtureAsMapping(asset_name);
 }
 
-std::shared_ptr<RuntimeStage> PlaygroundTest::OpenAssetAsRuntimeStage(
+std::shared_ptr<RuntimeStage> ComputePlaygroundTest::OpenAssetAsRuntimeStage(
     const char* asset_name) const {
   auto fixture = flutter::testing::OpenFixtureAsMapping(asset_name);
   if (!fixture || fixture->GetSize() == 0) {
@@ -60,11 +59,11 @@ static std::string FormatWindowTitle(const std::string& test_name) {
 }
 
 // |Playground|
-std::string PlaygroundTest::GetWindowTitle() const {
+std::string ComputePlaygroundTest::GetWindowTitle() const {
   return FormatWindowTitle(flutter::testing::GetCurrentTestName());
 }
 
-Scalar PlaygroundTest::GetSecondsElapsed() const {
+Scalar ComputePlaygroundTest::GetSecondsElapsed() const {
   return (fml::TimePoint::Now().ToEpochDelta() - start_time_).ToSecondsF();
 }
 

--- a/impeller/playground/compute_playground_test.h
+++ b/impeller/playground/compute_playground_test.h
@@ -1,0 +1,55 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#pragma once
+
+#include <memory>
+
+#include "flutter/fml/macros.h"
+#include "flutter/fml/time/time_delta.h"
+#include "flutter/testing/testing.h"
+#include "impeller/geometry/scalar.h"
+#include "impeller/playground/playground.h"
+
+namespace impeller {
+
+class ComputePlaygroundTest
+    : public Playground,
+      public ::testing::TestWithParam<PlaygroundBackend> {
+ public:
+  ComputePlaygroundTest();
+
+  virtual ~ComputePlaygroundTest();
+
+  void SetUp() override;
+
+  void TearDown() override;
+
+  // |Playground|
+  std::unique_ptr<fml::Mapping> OpenAssetAsMapping(
+      std::string asset_name) const override;
+
+  std::shared_ptr<RuntimeStage> OpenAssetAsRuntimeStage(
+      const char* asset_name) const;
+
+  // |Playground|
+  std::string GetWindowTitle() const override;
+
+  /// @brief Get the amount of time elapsed from the start of the playground
+  ///        test's execution.
+  Scalar GetSecondsElapsed() const;
+
+ private:
+  fml::TimeDelta start_time_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(ComputePlaygroundTest);
+};
+
+#define INSTANTIATE_COMPUTE_SUITE(playground)                              \
+  INSTANTIATE_TEST_SUITE_P(                                                \
+      Compute, playground, ::testing::Values(PlaygroundBackend::kMetal),   \
+      [](const ::testing::TestParamInfo<ComputePlaygroundTest::ParamType>& \
+             info) { return PlaygroundBackendToString(info.param); });
+
+}  // namespace impeller

--- a/impeller/playground/playground.h
+++ b/impeller/playground/playground.h
@@ -38,7 +38,9 @@ class Playground {
 
   static bool ShouldOpenNewPlaygrounds();
 
-  void SetupWindow(PlaygroundBackend backend);
+  void SetupContext(PlaygroundBackend backend);
+
+  void SetupWindow();
 
   void TeardownWindow();
 
@@ -81,6 +83,7 @@ class Playground {
   struct GLFWInitializer;
   std::unique_ptr<GLFWInitializer> glfw_initializer_;
   std::unique_ptr<PlaygroundImpl> impl_;
+  std::shared_ptr<Context> context_;
   std::unique_ptr<Renderer> renderer_;
   Point cursor_position_;
   ISize window_size_ = ISize{1024, 768};


### PR DESCRIPTION
Updates the compute test to add a struct
Updates compiler reflector to support structs in buffers
Updates compute playground tests to not setup a renderer/attempt to setup a renderer.