### PR TITLE
Reland "[macOS] Formalize FlutterViewController's initialization flow, and prohibit replacing"

### DIFF
--- a/shell/platform/darwin/macos/framework/Headers/FlutterEngine.h
+++ b/shell/platform/darwin/macos/framework/Headers/FlutterEngine.h
@@ -7,6 +7,8 @@
 
 #import <Foundation/Foundation.h>
 
+#include <stdint.h>
+
 #import "FlutterBinaryMessenger.h"
 #import "FlutterDartProject.h"
 #import "FlutterMacros.h"
@@ -14,6 +16,17 @@
 #import "FlutterTexture.h"
 
 // TODO: Merge this file with the iOS FlutterEngine.h.
+
+/**
+ * The view ID for APIs that don't support multi-view.
+ *
+ * Some single-view APIs will eventually be replaced by their multi-view
+ * variant. During the deprecation period, the single-view APIs will coexist with
+ * and work with the multi-view APIs as if the other views don't exist.  For
+ * backward compatibility, single-view APIs will always operate the view with
+ * this ID. Also, the first view assigned to the engine will also have this ID.
+ */
+extern const uint64_t kFlutterDefaultViewId;
 
 @class FlutterViewController;
 
@@ -67,6 +80,15 @@ FLUTTER_DARWIN_EXPORT
  *
  * The default view always has ID kFlutterDefaultViewId, and is the view
  * operated by the APIs that do not have a view ID specified.
+ *
+ * Setting this field from nil to a non-nil view controller also updates
+ * the view controller's engine and ID.
+ *
+ * Setting this field from non-nil to nil will terminate the engine if
+ * allowHeadlessExecution is NO.
+ *
+ * Setting this field from non-nil to a different non-nil FlutterViewController
+ * is prohibited and will throw an assertion error.
  */
 @property(nonatomic, nullable, weak) FlutterViewController* viewController;
 

