### PR TITLE
[Impeller] Apply the Windows friendly path solution for remaining ImpellerC paths

### DIFF
--- a/impeller/compiler/impellerc_main.cc
+++ b/impeller/compiler/impellerc_main.cc
@@ -77,10 +77,8 @@ bool Main(const fml::CommandLine& command_line) {
   reflector_options.entry_point_name = options.entry_point_name;
   reflector_options.shader_name =
       InferShaderNameFromPath(switches.source_file_name);
-  reflector_options.header_file_name =
-      ToUtf8(std::filesystem::path{switches.reflection_header_name}
-                 .filename()
-                 .native());
+  reflector_options.header_file_name = Utf8FromPath(
+      std::filesystem::path{switches.reflection_header_name}.filename());
 
   // Generate SkSL if needed.
   std::shared_ptr<fml::Mapping> sksl_mapping;

--- a/impeller/compiler/switches.cc
+++ b/impeller/compiler/switches.cc
@@ -100,7 +100,7 @@ static SourceType SourceTypeFromCommandLine(
 Switches::Switches(const fml::CommandLine& command_line)
     : target_platform(TargetPlatformFromCommandLine(command_line)),
       working_directory(std::make_shared<fml::UniqueFD>(fml::OpenDirectory(
-          ToUtf8(std::filesystem::current_path().native()).c_str(),
+          Utf8FromPath(std::filesystem::current_path()).c_str(),
           false,  // create if necessary,
           fml::FilePermission::kRead))),
       source_file_name(command_line.GetOptionValueWithDefault("input", "")),

--- a/impeller/compiler/types.cc
+++ b/impeller/compiler/types.cc
@@ -8,6 +8,7 @@
 #include <sstream>
 
 #include "flutter/fml/logging.h"
+#include "impeller/compiler/utilities.h"
 
 namespace impeller {
 namespace compiler {
@@ -77,7 +78,7 @@ std::string EntryPointFunctionNameFromSourceName(const std::string& file_name,
                                                  SourceType type) {
   std::stringstream stream;
   std::filesystem::path file_path(file_name);
-  stream << ToUtf8(file_path.stem().native()) << "_";
+  stream << Utf8FromPath(file_path.stem()) << "_";
   switch (type) {
     case SourceType::kUnknown:
       stream << "unknown";
@@ -251,15 +252,6 @@ std::string TargetPlatformSLExtension(TargetPlatform platform) {
       return "vk.spirv";
   }
   FML_UNREACHABLE();
-}
-
-std::string ToUtf8(const std::wstring& wstring) {
-  std::wstring_convert<std::codecvt_utf8<wchar_t>> myconv;
-  return myconv.to_bytes(wstring);
-}
-
-std::string ToUtf8(const std::string& string) {
-  return string;
 }
 
 bool TargetPlatformIsOpenGL(TargetPlatform platform) {

--- a/impeller/compiler/types.h
+++ b/impeller/compiler/types.h
@@ -67,9 +67,5 @@ spv::ExecutionModel ToExecutionModel(SourceType type);
 spirv_cross::CompilerMSL::Options::Platform TargetPlatformToMSLPlatform(
     TargetPlatform platform);
 
-std::string ToUtf8(const std::wstring& wstring);
-
-std::string ToUtf8(const std::string& string);
-
 }  // namespace compiler
 }  // namespace impeller


### PR DESCRIPTION
Fixes new engine build issues I'm running into on Windows today:

```
[6880/7798] ACTION //flutter/lib/ui/fixtures/shaders/suppo...pile_supported_op_shaders(//build/toolchain/win:clang_x64)
FAILED: gen/flutter/lib/ui/fixtures/shaders/supported_op_shaders/iplr/145_OpMatrixTimesVector.frag.iplr
C:/Users/bdero/.vpython-root/cf506f/Scripts/python.exe ../../build/gn_run_binary.py impellerc.exe --input=../../flutter/lib/ui/fixtures/shaders/supported_op_shaders/145_OpMatrixTimesVector.frag --include=../../flutter/lib/ui/fixtures/shaders/supported_op_shaders --include=C:/Users/bdero/projects/flutter/engine/src/flutter/impeller/compiler/shader_lib --depfile=gen/flutter/lib/ui/fixtures/shaders/supported_op_shaders/iplr/145_OpMatrixTimesVector.frag.d --sksl --sl=gen/flutter/lib/ui/fixtures/shaders/supported_op_shaders/iplr/145_OpMatrixTimesVector.frag.iplr --spirv=gen/flutter/lib/ui/fixtures/shaders/supported_op_shaders/iplr/145_OpMatrixTimesVector.frag.spirv --iplr
Could not figure out working directory.
Invalid flags specified.

ImpellerC is an offline shader processor and reflection engine.
---------------------------------------------------------------
Valid Argument are:
One of [ --metal-desktop --metal-ios --opengl-desktop --opengl-es --runtime-stage-gles --runtime-stage-metal --sksl --vulkan ]
--input=<glsl_file>
[optional] --input-kind={comp, frag, tesc, tese, vert, }
--sl=<sl_output_file>
--spirv=<spirv_output_file>
[optional] --iplr (causes --sl file to be emitted in iplr format)
[optional] --reflection-json=<reflection_json_file>
[optional] --reflection-header=<reflection_header_file>
[optional] --reflection-cc=<reflection_cc_file>
[optional,multiple] --include=<include_directory>
[optional,multiple] --define=<define>
[optional] --depfile=<depfile_path>
[optional] --json

[6881/7798] ACTION //flutter/lib/ui/fixtures/shaders/suppo...pile_supported_op_shaders(//build/toolchain/win:clang_x64)
FAILED: gen/flutter/lib/ui/fixtures/shaders/supported_op_shaders/iplr/167_OpLogicalAnd.frag.iplr
C:/Users/bdero/.vpython-root/cf506f/Scripts/python.exe ../../build/gn_run_binary.py impellerc.exe --input=../../flutter/lib/ui/fixtures/shaders/supported_op_shaders/167_OpLogicalAnd.frag --include=../../flutter/lib/ui/fixtures/shaders/supported_op_shaders --include=C:/Users/bdero/projects/flutter/engine/src/flutter/impeller/compiler/shader_lib --depfile=gen/flutter/lib/ui/fixtures/shaders/supported_op_shaders/iplr/167_OpLogicalAnd.frag.d --sksl --sl=gen/flutter/lib/ui/fixtures/shaders/supported_op_shaders/iplr/167_OpLogicalAnd.frag.iplr --spirv=gen/flutter/lib/ui/fixtures/shaders/supported_op_shaders/iplr/167_OpLogicalAnd.frag.spirv --iplr
Could not figure out working directory.
Invalid flags specified.

ImpellerC is an offline shader processor and reflection engine.
---------------------------------------------------------------
Valid Argument are:
One of [ --metal-desktop --metal-ios --opengl-desktop --opengl-es --runtime-stage-gles --runtime-stage-metal --sksl --vulkan ]
--input=<glsl_file>
[optional] --input-kind={comp, frag, tesc, tese, vert, }
--sl=<sl_output_file>
--spirv=<spirv_output_file>
[optional] --iplr (causes --sl file to be emitted in iplr format)
[optional] --reflection-json=<reflection_json_file>
[optional] --reflection-header=<reflection_header_file>
[optional] --reflection-cc=<reflection_cc_file>
[optional,multiple] --include=<include_directory>
[optional,multiple] --define=<define>
[optional] --depfile=<depfile_path>
[optional] --json

[7744/7798] STAMP obj/flutter/tools/font-subset/font-subset.stamp
ninja: build stopped: cannot make progress due to previous errors.
```

Replacing the working directory path alone works for the above, but I went ahead and just replaced the couple of other remaining paths/deleted the non-working utils.