### PR TITLE
[fuchsia][a11y] Set explicit hit regions in flatland embedder

### DIFF
--- a/shell/platform/fuchsia/flutter/flatland_external_view_embedder.h
+++ b/shell/platform/fuchsia/flutter/flatland_external_view_embedder.h
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "flutter/flow/embedded_views.h"
+#include "flutter/flow/rtree.h"
 #include "flutter/fml/logging.h"
 #include "flutter/fml/macros.h"
 #include "flutter/shell/common/canvas_spy.h"
@@ -144,18 +145,29 @@ class FlatlandExternalViewEmbedder final
 
   struct EmbedderLayer {
     EmbedderLayer(const SkISize& frame_size,
-                  std::optional<flutter::EmbeddedViewParams> view_params)
-        : embedded_view_params(std::move(view_params)),
+                  std::optional<flutter::EmbeddedViewParams> view_params,
+                  flutter::RTreeFactory rtree_factory)
+        : rtree(rtree_factory.getInstance()),
+          embedded_view_params(std::move(view_params)),
           recorder(std::make_unique<SkPictureRecorder>()),
           canvas_spy(std::make_unique<flutter::CanvasSpy>(
-              recorder->beginRecording(frame_size.width(),
-                                       frame_size.height()))),
-          surface_size(frame_size) {}
+              recorder->beginRecording(SkRect::Make(frame_size),
+                                       &rtree_factory))),
+          surface_size(frame_size),
+          picture(nullptr) {}
+
+    // Records paint operations applied to this layer's `SkCanvas`.
+    // These records are used to determine which portions of this layer
+    // contain content. The embedder propagates this information to scenic, so
+    // that scenic can accurately decide which portions of this layer may
+    // interact with input.
+    sk_sp<flutter::RTree> rtree;
 
     std::optional<flutter::EmbeddedViewParams> embedded_view_params;
     std::unique_ptr<SkPictureRecorder> recorder;
     std::unique_ptr<flutter::CanvasSpy> canvas_spy;
     SkISize surface_size;
+    sk_sp<SkPicture> picture;
   };
   using EmbedderLayerId = std::optional<uint32_t>;
   constexpr static EmbedderLayerId kRootLayerId = EmbedderLayerId{};

--- a/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland.cc
+++ b/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland.cc
@@ -850,7 +850,7 @@ void FakeFlatland::SetHitRegions(
 
   auto& transform = found_transform->second;
   FML_CHECK(transform);
-  transform->num_hit_regions = regions.size();
+  transform->hit_regions = std::move(regions);
 }
 
 void FakeFlatland::Clear() {

--- a/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland_types.cc
+++ b/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland_types.cc
@@ -72,7 +72,7 @@ std::shared_ptr<FakeTransform> CloneFakeTransform(
                            .children = CloneFakeTransformVector(
                                transform->children, transform_cache),
                            .content = CloneFakeContent(transform->content),
-                           .num_hit_regions = transform->num_hit_regions,
+                           .hit_regions = transform->hit_regions,
                        }));
   FML_CHECK(success);
 
@@ -136,7 +136,7 @@ bool FakeTransform::operator==(const FakeTransform& other) const {
   return id == other.id && translation == other.translation &&
          *clip_bounds == *other.clip_bounds &&
          orientation == other.orientation && children == other.children &&
-         content == other.content && num_hit_regions == other.num_hit_regions;
+         content == other.content && hit_regions == other.hit_regions;
 }
 
 bool FakeGraph::operator==(const FakeGraph& other) const {

--- a/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland_types.h
+++ b/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland_types.h
@@ -15,6 +15,7 @@
 #include <lib/fidl/cpp/interface_request.h>
 #include <zircon/types.h>
 
+#include <algorithm>
 #include <cstdint>
 #include <optional>
 #include <unordered_map>
@@ -96,6 +97,31 @@ inline bool operator==(const fuchsia::ui::composition::ImageProperties& a,
   }
 
   return size_equal;
+}
+
+inline bool operator==(const fuchsia::ui::composition::HitRegion& a,
+                       const fuchsia::ui::composition::HitRegion& b) {
+  return a.region == b.region && a.hit_test == b.hit_test;
+}
+
+inline bool operator!=(const fuchsia::ui::composition::HitRegion& a,
+                       const fuchsia::ui::composition::HitRegion& b) {
+  return !(a == b);
+}
+
+inline bool operator==(
+    const std::vector<fuchsia::ui::composition::HitRegion>& a,
+    const std::vector<fuchsia::ui::composition::HitRegion>& b) {
+  if (a.size() != b.size())
+    return false;
+
+  for (size_t i = 0; i < a.size(); ++i) {
+    if (a[i] != b[i]) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 namespace flutter_runner::testing {
@@ -194,7 +220,7 @@ struct FakeTransform {
 
   std::vector<std::shared_ptr<FakeTransform>> children;
   std::shared_ptr<FakeContent> content;
-  size_t num_hit_regions;
+  std::vector<fuchsia::ui::composition::HitRegion> hit_regions;
 };
 
 struct FakeGraph {


### PR DESCRIPTION
This change enables the screen reader to interact with flutter overlays on flatland (PR #33852 made the same change for GFX).

fxbug.dev/104956

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
