### PR TITLE
[fuchsia] Add trace flow for Flatland::Present

### DIFF
--- a/shell/platform/fuchsia/flutter/flatland_connection.cc
+++ b/shell/platform/fuchsia/flutter/flatland_connection.cc
@@ -7,6 +7,7 @@
 #include <zircon/status.h>
 
 #include "flutter/fml/logging.h"
+#include "flutter/fml/trace_event.h"
 
 namespace flutter_runner {
 
@@ -61,6 +62,10 @@ void FlatlandConnection::Present() {
 
 // This method is called from the raster thread.
 void FlatlandConnection::DoPresent() {
+  TRACE_DURATION("flutter", "FlatlandConnection::DoPresent");
+  TRACE_FLOW_BEGIN("gfx", "Flatland::Present", next_present_trace_id_);
+  ++next_present_trace_id_;
+
   FML_CHECK(present_credits_ > 0);
   --present_credits_;
 

--- a/shell/platform/fuchsia/flutter/flatland_connection.h
+++ b/shell/platform/fuchsia/flutter/flatland_connection.h
@@ -81,6 +81,9 @@ class FlatlandConnection final {
   uint32_t present_credits_ = 1;
   bool present_pending_ = false;
 
+  // A flow event trace id for following |Flatland::Present| calls into Scenic.
+  uint64_t next_present_trace_id_ = 0;
+
   // This struct contains state that is accessed from both from the UI thread
   // (in AwaitVsync) and the raster thread (in OnNextFrameBegin and Present).
   // You should always lock mutex_ before touching anything in this struct


### PR DESCRIPTION
This CL adds a trace flow event that starts from Flutter and ends at Scenic.