### PR TITLE
[Impeller] Add ability to set the entry-point name for HLSL shaders

### DIFF
--- a/impeller/compiler/compiler.cc
+++ b/impeller/compiler/compiler.cc
@@ -102,7 +102,8 @@ static CompilerBackend CreateCompiler(const spirv_cross::ParsedIR& ir,
     return {};
   }
   auto* backend = compiler.GetCompiler();
-  if (!EntryPointMustBeNamedMain(source_options.target_platform)) {
+  if (!EntryPointMustBeNamedMain(source_options.target_platform) &&
+      source_options.source_language == SourceLanguage::kGLSL) {
     backend->rename_entry_point("main", source_options.entry_point_name,
                                 ToExecutionModel(source_options.type));
   }

--- a/impeller/compiler/compiler_test.cc
+++ b/impeller/compiler/compiler_test.cc
@@ -67,7 +67,8 @@ std::unique_ptr<fml::FileMapping> CompilerTest::GetReflectionJson(
 
 bool CompilerTest::CanCompileAndReflect(const char* fixture_name,
                                         SourceType source_type,
-                                        SourceLanguage source_language) const {
+                                        SourceLanguage source_language,
+                                        const char* entry_point_name) const {
   auto fixture = flutter::testing::OpenFixtureAsMapping(fixture_name);
   if (!fixture || !fixture->GetMapping()) {
     VALIDATION_LOG << "Could not find shader in fixtures: " << fixture_name;
@@ -80,7 +81,8 @@ bool CompilerTest::CanCompileAndReflect(const char* fixture_name,
   source_options.working_directory = std::make_shared<fml::UniqueFD>(
       flutter::testing::OpenFixturesDirectory());
   source_options.entry_point_name = EntryPointFunctionNameFromSourceName(
-      fixture_name, SourceTypeFromFileName(fixture_name), source_language);
+      fixture_name, SourceTypeFromFileName(fixture_name), source_language,
+      entry_point_name);
 
   Reflector::Options reflector_options;
   reflector_options.header_file_name = ReflectionHeaderName(fixture_name);

--- a/impeller/compiler/compiler_test.h
+++ b/impeller/compiler/compiler_test.h
@@ -27,7 +27,8 @@ class CompilerTest : public ::testing::TestWithParam<TargetPlatform> {
   bool CanCompileAndReflect(
       const char* fixture_name,
       SourceType source_type = SourceType::kUnknown,
-      SourceLanguage source_language = SourceLanguage::kGLSL) const;
+      SourceLanguage source_language = SourceLanguage::kGLSL,
+      const char* entry_point_name = "main") const;
 
  private:
   fml::UniqueFD intermediates_directory_;

--- a/impeller/compiler/compiler_unittests.cc
+++ b/impeller/compiler/compiler_unittests.cc
@@ -37,6 +37,15 @@ TEST_P(CompilerTest, CanCompileHLSL) {
       "simple.vert.hlsl", SourceType::kVertexShader, SourceLanguage::kHLSL));
 }
 
+TEST_P(CompilerTest, CanCompileHLSLWithMultipleStages) {
+  ASSERT_TRUE(CanCompileAndReflect("multiple_stages.hlsl",
+                                   SourceType::kVertexShader,
+                                   SourceLanguage::kHLSL, "VertexShader"));
+  ASSERT_TRUE(CanCompileAndReflect("multiple_stages.hlsl",
+                                   SourceType::kFragmentShader,
+                                   SourceLanguage::kHLSL, "FragmentShader"));
+}
+
 TEST_P(CompilerTest, CanCompileTessellationControlShader) {
   ASSERT_TRUE(CanCompileAndReflect("sample.tesc"));
   ASSERT_TRUE(CanCompileAndReflect("sample.tesc",

--- a/impeller/compiler/impellerc_main.cc
+++ b/impeller/compiler/impellerc_main.cc
@@ -70,7 +70,8 @@ bool Main(const fml::CommandLine& command_line) {
   options.include_dirs = switches.include_directories;
   options.defines = switches.defines;
   options.entry_point_name = EntryPointFunctionNameFromSourceName(
-      switches.source_file_name, options.type, options.source_language);
+      switches.source_file_name, options.type, options.source_language,
+      switches.entry_point);
   options.json_format = switches.json_format;
 
   Reflector::Options reflector_options;

--- a/impeller/compiler/switches.cc
+++ b/impeller/compiler/switches.cc
@@ -57,6 +57,9 @@ void Switches::PrintHelp(std::ostream& stream) {
   stream << "--spirv=<spirv_output_file>" << std::endl;
   stream << "[optional] --source-language=glsl|hlsl (default: glsl)"
          << std::endl;
+  stream << "[optional] --entry-point=<entry_point_name> (default: main; "
+            "ignored for glsl)"
+         << std::endl;
   stream << "[optional] --iplr (causes --sl file to be emitted in iplr format)"
          << std::endl;
   stream << "[optional] --reflection-json=<reflection_json_file>" << std::endl;
@@ -120,7 +123,9 @@ Switches::Switches(const fml::CommandLine& command_line)
       reflection_cc_name(
           command_line.GetOptionValueWithDefault("reflection-cc", "")),
       depfile_path(command_line.GetOptionValueWithDefault("depfile", "")),
-      json_format(command_line.HasOption("json")) {
+      json_format(command_line.HasOption("json")),
+      entry_point(
+          command_line.GetOptionValueWithDefault("entry-point", "main")) {
   if (!working_directory || !working_directory->is_valid()) {
     return;
   }

--- a/impeller/compiler/switches.h
+++ b/impeller/compiler/switches.h
@@ -33,6 +33,7 @@ struct Switches {
   std::vector<std::string> defines;
   bool json_format;
   SourceLanguage source_language = SourceLanguage::kUnknown;
+  std::string entry_point;
 
   Switches();
 

--- a/impeller/compiler/switches_unittests.cc
+++ b/impeller/compiler/switches_unittests.cc
@@ -57,6 +57,18 @@ TEST(SwitchesTest, SourceLanguageCanBeSetToHLSL) {
   ASSERT_EQ(switches.source_language, SourceLanguage::kHLSL);
 }
 
+TEST(SwitchesTest, DefaultEntryPointIsMain) {
+  Switches switches = MakeSwitchesDesktopGL({});
+  ASSERT_TRUE(switches.AreValid(std::cout));
+  ASSERT_EQ(switches.entry_point, "main");
+}
+
+TEST(SwitchesTest, EntryPointCanBeSetForHLSL) {
+  Switches switches = MakeSwitchesDesktopGL({"--entry-point=CustomEntryPoint"});
+  ASSERT_TRUE(switches.AreValid(std::cout));
+  ASSERT_EQ(switches.entry_point, "CustomEntryPoint");
+}
+
 }  // namespace testing
 }  // namespace compiler
 }  // namespace impeller

--- a/impeller/compiler/types.cc
+++ b/impeller/compiler/types.cc
@@ -88,9 +88,10 @@ std::string SourceLanguageToString(SourceLanguage source_language) {
 std::string EntryPointFunctionNameFromSourceName(
     const std::string& file_name,
     SourceType type,
-    SourceLanguage source_language) {
+    SourceLanguage source_language,
+    const std::string& entry_point_name) {
   if (source_language == SourceLanguage::kHLSL) {
-    return "main";
+    return entry_point_name;
   }
 
   std::stringstream stream;

--- a/impeller/compiler/types.h
+++ b/impeller/compiler/types.h
@@ -60,7 +60,8 @@ std::string TargetPlatformSLExtension(TargetPlatform platform);
 std::string EntryPointFunctionNameFromSourceName(
     const std::string& file_name,
     SourceType type,
-    SourceLanguage source_language);
+    SourceLanguage source_language,
+    const std::string& entry_point_name);
 
 bool TargetPlatformNeedsSL(TargetPlatform platform);
 

--- a/impeller/fixtures/BUILD.gn
+++ b/impeller/fixtures/BUILD.gn
@@ -54,6 +54,7 @@ test_fixtures("file_fixtures") {
     "boston.jpg",
     "embarcadero.jpg",
     "kalimba.jpg",
+    "multiple_stages.hlsl",
     "resources_limit.vert",
     "sample.comp",
     "sample.frag",

--- a/impeller/fixtures/multiple_stages.hlsl
+++ b/impeller/fixtures/multiple_stages.hlsl
@@ -10,8 +10,12 @@ struct VertexOutput {
   float4 position : SV_POSITION;
 };
 
-VertexOutput main(VertexInput input) {
+VertexOutput VertexShader(VertexInput input) {
   VertexOutput output;
   output.position = float4(input.position, 1.0);
   return output;
+}
+
+float4 FragmentShader(VertexOutput input) {
+  return input.position;
 }


### PR DESCRIPTION
Allows for multiple stages to be defined in one HLSL shader.