### PR TITLE
Enable goma for arm64 iOS simulator build in engine_v2 recipe

### DIFF
--- a/ci/builders/mac_ios_engine.json
+++ b/ci/builders/mac_ios_engine.json
@@ -34,8 +34,7 @@
                 "debug",
                 "--simulator",
                 "--simulator-cpu=arm64",
-                "--no-lto",
-                "--no-goma"
+                "--no-lto"
             ],
             "name": "ios_debug_sim_arm64",
             "ninja": {


### PR DESCRIPTION
To match https://flutter.googlesource.com/recipes/+/refs/heads/main/recipes/engine/engine.py#1443

