### PR TITLE
[iOS] Ensure FlutterView's background color is not nil to avoid CAMetalLayer nextDrawable being time-consuming

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.mm
@@ -47,6 +47,11 @@
   if (self) {
     _delegate = delegate;
     self.layer.opaque = opaque;
+
+    // This line is necessary. CoreAnimation(or UIKit) may take this to do
+    // something to compute the final frame presented on screen, if we don't set this,
+    // it will make it take long time for us to take next CAMetalDrawable and will
+    // cause constant junk during rendering.
     self.backgroundColor = UIColor.clearColor;
   }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.mm
@@ -47,6 +47,7 @@
   if (self) {
     _delegate = delegate;
     self.layer.opaque = opaque;
+    self.backgroundColor = UIColor.clearColor;
   }
 
   return self;

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewTest.mm
@@ -49,4 +49,10 @@
   XCTAssertTrue(delegate.callbackCalled);
 }
 
+- (void)testFlutterViewBackgroundColorIsNotNil {
+  FakeDelegate* delegate = [[FakeDelegate alloc] init];
+  FlutterView* view = [[FlutterView alloc] initWithDelegate:delegate opaque:NO];
+  XCTAssertNotNil(view.backgroundColor);
+}
+
 @end


### PR DESCRIPTION
To Fix
- https://github.com/flutter/flutter/issues/103847

This looks crazy. 

I think that the view's background color is something related with CoreAnimation and `CAMetalDrawable` also related with it. And the thing draw's on it. Change it to a color not nil maybe have something to do with present behavior. So just set it to UIColor.clearcolor which is the same visually but can help reduce junk a lot.

Below video is tested on iPhone 13 Pro with local compiled engine in debug mode.
After this change the constant junk will reduce a lot on iOS.

### Before

https://user-images.githubusercontent.com/49340347/216589281-9a0b4b02-af44-419d-b186-a571e84b9022.mp4


### After
https://user-images.githubusercontent.com/49340347/216589285-18b7d207-cae9-4d70-b219-3fc589251742.mp4

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.