### PR TITLE
Revert "Roll Skia from 0c8127b3dd7d to 8b19fb0f57d4 (1 revision)"

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -18,7 +18,7 @@ vars = {
   'llvm_git': 'https://llvm.googlesource.com',
   # OCMock is for testing only so there is no google clone
   'ocmock_git': 'https://github.com/erikdoe/ocmock.git',
-  'skia_revision': '8b19fb0f57d47fd217add26a5eb3e430d7a0d473',
+  'skia_revision': '0c8127b3dd7d34bb98919f59c4f733b8d0dc506f',
 
   # WARNING: DO NOT EDIT canvaskit_cipd_instance MANUALLY
   # See `lib/web_ui/README.md` for how to roll CanvasKit to a new version.

--- a/ci/licenses_golden/licenses_skia
+++ b/ci/licenses_golden/licenses_skia
@@ -1,4 +1,4 @@
-Signature: 7140d8ef2695ea07f4bc05d55aab7947
+Signature: 78ca86992cb56b8a41e3f2fcd89eb957
 
 UNUSED LICENSES:
 


### PR DESCRIPTION
Reverts flutter/engine#37409

wasm build is failing repeatedly on this Skia roll: https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20Web%20Engine/14004/overview