### PR TITLE
[Impeller] Use DrawPath instead of Rect geometry when the paint style is stroke

### DIFF
--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -194,6 +194,11 @@ bool Canvas::AttemptDrawBlurredRRect(const Rect& rect,
 }
 
 void Canvas::DrawRect(Rect rect, const Paint& paint) {
+  if (paint.style == Paint::Style::kStroke) {
+    DrawPath(PathBuilder{}.AddRect(rect).TakePath(), paint);
+    return;
+  }
+
   if (AttemptDrawBlurredRRect(rect, 0, paint)) {
     return;
   }

--- a/impeller/display_list/display_list_unittests.cc
+++ b/impeller/display_list/display_list_unittests.cc
@@ -1120,5 +1120,43 @@ TEST_P(DisplayListTest, DrawVerticesSolidColorTrianglesWithIndices) {
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
 
+TEST_P(DisplayListTest, DrawShapes) {
+  flutter::DisplayListBuilder builder;
+  std::vector<flutter::DlStrokeJoin> joins = {
+      flutter::DlStrokeJoin::kBevel,
+      flutter::DlStrokeJoin::kRound,
+      flutter::DlStrokeJoin::kMiter,
+  };
+  flutter::DlPaint paint =                            //
+      flutter::DlPaint()                              //
+          .setColor(flutter::DlColor::kWhite())       //
+          .setDrawStyle(flutter::DlDrawStyle::kFill)  //
+          .setStrokeWidth(10);
+  flutter::DlPaint stroke_paint =                       //
+      flutter::DlPaint()                                //
+          .setColor(flutter::DlColor::kWhite())         //
+          .setDrawStyle(flutter::DlDrawStyle::kStroke)  //
+          .setStrokeWidth(10);
+  SkPath path = SkPath().addPoly({{150, 50}, {160, 50}}, false);
+
+  builder.translate(300, 50);
+  builder.scale(0.8, 0.8);
+  for (auto join : joins) {
+    paint.setStrokeJoin(join);
+    stroke_paint.setStrokeJoin(join);
+    builder.drawRect(SkRect::MakeXYWH(0, 0, 100, 100), paint);
+    builder.drawRect(SkRect::MakeXYWH(0, 150, 100, 100), stroke_paint);
+    builder.drawRRect(
+        SkRRect::MakeRectXY(SkRect::MakeXYWH(150, 0, 100, 100), 30, 30), paint);
+    builder.drawRRect(
+        SkRRect::MakeRectXY(SkRect::MakeXYWH(150, 150, 100, 100), 30, 30),
+        stroke_paint);
+    builder.drawCircle({350, 50}, 50, paint);
+    builder.drawCircle({350, 200}, 50, stroke_paint);
+    builder.translate(0, 300);
+  }
+  ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
+}
+
 }  // namespace testing
 }  // namespace impeller


### PR DESCRIPTION
Before:
![Screen Shot 2022-12-08 at 2 47 28 PM](https://user-images.githubusercontent.com/919017/206583323-e8c08524-495a-41ab-800f-89fa19d303f2.png)

After:
![Screen Shot 2022-12-08 at 2 44 19 PM](https://user-images.githubusercontent.com/919017/206583334-0a885d06-739b-442e-a6ca-48bd321e7ded.png)
