### PR TITLE
[gn] embed mac codesign metadata in android artifacts

### DIFF
--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -594,9 +594,7 @@ zip_bundle("android_javadoc") {
 
 generated_file("android_entitlement_config") {
   outputs = [ "$target_gen_dir/android_entitlements.txt" ]
-  contents = [
-    "gen_snapshot"
-  ]
+  contents = [ "gen_snapshot" ]
   deps = []
 }
 
@@ -656,12 +654,14 @@ if (target_cpu != "x86") {
 
     deps = [ "//third_party/dart/runtime/bin:gen_snapshot($host_toolchain)" ]
 
-    if(host_os == "mac"){
-        deps += [":android_entitlement_config"]
-        files += [{
-            source = "$target_gen_dir/android_entitlements.txt"
-            destination = "entitlements.txt"
-        },]
+    if (host_os == "mac") {
+      deps += [ ":android_entitlement_config" ]
+      files += [
+        {
+          source = "$target_gen_dir/android_entitlements.txt"
+          destination = "entitlements.txt"
+        },
+      ]
     }
   }
 }

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -592,6 +592,14 @@ zip_bundle("android_javadoc") {
   deps = [ ":gen_android_javadoc" ]
 }
 
+generated_file("android_entitlement_config") {
+  outputs = [ "$target_gen_dir/android_entitlements.txt" ]
+  contents = [
+    "gen_snapshot"
+  ]
+  deps = []
+}
+
 if (target_cpu != "x86") {
   zip_bundle("gen_snapshot") {
     gen_snapshot_bin = "gen_snapshot"
@@ -647,6 +655,14 @@ if (target_cpu != "x86") {
     ]
 
     deps = [ "//third_party/dart/runtime/bin:gen_snapshot($host_toolchain)" ]
+
+    if(host_os == "mac"){
+        deps += [":android_entitlement_config"]
+        files += [{
+            source = "$target_gen_dir/android_entitlements.txt"
+            destination = "entitlements.txt"
+        },]
+    }
   }
 }
 


### PR DESCRIPTION
Embeds mac codesign metadata in android artifacts. TLDR: metadata is embedded at top level as opposed to attached to leaf nodes.

The metadata isn't attached to the leaf nodes of build rules, because of the different gen_snapshot_(host tool chain) variations. As pointed out by Zach, in engine v1, not all andriod snapshots are generated through android build rules. For example, windows android snapshots are copied to a common path `"$root_build_dir/gen_snapshot/gen_snapshot.exe"`, and used out of the android gn file. In engine v2, all android snapshots are generated via the shell/platform/android build rules, and therefore it is good to embed a top level metadata. Since we only care about mac codesign metadata, windows gen snapshot entry points might not be relevant.