### PR TITLE
Enable UIA in Window

### DIFF
--- a/shell/platform/windows/BUILD.gn
+++ b/shell/platform/windows/BUILD.gn
@@ -229,7 +229,7 @@ executable("flutter_windows_unittests") {
       [ "//flutter/shell/platform/common:desktop_library_implementation" ]
 
   public_configs = [ "//flutter:config" ]
-  
+
   defines = [ "FLUTTER_ENGINE_USE_UIA" ]
 
   deps = [

--- a/shell/platform/windows/BUILD.gn
+++ b/shell/platform/windows/BUILD.gn
@@ -122,7 +122,10 @@ source_set("flutter_windows_source") {
 
   public_configs = [ ":relative_angle_headers" ]
 
-  defines = [ "FLUTTER_ENGINE_NO_PROTOTYPES" ]
+  defines = [
+    "FLUTTER_ENGINE_NO_PROTOTYPES",
+    "FLUTTER_ENGINE_USE_UIA",
+  ]
 
   public_deps = [
     "//flutter/fml:string_conversion",

--- a/shell/platform/windows/BUILD.gn
+++ b/shell/platform/windows/BUILD.gn
@@ -244,7 +244,7 @@ executable("flutter_windows_unittests") {
     "//third_party/rapidjson",
   ]
   
-  defines = [ "FLUTTER_ENGINE_USE_UIA "]
+  defines = [ "FLUTTER_ENGINE_USE_UIA" ]
 }
 
 shared_library("flutter_windows_glfw") {

--- a/shell/platform/windows/BUILD.gn
+++ b/shell/platform/windows/BUILD.gn
@@ -243,6 +243,8 @@ executable("flutter_windows_unittests") {
     "//flutter/third_party/tonic",
     "//third_party/rapidjson",
   ]
+  
+  defines = [ "FLUTTER_ENGINE_USE_UIA "]
 }
 
 shared_library("flutter_windows_glfw") {

--- a/shell/platform/windows/BUILD.gn
+++ b/shell/platform/windows/BUILD.gn
@@ -229,6 +229,8 @@ executable("flutter_windows_unittests") {
       [ "//flutter/shell/platform/common:desktop_library_implementation" ]
 
   public_configs = [ "//flutter:config" ]
+  
+  defines = [ "FLUTTER_ENGINE_USE_UIA" ]
 
   deps = [
     ":flutter_windows_fixtures",
@@ -243,8 +245,6 @@ executable("flutter_windows_unittests") {
     "//flutter/third_party/tonic",
     "//third_party/rapidjson",
   ]
-  
-  defines = [ "FLUTTER_ENGINE_USE_UIA" ]
 }
 
 shared_library("flutter_windows_glfw") {

--- a/shell/platform/windows/testing/mock_window.h
+++ b/shell/platform/windows/testing/mock_window.h
@@ -67,6 +67,8 @@ class MockWindow : public Window {
 
   MOCK_METHOD0(GetAxFragmentRootDelegate, ui::AXFragmentRootDelegateWin*());
 
+  MOCK_METHOD3(OnGetObject, LRESULT(UINT, WPARAM, LPARAM));
+
   void CallOnImeComposition(UINT const message,
                             WPARAM const wparam,
                             LPARAM const lparam);

--- a/shell/platform/windows/window.h
+++ b/shell/platform/windows/window.h
@@ -141,9 +141,9 @@ class Window : public KeyboardManager::WindowDelegate {
   //
   // The primary use of this function is to supply Windows with wrapped
   // semantics objects for use by Windows accessibility.
-  LRESULT OnGetObject(UINT const message,
-                      WPARAM const wparam,
-                      LPARAM const lparam);
+  virtual LRESULT OnGetObject(UINT const message,
+                              WPARAM const wparam,
+                              LPARAM const lparam);
 
   // Called when IME composing begins.
   virtual void OnComposeBegin() = 0;

--- a/shell/platform/windows/window_unittests.cc
+++ b/shell/platform/windows/window_unittests.cc
@@ -360,5 +360,22 @@ TEST(MockWindow, UnknownPointerTypeSkipsDirectManipulation) {
   window.InjectWindowMessage(DM_POINTERHITTEST, MAKEWPARAM(pointer_id, 0), 0);
 }
 
+// Test that the root UIA object is queried by WM_GETOBJECT.
+TEST(MockWindow, GetObjectUia) {
+  MockWindow window;
+  bool uia_called = false;
+  ON_CALL(window, OnGetObject).WillByDefault(Invoke([&uia_called](UINT msg, WPARAM wpar, LPARAM lpar){
+#ifdef FLUTTER_ENGINE_USE_UIA
+    uia_called = true;
+#endif  // FLUTTER_ENGINE_USE_UIA
+    return static_cast<LRESULT>(0);
+  }));
+  EXPECT_CALL(window, OnGetObject).Times(1);
+
+  window.InjectWindowMessage(WM_GETOBJECT, 0, UiaRootObjectId);
+
+  EXPECT_TRUE(uia_called);
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/shell/platform/windows/window_unittests.cc
+++ b/shell/platform/windows/window_unittests.cc
@@ -364,12 +364,13 @@ TEST(MockWindow, UnknownPointerTypeSkipsDirectManipulation) {
 TEST(MockWindow, GetObjectUia) {
   MockWindow window;
   bool uia_called = false;
-  ON_CALL(window, OnGetObject).WillByDefault(Invoke([&uia_called](UINT msg, WPARAM wpar, LPARAM lpar){
+  ON_CALL(window, OnGetObject)
+      .WillByDefault(Invoke([&uia_called](UINT msg, WPARAM wpar, LPARAM lpar) {
 #ifdef FLUTTER_ENGINE_USE_UIA
-    uia_called = true;
+        uia_called = true;
 #endif  // FLUTTER_ENGINE_USE_UIA
-    return static_cast<LRESULT>(0);
-  }));
+        return static_cast<LRESULT>(0);
+      }));
   EXPECT_CALL(window, OnGetObject).Times(1);
 
   window.InjectWindowMessage(WM_GETOBJECT, 0, UiaRootObjectId);


### PR DESCRIPTION
Enable returning a UIA object from Window's `OnGetObject`. Previously, the region of code that returns this object was gated by an unactivated `#ifdef`, which was the only thing stopping the WIP UIA implementation from being used.

https://github.com/flutter/flutter/issues/120365

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
