### PR TITLE
[Impeller] Speculatively attempt to fix Metal PSO construction errors on host targets.

### DIFF
--- a/impeller/renderer/backend/metal/pipeline_library_mtl.mm
+++ b/impeller/renderer/backend/metal/pipeline_library_mtl.mm
@@ -3,8 +3,10 @@
 // found in the LICENSE file.
 
 #include "impeller/renderer/backend/metal/pipeline_library_mtl.h"
+
 #include <Metal/Metal.h>
 
+#include "flutter/fml/build_config.h"
 #include "flutter/fml/container.h"
 #include "impeller/base/promise.h"
 #include "impeller/renderer/backend/metal/compute_pipeline_mtl.h"
@@ -131,9 +133,19 @@ PipelineFuture<PipelineDescriptor> PipelineLibraryMTL::GetPipeline(
             ));
         promise->set_value(new_pipeline);
       };
-  [device_ newRenderPipelineStateWithDescriptor:GetMTLRenderPipelineDescriptor(
-                                                    descriptor)
+  auto mtl_descriptor = GetMTLRenderPipelineDescriptor(descriptor);
+#if FML_OS_IOS
+  [device_ newRenderPipelineStateWithDescriptor:mtl_descriptor
                               completionHandler:completion_handler];
+#else   // FML_OS_IOS
+  // TODO(116919): Investigate and revert speculative fix to make MTL pipeline
+  //               state creation use a worker.
+  NSError* error = nil;
+  auto render_pipeline_state =
+      [device_ newRenderPipelineStateWithDescriptor:mtl_descriptor
+                                              error:&error];
+  completion_handler(render_pipeline_state, error);
+#endif  // FML_OS_IOS
   return pipeline_future;
 }
 


### PR DESCRIPTION
Makes the PSO construction not use a worker since the theory is that device teardown in the test harness is tickling a race condition in the Metal framework.

Fixes https://github.com/flutter/flutter/issues/114872 (speculatively).
Following up in https://github.com/flutter/flutter/issues/116919.