### PR TITLE
[Impeller] Account for the transform in DLVerticesGeometry coverage

### DIFF
--- a/impeller/display_list/display_list_unittests.cc
+++ b/impeller/display_list/display_list_unittests.cc
@@ -1056,9 +1056,11 @@ TEST_P(DisplayListTest, MaskBlursApplyCorrectlyToColorSources) {
 }
 
 TEST_P(DisplayListTest, DrawVerticesSolidColorTrianglesWithoutIndices) {
-  std::vector<SkPoint> positions = {SkPoint::Make(100, 300),
-                                    SkPoint::Make(200, 100),
-                                    SkPoint::Make(300, 300)};
+  // Use negative coordinates and then scale the transform by -1, -1 to make
+  // sure coverage is taking the transform into account.
+  std::vector<SkPoint> positions = {SkPoint::Make(-100, -300),
+                                    SkPoint::Make(-200, -100),
+                                    SkPoint::Make(-300, -300)};
   std::vector<flutter::DlColor> colors = {flutter::DlColor::kWhite(),
                                           flutter::DlColor::kGreen(),
                                           flutter::DlColor::kWhite()};
@@ -1071,6 +1073,7 @@ TEST_P(DisplayListTest, DrawVerticesSolidColorTrianglesWithoutIndices) {
   flutter::DlPaint paint;
 
   paint.setColor(flutter::DlColor::kRed().modulateOpacity(0.5));
+  builder.scale(-1, -1);
   builder.drawVertices(vertices, flutter::DlBlendMode::kSrcOver, paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));

--- a/impeller/display_list/display_list_vertices_geometry.cc
+++ b/impeller/display_list/display_list_vertices_geometry.cc
@@ -241,7 +241,7 @@ GeometryVertexType DLVerticesGeometry::GetVertexType() const {
 
 std::optional<Rect> DLVerticesGeometry::GetCoverage(
     const Matrix& transform) const {
-  return ToRect(vertices_->bounds());
+  return ToRect(vertices_->bounds()).TransformBounds(transform);
 }
 
 }  // namespace impeller


### PR DESCRIPTION
Happened across this bug while smoke testing Gallery.

Before:
![Screenshot 2023-01-19 at 2 36 07 AM](https://user-images.githubusercontent.com/919017/213420361-7e3d531e-77a9-42fe-a833-fd26a1630ab1.png)

After:
![Screenshot 2023-01-19 at 2 34 08 AM](https://user-images.githubusercontent.com/919017/213420378-589e3f4a-2150-4ed8-b75b-97b244b1e99e.png)
