### PR TITLE
[fuchsia] Enable CI for branches like `fuchsia_r51a`.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -8,7 +8,7 @@
 enabled_branches:
   - main
   - flutter-\d+\.\d+-candidate\.\d+
-  - fuchsia_r\d+
+  - fuchsia_r\d+[a-z]*
 
 platform_properties:
   linux:


### PR DESCRIPTION
We ended up needing a second cherrypick branch for the R51 release as the first release candidate was abandoned. This was the convention the Fuchsia team settled on for their branch name that we are trying to match.