### PR TITLE
[Impeller] specialize decal lookup in advanced blend shader.

### DIFF
--- a/impeller/entity/contents/filters/blend_filter_contents.cc
+++ b/impeller/entity/contents/filters/blend_filter_contents.cc
@@ -106,10 +106,13 @@ static std::optional<Snapshot> AdvancedBlend(
     cmd.pipeline = std::move(pipeline);
 
     typename FS::BlendInfo blend_info;
+    typename VS::FrameInfo frame_info;
+
+    frame_info.src_y_coord_scale = src_snapshot->texture->GetYCoordScale();
+    frame_info.dst_y_coord_scale = dst_snapshot->texture->GetYCoordScale();
 
     auto sampler = renderer.GetContext()->GetSamplerLibrary()->GetSampler({});
     FS::BindTextureSamplerDst(cmd, dst_snapshot->texture, sampler);
-    blend_info.dst_y_coord_scale = dst_snapshot->texture->GetYCoordScale();
     blend_info.dst_input_alpha = absorb_opacity ? dst_snapshot->opacity : 1.0;
 
     if (foreground_color.has_value()) {
@@ -122,12 +125,10 @@ static std::optional<Snapshot> AdvancedBlend(
     } else {
       blend_info.color_factor = 0;
       FS::BindTextureSamplerSrc(cmd, src_snapshot->texture, sampler);
-      blend_info.src_y_coord_scale = src_snapshot->texture->GetYCoordScale();
     }
     auto blend_uniform = host_buffer.EmplaceUniform(blend_info);
     FS::BindBlendInfo(cmd, blend_uniform);
 
-    typename VS::FrameInfo frame_info;
     frame_info.mvp = Matrix::MakeOrthographic(size);
 
     auto uniform_view = host_buffer.EmplaceUniform(frame_info);

--- a/impeller/entity/shaders/blending/advanced_blend.glsl
+++ b/impeller/entity/shaders/blending/advanced_blend.glsl
@@ -9,8 +9,6 @@
 
 uniform BlendInfo {
   float dst_input_alpha;
-  float dst_y_coord_scale;
-  float src_y_coord_scale;
   float color_factor;
   vec4 color;  // This color input is expected to be unpremultiplied.
 }
@@ -25,22 +23,17 @@ in vec2 v_src_texture_coords;
 out vec4 frag_color;
 
 void main() {
-  vec4 dst_sample =
-      IPSampleWithTileMode(texture_sampler_dst,           // sampler
-                           v_dst_texture_coords,          // texture coordinates
-                           blend_info.dst_y_coord_scale,  // y coordinate scale
-                           kTileModeDecal                 // tile mode
-                           ) *
-      blend_info.dst_input_alpha;
+  vec4 dst_sample = IPSampleDecal(texture_sampler_dst,  // sampler
+                                  v_dst_texture_coords  // texture coordinates
+                                  ) *
+                    blend_info.dst_input_alpha;
 
   vec4 dst = IPUnpremultiply(dst_sample);
   vec4 src = blend_info.color_factor > 0
                  ? blend_info.color
-                 : IPUnpremultiply(IPSampleWithTileMode(
-                       texture_sampler_src,           // sampler
-                       v_src_texture_coords,          // texture coordinates
-                       blend_info.src_y_coord_scale,  // y coordinate scale
-                       kTileModeDecal                 // tile mode
+                 : IPUnpremultiply(IPSampleDecal(
+                       texture_sampler_src,  // sampler
+                       v_src_texture_coords  // texture coordinates
                        ));
 
   vec4 blended = vec4(Blend(dst.rgb, src.rgb), 1) * dst.a;

--- a/impeller/entity/shaders/blending/advanced_blend.vert
+++ b/impeller/entity/shaders/blending/advanced_blend.vert
@@ -2,10 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <impeller/texture.glsl>
 #include <impeller/types.glsl>
 
 uniform FrameInfo {
   mat4 mvp;
+  float dst_y_coord_scale;
+  float src_y_coord_scale;
 }
 frame_info;
 
@@ -18,6 +21,8 @@ out vec2 v_src_texture_coords;
 
 void main() {
   gl_Position = frame_info.mvp * vec4(vertices, 0.0, 1.0);
-  v_dst_texture_coords = dst_texture_coords;
-  v_src_texture_coords = src_texture_coords;
+  v_dst_texture_coords =
+      IPRemapCoords(dst_texture_coords, frame_info.dst_y_coord_scale);
+  v_src_texture_coords =
+      IPRemapCoords(src_texture_coords, frame_info.src_y_coord_scale);
 }


### PR DESCRIPTION
From my previous investigation of shader performance, I found that providing a constant to IPSampleWithTileMode was not sufficient to cause the other code paths to be compiled out. instead use a  specialized sample function
