### PR TITLE
Remove usages of deprecated old `native "<name>"` syntax.

### DIFF
--- a/lib/ui/fixtures/ui_test.dart
+++ b/lib/ui/fixtures/ui_test.dart
@@ -12,7 +12,8 @@ void main() {}
 
 /// Mutiple tests use this to signal to the C++ side that they are ready for
 /// validation.
-void _finish() native 'Finish';
+@pragma('vm:external-name', 'Finish')
+external void _finish();
 
 @pragma('vm:entry-point')
 void customOnErrorTrue() {
@@ -58,10 +59,15 @@ void validateSceneBuilderAndScene() {
   scene.dispose();
   _validateSceneHasNoLayers();
 }
-_validateBuilderHasLayers(SceneBuilder builder) native 'ValidateBuilderHasLayers';
-_validateBuilderHasNoLayers() native 'ValidateBuilderHasNoLayers';
-_captureScene(Scene scene) native 'CaptureScene';
-_validateSceneHasNoLayers() native 'ValidateSceneHasNoLayers';
+
+@pragma('vm:external-name', 'ValidateBuilderHasLayers')
+external _validateBuilderHasLayers(SceneBuilder builder);
+@pragma('vm:external-name', 'ValidateBuilderHasNoLayers')
+external _validateBuilderHasNoLayers();
+@pragma('vm:external-name', 'CaptureScene')
+external _captureScene(Scene scene);
+@pragma('vm:external-name', 'ValidateSceneHasNoLayers')
+external _validateSceneHasNoLayers();
 
 @pragma('vm:entry-point')
 void validateEngineLayerDispose() {
@@ -74,9 +80,13 @@ void validateEngineLayerDispose() {
   layer.dispose();
   _validateEngineLayerDispose();
 }
-_captureRootLayer(SceneBuilder sceneBuilder) native 'CaptureRootLayer';
-_validateLayerTreeCounts() native 'ValidateLayerTreeCounts';
-_validateEngineLayerDispose() native 'ValidateEngineLayerDispose';
+
+@pragma('vm:external-name', 'CaptureRootLayer')
+external _captureRootLayer(SceneBuilder sceneBuilder);
+@pragma('vm:external-name', 'ValidateLayerTreeCounts')
+external _validateLayerTreeCounts();
+@pragma('vm:external-name', 'ValidateEngineLayerDispose')
+external _validateEngineLayerDispose();
 
 @pragma('vm:entry-point')
 Future<void> createSingleFrameCodec() async {
@@ -98,7 +108,9 @@ Future<void> createSingleFrameCodec() async {
   assert(buffer.debugDisposed);
   _finish();
 }
-void _validateCodec(Codec codec) native 'ValidateCodec';
+
+@pragma('vm:external-name', 'ValidateCodec')
+external void _validateCodec(Codec codec);
 
 @pragma('vm:entry-point')
 void createVertices() {
@@ -126,7 +138,9 @@ void createVertices() {
   );
   _validateVertices(vertices);
 }
-void _validateVertices(Vertices vertices) native 'ValidateVertices';
+
+@pragma('vm:external-name', 'ValidateVertices')
+external void _validateVertices(Vertices vertices);
 
 @pragma('vm:entry-point')
 void sendSemanticsUpdate() {
@@ -212,12 +226,12 @@ void sendSemanticsUpdate() {
     transform: transform,
     childrenInTraversalOrder: childrenInTraversalOrder,
     childrenInHitTestOrder: childrenInHitTestOrder,
-    additionalActions: additionalActions
-  );
+    additionalActions: additionalActions);
   _semanticsUpdate(builder.build());
 }
 
-void _semanticsUpdate(SemanticsUpdate update) native 'SemanticsUpdate';
+@pragma('vm:external-name', 'SemanticsUpdate')
+external void _semanticsUpdate(SemanticsUpdate update);
 
 @pragma('vm:entry-point')
 void createPath() {
@@ -229,7 +243,9 @@ void createPath() {
     path.lineTo(100, 100);
   });
 }
-void _validatePath(Path path) native 'ValidatePath';
+
+@pragma('vm:external-name', 'ValidatePath')
+external void _validatePath(Path path);
 
 @pragma('vm:entry-point')
 void frameCallback(_Image, int) {
@@ -263,16 +279,19 @@ void platformMessageResponseTest() {
   });
 }
 
