### PR TITLE
[Windows] Prepare keyboard & text input plugins for multi-view

### DIFF
--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -17,6 +17,7 @@
 #include "flutter/shell/platform/common/path_utils.h"
 #include "flutter/shell/platform/windows/accessibility_bridge_windows.h"
 #include "flutter/shell/platform/windows/flutter_windows_view.h"
+#include "flutter/shell/platform/windows/keyboard_key_channel_handler.h"
 #include "flutter/shell/platform/windows/system_utils.h"
 #include "flutter/shell/platform/windows/task_runner.h"
 #include "flutter/third_party/accessibility/ax/ax_node.h"
@@ -206,6 +207,8 @@ FlutterWindowsEngine::FlutterWindowsEngine(
   // Set up internal channels.
   // TODO: Replace this with an embedder.h API. See
   // https://github.com/flutter/flutter/issues/71099
+  internal_plugin_registrar_ =
+      std::make_unique<PluginRegistrar>(plugin_registrar_.get());
   cursor_handler_ =
       std::make_unique<CursorHandler>(messenger_wrapper_.get(), this);
   platform_handler_ =
@@ -321,8 +324,10 @@ bool FlutterWindowsEngine::Run(std::string_view entrypoint) {
     host->OnVsync(baton);
   };
   args.on_pre_engine_restart_callback = [](void* user_data) {
+    // Reset the keyboard's state on hot restart.
     auto host = static_cast<FlutterWindowsEngine*>(user_data);
-    host->view()->OnPreEngineRestart();
+    // TODO: no-op if no view.
+    host->InitializeKeyboard();
   };
   args.update_semantics_callback = [](const FlutterSemanticsUpdate* update,
                                       void* user_data) {
@@ -401,6 +406,7 @@ bool FlutterWindowsEngine::Stop() {
 
 void FlutterWindowsEngine::SetView(FlutterWindowsView* view) {
   view_ = view;
+  InitializeKeyboard();
 }
 
 void FlutterWindowsEngine::OnVsync(intptr_t baton) {
@@ -559,6 +565,47 @@ void FlutterWindowsEngine::SendSystemLocales() {
                  [](const auto& arg) -> const auto* { return &arg; });
   embedder_api_.UpdateLocales(engine_, flutter_locale_list.data(),
                               flutter_locale_list.size());
+}
+
+void FlutterWindowsEngine::InitializeKeyboard() {
+  if (view_ == nullptr) {
+    FML_LOG(ERROR) << "Cannot initialize keyboard on Windows headless mode.";
+  }
+
+  auto internal_plugin_messenger = internal_plugin_registrar_->messenger();
+  KeyboardKeyEmbedderHandler::GetKeyStateHandler get_key_state = GetKeyState;
+  KeyboardKeyEmbedderHandler::MapVirtualKeyToScanCode map_vk_to_scan =
+      [](UINT virtual_key, bool extended) {
+        return MapVirtualKey(virtual_key,
+                             extended ? MAPVK_VK_TO_VSC_EX : MAPVK_VK_TO_VSC);
+      };
+  keyboard_key_handler_ = std::move(CreateKeyboardKeyHandler(
+      internal_plugin_messenger, get_key_state, map_vk_to_scan));
+  text_input_plugin_ =
+      std::move(CreateTextInputPlugin(internal_plugin_messenger));
+}
+
+std::unique_ptr<KeyboardHandlerBase>
+FlutterWindowsEngine::CreateKeyboardKeyHandler(
+    BinaryMessenger* messenger,
+    KeyboardKeyEmbedderHandler::GetKeyStateHandler get_key_state,
+    KeyboardKeyEmbedderHandler::MapVirtualKeyToScanCode map_vk_to_scan) {
+  auto keyboard_key_handler = std::make_unique<KeyboardKeyHandler>();
+  keyboard_key_handler->AddDelegate(
+      std::make_unique<KeyboardKeyEmbedderHandler>(
+          [this](const FlutterKeyEvent& event, FlutterKeyEventCallback callback,
+                 void* user_data) {
+            return SendKeyEvent(event, callback, user_data);
+          },
+          get_key_state, map_vk_to_scan));
+  keyboard_key_handler->AddDelegate(
+      std::make_unique<KeyboardKeyChannelHandler>(messenger));
+  return keyboard_key_handler;
+}
+
+std::unique_ptr<TextInputPlugin> FlutterWindowsEngine::CreateTextInputPlugin(
+    BinaryMessenger* messenger) {
+  return std::make_unique<TextInputPlugin>(messenger, view_);
 }
 
 bool FlutterWindowsEngine::RegisterExternalTexture(int64_t texture_id) {

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -324,10 +324,8 @@ bool FlutterWindowsEngine::Run(std::string_view entrypoint) {
     host->OnVsync(baton);
   };
   args.on_pre_engine_restart_callback = [](void* user_data) {
-    // Reset the keyboard's state on hot restart.
     auto host = static_cast<FlutterWindowsEngine*>(user_data);
-    // TODO: no-op if no view.
-    host->InitializeKeyboard();
+    host->OnPreEngineRestart();
   };
   args.update_semantics_callback = [](const FlutterSemanticsUpdate* update,
                                       void* user_data) {
@@ -670,6 +668,13 @@ std::shared_ptr<AccessibilityBridgeWindows>
 FlutterWindowsEngine::CreateAccessibilityBridge(FlutterWindowsEngine* engine,
                                                 FlutterWindowsView* view) {
   return std::make_shared<AccessibilityBridgeWindows>(engine, view);
+}
+
+void FlutterWindowsEngine::OnPreEngineRestart() {
+  // Reset the keyboard's state on hot restart.
+  if (view_) {
+    InitializeKeyboard();
+  }
 }
 
 gfx::NativeViewAccessible FlutterWindowsEngine::GetNativeAccessibleFromId(

--- a/shell/platform/windows/flutter_windows_engine.h
+++ b/shell/platform/windows/flutter_windows_engine.h
@@ -281,6 +281,12 @@ class FlutterWindowsEngine {
       FlutterWindowsEngine* engine,
       FlutterWindowsView* view);
 
+  // Invoked by the engine right before the engine is restarted.
+  //
+  // This should reset necessary states to as if the engine has just been
+  // created. This is typically caused by a hot restart (Shift-R in CLI.)
+  void OnPreEngineRestart();
+
  private:
   // Allows swapping out embedder_api_ calls in tests.
   friend class EngineModifier;

--- a/shell/platform/windows/flutter_windows_engine.h
+++ b/shell/platform/windows/flutter_windows_engine.h
@@ -25,10 +25,13 @@
 #include "flutter/shell/platform/windows/flutter_desktop_messenger.h"
 #include "flutter/shell/platform/windows/flutter_project_bundle.h"
 #include "flutter/shell/platform/windows/flutter_windows_texture_registrar.h"
+#include "flutter/shell/platform/windows/keyboard_handler_base.h"
+#include "flutter/shell/platform/windows/keyboard_key_embedder_handler.h"
 #include "flutter/shell/platform/windows/platform_handler.h"
 #include "flutter/shell/platform/windows/public/flutter_windows.h"
 #include "flutter/shell/platform/windows/settings_plugin.h"
 #include "flutter/shell/platform/windows/task_runner.h"
+#include "flutter/shell/platform/windows/text_input_plugin.h"
 #include "flutter/shell/platform/windows/window_proc_delegate_manager.h"
 #include "flutter/shell/platform/windows/window_state.h"
 #include "flutter/shell/platform/windows/windows_registry.h"
@@ -163,6 +166,11 @@ class FlutterWindowsEngine {
                     FlutterKeyEventCallback callback,
                     void* user_data);
 
+  KeyboardHandlerBase* keyboard_key_handler() {
+    return keyboard_key_handler_.get();
+  }
+  TextInputPlugin* text_input_plugin() { return text_input_plugin_.get(); }
+
   // Sends the given message to the engine, calling |reply| with |user_data|
   // when a response is received from the engine if they are non-null.
   bool SendPlatformMessage(const char* channel,
@@ -249,6 +257,22 @@ class FlutterWindowsEngine {
   void UpdateAccessibilityFeatures(FlutterAccessibilityFeature flags);
 
  protected:
+  // Creates the keyboard key handler.
+  //
+  // Exposing this method allows unit tests to override in order to
+  // capture information.
+  virtual std::unique_ptr<KeyboardHandlerBase> CreateKeyboardKeyHandler(
+      BinaryMessenger* messenger,
+      KeyboardKeyEmbedderHandler::GetKeyStateHandler get_key_state,
+      KeyboardKeyEmbedderHandler::MapVirtualKeyToScanCode map_vk_to_scan);
+
+  // Creates the text input plugin.
+  //
+  // Exposing this method allows unit tests to override in order to
+  // capture information.
+  virtual std::unique_ptr<TextInputPlugin> CreateTextInputPlugin(
+      BinaryMessenger* messenger);
+
   // Creates an accessibility bridge with the provided parameters.
   //
   // By default this method calls AccessibilityBridge's constructor. Exposing
@@ -266,6 +290,12 @@ class FlutterWindowsEngine {
   // Should be called just after the engine is run, and after any relevant
   // system changes.
   void SendSystemLocales();
+
+  // Create the keyboard & text input sub-systems.
+  //
+  // This requires that a view is attached to the engine.
+  // Calling this method again resets the keyboard state.
+  void InitializeKeyboard();
 
   void HandleAccessibilityMessage(FlutterDesktopMessengerRef messenger,
                                   const FlutterDesktopMessage* message);
@@ -309,11 +339,20 @@ class FlutterWindowsEngine {
   // May be nullptr if ANGLE failed to initialize.
   std::unique_ptr<AngleSurfaceManager> surface_manager_;
 
+  // The plugin registrar managing internal plugins.
+  std::unique_ptr<PluginRegistrar> internal_plugin_registrar_;
+
   // Handler for cursor events.
   std::unique_ptr<CursorHandler> cursor_handler_;
 
   // Handler for the flutter/platform channel.
   std::unique_ptr<PlatformHandler> platform_handler_;
+
+  // Handlers for keyboard events from Windows.
+  std::unique_ptr<KeyboardHandlerBase> keyboard_key_handler_;
+
+  // Handlers for text events from Windows.
+  std::unique_ptr<TextInputPlugin> text_input_plugin_;
 
   // The settings plugin.
   std::unique_ptr<SettingsPlugin> settings_plugin_;

--- a/shell/platform/windows/flutter_windows_view.h
+++ b/shell/platform/windows/flutter_windows_view.h
@@ -17,10 +17,7 @@
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/windows/angle_surface_manager.h"
 #include "flutter/shell/platform/windows/flutter_windows_engine.h"
-#include "flutter/shell/platform/windows/keyboard_handler_base.h"
-#include "flutter/shell/platform/windows/keyboard_key_embedder_handler.h"
 #include "flutter/shell/platform/windows/public/flutter_windows.h"
-#include "flutter/shell/platform/windows/text_input_plugin.h"
 #include "flutter/shell/platform/windows/text_input_plugin_delegate.h"
 #include "flutter/shell/platform/windows/window_binding_handler.h"
 #include "flutter/shell/platform/windows/window_binding_handler_delegate.h"
@@ -101,12 +98,6 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate,
 
   // Sets the cursor directly from a cursor handle.
   void SetFlutterCursor(HCURSOR cursor);
-
-  // Invoked by the engine right before the engine is restarted.
-  //
-  // This should reset necessary states to as if the view has just been
-  // created. This is typically caused by a hot restart (Shift-R in CLI.)
-  void OnPreEngineRestart();
 
   // |WindowBindingHandlerDelegate|
   void OnWindowSizeChanged(size_t width, size_t height) override;
@@ -209,21 +200,6 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate,
   virtual ui::AXFragmentRootDelegateWin* GetAxFragmentRootDelegate() override;
 
  protected:
-  // Called to create keyboard key handler.
-  //
-  // The provided |dispatch_event| is where to inject events into the system,
-  // while |get_key_state| is where to acquire keyboard states. They will be
-  // the system APIs in production classes, but might be replaced with mock
-  // functions in unit tests.
-  virtual std::unique_ptr<KeyboardHandlerBase> CreateKeyboardKeyHandler(
-      BinaryMessenger* messenger,
-      KeyboardKeyEmbedderHandler::GetKeyStateHandler get_key_state,
-      KeyboardKeyEmbedderHandler::MapVirtualKeyToScanCode map_vk_to_scan);
-
-  // Called to create text input plugin.
-  virtual std::unique_ptr<TextInputPlugin> CreateTextInputPlugin(
-      BinaryMessenger* messenger);
-
   virtual void NotifyWinEventWrapper(ui::AXPlatformNodeWin* node,
                                      ax::mojom::Event event);
 
@@ -268,11 +244,6 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate,
     // and the buffers have been swapped.
     kDone,
   };
-
-  // Initialize states related to keyboard.
-  //
-  // This is called when the view is first created, or restarted.
-  void InitializeKeyboard();
 
   // Sends a window metrics update to the Flutter engine using current window
   // dimensions in physical
@@ -378,15 +349,6 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate,
 
   // Keeps track of pointer states in relation to the window.
   std::unordered_map<int32_t, std::unique_ptr<PointerState>> pointer_states_;
-
-  // The plugin registrar managing internal plugins.
-  std::unique_ptr<PluginRegistrar> internal_plugin_registrar_;
-
-  // Handlers for keyboard events from Windows.
-  std::unique_ptr<KeyboardHandlerBase> keyboard_key_handler_;
-
-  // Handlers for text events from Windows.
-  std::unique_ptr<TextInputPlugin> text_input_plugin_;
 
   // Currently configured WindowBindingHandler for view.
   std::unique_ptr<WindowBindingHandler> binding_handler_;

--- a/shell/platform/windows/keyboard_unittests.cc
+++ b/shell/platform/windows/keyboard_unittests.cc
@@ -316,76 +316,6 @@ class MockKeyboardManagerDelegate : public KeyboardManager::WindowDelegate,
   std::list<Win32Message> redispatched_messages_;
 };
 
-// A FlutterWindowsView that overrides the RegisterKeyboardHandlers function
-// to register the keyboard hook handlers that can be spied upon.
-class TestFlutterWindowsView : public FlutterWindowsView {
- public:
-  typedef std::function<void(const std::u16string& text)> U16StringHandler;
-
-  TestFlutterWindowsView(
-      U16StringHandler on_text,
-      KeyboardKeyEmbedderHandler::GetKeyStateHandler get_keyboard_state,
-      KeyboardKeyEmbedderHandler::MapVirtualKeyToScanCode map_vk_to_scan)
-      // The WindowBindingHandler is used for window size and such, and doesn't
-      // affect keyboard.
-      : FlutterWindowsView(
-            std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>()),
-        get_keyboard_state_(std::move(get_keyboard_state)),
-        map_vk_to_scan_(std::move(map_vk_to_scan)),
-        on_text_(std::move(on_text)) {}
-
-  void OnText(const std::u16string& text) override { on_text_(text); }
-
-  void HandleMessage(const char* channel,
-                     const char* method,
-                     const char* args) {
-    rapidjson::Document args_doc;
-    args_doc.Parse(args);
-    FML_DCHECK(!args_doc.HasParseError());
-
-    rapidjson::Document message_doc(rapidjson::kObjectType);
-    auto& allocator = message_doc.GetAllocator();
-    message_doc.AddMember("method", rapidjson::Value(method, allocator),
-                          allocator);
-    message_doc.AddMember("args", args_doc, allocator);
-
-    rapidjson::StringBuffer buffer;
-    rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-    message_doc.Accept(writer);
-
-    std::unique_ptr<std::vector<uint8_t>> data =
-        JsonMessageCodec::GetInstance().EncodeMessage(message_doc);
-    FlutterPlatformMessageResponseHandle response_handle;
-    const FlutterPlatformMessage message = {
-        sizeof(FlutterPlatformMessage),  // struct_size
-        channel,                         // channel
-        data->data(),                    // message
-        data->size(),                    // message_size
-        &response_handle,                // response_handle
-    };
-    GetEngine()->HandlePlatformMessage(&message);
-  }
-
- protected:
-  std::unique_ptr<KeyboardHandlerBase> CreateKeyboardKeyHandler(
-      BinaryMessenger* messenger,
-      KeyboardKeyEmbedderHandler::GetKeyStateHandler get_key_state,
-      KeyboardKeyEmbedderHandler::MapVirtualKeyToScanCode map_vk_to_scan)
-      override {
-    return FlutterWindowsView::CreateKeyboardKeyHandler(
-        messenger,
-        [this](int virtual_key) { return get_keyboard_state_(virtual_key); },
-        [this](int virtual_key, bool extended) {
-          return map_vk_to_scan_(virtual_key, extended);
-        });
-  }
-
- private:
-  U16StringHandler on_text_;
-  KeyboardKeyEmbedderHandler::GetKeyStateHandler get_keyboard_state_;
-  KeyboardKeyEmbedderHandler::MapVirtualKeyToScanCode map_vk_to_scan_;
-};
-
 typedef struct {
   enum {
     kKeyCallOnKey,
@@ -411,6 +341,20 @@ void clear_key_calls() {
   key_calls.clear();
 }
 
+// A FlutterWindowsView that spies on text.
+class TestFlutterWindowsView : public FlutterWindowsView {
+ public:
+  TestFlutterWindowsView(std::unique_ptr<WindowBindingHandler> window)
+      : FlutterWindowsView(std::move(window)) {}
+
+  void OnText(const std::u16string& text) override {
+    key_calls.push_back(KeyCall{
+        .type = KeyCall::kKeyCallOnText,
+        .text = text,
+    });
+  }
+};
+
 class KeyboardTester {
  public:
   using ResponseHandler =
@@ -420,35 +364,10 @@ class KeyboardTester {
       : callback_handler_(RespondValue(false)),
         map_virtual_key_layout_(LayoutDefault) {
     view_ = std::make_unique<TestFlutterWindowsView>(
-        [](const std::u16string& text) {
-          key_calls.push_back(KeyCall{
-              .type = KeyCall::kKeyCallOnText,
-              .text = text,
-          });
-        },
-        [this](int virtual_key) -> SHORT {
-          // `window_` is not initialized yet when this callback is first
-          // called.
-          return window_ ? window_->GetKeyState(virtual_key) : 0;
-        },
-        [this](UINT virtual_key, bool extended) -> SHORT {
-          return map_virtual_key_layout_(
-              virtual_key, extended ? MAPVK_VK_TO_VSC_EX : MAPVK_VK_TO_VSC);
-        });
-    view_->SetEngine(GetTestEngine(
-        context, [&callback_handler = callback_handler_](
-                     const FlutterKeyEvent* event,
-                     MockKeyResponseController::ResponseCallback callback) {
-          FlutterKeyEvent clone_event = *event;
-          clone_event.character = event->character == nullptr
-                                      ? nullptr
-                                      : clone_string(event->character);
-          key_calls.push_back(KeyCall{
-              .type = KeyCall::kKeyCallOnKey,
-              .key_event = clone_event,
-          });
-          callback_handler(event, callback);
-        }));
+        // The WindowBindingHandler is used for window size and such, and
+        // doesn't affect keyboard.
+        std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>());
+    view_->SetEngine(GetTestEngine(context));
     window_ = std::make_unique<MockKeyboardManagerDelegate>(
         view_.get(), [this](UINT virtual_key) -> SHORT {
           return map_virtual_key_layout_(virtual_key, MAPVK_VK_TO_CHAR);
@@ -481,6 +400,37 @@ class KeyboardTester {
     window_->InjectKeyboardChanges(changes);
   }
 
+  // Simulates receiving a platform message from the framework.
+  void InjectPlatformMessage(const char* channel,
+                             const char* method,
+                             const char* args) {
+    rapidjson::Document args_doc;
+    args_doc.Parse(args);
+    FML_DCHECK(!args_doc.HasParseError());
+
+    rapidjson::Document message_doc(rapidjson::kObjectType);
+    auto& allocator = message_doc.GetAllocator();
+    message_doc.AddMember("method", rapidjson::Value(method, allocator),
+                          allocator);
+    message_doc.AddMember("args", args_doc, allocator);
+
+    rapidjson::StringBuffer buffer;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+    message_doc.Accept(writer);
+
+    std::unique_ptr<std::vector<uint8_t>> data =
+        JsonMessageCodec::GetInstance().EncodeMessage(message_doc);
+    FlutterPlatformMessageResponseHandle response_handle;
+    const FlutterPlatformMessage message = {
+        sizeof(FlutterPlatformMessage),  // struct_size
+        channel,                         // channel
+        data->data(),                    // message
+        data->size(),                    // message_size
+        &response_handle,                // response_handle
+    };
+    view_->GetEngine()->HandlePlatformMessage(&message);
+  }
+
   // Get the number of redispatched messages since the last clear, then clear
   // the counter.
   size_t RedispatchedMessageCountAndClear() {
@@ -500,10 +450,20 @@ class KeyboardTester {
   // overridden methods for sending platform messages, so that the engine can
   // respond as if the framework were connected.
   std::unique_ptr<FlutterWindowsEngine> GetTestEngine(
-      WindowsTestContext& context,
-      MockKeyResponseController::EmbedderCallbackHandler
-          embedder_callback_handler) {
+      WindowsTestContext& context) {
     FlutterWindowsEngineBuilder builder{context};
+
+    builder.SetCreateKeyboardHandlerCallbacks(
+        [this](int virtual_key) -> SHORT {
+          // `window_` is not initialized yet when this callback is first
+          // called.
+          return window_ ? window_->GetKeyState(virtual_key) : 0;
+        },
+        [this](UINT virtual_key, bool extended) -> SHORT {
+          return map_virtual_key_layout_(
+              virtual_key, extended ? MAPVK_VK_TO_VSC_EX : MAPVK_VK_TO_VSC);
+        });
+
     auto engine = builder.Build();
 
     EngineModifier modifier(engine.get());
@@ -511,7 +471,19 @@ class KeyboardTester {
     auto key_response_controller =
         std::make_shared<MockKeyResponseController>();
     key_response_controller->SetEmbedderResponse(
-        std::move(embedder_callback_handler));
+        [&callback_handler = callback_handler_](
+            const FlutterKeyEvent* event,
+            MockKeyResponseController::ResponseCallback callback) {
+          FlutterKeyEvent clone_event = *event;
+          clone_event.character = event->character == nullptr
+                                      ? nullptr
+                                      : clone_string(event->character);
+          key_calls.push_back(KeyCall{
+              .type = KeyCall::kKeyCallOnKey,
+              .key_event = clone_event,
+          });
+          callback_handler(event, callback);
+        });
     key_response_controller->SetTextInputResponse(
         [](std::unique_ptr<rapidjson::Document> document) {
           rapidjson::StringBuffer buffer;
@@ -522,10 +494,10 @@ class KeyboardTester {
               .text_method_call = buffer.GetString(),
           });
         });
-
     MockEmbedderApiForKeyboard(modifier, key_response_controller);
 
     engine->Run();
+
     return engine;
   }
 
@@ -995,7 +967,8 @@ TEST_F(KeyboardTest, RestartClearsKeyboardState) {
           kWmResultZero)});
 
   // Send the "hot restart" signal. This should reset the keyboard's state.
-  tester.GetView().OnPreEngineRestart();
+  // TODO:
+  //tester.GetView().OnPreEngineRestart();
 
   // Hold A. Notice the message declares the key is already down, however, the
   // the keyboard does not send a repeat event as its state was reset.
@@ -2179,7 +2152,7 @@ TEST_F(KeyboardTest, TextInputSubmit) {
 
   // US Keyboard layout
 
-  tester.GetView().HandleMessage(
+  tester.InjectPlatformMessage(
       "flutter/textinput", "TextInput.setClient",
       R"|([108, {"inputAction": "TextInputAction.none"}])|");
 

--- a/shell/platform/windows/keyboard_unittests.cc
+++ b/shell/platform/windows/keyboard_unittests.cc
@@ -973,8 +973,7 @@ TEST_F(KeyboardTest, RestartClearsKeyboardState) {
       WmCharInfo{'a', kScanCodeKeyA, kNotExtended, kWasUp}.Build(
           kWmResultZero)});
 
-  // Send the "hot restart" signal. This should reset the keyboard's state.
-  // TODO:
+  // Reset the keyboard's state.
   tester.ResetKeyboard();
 
   // Hold A. Notice the message declares the key is already down, however, the

--- a/shell/platform/windows/testing/engine_modifier.h
+++ b/shell/platform/windows/testing/engine_modifier.h
@@ -60,6 +60,10 @@ class EngineModifier {
   // engine unless overwritten again.
   void ReleaseSurfaceManager() { engine_->surface_manager_.release(); }
 
+  // Run the FlutterWindowsEngine's handler that runs right before an engine
+  // restart. This resets the keyboard's state if it exists.
+  void Restart() { engine_->OnPreEngineRestart(); }
+
  private:
   FlutterWindowsEngine* engine_;
 };

--- a/shell/platform/windows/testing/flutter_windows_engine_builder.cc
+++ b/shell/platform/windows/testing/flutter_windows_engine_builder.cc
@@ -7,6 +7,42 @@
 namespace flutter {
 namespace testing {
 
+class TestFlutterWindowsEngine : public FlutterWindowsEngine {
+ public:
+  TestFlutterWindowsEngine(
+      const FlutterProjectBundle& project,
+      KeyboardKeyEmbedderHandler::GetKeyStateHandler get_key_state,
+      KeyboardKeyEmbedderHandler::MapVirtualKeyToScanCode map_vk_to_scan)
+      : FlutterWindowsEngine(project),
+        get_key_state_(std::move(get_key_state)),
+        map_vk_to_scan_(std::move(map_vk_to_scan)) {}
+
+  // Prevent copying.
+  TestFlutterWindowsEngine(TestFlutterWindowsEngine const&) = delete;
+  TestFlutterWindowsEngine& operator=(TestFlutterWindowsEngine const&) = delete;
+
+ protected:
+  std::unique_ptr<KeyboardHandlerBase> CreateKeyboardKeyHandler(
+      BinaryMessenger* messenger,
+      KeyboardKeyEmbedderHandler::GetKeyStateHandler get_key_state,
+      KeyboardKeyEmbedderHandler::MapVirtualKeyToScanCode map_vk_to_scan) {
+    if (get_key_state_) {
+      get_key_state = get_key_state_;
+    }
+
+    if (map_vk_to_scan_) {
+      map_vk_to_scan = map_vk_to_scan_;
+    }
+
+    return FlutterWindowsEngine::CreateKeyboardKeyHandler(
+        messenger, get_key_state, map_vk_to_scan);
+  }
+
+ private:
+  KeyboardKeyEmbedderHandler::GetKeyStateHandler get_key_state_;
+  KeyboardKeyEmbedderHandler::MapVirtualKeyToScanCode map_vk_to_scan_;
+};
+
 FlutterWindowsEngineBuilder::FlutterWindowsEngineBuilder(
     WindowsTestContext& context)
     : context_(context) {
@@ -24,6 +60,13 @@ void FlutterWindowsEngineBuilder::SetDartEntrypoint(std::string entrypoint) {
 
 void FlutterWindowsEngineBuilder::AddDartEntrypointArgument(std::string arg) {
   dart_entrypoint_arguments_.emplace_back(std::move(arg));
+}
+
+void FlutterWindowsEngineBuilder::SetCreateKeyboardHandlerCallbacks(
+    KeyboardKeyEmbedderHandler::GetKeyStateHandler get_key_state,
+    KeyboardKeyEmbedderHandler::MapVirtualKeyToScanCode map_vk_to_scan) {
+  get_key_state_ = std::move(get_key_state);
+  map_vk_to_scan_ = std::move(map_vk_to_scan);
 }
 
 std::unique_ptr<FlutterWindowsEngine> FlutterWindowsEngineBuilder::Build() {
@@ -44,7 +87,7 @@ std::unique_ptr<FlutterWindowsEngine> FlutterWindowsEngineBuilder::Build() {
 
   FlutterProjectBundle project(properties_);
 
-  return std::make_unique<FlutterWindowsEngine>(project);
+  return std::make_unique<TestFlutterWindowsEngine>(project, get_key_state_, map_vk_to_scan_);
 }
 
 }  // namespace testing

--- a/shell/platform/windows/testing/flutter_windows_engine_builder.cc
+++ b/shell/platform/windows/testing/flutter_windows_engine_builder.cc
@@ -87,7 +87,8 @@ std::unique_ptr<FlutterWindowsEngine> FlutterWindowsEngineBuilder::Build() {
 
   FlutterProjectBundle project(properties_);
 
-  return std::make_unique<TestFlutterWindowsEngine>(project, get_key_state_, map_vk_to_scan_);
+  return std::make_unique<TestFlutterWindowsEngine>(project, get_key_state_,
+                                                    map_vk_to_scan_);
 }
 
 }  // namespace testing

--- a/shell/platform/windows/testing/flutter_windows_engine_builder.h
+++ b/shell/platform/windows/testing/flutter_windows_engine_builder.h
@@ -8,6 +8,7 @@
 #include <memory>
 
 #include "flutter/shell/platform/windows/flutter_windows_engine.h"
+#include "flutter/shell/platform/windows/keyboard_key_embedder_handler.h"
 #include "flutter/shell/platform/windows/public/flutter_windows.h"
 #include "flutter/shell/platform/windows/testing/windows_test_context.h"
 
@@ -23,6 +24,10 @@ class FlutterWindowsEngineBuilder {
 
   void AddDartEntrypointArgument(std::string arg);
 
+  void SetCreateKeyboardHandlerCallbacks(
+      KeyboardKeyEmbedderHandler::GetKeyStateHandler get_key_state,
+      KeyboardKeyEmbedderHandler::MapVirtualKeyToScanCode map_vk_to_scan);
+
   std::unique_ptr<FlutterWindowsEngine> Build();
 
   // Prevent copying.
@@ -35,6 +40,8 @@ class FlutterWindowsEngineBuilder {
   FlutterDesktopEngineProperties properties_ = {};
   std::string dart_entrypoint_;
   std::vector<std::string> dart_entrypoint_arguments_;
+  KeyboardKeyEmbedderHandler::GetKeyStateHandler get_key_state_;
+  KeyboardKeyEmbedderHandler::MapVirtualKeyToScanCode map_vk_to_scan_;
 };
 
 }  // namespace testing

--- a/shell/platform/windows/text_input_plugin.cc
+++ b/shell/platform/windows/text_input_plugin.cc
@@ -5,6 +5,7 @@
 #include "flutter/shell/platform/windows/text_input_plugin.h"
 #include "flutter/fml/string_conversion.h"
 #include "flutter/shell/platform/common/text_editing_delta.h"
+#include "flutter/shell/platform/windows/text_input_plugin_delegate.h"
 
 #include <windows.h>
 

--- a/shell/platform/windows/text_input_plugin.h
+++ b/shell/platform/windows/text_input_plugin.h
@@ -16,9 +16,10 @@
 #include "flutter/shell/platform/common/text_editing_delta.h"
 #include "flutter/shell/platform/common/text_input_model.h"
 #include "flutter/shell/platform/windows/keyboard_handler_base.h"
-#include "flutter/shell/platform/windows/text_input_plugin_delegate.h"
 
 namespace flutter {
+
+class TextInputPluginDelegate;
 
 // Implements a text input plugin.
 //

--- a/shell/platform/windows/text_input_plugin_unittest.cc
+++ b/shell/platform/windows/text_input_plugin_unittest.cc
@@ -10,6 +10,7 @@
 #include "flutter/shell/platform/common/json_message_codec.h"
 #include "flutter/shell/platform/common/json_method_codec.h"
 #include "flutter/shell/platform/windows/testing/test_binary_messenger.h"
+#include "flutter/shell/platform/windows/text_input_plugin_delegate.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 


### PR DESCRIPTION
The keyboard & text input plugins are singletons, however, they are currently owned by the view. This change makes them shared by the `FlutterWindowsEngine` to prepare for a multi-view world.

Part of https://github.com/flutter/flutter/issues/115611

## Keyboard

Type | Category | Notes
-- | -- | --
`KeyboardManager` | 1 per window | Receives Windows messages for key events. If the message isn't handled by Flutter, it redispatches the message back to Windows and then ignores Windows's redelivery of the message.<br/><br/>The `KeyboardManager` is owned by the `Window`, but in the future it will be refactored to be owned by the `FlutterWindowsView`. Currently it cannot be 1 per engine as redispatched messages' state must be tracked separately for each `Window`.
`KeyboardKeyHandler` | 1 per engine | Delegates keyboard events to `KeyboardKeyEmbedderHandler` and `KeyboardKeyChannelHandler`. Previously `KeyboardKeyHandler` was 1 per view.
`KeyboardKeyEmbedderHandler` | 1 per engine | Sends Flutter key events from the engine to the framework through the embedder API. Previously `KeyboardKeyEmbedderHandler` was 1 per view.
`KeyboardKeyChannelHandler` | 1 per engine | Sends raw key events from the engine to the framework through a method channel. Previously `KeyboardKeyChannelHandler` was 1 per view.

## Text input

Type | Category | Notes
-- | -- | --
`TextInputPlugin` | 1 per engine | Manages text input. Previously `TextInputPlugin` was 1 per view.
`TextInputPluginDelegate` | 1 per view | Used by `TextInputPlugin` to update the window as the user interacts with text input. For example, it updates the window's caret.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
