### PR TITLE
Add SkSurface include to every file where it's used

### DIFF
--- a/display_list/display_list_benchmarks.cc
+++ b/display_list/display_list_benchmarks.cc
@@ -7,6 +7,7 @@
 #include "flutter/display_list/display_list_flags.h"
 
 #include "third_party/skia/include/core/SkPoint.h"
+#include "third_party/skia/include/core/SkSurface.h"
 #include "third_party/skia/include/core/SkTextBlob.h"
 
 namespace flutter {

--- a/display_list/display_list_benchmarks_gl.cc
+++ b/display_list/display_list_benchmarks_gl.cc
@@ -6,6 +6,7 @@
 #include "flutter/display_list/display_list_benchmarks.h"
 
 #include "third_party/skia/include/core/SkCanvas.h"
+#include "third_party/skia/include/core/SkSurface.h"
 
 namespace flutter {
 namespace testing {

--- a/display_list/display_list_benchmarks_gl.h
+++ b/display_list/display_list_benchmarks_gl.h
@@ -6,7 +6,10 @@
 #define FLUTTER_FLOW_DISPLAY_LIST_BENCHMARKS_GL_H_
 
 #include "flutter/display_list/display_list_benchmarks_canvas_provider.h"
+
 #include "flutter/testing/test_gl_surface.h"
+
+#include "third_party/skia/include/core/SkSurface.h"
 
 namespace flutter {
 namespace testing {

--- a/display_list/display_list_benchmarks_metal.cc
+++ b/display_list/display_list_benchmarks_metal.cc
@@ -6,6 +6,7 @@
 #include "flutter/display_list/display_list_benchmarks.h"
 
 #include "third_party/skia/include/core/SkCanvas.h"
+#include "third_party/skia/include/core/SkSurface.h"
 
 namespace flutter {
 namespace testing {

--- a/display_list/display_list_benchmarks_metal.h
+++ b/display_list/display_list_benchmarks_metal.h
@@ -8,6 +8,8 @@
 #include "flutter/display_list/display_list_benchmarks_canvas_provider.h"
 #include "flutter/testing/test_metal_surface.h"
 
+#include "third_party/skia/include/core/SkSurface.h"
+
 namespace flutter {
 namespace testing {
 

--- a/display_list/display_list_benchmarks_software.cc
+++ b/display_list/display_list_benchmarks_software.cc
@@ -5,6 +5,8 @@
 #include "flutter/display_list/display_list_benchmarks_software.h"
 #include "flutter/display_list/display_list_benchmarks.h"
 
+#include "third_party/skia/include/core/SkSurface.h"
+
 namespace flutter {
 namespace testing {
 

--- a/display_list/display_list_unittests.cc
+++ b/display_list/display_list_unittests.cc
@@ -21,6 +21,8 @@
 #include "flutter/testing/display_list_testing.h"
 #include "flutter/testing/testing.h"
 
+#include "third_party/skia/include/core/SkSurface.h"
+
 namespace flutter {
 namespace testing {
 

--- a/flow/instrumentation.h
+++ b/flow/instrumentation.h
@@ -10,7 +10,9 @@
 #include "flutter/fml/macros.h"
 #include "flutter/fml/time/time_delta.h"
 #include "flutter/fml/time/time_point.h"
+
 #include "third_party/skia/include/core/SkCanvas.h"
+#include "third_party/skia/include/core/SkSurface.h"
 
 namespace flutter {
 

--- a/flow/layers/physical_shape_layer_unittests.cc
+++ b/flow/layers/physical_shape_layer_unittests.cc
@@ -11,6 +11,8 @@
 #include "flutter/fml/macros.h"
 #include "flutter/testing/mock_canvas.h"
 
+#include "third_party/skia/include/core/SkSurface.h"
+
 namespace flutter {
 namespace testing {
 

--- a/flow/surface_frame.cc
+++ b/flow/surface_frame.cc
@@ -9,6 +9,8 @@
 
 #include "flutter/fml/logging.h"
 #include "flutter/fml/trace_event.h"
+
+#include "third_party/skia/include/core/SkSurface.h"
 #include "third_party/skia/include/utils/SkNWayCanvas.h"
 
 namespace flutter {

--- a/flow/surface_frame.h
+++ b/flow/surface_frame.h
@@ -12,6 +12,7 @@
 #include "flutter/display_list/display_list_canvas_recorder.h"
 #include "flutter/fml/macros.h"
 #include "flutter/fml/time/time_point.h"
+
 #include "third_party/skia/include/core/SkCanvas.h"
 #include "third_party/skia/include/core/SkSurface.h"
 

--- a/lib/ui/painting/image_encoding.cc
+++ b/lib/ui/painting/image_encoding.cc
@@ -18,6 +18,7 @@
 #endif  // IMPELLER_SUPPORTS_RENDERING
 #include "flutter/lib/ui/painting/image_encoding_skia.h"
 #include "third_party/skia/include/core/SkEncodedImageFormat.h"
+#include "third_party/skia/include/core/SkSurface.h"
 #include "third_party/tonic/dart_persistent_value.h"
 #include "third_party/tonic/logging/dart_invoke.h"
 #include "third_party/tonic/typed_data/typed_list.h"

--- a/shell/common/rasterizer_unittests.cc
+++ b/shell/common/rasterizer_unittests.cc
@@ -15,6 +15,8 @@
 #include "flutter/shell/common/thread_host.h"
 #include "flutter/testing/testing.h"
 
+#include "third_party/skia/include/core/SkSurface.h"
+
 #include "gmock/gmock.h"
 
 using testing::_;

--- a/shell/common/shell_test_platform_view_vulkan.cc
+++ b/shell/common/shell_test_platform_view_vulkan.cc
@@ -12,6 +12,8 @@
 #include "flutter/vulkan/vulkan_skia_proc_table.h"
 #include "flutter/vulkan/vulkan_utilities.h"
 
+#include "third_party/skia/include/core/SkSurface.h"
+
 #if OS_FUCHSIA
 #define VULKAN_SO_PATH "libvulkan.so"
 #elif FML_OS_MACOSX

--- a/shell/gpu/gpu_surface_gl_skia.h
+++ b/shell/gpu/gpu_surface_gl_skia.h
@@ -14,6 +14,8 @@
 #include "flutter/fml/macros.h"
 #include "flutter/fml/memory/weak_ptr.h"
 #include "flutter/shell/gpu/gpu_surface_gl_delegate.h"
+
+#include "third_party/skia/include/core/SkSurface.h"
 #include "third_party/skia/include/gpu/GrDirectContext.h"
 
 namespace flutter {

--- a/shell/gpu/gpu_surface_software.cc
+++ b/shell/gpu/gpu_surface_software.cc
@@ -5,7 +5,10 @@
 #include "flutter/shell/gpu/gpu_surface_software.h"
 
 #include <memory>
+
 #include "flutter/fml/logging.h"
+
+#include "third_party/skia/include/core/SkSurface.h"
 
 namespace flutter {
 

--- a/shell/gpu/gpu_surface_vulkan.cc
+++ b/shell/gpu/gpu_surface_vulkan.cc
@@ -5,9 +5,11 @@
 #include "flutter/shell/gpu/gpu_surface_vulkan.h"
 
 #include "flutter/fml/logging.h"
-#include "fml/trace_event.h"
-#include "include/core/SkColorSpace.h"
-#include "include/core/SkSize.h"
+#include "flutter/fml/trace_event.h"
+
+#include "third_party/skia/include/core/SkColorSpace.h"
+#include "third_party/skia/include/core/SkSize.h"
+#include "third_party/skia/include/core/SkSurface.h"
 #include "vulkan/vulkan_core.h"
 
 namespace flutter {

--- a/shell/gpu/gpu_surface_vulkan.h
+++ b/shell/gpu/gpu_surface_vulkan.h
@@ -14,7 +14,9 @@
 #include "flutter/vulkan/vulkan_backbuffer.h"
 #include "flutter/vulkan/vulkan_native_surface.h"
 #include "flutter/vulkan/vulkan_window.h"
-#include "include/core/SkRefCnt.h"
+
+#include "third_party/skia/include/core/SkRefCnt.h"
+#include "third_party/skia/include/core/SkSurface.h"
 
 namespace flutter {
 

--- a/shell/platform/android/android_surface_software.cc
+++ b/shell/platform/android/android_surface_software.cc
@@ -13,7 +13,9 @@
 #include "flutter/fml/trace_event.h"
 #include "flutter/shell/platform/android/android_shell_holder.h"
 #include "flutter/shell/platform/android/jni/platform_view_android_jni.h"
+
 #include "third_party/skia/include/core/SkImage.h"
+#include "third_party/skia/include/core/SkSurface.h"
 
 namespace flutter {
 

--- a/shell/platform/android/android_surface_software.h
+++ b/shell/platform/android/android_surface_software.h
@@ -12,6 +12,8 @@
 #include "flutter/shell/platform/android/jni/platform_view_android_jni.h"
 #include "flutter/shell/platform/android/surface/android_surface.h"
 
+#include "third_party/skia/include/core/SkSurface.h"
+
 namespace flutter {
 
 class AndroidSurfaceSoftware final : public AndroidSurface,

--- a/shell/platform/android/external_view_embedder/external_view_embedder_unittests.cc
+++ b/shell/platform/android/external_view_embedder/external_view_embedder_unittests.cc
@@ -5,6 +5,7 @@
 #define FML_USED_ON_EMBEDDER
 
 #include <memory>
+
 #include "flutter/shell/platform/android/external_view_embedder/external_view_embedder.h"
 
 #include "flutter/flow/embedded_views.h"
@@ -14,8 +15,10 @@
 #include "flutter/shell/platform/android/jni/jni_mock.h"
 #include "flutter/shell/platform/android/surface/android_surface.h"
 #include "flutter/shell/platform/android/surface/android_surface_mock.h"
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "third_party/skia/include/core/SkSurface.h"
 #include "third_party/skia/include/gpu/GrDirectContext.h"
 
 namespace flutter {

--- a/shell/platform/darwin/ios/ios_surface_software.h
+++ b/shell/platform/darwin/ios/ios_surface_software.h
@@ -12,6 +12,8 @@
 #import "flutter/shell/platform/darwin/ios/ios_context.h"
 #import "flutter/shell/platform/darwin/ios/ios_surface.h"
 
+#include "third_party/skia/include/core/SkSurface.h"
+
 @class CALayer;
 
 namespace flutter {

--- a/shell/platform/darwin/ios/ios_surface_software.mm
+++ b/shell/platform/darwin/ios/ios_surface_software.mm
@@ -11,6 +11,8 @@
 #include "flutter/fml/logging.h"
 #include "flutter/fml/platform/darwin/cf_utils.h"
 #include "flutter/fml/trace_event.h"
+
+#include "third_party/skia/include/core/SkSurface.h"
 #include "third_party/skia/include/utils/mac/SkCGUtils.h"
 
 namespace flutter {

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -19,6 +19,7 @@
 #include "flutter/fml/thread.h"
 #include "third_party/dart/runtime/bin/elf_loader.h"
 #include "third_party/dart/runtime/include/dart_native_api.h"
+#include "third_party/skia/include/core/SkSurface.h"
 
 #if !defined(FLUTTER_NO_EXPORT)
 #if FML_OS_WIN

--- a/shell/platform/embedder/embedder_render_target.cc
+++ b/shell/platform/embedder/embedder_render_target.cc
@@ -8,6 +8,8 @@
 
 #include "flutter/fml/logging.h"
 
+#include "third_party/skia/include/core/SkSurface.h"
+
 namespace flutter {
 
 EmbedderRenderTarget::EmbedderRenderTarget(FlutterBackingStore backing_store,

--- a/shell/platform/embedder/embedder_surface_metal.h
+++ b/shell/platform/embedder/embedder_surface_metal.h
@@ -11,6 +11,8 @@
 #include "flutter/shell/platform/embedder/embedder_external_view_embedder.h"
 #include "flutter/shell/platform/embedder/embedder_surface.h"
 
+#include "third_party/skia/include/core/SkSurface.h"
+
 namespace flutter {
 
 class EmbedderSurfaceMetal final : public EmbedderSurface,

--- a/shell/platform/embedder/embedder_surface_software.cc
+++ b/shell/platform/embedder/embedder_surface_software.cc
@@ -7,8 +7,10 @@
 #include <utility>
 
 #include "flutter/fml/trace_event.h"
+
 #include "third_party/skia/include/core/SkColorSpace.h"
 #include "third_party/skia/include/core/SkImageInfo.h"
+#include "third_party/skia/include/core/SkSurface.h"
 #include "third_party/skia/include/gpu/GrDirectContext.h"
 
 namespace flutter {

--- a/shell/platform/embedder/embedder_surface_software.h
+++ b/shell/platform/embedder/embedder_surface_software.h
@@ -10,6 +10,8 @@
 #include "flutter/shell/platform/embedder/embedder_external_view_embedder.h"
 #include "flutter/shell/platform/embedder/embedder_surface.h"
 
+#include "third_party/skia/include/core/SkSurface.h"
+
 namespace flutter {
 
 class EmbedderSurfaceSoftware final : public EmbedderSurface,

--- a/shell/platform/embedder/tests/embedder_metal_unittests.mm
+++ b/shell/platform/embedder/tests/embedder_metal_unittests.mm
@@ -19,6 +19,8 @@
 #include "flutter/testing/assertions_skia.h"
 #include "flutter/testing/testing.h"
 
+#include "third_party/skia/include/core/SkSurface.h"
+
 // CREATE_NATIVE_ENTRY is leaky by design
 // NOLINTBEGIN(clang-analyzer-core.StackAddressEscape)
 

--- a/shell/platform/embedder/tests/embedder_test_backingstore_producer.h
+++ b/shell/platform/embedder/tests/embedder_test_backingstore_producer.h
@@ -9,6 +9,8 @@
 #include "flutter/fml/macros.h"
 #include "flutter/fml/memory/ref_ptr_internal.h"
 #include "flutter/shell/platform/embedder/embedder.h"
+
+#include "third_party/skia/include/core/SkSurface.h"
 #include "third_party/skia/include/gpu/GrDirectContext.h"
 
 #ifdef SHELL_ENABLE_METAL

--- a/shell/platform/embedder/tests/embedder_test_context_software.h
+++ b/shell/platform/embedder/tests/embedder_test_context_software.h
@@ -7,6 +7,8 @@
 
 #include "flutter/shell/platform/embedder/tests/embedder_test_context.h"
 
+#include "third_party/skia/include/core/SkSurface.h"
+
 namespace flutter {
 namespace testing {
 

--- a/shell/platform/embedder/tests/embedder_unittests_util.cc
+++ b/shell/platform/embedder/tests/embedder_unittests_util.cc
@@ -10,6 +10,8 @@
 #include "flutter/shell/platform/embedder/tests/embedder_test_backingstore_producer.h"
 #include "flutter/shell/platform/embedder/tests/embedder_unittests_util.h"
 
+#include "third_party/skia/include/core/SkSurface.h"
+
 namespace flutter {
 namespace testing {
 

--- a/shell/platform/fuchsia/flutter/software_surface.cc
+++ b/shell/platform/fuchsia/flutter/software_surface.cc
@@ -16,8 +16,10 @@
 #include "flutter/fml/trace_event.h"
 #include "fuchsia/sysmem/cpp/fidl.h"
 #include "include/core/SkImageInfo.h"
+
 #include "third_party/skia/include/core/SkColorSpace.h"
 #include "third_party/skia/include/core/SkImageInfo.h"
+#include "third_party/skia/include/core/SkSurface.h"
 
 #include "../runtime/dart/utils/inlines.h"
 

--- a/shell/platform/fuchsia/flutter/vulkan_surface_producer.cc
+++ b/shell/platform/fuchsia/flutter/vulkan_surface_producer.cc
@@ -14,6 +14,8 @@
 #include "flutter/fml/trace_event.h"
 #include "flutter/vulkan/vulkan_skia_proc_table.h"
 #include "flutter_vma/flutter_skia_vma.h"
+
+#include "third_party/skia/include/core/SkSurface.h"
 #include "third_party/skia/include/gpu/GrBackendSemaphore.h"
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
 #include "third_party/skia/include/gpu/vk/GrVkBackendContext.h"

--- a/shell/testing/tester_main.cc
+++ b/shell/testing/tester_main.cc
@@ -24,8 +24,10 @@
 #include "flutter/shell/common/switches.h"
 #include "flutter/shell/common/thread_host.h"
 #include "flutter/shell/gpu/gpu_surface_software.h"
+
 #include "third_party/dart/runtime/include/bin/dart_io_api.h"
 #include "third_party/dart/runtime/include/dart_api.h"
+#include "third_party/skia/include/core/SkSurface.h"
 
 #if defined(FML_OS_WIN)
 #include <combaseapi.h>

--- a/testing/test_gl_surface.h
+++ b/testing/test_gl_surface.h
@@ -8,6 +8,8 @@
 #include <cstdint>
 
 #include "flutter/fml/macros.h"
+
+#include "third_party/skia/include/core/SkSurface.h"
 #include "third_party/skia/include/gpu/GrDirectContext.h"
 
 namespace flutter {

--- a/testing/test_metal_surface.cc
+++ b/testing/test_metal_surface.cc
@@ -7,6 +7,8 @@
 #include "flutter/fml/logging.h"
 #include "flutter/testing/test_metal_surface_impl.h"
 
+#include "third_party/skia/include/core/SkSurface.h"
+
 namespace flutter {
 
 bool TestMetalSurface::PlatformSupportsMetal() {

--- a/testing/test_metal_surface_impl.h
+++ b/testing/test_metal_surface_impl.h
@@ -9,6 +9,8 @@
 #include "flutter/testing/test_metal_context.h"
 #include "flutter/testing/test_metal_surface.h"
 
+#include "third_party/skia/include/core/SkSurface.h"
+
 namespace flutter {
 
 class TestMetalSurfaceImpl : public TestMetalSurface {

--- a/vulkan/vulkan_swapchain.cc
+++ b/vulkan/vulkan_swapchain.cc
@@ -7,6 +7,7 @@
 #include "flutter/vulkan/procs/vulkan_proc_table.h"
 
 #include "third_party/skia/include/core/SkColorSpace.h"
+#include "third_party/skia/include/core/SkSurface.h"
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
 #include "third_party/skia/include/gpu/GrDirectContext.h"
 #include "third_party/skia/include/gpu/vk/GrVkTypes.h"

--- a/vulkan/vulkan_window.cc
+++ b/vulkan/vulkan_window.cc
@@ -11,12 +11,14 @@
 
 #include "flutter/flutter_vma/flutter_skia_vma.h"
 #include "flutter/vulkan/vulkan_skia_proc_table.h"
-#include "third_party/skia/include/gpu/GrDirectContext.h"
 #include "vulkan_application.h"
 #include "vulkan_device.h"
 #include "vulkan_native_surface.h"
 #include "vulkan_surface.h"
 #include "vulkan_swapchain.h"
+
+#include "third_party/skia/include/core/SkSurface.h"
+#include "third_party/skia/include/gpu/GrDirectContext.h"
 
 namespace vulkan {
 


### PR DESCRIPTION
This is a follow-up to https://github.com/flutter/engine/pull/39295, which just includes `SkSurface` in every file where it's used to ensure the Skia roll gets unblocked. To save time, I didn't normalize the includes based on header dependencies.

Blocked Skia roll: https://github.com/flutter/engine/pull/39299