### PR TITLE
[macOS] Eliminate Vulkan hack for macOS < 10.14

### DIFF
--- a/vulkan/procs/vulkan_interface.h
+++ b/vulkan/procs/vulkan_interface.h
@@ -24,14 +24,6 @@
 #endif  // VK_USE_PLATFORM_FUCHSIA
 #endif  // OS_FUCHSIA
 
-// TODO(dnfield): vulkan_metal.h has some unguarded availability checks for
-// macOS 10.13. We can remove this if we bump to 10.14 or if that gets fixed
-// upstream, but fixing it upstream will take some time to flow through to
-// ANGLE's DEPS.
-#ifdef VK_USE_PLATFORM_METAL_EXT
-#undef VK_USE_PLATFORM_METAL_EXT
-#endif  // VK_USE_PLATFORM_METAL_EXT
-
 #include <vulkan/vulkan.h>
 
 #define VK_CALL_LOG_ERROR(expression)                     \


### PR DESCRIPTION
Eliminates an undef of VK_USE_PLATFORM_METAL_EXT that works around some unguarded `@available` checks for macOS 10.13. Our minimum macOS SDK is now macOS 10.14 so we can safely assume Metal support since it's a requirement for macOS 10.14.

No test changes since this should only affect the graphics backend used in tests; the tests themselves should be the same regardless of which backend is in use.

Issue: https://github.com/flutter/flutter/issues/114445

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
