### PR TITLE
Sped up reading with FlutterStandardCodec.

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -2417,6 +2417,8 @@ ORIGIN: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterCh
 ORIGIN: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterChannelsTest.m + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterCodecs.mm + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterStandardCodec.mm + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterStandardCodecHelper.c + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterStandardCodecHelper.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterStandardCodec_Internal.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/graphics/FlutterDarwinContextMetalImpeller.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/graphics/FlutterDarwinContextMetalImpeller.mm + ../../../flutter/LICENSE

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -4872,6 +4872,8 @@ FILE: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterChan
 FILE: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterChannelsTest.m
 FILE: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterCodecs.mm
 FILE: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterStandardCodec.mm
+FILE: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterStandardCodecHelper.c
+FILE: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterStandardCodecHelper.h
 FILE: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterStandardCodec_Internal.h
 FILE: ../../../flutter/shell/platform/darwin/graphics/FlutterDarwinContextMetalImpeller.h
 FILE: ../../../flutter/shell/platform/darwin/graphics/FlutterDarwinContextMetalImpeller.mm

--- a/shell/platform/darwin/BUILD.gn
+++ b/shell/platform/darwin/BUILD.gn
@@ -47,6 +47,7 @@ source_set("flutter_channels_arc") {
     "common/framework/Source/FlutterChannels.mm",
     "common/framework/Source/FlutterCodecs.mm",
     "common/framework/Source/FlutterStandardCodec.mm",
+    "common/framework/Source/FlutterStandardCodecHelper.c",
     "common/framework/Source/FlutterStandardCodec_Internal.h",
   ]
 

--- a/shell/platform/darwin/common/BUILD.gn
+++ b/shell/platform/darwin/common/BUILD.gn
@@ -37,6 +37,7 @@ source_set("framework_shared") {
     "framework/Source/FlutterChannels.mm",
     "framework/Source/FlutterCodecs.mm",
     "framework/Source/FlutterStandardCodec.mm",
+    "framework/Source/FlutterStandardCodecHelper.c",
     "framework/Source/FlutterStandardCodec_Internal.h",
   ]
 

