### PR TITLE
fix use of intersect/intersects in DisplayListRasterCacheItem

### DIFF
--- a/flow/layers/display_list_layer_unittests.cc
+++ b/flow/layers/display_list_layer_unittests.cc
@@ -98,6 +98,20 @@ TEST_F(DisplayListLayerTest, SimpleDisplayList) {
   EXPECT_EQ(mock_canvas().draw_calls(), expected_draw_calls);
 }
 
+TEST_F(DisplayListLayerTest, CachingDoesNotChangeCullRect) {
+  const SkPoint layer_offset = SkPoint::Make(10, 10);
+  DisplayListBuilder builder;
+  builder.drawRect({10, 10, 20, 20});
+  auto display_list = builder.Build();
+  auto layer = std::make_shared<DisplayListLayer>(
+      layer_offset, SkiaGPUObject(display_list, unref_queue()), true, false);
+
+  SkRect original_cull_rect = preroll_context()->cull_rect;
+  use_mock_raster_cache();
+  layer->Preroll(preroll_context(), SkMatrix::I());
+  ASSERT_EQ(preroll_context()->cull_rect, original_cull_rect);
+}
+
 TEST_F(DisplayListLayerTest, SimpleDisplayListOpacityInheritance) {
   const SkPoint layer_offset = SkPoint::Make(1.5f, -0.5f);
   const SkRect picture_bounds = SkRect::MakeLTRB(5.0f, 6.0f, 20.5f, 21.5f);

--- a/flow/layers/display_list_raster_cache_item.cc
+++ b/flow/layers/display_list_raster_cache_item.cc
@@ -108,7 +108,7 @@ void DisplayListRasterCacheItem::PrerollFinalize(PrerollContext* context,
   // if the rect is intersect we will get the entry access_count to confirm if
   // it great than the threshold. Otherwise we only increase the entry
   // access_count.
-  bool visible = context->cull_rect.intersect(bounds);
+  bool visible = context->cull_rect.intersects(bounds);
   int accesses = raster_cache->MarkSeen(key_id_, matrix, visible);
   if (!visible || accesses <= raster_cache->access_threshold()) {
     cache_state_ = kNone;


### PR DESCRIPTION
This problem was discovered when some of the benchmarks changed under the LayerStateStack mechanism, it looks like the code in DLRCI::PrerollFinalize was mutating the preroll context cull_rect when it was just wanting to check for intersection due to the use of the wrong `SkRect` method (`intersect` instead of `intersects`). This meant that we would be less likely to cache other DLLayers inside the same sub-tree. Only a layer that saved and restored the cull_rect such as the clip layers or the transform layer would protect against this issue.

This problem will be fixed when the LayerStateStack code eventually goes in as a side effect of relegating the culling to the LSS object, but this PR will introduce the fix earlier so that any benchmarks can be rebased to the new behavior. Then when LSS is finally landed, it should have no incidental impacts on the benchmarks and we can get a clearer picture of how the new mechanism itself affects performance.