### PR TITLE
[Impeller Scene] Fix crasher for nodes with no meshes

### DIFF
--- a/impeller/scene/node.cc
+++ b/impeller/scene/node.cc
@@ -43,12 +43,14 @@ Node Node::MakeFromFlatbuffer(const fb::Scene& scene, Allocator& allocator) {
 Node Node::MakeFromFlatbuffer(const fb::Node& node, Allocator& allocator) {
   Node result;
 
-  Mesh mesh;
-  for (const auto* primitives : *node.mesh_primitives()) {
-    auto geometry = Geometry::MakeFromFlatbuffer(*primitives, allocator);
-    mesh.AddPrimitive({geometry, Material::MakeUnlit()});
+  if (node.mesh_primitives()) {
+    Mesh mesh;
+    for (const auto* primitives : *node.mesh_primitives()) {
+      auto geometry = Geometry::MakeFromFlatbuffer(*primitives, allocator);
+      mesh.AddPrimitive({geometry, Material::MakeUnlit()});
+    }
+    result.SetMesh(std::move(mesh));
   }
-  result.SetMesh(std::move(mesh));
 
   if (!node.children()) {
     return result;


### PR DESCRIPTION
The included test crashes without the fix.

https://user-images.githubusercontent.com/919017/208228212-a8d1a323-251b-4b70-819d-032613b3ef1e.mov

I also put some test camera code inline, gonna move it into a reusable utility when we need it again in a playground.