### PR TITLE
Revert "Roll Clang from a93d03310e2c to bca75abc01f3"

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -40,7 +40,7 @@ vars = {
   # The list of revisions for these tools comes from Fuchsia, here:
   # https://fuchsia.googlesource.com/integration/+/HEAD/toolchain
   # If there are problems with the toolchain, contact fuchsia-toolchain@.
-  'clang_version': 'git_revision:bca75abc01f303512da409cf25a1d267b89b7276',
+  'clang_version': 'git_revision:a93d03310e2c02fa5e24544df4706650f85788f7',
 
   # When updating the Dart revision, ensure that all entries that are
   # dependencies of Dart are also updated to match the entries in the


### PR DESCRIPTION
Reverts flutter/engine#37076

A number of users on m1 macs can't build ios configurations as the binaries are immediately killed with -9. Revert until we figure this out

https://bugs.fuchsia.dev/p/fuchsia/issues/detail?id=113913