### PR TITLE
Migrate iOS and Android to use pushRouteInformation

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -829,11 +829,13 @@ import java.util.List;
   void onNewIntent(@NonNull Intent intent) {
     ensureAlive();
     if (flutterEngine != null) {
-      Log.v(TAG, "Forwarding onNewIntent() to FlutterEngine and sending pushRoute message.");
+      Log.v(
+          TAG,
+          "Forwarding onNewIntent() to FlutterEngine and sending pushRouteInformation message.");
       flutterEngine.getActivityControlSurface().onNewIntent(intent);
       String initialRoute = maybeGetInitialRouteFromIntent(intent);
       if (initialRoute != null && !initialRoute.isEmpty()) {
-        flutterEngine.getNavigationChannel().pushRoute(initialRoute);
+        flutterEngine.getNavigationChannel().pushRouteInformation(initialRoute);
       }
     } else {
       Log.w(TAG, "onNewIntent() invoked before FlutterFragment was attached to an Activity.");

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/NavigationChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/NavigationChannel.java
@@ -11,6 +11,8 @@ import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.plugin.common.JSONMethodCodec;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
+import java.util.HashMap;
+import java.util.Map;
 
 /** TODO(mattcarroll): fill in javadoc for NavigationChannel. */
 public class NavigationChannel {
@@ -41,6 +43,13 @@ public class NavigationChannel {
   public void pushRoute(@NonNull String route) {
     Log.v(TAG, "Sending message to push route '" + route + "'");
     channel.invokeMethod("pushRoute", route);
+  }
+
+  public void pushRouteInformation(@NonNull String route) {
+    Log.v(TAG, "Sending message to push route information '" + route + "'");
+    Map<String, String> message = new HashMap<>();
+    message.put("location", route);
+    channel.invokeMethod("pushRouteInformation", message);
   }
 
   public void popRoute() {

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -361,7 +361,7 @@ public class FlutterView extends SurfaceView
   }
 
   public void pushRoute(String route) {
-    navigationChannel.pushRoute(route);
+    navigationChannel.pushRouteInformation(route);
   }
 
   public void popRoute() {

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -361,7 +361,7 @@ public class FlutterView extends SurfaceView
   }
 
   public void pushRoute(String route) {
-    navigationChannel.pushRouteInformation(route);
+    navigationChannel.pushRoute(route);
   }
 
   public void popRoute() {

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
@@ -726,7 +726,7 @@ public class FlutterActivityAndFragmentDelegateTest {
   }
 
   @Test
-  public void itSendsPushRouteMessageWhenOnNewIntent() {
+  public void itSendsPushRouteInformationMessageWhenOnNewIntent() {
     when(mockHost.shouldHandleDeeplinking()).thenReturn(true);
     // Create the real object that we're testing.
     FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
@@ -742,11 +742,11 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // Verify that the navigation channel was given the push route message.
     verify(mockFlutterEngine.getNavigationChannel(), times(1))
-        .pushRoute("/custom/route?query=test");
+        .pushRouteInformation("/custom/route?query=test");
   }
 
   @Test
-  public void itDoesNotSendPushRouteMessageWhenOnNewIntentIsNonHierarchicalUri() {
+  public void itDoesNotSendPushRouteInformationMessageWhenOnNewIntentIsNonHierarchicalUri() {
     when(mockHost.shouldHandleDeeplinking()).thenReturn(true);
     // Create the real object that we're testing.
     FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
@@ -764,11 +764,12 @@ public class FlutterActivityAndFragmentDelegateTest {
     delegate.onNewIntent(mockIntent);
 
     // Verify that the navigation channel was not given a push route message.
-    verify(mockFlutterEngine.getNavigationChannel(), times(0)).pushRoute("mailto:test@test.com");
+    verify(mockFlutterEngine.getNavigationChannel(), times(0))
+        .pushRouteInformation("mailto:test@test.com");
   }
 
   @Test
-  public void itSendsPushRouteMessageWhenOnNewIntentWithQueryParameterAndFragment() {
+  public void itSendsPushRouteInformationMessageWhenOnNewIntentWithQueryParameterAndFragment() {
     when(mockHost.shouldHandleDeeplinking()).thenReturn(true);
     // Create the real object that we're testing.
     FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
@@ -785,11 +786,11 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // Verify that the navigation channel was given the push route message.
     verify(mockFlutterEngine.getNavigationChannel(), times(1))
-        .pushRoute("/custom/route?query=test#fragment");
+        .pushRouteInformation("/custom/route?query=test#fragment");
   }
 
   @Test
-  public void itSendsPushRouteMessageWhenOnNewIntentWithFragmentNoQueryParameter() {
+  public void itSendsPushRouteInformationMessageWhenOnNewIntentWithFragmentNoQueryParameter() {
     when(mockHost.shouldHandleDeeplinking()).thenReturn(true);
     // Create the real object that we're testing.
     FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
@@ -804,11 +805,12 @@ public class FlutterActivityAndFragmentDelegateTest {
     delegate.onNewIntent(mockIntent);
 
     // Verify that the navigation channel was given the push route message.
-    verify(mockFlutterEngine.getNavigationChannel(), times(1)).pushRoute("/custom/route#fragment");
+    verify(mockFlutterEngine.getNavigationChannel(), times(1))
+        .pushRouteInformation("/custom/route#fragment");
   }
 
   @Test
-  public void itSendsPushRouteMessageWhenOnNewIntentNoQueryParameter() {
+  public void itSendsPushRouteInformationMessageWhenOnNewIntentNoQueryParameter() {
     when(mockHost.shouldHandleDeeplinking()).thenReturn(true);
     // Create the real object that we're testing.
     FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
@@ -823,7 +825,8 @@ public class FlutterActivityAndFragmentDelegateTest {
     delegate.onNewIntent(mockIntent);
 
     // Verify that the navigation channel was given the push route message.
-    verify(mockFlutterEngine.getNavigationChannel(), times(1)).pushRoute("/custom/route");
+    verify(mockFlutterEngine.getNavigationChannel(), times(1))
+        .pushRouteInformation("/custom/route");
   }
 
   @Test

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -157,8 +157,11 @@ static NSString* const kRestorationStateAppModificationKey = @"mod-date";
                        if ([url.fragment length] != 0) {
                          fullRoute = [NSString stringWithFormat:@"%@#%@", fullRoute, url.fragment];
                        }
-                       [flutterViewController.engine.navigationChannel invokeMethod:@"pushRoute"
-                                                                          arguments:fullRoute];
+                       [flutterViewController.engine.navigationChannel
+                           invokeMethod:@"pushRouteInformation"
+                              arguments:@{
+                                @"location" : fullRoute,
+                              }];
                      }
                    }];
       return YES;

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
@@ -68,7 +68,7 @@ FLUTTER_ASSERT_ARC
                             options:@{}];
   XCTAssertTrue(result);
   OCMVerify([self.mockNavigationChannel invokeMethod:@"pushRouteInformation"
-                                           arguments:@"/custom/route?query=test"]);
+                                           arguments:@{@"location" : @"/custom/route?query=test"}]);
 }
 
 - (void)testLaunchUrlWithDeepLinkingNotSet {
@@ -104,8 +104,9 @@ FLUTTER_ASSERT_ARC
           openURL:[NSURL URLWithString:@"http://myApp/custom/route?query=test#fragment"]
           options:@{}];
   XCTAssertTrue(result);
-  OCMVerify([self.mockNavigationChannel invokeMethod:@"pushRouteInformation"
-                                           arguments:@"/custom/route?query=test#fragment"]);
+  OCMVerify([self.mockNavigationChannel
+      invokeMethod:@"pushRouteInformation"
+         arguments:@{@"location" : @"/custom/route?query=test#fragment"}]);
 }
 
 - (void)testLaunchUrlWithFragmentNoQueryParameter {
@@ -118,7 +119,7 @@ FLUTTER_ASSERT_ARC
                             options:@{}];
   XCTAssertTrue(result);
   OCMVerify([self.mockNavigationChannel invokeMethod:@"pushRouteInformation"
-                                           arguments:@"/custom/route#fragment"]);
+                                           arguments:@{@"location" : @"/custom/route#fragment"}]);
 }
 
 - (void)testReleasesWindowOnDealloc {
@@ -152,7 +153,7 @@ FLUTTER_ASSERT_ARC
         }];
   XCTAssertTrue(result);
   OCMVerify([self.mockNavigationChannel invokeMethod:@"pushRouteInformation"
-                                           arguments:@"/custom/route?query=test"]);
+                                           arguments:@{@"location" : @"/custom/route?query=test"}]);
 }
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
@@ -67,7 +67,7 @@ FLUTTER_ASSERT_ARC
                             openURL:[NSURL URLWithString:@"http://myApp/custom/route?query=test"]
                             options:@{}];
   XCTAssertTrue(result);
