### PR TITLE
Running macOS resize listener in background queue to avoid frozen animations when the main thread is blocked

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm
@@ -78,8 +78,6 @@
 }
 
 - (void)commit:(NSArray<FlutterSurfacePresentInfo*>*)surfaces {
-  FML_DCHECK([NSThread isMainThread]);
-
   // Release all unused back buffer surfaces and replace them with front surfaces.
   [_backBufferCache replaceSurfaces:_frontSurfaces];
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterThreadSynchronizer.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterThreadSynchronizer.mm
@@ -25,8 +25,6 @@
 @implementation FlutterThreadSynchronizer
 
 - (void)drain {
-  FML_DCHECK([NSThread isMainThread]);
-
   [CATransaction begin];
   [CATransaction setDisableActions:YES];
   for (dispatch_block_t block : _scheduledBlocks) {
@@ -88,7 +86,7 @@
     if (_beginResizeWaiting) {
       _condBlockBeginResize.notify_all();
     } else {
-      dispatch_async(dispatch_get_main_queue(), ^{
+      dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INTERACTIVE, 0), ^{
         std::unique_lock<std::mutex> lock(_mutex);
         [self drain];
       });


### PR DESCRIPTION
This changes part of the macOS embedder to run its resize listener in a background queue rather than the main thread. This change is necessary because some AppKit APIs must be called in the main thread and block until they return, which currently causes the app to freeze during that time. Out of the box I've noticed this while interacting with the macOS menu bar, which causes brief but noticeable jank. A more serious problem is that this makes implementing plugins that use certain native functionality impractical, as they can cause anything from jank to freezing the entire app for extended periods of time. This is the problem I'm currently encountering: showing a native context menu via [`NSMenu.popUpContextMenu`][2] freezes the entire app until the menu is dismissed.

Although the tests pass and I haven't observed any issues running a real app with these changes, I assume the `isMainThread` assertions I took out were there for a reason and this can't be merged as-is. I'm opening this PR as a draft in the hopes that someone more familiar with the codebase knows what those assertions were for and can point me in the right direction so I can work on a proper implementation w/ test coverage. I'd especially appreciate any input from:

- @knopp, who recently merged a major refactor of the macOS rendering infrastructure
- @cbracken, who weighed in on my original bug report on this issue and was a reviewer on knopp's recent macOS refactor PR
- @dkwingsmt, who was also a reviewer on knopp's PR

Closes flutter/flutter#104638

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[1]: https://developer.apple.com/documentation/dispatch/dispatchqos/1780708-userinteractive
[2]: https://developer.apple.com/documentation/appkit/nsmenu/1518170-popupcontextmenu
