### PR TITLE
[macOS] Eliminate macOS 10.14 availability check

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMac.mm
+++ b/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMac.mm
@@ -216,30 +216,6 @@ AccessibilityBridgeMac::MacOSEventsFromAXEvent(ui::AXEventGenerator::Event event
       break;
     }
     case ui::AXEventGenerator::Event::LIVE_REGION_CHANGED: {
-      if (@available(macOS 10.14, *)) {
-        // Do nothing on macOS >=10.14.
-      } else {
-        // Uses the announcement API to get around OS <= 10.13 VoiceOver bug
-        // where it stops announcing live regions after the first time focus
-        // leaves any content area.
-        // Unfortunately this produces an annoying boing sound with each live
-        // announcement, but the alternative is almost no live region support.
-        NSString* announcement = [[NSString alloc]
-            initWithUTF8String:mac_platform_node_delegate->GetLiveRegionText().c_str()];
-        NSDictionary* notification_info = @{
-          NSAccessibilityAnnouncementKey : announcement,
-          NSAccessibilityPriorityKey : @(NSAccessibilityPriorityLow)
-        };
-        // Triggers VoiceOver speech and show on Braille display, if available.
-        // The Braille will only appear for a few seconds, and then will be replaced
-        // with the previous announcement.
-        events.push_back({
-            .name = NSAccessibilityAnnouncementRequestedNotification,
-            .target = [NSApp mainWindow],
-            .user_info = notification_info,
-        });
-        break;
-      }
       // Uses native VoiceOver support for live regions.
       events.push_back({
           .name = kAccessibilityLiveRegionChangedNotification,


### PR DESCRIPTION
Now that the macOS embedders have all been updated to use a minimum macOS SDK of 10.14, eliminate the remaining `@available` checks dependent on that version.

This is one in a series of post-10.14 cleanup patches.

No tests are added since the code removed was a workaround for macOS 10.13. We now build with both a minimum SDK and deployment target of 10.14, and as such the workaround was already disabled at compile-time, making this change effectively a no-op.

Issue: https://github.com/flutter/flutter/issues/114445

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
