### PR TITLE
[Impeller] Fix DrawPaint regression

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -1121,6 +1121,7 @@ TEST_P(AiksTest, CanDrawPaint) {
   Paint paint;
   paint.color = Color::MediumTurquoise();
   Canvas canvas;
+  canvas.Scale(Vector2(0.2, 0.2));
   canvas.DrawPaint(paint);
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }

--- a/impeller/entity/contents/clip_contents.cc
+++ b/impeller/entity/contents/clip_contents.cc
@@ -121,8 +121,7 @@ bool ClipContents::Render(const ContentContext& renderer,
   auto allocator = renderer.GetContext()->GetResourceAllocator();
   cmd.BindVertices(geometry_result.vertex_buffer);
 
-  info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-             entity.GetTransformation();
+  info.mvp = geometry_result.transform;
   VS::BindVertInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(info));
 
   pass.AddCommand(std::move(cmd));

--- a/impeller/entity/contents/linear_gradient_contents.cc
+++ b/impeller/entity/contents/linear_gradient_contents.cc
@@ -66,17 +66,17 @@ bool LinearGradientContents::Render(const ContentContext& renderer,
   gradient_info.half_texel = Vector2(0.5 / gradient_texture->GetSize().width,
                                      0.5 / gradient_texture->GetSize().height);
 
+  auto geometry_result =
+      GetGeometry()->GetPositionBuffer(renderer, entity, pass);
+
   VS::FrameInfo frame_info;
-  frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransformation();
+  frame_info.mvp = geometry_result.transform;
   frame_info.matrix = GetInverseMatrix();
 
   Command cmd;
   cmd.label = "LinearGradientFill";
   cmd.stencil_reference = entity.GetStencilDepth();
 
-  auto geometry_result =
-      GetGeometry()->GetPositionBuffer(renderer, entity, pass);
   auto options = OptionsFromPassAndEntity(pass, entity);
   if (geometry_result.prevent_overdraw) {
     options.stencil_compare = CompareFunction::kEqual;

--- a/impeller/entity/contents/radial_gradient_contents.cc
+++ b/impeller/entity/contents/radial_gradient_contents.cc
@@ -66,17 +66,17 @@ bool RadialGradientContents::Render(const ContentContext& renderer,
   gradient_info.half_texel = Vector2(0.5 / gradient_texture->GetSize().width,
                                      0.5 / gradient_texture->GetSize().height);
 
+  auto geometry_result =
+      GetGeometry()->GetPositionBuffer(renderer, entity, pass);
+
   VS::FrameInfo frame_info;
-  frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransformation();
+  frame_info.mvp = geometry_result.transform;
   frame_info.matrix = GetInverseMatrix();
 
   Command cmd;
   cmd.label = "RadialGradientFill";
   cmd.stencil_reference = entity.GetStencilDepth();
 
-  auto geometry_result =
-      GetGeometry()->GetPositionBuffer(renderer, entity, pass);
   auto options = OptionsFromPassAndEntity(pass, entity);
   if (geometry_result.prevent_overdraw) {
     options.stencil_compare = CompareFunction::kEqual;

--- a/impeller/entity/contents/runtime_effect_contents.cc
+++ b/impeller/entity/contents/runtime_effect_contents.cc
@@ -144,8 +144,7 @@ bool RuntimeEffectContents::Render(const ContentContext& renderer,
   ///
 
   VS::VertInfo frame_info;
-  frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransformation();
+  frame_info.mvp = geometry_result.transform;
   VS::BindVertInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frame_info));
 
   //--------------------------------------------------------------------------

--- a/impeller/entity/contents/solid_color_contents.cc
+++ b/impeller/entity/contents/solid_color_contents.cc
@@ -71,8 +71,7 @@ bool SolidColorContents::Render(const ContentContext& renderer,
   cmd.BindVertices(geometry_result.vertex_buffer);
 
   VS::VertInfo vert_info;
-  vert_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                  entity.GetTransformation();
+  vert_info.mvp = geometry_result.transform;
   VS::BindVertInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(vert_info));
 
   FS::FragInfo frag_info;

--- a/impeller/entity/contents/sweep_gradient_contents.cc
+++ b/impeller/entity/contents/sweep_gradient_contents.cc
@@ -72,16 +72,16 @@ bool SweepGradientContents::Render(const ContentContext& renderer,
   gradient_info.half_texel = Vector2(0.5 / gradient_texture->GetSize().width,
                                      0.5 / gradient_texture->GetSize().height);
 
+  auto geometry_result =
+      GetGeometry()->GetPositionBuffer(renderer, entity, pass);
+
   VS::FrameInfo frame_info;
-  frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransformation();
+  frame_info.mvp = geometry_result.transform;
   frame_info.matrix = GetInverseMatrix();
 
   Command cmd;
   cmd.label = "SweepGradientFill";
   cmd.stencil_reference = entity.GetStencilDepth();
-  auto geometry_result =
-      GetGeometry()->GetPositionBuffer(renderer, entity, pass);
 
   auto options = OptionsFromPassAndEntity(pass, entity);
   if (geometry_result.prevent_overdraw) {

--- a/impeller/entity/contents/tiled_texture_contents.cc
+++ b/impeller/entity/contents/tiled_texture_contents.cc
@@ -50,9 +50,11 @@ bool TiledTextureContents::Render(const ContentContext& renderer,
 
   auto& host_buffer = pass.GetTransientsBuffer();
 
+  auto geometry_result =
+      GetGeometry()->GetPositionBuffer(renderer, entity, pass);
+
   VS::VertInfo vert_info;
-  vert_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                  entity.GetTransformation();
+  vert_info.mvp = geometry_result.transform;
   vert_info.matrix = GetInverseMatrix();
   vert_info.texture_size = Vector2{static_cast<Scalar>(texture_size.width),
                                    static_cast<Scalar>(texture_size.height)};
@@ -66,9 +68,6 @@ bool TiledTextureContents::Render(const ContentContext& renderer,
   Command cmd;
   cmd.label = "TiledTextureFill";
   cmd.stencil_reference = entity.GetStencilDepth();
-
-  auto geometry_result =
-      GetGeometry()->GetPositionBuffer(renderer, entity, pass);
 
   auto options = OptionsFromPassAndEntity(pass, entity);
   if (geometry_result.prevent_overdraw) {

--- a/impeller/entity/contents/vertices_contents.cc
+++ b/impeller/entity/contents/vertices_contents.cc
@@ -76,8 +76,7 @@ bool VerticesContents::Render(const ContentContext& renderer,
       cmd.BindVertices(geometry_result.vertex_buffer);
 
       VS::VertInfo vert_info;
-      vert_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                      entity.GetTransformation();
+      vert_info.mvp = geometry_result.transform;
       vert_info.color = color_.Premultiply();
       VS::BindVertInfo(cmd,
                        pass.GetTransientsBuffer().EmplaceUniform(vert_info));

--- a/impeller/entity/geometry.cc
+++ b/impeller/entity/geometry.cc
@@ -5,6 +5,7 @@
 #include "impeller/entity/geometry.h"
 #include "impeller/entity/contents/content_context.h"
 #include "impeller/entity/position_color.vert.h"
+#include "impeller/geometry/matrix.h"
 #include "impeller/geometry/path_builder.h"
 #include "impeller/renderer/device_buffer.h"
 #include "impeller/renderer/render_pass.h"
@@ -106,6 +107,8 @@ GeometryResult VerticesGeometry::GetPositionBuffer(
               .index_count = vertices_.GetIndices().size(),
               .index_type = IndexType::k16bit,
           },
+      .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
+                   entity.GetTransformation(),
       .prevent_overdraw = false,
   };
 }
@@ -168,6 +171,8 @@ GeometryResult VerticesGeometry::GetPositionColorBuffer(
               .index_count = vertices_.GetIndices().size(),
               .index_type = IndexType::k16bit,
           },
+      .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
+                   entity.GetTransformation(),
       .prevent_overdraw = false,
   };
 }
@@ -224,6 +229,8 @@ GeometryResult FillPathGeometry::GetPositionBuffer(
   return GeometryResult{
       .type = PrimitiveType::kTriangle,
       .vertex_buffer = vertex_buffer,
+      .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
+                   entity.GetTransformation(),
       .prevent_overdraw = false,
   };
 }
@@ -577,6 +584,8 @@ GeometryResult StrokePathGeometry::GetPositionBuffer(
   return GeometryResult{
       .type = PrimitiveType::kTriangleStrip,
       .vertex_buffer = vertex_buffer,
+      .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
+                   entity.GetTransformation(),
       .prevent_overdraw = true,
   };
 }
@@ -627,14 +636,16 @@ GeometryResult CoverGeometry::GetPositionBuffer(const ContentContext& renderer,
   auto& host_buffer = pass.GetTransientsBuffer();
   return GeometryResult{
       .type = PrimitiveType::kTriangleStrip,
-      .vertex_buffer = {.vertex_buffer = host_buffer.Emplace(
-                            rect.GetPoints().data(), 8 * sizeof(float),
-                            alignof(float)),
-                        .index_buffer = host_buffer.Emplace(
-                            kRectIndicies, 4 * sizeof(uint16_t),
-                            alignof(uint16_t)),
-                        .index_count = 4,
-                        .index_type = IndexType::k16bit},
+      .vertex_buffer =
+          {
+              .vertex_buffer = host_buffer.Emplace(
+                  rect.GetPoints().data(), 8 * sizeof(float), alignof(float)),
+              .index_buffer = host_buffer.Emplace(
+                  kRectIndicies, 4 * sizeof(uint16_t), alignof(uint16_t)),
+              .index_count = 4,
+              .index_type = IndexType::k16bit,
+          },
+      .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()),
       .prevent_overdraw = false,
   };
 }
@@ -660,14 +671,17 @@ GeometryResult RectGeometry::GetPositionBuffer(const ContentContext& renderer,
   auto& host_buffer = pass.GetTransientsBuffer();
   return GeometryResult{
       .type = PrimitiveType::kTriangleStrip,
-      .vertex_buffer = {.vertex_buffer = host_buffer.Emplace(
-                            rect_.GetPoints().data(), 8 * sizeof(float),
-                            alignof(float)),
-                        .index_buffer = host_buffer.Emplace(
-                            kRectIndicies, 4 * sizeof(uint16_t),
-                            alignof(uint16_t)),
-                        .index_count = 4,
-                        .index_type = IndexType::k16bit},
+      .vertex_buffer =
+          {
+              .vertex_buffer = host_buffer.Emplace(
+                  rect_.GetPoints().data(), 8 * sizeof(float), alignof(float)),
+              .index_buffer = host_buffer.Emplace(
+                  kRectIndicies, 4 * sizeof(uint16_t), alignof(uint16_t)),
+              .index_count = 4,
+              .index_type = IndexType::k16bit,
+          },
+      .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
+                   entity.GetTransformation(),
       .prevent_overdraw = false,
   };
 }

--- a/impeller/entity/geometry.h
+++ b/impeller/entity/geometry.h
@@ -21,6 +21,7 @@ class Tessellator;
 struct GeometryResult {
   PrimitiveType type;
   VertexBuffer vertex_buffer;
+  Matrix transform;
   bool prevent_overdraw;
 };
 


### PR DESCRIPTION
* Gives the responsibility of building the vertex transform to Geometry.
* Fix an issue where the entity transform is getting applied for cover geometry instead of always covering the whole render target.
* Enables more optimizations in the future revolving around GPU geometry reuse.

Before:
![Screen Shot 2022-11-12 at 3 05 53 PM](https://user-images.githubusercontent.com/919017/201498040-67dc77fd-7074-4e5f-b77c-75e0577dd7bd.png)

After:
![Screen Shot 2022-11-12 at 3 04 39 PM](https://user-images.githubusercontent.com/919017/201498037-b54b0dae-0aed-4cf9-a943-0f1d1625c902.png)

(This is also visible in a few other playgrounds.)