### PR TITLE
Use SkImageFilters::Shader instead of ::Paint

### DIFF
--- a/flow/layers/backdrop_filter_layer_unittests.cc
+++ b/flow/layers/backdrop_filter_layer_unittests.cc
@@ -87,7 +87,7 @@ TEST_F(BackdropFilterLayerTest, SimpleFilter) {
   const SkRect child_bounds = SkRect::MakeLTRB(5.0f, 6.0f, 20.5f, 21.5f);
   const SkPath child_path = SkPath().addRect(child_bounds);
   const SkPaint child_paint = SkPaint(SkColors::kYellow);
-  auto layer_filter = SkImageFilters::Paint(SkPaint(SkColors::kMagenta));
+  auto layer_filter = SkImageFilters::Shader(SkShaders::Color(SkColors::kMagenta, /*colorSpace=*/nullptr));
   auto mock_layer = std::make_shared<MockLayer>(child_path, child_paint);
   auto layer = std::make_shared<BackdropFilterLayer>(
       DlImageFilter::From(layer_filter), DlBlendMode::kSrcOver);
@@ -117,7 +117,7 @@ TEST_F(BackdropFilterLayerTest, NonSrcOverBlend) {
   const SkRect child_bounds = SkRect::MakeLTRB(5.0f, 6.0f, 20.5f, 21.5f);
   const SkPath child_path = SkPath().addRect(child_bounds);
   const SkPaint child_paint = SkPaint(SkColors::kYellow);
-  auto layer_filter = SkImageFilters::Paint(SkPaint(SkColors::kMagenta));
+  auto layer_filter = SkImageFilters::Shader(SkShaders::Color(SkColors::kMagenta, /*colorSpace=*/nullptr));
   auto mock_layer = std::make_shared<MockLayer>(child_path, child_paint);
   auto layer = std::make_shared<BackdropFilterLayer>(
       DlImageFilter::From(layer_filter), DlBlendMode::kSrc);
@@ -155,7 +155,7 @@ TEST_F(BackdropFilterLayerTest, MultipleChildren) {
   const SkPaint child_paint2 = SkPaint(SkColors::kCyan);
   SkRect children_bounds = child_path1.getBounds();
   children_bounds.join(child_path2.getBounds());
-  auto layer_filter = SkImageFilters::Paint(SkPaint(SkColors::kMagenta));
+  auto layer_filter = SkImageFilters::Shader(SkShaders::Color(SkColors::kMagenta, /*colorSpace=*/nullptr));
   auto mock_layer1 = std::make_shared<MockLayer>(child_path1, child_paint1);
   auto mock_layer2 = std::make_shared<MockLayer>(child_path2, child_paint2);
   auto layer = std::make_shared<BackdropFilterLayer>(
@@ -200,8 +200,8 @@ TEST_F(BackdropFilterLayerTest, Nested) {
   const SkPaint child_paint2 = SkPaint(SkColors::kCyan);
   SkRect children_bounds = child_path1.getBounds();
   children_bounds.join(child_path2.getBounds());
-  auto layer_filter1 = SkImageFilters::Paint(SkPaint(SkColors::kMagenta));
-  auto layer_filter2 = SkImageFilters::Paint(SkPaint(SkColors::kDkGray));
+  auto layer_filter1 = SkImageFilters::Shader(SkShaders::Color(SkColors::kMagenta, /*colorSpace=*/nullptr));
+  auto layer_filter2 = SkImageFilters::Shader(SkShaders::Color(SkColors::kDkGray, /*colorSpace=*/nullptr));
   auto mock_layer1 = std::make_shared<MockLayer>(child_path1, child_paint1);
   auto mock_layer2 = std::make_shared<MockLayer>(child_path2, child_paint2);
   auto layer1 = std::make_shared<BackdropFilterLayer>(

--- a/flow/layers/backdrop_filter_layer_unittests.cc
+++ b/flow/layers/backdrop_filter_layer_unittests.cc
@@ -87,7 +87,8 @@ TEST_F(BackdropFilterLayerTest, SimpleFilter) {
   const SkRect child_bounds = SkRect::MakeLTRB(5.0f, 6.0f, 20.5f, 21.5f);
   const SkPath child_path = SkPath().addRect(child_bounds);
   const SkPaint child_paint = SkPaint(SkColors::kYellow);
-  auto layer_filter = SkImageFilters::Shader(SkShaders::Color(SkColors::kMagenta, /*colorSpace=*/nullptr));
+  auto layer_filter = SkImageFilters::Shader(
+      SkShaders::Color(SkColors::kMagenta, /*colorSpace=*/nullptr));
   auto mock_layer = std::make_shared<MockLayer>(child_path, child_paint);
   auto layer = std::make_shared<BackdropFilterLayer>(
       DlImageFilter::From(layer_filter), DlBlendMode::kSrcOver);
@@ -117,7 +118,8 @@ TEST_F(BackdropFilterLayerTest, NonSrcOverBlend) {
   const SkRect child_bounds = SkRect::MakeLTRB(5.0f, 6.0f, 20.5f, 21.5f);
   const SkPath child_path = SkPath().addRect(child_bounds);
   const SkPaint child_paint = SkPaint(SkColors::kYellow);
-  auto layer_filter = SkImageFilters::Shader(SkShaders::Color(SkColors::kMagenta, /*colorSpace=*/nullptr));
+  auto layer_filter = SkImageFilters::Shader(
+      SkShaders::Color(SkColors::kMagenta, /*colorSpace=*/nullptr));
   auto mock_layer = std::make_shared<MockLayer>(child_path, child_paint);
   auto layer = std::make_shared<BackdropFilterLayer>(
       DlImageFilter::From(layer_filter), DlBlendMode::kSrc);
@@ -155,7 +157,8 @@ TEST_F(BackdropFilterLayerTest, MultipleChildren) {
   const SkPaint child_paint2 = SkPaint(SkColors::kCyan);
   SkRect children_bounds = child_path1.getBounds();
   children_bounds.join(child_path2.getBounds());
-  auto layer_filter = SkImageFilters::Shader(SkShaders::Color(SkColors::kMagenta, /*colorSpace=*/nullptr));
+  auto layer_filter = SkImageFilters::Shader(
+      SkShaders::Color(SkColors::kMagenta, /*colorSpace=*/nullptr));
   auto mock_layer1 = std::make_shared<MockLayer>(child_path1, child_paint1);
   auto mock_layer2 = std::make_shared<MockLayer>(child_path2, child_paint2);
   auto layer = std::make_shared<BackdropFilterLayer>(
@@ -200,8 +203,10 @@ TEST_F(BackdropFilterLayerTest, Nested) {
   const SkPaint child_paint2 = SkPaint(SkColors::kCyan);
   SkRect children_bounds = child_path1.getBounds();
   children_bounds.join(child_path2.getBounds());
-  auto layer_filter1 = SkImageFilters::Shader(SkShaders::Color(SkColors::kMagenta, /*colorSpace=*/nullptr));
-  auto layer_filter2 = SkImageFilters::Shader(SkShaders::Color(SkColors::kDkGray, /*colorSpace=*/nullptr));
+  auto layer_filter1 = SkImageFilters::Shader(
+      SkShaders::Color(SkColors::kMagenta, /*colorSpace=*/nullptr));
+  auto layer_filter2 = SkImageFilters::Shader(
+      SkShaders::Color(SkColors::kDkGray, /*colorSpace=*/nullptr));
   auto mock_layer1 = std::make_shared<MockLayer>(child_path1, child_paint1);
   auto mock_layer2 = std::make_shared<MockLayer>(child_path2, child_paint2);
   auto layer1 = std::make_shared<BackdropFilterLayer>(


### PR DESCRIPTION
SkImageFilters::Paint() is deprecated and will be removed in https://skia-review.googlesource.com/c/skia/+/604917.
These unit tests are the last known usage of ::Paint(), but since they are just solid colors, the migration is very straightforward to switch to SkShader::Color().

https://bugs.chromium.org/p/skia/issues/detail?id=13927

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
