### PR TITLE
Shader warmup

### DIFF
--- a/shell/platform/fuchsia/flutter/vulkan_surface.cc
+++ b/shell/platform/fuchsia/flutter/vulkan_surface.cc
@@ -184,7 +184,7 @@ VulkanSurface::~VulkanSurface() {
     if (buffer_id_) {
       session_->DeregisterBufferCollection(buffer_id_);
     }
-  } else {
+  } else if (release_image_callback_) {
     release_image_callback_();
   }
   wait_.Cancel();


### PR DESCRIPTION
This PR fixes illegal behavior in the ~VulkanSurface() destructor, which invokes a `std::function` without first checking if it is empty; it will be empty if nobody calls `VulkanSurface::SetReleaseImageCallback()`.  This is true in the case of Skia shader warmup on Fuchsia.

This CL fixes the following issue: https://bugs.fuchsia.dev/p/fuchsia/issues/detail?id=115400

Note: the root cause is not directly related to shader warmup, and could potentially manifest in other situations (not after this PR is merged though).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
