### PR TITLE
[web] Prevent (forced-colors: active) from making the invisible text fields visible

### DIFF
--- a/lib/web_ui/lib/src/engine/dom.dart
+++ b/lib/web_ui/lib/src/engine/dom.dart
@@ -332,6 +332,7 @@ extension DomCSSStyleDeclarationExtension on DomCSSStyleDeclaration {
   set right(String value) => setProperty('right', value);
   set bottom(String value) => setProperty('bottom', value);
   set backgroundColor(String value) => setProperty('background-color', value);
+  set caretColor(String value) => setProperty('caret-color', value);
   set pointerEvents(String value) => setProperty('pointer-events', value);
   set filter(String value) => setProperty('filter', value);
   set zIndex(String value) => setProperty('z-index', value);
@@ -400,6 +401,7 @@ extension DomCSSStyleDeclarationExtension on DomCSSStyleDeclaration {
   String get right => getPropertyValue('right');
   String get bottom => getPropertyValue('bottom');
   String get backgroundColor => getPropertyValue('background-color');
+  String get caretColor => getPropertyValue('caret-color');
   String get pointerEvents => getPropertyValue('pointer-events');
   String get filter => getPropertyValue('filter');
   String get zIndex => getPropertyValue('z-index');

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -60,6 +60,7 @@ void _setStaticStyleAttributes(DomHTMLElement domElement) {
   final DomCSSStyleDeclaration elementStyle = domElement.style;
   elementStyle
     // Prevent (forced-colors: active) from making our invisible text fields visible.
+    // For more details, see: https://developer.mozilla.org/en-US/docs/Web/CSS/forced-color-adjust
     ..setProperty('forced-color-adjust', 'none')
     ..whiteSpace = 'pre-wrap'
     ..alignContent = 'center'

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -59,6 +59,8 @@ void _setStaticStyleAttributes(DomHTMLElement domElement) {
 
   final DomCSSStyleDeclaration elementStyle = domElement.style;
   elementStyle
+    // Prevent (forced-colors: active) from making our invisible text fields visible.
+    ..setProperty('forced-color-adjust', 'none')
     ..whiteSpace = 'pre-wrap'
     ..alignContent = 'center'
     ..position = 'absolute'
@@ -69,19 +71,18 @@ void _setStaticStyleAttributes(DomHTMLElement domElement) {
     ..color = 'transparent'
     ..backgroundColor = 'transparent'
     ..background = 'transparent'
+    // This property makes the input's blinking cursor transparent.
+    ..caretColor = 'transparent'
     ..outline = 'none'
     ..border = 'none'
     ..resize = 'none'
-    ..textShadow = 'transparent'
+    ..textShadow = 'none'
     ..overflow = 'hidden'
     ..transformOrigin = '0 0 0';
 
   if (browserHasAutofillOverlay()) {
     domElement.classList.add(transparentTextEditingClass);
   }
-
-  // This property makes the input's blinking cursor transparent.
-  elementStyle.setProperty('caret-color', 'transparent');
 
   if (_debugVisibleTextEditing) {
     elementStyle

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -2475,6 +2475,36 @@ Future<void> testMain() async {
       expect(textEditingDeltaState.composingExtent, -1);
     });
   });
+
+  group('text editing styles', () {
+    test('invisible element', () {
+      editingStrategy!.enable(
+        singlelineConfig,
+        onChange: trackEditingState,
+        onAction: trackInputAction,
+      );
+
+      final DomHTMLElement input = editingStrategy!.activeDomElement;
+      expect(input.style.color, 'transparent');
+      expect(input.style.background, 'transparent');
+      expect(input.style.backgroundColor, 'transparent');
+      expect(input.style.caretColor, 'transparent');
+      expect(input.style.outline, 'none');
+      expect(input.style.border, 'none');
+      expect(input.style.textShadow, 'none');
+    });
+
+    test('prevents effect of (forced-colors: active)', () {
+      editingStrategy!.enable(
+        singlelineConfig,
+        onChange: trackEditingState,
+        onAction: trackInputAction,
+      );
+
+      final DomHTMLElement input = editingStrategy!.activeDomElement;
+      expect(input.style.getPropertyValue('forced-color-adjust'), 'none');
+    });
+  });
 }
 
 DomKeyboardEvent dispatchKeyboardEvent(


### PR DESCRIPTION
When `(forced-colors: active)` is enabled in Chrome settings, it messes with the trasnparent styles that we set on text fields. This PR adds `forced-color-adjust: none;` to prevent that.