### PR TITLE
[Windows] Remove dead code from FlutterWindow tests

### DIFF
--- a/shell/platform/windows/flutter_window_unittests.cc
+++ b/shell/platform/windows/flutter_window_unittests.cc
@@ -2,24 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "flutter/shell/platform/common/json_message_codec.h"
-#include "flutter/shell/platform/embedder/embedder.h"
-#include "flutter/shell/platform/embedder/test_utils/proc_table_replacement.h"
-#include "flutter/shell/platform/windows/flutter_windows_engine.h"
-#include "flutter/shell/platform/windows/keyboard_key_channel_handler.h"
-#include "flutter/shell/platform/windows/keyboard_key_handler.h"
-#include "flutter/shell/platform/windows/testing/engine_modifier.h"
 #include "flutter/shell/platform/windows/testing/flutter_window_test.h"
 #include "flutter/shell/platform/windows/testing/mock_window_binding_handler.h"
 #include "flutter/shell/platform/windows/testing/mock_window_binding_handler_delegate.h"
-#include "flutter/shell/platform/windows/testing/test_keyboard.h"
-#include "flutter/shell/platform/windows/text_input_plugin.h"
-#include "flutter/shell/platform/windows/text_input_plugin_delegate.h"
+#include "flutter/shell/platform/windows/testing/wm_builders.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-
-#include <rapidjson/document.h>
 
 using testing::_;
 using testing::Invoke;
