### PR TITLE
[Impeller] Switch to nearest sampling for the text atlas

### DIFF
--- a/impeller/entity/contents/text_contents.cc
+++ b/impeller/entity/contents/text_contents.cc
@@ -78,8 +78,8 @@ static bool CommonRender(
   VS::BindFrameInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frame_info));
 
   SamplerDescriptor sampler_desc;
-  sampler_desc.min_filter = MinMagFilter::kLinear;
-  sampler_desc.mag_filter = MinMagFilter::kLinear;
+  sampler_desc.min_filter = MinMagFilter::kNearest;
+  sampler_desc.mag_filter = MinMagFilter::kNearest;
   sampler_desc.mip_filter = MipFilter::kNone;
 
   typename FS::FragInfo frag_info;
@@ -146,10 +146,10 @@ static bool CommonRender(
       for (const auto& point : unit_points) {
         typename VS::PerVertexData vtx;
         vtx.unit_position = point;
-        vtx.destination_position = offset_glyph_position + Point(0.5, 0.5);
+        vtx.destination_position = offset_glyph_position;
         vtx.destination_size = Point(glyph_position.glyph.bounds.size);
-        vtx.source_position = atlas_position + Point(0.5, 0.5);
-        vtx.source_glyph_size = atlas_glyph_size - Point(1.0, 1.0);
+        vtx.source_position = atlas_position;
+        vtx.source_glyph_size = atlas_glyph_size;
         if constexpr (std::is_same_v<TPipeline, GlyphAtlasPipeline>) {
           vtx.has_color =
               glyph_position.glyph.type == Glyph::Type::kBitmap ? 1.0 : 0.0;

--- a/impeller/entity/shaders/glyph_atlas.frag
+++ b/impeller/entity/shaders/glyph_atlas.frag
@@ -21,13 +21,14 @@ out vec4 frag_color;
 
 void main() {
   vec2 uv_size = v_source_glyph_size / frag_info.atlas_size;
-  vec2 offset = v_source_position / frag_info.atlas_size;
+  vec2 uv_position = v_source_position / frag_info.atlas_size;
   if (v_has_color == 1.0) {
     frag_color =
-        texture(glyph_atlas_sampler, v_unit_position * uv_size + offset);
+        texture(glyph_atlas_sampler, v_unit_position * uv_size + uv_position);
   } else {
     frag_color =
-        texture(glyph_atlas_sampler, v_unit_position * uv_size + offset).aaaa *
+        texture(glyph_atlas_sampler, v_unit_position * uv_size + uv_position)
+            .aaaa *
         frag_info.text_color;
   }
 }

--- a/impeller/entity/shaders/glyph_atlas.vert
+++ b/impeller/entity/shaders/glyph_atlas.vert
@@ -26,7 +26,8 @@ void main() {
   gl_Position = IPPositionForGlyphPosition(
       frame_info.mvp, unit_position, destination_position, destination_size);
   v_unit_position = unit_position;
-  v_source_position = source_position;
+  // Pixel snap the source (sampling) start position.
+  v_source_position = round(source_position);
   v_source_glyph_size = source_glyph_size;
   v_has_color = has_color;
 }


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/118613.

* Remove residual position offsets. These were used to help mitigate the infamous glyph overlap problem, which has since been solved.
* Always pixel snap the source position.
* Switch from linear sampling to nearest sampling.


Before (top), after (bottom):
![Screenshot 2023-01-24 at 12 21 11 PM](https://user-images.githubusercontent.com/919017/214402479-7320e57d-6b84-4347-9435-697eaf3d4d10.png)

Before:
![Screen Shot 2023-01-24 at 12 14 44 PM](https://user-images.githubusercontent.com/919017/214402720-c8354897-6e59-4612-8918-6a03520a195a.png)

After:
![Screen Shot 2023-01-24 at 12 17 31 PM](https://user-images.githubusercontent.com/919017/214402753-d93153d9-3d50-47a1-90d9-1bacb41eb7a2.png)

