### PR TITLE
Fire UIA event on Checkbox state change

### DIFF
--- a/third_party/accessibility/ax/platform/ax_platform_node_win.cc
+++ b/third_party/accessibility/ax/platform/ax_platform_node_win.cc
@@ -5266,7 +5266,6 @@ std::optional<EVENTID> AXPlatformNodeWin::MojoEventToUIAEvent(
   }
 }
 
-// static
 std::optional<PROPERTYID> AXPlatformNodeWin::MojoEventToUIAProperty(
     ax::mojom::Event event) {
   switch (event) {
@@ -5281,6 +5280,11 @@ std::optional<PROPERTYID> AXPlatformNodeWin::MojoEventToUIAProperty(
     case ax::mojom::Event::kSelectionAdd:
     case ax::mojom::Event::kSelectionRemove:
       return UIA_SelectionItemIsSelectedPropertyId;
+    case ax::mojom::Event::kValueChanged:
+      if (SupportsToggle(GetData().role)) {
+        return UIA_ToggleToggleStatePropertyId;
+      }
+      return std::nullopt;
     default:
       return std::nullopt;
   }

--- a/third_party/accessibility/ax/platform/ax_platform_node_win.h
+++ b/third_party/accessibility/ax/platform/ax_platform_node_win.h
@@ -470,8 +470,7 @@ class AX_EXPORT __declspec(uuid("26f5641a-246d-457b-a96d-07f3fae6acf2"))
   static std::optional<EVENTID> MojoEventToUIAEvent(ax::mojom::Event event);
 
   // Convert a mojo event to a UIA property id. Exposed for testing.
-  std::optional<PROPERTYID> MojoEventToUIAProperty(
-      ax::mojom::Event event);
+  std::optional<PROPERTYID> MojoEventToUIAProperty(ax::mojom::Event event);
 
   // |AXPlatformNodeBase|
   bool IsDescendantOf(AXPlatformNode* ancestor) const override;

--- a/third_party/accessibility/ax/platform/ax_platform_node_win.h
+++ b/third_party/accessibility/ax/platform/ax_platform_node_win.h
@@ -470,7 +470,7 @@ class AX_EXPORT __declspec(uuid("26f5641a-246d-457b-a96d-07f3fae6acf2"))
   static std::optional<EVENTID> MojoEventToUIAEvent(ax::mojom::Event event);
 
   // Convert a mojo event to a UIA property id. Exposed for testing.
-  static std::optional<PROPERTYID> MojoEventToUIAProperty(
+  std::optional<PROPERTYID> MojoEventToUIAProperty(
       ax::mojom::Event event);
 
   // |AXPlatformNodeBase|

--- a/third_party/accessibility/ax/platform/ax_platform_node_win_unittest.cc
+++ b/third_party/accessibility/ax/platform/ax_platform_node_win_unittest.cc
@@ -4674,4 +4674,16 @@ TEST_F(AXPlatformNodeWinTest, IScrollProviderSetScrollPercent) {
   EXPECT_EQ(y_scroll_percent, 34);
 }
 
+TEST_F(AXPlatformNodeWinTest, MojoEventToUIAPropertyTest) {
+  AXNodeData root;
+  root.id = 1;
+  root.role = ax::mojom::Role::kCheckBox;
+  root.AddIntAttribute(ax::mojom::IntAttribute::kCheckedState, static_cast<int>(ax::mojom::CheckedState::kMixed));
+
+  Init(root);
+
+  ComPtr<AXPlatformNodeWin> platform_node = QueryInterfaceFromNode<AXPlatformNodeWin>(GetRootAsAXNode());
+  EXPECT_EQ(platform_node->MojoEventToUIAProperty(ax::mojom::Event::kValueChanged), UIA_ToggleToggleStatePropertyId);
+}
+
 }  // namespace ui

--- a/third_party/accessibility/ax/platform/ax_platform_node_win_unittest.cc
+++ b/third_party/accessibility/ax/platform/ax_platform_node_win_unittest.cc
@@ -4678,12 +4678,16 @@ TEST_F(AXPlatformNodeWinTest, MojoEventToUIAPropertyTest) {
   AXNodeData root;
   root.id = 1;
   root.role = ax::mojom::Role::kCheckBox;
-  root.AddIntAttribute(ax::mojom::IntAttribute::kCheckedState, static_cast<int>(ax::mojom::CheckedState::kMixed));
+  root.AddIntAttribute(ax::mojom::IntAttribute::kCheckedState,
+                       static_cast<int>(ax::mojom::CheckedState::kMixed));
 
   Init(root);
 
-  ComPtr<AXPlatformNodeWin> platform_node = QueryInterfaceFromNode<AXPlatformNodeWin>(GetRootAsAXNode());
-  EXPECT_EQ(platform_node->MojoEventToUIAProperty(ax::mojom::Event::kValueChanged), UIA_ToggleToggleStatePropertyId);
+  ComPtr<AXPlatformNodeWin> platform_node =
+      QueryInterfaceFromNode<AXPlatformNodeWin>(GetRootAsAXNode());
+  EXPECT_EQ(
+      platform_node->MojoEventToUIAProperty(ax::mojom::Event::kValueChanged),
+      UIA_ToggleToggleStatePropertyId);
 }
 
 }  // namespace ui


### PR DESCRIPTION
When a checkbox has its state changed, fire a UIA property change event for the toggle state property, so that screen readers can read the updated state.

Part of https://github.com/flutter/flutter/issues/119350. I still need to confirm what the appropriate behavior should be when hitting NVDA+UP when focusing on a checkbox before I can potentially close that issue.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
