### PR TITLE
Do not call Dart_NotifyIdle when in Dart_PerformanceMode_Latency

### DIFF
--- a/lib/ui/window/platform_configuration.cc
+++ b/lib/ui/window/platform_configuration.cc
@@ -371,9 +371,17 @@ void PlatformConfigurationNativeApi::SetIsolateDebugName(
   UIDartState::Current()->SetDebugName(name);
 }
 
+Dart_PerformanceMode PlatformConfigurationNativeApi::current_performace_mode_ =
+    Dart_PerformanceMode_Default;
+
+Dart_PerformanceMode PlatformConfigurationNativeApi::GetDartPerformanceMode() {
+  return current_performace_mode_;
+}
+
 int PlatformConfigurationNativeApi::RequestDartPerformanceMode(int mode) {
   UIDartState::ThrowIfUIOperationsProhibited();
-  return Dart_SetPerformanceMode(static_cast<Dart_PerformanceMode>(mode));
+  current_performace_mode_ = static_cast<Dart_PerformanceMode>(mode);
+  return Dart_SetPerformanceMode(current_performace_mode_);
 }
 
 Dart_Handle PlatformConfigurationNativeApi::GetPersistentIsolateData() {

--- a/lib/ui/window/platform_configuration.h
+++ b/lib/ui/window/platform_configuration.h
@@ -515,9 +515,18 @@ class PlatformConfigurationNativeApi {
   ///
   static int RequestDartPerformanceMode(int mode);
 
+  //--------------------------------------------------------------------------
+  /// @brief      Returns the current performance mode of the Dart VM. Defaults
+  /// to `Dart_PerformanceMode_Default` if no prior requests to change the
+  /// performance mode have been made.
+  static Dart_PerformanceMode GetDartPerformanceMode();
+
   static int64_t GetRootIsolateToken();
 
   static void RegisterBackgroundIsolate(int64_t root_isolate_token);
+
+ private:
+  static Dart_PerformanceMode current_performace_mode_;
 };
 
 }  // namespace flutter

--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -219,6 +219,12 @@ bool RuntimeController::NotifyIdle(fml::TimePoint deadline) {
 
   tonic::DartState::Scope scope(root_isolate);
 
+  Dart_PerformanceMode performance_mode =
+      PlatformConfigurationNativeApi::GetDartPerformanceMode();
+  if (performance_mode == Dart_PerformanceMode::Dart_PerformanceMode_Latency) {
+    return false;
+  }
+
   Dart_NotifyIdle(deadline.ToEpochDelta().ToMicroseconds());
 
   // Idle notifications being in isolate scope are part of the contract.

--- a/shell/common/fixtures/shell_test.dart
+++ b/shell/common/fixtures/shell_test.dart
@@ -204,6 +204,14 @@ void canAccessIsolateLaunchData() {
   );
 }
 
+@pragma('vm:entry-point')
+void performanceModeImpactsNotifyIdle() {
+  notifyNativeBool(false);
+  PlatformDispatcher.instance.requestDartPerformanceMode(DartPerformanceMode.latency);
+  notifyNativeBool(true);
+  PlatformDispatcher.instance.requestDartPerformanceMode(DartPerformanceMode.balanced);
+}
+
 @pragma('vm:external-name', 'NotifyMessage')
 external void notifyMessage(String string);
 


### PR DESCRIPTION
This is to ensure that smoother animations take precedence over idle notifications that trigger GC work.
