### PR TITLE
Inline usage of SkIsPow2

### DIFF
--- a/display_list/display_list_builder.cc
+++ b/display_list/display_list_builder.cc
@@ -26,8 +26,8 @@ static void CopyV(void* dst, const S* src, int n, Rest&&... rest) {
   CopyV(SkTAddOffset<void>(dst, n * sizeof(S)), std::forward<Rest>(rest)...);
 }
 
-constexpr inline bool is_power_of_two(int value) {
-    return (value & (value - 1)) == 0;
+static constexpr inline bool is_power_of_two(int value) {
+  return (value & (value - 1)) == 0;
 }
 
 template <typename T, typename... Args>

--- a/display_list/display_list_builder.cc
+++ b/display_list/display_list_builder.cc
@@ -26,12 +26,16 @@ static void CopyV(void* dst, const S* src, int n, Rest&&... rest) {
   CopyV(SkTAddOffset<void>(dst, n * sizeof(S)), std::forward<Rest>(rest)...);
 }
 
+constexpr inline bool is_power_of_two(int value) {
+    return (value & (value - 1)) == 0;
+}
+
 template <typename T, typename... Args>
 void* DisplayListBuilder::Push(size_t pod, int render_op_inc, Args&&... args) {
   size_t size = SkAlignPtr(sizeof(T) + pod);
   FML_DCHECK(size < (1 << 24));
   if (used_ + size > allocated_) {
-    static_assert(SkIsPow2(DL_BUILDER_PAGE),
+    static_assert(is_power_of_two(DL_BUILDER_PAGE),
                   "This math needs updating for non-pow2.");
     // Next greater multiple of DL_BUILDER_PAGE.
     allocated_ = (used_ + size + DL_BUILDER_PAGE) & ~(DL_BUILDER_PAGE - 1);


### PR DESCRIPTION
Skia is planning to remove include/core/SkMath.h from the public API.

This was the only usage of those functions that I could find.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
