### PR TITLE
[Impeller] Use the start/end tangent of contours to compute stroke contour cap normals

### DIFF
--- a/impeller/display_list/display_list_unittests.cc
+++ b/impeller/display_list/display_list_unittests.cc
@@ -109,11 +109,13 @@ TEST_P(DisplayListTest, CanDrawArc) {
   auto callback = [&]() {
     static float start_angle = 45;
     static float sweep_angle = 270;
+    static float stroke_width = 10;
     static bool use_center = true;
 
     ImGui::Begin("Controls", nullptr, ImGuiWindowFlags_AlwaysAutoResize);
     ImGui::SliderFloat("Start angle", &start_angle, -360, 360);
     ImGui::SliderFloat("Sweep angle", &sweep_angle, -360, 360);
+    ImGui::SliderFloat("Stroke width", &stroke_width, 0, 100);
     ImGui::Checkbox("Use center", &use_center);
     ImGui::End();
 
@@ -125,7 +127,7 @@ TEST_P(DisplayListTest, CanDrawArc) {
     Vector2 scale = GetContentScale();
     builder.scale(scale.x, scale.y);
     builder.setStyle(flutter::DlDrawStyle::kStroke);
-    builder.setStrokeCap(flutter::DlStrokeCap::kRound);
+    builder.setStrokeCap(flutter::DlStrokeCap::kButt);
     builder.setStrokeJoin(flutter::DlStrokeJoin::kMiter);
     builder.setStrokeMiter(10);
     auto rect = SkRect::MakeLTRB(p1.x, p1.y, p2.x, p2.y);
@@ -133,7 +135,7 @@ TEST_P(DisplayListTest, CanDrawArc) {
     builder.setStrokeWidth(2);
     builder.drawRect(rect);
     builder.setColor(SK_ColorRED);
-    builder.setStrokeWidth(10);
+    builder.setStrokeWidth(stroke_width);
     builder.drawArc(rect, start_angle, sweep_angle, use_center);
 
     return builder.Build();

--- a/impeller/geometry/path.cc
+++ b/impeller/geometry/path.cc
@@ -242,18 +242,55 @@ Path::Polyline Path::CreatePolyline(Scalar tolerance) const {
     }
   };
 
+  auto get_path_component =
+      [this](size_t component_i) -> std::optional<const PathComponent*> {
+    if (component_i >= components_.size()) {
+      return std::nullopt;
+    }
+    const auto& component = components_[component_i];
+    switch (component.type) {
+      case ComponentType::kLinear:
+        return &linears_[component.index];
+      case ComponentType::kQuadratic:
+        return &quads_[component.index];
+      case ComponentType::kCubic:
+        return &cubics_[component.index];
+      case ComponentType::kContour:
+        return std::nullopt;
+    }
+  };
+
+  std::optional<const PathComponent*> previous_path_component;
+  auto end_contour = [&polyline, &previous_path_component]() {
+    // Whenever a contour has ended, extract the exact end direction from the
+    // last component.
+    if (polyline.contours.empty()) {
+      return;
+    }
+    if (!previous_path_component.has_value()) {
+      return;
+    }
+    auto& contour = polyline.contours.back();
+    contour.end_direction =
+        previous_path_component.value()->GetEndDirection().value_or(
+            Vector2(0, 1));
+  };
+
   for (size_t component_i = 0; component_i < components_.size();
        component_i++) {
     const auto& component = components_[component_i];
     switch (component.type) {
       case ComponentType::kLinear:
         collect_points(linears_[component.index].CreatePolyline());
+        previous_path_component = &linears_[component.index];
         break;
       case ComponentType::kQuadratic:
         collect_points(quads_[component.index].CreatePolyline(tolerance));
+        previous_path_component = &quads_[component.index];
         break;
       case ComponentType::kCubic:
         collect_points(cubics_[component.index].CreatePolyline(tolerance));
+        previous_path_component = &cubics_[component.index];
         break;
       case ComponentType::kContour:
         if (component_i == components_.size() - 1) {
@@ -261,13 +298,25 @@ Path::Polyline Path::CreatePolyline(Scalar tolerance) const {
           // contour, so skip it.
           continue;
         }
+        end_contour();
+
+        Vector2 start_direction(0, -1);
+        auto first_component = get_path_component(component_i + 1);
+        if (first_component.has_value()) {
+          start_direction =
+              first_component.value()->GetStartDirection().value_or(
+                  Vector2(0, -1));
+        }
+
         const auto& contour = contours_[component.index];
         polyline.contours.push_back({.start_index = polyline.points.size(),
-                                     .is_closed = contour.is_closed});
+                                     .is_closed = contour.is_closed,
+                                     .start_direction = start_direction});
         previous_contour_point = std::nullopt;
         collect_points({contour.destination});
         break;
     }
+    end_contour();
   }
   return polyline;
 }

--- a/impeller/geometry/path.h
+++ b/impeller/geometry/path.h
@@ -49,6 +49,11 @@ class Path {
     /// Denotes whether the last point of this contour is connected to the first
     /// point of this contour or not.
     bool is_closed;
+
+    /// The direction of the contour's start cap.
+    Vector2 start_direction;
+    /// The direction of the contour's end cap.
+    Vector2 end_direction;
   };
 
   /// One or more contours represented as a series of points and indices in

--- a/impeller/geometry/path_component.cc
+++ b/impeller/geometry/path_component.cc
@@ -8,6 +8,8 @@
 
 namespace impeller {
 
+PathComponent::~PathComponent() = default;
+
 /*
  *  Based on: https://en.wikipedia.org/wiki/B%C3%A9zier_curve#Specific_cases
  */
@@ -65,6 +67,14 @@ std::vector<Point> LinearPathComponent::CreatePolyline() const {
 
 std::vector<Point> LinearPathComponent::Extrema() const {
   return {p1, p2};
+}
+
+std::optional<Vector2> LinearPathComponent::GetStartDirection() const {
+  return (p1 - p2).Normalize();
+}
+
+std::optional<Vector2> LinearPathComponent::GetEndDirection() const {
+  return (p2 - p1).Normalize();
 }
 
 Point QuadraticPathComponent::Solve(Scalar time) const {
@@ -137,6 +147,14 @@ void QuadraticPathComponent::FillPointsForPolyline(std::vector<Point>& points,
 std::vector<Point> QuadraticPathComponent::Extrema() const {
   CubicPathComponent elevated(*this);
   return elevated.Extrema();
+}
+
+std::optional<Vector2> QuadraticPathComponent::GetStartDirection() const {
+  return (p1 - cp).Normalize();
+}
+
+std::optional<Vector2> QuadraticPathComponent::GetEndDirection() const {
+  return (p2 - cp).Normalize();
 }
 
 Point CubicPathComponent::Solve(Scalar time) const {
@@ -281,6 +299,14 @@ std::vector<Point> CubicPathComponent::Extrema() const {
   }
 
   return points;
+}
+
+std::optional<Vector2> CubicPathComponent::GetStartDirection() const {
+  return (p1 - cp1).Normalize();
+}
+
+std::optional<Vector2> CubicPathComponent::GetEndDirection() const {
+  return (p2 - cp2).Normalize();
 }
 
 }  // namespace impeller

--- a/impeller/geometry/path_component.h
+++ b/impeller/geometry/path_component.h
@@ -22,7 +22,14 @@ namespace impeller {
 // points for the given scale.
 static constexpr Scalar kDefaultCurveTolerance = .1f;
 
-struct LinearPathComponent {
+struct PathComponent {
+  virtual ~PathComponent();
+
+  virtual std::optional<Vector2> GetStartDirection() const = 0;
+  virtual std::optional<Vector2> GetEndDirection() const = 0;
+};
+
+struct LinearPathComponent : public PathComponent {
   Point p1;
   Point p2;
 
@@ -39,9 +46,13 @@ struct LinearPathComponent {
   bool operator==(const LinearPathComponent& other) const {
     return p1 == other.p1 && p2 == other.p2;
   }
+
+  std::optional<Vector2> GetStartDirection() const override;
+
+  std::optional<Vector2> GetEndDirection() const override;
 };
 
-struct QuadraticPathComponent {
+struct QuadraticPathComponent : public PathComponent {
   Point p1;
   Point cp;
   Point p2;
@@ -76,9 +87,13 @@ struct QuadraticPathComponent {
   bool operator==(const QuadraticPathComponent& other) const {
     return p1 == other.p1 && cp == other.cp && p2 == other.p2;
   }
+
+  std::optional<Vector2> GetStartDirection() const override;
+
+  std::optional<Vector2> GetEndDirection() const override;
 };
 
-struct CubicPathComponent {
+struct CubicPathComponent : public PathComponent {
   Point p1;
   Point cp1;
   Point cp2;
@@ -117,6 +132,10 @@ struct CubicPathComponent {
     return p1 == other.p1 && cp1 == other.cp1 && cp2 == other.cp2 &&
            p2 == other.p2;
   }
+
+  std::optional<Vector2> GetStartDirection() const override;
+
+  std::optional<Vector2> GetEndDirection() const override;
 
  private:
   QuadraticPathComponent Lower() const;


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/118945.

* Instead of using the direction from/to the start/end points of the contour for a cap normal, use the curve's analytical start/end tangent for perfect results.
* Append points to draw the `Cap::kButt` cap, since it may no longer align perfectly with the last line segment direction.
* This also fixes similar slightly wrong results for closed path shapes such as ovals when using `Cap::kButt`.

Before:

https://user-images.githubusercontent.com/919017/214541644-6f8b0414-4c50-4d50-aafe-1b100dace66e.mov

After:

https://user-images.githubusercontent.com/919017/214541675-207324f2-af59-4c21-bc14-68c720bfd0c8.mov

