### PR TITLE
Correct FrameTimingRecorder's raster start time.

### DIFF
--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -512,6 +512,8 @@ RasterStatus Rasterizer::DrawToSurfaceUnsafe(
   // frame after calling `BeginFrame` as this operation resets the GL context.
   auto frame = surface_->AcquireFrame(layer_tree.frame_size());
   if (frame == nullptr) {
+    frame_timings_recorder.RecordRasterEnd(
+        &compositor_context_->raster_cache());
     return RasterStatus::kFailed;
   }
 

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -504,6 +504,8 @@ RasterStatus Rasterizer::DrawToSurfaceUnsafe(
     embedder_root_canvas = external_view_embedder_->GetRootCanvas();
   }
 
+  frame_timings_recorder.RecordRasterStart(fml::TimePoint::Now());
+
   // On Android, the external view embedder deletes surfaces in `BeginFrame`.
   //
   // Deleting a surface also clears the GL context. Therefore, acquire the
@@ -536,7 +538,6 @@ RasterStatus Rasterizer::DrawToSurfaceUnsafe(
   );
   if (compositor_frame) {
     compositor_context_->raster_cache().BeginFrame();
-    frame_timings_recorder.RecordRasterStart(fml::TimePoint::Now());
 
     std::unique_ptr<FrameDamage> damage;
     // when leaf layer tracing is enabled we wish to repaint the whole frame

--- a/shell/gpu/gpu_surface_metal_skia.mm
+++ b/shell/gpu/gpu_surface_metal_skia.mm
@@ -201,7 +201,6 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetalSkia::AcquireFrameFromCAMetalLayer(
 
 std::unique_ptr<SurfaceFrame> GPUSurfaceMetalSkia::AcquireFrameFromMTLTexture(
     const SkISize& frame_info) {
-  TRACE_EVENT0("flutter", "GPUSurfaceMetalSkia::AcquireFrameFromMTLTexture");
   GPUMTLTextureInfo texture = delegate_->GetMTLTexture(frame_info);
   id<MTLTexture> mtl_texture = (id<MTLTexture>)(texture.texture);
 

--- a/shell/gpu/gpu_surface_metal_skia.mm
+++ b/shell/gpu/gpu_surface_metal_skia.mm
@@ -119,7 +119,6 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetalSkia::AcquireFrame(const SkISize& f
 
 std::unique_ptr<SurfaceFrame> GPUSurfaceMetalSkia::AcquireFrameFromCAMetalLayer(
     const SkISize& frame_info) {
-  TRACE_EVENT0("flutter", "GPUSurfaceMetalSkia::AcquireFrameFromCAMetalLayer");
   auto layer = delegate_->GetCAMetalLayer(frame_info);
   if (!layer) {
     FML_LOG(ERROR) << "Invalid CAMetalLayer given by the embedder.";

--- a/shell/gpu/gpu_surface_metal_skia.mm
+++ b/shell/gpu/gpu_surface_metal_skia.mm
@@ -86,6 +86,7 @@ void GPUSurfaceMetalSkia::PrecompileKnownSkSLsIfNecessary() {
 
 // |Surface|
 std::unique_ptr<SurfaceFrame> GPUSurfaceMetalSkia::AcquireFrame(const SkISize& frame_size) {
+  TRACE_EVENT0("flutter", "GPUSurfaceMetalSkia::AcquireFrame");
   if (!IsValid()) {
     FML_LOG(ERROR) << "Metal surface was invalid.";
     return nullptr;
@@ -118,6 +119,7 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetalSkia::AcquireFrame(const SkISize& f
 
 std::unique_ptr<SurfaceFrame> GPUSurfaceMetalSkia::AcquireFrameFromCAMetalLayer(
     const SkISize& frame_info) {
+  TRACE_EVENT0("flutter", "GPUSurfaceMetalSkia::AcquireFrameFromCAMetalLayer");
   auto layer = delegate_->GetCAMetalLayer(frame_info);
   if (!layer) {
     FML_LOG(ERROR) << "Invalid CAMetalLayer given by the embedder.";
@@ -199,6 +201,7 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetalSkia::AcquireFrameFromCAMetalLayer(
 
 std::unique_ptr<SurfaceFrame> GPUSurfaceMetalSkia::AcquireFrameFromMTLTexture(
     const SkISize& frame_info) {
+  TRACE_EVENT0("flutter", "GPUSurfaceMetalSkia::AcquireFrameFromMTLTexture");
   GPUMTLTextureInfo texture = delegate_->GetMTLTexture(frame_info);
   id<MTLTexture> mtl_texture = (id<MTLTexture>)(texture.texture);
 

--- a/shell/gpu/gpu_surface_metal_skia.mm
+++ b/shell/gpu/gpu_surface_metal_skia.mm
@@ -86,7 +86,6 @@ void GPUSurfaceMetalSkia::PrecompileKnownSkSLsIfNecessary() {
 
 // |Surface|
 std::unique_ptr<SurfaceFrame> GPUSurfaceMetalSkia::AcquireFrame(const SkISize& frame_size) {
-  TRACE_EVENT0("flutter", "GPUSurfaceMetalSkia::AcquireFrame");
   if (!IsValid()) {
     FML_LOG(ERROR) << "Metal surface was invalid.";
     return nullptr;


### PR DESCRIPTION
Fix:
- https://github.com/flutter/flutter/issues/118088


The code 
```C++
auto frame = surface_->AcquireFrame(layer_tree.frame_size());
```
**could be very time-consuming sometimes. I think we should record it into raster time**. So that we can observe this correctly using **DevTools or `addTimingCallback` of framework side.**

**About why this operation will be time-consuming, see PR below (Still WIP & Needs triage)**
- https://github.com/flutter/engine/pull/38551

# Preview

## DevTools

**Before patch:**

https://user-images.githubusercontent.com/49340347/210971082-6fc1c547-7c08-4ace-a8a2-2f57d97b6402.mp4

**After patch:**

https://user-images.githubusercontent.com/49340347/210971039-0b0b39a7-fc36-4c51-8a21-5ade027a122b.mp4

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.