### PR TITLE
Set the ivar to nil after release it in dealloc method. 

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -261,20 +261,27 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
       }];
 
   [_labelPrefix release];
+  _labelPrefix = nil;
   [_initialRoute release];
+  _initialRoute = nil;
   [_pluginPublications release];
+  _pluginPublications = nil;
   [_registrars release];
+  _registrars = nil;
   _binaryMessenger.parent = nil;
   _textureRegistry.parent = nil;
   [_binaryMessenger release];
+  _binaryMessenger = nil;
   [_textureRegistry release];
   _textureRegistry = nil;
   [_isolateId release];
+  _isolateId = nil;
 
   NSNotificationCenter* center = [NSNotificationCenter defaultCenter];
   if (_flutterViewControllerWillDeallocObserver) {
     [center removeObserver:_flutterViewControllerWillDeallocObserver];
     [_flutterViewControllerWillDeallocObserver release];
+    _flutterViewControllerWillDeallocObserver = nil;
   }
   [center removeObserver:self];
 


### PR DESCRIPTION
As https://github.com/flutter/engine/pull/37666#discussion_r1024396618 mentioned, the correct pattern is the set the ivar to nil after release it in dealloc method.

Related issue: https://github.com/flutter/flutter/issues/118217

## Pre-launch Checklist

- [✓] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [✓] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [✓] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [✓] I signed the [CLA].
- [✓] I listed at least one issue that this PR fixes in the description above.
- [✓] I updated/added relevant documentation (doc comments with `///`).
- [✓] I added new tests to check the change I am making, or this PR is [test-exempt].
- [✓] All existing and new tests are passing.