### PR TITLE
Add more missing includes of Skia headers

### DIFF
--- a/display_list/display_list_matrix_clip_tracker.h
+++ b/display_list/display_list_matrix_clip_tracker.h
@@ -10,8 +10,11 @@
 #include "flutter/fml/logging.h"
 #include "third_party/skia/include/core/SkClipOp.h"
 #include "third_party/skia/include/core/SkM44.h"
+#include "third_party/skia/include/core/SkMatrix.h"
 #include "third_party/skia/include/core/SkPath.h"
 #include "third_party/skia/include/core/SkRRect.h"
+#include "third_party/skia/include/core/SkRect.h"
+#include "third_party/skia/include/core/SkScalar.h"
 
 namespace flutter {
 


### PR DESCRIPTION
This is a followup to 3626c487a610eff4 which adds more potentially-missing includes from display_list_matrix_clip_tracker.h

We are actively cleaning up our public API includes, and this aims to prevent future breakages.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

