### PR TITLE
[Embedder API] Introduce new semantics update callback and migrate Windows

### DIFF
--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -1031,7 +1031,8 @@ typedef void (*FlutterDataCallback)(const uint8_t* /* data */,
 typedef int64_t FlutterPlatformViewIdentifier;
 
 /// `FlutterSemanticsNode` ID used as a sentinel to signal the end of a batch of
-/// semantics node updates.
+/// semantics node updates. This is unused if using
+/// `FlutterUpdateSemanticsCallback`.
 FLUTTER_EXPORT
 extern const int32_t kFlutterSemanticsNodeIdBatchEnd;
 
@@ -1040,7 +1041,7 @@ extern const int32_t kFlutterSemanticsNodeIdBatchEnd;
 /// The semantics tree is maintained during the semantics phase of the pipeline
 /// (i.e., during PipelineOwner.flushSemantics), which happens after
 /// compositing. Updates are then pushed to embedders via the registered
-/// `FlutterUpdateSemanticsNodeCallback`.
+/// `FlutterUpdateSemanticsCallback`.
 typedef struct {
   /// The size of this struct. Must be sizeof(FlutterSemanticsNode).
   size_t struct_size;
@@ -1109,7 +1110,8 @@ typedef struct {
 } FlutterSemanticsNode;
 
 /// `FlutterSemanticsCustomAction` ID used as a sentinel to signal the end of a
-/// batch of semantics custom action updates.
+/// batch of semantics custom action updates. This is unused if using
+/// `FlutterUpdateSemanticsCallback`.
 FLUTTER_EXPORT
 extern const int32_t kFlutterSemanticsCustomActionIdBatchEnd;
 
@@ -1136,6 +1138,20 @@ typedef struct {
   const char* hint;
 } FlutterSemanticsCustomAction;
 
+/// A batch of updates to semantics nodes and custom actions.
+typedef struct {
+  /// The size of the struct. Must be sizeof(FlutterSemanticsUpdate).
+  size_t struct_size;
+  /// The number of semantics node updates.
+  size_t nodes_count;
+  // Array of semantics nodes. Has length `nodes_count`.
+  FlutterSemanticsNode* nodes;
+  /// The number of semantics custom action updates.
+  size_t custom_actions_count;
+  /// Array of semantics custom actions. Has length `custom_actions_count`.
+  FlutterSemanticsCustomAction* custom_actions;
+} FlutterSemanticsUpdate;
+
 typedef void (*FlutterUpdateSemanticsNodeCallback)(
     const FlutterSemanticsNode* /* semantics node */,
     void* /* user data */);
@@ -1143,6 +1159,10 @@ typedef void (*FlutterUpdateSemanticsNodeCallback)(
 typedef void (*FlutterUpdateSemanticsCustomActionCallback)(
     const FlutterSemanticsCustomAction* /* semantics custom action */,
     void* /* user data */);
+
+typedef void (*FlutterUpdateSemanticsCallback)(
+    const FlutterSemanticsUpdate* /* semantics update */,
+    void* /* user data*/);
 
 typedef struct _FlutterTaskRunner* FlutterTaskRunner;
 
@@ -1739,24 +1759,32 @@ typedef struct {
   /// The callback invoked by the engine in root isolate scope. Called
   /// immediately after the root isolate has been created and marked runnable.
   VoidCallback root_isolate_create_callback;
-  /// The callback invoked by the engine in order to give the embedder the
-  /// chance to respond to semantics node updates from the Dart application.
+  /// The legacy callback invoked by the engine in order to give the embedder
+  /// the chance to respond to semantics node updates from the Dart application.
   /// Semantics node updates are sent in batches terminated by a 'batch end'
   /// callback that is passed a sentinel `FlutterSemanticsNode` whose `id` field
   /// has the value `kFlutterSemanticsNodeIdBatchEnd`.
   ///
   /// The callback will be invoked on the thread on which the `FlutterEngineRun`
   /// call is made.
+  ///
+  /// @deprecated    Prefer using `update_semantics_callback` instead. If this
+  ///                calback is provided, `update_semantics_callback` must not
+  ///                be provided.
   FlutterUpdateSemanticsNodeCallback update_semantics_node_callback;
-  /// The callback invoked by the engine in order to give the embedder the
-  /// chance to respond to updates to semantics custom actions from the Dart
-  /// application.  Custom action updates are sent in batches terminated by a
+  /// The legacy callback invoked by the engine in order to give the embedder
+  /// the chance to respond to updates to semantics custom actions from the Dart
+  /// application. Custom action updates are sent in batches terminated by a
   /// 'batch end' callback that is passed a sentinel
   /// `FlutterSemanticsCustomAction` whose `id` field has the value
   /// `kFlutterSemanticsCustomActionIdBatchEnd`.
   ///
   /// The callback will be invoked on the thread on which the `FlutterEngineRun`
   /// call is made.
+  ///
+  /// @deprecated    Prefer using `update_semantics_callback` instead. If this
+  ///                calback is provided, `update_semantics_callback` must not
+  ///                be provided.
   FlutterUpdateSemanticsCustomActionCallback
       update_semantics_custom_action_callback;
   /// Path to a directory used to store data that is cached across runs of a
@@ -1893,6 +1921,17 @@ typedef struct {
   //
   // The first argument is the `user_data` from `FlutterEngineInitialize`.
   OnPreEngineRestartCallback on_pre_engine_restart_callback;
+
+  /// The callback invoked by the engine in order to give the embedder the
+  /// chance to respond to updates to semantics nodes and custom actions from
+  /// the Dart application.
+  ///
+  /// The callback will be invoked on the thread on which the `FlutterEngineRun`
+  /// call is made.
+  ///
+  /// If this callback is provided, update_semantics_node_callback and
+  /// update_semantics_custom_action_callback must not be provided.
+  FlutterUpdateSemanticsCallback update_semantics_callback;
 } FlutterProjectArgs;
 
 #ifndef FLUTTER_ENGINE_NO_PROTOTYPES
@@ -2234,8 +2273,8 @@ FlutterEngineResult FlutterEngineMarkExternalTextureFrameAvailable(
 /// @param[in]  engine     A running engine instance.
 /// @param[in]  enabled    When enabled, changes to the semantic contents of the
 ///                        window are sent via the
-///                        `FlutterUpdateSemanticsNodeCallback` registered to
-///                        `update_semantics_node_callback` in
+///                        `FlutterUpdateSemanticsCallback` registered to
+///                        `update_semantics_callback` in
 ///                        `FlutterProjectArgs`.
 ///
 /// @return     The result of the call.

--- a/shell/platform/embedder/tests/embedder_a11y_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_a11y_unittests.cc
@@ -24,6 +24,21 @@ namespace testing {
 
 using EmbedderA11yTest = testing::EmbedderTest;
 
+TEST_F(EmbedderTest, CannotProvideNewAndLegacySemanticsCallback) {
+  EmbedderConfigBuilder builder(
+      GetEmbedderContext(EmbedderTestContextType::kSoftwareContext));
+  builder.SetSoftwareRendererConfig();
+  builder.GetProjectArgs().update_semantics_callback =
+      [](const FlutterSemanticsUpdate* update, void* user_data) {};
+  builder.GetProjectArgs().update_semantics_node_callback =
+      [](const FlutterSemanticsNode* update, void* user_data) {};
+  builder.GetProjectArgs().update_semantics_custom_action_callback =
+      [](const FlutterSemanticsCustomAction* update, void* user_data) {};
+  auto engine = builder.InitializeEngine();
+  ASSERT_FALSE(engine.is_valid());
+  engine.reset();
+}
+
 TEST_F(EmbedderA11yTest, A11yTreeIsConsistent) {
 #if defined(OS_FUCHSIA)
   GTEST_SKIP() << "This test crashes on Fuchsia. https://fxbug.dev/87493 ";
@@ -67,6 +82,35 @@ TEST_F(EmbedderA11yTest, A11yTreeIsConsistent) {
             ASSERT_NE(notify_semantics_action_callback, nullptr);
             notify_semantics_action_callback(args);
           })));
+
+  fml::AutoResetWaitableEvent semantics_update_latch;
+  context.SetSemanticsUpdateCallback([&](const FlutterSemanticsUpdate* update) {
+    ASSERT_EQ(size_t(4), update->nodes_count);
+    ASSERT_EQ(size_t(1), update->custom_actions_count);
+
+    for (size_t i = 0; i < update->nodes_count; i++) {
+      const FlutterSemanticsNode* node = update->nodes + i;
+
+      ASSERT_EQ(1.0, node->transform.scaleX);
+      ASSERT_EQ(2.0, node->transform.skewX);
+      ASSERT_EQ(3.0, node->transform.transX);
+      ASSERT_EQ(4.0, node->transform.skewY);
+      ASSERT_EQ(5.0, node->transform.scaleY);
+      ASSERT_EQ(6.0, node->transform.transY);
+      ASSERT_EQ(7.0, node->transform.pers0);
+      ASSERT_EQ(8.0, node->transform.pers1);
+      ASSERT_EQ(9.0, node->transform.pers2);
+
+      if (node->id == 128) {
+        ASSERT_EQ(0x3f3, node->platform_view_id);
+      } else {
+        ASSERT_NE(kFlutterSemanticsNodeIdBatchEnd, node->id);
+        ASSERT_EQ(0, node->platform_view_id);
+      }
+    }
+
+    semantics_update_latch.Signal();
+  });
 
   EmbedderConfigBuilder builder(context);
   builder.SetSoftwareRendererConfig();
@@ -124,6 +168,93 @@ TEST_F(EmbedderA11yTest, A11yTreeIsConsistent) {
   latch.Wait();
 
   // Wait for UpdateSemantics callback on platform (current) thread.
+  latch.Wait();
+  fml::MessageLoop::GetCurrent().RunExpiredTasksNow();
+  semantics_update_latch.Wait();
+
+  // Dispatch a tap to semantics node 42. Wait for NotifySemanticsAction.
+  notify_semantics_action_callback = [&](Dart_NativeArguments args) {
+    int64_t node_id = 0;
+    Dart_GetNativeIntegerArgument(args, 0, &node_id);
+    ASSERT_EQ(42, node_id);
+
+    int64_t action_id;
+    auto handle = Dart_GetNativeIntegerArgument(args, 1, &action_id);
+    ASSERT_FALSE(Dart_IsError(handle));
+    ASSERT_EQ(static_cast<int32_t>(flutter::SemanticsAction::kTap), action_id);
+
+    Dart_Handle semantic_args = Dart_GetNativeArgument(args, 2);
+    int64_t data;
+    Dart_Handle dart_int = Dart_ListGetAt(semantic_args, 0);
+    Dart_IntegerToInt64(dart_int, &data);
+    ASSERT_EQ(2, data);
+
+    dart_int = Dart_ListGetAt(semantic_args, 1);
+    Dart_IntegerToInt64(dart_int, &data);
+    ASSERT_EQ(1, data);
+    latch.Signal();
+  };
+  std::vector<uint8_t> bytes({2, 1});
+  result = FlutterEngineDispatchSemanticsAction(
+      engine.get(), 42, kFlutterSemanticsActionTap, &bytes[0], bytes.size());
+  ASSERT_EQ(result, FlutterEngineResult::kSuccess);
+  latch.Wait();
+
+  // Disable semantics. Wait for NotifySemanticsEnabled(false).
+  notify_semantics_enabled_callback = [&](Dart_NativeArguments args) {
+    bool enabled = true;
+    Dart_GetNativeBooleanArgument(args, 0, &enabled);
+    ASSERT_FALSE(enabled);
+    latch.Signal();
+  };
+  result = FlutterEngineUpdateSemanticsEnabled(engine.get(), false);
+  ASSERT_EQ(result, FlutterEngineResult::kSuccess);
+  latch.Wait();
+}
+
+TEST_F(EmbedderA11yTest, A11yTreeIsConsistentUsingLegacyCallbacks) {
+  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+
+  fml::AutoResetWaitableEvent latch;
+
+  // Called by the Dart text fixture on the UI thread to signal that the C++
+  // unittest should resume.
+  context.AddNativeCallback(
+      "SignalNativeTest", CREATE_NATIVE_ENTRY(([&latch](Dart_NativeArguments) {
+        latch.Signal();
+      })));
+
+  // Called by test fixture on UI thread to pass data back to this test.
+  NativeEntry notify_semantics_enabled_callback;
+  context.AddNativeCallback(
+      "NotifySemanticsEnabled",
+      CREATE_NATIVE_ENTRY(
+          ([&notify_semantics_enabled_callback](Dart_NativeArguments args) {
+            ASSERT_NE(notify_semantics_enabled_callback, nullptr);
+            notify_semantics_enabled_callback(args);
+          })));
+
+  NativeEntry notify_accessibility_features_callback;
+  context.AddNativeCallback(
+      "NotifyAccessibilityFeatures",
+      CREATE_NATIVE_ENTRY((
+          [&notify_accessibility_features_callback](Dart_NativeArguments args) {
+            ASSERT_NE(notify_accessibility_features_callback, nullptr);
+            notify_accessibility_features_callback(args);
+          })));
+
+  NativeEntry notify_semantics_action_callback;
+  context.AddNativeCallback(
+      "NotifySemanticsAction",
+      CREATE_NATIVE_ENTRY(
+          ([&notify_semantics_action_callback](Dart_NativeArguments args) {
+            ASSERT_NE(notify_semantics_action_callback, nullptr);
+            notify_semantics_action_callback(args);
+          })));
+
+  fml::AutoResetWaitableEvent semantics_node_latch;
+  fml::AutoResetWaitableEvent semantics_action_latch;
+
   int node_batch_end_count = 0;
   int action_batch_end_count = 0;
 
@@ -131,6 +262,7 @@ TEST_F(EmbedderA11yTest, A11yTreeIsConsistent) {
   context.SetSemanticsNodeCallback([&](const FlutterSemanticsNode* node) {
     if (node->id == kFlutterSemanticsNodeIdBatchEnd) {
       ++node_batch_end_count;
+      semantics_node_latch.Signal();
     } else {
       // Batches should be completed after all nodes are received.
       ASSERT_EQ(0, node_batch_end_count);
@@ -160,6 +292,7 @@ TEST_F(EmbedderA11yTest, A11yTreeIsConsistent) {
       [&](const FlutterSemanticsCustomAction* action) {
         if (action->id == kFlutterSemanticsCustomActionIdBatchEnd) {
           ++action_batch_end_count;
+          semantics_action_latch.Signal();
         } else {
           // Batches should be completed after all actions are received.
           ASSERT_EQ(0, node_batch_end_count);
@@ -169,8 +302,66 @@ TEST_F(EmbedderA11yTest, A11yTreeIsConsistent) {
         }
       });
 
+  EmbedderConfigBuilder builder(context);
+  builder.SetSoftwareRendererConfig();
+  builder.SetDartEntrypoint("a11y_main");
+
+  auto engine = builder.LaunchEngine();
+  ASSERT_TRUE(engine.is_valid());
+
+  // Wait for initial NotifySemanticsEnabled(false).
+  notify_semantics_enabled_callback = [&](Dart_NativeArguments args) {
+    bool enabled = true;
+    auto handle = Dart_GetNativeBooleanArgument(args, 0, &enabled);
+    ASSERT_FALSE(Dart_IsError(handle));
+    ASSERT_FALSE(enabled);
+    latch.Signal();
+  };
+  latch.Wait();
+
+  // Prepare to NotifyAccessibilityFeatures call
+  fml::AutoResetWaitableEvent notify_features_latch;
+  notify_accessibility_features_callback = [&](Dart_NativeArguments args) {
+    bool enabled = true;
+    auto handle = Dart_GetNativeBooleanArgument(args, 0, &enabled);
+    ASSERT_FALSE(Dart_IsError(handle));
+    ASSERT_FALSE(enabled);
+    notify_features_latch.Signal();
+  };
+
+  // Enable semantics. Wait for NotifySemanticsEnabled(true).
+  notify_semantics_enabled_callback = [&](Dart_NativeArguments args) {
+    bool enabled = false;
+    auto handle = Dart_GetNativeBooleanArgument(args, 0, &enabled);
+    ASSERT_FALSE(Dart_IsError(handle));
+    ASSERT_TRUE(enabled);
+    latch.Signal();
+  };
+  auto result = FlutterEngineUpdateSemanticsEnabled(engine.get(), true);
+  ASSERT_EQ(result, FlutterEngineResult::kSuccess);
+  latch.Wait();
+
+  // Wait for initial accessibility features (reduce_motion == false)
+  notify_features_latch.Wait();
+
+  // Set accessibility features: (reduce_motion == true)
+  notify_accessibility_features_callback = [&](Dart_NativeArguments args) {
+    bool enabled = false;
+    auto handle = Dart_GetNativeBooleanArgument(args, 0, &enabled);
+    ASSERT_FALSE(Dart_IsError(handle));
+    ASSERT_TRUE(enabled);
+    latch.Signal();
+  };
+  result = FlutterEngineUpdateAccessibilityFeatures(
+      engine.get(), kFlutterAccessibilityFeatureReduceMotion);
+  ASSERT_EQ(result, FlutterEngineResult::kSuccess);
+  latch.Wait();
+
+  // Wait for UpdateSemantics callback on platform (current) thread.
   latch.Wait();
   fml::MessageLoop::GetCurrent().RunExpiredTasksNow();
+  semantics_node_latch.Wait();
+  semantics_action_latch.Wait();
   ASSERT_EQ(4, node_count);
   ASSERT_EQ(1, node_batch_end_count);
   ASSERT_EQ(1, action_count);

--- a/shell/platform/embedder/tests/embedder_config_builder.cc
+++ b/shell/platform/embedder/tests/embedder_config_builder.cc
@@ -247,10 +247,12 @@ void EmbedderConfigBuilder::SetIsolateCreateCallbackHook() {
 }
 
 void EmbedderConfigBuilder::SetSemanticsCallbackHooks() {
+  project_args_.update_semantics_callback =
+      context_.GetUpdateSemanticsCallbackHook();
   project_args_.update_semantics_node_callback =
-      EmbedderTestContext::GetUpdateSemanticsNodeCallbackHook();
+      context_.GetUpdateSemanticsNodeCallbackHook();
   project_args_.update_semantics_custom_action_callback =
-      EmbedderTestContext::GetUpdateSemanticsCustomActionCallbackHook();
+      context_.GetUpdateSemanticsCustomActionCallbackHook();
 }
 
 void EmbedderConfigBuilder::SetLogMessageCallbackHook() {

--- a/shell/platform/embedder/tests/embedder_test_context.cc
+++ b/shell/platform/embedder/tests/embedder_test_context.cc
@@ -121,6 +121,11 @@ void EmbedderTestContext::AddNativeCallback(const char* name,
   native_resolver_->AddNativeCallback({name}, function);
 }
 
+void EmbedderTestContext::SetSemanticsUpdateCallback(
+    SemanticsUpdateCallback update_semantics_callback) {
+  update_semantics_callback_ = std::move(update_semantics_callback);
+}
+
 void EmbedderTestContext::SetSemanticsNodeCallback(
     SemanticsNodeCallback update_semantics_node_callback) {
   update_semantics_node_callback_ = std::move(update_semantics_node_callback);
@@ -149,22 +154,44 @@ void EmbedderTestContext::SetLogMessageCallback(
   log_message_callback_ = callback;
 }
 
+FlutterUpdateSemanticsCallback
+EmbedderTestContext::GetUpdateSemanticsCallbackHook() {
+  if (update_semantics_callback_ == nullptr) {
+    return nullptr;
+  }
+
+  return [](const FlutterSemanticsUpdate* update, void* user_data) {
+    auto context = reinterpret_cast<EmbedderTestContext*>(user_data);
+    if (context->update_semantics_callback_) {
+      context->update_semantics_callback_(update);
+    }
+  };
+}
+
 FlutterUpdateSemanticsNodeCallback
 EmbedderTestContext::GetUpdateSemanticsNodeCallbackHook() {
+  if (update_semantics_node_callback_ == nullptr) {
+    return nullptr;
+  }
+
   return [](const FlutterSemanticsNode* semantics_node, void* user_data) {
     auto context = reinterpret_cast<EmbedderTestContext*>(user_data);
-    if (auto callback = context->update_semantics_node_callback_) {
-      callback(semantics_node);
+    if (context->update_semantics_node_callback_) {
+      context->update_semantics_node_callback_(semantics_node);
     }
   };
 }
 
 FlutterUpdateSemanticsCustomActionCallback
 EmbedderTestContext::GetUpdateSemanticsCustomActionCallbackHook() {
+  if (update_semantics_custom_action_callback_ == nullptr) {
+    return nullptr;
+  }
+
   return [](const FlutterSemanticsCustomAction* action, void* user_data) {
     auto context = reinterpret_cast<EmbedderTestContext*>(user_data);
-    if (auto callback = context->update_semantics_custom_action_callback_) {
-      callback(action);
+    if (context->update_semantics_custom_action_callback_) {
+      context->update_semantics_custom_action_callback_(action);
     }
   };
 }
@@ -172,8 +199,8 @@ EmbedderTestContext::GetUpdateSemanticsCustomActionCallbackHook() {
 FlutterLogMessageCallback EmbedderTestContext::GetLogMessageCallbackHook() {
   return [](const char* tag, const char* message, void* user_data) {
     auto context = reinterpret_cast<EmbedderTestContext*>(user_data);
-    if (auto callback = context->log_message_callback_) {
-      callback(tag, message);
+    if (context->log_message_callback_) {
+      context->log_message_callback_(tag, message);
     }
   };
 }

--- a/shell/platform/embedder/tests/embedder_test_context.h
+++ b/shell/platform/embedder/tests/embedder_test_context.h
@@ -24,6 +24,8 @@
 namespace flutter {
 namespace testing {
 
+using SemanticsUpdateCallback =
+    std::function<void(const FlutterSemanticsUpdate*)>;
 using SemanticsNodeCallback = std::function<void(const FlutterSemanticsNode*)>;
 using SemanticsActionCallback =
     std::function<void(const FlutterSemanticsCustomAction*)>;
@@ -68,6 +70,8 @@ class EmbedderTestContext {
   void SetRootSurfaceTransformation(SkMatrix matrix);
 
   void AddIsolateCreateCallback(const fml::closure& closure);
+
+  void SetSemanticsUpdateCallback(SemanticsUpdateCallback update_semantics);
 
   void AddNativeCallback(const char* name, Dart_NativeFunction function);
 
@@ -120,6 +124,7 @@ class EmbedderTestContext {
   UniqueAOTData aot_data_;
   std::vector<fml::closure> isolate_create_callbacks_;
   std::shared_ptr<TestDartNativeResolver> native_resolver_;
+  SemanticsUpdateCallback update_semantics_callback_;
   SemanticsNodeCallback update_semantics_node_callback_;
   SemanticsActionCallback update_semantics_custom_action_callback_;
   std::function<void(const FlutterPlatformMessage*)> platform_message_callback_;
@@ -131,10 +136,11 @@ class EmbedderTestContext {
 
   static VoidCallback GetIsolateCreateCallbackHook();
 
-  static FlutterUpdateSemanticsNodeCallback
-  GetUpdateSemanticsNodeCallbackHook();
+  FlutterUpdateSemanticsCallback GetUpdateSemanticsCallbackHook();
 
-  static FlutterUpdateSemanticsCustomActionCallback
+  FlutterUpdateSemanticsNodeCallback GetUpdateSemanticsNodeCallbackHook();
+
+  FlutterUpdateSemanticsCustomActionCallback
   GetUpdateSemanticsCustomActionCallbackHook();
 
   static FlutterLogMessageCallback GetLogMessageCallbackHook();

--- a/shell/platform/windows/flutter_windows_engine_unittests.cc
+++ b/shell/platform/windows/flutter_windows_engine_unittests.cc
@@ -77,6 +77,9 @@ TEST_F(FlutterWindowsEngineTest, RunDoesExpectedInitialization) {
         EXPECT_NE(args->custom_task_runners->thread_priority_setter, nullptr);
         EXPECT_EQ(args->custom_dart_entrypoint, nullptr);
         EXPECT_NE(args->vsync_callback, nullptr);
+        EXPECT_NE(args->update_semantics_callback, nullptr);
+        EXPECT_EQ(args->update_semantics_node_callback, nullptr);
+        EXPECT_EQ(args->update_semantics_custom_action_callback, nullptr);
 
         args->custom_task_runners->thread_priority_setter(
             FlutterThreadPriority::kRaster);


### PR DESCRIPTION
This introduces a new embedder API to notify the embedder of semantic updates, and, migrates Windows to this new embedder API. The Linux and macOS migrations will be done in follow-up changes.

Part of https://github.com/flutter/flutter/issues/114201

## Background

In the old embedder API, the engine breaks up a batch of semantic updates and sends each update individually to the embedder. This is problematic as there may be dependencies across these updates, so the ordering of these updates is crucial to prevent crashes (see https://github.com/flutter/flutter/issues/103808 and https://github.com/flutter/engine/pull/35792). In other words, there was an implicit contract between the embedder and the engine on the ordering of these updates.

The new embedder API just sends the entire batch of semantic updates in one go, allowing us to remove ordering concerns from the embedder API.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
