### PR TITLE
[macOS] Remove usages of FlutterViewController#loadView

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest_mrc.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest_mrc.mm
@@ -124,6 +124,9 @@ FLUTTER_ASSERT_NOT_ARC
                                                                                 nibName:nil
                                                                                  bundle:nil];
 
+  [viewController loadView];
+  [viewController viewDidLoad];
+
   VSyncClient* client = viewController.touchRateCorrectionVSyncClient;
   CADisplayLink* link = [client getDisplayLink];
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest_mrc.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest_mrc.mm
@@ -123,7 +123,6 @@ FLUTTER_ASSERT_NOT_ARC
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engine
                                                                                 nibName:nil
                                                                                  bundle:nil];
-
   [viewController loadView];
   [viewController viewDidLoad];
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest_mrc.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest_mrc.mm
@@ -123,8 +123,6 @@ FLUTTER_ASSERT_NOT_ARC
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engine
                                                                                 nibName:nil
                                                                                  bundle:nil];
-  [viewController loadView];
-  [viewController viewDidLoad];
 
   VSyncClient* client = viewController.touchRateCorrectionVSyncClient;
   CADisplayLink* link = [client getDisplayLink];

--- a/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacTest.mm
@@ -69,7 +69,6 @@ TEST(AccessibilityBridgeMacTest, sendsAccessibilityCreateNotificationToWindowOfF
       initWithAssetsPath:fixtures
              ICUDataPath:[fixtures stringByAppendingString:@"/icudtl.dat"]];
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithProject:project];
-  [viewController loadView];
   [engine setViewController:viewController];
 
   NSWindow* expectedTarget = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 800, 600)
@@ -128,7 +127,6 @@ TEST(AccessibilityBridgeMacTest, doesNotSendAccessibilityCreateNotificationWhenH
       initWithAssetsPath:fixtures
              ICUDataPath:[fixtures stringByAppendingString:@"/icudtl.dat"]];
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithProject:project];
-  [viewController loadView];
   [engine setViewController:viewController];
   // Setting up bridge so that the AccessibilityBridgeMacDelegateSpy
   // can query semantics information from.
@@ -180,7 +178,6 @@ TEST(AccessibilityBridgeMacTest, doesNotSendAccessibilityCreateNotificationWhenN
       initWithAssetsPath:fixtures
              ICUDataPath:[fixtures stringByAppendingString:@"/icudtl.dat"]];
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithProject:project];
-  [viewController loadView];
   [engine setViewController:viewController];
 
   // Setting up bridge so that the AccessibilityBridgeMacDelegateSpy

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -157,9 +157,6 @@ constexpr char kTextPlainFormat[] = "text/plain";
 }
 
 - (NSView*)view {
-  if (!_flutterEngine.viewController.viewLoaded) {
-    [_flutterEngine.viewController loadView];
-  }
   return _flutterEngine.viewController.flutterView;
 }
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
@@ -138,7 +138,6 @@ TEST_F(FlutterEngineTest, BackgroundIsBlack) {
       initWithAssetsPath:fixtures
              ICUDataPath:[fixtures stringByAppendingString:@"/icudtl.dat"]];
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithProject:project];
-  [viewController loadView];
   viewController.flutterView.frame = CGRectMake(0, 0, 800, 600);
   [engine setViewController:viewController];
 
@@ -170,7 +169,6 @@ TEST_F(FlutterEngineTest, CanOverrideBackgroundColor) {
       initWithAssetsPath:fixtures
              ICUDataPath:[fixtures stringByAppendingString:@"/icudtl.dat"]];
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithProject:project];
-  [viewController loadView];
   viewController.flutterView.frame = CGRectMake(0, 0, 800, 600);
   [engine setViewController:viewController];
   viewController.flutterView.backgroundColor = [NSColor whiteColor];
@@ -197,7 +195,7 @@ TEST_F(FlutterEngineTest, CanToggleAccessibility) {
       initWithAssetsPath:fixtures
              ICUDataPath:[fixtures stringByAppendingString:@"/icudtl.dat"]];
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithProject:project];
-  [viewController loadView];
+  [viewController loadView]; // TODO
   [engine setViewController:viewController];
   // Enable the semantics.
   bool enabled_called = false;
@@ -373,7 +371,6 @@ TEST_F(FlutterEngineTest, ResetsAccessibilityBridgeWhenSetsNewViewController) {
       initWithAssetsPath:fixtures
              ICUDataPath:[fixtures stringByAppendingString:@"/icudtl.dat"]];
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithProject:project];
-  [viewController loadView];
   [engine setViewController:viewController];
   // Enable the semantics.
   bool enabled_called = false;
