### PR TITLE
increase first frame timeout

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
@@ -210,7 +210,7 @@ FLUTTER_ASSERT_ARC
                        [timeoutFirstFrame fulfill];
                      }
                    }];
-  [self waitForExpectationsWithTimeout:1 handler:nil];
+  [self waitForExpectationsWithTimeout:5 handler:nil];
 }
 
 - (void)testSpawn {


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/120239

Maybe we were just barely hitting the timeout before? Could be worth trying.