### PR TITLE
Display list R-Tree culling

### DIFF
--- a/ci/licenses_golden/excluded_files
+++ b/ci/licenses_golden/excluded_files
@@ -39,7 +39,7 @@
 ../../../flutter/display_list/display_list_matrix_clip_tracker_unittests.cc
 ../../../flutter/display_list/display_list_paint_unittests.cc
 ../../../flutter/display_list/display_list_path_effect_unittests.cc
-../../../flutter/display_list/display_list_rect_unittests.cc
+../../../flutter/display_list/display_list_rtree_unittests.cc
 ../../../flutter/display_list/display_list_unittests.cc
 ../../../flutter/display_list/display_list_utils_unittests.cc
 ../../../flutter/display_list/display_list_vertices_unittests.cc

--- a/ci/licenses_golden/excluded_files
+++ b/ci/licenses_golden/excluded_files
@@ -39,6 +39,7 @@
 ../../../flutter/display_list/display_list_matrix_clip_tracker_unittests.cc
 ../../../flutter/display_list/display_list_paint_unittests.cc
 ../../../flutter/display_list/display_list_path_effect_unittests.cc
+../../../flutter/display_list/display_list_rect_unittests.cc
 ../../../flutter/display_list/display_list_unittests.cc
 ../../../flutter/display_list/display_list_utils_unittests.cc
 ../../../flutter/display_list/display_list_vertices_unittests.cc

