### PR TITLE
[Impeller] Make text glyph offsets respect the current transform

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -18,6 +18,7 @@
 #include "impeller/entity/contents/scene_contents.h"
 #include "impeller/entity/contents/tiled_texture_contents.h"
 #include "impeller/geometry/color.h"
+#include "impeller/geometry/constants.h"
 #include "impeller/geometry/geometry_unittests.h"
 #include "impeller/geometry/matrix.h"
 #include "impeller/geometry/path_builder.h"
@@ -1179,6 +1180,20 @@ TEST_P(AiksTest, CanRenderTextOutsideBoundaries) {
     }
     canvas.Restore();
   }
+
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
+TEST_P(AiksTest, TextRotated) {
+  Canvas canvas;
+  canvas.Transform(Matrix(0.5, -0.3, 0, -0.002,  //
+                          0, 1, 0, 0,            //
+                          0, 0, 0.3, 0,          //
+                          100, 100, 0, 1.3));
+
+  ASSERT_TRUE(RenderTextInCanvas(
+      GetContext(), canvas, "the quick brown fox jumped over the lazy dog!.?",
+      "Roboto-Regular.ttf"));
 
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }

--- a/impeller/compiler/shader_lib/impeller/transform.glsl
+++ b/impeller/compiler/shader_lib/impeller/transform.glsl
@@ -15,14 +15,15 @@ vec2 IPVec2TransformPosition(mat4 matrix, vec2 point) {
 // atlas.
 vec4 IPPositionForGlyphPosition(mat4 mvp,
                                 vec2 unit_position,
-                                vec2 glyph_position,
-                                vec2 glyph_size) {
-  vec4 translate =
-      mvp[0] * glyph_position.x + mvp[1] * glyph_position.y + mvp[3];
-  mat4 translated_mvp =
-      mat4(mvp[0], mvp[1], mvp[2], vec4(translate.xyz, mvp[3].w));
-  return translated_mvp * vec4(unit_position.x * glyph_size.x,
-                               unit_position.y * glyph_size.y, 0.0, 1.0);
+                                vec2 destination_position,
+                                vec2 destination_size) {
+  mat4 translation = mat4(1, 0, 0, 0,  //
+                          0, 1, 0, 0,  //
+                          0, 0, 1, 0,  //
+                          destination_position.xy, 0, 1);
+  return mvp * translation *
+         vec4(unit_position.x * destination_size.x,
+              unit_position.y * destination_size.y, 0.0, 1.0);
 }
 
 #endif


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/117428.

Whoops, forgot to account for the Z basis.

Before:
![Screen Shot 2023-01-24 at 7 50 16 PM](https://user-images.githubusercontent.com/919017/214486347-05cdcc71-203e-494c-a4b0-18a04013a73b.png)
![Screenshot 2023-01-24 at 9 14 09 PM](https://user-images.githubusercontent.com/919017/214486384-09f69f2a-3e5c-482f-a4c9-2e715c3c833e.png)


After:
![Screen Shot 2023-01-24 at 7 48 22 PM](https://user-images.githubusercontent.com/919017/214486344-8ec76057-b3fe-4746-98c9-07d494f6de53.png)
![Screenshot 2023-01-24 at 9 13 03 PM](https://user-images.githubusercontent.com/919017/214486369-268bb8d8-28f8-41b2-9ab5-461868c5445b.png)
