### PR TITLE
Reland "Migrate darwin common "framework_shared" target to ARC #37049" 

### DIFF
--- a/shell/platform/darwin/BUILD.gn
+++ b/shell/platform/darwin/BUILD.gn
@@ -26,6 +26,20 @@ source_set("flutter_channels") {
   sources = [
     "common/buffer_conversions.h",
     "common/buffer_conversions.mm",
+  ]
+
+  deps = [ "//flutter/fml" ]
+
+  public_deps = [ ":flutter_channels_arc" ]
+
+  public_configs = [ "//flutter:config" ]
+}
+
+source_set("flutter_channels_arc") {
+  cflags_objc = flutter_cflags_objc_arc
+  cflags_objcc = flutter_cflags_objcc_arc
+
+  sources = [
     "common/framework/Headers/FlutterBinaryMessenger.h",
     "common/framework/Headers/FlutterChannels.h",
     "common/framework/Headers/FlutterCodecs.h",
@@ -36,13 +50,12 @@ source_set("flutter_channels") {
     "common/framework/Source/FlutterStandardCodec_Internal.h",
   ]
 
-  deps = [
-    "//flutter/common",
-    "//flutter/flow",
-    "//flutter/fml",
-    "//flutter/runtime",
-    "//flutter/shell/common",
-    "//third_party/skia",
+  public = [
+    "common/framework/Headers/FlutterBinaryMessenger.h",
+    "common/framework/Headers/FlutterChannels.h",
+    "common/framework/Headers/FlutterCodecs.h",
+    "common/framework/Headers/FlutterMacros.h",
+    "common/framework/Source/FlutterStandardCodec_Internal.h",
   ]
 
   public_configs = [ "//flutter:config" ]

--- a/shell/platform/darwin/common/BUILD.gn
+++ b/shell/platform/darwin/common/BUILD.gn
@@ -16,15 +16,7 @@ source_set("common") {
     "command_line.mm",
   ]
 
-  deps = [
-    "//flutter/common",
-    "//flutter/flow",
-    "//flutter/fml",
-    "//flutter/runtime",
-    "//flutter/shell/common",
-    "//third_party/dart/runtime:dart_api",
-    "//third_party/skia",
-  ]
+  deps = [ "//flutter/fml" ]
 
   public_configs = [ "//flutter:config" ]
 }
@@ -38,8 +30,8 @@ config("framework_relative_headers") {
 
 # Framework code shared between iOS and macOS.
 source_set("framework_shared") {
-  cflags_objc = flutter_cflags_objc
-  cflags_objcc = flutter_cflags_objcc
+  cflags_objc = flutter_cflags_objc_arc
+  cflags_objcc = flutter_cflags_objcc_arc
 
   sources = [
     "framework/Source/FlutterChannels.mm",

--- a/shell/platform/darwin/common/framework/Headers/FlutterCodecs.h
+++ b/shell/platform/darwin/common/framework/Headers/FlutterCodecs.h
@@ -344,17 +344,17 @@ FLUTTER_DARWIN_EXPORT
 /**
  * The type of the encoded values.
  */
-@property(readonly, nonatomic) FlutterStandardDataType type;
+@property(readonly, nonatomic, assign) FlutterStandardDataType type;
 
 /**
  * The number of value items encoded.
  */
-@property(readonly, nonatomic) UInt32 elementCount;
+@property(readonly, nonatomic, assign) UInt32 elementCount;
 
 /**
  * The number of bytes used by the encoding of a single value item.
  */
-@property(readonly, nonatomic) UInt8 elementSize;
+@property(readonly, nonatomic, assign) UInt8 elementSize;
 @end
 
 /**

--- a/shell/platform/darwin/common/framework/Source/FlutterChannelsTest.m
+++ b/shell/platform/darwin/common/framework/Source/FlutterChannelsTest.m
@@ -234,6 +234,78 @@
   OCMVerify([binaryMessenger cleanUpConnection:connection]);
 }
 
+- (void)testBasicMessageChannelInvokeHandlerAfterChannelReleased {
+  NSString* channelName = @"foo";
+  __block NSString* handlerMessage;
+  __block FlutterBinaryMessageHandler messageHandler;
+  @autoreleasepool {
+    FlutterBinaryMessengerConnection connection = 123;
+    id binaryMessenger = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
+    id codec = OCMProtocolMock(@protocol(FlutterMessageCodec));
+    id taskQueue = OCMClassMock([NSObject class]);
+    FlutterBasicMessageChannel* channel =
+        [[FlutterBasicMessageChannel alloc] initWithName:channelName
+                                         binaryMessenger:binaryMessenger
+                                                   codec:codec
+                                               taskQueue:taskQueue];
+
+    FlutterMessageHandler handler = ^(id _Nullable message, FlutterReply callback) {
+      handlerMessage = message;
+    };
+    OCMStub([binaryMessenger
+                setMessageHandlerOnChannel:channelName
+                      binaryMessageHandler:[OCMArg checkWithBlock:^BOOL(
+                                                       FlutterBinaryMessageHandler handler) {
+                        messageHandler = handler;
+                        return YES;
+                      }]
+                                 taskQueue:taskQueue])
+        .andReturn(connection);
+    OCMStub([codec decode:[OCMArg any]]).andReturn(@"decoded message");
+    [channel setMessageHandler:handler];
+  }
+  // Channel is released, messageHandler should still retain the codec. The codec
+  // internally makes a `decode` call and updates the `handlerMessage` to "decoded message".
+  messageHandler([NSData data], ^(NSData* data){
+                 });
+  XCTAssertEqualObjects(handlerMessage, @"decoded message");
+}
+
+- (void)testMethodChannelInvokeHandlerAfterChannelReleased {
+  NSString* channelName = @"foo";
+  FlutterBinaryMessengerConnection connection = 123;
+  __block FlutterMethodCall* decodedMethodCall;
+  __block FlutterBinaryMessageHandler messageHandler;
+  @autoreleasepool {
+    id binaryMessenger = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
+    id codec = OCMProtocolMock(@protocol(FlutterMethodCodec));
+    id taskQueue = OCMClassMock([NSObject class]);
+    FlutterMethodChannel* channel = [[FlutterMethodChannel alloc] initWithName:channelName
+                                                               binaryMessenger:binaryMessenger
+                                                                         codec:codec
+                                                                     taskQueue:taskQueue];
+    FlutterMethodCallHandler handler = ^(FlutterMethodCall* call, FlutterResult result) {
+      decodedMethodCall = call;
+    };
+    OCMStub([binaryMessenger
+                setMessageHandlerOnChannel:channelName
+                      binaryMessageHandler:[OCMArg checkWithBlock:^BOOL(
+                                                       FlutterBinaryMessageHandler handler) {
+                        messageHandler = handler;
+                        return YES;
+                      }]
+                                 taskQueue:taskQueue])
+        .andReturn(connection);
+    OCMStub([codec decodeMethodCall:[OCMArg any]])
+        .andReturn([FlutterMethodCall methodCallWithMethodName:@"decoded method call"
+                                                     arguments:nil]);
+    [channel setMethodCallHandler:handler];
+  }
+  messageHandler([NSData data], ^(NSData* data){
+                 });
+  XCTAssertEqualObjects(decodedMethodCall.method, @"decoded method call");
+}
+
 - (void)testMethodChannelTaskQueue {
   NSString* channelName = @"foo";
   FlutterBinaryMessengerConnection connection = 123;

--- a/shell/platform/darwin/common/framework/Source/FlutterCodecs.mm
+++ b/shell/platform/darwin/common/framework/Source/FlutterCodecs.mm
@@ -6,6 +6,8 @@
 
 #include <cstring>
 
+FLUTTER_ASSERT_ARC
+
 @implementation FlutterBinaryCodec
 + (instancetype)sharedInstance {
   static id _sharedInstance = nil;
@@ -48,7 +50,7 @@
   if (message == nil) {
     return nil;
   }
-  return [[[NSString alloc] initWithData:message encoding:NSUTF8StringEncoding] autorelease];
+  return [[NSString alloc] initWithData:message encoding:NSUTF8StringEncoding];
 }
 @end
 

--- a/shell/platform/darwin/common/framework/Source/FlutterStandardCodec.mm
+++ b/shell/platform/darwin/common/framework/Source/FlutterStandardCodec.mm
@@ -4,6 +4,8 @@
 
 #import "flutter/shell/platform/darwin/common/framework/Source/FlutterStandardCodec_Internal.h"
 
+FLUTTER_ASSERT_ARC
+
 #pragma mark - Codec for basic message channel
 
 @implementation FlutterStandardMessageCodec {
@@ -12,27 +14,21 @@
 + (instancetype)sharedInstance {
   static id _sharedInstance = nil;
   if (!_sharedInstance) {
-    FlutterStandardReaderWriter* readerWriter =
-        [[[FlutterStandardReaderWriter alloc] init] autorelease];
+    FlutterStandardReaderWriter* readerWriter = [[FlutterStandardReaderWriter alloc] init];
     _sharedInstance = [[FlutterStandardMessageCodec alloc] initWithReaderWriter:readerWriter];
   }
   return _sharedInstance;
 }
 
 + (instancetype)codecWithReaderWriter:(FlutterStandardReaderWriter*)readerWriter {
-  return [[[FlutterStandardMessageCodec alloc] initWithReaderWriter:readerWriter] autorelease];
+  return [[FlutterStandardMessageCodec alloc] initWithReaderWriter:readerWriter];
 }
 
 - (instancetype)initWithReaderWriter:(FlutterStandardReaderWriter*)readerWriter {
   self = [super init];
   NSAssert(self, @"Super init cannot be nil");
-  _readerWriter = [readerWriter retain];
+  _readerWriter = readerWriter;
   return self;
-}
-
-- (void)dealloc {
-  [_readerWriter release];
-  [super dealloc];
 }
 
 - (NSData*)encode:(id)message {
@@ -64,27 +60,21 @@
 + (instancetype)sharedInstance {
   static id _sharedInstance = nil;
   if (!_sharedInstance) {
-    FlutterStandardReaderWriter* readerWriter =
-        [[[FlutterStandardReaderWriter alloc] init] autorelease];
+    FlutterStandardReaderWriter* readerWriter = [[FlutterStandardReaderWriter alloc] init];
     _sharedInstance = [[FlutterStandardMethodCodec alloc] initWithReaderWriter:readerWriter];
   }
   return _sharedInstance;
 }
 
 + (instancetype)codecWithReaderWriter:(FlutterStandardReaderWriter*)readerWriter {
-  return [[[FlutterStandardMethodCodec alloc] initWithReaderWriter:readerWriter] autorelease];
+  return [[FlutterStandardMethodCodec alloc] initWithReaderWriter:readerWriter];
 }
 
 - (instancetype)initWithReaderWriter:(FlutterStandardReaderWriter*)readerWriter {
   self = [super init];
   NSAssert(self, @"Super init cannot be nil");
-  _readerWriter = [readerWriter retain];
+  _readerWriter = readerWriter;
   return self;
-}
-
-- (void)dealloc {
-  [_readerWriter release];
-  [super dealloc];
 }
 
 - (NSData*)encodeMethodCall:(FlutterMethodCall*)call {
@@ -173,7 +163,7 @@ using namespace flutter;
 }
 
 + (instancetype)typedDataWithData:(NSData*)data type:(FlutterStandardDataType)type {
-  return [[[FlutterStandardTypedData alloc] initWithData:data type:type] autorelease];
+  return [[FlutterStandardTypedData alloc] initWithData:data type:type];
 }
 
 - (instancetype)initWithData:(NSData*)data type:(FlutterStandardDataType)type {
@@ -182,16 +172,11 @@ using namespace flutter;
   NSAssert(data.length % elementSize == 0, @"Data must contain integral number of elements");
   self = [super init];
   NSAssert(self, @"Super init cannot be nil");
-  _data = [data retain];
+  _data = [data copy];
   _type = type;
   _elementSize = elementSize;
   _elementCount = data.length / elementSize;
   return self;
-}
-
-- (void)dealloc {
-  [_data release];
-  [super dealloc];
 }
 
 - (BOOL)isEqual:(id)object {
@@ -220,13 +205,8 @@ using namespace flutter;
 - (instancetype)initWithData:(NSMutableData*)data {
   self = [super init];
   NSAssert(self, @"Super init cannot be nil");
-  _data = [data retain];
+  _data = data;
   return self;
-}
-
-- (void)dealloc {
-  [_data release];
-  [super dealloc];
 }
 
 - (void)writeByte:(UInt8)value {
@@ -273,7 +253,7 @@ using namespace flutter;
   if (value == nil || value == [NSNull null]) {
     [self writeByte:FlutterStandardFieldNil];
   } else if ([value isKindOfClass:[NSNumber class]]) {
-    CFNumberRef number = (CFNumberRef)value;
+    CFNumberRef number = (__bridge CFNumberRef)value;
     BOOL success = NO;
     if (CFGetTypeID(number) == CFBooleanGetTypeID()) {
       BOOL b = CFBooleanGetValue((CFBooleanRef)number);
@@ -348,14 +328,9 @@ using namespace flutter;
 - (instancetype)initWithData:(NSData*)data {
   self = [super init];
   NSAssert(self, @"Super init cannot be nil");
-  _data = [data retain];
+  _data = [data copy];
   _range = NSMakeRange(0, 0);
   return self;
-}
-
-- (void)dealloc {
-  [_data release];
-  [super dealloc];
 }
 
 - (BOOL)hasMore {
@@ -398,7 +373,7 @@ using namespace flutter;
 
 - (NSString*)readUTF8 {
   NSData* bytes = [self readData:[self readSize]];
-  return [[[NSString alloc] initWithData:bytes encoding:NSUTF8StringEncoding] autorelease];
+  return [[NSString alloc] initWithData:bytes encoding:NSUTF8StringEncoding];
 }
 
 - (void)readAlignment:(UInt8)alignment {
@@ -482,10 +457,10 @@ using namespace flutter;
 
 @implementation FlutterStandardReaderWriter
 - (FlutterStandardWriter*)writerWithData:(NSMutableData*)data {
-  return [[[FlutterStandardWriter alloc] initWithData:data] autorelease];
+  return [[FlutterStandardWriter alloc] initWithData:data];
 }
 
 - (FlutterStandardReader*)readerWithData:(NSData*)data {
-  return [[[FlutterStandardReader alloc] initWithData:data] autorelease];
+  return [[FlutterStandardReader alloc] initWithData:data];
 }
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterRestorationPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterRestorationPluginTest.mm
@@ -80,7 +80,7 @@ FLUTTER_ASSERT_ARC
   [restorationPlugin setRestorationData:data];
   XCTAssertEqual([capturedResult count], 2u);
   XCTAssertEqual([capturedResult objectForKey:@"enabled"], @YES);
-  XCTAssertEqual([[capturedResult objectForKey:@"data"] data], data);
+  XCTAssertEqualObjects([[capturedResult objectForKey:@"data"] data], data);
 }
 
 - (void)testRestorationDisabledRespondsRightAway {
@@ -112,7 +112,7 @@ FLUTTER_ASSERT_ARC
                                }];
   XCTAssertEqual([capturedResult count], 2u);
   XCTAssertEqual([capturedResult objectForKey:@"enabled"], @YES);
-  XCTAssertEqual([[capturedResult objectForKey:@"data"] data], data);
+  XCTAssertEqualObjects([[capturedResult objectForKey:@"data"] data], data);
 }
 
 - (void)testRespondsWithNoDataWhenRestorationIsCompletedWithoutData {
@@ -161,7 +161,7 @@ FLUTTER_ASSERT_ARC
                                result:^(id _Nullable result) {
                                  XCTAssertNil(result);
                                }];
-  XCTAssertEqual([restorationPlugin restorationData], data);
+  XCTAssertEqualObjects([restorationPlugin restorationData], data);
 }
 
 - (void)testRespondsWithDataSetByFramework {
@@ -177,7 +177,7 @@ FLUTTER_ASSERT_ARC
                                result:^(id _Nullable result) {
                                  XCTAssertNil(result);
                                }];
-  XCTAssertEqual([restorationPlugin restorationData], data);
+  XCTAssertEqualObjects([restorationPlugin restorationData], data);
 
   __block id capturedResult;
   methodCall = [FlutterMethodCall methodCallWithMethodName:@"get" arguments:nil];
@@ -187,7 +187,7 @@ FLUTTER_ASSERT_ARC
                                }];
   XCTAssertEqual([capturedResult count], 2u);
   XCTAssertEqual([capturedResult objectForKey:@"enabled"], @YES);
-  XCTAssertEqual([[capturedResult objectForKey:@"data"] data], data);
+  XCTAssertEqualObjects([[capturedResult objectForKey:@"data"] data], data);
 }
 
 - (void)testResetClearsData {
@@ -203,7 +203,7 @@ FLUTTER_ASSERT_ARC
                                result:^(id _Nullable result) {
                                  XCTAssertNil(result);
                                }];
-  XCTAssertEqual([restorationPlugin restorationData], data);
+  XCTAssertEqualObjects([restorationPlugin restorationData], data);
 
   [restorationPlugin reset];
   XCTAssertNil([restorationPlugin restorationData]);


### PR DESCRIPTION
Relands https://github.com/flutter/engine/pull/37219, which was reverted at https://github.com/flutter/engine/pull/37320 due to a benchmark regression. https://github.com/flutter/flutter/issues/114697

There is no change in this PR compares to https://github.com/flutter/engine/pull/37219

The benchmark regression is due to a performance regression caused by ARC, specifically here: https://github.com/flutter/engine/blob/main/shell/platform/darwin/common/framework/Source/FlutterStandardCodec.mm#L458-L464 . 
This regression is unavoidable and been discussed at several places online: https://jimmymandersson.medium.com/understanding-arcs-effect-on-your-apps-performance-377e39076a88

I create two simple sample test cases comparing ARC and ARC in performance and the result shows (from my machine) that the ARC version of the test took 8ms and MRC took 6ms: https://github.com/cyanglaz/MrcVSArc

ARC has many benefits so I think we should still migrate to it. Please advise if there are any to optimize the ARC code in this PR to reduce the regression.

I also have tested the performance if all the "copy"s are reverted to "retain", but the improvement is very minimal. I'd suggest keep them as copy so the code is safer. 

part of https://github.com/flutter/flutter/issues/112232

cc @zanderso @stuartmorgan @gaaclarke for thoughts. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
