### PR TITLE
[Impeller] improve gaussian blur performance on Android

### DIFF
--- a/impeller/compiler/shader_lib/impeller/texture.glsl
+++ b/impeller/compiler/shader_lib/impeller/texture.glsl
@@ -19,6 +19,13 @@ vec4 IPSample(sampler2D texture_sampler, vec2 coords, float y_coord_scale) {
   return texture(texture_sampler, coords);
 }
 
+vec2 IPRemapCoords(vec2 coords, float y_coord_scale) {
+  if (y_coord_scale < 0.0) {
+    coords.y = 1.0 - coords.y;
+  }
+  return coords;
+}
+
 /// Sample from a texture.
 ///
 /// If `y_coord_scale` < 0.0, the Y coordinate is flipped. This is useful
@@ -117,6 +124,15 @@ vec4 IPSampleLinearWithTileMode(sampler2D tex,
 
   return IPSampleLinear(tex, IPVec2Tile(coords, x_tile_mode, y_tile_mode),
                         y_coord_scale, half_texel);
+}
+
+/// Sample a texture with decal tile mode.
+vec4 IPSampleDecal(sampler2D texture_sampler, vec2 coords) {
+  if (any(lessThan(coords, vec2(0))) ||
+      any(greaterThanEqual(coords, vec2(1)))) {
+    return vec4(0);
+  }
+  return texture(texture_sampler, coords);
 }
 
 /// Sample a texture, emulating a specific tile mode.

