### PR TITLE
[web] cache sample and stencil params

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -117,6 +117,8 @@ extension CanvasKitExtension on CanvasKit {
     int width,
     int height,
     ColorSpace colorSpace,
+    int sampleCount,
+    int stencil,
   );
   external SkSurface MakeSWCanvasSurface(DomCanvasElement canvas);
 

--- a/lib/web_ui/lib/src/engine/canvaskit/surface.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/surface.dart
@@ -358,9 +358,9 @@ class Surface {
   }
 
   void _initWebglParams() {
-    var gl = htmlCanvas!.getGlContext(webGLVersion);
-    _sampleCount = gl.getParameter(gl.SAMPLES);
-    _stencilBits = gl.getParameter(gl.STENCIL_BITS);
+    final WebGLContext gl = htmlCanvas!.getGlContext(webGLVersion);
+    _sampleCount = gl.getParameter(gl.samples);
+    _stencilBits = gl.getParameter(gl.stencilBits);
   }
 
   CkSurface _createNewSurface(ui.Size size) {

--- a/lib/web_ui/lib/src/engine/canvaskit/surface.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/surface.dart
@@ -98,6 +98,8 @@ class Surface {
   DomCanvasElement? htmlCanvas;
   int _pixelWidth = -1;
   int _pixelHeight = -1;
+  int _sampleCount = -1;
+  int _stencilBits = -1;
 
   /// Specify the GPU resource cache limits.
   void setSkiaResourceCacheMaxBytes(int bytes) {
@@ -334,6 +336,9 @@ class Surface {
           majorVersion: webGLVersion.toDouble(),
         ),
       ).toInt();
+      if (_sampleCount == -1 || _stencilBits == -1) {
+        _initWebglParams();
+      }
 
       _glContext = glContext;
 
@@ -350,6 +355,12 @@ class Surface {
     }
 
     htmlElement.append(htmlCanvas);
+  }
+
+  void _initWebglParams() {
+    var gl = htmlCanvas!.getGlContext(webGLVersion);
+    _sampleCount = gl.getParameter(gl.SAMPLES);
+    _stencilBits = gl.getParameter(gl.STENCIL_BITS);
   }
 
   CkSurface _createNewSurface(ui.Size size) {
@@ -369,6 +380,8 @@ class Surface {
         size.width.ceil(),
         size.height.ceil(),
         SkColorSpaceSRGB,
+        _sampleCount,
+        _stencilBits
       );
 
       if (skSurface == null) {

--- a/lib/web_ui/lib/src/engine/dom.dart
+++ b/lib/web_ui/lib/src/engine/dom.dart
@@ -624,6 +624,25 @@ extension DomCanvasElementExtension on DomCanvasElement {
 
   DomCanvasRenderingContext2D get context2D =>
       getContext('2d')! as DomCanvasRenderingContext2D;
+
+  WebGLContext getGlContext(int majorVersion) {
+    if (majorVersion == 1) {
+      return getContext('webgl')! as WebGLContext;
+    }
+    return getContext('webgl2')! as WebGLContext;
+  }
+}
+
+@JS()
+@staticInterop
+class WebGLContext {}
+
+extension WebGLContextExtension on WebGLContext {
+  external int getParameter(int value);
+
+  external int get SAMPLES;
+
+  external int get STENCIL_BITS;
 }
 
 @JS()

--- a/lib/web_ui/lib/src/engine/dom.dart
+++ b/lib/web_ui/lib/src/engine/dom.dart
@@ -640,9 +640,11 @@ class WebGLContext {}
 extension WebGLContextExtension on WebGLContext {
   external int getParameter(int value);
 
-  external int get SAMPLES;
+  @JS('SAMPLES')
+  external int get samples;
 
-  external int get STENCIL_BITS;
+  @JS('STENCIL_BITS')
+  external int get stencilBits;
 }
 
 @JS()

--- a/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
+++ b/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:math';
 import 'dart:typed_data';
+import 'dart:web_gl';
 
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
@@ -1780,5 +1781,34 @@ void _paragraphTests() {
       )),
       canvasKit.TextHeightBehavior.DisableAll,
     );
+  });
+
+  test('MakeOnScreenGLSurface test', () {
+    final DomCanvasElement canvas = createDomCanvasElement(
+      width: 100,
+      height: 100,
+    );
+    final WebGLContext gl = canvas.getGlContext(webGLVersion);
+    final int sampleCount = gl.getParameter(gl.samples);
+    final int stencilBits = gl.getParameter(gl.stencilBits);
+
+    final int glContext = canvasKit.GetWebGLContext(
+      canvas,
+      SkWebGLContextOptions(
+        antialias: 0,
+        majorVersion: webGLVersion.toDouble(),
+      ),
+    ).toInt();
+    final SkGrContext grContext =  canvasKit.MakeGrContext(glContext);
+    final SkSurface? skSurface = canvasKit.MakeOnScreenGLSurface(
+      grContext,
+      100,
+      100,
+      SkColorSpaceSRGB,
+      sampleCount,
+      stencilBits
+    );
+
+    expect(skSurface, isNotNull);
   });
 }

--- a/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
+++ b/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
@@ -1809,5 +1809,5 @@ void _paragraphTests() {
     );
 
     expect(skSurface, isNotNull);
-  });
+  }, skip: isFirefox); // Intended: Headless firefox has no webgl support https://github.com/flutter/flutter/issues/109265
 }

--- a/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
+++ b/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
@@ -4,7 +4,6 @@
 
 import 'dart:math';
 import 'dart:typed_data';
-import 'dart:web_gl';
 
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/117934

Now the only expensive part is some style recalc/relayout whenever the canvas is eventually resized.

## Before

<img width="1728" alt="Screenshot 2023-01-12 at 8 09 30 PM" src="https://user-images.githubusercontent.com/8975114/212235493-b70eac97-1dd4-4e29-901b-fee97c4b1ef6.png">

#After

<img width="1728" alt="Screenshot 2023-01-12 at 8 08 23 PM" src="https://user-images.githubusercontent.com/8975114/212235458-754de389-6468-4244-ad3c-deacd8bc1bba.png">