@@ -430,7 +427,6 @@ TEST_F(FlutterEngineTest, ResetsAccessibilityBridgeWhenSetsNewViewController) {
   // Set up a new view controller.
   FlutterViewController* newViewController =
       [[FlutterViewController alloc] initWithProject:project];
-  [newViewController loadView];
   [engine setViewController:newViewController];
 
   auto new_native_root = engine.accessibilityBridge.lock()->GetFlutterPlatformNodeDelegateFromID(0);
@@ -465,7 +461,6 @@ TEST(FlutterEngine, Compositor) {
   FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"test" project:project];
 
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithProject:project];
-  [viewController loadView];
   viewController.flutterView.frame = CGRectMake(0, 0, 800, 600);
   [engine setViewController:viewController];
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
@@ -195,7 +195,8 @@ TEST_F(FlutterEngineTest, CanToggleAccessibility) {
       initWithAssetsPath:fixtures
              ICUDataPath:[fixtures stringByAppendingString:@"/icudtl.dat"]];
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithProject:project];
-  [viewController loadView]; // TODO
+  // Load view. Accessibility tree can only be used when the view is loaded.
+  [viewController view];
   [engine setViewController:viewController];
   // Enable the semantics.
   bool enabled_called = false;

--- a/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm
@@ -228,7 +228,6 @@ TEST(FlutterPlatformNodeDelegateMac, TextFieldUsesFlutterTextField) {
       initWithAssetsPath:fixtures
              ICUDataPath:[fixtures stringByAppendingString:@"/icudtl.dat"]];
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithProject:project];
-  [viewController loadView];
   [engine setViewController:viewController];
 
   // Unit test localization is unnecessary.

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
@@ -1419,7 +1419,6 @@ TEST(FlutterTextInputPluginTest, CanWorkWithFlutterTextField) {
       initWithAssetsPath:fixtures
              ICUDataPath:[fixtures stringByAppendingString:@"/icudtl.dat"]];
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithProject:project];
-  [viewController loadView];
   [engine setViewController:viewController];
   // Create a NSWindow so that the native text field can become first responder.
   NSWindow* window = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 800, 600)
@@ -1488,7 +1487,6 @@ TEST(FlutterTextInputPluginTest, CanNotBecomeResponderIfNoViewController) {
       initWithAssetsPath:fixtures
              ICUDataPath:[fixtures stringByAppendingString:@"/icudtl.dat"]];
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithProject:project];
-  [viewController loadView];
   [engine setViewController:viewController];
   // Creates a NSWindow so that the native text field can become first responder.
   NSWindow* window = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 800, 600)
@@ -1525,7 +1523,6 @@ TEST(FlutterTextInputPluginTest, IsAddedAndRemovedFromViewHierarchy) {
       initWithAssetsPath:fixtures
              ICUDataPath:[fixtures stringByAppendingString:@"/icudtl.dat"]];
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithProject:project];
-  [viewController loadView];
   [engine setViewController:viewController];
 
   NSWindow* window = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 800, 600)

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputSemanticsObjectTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputSemanticsObjectTest.mm
@@ -33,7 +33,6 @@ TEST(FlutterTextInputSemanticsObjectTest, DoesInitialize) {
         initWithAssetsPath:fixtures
                ICUDataPath:[fixtures stringByAppendingString:@"/icudtl.dat"]];
     FlutterViewController* viewController = [[FlutterViewController alloc] initWithProject:project];
-    [viewController loadView];
     [engine setViewController:viewController];
     // Create a NSWindow so that the native text field can become first responder.
     NSWindow* window = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 800, 600)

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -288,7 +288,7 @@ void OnKeyboardLayoutChanged(CFNotificationCenterRef center,
   FlutterDartProject* _project;
 }
 
