### PR TITLE
[web] Implement overlay with canvas2d to bypass the limits of number of active WebGL contexts

### DIFF
--- a/lib/web_ui/lib/src/engine.dart
+++ b/lib/web_ui/lib/src/engine.dart
@@ -50,6 +50,8 @@ export 'engine/canvaskit/rasterizer.dart';
 export 'engine/canvaskit/renderer.dart';
 export 'engine/canvaskit/shader.dart';
 export 'engine/canvaskit/skia_object_cache.dart';
+export 'engine/canvaskit/snapshot_surface.dart';
+export 'engine/canvaskit/snapshot_surface_factory.dart';
 export 'engine/canvaskit/surface.dart';
 export 'engine/canvaskit/surface_factory.dart';
 export 'engine/canvaskit/text.dart';

--- a/lib/web_ui/lib/src/engine/canvaskit/snapshot_surface.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/snapshot_surface.dart
@@ -1,0 +1,94 @@
+import 'package:ui/src/engine.dart';
+import 'package:ui/ui.dart' as ui;
+
+/// A surface that can store the contents of a Surface. Used as overlay for
+/// platform views.
+class SnapshotSurface {
+  /// The root HTML element for this surface.
+  final DomElement htmlElement = createDomElement('flt-canvas-container');
+
+  /// The underlying `<canvas>` element used for this snapshot surface.
+  DomCanvasElement? htmlCanvas;
+
+  /// The 2D rendering context of [htmlCanvas].
+  DomCanvasRenderingContext2D? canvasContext;
+
+  late ui.Size _currentPhysicalSize;
+
+  ui.Size get physicalSize => _currentPhysicalSize;
+
+  /// Creates a <canvas> and context for the given [size].
+  void createOrUpdateSurface(ui.Size size) {
+    if (size.isEmpty) {
+      throw CanvasKitError('Cannot create snapshot surfaces of empty size.');
+    }
+
+    _currentPhysicalSize = size;
+
+    if (htmlCanvas == null) {
+      _createNewCanvas();
+    } else {
+      htmlCanvas?.width = size.width.ceilToDouble();
+      htmlCanvas?.height = size.height.ceilToDouble();
+      _updateLogicalHtmlCanvasSize();
+    }
+  }
+
+  /// This function is expensive.
+  ///
+  /// It's better to reuse canvas if possible.
+  void _createNewCanvas() {
+    // Clear the container, if it's not empty. We're going to create a new <canvas>.
+    if (this.htmlCanvas != null) {
+      this.htmlCanvas!.remove();
+    }
+
+    // If `physicalSize` is not precise, use a slightly bigger canvas. This way
+    // we ensure that the rendred picture covers the entire browser window.
+    final DomCanvasElement htmlCanvas = createDomCanvasElement(
+      width: _currentPhysicalSize.width.ceil(),
+      height: _currentPhysicalSize.height.ceil(),
+    );
+
+    this.htmlCanvas = htmlCanvas;
+
+    // The DOM elements used to render pictures are used purely to put pixels on
+    // the screen. They have no semantic information. If an assistive technology
+    // attempts to scan picture content it will look like garbage and confuse
+    // users. UI semantics are exported as a separate DOM tree rendered parallel
+    // to pictures.
+    //
+    // Why are layer and scene elements not hidden from ARIA? Because those
+    // elements may contain platform views, and platform views must be
+    // accessible.
+    htmlCanvas.setAttribute('aria-hidden', 'true');
+
+    htmlCanvas.style.position = 'absolute';
+    _updateLogicalHtmlCanvasSize();
+
+    canvasContext = htmlCanvas.context2D;
+    canvasContext?.globalCompositeOperation = 'copy';
+
+    htmlElement.append(htmlCanvas);
+  }
+
+  /// Sets the CSS size of the canvas so that canvas pixels are 1:1 with device
+  /// pixels.
+  ///
+  /// The logical size of the canvas is not based on the size of the window
+  /// but on the size of the canvas, which, due to `ceil()` above, may not be
+  /// the same as the window. We do not round/floor/ceil the logical size as
+  /// CSS pixels can contain more than one physical pixel and therefore to
+  /// match the size of the window precisely we use the most precise floating
+  /// point value we can get.
+  void _updateLogicalHtmlCanvasSize() {
+    final ui.Size logicalSize = _currentPhysicalSize / window.devicePixelRatio;
+    final DomCSSStyleDeclaration style = htmlCanvas!.style;
+    style.width = '${logicalSize.width}px';
+    style.height = '${logicalSize.height}px';
+  }
+
+  void dispose() {
+    htmlElement.remove();
+  }
+}

