### PR TITLE
Use FML_DCHECK in place of assert in codec utils

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -2417,7 +2417,7 @@ ORIGIN: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterCh
 ORIGIN: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterChannelsTest.m + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterCodecs.mm + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterStandardCodec.mm + ../../../flutter/LICENSE
-ORIGIN: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterStandardCodecHelper.c + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterStandardCodecHelper.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterStandardCodecHelper.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterStandardCodec_Internal.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/graphics/FlutterDarwinContextMetalImpeller.h + ../../../flutter/LICENSE
@@ -4874,7 +4874,7 @@ FILE: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterChan
 FILE: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterChannelsTest.m
 FILE: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterCodecs.mm
 FILE: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterStandardCodec.mm
-FILE: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterStandardCodecHelper.c
+FILE: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterStandardCodecHelper.cc
 FILE: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterStandardCodecHelper.h
 FILE: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterStandardCodec_Internal.h
 FILE: ../../../flutter/shell/platform/darwin/graphics/FlutterDarwinContextMetalImpeller.h

--- a/shell/platform/darwin/BUILD.gn
+++ b/shell/platform/darwin/BUILD.gn
@@ -47,7 +47,7 @@ source_set("flutter_channels_arc") {
     "common/framework/Source/FlutterChannels.mm",
     "common/framework/Source/FlutterCodecs.mm",
     "common/framework/Source/FlutterStandardCodec.mm",
-    "common/framework/Source/FlutterStandardCodecHelper.c",
+    "common/framework/Source/FlutterStandardCodecHelper.cc",
     "common/framework/Source/FlutterStandardCodec_Internal.h",
   ]
 
@@ -60,6 +60,8 @@ source_set("flutter_channels_arc") {
   ]
 
   public_configs = [ "//flutter:config" ]
+
+  deps = [ "//flutter/fml" ]
 }
 
 test_fixtures("flutter_channels_fixtures") {

--- a/shell/platform/darwin/common/BUILD.gn
+++ b/shell/platform/darwin/common/BUILD.gn
@@ -37,7 +37,7 @@ source_set("framework_shared") {
     "framework/Source/FlutterChannels.mm",
     "framework/Source/FlutterCodecs.mm",
     "framework/Source/FlutterStandardCodec.mm",
-    "framework/Source/FlutterStandardCodecHelper.c",
+    "framework/Source/FlutterStandardCodecHelper.cc",
     "framework/Source/FlutterStandardCodec_Internal.h",
   ]
 
@@ -49,4 +49,6 @@ source_set("framework_shared") {
     "//flutter:config",
     ":framework_relative_headers",
   ]
+
+  deps = [ "//flutter/fml" ]
 }


### PR DESCRIPTION
Even though the file is pure C code, it's useful to use a C++ or Objective-C++ filename in order to use FML (assertions) in the implementation. 

Three implementation changes:
* Since the file is now C++, some implicit void* conversions now require an explicit cast.
* A malloc/free of a buffer has been replaced with a std::vector.
* An `assert()` was changed to `FML_DCHECK` for consistency with the rest of the embedder.

No test changes since there are no semantic changes. 

Existing tests are in:
https://github.com/flutter/engine/blob/main/shell/platform/darwin/common/framework/Source/flutter_standard_codec_unittest.mm

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
