### PR TITLE
[embedder] Expose metal surface from test context

### DIFF
--- a/shell/platform/embedder/tests/embedder_test_context_metal.cc
+++ b/shell/platform/embedder/tests/embedder_test_context_metal.cc
@@ -47,6 +47,10 @@ TestMetalContext* EmbedderTestContextMetal::GetTestMetalContext() {
   return metal_context_.get();
 }
 
+TestMetalSurface* EmbedderTestContextMetal::GetTestMetalSurface() {
+  return metal_surface_.get();
+}
+
 void EmbedderTestContextMetal::SetPresentCallback(
     PresentCallback present_callback) {
   present_callback_ = std::move(present_callback);
@@ -77,10 +81,6 @@ bool EmbedderTestContextMetal::PopulateExternalTexture(
   } else {
     return false;
   }
-}
-
-TestMetalContext::TextureInfo EmbedderTestContextMetal::GetTextureInfo() {
-  return metal_surface_->GetTextureInfo();
 }
 
 void EmbedderTestContextMetal::SetNextDrawableCallback(

--- a/shell/platform/embedder/tests/embedder_test_context_metal.h
+++ b/shell/platform/embedder/tests/embedder_test_context_metal.h
@@ -53,8 +53,7 @@ class EmbedderTestContextMetal : public EmbedderTestContext {
 
   TestMetalContext* GetTestMetalContext();
 
-  // Returns the TextureInfo for the test Metal surface.
-  TestMetalContext::TextureInfo GetTextureInfo();
+  TestMetalSurface* GetTestMetalSurface();
 
   // Override the default handling for GetNextDrawable.
   void SetNextDrawableCallback(NextDrawableCallback next_drawable_callback);

--- a/shell/platform/embedder/tests/embedder_unittests_metal.mm
+++ b/shell/platform/embedder/tests/embedder_unittests_metal.mm
@@ -242,7 +242,8 @@ TEST_F(EmbedderTest, TextureDestructionCallbackCalledWithoutCustomCompositorMeta
 
   auto collect_context = std::make_unique<CollectContext>();
   context.SetNextDrawableCallback([&context, &collect_context](const FlutterFrameInfo* frame_info) {
-    auto texture_info = context.GetTextureInfo();
+    auto texture_info = context.GetTestMetalSurface()->GetTextureInfo();
+
     FlutterMetalTexture texture;
     texture.struct_size = sizeof(FlutterMetalTexture);
     texture.texture_id = texture_info.texture_id;


### PR DESCRIPTION
This is a minor cleanup that exposes the test metal surface to tests via EmbedderTestContextMeta::GetTestMetalSurface for parity with the GetTestMetalContext method which exposes the test metal context. This eliminates the need for the more specific GetTextureInfo method since the texture info is accessible via the test context.

This is a test refactoring with no semantic differences to the engine.

Issue: https://github.com/flutter/flutter/issues/116381

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
