### PR TITLE
[Web][HTML] Add mirrored characters support for RTL languages

### DIFF
--- a/lib/web_ui/lib/src/engine/text/canvas_paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/canvas_paragraph.dart
@@ -174,6 +174,9 @@ class CanvasParagraph implements ui.Paragraph {
         }
 
         final DomElement spanElement = domDocument.createElement('flt-span');
+        if (fragment.textDirection == ui.TextDirection.rtl) {
+          spanElement.setAttribute('dir', 'rtl');
+        }
         applyTextStyleToElement(element: spanElement, style: fragment.style);
         _positionSpanElement(spanElement, line, fragment);
 

--- a/lib/web_ui/test/text/canvas_paragraph_builder_test.dart
+++ b/lib/web_ui/test/text/canvas_paragraph_builder_test.dart
@@ -460,9 +460,8 @@ Future<void> testMain() async {
   // Set dir attribute for RTL fragments in order to let the browser
   // handle mirrored characters.
   test('Sets "dir" attribute for RTL fragment', () {
-    const double fontSize = 20.0;
     final EngineParagraphStyle style = EngineParagraphStyle(
-      fontSize: fontSize,
+      fontSize: 20.0,
       textDirection: TextDirection.rtl,
     );
     final CanvasParagraphBuilder builder = CanvasParagraphBuilder(style);
@@ -477,13 +476,13 @@ Future<void> testMain() async {
     expectOuterHtml(
       paragraph,
       '<flt-paragraph style="${paragraphStyle()}">'
-      '<flt-span dir="rtl" style="${spanStyle(top: null, left: null, width: null, fontSize: fontSize)}">'
+      '<flt-span dir="rtl" style="${spanStyle(top: null, left: null, width: null, fontSize: 20)}">'
       '('
       '</flt-span>'
-      '<flt-span style="${spanStyle(top: null, left: null, width: null, fontSize: fontSize)}">'
+      '<flt-span style="${spanStyle(top: null, left: null, width: null, fontSize: 20)}">'
       '1'
       '</flt-span>'
-      '<flt-span dir="rtl" style="${spanStyle(top: null, left: null, width: null, fontSize: fontSize)}">'
+      '<flt-span dir="rtl" style="${spanStyle(top: null, left: null, width: null, fontSize: 20)}">'
       ')'
       '</flt-span>'
       '</flt-paragraph>',

--- a/lib/web_ui/test/text/canvas_paragraph_builder_test.dart
+++ b/lib/web_ui/test/text/canvas_paragraph_builder_test.dart
@@ -455,6 +455,41 @@ Future<void> testMain() async {
     );
     debugEmulateFlutterTesterEnvironment = true;
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/108431.
+  // Set dir attribute for RTL fragments in order to let the browser
+  // handle mirrored characters.
+  test('Sets "dir" attribute for RTL fragment', () {
+    const double fontSize = 20.0;
+    final EngineParagraphStyle style = EngineParagraphStyle(
+      fontSize: fontSize,
+      textDirection: TextDirection.rtl,
+    );
+    final CanvasParagraphBuilder builder = CanvasParagraphBuilder(style);
+
+    builder.addText('(1)');
+
+    final CanvasParagraph paragraph = builder.build();
+    expect(paragraph.paragraphStyle, style);
+    expect(paragraph.plainText, '(1)');
+
+    paragraph.layout(const ParagraphConstraints(width: double.infinity));
+    expectOuterHtml(
+      paragraph,
+      '<flt-paragraph style="${paragraphStyle()}">'
+      '<flt-span dir="rtl" style="${spanStyle(top: null, left: null, width: null, fontSize: fontSize)}">'
+      '('
+      '</flt-span>'
+      '<flt-span style="${spanStyle(top: null, left: null, width: null, fontSize: fontSize)}">'
+      '1'
+      '</flt-span>'
+      '<flt-span dir="rtl" style="${spanStyle(top: null, left: null, width: null, fontSize: fontSize)}">'
+      ')'
+      '</flt-span>'
+      '</flt-paragraph>',
+      ignorePositions: true,
+    );
+  });
 }
 
 const String defaultFontFamily = 'Ahem';


### PR DESCRIPTION
## Description

Handling RTL text in the HTML renderer was introduced by https://github.com/flutter/engine/pull/26811.

It seems that there is a missing piece related to mirrored characters (see https://www.w3.org/International/articles/inline-bidi-markup/uba-basics#mirroring).

This PR adds this feature by relying on the HTML “dir” attribute.

## Before/after

Here is a simplified sample (compared to the one in https://github.com/flutter/flutter/issues/108431) to illustrate the issue:

<details>
<summary>Code sample</summary>

```dart
import 'package:flutter/material.dart';

void main() {
  runApp(const MyApp());
}

class MyApp extends StatelessWidget {
  const MyApp({Key? key}) : super(key: key);

  @override
  Widget build(BuildContext context) {
    return const MaterialApp(
      title: 'Flutter Demo',
      home: MyHomePage(),
      debugShowCheckedModeBanner: false,
    );
  }
}

class MyHomePage extends StatelessWidget {
  const MyHomePage({Key? key}) : super(key: key);

  @override
  Widget build(BuildContext context) {
    return const Scaffold(
      backgroundColor: Colors.deepPurple,
      body: Center(
        child: Text(
          "(1)",
          textDirection: TextDirection.rtl,
          style: TextStyle(fontSize: 40, fontWeight: FontWeight.bold, color: Colors.white),
        ),
      ),
    );
  }
}

```
</details

Before (using HTML Renderer):
![Capture d’écran du 2023-01-26 16-44-58](https://user-images.githubusercontent.com/840911/214881251-979f25ae-1784-4b89-80de-d97a59150fcb.png)

After (using HTML Renderer):
![Capture d’écran du 2023-01-26 16-45-48](https://user-images.githubusercontent.com/840911/214881372-1c4ca7bc-2ea2-468e-ace4-abc7279741d0.png)


## Implementation choice

@mdebbar
 I was not able to figure out if there is already some web_ui code to handle mirrored characters.
So the solution I choosed is to rely on the HTML dir attribute and apply it to “flt-span” which is created for each text fragment (adding it only when a text fragment direction is RTL).

## Related Issue

Fixes: https://github.com/flutter/flutter/issues/108431

## Tests

Adds 1 test.
