### PR TITLE
[Windows] Fix the 'engine restart resets keyboard' test

### DIFF
--- a/shell/platform/windows/flutter_windows_view_unittests.cc
+++ b/shell/platform/windows/flutter_windows_view_unittests.cc
@@ -116,38 +116,6 @@ TEST(FlutterWindowsViewTest, KeySequence) {
   key_event_logs.clear();
 }
 
-TEST(FlutterWindowsViewTest, RestartClearsKeyboardState) {
-  std::unique_ptr<FlutterWindowsEngine> engine = GetTestEngine();
-
-  auto window_binding_handler =
-      std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();
-  FlutterWindowsView view(std::move(window_binding_handler));
-  view.SetEngine(std::move(engine));
-
-  test_response = false;
-
-  // Receives a KeyA down. Events are dispatched and decided unhandled. Now the
-  // keyboard key handler is waiting for the redispatched event.
-  view.OnKey(kVirtualKeyA, kScanCodeKeyA, WM_KEYDOWN, 'a', false, false,
-             [](bool handled) {});
-  EXPECT_EQ(key_event_logs.size(), 2);
-  EXPECT_EQ(key_event_logs[0], kKeyEventFromEmbedder);
-  EXPECT_EQ(key_event_logs[1], kKeyEventFromChannel);
-  key_event_logs.clear();
-
-  // Resets state so that the keyboard key handler is no longer waiting.
-  view.OnPreEngineRestart();
-
-  // Receives another KeyA down. If the state had not been cleared, this event
-  // will be considered the redispatched event and ignored.
-  view.OnKey(kVirtualKeyA, kScanCodeKeyA, WM_KEYDOWN, 'a', false, false,
-             [](bool handled) {});
-  EXPECT_EQ(key_event_logs.size(), 2);
-  EXPECT_EQ(key_event_logs[0], kKeyEventFromEmbedder);
-  EXPECT_EQ(key_event_logs[1], kKeyEventFromChannel);
-  key_event_logs.clear();
-}
-
 TEST(FlutterWindowsViewTest, EnableSemantics) {
   std::unique_ptr<FlutterWindowsEngine> engine = GetTestEngine();
   EngineModifier modifier(engine.get());


### PR DESCRIPTION
The `FlutterWindowsViewTest.RestartClearsKeyboardState` test used to verify that restarting the engine reset the keyboard's state. This test was broken some time ago but still passed. This change fixes the test.

Part of https://github.com/flutter/flutter/issues/115611

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
