### PR TITLE
[flutter release + cherry pick] @alwaysThrows is deprecated. Return `Never` instead. (#39269)

### DIFF
--- a/lib/web_ui/dev/utils.dart
+++ b/lib/web_ui/dev/utils.dart
@@ -224,8 +224,7 @@ class ProcessManager {
     return (await eval()).stderr;
   }
 
-  @alwaysThrows
-  void _throwProcessException({required String description, int? exitCode}) {
+  Never _throwProcessException({required String description, int? exitCode}) {
     throw ProcessException(
       description: description,
       executable: executable,


### PR DESCRIPTION
TLDR: this fixes the breakages in the web engine build. such as https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20Web%20Engine/15016/overview

long story:
Web failure
We are trying to land 8 engine cherry picks, but linux web engine was failing on the release branches with a deprecation warning
Casey pointed me to Zach on post submit failures. Zach added me to flutter web channel, and connected me with Yegor. 
At first the error was thought to be a flake or a recipe version mismatch. Examining build history and recipe versions were fruitless. 
The cherry picked engine pr doesn’t relate to the web failure, so initially the failure was suspected to be caused by dart changes on the release branch. And Zach connected us with Siva. we examined dart commits between dart main -> dev -> beta -> stable, and didn’t find any culprit.
In the mean time, Jackson proposed a fix PR https://github.com/flutter/engine/pull/39269 and pointed to Sam’s change https://github.com/dart-lang/sdk/commit/b1525bcf19a0b990ebdaf6f25dd18842f10b907b. However, this idea was initially turned down because people believe the newest changes in dart should not make it into the flutter release branch
However, Yegor later pointed out that dart pub get would pick up an unpinned version of the meta package. in https://github.com/flutter/engine/blob/main/lib/web_ui/pubspec.yaml web ui picks up the newest meta package. And it was probably what happened in https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8790504714907691905/+/u/web_engine_analysis/stdout
The understandings brought us back to the solution of Jackson’s pr, and a fix forward on head, and then a cherry pick was deemed to be the solution.
It turned out that this failure was the same failure that caused the engine tree to be closed. And luci-broken blocked the fix. Godofredo helped with adding the label “[warning: land on red to fix tree breakage](https://github.com/flutter/engine/labels/warning%3A%20land%20on%20red%20to%20fix%20tree%20breakage)”. And merged it into head.
I cherry picked it to stable branch.
Thanks Jackson, Yegor, Zach, Siva, Casey, Godofredo for the help!