### PR TITLE
Fix cpp-wrappers archive.

### DIFF
--- a/shell/platform/windows/client_wrapper/BUILD.gn
+++ b/shell/platform/windows/client_wrapper/BUILD.gn
@@ -138,11 +138,26 @@ zip_bundle("client_wrapper_archive") {
       },
     ]
   }
+
+  # Headers
   headers = core_cpp_client_wrapper_includes +
             core_cpp_client_wrapper_internal_headers
   foreach(header, headers) {
     rebased_path =
         rebase_path(header, "//flutter/shell/platform/common/client_wrapper")
+    tmp_files += [
+      {
+        source = header
+        destination = "cpp_client_wrapper/$rebased_path"
+      },
+    ]
+  }
+
+  # Wrapper includes
+  foreach(header, _wrapper_includes) {
+    rebased_path =
+        rebase_path("//flutter/shell/platform/windows/client_wrapper/$header",
+                    "//flutter/shell/platform/windows/client_wrapper")
     tmp_files += [
       {
         source = header

--- a/shell/platform/windows/client_wrapper/BUILD.gn
+++ b/shell/platform/windows/client_wrapper/BUILD.gn
@@ -120,21 +120,21 @@ zip_bundle("client_wrapper_archive") {
     "//flutter/shell/platform/common/client_wrapper:client_wrapper",
   ]
   tmp_files = []
-  foreach(source, client_wrapper_file_archive_list) {
+  foreach(source_file, client_wrapper_file_archive_list) {
     tmp_files += [
       {
-        source = "//flutter/shell/platform/common/client_wrapper/$source"
-        destination = "cpp_client_wrapper/$source"
+        source = "//flutter/shell/platform/common/client_wrapper/$source_file"
+        destination = "cpp_client_wrapper/$source_file"
       },
     ]
   }
 
   # Windows specific source code files
-  foreach(source, win_client_wrapper_file_archive_list) {
+  foreach(source_file, win_client_wrapper_file_archive_list) {
     tmp_files += [
       {
-        source = "//flutter/shell/platform/windows/client_wrapper/$source"
-        destination = "cpp_client_wrapper/$source"
+        source = "//flutter/shell/platform/windows/client_wrapper/$source_file"
+        destination = "cpp_client_wrapper/$source_file"
       },
     ]
   }


### PR DESCRIPTION
This is to place the files in the correct files. $source variable is being overridden with the full path. It also includes missing header files.

Bug: https://github.com/flutter/flutter/issues/120058

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
