### PR TITLE
Made FlutterTextField that outlive FlutterTextPlatformNode not crash

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
@@ -12,6 +12,10 @@
 #import <OCMock/OCMock.h>
 #import "flutter/testing/testing.h"
 
+@interface FlutterTextField (Testing)
+- (void)setPlatformNode:(flutter::FlutterTextPlatformNode*)node;
+@end
+
 @interface FlutterTextFieldMock : FlutterTextField
 
 @property(nonatomic) NSString* lastUpdatedString;
@@ -1434,37 +1438,47 @@ TEST(FlutterTextInputPluginTest, CanWorkWithFlutterTextField) {
   node_data.SetValue("initial text");
   ax_node.SetData(node_data);
   delegate.Init(engine.accessibilityBridge, &ax_node);
-  FlutterTextPlatformNode text_platform_node(&delegate, viewController);
+  {
+    FlutterTextPlatformNode text_platform_node(&delegate, viewController);
 
-  FlutterTextFieldMock* mockTextField =
-      [[FlutterTextFieldMock alloc] initWithPlatformNode:&text_platform_node
-                                             fieldEditor:viewController.textInputPlugin];
-  [viewController.view addSubview:mockTextField];
-  [mockTextField startEditing];
+    FlutterTextFieldMock* mockTextField =
+        [[FlutterTextFieldMock alloc] initWithPlatformNode:&text_platform_node
+                                               fieldEditor:viewController.textInputPlugin];
+    [viewController.view addSubview:mockTextField];
+    [mockTextField startEditing];
 
-  NSDictionary* arguments = @{
-    @"inputAction" : @"action",
-    @"inputType" : @{@"name" : @"inputName"},
-  };
-  FlutterMethodCall* methodCall = [FlutterMethodCall methodCallWithMethodName:@"TextInput.setClient"
-                                                                    arguments:@[ @(1), arguments ]];
-  FlutterResult result = ^(id result) {
-  };
-  [viewController.textInputPlugin handleMethodCall:methodCall result:result];
+    NSDictionary* arguments = @{
+      @"inputAction" : @"action",
+      @"inputType" : @{@"name" : @"inputName"},
+    };
+    FlutterMethodCall* methodCall =
+        [FlutterMethodCall methodCallWithMethodName:@"TextInput.setClient"
+                                          arguments:@[ @(1), arguments ]];
+    FlutterResult result = ^(id result) {
+    };
+    [viewController.textInputPlugin handleMethodCall:methodCall result:result];
 
-  arguments = @{
-    @"text" : @"new text",
-    @"selectionBase" : @(1),
-    @"selectionExtent" : @(2),
-    @"composingBase" : @(-1),
-    @"composingExtent" : @(-1),
-  };
+    arguments = @{
+      @"text" : @"new text",
+      @"selectionBase" : @(1),
+      @"selectionExtent" : @(2),
+      @"composingBase" : @(-1),
+      @"composingExtent" : @(-1),
+    };
 
-  methodCall = [FlutterMethodCall methodCallWithMethodName:@"TextInput.setEditingState"
-                                                 arguments:arguments];
-  [viewController.textInputPlugin handleMethodCall:methodCall result:result];
-  EXPECT_EQ([mockTextField.lastUpdatedString isEqualToString:@"new text"], YES);
-  EXPECT_EQ(NSEqualRanges(mockTextField.lastUpdatedSelection, NSMakeRange(1, 1)), YES);
+    methodCall = [FlutterMethodCall methodCallWithMethodName:@"TextInput.setEditingState"
+                                                   arguments:arguments];
+    [viewController.textInputPlugin handleMethodCall:methodCall result:result];
+    EXPECT_EQ([mockTextField.lastUpdatedString isEqualToString:@"new text"], YES);
+    EXPECT_EQ(NSEqualRanges(mockTextField.lastUpdatedSelection, NSMakeRange(1, 1)), YES);
+
+    // This blocks the FlutterTextFieldMock, which is held onto by the main event
+    // loop, from crashing.
+    [mockTextField setPlatformNode:nil];
+  }
+
+  // This verifies that clearing the platform node works.
+  [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
 }
 
 TEST(FlutterTextInputPluginTest, CanNotBecomeResponderIfNoViewController) {

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputSemanticsObject.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputSemanticsObject.mm
@@ -91,12 +91,18 @@
 #pragma mark - NSView
 
 - (NSRect)frame {
+  if (!_node) {
+    return NSZeroRect;
+  }
   return _node->GetFrame();
 }
 
 #pragma mark - NSAccessibilityProtocol
 
 - (void)setAccessibilityFocused:(BOOL)isFocused {
+  if (!_node) {
+    return;
+  }
   [super setAccessibilityFocused:isFocused];
   ui::AXActionData data;
   data.action = isFocused ? ax::mojom::Action::kFocus : ax::mojom::Action::kBlur;
@@ -108,6 +114,9 @@
     return;
   }
   if (self.currentEditor == _plugin) {
+    return;
+  }
+  if (!_node) {
     return;
   }
   // Selecting text seems to be the only way to make the field editor
@@ -131,6 +140,10 @@
     selection = NSMakeRange([self stringValue].length, 0);
   }
   [self updateString:textValue withSelection:selection];
+}
+
+- (void)setPlatformNode:(flutter::FlutterTextPlatformNode*)node {
+  _node = node;
 }
 
 #pragma mark - NSObject
@@ -159,6 +172,7 @@ FlutterTextPlatformNode::FlutterTextPlatformNode(FlutterPlatformNodeDelegate* de
 }
 
 FlutterTextPlatformNode::~FlutterTextPlatformNode() {
+  [appkit_text_field_ setPlatformNode:nil];
   EnsureDetachedFromView();
 }
 


### PR DESCRIPTION
The crash happens because there is a dangling pointer when the FlutterTextPlatformNode is deleted but the main event loop has a retain on the FlutterTextField.  I'm not sure how problematic this is in practice but it affected tests.

fixes https://github.com/flutter/flutter/issues/115599

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
