### PR TITLE
Consider more `ax::mojom::Role`s as text

### DIFF
--- a/third_party/accessibility/ax/ax_node_position_unittest.cc
+++ b/third_party/accessibility/ax/ax_node_position_unittest.cc
@@ -297,6 +297,7 @@ void AXPositionTest::SetUp() {
                                true);
   text_field_.AddState(ax::mojom::State::kEditable);
   text_field_.SetValue(TEXT_VALUE);
+  text_field_.SetName(TEXT_VALUE);
   text_field_.AddIntListAttribute(
       ax::mojom::IntListAttribute::kCachedLineStarts,
       std::vector<int32_t>{0, 7});
@@ -1078,7 +1079,7 @@ TEST_F(AXPositionTest, GetMaxTextOffsetAndGetTextWithGeneratedContent) {
   root_1.role = ax::mojom::Role::kRootWebArea;
   root_1.child_ids = {text_field_2.id};
 
-  text_field_2.role = ax::mojom::Role::kTextField;
+  text_field_2.role = ax::mojom::Role::kGroup;
   text_field_2.SetValue("3.14");
   text_field_2.child_ids = {static_text_3.id, static_text_5.id};
 
@@ -1573,7 +1574,7 @@ TEST_F(AXPositionTest, AtStartAndEndOfLineInsideTextField) {
 
   AXNodeData text_field_data_1;
   text_field_data_1.id = 2;
-  text_field_data_1.role = ax::mojom::Role::kTextField;
+  text_field_data_1.role = ax::mojom::Role::kGroup;
   // "kIsLineBreakingObject" and the "kEditable" state are not strictly
   // necessary but are added for completeness.
   text_field_data_1.AddBoolAttribute(
@@ -1613,7 +1614,7 @@ TEST_F(AXPositionTest, AtStartAndEndOfLineInsideTextField) {
 
   AXNodeData text_field_data_2;
   text_field_data_2.id = 7;
-  text_field_data_2.role = ax::mojom::Role::kTextField;
+  text_field_data_2.role = ax::mojom::Role::kGroup;
   // "kIsLineBreakingObject" and the "kEditable" state are not strictly
   // necessary but are added for completeness.
   text_field_data_2.AddBoolAttribute(
@@ -7567,7 +7568,7 @@ TEST_F(AXPositionTest, EmptyObjectReplacedByCharacterTextNavigation) {
   inline_box_3.AddIntListAttribute(ax::mojom::IntListAttribute::kWordEnds,
                                    std::vector<int32_t>{6});
 
-  text_field_4.role = ax::mojom::Role::kTextField;
+  text_field_4.role = ax::mojom::Role::kGroup;
   text_field_4.child_ids = {generic_container_5.id};
 
   generic_container_5.role = ax::mojom::Role::kGenericContainer;

--- a/third_party/accessibility/ax/ax_range_unittest.cc
+++ b/third_party/accessibility/ax/ax_range_unittest.cc
@@ -205,7 +205,7 @@ void AXRangeTest::SetUp() {
   check_box2_.AddIntAttribute(ax::mojom::IntAttribute::kPreviousOnLineId,
                               check_box1_.id);
 
-  text_field_.role = ax::mojom::Role::kTextField;
+  text_field_.role = ax::mojom::Role::kGroup;
   text_field_.AddState(ax::mojom::State::kEditable);
   text_field_.SetValue(TEXT_FIELD);
   text_field_.AddIntListAttribute(

--- a/third_party/accessibility/ax/ax_role_properties.cc
+++ b/third_party/accessibility/ax/ax_role_properties.cc
@@ -687,6 +687,9 @@ bool IsText(ax::mojom::Role role) {
     case ax::mojom::Role::kInlineTextBox:
     case ax::mojom::Role::kLineBreak:
     case ax::mojom::Role::kStaticText:
+    case ax::mojom::Role::kTextField:
+    case ax::mojom::Role::kTextFieldWithComboBox:
+    case ax::mojom::Role::kLabelText:
       return true;
     default:
       return false;


### PR DESCRIPTION
Chromium does not use `kTextField` or `kLabel` for text leaf nodes; we do. Adds these roles to the `IsText` helper method.

Part of https://github.com/flutter/flutter/issues/116219

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
