### PR TITLE
[Impeller] Add playground to demonstrate mask blur + color source application problems

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -12,6 +12,7 @@
 #include "impeller/aiks/aiks_playground.h"
 #include "impeller/aiks/canvas.h"
 #include "impeller/aiks/image.h"
+#include "impeller/entity/contents/filters/inputs/filter_input.h"
 #include "impeller/entity/contents/tiled_texture_contents.h"
 #include "impeller/geometry/color.h"
 #include "impeller/geometry/geometry_unittests.h"

--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -161,7 +161,7 @@ bool Canvas::AttemptDrawBlurredRRect(const Rect& rect,
                                      Scalar corner_radius,
                                      const Paint& paint) {
   // TODO(114184): This should return false when the paint's ColorSource is not
-  //               solid color.
+  //               color.
   if (!paint.mask_blur_descriptor.has_value() ||
       paint.mask_blur_descriptor->style != FilterContents::BlurStyle::kNormal ||
       paint.style != Paint::Style::kFill) {


### PR DESCRIPTION
My intention with this test was to repro https://github.com/flutter/flutter/issues/114184, but this also demonstrates other known fidelity problems:

![Screen Shot 2022-11-13 at 2 47 19 PM](https://user-images.githubusercontent.com/919017/201548912-ede5a1b1-6ffe-489b-b8da-f229bc0f53c3.png)

* The top two RRects (using the Color ColorSource) are rendering correctly.
* The bottom two are supposed to both be blurred linear gradients.