### PR TITLE
Revert "Remove uses of `--full-dart-sdk` from the engine_v2 builders."

### DIFF
--- a/ci/builders/linux_arm_host_engine.json
+++ b/ci/builders/linux_arm_host_engine.json
@@ -59,6 +59,7 @@
             "gn": [
                 "--runtime-mode",
                 "debug",
+                "--full-dart-sdk",
                 "--target-os=linux",
                 "--linux-cpu=arm64",
                 "--prebuilt-dart-sdk"

--- a/ci/builders/linux_host_engine.json
+++ b/ci/builders/linux_host_engine.json
@@ -78,6 +78,7 @@
                         "out/host_debug/zip_archives/linux-x64/font-subset.zip",
                         "out/host_debug/zip_archives/flutter_patched_sdk.zip",
                         "out/host_debug/zip_archives/dart-sdk-linux-x64.zip",
+                        "out/host_debug/zip_archives/flutter-web-sdk-linux-x64.zip",
                         "out/host_debug/zip_archives/linux-x64/linux-x64-flutter-gtk.zip"
                     ]
                 }
@@ -92,6 +93,7 @@
             "gn": [
                 "--runtime-mode",
                 "debug",
+                "--full-dart-sdk",
                 "--prebuilt-dart-sdk",
                 "--build-embedder-examples"
             ],
@@ -103,6 +105,7 @@
                     "flutter/build/archives:embedder",
                     "flutter/build/archives:flutter_patched_sdk",
                     "flutter/build/archives:dart_sdk_archive",
+                    "flutter/web_sdk",
                     "flutter/tools/font-subset",
                     "flutter/shell/platform/linux:flutter_gtk"
                 ]

--- a/ci/builders/mac_host_engine.json
+++ b/ci/builders/mac_host_engine.json
@@ -8,7 +8,8 @@
                     "include_paths": [
                         "out/host_debug/zip_archives/darwin-x64/artifacts.zip",
                         "out/host_debug/zip_archives/darwin-x64/FlutterEmbedder.framework.zip",
-                        "out/host_debug/zip_archives/dart-sdk-darwin-x64.zip"
+                        "out/host_debug/zip_archives/dart-sdk-darwin-x64.zip",
+                        "out/host_debug/zip_archives/flutter-web-sdk-darwin-x64.zip"
                     ],
                     "name": "host_debug"
                 }
@@ -25,6 +26,7 @@
                 "--runtime-mode",
                 "debug",
                 "--no-lto",
+                "--full-dart-sdk",
                 "--prebuilt-dart-sdk",
                 "--build-embedder-examples"
             ],
@@ -35,6 +37,7 @@
                     "flutter/shell/platform/darwin/macos:zip_macos_flutter_framework",
                     "flutter/build/archives:artifacts",
                     "flutter/build/archives:dart_sdk_archive",
+                    "flutter/web_sdk",
                     "flutter/build/archives:archive_gen_snapshot",
                     "flutter/build/archives:flutter_embedder_framework"
                 ]
@@ -159,6 +162,7 @@
                 "--runtime-mode",
                 "debug",
                 "--no-lto",
+                "--full-dart-sdk",
                 "--prebuilt-dart-sdk"
             ],
             "name": "mac_debug_arm64",

