### PR TITLE
Remove deprecated `updateSemantics` APIs.

### DIFF
--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -750,27 +750,6 @@ class PlatformDispatcher {
     _invoke(onAccessibilityFeaturesChanged, _onAccessibilityFeaturesChangedZone,);
   }
 
-  /// Change the retained semantics data about this platform dispatcher.
-  ///
-  /// If [semanticsEnabled] is true, the user has requested that this function
-  /// be called whenever the semantic content of this platform dispatcher
-  /// changes.
-  ///
-  /// In either case, this function disposes the given update, which means the
-  /// semantics update cannot be used further.
-  @Deprecated('''
-    In a multi-view world, the platform dispatcher can no longer provide apis
-    to update semantics since each view will host its own semantics tree.
-
-    Semantics updates must be passed to an individual [FlutterView]. To update
-    semantics, use PlatformDispatcher.instance.views to get a [FlutterView] and
-    call `updateSemantics`.
-  ''')
-  void updateSemantics(SemanticsUpdate update) => _updateSemantics(update);
-
-  @FfiNative<Void Function(Pointer<Void>)>('PlatformConfigurationNativeApi::UpdateSemantics')
-  external static void _updateSemantics(SemanticsUpdate update);
-
   /// The system-reported default locale of the device.
   ///
   /// This establishes the language and formatting conventions that application

--- a/lib/web_ui/lib/platform_dispatcher.dart
+++ b/lib/web_ui/lib/platform_dispatcher.dart
@@ -83,15 +83,7 @@ abstract class PlatformDispatcher {
   VoidCallback? get onAccessibilityFeaturesChanged;
   set onAccessibilityFeaturesChanged(VoidCallback? callback);
 
-  @Deprecated('''
-    In a multi-view world, the platform dispatcher can no longer provide apis
-    to update semantics since each view will host its own semantics tree.
-
-    Semantics updates must be passed to an individual [FlutterView]. To update
-    semantics, use PlatformDispatcher.instance.views to get a [FlutterView] and
-    call `updateSemantics`.
-  ''')
-  void updateSemantics(SemanticsUpdate update);
+  void updateSemantics(SemanticsUpdate update, FlutterView view);
 
   Locale get locale;
 

--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -683,31 +683,16 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
     _onAccessibilityFeaturesChangedZone = Zone.current;
   }
 
+  @override
+  void updateSemantics(ui.SemanticsUpdate update, ui.FlutterView view) {
+    EngineSemanticsOwner.instance.updateSemantics(update);
+  }
+
   /// Engine code should use this method instead of the callback directly.
   /// Otherwise zones won't work properly.
   void invokeOnAccessibilityFeaturesChanged() {
     invoke(
         _onAccessibilityFeaturesChanged, _onAccessibilityFeaturesChangedZone);
-  }
-
-  /// Change the retained semantics data about this window.
-  ///
-  /// If [semanticsEnabled] is true, the user has requested that this function
-  /// be called whenever the semantic content of this window changes.
-  ///
-  /// In either case, this function disposes the given update, which means the
-  /// semantics update cannot be used further.
-  @override
-  @Deprecated('''
-    In a multi-view world, the platform dispatcher can no longer provide apis
-    to update semantics since each view will host its own semantics tree.
-
-    Semantics updates must be passed to an individual [FlutterView]. To update
-    semantics, use PlatformDispatcher.instance.views to get a [FlutterView] and
-    call `updateSemantics`.
-  ''')
-  void updateSemantics(ui.SemanticsUpdate update) {
-    EngineSemanticsOwner.instance.updateSemantics(update);
   }
 
   /// This is equivalent to `locales.first`, except that it will provide an

--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -684,7 +684,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
   }
 
   @override
-  void updateSemantics(ui.SemanticsUpdate update, ui.FlutterView view) {
+  void updateSemantics(ui.SemanticsUpdate update, [ui.FlutterView? view]) {
     EngineSemanticsOwner.instance.updateSemantics(update);
   }
 

--- a/lib/web_ui/lib/window.dart
+++ b/lib/web_ui/lib/window.dart
@@ -16,7 +16,7 @@ abstract class FlutterView {
   WindowPadding get padding => viewConfiguration.padding;
   List<DisplayFeature> get displayFeatures => viewConfiguration.displayFeatures;
   void render(Scene scene) => platformDispatcher.render(scene, this);
-  void updateSemantics(SemanticsUpdate update) => platformDispatcher.updateSemantics(update);
+  void updateSemantics(SemanticsUpdate update) => platformDispatcher.updateSemantics(update, this);
 }
 
 abstract class FlutterWindow extends FlutterView {


### PR DESCRIPTION


## fixes https://github.com/flutter/flutter/issues/112221

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
