### PR TITLE
[macOS] Move to new update semantics embedder API

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
@@ -165,14 +165,12 @@ TEST_F(FlutterEngineTest, CanToggleAccessibility) {
   FlutterEngine* engine = GetFlutterEngine();
   // Capture the update callbacks before the embedder API initializes.
   auto original_init = engine.embedderAPI.Initialize;
-  std::function<void(const FlutterSemanticsNode*, void*)> update_node_callback;
-  std::function<void(const FlutterSemanticsCustomAction*, void*)> update_action_callback;
+  std::function<void(const FlutterSemanticsUpdate*, void*)> update_semantics_callback;
   engine.embedderAPI.Initialize = MOCK_ENGINE_PROC(
-      Initialize, ([&update_action_callback, &update_node_callback, &original_init](
+      Initialize, ([&update_semantics_callback, &original_init](
                        size_t version, const FlutterRendererConfig* config,
                        const FlutterProjectArgs* args, void* user_data, auto engine_out) {
-        update_node_callback = args->update_semantics_node_callback;
-        update_action_callback = args->update_semantics_custom_action_callback;
+        update_semantics_callback = args->update_semantics_callback;
         return original_init(version, config, args, user_data, engine_out);
       }));
   EXPECT_TRUE([engine runWithEntrypoint:@"main"]);
@@ -210,7 +208,6 @@ TEST_F(FlutterEngineTest, CanToggleAccessibility) {
   int32_t children[] = {1};
   root.children_in_traversal_order = children;
   root.custom_accessibility_actions_count = 0;
-  update_node_callback(&root, (void*)CFBridgingRetain(engine));
 
   FlutterSemanticsNode child1;
   child1.id = 1;
@@ -226,15 +223,13 @@ TEST_F(FlutterEngineTest, CanToggleAccessibility) {
   child1.tooltip = "";
   child1.child_count = 0;
   child1.custom_accessibility_actions_count = 0;
-  update_node_callback(&child1, (void*)CFBridgingRetain(engine));
 
-  FlutterSemanticsNode node_batch_end;
-  node_batch_end.id = kFlutterSemanticsNodeIdBatchEnd;
-  update_node_callback(&node_batch_end, (void*)CFBridgingRetain(engine));
-
-  FlutterSemanticsCustomAction action_batch_end;
-  action_batch_end.id = kFlutterSemanticsNodeIdBatchEnd;
-  update_action_callback(&action_batch_end, (void*)CFBridgingRetain(engine));
+  FlutterSemanticsUpdate update;
+  update.nodes_count = 2;
+  FlutterSemanticsNode nodes[] = {root, child1};
+  update.nodes = nodes;
+  update.custom_actions_count = 0;
+  update_semantics_callback(&update, (__bridge void*)engine);
 
   // Verify the accessibility tree is attached to the flutter view.
   EXPECT_EQ([engine.viewController.flutterView.accessibilityChildren count], 1u);
@@ -267,14 +262,12 @@ TEST_F(FlutterEngineTest, CanToggleAccessibilityWhenHeadless) {
   FlutterEngine* engine = GetFlutterEngine();
   // Capture the update callbacks before the embedder API initializes.
   auto original_init = engine.embedderAPI.Initialize;
-  std::function<void(const FlutterSemanticsNode*, void*)> update_node_callback;
-  std::function<void(const FlutterSemanticsCustomAction*, void*)> update_action_callback;
+  std::function<void(const FlutterSemanticsUpdate*, void*)> update_semantics_callback;
   engine.embedderAPI.Initialize = MOCK_ENGINE_PROC(
-      Initialize, ([&update_action_callback, &update_node_callback, &original_init](
+      Initialize, ([&update_semantics_callback, &original_init](
                        size_t version, const FlutterRendererConfig* config,
                        const FlutterProjectArgs* args, void* user_data, auto engine_out) {
-        update_node_callback = args->update_semantics_node_callback;
-        update_action_callback = args->update_semantics_custom_action_callback;
+        update_semantics_callback = args->update_semantics_callback;
         return original_init(version, config, args, user_data, engine_out);
       }));
   EXPECT_TRUE([engine runWithEntrypoint:@"main"]);
@@ -305,7 +298,6 @@ TEST_F(FlutterEngineTest, CanToggleAccessibilityWhenHeadless) {
   int32_t children[] = {1};
   root.children_in_traversal_order = children;
   root.custom_accessibility_actions_count = 0;
-  update_node_callback(&root, (void*)CFBridgingRetain(engine));
 
   FlutterSemanticsNode child1;
   child1.id = 1;
@@ -321,15 +313,13 @@ TEST_F(FlutterEngineTest, CanToggleAccessibilityWhenHeadless) {
   child1.tooltip = "";
   child1.child_count = 0;
   child1.custom_accessibility_actions_count = 0;
-  update_node_callback(&child1, (void*)CFBridgingRetain(engine));
 
-  FlutterSemanticsNode node_batch_end;
-  node_batch_end.id = kFlutterSemanticsNodeIdBatchEnd;
-  update_node_callback(&node_batch_end, (void*)CFBridgingRetain(engine));
-
-  FlutterSemanticsCustomAction action_batch_end;
-  action_batch_end.id = kFlutterSemanticsNodeIdBatchEnd;
-  update_action_callback(&action_batch_end, (void*)CFBridgingRetain(engine));
+  FlutterSemanticsUpdate update;
+  update.nodes_count = 2;
+  FlutterSemanticsNode nodes[] = {root, child1};
+  update.nodes = nodes;
+  update.custom_actions_count = 0;
+  update_semantics_callback(&update, (__bridge void*)engine);
 
   // No crashes.
   EXPECT_EQ(engine.viewController, nil);
@@ -351,14 +341,12 @@ TEST_F(FlutterEngineTest, ResetsAccessibilityBridgeWhenSetsNewViewController) {
   FlutterEngine* engine = GetFlutterEngine();
   // Capture the update callbacks before the embedder API initializes.
   auto original_init = engine.embedderAPI.Initialize;
-  std::function<void(const FlutterSemanticsNode*, void*)> update_node_callback;
-  std::function<void(const FlutterSemanticsCustomAction*, void*)> update_action_callback;
+  std::function<void(const FlutterSemanticsUpdate*, void*)> update_semantics_callback;
   engine.embedderAPI.Initialize = MOCK_ENGINE_PROC(
-      Initialize, ([&update_action_callback, &update_node_callback, &original_init](
+      Initialize, ([&update_semantics_callback, &original_init](
                        size_t version, const FlutterRendererConfig* config,
                        const FlutterProjectArgs* args, void* user_data, auto engine_out) {
-        update_node_callback = args->update_semantics_node_callback;
-        update_action_callback = args->update_semantics_custom_action_callback;
+        update_semantics_callback = args->update_semantics_callback;
         return original_init(version, config, args, user_data, engine_out);
       }));
   EXPECT_TRUE([engine runWithEntrypoint:@"main"]);
@@ -396,7 +384,6 @@ TEST_F(FlutterEngineTest, ResetsAccessibilityBridgeWhenSetsNewViewController) {
   int32_t children[] = {1};
   root.children_in_traversal_order = children;
   root.custom_accessibility_actions_count = 0;
-  update_node_callback(&root, (void*)CFBridgingRetain(engine));
 
   FlutterSemanticsNode child1;
   child1.id = 1;
@@ -412,15 +399,13 @@ TEST_F(FlutterEngineTest, ResetsAccessibilityBridgeWhenSetsNewViewController) {
   child1.tooltip = "";
   child1.child_count = 0;
   child1.custom_accessibility_actions_count = 0;
-  update_node_callback(&child1, (void*)CFBridgingRetain(engine));
 
-  FlutterSemanticsNode node_batch_end;
-  node_batch_end.id = kFlutterSemanticsNodeIdBatchEnd;
-  update_node_callback(&node_batch_end, (void*)CFBridgingRetain(engine));
-
-  FlutterSemanticsCustomAction action_batch_end;
-  action_batch_end.id = kFlutterSemanticsNodeIdBatchEnd;
-  update_action_callback(&action_batch_end, (void*)CFBridgingRetain(engine));
+  FlutterSemanticsUpdate update;
+  update.nodes_count = 2;
+  FlutterSemanticsNode nodes[] = {root, child1};
+  update.nodes = nodes;
+  update.custom_actions_count = 0;
+  update_semantics_callback(&update, (__bridge void*)engine);
 
   auto native_root = engine.accessibilityBridge.lock()->GetFlutterPlatformNodeDelegateFromID(0);
   EXPECT_FALSE(native_root.expired());


### PR DESCRIPTION
Move the macOS embedder to use the new update semantics embedder API introduced by https://github.com/flutter/engine/pull/37129.

Part of https://github.com/flutter/flutter/issues/114201

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