--- a/ci/builders/web_engine.json
+++ b/ci/builders/web_engine.json
@@ -1,41 +1,102 @@
 {
-    "generators": {
-        "pub_dirs": [
-            "flutter/lib/web_ui/",
-            "flutter/web_sdk/web_engine_tester/"
-        ],
-        "tasks": [
-            {
-                "name": "compile web_tests",
-                "parameters": [
-                    "run",
-                    "compile_tests"
+    "builds": [
+        {
+            "archives": [],
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Windows-10"
+            ],
+            "gn": [
+                "--runtime-mode",
+                "debug",
+                "--unoptimized",
+                "--full-dart-sdk",
+                "--prebuilt-dart-sdk"
+            ],
+            "name": "windows_host_debug",
+            "ninja": {
+                "config": "host_debug_unopt",
+                "targets": []
+            },
+            "platform": "Windows",
+            "tests": []
+        },
+        {
+            "archives": [],
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux"
+            ],
+            "generators": {
+                "pub_dirs": [
+                    "flutter/lib/web_ui/",
+                    "flutter/web_sdk/web_engine_tester/"
                 ],
-                "scripts": [
-                    "out/host_debug_unopt/dart-sdk/bin/dart",
-                    "flutter/lib/web_ui/dev/felt.dart"
+                "tasks": [
+                    {
+                        "name": "compile web_tests",
+                        "parameters": [
+                            "run",
+                            "compile_tests"
+                        ],
+                        "scripts": [
+                            "out/host_debug_unopt/dart-sdk/bin/dart",
+                            "flutter/lib/web_ui/dev/felt.dart"
+                        ]
+                    },
+                    {
+                        "name": "check licenses",
+                        "parameters": [
+                            "check-licenses"
+                        ],
+                        "scripts": [
+                            "out/host_debug_unopt/dart-sdk/bin/dart",
+                            "flutter/lib/web_ui/dev/felt.dart"
+                        ]
+                    },
+                    {
+                        "name": "web engine analysis",
+                        "parameters": [],
+                        "scripts": [
+                            "flutter/lib/web_ui/dev/web_engine_analysis.sh"
+                        ]
+                    }
                 ]
             },
-            {
-                "name": "check licenses",
-                "parameters": [
-                    "check-licenses"
-                ],
-                "scripts": [
-                    "out/host_debug_unopt/dart-sdk/bin/dart",
-                    "flutter/lib/web_ui/dev/felt.dart"
-                ]
+            "gn": [
+                "--runtime-mode",
+                "debug",
+                "--unoptimized",
+                "--full-dart-sdk"
+            ],
+            "name": "linux_host_debug_unopt",
+            "ninja": {
+                "config": "host_debug_unopt",
+                "targets": []
             },
-            {
-                "name": "web engine analysis",
-                "parameters": [
-                    "analyze"
-                ],
-                "scripts": [
-                    "out/host_debug_unopt/dart-sdk/bin/dart",
-                    "flutter/lib/web_ui/dev/felt.dart"
-                ]
-            }
-        ]
-    }
+            "platform": "Linux",
+            "tests": []
+        },
+        {
+            "archives": [],
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Mac"
+            ],
+            "gn": [
+                "--runtime-mode",
+                "debug",
+                "--unoptimized",
+                "--full-dart-sdk",
+                "--prebuilt-dart-sdk"
+            ],
+            "name": "mac_host_debug_unopt",
+            "ninja": {
+                "config": "host_debug_unopt",
+                "targets": []
+            },
+            "platform": "Mac",
+            "tests": []
+        }
+    ]
 }

--- a/ci/builders/windows_arm_host_engine.json
+++ b/ci/builders/windows_arm_host_engine.json
@@ -11,7 +11,8 @@
                         "out/host_debug_arm64/zip_archives/windows-arm64/font-subset.zip",
                         "out/host_debug_arm64/zip_archives/dart-sdk-windows-arm64.zip",
                         "out/host_debug_arm64/zip_archives/windows-arm64-debug/windows-arm64-flutter.zip",
-                        "out/host_debug_arm64/zip_archives/windows-arm64/flutter-cpp-client-wrapper.zip"
+                        "out/host_debug_arm64/zip_archives/windows-arm64/flutter-cpp-client-wrapper.zip",
+                        "out/host_debug_arm64/zip_archives/flutter-web-sdk-windows-arm64.zip"
                     ],
                     "name": "host_debug_arm64"
                 }
@@ -26,6 +27,7 @@
             "gn": [
                 "--runtime-mode",
                 "debug",
+                "--full-dart-sdk",
                 "--no-lto",
                 "--windows-cpu",
                 "arm64"
@@ -39,7 +41,8 @@
                     "flutter/tools/font-subset",
                     "flutter/build/archives:dart_sdk_archive",
                     "flutter/shell/platform/windows/client_wrapper:client_wrapper_archive",
-                    "flutter/build/archives:windows_flutter"
+                    "flutter/build/archives:windows_flutter",
+                    "flutter/web_sdk"
                 ]
             },
             "tests": []

--- a/ci/builders/windows_host_engine.json
+++ b/ci/builders/windows_host_engine.json
@@ -11,7 +11,8 @@
                         "out/host_debug/zip_archives/windows-x64/font-subset.zip",
                         "out/host_debug/zip_archives/dart-sdk-windows-x64.zip",
                         "out/host_debug/zip_archives/windows-x64-debug/windows-x64-flutter.zip",
-                        "out/host_debug/zip_archives/windows-x64/flutter-cpp-client-wrapper.zip"
+                        "out/host_debug/zip_archives/windows-x64/flutter-cpp-client-wrapper.zip",
+                        "out/host_debug/zip_archives/flutter-web-sdk-windows-x64.zip"
                     ],
                     "name": "host_debug"
                 }
@@ -26,6 +27,7 @@
             "gn": [
                 "--runtime-mode",
                 "debug",
+                "--full-dart-sdk",
                 "--no-lto"
             ],
             "name": "host_debug",
@@ -38,7 +40,8 @@
                     "flutter/tools/font-subset",
                     "flutter/build/archives:dart_sdk_archive",
                     "flutter/shell/platform/windows/client_wrapper:client_wrapper_archive",
