### PR TITLE
Improve crashes if messenger APIs are used incorrectly

### DIFF
--- a/shell/platform/common/client_wrapper/include/flutter/method_channel.h
+++ b/shell/platform/common/client_wrapper/include/flutter/method_channel.h
@@ -91,9 +91,8 @@ class MethodChannel {
   // Registers a handler that should be called any time a method call is
   // received on this channel. A null handler will remove any previous handler.
   //
-  // Note that the MethodChannel does not own the handler, and will not
-  // unregister it on destruction, so the caller is responsible for
-  // unregistering explicitly if it should no longer be called.
+  // The handler will be owned by the underlying BinaryMessageHandler.
+  // Destroying the MethodChannel will not unregister the handler.
   void SetMethodCallHandler(MethodCallHandler<T> handler) const {
     if (!handler) {
       messenger_->SetMessageHandler(name_, nullptr);

--- a/shell/platform/common/client_wrapper/include/flutter/method_channel.h
+++ b/shell/platform/common/client_wrapper/include/flutter/method_channel.h
@@ -92,7 +92,9 @@ class MethodChannel {
   // received on this channel. A null handler will remove any previous handler.
   //
   // The handler will be owned by the underlying BinaryMessageHandler.
-  // Destroying the MethodChannel will not unregister the handler.
+  // Destroying the MethodChannel will not unregister the handler, so
+  // the caller is responsible for unregistering explicitly if the handler
+  // stops being valid before the engine is destroyed.
   void SetMethodCallHandler(MethodCallHandler<T> handler) const {
     if (!handler) {
       messenger_->SetMessageHandler(name_, nullptr);

--- a/shell/platform/common/public/flutter_messenger.h
+++ b/shell/platform/common/public/flutter_messenger.h
@@ -58,6 +58,8 @@ FLUTTER_EXPORT bool FlutterDesktopMessengerSend(
     const uint8_t* message,
     const size_t message_size);
 
+// Sends a binary message to the Flutter side on the specified channel.
+// The |reply| callback will be executed when a response is received.
 FLUTTER_EXPORT bool FlutterDesktopMessengerSendWithReply(
     FlutterDesktopMessengerRef messenger,
     const char* channel,

--- a/shell/platform/windows/flutter_windows.cc
+++ b/shell/platform/windows/flutter_windows.cc
@@ -265,6 +265,9 @@ bool FlutterDesktopMessengerSendWithReply(FlutterDesktopMessengerRef messenger,
                                           const size_t message_size,
                                           const FlutterDesktopBinaryReply reply,
                                           void* user_data) {
+  FML_DCHECK(FlutterDesktopMessengerIsAvailable(messenger))
+      << "Messenger must reference a running engine to send a message";
+
   return flutter::FlutterDesktopMessenger::FromRef(messenger)
       ->GetEngine()
       ->SendPlatformMessage(channel, message, message_size, reply, user_data);
@@ -283,6 +286,9 @@ void FlutterDesktopMessengerSendResponse(
     const FlutterDesktopMessageResponseHandle* handle,
     const uint8_t* data,
     size_t data_length) {
+  FML_DCHECK(FlutterDesktopMessengerIsAvailable(messenger))
+      << "Messenger must reference a running engine to send a response";
+
   flutter::FlutterDesktopMessenger::FromRef(messenger)
       ->GetEngine()
       ->SendPlatformMessageResponse(handle, data, data_length);
@@ -292,6 +298,9 @@ void FlutterDesktopMessengerSetCallback(FlutterDesktopMessengerRef messenger,
                                         const char* channel,
                                         FlutterDesktopMessageCallback callback,
                                         void* user_data) {
+  FML_DCHECK(FlutterDesktopMessengerIsAvailable(messenger))
+      << "Messenger must reference a running engine to set a callback";
+
   flutter::FlutterDesktopMessenger::FromRef(messenger)
       ->GetEngine()
       ->message_dispatcher()


### PR DESCRIPTION
The previous `MethodCall` documentation made it seem like you *must* unregister handlers. This is not  necessary during engine shutdown as that causes a crash after https://github.com/flutter/engine/pull/36909. This attempts to improve the comments & crashes for clarity.

See the conversation in https://github.com/flutter/engine/pull/38941

New crash messages:

```
[FATAL:flutter/shell/platform/windows/flutter_windows.cc(301)] Check failed: FlutterDesktopMessengerIsAvailable(messenger). Messenger must reference a running engine to set a callback
```

```
[FATAL:flutter/shell/platform/windows/flutter_windows.cc(268)] Check failed: FlutterDesktopMessengerIsAvailable(messenger). Messenger must reference a running engine to send a message
```

Addresses https://github.com/flutter/flutter/issues/118611

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
