### PR TITLE
[Impeller] Fix asset names used for the generated entrypoint name can contain invalid identifiers for the target language

### DIFF
--- a/impeller/compiler/switches_unittests.cc
+++ b/impeller/compiler/switches_unittests.cc
@@ -69,6 +69,15 @@ TEST(SwitchesTest, EntryPointCanBeSetForHLSL) {
   ASSERT_EQ(switches.entry_point, "CustomEntryPoint");
 }
 
+TEST(SwitchesTEst, ConvertToEntrypointName) {
+  ASSERT_EQ(ConvertToEntrypointName("mandelbrot_unrolled"), "mandelbrot_unrolled");
+  ASSERT_EQ(ConvertToEntrypointName("mandelbrot-unrolled"), "mandelbrotunrolled");
+  ASSERT_EQ(ConvertToEntrypointName("7_"), "i_7_");
+  ASSERT_EQ(ConvertToEntrypointName("415"), "i_415");
+  ASSERT_EQ(ConvertToEntrypointName("#$%"), "i_");
+  ASSERT_EQ(ConvertToEntrypointName(""), "");
+}
+
 }  // namespace testing
 }  // namespace compiler
 }  // namespace impeller

--- a/impeller/compiler/switches_unittests.cc
+++ b/impeller/compiler/switches_unittests.cc
@@ -70,8 +70,10 @@ TEST(SwitchesTest, EntryPointCanBeSetForHLSL) {
 }
 
 TEST(SwitchesTEst, ConvertToEntrypointName) {
-  ASSERT_EQ(ConvertToEntrypointName("mandelbrot_unrolled"), "mandelbrot_unrolled");
-  ASSERT_EQ(ConvertToEntrypointName("mandelbrot-unrolled"), "mandelbrotunrolled");
+  ASSERT_EQ(ConvertToEntrypointName("mandelbrot_unrolled"),
+            "mandelbrot_unrolled");
+  ASSERT_EQ(ConvertToEntrypointName("mandelbrot-unrolled"),
+            "mandelbrotunrolled");
   ASSERT_EQ(ConvertToEntrypointName("7_"), "i_7_");
   ASSERT_EQ(ConvertToEntrypointName("415"), "i_415");
   ASSERT_EQ(ConvertToEntrypointName("#$%"), "i_");

--- a/impeller/compiler/types.cc
+++ b/impeller/compiler/types.cc
@@ -96,7 +96,7 @@ std::string EntryPointFunctionNameFromSourceName(
 
   std::stringstream stream;
   std::filesystem::path file_path(file_name);
-  stream << Utf8FromPath(file_path.stem()) << "_";
+  stream << ConvertToEntrypointName(Utf8FromPath(file_path.stem())) << "_";
   switch (type) {
     case SourceType::kUnknown:
       stream << "unknown";

--- a/impeller/compiler/utilities.cc
+++ b/impeller/compiler/utilities.cc
@@ -43,5 +43,23 @@ std::string ConvertToCamelCase(std::string_view string) {
   return stream.str();
 }
 
+std::string ConvertToEntrypointName(std::string_view string) {
+  if (string.empty()) {
+    return "";
+  }
+  std::stringstream stream;
+  // Append a prefix if the first character is not a letter.
+  if (!std::isalpha(string.data()[0])) {
+    stream << "i_";
+  }
+  for (size_t i = 0, count = string.length(); i < count; i++) {
+    auto ch = string.data()[i];
+    if (std::isalnum(ch) || ch == '_') {
+      stream << ch;
+    }
+  }
+  return stream.str();
+}
+
 }  // namespace compiler
 }  // namespace impeller

--- a/impeller/compiler/utilities.h
+++ b/impeller/compiler/utilities.h
@@ -25,5 +25,9 @@ std::string InferShaderNameFromPath(std::string_view path);
 
 std::string ConvertToCamelCase(std::string_view string);
 
+/// @brief  Ensure that the entrypoint name is a valid identifier in the target
+///         language.
+std::string ConvertToEntrypointName(std::string_view string);
+
 }  // namespace compiler
 }  // namespace impeller


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/116863
