### PR TITLE
[Impeller] Always include SkSL in .iplr files

### DIFF
--- a/impeller/compiler/reflector.cc
+++ b/impeller/compiler/reflector.cc
@@ -356,6 +356,9 @@ std::shared_ptr<RuntimeStageData> Reflector::GenerateRuntimeStageData() const {
       options_.target_platform              //
   );
   data->SetShaderData(shader_data_);
+  if (sksl_data_) {
+    data->SetSkSLData(sksl_data_);
+  }
   ir_->for_each_typed_id<spirv_cross::SPIRVariable>(
       [&](uint32_t, const spirv_cross::SPIRVariable& var) {
         if (var.storage != spv::StorageClassUniformConstant) {

--- a/impeller/compiler/reflector.h
+++ b/impeller/compiler/reflector.h
@@ -94,6 +94,7 @@ class Reflector {
   const Options options_;
   const std::shared_ptr<const spirv_cross::ParsedIR> ir_;
   const std::shared_ptr<fml::Mapping> shader_data_;
+  const std::shared_ptr<fml::Mapping> sksl_data_;
   const CompilerBackend compiler_;
   std::unique_ptr<const nlohmann::json> template_arguments_;
   std::shared_ptr<fml::Mapping> reflection_header_;

--- a/impeller/compiler/runtime_stage_data.cc
+++ b/impeller/compiler/runtime_stage_data.cc
@@ -30,6 +30,10 @@ void RuntimeStageData::SetShaderData(std::shared_ptr<fml::Mapping> shader) {
   shader_ = std::move(shader);
 }
 
+void RuntimeStageData::SetSkSLData(std::shared_ptr<fml::Mapping> sksl) {
+  sksl_ = std::move(sksl);
+}
+
 static std::optional<fb::Stage> ToStage(spv::ExecutionModel stage) {
   switch (stage) {
     case spv::ExecutionModel::ExecutionModelVertex:
@@ -137,6 +141,11 @@ std::shared_ptr<fml::Mapping> RuntimeStageData::CreateMapping() const {
   if (shader_->GetSize() > 0u) {
     runtime_stage.shader = {shader_->GetMapping(),
                             shader_->GetMapping() + shader_->GetSize()};
+  }
+  // It is not an error for the SkSL to be ommitted.
+  if (sksl_->GetSize() > 0u) {
+    runtime_stage.sksl = {sksl_->GetMapping(),
+                          sksl_->GetMapping() + sksl_->GetSize()};
   }
   for (const auto& uniform : uniforms_) {
     auto desc = std::make_unique<fb::UniformDescriptionT>();

--- a/impeller/compiler/runtime_stage_data.h
+++ b/impeller/compiler/runtime_stage_data.h
@@ -37,6 +37,8 @@ class RuntimeStageData {
 
   void SetShaderData(std::shared_ptr<fml::Mapping> shader);
 
+  void SetSkSLData(std::shared_ptr<fml::Mapping> sksl);
+
   std::shared_ptr<fml::Mapping> CreateMapping() const;
 
  private:
@@ -45,6 +47,7 @@ class RuntimeStageData {
   const TargetPlatform target_platform_;
   std::vector<UniformDescription> uniforms_;
   std::shared_ptr<fml::Mapping> shader_;
+  std::shared_ptr<fml::Mapping> sksl_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(RuntimeStageData);
 };

--- a/impeller/compiler/types.cc
+++ b/impeller/compiler/types.cc
@@ -296,5 +296,22 @@ bool TargetPlatformIsMetal(TargetPlatform platform) {
   FML_UNREACHABLE();
 }
 
+bool TargetPlatformBundlesSkSL(TargetPlatform platform) {
+  switch (platform) {
+    case TargetPlatform::kSkSL:
+    case TargetPlatform::kRuntimeStageMetal:
+    case TargetPlatform::kRuntimeStageGLES:
+      return true;
+    case TargetPlatform::kMetalDesktop:
+    case TargetPlatform::kMetalIOS:
+    case TargetPlatform::kUnknown:
+    case TargetPlatform::kOpenGLES:
+    case TargetPlatform::kOpenGLDesktop:
+    case TargetPlatform::kVulkan:
+      return false;
+  }
+  FML_UNREACHABLE();
+}
+
 }  // namespace compiler
 }  // namespace impeller

--- a/impeller/compiler/types.h
+++ b/impeller/compiler/types.h
@@ -56,6 +56,8 @@ bool TargetPlatformNeedsSL(TargetPlatform platform);
 
 bool TargetPlatformNeedsReflection(TargetPlatform platform);
 
+bool TargetPlatformBundlesSkSL(TargetPlatform platform);
+
 std::string ShaderCErrorToString(shaderc_compilation_status status);
 
 shaderc_shader_kind ToShaderCShaderKind(SourceType type);

--- a/impeller/runtime_stage/runtime_stage.cc
+++ b/impeller/runtime_stage/runtime_stage.cc
@@ -96,6 +96,12 @@ RuntimeStage::RuntimeStage(std::shared_ptr<fml::Mapping> payload)
       [payload = payload_](auto, auto) {}  //
   );
 
+  sksl_mapping_ = std::make_shared<fml::NonOwnedMapping>(
+      runtime_stage->sksl()->data(),       //
+      runtime_stage->sksl()->size(),       //
+      [payload = payload_](auto, auto) {}  //
+  );
+
   is_valid_ = true;
 }
 
@@ -109,6 +115,10 @@ bool RuntimeStage::IsValid() const {
 
 const std::shared_ptr<fml::Mapping>& RuntimeStage::GetCodeMapping() const {
   return code_mapping_;
+}
+
+const std::shared_ptr<fml::Mapping>& RuntimeStage::GetSkSLMapping() const {
+  return sksl_mapping_;
 }
 
 const std::vector<RuntimeUniformDescription>& RuntimeStage::GetUniforms()

--- a/impeller/runtime_stage/runtime_stage.fbs
+++ b/impeller/runtime_stage/runtime_stage.fbs
@@ -50,6 +50,7 @@ table RuntimeStage {
   entrypoint: string;
   uniforms: [UniformDescription];
   shader: [ubyte];
+  sksl: [ubyte];
 }
 
 root_type RuntimeStage;

--- a/impeller/runtime_stage/runtime_stage.h
+++ b/impeller/runtime_stage/runtime_stage.h
@@ -34,11 +34,14 @@ class RuntimeStage {
 
   const std::shared_ptr<fml::Mapping>& GetCodeMapping() const;
 
+  const std::shared_ptr<fml::Mapping>& GetSkSLMapping() const;
+
  private:
   RuntimeShaderStage stage_ = RuntimeShaderStage::kVertex;
   std::shared_ptr<fml::Mapping> payload_;
   std::string entrypoint_;
   std::shared_ptr<fml::Mapping> code_mapping_;
+  std::shared_ptr<fml::Mapping> sksl_mapping_;
   std::vector<RuntimeUniformDescription> uniforms_;
   bool is_valid_ = false;
 

--- a/lib/ui/painting/fragment_program.cc
+++ b/lib/ui/painting/fragment_program.cc
@@ -60,7 +60,7 @@ std::string FragmentProgram::initFromAsset(const std::string& asset_name) {
     runtime_effect_ = DlRuntimeEffect::MakeImpeller(
         std::make_unique<impeller::RuntimeStage>(std::move(runtime_stage)));
   } else {
-    auto code_mapping = runtime_stage.GetCodeMapping();
+    auto code_mapping = runtime_stage.GetSkSLMapping();
     auto code_size = code_mapping->GetSize();
     const char* sksl =
         reinterpret_cast<const char*>(code_mapping->GetMapping());


### PR DESCRIPTION
The backend is chosen at runtime, so the shaders bundled with an app must include both SkSL and the platform specific shader.

Related https://github.com/flutter/flutter/issues/114197