### PR TITLE
[Impeller] Don't ceil subpass texture sizes

### DIFF
--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -324,11 +324,11 @@ EntityPass::EntityResult EntityPass::GetEntityForElement(
 
     RenderTarget subpass_target;
     if (subpass->reads_from_pass_texture_ > 0) {
-      subpass_target = CreateRenderTarget(
-          renderer, ISize::Ceil(subpass_coverage->size), true);
+      subpass_target =
+          CreateRenderTarget(renderer, ISize(subpass_coverage->size), true);
     } else {
-      subpass_target = CreateRenderTarget(
-          renderer, ISize::Ceil(subpass_coverage->size), false);
+      subpass_target =
+          CreateRenderTarget(renderer, ISize(subpass_coverage->size), false);
     }
 
     auto subpass_texture = subpass_target.GetRenderTargetTexture();

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -322,14 +322,10 @@ EntityPass::EntityResult EntityPass::GetEntityForElement(
       return EntityPass::EntityResult::Skip();
     }
 
-    RenderTarget subpass_target;
-    if (subpass->reads_from_pass_texture_ > 0) {
-      subpass_target =
-          CreateRenderTarget(renderer, ISize(subpass_coverage->size), true);
-    } else {
-      subpass_target =
-          CreateRenderTarget(renderer, ISize(subpass_coverage->size), false);
-    }
+    auto subpass_target =
+        CreateRenderTarget(renderer,                       //
+                           ISize(subpass_coverage->size),  //
+                           subpass->reads_from_pass_texture_ > 0);
 
     auto subpass_texture = subpass_target.GetRenderTargetTexture();
 


### PR DESCRIPTION
"Resolves" https://github.com/flutter/flutter/issues/119289.

Rather than expanding the layer to account for subpixel offsets, cut away partially covered edge pixels of subpass textures. This is a tiny fidelity compromise to behave more like Skia does for filtered savelayers.

Impeller before:

https://user-images.githubusercontent.com/919017/216296837-19593b7c-05af-4477-955b-819183973a6f.mov

Impeller after:

https://user-images.githubusercontent.com/919017/216294182-46f90dd6-aed2-4106-9514-432789b10452.mov

This isn't a perfect result, but it at least closely matches the behavior of Skia.

Skia:

https://user-images.githubusercontent.com/919017/216294269-310c4a83-19b4-485b-9c1f-f55edbe0d65b.mov




