### PR TITLE
Enter a scope before calling Dart APIs in ThrowIfUIOperationsProhibited

### DIFF
--- a/lib/ui/ui_dart_state.cc
+++ b/lib/ui/ui_dart_state.cc
@@ -97,6 +97,7 @@ void UIDartState::DidSetIsolate() {
 
 void UIDartState::ThrowIfUIOperationsProhibited() {
   if (!UIDartState::Current()->IsRootIsolate()) {
+    Dart_EnterScope();
     Dart_ThrowException(
         tonic::ToDart("UI actions are only available on root isolate."));
   }

--- a/testing/dart/isolate_test.dart
+++ b/testing/dart/isolate_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:isolate';
+import 'dart:ui';
 
 import 'package:litetest/litetest.dart';
 
@@ -19,5 +20,15 @@ void main() {
       threw = true;
     }
     expect(threw, true);
+  });
+
+  test('UI isolate API throws in a background isolate', () async {
+    void callUiApi(void message) {
+      PlatformDispatcher.instance.onReportTimings = (_) {};
+    }
+    final ReceivePort errorPort = ReceivePort();
+    await Isolate.spawn<void>(callUiApi, null, onError: errorPort.sendPort);
+    final List<dynamic> isolateError = await errorPort.first as List<dynamic>;
+    expect(isolateError[0], 'UI actions are only available on root isolate.');
   });
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/114138
