### PR TITLE
Use traingle strip for difference clip

### DIFF
--- a/impeller/entity/contents/clip_contents.cc
+++ b/impeller/entity/contents/clip_contents.cc
@@ -96,6 +96,7 @@ bool ClipContents::Render(const ContentContext& renderer,
       info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize());
       VS::BindVertInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(info));
 
+      options.primitive_type = PrimitiveType::kTriangleStrip;
       cmd.pipeline = renderer.GetClipPipeline(options);
       pass.AddCommand(cmd);
     }


### PR DESCRIPTION
This was wrongly removed in https://github.com/flutter/engine/pull/37315/ where I assumed that this was overwritten by geometry_result a few lines below, but there is indeed a pipeline created earlier in line:100.

Fixes: https://github.com/flutter/flutter/issues/114870
