### PR TITLE
[macOS] Merge FlutterBackingStore implementations

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterBackingStore.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterBackingStore.h
@@ -11,13 +11,6 @@
  */
 @interface FlutterRenderBackingStore : NSObject
 
-@end
-
-/**
- * Wraps a Metal texture.
- */
-@interface FlutterMetalRenderBackingStore : FlutterRenderBackingStore
-
 /**
  * MTLTexture referenced by this backing store instance.
  */

--- a/shell/platform/darwin/macos/framework/Source/FlutterBackingStore.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterBackingStore.mm
@@ -5,9 +5,6 @@
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterBackingStore.h"
 
 @implementation FlutterRenderBackingStore
-@end
-
-@implementation FlutterMetalRenderBackingStore
 
 - (instancetype)initWithTexture:(id<MTLTexture>)texture {
   self = [super init];

--- a/shell/platform/darwin/macos/framework/Source/FlutterCompositor.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterCompositor.mm
@@ -37,8 +37,7 @@ bool FlutterCompositor::CreateBackingStore(const FlutterBackingStoreConfig* conf
     StartFrame();
     // If the backing store is for the first layer, return the MTLTexture for the
     // FlutterView.
-    FlutterMetalRenderBackingStore* backingStore =
-        reinterpret_cast<FlutterMetalRenderBackingStore*>([view backingStoreForSize:size]);
+    FlutterRenderBackingStore* backingStore = [view backingStoreForSize:size];
     backing_store_out->metal.texture.texture =
         (__bridge FlutterMetalTextureHandle)backingStore.texture;
   } else {

--- a/shell/platform/darwin/macos/framework/Source/FlutterCompositorUnittests.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterCompositorUnittests.mm
@@ -43,8 +43,7 @@ namespace {
 
 id<FlutterViewProvider> MockViewProvider() {
   FlutterView* viewMock = OCMClassMock([FlutterView class]);
-  FlutterMetalRenderBackingStore* backingStoreMock =
-      OCMClassMock([FlutterMetalRenderBackingStore class]);
+  FlutterRenderBackingStore* backingStoreMock = OCMClassMock([FlutterRenderBackingStore class]);
   __block id<MTLTexture> textureMock = OCMProtocolMock(@protocol(MTLTexture));
   OCMStub([backingStoreMock texture]).andReturn(textureMock);
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterRenderer.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterRenderer.mm
@@ -95,8 +95,7 @@ static bool OnAcquireExternalTexture(FlutterEngine* engine,
     // FlutterMetalTexture has texture `null`, therefore is discarded.
     return FlutterMetalTexture{};
   }
-  FlutterMetalRenderBackingStore* backingStore =
-      (FlutterMetalRenderBackingStore*)[view backingStoreForSize:size];
+  FlutterRenderBackingStore* backingStore = [view backingStoreForSize:size];
   id<MTLTexture> texture = backingStore.texture;
   FlutterMetalTexture embedderTexture;
   embedderTexture.struct_size = sizeof(FlutterMetalTexture);

--- a/shell/platform/darwin/macos/framework/Source/FlutterResizableBackingStoreProvider.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterResizableBackingStoreProvider.h
@@ -10,10 +10,16 @@
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterResizeSynchronizer.h"
 
 /**
- * Represents a buffer that can be resized.
+ * Provides resizable buffers backed by a MTLTexture.
  */
-@protocol FlutterResizableBackingStoreProvider <FlutterResizeSynchronizerDelegate>
+@interface FlutterResizableBackingStoreProvider : NSObject <FlutterResizeSynchronizerDelegate>
 
+/**
+ * Creates a resizable backing store provider for the given CAMetalLayer.
+ */
+- (nonnull instancetype)initWithDevice:(nonnull id<MTLDevice>)device
+                          commandQueue:(nonnull id<MTLCommandQueue>)commandQueue
+                                 layer:(nonnull CALayer*)layer;
 /**
  * Notify of the required backing store size updates. Called during window resize.
  */
@@ -23,21 +29,5 @@
  * Returns the FlutterBackingStore corresponding to the latest size.
  */
 - (nonnull FlutterRenderBackingStore*)backingStore;
-
-@end
-
-/**
- * Metal-backed FlutterResizableBackingStoreProvider. Backing store in this context implies a
- * MTLTexture.
- */
-@interface FlutterMetalResizableBackingStoreProvider
-    : NSObject <FlutterResizableBackingStoreProvider>
-
-/**
- * Creates a resizable backing store provider for the given CAMetalLayer.
- */
-- (nonnull instancetype)initWithDevice:(nonnull id<MTLDevice>)device
-                          commandQueue:(nonnull id<MTLCommandQueue>)commandQueue
-                                 layer:(nonnull CALayer*)layer;
 
 @end

--- a/shell/platform/darwin/macos/framework/Source/FlutterResizableBackingStoreProvider.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterResizableBackingStoreProvider.mm
@@ -8,7 +8,7 @@
 
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.h"
 
-@implementation FlutterMetalResizableBackingStoreProvider {
+@implementation FlutterResizableBackingStoreProvider {
   id<MTLDevice> _device;
   id<MTLCommandQueue> _commandQueue;
   FlutterSurfaceManager* _surfaceManager;

--- a/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm
@@ -143,7 +143,7 @@ static const double kIdleDelay = 1.0;
 - (nonnull FlutterRenderBackingStore*)renderBuffer {
   [self ensureBackBuffer];
   id<MTLTexture> texture = _textures[kFlutterSurfaceManagerBackBuffer];
-  return [[FlutterMetalRenderBackingStore alloc] initWithTexture:texture];
+  return [[FlutterRenderBackingStore alloc] initWithTexture:texture];
 }
 
 - (id<MTLTexture>)createTextureForSurface:(FlutterIOSurfaceHolder*)surface size:(CGSize)size {

--- a/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManagerTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManagerTest.mm
@@ -43,8 +43,7 @@ TEST(FlutterSurfaceManager, EnsureSizeUpdatesSize) {
   FlutterSurfaceManager* surfaceManager = CreateSurfaceManager();
   CGSize size = CGSizeMake(100, 50);
   [surfaceManager ensureSurfaceSize:size];
-  id<MTLTexture> texture =
-      (reinterpret_cast<FlutterMetalRenderBackingStore*>([surfaceManager renderBuffer])).texture;
+  id<MTLTexture> texture = [surfaceManager renderBuffer].texture;
   CGSize textureSize = CGSizeMake(texture.width, texture.height);
   ASSERT_TRUE(CGSizeEqualToSize(size, textureSize));
 }
@@ -55,8 +54,7 @@ TEST(FlutterSurfaceManager, EnsureSizeUpdatesSizeForBackBuffer) {
   [surfaceManager ensureSurfaceSize:size];
   [surfaceManager renderBuffer];  // make sure we have back buffer
   [surfaceManager swapBuffers];
-  id<MTLTexture> texture =
-      (reinterpret_cast<FlutterMetalRenderBackingStore*>([surfaceManager renderBuffer])).texture;
+  id<MTLTexture> texture = [surfaceManager renderBuffer].texture;
   CGSize textureSize = CGSizeMake(texture.width, texture.height);
   ASSERT_TRUE(CGSizeEqualToSize(size, textureSize));
 }

--- a/shell/platform/darwin/macos/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterView.mm
@@ -12,7 +12,7 @@
 @interface FlutterView () {
   __weak id<FlutterViewReshapeListener> _reshapeListener;
   FlutterResizeSynchronizer* _resizeSynchronizer;
-  id<FlutterResizableBackingStoreProvider> _resizableBackingStoreProvider;
+  FlutterResizableBackingStoreProvider* _resizableBackingStoreProvider;
 }
 
 @end
@@ -29,9 +29,9 @@
     [self setLayerContentsRedrawPolicy:NSViewLayerContentsRedrawDuringViewResize];
     _reshapeListener = reshapeListener;
     _resizableBackingStoreProvider =
-        [[FlutterMetalResizableBackingStoreProvider alloc] initWithDevice:device
-                                                             commandQueue:commandQueue
-                                                                    layer:self.layer];
+        [[FlutterResizableBackingStoreProvider alloc] initWithDevice:device
+                                                        commandQueue:commandQueue
+                                                               layer:self.layer];
     _resizeSynchronizer =
         [[FlutterResizeSynchronizer alloc] initWithDelegate:_resizableBackingStoreProvider];
   }


### PR DESCRIPTION
Now that OpenGL support has been removed from the macOS embedder, we merge FlutterRenderBackingStore and its only implementing subclass, FlutterMetalRenderBackingStore, and similarly
FlutterRenderBackingStoreProvider and its only implementing subclass FlutterMetalRenderBackingStoreProvider.

Issue: https://github.com/flutter/flutter/issues/108304
Issue: https://github.com/flutter/flutter/issues/114445

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
