### PR TITLE
[Impeller] Process ImpellerC include paths the same way as output paths

### DIFF
--- a/impeller/compiler/impellerc_main.cc
+++ b/impeller/compiler/impellerc_main.cc
@@ -110,10 +110,9 @@ bool Main(const fml::CommandLine& command_line) {
 
   auto spriv_file_name = std::filesystem::absolute(
       std::filesystem::current_path() / switches.spirv_file_name);
-  if (!fml::WriteAtomically(
-          *switches.working_directory,
-          reinterpret_cast<const char*>(spriv_file_name.u8string().c_str()),
-          *compiler.GetSPIRVAssembly())) {
+  if (!fml::WriteAtomically(*switches.working_directory,
+                            Utf8FromPath(spriv_file_name).c_str(),
+                            *compiler.GetSPIRVAssembly())) {
     std::cerr << "Could not write file to " << switches.spirv_file_name
               << std::endl;
     return false;
@@ -144,10 +143,9 @@ bool Main(const fml::CommandLine& command_line) {
         std::cerr << "Runtime stage data could not be created." << std::endl;
         return false;
       }
-      if (!fml::WriteAtomically(*switches.working_directory,  //
-                                reinterpret_cast<const char*>(
-                                    sl_file_name.u8string().c_str()),  //
-                                *stage_data_mapping                    //
+      if (!fml::WriteAtomically(*switches.working_directory,         //
+                                Utf8FromPath(sl_file_name).c_str(),  //
+                                *stage_data_mapping                  //
                                 )) {
         std::cerr << "Could not write file to " << switches.sl_file_name
                   << std::endl;
@@ -159,10 +157,9 @@ bool Main(const fml::CommandLine& command_line) {
         return false;
       }
     } else {
-      if (!fml::WriteAtomically(
-              *switches.working_directory,
-              reinterpret_cast<const char*>(sl_file_name.u8string().c_str()),
-              *compiler.GetSLShaderSource())) {
+      if (!fml::WriteAtomically(*switches.working_directory,
+                                Utf8FromPath(sl_file_name).c_str(),
+                                *compiler.GetSLShaderSource())) {
         std::cerr << "Could not write file to " << switches.sl_file_name
                   << std::endl;
         return false;
@@ -176,8 +173,7 @@ bool Main(const fml::CommandLine& command_line) {
           std::filesystem::current_path() / switches.reflection_json_name);
       if (!fml::WriteAtomically(
               *switches.working_directory,
-              reinterpret_cast<const char*>(
-                  reflection_json_name.u8string().c_str()),
+              Utf8FromPath(reflection_json_name).c_str(),
               *compiler.GetReflector()->GetReflectionJSON())) {
         std::cerr << "Could not write reflection json to "
                   << switches.reflection_json_name << std::endl;
@@ -191,8 +187,7 @@ bool Main(const fml::CommandLine& command_line) {
                                     switches.reflection_header_name.c_str());
       if (!fml::WriteAtomically(
               *switches.working_directory,
-              reinterpret_cast<const char*>(
-                  reflection_header_name.u8string().c_str()),
+              Utf8FromPath(reflection_header_name).c_str(),
               *compiler.GetReflector()->GetReflectionHeader())) {
         std::cerr << "Could not write reflection header to "
                   << switches.reflection_header_name << std::endl;
@@ -205,8 +200,7 @@ bool Main(const fml::CommandLine& command_line) {
           std::filesystem::absolute(std::filesystem::current_path() /
                                     switches.reflection_cc_name.c_str());
       if (!fml::WriteAtomically(*switches.working_directory,
-                                reinterpret_cast<const char*>(
-                                    reflection_cc_name.u8string().c_str()),
+                                Utf8FromPath(reflection_cc_name).c_str(),
                                 *compiler.GetReflector()->GetReflectionCC())) {
         std::cerr << "Could not write reflection CC to "
                   << switches.reflection_cc_name << std::endl;
@@ -234,10 +228,9 @@ bool Main(const fml::CommandLine& command_line) {
     }
     auto depfile_path = std::filesystem::absolute(
         std::filesystem::current_path() / switches.depfile_path.c_str());
-    if (!fml::WriteAtomically(
-            *switches.working_directory,
-            reinterpret_cast<const char*>(depfile_path.u8string().c_str()),
-            *compiler.CreateDepfileContents({result_file}))) {
+    if (!fml::WriteAtomically(*switches.working_directory,
+                              Utf8FromPath(depfile_path).c_str(),
+                              *compiler.CreateDepfileContents({result_file}))) {
       std::cerr << "Could not write depfile to " << switches.depfile_path
                 << std::endl;
       return false;

--- a/impeller/compiler/switches.cc
+++ b/impeller/compiler/switches.cc
@@ -8,6 +8,7 @@
 #include <map>
 
 #include "flutter/fml/file.h"
+#include "impeller/compiler/utilities.h"
 
 namespace impeller {
 namespace compiler {
@@ -126,12 +127,11 @@ Switches::Switches(const fml::CommandLine& command_line)
 
     // fml::OpenDirectoryReadOnly for Windows doesn't handle relative paths
     // beginning with `../` well, so we build an absolute path.
-    auto include_dir_absolute =
-        ToUtf8(std::filesystem::absolute(std::filesystem::current_path() /
-                                         include_dir_path)
-                   .native());
+    auto include_dir_absolute = std::filesystem::absolute(
+        std::filesystem::current_path() / include_dir_path);
+
     auto dir = std::make_shared<fml::UniqueFD>(fml::OpenDirectoryReadOnly(
-        *working_directory, include_dir_absolute.c_str()));
+        *working_directory, Utf8FromPath(include_dir_absolute).c_str()));
     if (!dir || !dir->is_valid()) {
       continue;
     }

--- a/impeller/compiler/utilities.cc
+++ b/impeller/compiler/utilities.cc
@@ -11,9 +11,13 @@
 namespace impeller {
 namespace compiler {
 
+std::string Utf8FromPath(const std::filesystem::path& path) {
+  return reinterpret_cast<const char*>(path.u8string().c_str());
+}
+
 std::string InferShaderNameFromPath(std::string_view path) {
-  return reinterpret_cast<const char*>(
-      std::filesystem::path{path}.stem().u8string().c_str());
+  auto p = std::filesystem::path{path}.stem();
+  return Utf8FromPath(p);
 }
 
 std::string ConvertToCamelCase(std::string_view string) {

--- a/impeller/compiler/utilities.h
+++ b/impeller/compiler/utilities.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <filesystem>
 #include <string>
 #include <string_view>
 
@@ -11,6 +12,8 @@
 
 namespace impeller {
 namespace compiler {
+
+std::string Utf8FromPath(const std::filesystem::path& path);
 
 std::string InferShaderNameFromPath(std::string_view path);
 


### PR DESCRIPTION
Without having reproduced the problem yet, I'm hoping this will fix the Windows test failure in https://github.com/flutter/flutter/pull/114214. Either way, this refactor simplifies an ugly aspect of the code.

This moves our "works everywhere" solution for utf8-respecting paths to a utility method, and passes include input paths through it.

History of how we got here:
https://github.com/flutter/engine/pull/36158
https://github.com/flutter/engine/pull/36223