### PR TITLE
Get the vulkan backend working again

### DIFF
--- a/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/impeller/renderer/backend/vulkan/context_vk.cc
@@ -40,6 +40,12 @@ VKAPI_ATTR VkBool32 VKAPI_CALL DebugUtilsMessengerCallback(
   const auto prefix = impeller::vk::to_string(
       impeller::vk::DebugUtilsMessageSeverityFlagBitsEXT{severity});
 
+  // There isn't stable messageIdNumber for this validation failure.
+  if (strstr(pCallbackData->pMessageIdName,
+             "CoreValidation-Shader-OutputNotConsumed") != nullptr) {
+    return VK_FALSE;
+  }
+
   FML_DCHECK(false) << prefix << "[" << pCallbackData->messageIdNumber << "]["
                     << pCallbackData->pMessageIdName
                     << "] : " << pCallbackData->pMessage;
@@ -596,7 +602,7 @@ PixelFormat ContextVK::GetColorAttachmentPixelFormat() const {
 }
 
 const BackendFeatures& ContextVK::GetBackendFeatures() const {
-  return kModernBackendFeatures;
+  return kLegacyBackendFeatures;
 }
 
 vk::Queue ContextVK::GetGraphicsQueue() const {

--- a/impeller/renderer/backend/vulkan/swapchain_details_vk.cc
+++ b/impeller/renderer/backend/vulkan/swapchain_details_vk.cc
@@ -74,7 +74,7 @@ vk::PresentModeKHR SwapchainDetailsVK::PickPresentationMode() const {
     }
   }
 
-  VALIDATION_LOG << "Picking a sub-optimal presentation mode.";
+  FML_LOG(ERROR) << "Picking a sub-optimal presentation mode.";
   // Vulkan spec dictates that FIFO is always available.
   return vk::PresentModeKHR::eFifo;
 }

--- a/impeller/tools/impeller.gni
+++ b/impeller/tools/impeller.gni
@@ -18,7 +18,7 @@ declare_args() {
   impeller_enable_opengles = is_mac || is_linux || is_win || is_android
 
   # Whether the Vulkan backend is enabled.
-  impeller_enable_vulkan = is_linux || is_android
+  impeller_enable_vulkan = is_mac || is_linux || is_android
 
   # Whether to use a prebuilt impellerc.
   # If this is the empty string, impellerc will be built.

--- a/impeller/tools/impeller.gni
+++ b/impeller/tools/impeller.gni
@@ -18,7 +18,7 @@ declare_args() {
   impeller_enable_opengles = is_mac || is_linux || is_win || is_android
 
   # Whether the Vulkan backend is enabled.
-  impeller_enable_vulkan = is_mac || is_linux || is_android
+  impeller_enable_vulkan = is_linux || is_android
 
   # Whether to use a prebuilt impellerc.
   # If this is the empty string, impellerc will be built.


### PR DESCRIPTION
* Disables modern features as SSBOs are wired on Vulkan yet.
* Sub-optimal presentation mode must not be a fatal issue.
* Allow for shader outputs not to be consumed.
