### PR TITLE
[macOS] Cleanup unnecessary references to Metal

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterCompositorUnittests.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterCompositorUnittests.mm
@@ -10,16 +10,16 @@
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterViewProvider.h"
 #import "flutter/testing/testing.h"
 
-@interface FlutterViewMockProviderMetal : NSObject <FlutterViewProvider> {
+@interface FlutterViewMockProvider : NSObject <FlutterViewProvider> {
   FlutterView* _defaultView;
 }
 /**
- * Create a FlutterViewMockProviderMetal with the provided view as the default view.
+ * Create a FlutterViewMockProvider with the provided view as the default view.
  */
 - (nonnull instancetype)initWithDefaultView:(nonnull FlutterView*)view;
 @end
 
-@implementation FlutterViewMockProviderMetal
+@implementation FlutterViewMockProvider
 
 - (nonnull instancetype)initWithDefaultView:(nonnull FlutterView*)view {
   self = [super init];
@@ -58,7 +58,7 @@ id<FlutterViewProvider> MockViewProvider() {
       })
       .andReturn(backingStoreMock);
 
-  return [[FlutterViewMockProviderMetal alloc] initWithDefaultView:viewMock];
+  return [[FlutterViewMockProvider alloc] initWithDefaultView:viewMock];
 }
 }  // namespace
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManagerTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManagerTest.mm
@@ -9,13 +9,13 @@
 #include "flutter/testing/testing.h"
 #include "gtest/gtest.h"
 
-@interface TestMetalView : NSView
+@interface TestView : NSView
 
 - (nonnull instancetype)init;
 
 @end
 
-@implementation TestMetalView
+@implementation TestView
 
 - (instancetype)init {
   self = [super initWithFrame:NSZeroRect];
@@ -32,7 +32,7 @@ namespace flutter::testing {
 static FlutterSurfaceManager* CreateSurfaceManager() {
   id<MTLDevice> device = MTLCreateSystemDefaultDevice();
   id<MTLCommandQueue> commandQueue = [device newCommandQueue];
-  TestMetalView* metalView = [[TestMetalView alloc] init];
+  TestView* metalView = [[TestView alloc] init];
   CALayer* layer = reinterpret_cast<CALayer*>(metalView.layer);
   return [[FlutterSurfaceManager alloc] initWithDevice:device
                                           commandQueue:commandQueue


### PR DESCRIPTION
Removes a few unncessary references to Metal in the macOS embedder. Now that Metal is the only supported rendering implementation for the macOS embedder, specifying a class as a Metal variant is redundant.

Issue: https://github.com/flutter/flutter/issues/108304
Issue: https://github.com/flutter/flutter/issues/114445

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
