### PR TITLE
Roll Skia from b8c0a78a2378 to e1f3980272f3 (24 revisions)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -18,7 +18,7 @@ vars = {
   'llvm_git': 'https://llvm.googlesource.com',
   # OCMock is for testing only so there is no google clone
   'ocmock_git': 'https://github.com/erikdoe/ocmock.git',
-  'skia_revision': 'b8c0a78a2378c621d90733b82f69a7ab356732ee',
+  'skia_revision': 'e1f3980272f36023aa300c739fee8bef345f2ab3',
 
   # WARNING: DO NOT EDIT canvaskit_cipd_instance MANUALLY
   # See `lib/web_ui/README.md` for how to roll CanvasKit to a new version.

--- a/ci/licenses_golden/excluded_files
+++ b/ci/licenses_golden/excluded_files
@@ -2608,6 +2608,8 @@
 ../../../third_party/skia/specs
 ../../../third_party/skia/src/BUILD.bazel
 ../../../third_party/skia/src/android/BUILD.bazel
+../../../third_party/skia/src/base/BUILD.bazel
+../../../third_party/skia/src/base/README.md
 ../../../third_party/skia/src/codec/BUILD.bazel
 ../../../third_party/skia/src/core/BUILD.bazel
 ../../../third_party/skia/src/effects/BUILD.bazel

--- a/ci/licenses_golden/licenses_skia
+++ b/ci/licenses_golden/licenses_skia
@@ -1,4 +1,4 @@
-Signature: fdca516e6e3f00c9c96304eaf4bf26ec
+Signature: 1b7e0d1182c107163b421488f3059d82
 
 ====================================================================================================
 LIBRARY: etc1
@@ -7983,7 +7983,6 @@ LIBRARY: skia
 ORIGIN: ../../../third_party/skia/gm/batchedconvexpaths.cpp + ../../../third_party/skia/LICENSE
 ORIGIN: ../../../third_party/skia/gm/destcolor.cpp + ../../../third_party/skia/LICENSE
 ORIGIN: ../../../third_party/skia/include/private/SkSLProgramKind.h + ../../../third_party/skia/LICENSE
-ORIGIN: ../../../third_party/skia/include/private/base/SkStringView.h + ../../../third_party/skia/LICENSE
 ORIGIN: ../../../third_party/skia/include/private/chromium/SkChromeRemoteGlyphCache.h + ../../../third_party/skia/LICENSE
 ORIGIN: ../../../third_party/skia/include/sksl/DSLBlock.h + ../../../third_party/skia/LICENSE
 ORIGIN: ../../../third_party/skia/include/sksl/DSLCase.h + ../../../third_party/skia/LICENSE
@@ -7993,6 +7992,7 @@ ORIGIN: ../../../third_party/skia/include/sksl/DSLStatement.h + ../../../third_p
 ORIGIN: ../../../third_party/skia/include/sksl/SkSLDebugTrace.h + ../../../third_party/skia/LICENSE
 ORIGIN: ../../../third_party/skia/include/sksl/SkSLErrorReporter.h + ../../../third_party/skia/LICENSE
 ORIGIN: ../../../third_party/skia/include/sksl/SkSLPosition.h + ../../../third_party/skia/LICENSE
+ORIGIN: ../../../third_party/skia/src/base/SkStringView.h + ../../../third_party/skia/LICENSE
 ORIGIN: ../../../third_party/skia/src/gpu/ganesh/GrVertexChunkArray.cpp + ../../../third_party/skia/LICENSE
 ORIGIN: ../../../third_party/skia/src/gpu/ganesh/GrVertexChunkArray.h + ../../../third_party/skia/LICENSE
 ORIGIN: ../../../third_party/skia/src/gpu/ganesh/effects/GrModulateAtlasCoverageEffect.cpp + ../../../third_party/skia/LICENSE
@@ -8027,7 +8027,6 @@ TYPE: LicenseType.bsd
 FILE: ../../../third_party/skia/gm/batchedconvexpaths.cpp
 FILE: ../../../third_party/skia/gm/destcolor.cpp
 FILE: ../../../third_party/skia/include/private/SkSLProgramKind.h
-FILE: ../../../third_party/skia/include/private/base/SkStringView.h
 FILE: ../../../third_party/skia/include/private/chromium/SkChromeRemoteGlyphCache.h
 FILE: ../../../third_party/skia/include/sksl/DSLBlock.h
 FILE: ../../../third_party/skia/include/sksl/DSLCase.h
@@ -8037,6 +8036,7 @@ FILE: ../../../third_party/skia/include/sksl/DSLStatement.h
 FILE: ../../../third_party/skia/include/sksl/SkSLDebugTrace.h
 FILE: ../../../third_party/skia/include/sksl/SkSLErrorReporter.h
 FILE: ../../../third_party/skia/include/sksl/SkSLPosition.h
+FILE: ../../../third_party/skia/src/base/SkStringView.h
 FILE: ../../../third_party/skia/src/gpu/ganesh/GrVertexChunkArray.cpp
 FILE: ../../../third_party/skia/src/gpu/ganesh/GrVertexChunkArray.h
 FILE: ../../../third_party/skia/src/gpu/ganesh/effects/GrModulateAtlasCoverageEffect.cpp
@@ -8872,10 +8872,12 @@ LIBRARY: skia
 ORIGIN: ../../../third_party/skia/include/private/SkDeque.h + ../../../third_party/skia/LICENSE
 ORIGIN: ../../../third_party/skia/include/private/SkMalloc.h + ../../../third_party/skia/LICENSE
 ORIGIN: ../../../third_party/skia/include/private/SkTo.h + ../../../third_party/skia/LICENSE
+ORIGIN: ../../../third_party/skia/src/core/SkFloatingPoint.cpp + ../../../third_party/skia/LICENSE
 TYPE: LicenseType.bsd
 FILE: ../../../third_party/skia/include/private/SkDeque.h
 FILE: ../../../third_party/skia/include/private/SkMalloc.h
 FILE: ../../../third_party/skia/include/private/SkTo.h
+FILE: ../../../third_party/skia/src/core/SkFloatingPoint.cpp
 ----------------------------------------------------------------------------------------------------
 Copyright 2023 Google LLC
 


### PR DESCRIPTION
Landing this roll manually because it seems to have failed in error and the latest hash has introduced some other errors.
related issue: https://github.com/flutter/flutter/issues/118280

https://skia.googlesource.com/skia.git/+log/b8c0a78a2378..e1f3980272f3

2023-01-09 johnstiles@google.com Add support for diagonal matrix contructors in RP codegen. 2023-01-09 jcgregorio@google.com Reboot Android devices after running a task. 2023-01-09 johnstiles@google.com Coalesce adjacent push_zeros ops. 2023-01-09 jvanverth@google.com [graphite] More steps to Recording replay for text. 2023-01-09 robertphillips@google.com Clean up compilation settings 2023-01-09 kjlubick@google.com Clear special surfaces with red color on debug tests 2023-01-09 robertphillips@google.com [graphite] Centralize Graphite onMakeTextureImage stubs in SkImage_GpuBase 2023-01-09 kjlubick@google.com Add tests for solving cubic roots with double precision. 2023-01-09 robertphillips@google.com [graphite] Add onReinterpretColorSpace implementation 2023-01-09 kjlubick@google.com Move SkStringView from include/private/base into src/base 2023-01-09 kyslov@google.com jpegr codec: implement opt-in sdr/hdr decoding 2023-01-09 skia-autoroll@skia-public.iam.gserviceaccount.com Roll SK Tool from 10524e337d18 to 802522fda586 2023-01-09 skia-recreate-skps@skia-swarming-bots.iam.gserviceaccount.com Update SKP version 2023-01-09 skia-autoroll@skia-public.iam.gserviceaccount.com Roll vulkan-deps from e7c0454c0991 to 8c09d95e66d0 (1 revision) 2023-01-09 skia-autoroll@skia-public.iam.gserviceaccount.com Roll Skia Infra from 3c706ee3c271 to 10524e337d18 (10 revisions) 2023-01-09 skia-autoroll@skia-public.iam.gserviceaccount.com Roll ANGLE from 1d2b20f53532 to 9c1598af45f5 (8 revisions) 2023-01-09 skia-autoroll@skia-public.iam.gserviceaccount.com Roll Dawn from 582ce0b0b4c8 to a3544353e82d (20 revisions) 2023-01-08 49699333+dependabot[bot]@users.noreply.github.com Bump json5 from 1.0.1 to 1.0.2 in /experimental/tskit 2023-01-07 49699333+dependabot[bot]@users.noreply.github.com Bump json5 from 2.1.3 to 2.2.3 in /modules/pathkit 2023-01-07 49699333+dependabot[bot]@users.noreply.github.com Bump json5 from 2.1.3 to 2.2.3 in /modules/canvaskit 2023-01-07 skia-autoroll@skia-public.iam.gserviceaccount.com Roll vulkan-deps from 68f9998c8591 to e7c0454c0991 (2 revisions) 2023-01-06 skia-autoroll@skia-public.iam.gserviceaccount.com Roll vulkan-deps from d3d26aeb92d2 to 68f9998c8591 (4 revisions) 2023-01-06 johnstiles@google.com Implement x++ and x-- in RP codegen. 2023-01-06 johnstiles@google.com Disable fract() intrinsic test on Tegra3.

If this roll has caused a breakage, revert this CL and stop the roller using the controls here:
https://autoroll.skia.org/r/skia-flutter-autoroll
Please CC herb@google.com,jimgraham@google.com on the revert to ensure that a human is aware of the problem.

To file a bug in Skia: https://bugs.chromium.org/p/skia/issues/entry To file a bug in Flutter: https://github.com/flutter/flutter/issues/new/choose

To report a problem with the AutoRoller itself, please file a bug: https://bugs.chromium.org/p/skia/issues/entry?template=Autoroller+Bug

Documentation for the AutoRoller is here:
https://skia.googlesource.com/buildbot/+doc/main/autoroll/README.md

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
