### PR TITLE
Copy Windows gen_snapshot to a standard location

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -257,7 +257,13 @@ if (is_fuchsia && enable_unittests) {
 # Dart tree, and is less ambiguous than specifying the binary to build since
 # we can specify the toolchain to use, too.
 if (host_os == "win") {
-  group("gen_snapshot") {
-    deps = [ "//third_party/dart/runtime/bin:gen_snapshot($host_toolchain)" ]
+  _gen_snapshot_target =
+      "//third_party/dart/runtime/bin:gen_snapshot($host_toolchain)"
+  copy("gen_snapshot") {
+    deps = [ _gen_snapshot_target ]
+
+    gen_snapshot_out_dir = get_label_info(_gen_snapshot_target, "root_out_dir")
+    sources = [ "$gen_snapshot_out_dir/gen_snapshot.exe" ]
+    outputs = [ "$root_build_dir/gen_snapshot/gen_snapshot.exe" ]
   }
 }


### PR DESCRIPTION
https://github.com/flutter/buildroot/pull/645 and https://github.com/flutter/engine/pull/37125 will cause the android arm64 gen_snapshot to be generated under `clang_x64` similar to other cross-builds. That would break the CI recipe. Instead, this PR copies the `gen_snapshot` for all configs to a standard location so that we can do a soft transition.