--- a/shell/platform/darwin/common/framework/Source/FlutterStandardCodecHelper.c
+++ b/shell/platform/darwin/common/framework/Source/FlutterStandardCodecHelper.c
@@ -1,0 +1,189 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/darwin/common/framework/Source/FlutterStandardCodecHelper.h"
+#include <stdint.h>
+
+void FlutterStandardCodecHelperReadAlignment(unsigned long* location,
+                                             uint8_t alignment) {
+  uint8_t mod = *location % alignment;
+  if (mod) {
+    *location += (alignment - mod);
+  }
+}
+
+static uint8_t PeekByte(unsigned long location, CFDataRef data) {
+  uint8_t result;
+  CFRange range = CFRangeMake(location, 1);
+  CFDataGetBytes(data, range, &result);
+  return result;
+}
+
+static bool IsStandardType(uint8_t type) {
+  switch (type) {
+    case FlutterStandardFieldNil:
+    case FlutterStandardFieldTrue:
+    case FlutterStandardFieldFalse:
+    case FlutterStandardFieldInt32:
+    case FlutterStandardFieldInt64:
+    case FlutterStandardFieldIntHex:
+    case FlutterStandardFieldFloat64:
+    case FlutterStandardFieldString:
+    case FlutterStandardFieldUInt8Data:
+    case FlutterStandardFieldInt32Data:
+    case FlutterStandardFieldInt64Data:
+    case FlutterStandardFieldFloat64Data:
+    case FlutterStandardFieldList:
+    case FlutterStandardFieldMap:
+    case FlutterStandardFieldFloat32Data:
+      return true;
+    default:
+      return false;
+  }
+}
+
+void FlutterStandardCodecHelperReadBytes(unsigned long* location,
+                                         unsigned long length,
+                                         void* destination,
+                                         CFDataRef data) {
+  CFRange range = CFRangeMake(*location, length);
+  CFDataGetBytes(data, range, destination);
+  *location += length;
+}
+
+uint8_t FlutterStandardCodecHelperReadByte(unsigned long* location,
+                                           CFDataRef data) {
+  uint8_t value;
+  FlutterStandardCodecHelperReadBytes(location, 1, &value, data);
+  return value;
+}
+
+uint32_t FlutterStandardCodecHelperReadSize(unsigned long* location,
+                                            CFDataRef data) {
+  uint8_t byte = FlutterStandardCodecHelperReadByte(location, data);
+  if (byte < 254) {
+    return (uint32_t)byte;
+  } else if (byte == 254) {
+    UInt16 value;
+    FlutterStandardCodecHelperReadBytes(location, 2, &value, data);
+    return value;
+  } else {
+    UInt32 value;
+    FlutterStandardCodecHelperReadBytes(location, 4, &value, data);
+    return value;
+  }
+}
+
+static CFDataRef ReadDataNoCopy(unsigned long* location,
+                                unsigned long length,
+                                CFDataRef data) {
+  CFDataRef result = CFDataCreateWithBytesNoCopy(
+      kCFAllocatorDefault, CFDataGetBytePtr(data) + *location, length,
+      kCFAllocatorNull);
+  *location += length;
+  return CFAutorelease(result);
+}
+
+CFStringRef FlutterStandardCodecHelperReadUTF8(unsigned long* location,
+                                               CFDataRef data) {
+  uint32_t size = FlutterStandardCodecHelperReadSize(location, data);
+  CFDataRef bytes = ReadDataNoCopy(location, size, data);
+  CFStringRef result = CFStringCreateFromExternalRepresentation(
+      kCFAllocatorDefault, bytes, kCFStringEncodingUTF8);
+  return CFAutorelease(result);
+}
+
+// Peeks ahead to see if we are reading a standard type.  If so, recurse
+// directly to FlutterStandardCodecHelperReadValueOfType, otherwise recurse to
+// objc.
+static inline CFTypeRef FastReadValue(
+    unsigned long* location,
+    CFDataRef data,
+    CFTypeRef (*ReadValue)(CFTypeRef),
+    CFTypeRef (*ReadTypedDataOfType)(FlutterStandardField, CFTypeRef),
+    CFTypeRef user_data) {
+  uint8_t type = PeekByte(*location, data);
+  if (IsStandardType(type)) {
+    *location += 1;
+    return FlutterStandardCodecHelperReadValueOfType(
+        location, data, type, ReadValue, ReadTypedDataOfType, user_data);
+  } else {
+    return ReadValue(user_data);
+  }
+}
+
+CFTypeRef FlutterStandardCodecHelperReadValueOfType(
+    unsigned long* location,
+    CFDataRef data,
+    uint8_t type,
+    CFTypeRef (*ReadValue)(CFTypeRef),
+    CFTypeRef (*ReadTypedDataOfType)(FlutterStandardField, CFTypeRef),
+    CFTypeRef user_data) {
+  FlutterStandardField field = (FlutterStandardField)type;
+  switch (field) {
+    case FlutterStandardFieldNil:
+      return nil;
+    case FlutterStandardFieldTrue:
+      return kCFBooleanTrue;
+    case FlutterStandardFieldFalse:
+      return kCFBooleanFalse;
+    case FlutterStandardFieldInt32: {
+      int32_t value;
+      FlutterStandardCodecHelperReadBytes(location, 4, &value, data);
+      return CFAutorelease(
+          CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, &value));
+    }
+    case FlutterStandardFieldInt64: {
+      int64_t value;
+      FlutterStandardCodecHelperReadBytes(location, 8, &value, data);
+      return CFAutorelease(
+          CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt64Type, &value));
+    }
+    case FlutterStandardFieldFloat64: {
+      Float64 value;
+      FlutterStandardCodecHelperReadAlignment(location, 8);
+      FlutterStandardCodecHelperReadBytes(location, 8, &value, data);
+      return CFAutorelease(
+          CFNumberCreate(kCFAllocatorDefault, kCFNumberDoubleType, &value));
+    }
+    case FlutterStandardFieldIntHex:
+    case FlutterStandardFieldString:
+      return FlutterStandardCodecHelperReadUTF8(location, data);
+    case FlutterStandardFieldUInt8Data:
+    case FlutterStandardFieldInt32Data:
+    case FlutterStandardFieldInt64Data:
+    case FlutterStandardFieldFloat32Data:
+    case FlutterStandardFieldFloat64Data:
+      return ReadTypedDataOfType(field, user_data);
+    case FlutterStandardFieldList: {
+      UInt32 length = FlutterStandardCodecHelperReadSize(location, data);
+      CFMutableArrayRef array = CFArrayCreateMutable(
+          kCFAllocatorDefault, length, &kCFTypeArrayCallBacks);
+      for (UInt32 i = 0; i < length; i++) {
+        CFTypeRef value = FastReadValue(location, data, ReadValue,
+                                        ReadTypedDataOfType, user_data);
+        CFArrayAppendValue(array, (value == nil ? kCFNull : value));
+      }
+      return CFAutorelease(array);
+    }
+    case FlutterStandardFieldMap: {
+      UInt32 size = FlutterStandardCodecHelperReadSize(location, data);
+      CFMutableDictionaryRef dict = CFDictionaryCreateMutable(
+          kCFAllocatorDefault, size, &kCFTypeDictionaryKeyCallBacks,
+          &kCFTypeDictionaryValueCallBacks);
+      for (UInt32 i = 0; i < size; i++) {
+        CFTypeRef key = FastReadValue(location, data, ReadValue,
+                                      ReadTypedDataOfType, user_data);
+        CFTypeRef val = FastReadValue(location, data, ReadValue,
+                                      ReadTypedDataOfType, user_data);
+        CFDictionaryAddValue(dict, (key == nil ? kCFNull : key),
+                             (val == nil ? kCFNull : val));
+      }
+      return CFAutorelease(dict);
+    }
+    default:
+      // Malformed message.
+      assert(false);
+  }
+}

