### PR TITLE
Remove superfluous words from comments

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -242,7 +242,7 @@ deps = {
    #
    # The dependencies in this section should match the layout in the Fuchsia gn
    # build. Eventually, we'll manage these dependencies together with Fuchsia
-   # and not have to specific specific hashes.
+   # and not have to specific hashes.
 
   'src/third_party/rapidjson':
    Var('fuchsia_git') + '/third_party/rapidjson' + '@' + 'ef3564c5c8824989393b87df25355baf35ff544b',

--- a/Doxyfile
+++ b/Doxyfile
@@ -707,7 +707,7 @@ SHOW_NAMESPACES        = YES
 # The FILE_VERSION_FILTER tag can be used to specify a program or script that
 # doxygen should invoke to get the current version for each file (typically from
 # the version control system). Doxygen will invoke the program by executing (via
-# popen()) the command command input-file, where command is the value of the
+# popen()) the command input-file, where command is the value of the
 # FILE_VERSION_FILTER tag, and input-file is the name of an input file provided
 # by doxygen. Whatever the program writes to standard output is used as the file
 # version. For an example see the documentation.

--- a/ci/scan_flattened_deps.py
+++ b/ci/scan_flattened_deps.py
@@ -27,7 +27,7 @@ OSV_VULN_DB_URL = 'https://osv.dev/vulnerability/'
 SECONDS_PER_YEAR = 31556952
 UPSTREAM_PREFIX = 'upstream_'
 
-failed_deps = []  # deps which fail to be be cloned or git-merge based
+failed_deps = []  # deps which fail to be cloned or git-merge based
 
 sarif_log = {
     '$schema':

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -679,7 +679,7 @@ TEST_P(EntityTest, BlendingModeOptions) {
   std::vector<BlendMode> blend_mode_values;
   {
     // Force an exhausiveness check with a switch. When adding blend modes,
-    // update this switch with a new name/value to to make it selectable in the
+    // update this switch with a new name/value to make it selectable in the
     // test GUI.
 
     const BlendMode b{};

--- a/impeller/geometry/path.h
+++ b/impeller/geometry/path.h
@@ -25,7 +25,7 @@ enum class FillType {
 //------------------------------------------------------------------------------
 /// @brief      Paths are lightweight objects that describe a collection of
 ///             linear, quadratic, or cubic segments. These segments may be
-///             be broken up by move commands, which are effectively linear
+///             broken up by move commands, which are effectively linear
 ///             commands that pick up the pen rather than continuing to draw.
 ///
 ///             All shapes supported by Impeller are paths either directly or

--- a/impeller/renderer/texture_descriptor.h
+++ b/impeller/renderer/texture_descriptor.h
@@ -14,7 +14,7 @@ namespace impeller {
 
 //------------------------------------------------------------------------------
 /// @brief      A lightweight object that describes the attributes of a texture
-///             that can then used used an allocator to create that texture.
+///             that can then used an allocator to create that texture.
 ///
 struct TextureDescriptor {
   StorageMode storage_mode = StorageMode::kDeviceTransient;

--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -36,7 +36,7 @@ group("generate_snapshot_bins") {
     deps += [ ":create_arm_gen_snapshot" ]
   }
 
-  # Build analyze_snapshot for for 64-bit target CPUs.
+  # Build analyze_snapshot for 64-bit target CPUs.
   if (target_cpu == "x64" || target_cpu == "arm64") {
     deps +=
         [ "//third_party/dart/runtime/bin:analyze_snapshot($host_toolchain)" ]

--- a/lib/ui/geometry.dart
+++ b/lib/ui/geometry.dart
@@ -1227,7 +1227,7 @@ class RRect {
          brRadiusY: bottomRight.y,
        );
 
-  /// Construct a rounded rectangle from its bounding box and and topLeft,
+  /// Construct a rounded rectangle from its bounding box and topLeft,
   /// topRight, bottomRight, and bottomLeft radii.
   ///
   /// The corner radii default to [Radius.zero], i.e. right-angled corners. Will

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -2646,7 +2646,7 @@ class Path extends NativeFieldWrapperClass1 {
   /// `clockwise` and `largeArc` in such a way that the sweep angle
   /// is always less than 360 degrees.
   ///
-  /// A simple line is appended if either either radii are zero or the last
+  /// A simple line is appended if either radii are zero or the last
   /// point in the path is `arcEnd`. The radii are scaled to fit the last path
   /// point if both are greater than zero but too small to describe an arc.
   ///
@@ -2674,7 +2674,7 @@ class Path extends NativeFieldWrapperClass1 {
   /// path in a direction determined by `clockwise` and `largeArc`
   /// in such a way that the sweep angle is always less than 360 degrees.
   ///
-  /// A simple line is appended if either either radii are zero, or, both
+  /// A simple line is appended if either radii are zero, or, both
   /// `arcEndDelta.dx` and `arcEndDelta.dy` are zero. The radii are scaled to
   /// fit the last path point if both are greater than zero but too small to
   /// describe an arc.
@@ -4973,7 +4973,7 @@ class Canvas extends NativeFieldWrapperClass1 {
   ///
   /// Use [save] and [saveLayer] to push state onto the stack.
   ///
-  /// If the state was pushed with with [saveLayer], then this call will also
+  /// If the state was pushed with [saveLayer], then this call will also
   /// cause the new layer to be composited into the previous layer.
   @FfiNative<Void Function(Pointer<Void>)>('Canvas::restore', isLeaf: true)
   external void restore();

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -6260,7 +6260,7 @@ class Shadow {
 
   /// Linearly interpolate between two shadows.
   ///
-  /// If either shadow is null, this function linearly interpolates from a
+  /// If either shadow is null, this function linearly interpolates from
   /// a shadow that matches the other shadow in color but has a zero
   /// offset and a zero blurRadius.
   ///

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -1928,7 +1928,7 @@ class Locale {
   /// [language](https://github.com/unicode-org/cldr/blob/master/common/validity/language.xml),
   /// [region](https://github.com/unicode-org/cldr/blob/master/common/validity/region.xml). The
   /// primary language subtag must be at least two and at most eight lowercase
-  /// letters, but not four letters. The region region subtag must be two
+  /// letters, but not four letters. The region subtag must be two
   /// uppercase letters or three digits. See the [Unicode Language
   /// Identifier](https://www.unicode.org/reports/tr35/#Unicode_language_identifier)
   /// specification.

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -1194,7 +1194,7 @@ class TextHeightBehavior {
   /// Whether to apply the [TextStyle.height] modifier to the ascent of the first
   /// line in the paragraph.
   ///
-  /// When true, the [TextStyle.height] modifier will be applied to to the ascent
+  /// When true, the [TextStyle.height] modifier will be applied to the ascent
   /// of the first line. When false, the font's default ascent will be used and
   /// the [TextStyle.height] will have no effect on the ascent of the first line.
   ///
@@ -1206,7 +1206,7 @@ class TextHeightBehavior {
   /// Whether to apply the [TextStyle.height] modifier to the descent of the last
   /// line in the paragraph.
   ///
-  /// When true, the [TextStyle.height] modifier will be applied to to the descent
+  /// When true, the [TextStyle.height] modifier will be applied to the descent
   /// of the last line. When false, the font's default descent will be used and
   /// the [TextStyle.height] will have no effect on the descent of the last line.
   ///

--- a/lib/ui/ui_dart_state.h
+++ b/lib/ui/ui_dart_state.h
@@ -170,7 +170,7 @@ class UIDartState : public tonic::DartState {
     return unhandled_exception_callback_;
   }
 
-  /// Returns a enumeration that that uniquely represents this root isolate.
+  /// Returns a enumeration that uniquely represents this root isolate.
   /// Returns `0` if called from a non-root isolate.
   int64_t GetRootIsolateToken() const;
 

--- a/lib/web_ui/lib/src/engine/html/path/path.dart
+++ b/lib/web_ui/lib/src/engine/html/path/path.dart
@@ -658,7 +658,7 @@ class SurfacePath implements ui.Path {
   /// `clockwise` and `largeArc` in such a way that the sweep angle
   /// is always less than 360 degrees.
   ///
-  /// A simple line is appended if either either radii are zero or the last
+  /// A simple line is appended if either radii are zero or the last
   /// point in the path is `arcEnd`. The radii are scaled to fit the last path
   /// point if both are greater than zero but too small to describe an arc.
   ///
@@ -851,7 +851,7 @@ class SurfacePath implements ui.Path {
   /// path in a direction determined by `clockwise` and `largeArc`
   /// in such a way that the sweep angle is always less than 360 degrees.
   ///
-  /// A simple line is appended if either either radii are zero, or, both
+  /// A simple line is appended if either radii are zero, or, both
   /// `arcEndDelta.dx` and `arcEndDelta.dy` are zero. The radii are scaled to
   /// fit the last path point if both are greater than zero but too small to
   /// describe an arc.

--- a/lib/web_ui/lib/src/engine/keyboard_binding.dart
+++ b/lib/web_ui/lib/src/engine/keyboard_binding.dart
@@ -369,7 +369,7 @@ class KeyboardConverter {
     _keyGuards.remove(physicalKey)?.call();
     _keyGuards[physicalKey] = cancelingCallback;
   }
-  // Call this method on an up event event of a non-modifier key.
+  // Call this method on an up event of a non-modifier key.
   void _stopGuardingKey(int physicalKey) {
     _keyGuards.remove(physicalKey)?.call();
   }

--- a/lib/web_ui/lib/src/engine/navigation/history.dart
+++ b/lib/web_ui/lib/src/engine/navigation/history.dart
@@ -32,7 +32,7 @@ BrowserHistory createHistoryForExistingState(UrlStrategy? urlStrategy) {
 /// interact with the html browser history and should come up with their own
 /// ways to manage the states in the browser history.
 ///
-/// There should only be one global instance among all all subclasses.
+/// There should only be one global instance among all subclasses.
 ///
 /// See also:
 ///

--- a/lib/web_ui/lib/src/engine/safe_browser_api.dart
+++ b/lib/web_ui/lib/src/engine/safe_browser_api.dart
@@ -1040,7 +1040,7 @@ class OffScreenCanvas {
     }
   }
 
-  /// Draws an image to canvas for both offscreen canvas canvas context2d.
+  /// Draws an image to canvas for both offscreen canvas context2d.
   void drawImage(Object image, int x, int y, int width, int height) {
     js_util.callMethod<void>(
         getContext2d()!, 'drawImage', <dynamic>[image, x, y, width, height]);

--- a/lib/web_ui/lib/src/engine/text/font_collection.dart
+++ b/lib/web_ui/lib/src/engine/text/font_collection.dart
@@ -132,7 +132,7 @@ class FontManager {
   ///
   /// Safari 12 and Firefox crash if you create a [DomFontFace] with a font
   /// family that is not correct CSS syntax. Font family names with invalid
-  /// characters are accepted accepted on these browsers, when wrapped it in
+  /// characters are accepted on these browsers, when wrapped it in
   /// quotes.
   ///
   /// Additionally, for Safari 12 to work [DomFontFace] name should be

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -1364,7 +1364,7 @@ abstract class DefaultTextEditingStrategy with CompositionAwareMixin implements 
         editingDeltaState.deltaStart = lastEditingState!.extentOffset!;
         editingDeltaState.deltaEnd = lastEditingState!.extentOffset!;
       } else if (eventData != null) {
-        // When event.data is not null we we will begin by considering this delta as an insertion
+        // When event.data is not null we will begin by considering this delta as an insertion
         // at the selection extentOffset. This may change due to logic in handleChange to handle
         // composition and other IME behaviors.
         editingDeltaState.deltaText = eventData;

--- a/lib/web_ui/test/engine/profiler_test.dart
+++ b/lib/web_ui/test/engine/profiler_test.dart
@@ -73,7 +73,7 @@ void _profilerTests() {
       () => Profiler.instance.benchmark('foo', 123),
 
       // dart2js throws a NoSuchMethodError, dart2wasm throws a TypeError here.
-      // Just make make sure it throws an error in this case.
+      // Just make sure it throws an error in this case.
       throwsA(isA<Error>()),
     );
     expect(data, isEmpty);

--- a/runtime/dart_isolate.h
+++ b/runtime/dart_isolate.h
@@ -103,7 +103,7 @@ class DartIsolate : public UIDartState {
     ///
     Uninitialized,
     //--------------------------------------------------------------------------
-    /// The Dart isolate has been been fully initialized but none of the
+    /// The Dart isolate has been fully initialized but none of the
     /// libraries referenced by that isolate have been loaded yet. This is an
     /// internal phase and callers can never get a reference to a Dart isolate
     /// in this phase.

--- a/runtime/runtime_controller.h
+++ b/runtime/runtime_controller.h
@@ -535,7 +535,7 @@ class RuntimeController : public PlatformConfigurationClient {
   ///                              temporary conditions such as no network.
   ///                              Transient errors allow the dart VM to
   ///                              re-request the same deferred library and
-  ///                              and loading_unit_id again. Non-transient
+  ///                              loading_unit_id again. Non-transient
   ///                              errors are permanent and attempts to
   ///                              re-request the library will instantly
   ///                              complete with an error.

--- a/runtime/runtime_controller.h
+++ b/runtime/runtime_controller.h
@@ -477,7 +477,7 @@ class RuntimeController : public PlatformConfigurationClient {
   /// @brief      Get an identifier that represents the Dart isolate group the
   ///             root isolate is in.
   ///
-  /// @return     The root isolate isolate group identifier, zero if one can't
+  /// @return     The root isolate group identifier, zero if one can't
   ///             be established.
   uint64_t GetRootIsolateGroup() const;
 

--- a/shell/common/animator.h
+++ b/shell/common/animator.h
@@ -78,7 +78,7 @@ class Animator final {
 
   // Enqueue |trace_flow_id| into |trace_flow_ids_|.  The flow event will be
   // ended at either the next frame, or the next vsync interval with no active
-  // active rendering.
+  // rendering.
   void EnqueueTraceFlowId(uint64_t trace_flow_id);
 
  private:

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -870,7 +870,7 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
   ///                              temporary conditions such as no network.
   ///                              Transient errors allow the dart VM to
   ///                              re-request the same deferred library and
-  ///                              and loading_unit_id again. Non-transient
+  ///                              loading_unit_id again. Non-transient
   ///                              errors are permanent and attempts to
   ///                              re-request the library will instantly
   ///                              complete with an error.

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -707,7 +707,7 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
   /// @param[in]  trace_flow_id  The trace flow identifier associated with the
   ///                            pointer data packet. The engine uses this trace
   ///                            identifier to connect trace flows in the
-  ///                            timeline from the input event event to the
+  ///                            timeline from the input event to the
   ///                            frames generated due to those input events.
   ///                            These flows are tagged as "PointerEvent" in the
   ///                            timeline and allow grouping frames and input

--- a/shell/common/platform_message_handler.h
+++ b/shell/common/platform_message_handler.h
@@ -24,10 +24,10 @@ class PlatformMessageHandler {
   virtual void HandlePlatformMessage(
       std::unique_ptr<PlatformMessage> message) = 0;
 
-  /// Returns true if the platform message will ALWAYS be be dispatched to the
+  /// Returns true if the platform message will ALWAYS be dispatched to the
   /// platform thread.
   ///
-  /// Platforms thats support Background Platform Channels will return
+  /// Platforms that support Background Platform Channels will return
   /// false.
   virtual bool DoesHandlePlatformMessageOnPlatformThread() const = 0;
 

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -278,7 +278,7 @@ class PlatformView {
     ///                              temporary conditions such as no network.
     ///                              Transient errors allow the dart VM to
     ///                              re-request the same deferred library and
-    ///                              and loading_unit_id again. Non-transient
+    ///                              loading_unit_id again. Non-transient
     ///                              errors are permanent and attempts to
     ///                              re-request the library will instantly
     ///                              complete with an error.
@@ -759,7 +759,7 @@ class PlatformView {
   ///                              temporary conditions such as no network.
   ///                              Transient errors allow the dart VM to
   ///                              re-request the same deferred library and
-  ///                              and loading_unit_id again. Non-transient
+  ///                              loading_unit_id again. Non-transient
   ///                              errors are permanent and attempts to
   ///                              re-request the library will instantly
   ///                              complete with an error.

--- a/shell/common/run_configuration.h
+++ b/shell/common/run_configuration.h
@@ -35,7 +35,7 @@ class RunConfiguration {
   ///             will attempt to look for the VM and isolate snapshots in the
   ///             assets directory (must be specified in settings). In AOT mode,
   ///             it will attempt to look for known snapshot symbols in the
-  ///             currently currently loaded process. The entrypoint defaults to
+  ///             currently loaded process. The entrypoint defaults to
   ///             the "main" method in the root library.
   ///
   /// @param[in]  settings   The settings object used to look for the various

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -1709,7 +1709,7 @@ bool Shell::OnServiceProtocolFlushUIThreadTasks(
   // It can potentially starve the service isolate if the main isolate pauses
   // at a breakpoint or is in an infinite loop.
   //
-  // It should be invoked from the VM Service and and blocks it until UI thread
+  // It should be invoked from the VM Service and blocks it until UI thread
   // tasks are processed.
   response->SetObject();
   response->AddMember("type", "Success", response->GetAllocator());

--- a/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
+++ b/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
@@ -329,7 +329,7 @@ public final class FlutterActivityDelegate
       args.add("--endless-trace-buffer");
     }
     // NOTE: all flags provided with this argument are subject to filtering
-    // based on a a list of allowed flags in shell/common/switches.cc. If any
+    // based on a list of allowed flags in shell/common/switches.cc. If any
     // flag provided is not allowed, the process will immediately terminate.
     if (intent.hasExtra("dart-flags")) {
       args.add("--dart-flags=" + intent.getStringExtra("dart-flags"));

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterShellArgs.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterShellArgs.java
@@ -129,7 +129,7 @@ public class FlutterShellArgs {
     }
 
     // NOTE: all flags provided with this argument are subject to filtering
-    // based on a a list of allowed flags in shell/common/switches.cc. If any
+    // based on a list of allowed flags in shell/common/switches.cc. If any
     // flag provided is not allowed, the process will immediately terminate.
     if (intent.hasExtra(ARG_KEY_DART_FLAGS)) {
       args.add(ARG_DART_FLAGS + "=" + intent.getStringExtra(ARG_KEY_DART_FLAGS));

--- a/shell/platform/android/io/flutter/embedding/engine/deferredcomponents/DeferredComponentManager.java
+++ b/shell/platform/android/io/flutter/embedding/engine/deferredcomponents/DeferredComponentManager.java
@@ -114,7 +114,7 @@ public interface DeferredComponentManager {
    *     negative loadingUnitId is passed, then componentName must not be null. Passing a
    *     loadingUnitId larger than the highest valid loading unit's id will cause the Dart
    *     loadLibrary() to complete with a failure.
-   * @param componentName The deferred component component name as defined in bundle_config.yaml.
+   * @param componentName The deferred component name as defined in bundle_config.yaml.
    *     This may be null if the deferred component to be loaded is associated with a loading
    *     unit/deferred dart library. In this case, it is this method's responsibility to map the
    *     loadingUnitId to its corresponding componentName. When loading asset-only or other deferred

--- a/shell/platform/android/io/flutter/embedding/engine/deferredcomponents/DeferredComponentManager.java
+++ b/shell/platform/android/io/flutter/embedding/engine/deferredcomponents/DeferredComponentManager.java
@@ -114,12 +114,12 @@ public interface DeferredComponentManager {
    *     negative loadingUnitId is passed, then componentName must not be null. Passing a
    *     loadingUnitId larger than the highest valid loading unit's id will cause the Dart
    *     loadLibrary() to complete with a failure.
-   * @param componentName The deferred component name as defined in bundle_config.yaml.
-   *     This may be null if the deferred component to be loaded is associated with a loading
-   *     unit/deferred dart library. In this case, it is this method's responsibility to map the
-   *     loadingUnitId to its corresponding componentName. When loading asset-only or other deferred
-   *     components without an associated Dart deferred library, loading unit id should a negative
-   *     value and componentName must be non-null.
+   * @param componentName The deferred component name as defined in bundle_config.yaml. This may be
+   *     null if the deferred component to be loaded is associated with a loading unit/deferred dart
+   *     library. In this case, it is this method's responsibility to map the loadingUnitId to its
+   *     corresponding componentName. When loading asset-only or other deferred components without
+   *     an associated Dart deferred library, loading unit id should a negative value and
+   *     componentName must be non-null.
    */
   public abstract void installDeferredComponent(int loadingUnitId, String componentName);
 

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -525,7 +525,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
         private long configureForVirtualDisplay(
             @NonNull PlatformView platformView,
             @NonNull PlatformViewsChannel.PlatformViewCreationRequest request) {
-          // This mode adds the view to a virtual display, which is is wired up to a GL texture that
+          // This mode adds the view to a virtual display, which is wired up to a GL texture that
           // is composed by the Flutter engine.
 
           // API level 20 is required to use VirtualDisplay#setSurface.

--- a/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java
@@ -161,7 +161,7 @@ class VirtualDisplayController {
                   @Override
                   public void run() {
                     // We need some delay here until the frame propagates through the vd surface to
-                    // to the texture,
+                    // the texture,
                     // 128ms was picked pretty arbitrarily based on trial and error.
                     // As long as we invoke the runnable after a new frame is available we avoid the
                     // scaling jank

--- a/shell/platform/common/client_wrapper/standard_codec.cc
+++ b/shell/platform/common/client_wrapper/standard_codec.cc
@@ -98,7 +98,7 @@ EncodableValue StandardCodecSerializer::ReadValue(
 void StandardCodecSerializer::WriteValue(const EncodableValue& value,
                                          ByteStreamWriter* stream) const {
   stream->WriteByte(static_cast<uint8_t>(EncodedTypeForValue(value)));
-  // TODO(cbracken): Consider replacing this this with std::visit.
+  // TODO(cbracken): Consider replacing this with std::visit.
   switch (value.index()) {
     case 0:
     case 1:

--- a/shell/platform/common/incoming_message_dispatcher.h
+++ b/shell/platform/common/incoming_message_dispatcher.h
@@ -30,7 +30,7 @@ class IncomingMessageDispatcher {
   IncomingMessageDispatcher& operator=(IncomingMessageDispatcher const&) =
       delete;
 
-  // Routes |message| to to the registered handler for its channel, if any.
+  // Routes |message| to the registered handler for its channel, if any.
   //
   // If input blocking has been enabled on that channel, wraps the call to the
   // handler with calls to the given callbacks to block and then unblock input.

--- a/shell/platform/darwin/Doxyfile
+++ b/shell/platform/darwin/Doxyfile
@@ -727,7 +727,7 @@ SHOW_NAMESPACES        = YES
 # The FILE_VERSION_FILTER tag can be used to specify a program or script that
 # doxygen should invoke to get the current version for each file (typically from
 # the version control system). Doxygen will invoke the program by executing (via
-# popen()) the command command input-file, where command is the value of the
+# popen()) the command input-file, where command is the value of the
 # FILE_VERSION_FILTER tag, and input-file is the name of an input file provided
 # by doxygen. Whatever the program writes to standard output is used as the file
 # version. For an example see the documentation.

--- a/shell/platform/darwin/ios/framework/Source/FlutterEmbedderKeyResponder.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEmbedderKeyResponder.mm
@@ -863,7 +863,7 @@ void HandleResponse(bool handled, void* user_data);
     // The caps lock modifier needs to be unset only if it was already on
     // and this is a key up. This is because it indicates the lock state, and
     // not the key press state. The caps lock state should be on between the
-    // first down, and the second up (i.e. while the lock in in effect), and
+    // first down, and the second up (i.e. while the lock in effect), and
     // this code turns it off at the second up event. The OS leaves it on still
     // because of iOS's weird late processing of modifier states. Synthesis of
     // the appropriate synthesized key events happens in synchronizeModifiers.

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -662,7 +662,7 @@ static BOOL IsSelectionRectCloserToPoint(CGPoint point,
 @end
 
 // A FlutterTextInputView that masquerades as a UITextField, and forwards
-// selectors it can't respond to to a shared UITextField instance.
+// selectors it can't respond to a shared UITextField instance.
 //
 // Relevant API docs claim that password autofill supports any custom view
 // that adopts the UITextInput protocol, automatic strong password seems to

--- a/shell/platform/darwin/macos/framework/Headers/FlutterPluginRegistrarMacOS.h
+++ b/shell/platform/darwin/macos/framework/Headers/FlutterPluginRegistrarMacOS.h
@@ -16,7 +16,7 @@
 
 /**
  * The protocol for an object managing registration for a plugin. It provides access to application
- * context, as as allowing registering for callbacks for handling various conditions.
+ * context, as allowing registering for callbacks for handling various conditions.
  *
  * Currently the macOS PluginRegistrar has very limited functionality, but is expected to expand
  * over time to more closely match the functionality of FlutterPluginRegistrar.

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -554,7 +554,7 @@ static char markerKey;
 - (BOOL)performKeyEquivalent:(NSEvent*)event {
   if ([_flutterViewController isDispatchingKeyEvent:event]) {
     // When NSWindow is nextResponder, keyboard manager will send to it
-    // unhandled events (through [NSWindow keyDown:]). If event has has both
+    // unhandled events (through [NSWindow keyDown:]). If event has both
     // control and cmd modifiers set (i.e. cmd+control+space - emoji picker)
     // NSWindow will then send this event as performKeyEquivalent: to first
     // responder, which is FlutterTextInputPlugin. If that's the case, the

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -830,7 +830,7 @@ typedef enum {
   /// any other buttons are still pressed when one button is released, that
   /// should be sent as a kMove rather than a kUp.
   kUp,
-  /// The pointer, which must have been been up, is now down.
+  /// The pointer, which must have been up, is now down.
   ///
   /// For touch, this means that the pointer has come into contact with the
   /// screen. For a mouse, it means a button is now pressed. Note that if any

--- a/shell/platform/embedder/embedder_task_runner.h
+++ b/shell/platform/embedder/embedder_task_runner.h
@@ -34,7 +34,7 @@ class EmbedderTaskRunner final : public fml::TaskRunner {
                        fml::TimePoint target_time)>
         post_task_callback;
     //--------------------------------------------------------------------------
-    /// Asks the embedder if tasks posted to it on this task task runner via the
+    /// Asks the embedder if tasks posted to it on this task runner via the
     /// `post_task_callback` will be executed (after task expiry) on the calling
     /// thread.
     ///

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -117,7 +117,7 @@ TEST_F(EmbedderTest, CanInvokeCustomEntrypointMacro) {
   auto native_entry1 = CREATE_NATIVE_ENTRY(entry1);
   context.AddNativeCallback("SayHiFromCustomEntrypoint1", native_entry1);
 
-  // Can be wrapped in in the args.
+  // Can be wrapped in the args.
   auto entry2 = [&latch2](Dart_NativeArguments args) {
     FML_LOG(INFO) << "In Callback 2";
     latch2.Signal();

--- a/shell/platform/fuchsia/dart_runner/dart_test_component_controller.h
+++ b/shell/platform/fuchsia/dart_runner/dart_test_component_controller.h
@@ -67,7 +67,7 @@ class DartTestComponentController
   }
 
  private:
-  /// Helper for actually running the Dart main. Returns Returns a promise.
+  /// Helper for actually running the Dart main. Returns a promise.
   fpromise::promise<> RunDartMain();
 
   /// Creates and binds the namespace for this component. Returns true if

--- a/shell/platform/fuchsia/flutter/tests/integration/utils/portable_ui_test.h
+++ b/shell/platform/fuchsia/flutter/tests/integration/utils/portable_ui_test.h
@@ -114,10 +114,10 @@ class PortableUITest : public ::loop_fixture::RealLoop {
   virtual void ExtendRealm() = 0;
 
   // Returns the test-specific test-ui-stack component url to use.
-  // Usually overriden to return a value from gtest GetParam()
+  // Usually overridden to return a value from gtest GetParam()
   virtual std::string GetTestUIStackUrl() = 0;
 
-  // Helper method to watch watch for view geometry updates.
+  // Helper method to watch for view geometry updates.
   void WatchViewGeometry();
 
   // Helper method to process a view geometry update.

--- a/shell/platform/fuchsia/runtime/dart/utils/vmservice_object.cc
+++ b/shell/platform/fuchsia/runtime/dart/utils/vmservice_object.cc
@@ -37,7 +37,7 @@ namespace dart_utils {
 
 void VMServiceObject::GetContents(LazyEntryVector* out_vector) const {
   // List /tmp/dart.services if it exists, and push its contents as
-  // as the conrtents of this directory.
+  // the contents of this directory.
   std::vector<std::string> files;
   if (!ReadDirContents(kPortDir, &files)) {
     FX_LOGF(ERROR, LOG_TAG,

--- a/shell/platform/glfw/client_wrapper/BUILD.gn
+++ b/shell/platform/glfw/client_wrapper/BUILD.gn
@@ -19,7 +19,7 @@ _wrapper_sources = [
 
 # This code will be merged into .../common/cpp/client_wrapper for client use,
 # so uses header paths that assume the merged state. Include the header
-# header directory of the core wrapper files so these includes will work.
+# directory of the core wrapper files so these includes will work.
 config("relative_core_wrapper_headers") {
   include_dirs =
       [ "//flutter/shell/platform/common/client_wrapper/include/flutter" ]

--- a/shell/platform/glfw/client_wrapper/include/flutter/flutter_window_controller.h
+++ b/shell/platform/glfw/client_wrapper/include/flutter/flutter_window_controller.h
@@ -64,7 +64,7 @@ class FlutterWindowController : public PluginRegistry {
   //
   // The |arguments| are passed to the Flutter engine. See:
   // https://github.com/flutter/engine/blob/main/shell/common/switches.h for
-  // for details. Not all arguments will apply to desktop.
+  // details. Not all arguments will apply to desktop.
   //
   // The |aot_library_path| is the path to the libapp.so file for the Flutter
   // application to be run. While this parameter is only required in AOT mode,

--- a/shell/platform/linux/fl_engine_private.h
+++ b/shell/platform/linux/fl_engine_private.h
@@ -100,7 +100,7 @@ FlutterEngineProcTable* fl_engine_get_embedder_api(FlEngine* engine);
  * Registers the function called when a platform message is received. Call
  * fl_engine_send_platform_message_response() with the response to this message.
  * Ownership of #FlutterPlatformMessageResponseHandle is
- * transferred to the caller, and the message must be responded to to avoid
+ * transferred to the caller, and the message must be responded to avoid
  * memory leaks.
  */
 void fl_engine_set_platform_message_handler(

--- a/shell/platform/linux/fl_event_channel_test.cc
+++ b/shell/platform/linux/fl_event_channel_test.cc
@@ -66,7 +66,7 @@ static void cancel_channel(FlBinaryMessenger* messenger, FlValue* args) {
                                   nullptr, nullptr);
 }
 
-// Called when when the remote end starts listening on the channel.
+// Called when the remote end starts listening on the channel.
 static FlMethodErrorResponse* listen_listen_cb(FlEventChannel* channel,
                                                FlValue* args,
                                                gpointer user_data) {
@@ -98,7 +98,7 @@ TEST(FlEventChannelTest, Listen) {
   g_object_unref(channel);
 }
 
-// Called when when the remote end starts listening on the channel.
+// Called when the remote end starts listening on the channel.
 static FlMethodErrorResponse* listen_exception_listen_cb(
     FlEventChannel* channel,
     FlValue* args,
@@ -161,7 +161,7 @@ TEST(FlEventChannelTest, ListenException) {
   g_object_unref(channel);
 }
 
-// Called when when the remote end cancels their subscription.
+// Called when the remote end cancels their subscription.
 static FlMethodErrorResponse* cancel_cancel_cb(FlEventChannel* channel,
                                                FlValue* args,
                                                gpointer user_data) {
@@ -194,7 +194,7 @@ TEST(FlEventChannelTest, Cancel) {
   g_object_unref(channel);
 }
 
-// Called when when the remote end cancels their subscription.
+// Called when the remote end cancels their subscription.
 static FlMethodErrorResponse* cancel_exception_cancel_cb(
     FlEventChannel* channel,
     FlValue* args,
@@ -267,7 +267,7 @@ TEST(FlEventChannelTest, CancelException) {
   g_object_unref(channel);
 }
 
-// Called when when the remote end starts listening on the channel.
+// Called when the remote end starts listening on the channel.
 static FlMethodErrorResponse* args_listen_cb(FlEventChannel* channel,
                                              FlValue* args,
                                              gpointer user_data) {
@@ -277,7 +277,7 @@ static FlMethodErrorResponse* args_listen_cb(FlEventChannel* channel,
   return nullptr;
 }
 
-// Called when when the remote end cancels their subscription.
+// Called when the remote end cancels their subscription.
 static FlMethodErrorResponse* args_cancel_cb(FlEventChannel* channel,
                                              FlValue* args,
                                              gpointer user_data) {
@@ -313,7 +313,7 @@ TEST(FlEventChannelTest, Args) {
   g_object_unref(channel);
 }
 
-// Called when when the remote end starts listening on the channel.
+// Called when the remote end starts listening on the channel.
 static FlMethodErrorResponse* send_events_listen_cb(FlEventChannel* channel,
                                                     FlValue* args,
                                                     gpointer user_data) {

--- a/shell/platform/linux/fl_method_channel_test.cc
+++ b/shell/platform/linux/fl_method_channel_test.cc
@@ -14,7 +14,7 @@
 #include "flutter/shell/platform/linux/testing/fl_test.h"
 #include "flutter/shell/platform/linux/testing/mock_renderer.h"
 
-// Called when when the method call response is received in the InvokeMethod
+// Called when the method call response is received in the InvokeMethod
 // test.
 static void method_response_cb(GObject* object,
                                GAsyncResult* result,
@@ -53,7 +53,7 @@ TEST(FlMethodChannelTest, InvokeMethod) {
   g_main_loop_run(loop);
 }
 
-// Called when when the method call response is received in the
+// Called when the method call response is received in the
 // InvokeMethodNullptrArgsMessage test.
 static void nullptr_args_response_cb(GObject* object,
                                      GAsyncResult* result,
@@ -89,7 +89,7 @@ TEST(FlMethodChannelTest, InvokeMethodNullptrArgsMessage) {
   g_main_loop_run(loop);
 }
 
-// Called when when the method call response is received in the
+// Called when the method call response is received in the
 // InvokeMethodError test.
 static void error_response_cb(GObject* object,
                               GAsyncResult* result,
@@ -137,7 +137,7 @@ TEST(FlMethodChannelTest, InvokeMethodError) {
   g_main_loop_run(loop);
 }
 
-// Called when when the method call response is received in the
+// Called when the method call response is received in the
 // InvokeMethodNotImplemented test.
 static void not_implemented_response_cb(GObject* object,
                                         GAsyncResult* result,
@@ -170,7 +170,7 @@ TEST(FlMethodChannelTest, InvokeMethodNotImplemented) {
   g_main_loop_run(loop);
 }
 
-// Called when when the method call response is received in the
+// Called when the method call response is received in the
 // InvokeMethodFailure test.
 static void failure_response_cb(GObject* object,
                                 GAsyncResult* result,

--- a/shell/platform/windows/keyboard_key_handler.h
+++ b/shell/platform/windows/keyboard_key_handler.h
@@ -71,7 +71,7 @@ class KeyboardKeyHandler : public KeyboardHandlerBase {
   // Windows requires a synchronous response of whether a key event should be
   // handled, while the query to Flutter is always asynchronous. This is
   // resolved by the "redispatching" algorithm: by default, the response to a
-  // fresh event is always always true. The event is then sent to the framework.
+  // fresh event is always true. The event is then sent to the framework.
   // If the framework later decides not to handle the event, this class will
   // create an identical event and dispatch it to the system, and remember all
   // synthesized events. The fist time an exact event (by |ComputeEventHash|) is

--- a/shell/platform/windows/keyboard_manager.h
+++ b/shell/platform/windows/keyboard_manager.h
@@ -43,7 +43,7 @@ namespace flutter {
 class KeyboardManager {
  public:
   // Define how the keyboard manager accesses Win32 system calls (to allow
-  // mocking) and sends key calls and and text calls.
+  // mocking) and sends key calls and text calls.
   //
   // Typically implemented by |Window|.
   class WindowDelegate {

--- a/third_party/accessibility/ax/platform/ax_platform_node_delegate.h
+++ b/third_party/accessibility/ax/platform/ax_platform_node_delegate.h
@@ -311,7 +311,7 @@ class AX_EXPORT AXPlatformNodeDelegate {
   // produce appropriate results. It may optionally return no value, indicating
   // that the delegate does not have all the information required to calculate
   // this value and it is the responsibility of the AXPlatformNode itself to
-  // to calculate it.
+  // calculate it.
   virtual std::optional<int> FindTextBoundary(
       ax::mojom::TextBoundary boundary,
       int offset,

--- a/third_party/accessibility/ax/platform/ax_platform_node_textrangeprovider_win_unittest.cc
+++ b/third_party/accessibility/ax/platform/ax_platform_node_textrangeprovider_win_unittest.cc
@@ -4398,7 +4398,7 @@ TEST_F(AXPlatformNodeTextRangeProviderTest,
   }
 
   {
-    // |heading_text_node| has a a spelling error for one word, and no
+    // |heading_text_node| has a spelling error for one word, and no
     // annotations for the remaining text, so the range has mixed annotations.
     EXPECT_UIA_TEXTATTRIBUTE_MIXED(heading_text_range_provider,
                                    UIA_AnnotationTypesAttributeId);

--- a/third_party/accessibility/ax/platform/ax_platform_node_win.h
+++ b/third_party/accessibility/ax/platform/ax_platform_node_win.h
@@ -698,7 +698,7 @@ class AX_EXPORT __declspec(uuid("26f5641a-246d-457b-a96d-07f3fae6acf2"))
   };
 
   // Determine if a text range overlaps a |marker_type|, and whether
-  // the overlap is a partial or or complete match.
+  // the overlap is a partial or complete match.
   MarkerTypeRangeResult GetMarkerTypeFromRange(
       const std::optional<int>& start_offset,
       const std::optional<int>& end_offset,

--- a/third_party/txt/src/txt/font_collection.cc
+++ b/third_party/txt/src/txt/font_collection.cc
@@ -254,7 +254,7 @@ void FontCollection::SortSkTypefaces(
           // of multiple widths (e.g. condensed, expanded), opt to be
           // conservative and select the most standard width.
           //
-          // If a specific width is desired, it should be be narrowed down via
+          // If a specific width is desired, it should be narrowed down via
           // the family name.
           //
           // The font weights are also sorted lightest to heaviest but Flutter

--- a/third_party/txt/src/utils/TypeHelpers.h
+++ b/third_party/txt/src/utils/TypeHelpers.h
@@ -66,7 +66,7 @@ struct traits {
     has_trivial_ctor = is_pointer || trait_trivial_ctor<TYPE>::value,
     // whether this type's destructor is a no-op
     has_trivial_dtor = is_pointer || trait_trivial_dtor<TYPE>::value,
-    // whether this type type can be copy-constructed with memcpy
+    // whether this type can be copy-constructed with memcpy
     has_trivial_copy = is_pointer || trait_trivial_copy<TYPE>::value,
     // whether this type can be moved with memmove
     has_trivial_move = is_pointer || trait_trivial_move<TYPE>::value

--- a/tools/fuchsia/gn-sdk/config/config.gni
+++ b/tools/fuchsia/gn-sdk/config/config.gni
@@ -14,7 +14,7 @@ declare_args() {
   # requires the Fuchsia _Core_ SDK (for dart libraries, in the core SDK, but
   # excluded from the GN SDK), the Fuchsia SDK assumption that the build files
   # are in the same SDK directory path as the APIs does not hold true. (And
-  # there are are a couple of other minor tweaks that appear to be needed, at
+  # there are a couple of other minor tweaks that appear to be needed, at
   # this time.) This use case will be discussed with the SDK team, to see if we
   # can come up with a cleaner solution.
 

--- a/tools/gn
+++ b/tools/gn
@@ -391,8 +391,7 @@ def to_gn_args(args):
   # Desktop embeddings can have more dependencies than the engine library,
   # which can be problematic in some build environments (e.g., building on
   # Linux will bring in pkg-config dependencies at generation time). These
-  # flags allow preventing those those targets from being part of the build
-  # tree.
+  # flags allow preventing those targets from being part of the build tree.
   gn_args['enable_desktop_embeddings'] = not args.disable_desktop_embeddings
 
   # Overrides whether Boring SSL is compiled with system as. Only meaningful


### PR DESCRIPTION
This PR removes extra words e.g. `be be` or `to to`.



## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
