### PR TITLE
[Impeller] opt float/sampler into relaxed precision for gles

### DIFF
--- a/impeller/compiler/shader_lib/impeller/types.glsl
+++ b/impeller/compiler/shader_lib/impeller/types.glsl
@@ -5,12 +5,9 @@
 #ifndef TYPES_GLSL_
 #define TYPES_GLSL_
 
-#ifdef IMPELLER_TARGET_METAL
 #extension GL_AMD_gpu_shader_half_float : enable
 
-#else
-
-#extension GL_AMD_gpu_shader_half_float : enable
+#ifndef IMPELLER_TARGET_METAL
 
 precision mediump sampler2D;
 precision mediump float;

--- a/impeller/compiler/shader_lib/impeller/types.glsl
+++ b/impeller/compiler/shader_lib/impeller/types.glsl
@@ -5,6 +5,24 @@
 #ifndef TYPES_GLSL_
 #define TYPES_GLSL_
 
+#ifdef IMPELLER_TARGET_METAL
+#extension GL_AMD_gpu_shader_half_float : enable
+
+#else
+
+#extension GL_AMD_gpu_shader_half_float : enable
+
+precision mediump sampler2D;
+precision mediump float;
+
+#define float16_t float
+#define f16vec2 vec2
+#define f16vec3 vec3
+#define f16vec4 vec4
+#define f16mat4 mat4
+
+#endif  // IMPELLER_TARGET_METAL
+
 #define BoolF float
 #define BoolV2 vec2
 #define BoolV3 vec3

--- a/impeller/entity/shaders/atlas_fill.frag
+++ b/impeller/entity/shaders/atlas_fill.frag
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include <impeller/texture.glsl>
+#include <impeller/types.glsl>
 
 uniform sampler2D texture_sampler;
 

--- a/impeller/entity/shaders/atlas_fill.vert
+++ b/impeller/entity/shaders/atlas_fill.vert
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <impeller/types.glsl>
+
 uniform VertInfo {
   mat4 mvp;
 }

--- a/impeller/entity/shaders/blending/advanced_blend.glsl
+++ b/impeller/entity/shaders/blending/advanced_blend.glsl
@@ -5,6 +5,7 @@
 #include <impeller/blending.glsl>
 #include <impeller/color.glsl>
 #include <impeller/texture.glsl>
