### PR TITLE
[web] Changes to EditableState to be able to handle Framework text selection shortcuts 

### DIFF
--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -666,14 +666,18 @@ class EditingState {
       this.text,
       int? baseOffset,
       int? extentOffset,
-      this.composingBaseOffset,
-      this.composingExtentOffset
+      this.composingBaseOffset = -1,
+      this.composingExtentOffset = -1
     }) :
-    // Don't allow negative numbers. Pick the smallest selection index for base.
-    baseOffset = math.max(0, math.min(baseOffset ?? 0, extentOffset ?? 0)),
-    // Don't allow negative numbers. Pick the greatest selection index for extent.
-    extentOffset = math.max(0, math.max(baseOffset ?? 0, extentOffset ?? 0));
+        // Don't allow negative numbers.
+        baseOffset = math.max(0, baseOffset ?? 0),
+        // Don't allow negative numbers.
+        extentOffset = math.max(0, extentOffset ?? 0);
 
+  // Pick the smallest selection index for base.
+  int get minOffset => math.min(baseOffset ?? 0, extentOffset ?? 0);
+  // Pick the greatest selection index for extent.
+  int get maxOffset => math.max(baseOffset ?? 0, extentOffset ?? 0);
   /// Creates an [EditingState] instance using values from an editing state Map
   /// coming from Flutter.
   ///
@@ -707,8 +711,8 @@ class EditingState {
       text: text,
       baseOffset: selectionBase,
       extentOffset: selectionExtent,
-      composingBaseOffset: composingBase,
-      composingExtentOffset: composingExtent
+      composingBaseOffset: composingBase ?? -1,
+      composingExtentOffset: composingExtent ?? -1
     );
   }
 
@@ -773,10 +777,10 @@ class EditingState {
   final int? extentOffset;
 
   /// The offset at which [CompositionAwareMixin.composingText] begins, if any.
-  final int? composingBaseOffset;
+  final int composingBaseOffset;
 
   /// The offset at which [CompositionAwareMixin.composingText] terminates, if any.
-  final int? composingExtentOffset;
+  final int composingExtentOffset;
 
   /// Whether the current editing state is valid or not.
   bool get isValid => baseOffset! >= 0 && extentOffset! >= 0;
@@ -796,8 +800,8 @@ class EditingState {
     }
     return other is EditingState &&
         other.text == text &&
-        other.baseOffset == baseOffset &&
-        other.extentOffset == extentOffset &&
+        other.minOffset == minOffset &&
+        other.maxOffset == maxOffset &&
         other.composingBaseOffset == composingBaseOffset &&
         other.composingExtentOffset == composingExtentOffset;
   }
