### PR TITLE
[Impeller] Make dark text appear less emboldened

### DIFF
--- a/impeller/typographer/backends/skia/text_frame_skia.cc
+++ b/impeller/typographer/backends/skia/text_frame_skia.cc
@@ -29,6 +29,7 @@ static Font ToFont(const SkTextBlobRunIterator& run, Scalar scale) {
   metrics.point_size = font.getSize();
   metrics.embolden = font.isEmbolden();
   metrics.skewX = font.getSkewX();
+  metrics.scaleX = font.getScaleX();
 
   return Font{std::move(typeface), metrics};
 }

--- a/impeller/typographer/font.h
+++ b/impeller/typographer/font.h
@@ -41,10 +41,11 @@ class Font : public Comparable<Font> {
     Scalar point_size = 12.0f;
     bool embolden = false;
     Scalar skewX = 0.0f;
+    Scalar scaleX = 1.0f;
 
     constexpr bool operator==(const Metrics& o) const {
       return scale == o.scale && point_size == o.point_size &&
-             embolden == o.embolden && skewX == o.skewX;
+             embolden == o.embolden && skewX == o.skewX && scaleX == o.scaleX;
     }
   };
 


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/119234.
Resolves https://github.com/flutter/flutter/issues/119805.

I think what's going on here is that Skia applies a curve to the antialiased edges of text based on its color (see [this old chromium bug](https://bugs.chromium.org/p/chromium/issues/detail?id=898928), for example). Since we were asking Skia to draw white text, it biased the edges towards being more saturated.

By flipping the paint color from white to black, Skia's antialiasing behaves like we're drawing black text, which does the opposite.

This makes black text on a white background look almost identical to Skia, but note that white text now looks a bit too thin (seems like a better outcome than making the text too thick?).

For a more perfect solution, we can incorporate the expected text color into the glyphs. I'm experimenting with this at the moment, but this PR at least makes the most common case behave better.

Top = Impeller before
Middle = Impeller after
Bottom = Skia

![Screenshot 2023-02-03 at 7 01 23 PM](https://user-images.githubusercontent.com/919017/216746143-c4bf7f52-030f-4c81-b22c-2c278504078e.png)

![Screenshot 2023-02-03 at 7 32 31 PM](https://user-images.githubusercontent.com/919017/216746147-8cf81006-2349-419c-9a3c-93511afcc413.png)
