### PR TITLE
[impeller] use half precision for all advanced blends

### DIFF
--- a/impeller/compiler/shader_lib/impeller/blending.glsl
+++ b/impeller/compiler/shader_lib/impeller/blending.glsl
@@ -7,46 +7,48 @@
 
 #include <impeller/branching.glsl>
 #include <impeller/constants.glsl>
+#include <impeller/types.glsl>
 
 //------------------------------------------------------------------------------
 /// HSV utilities.
 ///
 
-float IPLuminosity(vec3 color) {
-  return color.r * 0.3 + color.g * 0.59 + color.b * 0.11;
+float16_t IPLuminosity(f16vec3 color) {
+  return color.r * 0.3hf + color.g * 0.59hf + color.b * 0.11hf;
 }
 
 /// Scales the color's luma by the amount necessary to place the color
 /// components in a 1-0 range.
-vec3 IPClipColor(vec3 color) {
-  float lum = IPLuminosity(color);
-  float mn = min(min(color.r, color.g), color.b);
-  float mx = max(max(color.r, color.g), color.b);
+f16vec3 IPClipColor(f16vec3 color) {
+  float16_t lum = IPLuminosity(color);
+  float16_t mn = min(min(color.r, color.g), color.b);
+  float16_t mx = max(max(color.r, color.g), color.b);
   // `lum - mn` and `mx - lum` will always be >= 0 in the following conditions,
   // so adding a tiny value is enough to make these divisions safe.
-  if (mn < 0) {
-    color = lum + (((color - lum) * lum) / (lum - mn + kEhCloseEnough));
+  if (mn < 0.0hf) {
+    color = lum + (((color - lum) * lum) / (lum - mn + kEhCloseEnoughHf));
   }
-  if (mx > 1) {
-    color = lum + (((color - lum) * (1 - lum)) / (mx - lum + kEhCloseEnough));
+  if (mx > 1.0hf) {
+    color =
+        lum + (((color - lum) * (1.0hf - lum)) / (mx - lum + kEhCloseEnoughHf));
   }
   return color;
 }
 
-vec3 IPSetLuminosity(vec3 color, float luminosity) {
-  float relative_lum = luminosity - IPLuminosity(color);
+f16vec3 IPSetLuminosity(f16vec3 color, float16_t luminosity) {
+  float16_t relative_lum = luminosity - IPLuminosity(color);
   return IPClipColor(color + relative_lum);
 }
 
-float IPSaturation(vec3 color) {
+float16_t IPSaturation(f16vec3 color) {
   return max(max(color.r, color.g), color.b) -
          min(min(color.r, color.g), color.b);
 }
 
-vec3 IPSetSaturation(vec3 color, float saturation) {
-  float mn = min(min(color.r, color.g), color.b);
-  float mx = max(max(color.r, color.g), color.b);
-  return (mn < mx) ? ((color - mn) * saturation) / (mx - mn) : vec3(0);
+f16vec3 IPSetSaturation(f16vec3 color, float16_t saturation) {
+  float16_t mn = min(min(color.r, color.g), color.b);
+  float16_t mx = max(max(color.r, color.g), color.b);
+  return (mn < mx) ? ((color - mn) * saturation) / (mx - mn) : f16vec3(0.0hf);
 }
 
 //------------------------------------------------------------------------------
@@ -58,134 +60,135 @@ vec3 IPSetSaturation(vec3 color, float saturation) {
 /// applied to the destination using `SourceOver` alpha compositing.
 ///
 
-vec3 IPBlendScreen(vec3 dst, vec3 src) {
+f16vec3 IPBlendScreen(f16vec3 dst, f16vec3 src) {
   // https://www.w3.org/TR/compositing-1/#blendingscreen
   return dst + src - (dst * src);
 }
 
-vec3 IPBlendHardLight(vec3 dst, vec3 src) {
+f16vec3 IPBlendHardLight(f16vec3 dst, f16vec3 src) {
   // https://www.w3.org/TR/compositing-1/#blendinghardlight
-  return IPVec3Choose(dst * (2 * src), IPBlendScreen(dst, 2 * src - 1), src);
+  return IPf16Vec3Choose(dst * (2.0hf * src),
+                         IPBlendScreen(dst, 2.0hf * src - 1.0hf), src);
 }
 
-vec3 IPBlendOverlay(vec3 dst, vec3 src) {
+f16vec3 IPBlendOverlay(f16vec3 dst, f16vec3 src) {
   // https://www.w3.org/TR/compositing-1/#blendingoverlay
   // HardLight, but with reversed parameters.
   return IPBlendHardLight(src, dst);
 }
 
-vec3 IPBlendDarken(vec3 dst, vec3 src) {
+f16vec3 IPBlendDarken(f16vec3 dst, f16vec3 src) {
   // https://www.w3.org/TR/compositing-1/#blendingdarken
   return min(dst, src);
 }
 
-vec3 IPBlendLighten(vec3 dst, vec3 src) {
+f16vec3 IPBlendLighten(f16vec3 dst, f16vec3 src) {
   // https://www.w3.org/TR/compositing-1/#blendinglighten
   return max(dst, src);
 }
 
-vec3 IPBlendColorDodge(vec3 dst, vec3 src) {
+f16vec3 IPBlendColorDodge(f16vec3 dst, f16vec3 src) {
   // https://www.w3.org/TR/compositing-1/#blendingcolordodge
 
-  vec3 color = min(vec3(1), dst / (1 - src));
+  f16vec3 color = min(f16vec3(1.0hf), dst / (1.0hf - src));
 
-  if (dst.r < kEhCloseEnough) {
-    color.r = 0;
+  if (dst.r < kEhCloseEnoughHf) {
+    color.r = 0.0hf;
   }
-  if (dst.g < kEhCloseEnough) {
-    color.g = 0;
+  if (dst.g < kEhCloseEnoughHf) {
+    color.g = 0.0hf;
   }
-  if (dst.b < kEhCloseEnough) {
-    color.b = 0;
+  if (dst.b < kEhCloseEnoughHf) {
+    color.b = 0.0hf;
   }
 
-  if (1 - src.r < kEhCloseEnough) {
-    color.r = 1;
+  if (1.0hf - src.r < kEhCloseEnoughHf) {
+    color.r = 1.0hf;
   }
-  if (1 - src.g < kEhCloseEnough) {
-    color.g = 1;
+  if (1.0hf - src.g < kEhCloseEnoughHf) {
+    color.g = 1.0hf;
   }
-  if (1 - src.b < kEhCloseEnough) {
-    color.b = 1;
+  if (1.0hf - src.b < kEhCloseEnoughHf) {
+    color.b = 1.0hf;
   }
 
   return color;
 }
 
-vec3 IPBlendColorBurn(vec3 dst, vec3 src) {
+f16vec3 IPBlendColorBurn(f16vec3 dst, f16vec3 src) {
   // https://www.w3.org/TR/compositing-1/#blendingcolorburn
 
-  vec3 color = 1 - min(vec3(1), (1 - dst) / src);
+  f16vec3 color = 1.0hf - min(f16vec3(1.0hf), (1.0hf - dst) / src);
 
-  if (1 - dst.r < kEhCloseEnough) {
-    color.r = 1;
+  if (1.0hf - dst.r < kEhCloseEnoughHf) {
+    color.r = 1.0hf;
   }
-  if (1 - dst.g < kEhCloseEnough) {
-    color.g = 1;
+  if (1.0hf - dst.g < kEhCloseEnoughHf) {
+    color.g = 1.0hf;
   }
-  if (1 - dst.b < kEhCloseEnough) {
-    color.b = 1;
+  if (1.0hf - dst.b < kEhCloseEnoughHf) {
+    color.b = 1.0hf;
   }
 
-  if (src.r < kEhCloseEnough) {
-    color.r = 0;
+  if (src.r < kEhCloseEnoughHf) {
+    color.r = 0.0hf;
   }
-  if (src.g < kEhCloseEnough) {
-    color.g = 0;
+  if (src.g < kEhCloseEnoughHf) {
+    color.g = 0.0hf;
   }
-  if (src.b < kEhCloseEnough) {
-    color.b = 0;
+  if (src.b < kEhCloseEnoughHf) {
+    color.b = 0.0hf;
   }
 
   return color;
 }
 
-vec3 IPBlendSoftLight(vec3 dst, vec3 src) {
+f16vec3 IPBlendSoftLight(f16vec3 dst, f16vec3 src) {
   // https://www.w3.org/TR/compositing-1/#blendingsoftlight
+  f16vec3 D =
+      IPf16Vec3ChooseCutoff(((16.0hf * dst - 12.0hf) * dst + 4.0hf) * dst,  //
+                            sqrt(dst),                                      //
+                            dst,                                            //
+                            0.25hf);
 
-  vec3 D = IPVec3ChooseCutoff(((16 * dst - 12) * dst + 4) * dst,  //
-                              sqrt(dst),                          //
-                              dst,                                //
-                              0.25);
-
-  return IPVec3Choose(dst - (1 - 2 * src) * dst * (1 - dst),  //
-                      dst + (2 * src - 1) * (D - dst),        //
-                      src);
+  return IPf16Vec3Choose(dst - (1.0hf - 2.0hf * src) * dst * (1.0hf - dst),  //
+                         dst + (2.0hf * src - 1.0hf) * (D - dst),            //
+                         src);
 }
 
-vec3 IPBlendDifference(vec3 dst, vec3 src) {
+f16vec3 IPBlendDifference(f16vec3 dst, f16vec3 src) {
   // https://www.w3.org/TR/compositing-1/#blendingdifference
   return abs(dst - src);
 }
 
-vec3 IPBlendExclusion(vec3 dst, vec3 src) {
+f16vec3 IPBlendExclusion(f16vec3 dst, f16vec3 src) {
   // https://www.w3.org/TR/compositing-1/#blendingexclusion
-  return dst + src - 2 * dst * src;
+  return dst + src - 2.0hf * dst * src;
 }
 
-vec3 IPBlendMultiply(vec3 dst, vec3 src) {
+f16vec3 IPBlendMultiply(f16vec3 dst, f16vec3 src) {
   // https://www.w3.org/TR/compositing-1/#blendingmultiply
   return dst * src;
 }
 
-vec3 IPBlendHue(vec3 dst, vec3 src) {
+f16vec3 IPBlendHue(f16vec3 dst, f16vec3 src) {
   // https://www.w3.org/TR/compositing-1/#blendinghue
   return IPSetLuminosity(IPSetSaturation(src, IPSaturation(dst)),
                          IPLuminosity(dst));
 }
 
-vec3 IPBlendSaturation(vec3 dst, vec3 src) {
+f16vec3 IPBlendSaturation(f16vec3 dst, f16vec3 src) {
   // https://www.w3.org/TR/compositing-1/#blendingsaturation
   return IPSetLuminosity(IPSetSaturation(dst, IPSaturation(src)),
                          IPLuminosity(dst));
 }
 
-vec3 IPBlendColor(vec3 dst, vec3 src) {
+f16vec3 IPBlendColor(f16vec3 dst, f16vec3 src) {
   // https://www.w3.org/TR/compositing-1/#blendingcolor
   return IPSetLuminosity(src, IPLuminosity(dst));
 }
 
-vec3 IPBlendLuminosity(vec3 dst, vec3 src) {
+f16vec3 IPBlendLuminosity(f16vec3 dst, f16vec3 src) {
   // https://www.w3.org/TR/compositing-1/#blendingluminosity
   return IPSetLuminosity(dst, IPLuminosity(src));
 }

--- a/impeller/compiler/shader_lib/impeller/branching.glsl
+++ b/impeller/compiler/shader_lib/impeller/branching.glsl
@@ -49,4 +49,24 @@ vec3 IPVec3Choose(vec3 a, vec3 b, vec3 value) {
   return IPVec3ChooseCutoff(a, b, value, 0.5);
 }
 
+/// Perform a branchless greater than check for each f16vec3 component.
+///
+/// Returns 1.0 if x > y, otherwise 0.0.
+f16vec3 IPf16Vec3IsGreaterThan(f16vec3 x, f16vec3 y) {
+  return max(sign(x - y), 0.0hf);
+}
+
+/// For each f16vec3 component, if value > cutoff, return b, otherwise return a.
+f16vec3 IPf16Vec3ChooseCutoff(f16vec3 a,
+                              f16vec3 b,
+                              f16vec3 value,
+                              float16_t cutoff) {
+  return mix(a, b, IPf16Vec3IsGreaterThan(value, f16vec3(cutoff)));
+}
+
+/// For each f16vec3 component, if value > 0.5, return b, otherwise return a.
+f16vec3 IPf16Vec3Choose(f16vec3 a, f16vec3 b, f16vec3 value) {
+  return IPf16Vec3ChooseCutoff(a, b, value, 0.5hf);
+}
+
 #endif

--- a/impeller/compiler/shader_lib/impeller/constants.glsl
+++ b/impeller/compiler/shader_lib/impeller/constants.glsl
@@ -5,6 +5,10 @@
 #ifndef CONSTANTS_GLSL_
 #define CONSTANTS_GLSL_
 
+#include <impeller/types.glsl>
+
+const float16_t kEhCloseEnoughHf = 0.000001hf;
+
 const float kEhCloseEnough = 0.000001;
 
 // 1 / (2 * pi)

--- a/impeller/entity/shaders/blending/advanced_blend.glsl
+++ b/impeller/entity/shaders/blending/advanced_blend.glsl
@@ -43,8 +43,7 @@ void main() {
                        kTileModeDecal                 // tile mode
                        ));
 
-  vec4 blended = vec4(Blend(dst.rgb, src.rgb), 1) * dst.a;
+  vec4 blended = vec4(Blend(f16vec3(dst.rgb), f16vec3(src.rgb)), 1) * dst.a;
 
   frag_color = mix(dst_sample, blended, src.a);
-  // frag_color = dst_sample;
 }

--- a/impeller/entity/shaders/blending/advanced_blend_color.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_color.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendColor(dst, src);
 }
 

--- a/impeller/entity/shaders/blending/advanced_blend_colorburn.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_colorburn.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendColorBurn(dst, src);
 }
 

--- a/impeller/entity/shaders/blending/advanced_blend_colordodge.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_colordodge.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendColorDodge(dst, src);
 }
 

--- a/impeller/entity/shaders/blending/advanced_blend_darken.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_darken.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendDarken(dst, src);
 }
 

--- a/impeller/entity/shaders/blending/advanced_blend_difference.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_difference.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendDifference(dst, src);
 }
 

--- a/impeller/entity/shaders/blending/advanced_blend_exclusion.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_exclusion.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendExclusion(dst, src);
 }
 

--- a/impeller/entity/shaders/blending/advanced_blend_hardlight.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_hardlight.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendHardLight(dst, src);
 }
 

--- a/impeller/entity/shaders/blending/advanced_blend_hue.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_hue.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendHue(dst, src);
 }
 

--- a/impeller/entity/shaders/blending/advanced_blend_lighten.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_lighten.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendLighten(dst, src);
 }
 

--- a/impeller/entity/shaders/blending/advanced_blend_luminosity.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_luminosity.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendLuminosity(dst, src);
 }
 

--- a/impeller/entity/shaders/blending/advanced_blend_multiply.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_multiply.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendMultiply(dst, src);
 }
 

--- a/impeller/entity/shaders/blending/advanced_blend_overlay.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_overlay.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendOverlay(dst, src);
 }
 

--- a/impeller/entity/shaders/blending/advanced_blend_saturation.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_saturation.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendSaturation(dst, src);
 }
 

--- a/impeller/entity/shaders/blending/advanced_blend_screen.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_screen.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendScreen(dst, src);
 }
 

--- a/impeller/entity/shaders/blending/advanced_blend_softlight.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_softlight.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendSoftLight(dst, src);
 }
 


### PR DESCRIPTION
Example of differences in shader: https://gist.github.com/jonahwilliams/2194d45d671991f3eb0b030bf27a9068

Advanced blends seem like a good usage of half precision, since they generaly only have two inputs to convert and mostly operate on colors. TBD whether or not this is actually faster on iOS.

https://github.com/flutter/flutter/issues/115044