### PR TITLE
[Impeller Scene] Add ColorSourceContents for drawing a node

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1259,6 +1259,8 @@ ORIGIN: ../../../flutter/impeller/entity/contents/rrect_shadow_contents.cc + ../
 ORIGIN: ../../../flutter/impeller/entity/contents/rrect_shadow_contents.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/entity/contents/runtime_effect_contents.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/entity/contents/runtime_effect_contents.h + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/impeller/entity/contents/scene_contents.cc + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/impeller/entity/contents/scene_contents.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/entity/contents/solid_color_contents.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/entity/contents/solid_color_contents.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/entity/contents/sweep_gradient_contents.cc + ../../../flutter/LICENSE
@@ -3716,6 +3718,8 @@ FILE: ../../../flutter/impeller/entity/contents/rrect_shadow_contents.cc
 FILE: ../../../flutter/impeller/entity/contents/rrect_shadow_contents.h
 FILE: ../../../flutter/impeller/entity/contents/runtime_effect_contents.cc
 FILE: ../../../flutter/impeller/entity/contents/runtime_effect_contents.h
+FILE: ../../../flutter/impeller/entity/contents/scene_contents.cc
+FILE: ../../../flutter/impeller/entity/contents/scene_contents.h
 FILE: ../../../flutter/impeller/entity/contents/solid_color_contents.cc
 FILE: ../../../flutter/impeller/entity/contents/solid_color_contents.h
 FILE: ../../../flutter/impeller/entity/contents/sweep_gradient_contents.cc

--- a/impeller/aiks/paint.h
+++ b/impeller/aiks/paint.h
@@ -44,6 +44,7 @@ struct Paint {
     kConicalGradient,
     kSweepGradient,
     kRuntimeEffect,
+    kScene,
   };
 
   struct MaskBlurDescriptor {

--- a/impeller/display_list/display_list_dispatcher.cc
+++ b/impeller/display_list/display_list_dispatcher.cc
@@ -27,6 +27,7 @@
 #include "impeller/entity/contents/linear_gradient_contents.h"
 #include "impeller/entity/contents/radial_gradient_contents.h"
 #include "impeller/entity/contents/runtime_effect_contents.h"
+#include "impeller/entity/contents/scene_contents.h"
 #include "impeller/entity/contents/sweep_gradient_contents.h"
 #include "impeller/entity/contents/tiled_texture_contents.h"
 #include "impeller/entity/entity.h"
@@ -500,6 +501,20 @@ void DisplayListDispatcher::setColorSource(
       };
       return;
     }
+    case Paint::ColorSourceType::kScene: {
+      // const flutter::DlSceneColorSource* scene_color_source =
+      // source->asScene(); std::shared_ptr<scene::Node> scene_node =
+      // scene_color_source->node(); Matrix camera_transform =
+      //   scene_color_node->camera_transform();
+
+      paint_.color_source = [/*scene_node, camera_transform*/]() {
+        auto contents = std::make_shared<SceneContents>();
+        // contents->SetNode(scene_node);
+        // contents->SetCameraTransform(camera_transform);
+        return contents;
+      };
+    }
+      return;
     case Paint::ColorSourceType::kConicalGradient:
       UNIMPLEMENTED;
       break;

