### PR TITLE
[Draft] Remove nextDrawable calls to compare performance.

### DIFF
--- a/flow/surface_frame.cc
+++ b/flow/surface_frame.cc
@@ -24,14 +24,15 @@ SurfaceFrame::SurfaceFrame(sk_sp<SkSurface> surface,
       submit_callback_(submit_callback),
       context_result_(std::move(context_result)) {
   FML_DCHECK(submit_callback_);
-  if (surface_) {
-    canvas_ = surface_->getCanvas();
-  } else if (display_list_fallback) {
-    FML_DCHECK(!frame_size.isEmpty());
-    dl_recorder_ =
-        sk_make_sp<DisplayListCanvasRecorder>(SkRect::Make(frame_size));
-    canvas_ = dl_recorder_.get();
-  }
+  canvas_ = new SkCanvas();
+  // if (surface_) {
+  //   canvas_ = surface_->getCanvas();
+  // } else if (display_list_fallback) {
+  //   FML_DCHECK(!frame_size.isEmpty());
+  //   dl_recorder_ =
+  //       sk_make_sp<DisplayListCanvasRecorder>(SkRect::Make(frame_size));
+  //   canvas_ = dl_recorder_.get();
+  // }
 }
 
 bool SurfaceFrame::Submit() {

--- a/shell/platform/darwin/ios/ios_surface_metal_skia.mm
+++ b/shell/platform/darwin/ios/ios_surface_metal_skia.mm
@@ -80,10 +80,11 @@ bool IOSSurfaceMetalSkia::PresentDrawable(GrMTLHandle drawable) const {
 
   auto command_buffer =
       fml::scoped_nsprotocol<id<MTLCommandBuffer>>([[command_queue_ commandBuffer] retain]);
+  [command_buffer.get() presentDrawable:reinterpret_cast<id<CAMetalDrawable>>(drawable)];
   [command_buffer.get() commit];
-  [command_buffer.get() waitUntilScheduled];
+  // [command_buffer.get() waitUntilScheduled];
 
-  [reinterpret_cast<id<CAMetalDrawable>>(drawable) present];
+  // [reinterpret_cast<id<CAMetalDrawable>>(drawable) present];
   return true;
 }
 

--- a/shell/platform/darwin/ios/ios_surface_metal_skia.mm
+++ b/shell/platform/darwin/ios/ios_surface_metal_skia.mm
@@ -73,16 +73,15 @@ GPUCAMetalLayerHandle IOSSurfaceMetalSkia::GetCAMetalLayer(const SkISize& frame_
 
 // |GPUSurfaceMetalDelegate|
 bool IOSSurfaceMetalSkia::PresentDrawable(GrMTLHandle drawable) const {
-  if (drawable == nullptr) {
-    FML_DLOG(ERROR) << "Could not acquire next Metal drawable from the SkSurface.";
-    return false;
-  }
+  // if (drawable == nullptr) {
+  //   FML_DLOG(ERROR) << "Could not acquire next Metal drawable from the SkSurface.";
+  //   return false;
+  // }
 
   auto command_buffer =
       fml::scoped_nsprotocol<id<MTLCommandBuffer>>([[command_queue_ commandBuffer] retain]);
-  [command_buffer.get() presentDrawable:reinterpret_cast<id<CAMetalDrawable>>(drawable)];
   [command_buffer.get() commit];
-  // [command_buffer.get() waitUntilScheduled];
+  [command_buffer.get() waitUntilScheduled];
 
   // [reinterpret_cast<id<CAMetalDrawable>>(drawable) present];
   return true;


### PR DESCRIPTION
Removes `nextDrawable`. Run this engine with example code in https://github.com/flutter/flutter/issues/116640 to see the jitter.

This engine will not render any skia drawings, but the PlatformViews will be shown.