### PR TITLE
[Linux][FlView] fix rendering on startup when shown after plugin registration

### DIFF
--- a/shell/platform/linux/fl_view.cc
+++ b/shell/platform/linux/fl_view.cc
@@ -200,6 +200,12 @@ static void handle_geometry_changed(FlView* self) {
       self->engine, allocation.width * scale_factor,
       allocation.height * scale_factor, scale_factor);
 
+  // Make sure the view has been realized and its size has been allocated before
+  // waiting for a frame. `fl_view_realize()` and `fl_view_size_allocate()` may
+  // be called in either order depending on the order in which the window is
+  // shown and the view is added to a container in the app runner.
+  //
+  // Note: `gtk_widget_init()` initializes the size allocation to 1x1.
   if (allocation.width > 1 && allocation.height > 1 &&
       gtk_widget_get_realized(GTK_WIDGET(self))) {
     fl_renderer_wait_for_frame(self->renderer, allocation.width * scale_factor,

--- a/shell/platform/linux/fl_view.cc
+++ b/shell/platform/linux/fl_view.cc
@@ -200,8 +200,11 @@ static void handle_geometry_changed(FlView* self) {
       self->engine, allocation.width * scale_factor,
       allocation.height * scale_factor, scale_factor);
 
-  fl_renderer_wait_for_frame(self->renderer, allocation.width * scale_factor,
-                             allocation.height * scale_factor);
+  if (allocation.width > 1 && allocation.height > 1 &&
+      gtk_widget_get_realized(GTK_WIDGET(self))) {
+    fl_renderer_wait_for_frame(self->renderer, allocation.width * scale_factor,
+                               allocation.height * scale_factor);
+  }
 }
 
 // Adds a widget to render in this view.
@@ -661,6 +664,8 @@ static void fl_view_realize(GtkWidget* widget) {
     g_warning("Failed to start Flutter engine: %s", error->message);
     return;
   }
+
+  handle_geometry_changed(self);
 }
 
 // Implements GtkWidget::get-preferred-width


### PR DESCRIPTION
This PR contains the engine-side changes required for changing the Linux app template to show the window after registering plugins (flutter/flutter#118269).

Currently, `FlView` assumes that it gets realized before its size gets allocated. If we change the order in the app template, the view gets added to a layout first and then realized. Make sure to call `handle_geometry_changed()` from both and check the pre-conditions for `fl_renderer_wait_for_frame()` to ensure that the first frame is rendered regardless of the order of `size-allocate` and `realize`.

This makes it possible to change [my_application.cc](https://github.com/flutter/flutter/blob/master/packages/flutter_tools/templates/app_shared/linux.tmpl/my_application.cc.tmpl) as follows:
```diff
diff --git a/linux/my_application.cc b/linux/my_application.cc
index d9eae08..59af183 100644
--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -48,7 +48,6 @@ static void my_application_activate(GApplication* application) {
   }
 
   gtk_window_set_default_size(window, 1280, 720);
-  gtk_widget_show(GTK_WIDGET(window));
 
   g_autoptr(FlDartProject) project = fl_dart_project_new();
   fl_dart_project_set_dart_entrypoint_arguments(project, self->dart_entrypoint_arguments);
@@ -59,6 +58,7 @@ static void my_application_activate(GApplication* application) {
 
   fl_register_plugins(FL_PLUGIN_REGISTRY(view));
 
+  gtk_widget_show(GTK_WIDGET(window));
   gtk_widget_grab_focus(GTK_WIDGET(view));
 }
 
```

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/140617/213274170-94318980-e774-4c2f-b4c1-2267321383b5.png) | ![image](https://user-images.githubusercontent.com/140617/213274247-d08a4fbc-7a16-4ad2-aefe-0e306566fa3e.png) |

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
