### PR TITLE
[Impeller] Add a new API 'Context::WaitUntilCommandsCompleted' to ensure that commands are completed.

### DIFF
--- a/impeller/renderer/backend/gles/context_gles.cc
+++ b/impeller/renderer/backend/gles/context_gles.cc
@@ -123,6 +123,15 @@ std::shared_ptr<CommandBuffer> ContextGLES::CreateCommandBuffer() const {
 }
 
 // |Context|
+bool ContextGLES::WaitUntilCommandsCompleted() {
+  const auto result = reactor_->React();
+  if (result) {
+    reactor_->GetProcTable().Finish();
+  }
+  return result;
+}
+
+// |Context|
 std::shared_ptr<WorkQueue> ContextGLES::GetWorkQueue() const {
   return work_queue_;
 }

--- a/impeller/renderer/backend/gles/context_gles.h
+++ b/impeller/renderer/backend/gles/context_gles.h
@@ -73,6 +73,9 @@ class ContextGLES final : public Context,
   // |Context|
   bool SupportsOffscreenMSAA() const override;
 
+  // |Context|
+  bool WaitUntilCommandsCompleted() override;
+
   FML_DISALLOW_COPY_AND_ASSIGN(ContextGLES);
 };
 

--- a/impeller/renderer/backend/gles/proc_table_gles.h
+++ b/impeller/renderer/backend/gles/proc_table_gles.h
@@ -163,7 +163,8 @@ struct GLProc {
   PROC(UseProgram);                          \
   PROC(VertexAttribPointer);                 \
   PROC(Viewport);                            \
-  PROC(ReadPixels);
+  PROC(ReadPixels);                          \
+  PROC(Finish);
 
 #define FOR_EACH_IMPELLER_GLES3_PROC(PROC) PROC(BlitFramebuffer);
 

--- a/impeller/renderer/backend/metal/command_buffer_mtl.h
+++ b/impeller/renderer/backend/metal/command_buffer_mtl.h
@@ -13,6 +13,8 @@ namespace impeller {
 
 class CommandBufferMTL final : public CommandBuffer {
  public:
+  using SubmitCallback = std::function<void(id<MTLCommandBuffer>)>;
+
   // |CommandBuffer|
   ~CommandBufferMTL() override;
 
@@ -20,9 +22,11 @@ class CommandBufferMTL final : public CommandBuffer {
   friend class ContextMTL;
 
   id<MTLCommandBuffer> buffer_ = nullptr;
+  SubmitCallback submit_callback_ = nullptr;
 
   CommandBufferMTL(const std::weak_ptr<const Context>& context,
-                   id<MTLCommandQueue> queue);
+                   id<MTLCommandQueue> queue,
+                   SubmitCallback submit_callback);
 
   // |CommandBuffer|
   void SetLabel(const std::string& label) const override;

--- a/impeller/renderer/backend/metal/command_buffer_mtl.mm
+++ b/impeller/renderer/backend/metal/command_buffer_mtl.mm
@@ -122,8 +122,11 @@ static id<MTLCommandBuffer> CreateCommandBuffer(id<MTLCommandQueue> queue) {
 }
 
 CommandBufferMTL::CommandBufferMTL(const std::weak_ptr<const Context>& context,
-                                   id<MTLCommandQueue> queue)
-    : CommandBuffer(context), buffer_(CreateCommandBuffer(queue)) {}
+                                   id<MTLCommandQueue> queue,
+                                   SubmitCallback submit_callback)
+    : CommandBuffer(context),
+      buffer_(CreateCommandBuffer(queue)),
+      submit_callback_(submit_callback) {}
 
 CommandBufferMTL::~CommandBufferMTL() = default;
 
@@ -164,6 +167,10 @@ bool CommandBufferMTL::OnSubmitCommands(CompletionCallback callback) {
   }
 
   [buffer_ commit];
+  if (submit_callback_) {
+    submit_callback_(buffer_);
+  }
+
   [buffer_ waitUntilScheduled];
   buffer_ = nil;
   return true;

--- a/impeller/renderer/backend/metal/command_buffer_mtl.mm
+++ b/impeller/renderer/backend/metal/command_buffer_mtl.mm
@@ -126,7 +126,7 @@ CommandBufferMTL::CommandBufferMTL(const std::weak_ptr<const Context>& context,
                                    SubmitCallback submit_callback)
     : CommandBuffer(context),
       buffer_(CreateCommandBuffer(queue)),
-      submit_callback_(submit_callback) {}
+      submit_callback_(std::move(submit_callback)) {}
 
 CommandBufferMTL::~CommandBufferMTL() = default;
 

--- a/impeller/renderer/backend/metal/context_mtl.h
+++ b/impeller/renderer/backend/metal/context_mtl.h
@@ -39,6 +39,7 @@ class ContextMTL final : public Context,
  private:
   id<MTLDevice> device_ = nullptr;
   id<MTLCommandQueue> command_queue_ = nullptr;
+  id<MTLCommandBuffer> last_submitted_buffer_ = nullptr;
   std::shared_ptr<ShaderLibraryMTL> shader_library_;
   std::shared_ptr<PipelineLibraryMTL> pipeline_library_;
   std::shared_ptr<SamplerLibrary> sampler_library_;
@@ -66,6 +67,9 @@ class ContextMTL final : public Context,
 
   // |Context|
   std::shared_ptr<CommandBuffer> CreateCommandBuffer() const override;
+
+  // |Context|
+  bool WaitUntilCommandsCompleted() override;
 
   // |Context|
   std::shared_ptr<WorkQueue> GetWorkQueue() const override;

--- a/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/impeller/renderer/backend/vulkan/context_vk.cc
@@ -528,6 +528,15 @@ std::shared_ptr<CommandBuffer> ContextVK::CreateCommandBuffer() const {
                                  surface_producer_.get());
 }
 
+bool ContextVK::WaitUntilCommandsCompleted() {
+  auto result = device_->waitIdle();
+  if (result != vk::Result::eSuccess) {
+    VALIDATION_LOG << "Failed to wait device idle: " << vk::to_string(result);
+    return false;
+  }
+  return true;
+}
+
 vk::Instance ContextVK::GetInstance() const {
   return *instance_;
 }

--- a/impeller/renderer/backend/vulkan/context_vk.h
+++ b/impeller/renderer/backend/vulkan/context_vk.h
@@ -137,6 +137,9 @@ class ContextVK final : public Context, public BackendCast<ContextVK, Context> {
   std::shared_ptr<CommandBuffer> CreateCommandBuffer() const override;
 
   // |Context|
+  bool WaitUntilCommandsCompleted() override;
+
+  // |Context|
   PixelFormat GetColorAttachmentPixelFormat() const override;
 
   // |Context|

--- a/impeller/renderer/context.h
+++ b/impeller/renderer/context.h
@@ -39,6 +39,8 @@ class Context : public std::enable_shared_from_this<Context> {
 
   virtual std::shared_ptr<CommandBuffer> CreateCommandBuffer() const = 0;
 
+  virtual bool WaitUntilCommandsCompleted() = 0;
+
   virtual std::shared_ptr<WorkQueue> GetWorkQueue() const = 0;
 
   //----------------------------------------------------------------------------

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -625,6 +625,8 @@ TEST_P(RendererTest, CanBlitTextureToBuffer) {
       if (!buffer->SubmitCommands()) {
         return false;
       }
+
+      context->WaitUntilCommandsCompleted();
     }
 
     {

--- a/shell/common/snapshot_controller_impeller.cc
+++ b/shell/common/snapshot_controller_impeller.cc
@@ -63,6 +63,7 @@ sk_sp<DlImage> SnapshotControllerImpeller::DoMakeRasterSnapshot(
 
     std::shared_ptr<impeller::Image> image =
         picture.ToImage(*context, render_target_size);
+    context->GetContext()->WaitUntilCommandsCompleted();
     if (image) {
       return impeller::DlImageImpeller::Make(image->GetTexture());
     }


### PR DESCRIPTION
I'm working on https://github.com/flutter/flutter/issues/110829, and I found that Impeller doesn't have an API to ensure that all commands are completed.

Let's take the following code as an example. In the following piece of code, we will draw the `DisplayList` into a `Texture` in the Raster thread, and then blit the `Texture` into the `CPU Buffer` on the IO thread.  So we need to ensure that when we do the blit operation on the IO thread, the commands about the DisplayList drawn to the Texture have been completed in the GPU.
``` dart
final ui.PictureRecorder recorder = ui.PictureRecorder();
final ui.Canvas canvas = ui.Canvas(recorder);
canvas.drawRect(const Rect.fromLTWH(0.0, 0.0, 100, 100), Paint()..color = Colors.red);
final ui.Picture picture = recorder.endRecording();
ui.Image image = await picture.toImage(100, 100);
ByteData? byteData = await image.toByteData();
```

Another place where we need to use this new API is "blit texture to buffer". We need to ensure that the blit operation has been executed on the gpu before using the cpu buffer.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

