### PR TITLE
[Impeller] Retain embolden/skew font properties when rendering text glyphs

### DIFF
--- a/impeller/typographer/backends/skia/text_frame_skia.cc
+++ b/impeller/typographer/backends/skia/text_frame_skia.cc
@@ -27,6 +27,8 @@ static Font ToFont(const SkTextBlobRunIterator& run, Scalar scale) {
   Font::Metrics metrics;
   metrics.scale = scale;
   metrics.point_size = font.getSize();
+  metrics.embolden = font.isEmbolden();
+  metrics.skewX = font.getSkewX();
 
   return Font{std::move(typeface), metrics};
 }

--- a/impeller/typographer/backends/skia/text_render_context_skia.cc
+++ b/impeller/typographer/backends/skia/text_render_context_skia.cc
@@ -296,6 +296,11 @@ static void DrawGlyph(SkCanvas* canvas,
   SkFont sk_font(
       TypefaceSkia::Cast(*font_glyph.font.GetTypeface()).GetSkiaTypeface(),
       metrics.point_size);
+  sk_font.setEdging(SkFont::Edging::kAntiAlias);
+  sk_font.setHinting(SkFontHinting::kSlight);
+  sk_font.setEmbolden(metrics.embolden);
+  sk_font.setSkewX(metrics.skewX);
+
   auto glyph_color = SK_ColorWHITE;
 
   SkPaint glyph_paint;

--- a/impeller/typographer/font.h
+++ b/impeller/typographer/font.h
@@ -11,6 +11,7 @@
 #include "impeller/base/comparable.h"
 #include "impeller/typographer/glyph.h"
 #include "impeller/typographer/typeface.h"
+#include "include/core/SkFont.h"
 
 namespace impeller {
 
@@ -38,9 +39,12 @@ class Font : public Comparable<Font> {
     /// The point size of the font.
     ///
     Scalar point_size = 12.0f;
+    bool embolden = false;
+    Scalar skewX = 0.0f;
 
     constexpr bool operator==(const Metrics& o) const {
-      return scale == o.scale && point_size == o.point_size;
+      return scale == o.scale && point_size == o.point_size &&
+             embolden == o.embolden && skewX == o.skewX;
     }
   };
 


### PR DESCRIPTION
Resolves: https://github.com/flutter/flutter/issues/119489

These options are more like implementation hacks we use to tickle Skia into rendering text the way we want. They're not generally applicable to fonts/typefaces, and so I'm working on a patch that just makes us hold onto a backend-specific font resource instead of decomposing/reconstructing from metrics. In the meantime, this patch fixes the most egregious rendering error.

I had some trouble getting a repro of this issue in a playground, but I'll add one in a follow-up if I end up getting one working.

Before:

![Screen Shot 2023-02-03 at 3 20 53 AM](https://user-images.githubusercontent.com/919017/216726851-fbbc280f-56a6-4603-82f9-8deb5b1248d6.png)

After:

![Screen Shot 2023-02-03 at 3 01 19 PM](https://user-images.githubusercontent.com/919017/216727037-e73fa36b-fe49-44fd-bc77-9eb0a490d3f8.png)

