### PR TITLE
Revert "[fuchsia] Diagnostics directory rights are R* (#39203)"

### DIFF
--- a/shell/platform/fuchsia/dart_runner/meta/common.shard.cml
+++ b/shell/platform/fuchsia/dart_runner/meta/common.shard.cml
@@ -8,7 +8,7 @@
         // have support for CML includes from the SDK.
         {
             directory: "diagnostics",
-            rights: [ "r*" ],
+            rights: [ "connect" ],
             path: "/diagnostics",
         },
     ],

--- a/shell/platform/fuchsia/flutter/meta/common.shard.cml
+++ b/shell/platform/fuchsia/flutter/meta/common.shard.cml
@@ -8,7 +8,7 @@
         // have support for CML includes from the SDK.
         {
             directory: "diagnostics",
-            rights: [ "r*" ],
+            rights: [ "connect" ],
             path: "/diagnostics",
         },
     ],


### PR DESCRIPTION
This reverts commit 225ae87334a5df010dc21b2c2dc7063cd65e2265.

The related CL https://fuchsia-review.git.corp.google.com/c/fuchsia/+/792471 is being reverted as well: https://fuchsia-review.git.corp.google.com/c/fuchsia/+/794843

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
