### PR TITLE
[windows] Fix crash when calling `FlutterDesktopMessengerSetCallback` after engine shutdown

### DIFF
--- a/shell/platform/windows/flutter_windows.cc
+++ b/shell/platform/windows/flutter_windows.cc
@@ -292,10 +292,12 @@ void FlutterDesktopMessengerSetCallback(FlutterDesktopMessengerRef messenger,
                                         const char* channel,
                                         FlutterDesktopMessageCallback callback,
                                         void* user_data) {
-  flutter::FlutterDesktopMessenger::FromRef(messenger)
-      ->GetEngine()
-      ->message_dispatcher()
-      ->SetMessageCallback(channel, callback, user_data);
+  auto engine =
+      flutter::FlutterDesktopMessenger::FromRef(messenger)->GetEngine();
+  if (engine) {
+    engine->message_dispatcher()->SetMessageCallback(channel, callback,
+                                                     user_data);
+  }
 }
 
 FlutterDesktopMessengerRef FlutterDesktopMessengerAddRef(


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/118611

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
