### PR TITLE
[Impeller] Check the correct stencil coverage when deciding whether to elide a restore

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -278,11 +278,11 @@ TEST_P(AiksTest, CanRenderWithContiguousClipRestores) {
 
   canvas.Save();
 
-  // Append two clips. First with empty coverage.
+  // Append two clips, the second resulting in empty coverage.
   canvas.ClipPath(
       PathBuilder{}.AddRect(Rect::MakeXYWH(100, 100, 100, 100)).TakePath());
   canvas.ClipPath(
-      PathBuilder{}.AddRect(Rect::MakeXYWH(100, 100, 100, 100)).TakePath());
+      PathBuilder{}.AddRect(Rect::MakeXYWH(300, 300, 100, 100)).TakePath());
 
   // Restore to no clips.
   canvas.Restore();

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -460,10 +460,9 @@ bool EntityPass::OnRender(
             element_entity.GetStencilDepth() - stencil_depth_floor;
         FML_DCHECK(restoration_depth < stencil_stack.size());
 
-        auto restored_coverage = stencil_stack.back().coverage;
         stencil_stack.resize(restoration_depth + 1);
 
-        if (!restored_coverage.has_value()) {
+        if (!stencil_stack.back().coverage.has_value()) {
           // Running this restore op won't make anything renderable, so skip it.
           return true;
         }


### PR DESCRIPTION
Just noticed this while carefully reviewing the stencil coverage stack again today. This is much more rare/a subset of the original issue that was fixed by https://github.com/flutter/engine/pull/38964, but could still result in lots of draw calls getting culled. Slightly modified the playground to detect this case too.

Before
![Screenshot 2023-01-19 at 5 49 35 PM](https://user-images.githubusercontent.com/919017/213603135-fbf86668-a00d-401b-8b33-c50d2f2dbdcf.png)


After
![Screenshot 2023-01-19 at 5 51 42 PM](https://user-images.githubusercontent.com/919017/213603138-89ede97c-6733-48e7-8d33-f0c3607e31aa.png)
