### PR TITLE
Moved clang-tidy tests to test library.

### DIFF
--- a/tools/clang_tidy/lib/src/options.dart
+++ b/tools/clang_tidy/lib/src/options.dart
@@ -8,8 +8,9 @@ import 'package:args/args.dart';
 import 'package:path/path.dart' as path;
 
 // Path to root of the flutter/engine repository containing this script.
-final String _engineRoot = path.dirname(path.dirname(path.dirname(path.dirname(path.fromUri(io.Platform.script)))));
-
+String _engineRoot() {
+  return path.dirname(path.dirname(io.Directory.current.path));
+}
 
 /// Adds warnings as errors for only specific runs.  This is helpful if migrating one platform at a time.
 String? _platformSpecificWarningsAsErrors(ArgResults options) {
@@ -153,7 +154,7 @@ class Options {
       'src-dir',
       help: 'Path to the engine src directory. Cannot be used with --compile-commands.',
       valueHelp: 'path/to/engine/src',
-      defaultsTo: path.dirname(_engineRoot),
+      defaultsTo: path.dirname(_engineRoot()),
     )
     ..addOption(
       'checks',
@@ -172,7 +173,7 @@ class Options {
   final io.File buildCommandsPath;
 
   /// The root of the flutter/engine repository.
-  final io.Directory repoPath = io.Directory(_engineRoot);
+  final io.Directory repoPath = io.Directory(_engineRoot());
 
   /// Argument sent as `warnings-as-errors` to clang-tidy.
   final String? warningsAsErrors;

--- a/tools/clang_tidy/pubspec.yaml
+++ b/tools/clang_tidy/pubspec.yaml
@@ -25,8 +25,8 @@ dependencies:
 dev_dependencies:
   async_helper: any
   expect: any
-  litetest: any
   smith: any
+  test: any
 
 dependency_overrides:
   args:


### PR DESCRIPTION
Now you can run the tests simply by executing `dart test test` as would be expected.  It tries to find the compile_commands.json file, you can also set it with an environment variable which will override that.  Also it creates the temp file it uses in one test instead of using the test file itself.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