-  OCMVerify([self.mockNavigationChannel invokeMethod:@"pushRoute"
+  OCMVerify([self.mockNavigationChannel invokeMethod:@"pushRouteInformation"
                                            arguments:@"/custom/route?query=test"]);
 }
 
@@ -104,7 +104,7 @@ FLUTTER_ASSERT_ARC
           openURL:[NSURL URLWithString:@"http://myApp/custom/route?query=test#fragment"]
           options:@{}];
   XCTAssertTrue(result);
-  OCMVerify([self.mockNavigationChannel invokeMethod:@"pushRoute"
+  OCMVerify([self.mockNavigationChannel invokeMethod:@"pushRouteInformation"
                                            arguments:@"/custom/route?query=test#fragment"]);
 }
 
@@ -117,7 +117,7 @@ FLUTTER_ASSERT_ARC
                             openURL:[NSURL URLWithString:@"http://myApp/custom/route#fragment"]
                             options:@{}];
   XCTAssertTrue(result);
-  OCMVerify([self.mockNavigationChannel invokeMethod:@"pushRoute"
+  OCMVerify([self.mockNavigationChannel invokeMethod:@"pushRouteInformation"
                                            arguments:@"/custom/route#fragment"]);
 }
 
@@ -139,7 +139,7 @@ FLUTTER_ASSERT_ARC
 
 #pragma mark - Deep linking
 
-- (void)testUniversalLinkPushRoute {
+- (void)testUniversalLinkPushRouteInformation {
   OCMStub([self.mockMainBundle objectForInfoDictionaryKey:@"FlutterDeepLinkingEnabled"])
       .andReturn(@YES);
 
@@ -151,7 +151,7 @@ FLUTTER_ASSERT_ARC
         restorationHandler:^(NSArray<id<UIUserActivityRestoring>>* __nullable restorableObjects){
         }];
   XCTAssertTrue(result);
-  OCMVerify([self.mockNavigationChannel invokeMethod:@"pushRoute"
+  OCMVerify([self.mockNavigationChannel invokeMethod:@"pushRouteInformation"
                                            arguments:@"/custom/route?query=test"]);
 }
 


### PR DESCRIPTION
Related https://github.com/flutter/flutter/issues/100624

The end goal is to send entire uri to the framework without introducing breaking change. The pushRoute API takes a fixed string that contains everything after the authority and is hard to extend. Therefore migrate both embedding to more flexible pushRouteInformation API

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