@@ -825,12 +829,12 @@ class EditingState {
     if (domInstanceOfString(domElement, 'HTMLInputElement')) {
       final DomHTMLInputElement element = domElement! as DomHTMLInputElement;
       element.value = text;
-      element.setSelectionRange(baseOffset!, extentOffset!);
+      element.setSelectionRange(minOffset, maxOffset);
     } else if (domInstanceOfString(domElement, 'HTMLTextAreaElement')) {
       final DomHTMLTextAreaElement element = domElement! as
           DomHTMLTextAreaElement;
       element.value = text;
-      element.setSelectionRange(baseOffset!, extentOffset!);
+      element.setSelectionRange(minOffset, maxOffset);
     } else {
       throw UnsupportedError('Unsupported DOM element type: <${domElement?.tagName}> (${domElement.runtimeType})');
     }

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -674,10 +674,6 @@ class EditingState {
         // Don't allow negative numbers.
         extentOffset = math.max(0, extentOffset ?? 0);
 
-  // Pick the smallest selection index for base.
-  int get minOffset => math.min(baseOffset ?? 0, extentOffset ?? 0);
-  // Pick the greatest selection index for extent.
-  int get maxOffset => math.max(baseOffset ?? 0, extentOffset ?? 0);
   /// Creates an [EditingState] instance using values from an editing state Map
   /// coming from Flutter.
   ///
@@ -739,6 +735,11 @@ class EditingState {
       throw UnsupportedError('Initialized with unsupported input type');
     }
   }
+
+  // Pick the smallest selection index for base.
+  int get minOffset => math.min(baseOffset ?? 0, extentOffset ?? 0);
+  // Pick the greatest selection index for extent.
+  int get maxOffset => math.max(baseOffset ?? 0, extentOffset ?? 0);
 
     EditingState copyWith({
      String? text,

--- a/lib/web_ui/test/composition_test.dart
+++ b/lib/web_ui/test/composition_test.dart
@@ -184,7 +184,7 @@ Future<void> testMain() async {
       expect(
           editingStrategy.lastEditingState,
           isA<EditingState>()
-              .having((EditingState editingState) => editingState.composingBaseOffset!,
+              .having((EditingState editingState) => editingState.composingBaseOffset,
                   'composingBaseOffset', beforeComposingText.length - composingText.length)
               .having((EditingState editingState) => editingState.composingExtentOffset,
                   'composingExtentOffset', beforeComposingText.length));

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -2242,6 +2242,7 @@ Future<void> testMain() async {
       expect(normalEditingState.minOffset, 2);
       expect(normalEditingState.maxOffset, 6);
     });
+    
     test('Configure input element from the editing state', () {
       final DomHTMLInputElement input =
           defaultTextEditingRoot.querySelector('input')! as DomHTMLInputElement;

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -2259,6 +2259,7 @@ Future<void> testMain() async {
       expect(normalEditingState.maxOffset, 6);
     });
 
+
     test('Configure input element from the editing state', () {
       final DomHTMLInputElement input =
           defaultTextEditingRoot.querySelector('input')! as DomHTMLInputElement;

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -2360,6 +2360,7 @@ Future<void> testMain() async {
         expect(editingState1 == editingState2, isTrue);
         expect(editingState1 != editingState3, isTrue);
       });
+
       test('Takes flipped base and extent offsets into account', () {
         final EditingState flippedEditingState =
             EditingState(baseOffset: 10, extentOffset: 4);

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -2231,6 +2231,22 @@ Future<void> testMain() async {
       );
     });
 
+    test('Sets default composing offsets if none given', () {
+      final EditingState editingState =
+          EditingState(text: 'Test', baseOffset: 2, extentOffset: 4);
+      final EditingState editingStateFromFrameworkMsg =
+          EditingState.fromFrameworkMessage(<String, dynamic>{
+        'selectionBase': 10,
+        'selectionExtent': 4,
+      });
+
+      expect(editingState.composingBaseOffset, -1);
+      expect(editingState.composingExtentOffset, -1);
+
+      expect(editingStateFromFrameworkMsg.composingBaseOffset, -1);
+      expect(editingStateFromFrameworkMsg.composingExtentOffset, -1);
+    });
+
     test('Correctly identifies min and max offsets', () {
       final EditingState flippedEditingState =
           EditingState(baseOffset: 10, extentOffset: 4);

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -2259,7 +2259,6 @@ Future<void> testMain() async {
       expect(normalEditingState.maxOffset, 6);
     });
 
-
     test('Configure input element from the editing state', () {
       final DomHTMLInputElement input =
           defaultTextEditingRoot.querySelector('input')! as DomHTMLInputElement;

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -1557,8 +1557,8 @@ Future<void> testMain() async {
             'text': 'something',
             'selectionBase': 9,
             'selectionExtent': 9,
-            'composingBase': null,
-            'composingExtent': null
+            'composingBase': -1,
+            'composingExtent': -1
           }
         ],
       );
@@ -1583,8 +1583,8 @@ Future<void> testMain() async {
             'text': 'something',
             'selectionBase': 2,
             'selectionExtent': 5,
-            'composingBase': null,
-            'composingExtent': null
+            'composingBase': -1,
+            'composingExtent': -1
           }
         ],
       );
@@ -1641,8 +1641,8 @@ Future<void> testMain() async {
                 'deltaEnd': -1,
                 'selectionBase': 2,
                 'selectionExtent': 5,
-                'composingBase': null,
-                'composingExtent': null
+                'composingBase': -1,
+                'composingExtent': -1
               }
             ],
           }
@@ -1724,8 +1724,8 @@ Future<void> testMain() async {
               'text': 'something',
               'selectionBase': 9,
               'selectionExtent': 9,
-              'composingBase': null,
-              'composingExtent': null
+              'composingBase': -1,
+              'composingExtent': -1
             }
           },
         ],
@@ -1796,8 +1796,8 @@ Future<void> testMain() async {
             'text': 'something\nelse',
             'selectionBase': 14,
             'selectionExtent': 14,
-            'composingBase': null,
-            'composingExtent': null
+            'composingBase': -1,
+            'composingExtent': -1
           }
         ],
       );
