### PR TITLE
[Windows] Remove accessibility root assumptions

### DIFF
--- a/shell/platform/common/accessibility_bridge.cc
+++ b/shell/platform/common/accessibility_bridge.cc
@@ -78,8 +78,8 @@ void AccessibilityBridge::CommitUpdates() {
   // entire subtree into a list. We pick another node from the remaining update,
   // and keep doing so until the update map is empty. We then concatenate the
   // lists in the reversed order, this guarantees parent updates always come
-  // before child updates. Furthermore, the root is guaranteed to be the
-  // first node of the last list.
+  // before child updates. If the root is in the update, it is guaranteed to
+  // be the first node of the last list.
   std::vector<std::vector<SemanticsNode>> results;
   while (!pending_semantics_node_updates_.empty()) {
     auto begin = pending_semantics_node_updates_.begin();
@@ -96,8 +96,9 @@ void AccessibilityBridge::CommitUpdates() {
     }
   }
 
-  // Set the tree's root if necessary. The new root is the last list's first
-  // node.
+  // The first update must set the tree's root, which is guaranteed to be the
+  // last list's first node. A tree's root node never changes, though it can be
+  // modified.
   if (!results.empty() && GetRootAsAXNode()->id() == ui::AXNode::kInvalidAXID) {
     FML_DCHECK(!results.back().empty());
 

--- a/shell/platform/common/accessibility_bridge.cc
+++ b/shell/platform/common/accessibility_bridge.cc
@@ -78,7 +78,8 @@ void AccessibilityBridge::CommitUpdates() {
   // entire subtree into a list. We pick another node from the remaining update,
   // and keep doing so until the update map is empty. We then concatenate the
   // lists in the reversed order, this guarantees parent updates always come
-  // before child updates.
+  // before child updates. Furthermore, the root is guaranteed to be the
+  // first node of the last list.
   std::vector<std::vector<SemanticsNode>> results;
   while (!pending_semantics_node_updates_.empty()) {
     auto begin = pending_semantics_node_updates_.begin();
@@ -93,6 +94,14 @@ void AccessibilityBridge::CommitUpdates() {
     for (SemanticsNode node : results[i - 1]) {
       ConvertFlutterUpdate(node, update);
     }
+  }
+
+  // Set the tree's root if necessary. The new root is the last list's first
+  // node.
+  if (!results.empty() && tree_->root()->id() == ui::AXNode::kInvalidAXID) {
+    FML_DCHECK(!results.back().empty());
+
+    update.root_id = results.back().front().id;
   }
 
   tree_->Unserialize(update);

--- a/shell/platform/common/accessibility_bridge.cc
+++ b/shell/platform/common/accessibility_bridge.cc
@@ -98,7 +98,7 @@ void AccessibilityBridge::CommitUpdates() {
 
   // Set the tree's root if necessary. The new root is the last list's first
   // node.
-  if (!results.empty() && tree_->root()->id() == ui::AXNode::kInvalidAXID) {
+  if (!results.empty() && GetRootAsAXNode()->id() == ui::AXNode::kInvalidAXID) {
     FML_DCHECK(!results.back().empty());
 
     update.root_id = results.back().front().id;

--- a/shell/platform/common/accessibility_bridge.h
+++ b/shell/platform/common/accessibility_bridge.h
@@ -50,7 +50,9 @@ class AccessibilityBridge
 
   //-----------------------------------------------------------------------------
   /// @brief      The ID of the root node in the accessibility tree. In Flutter,
-  //              this is always 0.
+  ///             this is always 0.
+  //  TODO(loicsharma): Remove this as it incorrect in a multi-view world.
+  //  See: https://github.com/flutter/flutter/issues/119391
   static constexpr int32_t kRootNodeId = 0;
 
   //------------------------------------------------------------------------------

--- a/shell/platform/common/accessibility_bridge.h
+++ b/shell/platform/common/accessibility_bridge.h
@@ -51,7 +51,7 @@ class AccessibilityBridge
   //-----------------------------------------------------------------------------
   /// @brief      The ID of the root node in the accessibility tree. In Flutter,
   ///             this is always 0.
-  //  TODO(loicsharma): Remove this as it incorrect in a multi-view world.
+  //  TODO(loicsharma): Remove this as it is incorrect in a multi-view world.
   //  See: https://github.com/flutter/flutter/issues/119391
   static constexpr int32_t kRootNodeId = 0;
 

--- a/shell/platform/common/accessibility_bridge_unittests.cc
+++ b/shell/platform/common/accessibility_bridge_unittests.cc
@@ -37,7 +37,7 @@ FlutterSemanticsNode CreateSemanticsNode(
   };
 }
 
-TEST(AccessibilityBridgeTest, basicTest) {
+TEST(AccessibilityBridgeTest, BasicTest) {
   std::shared_ptr<TestAccessibilityBridge> bridge =
       std::make_shared<TestAccessibilityBridge>();
 
@@ -66,7 +66,74 @@ TEST(AccessibilityBridgeTest, basicTest) {
   EXPECT_EQ(child2_node->GetName(), "child 2");
 }
 
-TEST(AccessibilityBridgeTest, canFireChildrenChangedCorrectly) {
+// Flutter used to assume that the accessibility root had ID 0.
+// In a multi-view world, each view has its own accessibility root
+// with a unique node ID that is globally unique.
+TEST(AccessibilityBridgeTest, AccessibilityRootId) {
+  std::shared_ptr<TestAccessibilityBridge> bridge =
+      std::make_shared<TestAccessibilityBridge>();
+
+  std::vector<int32_t> children{456, 789};
+  FlutterSemanticsNode root = CreateSemanticsNode(123, "root", &children);
+  FlutterSemanticsNode child1 = CreateSemanticsNode(456, "child 1");
+  FlutterSemanticsNode child2 = CreateSemanticsNode(789, "child 2");
+
+  bridge->AddFlutterSemanticsNodeUpdate(&root);
+  bridge->AddFlutterSemanticsNodeUpdate(&child1);
+  bridge->AddFlutterSemanticsNodeUpdate(&child2);
+  bridge->CommitUpdates();
+
+  auto root_node = bridge->GetFlutterPlatformNodeDelegateFromID(123).lock();
+  auto child1_node = bridge->GetFlutterPlatformNodeDelegateFromID(456).lock();
+  auto child2_node = bridge->GetFlutterPlatformNodeDelegateFromID(789).lock();
+  auto fake_delegate = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
+
+  EXPECT_EQ(root_node->GetChildCount(), 2);
+  EXPECT_EQ(root_node->GetData().child_ids[0], 456);
+  EXPECT_EQ(root_node->GetData().child_ids[1], 789);
+  EXPECT_EQ(root_node->GetName(), "root");
+
+  EXPECT_EQ(child1_node->GetChildCount(), 0);
+  EXPECT_EQ(child1_node->GetName(), "child 1");
+
+  EXPECT_EQ(child2_node->GetChildCount(), 0);
+  EXPECT_EQ(child2_node->GetName(), "child 2");
+
+  ASSERT_FALSE(fake_delegate);
+}
+
+// Semantic nodes can be added out of tree order.
+TEST(AccessibilityBridgeTest, AddOrder) {
+  std::shared_ptr<TestAccessibilityBridge> bridge =
+      std::make_shared<TestAccessibilityBridge>();
+
+  std::vector<int32_t> children{456, 789};
+  FlutterSemanticsNode root = CreateSemanticsNode(123, "root", &children);
+  FlutterSemanticsNode child1 = CreateSemanticsNode(456, "child 1");
+  FlutterSemanticsNode child2 = CreateSemanticsNode(789, "child 2");
+
+  bridge->AddFlutterSemanticsNodeUpdate(&child2);
+  bridge->AddFlutterSemanticsNodeUpdate(&root);
+  bridge->AddFlutterSemanticsNodeUpdate(&child1);
+  bridge->CommitUpdates();
+
+  auto root_node = bridge->GetFlutterPlatformNodeDelegateFromID(123).lock();
+  auto child1_node = bridge->GetFlutterPlatformNodeDelegateFromID(456).lock();
+  auto child2_node = bridge->GetFlutterPlatformNodeDelegateFromID(789).lock();
+
+  EXPECT_EQ(root_node->GetChildCount(), 2);
+  EXPECT_EQ(root_node->GetData().child_ids[0], 456);
+  EXPECT_EQ(root_node->GetData().child_ids[1], 789);
+  EXPECT_EQ(root_node->GetName(), "root");
+
+  EXPECT_EQ(child1_node->GetChildCount(), 0);
+  EXPECT_EQ(child1_node->GetName(), "child 1");
+
+  EXPECT_EQ(child2_node->GetChildCount(), 0);
+  EXPECT_EQ(child2_node->GetName(), "child 2");
+}
+
+TEST(AccessibilityBridgeTest, CanFireChildrenChangedCorrectly) {
   std::shared_ptr<TestAccessibilityBridge> bridge =
       std::make_shared<TestAccessibilityBridge>();
 
@@ -114,7 +181,7 @@ TEST(AccessibilityBridgeTest, canFireChildrenChangedCorrectly) {
               Contains(ui::AXEventGenerator::Event::SUBTREE_CREATED));
 }
 
-TEST(AccessibilityBridgeTest, canRecreateNodeDelegates) {
+TEST(AccessibilityBridgeTest, CanRecreateNodeDelegates) {
   std::shared_ptr<TestAccessibilityBridge> bridge =
       std::make_shared<TestAccessibilityBridge>();
 
@@ -148,7 +215,7 @@ TEST(AccessibilityBridgeTest, canRecreateNodeDelegates) {
   EXPECT_EQ(new_child1_node->GetName(), "child 1");
 }
 
-TEST(AccessibilityBridgeTest, canHandleSelectionChangeCorrectly) {
+TEST(AccessibilityBridgeTest, CanHandleSelectionChangeCorrectly) {
   std::shared_ptr<TestAccessibilityBridge> bridge =
       std::make_shared<TestAccessibilityBridge>();
   FlutterSemanticsNode root = CreateSemanticsNode(0, "root");
@@ -180,7 +247,7 @@ TEST(AccessibilityBridgeTest, canHandleSelectionChangeCorrectly) {
             ui::AXEventGenerator::Event::OTHER_ATTRIBUTE_CHANGED);
 }
 
-TEST(AccessibilityBridgeTest, doesNotAssignEditableRootToSelectableText) {
+TEST(AccessibilityBridgeTest, DoesNotAssignEditableRootToSelectableText) {
   std::shared_ptr<TestAccessibilityBridge> bridge =
       std::make_shared<TestAccessibilityBridge>();
   FlutterSemanticsNode root = CreateSemanticsNode(0, "root");

--- a/shell/platform/common/accessibility_bridge_unittests.cc
+++ b/shell/platform/common/accessibility_bridge_unittests.cc
@@ -68,7 +68,7 @@ TEST(AccessibilityBridgeTest, BasicTest) {
 
 // Flutter used to assume that the accessibility root had ID 0.
 // In a multi-view world, each view has its own accessibility root
-// with a unique node ID that is globally unique.
+// with a globally unique node ID.
 TEST(AccessibilityBridgeTest, AccessibilityRootId) {
   std::shared_ptr<TestAccessibilityBridge> bridge =
       std::make_shared<TestAccessibilityBridge>();

--- a/shell/platform/common/accessibility_bridge_unittests.cc
+++ b/shell/platform/common/accessibility_bridge_unittests.cc
@@ -115,8 +115,10 @@ TEST(AccessibilityBridgeTest, AddOrder) {
   std::vector<int32_t> child3_children{90};
   FlutterSemanticsNode root = CreateSemanticsNode(12, "root", &root_children);
   FlutterSemanticsNode child1 = CreateSemanticsNode(34, "child 1");
-  FlutterSemanticsNode child2 = CreateSemanticsNode(56, "child 2", &child2_children);
-  FlutterSemanticsNode child3 = CreateSemanticsNode(78, "child 3", &child3_children);
+  FlutterSemanticsNode child2 =
+      CreateSemanticsNode(56, "child 2", &child2_children);
+  FlutterSemanticsNode child3 =
+      CreateSemanticsNode(78, "child 3", &child3_children);
   FlutterSemanticsNode child4 = CreateSemanticsNode(90, "child 4");
 
   bridge->AddFlutterSemanticsNodeUpdate(&child3);

--- a/shell/platform/common/accessibility_bridge_unittests.cc
+++ b/shell/platform/common/accessibility_bridge_unittests.cc
@@ -89,6 +89,7 @@ TEST(AccessibilityBridgeTest, AccessibilityRootId) {
   auto fake_delegate = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
 
   EXPECT_EQ(bridge->GetRootAsAXNode()->id(), 123);
+  EXPECT_EQ(bridge->RootDelegate()->GetName(), "root");
 
   EXPECT_EQ(root_node->GetChildCount(), 2);
   EXPECT_EQ(root_node->GetData().child_ids[0], 456);
@@ -132,6 +133,7 @@ TEST(AccessibilityBridgeTest, AddOrder) {
   auto child4_node = bridge->GetFlutterPlatformNodeDelegateFromID(90).lock();
 
   EXPECT_EQ(bridge->GetRootAsAXNode()->id(), 12);
+  EXPECT_EQ(bridge->RootDelegate()->GetName(), "root");
 
   EXPECT_EQ(root_node->GetChildCount(), 2);
   EXPECT_EQ(root_node->GetData().child_ids[0], 34);

--- a/shell/platform/common/accessibility_bridge_unittests.cc
+++ b/shell/platform/common/accessibility_bridge_unittests.cc
@@ -88,6 +88,8 @@ TEST(AccessibilityBridgeTest, AccessibilityRootId) {
   auto child2_node = bridge->GetFlutterPlatformNodeDelegateFromID(789).lock();
   auto fake_delegate = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
 
+  EXPECT_EQ(bridge->GetRootAsAXNode()->id(), 123);
+
   EXPECT_EQ(root_node->GetChildCount(), 2);
   EXPECT_EQ(root_node->GetData().child_ids[0], 456);
   EXPECT_EQ(root_node->GetData().child_ids[1], 789);
@@ -128,6 +130,8 @@ TEST(AccessibilityBridgeTest, AddOrder) {
   auto child2_node = bridge->GetFlutterPlatformNodeDelegateFromID(56).lock();
   auto child3_node = bridge->GetFlutterPlatformNodeDelegateFromID(78).lock();
   auto child4_node = bridge->GetFlutterPlatformNodeDelegateFromID(90).lock();
+
+  EXPECT_EQ(bridge->GetRootAsAXNode()->id(), 12);
 
   EXPECT_EQ(root_node->GetChildCount(), 2);
   EXPECT_EQ(root_node->GetData().child_ids[0], 34);


### PR DESCRIPTION
Today, the root accessibility semantics node is guaranteed to have ID 0. In a multi-window world, each view will have its own semantics tree, but semantic node IDs will be globally unique. In other words, the semantics tree's root will no longer be guaranteed to have ID 0.

This change removes the "root ID is 0" assumption from the Windows embedder. Note that other embedders (macOS, iOS, Fuchsia, etc...) also need updates, which will be done in follow-up PRs.

Part of https://github.com/flutter/flutter/issues/119391

## Manual test

<details>
<summary>Manual test...</summary>

Apply the framework patch below, run an app, and verify the accessibility works as expected:

```diff
diff --git a/packages/flutter/lib/src/semantics/semantics.dart b/packages/flutter/lib/src/semantics/semantics.dart
index 969f822f5f..6431b3ed28 100644
--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -1650,7 +1650,7 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
     this.key,
     VoidCallback? showOnScreen,
     required SemanticsOwner owner,
-  }) : _id = 0,
+  }) : _id = 123,
        _showOnScreen = showOnScreen {
     attach(owner);
   }
@@ -1663,7 +1663,7 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
   // bits are reserved for engine generated IDs.
   static const int _maxFrameworkAccessibilityIdentifier = (1<<16) - 1;

-  static int _lastIdentifier = 0;
+  static int _lastIdentifier = 123;
   static int _generateNewId() {
     _lastIdentifier = (_lastIdentifier + 1) % _maxFrameworkAccessibilityIdentifier;
     return _lastIdentifier;
```

</details>

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
