### PR TITLE
Install CIPD ninja using DEPS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ docs/doxygen/
 xcuserdata
 
 third_party/gn/
+third_party/ninja/ninja*
 
 # Miscellaneous
 *.class

--- a/DEPS
+++ b/DEPS
@@ -616,6 +616,15 @@ deps = {
     ],
     'dep_type': 'cipd',
   },
+  'src/flutter/third_party/ninja': {
+    'packages': [
+      {
+        'package': 'infra/3pp/tools/ninja/${{platform}}',
+        'version': 'version:2@1.8.2.chromium.3',
+      }
+    ],
+    'dep_type': 'cipd',
+  },
 
   'src/buildtools/emsdk': {
    'url': Var('skia_git') + '/external/github.com/emscripten-core/emsdk.git' + '@' + 'fc645b7626ebf86530dbd82fbece74d457e7ae07',

--- a/ci/licenses_golden/tool_signature
+++ b/ci/licenses_golden/tool_signature
@@ -1,2 +1,2 @@
-Signature: fd17294a410a1a503ab9aa72a0797dbe
+Signature: ae1981a94872d143d802356ab0f1a35e
 

--- a/third_party/ninja/README.flutter
+++ b/third_party/ninja/README.flutter
@@ -1,0 +1,17 @@
+Name: ninja
+Short Name: ninja
+URL: https://github.com/ninja-build/ninja
+Revision: See the CIPD version in DEPS
+License: Apache License 2.0
+License File: https://github.com/ninja-build/ninja/blob/master/COPYING
+Security Critical: no
+
+Description:
+Ninja is a small build system with a focus on speed, and is used to build
+this project.
+
+The CIPD packages are built using the 3pp pipeline.
+https://chromium.googlesource.com/infra/infra/+/refs/heads/main/3pp/ninja/
+
+Local Modifications:
+None

--- a/tools/licenses/lib/main.dart
+++ b/tools/licenses/lib/main.dart
@@ -1021,9 +1021,10 @@ class _RepositoryDirectory extends _RepositoryEntry implements LicenseSource {
     return !entry.fullName.endsWith('third_party/gn') &&
            !entry.fullName.endsWith('third_party/gradle') &&
            !entry.fullName.endsWith('third_party/imgui') &&
-           !entry.fullName.endsWith('third_party/tinygltf') &&
-           !entry.fullName.endsWith('third_party/json/docs') &&
            !entry.fullName.endsWith('third_party/json/LICENSES') &&
+           !entry.fullName.endsWith('third_party/json/docs') &&
+           !entry.fullName.endsWith('third_party/ninja') &&
+           !entry.fullName.endsWith('third_party/tinygltf') &&
             entry.name != '.ccls-cache' &&
             entry.name != '.cipd' &&
             entry.name != '.git' &&


### PR DESCRIPTION
Install CIPD ninja using DEPS

This is required to deprecate ninja binary in depot_tools. 
See https://crbug.com/1340825 and chromium/src's CL https://crrev.com/c/3869740 for more contexts.
