### PR TITLE
Add mmap dependency to flutter_frontend_server

### DIFF
--- a/flutter_frontend_server/pubspec.yaml
+++ b/flutter_frontend_server/pubspec.yaml
@@ -77,6 +77,8 @@ dependency_overrides:
     path: ../testing/litetest
   meta:
     path: ../../third_party/dart/pkg/meta
+  mmap:
+    path: ../../third_party/dart/pkg/mmap
   package_config:
     path: ../../third_party/dart/third_party/pkg/package_config
   path:


### PR DESCRIPTION
In a follow-up change in Dart SDK, package:compiler (a dependency of flutter_frontend_server) will start using package:mmap