-void _callPlatformMessageResponseDartPort(int port) native 'CallPlatformMessageResponseDartPort';
-void _callPlatformMessageResponseDart(void Function(ByteData? result) callback) native 'CallPlatformMessageResponseDart';
-void _finishCallResponse(bool didPass) native 'FinishCallResponse';
+@pragma('vm:external-name', 'CallPlatformMessageResponseDartPort')
+external void _callPlatformMessageResponseDartPort(int port);
+@pragma('vm:external-name', 'CallPlatformMessageResponseDart')
+external void _callPlatformMessageResponseDart(void Function(ByteData? result) callback);
+@pragma('vm:external-name', 'FinishCallResponse')
+external void _finishCallResponse(bool didPass);
 
 @pragma('vm:entry-point')
 void messageCallback(dynamic data) {}
 
 @pragma('vm:entry-point')
-void validateConfiguration() native 'ValidateConfiguration';
-
+@pragma('vm:external-name', 'ValidateConfiguration')
+external void validateConfiguration();
 
 // Draw a circle on a Canvas that has a PictureRecorder. Take the image from
 // the PictureRecorder, and encode it as png. Check that the png data is
@@ -295,9 +314,11 @@ Future<void> encodeImageProducesExternalUint8List() async {
     _validateExternal(result);
   });
 }
