### PR TITLE
[macOS] Add explicit weak/strong/copy annotations

### DIFF
--- a/shell/platform/darwin/macos/framework/Headers/FlutterDartProject.h
+++ b/shell/platform/darwin/macos/framework/Headers/FlutterDartProject.h
@@ -44,7 +44,7 @@ FLUTTER_DARWIN_EXPORT
  *
  * Set this to nil to pass no arguments to the Dart entrypoint.
  */
-@property(nonatomic, nullable, strong) NSArray<NSString*>* dartEntrypointArguments;
+@property(nonatomic, nullable, copy) NSArray<NSString*>* dartEntrypointArguments;
 
 @end
 

--- a/shell/platform/darwin/macos/framework/Headers/FlutterViewController.h
+++ b/shell/platform/darwin/macos/framework/Headers/FlutterViewController.h
@@ -115,6 +115,6 @@ FLUTTER_DARWIN_EXPORT
  * }
  * ```
  */
-@property(readwrite, nonatomic, nullable) NSColor* backgroundColor;
+@property(readwrite, nonatomic, nullable, copy) NSColor* backgroundColor;
 
 @end

--- a/shell/platform/darwin/macos/framework/Source/FlutterEmbedderKeyResponder.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEmbedderKeyResponder.mm
@@ -285,7 +285,7 @@ struct FlutterKeyPendingResponse {
  * Only set in debug mode. Nil in release mode, or if the callback has not been
  * handled.
  */
-@property(nonatomic) NSString* debugHandleSource;
+@property(nonatomic, copy) NSString* debugHandleSource;
 @end
 
 @implementation FlutterKeyCallbackGuard {

--- a/shell/platform/darwin/macos/framework/Source/FlutterKeyPrimaryResponder.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterKeyPrimaryResponder.h
@@ -31,6 +31,6 @@ typedef void (^FlutterAsyncKeyCallback)(BOOL handled);
  * deriving logical keys.
  */
 @required
-@property(nonatomic) NSMutableDictionary<NSNumber*, NSNumber*>* _Nullable layoutMap;
+@property(nonatomic, nullable, strong) NSMutableDictionary<NSNumber*, NSNumber*>* layoutMap;
 
 @end

--- a/shell/platform/darwin/macos/framework/Source/FlutterKeyboardManagerTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterKeyboardManagerTest.mm
@@ -211,8 +211,8 @@ void clearEvents(std::vector<FlutterKeyEvent>& events) {
 - (void)recordCallTypesTo:(nonnull NSMutableArray<NSNumber*>*)typeStorage
                  forTypes:(uint32_t)typeMask;
 
-@property(nonatomic) FlutterKeyboardManager* manager;
-@property(nonatomic) NSResponder* nextResponder;
+@property(readonly, nonatomic, strong) FlutterKeyboardManager* manager;
+@property(nonatomic, nullable, strong) NSResponder* nextResponder;
 
 #pragma mark - Private
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
@@ -18,7 +18,7 @@
 
 @interface FlutterTextFieldMock : FlutterTextField
 
-@property(nonatomic) NSString* lastUpdatedString;
+@property(nonatomic, nullable, copy) NSString* lastUpdatedString;
 @property(nonatomic) NSRange lastUpdatedSelection;
 
 @end


### PR DESCRIPTION
This adds explicit strong/copy Objective-C property annotations where they were previously implied on NSObject properties and fixes on case where it was previously improperly specified.

Issue: b/254864882

This corrects an annotation introduced in https://github.com/flutter/engine/pull/36929.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
