### PR TITLE
[Impeller] improve rrect blur performance on Android

### DIFF
--- a/impeller/compiler/shader_lib/impeller/gaussian.glsl
+++ b/impeller/compiler/shader_lib/impeller/gaussian.glsl
@@ -13,12 +13,17 @@ float IPGaussian(float x, float sigma) {
   return exp(-0.5 * x * x / variance) / (kSqrtTwoPi * sigma);
 }
 
+/// Gaussian distribution function.
+float IPGaussian(float x, float sigma, float variance) {
+  return exp(-0.5 * pow(x, 2.0) / variance) / (kSqrtTwoPi * sigma);
+}
+
 /// Abramowitz and Stegun erf approximation.
 float IPErf(float x) {
   float a = abs(x);
   // 0.278393*x + 0.230389*x^2 + 0.078108*x^4 + 1
   float b = (0.278393 + (0.230389 + 0.078108 * a * a) * a) * a + 1.0;
-  return sign(x) * (1 - 1 / (b * b * b * b));
+  return sign(x) * (1 - 1 / b * b * b * b);
 }
 
 /// Vec2 variation for the Abramowitz and Stegun erf approximation.

--- a/impeller/compiler/shader_lib/impeller/gaussian.glsl
+++ b/impeller/compiler/shader_lib/impeller/gaussian.glsl
@@ -9,12 +9,7 @@
 
 /// Gaussian distribution function.
 float IPGaussian(float x, float sigma) {
-  float variance = sigma * sigma;
-  return exp(-0.5 * x * x / variance) / (kSqrtTwoPi * sigma);
-}
-
-/// Gaussian distribution function.
-float IPGaussian(float x, float sigma, float variance) {
+  float variance = pow(sigma, 2.0;
   return exp(-0.5 * pow(x, 2.0) / variance) / (kSqrtTwoPi * sigma);
 }
 
@@ -23,7 +18,7 @@ float IPErf(float x) {
   float a = abs(x);
   // 0.278393*x + 0.230389*x^2 + 0.078108*x^4 + 1
   float b = (0.278393 + (0.230389 + 0.078108 * a * a) * a) * a + 1.0;
-  return sign(x) * (1 - 1 / b * b * b * b);
+  return sign(x) * (1 - 1 / pow(b, 4.0));
 }
 
 /// Vec2 variation for the Abramowitz and Stegun erf approximation.

--- a/impeller/entity/BUILD.gn
+++ b/impeller/entity/BUILD.gn
@@ -50,6 +50,7 @@ impeller_shaders("entity_shaders") {
     "shaders/radial_gradient_fill.frag",
     "shaders/rrect_blur.vert",
     "shaders/rrect_blur.frag",
+    "shaders/rrect_blur_no_sigma.frag",
     "shaders/runtime_effect.vert",
     "shaders/solid_fill.frag",
     "shaders/solid_fill.vert",

--- a/impeller/entity/contents/content_context.cc
+++ b/impeller/entity/contents/content_context.cc
@@ -169,6 +169,8 @@ ContentContext::ContentContext(std::shared_ptr<Context> context)
       CreateDefaultPipeline<SweepGradientFillPipeline>(*context_);
   rrect_blur_pipelines_[{}] =
       CreateDefaultPipeline<RRectBlurPipeline>(*context_);
+  rrect_blur_no_sigma_pipelines_[{}] =
+      CreateDefaultPipeline<RRectBlurNoSigmaPipeline>(*context_);
   texture_blend_pipelines_[{}] =
       CreateDefaultPipeline<BlendPipeline>(*context_);
   blend_color_pipelines_[{}] =

--- a/impeller/entity/contents/content_context.h
+++ b/impeller/entity/contents/content_context.h
@@ -51,6 +51,7 @@
 #include "impeller/entity/radial_gradient_fill.frag.h"
 #include "impeller/entity/rrect_blur.frag.h"
 #include "impeller/entity/rrect_blur.vert.h"
+#include "impeller/entity/rrect_blur_no_sigma.frag.h"
 #include "impeller/entity/solid_fill.frag.h"
 #include "impeller/entity/solid_fill.vert.h"
 #include "impeller/entity/srgb_to_linear_filter.frag.h"
@@ -98,6 +99,8 @@ using SweepGradientSSBOFillPipeline =
 using BlendPipeline = RenderPipelineT<BlendVertexShader, BlendFragmentShader>;
 using RRectBlurPipeline =
     RenderPipelineT<RrectBlurVertexShader, RrectBlurFragmentShader>;
+using RRectBlurNoSigmaPipeline =
+    RenderPipelineT<RrectBlurVertexShader, RrectBlurNoSigmaFragmentShader>;
 using BlendPipeline = RenderPipelineT<BlendVertexShader, BlendFragmentShader>;
 using BlendColorPipeline = RenderPipelineT<AdvancedBlendVertexShader,
                                            AdvancedBlendColorFragmentShader>;
@@ -249,6 +252,11 @@ class ContentContext {
   std::shared_ptr<Pipeline<PipelineDescriptor>> GetRRectBlurPipeline(
       ContentContextOptions opts) const {
     return GetPipeline(rrect_blur_pipelines_, opts);
+  }
+
+  std::shared_ptr<Pipeline<PipelineDescriptor>> GetRRectBlurNoSigmaPipeline(
+      ContentContextOptions opts) const {
+    return GetPipeline(rrect_blur_no_sigma_pipelines_, opts);
   }
 
   std::shared_ptr<Pipeline<PipelineDescriptor>> GetSweepGradientFillPipeline(
@@ -456,6 +464,7 @@ class ContentContext {
   mutable Variants<SweepGradientSSBOFillPipeline>
       sweep_gradient_ssbo_fill_pipelines_;
   mutable Variants<RRectBlurPipeline> rrect_blur_pipelines_;
+  mutable Variants<RRectBlurNoSigmaPipeline> rrect_blur_no_sigma_pipelines_;
   mutable Variants<BlendPipeline> texture_blend_pipelines_;
   mutable Variants<TexturePipeline> texture_pipelines_;
   mutable Variants<TiledTexturePipeline> tiled_texture_pipelines_;

--- a/impeller/entity/contents/rrect_shadow_contents.cc
+++ b/impeller/entity/contents/rrect_shadow_contents.cc
@@ -55,8 +55,6 @@ bool RRectShadowContents::Render(const ContentContext& renderer,
   }
 
   using VS = RRectBlurPipeline::VertexShader;
-  using FS = RRectBlurPipeline::FragmentShader;
-
   VertexBufferBuilder<VS::PerVertexData> vtx_builder;
 
   auto blur_radius = Radius{sigma_}.radius;
@@ -71,20 +69,34 @@ bool RRectShadowContents::Render(const ContentContext& renderer,
         {Point(left, top)},
         {Point(right, top)},
         {Point(left, bottom)},
-        {Point(left, bottom)},
-        {Point(right, top)},
         {Point(right, bottom)},
     });
+    vtx_builder.AddIndices({0, 1, 2, 1, 2, 3});
   }
 
   Command cmd;
   cmd.label = "RRect Shadow";
-  auto opts = OptionsFromPassAndEntity(pass, entity);
-  opts.primitive_type = PrimitiveType::kTriangle;
-  cmd.pipeline = renderer.GetRRectBlurPipeline(opts);
   cmd.stencil_reference = entity.GetStencilDepth();
 
   cmd.BindVertices(vtx_builder.CreateVertexBuffer(pass.GetTransientsBuffer()));
+
+  if (sigma_.sigma > 0) {
+    return RenderWithSigma(renderer, entity, pass, std::move(cmd));
+  }
+  return RenderNoSigma(renderer, entity, pass, std::move(cmd));
+}
+
+bool RRectShadowContents::RenderWithSigma(const ContentContext& renderer,
+                                          const Entity& entity,
+                                          RenderPass& pass,
+                                          Command cmd) const {
+  using FS = RRectBlurPipeline::FragmentShader;
+  using VS = RRectBlurPipeline::VertexShader;
+
+  auto positive_rect = rect_->GetPositive();
+  auto opts = OptionsFromPassAndEntity(pass, entity);
+  opts.primitive_type = PrimitiveType::kTriangle;
+  cmd.pipeline = renderer.GetRRectBlurPipeline(opts);
 
   VS::VertInfo vert_info;
   vert_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
@@ -99,6 +111,36 @@ bool RRectShadowContents::Render(const ContentContext& renderer,
   frag_info.corner_radius =
       std::min(corner_radius_, std::min(positive_rect.size.width / 2.0f,
                                         positive_rect.size.height / 2.0f));
+  FS::BindFragInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frag_info));
+
+  if (!pass.AddCommand(std::move(cmd))) {
+    return false;
+  }
+
+  return true;
+}
+
+bool RRectShadowContents::RenderNoSigma(const ContentContext& renderer,
+                                        const Entity& entity,
+                                        RenderPass& pass,
+                                        Command cmd) const {
+  using FS = RRectBlurNoSigmaPipeline::FragmentShader;
+  using VS = RRectBlurNoSigmaPipeline::VertexShader;
+
+  auto positive_rect = rect_->GetPositive();
+  auto opts = OptionsFromPassAndEntity(pass, entity);
+  opts.primitive_type = PrimitiveType::kTriangle;
+  cmd.pipeline = renderer.GetRRectBlurNoSigmaPipeline(opts);
+
+  VS::VertInfo vert_info;
+  vert_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
+                  entity.GetTransformation() *
+                  Matrix::MakeTranslation({positive_rect.origin});
+  VS::BindVertInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(vert_info));
+
+  FS::FragInfo frag_info;
+  frag_info.color = color_;
+  frag_info.rect_size = Point(positive_rect.size);
   FS::BindFragInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frag_info));
 
   if (!pass.AddCommand(std::move(cmd))) {

--- a/impeller/entity/contents/rrect_shadow_contents.h
+++ b/impeller/entity/contents/rrect_shadow_contents.h
@@ -14,9 +14,7 @@
 
 namespace impeller {
 
-class Path;
-class HostBuffer;
-struct VertexBuffer;
+struct Command;
 
 class RRectShadowContents final : public Contents {
  public:
@@ -39,6 +37,16 @@ class RRectShadowContents final : public Contents {
               RenderPass& pass) const override;
 
  private:
+  bool RenderWithSigma(const ContentContext& renderer,
+                       const Entity& entity,
+                       RenderPass& pass,
+                       Command cmd) const;
+
+  bool RenderNoSigma(const ContentContext& renderer,
+                     const Entity& entity,
+                     RenderPass& pass,
+                     Command cmd) const;
+
   std::optional<Rect> rect_;
   Scalar corner_radius_;
   Sigma sigma_;

--- a/impeller/entity/shaders/rrect_blur_no_sigma.frag
+++ b/impeller/entity/shaders/rrect_blur_no_sigma.frag
@@ -1,0 +1,30 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <impeller/gaussian.glsl>
+#include <impeller/types.glsl>
+
+uniform FragInfo {
+  vec4 color;
+  vec2 rect_size;
+  float corner_radius;
+}
+frag_info;
+
+in vec2 v_position;
+
+out vec4 frag_color;
+
+float RRectDistance(vec2 sample_position, vec2 half_size) {
+  vec2 space = abs(sample_position) - half_size + frag_info.corner_radius;
+  return length(max(space, 0.0)) + min(max(space.x, space.y), 0.0) -
+         frag_info.corner_radius;
+}
+
+void main() {
+  vec2 half_size = frag_info.rect_size * 0.5;
+  vec2 sample_position = v_position - half_size;
+
+  frag_color *= frag_info.color * -RRectDistance(sample_position, half_size);
+}

--- a/impeller/renderer/vertex_buffer_builder.h
+++ b/impeller/renderer/vertex_buffer_builder.h
@@ -67,6 +67,14 @@ class VertexBufferBuilder {
     return *this;
   }
 
+  VertexBufferBuilder& AddIndices(std::initializer_list<IndexType_> indices) {
+    indices_.reserve(indices.size());
+    for (auto& index : indices) {
+      indices_.emplace_back(index);
+    }
+    return *this;
+  }
+
   VertexBufferBuilder& AppendIndex(IndexType_ index) {
     indices_.emplace_back(index);
     return *this;


### PR DESCRIPTION
Improve the rrect blur performance by separating out the sigma > 0 and sigma <= 0 cases into distinct shaders. This change accounts for the vast majority of the performance improvement, which can be seen in the significant % of cycle reduction and removal of stack spilling on older GPUs in the malioc diff below.


<details>
```diff
[Mali-T880]
Main shader
===========

Work registers: 4 (100% used at 100% occupancy)
Uniform registers: 1 (5% used)
- Stack spilling: true
+ Stack spilling: false

                                A      LS       T    Bound
- Total instruction cycles:   12.00    4.00    0.00        A
+ Total instruction cycles:    8.00    1.00    0.00        A
- Shortest path cycles:        2.64    3.00    0.00       LS
+ Shortest path cycles:        7.59    1.00    0.00        A
Longest path cycles:          N/A     N/A     N/A      N/A

A = Arithmetic, LS = Load/Store, T = Texture

Shader properties
=================

Has uniform computation: false



[Mali-T860]
Main shader
===========

Work registers: 4 (100% used at 100% occupancy)
Uniform registers: 1 (5% used)
- Stack spilling: true
+ Stack spilling: false

                                A      LS       T    Bound
- Total instruction cycles:   18.00    4.00    0.00        A
+ Total instruction cycles:   12.00    1.00    0.00        A
- Shortest path cycles:        4.00    3.00    0.00        A
+ Shortest path cycles:       11.50    1.00    0.00        A
Longest path cycles:          N/A     N/A     N/A      N/A

A = Arithmetic, LS = Load/Store, T = Texture

Shader properties
=================

Has uniform computation: false



[Mali-T830]
Main shader
===========

Work registers: 4 (100% used at 100% occupancy)
Uniform registers: 1 (5% used)
- Stack spilling: true
+ Stack spilling: false

                                A      LS       T    Bound
- Total instruction cycles:   18.00    4.00    0.00        A
+ Total instruction cycles:   12.00    1.00    0.00        A
- Shortest path cycles:        2.12    3.00    0.00       LS
+ Shortest path cycles:        5.00    1.00    0.00        A
Longest path cycles:          N/A     N/A     N/A      N/A

A = Arithmetic, LS = Load/Store, T = Texture

Shader properties
=================

Has uniform computation: false



[Mali-T820]
Main shader
===========

Work registers: 4 (100% used at 100% occupancy)
Uniform registers: 1 (5% used)
- Stack spilling: true
+ Stack spilling: false

                                A      LS       T    Bound
- Total instruction cycles:   36.00    4.00    0.00        A
+ Total instruction cycles:   24.00    1.00    0.00        A
- Shortest path cycles:        4.25    3.00    0.00        A
+ Shortest path cycles:       10.00    1.00    0.00        A
Longest path cycles:          N/A     N/A     N/A      N/A

A = Arithmetic, LS = Load/Store, T = Texture

Shader properties
=================

Has uniform computation: false



[Mali-T760]
Main shader
===========

Work registers: 4 (100% used at 100% occupancy)
Uniform registers: 1 (5% used)
- Stack spilling: true
+ Stack spilling: false

                                A      LS       T    Bound
- Total instruction cycles:   18.00    4.00    0.00        A
+ Total instruction cycles:   12.00    1.00    0.00        A
- Shortest path cycles:        4.00    3.00    0.00        A
+ Shortest path cycles:       11.50    1.00    0.00        A
Longest path cycles:          N/A     N/A     N/A      N/A

A = Arithmetic, LS = Load/Store, T = Texture

Shader properties
=================

Has uniform computation: false



[Mali-T720]
Main shader
===========

Work registers: 4 (100% used at 100% occupancy)
Uniform registers: 1 (5% used)
- Stack spilling: true
+ Stack spilling: false

                                A      LS       T    Bound
- Total instruction cycles:   36.00    4.00    0.00        A
+ Total instruction cycles:   24.00    1.00    0.00        A
- Shortest path cycles:        4.25    3.00    0.00        A
+ Shortest path cycles:       10.25    1.00    0.00        A
Longest path cycles:          N/A     N/A     N/A      N/A

A = Arithmetic, LS = Load/Store, T = Texture


[Mali-G78AE]
Main shader
===========

Work registers: 32 (100% used at 100% occupancy)
- Uniform registers: 26 (40% used)
+ Uniform registers: 24 (37% used)
Stack spilling: false
- 16-bit arithmetic: 26%
+ 16-bit arithmetic: 29%

                                A      LS       V       T    Bound
- Total instruction cycles:    3.24    0.00    0.12    0.00        A
+ Total instruction cycles:    2.47    0.00    0.12    0.00        A
- Shortest path cycles:        0.20    0.00    0.12    0.00        A
+ Shortest path cycles:        2.47    0.00    0.12    0.00        A
- Longest path cycles:         3.11    0.00    0.12    0.00        A
+ Longest path cycles:         2.47    0.00    0.12    0.00        A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

Has uniform computation: true
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G78]
Main shader
===========

Work registers: 32 (100% used at 100% occupancy)
- Uniform registers: 26 (40% used)
+ Uniform registers: 24 (37% used)
Stack spilling: false
- 16-bit arithmetic: 26%
+ 16-bit arithmetic: 29%

                                A      LS       V       T    Bound
- Total instruction cycles:    3.24    0.00    0.12    0.00        A
+ Total instruction cycles:    2.47    0.00    0.12    0.00        A
- Shortest path cycles:        0.20    0.00    0.12    0.00        A
+ Shortest path cycles:        2.47    0.00    0.12    0.00        A
- Longest path cycles:         3.11    0.00    0.12    0.00        A
+ Longest path cycles:         2.47    0.00    0.12    0.00        A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

Has uniform computation: true
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G77]
Main shader
===========

Work registers: 32 (100% used at 100% occupancy)
- Uniform registers: 26 (40% used)
+ Uniform registers: 24 (37% used)
Stack spilling: false
- 16-bit arithmetic: 26%
+ 16-bit arithmetic: 29%

                                A      LS       V       T    Bound
- Total instruction cycles:    3.24    0.00    0.12    0.00        A
+ Total instruction cycles:    2.47    0.00    0.12    0.00        A
- Shortest path cycles:        0.20    0.00    0.12    0.00        A
+ Shortest path cycles:        2.47    0.00    0.12    0.00        A
- Longest path cycles:         3.11    0.00    0.12    0.00        A
+ Longest path cycles:         2.47    0.00    0.12    0.00        A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

Has uniform computation: true
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G76]
Main shader
===========

- Work registers: 25 (78% used at 100% occupancy)
+ Work registers: 22 (68% used at 100% occupancy)
- Uniform registers: 22 (34% used)
+ Uniform registers: 16 (25% used)
Stack spilling: false
- 16-bit arithmetic: 35%
+ 16-bit arithmetic: 42%

                                A      LS       V       T    Bound
- Total instruction cycles:    2.53    0.00    0.12    0.00        A
+ Total instruction cycles:    1.67    0.00    0.12    0.00        A
- Shortest path cycles:        0.71    0.00    0.12    0.00        A
+ Shortest path cycles:        1.67    0.00    0.12    0.00        A
Longest path cycles:          N/A     N/A     N/A     N/A      N/A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

Has uniform computation: true
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G72]
Main shader
===========

- Work registers: 26 (81% used at 100% occupancy)
+ Work registers: 23 (71% used at 100% occupancy)
- Uniform registers: 22 (34% used)
+ Uniform registers: 16 (25% used)
Stack spilling: false
- 16-bit arithmetic: 35%
+ 16-bit arithmetic: 42%

                                A      LS       V       T    Bound
- Total instruction cycles:    5.07    0.00    0.25    0.00        A
+ Total instruction cycles:    3.40    0.00    0.25    0.00        A
- Shortest path cycles:        1.42    0.00    0.25    0.00        A
+ Shortest path cycles:        3.40    0.00    0.25    0.00        A
Longest path cycles:          N/A     N/A     N/A     N/A      N/A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

Has uniform computation: true
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G715]
Main shader
===========

Work registers: 32 (100% used at 100% occupancy)
- Uniform registers: 26 (40% used)
+ Uniform registers: 24 (37% used)
Stack spilling: false
- 16-bit arithmetic: 26%
+ 16-bit arithmetic: 29%

                                A      LS       V       T    Bound
- Total instruction cycles:    1.10    0.00    0.03    0.00        A
+ Total instruction cycles:    0.85    0.00    0.03    0.00        A
- Shortest path cycles:        0.07    0.00    0.03    0.00        A
+ Shortest path cycles:        0.84    0.00    0.03    0.00        A
- Longest path cycles:         1.06    0.00    0.03    0.00        A
+ Longest path cycles:         0.85    0.00    0.03    0.00        A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

Has uniform computation: true
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G710]
Main shader
===========

Work registers: 32 (100% used at 100% occupancy)
- Uniform registers: 26 (40% used)
+ Uniform registers: 24 (37% used)
Stack spilling: false
- 16-bit arithmetic: 26%
+ 16-bit arithmetic: 29%

                                A      LS       V       T    Bound
- Total instruction cycles:    2.20    0.00    0.06    0.00        A
+ Total instruction cycles:    1.70    0.00    0.06    0.00        A
- Shortest path cycles:        0.13    0.00    0.06    0.00        A
+ Shortest path cycles:        1.69    0.00    0.06    0.00        A
- Longest path cycles:         2.12    0.00    0.06    0.00        A
+ Longest path cycles:         1.70    0.00    0.06    0.00        A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

Has uniform computation: true
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G71]
Main shader
===========

- Work registers: 29 (90% used at 100% occupancy)
+ Work registers: 24 (75% used at 100% occupancy)
- Uniform registers: 22 (34% used)
+ Uniform registers: 16 (25% used)
Stack spilling: false
- 16-bit arithmetic: 29%
+ 16-bit arithmetic: 37%

                                A      LS       V       T    Bound
- Total instruction cycles:    5.33    0.00    0.25    0.00        A
+ Total instruction cycles:    3.67    0.00    0.25    0.00        A
- Shortest path cycles:        1.25    0.00    0.25    0.00        A
+ Shortest path cycles:        3.67    0.00    0.25    0.00        A
Longest path cycles:          N/A     N/A     N/A     N/A      N/A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

Has uniform computation: true
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G68]
Main shader
===========

Work registers: 32 (100% used at 100% occupancy)
- Uniform registers: 26 (40% used)
+ Uniform registers: 24 (37% used)
Stack spilling: false
- 16-bit arithmetic: 26%
+ 16-bit arithmetic: 29%

                                A      LS       V       T    Bound
- Total instruction cycles:    3.24    0.00    0.12    0.00        A
+ Total instruction cycles:    2.47    0.00    0.12    0.00        A
- Shortest path cycles:        0.20    0.00    0.12    0.00        A
+ Shortest path cycles:        2.47    0.00    0.12    0.00        A
- Longest path cycles:         3.11    0.00    0.12    0.00        A
+ Longest path cycles:         2.47    0.00    0.12    0.00        A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

Has uniform computation: true
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G615]
Main shader
===========

Work registers: 32 (100% used at 100% occupancy)
- Uniform registers: 26 (40% used)
+ Uniform registers: 24 (37% used)
Stack spilling: false
- 16-bit arithmetic: 26%
+ 16-bit arithmetic: 29%

                                A      LS       V       T    Bound
- Total instruction cycles:    1.10    0.00    0.03    0.00        A
+ Total instruction cycles:    0.85    0.00    0.03    0.00        A
- Shortest path cycles:        0.07    0.00    0.03    0.00        A
+ Shortest path cycles:        0.84    0.00    0.03    0.00        A
- Longest path cycles:         1.06    0.00    0.03    0.00        A
+ Longest path cycles:         0.85    0.00    0.03    0.00        A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

Has uniform computation: true
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G610]
Main shader
===========

Work registers: 32 (100% used at 100% occupancy)
- Uniform registers: 26 (40% used)
+ Uniform registers: 24 (37% used)
Stack spilling: false
- 16-bit arithmetic: 26%
+ 16-bit arithmetic: 29%

                                A      LS       V       T    Bound
- Total instruction cycles:    2.20    0.00    0.06    0.00        A
+ Total instruction cycles:    1.70    0.00    0.06    0.00        A
- Shortest path cycles:        0.13    0.00    0.06    0.00        A
+ Shortest path cycles:        1.69    0.00    0.06    0.00        A
- Longest path cycles:         2.12    0.00    0.06    0.00        A
+ Longest path cycles:         1.70    0.00    0.06    0.00        A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

Has uniform computation: true
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G57]
Main shader
===========

Work registers: 32 (100% used at 100% occupancy)
- Uniform registers: 26 (40% used)
+ Uniform registers: 24 (37% used)
Stack spilling: false
- 16-bit arithmetic: 26%
+ 16-bit arithmetic: 29%

                                A      LS       V       T    Bound
- Total instruction cycles:    3.24    0.00    0.12    0.00        A
+ Total instruction cycles:    2.47    0.00    0.12    0.00        A
- Shortest path cycles:        0.20    0.00    0.12    0.00        A
+ Shortest path cycles:        2.47    0.00    0.12    0.00        A
- Longest path cycles:         3.11    0.00    0.12    0.00        A
+ Longest path cycles:         2.47    0.00    0.12    0.00        A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

Has uniform computation: true
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G52]
Main shader
===========

- Work registers: 25 (78% used at 100% occupancy)
+ Work registers: 22 (68% used at 100% occupancy)
- Uniform registers: 22 (34% used)
+ Uniform registers: 16 (25% used)
Stack spilling: false
- 16-bit arithmetic: 35%
+ 16-bit arithmetic: 42%

                                A      LS       V       T    Bound
- Total instruction cycles:    2.53    0.00    0.12    0.00        A
+ Total instruction cycles:    1.67    0.00    0.12    0.00        A
- Shortest path cycles:        0.71    0.00    0.12    0.00        A
+ Shortest path cycles:        1.67    0.00    0.12    0.00        A
Longest path cycles:          N/A     N/A     N/A     N/A      N/A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

Has uniform computation: true
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G510]
Main shader
===========

Work registers: 32 (100% used at 100% occupancy)
- Uniform registers: 26 (40% used)
+ Uniform registers: 24 (37% used)
Stack spilling: false
- 16-bit arithmetic: 26%
+ 16-bit arithmetic: 29%

                                A      LS       V       T    Bound
- Total instruction cycles:    2.94    0.00    0.06    0.00        A
+ Total instruction cycles:    2.27    0.00    0.06    0.00        A
- Shortest path cycles:        0.18    0.00    0.06    0.00        A
+ Shortest path cycles:        2.25    0.00    0.06    0.00        A
- Longest path cycles:         2.83    0.00    0.06    0.00        A
+ Longest path cycles:         2.27    0.00    0.06    0.00        A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

Has uniform computation: true
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G51]
Main shader
===========

- Work registers: 26 (81% used at 100% occupancy)
+ Work registers: 23 (71% used at 100% occupancy)
- Uniform registers: 22 (34% used)
+ Uniform registers: 16 (25% used)
Stack spilling: false
- 16-bit arithmetic: 35%
+ 16-bit arithmetic: 42%

                                A      LS       V       T    Bound
- Total instruction cycles:    5.07    0.00    0.12    0.00        A
+ Total instruction cycles:    3.40    0.00    0.12    0.00        A
- Shortest path cycles:        1.42    0.00    0.12    0.00        A
+ Shortest path cycles:        3.40    0.00    0.12    0.00        A
Longest path cycles:          N/A     N/A     N/A     N/A      N/A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

Has uniform computation: true
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G310]
Main shader
===========

Work registers: 32 (100% used at 100% occupancy)
- Uniform registers: 26 (40% used)
+ Uniform registers: 24 (37% used)
Stack spilling: false
- 16-bit arithmetic: 26%
+ 16-bit arithmetic: 29%

                                A      LS       V       T    Bound
- Total instruction cycles:    4.41    0.00    0.12    0.00        A
+ Total instruction cycles:    3.41    0.00    0.12    0.00        A
- Shortest path cycles:        0.27    0.00    0.12    0.00        A
+ Shortest path cycles:        3.38    0.00    0.12    0.00        A
- Longest path cycles:         4.24    0.00    0.12    0.00        A
+ Longest path cycles:         3.41    0.00    0.12    0.00        A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

Has uniform computation: true
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G31]
Main shader
===========

- Work registers: 26 (81% used at 100% occupancy)
+ Work registers: 23 (71% used at 100% occupancy)
- Uniform registers: 22 (34% used)
+ Uniform registers: 16 (25% used)
Stack spilling: false
- 16-bit arithmetic: 35%
+ 16-bit arithmetic: 42%

                                A      LS       V       T    Bound
- Total instruction cycles:    7.60    0.00    0.12    0.00        A
+ Total instruction cycles:    5.10    0.00    0.12    0.00        A
- Shortest path cycles:        2.12    0.00    0.12    0.00        A
+ Shortest path cycles:        5.10    0.00    0.12    0.00        A
Longest path cycles:          N/A     N/A     N/A     N/A      N/A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

Has uniform computation: true
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Immortalis-G715]
Main shader
===========

Work registers: 32 (100% used at 100% occupancy)
- Uniform registers: 26 (40% used)
+ Uniform registers: 24 (37% used)
Stack spilling: false
- 16-bit arithmetic: 26%
+ 16-bit arithmetic: 29%

                                A      LS       V       T    Bound
- Total instruction cycles:    1.10    0.00    0.03    0.00        A
+ Total instruction cycles:    0.85    0.00    0.03    0.00        A
- Shortest path cycles:        0.07    0.00    0.03    0.00        A
+ Shortest path cycles:        0.84    0.00    0.03    0.00        A
- Longest path cycles:         1.06    0.00    0.03    0.00        A
+ Longest path cycles:         0.85    0.00    0.03    0.00        A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

Has uniform computation: true
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false
```
</details>
