### PR TITLE
[canvaskit] Fix Shader program tests

### DIFF
--- a/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
+++ b/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
@@ -347,6 +347,47 @@ void _shaderTests() {
         ),
         isNotNull);
   });
+
+  test('RuntimeEffect', () {
+    // TODO(hterkelsen): Remove this check when local CanvasKit is default.
+    if (isRuntimeEffectAvailable) {
+      const String kSkSlProgram = r'''
+half4 main(vec2 fragCoord) {
+  return vec4(1.0, 0.0, 0.0, 1.0);
+}
+  ''';
+
+      final SkRuntimeEffect? effect = MakeRuntimeEffect(kSkSlProgram);
+      expect(effect, isNotNull);
+
+      const String kInvalidSkSlProgram = '';
+
+      // Invalid SkSL returns null.
+      final SkRuntimeEffect? invalidEffect = MakeRuntimeEffect(kInvalidSkSlProgram);
+      expect(invalidEffect, isNull);
+
+      final SkShader? shader = effect!.makeShader(<double>[]);
+      expect(shader, isNotNull);
+
+      // mismatched uniforms returns null.
+      final SkShader? invalidShader = effect.makeShader(<double>[1]);
+
+      expect(invalidShader, isNull);
+
+      const String kSkSlProgramWithUniforms = r'''
+uniform vec4 u_color;
+
+half4 main(vec2 fragCoord) {
+  return u_color;
+}
+  ''';
+
+      final SkShader? shaderWithUniform = MakeRuntimeEffect(kSkSlProgramWithUniforms)
+        !.makeShader(<double>[1.0, 0.0, 0.0, 1.0]);
+
+      expect(shaderWithUniform, isNotNull);
+    }
+  });
 }
 
 SkShader _makeTestShader() {
@@ -1707,46 +1748,4 @@ void _paragraphTests() {
       canvasKit.TextHeightBehavior.DisableAll,
     );
   });
-
-  test('RuntimeEffect', () {
-    // Is supported..
-    expect(isRuntimeEffectAvailable, isTrue);
-
-    const String kSkSlProgram = r'''
-half4 main(vec2 fragCoord) {
-  return vec4(1.0, 0.0, 0.0, 1.0);
-}
-''';
-
-    final SkRuntimeEffect? effect = MakeRuntimeEffect(kSkSlProgram);
-    expect(effect, isNotNull);
-
-    const String kInvalidSkSlProgram = '';
-
-    // Invalid SkSL returns null.
-    final SkRuntimeEffect? invalidEffect = MakeRuntimeEffect(kInvalidSkSlProgram);
-    expect(invalidEffect, isNull);
-
-    final SkShader? shader = effect!.makeShader(<double>[]);
-    expect(shader, isNotNull);
-
-    // mismatched uniforms returns null.
-    final SkShader? invalidShader = effect.makeShader(<double>[1]);
-
-    expect(invalidShader, isNull);
-
-    const String kSkSlProgramWithUniforms = r'''
-uniform vec4 u_color;
-
-half4 main(vec2 fragCoord) {
-  return u_color;
-}
-''';
-
-    final SkShader? shaderWithUniform = MakeRuntimeEffect(kSkSlProgramWithUniforms)
-      !.makeShader(<double>[1.0, 0.0, 0.0, 1.0]);
-
-    expect(shaderWithUniform, isNotNull);
-  // TODO(hterkelsen): https://github.com/flutter/flutter/issues/115327
-  }, skip: true);
 }

--- a/lib/web_ui/test/canvaskit/fragment_program_test.dart
+++ b/lib/web_ui/test/canvaskit/fragment_program_test.dart
@@ -186,27 +186,29 @@ void testMain() {
   });
 
   test('FragmentProgram can be created from JSON IPLR bundle', () async {
-    final Uint8List data = utf8.encode(kJsonIPLR) as Uint8List;
-    final CkFragmentProgram program = await CkFragmentProgram.fromBytes('test', data);
+    // TODO(hterkelsen): Remove this check when local CanvasKit is default.
+    if (isRuntimeEffectAvailable) {
+      final Uint8List data = utf8.encode(kJsonIPLR) as Uint8List;
+      final CkFragmentProgram program = await CkFragmentProgram.fromBytes('test', data);
 
-    expect(program.effect, isNotNull);
-    expect(program.floatCount, 17);
-    expect(program.textureCount, 0);
-    expect(program.uniforms, hasLength(17));
-    expect(program.name, 'test');
+      expect(program.effect, isNotNull);
+      expect(program.floatCount, 17);
+      expect(program.textureCount, 0);
+      expect(program.uniforms, hasLength(17));
+      expect(program.name, 'test');
 
-    final ui.FragmentShader shader = program.fragmentShader();
+      final ui.FragmentShader shader = program.fragmentShader();
 
-    shader.setFloat(0, 4);
-    shader.dispose();
+      shader.setFloat(0, 4);
+      shader.dispose();
 
-    expect(shader.debugDisposed, true);
+      expect(shader.debugDisposed, true);
 
-    final ui.FragmentShader shader2 = program.fragmentShader();
+      final ui.FragmentShader shader2 = program.fragmentShader();
 
-    shader.setFloat(0, 5);
-    shader2.dispose();
-    expect(shader2.debugDisposed, true);
-  // TODO(hterkelsen): https://github.com/flutter/flutter/issues/115327
-  }, skip: true);
+      shader.setFloat(0, 5);
+      shader2.dispose();
+      expect(shader2.debugDisposed, true);
+    }
+  });
 }


### PR DESCRIPTION
This fixes the fragment shader tests that regressed as a result of test results not being reported properly.

`skip: !isRuntimeEffectAvailable` doesn't work here because even when it *is* available (when running against a locally-built CanvasKit), the test is skipped anyway. I suspect that the skip checks are done before CanvasKit is initialized.

Partially addresses https://github.com/flutter/flutter/issues/115327

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
