### PR TITLE
[macos] Move TextInputPlugin outside of visible area

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -245,9 +245,9 @@ static char markerKey;
 }
 
 - (instancetype)initWithViewController:(FlutterViewController*)viewController {
-  // The view needs a non-zero frame and must be placed outside of visible area.
+  // The view needs an empty frame otherwise it is visible on dark background.
   // https://github.com/flutter/flutter/issues/118504
-  self = [super initWithFrame:NSMakeRect(-100, -100, 1, 1)];
+  self = [super initWithFrame:NSZeroRect];
   if (self != nil) {
     _flutterViewController = viewController;
     _channel = [FlutterMethodChannel methodChannelWithName:kTextInputChannel

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -245,8 +245,9 @@ static char markerKey;
 }
 
 - (instancetype)initWithViewController:(FlutterViewController*)viewController {
-  // The view needs a non-zero frame.
-  self = [super initWithFrame:NSMakeRect(0, 0, 1, 1)];
+  // The view needs a non-zero frame and must be placed outside of visible area.
+  // https://github.com/flutter/flutter/issues/118504
+  self = [super initWithFrame:NSMakeRect(-100, -100, 1, 1)];
   if (self != nil) {
     _flutterViewController = viewController;
     _channel = [FlutterMethodChannel methodChannelWithName:kTextInputChannel

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
@@ -1554,4 +1554,20 @@ TEST(FlutterTextInputPluginTest, IsAddedAndRemovedFromViewHierarchy) {
   ASSERT_FALSE(window.firstResponder == viewController.textInputPlugin);
 }
 
+TEST(FlutterTextInputPluginTest, HasZeroSize) {
+  id engineMock = OCMClassMock([FlutterEngine class]);
+  id binaryMessengerMock = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
+  OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
+      [engineMock binaryMessenger])
+      .andReturn(binaryMessengerMock);
+  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engineMock
+                                                                                nibName:@""
+                                                                                 bundle:nil];
+
+  FlutterTextInputPlugin* plugin =
+      [[FlutterTextInputPlugin alloc] initWithViewController:viewController];
+
+  ASSERT_TRUE(NSIsEmptyRect(plugin.frame));
+}
+
 }  // namespace flutter::testing


### PR DESCRIPTION
TextInputPlugin must be visible and in view hierarchy for emoji picker to work. This is trivial change that moves it completely outside of visible area.

Fixes https://github.com/flutter/flutter/issues/118504

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
