### PR TITLE
[Windows] Fix missing includes when building using Visual Studio 17.4

### DIFF
--- a/testing/test_dart_native_resolver.h
+++ b/testing/test_dart_native_resolver.h
@@ -8,6 +8,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <string>
 
 #include "flutter/fml/macros.h"
 #include "third_party/dart/runtime/include/dart_api.h"

--- a/third_party/accessibility/ax/ax_table_info.h
+++ b/third_party/accessibility/ax/ax_table_info.h
@@ -7,6 +7,7 @@
 
 #include <map>
 #include <set>
+#include <string>
 #include <unordered_map>
 #include <vector>
 


### PR DESCRIPTION
Add `#include <string>` to headers that reference `std::string` but did not include them explicitly. This fixes some of the build errors that prevents Visual Studio 17.4+ from building the Flutter engine.

Part of https://github.com/flutter/flutter/issues/117932

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
