### PR TITLE
Only build analyze_snapshot on Linux host

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -82,9 +82,6 @@ group("flutter") {
         # gen_snapshot for the host and not the target.
         "//third_party/dart/runtime/bin:gen_snapshot",
 
-        # Built alongside gen_snapshot for 64 bit targets
-        "//third_party/dart/runtime/bin:analyze_snapshot",
-
         # Impeller artifacts - compiler and libtessellator
         "//flutter/impeller/compiler:impellerc",
         "//flutter/impeller/tessellator:tessellator_shared",
@@ -92,6 +89,13 @@ group("flutter") {
         # path_ops
         "//flutter/tools/path_ops",
       ]
+
+      if (host_os == "linux") {
+        public_deps += [
+          # Built alongside gen_snapshot for 64 bit targets
+          "//third_party/dart/runtime/bin:analyze_snapshot",
+        ]
+      }
 
       if (full_dart_sdk) {
         public_deps += [ "//flutter/web_sdk" ]

--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -37,7 +37,7 @@ group("generate_snapshot_bins") {
   }
 
   # Build analyze_snapshot for 64-bit target CPUs.
-  if (target_cpu == "x64" || target_cpu == "arm64") {
+  if (host_os == "linux" && (target_cpu == "x64" || target_cpu == "arm64")) {
     deps +=
         [ "//third_party/dart/runtime/bin:analyze_snapshot($host_toolchain)" ]
   }

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -667,7 +667,7 @@ if (target_cpu != "x86") {
   }
 }
 
-if (target_cpu == "x64" || target_cpu == "arm64") {
+if (host_os == "linux" && (target_cpu == "x64" || target_cpu == "arm64")) {
   zip_bundle("analyze_snapshot") {
     deps =
         [ "//third_party/dart/runtime/bin:analyze_snapshot($host_toolchain)" ]


### PR DESCRIPTION
To unblock the Dart SDK -> Engine roll.
