### PR TITLE
[Impeller] Generate a Metal library symbols file for shader debugging.

### DIFF
--- a/impeller/renderer/backend/metal/context_mtl.mm
+++ b/impeller/renderer/backend/metal/context_mtl.mm
@@ -149,6 +149,9 @@ static NSArray<id<MTLLibrary>>* MTLShaderLibraryFromFileData(
                      << shader_library_error.localizedDescription.UTF8String;
       return nil;
     }
+    if (!label.empty()) {
+      library.label = @(label.c_str());
+    }
     [found_libraries addObject:library];
   }
   return found_libraries;

--- a/impeller/tools/build_metal_library.py
+++ b/impeller/tools/build_metal_library.py
@@ -81,6 +81,8 @@ def main():
       '-Oz',
       # Allow aggressive, lossy floating-point optimizations.
       '-ffast-math',
+      # Record symbols in a separate *.metallibsym file.
+      '-frecord-sources=flat',
       '-MF',
       args.depfile,
       '-o',
@@ -97,7 +99,7 @@ def main():
   elif args.platform == 'ios':
     command += [
         '--std=ios-metal1.2',
-        '-mios-version-min=10.0',
+        '-mios-version-min=11.0',
     ]
   elif args.platform == 'ios-simulator':
     command += [

--- a/impeller/tools/impeller.gni
+++ b/impeller/tools/impeller.gni
@@ -130,8 +130,13 @@ template("metal_library") {
     inputs = invoker.sources
 
     metal_library_path = "$root_out_dir/shaders/$metal_library_name.metallib"
+    metal_library_symbols_path =
+        "$root_out_dir/shaders/$metal_library_name.metallibsym"
 
-    outputs = [ metal_library_path ]
+    outputs = [
+      metal_library_path,
+      metal_library_symbols_path,
+    ]
 
     script = "//flutter/impeller/tools/build_metal_library.py"
 


### PR DESCRIPTION
Towards fixing https://github.com/flutter/flutter/issues/120326. This allows you to specify the sources for the Impeller Metal Library. The user is meant to navigate to `out/<engine_variant>/shaders/entity.metallibsym` when Xcode prompts for sources (you only
need to do this once).

Shader debugging with line by line profiling is still not a turnkey operation though. This works fine on macOS. But on iOS, I had to bump up the min iOS version level to iOS 12 for the sources to show up and specify `-g` to the `metal` compiler for line by line profiling. The performance of the shaders was identical after the changes though so I suspect engine developers will patch in these flags locally to develop and debug shaders. Or develop on macOS.

<img width="1007" alt="Screenshot 2023-02-09 at 9 32 19 PM" src="https://user-images.githubusercontent.com/44085/218009183-adac6e42-5f9a-4588-82a1-2114b0358927.png">
