### PR TITLE
[Impeller] uniform offsets account for size

### DIFF
--- a/impeller/entity/contents/runtime_effect_contents.cc
+++ b/impeller/entity/contents/runtime_effect_contents.cc
@@ -152,6 +152,7 @@ bool RuntimeEffectContents::Render(const ContentContext& renderer,
   ///
 
   size_t buffer_index = 0;
+  size_t buffer_offset = 0;
   size_t sampler_index = 0;
   for (auto uniform : runtime_stage_->GetUniforms()) {
     // TODO(113715): Populate this metadata once GLES is able to handle
@@ -180,8 +181,8 @@ bool RuntimeEffectContents::Render(const ContentContext& renderer,
         size_t alignment =
             std::max(uniform.bit_width / 8, DefaultUniformAlignment());
         auto buffer_view = pass.GetTransientsBuffer().Emplace(
-            uniform_data_->data() + uniform.location * sizeof(float),
-            uniform.GetSize(), alignment);
+            uniform_data_->data() + buffer_offset, uniform.GetSize(),
+            alignment);
 
         ShaderUniformSlot uniform_slot;
         uniform_slot.name = uniform.name.c_str();
@@ -189,6 +190,7 @@ bool RuntimeEffectContents::Render(const ContentContext& renderer,
         cmd.BindResource(ShaderStage::kFragment, uniform_slot, metadata,
                          buffer_view);
         buffer_index++;
+        buffer_offset += uniform.GetSize();
         break;
       }
       case kBoolean:

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -2097,11 +2097,11 @@ TEST_P(EntityTest, RuntimeEffect) {
     contents->SetRuntimeStage(runtime_stage);
 
     struct FragUniforms {
-      Scalar iTime;
       Vector2 iResolution;
+      Scalar iTime;
     } frag_uniforms = {
-        .iTime = static_cast<Scalar>(GetSecondsElapsed()),
         .iResolution = Vector2(GetWindowSize().width, GetWindowSize().height),
+        .iTime = static_cast<Scalar>(GetSecondsElapsed()),
     };
     auto uniform_data = std::make_shared<std::vector<uint8_t>>();
     uniform_data->resize(sizeof(FragUniforms));

--- a/impeller/fixtures/runtime_stage_example.frag
+++ b/impeller/fixtures/runtime_stage_example.frag
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-layout(location = 0) uniform float iTime;
-layout(location = 1) uniform vec2 iResolution;
+layout(location = 0) uniform vec2 iResolution;
+layout(location = 1) uniform float iTime;
 
 layout(location = 0) out vec4 fragColor;
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/118847

When reading from the uniform buffer account for vec2/3/4 uniforms being larger than a single float.
