### PR TITLE
Add package:ffi as path dependency to flutter_frontend_server

### DIFF
--- a/flutter_frontend_server/pubspec.yaml
+++ b/flutter_frontend_server/pubspec.yaml
@@ -55,6 +55,8 @@ dependency_overrides:
     path: ../../third_party/dart/pkg/dev_compiler
   expect:
     path: ../../third_party/dart/pkg/expect
+  ffi:
+    path: ../../third_party/dart/third_party/pkg/ffi
   fixnum:
     path: ../../third_party/dart/third_party/pkg/fixnum
   front_end:


### PR DESCRIPTION
The CL in [0] added package:ffi as dependency to package:compiler. Since flutter_frontend_server needs all dependencies as path dependencies, we need to add package:ffi there via path.

[0] https://dart-review.googlesource.com/c/sdk/+/269640
