### PR TITLE
[fuchsia] fdio_service_connect no longer provides rights which we need

### DIFF
--- a/shell/platform/fuchsia/flutter/component_v1.cc
+++ b/shell/platform/fuchsia/flutter/component_v1.cc
@@ -217,8 +217,7 @@ ComponentV1::ComponentV1(
 
   // Clone and check if client is servicing the directory.
   directory_ptr_->Clone(fuchsia::io::OpenFlags::DESCRIBE |
-                            fuchsia::io::OpenFlags::RIGHT_READABLE |
-                            fuchsia::io::OpenFlags::RIGHT_WRITABLE,
+                            fuchsia::io::OpenFlags::CLONE_SAME_RIGHTS,
                         cloned_directory_ptr_.NewRequest());
 
   cloned_directory_ptr_.events().OnOpen = [this](zx_status_t status,
@@ -234,8 +233,11 @@ ComponentV1::ComponentV1(
     for (auto& dir_str : other_dirs) {
       fuchsia::io::DirectoryHandle dir;
       auto request = dir.NewRequest().TakeChannel();
-      auto status = fdio_service_connect_at(directory_ptr_.channel().get(),
-                                            dir_str, request.release());
+      auto status = fdio_open_at(
+          directory_ptr_.channel().get(), dir_str,
+          static_cast<uint32_t>(fuchsia::io::OpenFlags::DIRECTORY |
+                                fuchsia::io::OpenFlags::RIGHT_READABLE),
+          request.release());
       if (status == ZX_OK) {
         outgoing_dir_->AddEntry(
             dir_str, std::make_unique<vfs::RemoteDir>(dir.TakeChannel()));


### PR DESCRIPTION
fdio_service_connect no longer provides rights. Since we need the READABLE right when opening the debug/ctrl/diagnostics directories, this change uses fdio_open_at.

This change also fixes the Clone to remove specific rights and instead use CLONE_SAME_RIGHTS.

Verified locally that we no longer get ACCESS_DENIED on the diagnostics directory when opening in component manager.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
