### PR TITLE
[web] Improve CPU usage when building wasm_release

### DIFF
--- a/lib/web_ui/dev/build.dart
+++ b/lib/web_ui/dev/build.dart
@@ -133,12 +133,13 @@ class NinjaPipelineStep extends ProcessStep {
   Future<ProcessManager> createProcess() {
     print('Running autoninja...');
     return startProcess(
-      // When build the wasm target that includes CanvasKit, we need to use
-      // `ninja` directly to avoid having a high `-j` value that could
-      // potentially slow down the entire machine because emscripten doesn't use
-      // goma.
-      host ? 'autoninja' : 'ninja',
+      'autoninja',
       <String>[
+        // When building the wasm target that includes CanvasKit, we need to use
+        // `--offline` to prevent `autoninja` from using `goma` which would lead
+        // to a high `-j` value that causes high CPU usage. This is because goma
+        // doesn't support emscripten yet.
+        if (!host) '--offline',
         '-C',
         target.path,
       ],

--- a/tools/gn
+++ b/tools/gn
@@ -228,7 +228,11 @@ def to_gn_args(args):
       ('cygwin', 'win')):
     goma_home_dir = os.path.join('c:\\', 'src', 'goma', 'goma-win64')
 
-  if args.goma and goma_dir:
+  if args.target_os == 'wasm' or args.web:
+    gn_args['use_goma'] = False
+    gn_args['goma_dir'] = None
+    print('Disabling GOMA for wasm builds, it is not supported yet.')
+  elif args.goma and goma_dir:
     gn_args['use_goma'] = True
     gn_args['goma_dir'] = goma_dir
   elif args.goma and os.path.exists(goma_home_dir):


### PR DESCRIPTION
Doing a `felt build` (without `--host`) causes high cpu usage for some people (including me and @htoor3). This is because our build tries to use `goma` with a high parallelization factor that all ends up happening in the local machine because `goma` doesn't support `emscripten` yet.

This PR disables `goma` for wasm/web builds.