### PR TITLE
[Impeller] enable blending on RuntimeEffectsContents

### DIFF
--- a/impeller/entity/contents/runtime_effect_contents.cc
+++ b/impeller/entity/contents/runtime_effect_contents.cc
@@ -114,7 +114,8 @@ bool RuntimeEffectContents::Render(const ContentContext& renderer,
     VALIDATION_LOG << "Failed to set stage inputs for runtime effect pipeline.";
   }
   desc.SetVertexDescriptor(std::move(vertex_descriptor));
-  desc.SetColorAttachmentDescriptor(0u, {.format = PixelFormat::kDefaultColor});
+  desc.SetColorAttachmentDescriptor(
+      0u, {.format = PixelFormat::kDefaultColor, .blending_enabled = true});
   desc.SetStencilAttachmentDescriptors({});
   desc.SetStencilPixelFormat(PixelFormat::kDefaultStencil);
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/115031

Textures were fine, but without blending enabled we always seemed to clear the screen. Even a fully transparent output from a shader would be black. This seems to fix things visually.