### PR TITLE
[web] Fixes invisible platform view compositing edge cases.

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
@@ -133,9 +133,8 @@ class HtmlViewEmbedder {
           'displayed at once. '
           'You may experience incorrect rendering.');
     }
-    // We need an overlay for the first platform view no matter what. The first
-    // visible platform view doesn't need to create a new one if we already
-    // created one.
+    // We need an overlay for each visible platform view. Invisible platform
+    // views will be grouped with (at most) one visible platform view later.
     final bool needNewOverlay = platformViewManager.isVisible(viewId);
     if (needNewOverlay && hasAvailableOverlay) {
       final CkPictureRecorder pictureRecorder = CkPictureRecorder();
@@ -164,10 +163,11 @@ class HtmlViewEmbedder {
   CkCanvas? compositeEmbeddedView(int viewId) {
     final int overlayIndex = _context.visibleViewCount;
     _compositionOrder.add(viewId);
+    // Keep track of the number of visible platform views.
     if (platformViewManager.isVisible(viewId)) {
       _context.visibleViewCount++;
     }
-    // We need a new overlay if this is a visible view or if we don't have one yet.
+    // We need a new overlay if this is a visible view.
     final bool needNewOverlay = platformViewManager.isVisible(viewId);
     CkPictureRecorder? recorderToUseForRendering;
     if (needNewOverlay) {
@@ -415,8 +415,8 @@ class HtmlViewEmbedder {
     _updateOverlays(diffResult);
     assert(
       _context.pictureRecorders.length == _overlays.length,
-      'There should be the same picture recorders (${_context.pictureRecorders.length}) '
-      'than overlays (${_overlays.length}).',
+      'There should be the same number of picture recorders '
+      '(${_context.pictureRecorders.length}) as overlays (${_overlays.length}).',
     );
     int pictureRecorderIndex = 0;
 
@@ -593,15 +593,13 @@ class HtmlViewEmbedder {
       // overlays.
       return;
     }
-    final List<List<int>> overlayGroups = getOverlayGroups(_compositionOrder);
-    final List<int> viewsNeedingOverlays = overlayGroups
-        .where(
-          (List<int> group) => group.any(
-            (int viewId) => platformViewManager.isVisible(viewId)
-          )
-        )
-        .map((List<int> group) => group.last)
-        .toList();
+    // Group platform views from their composition order.
+    // Each group contains one visible view, and any number of invisible views
+    // before or after that visible view.
+    final List<OverlayGroup> overlayGroups =
+        getOverlayGroups(_compositionOrder);
+    final List<int> viewsNeedingOverlays =
+        overlayGroups.map((OverlayGroup group) => group.last).toList();
     // If there were more visible views than overlays, then the last group
     // doesn't have an overlay.
     if (viewsNeedingOverlays.length > SurfaceFactory.instance.maximumOverlays) {
@@ -641,44 +639,48 @@ class HtmlViewEmbedder {
   // If there are more visible views than overlays, then the views which cannot
   // be assigned an overlay are grouped together and will be rendered on top of
   // the rest of the scene.
-  List<List<int>> getOverlayGroups(List<int> views) {
-    // Visibility groups are typically a visible view followed by zero or more
-    // invisible views. However, if the view list begins with one or more
-    // invisible views, we can group them with the first visible view.
+  List<OverlayGroup> getOverlayGroups(List<int> views) {
     final int maxOverlays = SurfaceFactory.instance.maximumOverlays;
     if (maxOverlays == 0) {
-      return const <List<int>>[];
+      return const <OverlayGroup>[];
     }
-    bool foundFirstVisibleView = false;
-    final List<List<int>> result = <List<int>>[];
-    List<int> currentGroup = <int>[];
-    int i = 0;
-    for (; i < views.length; i++) {
+    final List<OverlayGroup> result = <OverlayGroup>[];
+    OverlayGroup currentGroup = OverlayGroup(<int>[]);
+
+    for (int i = 0; i < views.length; i++) {
       final int view = views[i];
       if (platformViewManager.isInvisible(view)) {
+        // We add as many invisible views as we find to the current group.
         currentGroup.add(view);
       } else {
-        if (foundFirstVisibleView) {
-          result.add(currentGroup);
-          // If we are out of overlays, then break let the rest of the views be
-          // added to an extra group that will be rendered on top of the scene.
-          if (result.length == maxOverlays) {
-            currentGroup = <int>[];
-            break;
-          } else {
-            currentGroup = <int>[view];
-          }
+        // `view` is visible.
+        if (!currentGroup.hasVisibleView) {
+          // If `view` is the first visible one of the group, add it.
+          currentGroup.add(view, visible: true);
         } else {
-          // We hit this case if this is the first visible view.
-          foundFirstVisibleView = true;
-          currentGroup.add(view);
+          // There's already a visible `view` in `currentGroup`, so a new
+          // OverlayGroup will be needed.
+          // Let's decide what to do with the `currentGroup` first:
+          if (currentGroup.hasVisibleView) {
+            // We only care about groups that have one visible view.
+            result.add(currentGroup);
+          }
+          // If there are overlays still available.
+          if (result.length < maxOverlays) {
+            // Create a new group, starting with `view`.
+            currentGroup = OverlayGroup(<int>[view], visible: true);
+          } else {
+            // Add the rest of the views to a final group that will be rendered
+            // on top of the scene.
+            currentGroup = OverlayGroup(views.sublist(i), visible: true);
+            // And break out of the loop!
+            break;
+          }
         }
       }
     }
-    if (i < views.length) {
-      currentGroup.addAll(views.sublist(i));
-    }
-    if (currentGroup.isNotEmpty) {
+    // Handle the last group to be (maybe) returned.
+    if (currentGroup.hasVisibleView) {
       result.add(currentGroup);
     }
     return result;
@@ -724,6 +726,39 @@ class HtmlViewEmbedder {
     _activeCompositionOrder.clear();
     _compositionOrder.clear();
   }
+}
+
+/// A group of views that will be composited together within the same overlay.
+///
+/// Each OverlayGroup is a sublist of the composition order which can share the
+/// same overlay.
+///
+/// Every overlay group is a list containing a visible view preceded or followed
+/// by zero or more invisible views.
+class OverlayGroup {
+  /// Constructor
+  OverlayGroup(
+    List<int> viewGroup, {
+    bool visible = false,
+  })  : _group = viewGroup,
+        _containsVisibleView = visible;
+
+  // The internal list of ints.
+  final List<int> _group;
+  // A boolean flag to mark if any visible view has been added to the list.
+  bool _containsVisibleView;
+
+  /// Add a [view] (maybe [visible]) to this group.
+  void add(int view, {bool visible = false}) {
+    _group.add(view);
+    _containsVisibleView |= visible;
+  }
+
+  /// Get the "last" view added to this group.
+  int get last => _group.last;
+
+  /// Returns true if this group contains any visible view.
+  bool get hasVisibleView => _group.isNotEmpty && _containsVisibleView;
 }
 
 /// Represents a Clip Chain (for a view).

--- a/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
@@ -136,8 +136,7 @@ class HtmlViewEmbedder {
     // We need an overlay for the first platform view no matter what. The first
     // visible platform view doesn't need to create a new one if we already
     // created one.
-    final bool needNewOverlay = (platformViewManager.isVisible(viewId) &&
-            _context.seenFirstVisibleViewInPreroll) ||
+    final bool needNewOverlay = platformViewManager.isVisible(viewId) ||
         _context.pictureRecordersCreatedDuringPreroll.isEmpty;
     if (platformViewManager.isVisible(viewId)) {
       _context.seenFirstVisibleViewInPreroll = true;
@@ -174,8 +173,7 @@ class HtmlViewEmbedder {
       _context.visibleViewCount++;
     }
     // We need a new overlay if this is a visible view or if we don't have one yet.
-    final bool needNewOverlay = (platformViewManager.isVisible(viewId) &&
-            _context.seenFirstVisibleView) ||
+    final bool needNewOverlay = platformViewManager.isVisible(viewId) ||
         _context.pictureRecorders.isEmpty;
     if (platformViewManager.isVisible(viewId)) {
       _context.seenFirstVisibleView = true;
@@ -669,10 +667,24 @@ class HtmlViewEmbedder {
           } else {
             currentGroup = <int>[view];
           }
-        } else {
-          // We hit this case if this is the first visible view.
+        }
+        if (!foundFirstVisibleView) {
+          // First visible view found...
           foundFirstVisibleView = true;
-          currentGroup.add(view);
+          if (currentGroup.isNotEmpty) {
+            // If we've seen invisible views earlier, split them off...
+            result.add(currentGroup);
+            // If we are out of overlays, then break let the rest of the views be
+            // added to an extra group that will be rendered on top of the scene.
+            if (result.length == maxOverlays) {
+              currentGroup = <int>[];
+              break;
+            } else {
+              currentGroup = <int>[view];
+            }
+          } else {
+            currentGroup.add(view);
+          }
         }
       }
     }

--- a/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
@@ -594,8 +594,14 @@ class HtmlViewEmbedder {
       return;
     }
     final List<List<int>> overlayGroups = getOverlayGroups(_compositionOrder);
-    final List<int> viewsNeedingOverlays =
-        overlayGroups.map((List<int> group) => group.last).toList();
+    final List<int> viewsNeedingOverlays = overlayGroups
+        .where(
+          (List<int> group) => group.any(
+            (int viewId) => platformViewManager.isVisible(viewId)
+          )
+        )
+        .map((List<int> group) => group.last)
+        .toList();
     // If there were more visible views than overlays, then the last group
     // doesn't have an overlay.
     if (viewsNeedingOverlays.length > SurfaceFactory.instance.maximumOverlays) {


### PR DESCRIPTION
This PR fixes a couple of edge case with the canvaskit platform view embedder where if an app would have an "invisible" platform view as its first platform view in the scene, it would prevent "visible" views from being composited at the right spot of the DOM.

The issue is fixed by:

* Simplifying the logic to determine whether a canvaskit overlay is needed (it's now only triggered by visible platform views) in the preroll/composite stages.

The above introduces a new corner case, for apps that only contain invisible platform views, that is fixed by:

* Excluding platform view groups without any visible platform view from the "viewsNeedingOverlays" computation when updating the overlays in the submitFrame stage.

### Related issues

* Fixes https://github.com/flutter/flutter/issues/118452

### Testing

* Unit tests are updated with the new behavior where apps with only invisible views don't render a second overlay at all.
* Our example apps for Link Widget and Pointer Interceptor seem to work fine with the change.

This PR also modifies the test matcher used to test this feature to improve its assertions (expected and actual were reversed, actual values look now very similar to the expected ones, and error messages are easier to understand), and to make test cases easier to find by adding an optional `reason` field.

<details>
<summary>Click to expand sample test failure output before and after this PR</summary>

**Before**

```
00:04 +17 -1: HtmlViewEmbedder does not create overlays for invisible platform views [E]                          
  Expected: an object with length of <4>
    Actual: [
              _EmbeddedViewMarker:_EmbeddedViewMarker.overlay,
              _EmbeddedViewMarker:_EmbeddedViewMarker.platformView,
              _EmbeddedViewMarker:_EmbeddedViewMarker.platformView
            ]
     Which: has length of <3>
```

Note that the "Actual" above is the *expected* in the test. See below.

**After**

```
00:04 +17 -1: HtmlViewEmbedder does not create overlays for invisible platform views [E]                          
  Expected: [
              _EmbeddedViewMarker:_EmbeddedViewMarker.overlay,
              _EmbeddedViewMarker:_EmbeddedViewMarker.platformView,
              _EmbeddedViewMarker:_EmbeddedViewMarker.platformView
            ]
    Actual: [
              _EmbeddedViewMarker:_EmbeddedViewMarker.overlay,
              _EmbeddedViewMarker:_EmbeddedViewMarker.platformView,
              _EmbeddedViewMarker:_EmbeddedViewMarker.platformView,
              _EmbeddedViewMarker:_EmbeddedViewMarker.overlay
            ]
     Which: at location [3] is [
              _EmbeddedViewMarker:_EmbeddedViewMarker.overlay,
              _EmbeddedViewMarker:_EmbeddedViewMarker.platformView,
              _EmbeddedViewMarker:_EmbeddedViewMarker.platformView,
              _EmbeddedViewMarker:_EmbeddedViewMarker.overlay
            ] which longer than expected
  Overlay created after a group containing a visible view.
```

</summary>


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
