### PR TITLE
[Impeller] Remove validation log when the pipeline library is collected before pipeline is setup.

### DIFF
--- a/impeller/renderer/backend/metal/pipeline_library_mtl.mm
+++ b/impeller/renderer/backend/metal/pipeline_library_mtl.mm
@@ -119,8 +119,6 @@ PipelineFuture<PipelineDescriptor> PipelineLibraryMTL::GetPipeline(
 
         auto strong_this = weak_this.lock();
         if (!strong_this) {
-          VALIDATION_LOG << "Library was collected before a pending pipeline "
-                            "creation could finish.";
           promise->set_value(nullptr);
           return;
         }


### PR DESCRIPTION
This is a benign condition but the validation logs could be fatal since https://github.com/flutter/engine/commit/8744c93c4d5. Don't crash in these situations.