### PR TITLE
Add CI builder for windows-arm64.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -510,6 +510,14 @@ targets:
       release_build: "true"
       config_name: windows_host_engine
 
+  - name: Windows windows_arm_host_engine
+    bringup: true
+    recipe: engine_v2/engine_v2
+    timeout: 60
+    properties:
+      release_build: "true"
+      config_name: windows_arm_host_engine
+
   - name: Windows Unopt
     recipe: engine/engine_unopt
     properties:

--- a/build/archives/BUILD.gn
+++ b/build/archives/BUILD.gn
@@ -227,7 +227,7 @@ if (build_engine_artifacts && !flutter_prebuilt_dart_sdk) {
 # Archives Flutter Windows Artifacts
 if (host_os == "win") {
   zip_bundle("windows_flutter") {
-    output = "$full_platform_name-$flutter_runtime_mode/$full_platform_name-flutter.zip"
+    output = "$full_target_platform_name-$flutter_runtime_mode/$full_target_platform_name-flutter.zip"
     deps = [
       "//flutter/shell/platform/common:publish_headers",
       "//flutter/shell/platform/windows:flutter_windows",

--- a/ci/builders/windows_arm_host_engine.json
+++ b/ci/builders/windows_arm_host_engine.json
@@ -1,0 +1,124 @@
+{
+    "builds": [
+        {
+            "archives": [
+                {
+                    "base_path": "out/host_debug_arm64/zip_archives/",
+                    "type": "gcs",
+                    "include_paths": [
+                        "out/host_debug_arm64/zip_archives/windows-arm64/artifacts.zip",
+                        "out/host_debug_arm64/zip_archives/windows-arm64/windows-arm64-embedder.zip",
+                        "out/host_debug_arm64/zip_archives/windows-arm64/font-subset.zip",
+                        "out/host_debug_arm64/zip_archives/dart-sdk-windows-arm64.zip",
+                        "out/host_debug_arm64/zip_archives/windows-arm64-debug/windows-arm64-flutter.zip",
+                        "out/host_debug_arm64/zip_archives/windows-arm64/flutter-cpp-client-wrapper.zip",
+                        "out/host_debug_arm64/zip_archives/flutter-web-sdk-windows-arm64.zip"
+                    ],
+                    "name": "host_debug_arm64"
+                }
+            ],
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Windows-10"
+            ],
+            "gclient_custom_vars": {
+                "download_android_deps": false
+            },
+            "gn": [
+                "--runtime-mode",
+                "debug",
+                "--full-dart-sdk",
+                "--no-lto",
+                "--windows-cpu",
+                "arm64"
+            ],
+            "name": "host_debug_arm64",
+            "ninja": {
+                "config": "host_debug_arm64",
+                "targets": [
+                    "flutter/build/archives:artifacts",
+                    "flutter/build/archives:embedder",
+                    "flutter/tools/font-subset",
+                    "flutter/build/archives:dart_sdk_archive",
+                    "flutter/shell/platform/windows/client_wrapper:client_wrapper_archive",
+                    "flutter/build/archives:windows_flutter",
+                    "flutter/web_sdk"
+                ]
+            },
+            "tests": []
+        },
+        {
+            "archives": [
+                {
+                    "base_path": "out/host_profile_arm64/zip_archives/",
+                    "type": "gcs",
+                    "include_paths": [
+                        "out/host_profile_arm64/zip_archives/windows-arm64-profile/windows-arm64-flutter.zip"
+                    ],
+                    "name": "host_profile_arm64"
+                }
+            ],
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Windows-10"
+            ],
+            "gclient_custom_vars": {
+                "download_android_deps": false
+            },
+            "gn": [
+                "--runtime-mode",
+                "profile",
+                "--no-lto",
+                "--windows-cpu",
+                "arm64"
+            ],
+            "name": "host_profile_arm64",
+            "ninja": {
+                "config": "host_profile_arm64",
+                "targets": [
+                    "windows",
+                    "gen_snapshot",
+                    "flutter/build/archives:windows_flutter"
+                ]
+            },
+            "tests": []
+        },
+        {
+            "archives": [
+                {
+                    "base_path": "out/host_release_arm64/zip_archives/",
+                    "type": "gcs",
+                    "include_paths": [
+                        "out/host_release_arm64/zip_archives/windows-arm64-release/windows-arm64-flutter.zip"
+                    ],
+                    "name": "host_profile_arm64"
+                }
+            ],
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Windows-10"
+            ],
+            "gclient_custom_vars": {
+                "download_android_deps": false
+            },
+            "generators": {},
+            "gn": [
+                "--runtime-mode",
+                "release",
+                "--no-lto",
+                "--windows-cpu",
+                "arm64"
+            ],
+            "name": "host_release_arm64",
+            "ninja": {
+                "config": "host_release_arm64",
+                "targets": [
+                    "windows",
+                    "gen_snapshot",
+                    "flutter/build/archives:windows_flutter"
+                ]
+            },
+            "tests": []
+        }
+    ]
+}

--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -530,7 +530,8 @@ if (is_mac) {
 
 if (host_os == "linux" || host_os == "win") {
   zip_bundle("embedder-archive") {
-    output = "$full_platform_name/$full_platform_name-embedder.zip"
+    output =
+        "$full_target_platform_name/$full_target_platform_name-embedder.zip"
     deps = [
       "//flutter/shell/platform/embedder:copy_headers",
       "//flutter/shell/platform/embedder:flutter_engine_library",

--- a/shell/platform/windows/client_wrapper/BUILD.gn
+++ b/shell/platform/windows/client_wrapper/BUILD.gn
@@ -113,7 +113,7 @@ win_client_wrapper_file_archive_list = [
 ]
 
 zip_bundle("client_wrapper_archive") {
-  output = "$full_platform_name/flutter-cpp-client-wrapper.zip"
+  output = "$full_target_platform_name/flutter-cpp-client-wrapper.zip"
   deps = [
     ":client_wrapper_windows",
     ":publish_wrapper_windows",

--- a/web_sdk/BUILD.gn
+++ b/web_sdk/BUILD.gn
@@ -551,7 +551,7 @@ if (!is_fuchsia) {
       # TODO(jacksongardner): remove this once we stop making platform-specific
       # flutter_web_sdk archives.
       # https://github.com/flutter/flutter/issues/113303
-      output = "flutter-web-sdk-${full_platform_name}.zip"
+      output = "flutter-web-sdk-${full_target_platform_name}.zip"
     }
     deps = [
              ":flutter_ddc_modules",


### PR DESCRIPTION
This PR adds support for windows-arm64 artifacts, using new infrastructure that will be used from January 2023, and replacing https://flutter.googlesource.com/recipes/.

I checked locally that targets are correctly built and expected zips are there 👍.

All packages can be cross compiled from an x64 machine.
Unittests are disabled, as they require an arm64 machine.

Solves this issue: https://github.com/flutter/flutter/issues/115983

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
