### PR TITLE
Revert "Started using FlutterEngineGroups by default on Android  (#37822)"

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -149,8 +149,7 @@ import java.util.List;
  *
  * <pre>{@code
  * // Create and pre-warm a FlutterEngine.
- * FlutterEngineGroup group = new FlutterEngineGroup(context);
- * FlutterEngine flutterEngine = group.createAndRunDefaultEngine(context);
+ * FlutterEngine flutterEngine = new FlutterEngine(context);
  * flutterEngine.getDartExecutor().executeDartEntrypoint(DartEntrypoint.createDefault());
  *
  * // Cache the pre-warmed FlutterEngine in the FlutterEngineCache.

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -90,7 +90,6 @@ import java.util.List;
   private boolean isFirstFrameRendered;
   private boolean isAttached;
   private Integer previousVisibility;
-  @Nullable private FlutterEngineGroup engineGroup;
 
   @NonNull
   private final FlutterUiDisplayListener flutterUiDisplayListener =
@@ -110,15 +109,8 @@ import java.util.List;
       };
 
   FlutterActivityAndFragmentDelegate(@NonNull Host host) {
-    this(host, null);
-  }
-
-  FlutterActivityAndFragmentDelegate(@NonNull Host host, @Nullable FlutterEngineGroup engineGroup) {
     this.host = host;
     this.isFirstFrameRendered = false;
-    if (engineGroup != null) {
-      this.engineGroup = engineGroup;
-    }
   }
 
   /**
@@ -306,16 +298,12 @@ import java.util.List;
         TAG,
         "No preferred FlutterEngine was provided. Creating a new FlutterEngine for"
             + " this FlutterFragment.");
-
-    FlutterEngineGroup group =
-        engineGroup == null
-            ? new FlutterEngineGroup(host.getContext(), host.getFlutterShellArgs().toArray())
-            : engineGroup;
     flutterEngine =
-        group.createAndRunEngine(
-            new FlutterEngineGroup.Options(host.getContext())
-                .setAutomaticallyRegisterPlugins(false)
-                .setWaitForRestorationData(host.shouldRestoreAndSaveState()));
+        new FlutterEngine(
+            host.getContext(),
+            host.getFlutterShellArgs().toArray(),
+            /*automaticallyRegisterPlugins=*/ false,
+            /*willProvideRestorationData=*/ host.shouldRestoreAndSaveState());
     isFlutterEngineFromHost = false;
   }
 

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
@@ -79,8 +79,7 @@ import java.util.List;
  *
  * <pre>{@code
  * // Create and pre-warm a FlutterEngine.
- * FlutterEngineGroup group = new FlutterEngineGroup(context);
- * FlutterEngine flutterEngine = group.createAndRunDefaultEngine(context);
+ * FlutterEngine flutterEngine = new FlutterEngine(context);
  * flutterEngine
  *   .getDartExecutor()
  *   .executeDartEntrypoint(DartEntrypoint.createDefault());

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
@@ -9,7 +9,6 @@ import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.res.AssetManager;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.annotation.VisibleForTesting;
 import io.flutter.FlutterInjector;
 import io.flutter.Log;
 import io.flutter.embedding.engine.dart.DartExecutor;
@@ -280,27 +279,6 @@ public class FlutterEngine {
       @Nullable String[] dartVmArgs,
       boolean automaticallyRegisterPlugins,
       boolean waitForRestorationData) {
-    this(
-        context,
-        flutterLoader,
-        flutterJNI,
-        platformViewsController,
-        dartVmArgs,
-        automaticallyRegisterPlugins,
-        waitForRestorationData,
-        null);
-  }
-
-  @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
-  public FlutterEngine(
-      @NonNull Context context,
-      @Nullable FlutterLoader flutterLoader,
-      @NonNull FlutterJNI flutterJNI,
-      @NonNull PlatformViewsController platformViewsController,
-      @Nullable String[] dartVmArgs,
-      boolean automaticallyRegisterPlugins,
-      boolean waitForRestorationData,
-      @Nullable FlutterEngineGroup group) {
     AssetManager assetManager;
     try {
       assetManager = context.createPackageContext(context.getPackageName(), 0).getAssets();
@@ -369,8 +347,7 @@ public class FlutterEngine {
     this.platformViewsController.onAttachedToJNI();
 
     this.pluginRegistry =
-        new FlutterEngineConnectionRegistry(
-            context.getApplicationContext(), this, flutterLoader, group);
+        new FlutterEngineConnectionRegistry(context.getApplicationContext(), this, flutterLoader);
 
     localizationPlugin.sendLocalesToFlutter(context.getResources().getConfiguration());
 

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngineConnectionRegistry.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngineConnectionRegistry.java
@@ -97,8 +97,7 @@ import java.util.Set;
   FlutterEngineConnectionRegistry(
       @NonNull Context appContext,
       @NonNull FlutterEngine flutterEngine,
-      @NonNull FlutterLoader flutterLoader,
-      @Nullable FlutterEngineGroup group) {
+      @NonNull FlutterLoader flutterLoader) {
     this.flutterEngine = flutterEngine;
     pluginBinding =
         new FlutterPlugin.FlutterPluginBinding(
@@ -107,8 +106,7 @@ import java.util.Set;
             flutterEngine.getDartExecutor(),
             flutterEngine.getRenderer(),
             flutterEngine.getPlatformViewsController().getRegistry(),
-            new DefaultFlutterAssets(flutterLoader),
-            group);
+            new DefaultFlutterAssets(flutterLoader));
   }
 
   public void destroy() {

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngineGroup.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngineGroup.java
@@ -210,8 +210,7 @@ public class FlutterEngineGroup {
         platformViewsController, // PlatformViewsController.
         null, // String[]. The Dart VM has already started, this arguments will have no effect.
         automaticallyRegisterPlugins, // boolean.
-        waitForRestorationData, // boolean.
-        this);
+        waitForRestorationData); // boolean.
   }
 
   /** Options that control how a FlutterEngine should be created. */

--- a/shell/platform/android/io/flutter/embedding/engine/plugins/FlutterPlugin.java
+++ b/shell/platform/android/io/flutter/embedding/engine/plugins/FlutterPlugin.java
@@ -6,10 +6,8 @@ package io.flutter.embedding.engine.plugins;
 
 import android.content.Context;
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.lifecycle.Lifecycle;
 import io.flutter.embedding.engine.FlutterEngine;
-import io.flutter.embedding.engine.FlutterEngineGroup;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.platform.PlatformViewRegistry;
 import io.flutter.view.TextureRegistry;
@@ -109,7 +107,6 @@ public interface FlutterPlugin {
     private final TextureRegistry textureRegistry;
     private final PlatformViewRegistry platformViewRegistry;
     private final FlutterAssets flutterAssets;
-    private final FlutterEngineGroup group;
 
     public FlutterPluginBinding(
         @NonNull Context applicationContext,
@@ -117,15 +114,13 @@ public interface FlutterPlugin {
         @NonNull BinaryMessenger binaryMessenger,
         @NonNull TextureRegistry textureRegistry,
         @NonNull PlatformViewRegistry platformViewRegistry,
-        @NonNull FlutterAssets flutterAssets,
-        @Nullable FlutterEngineGroup group) {
+        @NonNull FlutterAssets flutterAssets) {
       this.applicationContext = applicationContext;
       this.flutterEngine = flutterEngine;
       this.binaryMessenger = binaryMessenger;
       this.textureRegistry = textureRegistry;
       this.platformViewRegistry = platformViewRegistry;
       this.flutterAssets = flutterAssets;
-      this.group = group;
     }
 
     @NonNull
@@ -161,21 +156,6 @@ public interface FlutterPlugin {
     @NonNull
     public FlutterAssets getFlutterAssets() {
       return flutterAssets;
-    }
-
-    /**
-     * Accessor for the {@link FlutterEngineGroup} used to create the {@link FlutterEngine} for the
-     * app.
-     *
-     * <p>This is useful in the rare case that a plugin has to spawn its own engine (for example,
-     * running an engine the background). The result is nullable since old versions of Flutter and
-     * custom setups may not have used a {@link FlutterEngineGroup}. Failing to use this when it is
-     * available will result in suboptimal performance and odd behaviors related to Dart isolate
-     * groups.
-     */
-    @Nullable
-    public FlutterEngineGroup getEngineGroup() {
-      return group;
     }
   }
 

--- a/shell/platform/android/io/flutter/embedding/engine/plugins/shim/ShimPluginRegistry.java
+++ b/shell/platform/android/io/flutter/embedding/engine/plugins/shim/ShimPluginRegistry.java
@@ -25,8 +25,7 @@ import java.util.Set;
  *
  * <pre>
  * // Create the FlutterEngine that will back the Flutter UI.
- * FlutterEngineGroup group = new FlutterEngineGroup(context);
- * FlutterEngine flutterEngine = group.createAndRunDefaultEngine(context);
+ * FlutterEngine flutterEngine = new FlutterEngine(context);
  *
  * // Create a ShimPluginRegistry and wrap the FlutterEngine with the shim.
  * ShimPluginRegistry shimPluginRegistry = new ShimPluginRegistry(flutterEngine, platformViewsController);

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
@@ -1159,22 +1159,6 @@ public class FlutterActivityAndFragmentDelegateTest {
     assertNull(delegate.activePreDrawListener);
   }
 
-  @Test
-  public void usesFlutterEngineGroup() {
-    FlutterEngineGroup mockEngineGroup = mock(FlutterEngineGroup.class);
-    when(mockEngineGroup.createAndRunEngine(any(FlutterEngineGroup.Options.class)))
-        .thenReturn(mockFlutterEngine);
-    FlutterActivityAndFragmentDelegate.Host host =
-        mock(FlutterActivityAndFragmentDelegate.Host.class);
-    when(mockHost.getContext()).thenReturn(ctx);
-
-    FlutterActivityAndFragmentDelegate delegate =
-        new FlutterActivityAndFragmentDelegate(mockHost, mockEngineGroup);
-    delegate.onAttach(ctx);
-    FlutterEngine engineUnderTest = delegate.getFlutterEngine();
-    assertEquals(engineUnderTest, mockFlutterEngine);
-  }
-
   /**
    * Creates a mock {@link io.flutter.embedding.engine.FlutterEngine}.
    *

--- a/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineConnectionRegistryTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineConnectionRegistryTest.java
@@ -40,7 +40,7 @@ public class FlutterEngineConnectionRegistryTest {
     FakeFlutterPlugin fakePlugin2 = new FakeFlutterPlugin();
 
     FlutterEngineConnectionRegistry registry =
-        new FlutterEngineConnectionRegistry(context, flutterEngine, flutterLoader, null);
+        new FlutterEngineConnectionRegistry(context, flutterEngine, flutterLoader);
 
     // Verify that the registry doesn't think it contains our plugin yet.
     assertFalse(registry.has(fakePlugin1.getClass()));
@@ -86,7 +86,7 @@ public class FlutterEngineConnectionRegistryTest {
 
     // Set up the environment to get the required internal data
     FlutterEngineConnectionRegistry registry =
-        new FlutterEngineConnectionRegistry(context, flutterEngine, flutterLoader, null);
+        new FlutterEngineConnectionRegistry(context, flutterEngine, flutterLoader);
     FakeActivityAwareFlutterPlugin fakePlugin = new FakeActivityAwareFlutterPlugin();
     registry.add(fakePlugin);
     registry.attachToActivity(appComponent, lifecycle);
@@ -129,7 +129,7 @@ public class FlutterEngineConnectionRegistryTest {
 
     // Test attachToActivity with an Activity that has no Intent.
     FlutterEngineConnectionRegistry registry =
-        new FlutterEngineConnectionRegistry(context, flutterEngine, flutterLoader, null);
+        new FlutterEngineConnectionRegistry(context, flutterEngine, flutterLoader);
     registry.attachToActivity(appComponent, mock(Lifecycle.class));
     verify(platformViewsController).setSoftwareRendering(false);
 

--- a/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineTest.java
@@ -25,11 +25,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import io.flutter.FlutterInjector;
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.FlutterEngine.EngineLifecycleListener;
-import io.flutter.embedding.engine.FlutterEngineGroup;
 import io.flutter.embedding.engine.FlutterJNI;
 import io.flutter.embedding.engine.loader.FlutterLoader;
-import io.flutter.embedding.engine.plugins.FlutterPlugin;
-import io.flutter.embedding.engine.plugins.PluginRegistry;
 import io.flutter.plugin.platform.PlatformViewsController;
 import io.flutter.plugins.GeneratedPluginRegistrant;
 import java.util.List;
@@ -325,35 +322,5 @@ public class FlutterEngineTest {
             /*automaticallyRegisterPlugins=*/ false);
 
     assertTrue(engineUnderTest.getDartExecutor().isExecutingDart());
-  }
-
-  @Test
-  public void passesEngineGroupToPlugins() throws NameNotFoundException {
-    Context packageContext = mock(Context.class);
-
-    when(mockContext.createPackageContext(any(), anyInt())).thenReturn(packageContext);
-    when(flutterJNI.isAttached()).thenReturn(true);
-
-    FlutterEngineGroup mockGroup = mock(FlutterEngineGroup.class);
-
-    FlutterEngine engineUnderTest =
-        new FlutterEngine(
-            mockContext,
-            mock(FlutterLoader.class),
-            flutterJNI,
-            new PlatformViewsController(),
-            /*dartVmArgs=*/ new String[] {},
-            /*automaticallyRegisterPlugins=*/ false,
-            /*waitForRestorationData=*/ false,
-            mockGroup);
-
-    PluginRegistry registry = engineUnderTest.getPlugins();
-    FlutterPlugin mockPlugin = mock(FlutterPlugin.class);
-    ArgumentCaptor<FlutterPlugin.FlutterPluginBinding> pluginBindingCaptor =
-        ArgumentCaptor.forClass(FlutterPlugin.FlutterPluginBinding.class);
-    registry.add(mockPlugin);
-    verify(mockPlugin).onAttachedToEngine(pluginBindingCaptor.capture());
-    assertNotNull(pluginBindingCaptor.getValue());
-    assertEquals(mockGroup, pluginBindingCaptor.getValue().getEngineGroup());
   }
 }


### PR DESCRIPTION
This reverts commit 47a358c5e8fc4a6deb057f738ce1e3432eb9c98f.

This commit caused a regression in the entrypoint_dart_registrant test.
