### PR TITLE
[ios] Lock refresh rate to 80fps when threads are merged

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h
+++ b/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h
@@ -15,6 +15,13 @@
 
 @interface DisplayLinkManager : NSObject
 
+// Whether the max refresh rate on iPhone Pro-motion devices are enabled.
+// This reflects the value of `CADisableMinimumFrameDurationOnPhone` in the
+// info.plist file.
+//
+// Note on iPads that support Pro-motion, the max refresh rate is always enabled.
+@property(class, nonatomic, readonly) BOOL maxRefreshRateEnabledOnIPhone;
+
 //------------------------------------------------------------------------------
 /// @brief      The display refresh rate used for reporting purposes. The engine does not care
 ///             about this for frame scheduling. It is only used by tools for instrumentation. The
@@ -51,6 +58,8 @@
 
 - (double)getRefreshRate;
 
+- (void)setMaxRefreshRate:(double)refreshRate;
+
 @end
 
 namespace flutter {
@@ -64,11 +73,16 @@ class VsyncWaiterIOS final : public VsyncWaiter, public VariableRefreshRateRepor
   // |VariableRefreshRateReporter|
   double GetRefreshRate() const override;
 
- private:
-  fml::scoped_nsobject<VSyncClient> client_;
+  // Made public for testing.
+  fml::scoped_nsobject<VSyncClient> GetVsyncClient() const;
 
   // |VsyncWaiter|
+  // Made public for testing.
   void AwaitVSync() override;
+
+ private:
+  fml::scoped_nsobject<VSyncClient> client_;
+  double max_refresh_rate_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(VsyncWaiterIOS);
 };

--- a/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
+++ b/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
@@ -12,7 +12,11 @@
 
 #include "flutter/common/task_runners.h"
 #include "flutter/fml/logging.h"
+#include "flutter/fml/memory/task_runner_checker.h"
 #include "flutter/fml/trace_event.h"
+
+// When calculating refresh rate diffrence, anything within 0.1 fps is ignored.
+const static double kRefreshRateDiffToIgnore = 0.1;
 
 namespace flutter {
 
@@ -26,6 +30,7 @@ VsyncWaiterIOS::VsyncWaiterIOS(const flutter::TaskRunners& task_runners)
   client_ =
       fml::scoped_nsobject{[[VSyncClient alloc] initWithTaskRunner:task_runners_.GetUITaskRunner()
                                                           callback:callback]};
+  max_refresh_rate_ = [DisplayLinkManager displayRefreshRate];
 }
 
 VsyncWaiterIOS::~VsyncWaiterIOS() {
@@ -35,12 +40,29 @@ VsyncWaiterIOS::~VsyncWaiterIOS() {
 }
 
 void VsyncWaiterIOS::AwaitVSync() {
+  double new_max_refresh_rate = [DisplayLinkManager displayRefreshRate];
+  if (fml::TaskRunnerChecker::RunsOnTheSameThread(
+          task_runners_.GetRasterTaskRunner()->GetTaskQueueId(),
+          task_runners_.GetPlatformTaskRunner()->GetTaskQueueId())) {
+    // Pressure tested on iPhone 13 pro, the oldest iPhone that supports refresh rate greater than
+    // 60fps. A flutter app can handle fast scrolling on 80 fps with 6 PlatformViews in the scene at
+    // the same time.
+    new_max_refresh_rate = 80;
+  }
+  if (fabs(new_max_refresh_rate - max_refresh_rate_) > kRefreshRateDiffToIgnore) {
+    max_refresh_rate_ = new_max_refresh_rate;
+    [client_.get() setMaxRefreshRate:max_refresh_rate_];
+  }
   [client_.get() await];
 }
 
 // |VariableRefreshRateReporter|
 double VsyncWaiterIOS::GetRefreshRate() const {
   return [client_.get() getRefreshRate];
+}
+
+fml::scoped_nsobject<VSyncClient> VsyncWaiterIOS::GetVsyncClient() const {
+  return client_;
 }
 
 }  // namespace flutter
@@ -64,7 +86,7 @@ double VsyncWaiterIOS::GetRefreshRate() const {
     };
     display_link_.get().paused = YES;
 
-    [self setMaxRefreshRateIfEnabled];
+    [self setMaxRefreshRate:[DisplayLinkManager displayRefreshRate]];
 
     task_runner->PostTask([client = [self retain]]() {
       [client->display_link_.get() addToRunLoop:[NSRunLoop currentRunLoop]
@@ -76,15 +98,12 @@ double VsyncWaiterIOS::GetRefreshRate() const {
   return self;
 }
 
-- (void)setMaxRefreshRateIfEnabled {
-  NSNumber* minimumFrameRateDisabled =
-      [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CADisableMinimumFrameDurationOnPhone"];
-  if (![minimumFrameRateDisabled boolValue]) {
+- (void)setMaxRefreshRate:(double)refreshRate {
+  if (!DisplayLinkManager.maxRefreshRateEnabledOnIPhone) {
     return;
   }
-  double maxFrameRate = fmax([DisplayLinkManager displayRefreshRate], 60);
+  double maxFrameRate = fmax(refreshRate, 60);
   double minFrameRate = fmax(maxFrameRate / 2, 60);
-
   if (@available(iOS 15.0, *)) {
     display_link_.get().preferredFrameRateRange =
         CAFrameRateRangeMake(minFrameRate, maxFrameRate, maxFrameRate);
@@ -168,6 +187,11 @@ double VsyncWaiterIOS::GetRefreshRate() const {
 
 - (void)onDisplayLink:(CADisplayLink*)link {
   // no-op.
+}
+
++ (BOOL)maxRefreshRateEnabledOnIPhone {
+  return [[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CADisableMinimumFrameDurationOnPhone"]
+      boolValue];
 }
 
 @end


### PR DESCRIPTION
When there are PlatformViews on the screen (threads merged), Flutter engine cannot consistently hit 120 fps, especially when the PlatformView is animating (scrolling etc), thus producing janks. 
This PR locks the refresh rate to 80fps to avoid janks.

Fixes https://github.com/flutter/flutter/issues/116640

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
