### PR TITLE
[Impeller] Add ability to unregister shaders

### DIFF
--- a/impeller/renderer/backend/gles/shader_library_gles.cc
+++ b/impeller/renderer/backend/gles/shader_library_gles.cc
@@ -137,4 +137,23 @@ void ShaderLibraryGLES::RegisterFunction(std::string name,
   callback(true);
 }
 
+// |ShaderLibrary|
+void ShaderLibraryGLES::UnregisterFunction(std::string name,
+                                           ShaderStage stage) {
+  ReaderLock lock(functions_mutex_);
+
+  const auto key = ShaderKey{name, stage};
+
+  auto found = functions_.find(key);
+  if (found != functions_.end()) {
+    VALIDATION_LOG << "Library function named " << name
+                   << " was not found, so it couldn't be unregistered.";
+    return;
+  }
+
+  functions_.erase(found);
+
+  return;
+}
+
 }  // namespace impeller

--- a/impeller/renderer/backend/gles/shader_library_gles.h
+++ b/impeller/renderer/backend/gles/shader_library_gles.h
@@ -43,6 +43,9 @@ class ShaderLibraryGLES final : public ShaderLibrary {
                         std::shared_ptr<fml::Mapping> code,
                         RegistrationCallback callback) override;
 
+  // |ShaderLibrary|
+  void UnregisterFunction(std::string name, ShaderStage stage) override;
+
   FML_DISALLOW_COPY_AND_ASSIGN(ShaderLibraryGLES);
 };
 

--- a/impeller/renderer/backend/metal/shader_library_mtl.h
+++ b/impeller/renderer/backend/metal/shader_library_mtl.h
@@ -51,6 +51,9 @@ class ShaderLibraryMTL final : public ShaderLibrary {
                         std::shared_ptr<fml::Mapping> code,
                         RegistrationCallback callback) override;
 
+  // |ShaderLibrary|
+  void UnregisterFunction(std::string name, ShaderStage stage) override;
+
   id<MTLDevice> GetDevice() const;
 
   void RegisterLibrary(id<MTLLibrary> library);

--- a/impeller/renderer/backend/vulkan/shader_library_vk.cc
+++ b/impeller/renderer/backend/vulkan/shader_library_vk.cc
@@ -114,12 +114,32 @@ bool ShaderLibraryVK::IsValid() const {
 std::shared_ptr<const ShaderFunction> ShaderLibraryVK::GetFunction(
     std::string_view name,
     ShaderStage stage) {
+  ReaderLock lock(functions_mutex_);
+
   const auto key = ShaderKey{{name.data(), name.size()}, stage};
   auto found = functions_.find(key);
   if (found != functions_.end()) {
     return found->second;
   }
   return nullptr;
+}
+
+// |ShaderLibrary|
+void ShaderLibraryVK::UnregisterFunction(std::string name, ShaderStage stage) {
+  ReaderLock lock(functions_mutex_);
+
+  const auto key = ShaderKey{name, stage};
+
+  auto found = functions_.find(key);
+  if (found != functions_.end()) {
+    VALIDATION_LOG << "Library function named " << name
+                   << " was not found, so it couldn't be unregistered.";
+    return;
+  }
+
+  functions_.erase(found);
+
+  return;
 }
 
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/shader_library_vk.h
+++ b/impeller/renderer/backend/vulkan/shader_library_vk.h
@@ -6,6 +6,7 @@
 
 #include "flutter/fml/macros.h"
 #include "impeller/base/comparable.h"
+#include "impeller/base/thread.h"
 #include "impeller/renderer/backend/vulkan/vk.h"
 #include "impeller/renderer/shader_key.h"
 #include "impeller/renderer/shader_library.h"
@@ -23,6 +24,7 @@ class ShaderLibraryVK final : public ShaderLibrary {
  private:
   friend class ContextVK;
   const UniqueID library_id_;
+  mutable RWMutex functions_mutex_;
   ShaderFunctionMap functions_;
   bool is_valid_ = false;
 
@@ -33,6 +35,9 @@ class ShaderLibraryVK final : public ShaderLibrary {
   // |ShaderLibrary|
   std::shared_ptr<const ShaderFunction> GetFunction(std::string_view name,
                                                     ShaderStage stage) override;
+
+  // |ShaderLibrary|
+  void UnregisterFunction(std::string name, ShaderStage stage) override;
 
   FML_DISALLOW_COPY_AND_ASSIGN(ShaderLibraryVK);
 };

--- a/impeller/renderer/shader_library.h
+++ b/impeller/renderer/shader_library.h
@@ -33,6 +33,8 @@ class ShaderLibrary : public std::enable_shared_from_this<ShaderLibrary> {
                                 std::shared_ptr<fml::Mapping> code,
                                 RegistrationCallback callback);
 
+  virtual void UnregisterFunction(std::string name, ShaderStage stage) = 0;
+
  protected:
   ShaderLibrary();
 

--- a/impeller/runtime_stage/runtime_stage_unittests.cc
+++ b/impeller/runtime_stage/runtime_stage_unittests.cc
@@ -207,9 +207,20 @@ TEST_P(RuntimeStageTest, CanRegisterStage) {
         reg.set_value(result);
       }));
   ASSERT_TRUE(future.get());
-  auto function =
-      library->GetFunction(stage.GetEntrypoint(), ShaderStage::kFragment);
-  ASSERT_NE(function, nullptr);
+  {
+    auto function =
+        library->GetFunction(stage.GetEntrypoint(), ShaderStage::kFragment);
+    ASSERT_NE(function, nullptr);
+  }
+
+  // Check if unregistering works.
+
+  library->UnregisterFunction(stage.GetEntrypoint(), ShaderStage::kFragment);
+  {
+    auto function =
+        library->GetFunction(stage.GetEntrypoint(), ShaderStage::kFragment);
+    ASSERT_EQ(function, nullptr);
+  }
 }
 
 TEST_P(RuntimeStageTest, CanCreatePipelineFromRuntimeStage) {


### PR DESCRIPTION
* I haven't comprehensively verified that this doesn't leak GPU resources.
* For Metal, since `GetFunction` searches through the libraries to find a matching function if one doesn't exist in the function map, I do the same and delete the library if found. I think we should tighten this up at some point by either back shader keys to specific libraries, or perhaps separate `RegisterFunction` libraries into their own list distinct from those passed in through the ctor.