### PR TITLE
Deprecate SingletonFlutterWindow and global window singleton

### DIFF
--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -284,21 +284,30 @@ class FlutterView {
   external static void _updateSemantics(SemanticsUpdate update);
 }
 
-/// A [FlutterView] that includes access to setting callbacks and retrieving
-/// properties that reside on the [PlatformDispatcher].
+/// Deprecated. Will be removed in a future version of Flutter.
 ///
-/// It is the type of the global [window] singleton used by applications that
-/// only have a single main window.
+/// This class has been deprecated to prepare for Flutter's upcoming support
+/// for multiple views and eventually multiple windows.
 ///
-/// In addition to the properties of [FlutterView], this class provides access
-/// to platform-specific properties. To modify or retrieve these properties,
-/// applications designed for more than one main window should prefer using
-/// `WidgetsBinding.instance.platformDispatcher` instead.
+/// This class has been split into two classes: [FlutterView] and
+/// [PlatformDispatcher]. The [FlutterView] gives an application access to
+/// view-specific functionality while the [PlatformDispatcher] contains
+/// platform-specific functionality that applies to all views.
 ///
-/// Prefer access through `WidgetsBinding.instance.window` or
-/// `WidgetsBinding.instance.platformDispatcher` over a static reference to
-/// [window], or [PlatformDispatcher.instance]. See the documentation for
-/// [PlatformDispatcher.instance] for more details about this recommendation.
+/// This class is used to back the global [window] singleton, which is also
+/// deprecated. See the docs on [window] for migration options.
+///
+/// See also:
+///
+/// * [FlutterView], which gives an application access to view-specific
+///   functionality.
+/// * [PlatformDispatcher], which gives an application access to
+///   platform-specific functionality.
+@Deprecated(
+  'Use FlutterView or PlatformDispatcher instead. '
+  'Deprecated to prepare for the upcoming multi-window support. '
+  'This feature was deprecated after v3.7.0-32.0.pre.'
+)
 class SingletonFlutterWindow extends FlutterView {
   SingletonFlutterWindow._(super.windowId, super.platformDispatcher)
       : super._();
@@ -552,7 +561,7 @@ class SingletonFlutterWindow extends FlutterView {
   /// {@macro dart.ui.window.accessorForwardWarning}
   ///
   /// It's preferred to use [SchedulerBinding.addTimingsCallback] than to use
-  /// [SingletonFlutterWindow.onReportTimings] directly because
+  /// [PlatformDispatcher.onReportTimings] directly because
   /// [SchedulerBinding.addTimingsCallback] allows multiple callbacks.
   ///
   /// This can be used to see if the window has missed frames (through
@@ -867,35 +876,44 @@ enum Brightness {
   light,
 }
 
-/// The [SingletonFlutterWindow] representing the main window for applications
-/// where there is only one window, such as applications designed for
-/// single-display mobile devices.
+/// Deprecated. Will be removed in a future version of Flutter.
 ///
-/// Applications that are designed to use more than one window should interact
-/// with the `WidgetsBinding.instance.platformDispatcher` instead.
+/// This property has been deprecated to prepare for Flutter's upcoming support
+/// for multiple views and eventually multiple windows.
 ///
-/// Consider avoiding static references to this singleton through
-/// [PlatformDispatcher.instance] and instead prefer using a binding for
-/// dependency resolution such as `WidgetsBinding.instance.window`.
+/// It used to represent the only window into which an application could draw
+/// content while giving the application access to window- and platform-specific
+/// functionality.
 ///
-/// Static access of this `window` object means that Flutter has few, if any
-/// options to fake or mock the given object in tests. Even in cases where Dart
-/// offers special language constructs to forcefully shadow such properties,
-/// those mechanisms would only be reasonable for tests and they would not be
-/// reasonable for a future of Flutter where we legitimately want to select an
-/// appropriate implementation at runtime.
+/// Several options exist to migrate code that relies on this property. They are
+/// listed below in order of preference:
 ///
-/// The only place that `WidgetsBinding.instance.window` is inappropriate is if
-/// access to these APIs is required before the binding is initialized by
-/// invoking `runApp()` or `WidgetsFlutterBinding.instance.ensureInitialized()`.
-/// In that case, it is necessary (though unfortunate) to use the
-/// [PlatformDispatcher.instance] object statically.
+/// The current [FlutterView] can be obtained from the context via [View.of]. It
+/// gives access to the same functionality as this deprecated global [window]
+/// property. However, some functionality has moved to the [PlatformDispatcher],
+/// which is exposed via [FlutterView.platformDispatcher].
+///
+/// If no context is available to look up a [FlutterView], the
+/// [PlatformDispatcher] can be consulted directly for platform-specific
+/// functionality. It also maintains a list of all available [FlutterView]s in
+/// [PlatformDispatcher.views] to access view-specific functionality without a
+/// context. If possible, consider accessing the [PlatformDispatcher] via the
+/// binding (e.g. `WidgetsBinding.instance.platformDispatcher`) instead of the
+/// static singleton [PlatformDispatcher.instance]. See
+/// [PlatformDispatcher.instance] for more information about why this is
+/// preferred.
 ///
 /// See also:
 ///
-/// * [PlatformDispatcher.views], contains the current list of Flutter windows
-///   belonging to the application, including top level application windows like
-///   this one.
+/// * [FlutterView], which gives an application access to view-specific
+///   functionality.
+/// * [PlatformDispatcher], which gives an application access to
+///   platform-specific functionality.
+@Deprecated(
+  'Look up the current FlutterView from the context via View.of(context) or consult the PlatformDispatcher directly instead.'
+  'Deprecated to prepare for the upcoming multi-window support. '
+  'This feature was deprecated after v3.7.0-32.0.pre.'
+)
 final SingletonFlutterWindow window = SingletonFlutterWindow._(0, PlatformDispatcher.instance);
 
 /// Additional data available on each flutter frame.


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/116929.