### PR TITLE
ColorFilterLayer clips to its paint bounds

### DIFF
--- a/display_list/display_list_builder_multiplexer.cc
+++ b/display_list/display_list_builder_multiplexer.cc
@@ -11,10 +11,9 @@ void DisplayListBuilderMultiplexer::addBuilder(DisplayListBuilder* builder) {
 }
 
 
-void DisplayListBuilderMultiplexer::clipRect(
-    const SkRect& rect,
-    SkClipOp clip_op,
-    bool is_aa) {
+void DisplayListBuilderMultiplexer::clipRect(const SkRect& rect,
+                                             SkClipOp clip_op,
+                                             bool is_aa) {
   for (auto* builder : builders_) {
     builder->clipRect(rect, clip_op, is_aa);
   }

--- a/display_list/display_list_builder_multiplexer.cc
+++ b/display_list/display_list_builder_multiplexer.cc
@@ -10,7 +10,6 @@ void DisplayListBuilderMultiplexer::addBuilder(DisplayListBuilder* builder) {
   builders_.push_back(builder);
 }
 
-
 void DisplayListBuilderMultiplexer::clipRect(const SkRect& rect,
                                              SkClipOp clip_op,
                                              bool is_aa) {

--- a/display_list/display_list_builder_multiplexer.cc
+++ b/display_list/display_list_builder_multiplexer.cc
@@ -10,14 +10,6 @@ void DisplayListBuilderMultiplexer::addBuilder(DisplayListBuilder* builder) {
   builders_.push_back(builder);
 }
 
-void DisplayListBuilderMultiplexer::saveLayer(
-    const SkRect* bounds,
-    const DlPaint* paint,
-    const DlImageFilter* backdrop_filter) {
-  for (auto* builder : builders_) {
-    builder->saveLayer(bounds, paint, backdrop_filter);
-  }
-}
 
 void DisplayListBuilderMultiplexer::clipRect(
     const SkRect& rect,
@@ -25,6 +17,21 @@ void DisplayListBuilderMultiplexer::clipRect(
     bool is_aa) {
   for (auto* builder : builders_) {
     builder->clipRect(rect, clip_op, is_aa);
+  }
+}
+
+void DisplayListBuilderMultiplexer::save() {
+  for (auto* builder : builders_) {
+    builder->save();
+  }
+}
+
+void DisplayListBuilderMultiplexer::saveLayer(
+    const SkRect* bounds,
+    const DlPaint* paint,
+    const DlImageFilter* backdrop_filter) {
+  for (auto* builder : builders_) {
+    builder->saveLayer(bounds, paint, backdrop_filter);
   }
 }
 

--- a/display_list/display_list_builder_multiplexer.cc
+++ b/display_list/display_list_builder_multiplexer.cc
@@ -19,6 +19,15 @@ void DisplayListBuilderMultiplexer::saveLayer(
   }
 }
 
+void DisplayListBuilderMultiplexer::clipRect(
+    const SkRect& rect,
+    SkClipOp clip_op,
+    bool is_aa) {
+  for (auto* builder : builders_) {
+    builder->clipRect(rect, clip_op, is_aa);
+  }
+}
+
 void DisplayListBuilderMultiplexer::restore() {
   for (auto* builder : builders_) {
     builder->restore();

--- a/display_list/display_list_builder_multiplexer.h
+++ b/display_list/display_list_builder_multiplexer.h
@@ -25,6 +25,8 @@ class DisplayListBuilderMultiplexer {
                  const DlPaint* paint,
                  const DlImageFilter* backdrop_filter = nullptr);
 
+  void clipRect(const SkRect& rect, SkClipOp clip_op, bool is_aa);
+
   void restore();
 
  private:

--- a/display_list/display_list_builder_multiplexer.h
+++ b/display_list/display_list_builder_multiplexer.h
@@ -21,11 +21,13 @@ class DisplayListBuilderMultiplexer {
 
   void addBuilder(DisplayListBuilder* builder);
 
+  void clipRect(const SkRect& rect, SkClipOp clip_op, bool is_aa);
+
+  void save();
+
   void saveLayer(const SkRect* bounds,
                  const DlPaint* paint,
                  const DlImageFilter* backdrop_filter = nullptr);
-
-  void clipRect(const SkRect& rect, SkClipOp clip_op, bool is_aa);
 
   void restore();
 

--- a/display_list/display_list_canvas_unittests.cc
+++ b/display_list/display_list_canvas_unittests.cc
@@ -3039,7 +3039,7 @@ TEST_F(DisplayListCanvas, DrawAtlasLinear) {
 
 sk_sp<SkPicture> makeTestPicture() {
   SkPictureRecorder recorder;
-  SkCanvas* cv = recorder.beginRecording(kRenderBounds);
+  SkCanvas* cv = recorder.beginRecording(kTestBounds);
   SkPaint p;
   p.setStyle(SkPaint::kFill_Style);
   p.setColor(SK_ColorRED);

--- a/flow/layers/color_filter_layer.cc
+++ b/flow/layers/color_filter_layer.cc
@@ -80,7 +80,9 @@ void ColorFilterLayer::Paint(PaintContext& context) const {
     FML_DCHECK(context.builder_multiplexer);
     if (needs_clip) {
       context.builder_multiplexer->save();
-      context.builder_multiplexer->clipRect(paint_bounds());
+      context.builder_multiplexer->clipRect(paint_bounds(),
+                                            SkClipOp::kIntersect,
+                                            /*is_aa=*/false);
     }
     context.builder_multiplexer->saveLayer(&paint_bounds(),
                                            cache_paint.dl_paint());
@@ -92,7 +94,9 @@ void ColorFilterLayer::Paint(PaintContext& context) const {
   } else {
     if (needs_clip) {
       context.internal_nodes_canvas->save();
-      context.internal_nodes_canvas->clipRect(paint_bounds());
+      context.internal_nodes_canvas->clipRect(paint_bounds(),
+                                              SkClipOp::kIntersect,
+                                              /*is_aa=*/false);
     }
     Layer::AutoSaveLayer save = Layer::AutoSaveLayer::Create(
         context, paint_bounds(), cache_paint.sk_paint());

--- a/flow/layers/color_filter_layer.cc
+++ b/flow/layers/color_filter_layer.cc
@@ -73,7 +73,7 @@ void ColorFilterLayer::Paint(PaintContext& context) const {
   // the extent of the layer during the restore()). ColorFilterLayer must clip
   // before the saveLayer in these cases to ensure it doesn't go beyond its
   // reported paint_bounds().
-  const bool needs_clip = filter_->modifies_transparent_black();
+  const bool needs_clip = filter_ && filter_->modifies_transparent_black();
   AutoCachePaint cache_paint(context);
   cache_paint.setColorFilter(filter_.get());
   if (context.leaf_nodes_builder) {

--- a/flow/layers/color_filter_layer_unittests.cc
+++ b/flow/layers/color_filter_layer_unittests.cc
@@ -483,7 +483,9 @@ TEST_F(ColorFilterLayerTest, ModifiesTransparentBlack) {
   /* ColorFilterLayer::Paint() */ {
     DlPaint dl_paint;
     dl_paint.setColorFilter(&layer_filter);
-    expected_builder.clipRect(child_path.getBounds());
+    expected_builder.clipRect(child_path.getBounds(),
+                              SkClipOp::kIntersect,
+                              /*is_aa=*/false);
     expected_builder.saveLayer(&child_path.getBounds(), &dl_paint);
       /* MockLayer::Paint() */ {
         expected_builder.drawPath(child_path, DlPaint().setColor(0xFF000000));

--- a/flow/layers/color_filter_layer_unittests.cc
+++ b/flow/layers/color_filter_layer_unittests.cc
@@ -493,7 +493,7 @@ TEST_F(ColorFilterLayerTest, ModifiesTransparentBlack) {
     expected_builder.restore();
   }
 
-  opacity_layer->Paint(display_list_paint_context());
+  color_filter_layer->Paint(display_list_paint_context());
   EXPECT_TRUE(DisplayListsEQ_Verbose(expected_builder.Build(), display_list()));
 }
 

--- a/flow/layers/color_filter_layer_unittests.cc
+++ b/flow/layers/color_filter_layer_unittests.cc
@@ -483,6 +483,7 @@ TEST_F(ColorFilterLayerTest, ModifiesTransparentBlack) {
   /* ColorFilterLayer::Paint() */ {
     DlPaint dl_paint;
     dl_paint.setColorFilter(&layer_filter);
+    expected_builder.save();
     expected_builder.clipRect(child_path.getBounds(), SkClipOp::kIntersect,
                               /*is_aa=*/false);
     expected_builder.saveLayer(&child_path.getBounds(), &dl_paint);

--- a/flow/layers/color_filter_layer_unittests.cc
+++ b/flow/layers/color_filter_layer_unittests.cc
@@ -454,15 +454,16 @@ TEST_F(ColorFilterLayerTest, OpacityInheritance) {
 }
 
 TEST_F(ColorFilterLayerTest, ModifiesTransparentBlack) {
-  // In Skia, saveLayers with a color filter that modifies transparent black will fill all pixels
-  // within the clip, going beyond the user bounds hint. ColorFilterLayer must insert a clipRect
-  // before saveLayer to ensure it doesn't draw beyond its reported bounds.
+  // In Skia, saveLayers with a color filter that modifies transparent black
+  // will fill all pixels within the clip, going beyond the user bounds hint.
+  // ColorFilterLayer must insert a clipRect before saveLayer to ensure it
+  // doesn't draw beyond its reported bounds.
   // clang-format off
   float matrix[20] = {
-    0, 1, 0, 0, 0,
-    0, 0, 1, 0, 0,
-    1, 0, 0, 0, 0,
-    0, 0, 0, 1, 0,
+    -1, 0, 0, 0, 1,
+     0,-1, 0, 0, 1,
+     0, 0,-1, 0, 1,
+     0, 0, 0,-1, 1,
   };
   // clang-format on
   auto layer_filter = DlMatrixColorFilter(matrix);

--- a/flow/layers/color_filter_layer_unittests.cc
+++ b/flow/layers/color_filter_layer_unittests.cc
@@ -490,6 +490,7 @@ TEST_F(ColorFilterLayerTest, ModifiesTransparentBlack) {
       expected_builder.drawPath(child_path, DlPaint().setColor(0xFF000000));
     }
     expected_builder.restore();
+    expected_builder.restore();
   }
 
   color_filter_layer->Paint(display_list_paint_context());

--- a/flow/layers/color_filter_layer_unittests.cc
+++ b/flow/layers/color_filter_layer_unittests.cc
@@ -483,13 +483,12 @@ TEST_F(ColorFilterLayerTest, ModifiesTransparentBlack) {
   /* ColorFilterLayer::Paint() */ {
     DlPaint dl_paint;
     dl_paint.setColorFilter(&layer_filter);
-    expected_builder.clipRect(child_path.getBounds(),
-                              SkClipOp::kIntersect,
+    expected_builder.clipRect(child_path.getBounds(), SkClipOp::kIntersect,
                               /*is_aa=*/false);
     expected_builder.saveLayer(&child_path.getBounds(), &dl_paint);
-      /* MockLayer::Paint() */ {
-        expected_builder.drawPath(child_path, DlPaint().setColor(0xFF000000));
-      }
+    /* MockLayer::Paint() */ {
+      expected_builder.drawPath(child_path, DlPaint().setColor(0xFF000000));
+    }
     expected_builder.restore();
   }
 

--- a/tools/gn
+++ b/tools/gn
@@ -276,8 +276,6 @@ def to_gn_args(args):
   gn_args['skia_use_wuffs'] = True
   gn_args['skia_use_expat'] = args.target_os == 'android'
   gn_args['skia_use_fontconfig'] = args.enable_fontconfig
-  gn_args['skia_use_legacy_layer_bounds'
-         ] = True  # Temporary: See skbug.com/12083, skbug.com/12303.
 
   if args.enable_skshaper:
     gn_args['skia_use_icu'] = True


### PR DESCRIPTION
Removes use of staging flag `skia_use_legacy_layer_bounds`, and preserves previous behavior for ColorFilterLayers that affect transparent black by clipping before the saveLayer() to prevent the layer from changing all transparent black pixels on the canvas. Adds a unit test to make sure the display list is modified appropriately in that case.

https://bugs.chromium.org/p/skia/issues/detail?id=12083

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
