### PR TITLE
Avoid segfault when converting no-op ColorFilter to ImageFilter

### DIFF
--- a/lib/ui/painting/image_filter.cc
+++ b/lib/ui/painting/image_filter.cc
@@ -74,8 +74,11 @@ void ImageFilter::initMatrix(const tonic::Float64List& matrix4,
 
 void ImageFilter::initColorFilter(ColorFilter* colorFilter) {
   FML_DCHECK(colorFilter);
-  filter_ =
-      std::make_shared<DlColorFilterImageFilter>(colorFilter->dl_filter());
+  auto dl_filter = colorFilter->dl_filter();
+  // Skia may return nullptr if the colorfilter is a no-op.
+  if (dl_filter) {
+    filter_ = std::make_shared<DlColorFilterImageFilter>(dl_filter);
+  }
 }
 
 void ImageFilter::initComposeFilter(ImageFilter* outer, ImageFilter* inner) {

--- a/testing/dart/canvas_test.dart
+++ b/testing/dart/canvas_test.dart
@@ -110,6 +110,9 @@ void testNoCrashes() {
     testCanvas((Canvas canvas) => canvas.drawVertices(Vertices(VertexMode.triangles, <Offset>[],
                                                                indices: <int>[]), BlendMode.screen, paint));
     testCanvas((Canvas canvas) => canvas.drawVertices(Vertices(VertexMode.triangles, <Offset>[])..dispose(), BlendMode.screen, paint));
+
+    // Regression test for https://github.com/flutter/flutter/issues/115143
+    testCanvas((Canvas canvas) => canvas.drawPaint(Paint()..imageFilter = const ColorFilter.mode(Color(0x00000000), BlendMode.xor)));
   });
 }
 


### PR DESCRIPTION
When constructing the `DlColorFilterImageFilter`, it doesn't tolerate nullptr. But if Skia decides the color filter is a no-op, we're giving it nullptr.

It might be useful to have something in DL to signify no-op, or otherwise optimize these away, but it's probably a micro-optimization if anything and we should at least avoid crashing.

fixes https://github.com/flutter/flutter/issues/115143