### PR TITLE
Pass the correct name for gclient variables in ci.yaml (#37429)

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -268,8 +268,8 @@ targets:
       add_recipes_cq: "true"
       cores: "32"
       gcs_goldens_bucket: flutter_logs
-      gclient_custom_vars: >-
-        {"download_emsdk": True}
+      gclient_variables: >-
+        {"download_emsdk": true}
       dependencies: >-
         [
           {"dependency": "goldctl", "version": "git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603"}
@@ -409,8 +409,8 @@ targets:
     properties:
       add_recipes_cq: "true"
       gcs_goldens_bucket: flutter_logs
-      gclient_custom_vars: >-
-        {"download_emsdk": True}
+      gclient_variables: >-
+        {"download_emsdk": true}
       dependencies: >-
         [
           {"dependency": "goldctl", "version": "git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603"}
@@ -485,7 +485,7 @@ targets:
   - name: Windows Web Engine
     recipe: engine/web_engine
     properties:
-      gclient_custom_vars: >-
+      gclient_variables: >-
         {"download_emsdk": true}
       gcs_goldens_bucket: flutter_logs
     timeout: 60


### PR DESCRIPTION
Cherry-pick to fix test failures in release branch due to incorrect .ci.yaml values. 