-                    "flutter/build/archives:windows_flutter"
+                    "flutter/build/archives:windows_flutter",
+                    "flutter/web_sdk"
                 ]
             },
             "tests": [

--- a/lib/web_ui/dev/felt_windows.bat
+++ b/lib/web_ui/dev/felt_windows.bat
@@ -1,0 +1,68 @@
+:: TODO(yjbanov): migrate LUCI to felt.bat and delete this file.
+:: felt_windows: a command-line utility for Windows for building and testing
+:: Flutter web engine.
+:: FELT stands for Flutter Engine Local Tester.
+
+@ECHO OFF
+SETLOCAL
+
+FOR /F "tokens=1-2 delims=:" %%a in ('where gclient') DO SET GCLIENT_PATH=%%b
+IF %GCLIENT_PATH%==[] (ECHO "ERROR: gclient is not in your PATH")
+
+FOR /F "tokens=1-2 delims=:" %%a in ('where ninja') DO SET NINJA_PATH=%%b
+IF %NINJA_PATH%==[] (ECHO "ERROR: ninja is not in your PATH")
+
+SET FELT_DIR=%~dp0
+
+:: web_ui directory is the parent of felt directory.
+FOR %%a IN ("%FELT_DIR:~0,-1%") DO SET WEB_UI_DIR=%%~dpa
+
+:: Flutter Directory is grandparent of web_ui directory.
+FOR %%a IN ("%WEB_UI_DIR:~0,-1%") DO SET orTempValue=%%~dpa
+FOR %%a IN ("%orTempValue:~0,-1%") DO SET FLUTTER_DIR=%%~dpa
+
+:: Engine source directory is the parent of flutter directory.
+FOR %%a IN ("%FLUTTER_DIR:~0,-1%") DO SET ENGINE_SRC_DIR=%%~dpa
+
+SET DEV_DIR="%WEB_UI_DIR%dev"
+SET OUT_DIR="%ENGINE_SRC_DIR%out"
+SET HOST_DEBUG_UNOPT_DIR="%ENGINE_SRC_DIR%out\host_debug_unopt"
+SET SCRIPT_PATH="%DEV_DIR%felt.dart"
+SET STAMP_PATH="%DART_TOOL_DIR%felt.snapshot.stamp"
+SET GN="%FLUTTER_DIR%tools\gn"
+SET DART_TOOL_DIR="%WEB_UI_DIR%.dart_tool"
+SET SNAPSHOT_PATH="%DART_TOOL_DIR%felt.snapshot"
+SET SDK_PREBUILTS_DIR=%FLUTTER_DIR%\prebuilts
+SET PREBUILT_TARGET=windows-x64
+IF NOT DEFINED DART_SDK_DIR (
+  SET DART_SDK_DIR=%SDK_PREBUILTS_DIR%\%PREBUILT_TARGET%\dart-sdk
+)
+
+:: Set revision from using git in Flutter directory.
+CD %FLUTTER_DIR%
+FOR /F "tokens=1 delims=:" %%a in ('git rev-parse HEAD') DO SET REVISION=%%a
+
+SET orTempValue=1
+IF NOT EXIST %OUT_DIR% (SET orTempValue=0)
+IF NOT EXIST %HOST_DEBUG_UNOPT_DIR% (SET orTempValue=0)
+IF %orTempValue%==0 (
+  ECHO "Compiling the Dart SDK."
+  CALL gclient sync
+  CALL python %GN% --unoptimized --full-dart-sdk
+  CALL ninja -C %HOST_DEBUG_UNOPT_DIR%)
+
+:: TODO(yjbanov): The batch script does not support snapshot option.
+:: Support snapshot option.
+CALL :installdeps
+IF "%1"=="test" (%DART_SDK_DIR%\bin\dart %DEV_DIR%\felt.dart %* --browser=chrome) ELSE ( %DART_SDK_DIR%\bin\dart %DEV_DIR%\felt.dart %* )
+
+EXIT /B %ERRORLEVEL%
+
+:installdeps
+ECHO "Running \`pub get\` in 'engine/src/flutter/web_sdk/web_engine_tester'"
+cd "%FLUTTER_DIR%web_sdk\web_engine_tester"
+CALL %DART_SDK_DIR%\bin\dart pub get
+ECHO "Running \`pub get\` in 'engine/src/flutter/lib/web_ui'"
+cd %WEB_UI_DIR%
+CALL %DART_SDK_DIR%\bin\dart pub get
+EXIT /B 0


### PR DESCRIPTION
Reverts flutter/engine#39297 to recover the roll: https://github.com/flutter/flutter/issues/119665