### PR TITLE
[Impeller] Manage deletions using a deletion queue

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1451,6 +1451,8 @@ FILE: ../../../flutter/impeller/renderer/backend/vulkan/command_pool_vk.cc
 FILE: ../../../flutter/impeller/renderer/backend/vulkan/command_pool_vk.h
 FILE: ../../../flutter/impeller/renderer/backend/vulkan/context_vk.cc
 FILE: ../../../flutter/impeller/renderer/backend/vulkan/context_vk.h
+FILE: ../../../flutter/impeller/renderer/backend/vulkan/deletion_queue_vk.cc
+FILE: ../../../flutter/impeller/renderer/backend/vulkan/deletion_queue_vk.h
 FILE: ../../../flutter/impeller/renderer/backend/vulkan/descriptor_pool_vk.cc
 FILE: ../../../flutter/impeller/renderer/backend/vulkan/descriptor_pool_vk.h
 FILE: ../../../flutter/impeller/renderer/backend/vulkan/device_buffer_vk.cc

--- a/impeller/renderer/backend/vulkan/BUILD.gn
+++ b/impeller/renderer/backend/vulkan/BUILD.gn
@@ -18,6 +18,8 @@ impeller_component("vulkan") {
     "command_pool_vk.h",
     "context_vk.cc",
     "context_vk.h",
+    "deletion_queue_vk.cc",
+    "deletion_queue_vk.h",
     "descriptor_pool_vk.cc",
     "descriptor_pool_vk.h",
     "device_buffer_vk.cc",

--- a/impeller/renderer/backend/vulkan/command_buffer_vk.cc
+++ b/impeller/renderer/backend/vulkan/command_buffer_vk.cc
@@ -115,17 +115,17 @@ std::shared_ptr<RenderPass> CommandBufferVK::OnCreateRenderPass(
   render_pass_create.setSubpassCount(1);
   render_pass_create.setPSubpasses(&subpass_desc);
 
-  auto render_pass_create_res =
-      device_.createRenderPassUnique(render_pass_create);
+  auto render_pass_create_res = device_.createRenderPass(render_pass_create);
   if (render_pass_create_res.result != vk::Result::eSuccess) {
     VALIDATION_LOG << "Failed to create render pass: "
                    << vk::to_string(render_pass_create_res.result);
     return nullptr;
   }
 
-  return std::make_shared<RenderPassVK>(
-      context_, device_, std::move(target), std::move(command_buffer_),
-      std::move(render_pass_create_res.value), surface_producer_);
+  vk::RenderPass render_pass = render_pass_create_res.value;
+  return std::make_shared<RenderPassVK>(context_, device_, std::move(target),
+                                        std::move(command_buffer_), render_pass,
+                                        surface_producer_);
 }
 
 std::shared_ptr<BlitPass> CommandBufferVK::OnCreateBlitPass() const {

--- a/impeller/renderer/backend/vulkan/context_vk.h
+++ b/impeller/renderer/backend/vulkan/context_vk.h
@@ -11,6 +11,7 @@
 #include "flutter/fml/mapping.h"
 #include "impeller/base/backend_cast.h"
 #include "impeller/renderer/backend/vulkan/command_pool_vk.h"
+#include "impeller/renderer/backend/vulkan/deletion_queue_vk.h"
 #include "impeller/renderer/backend/vulkan/descriptor_pool_vk.h"
 #include "impeller/renderer/backend/vulkan/pipeline_library_vk.h"
 #include "impeller/renderer/backend/vulkan/sampler_library_vk.h"
@@ -85,11 +86,13 @@ class ContextVK final : public Context, public BackendCast<ContextVK, Context> {
 
   std::unique_ptr<Surface> AcquireSurface(size_t current_frame);
 
-  std::shared_ptr<DescriptorPoolVK> GetDescriptorPool() const;
+  std::unique_ptr<DescriptorPoolVK> CreateDescriptorPool() const;
 
 #ifdef FML_OS_ANDROID
   vk::UniqueSurfaceKHR CreateAndroidSurface(ANativeWindow* window) const;
 #endif  // FML_OS_ANDROID
+
+  DeletionQueueVK* GetDeletionQueue(size_t frame_num) const;
 
  private:
   std::shared_ptr<fml::ConcurrentTaskRunner> worker_task_runner_;
@@ -111,7 +114,7 @@ class ContextVK final : public Context, public BackendCast<ContextVK, Context> {
   std::unique_ptr<CommandPoolVK> graphics_command_pool_;
   std::unique_ptr<SurfaceProducerVK> surface_producer_;
   std::shared_ptr<WorkQueue> work_queue_;
-  std::shared_ptr<DescriptorPoolVK> descriptor_pool_;
+  std::vector<std::unique_ptr<DeletionQueueVK>> deletion_queues_;
   bool is_valid_ = false;
 
   ContextVK(

--- a/impeller/renderer/backend/vulkan/deletion_queue_vk.cc
+++ b/impeller/renderer/backend/vulkan/deletion_queue_vk.cc
@@ -1,0 +1,27 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/renderer/backend/vulkan/deletion_queue_vk.h"
+
+namespace impeller {
+
+DeletionQueueVK::DeletionQueueVK() = default;
+
+DeletionQueueVK::~DeletionQueueVK() {
+  Flush();
+}
+
+void DeletionQueueVK::Flush() {
+  for (auto it = deletors_.rbegin(); it != deletors_.rend(); ++it) {
+    (*it)();
+  }
+
+  deletors_.clear();
+}
+
+void DeletionQueueVK::Push(Deletor&& deletor) {
+  deletors_.push_back(std::move(deletor));
+}
+
+}  // namespace impeller

--- a/impeller/renderer/backend/vulkan/deletion_queue_vk.h
+++ b/impeller/renderer/backend/vulkan/deletion_queue_vk.h
@@ -1,0 +1,32 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#pragma once
+
+#include <deque>
+#include <functional>
+
+#include "flutter/fml/macros.h"
+
+namespace impeller {
+
+class DeletionQueueVK {
+ public:
+  using Deletor = std::function<void()>;
+
+  explicit DeletionQueueVK();
+
+  ~DeletionQueueVK();
+
+  void Flush();
+
+  void Push(Deletor&& deletor);
+
+ private:
+  std::deque<Deletor> deletors_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(DeletionQueueVK);
+};
+
+}  // namespace impeller

--- a/impeller/renderer/backend/vulkan/descriptor_pool_vk.cc
+++ b/impeller/renderer/backend/vulkan/descriptor_pool_vk.cc
@@ -10,7 +10,7 @@
 
 namespace impeller {
 
-DescriptorPoolVK::DescriptorPoolVK(vk::Device device) : device_(device) {
+DescriptorPoolVK::DescriptorPoolVK(vk::Device device) {
   constexpr size_t kPoolSize = 1024;
 
   std::vector<vk::DescriptorPoolSize> pool_sizes = {
@@ -48,10 +48,6 @@ vk::DescriptorPool DescriptorPoolVK::GetPool() {
   return pool_;
 }
 
-DescriptorPoolVK::~DescriptorPoolVK() {
-  if (is_valid_) {
-    device_.destroyDescriptorPool(pool_);
-  }
-}
+DescriptorPoolVK::~DescriptorPoolVK() = default;
 
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/descriptor_pool_vk.h
+++ b/impeller/renderer/backend/vulkan/descriptor_pool_vk.h
@@ -22,7 +22,6 @@ class DescriptorPoolVK {
   vk::DescriptorPool GetPool();
 
  private:
-  vk::Device device_;
   vk::DescriptorPool pool_;
   bool is_valid_ = false;
 

--- a/impeller/renderer/backend/vulkan/render_pass_vk.h
+++ b/impeller/renderer/backend/vulkan/render_pass_vk.h
@@ -6,6 +6,7 @@
 
 #include <vector>
 #include "flutter/fml/macros.h"
+#include "impeller/renderer/backend/vulkan/context_vk.h"
 #include "impeller/renderer/backend/vulkan/surface_producer_vk.h"
 #include "impeller/renderer/backend/vulkan/texture_vk.h"
 #include "impeller/renderer/backend/vulkan/vk.h"
@@ -23,7 +24,7 @@ class RenderPassVK final : public RenderPass {
                vk::Device device,
                const RenderTarget& target,
                vk::UniqueCommandBuffer command_buffer,
-               vk::UniqueRenderPass render_pass,
+               vk::RenderPass render_pass,
                SurfaceProducerVK* surface_producer);
 
   // |RenderPass|
@@ -34,7 +35,7 @@ class RenderPassVK final : public RenderPass {
 
   vk::Device device_;
   vk::UniqueCommandBuffer command_buffer_;
-  vk::UniqueRenderPass render_pass_;
+  vk::RenderPass render_pass_;
   SurfaceProducerVK* surface_producer_;
 
   std::string label_ = "";
@@ -76,6 +77,8 @@ class RenderPassVK final : public RenderPass {
                              vk::Image image,
                              vk::ImageLayout layout_old,
                              vk::ImageLayout layout_new) const;
+
+  const ContextVK& GetContextVK() const;
 
   FML_DISALLOW_COPY_AND_ASSIGN(RenderPassVK);
 };

--- a/impeller/renderer/backend/vulkan/surface_producer_vk.h
+++ b/impeller/renderer/backend/vulkan/surface_producer_vk.h
@@ -46,10 +46,6 @@ class SurfaceProducerVK {
   // take ownership of the command buffer until present.
   bool QueueCommandBuffer(uint32_t frame_num, vk::UniqueCommandBuffer buffer);
 
-  void StashRP(uint32_t frame_num, vk::UniqueRenderPass data) {
-    stash_rp_[frame_num].push_back(std::move(data));
-  }
-
  private:
   std::weak_ptr<Context> context_;
 
@@ -64,7 +60,6 @@ class SurfaceProducerVK {
   // sync objects
   std::unique_ptr<SurfaceSyncObjectsVK> sync_objects_[kMaxFramesInFlight];
   std::vector<vk::UniqueCommandBuffer> command_buffers_[kMaxFramesInFlight];
-  std::vector<vk::UniqueRenderPass> stash_rp_[kMaxFramesInFlight];
 
   FML_DISALLOW_COPY_AND_ASSIGN(SurfaceProducerVK);
 };

--- a/shell/common/shell_io_manager.cc
+++ b/shell/common/shell_io_manager.cc
@@ -22,8 +22,7 @@ sk_sp<GrDirectContext> ShellIOManager::CreateCompatibleResourceLoadingContext(
 
   const auto options = MakeDefaultContextOptions(ContextType::kResource);
 
-  if (auto context =
-          GrDirectContext::MakeGL(std::move(gl_interface), options)) {
+  if (auto context = GrDirectContext::MakeGL(gl_interface, options)) {
     // Do not cache textures created by the image decoder.  These textures
     // should be deleted when they are no longer referenced by an SkImage.
     context->setResourceCacheLimit(0);


### PR DESCRIPTION
- This change allows us to cleanup descriptor pools at end of each frame, and make lifecycle management for other resourced tied to each frame easier.
- As an example, render pass destruction is now managed by deletion queue.
