### PR TITLE
[macOS] Move A11yBridge to FVC

### DIFF
--- a/shell/platform/darwin/macos/framework/Headers/FlutterEngine.h
+++ b/shell/platform/darwin/macos/framework/Headers/FlutterEngine.h
@@ -23,7 +23,7 @@
  * Some single-view APIs will eventually be replaced by their multi-view
  * variant. During the deprecation period, the single-view APIs will coexist with
  * and work with the multi-view APIs as if the other views don't exist.  For
- * backward compatibility, single-view APIs will always operate the view with
+ * backward compatibility, single-view APIs will always operate on the view with
  * this ID. Also, the first view assigned to the engine will also have this ID.
  */
 extern const uint64_t kFlutterDefaultViewId;

--- a/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacTest.mm
@@ -32,17 +32,15 @@ class AccessibilityBridgeMacSpy : public AccessibilityBridgeMac {
 }  // namespace
 }  // namespace flutter::testing
 
-@interface AccessibilityBridgeTestEngine : FlutterEngine
-- (std::shared_ptr<flutter::AccessibilityBridgeMac>)
-    createAccessibilityBridge:(nonnull FlutterEngine*)engine
-               viewController:(nonnull FlutterViewController*)viewController;
+@interface AccessibilityBridgeTestViewController : FlutterViewController
+- (std::shared_ptr<flutter::AccessibilityBridgeMac>)createAccessibilityBridgeWithEngine:
+    (nonnull FlutterEngine*)engine;
 @end
 
-@implementation AccessibilityBridgeTestEngine
-- (std::shared_ptr<flutter::AccessibilityBridgeMac>)
-    createAccessibilityBridge:(nonnull FlutterEngine*)engine
-               viewController:(nonnull FlutterViewController*)viewController {
-  return std::make_shared<flutter::testing::AccessibilityBridgeMacSpy>(engine, viewController);
+@implementation AccessibilityBridgeTestViewController
+- (std::shared_ptr<flutter::AccessibilityBridgeMac>)createAccessibilityBridgeWithEngine:
+    (nonnull FlutterEngine*)engine {
+  return std::make_shared<flutter::testing::AccessibilityBridgeMacSpy>(engine, self);
 }
 @end
 
@@ -56,10 +54,7 @@ FlutterViewController* CreateTestViewController() {
   FlutterDartProject* project = [[FlutterDartProject alloc]
       initWithAssetsPath:fixtures
              ICUDataPath:[fixtures stringByAppendingString:@"/icudtl.dat"]];
-  FlutterEngine* engine = [[AccessibilityBridgeTestEngine alloc] initWithName:@"test"
-                                                                      project:project
-                                                       allowHeadlessExecution:true];
-  return [[FlutterViewController alloc] initWithEngine:engine nibName:nil bundle:nil];
+  return [[AccessibilityBridgeTestViewController alloc] initWithProject:project];
 }
 }  // namespace
 
