### PR TITLE
Revert "Sdk roll failure - add facet to allowlist test_manager and other packages."

### DIFF
--- a/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_aot_runner/meta/dart-aot-runner-integration-test.cml
+++ b/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_aot_runner/meta/dart-aot-runner-integration-test.cml
@@ -37,14 +37,4 @@
             to: "#realm_builder",
         },
     ],
-    // TODO(https://fxbug.dev/114584): Figure out how to bring these in as deps (if possible oot).
-    facets: {
-        "fuchsia.test": {
-            "deprecated-allowed-packages": [
-                "dart_aot_echo_server",
-                "test_manager",
-                "oot_dart_aot_runner"
-            ],
-        },
-    },
 }

--- a/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_jit_runner/meta/dart-jit-runner-integration-test.cml
+++ b/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_jit_runner/meta/dart-jit-runner-integration-test.cml
@@ -37,14 +37,4 @@
             to: "#realm_builder",
         },
     ],
-    // TODO(https://fxbug.dev/114584): Figure out how to bring these in as deps (if possible oot).
-    facets: {
-        "fuchsia.test": {
-            "deprecated-allowed-packages": [
-                "dart_jit_echo_server",
-                "test_manager",
-                "oot_dart_jit_runner"
-            ],
-        },
-    },
 }

--- a/shell/platform/fuchsia/flutter/tests/integration/embedder/meta/flutter-embedder-test.cml
+++ b/shell/platform/fuchsia/flutter/tests/integration/embedder/meta/flutter-embedder-test.cml
@@ -27,19 +27,4 @@
             to: "#realm_builder",
         },
     ],
-    // TODO(https://fxbug.dev/114584): Figure out how to bring these in as deps (if possible oot).
-    facets: {
-        "fuchsia.test": {
-            "deprecated-allowed-packages": [
-                "child-view",
-                "oot_flutter_aot_runner",
-                "oot_flutter_jit_runner",
-                "oot_flutter_jit_product_runner",
-                "oot_flutter_aot_product_runner",
-                "parent-view",
-                "test-ui-stack",
-                "test_manager",
-            ],
-        },
-    },
 }

--- a/shell/platform/fuchsia/flutter/tests/integration/mouse-input/meta/mouse-input-test.cml
+++ b/shell/platform/fuchsia/flutter/tests/integration/mouse-input/meta/mouse-input-test.cml
@@ -52,21 +52,4 @@
             to: "#realm_builder",
         },
     ],
-    // TODO(https://fxbug.dev/114584): Figure out how to bring these in as deps (if possible oot).
-    facets: {
-        "fuchsia.test": {
-            "deprecated-allowed-packages": [
-                "child-view",
-                "cursor",
-                "flatland-scene-manager-test-ui-stack",
-                "mouse-input-view",
-                "oot_flutter_aot_runner",
-                "oot_flutter_jit_runner",
-                "oot_flutter_jit_product_runner",
-                "oot_flutter_aot_product_runner",
-                "test_manager",
-                "test-ui-stack",
-            ],
-        },
-    },
 }

--- a/shell/platform/fuchsia/flutter/tests/integration/text-input/meta/text-input-test.cml
+++ b/shell/platform/fuchsia/flutter/tests/integration/text-input/meta/text-input-test.cml
@@ -39,16 +39,4 @@
             to: "#realm_builder",
         },
     ],
-    // TODO(https://fxbug.dev/114584): Figure out how to bring these in as deps (if possible oot).
-    facets: {
-        "fuchsia.test": {
-            "deprecated-allowed-packages": [
-                "oot_flutter_aot_runner",
-                "oot_flutter_jit_runner",
-                "oot_flutter_jit_product_runner",
-                "oot_flutter_aot_product_runner",
-                "test_manager",
-            ],
-        },
-    },
 }

--- a/shell/platform/fuchsia/flutter/tests/integration/touch-input/meta/touch-input-test.cml
+++ b/shell/platform/fuchsia/flutter/tests/integration/touch-input/meta/touch-input-test.cml
@@ -50,18 +50,4 @@
             to: "#realm_builder",
         },
     ],
-    // TODO(https://fxbug.dev/114584): Figure out how to bring these in as deps (if possible oot).
-    facets: {
-        "fuchsia.test": {
-            "deprecated-allowed-packages": [
-                "gfx-root-presenter-test-ui-stack",
-                "oot_flutter_aot_runner",
-                "oot_flutter_jit_runner",
-                "oot_flutter_jit_product_runner",
-                "oot_flutter_aot_product_runner",
-                "test_manager",
-                "touch-input-view",
-            ],
-        },
-    },
 }


### PR DESCRIPTION
Reverts flutter/engine#37395

link to failure resulting in revert: https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20Fuchsia%20FEMU/12755/overview