### PR TITLE
Remove `Linux Web Engine` from recipes CQ

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -264,9 +264,8 @@ targets:
 
   - name: Linux Web Engine
     recipe: engine/web_engine
-    bringup: true
+    bringup: true # https://github.com/flutter/flutter/issues/115404
     properties:
-      add_recipes_cq: "true"
       cores: "32"
       gcs_goldens_bucket: flutter_logs
       gclient_variables: >-

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -264,8 +264,8 @@ targets:
 
   - name: Linux Web Engine
     recipe: engine/web_engine
-    bringup: true # https://github.com/flutter/flutter/issues/115404
     properties:
+      add_recipes_cq: "true"
       cores: "32"
       gcs_goldens_bucket: flutter_logs
       gclient_variables: >-


### PR DESCRIPTION
https://github.com/flutter/engine/pull/37658 put `Linux Web Engine` to `bringup: true`, and this results in the building not running in `try`.

Recipes CQ is based on latest `SUCCESS` try build, and unfortunately the latest old `SUCCESS` build regressed and is not passing (https://luci-milo.appspot.com/raw/build/logs.chromium.org/flutter/led/flutter-try-builder_chops-service-accounts.iam.gserviceaccount.com/c6142507bd4bf04bd0a33fb0b14b15d9c0e61dd4c3437765894d7e9405292a57/+/build.proto?server=chromium-swarm.appspot.com).

This PR skips the builder in CQ to unblock recipes workflow (https://flutter-review.git.corp.google.com/c/recipes/+/35962).