### PR TITLE
[impellerc] speculative fix for include errors with impellerc shader lib

### DIFF
--- a/impeller/compiler/switches.cc
+++ b/impeller/compiler/switches.cc
@@ -7,7 +7,6 @@
 #include <algorithm>
 #include <cctype>
 #include <filesystem>
-#include <iostream>
 #include <map>
 
 #include "flutter/fml/file.h"

--- a/impeller/compiler/switches.cc
+++ b/impeller/compiler/switches.cc
@@ -8,6 +8,7 @@
 #include <cctype>
 #include <filesystem>
 #include <map>
+#include <iostream>
 
 #include "flutter/fml/file.h"
 #include "impeller/compiler/types.h"
@@ -156,9 +157,14 @@ Switches::Switches(const fml::CommandLine& command_line)
     // Note that the `include_dir_path` is already utf8 encoded, and so we
     // mustn't attempt to double-convert it to utf8 lest multi-byte characters
     // will become mangled.
-    auto cwd = Utf8FromPath(std::filesystem::current_path());
-    auto include_dir_absolute = std::filesystem::absolute(
-        std::filesystem::path(cwd) / include_dir_path);
+    std::filesystem::path include_dir_absolute;
+    if (std::filesystem::path(include_dir_path).is_absolute()) {
+      include_dir_absolute = std::filesystem::path(include_dir_path);
+    } else {
+      auto cwd = Utf8FromPath(std::filesystem::current_path());
+      include_dir_absolute = std::filesystem::absolute(
+          std::filesystem::path(cwd) / include_dir_path);
+    }
 
     auto dir = std::make_shared<fml::UniqueFD>(fml::OpenDirectoryReadOnly(
         *working_directory, include_dir_absolute.string().c_str()));

--- a/impeller/compiler/switches.cc
+++ b/impeller/compiler/switches.cc
@@ -7,8 +7,8 @@
 #include <algorithm>
 #include <cctype>
 #include <filesystem>
-#include <map>
 #include <iostream>
+#include <map>
 
 #include "flutter/fml/file.h"
 #include "impeller/compiler/types.h"


### PR DESCRIPTION
Part of a speculative fix I'm making for https://github.com/flutter/flutter/issues/115433. If the path is already absolute, don't convert again. probably does nothing. 🤷 