-void _encodeImage(Image i, int format, void Function(Uint8List result))
-  native 'EncodeImage';
-void _validateExternal(Uint8List result) native 'ValidateExternal';
+
+@pragma('vm:external-name', 'EncodeImage')
+external void _encodeImage(Image i, int format, void Function(Uint8List result));
+@pragma('vm:external-name', 'ValidateExternal')
+external void _validateExternal(Uint8List result);
 
 @pragma('vm:entry-point')
 Future<void> pumpImage() async {
@@ -358,7 +379,9 @@ Future<void> pumpImage() async {
   window.onBeginFrame = renderImage;
   window.scheduleFrame();
 }
-void _captureImageAndPicture(Image image, Picture picture) native 'CaptureImageAndPicture';
+
+@pragma('vm:external-name', 'CaptureImageAndPicture')
+external void _captureImageAndPicture(Image image, Picture picture);
 
 @pragma('vm:entry-point')
 void convertPaintToDlPaint() {
@@ -370,7 +393,8 @@ void convertPaintToDlPaint() {
   paint.style = PaintingStyle.stroke;
   _convertPaintToDlPaint(paint);
 }
-void _convertPaintToDlPaint(Paint paint) native 'ConvertPaintToDlPaint';
+@pragma('vm:external-name',  'ConvertPaintToDlPaint')
+external void _convertPaintToDlPaint(Paint paint);
 
 @pragma('vm:entry-point')
 void hooksTests() async {
@@ -992,7 +1016,8 @@ Future<T> _futurize<T>(_Callbacker<T> callbacker) {
   return completer.future;
 }
 
-void _callHook(
+@pragma('vm:external-name', 'CallHook')
+external void _callHook(
   String name, [
   int argCount = 0,
   Object? arg0,
@@ -1015,4 +1040,4 @@ void _callHook(
   Object? arg18,
   Object? arg19,
   Object? arg20,
-]) native 'CallHook';
+]);

--- a/runtime/fixtures/dart_tool/flutter_build/dart_plugin_registrant.dart
+++ b/runtime/fixtures/dart_tool/flutter_build/dart_plugin_registrant.dart
@@ -6,7 +6,8 @@ import 'dart:isolate';
 import 'dart:ui';
 import 'dart:io' show Platform;
 
-void passMessage(String message) native 'PassMessage';
+@pragma('vm:external-name', 'PassMessage')
+external void passMessage(String message);
 
 bool didCallRegistrantBeforeEntrypoint = false;
 

--- a/runtime/fixtures/no_dart_plugin_registrant_test.dart
+++ b/runtime/fixtures/no_dart_plugin_registrant_test.dart
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-void passMessage(String message) native 'PassMessage';
+@pragma('vm:external-name', 'PassMessage')
+external void passMessage(String message);
 
 void main() {
   passMessage('main() was called');

--- a/runtime/fixtures/runtime_test.dart
+++ b/runtime/fixtures/runtime_test.dart
@@ -44,13 +44,16 @@ void canCallDeferredLibrary() {
   notifyNative();
 }
 
-void notifyNative() native 'NotifyNative';
+@pragma('vm:external-name', 'NotifyNative')
+external void notifyNative();
 
 @pragma('vm:entry-point')
 void testIsolateShutdown() {  }
 
-void notifyResult(bool success) native 'NotifyNative';
-void passMessage(String message) native 'PassMessage';
+@pragma('vm:external-name', 'NotifyNative')
+external void notifyResult(bool success);
+@pragma('vm:external-name', 'PassMessage')
+external void passMessage(String message);
 
 void secondaryIsolateMain(String message) {
   print('Secondary isolate got message: ' + message);
@@ -112,7 +115,8 @@ void testIsolateStartupFailure() async {
   // test in an isolate.
   Isolate.spawn(mainTest, null);
 }
-void makeNextIsolateSpawnFail() native 'MakeNextIsolateSpawnFail';
+@pragma('vm:external-name', 'MakeNextIsolateSpawnFail')
+external void makeNextIsolateSpawnFail();
 
 @pragma('vm:entry-point')
 void testCanReceiveArguments(List<String> args) {
@@ -124,7 +128,8 @@ void trampoline() {
   notifyNative();
 }
 
-void notifySuccess(bool success) native 'NotifySuccess';
+@pragma('vm:external-name', 'NotifySuccess')
+external void notifySuccess(bool success);
 
 @pragma('vm:entry-point')
 void testCanConvertEmptyList(List<int> args){

--- a/shell/common/fixtures/shell_test.dart
+++ b/shell/common/fixtures/shell_test.dart
@@ -9,9 +9,12 @@ import 'dart:ui';
 
 void main() {}
 
-void nativeReportTimingsCallback(List<int> timings) native 'NativeReportTimingsCallback';
-void nativeOnBeginFrame(int microseconds) native 'NativeOnBeginFrame';
-void nativeOnPointerDataPacket(List<int> sequences) native 'NativeOnPointerDataPacket';
+@pragma('vm:external-name', 'NativeReportTimingsCallback')
+external void nativeReportTimingsCallback(List<int> timings);
+@pragma('vm:external-name', 'NativeOnBeginFrame')
+external void nativeOnBeginFrame(int microseconds);
+@pragma('vm:external-name', 'NativeOnPointerDataPacket')
+external void nativeOnPointerDataPacket(List<int> sequences);
 
 @pragma('vm:entry-point')
 void onErrorA() {
@@ -33,8 +36,10 @@ void onErrorB() {
   throw Exception('I should be coming from B');
 }
 
-void notifyErrorA(String message) native 'NotifyErrorA';
-void notifyErrorB(String message) native 'NotifyErrorB';
+@pragma('vm:external-name', 'NotifyErrorA')
+external void notifyErrorA(String message);
+@pragma('vm:external-name', 'NotifyErrorB')
+external void notifyErrorB(String message);
 
 @pragma('vm:entry-point')
 void drawFrames() {
@@ -105,7 +110,8 @@ void reportMetrics() {
   };
 }
 
-void _reportMetrics(double devicePixelRatio, double width, double height) native 'ReportMetrics';
+@pragma('vm:external-name', 'ReportMetrics')
+external void _reportMetrics(double devicePixelRatio, double width, double height);
 
 @pragma('vm:entry-point')
 void dummyReportTimingsMain() {
@@ -117,10 +123,12 @@ void fixturesAreFunctionalMain() {
   sayHiFromFixturesAreFunctionalMain();
 }
 
-void sayHiFromFixturesAreFunctionalMain() native 'SayHiFromFixturesAreFunctionalMain';
+@pragma('vm:external-name', 'SayHiFromFixturesAreFunctionalMain')
+external void sayHiFromFixturesAreFunctionalMain();
 
 @pragma('vm:entry-point')
-void notifyNative() native 'NotifyNative';
+@pragma('vm:external-name', 'NotifyNative')
+external void notifyNative();
 
 @pragma('vm:entry-point')
 void thousandCallsToNative() {
@@ -164,7 +172,8 @@ void testSkiaResourceCacheSendsResponse() {
   );
 }
 
-void notifyWidthHeight(int width, int height) native 'NotifyWidthHeight';
+@pragma('vm:external-name', 'NotifyWidthHeight')
+external void notifyWidthHeight(int width, int height);
 
 @pragma('vm:entry-point')
 void canCreateImageFromDecompressedData() {
@@ -195,15 +204,18 @@ void canAccessIsolateLaunchData() {
   );
 }
 
-void notifyMessage(String string) native 'NotifyMessage';
+@pragma('vm:external-name', 'NotifyMessage')
+external void notifyMessage(String string);
 
 @pragma('vm:entry-point')
 void canConvertMappings() {
   sendFixtureMapping(getFixtureMapping());
 }
 
-List<int> getFixtureMapping() native 'GetFixtureMapping';
-void sendFixtureMapping(List<int> list) native 'SendFixtureMapping';
+@pragma('vm:external-name', 'GetFixtureMapping')
+external List<int> getFixtureMapping();
+@pragma('vm:external-name', 'SendFixtureMapping')
+external void sendFixtureMapping(List<int> list);
 
 @pragma('vm:entry-point')
 void canDecompressImageFromAsset() {
@@ -215,7 +227,8 @@ void canDecompressImageFromAsset() {
   );
 }
 
-List<int> getFixtureImage() native 'GetFixtureImage';
+@pragma('vm:external-name', 'GetFixtureImage')
+external List<int> getFixtureImage();
 
 @pragma('vm:entry-point')
 void canRegisterImageDecoders() {
@@ -228,9 +241,11 @@ void canRegisterImageDecoders() {
   );
 }
 
-void notifyLocalTime(String string) native 'NotifyLocalTime';
+@pragma('vm:external-name', 'NotifyLocalTime')
+external void notifyLocalTime(String string);
 
-bool waitFixture() native 'WaitFixture';
+@pragma('vm:external-name', 'WaitFixture')
+external bool waitFixture();
 
 // Return local date-time as a string, to an hour resolution.  So, "2020-07-23
 // 14:03:22" will become "2020-07-23 14".
@@ -255,9 +270,11 @@ void timezonesChange() {
   } while (waitFixture());
 }
 
-void notifyCanAccessResource(bool success) native 'NotifyCanAccessResource';
+@pragma('vm:external-name', 'NotifyCanAccessResource')
+external void notifyCanAccessResource(bool success);
 
-void notifySetAssetBundlePath() native 'NotifySetAssetBundlePath';
+@pragma('vm:external-name', 'NotifySetAssetBundlePath')
+external void notifySetAssetBundlePath();
 
 @pragma('vm:entry-point')
 void canAccessResourceFromAssetDir() async {
@@ -271,9 +288,11 @@ void canAccessResourceFromAssetDir() async {
   );
 }
 
-void notifyNativeWhenEngineRun(bool success) native 'NotifyNativeWhenEngineRun';
+@pragma('vm:external-name', 'NotifyNativeWhenEngineRun')
+external void notifyNativeWhenEngineRun(bool success);
 
-void notifyNativeWhenEngineSpawn(bool success) native 'NotifyNativeWhenEngineSpawn';
+@pragma('vm:external-name', 'NotifyNativeWhenEngineSpawn')
+external void notifyNativeWhenEngineSpawn(bool success);
 
 @pragma('vm:entry-point')
 void canReceiveArgumentsWhenEngineRun(List<String> args) {
@@ -395,7 +414,8 @@ Future<void> runCallback(IsolateParam param) async {
 }
 
 @pragma('vm:entry-point')
-void notifyNativeBool(bool value) native 'NotifyNativeBool';
+@pragma('vm:external-name', 'NotifyNativeBool')
+external void notifyNativeBool(bool value);
 
 @pragma('vm:entry-point')
 Future<void> testPluginUtilitiesCallbackHandle() async {

--- a/shell/platform/darwin/macos/framework/Source/fixtures/flutter_desktop_test.dart
+++ b/shell/platform/darwin/macos/framework/Source/fixtures/flutter_desktop_test.dart
@@ -5,7 +5,8 @@
 import 'dart:io';
 import 'dart:ui';
 
-void signalNativeTest() native 'SignalNativeTest';
+@pragma('vm:external-name', 'SignalNativeTest')
+external void signalNativeTest();
 
 void main() {
 }
@@ -14,7 +15,8 @@ void main() {
 ///
 /// This is used to notify the native side of the test of a string value from
 /// the Dart fixture under test.
-void notifyStringValue(String s) native 'NotifyStringValue';
+@pragma('vm:external-name', 'NotifyStringValue')
+external void notifyStringValue(String s);
 
 @pragma('vm:entry-point')
 void executableNameNotNull() {

--- a/shell/platform/embedder/fixtures/main.dart
+++ b/shell/platform/embedder/fixtures/main.dart
@@ -18,7 +18,8 @@ void customEntrypoint() {
   sayHiFromCustomEntrypoint();
 }
 
-void sayHiFromCustomEntrypoint() native 'SayHiFromCustomEntrypoint';
+@pragma('vm:external-name', 'SayHiFromCustomEntrypoint')
+external void sayHiFromCustomEntrypoint();
 
 @pragma('vm:entry-point')
 void customEntrypoint1() {
@@ -27,9 +28,12 @@ void customEntrypoint1() {
   sayHiFromCustomEntrypoint3();
 }
 
-void sayHiFromCustomEntrypoint1() native 'SayHiFromCustomEntrypoint1';
-void sayHiFromCustomEntrypoint2() native 'SayHiFromCustomEntrypoint2';
-void sayHiFromCustomEntrypoint3() native 'SayHiFromCustomEntrypoint3';
+@pragma('vm:external-name', 'SayHiFromCustomEntrypoint1')
+external void sayHiFromCustomEntrypoint1();
+@pragma('vm:external-name', 'SayHiFromCustomEntrypoint2')
+external void sayHiFromCustomEntrypoint2();
+@pragma('vm:external-name', 'SayHiFromCustomEntrypoint3')
+external void sayHiFromCustomEntrypoint3();
 
 @pragma('vm:entry-point')
 void terminateExitCodeHandler() {
@@ -41,8 +45,8 @@ void executableNameNotNull() {
   notifyStringValue(Platform.executable);
 }
 
-void notifyStringValue(String value) native 'NotifyStringValue';
-
+@pragma('vm:external-name', 'NotifyStringValue')
+external void notifyStringValue(String value);
 
 @pragma('vm:entry-point')
 void invokePlatformTaskRunner() {
@@ -63,14 +67,18 @@ Float64List kTestTransform = () {
   return values;
 }();
 
-void signalNativeTest() native 'SignalNativeTest';
-void signalNativeCount(int count) native 'SignalNativeCount';
-void signalNativeMessage(String message) native 'SignalNativeMessage';
-void notifySemanticsEnabled(bool enabled) native 'NotifySemanticsEnabled';
-void notifyAccessibilityFeatures(bool reduceMotion)
-    native 'NotifyAccessibilityFeatures';
-void notifySemanticsAction(int nodeId, int action, List<int> data)
-    native 'NotifySemanticsAction';
+@pragma('vm:external-name', 'SignalNativeTest')
+external void signalNativeTest();
+@pragma('vm:external-name', 'SignalNativeCount')
+external void signalNativeCount(int count);
+@pragma('vm:external-name', 'SignalNativeMessage')
+external void signalNativeMessage(String message);
+@pragma('vm:external-name', 'NotifySemanticsEnabled')
+external void notifySemanticsEnabled(bool enabled);
+@pragma('vm:external-name', 'NotifyAccessibilityFeatures')
+external void notifyAccessibilityFeatures(bool reduceMotion);
+@pragma('vm:external-name', 'NotifySemanticsAction')
+external void notifySemanticsAction(int nodeId, int action, List<int> data);
 
 /// Returns a future that completes when
 /// `PlatformDispatcher.instance.onSemanticsEnabledChanged` fires.
@@ -555,8 +563,9 @@ Picture CreateGradientBox(Size size) {
   return baseRecorder.endRecording();
 }
 
-void _echoKeyEvent(int change, int timestamp, int physical, int logical,
-    int charCode, bool synthesized) native 'EchoKeyEvent';
+@pragma('vm:external-name', 'EchoKeyEvent')
+external void _echoKeyEvent(int change, int timestamp, int physical,
+    int logical, int charCode, bool synthesized);
 
 // Convert `kind` in enum form to its integer form.
 //
@@ -925,7 +934,8 @@ void scene_builder_with_complex_clips() {
   PlatformDispatcher.instance.scheduleFrame();
 }
 
-void sendObjectToNativeCode(dynamic object) native 'SendObjectToNativeCode';
+@pragma('vm:external-name', 'SendObjectToNativeCode')
+external void sendObjectToNativeCode(dynamic object);
 
 @pragma('vm:entry-point')
 void objects_can_be_posted() {
@@ -977,8 +987,8 @@ void render_targets_are_recycled() {
   PlatformDispatcher.instance.scheduleFrame();
 }
 
-void nativeArgumentsCallback(List<String> args)
-    native 'NativeArgumentsCallback';
+@pragma('vm:external-name', 'NativeArgumentsCallback')
+external void nativeArgumentsCallback(List<String> args);
 
 @pragma('vm:entry-point')
 void custom_logger(List<String> args) {
@@ -990,8 +1000,8 @@ void dart_entrypoint_args(List<String> args) {
   nativeArgumentsCallback(args);
 }
 
-void snapshotsCallback(Image big_image, Image small_image)
-    native 'SnapshotsCallback';
+@pragma('vm:external-name', 'SnapshotsCallback')
+external void snapshotsCallback(Image big_image, Image small_image);
 
 @pragma('vm:entry-point')
 void snapshot_large_scene(int max_size) async {

--- a/shell/platform/fuchsia/dart-pkg/fuchsia/lib/fuchsia.dart
+++ b/shell/platform/fuchsia/dart-pkg/fuchsia/lib/fuchsia.dart
@@ -59,7 +59,8 @@ class MxStartupInfo {
   }
 }
 
-void _setReturnCode(int returnCode) native 'SetReturnCode';
+@pragma('vm:external-name', 'SetReturnCode')
+external void _setReturnCode(int returnCode);
 
 void exit(int returnCode) {
   _setReturnCode(returnCode);

--- a/shell/platform/fuchsia/dart-pkg/zircon/lib/src/handle.dart
+++ b/shell/platform/fuchsia/dart-pkg/zircon/lib/src/handle.dart
@@ -17,33 +17,40 @@ class Handle extends NativeFieldWrapperClass1 {
   factory Handle.invalid() {
     return _createInvalid();
   }
-  static Handle _createInvalid() native 'Handle_CreateInvalid';
+  @pragma('vm:external-name', 'Handle_CreateInvalid')
+  external static Handle _createInvalid();
 
-  int get handle native 'Handle_handle';
+  @pragma('vm:external-name', 'Handle_handle')
+  external int get handle;
 
-  int get koid native 'Handle_koid';
+  @pragma('vm:external-name', 'Handle_koid')
+  external int get koid;
 
   @override
   String toString() => 'Handle($handle)';
 
   @override
   bool operator ==(Object other) {
-    return other is Handle
-        && other.handle == handle;
+    return other is Handle &&
+        other.handle == handle;
   }
 
   @override
   int get hashCode => handle.hashCode;
 
   // Common handle operations.
-  bool get isValid native 'Handle_is_valid';
-  int close() native 'Handle_Close';
-  HandleWaiter asyncWait(int signals, AsyncWaitCallback callback)
-      native 'Handle_AsyncWait';
+  @pragma('vm:external-name', 'Handle_is_valid')
+  external bool get isValid;
+  @pragma('vm:external-name', 'Handle_Close')
+  external int close();
+  @pragma('vm:external-name', 'Handle_AsyncWait')
+  external HandleWaiter asyncWait(int signals, AsyncWaitCallback callback);
 
-  Handle duplicate(int rights) native 'Handle_Duplicate';
+  @pragma('vm:external-name', 'Handle_Duplicate')
+  external Handle duplicate(int rights);
 
-  Handle replace(int rights) native 'Handle_Replace';
+  @pragma('vm:external-name', 'Handle_Replace')
+  external Handle replace(int rights);
 }
 
 @pragma('vm:entry-point')

--- a/shell/platform/fuchsia/dart-pkg/zircon/lib/src/handle.dart
+++ b/shell/platform/fuchsia/dart-pkg/zircon/lib/src/handle.dart
@@ -31,8 +31,8 @@ class Handle extends NativeFieldWrapperClass1 {
 
   @override
   bool operator ==(Object other) {
-    return other is Handle &&
-        other.handle == handle;
+    return other is Handle
+        && other.handle == handle;
   }
 
   @override

--- a/shell/platform/fuchsia/dart-pkg/zircon/lib/src/handle_disposition.dart
+++ b/shell/platform/fuchsia/dart-pkg/zircon/lib/src/handle_disposition.dart
@@ -14,14 +14,19 @@ class HandleDisposition extends NativeFieldWrapperClass1 {
     _constructor(operation, handle, type, rights);
   }
 
-  void _constructor(int operation, Handle handle, int type, int rights)
-      native 'HandleDisposition_constructor';
+  @pragma('vm:external-name', 'HandleDisposition_constructor')
+  external void _constructor(int operation, Handle handle, int type, int rights);
 
-  int get operation native 'HandleDisposition_operation';
-  Handle get handle native 'HandleDisposition_handle';
-  int get type native 'HandleDisposition_type';
-  int get rights native 'HandleDisposition_rights';
-  int get result native 'HandleDisposition_result';
+  @pragma('vm:external-name', 'HandleDisposition_operation')
+  external int get operation;
+  @pragma('vm:external-name', 'HandleDisposition_handle')
+  external Handle get handle;
+  @pragma('vm:external-name', 'HandleDisposition_type')
+  external int get type;
+  @pragma('vm:external-name', 'HandleDisposition_rights')
+  external int get rights;
+  @pragma('vm:external-name', 'HandleDisposition_result')
+  external int get result;
 
   @override
   String toString() =>

--- a/shell/platform/fuchsia/dart-pkg/zircon/lib/src/handle_waiter.dart
+++ b/shell/platform/fuchsia/dart-pkg/zircon/lib/src/handle_waiter.dart
@@ -15,5 +15,6 @@ class HandleWaiter extends NativeFieldWrapperClass1 {
   @pragma('vm:entry-point')
   HandleWaiter._();
 
-  void cancel() native 'HandleWaiter_Cancel';
+  @pragma('vm:external-name', 'HandleWaiter_Cancel')
+  external void cancel();
 }

--- a/shell/platform/fuchsia/dart-pkg/zircon/lib/src/system.dart
+++ b/shell/platform/fuchsia/dart-pkg/zircon/lib/src/system.dart
@@ -196,44 +196,48 @@ class System extends NativeFieldWrapperClass1 {
   System._();
 
   // Channel operations.
-  static HandlePairResult channelCreate([int options = 0])
-      native 'System_ChannelCreate';
-  static HandleResult channelFromFile(String path)
-      native 'System_ChannelFromFile';
-  static int connectToService(String path, Handle channel)
-    native 'System_ConnectToService';
-  static int channelWrite(Handle channel, ByteData data, List<Handle> handles)
-      native 'System_ChannelWrite';
-  static int channelWriteEtc(Handle channel, ByteData data, List<HandleDisposition> handleDispositions)
-      native 'System_ChannelWriteEtc';
-  static ReadResult channelQueryAndRead(Handle channel)
-      native 'System_ChannelQueryAndRead';
-  static ReadEtcResult channelQueryAndReadEtc(Handle channel)
-      native 'System_ChannelQueryAndReadEtc';
+  @pragma('vm:external-name', 'System_ChannelCreate')
+  external static HandlePairResult channelCreate([int options = 0]);
+  @pragma('vm:external-name', 'System_ChannelFromFile')
+  external static HandleResult channelFromFile(String path);
+  @pragma('vm:external-name', 'System_ConnectToService')
+  external static int connectToService(String path, Handle channel);
+  @pragma('vm:external-name', 'System_ChannelWrite')
+  external static int channelWrite(Handle channel, ByteData data, List<Handle> handles);
+  @pragma('vm:external-name', 'System_ChannelWriteEtc')
+  external static int channelWriteEtc(Handle channel, ByteData data, List<HandleDisposition> handleDispositions);
+  @pragma('vm:external-name', 'System_ChannelQueryAndRead')
+  external static ReadResult channelQueryAndRead(Handle channel);
+  @pragma('vm:external-name', 'System_ChannelQueryAndReadEtc')
+  external static ReadEtcResult channelQueryAndReadEtc(Handle channel);
 
   // Eventpair operations.
-  static HandlePairResult eventpairCreate([int options = 0])
-      native 'System_EventpairCreate';
+  @pragma('vm:external-name', 'System_EventpairCreate')
+  external static HandlePairResult eventpairCreate([int options = 0]);
 
   // Socket operations.
-  static HandlePairResult socketCreate([int options = 0])
-      native 'System_SocketCreate';
-  static WriteResult socketWrite(Handle socket, ByteData data, int options)
-      native 'System_SocketWrite';
-  static ReadResult socketRead(Handle socket, int size)
-      native 'System_SocketRead';
+  @pragma('vm:external-name', 'System_SocketCreate')
+  external static HandlePairResult socketCreate([int options = 0]);
+  @pragma('vm:external-name', 'System_SocketWrite')
+  external static WriteResult socketWrite(Handle socket, ByteData data, int options);
+  @pragma('vm:external-name', 'System_SocketRead')
+  external static ReadResult socketRead(Handle socket, int size);
 
   // Vmo operations.
-  static HandleResult vmoCreate(int size, [int options = 0])
-      native 'System_VmoCreate';
-  static FromFileResult vmoFromFile(String path) native 'System_VmoFromFile';
-  static GetSizeResult vmoGetSize(Handle vmo) native 'System_VmoGetSize';
-  static int vmoSetSize(Handle vmo, int size) native 'System_VmoSetSize';
-  static int vmoWrite(Handle vmo, int offset, ByteData bytes)
-      native 'System_VmoWrite';
-  static ReadResult vmoRead(Handle vmo, int offset, int size)
-      native 'System_VmoRead';
-  static MapResult vmoMap(Handle vmo) native 'System_VmoMap';
+  @pragma('vm:external-name', 'System_VmoCreate')
+  external static HandleResult vmoCreate(int size, [int options = 0]);
+  @pragma('vm:external-name', 'System_VmoFromFile')
+  external static FromFileResult vmoFromFile(String path);
+  @pragma('vm:external-name', 'System_VmoGetSize')
+  external static GetSizeResult vmoGetSize(Handle vmo);
+  @pragma('vm:external-name', 'System_VmoSetSize')
+  external static int vmoSetSize(Handle vmo, int size);
+  @pragma('vm:external-name', 'System_VmoWrite')
+  external static int vmoWrite(Handle vmo, int offset, ByteData bytes);
+  @pragma('vm:external-name', 'System_VmoRead')
+  external static ReadResult vmoRead(Handle vmo, int offset, int size);
+  @pragma('vm:external-name', 'System_VmoMap')
+  external static MapResult vmoMap(Handle vmo);
 
   // Time operations.
   static int clockGetMonotonic() {
@@ -244,7 +248,8 @@ class System extends NativeFieldWrapperClass1 {
     }
   }
 
-  static int _nativeClockGetMonotonic() native 'System_ClockGetMonotonic';
+  @pragma('vm:external-name', 'System_ClockGetMonotonic')
+  external static int _nativeClockGetMonotonic();
 
   // TODO(edcoyne): Remove this, it is required to safely do an API transition across repos.
   static int reboot() { return -2; /*ZX_ERR_NOT_SUPPORTED*/ }

--- a/shell/platform/fuchsia/dart_runner/embedder/builtin.dart
+++ b/shell/platform/fuchsia/dart_runner/embedder/builtin.dart
@@ -20,7 +20,8 @@ void _print(arg) {
 }
 
 class _Logger {
-  static void _printString(String s) native "Logger_PrintString";
+  @pragma('vm:external-name', 'Logger_PrintString')
+  external static void _printString(String s);
 }
 
 @pragma('vm:entry-point')
@@ -36,7 +37,8 @@ Uri _scriptUri() {
   }
 }
 
-void _scheduleMicrotask(void callback()) native "ScheduleMicrotask";
+@pragma('vm:external-name', 'ScheduleMicrotask')
+external void _scheduleMicrotask(void callback());
 
 @pragma('vm:entry-point')
 _getScheduleMicrotaskClosure() => _scheduleMicrotask;

--- a/shell/platform/windows/fixtures/main.dart
+++ b/shell/platform/windows/fixtures/main.dart
@@ -8,19 +8,24 @@ import 'dart:typed_data' show ByteData, Uint8List;
 import 'dart:ui' as ui;
 
 // Signals a waiting latch in the native test.
-void signal() native 'Signal';
+@pragma('vm:external-name', 'Signal')
+external void signal();
 
 // Signals a waiting latch in the native test, passing a boolean value.
-void signalBoolValue(bool value) native 'SignalBoolValue';
+@pragma('vm:external-name', 'SignalBoolValue')
+external void signalBoolValue(bool value);
 
 // Signals a waiting latch in the native test, passing a string value.
-void signalStringValue(String value) native 'SignalStringValue';
+@pragma('vm:external-name', 'SignalStringValue')
+external void signalStringValue(String value);
 
 // Signals a waiting latch in the native test, which returns a value to the fixture.
-bool signalBoolReturn() native 'SignalBoolReturn';
+@pragma('vm:external-name', 'SignalBoolReturn')
+external bool signalBoolReturn();
 
 // Notify the native test that the first frame has been scheduled.
-void notifyFirstFrameScheduled() native 'NotifyFirstFrameScheduled';
+@pragma('vm:external-name', 'NotifyFirstFrameScheduled')
+external void notifyFirstFrameScheduled();
 
 void main() {}
 

--- a/shell/platform/windows/testing/windows_test_context.h
+++ b/shell/platform/windows/testing/windows_test_context.h
@@ -35,7 +35,8 @@ class WindowsTestContext {
   // Registers a native function callable from Dart code in test fixtures. In
   // the Dart test fixture, the associated function can be declared as:
   //
-  //   ReturnType functionName() native 'IdentifyingName';
+  //   @pragma('vm:external-name', 'IdentifyingName')
+  //   external ReturnType functionName();
   //
   // where `IdentifyingName` matches the |name| parameter to this method.
   void AddNativeFunction(std::string_view name, Dart_NativeFunction function);

--- a/third_party/tonic/tests/fixtures/tonic_test.dart
+++ b/third_party/tonic/tests/fixtures/tonic_test.dart
@@ -13,9 +13,11 @@ class SomeClass {
   SomeClass(this.i);
 }
 
-void giveObjectToNative(Object someObject) native 'GiveObjectToNative';
+@pragma('vm:external-name', 'GiveObjectToNative')
+external void giveObjectToNative(Object someObject);
 
-void signalDone() native 'SignalDone';
+@pragma('vm:external-name', 'SignalDone')
+external void signalDone();
 
 @pragma('vm:entry-point')
 void callGiveObjectToNative() {


### PR DESCRIPTION
The old `native "<name>"` syntax is being replaced with external functions that
have a `@pragma("external-name", "<name>")`.

See https://github.com/dart-lang/sdk/issues/28791