### PR TITLE
[Windows] Use 'FlutterWindowsEngineBuilder' in keyboard unit tests

### DIFF
--- a/shell/platform/windows/keyboard_unittests.cc
+++ b/shell/platform/windows/keyboard_unittests.cc
@@ -262,7 +262,7 @@ class MockKeyboardManagerDelegate : public KeyboardManager::WindowDelegate,
   }
 
   // This method is called for each message injected by test cases with
-  // `InjectMessages`.
+  // `tester.InjectMessages`.
   LRESULT Win32SendMessage(UINT const message,
                            WPARAM const wparam,
                            LPARAM const lparam) override {
@@ -1976,6 +1976,7 @@ TEST_F(KeyboardTest, UpOnlyImeEventsAreCorrectlyHandled) {
 // will crash upon the response.
 TEST_F(KeyboardTest, SlowFrameworkResponse) {
   KeyboardTester tester{GetContext()};
+
   std::vector<MockKeyResponseController::ResponseCallback> recorded_callbacks;
 
   // Store callbacks to manually call them.
@@ -2181,7 +2182,6 @@ TEST_F(KeyboardTest, TextInputSubmit) {
 }
 
 TEST_F(KeyboardTest, VietnameseTelexAddDiacriticWithFastResponse) {
-  KeyboardTester tester{GetContext()};
   // In this test, the user presses the folloing keys:
   //
   //   Key         Current text
@@ -2191,6 +2191,7 @@ TEST_F(KeyboardTest, VietnameseTelexAddDiacriticWithFastResponse) {
   //
   // And the Backspace event is responded immediately.
 
+  KeyboardTester tester{GetContext()};
   tester.Responding(false);
 
   // US Keyboard layout
@@ -2264,7 +2265,6 @@ TEST_F(KeyboardTest, VietnameseTelexAddDiacriticWithFastResponse) {
 
 void VietnameseTelexAddDiacriticWithSlowResponse(WindowsTestContext& context,
                                                  bool backspace_response) {
-  KeyboardTester tester{context};
   // In this test, the user presses the following keys:
   //
   //   Key         Current text
@@ -2273,6 +2273,8 @@ void VietnameseTelexAddDiacriticWithSlowResponse(WindowsTestContext& context,
   //   F           à
   //
   // And the Backspace down event is responded slowly with `backspace_response`.
+
+  KeyboardTester tester{context};
   tester.Responding(false);
 
   // US Keyboard layout


### PR DESCRIPTION
This makes the Windows keyboard tests use the new `FlutterWindowsEngineBuilder` to create an engine to test against. This will make testing easier when the keyboard & text plugins are moved up from the view to the engine.

Part of https://github.com/flutter/flutter/issues/115611

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
