### PR TITLE
[web] dont look up webgl params if no GPU is available

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/surface.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/surface.dart
@@ -336,9 +336,6 @@ class Surface {
           majorVersion: webGLVersion.toDouble(),
         ),
       ).toInt();
-      if (_sampleCount == -1 || _stencilBits == -1) {
-        _initWebglParams();
-      }
 
       _glContext = glContext;
 
@@ -347,6 +344,9 @@ class Surface {
         if (_grContext == null) {
           throw CanvasKitError('Failed to initialize CanvasKit. '
               'CanvasKit.MakeGrContext returned null.');
+        }
+        if (_sampleCount == -1 || _stencilBits == -1) {
+          _initWebglParams();
         }
         // Set the cache byte limit for this grContext, if not specified it will
         // use CanvasKit's default.


### PR DESCRIPTION
Potentially fixes https://github.com/flutter/flutter/issues/118633

The glcontext being 0 indicates we are going to use software rendering, so don't try to look up gl parameters.