--- a/impeller/entity/BUILD.gn
+++ b/impeller/entity/BUILD.gn
@@ -33,6 +33,7 @@ impeller_shaders("entity_shaders") {
     "shaders/color_matrix_color_filter.frag",
     "shaders/color_matrix_color_filter.vert",
     "shaders/gaussian_blur.frag",
+    "shaders/gaussian_blur_decal.frag",
     "shaders/gaussian_blur.vert",
     "shaders/glyph_atlas.frag",
     "shaders/glyph_atlas.vert",

--- a/impeller/entity/contents/content_context.cc
+++ b/impeller/entity/contents/content_context.cc
@@ -205,6 +205,8 @@ ContentContext::ContentContext(std::shared_ptr<Context> context)
       CreateDefaultPipeline<TiledTexturePipeline>(*context_);
   gaussian_blur_pipelines_[{}] =
       CreateDefaultPipeline<GaussianBlurPipeline>(*context_);
+  gaussian_blur_decal_pipelines_[{}] =
+      CreateDefaultPipeline<GaussianBlurDecalPipeline>(*context_);
   border_mask_blur_pipelines_[{}] =
       CreateDefaultPipeline<BorderMaskBlurPipeline>(*context_);
   morphology_filter_pipelines_[{}] =

--- a/impeller/entity/contents/content_context.h
+++ b/impeller/entity/contents/content_context.h
@@ -38,6 +38,7 @@
 #include "impeller/entity/entity.h"
 #include "impeller/entity/gaussian_blur.frag.h"
 #include "impeller/entity/gaussian_blur.vert.h"
+#include "impeller/entity/gaussian_blur_decal.frag.h"
 #include "impeller/entity/glyph_atlas.frag.h"
 #include "impeller/entity/glyph_atlas.vert.h"
 #include "impeller/entity/glyph_atlas_sdf.frag.h"
@@ -146,6 +147,8 @@ using TiledTexturePipeline = RenderPipelineT<TiledTextureFillVertexShader,
                                              TiledTextureFillFragmentShader>;
 using GaussianBlurPipeline =
     RenderPipelineT<GaussianBlurVertexShader, GaussianBlurFragmentShader>;
+using GaussianBlurDecalPipeline =
+    RenderPipelineT<GaussianBlurVertexShader, GaussianBlurDecalFragmentShader>;
 using BorderMaskBlurPipeline =
     RenderPipelineT<BorderMaskBlurVertexShader, BorderMaskBlurFragmentShader>;
 using MorphologyFilterPipeline =
@@ -279,6 +282,11 @@ class ContentContext {
   std::shared_ptr<Pipeline<PipelineDescriptor>> GetGaussianBlurPipeline(
       ContentContextOptions opts) const {
     return GetPipeline(gaussian_blur_pipelines_, opts);
+  }
+
+  std::shared_ptr<Pipeline<PipelineDescriptor>> GetGaussianBlurDecalPipeline(
+      ContentContextOptions opts) const {
+    return GetPipeline(gaussian_blur_decal_pipelines_, opts);
   }
 
   std::shared_ptr<Pipeline<PipelineDescriptor>> GetBorderMaskBlurPipeline(
@@ -460,6 +468,7 @@ class ContentContext {
   mutable Variants<TexturePipeline> texture_pipelines_;
   mutable Variants<TiledTexturePipeline> tiled_texture_pipelines_;
   mutable Variants<GaussianBlurPipeline> gaussian_blur_pipelines_;
+  mutable Variants<GaussianBlurDecalPipeline> gaussian_blur_decal_pipelines_;
   mutable Variants<BorderMaskBlurPipeline> border_mask_blur_pipelines_;
   mutable Variants<MorphologyFilterPipeline> morphology_filter_pipelines_;
   mutable Variants<ColorMatrixColorFilterPipeline>

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -183,13 +183,12 @@ std::optional<Snapshot> DirectionalGaussianBlurFilterContents::RenderFilter(
 
     VS::FrameInfo frame_info;
     frame_info.mvp = Matrix::MakeOrthographic(ISize(1, 1));
-
-    FS::FragInfo frag_info;
-    frag_info.texture_sampler_y_coord_scale =
+    frame_info.texture_sampler_y_coord_scale =
         input_snapshot->texture->GetYCoordScale();
-    frag_info.alpha_mask_sampler_y_coord_scale =
+    frame_info.alpha_mask_sampler_y_coord_scale =
         source_snapshot->texture->GetYCoordScale();
 
+    FS::FragInfo frag_info;
     auto r = Radius{transformed_blur_radius_length};
     frag_info.blur_sigma = Sigma{r}.sigma;
     frag_info.blur_radius = r.radius;
@@ -198,7 +197,6 @@ std::optional<Snapshot> DirectionalGaussianBlurFilterContents::RenderFilter(
     frag_info.blur_direction =
         pass_transform.Invert().TransformDirection(Vector2(1, 0)).Normalize();
 
-    frag_info.tile_mode = static_cast<Scalar>(tile_mode_);
     frag_info.src_factor = src_color_factor_;
     frag_info.inner_blur_factor = inner_blur_factor_;
     frag_info.outer_blur_factor = outer_blur_factor_;
@@ -207,19 +205,48 @@ std::optional<Snapshot> DirectionalGaussianBlurFilterContents::RenderFilter(
     Command cmd;
     cmd.label = SPrintF("Gaussian Blur Filter (Radius=%.2f)",
                         transformed_blur_radius_length);
+    cmd.BindVertices(vtx_buffer);
+
     auto options = OptionsFromPass(pass);
     options.blend_mode = BlendMode::kSource;
-    cmd.pipeline = renderer.GetGaussianBlurPipeline(options);
-    cmd.BindVertices(vtx_buffer);
+    auto input_descriptor = input_snapshot->sampler_descriptor;
+    auto source_descriptor = source_snapshot->sampler_descriptor;
+    switch (tile_mode_) {
+      case Entity::TileMode::kDecal:
+        cmd.pipeline = renderer.GetGaussianBlurDecalPipeline(options);
+        break;
+      case Entity::TileMode::kClamp:
+        cmd.pipeline = renderer.GetGaussianBlurPipeline(options);
+        input_descriptor.width_address_mode = SamplerAddressMode::kClampToEdge;
+        input_descriptor.height_address_mode = SamplerAddressMode::kClampToEdge;
+        source_descriptor.width_address_mode = SamplerAddressMode::kClampToEdge;
+        source_descriptor.height_address_mode =
+            SamplerAddressMode::kClampToEdge;
+        break;
+      case Entity::TileMode::kMirror:
+        cmd.pipeline = renderer.GetGaussianBlurPipeline(options);
+        input_descriptor.width_address_mode = SamplerAddressMode::kMirror;
+        input_descriptor.height_address_mode = SamplerAddressMode::kMirror;
+        source_descriptor.width_address_mode = SamplerAddressMode::kMirror;
+        source_descriptor.height_address_mode = SamplerAddressMode::kMirror;
+        break;
+      case Entity::TileMode::kRepeat:
+        cmd.pipeline = renderer.GetGaussianBlurPipeline(options);
+        input_descriptor.width_address_mode = SamplerAddressMode::kRepeat;
+        input_descriptor.height_address_mode = SamplerAddressMode::kRepeat;
+        source_descriptor.width_address_mode = SamplerAddressMode::kRepeat;
+        source_descriptor.height_address_mode = SamplerAddressMode::kRepeat;
+        break;
+    }
 
     FS::BindTextureSampler(
         cmd, input_snapshot->texture,
         renderer.GetContext()->GetSamplerLibrary()->GetSampler(
-            input_snapshot->sampler_descriptor));
+            input_descriptor));
     FS::BindAlphaMaskSampler(
         cmd, source_snapshot->texture,
         renderer.GetContext()->GetSamplerLibrary()->GetSampler(
-            source_snapshot->sampler_descriptor));
+            source_descriptor));
     VS::BindFrameInfo(cmd, host_buffer.EmplaceUniform(frame_info));
     FS::BindFragInfo(cmd, host_buffer.EmplaceUniform(frag_info));
 

--- a/impeller/entity/shaders/gaussian_blur.glsl
+++ b/impeller/entity/shaders/gaussian_blur.glsl
@@ -1,0 +1,70 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// 1D (directional) gaussian blur.
+//
+// Paths for future optimization:
+//   * Remove the uv bounds multiplier in SampleColor by adding optional
+//     support for SamplerAddressMode::ClampToBorder in the texture sampler.
+//   * Render both blur passes into a smaller texture than the source image
+//     (~1/radius size).
+//   * If doing the small texture render optimization, cache misses can be
+//     reduced in the first pass by sampling the source textures with a mip
+//     level of log2(min_radius).
+
+#include <impeller/constants.glsl>
+#include <impeller/gaussian.glsl>
+#include <impeller/texture.glsl>
+#include <impeller/types.glsl>
+
+uniform sampler2D texture_sampler;
+uniform sampler2D alpha_mask_sampler;
+
+uniform FragInfo {
+  vec2 texture_size;
+  vec2 blur_direction;
+
+  // The blur sigma and radius have a linear relationship which is defined
+  // host-side, but both are useful controls here. Sigma (pixels per standard
+  // deviation) is used to define the gaussian function itself, whereas the
+  // radius is used to limit how much of the function is integrated.
+  float blur_sigma;
+  float blur_radius;
+
+  float src_factor;
+  float inner_blur_factor;
+  float outer_blur_factor;
+}
+frag_info;
+
+in vec2 v_texture_coords;
+in vec2 v_src_texture_coords;
+
+out vec4 frag_color;
+
+void main() {
+  vec4 total_color = vec4(0);
+  float gaussian_integral = 0;
+  vec2 blur_uv_offset = frag_info.blur_direction / frag_info.texture_size;
+
+  for (float i = -frag_info.blur_radius; i <= frag_info.blur_radius; i++) {
+    float gaussian = IPGaussian(i, frag_info.blur_sigma);
+    gaussian_integral += gaussian;
+    total_color +=
+        gaussian *
+        Sample(texture_sampler,                       // sampler
+               v_texture_coords + blur_uv_offset * i  // texture coordinates
+        );
+  }
+
+  vec4 blur_color = total_color / gaussian_integral;
+
+  vec4 src_color = Sample(alpha_mask_sampler,   // sampler
+                          v_src_texture_coords  // texture coordinates
+  );
+  float blur_factor = frag_info.inner_blur_factor * float(src_color.a > 0) +
+                      frag_info.outer_blur_factor * float(src_color.a == 0);
+
+  frag_color = blur_color * blur_factor + src_color * frag_info.src_factor;
+}

--- a/impeller/entity/shaders/gaussian_blur.vert
+++ b/impeller/entity/shaders/gaussian_blur.vert
@@ -2,10 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <impeller/texture.glsl>
 #include <impeller/types.glsl>
 
 uniform FrameInfo {
   mat4 mvp;
+  float texture_sampler_y_coord_scale;
+  float alpha_mask_sampler_y_coord_scale;
 }
 frame_info;
 
@@ -18,6 +21,8 @@ out vec2 v_src_texture_coords;
 
 void main() {
   gl_Position = frame_info.mvp * vec4(vertices, 0.0, 1.0);
-  v_texture_coords = texture_coords;
-  v_src_texture_coords = src_texture_coords;
+  v_texture_coords =
+      IPRemapCoords(texture_coords, frame_info.texture_sampler_y_coord_scale);
+  v_src_texture_coords = IPRemapCoords(
+      src_texture_coords, frame_info.alpha_mask_sampler_y_coord_scale);
 }

--- a/impeller/entity/shaders/gaussian_blur_decal.frag
+++ b/impeller/entity/shaders/gaussian_blur_decal.frag
@@ -5,7 +5,7 @@
 #include <impeller/texture.glsl>
 
 vec4 Sample(sampler2D tex, vec2 coords) {
-  return texture(tex, coords);
+  return IPSampleDecal(tex, coords);
 }
 
 #include "gaussian_blur.glsl"


### PR DESCRIPTION
* Use sampler address mode for clamp, mirror, and repeat tile modes. Add specialzied shader for decal tile mode. 
* Move texture flip to vertex shader

<details>

```diff
**[/Users/jonahwilliams/engine/src/out/android_debug_arm64/gen/flutter/impeller/entity/gles/gaussian_blur.frag.gles]**

[Mali-T880]
Main shader
===========

- Work registers: 4 (100% used at 100% occupancy)
+ Work registers: 3 (75% used at 100% occupancy)
- Uniform registers: 2 (10% used)
+ Uniform registers: 2 (9% used)
Stack spilling: false

                                A      LS       T    Bound
- Total instruction cycles:   22.67    2.00    2.00        A
+ Total instruction cycles:    5.00    2.00    2.00        A
- Shortest path cycles:        4.62    2.00    0.00        A
+ Shortest path cycles:        2.97    2.00    1.00        A
Longest path cycles:          N/A     N/A     N/A      N/A

A = Arithmetic, LS = Load/Store, T = Texture

Shader properties
=================

Has uniform computation: false



[Mali-T860]
Main shader
===========

- Work registers: 4 (100% used at 100% occupancy)
+ Work registers: 3 (75% used at 100% occupancy)
- Uniform registers: 2 (10% used)
+ Uniform registers: 2 (9% used)
Stack spilling: false

                                A      LS       T    Bound
- Total instruction cycles:   34.00    2.00    2.00        A
+ Total instruction cycles:    7.50    2.00    2.00        A
- Shortest path cycles:        7.00    2.00    0.00        A
+ Shortest path cycles:        4.50    2.00    1.00        A
Longest path cycles:          N/A     N/A     N/A      N/A

A = Arithmetic, LS = Load/Store, T = Texture

Shader properties
=================

Has uniform computation: false



[Mali-T830]
Main shader
===========

Work registers: 4 (100% used at 100% occupancy)
Uniform registers: 2 (10% used)
Stack spilling: false

                                A      LS       T    Bound
- Total instruction cycles:   32.50    2.00    2.00        A
+ Total instruction cycles:    7.50    2.00    2.00        A
- Shortest path cycles:        4.62    2.00    0.00        A
+ Shortest path cycles:        3.25    2.00    1.00        A
Longest path cycles:          N/A     N/A     N/A      N/A

A = Arithmetic, LS = Load/Store, T = Texture

Shader properties
=================

Has uniform computation: false



[Mali-T820]
Main shader
===========

Work registers: 4 (100% used at 100% occupancy)
Uniform registers: 2 (10% used)
Stack spilling: false

                                A      LS       T    Bound
- Total instruction cycles:   65.00    2.00    2.00        A
+ Total instruction cycles:   15.00    2.00    2.00        A
- Shortest path cycles:        9.25    2.00    0.00        A
+ Shortest path cycles:        6.50    2.00    1.00        A
Longest path cycles:          N/A     N/A     N/A      N/A

A = Arithmetic, LS = Load/Store, T = Texture

Shader properties
=================

Has uniform computation: false



[Mali-T760]
Main shader
===========

- Work registers: 4 (100% used at 100% occupancy)
+ Work registers: 3 (75% used at 100% occupancy)
- Uniform registers: 2 (10% used)
+ Uniform registers: 2 (9% used)
Stack spilling: false

                                A      LS       T    Bound
- Total instruction cycles:   34.00    2.00    2.00        A
+ Total instruction cycles:    7.50    2.00    2.00        A
- Shortest path cycles:        7.00    2.00    0.00        A
+ Shortest path cycles:        4.50    2.00    1.00        A
Longest path cycles:          N/A     N/A     N/A      N/A

A = Arithmetic, LS = Load/Store, T = Texture

Shader properties
=================

Has uniform computation: false



[Mali-T720]
Main shader
===========

- Work registers: 4 (100% used at 100% occupancy)
+ Work registers: 3 (75% used at 100% occupancy)
- Uniform registers: 2 (10% used)
+ Uniform registers: 2 (9% used)
Stack spilling: false

                                A      LS       T    Bound
- Total instruction cycles:   63.00    2.00    2.00        A
+ Total instruction cycles:   14.00    2.00    2.00        A
- Shortest path cycles:        8.75    2.00    0.00        A
+ Shortest path cycles:        5.50    2.00    1.00        A
Longest path cycles:          N/A     N/A     N/A      N/A

A = Arithmetic, LS = Load/Store, T = Texture


[Mali-G78AE]
Main shader
===========

- Work registers: 20 (62% used at 100% occupancy)
+ Work registers: 19 (59% used at 100% occupancy)
- Uniform registers: 16 (25% used)
+ Uniform registers: 12 (18% used)
Stack spilling: false
- 16-bit arithmetic: 91%
+ 16-bit arithmetic: 76%

                                A      LS       V       T    Bound
- Total instruction cycles:    1.55    0.00    0.25    0.50        A
+ Total instruction cycles:    0.33    0.00    0.50    0.50     V, T
- Shortest path cycles:        0.27    0.00    0.12    0.00        A
+ Shortest path cycles:        0.12    0.00    0.25    0.25     V, T
Longest path cycles:          N/A     N/A     N/A     N/A      N/A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

Has uniform computation: true
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G78]
Main shader
===========

- Work registers: 20 (62% used at 100% occupancy)
+ Work registers: 19 (59% used at 100% occupancy)
- Uniform registers: 16 (25% used)
+ Uniform registers: 12 (18% used)
Stack spilling: false
- 16-bit arithmetic: 91%
+ 16-bit arithmetic: 76%

                                A      LS       V       T    Bound
- Total instruction cycles:    1.55    0.00    0.25    0.50        A
+ Total instruction cycles:    0.33    0.00    0.50    0.50     V, T
- Shortest path cycles:        0.27    0.00    0.12    0.00        A
+ Shortest path cycles:        0.12    0.00    0.25    0.25     V, T
Longest path cycles:          N/A     N/A     N/A     N/A      N/A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

Has uniform computation: true
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G77]
Main shader
===========

- Work registers: 20 (62% used at 100% occupancy)
+ Work registers: 19 (59% used at 100% occupancy)
- Uniform registers: 16 (25% used)
+ Uniform registers: 12 (18% used)
Stack spilling: false
- 16-bit arithmetic: 91%
+ 16-bit arithmetic: 76%

                                A      LS       V       T    Bound
- Total instruction cycles:    1.55    0.00    0.25    0.50        A
+ Total instruction cycles:    0.33    0.00    0.50    0.50     V, T
- Shortest path cycles:        0.27    0.00    0.12    0.00        A
+ Shortest path cycles:        0.12    0.00    0.25    0.25     V, T
Longest path cycles:          N/A     N/A     N/A     N/A      N/A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

Has uniform computation: true
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G76]
Main shader
===========

Work registers: 20 (62% used at 100% occupancy)
- Uniform registers: 18 (28% used)
+ Uniform registers: 12 (18% used)
Stack spilling: false
- 16-bit arithmetic: 91%
+ 16-bit arithmetic: 68%

                                A      LS       V       T    Bound
- Total instruction cycles:    4.53    0.00    0.25    1.00        A
+ Total instruction cycles:    1.21    0.00    0.50    1.00        A
- Shortest path cycles:        0.96    0.00    0.12    0.00        A
+ Shortest path cycles:        0.67    0.00    0.25    0.50        A
Longest path cycles:          N/A     N/A     N/A     N/A      N/A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

Has uniform computation: true
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G72]
Main shader
===========

- Work registers: 22 (68% used at 100% occupancy)
+ Work registers: 21 (65% used at 100% occupancy)
- Uniform registers: 18 (28% used)
+ Uniform registers: 12 (18% used)
Stack spilling: false
- 16-bit arithmetic: 91%
+ 16-bit arithmetic: 68%

                                A      LS       V       T    Bound
- Total instruction cycles:    9.27    0.00    0.50    2.00        A
+ Total instruction cycles:    2.42    0.00    1.00    2.00        A
- Shortest path cycles:        1.92    0.00    0.25    0.00        A
+ Shortest path cycles:        1.33    0.00    0.50    1.00        A
Longest path cycles:          N/A     N/A     N/A     N/A      N/A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

Has uniform computation: true
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G715]
Main shader
===========

- Work registers: 20 (62% used at 100% occupancy)
+ Work registers: 19 (59% used at 100% occupancy)
- Uniform registers: 16 (25% used)
+ Uniform registers: 12 (18% used)
Stack spilling: false
- 16-bit arithmetic: 72%
+ 16-bit arithmetic: 76%

                                A      LS       V       T    Bound
- Total instruction cycles:    0.82    0.00    0.06    0.25        A
+ Total instruction cycles:    0.14    0.00    0.12    0.25        T
- Shortest path cycles:        0.15    0.00    0.03    0.00        A
+ Shortest path cycles:        0.06    0.00    0.06    0.12        T
Longest path cycles:          N/A     N/A     N/A     N/A      N/A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

Has uniform computation: true
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G710]
Main shader
===========

- Work registers: 20 (62% used at 100% occupancy)
+ Work registers: 19 (59% used at 100% occupancy)
- Uniform registers: 16 (25% used)
+ Uniform registers: 12 (18% used)
Stack spilling: false
- 16-bit arithmetic: 91%
+ 16-bit arithmetic: 76%

                                A      LS       V       T    Bound
- Total instruction cycles:    1.20    0.00    0.12    0.25        A
+ Total instruction cycles:    0.29    0.00    0.25    0.25        A
- Shortest path cycles:        0.22    0.00    0.06    0.00        A
+ Shortest path cycles:        0.12    0.00    0.12    0.12     V, T
Longest path cycles:          N/A     N/A     N/A     N/A      N/A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

Has uniform computation: true
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G71]
Main shader
===========

- Work registers: 21 (65% used at 100% occupancy)
+ Work registers: 20 (62% used at 100% occupancy)
- Uniform registers: 20 (31% used)
+ Uniform registers: 14 (21% used)
Stack spilling: false
- 16-bit arithmetic: 85%
+ 16-bit arithmetic: 60%

                                A      LS       V       T    Bound
- Total instruction cycles:    9.83    0.00    0.50    2.00        A
+ Total instruction cycles:    2.67    0.00    1.00    2.00        A
- Shortest path cycles:        1.83    0.00    0.25    0.00        A
+ Shortest path cycles:        1.33    0.00    0.50    1.00        A
Longest path cycles:          N/A     N/A     N/A     N/A      N/A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

Has uniform computation: true
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G68]
Main shader
===========

- Work registers: 20 (62% used at 100% occupancy)
+ Work registers: 19 (59% used at 100% occupancy)
- Uniform registers: 16 (25% used)
+ Uniform registers: 12 (18% used)
Stack spilling: false
- 16-bit arithmetic: 91%
+ 16-bit arithmetic: 76%

                                A      LS       V       T    Bound
- Total instruction cycles:    1.55    0.00    0.25    0.50        A
+ Total instruction cycles:    0.33    0.00    0.50    0.50     V, T
- Shortest path cycles:        0.27    0.00    0.12    0.00        A
+ Shortest path cycles:        0.12    0.00    0.25    0.25     V, T
Longest path cycles:          N/A     N/A     N/A     N/A      N/A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

Has uniform computation: true
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G615]
Main shader
===========

- Work registers: 20 (62% used at 100% occupancy)
+ Work registers: 19 (59% used at 100% occupancy)
- Uniform registers: 16 (25% used)
+ Uniform registers: 12 (18% used)
Stack spilling: false
- 16-bit arithmetic: 72%
+ 16-bit arithmetic: 76%

                                A      LS       V       T    Bound
- Total instruction cycles:    0.82    0.00    0.06    0.25        A
+ Total instruction cycles:    0.14    0.00    0.12    0.25        T
- Shortest path cycles:        0.15    0.00    0.03    0.00        A
+ Shortest path cycles:        0.06    0.00    0.06    0.12        T
Longest path cycles:          N/A     N/A     N/A     N/A      N/A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

Has uniform computation: true
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G610]
Main shader
===========

- Work registers: 20 (62% used at 100% occupancy)
+ Work registers: 19 (59% used at 100% occupancy)
- Uniform registers: 16 (25% used)
+ Uniform registers: 12 (18% used)
Stack spilling: false
- 16-bit arithmetic: 91%
+ 16-bit arithmetic: 76%

                                A      LS       V       T    Bound
- Total instruction cycles:    1.20    0.00    0.12    0.25        A
+ Total instruction cycles:    0.29    0.00    0.25    0.25        A
- Shortest path cycles:        0.22    0.00    0.06    0.00        A
+ Shortest path cycles:        0.12    0.00    0.12    0.12     V, T
Longest path cycles:          N/A     N/A     N/A     N/A      N/A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

Has uniform computation: true
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G57]
Main shader
===========

- Work registers: 20 (62% used at 100% occupancy)
+ Work registers: 19 (59% used at 100% occupancy)
- Uniform registers: 16 (25% used)
+ Uniform registers: 12 (18% used)
Stack spilling: false
- 16-bit arithmetic: 91%
+ 16-bit arithmetic: 76%

                                A      LS       V       T    Bound
- Total instruction cycles:    1.55    0.00    0.25    0.50        A
+ Total instruction cycles:    0.33    0.00    0.50    0.50     V, T
- Shortest path cycles:        0.27    0.00    0.12    0.00        A
+ Shortest path cycles:        0.12    0.00    0.25    0.25     V, T
Longest path cycles:          N/A     N/A     N/A     N/A      N/A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

Has uniform computation: true
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G52]
Main shader
===========

Work registers: 20 (62% used at 100% occupancy)
- Uniform registers: 18 (28% used)
+ Uniform registers: 12 (18% used)
Stack spilling: false
- 16-bit arithmetic: 91%
+ 16-bit arithmetic: 68%

                                A      LS       V       T    Bound
- Total instruction cycles:    4.53    0.00    0.25    1.00        A
+ Total instruction cycles:    1.21    0.00    0.50    1.00        A
- Shortest path cycles:        0.96    0.00    0.12    0.00        A
+ Shortest path cycles:        0.67    0.00    0.25    0.50        A
Longest path cycles:          N/A     N/A     N/A     N/A      N/A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

Has uniform computation: true
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G510]
Main shader
===========

- Work registers: 20 (62% used at 100% occupancy)
+ Work registers: 19 (59% used at 100% occupancy)
- Uniform registers: 16 (25% used)
+ Uniform registers: 12 (18% used)
Stack spilling: false
- 16-bit arithmetic: 91%
+ 16-bit arithmetic: 76%

                                A      LS       V       T    Bound
- Total instruction cycles:    1.60    0.00    0.12    0.25        A
+ Total instruction cycles:    0.39    0.00    0.25    0.25        A
- Shortest path cycles:        0.29    0.00    0.06    0.00        A
+ Shortest path cycles:        0.16    0.00    0.12    0.12        A
Longest path cycles:          N/A     N/A     N/A     N/A      N/A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

Has uniform computation: true
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G51]
Main shader
===========

- Work registers: 20 (62% used at 100% occupancy)
+ Work registers: 21 (65% used at 100% occupancy)
- Uniform registers: 18 (28% used)
+ Uniform registers: 12 (18% used)
Stack spilling: false
- 16-bit arithmetic: 91%
+ 16-bit arithmetic: 68%

                                A      LS       V       T    Bound
- Total instruction cycles:    9.07    0.00    0.25    1.00        A
+ Total instruction cycles:    2.42    0.00    0.50    1.00        A
- Shortest path cycles:        1.92    0.00    0.12    0.00        A
+ Shortest path cycles:        1.33    0.00    0.25    0.50        A
Longest path cycles:          N/A     N/A     N/A     N/A      N/A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

Has uniform computation: true
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G310]
Main shader
===========

- Work registers: 20 (62% used at 100% occupancy)
+ Work registers: 19 (59% used at 100% occupancy)
- Uniform registers: 16 (25% used)
+ Uniform registers: 12 (18% used)
Stack spilling: false
- 16-bit arithmetic: 91%
+ 16-bit arithmetic: 76%

                                A      LS       V       T    Bound
- Total instruction cycles:    2.41    0.00    0.25    0.50        A
+ Total instruction cycles:    0.58    0.00    0.50    0.50        A
- Shortest path cycles:        0.44    0.00    0.12    0.00        A
+ Shortest path cycles:        0.23    0.00    0.25    0.25     V, T
Longest path cycles:          N/A     N/A     N/A     N/A      N/A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

Has uniform computation: true
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Mali-G31]
Main shader
===========

- Work registers: 20 (62% used at 100% occupancy)
+ Work registers: 21 (65% used at 100% occupancy)
- Uniform registers: 18 (28% used)
+ Uniform registers: 12 (18% used)
Stack spilling: false
- 16-bit arithmetic: 91%
+ 16-bit arithmetic: 68%

                                A      LS       V       T    Bound
- Total instruction cycles:   13.60    0.00    0.25    1.00        A
+ Total instruction cycles:    3.62    0.00    0.50    1.00        A
- Shortest path cycles:        2.88    0.00    0.12    0.00        A
+ Shortest path cycles:        2.00    0.00    0.25    0.50        A
Longest path cycles:          N/A     N/A     N/A     N/A      N/A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

Has uniform computation: true
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false



[Immortalis-G715]
Main shader
===========

- Work registers: 20 (62% used at 100% occupancy)
+ Work registers: 19 (59% used at 100% occupancy)
- Uniform registers: 16 (25% used)
+ Uniform registers: 12 (18% used)
Stack spilling: false
- 16-bit arithmetic: 72%
+ 16-bit arithmetic: 76%

                                A      LS       V       T    Bound
- Total instruction cycles:    0.82    0.00    0.06    0.25        A
+ Total instruction cycles:    0.14    0.00    0.12    0.25        T
- Shortest path cycles:        0.15    0.00    0.03    0.00        A
+ Shortest path cycles:        0.06    0.00    0.06    0.12        T
Longest path cycles:          N/A     N/A     N/A     N/A      N/A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture

Shader properties
=================

Has uniform computation: true
Has side-effects: false
Modifies coverage: false
Uses late ZS test: false
Uses late ZS update: false
Reads color buffer: false


```


</details>