### PR TITLE
[Impeller] Use minimal coverage for stencil restores after overdraw prevention

### DIFF
--- a/impeller/entity/contents/clip_contents.h
+++ b/impeller/entity/contents/clip_contents.h
@@ -55,6 +55,12 @@ class ClipRestoreContents final : public Contents {
 
   ~ClipRestoreContents();
 
+  /// @brief  The area on the pass texture where this clip restore will be
+  ///         applied. If unset, the entire pass texture will be restored.
+  ///
+  /// @note   This rectangle is not transformed by the entity's transformation.
+  void SetRestoreCoverage(std::optional<Rect> coverage);
+
   // |Contents|
   std::optional<Rect> GetCoverage(const Entity& entity) const override;
 
@@ -73,6 +79,8 @@ class ClipRestoreContents final : public Contents {
               RenderPass& pass) const override;
 
  private:
+  std::optional<Rect> restore_coverage_;
+
   FML_DISALLOW_COPY_AND_ASSIGN(ClipRestoreContents);
 };
 

--- a/impeller/entity/contents/linear_gradient_contents.cc
+++ b/impeller/entity/contents/linear_gradient_contents.cc
@@ -111,7 +111,9 @@ bool LinearGradientContents::RenderTexture(const ContentContext& renderer,
   }
 
   if (geometry_result.prevent_overdraw) {
-    return ClipRestoreContents().Render(renderer, entity, pass);
+    auto restore = ClipRestoreContents();
+    restore.SetRestoreCoverage(GetCoverage(entity));
+    return restore.Render(renderer, entity, pass);
   }
   return true;
 }
@@ -165,7 +167,9 @@ bool LinearGradientContents::RenderSSBO(const ContentContext& renderer,
   }
 
   if (geometry_result.prevent_overdraw) {
-    return ClipRestoreContents().Render(renderer, entity, pass);
+    auto restore = ClipRestoreContents();
+    restore.SetRestoreCoverage(GetCoverage(entity));
+    return restore.Render(renderer, entity, pass);
   }
   return true;
 }

--- a/impeller/entity/contents/radial_gradient_contents.cc
+++ b/impeller/entity/contents/radial_gradient_contents.cc
@@ -103,7 +103,9 @@ bool RadialGradientContents::RenderSSBO(const ContentContext& renderer,
   }
 
   if (geometry_result.prevent_overdraw) {
-    return ClipRestoreContents().Render(renderer, entity, pass);
+    auto restore = ClipRestoreContents();
+    restore.SetRestoreCoverage(GetCoverage(entity));
+    return restore.Render(renderer, entity, pass);
   }
   return true;
 }
@@ -166,7 +168,9 @@ bool RadialGradientContents::RenderTexture(const ContentContext& renderer,
   }
 
   if (geometry_result.prevent_overdraw) {
-    return ClipRestoreContents().Render(renderer, entity, pass);
+    auto restore = ClipRestoreContents();
+    restore.SetRestoreCoverage(GetCoverage(entity));
+    return restore.Render(renderer, entity, pass);
   }
   return true;
 }

--- a/impeller/entity/contents/runtime_effect_contents.cc
+++ b/impeller/entity/contents/runtime_effect_contents.cc
@@ -238,7 +238,9 @@ bool RuntimeEffectContents::Render(const ContentContext& renderer,
   pass.AddCommand(std::move(cmd));
 
   if (geometry_result.prevent_overdraw) {
-    return ClipRestoreContents().Render(renderer, entity, pass);
+    auto restore = ClipRestoreContents();
+    restore.SetRestoreCoverage(GetCoverage(entity));
+    return restore.Render(renderer, entity, pass);
   }
   return true;
 }

--- a/impeller/entity/contents/solid_color_contents.cc
+++ b/impeller/entity/contents/solid_color_contents.cc
@@ -83,7 +83,9 @@ bool SolidColorContents::Render(const ContentContext& renderer,
   }
 
   if (geometry_result.prevent_overdraw) {
-    return ClipRestoreContents().Render(renderer, entity, pass);
+    auto restore = ClipRestoreContents();
+    restore.SetRestoreCoverage(GetCoverage(entity));
+    return restore.Render(renderer, entity, pass);
   }
   return true;
 }

--- a/impeller/entity/contents/sweep_gradient_contents.cc
+++ b/impeller/entity/contents/sweep_gradient_contents.cc
@@ -109,7 +109,9 @@ bool SweepGradientContents::RenderSSBO(const ContentContext& renderer,
   }
 
   if (geometry_result.prevent_overdraw) {
-    return ClipRestoreContents().Render(renderer, entity, pass);
+    auto restore = ClipRestoreContents();
+    restore.SetRestoreCoverage(GetCoverage(entity));
+    return restore.Render(renderer, entity, pass);
   }
   return true;
 }
@@ -173,7 +175,9 @@ bool SweepGradientContents::RenderTexture(const ContentContext& renderer,
   }
 
   if (geometry_result.prevent_overdraw) {
-    return ClipRestoreContents().Render(renderer, entity, pass);
+    auto restore = ClipRestoreContents();
+    restore.SetRestoreCoverage(GetCoverage(entity));
+    return restore.Render(renderer, entity, pass);
   }
   return true;
 }

--- a/impeller/entity/contents/tiled_texture_contents.cc
+++ b/impeller/entity/contents/tiled_texture_contents.cc
@@ -96,7 +96,9 @@ bool TiledTextureContents::Render(const ContentContext& renderer,
   }
 
   if (geometry_result.prevent_overdraw) {
-    return ClipRestoreContents().Render(renderer, entity, pass);
+    auto restore = ClipRestoreContents();
+    restore.SetRestoreCoverage(GetCoverage(entity));
+    return restore.Render(renderer, entity, pass);
   }
   return true;
 }


### PR DESCRIPTION
I'm hoping this'll eliminate much of the delta in https://github.com/flutter/flutter/issues/119881#issuecomment-1414812797.

Up until now, clip restores have always just covered the whole render target. But in some cases (like with overdraw prevention when drawing stroke paths), the restore area may be comparatively tiny. In the reduced test case linked above, this is a worst case scenario, because each dash takes up only a tiny sliver of pixels, and the interleaving restores repeatedly hammer the raster pipeline by stencil checking the whole screen.

Frame capture times haven't been historically reliable for me, but I seem to be getting a consistent order of magnitude difference on my iPhone 12 mini.

As an aside, I may come back around and try to refactor the overdraw prevention bits for dryness later.

Before:
![Screenshot 2023-02-02 at 9 16 56 PM](https://user-images.githubusercontent.com/919017/216530576-0ef2da86-612b-41f6-b71e-f0d4d31ab5b8.png)


After:
![Screenshot 2023-02-02 at 10 26 28 PM](https://user-images.githubusercontent.com/919017/216530560-7bc4f47e-7248-4e21-b50f-4c5cb891d463.png)
