### PR TITLE
[web] correct float count in runtime effect

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/painting.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/painting.dart
@@ -423,11 +423,12 @@ class CkFragmentProgram implements ui.FragmentProgram {
       if (type == UniformType.SampledImage) {
         textureCount += 1;
       } else {
+        final Object? rows = rawUniformData['rows'];
         final Object? bitWidth = rawUniformData['bit_width'];
-        if (bitWidth is! int) {
+        if (bitWidth is! int || rows is! int) {
           throw const FormatException('Invalid Shader Data');
         }
-        floatCount += bitWidth ~/ 32;
+        floatCount += (bitWidth ~/ 32) * rows;
       }
       uniforms[location] = UniformData(
         name: name,

--- a/lib/web_ui/test/canvaskit/fragment_program_test.dart
+++ b/lib/web_ui/test/canvaskit/fragment_program_test.dart
@@ -192,7 +192,7 @@ void testMain() {
       final CkFragmentProgram program = await CkFragmentProgram.fromBytes('test', data);
 
       expect(program.effect, isNotNull);
-      expect(program.floatCount, 17);
+      expect(program.floatCount, 32);
       expect(program.textureCount, 0);
       expect(program.uniforms, hasLength(17));
       expect(program.name, 'test');


### PR DESCRIPTION
Ensure that vec2, vec3, et cetera are mapped to multiple floats. Test would have failed if it was running