### PR TITLE
Clang-tidy: Fixed math on shard-id validator.

### DIFF
--- a/tools/clang_tidy/lib/src/options.dart
+++ b/tools/clang_tidy/lib/src/options.dart
@@ -120,7 +120,7 @@ class Options {
     }
     final String? shardIdString = argResults['shard-id'] as String?;
     final int? shardId = shardIdString == null ? null : int.parse(shardIdString);
-    if (shardId != null && (shardId >= shardCommands.length || shardId < 0)) {
+    if (shardId != null && (shardId > shardCommands.length || shardId < 0)) {
       return Options._error('Invalid shard-id value: $shardId.', errSink: errSink);
     }
     return Options._fromArgResults(

--- a/tools/clang_tidy/test/clang_tidy_test.dart
+++ b/tools/clang_tidy/test/clang_tidy_test.dart
@@ -8,6 +8,7 @@ import 'package:clang_tidy/clang_tidy.dart';
 import 'package:clang_tidy/src/command.dart';
 import 'package:clang_tidy/src/options.dart';
 import 'package:litetest/litetest.dart';
+import 'package:path/path.dart' as path;
 import 'package:process_runner/process_runner.dart';
 
 // Recorded locally from clang-tidy.
@@ -113,6 +114,44 @@ Future<int> main(List<String> args) async {
     expect(errBuffer.toString(), contains(
       'ERROR: --compile-commands option cannot be used with --src-dir.',
     ));
+  });
+
+  test('shard-id valid', () async {
+    final StringBuffer outBuffer = StringBuffer();
+    final StringBuffer errBuffer = StringBuffer();
+    final String variant = path.basename(io.File(buildCommands).parent.path);
+    final ClangTidy clangTidy = ClangTidy.fromCommandLine(
+      <String>[
+        '--shard-variants=$variant',
+        '--shard-id=1',
+      ],
+      outSink: outBuffer,
+      errSink: errBuffer,
+    );
+
+    final int result = await clangTidy.run();
+
+    expect(clangTidy.options.help, isFalse);
+    expect(result, equals(0));
+  });
+
+  test('shard-id invalid', () async {
+    final StringBuffer outBuffer = StringBuffer();
+    final StringBuffer errBuffer = StringBuffer();
+    final String variant = path.basename(io.File(buildCommands).parent.path);
+    final ClangTidy clangTidy = ClangTidy.fromCommandLine(
+      <String>[
+        '--shard-variants=$variant',
+        '--shard-id=2',
+      ],
+      outSink: outBuffer,
+      errSink: errBuffer,
+    );
+
+    final int result = await clangTidy.run();
+
+    expect(clangTidy.options.help, isFalse);
+    expect(result, equals(1));
   });
 
   test('Error when --compile-commands path does not exist', () async {

--- a/tools/clang_tidy/test/clang_tidy_test.dart
+++ b/tools/clang_tidy/test/clang_tidy_test.dart
@@ -140,13 +140,22 @@ void _withTempFile(String prefix, void Function(String path) func) {
   });
 
   test('shard-id invalid', () async {
-    final String variant = path.basename(io.File(buildCommands).parent.path);
-    final Options options = Options.fromCommandLine( <String>[
-        '--shard-variants=$variant',
+    _withTempFile('shard-id-valid', (String path) {
+      final StringBuffer errBuffer = StringBuffer();
+      final Options options = Options.fromCommandLine(<String>[
+        '--compile-commands=$path',
+        '--shard-variants=variant',
         '--shard-id=2',
-      ],);
-    expect(options.errorMessage, isNotNull);
-    expect(options.shardId, isNull);
+      ], errSink: errBuffer);
+      expect(options.errorMessage, isNotNull);
+      expect(options.shardId, isNull);
+      print('foo ${options.errorMessage}');
+      expect(
+          options.errorMessage,
+          contains(
+            'Invalid shard-id value',
+          ));
+    });
   });
 
   test('Error when --compile-commands path does not exist', () async {

--- a/tools/clang_tidy/test/clang_tidy_test.dart
+++ b/tools/clang_tidy/test/clang_tidy_test.dart
@@ -117,41 +117,23 @@ Future<int> main(List<String> args) async {
   });
 
   test('shard-id valid', () async {
-    final StringBuffer outBuffer = StringBuffer();
-    final StringBuffer errBuffer = StringBuffer();
     final String variant = path.basename(io.File(buildCommands).parent.path);
-    final ClangTidy clangTidy = ClangTidy.fromCommandLine(
-      <String>[
+    final Options options = Options.fromCommandLine( <String>[
         '--shard-variants=$variant',
         '--shard-id=1',
-      ],
-      outSink: outBuffer,
-      errSink: errBuffer,
-    );
-
-    final int result = await clangTidy.run();
-
-    expect(clangTidy.options.help, isFalse);
-    expect(result, equals(0));
+      ],);
+    expect(options.errorMessage, isNull);
+    expect(options.shardId, equals(1));
   });
 
   test('shard-id invalid', () async {
-    final StringBuffer outBuffer = StringBuffer();
-    final StringBuffer errBuffer = StringBuffer();
     final String variant = path.basename(io.File(buildCommands).parent.path);
-    final ClangTidy clangTidy = ClangTidy.fromCommandLine(
-      <String>[
+    final Options options = Options.fromCommandLine( <String>[
         '--shard-variants=$variant',
         '--shard-id=2',
-      ],
-      outSink: outBuffer,
-      errSink: errBuffer,
-    );
-
-    final int result = await clangTidy.run();
-
-    expect(clangTidy.options.help, isFalse);
-    expect(result, equals(1));
+      ],);
+    expect(options.errorMessage, isNotNull);
+    expect(options.shardId, isNull);
   });
 
   test('Error when --compile-commands path does not exist', () async {

--- a/tools/clang_tidy/test/clang_tidy_test.dart
+++ b/tools/clang_tidy/test/clang_tidy_test.dart
@@ -39,6 +39,18 @@ Suppressed 3474 warnings (3466 in non-user code, 8 NOLINT).
 Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
 1 warning treated as error''';
 
+void _withTempFile(String prefix, void Function(String path) func) {
+  final String filePath =
+      path.join(io.Directory.systemTemp.path, '$prefix-temp-file');
+  final io.File file = io.File(filePath);
+  file.createSync();
+  try {
+    func(file.path);
+  } finally {
+    file.deleteSync();
+  }
+}
+
 Future<int> main(List<String> args) async {
   if (args.isEmpty) {
     io.stderr.writeln(
@@ -115,17 +127,6 @@ Future<int> main(List<String> args) async {
       'ERROR: --compile-commands option cannot be used with --src-dir.',
     ));
   });
-
-void _withTempFile(String prefix, void Function(String path) func) {
-    final String filePath = path.join(io.Directory.systemTemp.path, '$prefix-temp-file');
-    final io.File file = io.File(filePath);
-    file.createSync();
-    try {
-      func(file.path);
-    } finally {
-      file.deleteSync();
-    }
-  }
 
   test('shard-id valid', () async {
     _withTempFile('shard-id-valid', (String path) {


### PR DESCRIPTION
fixes failure: https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8798099822610209889/+/u/test:_lint_host_debug/stdout

That resulted in revert: https://flutter-review.git.corp.google.com/c/recipes/+/35742

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
