### PR TITLE
Update engine v2 builds to remove gclient_custom_var support

### DIFF
--- a/ci/builders/linux_android_aot_engine.json
+++ b/ci/builders/linux_android_aot_engine.json
@@ -18,9 +18,6 @@
                 "device_type=none",
                 "os=Linux"
             ],
-            "gclient_custom_vars": {
-                "download_android_deps": false
-            },
             "gn": [
                 "--runtime-mode",
                 "profile",
@@ -58,9 +55,6 @@
                 "device_type=none",
                 "os=Linux"
             ],
-            "gclient_custom_vars": {
-                "download_android_deps": false
-            },
             "gn": [
                 "--runtime-mode",
                 "release",
@@ -98,9 +92,6 @@
                 "device_type=none",
                 "os=Linux"
             ],
-            "gclient_custom_vars": {
-                "download_android_deps": false
-            },
             "gn": [
                 "--runtime-mode",
                 "release",
@@ -136,9 +127,6 @@
                 "device_type=none",
                 "os=Linux"
             ],
-            "gclient_custom_vars": {
-                "download_android_deps": false
-            },
             "gn": [
                 "--android",
                 "--runtime-mode",
@@ -175,9 +163,6 @@
                 "device_type=none",
                 "os=Linux"
             ],
-            "gclient_custom_vars": {
-                "download_android_deps": false
-            },
             "gn": [
                 "--runtime-mode",
                 "profile",
@@ -214,9 +199,6 @@
                 "device_type=none",
                 "os=Linux"
             ],
-            "gclient_custom_vars": {
-                "download_android_deps": false
-            },
             "gn": [
                 "--runtime-mode",
                 "release",

--- a/ci/builders/linux_android_debug_engine.json
+++ b/ci/builders/linux_android_debug_engine.json
@@ -62,9 +62,6 @@
                 "device_type=none",
                 "os=Linux"
             ],
-            "gclient_custom_vars": {
-                "download_android_deps": false
-            },
             "gn": [
                 "--android",
                 "--unoptimized",
@@ -148,9 +145,6 @@
                 "device_type=none",
                 "os=Linux"
             ],
-            "gclient_custom_vars": {
-                "download_android_deps": false
-            },
             "gn": [
                 "--android",
                 "--android-cpu=arm64",
@@ -183,9 +177,6 @@
                 "device_type=none",
                 "os=Linux"
             ],
-            "gclient_custom_vars": {
-                "download_android_deps": false
-            },
             "gn": [
                 "--android",
                 "--android-cpu=x86",
@@ -218,9 +209,6 @@
                 "device_type=none",
                 "os=Linux"
             ],
-            "gclient_custom_vars": {
-                "download_android_deps": false
-            },
             "gn": [
                 "--android",
                 "--android-cpu=x64",

--- a/ci/builders/linux_arm_host_engine.json
+++ b/ci/builders/linux_arm_host_engine.json
@@ -15,9 +15,6 @@
                 "device_type=none",
                 "os=Linux"
             ],
-            "gclient_custom_vars": {
-                "download_android_deps": false
-            },
             "gn": [
                 "--runtime-mode",
                 "profile",
@@ -53,9 +50,6 @@
                 "device_type=none",
                 "os=Linux"
             ],
-            "gclient_custom_vars": {
-                "download_android_deps": false
-            },
             "gn": [
                 "--runtime-mode",
                 "debug",
@@ -91,9 +85,6 @@
                 "device_type=none",
                 "os=Linux"
             ],
-            "gclient_custom_vars": {
-                "download_android_deps": false
-            },
             "gn": [
                 "--runtime-mode",
                 "release",

--- a/ci/builders/linux_host_engine.json
+++ b/ci/builders/linux_host_engine.json
@@ -6,9 +6,6 @@
                 "device_type=none",
                 "os=Linux"
             ],
-            "gclient_custom_vars": {
-                "download_android_deps": false
-            },
             "gn": [
                 "--runtime-mode",
                 "debug",
@@ -31,9 +28,6 @@
               "device_type=none",
               "os=Linux"
           ],
-          "gclient_custom_vars": {
-              "download_android_deps": false
-          },
           "gn": [
               "--runtime-mode",
               "debug",
@@ -88,9 +82,6 @@
                 "device_type=none",
                 "os=Linux"
             ],
-            "gclient_custom_vars": {
-                "download_android_deps": false
-            },
             "gn": [
                 "--runtime-mode",
                 "debug",
@@ -128,9 +119,6 @@
                 "device_type=none",
                 "os=Linux"
             ],
