### PR TITLE
[macOS] Update FlutterView layer scale when backing properties change

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -2637,8 +2637,8 @@ ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterVie
 ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterViewEngineProvider.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterViewEngineProvider.mm + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterViewEngineProviderTest.mm + ../../../flutter/LICENSE
-ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterViewTest.mm + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterViewProvider.h + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterViewTest.mm + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/KeyCodeMap.g.mm + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/KeyCodeMap_Internal.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/TestFlutterPlatformView.h + ../../../flutter/LICENSE
@@ -5101,6 +5101,7 @@ FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterViewE
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterViewEngineProvider.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterViewEngineProviderTest.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterViewProvider.h
+FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterViewTest.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/KeyCodeMap.g.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/KeyCodeMap_Internal.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/TestFlutterPlatformView.h

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -2637,6 +2637,7 @@ ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterVie
 ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterViewEngineProvider.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterViewEngineProvider.mm + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterViewEngineProviderTest.mm + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterViewTest.mm + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterViewProvider.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/KeyCodeMap.g.mm + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/KeyCodeMap_Internal.h + ../../../flutter/LICENSE

--- a/shell/platform/darwin/macos/BUILD.gn
+++ b/shell/platform/darwin/macos/BUILD.gn
@@ -182,6 +182,7 @@ executable("flutter_desktop_darwin_unittests") {
     "framework/Source/FlutterViewControllerTestUtils.h",
     "framework/Source/FlutterViewControllerTestUtils.mm",
     "framework/Source/FlutterViewEngineProviderTest.mm",
+    "framework/Source/FlutterViewTest.mm",
     "framework/Source/TestFlutterPlatformView.h",
     "framework/Source/TestFlutterPlatformView.mm",
   ]

--- a/shell/platform/darwin/macos/framework/Source/FlutterCompositor.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterCompositor.mm
@@ -88,7 +88,7 @@ void FlutterCompositor::PresentPlatformView(FlutterView* default_base_view,
 
   FML_DCHECK(platform_view) << "Platform view not found for id: " << platform_view_id;
 
-  CGFloat scale = platform_view.layer.contentsScale;
+  CGFloat scale = default_base_view.layer.contentsScale;
   platform_view.frame = CGRectMake(layer->offset.x / scale, layer->offset.y / scale,
                                    layer->size.width / scale, layer->size.height / scale);
   if (platform_view.superview == nil) {

--- a/shell/platform/darwin/macos/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterView.mm
@@ -101,6 +101,7 @@
 }
 
 - (void)viewDidChangeBackingProperties {
+  self.layer.contentsScale = self.window.backingScaleFactor;
   [super viewDidChangeBackingProperties];
   // Force redraw
   [_reshapeListener viewDidReshape:self];

--- a/shell/platform/darwin/macos/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterView.mm
@@ -101,10 +101,15 @@
 }
 
 - (void)viewDidChangeBackingProperties {
-  self.layer.contentsScale = self.window.backingScaleFactor;
   [super viewDidChangeBackingProperties];
   // Force redraw
   [_reshapeListener viewDidReshape:self];
+}
+
+- (BOOL)layer:(CALayer*)layer
+    shouldInheritContentsScale:(CGFloat)newScale
+                    fromWindow:(NSWindow*)window {
+  return YES;
 }
 
 - (void)shutdown {

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewTest.mm
@@ -1,0 +1,45 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterView.h"
+
+#import <Metal/Metal.h>
+#import <OCMock/OCMock.h>
+
+#import "flutter/testing/testing.h"
+
+@interface TestReshapeListener : NSObject <FlutterViewReshapeListener>
+
+@end
+
+@implementation TestReshapeListener
+
+- (void)viewDidReshape:(nonnull NSView*)view {
+}
+
+@end
+
+TEST(FlutterView, BackingPropertiesChangeUpdatesLayerScale) {
+  id<MTLDevice> device = MTLCreateSystemDefaultDevice();
+  id<MTLCommandQueue> queue = [device newCommandQueue];
+  TestReshapeListener* listener = [[TestReshapeListener alloc] init];
+  FlutterView* view = [[FlutterView alloc] initWithMTLDevice:device
+                                                commandQueue:queue
+                                             reshapeListener:listener];
+
+  view.layer.contentsScale = 1.0;
+
+  FlutterView* mockView = OCMPartialMock(view);
+
+  NSWindow* mockWindow = OCMClassMock([NSWindow class]);
+  OCMStub([mockWindow backingScaleFactor]).andReturn(3.0);
+
+  OCMStub([mockView window]).andReturn(mockWindow);
+
+  EXPECT_EQ(view.layer.contentsScale, 1.0);
+
+  [mockView viewDidChangeBackingProperties];
+
+  EXPECT_EQ(view.layer.contentsScale, 3.0);
+}

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewTest.mm
@@ -5,7 +5,6 @@
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterView.h"
 
 #import <Metal/Metal.h>
-#import <OCMock/OCMock.h>
 
 #import "flutter/testing/testing.h"
 
@@ -20,26 +19,12 @@
 
 @end
 
-TEST(FlutterView, BackingPropertiesChangeUpdatesLayerScale) {
+TEST(FlutterView, ShouldInheritContentsScaleReturnsYes) {
   id<MTLDevice> device = MTLCreateSystemDefaultDevice();
   id<MTLCommandQueue> queue = [device newCommandQueue];
   TestReshapeListener* listener = [[TestReshapeListener alloc] init];
   FlutterView* view = [[FlutterView alloc] initWithMTLDevice:device
                                                 commandQueue:queue
                                              reshapeListener:listener];
-
-  view.layer.contentsScale = 1.0;
-
-  FlutterView* mockView = OCMPartialMock(view);
-
-  NSWindow* mockWindow = OCMClassMock([NSWindow class]);
-  OCMStub([mockWindow backingScaleFactor]).andReturn(3.0);
-
-  OCMStub([mockView window]).andReturn(mockWindow);
-
-  EXPECT_EQ(view.layer.contentsScale, 1.0);
-
-  [mockView viewDidChangeBackingProperties];
-
-  EXPECT_EQ(view.layer.contentsScale, 3.0);
+  EXPECT_EQ([view layer:view.layer shouldInheritContentsScale:3.0 fromWindow:view.window], YES);
 }


### PR DESCRIPTION
This fixes problem introduced in https://github.com/flutter/engine/pull/37789.

CALayer scale is used to position surfaces, but the scale is not updated when backing window properties change.

Implementing CALayer's delegate (FlutterView) [layer:shouldInheritContentsScale:fromWindow:] takes care of this.

Fixes https://github.com/flutter/flutter/issues/117247

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
