### PR TITLE
[fuchsia] Manually roll Fuchsia Linux SDK.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -826,7 +826,7 @@ deps = {
      'packages': [
        {
         'package': 'fuchsia/sdk/core/linux-amd64',
-        'version': 'e2lfUFBW5ddtTZBbwpfFb9CPMHUJF6xmQmYDmaz5Df8C'
+        'version': 'zwfwHRSLdmV61hYqecvVYmk53-hABFbkUNUIMY8ZZVQC'
        }
      ],
      'condition': 'host_os == "linux" and not download_fuchsia_sdk',

--- a/ci/licenses_golden/excluded_files
+++ b/ci/licenses_golden/excluded_files
@@ -490,6 +490,7 @@
 ../../../fuchsia/sdk/linux/fidl/fuchsia.hardware.adc/meta.json
 ../../../fuchsia/sdk/linux/fidl/fuchsia.hardware.audio.signalprocessing/meta.json
 ../../../fuchsia/sdk/linux/fidl/fuchsia.hardware.audio/meta.json
+../../../fuchsia/sdk/linux/fidl/fuchsia.hardware.i2c/meta.json
 ../../../fuchsia/sdk/linux/fidl/fuchsia.hardware.light/meta.json
 ../../../fuchsia/sdk/linux/fidl/fuchsia.hardware.network/meta.json
 ../../../fuchsia/sdk/linux/fidl/fuchsia.hardware.power.statecontrol/meta.json

--- a/ci/licenses_golden/licenses_fuchsia
+++ b/ci/licenses_golden/licenses_fuchsia
@@ -1,4 +1,4 @@
-Signature: 4b0162e54f800056ccba552592ba5b88
+Signature: 9c8c53a57708a1bdfa8abb9badb41bb1
 
 ====================================================================================================
 LIBRARY: fuchsia_sdk
@@ -1242,6 +1242,7 @@ ORIGIN: ../../../fuchsia/sdk/linux/fidl/fuchsia.camera/manager.fidl + ../../../f
 ORIGIN: ../../../fuchsia/sdk/linux/fidl/fuchsia.data/data.fidl + ../../../fuchsia/sdk/linux/LICENSE
 ORIGIN: ../../../fuchsia/sdk/linux/fidl/fuchsia.developer.tiles/tiles.fidl + ../../../fuchsia/sdk/linux/LICENSE
 ORIGIN: ../../../fuchsia/sdk/linux/fidl/fuchsia.gpu.magma/magma.fidl + ../../../fuchsia/sdk/linux/LICENSE
+ORIGIN: ../../../fuchsia/sdk/linux/fidl/fuchsia.hardware.i2c/i2c.fidl + ../../../fuchsia/sdk/linux/LICENSE
 ORIGIN: ../../../fuchsia/sdk/linux/fidl/fuchsia.images/encoded_image.fidl + ../../../fuchsia/sdk/linux/LICENSE
 ORIGIN: ../../../fuchsia/sdk/linux/fidl/fuchsia.images/image_info.fidl + ../../../fuchsia/sdk/linux/LICENSE
 ORIGIN: ../../../fuchsia/sdk/linux/fidl/fuchsia.images/memory_type.fidl + ../../../fuchsia/sdk/linux/LICENSE
@@ -1494,6 +1495,7 @@ FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.camera/manager.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.data/data.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.developer.tiles/tiles.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.gpu.magma/magma.fidl
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.hardware.i2c/i2c.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.images/encoded_image.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.images/image_info.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.images/memory_type.fidl


### PR DESCRIPTION
There's a licenses failure that the SDK roll isn't taking care of for some reason ([example failure](https://ci.chromium.org/ui/p/flutter/builders/try/Linux%20License/8073/overview)). Manually rolling with the change to resolve.