### PR TITLE
Use Windows high contrast black/white theme with `MaterialApp` themes

### DIFF
--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -668,6 +668,7 @@ void FlutterWindowsEngine::UpdateHighContrastEnabled(bool enabled) {
         ~FlutterAccessibilityFeature::kFlutterAccessibilityFeatureHighContrast;
   }
   UpdateAccessibilityFeatures(static_cast<FlutterAccessibilityFeature>(flags));
+  settings_plugin_->UpdateHighContrastMode(enabled);
 }
 
 int FlutterWindowsEngine::EnabledAccessibilityFeatures() const {

--- a/shell/platform/windows/settings_plugin.cc
+++ b/shell/platform/windows/settings_plugin.cc
@@ -36,7 +36,8 @@ int GetLuminance(DWORD color) {
 }
 
 // Return kLight if light mode for apps is selected, otherwise return kDark.
-SettingsPlugin::PlatformBrightness GetThemeBrightness() {DWORD use_light_theme;
+SettingsPlugin::PlatformBrightness GetThemeBrightness() {
+  DWORD use_light_theme;
   DWORD use_light_theme_size = sizeof(use_light_theme);
   LONG result = RegGetValue(HKEY_CURRENT_USER, kGetPreferredBrightnessRegKey,
                             kGetPreferredBrightnessRegValue, RRF_RT_REG_DWORD,

--- a/shell/platform/windows/settings_plugin.cc
+++ b/shell/platform/windows/settings_plugin.cc
@@ -44,7 +44,7 @@ SettingsPlugin::PlatformBrightness GetThemeBrightness() {DWORD use_light_theme;
 
   if (result == 0) {
     return use_light_theme ? SettingsPlugin::PlatformBrightness::kLight
-                            : SettingsPlugin::PlatformBrightness::kDark;
+                           : SettingsPlugin::PlatformBrightness::kDark;
   } else {
     // The current OS does not support dark mode. (Older Windows 10 or before
     // Windows 10)

--- a/shell/platform/windows/settings_plugin.cc
+++ b/shell/platform/windows/settings_plugin.cc
@@ -34,6 +34,23 @@ int GetLuminance(DWORD color) {
   int b = GetBValue(color);
   return (r + r + r + b + (g << 2)) >> 3;
 }
+
+// Return kLight if light mode for apps is selected, otherwise return kDark.
+SettingsPlugin::PlatformBrightness GetThemeBrightness() {DWORD use_light_theme;
+  DWORD use_light_theme_size = sizeof(use_light_theme);
+  LONG result = RegGetValue(HKEY_CURRENT_USER, kGetPreferredBrightnessRegKey,
+                            kGetPreferredBrightnessRegValue, RRF_RT_REG_DWORD,
+                            nullptr, &use_light_theme, &use_light_theme_size);
+
+  if (result == 0) {
+    return use_light_theme ? SettingsPlugin::PlatformBrightness::kLight
+                            : SettingsPlugin::PlatformBrightness::kDark;
+  } else {
+    // The current OS does not support dark mode. (Older Windows 10 or before
+    // Windows 10)
+    return SettingsPlugin::PlatformBrightness::kLight;
+  }
+}
 }  // namespace
 
 SettingsPlugin::SettingsPlugin(BinaryMessenger* messenger,
@@ -117,20 +134,7 @@ SettingsPlugin::PlatformBrightness SettingsPlugin::GetPreferredBrightness() {
     return luminance >= 127 ? SettingsPlugin::PlatformBrightness::kLight
                             : SettingsPlugin::PlatformBrightness::kDark;
   } else {
-    DWORD use_light_theme;
-    DWORD use_light_theme_size = sizeof(use_light_theme);
-    LONG result = RegGetValue(HKEY_CURRENT_USER, kGetPreferredBrightnessRegKey,
-                              kGetPreferredBrightnessRegValue, RRF_RT_REG_DWORD,
-                              nullptr, &use_light_theme, &use_light_theme_size);
-
-    if (result == 0) {
-      return use_light_theme ? SettingsPlugin::PlatformBrightness::kLight
-                             : SettingsPlugin::PlatformBrightness::kDark;
-    } else {
-      // The current OS does not support dark mode. (Older Windows 10 or before
-      // Windows 10)
-      return SettingsPlugin::PlatformBrightness::kLight;
-    }
+    return GetThemeBrightness();
   }
 }
 

--- a/shell/platform/windows/settings_plugin.cc
+++ b/shell/platform/windows/settings_plugin.cc
@@ -26,6 +26,14 @@ constexpr wchar_t kGetPreferredBrightnessRegValue[] = L"AppsUseLightTheme";
 constexpr wchar_t kGetTextScaleFactorRegKey[] =
     L"Software\\Microsoft\\Accessibility";
 constexpr wchar_t kGetTextScaleFactorRegValue[] = L"TextScaleFactor";
+
+// Return an approximation of the apparent luminance of a given color.
+int GetLuminance(DWORD color) {
+  int r = GetRValue(color);
+  int g = GetGValue(color);
+  int b = GetBValue(color);
+  return (r + r + r + b + (g << 2)) >> 3;
+}
 }  // namespace
 
 SettingsPlugin::SettingsPlugin(BinaryMessenger* messenger,
@@ -104,12 +112,9 @@ float SettingsPlugin::GetTextScaleFactor() {
 
 SettingsPlugin::PlatformBrightness SettingsPlugin::GetPreferredBrightness() {
   if (is_high_contrast_) {
-    DWORD text_color = GetSysColor(COLOR_WINDOW);
-    int r = GetRValue(text_color);
-    int g = GetGValue(text_color);
-    int b = GetBValue(text_color);
-    int luminance = (r + r + r + b + (g << 2)) >> 3;
-    return luminance >= 0.5 ? SettingsPlugin::PlatformBrightness::kLight
+    DWORD window_color = GetSysColor(COLOR_WINDOW);
+    int luminance = GetLuminance(window_color);
+    return luminance >= 127 ? SettingsPlugin::PlatformBrightness::kLight
                             : SettingsPlugin::PlatformBrightness::kDark;
   } else {
     DWORD use_light_theme;

--- a/shell/platform/windows/settings_plugin.h
+++ b/shell/platform/windows/settings_plugin.h
@@ -23,6 +23,8 @@ namespace flutter {
 // These are typically set in the control panel.
 class SettingsPlugin {
  public:
+  enum struct PlatformBrightness { kDark, kLight };
+
   explicit SettingsPlugin(BinaryMessenger* messenger, TaskRunner* task_runner);
 
   virtual ~SettingsPlugin();
@@ -37,9 +39,10 @@ class SettingsPlugin {
   // this automatically.
   virtual void StopWatching();
 
- protected:
-  enum struct PlatformBrightness { kDark, kLight };
+  // Update the high contrast status of the system.
+  virtual void UpdateHighContrastMode(bool is_high_contrast);
 
+ protected:
   // Returns `true` if the user uses 24 hour time.
   virtual bool GetAlwaysUse24HourFormat();
 
@@ -54,6 +57,8 @@ class SettingsPlugin {
 
   // Starts watching text scale factor changes.
   virtual void WatchTextScaleFactorChanged();
+
+  bool is_high_contrast_ = false;
 
  private:
   std::unique_ptr<BasicMessageChannel<rapidjson::Document>> channel_;

--- a/shell/platform/windows/settings_plugin_unittests.cc
+++ b/shell/platform/windows/settings_plugin_unittests.cc
@@ -73,9 +73,10 @@ TEST(SettingsPluginTest, StartWatchingStartsWatchingChanges) {
 }
 
 TEST(SettingsPluginTest, HighContrastModeHonored) {
-  TestBinaryMessenger messenger([](const std::string& channel,
+  int times = 0;
+  TestBinaryMessenger messenger([&times](const std::string& channel,
                                    const uint8_t* message, size_t message_size,
-                                   BinaryReply reply) {});
+                                   BinaryReply reply) { times++; });
   ::testing::NiceMock<MockSettingsPlugin> settings_plugin(&messenger, nullptr);
 
   settings_plugin.UpdateHighContrastMode(true);
@@ -83,6 +84,8 @@ TEST(SettingsPluginTest, HighContrastModeHonored) {
 
   settings_plugin.UpdateHighContrastMode(false);
   EXPECT_FALSE(settings_plugin.is_high_contrast());
+
+  EXPECT_EQ(times, 2);
 }
 
 }  // namespace testing

--- a/shell/platform/windows/settings_plugin_unittests.cc
+++ b/shell/platform/windows/settings_plugin_unittests.cc
@@ -76,7 +76,10 @@ TEST(SettingsPluginTest, HighContrastModeHonored) {
   int times = 0;
   TestBinaryMessenger messenger([&times](const std::string& channel,
                                    const uint8_t* message, size_t message_size,
-                                   BinaryReply reply) { times++; });
+                                   BinaryReply reply) {
+    ASSERT_EQ(channel, "flutter/settings");
+    times++;
+  });
   ::testing::NiceMock<MockSettingsPlugin> settings_plugin(&messenger, nullptr);
 
   settings_plugin.UpdateHighContrastMode(true);

--- a/shell/platform/windows/settings_plugin_unittests.cc
+++ b/shell/platform/windows/settings_plugin_unittests.cc
@@ -74,12 +74,12 @@ TEST(SettingsPluginTest, StartWatchingStartsWatchingChanges) {
 
 TEST(SettingsPluginTest, HighContrastModeHonored) {
   int times = 0;
-  TestBinaryMessenger messenger([&times](const std::string& channel,
-                                   const uint8_t* message, size_t message_size,
-                                   BinaryReply reply) {
-    ASSERT_EQ(channel, "flutter/settings");
-    times++;
-  });
+  TestBinaryMessenger messenger(
+      [&times](const std::string& channel, const uint8_t* message,
+               size_t message_size, BinaryReply reply) {
+        ASSERT_EQ(channel, "flutter/settings");
+        times++;
+      });
   ::testing::NiceMock<MockSettingsPlugin> settings_plugin(&messenger, nullptr);
 
   settings_plugin.UpdateHighContrastMode(true);

--- a/shell/platform/windows/settings_plugin_unittests.cc
+++ b/shell/platform/windows/settings_plugin_unittests.cc
@@ -26,6 +26,10 @@ class MockSettingsPlugin : public SettingsPlugin {
   MOCK_METHOD0(GetTextScaleFactor, float());
   MOCK_METHOD0(GetPreferredBrightness, PlatformBrightness());
 
+  bool is_high_contrast() {
+    return is_high_contrast_;
+  }
+
   MOCK_METHOD0(WatchPreferredBrightnessChanged, void());
   MOCK_METHOD0(WatchTextScaleFactorChanged, void());
 };
@@ -68,6 +72,19 @@ TEST(SettingsPluginTest, StartWatchingStartsWatchingChanges) {
   EXPECT_CALL(settings_plugin, WatchTextScaleFactorChanged).Times(1);
 
   settings_plugin.StartWatching();
+}
+
+TEST(SettingsPluginTest, HighContrastModeHonored) {
+  TestBinaryMessenger messenger([](const std::string& channel,
+                                   const uint8_t* message, size_t message_size,
+                                   BinaryReply reply) {});
+  ::testing::NiceMock<MockSettingsPlugin> settings_plugin(&messenger, nullptr);
+
+  settings_plugin.UpdateHighContrastMode(true);
+  EXPECT_TRUE(settings_plugin.is_high_contrast());
+
+  settings_plugin.UpdateHighContrastMode(false);
+  EXPECT_FALSE(settings_plugin.is_high_contrast());
 }
 
 }  // namespace testing

--- a/shell/platform/windows/settings_plugin_unittests.cc
+++ b/shell/platform/windows/settings_plugin_unittests.cc
@@ -21,14 +21,12 @@ class MockSettingsPlugin : public SettingsPlugin {
 
   virtual ~MockSettingsPlugin() = default;
 
+  bool is_high_contrast() { return is_high_contrast_; }
+
   // |SettingsPlugin|
   MOCK_METHOD0(GetAlwaysUse24HourFormat, bool());
   MOCK_METHOD0(GetTextScaleFactor, float());
   MOCK_METHOD0(GetPreferredBrightness, PlatformBrightness());
-
-  bool is_high_contrast() {
-    return is_high_contrast_;
-  }
 
   MOCK_METHOD0(WatchPreferredBrightnessChanged, void());
   MOCK_METHOD0(WatchTextScaleFactorChanged, void());


### PR DESCRIPTION
`MaterialApp` has a `highContrastTheme` and a `highContrastDarkTheme`. Currently, on windows, which of these to use is based on whether or not dark mode for apps is enabled. However, the app dark mode setting is independent of the high contrast theme, which may be black or white. Now, check the high contrast theme to determine which `MaterialApp` theme to use when high contrast mode is enabled.

[flutter/flutter#75883](https://github.com/flutter/flutter/issues/75883)

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
