### PR TITLE
[Impeller] Replace existing shaders when a new RuntimeStage arrives through the dispatcher

### DIFF
--- a/impeller/entity/contents/runtime_effect_contents.cc
+++ b/impeller/entity/contents/runtime_effect_contents.cc
@@ -52,6 +52,13 @@ bool RuntimeEffectContents::Render(const ContentContext& renderer,
   std::shared_ptr<const ShaderFunction> function = library->GetFunction(
       runtime_stage_->GetEntrypoint(), ShaderStage::kFragment);
 
+  if (function && runtime_stage_->IsDirty()) {
+    library->UnregisterFunction(runtime_stage_->GetEntrypoint(),
+                                ShaderStage::kFragment);
+
+    function = nullptr;
+  }
+
   if (!function) {
     std::promise<bool> promise;
     auto future = promise.get_future();
@@ -79,6 +86,8 @@ bool RuntimeEffectContents::Render(const ContentContext& renderer,
           << runtime_stage_->GetEntrypoint() << ")";
       return false;
     }
+
+    runtime_stage_->SetClean();
   }
 
   //--------------------------------------------------------------------------

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -2041,12 +2041,21 @@ TEST_P(EntityTest, RuntimeEffect) {
     GTEST_SKIP_("This test only has a Metal fixture at the moment.");
   }
 
+  auto runtime_stage =
+      OpenAssetAsRuntimeStage("runtime_stage_example.frag.iplr");
+  ASSERT_TRUE(runtime_stage->IsDirty());
+
+  bool first_frame = true;
   auto callback = [&](ContentContext& context, RenderPass& pass) -> bool {
+    if (first_frame) {
+      first_frame = false;
+    } else {
+      assert(runtime_stage->IsDirty() == false);
+    }
+
     auto contents = std::make_shared<RuntimeEffectContents>();
     contents->SetGeometry(Geometry::MakeCover());
 
-    auto runtime_stage =
-        OpenAssetAsRuntimeStage("runtime_stage_example.frag.iplr");
     contents->SetRuntimeStage(runtime_stage);
 
     struct FragUniforms {

--- a/impeller/runtime_stage/runtime_stage.cc
+++ b/impeller/runtime_stage/runtime_stage.cc
@@ -144,4 +144,12 @@ RuntimeShaderStage RuntimeStage::GetShaderStage() const {
   return stage_;
 }
 
+bool RuntimeStage::IsDirty() const {
+  return is_dirty_;
+}
+
+void RuntimeStage::SetClean() {
+  is_dirty_ = false;
+}
+
 }  // namespace impeller

--- a/impeller/runtime_stage/runtime_stage.h
+++ b/impeller/runtime_stage/runtime_stage.h
@@ -36,6 +36,10 @@ class RuntimeStage {
 
   const std::shared_ptr<fml::Mapping>& GetSkSLMapping() const;
 
+  bool IsDirty() const;
+
+  void SetClean();
+
  private:
   RuntimeShaderStage stage_ = RuntimeShaderStage::kVertex;
   std::shared_ptr<fml::Mapping> payload_;
@@ -44,6 +48,7 @@ class RuntimeStage {
   std::shared_ptr<fml::Mapping> sksl_mapping_;
   std::vector<RuntimeUniformDescription> uniforms_;
   bool is_valid_ = false;
+  bool is_dirty_ = true;
 
   FML_DISALLOW_COPY_AND_ASSIGN(RuntimeStage);
 };


### PR DESCRIPTION
This is a quick and dirty way to get hot reloading working for runtime stage shaders in Impeller.

I'm still trying to work out how we should manage accessing the Impeller context held by the surface for https://github.com/flutter/flutter/issues/113719, so this is a simple/low risk stopgap to get hot reload working in the meantime.

Making hot reload actually work with `flutter run/attach` is blocked on https://github.com/flutter/flutter/issues/114654.