--- a/shell/platform/darwin/common/framework/Source/FlutterStandardCodecHelper.c
+++ b/shell/platform/darwin/common/framework/Source/FlutterStandardCodecHelper.c
@@ -20,29 +20,6 @@ static uint8_t PeekByte(unsigned long location, CFDataRef data) {
   return result;
 }
 
-static bool IsStandardType(uint8_t type) {
-  switch (type) {
-    case FlutterStandardFieldNil:
-    case FlutterStandardFieldTrue:
-    case FlutterStandardFieldFalse:
-    case FlutterStandardFieldInt32:
-    case FlutterStandardFieldInt64:
-    case FlutterStandardFieldIntHex:
-    case FlutterStandardFieldFloat64:
-    case FlutterStandardFieldString:
-    case FlutterStandardFieldUInt8Data:
-    case FlutterStandardFieldInt32Data:
-    case FlutterStandardFieldInt64Data:
-    case FlutterStandardFieldFloat64Data:
-    case FlutterStandardFieldList:
-    case FlutterStandardFieldMap:
-    case FlutterStandardFieldFloat32Data:
-      return true;
-    default:
-      return false;
-  }
-}
-
 void FlutterStandardCodecHelperReadBytes(unsigned long* location,
                                          unsigned long length,
                                          void* destination,
@@ -104,7 +81,7 @@ static inline CFTypeRef FastReadValue(
     CFTypeRef (*ReadTypedDataOfType)(FlutterStandardField, CFTypeRef),
     CFTypeRef user_data) {
   uint8_t type = PeekByte(*location, data);
-  if (IsStandardType(type)) {
+  if (FlutterStandardFieldIsStandardType(type)) {
     *location += 1;
     return FlutterStandardCodecHelperReadValueOfType(
         location, data, type, ReadValue, ReadTypedDataOfType, user_data);

--- a/shell/platform/darwin/common/framework/Source/FlutterStandardCodecHelper.h
+++ b/shell/platform/darwin/common/framework/Source/FlutterStandardCodecHelper.h
@@ -6,12 +6,14 @@
 #define SHELL_PLATFORM_DARWIN_COMMON_FRAMEWORK_SOURCE_FLUTTERSTANDARDCODECHELPER_H_
 
 #include <CoreFoundation/CoreFoundation.h>
+#include <stdbool.h>
 #include <stdint.h>
 
 #if defined(__cplusplus)
 extern "C" {
 #endif
 
+// Note: Update FlutterStandardFieldIsStandardType if this changes.
 typedef enum {
   FlutterStandardFieldNil,
   FlutterStandardFieldTrue,
@@ -29,6 +31,11 @@ typedef enum {
   FlutterStandardFieldMap,
   FlutterStandardFieldFloat32Data,
 } FlutterStandardField;
+
+static inline bool FlutterStandardFieldIsStandardType(uint8_t field) {
+  return field <= FlutterStandardFieldFloat32Data &&
+         field >= FlutterStandardFieldNil;
+}
 
 void FlutterStandardCodecHelperReadAlignment(unsigned long* location,
                                              uint8_t alignment);

--- a/shell/platform/darwin/common/framework/Source/FlutterStandardCodecHelper.h
+++ b/shell/platform/darwin/common/framework/Source/FlutterStandardCodecHelper.h
@@ -1,0 +1,62 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef SHELL_PLATFORM_DARWIN_COMMON_FRAMEWORK_SOURCE_FLUTTERSTANDARDCODECHELPER_H_
+#define SHELL_PLATFORM_DARWIN_COMMON_FRAMEWORK_SOURCE_FLUTTERSTANDARDCODECHELPER_H_
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <stdint.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+typedef enum {
+  FlutterStandardFieldNil,
+  FlutterStandardFieldTrue,
+  FlutterStandardFieldFalse,
+  FlutterStandardFieldInt32,
+  FlutterStandardFieldInt64,
+  FlutterStandardFieldIntHex,
+  FlutterStandardFieldFloat64,
+  FlutterStandardFieldString,
+  FlutterStandardFieldUInt8Data,
+  FlutterStandardFieldInt32Data,
+  FlutterStandardFieldInt64Data,
+  FlutterStandardFieldFloat64Data,
+  FlutterStandardFieldList,
+  FlutterStandardFieldMap,
+  FlutterStandardFieldFloat32Data,
+} FlutterStandardField;
+
+void FlutterStandardCodecHelperReadAlignment(unsigned long* location,
+                                             uint8_t alignment);
+
+void FlutterStandardCodecHelperReadBytes(unsigned long* location,
+                                         unsigned long length,
+                                         void* destination,
+                                         CFDataRef data);
+
+uint8_t FlutterStandardCodecHelperReadByte(unsigned long* location,
+                                           CFDataRef data);
+
+uint32_t FlutterStandardCodecHelperReadSize(unsigned long* location,
+                                            CFDataRef data);
+
+CFStringRef FlutterStandardCodecHelperReadUTF8(unsigned long* location,
+                                               CFDataRef data);
+
+CFTypeRef FlutterStandardCodecHelperReadValueOfType(
+    unsigned long* location,
+    CFDataRef data,
+    uint8_t type,
+    CFTypeRef (*ReadValue)(CFTypeRef),
+    CFTypeRef (*ReadTypedDataOfType)(FlutterStandardField, CFTypeRef),
+    CFTypeRef user_data);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif  // SHELL_PLATFORM_DARWIN_COMMON_FRAMEWORK_SOURCE_FLUTTERSTANDARDCODECHELPER_H_

--- a/shell/platform/darwin/common/framework/Source/FlutterStandardCodec_Internal.h
+++ b/shell/platform/darwin/common/framework/Source/FlutterStandardCodec_Internal.h
@@ -6,27 +6,11 @@
 #define SHELL_PLATFORM_DARWIN_COMMON_FRAMEWORK_SOURCE_FLUTTERSTANDARDCODECINTERNAL_H_
 
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterCodecs.h"
-
-typedef NS_ENUM(NSInteger, FlutterStandardField) {
-  FlutterStandardFieldNil,
-  FlutterStandardFieldTrue,
-  FlutterStandardFieldFalse,
-  FlutterStandardFieldInt32,
-  FlutterStandardFieldInt64,
-  FlutterStandardFieldIntHex,
-  FlutterStandardFieldFloat64,
-  FlutterStandardFieldString,
-  FlutterStandardFieldUInt8Data,
-  FlutterStandardFieldInt32Data,
-  FlutterStandardFieldInt64Data,
-  FlutterStandardFieldFloat64Data,
-  FlutterStandardFieldList,
-  FlutterStandardFieldMap,
-  FlutterStandardFieldFloat32Data,
-};
+#import "flutter/shell/platform/darwin/common/framework/Source/FlutterStandardCodecHelper.h"
 
 namespace flutter {
-FlutterStandardField FlutterStandardFieldForDataType(FlutterStandardDataType type) {
+FlutterStandardField FlutterStandardFieldForDataType(
+    FlutterStandardDataType type) {
   switch (type) {
     case FlutterStandardDataTypeUInt8:
       return FlutterStandardFieldUInt8Data;
@@ -40,7 +24,8 @@ FlutterStandardField FlutterStandardFieldForDataType(FlutterStandardDataType typ
       return FlutterStandardFieldFloat64Data;
   }
 }
-FlutterStandardDataType FlutterStandardDataTypeForField(FlutterStandardField field) {
+FlutterStandardDataType FlutterStandardDataTypeForField(
+    FlutterStandardField field) {
   switch (field) {
     case FlutterStandardFieldUInt8Data:
       return FlutterStandardDataTypeUInt8;


### PR DESCRIPTION
No functional change, just an improvement in 19% increase codec reading speed.  The gains were using a CFData create function that avoids a copy for a temporary data object until it is converted to a string, avoiding some objc_msgSend, avoiding some retain/release, and avoiding the objc recursion if we know the next object we are reading can be read in C.

before:
<img width="719" alt="Screen Shot 2022-12-15 at 8 56 17 AM" src="https://user-images.githubusercontent.com/30870216/207963470-7d553547-0ff8-45a1-b1c6-1702b336343e.png">

after:
<img width="658" alt="Screen Shot 2022-12-15 at 12 40 04 PM" src="https://user-images.githubusercontent.com/30870216/207963442-0e7f9833-b8e3-4cbb-906c-8abcfbb3e4b5.png">

tests:
- performance benchmark will be covered by the platform_channel_benchmarks
- integration tests exist for channels

implementation of investigation @cyanglaz and I did on https://github.com/flutter/engine/pull/37883

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