-            "gclient_custom_vars": {
-                "download_android_deps": false
-            },
             "gn": [
                 "--runtime-mode",
                 "profile",
@@ -178,9 +166,6 @@
                 "device_type=none",
                 "os=Linux"
             ],
-            "gclient_custom_vars": {
-                "download_android_deps": false
-            },
             "gn": [
                 "--runtime-mode",
                 "release",

--- a/ci/builders/mac_android_aot_engine.json
+++ b/ci/builders/mac_android_aot_engine.json
@@ -16,9 +16,6 @@
                 "os=Mac-12",
                 "cpu=x86"
             ],
-            "gclient_custom_vars": {
-                "download_android_deps": false
-            },
             "gn": [
                 "--runtime-mode",
                 "profile",
@@ -50,9 +47,6 @@
                 "os=Mac-12",
                 "cpu=x86"
             ],
-            "gclient_custom_vars": {
-                "download_android_deps": false
-            },
             "gn": [
                 "--runtime-mode",
                 "profile",
@@ -85,9 +79,6 @@
                 "os=Mac-12",
                 "cpu=x86"
             ],
-            "gclient_custom_vars": {
-                "download_android_deps": false
-            },
             "gn": [
                 "--runtime-mode",
                 "profile",
@@ -120,9 +111,6 @@
                 "os=Mac-12",
                 "cpu=x86"
             ],
-            "gclient_custom_vars": {
-                "download_android_deps": false
-            },
             "gn": [
                 "--runtime-mode",
                 "release",
@@ -154,9 +142,6 @@
                 "os=Mac-12",
                 "cpu=x86"
             ],
-            "gclient_custom_vars": {
-                "download_android_deps": false
-            },
             "gn": [
                 "--runtime-mode",
                 "release",
@@ -189,9 +174,6 @@
                 "os=Mac-12",
                 "cpu=x86"
             ],
-            "gclient_custom_vars": {
-                "download_android_deps": false
-            },
             "gn": [
                 "--runtime-mode",
                 "release",

--- a/ci/builders/mac_host_engine.json
+++ b/ci/builders/mac_host_engine.json
@@ -19,9 +19,6 @@
                 "os=Mac-12",
                 "cpu=x86"
             ],
-            "gclient_custom_vars": {
-                "download_android_deps": false
-            },
             "gn": [
                 "--runtime-mode",
                 "debug",
@@ -60,9 +57,6 @@
                 "os=Mac-12",
                 "cpu=x86"
             ],
-            "gclient_custom_vars": {
-                "download_android_deps": false
-            },
             "gn": [
                 "--runtime-mode",
                 "profile",
@@ -113,9 +107,6 @@
                 "os=Mac-12",
                 "cpu=x86"
             ],
-            "gclient_custom_vars": {
-                "download_android_deps": false
-            },
             "gn": [
                 "--runtime-mode",
                 "release",
@@ -152,9 +143,6 @@
                 "os=Mac-12",
                 "cpu=x86"
             ],
-            "gclient_custom_vars": {
-                "download_android_deps": false
-            },
             "gn": [
                 "--mac",
                 "--mac-cpu",
@@ -191,9 +179,6 @@
                 "os=Mac-12",
                 "cpu=x86"
             ],
-            "gclient_custom_vars": {
-                "download_android_deps": false
-            },
             "gn": [
                 "--mac",
                 "--mac-cpu",
@@ -229,9 +214,6 @@
                 "os=Mac-12",
                 "cpu=x86"
             ],
-            "gclient_custom_vars": {
-                "download_android_deps": false
-            },
             "gn": [
                 "--mac",
                 "--mac-cpu",

--- a/ci/builders/windows_host_engine.json
+++ b/ci/builders/windows_host_engine.json
@@ -21,9 +21,6 @@
                 "device_type=none",
                 "os=Windows-10"
             ],
-            "gclient_custom_vars": {
-                "download_android_deps": false
-            },
             "gn": [
                 "--runtime-mode",
                 "debug",
@@ -74,9 +71,6 @@
                 "device_type=none",
                 "os=Windows-10"
             ],
-            "gclient_custom_vars": {
-                "download_android_deps": false
-            },
             "gn": [
                 "--runtime-mode",
                 "profile",
@@ -108,9 +102,6 @@
                 "device_type=none",
                 "os=Windows-10"
             ],
-            "gclient_custom_vars": {
-                "download_android_deps": false
-            },
             "generators": {},
             "gn": [
                 "--runtime-mode",


### PR DESCRIPTION
The support for per-build custom gclient variable overrides is removed from the build recipes, so the unused fields in the build configuration json are removed here.

This completes the change made in https://github.com/flutter/engine/pull/37351

Bug: flutter/flutter#114656
