### PR TITLE
Override _accessibilityHitTest to fix IOS 16 semantics issues 

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.h
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.h
@@ -66,6 +66,12 @@ constexpr float kScrollExtentMaxForInf = 1000;
 @property(nonatomic, strong) NSArray<SemanticsObject*>* children;
 
 /**
+ * Direct children of this semantics object in hit test order. Each child's `parent` property 
+ * must be equal to this object.
+ */
+@property(nonatomic, strong) NSArray<SemanticsObject*>* childrenInHitTestOrder;
+
+/**
  * The UIAccessibility that represents this object.
  *
  * By default, this return self. Subclasses can override to return different

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.h
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.h
@@ -66,7 +66,7 @@ constexpr float kScrollExtentMaxForInf = 1000;
 @property(nonatomic, strong) NSArray<SemanticsObject*>* children;
 
 /**
- * Direct children of this semantics object in hit test order. Each child's `parent` property 
+ * Direct children of this semantics object in hit test order. Each child's `parent` property
  * must be equal to this object.
  */
 @property(nonatomic, strong) NSArray<SemanticsObject*>* childrenInHitTestOrder;

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -531,6 +531,7 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
   return rect.width() * rect.height();
 }
 
+// Find the smallest eligiable semantics object for _accessibilityHitTest.
 - (SemanticsObject*)search:(SemanticsObject*)semanticsObject withPoint:(CGPoint)point {
   if ([semanticsObject children].count == 0) {
     // Check if the current semantic object should be returned.
@@ -565,6 +566,8 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 // For overlapping UIAccessibilityElements (e.g. a stack) in IOS, the focus goes to the smallest
 // object before IOS 16, but to the top-left object in IOS 16.
 // Override this method to focus the smallest object.
+// TODO(hangyujin): The ideal way is to pass the z-inex from framework to search the object 
+// with the highest z-index. https://github.com/flutter/flutter/issues/118656
 - (id)_accessibilityHitTest:(CGPoint)point withEvent:(UIEvent*)event {
   return [self search:self withPoint:point];
 }

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -536,32 +536,19 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
   if ([self children].count == 0) {
     // Check if the current semantic object should be returned.
     if ([self containsPoint:point] && [self isFocusable]) {
-      return self;
+      return self.nativeAccessibility;
     }
     return nil;
   }
 
-  SemanticsObject* smallestObject = nil;
-  // Traverse all semantics children to find an eligible and smallest one.
-  for (SemanticsObject* child in [self children]) {
+  // Traverse all semantics children to find an eligible one.
+  for (SemanticsObject* child in [self childrenInHitTestOrder]) {
     // Continue searching the child semantic tree if it contains the point.
     if ([child containsPoint:point]) {
-      SemanticsObject* childSearchResult = [child search:point];
-      if (childSearchResult != nil &&
-          (smallestObject == nil || [childSearchResult size] < [smallestObject size])) {
-        smallestObject = childSearchResult;
-      }
+      return [child search:point];
     }
   }
 
-  if (smallestObject != nil) {
-    return smallestObject;
-  }
-
-  // Check if the current semantic object should be returned.
-  if ([self containsPoint:point] && [self isFocusable]) {
-    return self;
-  }
   return nil;
 }
 

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -307,12 +307,8 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
     [child privateSetParent:nil];
   }
   [_children removeAllObjects];
-  [_children release];
-
-  for (SemanticsObject* child in _childrenInHitTestOrder) {
-    [child privateSetParent:nil];
-  }
   [_childrenInHitTestOrder removeAllObjects];
+  [_children release];
   [_childrenInHitTestOrder release];
 
   _parent = nil;
@@ -330,6 +326,17 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
   [_children release];
   _children = [[NSMutableArray alloc] initWithArray:children];
   for (SemanticsObject* child in _children) {
+    [child privateSetParent:self];
+  }
+}
+
+- (void)setChildrenInHitTestOrder:(NSArray<SemanticsObject*>*)childrenInHitTestOrder {
+  for (SemanticsObject* child in _childrenInHitTestOrder) {
+    [child privateSetParent:nil];
+  }
+  [_childrenInHitTestOrder release];
+  _childrenInHitTestOrder = [[NSMutableArray alloc] initWithArray:childrenInHitTestOrder];
+  for (SemanticsObject* child in _childrenInHitTestOrder) {
     [child privateSetParent:self];
   }
 }

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -552,7 +552,7 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 
   // Continue searching the child semantic tree.
   if (smallestObject != nil) {
-    return [smallestObject search: point];
+    return [smallestObject search:point];
   }
 
   // Check if the current semantic object should be returned.
