### PR TITLE
[Impeller] Fix typo in compiller help

### DIFF
--- a/impeller/compiler/switches.cc
+++ b/impeller/compiler/switches.cc
@@ -48,7 +48,7 @@ void Switches::PrintHelp(std::ostream& stream) {
   }
   stream << " ]" << std::endl;
   stream << "--input=<source_file>" << std::endl;
-  stream << "[optional] --input-kind={";
+  stream << "[optional] --input-type={";
   for (const auto& source_type : kKnownSourceTypes) {
     stream << source_type.first << ", ";
   }


### PR DESCRIPTION
Fixes typo in Impeller compiler help, where the argument `input-type` is incorrectly shown as `input-kind`

Fixes https://github.com/flutter/flutter/issues/116865