### PR TITLE
Turn on clang tidy error for underscores in Google tests

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -29,6 +29,7 @@ readability-identifier-naming,\
 clang-diagnostic-*,\
 google-objc-*,\
 google-explicit-constructor,\
+google-readability-avoid-underscore-in-googletest-name,\
 performance-move-const-arg,\
 performance-unnecessary-value-param"
 

--- a/display_list/display_list_image_filter_unittests.cc
+++ b/display_list/display_list_image_filter_unittests.cc
@@ -653,7 +653,7 @@ TEST(DisplayListImageFilter, ComposeBoundsWithUnboundedInnerAndOuter) {
 }
 
 // See https://github.com/flutter/flutter/issues/108433
-TEST(DisplayListImageFilter, Issue_108433) {
+TEST(DisplayListImageFilter, Issue108433) {
   auto input_bounds = SkIRect::MakeLTRB(20, 20, 80, 80);
 
   auto sk_filter = SkColorFilters::Blend(SK_ColorRED, SkBlendMode::kSrcOver);

--- a/flow/raster_cache_unittests.cc
+++ b/flow/raster_cache_unittests.cc
@@ -709,7 +709,7 @@ TEST(RasterCache, RasterCacheKeySameType) {
   ASSERT_EQ(map[layer_children_third_key], 300);
 }
 
-TEST(RasterCache, RasterCacheKeyID_Equal) {
+TEST(RasterCache, RasterCacheKeyIDEqual) {
   RasterCacheKeyID first = RasterCacheKeyID(1, RasterCacheKeyType::kLayer);
   RasterCacheKeyID second = RasterCacheKeyID(2, RasterCacheKeyType::kLayer);
   RasterCacheKeyID third =
@@ -729,7 +729,7 @@ TEST(RasterCache, RasterCacheKeyID_Equal) {
   ASSERT_NE(fifth, sixth);
 }
 
-TEST(RasterCache, RasterCacheKeyID_HashCode) {
+TEST(RasterCache, RasterCacheKeyIDHashCode) {
   uint64_t foo = 1;
   uint64_t bar = 2;
   RasterCacheKeyID first = RasterCacheKeyID(foo, RasterCacheKeyType::kLayer);
@@ -763,7 +763,7 @@ TEST(RasterCache, RasterCacheKeyID_HashCode) {
 
 using RasterCacheTest = SkiaGPUObjectLayerTest;
 
-TEST_F(RasterCacheTest, RasterCacheKeyID_LayerChildrenIds) {
+TEST_F(RasterCacheTest, RasterCacheKeyIDLayerChildrenIds) {
   auto layer = std::make_shared<ContainerLayer>();
 
   const SkPath child_path = SkPath().addRect(SkRect::MakeWH(5.0f, 5.0f));

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -1629,44 +1629,55 @@ static void expectSoftwareRenderingOutputMatches(
       std::vector<uint8_t>(bytes, bytes + sizeof(T)));
 }
 
-#define SW_PIXFMT_TEST_F(dart_entrypoint, pixfmt, matcher)                \
-  TEST_F(EmbedderTest,                                                    \
-         SoftwareRenderingPixelFormats_##dart_entrypoint##_##pixfmt) {    \
+#define SW_PIXFMT_TEST_F(test_name, dart_entrypoint, pixfmt, matcher)     \
+  TEST_F(EmbedderTest, SoftwareRenderingPixelFormats##test_name) {        \
     expectSoftwareRenderingOutputMatches(*this, #dart_entrypoint, pixfmt, \
                                          matcher);                        \
   }
 
 // Don't test the pixel formats that contain padding (so an X) and the kNative32
 // pixel format here, so we don't add any flakiness.
-SW_PIXFMT_TEST_F(draw_solid_red, kRGB565, (uint16_t)0xF800);
-SW_PIXFMT_TEST_F(draw_solid_red, kRGBA4444, (uint16_t)0xF00F);
-SW_PIXFMT_TEST_F(draw_solid_red,
+SW_PIXFMT_TEST_F(RedRGBA565xF800, draw_solid_red, kRGB565, (uint16_t)0xF800);
+SW_PIXFMT_TEST_F(RedRGBA4444xF00F, draw_solid_red, kRGBA4444, (uint16_t)0xF00F);
+SW_PIXFMT_TEST_F(RedRGBA8888xFFx00x00xFF,
+                 draw_solid_red,
                  kRGBA8888,
                  (std::vector<uint8_t>{0xFF, 0x00, 0x00, 0xFF}));
-SW_PIXFMT_TEST_F(draw_solid_red,
+SW_PIXFMT_TEST_F(RedBGRA8888x00x00xFFxFF,
+                 draw_solid_red,
                  kBGRA8888,
                  (std::vector<uint8_t>{0x00, 0x00, 0xFF, 0xFF}));
-SW_PIXFMT_TEST_F(draw_solid_red, kGray8, (uint8_t)0x36);
+SW_PIXFMT_TEST_F(RedGray8x36, draw_solid_red, kGray8, (uint8_t)0x36);
 
-SW_PIXFMT_TEST_F(draw_solid_green, kRGB565, (uint16_t)0x07E0);
-SW_PIXFMT_TEST_F(draw_solid_green, kRGBA4444, (uint16_t)0x0F0F);
-SW_PIXFMT_TEST_F(draw_solid_green,
+SW_PIXFMT_TEST_F(GreenRGB565x07E0, draw_solid_green, kRGB565, (uint16_t)0x07E0);
+SW_PIXFMT_TEST_F(GreenRGBA4444x0F0F,
+                 draw_solid_green,
+                 kRGBA4444,
+                 (uint16_t)0x0F0F);
+SW_PIXFMT_TEST_F(GreenRGBA8888x00xFFx00xFF,
+                 draw_solid_green,
                  kRGBA8888,
                  (std::vector<uint8_t>{0x00, 0xFF, 0x00, 0xFF}));
-SW_PIXFMT_TEST_F(draw_solid_green,
+SW_PIXFMT_TEST_F(GreenBGRA8888x00xFFx00xFF,
+                 draw_solid_green,
                  kBGRA8888,
                  (std::vector<uint8_t>{0x00, 0xFF, 0x00, 0xFF}));
-SW_PIXFMT_TEST_F(draw_solid_green, kGray8, (uint8_t)0xB6);
+SW_PIXFMT_TEST_F(GreenGray8xB6, draw_solid_green, kGray8, (uint8_t)0xB6);
 
-SW_PIXFMT_TEST_F(draw_solid_blue, kRGB565, (uint16_t)0x001F);
-SW_PIXFMT_TEST_F(draw_solid_blue, kRGBA4444, (uint16_t)0x00FF);
-SW_PIXFMT_TEST_F(draw_solid_blue,
+SW_PIXFMT_TEST_F(BlueRGB565x001F, draw_solid_blue, kRGB565, (uint16_t)0x001F);
+SW_PIXFMT_TEST_F(BlueRGBA4444x00FF,
+                 draw_solid_blue,
+                 kRGBA4444,
+                 (uint16_t)0x00FF);
+SW_PIXFMT_TEST_F(BlueRGBA8888x00x00xFFxFF,
+                 draw_solid_blue,
                  kRGBA8888,
                  (std::vector<uint8_t>{0x00, 0x00, 0xFF, 0xFF}));
-SW_PIXFMT_TEST_F(draw_solid_blue,
+SW_PIXFMT_TEST_F(BlueBGRA8888xFFx00x00xFF,
+                 draw_solid_blue,
                  kBGRA8888,
                  (std::vector<uint8_t>{0xFF, 0x00, 0x00, 0xFF}));
-SW_PIXFMT_TEST_F(draw_solid_blue, kGray8, (uint8_t)0x12);
+SW_PIXFMT_TEST_F(BlueGray8x12, draw_solid_blue, kGray8, (uint8_t)0x12);
 
 //------------------------------------------------------------------------------
 // Key Data


### PR DESCRIPTION
Turn on `google-readability-avoid-underscore-in-googletest-name` clang-tidy warning and fix violations.

https://google.github.io/googletest/faq.html#why-should-test-suite-names-and-test-names-not-contain-underscore

Example:
```
/b/s/w/ir/cache/builder/src/flutter/shell/platform/embedder/tests/embedder_unittests.cc:1641:1: error: avoid using "_" in test name "SoftwareRenderingPixelFormats_draw_solid_red_kRGB565" according to Googletest FAQ [google-readability-avoid-underscore-in-googletest-name,-warnings-as-errors]
SW_PIXFMT_TEST_F(draw_solid_red, kRGB565, (uint16_t)0xF800);
^
/b/s/w/ir/cache/builder/src/flutter/shell/platform/embedder/tests/embedder_unittests.cc:1634:10: note: expanded from macro 'SW_PIXFMT_TEST_F'
         SoftwareRenderingPixelFormats_##dart_entrypoint##_##pixfmt) {    \
         ^
note: expanded from here
```
https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8797288801511583249/+/u/test:_lint_host_debug/stdout

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