+#include <impeller/types.glsl>
 
 uniform BlendInfo {
   float dst_input_alpha;

--- a/impeller/entity/shaders/blending/advanced_blend.vert
+++ b/impeller/entity/shaders/blending/advanced_blend.vert
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <impeller/types.glsl>
+
 uniform FrameInfo {
   mat4 mvp;
 }

--- a/impeller/entity/shaders/blending/blend.frag
+++ b/impeller/entity/shaders/blending/blend.frag
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include <impeller/texture.glsl>
+#include <impeller/types.glsl>
 
 uniform sampler2D texture_sampler_src;
 

--- a/impeller/entity/shaders/blending/blend.vert
+++ b/impeller/entity/shaders/blending/blend.vert
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <impeller/types.glsl>
+
 uniform FrameInfo {
   mat4 mvp;
 }

--- a/impeller/entity/shaders/border_mask_blur.frag
+++ b/impeller/entity/shaders/border_mask_blur.frag
@@ -4,6 +4,7 @@
 
 #include <impeller/gaussian.glsl>
 #include <impeller/texture.glsl>
+#include <impeller/types.glsl>
 
 // Constant time mask blur for image borders.
 //

--- a/impeller/entity/shaders/border_mask_blur.vert
+++ b/impeller/entity/shaders/border_mask_blur.vert
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <impeller/types.glsl>
+
 uniform FrameInfo {
   mat4 mvp;
 

--- a/impeller/entity/shaders/color_matrix_color_filter.frag
+++ b/impeller/entity/shaders/color_matrix_color_filter.frag
@@ -4,6 +4,7 @@
 
 #include <impeller/color.glsl>
 #include <impeller/texture.glsl>
+#include <impeller/types.glsl>
 
 // A color filter that transforms colors through a 4x5 color matrix.
 //

--- a/impeller/entity/shaders/color_matrix_color_filter.vert
+++ b/impeller/entity/shaders/color_matrix_color_filter.vert
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <impeller/types.glsl>
+
 uniform FrameInfo {
   mat4 mvp;
 }

--- a/impeller/entity/shaders/gaussian_blur.frag
+++ b/impeller/entity/shaders/gaussian_blur.frag
@@ -16,6 +16,7 @@
 #include <impeller/constants.glsl>
 #include <impeller/gaussian.glsl>
 #include <impeller/texture.glsl>
+#include <impeller/types.glsl>
 
 uniform sampler2D texture_sampler;
 uniform sampler2D alpha_mask_sampler;

--- a/impeller/entity/shaders/gaussian_blur.vert
+++ b/impeller/entity/shaders/gaussian_blur.vert
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <impeller/types.glsl>
+
 uniform FrameInfo {
   mat4 mvp;
 }

--- a/impeller/entity/shaders/glyph_atlas.frag
+++ b/impeller/entity/shaders/glyph_atlas.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <impeller/types.glsl>
+
 uniform sampler2D glyph_atlas_sampler;
 
 uniform FragInfo {

--- a/impeller/entity/shaders/glyph_atlas.vert
+++ b/impeller/entity/shaders/glyph_atlas.vert
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include <impeller/transform.glsl>
+#include <impeller/types.glsl>
 
 uniform FrameInfo {
   mat4 mvp;

--- a/impeller/entity/shaders/glyph_atlas_sdf.frag
+++ b/impeller/entity/shaders/glyph_atlas_sdf.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <impeller/types.glsl>
+
 uniform sampler2D glyph_atlas_sampler;
 
 uniform FragInfo {

--- a/impeller/entity/shaders/glyph_atlas_sdf.vert
+++ b/impeller/entity/shaders/glyph_atlas_sdf.vert
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <impeller/types.glsl>
+
 #include <impeller/transform.glsl>
 
 uniform FrameInfo {

--- a/impeller/entity/shaders/gradient_fill.vert
+++ b/impeller/entity/shaders/gradient_fill.vert
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include <impeller/transform.glsl>
+#include <impeller/types.glsl>
 
 uniform FrameInfo {
   mat4 mvp;

--- a/impeller/entity/shaders/linear_gradient_fill.frag
+++ b/impeller/entity/shaders/linear_gradient_fill.frag
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include <impeller/texture.glsl>
+#include <impeller/types.glsl>
 
 uniform sampler2D texture_sampler;
 

--- a/impeller/entity/shaders/linear_gradient_ssbo_fill.frag
+++ b/impeller/entity/shaders/linear_gradient_ssbo_fill.frag
@@ -4,6 +4,7 @@
 
 #include <impeller/gradient.glsl>
 #include <impeller/texture.glsl>
+#include <impeller/types.glsl>
 
 readonly buffer ColorData {
   vec4 colors[];

--- a/impeller/entity/shaders/linear_to_srgb_filter.frag
+++ b/impeller/entity/shaders/linear_to_srgb_filter.frag
@@ -4,6 +4,7 @@
 
 #include <impeller/color.glsl>
 #include <impeller/texture.glsl>
+#include <impeller/types.glsl>
 
 // A color filter that applies the sRGB gamma curve to the color.
 //

--- a/impeller/entity/shaders/linear_to_srgb_filter.vert
+++ b/impeller/entity/shaders/linear_to_srgb_filter.vert
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <impeller/types.glsl>
+
 uniform FrameInfo {
   mat4 mvp;
 }

--- a/impeller/entity/shaders/morphology_filter.frag
+++ b/impeller/entity/shaders/morphology_filter.frag
@@ -4,6 +4,7 @@
 
 #include <impeller/constants.glsl>
 #include <impeller/texture.glsl>
+#include <impeller/types.glsl>
 
 // These values must correspond to the order of the items in the
 // 'FilterContents::MorphType' enum class.

--- a/impeller/entity/shaders/morphology_filter.vert
+++ b/impeller/entity/shaders/morphology_filter.vert
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <impeller/types.glsl>
+
 uniform FrameInfo {
   mat4 mvp;
 }

--- a/impeller/entity/shaders/position.vert
+++ b/impeller/entity/shaders/position.vert
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include <impeller/transform.glsl>
+#include <impeller/types.glsl>
 
 uniform VertInfo {
   mat4 mvp;

--- a/impeller/entity/shaders/position_color.vert
+++ b/impeller/entity/shaders/position_color.vert
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include <impeller/transform.glsl>
+#include <impeller/types.glsl>
 
 uniform VertInfo {
   mat4 mvp;

--- a/impeller/entity/shaders/position_uv.vert
+++ b/impeller/entity/shaders/position_uv.vert
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include <impeller/transform.glsl>
+#include <impeller/types.glsl>
 
 uniform VertInfo {
   mat4 mvp;

--- a/impeller/entity/shaders/radial_gradient_fill.frag
+++ b/impeller/entity/shaders/radial_gradient_fill.frag
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include <impeller/texture.glsl>
+#include <impeller/types.glsl>
 
 uniform sampler2D texture_sampler;
 

--- a/impeller/entity/shaders/radial_gradient_ssbo_fill.frag
+++ b/impeller/entity/shaders/radial_gradient_ssbo_fill.frag
@@ -4,6 +4,7 @@
 
 #include <impeller/gradient.glsl>
 #include <impeller/texture.glsl>
+#include <impeller/types.glsl>
 
 readonly buffer ColorData {
   vec4 colors[];

--- a/impeller/entity/shaders/rrect_blur.frag
+++ b/impeller/entity/shaders/rrect_blur.frag
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include <impeller/gaussian.glsl>
+#include <impeller/types.glsl>
 
 uniform FragInfo {
   vec4 color;

--- a/impeller/entity/shaders/rrect_blur.vert
+++ b/impeller/entity/shaders/rrect_blur.vert
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <impeller/types.glsl>
+
 uniform VertInfo {
   mat4 mvp;
 }

--- a/impeller/entity/shaders/runtime_effect.vert
+++ b/impeller/entity/shaders/runtime_effect.vert
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <impeller/types.glsl>
+
 uniform VertInfo {
   mat4 mvp;
 }

--- a/impeller/entity/shaders/solid_fill.frag
+++ b/impeller/entity/shaders/solid_fill.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <impeller/types.glsl>
+
 uniform FragInfo {
   vec4 color;
 }

--- a/impeller/entity/shaders/solid_fill.vert
+++ b/impeller/entity/shaders/solid_fill.vert
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <impeller/types.glsl>
+
 uniform VertInfo {
   mat4 mvp;
 }

--- a/impeller/entity/shaders/srgb_to_linear_filter.frag
+++ b/impeller/entity/shaders/srgb_to_linear_filter.frag
@@ -8,6 +8,8 @@
 // Creates a color filter that applies the inverse of the sRGB gamma curve
 // to the RGB channels.
 
+#include <impeller/types.glsl>
+
 uniform sampler2D input_texture;
 
 uniform FragInfo {

--- a/impeller/entity/shaders/srgb_to_linear_filter.vert
+++ b/impeller/entity/shaders/srgb_to_linear_filter.vert
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <impeller/types.glsl>
+
 uniform FrameInfo {
   mat4 mvp;
 }

--- a/impeller/entity/shaders/sweep_gradient_fill.frag
+++ b/impeller/entity/shaders/sweep_gradient_fill.frag
@@ -4,6 +4,7 @@
 
 #include <impeller/constants.glsl>
 #include <impeller/texture.glsl>
+#include <impeller/types.glsl>
 
 uniform sampler2D texture_sampler;
 

--- a/impeller/entity/shaders/sweep_gradient_ssbo_fill.frag
+++ b/impeller/entity/shaders/sweep_gradient_ssbo_fill.frag
@@ -5,6 +5,7 @@
 #include <impeller/constants.glsl>
 #include <impeller/gradient.glsl>
 #include <impeller/texture.glsl>
+#include <impeller/types.glsl>
 
 readonly buffer ColorData {
   vec4 colors[];

--- a/impeller/entity/shaders/texture_fill.frag
+++ b/impeller/entity/shaders/texture_fill.frag
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include <impeller/texture.glsl>
+#include <impeller/types.glsl>
 
 uniform sampler2D texture_sampler;
 

--- a/impeller/entity/shaders/texture_fill.vert
+++ b/impeller/entity/shaders/texture_fill.vert
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <impeller/types.glsl>
+
 uniform VertInfo {
   mat4 mvp;
 }

--- a/impeller/entity/shaders/tiled_texture_fill.frag
+++ b/impeller/entity/shaders/tiled_texture_fill.frag
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include <impeller/texture.glsl>
+#include <impeller/types.glsl>
 
 uniform sampler2D texture_sampler;
 

--- a/impeller/entity/shaders/tiled_texture_fill.vert
+++ b/impeller/entity/shaders/tiled_texture_fill.vert
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include <impeller/transform.glsl>
+#include <impeller/types.glsl>
 
 uniform VertInfo {
   mat4 mvp;

--- a/impeller/entity/shaders/vertices.frag
+++ b/impeller/entity/shaders/vertices.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <impeller/types.glsl>
+
 in vec4 v_color;
 
 out vec4 frag_color;

--- a/impeller/entity/shaders/yuv_to_rgb_filter.frag
+++ b/impeller/entity/shaders/yuv_to_rgb_filter.frag
@@ -4,6 +4,7 @@
 
 #include <impeller/color.glsl>
 #include <impeller/texture.glsl>
+#include <impeller/types.glsl>
 
 uniform sampler2D y_texture;
 uniform sampler2D uv_texture;

--- a/impeller/entity/shaders/yuv_to_rgb_filter.vert
+++ b/impeller/entity/shaders/yuv_to_rgb_filter.vert
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <impeller/types.glsl>
+
 uniform FrameInfo {
   mat4 mvp;
 }


### PR DESCRIPTION
Simplified version of https://github.com/flutter/engine/pull/37823/

Part of https://github.com/flutter/flutter/issues/115044

Introduce float16_t, f16vec2, et cetera types (but don't necessarily use them). Opt gles into relaxed precision.

We can't really use the float16 types, because they currently 1) are unsupported by reflector.cc 2) even if they were supported would lead to different codegen based on the target platform.

Until that is resolved, we can only use float16 types within the shader itself, which means explicit conversions are required. Because these aren't free, its less straightforward to apply.

Why can't precision mediump float compile to have on MSL? In short, because mediump/lowp are just treated as hints to the driver that compiles the shader - they can and will be discarded. As a result, there are no conversions and such. Whereas in MSL half and float are distinct types and conversions must be explict. functions like `max` or `mix` are generic and can't be invoked with a mix of half/float values.

To correctly generate MSL with `half` types, we need to use types such as `float_16t, f16vec2` et cetera.

See also:
* https://registry.khronos.org/OpenGL/extensions/AMD/AMD_gpu_shader_half_float.txt
* https://github.com/KhronosGroup/Vulkan-Samples/tree/master/samples/performance/16bit_arithmetic#explicit-16-bit-arithmetic-vs-mediump--relaxedprecision
