### PR TITLE
Remove single view assumptions from `window.dart`

### DIFF
--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -226,6 +226,7 @@ class PlatformDispatcher {
     }
     _viewConfigurations[id] = previousConfiguration.copyWith(
       view: _views[id],
+      window: _views[id],
       devicePixelRatio: devicePixelRatio,
       geometry: Rect.fromLTWH(0.0, 0.0, width, height),
       viewPadding: WindowPadding._(
@@ -1349,7 +1350,7 @@ class ViewConfiguration {
   final double devicePixelRatio;
 
   /// The geometry requested for the view on the screen or within its parent
-  /// view, in logical pixels.
+  /// window, in logical pixels.
   final Rect geometry;
 
   /// Whether or not the view is currently visible on the screen.

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -222,7 +222,7 @@ class PlatformDispatcher {
     final ViewConfiguration previousConfiguration =
         _viewConfigurations[id] ?? const ViewConfiguration();
     if (!_views.containsKey(id)) {
-      _views[id] = FlutterWindow._(id, this);
+      _views[id] = FlutterView._(id, this);
     }
     _viewConfigurations[id] = previousConfiguration.copyWith(
       window: _views[id],

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -1291,11 +1291,11 @@ class PlatformConfiguration {
 class ViewConfiguration {
   /// A const constructor for an immutable [ViewConfiguration].
   const ViewConfiguration({
-    this.view,
+    FlutterView? view,
     @Deprecated('''
       Use the `view` property instead.
     ''')
-    this.window,
+    FlutterView? window,
     this.devicePixelRatio = 1.0,
     this.geometry = Rect.zero,
     this.visible = false,
@@ -1305,7 +1305,8 @@ class ViewConfiguration {
     this.padding = WindowPadding.zero,
     this.gestureSettings = const GestureSettings(),
     this.displayFeatures = const <DisplayFeature>[],
-  }) : assert(!(window != null && view != null));
+  }) : assert(!(window != null && view != null)),
+    _view = view ?? window;
 
   /// Copy this configuration with some fields replaced.
   ViewConfiguration copyWith({
@@ -1323,7 +1324,6 @@ class ViewConfiguration {
   }) {
     return ViewConfiguration(
       view: view ?? this.view,
-      window: window ?? this.window,
       devicePixelRatio: devicePixelRatio ?? this.devicePixelRatio,
       geometry: geometry ?? this.geometry,
       visible: visible ?? this.visible,
@@ -1343,8 +1343,10 @@ class ViewConfiguration {
   @Deprecated('''
       Use the `view` property instead.
   ''')
-  final FlutterView? window;
-  final FlutterView? view;
+  FlutterView? get window => _view;
+  FlutterView? get view => _view;
+
+  final FlutterView?  _view;
 
   /// The pixel density of the output surface.
   final double devicePixelRatio;

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -1290,8 +1290,8 @@ class PlatformConfiguration {
 class ViewConfiguration {
   /// A const constructor for an immutable [ViewConfiguration].
   ///
-  /// When constructing a view configuration, supply either the `view` or the
-  /// `window` property, but not both since the `view` and `window` property
+  /// When constructing a view configuration, supply either the [view] or the
+  /// [window] property, but not both since the [view] and [window] property
   /// are backed by the same instance variable.
   const ViewConfiguration({
     FlutterView? view,

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -1344,6 +1344,11 @@ class ViewConfiguration {
       Use the `view` property instead.
   ''')
   FlutterView? get window => _view;
+
+  /// The top level view into which the view is placed and its geometry is
+  /// relative to.
+  ///
+  /// If null, then this configuration represents a top level view itself.
   FlutterView? get view => _view;
 
   final FlutterView?  _view;

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -1309,7 +1309,7 @@ class ViewConfiguration {
     this.padding = WindowPadding.zero,
     this.gestureSettings = const GestureSettings(),
     this.displayFeatures = const <DisplayFeature>[],
-  }) : assert(!(window != null && view != null)),
+  }) : assert(window == null || view == null),
     _view = view ?? window;
 
   /// Copy this configuration with some fields replaced.

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -1329,7 +1329,7 @@ class ViewConfiguration {
   }) {
     assert(view == null || window == null);
     return ViewConfiguration(
-      view: view ?? this.view,
+      view: view ?? window ?? _view,
       devicePixelRatio: devicePixelRatio ?? this.devicePixelRatio,
       geometry: geometry ?? this.geometry,
       visible: visible ?? this.visible,

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -1290,6 +1290,10 @@ class PlatformConfiguration {
 /// An immutable view configuration.
 class ViewConfiguration {
   /// A const constructor for an immutable [ViewConfiguration].
+  ///
+  /// When constructing a view configuration, supply either the `view` or the
+  /// `window` property, but not both since the `view` and `window` property
+  /// are backed by the same instance variable.
   const ViewConfiguration({
     FlutterView? view,
     @Deprecated('''

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -225,7 +225,7 @@ class PlatformDispatcher {
       _views[id] = FlutterView._(id, this);
     }
     _viewConfigurations[id] = previousConfiguration.copyWith(
-      window: _views[id],
+      view: _views[id],
       devicePixelRatio: devicePixelRatio,
       geometry: Rect.fromLTWH(0.0, 0.0, width, height),
       viewPadding: WindowPadding._(
@@ -1290,7 +1290,7 @@ class PlatformConfiguration {
 class ViewConfiguration {
   /// A const constructor for an immutable [ViewConfiguration].
   const ViewConfiguration({
-    this.window,
+    this.view,
     this.devicePixelRatio = 1.0,
     this.geometry = Rect.zero,
     this.visible = false,
@@ -1304,7 +1304,7 @@ class ViewConfiguration {
 
   /// Copy this configuration with some fields replaced.
   ViewConfiguration copyWith({
-    FlutterView? window,
+    FlutterView? view,
     double? devicePixelRatio,
     Rect? geometry,
     bool? visible,
@@ -1316,7 +1316,7 @@ class ViewConfiguration {
     List<DisplayFeature>? displayFeatures,
   }) {
     return ViewConfiguration(
-      window: window ?? this.window,
+      view: view ?? this.view,
       devicePixelRatio: devicePixelRatio ?? this.devicePixelRatio,
       geometry: geometry ?? this.geometry,
       visible: visible ?? this.visible,
@@ -1333,7 +1333,7 @@ class ViewConfiguration {
   /// relative to.
   ///
   /// If null, then this configuration represents a top level view itself.
-  final FlutterView? window;
+  final FlutterView? view;
 
   /// The pixel density of the output surface.
   final double devicePixelRatio;

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -1316,6 +1316,11 @@ class ViewConfiguration {
   /// Copy this configuration with some fields replaced.
   ViewConfiguration copyWith({
     FlutterView? view,
+    @Deprecated('''
+      Use the `view` property instead.
+      This change is related to adding multi-view support in Flutter.
+      This feature was deprecated after 3.7.0-1.2.pre.
+    ''')
     FlutterView? window,
     double? devicePixelRatio,
     Rect? geometry,

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -1298,6 +1298,8 @@ class ViewConfiguration {
     FlutterView? view,
     @Deprecated('''
       Use the `view` property instead.
+      This change is related to adding multi-view support in Flutter.
+      This feature was deprecated after 3.7.0-1.2.pre.
     ''')
     FlutterView? window,
     this.devicePixelRatio = 1.0,
@@ -1345,7 +1347,9 @@ class ViewConfiguration {
   ///
   /// If null, then this configuration represents a top level view itself.
   @Deprecated('''
-      Use the `view` property instead.
+    Use the `view` property instead.
+    This change is related to adding multi-view support in Flutter.
+    This feature was deprecated after 3.7.0-1.2.pre.
   ''')
   FlutterView? get window => _view;
 

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -1349,7 +1349,7 @@ class ViewConfiguration {
   final double devicePixelRatio;
 
   /// The geometry requested for the view on the screen or within its parent
-  /// window, in logical pixels.
+  /// view, in logical pixels.
   final Rect geometry;
 
   /// Whether or not the view is currently visible on the screen.
@@ -1437,7 +1437,7 @@ class ViewConfiguration {
 
   @override
   String toString() {
-    return '$runtimeType[window: $window, geometry: $geometry]';
+    return '$runtimeType[view: $view, geometry: $geometry]';
   }
 }
 
@@ -1676,7 +1676,7 @@ enum AppLifecycleState {
   /// On Android, this corresponds to an app or the Flutter host view running
   /// in the foreground inactive state.  Apps transition to this state when
   /// another activity is focused, such as a split-screen app, a phone call,
-  /// a picture-in-picture app, a system dialog, or another window.
+  /// a picture-in-picture app, a system dialog, or another view.
   ///
   /// Apps in this state should assume that they may be [paused] at any time.
   inactive,

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -226,7 +226,6 @@ class PlatformDispatcher {
     }
     _viewConfigurations[id] = previousConfiguration.copyWith(
       view: _views[id],
-      window: _views[id],
       devicePixelRatio: devicePixelRatio,
       geometry: Rect.fromLTWH(0.0, 0.0, width, height),
       viewPadding: WindowPadding._(
@@ -1328,6 +1327,7 @@ class ViewConfiguration {
     GestureSettings? gestureSettings,
     List<DisplayFeature>? displayFeatures,
   }) {
+    assert(view == null || window == null);
     return ViewConfiguration(
       view: view ?? this.view,
       devicePixelRatio: devicePixelRatio ?? this.devicePixelRatio,

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -1305,7 +1305,7 @@ class ViewConfiguration {
     this.padding = WindowPadding.zero,
     this.gestureSettings = const GestureSettings(),
     this.displayFeatures = const <DisplayFeature>[],
-  });
+  }) : assert(!(window != null && view != null));
 
   /// Copy this configuration with some fields replaced.
   ViewConfiguration copyWith({

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -1293,7 +1293,7 @@ class ViewConfiguration {
   const ViewConfiguration({
     this.view,
     @Deprecated('''
-      Renaming window to view as the class `FlutterWindow` has been deprecated.
+      Renaming window to view since `FlutterWindow` has been removed from dart::ui.
     ''')
     this.window,
     this.devicePixelRatio = 1.0,
@@ -1341,7 +1341,7 @@ class ViewConfiguration {
   ///
   /// If null, then this configuration represents a top level view itself.
   @Deprecated('''
-    Renaming window to view as the class `FlutterWindow` has been deprecated.
+    Renaming window to view since `FlutterWindow` has been removed from dart::ui.
   ''')
   final FlutterView? window;
   final FlutterView? view;

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -1293,7 +1293,7 @@ class ViewConfiguration {
   const ViewConfiguration({
     this.view,
     @Deprecated('''
-      Renaming window to view since `FlutterWindow` has been removed from dart::ui.
+      Use the `view` property instead.
     ''')
     this.window,
     this.devicePixelRatio = 1.0,
@@ -1341,7 +1341,7 @@ class ViewConfiguration {
   ///
   /// If null, then this configuration represents a top level view itself.
   @Deprecated('''
-    Renaming window to view since `FlutterWindow` has been removed from dart::ui.
+      Use the `view` property instead.
   ''')
   final FlutterView? window;
   final FlutterView? view;

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -1342,10 +1342,9 @@ class ViewConfiguration {
     );
   }
 
-  /// The top level view into which the view is placed and its geometry is
-  /// relative to.
+  /// The top level view for which this [ViewConfiguration]'s properties apply to.
   ///
-  /// If null, then this configuration represents a top level view itself.
+  /// If this property is null, this [ViewConfiguration] is a top level view.
   @Deprecated('''
     Use the `view` property instead.
     This change is related to adding multi-view support in Flutter.
@@ -1353,10 +1352,9 @@ class ViewConfiguration {
   ''')
   FlutterView? get window => _view;
 
-  /// The top level view into which the view is placed and its geometry is
-  /// relative to.
+  /// The top level view for which this [ViewConfiguration]'s properties apply to.
   ///
-  /// If null, then this configuration represents a top level view itself.
+  /// If this property is null, this [ViewConfiguration] is a top level view.
   FlutterView? get view => _view;
 
   final FlutterView?  _view;

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -1291,6 +1291,10 @@ class ViewConfiguration {
   /// A const constructor for an immutable [ViewConfiguration].
   const ViewConfiguration({
     this.view,
+    @Deprecated('''
+      Renaming window to view as the class `FlutterWindow` has been deprecated.
+    ''')
+    this.window,
     this.devicePixelRatio = 1.0,
     this.geometry = Rect.zero,
     this.visible = false,
@@ -1305,6 +1309,7 @@ class ViewConfiguration {
   /// Copy this configuration with some fields replaced.
   ViewConfiguration copyWith({
     FlutterView? view,
+    FlutterView? window,
     double? devicePixelRatio,
     Rect? geometry,
     bool? visible,
@@ -1317,6 +1322,7 @@ class ViewConfiguration {
   }) {
     return ViewConfiguration(
       view: view ?? this.view,
+      window: window ?? this.window,
       devicePixelRatio: devicePixelRatio ?? this.devicePixelRatio,
       geometry: geometry ?? this.geometry,
       visible: visible ?? this.visible,
@@ -1333,6 +1339,10 @@ class ViewConfiguration {
   /// relative to.
   ///
   /// If null, then this configuration represents a top level view itself.
+  @Deprecated('''
+    Renaming window to view as the class `FlutterWindow` has been deprecated.
+  ''')
+  final FlutterView? window;
   final FlutterView? view;
 
   /// The pixel density of the output surface.

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -5,8 +5,8 @@ part of dart.ui;
 
 /// A view into which a Flutter [Scene] is drawn.
 ///
-/// Each [FlutterView] has its own layer tree that is shown whenever [render]
-/// is called on it with a [Scene].
+/// Each [FlutterView] has its own layer tree that is rendered 
+/// whenever [render] is called on it with a [Scene].
 ///
 /// ## Insets and Padding
 ///

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -55,8 +55,7 @@ class FlutterView {
   FlutterView._(this._viewId, this.platformDispatcher);
 
   /// The opaque ID for this view.
-  final Object _viewId;
-  Object get viewId => _viewId;
+  final Object viewId;
 
   /// The platform dispatcher that this view is registered with, and gets its
   /// information from.

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -61,6 +61,7 @@ class FlutterView {
 
   /// The opaque ID for this view.
   final Object _viewId;
+  Object get viewId => _viewId;
 
   /// The platform dispatcher that this view is registered with, and gets its
   /// information from.

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -5,8 +5,8 @@ part of dart.ui;
 
 /// A view into which a Flutter [Scene] is drawn.
 ///
-/// Each [FlutterView] has its own layer tree that is rendered into an area
-/// inside of a [SingletonFlutterWindow] whenever [render] is called with a [Scene].
+/// Each [FlutterView] has its own layer tree that is shown whenever [render]
+/// is called on it with a [Scene].
 ///
 /// ## Insets and Padding
 ///
@@ -51,11 +51,6 @@ part of dart.ui;
 /// the [viewPadding] anyway, so there is no need to account for
 /// that in the [padding], which is always safe to use for such
 /// calculations.
-///
-/// See also:
-///
-///  * [FlutterView], a special case of a [FlutterView] that is represented on
-///    the platform as a separate window which can host other [FlutterView]s.
 class FlutterView {
   FlutterView._(this._viewId, this.platformDispatcher);
 

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -6,7 +6,7 @@ part of dart.ui;
 /// A view into which a Flutter [Scene] is drawn.
 ///
 /// Each [FlutterView] has its own layer tree that is rendered into an area
-/// inside of a [FlutterWindow] whenever [render] is called with a [Scene].
+/// inside of a [SingletonFlutterWindow] whenever [render] is called with a [Scene].
 ///
 /// ## Insets and Padding
 ///
@@ -54,15 +54,23 @@ part of dart.ui;
 ///
 /// See also:
 ///
-///  * [FlutterWindow], a special case of a [FlutterView] that is represented on
+///  * [FlutterView], a special case of a [FlutterView] that is represented on
 ///    the platform as a separate window which can host other [FlutterView]s.
-abstract class FlutterView {
+class FlutterView {
+  FlutterView._(this._viewId, this.platformDispatcher);
+
+  /// The opaque ID for this view.
+  final Object _viewId;
+
   /// The platform dispatcher that this view is registered with, and gets its
   /// information from.
-  PlatformDispatcher get platformDispatcher;
+  final PlatformDispatcher platformDispatcher;
 
   /// The configuration of this view.
-  ViewConfiguration get viewConfiguration;
+  ViewConfiguration get viewConfiguration {
+    assert(platformDispatcher._viewConfigurations.containsKey(_viewId));
+    return platformDispatcher._viewConfigurations[_viewId]!;
+  }
 
   /// The number of device pixels for each logical pixel for the screen this
   /// view is displayed on.
@@ -281,39 +289,7 @@ abstract class FlutterView {
   external static void _updateSemantics(SemanticsUpdate update);
 }
 
-/// A top-level platform window displaying a Flutter layer tree drawn from a
-/// [Scene].
-///
-/// The current list of all Flutter views for the application is available from
-/// `WidgetsBinding.instance.platformDispatcher.views`. Only views that are of type
-/// [FlutterWindow] are top level platform windows.
-///
-/// There is also a [PlatformDispatcher.instance] singleton object in `dart:ui`
-/// if `WidgetsBinding` is unavailable, but we strongly advise avoiding a static
-/// reference to it. See the documentation for [PlatformDispatcher.instance] for
-/// more details about why it should be avoided.
-///
-/// See also:
-///
-/// * [PlatformDispatcher], which manages the current list of [FlutterView] (and
-///   thus [FlutterWindow]) instances.
-class FlutterWindow extends FlutterView {
-  FlutterWindow._(this._windowId, this.platformDispatcher);
-
-  /// The opaque ID for this view.
-  final Object _windowId;
-
-  @override
-  final PlatformDispatcher platformDispatcher;
-
-  @override
-  ViewConfiguration get viewConfiguration {
-    assert(platformDispatcher._viewConfigurations.containsKey(_windowId));
-    return platformDispatcher._viewConfigurations[_windowId]!;
-  }
-}
-
-/// A [FlutterWindow] that includes access to setting callbacks and retrieving
+/// A [FlutterView] that includes access to setting callbacks and retrieving
 /// properties that reside on the [PlatformDispatcher].
 ///
 /// It is the type of the global [window] singleton used by applications that
@@ -328,7 +304,7 @@ class FlutterWindow extends FlutterView {
 /// `WidgetsBinding.instance.platformDispatcher` over a static reference to
 /// [window], or [PlatformDispatcher.instance]. See the documentation for
 /// [PlatformDispatcher.instance] for more details about this recommendation.
-class SingletonFlutterWindow extends FlutterWindow {
+class SingletonFlutterWindow extends FlutterView {
   SingletonFlutterWindow._(super.windowId, super.platformDispatcher)
       : super._();
 

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -52,7 +52,7 @@ part of dart.ui;
 /// that in the [padding], which is always safe to use for such
 /// calculations.
 class FlutterView {
-  FlutterView._(this._viewId, this.platformDispatcher);
+  FlutterView._(this.viewId, this.platformDispatcher);
 
   /// The opaque ID for this view.
   final Object viewId;
@@ -63,8 +63,8 @@ class FlutterView {
 
   /// The configuration of this view.
   ViewConfiguration get viewConfiguration {
-    assert(platformDispatcher._viewConfigurations.containsKey(_viewId));
-    return platformDispatcher._viewConfigurations[_viewId]!;
+    assert(platformDispatcher._viewConfigurations.containsKey(viewId));
+    return platformDispatcher._viewConfigurations[viewId]!;
   }
 
   /// The number of device pixels for each logical pixel for the screen this

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -5,7 +5,7 @@ part of dart.ui;
 
 /// A view into which a Flutter [Scene] is drawn.
 ///
-/// Each [FlutterView] has its own layer tree that is rendered 
+/// Each [FlutterView] has its own layer tree that is rendered
 /// whenever [render] is called on it with a [Scene].
 ///
 /// ## Insets and Padding

--- a/lib/web_ui/lib/platform_dispatcher.dart
+++ b/lib/web_ui/lib/platform_dispatcher.dart
@@ -222,8 +222,9 @@ class ViewConfiguration {
     GestureSettings? gestureSettings,
     List<DisplayFeature>? displayFeatures,
   }) {
+    assert(view == null || window == null);
     return ViewConfiguration(
-      view: view ?? this.view,
+      view: view ?? window ?? _view,
       devicePixelRatio: devicePixelRatio ?? this.devicePixelRatio,
       geometry: geometry ?? this.geometry,
       visible: visible ?? this.visible,

--- a/lib/web_ui/lib/platform_dispatcher.dart
+++ b/lib/web_ui/lib/platform_dispatcher.dart
@@ -208,6 +208,7 @@ class ViewConfiguration {
 
   ViewConfiguration copyWith({
     FlutterView? view,
+    FlutterView? window,
     double? devicePixelRatio,
     Rect? geometry,
     bool? visible,
@@ -220,6 +221,7 @@ class ViewConfiguration {
   }) {
     return ViewConfiguration(
       view: view ?? this.view,
+      window: window ?? this.window,
       devicePixelRatio: devicePixelRatio ?? this.devicePixelRatio,
       geometry: geometry ?? this.geometry,
       visible: visible ?? this.visible,

--- a/lib/web_ui/lib/platform_dispatcher.dart
+++ b/lib/web_ui/lib/platform_dispatcher.dart
@@ -193,6 +193,8 @@ class ViewConfiguration {
     FlutterView? view,
     @Deprecated('''
       Use the `view` property instead.
+      This change is related to adding multi-view support in Flutter.
+      This feature was deprecated after 3.7.0-1.2.pre.
     ''')
     FlutterView? window,
     this.devicePixelRatio = 1.0,
@@ -235,7 +237,9 @@ class ViewConfiguration {
   }
 
   @Deprecated('''
-    Renaming window to view as the class `FlutterWindow` has been deprecated.
+    Use the `view` property instead.
+    This change is related to adding multi-view support in Flutter.
+    This feature was deprecated after 3.7.0-1.2.pre.
   ''')
   FlutterView? get window => _view;
   FlutterView? get view => _view;

--- a/lib/web_ui/lib/platform_dispatcher.dart
+++ b/lib/web_ui/lib/platform_dispatcher.dart
@@ -190,11 +190,11 @@ class PlatformConfiguration {
 
 class ViewConfiguration {
   const ViewConfiguration({
-    this.view,
+    FlutterView? view,
     @Deprecated('''
-      Renaming window to view as the class `FlutterWindow` has been deprecated.
+      Use the `view` property instead.
     ''')
-    this.window,
+    FlutterView? window,
     this.devicePixelRatio = 1.0,
     this.geometry = Rect.zero,
     this.visible = false,
@@ -204,7 +204,8 @@ class ViewConfiguration {
     this.padding = WindowPadding.zero,
     this.gestureSettings = const GestureSettings(),
     this.displayFeatures = const <DisplayFeature>[],
-  });
+  }) : assert(!(window != null && view != null)),
+  _view = view ?? window;
 
   ViewConfiguration copyWith({
     FlutterView? view,
@@ -221,7 +222,6 @@ class ViewConfiguration {
   }) {
     return ViewConfiguration(
       view: view ?? this.view,
-      window: window ?? this.window,
       devicePixelRatio: devicePixelRatio ?? this.devicePixelRatio,
       geometry: geometry ?? this.geometry,
       visible: visible ?? this.visible,
@@ -237,8 +237,9 @@ class ViewConfiguration {
   @Deprecated('''
     Renaming window to view as the class `FlutterWindow` has been deprecated.
   ''')
-  final FlutterView? window;
-  final FlutterView? view;
+  FlutterView? get window => _view;
+  FlutterView? get view => _view;
+  final FlutterView? _view;
   final double devicePixelRatio;
   final Rect geometry;
   final bool visible;

--- a/lib/web_ui/lib/platform_dispatcher.dart
+++ b/lib/web_ui/lib/platform_dispatcher.dart
@@ -191,6 +191,10 @@ class PlatformConfiguration {
 class ViewConfiguration {
   const ViewConfiguration({
     this.view,
+    @Deprecated('''
+      Renaming window to view as the class `FlutterWindow` has been deprecated.
+    ''')
+    this.window,
     this.devicePixelRatio = 1.0,
     this.geometry = Rect.zero,
     this.visible = false,
@@ -228,6 +232,10 @@ class ViewConfiguration {
     );
   }
 
+  @Deprecated('''
+    Renaming window to view as the class `FlutterWindow` has been deprecated.
+  ''')
+  final FlutterView? window;
   final FlutterView? view;
   final double devicePixelRatio;
   final Rect geometry;

--- a/lib/web_ui/lib/platform_dispatcher.dart
+++ b/lib/web_ui/lib/platform_dispatcher.dart
@@ -31,7 +31,7 @@ abstract class PlatformDispatcher {
   VoidCallback? get onPlatformConfigurationChanged;
   set onPlatformConfigurationChanged(VoidCallback? callback);
 
-  Map<Object, FlutterView> get views;
+  Iterable<FlutterView> get views;
 
   VoidCallback? get onMetricsChanged;
   set onMetricsChanged(VoidCallback? callback);

--- a/lib/web_ui/lib/platform_dispatcher.dart
+++ b/lib/web_ui/lib/platform_dispatcher.dart
@@ -204,7 +204,7 @@ class ViewConfiguration {
     this.padding = WindowPadding.zero,
     this.gestureSettings = const GestureSettings(),
     this.displayFeatures = const <DisplayFeature>[],
-  }) : assert(!(window != null && view != null)),
+  }) : assert(window == null || view == null),
   _view = view ?? window;
 
   ViewConfiguration copyWith({

--- a/lib/web_ui/lib/platform_dispatcher.dart
+++ b/lib/web_ui/lib/platform_dispatcher.dart
@@ -31,7 +31,7 @@ abstract class PlatformDispatcher {
   VoidCallback? get onPlatformConfigurationChanged;
   set onPlatformConfigurationChanged(VoidCallback? callback);
 
-  Iterable<FlutterView> get views;
+  Map<Object, FlutterView> get views;
 
   VoidCallback? get onMetricsChanged;
   set onMetricsChanged(VoidCallback? callback);
@@ -190,7 +190,7 @@ class PlatformConfiguration {
 
 class ViewConfiguration {
   const ViewConfiguration({
-    this.window,
+    this.view,
     this.devicePixelRatio = 1.0,
     this.geometry = Rect.zero,
     this.visible = false,
@@ -203,7 +203,7 @@ class ViewConfiguration {
   });
 
   ViewConfiguration copyWith({
-    FlutterWindow? window,
+    FlutterView? view,
     double? devicePixelRatio,
     Rect? geometry,
     bool? visible,
@@ -215,7 +215,7 @@ class ViewConfiguration {
     List<DisplayFeature>? displayFeatures,
   }) {
     return ViewConfiguration(
-      window: window ?? this.window,
+      view: view ?? this.view,
       devicePixelRatio: devicePixelRatio ?? this.devicePixelRatio,
       geometry: geometry ?? this.geometry,
       visible: visible ?? this.visible,
@@ -228,7 +228,7 @@ class ViewConfiguration {
     );
   }
 
-  final FlutterWindow? window;
+  final FlutterView? view;
   final double devicePixelRatio;
   final Rect geometry;
   final bool visible;

--- a/lib/web_ui/lib/platform_dispatcher.dart
+++ b/lib/web_ui/lib/platform_dispatcher.dart
@@ -211,6 +211,11 @@ class ViewConfiguration {
 
   ViewConfiguration copyWith({
     FlutterView? view,
+    @Deprecated('''
+      Use the `view` property instead.
+      This change is related to adding multi-view support in Flutter.
+      This feature was deprecated after 3.7.0-1.2.pre.
+    ''')
     FlutterView? window,
     double? devicePixelRatio,
     Rect? geometry,

--- a/lib/web_ui/lib/platform_dispatcher.dart
+++ b/lib/web_ui/lib/platform_dispatcher.dart
@@ -249,7 +249,7 @@ class ViewConfiguration {
 
   @override
   String toString() {
-    return '$runtimeType[window: $window, geometry: $geometry]';
+    return '$runtimeType[view: $view, geometry: $geometry]';
   }
 }
 

--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -479,7 +479,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
         final MethodCall decoded = codec.decodeMethodCall(data);
         switch (decoded.method) {
           case 'SystemNavigator.pop':
-            // TODO(gspencergoog): As multi-window support expands, the pop call
+            // TODO(a-wallen): As multi-window support expands, the pop call
             // will need to include the window ID. Right now only one window is
             // supported.
             (_views[0]! as EngineFlutterWindow)
@@ -569,7 +569,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
         return;
 
       case 'flutter/navigation':
-        // TODO(gspencergoog): As multi-window support expands, the navigation call
+        // TODO(a-wallen): As multi-window support expands, the navigation call
         // will need to include the window ID. Right now only one window is
         // supported.
         (_views[0]! as EngineFlutterWindow)

--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -141,6 +141,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
   Iterable<ui.FlutterView> get views => _views.values;
   final Map<Object, ui.FlutterView> _views = <Object, ui.FlutterView>{};
   ui.FlutterView? getViewById(Object id) => _views[id];
+  void addView(Object id, ui.FlutterView view) => _views[id] = view;
 
   /// A map of opaque platform window identifiers to window configurations.
   ///

--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -136,7 +136,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
         _onPlatformConfigurationChanged, _onPlatformConfigurationChangedZone);
   }
 
-  /// The current list of windows,
+  /// The current list of windows.
   @override
   Iterable<ui.FlutterView> get views => viewData.values;
   final Map<Object, ui.FlutterView> viewData = <Object, ui.FlutterView>{};

--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -481,7 +481,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
             // TODO(gspencergoog): As multi-window support expands, the pop call
             // will need to include the window ID. Right now only one window is
             // supported.
-            (windows[0]! as EngineFlutterWindow)
+            (_views[0]! as EngineFlutterWindow)
                 .browserHistory
                 .exit()
                 .then((_) {
@@ -571,7 +571,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
         // TODO(gspencergoog): As multi-window support expands, the navigation call
         // will need to include the window ID. Right now only one window is
         // supported.
-        (windows[0]! as EngineFlutterWindow)
+        (_views[0]! as EngineFlutterWindow)
             .handleNavigationMessage(data)
             .then((bool handled) {
           if (handled) {
@@ -1160,7 +1160,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
   @override
   String get defaultRouteName {
     return _defaultRouteName ??=
-        (windows[0]! as EngineFlutterWindow).browserHistory.currentPath;
+        (_views[0]! as EngineFlutterWindow).browserHistory.currentPath;
   }
 
   /// Lazily initialized when the `defaultRouteName` getter is invoked.

--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -480,7 +480,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
             // TODO(a-wallen): As multi-window support expands, the pop call
             // will need to include the view ID. Right now only one view is
             // supported.
-            (viewData[0]! as EngineFlutterWindow)
+            (viewData[kSingletonViewId]! as EngineFlutterWindow)
                 .browserHistory
                 .exit()
                 .then((_) {
@@ -570,7 +570,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
         // TODO(a-wallen): As multi-window support expands, the navigation call
         // will need to include the view ID. Right now only one view is
         // supported.
-        (viewData[0]! as EngineFlutterWindow)
+        (viewData[kSingletonViewId]! as EngineFlutterWindow)
             .handleNavigationMessage(data)
             .then((bool handled) {
           if (handled) {
@@ -1159,7 +1159,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
   @override
   String get defaultRouteName {
     return _defaultRouteName ??=
-        (viewData[0]! as EngineFlutterWindow).browserHistory.currentPath;
+        (viewData[kSingletonViewId]! as EngineFlutterWindow).browserHistory.currentPath;
   }
 
   /// Lazily initialized when the `defaultRouteName` getter is invoked.

--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -138,8 +138,9 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
 
   /// The current list of windows,
   @override
-  final Map<Object, ui.FlutterView> views = <Object, ui.FlutterView>{};
-
+  Iterable<ui.FlutterView> get views => _windows.values;
+  Map<Object, ui.FlutterView> get windows => _windows;
+  final Map<Object, ui.FlutterView> _windows = <Object, ui.FlutterView>{};
   /// A map of opaque platform window identifiers to window configurations.
   ///
   /// This should be considered a protected member, only to be used by
@@ -479,7 +480,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
             // TODO(gspencergoog): As multi-window support expands, the pop call
             // will need to include the window ID. Right now only one window is
             // supported.
-            (views[0]! as EngineFlutterWindow)
+            (windows[0]! as EngineFlutterWindow)
                 .browserHistory
                 .exit()
                 .then((_) {
@@ -569,7 +570,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
         // TODO(gspencergoog): As multi-window support expands, the navigation call
         // will need to include the window ID. Right now only one window is
         // supported.
-        (views[0]! as EngineFlutterWindow)
+        (windows[0]! as EngineFlutterWindow)
             .handleNavigationMessage(data)
             .then((bool handled) {
           if (handled) {
@@ -1158,7 +1159,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
   @override
   String get defaultRouteName {
     return _defaultRouteName ??=
-        (views[0]! as EngineFlutterWindow).browserHistory.currentPath;
+        (windows[0]! as EngineFlutterWindow).browserHistory.currentPath;
   }
 
   /// Lazily initialized when the `defaultRouteName` getter is invoked.

--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -478,7 +478,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
         switch (decoded.method) {
           case 'SystemNavigator.pop':
             // TODO(a-wallen): As multi-window support expands, the pop call
-            // will need to include the window ID. Right now only one window is
+            // will need to include the view ID. Right now only one view is
             // supported.
             (viewData[0]! as EngineFlutterWindow)
                 .browserHistory
@@ -568,7 +568,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
 
       case 'flutter/navigation':
         // TODO(a-wallen): As multi-window support expands, the navigation call
-        // will need to include the window ID. Right now only one window is
+        // will need to include the view ID. Right now only one view is
         // supported.
         (viewData[0]! as EngineFlutterWindow)
             .handleNavigationMessage(data)

--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -138,9 +138,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
 
   /// The current list of windows,
   @override
-  Iterable<ui.FlutterView> get views => _windows.values;
-  Map<Object, ui.FlutterWindow> get windows => _windows;
-  final Map<Object, ui.FlutterWindow> _windows = <Object, ui.FlutterWindow>{};
+  final Map<Object, ui.FlutterView> views = <Object, ui.FlutterView>{};
 
   /// A map of opaque platform window identifiers to window configurations.
   ///
@@ -481,7 +479,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
             // TODO(gspencergoog): As multi-window support expands, the pop call
             // will need to include the window ID. Right now only one window is
             // supported.
-            (_windows[0]! as EngineFlutterWindow)
+            (views[0]! as EngineFlutterWindow)
                 .browserHistory
                 .exit()
                 .then((_) {
@@ -571,7 +569,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
         // TODO(gspencergoog): As multi-window support expands, the navigation call
         // will need to include the window ID. Right now only one window is
         // supported.
-        (_windows[0]! as EngineFlutterWindow)
+        (views[0]! as EngineFlutterWindow)
             .handleNavigationMessage(data)
             .then((bool handled) {
           if (handled) {
@@ -1160,7 +1158,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
   @override
   String get defaultRouteName {
     return _defaultRouteName ??=
-        (_windows[0]! as EngineFlutterWindow).browserHistory.currentPath;
+        (views[0]! as EngineFlutterWindow).browserHistory.currentPath;
   }
 
   /// Lazily initialized when the `defaultRouteName` getter is invoked.

--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -138,10 +138,8 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
 
   /// The current list of windows,
   @override
-  Iterable<ui.FlutterView> get views => _views.values;
-  final Map<Object, ui.FlutterView> _views = <Object, ui.FlutterView>{};
-  ui.FlutterView? getViewById(Object id) => _views[id];
-  void addView(Object id, ui.FlutterView view) => _views[id] = view;
+  Iterable<ui.FlutterView> get views => viewData.values;
+  final Map<Object, ui.FlutterView> viewData = <Object, ui.FlutterView>{};
 
   /// A map of opaque platform window identifiers to window configurations.
   ///
@@ -482,7 +480,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
             // TODO(a-wallen): As multi-window support expands, the pop call
             // will need to include the window ID. Right now only one window is
             // supported.
-            (_views[0]! as EngineFlutterWindow)
+            (viewData[0]! as EngineFlutterWindow)
                 .browserHistory
                 .exit()
                 .then((_) {
@@ -572,7 +570,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
         // TODO(a-wallen): As multi-window support expands, the navigation call
         // will need to include the window ID. Right now only one window is
         // supported.
-        (_views[0]! as EngineFlutterWindow)
+        (viewData[0]! as EngineFlutterWindow)
             .handleNavigationMessage(data)
             .then((bool handled) {
           if (handled) {
@@ -1161,7 +1159,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
   @override
   String get defaultRouteName {
     return _defaultRouteName ??=
-        (_views[0]! as EngineFlutterWindow).browserHistory.currentPath;
+        (viewData[0]! as EngineFlutterWindow).browserHistory.currentPath;
   }
 
   /// Lazily initialized when the `defaultRouteName` getter is invoked.

--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -138,9 +138,10 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
 
   /// The current list of windows,
   @override
-  Iterable<ui.FlutterView> get views => _windows.values;
-  Map<Object, ui.FlutterView> get windows => _windows;
-  final Map<Object, ui.FlutterView> _windows = <Object, ui.FlutterView>{};
+  Iterable<ui.FlutterView> get views => _views.values;
+  final Map<Object, ui.FlutterView> _views = <Object, ui.FlutterView>{};
+  ui.FlutterView? getViewById(Object id) => _views[id];
+
   /// A map of opaque platform window identifiers to window configurations.
   ///
   /// This should be considered a protected member, only to be used by

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -59,6 +59,7 @@ class EngineFlutterWindow extends ui.SingletonFlutterWindow {
   }
 
   final Object _viewId;
+
   @override
   Object get viewId => _viewId;
 

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -27,6 +27,9 @@ typedef _HandleMessageCallBack = Future<bool> Function();
 /// When set to true, all platform messages will be printed to the console.
 const bool debugPrintPlatformMessages = false;
 
+/// The view ID for a singleton flutter window.
+const int kSingletonViewId = 0;
+
 /// Whether [_customUrlStrategy] has been set or not.
 ///
 /// It is valid to set [_customUrlStrategy] to null, so we can't use a null
@@ -346,7 +349,7 @@ class EngineSingletonFlutterWindow extends EngineFlutterWindow {
 /// API surface, providing Web-specific functionality that the standard
 /// `dart:ui` version does not.
 final EngineSingletonFlutterWindow window =
-    EngineSingletonFlutterWindow(0, EnginePlatformDispatcher.instance);
+    EngineSingletonFlutterWindow(kSingletonViewId, EnginePlatformDispatcher.instance);
 
 /// The Web implementation of [ui.WindowPadding].
 class WindowPadding implements ui.WindowPadding {

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -342,28 +342,6 @@ class EngineSingletonFlutterWindow extends EngineFlutterWindow {
   double? _debugDevicePixelRatio;
 }
 
-/// A type of [FlutterView] that can be hosted inside of a [FlutterWindow].
-class EngineFlutterWindowView extends ui.FlutterView {
-  EngineFlutterWindowView._(this._viewId, this.platformDispatcher);
-
-  final Object _viewId;
-
-  @override
-  Object get viewId => _viewId;
-
-  @override
-  final ui.PlatformDispatcher platformDispatcher;
-
-  @override
-  ui.ViewConfiguration get viewConfiguration {
-    final EnginePlatformDispatcher engineDispatcher =
-        platformDispatcher as EnginePlatformDispatcher;
-    assert(engineDispatcher.windowConfigurations.containsKey(_viewId));
-    return engineDispatcher.windowConfigurations[_viewId] ??
-        const ui.ViewConfiguration();
-  }
-}
-
 /// The window singleton.
 ///
 /// `dart:ui` window delegates to this value. However, this value has a wider

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -58,10 +58,8 @@ class EngineFlutterWindow extends ui.SingletonFlutterWindow {
     });
   }
 
-  final Object _viewId;
-
   @override
-  Object get viewId => _viewId;
+  final Object viewId;
 
   @override
   final ui.PlatformDispatcher platformDispatcher;

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -46,7 +46,7 @@ class EngineFlutterWindow extends ui.SingletonFlutterWindow {
   EngineFlutterWindow(this._viewId, this.platformDispatcher) {
     final EnginePlatformDispatcher engineDispatcher =
         platformDispatcher as EnginePlatformDispatcher;
-    engineDispatcher.windows[_viewId] = this;
+    engineDispatcher.addView(_viewId, this);
     engineDispatcher.windowConfigurations[_viewId] = const ui.ViewConfiguration();
     if (_isUrlStrategySet) {
       _browserHistory = createHistoryForExistingState(_customUrlStrategy);

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -46,7 +46,7 @@ class EngineFlutterWindow extends ui.SingletonFlutterWindow {
   EngineFlutterWindow(this._windowId, this.platformDispatcher) {
     final EnginePlatformDispatcher engineDispatcher =
         platformDispatcher as EnginePlatformDispatcher;
-    engineDispatcher.windows[_windowId] = this;
+    engineDispatcher.views[_windowId] = this;
     engineDispatcher.windowConfigurations[_windowId] = const ui.ViewConfiguration();
     if (_isUrlStrategySet) {
       _browserHistory = createHistoryForExistingState(_customUrlStrategy);
@@ -59,6 +59,9 @@ class EngineFlutterWindow extends ui.SingletonFlutterWindow {
   }
 
   final Object _windowId;
+
+  @override
+  Object get viewId => _windowId;
 
   @override
   final ui.PlatformDispatcher platformDispatcher;
@@ -340,10 +343,13 @@ class EngineSingletonFlutterWindow extends EngineFlutterWindow {
 }
 
 /// A type of [FlutterView] that can be hosted inside of a [FlutterWindow].
-class EngineFlutterWindowView extends ui.FlutterWindow {
+class EngineFlutterWindowView extends ui.FlutterView {
   EngineFlutterWindowView._(this._viewId, this.platformDispatcher);
 
   final Object _viewId;
+
+  @override
+  Object get viewId => _viewId;
 
   @override
   final ui.PlatformDispatcher platformDispatcher;

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -43,11 +43,11 @@ set customUrlStrategy(UrlStrategy? strategy) {
 
 /// The Web implementation of [ui.SingletonFlutterWindow].
 class EngineFlutterWindow extends ui.SingletonFlutterWindow {
-  EngineFlutterWindow(this._windowId, this.platformDispatcher) {
+  EngineFlutterWindow(this._viewId, this.platformDispatcher) {
     final EnginePlatformDispatcher engineDispatcher =
         platformDispatcher as EnginePlatformDispatcher;
-    engineDispatcher.views[_windowId] = this;
-    engineDispatcher.windowConfigurations[_windowId] = const ui.ViewConfiguration();
+    engineDispatcher.windows[_viewId] = this;
+    engineDispatcher.windowConfigurations[_viewId] = const ui.ViewConfiguration();
     if (_isUrlStrategySet) {
       _browserHistory = createHistoryForExistingState(_customUrlStrategy);
     }
@@ -58,10 +58,9 @@ class EngineFlutterWindow extends ui.SingletonFlutterWindow {
     });
   }
 
-  final Object _windowId;
-
+  final Object _viewId;
   @override
-  Object get viewId => _windowId;
+  Object get viewId => _viewId;
 
   @override
   final ui.PlatformDispatcher platformDispatcher;
@@ -205,8 +204,8 @@ class EngineFlutterWindow extends ui.SingletonFlutterWindow {
   ui.ViewConfiguration get viewConfiguration {
     final EnginePlatformDispatcher engineDispatcher =
         platformDispatcher as EnginePlatformDispatcher;
-    assert(engineDispatcher.windowConfigurations.containsKey(_windowId));
-    return engineDispatcher.windowConfigurations[_windowId] ??
+    assert(engineDispatcher.windowConfigurations.containsKey(_viewId));
+    return engineDispatcher.windowConfigurations[_viewId] ??
         const ui.ViewConfiguration();
   }
 

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -46,7 +46,7 @@ class EngineFlutterWindow extends ui.SingletonFlutterWindow {
   EngineFlutterWindow(this._viewId, this.platformDispatcher) {
     final EnginePlatformDispatcher engineDispatcher =
         platformDispatcher as EnginePlatformDispatcher;
-    engineDispatcher.addView(_viewId, this);
+    engineDispatcher.viewData[_viewId] = this;
     engineDispatcher.windowConfigurations[_viewId] = const ui.ViewConfiguration();
     if (_isUrlStrategySet) {
       _browserHistory = createHistoryForExistingState(_customUrlStrategy);

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -43,11 +43,11 @@ set customUrlStrategy(UrlStrategy? strategy) {
 
 /// The Web implementation of [ui.SingletonFlutterWindow].
 class EngineFlutterWindow extends ui.SingletonFlutterWindow {
-  EngineFlutterWindow(this._viewId, this.platformDispatcher) {
+  EngineFlutterWindow(this.viewId, this.platformDispatcher) {
     final EnginePlatformDispatcher engineDispatcher =
         platformDispatcher as EnginePlatformDispatcher;
-    engineDispatcher.viewData[_viewId] = this;
-    engineDispatcher.windowConfigurations[_viewId] = const ui.ViewConfiguration();
+    engineDispatcher.viewData[viewId] = this;
+    engineDispatcher.windowConfigurations[viewId] = const ui.ViewConfiguration();
     if (_isUrlStrategySet) {
       _browserHistory = createHistoryForExistingState(_customUrlStrategy);
     }
@@ -203,8 +203,8 @@ class EngineFlutterWindow extends ui.SingletonFlutterWindow {
   ui.ViewConfiguration get viewConfiguration {
     final EnginePlatformDispatcher engineDispatcher =
         platformDispatcher as EnginePlatformDispatcher;
-    assert(engineDispatcher.windowConfigurations.containsKey(_viewId));
-    return engineDispatcher.windowConfigurations[_viewId] ??
+    assert(engineDispatcher.windowConfigurations.containsKey(viewId));
+    return engineDispatcher.windowConfigurations[viewId] ??
         const ui.ViewConfiguration();
   }
 

--- a/lib/web_ui/lib/window.dart
+++ b/lib/web_ui/lib/window.dart
@@ -7,6 +7,7 @@ part of ui;
 abstract class FlutterView {
   PlatformDispatcher get platformDispatcher;
   ViewConfiguration get viewConfiguration;
+  Object get viewId;
   double get devicePixelRatio => viewConfiguration.devicePixelRatio;
   Rect get physicalGeometry => viewConfiguration.geometry;
   Size get physicalSize => viewConfiguration.geometry.size;
@@ -19,15 +20,7 @@ abstract class FlutterView {
   void updateSemantics(SemanticsUpdate update) => platformDispatcher.updateSemantics(update);
 }
 
-abstract class FlutterWindow extends FlutterView {
-  @override
-  PlatformDispatcher get platformDispatcher;
-
-  @override
-  ViewConfiguration get viewConfiguration;
-}
-
-abstract class SingletonFlutterWindow extends FlutterWindow {
+abstract class SingletonFlutterWindow extends FlutterView {
   VoidCallback? get onMetricsChanged => platformDispatcher.onMetricsChanged;
   set onMetricsChanged(VoidCallback? callback) {
     platformDispatcher.onMetricsChanged = callback;

--- a/lib/web_ui/test/engine/platform_dispatcher_test.dart
+++ b/lib/web_ui/test/engine/platform_dispatcher_test.dart
@@ -186,7 +186,9 @@ void testMain() {
   test('Initialize a ViewConfiguration with a window', () {
     final ui.FlutterView window = EngineFlutterWindow(0, ui.PlatformDispatcher.instance);
     // ignore: deprecated_member_use
-    ui.ViewConfiguration(window: window);
+    final ui.ViewConfiguration configuration = ui.ViewConfiguration(window: window);
+    // ignore: deprecated_member_use
+    expect(window, configuration.window);
   });
 
   test("copyWith() on a ViewConfiguration asserts that both a window aren't provided", () {

--- a/lib/web_ui/test/engine/platform_dispatcher_test.dart
+++ b/lib/web_ui/test/engine/platform_dispatcher_test.dart
@@ -183,6 +183,12 @@ void testMain() {
     expect(viewConfiguration.window, viewConfiguration.view);
   });
 
+  test('Initialize a ViewConfiguration with a window', () {
+    final ui.FlutterView window = EngineFlutterWindow(0, ui.PlatformDispatcher.instance);
+    // ignore: deprecated_member_use
+    ui.ViewConfiguration(window: window);
+  });
+
   test("copyWith() on a ViewConfiguration asserts that both a window aren't provided", () {
     final ui.FlutterView window = EngineFlutterWindow(0, ui.PlatformDispatcher.instance);
     // ignore: deprecated_member_use

--- a/lib/web_ui/test/engine/platform_dispatcher_test.dart
+++ b/lib/web_ui/test/engine/platform_dispatcher_test.dart
@@ -178,7 +178,7 @@ void testMain() {
     final ui.FlutterView window = EngineFlutterWindow(0, ui.PlatformDispatcher.instance);
     final ui.ViewConfiguration viewConfiguration = ui.ViewConfiguration(view: window);
     // ignore: deprecated_member_use
-    expect(viewConfiguration.window, window);
+    expect(viewConfiguration.view, window);
     // ignore: deprecated_member_use
     expect(viewConfiguration.window, viewConfiguration.view);
   });

--- a/lib/web_ui/test/engine/platform_dispatcher_test.dart
+++ b/lib/web_ui/test/engine/platform_dispatcher_test.dart
@@ -11,6 +11,8 @@ import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' as ui;
 
+import '../matchers.dart';
+
 void main() {
   internalBootstrapBrowserTest(() => testMain);
 }
@@ -159,6 +161,34 @@ void testMain() {
       expect(isCalled, isTrue);
       expect(ui.PlatformDispatcher.instance.textScaleFactor, findBrowserTextScaleFactor());
     });
+  });
+
+  test('ViewConfiguration asserts that both window and view are not provided', () {
+    expect(() {
+      // ignore: deprecated_member_use
+      final EngineFlutterWindow window = EngineFlutterWindow(0, ui.PlatformDispatcher.instance);
+      ui.ViewConfiguration(
+        window: window,
+        view: window,
+      );
+    }, throwsAssertionError);
+  });
+
+  test("A ViewConfiguration's view and window are backed with the same property", () {
+    final ui.FlutterView window = EngineFlutterWindow(0, ui.PlatformDispatcher.instance);
+    final ui.ViewConfiguration viewConfiguration = ui.ViewConfiguration(view: window);
+    // ignore: deprecated_member_use
+    expect(viewConfiguration.window, window);
+    // ignore: deprecated_member_use
+    expect(viewConfiguration.window, viewConfiguration.view);
+  });
+
+  test('Calling copyWith on a ViewConfiguration with both a window and view throws an error', () {
+    final ui.FlutterView window = EngineFlutterWindow(0, ui.PlatformDispatcher.instance);
+    // ignore: deprecated_member_use
+    expect(() {
+      ui.ViewConfiguration(view: window).copyWith(view: window, window: window);
+    }, throwsAssertionError);
   });
 }
 

--- a/lib/web_ui/test/engine/platform_dispatcher_test.dart
+++ b/lib/web_ui/test/engine/platform_dispatcher_test.dart
@@ -163,7 +163,7 @@ void testMain() {
     });
   });
 
-  test('ViewConfiguration asserts that both window and view are not provided', () {
+  test('A ViewConfiguration asserts that both window and view are not provided', () {
     expect(() {
       // ignore: deprecated_member_use
       final EngineFlutterWindow window = EngineFlutterWindow(0, ui.PlatformDispatcher.instance);
@@ -183,7 +183,7 @@ void testMain() {
     expect(viewConfiguration.window, viewConfiguration.view);
   });
 
-  test('Calling copyWith on a ViewConfiguration with both a window and view throws an error', () {
+  test("copyWith() on a ViewConfiguration asserts that both a window aren't provided", () {
     final ui.FlutterView window = EngineFlutterWindow(0, ui.PlatformDispatcher.instance);
     // ignore: deprecated_member_use
     expect(() {

--- a/testing/dart/BUILD.gn
+++ b/testing/dart/BUILD.gn
@@ -37,6 +37,7 @@ tests = [
   "paragraph_test.dart",
   "path_test.dart",
   "picture_test.dart",
+  "platform_dispatcher_test.dart",
   "platform_view_test.dart",
   "plugin_utilities_test.dart",
   "semantics_test.dart",

--- a/testing/dart/platform_dispatcher_test.dart
+++ b/testing/dart/platform_dispatcher_test.dart
@@ -26,6 +26,12 @@ void main() {
     expect(viewConfiguration.window, viewConfiguration.view);
   });
 
+  test('Initialize a ViewConfiguration with a window', () {
+    final FlutterView view = PlatformDispatcher.instance.views.first;
+    // ignore: deprecated_member_use
+    ViewConfiguration(window: view);
+  });
+
   test("copyWith() on a ViewConfiguration asserts that both a window aren't provided", () {
     final FlutterView view = PlatformDispatcher.instance.views.first;
     expectAssertion(() {

--- a/testing/dart/platform_dispatcher_test.dart
+++ b/testing/dart/platform_dispatcher_test.dart
@@ -7,7 +7,7 @@ import 'dart:ui';
 import 'package:litetest/litetest.dart';
 
 void main() {
-  test('ViewConfiguration asserts that both window and view are not provided', () async {
+  test('A ViewConfiguration asserts that both window and view are not provided', () {
     expectAssertion(() {
       return ViewConfiguration(
       // ignore: deprecated_member_use
@@ -17,7 +17,7 @@ void main() {
     });
   });
 
-  test("A ViewConfiguration's view and window are backed with the same property", () async {
+  test("A ViewConfiguration's view and window are backed with the same property", () {
     final FlutterView view = PlatformDispatcher.instance.views.first;
     final ViewConfiguration viewConfiguration = ViewConfiguration(view: view);
     // ignore: deprecated_member_use
@@ -26,7 +26,7 @@ void main() {
     expect(viewConfiguration.window, viewConfiguration.view);
   });
 
-  test('Calling copyWith on a ViewConfiguration with both a window and view throws an error', () async {
+  test("copyWith() on a ViewConfiguration asserts that both a window aren't provided", () {
     final FlutterView view = PlatformDispatcher.instance.views.first;
     expectAssertion(() {
       // ignore: deprecated_member_use

--- a/testing/dart/platform_dispatcher_test.dart
+++ b/testing/dart/platform_dispatcher_test.dart
@@ -1,0 +1,36 @@
+// Copyright 2022 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui';
+
+import 'package:litetest/litetest.dart';
+
+void main() {
+  test('ViewConfiguration asserts that both window and view are not provided', () async {
+    expectAssertion(() {
+      return ViewConfiguration(
+      // ignore: deprecated_member_use
+        window: PlatformDispatcher.instance.views.first,
+        view: PlatformDispatcher.instance.views.first,
+      );
+    });
+  });
+
+  test("A ViewConfiguration's view and window are backed with the same property", () async {
+    final FlutterView view = PlatformDispatcher.instance.views.first;
+    final ViewConfiguration viewConfiguration = ViewConfiguration(view: view);
+    // ignore: deprecated_member_use
+    expect(viewConfiguration.window, view);
+    // ignore: deprecated_member_use
+    expect(viewConfiguration.window, viewConfiguration.view);
+  });
+
+  test('Calling copyWith on a ViewConfiguration with both a window and view throws an error', () async {
+    final FlutterView view = PlatformDispatcher.instance.views.first;
+    expectAssertion(() {
+      // ignore: deprecated_member_use
+      return ViewConfiguration(view: view)..copyWith(view: view, window: view);
+    });
+  });
+}

--- a/testing/scenario_app/lib/src/scenario.dart
+++ b/testing/scenario_app/lib/src/scenario.dart
@@ -7,7 +7,7 @@ import 'dart:ui';
 
 /// A scenario to run for testing.
 abstract class Scenario {
-  /// Creates a new scenario using a specific FlutterWindow instance.
+  /// Creates a new scenario using a specific FlutterView instance.
   Scenario(this.dispatcher);
 
   /// The window used by this scenario. May be mocked.


### PR DESCRIPTION
Removes `FlutterView` to support multi-window.

Fixes https://github.com/flutter/flutter/issues/112204

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
