### PR TITLE
[Windows] Synthesize modifier keys events on pointer events

### DIFF
--- a/shell/platform/windows/flutter_window.cc
+++ b/shell/platform/windows/flutter_window.cc
@@ -156,8 +156,10 @@ void FlutterWindow::OnPaint() {
 void FlutterWindow::OnPointerMove(double x,
                                   double y,
                                   FlutterPointerDeviceKind device_kind,
-                                  int32_t device_id) {
-  binding_handler_delegate_->OnPointerMove(x, y, device_kind, device_id);
+                                  int32_t device_id,
+                                  int modifiers_state) {
+  binding_handler_delegate_->OnPointerMove(x, y, device_kind, device_id,
+                                           modifiers_state);
 }
 
 void FlutterWindow::OnPointerDown(double x,

--- a/shell/platform/windows/flutter_window.h
+++ b/shell/platform/windows/flutter_window.h
@@ -41,7 +41,8 @@ class FlutterWindow : public Window, public WindowBindingHandler {
   void OnPointerMove(double x,
                      double y,
                      FlutterPointerDeviceKind device_kind,
-                     int32_t device_id) override;
+                     int32_t device_id,
+                     int modifiers_state) override;
 
   // |Window|
   void OnPointerDown(double x,

--- a/shell/platform/windows/flutter_window_unittests.cc
+++ b/shell/platform/windows/flutter_window_unittests.cc
@@ -42,6 +42,9 @@ class SpyKeyboardKeyHandler : public KeyboardHandlerBase {
     ON_CALL(*this, KeyboardHook(_, _, _, _, _, _, _))
         .WillByDefault(Invoke(real_implementation_.get(),
                               &KeyboardKeyHandler::KeyboardHook));
+    ON_CALL(*this, SyncModifiersIfNeeded(_))
+        .WillByDefault(Invoke(real_implementation_.get(),
+                              &KeyboardKeyHandler::SyncModifiersIfNeeded));
   }
 
   MOCK_METHOD7(KeyboardHook,
@@ -52,6 +55,8 @@ class SpyKeyboardKeyHandler : public KeyboardHandlerBase {
                     bool extended,
                     bool was_down,
                     KeyEventCallback callback));
+
+  MOCK_METHOD1(SyncModifiersIfNeeded, void(int modifiers_state));
 
  private:
   std::unique_ptr<KeyboardKeyHandler> real_implementation_;
@@ -266,15 +271,15 @@ TEST(FlutterWindowTest, OnPointerStarSendsDeviceType) {
   // Move
   EXPECT_CALL(delegate,
               OnPointerMove(10.0, 10.0, kFlutterPointerDeviceKindMouse,
-                            kDefaultPointerDeviceId))
+                            kDefaultPointerDeviceId, 0))
       .Times(1);
   EXPECT_CALL(delegate,
               OnPointerMove(10.0, 10.0, kFlutterPointerDeviceKindTouch,
-                            kDefaultPointerDeviceId))
+                            kDefaultPointerDeviceId, 0))
       .Times(1);
   EXPECT_CALL(delegate,
               OnPointerMove(10.0, 10.0, kFlutterPointerDeviceKindStylus,
-                            kDefaultPointerDeviceId))
+                            kDefaultPointerDeviceId, 0))
       .Times(1);
 
   // Down