@@ -30,74 +19,6 @@ namespace testing {
 
 namespace {
 static constexpr int32_t kDefaultPointerDeviceId = 0;
-
-// A key event handler that can be spied on while it forwards calls to the real
-// key event handler.
-class SpyKeyboardKeyHandler : public KeyboardHandlerBase {
- public:
-  SpyKeyboardKeyHandler(flutter::BinaryMessenger* messenger) {
-    real_implementation_ = std::make_unique<KeyboardKeyHandler>();
-    real_implementation_->AddDelegate(
-        std::make_unique<KeyboardKeyChannelHandler>(messenger));
-    ON_CALL(*this, KeyboardHook(_, _, _, _, _, _, _))
-        .WillByDefault(Invoke(real_implementation_.get(),
-                              &KeyboardKeyHandler::KeyboardHook));
-    ON_CALL(*this, SyncModifiersIfNeeded(_))
-        .WillByDefault(Invoke(real_implementation_.get(),
-                              &KeyboardKeyHandler::SyncModifiersIfNeeded));
-  }
-
-  MOCK_METHOD7(KeyboardHook,
-               void(int key,
-                    int scancode,
-                    int action,
-                    char32_t character,
-                    bool extended,
-                    bool was_down,
-                    KeyEventCallback callback));
-
-  MOCK_METHOD1(SyncModifiersIfNeeded, void(int modifiers_state));
-
- private:
-  std::unique_ptr<KeyboardKeyHandler> real_implementation_;
-};
-
-// A text input plugin that can be spied on while it forwards calls to the real
-// text input plugin.
-class SpyTextInputPlugin : public TextInputPlugin,
-                           public TextInputPluginDelegate {
- public:
-  SpyTextInputPlugin(flutter::BinaryMessenger* messenger)
-      : TextInputPlugin(messenger, this) {
-    real_implementation_ = std::make_unique<TextInputPlugin>(messenger, this);
-    ON_CALL(*this, KeyboardHook(_, _, _, _, _, _))
-        .WillByDefault(
-            Invoke(real_implementation_.get(), &TextInputPlugin::KeyboardHook));
-    ON_CALL(*this, TextHook(_))
-        .WillByDefault(
-            Invoke(real_implementation_.get(), &TextInputPlugin::TextHook));
-  }
-
-  MOCK_METHOD6(KeyboardHook,
-               void(int key,
-                    int scancode,
-                    int action,
-                    char32_t character,
-                    bool extended,
-                    bool was_down));
-  MOCK_METHOD1(TextHook, void(const std::u16string& text));
-  MOCK_METHOD0(ComposeBeginHook, void());
-  MOCK_METHOD0(ComposeCommitHook, void());
-  MOCK_METHOD0(ComposeEndHook, void());
-  MOCK_METHOD2(ComposeChangeHook,
-               void(const std::u16string& text, int cursor_pos));
-
-  virtual void OnCursorRectUpdated(const Rect& rect) {}
-  virtual void OnResetImeComposing() {}
-
- private:
-  std::unique_ptr<TextInputPlugin> real_implementation_;
-};
 
 class MockFlutterWindow : public FlutterWindow {
  public:
@@ -154,67 +75,15 @@ class MockFlutterWindow : public FlutterWindow {
   }
 };
 
-// A FlutterWindowsView that overrides the RegisterKeyboardHandlers function
-// to register the keyboard hook handlers that can be spied upon.
-class TestFlutterWindowsView : public FlutterWindowsView {
+class MockFlutterWindowsView : public FlutterWindowsView {
  public:
-  TestFlutterWindowsView(std::unique_ptr<WindowBindingHandler> window_binding)
+  MockFlutterWindowsView(std::unique_ptr<WindowBindingHandler> window_binding)
       : FlutterWindowsView(std::move(window_binding)) {}
-  ~TestFlutterWindowsView() {}
-
-  SpyKeyboardKeyHandler* key_event_handler;
-  SpyTextInputPlugin* text_input_plugin;
+  ~MockFlutterWindowsView() {}
 
   MOCK_METHOD2(NotifyWinEventWrapper,
                void(ui::AXPlatformNodeWin*, ax::mojom::Event));
-
- protected:
-  std::unique_ptr<KeyboardHandlerBase> CreateKeyboardKeyHandler(
-      flutter::BinaryMessenger* messenger,
-      flutter::KeyboardKeyEmbedderHandler::GetKeyStateHandler get_key_state,
-      KeyboardKeyEmbedderHandler::MapVirtualKeyToScanCode map_vk_to_scan)
-      override {
-    auto spy_key_event_handler =
-        std::make_unique<SpyKeyboardKeyHandler>(messenger);
-    key_event_handler = spy_key_event_handler.get();
-    return spy_key_event_handler;
-  }
-
-  std::unique_ptr<TextInputPlugin> CreateTextInputPlugin(
-      flutter::BinaryMessenger* messenger) override {
-    auto spy_key_event_handler =
-        std::make_unique<SpyTextInputPlugin>(messenger);
-    text_input_plugin = spy_key_event_handler.get();
-    return spy_key_event_handler;
-  }
 };
-
-// The static value to return as the "handled" value from the framework for key
-// events. Individual tests set this to change the framework response that the
-// test engine simulates.
-static bool test_response = false;
-
-// Returns an engine instance configured with dummy project path values, and
-// overridden methods for sending platform messages, so that the engine can
-// respond as if the framework were connected.
-std::unique_ptr<FlutterWindowsEngine> GetTestEngine() {
-  FlutterDesktopEngineProperties properties = {};
-  properties.assets_path = L"C:\\foo\\flutter_assets";
-  properties.icu_data_path = L"C:\\foo\\icudtl.dat";
-  properties.aot_library_path = L"C:\\foo\\aot.so";
-  FlutterProjectBundle project(properties);
-  auto engine = std::make_unique<FlutterWindowsEngine>(project);
-
-  EngineModifier modifier(engine.get());
-  auto key_response_controller = std::make_shared<MockKeyResponseController>();
-  key_response_controller->SetChannelResponse(
-      [](MockKeyResponseController::ResponseCallback callback) {
-        callback(test_response);
-      });
-  MockEmbedderApiForKeyboard(modifier, key_response_controller);
-
-  return engine;
-}
 
 }  // namespace
 
@@ -419,7 +288,7 @@ TEST(FlutterWindowTest, AlertNode) {
   ON_CALL(*win32window, GetPlatformWindow()).WillByDefault(Return(nullptr));
   ON_CALL(*win32window, GetAxFragmentRootDelegate())
       .WillByDefault(Return(nullptr));
-  TestFlutterWindowsView view(std::move(win32window));
+  MockFlutterWindowsView view(std::move(win32window));
   std::wstring message = L"Test alert";
   EXPECT_CALL(view, NotifyWinEventWrapper(_, ax::mojom::Event::kAlert))
       .Times(1);


### PR DESCRIPTION
Removes dead code in the `FlutterWindow` unit tests.

Part of https://github.com/flutter/flutter/issues/115611

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
