### PR TITLE
fix the SurfaceView not hide issue.

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
+++ b/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
@@ -9,6 +9,7 @@ import android.graphics.Canvas;
 import android.graphics.Matrix;
 import android.graphics.Path;
 import android.view.MotionEvent;
+import android.view.SurfaceView;
 import android.view.View;
 import android.view.ViewTreeObserver;
 import android.view.accessibility.AccessibilityEvent;
@@ -18,7 +19,6 @@ import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import io.flutter.embedding.android.AndroidTouchProcessor;
 import io.flutter.util.ViewUtils;
-import android.view.SurfaceView;
 
 /**
  * A view that applies the {@link io.flutter.embedding.engine.mutatorsstack.FlutterMutatorsStack} to

--- a/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
+++ b/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
@@ -181,6 +181,7 @@ public class FlutterMutatorView extends FrameLayout {
 
   @Override
   public void setVisibility(int visibility) {
+    super.setVisibility(visibility);
     final View childView = this.getChildAt(0);
     if (childView != null && childView instanceof SurfaceView) {
       childView.setVisibility(visibility);

--- a/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
+++ b/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
@@ -18,6 +18,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import io.flutter.embedding.android.AndroidTouchProcessor;
 import io.flutter.util.ViewUtils;
+import android.view.SurfaceView;
 
 /**
  * A view that applies the {@link io.flutter.embedding.engine.mutatorsstack.FlutterMutatorsStack} to
@@ -176,6 +177,14 @@ public class FlutterMutatorView extends FrameLayout {
     // for the current platform view.
     // See AccessibilityBridge for more.
     return super.requestSendAccessibilityEvent(child, event);
+  }
+
+  @Override
+  public void setVisibility(int visibility) {
+    final View childView = this.getChildAt(0);
+    if (childView != null && childView instanceof SurfaceView) {
+      childView.setVisibility(visibility);
+    }
   }
 
   @Override

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -1224,8 +1224,16 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
       if (currentFrameUsedPlatformViewIds.contains(viewId)
           && (isFrameRenderedUsingImageReaders || !synchronizeToNativeViewHierarchy)) {
         parentView.setVisibility(View.VISIBLE);
+        final View childView = ((FlutterMutatorView) parentView).getChildAt(0);
+        if (childView != null && childView instanceof SurfaceView) {
+          childView.setVisibility(View.VISIBLE);
+        }
       } else {
         parentView.setVisibility(View.GONE);
+        final View childView = ((FlutterMutatorView) parentView).getChildAt(0);
+        if (childView != null && childView instanceof SurfaceView) {
+          childView.setVisibility(View.GONE);
+        }
       }
     }
   }

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -1224,16 +1224,8 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
       if (currentFrameUsedPlatformViewIds.contains(viewId)
           && (isFrameRenderedUsingImageReaders || !synchronizeToNativeViewHierarchy)) {
         parentView.setVisibility(View.VISIBLE);
-        final View childView = ((FlutterMutatorView) parentView).getChildAt(0);
-        if (childView != null && childView instanceof SurfaceView) {
-          childView.setVisibility(View.VISIBLE);
-        }
       } else {
         parentView.setVisibility(View.GONE);
-        final View childView = ((FlutterMutatorView) parentView).getChildAt(0);
-        if (childView != null && childView instanceof SurfaceView) {
-          childView.setVisibility(View.GONE);
-        }
       }
     }
   }

--- a/shell/platform/android/test/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorViewTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.*;
 import android.content.Context;
 import android.graphics.Matrix;
 import android.view.MotionEvent;
+import android.view.SurfaceView;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
@@ -228,6 +229,17 @@ public class FlutterMutatorViewTest {
     final boolean eventSent =
         wrapperView.requestSendAccessibilityEvent(embeddedView, mock(AccessibilityEvent.class));
     assertFalse(eventSent);
+  }
+
+  @Test
+  public void validateSurfaceViewAsChildVisibility() {
+    final FlutterMutatorView mutatorView = new FlutterMutatorView(ctx);
+    final SurfaceView childView = new SurfaceView(ctx);
+    mutatorView.addView(childView);
+    mutatorView.setVisibility(View.VISIBLE);
+    assertTrue(childView.getVisibility() == View.VISIBLE);
+    mutatorView.setVisibility(View.GONE);
+    assertTrue(childView.getVisibility() == View.GONE);
   }
 
   @Implements(ViewGroup.class)


### PR DESCRIPTION
This PR fixed the issue: https://github.com/flutter/flutter/issues/113601.

The reason is that the embedded PlatformView holds a SurfaceView which needs force to set View.GONE or View.VISIBLE when hide/show.

Below is the demo code:
![image](https://user-images.githubusercontent.com/5646684/202183450-bb38faf1-5202-484e-92b0-d7c4a9b64c55.png)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
