### PR TITLE
[web] Update text editing test skips

### DIFF
--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -2565,10 +2565,9 @@ Future<void> testMain() async {
       expect(input.style.backgroundColor, 'transparent');
       expect(input.style.caretColor, 'transparent');
       expect(input.style.outline, 'none');
-      expect(input.style.border, 'none');
+      expect(input.style.border.split(' '), contains('none'));
       expect(input.style.textShadow, 'none');
-    // TODO(hterkelsen): https://github.com/flutter/flutter/issues/115327
-    }, skip: isFirefox);
+    });
 
     test('prevents effect of (forced-colors: active)', () {
       editingStrategy!.enable(
@@ -2579,7 +2578,9 @@ Future<void> testMain() async {
 
       final DomHTMLElement input = editingStrategy!.activeDomElement;
       expect(input.style.getPropertyValue('forced-color-adjust'), 'none');
-    // TODO(hterkelsen): https://github.com/flutter/flutter/issues/115327
+    // TODO(hterkelsen): Firefox does not support forced-color-adjust even
+    // though it supports forced-colors. Safari doesn't support forced-colors
+    // so this isn't a problem there.
     }, skip: isFirefox || isSafari);
   });
 }


### PR DESCRIPTION
This fixes the text editing tests that regressed as a result of test results not being reported properly.

Partially addresses https://github.com/flutter/flutter/issues/115327

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
