### PR TITLE
[impeller] change input order in ColorFilterContents::MakeBlend

### DIFF
--- a/impeller/entity/contents/filters/blend_filter_contents.cc
+++ b/impeller/entity/contents/filters/blend_filter_contents.cc
@@ -159,7 +159,7 @@ static std::optional<Snapshot> PipelineBlend(
   using VS = BlendPipeline::VertexShader;
   using FS = BlendPipeline::FragmentShader;
 
-  auto input_snapshot = inputs[0]->GetSnapshot(renderer, entity);
+  auto dst_snapshot = inputs[0]->GetSnapshot(renderer, entity);
 
   ContentContext::SubpassCallback callback = [&](const ContentContext& renderer,
                                                  RenderPass& pass) {
@@ -213,7 +213,7 @@ static std::optional<Snapshot> PipelineBlend(
     // Draw the first texture using kSource.
     options.blend_mode = BlendMode::kSource;
     cmd.pipeline = renderer.GetBlendPipeline(options);
-    if (!add_blend_command(input_snapshot)) {
+    if (!add_blend_command(dst_snapshot)) {
       return true;
     }
 
@@ -225,8 +225,8 @@ static std::optional<Snapshot> PipelineBlend(
 
       for (auto texture_i = inputs.begin() + 1; texture_i < inputs.end();
            texture_i++) {
-        auto input = texture_i->get()->GetSnapshot(renderer, entity);
-        if (!add_blend_command(input)) {
+        auto src_input = texture_i->get()->GetSnapshot(renderer, entity);
+        if (!add_blend_command(src_input)) {
           return true;
         }
       }
@@ -264,7 +264,7 @@ static std::optional<Snapshot> PipelineBlend(
       .transform = Matrix::MakeTranslation(coverage.origin),
       .sampler_descriptor =
           inputs[0]->GetSnapshot(renderer, entity)->sampler_descriptor,
-      .opacity = absorb_opacity ? 1.0f : input_snapshot->opacity};
+      .opacity = absorb_opacity ? 1.0f : dst_snapshot->opacity};
 }
 
 #define BLEND_CASE(mode)                                                    \

--- a/impeller/entity/contents/filters/color_filter_contents.cc
+++ b/impeller/entity/contents/filters/color_filter_contents.cc
@@ -37,7 +37,7 @@ std::shared_ptr<ColorFilterContents> ColorFilterContents::MakeBlend(
   std::shared_ptr<BlendFilterContents> new_blend;
   for (auto in_i = inputs.begin() + 1; in_i < inputs.end(); in_i++) {
     new_blend = std::make_shared<BlendFilterContents>();
-    new_blend->SetInputs({*in_i, blend_input});
+    new_blend->SetInputs({blend_input, *in_i});
     new_blend->SetBlendMode(blend_mode);
     if (in_i < inputs.end() - 1 || foreground_color.has_value()) {
       blend_input = FilterInput::Make(

--- a/impeller/entity/contents/filters/color_filter_contents.h
+++ b/impeller/entity/contents/filters/color_filter_contents.h
@@ -10,6 +10,7 @@ namespace impeller {
 
 class ColorFilterContents : public FilterContents {
  public:
+  /// @brief the [inputs] are expected to be in the order of dst, src.
   static std::shared_ptr<ColorFilterContents> MakeBlend(
       BlendMode blend_mode,
       FilterInput::Vector inputs,

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -531,9 +531,9 @@ bool EntityPass::OnRender(
       }
 
       FilterInput::Vector inputs = {
-          FilterInput::Make(result.entity.GetContents()),
           FilterInput::Make(texture,
-                            result.entity.GetTransformation().Invert())};
+                            result.entity.GetTransformation().Invert()),
+          FilterInput::Make(result.entity.GetContents())};
       auto contents =
           ColorFilterContents::MakeBlend(result.entity.GetBlendMode(), inputs);
       contents->SetCoverageCrop(result.entity.GetCoverage());

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -856,7 +856,7 @@ TEST_P(EntityTest, Filters) {
 
     auto blend1 = ColorFilterContents::MakeBlend(
         BlendMode::kScreen,
-        {fi_bridge, FilterInput::Make(blend0), fi_bridge, fi_bridge});
+        {FilterInput::Make(blend0), fi_bridge, fi_bridge, fi_bridge});
 
     Entity entity;
     entity.SetTransformation(Matrix::MakeScale(GetContentScale()) *

--- a/impeller/entity/shaders/blending/advanced_blend.glsl
+++ b/impeller/entity/shaders/blending/advanced_blend.glsl
@@ -46,5 +46,4 @@ void main() {
   vec4 blended = vec4(Blend(dst.rgb, src.rgb), 1) * dst.a;
 
   frag_color = mix(dst_sample, blended, src.a);
-  // frag_color = dst_sample;
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/118903

Both pipeline and advanced blends internally used the order dst, src, src, however the ColorFilterContents::MakeFilter would jumble the order and the only usage in the engine compensated for this.

(Of course, still need to double check)
