### PR TITLE
[Windows] Fix crash if the Dart entry point is null

### DIFF
--- a/shell/platform/windows/flutter_windows.cc
+++ b/shell/platform/windows/flutter_windows.cc
@@ -145,7 +145,12 @@ bool FlutterDesktopEngineDestroy(FlutterDesktopEngineRef engine_ref) {
 
 bool FlutterDesktopEngineRun(FlutterDesktopEngineRef engine,
                              const char* entry_point) {
-  return EngineFromHandle(engine)->Run(entry_point);
+  std::string_view entry_point_view{""};
+  if (entry_point != nullptr) {
+    entry_point_view = entry_point;
+  }
+
+  return EngineFromHandle(engine)->Run(entry_point_view);
 }
 
 uint64_t FlutterDesktopEngineProcessMessages(FlutterDesktopEngineRef engine) {

--- a/shell/platform/windows/flutter_windows_unittests.cc
+++ b/shell/platform/windows/flutter_windows_unittests.cc
@@ -89,6 +89,16 @@ TEST_F(WindowsTest, LaunchCustomEntrypointInEngineRunInvocation) {
   ASSERT_TRUE(FlutterDesktopEngineRun(engine.get(), "customEntrypoint"));
 }
 
+// Verify that the engine can launch in headless mode.
+TEST_F(WindowsTest, LaunchHeadlessEngine) {
+  auto& context = GetContext();
+  WindowsConfigBuilder builder(context);
+  EnginePtr engine{builder.InitializeEngine()};
+  ASSERT_NE(engine, nullptr);
+
+  ASSERT_TRUE(FlutterDesktopEngineRun(engine.get(), nullptr));
+}
+
 // Verify that engine fails to launch when a conflicting entrypoint in
 // FlutterDesktopEngineProperties.dart_entrypoint and the
 // FlutterDesktopEngineRun parameter.

--- a/shell/platform/windows/public/flutter_windows.h
+++ b/shell/platform/windows/public/flutter_windows.h
@@ -147,7 +147,7 @@ FLUTTER_EXPORT bool FlutterDesktopEngineDestroy(FlutterDesktopEngineRef engine);
 // set in the dart_entrypoint field of the FlutterDesktopEngineProperties
 // struct passed to FlutterDesktopEngineCreate.
 //
-// If sprecified, entry_point must be the name of a top-level function from the
+// If specified, entry_point must be the name of a top-level function from the
 // same Dart library that contains the app's main() function, and must be
 // decorated with `@pragma(vm:entry-point)` to ensure the method is not
 // tree-shaken by the Dart compiler. If conflicting non-null values are passed


### PR DESCRIPTION
The Windows Flutter engine crashes if it is launched without a `nullptr` Dart entry point:

```
strlen()
std::_Narrow_char_traits<char,int>::length
std::basic_string_view<char,std::char_traits<char>>::basic_string_view
FlutterDesktopEngineRunLine
flutter::FlutterEngine::Run
flutter::FlutterEngine::Run
wWinMain
```

This is needed for scenarios like headless mode with no views. Fixes https://github.com/flutter/flutter/issues/116753

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
