### PR TITLE
[Impeller] Use the fast rrect blur path for blurred circles/circular shadows

### DIFF
--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -160,6 +160,8 @@ void Canvas::DrawPaint(const Paint& paint) {
 bool Canvas::AttemptDrawBlurredRRect(const Rect& rect,
                                      Scalar corner_radius,
                                      const Paint& paint) {
+  // TODO(114184): This should return false when the paint's ColorSource is not
+  //               solid color.
   if (!paint.mask_blur_descriptor.has_value() ||
       paint.mask_blur_descriptor->style != FilterContents::BlurStyle::kNormal ||
       paint.style != Paint::Style::kFill) {

--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -159,35 +159,37 @@ void Canvas::DrawPaint(const Paint& paint) {
 
 bool Canvas::AttemptDrawBlurredRRect(const Rect& rect,
                                      Scalar corner_radius,
-                                     Paint& paint) {
+                                     const Paint& paint) {
   if (!paint.mask_blur_descriptor.has_value() ||
       paint.mask_blur_descriptor->style != FilterContents::BlurStyle::kNormal ||
       paint.style != Paint::Style::kFill) {
     return false;
   }
 
+  Paint new_paint = paint;
+
   // For symmetrically mask blurred solid RRects, absorb the mask blur and use
   // a faster SDF approximation.
 
   auto contents = std::make_shared<RRectShadowContents>();
-  contents->SetColor(paint.color);
-  contents->SetSigma(paint.mask_blur_descriptor->sigma);
+  contents->SetColor(new_paint.color);
+  contents->SetSigma(new_paint.mask_blur_descriptor->sigma);
   contents->SetRRect(rect, corner_radius);
 
-  paint.mask_blur_descriptor = std::nullopt;
+  new_paint.mask_blur_descriptor = std::nullopt;
 
   Entity entity;
   entity.SetTransformation(GetCurrentTransformation());
   entity.SetStencilDepth(GetStencilDepth());
-  entity.SetBlendMode(paint.blend_mode);
-  entity.SetContents(paint.WithFilters(std::move(contents)));
+  entity.SetBlendMode(new_paint.blend_mode);
+  entity.SetContents(new_paint.WithFilters(std::move(contents)));
 
   GetCurrentPass().AddEntity(entity);
 
   return true;
 }
 
-void Canvas::DrawRect(Rect rect, Paint paint) {
+void Canvas::DrawRect(Rect rect, const Paint& paint) {
   if (AttemptDrawBlurredRRect(rect, 0, paint)) {
     return;
   }
@@ -202,7 +204,7 @@ void Canvas::DrawRect(Rect rect, Paint paint) {
   GetCurrentPass().AddEntity(entity);
 }
 
-void Canvas::DrawRRect(Rect rect, Scalar corner_radius, Paint paint) {
+void Canvas::DrawRRect(Rect rect, Scalar corner_radius, const Paint& paint) {
   if (AttemptDrawBlurredRRect(rect, corner_radius, paint)) {
     return;
   }
@@ -210,6 +212,11 @@ void Canvas::DrawRRect(Rect rect, Scalar corner_radius, Paint paint) {
 }
 
 void Canvas::DrawCircle(Point center, Scalar radius, const Paint& paint) {
+  Size half_size(radius, radius);
+  if (AttemptDrawBlurredRRect(Rect(center - half_size, half_size * 2), radius,
+                              paint)) {
+    return;
+  }
   DrawPath(PathBuilder{}.AddCircle(center, radius).TakePath(), paint);
 }
 

--- a/impeller/aiks/canvas.h
+++ b/impeller/aiks/canvas.h
@@ -70,9 +70,9 @@ class Canvas {
 
   void DrawPaint(const Paint& paint);
 
-  void DrawRect(Rect rect, Paint paint);
+  void DrawRect(Rect rect, const Paint& paint);
 
-  void DrawRRect(Rect rect, Scalar corner_radius, Paint paint);
+  void DrawRRect(Rect rect, Scalar corner_radius, const Paint& paint);
 
   void DrawCircle(Point center, Scalar radius, const Paint& paint);
 
@@ -134,7 +134,7 @@ class Canvas {
 
   bool AttemptDrawBlurredRRect(const Rect& rect,
                                Scalar corner_radius,
-                               Paint& paint);
+                               const Paint& paint);
 
   FML_DISALLOW_COPY_AND_ASSIGN(Canvas);
 };

--- a/impeller/display_list/display_list_dispatcher.cc
+++ b/impeller/display_list/display_list_dispatcher.cc
@@ -973,14 +973,18 @@ void DisplayListDispatcher::drawRect(const SkRect& rect) {
 
 // |flutter::Dispatcher|
 void DisplayListDispatcher::drawOval(const SkRect& bounds) {
-  auto path = PathBuilder{}.AddOval(ToRect(bounds)).TakePath();
-  canvas_.DrawPath(path, paint_);
+  if (bounds.width() == bounds.height()) {
+    canvas_.DrawCircle(ToPoint(bounds.center()), bounds.width() * 0.5, paint_);
+  } else {
+    auto path = PathBuilder{}.AddOval(ToRect(bounds)).TakePath();
+    canvas_.DrawPath(path, paint_);
+  }
 }
 
 // |flutter::Dispatcher|
 void DisplayListDispatcher::drawCircle(const SkPoint& center, SkScalar radius) {
   auto path = PathBuilder{}.AddCircle(ToPoint(center), radius).TakePath();
-  canvas_.DrawPath(path, paint_);
+  canvas_.DrawCircle(ToPoint(center), radius, paint_);
 }
 
 // |flutter::Dispatcher|
@@ -1242,11 +1246,13 @@ void DisplayListDispatcher::drawShadow(const SkPath& path,
 
   SkRect rect;
   SkRRect rrect;
+  SkRect oval;
   if (path.isRect(&rect)) {
-    canvas_.DrawRect(ToRect(rect), std::move(paint));
+    canvas_.DrawRect(ToRect(rect), paint);
   } else if (path.isRRect(&rrect) && rrect.isSimple()) {
-    canvas_.DrawRRect(ToRect(rrect.rect()), rrect.getSimpleRadii().fX,
-                      std::move(paint));
+    canvas_.DrawRRect(ToRect(rrect.rect()), rrect.getSimpleRadii().fX, paint);
+  } else if (path.isOval(&oval) && oval.width() == oval.height()) {
+    canvas_.DrawCircle(ToPoint(oval.center()), oval.width() * 0.5, paint);
   } else {
     canvas_.DrawPath(ToPath(path), paint);
   }


### PR DESCRIPTION
Also, only copy the paint state when it needs to be modified.

Also also, I filed https://github.com/flutter/flutter/issues/114184 to document that we need to make this not apply when the paint color source isn't solid color (this feature predates color sources and geometry).

Of course, the slow blur's downsampling behavior clearly still needs some fixing up too, as can be observed below ;)

Before:
![Screen Shot 2022-10-27 at 2 10 16 PM](https://user-images.githubusercontent.com/919017/198399467-c0888fc9-7211-49ad-b523-e9f73ac4575b.png)

After:
![Screen Shot 2022-10-27 at 2 09 36 PM](https://user-images.githubusercontent.com/919017/198399476-f713eb5d-abce-4284-a9b9-8478760381aa.png)