### PR TITLE
[macOS, iOS] Migrate from assert to FML_DCHECK

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterCallbackCache.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterCallbackCache.mm
@@ -4,6 +4,7 @@
 
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterCallbackCache_Internal.h"
 
+#include "flutter/fml/logging.h"
 #include "flutter/lib/ui/plugins/callback_cache.h"
 
 @implementation FlutterCallbackInformation
@@ -32,7 +33,7 @@
 }
 
 + (void)setCachePath:(NSString*)path {
-  assert(path != nil);
+  FML_DCHECK(path != nil);
   flutter::DartCallbackCache::SetCachePath([path UTF8String]);
   NSString* cache_path =
       [NSString stringWithUTF8String:flutter::DartCallbackCache::GetCachePath().c_str()];

--- a/shell/platform/darwin/ios/framework/Source/FlutterFakeKeyEvents.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterFakeKeyEvents.mm
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterFakeKeyEvents.h"
+
+#include "flutter/fml/logging.h"
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterMacros.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/KeyCodeMap_Internal.h"
 
@@ -108,8 +110,8 @@ FlutterUIPressProxy* keyEventWithPhase(UIPressPhase phase,
                                        const char* characters,
                                        const char* charactersIgnoringModifiers)
     API_AVAILABLE(ios(13.4)) {
-  assert(!(modifierFlags & kModifierFlagSidedMask) &&
-         "iOS doesn't supply modifier side flags, so don't create events with them.");
+  FML_DCHECK(!(modifierFlags & kModifierFlagSidedMask))
+      << "iOS doesn't supply modifier side flags, so don't create events with them.";
   UIKey* key =
       [[FakeUIKey alloc] initWithData:keyCode
                         modifierFlags:modifierFlags

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -2,10 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <utility>
-
 #import "flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h"
 
+#include <utility>
+
+#include "flutter/fml/logging.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.h"
@@ -243,7 +244,7 @@ static void ReplaceSemanticsObject(SemanticsObject* oldObject,
                                    SemanticsObject* newObject,
                                    NSMutableDictionary<NSNumber*, SemanticsObject*>* objects) {
   // `newObject` should represent the same id as `oldObject`.
-  assert(oldObject.node.id == newObject.uid);
+  FML_DCHECK(oldObject.node.id == newObject.uid);
   NSNumber* nodeId = @(oldObject.node.id);
   NSUInteger positionInChildlist = [oldObject.parent.children indexOfObject:oldObject];
   [[oldObject retain] autorelease];

--- a/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm
@@ -3,10 +3,13 @@
 // found in the LICENSE file.
 
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.h"
-#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterSurface.h"
 
 #import <Metal/Metal.h>
+
 #include <algorithm>
+
+#include "flutter/fml/logging.h"
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterSurface.h"
 
 @implementation FlutterSurfacePresentInfo
 @end
@@ -75,7 +78,7 @@
 }
 
 - (void)commit:(NSArray<FlutterSurfacePresentInfo*>*)surfaces {
-  assert([NSThread isMainThread]);
+  FML_DCHECK([NSThread isMainThread]);
 
   // Release all unused back buffer surfaces and replace them with front surfaces.
   [_backBufferCache replaceSurfaces:_frontSurfaces];

--- a/shell/platform/darwin/macos/framework/Source/FlutterThreadSynchronizer.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterThreadSynchronizer.mm
@@ -1,10 +1,12 @@
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterThreadSynchronizer.h"
-#import "fml/synchronization/waitable_event.h"
 
 #import <QuartzCore/QuartzCore.h>
 
 #include <mutex>
 #include <vector>
+
+#import "flutter/fml/logging.h"
+#import "flutter/fml/synchronization/waitable_event.h"
 
 @interface FlutterThreadSynchronizer () {
   std::mutex _mutex;
@@ -23,7 +25,7 @@
 @implementation FlutterThreadSynchronizer
 
 - (void)drain {
-  assert([NSThread isMainThread]);
+  FML_DCHECK([NSThread isMainThread]);
 
   [CATransaction begin];
   [CATransaction setDisableActions:YES];


### PR DESCRIPTION
Eliminates raw C asserts in the macOS and iOS embedders, replacing them with `FML_DCHECK` for consistency with the rest of the codebase.

No semantic change so no changes to tests.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
