### PR TITLE
Bump ninja version to 1.11.1

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -754,7 +754,7 @@ deps = {
     'packages': [
       {
         'package': 'infra/3pp/tools/ninja/${{platform}}',
-        'version': 'version:2@1.8.2.chromium.3',
+        'version': 'version:2@1.11.1.chromium.4',
       }
     ],
     'dep_type': 'cipd',


### PR DESCRIPTION
The protobuf GN templates that the Dart SDK uses produce depfiles with multiple outputs. This was only supported in `ninja 1.10.0` (https://github.com/ninja-build/ninja/issues/1184#issuecomment-579804128)