### PR TITLE
[web] Avoid returning `int` from js interop classes.

### DIFF
--- a/lib/web_ui/lib/src/engine/assets.dart
+++ b/lib/web_ui/lib/src/engine/assets.dart
@@ -84,7 +84,7 @@ class AssetManager {
           printWarning('Asset manifest does not exist at `$url` – ignoring.');
           return Uint8List.fromList(utf8.encode('{}')).buffer.asByteData();
         }
-        throw AssetManagerException(url, request.status!);
+        throw AssetManagerException(url, request.status!.toInt());
       }
 
       final String? constructorName = target == null ? 'null' :

--- a/lib/web_ui/lib/src/engine/browser_detection.dart
+++ b/lib/web_ui/lib/src/engine/browser_detection.dart
@@ -142,7 +142,7 @@ OperatingSystem detectOperatingSystem({
     // iDevices requesting a "desktop site" spoof their UA so it looks like a Mac.
     // This checks if we're in a touch device, or on a real mac.
     final int maxTouchPoints =
-        overrideMaxTouchPoints ?? domWindow.navigator.maxTouchPoints ?? 0;
+        overrideMaxTouchPoints ?? domWindow.navigator.maxTouchPoints?.toInt() ?? 0;
     if (maxTouchPoints > 2) {
       return OperatingSystem.iOs;
     }

--- a/lib/web_ui/lib/src/engine/canvaskit/canvas.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvas.dart
@@ -35,7 +35,7 @@ class CkCanvas {
 
   final SkCanvas skCanvas;
 
-  int? get saveCount => skCanvas.getSaveCount();
+  int? get saveCount => skCanvas.getSaveCount().toInt();
 
   void clear(ui.Color color) {
     skCanvas.clear(toSharedSkColor1(color));
@@ -272,7 +272,7 @@ class CkCanvas {
   }
 
   int save() {
-    return skCanvas.save();
+    return skCanvas.save().toInt();
   }
 
   void saveLayer(ui.Rect bounds, CkPaint? paint) {

--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -96,10 +96,10 @@ extension CanvasKitExtension on CanvasKit {
   );
 
   // Text decoration enum is embedded in the CanvasKit object itself.
-  external int get NoDecoration;
-  external int get UnderlineDecoration;
-  external int get OverlineDecoration;
-  external int get LineThroughDecoration;
+  external double get NoDecoration;
+  external double get UnderlineDecoration;
+  external double get OverlineDecoration;
+  external double get LineThroughDecoration;
   // End of text decoration enum.
 
   external SkTextDecorationStyleEnum get DecorationStyle;
@@ -109,7 +109,7 @@ extension CanvasKitExtension on CanvasKit {
   external SkFontMgrNamespace get FontMgr;
   external TypefaceFontProviderNamespace get TypefaceFontProvider;
   external SkTypefaceFactory get Typeface;
-  external int GetWebGLContext(
+  external double GetWebGLContext(
       DomCanvasElement canvas, SkWebGLContextOptions options);
   external SkGrContext MakeGrContext(int glContext);
   external SkSurface? MakeOnScreenGLSurface(
@@ -195,8 +195,8 @@ class SkSurface {}
 extension SkSurfaceExtension on SkSurface {
   external SkCanvas getCanvas();
   external void flush();
-  external int width();
-  external int height();
+  external double width();
+  external double height();
   external void dispose();
   external SkImage makeImageSnapshot();
 }
@@ -226,7 +226,7 @@ extension SkFontSlantEnumExtension on SkFontSlantEnum {
 class SkFontSlant {}
 
 extension SkFontSlantExtension on SkFontSlant {
-  external int get value;
+  external double get value;
 }
 
 final List<SkFontSlant> _skFontSlants = <SkFontSlant>[
@@ -260,7 +260,7 @@ extension SkFontWeightEnumExtension on SkFontWeightEnum {
 class SkFontWeight {}
 
 extension SkFontWeightExtension on SkFontWeight {
-  external int get value;
+  external double get value;
 }
 
 final List<SkFontWeight> _skFontWeights = <SkFontWeight>[
@@ -293,7 +293,7 @@ extension SkAffinityEnumExtension on SkAffinityEnum {
 class SkAffinity {}
 
 extension SkAffinityExtension on SkAffinity {
-  external int get value;
+  external double get value;
 }
 
 final List<SkAffinity> _skAffinitys = <SkAffinity>[
@@ -319,7 +319,7 @@ extension SkTextDirectionEnumExtension on SkTextDirectionEnum {
 class SkTextDirection {}
 
 extension SkTextDirectionExtension on SkTextDirection {
-  external int get value;
+  external double get value;
 }
 
 // Flutter enumerates text directions as RTL, LTR, while CanvasKit
@@ -351,7 +351,7 @@ extension SkTextAlignEnumExtension on SkTextAlignEnum {
 class SkTextAlign {}
 
 extension SkTextAlignExtension on SkTextAlign {
-  external int get value;
+  external double get value;
 }
 
 final List<SkTextAlign> _skTextAligns = <SkTextAlign>[
@@ -383,7 +383,7 @@ extension SkTextHeightBehaviorEnumExtension on SkTextHeightBehaviorEnum {
 class SkTextHeightBehavior {}
 
 extension SkTextHeightBehaviorExtension on SkTextHeightBehavior {
-  external int get value;
+  external double get value;
 }
 
 final List<SkTextHeightBehavior> _skTextHeightBehaviors =
@@ -418,7 +418,7 @@ extension SkRectHeightStyleEnumExtension on SkRectHeightStyleEnum {
 class SkRectHeightStyle {}
 
 extension SkRectHeightStyleExtension on SkRectHeightStyle {
-  external int get value;
+  external double get value;
 }
 
 final List<SkRectHeightStyle> _skRectHeightStyles = <SkRectHeightStyle>[
@@ -448,7 +448,7 @@ extension SkRectWidthStyleEnumExtension on SkRectWidthStyleEnum {
 class SkRectWidthStyle {}
 
 extension SkRectWidthStyleExtension on SkRectWidthStyle {
-  external int get value;
+  external double get value;
 }
 
 final List<SkRectWidthStyle> _skRectWidthStyles = <SkRectWidthStyle>[
@@ -476,7 +476,7 @@ extension SkVertexModeEnumExtension on SkVertexModeEnum {
 class SkVertexMode {}
 
 extension SkVertexModeExtension on SkVertexMode {
-  external int get value;
+  external double get value;
 }
 
 final List<SkVertexMode> _skVertexModes = <SkVertexMode>[
@@ -504,7 +504,7 @@ extension SkPointModeEnumExtension on SkPointModeEnum {
 class SkPointMode {}
 
 extension SkPointModeExtension on SkPointMode {
-  external int get value;
+  external double get value;
 }
 
 final List<SkPointMode> _skPointModes = <SkPointMode>[
@@ -531,7 +531,7 @@ extension SkClipOpEnumExtension on SkClipOpEnum {
 class SkClipOp {}
 
 extension SkClipOpExtension on SkClipOp {
-  external int get value;
+  external double get value;
 }
 
 final List<SkClipOp> _skClipOps = <SkClipOp>[
@@ -557,7 +557,7 @@ extension SkFillTypeEnumExtension on SkFillTypeEnum {
 class SkFillType {}
 
 extension SkFillTypeExtension on SkFillType {
-  external int get value;
+  external double get value;
 }
 
 final List<SkFillType> _skFillTypes = <SkFillType>[
@@ -586,7 +586,7 @@ extension SkPathOpEnumExtension on SkPathOpEnum {
 class SkPathOp {}
 
 extension SkPathOpExtension on SkPathOp {
-  external int get value;
+  external double get value;
 }
 
 final List<SkPathOp> _skPathOps = <SkPathOp>[
@@ -617,7 +617,7 @@ extension SkBlurStyleEnumExtension on SkBlurStyleEnum {
 class SkBlurStyle {}
 
 extension SkBlurStyleExtension on SkBlurStyle {
-  external int get value;
+  external double get value;
 }
 
 final List<SkBlurStyle> _skBlurStyles = <SkBlurStyle>[
@@ -646,7 +646,7 @@ extension SkStrokeCapEnumExtension on SkStrokeCapEnum {
 class SkStrokeCap {}
 
 extension SkStrokeCapExtension on SkStrokeCap {
-  external int get value;
+  external double get value;
 }
 
 final List<SkStrokeCap> _skStrokeCaps = <SkStrokeCap>[
@@ -673,7 +673,7 @@ extension SkPaintStyleEnumExtension on SkPaintStyleEnum {
 class SkPaintStyle {}
 
 extension SkPaintStyleExtension on SkPaintStyle {
-  external int get value;
+  external double get value;
 }
 
 final List<SkPaintStyle> _skPaintStyles = <SkPaintStyle>[
@@ -726,7 +726,7 @@ extension SkBlendModeEnumExtension on SkBlendModeEnum {
 class SkBlendMode {}
 
 extension SkBlendModeExtension on SkBlendMode {
-  external int get value;
+  external double get value;
 }
 
 final List<SkBlendMode> _skBlendModes = <SkBlendMode>[
@@ -780,7 +780,7 @@ extension SkStrokeJoinEnumExtension on SkStrokeJoinEnum {
 class SkStrokeJoin {}
 
 extension SkStrokeJoinExtension on SkStrokeJoin {
-  external int get value;
+  external double get value;
 }
 
 final List<SkStrokeJoin> _skStrokeJoins = <SkStrokeJoin>[
@@ -809,7 +809,7 @@ extension SkTileModeEnumExtension on SkTileModeEnum {
 class SkTileMode {}
 
 extension SkTileModeExtension on SkTileMode {
-  external int get value;
+  external double get value;
 }
 
 final List<SkTileMode> _skTileModes = <SkTileMode>[
@@ -837,7 +837,7 @@ extension SkFilterModeEnumExtension on SkFilterModeEnum {
 class SkFilterMode {}
 
 extension SkFilterModeExtension on SkFilterMode {
-  external int get value;
+  external double get value;
 }
 
 SkFilterMode toSkFilterMode(ui.FilterQuality filterQuality) {
@@ -861,7 +861,7 @@ extension SkMipmapModeEnumExtension on SkMipmapModeEnum {
 class SkMipmapMode {}
 
 extension SkMipmapModeExtension on SkMipmapMode {
-  external int get value;
+  external double get value;
 }
 
 SkMipmapMode toSkMipmapMode(ui.FilterQuality filterQuality) {
@@ -885,7 +885,7 @@ extension SkAlphaTypeEnumExtension on SkAlphaTypeEnum {
 class SkAlphaType {}
 
 extension SkAlphaTypeExtension on SkAlphaType {
-  external int get value;
+  external double get value;
 }
 
 @JS()
@@ -911,7 +911,7 @@ extension SkColorTypeEnumExtension on SkColorTypeEnum {
 class SkColorType {}
 
 extension SkColorTypeExtension on SkColorType {
-  external int get value;
+  external double get value;
 }
 
 @JS()
@@ -920,19 +920,19 @@ extension SkColorTypeExtension on SkColorType {
 class SkAnimatedImage {}
 
 extension SkAnimatedImageExtension on SkAnimatedImage {
-  external int getFrameCount();
+  external double getFrameCount();
 
-  external int getRepetitionCount();
+  external double getRepetitionCount();
 
   /// Returns duration in milliseconds.
-  external int currentFrameDuration();
+  external double currentFrameDuration();
 
   /// Advances to the next frame and returns its duration in milliseconds.
-  external int decodeNextFrame();
+  external double decodeNextFrame();
 
   external SkImage makeImageAtCurrentFrame();
-  external int width();
-  external int height();
+  external double width();
+  external double height();
 
   /// Deletes the C++ object.
   ///
@@ -948,8 +948,8 @@ class SkImage {}
 
 extension SkImageExtension on SkImage {
   external void delete();
-  external int width();
-  external int height();
+  external double width();
+  external double height();
   external SkShader makeShaderCubic(
     SkTileMode tileModeX,
     SkTileMode tileModeY,
@@ -1786,8 +1786,8 @@ extension SkCanvasExtension on SkCanvas {
     SkBlendMode blendMode,
     SkPaint paint,
   );
-  external int save();
-  external int getSaveCount();
+  external double save();
+  external double getSaveCount();
   external void saveLayer(
     SkPaint? paint,
     Float32List? bounds,
@@ -1902,7 +1902,7 @@ extension SkTextDecorationStyleEnumExtension on SkTextDecorationStyleEnum {
 class SkTextDecorationStyle {}
 
 extension SkTextDecorationStyleExtension on SkTextDecorationStyle {
-  external int get value;
+  external double get value;
 }
 
 final List<SkTextDecorationStyle> _skTextDecorationStyles =
@@ -1932,7 +1932,7 @@ extension SkTextBaselineEnumExtension on SkTextBaselineEnum {
 class SkTextBaseline {}
 
 extension SkTextBaselineExtension on SkTextBaseline {
-  external int get value;
+  external double get value;
 }
 
 final List<SkTextBaseline> _skTextBaselines = <SkTextBaseline>[
@@ -1962,7 +1962,7 @@ extension SkPlaceholderAlignmentEnumExtension on SkPlaceholderAlignmentEnum {
 class SkPlaceholderAlignment {}
 
 extension SkPlaceholderAlignmentExtension on SkPlaceholderAlignment {
-  external int get value;
+  external double get value;
 }
 
 final List<SkPlaceholderAlignment> _skPlaceholderAlignments =
@@ -2120,10 +2120,10 @@ extension TypefaceFontProviderExtension on TypefaceFontProvider {
 class SkLineMetrics {}
 
 extension SkLineMetricsExtension on SkLineMetrics {
-  external int get startIndex;
-  external int get endIndex;
-  external int get endExcludingWhitespaces;
-  external int get endIncludingNewline;
+  external double get startIndex;
+  external double get endIndex;
+  external double get endExcludingWhitespaces;
+  external double get endIncludingNewline;
   external bool get isHardBreak;
   external double get ascent;
   external double get descent;
@@ -2131,7 +2131,7 @@ extension SkLineMetricsExtension on SkLineMetrics {
   external double get width;
   external double get left;
   external double get baseline;
-  external int get lineNumber;
+  external double get lineNumber;
 }
 
 @JS()
@@ -2171,7 +2171,7 @@ class SkTextPosition {}
 
 extension SkTextPositionExtnsion on SkTextPosition {
   external SkAffinity get affinity;
-  external int get pos;
+  external double get pos;
 }
 
 @JS()
@@ -2179,8 +2179,8 @@ extension SkTextPositionExtnsion on SkTextPosition {
 class SkTextRange {}
 
 extension SkTextRangeExtension on SkTextRange {
-  external int get start;
-  external int get end;
+  external double get start;
+  external double get end;
 }
 
 @JS()
@@ -2475,7 +2475,7 @@ void debugResetBrowserSupportsFinalizationRegistry() {
 class SkData {}
 
 extension SkDataExtension on SkData {
-  external int size();
+  external double size();
   external bool isEmpty();
   external Uint8List bytes();
   external void delete();
@@ -2498,11 +2498,11 @@ extension SkImageInfoExtension on SkImageInfo {
   external SkAlphaType get alphaType;
   external ColorSpace get colorSpace;
   external SkColorType get colorType;
-  external int get height;
+  external double get height;
   external bool get isEmpty;
   external bool get isOpaque;
   external Float32List get bounds;
-  external int get width;
+  external double get width;
   external SkImageInfo makeAlphaType(SkAlphaType alphaType);
   external SkImageInfo makeColorSpace(ColorSpace colorSpace);
   external SkImageInfo makeColorType(SkColorType colorType);
@@ -2526,8 +2526,8 @@ extension SkPartialImageInfoExtension on SkPartialImageInfo {
   external SkAlphaType get alphaType;
   external ColorSpace get colorSpace;
   external SkColorType get colorType;
-  external int get height;
-  external int get width;
+  external double get height;
+  external double get width;
 }
 
 /// Helper interop methods for [patchCanvasKitModule].

--- a/lib/web_ui/lib/src/engine/canvaskit/image.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image.dart
@@ -111,7 +111,7 @@ Future<Uint8List> fetchImage(
   if (chunkCallback != null) {
     request.addEventListener('progress', allowInterop((DomEvent event)  {
       event = event as DomProgressEvent;
-      chunkCallback.call(event.loaded!, event.total!);
+      chunkCallback.call(event.loaded!.toInt(), event.total!.toInt());
     }));
   }
 
@@ -123,7 +123,7 @@ Future<Uint8List> fetchImage(
   }));
 
   request.addEventListener('load', allowInterop((DomEvent event) {
-    final int status = request.status!;
+    final int status = request.status!.toInt();
     final bool accepted = status >= 200 && status < 300;
     final bool fileUri = status == 0; // file:// URIs have status of 0.
     final bool notModified = status == 304;
@@ -173,8 +173,8 @@ class CkImage implements ui.Image, StackTraceDebugger {
             'be able to resurrect it once it has been garbage collected.');
         return;
       }
-      final int originalWidth = skImage.width();
-      final int originalHeight = skImage.height();
+      final int originalWidth = skImage.width().toInt();
+      final int originalHeight = skImage.height().toInt();
       box = SkiaObjectBox<CkImage, SkImage>.resurrectable(this, skImage, () {
         final SkImage? skImage = canvasKit.MakeImage(
           SkImageInfo(
@@ -277,13 +277,13 @@ class CkImage implements ui.Image, StackTraceDebugger {
   @override
   int get width {
     assert(_debugCheckIsNotDisposed());
-    return skImage.width();
+    return skImage.width().toInt();
   }
 
   @override
   int get height {
     assert(_debugCheckIsNotDisposed());
-    return skImage.height();
+    return skImage.height().toInt();
   }
 
   @override
@@ -328,8 +328,8 @@ class CkImage implements ui.Image, StackTraceDebugger {
         alphaType: alphaType,
         colorType: colorType,
         colorSpace: colorSpace,
-        width: skImage.width(),
-        height: skImage.height(),
+        width: skImage.width().toInt(),
+        height: skImage.height().toInt(),
       );
       bytes = skImage.readPixels(0, 0, imageInfo);
     } else {

--- a/lib/web_ui/lib/src/engine/canvaskit/image_wasm_codecs.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image_wasm_codecs.dart
@@ -45,8 +45,8 @@ class CkAnimatedImage extends ManagedSkiaObject<SkAnimatedImage>
       );
     }
 
-    _frameCount = animatedImage.getFrameCount();
-    _repetitionCount = animatedImage.getRepetitionCount();
+    _frameCount = animatedImage.getFrameCount().toInt();
+    _repetitionCount = animatedImage.getRepetitionCount().toInt();
 
     // Normally CanvasKit initializes `SkAnimatedImage` to point to the first
     // frame in the animation. However, if the Skia object has been deleted then
@@ -116,7 +116,7 @@ class CkAnimatedImage extends ManagedSkiaObject<SkAnimatedImage>
     // current Skia frame, then advance SkAnimatedImage to the next frame, and
     // return the current frame.
     final ui.FrameInfo currentFrame = AnimatedImageFrameInfo(
-      Duration(milliseconds: animatedImage.currentFrameDuration()),
+      Duration(milliseconds: animatedImage.currentFrameDuration().toInt()),
       CkImage(animatedImage.makeImageAtCurrentFrame()),
     );
 

--- a/lib/web_ui/lib/src/engine/canvaskit/image_web_codecs.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image_web_codecs.dart
@@ -179,8 +179,8 @@ class CkBrowserImageDecoder implements ui.Codec {
       // package:js bindings don't work with getters that return a Promise, which
       // is why js_util is used instead.
       await promiseToFuture<void>(getJsProperty(webDecoder, 'completed'));
-      frameCount = webDecoder.tracks.selectedTrack!.frameCount;
-      repetitionCount = webDecoder.tracks.selectedTrack!.repetitionCount;
+      frameCount = webDecoder.tracks.selectedTrack!.frameCount.toInt();
+      repetitionCount = webDecoder.tracks.selectedTrack!.repetitionCount.toInt();
 
       _cachedWebDecoder = webDecoder;
 
@@ -234,15 +234,15 @@ class CkBrowserImageDecoder implements ui.Codec {
         alphaType: canvasKit.AlphaType.Premul,
         colorType: canvasKit.ColorType.RGBA_8888,
         colorSpace: SkColorSpaceSRGB,
-        width: frame.displayWidth,
-        height: frame.displayHeight,
+        width: frame.displayWidth.toInt(),
+        height: frame.displayHeight.toInt(),
       ),
     );
 
     // Duration can be null if the image is not animated. However, Flutter
     // requires a non-null value. 0 indicates that the frame is meant to be
     // displayed indefinitely, which is fine for a static image.
-    final Duration duration = Duration(microseconds: frame.duration ?? 0);
+    final Duration duration = Duration(microseconds: frame.duration?.toInt() ?? 0);
 
     if (skImage == null) {
       throw ImageCodecException(
@@ -445,7 +445,7 @@ bool _shouldReadPixelsUnmodified(VideoFrame videoFrame, ui.ImageByteFormat forma
 }
 
 Future<ByteBuffer> readVideoFramePixelsUnmodified(VideoFrame videoFrame) async {
-  final int size = videoFrame.allocationSize();
+  final int size = videoFrame.allocationSize().toInt();
   final Uint8List destination = Uint8List(size);
   final JsPromise copyPromise = videoFrame.copyTo(destination);
   await promiseToFuture<void>(copyPromise);
@@ -453,8 +453,8 @@ Future<ByteBuffer> readVideoFramePixelsUnmodified(VideoFrame videoFrame) async {
 }
 
 Future<Uint8List> encodeVideoFrameAsPng(VideoFrame videoFrame) async {
-  final int width = videoFrame.displayWidth;
-  final int height = videoFrame.displayHeight;
+  final int width = videoFrame.displayWidth.toInt();
+  final int height = videoFrame.displayHeight.toInt();
   final DomCanvasElement canvas = createDomCanvasElement(width: width, height:
       height);
   final DomCanvasRenderingContext2D ctx = canvas.context2D;

--- a/lib/web_ui/lib/src/engine/canvaskit/surface.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/surface.dart
@@ -327,7 +327,7 @@ class Surface {
           antialias: _kUsingMSAA ? 1 : 0,
           majorVersion: webGLVersion,
         ),
-      );
+      ).toInt();
 
       _glContext = glContext;
 
@@ -429,8 +429,8 @@ class CkSurface {
 
   int? get context => _glContext;
 
-  int width() => surface.width();
-  int height() => surface.height();
+  int width() => surface.width().toInt();
+  int height() => surface.height().toInt();
 
   void dispose() {
     if (_isDisposed) {

--- a/lib/web_ui/lib/src/engine/canvaskit/text.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/text.dart
@@ -363,15 +363,15 @@ class CkTextStyle implements ui.TextStyle {
     }
 
     if (decoration != null) {
-      int decorationValue = canvasKit.NoDecoration;
+      int decorationValue = canvasKit.NoDecoration.toInt();
       if (decoration.contains(ui.TextDecoration.underline)) {
-        decorationValue |= canvasKit.UnderlineDecoration;
+        decorationValue |= canvasKit.UnderlineDecoration.toInt();
       }
       if (decoration.contains(ui.TextDecoration.overline)) {
-        decorationValue |= canvasKit.OverlineDecoration;
+        decorationValue |= canvasKit.OverlineDecoration.toInt();
       }
       if (decoration.contains(ui.TextDecoration.lineThrough)) {
-        decorationValue |= canvasKit.LineThroughDecoration;
+        decorationValue |= canvasKit.LineThroughDecoration.toInt();
       }
       properties.decoration = decorationValue;
     }
@@ -785,7 +785,7 @@ class CkParagraph extends SkiaObject<SkParagraph> implements ui.Paragraph {
         break;
     }
     final SkTextRange skRange = paragraph.getWordBoundary(characterPosition);
-    return ui.TextRange(start: skRange.start, end: skRange.end);
+    return ui.TextRange(start: skRange.start.toInt(), end: skRange.end.toInt());
   }
 
   @override
@@ -808,7 +808,7 @@ class CkParagraph extends SkiaObject<SkParagraph> implements ui.Paragraph {
     final int offset = position.offset;
     for (final SkLineMetrics metric in metrics) {
       if (offset >= metric.startIndex && offset <= metric.endIndex) {
-        return ui.TextRange(start: metric.startIndex, end: metric.endIndex);
+        return ui.TextRange(start: metric.startIndex.toInt(), end: metric.endIndex.toInt());
       }
     }
     return ui.TextRange.empty;
@@ -876,7 +876,7 @@ class CkLineMetrics implements ui.LineMetrics {
   double get width => skLineMetrics.width;
 
   @override
-  int get lineNumber => skLineMetrics.lineNumber;
+  int get lineNumber => skLineMetrics.lineNumber.toInt();
 }
 
 class CkParagraphBuilder implements ui.ParagraphBuilder {

--- a/lib/web_ui/lib/src/engine/canvaskit/util.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/util.dart
@@ -35,9 +35,9 @@ Float32List makeFreshSkColor(ui.Color color) {
 
 ui.TextPosition fromPositionWithAffinity(SkTextPosition positionWithAffinity) {
   final ui.TextAffinity affinity =
-      ui.TextAffinity.values[positionWithAffinity.affinity.value];
+      ui.TextAffinity.values[positionWithAffinity.affinity.value.toInt()];
   return ui.TextPosition(
-    offset: positionWithAffinity.pos,
+    offset: positionWithAffinity.pos.toInt(),
     affinity: affinity,
   );
 }

--- a/lib/web_ui/lib/src/engine/configuration.dart
+++ b/lib/web_ui/lib/src/engine/configuration.dart
@@ -204,7 +204,8 @@ class FlutterConfiguration {
   ///
   /// This value can be specified using either the `FLUTTER_WEB_MAXIMUM_SURFACES`
   /// environment variable, or using the runtime configuration.
-  int get canvasKitMaximumSurfaces => _configuration?.canvasKitMaximumSurfaces ?? _defaultCanvasKitMaximumSurfaces;
+  int get canvasKitMaximumSurfaces =>
+      _configuration?.canvasKitMaximumSurfaces?.toInt() ?? _defaultCanvasKitMaximumSurfaces;
   static const int _defaultCanvasKitMaximumSurfaces = int.fromEnvironment(
     'FLUTTER_WEB_MAXIMUM_SURFACES',
     defaultValue: 8,
@@ -251,7 +252,7 @@ class JsFlutterConfiguration {}
 extension JsFlutterConfigurationExtension on JsFlutterConfiguration {
   external String? get canvasKitBaseUrl;
   external bool? get canvasKitForceCpuOnly;
-  external int? get canvasKitMaximumSurfaces;
+  external double? get canvasKitMaximumSurfaces;
   external bool? get debugShowSemanticsNodes;
   external DomElement? get hostElement;
   external String? get renderer;

--- a/lib/web_ui/lib/src/engine/dom.dart
+++ b/lib/web_ui/lib/src/engine/dom.dart
@@ -28,13 +28,11 @@ class DomWindow extends DomEventTarget {}
 
 extension DomWindowExtension on DomWindow {
   external DomConsole get console;
-  external num get devicePixelRatio;
+  external double get devicePixelRatio;
   external DomDocument get document;
   external DomHistory get history;
-  int? get innerHeight =>
-      js_util.getProperty<double?>(this, 'innerHeight')?.toInt();
-  int? get innerWidth =>
-      js_util.getProperty<double?>(this, 'innerWidth')?.toInt();
+  external double? get innerHeight;
+  external double? get innerWidth;
   external DomLocation get location;
   external DomNavigator get navigator;
   external DomVisualViewport? get visualViewport;
@@ -52,9 +50,7 @@ extension DomWindowExtension on DomWindow {
         if (pseudoElt != null) pseudoElt
       ]) as DomCSSStyleDeclaration;
   external DomScreen? get screen;
-  int requestAnimationFrame(DomRequestAnimationFrameCallback callback) =>
-      js_util.callMethod<double>(this, 'requestAnimationFrame',
-          <Object>[callback]).toInt();
+  external double requestAnimationFrame(DomRequestAnimationFrameCallback callback);
   void postMessage(Object message, String targetOrigin,
           [List<DomMessagePort>? messagePorts]) =>
       js_util.callMethod(this, 'postMessage', <Object?>[
@@ -92,8 +88,7 @@ class DomNavigator {}
 
 extension DomNavigatorExtension on DomNavigator {
   external DomClipboard? get clipboard;
-  int? get maxTouchPoints =>
-      js_util.getProperty<double?>(this, 'maxTouchPoints')?.toInt();
+  external double? get maxTouchPoints;
   external String get vendor;
   external String get language;
   external String? get platform;
@@ -179,7 +174,7 @@ class DomEvent {}
 
 extension DomEventExtension on DomEvent {
   external DomEventTarget? get target;
-  external num? get timeStamp;
+  external double? get timeStamp;
   external String get type;
   external void preventDefault();
   external void stopPropagation();
@@ -203,10 +198,8 @@ DomEvent createDomEvent(String type, String name) {
 class DomProgressEvent extends DomEvent {}
 
 extension DomProgressEventExtension on DomProgressEvent {
-  int? get loaded =>
-    js_util.getProperty<double?>(this, 'loaded')?.toInt();
-  int? get total =>
-    js_util.getProperty<double?>(this, 'total')?.toInt();
+  external double? get loaded;
+  external double? get total;
 }
 
 @JS()
@@ -257,10 +250,8 @@ DomElement createDomElement(String tag) => domDocument.createElement(tag);
 extension DomElementExtension on DomElement {
   Iterable<DomElement> get children => createDomListWrapper<DomElement>(
       js_util.getProperty<_DomList>(this, 'children'));
-  int get clientHeight =>
-      js_util.getProperty<double>(this, 'clientHeight').toInt();
-  int get clientWidth =>
-      js_util.getProperty<double>(this, 'clientWidth').toInt();
+  external double get clientHeight;
+  external double get clientWidth;
   external String get id;
   external set id(String id);
   external set innerHtml(String? html);
@@ -280,18 +271,13 @@ extension DomElementExtension on DomElement {
   external void setAttribute(String name, Object value);
   void appendText(String text) => append(createDomText(text));
   external void removeAttribute(String name);
-  set tabIndex(int? value) =>
-      js_util.setProperty<double?>(this, 'tabIndex', value?.toDouble());
-  int? get tabIndex =>
-      js_util.getProperty<double?>(this, 'tabIndex')?.toInt();
+  external set tabIndex(double? value);
+  external double? get tabIndex;
   external void focus();
-  int get scrollTop => js_util.getProperty<double>(this, 'scrollTop').toInt();
-  set scrollTop(int value) =>
-      js_util.setProperty<double>(this, 'scrollTop', value.toDouble());
-  int get scrollLeft =>
-      js_util.getProperty<double>(this, 'scrollLeft').toInt();
-  set scrollLeft(int value) =>
-      js_util.setProperty<double>(this, 'scrollLeft', value.toDouble());
+  external double get scrollTop;
+  external set scrollTop(double value);
+  external double get scrollLeft;
+  external set scrollLeft(double value);
   external DomTokenList get classList;
   external set className(String value);
   external String get className;
@@ -471,8 +457,7 @@ extension DomCSSStyleDeclarationExtension on DomCSSStyleDeclaration {
 class DomHTMLElement extends DomElement {}
 
 extension DomHTMLElementExtension on DomHTMLElement {
-  int get offsetWidth =>
-      js_util.getProperty<double>(this, 'offsetWidth').toInt();
+  external double get offsetWidth;
 }
 
 @JS()
@@ -510,14 +495,10 @@ extension DomHTMLImageElementExtension on DomHTMLImageElement {
   external set alt(String? value);
   external String? get src;
   external set src(String? value);
-  int get naturalWidth =>
-      js_util.getProperty<double>(this, 'naturalWidth').toInt();
-  int get naturalHeight =>
-      js_util.getProperty<double>(this, 'naturalHeight').toInt();
-  set width(int? value) =>
-      js_util.setProperty<double?>(this, 'width', value?.toDouble());
-  set height(int? value) =>
-      js_util.setProperty<double?>(this, 'height', value?.toDouble());
+  external double get naturalWidth;
+  external double get naturalHeight;
+  external set width(double? value);
+  external set height(double? value);
   Future<dynamic> decode() =>
       js_util.promiseToFuture(js_util.callMethod(this, 'decode', <Object>[]));
 }
@@ -600,23 +581,19 @@ DomCanvasElement createDomCanvasElement({int? width, int? height}) {
   final DomCanvasElement canvas =
       domWindow.document.createElement('canvas') as DomCanvasElement;
   if (width != null) {
-    canvas.width = width;
+    canvas.width = width.toDouble();
   }
   if (height != null) {
-    canvas.height = height;
+    canvas.height = height.toDouble();
   }
   return canvas;
 }
 
 extension DomCanvasElementExtension on DomCanvasElement {
-  int? get width =>
-      js_util.getProperty<double?>(this, 'width')?.toInt();
-  set width(int? value) =>
-      js_util.setProperty<double?>(this, 'width', value?.toDouble());
-  int? get height =>
-      js_util.getProperty<double?>(this, 'height')?.toInt();
-  set height(int? value) =>
-      js_util.setProperty<double?>(this, 'height', value?.toDouble());
+  external double? get width;
+  external set width(double? value);
+  external double? get height;
+  external set height(double? value);
   external bool? get isConnected;
   String toDataURL([String type = 'image/png']) =>
       js_util.callMethod(this, 'toDataURL', <Object>[type]);
@@ -752,8 +729,7 @@ extension DomXMLHttpRequestExtension on DomXMLHttpRequest {
   external dynamic get response;
   external String? get responseText;
   external String get responseType;
-  int? get status =>
-      js_util.getProperty<double?>(this, 'status')?.toInt();
+  external double? get status;
   external set responseType(String value);
   void open(String method, String url, [bool? async]) => js_util.callMethod(
       this, 'open', <Object>[method, url, if (async != null) async]);
@@ -771,7 +747,7 @@ Future<DomXMLHttpRequest> domHttpRequest(String url,
   }
 
   xhr.addEventListener('load', allowInterop((DomEvent e) {
-    final int status = xhr.status!;
+    final int status = xhr.status!.toInt();
     final bool accepted = status >= 200 && status < 300;
     final bool fileUri = status == 0;
     final bool notModified = status == 304;
@@ -807,7 +783,7 @@ DomText createDomText(String data) => domDocument.createTextNode(data);
 class DomTextMetrics {}
 
 extension DomTextMetricsExtension on DomTextMetrics {
-  external num? get width;
+  external double? get width;
 }
 
 @JS()
@@ -825,14 +801,14 @@ extension DomExceptionExtension on DomException {
 class DomRectReadOnly {}
 
 extension DomRectReadOnlyExtension on DomRectReadOnly {
-  external num get x;
-  external num get y;
-  external num get width;
-  external num get height;
-  external num get top;
-  external num get right;
-  external num get bottom;
-  external num get left;
+  external double get x;
+  external double get y;
+  external double get width;
+  external double get height;
+  external double get top;
+  external double get right;
+  external double get bottom;
+  external double get left;
 }
 
 DomRect createDomRectFromPoints(DomPoint a, DomPoint b) {
@@ -884,8 +860,8 @@ typedef DomFontFaceSetForEachCallback = void Function(
 class DomVisualViewport extends DomEventTarget {}
 
 extension DomVisualViewportExtension on DomVisualViewport {
-  external num? get height;
-  external num? get width;
+  external double? get height;
+  external double? get width;
 }
 
 @JS()
@@ -900,10 +876,10 @@ extension DomHTMLTextAreaElementExtension on DomHTMLTextAreaElement {
   external void select();
   external set placeholder(String? value);
   external set name(String value);
-  external int? get selectionStart;
-  external int? get selectionEnd;
-  external set selectionStart(int? value);
-  external set selectionEnd(int? value);
+  external double? get selectionStart;
+  external double? get selectionEnd;
+  external set selectionStart(double? value);
+  external set selectionEnd(double? value);
   external String? get value;
   void setSelectionRange(int start, int end, [String? direction]) =>
       js_util.callMethod(this, 'setSelectionRange',
@@ -949,10 +925,8 @@ extension DomKeyboardEventExtension on DomKeyboardEvent {
   external String? get code;
   external bool get ctrlKey;
   external String? get key;
-  int get keyCode =>
-      js_util.getProperty<double>(this, 'keyCode').toInt();
-  int get location =>
-      js_util.getProperty<double>(this, 'location').toInt();
+  external double get keyCode;
+  external double get location;
   external bool get metaKey;
   external bool? get repeat;
   external bool get shiftKey;
@@ -1107,16 +1081,14 @@ DomPath2D createDomPath2D([Object? path]) =>
 class DomMouseEvent extends DomUIEvent {}
 
 extension DomMouseEventExtension on DomMouseEvent {
-  external num get clientX;
-  external num get clientY;
-  external num get offsetX;
-  external num get offsetY;
+  external double get clientX;
+  external double get clientY;
+  external double get offsetX;
+  external double get offsetY;
   DomPoint get client => DomPoint(clientX, clientY);
   DomPoint get offset => DomPoint(offsetX, offsetY);
-  int get button =>
-      js_util.getProperty<double>(this, 'button').toInt();
-  int? get buttons =>
-      js_util.getProperty<double?>(this, 'buttons')?.toInt();
+  external double get button;
+  external double? get buttons;
   external bool getModifierState(String keyArg);
 }
 
@@ -1129,14 +1101,11 @@ DomMouseEvent createDomMouseEvent(String type, [Map<dynamic, dynamic>? init]) =>
 class DomPointerEvent extends DomMouseEvent {}
 
 extension DomPointerEventExtension on DomPointerEvent {
-  int? get pointerId =>
-      js_util.getProperty<double?>(this, 'pointerId')?.toInt();
+  external double? get pointerId;
   external String? get pointerType;
-  external num? get pressure;
-  int? get tiltX =>
-      js_util.getProperty<double?>(this, 'tiltX')?.toInt();
-  int? get tiltY =>
-      js_util.getProperty<double?>(this, 'tiltY')?.toInt();
+  external double? get pressure;
+  external double? get tiltX;
+  external double? get tiltY;
   List<DomPointerEvent> getCoalescedEvents() =>
       js_util.callMethod<List<Object?>>(
           this, 'getCoalescedEvents', <Object>[]).cast<DomPointerEvent>();
@@ -1152,10 +1121,9 @@ DomPointerEvent createDomPointerEvent(String type,
 class DomWheelEvent extends DomMouseEvent {}
 
 extension DomWheelEventExtension on DomWheelEvent {
-  external num get deltaX;
-  external num get deltaY;
-  int get deltaMode =>
-      js_util.getProperty<double>(this, 'deltaMode').toInt();
+  external double get deltaX;
+  external double get deltaY;
+  external double get deltaMode;
 }
 
 @JS()
@@ -1177,10 +1145,9 @@ extension DomTouchEventExtension on DomTouchEvent {
 class DomTouch {}
 
 extension DomTouchExtension on DomTouch {
-  int? get identifier =>
-      js_util.getProperty<double?>(this, 'identifier')?.toInt();
-  external num get clientX;
-  external num get clientY;
+  external double? get identifier;
+  external double get clientX;
+  external double get clientY;
   DomPoint get client => DomPoint(clientX, clientY);
 }
 
@@ -1220,14 +1187,10 @@ extension DomHTMLInputElementExtension on DomHTMLInputElement {
   external set placeholder(String? value);
   external set name(String? value);
   external set autocomplete(String value);
-  int? get selectionStart =>
-      js_util.getProperty<double?>(this, 'selectionStart')?.toInt();
-  int? get selectionEnd =>
-      js_util.getProperty<double?>(this, 'selectionEnd')?.toInt();
-  set selectionStart(int? value) =>
-      js_util.setProperty<double?>(this, 'selectionStart', value?.toDouble());
-  set selectionEnd(int? value) =>
-      js_util.setProperty<double?>(this, 'selectionEnd', value?.toDouble());
+  external double? get selectionStart;
+  external double? get selectionEnd;
+  external set selectionStart(double? value);
+  external set selectionEnd(double? value);
   void setSelectionRange(int start, int end, [String? direction]) =>
       js_util.callMethod(this, 'setSelectionRange',
           <Object>[start.toDouble(), end.toDouble(),
@@ -1276,14 +1239,10 @@ DomHTMLLabelElement createDomHTMLLabelElement() =>
 class DomOffscreenCanvas extends DomEventTarget {}
 
 extension DomOffscreenCanvasExtension on DomOffscreenCanvas {
-  int? get height =>
-      js_util.getProperty<double?>(this, 'height')?.toInt();
-  int? get width =>
-      js_util.getProperty<double?>(this, 'width')?.toInt();
-  set height(int? value) =>
-      js_util.setProperty<double?>(this, 'height', value?.toDouble());
-  set width(int? value) =>
-      js_util.setProperty<double?>(this, 'width', value?.toDouble());
+  external double? get height;
+  external double? get width;
+  external set height(double? value);
+  external set width(double? value);
   Object? getContext(String contextType, [Map<dynamic, dynamic>? attributes]) {
     return js_util.callMethod(this, 'getContext', <Object?>[
       contextType,
@@ -1348,10 +1307,10 @@ class DomCSSStyleSheet extends DomStyleSheet {}
 
 extension DomCSSStyleSheetExtension on DomCSSStyleSheet {
   external DomCSSRuleList get cssRules;
-  int insertRule(String rule, [int? index]) => js_util
+  double insertRule(String rule, [int? index]) => js_util
       .callMethod<double>(
           this, 'insertRule',
-          <Object>[rule, if (index != null) index.toDouble()]).toInt();
+          <Object>[rule, if (index != null) index.toDouble()]);
 }
 
 @JS()
@@ -1460,8 +1419,7 @@ extension DomMessageChannelExtension on DomMessageChannel {
 class DomCSSRuleList {}
 
 extension DomCSSRuleListExtension on DomCSSRuleList {
-  int get length =>
-      js_util.getProperty<double>(this, 'length').toInt();
+  external double get length;
 }
 
 /// A factory to create `TrustedTypePolicy` objects.
@@ -1620,8 +1578,7 @@ bool domInstanceOfString(Object? element, String objectType) =>
 class _DomList {}
 
 extension DomListExtension on _DomList {
-  int get length =>
-      js_util.getProperty<double>(this, 'length').toInt();
+  external double get length;
   DomNode item(int index) =>
       js_util.callMethod<DomNode>(this, 'item', <Object>[index.toDouble()]);
 }
@@ -1655,7 +1612,7 @@ class _DomListWrapper<T> extends Iterable<T> {
 
   /// Override the length to avoid iterating through the whole collection.
   @override
-  int get length => list.length;
+  int get length => list.length.toInt();
 }
 
 /// This is a work around for a `TypeError` which can be triggered by calling
@@ -1681,9 +1638,9 @@ class DomV8BreakIterator {}
 
 extension DomV8BreakIteratorExtension on DomV8BreakIterator {
   external void adoptText(String text);
-  external int first();
-  external int next();
-  external int current();
+  external double first();
+  external double next();
+  external double current();
   external String breakType();
 }
 

--- a/lib/web_ui/lib/src/engine/embedder.dart
+++ b/lib/web_ui/lib/src/engine/embedder.dart
@@ -340,7 +340,7 @@ class FlutterViewEmbedder {
       // Firefox returns correct values for innerHeight, innerWidth.
       // Firefox also triggers domWindow.onResize therefore this timer does
       // not need to be set up for Firefox.
-      final int initialInnerWidth = domWindow.innerWidth!;
+      final int initialInnerWidth = domWindow.innerWidth!.toInt();
       // Counts how many times screen size was checked. It is checked up to 5
       // times.
       int checkCount = 0;
@@ -551,7 +551,7 @@ void applyGlobalCssRulesToSheet(
     // - See: https://github.com/flutter/flutter/issues/44803
     sheet.insertRule(
       'flt-paragraph, flt-span {line-height: 100%;}',
-      sheet.cssRules.length,
+      sheet.cssRules.length.toInt(),
     );
   }
 
@@ -571,7 +571,7 @@ void applyGlobalCssRulesToSheet(
       left: 0;
     }
     ''',
-    sheet.cssRules.length,
+    sheet.cssRules.length.toInt(),
   );
 
   if (isWebKit) {
@@ -579,7 +579,7 @@ void applyGlobalCssRulesToSheet(
         'flt-semantics input[type=range]::-webkit-slider-thumb {'
         '  -webkit-appearance: none;'
         '}',
-        sheet.cssRules.length);
+        sheet.cssRules.length.toInt());
   }
 
   if (isFirefox) {
@@ -587,12 +587,12 @@ void applyGlobalCssRulesToSheet(
         'input::-moz-selection {'
         '  background-color: transparent;'
         '}',
-        sheet.cssRules.length);
+        sheet.cssRules.length.toInt());
     sheet.insertRule(
         'textarea::-moz-selection {'
         '  background-color: transparent;'
         '}',
-        sheet.cssRules.length);
+        sheet.cssRules.length.toInt());
   } else {
     // On iOS, the invisible semantic text field has a visible cursor and
     // selection highlight. The following 2 CSS rules force everything to be
@@ -601,12 +601,12 @@ void applyGlobalCssRulesToSheet(
         'input::selection {'
         '  background-color: transparent;'
         '}',
-        sheet.cssRules.length);
+        sheet.cssRules.length.toInt());
     sheet.insertRule(
         'textarea::selection {'
         '  background-color: transparent;'
         '}',
-        sheet.cssRules.length);
+        sheet.cssRules.length.toInt());
   }
   sheet.insertRule('''
     flt-semantics input,
@@ -614,7 +614,7 @@ void applyGlobalCssRulesToSheet(
     flt-semantics [contentEditable="true"] {
     caret-color: transparent;
   }
-  ''', sheet.cssRules.length);
+  ''', sheet.cssRules.length.toInt());
 
   // By default on iOS, Safari would highlight the element that's being tapped
   // on using gray background. This CSS rule disables that.
@@ -623,7 +623,7 @@ void applyGlobalCssRulesToSheet(
       $glassPaneTagName * {
       -webkit-tap-highlight-color: transparent;
     }
-    ''', sheet.cssRules.length);
+    ''', sheet.cssRules.length.toInt());
   }
 
   // Hide placeholder text
@@ -633,7 +633,7 @@ void applyGlobalCssRulesToSheet(
       opacity: 0;
     }
     ''',
-    sheet.cssRules.length,
+    sheet.cssRules.length.toInt(),
   );
 
   // This css prevents an autofill overlay brought by the browser during
@@ -647,7 +647,7 @@ void applyGlobalCssRulesToSheet(
       .transparentTextEditing:-webkit-autofill:active {
         -webkit-transition-delay: 99999s;
       }
-    ''', sheet.cssRules.length);
+    ''', sheet.cssRules.length.toInt());
   }
 }
 

--- a/lib/web_ui/lib/src/engine/html/scene.dart
+++ b/lib/web_ui/lib/src/engine/html/scene.dart
@@ -48,8 +48,8 @@ class PersistedScene extends PersistedContainerSurface {
     // TODO(yjbanov): in the add2app scenario where we might be hosted inside
     //                a custom element, this will be different. We will need to
     //                update this code when we add add2app support.
-    final double screenWidth = domWindow.innerWidth!.toDouble();
-    final double screenHeight = domWindow.innerHeight!.toDouble();
+    final double screenWidth = domWindow.innerWidth!;
+    final double screenHeight = domWindow.innerHeight!;
     localClipBounds = ui.Rect.fromLTRB(0, 0, screenWidth, screenHeight);
     projectedClip = null;
   }

--- a/lib/web_ui/lib/src/engine/html/surface_stats.dart
+++ b/lib/web_ui/lib/src/engine/html/surface_stats.dart
@@ -97,7 +97,7 @@ class DebugSurfaceStats {
 DomCanvasRenderingContext2D? _debugSurfaceStatsOverlayCtx;
 
 void debugRepaintSurfaceStatsOverlay(PersistedScene scene) {
-  final int overlayWidth = domWindow.innerWidth!;
+  final int overlayWidth = domWindow.innerWidth!.toInt();
   const int rowHeight = 30;
   const int rowCount = 4;
   const int overlayHeight = rowHeight * rowCount;
@@ -296,7 +296,7 @@ void debugPrintSurfaceStats(PersistedScene scene, int frameNumber) {
     final int pixelCount = canvasElements
         .cast<DomCanvasElement>()
         .map<int>((DomCanvasElement e) {
-      final int pixels = e.width! * e.height!;
+      final int pixels = (e.width! * e.height!).toInt();
       canvasInfo.writeln('    - ${e.width!} x ${e.height!} = $pixels pixels');
       return pixels;
     }).fold(0, (int total, int pixels) => total + pixels);

--- a/lib/web_ui/lib/src/engine/html_image_codec.dart
+++ b/lib/web_ui/lib/src/engine/html_image_codec.dart
@@ -53,8 +53,8 @@ class HtmlCodec implements ui.Codec {
       // ignore: unawaited_futures
       imgElement.decode().then((dynamic _) {
         chunkCallback?.call(100, 100);
-        int naturalWidth = imgElement.naturalWidth;
-        int naturalHeight = imgElement.naturalHeight;
+        int naturalWidth = imgElement.naturalWidth.toInt();
+        int naturalHeight = imgElement.naturalHeight.toInt();
         // Workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=700533.
         if (naturalWidth == 0 && naturalHeight == 0 && browserEngine == BrowserEngine.firefox) {
           const int kDefaultImageSizeFallback = 300;
@@ -103,8 +103,8 @@ class HtmlCodec implements ui.Codec {
       imgElement.removeEventListener('error', errorListener);
       final HtmlImage image = HtmlImage(
         imgElement,
-        imgElement.naturalWidth,
-        imgElement.naturalHeight,
+        imgElement.naturalWidth.toInt(),
+        imgElement.naturalHeight.toInt(),
       );
       completer.complete(SingleFrameInfo(image));
     });
@@ -188,8 +188,8 @@ class HtmlImage implements ui.Image {
       case ui.ImageByteFormat.rawRgba:
       case ui.ImageByteFormat.rawStraightRgba:
         final DomCanvasElement canvas = createDomCanvasElement()
-          ..width = width
-          ..height = height;
+          ..width = width.toDouble()
+          ..height = height.toDouble();
         final DomCanvasRenderingContext2D ctx = canvas.context2D;
         ctx.drawImage(imgElement, 0, 0);
         final DomImageData imageData = ctx.getImageData(0, 0, width, height);

--- a/lib/web_ui/lib/src/engine/keyboard_binding.dart
+++ b/lib/web_ui/lib/src/engine/keyboard_binding.dart
@@ -190,9 +190,9 @@ class FlutterHtmlKeyboardEvent {
   String get type => _event.type;
   String? get code => _event.code;
   String? get key => _event.key;
-  int get keyCode => _event.keyCode;
+  int get keyCode => _event.keyCode.toInt();
   bool? get repeat => _event.repeat;
-  int? get location => _event.location;
+  int? get location => _event.location.toInt();
   num? get timeStamp => _event.timeStamp;
   bool get altKey => _event.altKey;
   bool get ctrlKey => _event.ctrlKey;

--- a/lib/web_ui/lib/src/engine/picture.dart
+++ b/lib/web_ui/lib/src/engine/picture.dart
@@ -64,8 +64,8 @@ class EnginePicture implements ui.Picture {
     final String imageDataUrl = canvas.toDataUrl();
     final DomHTMLImageElement imageElement = createDomHTMLImageElement()
       ..src = imageDataUrl
-      ..width = width
-      ..height = height;
+      ..width = width.toDouble()
+      ..height = height.toDouble();
 
     // The image loads asynchronously. We need to wait before returning,
     // otherwise the returned HtmlImage will be temporarily unusable.

--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -185,9 +185,9 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
 
   /// Returns device pixel ratio returned by browser.
   static double get browserDevicePixelRatio {
-    final double? ratio = domWindow.devicePixelRatio as double?;
-    // Guard against WebOS returning 0 and other browsers returning null.
-    return (ratio == null || ratio == 0.0) ? 1.0 : ratio;
+    final double ratio = domWindow.devicePixelRatio;
+    // Guard against WebOS returning 0.
+    return (ratio == 0.0) ? 1.0 : ratio;
   }
 
   /// A callback invoked when any window begins a frame.

--- a/lib/web_ui/lib/src/engine/safe_browser_api.dart
+++ b/lib/web_ui/lib/src/engine/safe_browser_api.dart
@@ -202,8 +202,8 @@ DomCanvasElement? tryCreateCanvasElement(int width, int height) {
     return null;
   }
   try {
-    canvas.width = width;
-    canvas.height = height;
+    canvas.width = width.toDouble();
+    canvas.height = height.toDouble();
   } catch (e) {
     // It seems the tribal knowledge of why we anticipate an exception while
     // setting width/height on a non-null canvas and why it's OK to return null
@@ -336,14 +336,14 @@ class DecodeOptions {
 class VideoFrame implements DomCanvasImageSource {}
 
 extension VideoFrameExtension on VideoFrame {
-  external int allocationSize();
+  external double allocationSize();
   external JsPromise copyTo(Uint8List destination);
   external String? get format;
-  external int get codedWidth;
-  external int get codedHeight;
-  external int get displayWidth;
-  external int get displayHeight;
-  external int? get duration;
+  external double get codedWidth;
+  external double get codedHeight;
+  external double get displayWidth;
+  external double get displayHeight;
+  external double? get duration;
   external VideoFrame clone();
   external void close();
 }
@@ -374,8 +374,8 @@ extension ImageTrackListExtension on ImageTrackList {
 class ImageTrack {}
 
 extension ImageTrackExtension on ImageTrack {
-  external int get repetitionCount;
-  external int get frameCount;
+  external double get repetitionCount;
+  external double get frameCount;
 }
 
 void scaleCanvas2D(Object context2d, num x, num y) {
@@ -990,11 +990,11 @@ class OffScreenCanvas {
       width = requestedWidth;
       height = requestedHeight;
       if(offScreenCanvas != null) {
-        offScreenCanvas!.width = requestedWidth;
-        offScreenCanvas!.height = requestedHeight;
+        offScreenCanvas!.width = requestedWidth.toDouble();
+        offScreenCanvas!.height = requestedHeight.toDouble();
       } else if (canvasElement != null) {
-        canvasElement!.width = requestedWidth;
-        canvasElement!.height = requestedHeight;
+        canvasElement!.width = requestedWidth.toDouble();
+        canvasElement!.height = requestedHeight.toDouble();
         _updateCanvasCssSize(canvasElement!);
       }
     }

--- a/lib/web_ui/lib/src/engine/semantics/scrollable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/scrollable.dart
@@ -131,10 +131,10 @@ class Scrollable extends RoleManager {
   /// The value of "scrollTop" or "scrollLeft", depending on the scroll axis.
   int get _domScrollPosition {
     if (semanticsObject.isVerticalScrollContainer) {
-      return semanticsObject.element.scrollTop;
+      return semanticsObject.element.scrollTop.toInt();
     } else {
       assert(semanticsObject.isHorizontalScrollContainer);
-      return semanticsObject.element.scrollLeft;
+      return semanticsObject.element.scrollLeft.toInt();
     }
   }
 
@@ -167,9 +167,9 @@ class Scrollable extends RoleManager {
         ..width = '${rect.width.round()}px'
         ..height = '${canonicalNeutralScrollPosition}px';
 
-      element.scrollTop = canonicalNeutralScrollPosition;
+      element.scrollTop = canonicalNeutralScrollPosition.toDouble();
       // Read back because the effective value depends on the amount of content.
-      _effectiveNeutralScrollPosition = element.scrollTop;
+      _effectiveNeutralScrollPosition = element.scrollTop.toInt();
       semanticsObject
         ..verticalContainerAdjustment =
             _effectiveNeutralScrollPosition.toDouble()
@@ -184,9 +184,9 @@ class Scrollable extends RoleManager {
         ..width = '${canonicalNeutralScrollPosition}px'
         ..height = '${rect.height.round()}px';
 
-      element.scrollLeft = canonicalNeutralScrollPosition;
+      element.scrollLeft = canonicalNeutralScrollPosition.toDouble();
       // Read back because the effective value depends on the amount of content.
-      _effectiveNeutralScrollPosition = element.scrollLeft;
+      _effectiveNeutralScrollPosition = element.scrollLeft.toInt();
       semanticsObject
         ..verticalContainerAdjustment = 0.0
         ..horizontalContainerAdjustment =

--- a/lib/web_ui/lib/src/engine/text/font_collection.dart
+++ b/lib/web_ui/lib/src/engine/text/font_collection.dart
@@ -289,7 +289,7 @@ class _PolyfillFontManager extends FontManager {
     paragraph.text = _testString;
 
     domDocument.body!.append(paragraph);
-    final int sansSerifWidth = paragraph.offsetWidth;
+    final int sansSerifWidth = paragraph.offsetWidth.toInt();
 
     paragraph.style.fontFamily = "'$family', $fallbackFontName";
 

--- a/lib/web_ui/lib/src/engine/text/line_breaker.dart
+++ b/lib/web_ui/lib/src/engine/text/line_breaker.dart
@@ -80,7 +80,7 @@ class V8LineBreakFragmenter extends TextFragmenter implements LineBreakFragmente
     while (iterator.next() != -1) {
       final LineBreakType type = _getBreakType(iterator);
 
-      final int fragmentEnd = iterator.current();
+      final int fragmentEnd = iterator.current().toInt();
       int trailingNewlines = 0;
       int trailingSpaces = 0;
 
@@ -128,7 +128,7 @@ class V8LineBreakFragmenter extends TextFragmenter implements LineBreakFragmente
 
   /// Gets break type from v8BreakIterator.
   LineBreakType _getBreakType(DomV8BreakIterator iterator) {
-    final int fragmentEnd = iterator.current();
+    final int fragmentEnd = iterator.current().toInt();
 
     // I don't know why v8BreakIterator uses the type "none" to mean "soft break".
     if (iterator.breakType() != 'none') {

--- a/lib/web_ui/lib/src/engine/text/measurement.dart
+++ b/lib/web_ui/lib/src/engine/text/measurement.dart
@@ -102,7 +102,7 @@ double measureSubstring(
   } else {
     final String sub =
       start == 0 && end == text.length ? text : text.substring(start, end);
-    width = canvasContext.measureText(sub).width!.toDouble();
+    width = canvasContext.measureText(sub).width!;
   }
 
   _lastStart = start;

--- a/lib/web_ui/lib/src/engine/text/ruler.dart
+++ b/lib/web_ui/lib/src/engine/text/ruler.dart
@@ -137,7 +137,7 @@ class TextDimensions {
 
   /// The height of the paragraph being measured.
   double get height {
-    double cachedHeight = _readAndCacheMetrics().height as double;
+    double cachedHeight = _readAndCacheMetrics().height;
     if (browserEngine == BrowserEngine.firefox &&
       // In the flutter tester environment, we use a predictable-size for font
       // measurement tests.
@@ -170,7 +170,7 @@ class TextHeightRuler {
   final TextDimensions _dimensions = TextDimensions(domDocument.createElement('flt-paragraph'));
 
   /// The alphabetic baseline for this ruler's [textHeightStyle].
-  late final double alphabeticBaseline = _probe.getBoundingClientRect().bottom.toDouble();
+  late final double alphabeticBaseline = _probe.getBoundingClientRect().bottom;
 
   /// The height for this ruler's [textHeightStyle].
   late final double height = _dimensions.height;

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -724,15 +724,15 @@ class EditingState {
       final DomHTMLInputElement element = domElement! as DomHTMLInputElement;
       return EditingState(
           text: element.value,
-          baseOffset: element.selectionStart,
-          extentOffset: element.selectionEnd);
+          baseOffset: element.selectionStart?.toInt(),
+          extentOffset: element.selectionEnd?.toInt());
     } else if (domInstanceOfString(domElement, 'HTMLTextAreaElement')) {
       final DomHTMLTextAreaElement element = domElement! as
           DomHTMLTextAreaElement;
       return EditingState(
           text: element.value,
-          baseOffset: element.selectionStart,
-          extentOffset: element.selectionEnd);
+          baseOffset: element.selectionStart?.toInt(),
+          extentOffset: element.selectionEnd?.toInt());
     } else {
       throw UnsupportedError('Initialized with unsupported input type');
     }

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -247,14 +247,14 @@ class EngineFlutterWindow extends ui.SingletonFlutterWindow {
           /// text editing to make sure inset is correctly reported to
           /// framework.
           final double docWidth =
-              domDocument.documentElement!.clientWidth.toDouble();
+              domDocument.documentElement!.clientWidth;
           final double docHeight =
-              domDocument.documentElement!.clientHeight.toDouble();
+              domDocument.documentElement!.clientHeight;
           windowInnerWidth = docWidth * devicePixelRatio;
           windowInnerHeight = docHeight * devicePixelRatio;
         } else {
-          windowInnerWidth = viewport.width!.toDouble() * devicePixelRatio;
-          windowInnerHeight = viewport.height!.toDouble() * devicePixelRatio;
+          windowInnerWidth = viewport.width! * devicePixelRatio;
+          windowInnerHeight = viewport.height! * devicePixelRatio;
         }
       } else {
         windowInnerWidth = domWindow.innerWidth! * devicePixelRatio;
@@ -280,7 +280,7 @@ class EngineFlutterWindow extends ui.SingletonFlutterWindow {
         windowInnerHeight =
             domDocument.documentElement!.clientHeight * devicePixelRatio;
       } else {
-        windowInnerHeight = viewport.height!.toDouble() * devicePixelRatio;
+        windowInnerHeight = viewport.height! * devicePixelRatio;
       }
     } else {
       windowInnerHeight = domWindow.innerHeight! * devicePixelRatio;
@@ -309,8 +309,8 @@ class EngineFlutterWindow extends ui.SingletonFlutterWindow {
     double width = 0;
     if (domWindow.visualViewport != null) {
       height =
-          domWindow.visualViewport!.height!.toDouble() * devicePixelRatio;
-      width = domWindow.visualViewport!.width!.toDouble() * devicePixelRatio;
+          domWindow.visualViewport!.height! * devicePixelRatio;
+      width = domWindow.visualViewport!.width! * devicePixelRatio;
     } else {
       height = domWindow.innerHeight! * devicePixelRatio;
       width = domWindow.innerWidth! * devicePixelRatio;

--- a/lib/web_ui/test/engine/surface/scene_builder_test.dart
+++ b/lib/web_ui/test/engine/surface/scene_builder_test.dart
@@ -35,7 +35,7 @@ void testMain() {
     test('pushTransform implements surface lifecycle', () {
       testLayerLifeCycle((ui.SceneBuilder sceneBuilder, ui.EngineLayer? oldLayer) {
         return sceneBuilder.pushTransform(
-            (Matrix4.identity()..scale(domWindow.devicePixelRatio as double)).toFloat64());
+            (Matrix4.identity()..scale(domWindow.devicePixelRatio)).toFloat64());
       }, () {
         return '''<s><flt-transform></flt-transform></s>''';
       });
@@ -595,8 +595,8 @@ void testMain() {
 
     final DomElement content = builder.build().webOnlyRootElement!;
     final DomCanvasElement canvas = content.querySelector('canvas')! as DomCanvasElement;
-    final int unscaledWidth = canvas.width!;
-    final int unscaledHeight = canvas.height!;
+    final int unscaledWidth = canvas.width!.toInt();
+    final int unscaledHeight = canvas.height!.toInt();
 
     // Force update to scene which will utilize reuse code path.
     final SurfaceSceneBuilder builder2 = SurfaceSceneBuilder();
@@ -627,8 +627,8 @@ void testMain() {
 
     final DomElement content = builder.build().webOnlyRootElement!;
     final DomCanvasElement canvas = content.querySelector('canvas')! as DomCanvasElement;
-    final int unscaledWidth = canvas.width!;
-    final int unscaledHeight = canvas.height!;
+    final int unscaledWidth = canvas.width!.toInt();
+    final int unscaledHeight = canvas.height!.toInt();
 
     // Force update to scene which will utilize reuse code path.
     final SurfaceSceneBuilder builder2 = SurfaceSceneBuilder();

--- a/lib/web_ui/test/engine/surface/surface_test.dart
+++ b/lib/web_ui/test/engine/surface/surface_test.dart
@@ -160,7 +160,7 @@ void testMain() {
       final SurfaceSceneBuilder builder1 = SurfaceSceneBuilder();
       final PersistedTransform a1 =
           builder1.pushTransform(
-              (Matrix4.identity()..scale(domWindow.devicePixelRatio as double)).toFloat64()) as PersistedTransform;
+              (Matrix4.identity()..scale(domWindow.devicePixelRatio)).toFloat64()) as PersistedTransform;
       final PersistedOpacity b1 = builder1.pushOpacity(100) as PersistedOpacity;
       final PersistedTransform c1 =
           builder1.pushTransform(Matrix4.identity().toFloat64()) as PersistedTransform;
@@ -181,7 +181,7 @@ void testMain() {
       final SurfaceSceneBuilder builder2 = SurfaceSceneBuilder();
       final PersistedTransform a2 =
           builder2.pushTransform(
-              (Matrix4.identity()..scale(domWindow.devicePixelRatio as double)).toFloat64(),
+              (Matrix4.identity()..scale(domWindow.devicePixelRatio)).toFloat64(),
               oldLayer: a1) as PersistedTransform;
       final PersistedTransform c2 =
           builder2.pushTransform(Matrix4.identity().toFloat64(), oldLayer: c1) as PersistedTransform;


### PR DESCRIPTION
While ints can flow to JS on all backends, Dart2Wasm does not currently support returning ints from JS. The reason is because there is really no way to support this in the general case. This CL does not change any public APIs, but rather instead we introduce tiny trampolines to handle the conversion.