### PR TITLE
Limit selection change to focused node on Windows

### DIFF
--- a/shell/platform/common/accessibility_bridge.cc
+++ b/shell/platform/common/accessibility_bridge.cc
@@ -527,11 +527,12 @@ void AccessibilityBridge::SetTooltipFromFlutterUpdate(
 void AccessibilityBridge::SetTreeData(const SemanticsNode& node,
                                       ui::AXTreeUpdate& tree_update) {
   FlutterSemanticsFlag flags = node.flags;
-  // Set selection if:
+  // Set selection of the focused node if:
   // 1. this text field has a valid selection
   // 2. this text field doesn't have a valid selection but had selection stored
   //    in the tree.
-  if (flags & FlutterSemanticsFlag::kFlutterSemanticsFlagIsTextField) {
+  if (flags & FlutterSemanticsFlag::kFlutterSemanticsFlagIsTextField &&
+      flags & FlutterSemanticsFlag::kFlutterSemanticsFlagIsFocused) {
     if (node.text_selection_base != -1) {
       tree_update.tree_data.sel_anchor_object_id = node.id;
       tree_update.tree_data.sel_anchor_offset = node.text_selection_base;

--- a/shell/platform/common/accessibility_bridge_unittests.cc
+++ b/shell/platform/common/accessibility_bridge_unittests.cc
@@ -152,7 +152,9 @@ TEST(AccessibilityBridgeTest, canHandleSelectionChangeCorrectly) {
   std::shared_ptr<TestAccessibilityBridge> bridge =
       std::make_shared<TestAccessibilityBridge>();
   FlutterSemanticsNode root = CreateSemanticsNode(0, "root");
-  root.flags = FlutterSemanticsFlag::kFlutterSemanticsFlagIsTextField;
+  root.flags = static_cast<FlutterSemanticsFlag>(
+      FlutterSemanticsFlag::kFlutterSemanticsFlagIsTextField |
+      FlutterSemanticsFlag::kFlutterSemanticsFlagIsFocused);
   bridge->AddFlutterSemanticsNodeUpdate(&root);
   bridge->CommitUpdates();
 

--- a/shell/platform/windows/accessibility_bridge_windows.cc
+++ b/shell/platform/windows/accessibility_bridge_windows.cc
@@ -54,8 +54,8 @@ void AccessibilityBridgeWindows::OnAccessibilityEvent(
             std::static_pointer_cast<FlutterPlatformNodeDelegateWindows>(
                 focus_delegate);
       }
-      DispatchWinAccessibilityEvent(win_delegate,
-                                    ax::mojom::Event::kDocumentSelectionChanged);
+      DispatchWinAccessibilityEvent(
+          win_delegate, ax::mojom::Event::kDocumentSelectionChanged);
       break;
     }
     case ui::AXEventGenerator::Event::FOCUS_CHANGED:

--- a/shell/platform/windows/accessibility_bridge_windows.cc
+++ b/shell/platform/windows/accessibility_bridge_windows.cc
@@ -41,10 +41,16 @@ void AccessibilityBridgeWindows::OnAccessibilityEvent(
       DispatchWinAccessibilityEvent(win_delegate,
                                     ax::mojom::Event::kChildrenChanged);
       break;
-    case ui::AXEventGenerator::Event::DOCUMENT_SELECTION_CHANGED:
+    case ui::AXEventGenerator::Event::DOCUMENT_SELECTION_CHANGED: {
+      ui::AXNode::AXID focus_id = GetAXTreeData().sel_focus_object_id;
+      auto focus_delegate =
+          GetFlutterPlatformNodeDelegateFromID(focus_id).lock();
       DispatchWinAccessibilityEvent(
-          win_delegate, ax::mojom::Event::kDocumentSelectionChanged);
+          std::static_pointer_cast<FlutterPlatformNodeDelegateWindows>(
+              focus_delegate),
+          ax::mojom::Event::kDocumentSelectionChanged);
       break;
+    }
     case ui::AXEventGenerator::Event::FOCUS_CHANGED:
       DispatchWinAccessibilityEvent(win_delegate, ax::mojom::Event::kFocus);
       SetFocus(win_delegate);

--- a/shell/platform/windows/accessibility_bridge_windows.cc
+++ b/shell/platform/windows/accessibility_bridge_windows.cc
@@ -44,7 +44,7 @@ void AccessibilityBridgeWindows::OnAccessibilityEvent(
     case ui::AXEventGenerator::Event::DOCUMENT_SELECTION_CHANGED: {
       // An event indicating a change in document selection should be fired
       // only for the focused node whose selection has changed. If a valid
-      // carat and selection exist in the app tree, they must both be within
+      // caret and selection exist in the app tree, they must both be within
       // the focus node.
       ui::AXNode::AXID focus_id = GetAXTreeData().sel_focus_object_id;
       auto focus_delegate =

--- a/shell/platform/windows/accessibility_bridge_windows.cc
+++ b/shell/platform/windows/accessibility_bridge_windows.cc
@@ -47,12 +47,13 @@ void AccessibilityBridgeWindows::OnAccessibilityEvent(
       ui::AXNode::AXID focus_id = GetAXTreeData().sel_focus_object_id;
       auto focus_delegate =
           GetFlutterPlatformNodeDelegateFromID(focus_id).lock();
-      if (focus_delegate) {
-        DispatchWinAccessibilityEvent(
+      if (!focus_delegate) {
+        win_delegate =
             std::static_pointer_cast<FlutterPlatformNodeDelegateWindows>(
-                focus_delegate),
-            ax::mojom::Event::kDocumentSelectionChanged);
+                focus_delegate);
       }
+      DispatchWinAccessibilityEvent(win_delegate,
+                                    ax::mojom::Event::kDocumentSelectionChanged);
       break;
     }
     case ui::AXEventGenerator::Event::FOCUS_CHANGED:

--- a/shell/platform/windows/accessibility_bridge_windows.cc
+++ b/shell/platform/windows/accessibility_bridge_windows.cc
@@ -42,13 +42,17 @@ void AccessibilityBridgeWindows::OnAccessibilityEvent(
                                     ax::mojom::Event::kChildrenChanged);
       break;
     case ui::AXEventGenerator::Event::DOCUMENT_SELECTION_CHANGED: {
+      // An event indicating a change in document selection should be fired
+      // only for the focused node whose selection has changed.
       ui::AXNode::AXID focus_id = GetAXTreeData().sel_focus_object_id;
       auto focus_delegate =
           GetFlutterPlatformNodeDelegateFromID(focus_id).lock();
-      DispatchWinAccessibilityEvent(
-          std::static_pointer_cast<FlutterPlatformNodeDelegateWindows>(
-              focus_delegate),
-          ax::mojom::Event::kDocumentSelectionChanged);
+      if (focus_delegate) {
+        DispatchWinAccessibilityEvent(
+            std::static_pointer_cast<FlutterPlatformNodeDelegateWindows>(
+                focus_delegate),
+            ax::mojom::Event::kDocumentSelectionChanged);
+      }
       break;
     }
     case ui::AXEventGenerator::Event::FOCUS_CHANGED:

--- a/shell/platform/windows/accessibility_bridge_windows.cc
+++ b/shell/platform/windows/accessibility_bridge_windows.cc
@@ -43,7 +43,9 @@ void AccessibilityBridgeWindows::OnAccessibilityEvent(
       break;
     case ui::AXEventGenerator::Event::DOCUMENT_SELECTION_CHANGED: {
       // An event indicating a change in document selection should be fired
-      // only for the focused node whose selection has changed.
+      // only for the focused node whose selection has changed. If a valid
+      // carat and selection exist in the app tree, they must both be within
+      // the focus node.
       ui::AXNode::AXID focus_id = GetAXTreeData().sel_focus_object_id;
       auto focus_delegate =
           GetFlutterPlatformNodeDelegateFromID(focus_id).lock();

--- a/shell/platform/windows/accessibility_bridge_windows_unittests.cc
+++ b/shell/platform/windows/accessibility_bridge_windows_unittests.cc
@@ -338,5 +338,11 @@ TEST(AccessibilityBridgeWindows, OnAccessibilityStateChanged) {
       ax::mojom::Event::kStateChanged);
 }
 
+TEST(AccessibilityBridgeWindows, OnDocumentSelectionChanged) {
+  ExpectWinEventFromAXEvent(
+      1, ui::AXEventGenerator::Event::DOCUMENT_SELECTION_CHANGED,
+      ax::mojom::Event::kDocumentSelectionChanged);
+}
+
 }  // namespace testing
 }  // namespace flutter


### PR DESCRIPTION
When the text selection of a node is changed, we should only set the AX tree's selection to that of the focused node. Currently, we set it for every node in the update, which means that whichever node happens to be last will have the selection that actually persists, even if it is not the focused node. The order of nodes when iterating through an update is meaningless. The focused flag is added to one unit test as well.

Part of https://github.com/flutter/flutter/issues/116219

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
