### PR TITLE
[Impeller] Cleanup shader generation and specify min macOS version.

### DIFF
--- a/impeller/tools/build_metal_library.py
+++ b/impeller/tools/build_metal_library.py
@@ -54,9 +54,7 @@ def main():
   ]
 
   # Select the SDK.
-  command += [
-    '-sdk'
-  ]
+  command += ['-sdk']
   if args.platform == 'mac':
     command += [
         'macosx',

--- a/impeller/tools/build_metal_library.py
+++ b/impeller/tools/build_metal_library.py
@@ -39,12 +39,6 @@ def main():
       help='The source file to compile. Can be specified multiple times.'
   )
   parser.add_argument(
-      '--optimize',
-      action='store_true',
-      default=False,
-      help='If available optimizations must be applied to the compiled Metal sources.'
-  )
-  parser.add_argument(
       '--platform',
       required=True,
       choices=['mac', 'ios', 'ios-simulator'],
@@ -59,73 +53,61 @@ def main():
       'xcrun',
   ]
 
+  # Select the SDK.
+  command += [
+    '-sdk'
+  ]
   if args.platform == 'mac':
     command += [
-        '-sdk',
         'macosx',
     ]
   elif args.platform == 'ios':
     command += [
-        '-sdk',
         'iphoneos',
     ]
   elif args.platform == 'ios-simulator':
     command += [
-        '-sdk',
         'iphonesimulator',
     ]
+  else:
+    raise 'Unknown target platform'
 
   command += [
       'metal',
-      # These warnings are from generated code and would make no sense to the GLSL
-      # author.
+      # These warnings are from generated code and would make no sense to the
+      # GLSL author.
       '-Wno-unused-variable',
       # Both user and system header will be tracked.
       '-MMD',
+      # Like -Os (and thus -O2), but reduces code size further.
+      '-Oz',
+      # Allow aggressive, lossy floating-point optimizations.
+      '-ffast-math',
       '-MF',
       args.depfile,
       '-o',
       args.output,
   ]
 
+  # Select the Metal standard and the minimum supported OS versions.
   # The Metal standard must match the specification in impellerc.
   if args.platform == 'mac':
     command += [
         '--std=macos-metal1.2',
+        '-mmacos-version-min=10.14',
     ]
-
-  if args.optimize:
+  elif args.platform == 'ios':
     command += [
-        # Like -Os (and thus -O2), but reduces code size further.
-        '-Oz',
-        # Allow aggressive, lossy floating-point optimizations.
-        '-ffast-math',
-        # limiting to ios-metal1.2 disables shader debug symbols, only
-        # enabling these in optimize mode.
-        # see https://github.com/flutter/flutter/issues/106066
         '--std=ios-metal1.2',
+        '-mios-version-min=10.0',
     ]
-    if args.platform == 'ios':
-      command += [
-          '-mios-version-min=10.0',
-      ]
-    elif args.platform == 'ios-simulator':
-      command += [
-          '-miphonesimulator-version-min=11.0',
-      ]
-  else:
+  elif args.platform == 'ios-simulator':
     command += [
-        # Embeds both sources and driver options in the output. This aids in
-        # debugging but should be removed from release builds.
-        # TODO(chinmaygarde): Use -frecord-sources when CI upgrades to
-        # Xcode 13.
-        '-MO',
-        # Assist the sampling profiler.
-        '-gline-tables-only',
-        '-g',
-        # Optimize for debuggability.
-        '-Og',
+        '--std=ios-metal1.2',
+        '-miphonesimulator-version-min=11.0',
     ]
+  else:
+    raise 'Unknown target platform'
 
   command += args.source
 

--- a/impeller/tools/impeller.gni
+++ b/impeller/tools/impeller.gni
@@ -135,10 +135,6 @@ template("metal_library") {
       rebase_path(depfile),
     ]
 
-    if (!is_debug) {
-      args += [ "--optimize" ]
-    }
-
     if (is_ios) {
       if (use_ios_simulator) {
         args += [ "--platform=ios-simulator" ]


### PR DESCRIPTION
We used to add workarounds for https://github.com/flutter/flutter/issues/106066.

However, that issue has been resolved. But the workarounds made it so that unopt local engine builds would build inconsistent shaders. Also, the mac builds would specify the iOS as well mac shader standards to the compiler. The mac target also never got a min OS version.

The script has been cleaned up for readability.