@@ -76,8 +71,8 @@ TEST(AccessibilityBridgeMacTest, sendsAccessibilityCreateNotificationToWindowOfF
   // Setting up bridge so that the AccessibilityBridgeMacDelegateSpy
   // can query semantics information from.
   engine.semanticsEnabled = YES;
-  auto bridge =
-      std::reinterpret_pointer_cast<AccessibilityBridgeMacSpy>(engine.accessibilityBridge.lock());
+  auto bridge = std::reinterpret_pointer_cast<AccessibilityBridgeMacSpy>(
+      viewController.accessibilityBridge.lock());
   FlutterSemanticsNode root;
   root.id = 0;
   root.flags = static_cast<FlutterSemanticsFlag>(0);
@@ -124,8 +119,8 @@ TEST(AccessibilityBridgeMacTest, doesNotSendAccessibilityCreateNotificationWhenH
   // Setting up bridge so that the AccessibilityBridgeMacDelegateSpy
   // can query semantics information from.
   engine.semanticsEnabled = YES;
-  auto bridge =
-      std::reinterpret_pointer_cast<AccessibilityBridgeMacSpy>(engine.accessibilityBridge.lock());
+  auto bridge = std::reinterpret_pointer_cast<AccessibilityBridgeMacSpy>(
+      viewController.accessibilityBridge.lock());
   FlutterSemanticsNode root;
   root.id = 0;
   root.flags = static_cast<FlutterSemanticsFlag>(0);
@@ -171,8 +166,8 @@ TEST(AccessibilityBridgeMacTest, doesNotSendAccessibilityCreateNotificationWhenN
   // Setting up bridge so that the AccessibilityBridgeMacDelegateSpy
   // can query semantics information from.
   engine.semanticsEnabled = YES;
-  auto bridge =
-      std::reinterpret_pointer_cast<AccessibilityBridgeMacSpy>(engine.accessibilityBridge.lock());
+  auto bridge = std::reinterpret_pointer_cast<AccessibilityBridgeMacSpy>(
+      viewController.accessibilityBridge.lock());
   FlutterSemanticsNode root;
   root.id = 0;
   root.flags = static_cast<FlutterSemanticsFlag>(0);

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h
@@ -31,8 +31,6 @@
  */
 @property(nonatomic) FlutterEngineProcTable& embedderAPI;
 
-@property(nonatomic, readonly) std::weak_ptr<flutter::AccessibilityBridgeMac> accessibilityBridge;
-
 /**
  * True if the semantics is enabled. The Flutter framework starts sending
  * semantics update through the embedder as soon as it is set to YES.
@@ -93,15 +91,4 @@
                        toTarget:(uint16_t)target
                        withData:(fml::MallocMapping)data;
 
-@end
-
-@interface FlutterEngine (TestMethods)
-/* Creates an accessibility bridge with the provided parameters.
- *
- * By default this method calls AccessibilityBridgeMac's initializer. Exposing
- * this method allows unit tests to override in order to capture information.
- */
-- (std::shared_ptr<flutter::AccessibilityBridgeMac>)
-    createAccessibilityBridge:(nonnull FlutterEngine*)engine
-               viewController:(nonnull FlutterViewController*)viewController;
 @end

--- a/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm
@@ -33,7 +33,7 @@ TEST(FlutterPlatformNodeDelegateMac, Basics) {
   FlutterViewController* viewController = CreateTestViewController();
   FlutterEngine* engine = viewController.engine;
   engine.semanticsEnabled = YES;
-  auto bridge = engine.accessibilityBridge.lock();
+  auto bridge = viewController.accessibilityBridge.lock();
   // Initialize ax node data.
   FlutterSemanticsNode root;
   root.id = 0;
@@ -69,7 +69,7 @@ TEST(FlutterPlatformNodeDelegateMac, SelectableTextHasCorrectSemantics) {
   FlutterViewController* viewController = CreateTestViewController();
   FlutterEngine* engine = viewController.engine;
   engine.semanticsEnabled = YES;
-  auto bridge = engine.accessibilityBridge.lock();
+  auto bridge = viewController.accessibilityBridge.lock();
   // Initialize ax node data.
   FlutterSemanticsNode root;
   root.id = 0;
@@ -111,7 +111,7 @@ TEST(FlutterPlatformNodeDelegateMac, SelectableTextWithoutSelectionReturnZeroRan
   FlutterViewController* viewController = CreateTestViewController();
   FlutterEngine* engine = viewController.engine;
   engine.semanticsEnabled = YES;
-  auto bridge = engine.accessibilityBridge.lock();
+  auto bridge = viewController.accessibilityBridge.lock();
   // Initialize ax node data.
   FlutterSemanticsNode root;
   root.id = 0;
@@ -158,7 +158,7 @@ TEST(FlutterPlatformNodeDelegateMac, CanPerformAction) {
   window.contentView = viewController.view;
 
   engine.semanticsEnabled = YES;
-  auto bridge = engine.accessibilityBridge.lock();
+  auto bridge = viewController.accessibilityBridge.lock();
   // Initialize ax node data.
   FlutterSemanticsNode root;
   root.id = 0;
@@ -233,7 +233,7 @@ TEST(FlutterPlatformNodeDelegateMac, TextFieldUsesFlutterTextField) {
   window.contentView = viewController.view;
   engine.semanticsEnabled = YES;
 
-  auto bridge = engine.accessibilityBridge.lock();
+  auto bridge = viewController.accessibilityBridge.lock();
   // Initialize ax node data.
   FlutterSemanticsNode root;
   root.id = 0;

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
@@ -1414,14 +1414,14 @@ TEST(FlutterTextInputPluginTest, CanWorkWithFlutterTextField) {
 
   engine.semanticsEnabled = YES;
 
-  auto bridge = engine.accessibilityBridge.lock();
+  auto bridge = viewController.accessibilityBridge.lock();
   FlutterPlatformNodeDelegateMac delegate(bridge, viewController);
   ui::AXTree tree;
   ui::AXNode ax_node(&tree, nullptr, 0, 0);
   ui::AXNodeData node_data;
   node_data.SetValue("initial text");
   ax_node.SetData(node_data);
-  delegate.Init(engine.accessibilityBridge, &ax_node);
+  delegate.Init(viewController.accessibilityBridge, &ax_node);
   {
     FlutterTextPlatformNode text_platform_node(&delegate, viewController);
 
@@ -1480,14 +1480,14 @@ TEST(FlutterTextInputPluginTest, CanNotBecomeResponderIfNoViewController) {
 
   engine.semanticsEnabled = YES;
 
-  auto bridge = engine.accessibilityBridge.lock();
+  auto bridge = viewController.accessibilityBridge.lock();
   FlutterPlatformNodeDelegateMac delegate(bridge, viewController);
   ui::AXTree tree;
   ui::AXNode ax_node(&tree, nullptr, 0, 0);
   ui::AXNodeData node_data;
   node_data.SetValue("initial text");
   ax_node.SetData(node_data);
-  delegate.Init(engine.accessibilityBridge, &ax_node);
+  delegate.Init(viewController.accessibilityBridge, &ax_node);
   FlutterTextPlatformNode text_platform_node(&delegate, viewController);
 
   FlutterTextField* textField = text_platform_node.GetNativeViewAccessible();

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputSemanticsObjectTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputSemanticsObjectTest.mm
@@ -41,14 +41,14 @@ TEST(FlutterTextInputSemanticsObjectTest, DoesInitialize) {
 
     engine.semanticsEnabled = YES;
 
-    auto bridge = engine.accessibilityBridge.lock();
+    auto bridge = viewController.accessibilityBridge.lock();
     FlutterPlatformNodeDelegateMac delegate(bridge, viewController);
     ui::AXTree tree;
     ui::AXNode ax_node(&tree, nullptr, 0, 0);
     ui::AXNodeData node_data;
     node_data.SetValue("initial text");
     ax_node.SetData(node_data);
-    delegate.Init(engine.accessibilityBridge, &ax_node);
+    delegate.Init(viewController.accessibilityBridge, &ax_node);
     // Verify that a FlutterTextField is attached to the view.
     FlutterTextPlatformNode text_platform_node(&delegate, viewController);
     id native_accessibility = text_platform_node.GetNativeViewAccessible();

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h
@@ -4,6 +4,8 @@
 
 #import "flutter/shell/platform/darwin/macos/framework/Headers/FlutterViewController.h"
 
+#include <memory>
+
 #import "flutter/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMac.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterKeyboardViewDelegate.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.h"
@@ -18,6 +20,8 @@
  * The text input plugin that handles text editing state for text fields.
  */
 @property(nonatomic, readonly, nonnull) FlutterTextInputPlugin* textInputPlugin;
+
+@property(nonatomic, readonly) std::weak_ptr<flutter::AccessibilityBridgeMac> accessibilityBridge;
 
 /**
  * Returns YES if provided event is being currently redispatched by keyboard manager.
@@ -38,11 +42,31 @@
  */
 - (void)detachFromEngine;
 
+/**
+ * Called by the associated FlutterEngine when FlutterEngine#semanticsEnabled
+ * has changed.
+ */
+- (void)notifySemanticsEnabledChanged;
+
+/**
+ * Notify from the framework that the semantics for this view needs to be
+ * updated.
+ */
+- (void)updateSemantics:(nonnull const FlutterSemanticsUpdate*)update;
+
 @end
 
 // Private methods made visible for testing
 @interface FlutterViewController (TestMethods)
 - (void)onAccessibilityStatusChanged:(BOOL)enabled;
+
+/* Creates an accessibility bridge with the provided parameters.
+ *
+ * By default this method calls AccessibilityBridgeMac's initializer. Exposing
+ * this method allows unit tests to override.
+ */
+- (std::shared_ptr<flutter::AccessibilityBridgeMac>)createAccessibilityBridgeWithEngine:
+    (nonnull FlutterEngine*)engine;
 
 - (nonnull FlutterView*)createFlutterViewWithMTLDevice:(nonnull id<MTLDevice>)device
                                           commandQueue:(nonnull id<MTLCommandQueue>)commandQueue;


### PR DESCRIPTION
This PR moves `AccessibilityBridgeMac` from `FlutterEngine` to `FlutterViewController`.

Currently, whether `FlutterEngine` has a non-null `AccessibilityBridge` only depends on the value of `semanticsEnabled`. The `_bridge` is initialized the moment `semanticsEnabled` turns true, even if `viewController` is null. Similarly, setting the view controller to null does not affect `_bridge` either. This is problematic because conceptually an `AccessibilityBridge` manages the a11y information for one view. Accessibility information does not make much sense without a view.

By moving the `AccessibilityBridge` into `FlutterViewController`, the lifecycles of these 2 classes are tied. The bridge exists only when the view controller exists _and_ semantics has been enabled. This is important because accessibility information should be view-specific.

| Before | After |
|----|----|
|`FlutterEngine#accessibilityBridge`|`FlutterViewController#accessibilityBridge`|
|`FlutterEngine#updateSemantics:`|`FlutterViewController#updateSemantics:`|
|`FlutterEngine#createAccessibilityBridge:viewController:`|`FlutterViewController#createAccessibilityBridgeWithEngine:`|
|-|`FlutterViewController#notifySemanticsEnabledChanged:`|

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
