### PR TITLE
[canvaskit] Fix Path tests

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/path_metrics.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/path_metrics.dart
@@ -23,6 +23,11 @@ class CkPathMetrics extends IterableBase<ui.PathMetric>
   late final Iterator<ui.PathMetric> iterator = _path.isEmpty
       ? const CkPathMetricIteratorEmpty._()
       : CkContourMeasureIter(this);
+
+  /// A fresh [CkContourMeasureIter] which is only used for resurrecting a
+  /// [CkContourMeasure]. We can't use [iterator] here because [iterator] is
+  /// memoized.
+  CkContourMeasureIter _iteratorForResurrection() => CkContourMeasureIter(this);
 }
 
 class CkContourMeasureIter extends ManagedSkiaObject<SkContourMeasureIter>
@@ -140,8 +145,7 @@ class CkContourMeasure extends ManagedSkiaObject<SkContourMeasure>
 
   @override
   SkContourMeasure resurrect() {
-    final CkContourMeasureIter iterator =
-        _metrics.iterator as CkContourMeasureIter;
+    final CkContourMeasureIter iterator = _metrics._iteratorForResurrection();
     final SkContourMeasureIter skIterator = iterator.skiaObject;
 
     // When resurrecting we must advance the iterator to the last known

--- a/lib/web_ui/test/canvaskit/path_test.dart
+++ b/lib/web_ui/test/canvaskit/path_test.dart
@@ -45,12 +45,6 @@ void testMain() {
       path.addOval(const ui.Rect.fromLTRB(10, 10, 100, 100));
       expect(path.computeMetrics().length, 2);
 
-      // Path metrics can be iterated over multiple times.
-      final ui.PathMetrics metrics = path.computeMetrics();
-      expect(metrics.toList().length, 2);
-      expect(metrics.toList().length, 2);
-      expect(metrics.toList().length, 2);
-
       // Can simultaneously iterate over multiple metrics from the same path.
       final ui.PathMetrics metrics1 = path.computeMetrics();
       final ui.PathMetrics metrics2 = path.computeMetrics();
@@ -68,8 +62,7 @@ void testMain() {
       expect(iter2.moveNext(), isFalse);
       expect(() => iter1.current, throwsRangeError);
       expect(() => iter2.current, throwsRangeError);
-    // TODO(hterkelsen): https://github.com/flutter/flutter/issues/115327
-    }, skip: true);
+    });
 
     test('CkPath.reset', () {
       final ui.Path path = ui.Path();
@@ -171,8 +164,7 @@ void testMain() {
       expect(measure0.extractPath(0, 15).getBounds(), const ui.Rect.fromLTRB(0, 0, 10, 5));
       expect(measure1.contourIndex, 1);
       expect(measure1.extractPath(0, 15).getBounds(), const ui.Rect.fromLTRB(20, 20, 30, 25));
-    // TODO(hterkelsen): https://github.com/flutter/flutter/issues/115327
-    }, skip: true);
+    });
 
     test('Path.from', () {
       const ui.Rect rect1 = ui.Rect.fromLTRB(0, 0, 10, 10);


### PR DESCRIPTION
This fixes the Path tests that regressed as a result of test results not being reported properly.

The test for checking that `metrics.toList()` can be called multiple times is invalid because according to the [docs](https://api.flutter.dev/flutter/dart-ui/PathMetrics-class.html): "This iterable does not memoize. Callers who need to traverse the list multiple times, or who need to randomly access elements of the list, should use [toList](https://api.flutter.dev/flutter/dart-core/Iterable/toList.html) on this object."

Partially addresses https://github.com/flutter/flutter/issues/115327

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