@@ -1812,8 +1812,8 @@ Future<void> testMain() async {
             'text': 'something\nelse',
             'selectionBase': 2,
             'selectionExtent': 5,
-            'composingBase': null,
-            'composingExtent': null
+            'composingBase': -1,
+            'composingExtent': -1
           }
         ],
       );
@@ -2231,6 +2231,17 @@ Future<void> testMain() async {
       );
     });
 
+    test('Correctly identifies min and max offsets', () {
+      final EditingState flippedEditingState =
+          EditingState(baseOffset: 10, extentOffset: 4);
+      final EditingState normalEditingState =
+          EditingState(baseOffset: 2, extentOffset: 6);
+
+      expect(flippedEditingState.minOffset, 4);
+      expect(flippedEditingState.maxOffset, 10);
+      expect(normalEditingState.minOffset, 2);
+      expect(normalEditingState.maxOffset, 6);
+    });
     test('Configure input element from the editing state', () {
       final DomHTMLInputElement input =
           defaultTextEditingRoot.querySelector('input')! as DomHTMLInputElement;
@@ -2262,6 +2273,20 @@ Future<void> testMain() async {
       expect(textArea.value, 'Test');
       expect(textArea.selectionStart, 1);
       expect(textArea.selectionEnd, 2);
+    });
+
+    test('Configure input element editing state for a flipped base and extent',
+        () {
+      final DomHTMLInputElement input =
+          defaultTextEditingRoot.querySelector('input')! as DomHTMLInputElement;
+      editingState =
+          EditingState(text: 'Hello World', baseOffset: 10, extentOffset: 2);
+
+      editingState.applyToDomElement(input);
+
+      expect(input.value, 'Hello World');
+      expect(input.selectionStart, 2);
+      expect(input.selectionEnd, 10);
     });
 
     test('Get Editing State from input element', () {
@@ -2316,6 +2341,16 @@ Future<void> testMain() async {
 
         expect(editingState1 == editingState2, isTrue);
         expect(editingState1 != editingState3, isTrue);
+      });
+      test('Takes flipped base and extent offsets into account', () {
+        final EditingState flippedEditingState =
+            EditingState(baseOffset: 10, extentOffset: 4);
+        final EditingState normalEditingState =
+            EditingState(baseOffset: 4, extentOffset: 10);
+
+        expect(normalEditingState, flippedEditingState);
+
+        expect(normalEditingState == flippedEditingState, isTrue);
       });
 
       test('takes composition range into account', () {

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -2242,7 +2242,7 @@ Future<void> testMain() async {
       expect(normalEditingState.minOffset, 2);
       expect(normalEditingState.maxOffset, 6);
     });
-    
+
     test('Configure input element from the editing state', () {
       final DomHTMLInputElement input =
           defaultTextEditingRoot.querySelector('input')! as DomHTMLInputElement;


### PR DESCRIPTION
Currently there's an issue in which keyboard shortcuts (shift + arrow keys) don't autoscroll on web inputs and textfields. Delegating these keyboard actions to the framework fixes this issue and allows for a more consistent UX for web. 

As part of that change, the `EditableState` class needs to be able to handle flipped base and extent offsets, as well as have sensible defaults for composing offsets.

Part 1 of fix for https://github.com/flutter/flutter/issues/107707

Framework changes PR: https://github.com/flutter/flutter/pull/114264


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.