### PR TITLE
Remove setSampler from FragmentShader

### DIFF
--- a/lib/ui/dart_ui.cc
+++ b/lib/ui/dart_ui.cc
@@ -175,7 +175,6 @@ typedef CanvasPath Path;
   V(FragmentProgram, initFromAsset, 2)                 \
   V(ReusableFragmentShader, Dispose, 1)                \
   V(ReusableFragmentShader, SetImageSampler, 3)        \
-  V(ReusableFragmentShader, SetSampler, 3)             \
   V(ReusableFragmentShader, ValidateSamplers, 1)       \
   V(Gradient, initLinear, 6)                           \
   V(Gradient, initRadial, 8)                           \

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -4245,7 +4245,7 @@ class FragmentProgram extends NativeFieldWrapperClass1 {
 /// [FragmentProgram.fragmentShader] method. The float uniforms list is
 /// initialized to the size expected by the shader and is zero-filled. Uniforms
 /// of float type can then be set by calling [setFloat]. Sampler uniforms are
-/// set by calling [setSampler].
+/// set by calling [setImageSampler].
 ///
 /// A [FragmentShader] can be re-used, and this is an efficient way to avoid
 /// allocating and re-initializing the uniform buffer and samplers. However,
@@ -4288,7 +4288,7 @@ class FragmentShader extends Shader {
   /// is:
   ///
   /// ```dart
-  /// void updateShader(ui.FragmentShader shader, Color color, ImageShader sampler) {
+  /// void updateShader(ui.FragmentShader shader, Color color, Image image) {
   ///   shader.setFloat(0, 23);  // uScale
   ///   shader.setFloat(1, 114); // uMagnitude x
   ///   shader.setFloat(2, 83);  // uMagnitude y
@@ -4300,12 +4300,12 @@ class FragmentShader extends Shader {
   ///   shader.setFloat(6, color.opacity);                     // uColor a
   ///
   ///   // initialize sampler uniform.
-  ///   shader.setSampler(0, sampler);
+  ///   shader.setImageSampler(0, image);
   /// }
   /// ```
   ///
   /// Note how the indexes used does not count the `sampler2D` uniform. This
-  /// uniform will be set separately with [setSampler], with the index starting
+  /// uniform will be set separately with [setImageSampler], with the index starting
   /// over at 0.
   ///
   /// Any float uniforms that are left uninitialized will default to `0`.
@@ -4326,18 +4326,6 @@ class FragmentShader extends Shader {
     _setImageSampler(index, image._image);
   }
 
-  /// Sets the sampler uniform at [index] to [sampler].
-  ///
-  /// The index provided to setSampler is the index of the sampler uniform defined
-  /// in the fragment program, excluding all non-sampler uniforms.
-  ///
-  /// All the sampler uniforms that a shader expects must be provided or the
-  /// results will be undefined.
-  void setSampler(int index, ImageShader sampler) {
-    assert(!debugDisposed, 'Tried to access uniforms on a disposed Shader: $this');
-    _setSampler(index, sampler);
-  }
-
   /// Releases the native resources held by the [FragmentShader].
   ///
   /// After this method is called, calling methods on the shader, or attaching
@@ -4355,9 +4343,6 @@ class FragmentShader extends Shader {
 
   @FfiNative<Void Function(Pointer<Void>, Handle, Handle)>('ReusableFragmentShader::SetImageSampler')
   external void _setImageSampler(int index, _Image sampler);
-
-  @FfiNative<Void Function(Pointer<Void>, Handle, Handle)>('ReusableFragmentShader::SetSampler')
-  external void _setSampler(int index, ImageShader sampler);
 
   @FfiNative<Bool Function(Pointer<Void>)>('ReusableFragmentShader::ValidateSamplers')
   external bool _validateSamplers();

--- a/lib/ui/painting/fragment_shader.cc
+++ b/lib/ui/painting/fragment_shader.cc
@@ -84,29 +84,6 @@ void ReusableFragmentShader::SetImageSampler(Dart_Handle index_handle,
   uniform_floats[float_count_ + 2 * index + 1] = image->height();
 }
 
-void ReusableFragmentShader::SetSampler(Dart_Handle index_handle,
-                                        Dart_Handle sampler_handle) {
-  uint64_t index = tonic::DartConverter<uint64_t>::FromDart(index_handle);
-  ImageShader* sampler =
-      tonic::DartConverter<ImageShader*>::FromDart(sampler_handle);
-  if (index >= samplers_.size()) {
-    Dart_ThrowException(tonic::ToDart("Sampler index out of bounds"));
-  }
-
-  // ImageShaders can hold a preferred value for sampling options and
-  // developers are encouraged to use that value or the value will be supplied
-  // by "the environment where it is used". The environment here does not
-  // contain a value to be used if the developer did not specify a preference
-  // when they constructed the ImageShader, so we will use kNearest which is
-  // the default filterQuality in a Paint object.
-  DlImageSampling sampling = DlImageSampling::kNearestNeighbor;
-  auto* uniform_floats =
-      reinterpret_cast<float*>(uniform_data_->writable_data());
-  samplers_[index] = sampler->shader(sampling);
-  uniform_floats[float_count_ + 2 * index] = sampler->width();
-  uniform_floats[float_count_ + 2 * index + 1] = sampler->height();
-}
-
 std::shared_ptr<DlColorSource> ReusableFragmentShader::shader(
     DlImageSampling sampling) {
   FML_CHECK(program_);

--- a/lib/ui/painting/fragment_shader.h
+++ b/lib/ui/painting/fragment_shader.h
@@ -36,8 +36,6 @@ class ReusableFragmentShader : public Shader {
 
   void SetImageSampler(Dart_Handle index, Dart_Handle image);
 
-  void SetSampler(Dart_Handle index, Dart_Handle sampler);
-
   bool ValidateSamplers();
 
   void Dispose();

--- a/lib/web_ui/lib/painting.dart
+++ b/lib/web_ui/lib/painting.dart
@@ -820,8 +820,6 @@ abstract class FragmentShader implements Shader {
 
   void setImageSampler(int index, Image image);
 
-  void setSampler(int index, ImageShader sampler);
-
   @override
   void dispose();
 

--- a/lib/web_ui/lib/src/engine/canvaskit/painting.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/painting.dart
@@ -487,13 +487,6 @@ class CkFragmentShader implements ui.FragmentShader {
   }
 
   @override
-  void setSampler(int index, ui.ImageShader sampler) {
-    samplers[index] = (sampler as CkShader).skiaObject;
-    setFloat(lastFloatIndex + 2 * index, (sampler as CkImageShader).imageWidth.toDouble());
-    setFloat(lastFloatIndex + 2 * index + 1, sampler.imageHeight.toDouble());
-  }
-
-  @override
   void dispose() {
     assert(() {
       _debugDisposed = true;

--- a/lib/web_ui/lib/src/engine/html/painting.dart
+++ b/lib/web_ui/lib/src/engine/html/painting.dart
@@ -308,11 +308,6 @@ class HtmlFragmentShader implements ui.FragmentShader {
   }
 
   @override
-  void setSampler(int index, ui.ImageShader sampler) {
-    throw UnsupportedError('FragmentShader is not supported for the HTML renderer.');
-  }
-
-  @override
   void dispose() {
     throw UnsupportedError('FragmentShader is not supported for the HTML renderer.');
   }

--- a/testing/dart/fragment_shader_test.dart
+++ b/testing/dart/fragment_shader_test.dart
@@ -484,11 +484,3 @@ Image _createBlueGreenImageSync() {
     picture.dispose();
   }
 }
-
-
-final Float64List _identityMatrix = Float64List.fromList(<double>[
-  1, 0, 0, 0,
-  0, 1, 0, 0,
-  0, 0, 1, 0,
-  0, 0, 0, 1,
-]);

--- a/testing/dart/fragment_shader_test.dart
+++ b/testing/dart/fragment_shader_test.dart
@@ -46,18 +46,15 @@ void main() async {
       'blue_green_sampler.frag.iplr',
     );
     final Image blueGreenImage = await _createBlueGreenImage();
-    final ImageShader imageShader = ImageShader(
-        blueGreenImage, TileMode.clamp, TileMode.clamp, _identityMatrix);
     final FragmentShader fragmentShader = program.fragmentShader();
 
     try {
-      fragmentShader.setSampler(1, imageShader);
+      fragmentShader.setImageSampler(1, blueGreenImage);
       fail('Unreachable');
     } catch (e) {
       expect(e, contains('Sampler index out of bounds'));
     } finally {
       fragmentShader.dispose();
-      imageShader.dispose();
       blueGreenImage.dispose();
     }
   });
@@ -86,11 +83,9 @@ void main() async {
       'blue_green_sampler.frag.iplr',
     );
     final Image blueGreenImage = await _createBlueGreenImage();
-    final ImageShader imageShader = ImageShader(
-        blueGreenImage, TileMode.clamp, TileMode.clamp, _identityMatrix);
 
     final FragmentShader shader = program.fragmentShader()
-      ..setSampler(0, imageShader);
+      ..setImageSampler(0, blueGreenImage);
     shader.dispose();
     try {
       final Paint paint = Paint()..shader = shader;  // ignore: unused_local_variable
@@ -100,7 +95,6 @@ void main() async {
     } catch (e) {
       expect(e.toString(), contains('Attempted to set a disposed shader'));
     }
-    imageShader.dispose();
     blueGreenImage.dispose();
   });
 
@@ -128,19 +122,17 @@ void main() async {
     }
   });
 
-  test('Disposed FragmentShader setSampler', () async {
+  test('Disposed FragmentShader setImageSampler', () async {
     final FragmentProgram program = await FragmentProgram.fromAsset(
       'blue_green_sampler.frag.iplr',
     );
     final Image blueGreenImage = await _createBlueGreenImage();
-    final ImageShader imageShader = ImageShader(
-        blueGreenImage, TileMode.clamp, TileMode.clamp, _identityMatrix);
 
     final FragmentShader shader = program.fragmentShader()
-      ..setSampler(0, imageShader);
+      ..setImageSampler(0, blueGreenImage);
     shader.dispose();
     try {
-      shader.setSampler(0, imageShader);
+      shader.setImageSampler(0, blueGreenImage);
       if (assertsEnabled) {
         fail('Unreachable');
       }
@@ -155,7 +147,6 @@ void main() async {
         contains('the native peer has been collected'),
       );
     }
-    imageShader.dispose();
     blueGreenImage.dispose();
   });
 
@@ -209,13 +200,10 @@ void main() async {
       'blue_green_sampler.frag.iplr',
     );
     final Image blueGreenImage = await _createBlueGreenImage();
-    final ImageShader imageShader = ImageShader(
-        blueGreenImage, TileMode.clamp, TileMode.clamp, _identityMatrix);
     final FragmentShader shader = program.fragmentShader()
-      ..setSampler(0, imageShader);
+      ..setImageSampler(0, blueGreenImage);
     await _expectShaderRendersGreen(shader);
     shader.dispose();
-    imageShader.dispose();
     blueGreenImage.dispose();
   });
 
@@ -224,13 +212,10 @@ void main() async {
       'blue_green_sampler.frag.iplr',
     );
     final Image blueGreenImage = _createBlueGreenImageSync();
-    final ImageShader imageShader = ImageShader(
-        blueGreenImage, TileMode.clamp, TileMode.clamp, _identityMatrix);
     final FragmentShader shader = program.fragmentShader()
-      ..setSampler(0, imageShader);
+      ..setImageSampler(0, blueGreenImage);
     await _expectShaderRendersGreen(shader);
     shader.dispose();
-    imageShader.dispose();
     blueGreenImage.dispose();
   });
 


### PR DESCRIPTION
Followup to https://github.com/flutter/engine/pull/37821.

I actually didn't find any setSampler usage in the framework, so just removing it before the engine roll finishes. 🤔 Am I missing anything?