### PR TITLE
extend const_finder to allow skipping particular classes

### DIFF
--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -837,7 +837,8 @@ def GatherConstFinderTests(build_dir):
       '--disable-dart-dev',
       os.path.join(test_dir, 'const_finder_test.dart'),
       os.path.join(build_dir, 'gen', 'frontend_server.dart.snapshot'),
-      os.path.join(build_dir, 'flutter_patched_sdk')
+      os.path.join(build_dir, 'flutter_patched_sdk'),
+      os.path.join(build_dir, 'dart-sdk', 'lib', 'libraries.json')
   ]
   yield EngineExecutableTask(
       build_dir,

--- a/tools/const_finder/bin/main.dart
+++ b/tools/const_finder/bin/main.dart
@@ -55,20 +55,7 @@ void main(List<String> args) {
     ..addFlag('help',
         abbr: 'h',
         negatable: false,
-        help: 'Print usage and exit')
-    ..addMultiOption('ignored-class-name',
-      help: 'The name of a class whose containing constant instances that '
-            'should not be retained. This is useful in situations--such as '
-            'the web--where unused constants are not tree shaken from dill '
-            'files.\n\nNote: each provided class name must pair with an '
-            'invocation of "--ignored-class-library-uri" and appear in the '
-            'same order.',
-        valueHelp: 'Icons')
-    ..addMultiOption('ignored-class-library-uri',
-        help: 'The package: URI of a class to ignore.\n\nNote: each provided '
-              'class name must pair with an invocation of '
-              '"--ignored-class-name" and appear in the same order.',
-        valueHelp: 'package:flutter/src/material/icons.dart');
+        help: 'Print usage and exit');
 
   final ArgResults argResults = parser.parse(args);
   T getArg<T>(String name) {
@@ -85,16 +72,10 @@ void main(List<String> args) {
     exit(0);
   }
 
-  final List<List<String>> ignoredClasses = _pairIgnoredClassNamesAndUris(
-    getArg<Object?>('ignored-class-name'),
-    getArg<Object?>('ignored-class-library-uri'),
-  );
-
   final ConstFinder finder = ConstFinder(
     kernelFilePath: getArg<String>('kernel-file'),
     classLibraryUri: getArg<String>('class-library-uri'),
     className: getArg<String>('class-name'),
-    ignoredClasses: ignoredClasses,
   );
 
   final JsonEncoder encoder = getArg<bool>('pretty')
@@ -102,39 +83,4 @@ void main(List<String> args) {
       : const JsonEncoder();
 
   stdout.writeln(encoder.convert(finder.findInstances()));
-}
-
-List<List<String>> _pairIgnoredClassNamesAndUris(Object? names, Object? uris) {
-  // If the user provided neither option then we will not ignore any classes.
-  if (names == null && uris == null) {
-    return const <List<String>>[];
-  }
-  // If the user provided one of the options but not the other, than this is a
-  // error!
-  if (names == null || uris == null) {
-    stderr.writeln(
-      'To ignore specific classes, both "--ignored-class-name" AND '
-      '"--ignored-class-library-uri" must be provided in order to uniquely '
-      'identify the class.',
-    );
-    exit(1);
-  }
-
-  names = names as List<String>;
-  uris = uris as List<String>;
-  final List<List<String>> pairs = <List<String>>[];
-
-  if (names.length != uris.length) {
-    stderr.writeln(
-      '"--ignored-class-name" was provided ${names.length} time(s) but '
-      '"--ignored-class-library-uri" was provided ${uris.length} time(s). '
-      'Each ignored class name must be paired with exactly one ignored class '
-      'library uri, provided in the same order.',
-    );
-    exit(1);
-  }
-  for (int i = 0; i < names.length; i++) {
-    pairs.add(<String>[uris[i], names[i]]);
-  }
-  return pairs;
 }

--- a/tools/const_finder/bin/main.dart
+++ b/tools/const_finder/bin/main.dart
@@ -42,12 +42,16 @@ void main(List<String> args) {
     ..addOption('kernel-file',
         valueHelp: 'path/to/main.dill',
         help: 'The path to a kernel file to parse, which was created from the '
-            'main-package-uri library.')
+            'main-package-uri library.',
+        mandatory: true)
     ..addOption('class-library-uri',
+        mandatory: true,
         help: 'The package: URI of the class to find.',
         valueHelp: 'package:flutter/src/widgets/icon_data.dart')
     ..addOption('class-name',
-        help: 'The class name for the class to find.', valueHelp: 'IconData')
+        help: 'The class name for the class to find.',
+        valueHelp: 'IconData',
+        mandatory: true)
     ..addSeparator('Optional arguments:')
     ..addFlag('pretty',
         negatable: false,
@@ -58,14 +62,7 @@ void main(List<String> args) {
         help: 'Print usage and exit');
 
   final ArgResults argResults = parser.parse(args);
-  T getArg<T>(String name) {
-    try {
-      return argResults[name] as T;
-    } catch (err) {
-      stderr.writeln('Parsing error trying to parse the argument "$name"');
-      rethrow;
-    }
-  }
+  T getArg<T>(String name) => argResults[name] as T;
 
   if (getArg<bool>('help')) {
     stdout.writeln(parser.usage);

--- a/tools/const_finder/bin/main.dart
+++ b/tools/const_finder/bin/main.dart
@@ -59,10 +59,29 @@ void main(List<String> args) {
     ..addFlag('help',
         abbr: 'h',
         negatable: false,
-        help: 'Print usage and exit');
+        help: 'Print usage and exit')
+    ..addOption('annotation-class-name',
+        help: 'The class name of the annotation for classes that should be '
+              'ignored.',
+        valueHelp: 'StaticIconProvider')
+    ..addOption('annotation-class-library-uri',
+        help: 'The package: URI of the class of the annotation for classes '
+              'that should be ignored.',
+        valueHelp: 'package:flutter/src/material/icons.dart');
 
   final ArgResults argResults = parser.parse(args);
   T getArg<T>(String name) => argResults[name] as T;
+
+  final String? annotationClassName = getArg<String?>('annotation-class-name');
+  final String? annotationClassLibraryUri = getArg<String?>('annotation-class-library-uri');
+
+  final bool annotationClassNameProvided = annotationClassName != null;
+  final bool annotationClassLibraryUriProvided = annotationClassLibraryUri != null;
+  if (annotationClassNameProvided != annotationClassLibraryUriProvided) {
+    throw StateError(
+      'If either "--annotation-class-name" or "--annotation-class-library-uri" are provided they both must be',
+    );
+  }
 
   if (getArg<bool>('help')) {
     stdout.writeln(parser.usage);
@@ -73,6 +92,8 @@ void main(List<String> args) {
     kernelFilePath: getArg<String>('kernel-file'),
     classLibraryUri: getArg<String>('class-library-uri'),
     className: getArg<String>('class-name'),
+    annotationClassName: annotationClassName,
+    annotationClassLibraryUri: annotationClassLibraryUri,
   );
 
   final JsonEncoder encoder = getArg<bool>('pretty')

--- a/tools/const_finder/bin/main.dart
+++ b/tools/const_finder/bin/main.dart
@@ -55,20 +55,46 @@ void main(List<String> args) {
     ..addFlag('help',
         abbr: 'h',
         negatable: false,
-        help: 'Print usage and exit');
+        help: 'Print usage and exit')
+    ..addMultiOption('ignored-class-name',
+      help: 'The name of a class whose containing constant instances that '
+            'should not be retained. This is useful in situations--such as '
+            'the web--where unused constants are not tree shaken from dill '
+            'files.\n\nNote: each provided class name must pair with an '
+            'invocation of "--ignored-class-library-uri" and appear in the '
+            'same order.',
+        valueHelp: 'Icons')
+    ..addMultiOption('ignored-class-library-uri',
+        help: 'The package: URI of a class to ignore.\n\nNote: each provided '
+              'class name must pair with an invocation of '
+              '"--ignored-class-name" and appear in the same order.',
+        valueHelp: 'package:flutter/src/material/icons.dart');
 
   final ArgResults argResults = parser.parse(args);
-  T getArg<T>(String name) => argResults[name] as T;
+  T getArg<T>(String name) {
+    try {
+      return argResults[name] as T;
+    } catch (err) {
+      stderr.writeln('Parsing error trying to parse the argument "$name"');
+      rethrow;
+    }
+  }
 
   if (getArg<bool>('help')) {
     stdout.writeln(parser.usage);
     exit(0);
   }
 
+  final List<List<String>> ignoredClasses = _pairIgnoredClassNamesAndUris(
+    getArg<Object?>('ignored-class-name'),
+    getArg<Object?>('ignored-class-library-uri'),
+  );
+
   final ConstFinder finder = ConstFinder(
     kernelFilePath: getArg<String>('kernel-file'),
     classLibraryUri: getArg<String>('class-library-uri'),
     className: getArg<String>('class-name'),
+    ignoredClasses: ignoredClasses,
   );
 
   final JsonEncoder encoder = getArg<bool>('pretty')
@@ -76,4 +102,39 @@ void main(List<String> args) {
       : const JsonEncoder();
 
   stdout.writeln(encoder.convert(finder.findInstances()));
+}
+
+List<List<String>> _pairIgnoredClassNamesAndUris(Object? names, Object? uris) {
+  // If the user provided neither option then we will not ignore any classes.
+  if (names == null && uris == null) {
+    return const <List<String>>[];
+  }
+  // If the user provided one of the options but not the other, than this is a
+  // error!
+  if (names == null || uris == null) {
+    stderr.writeln(
+      'To ignore specific classes, both "--ignored-class-name" AND '
+      '"--ignored-class-library-uri" must be provided in order to uniquely '
+      'identify the class.',
+    );
+    exit(1);
+  }
+
+  names = names as List<String>;
+  uris = uris as List<String>;
+  final List<List<String>> pairs = <List<String>>[];
+
+  if (names.length != uris.length) {
+    stderr.writeln(
+      '"--ignored-class-name" was provided ${names.length} time(s) but '
+      '"--ignored-class-library-uri" was provided ${uris.length} time(s). '
+      'Each ignored class name must be paired with exactly one ignored class '
+      'library uri, provided in the same order.',
+    );
+    exit(1);
+  }
+  for (int i = 0; i < names.length; i++) {
+    pairs.add(<String>[uris[i], names[i]]);
+  }
+  return pairs;
 }

--- a/tools/const_finder/lib/const_finder.dart
+++ b/tools/const_finder/lib/const_finder.dart
@@ -76,15 +76,15 @@ class _ConstVisitor extends RecursiveVisitor<void> {
 
   @override
   void visitClass(Class node) {
-    // check if this is a class that we should ignore
-    if (_isStaticIconProvider(node)) {
-      inIgnoredClass = true;
+    // Check if this is a class that we should ignore.
+    if (!_isStaticIconProvider(node)) {
+      // Not an ignored class.
       super.visitClass(node);
-      inIgnoredClass = false;
       return;
     }
-    // not an ignored class
+    inIgnoredClass = true;
     super.visitClass(node);
+    inIgnoredClass = false;
   }
 
   // Constants from classes annotated with an instance of StaticIconProvider

--- a/tools/const_finder/lib/const_finder.dart
+++ b/tools/const_finder/lib/const_finder.dart
@@ -96,10 +96,7 @@ class _ConstVisitor extends RecursiveVisitor<void> {
       }
 
       final DartType type = expression.type;
-      if (type is InterfaceType && type.classNode.name == 'StaticIconProvider') {
-        return true;
-      }
-      return false;
+      return type is InterfaceType && type.classNode.name == 'StaticIconProvider';
     });
   }
 

--- a/tools/const_finder/lib/const_finder.dart
+++ b/tools/const_finder/lib/const_finder.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:collection';
-import 'dart:io' as io;
 
 import 'package:kernel/kernel.dart';
 
@@ -113,10 +112,6 @@ class _ConstVisitor extends RecursiveVisitor<void> {
   }
 }
 
-void _printStackTrace(Node node) {
-  io.stderr.writeln(StackTrace.current);
-}
-
 /// For debugging.
 Library? lastLibrary;
 
@@ -150,7 +145,7 @@ class ConstFinder {
     return <String, dynamic>{
       'constantInstances': _visitor.constantInstances,
       'nonConstantLocations': _visitor.nonConstantLocations,
-      'skippedConstantInstances': _visitor.skippedConstantInstances,
+      //'skippedConstantInstances': _visitor.skippedConstantInstances,
     };
   }
 }

--- a/tools/const_finder/pubspec.yaml
+++ b/tools/const_finder/pubspec.yaml
@@ -6,7 +6,7 @@ name: const_finder
 publish_to: none
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
 
 # Do not add any dependencies that require more than what is provided in
 # //third_party/dart/pkg or //third_party/dart/third_party/pkg.

--- a/tools/const_finder/test/const_finder_test.dart
+++ b/tools/const_finder/test/const_finder_test.dart
@@ -201,7 +201,8 @@ void _checkNonConstsFrontend(String dillPath, Compiler compiler) {
   );
 }
 