-@dynamic view;
+@synthesize flutterView = _flutterView;
 
 /**
  * Performs initialization that's common between the different init paths.
@@ -349,7 +349,6 @@ static void CommonInit(FlutterViewController* controller) {
     _engine = engine;
     CommonInit(self);
     if (engine.running) {
-      [self loadView];
       engine.viewController = self;
       [self initializeKeyboard];
     }
@@ -409,6 +408,16 @@ static void CommonInit(FlutterViewController* controller) {
 }
 
 #pragma mark - Public methods
+
+- (FlutterView*)flutterView {
+  if (!self.viewLoaded) {
+    // This calls loadView. See
+    // https://developer.apple.com/documentation/appkit/nsviewcontroller/1434401-view?language=objc.
+    [self view];
+  }
+  NSAssert(_flutterView != nil, @"The _flutterView is nil after viewDidLoad.");
+  return _flutterView;
+}
 
 - (void)setMouseTrackingMode:(FlutterMouseTrackingMode)mode {
   if (_mouseTrackingMode == mode) {

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -286,9 +286,9 @@ void OnKeyboardLayoutChanged(CFNotificationCenterRef center,
 @implementation FlutterViewController {
   // The project to run in this controller's engine.
   FlutterDartProject* _project;
-}
 
-@synthesize flutterView = _flutterView;
+  FlutterView* _flutterView;
+}
 
 /**
  * Performs initialization that's common between the different init paths.

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
@@ -74,7 +74,6 @@ NSResponder* mockResponder() {
 TEST(FlutterViewController, HasViewThatHidesOtherViewsInAccessibility) {
   FlutterViewController* viewControllerMock = CreateMockViewController();
 
-  [viewControllerMock loadView];
   auto subViews = [viewControllerMock.view subviews];
 
   EXPECT_EQ([subViews count], 1u);
@@ -273,10 +272,11 @@ TEST(FlutterViewControllerTest, testFlutterViewIsConfigured) {
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engineMock
                                                                                 nibName:@""
                                                                                  bundle:nil];
-  [viewController loadView];
+  [viewController view];
 
   @try {
-    // Make sure "renderer" was called during "loadView", which means "flutterView" is created
+    // Make sure "renderer" was called when loading the view, which means
+    // "flutterView" is created
     OCMVerify([engineMock renderer]);
   } @catch (...) {
     return false;
@@ -473,7 +473,7 @@ TEST(FlutterViewControllerTest, testFlutterViewIsConfigured) {
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engineMock
                                                                                 nibName:@""
                                                                                  bundle:nil];
-  [viewController loadView];
+  [viewController loadView]; // TODO
 
   // Test for pan events.
   // Start gesture.

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
@@ -94,7 +94,6 @@ TEST(FlutterViewController, HasViewThatHidesOtherViewsInAccessibility) {
 
 TEST(FlutterViewController, FlutterViewAcceptsFirstMouse) {
   FlutterViewController* viewControllerMock = CreateMockViewController();
-  [viewControllerMock loadView];
   EXPECT_EQ([viewControllerMock.flutterView acceptsFirstMouse:nil], YES);
 }
 
@@ -105,7 +104,6 @@ TEST(FlutterViewController, ReparentsPluginWhenAccessibilityDisabled) {
       initWithAssetsPath:fixtures
              ICUDataPath:[fixtures stringByAppendingString:@"/icudtl.dat"]];
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithProject:project];
-  [viewController loadView];
   [engine setViewController:viewController];
   // Creates a NSWindow so that sub view can be first responder.
   NSWindow* window = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 800, 600)

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
@@ -473,7 +473,9 @@ TEST(FlutterViewControllerTest, testFlutterViewIsConfigured) {
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engineMock
                                                                                 nibName:@""
                                                                                  bundle:nil];
-  [viewController loadView]; // TODO
+  // Load view. It is asserted that the view must be loaded before the view
+  // controller handles the mouse event.
+  [viewController view];
 
   // Test for pan events.
   // Start gesture.

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h
@@ -10,7 +10,12 @@
 
 @interface FlutterViewController () <FlutterKeyboardViewDelegate>
 
-// The FlutterView for this view controller.
+/**
+ * The FlutterView for this view controller.
+ *
+ * Reading this property triggers loadView if the view is not loaded yet,
+ * similar to NSViewController#view.
+ */
 @property(nonatomic, readonly, nullable) FlutterView* flutterView;
 
 /**


### PR DESCRIPTION
The macOS specification clearly said that `loadView` should not be directly called, and that calling `view` when the view is nil will automatically trigger `loadView`. This PR removed almost all usages of `loadView` except for a few in tests. The PR also changes `FlutterViewController#flutterView`, which is equivalent to `view`, to also follow the convention of initializatio-on-first-use. 

The most important outcome is removing the `loadView` call in `FlutterViewController`'s initializer, as this extra call introduced in https://github.com/flutter/engine/pull/36410 confusingly complicates the initialization process.

cc @sergiy-sc Any reason you added this call? Was it a mistake?

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
