### PR TITLE
Add setImageSampler (for replacing setSampler)

### DIFF
--- a/lib/ui/dart_ui.cc
+++ b/lib/ui/dart_ui.cc
@@ -174,6 +174,7 @@ typedef CanvasPath Path;
   V(EngineLayer, dispose, 1)                           \
   V(FragmentProgram, initFromAsset, 2)                 \
   V(ReusableFragmentShader, Dispose, 1)                \
+  V(ReusableFragmentShader, SetImageSampler, 3)        \
   V(ReusableFragmentShader, SetSampler, 3)             \
   V(ReusableFragmentShader, ValidateSamplers, 1)       \
   V(Gradient, initLinear, 6)                           \

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -4323,7 +4323,7 @@ class FragmentShader extends Shader {
   /// results will be undefined.
   void setImageSampler(int index, Image image) {
     assert(!debugDisposed, 'Tried to access uniforms on a disposed Shader: $this');
-    _setImageSampler(index, image);
+    _setImageSampler(index, image._image);
   }
 
   /// Sets the sampler uniform at [index] to [sampler].
@@ -4354,7 +4354,7 @@ class FragmentShader extends Shader {
   external Float32List _constructor(FragmentProgram program, int floatUniforms, int samplerUniforms);
 
   @FfiNative<Void Function(Pointer<Void>, Handle, Handle)>('ReusableFragmentShader::SetImageSampler')
-  external void _setImageSampler(int index, Image sampler);
+  external void _setImageSampler(int index, _Image sampler);
 
   @FfiNative<Void Function(Pointer<Void>, Handle, Handle)>('ReusableFragmentShader::SetSampler')
   external void _setSampler(int index, ImageShader sampler);

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -4333,8 +4333,6 @@ class FragmentShader extends Shader {
   ///
   /// All the sampler uniforms that a shader expects must be provided or the
   /// results will be undefined.
-  ///
-  /// Use of this method may result in poor performance with the Impeller backend.
   void setSampler(int index, ImageShader sampler) {
     assert(!debugDisposed, 'Tried to access uniforms on a disposed Shader: $this');
     _setSampler(index, sampler);

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -4314,6 +4314,18 @@ class FragmentShader extends Shader {
     _floats[index] = value;
   }
 
+  /// Sets the sampler uniform at [index] to [image].
+  ///
+  /// The index provided to setSampler is the index of the sampler uniform defined
+  /// in the fragment program, excluding all non-sampler uniforms.
+  ///
+  /// All the sampler uniforms that a shader expects must be provided or the
+  /// results will be undefined.
+  void setImageSampler(int index, Image image) {
+    assert(!debugDisposed, 'Tried to access uniforms on a disposed Shader: $this');
+    _setImageSampler(index, image);
+  }
+
   /// Sets the sampler uniform at [index] to [sampler].
   ///
   /// The index provided to setSampler is the index of the sampler uniform defined
@@ -4321,6 +4333,9 @@ class FragmentShader extends Shader {
   ///
   /// All the sampler uniforms that a shader expects must be provided or the
   /// results will be undefined.
+  ///
+  /// Use of this method may result in poor performance with the Impeller backend.
+  @Deprecated('Use setImageSampler instead.')
   void setSampler(int index, ImageShader sampler) {
     assert(!debugDisposed, 'Tried to access uniforms on a disposed Shader: $this');
     _setSampler(index, sampler);
@@ -4340,6 +4355,9 @@ class FragmentShader extends Shader {
 
   @FfiNative<Handle Function(Handle, Handle, Handle, Handle)>('ReusableFragmentShader::Create')
   external Float32List _constructor(FragmentProgram program, int floatUniforms, int samplerUniforms);
+
+  @FfiNative<Void Function(Pointer<Void>, Handle, Handle)>('ReusableFragmentShader::SetImageSampler')
+  external void _setImageSampler(int index, Image sampler);
 
   @FfiNative<Void Function(Pointer<Void>, Handle, Handle)>('ReusableFragmentShader::SetSampler')
   external void _setSampler(int index, ImageShader sampler);

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -4316,7 +4316,7 @@ class FragmentShader extends Shader {
 
   /// Sets the sampler uniform at [index] to [image].
   ///
-  /// The index provided to setSampler is the index of the sampler uniform defined
+  /// The index provided to setImageSampler is the index of the sampler uniform defined
   /// in the fragment program, excluding all non-sampler uniforms.
   ///
   /// All the sampler uniforms that a shader expects must be provided or the

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -4335,7 +4335,6 @@ class FragmentShader extends Shader {
   /// results will be undefined.
   ///
   /// Use of this method may result in poor performance with the Impeller backend.
-  @Deprecated('Use setImageSampler instead.')
   void setSampler(int index, ImageShader sampler) {
     assert(!debugDisposed, 'Tried to access uniforms on a disposed Shader: $this');
     _setSampler(index, sampler);

--- a/lib/ui/painting/fragment_shader.cc
+++ b/lib/ui/painting/fragment_shader.cc
@@ -5,6 +5,8 @@
 #include <memory>
 #include <utility>
 
+#include "display_list/display_list_color_source.h"
+#include "display_list/display_list_tile_mode.h"
 #include "flutter/lib/ui/painting/fragment_shader.h"
 
 #include "flutter/lib/ui/dart_wrapper.h"
@@ -59,6 +61,27 @@ bool ReusableFragmentShader::ValidateSamplers() {
     }
   }
   return true;
+}
+
+void ReusableFragmentShader::SetImageSampler(Dart_Handle index_handle,
+                                             Dart_Handle image_handle) {
+  uint64_t index = tonic::DartConverter<uint64_t>::FromDart(index_handle);
+  CanvasImage* image =
+      tonic::DartConverter<CanvasImage*>::FromDart(image_handle);
+  if (index >= samplers_.size()) {
+    Dart_ThrowException(tonic::ToDart("Sampler index out of bounds"));
+  }
+
+  // TODO(115794): Once the DlImageSampling enum is replaced, expose the
+  //               sampling options as a new default parameter for users.
+  samplers_[index] = std::make_shared<DlImageColorSource>(
+      image->image(), DlTileMode::kClamp, DlTileMode::kClamp,
+      DlImageSampling::kNearestNeighbor, nullptr);
+
+  auto* uniform_floats =
+      reinterpret_cast<float*>(uniform_data_->writable_data());
+  uniform_floats[float_count_ + 2 * index] = image->width();
+  uniform_floats[float_count_ + 2 * index + 1] = image->height();
 }
 
 void ReusableFragmentShader::SetSampler(Dart_Handle index_handle,

--- a/lib/ui/painting/fragment_shader.cc
+++ b/lib/ui/painting/fragment_shader.cc
@@ -5,10 +5,10 @@
 #include <memory>
 #include <utility>
 
-#include "display_list/display_list_color_source.h"
-#include "display_list/display_list_tile_mode.h"
 #include "flutter/lib/ui/painting/fragment_shader.h"
 
+#include "flutter/display_list/display_list_color_source.h"
+#include "flutter/display_list/display_list_tile_mode.h"
 #include "flutter/lib/ui/dart_wrapper.h"
 #include "flutter/lib/ui/painting/fragment_program.h"
 #include "flutter/lib/ui/ui_dart_state.h"

--- a/lib/ui/painting/fragment_shader.h
+++ b/lib/ui/painting/fragment_shader.h
@@ -34,6 +34,8 @@ class ReusableFragmentShader : public Shader {
                             Dart_Handle float_count,
                             Dart_Handle sampler_count);
 
+  void SetImageSampler(Dart_Handle index, Dart_Handle image);
+
   void SetSampler(Dart_Handle index, Dart_Handle sampler);
 
   bool ValidateSamplers();

--- a/lib/web_ui/lib/painting.dart
+++ b/lib/web_ui/lib/painting.dart
@@ -818,6 +818,8 @@ abstract class FragmentProgram {
 abstract class FragmentShader implements Shader {
   void setFloat(int index, double value);
 
+  void setImageSampler(int index, Image image);
+
   void setSampler(int index, ImageShader sampler);
 
   @override

--- a/lib/web_ui/lib/src/engine/canvaskit/painting.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/painting.dart
@@ -8,6 +8,7 @@ import 'dart:typed_data';
 import 'package:ui/ui.dart' as ui;
 
 import '../color_filter.dart';
+import '../vector_math.dart';
 import 'canvaskit_api.dart';
 import 'color_filter.dart';
 import 'image_filter.dart';
@@ -474,6 +475,19 @@ class CkFragmentShader implements ui.FragmentShader {
   @override
   void setFloat(int index, double value) {
     floats[index] = value;
+  }
+
+  @override
+  void setImageSampler(int index, ui.Image image) {
+    ui.ImageShader sampler = ui.ImageShader(
+        image,
+        ui.TileMode.clamp,
+        ui.TileMode.clamp,
+        Float32List.fromList(Matrix4.identity().storage),
+        null);
+    samplers[index] = (sampler as CkShader).skiaObject;
+    setFloat(lastFloatIndex + 2 * index, (sampler as CkImageShader).imageWidth.toDouble());
+    setFloat(lastFloatIndex + 2 * index + 1, sampler.imageHeight.toDouble());
   }
 
   @override

--- a/lib/web_ui/lib/src/engine/canvaskit/painting.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/painting.dart
@@ -480,7 +480,7 @@ class CkFragmentShader implements ui.FragmentShader {
   @override
   void setImageSampler(int index, ui.Image image) {
     ui.ImageShader sampler = ui.ImageShader(image, ui.TileMode.clamp,
-        ui.TileMode.clamp, Matrix4.identity().storage);
+        ui.TileMode.clamp, toMatrix64(Matrix4.identity().storage));
     samplers[index] = (sampler as CkShader).skiaObject;
     setFloat(lastFloatIndex + 2 * index, (sampler as CkImageShader).imageWidth.toDouble());
     setFloat(lastFloatIndex + 2 * index + 1, sampler.imageHeight.toDouble());

--- a/lib/web_ui/lib/src/engine/canvaskit/painting.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/painting.dart
@@ -479,12 +479,8 @@ class CkFragmentShader implements ui.FragmentShader {
 
   @override
   void setImageSampler(int index, ui.Image image) {
-    ui.ImageShader sampler = ui.ImageShader(
-        image,
-        ui.TileMode.clamp,
-        ui.TileMode.clamp,
-        Float32List.fromList(Matrix4.identity().storage),
-        null);
+    ui.ImageShader sampler = ui.ImageShader(image, ui.TileMode.clamp,
+        ui.TileMode.clamp, Float32List.fromList(Matrix4.identity().storage));
     samplers[index] = (sampler as CkShader).skiaObject;
     setFloat(lastFloatIndex + 2 * index, (sampler as CkImageShader).imageWidth.toDouble());
     setFloat(lastFloatIndex + 2 * index + 1, sampler.imageHeight.toDouble());

--- a/lib/web_ui/lib/src/engine/canvaskit/painting.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/painting.dart
@@ -480,7 +480,7 @@ class CkFragmentShader implements ui.FragmentShader {
   @override
   void setImageSampler(int index, ui.Image image) {
     ui.ImageShader sampler = ui.ImageShader(image, ui.TileMode.clamp,
-        ui.TileMode.clamp, Float32List.fromList(Matrix4.identity().storage));
+        ui.TileMode.clamp, Matrix4.identity().storage);
     samplers[index] = (sampler as CkShader).skiaObject;
     setFloat(lastFloatIndex + 2 * index, (sampler as CkImageShader).imageWidth.toDouble());
     setFloat(lastFloatIndex + 2 * index + 1, sampler.imageHeight.toDouble());

--- a/lib/web_ui/lib/src/engine/canvaskit/painting.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/painting.dart
@@ -479,7 +479,7 @@ class CkFragmentShader implements ui.FragmentShader {
 
   @override
   void setImageSampler(int index, ui.Image image) {
-    ui.ImageShader sampler = ui.ImageShader(image, ui.TileMode.clamp,
+    final ui.ImageShader sampler = ui.ImageShader(image, ui.TileMode.clamp,
         ui.TileMode.clamp, toMatrix64(Matrix4.identity().storage));
     samplers[index] = (sampler as CkShader).skiaObject;
     setFloat(lastFloatIndex + 2 * index, (sampler as CkImageShader).imageWidth.toDouble());

--- a/lib/web_ui/lib/src/engine/html/painting.dart
+++ b/lib/web_ui/lib/src/engine/html/painting.dart
@@ -303,6 +303,11 @@ class HtmlFragmentShader implements ui.FragmentShader {
   }
 
   @override
+  void setImageSampler(int index, ui.Image image) {
+    throw UnsupportedError('FragmentShader is not supported for the HTML renderer.');
+  }
+
+  @override
   void setSampler(int index, ui.ImageShader sampler) {
     throw UnsupportedError('FragmentShader is not supported for the HTML renderer.');
   }


### PR DESCRIPTION
`setImageSampler` guarantees we don't need an additional texture/render pass per-sampler. It's possible for users to emulate the functionality of `setSampler` in-shader.

The intention is to do the following before the stable branch cut:
1. Land this and roll into the framework.
1. Migrate stuff in the framework from `setSampler` to `setImageSampler`.
1. Remove `setSampler`.

I filed https://github.com/flutter/flutter/issues/115794 along the way.
