### PR TITLE
Fix Skia includes of SkEncodedImageFormat et al

### DIFF
--- a/lib/ui/painting/image_decoder_unittests.cc
+++ b/lib/ui/painting/image_decoder_unittests.cc
@@ -18,6 +18,11 @@
 #include "flutter/testing/test_dart_native_resolver.h"
 #include "flutter/testing/test_gl_surface.h"
 #include "flutter/testing/testing.h"
+#include "third_party/skia/include/codec/SkCodecAnimation.h"
+#include "third_party/skia/include/core/SkData.h"
+#include "third_party/skia/include/core/SkEncodedImageFormat.h"
+#include "third_party/skia/include/core/SkImageInfo.h"
+#include "third_party/skia/include/core/SkSize.h"
 
 namespace flutter {
 namespace testing {

--- a/third_party/txt/tests/render_test.cc
+++ b/third_party/txt/tests/render_test.cc
@@ -19,6 +19,9 @@
 #include <string>
 
 #include "flutter/fml/logging.h"
+#include "third_party/skia/include/core/SkBitmap.h"
+#include "third_party/skia/include/core/SkCanvas.h"
+#include "third_party/skia/include/core/SkEncodedImageFormat.h"
 #include "third_party/skia/include/core/SkImageEncoder.h"
 #include "third_party/skia/include/core/SkStream.h"
 #include "txt/asset_font_manager.h"


### PR DESCRIPTION
In <https://skia-review.googlesource.com/c/skia/+/597559>, Skia is changing an #include to a forward declare in a public header. This requires some Flutter files to include that file directly instead of depending on the (now removed) transitive include.

While I was fixing up these files, I made a few pre-emptive fixes of these missing includes.

## Pre-launch Checklist

- [ x ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ x ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ x ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ x  ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ x ] I signed the [CLA].
- [ x ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].
