### PR TITLE
[dart] Run generate_sdk_version_file.py to be compatible with dart ch…

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -722,6 +722,12 @@ hooks = [
     'action': ['python3', 'src/third_party/dart/tools/generate_package_config.py'],
   },
   {
+    # Generate the sdk/version file.
+    'name': 'Generate sdk/version',
+    'pattern': '.',
+    'action': ['python3', 'src/third_party/dart/tools/generate_sdk_version_file.py'],
+  },
+  {
     # Update the Windows toolchain if necessary.
     'name': 'win_toolchain',
     'condition': 'download_windows_deps',

--- a/ci/licenses_golden/licenses_third_party
+++ b/ci/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: e54286872cbf35f18a66b564937e9d97
+Signature: 499eb68044d9c4ec34a5c64ea8fac288
 
 UNUSED LICENSES:
 
@@ -17357,6 +17357,7 @@ FILE: ../../../third_party/dart/sdk/lib/html/html_common/conversions_dart2js.dar
 FILE: ../../../third_party/dart/sdk/lib/html/html_common/html_common.dart
 FILE: ../../../third_party/dart/sdk/lib/libraries.json
 FILE: ../../../third_party/dart/sdk/lib/vmservice_libraries.json
+FILE: ../../../third_party/dart/sdk/version
 FILE: ../../../third_party/dart/third_party/clang.tar.gz.sha1
 ----------------------------------------------------------------------------------------------------
 Copyright 2012, the Dart project authors.


### PR DESCRIPTION
A recent change on the dart side (https://github.com/dart-lang/sdk/commit/60029641af8f6b2e25913e9b3ae94cb89c73b222) requires the 'sdk/version' file to exist for dart to compile. That's not currently the case in flutter, but this PR adds the DEPs entry to generate it.