### PR TITLE
Fix incorrect viewInsets during keyboard animation with EdgeToEdge

### DIFF
--- a/shell/platform/android/io/flutter/plugin/editing/ImeSyncDeferringInsetsCallback.java
+++ b/shell/platform/android/io/flutter/plugin/editing/ImeSyncDeferringInsetsCallback.java
@@ -47,9 +47,7 @@ import java.util.List;
 @SuppressLint({"NewApi", "Override"})
 @Keep
 class ImeSyncDeferringInsetsCallback {
-  private int overlayInsetTypes;
-  private int deferredInsetTypes;
-
+  private final int deferredInsetTypes = WindowInsets.Type.ime();
   private View view;
   private WindowInsets lastWindowInsets;
   private AnimationCallback animationCallback;
@@ -67,10 +65,7 @@ class ImeSyncDeferringInsetsCallback {
   // initial WindowInset.
   private boolean needsSave = false;
 
-  ImeSyncDeferringInsetsCallback(
-      @NonNull View view, int overlayInsetTypes, int deferredInsetTypes) {
-    this.overlayInsetTypes = overlayInsetTypes;
-    this.deferredInsetTypes = deferredInsetTypes;
+  ImeSyncDeferringInsetsCallback(@NonNull View view) {
     this.view = view;
     this.animationCallback = new AnimationCallback();
     this.insetsListener = new InsetsListener();
@@ -131,24 +126,24 @@ class ImeSyncDeferringInsetsCallback {
       if (!matching) {
         return insets;
       }
+
+      // The IME insets include the height of the navigation bar. If the app isn't laid out behind
+      // the navigation bar, this causes the IME insets will be too large during the animation.
+      // To fix this, we subtract the systemBars bottom inset if the system UI flags for laying out
+      // behind the navigation bar aren't present.
+      int excludedInsets = 0;
+      int systemUiFlags = view.getWindowSystemUiVisibility();
+      if ((systemUiFlags & View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION) == 0
+          && (systemUiFlags & View.SYSTEM_UI_FLAG_HIDE_NAVIGATION) == 0) {
+        excludedInsets = insets.getInsets(WindowInsets.Type.systemBars()).bottom;
+      }
+
       WindowInsets.Builder builder = new WindowInsets.Builder(lastWindowInsets);
-      // Overlay the ime-only insets with the full insets.
-      //
-      // The IME insets passed in by onProgress assumes that the entire animation
-      // occurs above any present navigation and status bars. This causes the
-      // IME inset to be too large for the animation. To remedy this, we merge the
-      // IME inset with other insets present via a subtract + reLu, which causes the
-      // IME inset to be overlaid with any bars present.
       Insets newImeInsets =
           Insets.of(
-              0,
-              0,
-              0,
-              Math.max(
-                  insets.getInsets(deferredInsetTypes).bottom
-                      - insets.getInsets(overlayInsetTypes).bottom,
-                  0));
+              0, 0, 0, Math.max(insets.getInsets(deferredInsetTypes).bottom - excludedInsets, 0));
       builder.setInsets(deferredInsetTypes, newImeInsets);
+
       // Directly call onApplyWindowInsets of the view as we do not want to pass through
       // the onApplyWindowInsets defined in this class, which would consume the insets
       // as if they were a non-animation inset change and cache it for re-dispatch in

--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -15,7 +15,6 @@ import android.util.SparseArray;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.ViewStructure;
-import android.view.WindowInsets;
 import android.view.autofill.AutofillId;
 import android.view.autofill.AutofillManager;
 import android.view.autofill.AutofillValue;
@@ -80,19 +79,7 @@ public class TextInputPlugin implements ListenableEditingState.EditingStateWatch
     // the Flutter view to grow and shrink to accommodate Android
     // controlled keyboard animations.
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-      int mask = 0;
-      if ((View.SYSTEM_UI_FLAG_HIDE_NAVIGATION & mView.getWindowSystemUiVisibility()) == 0) {
-        mask = mask | WindowInsets.Type.navigationBars();
-      }
-      if ((View.SYSTEM_UI_FLAG_FULLSCREEN & mView.getWindowSystemUiVisibility()) == 0) {
-        mask = mask | WindowInsets.Type.statusBars();
-      }
-      imeSyncCallback =
-          new ImeSyncDeferringInsetsCallback(
-              view,
-              mask, // Overlay, insets that should be merged with the deferred insets
-              WindowInsets.Type.ime() // Deferred, insets that will animate
-              );
+      imeSyncCallback = new ImeSyncDeferringInsetsCallback(view);
       imeSyncCallback.install();
     }
 


### PR DESCRIPTION
Currently during the keyboard animation, the navigation bar insets are subtracted from the keyboard insets. This is correct when the app isn't laid out behind the navigation bar, but results in incorrect viewInsets when the app's running in edge-to-edge or fullscreen.

This change checks if the app is being laid out behind the navigation bar and adjusts the bottom insets accordingly during the keyboard animation.

Fixes https://github.com/flutter/flutter/issues/89914

Tested on Android 13 (Pixel 7) using the code sample here: https://github.com/flutter/flutter/issues/109623

### Before

https://user-images.githubusercontent.com/20386860/216786596-24c764b1-a71c-42cf-97a2-3ba10b717819.mp4

### After

https://user-images.githubusercontent.com/20386860/216786591-155ec6a6-b3c5-41e0-a45f-169861077ce2.mp4


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.