### PR TITLE
[embedder] Ensure FlutterMetalTexture cleanup call

### DIFF
--- a/shell/gpu/gpu_surface_metal_delegate.h
+++ b/shell/gpu/gpu_surface_metal_delegate.h
@@ -26,9 +26,13 @@ typedef void* GPUCAMetalLayerHandle;
 // expected to be id<MTLTexture>
 typedef const void* GPUMTLTextureHandle;
 
+typedef void (*GPUMTLDestructionCallback)(void* /* destruction_context */);
+
 struct GPUMTLTextureInfo {
   int64_t texture_id;
   GPUMTLTextureHandle texture;
+  GPUMTLDestructionCallback destruction_callback;
+  void* destruction_context;
 };
 
 enum class MTLRenderTargetType { kMTLTexture, kCAMetalLayer };

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -477,6 +477,8 @@ InferMetalPlatformViewCreationCallback(
     FlutterMetalTexture metal_texture = ptr(user_data, &frame_info);
     texture_info.texture_id = metal_texture.texture_id;
     texture_info.texture = metal_texture.texture;
+    texture_info.destruction_callback = metal_texture.destruction_callback;
+    texture_info.destruction_context = metal_texture.user_data;
     return texture_info;
   };
 

--- a/shell/platform/embedder/fixtures/main.dart
+++ b/shell/platform/embedder/fixtures/main.dart
@@ -498,6 +498,25 @@ void can_composite_platform_views_with_platform_layer_on_bottom() {
   PlatformDispatcher.instance.scheduleFrame();
 }
 
+@pragma('vm:external-name', 'SignalBeginFrame')
+external void signalBeginFrame();
+
+@pragma('vm:entry-point')
+void texture_destruction_callback_called_without_custom_compositor() async {
+  PlatformDispatcher.instance.onBeginFrame = (Duration duration) {
+    Color red = Color.fromARGB(127, 255, 0, 0);
+    Size size = Size(50.0, 150.0);
+    SceneBuilder builder = SceneBuilder();
+    builder.pushOffset(0.0, 0.0);
+    builder.addPicture(
+        Offset(10.0, 10.0), CreateColoredBox(red, size)); // red - flutter
+    builder.pop();
+    PlatformDispatcher.instance.views.first.render(builder.build());
+  };
+  PlatformDispatcher.instance.scheduleFrame();
+}
+
+
 @pragma('vm:entry-point')
 void can_render_scene_without_custom_compositor() {
   PlatformDispatcher.instance.onBeginFrame = (Duration duration) {

--- a/shell/platform/embedder/tests/embedder_test_context_metal.cc
+++ b/shell/platform/embedder/tests/embedder_test_context_metal.cc
@@ -71,10 +71,22 @@ bool EmbedderTestContextMetal::PopulateExternalTexture(
   }
 }
 
+TestMetalContext::TextureInfo EmbedderTestContextMetal::GetTextureInfo() {
+  return metal_surface_->GetTextureInfo();
+}
+
+void EmbedderTestContextMetal::SetNextDrawableCallback(
+    NextDrawableCallback next_drawable_callback) {
+  next_drawable_callback_ = std::move(next_drawable_callback);
+}
+
 FlutterMetalTexture EmbedderTestContextMetal::GetNextDrawable(
     const FlutterFrameInfo* frame_info) {
-  auto texture_info = metal_surface_->GetTextureInfo();
+  if (next_drawable_callback_ != nullptr) {
+    return next_drawable_callback_(frame_info);
+  }
 
+  auto texture_info = metal_surface_->GetTextureInfo();
   FlutterMetalTexture texture;
   texture.struct_size = sizeof(FlutterMetalTexture);
   texture.texture_id = texture_info.texture_id;

--- a/shell/platform/embedder/tests/embedder_test_context_metal.h
+++ b/shell/platform/embedder/tests/embedder_test_context_metal.h
@@ -20,6 +20,9 @@ class EmbedderTestContextMetal : public EmbedderTestContext {
                          size_t h,
                          FlutterMetalExternalTexture* output)>;
 
+  using NextDrawableCallback =
+      std::function<FlutterMetalTexture(const FlutterFrameInfo* frame_info)>;
+
   explicit EmbedderTestContextMetal(std::string assets_path = "");
 
   ~EmbedderTestContextMetal() override;
@@ -45,6 +48,12 @@ class EmbedderTestContextMetal : public EmbedderTestContext {
 
   TestMetalContext* GetTestMetalContext();
 
+  // Returns the TextureInfo for the test Metal surface.
+  TestMetalContext::TextureInfo GetTextureInfo();
+
+  // Override the default handling for GetNextDrawable.
+  void SetNextDrawableCallback(NextDrawableCallback next_drawable_callback);
+
   FlutterMetalTexture GetNextDrawable(const FlutterFrameInfo* frame_info);
 
  private:
@@ -56,6 +65,7 @@ class EmbedderTestContextMetal : public EmbedderTestContext {
   std::unique_ptr<TestMetalContext> metal_context_;
   std::unique_ptr<TestMetalSurface> metal_surface_;
   size_t present_count_ = 0;
+  NextDrawableCallback next_drawable_callback_ = nullptr;
 
   void SetupSurface(SkISize surface_size) override;
 


### PR DESCRIPTION
This ensures `FlutterMetalTexture.destruction_callback` gets called.

`FlutterRendererConfig.get_next_drawable_callback` holds a callback used by the embedder API to request a drawable; in the case of Metal, this drawable is a FlutterMetalTexture.

`FlutterMetalTexture.destruction_callback` should be called when it's safe to release resources associated with the `FlutterMetalTexture`. This callback is not currently invoked for textures returned via `FlutterRendererConfig.get_next_drawable_callback`; instead we unpack the returned struct and pass it on.

In the compositor codepath, we do create an `SkSurface` that triggers the destruction callback, here:
https://github.com/flutter/engine/blob/303e26e96561d9b76f2344e97a5fc32eb6dfdb9a/shell/platform/embedder/embedder.cc#L868-L881

Issue: https://github.com/flutter/flutter/issues/116381

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
