### PR TITLE
[impeller] Use VK_FORMAT_R8_UINT rather than VK_FORMAT_S8_UINT

### DIFF
--- a/impeller/renderer/backend/vulkan/allocator_vk.cc
+++ b/impeller/renderer/backend/vulkan/allocator_vk.cc
@@ -135,7 +135,9 @@ std::shared_ptr<Texture> AllocatorVK::OnCreateTexture(
                                           &alloc_create_info, &img, &allocation,
                                           &allocation_info)};
   if (result != vk::Result::eSuccess) {
-    VALIDATION_LOG << "Unable to allocate an image";
+    VALIDATION_LOG << "Unable to allocate an image, format requested was: "
+                   << PixelFormatToString(desc.format)
+                   << ", error was: " << vk::to_string(result);
     return nullptr;
   }
 

--- a/impeller/renderer/backend/vulkan/formats_vk.h
+++ b/impeller/renderer/backend/vulkan/formats_vk.h
@@ -153,7 +153,7 @@ constexpr vk::Format ToVKImageFormat(PixelFormat format) {
     case PixelFormat::kR16G16B16A16Float:
       return vk::Format::eR16G16B16A16Sfloat;
     case PixelFormat::kS8UInt:
-      return vk::Format::eS8Uint;
+      return vk::Format::eR8Uint;
     case PixelFormat::kD32FloatS8UInt:
       return vk::Format::eD32SfloatS8Uint;
     case PixelFormat::kR8UNormInt:
@@ -188,7 +188,7 @@ constexpr PixelFormat ToPixelFormat(vk::Format format) {
     case vk::Format::eR16G16B16A16Sfloat:
       return PixelFormat::kR16G16B16A16Float;
 
-    case vk::Format::eS8Uint:
+    case vk::Format::eR8Uint:
       return PixelFormat::kS8UInt;
 
     case vk::Format::eD32SfloatS8Uint:

--- a/impeller/renderer/formats.cc
+++ b/impeller/renderer/formats.cc
@@ -76,4 +76,35 @@ bool Attachment::IsValid() const {
   return true;
 }
 
+const char* PixelFormatToString(PixelFormat format) {
+  switch (format) {
+    case PixelFormat::kUnknown:
+      return "kUnknown";
+    case PixelFormat::kA8UNormInt:
+      return "A8UNormInt";
+    case PixelFormat::kR8UNormInt:
+      return "kR8UNormInt";
+    case PixelFormat::kR8G8UNormInt:
+      return "kR8G8UNormInt";
+    case PixelFormat::kR8G8B8A8UNormInt:
+      return "kR8G8B8A8UNormInt";
+    case PixelFormat::kR8G8B8A8UNormIntSRGB:
+      return "kR8G8B8A8UNormIntSRGB";
+    case PixelFormat::kB8G8R8A8UNormInt:
+      return "kB8G8R8A8UNormInt";
+    case PixelFormat::kB8G8R8A8UNormIntSRGB:
+      return "kB8G8R8A8UNormIntSRGB";
+    case PixelFormat::kR32G32B32A32Float:
+      return "kR32G32B32A32Float";
+    case PixelFormat::kR16G16B16A16Float:
+      return "kR16G16B16A16Float";
+    case PixelFormat::kS8UInt:
+      return "kS8UInt";
+    case PixelFormat::kD32FloatS8UInt:
+      return "kD32FloatS8UInt";
+  }
+
+  FML_UNREACHABLE();
+}
+
 }  // namespace impeller

--- a/impeller/renderer/formats.h
+++ b/impeller/renderer/formats.h
@@ -103,6 +103,8 @@ enum class PixelFormat {
   kDefaultStencil = kS8UInt,
 };
 
+const char* PixelFormatToString(PixelFormat format);
+
 enum class BlendFactor {
   kZero,
   kOne,


### PR DESCRIPTION
eS8Uint is not necessarily supported: https://bugs.chromium.org/p/angleproject/issues/detail?id=2655
