### PR TITLE
Fix "unexpected masked action" assertion crash

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/AndroidTouchProcessor.java
+++ b/shell/platform/android/io/flutter/embedding/android/AndroidTouchProcessor.java
@@ -389,7 +389,7 @@ public class AndroidTouchProcessor {
     if (maskedAction == MotionEvent.ACTION_SCROLL) {
       return PointerChange.HOVER;
     }
-    throw new AssertionError("Unexpected masked action");
+    return -1;
   }
 
   @PointerChange

--- a/shell/platform/android/test/io/flutter/embedding/android/AndroidTouchProcessorTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/AndroidTouchProcessorTest.java
@@ -3,6 +3,8 @@ package io.flutter.embedding.android;
 import static junit.framework.TestCase.assertEquals;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import android.annotation.TargetApi;
@@ -205,5 +207,15 @@ public class AndroidTouchProcessorTest {
     assertEquals(10.0, readPointerPhysicalX(packet));
     assertEquals(5.0, readPointerPhysicalY(packet));
     inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  public void unexpectedMaskedAction() {
+    // Regression test for https://github.com/flutter/flutter/issues/111068
+    MotionEventMocker mocker =
+        new MotionEventMocker(1, InputDevice.SOURCE_STYLUS, MotionEvent.TOOL_TYPE_STYLUS);
+    // ACTION_BUTTON_PRESS is not handled by AndroidTouchProcessor, nothing should be dispatched.
+    touchProcessor.onTouchEvent(mocker.mockEvent(MotionEvent.ACTION_BUTTON_PRESS, 0.0f, 0.0f, 0));
+    verify(mockRenderer, never()).dispatchPointerDataPacket(ByteBuffer.allocate(0), 0);
   }
 }


### PR DESCRIPTION
In #34060 I changed a `return -1` to an assertion, this was a mistake. The returning -1 was correct, the events with those values get filtered out in `addPointerForIndex` later on. It's the correct behaviour to skip events we don't understand rather than crashing.

Fixes #111068

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
