### PR TITLE
Fix classes that shouldn't be extended/instantiated/mixedin

### DIFF
--- a/lib/ui/isolate_name_server.dart
+++ b/lib/ui/isolate_name_server.dart
@@ -20,9 +20,9 @@ part of dart.ui;
 /// recommended to establish a separate communication channel in that first
 /// message (e.g. by passing a dedicated [SendPort]).
 class IsolateNameServer {
-  // This class is only a namespace, and should not be instantiated or
-  // extended directly.
-  factory IsolateNameServer._() => throw UnsupportedError('Namespace');
+  // This class is not meant to be instantiated or extended; this constructor
+  // prevents instantiation and extension.
+  IsolateNameServer._();
 
   /// Looks up the [SendPort] associated with a given name.
   ///

--- a/lib/ui/natives.dart
+++ b/lib/ui/natives.dart
@@ -7,6 +7,10 @@ part of dart.ui;
 
 /// Helper functions for Dart Plugin Registrants.
 class DartPluginRegistrant {
+  // This class is not meant to be instantiated or extended; this constructor
+  // prevents instantiation and extension.
+  DartPluginRegistrant._();
+
   static bool _wasInitialized = false;
 
   /// Makes sure the that the Dart Plugin Registrant has been called for this

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -3501,8 +3501,7 @@ class _ColorFilter extends NativeFieldWrapperClass1 {
 ///  * [SceneBuilder.pushImageFilter], which is the low-level API for using
 ///    this class as a child layer filter.
 abstract class ImageFilter {
-  // This class is not meant to be instantiated or extended outside of dart:ui;
-  // this constructor prevents instantiation and extension.
+  // This class is not meant to be extended; this constructor prevents extension.
   ImageFilter._(); // ignore: unused_element
 
   /// Creates an image filter that applies a Gaussian blur.

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -3501,6 +3501,10 @@ class _ColorFilter extends NativeFieldWrapperClass1 {
 ///  * [SceneBuilder.pushImageFilter], which is the low-level API for using
 ///    this class as a child layer filter.
 abstract class ImageFilter {
+  // This class is not meant to be instantiated or extended outside of dart:ui;
+  // this constructor prevents instantiation and extension.
+  ImageFilter._();
+
   /// Creates an image filter that applies a Gaussian blur.
   factory ImageFilter.blur({ double sigmaX = 0.0, double sigmaY = 0.0, TileMode tileMode = TileMode.clamp }) {
     return _GaussianBlurImageFilter(sigmaX: sigmaX, sigmaY: sigmaY, tileMode: tileMode);

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -3503,7 +3503,7 @@ class _ColorFilter extends NativeFieldWrapperClass1 {
 abstract class ImageFilter {
   // This class is not meant to be instantiated or extended outside of dart:ui;
   // this constructor prevents instantiation and extension.
-  ImageFilter._();
+  ImageFilter._(); // ignore: unused_element
 
   /// Creates an image filter that applies a Gaussian blur.
   factory ImageFilter.blur({ double sigmaX = 0.0, double sigmaY = 0.0, TileMode tileMode = TileMode.clamp }) {

--- a/lib/ui/plugins.dart
+++ b/lib/ui/plugins.dart
@@ -40,9 +40,9 @@ class CallbackHandle {
 ///  * [IsolateNameServer], which provides utilities for dealing with
 ///    [Isolate]s.
 class PluginUtilities {
-  // This class is only a namespace, and should not be instantiated or
-  // extended directly.
-  factory PluginUtilities._() => throw UnsupportedError('Namespace');
+  // This class is not meant to be instantiated or extended; this constructor
+  // prevents instantiation and extension.
+  PluginUtilities._();
 
   static final Map<Function, CallbackHandle?> _forwardCache =
       <Function, CallbackHandle?>{};


### PR DESCRIPTION
This was discovered when investigating which classes could potentially be used as a mixin and may need a mixin class modifier in Dart 3. These classes came up as potential mixin candidates even though they really shouldn't be candidates.

Part of https://github.com/flutter/flutter/issues/118837.