### PR TITLE
[fuchsia] Set presentation end times based on Flatland feedback

### DIFF
--- a/shell/platform/fuchsia/flutter/flatland_connection.h
+++ b/shell/platform/fuchsia/flutter/flatland_connection.h
@@ -10,6 +10,7 @@
 #include "flutter/fml/closure.h"
 #include "flutter/fml/macros.h"
 #include "flutter/fml/time/time_delta.h"
+#include "flutter/fml/time/time_point.h"
 
 #include "vsync_waiter.h"
 
@@ -22,9 +23,10 @@ namespace flutter_runner {
 using on_frame_presented_event =
     std::function<void(fuchsia::scenic::scheduling::FramePresentedInfo)>;
 
-// Set to zero for now for maximum simplicity until we have real values.
+// 2ms interval to target vsync is only used until Scenic sends presentation
+// feedback, or when we run out of present credits.
 static constexpr fml::TimeDelta kDefaultFlatlandPresentationInterval =
-    fml::TimeDelta::FromSecondsF(0);
+    fml::TimeDelta::FromMilliseconds(2);
 
 // The component residing on the raster thread that is responsible for
 // maintaining the Flatland instance connection and presenting updates.
@@ -87,6 +89,7 @@ class FlatlandConnection final {
     FireCallbackCallback fire_callback_;
     bool fire_callback_pending_ = false;
     bool first_present_called_ = false;
+    fml::TimePoint next_presentation_time_;
   } threadsafe_state_;
 
   std::vector<zx::event> acquire_fences_;

--- a/shell/platform/fuchsia/flutter/tests/flatland_external_view_embedder_unittests.cc
+++ b/shell/platform/fuchsia/flutter/tests/flatland_external_view_embedder_unittests.cc
@@ -300,8 +300,12 @@ Matcher<std::shared_ptr<FakeTransform>> IsClipTransformLayer(
 fuchsia::ui::composition::OnNextFrameBeginValues WithPresentCredits(
     uint32_t additional_present_credits) {
   fuchsia::ui::composition::OnNextFrameBeginValues values;
-
   values.set_additional_present_credits(additional_present_credits);
+  fuchsia::scenic::scheduling::PresentationInfo info_1;
+  info_1.set_presentation_time(123);
+  std::vector<fuchsia::scenic::scheduling::PresentationInfo> infos;
+  infos.push_back(std::move(info_1));
+  values.set_future_presentation_infos(std::move(infos));
   return values;
 }
 


### PR DESCRIPTION
This CL processes the Flatland's presentation callback to set the correct Vsync times for frame end.

Bug: fxb/114588