### PR TITLE
[Impeller] Improve border_mask_blur performance on Android

### DIFF
--- a/impeller/compiler/shader_lib/impeller/gaussian.glsl
+++ b/impeller/compiler/shader_lib/impeller/gaussian.glsl
@@ -30,20 +30,29 @@ vec2 IPVec2Erf(vec2 x) {
 }
 
 /// Indefinite integral of the Gaussian function (with constant range 0->1).
-float IPGaussianIntegral(float x, float sigma) {
+float IPGaussianIntegral(float x, float half_sqrt_two_sigma) {
   // ( 1 + erf( x * (sqrt(2) / (2 * sigma) ) ) / 2
   // Because this sigmoid is always > 1, we remap it (n * 1.07 - 0.07)
   // so that it always fades to zero before it reaches the blur radius.
-  return 0.535 * IPErf(x * (kHalfSqrtTwo / sigma)) + 0.465;
+  return 0.535 * IPErf(x * half_sqrt_two_sigma) + 0.465;
 }
 
 /// Vec2 variation for the indefinite integral of the Gaussian function (with
 /// constant range 0->1).
-vec2 IPVec2GaussianIntegral(vec2 x, float sigma) {
+vec2 IPVec2GaussianIntegral(vec2 x, float half_sqrt_two_sigma) {
   // ( 1 + erf( x * (sqrt(2) / (2 * sigma) ) ) / 2
   // Because this sigmoid is always > 1, we remap it (n * 1.07 - 0.07)
   // so that it always fades to zero before it reaches the blur radius.
-  return 0.535 * IPVec2Erf(x * (kHalfSqrtTwo / sigma)) + 0.465;
+  return 0.535 * IPVec2Erf(x * half_sqrt_two_sigma) + 0.465;
+}
+
+/// Vec2 variation for the indefinite integral of the Gaussian function (with
+/// constant range 0->1).
+vec2 IPVec2GaussianIntegral(vec2 x, vec2 half_sqrt_two_sigma) {
+  // ( 1 + erf( x * (sqrt(2) / (2 * sigma) ) ) / 2
+  // Because this sigmoid is always > 1, we remap it (n * 1.07 - 0.07)
+  // so that it always fades to zero before it reaches the blur radius.
+  return 0.535 * IPVec2Erf(x * half_sqrt_two_sigma) + 0.465;
 }
 
 /// Simple logistic sigmoid with a domain of [-1, 1] and range of [0, 1].

--- a/impeller/compiler/shader_lib/impeller/texture.glsl
+++ b/impeller/compiler/shader_lib/impeller/texture.glsl
@@ -19,6 +19,13 @@ vec4 IPSample(sampler2D texture_sampler, vec2 coords, float y_coord_scale) {
   return texture(texture_sampler, coords);
 }
 
+vec2 IPRemapCoords(vec2 coords, float y_coord_scale) {
+  if (y_coord_scale < 0.0) {
+    coords.y = 1.0 - coords.y;
+  }
+  return coords;
+}
+
 /// Sample from a texture.
 ///
 /// If `y_coord_scale` < 0.0, the Y coordinate is flipped. This is useful

--- a/impeller/entity/shaders/border_mask_blur.frag
+++ b/impeller/entity/shaders/border_mask_blur.frag
@@ -18,37 +18,37 @@
 uniform sampler2D texture_sampler;
 
 uniform FragInfo {
-  float texture_sampler_y_coord_scale;
+  float src_factor;
+  float inner_blur_factor;
+  float outer_blur_factor;
+  vec2 half_sqrt_two_sigma_uv;
 }
 frag_info;
 
 in vec2 v_texture_coords;
-in vec2 v_sigma_uv;
-in float v_src_factor;
-in float v_inner_blur_factor;
-in float v_outer_blur_factor;
 
 out vec4 frag_color;
 
 float BoxBlurMask(vec2 uv) {
   // LTRB
-  return IPGaussianIntegral(uv.x, v_sigma_uv.x) *      //
-         IPGaussianIntegral(uv.y, v_sigma_uv.y) *      //
-         IPGaussianIntegral(1 - uv.x, v_sigma_uv.x) *  //
-         IPGaussianIntegral(1 - uv.y, v_sigma_uv.y);
+  vec2 parts =
+      IPVec2GaussianIntegral(uv, frag_info.half_sqrt_two_sigma_uv) *  //
+      IPVec2GaussianIntegral(1 - uv, frag_info.half_sqrt_two_sigma_uv);
+  return parts.x * parts.y;
 }
 
 void main() {
-  vec4 image_color = IPSample(texture_sampler, v_texture_coords,
-                              frag_info.texture_sampler_y_coord_scale);
+  vec4 image_color = texture(texture_sampler, v_texture_coords);
   float blur_factor = BoxBlurMask(v_texture_coords);
 
   float within_bounds =
       float(v_texture_coords.x >= 0 && v_texture_coords.y >= 0 &&
             v_texture_coords.x < 1 && v_texture_coords.y < 1);
   float inner_factor =
-      (v_inner_blur_factor * blur_factor + v_src_factor) * within_bounds;
-  float outer_factor = v_outer_blur_factor * blur_factor * (1 - within_bounds);
+      (frag_info.inner_blur_factor * blur_factor + frag_info.src_factor) *
+      within_bounds;
+  float outer_factor =
+      frag_info.outer_blur_factor * blur_factor * (1 - within_bounds);
 
   float mask_factor = inner_factor + outer_factor;
   frag_color = image_color * mask_factor;

--- a/impeller/entity/shaders/border_mask_blur.vert
+++ b/impeller/entity/shaders/border_mask_blur.vert
@@ -2,16 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <impeller/texture.glsl>
 #include <impeller/types.glsl>
 
 uniform FrameInfo {
   mat4 mvp;
-
-  vec2 sigma_uv;
-
-  float src_factor;
-  float inner_blur_factor;
-  float outer_blur_factor;
+  float texture_sampler_y_coord_scale;
 }
 frame_info;
 
@@ -19,16 +15,9 @@ in vec2 vertices;
 in vec2 texture_coords;
 
 out vec2 v_texture_coords;
-out vec2 v_sigma_uv;
-out float v_src_factor;
-out float v_inner_blur_factor;
-out float v_outer_blur_factor;
 
 void main() {
   gl_Position = frame_info.mvp * vec4(vertices, 0.0, 1.0);
-  v_texture_coords = texture_coords;
-  v_sigma_uv = frame_info.sigma_uv;
-  v_src_factor = frame_info.src_factor;
-  v_inner_blur_factor = frame_info.inner_blur_factor;
-  v_outer_blur_factor = frame_info.outer_blur_factor;
+  v_texture_coords =
+      IPRemapCoords(texture_coords, frame_info.texture_sampler_y_coord_scale);
 }


### PR DESCRIPTION
Improve performance of border mask blur:

* Move computation of texture flip to vertex shader (Reduces Arithmetic usage, marginally increases varying usage)
* Move uniforms used in fragment shader to fragment UBO (Reduces varying usage)
* Vectorize usage of IPVec2GaussianIntegral (Reduces Arithmetic usage slightly on low end devices)
* Compute kHalfSqrtTwo / sigma in contents (Removes uniform computation)


<details>malioc diff

```diff
[Mali-T880]
Main shader
===========

- Work registers: 3 (75% used at 100% occupancy)
+ Work registers: 4 (100% used at 100% occupancy)
- Uniform registers: 1 (4% used)
+ Uniform registers: 1 (5% used)
Stack spilling: false

                                A      LS       T    Bound
- Total instruction cycles:    9.00    3.00    1.00        A
+ Total instruction cycles:    8.00    1.00    1.00        A
- Shortest path cycles:        8.58    3.00    1.00        A
+ Shortest path cycles:        7.59    1.00    1.00        A
- Longest path cycles:         8.58    3.00    1.00        A
+ Longest path cycles:         7.59    1.00    1.00        A

A = Arithmetic, LS = Load/Store, T = Texture

Shader properties
=================

Has uniform computation: false



[Mali-T860]
Main shader
===========

- Work registers: 3 (75% used at 100% occupancy)
+ Work registers: 4 (100% used at 100% occupancy)
- Uniform registers: 1 (4% used)
+ Uniform registers: 1 (5% used)
Stack spilling: false

                                A      LS       T    Bound
- Total instruction cycles:   13.50    3.00    1.00        A
+ Total instruction cycles:   12.00    1.00    1.00        A
- Shortest path cycles:       13.00    3.00    1.00        A
+ Shortest path cycles:       11.50    1.00    1.00        A
- Longest path cycles:        13.00    3.00    1.00        A
+ Longest path cycles:        11.50    1.00    1.00        A

A = Arithmetic, LS = Load/Store, T = Texture

Shader properties
=================

Has uniform computation: false



[Mali-T830]
Main shader
===========

Work registers: 4 (100% used at 100% occupancy)
Uniform registers: 1 (5% used)
Stack spilling: false

                                A      LS       T    Bound
- Total instruction cycles:   13.50    3.00    1.00        A
+ Total instruction cycles:   12.00    1.00    1.00        A
- Shortest path cycles:        5.75    3.00    1.00        A
+ Shortest path cycles:        5.88    1.00    1.00        A
- Longest path cycles:         5.75    3.00    1.00        A
+ Longest path cycles:         5.88    1.00    1.00        A

A = Arithmetic, LS = Load/Store, T = Texture

Shader properties
=================

Has uniform computation: false



[Mali-T820]
Main shader
===========

Work registers: 4 (100% used at 100% occupancy)
Uniform registers: 1 (5% used)
Stack spilling: false

                                A      LS       T    Bound
- Total instruction cycles:   27.00    3.00    1.00        A
+ Total instruction cycles:   24.00    1.00    1.00        A
- Shortest path cycles:       11.50    3.00    1.00        A
+ Shortest path cycles:       11.75    1.00    1.00        A
- Longest path cycles:        11.50    3.00    1.00        A
+ Longest path cycles:        11.75    1.00    1.00        A

A = Arithmetic, LS = Load/Store, T = Texture

Shader properties
=================

Has uniform computation: false



[Mali-T760]
Main shader
===========

- Work registers: 3 (75% used at 100% occupancy)
+ Work registers: 4 (100% used at 100% occupancy)
- Uniform registers: 1 (4% used)
+ Uniform registers: 1 (5% used)
Stack spilling: false

                                A      LS       T    Bound
- Total instruction cycles:   13.50    3.00    1.00        A
+ Total instruction cycles:   12.00    1.00    1.00        A
- Shortest path cycles:       13.00    3.00    1.00        A
+ Shortest path cycles:       11.50    1.00    1.00        A
- Longest path cycles:        13.00    3.00    1.00        A
+ Longest path cycles:        11.50    1.00    1.00        A

A = Arithmetic, LS = Load/Store, T = Texture

Shader properties
=================

Has uniform computation: false



[Mali-T720]
Main shader
===========

Work registers: 4 (100% used at 100% occupancy)
Uniform registers: 1 (5% used)
Stack spilling: false

                                A      LS       T    Bound
- Total instruction cycles:   27.00    3.00    1.00        A
+ Total instruction cycles:   24.00    1.00    1.00        A
- Shortest path cycles:       11.75    3.00    1.00        A
+ Shortest path cycles:       11.75    1.00    1.00        A
- Longest path cycles:        11.75    3.00    1.00        A
+ Longest path cycles:        11.75    1.00    1.00        A

A = Arithmetic, LS = Load/Store, T = Texture


[Mali-G78AE]
Main shader
===========

Work registers: 31 (96% used at 100% occupancy)
- Uniform registers: 10 (15% used)
+ Uniform registers: 12 (18% used)
Stack spilling: false
- 16-bit arithmetic: 17%
+ 16-bit arithmetic: 11%

                                A      LS       V       T    Bound
- Total instruction cycles:    0.91    0.00    0.62    0.25        A
+ Total instruction cycles:    0.86    0.00    0.25    0.25        A
- Shortest path cycles:        0.91    0.00    0.62    0.25        A
+ Shortest path cycles:        0.86    0.00    0.25    0.25        A
- Longest path cycles:         0.91    0.00    0.62    0.25        A
+ Longest path cycles:         0.86    0.00    0.25    0.25        A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

- Has uniform computation: true
+ Has uniform computation: false
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G78]
Main shader
===========

Work registers: 31 (96% used at 100% occupancy)
- Uniform registers: 10 (15% used)
+ Uniform registers: 12 (18% used)
Stack spilling: false
- 16-bit arithmetic: 17%
+ 16-bit arithmetic: 11%

                                A      LS       V       T    Bound
- Total instruction cycles:    0.91    0.00    0.62    0.25        A
+ Total instruction cycles:    0.86    0.00    0.25    0.25        A
- Shortest path cycles:        0.91    0.00    0.62    0.25        A
+ Shortest path cycles:        0.86    0.00    0.25    0.25        A
- Longest path cycles:         0.91    0.00    0.62    0.25        A
+ Longest path cycles:         0.86    0.00    0.25    0.25        A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

- Has uniform computation: true
+ Has uniform computation: false
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G77]
Main shader
===========

Work registers: 31 (96% used at 100% occupancy)
- Uniform registers: 10 (15% used)
+ Uniform registers: 12 (18% used)
Stack spilling: false
- 16-bit arithmetic: 17%
+ 16-bit arithmetic: 11%

                                A      LS       V       T    Bound
- Total instruction cycles:    0.91    0.00    0.62    0.25        A
+ Total instruction cycles:    0.86    0.00    0.25    0.25        A
- Shortest path cycles:        0.91    0.00    0.62    0.25        A
+ Shortest path cycles:        0.86    0.00    0.25    0.25        A
- Longest path cycles:         0.91    0.00    0.62    0.25        A
+ Longest path cycles:         0.86    0.00    0.25    0.25        A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

- Has uniform computation: true
+ Has uniform computation: false
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G76]
Main shader
===========

- Work registers: 30 (93% used at 100% occupancy)
+ Work registers: 31 (96% used at 100% occupancy)
- Uniform registers: 2 (3% used)
+ Uniform registers: 4 (6% used)
Stack spilling: false
- 16-bit arithmetic: 18%
+ 16-bit arithmetic: 16%

                                A      LS       V       T    Bound
- Total instruction cycles:    2.47    0.00    0.75    0.50        A
+ Total instruction cycles:    2.37    0.00    0.25    0.50        A
- Shortest path cycles:        2.47    0.00    0.75    0.50        A
+ Shortest path cycles:        2.37    0.00    0.25    0.50        A
- Longest path cycles:         2.47    0.00    0.75    0.50        A
+ Longest path cycles:         2.37    0.00    0.25    0.50        A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

Has uniform computation: false
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G72]
Main shader
===========

- Work registers: 34 (53% used at 50% occupancy)
+ Work registers: 33 (51% used at 50% occupancy)
- Uniform registers: 2 (3% used)
+ Uniform registers: 4 (6% used)
Stack spilling: false
- 16-bit arithmetic: 18%
+ 16-bit arithmetic: 16%

                                A      LS       V       T    Bound
- Total instruction cycles:    5.17    0.00    1.50    1.00        A
+ Total instruction cycles:    4.73    0.00    0.50    1.00        A
- Shortest path cycles:        5.17    0.00    1.50    1.00        A
+ Shortest path cycles:        4.73    0.00    0.50    1.00        A
- Longest path cycles:         5.17    0.00    1.50    1.00        A
+ Longest path cycles:         4.73    0.00    0.50    1.00        A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

Has uniform computation: false
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G715]
Main shader
===========

Work registers: 31 (96% used at 100% occupancy)
- Uniform registers: 10 (15% used)
+ Uniform registers: 12 (18% used)
Stack spilling: false
- 16-bit arithmetic: 16%
+ 16-bit arithmetic: 10%

                                A      LS       V       T    Bound
- Total instruction cycles:    0.34    0.00    0.16    0.12        A
+ Total instruction cycles:    0.30    0.00    0.06    0.12        A
- Shortest path cycles:        0.33    0.00    0.16    0.12        A
+ Shortest path cycles:        0.29    0.00    0.06    0.12        A
- Longest path cycles:         0.34    0.00    0.16    0.12        A
+ Longest path cycles:         0.30    0.00    0.06    0.12        A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

- Has uniform computation: true
+ Has uniform computation: false
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G710]
Main shader
===========

Work registers: 31 (96% used at 100% occupancy)
- Uniform registers: 10 (15% used)
+ Uniform registers: 12 (18% used)
Stack spilling: false
- 16-bit arithmetic: 17%
+ 16-bit arithmetic: 11%

                                A      LS       V       T    Bound
- Total instruction cycles:    0.66    0.00    0.31    0.12        A
+ Total instruction cycles:    0.59    0.00    0.12    0.12        A
- Shortest path cycles:        0.65    0.00    0.31    0.12        A
+ Shortest path cycles:        0.57    0.00    0.12    0.12        A
- Longest path cycles:         0.66    0.00    0.31    0.12        A
+ Longest path cycles:         0.59    0.00    0.12    0.12        A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

- Has uniform computation: true
+ Has uniform computation: false
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G71]
Main shader
===========

- Work registers: 41 (64% used at 50% occupancy)
+ Work registers: 36 (56% used at 50% occupancy)
- Uniform registers: 2 (3% used)
+ Uniform registers: 4 (6% used)
Stack spilling: false
16-bit arithmetic: 13%

                                A      LS       V       T    Bound
- Total instruction cycles:    6.17    0.00    1.50    1.00        A
+ Total instruction cycles:    5.17    0.00    0.50    1.00        A
- Shortest path cycles:        6.17    0.00    1.50    1.00        A
+ Shortest path cycles:        5.17    0.00    0.50    1.00        A
- Longest path cycles:         6.17    0.00    1.50    1.00        A
+ Longest path cycles:         5.17    0.00    0.50    1.00        A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

Has uniform computation: false
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G68]
Main shader
===========

Work registers: 31 (96% used at 100% occupancy)
- Uniform registers: 10 (15% used)
+ Uniform registers: 12 (18% used)
Stack spilling: false
- 16-bit arithmetic: 17%
+ 16-bit arithmetic: 11%

                                A      LS       V       T    Bound
- Total instruction cycles:    0.91    0.00    0.62    0.25        A
+ Total instruction cycles:    0.86    0.00    0.25    0.25        A
- Shortest path cycles:        0.91    0.00    0.62    0.25        A
+ Shortest path cycles:        0.86    0.00    0.25    0.25        A
- Longest path cycles:         0.91    0.00    0.62    0.25        A
+ Longest path cycles:         0.86    0.00    0.25    0.25        A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

- Has uniform computation: true
+ Has uniform computation: false
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G615]
Main shader
===========

Work registers: 31 (96% used at 100% occupancy)
- Uniform registers: 10 (15% used)
+ Uniform registers: 12 (18% used)
Stack spilling: false
- 16-bit arithmetic: 16%
+ 16-bit arithmetic: 10%

                                A      LS       V       T    Bound
- Total instruction cycles:    0.34    0.00    0.16    0.12        A
+ Total instruction cycles:    0.30    0.00    0.06    0.12        A
- Shortest path cycles:        0.33    0.00    0.16    0.12        A
+ Shortest path cycles:        0.29    0.00    0.06    0.12        A
- Longest path cycles:         0.34    0.00    0.16    0.12        A
+ Longest path cycles:         0.30    0.00    0.06    0.12        A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

- Has uniform computation: true
+ Has uniform computation: false
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G610]
Main shader
===========

Work registers: 31 (96% used at 100% occupancy)
- Uniform registers: 10 (15% used)
+ Uniform registers: 12 (18% used)
Stack spilling: false
- 16-bit arithmetic: 17%
+ 16-bit arithmetic: 11%

                                A      LS       V       T    Bound
- Total instruction cycles:    0.66    0.00    0.31    0.12        A
+ Total instruction cycles:    0.59    0.00    0.12    0.12        A
- Shortest path cycles:        0.65    0.00    0.31    0.12        A
+ Shortest path cycles:        0.57    0.00    0.12    0.12        A
- Longest path cycles:         0.66    0.00    0.31    0.12        A
+ Longest path cycles:         0.59    0.00    0.12    0.12        A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

- Has uniform computation: true
+ Has uniform computation: false
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G57]
Main shader
===========

Work registers: 31 (96% used at 100% occupancy)
- Uniform registers: 10 (15% used)
+ Uniform registers: 12 (18% used)
Stack spilling: false
- 16-bit arithmetic: 17%
+ 16-bit arithmetic: 11%

                                A      LS       V       T    Bound
- Total instruction cycles:    0.91    0.00    0.62    0.25        A
+ Total instruction cycles:    0.86    0.00    0.25    0.25        A
- Shortest path cycles:        0.91    0.00    0.62    0.25        A
+ Shortest path cycles:        0.86    0.00    0.25    0.25        A
- Longest path cycles:         0.91    0.00    0.62    0.25        A
+ Longest path cycles:         0.86    0.00    0.25    0.25        A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

- Has uniform computation: true
+ Has uniform computation: false
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G52]
Main shader
===========

- Work registers: 30 (93% used at 100% occupancy)
+ Work registers: 31 (96% used at 100% occupancy)
- Uniform registers: 2 (3% used)
+ Uniform registers: 4 (6% used)
Stack spilling: false
- 16-bit arithmetic: 18%
+ 16-bit arithmetic: 16%

                                A      LS       V       T    Bound
- Total instruction cycles:    2.47    0.00    0.75    0.50        A
+ Total instruction cycles:    2.37    0.00    0.25    0.50        A
- Shortest path cycles:        2.47    0.00    0.75    0.50        A
+ Shortest path cycles:        2.37    0.00    0.25    0.50        A
- Longest path cycles:         2.47    0.00    0.75    0.50        A
+ Longest path cycles:         2.37    0.00    0.25    0.50        A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

Has uniform computation: false
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G510]
Main shader
===========

Work registers: 31 (96% used at 100% occupancy)
- Uniform registers: 10 (15% used)
+ Uniform registers: 12 (18% used)
Stack spilling: false
- 16-bit arithmetic: 17%
+ 16-bit arithmetic: 11%

                                A      LS       V       T    Bound
- Total instruction cycles:    0.89    0.00    0.31    0.12        A
+ Total instruction cycles:    0.78    0.00    0.12    0.12        A
- Shortest path cycles:        0.86    0.00    0.31    0.12        A
+ Shortest path cycles:        0.76    0.00    0.12    0.12        A
- Longest path cycles:         0.89    0.00    0.31    0.12        A
+ Longest path cycles:         0.78    0.00    0.12    0.12        A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

- Has uniform computation: true
+ Has uniform computation: false
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G51]
Main shader
===========

- Work registers: 30 (93% used at 100% occupancy)
+ Work registers: 32 (100% used at 100% occupancy)
- Uniform registers: 2 (3% used)
+ Uniform registers: 4 (6% used)
Stack spilling: false
- 16-bit arithmetic: 18%
+ 16-bit arithmetic: 16%

                                A      LS       V       T    Bound
- Total instruction cycles:    5.17    0.00    0.75    0.50        A
+ Total instruction cycles:    4.73    0.00    0.25    0.50        A
- Shortest path cycles:        5.17    0.00    0.75    0.50        A
+ Shortest path cycles:        4.73    0.00    0.25    0.50        A
- Longest path cycles:         5.17    0.00    0.75    0.50        A
+ Longest path cycles:         4.73    0.00    0.25    0.50        A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

Has uniform computation: false
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G310]
Main shader
===========

Work registers: 31 (96% used at 100% occupancy)
- Uniform registers: 10 (15% used)
+ Uniform registers: 12 (18% used)
Stack spilling: false
- 16-bit arithmetic: 17%
+ 16-bit arithmetic: 11%

                                A      LS       V       T    Bound
- Total instruction cycles:    1.33    0.00    0.62    0.25        A
+ Total instruction cycles:    1.17    0.00    0.25    0.25        A
- Shortest path cycles:        1.30    0.00    0.62    0.25        A
+ Shortest path cycles:        1.14    0.00    0.25    0.25        A
- Longest path cycles:         1.33    0.00    0.62    0.25        A
+ Longest path cycles:         1.17    0.00    0.25    0.25        A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

- Has uniform computation: true
+ Has uniform computation: false
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G31]
Main shader
===========

- Work registers: 30 (93% used at 100% occupancy)
+ Work registers: 32 (100% used at 100% occupancy)
- Uniform registers: 2 (3% used)
+ Uniform registers: 4 (6% used)
Stack spilling: false
- 16-bit arithmetic: 18%
+ 16-bit arithmetic: 16%

                                A      LS       V       T    Bound
- Total instruction cycles:    7.75    0.00    0.75    0.50        A
+ Total instruction cycles:    7.10    0.00    0.25    0.50        A
- Shortest path cycles:        7.75    0.00    0.75    0.50        A
+ Shortest path cycles:        7.10    0.00    0.25    0.50        A
- Longest path cycles:         7.75    0.00    0.75    0.50        A
+ Longest path cycles:         7.10    0.00    0.25    0.50        A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

Has uniform computation: false
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Immortalis-G715]
Main shader
===========

Work registers: 31 (96% used at 100% occupancy)
- Uniform registers: 10 (15% used)
+ Uniform registers: 12 (18% used)
Stack spilling: false
- 16-bit arithmetic: 16%
+ 16-bit arithmetic: 10%

                                A      LS       V       T    Bound
- Total instruction cycles:    0.34    0.00    0.16    0.12        A
+ Total instruction cycles:    0.30    0.00    0.06    0.12        A
- Shortest path cycles:        0.33    0.00    0.16    0.12        A
+ Shortest path cycles:        0.29    0.00    0.06    0.12        A
- Longest path cycles:         0.34    0.00    0.16    0.12        A
+ Longest path cycles:         0.30    0.00    0.06    0.12        A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

- Has uniform computation: true
+ Has uniform computation: false
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false

```

</details>
