### PR TITLE
Remove unnecessary null checks in doc snippet

### DIFF
--- a/lib/ui/hash_codes.dart
+++ b/lib/ui/hash_codes.dart
@@ -8,6 +8,7 @@ part of dart.ui;
 // int foo = 0;
 // int bar = 0;
 // List<int> quux = <int>[];
+// List<int>? thud;
 // int baz = 0;
 
 class _HashEnd { const _HashEnd(); }
@@ -59,11 +60,11 @@ class _Jenkins {
 /// int get hashCode => Object.hash(foo, bar, Object.hashAll(quux), baz);
 /// ```
 ///
-/// If `quux` in this example was nullable, then it would need special handling,
+/// If a parameter is nullable, then it needs special handling,
 /// because [Object.hashAll]'s argument is not nullable:
 ///
 /// ```dart
-/// int get hashCode => Object.hash(foo, bar, quux == null ? null : Object.hashAll(quux), baz);
+/// int get hashCode => Object.hash(foo, bar, thud == null ? null : Object.hashAll(thud), baz);
 /// ```
 @Deprecated(
   'Use Object.hash() instead. '


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/118837.
Related to https://github.com/flutter/flutter/pull/118849.

Dart 3 drops support for non-null safe code, so we can finally turn on the unnecessary_null_comparison lint and remove the unnecessary checks it flags.