--- a/lib/web_ui/lib/src/engine/canvaskit/snapshot_surface_factory.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/snapshot_surface_factory.dart
@@ -1,0 +1,154 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+import 'dart:math' as math show max;
+
+import 'package:meta/meta.dart';
+
+import '../../engine.dart';
+
+/// Caches snapshot surfaces used to overlay platform views.
+class SnapshotSurfaceFactory {
+  SnapshotSurfaceFactory(int maximumSurfaces)
+      : maximumSurfaces = math.max(maximumSurfaces, 1) {
+    if (assertionsEnabled) {
+      if (maximumSurfaces < 1) {
+        printWarning('Attempted to create a $SnapshotSurfaceFactory with '
+            '$maximumSurfaces maximum surfaces. At least 1 surface is required '
+            'for rendering.');
+      }
+      registerHotRestartListener(debugClear);
+    }
+  }
+
+  /// The lazy-initialized singleton surface factory.
+  ///
+  /// [debugClear] causes this singleton to be reinitialized.
+  static SnapshotSurfaceFactory get instance => _instance ??=
+      SnapshotSurfaceFactory(configuration.canvasKitMaximumSurfaces);
+
+  /// Returns the raw (potentially uninitialized) value of the singleton.
+  ///
+  /// Useful in tests for checking the lifecycle of this class.
+  static SnapshotSurfaceFactory? get debugUninitializedInstance => _instance;
+
+  // Override the current instance with a new one.
+  //
+  // This should only be used in tests.
+  static void debugSetInstance(SnapshotSurfaceFactory newInstance) {
+    _instance = newInstance;
+  }
+
+  static SnapshotSurfaceFactory? _instance;
+
+  /// The maximum number of surfaces which can be live at once.
+  final int maximumSurfaces;
+
+  /// The maximum number of assignable overlays.
+  ///
+  /// This is just `maximumSurfaces - 1` (the maximum number of surfaces minus
+  /// the required base surface).
+  int get maximumOverlays => maximumSurfaces - 1;
+
+  /// Surfaces created by this factory which are currently in use.
+  final List<SnapshotSurface> _liveSurfaces = <SnapshotSurface>[];
+
+  /// Surfaces created by this factory which are no longer in use. These can be
+  /// reused.
+  final List<SnapshotSurface> _cache = <SnapshotSurface>[];
+
+  /// The number of surfaces which have been created by this factory.
+  int get _surfaceCount => _liveSurfaces.length + _cache.length + 1;
+
+  /// The number of available overlay surfaces.
+  ///
+  /// This does not include the base surface.
+  int get numAvailableOverlays => maximumOverlays - _liveSurfaces.length;
+
+  /// The number of surfaces created by this factory. Used for testing.
+  @visibleForTesting
+  int get debugSurfaceCount => _surfaceCount;
+
+  /// Returns the number of cached surfaces.
+  ///
+  /// Useful in tests.
+  int get debugCacheSize => _cache.length;
+
+  /// Gets an overlay surface from the cache or creates a new one if it wouldn't
+  /// exceed the maximum. If there are no available surfaces, returns `null`.
+  SnapshotSurface? getSurface() {
+    if (_cache.isNotEmpty) {
+      final SnapshotSurface surface = _cache.removeLast();
+      _liveSurfaces.add(surface);
+      return surface;
+    } else if (debugSurfaceCount < maximumSurfaces) {
+      final SnapshotSurface surface = SnapshotSurface();
+      _liveSurfaces.add(surface);
+      return surface;
+    } else {
+      return null;
+    }
+  }
+
+  /// Releases all surfaces so they can be reused in the next frame.
+  ///
+  /// If a released surface is in the DOM, it is not removed. This allows the
+  /// engine to release the surfaces at the end of the frame so they are ready
+  /// to be used in the next frame, but still used for painting in the current
+  /// frame.
+  void releaseSurfaces() {
+    _cache.addAll(_liveSurfaces);
+    _liveSurfaces.clear();
+  }
+
+  /// Removes all snapshot surfaces from the DOM.
+  ///
+  /// This is called at the beginning of the frame to prepare for painting into
+  /// the new surfaces.
+  void removeSurfacesFromDom() {
+    _cache.forEach(_removeFromDom);
+  }
+
+  /// Removes [surface] from the DOM.
+  void _removeFromDom(SnapshotSurface surface) {
+    surface.htmlElement.remove();
+  }
+
+  /// Signals that a surface is no longer being used. It can be reused.
+  void releaseSurface(SnapshotSurface surface) {
+    assert(
+        _liveSurfaces.contains(surface),
+        'Attempting to release a Surface which '
+        'was not created by this factory');
+    surface.htmlElement.remove();
+    _liveSurfaces.remove(surface);
+    _cache.add(surface);
+  }
+
+  /// Returns [true] if [surface] is currently being used to paint content.
+  ///
+  /// The base surface always counts as live.
+  ///
+  /// If a surface is not live, then it must be in the cache and ready to be
+  /// reused.
+  bool isLive(SnapshotSurface surface) {
+    if (_liveSurfaces.contains(surface)) {
+      return true;
+    }
+    assert(_cache.contains(surface));
+    return false;
+  }
+
+  /// Dispose all snapshot surfaces created by this factory. Used in tests.
+  void debugClear() {
+    for (final SnapshotSurface surface in _cache) {
+      surface.dispose();
+    }
+    for (final SnapshotSurface surface in _liveSurfaces) {
+      surface.dispose();
+    }
+    _liveSurfaces.clear();
+    _cache.clear();
+    _instance = null;
+  }
+}

