### PR TITLE
[CP] [Impeller] Check the correct stencil coverage when deciding whether to elide a restore

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -273,11 +273,11 @@ TEST_P(AiksTest, CanRenderWithContiguousClipRestores) {
 
   canvas.Save();
 
-  // Append two clips. First with empty coverage.
+  // Append two clips, the second resulting in empty coverage.
   canvas.ClipPath(
       PathBuilder{}.AddRect(Rect::MakeXYWH(100, 100, 100, 100)).TakePath());
   canvas.ClipPath(
-      PathBuilder{}.AddRect(Rect::MakeXYWH(100, 100, 100, 100)).TakePath());
+      PathBuilder{}.AddRect(Rect::MakeXYWH(300, 300, 100, 100)).TakePath());
 
   // Restore to no clips.
   canvas.Restore();

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -460,10 +460,9 @@ bool EntityPass::OnRender(
             element_entity.GetStencilDepth() - stencil_depth_floor;
         FML_DCHECK(restoration_depth < stencil_stack.size());
 
-        auto restored_coverage = stencil_stack.back().coverage;
         stencil_stack.resize(restoration_depth + 1);
 
-        if (!restored_coverage.has_value()) {
+        if (!stencil_stack.back().coverage.has_value()) {
           // Running this restore op won't make anything renderable, so skip it.
           return true;
         }


### PR DESCRIPTION
CP of https://github.com/flutter/engine/commit/730e88fb67878fbfdb9bb60545fecdb2990bc9fd for `flutter-3.7-candidate.1`