### PR TITLE
clipPath to use fillType param

### DIFF
--- a/lib/web_ui/lib/src/engine/html/path_to_svg_clip.dart
+++ b/lib/web_ui/lib/src/engine/html/path_to_svg_clip.dart
@@ -51,7 +51,11 @@ SVGSVGElement pathToSvgClipPath(ui.Path path,
     clipPath.setAttribute('clipPathUnits', 'objectBoundingBox');
     svgPath.setAttribute('transform', 'scale($scaleX, $scaleY)');
   }
-
+  if (path.fillType == ui.PathFillType.evenOdd) {
+    svgPath.setAttribute('clip-rule', 'evenodd');
+  } else {
+    svgPath.setAttribute('clip-rule', 'nonzero');
+  }
   svgPath.setAttribute('d', pathToSvg((path as SurfacePath).pathRef, offsetX: offsetX, offsetY: offsetY));
   return root;
 }

--- a/lib/web_ui/test/html/canvas_clip_path_golden_test.dart
+++ b/lib/web_ui/test/html/canvas_clip_path_golden_test.dart
@@ -119,6 +119,50 @@ Future<void> testMain() async {
     await canvasScreenshot(rc, 'image_clipped_by_oval_path',
         region: const Rect.fromLTWH(0, 0, 600, 800));
   });
+
+  test('Clips with fillType evenOdd', () async {
+    final engine.RecordingCanvas rc = engine.RecordingCanvas(const Rect.fromLTRB(0, 0, 500, 500));
+    rc.save();
+    const double testWidth = 400;
+    const double testHeight = 350;
+
+    // draw RGB test image
+    rc.drawImageRect(createTestImage(), const Rect.fromLTRB(0, 0, testWidth, testHeight),
+        const Rect.fromLTWH(0, 0, testWidth, testHeight), engine.SurfacePaint());
+
+    // draw a clipping path with:
+    // 1) an outside larger rectangle
+    // 2) a smaller inner rectangle specified by a path
+    final Path path = Path();
+    path.addRect(const Rect.fromLTWH(0, 0, testWidth, testHeight));
+    const double left = 25;
+    const double top = 30;
+    const double right = 300;
+    const double bottom = 250;
+    path
+      ..moveTo(left, top)
+      ..lineTo(right,top)
+      ..lineTo(right,bottom)
+      ..lineTo(left, bottom)
+      ..close();
+    path.fillType = PathFillType.evenOdd;
+    rc.clipPath(path);
+
+    // draw an orange paint path of size testWidth and testHeight
+    final Path paintPath = Path();
+    paintPath.addRect(const Rect.fromLTWH(0, 0, testWidth, testHeight));
+    paintPath.close();
+    rc.drawPath(paintPath,
+        engine.SurfacePaint()
+          ..color = const Color(0xFFFF9800)
+          ..style = PaintingStyle.fill);
+    rc.restore();
+
+    // when fillType is set to evenOdd from the clipping path, expect the inner
+    // rectangle should clip some of the orange painted portion, revealing the RGB testImage
+    await canvasScreenshot(rc, 'clipPath_uses_fillType_evenOdd',
+        region: const Rect.fromLTWH(0, 0, 600, 800));
+  });
 }
 
 engine.HtmlImage createTestImage({int width = 200, int height = 150}) {


### PR DESCRIPTION
When using DOM rendering with HTML renderer, specifying `path.fillType` to `evenOdd` had no effect.

Fixed so that we account for the `fillType` param for a path. 

fixes: https://github.com/flutter/flutter/issues/81637

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
