### PR TITLE
Add semantics constants to the exported symbols list for the embedder library

### DIFF
--- a/shell/platform/embedder/embedder_exports.lst
+++ b/shell/platform/embedder/embedder_exports.lst
@@ -8,6 +8,7 @@
   global:
     Flutter*;
     __Flutter*;
+    kFlutter*;
     kDartIsolateSnapshotData;
     kDartIsolateSnapshotInstructions;
     kDartVmSnapshotData;

--- a/testing/symbols/verify_exported.dart
+++ b/testing/symbols/verify_exported.dart
@@ -274,7 +274,8 @@ int _checkLinux(String outPath, String nmPath, Iterable<String> builds) {
         break;
       }
       if (!(entry.name.startsWith('Flutter')
-            || entry.name.startsWith('__Flutter'))) {
+            || entry.name.startsWith('__Flutter')
+            || entry.name.startsWith('kFlutter'))) {
         print('ERROR: $libFlutter exports an unexpected symbol name: ($entry)');
         print(' Library has $entries.');
         failures++;


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/114657