### PR TITLE
update Scene.toImageSync test to use proper bounds in the request

### DIFF
--- a/testing/dart/compositing_test.dart
+++ b/testing/dart/compositing_test.dart
@@ -42,16 +42,16 @@ void main() {
     builder.addTexture(0, width: 10, height: 10);
 
     final Scene scene = builder.build();
-    final Image image = scene.toImageSync(10, 10);
+    final Image image = scene.toImageSync(20, 20);
     scene.dispose();
 
-    expect(image.width, 10);
-    expect(image.height, 10);
+    expect(image.width, 20);
+    expect(image.height, 20);
 
     final ByteData? data = await image.toByteData();
 
     expect(data, isNotNull);
-    expect(data!.lengthInBytes, 10 * 10 * 4);
+    expect(data!.lengthInBytes, 20 * 20 * 4);
     expect(data.buffer.asUint8List()[0], 0);
     expect(data.buffer.asUint8List()[1], 0);
     expect(data.buffer.asUint8List()[2], 0);


### PR DESCRIPTION
Fixes a relatively benign bug in a unit test that relies on overly conservative bounds checking in Skia. As we move to more accurate bounds culling tests this unit test will fail to have its Scene painted at all since the bounds of the scene are outside the image space. These changes now request an image that actually contains the scene.