### PR TITLE
[Impeller] Support HLSL ingestion in ImpellerC

### DIFF
--- a/impeller/compiler/compiler_test.cc
+++ b/impeller/compiler/compiler_test.cc
@@ -66,19 +66,21 @@ std::unique_ptr<fml::FileMapping> CompilerTest::GetReflectionJson(
 }
 
 bool CompilerTest::CanCompileAndReflect(const char* fixture_name,
-                                        SourceType source_type) const {
+                                        SourceType source_type,
+                                        SourceLanguage source_language) const {
   auto fixture = flutter::testing::OpenFixtureAsMapping(fixture_name);
-  if (!fixture->GetMapping()) {
+  if (!fixture || !fixture->GetMapping()) {
     VALIDATION_LOG << "Could not find shader in fixtures: " << fixture_name;
     return false;
   }
 
   SourceOptions source_options(fixture_name, source_type);
   source_options.target_platform = GetParam();
+  source_options.source_language = source_language;
   source_options.working_directory = std::make_shared<fml::UniqueFD>(
       flutter::testing::OpenFixturesDirectory());
   source_options.entry_point_name = EntryPointFunctionNameFromSourceName(
-      fixture_name, SourceTypeFromFileName(fixture_name));
+      fixture_name, SourceTypeFromFileName(fixture_name), source_language);
 
   Reflector::Options reflector_options;
   reflector_options.header_file_name = ReflectionHeaderName(fixture_name);

--- a/impeller/compiler/compiler_test.h
+++ b/impeller/compiler/compiler_test.h
@@ -26,7 +26,8 @@ class CompilerTest : public ::testing::TestWithParam<TargetPlatform> {
 
   bool CanCompileAndReflect(
       const char* fixture_name,
-      SourceType source_type = SourceType::kUnknown) const;
+      SourceType source_type = SourceType::kUnknown,
+      SourceLanguage source_language = SourceLanguage::kGLSL) const;
 
  private:
   fml::UniqueFD intermediates_directory_;

--- a/impeller/compiler/compiler_unittests.cc
+++ b/impeller/compiler/compiler_unittests.cc
@@ -28,6 +28,13 @@ TEST(CompilerTest, ShaderKindMatchingIsSuccessful) {
 TEST_P(CompilerTest, CanCompile) {
   ASSERT_TRUE(CanCompileAndReflect("sample.vert"));
   ASSERT_TRUE(CanCompileAndReflect("sample.vert", SourceType::kVertexShader));
+  ASSERT_TRUE(CanCompileAndReflect("sample.vert", SourceType::kVertexShader,
+                                   SourceLanguage::kGLSL));
+}
+
+TEST_P(CompilerTest, CanCompileHLSL) {
+  ASSERT_TRUE(CanCompileAndReflect(
+      "simple.vert.hlsl", SourceType::kVertexShader, SourceLanguage::kHLSL));
 }
 
 TEST_P(CompilerTest, CanCompileTessellationControlShader) {

--- a/impeller/compiler/impellerc_main.cc
+++ b/impeller/compiler/impellerc_main.cc
@@ -59,6 +59,7 @@ bool Main(const fml::CommandLine& command_line) {
 
   SourceOptions options;
   options.target_platform = switches.target_platform;
+  options.source_language = switches.source_language;
   if (switches.input_type == SourceType::kUnknown) {
     options.type = SourceTypeFromFileName(switches.source_file_name);
   } else {
@@ -69,7 +70,7 @@ bool Main(const fml::CommandLine& command_line) {
   options.include_dirs = switches.include_directories;
   options.defines = switches.defines;
   options.entry_point_name = EntryPointFunctionNameFromSourceName(
-      switches.source_file_name, options.type);
+      switches.source_file_name, options.type, options.source_language);
   options.json_format = switches.json_format;
 
   Reflector::Options reflector_options;

--- a/impeller/compiler/source_options.h
+++ b/impeller/compiler/source_options.h
@@ -19,6 +19,7 @@ namespace compiler {
 struct SourceOptions {
   SourceType type = SourceType::kUnknown;
   TargetPlatform target_platform = TargetPlatform::kUnknown;
+  SourceLanguage source_language = SourceLanguage::kUnknown;
   std::shared_ptr<fml::UniqueFD> working_directory;
   std::vector<IncludeDir> include_dirs;
   std::string file_name = "main.glsl";

--- a/impeller/compiler/switches.h
+++ b/impeller/compiler/switches.h
@@ -32,6 +32,7 @@ struct Switches {
   std::string depfile_path;
   std::vector<std::string> defines;
   bool json_format;
+  SourceLanguage source_language = SourceLanguage::kUnknown;
 
   Switches();
 

--- a/impeller/compiler/switches_unittests.cc
+++ b/impeller/compiler/switches_unittests.cc
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <initializer_list>
+#include <vector>
+
 #include "flutter/fml/command_line.h"
 #include "flutter/fml/file.h"
 #include "flutter/testing/testing.h"
@@ -12,6 +15,19 @@ namespace impeller {
 namespace compiler {
 namespace testing {
 
+Switches MakeSwitchesDesktopGL(
+    std::initializer_list<const char*> additional_options = {}) {
+  std::vector<const char*> options = {"--opengl-desktop", "--input=input.vert",
+                                      "--sl=output.vert",
+                                      "--spirv=output.spirv"};
+  options.insert(options.end(), additional_options.begin(),
+                 additional_options.end());
+
+  auto cl = fml::CommandLineFromIteratorsWithArgv0("impellerc", options.begin(),
+                                                   options.end());
+  return Switches(cl);
+}
+
 TEST(SwitchesTest, DoesntMangleUnicodeIncludes) {
   const char* directory_name = "test_shader_include_Ã�";
   fml::CreateDirectory(flutter::testing::OpenFixturesDirectory(),
@@ -21,14 +37,24 @@ TEST(SwitchesTest, DoesntMangleUnicodeIncludes) {
       std::string(flutter::testing::GetFixturesPath()) + "/" + directory_name;
   auto include_option = "--include=" + include_path;
 
-  const auto cl = fml::CommandLineFromInitializerList(
-      {"impellerc", "--opengl-desktop", "--input=input.vert",
-       "--sl=output.vert", "--spirv=output.spirv", include_option.c_str()});
-  Switches switches(cl);
+  Switches switches = MakeSwitchesDesktopGL({include_option.c_str()});
+
   ASSERT_TRUE(switches.AreValid(std::cout));
   ASSERT_EQ(switches.include_directories.size(), 1u);
   ASSERT_NE(switches.include_directories[0].dir, nullptr);
   ASSERT_EQ(switches.include_directories[0].name, include_path);
+}
+
+TEST(SwitchesTest, SourceLanguageDefaultsToGLSL) {
+  Switches switches = MakeSwitchesDesktopGL();
+  ASSERT_TRUE(switches.AreValid(std::cout));
+  ASSERT_EQ(switches.source_language, SourceLanguage::kGLSL);
+}
+
+TEST(SwitchesTest, SourceLanguageCanBeSetToHLSL) {
+  Switches switches = MakeSwitchesDesktopGL({"--source-language=hLsL"});
+  ASSERT_TRUE(switches.AreValid(std::cout));
+  ASSERT_EQ(switches.source_language, SourceLanguage::kHLSL);
 }
 
 }  // namespace testing

--- a/impeller/compiler/types.cc
+++ b/impeller/compiler/types.cc
@@ -74,8 +74,25 @@ std::string TargetPlatformToString(TargetPlatform platform) {
   FML_UNREACHABLE();
 }
 
-std::string EntryPointFunctionNameFromSourceName(const std::string& file_name,
-                                                 SourceType type) {
+std::string SourceLanguageToString(SourceLanguage source_language) {
+  switch (source_language) {
+    case SourceLanguage::kUnknown:
+      return "Unknown";
+    case SourceLanguage::kGLSL:
+      return "GLSL";
+    case SourceLanguage::kHLSL:
+      return "HLSL";
+  }
+}
+
+std::string EntryPointFunctionNameFromSourceName(
+    const std::string& file_name,
+    SourceType type,
+    SourceLanguage source_language) {
+  if (source_language == SourceLanguage::kHLSL) {
+    return "main";
+  }
+
   std::stringstream stream;
   std::filesystem::path file_path(file_name);
   stream << Utf8FromPath(file_path.stem()) << "_";

--- a/impeller/compiler/types.h
+++ b/impeller/compiler/types.h
@@ -37,6 +37,12 @@ enum class TargetPlatform {
   kSkSL,
 };
 
+enum class SourceLanguage {
+  kUnknown,
+  kGLSL,
+  kHLSL,
+};
+
 bool TargetPlatformIsMetal(TargetPlatform platform);
 
 bool TargetPlatformIsOpenGL(TargetPlatform platform);
@@ -47,10 +53,14 @@ std::string SourceTypeToString(SourceType type);
 
 std::string TargetPlatformToString(TargetPlatform platform);
 
+std::string SourceLanguageToString(SourceLanguage source_language);
+
 std::string TargetPlatformSLExtension(TargetPlatform platform);
 
-std::string EntryPointFunctionNameFromSourceName(const std::string& file_name,
-                                                 SourceType type);
+std::string EntryPointFunctionNameFromSourceName(
+    const std::string& file_name,
+    SourceType type,
+    SourceLanguage source_language);
 
 bool TargetPlatformNeedsSL(TargetPlatform platform);
 

--- a/impeller/fixtures/BUILD.gn
+++ b/impeller/fixtures/BUILD.gn
@@ -61,6 +61,7 @@ test_fixtures("file_fixtures") {
     "sample.tese",
     "sample.vert",
     "sample_with_binding.vert",
+    "simple.vert.hlsl",
     "sa%m#ple.vert",
     "struct_def_bug.vert",
     "table_mountain_nx.png",

--- a/impeller/fixtures/simple.vert.hlsl
+++ b/impeller/fixtures/simple.vert.hlsl
@@ -1,0 +1,18 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+struct VertexInput {
+  float3 position : POSITION;
+};
+
+struct VertexOutput {
+  float4 position : SV_POSITION;
+};
+
+VertexOutput
+main(VertexInput input) {
+  VertexOutput output;
+  output.position = float4(input.position, 1.0);
+  return output;
+}


### PR DESCRIPTION
For experimenting with HLSL features offered by glslc.

Adds a `--source-language` option that defaults to GLSL.

Right now, the entry point is always set to "main", which means it's not possible to combine multiple stages in one file. I'm planning to add an optional `--entry-point` flag to address this later.