### PR TITLE
Make `AccessibilityBridge` a `AXPlatformTreeManager`

### DIFF
--- a/shell/platform/common/accessibility_bridge.cc
+++ b/shell/platform/common/accessibility_bridge.cc
@@ -694,9 +694,6 @@ ui::AXTree* AccessibilityBridge::GetTree() const {
 ui::AXPlatformNode* AccessibilityBridge::GetPlatformNodeFromTree(
     const ui::AXNode::AXID node_id) const {
   auto platform_delegate_weak = GetFlutterPlatformNodeDelegateFromID(node_id);
-  if (platform_delegate_weak.expired()) {
-    return nullptr;
-  }
   auto platform_delegate = platform_delegate_weak.lock();
   if (!platform_delegate) {
     return nullptr;

--- a/shell/platform/common/accessibility_bridge.cc
+++ b/shell/platform/common/accessibility_bridge.cc
@@ -20,7 +20,8 @@ constexpr int kHasScrollingAction =
     FlutterSemanticsAction::kFlutterSemanticsActionScrollDown;
 
 // AccessibilityBridge
-AccessibilityBridge::AccessibilityBridge() {
+AccessibilityBridge::AccessibilityBridge()
+    : tree_(std::make_unique<ui::AXTree>()) {
   event_generator_.SetTree(tree_.get());
   tree_->AddObserver(static_cast<ui::AXTreeObserver*>(this));
   ui::AXTreeData data = tree_->data();
@@ -68,7 +69,7 @@ void AccessibilityBridge::CommitUpdates() {
 
   // Second, apply the pending node updates. This also moves reparented nodes to
   // their new parents if needed.
-  ui::AXTreeUpdate update{.tree_data = tree_.data()};
+  ui::AXTreeUpdate update{.tree_data = tree_->data()};
 
   // Figure out update order, ui::AXTree only accepts update in tree order,
   // where parent node must come before the child node in
@@ -244,7 +245,7 @@ AccessibilityBridge::CreateRemoveReparentedNodesUpdate() {
   }
 
   ui::AXTreeUpdate update{
-      .tree_data = tree_.data(),
+      .tree_data = tree_->data(),
       .nodes = std::vector<ui::AXNodeData>(),
   };
 

--- a/shell/platform/common/accessibility_bridge.cc
+++ b/shell/platform/common/accessibility_bridge.cc
@@ -7,6 +7,7 @@
 #include <functional>
 #include <utility>
 
+#include "flutter/third_party/accessibility/ax/ax_tree_manager_map.h"
 #include "flutter/third_party/accessibility/ax/ax_tree_update.h"
 #include "flutter/third_party/accessibility/base/logging.h"
 
@@ -20,13 +21,17 @@ constexpr int kHasScrollingAction =
 
 // AccessibilityBridge
 AccessibilityBridge::AccessibilityBridge() {
-  event_generator_.SetTree(&tree_);
-  tree_.AddObserver(static_cast<ui::AXTreeObserver*>(this));
+  event_generator_.SetTree(tree_.get());
+  tree_->AddObserver(static_cast<ui::AXTreeObserver*>(this));
+  ui::AXTreeData data = tree_->data();
+  data.tree_id = ui::AXTreeID::CreateNewAXTreeID();
+  tree_->UpdateData(data);
+  ui::AXTreeManagerMap::GetInstance().AddTreeManager(tree_->GetAXTreeID(), this);
 }
 
 AccessibilityBridge::~AccessibilityBridge() {
   event_generator_.ReleaseTree();
-  tree_.RemoveObserver(static_cast<ui::AXTreeObserver*>(this));
+  tree_->RemoveObserver(static_cast<ui::AXTreeObserver*>(this));
 }
 
 void AccessibilityBridge::AddFlutterSemanticsNodeUpdate(
@@ -51,9 +56,9 @@ void AccessibilityBridge::CommitUpdates() {
   std::optional<ui::AXTreeUpdate> remove_reparented =
       CreateRemoveReparentedNodesUpdate();
   if (remove_reparented.has_value()) {
-    tree_.Unserialize(remove_reparented.value());
+    tree_->Unserialize(remove_reparented.value());
 
-    std::string error = tree_.error();
+    std::string error = tree_->error();
     if (!error.empty()) {
       FML_LOG(ERROR) << "Failed to update ui::AXTree, error: " << error;
       assert(false);
@@ -88,11 +93,11 @@ void AccessibilityBridge::CommitUpdates() {
     }
   }
 
-  tree_.Unserialize(update);
+  tree_->Unserialize(update);
   pending_semantics_node_updates_.clear();
   pending_semantics_custom_action_updates_.clear();
 
-  std::string error = tree_.error();
+  std::string error = tree_->error();
   if (!error.empty()) {
     FML_LOG(ERROR) << "Failed to update ui::AXTree, error: " << error;
     return;
@@ -122,7 +127,7 @@ AccessibilityBridge::GetFlutterPlatformNodeDelegateFromID(
 }
 
 const ui::AXTreeData& AccessibilityBridge::GetAXTreeData() const {
-  return tree_.data();
+  return tree_->data();
 }
 
 const std::vector<ui::AXEventGenerator::TargetedEvent>
@@ -201,7 +206,7 @@ AccessibilityBridge::CreateRemoveReparentedNodesUpdate() {
   for (auto node_update : pending_semantics_node_updates_) {
     for (int32_t child_id : node_update.second.children_in_traversal_order) {
       // Skip nodes that don't exist or have a parent in the current tree.
-      ui::AXNode* child = tree_.GetFromId(child_id);
+      ui::AXNode* child = tree_->GetFromId(child_id);
       if (!child) {
         continue;
       }
@@ -222,7 +227,7 @@ AccessibilityBridge::CreateRemoveReparentedNodesUpdate() {
       // Create an update to remove the child from its previous parent.
       int32_t parent_id = child->parent()->id();
       if (updates.find(parent_id) == updates.end()) {
-        updates[parent_id] = tree_.GetFromId(parent_id)->data();
+        updates[parent_id] = tree_->GetFromId(parent_id)->data();
       }
 
       ui::AXNodeData* parent = &updates[parent_id];
@@ -649,8 +654,63 @@ gfx::NativeViewAccessible AccessibilityBridge::GetNativeAccessibleFromId(
 gfx::RectF AccessibilityBridge::RelativeToGlobalBounds(const ui::AXNode* node,
                                                        bool& offscreen,
                                                        bool clip_bounds) {
-  return tree_.RelativeToTreeBounds(node, gfx::RectF(), &offscreen,
+  return tree_->RelativeToTreeBounds(node, gfx::RectF(), &offscreen,
                                     clip_bounds);
+}
+
+ui::AXNode* AccessibilityBridge::GetNodeFromTree(
+    ui::AXTreeID tree_id,
+    ui::AXNode::AXID node_id) const {
+  return GetNodeFromTree(node_id);
+}
+
+ui::AXNode* AccessibilityBridge::GetNodeFromTree(
+    ui::AXNode::AXID node_id) const {
+  return tree_->GetFromId(node_id);
+}
+
+ui::AXTreeID AccessibilityBridge::GetTreeID() const {
+  return tree_->GetAXTreeID();
+}
+
+ui::AXTreeID AccessibilityBridge::GetParentTreeID() const {
+  return ui::AXTreeIDUnknown();
+}
+
+ui::AXNode* AccessibilityBridge::GetRootAsAXNode() const {
+  return tree_->root();
+}
+
+ui::AXNode* AccessibilityBridge::GetParentNodeFromParentTreeAsAXNode() const {
+  return nullptr;
+}
+
+ui::AXTree* AccessibilityBridge::GetTree() const {
+  return tree_.get();
+}
+
+ui::AXPlatformNode* AccessibilityBridge::GetPlatformNodeFromTree(
+    const ui::AXNode::AXID node_id) const {
+  auto platform_delegate_weak = GetFlutterPlatformNodeDelegateFromID(node_id);
+  if (platform_delegate_weak.expired()) {
+    return nullptr;
+  }
+  auto platform_delegate = platform_delegate_weak.lock();
+  if (!platform_delegate) {
+    return nullptr;
+  }
+  return platform_delegate->GetPlatformNode();
+}
+
+ui::AXPlatformNode* AccessibilityBridge::GetPlatformNodeFromTree(
+    const ui::AXNode& node) const {
+  return GetPlatformNodeFromTree(node.id());
+}
+
+ui::AXPlatformNodeDelegate* AccessibilityBridge::RootDelegate() const {
+  return GetFlutterPlatformNodeDelegateFromID(GetRootAsAXNode()->id())
+      .lock()
+      .get();
 }
 
 }  // namespace flutter

--- a/shell/platform/common/accessibility_bridge.cc
+++ b/shell/platform/common/accessibility_bridge.cc
@@ -27,7 +27,8 @@ AccessibilityBridge::AccessibilityBridge()
   ui::AXTreeData data = tree_->data();
   data.tree_id = ui::AXTreeID::CreateNewAXTreeID();
   tree_->UpdateData(data);
-  ui::AXTreeManagerMap::GetInstance().AddTreeManager(tree_->GetAXTreeID(), this);
+  ui::AXTreeManagerMap::GetInstance().AddTreeManager(tree_->GetAXTreeID(),
+                                                     this);
 }
 
 AccessibilityBridge::~AccessibilityBridge() {
@@ -656,7 +657,7 @@ gfx::RectF AccessibilityBridge::RelativeToGlobalBounds(const ui::AXNode* node,
                                                        bool& offscreen,
                                                        bool clip_bounds) {
   return tree_->RelativeToTreeBounds(node, gfx::RectF(), &offscreen,
-                                    clip_bounds);
+                                     clip_bounds);
 }
 
 ui::AXNode* AccessibilityBridge::GetNodeFromTree(

--- a/shell/platform/common/accessibility_bridge.h
+++ b/shell/platform/common/accessibility_bridge.h
@@ -14,6 +14,7 @@
 #include "flutter/third_party/accessibility/ax/ax_tree.h"
 #include "flutter/third_party/accessibility/ax/ax_tree_observer.h"
 #include "flutter/third_party/accessibility/ax/platform/ax_platform_node_delegate.h"
+#include "flutter/third_party/accessibility/ax/platform/ax_platform_tree_manager.h"
 
 #include "flutter_platform_node_delegate.h"
 
@@ -39,6 +40,7 @@ namespace flutter {
 class AccessibilityBridge
     : public std::enable_shared_from_this<AccessibilityBridge>,
       public FlutterPlatformNodeDelegate::OwnerBridge,
+      public ui::AXPlatformTreeManager,
       private ui::AXTreeObserver {
  public:
   //-----------------------------------------------------------------------------
@@ -105,6 +107,39 @@ class AccessibilityBridge
   ///             all pending events.
   const std::vector<ui::AXEventGenerator::TargetedEvent> GetPendingEvents()
       const;
+
+  // |AXTreeManager|
+  ui::AXNode* GetNodeFromTree(const ui::AXTreeID tree_id,
+                              const ui::AXNode::AXID node_id) const override;
+
+  // |AXTreeManager|
+  ui::AXNode* GetNodeFromTree(const ui::AXNode::AXID node_id) const override;
+
+  // |AXTreeManager|
+  ui::AXTreeID GetTreeID() const override;
+
+  // |AXTreeManager|
+  ui::AXTreeID GetParentTreeID() const override;
+
+  // |AXTreeManager|
+  ui::AXNode* GetRootAsAXNode() const override;
+
+  // |AXTreeManager|
+  ui::AXNode* GetParentNodeFromParentTreeAsAXNode() const override;
+
+  // |AXTreeManager|
+  ui::AXTree* GetTree() const override;
+
+  // |AXPlatformTreeManager|
+  ui::AXPlatformNode* GetPlatformNodeFromTree(
+      const ui::AXNode::AXID node_id) const override;
+
+  // |AXPlatformTreeManager|
+  ui::AXPlatformNode* GetPlatformNodeFromTree(
+      const ui::AXNode& node) const override;
+
+  // |AXPlatformTreeManager|
+  ui::AXPlatformNodeDelegate* RootDelegate() const override;
 
  protected:
   //---------------------------------------------------------------------------
@@ -176,7 +211,7 @@ class AccessibilityBridge
   std::unordered_map<AccessibilityNodeId,
                      std::shared_ptr<FlutterPlatformNodeDelegate>>
       id_wrapper_map_;
-  ui::AXTree tree_;
+  std::unique_ptr<ui::AXTree> tree_;
   ui::AXEventGenerator event_generator_;
   std::unordered_map<int32_t, SemanticsNode> pending_semantics_node_updates_;
   std::unordered_map<int32_t, SemanticsCustomAction>

--- a/shell/platform/common/accessibility_bridge_unittests.cc
+++ b/shell/platform/common/accessibility_bridge_unittests.cc
@@ -489,7 +489,8 @@ TEST(AccessibilityBridgeTest, AXTreeManagerTest) {
       std::make_shared<TestAccessibilityBridge>();
 
   ui::AXTreeID tree_id = bridge->GetTreeID();
-  ui::AXTreeManager* manager = ui::AXTreeManagerMap::GetInstance().GetManager(tree_id);
+  ui::AXTreeManager* manager =
+      ui::AXTreeManagerMap::GetInstance().GetManager(tree_id);
   ASSERT_EQ(manager, static_cast<ui::AXTreeManager*>(bridge.get()));
 }
 

--- a/shell/platform/common/accessibility_bridge_unittests.cc
+++ b/shell/platform/common/accessibility_bridge_unittests.cc
@@ -7,6 +7,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+#include "flutter/third_party/accessibility/ax/ax_tree_manager_map.h"
 #include "test_accessibility_bridge.h"
 
 namespace flutter {
@@ -481,6 +482,15 @@ TEST(AccessibilityBridgeTest, CanReparentNodeWithChild) {
       Contains(ui::AXEventGenerator::Event::OTHER_ATTRIBUTE_CHANGED).Times(1));
   EXPECT_THAT(bridge->accessibility_events,
               Contains(ui::AXEventGenerator::Event::ROLE_CHANGED).Times(1));
+}
+
+TEST(AccessibilityBridgeTest, AXTreeManagerTest) {
+  std::shared_ptr<TestAccessibilityBridge> bridge =
+      std::make_shared<TestAccessibilityBridge>();
+
+  ui::AXTreeID tree_id = bridge->GetTreeID();
+  ui::AXTreeManager* manager = ui::AXTreeManagerMap::GetInstance().GetManager(tree_id);
+  ASSERT_EQ(manager, static_cast<ui::AXTreeManager*>(bridge.get()));
 }
 
 }  // namespace testing

--- a/shell/platform/common/flutter_platform_node_delegate.cc
+++ b/shell/platform/common/flutter_platform_node_delegate.cc
@@ -114,4 +114,8 @@ FlutterPlatformNodeDelegate::GetOwnerBridge() const {
   return bridge_;
 }
 
+ui::AXPlatformNode* FlutterPlatformNodeDelegate::GetPlatformNode() const {
+  return nullptr;
+}
+
 }  // namespace flutter

--- a/shell/platform/common/flutter_platform_node_delegate.h
+++ b/shell/platform/common/flutter_platform_node_delegate.h
@@ -144,6 +144,9 @@ class FlutterPlatformNodeDelegate : public ui::AXPlatformNodeDelegateBase {
   ///             platform thread.
   std::weak_ptr<OwnerBridge> GetOwnerBridge() const;
 
+  // Get the platform node represented by this delegate.
+  virtual ui::AXPlatformNode* GetPlatformNode() const;
+
  private:
   ui::AXNode* ax_node_;
   std::weak_ptr<OwnerBridge> bridge_;

--- a/shell/platform/windows/flutter_platform_node_delegate_windows.cc
+++ b/shell/platform/windows/flutter_platform_node_delegate_windows.cc
@@ -107,4 +107,9 @@ FlutterPlatformNodeDelegateWindows::GetTargetForNativeAccessibilityEvent() {
   return view_->GetPlatformWindow();
 }
 
+ui::AXPlatformNode* FlutterPlatformNodeDelegateWindows::GetPlatformNode()
+    const {
+  return ax_platform_node_;
+}
+
 }  // namespace flutter

--- a/shell/platform/windows/flutter_platform_node_delegate_windows.h
+++ b/shell/platform/windows/flutter_platform_node_delegate_windows.h
@@ -51,6 +51,9 @@ class FlutterPlatformNodeDelegateWindows : public FlutterPlatformNodeDelegate {
   // | AXPlatformNodeDelegate |
   gfx::AcceleratedWidget GetTargetForNativeAccessibilityEvent() override;
 
+  // | FlutterPlatformNodeDelegate |
+  ui::AXPlatformNode* GetPlatformNode() const override;
+
  private:
   ui::AXPlatformNode* ax_platform_node_;
   std::weak_ptr<AccessibilityBridge> bridge_;


### PR DESCRIPTION
For UIA implementation, we must have an `AXPlatformTreeManager` to  manage the trees of platform nodes. the `AccessibilityBridge` already serves a similar purpose.

Part of https://github.com/flutter/flutter/issues/116219

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
