### PR TITLE
[iOS] Change locale format for spell check

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterSpellCheckPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterSpellCheckPlugin.mm
@@ -63,7 +63,7 @@ static NSString* const kInitiateSpellCheck = @"SpellCheck.initiateSpellCheck";
                                                                    inLanguage:(NSString*)language {
   // Transform Dart Locale format to iOS language format.
   NSArray<NSString*>* languageCodes = [language componentsSeparatedByString:@"-"];
-  NSString lastCode = [[languageCodes lastObject] uppercaseString];
+  NSString* lastCode = [[languageCodes lastObject] uppercaseString];
   language = [NSString stringWithFormat:@"%@_%@", [languageCodes firstObject], lastCode];
 
   if (![UITextChecker.availableLanguages containsObject:language]) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterSpellCheckPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterSpellCheckPlugin.mm
@@ -64,6 +64,7 @@ static NSString* const kInitiateSpellCheck = @"SpellCheck.initiateSpellCheck";
   // Transform Dart Locale format to iOS language format if necessary.
   if ([language containsString:@"-"]) {
     NSArray<NSString*>* languageCodes = [language componentsSeparatedByString:@"-"];
+    FML_DCHECK(languageCodes.count == 2);
     NSString* lastCode = [[languageCodes lastObject] uppercaseString];
     language = [NSString stringWithFormat:@"%@_%@", [languageCodes firstObject], lastCode];
   }

--- a/shell/platform/darwin/ios/framework/Source/FlutterSpellCheckPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterSpellCheckPlugin.mm
@@ -62,7 +62,10 @@ static NSString* const kInitiateSpellCheck = @"SpellCheck.initiateSpellCheck";
 - (NSArray<NSDictionary<NSString*, id>*>*)findAllSpellCheckSuggestionsForText:(NSString*)text
                                                                    inLanguage:(NSString*)language {
   // Transform Dart Locale format to iOS language format.
-  language = [language stringByReplacingOccurrencesOfString:@"-" withString:@"_"];
+  NSArray<NSString*>* languageCodes = [language componentsSeparatedByString:@"-"];
+  NSString lastCode = [[languageCodes lastObject] uppercaseString];
+  language = [NSString stringWithFormat:@"%@_%@", [languageCodes firstObject], lastCode];
+
   if (![UITextChecker.availableLanguages containsObject:language]) {
     return nil;
   }

--- a/shell/platform/darwin/ios/framework/Source/FlutterSpellCheckPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterSpellCheckPlugin.mm
@@ -61,10 +61,12 @@ static NSString* const kInitiateSpellCheck = @"SpellCheck.initiateSpellCheck";
 // Returns an empty array if no spell check suggestions.
 - (NSArray<NSDictionary<NSString*, id>*>*)findAllSpellCheckSuggestionsForText:(NSString*)text
                                                                    inLanguage:(NSString*)language {
-  // Transform Dart Locale format to iOS language format.
-  NSArray<NSString*>* languageCodes = [language componentsSeparatedByString:@"-"];
-  NSString* lastCode = [[languageCodes lastObject] uppercaseString];
-  language = [NSString stringWithFormat:@"%@_%@", [languageCodes firstObject], lastCode];
+  // Transform Dart Locale format to iOS language format if necessary.
+  if ([language containsString:@"-"]) {
+    NSArray<NSString*>* languageCodes = [language componentsSeparatedByString:@"-"];
+    NSString* lastCode = [[languageCodes lastObject] uppercaseString];
+    language = [NSString stringWithFormat:@"%@_%@", [languageCodes firstObject], lastCode];
+  }
 
   if (![UITextChecker.availableLanguages containsObject:language]) {
     return nil;

--- a/shell/platform/darwin/ios/framework/Source/FlutterSpellCheckPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterSpellCheckPluginTest.mm
@@ -274,7 +274,7 @@
   self.partialMockPlugin = OCMPartialMock(self.plugin);
   OCMStub([self.partialMockPlugin textChecker]).andReturn(self.mockTextChecker);
   id textCheckerClassMock = OCMClassMock([UITextChecker class]);
-  [[[textCheckerClassMock stub] andReturn:@[ @"en_us" ]] availableLanguages];
+  [[[textCheckerClassMock stub] andReturn:@[ @"en_US" ]] availableLanguages];
   NSArray* suggestions1 = @[ @"suggestion 1", @"suggestion 2" ];
 
   [self mockUITextCheckerWithExpectedMisspelledWordRange:NSMakeRange(0, 5)


### PR DESCRIPTION
Corrects locale format for spell check.

According to [docs](https://developer.apple.com/documentation/uikit/uitextchecker/1621029-rangeofmisspelledword), the format should look like `[language designator]_[region designator]` where the language designator is a "ISO 639-1" standard code and the region designator is a "ISO 3166-1 standard, a two-letter, capitalized code" ([source](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPInternational/LanguageandLocaleIDs/LanguageandLocaleIDs.html)). I used [this PR](https://github.com/flutter/flutter/pull/116222) to discover and test the fix manually.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