@@ -323,7 +328,7 @@ TEST(FlutterWindowTest, OnPointerStarSendsDeviceType) {
       .Times(1);
 
   win32window.OnPointerMove(10.0, 10.0, kFlutterPointerDeviceKindMouse,
-                            kDefaultPointerDeviceId);
+                            kDefaultPointerDeviceId, 0);
   win32window.OnPointerDown(10.0, 10.0, kFlutterPointerDeviceKindMouse,
                             kDefaultPointerDeviceId, WM_LBUTTONDOWN);
   win32window.OnPointerUp(10.0, 10.0, kFlutterPointerDeviceKindMouse,
@@ -333,7 +338,7 @@ TEST(FlutterWindowTest, OnPointerStarSendsDeviceType) {
 
   // Touch
   win32window.OnPointerMove(10.0, 10.0, kFlutterPointerDeviceKindTouch,
-                            kDefaultPointerDeviceId);
+                            kDefaultPointerDeviceId, 0);
   win32window.OnPointerDown(10.0, 10.0, kFlutterPointerDeviceKindTouch,
                             kDefaultPointerDeviceId, WM_LBUTTONDOWN);
   win32window.OnPointerUp(10.0, 10.0, kFlutterPointerDeviceKindTouch,
@@ -343,7 +348,7 @@ TEST(FlutterWindowTest, OnPointerStarSendsDeviceType) {
 
   // Pen
   win32window.OnPointerMove(10.0, 10.0, kFlutterPointerDeviceKindStylus,
-                            kDefaultPointerDeviceId);
+                            kDefaultPointerDeviceId, 0);
   win32window.OnPointerDown(10.0, 10.0, kFlutterPointerDeviceKindStylus,
                             kDefaultPointerDeviceId, WM_LBUTTONDOWN);
   win32window.OnPointerUp(10.0, 10.0, kFlutterPointerDeviceKindStylus,

--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -166,7 +166,9 @@ void FlutterWindowsView::OnWindowRepaint() {
 void FlutterWindowsView::OnPointerMove(double x,
                                        double y,
                                        FlutterPointerDeviceKind device_kind,
-                                       int32_t device_id) {
+                                       int32_t device_id,
+                                       int modifiers_state) {
+  keyboard_key_handler_->SyncModifiersIfNeeded(modifiers_state);
   SendPointerMove(x, y, GetOrCreatePointerState(device_kind, device_id));
 }
 
@@ -285,8 +287,6 @@ void FlutterWindowsView::OnResetImeComposing() {
 
 void FlutterWindowsView::InitializeKeyboard() {
   auto internal_plugin_messenger = internal_plugin_registrar_->messenger();
-  // TODO(cbracken): This can be inlined into KeyboardKeyEmedderHandler once
-  // UWP code is removed. https://github.com/flutter/flutter/issues/102172.
   KeyboardKeyEmbedderHandler::GetKeyStateHandler get_key_state = GetKeyState;
   KeyboardKeyEmbedderHandler::MapVirtualKeyToScanCode map_vk_to_scan =
       [](UINT virtual_key, bool extended) {

--- a/shell/platform/windows/flutter_windows_view.h
+++ b/shell/platform/windows/flutter_windows_view.h
@@ -112,7 +112,8 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate,
   void OnPointerMove(double x,
                      double y,
                      FlutterPointerDeviceKind device_kind,
-                     int32_t device_id) override;
+                     int32_t device_id,
+                     int modifiers_state) override;
 
   // |WindowBindingHandlerDelegate|
   void OnPointerDown(double x,

--- a/shell/platform/windows/keyboard_handler_base.h
+++ b/shell/platform/windows/keyboard_handler_base.h
@@ -29,6 +29,10 @@ class KeyboardHandlerBase {
                             bool extended,
                             bool was_down,
                             KeyEventCallback callback) = 0;
+
+  // If needed, synthesize modifier keys events by comparing the
+  // given modifiers state to the known pressing state..
+  virtual void SyncModifiersIfNeeded(int modifiers_state) = 0;
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/keyboard_key_channel_handler.cc
+++ b/shell/platform/windows/keyboard_key_channel_handler.cc
@@ -109,6 +109,10 @@ KeyboardKeyChannelHandler::KeyboardKeyChannelHandler(
 
 KeyboardKeyChannelHandler::~KeyboardKeyChannelHandler() = default;
 
+void KeyboardKeyChannelHandler::SyncModifiersIfNeeded(int modifiers_state) {
+  // Do nothing
+}
+
 void KeyboardKeyChannelHandler::KeyboardHook(
     int key,
     int scancode,

--- a/shell/platform/windows/keyboard_key_channel_handler.h
+++ b/shell/platform/windows/keyboard_key_channel_handler.h
@@ -38,6 +38,8 @@ class KeyboardKeyChannelHandler
                     bool was_down,
                     std::function<void(bool)> callback);
 
+  void SyncModifiersIfNeeded(int modifiers_state);
+
  private:
   // The Flutter system channel for key event messages.
   std::unique_ptr<flutter::BasicMessageChannel<rapidjson::Document>> channel_;

--- a/shell/platform/windows/keyboard_key_embedder_handler.h
+++ b/shell/platform/windows/keyboard_key_embedder_handler.h
@@ -70,6 +70,8 @@ class KeyboardKeyEmbedderHandler
                     bool was_down,
                     std::function<void(bool)> callback) override;
 
+  void SyncModifiersIfNeeded(int modifiers_state) override;
+
  private:
   struct PendingResponse {
     std::function<void(bool, uint64_t)> callback;
@@ -109,26 +111,39 @@ class KeyboardKeyEmbedderHandler
   // Assign |critical_keys_| with basic information.
   void InitCriticalKeys(MapVirtualKeyToScanCode map_virtual_key_to_scan_code);
   // Update |critical_keys_| with last seen logical and physical key.
-  void UpdateLastSeenCritialKey(int virtual_key,
-                                uint64_t physical_key,
-                                uint64_t logical_key);
+  void UpdateLastSeenCriticalKey(int virtual_key,
+                                 uint64_t physical_key,
+                                 uint64_t logical_key);
   // Check each key's state from |get_key_state_| and synthesize events
   // if their toggling states have been desynchronized.
-  void SynchronizeCritialToggledStates(int event_virtual_key,
-                                       bool is_event_down,
-                                       bool* event_key_can_be_repeat);
+  void SynchronizeCriticalToggledStates(int event_virtual_key,
+                                        bool is_event_down,
+                                        bool* event_key_can_be_repeat);
   // Check each key's state from |get_key_state_| and synthesize events
   // if their pressing states have been desynchronized.
-  void SynchronizeCritialPressedStates(int event_virtual_key,
-                                       int event_physical_key,
-                                       bool is_event_down,
-                                       bool event_key_can_be_repeat);
+  void SynchronizeCriticalPressedStates(int event_virtual_key,
+                                        int event_physical_key,
+                                        bool is_event_down,
+                                        bool event_key_can_be_repeat);
 
   // Wraps perform_send_event_ with state tracking. Use this instead of
   // |perform_send_event_| to send events to the framework.
   void SendEvent(const FlutterKeyEvent& event,
                  FlutterKeyEventCallback callback,
                  void* user_data);
+
+  // Send a synthesized down event and update pressing records.
+  void SendSynthesizeDownEvent(uint64_t physical, uint64_t logical);
+
+  // Send a synthesized up event and update pressing records.
+  void SendSynthesizeUpEvent(uint64_t physical, uint64_t logical);
+
+  // Send a synthesized up or down event depending on the current pressing
+  // state.
+  void SynthesizeIfNeeded(uint64_t physical_left,
+                          uint64_t physical_right,
+                          uint64_t logical_left,
+                          bool is_pressed);
 
   std::function<void(const FlutterKeyEvent&, FlutterKeyEventCallback, void*)>
       perform_send_event_;

--- a/shell/platform/windows/keyboard_key_handler.cc
+++ b/shell/platform/windows/keyboard_key_handler.cc
@@ -31,6 +31,12 @@ void KeyboardKeyHandler::AddDelegate(
   delegates_.push_back(std::move(delegate));
 }
 
+void KeyboardKeyHandler::SyncModifiersIfNeeded(int modifiers_state) {
+  // Only call SyncModifierIfNeeded on the key embedder handler.
+  auto& key_embedder_handler = delegates_.front();
+  key_embedder_handler->SyncModifiersIfNeeded(modifiers_state);
+}
+
 void KeyboardKeyHandler::KeyboardHook(int key,
                                       int scancode,
                                       int action,

--- a/shell/platform/windows/keyboard_key_handler.h
+++ b/shell/platform/windows/keyboard_key_handler.h
@@ -47,6 +47,8 @@ class KeyboardKeyHandler : public KeyboardHandlerBase {
                               bool was_down,
                               KeyEventCallback callback) = 0;
 
+    virtual void SyncModifiersIfNeeded(int modifiers_state) = 0;
+
     virtual ~KeyboardKeyHandlerDelegate();
   };
 
@@ -57,6 +59,9 @@ class KeyboardKeyHandler : public KeyboardHandlerBase {
 
   // Add a delegate that handles events received by |KeyboardHook|.
   void AddDelegate(std::unique_ptr<KeyboardKeyHandlerDelegate> delegate);
+
+  // Synthesize modifier keys events if needed.
+  void SyncModifiersIfNeeded(int modifiers_state) override;
 
   // Handles a key event.
   //

--- a/shell/platform/windows/keyboard_key_handler_unittests.cc
+++ b/shell/platform/windows/keyboard_key_handler_unittests.cc
@@ -87,6 +87,10 @@ class MockKeyHandlerDelegate
     callback_handler(hook_history->back().callback);
   }
 
+  virtual void SyncModifiersIfNeeded(int modifiers_state) {
+    // Do Nothing
+  }
+
   CallbackHandler callback_handler;
   int delegate_id;
   std::list<KeyboardHookCall>* hook_history;

--- a/shell/platform/windows/keyboard_unittests.cc
+++ b/shell/platform/windows/keyboard_unittests.cc
@@ -1832,7 +1832,7 @@ TEST(KeyboardTest, SynthesizeModifiers) {
   EXPECT_EQ(tester.RedispatchedMessageCountAndClear(), 1);
 
   // CapsLock, phase 0 -> 2 -> 0.
-  // (For phases, see |SynchronizeCritialToggledStates|.)
+  // (For phases, see |SynchronizeCriticalToggledStates|.)
   tester.InjectKeyboardChanges(std::vector<KeyboardChange>{
       KeyStateChange{VK_CAPITAL, false, true}, event1});
   EXPECT_EQ(key_calls.size(), 3);

--- a/shell/platform/windows/keyboard_utils.h
+++ b/shell/platform/windows/keyboard_utils.h
@@ -11,6 +11,15 @@
 
 namespace flutter {
 
+constexpr int kShift = 1 << 0;
+constexpr int kControl = 1 << 3;
+constexpr int kScanCodeShiftLeft = 0x2a;
+constexpr int kScanCodeShiftRight = 0x36;
+constexpr int kKeyCodeShiftLeft = 0xa0;
+constexpr int kScanCodeControlLeft = 0x1d;
+constexpr int kScanCodeControlRight = 0xe01d;
+constexpr int kKeyCodeControlLeft = 0xa2;
+
 // The bit of a mapped character in a WM_KEYDOWN message that indicates the
 // character is a dead key.
 //

--- a/shell/platform/windows/testing/mock_window.h
+++ b/shell/platform/windows/testing/mock_window.h
@@ -41,8 +41,8 @@ class MockWindow : public Window {
   MOCK_METHOD1(OnDpiScale, void(unsigned int));
   MOCK_METHOD2(OnResize, void(unsigned int, unsigned int));
   MOCK_METHOD0(OnPaint, void());
-  MOCK_METHOD4(OnPointerMove,
-               void(double, double, FlutterPointerDeviceKind, int32_t));
+  MOCK_METHOD5(OnPointerMove,
+               void(double, double, FlutterPointerDeviceKind, int32_t, int));
   MOCK_METHOD5(OnPointerDown,
                void(double, double, FlutterPointerDeviceKind, int32_t, UINT));
   MOCK_METHOD5(OnPointerUp,

--- a/shell/platform/windows/testing/mock_window_binding_handler_delegate.h
+++ b/shell/platform/windows/testing/mock_window_binding_handler_delegate.h
@@ -23,8 +23,8 @@ class MockWindowBindingHandlerDelegate : public WindowBindingHandlerDelegate {
 
   MOCK_METHOD2(OnWindowSizeChanged, void(size_t, size_t));
   MOCK_METHOD0(OnWindowRepaint, void());
-  MOCK_METHOD4(OnPointerMove,
-               void(double, double, FlutterPointerDeviceKind, int32_t));
+  MOCK_METHOD5(OnPointerMove,
+               void(double, double, FlutterPointerDeviceKind, int32_t, int));
   MOCK_METHOD5(OnPointerDown,
                void(double,
                     double,

--- a/shell/platform/windows/window.cc
+++ b/shell/platform/windows/window.cc
@@ -15,6 +15,7 @@
 #include <cstring>
 
 #include "flutter/shell/platform/windows/dpi_utils.h"
+#include "flutter/shell/platform/windows/keyboard_utils.h"
 
 namespace flutter {
 
@@ -379,7 +380,7 @@ Window::HandleMessage(UINT const message,
             OnPointerDown(x, y, kFlutterPointerDeviceKindTouch, touch_id,
                           WM_LBUTTONDOWN);
           } else if (touch.dwFlags & TOUCHEVENTF_MOVE) {
-            OnPointerMove(x, y, kFlutterPointerDeviceKindTouch, touch_id);
+            OnPointerMove(x, y, kFlutterPointerDeviceKindTouch, touch_id, 0);
           } else if (touch.dwFlags & TOUCHEVENTF_UP) {
             OnPointerUp(x, y, kFlutterPointerDeviceKindTouch, touch_id,
                         WM_LBUTTONDOWN);
@@ -401,7 +402,15 @@ Window::HandleMessage(UINT const message,
         mouse_x_ = static_cast<double>(xPos);
         mouse_y_ = static_cast<double>(yPos);
 
-        OnPointerMove(mouse_x_, mouse_y_, device_kind, kDefaultPointerDeviceId);
+        int mods = 0;
+        if (wparam & MK_CONTROL) {
+          mods |= kControl;
+        }
+        if (wparam & MK_SHIFT) {
+          mods |= kShift;
+        }
+        OnPointerMove(mouse_x_, mouse_y_, device_kind, kDefaultPointerDeviceId,
+                      mods);
       }
       break;
     case WM_MOUSELEAVE:

--- a/shell/platform/windows/window.h
+++ b/shell/platform/windows/window.h
@@ -109,7 +109,8 @@ class Window : public KeyboardManager::WindowDelegate {
   virtual void OnPointerMove(double x,
                              double y,
                              FlutterPointerDeviceKind device_kind,
-                             int32_t device_id) = 0;
+                             int32_t device_id,
+                             int modifiers_state) = 0;
 
   // Called when the a mouse button, determined by |button|, goes down.
   virtual void OnPointerDown(double x,

--- a/shell/platform/windows/window_binding_handler_delegate.h
+++ b/shell/platform/windows/window_binding_handler_delegate.h
@@ -32,7 +32,8 @@ class WindowBindingHandlerDelegate {
   virtual void OnPointerMove(double x,
                              double y,
                              FlutterPointerDeviceKind device_kind,
-                             int32_t device_id) = 0;
+                             int32_t device_id,
+                             int modifiers_state) = 0;
 
   // Notifies delegate that backing window mouse pointer button has been
   // pressed. Typically called by currently configured WindowBindingHandler.

--- a/shell/platform/windows/window_unittests.cc
+++ b/shell/platform/windows/window_unittests.cc
@@ -166,7 +166,7 @@ TEST(MockWindow, MouseLeave) {
   const double mouse_y = 20.0;
 
   EXPECT_CALL(window, OnPointerMove(mouse_x, mouse_y,
-                                    kFlutterPointerDeviceKindMouse, 0))
+                                    kFlutterPointerDeviceKindMouse, 0, 0))
       .Times(1);
   EXPECT_CALL(window, OnPointerLeave(mouse_x, mouse_y,
                                      kFlutterPointerDeviceKindMouse, 0))


### PR DESCRIPTION
## Description

This PR implements modifier keys states synchronization based on pointer events.
It is the Windows implementation for https://github.com/flutter/flutter/issues/115066.
Win32 mouse events only expose flags for Shift and Control, so only those two modifiers are sync.

## Related Issue

https://github.com/flutter/flutter/issues/115066

## Tests

Adds 4 tests.