--- a/lib/web_ui/lib/src/engine/canvaskit/surface.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/surface.dart
@@ -442,12 +442,10 @@ class Surface {
   }
 
   void saveTo(SnapshotSurface target) {
-    final int surfaceHeight = _currentSurfaceSize!.height.ceil();
-
     target.canvasContext?.drawImage(
       htmlCanvas!,
       0,
-      -(surfaceHeight - target.physicalSize.height),
+      -(_pixelHeight - target.physicalSize.height),
     );
   }
 

--- a/lib/web_ui/lib/src/engine/canvaskit/surface_factory.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/surface_factory.dart
@@ -1,166 +1,17 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-import 'dart:math' as math show max;
-
-import 'package:meta/meta.dart';
-
 import '../../engine.dart';
 
-/// Caches surfaces used to overlay platform views.
+/// Provides surfaces for painting.
 class SurfaceFactory {
-  SurfaceFactory(int maximumSurfaces)
-      : maximumSurfaces = math.max(maximumSurfaces, 1) {
-    if (assertionsEnabled) {
-      if (maximumSurfaces < 1) {
-        printWarning('Attempted to create a $SurfaceFactory with '
-            '$maximumSurfaces maximum surfaces. At least 1 surface is required '
-            'for rendering.');
-      }
-      registerHotRestartListener(debugClear);
-    }
-  }
-
-  /// The lazy-initialized singleton surface factory.
-  ///
-  /// [debugClear] causes this singleton to be reinitialized.
-  static SurfaceFactory get instance =>
-      _instance ??= SurfaceFactory(configuration.canvasKitMaximumSurfaces);
-
-  /// Returns the raw (potentially uninitialized) value of the singleton.
-  ///
-  /// Useful in tests for checking the lifecycle of this class.
-  static SurfaceFactory? get debugUninitializedInstance => _instance;
-
-  // Override the current instance with a new one.
-  //
-  // This should only be used in tests.
-  static void debugSetInstance(SurfaceFactory newInstance) {
-    _instance = newInstance;
-  }
-
-  static SurfaceFactory? _instance;
+  static final SurfaceFactory instance = SurfaceFactory();
 
   /// The base surface to paint on. This is the default surface which will be
-  /// painted to. If there are no platform views, then this surface will receive
-  /// all painting commands.
+  /// painted to.
   final Surface baseSurface = Surface();
-
-  /// The maximum number of surfaces which can be live at once.
-  final int maximumSurfaces;
 
   /// A surface used specifically for `Picture.toImage` when software rendering
   /// is supported.
   late final Surface pictureToImageSurface = Surface();
-
-  /// The maximum number of assignable overlays.
-  ///
-  /// This is just `maximumSurfaces - 1` (the maximum number of surfaces minus
-  /// the required base surface).
-  int get maximumOverlays => maximumSurfaces - 1;
-
-  /// Surfaces created by this factory which are currently in use.
-  final List<Surface> _liveSurfaces = <Surface>[];
-
-  /// Surfaces created by this factory which are no longer in use. These can be
-  /// reused.
-  final List<Surface> _cache = <Surface>[];
-
-  /// The number of surfaces which have been created by this factory.
-  int get _surfaceCount => _liveSurfaces.length + _cache.length + 1;
-
-  /// The number of available overlay surfaces.
-  ///
-  /// This does not include the base surface.
-  int get numAvailableOverlays => maximumOverlays - _liveSurfaces.length;
-
-  /// The number of surfaces created by this factory. Used for testing.
-  @visibleForTesting
-  int get debugSurfaceCount => _surfaceCount;
-
-  /// Returns the number of cached surfaces.
-  ///
-  /// Useful in tests.
-  int get debugCacheSize => _cache.length;
-
-  /// Gets an overlay surface from the cache or creates a new one if it wouldn't
-  /// exceed the maximum. If there are no available surfaces, returns `null`.
-  Surface? getSurface() {
-    if (_cache.isNotEmpty) {
-      final Surface surface = _cache.removeLast();
-      _liveSurfaces.add(surface);
-      return surface;
-    } else if (debugSurfaceCount < maximumSurfaces) {
-      final Surface surface = Surface();
-      _liveSurfaces.add(surface);
-      return surface;
-    } else {
-      return null;
-    }
-  }
-
-  /// Releases all surfaces so they can be reused in the next frame.
-  ///
-  /// If a released surface is in the DOM, it is not removed. This allows the
-  /// engine to release the surfaces at the end of the frame so they are ready
-  /// to be used in the next frame, but still used for painting in the current
-  /// frame.
-  void releaseSurfaces() {
-    _cache.addAll(_liveSurfaces);
-    _liveSurfaces.clear();
-  }
-
-  /// Removes all surfaces except the base surface from the DOM.
-  ///
-  /// This is called at the beginning of the frame to prepare for painting into
-  /// the new surfaces.
-  void removeSurfacesFromDom() {
-    _cache.forEach(_removeFromDom);
-  }
-
-  // Removes [surface] from the DOM.
-  void _removeFromDom(Surface surface) {
-    surface.htmlElement.remove();
-  }
-
-  /// Signals that a surface is no longer being used. It can be reused.
-  void releaseSurface(Surface surface) {
-    assert(surface != baseSurface, 'Attempting to release the base surface');
-    assert(
-        _liveSurfaces.contains(surface),
-        'Attempting to release a Surface which '
-        'was not created by this factory');
-    surface.htmlElement.remove();
-    _liveSurfaces.remove(surface);
-    _cache.add(surface);
-  }
-
-  /// Returns [true] if [surface] is currently being used to paint content.
-  ///
-  /// The base surface always counts as live.
-  ///
-  /// If a surface is not live, then it must be in the cache and ready to be
-  /// reused.
-  bool isLive(Surface surface) {
-    if (surface == baseSurface ||
-        _liveSurfaces.contains(surface)) {
-      return true;
-    }
-    assert(_cache.contains(surface));
-    return false;
-  }
-
-  /// Dispose all surfaces created by this factory. Used in tests.
-  void debugClear() {
-    for (final Surface surface in _cache) {
-      surface.dispose();
-    }
-    for (final Surface surface in _liveSurfaces) {
-      surface.dispose();
-    }
-    baseSurface.dispose();
-    _liveSurfaces.clear();
-    _cache.clear();
-    _instance = null;
-  }
 }

--- a/lib/web_ui/lib/src/engine/dom.dart
+++ b/lib/web_ui/lib/src/engine/dom.dart
@@ -583,7 +583,7 @@ class DomPerformanceMeasure extends DomPerformanceEntry {}
 
 @JS()
 @staticInterop
-class DomCanvasElement extends DomHTMLElement {}
+class DomCanvasElement extends DomHTMLElement implements DomCanvasImageSource {}
 
 @visibleForTesting
 int debugCanvasCount = 0;


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/120156

This also makes images created from `toImageSync` available to overlay surfaces.