--- a/shell/platform/darwin/macos/framework/Headers/FlutterViewController.h
+++ b/shell/platform/darwin/macos/framework/Headers/FlutterViewController.h
@@ -25,6 +25,25 @@ typedef NS_ENUM(NSInteger, FlutterMouseTrackingMode) {
 
 /**
  * Controls a view that displays Flutter content and manages input.
+ *
+ * A FlutterViewController works with a FlutterEngine. Upon creation, the view
+ * controller is always added to an engine, either a given engine, or it implicitly
+ * creates an engine and add itself to that engine.
+ *
+ * The FlutterEngine assigns each view controller attached to it a unique ID.
+ * Each view controller corresponds to a view, and the ID is used by the framework
+ * to specify which view to operate.
+ *
+ * A FlutterViewController can also be unattached to an engine after it is manually
+ * unset from the engine, or transiently during the initialization process.
+ * An unattached view controller is invalid. Whether the view controller is attached
+ * can be queried using FlutterViewController#attached.
+ *
+ * The FlutterViewController strongly references the FlutterEngine, while
+ * the engine weakly the view controller. When a FlutterViewController is deallocated,
+ * it automatically removes itself from its attached engine. When a FlutterEngine
+ * has no FlutterViewControllers attached, it might shut down itself or not depending
+ * on its configuration.
  */
 FLUTTER_DARWIN_EXPORT
 @interface FlutterViewController : NSViewController <FlutterPluginRegistry>
@@ -35,6 +54,16 @@ FLUTTER_DARWIN_EXPORT
 @property(nonatomic, nonnull, readonly) FlutterEngine* engine;
 
 /**
+ * The identifier for this view controller.
+ *
+ * The ID is assigned by FlutterEngine when the view controller is attached.
+ *
+ * If the view controller is unattached (see FlutterViewController#attached),
+ * reading this property throws an assertion.
+ */
+@property(nonatomic, readonly) uint64_t id;
+
+/**
  * The style of mouse tracking to use for the view. Defaults to
  * FlutterMouseTrackingModeInKeyWindow.
  */
@@ -42,6 +71,12 @@ FLUTTER_DARWIN_EXPORT
 
 /**
  * Initializes a controller that will run the given project.
+ *
+ * In this initializer, this controller creates an engine, and is attached to
+ * that engine as the default controller. In this way, this controller can not
+ * be set to other engines. This initializer is suitable for the first Flutter
+ * view controller of the app. To use the controller with an existing engine,
+ * use initWithEngine:nibName:bundle: instead.
  *
  * @param project The project to run in this view controller. If nil, a default `FlutterDartProject`
  *                will be used.
@@ -56,7 +91,8 @@ FLUTTER_DARWIN_EXPORT
 /**
  * Initializes this FlutterViewController with the specified `FlutterEngine`.
  *
- * The initialized viewcontroller will attach itself to the engine as part of this process.
+ * This initializer is suitable for both the first Flutter view controller and
+ * the following ones of the app.
  *
  * @param engine The `FlutterEngine` instance to attach to. Cannot be nil.
  * @param nibName The NIB name to initialize this controller with.
@@ -65,6 +101,12 @@ FLUTTER_DARWIN_EXPORT
 - (nonnull instancetype)initWithEngine:(nonnull FlutterEngine*)engine
                                nibName:(nullable NSString*)nibName
                                 bundle:(nullable NSBundle*)nibBundle NS_DESIGNATED_INITIALIZER;
+
+/**
+ * Return YES if the view controller is attached to an engine.
+ */
+- (BOOL)attached;
+
 /**
  * Invoked by the engine right before the engine is restarted.
  *

--- a/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacTest.mm
@@ -51,26 +51,22 @@ namespace flutter::testing {
 namespace {
 
 // Returns an engine configured for the text fixture resource configuration.
-FlutterEngine* CreateTestEngine() {
+FlutterViewController* CreateTestViewController() {
   NSString* fixtures = @(testing::GetFixturesPath());
   FlutterDartProject* project = [[FlutterDartProject alloc]
       initWithAssetsPath:fixtures
              ICUDataPath:[fixtures stringByAppendingString:@"/icudtl.dat"]];
-  return [[AccessibilityBridgeTestEngine alloc] initWithName:@"test"
-                                                     project:project
-                                      allowHeadlessExecution:true];
+  FlutterEngine* engine = [[AccessibilityBridgeTestEngine alloc] initWithName:@"test"
+                                                                      project:project
+                                                       allowHeadlessExecution:true];
+  return [[FlutterViewController alloc] initWithEngine:engine nibName:nil bundle:nil];
 }
 }  // namespace
 
 TEST(AccessibilityBridgeMacTest, sendsAccessibilityCreateNotificationToWindowOfFlutterView) {
-  FlutterEngine* engine = CreateTestEngine();
-  NSString* fixtures = @(testing::GetFixturesPath());
-  FlutterDartProject* project = [[FlutterDartProject alloc]
-      initWithAssetsPath:fixtures
-             ICUDataPath:[fixtures stringByAppendingString:@"/icudtl.dat"]];
-  FlutterViewController* viewController = [[FlutterViewController alloc] initWithProject:project];
+  FlutterViewController* viewController = CreateTestViewController();
+  FlutterEngine* engine = viewController.engine;
   [viewController loadView];
-  [engine setViewController:viewController];
 
   NSWindow* expectedTarget = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 800, 600)
                                                          styleMask:NSBorderlessWindowMask
@@ -122,14 +118,9 @@ TEST(AccessibilityBridgeMacTest, sendsAccessibilityCreateNotificationToWindowOfF
 }
 
 TEST(AccessibilityBridgeMacTest, doesNotSendAccessibilityCreateNotificationWhenHeadless) {
-  FlutterEngine* engine = CreateTestEngine();
-  NSString* fixtures = @(testing::GetFixturesPath());
-  FlutterDartProject* project = [[FlutterDartProject alloc]
-      initWithAssetsPath:fixtures
-             ICUDataPath:[fixtures stringByAppendingString:@"/icudtl.dat"]];
-  FlutterViewController* viewController = [[FlutterViewController alloc] initWithProject:project];
+  FlutterViewController* viewController = CreateTestViewController();
+  FlutterEngine* engine = viewController.engine;
   [viewController loadView];
-  [engine setViewController:viewController];
   // Setting up bridge so that the AccessibilityBridgeMacDelegateSpy
   // can query semantics information from.
   engine.semanticsEnabled = YES;
@@ -173,15 +164,9 @@ TEST(AccessibilityBridgeMacTest, doesNotSendAccessibilityCreateNotificationWhenH
 }
 
 TEST(AccessibilityBridgeMacTest, doesNotSendAccessibilityCreateNotificationWhenNoWindow) {
-  FlutterEngine* engine = CreateTestEngine();
-  // Create a view controller without attaching it to a window.
-  NSString* fixtures = @(testing::GetFixturesPath());
-  FlutterDartProject* project = [[FlutterDartProject alloc]
-      initWithAssetsPath:fixtures
-             ICUDataPath:[fixtures stringByAppendingString:@"/icudtl.dat"]];
-  FlutterViewController* viewController = [[FlutterViewController alloc] initWithProject:project];
+  FlutterViewController* viewController = CreateTestViewController();
+  FlutterEngine* engine = viewController.engine;
   [viewController loadView];
-  [engine setViewController:viewController];
 
   // Setting up bridge so that the AccessibilityBridgeMacDelegateSpy
   // can query semantics information from.

--- a/shell/platform/darwin/macos/framework/Source/FlutterCompositor.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterCompositor.h
@@ -10,7 +10,6 @@
 
 #include "flutter/fml/macros.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewController.h"
-#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterView.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterViewProvider.h"
 #include "flutter/shell/platform/embedder/embedder.h"
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
@@ -134,14 +134,11 @@ TEST_F(FlutterEngineTest, BackgroundIsBlack) {
   EXPECT_TRUE([engine runWithEntrypoint:@"backgroundTest"]);
   EXPECT_TRUE(engine.running);
 
-  NSString* fixtures = @(flutter::testing::GetFixturesPath());
-  FlutterDartProject* project = [[FlutterDartProject alloc]
-      initWithAssetsPath:fixtures
-             ICUDataPath:[fixtures stringByAppendingString:@"/icudtl.dat"]];
-  FlutterViewController* viewController = [[FlutterViewController alloc] initWithProject:project];
+  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engine
+                                                                                nibName:nil
+                                                                                 bundle:nil];
   [viewController loadView];
   viewController.flutterView.frame = CGRectMake(0, 0, 800, 600);
-  [engine setViewController:viewController];
 
   latch.Wait();
 }
@@ -166,14 +163,11 @@ TEST_F(FlutterEngineTest, CanOverrideBackgroundColor) {
   EXPECT_TRUE([engine runWithEntrypoint:@"backgroundTest"]);
   EXPECT_TRUE(engine.running);
 
-  NSString* fixtures = @(flutter::testing::GetFixturesPath());
-  FlutterDartProject* project = [[FlutterDartProject alloc]
-      initWithAssetsPath:fixtures
-             ICUDataPath:[fixtures stringByAppendingString:@"/icudtl.dat"]];
-  FlutterViewController* viewController = [[FlutterViewController alloc] initWithProject:project];
+  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engine
+                                                                                nibName:nil
+                                                                                 bundle:nil];
   [viewController loadView];
   viewController.flutterView.frame = CGRectMake(0, 0, 800, 600);
-  [engine setViewController:viewController];
   viewController.flutterView.backgroundColor = [NSColor whiteColor];
 
   latch.Wait();
@@ -193,13 +187,10 @@ TEST_F(FlutterEngineTest, CanToggleAccessibility) {
       }));
   EXPECT_TRUE([engine runWithEntrypoint:@"main"]);
   // Set up view controller.
-  NSString* fixtures = @(testing::GetFixturesPath());
-  FlutterDartProject* project = [[FlutterDartProject alloc]
-      initWithAssetsPath:fixtures
-             ICUDataPath:[fixtures stringByAppendingString:@"/icudtl.dat"]];
-  FlutterViewController* viewController = [[FlutterViewController alloc] initWithProject:project];
+  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engine
+                                                                                nibName:nil
+                                                                                 bundle:nil];
   [viewController loadView];
-  [engine setViewController:viewController];
   // Enable the semantics.
   bool enabled_called = false;
   engine.embedderAPI.UpdateSemanticsEnabled =
@@ -337,6 +328,8 @@ TEST_F(FlutterEngineTest, CanToggleAccessibilityWhenHeadless) {
   FlutterSemanticsNode nodes[] = {root, child1};
   update.nodes = nodes;
   update.custom_actions_count = 0;
+  // This call updates semantics for the default view, which does not exist,
+  // and therefore this call is invalid. But the engine should not crash.
   update_semantics_callback(&update, (__bridge void*)engine);
 
   // No crashes.
@@ -353,93 +346,6 @@ TEST_F(FlutterEngineTest, CanToggleAccessibilityWhenHeadless) {
   EXPECT_FALSE(semanticsEnabled);
   // Still no crashes
   EXPECT_EQ(engine.viewController, nil);
-}
-
-TEST_F(FlutterEngineTest, ResetsAccessibilityBridgeWhenSetsNewViewController) {
-  FlutterEngine* engine = GetFlutterEngine();
-  // Capture the update callbacks before the embedder API initializes.
-  auto original_init = engine.embedderAPI.Initialize;
-  std::function<void(const FlutterSemanticsUpdate*, void*)> update_semantics_callback;
-  engine.embedderAPI.Initialize = MOCK_ENGINE_PROC(
-      Initialize, ([&update_semantics_callback, &original_init](
-                       size_t version, const FlutterRendererConfig* config,
-                       const FlutterProjectArgs* args, void* user_data, auto engine_out) {
-        update_semantics_callback = args->update_semantics_callback;
-        return original_init(version, config, args, user_data, engine_out);
-      }));
-  EXPECT_TRUE([engine runWithEntrypoint:@"main"]);
-  // Set up view controller.
-  NSString* fixtures = @(testing::GetFixturesPath());
-  FlutterDartProject* project = [[FlutterDartProject alloc]
-      initWithAssetsPath:fixtures
-             ICUDataPath:[fixtures stringByAppendingString:@"/icudtl.dat"]];
-  FlutterViewController* viewController = [[FlutterViewController alloc] initWithProject:project];
-  [viewController loadView];
-  [engine setViewController:viewController];
-  // Enable the semantics.
-  bool enabled_called = false;
-  engine.embedderAPI.UpdateSemanticsEnabled =
-      MOCK_ENGINE_PROC(UpdateSemanticsEnabled, ([&enabled_called](auto engine, bool enabled) {
-                         enabled_called = enabled;
-                         return kSuccess;
-                       }));
-  engine.semanticsEnabled = YES;
-  EXPECT_TRUE(enabled_called);
-  // Send flutter semantics updates.
-  FlutterSemanticsNode root;
-  root.id = 0;
-  root.flags = static_cast<FlutterSemanticsFlag>(0);
-  root.actions = static_cast<FlutterSemanticsAction>(0);
-  root.text_selection_base = -1;
-  root.text_selection_extent = -1;
-  root.label = "root";
-  root.hint = "";
-  root.value = "";
-  root.increased_value = "";
-  root.decreased_value = "";
-  root.tooltip = "";
-  root.child_count = 1;
-  int32_t children[] = {1};
-  root.children_in_traversal_order = children;
-  root.custom_accessibility_actions_count = 0;
-
-  FlutterSemanticsNode child1;
-  child1.id = 1;
-  child1.flags = static_cast<FlutterSemanticsFlag>(0);
-  child1.actions = static_cast<FlutterSemanticsAction>(0);
-  child1.text_selection_base = -1;
-  child1.text_selection_extent = -1;
-  child1.label = "child 1";
-  child1.hint = "";
-  child1.value = "";
-  child1.increased_value = "";
-  child1.decreased_value = "";
-  child1.tooltip = "";
-  child1.child_count = 0;
-  child1.custom_accessibility_actions_count = 0;
-
-  FlutterSemanticsUpdate update;
-  update.nodes_count = 2;
-  FlutterSemanticsNode nodes[] = {root, child1};
-  update.nodes = nodes;
-  update.custom_actions_count = 0;
-  update_semantics_callback(&update, (__bridge void*)engine);
-
-  auto native_root = engine.accessibilityBridge.lock()->GetFlutterPlatformNodeDelegateFromID(0);
-  EXPECT_FALSE(native_root.expired());
-
-  // Set up a new view controller.
-  FlutterViewController* newViewController =
-      [[FlutterViewController alloc] initWithProject:project];
-  [newViewController loadView];
-  [engine setViewController:newViewController];
-
-  auto new_native_root = engine.accessibilityBridge.lock()->GetFlutterPlatformNodeDelegateFromID(0);
-  // The tree is recreated and the old tree will be destroyed.
-  EXPECT_FALSE(new_native_root.expired());
-  EXPECT_TRUE(native_root.expired());
-
-  [engine setViewController:nil];
 }
 
 TEST_F(FlutterEngineTest, NativeCallbacks) {
@@ -465,10 +371,11 @@ TEST(FlutterEngine, Compositor) {
              ICUDataPath:[fixtures stringByAppendingString:@"/icudtl.dat"]];
   FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"test" project:project];
 
-  FlutterViewController* viewController = [[FlutterViewController alloc] initWithProject:project];
+  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engine
+                                                                                nibName:nil
+                                                                                 bundle:nil];
   [viewController loadView];
   viewController.flutterView.frame = CGRectMake(0, 0, 800, 600);
-  [engine setViewController:viewController];
 
   EXPECT_TRUE([engine runWithEntrypoint:@"canCompositePlatformViews"]);
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm
@@ -19,18 +19,19 @@
 namespace flutter::testing {
 
 namespace {
-// Returns an engine configured for the text fixture resource configuration.
-FlutterEngine* CreateTestEngine() {
+// Returns a view controller configured for the text fixture resource configuration.
+FlutterViewController* CreateTestViewController() {
   NSString* fixtures = @(testing::GetFixturesPath());
   FlutterDartProject* project = [[FlutterDartProject alloc]
       initWithAssetsPath:fixtures
              ICUDataPath:[fixtures stringByAppendingString:@"/icudtl.dat"]];
-  return [[FlutterEngine alloc] initWithName:@"test" project:project allowHeadlessExecution:true];
+  return [[FlutterViewController alloc] initWithProject:project];
 }
 }  // namespace
 
 TEST(FlutterPlatformNodeDelegateMac, Basics) {
-  FlutterEngine* engine = CreateTestEngine();
+  FlutterViewController* viewController = CreateTestViewController();
+  FlutterEngine* engine = viewController.engine;
   engine.semanticsEnabled = YES;
   auto bridge = engine.accessibilityBridge.lock();
   // Initialize ax node data.
@@ -65,7 +66,8 @@ TEST(FlutterPlatformNodeDelegateMac, Basics) {
 }
 
 TEST(FlutterPlatformNodeDelegateMac, SelectableTextHasCorrectSemantics) {
-  FlutterEngine* engine = CreateTestEngine();
+  FlutterViewController* viewController = CreateTestViewController();
+  FlutterEngine* engine = viewController.engine;
   engine.semanticsEnabled = YES;
   auto bridge = engine.accessibilityBridge.lock();
   // Initialize ax node data.
@@ -106,7 +108,8 @@ TEST(FlutterPlatformNodeDelegateMac, SelectableTextHasCorrectSemantics) {
 }
 
 TEST(FlutterPlatformNodeDelegateMac, SelectableTextWithoutSelectionReturnZeroRange) {
-  FlutterEngine* engine = CreateTestEngine();
+  FlutterViewController* viewController = CreateTestViewController();
+  FlutterEngine* engine = viewController.engine;
   engine.semanticsEnabled = YES;
   auto bridge = engine.accessibilityBridge.lock();
   // Initialize ax node data.
@@ -144,15 +147,8 @@ TEST(FlutterPlatformNodeDelegateMac, SelectableTextWithoutSelectionReturnZeroRan
 // NOLINTBEGIN(clang-analyzer-core.StackAddressEscape)
 
 TEST(FlutterPlatformNodeDelegateMac, CanPerformAction) {
-  FlutterEngine* engine = CreateTestEngine();
-
-  // Set up view controller.
-  NSString* fixtures = @(testing::GetFixturesPath());
-  FlutterDartProject* project = [[FlutterDartProject alloc]
-      initWithAssetsPath:fixtures
-             ICUDataPath:[fixtures stringByAppendingString:@"/icudtl.dat"]];
-  FlutterViewController* viewController = [[FlutterViewController alloc] initWithProject:project];
-  [engine setViewController:viewController];
+  FlutterViewController* viewController = CreateTestViewController();
+  FlutterEngine* engine = viewController.engine;
 
   // Attach the view to a NSWindow.
   NSWindow* window = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 800, 600)
@@ -222,14 +218,9 @@ TEST(FlutterPlatformNodeDelegateMac, CanPerformAction) {
 // NOLINTEND(clang-analyzer-core.StackAddressEscape)
 
 TEST(FlutterPlatformNodeDelegateMac, TextFieldUsesFlutterTextField) {
-  FlutterEngine* engine = CreateTestEngine();
-  NSString* fixtures = @(testing::GetFixturesPath());
-  FlutterDartProject* project = [[FlutterDartProject alloc]
-      initWithAssetsPath:fixtures
-             ICUDataPath:[fixtures stringByAppendingString:@"/icudtl.dat"]];
-  FlutterViewController* viewController = [[FlutterViewController alloc] initWithProject:project];
+  FlutterViewController* viewController = CreateTestViewController();
+  FlutterEngine* engine = viewController.engine;
   [viewController loadView];
-  [engine setViewController:viewController];
 
   // Unit test localization is unnecessary.
   // NOLINTNEXTLINE(clang-analyzer-optin.osx.cocoa.localizability.NonLocalizedStringChecker)

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
@@ -4,6 +4,7 @@
 
 #import "flutter/shell/platform/darwin/macos/framework/Headers/FlutterViewController.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterDartProject_Internal.h"
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterEngineTestUtils.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterTextInputSemanticsObject.h"
@@ -37,6 +38,16 @@
 - (BOOL)isActive;
 @end
 
+@interface TextInputTestViewController : FlutterViewController
+@end
+
+@implementation TextInputTestViewController
+- (nonnull FlutterView*)createFlutterViewWithMTLDevice:(id<MTLDevice>)device
+                                          commandQueue:(id<MTLCommandQueue>)commandQueue {
+  return OCMClassMock([NSView class]);
+}
+@end
+
 @interface FlutterInputPluginTestObjc : NSObject
 - (bool)testEmptyCompositionRange;
 - (bool)testClearClientDuringComposing;
@@ -45,7 +56,7 @@
 @implementation FlutterInputPluginTestObjc
 
 - (bool)testEmptyCompositionRange {
-  id engineMock = OCMClassMock([FlutterEngine class]);
+  id engineMock = flutter::testing::CreateMockFlutterEngine(@"");
   id binaryMessengerMock = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
   OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
       [engineMock binaryMessenger])
@@ -110,7 +121,7 @@
 }
 
 - (bool)testSetMarkedTextWithSelectionChange {
-  id engineMock = OCMClassMock([FlutterEngine class]);
+  id engineMock = flutter::testing::CreateMockFlutterEngine(@"");
   id binaryMessengerMock = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
   OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
       [engineMock binaryMessenger])
@@ -178,7 +189,7 @@
 }
 
 - (bool)testSetMarkedTextWithReplacementRange {
-  id engineMock = OCMClassMock([FlutterEngine class]);
+  id engineMock = flutter::testing::CreateMockFlutterEngine(@"");
   id binaryMessengerMock = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
   OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
       [engineMock binaryMessenger])
@@ -246,7 +257,7 @@
 }
 
 - (bool)testComposingRegionRemovedByFramework {
-  id engineMock = OCMClassMock([FlutterEngine class]);
+  id engineMock = flutter::testing::CreateMockFlutterEngine(@"");
   id binaryMessengerMock = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
   OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
       [engineMock binaryMessenger])
@@ -324,7 +335,7 @@
 
 - (bool)testClearClientDuringComposing {
   // Set up FlutterTextInputPlugin.
-  id engineMock = OCMClassMock([FlutterEngine class]);
+  id engineMock = flutter::testing::CreateMockFlutterEngine(@"");
   id binaryMessengerMock = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
   OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
       [engineMock binaryMessenger])
@@ -377,26 +388,18 @@
 }
 
 - (bool)testFirstRectForCharacterRange {
-  id engineMock = OCMClassMock([FlutterEngine class]);
+  id engineMock = flutter::testing::CreateMockFlutterEngine(@"");
   id binaryMessengerMock = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
   OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
       [engineMock binaryMessenger])
       .andReturn(binaryMessengerMock);
-  FlutterViewController* controllerMock = OCMClassMock([FlutterViewController class]);
-  OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
-      [controllerMock engine])
-      .andReturn(engineMock);
-
-  id viewMock = OCMClassMock([NSView class]);
+  FlutterViewController* controllerMock =
+      [[TextInputTestViewController alloc] initWithEngine:engineMock nibName:nil bundle:nil];
+  [controllerMock loadView];
+  id viewMock = controllerMock.flutterView;
   OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
       [viewMock bounds])
       .andReturn(NSMakeRect(0, 0, 200, 200));
-  OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
-      controllerMock.viewLoaded)
-      .andReturn(YES);
-  OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
-      [controllerMock flutterView])
-      .andReturn(viewMock);
 
   id windowMock = OCMClassMock([NSWindow class]);
   OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
@@ -453,26 +456,18 @@
 }
 
 - (bool)testFirstRectForCharacterRangeAtInfinity {
-  id engineMock = OCMClassMock([FlutterEngine class]);
+  id engineMock = flutter::testing::CreateMockFlutterEngine(@"");
   id binaryMessengerMock = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
   OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
       [engineMock binaryMessenger])
       .andReturn(binaryMessengerMock);
-  FlutterViewController* controllerMock = OCMClassMock([FlutterViewController class]);
-  OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
-      [controllerMock engine])
-      .andReturn(engineMock);
-
-  id viewMock = OCMClassMock([NSView class]);
+  FlutterViewController* controllerMock =
+      [[TextInputTestViewController alloc] initWithEngine:engineMock nibName:nil bundle:nil];
+  [controllerMock loadView];
+  id viewMock = controllerMock.flutterView;
   OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
       [viewMock bounds])
       .andReturn(NSMakeRect(0, 0, 200, 200));
-  OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
-      controllerMock.viewLoaded)
-      .andReturn(YES);
-  OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
-      [controllerMock flutterView])
-      .andReturn(viewMock);
 
   id windowMock = OCMClassMock([NSWindow class]);
   OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
@@ -515,26 +510,18 @@
 }
 
 - (bool)testFirstRectForCharacterRangeWithEsotericAffineTransform {
-  id engineMock = OCMClassMock([FlutterEngine class]);
+  id engineMock = flutter::testing::CreateMockFlutterEngine(@"");
   id binaryMessengerMock = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
   OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
       [engineMock binaryMessenger])
       .andReturn(binaryMessengerMock);
-  FlutterViewController* controllerMock = OCMClassMock([FlutterViewController class]);
-  OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
-      [controllerMock engine])
-      .andReturn(engineMock);
-
-  id viewMock = OCMClassMock([NSView class]);
+  FlutterViewController* controllerMock =
+      [[TextInputTestViewController alloc] initWithEngine:engineMock nibName:nil bundle:nil];
+  [controllerMock loadView];
+  id viewMock = controllerMock.flutterView;
   OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
       [viewMock bounds])
       .andReturn(NSMakeRect(0, 0, 200, 200));
-  OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
-      controllerMock.viewLoaded)
-      .andReturn(YES);
-  OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
-      [controllerMock flutterView])
-      .andReturn(viewMock);
 
   id windowMock = OCMClassMock([NSWindow class]);
   OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
@@ -595,7 +582,7 @@
 }
 
 - (bool)testSetEditingStateWithTextEditingDelta {
-  id engineMock = OCMClassMock([FlutterEngine class]);
+  id engineMock = flutter::testing::CreateMockFlutterEngine(@"");
   id binaryMessengerMock = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
   OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
       [engineMock binaryMessenger])
@@ -651,7 +638,7 @@
 }
 
 - (bool)testOperationsThatTriggerDelta {
-  id engineMock = OCMClassMock([FlutterEngine class]);
+  id engineMock = flutter::testing::CreateMockFlutterEngine(@"");
   id binaryMessengerMock = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
   OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
       [engineMock binaryMessenger])
@@ -768,7 +755,7 @@
 }
 
 - (bool)testComposingWithDelta {
-  id engineMock = OCMClassMock([FlutterEngine class]);
+  id engineMock = flutter::testing::CreateMockFlutterEngine(@"");
   id binaryMessengerMock = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
   OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
       [engineMock binaryMessenger])
@@ -1005,7 +992,7 @@
 }
 
 - (bool)testComposingWithDeltasWhenSelectionIsActive {
-  id engineMock = OCMClassMock([FlutterEngine class]);
+  id engineMock = flutter::testing::CreateMockFlutterEngine(@"");
   id binaryMessengerMock = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
   OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
       [engineMock binaryMessenger])
@@ -1134,7 +1121,7 @@
 }
 
 - (bool)unhandledKeyEquivalent {
-  id engineMock = OCMClassMock([FlutterEngine class]);
+  id engineMock = flutter::testing::CreateMockFlutterEngine(@"");
   id binaryMessengerMock = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
   OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
       [engineMock binaryMessenger])
@@ -1210,7 +1197,7 @@
 }
 
 - (bool)testLocalTextAndSelectionUpdateAfterDelta {
-  id engineMock = OCMClassMock([FlutterEngine class]);
+  id engineMock = flutter::testing::CreateMockFlutterEngine(@"");
   id binaryMessengerMock = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
   OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
       [engineMock binaryMessenger])
@@ -1271,7 +1258,7 @@
 }
 
 - (bool)testSelectorsAreForwardedToFramework {
-  id engineMock = OCMClassMock([FlutterEngine class]);
+  id engineMock = flutter::testing::CreateMockFlutterEngine(@"");
   id binaryMessengerMock = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
   OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
       [engineMock binaryMessenger])
@@ -1414,13 +1401,10 @@ TEST(FlutterTextInputPluginTest, TestSelectorsAreForwardedToFramework) {
 
 TEST(FlutterTextInputPluginTest, CanWorkWithFlutterTextField) {
   FlutterEngine* engine = CreateTestEngine();
-  NSString* fixtures = @(testing::GetFixturesPath());
-  FlutterDartProject* project = [[FlutterDartProject alloc]
-      initWithAssetsPath:fixtures
-             ICUDataPath:[fixtures stringByAppendingString:@"/icudtl.dat"]];
-  FlutterViewController* viewController = [[FlutterViewController alloc] initWithProject:project];
+  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engine
+                                                                                nibName:nil
+                                                                                 bundle:nil];
   [viewController loadView];
-  [engine setViewController:viewController];
   // Create a NSWindow so that the native text field can become first responder.
   NSWindow* window = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 800, 600)
                                                  styleMask:NSBorderlessWindowMask
@@ -1483,13 +1467,10 @@ TEST(FlutterTextInputPluginTest, CanWorkWithFlutterTextField) {
 
 TEST(FlutterTextInputPluginTest, CanNotBecomeResponderIfNoViewController) {
   FlutterEngine* engine = CreateTestEngine();
-  NSString* fixtures = @(testing::GetFixturesPath());
-  FlutterDartProject* project = [[FlutterDartProject alloc]
-      initWithAssetsPath:fixtures
-             ICUDataPath:[fixtures stringByAppendingString:@"/icudtl.dat"]];
-  FlutterViewController* viewController = [[FlutterViewController alloc] initWithProject:project];
+  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engine
+                                                                                nibName:nil
+                                                                                 bundle:nil];
   [viewController loadView];
-  [engine setViewController:viewController];
   // Creates a NSWindow so that the native text field can become first responder.
   NSWindow* window = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 800, 600)
                                                  styleMask:NSBorderlessWindowMask
@@ -1520,13 +1501,10 @@ TEST(FlutterTextInputPluginTest, CanNotBecomeResponderIfNoViewController) {
 
 TEST(FlutterTextInputPluginTest, IsAddedAndRemovedFromViewHierarchy) {
   FlutterEngine* engine = CreateTestEngine();
-  NSString* fixtures = @(testing::GetFixturesPath());
-  FlutterDartProject* project = [[FlutterDartProject alloc]
-      initWithAssetsPath:fixtures
-             ICUDataPath:[fixtures stringByAppendingString:@"/icudtl.dat"]];
-  FlutterViewController* viewController = [[FlutterViewController alloc] initWithProject:project];
+  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engine
+                                                                                nibName:nil
+                                                                                 bundle:nil];
   [viewController loadView];
-  [engine setViewController:viewController];
 
   NSWindow* window = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 800, 600)
                                                  styleMask:NSBorderlessWindowMask

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputSemanticsObjectTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputSemanticsObjectTest.mm
@@ -28,13 +28,10 @@ FlutterEngine* CreateTestEngine() {
 TEST(FlutterTextInputSemanticsObjectTest, DoesInitialize) {
   FlutterEngine* engine = CreateTestEngine();
   {
-    NSString* fixtures = @(testing::GetFixturesPath());
-    FlutterDartProject* project = [[FlutterDartProject alloc]
-        initWithAssetsPath:fixtures
-               ICUDataPath:[fixtures stringByAppendingString:@"/icudtl.dat"]];
-    FlutterViewController* viewController = [[FlutterViewController alloc] initWithProject:project];
+    FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engine
+                                                                                  nibName:nil
+                                                                                   bundle:nil];
     [viewController loadView];
-    [engine setViewController:viewController];
     // Create a NSWindow so that the native text field can become first responder.
     NSWindow* window = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 800, 600)
                                                    styleMask:NSBorderlessWindowMask

--- a/shell/platform/darwin/macos/framework/Source/FlutterView.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterView.h
@@ -10,17 +10,6 @@
 #include <stdint.h>
 
 /**
- * The view ID for APIs that don't support multi-view.
- *
- * Some single-view APIs will eventually be replaced by their multi-view
- * variant. During the deprecation period, the single-view APIs will coexist with
- * and work with the multi-view APIs as if the other views don't exist.  For
- * backward compatibility, single-view APIs will always operate the view with
- * this ID. Also, the first view assigned to the engine will also have this ID.
- */
-constexpr uint64_t kFlutterDefaultViewId = 0;
-
-/**
  * Listener for view resizing.
  */
 @protocol FlutterViewReshapeListener <NSObject>

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -286,21 +286,34 @@ void OnKeyboardLayoutChanged(CFNotificationCenterRef center,
 @implementation FlutterViewController {
   // The project to run in this controller's engine.
   FlutterDartProject* _project;
+
+  uint64_t _id;
 }
 
+@dynamic id;
 @dynamic view;
 
 /**
  * Performs initialization that's common between the different init paths.
  */
-static void CommonInit(FlutterViewController* controller) {
-  if (!controller->_engine) {
-    controller->_engine = [[FlutterEngine alloc] initWithName:@"io.flutter"
-                                                      project:controller->_project
-                                       allowHeadlessExecution:NO];
+static void CommonInit(FlutterViewController* controller, FlutterEngine* engine) {
+  if (!engine) {
+    engine = [[FlutterEngine alloc] initWithName:@"io.flutter"
+                                         project:controller->_project
+                          allowHeadlessExecution:NO];
   }
+  NSCAssert(controller.engine == nil,
+            @"The FlutterViewController is unexpectedly attached to "
+            @"engine %@ before initialization.",
+            controller.engine);
+  engine.viewController = controller;
+  NSCAssert(controller.engine != nil,
+            @"The FlutterViewController unexpectedly stays unattached after initialization. "
+            @"In unit tests, this is likely because either the FlutterViewController or "
+            @"the FlutterEngine is mocked. Please subclass these classes instead.");
   controller->_mouseTrackingMode = FlutterMouseTrackingModeInKeyWindow;
   controller->_textInputPlugin = [[FlutterTextInputPlugin alloc] initWithViewController:controller];
+  [controller initializeKeyboard];
   // macOS fires this message when changing IMEs.
   CFNotificationCenterRef cfCenter = CFNotificationCenterGetDistributedCenter();
   __weak FlutterViewController* weakSelf = controller;
@@ -313,7 +326,7 @@ static void CommonInit(FlutterViewController* controller) {
   self = [super initWithCoder:coder];
   NSAssert(self, @"Super init cannot be nil");
 
-  CommonInit(self);
+  CommonInit(self, nil);
   return self;
 }
 
@@ -321,7 +334,7 @@ static void CommonInit(FlutterViewController* controller) {
   self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
   NSAssert(self, @"Super init cannot be nil");
 
-  CommonInit(self);
+  CommonInit(self, nil);
   return self;
 }
 
@@ -330,7 +343,7 @@ static void CommonInit(FlutterViewController* controller) {
   NSAssert(self, @"Super init cannot be nil");
 
   _project = project;
-  CommonInit(self);
+  CommonInit(self, nil);
   return self;
 }
 
@@ -346,13 +359,7 @@ static void CommonInit(FlutterViewController* controller) {
 
   self = [super initWithNibName:nibName bundle:nibBundle];
   if (self) {
-    _engine = engine;
-    CommonInit(self);
-    if (engine.running) {
-      [self loadView];
-      engine.viewController = self;
-      [self initializeKeyboard];
-    }
+    CommonInit(self, engine);
   }
 
   return self;
@@ -370,9 +377,7 @@ static void CommonInit(FlutterViewController* controller) {
     NSLog(@"Unable to create FlutterView; no MTLDevice or MTLCommandQueue available.");
     return;
   }
-  flutterView = [[FlutterView alloc] initWithMTLDevice:device
-                                          commandQueue:commandQueue
-                                       reshapeListener:self];
+  flutterView = [self createFlutterViewWithMTLDevice:device commandQueue:commandQueue];
   if (_backgroundColor != nil) {
     [flutterView setBackgroundColor:_backgroundColor];
   }
@@ -423,16 +428,33 @@ static void CommonInit(FlutterViewController* controller) {
   [_flutterView setBackgroundColor:_backgroundColor];
 }
 
+- (uint64_t)id {
+  NSAssert([self attached], @"This view controller is not attched.");
+  return _id;
+}
+
 - (void)onPreEngineRestart {
   [self initializeKeyboard];
+}
+
+- (void)attachToEngine:(nonnull FlutterEngine*)engine withId:(uint64_t)viewId {
+  NSAssert(_engine == nil, @"Already attached to an engine %@.", _engine);
+  _engine = engine;
+  _id = viewId;
+}
+
+- (void)detachFromEngine {
+  NSAssert(_engine != nil, @"Not attached to any engine.");
+  _engine = nil;
+}
+
+- (BOOL)attached {
+  return _engine != nil;
 }
 
 #pragma mark - Private methods
 
 - (BOOL)launchEngine {
-  [self initializeKeyboard];
-
-  _engine.viewController = self;
   if (![_engine runWithEntrypoint:nil]) {
     return NO;
   }
@@ -689,6 +711,13 @@ static void CommonInit(FlutterViewController* controller) {
     // back.
     [self.view addSubview:_textInputPlugin];
   }
+}
+
+- (nonnull FlutterView*)createFlutterViewWithMTLDevice:(id<MTLDevice>)device
+                                          commandQueue:(id<MTLCommandQueue>)commandQueue {
+  return [[FlutterView alloc] initWithMTLDevice:device
+                                   commandQueue:commandQueue
+                                reshapeListener:self];
 }
 
 - (void)onKeyboardLayoutChanged {

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
@@ -11,6 +11,7 @@
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterBinaryMessenger.h"
 #import "flutter/shell/platform/darwin/macos/framework/Headers/FlutterEngine.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterDartProject_Internal.h"
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterEngineTestUtils.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterRenderer.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTestUtils.h"
@@ -136,11 +137,9 @@ TEST(FlutterViewController, FlutterViewAcceptsFirstMouse) {
 
 TEST(FlutterViewController, ReparentsPluginWhenAccessibilityDisabled) {
   FlutterEngine* engine = CreateTestEngine();
-  NSString* fixtures = @(testing::GetFixturesPath());
-  FlutterDartProject* project = [[FlutterDartProject alloc]
-      initWithAssetsPath:fixtures
-             ICUDataPath:[fixtures stringByAppendingString:@"/icudtl.dat"]];
-  FlutterViewController* viewController = [[FlutterViewController alloc] initWithProject:project];
+  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engine
+                                                                                nibName:nil
+                                                                                 bundle:nil];
   [viewController loadView];
   [engine setViewController:viewController];
   // Creates a NSWindow so that sub view can be first responder.
@@ -214,7 +213,7 @@ TEST(FlutterViewControllerTest, testFlutterViewIsConfigured) {
 @implementation FlutterViewControllerTestObjC
 
 - (bool)testKeyEventsAreSentToFramework {
-  id engineMock = OCMClassMock([FlutterEngine class]);
+  id engineMock = flutter::testing::CreateMockFlutterEngine(@"");
   id binaryMessengerMock = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
   OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
       [engineMock binaryMessenger])
@@ -252,7 +251,7 @@ TEST(FlutterViewControllerTest, testFlutterViewIsConfigured) {
 }
 
 - (bool)testKeyEventsArePropagatedIfNotHandled {
-  id engineMock = OCMClassMock([FlutterEngine class]);
+  id engineMock = flutter::testing::CreateMockFlutterEngine(@"");
   id binaryMessengerMock = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
   OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
       [engineMock binaryMessenger])
@@ -307,7 +306,7 @@ TEST(FlutterViewControllerTest, testFlutterViewIsConfigured) {
 }
 
 - (bool)testFlutterViewIsConfigured {
-  id engineMock = OCMClassMock([FlutterEngine class]);
+  id engineMock = flutter::testing::CreateMockFlutterEngine(@"");
 
   FlutterRenderer* renderer_ = [[FlutterRenderer alloc] initWithFlutterEngine:engineMock];
   OCMStub([engineMock renderer]).andReturn(renderer_);
@@ -328,7 +327,7 @@ TEST(FlutterViewControllerTest, testFlutterViewIsConfigured) {
 }
 
 - (bool)testFlagsChangedEventsArePropagatedIfNotHandled {
-  id engineMock = OCMClassMock([FlutterEngine class]);
+  id engineMock = flutter::testing::CreateMockFlutterEngine(@"");
   id binaryMessengerMock = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
   OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
       [engineMock binaryMessenger])
@@ -381,7 +380,7 @@ TEST(FlutterViewControllerTest, testFlutterViewIsConfigured) {
 }
 
 - (bool)testKeyEventsAreNotPropagatedIfHandled {
-  id engineMock = OCMClassMock([FlutterEngine class]);
+  id engineMock = flutter::testing::CreateMockFlutterEngine(@"");
   id binaryMessengerMock = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
   OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
       [engineMock binaryMessenger])
@@ -436,7 +435,7 @@ TEST(FlutterViewControllerTest, testFlutterViewIsConfigured) {
 }
 
 - (bool)testKeyboardIsRestartedOnEngineRestart {
-  id engineMock = OCMClassMock([FlutterEngine class]);
+  id engineMock = flutter::testing::CreateMockFlutterEngine(@"");
   id binaryMessengerMock = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
   OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
       [engineMock binaryMessenger])
@@ -498,7 +497,7 @@ TEST(FlutterViewControllerTest, testFlutterViewIsConfigured) {
 }
 
 - (bool)testTrackpadGesturesAreSentToFramework {
-  id engineMock = OCMClassMock([FlutterEngine class]);
+  id engineMock = flutter::testing::CreateMockFlutterEngine(@"");
   // Need to return a real renderer to allow view controller to load.
   FlutterRenderer* renderer_ = [[FlutterRenderer alloc] initWithFlutterEngine:engineMock];
   OCMStub([engineMock renderer]).andReturn(renderer_);
@@ -794,7 +793,7 @@ TEST(FlutterViewControllerTest, testFlutterViewIsConfigured) {
 }
 
 - (bool)testViewWillAppearCalledMultipleTimes {
-  id engineMock = OCMClassMock([FlutterEngine class]);
+  id engineMock = flutter::testing::CreateMockFlutterEngine(@"");
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engineMock
                                                                                 nibName:@""
                                                                                  bundle:nil];

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
@@ -803,7 +803,7 @@ TEST(FlutterViewControllerTest, testFlutterViewIsConfigured) {
 }
 
 - (bool)testModifierKeysAreSynthesizedOnMouseMove {
-  id engineMock = OCMClassMock([FlutterEngine class]);
+  id engineMock = flutter::testing::CreateMockFlutterEngine(@"");
   // Need to return a real renderer to allow view controller to load.
   FlutterRenderer* renderer_ = [[FlutterRenderer alloc] initWithFlutterEngine:engineMock];
   OCMStub([engineMock renderer]).andReturn(renderer_);
@@ -824,7 +824,6 @@ TEST(FlutterViewControllerTest, testFlutterViewIsConfigured) {
                                                                                 nibName:@""
                                                                                  bundle:nil];
   [viewController loadView];
-  [engineMock setViewController:viewController];
   [viewController viewWillAppear];
 
   // Zeroed modifier flag should not synthesize events.

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h
@@ -4,6 +4,7 @@
 
 #import "flutter/shell/platform/darwin/macos/framework/Headers/FlutterViewController.h"
 
+#import "flutter/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMac.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterKeyboardViewDelegate.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterView.h"
@@ -23,9 +24,27 @@
  */
 - (BOOL)isDispatchingKeyEvent:(nonnull NSEvent*)event;
 
+/**
+ * Set the `engine` and `id` of this controller.
+ *
+ * This method is called by FlutterEngine.
+ */
+- (void)attachToEngine:(nonnull FlutterEngine*)engine withId:(uint64_t)viewId;
+
+/**
+ * Reset the `engine` and `id` of this controller.
+ *
+ * This method is called by FlutterEngine.
+ */
+- (void)detachFromEngine;
+
 @end
 
 // Private methods made visible for testing
 @interface FlutterViewController (TestMethods)
 - (void)onAccessibilityStatusChanged:(BOOL)enabled;
+
+- (nonnull FlutterView*)createFlutterViewWithMTLDevice:(nonnull id<MTLDevice>)device
+                                          commandQueue:(nonnull id<MTLCommandQueue>)commandQueue;
+
 @end

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewProvider.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewProvider.h
@@ -4,6 +4,8 @@
 
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterView.h"
 
+extern const uint64_t kFlutterDefaultViewId;
+
 /**
  * An interface to query FlutterView.
  *


### PR DESCRIPTION
Reland https://github.com/flutter/engine/pull/38981. 

Fixed a test that was introduced in https://github.com/flutter/engine/pull/37870 but used the legacy convention. 

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
