### PR TITLE
[Impeller Scene] Animation binding and playback

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1607,6 +1607,14 @@ ORIGIN: ../../../flutter/impeller/runtime_stage/runtime_stage_playground.cc + ..
 ORIGIN: ../../../flutter/impeller/runtime_stage/runtime_stage_playground.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/runtime_stage/runtime_types.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/runtime_stage/runtime_types.h + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/impeller/scene/animation/animation.cc + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/impeller/scene/animation/animation.h + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/impeller/scene/animation/animation_clip.cc + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/impeller/scene/animation/animation_clip.h + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/impeller/scene/animation/animation_player.cc + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/impeller/scene/animation/animation_player.h + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/impeller/scene/animation/property_resolver.cc + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/impeller/scene/animation/property_resolver.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/scene/camera.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/scene/camera.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/scene/geometry.cc + ../../../flutter/LICENSE
@@ -4067,6 +4075,14 @@ FILE: ../../../flutter/impeller/runtime_stage/runtime_stage_playground.cc
 FILE: ../../../flutter/impeller/runtime_stage/runtime_stage_playground.h
 FILE: ../../../flutter/impeller/runtime_stage/runtime_types.cc
 FILE: ../../../flutter/impeller/runtime_stage/runtime_types.h
+FILE: ../../../flutter/impeller/scene/animation/animation.cc
+FILE: ../../../flutter/impeller/scene/animation/animation.h
+FILE: ../../../flutter/impeller/scene/animation/animation_clip.cc
+FILE: ../../../flutter/impeller/scene/animation/animation_clip.h
+FILE: ../../../flutter/impeller/scene/animation/animation_player.cc
+FILE: ../../../flutter/impeller/scene/animation/animation_player.h
+FILE: ../../../flutter/impeller/scene/animation/property_resolver.cc
+FILE: ../../../flutter/impeller/scene/animation/property_resolver.h
 FILE: ../../../flutter/impeller/scene/camera.cc
 FILE: ../../../flutter/impeller/scene/camera.h
 FILE: ../../../flutter/impeller/scene/geometry.cc

