### PR TITLE
Add `TextProvider` and `TextEdit` patterns to `AXPlatformNodeWin`

### DIFF
--- a/third_party/accessibility/ax/platform/ax_platform_node_win.cc
+++ b/third_party/accessibility/ax/platform/ax_platform_node_win.cc
@@ -5600,13 +5600,13 @@ AXPlatformNodeWin::GetPatternProviderFactoryMethod(PATTERNID pattern_id) {
       }
       break;
 
-      case UIA_TextEditPatternId:
-      case UIA_TextPatternId:
-        if (IsText() || IsTextField() ||
-            data.role == ax::mojom::Role::kRootWebArea) {
-          return &AXPlatformNodeTextProviderWin::CreateIUnknown;
-        }
-        break;
+    case UIA_TextEditPatternId:
+    case UIA_TextPatternId:
+      if (IsText() || IsTextField() ||
+          data.role == ax::mojom::Role::kRootWebArea) {
+        return &AXPlatformNodeTextProviderWin::CreateIUnknown;
+      }
+      break;
 
     case UIA_TogglePatternId:
       if (SupportsToggle(data.role)) {

--- a/third_party/accessibility/ax/platform/ax_platform_node_win.cc
+++ b/third_party/accessibility/ax/platform/ax_platform_node_win.cc
@@ -31,6 +31,7 @@
 #include "ax_fragment_root_win.h"
 #include "ax_platform_node_delegate.h"
 #include "ax_platform_node_delegate_utils_win.h"
+#include "ax_platform_node_textprovider_win.h"
 #include "shellscalingapi.h"
 #include "uia_registrar_win.h"
 
@@ -5599,10 +5600,13 @@ AXPlatformNodeWin::GetPatternProviderFactoryMethod(PATTERNID pattern_id) {
       }
       break;
 
-      // TODO(schectman): add implementations for ITextProvider and
-      // ITextRangeProvider interfaces.
-      // https://github.com/flutter/flutter/issues/114547 and
-      // https://github.com/flutter/flutter/issues/109804
+      case UIA_TextEditPatternId:
+      case UIA_TextPatternId:
+        if (IsText() || IsTextField() ||
+            data.role == ax::mojom::Role::kRootWebArea) {
+          return &AXPlatformNodeTextProviderWin::CreateIUnknown;
+        }
+        break;
 
     case UIA_TogglePatternId:
       if (SupportsToggle(data.role)) {

--- a/third_party/accessibility/ax/platform/ax_platform_node_win_unittest.cc
+++ b/third_party/accessibility/ax/platform/ax_platform_node_win_unittest.cc
@@ -3509,11 +3509,13 @@ TEST_F(AXPlatformNodeWinTest, GetPatternProviderSupportedPatterns) {
 
   Init(update);
 
-  EXPECT_EQ(PatternSet({UIA_ScrollItemPatternId}),
+  EXPECT_EQ(PatternSet({UIA_ScrollItemPatternId, UIA_TextPatternId,
+                        UIA_TextEditPatternId}),
             GetSupportedPatternsFromNodeId(root_id));
 
   EXPECT_EQ(PatternSet({UIA_ScrollItemPatternId, UIA_ValuePatternId,
-                        UIA_ExpandCollapsePatternId}),
+                        UIA_ExpandCollapsePatternId, UIA_TextPatternId,
+                        UIA_TextEditPatternId}),
             GetSupportedPatternsFromNodeId(text_field_with_combo_box_id));
 
   EXPECT_EQ(PatternSet({UIA_ScrollItemPatternId, UIA_ValuePatternId,


### PR DESCRIPTION
For UIA implementation, this will enable `AXPlatformNodeWin` to provide the appropriate text patterns, which will be necessary for more complicated screen reader interop such as narrating the selection.

Part of https://github.com/flutter/flutter/issues/116219

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
