### PR TITLE
Revert "[impeller] Remove declare_undefined_values"

### DIFF
--- a/impeller/compiler/spirv_sksl.cc
+++ b/impeller/compiler/spirv_sksl.cc
@@ -349,6 +349,8 @@ void CompilerSkSL::emit_resources() {
   if (emit_global_variable_resources()) {
     statement("");
   }
+
+  declare_undefined_values();
 }
 
 void CompilerSkSL::emit_interface_block(const SPIRVariable& var) {


### PR DESCRIPTION
Reverts flutter/engine#37829

This breaks impellerc unless spirv-cross is also rolled forward.