### PR TITLE
Build ios with goma.

### DIFF
--- a/ci/builders/mac_ios_engine_profile.json
+++ b/ci/builders/mac_ios_engine_profile.json
@@ -35,8 +35,7 @@
                 "debug",
                 "--simulator",
                 "--simulator-cpu=arm64",
-                "--no-lto",
-                "--no-goma"
+                "--no-lto"
             ],
             "name": "ios_debug_sim_arm64",
             "ninja": {

--- a/ci/builders/mac_ios_engine_release.json
+++ b/ci/builders/mac_ios_engine_release.json
@@ -31,8 +31,7 @@
             "gn": [
                 "--ios",
                 "--runtime-mode",
-                "release",
-                "--no-goma"
+                "release"
             ],
             "name": "ios_release",
             "ninja": {
@@ -59,8 +58,7 @@
                 "debug",
                 "--simulator",
                 "--simulator-cpu=arm64",
-                "--no-lto",
-                "--no-goma"
+                "--no-lto"
             ],
             "name": "ios_debug_sim_arm64",
             "ninja": {


### PR DESCRIPTION
The configurations were passing no-goma explicitly to the gn command which was disabling the use of goma.

Bug: https://github.com/flutter/flutter/issues/114477

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
