### PR TITLE
Sped up FlutterStandardCodec writing speed.

### DIFF
--- a/shell/platform/darwin/common/framework/Source/FlutterStandardCodecHelper.h
+++ b/shell/platform/darwin/common/framework/Source/FlutterStandardCodecHelper.h
@@ -49,8 +49,8 @@ typedef enum {
 } FlutterStandardCodecObjcType;
 
 ///////////////////////////////////////////////////////////////////////////////
-// Reader Helpers
-///////////////////////////////////////////////////////////////////////////////
+///\name Reader Helpers
+///@{
 
 void FlutterStandardCodecHelperReadAlignment(unsigned long* location,
                                              uint8_t alignment);
@@ -77,9 +77,11 @@ CFTypeRef FlutterStandardCodecHelperReadValueOfType(
     CFTypeRef (*ReadTypedDataOfType)(FlutterStandardField, CFTypeRef),
     CFTypeRef user_data);
 
+///@}
+
 ///////////////////////////////////////////////////////////////////////////////
-// Writer Helpers
-///////////////////////////////////////////////////////////////////////////////
+///\name Writer Helpers
+///@{
 
 void FlutterStandardCodecHelperWriteByte(CFMutableDataRef data, uint8_t value);
 
@@ -100,6 +102,8 @@ void FlutterStandardCodecHelperWriteData(CFMutableDataRef data,
 
 bool FlutterStandardCodecHelperWriteNumber(CFMutableDataRef data,
                                            CFNumberRef number);
+
+///@}
 
 #if defined(__cplusplus)
 }

--- a/shell/platform/darwin/common/framework/Source/FlutterStandardCodecHelper.h
+++ b/shell/platform/darwin/common/framework/Source/FlutterStandardCodecHelper.h
@@ -48,6 +48,10 @@ typedef enum {
   FlutterStandardCodecObjcTypeUnknown,
 } FlutterStandardCodecObjcType;
 
+///////////////////////////////////////////////////////////////////////////////
+// Reader Helpers
+///////////////////////////////////////////////////////////////////////////////
+
 void FlutterStandardCodecHelperReadAlignment(unsigned long* location,
                                              uint8_t alignment);
 
@@ -73,7 +77,10 @@ CFTypeRef FlutterStandardCodecHelperReadValueOfType(
     CFTypeRef (*ReadTypedDataOfType)(FlutterStandardField, CFTypeRef),
     CFTypeRef user_data);
 
-//////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////
+// Writer Helpers
+///////////////////////////////////////////////////////////////////////////////
+
 void FlutterStandardCodecHelperWriteByte(CFMutableDataRef data, uint8_t value);
 
 void FlutterStandardCodecHelperWriteBytes(CFMutableDataRef data,

--- a/shell/platform/darwin/common/framework/Source/FlutterStandardCodecHelper.h
+++ b/shell/platform/darwin/common/framework/Source/FlutterStandardCodecHelper.h
@@ -37,6 +37,17 @@ static inline bool FlutterStandardFieldIsStandardType(uint8_t field) {
          field >= FlutterStandardFieldNil;
 }
 
+typedef enum {
+  FlutterStandardCodecObjcTypeNil,
+  FlutterStandardCodecObjcTypeNSNumber,
+  FlutterStandardCodecObjcTypeNSString,
+  FlutterStandardCodecObjcTypeFlutterStandardTypedData,
+  FlutterStandardCodecObjcTypeNSData,
+  FlutterStandardCodecObjcTypeNSArray,
+  FlutterStandardCodecObjcTypeNSDictionary,
+  FlutterStandardCodecObjcTypeUnknown,
+} FlutterStandardCodecObjcType;
+
 void FlutterStandardCodecHelperReadAlignment(unsigned long* location,
                                              uint8_t alignment);
 
@@ -61,6 +72,27 @@ CFTypeRef FlutterStandardCodecHelperReadValueOfType(
     CFTypeRef (*ReadValue)(CFTypeRef),
     CFTypeRef (*ReadTypedDataOfType)(FlutterStandardField, CFTypeRef),
     CFTypeRef user_data);
+
+//////////////////////////////////////////////
+void FlutterStandardCodecHelperWriteByte(CFMutableDataRef data, uint8_t value);
+
+void FlutterStandardCodecHelperWriteBytes(CFMutableDataRef data,
+                                          const void* bytes,
+                                          unsigned long length);
+
+void FlutterStandardCodecHelperWriteSize(CFMutableDataRef data, uint32_t size);
+
+void FlutterStandardCodecHelperWriteAlignment(CFMutableDataRef data,
+                                              uint8_t alignment);
+
+void FlutterStandardCodecHelperWriteUTF8(CFMutableDataRef data,
+                                         CFStringRef value);
+
+void FlutterStandardCodecHelperWriteData(CFMutableDataRef data,
+                                         CFDataRef value);
+
+bool FlutterStandardCodecHelperWriteNumber(CFMutableDataRef data,
+                                           CFNumberRef number);
 
 #if defined(__cplusplus)
 }


### PR DESCRIPTION
This improves encoding time 18% (based on the platform channel large benchmark).

This follows up on the investigation done in https://github.com/flutter/engine/pull/37883.  After this lands we should be almost back where we were before the ARC migration.

This includes the following optimizations:
1) A big win was made from avoiding `[NSNull null]` since it caused alot of ARC activity
1) Iterating over maps doesn't require looking up the values now
1) NSStrings in utf8 format will get read from directly (I'm not sure how this compares with objc logic)
1) For common datatypes no arc should be used (e.g. a List with Strings and Ints)
1) For common datatypes recursion happens with c function invocations instead of objc_msgSend

There is no functional change here, just performance change.

before:
<img width="656" alt="Screen Shot 2022-12-15 at 11 04 36 PM" src="https://user-images.githubusercontent.com/30870216/208042918-5e556cda-1bbc-4abc-a59b-e9afe18240db.png">

after:
<img width="516" alt="Screen Shot 2022-12-15 at 10 58 59 PM" src="https://user-images.githubusercontent.com/30870216/208042943-b6051182-5dbc-47ab-8653-e93f86071302.png">

There are existing tests that cover the PR:
 - platform channel benchmarks
 - unit tests in the engine
 - integration tests in the framework

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
