### PR TITLE
[Impeller] RRect blur improvements

### DIFF
--- a/impeller/compiler/shader_lib/impeller/constants.glsl
+++ b/impeller/compiler/shader_lib/impeller/constants.glsl
@@ -16,4 +16,7 @@ const float kSqrtTwoPi = 2.50662827463;
 // sqrt(2) / 2 == 1 / sqrt(2)
 const float kHalfSqrtTwo = 0.70710678118;
 
+// sqrt(3)
+const float kSqrtThree = 1.73205080757;
+
 #endif

--- a/impeller/compiler/shader_lib/impeller/gaussian.glsl
+++ b/impeller/compiler/shader_lib/impeller/gaussian.glsl
@@ -29,21 +29,23 @@ vec2 IPVec2Erf(vec2 x) {
   return sign(x) * (1 - 1 / (b * b * b * b));
 }
 
-/// Indefinite integral of the Gaussian function (with constant range 0->1).
+/// The indefinite integral of the Gaussian function.
+/// Uses a very close approximation of Erf.
 float IPGaussianIntegral(float x, float sigma) {
   // ( 1 + erf( x * (sqrt(2) / (2 * sigma) ) ) / 2
-  // Because this sigmoid is always > 1, we remap it (n * 1.07 - 0.07)
-  // so that it always fades to zero before it reaches the blur radius.
-  return 0.535 * IPErf(x * (kHalfSqrtTwo / sigma)) + 0.465;
+  return (1 + IPErf(x * (kHalfSqrtTwo / sigma))) * 0.5;
 }
 
-/// Vec2 variation for the indefinite integral of the Gaussian function (with
-/// constant range 0->1).
+/// Vec2 variation for the indefinite integral of the Gaussian function.
+/// Uses a very close approximation of Erf.
 vec2 IPVec2GaussianIntegral(vec2 x, float sigma) {
   // ( 1 + erf( x * (sqrt(2) / (2 * sigma) ) ) / 2
-  // Because this sigmoid is always > 1, we remap it (n * 1.07 - 0.07)
-  // so that it always fades to zero before it reaches the blur radius.
-  return 0.535 * IPVec2Erf(x * (kHalfSqrtTwo / sigma)) + 0.465;
+  return (1 + IPVec2Erf(x * (kHalfSqrtTwo / sigma))) * 0.5;
+}
+
+/// Simpler (but less accurate) approximation of the Gaussian integral.
+vec2 IPVec2FastGaussianIntegral(vec2 x, float sigma) {
+  return 1 / (1 + exp(-kSqrtThree / sigma * x));
 }
 
 /// Simple logistic sigmoid with a domain of [-1, 1] and range of [0, 1].

--- a/impeller/entity/contents/rrect_shadow_contents.cc
+++ b/impeller/entity/contents/rrect_shadow_contents.cc
@@ -39,7 +39,7 @@ std::optional<Rect> RRectShadowContents::GetCoverage(
     return std::nullopt;
   }
 
-  Scalar radius = Radius{sigma_}.radius;
+  Scalar radius = sigma_.sigma * 2;
 
   auto ltrb = rect_->GetLTRB();
   Rect bounds = Rect::MakeLTRB(ltrb[0] - radius, ltrb[1] - radius,
@@ -59,7 +59,7 @@ bool RRectShadowContents::Render(const ContentContext& renderer,
 
   VertexBufferBuilder<VS::PerVertexData> vtx_builder;
 
-  auto blur_radius = Radius{sigma_}.radius;
+  auto blur_radius = sigma_.sigma * 2;
   auto positive_rect = rect_->GetPositive();
   {
     auto left = -blur_radius;

--- a/impeller/entity/shaders/rrect_blur.frag
+++ b/impeller/entity/shaders/rrect_blur.frag
@@ -17,7 +17,7 @@ in vec2 v_position;
 
 out vec4 frag_color;
 
-const int kSampleCount = 5;
+const int kSampleCount = 4;
 
 float RRectDistance(vec2 sample_position, vec2 half_size) {
   vec2 space = abs(sample_position) - half_size + frag_info.corner_radius;
@@ -37,8 +37,8 @@ float RRectShadowX(vec2 sample_position, vec2 half_size) {
       sqrt(max(0, frag_info.corner_radius * frag_info.corner_radius -
                       space * space));
 
-  // Map the linear distance field to the analytical Gaussian integral.
-  vec2 integral = IPVec2GaussianIntegral(
+  // Map the linear distance field to the approximate Gaussian integral.
+  vec2 integral = IPVec2FastGaussianIntegral(
       sample_position.x + vec2(-rrect_distance, rrect_distance),
       frag_info.blur_sigma);
   return integral.y - integral.x;


### PR DESCRIPTION
Address the RRect blur discontinuities brought up in https://github.com/flutter/flutter/issues/116584 by increasing the radius per sigma ratio from sqrt(3) to 2 (~15%). Upon close examination, I noticed that Skia's blurs appear to extend out about this much further.

To offset the additional GPU load, I applied a couple of speed-ups I've been meaning to get around to:
* Decrease the number of samples from 5 to 4.
* Use a faster approximation for the Gaussian integral. For this I just grabbed the logistic function and fit it as close to the Gaussian integral as possible. It's very close! I recall seeing one of Skia's blur paths use a sigmoid like this to populate a LUT a while back... this might be why some of Skia's blurs look a bit softer/lighter than ours in some places.

Blue is the old integral, purple is the new one. `s` is sigma:

https://user-images.githubusercontent.com/919017/208595034-0b4b0e06-6fc2-4c76-9861-fdf2cae7b95a.mov

Before:
![Screen Shot 2022-12-19 at 9 26 09 PM](https://user-images.githubusercontent.com/919017/208593226-090fc869-6822-4d89-839e-c8494b1d5943.png)

After:
![Screen Shot 2022-12-19 at 9 25 19 PM](https://user-images.githubusercontent.com/919017/208593233-0e6a9a7a-a133-47fe-a35d-d02f2050e49c.png)
