### PR TITLE
[Impeller Scene] Fix material/vertex color overlapping

### DIFF
--- a/impeller/scene/material.cc
+++ b/impeller/scene/material.cc
@@ -79,9 +79,11 @@ std::unique_ptr<UnlitMaterial> UnlitMaterial::MakeFromFlatbuffer(
 
   auto result = Material::MakeUnlit();
 
-  result->SetColor(material.base_color_factor()
-                       ? importer::ToColor(*material.base_color_factor())
-                       : Color::White());
+  if (material.base_color_factor()) {
+    result->SetColor(importer::ToColor(*material.base_color_factor()));
+    result->SetVertexColorWeight(0);
+  }
+
   if (material.base_color_texture() >= 0 &&
       material.base_color_texture() < static_cast<int32_t>(textures.size())) {
     result->SetColorTexture(textures[material.base_color_texture()]);


### PR DESCRIPTION
Quick fix to make material base colors take precedent when present over vertex colors by default for imported models.

Before:

<img width="1136" alt="Screenshot 2023-01-04 at 5 43 41 PM" src="https://user-images.githubusercontent.com/919017/210682680-8439011c-9c24-4401-af15-550a93498f10.png">


After:

<img width="1136" alt="Screenshot 2023-01-04 at 5 42 41 PM" src="https://user-images.githubusercontent.com/919017/210682682-b1c8f2fe-41a7-49ea-a210-b68cc2d4f734.png">
