### PR TITLE
Remove single window/view assumption from `SceneBuilder`

### DIFF
--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -878,12 +878,16 @@ class SceneBuilder extends NativeFieldWrapperClass1 {
   ///
   /// After calling this function, the scene builder object is invalid and
   /// cannot be used further.
-  Scene build() {
+  Scene build({
+    required Rect bounds,
+    double displayPixelRatio = 1.0,
+    double touchSlop = -1.0,
+  }) {
     final Scene scene = Scene._();
-    _build(scene);
+    _build(scene, bounds.width, bounds.height, displayPixelRatio, touchSlop);
     return scene;
   }
 
-  @FfiNative<Void Function(Pointer<Void>, Handle)>('SceneBuilder::build')
-  external void _build(Scene outScene);
+  @FfiNative<Void Function(Pointer<Void>, Handle, Double, Double, Double, Double)>('SceneBuilder::build')
+  external void _build(Scene outScene, double width, double height, double displayPixelRatio, double touchSlop);
 }

--- a/lib/ui/compositing/scene.cc
+++ b/lib/ui/compositing/scene.cc
@@ -27,29 +27,25 @@ IMPLEMENT_WRAPPERTYPEINFO(ui, Scene);
 
 void Scene::create(Dart_Handle scene_handle,
                    std::shared_ptr<flutter::Layer> rootLayer,
+                   flutter::ViewportMetrics viewportMetrics,
                    uint32_t rasterizerTracingThreshold,
                    bool checkerboardRasterCacheImages,
                    bool checkerboardOffscreenLayers) {
   auto scene = fml::MakeRefCounted<Scene>(
-      std::move(rootLayer), rasterizerTracingThreshold,
+      std::move(rootLayer), rasterizerTracingThreshold, viewportMetrics,
       checkerboardRasterCacheImages, checkerboardOffscreenLayers);
   scene->AssociateWithDartWrapper(scene_handle);
 }
 
 Scene::Scene(std::shared_ptr<flutter::Layer> rootLayer,
              uint32_t rasterizerTracingThreshold,
+             flutter::ViewportMetrics viewportMetrics,
              bool checkerboardRasterCacheImages,
              bool checkerboardOffscreenLayers) {
-  // Currently only supports a single window.
-  auto viewport_metrics = UIDartState::Current()
-                              ->platform_configuration()
-                              ->get_window(0)
-                              ->viewport_metrics();
-
   layer_tree_ = std::make_shared<LayerTree>(
-      SkISize::Make(viewport_metrics.physical_width,
-                    viewport_metrics.physical_height),
-      static_cast<float>(viewport_metrics.device_pixel_ratio));
+      SkISize::Make(viewportMetrics.physical_width,
+                    viewportMetrics.physical_height),
+      static_cast<float>(viewportMetrics.device_pixel_ratio));
   layer_tree_->set_root_layer(std::move(rootLayer));
   layer_tree_->set_rasterizer_tracing_threshold(rasterizerTracingThreshold);
   layer_tree_->set_checkerboard_raster_cache_images(

--- a/lib/ui/compositing/scene.h
+++ b/lib/ui/compositing/scene.h
@@ -10,6 +10,7 @@
 
 #include "flutter/flow/layers/layer_tree.h"
 #include "flutter/lib/ui/dart_wrapper.h"
+#include "flutter/lib/ui/window/window.h"
 #include "third_party/skia/include/core/SkPicture.h"
 
 namespace flutter {
@@ -22,6 +23,7 @@ class Scene : public RefCountedDartWrappable<Scene> {
   ~Scene() override;
   static void create(Dart_Handle scene_handle,
                      std::shared_ptr<flutter::Layer> rootLayer,
+                     flutter::ViewportMetrics viewportMetrics,
                      uint32_t rasterizerTracingThreshold,
                      bool checkerboardRasterCacheImages,
                      bool checkerboardOffscreenLayers);
@@ -41,6 +43,7 @@ class Scene : public RefCountedDartWrappable<Scene> {
  private:
   Scene(std::shared_ptr<flutter::Layer> rootLayer,
         uint32_t rasterizerTracingThreshold,
+        flutter::ViewportMetrics viewportMetrics,
         bool checkerboardRasterCacheImages,
         bool checkerboardOffscreenLayers);
 

--- a/lib/ui/compositing/scene_builder.cc
+++ b/lib/ui/compositing/scene_builder.cc
@@ -24,6 +24,7 @@
 #include "flutter/fml/build_config.h"
 #include "flutter/lib/ui/painting/matrix.h"
 #include "flutter/lib/ui/painting/shader.h"
+#include "flutter/lib/ui/window/platform_configuration.h"
 #include "third_party/skia/include/core/SkColorFilter.h"
 #include "third_party/tonic/converter/dart_converter.h"
 #include "third_party/tonic/dart_args.h"
@@ -312,12 +313,20 @@ void SceneBuilder::setCheckerboardOffscreenLayers(bool checkerboard) {
   checkerboard_offscreen_layers_ = checkerboard;
 }
 
-void SceneBuilder::build(Dart_Handle scene_handle) {
+void SceneBuilder::build(Dart_Handle scene_handle,
+                         double width,
+                         double height,
+                         double displayPixelRatio,
+                         double touchSlop) {
   FML_DCHECK(layer_stack_.size() >= 1);
 
-  Scene::create(
-      scene_handle, std::move(layer_stack_[0]), rasterizer_tracing_threshold_,
-      checkerboard_raster_cache_images_, checkerboard_offscreen_layers_);
+  auto viewport_metrics =
+      ViewportMetrics(width, height, displayPixelRatio, touchSlop);
+
+  Scene::create(scene_handle, std::move(layer_stack_[0]), viewport_metrics,
+                rasterizer_tracing_threshold_,
+                checkerboard_raster_cache_images_,
+                checkerboard_offscreen_layers_);
   layer_stack_.clear();
   ClearDartWrapper();  // may delete this object.
 }

--- a/lib/ui/compositing/scene_builder.h
+++ b/lib/ui/compositing/scene_builder.h
@@ -137,7 +137,11 @@ class SceneBuilder : public RefCountedDartWrappable<SceneBuilder> {
   void setCheckerboardRasterCacheImages(bool checkerboard);
   void setCheckerboardOffscreenLayers(bool checkerboard);
 
-  void build(Dart_Handle scene_handle);
+  void build(Dart_Handle scene_handle,
+             double width,
+             double height,
+             double displayPixelRatio,
+             double touchSlop);
 
   const std::vector<std::shared_ptr<ContainerLayer>>& layer_stack() {
     return layer_stack_;


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/112202

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
