### PR TITLE
[Impeller] ensure 1x1 has mipcount of 1

### DIFF
--- a/impeller/geometry/geometry_unittests.cc
+++ b/impeller/geometry/geometry_unittests.cc
@@ -641,6 +641,7 @@ TEST(GeometryTest, CanGenerateMipCounts) {
   ASSERT_EQ((Size{128, -25}.MipCount()), 1u);
   ASSERT_EQ((Size{-128, 25}.MipCount()), 1u);
   ASSERT_EQ((Size{1, 1}.MipCount()), 1u);
+  ASSERT_EQ((Size{0, 0}.MipCount()), 1u);
 }
 
 TEST(GeometryTest, CanConvertTTypesExplicitly) {

--- a/impeller/geometry/geometry_unittests.cc
+++ b/impeller/geometry/geometry_unittests.cc
@@ -640,6 +640,7 @@ TEST(GeometryTest, CanGenerateMipCounts) {
   ASSERT_EQ((Size{128, 0}.MipCount()), 1u);
   ASSERT_EQ((Size{128, -25}.MipCount()), 1u);
   ASSERT_EQ((Size{-128, 25}.MipCount()), 1u);
+  ASSERT_EQ((Size{1, 1}.MipCount()), 1u);
 }
 
 TEST(GeometryTest, CanConvertTTypesExplicitly) {

--- a/impeller/geometry/size.h
+++ b/impeller/geometry/size.h
@@ -99,12 +99,12 @@ struct TSize {
   }
 
   constexpr size_t MipCount() const {
+    constexpr size_t minimum_mip = 1u;
     if (!IsPositive()) {
-      return 1u;
+      return minimum_mip;
     }
-    constexpr size_t minimumMip = 1u;
     size_t result = std::max(ceil(log2(width)), ceil(log2(height)));
-    return std::max(result, minimumMip);
+    return std::max(result, minimum_mip);
   }
 };
 

--- a/impeller/geometry/size.h
+++ b/impeller/geometry/size.h
@@ -102,7 +102,9 @@ struct TSize {
     if (!IsPositive()) {
       return 1u;
     }
-    return std::max(ceil(log2(width)), ceil(log2(height)));
+    constexpr size_t minimumMip = 1u;
+    size_t result = std::max(ceil(log2(width)), ceil(log2(height)));
+    return std::max(result, minimumMip);
   }
 };
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/119245

Before mipcount of 1x1 image would be 0, resulting in invalid texture
