### PR TITLE
Update flutter integration tests to use non deprecated methods in realm builder test api.

### DIFF
--- a/shell/platform/fuchsia/flutter/tests/integration/embedder/flutter-embedder-test.cc
+++ b/shell/platform/fuchsia/flutter/tests/integration/embedder/flutter-embedder-test.cc
@@ -330,11 +330,13 @@ void FlutterEmbedderTest::LaunchParentViewInRealm(
 
   // Instruct Test UI Stack to present parent-view's View.
   std::optional<zx_koid_t> view_ref_koid;
-  scene_provider_ = realm_->Connect<fuchsia::ui::test::scene::Controller>();
+  scene_provider_ =
+      realm_->component().Connect<fuchsia::ui::test::scene::Controller>();
   scene_provider_.set_error_handler(
       [](auto) { FML_LOG(ERROR) << "Error from test scene provider"; });
   fuchsia::ui::test::scene::ControllerAttachClientViewRequest request;
-  request.set_view_provider(realm_->Connect<fuchsia::ui::app::ViewProvider>());
+  request.set_view_provider(
+      realm_->component().Connect<fuchsia::ui::app::ViewProvider>());
   scene_provider_->RegisterViewTreeWatcher(view_tree_watcher_.NewRequest(),
                                            []() {});
   scene_provider_->AttachClientView(
@@ -355,7 +357,7 @@ void FlutterEmbedderTest::LaunchParentViewInRealm(
   });
   FML_LOG(INFO) << "Client view has rendered";
 
-  scenic_ = realm_->Connect<fuchsia::ui::scenic::Scenic>();
+  scenic_ = realm_->component().Connect<fuchsia::ui::scenic::Scenic>();
   FML_LOG(INFO) << "Launched parent-view";
 }
 

--- a/shell/platform/fuchsia/flutter/tests/integration/utils/portable_ui_test.cc
+++ b/shell/platform/fuchsia/flutter/tests/integration/utils/portable_ui_test.cc
@@ -142,14 +142,16 @@ bool PortableUITest::HasViewConnected(zx_koid_t view_ref_koid) {
 }
 
 void PortableUITest::LaunchClient() {
-  scene_provider_ = realm_->Connect<fuchsia::ui::test::scene::Controller>();
+  scene_provider_ =
+      realm_->component().Connect<fuchsia::ui::test::scene::Controller>();
   scene_provider_.set_error_handler([](auto) {
     FML_LOG(ERROR) << "Error from test scene provider: "
                    << &zx_status_get_string;
   });
 
   fuchsia::ui::test::scene::ControllerAttachClientViewRequest request;
-  request.set_view_provider(realm_->Connect<fuchsia::ui::app::ViewProvider>());
+  request.set_view_provider(
+      realm_->component().Connect<fuchsia::ui::app::ViewProvider>());
   scene_provider_->RegisterViewTreeWatcher(view_tree_watcher_.NewRequest(),
                                            []() {});
   scene_provider_->AttachClientView(
@@ -214,7 +216,8 @@ void PortableUITest::LaunchClientWithEmbeddedView() {
 
 void PortableUITest::RegisterTouchScreen() {
   FML_LOG(INFO) << "Registering fake touch screen";
-  input_registry_ = realm_->Connect<fuchsia::ui::test::input::Registry>();
+  input_registry_ =
+      realm_->component().Connect<fuchsia::ui::test::input::Registry>();
   input_registry_.set_error_handler([](auto) {
     FML_LOG(ERROR) << "Error from input helper: " << &zx_status_get_string;
   });
@@ -232,7 +235,8 @@ void PortableUITest::RegisterTouchScreen() {
 
 void PortableUITest::RegisterMouse() {
   FML_LOG(INFO) << "Registering fake mouse";
-  input_registry_ = realm_->Connect<fuchsia::ui::test::input::Registry>();
+  input_registry_ =
+      realm_->component().Connect<fuchsia::ui::test::input::Registry>();
   input_registry_.set_error_handler([](auto) {
     FML_LOG(ERROR) << "Error from input helper: " << &zx_status_get_string;
   });
@@ -249,7 +253,8 @@ void PortableUITest::RegisterMouse() {
 
 void PortableUITest::RegisterKeyboard() {
   FML_LOG(INFO) << "Registering fake keyboard";
-  input_registry_ = realm_->Connect<fuchsia::ui::test::input::Registry>();
+  input_registry_ =
+      realm_->component().Connect<fuchsia::ui::test::input::Registry>();
   input_registry_.set_error_handler([](auto) {
     FML_LOG(ERROR) << "Error from input helper: " << &zx_status_get_string;
   });


### PR DESCRIPTION
Update flutter-embedder-test and portable_ui_test to use updated non-deprecated methods in the realm_builder api.
