### PR TITLE
Download emsdk for web framework tests.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -309,6 +309,8 @@ targets:
       - master
     properties:
       add_recipes_cq: "true"
+      gclient_variables: >-
+        {"download_emsdk": true}
       dependencies: >-
         [
           {"dependency": "chrome_and_driver", "version": "version:96.2"},


### PR DESCRIPTION
This is in preparation for changes that will use `--local-web-sdk` instead of `--local-engine` for the web framework tests.