### PR TITLE
Make iOS PlatformView to reuse VisualEffectView when possible.

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -450,7 +450,7 @@ void FlutterPlatformViewsController::ApplyMutators(const MutatorsStack& mutators
         break;
       case kBackdropFilter: {
         // Only support DlBlurImageFilter for BackdropFilter.
-        if (!(*iter)->GetFilterMutation().GetFilter().asBlur() || !canApplyBlurBackdrop) {
+        if (!canApplyBlurBackdrop || !(*iter)->GetFilterMutation().GetFilter().asBlur()) {
           break;
         }
         CGRect filterRect =

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -508,19 +508,19 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   [mockFlutterView setNeedsLayout];
   [mockFlutterView layoutIfNeeded];
 
-  NSUInteger numberOfExpectedVisualEffectView = 0;
+  NSMutableArray* originalVisualEffectViews = [[[NSMutableArray alloc] init] autorelease];
   for (UIView* subview in childClippingView.subviews) {
     if (![subview isKindOfClass:[UIVisualEffectView class]]) {
       continue;
     }
-    XCTAssertLessThan(numberOfExpectedVisualEffectView, 1u);
+    XCTAssertLessThan(originalVisualEffectViews.count, 1u);
     if ([self validateOneVisualEffectView:subview
                             expectedFrame:CGRectMake(0, 0, 10, 10)
                               inputRadius:(CGFloat)5]) {
-      numberOfExpectedVisualEffectView++;
+      [originalVisualEffectViews addObject:subview];
     }
   }
-  XCTAssertEqual(numberOfExpectedVisualEffectView, 1u);
+  XCTAssertEqual(originalVisualEffectViews.count, 1u);
 
   //
   // Simulate adding 1 backdrop filter (create a new mutators stack)
@@ -541,20 +541,28 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   [mockFlutterView setNeedsLayout];
   [mockFlutterView layoutIfNeeded];
 
-  numberOfExpectedVisualEffectView = 0;
+  NSMutableArray* newVisualEffectViews = [[[NSMutableArray alloc] init] autorelease];
   for (UIView* subview in childClippingView.subviews) {
     if (![subview isKindOfClass:[UIVisualEffectView class]]) {
       continue;
     }
-    XCTAssertLessThan(numberOfExpectedVisualEffectView, 2u);
+    XCTAssertLessThan(newVisualEffectViews.count, 2u);
 
     if ([self validateOneVisualEffectView:subview
                             expectedFrame:CGRectMake(0, 0, 10, 10)
                               inputRadius:(CGFloat)5]) {
-      numberOfExpectedVisualEffectView++;
+      [newVisualEffectViews addObject:subview];
     }
   }
-  XCTAssertEqual(numberOfExpectedVisualEffectView, 2u);
+  XCTAssertEqual(newVisualEffectViews.count, 2u);
+  for (NSUInteger i = 0; i < originalVisualEffectViews.count; i++) {
+    UIView* originalView = originalVisualEffectViews[i];
+    UIView* newView = newVisualEffectViews[i];
+    // Compare reference.
+    XCTAssertEqual(originalView, newView);
+    id mockOrignalView = OCMPartialMock(originalView);
+    OCMReject([mockOrignalView removeFromSuperview]);
+  }
 }
 
 - (void)testRemoveBackdropFilters {
@@ -613,6 +621,19 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   [mockFlutterView setNeedsLayout];
   [mockFlutterView layoutIfNeeded];
 
+  NSMutableArray* originalVisualEffectViews = [[[NSMutableArray alloc] init] autorelease];
+  for (UIView* subview in childClippingView.subviews) {
+    if (![subview isKindOfClass:[UIVisualEffectView class]]) {
+      continue;
+    }
+    XCTAssertLessThan(originalVisualEffectViews.count, 5u);
+    if ([self validateOneVisualEffectView:subview
+                            expectedFrame:CGRectMake(0, 0, 10, 10)
+                              inputRadius:(CGFloat)5]) {
+      [originalVisualEffectViews addObject:subview];
+    }
+  }
+
   // Simulate removing 1 backdrop filter (create a new mutators stack)
   // Create embedded view params
   flutter::MutatorsStack stack2;
@@ -631,19 +652,29 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   [mockFlutterView setNeedsLayout];
   [mockFlutterView layoutIfNeeded];
 
-  NSUInteger numberOfExpectedVisualEffectView = 0;
+  NSMutableArray* newVisualEffectViews = [[[NSMutableArray alloc] init] autorelease];
   for (UIView* subview in childClippingView.subviews) {
     if (![subview isKindOfClass:[UIVisualEffectView class]]) {
       continue;
     }
-    XCTAssertLessThan(numberOfExpectedVisualEffectView, 4u);
+    XCTAssertLessThan(newVisualEffectViews.count, 4u);
     if ([self validateOneVisualEffectView:subview
                             expectedFrame:CGRectMake(0, 0, 10, 10)
                               inputRadius:(CGFloat)5]) {
-      numberOfExpectedVisualEffectView++;
+      [newVisualEffectViews addObject:subview];
     }
   }
-  XCTAssertEqual(numberOfExpectedVisualEffectView, 4u);
+  XCTAssertEqual(newVisualEffectViews.count, 4u);
+
+  for (NSUInteger i = 0; i < newVisualEffectViews.count; i++) {
+    UIView* newView = newVisualEffectViews[i];
+    id mockNewView = OCMPartialMock(newView);
+    UIView* originalView = originalVisualEffectViews[i];
+    // Compare reference.
+    XCTAssertEqual(originalView, newView);
+    OCMReject([mockNewView removeFromSuperview]);
+    [mockNewView stopMocking];
+  }
 
   // Simulate removing all backdrop filters (replace the mutators stack)
   // Update embedded view params, delete except screenScaleMatrix
@@ -660,7 +691,7 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   [mockFlutterView setNeedsLayout];
   [mockFlutterView layoutIfNeeded];
 
-  numberOfExpectedVisualEffectView = 0;
+  NSUInteger numberOfExpectedVisualEffectView = 0u;
   for (UIView* subview in childClippingView.subviews) {
     if ([subview isKindOfClass:[UIVisualEffectView class]]) {
       numberOfExpectedVisualEffectView++;
@@ -725,6 +756,19 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   [mockFlutterView setNeedsLayout];
   [mockFlutterView layoutIfNeeded];
 
+  NSMutableArray* originalVisualEffectViews = [[[NSMutableArray alloc] init] autorelease];
+  for (UIView* subview in childClippingView.subviews) {
+    if (![subview isKindOfClass:[UIVisualEffectView class]]) {
+      continue;
+    }
+    XCTAssertLessThan(originalVisualEffectViews.count, 5u);
+    if ([self validateOneVisualEffectView:subview
+                            expectedFrame:CGRectMake(0, 0, 10, 10)
+                              inputRadius:(CGFloat)5]) {
+      [originalVisualEffectViews addObject:subview];
+    }
+  }
+
   // Simulate editing 1 backdrop filter in the middle of the stack (create a new mutators stack)
   // Create embedded view params
   flutter::MutatorsStack stack2;
@@ -751,23 +795,33 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   [mockFlutterView setNeedsLayout];
   [mockFlutterView layoutIfNeeded];
 
-  NSUInteger numberOfExpectedVisualEffectView = 0;
+  NSMutableArray* newVisualEffectViews = [[[NSMutableArray alloc] init] autorelease];
   for (UIView* subview in childClippingView.subviews) {
     if (![subview isKindOfClass:[UIVisualEffectView class]]) {
       continue;
     }
-    XCTAssertLessThan(numberOfExpectedVisualEffectView, 5u);
+    XCTAssertLessThan(newVisualEffectViews.count, 5u);
     CGFloat expectInputRadius = 5;
-    if (numberOfExpectedVisualEffectView == 3) {
+    if (newVisualEffectViews.count == 3) {
       expectInputRadius = 2;
     }
     if ([self validateOneVisualEffectView:subview
                             expectedFrame:CGRectMake(0, 0, 10, 10)
                               inputRadius:(CGFloat)expectInputRadius]) {
-      numberOfExpectedVisualEffectView++;
+      [newVisualEffectViews addObject:subview];
     }
   }
-  XCTAssertEqual(numberOfExpectedVisualEffectView, 5u);
+  XCTAssertEqual(newVisualEffectViews.count, 5u);
+  for (NSUInteger i = 0; i < newVisualEffectViews.count; i++) {
+    UIView* newView = newVisualEffectViews[i];
+    id mockNewView = OCMPartialMock(newView);
+    UIView* originalView = originalVisualEffectViews[i];
+    // Compare reference.
+    XCTAssertEqual(originalView, newView);
+    OCMReject([mockNewView removeFromSuperview]);
+    [mockNewView stopMocking];
+  }
+  [newVisualEffectViews removeAllObjects];
 
   // Simulate editing 1 backdrop filter in the beginning of the stack (replace the mutators stack)
   // Update embedded view params, delete except screenScaleMatrix
@@ -794,23 +848,31 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   [mockFlutterView setNeedsLayout];
   [mockFlutterView layoutIfNeeded];
 
-  numberOfExpectedVisualEffectView = 0;
   for (UIView* subview in childClippingView.subviews) {
     if (![subview isKindOfClass:[UIVisualEffectView class]]) {
       continue;
     }
-    XCTAssertLessThan(numberOfExpectedVisualEffectView, 5u);
+    XCTAssertLessThan(newVisualEffectViews.count, 5u);
     CGFloat expectInputRadius = 5;
-    if (numberOfExpectedVisualEffectView == 0) {
+    if (newVisualEffectViews.count == 0) {
       expectInputRadius = 2;
     }
     if ([self validateOneVisualEffectView:subview
                             expectedFrame:CGRectMake(0, 0, 10, 10)
                               inputRadius:(CGFloat)expectInputRadius]) {
-      numberOfExpectedVisualEffectView++;
+      [newVisualEffectViews addObject:subview];
     }
   }
-  XCTAssertEqual(numberOfExpectedVisualEffectView, 5u);
+  for (NSUInteger i = 0; i < newVisualEffectViews.count; i++) {
+    UIView* newView = newVisualEffectViews[i];
+    id mockNewView = OCMPartialMock(newView);
+    UIView* originalView = originalVisualEffectViews[i];
+    // Compare reference.
+    XCTAssertEqual(originalView, newView);
+    OCMReject([mockNewView removeFromSuperview]);
+    [mockNewView stopMocking];
+  }
+  [newVisualEffectViews removeAllObjects];
 
   // Simulate editing 1 backdrop filter in the end of the stack (replace the mutators stack)
   // Update embedded view params, delete except screenScaleMatrix
@@ -837,23 +899,33 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   [mockFlutterView setNeedsLayout];
   [mockFlutterView layoutIfNeeded];
 
-  numberOfExpectedVisualEffectView = 0;
   for (UIView* subview in childClippingView.subviews) {
     if (![subview isKindOfClass:[UIVisualEffectView class]]) {
       continue;
     }
-    XCTAssertLessThan(numberOfExpectedVisualEffectView, 5u);
+    XCTAssertLessThan(newVisualEffectViews.count, 5u);
     CGFloat expectInputRadius = 5;
-    if (numberOfExpectedVisualEffectView == 4) {
+    if (newVisualEffectViews.count == 4) {
       expectInputRadius = 2;
     }
     if ([self validateOneVisualEffectView:subview
                             expectedFrame:CGRectMake(0, 0, 10, 10)
                               inputRadius:(CGFloat)expectInputRadius]) {
-      numberOfExpectedVisualEffectView++;
+      [newVisualEffectViews addObject:subview];
     }
   }
-  XCTAssertEqual(numberOfExpectedVisualEffectView, 5u);
+  XCTAssertEqual(newVisualEffectViews.count, 5u);
+
+  for (NSUInteger i = 0; i < newVisualEffectViews.count; i++) {
+    UIView* newView = newVisualEffectViews[i];
+    id mockNewView = OCMPartialMock(newView);
+    UIView* originalView = originalVisualEffectViews[i];
+    // Compare reference.
+    XCTAssertEqual(originalView, newView);
+    OCMReject([mockNewView removeFromSuperview]);
+    [mockNewView stopMocking];
+  }
+  [newVisualEffectViews removeAllObjects];
 
   // Simulate editing all backdrop filters in the stack (replace the mutators stack)
   // Update embedded view params, delete except screenScaleMatrix
@@ -875,19 +947,29 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   [mockFlutterView setNeedsLayout];
   [mockFlutterView layoutIfNeeded];
 
-  numberOfExpectedVisualEffectView = 0;
   for (UIView* subview in childClippingView.subviews) {
     if (![subview isKindOfClass:[UIVisualEffectView class]]) {
       continue;
     }
-    XCTAssertLessThan(numberOfExpectedVisualEffectView, 5u);
+    XCTAssertLessThan(newVisualEffectViews.count, 5u);
     if ([self validateOneVisualEffectView:subview
                             expectedFrame:CGRectMake(0, 0, 10, 10)
-                              inputRadius:(CGFloat)numberOfExpectedVisualEffectView]) {
-      numberOfExpectedVisualEffectView++;
+                              inputRadius:(CGFloat)newVisualEffectViews.count]) {
+      [newVisualEffectViews addObject:subview];
     }
   }
-  XCTAssertEqual(numberOfExpectedVisualEffectView, 5u);
+  XCTAssertEqual(newVisualEffectViews.count, 5u);
+
+  for (NSUInteger i = 0; i < newVisualEffectViews.count; i++) {
+    UIView* newView = newVisualEffectViews[i];
+    id mockNewView = OCMPartialMock(newView);
+    UIView* originalView = originalVisualEffectViews[i];
+    // Compare reference.
+    XCTAssertEqual(originalView, newView);
+    OCMReject([mockNewView removeFromSuperview]);
+    [mockNewView stopMocking];
+  }
+  [newVisualEffectViews removeAllObjects];
 }
 
 - (void)testApplyBackdropFilterNotDlBlurImageFilter {

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -92,7 +92,7 @@
 
 // Applies blur backdrop filters to the ChildClippingView with blur values from
 // filters.
-- (void)applyBlurBackdropFilters:(NSMutableArray<PlatformViewFilter*>*)filters;
+- (void)applyBlurBackdropFilters:(NSArray<PlatformViewFilter*>*)filters;
 
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
@@ -198,7 +198,7 @@ static BOOL _preparedOnce = NO;
 
 - (void)applyBlurBackdropFilters:(NSArray<PlatformViewFilter*>*)filters {
   FML_DCHECK(self.filters.count == self.backdropFilterSubviews.count);
-  if (self.filters.count == 0 && filters.count == 0) {
+  if ((!self.filters || self.filters.count == 0) && filters.count == 0) {
     return;
   }
   self.filters = filters;
@@ -228,13 +228,6 @@ static BOOL _preparedOnce = NO;
   _backdropFilterSubviews = nil;
 
   [super dealloc];
-}
-
-- (NSMutableArray*)filters {
-  if (!_filters) {
-    _filters = [[[NSMutableArray alloc] init] retain];
-  }
-  return _filters;
 }
 
 - (NSMutableArray*)backdropFilterSubviews {

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
@@ -198,7 +198,7 @@ static BOOL _preparedOnce = NO;
 
 - (void)applyBlurBackdropFilters:(NSArray<PlatformViewFilter*>*)filters {
   FML_DCHECK(self.filters.count == self.backdropFilterSubviews.count);
-  if ((!self.filters || self.filters.count == 0) && filters.count == 0) {
+  if (self.filters.count == 0 && filters.count == 0) {
     return;
   }
   self.filters = filters;

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
@@ -177,7 +177,7 @@ static BOOL _preparedOnce = NO;
 
 @interface ChildClippingView ()
 
-@property(retain, nonatomic) NSMutableArray<PlatformViewFilter*>* filters;
+@property(retain, nonatomic) NSArray<PlatformViewFilter*>* filters;
 @property(retain, nonatomic) NSMutableArray<UIVisualEffectView*>* backdropFilterSubviews;
 
 @end
@@ -196,7 +196,7 @@ static BOOL _preparedOnce = NO;
   return NO;
 }
 
-- (void)applyBlurBackdropFilters:(NSMutableArray<PlatformViewFilter*>*)filters {
+- (void)applyBlurBackdropFilters:(NSArray<PlatformViewFilter*>*)filters {
   FML_DCHECK(self.filters.count == self.backdropFilterSubviews.count);
   if (self.filters.count == 0 && filters.count == 0) {
     return;

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
@@ -67,6 +67,18 @@ BOOL BlurRadiusEqualToBlurRadius(CGFloat radius1, CGFloat radius2) {
 
 }  // namespace flutter
 
+@interface PlatformViewFilter ()
+
+// `YES` if the backdropFilterView has been configured at least once.
+@property(nonatomic) BOOL backdropFilterViewConfigured;
+@property(nonatomic, retain) UIVisualEffectView* backdropFilterView;
+
+// Updates the `visualEffectView` with the current filter parameters.
+// Also sets `self.backdropFilterView` to the updated visualEffectView.
+- (void)updateVisualEffectView:(UIVisualEffectView*)visualEffectView;
+
+@end
+
 @implementation PlatformViewFilter
 
 static NSObject* _gaussianBlurFilter = nil;
@@ -89,17 +101,8 @@ static BOOL _preparedOnce = NO;
       [self release];
       return nil;
     }
-    NSObject* gaussianBlurFilter = [[_gaussianBlurFilter copy] autorelease];
-    FML_DCHECK(gaussianBlurFilter);
-    UIView* backdropView = visualEffectView.subviews[_indexOfBackdropView];
-    [gaussianBlurFilter setValue:@(_blurRadius) forKey:@"inputRadius"];
-    backdropView.layer.filters = @[ gaussianBlurFilter ];
-
-    UIView* visualEffectSubview = visualEffectView.subviews[_indexOfVisualEffectSubview];
-    visualEffectSubview.layer.backgroundColor = UIColor.clearColor.CGColor;
-
     _backdropFilterView = [visualEffectView retain];
-    _backdropFilterView.frame = _frame;
+    _backdropFilterViewConfigured = NO;
   }
   return self;
 }
@@ -145,11 +148,37 @@ static BOOL _preparedOnce = NO;
   [super dealloc];
 }
 
+- (UIVisualEffectView*)backdropFilterView {
+  FML_DCHECK(_backdropFilterView);
+  if (!self.backdropFilterViewConfigured) {
+    [self updateVisualEffectView:_backdropFilterView];
+    self.backdropFilterViewConfigured = YES;
+  }
+  return _backdropFilterView;
+}
+
+- (void)updateVisualEffectView:(UIVisualEffectView*)visualEffectView {
+  NSObject* gaussianBlurFilter = [[_gaussianBlurFilter copy] autorelease];
+  FML_DCHECK(gaussianBlurFilter);
+  UIView* backdropView = visualEffectView.subviews[_indexOfBackdropView];
+  [gaussianBlurFilter setValue:@(_blurRadius) forKey:@"inputRadius"];
+  backdropView.layer.filters = @[ gaussianBlurFilter ];
+
+  UIView* visualEffectSubview = visualEffectView.subviews[_indexOfVisualEffectSubview];
+  visualEffectSubview.layer.backgroundColor = UIColor.clearColor.CGColor;
+  visualEffectView.frame = _frame;
+
+  if (_backdropFilterView != visualEffectView) {
+    _backdropFilterView = [visualEffectView retain];
+  }
+}
+
 @end
 
 @interface ChildClippingView ()
 
 @property(retain, nonatomic) NSMutableArray<PlatformViewFilter*>* filters;
+@property(retain, nonatomic) NSMutableArray<UIVisualEffectView*>* backdropFilterSubviews;
 
 @end
 
@@ -168,36 +197,35 @@ static BOOL _preparedOnce = NO;
 }
 
 - (void)applyBlurBackdropFilters:(NSMutableArray<PlatformViewFilter*>*)filters {
-  BOOL needUpdateFilterViews = NO;
-  if (self.filters.count != filters.count) {
-    needUpdateFilterViews = YES;
-  } else {
-    for (NSUInteger i = 0; i < filters.count; i++) {
-      if (!CGRectEqualToRect(self.filters[i].frame, filters[i].frame) ||
-          !flutter::BlurRadiusEqualToBlurRadius(self.filters[i].blurRadius,
-                                                filters[i].blurRadius)) {
-        needUpdateFilterViews = YES;
-      }
+  FML_DCHECK(self.filters.count == self.backdropFilterSubviews.count);
+  if (self.filters.count == 0 && filters.count == 0) {
+    return;
+  }
+  self.filters = [filters retain];
+  NSUInteger index = 0;
+  for (index = 0; index < self.filters.count; index++) {
+    UIVisualEffectView* backdropFilterView;
+    PlatformViewFilter* filter = self.filters[index];
+    if (self.backdropFilterSubviews.count <= index) {
+      backdropFilterView = filter.backdropFilterView;
+      [self addSubview:backdropFilterView];
+      [self.backdropFilterSubviews addObject:backdropFilterView];
+    } else {
+      [filter updateVisualEffectView:self.backdropFilterSubviews[index]];
     }
   }
-  if (needUpdateFilterViews) {
-    // Clear the old filter views.
-    for (PlatformViewFilter* filter in self.filters) {
-      [[filter backdropFilterView] removeFromSuperview];
-    }
-    // Update to the new filters.
-    self.filters = [filters retain];
-    // Add new filter views.
-    for (PlatformViewFilter* filter in self.filters) {
-      UIView* backdropFilterView = [filter backdropFilterView];
-      [self addSubview:backdropFilterView];
-    }
+  for (NSUInteger i = self.backdropFilterSubviews.count; i > index; i--) {
+    [self.backdropFilterSubviews[i - 1] removeFromSuperview];
+    [self.backdropFilterSubviews removeLastObject];
   }
 }
 
 - (void)dealloc {
   [_filters release];
   _filters = nil;
+
+  [_backdropFilterSubviews release];
+  _backdropFilterSubviews = nil;
 
   [super dealloc];
 }
@@ -207,6 +235,13 @@ static BOOL _preparedOnce = NO;
     _filters = [[[NSMutableArray alloc] init] retain];
   }
   return _filters;
+}
+
+- (NSMutableArray*)backdropFilterSubviews {
+  if (!_backdropFilterSubviews) {
+    _backdropFilterSubviews = [[[NSMutableArray alloc] init] retain];
+  }
+  return _backdropFilterSubviews;
 }
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
@@ -201,7 +201,7 @@ static BOOL _preparedOnce = NO;
   if (self.filters.count == 0 && filters.count == 0) {
     return;
   }
-  self.filters = [filters retain];
+  self.filters = filters;
   NSUInteger index = 0;
   for (index = 0; index < self.filters.count; index++) {
     UIVisualEffectView* backdropFilterView;


### PR DESCRIPTION
Keeps visual effect view alive and reuse them when possible.

Fixes https://github.com/flutter/flutter/issues/114443

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
