### PR TITLE
[fuchsia] Add output_path property to customize output path of .so files

### DIFF
--- a/tools/fuchsia/fuchsia_archive.gni
+++ b/tools/fuchsia/fuchsia_archive.gni
@@ -105,8 +105,14 @@ template("_fuchsia_archive") {
   }
 
   foreach(lib, pkg.libraries) {
+    output_path = ""
+
+    if (defined(lib.output_path)) {
+      output_path = lib.output_path
+    }
+
     copy_sources += [ "${lib.path}/${lib.name}" ]
-    copy_outputs += [ "$far_base_dir/lib/${lib.name}" ]
+    copy_outputs += [ "$far_base_dir/lib/${output_path}${lib.name}" ]
   }
 
   pkg_dir_deps = pkg.deps

--- a/tools/fuchsia/fuchsia_libs.gni
+++ b/tools/fuchsia/fuchsia_libs.gni
@@ -59,6 +59,7 @@ common_libs = [
   {
     name = "ld.so.1"
     path = rebase_path("$sysroot_dist_lib/$ld_so_path")
+    output_path = "asan/"
   },
 ]
 

--- a/tools/fuchsia/fuchsia_libs.gni
+++ b/tools/fuchsia/fuchsia_libs.gni
@@ -59,7 +59,7 @@ common_libs = [
   {
     name = "ld.so.1"
     path = rebase_path("$sysroot_dist_lib/$ld_so_path")
-    output_path = "asan/"
+    output_path = ld_so_path
   },
 ]
 


### PR DESCRIPTION
Fixes issue with missing .so files being thrown when attempting to run integration tests with ASAN enabled