### PR TITLE
[Impeller Scene] Use std::chrono for animation durations

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1146,6 +1146,7 @@ ORIGIN: ../../../flutter/impeller/base/thread.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/base/thread.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/base/thread_safety.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/base/thread_safety.h + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/impeller/base/timing.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/base/validation.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/base/validation.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/base/version.cc + ../../../flutter/LICENSE
@@ -3614,6 +3615,7 @@ FILE: ../../../flutter/impeller/base/thread.cc
 FILE: ../../../flutter/impeller/base/thread.h
 FILE: ../../../flutter/impeller/base/thread_safety.cc
 FILE: ../../../flutter/impeller/base/thread_safety.h
+FILE: ../../../flutter/impeller/base/timing.h
 FILE: ../../../flutter/impeller/base/validation.cc
 FILE: ../../../flutter/impeller/base/validation.h
 FILE: ../../../flutter/impeller/base/version.cc

--- a/impeller/base/BUILD.gn
+++ b/impeller/base/BUILD.gn
@@ -20,6 +20,7 @@ impeller_component("base") {
     "thread.h",
     "thread_safety.cc",
     "thread_safety.h",
+    "timing.h",
     "validation.cc",
     "validation.h",
     "version.cc",

--- a/impeller/base/timing.h
+++ b/impeller/base/timing.h
@@ -1,0 +1,15 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#pragma once
+
+#include <chrono>
+
+namespace impeller {
+
+using SecondsF = std::chrono::duration<float>;
+using Clock = std::chrono::high_resolution_clock;
+using TimePoint = std::chrono::time_point<std::chrono::high_resolution_clock>;
+
+}  // namespace impeller

--- a/impeller/scene/animation/animation.cc
+++ b/impeller/scene/animation/animation.cc
@@ -117,7 +117,7 @@ const std::vector<Animation::Channel>& Animation::GetChannels() const {
   return channels_;
 }
 
-std::chrono::duration<Scalar> Animation::GetEndTime() const {
+SecondsF Animation::GetEndTime() const {
   return end_time_;
 }
 

--- a/impeller/scene/animation/animation.cc
+++ b/impeller/scene/animation/animation.cc
@@ -117,7 +117,7 @@ const std::vector<Animation::Channel>& Animation::GetChannels() const {
   return channels_;
 }
 
-Scalar Animation::GetEndTime() const {
+std::chrono::duration<Scalar> Animation::GetEndTime() const {
   return end_time_;
 }
 

--- a/impeller/scene/animation/animation.h
+++ b/impeller/scene/animation/animation.h
@@ -60,14 +60,14 @@ class Animation final {
 
   const std::vector<Channel>& GetChannels() const;
 
-  Scalar GetEndTime() const;
+  std::chrono::duration<Scalar> GetEndTime() const;
 
  private:
   Animation();
 
   std::string name_;
   std::vector<Channel> channels_;
-  Scalar end_time_ = 0;
+  std::chrono::duration<Scalar> end_time_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(Animation);
 };

--- a/impeller/scene/animation/animation.h
+++ b/impeller/scene/animation/animation.h
@@ -10,6 +10,7 @@
 
 #include "flutter/fml/hash_combine.h"
 #include "flutter/fml/macros.h"
+#include "impeller/base/timing.h"
 #include "impeller/geometry/quaternion.h"
 #include "impeller/geometry/scalar.h"
 #include "impeller/geometry/vector.h"
@@ -60,14 +61,14 @@ class Animation final {
 
   const std::vector<Channel>& GetChannels() const;
 
-  std::chrono::duration<Scalar> GetEndTime() const;
+  SecondsF GetEndTime() const;
 
  private:
   Animation();
 
   std::string name_;
   std::vector<Channel> channels_;
-  std::chrono::duration<Scalar> end_time_;
+  SecondsF end_time_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(Animation);
 };

--- a/impeller/scene/animation/animation_clip.cc
+++ b/impeller/scene/animation/animation_clip.cc
@@ -5,6 +5,7 @@
 #include "impeller/scene/animation/animation_clip.h"
 
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <memory>
 #include <valarray>
@@ -43,7 +44,7 @@ void AnimationClip::Pause() {
 
 void AnimationClip::Stop() {
   SetPlaying(false);
-  Seek(0);
+  Seek(std::chrono::duration<Scalar>::zero());
 }
 
 bool AnimationClip::GetLoop() const {
@@ -70,16 +71,17 @@ void AnimationClip::SetWeight(Scalar weight) {
   weight_ = weight;
 }
 
-Scalar AnimationClip::GetPlaybackTime() const {
+std::chrono::duration<Scalar> AnimationClip::GetPlaybackTime() const {
   return playback_time_;
 }
 
-void AnimationClip::Seek(Scalar time) {
-  playback_time_ = std::clamp(time, 0.0f, animation_->GetEndTime());
+void AnimationClip::Seek(std::chrono::duration<Scalar> time) {
+  playback_time_ = std::clamp(time, std::chrono::duration<Scalar>::zero(),
+                              animation_->GetEndTime());
 }
 
-void AnimationClip::Advance(Scalar delta_time) {
-  if (!playing_ || delta_time <= 0) {
+void AnimationClip::Advance(std::chrono::duration<Scalar> delta_time) {
+  if (!playing_ || delta_time <= std::chrono::duration<Scalar>::zero()) {
     return;
   }
   delta_time *= playback_time_scale_;
@@ -87,22 +89,28 @@ void AnimationClip::Advance(Scalar delta_time) {
 
   /// Handle looping behavior.
 
-  Scalar end_time = animation_->GetEndTime();
-  if (end_time == 0) {
-    playback_time_ = 0;
+  auto end_time = animation_->GetEndTime();
+  if (end_time == std::chrono::duration<Scalar>::zero()) {
+    playback_time_ = std::chrono::duration<Scalar>::zero();
     return;
   }
-  if (!loop_ && (playback_time_ < 0 || playback_time_ > end_time)) {
+  if (!loop_ && (playback_time_ < std::chrono::duration<Scalar>::zero() ||
+                 playback_time_ > end_time)) {
     // If looping is disabled, clamp to the end (or beginning, if playing in
     // reverse) and pause.
     Pause();
-    playback_time_ = std::clamp(playback_time_, 0.0f, end_time);
+    playback_time_ = std::clamp(
+        playback_time_, std::chrono::duration<Scalar>::zero(), end_time);
   } else if (/* loop && */ playback_time_ > end_time) {
     // If looping is enabled and we ran off the end, loop to the beginning.
-    playback_time_ = std::fmod(std::abs(playback_time_), end_time);
-  } else if (/* loop && */ playback_time_ < 0) {
+    playback_time_ = std::chrono::duration<Scalar>(
+        std::fmod(std::abs(playback_time_.count()), end_time.count()));
+  } else if (/* loop && */ playback_time_ <
+             std::chrono::duration<Scalar>::zero()) {
     // If looping is enabled and we ran off the beginning, loop to the end.
-    playback_time_ = end_time - std::fmod(std::abs(playback_time_), end_time);
+    playback_time_ =
+        end_time - std::chrono::duration<Scalar>(std::fmod(
+                       std::abs(playback_time_.count()), end_time.count()));
   }
 }
 

--- a/impeller/scene/animation/animation_clip.cc
+++ b/impeller/scene/animation/animation_clip.cc
@@ -5,7 +5,6 @@
 #include "impeller/scene/animation/animation_clip.h"
 
 #include <algorithm>
-#include <chrono>
 #include <cmath>
 #include <memory>
 #include <valarray>
@@ -44,7 +43,7 @@ void AnimationClip::Pause() {
 
 void AnimationClip::Stop() {
   SetPlaying(false);
-  Seek(std::chrono::duration<Scalar>::zero());
+  Seek(SecondsF::zero());
 }
 
 bool AnimationClip::GetLoop() const {
@@ -71,17 +70,16 @@ void AnimationClip::SetWeight(Scalar weight) {
   weight_ = weight;
 }
 
-std::chrono::duration<Scalar> AnimationClip::GetPlaybackTime() const {
+SecondsF AnimationClip::GetPlaybackTime() const {
   return playback_time_;
 }
 
-void AnimationClip::Seek(std::chrono::duration<Scalar> time) {
-  playback_time_ = std::clamp(time, std::chrono::duration<Scalar>::zero(),
-                              animation_->GetEndTime());
+void AnimationClip::Seek(SecondsF time) {
+  playback_time_ = std::clamp(time, SecondsF::zero(), animation_->GetEndTime());
 }
 
-void AnimationClip::Advance(std::chrono::duration<Scalar> delta_time) {
-  if (!playing_ || delta_time <= std::chrono::duration<Scalar>::zero()) {
+void AnimationClip::Advance(SecondsF delta_time) {
+  if (!playing_ || delta_time <= SecondsF::zero()) {
     return;
   }
   delta_time *= playback_time_scale_;
@@ -90,27 +88,25 @@ void AnimationClip::Advance(std::chrono::duration<Scalar> delta_time) {
   /// Handle looping behavior.
 
   auto end_time = animation_->GetEndTime();
-  if (end_time == std::chrono::duration<Scalar>::zero()) {
-    playback_time_ = std::chrono::duration<Scalar>::zero();
+  if (end_time == SecondsF::zero()) {
+    playback_time_ = SecondsF::zero();
     return;
   }
-  if (!loop_ && (playback_time_ < std::chrono::duration<Scalar>::zero() ||
-                 playback_time_ > end_time)) {
+  if (!loop_ &&
+      (playback_time_ < SecondsF::zero() || playback_time_ > end_time)) {
     // If looping is disabled, clamp to the end (or beginning, if playing in
     // reverse) and pause.
     Pause();
-    playback_time_ = std::clamp(
-        playback_time_, std::chrono::duration<Scalar>::zero(), end_time);
+    playback_time_ = std::clamp(playback_time_, SecondsF::zero(), end_time);
   } else if (/* loop && */ playback_time_ > end_time) {
     // If looping is enabled and we ran off the end, loop to the beginning.
-    playback_time_ = std::chrono::duration<Scalar>(
-        std::fmod(std::abs(playback_time_.count()), end_time.count()));
-  } else if (/* loop && */ playback_time_ <
-             std::chrono::duration<Scalar>::zero()) {
+    playback_time_ =
+        SecondsF(std::fmod(std::abs(playback_time_.count()), end_time.count()));
+  } else if (/* loop && */ playback_time_ < SecondsF::zero()) {
     // If looping is enabled and we ran off the beginning, loop to the end.
     playback_time_ =
-        end_time - std::chrono::duration<Scalar>(std::fmod(
-                       std::abs(playback_time_.count()), end_time.count()));
+        end_time -
+        SecondsF(std::fmod(std::abs(playback_time_.count()), end_time.count()));
   }
 }
 

--- a/impeller/scene/animation/animation_clip.h
+++ b/impeller/scene/animation/animation_clip.h
@@ -49,15 +49,15 @@ class AnimationClip final {
   void SetWeight(Scalar weight);
 
   /// @brief  Get the current playback time of the animation.
-  std::chrono::duration<Scalar> GetPlaybackTime() const;
+  SecondsF GetPlaybackTime() const;
 
   /// @brief  Move the animation to the specified time. The given `time` is
   ///         clamped to the animation's playback range.
-  void Seek(std::chrono::duration<Scalar> time);
+  void Seek(SecondsF time);
 
   /// @brief  Advance the animation by `delta_time` seconds. Negative
   ///         `delta_time` values do nothing.
-  void Advance(std::chrono::duration<Scalar> delta_time);
+  void Advance(SecondsF delta_time);
 
   /// @brief  Applies the animation to all binded properties in the scene.
   void ApplyToBindings() const;
@@ -73,7 +73,7 @@ class AnimationClip final {
   std::shared_ptr<Animation> animation_;
   std::vector<ChannelBinding> bindings_;
 
-  std::chrono::duration<Scalar> playback_time_;
+  SecondsF playback_time_;
   Scalar playback_time_scale_ = 1;  // Seconds multiplier, can be negative.
   Scalar weight_ = 1;
   bool playing_ = false;

--- a/impeller/scene/animation/animation_clip.h
+++ b/impeller/scene/animation/animation_clip.h
@@ -49,15 +49,15 @@ class AnimationClip final {
   void SetWeight(Scalar weight);
 
   /// @brief  Get the current playback time of the animation.
-  Scalar GetPlaybackTime() const;
+  std::chrono::duration<Scalar> GetPlaybackTime() const;
 
   /// @brief  Move the animation to the specified time. The given `time` is
   ///         clamped to the animation's playback range.
-  void Seek(Scalar time);
+  void Seek(std::chrono::duration<Scalar> time);
 
   /// @brief  Advance the animation by `delta_time` seconds. Negative
   ///         `delta_time` values do nothing.
-  void Advance(Scalar delta_time);
+  void Advance(std::chrono::duration<Scalar> delta_time);
 
   /// @brief  Applies the animation to all binded properties in the scene.
   void ApplyToBindings() const;
@@ -73,7 +73,7 @@ class AnimationClip final {
   std::shared_ptr<Animation> animation_;
   std::vector<ChannelBinding> bindings_;
 
-  Scalar playback_time_ = 0;
+  std::chrono::duration<Scalar> playback_time_;
   Scalar playback_time_scale_ = 1;  // Seconds multiplier, can be negative.
   Scalar weight_ = 1;
   bool playing_ = false;

--- a/impeller/scene/animation/animation_player.cc
+++ b/impeller/scene/animation/animation_player.cc
@@ -4,6 +4,7 @@
 
 #include "impeller/scene/animation/animation_player.h"
 
+#include <chrono>
 #include <memory>
 
 #include "flutter/fml/time/time_point.h"
@@ -36,10 +37,10 @@ AnimationClip& AnimationPlayer::AddAnimation(
 
 void AnimationPlayer::Update() {
   if (!previous_time_.has_value()) {
-    previous_time_ = fml::TimePoint::Now().ToEpochDelta();
+    previous_time_ = std::chrono::high_resolution_clock::now();
   }
-  auto new_time = fml::TimePoint::Now().ToEpochDelta();
-  Scalar delta_time = (new_time - previous_time_.value()).ToSecondsF();
+  auto new_time = std::chrono::high_resolution_clock::now();
+  auto delta_time = new_time - previous_time_.value();
   previous_time_ = new_time;
 
   Reset();

--- a/impeller/scene/animation/animation_player.cc
+++ b/impeller/scene/animation/animation_player.cc
@@ -4,10 +4,10 @@
 
 #include "impeller/scene/animation/animation_player.h"
 
-#include <chrono>
 #include <memory>
 
 #include "flutter/fml/time/time_point.h"
+#include "impeller/base/timing.h"
 #include "impeller/scene/node.h"
 
 namespace impeller {
@@ -37,9 +37,9 @@ AnimationClip& AnimationPlayer::AddAnimation(
 
 void AnimationPlayer::Update() {
   if (!previous_time_.has_value()) {
-    previous_time_ = std::chrono::high_resolution_clock::now();
+    previous_time_ = Clock::now();
   }
-  auto new_time = std::chrono::high_resolution_clock::now();
+  auto new_time = Clock::now();
   auto delta_time = new_time - previous_time_.value();
   previous_time_ = new_time;
 

--- a/impeller/scene/animation/animation_player.h
+++ b/impeller/scene/animation/animation_player.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <memory>
 #include <optional>
 #include <unordered_set>
@@ -42,7 +43,8 @@ class AnimationPlayer final {
 
   std::vector<AnimationClip> clips_;
 
-  std::optional<fml::TimeDelta> previous_time_;
+  std::optional<std::chrono::time_point<std::chrono::high_resolution_clock>>
+      previous_time_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(AnimationPlayer);
 };

--- a/impeller/scene/animation/animation_player.h
+++ b/impeller/scene/animation/animation_player.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <chrono>
 #include <memory>
 #include <optional>
 #include <unordered_set>
@@ -13,6 +12,7 @@
 #include "flutter/fml/hash_combine.h"
 #include "flutter/fml/macros.h"
 #include "flutter/fml/time/time_delta.h"
+#include "impeller/base/timing.h"
 #include "impeller/geometry/matrix.h"
 #include "impeller/scene/animation/animation_clip.h"
 
@@ -43,8 +43,7 @@ class AnimationPlayer final {
 
   std::vector<AnimationClip> clips_;
 
-  std::optional<std::chrono::time_point<std::chrono::high_resolution_clock>>
-      previous_time_;
+  std::optional<TimePoint> previous_time_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(AnimationPlayer);
 };

--- a/impeller/scene/animation/property_resolver.cc
+++ b/impeller/scene/animation/property_resolver.cc
@@ -51,27 +51,28 @@ PropertyResolver::~PropertyResolver() = default;
 
 TimelineResolver::~TimelineResolver() = default;
 
-Scalar TimelineResolver::GetEndTime() {
+std::chrono::duration<Scalar> TimelineResolver::GetEndTime() {
   if (times_.empty()) {
-    return 0;
+    return std::chrono::duration<Scalar>::zero();
   }
-  return times_.back();
+  return std::chrono::duration<Scalar>(times_.back());
 }
 
-TimelineResolver::TimelineKey TimelineResolver::GetTimelineKey(Scalar time) {
-  if (times_.size() <= 1 || time <= times_.front()) {
+TimelineResolver::TimelineKey TimelineResolver::GetTimelineKey(
+    std::chrono::duration<Scalar> time) {
+  if (times_.size() <= 1 || time.count() <= times_.front()) {
     return {.index = 0, .lerp = 1};
   }
-  if (time >= times_.back()) {
+  if (time.count() >= times_.back()) {
     return {.index = times_.size() - 1, .lerp = 1};
   }
-  auto it = std::lower_bound(times_.begin(), times_.end(), time);
+  auto it = std::lower_bound(times_.begin(), times_.end(), time.count());
   size_t index = std::distance(times_.begin(), it);
 
   Scalar previous_time = *(it - 1);
   Scalar next_time = *it;
   return {.index = index,
-          .lerp = (time - previous_time) / (next_time - previous_time)};
+          .lerp = (time.count() - previous_time) / (next_time - previous_time)};
 }
 
 TranslationTimelineResolver::TranslationTimelineResolver() = default;
@@ -79,7 +80,7 @@ TranslationTimelineResolver::TranslationTimelineResolver() = default;
 TranslationTimelineResolver::~TranslationTimelineResolver() = default;
 
 void TranslationTimelineResolver::Apply(Node& target,
-                                        Scalar time,
+                                        std::chrono::duration<Scalar> time,
                                         Scalar weight) {
   if (values_.empty()) {
     return;
@@ -97,7 +98,9 @@ RotationTimelineResolver::RotationTimelineResolver() = default;
 
 RotationTimelineResolver::~RotationTimelineResolver() = default;
 
-void RotationTimelineResolver::Apply(Node& target, Scalar time, Scalar weight) {
+void RotationTimelineResolver::Apply(Node& target,
+                                     std::chrono::duration<Scalar> time,
+                                     Scalar weight) {
   if (values_.empty()) {
     return;
   }
@@ -114,7 +117,9 @@ ScaleTimelineResolver::ScaleTimelineResolver() = default;
 
 ScaleTimelineResolver::~ScaleTimelineResolver() = default;
 
-void ScaleTimelineResolver::Apply(Node& target, Scalar time, Scalar weight) {
+void ScaleTimelineResolver::Apply(Node& target,
+                                  std::chrono::duration<Scalar> time,
+                                  Scalar weight) {
   if (values_.empty()) {
     return;
   }

--- a/impeller/scene/animation/property_resolver.cc
+++ b/impeller/scene/animation/property_resolver.cc
@@ -51,15 +51,14 @@ PropertyResolver::~PropertyResolver() = default;
 
 TimelineResolver::~TimelineResolver() = default;
 
-std::chrono::duration<Scalar> TimelineResolver::GetEndTime() {
+SecondsF TimelineResolver::GetEndTime() {
   if (times_.empty()) {
-    return std::chrono::duration<Scalar>::zero();
+    return SecondsF::zero();
   }
-  return std::chrono::duration<Scalar>(times_.back());
+  return SecondsF(times_.back());
 }
 
-TimelineResolver::TimelineKey TimelineResolver::GetTimelineKey(
-    std::chrono::duration<Scalar> time) {
+TimelineResolver::TimelineKey TimelineResolver::GetTimelineKey(SecondsF time) {
   if (times_.size() <= 1 || time.count() <= times_.front()) {
     return {.index = 0, .lerp = 1};
   }
@@ -80,7 +79,7 @@ TranslationTimelineResolver::TranslationTimelineResolver() = default;
 TranslationTimelineResolver::~TranslationTimelineResolver() = default;
 
 void TranslationTimelineResolver::Apply(Node& target,
-                                        std::chrono::duration<Scalar> time,
+                                        SecondsF time,
                                         Scalar weight) {
   if (values_.empty()) {
     return;
@@ -99,7 +98,7 @@ RotationTimelineResolver::RotationTimelineResolver() = default;
 RotationTimelineResolver::~RotationTimelineResolver() = default;
 
 void RotationTimelineResolver::Apply(Node& target,
-                                     std::chrono::duration<Scalar> time,
+                                     SecondsF time,
                                      Scalar weight) {
   if (values_.empty()) {
     return;
@@ -117,9 +116,7 @@ ScaleTimelineResolver::ScaleTimelineResolver() = default;
 
 ScaleTimelineResolver::~ScaleTimelineResolver() = default;
 
-void ScaleTimelineResolver::Apply(Node& target,
-                                  std::chrono::duration<Scalar> time,
-                                  Scalar weight) {
+void ScaleTimelineResolver::Apply(Node& target, SecondsF time, Scalar weight) {
   if (values_.empty()) {
     return;
   }

--- a/impeller/scene/animation/property_resolver.h
+++ b/impeller/scene/animation/property_resolver.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <memory>
 #include <string>
 #include <vector>
@@ -38,14 +39,16 @@ class PropertyResolver {
 
   virtual ~PropertyResolver();
 
-  virtual Scalar GetEndTime() = 0;
+  virtual std::chrono::duration<Scalar> GetEndTime() = 0;
 
   /// @brief  Resolve and apply the property value to a target node. This
   ///         operation is additive; a given node property may be amended by
   ///         many different PropertyResolvers prior to rendering. For example,
   ///         an AnimationPlayer may blend multiple Animations together by
   ///         applying several AnimationClips.
-  virtual void Apply(Node& target, Scalar time, Scalar weight) = 0;
+  virtual void Apply(Node& target,
+                     std::chrono::duration<Scalar> time,
+                     Scalar weight) = 0;
 };
 
 class TimelineResolver : public PropertyResolver {
@@ -53,7 +56,7 @@ class TimelineResolver : public PropertyResolver {
   virtual ~TimelineResolver();
 
   // |Resolver|
-  Scalar GetEndTime();
+  std::chrono::duration<Scalar> GetEndTime();
 
  protected:
   struct TimelineKey {
@@ -63,7 +66,7 @@ class TimelineResolver : public PropertyResolver {
     /// and `timeline_index`. The range of this value should always be `0>N>=1`.
     Scalar lerp = 1;
   };
-  TimelineKey GetTimelineKey(Scalar time);
+  TimelineKey GetTimelineKey(std::chrono::duration<Scalar> time);
 
   std::vector<Scalar> times_;
 };
@@ -73,7 +76,9 @@ class TranslationTimelineResolver final : public TimelineResolver {
   ~TranslationTimelineResolver();
 
   // |Resolver|
-  void Apply(Node& target, Scalar time, Scalar weight) override;
+  void Apply(Node& target,
+             std::chrono::duration<Scalar> time,
+             Scalar weight) override;
 
  private:
   TranslationTimelineResolver();
@@ -90,7 +95,9 @@ class RotationTimelineResolver final : public TimelineResolver {
   ~RotationTimelineResolver();
 
   // |Resolver|
-  void Apply(Node& target, Scalar time, Scalar weight) override;
+  void Apply(Node& target,
+             std::chrono::duration<Scalar> time,
+             Scalar weight) override;
 
  private:
   RotationTimelineResolver();
@@ -107,7 +114,9 @@ class ScaleTimelineResolver final : public TimelineResolver {
   ~ScaleTimelineResolver();
 
   // |Resolver|
-  void Apply(Node& target, Scalar time, Scalar weight) override;
+  void Apply(Node& target,
+             std::chrono::duration<Scalar> time,
+             Scalar weight) override;
 
  private:
   ScaleTimelineResolver();

--- a/impeller/scene/animation/property_resolver.h
+++ b/impeller/scene/animation/property_resolver.h
@@ -4,13 +4,13 @@
 
 #pragma once
 
-#include <chrono>
 #include <memory>
 #include <string>
 #include <vector>
 
 #include "flutter/fml/hash_combine.h"
 #include "flutter/fml/macros.h"
+#include "impeller/base/timing.h"
 #include "impeller/geometry/quaternion.h"
 #include "impeller/geometry/scalar.h"
 #include "impeller/geometry/vector.h"
@@ -39,16 +39,14 @@ class PropertyResolver {
 
   virtual ~PropertyResolver();
 
-  virtual std::chrono::duration<Scalar> GetEndTime() = 0;
+  virtual SecondsF GetEndTime() = 0;
 
   /// @brief  Resolve and apply the property value to a target node. This
   ///         operation is additive; a given node property may be amended by
   ///         many different PropertyResolvers prior to rendering. For example,
   ///         an AnimationPlayer may blend multiple Animations together by
   ///         applying several AnimationClips.
-  virtual void Apply(Node& target,
-                     std::chrono::duration<Scalar> time,
-                     Scalar weight) = 0;
+  virtual void Apply(Node& target, SecondsF time, Scalar weight) = 0;
 };
 
 class TimelineResolver : public PropertyResolver {
@@ -56,7 +54,7 @@ class TimelineResolver : public PropertyResolver {
   virtual ~TimelineResolver();
 
   // |Resolver|
-  std::chrono::duration<Scalar> GetEndTime();
+  SecondsF GetEndTime();
 
  protected:
   struct TimelineKey {
@@ -66,7 +64,7 @@ class TimelineResolver : public PropertyResolver {
     /// and `timeline_index`. The range of this value should always be `0>N>=1`.
     Scalar lerp = 1;
   };
-  TimelineKey GetTimelineKey(std::chrono::duration<Scalar> time);
+  TimelineKey GetTimelineKey(SecondsF time);
 
   std::vector<Scalar> times_;
 };
@@ -76,9 +74,7 @@ class TranslationTimelineResolver final : public TimelineResolver {
   ~TranslationTimelineResolver();
 
   // |Resolver|
-  void Apply(Node& target,
-             std::chrono::duration<Scalar> time,
-             Scalar weight) override;
+  void Apply(Node& target, SecondsF time, Scalar weight) override;
 
  private:
   TranslationTimelineResolver();
@@ -95,9 +91,7 @@ class RotationTimelineResolver final : public TimelineResolver {
   ~RotationTimelineResolver();
 
   // |Resolver|
-  void Apply(Node& target,
-             std::chrono::duration<Scalar> time,
-             Scalar weight) override;
+  void Apply(Node& target, SecondsF time, Scalar weight) override;
 
  private:
   RotationTimelineResolver();
@@ -114,9 +108,7 @@ class ScaleTimelineResolver final : public TimelineResolver {
   ~ScaleTimelineResolver();
 
   // |Resolver|
-  void Apply(Node& target,
-             std::chrono::duration<Scalar> time,
-             Scalar weight) override;
+  void Apply(Node& target, SecondsF time, Scalar weight) override;
 
  private:
   ScaleTimelineResolver();


### PR DESCRIPTION
Follow-up to https://github.com/flutter/engine/pull/38595. 32 bit floats are plenty precise for the animation system, so I just kept the use of float-backed seconds everywhere to keep the conversions to a minimum.