### PR TITLE
catch file system exception in constfindertest

### DIFF
--- a/tools/const_finder/test/const_finder_test.dart
+++ b/tools/const_finder/test/const_finder_test.dart
@@ -393,7 +393,11 @@ class _Test {
   void dispose() {
     for (final String resource in resourcesToDispose) {
       stdout.writeln('Deleting $resource');
-      File(resource).deleteSync();
+      try {
+        File(resource).deleteSync();
+      } on FileSystemException catch (err) {
+        stderr.writeln(err.toString());
+      }
     }
   }
 


### PR DESCRIPTION
Follow-up fix for Dart HHH after https://github.com/flutter/engine/pull/37257#discussion_r1021517981