### PR TITLE
[Impeller] dont include sampler offset in float offset

### DIFF
--- a/impeller/entity/contents/runtime_effect_contents.cc
+++ b/impeller/entity/contents/runtime_effect_contents.cc
@@ -189,6 +189,7 @@ bool RuntimeEffectContents::Render(const ContentContext& renderer,
         uniform_slot.ext_res_0 = buffer_index;
         cmd.BindResource(ShaderStage::kFragment, uniform_slot, metadata,
                          buffer_view);
+        buffer_index++;
         break;
       }
       case kBoolean:
@@ -206,8 +207,6 @@ bool RuntimeEffectContents::Render(const ContentContext& renderer,
                        << ".";
         return true;
     }
-
-    buffer_index++;
   }
 
   pass.AddCommand(std::move(cmd));


### PR DESCRIPTION
Otherwise a sampler uniform early in the uniforms list will cause all subsequent float uniforms to be off by one.

Fixes https://github.com/flutter/flutter/issues/115246
