### PR TITLE
Revert "[web] Check for cached browsers on LUCI"

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -273,8 +273,6 @@ targets:
         {"download_emsdk": true}
       dependencies: >-
         [
-          {"dependency": "chrome_and_driver", "version": "version:107.0"},
-          {"dependency": "firefox", "version": "version:83.0"},
           {"dependency": "goldctl", "version": "git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603"}
         ]
     timeout: 60
@@ -503,10 +501,6 @@ targets:
       gclient_variables: >-
         {"download_emsdk": true}
       gcs_goldens_bucket: flutter_logs
-      dependencies: >-
-        [
-          {"dependency": "chrome_and_driver", "version": "version:107.0"}
-        ]
     timeout: 60
     runIf:
       - DEPS

--- a/lib/web_ui/README.md
+++ b/lib/web_ui/README.md
@@ -153,20 +153,6 @@ We test with Firefox on LUCI in the Linux Web Engine builder. The process for
 rolling Firefox is even easier than Chromium. Simply update `browser_lock.yaml`
 with the latest version of Firefox, and run `browser_roller.dart`.
 
-#### .ci.yaml
-
-After rolling Chrome and/or Firefox, also update the CI dependencies in
-`.ci.yaml` to make use of the new versions. The lines look like
-
-```yaml
-      dependencies: >-
-        [
-          {"dependency": "chrome_and_driver", "version": "version:107.0"},
-          {"dependency": "firefox", "version": "version:83.0"},
-          {"dependency": "goldctl", "version": "git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603"}
-        ]
-```
-
 ##### **browser_roller.dart**
 
 The script has the following command-line options:

--- a/lib/web_ui/dev/chrome_installer.dart
+++ b/lib/web_ui/dev/chrome_installer.dart
@@ -15,8 +15,6 @@ import 'common.dart';
 import 'environment.dart';
 import 'exceptions.dart';
 
-const String _chromeExecutableVar = 'CHROME_EXECUTABLE';
-
 /// Returns the installation of Chrome, installing it if necessary.
 ///
 /// If [requestedVersion] is null, uses the version specified on the
@@ -34,18 +32,6 @@ Future<BrowserInstallation> getOrInstallChrome(
   StringSink? infoLog,
 }) async {
   infoLog ??= io.stdout;
-
-  // When running on LUCI, if we specify the "chrome_and_driver" dependency,
-  // then the bot will download Chrome from CIPD and place it in a cache and
-  // set the environment variable CHROME_EXECUTABLE.
-  if (io.Platform.environment.containsKey(_chromeExecutableVar)) {
-    infoLog.writeln('Using Chrome from $_chromeExecutableVar variable: '
-      '${io.Platform.environment[_chromeExecutableVar]}');
-    return BrowserInstallation(
-      version: 'cipd',
-      executable: io.Platform.environment[_chromeExecutableVar]!,
-    );
-  }
 
   if (requestedVersion == 'system') {
     return BrowserInstallation(

--- a/lib/web_ui/dev/firefox.dart
+++ b/lib/web_ui/dev/firefox.dart
@@ -22,7 +22,7 @@ class FirefoxEnvironment implements BrowserEnvironment {
 
   @override
   Future<Browser> launchBrowserInstance(Uri url, {bool debug = false}) async {
-    return Firefox(url, _installation, debug: debug);
+    return Firefox(url, this, debug: debug);
   }
 
   @override
@@ -56,7 +56,8 @@ class FirefoxEnvironment implements BrowserEnvironment {
 class Firefox extends Browser {
   /// Starts a new instance of Firefox open to the given [url], which may be a
   /// [Uri] or a [String].
-  factory Firefox(Uri url, BrowserInstallation installation, {bool debug = false}) {
+  factory Firefox(Uri url, FirefoxEnvironment firefoxEnvironment, {bool debug = false}) {
+    final BrowserInstallation installation = firefoxEnvironment._installation;
     final Completer<Uri> remoteDebuggerCompleter = Completer<Uri>.sync();
     return Firefox._(BrowserProcess(() async {
       // Using a profile on opening will prevent popups related to profiles.

--- a/lib/web_ui/dev/firefox_installer.dart
+++ b/lib/web_ui/dev/firefox_installer.dart
@@ -11,8 +11,6 @@ import 'common.dart';
 import 'environment.dart';
 import 'exceptions.dart';
 
-const String _firefoxExecutableVar = 'FIREFOX_EXECUTABLE';
-
 /// Returns the installation of Firefox, installing it if necessary.
 ///
 /// If [requestedVersion] is null, uses the version specified on the
@@ -37,18 +35,6 @@ Future<BrowserInstallation> getOrInstallFirefox(
   }
 
   infoLog ??= io.stdout;
-
-  // When running on LUCI, if we specify the "firefox" dependency, then the
-  // bot will download Firefox from CIPD and place it in a cache and set the
-  // environment variable FIREFOX_EXECUTABLE.
-  if (io.Platform.environment.containsKey(_firefoxExecutableVar)) {
-    infoLog.writeln('Using Firefox from $_firefoxExecutableVar variable: '
-      '${io.Platform.environment[_firefoxExecutableVar]}');
-    return BrowserInstallation(
-      version: 'cipd',
-      executable: io.Platform.environment[_firefoxExecutableVar]!,
-    );
-  }
 
   if (requestedVersion == 'system') {
     return BrowserInstallation(


### PR DESCRIPTION
Reverts flutter/engine#37721

This will cause builds to fail until https://flutter-review.git.corp.google.com/c/recipes/+/36460 lands. But the recipes change can't land until Linux Web Engine is fixed.