@@ -569,7 +569,7 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 // TODO(hangyujin): The ideal way is to pass the z-inex from framework to search the object
 // with the highest z-index. https://github.com/flutter/flutter/issues/118656
 - (id)_accessibilityHitTest:(CGPoint)point withEvent:(UIEvent*)event {
-  return [self search: point];
+  return [self search:point];
 }
 
 - (NSAttributedString*)accessibilityAttributedLabel {

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -566,7 +566,7 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 // For overlapping UIAccessibilityElements (e.g. a stack) in IOS, the focus goes to the smallest
 // object before IOS 16, but to the top-left object in IOS 16.
 // Override this method to focus the smallest object.
-// TODO(hangyujin): The ideal way is to pass the z-inex from framework to search the object 
+// TODO(hangyujin): The ideal way is to pass the z-inex from framework to search the object
 // with the highest z-index. https://github.com/flutter/flutter/issues/118656
 - (id)_accessibilityHitTest:(CGPoint)point withEvent:(UIEvent*)event {
   return [self search:self withPoint:point];

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -10,7 +10,7 @@
 
 namespace {
 
-flutter::SemanticsAction GetSemanticsActionForScrollDirection( 
+flutter::SemanticsAction GetSemanticsActionForScrollDirection(
     UIAccessibilityScrollDirection direction) {
   // To describe the vertical scroll direction, UIAccessibilityScrollDirection uses the
   // direction the scroll bar moves in and SemanticsAction uses the direction the finger
@@ -517,23 +517,21 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
   return label;
 }
 
-- (bool) semanticsObjectContainsPoint:(SemanticsObject*)semanticsObject 
-                            withPoint:(CGPoint)point {
+- (bool)semanticsObjectContainsPoint:(SemanticsObject*)semanticsObject withPoint:(CGPoint)point {
   const SkRect& rect = [semanticsObject node].rect;
   CGRect localRect = CGRectMake(rect.x(), rect.y(), rect.width(), rect.height());
   CGRect globalRect = ConvertRectToGlobal(semanticsObject, localRect);
   return CGRectContainsPoint(globalRect, point);
 }
 
-- (double) getSize:(SemanticsObject*)semanticsObject {
+- (double)getSize:(SemanticsObject*)semanticsObject {
   const SkRect& rect = [semanticsObject node].rect;
   return rect.width() * rect.height();
 }
 
-- (SemanticsObject*) search:(SemanticsObject *)semanticsObject 
-                  withPoint:(CGPoint)point {
+- (SemanticsObject*)search:(SemanticsObject*)semanticsObject withPoint:(CGPoint)point {
   if ([semanticsObject children].count == 0) {
-    if([self semanticsObjectContainsPoint:semanticsObject withPoint: point]) {
+    if ([self semanticsObjectContainsPoint:semanticsObject withPoint:point]) {
       return semanticsObject;
     }
     return nil;
@@ -541,21 +539,21 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 
   SemanticsObject* bestChild = nil;
   for (SemanticsObject* child in [semanticsObject children]) {
-    if([self semanticsObjectContainsPoint:child withPoint: point]
-       && (bestChild == nil || [self getSize:child] < [self getSize:bestChild]))
-      bestChild=child;
+    if ([self semanticsObjectContainsPoint:child withPoint:point] &&
+        (bestChild == nil || [self getSize:child] < [self getSize:bestChild]))
+      bestChild = child;
   }
-  if(bestChild != nil) {
+  if (bestChild != nil) {
     return [self search:bestChild withPoint:point];
   }
-  if([self semanticsObjectContainsPoint:semanticsObject withPoint: point] && ![semanticsObject node].label.empty()) {
+  if ([self semanticsObjectContainsPoint:semanticsObject withPoint:point] &&
+      ![semanticsObject node].label.empty()) {
     return semanticsObject;
   }
   return nil;
 }
 
-- (id)_accessibilityHitTest:(CGPoint)point 
-                  withEvent:(UIEvent*)event {
+- (id)_accessibilityHitTest:(CGPoint)point withEvent:(UIEvent*)event {
   return [self search:self withPoint:point];
 }
 

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -526,7 +526,7 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
   return CGRectContainsPoint([self globalRect], point);
 }
 
-- (double)getSize {
+- (double)size {
   const SkRect& rect = [self node].rect;
   return rect.width() * rect.height();
 }
@@ -545,7 +545,7 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
   // Traverse all semantics children to find an eligible and smallest one.
   for (SemanticsObject* child in [semanticsObject children]) {
     if ([child containsPoint:point] &&
-        (smallestObject == nil || [child getSize] < [smallestObject getSize])) {
+        (smallestObject == nil || [child size] < [smallestObject size])) {
       smallestObject = child;
     }
   }

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -10,7 +10,7 @@
 
 namespace {
 
-flutter::SemanticsAction GetSemanticsActionForScrollDirection(
+flutter::SemanticsAction GetSemanticsActionForScrollDirection( 
     UIAccessibilityScrollDirection direction) {
   // To describe the vertical scroll direction, UIAccessibilityScrollDirection uses the
   // direction the scroll bar moves in and SemanticsAction uses the direction the finger
@@ -515,6 +515,48 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
                   : @([self node].tooltip.data());
   }
   return label;
+}
+
+- (bool) semanticsObjectContainsPoint:(SemanticsObject*)semanticsObject 
+                            withPoint:(CGPoint)point {
+  const SkRect& rect = [semanticsObject node].rect;
+  CGRect localRect = CGRectMake(rect.x(), rect.y(), rect.width(), rect.height());
+  CGRect globalRect = ConvertRectToGlobal(semanticsObject, localRect);
+  return CGRectContainsPoint(globalRect, point);
+}
+
+- (double) getSize:(SemanticsObject*)semanticsObject {
+  const SkRect& rect = [semanticsObject node].rect;
+  return rect.width() * rect.height();
+}
+
+- (SemanticsObject*) search:(SemanticsObject *)semanticsObject 
+                  withPoint:(CGPoint)point {
+  if ([semanticsObject children].count == 0) {
+    if([self semanticsObjectContainsPoint:semanticsObject withPoint: point]) {
+      return semanticsObject;
+    }
+    return nil;
+  }
+
+  SemanticsObject* bestChild = nil;
+  for (SemanticsObject* child in [semanticsObject children]) {
+    if([self semanticsObjectContainsPoint:child withPoint: point]
+       && (bestChild == nil || [self getSize:child] < [self getSize:bestChild]))
+      bestChild=child;
+  }
+  if(bestChild != nil) {
+    return [self search:bestChild withPoint:point];
+  }
+  if([self semanticsObjectContainsPoint:semanticsObject withPoint: point] && ![semanticsObject node].label.empty()) {
+    return semanticsObject;
+  }
+  return nil;
+}
+
+- (id)_accessibilityHitTest:(CGPoint)point 
+                  withEvent:(UIEvent*)event {
+  return [self search:self withPoint:point];
 }
 
 - (NSAttributedString*)accessibilityAttributedLabel {

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -545,11 +545,11 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
   // Traverse all semantics children to find an eligible and smallest one.
   for (SemanticsObject* child in [self children]) {
     // Continue searching the child semantic tree if it contains the point.
-    if ([child containsPoint:point]){
+    if ([child containsPoint:point]) {
       SemanticsObject* childSearchResult = [child search:point];
-      if(childSearchResult!=nil&&(smallestObject==nil||[childSearchResult size] < [smallestObject size]))
-         {
-          smallestObject = childSearchResult;
+      if (childSearchResult != nil &&
+          (smallestObject == nil || [childSearchResult size] < [smallestObject size])) {
+        smallestObject = childSearchResult;
       }
     }
   }
@@ -572,7 +572,7 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 // TODO(hangyujin): The ideal way is to pass the z-inex from framework to search the object
 // with the highest z-index. https://github.com/flutter/flutter/issues/118656
 - (id)_accessibilityHitTest:(CGPoint)point withEvent:(UIEvent*)event {
-  return [self search: point];
+  return [self search:point];
 }
 
 - (NSAttributedString*)accessibilityAttributedLabel {

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -267,6 +267,7 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 @implementation SemanticsObject {
   fml::scoped_nsobject<SemanticsObjectContainer> _container;
   NSMutableArray<SemanticsObject*>* _children;
+  NSMutableArray<SemanticsObject*>* _childrenInHitTestOrder;
   BOOL _inDealloc;
 }
 
@@ -295,6 +296,7 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
     _bridge = bridge;
     _uid = uid;
     _children = [[NSMutableArray alloc] init];
+    _childrenInHitTestOrder = [[NSMutableArray alloc] init];
   }
 
   return self;
@@ -306,6 +308,13 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
   }
   [_children removeAllObjects];
   [_children release];
+
+  for (SemanticsObject* child in _childrenInHitTestOrder) {
+    [child privateSetParent:nil];
+  }
+  [_childrenInHitTestOrder removeAllObjects];
+  [_childrenInHitTestOrder release];
+
   _parent = nil;
   _container.get().semanticsObject = nil;
   _inDealloc = YES;

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -521,8 +521,8 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
   return label;
 }
 
-// The point is in global coordinates, so use the global rect here.
 - (bool)containsPoint:(CGPoint)point {
+  // The point is in global coordinates, so use the global rect here.
   return CGRectContainsPoint([self globalRect], point);
 }
 

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -544,15 +544,18 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
   SemanticsObject* smallestObject = nil;
   // Traverse all semantics children to find an eligible and smallest one.
   for (SemanticsObject* child in [self children]) {
-    if ([child containsPoint:point] &&
-        (smallestObject == nil || [child size] < [smallestObject size])) {
-      smallestObject = child;
+    // Continue searching the child semantic tree if it contains the point.
+    if ([child containsPoint:point]){
+      SemanticsObject* childSearchResult = [child search:point];
+      if(childSearchResult!=nil&&(smallestObject==nil||[childSearchResult size] < [smallestObject size]))
+         {
+          smallestObject = childSearchResult;
+      }
     }
   }
 
-  // Continue searching the child semantic tree.
   if (smallestObject != nil) {
-    return [smallestObject search:point];
+    return smallestObject;
   }
 
   // Check if the current semantic object should be returned.
@@ -569,7 +572,7 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 // TODO(hangyujin): The ideal way is to pass the z-inex from framework to search the object
 // with the highest z-index. https://github.com/flutter/flutter/issues/118656
 - (id)_accessibilityHitTest:(CGPoint)point withEvent:(UIEvent*)event {
-  return [self search:point];
+  return [self search: point];
 }
 
 - (NSAttributedString*)accessibilityAttributedLabel {

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -534,8 +534,7 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 - (SemanticsObject*)search:(SemanticsObject*)semanticsObject withPoint:(CGPoint)point {
   if ([semanticsObject children].count == 0) {
     // Check if the current semantic object should be returned.
-    if ([semanticsObject containsPoint:point] &&
-        [self isFocusable:semanticsObject]) {
+    if ([semanticsObject containsPoint:point] && [self isFocusable:semanticsObject]) {
       return semanticsObject;
     }
     return nil;
@@ -556,8 +555,7 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
   }
 
   // Check if the current semantic object should be returned.
-  if ([semanticsObject containsPoint:point] &&
-      [self isFocusable:semanticsObject]) {
+  if ([semanticsObject containsPoint:point] && [self isFocusable:semanticsObject]) {
     return semanticsObject;
   }
   return nil;

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -535,7 +535,7 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 - (SemanticsObject*)search:(SemanticsObject*)semanticsObject withPoint:(CGPoint)point {
   if ([semanticsObject children].count == 0) {
     // Check if the current semantic object should be returned.
-    if ([semanticsObject containsPoint:point] && [self isFocusable:semanticsObject]) {
+    if ([semanticsObject containsPoint:point] && [semanticsObject isFocusable]) {
       return semanticsObject;
     }
     return nil;
@@ -556,7 +556,7 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
   }
 
   // Check if the current semantic object should be returned.
-  if ([semanticsObject containsPoint:point] && [self isFocusable:semanticsObject]) {
+  if ([semanticsObject containsPoint:point] && [semanticsObject isFocusable]) {
     return semanticsObject;
   }
   return nil;

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -528,21 +528,21 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 
 // Finds the first eligiable semantics object in hit test order.
 - (SemanticsObject*)search:(CGPoint)point {
-  if ([self children].count == 0) {
-    // Check if the current semantic object should be returned.
-    if ([self containsPoint:point] && [self isFocusable]) {
-      return self.nativeAccessibility;
-    }
-    return nil;
-  }
 
   // Search children in hit test order.
   for (SemanticsObject* child in [self childrenInHitTestOrder]) {
     if ([child containsPoint:point]) {
-      return [child search:point];
+      SemanticsObject* childSearchResult = [child search:point];
+      if(childSearchResult != nil) {
+        return childSearchResult;
+      }
     }
   }
 
+  // Check if the current semantic object should be returned.
+  if ([self containsPoint:point] && [self isFocusable]) {
+    return self.nativeAccessibility;
+  }
   return nil;
 }
 

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -531,7 +531,7 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
   return rect.width() * rect.height();
 }
 
-// Find the smallest eligiable semantics object for _accessibilityHitTest.
+// Finds the smallest eligiable semantics object for _accessibilityHitTest.
 - (SemanticsObject*)search:(CGPoint)point {
   if ([self children].count == 0) {
     // Check if the current semantic object should be returned.

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -528,12 +528,11 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 
 // Finds the first eligiable semantics object in hit test order.
 - (SemanticsObject*)search:(CGPoint)point {
-
   // Search children in hit test order.
   for (SemanticsObject* child in [self childrenInHitTestOrder]) {
     if ([child containsPoint:point]) {
       SemanticsObject* childSearchResult = [child search:point];
-      if(childSearchResult != nil) {
+      if (childSearchResult != nil) {
         return childSearchResult;
       }
     }

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -526,7 +526,7 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
   return CGRectContainsPoint([self globalRect], point);
 }
 
-// Finds the smallest eligiable semantics object for _accessibilityHitTest.
+// Finds the first eligiable semantics object in hit test order.
 - (SemanticsObject*)search:(CGPoint)point {
   if ([self children].count == 0) {
     // Check if the current semantic object should be returned.
@@ -536,9 +536,8 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
     return nil;
   }
 
-  // Traverse all semantics children to find an eligible one.
+  // Search children in hit test order.
   for (SemanticsObject* child in [self childrenInHitTestOrder]) {
-    // Continue searching the child semantic tree if it contains the point.
     if ([child containsPoint:point]) {
       return [child search:point];
     }
@@ -547,12 +546,10 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
   return nil;
 }
 
-// Override apple private method to fix https://github.com/flutter/flutter/issues/113377.
+// Overrides apple private method to fix https://github.com/flutter/flutter/issues/113377.
 // For overlapping UIAccessibilityElements (e.g. a stack) in IOS, the focus goes to the smallest
 // object before IOS 16, but to the top-left object in IOS 16.
-// Override this method to focus the smallest object.
-// TODO(hangyujin): The ideal way is to pass the z-inex from framework to search the object
-// with the highest z-index. https://github.com/flutter/flutter/issues/118656
+// Overrides this method to focus the first eligiable semantics object in hit test order.
 - (id)_accessibilityHitTest:(CGPoint)point withEvent:(UIEvent*)event {
   return [self search:point];
 }

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -546,7 +546,7 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
   }
 
   SemanticsObject* bestChild = nil;
-  // Traverse all semantics children to find an elligable and smallest one.
+  // Traverse all semantics children to find an eligible and smallest one.
   for (SemanticsObject* child in [semanticsObject children]) {
     if ([self semanticsObjectContainsPoint:child withPoint:point] &&
         (bestChild == nil || [self getSize:child] < [self getSize:bestChild])) {

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -526,11 +526,6 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
   return CGRectContainsPoint([self globalRect], point);
 }
 
-- (double)size {
-  const SkRect& rect = [self node].rect;
-  return rect.width() * rect.height();
-}
-
 // Finds the smallest eligiable semantics object for _accessibilityHitTest.
 - (SemanticsObject*)search:(CGPoint)point {
   if ([self children].count == 0) {

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -532,18 +532,18 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 }
 
 // Find the smallest eligiable semantics object for _accessibilityHitTest.
-- (SemanticsObject*)search:(SemanticsObject*)semanticsObject withPoint:(CGPoint)point {
-  if ([semanticsObject children].count == 0) {
+- (SemanticsObject*)search:(CGPoint)point {
+  if ([self children].count == 0) {
     // Check if the current semantic object should be returned.
-    if ([semanticsObject containsPoint:point] && [semanticsObject isFocusable]) {
-      return semanticsObject;
+    if ([self containsPoint:point] && [self isFocusable]) {
+      return self;
     }
     return nil;
   }
 
   SemanticsObject* smallestObject = nil;
   // Traverse all semantics children to find an eligible and smallest one.
-  for (SemanticsObject* child in [semanticsObject children]) {
+  for (SemanticsObject* child in [self children]) {
     if ([child containsPoint:point] &&
         (smallestObject == nil || [child size] < [smallestObject size])) {
       smallestObject = child;
@@ -552,12 +552,12 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 
   // Continue searching the child semantic tree.
   if (smallestObject != nil) {
-    return [self search:smallestObject withPoint:point];
+    return [smallestObject search: point];
   }
 
   // Check if the current semantic object should be returned.
-  if ([semanticsObject containsPoint:point] && [semanticsObject isFocusable]) {
-    return semanticsObject;
+  if ([self containsPoint:point] && [self isFocusable]) {
+    return self;
   }
   return nil;
 }
@@ -569,7 +569,7 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 // TODO(hangyujin): The ideal way is to pass the z-inex from framework to search the object
 // with the highest z-index. https://github.com/flutter/flutter/issues/118656
 - (id)_accessibilityHitTest:(CGPoint)point withEvent:(UIEvent*)event {
-  return [self search:self withPoint:point];
+  return [self search: point];
 }
 
 - (NSAttributedString*)accessibilityAttributedLabel {

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
@@ -157,7 +157,7 @@ class MockAccessibilityBridgeNoWindow : public AccessibilityBridgeIos {
   CGPoint point = CGPointMake(10, 10);
   id hitTestResult = [object0 _accessibilityHitTest:point withEvent:nil];
 
-  // // Focus to object2 because it's the smallest object
+  // Focus to object2 because it's the smallest object
   XCTAssertEqual(hitTestResult, object2);
 }
 
@@ -194,11 +194,8 @@ class MockAccessibilityBridgeNoWindow : public AccessibilityBridgeIos {
 
   CGPoint point = CGPointMake(10, 10);
   id hitTestResult = [object0 _accessibilityHitTest:point withEvent:nil];
-  int resultId = [hitTestResult node].id;
 
-  // Focus to object2 because it's the smallest object
-  XCTAssertEqual(resultId, 0);
-  // XCTAssertNil(hitTestResult);
+  XCTAssertNil(hitTestResult);
 }
 
 - (void)testAccessibilityHitTestOutOfRect {

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
@@ -128,7 +128,9 @@ class MockAccessibilityBridgeNoWindow : public AccessibilityBridgeIos {
   SemanticsObject* object2 = [[SemanticsObject alloc] initWithBridge:bridge uid:2];
   SemanticsObject* object3 = [[SemanticsObject alloc] initWithBridge:bridge uid:3];
   object0.children = @[ object1 ];
+  object0.childrenInHitTestOrder = @[ object1 ];
   object1.children = @[ object2, object3 ];
+  object1.childrenInHitTestOrder = @[ object2, object3 ];
 
   flutter::SemanticsNode node0;
   node0.id = 0;
@@ -157,7 +159,7 @@ class MockAccessibilityBridgeNoWindow : public AccessibilityBridgeIos {
   CGPoint point = CGPointMake(10, 10);
   id hitTestResult = [object0 _accessibilityHitTest:point withEvent:nil];
 
-  // Focus to object2 because it's the smallest object
+  // Focus to object2 because it's the first object in hit test order
   XCTAssertEqual(hitTestResult, object2);
 }
 
@@ -170,7 +172,9 @@ class MockAccessibilityBridgeNoWindow : public AccessibilityBridgeIos {
   SemanticsObject* object2 = [[SemanticsObject alloc] initWithBridge:bridge uid:2];
   SemanticsObject* object3 = [[SemanticsObject alloc] initWithBridge:bridge uid:3];
   object0.children = @[ object1 ];
+  object0.childrenInHitTestOrder = @[ object1 ];
   object1.children = @[ object2, object3 ];
+  object1.childrenInHitTestOrder = @[ object2, object3 ];
 
   flutter::SemanticsNode node0;
   node0.id = 0;
@@ -207,7 +211,9 @@ class MockAccessibilityBridgeNoWindow : public AccessibilityBridgeIos {
   SemanticsObject* object2 = [[SemanticsObject alloc] initWithBridge:bridge uid:2];
   SemanticsObject* object3 = [[SemanticsObject alloc] initWithBridge:bridge uid:3];
   object0.children = @[ object1 ];
+  object0.childrenInHitTestOrder = @[ object1 ];
   object1.children = @[ object2, object3 ];
+  object1.childrenInHitTestOrder = @[ object2, object3 ];
 
   flutter::SemanticsNode node0;
   node0.id = 0;

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
@@ -92,6 +92,11 @@ class MockAccessibilityBridgeNoWindow : public AccessibilityBridgeIos {
 @interface SemanticsObjectTest : XCTestCase
 @end
 
+@interface SemanticsObject (Tests)
+
+- (id)_accessibilityHitTest:(CGPoint)point withEvent:(UIEvent*)event;
+@end
+
 @implementation SemanticsObjectTest
 
 - (void)testCreate {
@@ -112,6 +117,129 @@ class MockAccessibilityBridgeNoWindow : public AccessibilityBridgeIos {
   XCTAssertEqual(parent, child.parent);
   parent.children = @[];
   XCTAssertNil(child.parent);
+}
+
+- (void)testAccessibilityHitTestFocusAtLeaf {
+  fml::WeakPtrFactory<flutter::AccessibilityBridgeIos> factory(
+      new flutter::MockAccessibilityBridge());
+  fml::WeakPtr<flutter::AccessibilityBridgeIos> bridge = factory.GetWeakPtr();
+  SemanticsObject* object0 = [[SemanticsObject alloc] initWithBridge:bridge uid:0];
+  SemanticsObject* object1 = [[SemanticsObject alloc] initWithBridge:bridge uid:1];
+  SemanticsObject* object2 = [[SemanticsObject alloc] initWithBridge:bridge uid:2];
+  SemanticsObject* object3 = [[SemanticsObject alloc] initWithBridge:bridge uid:3];
+  object0.children = @[ object1 ];
+  object1.children = @[ object2, object3 ];
+
+  flutter::SemanticsNode node0;
+  node0.id = 0;
+  node0.rect = SkRect::MakeXYWH(0, 0, 200, 200);
+  node0.label = "0";
+  [object0 setSemanticsNode:&node0];
+
+  flutter::SemanticsNode node1;
+  node1.id = 1;
+  node1.rect = SkRect::MakeXYWH(0, 0, 200, 200);
+  node1.label = "1";
+  [object1 setSemanticsNode:&node1];
+
+  flutter::SemanticsNode node2;
+  node2.id = 2;
+  node2.rect = SkRect::MakeXYWH(0, 0, 100, 100);
+  node2.label = "2";
+  [object2 setSemanticsNode:&node2];
+
+  flutter::SemanticsNode node3;
+  node3.id = 3;
+  node3.rect = SkRect::MakeXYWH(0, 0, 200, 200);
+  node3.label = "3";
+  [object3 setSemanticsNode:&node3];
+
+  CGPoint point = CGPointMake(10, 10);
+  id hitTestResult = [object0 _accessibilityHitTest:point withEvent:nil];
+
+  // // Focus to object2 because it's the smallest object
+  XCTAssertEqual(hitTestResult, object2);
+}
+
+- (void)testAccessibilityHitTestNoFocusableItem {
+  fml::WeakPtrFactory<flutter::AccessibilityBridgeIos> factory(
+      new flutter::MockAccessibilityBridge());
+  fml::WeakPtr<flutter::AccessibilityBridgeIos> bridge = factory.GetWeakPtr();
+  SemanticsObject* object0 = [[SemanticsObject alloc] initWithBridge:bridge uid:0];
+  SemanticsObject* object1 = [[SemanticsObject alloc] initWithBridge:bridge uid:1];
+  SemanticsObject* object2 = [[SemanticsObject alloc] initWithBridge:bridge uid:2];
+  SemanticsObject* object3 = [[SemanticsObject alloc] initWithBridge:bridge uid:3];
+  object0.children = @[ object1 ];
+  object1.children = @[ object2, object3 ];
+
+  flutter::SemanticsNode node0;
+  node0.id = 0;
+  node0.rect = SkRect::MakeXYWH(0, 0, 200, 200);
+  [object0 setSemanticsNode:&node0];
+
+  flutter::SemanticsNode node1;
+  node1.id = 1;
+  node1.rect = SkRect::MakeXYWH(0, 0, 200, 200);
+  [object1 setSemanticsNode:&node1];
+
+  flutter::SemanticsNode node2;
+  node2.id = 2;
+  node2.rect = SkRect::MakeXYWH(0, 0, 100, 100);
+  [object2 setSemanticsNode:&node2];
+
+  flutter::SemanticsNode node3;
+  node3.id = 3;
+  node3.rect = SkRect::MakeXYWH(0, 0, 200, 200);
+  [object3 setSemanticsNode:&node3];
+
+  CGPoint point = CGPointMake(10, 10);
+  id hitTestResult = [object0 _accessibilityHitTest:point withEvent:nil];
+  int resultId = [hitTestResult node].id;
+
+  // Focus to object2 because it's the smallest object
+  XCTAssertEqual(resultId, 0);
+  // XCTAssertNil(hitTestResult);
+}
+
+- (void)testAccessibilityHitTestOutOfRect {
+  fml::WeakPtrFactory<flutter::AccessibilityBridgeIos> factory(
+      new flutter::MockAccessibilityBridge());
+  fml::WeakPtr<flutter::AccessibilityBridgeIos> bridge = factory.GetWeakPtr();
+  SemanticsObject* object0 = [[SemanticsObject alloc] initWithBridge:bridge uid:0];
+  SemanticsObject* object1 = [[SemanticsObject alloc] initWithBridge:bridge uid:1];
+  SemanticsObject* object2 = [[SemanticsObject alloc] initWithBridge:bridge uid:2];
+  SemanticsObject* object3 = [[SemanticsObject alloc] initWithBridge:bridge uid:3];
+  object0.children = @[ object1 ];
+  object1.children = @[ object2, object3 ];
+
+  flutter::SemanticsNode node0;
+  node0.id = 0;
+  node0.rect = SkRect::MakeXYWH(0, 0, 200, 200);
+  node0.label = "0";
+  [object0 setSemanticsNode:&node0];
+
+  flutter::SemanticsNode node1;
+  node1.id = 1;
+  node1.rect = SkRect::MakeXYWH(0, 0, 200, 200);
+  node1.label = "1";
+  [object1 setSemanticsNode:&node1];
+
+  flutter::SemanticsNode node2;
+  node2.id = 2;
+  node2.rect = SkRect::MakeXYWH(0, 0, 100, 100);
+  node2.label = "2";
+  [object2 setSemanticsNode:&node2];
+
+  flutter::SemanticsNode node3;
+  node3.id = 3;
+  node3.rect = SkRect::MakeXYWH(0, 0, 200, 200);
+  node3.label = "3";
+  [object3 setSemanticsNode:&node3];
+
+  CGPoint point = CGPointMake(300, 300);
+  id hitTestResult = [object0 _accessibilityHitTest:point withEvent:nil];
+
+  XCTAssertNil(hitTestResult);
 }
 
 - (void)testReplaceChildAtIndex {

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -114,7 +114,7 @@ void AccessibilityBridge::UpdateSemantics(
       [newChildrenInHitTestOrder addObject:child];
     }
     object.children = newChildren;
-    object.childrenInHitTestOrder = newChildren;
+    object.childrenInHitTestOrder = newChildrenInHitTestOrder;
     if (!node.customAccessibilityActions.empty()) {
       NSMutableArray<FlutterCustomAccessibilityAction*>* accessibilityCustomActions =
           [[[NSMutableArray alloc] init] autorelease];

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -107,7 +107,14 @@ void AccessibilityBridge::UpdateSemantics(
       SemanticsObject* child = GetOrCreateObject(node.childrenInTraversalOrder[i], nodes);
       [newChildren addObject:child];
     }
+    NSMutableArray* newChildrenInHitTestOrder =
+        [[[NSMutableArray alloc] initWithCapacity:newChildCount] autorelease];
+    for (NSUInteger i = 0; i < newChildCount; ++i) {
+      SemanticsObject* child = GetOrCreateObject(node.childrenInHitTestOrder[i], nodes);
+      [newChildrenInHitTestOrder addObject:child];
+    }
     object.children = newChildren;
+    object.childrenInHitTestOrder = newChildren;
     if (!node.customAccessibilityActions.empty()) {
       NSMutableArray<FlutterCustomAccessibilityAction*>* accessibilityCustomActions =
           [[[NSMutableArray alloc] init] autorelease];

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
@@ -399,6 +399,7 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
     node.scrollExtentMax = 100.0;
     node.scrollPosition = 0.0;
     parent.childrenInTraversalOrder.push_back(1);
+    parent.childrenInHitTestOrder.push_back(1);
 
     flutter::SemanticsNode child;
     child.id = 2;
@@ -407,6 +408,7 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
     child.value = "value";
     child.hint = "hint";
     node.childrenInTraversalOrder.push_back(2);
+    node.childrenInHitTestOrder.push_back(2);
 
     nodes[0] = parent;
     nodes[1] = node;
@@ -427,6 +429,7 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
     new_node.scrollExtentMax = 100.0;
     new_node.scrollPosition = 0.0;
     new_node.childrenInTraversalOrder.push_back(2);
+    new_node.childrenInHitTestOrder.push_back(2);
 
     new_nodes[1] = new_node;
     bridge->UpdateSemantics(/*nodes=*/new_nodes, /*actions=*/actions);
@@ -489,6 +492,7 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
     node.scrollExtentMax = 100.0;
     node.scrollPosition = 0.0;
     parent.childrenInTraversalOrder.push_back(1);
+    parent.childrenInHitTestOrder.push_back(1);
     nodes[0] = parent;
     nodes[1] = node;
     flutter::CustomAccessibilityActionUpdates actions;
@@ -556,6 +560,7 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
     node.scrollExtentMax = 100.0;
     node.scrollPosition = 0.0;
     parent.childrenInTraversalOrder.push_back(1);
+    parent.childrenInHitTestOrder.push_back(1);
     nodes[0] = parent;
     nodes[1] = node;
     flutter::CustomAccessibilityActionUpdates actions;


### PR DESCRIPTION
issue: https://github.com/flutter/flutter/issues/113377

The issue is that for overlapping semantics  (e.g. a stack)
Before IOS 16, the focus goes to the smallest object.
In IOS 16, the focus goes to the top-left object.

This is an IOS bug and we can reproduce it by writing an sample IOS application with UIAccessibilityElement.

Under the hood, iOS calls a private method -[UIViewAccessibility _accessibilityHitTest:withEvent:] is used to determine which element is hit tested.

This PR is to override this private method to change the focus behavior and fix the issues.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
