### PR TITLE
Make NotifyIdle reject close and past deadlines.

### DIFF
--- a/runtime/runtime_controller.h
+++ b/runtime/runtime_controller.h
@@ -358,7 +358,7 @@ class RuntimeController : public PlatformConfigurationClient {
   ///
   /// @return     If the idle notification was forwarded to the running isolate.
   ///
-  virtual bool NotifyIdle(fml::TimePoint deadline);
+  virtual bool NotifyIdle(fml::TimeDelta deadline);
 
   //----------------------------------------------------------------------------
   /// @brief      Notify the Dart VM that the attached flutter view has been

--- a/shell/common/animator.h
+++ b/shell/common/animator.h
@@ -34,7 +34,7 @@ class Animator final {
     virtual void OnAnimatorBeginFrame(fml::TimePoint frame_target_time,
                                       uint64_t frame_number) = 0;
 
-    virtual void OnAnimatorNotifyIdle(fml::TimePoint deadline) = 0;
+    virtual void OnAnimatorNotifyIdle(fml::TimeDelta deadline) = 0;
 
     virtual void OnAnimatorUpdateLatestFrameTargetTime(
         fml::TimePoint frame_target_time) = 0;
@@ -100,13 +100,12 @@ class Animator final {
 
   std::unique_ptr<FrameTimingsRecorder> frame_timings_recorder_;
   uint64_t frame_request_number_ = 1;
-  fml::TimePoint dart_frame_deadline_;
+  fml::TimeDelta dart_frame_deadline_;
   std::shared_ptr<LayerTreePipeline> layer_tree_pipeline_;
   fml::Semaphore pending_frame_semaphore_;
   LayerTreePipeline::ProducerContinuation producer_continuation_;
   bool regenerate_layer_tree_ = false;
   bool frame_scheduled_ = false;
-  int notify_idle_task_id_ = 0;
   SkISize last_layer_tree_size_ = {0, 0};
   std::deque<uint64_t> trace_flow_ids_;
   bool has_rendered_ = false;

--- a/shell/common/animator_unittests.cc
+++ b/shell/common/animator_unittests.cc
@@ -28,7 +28,7 @@ class FakeAnimatorDelegate : public Animator::Delegate {
   MOCK_METHOD2(OnAnimatorBeginFrame,
                void(fml::TimePoint frame_target_time, uint64_t frame_number));
 
-  void OnAnimatorNotifyIdle(fml::TimePoint deadline) override {
+  void OnAnimatorNotifyIdle(fml::TimeDelta deadline) override {
     notify_idle_called_ = true;
   }
 

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -254,15 +254,10 @@ void Engine::BeginFrame(fml::TimePoint frame_time, uint64_t frame_number) {
 }
 
 void Engine::ReportTimings(std::vector<int64_t> timings) {
-  TRACE_EVENT0("flutter", "Engine::ReportTimings");
   runtime_controller_->ReportTimings(std::move(timings));
 }
 
-void Engine::NotifyIdle(fml::TimePoint deadline) {
-  auto trace_event = std::to_string(deadline.ToEpochDelta().ToMicroseconds() -
-                                    Dart_TimelineGetMicros());
-  TRACE_EVENT1("flutter", "Engine::NotifyIdle", "deadline_now_delta",
-               trace_event.c_str());
+void Engine::NotifyIdle(fml::TimeDelta deadline) {
   runtime_controller_->NotifyIdle(deadline);
 }
 

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -552,7 +552,7 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
   ///                       corresponding sweep can be performed within the
   ///                       deadline.
   ///
-  void NotifyIdle(fml::TimePoint deadline);
+  void NotifyIdle(fml::TimeDelta deadline);
 
   //----------------------------------------------------------------------------
   /// @brief      Notifies the engine that the attached flutter view has been

--- a/shell/common/engine_unittests.cc
+++ b/shell/common/engine_unittests.cc
@@ -77,7 +77,7 @@ class MockRuntimeController : public RuntimeController {
   MOCK_METHOD3(LoadDartDeferredLibraryError,
                void(intptr_t, const std::string, bool));
   MOCK_CONST_METHOD0(GetDartVM, DartVM*());
-  MOCK_METHOD1(NotifyIdle, bool(fml::TimePoint));
+  MOCK_METHOD1(NotifyIdle, bool(fml::TimeDelta));
 };
 
 std::unique_ptr<PlatformMessage> MakePlatformMessage(

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -1133,7 +1133,7 @@ void Shell::OnAnimatorBeginFrame(fml::TimePoint frame_target_time,
 }
 
 // |Animator::Delegate|
-void Shell::OnAnimatorNotifyIdle(fml::TimePoint deadline) {
+void Shell::OnAnimatorNotifyIdle(fml::TimeDelta deadline) {
   FML_DCHECK(is_setup_);
   FML_DCHECK(task_runners_.GetUITaskRunner()->RunsTasksOnCurrentThread());
 

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -591,7 +591,7 @@ class Shell final : public PlatformView::Delegate,
                             uint64_t frame_number) override;
 
   // |Animator::Delegate|
-  void OnAnimatorNotifyIdle(fml::TimePoint deadline) override;
+  void OnAnimatorNotifyIdle(fml::TimeDelta deadline) override;
 
   // |Animator::Delegate|
   void OnAnimatorUpdateLatestFrameTargetTime(

--- a/shell/common/shell_test.cc
+++ b/shell/common/shell_test.cc
@@ -152,7 +152,7 @@ void ShellTest::SetViewportMetrics(Shell* shell, double width, double height) {
   latch.Wait();
 }
 
-void ShellTest::NotifyIdle(Shell* shell, fml::TimePoint deadline) {
+void ShellTest::NotifyIdle(Shell* shell, fml::TimeDelta deadline) {
   fml::AutoResetWaitableEvent latch;
   shell->GetTaskRunners().GetUITaskRunner()->PostTask(
       [&latch, engine = shell->weak_engine_, deadline]() {

--- a/shell/common/shell_test.h
+++ b/shell/common/shell_test.h
@@ -74,7 +74,7 @@ class ShellTest : public FixtureTest {
       std::function<void(std::shared_ptr<ContainerLayer> root)>;
 
   static void SetViewportMetrics(Shell* shell, double width, double height);
-  static void NotifyIdle(Shell* shell, fml::TimePoint deadline);
+  static void NotifyIdle(Shell* shell, fml::TimeDelta deadline);
 
   static void PumpOneFrame(Shell* shell,
                            double width = 1,


### PR DESCRIPTION
This patch also eliminates some extraneous tracing that is happening every frame. It is possible to get the same trace calls by enabling the API stream if needed.

Also refactors the NotifyIdle callsites to just always work in TimeDeltas rather than converting back and forth between them and TimePoints, which I think reads more clearly.

Also refactors the way the delayed task gets posted to hopefully be a little more safe/clear.

This patch does not "solve" the problem of when we call notify idle and then immediately start pumping frames, e.g. when we get a super cheap frame and then follow it up with a transition.