### PR TITLE
[Impeller] Fix sampling management problems

### DIFF
--- a/impeller/display_list/display_list_dispatcher.cc
+++ b/impeller/display_list/display_list_dispatcher.cc
@@ -136,6 +136,9 @@ static impeller::SamplerDescriptor ToSamplerDescriptor(
       desc.label = "Nearest Sampler";
       break;
     case flutter::DlImageSampling::kLinear:
+    // Impeller doesn't support cubic sampling, but linear is closer to correct
+    // than nearest for this case.
+    case flutter::DlImageSampling::kCubic:
       desc.min_filter = desc.mag_filter = impeller::MinMagFilter::kLinear;
       desc.label = "Linear Sampler";
       break;
@@ -143,8 +146,6 @@ static impeller::SamplerDescriptor ToSamplerDescriptor(
       desc.min_filter = desc.mag_filter = impeller::MinMagFilter::kLinear;
       desc.mip_filter = impeller::MipFilter::kLinear;
       desc.label = "Mipmap Linear Sampler";
-      break;
-    default:
       break;
   }
   return desc;

--- a/impeller/entity/contents/contents.cc
+++ b/impeller/entity/contents/contents.cc
@@ -41,6 +41,7 @@ Contents::StencilCoverage Contents::GetStencilCoverage(
 std::optional<Snapshot> Contents::RenderToSnapshot(
     const ContentContext& renderer,
     const Entity& entity,
+    const std::optional<SamplerDescriptor>& sampler_descriptor,
     bool msaa_enabled) const {
   auto coverage = GetCoverage(entity);
   if (!coverage.has_value()) {
@@ -64,8 +65,15 @@ std::optional<Snapshot> Contents::RenderToSnapshot(
     return std::nullopt;
   }
 
-  return Snapshot{.texture = texture,
-                  .transform = Matrix::MakeTranslation(coverage->origin)};
+  auto snapshot = Snapshot{
+      .texture = texture,
+      .transform = Matrix::MakeTranslation(coverage->origin),
+  };
+  if (sampler_descriptor.has_value()) {
+    snapshot.sampler_descriptor = sampler_descriptor.value();
+  }
+
+  return snapshot;
 }
 
 bool Contents::ShouldRender(const Entity& entity,

--- a/impeller/entity/contents/contents.h
+++ b/impeller/entity/contents/contents.h
@@ -10,6 +10,7 @@
 
 #include "flutter/fml/macros.h"
 #include "impeller/geometry/rect.h"
+#include "impeller/renderer/sampler_descriptor.h"
 #include "impeller/renderer/snapshot.h"
 #include "impeller/renderer/texture.h"
 
@@ -61,6 +62,7 @@ class Contents {
   virtual std::optional<Snapshot> RenderToSnapshot(
       const ContentContext& renderer,
       const Entity& entity,
+      const std::optional<SamplerDescriptor>& sampler_descriptor = std::nullopt,
       bool msaa_enabled = true) const;
 
   virtual bool ShouldRender(const Entity& entity,

--- a/impeller/entity/contents/filters/filter_contents.cc
+++ b/impeller/entity/contents/filters/filter_contents.cc
@@ -237,6 +237,7 @@ std::optional<Rect> FilterContents::GetFilterCoverage(
 std::optional<Snapshot> FilterContents::RenderToSnapshot(
     const ContentContext& renderer,
     const Entity& entity,
+    const std::optional<SamplerDescriptor>& sampler_descriptor,
     bool msaa_enabled) const {
   Entity entity_with_local_transform = entity;
   entity_with_local_transform.SetTransformation(

--- a/impeller/entity/contents/filters/filter_contents.h
+++ b/impeller/entity/contents/filters/filter_contents.h
@@ -119,6 +119,7 @@ class FilterContents : public Contents {
   std::optional<Snapshot> RenderToSnapshot(
       const ContentContext& renderer,
       const Entity& entity,
+      const std::optional<SamplerDescriptor>& sampler_descriptor = std::nullopt,
       bool msaa_enabled = true) const override;
 
   virtual Matrix GetLocalTransform(const Matrix& parent_transform) const;

--- a/impeller/entity/contents/filters/inputs/contents_filter_input.cc
+++ b/impeller/entity/contents/filters/inputs/contents_filter_input.cc
@@ -4,6 +4,7 @@
 
 #include "impeller/entity/contents/filters/inputs/contents_filter_input.h"
 
+#include <optional>
 #include <utility>
 
 namespace impeller {
@@ -22,7 +23,8 @@ std::optional<Snapshot> ContentsFilterInput::GetSnapshot(
     const ContentContext& renderer,
     const Entity& entity) const {
   if (!snapshot_.has_value()) {
-    snapshot_ = contents_->RenderToSnapshot(renderer, entity, msaa_enabled_);
+    snapshot_ = contents_->RenderToSnapshot(renderer, entity, std::nullopt,
+                                            msaa_enabled_);
   }
   return snapshot_;
 }

--- a/impeller/entity/contents/texture_contents.cc
+++ b/impeller/entity/contents/texture_contents.cc
@@ -67,6 +67,7 @@ std::optional<Rect> TextureContents::GetCoverage(const Entity& entity) const {
 std::optional<Snapshot> TextureContents::RenderToSnapshot(
     const ContentContext& renderer,
     const Entity& entity,
+    const std::optional<SamplerDescriptor>& sampler_descriptor,
     bool msaa_enabled) const {
   auto bounds = path_.GetBoundingBox();
   if (!bounds.has_value()) {
@@ -78,14 +79,16 @@ std::optional<Snapshot> TextureContents::RenderToSnapshot(
   if (is_rect_ && source_rect_ == Rect::MakeSize(texture_->GetSize()) &&
       (opacity_ >= 1 - kEhCloseEnough || defer_applying_opacity_)) {
     auto scale = Vector2(bounds->size / Size(texture_->GetSize()));
-    return Snapshot{.texture = texture_,
-                    .transform = entity.GetTransformation() *
-                                 Matrix::MakeTranslation(bounds->origin) *
-                                 Matrix::MakeScale(scale),
-                    .sampler_descriptor = sampler_descriptor_,
-                    .opacity = opacity_};
+    return Snapshot{
+        .texture = texture_,
+        .transform = entity.GetTransformation() *
+                     Matrix::MakeTranslation(bounds->origin) *
+                     Matrix::MakeScale(scale),
+        .sampler_descriptor = sampler_descriptor.value_or(sampler_descriptor_),
+        .opacity = opacity_};
   }
-  return Contents::RenderToSnapshot(renderer, entity);
+  return Contents::RenderToSnapshot(
+      renderer, entity, sampler_descriptor.value_or(sampler_descriptor_));
 }
 
 bool TextureContents::Render(const ContentContext& renderer,

--- a/impeller/entity/contents/texture_contents.h
+++ b/impeller/entity/contents/texture_contents.h
@@ -55,6 +55,7 @@ class TextureContents final : public Contents {
   std::optional<Snapshot> RenderToSnapshot(
       const ContentContext& renderer,
       const Entity& entity,
+      const std::optional<SamplerDescriptor>& sampler_descriptor = std::nullopt,
       bool msaa_enabled = true) const override;
 
   // |Contents|

--- a/impeller/renderer/sampler_descriptor.cc
+++ b/impeller/renderer/sampler_descriptor.cc
@@ -3,9 +3,19 @@
 // found in the LICENSE file.
 
 #include "impeller/renderer/sampler_descriptor.h"
+#include "fml/logging.h"
 
 namespace impeller {
 
-//
+SamplerDescriptor::SamplerDescriptor() = default;
+
+SamplerDescriptor::SamplerDescriptor(std::string label,
+                                     MinMagFilter min_filter,
+                                     MinMagFilter mag_filter,
+                                     MipFilter mip_filter)
+    : min_filter(min_filter),
+      mag_filter(mag_filter),
+      mip_filter(mip_filter),
+      label(std::move(label)) {}
 
 }  // namespace impeller

--- a/impeller/renderer/sampler_descriptor.h
+++ b/impeller/renderer/sampler_descriptor.h
@@ -26,6 +26,13 @@ struct SamplerDescriptor final : public Comparable<SamplerDescriptor> {
 
   std::string label = "NN Clamp Sampler";
 
+  SamplerDescriptor();
+
+  SamplerDescriptor(std::string label,
+                    MinMagFilter min_filter,
+                    MinMagFilter mag_filter,
+                    MipFilter mip_filter);
+
   // Comparable<SamplerDescriptor>
   std::size_t GetHash() const override {
     return fml::HashCombine(min_filter, mag_filter, mip_filter,

--- a/impeller/renderer/snapshot.h
+++ b/impeller/renderer/snapshot.h
@@ -11,6 +11,7 @@
 #include "flutter/fml/macros.h"
 #include "impeller/geometry/matrix.h"
 #include "impeller/geometry/rect.h"
+#include "impeller/renderer/formats.h"
 #include "impeller/renderer/sampler_descriptor.h"
 #include "impeller/renderer/texture.h"
 
@@ -25,7 +26,11 @@ struct Snapshot {
   /// The transform that should be applied to this texture for rendering.
   Matrix transform;
 
-  SamplerDescriptor sampler_descriptor;
+  SamplerDescriptor sampler_descriptor =
+      SamplerDescriptor("Default Snapshot Sampler",
+                        MinMagFilter::kLinear,
+                        MinMagFilter::kLinear,
+                        MipFilter::kLinear);
 
   Scalar opacity = 1.0f;
 


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/118614.
Resolves https://github.com/gskinnerTeam/flutter-wonderous-app/issues/69.

* Add a `Contents::RenderToSnapshot` sampler descriptor param, so that `TextureContents::RenderToSnapshot` can apply the right sampler settings even when it's unable to passthrough.
* Make the blend filter apply the snapshot's sampling mode when rendering. Then, use nearest sampling for the final render (since the blend filter absorbs the transform).
* Treat the Cubic DL sampling mode as Linear instead of falling back to Nearest. Impeller doesn't support `kCubic` sampling (and perhaps we shouldn't).
* Make a default snapshot SamplerDescriptor have a clear label so that it's easy to spot in GPU captures.