### PR TITLE
[canvaskit] Fix Surface test

### DIFF
--- a/lib/web_ui/test/canvaskit/surface_test.dart
+++ b/lib/web_ui/test/canvaskit/surface_test.dart
@@ -169,7 +169,9 @@ void testMain() {
             surface.acquireFrame(const ui.Size(9, 19)).skiaSurface;
         // A new context is created.
         expect(afterContextLost, isNot(same(before)));
-      }
+      },
+      // Firefox can't create a WebGL2 context in headless mode.
+      skip: isFirefox,
     );
 
     // Regression test for https://github.com/flutter/flutter/issues/75286

--- a/lib/web_ui/test/canvaskit/surface_test.dart
+++ b/lib/web_ui/test/canvaskit/surface_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:js_util' as js_util;
+
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
@@ -141,20 +143,23 @@ void testMain() {
         // Emulate WebGL context loss.
         final DomCanvasElement canvas =
             surface.htmlElement.children.single as DomCanvasElement;
-        final dynamic ctx = canvas.getContext('webgl2');
-        expect(ctx, isNotNull);
-        final dynamic loseContextExtension =
-            ctx.getExtension('WEBGL_lose_context');
-        loseContextExtension.loseContext();
+        final Object ctx = canvas.getContext('webgl2')!;
+        final Object loseContextExtension = js_util.callMethod(
+          ctx, 
+          'getExtension',
+          <String>['WEBGL_lose_context'],
+        );
+        js_util.callMethod(loseContextExtension, 'loseContext', const <void>[]);
 
         // Pump a timer to allow the "lose context" event to propagate.
         await Future<void>.delayed(Duration.zero);
         // We don't create a new GL context until the context is restored.
         expect(surface.debugContextLost, isTrue);
-        expect(ctx.isContextLost(), isTrue);
+        final bool isContextLost = js_util.callMethod<bool>(ctx, 'isContextLost', const <void>[]);
+        expect(isContextLost, isTrue);
 
         // Emulate WebGL context restoration.
-        loseContextExtension.restoreContext();
+        js_util.callMethod(loseContextExtension, 'restoreContext', const <void>[]);
 
         // Pump a timer to allow the "restore context" event to propagate.
         await Future<void>.delayed(Duration.zero);
@@ -164,10 +169,7 @@ void testMain() {
             surface.acquireFrame(const ui.Size(9, 19)).skiaSurface;
         // A new context is created.
         expect(afterContextLost, isNot(same(before)));
-      },
-      // Firefox and Safari don't have the WEBGL_lose_context extension.
-      // TODO(hterkelsen): https://github.com/flutter/flutter/issues/115327
-      skip: true,
+      }
     );
 
     // Regression test for https://github.com/flutter/flutter/issues/75286

--- a/lib/web_ui/test/canvaskit/surface_test.dart
+++ b/lib/web_ui/test/canvaskit/surface_test.dart
@@ -145,7 +145,7 @@ void testMain() {
             surface.htmlElement.children.single as DomCanvasElement;
         final Object ctx = canvas.getContext('webgl2')!;
         final Object loseContextExtension = js_util.callMethod(
-          ctx, 
+          ctx,
           'getExtension',
           <String>['WEBGL_lose_context'],
         );


### PR DESCRIPTION
This fixes the Path tests that regressed as a result of test results not being reported properly.

Partially addresses https://github.com/flutter/flutter/issues/115327

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
