### PR TITLE
[Impeller Scene] Convert vertex positions to match Impeller's clip space orientation

### DIFF
--- a/impeller/scene/importer/importer_gltf.cc
+++ b/impeller/scene/importer/importer_gltf.cc
@@ -22,13 +22,12 @@ namespace impeller {
 namespace scene {
 namespace importer {
 
-static const std::map<std::string, VerticesBuilder::Attribute> kAttributes = {
-    {"POSITION", VerticesBuilder::Attribute::kPosition},
-    {"NORMAL", VerticesBuilder::Attribute::kNormal},
-    {"TANGENT", VerticesBuilder::Attribute::kTangent},
-    {"TEXCOORD_0", VerticesBuilder::Attribute::kTextureCoords},
-    {"COLOR_0", VerticesBuilder::Attribute::kColor},
-};
+static const std::map<std::string, VerticesBuilder::AttributeType> kAttributes =
+    {{"POSITION", VerticesBuilder::AttributeType::kPosition},
+     {"NORMAL", VerticesBuilder::AttributeType::kNormal},
+     {"TANGENT", VerticesBuilder::AttributeType::kTangent},
+     {"TEXCOORD_0", VerticesBuilder::AttributeType::kTextureCoords},
+     {"COLOR_0", VerticesBuilder::AttributeType::kColor}};
 
 static bool WithinRange(int index, size_t size) {
   return index >= 0 && static_cast<size_t>(index) < size;

--- a/impeller/scene/importer/importer_unittests.cc
+++ b/impeller/scene/importer/importer_unittests.cc
@@ -38,7 +38,7 @@ TEST(ImporterTest, CanParseGLTF) {
   auto& vertex = mesh.vertices[0];
 
   Vector3 position = ToVector3(vertex.position());
-  ASSERT_VECTOR3_NEAR(position, Vector3(-0.0100185, -0.522907, 0.133178));
+  ASSERT_VECTOR3_NEAR(position, Vector3(-0.0100185, -0.522907, -0.133178));
 
   Vector3 normal = ToVector3(vertex.normal());
   ASSERT_VECTOR3_NEAR(normal, Vector3(0.556997, -0.810833, 0.179733));

--- a/impeller/scene/importer/vertices_builder.h
+++ b/impeller/scene/importer/vertices_builder.h
@@ -17,14 +17,6 @@ namespace importer {
 
 class VerticesBuilder {
  public:
-  enum class Attribute {
-    kPosition,
-    kNormal,
-    kTangent,
-    kTextureCoords,
-    kColor,
-  };
-
   enum class ComponentType {
     kSignedByte = 5120,
     kUnsignedByte,
@@ -35,26 +27,48 @@ class VerticesBuilder {
     kFloat,
   };
 
-  VerticesBuilder();
+  enum class AttributeType {
+    kPosition,
+    kNormal,
+    kTangent,
+    kTextureCoords,
+    kColor,
+  };
 
-  void WriteFBVertices(std::vector<fb::Vertex>& vertices) const;
+  using ComponentConverter =
+      std::function<Scalar(const void* source, size_t byte_offset)>;
+  struct ComponentProperties {
+    size_t size_bytes = 0;
+    ComponentConverter convert_proc;
+  };
 
-  void SetAttributeFromBuffer(Attribute attribute,
-                              ComponentType component_type,
-                              const void* buffer_start,
-                              size_t stride_bytes,
-                              size_t count);
-
- private:
+  struct AttributeProperties;
+  using AttributeWriter =
+      std::function<void(Scalar* destination,
+                         const void* source,
+                         const ComponentProperties& component_props,
+                         const AttributeProperties& attribute_props)>;
   struct AttributeProperties {
     size_t offset_bytes;
     size_t size_bytes;
     size_t component_count;
+    AttributeWriter write_proc;
   };
 
-  static std::map<VerticesBuilder::Attribute,
+  VerticesBuilder();
+
+  void WriteFBVertices(std::vector<fb::Vertex>& vertices) const;
+
+  void SetAttributeFromBuffer(AttributeType attribute,
+                              ComponentType component_type,
+                              const void* buffer_start,
+                              size_t attribute_stride_bytes,
+                              size_t attribute_count);
+
+ private:
+  static std::map<VerticesBuilder::AttributeType,
                   VerticesBuilder::AttributeProperties>
-      kAttributes;
+      kAttributeTypes;
 
   struct Vertex {
     Vector3 position;

--- a/impeller/scene/importer/vertices_builder.h
+++ b/impeller/scene/importer/vertices_builder.h
@@ -49,9 +49,9 @@ class VerticesBuilder {
                          const ComponentProperties& component_props,
                          const AttributeProperties& attribute_props)>;
   struct AttributeProperties {
-    size_t offset_bytes;
-    size_t size_bytes;
-    size_t component_count;
+    size_t offset_bytes = 0;
+    size_t size_bytes = 0;
+    size_t component_count = 0;
     AttributeWriter write_proc;
   };
 


### PR DESCRIPTION
GLTF geometry follows a right-handed coordinate system where +z is model "front" and +y is model "top". Impeller has a left-handed clip space. Inverting Z is the simplest and most predictable conversion with respect to a default camera orientation such that model "right" is towards the right side of the viewport (+x in Impeller clip space) and model "top" is towards the top of the viewport (+y in Impeller clip space).

Also refactors the VerticesBuilder to support more specific behaviors (we'll need more AttributeWriter procs soon, like for tangents).

Before:
![Screen Shot 2022-12-09 at 6 10 39 PM](https://user-images.githubusercontent.com/919017/206823667-18c20dfb-5ce5-4eb8-8993-80d1d270166c.png)

After:
![Screen Shot 2022-12-09 at 6 09 37 PM](https://user-images.githubusercontent.com/919017/206823670-bf7d68c8-2a5f-4086-be84-365f65a91cd1.png)
