### PR TITLE
delete include of private GrMtlTypes header

### DIFF
--- a/shell/gpu/gpu_surface_metal_delegate.h
+++ b/shell/gpu/gpu_surface_metal_delegate.h
@@ -10,7 +10,6 @@
 #include "flutter/fml/macros.h"
 #include "third_party/skia/include/core/SkSize.h"
 #include "third_party/skia/include/core/SkSurface.h"
-#include "third_party/skia/include/gpu/mtl/GrMtlTypes.h"
 
 namespace flutter {
 

--- a/shell/gpu/gpu_surface_metal_skia.h
+++ b/shell/gpu/gpu_surface_metal_skia.h
@@ -10,7 +10,6 @@
 #include "flutter/fml/macros.h"
 #include "flutter/shell/gpu/gpu_surface_metal_delegate.h"
 #include "third_party/skia/include/gpu/GrDirectContext.h"
-#include "third_party/skia/include/gpu/mtl/GrMtlTypes.h"
 
 namespace flutter {
 

--- a/shell/platform/darwin/graphics/FlutterDarwinExternalTextureMetal.mm
+++ b/shell/platform/darwin/graphics/FlutterDarwinExternalTextureMetal.mm
@@ -12,7 +12,6 @@
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
 #include "third_party/skia/include/gpu/GrDirectContext.h"
 #include "third_party/skia/include/gpu/GrYUVABackendTextures.h"
-#include "third_party/skia/include/gpu/mtl/GrMtlTypes.h"
 
 FLUTTER_ASSERT_ARC
 

--- a/testing/test_metal_context.h
+++ b/testing/test_metal_context.h
@@ -9,7 +9,6 @@
 #include <mutex>
 
 #include "third_party/skia/include/gpu/GrDirectContext.h"
-#include "third_party/skia/include/gpu/mtl/GrMtlTypes.h"
 
 namespace flutter {
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/118330

Removes unnecessary includes of what is now a private Skia header file.

No tests because this is just a source compatibility change and is covered by existing unit tests.