### PR TITLE
Add back tooltip to Embedder

### DIFF
--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -1292,6 +1292,7 @@ FlutterSemanticsNode CreateEmbedderSemanticsNode(
       node.customAccessibilityActions.size(),
       node.customAccessibilityActions.data(),
       node.platformViewId,
+      node.tooltip.c_str(),
   };
 }
 

--- a/shell/platform/embedder/fixtures/main.dart
+++ b/shell/platform/embedder/fixtures/main.dart
@@ -165,7 +165,7 @@ void a11y_main() async {
       increasedValueAttributes: <StringAttribute>[],
       decreasedValue: '',
       decreasedValueAttributes: <StringAttribute>[],
-      tooltip: '',
+      tooltip: 'tooltip',
       additionalActions: Int32List(0),
     )
     ..updateNode(
@@ -196,7 +196,7 @@ void a11y_main() async {
       increasedValueAttributes: <StringAttribute>[],
       decreasedValue: '',
       decreasedValueAttributes: <StringAttribute>[],
-      tooltip: '',
+      tooltip: 'tooltip',
       additionalActions: Int32List(0),
       childrenInHitTestOrder: Int32List(0),
       childrenInTraversalOrder: Int32List(0),
@@ -231,7 +231,7 @@ void a11y_main() async {
       increasedValueAttributes: <StringAttribute>[],
       decreasedValue: '',
       decreasedValueAttributes: <StringAttribute>[],
-      tooltip: '',
+      tooltip: 'tooltip',
       additionalActions: Int32List(0),
     )
     ..updateNode(
@@ -263,7 +263,7 @@ void a11y_main() async {
       increasedValueAttributes: <StringAttribute>[],
       decreasedValue: '',
       decreasedValueAttributes: <StringAttribute>[],
-      tooltip: '',
+      tooltip: 'tooltip',
       childrenInHitTestOrder: Int32List(0),
       childrenInTraversalOrder: Int32List(0),
     )

--- a/shell/platform/embedder/tests/embedder_a11y_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_a11y_unittests.cc
@@ -24,7 +24,7 @@ namespace testing {
 
 using EmbedderA11yTest = testing::EmbedderTest;
 
-constexpr static char tooltip[] = "tooltip";
+constexpr static char kTooltip[] = "tooltip";
 
 TEST_F(EmbedderTest, CannotProvideNewAndLegacySemanticsCallback) {
   EmbedderConfigBuilder builder(
@@ -103,7 +103,7 @@ TEST_F(EmbedderA11yTest, A11yTreeIsConsistent) {
       ASSERT_EQ(7.0, node->transform.pers0);
       ASSERT_EQ(8.0, node->transform.pers1);
       ASSERT_EQ(9.0, node->transform.pers2);
-      ASSERT_EQ(std::strncmp(tooltip, node->tooltip, sizeof(tooltip) - 1), 0);
+      ASSERT_EQ(std::strncmp(kTooltip, node->tooltip, sizeof(kTooltip) - 1), 0);
 
       if (node->id == 128) {
         ASSERT_EQ(0x3f3, node->platform_view_id);
@@ -288,7 +288,7 @@ TEST_F(EmbedderA11yTest, A11yTreeIsConsistentUsingLegacyCallbacks) {
       ASSERT_EQ(7.0, node->transform.pers0);
       ASSERT_EQ(8.0, node->transform.pers1);
       ASSERT_EQ(9.0, node->transform.pers2);
-      ASSERT_EQ(std::strncmp(node->tooltip, tooltip, sizeof(tooltip) - 1), 0);
+      ASSERT_EQ(std::strncmp(kTooltip, node->tooltip, sizeof(kTooltip) - 1), 0);
 
       if (node->id == 128) {
         ASSERT_EQ(0x3f3, node->platform_view_id);

--- a/shell/platform/embedder/tests/embedder_a11y_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_a11y_unittests.cc
@@ -24,6 +24,8 @@ namespace testing {
 
 using EmbedderA11yTest = testing::EmbedderTest;
 
+const static char tooltip[] = "tooltip";
+
 TEST_F(EmbedderTest, CannotProvideNewAndLegacySemanticsCallback) {
   EmbedderConfigBuilder builder(
       GetEmbedderContext(EmbedderTestContextType::kSoftwareContext));
@@ -101,6 +103,7 @@ TEST_F(EmbedderA11yTest, A11yTreeIsConsistent) {
       ASSERT_EQ(7.0, node->transform.pers0);
       ASSERT_EQ(8.0, node->transform.pers1);
       ASSERT_EQ(9.0, node->transform.pers2);
+      ASSERT_EQ(std::strncmp(tooltip, node->tooltip, sizeof(tooltip) - 1), 0);
 
       if (node->id == 128) {
         ASSERT_EQ(0x3f3, node->platform_view_id);

--- a/shell/platform/embedder/tests/embedder_a11y_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_a11y_unittests.cc
@@ -24,7 +24,7 @@ namespace testing {
 
 using EmbedderA11yTest = testing::EmbedderTest;
 
-const static char tooltip[] = "tooltip";
+constexpr static char tooltip[] = "tooltip";
 
 TEST_F(EmbedderTest, CannotProvideNewAndLegacySemanticsCallback) {
   EmbedderConfigBuilder builder(
@@ -288,6 +288,7 @@ TEST_F(EmbedderA11yTest, A11yTreeIsConsistentUsingLegacyCallbacks) {
       ASSERT_EQ(7.0, node->transform.pers0);
       ASSERT_EQ(8.0, node->transform.pers1);
       ASSERT_EQ(9.0, node->transform.pers2);
+      ASSERT_EQ(std::strncmp(node->tooltip, tooltip, sizeof(tooltip) - 1), 0);
 
       if (node->id == 128) {
         ASSERT_EQ(0x3f3, node->platform_view_id);


### PR DESCRIPTION
[PR #37192](https://github.com/flutter/engine/pull/37129) accidentally removed the tooltip property when creating `FlutterSemanticsNode` in the embedder. This PR adds it back so that tooltips are again used by a11y.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
