### PR TITLE
Pin the analyzer package version in lib/web_ui

### DIFF
--- a/lib/web_ui/pubspec.yaml
+++ b/lib/web_ui/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
     path: ../../third_party/web_unicode
 
 dev_dependencies:
+  analyzer: 5.2.0
   archive: 3.1.2
   args: any
   async: any


### PR DESCRIPTION
Other web_ui package dependences are incompatible with analyzer-5.3.0
