### PR TITLE
Add external factories for @staticInterop classes instead of synthetic constructor

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -1865,7 +1865,9 @@ class SkParagraphStyle {}
 @JS()
 @anonymous
 @staticInterop
-class SkParagraphStyleProperties {}
+class SkParagraphStyleProperties {
+  external factory SkParagraphStyleProperties();
+}
 
 extension SkParagraphStylePropertiesExtension on SkParagraphStyleProperties {
   external set textAlign(SkTextAlign? value);
@@ -1981,7 +1983,9 @@ SkPlaceholderAlignment toSkPlaceholderAlignment(
 @JS()
 @anonymous
 @staticInterop
-class SkTextStyleProperties {}
+class SkTextStyleProperties {
+  external factory SkTextStyleProperties();
+}
 
 extension SkTextStylePropertiesExtension on SkTextStyleProperties {
   external set backgroundColor(Float32List? value);
@@ -2008,7 +2012,9 @@ extension SkTextStylePropertiesExtension on SkTextStyleProperties {
 @JS()
 @anonymous
 @staticInterop
-class SkStrutStyleProperties {}
+class SkStrutStyleProperties {
+  external factory SkStrutStyleProperties();
+}
 
 extension SkStrutStylePropertiesExtension on SkStrutStyleProperties {
   external set fontFamilies(List<String>? value);
@@ -2024,7 +2030,9 @@ extension SkStrutStylePropertiesExtension on SkStrutStyleProperties {
 @JS()
 @anonymous
 @staticInterop
-class SkFontStyle {}
+class SkFontStyle {
+  external factory SkFontStyle();
+}
 
 extension SkFontStyleExtension on SkFontStyle {
   external set weight(SkFontWeight? value);
@@ -2034,7 +2042,9 @@ extension SkFontStyleExtension on SkFontStyle {
 @JS()
 @anonymous
 @staticInterop
-class SkTextShadow {}
+class SkTextShadow {
+  external factory SkTextShadow();
+}
 
 extension SkTextShadowExtension on SkTextShadow {
   external set color(Float32List? value);
@@ -2045,7 +2055,9 @@ extension SkTextShadowExtension on SkTextShadow {
 @JS()
 @anonymous
 @staticInterop
-class SkFontFeature {}
+class SkFontFeature {
+  external factory SkFontFeature();
+}
 
 extension SkFontFeatureExtension on SkFontFeature {
   external set name(String? value);
@@ -2055,7 +2067,9 @@ extension SkFontFeatureExtension on SkFontFeature {
 @JS()
 @anonymous
 @staticInterop
-class SkFontVariation {}
+class SkFontVariation {
+  external factory SkFontVariation();
+}
 
 extension SkFontVariationExtension on SkFontVariation {
   external set axis(String? value);

--- a/lib/web_ui/lib/src/engine/text/font_collection.dart
+++ b/lib/web_ui/lib/src/engine/text/font_collection.dart
@@ -325,7 +325,7 @@ class _PolyfillFontManager extends FontManager {
     final String fontFaceDeclaration = fontStyleMap.keys
         .map((String name) => '$name: ${fontStyleMap[name]};')
         .join(' ');
-    final DomHTMLStyleElement fontLoadStyle = DomHTMLStyleElement();
+    final DomHTMLStyleElement fontLoadStyle = createDomHTMLStyleElement();
     fontLoadStyle.type = 'text/css';
     fontLoadStyle.innerHtml = '@font-face { $fontFaceDeclaration }';
     domDocument.head!.append(fontLoadStyle);


### PR DESCRIPTION
Per https://github.com/dart-lang/sdk/issues/49941, synthetic constructors will be disallowed on @staticInterop classes. Functionally, they are lowered to the same code.

Also fixes an erroneous call to the DomHTMLStyleConstructor instead of the relevant factory method.

Migration needed to fix https://github.com/dart-lang/sdk/issues/49941

These factories were added because they were caught by the flutter trybots (https://logs.chromium.org/logs/dart/buildbucket/cr-buildbucket/8798044738469408369/+/u/build_host_debug/stdout).

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [x] All existing and new tests are passing.
