### PR TITLE
Skip the skwasm unit test suite on Safari since it is flaky.

### DIFF
--- a/lib/web_ui/dev/steps/run_tests_step.dart
+++ b/lib/web_ui/dev/steps/run_tests_step.dart
@@ -104,9 +104,10 @@ class RunTestsStep implements PipelineStep {
       testsPassed &= io.exitCode == 0;
     }
 
+    // TODO(jacksongardner): enable this test suite on safari
     // For some reason, Safari is flaky when running the Skwasm test suite
     // See https://github.com/flutter/flutter/issues/115312
-    if (browserName != kSafari &&  sortedTests.skwasmTests.isNotEmpty) {
+    if (browserName != kSafari && sortedTests.skwasmTests.isNotEmpty) {
       await _runTestBatch(
         testFiles: sortedTests.skwasmTests,
         renderer: Renderer.skwasm,

--- a/lib/web_ui/dev/steps/run_tests_step.dart
+++ b/lib/web_ui/dev/steps/run_tests_step.dart
@@ -104,7 +104,9 @@ class RunTestsStep implements PipelineStep {
       testsPassed &= io.exitCode == 0;
     }
 
-    if (sortedTests.skwasmTests.isNotEmpty) {
+    // For some reason, Safari is flaky when running the Skwasm test suite
+    // See https://github.com/flutter/flutter/issues/115312
+    if (browserName != kSafari &&  sortedTests.skwasmTests.isNotEmpty) {
       await _runTestBatch(
         testFiles: sortedTests.skwasmTests,
         renderer: Renderer.skwasm,


### PR DESCRIPTION
We're having some periodic flakes of this part of the test suite on the Safari webdriver only. I suspect it has to do with only having a single unit test in the suite, but I'm not positive. Let's just disable this for now, I filed a follow-on issue for deeper investigation later: https://github.com/flutter/flutter/issues/115312