--- a/impeller/entity/BUILD.gn
+++ b/impeller/entity/BUILD.gn
@@ -134,6 +134,8 @@ impeller_component("entity") {
     "contents/rrect_shadow_contents.h",
     "contents/runtime_effect_contents.cc",
     "contents/runtime_effect_contents.h",
+    "contents/scene_contents.cc",
+    "contents/scene_contents.h",
     "contents/solid_color_contents.cc",
     "contents/solid_color_contents.h",
     "contents/sweep_gradient_contents.cc",
@@ -164,6 +166,7 @@ impeller_component("entity") {
     "../archivist",
     "../image",
     "../renderer",
+    "../scene",
     "../typographer",
   ]
 

--- a/impeller/entity/contents/color_source_contents.cc
+++ b/impeller/entity/contents/color_source_contents.cc
@@ -13,11 +13,11 @@ ColorSourceContents::ColorSourceContents() = default;
 
 ColorSourceContents::~ColorSourceContents() = default;
 
-void ColorSourceContents::SetGeometry(std::unique_ptr<Geometry> geometry) {
+void ColorSourceContents::SetGeometry(std::shared_ptr<Geometry> geometry) {
   geometry_ = std::move(geometry);
 }
 
-const std::unique_ptr<Geometry>& ColorSourceContents::GetGeometry() const {
+const std::shared_ptr<Geometry>& ColorSourceContents::GetGeometry() const {
   return geometry_;
 }
 

--- a/impeller/entity/contents/color_source_contents.h
+++ b/impeller/entity/contents/color_source_contents.h
@@ -18,7 +18,7 @@ class ColorSourceContents : public Contents {
 
   ~ColorSourceContents() override;
 
-  void SetGeometry(std::unique_ptr<Geometry> geometry);
+  void SetGeometry(std::shared_ptr<Geometry> geometry);
 
   void SetMatrix(Matrix matrix);
 
@@ -32,14 +32,14 @@ class ColorSourceContents : public Contents {
                     const std::optional<Rect>& stencil_coverage) const override;
 
  protected:
-  const std::unique_ptr<Geometry>& GetGeometry() const;
+  const std::shared_ptr<Geometry>& GetGeometry() const;
 
   const Matrix& GetInverseMatrix() const;
 
   Scalar GetAlpha() const;
 
  private:
-  std::unique_ptr<Geometry> geometry_;
+  std::shared_ptr<Geometry> geometry_;
   Matrix inverse_matrix_;
   Scalar alpha_ = 1.0;
 

--- a/impeller/entity/contents/content_context.cc
+++ b/impeller/entity/contents/content_context.cc
@@ -4,6 +4,7 @@
 
 #include "impeller/entity/contents/content_context.h"
 
+#include <memory>
 #include <sstream>
 
 #include "impeller/entity/entity.h"
@@ -146,7 +147,8 @@ static std::unique_ptr<PipelineT> CreateDefaultPipeline(
 ContentContext::ContentContext(std::shared_ptr<Context> context)
     : context_(std::move(context)),
       tessellator_(std::make_shared<Tessellator>()),
-      glyph_atlas_context_(std::make_shared<GlyphAtlasContext>()) {
+      glyph_atlas_context_(std::make_shared<GlyphAtlasContext>()),
+      scene_context_(std::make_shared<scene::SceneContext>(context_)) {
   if (!context_ || !context_->IsValid()) {
     return;
   }
@@ -296,6 +298,10 @@ std::shared_ptr<Texture> ContentContext::MakeSubpass(
   }
 
   return subpass_texture;
+}
+
+std::shared_ptr<scene::SceneContext> ContentContext::GetSceneContext() const {
+  return scene_context_;
 }
 
 std::shared_ptr<Tessellator> ContentContext::GetTessellator() const {

--- a/impeller/entity/contents/content_context.h
+++ b/impeller/entity/contents/content_context.h
@@ -8,8 +8,8 @@
 #include <unordered_map>
 
 #include "flutter/fml/hash_combine.h"
+#include "flutter/fml/logging.h"
 #include "flutter/fml/macros.h"
-#include "fml/logging.h"
 #include "impeller/base/validation.h"
 #include "impeller/entity/advanced_blend.vert.h"
 #include "impeller/entity/advanced_blend_color.frag.h"
@@ -65,11 +65,13 @@
 #include "impeller/entity/yuv_to_rgb_filter.vert.h"
 #include "impeller/renderer/formats.h"
 #include "impeller/renderer/pipeline.h"
+#include "impeller/scene/scene_context.h"
 
 #include "impeller/entity/position.vert.h"
 #include "impeller/entity/position_color.vert.h"
 #include "impeller/entity/position_uv.vert.h"
 
+#include "impeller/scene/scene_context.h"
 #include "impeller/typographer/glyph_atlas.h"
 
 #include "impeller/entity/linear_gradient_ssbo_fill.frag.h"
@@ -215,6 +217,8 @@ class ContentContext {
   ~ContentContext();
 
   bool IsValid() const;
+
+  std::shared_ptr<scene::SceneContext> GetSceneContext() const;
 
   std::shared_ptr<Tessellator> GetTessellator() const;
 
@@ -522,6 +526,7 @@ class ContentContext {
   bool is_valid_ = false;
   std::shared_ptr<Tessellator> tessellator_;
   std::shared_ptr<GlyphAtlasContext> glyph_atlas_context_;
+  std::shared_ptr<scene::SceneContext> scene_context_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(ContentContext);
 };

--- a/impeller/entity/contents/scene_contents.cc
+++ b/impeller/entity/contents/scene_contents.cc
@@ -50,7 +50,7 @@ bool SceneContents::Render(const ContentContext& renderer,
       "SceneContents",                   // label
       StorageMode::kDeviceTransient,     // color_storage_mode
       StorageMode::kDevicePrivate,       // color_resolve_storage_mode
-      LoadAction::kDontCare,             // color_load_action
+      LoadAction::kClear,                // color_load_action
       StoreAction::kMultisampleResolve,  // color_store_action
       StorageMode::kDeviceTransient,     // stencil_storage_mode
       LoadAction::kDontCare,             // stencil_load_action

--- a/impeller/entity/contents/scene_contents.cc
+++ b/impeller/entity/contents/scene_contents.cc
@@ -1,0 +1,65 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/entity/contents/scene_contents.h"
+
+#include "impeller/entity/contents/content_context.h"
+#include "impeller/entity/contents/tiled_texture_contents.h"
+#include "impeller/entity/entity.h"
+#include "impeller/geometry/path_builder.h"
+#include "impeller/renderer/formats.h"
+#include "impeller/scene/camera.h"
+#include "impeller/scene/scene.h"
+
+namespace impeller {
+
+SceneContents::SceneContents() = default;
+
+SceneContents::~SceneContents() = default;
+
+void SceneContents::SetCameraTransform(Matrix matrix) {
+  camera_transform_ = matrix;
+}
+
+void SceneContents::SetNode(std::shared_ptr<scene::Node> node) {
+  node_ = std::move(node);
+}
+
+bool SceneContents::Render(const ContentContext& renderer,
+                           const Entity& entity,
+                           RenderPass& pass) const {
+  if (!node_) {
+    return true;
+  }
+  auto coverage = GetCoverage(entity);
+  if (!coverage.has_value()) {
+    return true;
+  }
+
+  RenderTarget subpass_target = RenderTarget::CreateOffscreenMSAA(
+      *renderer.GetContext(),            // context
+      ISize(coverage.value().size),      // size
+      "SceneContents",                   // label
+      StorageMode::kDeviceTransient,     // color_storage_mode
+      StorageMode::kDevicePrivate,       // color_resolve_storage_mode
+      LoadAction::kDontCare,             // color_load_action
+      StoreAction::kMultisampleResolve,  // color_store_action
+      StorageMode::kDeviceTransient,     // stencil_storage_mode
+      LoadAction::kDontCare,             // stencil_load_action
+      StoreAction::kDontCare             // stencil_store_action
+  );
+
+  scene::Scene scene(renderer.GetSceneContext());
+  scene.GetRoot().AddChild(node_);
+
+  scene.Render(pass.GetRenderTarget(), camera_transform_);
+
+  // Render the texture to the pass.
+  TiledTextureContents final;
+  final.SetGeometry(GetGeometry());
+  final.SetTexture(subpass_target.GetRenderTargetTexture());
+  return final.Render(renderer, entity, pass);
+}
+
+}  // namespace impeller

--- a/impeller/entity/contents/scene_contents.h
+++ b/impeller/entity/contents/scene_contents.h
@@ -1,0 +1,35 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <memory>
+
+#include "impeller/entity/contents/color_source_contents.h"
+
+#include "impeller/geometry/matrix.h"
+#include "impeller/geometry/rect.h"
+#include "impeller/scene/node.h"
+
+namespace impeller {
+
+class SceneContents final : public ColorSourceContents {
+ public:
+  SceneContents();
+
+  ~SceneContents() override;
+
+  void SetCameraTransform(Matrix matrix);
+
+  void SetNode(std::shared_ptr<scene::Node> node);
+
+  // |Contents|
+  bool Render(const ContentContext& renderer,
+              const Entity& entity,
+              RenderPass& pass) const override;
+
+ private:
+  Matrix camera_transform_;
+  std::shared_ptr<scene::Node> node_;
+};
+
+}  // namespace impeller

--- a/impeller/geometry/rect.h
+++ b/impeller/geometry/rect.h
@@ -74,10 +74,10 @@ struct TRect {
   }
 
   constexpr static TRect MakeMaximum() {
-    return TRect::MakeLTRB(-std::numeric_limits<Scalar>::infinity(),
-                           -std::numeric_limits<Scalar>::infinity(),
-                           std::numeric_limits<Scalar>::infinity(),
-                           std::numeric_limits<Scalar>::infinity());
+    return TRect::MakeLTRB(-std::numeric_limits<Type>::infinity(),
+                           -std::numeric_limits<Type>::infinity(),
+                           std::numeric_limits<Type>::infinity(),
+                           std::numeric_limits<Type>::infinity());
   }
 
   template <class U>
@@ -121,6 +121,8 @@ struct TRect {
   constexpr bool IsZero() const { return size.IsZero(); }
 
   constexpr bool IsEmpty() const { return size.IsEmpty(); }
+
+  constexpr bool IsMaximum() const { return *this == MakeMaximum(); }
 
   constexpr auto GetLeft() const {
     return std::min(origin.x, origin.x + size.width);

--- a/impeller/scene/scene.cc
+++ b/impeller/scene/scene.cc
@@ -15,8 +15,8 @@
 namespace impeller {
 namespace scene {
 
-Scene::Scene(std::shared_ptr<Context> context)
-    : scene_context_(std::make_unique<SceneContext>(std::move(context))) {
+Scene::Scene(std::shared_ptr<SceneContext> scene_context)
+    : scene_context_(std::move(scene_context)) {
   root_.is_root_ = true;
 };
 
@@ -25,7 +25,7 @@ Node& Scene::GetRoot() {
 }
 
 bool Scene::Render(const RenderTarget& render_target,
-                   const Camera& camera) const {
+                   const Matrix& camera_transform) const {
   // Collect the render commands from the scene.
   SceneEncoder encoder;
   if (!root_.Render(encoder, Matrix())) {
@@ -36,7 +36,8 @@ bool Scene::Render(const RenderTarget& render_target,
   // Encode the commands.
 
   std::shared_ptr<CommandBuffer> command_buffer =
-      encoder.BuildSceneCommandBuffer(*scene_context_, camera, render_target);
+      encoder.BuildSceneCommandBuffer(*scene_context_, camera_transform,
+                                      render_target);
 
   // TODO(bdero): Do post processing.
 
@@ -46,6 +47,12 @@ bool Scene::Render(const RenderTarget& render_target,
   }
 
   return true;
+}
+
+bool Scene::Render(const RenderTarget& render_target,
+                   const Camera& camera) const {
+  return Render(render_target,
+                camera.GetTransform(render_target.GetRenderTargetSize()));
 }
 
 }  // namespace scene

--- a/impeller/scene/scene.cc
+++ b/impeller/scene/scene.cc
@@ -20,6 +20,12 @@ Scene::Scene(std::shared_ptr<SceneContext> scene_context)
   root_.is_root_ = true;
 };
 
+Scene::~Scene() {
+  for (auto& child : GetRoot().GetChildren()) {
+    child->parent_ = nullptr;
+  }
+}
+
 Node& Scene::GetRoot() {
   return root_;
 }

--- a/impeller/scene/scene.h
+++ b/impeller/scene/scene.h
@@ -20,14 +20,18 @@ namespace scene {
 class Scene {
  public:
   Scene() = delete;
-  explicit Scene(std::shared_ptr<Context> context);
+
+  explicit Scene(std::shared_ptr<SceneContext> scene_context);
 
   Node& GetRoot();
+
+  bool Render(const RenderTarget& render_target,
+              const Matrix& camera_transform) const;
 
   bool Render(const RenderTarget& render_target, const Camera& camera) const;
 
  private:
-  std::unique_ptr<SceneContext> scene_context_;
+  std::shared_ptr<SceneContext> scene_context_;
   Node root_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(Scene);

--- a/impeller/scene/scene.h
+++ b/impeller/scene/scene.h
@@ -23,6 +23,8 @@ class Scene {
 
   explicit Scene(std::shared_ptr<SceneContext> scene_context);
 
+  ~Scene();
+
   Node& GetRoot();
 
   bool Render(const RenderTarget& render_target,

--- a/impeller/scene/scene_encoder.cc
+++ b/impeller/scene/scene_encoder.cc
@@ -46,7 +46,7 @@ static void EncodeCommand(const SceneContext& scene_context,
 
 std::shared_ptr<CommandBuffer> SceneEncoder::BuildSceneCommandBuffer(
     const SceneContext& scene_context,
-    const Camera& camera,
+    const Matrix& camera_transform,
     RenderTarget render_target) const {
   {
     TextureDescriptor ds_texture;
@@ -91,9 +91,7 @@ std::shared_ptr<CommandBuffer> SceneEncoder::BuildSceneCommandBuffer(
   }
 
   for (auto& command : commands_) {
-    Matrix view_transform =
-        camera.GetTransform(render_pass->GetRenderTargetSize());
-    EncodeCommand(scene_context, view_transform, *render_pass, command);
+    EncodeCommand(scene_context, camera_transform, *render_pass, command);
   }
 
   if (!render_pass->EncodeCommands()) {

--- a/impeller/scene/scene_encoder.h
+++ b/impeller/scene/scene_encoder.h
@@ -35,7 +35,7 @@ class SceneEncoder {
 
   std::shared_ptr<CommandBuffer> BuildSceneCommandBuffer(
       const SceneContext& scene_context,
-      const Camera& camera,
+      const Matrix& camera_transform,
       RenderTarget render_target) const;
 
   std::vector<SceneCommand> commands_;

--- a/impeller/scene/scene_unittests.cc
+++ b/impeller/scene/scene_unittests.cc
@@ -33,9 +33,11 @@ using SceneTest = PlaygroundTest;
 INSTANTIATE_PLAYGROUND_SUITE(SceneTest);
 
 TEST_P(SceneTest, CuboidUnlit) {
+  auto scene_context = std::make_shared<SceneContext>(GetContext());
+
   Renderer::RenderCallback callback = [&](RenderTarget& render_target) {
     auto allocator = GetContext()->GetResourceAllocator();
-    auto scene = Scene(GetContext());
+    auto scene = Scene(scene_context);
 
     {
       Mesh mesh;
@@ -87,7 +89,8 @@ TEST_P(SceneTest, FlutterLogo) {
   gltf_scene->GetChildren()[0]->GetMesh().GetPrimitives()[0].material =
       material;
 
-  auto scene = Scene(GetContext());
+  auto scene_context = std::make_shared<SceneContext>(GetContext());
+  auto scene = Scene(scene_context);
   scene.GetRoot().AddChild(std::move(gltf_scene));
   scene.GetRoot().SetLocalTransform(Matrix::MakeScale({3, 3, 3}));
 
@@ -121,7 +124,8 @@ TEST_P(SceneTest, TwoTriangles) {
       Node::MakeFromFlatbuffer(*mapping, *allocator);
   ASSERT_NE(gltf_scene, nullptr);
 
-  auto scene = Scene(GetContext());
+  auto scene_context = std::make_shared<SceneContext>(GetContext());
+  auto scene = Scene(scene_context);
   scene.GetRoot().AddChild(std::move(gltf_scene));
 
   Renderer::RenderCallback callback = [&](RenderTarget& render_target) {

--- a/shell/platform/android/android_surface_gl_impeller.cc
+++ b/shell/platform/android/android_surface_gl_impeller.cc
@@ -5,12 +5,13 @@
 #include "flutter/shell/platform/android/android_surface_gl_impeller.h"
 
 #include "flutter/fml/logging.h"
-#include "flutter/impeller/entity/gles/entity_shaders_gles.h"
 #include "flutter/impeller/renderer/backend/gles/context_gles.h"
 #include "flutter/impeller/renderer/backend/gles/proc_table_gles.h"
 #include "flutter/impeller/toolkit/egl/context.h"
 #include "flutter/impeller/toolkit/egl/surface.h"
 #include "flutter/shell/gpu/gpu_surface_gl_impeller.h"
+#include "impeller/entity/gles/entity_shaders_gles.h"
+#include "impeller/scene/shaders/gles/scene_shaders_gles.h"
 
 namespace flutter {
 
@@ -59,6 +60,8 @@ static std::shared_ptr<impeller::Context> CreateImpellerContext(
       std::make_shared<fml::NonOwnedMapping>(
           impeller_entity_shaders_gles_data,
           impeller_entity_shaders_gles_length),
+      std::make_shared<fml::NonOwnedMapping>(
+          impeller_scene_shaders_gles_data, impeller_scene_shaders_gles_length),
   };
 
   auto context =

--- a/shell/platform/android/android_surface_vulkan_impeller.cc
+++ b/shell/platform/android/android_surface_vulkan_impeller.cc
@@ -15,6 +15,7 @@
 #include "flutter/vulkan/vulkan_native_surface_android.h"
 #include "impeller/entity/vk/entity_shaders_vk.h"
 #include "impeller/entity/vk/modern_shaders_vk.h"
+#include "impeller/scene/shaders/vk/scene_shaders_vk.h"
 
 namespace flutter {
 
@@ -24,6 +25,8 @@ std::shared_ptr<impeller::Context> CreateImpellerContext(
   std::vector<std::shared_ptr<fml::Mapping>> shader_mappings = {
       std::make_shared<fml::NonOwnedMapping>(impeller_entity_shaders_vk_data,
                                              impeller_entity_shaders_vk_length),
+      std::make_shared<fml::NonOwnedMapping>(impeller_scene_shaders_vk_data,
+                                             impeller_scene_shaders_vk_length),
       std::make_shared<fml::NonOwnedMapping>(impeller_modern_shaders_vk_data,
                                              impeller_modern_shaders_vk_length),
   };

--- a/shell/platform/darwin/graphics/FlutterDarwinContextMetalImpeller.mm
+++ b/shell/platform/darwin/graphics/FlutterDarwinContextMetalImpeller.mm
@@ -6,11 +6,12 @@
 
 #include "flutter/common/graphics/persistent_cache.h"
 #include "flutter/fml/logging.h"
-#include "flutter/impeller/entity/mtl/entity_shaders.h"
 #include "flutter/impeller/renderer/backend/metal/context_mtl.h"
 #include "flutter/shell/common/context_options.h"
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterMacros.h"
+#include "impeller/entity/mtl/entity_shaders.h"
 #include "impeller/entity/mtl/modern_shaders.h"
+#include "impeller/scene/shaders/mtl/scene_shaders.h"
 
 FLUTTER_ASSERT_ARC
 
@@ -18,6 +19,8 @@ static std::shared_ptr<impeller::ContextMTL> CreateImpellerContext() {
   std::vector<std::shared_ptr<fml::Mapping>> shader_mappings = {
       std::make_shared<fml::NonOwnedMapping>(impeller_entity_shaders_data,
                                              impeller_entity_shaders_length),
+      std::make_shared<fml::NonOwnedMapping>(impeller_scene_shaders_data,
+                                             impeller_scene_shaders_length),
       std::make_shared<fml::NonOwnedMapping>(impeller_modern_shaders_data,
                                              impeller_modern_shaders_length),
   };


### PR DESCRIPTION
This adds a `ColorSourceContents` which renders an Impeller Scene to a texture and blits it to the current layer respecting the geometry, blend mode, and clip stack.

I also added commented code in the display list dispatcher that can be uncommented once the `DlSceneColorSource` has been implemented.