### PR TITLE
[Impeller] Only apply the rrect blur fast path for solid Colors

### DIFF
--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -160,11 +160,14 @@ void Canvas::DrawPaint(const Paint& paint) {
 bool Canvas::AttemptDrawBlurredRRect(const Rect& rect,
                                      Scalar corner_radius,
                                      const Paint& paint) {
-  // TODO(114184): This should return false when the paint's ColorSource is not
-  //               color.
-  if (!paint.mask_blur_descriptor.has_value() ||
-      paint.mask_blur_descriptor->style != FilterContents::BlurStyle::kNormal ||
+  if (paint.color_source == nullptr ||
+      paint.color_source_type != Paint::ColorSourceType::kColor ||
       paint.style != Paint::Style::kFill) {
+    return false;
+  }
+
+  if (!paint.mask_blur_descriptor.has_value() ||
+      paint.mask_blur_descriptor->style != FilterContents::BlurStyle::kNormal) {
     return false;
   }
 

--- a/impeller/aiks/paint.h
+++ b/impeller/aiks/paint.h
@@ -36,6 +36,16 @@ struct Paint {
     kStroke,
   };
 
+  enum class ColorSourceType {
+    kColor,
+    kImage,
+    kLinearGradient,
+    kRadialGradient,
+    kConicalGradient,
+    kSweepGradient,
+    kRuntimeEffect,
+  };
+
   struct MaskBlurDescriptor {
     FilterContents::BlurStyle style;
     Sigma sigma;
@@ -48,6 +58,7 @@ struct Paint {
 
   Color color = Color::Black();
   std::optional<ColorSourceProc> color_source;
+  ColorSourceType color_source_type = ColorSourceType::kColor;
 
   Scalar stroke_width = 0.0;
   Cap stroke_cap = Cap::kButt;


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/114184.

~~This also reveals a different bug: It appears that the fast BorderMaskBlur filter is being used instead of the regular Gaussian blur.~~ ~~I think this is also a regression but there hasn't been a playground that reproduces it until now.~~ 
Actually, this isn't a regression -- we always apply the BorderMaskBlur filter for non-solid color sources. This is correct behavior for images, but I need to check over how Skia behaves with the rest of the color sources now that they're all mostly implemented.

Before
![Screen Shot 2022-11-13 at 2 47 19 PM](https://user-images.githubusercontent.com/919017/201763690-906bc480-293e-4242-872f-04bdad27d156.png)

After
![Screen Shot 2022-11-14 at 12 48 03 PM](https://user-images.githubusercontent.com/919017/201763684-b3f0ffec-bd6f-4e55-b918-b6b4ca3e6cb9.png)
