### PR TITLE
Revert "Move the two remaining engine v2 builds to prod."

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -240,6 +240,7 @@ targets:
     properties:
       release_build: "true"
       config_name: linux_arm_host_engine
+      environment: Production
 
   - name: Linux linux_host_engine
     recipe: engine_v2/engine_v2
@@ -247,6 +248,7 @@ targets:
     properties:
       release_build: "true"
       config_name: linux_host_engine
+      environment: Production
 
   - name: Linux linux_android_aot_engine
     recipe: engine_v2/engine_v2
@@ -254,6 +256,7 @@ targets:
     properties:
       release_build: "true"
       config_name: linux_android_aot_engine
+      environment: Production
 
   - name: Linux linux_android_debug_engine
     recipe: engine_v2/engine_v2
@@ -261,6 +264,7 @@ targets:
     properties:
       release_build: "true"
       config_name: linux_android_debug_engine
+      environment: Production
 
   - name: Linux Web Engine
     recipe: engine/web_engine
@@ -326,15 +330,18 @@ targets:
 
   - name: Mac mac_android_aot_engine
     recipe: engine_v2/engine_v2
+    bringup: true
     timeout: 60
     properties:
       config_name: mac_android_aot_engine
+      environment: Staging
 
   - name: Mac mac_host_engine
     recipe: engine_v2/engine_v2
     timeout: 60
     properties:
       config_name: mac_host_engine
+      environment: Production
 
   - name: Mac Unopt
     recipe: engine/engine_unopt
@@ -425,6 +432,7 @@ targets:
     timeout: 60
     properties:
       config_name: mac_ios_engine
+      environment: Production
       dependencies: >-
         [
           {"dependency": "jazzy", "version": "0.14.1"}
@@ -435,12 +443,15 @@ targets:
     timeout: 60
     properties:
       config_name: mac_ios_engine_profile
+      environment: Production
 
   - name:  Mac mac_ios_engine_release
     recipe: engine_v2/engine_v2
+    bringup: true
     timeout: 60
     properties:
       config_name: mac_ios_engine_release
+      environment: Staging
 
   - name: Windows Android AOT Engine
     recipe: engine/engine
@@ -463,6 +474,7 @@ targets:
     timeout: 60
     properties:
       config_name: windows_android_aot_engine
+      environment: Staging
 
   - name: Windows windows_host_engine
     recipe: engine_v2/engine_v2
@@ -470,6 +482,7 @@ targets:
     timeout: 60
     properties:
       config_name: windows_host_engine
+      environment: Staging
 
   - name: Windows Unopt
     recipe: engine/engine_unopt


### PR DESCRIPTION
Reverts flutter/engine#37274

https://ci.chromium.org/ui/p/flutter/builders/prod/Mac%20mac_ios_engine_release/3/overview