### PR TITLE
Ignore invalid filters when constructing an image compose filter

### DIFF
--- a/lib/ui/painting/image_filter.cc
+++ b/lib/ui/painting/image_filter.cc
@@ -83,8 +83,14 @@ void ImageFilter::initColorFilter(ColorFilter* colorFilter) {
 
 void ImageFilter::initComposeFilter(ImageFilter* outer, ImageFilter* inner) {
   FML_DCHECK(outer && inner);
-  filter_ = std::make_shared<DlComposeImageFilter>(outer->dl_filter(),
-                                                   inner->dl_filter());
+  if (!outer->dl_filter()) {
+    filter_ = inner->filter();
+  } else if (!inner->dl_filter()) {
+    filter_ = outer->filter();
+  } else {
+    filter_ = std::make_shared<DlComposeImageFilter>(outer->dl_filter(),
+                                                     inner->dl_filter());
+  }
 }
 
 }  // namespace flutter

--- a/testing/dart/canvas_test.dart
+++ b/testing/dart/canvas_test.dart
@@ -113,6 +113,11 @@ void testNoCrashes() {
 
     // Regression test for https://github.com/flutter/flutter/issues/115143
     testCanvas((Canvas canvas) => canvas.drawPaint(Paint()..imageFilter = const ColorFilter.mode(Color(0x00000000), BlendMode.xor)));
+
+    // Regression test for https://github.com/flutter/flutter/issues/120278
+    testCanvas((Canvas canvas) => canvas.drawPaint(Paint()..imageFilter = ImageFilter.compose(
+      outer: ImageFilter.matrix(Matrix4.identity().storage),
+      inner: ImageFilter.blur())));
   });
 }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/120278
