### PR TITLE
Revert "Remove deprecated TextInputClient scribble method code"

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -986,6 +986,10 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
 #pragma mark - FlutterViewEngineDelegate
 
 - (void)flutterTextInputView:(FlutterTextInputView*)textInputView showToolbar:(int)client {
+  // TODO(justinmc): Remove the TextInputClient usage when the framework has
+  // finished transitioning to using the Scribble channel.
+  // https://github.com/flutter/flutter/pull/104128
+  [_textInputChannel.get() invokeMethod:@"TextInputClient.showToolbar" arguments:@[ @(client) ]];
   [_scribbleChannel.get() invokeMethod:@"Scribble.showToolbar" arguments:@[ @(client) ]];
 }
 
@@ -993,6 +997,13 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
                   focusElement:(UIScribbleElementIdentifier)elementIdentifier
                        atPoint:(CGPoint)referencePoint
                         result:(FlutterResult)callback {
+  // TODO(justinmc): Remove the TextInputClient usage when the framework has
+  // finished transitioning to using the Scribble channel.
+  // https://github.com/flutter/flutter/pull/104128
+  [_textInputChannel.get()
+      invokeMethod:@"TextInputClient.focusElement"
+         arguments:@[ elementIdentifier, @(referencePoint.x), @(referencePoint.y) ]
+            result:callback];
   [_scribbleChannel.get()
       invokeMethod:@"Scribble.focusElement"
          arguments:@[ elementIdentifier, @(referencePoint.x), @(referencePoint.y) ]
@@ -1002,29 +1013,55 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
 - (void)flutterTextInputPlugin:(FlutterTextInputPlugin*)textInputPlugin
          requestElementsInRect:(CGRect)rect
                         result:(FlutterResult)callback {
+  // TODO(justinmc): Remove the TextInputClient usage when the framework has
+  // finished transitioning to using the Scribble channel.
+  // https://github.com/flutter/flutter/pull/104128
   [_scribbleChannel.get()
       invokeMethod:@"Scribble.requestElementsInRect"
+         arguments:@[ @(rect.origin.x), @(rect.origin.y), @(rect.size.width), @(rect.size.height) ]
+            result:callback];
+  [_textInputChannel.get()
+      invokeMethod:@"TextInputClient.requestElementsInRect"
          arguments:@[ @(rect.origin.x), @(rect.origin.y), @(rect.size.width), @(rect.size.height) ]
             result:callback];
 }
 
 - (void)flutterTextInputViewScribbleInteractionBegan:(FlutterTextInputView*)textInputView {
+  // TODO(justinmc): Remove the TextInputClient usage when the framework has
+  // finished transitioning to using the Scribble channel.
+  // https://github.com/flutter/flutter/pull/104128
+  [_textInputChannel.get() invokeMethod:@"TextInputClient.scribbleInteractionBegan" arguments:nil];
   [_scribbleChannel.get() invokeMethod:@"Scribble.scribbleInteractionBegan" arguments:nil];
 }
 
 - (void)flutterTextInputViewScribbleInteractionFinished:(FlutterTextInputView*)textInputView {
+  // TODO(justinmc): Remove the TextInputClient usage when the framework has
+  // finished transitioning to using the Scribble channel.
+  // https://github.com/flutter/flutter/pull/104128
+  [_textInputChannel.get() invokeMethod:@"TextInputClient.scribbleInteractionFinished"
+                              arguments:nil];
   [_scribbleChannel.get() invokeMethod:@"Scribble.scribbleInteractionFinished" arguments:nil];
 }
 
 - (void)flutterTextInputView:(FlutterTextInputView*)textInputView
     insertTextPlaceholderWithSize:(CGSize)size
                        withClient:(int)client {
+  // TODO(justinmc): Remove the TextInputClient usage when the framework has
+  // finished transitioning to using the Scribble channel.
+  // https://github.com/flutter/flutter/pull/104128
+  [_textInputChannel.get() invokeMethod:@"TextInputClient.insertTextPlaceholder"
+                              arguments:@[ @(client), @(size.width), @(size.height) ]];
   [_scribbleChannel.get() invokeMethod:@"Scribble.insertTextPlaceholder"
                              arguments:@[ @(client), @(size.width), @(size.height) ]];
 }
 
 - (void)flutterTextInputView:(FlutterTextInputView*)textInputView
        removeTextPlaceholder:(int)client {
+  // TODO(justinmc): Remove the TextInputClient usage when the framework has
+  // finished transitioning to using the Scribble channel.
+  // https://github.com/flutter/flutter/pull/104128
+  [_textInputChannel.get() invokeMethod:@"TextInputClient.removeTextPlaceholder"
+                              arguments:@[ @(client) ]];
   [_scribbleChannel.get() invokeMethod:@"Scribble.removeTextPlaceholder" arguments:@[ @(client) ]];
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -986,26 +986,21 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
 #pragma mark - FlutterViewEngineDelegate
 
 - (void)flutterTextInputView:(FlutterTextInputView*)textInputView showToolbar:(int)client {
-  // TODO(justinmc): Remove the TextInputClient usage when the framework has
-  // finished transitioning to using the Scribble channel.
-  // https://github.com/flutter/flutter/pull/104128
+  // TODO(justinmc): Switch from the TextInputClient to Scribble channel when
+  // the framework has finished transitioning to the Scribble channel.
+  // https://github.com/flutter/flutter/pull/115296
   [_textInputChannel.get() invokeMethod:@"TextInputClient.showToolbar" arguments:@[ @(client) ]];
-  [_scribbleChannel.get() invokeMethod:@"Scribble.showToolbar" arguments:@[ @(client) ]];
 }
 
 - (void)flutterTextInputPlugin:(FlutterTextInputPlugin*)textInputPlugin
                   focusElement:(UIScribbleElementIdentifier)elementIdentifier
                        atPoint:(CGPoint)referencePoint
                         result:(FlutterResult)callback {
-  // TODO(justinmc): Remove the TextInputClient usage when the framework has
-  // finished transitioning to using the Scribble channel.
-  // https://github.com/flutter/flutter/pull/104128
+  // TODO(justinmc): Switch from the TextInputClient to Scribble channel when
+  // the framework has finished transitioning to the Scribble channel.
+  // https://github.com/flutter/flutter/pull/115296
   [_textInputChannel.get()
       invokeMethod:@"TextInputClient.focusElement"
-         arguments:@[ elementIdentifier, @(referencePoint.x), @(referencePoint.y) ]
-            result:callback];
-  [_scribbleChannel.get()
-      invokeMethod:@"Scribble.focusElement"
          arguments:@[ elementIdentifier, @(referencePoint.x), @(referencePoint.y) ]
             result:callback];
 }
@@ -1013,13 +1008,9 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
 - (void)flutterTextInputPlugin:(FlutterTextInputPlugin*)textInputPlugin
          requestElementsInRect:(CGRect)rect
                         result:(FlutterResult)callback {
-  // TODO(justinmc): Remove the TextInputClient usage when the framework has
-  // finished transitioning to using the Scribble channel.
-  // https://github.com/flutter/flutter/pull/104128
-  [_scribbleChannel.get()
-      invokeMethod:@"Scribble.requestElementsInRect"
-         arguments:@[ @(rect.origin.x), @(rect.origin.y), @(rect.size.width), @(rect.size.height) ]
-            result:callback];
+  // TODO(justinmc): Switch from the TextInputClient to Scribble channel when
+  // the framework has finished transitioning to the Scribble channel.
+  // https://github.com/flutter/flutter/pull/115296
   [_textInputChannel.get()
       invokeMethod:@"TextInputClient.requestElementsInRect"
          arguments:@[ @(rect.origin.x), @(rect.origin.y), @(rect.size.width), @(rect.size.height) ]
@@ -1027,42 +1018,37 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
 }
 
 - (void)flutterTextInputViewScribbleInteractionBegan:(FlutterTextInputView*)textInputView {
-  // TODO(justinmc): Remove the TextInputClient usage when the framework has
-  // finished transitioning to using the Scribble channel.
-  // https://github.com/flutter/flutter/pull/104128
+  // TODO(justinmc): Switch from the TextInputClient to Scribble channel when
+  // the framework has finished transitioning to the Scribble channel.
+  // https://github.com/flutter/flutter/pull/115296
   [_textInputChannel.get() invokeMethod:@"TextInputClient.scribbleInteractionBegan" arguments:nil];
-  [_scribbleChannel.get() invokeMethod:@"Scribble.scribbleInteractionBegan" arguments:nil];
 }
 
 - (void)flutterTextInputViewScribbleInteractionFinished:(FlutterTextInputView*)textInputView {
-  // TODO(justinmc): Remove the TextInputClient usage when the framework has
-  // finished transitioning to using the Scribble channel.
-  // https://github.com/flutter/flutter/pull/104128
+  // TODO(justinmc): Switch from the TextInputClient to Scribble channel when
+  // the framework has finished transitioning to the Scribble channel.
+  // https://github.com/flutter/flutter/pull/115296
   [_textInputChannel.get() invokeMethod:@"TextInputClient.scribbleInteractionFinished"
                               arguments:nil];
-  [_scribbleChannel.get() invokeMethod:@"Scribble.scribbleInteractionFinished" arguments:nil];
 }
 
 - (void)flutterTextInputView:(FlutterTextInputView*)textInputView
     insertTextPlaceholderWithSize:(CGSize)size
                        withClient:(int)client {
-  // TODO(justinmc): Remove the TextInputClient usage when the framework has
-  // finished transitioning to using the Scribble channel.
-  // https://github.com/flutter/flutter/pull/104128
+  // TODO(justinmc): Switch from the TextInputClient to Scribble channel when
+  // the framework has finished transitioning to the Scribble channel.
+  // https://github.com/flutter/flutter/pull/115296
   [_textInputChannel.get() invokeMethod:@"TextInputClient.insertTextPlaceholder"
                               arguments:@[ @(client), @(size.width), @(size.height) ]];
-  [_scribbleChannel.get() invokeMethod:@"Scribble.insertTextPlaceholder"
-                             arguments:@[ @(client), @(size.width), @(size.height) ]];
 }
 
 - (void)flutterTextInputView:(FlutterTextInputView*)textInputView
        removeTextPlaceholder:(int)client {
-  // TODO(justinmc): Remove the TextInputClient usage when the framework has
-  // finished transitioning to using the Scribble channel.
-  // https://github.com/flutter/flutter/pull/104128
+  // TODO(justinmc): Switch from the TextInputClient to Scribble channel when
+  // the framework has finished transitioning to the Scribble channel.
+  // https://github.com/flutter/flutter/pull/115296
   [_textInputChannel.get() invokeMethod:@"TextInputClient.removeTextPlaceholder"
                               arguments:@[ @(client) ]];
-  [_scribbleChannel.get() invokeMethod:@"Scribble.removeTextPlaceholder" arguments:@[ @(client) ]];
 }
 
 - (void)flutterTextInputViewDidResignFirstResponder:(FlutterTextInputView*)textInputView {

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -50,6 +50,10 @@ static NSString* const kSetEditableSizeAndTransformMethod =
     @"TextInput.setEditableSizeAndTransform";
 static NSString* const kSetMarkedTextRectMethod = @"TextInput.setMarkedTextRect";
 static NSString* const kFinishAutofillContextMethod = @"TextInput.finishAutofillContext";
+// TODO(justinmc): Remove the TextInput method constant when the framework has
+// finished transitioning to using the Scribble channel.
+// https://github.com/flutter/flutter/pull/104128
+static NSString* const kDeprecatedSetSelectionRectsMethod = @"TextInput.setSelectionRects";
 static NSString* const kSetSelectionRectsMethod = @"Scribble.setSelectionRects";
 static NSString* const kStartLiveTextInputMethod = @"TextInput.startLiveTextInput";
 
@@ -2106,6 +2110,12 @@ static BOOL IsSelectionRectCloserToPoint(CGPoint point,
     result(nil);
   } else if ([method isEqualToString:kFinishAutofillContextMethod]) {
     [self triggerAutofillSave:[args boolValue]];
+    result(nil);
+    // TODO(justinmc): Remove the TextInput method constant when the framework has
+    // finished transitioning to using the Scribble channel.
+    // https://github.com/flutter/flutter/pull/104128
+  } else if ([method isEqualToString:kDeprecatedSetSelectionRectsMethod]) {
+    [self setSelectionRects:args];
     result(nil);
   } else if ([method isEqualToString:kSetSelectionRectsMethod]) {
     [self setSelectionRects:args];


### PR DESCRIPTION
The framework side of this was reverted long ago and still hasn't been relanded (https://github.com/flutter/flutter/pull/115296).  The result is that scribble does not currently work.  This PR will add back the original method channel calls so that it works in the meantime until the framework PR can be relanded.