### PR TITLE
[Impeller] Remove depth/stencil attachments from imgui pipeline

### DIFF
--- a/impeller/playground/imgui/imgui_impl_impeller.cc
+++ b/impeller/playground/imgui/imgui_impl_impeller.cc
@@ -94,12 +94,10 @@ bool ImGui_ImplImpeller_Init(
     auto desc = impeller::PipelineBuilder<impeller::ImguiRasterVertexShader,
                                           impeller::ImguiRasterFragmentShader>::
         MakeDefaultPipelineDescriptor(*context);
-    auto stencil = desc->GetFrontStencilAttachmentDescriptor();
-    if (stencil.has_value()) {
-      stencil->stencil_compare = impeller::CompareFunction::kAlways;
-      stencil->depth_stencil_pass = impeller::StencilOperation::kKeep;
-      desc->SetStencilAttachmentDescriptors(stencil.value());
-    }
+    desc->SetStencilPixelFormat(impeller::PixelFormat::kUnknown);
+    desc->SetStencilAttachmentDescriptors(std::nullopt);
+    desc->SetDepthPixelFormat(impeller::PixelFormat::kUnknown);
+    desc->SetDepthStencilAttachmentDescriptor(std::nullopt);
 
     bd->pipeline =
         context->GetPipelineLibrary()->GetPipeline(std::move(desc)).Get();

--- a/impeller/renderer/pipeline_descriptor.cc
+++ b/impeller/renderer/pipeline_descriptor.cc
@@ -135,19 +135,19 @@ PipelineDescriptor& PipelineDescriptor::SetStencilPixelFormat(
 }
 
 PipelineDescriptor& PipelineDescriptor::SetDepthStencilAttachmentDescriptor(
-    DepthAttachmentDescriptor desc) {
+    std::optional<DepthAttachmentDescriptor> desc) {
   depth_attachment_descriptor_ = desc;
   return *this;
 }
 
 PipelineDescriptor& PipelineDescriptor::SetStencilAttachmentDescriptors(
-    StencilAttachmentDescriptor front_and_back) {
+    std::optional<StencilAttachmentDescriptor> front_and_back) {
   return SetStencilAttachmentDescriptors(front_and_back, front_and_back);
 }
 
 PipelineDescriptor& PipelineDescriptor::SetStencilAttachmentDescriptors(
-    StencilAttachmentDescriptor front,
-    StencilAttachmentDescriptor back) {
+    std::optional<StencilAttachmentDescriptor> front,
+    std::optional<StencilAttachmentDescriptor> back) {
   front_stencil_attachment_descriptor_ = front;
   back_stencil_attachment_descriptor_ = back;
   return *this;

--- a/impeller/renderer/pipeline_descriptor.h
+++ b/impeller/renderer/pipeline_descriptor.h
@@ -71,17 +71,17 @@ class PipelineDescriptor final : public Comparable<PipelineDescriptor> {
   const ColorAttachmentDescriptor* GetLegacyCompatibleColorAttachment() const;
 
   PipelineDescriptor& SetDepthStencilAttachmentDescriptor(
-      DepthAttachmentDescriptor desc);
+      std::optional<DepthAttachmentDescriptor> desc);
 
   std::optional<DepthAttachmentDescriptor> GetDepthStencilAttachmentDescriptor()
       const;
 
   PipelineDescriptor& SetStencilAttachmentDescriptors(
-      StencilAttachmentDescriptor front_and_back);
+      std::optional<StencilAttachmentDescriptor> front_and_back);
 
   PipelineDescriptor& SetStencilAttachmentDescriptors(
-      StencilAttachmentDescriptor front,
-      StencilAttachmentDescriptor back);
+      std::optional<StencilAttachmentDescriptor> front,
+      std::optional<StencilAttachmentDescriptor> back);
 
   std::optional<StencilAttachmentDescriptor>
   GetFrontStencilAttachmentDescriptor() const;


### PR DESCRIPTION
Went through the playgrounds today. This fixes many failing playgrounds which started failing after I landed https://github.com/flutter/engine/pull/38118/files#diff-489549033945b523bbdb56af7684a119c7a2eaacf01a52270bd1f11404125a1aR266-R267.
That change unsets the depth/stencil attachments on the render target before drawing with the ImGui pipeline.