### PR TITLE
[const_finder] Ignore constructor invocations from generated tear-off declarations

### DIFF
--- a/tools/const_finder/pubspec.yaml
+++ b/tools/const_finder/pubspec.yaml
@@ -6,7 +6,7 @@ name: const_finder
 publish_to: none
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.17.0 <4.0.0"
 
 # Do not add any dependencies that require more than what is provided in
 # //third_party/dart/pkg or //third_party/dart/third_party/pkg.

--- a/tools/const_finder/test/const_finder_test.dart
+++ b/tools/const_finder/test/const_finder_test.dart
@@ -139,8 +139,9 @@ void _checkAnnotation(String dillPath, Compiler compiler) {
     annotationClassName: 'StaticIconProvider',
     annotationClassLibraryUri: 'package:const_finder_fixtures/static_icon_provider.dart',
   );
+  final Map<String, dynamic> instances = finder.findInstances();
   expectInstances(
-    finder.findInstances(),
+    instances,
     <String, dynamic>{
       'constantInstances': <Map<String, Object?>>[
         <String, Object?>{

--- a/tools/const_finder/test/const_finder_test.dart
+++ b/tools/const_finder/test/const_finder_test.dart
@@ -93,18 +93,18 @@ void _checkConsts(String dillPath, Compiler compiler) {
   if (compiler == Compiler.aot) {
     expectation['nonConstantLocations'] = <Object?>[];
   } else {
-    // Without true tree-shaking, there is a non-const reference in a
-    // never-invoked function that will be present in the dill.
     final String fixturesUrl = Platform.isWindows
       ? '/$fixtures'.replaceAll(Platform.pathSeparator, '/')
       : fixtures;
 
+    // Without true tree-shaking, there is a non-const reference in a
+    // never-invoked function that will be present in the dill.
     expectation['nonConstantLocations'] = <Object?>[
       <String, dynamic>{
-          'file': 'file://$fixturesUrl/pkg/package.dart',
-          'line': 14,
-          'column': 25,
-        },
+        'file': 'file://$fixturesUrl/pkg/package.dart',
+        'line': 14,
+        'column': 25,
+      },
     ];
   }
   expectInstances(

--- a/tools/const_finder/test/const_finder_test.dart
+++ b/tools/const_finder/test/const_finder_test.dart
@@ -155,6 +155,8 @@ void _checkAnnotation(String dillPath, Compiler compiler) {
           'targetValue': null,
         },
       ],
+      // TODO(fujino): This should have non-constant locations from the use of
+      // a tear-off, see https://github.com/flutter/flutter/issues/116797
       'nonConstantLocations': <Object?>[],
     },
     compiler,

--- a/tools/const_finder/test/fixtures/.dart_tool/package_config.json
+++ b/tools/const_finder/test/fixtures/.dart_tool/package_config.json
@@ -4,12 +4,12 @@
         {
             "name": "const_finder_fixtures",
             "rootUri": "../lib/",
-            "languageVersion": "2.12"
+            "languageVersion": "2.17"
         },
         {
             "name": "const_finder_fixtures_package",
             "rootUri": "../pkg/",
-            "languageVersion": "2.12"
+            "languageVersion": "2.17"
         }
     ]
 }

--- a/tools/const_finder/test/fixtures/lib/static_icon_provider.dart
+++ b/tools/const_finder/test/fixtures/lib/static_icon_provider.dart
@@ -7,8 +7,8 @@ import 'target.dart';
 void main() {
   Targets.used1.hit();
   Targets.used2.hit();
-  final Target used3 = helper(Target.new);
-  used3.hit();
+  final Target nonConstUsed3 = helper(Target.new);
+  nonConstUsed3.hit();
 }
 
 Target helper(Target Function(String, int, Target?) tearOff) {

--- a/tools/const_finder/test/fixtures/lib/static_icon_provider.dart
+++ b/tools/const_finder/test/fixtures/lib/static_icon_provider.dart
@@ -7,6 +7,12 @@ import 'target.dart';
 void main() {
   Targets.used1.hit();
   Targets.used2.hit();
+  final Target used3 = helper(Target.new);
+  used3.hit();
+}
+
+Target helper(Target Function(String, int, Target?) tearOff) {
+  return tearOff('from tear-off', 3, null);
 }
 
 @staticIconProvider

--- a/tools/const_finder/test/fixtures/lib/target.dart
+++ b/tools/const_finder/test/fixtures/lib/target.dart
@@ -15,8 +15,7 @@ class Target {
 }
 
 class ExtendsTarget extends Target {
-  const ExtendsTarget(String stringValue, int intValue, Target? targetValue)
-      : super(stringValue, intValue, targetValue);
+  const ExtendsTarget(super.stringValue, super.intValue, super.targetValue);
 }
 
 class ImplementsTarget implements Target {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/116807

Skip non-const locations that are:
1. within the target class (in production, this will be `IconData`
2. within a procedure that is:
  a. static
  b. a method
  c. named `_#new#tearOff`