### PR TITLE
Update docs to mention `felt build --host`

### DIFF
--- a/lib/web_ui/README.md
+++ b/lib/web_ui/README.md
@@ -25,9 +25,10 @@ get help for a specific subcommand, run `felt help SUBCOMMAND`.
 The most useful subcommands are:
 
 - `felt build` - builds a local Flutter Web engine ready to be used by the
-  Flutter framework. To use the local engine build, pass
-  `--local-engine=host_debug_unopt` to the `flutter` command, or to
-  `dev/bots/test.dart` when running a web shard, such as `web_tests`.
+  Flutter framework. To use the local engine build, build with
+  `felt build --host`, then pass `--local-engine=host_debug_unopt` to the
+  `flutter` command, or to `dev/bots/test.dart` when running a web shard, such
+  as `web_tests`.
 - `felt test` - runs web engine tests. By default, this runs all tests using
   Chromium. Passing one or more paths to specific tests would run just the
   specified tests. Run `felt help test` for more options.


### PR DESCRIPTION
I was failing to build the web engine locally with `felt build` until I realized that I needed to add the `--host` flag.  It's mentioned in the output for `felt build --help`, which is how I found it, but it doesn't seem to be mentioned in the web engine README.  So this PR adds it.

I'm unfamiliar with the situation behind the `--host` flag, so if this docs change is irrelevant or should go somewhere else, please close or let me know where else I should update.