--- a/display_list/BUILD.gn
+++ b/display_list/BUILD.gn
@@ -109,6 +109,7 @@ if (enable_unittests) {
       "display_list_matrix_clip_tracker_unittests.cc",
       "display_list_paint_unittests.cc",
       "display_list_path_effect_unittests.cc",
+      "display_list_rtree_unittests.cc",
       "display_list_unittests.cc",
       "display_list_utils_unittests.cc",
       "display_list_vertices_unittests.cc",

--- a/display_list/display_list.cc
+++ b/display_list/display_list.cc
@@ -52,17 +52,106 @@ DisplayList::~DisplayList() {
   DisposeOps(ptr, ptr + byte_count_);
 }
 
+class Culler {
+ public:
+  virtual bool init(DispatchContext& context) = 0;
+  virtual void update(DispatchContext& context) = 0;
+};
+class NopCuller : public Culler {
+ public:
+  static NopCuller instance;
+
+  bool init(DispatchContext& context) override {
+    context.next_render_index = 0;
+    return true;
+  }
+  void update(DispatchContext& context) override {}
+};
+NopCuller NopCuller::instance = NopCuller();
+class VectorCuller : public Culler {
+ public:
+  VectorCuller(sk_sp<const DlRTree> rtree, const std::vector<int>& rect_indices)
+      : rtree_(std::move(rtree)),
+        cur_(rect_indices.begin()),
+        end_(rect_indices.end()) {}
+
+  bool init(DispatchContext& context) override {
+    if (cur_ < end_) {
+      context.next_render_index = rtree_->id(*cur_++);
+      return true;
+    } else {
+      context.next_render_index = std::numeric_limits<int>::max();
+      return false;
+    }
+  }
+  void update(DispatchContext& context) override {
+    if (++context.cur_index > context.next_render_index) {
+      while (cur_ < end_) {
+        context.next_render_index = rtree_->id(*cur_++);
+        if (context.next_render_index >= context.cur_index) {
+          // It should be rare that we have duplicate indices
+          // but if we do, then having a while loop is a cheap
+          // insurance for those cases.
+          return;
+        }
+      }
+      context.next_render_index = std::numeric_limits<int>::max();
+    }
+  }
+
+ private:
+  const sk_sp<const DlRTree> rtree_;
+  std::vector<int>::const_iterator cur_;
+  std::vector<int>::const_iterator end_;
+};
+
+void DisplayList::Dispatch(Dispatcher& ctx) const {
+  uint8_t* ptr = storage_.get();
+  Dispatch(ctx, ptr, ptr + byte_count_, NopCuller::instance);
+}
+void DisplayList::Dispatch(Dispatcher& ctx, const SkRect& cull_rect) {
+  if (cull_rect.isEmpty()) {
+    return;
+  }
+  if (cull_rect.contains(bounds())) {
+    Dispatch(ctx);
+    return;
+  }
+  FML_DCHECK(rtree() != nullptr);
+  if (rtree() == nullptr) {
+    FML_LOG(ERROR) << "dispatched with culling rect on DL with no rtree";
+    Dispatch(ctx);
+    return;
+  }
+  uint8_t* ptr = storage_.get();
+  std::vector<int> rect_indices;
+  rtree()->search(cull_rect, &rect_indices);
+  VectorCuller culler(rtree(), rect_indices);
+  Dispatch(ctx, ptr, ptr + byte_count_, culler);
+}
+
 void DisplayList::Dispatch(Dispatcher& dispatcher,
                            uint8_t* ptr,
-                           uint8_t* end) const {
+                           uint8_t* end,
+                           Culler& culler) const {
+  DispatchContext context = {
+      .dispatcher = dispatcher,
+
+      .cur_index = 0,
+
+      .next_restore_index = std::numeric_limits<int>::max(),
+  };
+  if (!culler.init(context)) {
+    return;
+  }
   while (ptr < end) {
     auto op = reinterpret_cast<const DLOp*>(ptr);
     ptr += op->size;
     FML_DCHECK(ptr <= end);
     switch (op->type) {
-#define DL_OP_DISPATCH(name)                                \
-  case DisplayListOpType::k##name:                          \
-    static_cast<const name##Op*>(op)->dispatch(dispatcher); \
+#define DL_OP_DISPATCH(name)                             \
+  case DisplayListOpType::k##name:                       \
+    static_cast<const name##Op*>(op)->dispatch(context); \
     break;
 
       FOR_EACH_DISPLAY_LIST_OP(DL_OP_DISPATCH)
@@ -73,6 +162,7 @@ void DisplayList::Dispatch(Dispatcher& dispatcher,
         FML_DCHECK(false);
         return;
     }
+    culler.update(context);
   }
 }
 
@@ -166,18 +256,25 @@ static bool CompareOps(uint8_t* ptrA,
   return true;
 }
 
-void DisplayList::RenderTo(DisplayListBuilder* builder,
-                           SkScalar opacity) const {
+void DisplayList::RenderTo(DisplayListBuilder* builder, SkScalar opacity) {
   // TODO(100983): Opacity is not respected and attributes are not reset.
   if (!builder) {
     return;
   }
-  Dispatch(*builder);
+  if (has_rtree()) {
+    Dispatch(*builder, builder->getLocalClipBounds());
+  } else {
+    Dispatch(*builder);
+  }
 }
 
-void DisplayList::RenderTo(SkCanvas* canvas, SkScalar opacity) const {
+void DisplayList::RenderTo(SkCanvas* canvas, SkScalar opacity) {
   DisplayListCanvasDispatcher dispatcher(canvas, opacity);
-  Dispatch(dispatcher);
+  if (has_rtree()) {
+    Dispatch(dispatcher, canvas->getLocalClipBounds());
+  } else {
+    Dispatch(dispatcher);
+  }
 }
 
 bool DisplayList::Equals(const DisplayList* other) const {

--- a/display_list/display_list.h
+++ b/display_list/display_list.h
@@ -247,11 +247,12 @@ class DisplayList : public SkRefCnt {
   ~DisplayList();
 
   void Dispatch(Dispatcher& ctx) const;
-  void Dispatch(Dispatcher& ctx, const SkRect& cull_rect);
+  void Dispatch(Dispatcher& ctx, const SkRect& cull_rect) const;
 
-  void RenderTo(DisplayListBuilder* builder, SkScalar opacity = SK_Scalar1);
+  void RenderTo(DisplayListBuilder* builder,
+                SkScalar opacity = SK_Scalar1) const;
 
-  void RenderTo(SkCanvas* canvas, SkScalar opacity = SK_Scalar1);
+  void RenderTo(SkCanvas* canvas, SkScalar opacity = SK_Scalar1) const;
 
   // SkPicture always includes nested bytes, but nested ops are
   // only included if requested. The defaults used here for these
@@ -267,10 +268,10 @@ class DisplayList : public SkRefCnt {
 
   uint32_t unique_id() const { return unique_id_; }
 
-  const SkRect& bounds() { return bounds_; }
+  const SkRect& bounds() const { return bounds_; }
 
-  bool has_rtree() { return rtree_ != nullptr; }
-  sk_sp<const DlRTree> rtree() { return rtree_; }
+  bool has_rtree() const { return rtree_ != nullptr; }
+  sk_sp<const DlRTree> rtree() const { return rtree_; }
 
   bool Equals(const DisplayList* other) const;
   bool Equals(const DisplayList& other) const { return Equals(&other); }
@@ -278,7 +279,7 @@ class DisplayList : public SkRefCnt {
     return Equals(other.get());
   }
 
-  bool can_apply_group_opacity() { return can_apply_group_opacity_; }
+  bool can_apply_group_opacity() const { return can_apply_group_opacity_; }
 
   static void DisposeOps(uint8_t* ptr, uint8_t* end);
 
@@ -292,18 +293,20 @@ class DisplayList : public SkRefCnt {
               bool can_apply_group_opacity,
               sk_sp<const DlRTree> rtree);
 
-  DisplayListStorage storage_;
-  size_t byte_count_;
-  unsigned int op_count_;
+  static uint32_t next_unique_id();
 
-  size_t nested_byte_count_;
-  unsigned int nested_op_count_;
+  const DisplayListStorage storage_;
+  const size_t byte_count_;
+  const unsigned int op_count_;
 
-  uint32_t unique_id_;
-  SkRect bounds_;
+  const size_t nested_byte_count_;
+  const unsigned int nested_op_count_;
 
-  bool can_apply_group_opacity_;
-  sk_sp<const DlRTree> rtree_;
+  const uint32_t unique_id_;
+  const SkRect bounds_;
+
+  const bool can_apply_group_opacity_;
+  const sk_sp<const DlRTree> rtree_;
 
   void Dispatch(Dispatcher& ctx,
                 uint8_t* ptr,

--- a/display_list/display_list_builder.cc
+++ b/display_list/display_list_builder.cc
@@ -1210,7 +1210,7 @@ void DisplayListBuilder::drawDisplayList(
     case BoundsAccumulatorType::kRTree:
       auto rtree = display_list->rtree();
       if (rtree) {
-        std::list<SkRect> rects = rtree->searchNonOverlappingDrawnRects(bounds);
+        std::list<SkRect> rects = rtree->searchAndConsolidateRects(bounds);
         for (const SkRect& rect : rects) {
           // TODO (https://github.com/flutter/flutter/issues/114919): Attributes
           // are not necessarily `kDrawDisplayListFlags`.

--- a/display_list/display_list_builder.cc
+++ b/display_list/display_list_builder.cc
@@ -27,7 +27,7 @@ static void CopyV(void* dst, const S* src, int n, Rest&&... rest) {
 }
 
 template <typename T, typename... Args>
-void* DisplayListBuilder::Push(size_t pod, int op_inc, Args&&... args) {
+void* DisplayListBuilder::Push(size_t pod, int render_op_inc, Args&&... args) {
   size_t size = SkAlignPtr(sizeof(T) + pod);
   FML_DCHECK(size < (1 << 24));
   if (used_ + size > allocated_) {
@@ -45,7 +45,8 @@ void* DisplayListBuilder::Push(size_t pod, int op_inc, Args&&... args) {
   new (op) T{std::forward<Args>(args)...};
   op->type = T::kType;
   op->size = size;
-  op_count_ += op_inc;
+  render_op_count_ += render_op_inc;
+  op_index_++;
   return op + 1;
 }
 
@@ -54,10 +55,10 @@ sk_sp<DisplayList> DisplayListBuilder::Build() {
     restore();
   }
   size_t bytes = used_;
-  int count = op_count_;
+  int count = render_op_count_;
   size_t nested_bytes = nested_bytes_;
   int nested_count = nested_op_count_;
-  used_ = allocated_ = op_count_ = 0;
+  used_ = allocated_ = render_op_count_ = op_index_ = 0;
   nested_bytes_ = nested_op_count_ = 0;
   storage_.realloc(bytes);
   bool compatible = layer_stack_.back().is_group_opacity_compatible();
@@ -433,7 +434,9 @@ void DisplayListBuilder::setAttributesFromPaint(
 
 void DisplayListBuilder::checkForDeferredSave() {
   if (current_layer_->has_deferred_save_op_) {
+    size_t save_offset_ = used_;
     Push<SaveOp>(0, 1);
+    current_layer_->save_offset_ = save_offset_;
     current_layer_->has_deferred_save_op_ = false;
   }
 }
@@ -448,7 +451,10 @@ void DisplayListBuilder::save() {
 
 void DisplayListBuilder::restore() {
   if (layer_stack_.size() > 1) {
+    SaveOpBase* op = reinterpret_cast<SaveOpBase*>(
+        storage_.get() + current_layer_->save_offset());
     if (!current_layer_->has_deferred_save_op_) {
+      op->restore_index = op_index_;
       Push<RestoreOp>(0, 1);
     }
     // Grab the current layer info before we push the restore
@@ -486,6 +492,9 @@ void DisplayListBuilder::restore() {
     }
 
     if (layer_info.has_layer()) {
+      // Layers are never deferred for now, we need to update the
+      // following code if we ever do saveLayer culling...
+      FML_DCHECK(!layer_info.has_deferred_save_op_);
       if (layer_info.is_group_opacity_compatible()) {
         // We are now going to go back and modify the matching saveLayer
         // call to add the option indicating it can distribute an opacity
@@ -499,8 +508,6 @@ void DisplayListBuilder::restore() {
         // in the DisplayList are only allowed *during* the build phase.
         // Once built, the DisplayList records must remain read only to
         // ensure consistency of rendering and |Equals()| behavior.
-        SaveLayerOp* op = reinterpret_cast<SaveLayerOp*>(
-            storage_.get() + layer_info.save_layer_offset());
         op->options = op->options.with_can_distribute_opacity();
       }
     } else {
@@ -527,11 +534,11 @@ void DisplayListBuilder::saveLayer(const SkRect* bounds,
   size_t save_layer_offset = used_;
   if (backdrop) {
     bounds  //
-        ? Push<SaveLayerBackdropBoundsOp>(0, 1, *bounds, options, backdrop)
+        ? Push<SaveLayerBackdropBoundsOp>(0, 1, options, *bounds, backdrop)
         : Push<SaveLayerBackdropOp>(0, 1, options, backdrop);
   } else {
     bounds  //
-        ? Push<SaveLayerBoundsOp>(0, 1, *bounds, options)
+        ? Push<SaveLayerBoundsOp>(0, 1, options, *bounds)
         : Push<SaveLayerOp>(0, 1, options);
   }
   CheckLayerOpacityCompatibility(options.renders_with_attributes());
@@ -541,6 +548,10 @@ void DisplayListBuilder::saveLayer(const SkRect* bounds,
     // (eventual) corresponding restore is called, but rather than
     // remember this information in the LayerInfo until the restore
     // method is processed, we just mark the unbounded state up front.
+    // Another reason to accumulate the clip here rather than in
+    // restore is so that this savelayer will be tagged in the rtree
+    // with its full bounds and the right op_index so that it doesn't
+    // get culled during rendering.
     if (!paint_nops_on_transparency()) {
       // We will fill the clip of the outer layer when we restore
       AccumulateUnbounded();
@@ -1161,6 +1172,11 @@ void DisplayListBuilder::drawAtlas(const sk_sp<DlImage>& atlas,
 void DisplayListBuilder::drawPicture(const sk_sp<SkPicture> picture,
                                      const SkMatrix* matrix,
                                      bool render_with_attributes) {
+  matrix  //
+      ? Push<DrawSkPictureMatrixOp>(0, 1, picture, *matrix,
+                                    render_with_attributes)
+      : Push<DrawSkPictureOp>(0, 1, picture, render_with_attributes);
+
   // TODO(flar) cull rect really cannot be trusted in general, but it will
   // work for SkPictures generated from our own PictureRecorder or any
   // picture captured with an SkRTreeFactory or accurate bounds estimate.
@@ -1172,11 +1188,6 @@ void DisplayListBuilder::drawPicture(const sk_sp<SkPicture> picture,
                                         ? kDrawPictureWithPaintFlags
                                         : kDrawPictureFlags;
   AccumulateOpBounds(bounds, flags);
-
-  matrix  //
-      ? Push<DrawSkPictureMatrixOp>(0, 1, picture, *matrix,
-                                    render_with_attributes)
-      : Push<DrawSkPictureOp>(0, 1, picture, render_with_attributes);
   // The non-nested op count accumulated in the |Push| method will include
   // this call to |drawPicture| for non-nested op count metrics.
   // But, for nested op count metrics we want the |drawPicture| call itself
@@ -1189,6 +1200,8 @@ void DisplayListBuilder::drawPicture(const sk_sp<SkPicture> picture,
 }
 void DisplayListBuilder::drawDisplayList(
     const sk_sp<DisplayList> display_list) {
+  Push<DrawDisplayListOp>(0, 1, display_list);
+
   const SkRect bounds = display_list->bounds();
   switch (accumulator()->type()) {
     case BoundsAccumulatorType::kRect:
@@ -1208,7 +1221,6 @@ void DisplayListBuilder::drawDisplayList(
       }
       break;
   }
-  Push<DrawDisplayListOp>(0, 1, display_list);
   // The non-nested op count accumulated in the |Push| method will include
   // this call to |drawDisplayList| for non-nested op count metrics.
   // But, for nested op count metrics we want the |drawDisplayList| call itself
@@ -1222,8 +1234,8 @@ void DisplayListBuilder::drawDisplayList(
 void DisplayListBuilder::drawTextBlob(const sk_sp<SkTextBlob> blob,
                                       SkScalar x,
                                       SkScalar y) {
-  AccumulateOpBounds(blob->bounds().makeOffset(x, y), kDrawTextBlobFlags);
   Push<DrawTextBlobOp>(0, 1, blob, x, y);
+  AccumulateOpBounds(blob->bounds().makeOffset(x, y), kDrawTextBlobFlags);
   CheckLayerOpacityCompatibility();
 }
 void DisplayListBuilder::drawTextBlob(const sk_sp<SkTextBlob>& blob,
@@ -1238,13 +1250,13 @@ void DisplayListBuilder::drawShadow(const SkPath& path,
                                     const SkScalar elevation,
                                     bool transparent_occluder,
                                     SkScalar dpr) {
-  SkRect shadow_bounds = DisplayListCanvasDispatcher::ComputeShadowBounds(
-      path, elevation, dpr, getTransform());
-  AccumulateOpBounds(shadow_bounds, kDrawShadowFlags);
-
   transparent_occluder  //
       ? Push<DrawShadowTransparentOccluderOp>(0, 1, path, color, elevation, dpr)
       : Push<DrawShadowOp>(0, 1, path, color, elevation, dpr);
+
+  SkRect shadow_bounds = DisplayListCanvasDispatcher::ComputeShadowBounds(
+      path, elevation, dpr, getTransform());
+  AccumulateOpBounds(shadow_bounds, kDrawShadowFlags);
   UpdateLayerOpacityCompatibility(false);
 }
 
@@ -1318,7 +1330,7 @@ bool DisplayListBuilder::AdjustBoundsForPaint(SkRect& bounds,
 }
 
 void DisplayListBuilder::AccumulateUnbounded() {
-  accumulator()->accumulate(tracker_.device_cull_rect());
+  accumulator()->accumulate(tracker_.device_cull_rect(), op_index_ - 1);
 }
 
 void DisplayListBuilder::AccumulateOpBounds(SkRect& bounds,
@@ -1332,7 +1344,7 @@ void DisplayListBuilder::AccumulateOpBounds(SkRect& bounds,
 void DisplayListBuilder::AccumulateBounds(SkRect& bounds) {
   tracker_.mapRect(&bounds);
   if (bounds.intersect(tracker_.device_cull_rect())) {
-    accumulator()->accumulate(bounds);
+    accumulator()->accumulate(bounds, op_index_ - 1);
   }
 }
 

--- a/display_list/display_list_builder.h
+++ b/display_list/display_list_builder.h
@@ -366,7 +366,8 @@ class DisplayListBuilder final : public virtual Dispatcher,
   DisplayListStorage storage_;
   size_t used_ = 0;
   size_t allocated_ = 0;
-  int op_count_ = 0;
+  int render_op_count_ = 0;
+  int op_index_ = 0;
 
   // bytes and ops from |drawPicture| and |drawDisplayList|
   size_t nested_bytes_ = 0;
@@ -387,10 +388,10 @@ class DisplayListBuilder final : public virtual Dispatcher,
 
   class LayerInfo {
    public:
-    explicit LayerInfo(size_t save_layer_offset = 0,
+    explicit LayerInfo(size_t save_offset = 0,
                        bool has_layer = false,
                        std::shared_ptr<const DlImageFilter> filter = nullptr)
-        : save_layer_offset_(save_layer_offset),
+        : save_offset_(save_offset),
           has_layer_(has_layer),
           cannot_inherit_opacity_(false),
           has_compatible_op_(false),
@@ -403,7 +404,7 @@ class DisplayListBuilder final : public virtual Dispatcher,
     // the records inside the saveLayer that may impact how the saveLayer
     // is handled (e.g., |cannot_inherit_opacity| == false).
     // This offset is only valid if |has_layer| is true.
-    size_t save_layer_offset() const { return save_layer_offset_; }
+    size_t save_offset() const { return save_offset_; }
 
     bool has_layer() const { return has_layer_; }
     bool cannot_inherit_opacity() const { return cannot_inherit_opacity_; }
@@ -461,7 +462,7 @@ class DisplayListBuilder final : public virtual Dispatcher,
     bool is_unbounded() const { return is_unbounded_; }
 
    private:
-    size_t save_layer_offset_;
+    size_t save_offset_;
     bool has_layer_;
     bool cannot_inherit_opacity_;
     bool has_compatible_op_;

--- a/display_list/display_list_ops.h
+++ b/display_list/display_list_ops.h
@@ -428,7 +428,6 @@ struct RestoreOp final : DLOp {
     if (info.save_was_needed) {
       ctx.dispatcher.restore();
     }
-    FML_DCHECK(info.previous_restore_index > ctx.next_render_index);
     ctx.next_restore_index = info.previous_restore_index;
     ctx.save_infos.pop_back();
   }

--- a/display_list/display_list_ops.h
+++ b/display_list/display_list_ops.h
@@ -15,6 +15,27 @@
 
 namespace flutter {
 
+// Structure holding the information necessary to dispatch and
+// potentially cull the DLOps during playback.
+//
+// Generally drawing ops will execute as long as |cur_index|
+// is at or after |next_render_index|, so setting the latter
+// to 0 will render all primitives and setting it to MAX_INT
+// will skip all remaining rendering primitives.
+//
+// Save and saveLayer ops will execute as long as the next
+// rendering index is before their closing restore index.
+// They will also store their own restore index into the
+// |next_restore_index| field for use by clip and transform ops.
+//
+// Clip and transform ops will only execute if the next
+// render index is before the next restore index. Otherwise
+// their modified state will not be used before it gets
+// restored.
+//
+// Attribute ops always execute as they are too numerous and
+// cheap to deal with a complicated "lifetime" tracking to
+// determine if they will be used.
 struct DispatchContext {
   Dispatcher& dispatcher;
 

--- a/display_list/display_list_ops.h
+++ b/display_list/display_list_ops.h
@@ -15,6 +15,26 @@
 
 namespace flutter {
 
+struct DispatchContext {
+  Dispatcher& dispatcher;
+
+  int cur_index;
+  int next_render_index;
+
+  int next_restore_index;
+
+  struct SaveInfo {
+    SaveInfo(int previous_restore_index, bool save_was_needed)
+        : previous_restore_index(previous_restore_index),
+          save_was_needed(save_was_needed) {}
+
+    int previous_restore_index;
+    bool save_was_needed;
+  };
+
+  std::vector<SaveInfo> save_infos;
+};
+
 // Most Ops can be bulk compared using memcmp because they contain
 // only numeric values or constructs that are constructed from numeric
 // values.
@@ -69,8 +89,8 @@ struct DLOp {
                                                              \
     const bool value;                                        \
                                                              \
-    void dispatch(Dispatcher& dispatcher) const {            \
-      dispatcher.set##name(value);                           \
+    void dispatch(DispatchContext& ctx) const {              \
+      ctx.dispatcher.set##name(value);                       \
     }                                                        \
   };
 DEFINE_SET_BOOL_OP(AntiAlias)
@@ -87,8 +107,8 @@ DEFINE_SET_BOOL_OP(InvertColors)
                                                                          \
     const DlStroke##name value;                                          \
                                                                          \
-    void dispatch(Dispatcher& dispatcher) const {                        \
-      dispatcher.setStroke##name(value);                                 \
+    void dispatch(DispatchContext& ctx) const {                          \
+      ctx.dispatcher.setStroke##name(value);                             \
     }                                                                    \
   };
 DEFINE_SET_ENUM_OP(Cap)
@@ -103,7 +123,7 @@ struct SetStyleOp final : DLOp {
 
   const DlDrawStyle style;
 
-  void dispatch(Dispatcher& dispatcher) const { dispatcher.setStyle(style); }
+  void dispatch(DispatchContext& ctx) const { ctx.dispatcher.setStyle(style); }
 };
 // 4 byte header + 4 byte payload packs into minimum 8 bytes
 struct SetStrokeWidthOp final : DLOp {
@@ -113,8 +133,8 @@ struct SetStrokeWidthOp final : DLOp {
 
   const float width;
 
-  void dispatch(Dispatcher& dispatcher) const {
-    dispatcher.setStrokeWidth(width);
+  void dispatch(DispatchContext& ctx) const {
+    ctx.dispatcher.setStrokeWidth(width);
   }
 };
 // 4 byte header + 4 byte payload packs into minimum 8 bytes
@@ -125,8 +145,8 @@ struct SetStrokeMiterOp final : DLOp {
 
   const float limit;
 
-  void dispatch(Dispatcher& dispatcher) const {
-    dispatcher.setStrokeMiter(limit);
+  void dispatch(DispatchContext& ctx) const {
+    ctx.dispatcher.setStrokeMiter(limit);
   }
 };
 
@@ -138,7 +158,7 @@ struct SetColorOp final : DLOp {
 
   const DlColor color;
 
-  void dispatch(Dispatcher& dispatcher) const { dispatcher.setColor(color); }
+  void dispatch(DispatchContext& ctx) const { ctx.dispatcher.setColor(color); }
 };
 // 4 byte header + 4 byte payload packs into minimum 8 bytes
 struct SetBlendModeOp final : DLOp {
@@ -148,7 +168,9 @@ struct SetBlendModeOp final : DLOp {
 
   const DlBlendMode mode;
 
-  void dispatch(Dispatcher& dispatcher) const { dispatcher.setBlendMode(mode); }
+  void dispatch(DispatchContext& ctx) const {
+    ctx.dispatcher.setBlendMode(mode);
+  }
 };
 
 // Clear: 4 byte header + unused 4 byte payload uses 8 bytes
@@ -162,8 +184,8 @@ struct SetBlendModeOp final : DLOp {
                                                                                \
     Clear##name##Op() {}                                                       \
                                                                                \
-    void dispatch(Dispatcher& dispatcher) const {                              \
-      dispatcher.set##name(nullptr);                                           \
+    void dispatch(DispatchContext& ctx) const {                                \
+      ctx.dispatcher.set##name(nullptr);                                       \
     }                                                                          \
   };                                                                           \
   struct Set##name##Op final : DLOp {                                          \
@@ -173,8 +195,8 @@ struct SetBlendModeOp final : DLOp {
                                                                                \
     sk_sp<Sk##name> field;                                                     \
                                                                                \
-    void dispatch(Dispatcher& dispatcher) const {                              \
-      dispatcher.set##name(field);                                             \
+    void dispatch(DispatchContext& ctx) const {                                \
+      ctx.dispatcher.set##name(field);                                         \
     }                                                                          \
   };
 DEFINE_SET_CLEAR_SKREF_OP(Blender, blender)
@@ -195,8 +217,8 @@ DEFINE_SET_CLEAR_SKREF_OP(Blender, blender)
                                                                             \
     Clear##name##Op() {}                                                    \
                                                                             \
-    void dispatch(Dispatcher& dispatcher) const {                           \
-      dispatcher.set##name(nullptr);                                        \
+    void dispatch(DispatchContext& ctx) const {                             \
+      ctx.dispatcher.set##name(nullptr);                                    \
     }                                                                       \
   };                                                                        \
   struct SetPod##name##Op final : DLOp {                                    \
@@ -204,9 +226,9 @@ DEFINE_SET_CLEAR_SKREF_OP(Blender, blender)
                                                                             \
     SetPod##name##Op() {}                                                   \
                                                                             \
-    void dispatch(Dispatcher& dispatcher) const {                           \
+    void dispatch(DispatchContext& ctx) const {                             \
       const Dl##name* filter = reinterpret_cast<const Dl##name*>(this + 1); \
-      dispatcher.set##name(filter);                                         \
+      ctx.dispatcher.set##name(filter);                                     \
     }                                                                       \
   };                                                                        \
   struct SetSk##name##Op final : DLOp {                                     \
@@ -216,9 +238,9 @@ DEFINE_SET_CLEAR_SKREF_OP(Blender, blender)
                                                                             \
     sk_sp<Sk##sk_name> field;                                               \
                                                                             \
-    void dispatch(Dispatcher& dispatcher) const {                           \
+    void dispatch(DispatchContext& ctx) const {                             \
       DlUnknown##name dl_filter(field);                                     \
-      dispatcher.set##name(&dl_filter);                                     \
+      ctx.dispatcher.set##name(&dl_filter);                                 \
     }                                                                       \
   };
 DEFINE_SET_CLEAR_DLATTR_OP(ColorFilter, ColorFilter, filter)
@@ -242,8 +264,8 @@ struct SetImageColorSourceOp : DLOp {
 
   const DlImageColorSource source;
 
-  void dispatch(Dispatcher& dispatcher) const {
-    dispatcher.setColorSource(&source);
+  void dispatch(DispatchContext& ctx) const {
+    ctx.dispatcher.setColorSource(&source);
   }
 };
 
@@ -259,8 +281,8 @@ struct SetRuntimeEffectColorSourceOp : DLOp {
 
   const DlRuntimeEffectColorSource source;
 
-  void dispatch(Dispatcher& dispatcher) const {
-    dispatcher.setColorSource(&source);
+  void dispatch(DispatchContext& ctx) const {
+    ctx.dispatcher.setColorSource(&source);
   }
 
   DisplayListCompare equals(const SetRuntimeEffectColorSourceOp* other) const {
@@ -278,8 +300,8 @@ struct SetSharedImageFilterOp : DLOp {
 
   const std::shared_ptr<DlImageFilter> filter;
 
-  void dispatch(Dispatcher& dispatcher) const {
-    dispatcher.setImageFilter(filter.get());
+  void dispatch(DispatchContext& ctx) const {
+    ctx.dispatcher.setImageFilter(filter.get());
   }
 
   DisplayListCompare equals(const SetSharedImageFilterOp* other) const {
@@ -288,53 +310,80 @@ struct SetSharedImageFilterOp : DLOp {
   }
 };
 
-// 4 byte header + no payload uses minimum 8 bytes (4 bytes unused)
-struct SaveOp final : DLOp {
+// The base object for all save() and saveLayer() ops
+// 4 byte header + 8 byte payload packs neatly into 16 bytes (4 bytes unused)
+struct SaveOpBase : DLOp {
+  SaveOpBase() : options(), restore_index(0) {}
+
+  SaveOpBase(const SaveLayerOptions options)
+      : options(options), restore_index(0) {}
+
+  // options parameter is only used by saveLayer operations, but since
+  // it packs neatly into the empty space created by laying out the 64-bit
+  // offsets, it can be stored for free and defaulted to 0 for save operations.
+  SaveLayerOptions options;
+  int restore_index;
+
+  inline bool save_needed(DispatchContext& ctx) const {
+    bool needed = ctx.next_render_index <= restore_index;
+    ctx.save_infos.emplace_back(ctx.next_restore_index, needed);
+    ctx.next_restore_index = restore_index;
+    return needed;
+  }
+};
+// 24 byte SaveOpBase with no additional data (options is unsed here)
+struct SaveOp final : SaveOpBase {
   static const auto kType = DisplayListOpType::kSave;
 
-  SaveOp() {}
+  SaveOp() : SaveOpBase() {}
 
-  void dispatch(Dispatcher& dispatcher) const { dispatcher.save(); }
+  void dispatch(DispatchContext& ctx) const {
+    if (save_needed(ctx)) {
+      ctx.dispatcher.save();
+    }
+  }
 };
-// 4 byte header + 4 byte payload packs into minimum 8 bytes
-struct SaveLayerOp final : DLOp {
+// 16 byte SaveOpBase with no additional data
+struct SaveLayerOp final : SaveOpBase {
   static const auto kType = DisplayListOpType::kSaveLayer;
 
-  explicit SaveLayerOp(const SaveLayerOptions options) : options(options) {}
+  explicit SaveLayerOp(const SaveLayerOptions options) : SaveOpBase(options) {}
 
-  SaveLayerOptions options;
-
-  void dispatch(Dispatcher& dispatcher) const {
-    dispatcher.saveLayer(nullptr, options);
+  void dispatch(DispatchContext& ctx) const {
+    if (save_needed(ctx)) {
+      ctx.dispatcher.saveLayer(nullptr, options);
+    }
   }
 };
-// 4 byte header + 20 byte payload packs evenly into 24 bytes
-struct SaveLayerBoundsOp final : DLOp {
+// 24 byte SaveOpBase + 16 byte payload packs evenly into 40 bytes
+struct SaveLayerBoundsOp final : SaveOpBase {
   static const auto kType = DisplayListOpType::kSaveLayerBounds;
 
-  SaveLayerBoundsOp(SkRect rect, const SaveLayerOptions options)
-      : options(options), rect(rect) {}
+  SaveLayerBoundsOp(const SaveLayerOptions options, const SkRect& rect)
+      : SaveOpBase(options), rect(rect) {}
 
-  SaveLayerOptions options;
   const SkRect rect;
 
-  void dispatch(Dispatcher& dispatcher) const {
-    dispatcher.saveLayer(&rect, options);
+  void dispatch(DispatchContext& ctx) const {
+    if (save_needed(ctx)) {
+      ctx.dispatcher.saveLayer(&rect, options);
+    }
   }
 };
-// 4 byte header + 20 byte payload packs into minimum 24 bytes
-struct SaveLayerBackdropOp final : DLOp {
+// 24 byte SaveOpBase + 16 byte payload packs into minimum 40 bytes
+struct SaveLayerBackdropOp final : SaveOpBase {
   static const auto kType = DisplayListOpType::kSaveLayerBackdrop;
 
   explicit SaveLayerBackdropOp(const SaveLayerOptions options,
                                const DlImageFilter* backdrop)
-      : options(options), backdrop(backdrop->shared()) {}
+      : SaveOpBase(options), backdrop(backdrop->shared()) {}
 
-  SaveLayerOptions options;
   const std::shared_ptr<DlImageFilter> backdrop;
 
-  void dispatch(Dispatcher& dispatcher) const {
-    dispatcher.saveLayer(nullptr, options, backdrop.get());
+  void dispatch(DispatchContext& ctx) const {
+    if (save_needed(ctx)) {
+      ctx.dispatcher.saveLayer(nullptr, options, backdrop.get());
+    }
   }
 
   DisplayListCompare equals(const SaveLayerBackdropOp* other) const {
@@ -343,21 +392,22 @@ struct SaveLayerBackdropOp final : DLOp {
                : DisplayListCompare::kNotEqual;
   }
 };
-// 4 byte header + 36 byte payload packs evenly into 36 bytes
-struct SaveLayerBackdropBoundsOp final : DLOp {
+// 24 byte SaveOpBase + 32 byte payload packs into minimum 56 bytes
+struct SaveLayerBackdropBoundsOp final : SaveOpBase {
   static const auto kType = DisplayListOpType::kSaveLayerBackdropBounds;
 
-  SaveLayerBackdropBoundsOp(SkRect rect,
-                            const SaveLayerOptions options,
+  SaveLayerBackdropBoundsOp(const SaveLayerOptions options,
+                            const SkRect& rect,
                             const DlImageFilter* backdrop)
-      : options(options), rect(rect), backdrop(backdrop->shared()) {}
+      : SaveOpBase(options), rect(rect), backdrop(backdrop->shared()) {}
 
-  SaveLayerOptions options;
   const SkRect rect;
   const std::shared_ptr<DlImageFilter> backdrop;
 
-  void dispatch(Dispatcher& dispatcher) const {
-    dispatcher.saveLayer(&rect, options, backdrop.get());
+  void dispatch(DispatchContext& ctx) const {
+    if (save_needed(ctx)) {
+      ctx.dispatcher.saveLayer(&rect, options, backdrop.get());
+    }
   }
 
   DisplayListCompare equals(const SaveLayerBackdropBoundsOp* other) const {
@@ -373,12 +423,25 @@ struct RestoreOp final : DLOp {
 
   RestoreOp() {}
 
-  void dispatch(Dispatcher& dispatcher) const { dispatcher.restore(); }
+  void dispatch(DispatchContext& ctx) const {
+    DispatchContext::SaveInfo& info = ctx.save_infos.back();
+    if (info.save_was_needed) {
+      ctx.dispatcher.restore();
+    }
+    FML_DCHECK(info.previous_restore_index > ctx.next_render_index);
+    ctx.next_restore_index = info.previous_restore_index;
+    ctx.save_infos.pop_back();
+  }
 };
 
+struct TransformClipOpBase : DLOp {
+  inline bool op_needed(const DispatchContext& context) const {
+    return context.next_render_index <= context.next_restore_index;
+  }
+};
 // 4 byte header + 8 byte payload uses 12 bytes but is rounded up to 16 bytes
 // (4 bytes unused)
-struct TranslateOp final : DLOp {
+struct TranslateOp final : TransformClipOpBase {
   static const auto kType = DisplayListOpType::kTranslate;
 
   TranslateOp(SkScalar tx, SkScalar ty) : tx(tx), ty(ty) {}
@@ -386,11 +449,15 @@ struct TranslateOp final : DLOp {
   const SkScalar tx;
   const SkScalar ty;
 
-  void dispatch(Dispatcher& dispatcher) const { dispatcher.translate(tx, ty); }
+  void dispatch(DispatchContext& ctx) const {
+    if (op_needed(ctx)) {
+      ctx.dispatcher.translate(tx, ty);
+    }
+  }
 };
 // 4 byte header + 8 byte payload uses 12 bytes but is rounded up to 16 bytes
 // (4 bytes unused)
-struct ScaleOp final : DLOp {
+struct ScaleOp final : TransformClipOpBase {
   static const auto kType = DisplayListOpType::kScale;
 
   ScaleOp(SkScalar sx, SkScalar sy) : sx(sx), sy(sy) {}
@@ -398,21 +465,29 @@ struct ScaleOp final : DLOp {
   const SkScalar sx;
   const SkScalar sy;
 
-  void dispatch(Dispatcher& dispatcher) const { dispatcher.scale(sx, sy); }
+  void dispatch(DispatchContext& ctx) const {
+    if (op_needed(ctx)) {
+      ctx.dispatcher.scale(sx, sy);
+    }
+  }
 };
 // 4 byte header + 4 byte payload packs into minimum 8 bytes
-struct RotateOp final : DLOp {
+struct RotateOp final : TransformClipOpBase {
   static const auto kType = DisplayListOpType::kRotate;
 
   explicit RotateOp(SkScalar degrees) : degrees(degrees) {}
 
   const SkScalar degrees;
 
-  void dispatch(Dispatcher& dispatcher) const { dispatcher.rotate(degrees); }
+  void dispatch(DispatchContext& ctx) const {
+    if (op_needed(ctx)) {
+      ctx.dispatcher.rotate(degrees);
+    }
+  }
 };
 // 4 byte header + 8 byte payload uses 12 bytes but is rounded up to 16 bytes
 // (4 bytes unused)
-struct SkewOp final : DLOp {
+struct SkewOp final : TransformClipOpBase {
   static const auto kType = DisplayListOpType::kSkew;
 
   SkewOp(SkScalar sx, SkScalar sy) : sx(sx), sy(sy) {}
@@ -420,11 +495,15 @@ struct SkewOp final : DLOp {
   const SkScalar sx;
   const SkScalar sy;
 
-  void dispatch(Dispatcher& dispatcher) const { dispatcher.skew(sx, sy); }
+  void dispatch(DispatchContext& ctx) const {
+    if (op_needed(ctx)) {
+      ctx.dispatcher.skew(sx, sy);
+    }
+  }
 };
 // 4 byte header + 24 byte payload uses 28 bytes but is rounded up to 32 bytes
 // (4 bytes unused)
-struct Transform2DAffineOp final : DLOp {
+struct Transform2DAffineOp final : TransformClipOpBase {
   static const auto kType = DisplayListOpType::kTransform2DAffine;
 
   // clang-format off
@@ -436,14 +515,16 @@ struct Transform2DAffineOp final : DLOp {
   const SkScalar mxx, mxy, mxt;
   const SkScalar myx, myy, myt;
 
-  void dispatch(Dispatcher& dispatcher) const {
-    dispatcher.transform2DAffine(mxx, mxy, mxt,  //
-                                 myx, myy, myt);
+  void dispatch(DispatchContext& ctx) const {
+    if (op_needed(ctx)) {
+      ctx.dispatcher.transform2DAffine(mxx, mxy, mxt,  //
+                                       myx, myy, myt);
+    }
   }
 };
 // 4 byte header + 64 byte payload uses 68 bytes which is rounded up to 72 bytes
 // (4 bytes unused)
-struct TransformFullPerspectiveOp final : DLOp {
+struct TransformFullPerspectiveOp final : TransformClipOpBase {
   static const auto kType = DisplayListOpType::kTransformFullPerspective;
 
   // clang-format off
@@ -463,21 +544,27 @@ struct TransformFullPerspectiveOp final : DLOp {
   const SkScalar mzx, mzy, mzz, mzt;
   const SkScalar mwx, mwy, mwz, mwt;
 
-  void dispatch(Dispatcher& dispatcher) const {
-    dispatcher.transformFullPerspective(mxx, mxy, mxz, mxt,  //
-                                        myx, myy, myz, myt,  //
-                                        mzx, mzy, mzz, mzt,  //
-                                        mwx, mwy, mwz, mwt);
+  void dispatch(DispatchContext& ctx) const {
+    if (op_needed(ctx)) {
+      ctx.dispatcher.transformFullPerspective(mxx, mxy, mxz, mxt,  //
+                                              myx, myy, myz, myt,  //
+                                              mzx, mzy, mzz, mzt,  //
+                                              mwx, mwy, mwz, mwt);
+    }
   }
 };
 
 // 4 byte header with no payload.
-struct TransformResetOp final : DLOp {
+struct TransformResetOp final : TransformClipOpBase {
   static const auto kType = DisplayListOpType::kTransformReset;
 
   TransformResetOp() = default;
 
-  void dispatch(Dispatcher& dispatcher) const { dispatcher.transformReset(); }
+  void dispatch(DispatchContext& ctx) const {
+    if (op_needed(ctx)) {
+      ctx.dispatcher.transformReset();
+    }
+  }
 };
 
 // 4 byte header + 4 byte common payload packs into minimum 8 bytes
@@ -491,7 +578,7 @@ struct TransformResetOp final : DLOp {
 // packing into more bytes than needed (even when they are declared as
 // packed bit fields!)
 #define DEFINE_CLIP_SHAPE_OP(shapetype, clipop)                            \
-  struct Clip##clipop##shapetype##Op final : DLOp {                        \
+  struct Clip##clipop##shapetype##Op final : TransformClipOpBase {         \
     static const auto kType = DisplayListOpType::kClip##clipop##shapetype; \
                                                                            \
     Clip##clipop##shapetype##Op(Sk##shapetype shape, bool is_aa)           \
@@ -500,8 +587,10 @@ struct TransformResetOp final : DLOp {
     const bool is_aa;                                                      \
     const Sk##shapetype shape;                                             \
                                                                            \
-    void dispatch(Dispatcher& dispatcher) const {                          \
-      dispatcher.clip##shapetype(shape, SkClipOp::k##clipop, is_aa);       \
+    void dispatch(DispatchContext& ctx) const {                            \
+      if (op_needed(ctx)) {                                                \
+        ctx.dispatcher.clip##shapetype(shape, SkClipOp::k##clipop, is_aa); \
+      }                                                                    \
     }                                                                      \
   };
 DEFINE_CLIP_SHAPE_OP(Rect, Intersect)
@@ -511,7 +600,7 @@ DEFINE_CLIP_SHAPE_OP(RRect, Difference)
 #undef DEFINE_CLIP_SHAPE_OP
 
 #define DEFINE_CLIP_PATH_OP(clipop)                                      \
-  struct Clip##clipop##PathOp final : DLOp {                             \
+  struct Clip##clipop##PathOp final : TransformClipOpBase {              \
     static const auto kType = DisplayListOpType::kClip##clipop##Path;    \
                                                                          \
     Clip##clipop##PathOp(SkPath path, bool is_aa)                        \
@@ -520,8 +609,10 @@ DEFINE_CLIP_SHAPE_OP(RRect, Difference)
     const bool is_aa;                                                    \
     const SkPath path;                                                   \
                                                                          \
-    void dispatch(Dispatcher& dispatcher) const {                        \
-      dispatcher.clipPath(path, SkClipOp::k##clipop, is_aa);             \
+    void dispatch(DispatchContext& ctx) const {                          \
+      if (op_needed(ctx)) {                                              \
+        ctx.dispatcher.clipPath(path, SkClipOp::k##clipop, is_aa);       \
+      }                                                                  \
     }                                                                    \
                                                                          \
     DisplayListCompare equals(const Clip##clipop##PathOp* other) const { \
@@ -534,17 +625,27 @@ DEFINE_CLIP_PATH_OP(Intersect)
 DEFINE_CLIP_PATH_OP(Difference)
 #undef DEFINE_CLIP_PATH_OP
 
+struct DrawOpBase : DLOp {
+  inline bool op_needed(const DispatchContext& ctx) const {
+    return ctx.cur_index >= ctx.next_render_index;
+  }
+};
+
 // 4 byte header + no payload uses minimum 8 bytes (4 bytes unused)
-struct DrawPaintOp final : DLOp {
+struct DrawPaintOp final : DrawOpBase {
   static const auto kType = DisplayListOpType::kDrawPaint;
 
   DrawPaintOp() {}
 
-  void dispatch(Dispatcher& dispatcher) const { dispatcher.drawPaint(); }
+  void dispatch(DispatchContext& ctx) const {
+    if (op_needed(ctx)) {
+      ctx.dispatcher.drawPaint();
+    }
+  }
 };
 // 4 byte header + 8 byte payload uses 12 bytes but is rounded up to 16 bytes
 // (4 bytes unused)
-struct DrawColorOp final : DLOp {
+struct DrawColorOp final : DrawOpBase {
   static const auto kType = DisplayListOpType::kDrawColor;
 
   DrawColorOp(DlColor color, DlBlendMode mode) : color(color), mode(mode) {}
@@ -552,8 +653,10 @@ struct DrawColorOp final : DLOp {
   const DlColor color;
   const DlBlendMode mode;
 
-  void dispatch(Dispatcher& dispatcher) const {
-    dispatcher.drawColor(color, mode);
+  void dispatch(DispatchContext& ctx) const {
+    if (op_needed(ctx)) {
+      ctx.dispatcher.drawColor(color, mode);
+    }
   }
 };
 
@@ -563,15 +666,17 @@ struct DrawColorOp final : DLOp {
 // SkOval is same as SkRect
 // SkRRect is 52 more bytes, which packs efficiently into 56 bytes total
 #define DEFINE_DRAW_1ARG_OP(op_name, arg_type, arg_name)                  \
-  struct Draw##op_name##Op final : DLOp {                                 \
+  struct Draw##op_name##Op final : DrawOpBase {                           \
     static const auto kType = DisplayListOpType::kDraw##op_name;          \
                                                                           \
     explicit Draw##op_name##Op(arg_type arg_name) : arg_name(arg_name) {} \
                                                                           \
     const arg_type arg_name;                                              \
                                                                           \
-    void dispatch(Dispatcher& dispatcher) const {                         \
-      dispatcher.draw##op_name(arg_name);                                 \
+    void dispatch(DispatchContext& ctx) const {                           \
+      if (op_needed(ctx)) {                                               \
+        ctx.dispatcher.draw##op_name(arg_name);                           \
+      }                                                                   \
     }                                                                     \
   };
 DEFINE_DRAW_1ARG_OP(Rect, SkRect, rect)
@@ -581,14 +686,18 @@ DEFINE_DRAW_1ARG_OP(RRect, SkRRect, rrect)
 
 // 4 byte header + 16 byte payload uses 20 bytes but is rounded up to 24 bytes
 // (4 bytes unused)
-struct DrawPathOp final : DLOp {
+struct DrawPathOp final : DrawOpBase {
   static const auto kType = DisplayListOpType::kDrawPath;
 
   explicit DrawPathOp(SkPath path) : path(path) {}
 
   const SkPath path;
 
-  void dispatch(Dispatcher& dispatcher) const { dispatcher.drawPath(path); }
+  void dispatch(DispatchContext& ctx) const {
+    if (op_needed(ctx)) {
+      ctx.dispatcher.drawPath(path);
+    }
+  }
 
   DisplayListCompare equals(const DrawPathOp* other) const {
     return path == other->path ? DisplayListCompare::kEqual
@@ -603,7 +712,7 @@ struct DrawPathOp final : DLOp {
 // 2 x SkRRect is 104 more bytes, using 108 and rounding up to 112 bytes total
 //             (4 bytes unused)
 #define DEFINE_DRAW_2ARG_OP(op_name, type1, name1, type2, name2) \
-  struct Draw##op_name##Op final : DLOp {                        \
+  struct Draw##op_name##Op final : DrawOpBase {                  \
     static const auto kType = DisplayListOpType::kDraw##op_name; \
                                                                  \
     Draw##op_name##Op(type1 name1, type2 name2)                  \
@@ -612,8 +721,10 @@ struct DrawPathOp final : DLOp {
     const type1 name1;                                           \
     const type2 name2;                                           \
                                                                  \
-    void dispatch(Dispatcher& dispatcher) const {                \
-      dispatcher.draw##op_name(name1, name2);                    \
+    void dispatch(DispatchContext& ctx) const {                  \
+      if (op_needed(ctx)) {                                      \
+        ctx.dispatcher.draw##op_name(name1, name2);              \
+      }                                                          \
     }                                                            \
   };
 DEFINE_DRAW_2ARG_OP(Line, SkPoint, p0, SkPoint, p1)
@@ -622,7 +733,7 @@ DEFINE_DRAW_2ARG_OP(DRRect, SkRRect, outer, SkRRect, inner)
 #undef DEFINE_DRAW_2ARG_OP
 
 // 4 byte header + 28 byte payload packs efficiently into 32 bytes
-struct DrawArcOp final : DLOp {
+struct DrawArcOp final : DrawOpBase {
   static const auto kType = DisplayListOpType::kDrawArc;
 
   DrawArcOp(SkRect bounds, SkScalar start, SkScalar sweep, bool center)
@@ -633,8 +744,10 @@ struct DrawArcOp final : DLOp {
   const SkScalar sweep;
   const bool center;
 
-  void dispatch(Dispatcher& dispatcher) const {
-    dispatcher.drawArc(bounds, start, sweep, center);
+  void dispatch(DispatchContext& ctx) const {
+    if (op_needed(ctx)) {
+      ctx.dispatcher.drawArc(bounds, start, sweep, center);
+    }
   }
 };
 
@@ -644,18 +757,20 @@ struct DrawArcOp final : DLOp {
 // so this op will always pack efficiently
 // The point type is packed into 3 different OpTypes to avoid expanding
 // the fixed payload beyond the 8 bytes
-#define DEFINE_DRAW_POINTS_OP(name, mode)                              \
-  struct Draw##name##Op final : DLOp {                                 \
-    static const auto kType = DisplayListOpType::kDraw##name;          \
-                                                                       \
-    explicit Draw##name##Op(uint32_t count) : count(count) {}          \
-                                                                       \
-    const uint32_t count;                                              \
-                                                                       \
-    void dispatch(Dispatcher& dispatcher) const {                      \
-      const SkPoint* pts = reinterpret_cast<const SkPoint*>(this + 1); \
-      dispatcher.drawPoints(SkCanvas::PointMode::mode, count, pts);    \
-    }                                                                  \
+#define DEFINE_DRAW_POINTS_OP(name, mode)                                 \
+  struct Draw##name##Op final : DrawOpBase {                              \
+    static const auto kType = DisplayListOpType::kDraw##name;             \
+                                                                          \
+    explicit Draw##name##Op(uint32_t count) : count(count) {}             \
+                                                                          \
+    const uint32_t count;                                                 \
+                                                                          \
+    void dispatch(DispatchContext& ctx) const {                           \
+      if (op_needed(ctx)) {                                               \
+        const SkPoint* pts = reinterpret_cast<const SkPoint*>(this + 1);  \
+        ctx.dispatcher.drawPoints(SkCanvas::PointMode::mode, count, pts); \
+      }                                                                   \
+    }                                                                     \
   };
 DEFINE_DRAW_POINTS_OP(Points, kPoints_PointMode);
 DEFINE_DRAW_POINTS_OP(Lines, kLines_PointMode);
@@ -669,21 +784,24 @@ DEFINE_DRAW_POINTS_OP(Polygon, kPolygon_PointMode);
 // Note that the DlVertices object ends with an array of 16-bit
 // indices so the alignment can be up to 6 bytes off leading to
 // up to 6 bytes of overhead
-struct DrawVerticesOp final : DLOp {
+struct DrawVerticesOp final : DrawOpBase {
   static const auto kType = DisplayListOpType::kDrawVertices;
 
   DrawVerticesOp(DlBlendMode mode) : mode(mode) {}
 
   const DlBlendMode mode;
 
-  void dispatch(Dispatcher& dispatcher) const {
-    const DlVertices* vertices = reinterpret_cast<const DlVertices*>(this + 1);
-    dispatcher.drawVertices(vertices, mode);
+  void dispatch(DispatchContext& ctx) const {
+    if (op_needed(ctx)) {
+      const DlVertices* vertices =
+          reinterpret_cast<const DlVertices*>(this + 1);
+      ctx.dispatcher.drawVertices(vertices, mode);
+    }
   }
 };
 
 // 4 byte header + 12 byte payload packs efficiently into 16 bytes
-struct DrawSkVerticesOp final : DLOp {
+struct DrawSkVerticesOp final : DrawOpBase {
   static const auto kType = DisplayListOpType::kDrawSkVertices;
 
   DrawSkVerticesOp(sk_sp<SkVertices> vertices, SkBlendMode mode)
@@ -692,29 +810,33 @@ struct DrawSkVerticesOp final : DLOp {
   const SkBlendMode mode;
   const sk_sp<SkVertices> vertices;
 
-  void dispatch(Dispatcher& dispatcher) const {
-    dispatcher.drawSkVertices(vertices, mode);
+  void dispatch(DispatchContext& ctx) const {
+    if (op_needed(ctx)) {
+      ctx.dispatcher.drawSkVertices(vertices, mode);
+    }
   }
 };
 
 // 4 byte header + 40 byte payload uses 44 bytes but is rounded up to 48 bytes
 // (4 bytes unused)
-#define DEFINE_DRAW_IMAGE_OP(name, with_attributes)                    \
-  struct name##Op final : DLOp {                                       \
-    static const auto kType = DisplayListOpType::k##name;              \
-                                                                       \
-    name##Op(const sk_sp<DlImage> image,                               \
-             const SkPoint& point,                                     \
-             DlImageSampling sampling)                                 \
-        : point(point), sampling(sampling), image(std::move(image)) {} \
-                                                                       \
-    const SkPoint point;                                               \
-    const DlImageSampling sampling;                                    \
-    const sk_sp<DlImage> image;                                        \
-                                                                       \
-    void dispatch(Dispatcher& dispatcher) const {                      \
-      dispatcher.drawImage(image, point, sampling, with_attributes);   \
-    }                                                                  \
+#define DEFINE_DRAW_IMAGE_OP(name, with_attributes)                        \
+  struct name##Op final : DrawOpBase {                                     \
+    static const auto kType = DisplayListOpType::k##name;                  \
+                                                                           \
+    name##Op(const sk_sp<DlImage> image,                                   \
+             const SkPoint& point,                                         \
+             DlImageSampling sampling)                                     \
+        : point(point), sampling(sampling), image(std::move(image)) {}     \
+                                                                           \
+    const SkPoint point;                                                   \
+    const DlImageSampling sampling;                                        \
+    const sk_sp<DlImage> image;                                            \
+                                                                           \
+    void dispatch(DispatchContext& ctx) const {                            \
+      if (op_needed(ctx)) {                                                \
+        ctx.dispatcher.drawImage(image, point, sampling, with_attributes); \
+      }                                                                    \
+    }                                                                      \
   };
 DEFINE_DRAW_IMAGE_OP(DrawImage, false)
 DEFINE_DRAW_IMAGE_OP(DrawImageWithAttr, true)
@@ -722,7 +844,7 @@ DEFINE_DRAW_IMAGE_OP(DrawImageWithAttr, true)
 
 // 4 byte header + 72 byte payload uses 76 bytes but is rounded up to 80 bytes
 // (4 bytes unused)
-struct DrawImageRectOp final : DLOp {
+struct DrawImageRectOp final : DrawOpBase {
   static const auto kType = DisplayListOpType::kDrawImageRect;
 
   DrawImageRectOp(const sk_sp<DlImage> image,
@@ -745,15 +867,17 @@ struct DrawImageRectOp final : DLOp {
   const SkCanvas::SrcRectConstraint constraint;
   const sk_sp<DlImage> image;
 
-  void dispatch(Dispatcher& dispatcher) const {
-    dispatcher.drawImageRect(image, src, dst, sampling, render_with_attributes,
-                             constraint);
+  void dispatch(DispatchContext& ctx) const {
+    if (op_needed(ctx)) {
+      ctx.dispatcher.drawImageRect(image, src, dst, sampling,
+                                   render_with_attributes, constraint);
+    }
   }
 };
 
 // 4 byte header + 44 byte payload packs efficiently into 48 bytes
 #define DEFINE_DRAW_IMAGE_NINE_OP(name, render_with_attributes)                \
-  struct name##Op final : DLOp {                                               \
+  struct name##Op final : DrawOpBase {                                         \
     static const auto kType = DisplayListOpType::k##name;                      \
                                                                                \
     name##Op(const sk_sp<DlImage> image,                                       \
@@ -767,9 +891,11 @@ struct DrawImageRectOp final : DLOp {
     const DlFilterMode filter;                                                 \
     const sk_sp<DlImage> image;                                                \
                                                                                \
-    void dispatch(Dispatcher& dispatcher) const {                              \
-      dispatcher.drawImageNine(image, center, dst, filter,                     \
-                               render_with_attributes);                        \
+    void dispatch(DispatchContext& ctx) const {                                \
+      if (op_needed(ctx)) {                                                    \
+        ctx.dispatcher.drawImageNine(image, center, dst, filter,               \
+                                     render_with_attributes);                  \
+      }                                                                        \
     }                                                                          \
   };
 DEFINE_DRAW_IMAGE_NINE_OP(DrawImageNine, false)
@@ -777,7 +903,7 @@ DEFINE_DRAW_IMAGE_NINE_OP(DrawImageNineWithAttr, true)
 #undef DEFINE_DRAW_IMAGE_NINE_OP
 
 // 4 byte header + 60 byte payload packs evenly into 64 bytes
-struct DrawImageLatticeOp final : DLOp {
+struct DrawImageLatticeOp final : DrawOpBase {
   static const auto kType = DisplayListOpType::kDrawImageLattice;
 
   DrawImageLatticeOp(const sk_sp<DlImage> image,
@@ -806,20 +932,22 @@ struct DrawImageLatticeOp final : DLOp {
   const SkRect dst;
   const sk_sp<DlImage> image;
 
-  void dispatch(Dispatcher& dispatcher) const {
-    const int* xDivs = reinterpret_cast<const int*>(this + 1);
-    const int* yDivs = reinterpret_cast<const int*>(xDivs + x_count);
-    const SkColor* colors =
-        (cell_count == 0) ? nullptr
-                          : reinterpret_cast<const SkColor*>(yDivs + y_count);
-    const SkCanvas::Lattice::RectType* types =
-        (cell_count == 0)
-            ? nullptr
-            : reinterpret_cast<const SkCanvas::Lattice::RectType*>(colors +
-                                                                   cell_count);
-    dispatcher.drawImageLattice(
-        image, {xDivs, yDivs, types, x_count, y_count, &src, colors}, dst,
-        filter, with_paint);
+  void dispatch(DispatchContext& ctx) const {
+    if (op_needed(ctx)) {
+      const int* xDivs = reinterpret_cast<const int*>(this + 1);
+      const int* yDivs = reinterpret_cast<const int*>(xDivs + x_count);
+      const SkColor* colors =
+          (cell_count == 0) ? nullptr
+                            : reinterpret_cast<const SkColor*>(yDivs + y_count);
+      const SkCanvas::Lattice::RectType* types =
+          (cell_count == 0)
+              ? nullptr
+              : reinterpret_cast<const SkCanvas::Lattice::RectType*>(
+                    colors + cell_count);
+      ctx.dispatcher.drawImageLattice(
+          image, {xDivs, yDivs, types, x_count, y_count, &src, colors}, dst,
+          filter, with_paint);
+    }
   }
 };
 
@@ -830,7 +958,7 @@ struct DrawImageLatticeOp final : DLOp {
 // SkRect list is also a multiple of 16 bytes so it also packs well
 // DlColor list only packs well if the count is even, otherwise there
 // can be 4 unusued bytes at the end.
-struct DrawAtlasBaseOp : DLOp {
+struct DrawAtlasBaseOp : DrawOpBase {
   DrawAtlasBaseOp(const sk_sp<DlImage> atlas,
                   int count,
                   DlBlendMode mode,
@@ -870,14 +998,16 @@ struct DrawAtlasOp final : DrawAtlasBaseOp {
                         has_colors,
                         render_with_attributes) {}
 
-  void dispatch(Dispatcher& dispatcher) const {
-    const SkRSXform* xform = reinterpret_cast<const SkRSXform*>(this + 1);
-    const SkRect* tex = reinterpret_cast<const SkRect*>(xform + count);
-    const DlColor* colors =
-        has_colors ? reinterpret_cast<const DlColor*>(tex + count) : nullptr;
-    const DlBlendMode mode = static_cast<DlBlendMode>(mode_index);
-    dispatcher.drawAtlas(atlas, xform, tex, colors, count, mode, sampling,
-                         nullptr, render_with_attributes);
+  void dispatch(DispatchContext& ctx) const {
+    if (op_needed(ctx)) {
+      const SkRSXform* xform = reinterpret_cast<const SkRSXform*>(this + 1);
+      const SkRect* tex = reinterpret_cast<const SkRect*>(xform + count);
+      const DlColor* colors =
+          has_colors ? reinterpret_cast<const DlColor*>(tex + count) : nullptr;
+      const DlBlendMode mode = static_cast<DlBlendMode>(mode_index);
+      ctx.dispatcher.drawAtlas(atlas, xform, tex, colors, count, mode, sampling,
+                               nullptr, render_with_attributes);
+    }
   }
 };
 
@@ -905,19 +1035,21 @@ struct DrawAtlasCulledOp final : DrawAtlasBaseOp {
 
   const SkRect cull_rect;
 
-  void dispatch(Dispatcher& dispatcher) const {
-    const SkRSXform* xform = reinterpret_cast<const SkRSXform*>(this + 1);
-    const SkRect* tex = reinterpret_cast<const SkRect*>(xform + count);
-    const DlColor* colors =
-        has_colors ? reinterpret_cast<const DlColor*>(tex + count) : nullptr;
-    const DlBlendMode mode = static_cast<DlBlendMode>(mode_index);
-    dispatcher.drawAtlas(atlas, xform, tex, colors, count, mode, sampling,
-                         &cull_rect, render_with_attributes);
+  void dispatch(DispatchContext& ctx) const {
+    if (op_needed(ctx)) {
+      const SkRSXform* xform = reinterpret_cast<const SkRSXform*>(this + 1);
+      const SkRect* tex = reinterpret_cast<const SkRect*>(xform + count);
+      const DlColor* colors =
+          has_colors ? reinterpret_cast<const DlColor*>(tex + count) : nullptr;
+      const DlBlendMode mode = static_cast<DlBlendMode>(mode_index);
+      ctx.dispatcher.drawAtlas(atlas, xform, tex, colors, count, mode, sampling,
+                               &cull_rect, render_with_attributes);
+    }
   }
 };
 
 // 4 byte header + 12 byte payload packs evenly into 16 bytes
-struct DrawSkPictureOp final : DLOp {
+struct DrawSkPictureOp final : DrawOpBase {
   static const auto kType = DisplayListOpType::kDrawSkPicture;
 
   DrawSkPictureOp(sk_sp<SkPicture> picture, bool render_with_attributes)
@@ -927,13 +1059,15 @@ struct DrawSkPictureOp final : DLOp {
   const bool render_with_attributes;
   const sk_sp<SkPicture> picture;
 
-  void dispatch(Dispatcher& dispatcher) const {
-    dispatcher.drawPicture(picture, nullptr, render_with_attributes);
+  void dispatch(DispatchContext& ctx) const {
+    if (op_needed(ctx)) {
+      ctx.dispatcher.drawPicture(picture, nullptr, render_with_attributes);
+    }
   }
 };
 
 // 4 byte header + 52 byte payload packs evenly into 56 bytes
-struct DrawSkPictureMatrixOp final : DLOp {
+struct DrawSkPictureMatrixOp final : DrawOpBase {
   static const auto kType = DisplayListOpType::kDrawSkPictureMatrix;
 
   DrawSkPictureMatrixOp(sk_sp<SkPicture> picture,
@@ -947,14 +1081,16 @@ struct DrawSkPictureMatrixOp final : DLOp {
   const sk_sp<SkPicture> picture;
   const SkMatrix matrix;
 
-  void dispatch(Dispatcher& dispatcher) const {
-    dispatcher.drawPicture(picture, &matrix, render_with_attributes);
+  void dispatch(DispatchContext& ctx) const {
+    if (op_needed(ctx)) {
+      ctx.dispatcher.drawPicture(picture, &matrix, render_with_attributes);
+    }
   }
 };
 
 // 4 byte header + ptr aligned payload uses 12 bytes round up to 16
 // (4 bytes unused)
-struct DrawDisplayListOp final : DLOp {
+struct DrawDisplayListOp final : DrawOpBase {
   static const auto kType = DisplayListOpType::kDrawDisplayList;
 
   explicit DrawDisplayListOp(const sk_sp<DisplayList> display_list)
@@ -962,8 +1098,10 @@ struct DrawDisplayListOp final : DLOp {
 
   sk_sp<DisplayList> display_list;
 
-  void dispatch(Dispatcher& dispatcher) const {
-    dispatcher.drawDisplayList(display_list);
+  void dispatch(DispatchContext& ctx) const {
+    if (op_needed(ctx)) {
+      ctx.dispatcher.drawDisplayList(display_list);
+    }
   }
 
   DisplayListCompare equals(const DrawDisplayListOp* other) const {
@@ -975,7 +1113,7 @@ struct DrawDisplayListOp final : DLOp {
 
 // 4 byte header + 8 payload bytes + an aligned pointer take 24 bytes
 // (4 unused to align the pointer)
-struct DrawTextBlobOp final : DLOp {
+struct DrawTextBlobOp final : DrawOpBase {
   static const auto kType = DisplayListOpType::kDrawTextBlob;
 
   DrawTextBlobOp(const sk_sp<SkTextBlob> blob, SkScalar x, SkScalar y)
@@ -985,31 +1123,35 @@ struct DrawTextBlobOp final : DLOp {
   const SkScalar y;
   const sk_sp<SkTextBlob> blob;
 
-  void dispatch(Dispatcher& dispatcher) const {
-    dispatcher.drawTextBlob(blob, x, y);
+  void dispatch(DispatchContext& ctx) const {
+    if (op_needed(ctx)) {
+      ctx.dispatcher.drawTextBlob(blob, x, y);
+    }
   }
 };
 
 // 4 byte header + 28 byte payload packs evenly into 32 bytes
-#define DEFINE_DRAW_SHADOW_OP(name, transparent_occluder)                 \
-  struct Draw##name##Op final : DLOp {                                    \
-    static const auto kType = DisplayListOpType::kDraw##name;             \
-                                                                          \
-    Draw##name##Op(const SkPath& path,                                    \
-                   DlColor color,                                         \
-                   SkScalar elevation,                                    \
-                   SkScalar dpr)                                          \
-        : color(color), elevation(elevation), dpr(dpr), path(path) {}     \
-                                                                          \
-    const DlColor color;                                                  \
-    const SkScalar elevation;                                             \
-    const SkScalar dpr;                                                   \
-    const SkPath path;                                                    \
-                                                                          \
-    void dispatch(Dispatcher& dispatcher) const {                         \
-      dispatcher.drawShadow(path, color, elevation, transparent_occluder, \
-                            dpr);                                         \
-    }                                                                     \
+#define DEFINE_DRAW_SHADOW_OP(name, transparent_occluder)             \
+  struct Draw##name##Op final : DrawOpBase {                          \
+    static const auto kType = DisplayListOpType::kDraw##name;         \
+                                                                      \
+    Draw##name##Op(const SkPath& path,                                \
+                   DlColor color,                                     \
+                   SkScalar elevation,                                \
+                   SkScalar dpr)                                      \
+        : color(color), elevation(elevation), dpr(dpr), path(path) {} \
+                                                                      \
+    const DlColor color;                                              \
+    const SkScalar elevation;                                         \
+    const SkScalar dpr;                                               \
+    const SkPath path;                                                \
+                                                                      \
+    void dispatch(DispatchContext& ctx) const {                       \
+      if (op_needed(ctx)) {                                           \
+        ctx.dispatcher.drawShadow(path, color, elevation,             \
+                                  transparent_occluder, dpr);         \
+      }                                                               \
+    }                                                                 \
   };
 DEFINE_DRAW_SHADOW_OP(Shadow, false)
 DEFINE_DRAW_SHADOW_OP(ShadowTransparentOccluder, true)

--- a/display_list/display_list_ops.h
+++ b/display_list/display_list_ops.h
@@ -1071,11 +1071,18 @@ struct DrawSkPictureMatrixOp final : DrawOpBase {
   static const auto kType = DisplayListOpType::kDrawSkPictureMatrix;
 
   DrawSkPictureMatrixOp(sk_sp<SkPicture> picture,
-                        const SkMatrix matrix,
+                        const SkMatrix& matrix,
                         bool render_with_attributes)
       : render_with_attributes(render_with_attributes),
         picture(std::move(picture)),
-        matrix(matrix) {}
+        matrix(matrix) {
+    // The copy constructor might copy in an unknown or a resolved
+    // type depending on whether the source Matrix had been used
+    // since its last mutating method. Calling getType here forces
+    // the matrix object into a known state so that it can be bulk
+    // compared without having to introduce a custom equals() method.
+    this->matrix.getType();
+  }
 
   const bool render_with_attributes;
   const sk_sp<SkPicture> picture;

--- a/display_list/display_list_rtree.cc
+++ b/display_list/display_list_rtree.cc
@@ -14,6 +14,12 @@ DlRTree::DlRTree(const SkRect rects[],
                  bool p(int),
                  int invalid_id)
     : leaf_count_(0), invalid_id_(invalid_id) {
+  if (N <= 0) {
+    FML_DCHECK(N >= 0);
+    return;
+  }
+  FML_DCHECK(rects != nullptr);
+
   // Count the number of rectangles we actually want to track,
   // which includes only non-empty rectangles whose optional
   // ID is not filtered by the predicate.
@@ -133,6 +139,7 @@ DlRTree::DlRTree(const SkRect rects[],
 }
 
 void DlRTree::search(const SkRect& query, std::vector<int>* results) const {
+  FML_DCHECK(results != nullptr);
   if (query.isEmpty()) {
     return;
   }

--- a/display_list/display_list_rtree.cc
+++ b/display_list/display_list_rtree.cc
@@ -35,10 +35,10 @@ DlRTree::DlRTree(const SkRect rects[],
 
   // Count the total number of nodes (leaf and internal) up front
   // so we can resize the vector just once.
-  int total_node_count = leaf_count;
-  int gen_count = leaf_count;
+  uint32_t total_node_count = leaf_count;
+  uint32_t gen_count = leaf_count;
   while (gen_count > 1) {
-    int family_count = (gen_count + kMaxChildren - 1) / kMaxChildren;
+    uint32_t family_count = (gen_count + kMaxChildren - 1u) / kMaxChildren;
     total_node_count += family_count;
     gen_count = family_count;
   }
@@ -85,12 +85,12 @@ DlRTree::DlRTree(const SkRect rects[],
   // Each generation will end up reduced by a factor of up to kMaxChildren
   // until there is just one node left, which is the root node of
   // the R-Tree.
-  int gen_start = 0;
+  uint32_t gen_start = 0;
   gen_count = leaf_count;
   while (gen_count > 1) {
-    const int gen_end = gen_start + gen_count;
+    uint32_t gen_end = gen_start + gen_count;
 
-    const int family_count = (gen_count + kMaxChildren - 1) / kMaxChildren;
+    uint32_t family_count = (gen_count + kMaxChildren - 1u) / kMaxChildren;
     FML_DCHECK(gen_end + family_count <= total_node_count);
 
     // D here is similar to the variable in a Bresenham line algorithm where
@@ -113,8 +113,8 @@ DlRTree::DlRTree(const SkRect rects[],
     // don't care about the distribution of the extra children.
     int D = 0;
 
-    int sibling_index = gen_start;
-    int parent_index = gen_end;
+    uint32_t sibling_index = gen_start;
+    uint32_t parent_index = gen_end;
     Node* parent = nullptr;
     while (sibling_index < gen_end) {
       if ((D += family_count) > 0) {

--- a/display_list/display_list_rtree.h
+++ b/display_list/display_list_rtree.h
@@ -6,31 +6,85 @@
 #define FLUTTER_DISPLAY_LIST_RTREE_H_
 
 #include <list>
-#include <map>
 
-#include "third_party/skia/include/core/SkBBHFactory.h"
+#include "flutter/fml/logging.h"
 #include "third_party/skia/include/core/SkRect.h"
+#include "third_party/skia/include/core/SkRefCnt.h"
 
 namespace flutter {
 
-/**
- * An R-Tree implementation that forwards calls to an SkRTree. This is just
- * a copy of flow/rtree.h/cc until we can figure out where these utilities
- * can live with appropriate linking visibility.
- *
- * This implementation provides a searchNonOverlappingDrawnRects method,
- * which can be used to query the rects for the operations recorded in the tree.
- */
-class DlRTree : public SkBBoxHierarchy {
- public:
-  DlRTree();
+/// An R-Tree that stores a list of bounding rectangles with optional
+/// associated IDs and returns either a vector of result indices which
+/// can be used to get an ID or a bounds of the associated entry in the
+/// same order that the rectangles and IDs were provided to the constructor.
+class DlRTree : public SkRefCnt {
+ private:
+  static constexpr int kMaxChildren = 11;
 
-  void insert(const SkRect[],
-              const SkBBoxHierarchy::Metadata[],
-              int N) override;
-  void insert(const SkRect[], int N) override;
-  void search(const SkRect& query, std::vector<int>* results) const override;
-  size_t bytesUsed() const override;
+  // Leaf nodes at start of vector have an ID,
+  // Internal nodes after that have child index and count.
+  struct Node {
+    SkRect bounds;
+    union {
+      struct {
+        uint32_t index;
+        uint32_t count;
+      } child;
+      int id;
+    };
+  };
+
+ public:
+  /// Construct an R-Tree from the list of rectangles respecting the
+  /// order in which they appear in the list. An optional array of
+  /// IDs can be provided to tag each rectangle with information needed
+  /// by the caller.
+  DlRTree(
+      const SkRect rects[],
+      int unfilteredN,
+      const int ids[] = nullptr,
+      bool p(int) = [](int) { return true; });
+
+  /// Search the rectangles and return a vector of result indices for
+  /// rectangles that intersect the query. Note that the indices are
+  /// internal indices of the stored data and not the index of the
+  /// rectangles or ids in the constructor. The indices will be stored
+  /// in the results vector according to the order in which the rectangles
+  /// were supplied in the constructor, even though the actual numeric
+  /// values may not match.
+  void search(const SkRect& query, std::vector<int>* results) const {
+    if (query.isEmpty()) {
+      return;
+    }
+    if (nodes_.size() <= 0) {
+      return;
+    }
+    const Node& root = nodes_.back();
+    if (root.bounds.intersects(query)) {
+      if (nodes_.size() == 1) {
+        // The root node is the only node and it is a leaf node
+        results->push_back(0);
+      } else {
+        search(root, query, results);
+      }
+    }
+  }
+
+  /// Return the ID for the indicated result of a query
+  int id(int result_index) const {
+    FML_DCHECK(result_index < leaf_count_);
+    return nodes_[result_index].id;
+  }
+
+  /// Return the rectangle bounds for the indicated result of a query
+  const SkRect& bounds(int result_index) const {
+    FML_DCHECK(result_index < leaf_count_);
+    return nodes_[result_index].bounds;
+  }
+
+  size_t bytesUsed() const {
+    return sizeof(DlRTree) + sizeof(Node) * nodes_.size();
+  }
 
   // Finds the rects in the tree that represent drawing operations and intersect
   // with the query rect.
@@ -41,26 +95,15 @@ class DlRTree : public SkBBoxHierarchy {
   std::list<SkRect> searchNonOverlappingDrawnRects(const SkRect& query) const;
 
   // Insertion count (not overall node count, which may be greater).
-  int getCount() const { return all_ops_count_; }
+  // int getCount() const { return all_ops_count_; }
 
  private:
-  // A map containing the draw operation rects keyed off the operation index
-  // in the insert call.
-  std::map<int, SkRect> draw_op_;
-  sk_sp<SkBBoxHierarchy> bbh_;
-  int all_ops_count_;
-};
+  void search(const Node& parent,
+              const SkRect& query,
+              std::vector<int>* results) const;
 
-class DlRTreeFactory : public SkBBHFactory {
- public:
-  DlRTreeFactory();
-
-  // Gets the instance to the R-tree.
-  sk_sp<DlRTree> getInstance();
-  sk_sp<SkBBoxHierarchy> operator()() const override;
-
- private:
-  sk_sp<DlRTree> r_tree_;
+  std::vector<Node> nodes_;
+  int leaf_count_;
 };
 
 }  // namespace flutter

--- a/display_list/display_list_rtree.h
+++ b/display_list/display_list_rtree.h
@@ -75,14 +75,16 @@ class DlRTree : public SkRefCnt {
   /// invalid_id if the index is not a valid leaf node index.
   int id(int result_index) const {
     return (result_index >= 0 && result_index < leaf_count_)
-        ? nodes_[result_index].id : invalid_id_;
+               ? nodes_[result_index].id
+               : invalid_id_;
   }
 
   /// Return the rectangle bounds for the indicated result of a query
   /// or an empty rect if the index is not a valid leaf node index.
   const SkRect& bounds(int result_index) const {
     return (result_index >= 0 && result_index < leaf_count_)
-        ? nodes_[result_index].bounds : empty_;
+               ? nodes_[result_index].bounds
+               : empty_;
   }
 
   /// Returns the bytes used by the object and all of its node data.

--- a/display_list/display_list_rtree.h
+++ b/display_list/display_list_rtree.h
@@ -6,6 +6,7 @@
 #define FLUTTER_DISPLAY_LIST_RTREE_H_
 
 #include <list>
+#include <vector>
 
 #include "flutter/fml/logging.h"
 #include "third_party/skia/include/core/SkRect.h"

--- a/display_list/display_list_rtree.h
+++ b/display_list/display_list_rtree.h
@@ -15,9 +15,14 @@
 namespace flutter {
 
 /// An R-Tree that stores a list of bounding rectangles with optional
-/// associated IDs and returns either a vector of result indices which
-/// can be used to get an ID or a bounds of the associated entry in the
-/// same order that the rectangles and IDs were provided to the constructor.
+/// associated IDs.
+///
+/// The R-Tree can be searched in one of two ways:
+/// - Query for a list of hits among the original rectangles
+///   @see |search|
+/// - Query for a set of non-overlapping rectangles that are joined
+///   from the original rectangles that intersect a query rect
+///   @see |searchAndConsolidateRects|
 class DlRTree : public SkRefCnt {
  private:
   static constexpr int kMaxChildren = 11;
@@ -108,7 +113,7 @@ class DlRTree : public SkRefCnt {
   /// joined into a single rect which also intersects with the query rect.
   /// In other words, the bounds of each rect in the result list are mutually
   /// exclusive.
-  std::list<SkRect> searchNonOverlappingDrawnRects(const SkRect& query) const;
+  std::list<SkRect> searchAndConsolidateRects(const SkRect& query) const;
 
  private:
   static constexpr SkRect empty_ = SkRect::MakeEmpty();

--- a/display_list/display_list_rtree_unittests.cc
+++ b/display_list/display_list_rtree_unittests.cc
@@ -1,0 +1,266 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/display_list/display_list_rtree.h"
+#include "gtest/gtest.h"
+#include "third_party/skia/include/core/SkRect.h"
+
+namespace flutter {
+namespace testing {
+
+#ifndef NDEBUG
+TEST(DisplayListRTree, NullRectListNonZeroCount) {
+  EXPECT_DEATH_IF_SUPPORTED(new DlRTree(nullptr, 1), "rects != nullptr");
+}
+
+TEST(DisplayListRTree, NegativeCount) {
+  EXPECT_DEATH_IF_SUPPORTED(new DlRTree(nullptr, -1), "N >= 0");
+}
+
+TEST(DisplayListRTree, NullSearchResultVector) {
+  DlRTree tree(nullptr, 0);
+  EXPECT_DEATH_IF_SUPPORTED(tree.search(SkRect::MakeLTRB(0, 0, 1, 1), nullptr),
+                            "results != nullptr");
+}
+#endif
+
+TEST(DisplayListRTree, NullRectListZeroCount) {
+  DlRTree tree(nullptr, 0);
+  EXPECT_EQ(tree.leaf_count(), 0);
+  EXPECT_EQ(tree.node_count(), 0);
+  std::vector<int> results;
+  auto huge = SkRect::MakeLTRB(-1e6, -1e6, 1e6, 1e6);
+  tree.search(huge, &results);
+  EXPECT_EQ(results.size(), 0u);
+  auto list = tree.searchAndConsolidateRects(huge);
+  EXPECT_EQ(list.size(), 0u);
+}
+
+TEST(DisplayListRTree, ManySizes) {
+  const int kMaxN = 250;
+  SkRect rects[kMaxN + 1];
+  int ids[kMaxN + 1];
+  for (int i = 0; i <= kMaxN; i++) {
+    rects[i].setXYWH(i * 20, i * 20, 10, 10);
+    ids[i] = i + 42;
+  }
+  std::vector<int> results;
+  for (int N = 0; N <= kMaxN; N++) {
+    DlRTree tree(rects, N, ids);
+    auto desc = "node count = " + std::to_string(N);
+    EXPECT_EQ(tree.leaf_count(), N) << desc;
+    EXPECT_GE(tree.node_count(), N) << desc;
+    EXPECT_EQ(tree.id(-1), -1) << desc;
+    EXPECT_EQ(tree.bounds(-1), SkRect::MakeEmpty()) << desc;
+    EXPECT_EQ(tree.id(N), -1) << desc;
+    EXPECT_EQ(tree.bounds(N), SkRect::MakeEmpty()) << desc;
+    results.clear();
+    tree.search(SkRect::MakeEmpty(), &results);
+    EXPECT_EQ(results.size(), 0u) << desc;
+    results.clear();
+    tree.search(SkRect::MakeLTRB(2, 2, 8, 8), &results);
+    if (N == 0) {
+      EXPECT_EQ(results.size(), 0u) << desc;
+    } else {
+      EXPECT_EQ(results.size(), 1u) << desc;
+      EXPECT_EQ(results[0], 0) << desc;
+      EXPECT_EQ(tree.id(results[0]), ids[0]) << desc;
+      EXPECT_EQ(tree.bounds(results[0]), rects[0]) << desc;
+      for (int i = 1; i < N; i++) {
+        results.clear();
+        auto query = SkRect::MakeXYWH(i * 20 + 2, i * 20 + 2, 6, 6);
+        tree.search(query, &results);
+        EXPECT_EQ(results.size(), 1u) << desc;
+        EXPECT_EQ(results[0], i) << desc;
+        EXPECT_EQ(tree.id(results[0]), ids[i]) << desc;
+        EXPECT_EQ(tree.bounds(results[0]), rects[i]) << desc;
+        auto list = tree.searchAndConsolidateRects(query);
+        EXPECT_EQ(list.size(), 1u);
+        EXPECT_EQ(list.front(), rects[i]);
+      }
+    }
+  }
+}
+
+TEST(DisplayListRTree, HugeSize) {
+  const int N = 10000;
+  SkRect rects[N];
+  int ids[N];
+  for (int i = 0; i < N; i++) {
+    rects[i].setXYWH(i * 20, i * 20, 10, 10);
+    ids[i] = i + 42;
+  }
+  DlRTree tree(rects, N, ids);
+  EXPECT_EQ(tree.leaf_count(), N);
+  EXPECT_GE(tree.node_count(), N);
+  EXPECT_EQ(tree.id(-1), -1);
+  EXPECT_EQ(tree.bounds(-1), SkRect::MakeEmpty());
+  EXPECT_EQ(tree.id(N), -1);
+  EXPECT_EQ(tree.bounds(N), SkRect::MakeEmpty());
+  std::vector<int> results;
+  tree.search(SkRect::MakeEmpty(), &results);
+  EXPECT_EQ(results.size(), 0u);
+  for (int i = 0; i < N; i++) {
+    results.clear();
+    tree.search(SkRect::MakeXYWH(i * 20 + 2, i * 20 + 2, 6, 6), &results);
+    EXPECT_EQ(results.size(), 1u);
+    EXPECT_EQ(results[0], i);
+    EXPECT_EQ(tree.id(results[0]), ids[i]);
+    EXPECT_EQ(tree.bounds(results[0]), rects[i]);
+  }
+}
+
+TEST(DisplayListRTree, Grid) {
+  const int ROWS = 10;
+  const int COLS = 10;
+  const int N = ROWS * COLS;
+  SkRect rects[N];
+  int ids[N];
+  for (int r = 0; r < ROWS; r++) {
+    int y = r * 20 + 5;
+    for (int c = 0; c < COLS; c++) {
+      int x = c * 20 + 5;
+      int i = r * COLS + c;
+      rects[i] = SkRect::MakeXYWH(x, y, 10, 10);
+      ids[i] = i + 42;
+    }
+  }
+  DlRTree tree(rects, N, ids);
+  EXPECT_EQ(tree.leaf_count(), N);
+  EXPECT_GE(tree.node_count(), N);
+  EXPECT_EQ(tree.id(-1), -1);
+  EXPECT_EQ(tree.bounds(-1), SkRect::MakeEmpty());
+  EXPECT_EQ(tree.id(N), -1);
+  EXPECT_EQ(tree.bounds(N), SkRect::MakeEmpty());
+  std::vector<int> results;
+  tree.search(SkRect::MakeEmpty(), &results);
+  EXPECT_EQ(results.size(), 0u);
+  // Testing eqch rect for a single hit
+  for (int r = 0; r < ROWS; r++) {
+    int y = r * 20 + 5;
+    for (int c = 0; c < COLS; c++) {
+      int x = c * 20 + 5;
+      int i = r * COLS + c;
+      auto desc =
+          "row " + std::to_string(r + 1) + ", col " + std::to_string(c + 1);
+      results.clear();
+      auto query = SkRect::MakeXYWH(x + 2, y + 2, 6, 6);
+      tree.search(query, &results);
+      EXPECT_EQ(results.size(), 1u) << desc;
+      EXPECT_EQ(results[0], i) << desc;
+      EXPECT_EQ(tree.id(results[0]), ids[i]) << desc;
+      EXPECT_EQ(tree.bounds(results[0]), rects[i]) << desc;
+      auto list = tree.searchAndConsolidateRects(query);
+      EXPECT_EQ(list.size(), 1u);
+      EXPECT_EQ(list.front(), rects[i]);
+    }
+  }
+  // Testing inside each gap for no hits
+  for (int r = 1; r < ROWS; r++) {
+    int y = r * 20 + 5;
+    for (int c = 1; c < COLS; c++) {
+      int x = c * 20 + 5;
+      auto desc =
+          "row " + std::to_string(r + 1) + ", col " + std::to_string(c + 1);
+      results.clear();
+      auto query = SkRect::MakeXYWH(x - 8, y - 8, 6, 6);
+      tree.search(query, &results);
+      EXPECT_EQ(results.size(), 0u) << desc;
+      auto list = tree.searchAndConsolidateRects(query);
+      EXPECT_EQ(list.size(), 0u) << desc;
+    }
+  }
+  // Spanning each gap for a quad of hits
+  for (int r = 1; r < ROWS; r++) {
+    int y = r * 20 + 5;
+    for (int c = 1; c < COLS; c++) {
+      int x = c * 20 + 5;
+      // We will hit this rect and the ones above/left of us
+      int i = r * COLS + c;
+      auto desc =
+          "row " + std::to_string(r + 1) + ", col " + std::to_string(c + 1);
+      results.clear();
+      auto query = SkRect::MakeXYWH(x - 11, y - 11, 12, 12);
+      tree.search(query, &results);
+      EXPECT_EQ(results.size(), 4u) << desc;
+
+      // First rect is above and to the left
+      EXPECT_EQ(results[0], i - COLS - 1) << desc;
+      EXPECT_EQ(tree.id(results[0]), ids[i - COLS - 1]) << desc;
+      EXPECT_EQ(tree.bounds(results[0]), rects[i - COLS - 1]) << desc;
+
+      // Second rect is above
+      EXPECT_EQ(results[1], i - COLS) << desc;
+      EXPECT_EQ(tree.id(results[1]), ids[i - COLS]) << desc;
+      EXPECT_EQ(tree.bounds(results[1]), rects[i - COLS]) << desc;
+
+      // Third rect is left
+      EXPECT_EQ(results[2], i - 1) << desc;
+      EXPECT_EQ(tree.id(results[2]), ids[i - 1]) << desc;
+      EXPECT_EQ(tree.bounds(results[2]), rects[i - 1]) << desc;
+
+      // Fourth rect is us
+      EXPECT_EQ(results[3], i) << desc;
+      EXPECT_EQ(tree.id(results[3]), ids[i]) << desc;
+      EXPECT_EQ(tree.bounds(results[3]), rects[i]) << desc;
+
+      auto list = tree.searchAndConsolidateRects(query);
+      EXPECT_EQ(list.size(), 4u);
+      list.remove(rects[i - COLS - 1]);
+      list.remove(rects[i - COLS]);
+      list.remove(rects[i - 1]);
+      list.remove(rects[i]);
+      EXPECT_EQ(list.size(), 0u);
+    }
+  }
+}
+
+TEST(DisplayListRTree, OverlappingRects) {
+  SkRect rects[9];
+  for (int r = 0; r < 3; r++) {
+    int y = r * 20 + 10;
+    for (int c = 0; c < 3; c++) {
+      int x = c * 20 + 10;
+      rects[r * 3 + c].setLTRB(x - 15, y - 15, x + 15, y + 15);
+    }
+  }
+  DlRTree tree(rects, 9);
+  // Tiny rects only intersecting a single source rect
+  for (int r = 0; r < 3; r++) {
+    int y = r * 20 + 10;
+    for (int c = 0; c < 3; c++) {
+      int x = c * 20 + 10;
+      auto query = SkRect::MakeLTRB(x - 1, y - 1, x + 1, y + 1);
+      auto list = tree.searchAndConsolidateRects(query);
+      EXPECT_EQ(list.size(), 1u);
+      EXPECT_EQ(list.front(), rects[r * 3 + c]);
+    }
+  }
+  // Wide rects intersecting 3 source rects horizontally
+  for (int r = 0; r < 3; r++) {
+    int y = r * 20 + 10;
+    int x = 30;
+    auto query = SkRect::MakeLTRB(x - 6, y - 1, x + 6, y + 1);
+    auto list = tree.searchAndConsolidateRects(query);
+    EXPECT_EQ(list.size(), 1u);
+    EXPECT_EQ(list.front(), SkRect::MakeLTRB(x - 35, y - 15, x + 35, y + 15));
+  }
+  // Tall rects intersecting 3 source rects vertically
+  for (int c = 0; c < 3; c++) {
+    int x = c * 20 + 10;
+    int y = 30;
+    auto query = SkRect::MakeLTRB(x - 1, y - 6, x + 1, y + 6);
+    auto list = tree.searchAndConsolidateRects(query);
+    EXPECT_EQ(list.size(), 1u);
+    EXPECT_EQ(list.front(), SkRect::MakeLTRB(x - 15, y - 35, x + 15, y + 35));
+  }
+  // Finally intersecting all 9 rects
+  auto query = SkRect::MakeLTRB(24, 24, 36, 36);
+  auto list = tree.searchAndConsolidateRects(query);
+  EXPECT_EQ(list.size(), 1u);
+  EXPECT_EQ(list.front(), SkRect::MakeLTRB(-5, -5, 65, 65));
+}
+
+}  // namespace testing
+}  // namespace flutter

--- a/display_list/display_list_test_utils.cc
+++ b/display_list/display_list_test_utils.cc
@@ -304,7 +304,7 @@ std::vector<DisplayListInvocationGroup> CreateAllSaveRestoreOps() {
   return {
       {"Save(Layer)+Restore",
        {
-           {5, 104, 5, 104,
+           {5, 112, 5, 112,
             [](DisplayListBuilder& b) {
               b.saveLayer(nullptr, SaveLayerOptions::kNoAttributes,
                           &kTestCFImageFilter1);
@@ -320,7 +320,7 @@ std::vector<DisplayListInvocationGroup> CreateAllSaveRestoreOps() {
            // attributes to be distributed to the children. To prevent those
            // cases we include at least one clip operation and 2 overlapping
            // rendering primitives between each save/restore pair.
-           {5, 88, 5, 88,
+           {5, 96, 5, 96,
             [](DisplayListBuilder& b) {
               b.save();
               b.clipRect({0, 0, 25, 25}, SkClipOp::kIntersect, true);
@@ -328,7 +328,7 @@ std::vector<DisplayListInvocationGroup> CreateAllSaveRestoreOps() {
               b.drawRect({10, 10, 20, 20});
               b.restore();
             }},
-           {5, 88, 5, 88,
+           {5, 96, 5, 96,
             [](DisplayListBuilder& b) {
               b.saveLayer(nullptr, false);
               b.clipRect({0, 0, 25, 25}, SkClipOp::kIntersect, true);
@@ -336,7 +336,7 @@ std::vector<DisplayListInvocationGroup> CreateAllSaveRestoreOps() {
               b.drawRect({10, 10, 20, 20});
               b.restore();
             }},
-           {5, 88, 5, 88,
+           {5, 96, 5, 96,
             [](DisplayListBuilder& b) {
               b.saveLayer(nullptr, true);
               b.clipRect({0, 0, 25, 25}, SkClipOp::kIntersect, true);
@@ -344,7 +344,7 @@ std::vector<DisplayListInvocationGroup> CreateAllSaveRestoreOps() {
               b.drawRect({10, 10, 20, 20});
               b.restore();
             }},
-           {5, 104, 5, 104,
+           {5, 112, 5, 112,
             [](DisplayListBuilder& b) {
               b.saveLayer(&kTestBounds, false);
               b.clipRect({0, 0, 25, 25}, SkClipOp::kIntersect, true);
@@ -352,7 +352,7 @@ std::vector<DisplayListInvocationGroup> CreateAllSaveRestoreOps() {
               b.drawRect({10, 10, 20, 20});
               b.restore();
             }},
-           {5, 104, 5, 104,
+           {5, 112, 5, 112,
             [](DisplayListBuilder& b) {
               b.saveLayer(&kTestBounds, true);
               b.clipRect({0, 0, 25, 25}, SkClipOp::kIntersect, true);
@@ -369,7 +369,7 @@ std::vector<DisplayListInvocationGroup> CreateAllSaveRestoreOps() {
            //   b.drawRect({10, 10, 20, 20});
            //   b.restore();
            // }},
-           {5, 104, 5, 104,
+           {5, 112, 5, 112,
             [](DisplayListBuilder& b) {
               b.saveLayer(nullptr, SaveLayerOptions::kWithAttributes,
                           &kTestCFImageFilter1);
@@ -378,7 +378,7 @@ std::vector<DisplayListInvocationGroup> CreateAllSaveRestoreOps() {
               b.drawRect({10, 10, 20, 20});
               b.restore();
             }},
-           {5, 120, 5, 120,
+           {5, 128, 5, 128,
             [](DisplayListBuilder& b) {
               b.saveLayer(&kTestBounds, SaveLayerOptions::kNoAttributes,
                           &kTestCFImageFilter1);
@@ -387,7 +387,7 @@ std::vector<DisplayListInvocationGroup> CreateAllSaveRestoreOps() {
               b.drawRect({10, 10, 20, 20});
               b.restore();
             }},
-           {5, 120, 5, 120,
+           {5, 128, 5, 128,
             [](DisplayListBuilder& b) {
               b.saveLayer(&kTestBounds, SaveLayerOptions::kWithAttributes,
                           &kTestCFImageFilter1);

--- a/display_list/display_list_unittests.cc
+++ b/display_list/display_list_unittests.cc
@@ -273,12 +273,12 @@ TEST(DisplayList, SingleOpDisplayListsCompareToEachOther) {
 TEST(DisplayList, SingleOpDisplayListsAreEqualWhetherOrNotToPrepareRtree) {
   for (auto& group : allGroups) {
     for (size_t i = 0; i < group.variants.size(); i++) {
-      DisplayListBuilder buider1(/*prepare_rtree=*/false);
-      DisplayListBuilder buider2(/*prepare_rtree=*/true);
-      group.variants[i].invoker(buider1);
-      group.variants[i].invoker(buider2);
-      sk_sp<DisplayList> dl1 = buider1.Build();
-      sk_sp<DisplayList> dl2 = buider2.Build();
+      DisplayListBuilder builder1(/*prepare_rtree=*/false);
+      DisplayListBuilder builder2(/*prepare_rtree=*/true);
+      group.variants[i].invoker(builder1);
+      group.variants[i].invoker(builder2);
+      sk_sp<DisplayList> dl1 = builder1.Build();
+      sk_sp<DisplayList> dl2 = builder2.Build();
 
       auto desc = group.op_name + "(variant " + std::to_string(i + 1) + " )";
       ASSERT_EQ(dl1->op_count(false), dl2->op_count(false)) << desc;
@@ -286,8 +286,8 @@ TEST(DisplayList, SingleOpDisplayListsAreEqualWhetherOrNotToPrepareRtree) {
       ASSERT_EQ(dl1->op_count(true), dl2->op_count(true)) << desc;
       ASSERT_EQ(dl1->bytes(true), dl2->bytes(true)) << desc;
       ASSERT_EQ(dl1->bounds(), dl2->bounds()) << desc;
-      ASSERT_TRUE(dl1->Equals(*dl2)) << desc;
-      ASSERT_TRUE(dl2->Equals(*dl1)) << desc;
+      ASSERT_TRUE(DisplayListsEQ_Verbose(dl1, dl2)) << desc;
+      ASSERT_TRUE(DisplayListsEQ_Verbose(dl2, dl2)) << desc;
       ASSERT_EQ(dl1->rtree().get(), nullptr) << desc;
       ASSERT_NE(dl2->rtree().get(), nullptr) << desc;
     }

--- a/display_list/display_list_unittests.cc
+++ b/display_list/display_list_unittests.cc
@@ -1795,7 +1795,7 @@ static void test_rtree(const sk_sp<const DlRTree>& rtree,
   rtree->search(query, &indices);
   EXPECT_EQ(indices, expected_indices);
   EXPECT_EQ(indices.size(), expected_indices.size());
-  std::list<SkRect> rects = rtree->searchNonOverlappingDrawnRects(query);
+  std::list<SkRect> rects = rtree->searchAndConsolidateRects(query);
   // ASSERT_EQ(rects.size(), expected_indices.size());
   auto iterator = rects.cbegin();
   for (int i : expected_indices) {

--- a/display_list/display_list_utils.h
+++ b/display_list/display_list_utils.h
@@ -251,7 +251,7 @@ class BoundsAccumulator {
 
   virtual ~BoundsAccumulator() = default;
 
-  virtual void accumulate(const SkRect& r) = 0;
+  virtual void accumulate(const SkRect& r, int index = 0) = 0;
 
   /// Save aside the rects/bounds currently being accumulated and start
   /// accumulating a new set of rects/bounds. When restore is called,
@@ -296,7 +296,7 @@ class RectBoundsAccumulator final : public virtual BoundsAccumulator {
  public:
   void accumulate(SkScalar x, SkScalar y) { rect_.accumulate(x, y); }
   void accumulate(const SkPoint& p) { rect_.accumulate(p.fX, p.fY); }
-  void accumulate(const SkRect& r) override;
+  void accumulate(const SkRect& r, int index) override;
 
   bool is_empty() const { return rect_.is_empty(); }
   bool is_not_empty() const { return rect_.is_not_empty(); }
@@ -344,7 +344,7 @@ class RectBoundsAccumulator final : public virtual BoundsAccumulator {
 
 class RTreeBoundsAccumulator final : public virtual BoundsAccumulator {
  public:
-  void accumulate(const SkRect& r) override;
+  void accumulate(const SkRect& r, int index) override;
   void save() override;
   void restore() override;
 
@@ -362,6 +362,7 @@ class RTreeBoundsAccumulator final : public virtual BoundsAccumulator {
 
  private:
   std::vector<SkRect> rects_;
+  std::vector<int> rect_indices_;
   std::vector<size_t> saved_offsets_;
 };
 

--- a/flow/embedded_views.cc
+++ b/flow/embedded_views.cc
@@ -60,7 +60,7 @@ void DisplayListEmbedderViewSlice::end_recording() {
 
 std::list<SkRect> DisplayListEmbedderViewSlice::searchNonOverlappingDrawnRects(
     const SkRect& query) const {
-  return display_list_->rtree()->searchNonOverlappingDrawnRects(query);
+  return display_list_->rtree()->searchAndConsolidateRects(query);
 }
 
 void DisplayListEmbedderViewSlice::render_into(SkCanvas* canvas) {


### PR DESCRIPTION
Fixes: https://github.com/flutter/flutter/issues/92740

This PR uses an R-Tree (when computed by the Builder) to cull the dispatching of a DisplayList similar to what is done in SkPicture objects when constructed with a bbox factory.

Some additional changes:
- DlRTree no longer depends on the Skia bbox hierarchy base class
- DlRTree now uses a more streamlined approach to managing its data now that it is not relying on a generic superclass
- basic tests of R-Tree culling added, and some unit tests. Is something more sophisticated warranted?
- the code that tags rectangles with the rendering op index is currently executed post-`Push` which means the rectangles need to be tagged with `op_index_ - 1`. I eventually want to move the bounds calculations to before the `Push` calls and then potentially use them to proactively cull operations that will never be visible due to clipping.

The basic principle here is to add the "index" of every rendering op to the DisplayList R-Tree. At rendering time, if the DL is a super-set of the current clip bounds then an R-Tree search is done on those bounds and only the indicated rendering ops are executed. Also executed are all attribute ops, any saveLayer/restore enclosing a chosen rendering op, and any transform/clip operations that will be followed by a matched rendering op before their next restore.

Previous PR prototypes (now obsolete):

- https://github.com/flutter/engine/pull/38189 (based on buffer offsets)
- https://github.com/flutter/engine/pull/38304 (based on rendering op indices upon which this PR is based)