### PR TITLE
[embedder] Fix getting vkGetInstanceProcAddr

### DIFF
--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -562,7 +562,7 @@ InferVulkanPlatformViewCreationCallback(
 
   auto vk_instance = static_cast<VkInstance>(config->vulkan.instance);
   auto proc_addr =
-      vulkan_get_instance_proc_address(vk_instance, "GetInstanceProcAddr");
+      vulkan_get_instance_proc_address(vk_instance, "vkGetInstanceProcAddr");
 
   flutter::EmbedderSurfaceVulkan::VulkanDispatchTable vulkan_dispatch_table = {
       .get_instance_proc_address =

--- a/shell/platform/embedder/tests/embedder_config_builder.cc
+++ b/shell/platform/embedder/tests/embedder_config_builder.cc
@@ -513,7 +513,8 @@ void EmbedderConfigBuilder::InitializeVulkanRendererConfig() {
       [](void* context, FlutterVulkanInstanceHandle instance,
          const char* name) -> void* {
     auto proc_addr = reinterpret_cast<EmbedderTestContextVulkan*>(context)
-                         ->vulkan_context_->vk_->GetInstanceProcAddr;
+                         ->vulkan_context_->vk_->GetInstanceProcAddr(
+                             reinterpret_cast<VkInstance>(instance), name);
     return reinterpret_cast<void*>(proc_addr);
   };
   vulkan_renderer_config_.get_next_image_callback =


### PR DESCRIPTION
Vulkan embedder was incorrectly querying vkGetInstanceProcAddr without the vk prefix. Tests would not catch this because embedder tests were assuming that get_instance_proc_address_callback is only ever called to obtain vkGetInstanceProcAddr, and so just returned that function unconditionally.

Fixes: https://github.com/flutter/flutter/issues/118956

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].
