### PR TITLE
Cherry-pick Avoid animation jank by setting FlutterViewController backgroundColor to clearColor

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.mm
@@ -47,6 +47,12 @@
   if (self) {
     _delegate = delegate;
     self.layer.opaque = opaque;
+
+    // This line is necessary. CoreAnimation(or UIKit) may take this to do
+    // something to compute the final frame presented on screen, if we don't set this,
+    // it will make it take long time for us to take next CAMetalDrawable and will
+    // cause constant junk during rendering.
+    self.backgroundColor = UIColor.clearColor;
   }
 
   return self;

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewTest.mm
@@ -49,4 +49,10 @@
   XCTAssertTrue(delegate.callbackCalled);
 }
 
+- (void)testFlutterViewBackgroundColorIsNotNil {
+  FakeDelegate* delegate = [[FakeDelegate alloc] init];
+  FlutterView* view = [[FlutterView alloc] initWithDelegate:delegate opaque:NO];
+  XCTAssertNotNil(view.backgroundColor);
+}
+
 @end


### PR DESCRIPTION
Cherry-pick of https://github.com/flutter/engine/pull/39359 by @luckysmg.

https://github.com/flutter/flutter/issues/120130