### PR TITLE
Add rects to accumulator rather than bounds

### DIFF
--- a/display_list/display_list_utils.cc
+++ b/display_list/display_list_utils.cc
@@ -672,7 +672,12 @@ void DisplayListBoundsCalculator::drawPicture(const sk_sp<SkPicture> picture,
 }
 void DisplayListBoundsCalculator::drawDisplayList(
     const sk_sp<DisplayList> display_list) {
-  AccumulateOpBounds(display_list->bounds(), kDrawDisplayListFlags);
+  const SkRect bounds = display_list->bounds();
+  std::list<SkRect> rects =
+      display_list->rtree()->searchNonOverlappingDrawnRects(bounds);
+  for (const SkRect& rect : rects) {
+    AccumulateOpBounds(rect, kDrawDisplayListFlags);
+  }
 }
 void DisplayListBoundsCalculator::drawTextBlob(const sk_sp<SkTextBlob> blob,
                                                SkScalar x,

--- a/testing/scenario_app/run_ios_tests.sh
+++ b/testing/scenario_app/run_ios_tests.sh
@@ -52,12 +52,10 @@ echo "Running simulator tests with Impeller"
 echo ""
 
 # Skip testFontRenderingWhenSuppliedWithBogusFont: https://github.com/flutter/flutter/issues/113250
-# Skip testOneOverlayAndTwoIntersectingOverlays: https://github.com/flutter/flutter/issues/113251
 set -o pipefail && xcodebuild -sdk iphonesimulator \
   -scheme Scenarios \
   -destination 'platform=iOS Simulator,OS=13.0,name=iPhone 8' \
   clean test \
   FLUTTER_ENGINE="$FLUTTER_ENGINE" \
   -skip-testing "ScenariosUITests/BogusFontTextTest/testFontRenderingWhenSuppliedWithBogusFont" \
-  -skip-testing "ScenariosUITests/UnobstructedPlatformViewTests/testOneOverlayAndTwoIntersectingOverlays" \
   INFOPLIST_FILE="Scenarios/Info_Impeller.plist" # Plist with FLTEnableImpeller=YES


### PR DESCRIPTION
When the accumulator is an `RTreeBoundsAccumulator` rather than a `RectBoundsAccumulator` just accumulating the bounds results in incorrect results as the `rtree` would need to be aware of the constituent non-overlapping rectangles. This would work fine for `RectBoundsAccumulator` as it would just adjust its bounds based on the passed rects.

Fixes: https://github.com/flutter/flutter/issues/113251
