### PR TITLE
Remove usage of deprecated Fuchsia event source

### DIFF
--- a/shell/platform/fuchsia/flutter/tests/integration/text-input/meta/text-input-test.cml
+++ b/shell/platform/fuchsia/flutter/tests/integration/text-input/meta/text-input-test.cml
@@ -17,13 +17,6 @@
     program: {
         binary: "bin/app",
     },
-    use: [
-        { protocol: "fuchsia.sys2.EventSource" },
-        {
-            event: "stopped",
-            from: "framework",
-        },
-    ],
     offer: [
         {
             protocol: [


### PR DESCRIPTION
This capability is being removed by the Fuchsia platform (https://fuchsia-review.git.corp.google.com/c/fuchsia/+/758606), but is currently blocked on this usage.

This change simply removes the capability from this tests, where it doesn't seem to be used at all.

Fixes https://github.com/flutter/flutter/issues/115392

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [n/a] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
