### PR TITLE
[macOS] Implement platform view mutators

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -2572,6 +2572,7 @@ ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterMou
 ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterMouseCursorPlugin.mm + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterMutatorView.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterMutatorView.mm + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterMutatorViewTest.mm + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMac.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMac.mm + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm + ../../../flutter/LICENSE
@@ -5084,6 +5085,7 @@ FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterMouse
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterMouseCursorPlugin.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterMutatorView.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterMutatorView.mm
+FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterMutatorViewTest.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMac.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMac.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -2570,6 +2570,8 @@ ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterMen
 ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterMenuPlugin_Internal.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterMouseCursorPlugin.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterMouseCursorPlugin.mm + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterMutatorView.h + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterMutatorView.mm + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMac.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMac.mm + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm + ../../../flutter/LICENSE
@@ -5080,6 +5082,8 @@ FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterMenuP
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterMenuPlugin_Internal.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterMouseCursorPlugin.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterMouseCursorPlugin.mm
+FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterMutatorView.h
+FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterMutatorView.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMac.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMac.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm

--- a/shell/platform/darwin/macos/BUILD.gn
+++ b/shell/platform/darwin/macos/BUILD.gn
@@ -80,6 +80,8 @@ source_set("flutter_framework_source") {
     "framework/Source/FlutterMenuPlugin_Internal.h",
     "framework/Source/FlutterMouseCursorPlugin.h",
     "framework/Source/FlutterMouseCursorPlugin.mm",
+    "framework/Source/FlutterMutatorView.h",
+    "framework/Source/FlutterMutatorView.mm",
     "framework/Source/FlutterPlatformNodeDelegateMac.h",
     "framework/Source/FlutterPlatformNodeDelegateMac.mm",
     "framework/Source/FlutterPlatformViewController.h",

--- a/shell/platform/darwin/macos/BUILD.gn
+++ b/shell/platform/darwin/macos/BUILD.gn
@@ -174,6 +174,7 @@ executable("flutter_desktop_darwin_unittests") {
     "framework/Source/FlutterEngineTestUtils.mm",
     "framework/Source/FlutterKeyboardManagerTest.mm",
     "framework/Source/FlutterMenuPluginTest.mm",
+    "framework/Source/FlutterMutatorViewTest.mm",
     "framework/Source/FlutterPlatformNodeDelegateMacTest.mm",
     "framework/Source/FlutterPlatformViewControllerTest.mm",
     "framework/Source/FlutterRendererTest.mm",

--- a/shell/platform/darwin/macos/framework/Source/FlutterCompositor.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterCompositor.h
@@ -13,6 +13,8 @@
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterViewProvider.h"
 #include "flutter/shell/platform/embedder/embedder.h"
 
+@class FlutterMutatorView;
+
 namespace flutter {
 
 // FlutterCompositor creates and manages the backing stores used for
@@ -25,9 +27,8 @@ class FlutterCompositor {
   // The view_provider is used to query FlutterViews from view IDs,
   // which are used for presenting and creating backing stores.
   // It must not be null, and is typically FlutterViewEngineProvider.
-  explicit FlutterCompositor(
-      id<FlutterViewProvider> view_provider,
-      FlutterPlatformViewController* platform_views_controller);
+  explicit FlutterCompositor(id<FlutterViewProvider> view_provider,
+                             FlutterPlatformViewController* platform_views_controller);
 
   ~FlutterCompositor() = default;
 
@@ -48,23 +49,28 @@ class FlutterCompositor {
 
   // Presents the FlutterLayers by updating the FlutterView specified by
   // `view_id` using the layer content. Sets frame_started_ to false.
-  bool Present(uint64_t view_id,
-               const FlutterLayer** layers,
-               size_t layers_count);
+  bool Present(uint64_t view_id, const FlutterLayer** layers, size_t layers_count);
 
  private:
+  void PresentPlatformViews(FlutterView* default_base_view,
+                            const FlutterLayer** layers,
+                            size_t layers_count);
+
   // Presents the platform view layer represented by `layer`. `layer_index` is
   // used to position the layer in the z-axis. If the layer does not have a
   // superview, it will become subview of `default_base_view`.
-  void PresentPlatformView(FlutterView* default_base_view,
-                           const FlutterLayer* layer,
-                           size_t layer_position);
+  FlutterMutatorView* PresentPlatformView(FlutterView* default_base_view,
+                                          const FlutterLayer* layer,
+                                          size_t layer_position);
 
   // Where the compositor can query FlutterViews. Must not be null.
   id<FlutterViewProvider> const view_provider_;
 
   // The controller used to manage creation and deletion of platform views.
   const FlutterPlatformViewController* platform_view_controller_;
+
+  // Platform view to FlutterMutatorView that contains it.
+  NSMapTable<NSView*, FlutterMutatorView*>* mutator_views_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(FlutterCompositor);
 };

--- a/shell/platform/darwin/macos/framework/Source/FlutterMutatorView.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterMutatorView.h
@@ -1,0 +1,24 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <Cocoa/Cocoa.h>
+
+#include "flutter/shell/platform/embedder/embedder.h"
+
+/// FlutterMutatorView contains platform view and is responsible for applying
+/// FlutterLayer mutations to it.
+@interface FlutterMutatorView : NSView
+
+/// Designated initializer.
+- (nonnull instancetype)initWithPlatformView:(nonnull NSView*)platformView;
+
+/// Returns wrapped platform view.
+@property(readonly, nonnull) NSView* platformView;
+
+/// Applies mutations from FlutterLayer to the platform view. This may involve
+/// creating or removing intermediate subviews depending on current state and
+/// requested mutations.
+- (void)applyFlutterLayer:(nonnull const FlutterLayer*)layer;
+
+@end

--- a/shell/platform/darwin/macos/framework/Source/FlutterMutatorView.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterMutatorView.h
@@ -22,10 +22,3 @@
 - (void)applyFlutterLayer:(nonnull const FlutterLayer*)layer;
 
 @end
-
-@interface FlutterMutatorView (Private)
-
-@property(readonly, nonatomic, nonnull) NSMutableArray<NSView*>* pathClipViews;
-@property(readonly, nonatomic, nullable) NSView* platformViewContainer;
-
-@end

--- a/shell/platform/darwin/macos/framework/Source/FlutterMutatorView.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterMutatorView.h
@@ -22,3 +22,10 @@
 - (void)applyFlutterLayer:(nonnull const FlutterLayer*)layer;
 
 @end
+
+@interface FlutterMutatorView (Private)
+
+@property(readonly, nonatomic, nonnull) NSMutableArray<NSView*>* pathClipViews;
+@property(readonly, nonatomic, nullable) NSView* platformViewContainer;
+
+@end

--- a/shell/platform/darwin/macos/framework/Source/FlutterMutatorView.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterMutatorView.mm
@@ -1,0 +1,353 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterMutatorView.h"
+#include "flutter/fml/logging.h"
+
+#include <QuartzCore/QuartzCore.h>
+#include <vector>
+
+@interface FlutterMutatorView () {
+  /// Each of these views clips to a CGPathRef. These views, if present,
+  /// are nested (first is child of FlutterMutatorView and last is parent of
+  // _platformView).
+  NSMutableArray* _pathClipViews;
+
+  // View right above the platform view. Used to apply the final transform
+  // (sans the translation) to the platform view.
+  NSView* _platformViewContainer;
+
+  NSView* _platformView;
+}
+
+@end
+
+/// View that clips that content to a specific CGPathRef.
+/// Clipping is done through a CAShapeLayer mask, which avoids the need to
+/// rasterize the mask.
+@interface FlutterPathClipView : NSView
+
+@end
+
+@implementation FlutterPathClipView
+
+- (instancetype)initWithFrame:(NSRect)frameRect {
+  if (self = [super initWithFrame:frameRect]) {
+    self.wantsLayer = YES;
+  }
+  return self;
+}
+
+- (BOOL)isFlipped {
+  return YES;
+}
+
+/// Clip the view to the given path. Offset top left corner of platform view
+/// in global logical coordinates.
+- (void)maskToPath:(CGPathRef)path withOrigin:(CGPoint)origin {
+  CAShapeLayer* maskLayer = self.layer.mask;
+  if (maskLayer == nil) {
+    maskLayer = [CAShapeLayer layer];
+    self.layer.mask = maskLayer;
+  }
+  maskLayer.path = path;
+  maskLayer.transform = CATransform3DMakeTranslation(-origin.x, -origin.y, 0);
+}
+
+@end
+
+namespace {
+CATransform3D ToCATransform3D(const FlutterTransformation& t) {
+  CATransform3D transform = CATransform3DIdentity;
+  transform.m11 = t.scaleX;
+  transform.m21 = t.skewX;
+  transform.m41 = t.transX;
+  transform.m14 = t.pers0;
+  transform.m12 = t.skewY;
+  transform.m22 = t.scaleY;
+  transform.m42 = t.transY;
+  transform.m24 = t.pers1;
+  return transform;
+}
+
+CGRect FromFlutterRect(const FlutterRect& rect) {
+  return CGRectMake(rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top);
+}
+
+FlutterRect ToFlutterRect(const CGRect& rect) {
+  return FlutterRect{
+      .left = rect.origin.x,
+      .top = rect.origin.y,
+      .right = rect.origin.x + rect.size.width,
+      .bottom = rect.origin.y + rect.size.height,
+
+  };
+}
+
+/// Returns whether the point is inside ellipse with given radius (centered at 0, 0).
+bool PointInsideEllipse(const CGPoint& point, const FlutterSize& radius) {
+  return (point.x * point.x) / (radius.width * radius.width) +
+             (point.y * point.y) / (radius.height * radius.height) <
+         1.0;
+}
+
+bool RoundRectCornerIntersects(const FlutterRoundedRect& roundRect, const FlutterRect& rect) {
+  // Inner coordinate of the top left corner of the round rect.
+  CGPoint inner_top_left =
+      CGPointMake(roundRect.rect.left + roundRect.upper_left_corner_radius.width,
+                  roundRect.rect.top + roundRect.upper_left_corner_radius.height);
+
+  // Position of `rect` corner relative to inner_top_left.
+  CGPoint relative_top_left =
+      CGPointMake(rect.left - inner_top_left.x, rect.top - inner_top_left.y);
+
+  // `relative_top_left` is in upper left quadrant.
+  if (relative_top_left.x < 0 && relative_top_left.y < 0) {
+    if (!PointInsideEllipse(relative_top_left, roundRect.upper_left_corner_radius)) {
+      return true;
+    }
+  }
+
+  // Inner coordinate of the top right corner of the round rect.
+  CGPoint inner_top_right =
+      CGPointMake(roundRect.rect.right - roundRect.upper_right_corner_radius.width,
+                  roundRect.rect.top + roundRect.upper_right_corner_radius.height);
+
+  // Positon of `rect` corner relative to inner_top_right.
+  CGPoint relative_top_right =
+      CGPointMake(rect.right - inner_top_right.x, rect.top - inner_top_right.y);
+
+  // `relative_top_right` is in top right quadrant.
+  if (relative_top_right.x > 0 && relative_top_right.y < 0) {
+    if (!PointInsideEllipse(relative_top_right, roundRect.upper_right_corner_radius)) {
+      return true;
+    }
+  }
+
+  // Inner coordinate of the bottom left corner of the round rect.
+  CGPoint inner_bottom_left =
+      CGPointMake(roundRect.rect.left + roundRect.lower_left_corner_radius.width,
+                  roundRect.rect.bottom - roundRect.lower_left_corner_radius.height);
+
+  // Position of `rect` corner relative to inner_bottom_left.
+  CGPoint relative_bottom_left =
+      CGPointMake(rect.left - inner_bottom_left.x, rect.bottom - inner_bottom_left.y);
+
+  // `relative_bottom_left` is in bottom left quadrant.
+  if (relative_bottom_left.x < 0 && relative_bottom_left.y > 0) {
+    if (!PointInsideEllipse(relative_bottom_left, roundRect.lower_left_corner_radius)) {
+      return true;
+    }
+  }
+
+  // Inner coordinate of the bottom right corner of the round rect.
+  CGPoint inner_bottom_right =
+      CGPointMake(roundRect.rect.right - roundRect.lower_right_corner_radius.width,
+                  roundRect.rect.bottom - roundRect.lower_right_corner_radius.height);
+
+  // Position of `rect` corner relative to inner_bottom_right.
+  CGPoint relative_bottom_right =
+      CGPointMake(rect.right - inner_bottom_right.x, rect.bottom - inner_bottom_right.y);
+
+  // `relative_bottom_right` is in bottom right quadrant.
+  if (relative_bottom_right.x > 0 && relative_bottom_right.y > 0) {
+    if (!PointInsideEllipse(relative_bottom_right, roundRect.lower_right_corner_radius)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+CGPathRef PathFromRoundedRect(const FlutterRoundedRect& roundedRect) {
+  CGMutablePathRef path = CGPathCreateMutable();
+
+  const auto& rect = roundedRect.rect;
+  const auto& topLeft = roundedRect.upper_left_corner_radius;
+  const auto& topRight = roundedRect.upper_right_corner_radius;
+  const auto& bottomLeft = roundedRect.lower_left_corner_radius;
+  const auto& bottomRight = roundedRect.lower_right_corner_radius;
+
+  CGPathMoveToPoint(path, nullptr, rect.left + topLeft.width, rect.top);
+  CGPathAddLineToPoint(path, nullptr, rect.right - topRight.width, rect.top);
+  CGPathAddCurveToPoint(path, nullptr, rect.right, rect.top, rect.right, rect.top + topRight.height,
+                        rect.right, rect.top + topRight.height);
+  CGPathAddLineToPoint(path, nullptr, rect.right, rect.bottom - bottomRight.height);
+  CGPathAddCurveToPoint(path, nullptr, rect.right, rect.bottom, rect.right - bottomRight.width,
+                        rect.bottom, rect.right - bottomRight.width, rect.bottom);
+  CGPathAddLineToPoint(path, nullptr, rect.left + bottomLeft.width, rect.bottom);
+  CGPathAddCurveToPoint(path, nullptr, rect.left, rect.bottom, rect.left,
+                        rect.bottom - bottomLeft.height, rect.left,
+                        rect.bottom - bottomLeft.height);
+  CGPathAddLineToPoint(path, nullptr, rect.left, rect.top + topLeft.height);
+  CGPathAddCurveToPoint(path, nullptr, rect.left, rect.top, rect.left + topLeft.width, rect.top,
+                        rect.left + topLeft.width, rect.top);
+  CGPathCloseSubpath(path);
+  return path;
+}
+}  // namespace
+
+@implementation FlutterMutatorView
+
+- (NSView*)platformView {
+  return _platformView;
+}
+
+- (instancetype)initWithPlatformView:(NSView*)platformView {
+  if (self = [super initWithFrame:NSZeroRect]) {
+    _platformView = platformView;
+    _pathClipViews = [NSMutableArray array];
+    self.wantsLayer = YES;
+  }
+  return self;
+}
+
+- (NSView*)hitTest:(NSPoint)point {
+  return nil;
+}
+
+- (BOOL)isFlipped {
+  return YES;
+}
+
+/// Whenever possible view will be clipped using layer bounds.
+/// If clipping to path is needed, CAShapeLayer(s) will be used as mask.
+/// Clipping to round rect only clips to path if round corners are intersected.
+- (void)applyFlutterLayer:(const FlutterLayer*)layer {
+  CGFloat scale = self.superview.layer.contentsScale;
+
+  // Initial transform to compensate for scale factor. This is needed because all
+  // cocoa coordinates are logical but Flutter will send the physical to logical
+  // transform in mutations.
+  CATransform3D transform = CATransform3DMakeScale(1.0 / scale, 1.0 / scale, 1);
+
+  // Platform view transform after applying all transformation mutations.
+  CATransform3D finalTransform = transform;
+  for (size_t i = 0; i < layer->platform_view->mutations_count; ++i) {
+    auto mutation = layer->platform_view->mutations[i];
+    if (mutation->type == kFlutterPlatformViewMutationTypeTransformation) {
+      finalTransform =
+          CATransform3DConcat(ToCATransform3D(mutation->transformation), finalTransform);
+    }
+  }
+
+  CGRect untransformedBoundingRect =
+      CGRectMake(0, 0, layer->size.width / scale, layer->size.height / scale);
+
+  CGRect finalBoundingRect = CGRectApplyAffineTransform(
+      untransformedBoundingRect, CATransform3DGetAffineTransform(finalTransform));
+
+  self.frame = finalBoundingRect;
+
+  // Master clip in global logical coordinates. This is intersection of all clip rectangles
+  // present in mutators.
+  CGRect masterClip = finalBoundingRect;
+
+  self.layer.opacity = 1.0;
+
+  // Gathered pairs of rounded rect in local coordinates + appropriate transform.
+  std::vector<std::pair<FlutterRoundedRect, CGAffineTransform>> roundedRects;
+
+  for (size_t i = 0; i < layer->platform_view->mutations_count; ++i) {
+    auto mutation = layer->platform_view->mutations[i];
+    if (mutation->type == kFlutterPlatformViewMutationTypeTransformation) {
+      transform = CATransform3DConcat(ToCATransform3D(mutation->transformation), transform);
+    } else if (mutation->type == kFlutterPlatformViewMutationTypeClipRect) {
+      CGRect rect = CGRectApplyAffineTransform(FromFlutterRect(mutation->clip_rect),
+                                               CATransform3DGetAffineTransform(transform));
+      masterClip = CGRectIntersection(rect, masterClip);
+    } else if (mutation->type == kFlutterPlatformViewMutationTypeClipRoundedRect) {
+      CGAffineTransform affineTransform = CATransform3DGetAffineTransform(transform);
+      roundedRects.push_back(std::make_pair(mutation->clip_rounded_rect, affineTransform));
+      CGRect rect = CGRectApplyAffineTransform(FromFlutterRect(mutation->clip_rounded_rect.rect),
+                                               affineTransform);
+      masterClip = CGRectIntersection(rect, masterClip);
+    } else if (mutation->type == kFlutterPlatformViewMutationTypeOpacity) {
+      self.layer.opacity *= mutation->opacity;
+    }
+  }
+
+  if (CGRectIsNull(masterClip)) {
+    self.hidden = YES;
+    return;
+  }
+
+  self.hidden = NO;
+
+  /// Paths in global logical coordinates that need to be clipped to.
+  NSMutableArray* paths = [NSMutableArray array];
+
+  for (const auto& r : roundedRects) {
+    CGAffineTransform inverse = CGAffineTransformInvert(r.second);
+    // Transform master clip to clip rect coordinates and check if this view intersects one of the
+    // corners, which means we need to use path clipping.
+    CGRect localMasterClip = CGRectApplyAffineTransform(masterClip, inverse);
+
+    // Only clip to rounded rectangle path if the view intersects some of the round corners. If
+    // not, clipping to masterClip is enough.
+    if (RoundRectCornerIntersects(r.first, ToFlutterRect(localMasterClip))) {
+      CGPathRef path = PathFromRoundedRect(r.first);
+      CGPathRef transformedPath = CGPathCreateCopyByTransformingPath(path, &r.second);
+      [paths addObject:(__bridge id)transformedPath];
+      CGPathRelease(transformedPath);
+      CGPathRelease(path);
+    }
+  }
+
+  // Add / remove path clip views depending on the number of paths.
+
+  while (_pathClipViews.count > paths.count) {
+    NSView* view = _pathClipViews.lastObject;
+    [view removeFromSuperview];
+    [_pathClipViews removeLastObject];
+  }
+
+  NSView* lastView = self;
+
+  for (size_t i = 0; i < paths.count; ++i) {
+    FlutterPathClipView* pathClipView = nil;
+    if (i < _pathClipViews.count) {
+      pathClipView = _pathClipViews[i];
+    } else {
+      pathClipView = [[FlutterPathClipView alloc] initWithFrame:self.bounds];
+      [_pathClipViews addObject:pathClipView];
+      [lastView addSubview:pathClipView];
+    }
+    pathClipView.frame = self.bounds;
+    [pathClipView maskToPath:(__bridge CGPathRef)[paths objectAtIndex:i]
+                  withOrigin:finalBoundingRect.origin];
+    lastView = pathClipView;
+  }
+
+  // Used to apply sublayer transform.
+  if (_platformViewContainer == nil) {
+    _platformViewContainer = [[NSView alloc] initWithFrame:self.bounds];
+    _platformViewContainer.wantsLayer = YES;
+  }
+
+  [lastView addSubview:_platformViewContainer];
+  _platformViewContainer.frame = self.bounds;
+
+  [_platformViewContainer addSubview:_platformView];
+  _platformView.frame = untransformedBoundingRect;
+
+  // Transform for the platform view is finalTransform adjusted for bounding rect origin.
+  _platformViewContainer.layer.sublayerTransform = CATransform3DTranslate(
+      finalTransform, -finalBoundingRect.origin.x / finalTransform.m11 /* scaleX */,
+      -finalBoundingRect.origin.y / finalTransform.m22 /* scaleY */, 0);
+
+  // By default NSView clips children to frame. If masterClip is tighter than mutator view frame,
+  // the frame is set to masterClip and child offset adjusted to compensate for the difference.
+  if (!CGRectEqualToRect(masterClip, finalBoundingRect)) {
+    FML_DCHECK(self.subviews.count == 1);
+    auto subview = self.subviews.firstObject;
+    FML_DCHECK(subview.frame.origin.x == 0 && subview.frame.origin.y == 0);
+    subview.frame = CGRectMake(finalBoundingRect.origin.x - masterClip.origin.x,
+                               finalBoundingRect.origin.y - masterClip.origin.y,
+                               subview.frame.size.width, subview.frame.size.height);
+    self.frame = masterClip;
+  }
+}
+
+@end

--- a/shell/platform/darwin/macos/framework/Source/FlutterMutatorView.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterMutatorView.mm
@@ -194,6 +194,14 @@ CGPathRef PathFromRoundedRect(const FlutterRoundedRect& roundedRect) {
   return _platformView;
 }
 
+- (NSMutableArray*)pathClipViews {
+  return _pathClipViews;
+}
+
+- (NSView*)platformViewContainer {
+  return _platformViewContainer;
+}
+
 - (instancetype)initWithPlatformView:(NSView*)platformView {
   if (self = [super initWithFrame:NSZeroRect]) {
     _platformView = platformView;
@@ -215,7 +223,7 @@ CGPathRef PathFromRoundedRect(const FlutterRoundedRect& roundedRect) {
 /// If clipping to path is needed, CAShapeLayer(s) will be used as mask.
 /// Clipping to round rect only clips to path if round corners are intersected.
 - (void)applyFlutterLayer:(const FlutterLayer*)layer {
-  CGFloat scale = self.superview.layer.contentsScale;
+  CGFloat scale = self.superview != nil ? self.superview.layer.contentsScale : 1.0;
 
   // Initial transform to compensate for scale factor. This is needed because all
   // cocoa coordinates are logical but Flutter will send the physical to logical

--- a/shell/platform/darwin/macos/framework/Source/FlutterMutatorViewTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterMutatorViewTest.mm
@@ -1,0 +1,430 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterMutatorView.h"
+
+#include "third_party/googletest/googletest/include/gtest/gtest.h"
+
+namespace {
+void ApplyFlutterLayer(FlutterMutatorView* view,
+                       FlutterSize size,
+                       const std::vector<FlutterPlatformViewMutation>& mutations) {
+  FlutterLayer layer;
+  layer.struct_size = sizeof(FlutterLayer);
+  layer.type = kFlutterLayerContentTypePlatformView;
+  // Offset is ignored by mutator view, the bounding rect is determined by
+  // width and transform.
+  layer.offset = FlutterPoint{0, 0};
+  layer.size = size;
+
+  FlutterPlatformView flutterPlatformView;
+  flutterPlatformView.struct_size = sizeof(FlutterPlatformView);
+  flutterPlatformView.identifier = 0;
+
+  std::vector<const FlutterPlatformViewMutation*> mutationPointers;
+  for (auto& mutation : mutations) {
+    mutationPointers.push_back(&mutation);
+  }
+  flutterPlatformView.mutations = mutationPointers.data();
+  flutterPlatformView.mutations_count = mutationPointers.size();
+  layer.platform_view = &flutterPlatformView;
+
+  [view applyFlutterLayer:&layer];
+}
+}  // namespace
+
+TEST(FlutterMutatorViewTest, BasicFrameIsCorrect) {
+  NSView* platformView = [[NSView alloc] init];
+  FlutterMutatorView* mutatorView = [[FlutterMutatorView alloc] initWithPlatformView:platformView];
+
+  EXPECT_EQ(mutatorView.platformView, platformView);
+
+  std::vector<FlutterPlatformViewMutation> mutations{
+      {
+          .type = kFlutterPlatformViewMutationTypeTransformation,
+          .transformation =
+              FlutterTransformation{
+                  .scaleX = 1,
+                  .transX = 100,
+                  .scaleY = 1,
+                  .transY = 50,
+              },
+      },
+  };
+
+  ApplyFlutterLayer(mutatorView, FlutterSize{30, 20}, mutations);
+
+  EXPECT_TRUE(CGRectEqualToRect(mutatorView.frame, CGRectMake(100, 50, 30, 20)));
+  EXPECT_TRUE(CGRectEqualToRect(platformView.frame, CGRectMake(0, 0, 30, 20)));
+  EXPECT_EQ(mutatorView.pathClipViews.count, 0ull);
+  EXPECT_NE(mutatorView.platformViewContainer, nil);
+}
+
+TEST(FlutterMutatorViewTest, TransformedFrameIsCorrect) {
+  NSView* platformView = [[NSView alloc] init];
+  FlutterMutatorView* mutatorView = [[FlutterMutatorView alloc] initWithPlatformView:platformView];
+  NSView* mutatorViewParent = [[NSView alloc] init];
+  mutatorViewParent.wantsLayer = YES;
+  mutatorViewParent.layer.contentsScale = 2.0;
+  [mutatorViewParent addSubview:mutatorView];
+
+  std::vector<FlutterPlatformViewMutation> mutations{
+      {
+          .type = kFlutterPlatformViewMutationTypeTransformation,
+          .transformation =
+              FlutterTransformation{
+                  .scaleX = 2,
+                  .scaleY = 2,
+              },
+      },
+      {
+          .type = kFlutterPlatformViewMutationTypeTransformation,
+          .transformation =
+              FlutterTransformation{
+                  .scaleX = 1,
+                  .transX = 100,
+                  .scaleY = 1,
+                  .transY = 50,
+              },
+      },
+      {
+          .type = kFlutterPlatformViewMutationTypeTransformation,
+          .transformation =
+              FlutterTransformation{
+                  .scaleX = 1.5,
+                  .transX = -7.5,
+                  .scaleY = 1.5,
+                  .transY = -5,
+              },
+      },
+  };
+
+  // PlatformView size form engine comes in physical pixels
+  ApplyFlutterLayer(mutatorView, FlutterSize{30 * 2, 20 * 2}, mutations);
+  EXPECT_TRUE(CGRectEqualToRect(mutatorView.frame, CGRectMake(92.5, 45, 45, 30)));
+  EXPECT_TRUE(CGRectEqualToRect(platformView.frame, CGRectMake(0, 0, 30, 20)));
+  EXPECT_TRUE(
+      CATransform3DEqualToTransform(mutatorView.platformViewContainer.layer.sublayerTransform,
+                                    CATransform3DMakeScale(1.5, 1.5, 1)));
+}
+
+TEST(FlutterMutatorViewTest, FrameWithLooseClipIsCorrect) {
+  NSView* platformView = [[NSView alloc] init];
+  FlutterMutatorView* mutatorView = [[FlutterMutatorView alloc] initWithPlatformView:platformView];
+
+  EXPECT_EQ(mutatorView.platformView, platformView);
+
+  std::vector<FlutterPlatformViewMutation> mutations{
+      {
+          .type = kFlutterPlatformViewMutationTypeClipRect,
+          .clip_rect = FlutterRect{80, 40, 200, 100},
+      },
+      {
+          .type = kFlutterPlatformViewMutationTypeTransformation,
+          .transformation =
+              FlutterTransformation{
+                  .scaleX = 1,
+                  .transX = 100,
+                  .scaleY = 1,
+                  .transY = 50,
+              },
+      },
+  };
+
+  ApplyFlutterLayer(mutatorView, FlutterSize{30, 20}, mutations);
+
+  EXPECT_TRUE(CGRectEqualToRect(mutatorView.frame, CGRectMake(100, 50, 30, 20)));
+  EXPECT_TRUE(CGRectEqualToRect(platformView.frame, CGRectMake(0, 0, 30, 20)));
+}
+
+TEST(FlutterMutatorViewTest, FrameWithTightClipIsCorrect) {
+  NSView* platformView = [[NSView alloc] init];
+  FlutterMutatorView* mutatorView = [[FlutterMutatorView alloc] initWithPlatformView:platformView];
+
+  EXPECT_EQ(mutatorView.platformView, platformView);
+
+  std::vector<FlutterPlatformViewMutation> mutations{
+      {
+          .type = kFlutterPlatformViewMutationTypeClipRect,
+          .clip_rect = FlutterRect{80, 40, 200, 100},
+      },
+      {
+          .type = kFlutterPlatformViewMutationTypeClipRect,
+          .clip_rect = FlutterRect{110, 55, 120, 65},
+      },
+      {
+          .type = kFlutterPlatformViewMutationTypeTransformation,
+          .transformation =
+              FlutterTransformation{
+                  .scaleX = 1,
+                  .transX = 100,
+                  .scaleY = 1,
+                  .transY = 50,
+              },
+      },
+  };
+
+  ApplyFlutterLayer(mutatorView, FlutterSize{30, 20}, mutations);
+
+  EXPECT_TRUE(CGRectEqualToRect(mutatorView.frame, CGRectMake(110, 55, 10, 10)));
+  EXPECT_TRUE(
+      CGRectEqualToRect(mutatorView.subviews.firstObject.frame, CGRectMake(-10, -5, 30, 20)));
+  EXPECT_TRUE(CGRectEqualToRect(platformView.frame, CGRectMake(0, 0, 30, 20)));
+}
+
+TEST(FlutterMutatorViewTest, FrameWithTightClipAndTransformIsCorrect) {
+  NSView* platformView = [[NSView alloc] init];
+  FlutterMutatorView* mutatorView = [[FlutterMutatorView alloc] initWithPlatformView:platformView];
+  NSView* mutatorViewParent = [[NSView alloc] init];
+  mutatorViewParent.wantsLayer = YES;
+  mutatorViewParent.layer.contentsScale = 2.0;
+  [mutatorViewParent addSubview:mutatorView];
+
+  std::vector<FlutterPlatformViewMutation> mutations{
+      {
+          .type = kFlutterPlatformViewMutationTypeTransformation,
+          .transformation =
+              FlutterTransformation{
+                  .scaleX = 2,
+                  .scaleY = 2,
+              },
+      },
+      {
+          .type = kFlutterPlatformViewMutationTypeClipRect,
+          .clip_rect = FlutterRect{80, 40, 200, 100},
+      },
+      {
+          .type = kFlutterPlatformViewMutationTypeClipRect,
+          .clip_rect = FlutterRect{110, 55, 120, 65},
+      },
+      {
+          .type = kFlutterPlatformViewMutationTypeTransformation,
+          .transformation =
+              FlutterTransformation{
+                  .scaleX = 1,
+                  .transX = 100,
+                  .scaleY = 1,
+                  .transY = 50,
+              },
+      },
+      {
+          .type = kFlutterPlatformViewMutationTypeTransformation,
+          .transformation =
+              FlutterTransformation{
+                  .scaleX = 1.5,
+                  .transX = -7.5,
+                  .scaleY = 1.5,
+                  .transY = -5,
+              },
+      },
+  };
+
+  ApplyFlutterLayer(mutatorView, FlutterSize{30 * 2, 20 * 2}, mutations);
+
+  EXPECT_TRUE(CGRectEqualToRect(mutatorView.frame, CGRectMake(110, 55, 10, 10)));
+  EXPECT_TRUE(
+      CGRectEqualToRect(mutatorView.subviews.firstObject.frame, CGRectMake(-17.5, -10, 45, 30)));
+  EXPECT_TRUE(CGRectEqualToRect(platformView.frame, CGRectMake(0, 0, 30, 20)));
+}
+
+// Rounded rectangle without hitting the corner
+TEST(FlutterMutatorViewTest, RoundRectClipsToSimpleRectangle) {
+  NSView* platformView = [[NSView alloc] init];
+  FlutterMutatorView* mutatorView = [[FlutterMutatorView alloc] initWithPlatformView:platformView];
+
+  std::vector<FlutterPlatformViewMutation> mutations{
+      {
+          .type = kFlutterPlatformViewMutationTypeClipRoundedRect,
+          .clip_rounded_rect =
+              FlutterRoundedRect{
+                  .rect = FlutterRect{110, 30, 120, 90},
+                  .upper_left_corner_radius = FlutterSize{10, 10},
+                  .upper_right_corner_radius = FlutterSize{10, 10},
+                  .lower_right_corner_radius = FlutterSize{10, 10},
+                  .lower_left_corner_radius = FlutterSize{10, 10},
+              },
+      },
+      {
+          .type = kFlutterPlatformViewMutationTypeTransformation,
+          .transformation =
+              FlutterTransformation{
+                  .scaleX = 1,
+                  .transX = 100,
+                  .scaleY = 1,
+                  .transY = 50,
+              },
+      },
+  };
+
+  ApplyFlutterLayer(mutatorView, FlutterSize{30, 20}, mutations);
+
+  EXPECT_TRUE(CGRectEqualToRect(mutatorView.frame, CGRectMake(110, 50, 10, 20)));
+  EXPECT_TRUE(
+      CGRectEqualToRect(mutatorView.subviews.firstObject.frame, CGRectMake(-10, 0, 30, 20)));
+  EXPECT_TRUE(CGRectEqualToRect(platformView.frame, CGRectMake(0, 0, 30, 20)));
+  EXPECT_EQ(mutatorView.pathClipViews.count, 0ul);
+}
+
+TEST(FlutterMutatorViewTest, RoundRectClipsToPath) {
+  NSView* platformView = [[NSView alloc] init];
+  FlutterMutatorView* mutatorView = [[FlutterMutatorView alloc] initWithPlatformView:platformView];
+
+  std::vector<FlutterPlatformViewMutation> mutations{
+      {
+          .type = kFlutterPlatformViewMutationTypeClipRoundedRect,
+          .clip_rounded_rect =
+              FlutterRoundedRect{
+                  .rect = FlutterRect{110, 60, 150, 150},
+                  .upper_left_corner_radius = FlutterSize{10, 10},
+                  .upper_right_corner_radius = FlutterSize{10, 10},
+                  .lower_right_corner_radius = FlutterSize{10, 10},
+                  .lower_left_corner_radius = FlutterSize{10, 10},
+              },
+      },
+      {
+          .type = kFlutterPlatformViewMutationTypeTransformation,
+          .transformation =
+              FlutterTransformation{
+                  .scaleX = 1,
+                  .transX = 100,
+                  .scaleY = 1,
+                  .transY = 50,
+              },
+      },
+  };
+
+  ApplyFlutterLayer(mutatorView, FlutterSize{30, 20}, mutations);
+
+  EXPECT_TRUE(CGRectEqualToRect(mutatorView.frame, CGRectMake(110, 60, 20, 10)));
+  EXPECT_TRUE(
+      CGRectEqualToRect(mutatorView.subviews.firstObject.frame, CGRectMake(-10, -10, 30, 20)));
+  EXPECT_TRUE(CGRectEqualToRect(platformView.frame, CGRectMake(0, 0, 30, 20)));
+  EXPECT_EQ(mutatorView.pathClipViews.count, 1ul);
+  EXPECT_TRUE(
+      CATransform3DEqualToTransform(mutatorView.pathClipViews.firstObject.layer.mask.transform,
+                                    CATransform3DMakeTranslation(-100, -50, 0)));
+}
+
+TEST(FlutterMutatorViewTest, PathClipViewsAreAddedAndRemoved) {
+  NSView* platformView = [[NSView alloc] init];
+  FlutterMutatorView* mutatorView = [[FlutterMutatorView alloc] initWithPlatformView:platformView];
+
+  std::vector<FlutterPlatformViewMutation> mutations{
+      {
+          .type = kFlutterPlatformViewMutationTypeTransformation,
+          .transformation =
+              FlutterTransformation{
+                  .scaleX = 1,
+                  .transX = 100,
+                  .scaleY = 1,
+                  .transY = 50,
+              },
+      },
+  };
+
+  ApplyFlutterLayer(mutatorView, FlutterSize{30, 20}, mutations);
+
+  EXPECT_TRUE(CGRectEqualToRect(mutatorView.frame, CGRectMake(100, 50, 30, 20)));
+  EXPECT_EQ(mutatorView.pathClipViews.count, 0ull);
+
+  std::vector<FlutterPlatformViewMutation> mutations2{
+      {
+          .type = kFlutterPlatformViewMutationTypeClipRoundedRect,
+          .clip_rounded_rect =
+              FlutterRoundedRect{
+                  .rect = FlutterRect{110, 60, 150, 150},
+                  .upper_left_corner_radius = FlutterSize{10, 10},
+                  .upper_right_corner_radius = FlutterSize{10, 10},
+                  .lower_right_corner_radius = FlutterSize{10, 10},
+                  .lower_left_corner_radius = FlutterSize{10, 10},
+              },
+      },
+      {
+          .type = kFlutterPlatformViewMutationTypeTransformation,
+          .transformation =
+              FlutterTransformation{
+                  .scaleX = 1,
+                  .transX = 100,
+                  .scaleY = 1,
+                  .transY = 50,
+              },
+      },
+  };
+
+  ApplyFlutterLayer(mutatorView, FlutterSize{30, 20}, mutations2);
+
+  EXPECT_TRUE(CGRectEqualToRect(mutatorView.frame, CGRectMake(110, 60, 20, 10)));
+  EXPECT_TRUE(
+      CGRectEqualToRect(mutatorView.subviews.firstObject.frame, CGRectMake(-10, -10, 30, 20)));
+  EXPECT_TRUE(CGRectEqualToRect(platformView.frame, CGRectMake(0, 0, 30, 20)));
+  EXPECT_EQ(mutatorView.pathClipViews.count, 1ul);
+
+  EXPECT_EQ(platformView.superview, mutatorView.platformViewContainer);
+  EXPECT_EQ(mutatorView.platformViewContainer.superview, mutatorView.pathClipViews[0]);
+  EXPECT_EQ(mutatorView.pathClipViews[0].superview, mutatorView);
+
+  std::vector<FlutterPlatformViewMutation> mutations3{
+      {
+          .type = kFlutterPlatformViewMutationTypeClipRoundedRect,
+          .clip_rounded_rect =
+              FlutterRoundedRect{
+                  .rect = FlutterRect{110, 55, 150, 150},
+                  .upper_left_corner_radius = FlutterSize{10, 10},
+                  .upper_right_corner_radius = FlutterSize{10, 10},
+                  .lower_right_corner_radius = FlutterSize{10, 10},
+                  .lower_left_corner_radius = FlutterSize{10, 10},
+              },
+      },
+      {
+          .type = kFlutterPlatformViewMutationTypeClipRoundedRect,
+          .clip_rounded_rect =
+              FlutterRoundedRect{
+                  .rect = FlutterRect{30, 30, 120, 65},
+                  .upper_left_corner_radius = FlutterSize{10, 10},
+                  .upper_right_corner_radius = FlutterSize{10, 10},
+                  .lower_right_corner_radius = FlutterSize{10, 10},
+                  .lower_left_corner_radius = FlutterSize{10, 10},
+              },
+      },
+      {
+          .type = kFlutterPlatformViewMutationTypeTransformation,
+          .transformation =
+              FlutterTransformation{
+                  .scaleX = 1,
+                  .transX = 100,
+                  .scaleY = 1,
+                  .transY = 50,
+              },
+      },
+  };
+
+  ApplyFlutterLayer(mutatorView, FlutterSize{30, 20}, mutations3);
+
+  EXPECT_TRUE(CGRectEqualToRect(mutatorView.frame, CGRectMake(110, 55, 10, 10)));
+  EXPECT_TRUE(
+      CGRectEqualToRect(mutatorView.subviews.firstObject.frame, CGRectMake(-10, -5, 30, 20)));
+  EXPECT_EQ(mutatorView.pathClipViews.count, 2ul);
+
+  EXPECT_EQ(platformView.superview, mutatorView.platformViewContainer);
+  EXPECT_EQ(mutatorView.platformViewContainer.superview, mutatorView.pathClipViews[1]);
+  EXPECT_EQ(mutatorView.pathClipViews[1].superview, mutatorView.pathClipViews[0]);
+  EXPECT_EQ(mutatorView.pathClipViews[0].superview, mutatorView);
+
+  ApplyFlutterLayer(mutatorView, FlutterSize{30, 20}, mutations2);
+
+  EXPECT_TRUE(CGRectEqualToRect(mutatorView.frame, CGRectMake(110, 60, 20, 10)));
+  EXPECT_TRUE(
+      CGRectEqualToRect(mutatorView.subviews.firstObject.frame, CGRectMake(-10, -10, 30, 20)));
+  EXPECT_TRUE(CGRectEqualToRect(platformView.frame, CGRectMake(0, 0, 30, 20)));
+  EXPECT_EQ(mutatorView.pathClipViews.count, 1ul);
+
+  EXPECT_EQ(platformView.superview, mutatorView.platformViewContainer);
+  EXPECT_EQ(mutatorView.platformViewContainer.superview, mutatorView.pathClipViews[0]);
+  EXPECT_EQ(mutatorView.pathClipViews[0].superview, mutatorView);
+
+  ApplyFlutterLayer(mutatorView, FlutterSize{30, 20}, mutations);
+
+  EXPECT_TRUE(CGRectEqualToRect(mutatorView.frame, CGRectMake(100, 50, 30, 20)));
+  EXPECT_EQ(mutatorView.pathClipViews.count, 0ull);
+}

--- a/shell/platform/darwin/macos/framework/Source/FlutterMutatorViewTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterMutatorViewTest.mm
@@ -6,6 +6,13 @@
 
 #include "third_party/googletest/googletest/include/gtest/gtest.h"
 
+@interface FlutterMutatorView (Private)
+
+@property(readonly, nonatomic, nonnull) NSMutableArray<NSView*>* pathClipViews;
+@property(readonly, nonatomic, nullable) NSView* platformViewContainer;
+
+@end
+
 namespace {
 void ApplyFlutterLayer(FlutterMutatorView* view,
                        FlutterSize size,


### PR DESCRIPTION
This implements support for platform view mutators currently provided through the embedder API, namely:
- Opacity
- Clip Rect
- Clip RRect
- Transform

### Notes

- Clipping to paths (currently only round rect supported - see below) is done through `CAShapeLayer` masks, which avoids the need for rasterizing mask layer. 
- Clipping to round rectangle will only clip to path if one or more more corners are intersected by the view. Otherwise it behaves as if clipped by regular rectangle.

Clipping to arbitrary path is not currently supported by embedder API. However once there is a way to represent it in the embedder API it should be fairly straightforward to add to `FlutterMutatorView`.

Fixes https://github.com/flutter/flutter/issues/118142

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
