### PR TITLE
[Impeller] Add a limit to the Gaussian blur downsampling curve

### DIFF
--- a/impeller/display_list/display_list_unittests.cc
+++ b/impeller/display_list/display_list_unittests.cc
@@ -658,6 +658,9 @@ TEST_P(DisplayListTest, CanDrawZeroLengthLine) {
 TEST_P(DisplayListTest, CanDrawShadow) {
   flutter::DisplayListBuilder builder;
 
+  auto content_scale = GetContentScale() * 0.8;
+  builder.scale(content_scale.x, content_scale.y);
+
   constexpr size_t star_spikes = 5;
   constexpr SkScalar half_spike_rotation = kPi / star_spikes;
   constexpr SkScalar radius = 40;
@@ -677,24 +680,24 @@ TEST_P(DisplayListTest, CanDrawShadow) {
   std::array<SkPath, 4> paths = {
       SkPath{}.addRect(SkRect::MakeXYWH(0, 0, 200, 100)),
       SkPath{}.addRRect(
-          SkRRect::MakeRectXY(SkRect::MakeXYWH(0, 0, 200, 100), 30, 30)),
+          SkRRect::MakeRectXY(SkRect::MakeXYWH(20, 0, 200, 100), 30, 30)),
       SkPath{}.addCircle(100, 50, 50),
       SkPath{}.addPoly(star.data(), star.size(), true),
   };
   builder.setColor(flutter::DlColor::kWhite());
   builder.drawPaint();
   builder.setColor(flutter::DlColor::kCyan());
-  builder.translate(100, 100);
+  builder.translate(100, 50);
   for (size_t x = 0; x < paths.size(); x++) {
     builder.save();
-    for (size_t y = 0; y < 5; y++) {
-      builder.drawShadow(paths[x], flutter::DlColor::kBlack(), 3 + y * 5, false,
+    for (size_t y = 0; y < 6; y++) {
+      builder.drawShadow(paths[x], flutter::DlColor::kBlack(), 3 + y * 8, false,
                          1);
       builder.drawPath(paths[x]);
-      builder.translate(0, 200);
+      builder.translate(0, 150);
     }
     builder.restore();
-    builder.translate(300, 0);
+    builder.translate(250, 0);
   }
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -228,8 +228,11 @@ std::optional<Snapshot> DirectionalGaussianBlurFilterContents::RenderFilter(
 
   Vector2 scale;
   auto scale_curve = [](Scalar radius) {
-    const Scalar d = 4.0;
-    return std::min(1.0, d / (std::max(1.0f, radius) + d - 1.0));
+    constexpr Scalar decay = 4.0;   // Larger is more gradual.
+    constexpr Scalar limit = 0.95;  // The maximum percentage of the scaledown.
+    const Scalar curve =
+        std::min(1.0, decay / (std::max(1.0f, radius) + decay - 1.0));
+    return (curve - 1) * limit + 1;
   };
   {
     scale.x = scale_curve(transformed_blur_radius_length);


### PR DESCRIPTION
The parameterization of the downsampling curve continues. The curve was already nonlinear -- this change just sets the approach value to 0.05. A 95% max downsample seems to be more or less the sweet spot. At some point we may want to make the curve sliiightly less aggressive and set the decay to maybe 4.5 or 5.0 as the downsample is still slightly noticeable towards the half way point of the curve. I'll leave that as an exercise for another day.

https://user-images.githubusercontent.com/919017/201461622-1cd7a7df-e21c-4e8f-9837-1f202aca4715.mov

Before:
![Screen Shot 2022-11-11 at 10 20 04 PM](https://user-images.githubusercontent.com/919017/201461632-48fce705-9a5e-4954-860e-a32564dc5df2.png)

After:
![Screen Shot 2022-11-11 at 10 47 24 PM](https://user-images.githubusercontent.com/919017/201461634-86cd63bf-27f2-43ae-bde8-b97d1f9d522d.png)

The reason for the background weirdness in the after image is a bug with cover geometry I just found and will fix shortly.