### PR TITLE
properly namespace flutter software pixel formats

### DIFF
--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -299,8 +299,8 @@ typedef enum {
 ///
 ///   - all other formats are called packed formats, and the component order
 ///     as specified in the format name refers to the order in the native type.
-///     for example, for kRGB565, the R component uses the 5 least significant
-///     bits of the uint16_t pixel value.
+///     for example, for kFlutterSoftwarePixelFormatRGB565, the R component
+///     uses the 5 least significant bits of the uint16_t pixel value.
 ///
 /// Each pixel format in this list is documented with an example on how to get
 /// the color components from the pixel.
@@ -316,30 +316,31 @@ typedef enum {
   /// pixel with 8 bit grayscale value.
   /// The grayscale value is the luma value calculated from r, g, b
   /// according to BT.709. (gray = r*0.2126 + g*0.7152 + b*0.0722)
-  kGray8,
+  kFlutterSoftwarePixelFormatGray8,
 
   /// pixel with 5 bits red, 6 bits green, 5 bits blue, in 16-bit word.
   ///   r = p & 0x3F; g = (p>>5) & 0x3F; b = p>>11;
-  kRGB565,
+  kFlutterSoftwarePixelFormatRGB565,
 
   /// pixel with 4 bits for alpha, red, green, blue; in 16-bit word.
   ///   r = p & 0xF;  g = (p>>4) & 0xF;  b = (p>>8) & 0xF;   a = p>>12;
-  kRGBA4444,
+  kFlutterSoftwarePixelFormatRGBA4444,
 
   /// pixel with 8 bits for red, green, blue, alpha.
   ///   r = p[0]; g = p[1]; b = p[2]; a = p[3];
-  kRGBA8888,
+  kFlutterSoftwarePixelFormatRGBA8888,
 
   /// pixel with 8 bits for red, green and blue and 8 unused bits.
   ///   r = p[0]; g = p[1]; b = p[2];
-  kRGBX8888,
+  kFlutterSoftwarePixelFormatRGBX8888,
 
   /// pixel with 8 bits for blue, green, red and alpha.
   ///   r = p[2]; g = p[1]; b = p[0]; a = p[3];
-  kBGRA8888,
+  kFlutterSoftwarePixelFormatBGRA8888,
 
-  /// either kBGRA8888 or kRGBA8888 depending on CPU endianess and OS
-  kNative32,
+  /// either kFlutterSoftwarePixelFormatBGRA8888 or
+  /// kFlutterSoftwarePixelFormatRGBA8888 depending on CPU endianess and OS
+  kFlutterSoftwarePixelFormatNative32,
 } FlutterSoftwarePixelFormat;
 
 typedef struct {

--- a/shell/platform/embedder/pixel_formats.cc
+++ b/shell/platform/embedder/pixel_formats.cc
@@ -7,19 +7,19 @@
 
 std::optional<SkColorType> getSkColorType(FlutterSoftwarePixelFormat pixfmt) {
   switch (pixfmt) {
-    case kGray8:
+    case kFlutterSoftwarePixelFormatGray8:
       return kGray_8_SkColorType;
-    case kRGB565:
+    case kFlutterSoftwarePixelFormatRGB565:
       return kRGB_565_SkColorType;
-    case kRGBA4444:
+    case kFlutterSoftwarePixelFormatRGBA4444:
       return kARGB_4444_SkColorType;
-    case kRGBA8888:
+    case kFlutterSoftwarePixelFormatRGBA8888:
       return kRGBA_8888_SkColorType;
-    case kRGBX8888:
+    case kFlutterSoftwarePixelFormatRGBX8888:
       return kRGB_888x_SkColorType;
-    case kBGRA8888:
+    case kFlutterSoftwarePixelFormatBGRA8888:
       return kBGRA_8888_SkColorType;
-    case kNative32:
+    case kFlutterSoftwarePixelFormatNative32:
       return kN32_SkColorType;
     default:
       FML_LOG(ERROR) << "Invalid software rendering pixel format";

--- a/shell/platform/embedder/tests/embedder_assertions.h
+++ b/shell/platform/embedder/tests/embedder_assertions.h
@@ -355,20 +355,20 @@ inline std::string FlutterOpenGLTargetTypeToString(
 inline std::string FlutterSoftwarePixelFormatToString(
     FlutterSoftwarePixelFormat pixfmt) {
   switch (pixfmt) {
-    case kGray8:
-      return "kGray8";
-    case kRGB565:
-      return "kRGB565";
-    case kRGBA4444:
-      return "kRGBA4444";
-    case kRGBA8888:
-      return "kRGBA8888";
-    case kRGBX8888:
-      return "kRGBX8888";
-    case kBGRA8888:
-      return "kBGRA8888";
-    case kNative32:
-      return "kNative32";
+    case kFlutterSoftwarePixelFormatGray8:
+      return "kFlutterSoftwarePixelFormatGray8";
+    case kFlutterSoftwarePixelFormatRGB565:
+      return "kFlutterSoftwarePixelFormatRGB565";
+    case kFlutterSoftwarePixelFormatRGBA4444:
+      return "kFlutterSoftwarePixelFormatRGBA4444";
+    case kFlutterSoftwarePixelFormatRGBA8888:
+      return "kFlutterSoftwarePixelFormatRGBA8888";
+    case kFlutterSoftwarePixelFormatRGBX8888:
+      return "kFlutterSoftwarePixelFormatRGBX8888";
+    case kFlutterSoftwarePixelFormatBGRA8888:
+      return "kFlutterSoftwarePixelFormatBGRA8888";
+    case kFlutterSoftwarePixelFormatNative32:
+      return "kFlutterSoftwarePixelFormatNative32";
     default:
       FML_LOG(ERROR) << "Invalid software rendering pixel format";
   }

--- a/shell/platform/embedder/tests/embedder_config_builder.h
+++ b/shell/platform/embedder/tests/embedder_config_builder.h
@@ -108,7 +108,8 @@ class EmbedderConfigBuilder {
 
   void SetRenderTargetType(
       EmbedderTestBackingStoreProducer::RenderTargetType type,
-      FlutterSoftwarePixelFormat software_pixfmt = kNative32);
+      FlutterSoftwarePixelFormat software_pixfmt =
+          kFlutterSoftwarePixelFormatNative32);
 
   UniqueEngine LaunchEngine() const;
 

--- a/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
+++ b/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
@@ -36,8 +36,9 @@ EmbedderTestBackingStoreProducer::EmbedderTestBackingStoreProducer(
 #endif
 {
   if (type == RenderTargetType::kSoftwareBuffer &&
-      software_pixfmt_ != kNative32) {
-    FML_LOG(ERROR) << "Expected pixel format to be the default (kNative32) when"
+      software_pixfmt_ != kFlutterSoftwarePixelFormatNative32) {
+    FML_LOG(ERROR) << "Expected pixel format to be the default "
+                      "(kFlutterSoftwarePixelFormatNative32) when"
                       "backing store producer should produce deprecated v1 "
                       "software backing "
                       "stores.";

--- a/shell/platform/embedder/tests/embedder_test_backingstore_producer.h
+++ b/shell/platform/embedder/tests/embedder_test_backingstore_producer.h
@@ -38,10 +38,10 @@ class EmbedderTestBackingStoreProducer {
     kVulkanImage,
   };
 
-  EmbedderTestBackingStoreProducer(
-      sk_sp<GrDirectContext> context,
-      RenderTargetType type,
-      FlutterSoftwarePixelFormat software_pixfmt = kNative32);
+  EmbedderTestBackingStoreProducer(sk_sp<GrDirectContext> context,
+                                   RenderTargetType type,
+                                   FlutterSoftwarePixelFormat software_pixfmt =
+                                       kFlutterSoftwarePixelFormatNative32);
   ~EmbedderTestBackingStoreProducer();
 
   bool Create(const FlutterBackingStoreConfig* config,

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -1635,49 +1635,71 @@ static void expectSoftwareRenderingOutputMatches(
                                          matcher);                        \
   }
 
-// Don't test the pixel formats that contain padding (so an X) and the kNative32
-// pixel format here, so we don't add any flakiness.
-SW_PIXFMT_TEST_F(RedRGBA565xF800, draw_solid_red, kRGB565, (uint16_t)0xF800);
-SW_PIXFMT_TEST_F(RedRGBA4444xF00F, draw_solid_red, kRGBA4444, (uint16_t)0xF00F);
+// Don't test the pixel formats that contain padding (so an X) and the
+// kFlutterSoftwarePixelFormatNative32 pixel format here, so we don't add any
+// flakiness.
+SW_PIXFMT_TEST_F(RedRGBA565xF800,
+                 draw_solid_red,
+                 kFlutterSoftwarePixelFormatRGB565,
+                 (uint16_t)0xF800);
+SW_PIXFMT_TEST_F(RedRGBA4444xF00F,
+                 draw_solid_red,
+                 kFlutterSoftwarePixelFormatRGBA4444,
+                 (uint16_t)0xF00F);
 SW_PIXFMT_TEST_F(RedRGBA8888xFFx00x00xFF,
                  draw_solid_red,
-                 kRGBA8888,
+                 kFlutterSoftwarePixelFormatRGBA8888,
                  (std::vector<uint8_t>{0xFF, 0x00, 0x00, 0xFF}));
 SW_PIXFMT_TEST_F(RedBGRA8888x00x00xFFxFF,
                  draw_solid_red,
-                 kBGRA8888,
+                 kFlutterSoftwarePixelFormatBGRA8888,
                  (std::vector<uint8_t>{0x00, 0x00, 0xFF, 0xFF}));
-SW_PIXFMT_TEST_F(RedGray8x36, draw_solid_red, kGray8, (uint8_t)0x36);
+SW_PIXFMT_TEST_F(RedGray8x36,
+                 draw_solid_red,
+                 kFlutterSoftwarePixelFormatGray8,
+                 (uint8_t)0x36);
 
-SW_PIXFMT_TEST_F(GreenRGB565x07E0, draw_solid_green, kRGB565, (uint16_t)0x07E0);
+SW_PIXFMT_TEST_F(GreenRGB565x07E0,
+                 draw_solid_green,
+                 kFlutterSoftwarePixelFormatRGB565,
+                 (uint16_t)0x07E0);
 SW_PIXFMT_TEST_F(GreenRGBA4444x0F0F,
                  draw_solid_green,
-                 kRGBA4444,
+                 kFlutterSoftwarePixelFormatRGBA4444,
                  (uint16_t)0x0F0F);
 SW_PIXFMT_TEST_F(GreenRGBA8888x00xFFx00xFF,
                  draw_solid_green,
-                 kRGBA8888,
+                 kFlutterSoftwarePixelFormatRGBA8888,
                  (std::vector<uint8_t>{0x00, 0xFF, 0x00, 0xFF}));
 SW_PIXFMT_TEST_F(GreenBGRA8888x00xFFx00xFF,
                  draw_solid_green,
-                 kBGRA8888,
+                 kFlutterSoftwarePixelFormatBGRA8888,
                  (std::vector<uint8_t>{0x00, 0xFF, 0x00, 0xFF}));
-SW_PIXFMT_TEST_F(GreenGray8xB6, draw_solid_green, kGray8, (uint8_t)0xB6);
+SW_PIXFMT_TEST_F(GreenGray8xB6,
+                 draw_solid_green,
+                 kFlutterSoftwarePixelFormatGray8,
+                 (uint8_t)0xB6);
 
-SW_PIXFMT_TEST_F(BlueRGB565x001F, draw_solid_blue, kRGB565, (uint16_t)0x001F);
+SW_PIXFMT_TEST_F(BlueRGB565x001F,
+                 draw_solid_blue,
+                 kFlutterSoftwarePixelFormatRGB565,
+                 (uint16_t)0x001F);
 SW_PIXFMT_TEST_F(BlueRGBA4444x00FF,
                  draw_solid_blue,
-                 kRGBA4444,
+                 kFlutterSoftwarePixelFormatRGBA4444,
                  (uint16_t)0x00FF);
 SW_PIXFMT_TEST_F(BlueRGBA8888x00x00xFFxFF,
                  draw_solid_blue,
-                 kRGBA8888,
+                 kFlutterSoftwarePixelFormatRGBA8888,
                  (std::vector<uint8_t>{0x00, 0x00, 0xFF, 0xFF}));
 SW_PIXFMT_TEST_F(BlueBGRA8888xFFx00x00xFF,
                  draw_solid_blue,
-                 kBGRA8888,
+                 kFlutterSoftwarePixelFormatBGRA8888,
                  (std::vector<uint8_t>{0xFF, 0x00, 0x00, 0xFF}));
-SW_PIXFMT_TEST_F(BlueGray8x12, draw_solid_blue, kGray8, (uint8_t)0x12);
+SW_PIXFMT_TEST_F(BlueGray8x12,
+                 draw_solid_blue,
+                 kFlutterSoftwarePixelFormatGray8,
+                 (uint8_t)0x12);
 
 //------------------------------------------------------------------------------
 // Key Data


### PR DESCRIPTION


Renames the `FlutterSoftwarePixelFormat` enum values of `flutter_embedder.h`:
```
kGray8 --> kFlutterSoftwarePixelFormatGray8
kRGB565 --> kFlutterSoftwarePixelFormatRGB565
...
```
Fixes https://github.com/flutter/flutter/issues/118247.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
