### PR TITLE
[tools] Eliminate version on Obj-C docs

### DIFF
--- a/tools/gen_objcdoc.sh
+++ b/tools/gen_objcdoc.sh
@@ -49,7 +49,6 @@ jazzy \
   --author_url 'https://flutter.io'\
   --github_url 'https://github.com/flutter'\
   --github-file-prefix 'http://github.com/flutter/engine/blob/main'\
-  --module-version 1.0.0\
   --xcodebuild-arguments --objc,"$FLUTTER_UMBRELLA_HEADER",--,-x,objective-c,-isysroot,"$(xcrun --show-sdk-path --sdk iphonesimulator)",-I,"$(pwd)"\
   --module Flutter\
   --root-url https://api.flutter.dev/objc/\


### PR DESCRIPTION
Eliminates the --module-version flag to jazzy when generating Obj-C docs. This was hardcoded to 1.0.0. Since we have no knowledge of which Flutter version a given engine build will be part of, eliminate it altogether on the basis that it's better to have no version than the wrong version.

Before:
![image](https://user-images.githubusercontent.com/351029/206567687-0e036551-9f4d-4d66-a23c-e36db06bf967.png)

After:
![image](https://user-images.githubusercontent.com/351029/206567716-c45cff56-42e3-46e2-bb93-1efca72bde87.png)



## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
