### PR TITLE
Update web_sdk -> package test dependency to get updated package matcher

### DIFF
--- a/lib/web_ui/pubspec.yaml
+++ b/lib/web_ui/pubspec.yaml
@@ -33,7 +33,7 @@ dev_dependencies:
   shelf_web_socket: any
   stack_trace: any
   stream_channel: 2.1.1
-  test: 1.22.0
+  test: 1.22.1
   test_api: any
   test_core: any
   typed_data: any

--- a/web_sdk/pubspec.yaml
+++ b/web_sdk/pubspec.yaml
@@ -10,4 +10,4 @@ dependencies:
 
 dev_dependencies:
   analyzer: 4.3.1
-  test: 1.22.0
+  test: 1.22.1

--- a/web_sdk/web_engine_tester/pubspec.yaml
+++ b/web_sdk/web_engine_tester/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   js: 0.6.4
   stream_channel: 2.1.1
-  test: 1.22.0
+  test: 1.22.1
   webkit_inspection_protocol: 1.0.0
   stack_trace: 1.10.0
   ui:


### PR DESCRIPTION
Dependency to package test is updated in order to pick up the latest package matcher, which no longer uses a deprecated CyclicInitializationError class from dart:core which was recently removed from Dart SDK.

Issue: https://github.com/dart-lang/sdk/issues/49529
