### PR TITLE
Mark nodes as `kIsLineBreakingObject` by default, TODO further distinctions

### DIFF
--- a/shell/platform/common/accessibility_bridge.cc
+++ b/shell/platform/common/accessibility_bridge.cc
@@ -435,6 +435,9 @@ void AccessibilityBridge::SetBooleanAttributesFromFlutterUpdate(
       ax::mojom::BoolAttribute::kEditableRoot,
       flags & FlutterSemanticsFlag::kFlutterSemanticsFlagIsTextField &&
           (flags & FlutterSemanticsFlag::kFlutterSemanticsFlagIsReadOnly) == 0);
+  // TODO(schectman): When should a node have this attribute set?
+  // https://github.com/flutter/flutter/issues/118184
+  node_data.AddBoolAttribute(ax::mojom::BoolAttribute::kIsLineBreakingObject, true);
 }
 
 void AccessibilityBridge::SetIntAttributesFromFlutterUpdate(

--- a/shell/platform/common/accessibility_bridge.cc
+++ b/shell/platform/common/accessibility_bridge.cc
@@ -437,7 +437,8 @@ void AccessibilityBridge::SetBooleanAttributesFromFlutterUpdate(
           (flags & FlutterSemanticsFlag::kFlutterSemanticsFlagIsReadOnly) == 0);
   // TODO(schectman): When should a node have this attribute set?
   // https://github.com/flutter/flutter/issues/118184
-  node_data.AddBoolAttribute(ax::mojom::BoolAttribute::kIsLineBreakingObject, true);
+  node_data.AddBoolAttribute(ax::mojom::BoolAttribute::kIsLineBreakingObject,
+                             true);
 }
 
 void AccessibilityBridge::SetIntAttributesFromFlutterUpdate(

--- a/shell/platform/common/accessibility_bridge.cc
+++ b/shell/platform/common/accessibility_bridge.cc
@@ -435,6 +435,8 @@ void AccessibilityBridge::SetBooleanAttributesFromFlutterUpdate(
       ax::mojom::BoolAttribute::kEditableRoot,
       flags & FlutterSemanticsFlag::kFlutterSemanticsFlagIsTextField &&
           (flags & FlutterSemanticsFlag::kFlutterSemanticsFlagIsReadOnly) == 0);
+  // Mark nodes as line breaking so that screen readers don't
+  // merge all consecutive objects into one.
   // TODO(schectman): When should a node have this attribute set?
   // https://github.com/flutter/flutter/issues/118184
   node_data.AddBoolAttribute(ax::mojom::BoolAttribute::kIsLineBreakingObject,

--- a/shell/platform/common/accessibility_bridge_unittests.cc
+++ b/shell/platform/common/accessibility_bridge_unittests.cc
@@ -502,16 +502,17 @@ TEST(AccessibilityBridgeTest, LineBreakingObjectTest) {
 
   const int32_t root_id = 0;
 
-  FlutterSemanticsNode root =
-      CreateSemanticsNode(root_id, "root", {});
+  FlutterSemanticsNode root = CreateSemanticsNode(root_id, "root", {});
 
   bridge->AddFlutterSemanticsNodeUpdate(&root);
   bridge->CommitUpdates();
 
   auto root_node = bridge->GetFlutterPlatformNodeDelegateFromID(root_id).lock();
   auto root_data = root_node->GetData();
-  EXPECT_TRUE(root_data.HasBoolAttribute(ax::mojom::BoolAttribute::kIsLineBreakingObject));
-  EXPECT_TRUE(root_data.GetBoolAttribute(ax::mojom::BoolAttribute::kIsLineBreakingObject));
+  EXPECT_TRUE(root_data.HasBoolAttribute(
+      ax::mojom::BoolAttribute::kIsLineBreakingObject));
+  EXPECT_TRUE(root_data.GetBoolAttribute(
+      ax::mojom::BoolAttribute::kIsLineBreakingObject));
 
 }
 

--- a/shell/platform/common/accessibility_bridge_unittests.cc
+++ b/shell/platform/common/accessibility_bridge_unittests.cc
@@ -496,5 +496,24 @@ TEST(AccessibilityBridgeTest, AXTreeManagerTest) {
   ASSERT_EQ(manager, static_cast<ui::AXTreeManager*>(bridge.get()));
 }
 
+TEST(AccessibilityBridgeTest, LineBreakingObjectTest) {
+  std::shared_ptr<TestAccessibilityBridge> bridge =
+      std::make_shared<TestAccessibilityBridge>();
+
+  const int32_t root_id = 0;
+
+  FlutterSemanticsNode root =
+      CreateSemanticsNode(root_id, "root", {});
+
+  bridge->AddFlutterSemanticsNodeUpdate(&root);
+  bridge->CommitUpdates();
+
+  auto root_node = bridge->GetFlutterPlatformNodeDelegateFromID(root_id).lock();
+  auto root_data = root_node->GetData();
+  EXPECT_TRUE(root_data.HasBoolAttribute(ax::mojom::BoolAttribute::kIsLineBreakingObject));
+  EXPECT_TRUE(root_data.GetBoolAttribute(ax::mojom::BoolAttribute::kIsLineBreakingObject));
+
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/shell/platform/common/accessibility_bridge_unittests.cc
+++ b/shell/platform/common/accessibility_bridge_unittests.cc
@@ -513,7 +513,6 @@ TEST(AccessibilityBridgeTest, LineBreakingObjectTest) {
       ax::mojom::BoolAttribute::kIsLineBreakingObject));
   EXPECT_TRUE(root_data.GetBoolAttribute(
       ax::mojom::BoolAttribute::kIsLineBreakingObject));
-
 }
 
 }  // namespace testing


### PR DESCRIPTION
The line breaking attribute is currently unused, but will be needed for UIA text for Windows a11y. To keep all consecutive objects from being merged into one for screen readers, nodes will be marked as line breaking temporarily by default.

Part of https://github.com/flutter/flutter/issues/118184

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
