### PR TITLE
Clarify file sharing flags in FML filesystem APIs on Windows

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1020,6 +1020,7 @@ FILE: ../../../flutter/fml/platform/win/command_line_win.cc
 FILE: ../../../flutter/fml/platform/win/errors_win.cc
 FILE: ../../../flutter/fml/platform/win/errors_win.h
 FILE: ../../../flutter/fml/platform/win/file_win.cc
+FILE: ../../../flutter/fml/platform/win/file_win_unittests.cc
 FILE: ../../../flutter/fml/platform/win/mapping_win.cc
 FILE: ../../../flutter/fml/platform/win/message_loop_win.cc
 FILE: ../../../flutter/fml/platform/win/message_loop_win.h

--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -351,7 +351,10 @@ if (enable_unittests) {
     }
 
     if (is_win) {
-      sources += [ "platform/win/wstring_conversion_unittests.cc" ]
+      sources += [
+        "platform/win/file_win_unittests.cc",
+        "platform/win/wstring_conversion_unittests.cc",
+      ]
     }
 
     deps = [

--- a/fml/platform/win/file_win.cc
+++ b/fml/platform/win/file_win.cc
@@ -85,11 +85,11 @@ static DWORD GetDesiredAccessFlags(FilePermission permission) {
 static DWORD GetShareFlags(FilePermission permission) {
   switch (permission) {
     case FilePermission::kRead:
-      return FILE_SHARE_READ;
+      return FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE;
     case FilePermission::kWrite:
-      return FILE_SHARE_WRITE;
+      return 0;
     case FilePermission::kReadWrite:
-      return FILE_SHARE_READ | FILE_SHARE_WRITE;
+      return 0;
   }
   return FILE_SHARE_READ;
 }

--- a/fml/platform/win/file_win_unittests.cc
+++ b/fml/platform/win/file_win_unittests.cc
@@ -1,0 +1,32 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/fml/file.h"
+
+#include <Fileapi.h>
+
+#include "flutter/fml/platform/win/wstring_conversion.h"
+#include "gtest/gtest.h"
+
+namespace fml {
+namespace testing {
+
+TEST(FileWin, OpenDirectoryShare) {
+  fml::ScopedTemporaryDirectory temp_dir;
+  auto temp_path = Utf8ToWideString({temp_dir.path()});
+  fml::UniqueFD handle(
+      CreateFile(temp_path.c_str(), GENERIC_WRITE,
+                 FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING,
+                 FILE_ATTRIBUTE_NORMAL | FILE_FLAG_BACKUP_SEMANTICS, nullptr));
+  ASSERT_TRUE(handle.is_valid());
+
+  // Check that fml::OpenDirectory(FilePermission::kRead) works with a
+  // directory that has also been opened for writing.
+  auto dir = fml::OpenDirectory(temp_dir.path().c_str(), false,
+                                fml::FilePermission::kRead);
+  ASSERT_TRUE(dir.is_valid());
+}
+
+}  // namespace testing
+}  // namespace fml


### PR DESCRIPTION
Use shared mode when requesting read access and exclusive mode for write access