-// Note, since web dills don't have tree shaking, we aren't able to eliminate 
+// Note, since web dills don't have tree shaking, we aren't able to eliminate
+// an additional const versus _checkNonConstFrontend.
 void _checkNonConstsWeb(String dillPath, Compiler compiler) {
   assert(compiler == Compiler.dart2js);
   stdout.writeln('Checking for non-constant instances with $compiler');

--- a/tools/const_finder/test/const_finder_test.dart
+++ b/tools/const_finder/test/const_finder_test.dart
@@ -31,6 +31,8 @@ void expectInstances(dynamic value, dynamic expected, Compiler compiler) {
 
   final Equality<Object?> equality;
   if (compiler == Compiler.dart2js) {
+    // Ignore comparing nonConstantLocations in web dills because it will have
+    // extra fields.
     (value as Map<String, Object?>).remove('nonConstantLocations');
     (expected as Map<String, Object?>).remove('nonConstantLocations');
     equality = const Dart2JSDeepCollectionEquality();
@@ -114,9 +116,8 @@ void _checkConsts(String dillPath, Compiler compiler) {
   );
 }
 
-// Verify constants declared in a class specified in ignoredClasses will be ignored.
 void _checkAnnotation(String dillPath, Compiler compiler) {
-  stdout.writeln('Checking constant instances in a class annotated @staticConstantProvider are ignored with $compiler');
+  stdout.writeln('Checking constant instances in a class annotated with instance of StaticIconProvider are ignored with $compiler');
   final ConstFinder finder = ConstFinder(
     kernelFilePath: dillPath,
     classLibraryUri: 'package:const_finder_fixtures/target.dart',
@@ -421,9 +422,6 @@ class _Test {
       '--cfe-only',
       dartSource,
     ]);
-    if ((result.stderr as String).trim().isNotEmpty) {
-      print(result.stderr);
-    }
     checkProcessResult(result);
 
     resourcesToDispose.add(dillPath);

--- a/tools/const_finder/test/const_finder_test.dart
+++ b/tools/const_finder/test/const_finder_test.dart
@@ -145,7 +145,8 @@ void _checkDenyList(String dillPath, Compiler compiler) {
     compiler,
   );
 }
-void _checkNonConsts(String dillPath, Compiler compiler) {
+
+void _checkNonConstsFrontend(String dillPath, Compiler compiler) {
   stdout.writeln('Checking for non-constant instances with $compiler');
   final ConstFinder finder = ConstFinder(
     kernelFilePath: dillPath,
@@ -196,7 +197,36 @@ void _checkNonConsts(String dillPath, Compiler compiler) {
         }
       ]
     },
-    Compiler.frontendServer, // TODO foo bar
+    compiler,
+  );
+}
+
+// Note, since web dills don't have tree shaking, we aren't able to eliminate 
+void _checkNonConstsWeb(String dillPath, Compiler compiler) {
+  assert(compiler == Compiler.dart2js);
+  stdout.writeln('Checking for non-constant instances with $compiler');
+  final ConstFinder finder = ConstFinder(
+    kernelFilePath: dillPath,
+    classLibraryUri: 'package:const_finder_fixtures/target.dart',
+    className: 'Target',
+  );
+
+  expectInstances(
+    finder.findInstances(),
+    <String, dynamic>{
+      'constantInstances': <dynamic>[
+        <String, dynamic>{'stringValue': '1', 'intValue': 1, 'targetValue': null},
+        <String, dynamic>{'stringValue': '4', 'intValue': 4, 'targetValue': null},
+        <String, dynamic>{'stringValue': '6', 'intValue': 6, 'targetValue': null},
+        <String, dynamic>{'stringValue': '8', 'intValue': 8, 'targetValue': null},
+        <String, dynamic>{'stringValue': '10', 'intValue': 10, 'targetValue': null},
+        <String, dynamic>{'stringValue': '9', 'intValue': 9},
+        <String, dynamic>{'stringValue': '7', 'intValue': 7, 'targetValue': null},
+        <String, dynamic>{'stringValue': 'package', 'intValue': -1, 'targetValue': null},
+      ],
+      'nonConstantLocations': <dynamic>[]
+    },
+    compiler,
   );
 }
 
@@ -245,69 +275,69 @@ class TestRunner {
 
   void test() {
     final List<_Test> tests = <_Test>[
-      //_Test(
-      //  name: 'box_frontend',
-      //  dartSource: path.join(fixtures, 'lib', 'box.dart'),
-      //  frontendServer: frontendServer,
-      //  sdkRoot: sdkRoot,
-      //  librariesSpec: librariesSpec,
-      //  verify: _checkRecursion,
-      //  compiler: Compiler.frontendServer,
-      //),
-      //_Test(
-      //  name: 'box_web',
-      //  dartSource: path.join(fixtures, 'lib', 'box.dart'),
-      //  frontendServer: frontendServer,
-      //  sdkRoot: sdkRoot,
-      //  librariesSpec: librariesSpec,
-      //  verify: _checkRecursion,
-      //  compiler: Compiler.dart2js,
-      //),
-      //_Test(
-      //  name: 'consts_frontend',
-      //  dartSource: path.join(fixtures, 'lib', 'consts.dart'),
-      //  frontendServer: frontendServer,
-      //  sdkRoot: sdkRoot,
-      //  librariesSpec: librariesSpec,
-      //  verify: _checkConsts,
-      //  compiler: Compiler.frontendServer,
-      //),
-      //_Test(
-      //  name: 'consts_web',
-      //  dartSource: path.join(fixtures, 'lib', 'consts.dart'),
-      //  frontendServer: frontendServer,
-      //  sdkRoot: sdkRoot,
-      //  librariesSpec: librariesSpec,
-      //  verify: _checkConsts,
-      //  compiler: Compiler.dart2js,
-      //),
-      //_Test(
-      //  name: 'consts_and_non_frontend',
-      //  dartSource: path.join(fixtures, 'lib', 'consts_and_non.dart'),
-      //  frontendServer: frontendServer,
-      //  sdkRoot: sdkRoot,
-      //  librariesSpec: librariesSpec,
-      //  verify: _checkNonConsts,
-      //  compiler: Compiler.frontendServer,
-      //),
-      //_Test(
-      //  name: 'consts_and_non_web',
-      //  dartSource: path.join(fixtures, 'lib', 'consts_and_non.dart'),
-      //  frontendServer: frontendServer,
-      //  sdkRoot: sdkRoot,
-      //  librariesSpec: librariesSpec,
-      //  verify: _checkNonConsts,
-      //  compiler: Compiler.dart2js,
-      //),
-      //_Test(
-      //  name: 'denylist_frontend',
-      //  dartSource: path.join(fixtures, 'lib', 'denylist.dart'),
-      //  frontendServer: frontendServer,
-      //  sdkRoot: sdkRoot,
-      //  librariesSpec: librariesSpec,
-      //  verify: _checkDenyList,
-      //  compiler: Compiler.frontendServer,
-      //),
+      _Test(
+        name: 'box_frontend',
+        dartSource: path.join(fixtures, 'lib', 'box.dart'),
+        frontendServer: frontendServer,
+        sdkRoot: sdkRoot,
+        librariesSpec: librariesSpec,
+        verify: _checkRecursion,
+        compiler: Compiler.frontendServer,
+      ),
+      _Test(
+        name: 'box_web',
+        dartSource: path.join(fixtures, 'lib', 'box.dart'),
+        frontendServer: frontendServer,
+        sdkRoot: sdkRoot,
+        librariesSpec: librariesSpec,
+        verify: _checkRecursion,
+        compiler: Compiler.dart2js,
+      ),
+      _Test(
+        name: 'consts_frontend',
+        dartSource: path.join(fixtures, 'lib', 'consts.dart'),
+        frontendServer: frontendServer,
+        sdkRoot: sdkRoot,
+        librariesSpec: librariesSpec,
+        verify: _checkConsts,
+        compiler: Compiler.frontendServer,
+      ),
+      _Test(
+        name: 'consts_web',
+        dartSource: path.join(fixtures, 'lib', 'consts.dart'),
+        frontendServer: frontendServer,
+        sdkRoot: sdkRoot,
+        librariesSpec: librariesSpec,
+        verify: _checkConsts,
+        compiler: Compiler.dart2js,
+      ),
+      _Test(
+        name: 'consts_and_non_frontend',
+        dartSource: path.join(fixtures, 'lib', 'consts_and_non.dart'),
+        frontendServer: frontendServer,
+        sdkRoot: sdkRoot,
+        librariesSpec: librariesSpec,
+        verify: _checkNonConstsFrontend,
+        compiler: Compiler.frontendServer,
+      ),
+      _Test(
+        name: 'consts_and_non_web',
+        dartSource: path.join(fixtures, 'lib', 'consts_and_non.dart'),
+        frontendServer: frontendServer,
+        sdkRoot: sdkRoot,
+        librariesSpec: librariesSpec,
+        verify: _checkNonConstsWeb,
+        compiler: Compiler.dart2js,
+      ),
+      _Test(
+        name: 'denylist_frontend',
+        dartSource: path.join(fixtures, 'lib', 'denylist.dart'),
+        frontendServer: frontendServer,
+        sdkRoot: sdkRoot,
+        librariesSpec: librariesSpec,
+        verify: _checkDenyList,
+        compiler: Compiler.frontendServer,
+      ),
       _Test(
         name: 'denylist_web',
         dartSource: path.join(fixtures, 'lib', 'denylist.dart'),

--- a/tools/const_finder/test/const_finder_test.dart
+++ b/tools/const_finder/test/const_finder_test.dart
@@ -122,6 +122,8 @@ void _checkAnnotation(String dillPath, Compiler compiler) {
     kernelFilePath: dillPath,
     classLibraryUri: 'package:const_finder_fixtures/target.dart',
     className: 'Target',
+    annotationClassName: 'StaticIconProvider',
+    annotationClassLibraryUri: 'package:const_finder_fixtures/static_icon_provider.dart',
   );
   expectInstances(
     finder.findInstances(),
@@ -262,7 +264,7 @@ Future<void> main(List<String> args) async {
       sdkRoot: sdkRoot,
       librariesSpec: librariesSpec,
       verify: _checkRecursion,
-      compiler: Compiler.frontendServer,
+      compiler: Compiler.aot,
     ),
     _Test(
       name: 'box_web',
@@ -280,7 +282,7 @@ Future<void> main(List<String> args) async {
       sdkRoot: sdkRoot,
       librariesSpec: librariesSpec,
       verify: _checkConsts,
-      compiler: Compiler.frontendServer,
+      compiler: Compiler.aot,
     ),
     _Test(
       name: 'consts_web',
@@ -298,7 +300,7 @@ Future<void> main(List<String> args) async {
       sdkRoot: sdkRoot,
       librariesSpec: librariesSpec,
       verify: _checkNonConstsFrontend,
-      compiler: Compiler.frontendServer,
+      compiler: Compiler.aot,
     ),
     _Test(
       name: 'consts_and_non_web',
@@ -316,7 +318,7 @@ Future<void> main(List<String> args) async {
       sdkRoot: sdkRoot,
       librariesSpec: librariesSpec,
       verify: _checkAnnotation,
-      compiler: Compiler.frontendServer,
+      compiler: Compiler.aot,
     ),
     _Test(
       name: 'static_icon_provider_web',
@@ -347,7 +349,7 @@ Future<void> main(List<String> args) async {
 
 enum Compiler {
   // Uses TFA tree-shaking.
-  frontendServer,
+  aot,
   // Does not have TFA tree-shaking.
   dart2js,
 }
@@ -377,8 +379,8 @@ class _Test {
   void run() {
     stdout.writeln('Compiling $dartSource to $dillPath with $compiler');
 
-    if (compiler == Compiler.frontendServer) {
-      _compileTFADill();
+    if (compiler == Compiler.aot) {
+      _compileAOTDill();
     } else {
       _compileWebDill();
     }
@@ -395,7 +397,7 @@ class _Test {
     }
   }
 
-  void _compileTFADill() {
+  void _compileAOTDill() {
     checkProcessResult(Process.runSync(dart, <String>[
       frontendServer,
       '--sdk-root=$sdkRoot',

--- a/tools/const_finder/test/const_finder_test.dart
+++ b/tools/const_finder/test/const_finder_test.dart
@@ -115,16 +115,12 @@ void _checkConsts(String dillPath, Compiler compiler) {
 }
 
 // Verify constants declared in a class specified in ignoredClasses will be ignored.
-void _checkDenyList(String dillPath, Compiler compiler) {
-  stdout.writeln('Checking constant instances in a denylist are ignored with $compiler');
+void _checkAnnotation(String dillPath, Compiler compiler) {
+  stdout.writeln('Checking constant instances in a class annotated @staticConstantProvider are ignored with $compiler');
   final ConstFinder finder = ConstFinder(
     kernelFilePath: dillPath,
     classLibraryUri: 'package:const_finder_fixtures/target.dart',
     className: 'Target',
-    ignoredClasses: <List<String>>[<String>[
-      'package:const_finder_fixtures/denylist.dart',
-      'Targets',
-    ]],
   );
   expectInstances(
     finder.findInstances(),
@@ -313,21 +309,21 @@ Future<void> main(List<String> args) async {
       compiler: Compiler.dart2js,
     ),
     _Test(
-      name: 'denylist_frontend',
-      dartSource: path.join(fixtures, 'lib', 'denylist.dart'),
+      name: 'static_icon_provider_frontend',
+      dartSource: path.join(fixtures, 'lib', 'static_icon_provider.dart'),
       frontendServer: frontendServer,
       sdkRoot: sdkRoot,
       librariesSpec: librariesSpec,
-      verify: _checkDenyList,
+      verify: _checkAnnotation,
       compiler: Compiler.frontendServer,
     ),
     _Test(
-      name: 'denylist_web',
-      dartSource: path.join(fixtures, 'lib', 'denylist.dart'),
+      name: 'static_icon_provider_web',
+      dartSource: path.join(fixtures, 'lib', 'static_icon_provider.dart'),
       frontendServer: frontendServer,
       sdkRoot: sdkRoot,
       librariesSpec: librariesSpec,
-      verify: _checkDenyList,
+      verify: _checkAnnotation,
       compiler: Compiler.dart2js,
     ),
   ];

--- a/tools/const_finder/test/fixtures/lib/denylist.dart
+++ b/tools/const_finder/test/fixtures/lib/denylist.dart
@@ -1,0 +1,16 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'target.dart';
+
+void main() {
+  Targets.used1.hit();
+  Targets.used2.hit();
+}
+
+class Targets {
+  static const Target used1 = Target('used1', 1, null);
+  static const Target used2 = Target('used2', 2, null);
+  static const Target unused1 = Target('unused1', 1, null);
+}

--- a/tools/const_finder/test/fixtures/lib/static_icon_provider.dart
+++ b/tools/const_finder/test/fixtures/lib/static_icon_provider.dart
@@ -9,8 +9,17 @@ void main() {
   Targets.used2.hit();
 }
 
+@staticIconProvider
 class Targets {
   static const Target used1 = Target('used1', 1, null);
   static const Target used2 = Target('used2', 2, null);
   static const Target unused1 = Target('unused1', 1, null);
 }
+
+// const_finder explicitly does not retain constants appearing within a class
+// with this annotation.
+class StaticIconProvider {
+  const StaticIconProvider();
+}
+
+const StaticIconProvider staticIconProvider = StaticIconProvider();


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/57181

This updates the `const_finder` to recognize an annotation with the class name `StaticIconProvider`, which will lead to all constant references within that class being ignored. This will be a no-op for non-web Flutter builds, however will allow partial tree-shaking for Flutter for web builds (see https://github.com/flutter/flutter/issues/57181#issuecomment-1295418012 for why some unused icons will still be retained).

A follow-up framework/tool PR will be required to start calling const_finder during web builds, passing it the web dill and adding the annotation to the `Icons` class in https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/material/icons.dart.

I locally confirmed that a dill file created as part of `flutter build web --release` and a framework that had an `@StaticIconProvider()` annotation added resulted in most constants no longer being retained.