### PR TITLE
Fix potential null-pointer de-references

### DIFF
--- a/impeller/renderer/backend/vulkan/command_buffer_vk.cc
+++ b/impeller/renderer/backend/vulkan/command_buffer_vk.cc
@@ -129,7 +129,8 @@ std::shared_ptr<RenderPass> CommandBufferVK::OnCreateRenderPass(
 }
 
 std::shared_ptr<BlitPass> CommandBufferVK::OnCreateBlitPass() const {
-  FML_UNREACHABLE();
+  // TODO(kaushikiska): https://github.com/flutter/flutter/issues/112649
+  return nullptr;
 }
 
 std::shared_ptr<ComputePass> CommandBufferVK::OnCreateComputePass() const {

--- a/lib/ui/painting/image_decoder_impeller.cc
+++ b/lib/ui/painting/image_decoder_impeller.cc
@@ -179,20 +179,19 @@ sk_sp<DlImage> ImageDecoderImpeller::UploadTexture(
 
   {
     auto command_buffer = context->CreateCommandBuffer();
-    command_buffer->SetLabel("Mipmap Command Buffer");
     if (!command_buffer) {
       FML_DLOG(ERROR)
           << "Could not create command buffer for mipmap generation.";
       return nullptr;
     }
+    command_buffer->SetLabel("Mipmap Command Buffer");
 
     auto blit_pass = command_buffer->CreateBlitPass();
-    blit_pass->SetLabel("Mipmap Blit Pass");
     if (!blit_pass) {
       FML_DLOG(ERROR) << "Could not create blit pass for mipmap generation.";
       return nullptr;
     }
-
+    blit_pass->SetLabel("Mipmap Blit Pass");
     blit_pass->GenerateMipmap(texture);
 
     blit_pass->EncodeCommands(context->GetResourceAllocator());
@@ -233,6 +232,7 @@ void ImageDecoderImpeller::Decode(fml::RefPtr<ImageDescriptor> descriptor,
        io_runner = runners_.GetIOTaskRunner(),                    //
        result                                                     //
   ]() {
+        FML_CHECK(context) << "No valid impeller context";
         auto max_size_supported =
             context->GetResourceAllocator()->GetMaxTextureSizeSupported();
 

--- a/shell/platform/android/android_surface_vulkan_impeller.cc
+++ b/shell/platform/android/android_surface_vulkan_impeller.cc
@@ -116,4 +116,9 @@ bool AndroidSurfaceVulkanImpeller::SetNativeWindow(
   return false;
 }
 
+std::shared_ptr<impeller::Context>
+AndroidSurfaceVulkanImpeller::GetImpellerContext() {
+  return impeller_context_;
+}
+
 }  // namespace flutter

--- a/shell/platform/android/android_surface_vulkan_impeller.h
+++ b/shell/platform/android/android_surface_vulkan_impeller.h
@@ -41,6 +41,9 @@ class AndroidSurfaceVulkanImpeller : public AndroidSurface {
   bool ResourceContextClearCurrent() override;
 
   // |AndroidSurface|
+  std::shared_ptr<impeller::Context> GetImpellerContext() override;
+
+  // |AndroidSurface|
   bool SetNativeWindow(fml::RefPtr<AndroidNativeWindow> window) override;
 
  private:


### PR DESCRIPTION
1. When context is null, this is unlikely.
2. When one of the components obtained from context are null, e.g, blit-pass, command-buffer, etc.