### PR TITLE
[Impeller Scene] Import skinned mesh vertex data

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -4094,6 +4094,7 @@ FILE: ../../../flutter/impeller/scene/scene_context.cc
 FILE: ../../../flutter/impeller/scene/scene_context.h
 FILE: ../../../flutter/impeller/scene/scene_encoder.cc
 FILE: ../../../flutter/impeller/scene/scene_encoder.h
+FILE: ../../../flutter/impeller/scene/shaders/skinned.vert
 FILE: ../../../flutter/impeller/scene/shaders/unlit.frag
 FILE: ../../../flutter/impeller/scene/shaders/unskinned.vert
 FILE: ../../../flutter/impeller/tessellator/c/tessellator.cc

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1635,6 +1635,7 @@ ORIGIN: ../../../flutter/impeller/scene/scene_context.cc + ../../../flutter/LICE
 ORIGIN: ../../../flutter/impeller/scene/scene_context.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/scene/scene_encoder.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/scene/scene_encoder.h + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/impeller/scene/shaders/skinned.vert + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/scene/shaders/unlit.frag + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/scene/shaders/unskinned.vert + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/tessellator/c/tessellator.cc + ../../../flutter/LICENSE

--- a/impeller/scene/geometry.h
+++ b/impeller/scene/geometry.h
@@ -22,7 +22,7 @@ namespace impeller {
 namespace scene {
 
 class CuboidGeometry;
-class VertexBufferGeometry;
+class UnskinnedVertexBufferGeometry;
 
 class Geometry {
  public:
@@ -30,10 +30,10 @@ class Geometry {
 
   static std::shared_ptr<CuboidGeometry> MakeCuboid(Vector3 size);
 
-  static std::shared_ptr<VertexBufferGeometry> MakeVertexBuffer(
-      VertexBuffer vertex_buffer);
+  static std::shared_ptr<Geometry> MakeVertexBuffer(VertexBuffer vertex_buffer,
+                                                    bool is_skinned);
 
-  static std::shared_ptr<VertexBufferGeometry> MakeFromFlatbuffer(
+  static std::shared_ptr<Geometry> MakeFromFlatbuffer(
       const fb::MeshPrimitive& mesh,
       Allocator& allocator);
 
@@ -73,11 +73,11 @@ class CuboidGeometry final : public Geometry {
   FML_DISALLOW_COPY_AND_ASSIGN(CuboidGeometry);
 };
 
-class VertexBufferGeometry final : public Geometry {
+class UnskinnedVertexBufferGeometry final : public Geometry {
  public:
-  VertexBufferGeometry();
+  UnskinnedVertexBufferGeometry();
 
-  ~VertexBufferGeometry() override;
+  ~UnskinnedVertexBufferGeometry() override;
 
   void SetVertexBuffer(VertexBuffer vertex_buffer);
 
@@ -96,7 +96,33 @@ class VertexBufferGeometry final : public Geometry {
  private:
   VertexBuffer vertex_buffer_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(VertexBufferGeometry);
+  FML_DISALLOW_COPY_AND_ASSIGN(UnskinnedVertexBufferGeometry);
+};
+
+class SkinnedVertexBufferGeometry final : public Geometry {
+ public:
+  SkinnedVertexBufferGeometry();
+
+  ~SkinnedVertexBufferGeometry() override;
+
+  void SetVertexBuffer(VertexBuffer vertex_buffer);
+
+  // |Geometry|
+  GeometryType GetGeometryType() const override;
+
+  // |Geometry|
+  VertexBuffer GetVertexBuffer(Allocator& allocator) const override;
+
+  // |Geometry|
+  void BindToCommand(const SceneContext& scene_context,
+                     HostBuffer& buffer,
+                     const Matrix& transform,
+                     Command& command) const override;
+
+ private:
+  VertexBuffer vertex_buffer_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(SkinnedVertexBufferGeometry);
 };
 
 }  // namespace scene

--- a/impeller/scene/importer/vertices_builder.cc
+++ b/impeller/scene/importer/vertices_builder.cc
@@ -17,29 +17,36 @@ namespace impeller {
 namespace scene {
 namespace importer {
 
-VerticesBuilder::VerticesBuilder() = default;
+//------------------------------------------------------------------------------
+/// VerticesBuilder
+///
 
-void VerticesBuilder::WriteFBVertices(fb::MeshPrimitiveT& primitive) const {
-  auto vertex_buffer = fb::UnskinnedVertexBufferT();
-  vertex_buffer.vertices.resize(0);
-  for (auto& v : vertices_) {
-    vertex_buffer.vertices.push_back(fb::Vertex(
-        ToFBVec3(v.position), ToFBVec3(v.normal), ToFBVec4(v.tangent),
-        ToFBVec2(v.texture_coords), ToFBColor(v.color)));
-  }
-  primitive.vertices.Set(std::move(vertex_buffer));
+std::unique_ptr<VerticesBuilder> VerticesBuilder::MakeUnskinned() {
+  return std::make_unique<UnskinnedVerticesBuilder>();
 }
 
+std::unique_ptr<VerticesBuilder> VerticesBuilder::MakeSkinned() {
+  return std::make_unique<SkinnedVerticesBuilder>();
+}
+
+VerticesBuilder::VerticesBuilder() = default;
+
+VerticesBuilder::~VerticesBuilder() = default;
+
 /// @brief  Reads a numeric component from `source` and returns a 32bit float.
-///         Signed SourceTypes convert to a range of -1 to 1, and unsigned
-///         SourceTypes convert to a range of 0 to 1.
+///         If `normalized` is `true`, signed SourceTypes convert to a range of
+///         -1 to 1, and unsigned SourceTypes convert to a range of 0 to 1.
 template <typename SourceType>
-static Scalar ToNormalizedScalar(const void* source, size_t index) {
-  constexpr SourceType divisor = std::is_integral_v<SourceType>
-                                     ? std::numeric_limits<SourceType>::max()
-                                     : 1;
+static Scalar ToScalar(const void* source, size_t index, bool normalized) {
   const SourceType* s = reinterpret_cast<const SourceType*>(source) + index;
-  return static_cast<Scalar>(*s) / static_cast<Scalar>(divisor);
+  Scalar result = static_cast<Scalar>(*s);
+  if (normalized) {
+    constexpr SourceType divisor = std::is_integral_v<SourceType>
+                                       ? std::numeric_limits<SourceType>::max()
+                                       : 1;
+    result = static_cast<Scalar>(*s) / static_cast<Scalar>(divisor);
+  }
+  return result;
 }
 
 /// @brief  A ComponentWriter which simply converts all of an attribute's
@@ -53,7 +60,8 @@ static void PassthroughAttributeWriter(
              attribute.component_count * sizeof(Scalar));
   for (size_t component_i = 0; component_i < attribute.component_count;
        component_i++) {
-    *(destination + component_i) = component.convert_proc(source, component_i);
+    *(destination + component_i) =
+        component.convert_proc(source, component_i, true);
   }
 }
 
@@ -65,85 +73,179 @@ static void PositionAttributeWriter(
     const VerticesBuilder::ComponentProperties& component,
     const VerticesBuilder::AttributeProperties& attribute) {
   FML_DCHECK(attribute.component_count == 3);
-  *(destination + 0) = component.convert_proc(source, 0);
-  *(destination + 1) = component.convert_proc(source, 1);
-  *(destination + 2) = -component.convert_proc(source, 2);
+  *(destination + 0) = component.convert_proc(source, 0, true);
+  *(destination + 1) = component.convert_proc(source, 1, true);
+  *(destination + 2) = -component.convert_proc(source, 2, true);
+}
+
+/// @brief  A ComponentWriter which converts four vertex indices to scalars.
+static void JointsAttributeWriter(
+    Scalar* destination,
+    const void* source,
+    const VerticesBuilder::ComponentProperties& component,
+    const VerticesBuilder::AttributeProperties& attribute) {
+  FML_DCHECK(attribute.component_count == 4);
+  for (int i = 0; i < 4; i++) {
+    *(destination + i) = component.convert_proc(source, i, false);
+  }
 }
 
 std::map<VerticesBuilder::AttributeType, VerticesBuilder::AttributeProperties>
     VerticesBuilder::kAttributeTypes = {
         {VerticesBuilder::AttributeType::kPosition,
-         {.offset_bytes = offsetof(Vertex, position),
-          .size_bytes = sizeof(Vertex::position),
+         {.offset_bytes = offsetof(UnskinnedVerticesBuilder::Vertex, position),
+          .size_bytes = sizeof(UnskinnedVerticesBuilder::Vertex::position),
           .component_count = 3,
           .write_proc = PositionAttributeWriter}},
         {VerticesBuilder::AttributeType::kNormal,
-         {.offset_bytes = offsetof(Vertex, normal),
-          .size_bytes = sizeof(Vertex::normal),
+         {.offset_bytes = offsetof(UnskinnedVerticesBuilder::Vertex, normal),
+          .size_bytes = sizeof(UnskinnedVerticesBuilder::Vertex::normal),
           .component_count = 3,
           .write_proc = PassthroughAttributeWriter}},
         {VerticesBuilder::AttributeType::kTangent,
-         {.offset_bytes = offsetof(Vertex, tangent),
-          .size_bytes = sizeof(Vertex::tangent),
+         {.offset_bytes = offsetof(UnskinnedVerticesBuilder::Vertex, tangent),
+          .size_bytes = sizeof(UnskinnedVerticesBuilder::Vertex::tangent),
           .component_count = 4,
           .write_proc = PassthroughAttributeWriter}},
         {VerticesBuilder::AttributeType::kTextureCoords,
-         {.offset_bytes = offsetof(Vertex, texture_coords),
-          .size_bytes = sizeof(Vertex::texture_coords),
+         {.offset_bytes =
+              offsetof(UnskinnedVerticesBuilder::Vertex, texture_coords),
+          .size_bytes =
+              sizeof(UnskinnedVerticesBuilder::Vertex::texture_coords),
           .component_count = 2,
           .write_proc = PassthroughAttributeWriter}},
         {VerticesBuilder::AttributeType::kColor,
-         {.offset_bytes = offsetof(Vertex, color),
-          .size_bytes = sizeof(Vertex::color),
+         {.offset_bytes = offsetof(UnskinnedVerticesBuilder::Vertex, color),
+          .size_bytes = sizeof(UnskinnedVerticesBuilder::Vertex::color),
           .component_count = 4,
-          .write_proc = PassthroughAttributeWriter}}};
+          .write_proc = PassthroughAttributeWriter}},
+        {VerticesBuilder::AttributeType::kJoints,
+         {.offset_bytes = offsetof(SkinnedVerticesBuilder::Vertex, joints),
+          .size_bytes = sizeof(SkinnedVerticesBuilder::Vertex::joints),
+          .component_count = 4,
+          .write_proc = JointsAttributeWriter}},
+        {VerticesBuilder::AttributeType::kWeights,
+         {.offset_bytes = offsetof(SkinnedVerticesBuilder::Vertex, weights),
+          .size_bytes = sizeof(SkinnedVerticesBuilder::Vertex::weights),
+          .component_count = 4,
+          .write_proc = JointsAttributeWriter}}};
 
 static std::map<VerticesBuilder::ComponentType,
                 VerticesBuilder::ComponentProperties>
     kComponentTypes = {
         {VerticesBuilder::ComponentType::kSignedByte,
-         {.size_bytes = sizeof(int8_t),
-          .convert_proc = ToNormalizedScalar<int8_t>}},
+         {.size_bytes = sizeof(int8_t), .convert_proc = ToScalar<int8_t>}},
         {VerticesBuilder::ComponentType::kUnsignedByte,
-         {.size_bytes = sizeof(int8_t),
-          .convert_proc = ToNormalizedScalar<uint8_t>}},
+         {.size_bytes = sizeof(int8_t), .convert_proc = ToScalar<uint8_t>}},
         {VerticesBuilder::ComponentType::kSignedShort,
-         {.size_bytes = sizeof(int16_t),
-          .convert_proc = ToNormalizedScalar<int16_t>}},
+         {.size_bytes = sizeof(int16_t), .convert_proc = ToScalar<int16_t>}},
         {VerticesBuilder::ComponentType::kUnsignedShort,
-         {.size_bytes = sizeof(int16_t),
-          .convert_proc = ToNormalizedScalar<uint16_t>}},
+         {.size_bytes = sizeof(int16_t), .convert_proc = ToScalar<uint16_t>}},
         {VerticesBuilder::ComponentType::kSignedInt,
-         {.size_bytes = sizeof(int32_t),
-          .convert_proc = ToNormalizedScalar<int32_t>}},
+         {.size_bytes = sizeof(int32_t), .convert_proc = ToScalar<int32_t>}},
         {VerticesBuilder::ComponentType::kUnsignedInt,
-         {.size_bytes = sizeof(int32_t),
-          .convert_proc = ToNormalizedScalar<uint32_t>}},
+         {.size_bytes = sizeof(int32_t), .convert_proc = ToScalar<uint32_t>}},
         {VerticesBuilder::ComponentType::kFloat,
-         {.size_bytes = sizeof(float),
-          .convert_proc = ToNormalizedScalar<float>}},
+         {.size_bytes = sizeof(float), .convert_proc = ToScalar<float>}},
 };
 
-void VerticesBuilder::SetAttributeFromBuffer(AttributeType attribute,
-                                             ComponentType component_type,
-                                             const void* buffer_start,
-                                             size_t attribute_stride_bytes,
-                                             size_t attribute_count) {
-  if (attribute_count > vertices_.size()) {
-    vertices_.resize(attribute_count, Vertex());
-  }
-
+void VerticesBuilder::WriteAttribute(void* destination,
+                                     size_t destination_stride_bytes,
+                                     AttributeType attribute,
+                                     ComponentType component_type,
+                                     const void* source,
+                                     size_t attribute_stride_bytes,
+                                     size_t attribute_count) {
   const ComponentProperties& component_props = kComponentTypes[component_type];
   const AttributeProperties& attribute_props = kAttributeTypes[attribute];
   for (size_t i = 0; i < attribute_count; i++) {
-    const uint8_t* source = reinterpret_cast<const uint8_t*>(buffer_start) +
-                            attribute_stride_bytes * i;
-    uint8_t* destination = reinterpret_cast<uint8_t*>(&vertices_.data()[i]) +
-                           attribute_props.offset_bytes;
+    const uint8_t* src =
+        reinterpret_cast<const uint8_t*>(source) + attribute_stride_bytes * i;
+    uint8_t* dst = reinterpret_cast<uint8_t*>(destination) +
+                   i * destination_stride_bytes + attribute_props.offset_bytes;
 
-    attribute_props.write_proc(reinterpret_cast<Scalar*>(destination), source,
+    attribute_props.write_proc(reinterpret_cast<Scalar*>(dst), src,
                                component_props, attribute_props);
   }
+}
+
+//------------------------------------------------------------------------------
+/// UnskinnedVerticesBuilder
+///
+
+UnskinnedVerticesBuilder::UnskinnedVerticesBuilder() = default;
+
+UnskinnedVerticesBuilder::~UnskinnedVerticesBuilder() = default;
+
+void UnskinnedVerticesBuilder::WriteFBVertices(
+    fb::MeshPrimitiveT& primitive) const {
+  auto vertex_buffer = fb::UnskinnedVertexBufferT();
+  vertex_buffer.vertices.resize(0);
+  for (auto& v : vertices_) {
+    vertex_buffer.vertices.push_back(fb::Vertex(
+        ToFBVec3(v.position), ToFBVec3(v.normal), ToFBVec4(v.tangent),
+        ToFBVec2(v.texture_coords), ToFBColor(v.color)));
+  }
+  primitive.vertices.Set(std::move(vertex_buffer));
+}
+
+void UnskinnedVerticesBuilder::SetAttributeFromBuffer(
+    AttributeType attribute,
+    ComponentType component_type,
+    const void* buffer_start,
+    size_t attribute_stride_bytes,
+    size_t attribute_count) {
+  if (attribute_count > vertices_.size()) {
+    vertices_.resize(attribute_count, Vertex());
+  }
+  WriteAttribute(vertices_.data(),        // destination
+                 sizeof(Vertex),          // destination_stride_bytes
+                 attribute,               // attribute
+                 component_type,          // component_type
+                 buffer_start,            // source
+                 attribute_stride_bytes,  // attribute_stride_bytes
+                 attribute_count);        // attribute_count
+}
+
+//------------------------------------------------------------------------------
+/// SkinnedVerticesBuilder
+///
+
+SkinnedVerticesBuilder::SkinnedVerticesBuilder() = default;
+
+SkinnedVerticesBuilder::~SkinnedVerticesBuilder() = default;
+
+void SkinnedVerticesBuilder::WriteFBVertices(
+    fb::MeshPrimitiveT& primitive) const {
+  auto vertex_buffer = fb::SkinnedVertexBufferT();
+  vertex_buffer.vertices.resize(0);
+  for (auto& v : vertices_) {
+    auto unskinned_attributes = fb::Vertex(
+        ToFBVec3(v.vertex.position), ToFBVec3(v.vertex.normal),
+        ToFBVec4(v.vertex.tangent), ToFBVec2(v.vertex.texture_coords),
+        ToFBColor(v.vertex.color));
+    vertex_buffer.vertices.push_back(fb::SkinnedVertex(
+        unskinned_attributes, ToFBVec4(v.joints), ToFBVec4(v.weights)));
+  }
+  primitive.vertices.Set(std::move(vertex_buffer));
+}
+
+void SkinnedVerticesBuilder::SetAttributeFromBuffer(
+    AttributeType attribute,
+    ComponentType component_type,
+    const void* buffer_start,
+    size_t attribute_stride_bytes,
+    size_t attribute_count) {
+  if (attribute_count > vertices_.size()) {
+    vertices_.resize(attribute_count, Vertex());
+  }
+  WriteAttribute(vertices_.data(),        // destination
+                 sizeof(Vertex),          // destination_stride_bytes
+                 attribute,               // attribute
+                 component_type,          // component_type
+                 buffer_start,            // source
+                 attribute_stride_bytes,  // attribute_stride_bytes
+                 attribute_count);        // attribute_count
 }
 
 }  // namespace importer

--- a/impeller/scene/pipeline_key.h
+++ b/impeller/scene/pipeline_key.h
@@ -11,7 +11,8 @@ namespace scene {
 
 enum class GeometryType {
   kUnskinned = 0,
-  kLastType = kUnskinned,
+  kSkinned = 1,
+  kLastType = kSkinned,
 };
 enum class MaterialType {
   kUnlit = 0,

--- a/impeller/scene/scene_context.cc
+++ b/impeller/scene/scene_context.cc
@@ -5,6 +5,7 @@
 #include "impeller/scene/scene_context.h"
 #include "impeller/renderer/formats.h"
 #include "impeller/scene/material.h"
+#include "impeller/scene/shaders/skinned.vert.h"
 #include "impeller/scene/shaders/unlit.frag.h"
 #include "impeller/scene/shaders/unskinned.vert.h"
 
@@ -38,6 +39,8 @@ SceneContext::SceneContext(std::shared_ptr<Context> context)
   pipelines_[{PipelineKey{GeometryType::kUnskinned, MaterialType::kUnlit}}] =
       MakePipelineVariants<UnskinnedVertexShader, UnlitFragmentShader>(
           *context_);
+  pipelines_[{PipelineKey{GeometryType::kSkinned, MaterialType::kUnlit}}] =
+      MakePipelineVariants<SkinnedVertexShader, UnlitFragmentShader>(*context_);
 
   {
     impeller::TextureDescriptor texture_descriptor;

--- a/impeller/scene/shaders/BUILD.gn
+++ b/impeller/scene/shaders/BUILD.gn
@@ -8,6 +8,7 @@ impeller_shaders("shaders") {
   name = "scene"
 
   shaders = [
+    "skinned.vert",
     "unskinned.vert",
     "unlit.frag",
   ]

--- a/impeller/scene/shaders/skinned.vert
+++ b/impeller/scene/shaders/skinned.vert
@@ -1,0 +1,40 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+uniform VertInfo {
+  mat4 mvp;
+}
+vert_info;
+
+// This attribute layout is expected to be identical to `SkinnedVertex` within
+// `impeller/scene/importer/scene.fbs`.
+in vec3 position;
+in vec3 normal;
+in vec4 tangent;
+in vec2 texture_coords;
+in vec4 color;
+// TODO(bdero): Use the joint indices to sample bone matrices from a texture.
+in vec4 joints;
+in vec4 weights;
+
+out vec3 v_position;
+out mat3 v_tangent_space;
+out vec2 v_texture_coords;
+out vec4 v_color;
+
+void main() {
+  // The following two lines are temporary placeholders to prevent the vertex
+  // attributes from being removed from the shader.
+  v_color = joints;
+  v_color = weights;
+
+  gl_Position = vert_info.mvp * vec4(position, 1.0);
+  v_position = gl_Position.xyz;
+
+  vec3 lh_tangent = tangent.xyz * tangent.w;
+  v_tangent_space =
+      mat3(vert_info.mvp) * mat3(lh_tangent, cross(normal, lh_tangent), normal);
+  v_texture_coords = texture_coords;
+  v_color = color;
+}


### PR DESCRIPTION
Imports joint indices and weights and serves skinned mesh primitives through a placeholder vertex shader. I'll be adding skin import/joint sampling in a later patch.

A fun bug along the way:

https://user-images.githubusercontent.com/919017/209919475-36e1478d-ae5e-448f-a821-92311d7d3d77.mov

