### PR TITLE
Use arm64 engine variant on simulators in iOS unit tests

### DIFF
--- a/testing/ios/IosUnitTests/Tests/FlutterEngineConfig.xcconfig
+++ b/testing/ios/IosUnitTests/Tests/FlutterEngineConfig.xcconfig
@@ -1,1 +1,2 @@
-FLUTTER_ENGINE=ios_debug_sim_unopt
+FLUTTER_ENGINE[arch=x86_64]=ios_debug_sim_unopt
+FLUTTER_ENGINE[arch=arm64]=ios_debug_sim_unopt_arm64


### PR DESCRIPTION
When running `IosUnitTests`, default to the arm64 simulator engine variant when running on an arm64 simulator.


https://github.com/flutter/flutter/wiki/Testing-the-engine#xctest-unit-tests

Resolves to:
<img width="489" alt="Screenshot 2023-01-27 at 3 08 03 PM" src="https://user-images.githubusercontent.com/682784/215223782-8891925f-31de-4345-a0eb-370269dfe0f0.png">

https://developer.apple.com/documentation/xcode/adding-a-build-configuration-file-to-your-project?changes=_8#Apply-a-setting-conditionally-to-a-platform-or-architecture

Inspired by https://github.com/flutter/flutter/issues/119373

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
