### PR TITLE
[Android] Convert `int` in Dart to `long` instead of `int` in java.

### DIFF
--- a/shell/platform/android/android_context_gl_unittests.cc
+++ b/shell/platform/android/android_context_gl_unittests.cc
@@ -39,7 +39,7 @@ class MockPlatformViewAndroidJNI : public PlatformViewAndroidJNI {
   MOCK_METHOD1(SurfaceTextureDetachFromGLContext,
                void(JavaLocalRef surface_texture));
   MOCK_METHOD8(FlutterViewOnDisplayPlatformView,
-               void(int view_id,
+               void(int64_t view_id,
                     int x,
                     int y,
                     int width,

--- a/shell/platform/android/android_shell_holder_unittests.cc
+++ b/shell/platform/android/android_shell_holder_unittests.cc
@@ -31,7 +31,7 @@ class MockPlatformViewAndroidJNI : public PlatformViewAndroidJNI {
   MOCK_METHOD1(SurfaceTextureDetachFromGLContext,
                void(JavaLocalRef surface_texture));
   MOCK_METHOD8(FlutterViewOnDisplayPlatformView,
-               void(int view_id,
+               void(int64_t view_id,
                     int x,
                     int y,
                     int width,

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -1382,7 +1382,7 @@ public class FlutterJNI {
   // @SuppressWarnings("unused")
   @UiThread
   public void onDisplayPlatformView(
-      int viewId,
+      long viewId,
       int x,
       int y,
       int width,

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformViewsChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformViewsChannel.java
@@ -28,7 +28,7 @@ public class PlatformViewsChannel {
   private final MethodChannel channel;
   private PlatformViewsHandler handler;
 
-  public void invokeViewFocused(int viewId) {
+  public void invokeViewFocused(long viewId) {
     if (channel == null) {
       return;
     }
@@ -93,7 +93,7 @@ public class PlatformViewsChannel {
             if (usesPlatformViewLayer) {
               final PlatformViewCreationRequest request =
                   new PlatformViewCreationRequest(
-                      (int) createArgs.get("id"),
+                      ((Number) createArgs.get("id")).longValue(),
                       (String) createArgs.get("viewType"),
                       0,
                       0,
@@ -116,7 +116,7 @@ public class PlatformViewsChannel {
                           .TEXTURE_WITH_VIRTUAL_FALLBACK;
               final PlatformViewCreationRequest request =
                   new PlatformViewCreationRequest(
-                      (int) createArgs.get("id"),
+                      ((Number) createArgs.get("id")).longValue(),
                       (String) createArgs.get("viewType"),
                       createArgs.containsKey("top") ? (double) createArgs.get("top") : 0.0,
                       createArgs.containsKey("left") ? (double) createArgs.get("left") : 0.0,
@@ -144,7 +144,7 @@ public class PlatformViewsChannel {
 
         private void dispose(@NonNull MethodCall call, @NonNull MethodChannel.Result result) {
           Map<String, Object> disposeArgs = call.arguments();
-          int viewId = (int) disposeArgs.get("id");
+          long viewId = ((Number) disposeArgs.get("id")).longValue();
 
           try {
             handler.dispose(viewId);
@@ -158,7 +158,7 @@ public class PlatformViewsChannel {
           Map<String, Object> resizeArgs = call.arguments();
           PlatformViewResizeRequest resizeRequest =
               new PlatformViewResizeRequest(
-                  (int) resizeArgs.get("id"),
+                  ((Number) resizeArgs.get("id")).longValue(),
                   (double) resizeArgs.get("width"),
                   (double) resizeArgs.get("height"));
           try {
@@ -183,7 +183,7 @@ public class PlatformViewsChannel {
           Map<String, Object> offsetArgs = call.arguments();
           try {
             handler.offset(
-                (int) offsetArgs.get("id"),
+                ((Number) offsetArgs.get("id")).longValue(),
                 (double) offsetArgs.get("top"),
                 (double) offsetArgs.get("left"));
             result.success(null);
@@ -223,7 +223,7 @@ public class PlatformViewsChannel {
 
         private void setDirection(@NonNull MethodCall call, @NonNull MethodChannel.Result result) {
           Map<String, Object> setDirectionArgs = call.arguments();
-          int newDirectionViewId = (int) setDirectionArgs.get("id");
+          long newDirectionViewId = ((Number) setDirectionArgs.get("id")).longValue();
           int direction = (int) setDirectionArgs.get("direction");
 
           try {
@@ -235,7 +235,7 @@ public class PlatformViewsChannel {
         }
 
         private void clearFocus(@NonNull MethodCall call, @NonNull MethodChannel.Result result) {
-          int viewId = call.arguments();
+          long viewId = call.arguments();
           try {
             handler.clearFocus(viewId);
             result.success(null);
@@ -319,7 +319,7 @@ public class PlatformViewsChannel {
     long createForTextureLayer(@NonNull PlatformViewCreationRequest request);
 
     /** The Flutter application would like to dispose of an existing Android {@code View}. */
-    void dispose(int viewId);
+    void dispose(long viewId);
 
     /**
      * The Flutter application would like to resize an existing Android {@code View}.
@@ -334,7 +334,7 @@ public class PlatformViewsChannel {
     /**
      * The Flutter application would like to change the offset of an existing Android {@code View}.
      */
-    void offset(int viewId, double top, double left);
+    void offset(long viewId, double top, double left);
 
     /**
      * The user touched a platform view within Flutter.
@@ -348,10 +348,10 @@ public class PlatformViewsChannel {
      * {@code View}, i.e., platform view.
      */
     // TODO(mattcarroll): Introduce an annotation for @TextureId
-    void setDirection(int viewId, int direction);
+    void setDirection(long viewId, int direction);
 
     /** Clears the focus from the platform view with a give id if it is currently focused. */
-    void clearFocus(int viewId);
+    void clearFocus(long viewId);
 
     /**
      * Whether the render surface of {@code FlutterView} should be converted to a {@code
@@ -376,7 +376,7 @@ public class PlatformViewsChannel {
     }
 
     /** The ID of the platform view as seen by the Flutter side. */
-    public final int viewId;
+    public final long viewId;
 
     /** The type of Android {@code View} to create for this platform view. */
     @NonNull public final String viewType;
@@ -408,7 +408,7 @@ public class PlatformViewsChannel {
 
     /** Creates a request to construct a platform view. */
     public PlatformViewCreationRequest(
-        int viewId,
+        long viewId,
         @NonNull String viewType,
         double logicalTop,
         double logicalLeft,
@@ -430,7 +430,7 @@ public class PlatformViewsChannel {
 
     /** Creates a request to construct a platform view with the given display mode. */
     public PlatformViewCreationRequest(
-        int viewId,
+        long viewId,
         @NonNull String viewType,
         double logicalTop,
         double logicalLeft,
@@ -454,7 +454,7 @@ public class PlatformViewsChannel {
   /** Request sent from Flutter to resize a platform view. */
   public static class PlatformViewResizeRequest {
     /** The ID of the platform view as seen by the Flutter side. */
-    public final int viewId;
+    public final long viewId;
 
     /** The new density independent width to display the platform view. */
     public final double newLogicalWidth;
@@ -462,7 +462,7 @@ public class PlatformViewsChannel {
     /** The new density independent height to display the platform view. */
     public final double newLogicalHeight;
 
-    public PlatformViewResizeRequest(int viewId, double newLogicalWidth, double newLogicalHeight) {
+    public PlatformViewResizeRequest(long viewId, double newLogicalWidth, double newLogicalHeight) {
       this.viewId = viewId;
       this.newLogicalWidth = newLogicalWidth;
       this.newLogicalHeight = newLogicalHeight;
@@ -491,7 +491,7 @@ public class PlatformViewsChannel {
   /** The state of a touch event in Flutter within a platform view. */
   public static class PlatformViewTouch {
     /** The ID of the platform view as seen by the Flutter side. */
-    public final int viewId;
+    public final long viewId;
 
     /** The amount of time that the touch has been pressed. */
     @NonNull public final Number downTime;
@@ -525,7 +525,7 @@ public class PlatformViewsChannel {
     public final long motionEventId;
 
     public PlatformViewTouch(
-        int viewId,
+        long viewId,
         @NonNull Number downTime,
         @NonNull Number eventTime,
         int action,

--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -369,7 +369,7 @@ public class TextInputPlugin implements ListenableEditingState.EditingStateWatch
    * <p>This is called when a platform view is disposed to make sure we're not hanging to a stale
    * input connection.
    */
-  public void clearPlatformViewClient(int platformViewId) {
+  public void clearPlatformViewClient(long platformViewId) {
     if ((inputTarget.type == InputTarget.Type.VIRTUAL_DISPLAY_PLATFORM_VIEW
             || inputTarget.type == InputTarget.Type.PHYSICAL_DISPLAY_PLATFORM_VIEW)
         && inputTarget.id == platformViewId) {

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewFactory.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewFactory.java
@@ -28,7 +28,7 @@ public abstract class PlatformViewFactory {
    *     null, or no arguments were sent from the Flutter app.
    */
   @NonNull
-  public abstract PlatformView create(Context context, int viewId, @Nullable Object args);
+  public abstract PlatformView create(Context context, long viewId, @Nullable Object args);
 
   /** Returns the codec to be used for decoding the args parameter of {@link #create}. */
   @Nullable

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsAccessibilityDelegate.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsAccessibilityDelegate.java
@@ -16,10 +16,10 @@ public interface PlatformViewsAccessibilityDelegate {
    * there is no corresponding view.
    */
   @Nullable
-  View getPlatformViewById(int viewId);
+  View getPlatformViewById(long viewId);
 
   /** Returns true if the platform view uses virtual displays. */
-  boolean usesVirtualDisplay(int id);
+  boolean usesVirtualDisplay(long viewId);
 
   /**
    * Attaches an accessibility bridge for this platform views accessibility delegate.

--- a/shell/platform/android/io/flutter/plugin/platform/SingleViewPresentation.java
+++ b/shell/platform/android/io/flutter/plugin/platform/SingleViewPresentation.java
@@ -82,7 +82,7 @@ class SingleViewPresentation extends Presentation {
 
   // This is the view id assigned by the Flutter framework to the embedded view, we keep it here
   // so when we create the platform view we can tell it its view id.
-  private int viewId;
+  private long viewId;
 
   // The root view for the presentation, it has 2 childs: container which contains the embedded
   // view, and
@@ -110,7 +110,7 @@ class SingleViewPresentation extends Presentation {
       Display display,
       PlatformView view,
       AccessibilityEventsDelegate accessibilityEventsDelegate,
-      int viewId,
+      long viewId,
       OnFocusChangeListener focusChangeListener) {
     super(new ImmContext(outerContext), display);
     this.accessibilityEventsDelegate = accessibilityEventsDelegate;

--- a/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java
@@ -30,7 +30,7 @@ class VirtualDisplayController {
       TextureRegistry.SurfaceTextureEntry textureEntry,
       int width,
       int height,
-      int viewId,
+      long viewId,
       Object createParams,
       OnFocusChangeListener focusChangeListener) {
 
@@ -98,7 +98,7 @@ class VirtualDisplayController {
       Surface surface,
       TextureRegistry.SurfaceTextureEntry textureEntry,
       OnFocusChangeListener focusChangeListener,
-      int viewId,
+      long viewId,
       Object createParams) {
     this.context = context;
     this.accessibilityEventsDelegate = accessibilityEventsDelegate;

--- a/shell/platform/android/jni/jni_mock.h
+++ b/shell/platform/android/jni/jni_mock.h
@@ -66,7 +66,7 @@ class JNIMock final : public PlatformViewAndroidJNI {
 
   MOCK_METHOD(void,
               FlutterViewOnDisplayPlatformView,
-              (int view_id,
+              (int64_t view_id,
                int x,
                int y,
                int width,

--- a/shell/platform/android/jni/platform_view_android_jni.h
+++ b/shell/platform/android/jni/platform_view_android_jni.h
@@ -116,7 +116,7 @@ class PlatformViewAndroidJNI {
   /// @note       Must be called from the platform thread.
   ///
   virtual void FlutterViewOnDisplayPlatformView(
-      int view_id,
+      int64_t view_id,
       int x,
       int y,
       int width,

--- a/shell/platform/android/platform_view_android_jni_impl.cc
+++ b/shell/platform/android/platform_view_android_jni_impl.cc
@@ -1026,7 +1026,7 @@ bool PlatformViewAndroid::Register(JNIEnv* env) {
 
   g_on_display_platform_view_method =
       env->GetMethodID(g_flutter_jni_class->obj(), "onDisplayPlatformView",
-                       "(IIIIIIILio/flutter/embedding/engine/mutatorsstack/"
+                       "(JIIIIIILio/flutter/embedding/engine/mutatorsstack/"
                        "FlutterMutatorsStack;)V");
 
   if (g_on_display_platform_view_method == nullptr) {
@@ -1406,7 +1406,7 @@ void PlatformViewAndroidJNIImpl::SurfaceTextureDetachFromGLContext(
 }
 
 void PlatformViewAndroidJNIImpl::FlutterViewOnDisplayPlatformView(
-    int view_id,
+    int64_t view_id,
     int x,
     int y,
     int width,

--- a/shell/platform/android/platform_view_android_jni_impl.h
+++ b/shell/platform/android/platform_view_android_jni_impl.h
@@ -52,7 +52,7 @@ class PlatformViewAndroidJNIImpl final : public PlatformViewAndroidJNI {
 
   void SurfaceTextureDetachFromGLContext(JavaLocalRef surface_texture) override;
 
-  void FlutterViewOnDisplayPlatformView(int view_id,
+  void FlutterViewOnDisplayPlatformView(int64_t view_id,
                                         int x,
                                         int y,
                                         int width,

--- a/shell/platform/android/test/io/flutter/embedding/engine/FlutterJNITest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/FlutterJNITest.java
@@ -158,7 +158,7 @@ public class FlutterJNITest {
     FlutterMutatorsStack stack = new FlutterMutatorsStack();
     // --- Execute Test ---
     flutterJNI.onDisplayPlatformView(
-        /*viewId=*/ 1,
+        /*viewId=*/ 1L,
         /*x=*/ 10,
         /*y=*/ 20,
         /*width=*/ 100,
@@ -170,7 +170,7 @@ public class FlutterJNITest {
     // --- Verify Results ---
     verify(platformViewsController, times(1))
         .onDisplayPlatformView(
-            /*viewId=*/ 1,
+            /*viewId=*/ 1L,
             /*x=*/ 10,
             /*y=*/ 20,
             /*width=*/ 100,

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
@@ -323,7 +323,8 @@ public class PlatformViewsControllerTest {
   public void createPlatformViewMessage_initializesAndroidView() {
     PlatformViewsController platformViewsController = new PlatformViewsController();
 
-    final long platformViewId = 0L;
+    // The value is actually large enough to require a long.
+    final long platformViewId = 0x80000000L;
     assertNull(platformViewsController.getPlatformViewById(platformViewId));
 
     PlatformViewFactory viewFactory = mock(PlatformViewFactory.class);

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
@@ -129,7 +129,7 @@ public class PlatformViewsControllerTest {
   @Test
   @Config(shadows = {ShadowFlutterJNI.class, ShadowPlatformTaskQueue.class})
   public void virtualDisplay_handlesResizeResponseWithoutContext() {
-    final int platformViewId = 0;
+    final long platformViewId = 0L;
     FlutterView fakeFlutterView = new FlutterView(ApplicationProvider.getApplicationContext());
     VirtualDisplayController fakeVdController = mock(VirtualDisplayController.class);
     PlatformViewsController platformViewsController = new PlatformViewsController();
@@ -295,7 +295,7 @@ public class PlatformViewsControllerTest {
   public void getPlatformViewById_hybridComposition() {
     PlatformViewsController platformViewsController = new PlatformViewsController();
 
-    int platformViewId = 0;
+    final long platformViewId = 0L;
     assertNull(platformViewsController.getPlatformViewById(platformViewId));
 
     PlatformViewFactory viewFactory = mock(PlatformViewFactory.class);
@@ -323,7 +323,7 @@ public class PlatformViewsControllerTest {
   public void createPlatformViewMessage_initializesAndroidView() {
     PlatformViewsController platformViewsController = new PlatformViewsController();
 
-    int platformViewId = 0;
+    final long platformViewId = 0L;
     assertNull(platformViewsController.getPlatformViewById(platformViewId));
 
     PlatformViewFactory viewFactory = mock(PlatformViewFactory.class);
@@ -345,7 +345,7 @@ public class PlatformViewsControllerTest {
   public void createPlatformViewMessage_wrapsContextForVirtualDisplay() {
     PlatformViewsController platformViewsController = new PlatformViewsController();
 
-    int platformViewId = 0;
+    final long platformViewId = 0L;
     assertNull(platformViewsController.getPlatformViewById(platformViewId));
 
     PlatformViewFactory viewFactory = mock(PlatformViewFactory.class);
@@ -370,7 +370,7 @@ public class PlatformViewsControllerTest {
   public void createPlatformViewMessage_doesNotWrapContextForHybrid() {
     PlatformViewsController platformViewsController = new PlatformViewsController();
 
-    int platformViewId = 0;
+    final long platformViewId = 0L;
     assertNull(platformViewsController.getPlatformViewById(platformViewId));
 
     PlatformViewFactory viewFactory = mock(PlatformViewFactory.class);
@@ -395,7 +395,7 @@ public class PlatformViewsControllerTest {
     PlatformViewsController platformViewsController = new PlatformViewsController();
     platformViewsController.setSoftwareRendering(true);
 
-    int platformViewId = 0;
+    final long platformViewId = 0L;
     assertNull(platformViewsController.getPlatformViewById(platformViewId));
 
     PlatformViewFactory viewFactory = mock(PlatformViewFactory.class);
@@ -421,7 +421,7 @@ public class PlatformViewsControllerTest {
     PlatformViewsController platformViewsController = new PlatformViewsController();
     platformViewsController.setSoftwareRendering(true);
 
-    int platformViewId = 0;
+    final long platformViewId = 0L;
     assertNull(platformViewsController.getPlatformViewById(platformViewId));
 
     PlatformViewFactory viewFactory = mock(PlatformViewFactory.class);
@@ -454,7 +454,7 @@ public class PlatformViewsControllerTest {
     PlatformViewsController platformViewsController = new PlatformViewsController();
     platformViewsController.setSoftwareRendering(true);
 
-    int platformViewId = 0;
+    final long platformViewId = 0L;
     assertNull(platformViewsController.getPlatformViewById(platformViewId));
 
     PlatformViewFactory viewFactory = mock(PlatformViewFactory.class);
@@ -480,7 +480,7 @@ public class PlatformViewsControllerTest {
   public void createPlatformViewMessage_throwsIfViewIsNull() {
     PlatformViewsController platformViewsController = new PlatformViewsController();
 
-    int platformViewId = 0;
+    final long platformViewId = 0L;
     assertNull(platformViewsController.getPlatformViewById(platformViewId));
 
     PlatformViewFactory viewFactory = mock(PlatformViewFactory.class);
@@ -509,7 +509,7 @@ public class PlatformViewsControllerTest {
   public void createHybridPlatformViewMessage_throwsIfViewIsNull() {
     PlatformViewsController platformViewsController = new PlatformViewsController();
 
-    int platformViewId = 0;
+    final long platformViewId = 0L;
     assertNull(platformViewsController.getPlatformViewById(platformViewId));
 
     PlatformViewFactory viewFactory = mock(PlatformViewFactory.class);
@@ -537,7 +537,7 @@ public class PlatformViewsControllerTest {
   public void onDetachedFromJNI_clearsPlatformViewContext() {
     PlatformViewsController platformViewsController = new PlatformViewsController();
 
-    int platformViewId = 0;
+    final long platformViewId = 0L;
     assertNull(platformViewsController.getPlatformViewById(platformViewId));
 
     PlatformViewFactory viewFactory = mock(PlatformViewFactory.class);
@@ -568,7 +568,7 @@ public class PlatformViewsControllerTest {
   public void onPreEngineRestart_clearsPlatformViewContext() {
     PlatformViewsController platformViewsController = new PlatformViewsController();
 
-    int platformViewId = 0;
+    final long platformViewId = 0L;
     assertNull(platformViewsController.getPlatformViewById(platformViewId));
 
     PlatformViewFactory viewFactory = mock(PlatformViewFactory.class);
@@ -599,7 +599,7 @@ public class PlatformViewsControllerTest {
   public void createPlatformViewMessage_throwsIfViewHasParent() {
     PlatformViewsController platformViewsController = new PlatformViewsController();
 
-    int platformViewId = 0;
+    final long platformViewId = 0L;
     assertNull(platformViewsController.getPlatformViewById(platformViewId));
 
     PlatformViewFactory viewFactory = mock(PlatformViewFactory.class);
@@ -630,7 +630,7 @@ public class PlatformViewsControllerTest {
   public void createHybridPlatformViewMessage_throwsIfViewHasParent() {
     PlatformViewsController platformViewsController = new PlatformViewsController();
 
-    int platformViewId = 0;
+    final long platformViewId = 0L;
     assertNull(platformViewsController.getPlatformViewById(platformViewId));
 
     PlatformViewFactory viewFactory = mock(PlatformViewFactory.class);
@@ -660,7 +660,7 @@ public class PlatformViewsControllerTest {
   public void setPlatformViewDirection_throwIfPlatformViewNotFound() {
     PlatformViewsController platformViewsController = new PlatformViewsController();
 
-    int platformViewId = 0;
+    final long platformViewId = 0L;
     assertNull(platformViewsController.getPlatformViewById(platformViewId));
 
     PlatformViewFactory viewFactory = mock(PlatformViewFactory.class);
@@ -695,7 +695,7 @@ public class PlatformViewsControllerTest {
     PlatformViewsController platformViewsController = new PlatformViewsController();
     platformViewsController.setSoftwareRendering(true);
 
-    int platformViewId = 0;
+    final long platformViewId = 0L;
     assertNull(platformViewsController.getPlatformViewById(platformViewId));
 
     PlatformViewFactory viewFactory = mock(PlatformViewFactory.class);
@@ -731,7 +731,7 @@ public class PlatformViewsControllerTest {
   public void disposeAndroidView_hybridComposition() {
     PlatformViewsController platformViewsController = new PlatformViewsController();
 
-    int platformViewId = 0;
+    final long platformViewId = 0L;
     assertNull(platformViewsController.getPlatformViewById(platformViewId));
 
     PlatformViewFactory viewFactory = mock(PlatformViewFactory.class);
@@ -772,7 +772,7 @@ public class PlatformViewsControllerTest {
   public void disposeNullAndroidView() {
     PlatformViewsController platformViewsController = new PlatformViewsController();
 
-    int platformViewId = 0;
+    final long platformViewId = 0L;
     assertNull(platformViewsController.getPlatformViewById(platformViewId));
 
     PlatformViewFactory viewFactory = mock(PlatformViewFactory.class);
@@ -809,7 +809,7 @@ public class PlatformViewsControllerTest {
   public void onEndFrame_destroysOverlaySurfaceAfterFrameOnFlutterSurfaceView() {
     final PlatformViewsController platformViewsController = new PlatformViewsController();
 
-    final int platformViewId = 0;
+    final long platformViewId = 0L;
     assertNull(platformViewsController.getPlatformViewById(platformViewId));
 
     final PlatformViewFactory viewFactory = mock(PlatformViewFactory.class);
@@ -868,7 +868,7 @@ public class PlatformViewsControllerTest {
   public void onEndFrame_removesPlatformView() {
     final PlatformViewsController platformViewsController = new PlatformViewsController();
 
-    final int platformViewId = 0;
+    final long platformViewId = 0L;
     assertNull(platformViewsController.getPlatformViewById(platformViewId));
 
     final PlatformViewFactory viewFactory = mock(PlatformViewFactory.class);
@@ -909,7 +909,7 @@ public class PlatformViewsControllerTest {
   public void onEndFrame_removesPlatformViewParent() {
     final PlatformViewsController platformViewsController = new PlatformViewsController();
 
-    final int platformViewId = 0;
+    final long platformViewId = 0L;
     assertNull(platformViewsController.getPlatformViewById(platformViewId));
 
     final PlatformViewFactory viewFactory = mock(PlatformViewFactory.class);
@@ -952,7 +952,7 @@ public class PlatformViewsControllerTest {
   public void detach_destroysOverlaySurfaces() {
     final PlatformViewsController platformViewsController = new PlatformViewsController();
 
-    final int platformViewId = 0;
+    final long platformViewId = 0L;
     assertNull(platformViewsController.getPlatformViewById(platformViewId));
 
     final PlatformViewFactory viewFactory = mock(PlatformViewFactory.class);
@@ -1003,7 +1003,7 @@ public class PlatformViewsControllerTest {
   public void detachFromView_removesAndDestroysOverlayViews() {
     final PlatformViewsController platformViewsController = new PlatformViewsController();
 
-    final int platformViewId = 0;
+    final long platformViewId = 0L;
     assertNull(platformViewsController.getPlatformViewById(platformViewId));
 
     final PlatformViewFactory viewFactory = mock(PlatformViewFactory.class);
@@ -1041,7 +1041,7 @@ public class PlatformViewsControllerTest {
   public void destroyOverlaySurfaces_doesNotThrowIfFlutterViewIsDetached() {
     final PlatformViewsController platformViewsController = new PlatformViewsController();
 
-    final int platformViewId = 0;
+    final long platformViewId = 0L;
     assertNull(platformViewsController.getPlatformViewById(platformViewId));
 
     final PlatformViewFactory viewFactory = mock(PlatformViewFactory.class);
@@ -1079,7 +1079,7 @@ public class PlatformViewsControllerTest {
   public void destroyOverlaySurfaces_doesNotRemoveOverlayView() {
     final PlatformViewsController platformViewsController = new PlatformViewsController();
 
-    final int platformViewId = 0;
+    final long platformViewId = 0L;
     assertNull(platformViewsController.getPlatformViewById(platformViewId));
 
     final PlatformViewFactory viewFactory = mock(PlatformViewFactory.class);
@@ -1121,7 +1121,7 @@ public class PlatformViewsControllerTest {
   public void convertPlatformViewRenderSurfaceAsDefault() {
     final PlatformViewsController platformViewsController = new PlatformViewsController();
 
-    final int platformViewId = 0;
+    final long platformViewId = 0L;
     assertNull(platformViewsController.getPlatformViewById(platformViewId));
 
     final PlatformViewFactory viewFactory = mock(PlatformViewFactory.class);
@@ -1167,7 +1167,7 @@ public class PlatformViewsControllerTest {
   public void dontConverRenderSurfaceWhenFlagIsTrue() {
     final PlatformViewsController platformViewsController = new PlatformViewsController();
 
-    final int platformViewId = 0;
+    final long platformViewId = 0L;
     assertNull(platformViewsController.getPlatformViewById(platformViewId));
 
     final PlatformViewFactory viewFactory = mock(PlatformViewFactory.class);
@@ -1216,7 +1216,7 @@ public class PlatformViewsControllerTest {
     PlatformViewsController platformViewsController = new PlatformViewsController();
     platformViewsController.setSoftwareRendering(true);
 
-    int platformViewId = 100;
+    final long platformViewId = 0x80000000L;
     assertNull(platformViewsController.getPlatformViewById(platformViewId));
 
     PlatformViewFactory viewFactory = mock(PlatformViewFactory.class);
@@ -1251,7 +1251,7 @@ public class PlatformViewsControllerTest {
   public void revertImageViewAndRemoveImageView() {
     final PlatformViewsController platformViewsController = new PlatformViewsController();
 
-    final int platformViewId = 0;
+    final long platformViewId = 0L;
     assertNull(platformViewsController.getPlatformViewById(platformViewId));
 
     final PlatformViewFactory viewFactory = mock(PlatformViewFactory.class);
@@ -1274,8 +1274,9 @@ public class PlatformViewsControllerTest {
 
     // The simulation creates an Overlay on top of the PlatformView
     // This is going to be called `flutterView.convertToImageView`
+    final int overlaySurfaceId = 0;
     platformViewsController.createOverlaySurface();
-    platformViewsController.onDisplayOverlaySurface(platformViewId, 0, 0, 10, 10);
+    platformViewsController.onDisplayOverlaySurface(overlaySurfaceId, 0, 0, 10, 10);
 
     // This will contain three views: Background ImageView、PlatformView、Overlay ImageView
     assertEquals(flutterView.getChildCount(), 3);
@@ -1319,7 +1320,7 @@ public class PlatformViewsControllerTest {
   private static void createPlatformView(
       FlutterJNI jni,
       PlatformViewsController platformViewsController,
-      int platformViewId,
+      long platformViewId,
       String viewType,
       boolean hybrid) {
     final Map<String, Object> args = new HashMap<>();
@@ -1342,7 +1343,7 @@ public class PlatformViewsControllerTest {
   private static void setLayoutDirection(
       FlutterJNI jni,
       PlatformViewsController platformViewsController,
-      int platformViewId,
+      long platformViewId,
       int direction) {
     final Map<String, Object> args = new HashMap<>();
     args.put("id", platformViewId);
@@ -1360,7 +1361,7 @@ public class PlatformViewsControllerTest {
   private static void resize(
       FlutterJNI jni,
       PlatformViewsController platformViewsController,
-      int platformViewId,
+      long platformViewId,
       double width,
       double height) {
     final Map<String, Object> args = new HashMap<>();
@@ -1378,7 +1379,7 @@ public class PlatformViewsControllerTest {
   }
 
   private static void disposePlatformView(
-      FlutterJNI jni, PlatformViewsController platformViewsController, int platformViewId) {
+      FlutterJNI jni, PlatformViewsController platformViewsController, long platformViewId) {
 
     final Map<String, Object> args = new HashMap<>();
     args.put("hybrid", true);

--- a/testing/scenario_app/android/app/src/main/java/dev/flutter/scenarios/SurfacePlatformViewFactory.java
+++ b/testing/scenario_app/android/app/src/main/java/dev/flutter/scenarios/SurfacePlatformViewFactory.java
@@ -51,7 +51,7 @@ public final class SurfacePlatformViewFactory extends PlatformViewFactory {
   @SuppressWarnings("unchecked")
   @Override
   @NonNull
-  public PlatformView create(@NonNull Context context, int id, @Nullable Object args) {
+  public PlatformView create(@NonNull Context context, long id, @Nullable Object args) {
     if (preserveContext) {
       return new SurfacePlatformView(context);
     } else {

--- a/testing/scenario_app/android/app/src/main/java/dev/flutter/scenarios/TextPlatformViewFactory.java
+++ b/testing/scenario_app/android/app/src/main/java/dev/flutter/scenarios/TextPlatformViewFactory.java
@@ -41,7 +41,7 @@ public final class TextPlatformViewFactory extends PlatformViewFactory {
   @SuppressWarnings("unchecked")
   @Override
   @NonNull
-  public PlatformView create(@NonNull Context context, int id, @Nullable Object args) {
+  public PlatformView create(@NonNull Context context, long id, @Nullable Object args) {
     String params = (String) args;
     return new TextPlatformView(context, id, params);
   }
@@ -50,7 +50,7 @@ public final class TextPlatformViewFactory extends PlatformViewFactory {
     final TextView textView;
 
     @SuppressWarnings("unchecked")
-    TextPlatformView(@NonNull final Context context, int id, @Nullable String params) {
+    TextPlatformView(@NonNull final Context context, long id, @Nullable String params) {
       textView = new TextView(context);
       textView.setTextSize(72);
       textView.setBackgroundColor(Color.WHITE);

--- a/testing/scenario_app/android/app/src/main/java/dev/flutter/scenarios/TexturePlatformViewFactory.java
+++ b/testing/scenario_app/android/app/src/main/java/dev/flutter/scenarios/TexturePlatformViewFactory.java
@@ -47,7 +47,7 @@ public final class TexturePlatformViewFactory extends PlatformViewFactory {
   @SuppressWarnings("unchecked")
   @Override
   @NonNull
-  public PlatformView create(@NonNull Context context, int id, @Nullable Object args) {
+  public PlatformView create(@NonNull Context context, long id, @Nullable Object args) {
     return new TexturePlatformView(context);
   }
 


### PR DESCRIPTION
We should use the 64-bit to represent `int` in Dart.

As an example of an extreme case, if |viewId| is greater than `0x80000000` on the Dart side, the native code will throw the following exception:

<img width="1123" alt="image" src="https://user-images.githubusercontent.com/26625149/217752234-1f85e3b7-850f-40ab-be80-6aa899019b6a.png">


See the below codes for more details:
https://github.com/flutter/flutter/blob/19dfde6989b14bd7dedbc50d7edceef4e59879a4/packages/flutter/lib/src/services/message_codecs.dart#L399-L407


Related issue: https://github.com/flutter/flutter/issues/120256

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
