### PR TITLE
[Impeller] Correct the ordering of filters in 'Paint::WithFilters'

### DIFF
--- a/impeller/aiks/paint.cc
+++ b/impeller/aiks/paint.cc
@@ -45,9 +45,9 @@ std::shared_ptr<Contents> Paint::WithFilters(
     std::optional<bool> is_solid_color,
     const Matrix& effect_transform) const {
   bool is_solid_color_val = is_solid_color.value_or(!color_source);
+  input = WithColorFilter(input);
   input = WithMaskBlur(input, is_solid_color_val, effect_transform);
   input = WithImageFilter(input, effect_transform);
-  input = WithColorFilter(input);
   return input;
 }
 

--- a/impeller/display_list/display_list_unittests.cc
+++ b/impeller/display_list/display_list_unittests.cc
@@ -959,5 +959,34 @@ TEST_P(DisplayListTest, CanBlendDstOverAndDstCorrectly) {
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
 
+TEST_P(DisplayListTest, CanDrawCorrectlyWithColorFilterAndImageFilter) {
+  flutter::DisplayListBuilder builder;
+  const float green_color_matrix[20] = {
+      0, 0, 0, 0, 0,  //
+      0, 0, 0, 0, 1,  //
+      0, 0, 0, 0, 0,  //
+      0, 0, 0, 1, 0,  //
+  };
+  const float blue_color_matrix[20] = {
+      0, 0, 0, 0, 0,  //
+      0, 0, 0, 0, 0,  //
+      0, 0, 0, 0, 1,  //
+      0, 0, 0, 1, 0,  //
+  };
+  auto green_color_filter =
+      std::make_shared<flutter::DlMatrixColorFilter>(green_color_matrix);
+  auto blue_color_filter =
+      std::make_shared<flutter::DlMatrixColorFilter>(blue_color_matrix);
+  auto blue_image_filter =
+      std::make_shared<flutter::DlColorFilterImageFilter>(blue_color_filter);
+
+  flutter::DlPaint paint;
+  paint.setColor(flutter::DlColor::kRed());
+  paint.setColorFilter(green_color_filter);
+  paint.setImageFilter(blue_image_filter);
+  builder.drawRect(SkRect::MakeLTRB(100, 100, 500, 500), paint);
+  ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
+}
+
 }  // namespace testing
 }  // namespace impeller


### PR DESCRIPTION
It seems to apply the color filter first, and then apply the image filter.

See this example for details
https://fiddle.skia.org/c/5e62809886613c144f50fa99f1954850

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
