### PR TITLE
Revert "[macos] Move TextInputPlugin outside of visible area"

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -245,9 +245,8 @@ static char markerKey;
 }
 
 - (instancetype)initWithViewController:(FlutterViewController*)viewController {
-  // The view needs an empty frame otherwise it is visible on dark background.
-  // https://github.com/flutter/flutter/issues/118504
-  self = [super initWithFrame:NSZeroRect];
+  // The view needs a non-zero frame.
+  self = [super initWithFrame:NSMakeRect(0, 0, 1, 1)];
   if (self != nil) {
     _flutterViewController = viewController;
     _channel = [FlutterMethodChannel methodChannelWithName:kTextInputChannel

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
@@ -1532,20 +1532,4 @@ TEST(FlutterTextInputPluginTest, IsAddedAndRemovedFromViewHierarchy) {
   ASSERT_FALSE(window.firstResponder == viewController.textInputPlugin);
 }
 
-TEST(FlutterTextInputPluginTest, HasZeroSize) {
-  id engineMock = OCMClassMock([FlutterEngine class]);
-  id binaryMessengerMock = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
-  OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
-      [engineMock binaryMessenger])
-      .andReturn(binaryMessengerMock);
-  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engineMock
-                                                                                nibName:@""
-                                                                                 bundle:nil];
-
-  FlutterTextInputPlugin* plugin =
-      [[FlutterTextInputPlugin alloc] initWithViewController:viewController];
-
-  ASSERT_TRUE(NSIsEmptyRect(plugin.frame));
-}
-
 }  // namespace flutter::testing


### PR DESCRIPTION
Reverts flutter/engine#39031

Seems responsible for the test failure on CI here: https://ci.chromium.org/ui/p/flutter/builders/prod/Mac%20Production%20Engine%20Drone/23111/overview