--- a/impeller/scene/BUILD.gn
+++ b/impeller/scene/BUILD.gn
@@ -6,6 +6,14 @@ import("//flutter/impeller/tools/impeller.gni")
 
 impeller_component("scene") {
   sources = [
+    "animation/animation.cc",
+    "animation/animation.h",
+    "animation/animation_clip.cc",
+    "animation/animation_clip.h",
+    "animation/animation_player.cc",
+    "animation/animation_player.h",
+    "animation/property_resolver.cc",
+    "animation/property_resolver.h",
     "camera.cc",
     "camera.h",
     "geometry.cc",

--- a/impeller/scene/animation/animation.cc
+++ b/impeller/scene/animation/animation.cc
@@ -1,0 +1,125 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/scene/animation/animation.h"
+
+#include <algorithm>
+#include <cstring>
+#include <memory>
+#include <vector>
+
+#include "impeller/geometry/quaternion.h"
+#include "impeller/scene/importer/scene_flatbuffers.h"
+#include "impeller/scene/node.h"
+
+namespace impeller {
+namespace scene {
+
+std::shared_ptr<Animation> Animation::MakeFromFlatbuffer(
+    const fb::Animation& animation,
+    const std::vector<std::shared_ptr<Node>>& scene_nodes) {
+  auto result = std::shared_ptr<Animation>(new Animation());
+
+  result->name_ = animation.name()->str();
+  for (auto channel : *animation.channels()) {
+    if (channel->node() < 0 ||
+        static_cast<size_t>(channel->node()) >= scene_nodes.size() ||
+        !channel->timeline()) {
+      continue;
+    }
+
+    Animation::Channel out_channel;
+    out_channel.bind_target.node_name = scene_nodes[channel->node()]->GetName();
+
+    auto* times = channel->timeline();
+    std::vector<Scalar> out_times;
+    out_times.resize(channel->timeline()->size());
+    std::copy(times->begin(), times->end(), out_times.begin());
+
+    // TODO(bdero): Why are the entries in the keyframe value arrays not
+    //              contiguous in the flatbuffer? We should be able to get rid
+    //              of the subloops below and just memcpy instead.
+    switch (channel->keyframes_type()) {
+      case fb::Keyframes::TranslationKeyframes: {
+        out_channel.bind_target.property = Animation::Property::kTranslation;
+        auto* keyframes = channel->keyframes_as_TranslationKeyframes();
+        if (!keyframes->values()) {
+          continue;
+        }
+        std::vector<Vector3> out_values;
+        out_values.resize(keyframes->values()->size());
+        for (size_t value_i = 0; value_i < keyframes->values()->size();
+             value_i++) {
+          auto val = (*keyframes->values())[value_i];
+          out_values[value_i] = Vector3(val->x(), val->y(), val->z());
+        }
+        out_channel.resolver = PropertyResolver::MakeTranslationTimeline(
+            std::move(out_times), std::move(out_values));
+        break;
+      }
+      case fb::Keyframes::RotationKeyframes: {
+        out_channel.bind_target.property = Animation::Property::kRotation;
+        auto* keyframes = channel->keyframes_as_RotationKeyframes();
+        if (!keyframes->values()) {
+          continue;
+        }
+        std::vector<Quaternion> out_values;
+        out_values.resize(keyframes->values()->size());
+        for (size_t value_i = 0; value_i < keyframes->values()->size();
+             value_i++) {
+          auto val = (*keyframes->values())[value_i];
+          out_values[value_i] =
+              Quaternion(val->x(), val->y(), val->z(), val->w());
+        }
+        out_channel.resolver = PropertyResolver::MakeRotationTimeline(
+            std::move(out_times), std::move(out_values));
+        break;
+      }
+      case fb::Keyframes::ScaleKeyframes: {
+        out_channel.bind_target.property = Animation::Property::kScale;
+        auto* keyframes = channel->keyframes_as_ScaleKeyframes();
+        if (!keyframes->values()) {
+          continue;
+        }
+        std::vector<Vector3> out_values;
+        out_values.resize(keyframes->values()->size());
+        for (size_t value_i = 0; value_i < keyframes->values()->size();
+             value_i++) {
+          auto val = (*keyframes->values())[value_i];
+          out_values[value_i] = Vector3(val->x(), val->y(), val->z());
+        }
+        out_channel.resolver = PropertyResolver::MakeScaleTimeline(
+            std::move(out_times), std::move(out_values));
+        break;
+      }
+      case fb::Keyframes::NONE:
+        continue;
+    }
+
+    result->end_time_ =
+        std::max(result->end_time_, out_channel.resolver->GetEndTime());
+    result->channels_.push_back(std::move(out_channel));
+  }
+
+  return result;
+}
+
+Animation::Animation() = default;
+
+Animation::~Animation() = default;
+
+const std::string& Animation::GetName() const {
+  return name_;
+}
+
+const std::vector<Animation::Channel>& Animation::GetChannels() const {
+  return channels_;
+}
+
+Scalar Animation::GetEndTime() const {
+  return end_time_;
+}
+
+}  // namespace scene
+}  // namespace impeller

--- a/impeller/scene/animation/animation_clip.cc
+++ b/impeller/scene/animation/animation_clip.cc
@@ -1,0 +1,136 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/scene/animation/animation_clip.h"
+
+#include <algorithm>
+#include <cmath>
+#include <memory>
+#include <valarray>
+
+#include "impeller/scene/node.h"
+
+namespace impeller {
+namespace scene {
+
+AnimationClip::AnimationClip(std::shared_ptr<Animation> animation,
+                             Node* bind_target)
+    : animation_(std::move(animation)) {
+  BindToTarget(bind_target);
+}
+
+AnimationClip::~AnimationClip() = default;
+
+AnimationClip::AnimationClip(AnimationClip&&) = default;
+AnimationClip& AnimationClip::operator=(AnimationClip&&) = default;
+
+bool AnimationClip::IsPlaying() const {
+  return playing_;
+}
+
+void AnimationClip::SetPlaying(bool playing) {
+  playing_ = playing;
+}
+
+void AnimationClip::Play() {
+  SetPlaying(true);
+}
+
+void AnimationClip::Pause() {
+  SetPlaying(false);
+}
+
+void AnimationClip::Stop() {
+  SetPlaying(false);
+  Seek(0);
+}
+
+bool AnimationClip::GetLoop() const {
+  return loop_;
+}
+
+void AnimationClip::SetLoop(bool looping) {
+  loop_ = looping;
+}
+
+Scalar AnimationClip::GetPlaybackSpeed() const {
+  return playback_speed_;
+}
+
+void AnimationClip::SetPlaybackSpeed(Scalar playback_speed) {
+  playback_speed_ = playback_speed;
+}
+
+Scalar AnimationClip::GetWeight() const {
+  return weight_;
+}
+
+void AnimationClip::SetWeight(Scalar weight) {
+  weight_ = weight;
+}
+
+Scalar AnimationClip::GetPlaybackTime() const {
+  return playback_time_;
+}
+
+void AnimationClip::Seek(Scalar time) {
+  playback_time_ = std::clamp(time, 0.0f, animation_->GetEndTime());
+}
+
+void AnimationClip::Advance(Scalar delta_time) {
+  if (!playing_ || delta_time <= 0) {
+    return;
+  }
+  delta_time *= playback_speed_;
+  playback_time_ += delta_time;
+
+  /// Handle looping behavior.
+
+  Scalar end_time = animation_->GetEndTime();
+  if (end_time == 0) {
+    playback_time_ = 0;
+    return;
+  }
+  if (!loop_ && (playback_time_ < 0 || playback_time_ > end_time)) {
+    // If looping is disabled, clamp to the end (or beginning, if playing in
+    // reverse) and pause.
+    Pause();
+    playback_time_ = std::clamp(playback_time_, 0.0f, end_time);
+  } else if (/* loop && */ playback_time_ > end_time) {
+    // If looping is enabled and we ran off the end, loop to the beginning.
+    playback_time_ = std::fmod(std::abs(playback_time_), end_time);
+  } else if (/* loop && */ playback_time_ < 0) {
+    // If looping is enabled and we ran off the beginning, loop to the end.
+    playback_time_ = end_time - std::fmod(std::abs(playback_time_), end_time);
+  }
+}
+
+void AnimationClip::ApplyToBindings() const {
+  for (auto& binding : bindings_) {
+    binding.channel.resolver->Apply(*binding.node, playback_time_, weight_);
+  }
+}
+
+void AnimationClip::BindToTarget(Node* node) {
+  const auto& channels = animation_->GetChannels();
+  bindings_.clear();
+  bindings_.reserve(channels.size());
+
+  for (const auto& channel : channels) {
+    Node* channel_target;
+    if (channel.bind_target.node_name == node->GetName()) {
+      channel_target = node;
+    } else if (auto result =
+                   node->FindChildByName(channel.bind_target.node_name, true)) {
+      channel_target = result.get();
+    } else {
+      continue;
+    }
+    bindings_.push_back(
+        ChannelBinding{.channel = channel, .node = channel_target});
+  }
+}
+
+}  // namespace scene
+}  // namespace impeller

--- a/impeller/scene/animation/animation_clip.cc
+++ b/impeller/scene/animation/animation_clip.cc
@@ -54,12 +54,12 @@ void AnimationClip::SetLoop(bool looping) {
   loop_ = looping;
 }
 
-Scalar AnimationClip::GetPlaybackSpeed() const {
-  return playback_speed_;
+Scalar AnimationClip::GetPlaybackTimeScale() const {
+  return playback_time_scale_;
 }
 
-void AnimationClip::SetPlaybackSpeed(Scalar playback_speed) {
-  playback_speed_ = playback_speed;
+void AnimationClip::SetPlaybackTimeScale(Scalar playback_speed) {
+  playback_time_scale_ = playback_speed;
 }
 
 Scalar AnimationClip::GetWeight() const {
@@ -82,7 +82,7 @@ void AnimationClip::Advance(Scalar delta_time) {
   if (!playing_ || delta_time <= 0) {
     return;
   }
-  delta_time *= playback_speed_;
+  delta_time *= playback_time_scale_;
   playback_time_ += delta_time;
 
   /// Handle looping behavior.

--- a/impeller/scene/animation/animation_clip.h
+++ b/impeller/scene/animation/animation_clip.h
@@ -1,0 +1,88 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "flutter/fml/macros.h"
+#include "impeller/scene/animation/animation.h"
+
+namespace impeller {
+namespace scene {
+
+class Node;
+class AnimationPlayer;
+
+class AnimationClip final {
+ public:
+  AnimationClip(std::shared_ptr<Animation> animation, Node* bind_target);
+  ~AnimationClip();
+
+  AnimationClip(AnimationClip&&);
+  AnimationClip& operator=(AnimationClip&&);
+
+  bool IsPlaying() const;
+
+  void SetPlaying(bool playing);
+
+  void Play();
+
+  void Pause();
+
+  void Stop();
+
+  bool GetLoop() const;
+
+  void SetLoop(bool looping);
+
+  Scalar GetPlaybackSpeed() const;
+
+  /// @brief  Sets the animation playback speed. Negative values make the clip
+  ///         play in reverse.
+  void SetPlaybackSpeed(Scalar playback_speed);
+
+  Scalar GetWeight() const;
+
+  void SetWeight(Scalar weight);
+
+  /// @brief  Get the current playback time of the animation.
+  Scalar GetPlaybackTime() const;
+
+  /// @brief  Move the animation to the specified time. The given `time` is
+  ///         clamped to the animation's playback range.
+  void Seek(Scalar time);
+
+  /// @brief  Advance the animation by `delta_time` seconds. Negative
+  ///         `delta_time` values do nothing.
+  void Advance(Scalar delta_time);
+
+  /// @brief  Applies the animation to all binded properties in the scene.
+  void ApplyToBindings() const;
+
+ private:
+  void BindToTarget(Node* node);
+
+  struct ChannelBinding {
+    const Animation::Channel& channel;
+    Node* node;
+  };
+
+  std::shared_ptr<Animation> animation_;
+  std::vector<ChannelBinding> bindings_;
+
+  Scalar playback_time_ = 0;
+  Scalar playback_speed_ = 1;  // Seconds multiplier, can be negative.
+  Scalar weight_ = 1;
+  bool playing_ = false;
+  bool loop_ = false;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(AnimationClip);
+
+  friend AnimationPlayer;
+};
+
+}  // namespace scene
+}  // namespace impeller

--- a/impeller/scene/animation/animation_clip.h
+++ b/impeller/scene/animation/animation_clip.h
@@ -38,11 +38,11 @@ class AnimationClip final {
 
   void SetLoop(bool looping);
 
-  Scalar GetPlaybackSpeed() const;
+  Scalar GetPlaybackTimeScale() const;
 
   /// @brief  Sets the animation playback speed. Negative values make the clip
   ///         play in reverse.
-  void SetPlaybackSpeed(Scalar playback_speed);
+  void SetPlaybackTimeScale(Scalar playback_speed);
 
   Scalar GetWeight() const;
 
@@ -74,7 +74,7 @@ class AnimationClip final {
   std::vector<ChannelBinding> bindings_;
 
   Scalar playback_time_ = 0;
-  Scalar playback_speed_ = 1;  // Seconds multiplier, can be negative.
+  Scalar playback_time_scale_ = 1;  // Seconds multiplier, can be negative.
   Scalar weight_ = 1;
   bool playing_ = false;
   bool loop_ = false;

--- a/impeller/scene/animation/animation_player.cc
+++ b/impeller/scene/animation/animation_player.cc
@@ -1,0 +1,61 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/scene/animation/animation_player.h"
+
+#include <memory>
+
+#include "flutter/fml/time/time_point.h"
+#include "impeller/scene/node.h"
+
+namespace impeller {
+namespace scene {
+
+AnimationPlayer::AnimationPlayer() = default;
+AnimationPlayer::~AnimationPlayer() = default;
+
+AnimationPlayer::AnimationPlayer(AnimationPlayer&&) = default;
+AnimationPlayer& AnimationPlayer::operator=(AnimationPlayer&&) = default;
+
+AnimationClip& AnimationPlayer::AddAnimation(
+    std::shared_ptr<Animation> animation,
+    Node* bind_target) {
+  AnimationClip clip(std::move(animation), bind_target);
+
+  // Record all of the unique default transforms that this AnimationClip
+  // will mutate.
+  for (const auto& binding : clip.bindings_) {
+    default_target_transforms_.insert(DefaultTransform{
+        .node = binding.node, .transform = binding.node->GetLocalTransform()});
+  }
+
+  clips_.push_back(std::move(clip));
+  return clips_.back();
+}
+
+void AnimationPlayer::Update() {
+  if (!previous_time_.has_value()) {
+    previous_time_ = fml::TimePoint::Now().ToEpochDelta();
+  }
+  auto new_time = fml::TimePoint::Now().ToEpochDelta();
+  Scalar delta_time = (new_time - previous_time_.value()).ToSecondsF();
+  previous_time_ = new_time;
+
+  Reset();
+
+  // Update and apply all clips.
+  for (auto& clip : clips_) {
+    clip.Advance(delta_time);
+    clip.ApplyToBindings();
+  }
+}
+
+void AnimationPlayer::Reset() {
+  for (auto& default_transform : default_target_transforms_) {
+    default_transform.node->SetLocalTransform(default_transform.transform);
+  }
+}
+
+}  // namespace scene
+}  // namespace impeller

--- a/impeller/scene/animation/animation_player.cc
+++ b/impeller/scene/animation/animation_player.cc
@@ -26,8 +26,8 @@ AnimationClip& AnimationPlayer::AddAnimation(
   // Record all of the unique default transforms that this AnimationClip
   // will mutate.
   for (const auto& binding : clip.bindings_) {
-    default_target_transforms_.insert(DefaultTransform{
-        .node = binding.node, .transform = binding.node->GetLocalTransform()});
+    default_target_transforms_.insert(
+        {binding.node, binding.node->GetLocalTransform()});
   }
 
   clips_.push_back(std::move(clip));
@@ -52,8 +52,8 @@ void AnimationPlayer::Update() {
 }
 
 void AnimationPlayer::Reset() {
-  for (auto& default_transform : default_target_transforms_) {
-    default_transform.node->SetLocalTransform(default_transform.transform);
+  for (auto& [node, transform] : default_target_transforms_) {
+    node->SetLocalTransform(transform);
   }
 }
 

--- a/impeller/scene/animation/animation_player.h
+++ b/impeller/scene/animation/animation_player.h
@@ -38,28 +38,7 @@ class AnimationPlayer final {
   void Reset();
 
  private:
-  struct DefaultTransform {
-    Node* node;
-    Matrix transform;
-
-    struct Hash {
-      std::size_t operator()(const DefaultTransform& o) const {
-        return fml::HashCombine(o.node);
-      }
-    };
-
-    struct Equal {
-      bool operator()(const DefaultTransform& lhs,
-                      const DefaultTransform& rhs) const {
-        return lhs.node == rhs.node;
-      }
-    };
-  };
-
-  std::unordered_set<DefaultTransform,
-                     DefaultTransform::Hash,
-                     DefaultTransform::Equal>
-      default_target_transforms_;
+  std::unordered_map<Node*, Matrix> default_target_transforms_;
 
   std::vector<AnimationClip> clips_;
 

--- a/impeller/scene/animation/animation_player.h
+++ b/impeller/scene/animation/animation_player.h
@@ -1,0 +1,72 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <unordered_set>
+#include <vector>
+
+#include "flutter/fml/hash_combine.h"
+#include "flutter/fml/macros.h"
+#include "flutter/fml/time/time_delta.h"
+#include "impeller/geometry/matrix.h"
+#include "impeller/scene/animation/animation_clip.h"
+
+namespace impeller {
+namespace scene {
+
+class Node;
+
+class AnimationPlayer final {
+ public:
+  AnimationPlayer();
+  ~AnimationPlayer();
+
+  AnimationPlayer(AnimationPlayer&&);
+  AnimationPlayer& operator=(AnimationPlayer&&);
+
+  AnimationClip& AddAnimation(std::shared_ptr<Animation> animation,
+                              Node* bind_target);
+
+  /// @brief  Advanced all clips and updates animated properties in the scene.
+  void Update();
+
+  /// @brief  Reset all bound animation target transforms.
+  void Reset();
+
+ private:
+  struct DefaultTransform {
+    Node* node;
+    Matrix transform;
+
+    struct Hash {
+      std::size_t operator()(const DefaultTransform& o) const {
+        return fml::HashCombine(o.node);
+      }
+    };
+
+    struct Equal {
+      bool operator()(const DefaultTransform& lhs,
+                      const DefaultTransform& rhs) const {
+        return lhs.node == rhs.node;
+      }
+    };
+  };
+
+  std::unordered_set<DefaultTransform,
+                     DefaultTransform::Hash,
+                     DefaultTransform::Equal>
+      default_target_transforms_;
+
+  std::vector<AnimationClip> clips_;
+
+  std::optional<fml::TimeDelta> previous_time_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(AnimationPlayer);
+};
+
+}  // namespace scene
+}  // namespace impeller

--- a/impeller/scene/animation/property_resolver.cc
+++ b/impeller/scene/animation/property_resolver.cc
@@ -1,0 +1,131 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/scene/animation/property_resolver.h"
+
+#include <algorithm>
+#include <iterator>
+#include <memory>
+
+#include "impeller/geometry/point.h"
+#include "impeller/scene/node.h"
+
+namespace impeller {
+namespace scene {
+
+std::unique_ptr<TranslationTimelineResolver>
+PropertyResolver::MakeTranslationTimeline(std::vector<Scalar> times,
+                                          std::vector<Vector3> values) {
+  FML_DCHECK(times.size() == values.size());
+  auto result = std::unique_ptr<TranslationTimelineResolver>(
+      new TranslationTimelineResolver());
+  result->times_ = std::move(times);
+  result->values_ = std::move(values);
+  return result;
+}
+
+std::unique_ptr<RotationTimelineResolver>
+PropertyResolver::MakeRotationTimeline(std::vector<Scalar> times,
+                                       std::vector<Quaternion> values) {
+  FML_DCHECK(times.size() == values.size());
+  auto result =
+      std::unique_ptr<RotationTimelineResolver>(new RotationTimelineResolver());
+  result->times_ = std::move(times);
+  result->values_ = std::move(values);
+  return result;
+}
+
+std::unique_ptr<ScaleTimelineResolver> PropertyResolver::MakeScaleTimeline(
+    std::vector<Scalar> times,
+    std::vector<Vector3> values) {
+  FML_DCHECK(times.size() == values.size());
+  auto result =
+      std::unique_ptr<ScaleTimelineResolver>(new ScaleTimelineResolver());
+  result->times_ = std::move(times);
+  result->values_ = std::move(values);
+  return result;
+}
+
+PropertyResolver::~PropertyResolver() = default;
+
+TimelineResolver::~TimelineResolver() = default;
+
+Scalar TimelineResolver::GetEndTime() {
+  if (times_.empty()) {
+    return 0;
+  }
+  return times_.back();
+}
+
+TimelineResolver::TimelineKey TimelineResolver::GetTimelineKey(Scalar time) {
+  if (times_.size() <= 1 || time <= times_.front()) {
+    return {.index = 0, .lerp = 1};
+  }
+  if (time >= times_.back()) {
+    return {.index = times_.size() - 1, .lerp = 1};
+  }
+  auto it = std::lower_bound(times_.begin(), times_.end(), time);
+  size_t index = std::distance(times_.begin(), it);
+
+  Scalar previous_time = *(it - 1);
+  Scalar next_time = *it;
+  return {.index = index,
+          .lerp = (time - previous_time) / (next_time - previous_time)};
+}
+
+TranslationTimelineResolver::TranslationTimelineResolver() = default;
+
+TranslationTimelineResolver::~TranslationTimelineResolver() = default;
+
+void TranslationTimelineResolver::Apply(Node& target,
+                                        Scalar time,
+                                        Scalar weight) {
+  if (values_.empty()) {
+    return;
+  }
+  auto key = GetTimelineKey(time);
+  auto value = values_[key.index];
+  if (key.lerp < 1) {
+    value = values_[key.index - 1].Lerp(value, key.lerp);
+  }
+  target.SetLocalTransform(Matrix::MakeTranslation(value * weight) *
+                           target.GetLocalTransform());
+}
+
+RotationTimelineResolver::RotationTimelineResolver() = default;
+
+RotationTimelineResolver::~RotationTimelineResolver() = default;
+
+void RotationTimelineResolver::Apply(Node& target, Scalar time, Scalar weight) {
+  if (values_.empty()) {
+    return;
+  }
+  auto key = GetTimelineKey(time);
+  auto value = values_[key.index];
+  if (key.lerp < 1) {
+    value = values_[key.index - 1].Slerp(value, key.lerp);
+  }
+  target.SetLocalTransform(Matrix::MakeRotation(value * weight) *
+                           target.GetLocalTransform());
+}
+
+ScaleTimelineResolver::ScaleTimelineResolver() = default;
+
+ScaleTimelineResolver::~ScaleTimelineResolver() = default;
+
+void ScaleTimelineResolver::Apply(Node& target, Scalar time, Scalar weight) {
+  if (values_.empty()) {
+    return;
+  }
+  auto key = GetTimelineKey(time);
+  auto value = values_[key.index];
+  if (key.lerp < 1) {
+    value = values_[key.index - 1].Lerp(value, key.lerp);
+  }
+  target.SetLocalTransform(Matrix::MakeScale(value * weight) *
+                           target.GetLocalTransform());
+}
+
+}  // namespace scene
+}  // namespace impeller

--- a/impeller/scene/animation/property_resolver.h
+++ b/impeller/scene/animation/property_resolver.h
@@ -1,0 +1,123 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "flutter/fml/hash_combine.h"
+#include "flutter/fml/macros.h"
+#include "impeller/geometry/quaternion.h"
+#include "impeller/geometry/scalar.h"
+#include "impeller/geometry/vector.h"
+
+namespace impeller {
+namespace scene {
+
+class Node;
+class TranslationTimelineResolver;
+class RotationTimelineResolver;
+class ScaleTimelineResolver;
+
+class PropertyResolver {
+ public:
+  static std::unique_ptr<TranslationTimelineResolver> MakeTranslationTimeline(
+      std::vector<Scalar> times,
+      std::vector<Vector3> values);
+
+  static std::unique_ptr<RotationTimelineResolver> MakeRotationTimeline(
+      std::vector<Scalar> times,
+      std::vector<Quaternion> values);
+
+  static std::unique_ptr<ScaleTimelineResolver> MakeScaleTimeline(
+      std::vector<Scalar> times,
+      std::vector<Vector3> values);
+
+  virtual ~PropertyResolver();
+
+  virtual Scalar GetEndTime() = 0;
+
+  /// @brief  Resolve and apply the property value to a target node. This
+  ///         operation is additive; a given node property may be amended by
+  ///         many different PropertyResolvers prior to rendering. For example,
+  ///         an AnimationPlayer may blend multiple Animations together by
+  ///         applying several AnimationClips.
+  virtual void Apply(Node& target, Scalar time, Scalar weight) = 0;
+};
+
+class TimelineResolver : public PropertyResolver {
+ public:
+  virtual ~TimelineResolver();
+
+  // |Resolver|
+  Scalar GetEndTime();
+
+ protected:
+  struct TimelineKey {
+    /// The index of the closest previous keyframe.
+    size_t index = 0;
+    /// Used to interpolate between the resolved values for `timeline_index - 1`
+    /// and `timeline_index`. The range of this value should always be `0>N>=1`.
+    Scalar lerp = 1;
+  };
+  TimelineKey GetTimelineKey(Scalar time);
+
+  std::vector<Scalar> times_;
+};
+
+class TranslationTimelineResolver final : public TimelineResolver {
+ public:
+  ~TranslationTimelineResolver();
+
+  // |Resolver|
+  void Apply(Node& target, Scalar time, Scalar weight) override;
+
+ private:
+  TranslationTimelineResolver();
+
+  std::vector<Vector3> values_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(TranslationTimelineResolver);
+
+  friend PropertyResolver;
+};
+
+class RotationTimelineResolver final : public TimelineResolver {
+ public:
+  ~RotationTimelineResolver();
+
+  // |Resolver|
+  void Apply(Node& target, Scalar time, Scalar weight) override;
+
+ private:
+  RotationTimelineResolver();
+
+  std::vector<Quaternion> values_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(RotationTimelineResolver);
+
+  friend PropertyResolver;
+};
+
+class ScaleTimelineResolver final : public TimelineResolver {
+ public:
+  ~ScaleTimelineResolver();
+
+  // |Resolver|
+  void Apply(Node& target, Scalar time, Scalar weight) override;
+
+ private:
+  ScaleTimelineResolver();
+
+  std::vector<Vector3> values_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(ScaleTimelineResolver);
+
+  friend PropertyResolver;
+};
+
+}  // namespace scene
+}  // namespace impeller

--- a/impeller/scene/scene_unittests.cc
+++ b/impeller/scene/scene_unittests.cc
@@ -17,6 +17,7 @@
 #include "impeller/playground/playground.h"
 #include "impeller/playground/playground_test.h"
 #include "impeller/renderer/formats.h"
+#include "impeller/scene/animation/animation_clip.h"
 #include "impeller/scene/camera.h"
 #include "impeller/scene/geometry.h"
 #include "impeller/scene/importer/scene_flatbuffers.h"
@@ -121,6 +122,13 @@ TEST_P(SceneTest, TwoTriangles) {
   std::shared_ptr<Node> gltf_scene =
       Node::MakeFromFlatbuffer(*mapping, *allocator);
   ASSERT_NE(gltf_scene, nullptr);
+
+  auto animation = gltf_scene->FindAnimationByName("Metronome");
+  ASSERT_NE(animation, nullptr);
+
+  AnimationClip& metronome_clip = gltf_scene->AddAnimation(animation);
+  metronome_clip.SetLoop(true);
+  metronome_clip.Play();
 
   auto scene_context = std::make_shared<SceneContext>(GetContext());
   auto scene = Scene(scene_context);


### PR DESCRIPTION
Depends on https://github.com/flutter/engine/pull/38583, which adds animation import to SceneC.

This patch adds property-driving animation. So far, I've only implemented support for transform-related properties (translation/rotation/scale) for the purpose of skeletal animation playback, but other properties can be easily added later (e.g. morph target weights, material properties).
For the actual transform property channels, I added keyframe lerping timelines, but `PropertyResolver` is _not_ necessarily a timeline -- specialized curve-driven resolvers can easily be added later (e.g. sine waves, parameterized springs).

The "Two Triangles" playground now runs the imported "Metronome" animation, which is manipulating the bone transforms. However, this doesn't result in any visible change yet, as nothing is capturing the bone transforms and sending them to the GPU for the vertex shader to use when rendering skinned meshes. I'll be adding Skin deserialization in a later patch for this.

Notes:
* Animation-driven property updates are additive, which makes clips blendable.
* Nodes have an optional `AnimationPlayer`, which drives a set of `AnimationClip`s.
* An `AnimationClip` is a configurable instantiation of an `Animation` -- these are created when the user adds an `Animation` to a node in the scene.
* Property resolution works by using node names. `Animation` data is not scene-specific and can be bound to any node in any scene. Node names that can't be found are just ignored.
* When an `AnimationClip` is created, it resolves binding paths for all channels of the given `Animation`.
* When an `AnimationPlayer` is ticked, initial transform values are restored before applying the `AnimationClip`s.
* For convenience, deserialized nodes hang onto a read-only list of animations that can be queried later.

Usage:
```cpp
  std::shared_ptr<Node> gltf_scene =
      Node::MakeFromFlatbuffer(*mapping, *allocator);

  auto animation = gltf_scene->FindAnimationByName("Metronome");

  AnimationClip& metronome_clip = gltf_scene->AddAnimation(animation);
  metronome_clip.SetLoop(true);
  metronome_clip.Play();
```