### PR TITLE
`CommandPoolVK` allows for safely creating and freeing command buffers

### DIFF
--- a/impeller/renderer/backend/vulkan/command_buffer_vk.cc
+++ b/impeller/renderer/backend/vulkan/command_buffer_vk.cc
@@ -21,13 +21,13 @@ namespace impeller {
 std::shared_ptr<CommandBufferVK> CommandBufferVK::Create(
     const std::weak_ptr<const Context>& context_arg,
     vk::Device device,
-    vk::CommandPool command_pool) {
+    std::shared_ptr<CommandPoolVK> command_pool) {
   if (auto context = context_arg.lock()) {
     auto queue =
         reinterpret_cast<const ContextVK*>(context.get())->GetGraphicsQueue();
     auto fenced_command_buffer =
         std::make_shared<FencedCommandBufferVK>(device, queue, command_pool);
-    return std::make_shared<CommandBufferVK>(context, device, command_pool,
+    return std::make_shared<CommandBufferVK>(context, device,
                                              fenced_command_buffer);
   } else {
     return nullptr;
@@ -37,11 +37,9 @@ std::shared_ptr<CommandBufferVK> CommandBufferVK::Create(
 CommandBufferVK::CommandBufferVK(
     std::weak_ptr<const Context> context,
     vk::Device device,
-    vk::CommandPool command_pool,
     std::shared_ptr<FencedCommandBufferVK> command_buffer)
     : CommandBuffer(std::move(context)),
       device_(device),
-      command_pool_(command_pool),
       fenced_command_buffer_(std::move(command_buffer)) {
   is_valid_ = true;
 }

--- a/impeller/renderer/backend/vulkan/command_buffer_vk.h
+++ b/impeller/renderer/backend/vulkan/command_buffer_vk.h
@@ -17,11 +17,10 @@ class CommandBufferVK final : public CommandBuffer {
   static std::shared_ptr<CommandBufferVK> Create(
       const std::weak_ptr<const Context>& context,
       vk::Device device,
-      vk::CommandPool command_pool);
+      std::shared_ptr<CommandPoolVK> command_pool);
 
   CommandBufferVK(std::weak_ptr<const Context> context,
                   vk::Device device,
-                  vk::CommandPool command_pool,
                   std::shared_ptr<FencedCommandBufferVK> command_buffer);
 
   // |CommandBuffer|
@@ -31,7 +30,6 @@ class CommandBufferVK final : public CommandBuffer {
   friend class ContextVK;
 
   vk::Device device_;
-  vk::CommandPool command_pool_;
   vk::UniqueRenderPass render_pass_;
   std::shared_ptr<FencedCommandBufferVK> fenced_command_buffer_;
   bool is_valid_ = false;

--- a/impeller/renderer/backend/vulkan/command_pool_vk.h
+++ b/impeller/renderer/backend/vulkan/command_pool_vk.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <mutex>
+
 #include "flutter/fml/macros.h"
 #include "impeller/renderer/backend/vulkan/vk.h"
 
@@ -11,16 +13,20 @@ namespace impeller {
 
 class CommandPoolVK {
  public:
-  static std::unique_ptr<CommandPoolVK> Create(vk::Device device,
+  static std::shared_ptr<CommandPoolVK> Create(vk::Device device,
                                                uint32_t queue_index);
 
-  explicit CommandPoolVK(vk::UniqueCommandPool command_pool);
+  CommandPoolVK(vk::Device device, vk::UniqueCommandPool command_pool);
 
   ~CommandPoolVK();
 
-  vk::CommandPool Get() const;
+  vk::CommandBuffer CreateCommandBuffer();
+
+  void FreeCommandBuffers(const std::vector<vk::CommandBuffer>& buffers);
 
  private:
+  vk::Device device_;
+  std::mutex pool_mutex_;
   vk::UniqueCommandPool command_pool_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(CommandPoolVK);

--- a/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/impeller/renderer/backend/vulkan/context_vk.cc
@@ -526,7 +526,7 @@ std::shared_ptr<WorkQueue> ContextVK::GetWorkQueue() const {
 
 std::shared_ptr<CommandBuffer> ContextVK::CreateCommandBuffer() const {
   return CommandBufferVK::Create(weak_from_this(), *device_,
-                                 graphics_command_pool_->Get());
+                                 graphics_command_pool_);
 }
 
 vk::Instance ContextVK::GetInstance() const {

--- a/impeller/renderer/backend/vulkan/context_vk.h
+++ b/impeller/renderer/backend/vulkan/context_vk.h
@@ -111,7 +111,7 @@ class ContextVK final : public Context, public BackendCast<ContextVK, Context> {
   vk::UniqueSurfaceKHR surface_;
   vk::Format surface_format_;
   std::unique_ptr<SwapchainVK> swapchain_;
-  std::unique_ptr<CommandPoolVK> graphics_command_pool_;
+  std::shared_ptr<CommandPoolVK> graphics_command_pool_;
   std::unique_ptr<SurfaceProducerVK> surface_producer_;
   std::shared_ptr<WorkQueue> work_queue_;
   bool is_valid_ = false;

--- a/impeller/renderer/backend/vulkan/fenced_command_buffer_vk.h
+++ b/impeller/renderer/backend/vulkan/fenced_command_buffer_vk.h
@@ -7,6 +7,7 @@
 #include <memory>
 
 #include "flutter/fml/macros.h"
+#include "impeller/renderer/backend/vulkan/command_pool_vk.h"
 #include "impeller/renderer/backend/vulkan/deletion_queue_vk.h"
 #include "impeller/renderer/backend/vulkan/vk.h"
 
@@ -16,7 +17,7 @@ class FencedCommandBufferVK {
  public:
   FencedCommandBufferVK(vk::Device device,
                         vk::Queue queue,
-                        vk::CommandPool command_pool);
+                        std::shared_ptr<CommandPoolVK> command_pool);
 
   ~FencedCommandBufferVK();
 
@@ -32,7 +33,7 @@ class FencedCommandBufferVK {
  private:
   vk::Device device_;
   vk::Queue queue_;
-  vk::CommandPool command_pool_;
+  std::shared_ptr<CommandPoolVK> command_pool_;
   std::unique_ptr<DeletionQueueVK> deletion_queue_;
   vk::CommandBuffer command_buffer_;
   std::vector<vk::CommandBuffer> children_;


### PR DESCRIPTION
This fixes the validation errors:

```
Check failed: false. Error[337425955][UNASSIGNED-Threading-MultipleThreads] : Validation Error: [ UNASSIGNED-Threading-MultipleThreads ] Object 0: handle = 0x59ffe0000000003d, type = VK_OBJECT_TYPE_COMMAND_POOL; | MessageID = 0x141cb623 | THREADING ERROR : vkFreeCommandBuffers(): object of type VkCommandPool is simultaneously used in thread 471586061488 and thread 471275924656'
```
