### PR TITLE
[macOS] Add XCode marks for TextInputPlugin

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -20,7 +20,7 @@
 
 static NSString* const kTextInputChannel = @"flutter/textinput";
 
-#pragma mark - Textinput channel method names
+#pragma mark - TextInput channel method names
 // See https://api.flutter.dev/flutter/services/SystemChannels/textInput-constant.html
 static NSString* const kSetClientMethod = @"TextInput.setClient";
 static NSString* const kShowMethod = @"TextInput.show";
@@ -62,6 +62,7 @@ static NSString* const kAutofillHints = @"hints";
 static NSString* const kTextAffinityDownstream = @"TextAffinity.downstream";
 static NSString* const kTextAffinityUpstream = @"TextAffinity.upstream";
 
+#pragma mark - Enums
 /**
  * The affinity of the current cursor position. If the cursor is at a position representing
  * a line break, the cursor may be drawn either at the end of the current line (upstream)
@@ -71,6 +72,8 @@ typedef NS_ENUM(NSUInteger, FlutterTextAffinity) {
   kFlutterTextAffinityUpstream,
   kFlutterTextAffinityDownstream
 };
+
+#pragma mark - Static functions
 
 /*
  * Updates a range given base and extent fields.
@@ -135,6 +138,8 @@ static BOOL EnableAutocomplete(NSDictionary* configuration) {
   return EnableAutocompleteForTextInputConfiguration(configuration);
 }
 
+#pragma mark - NSEvent (KeyEquivalentMarker) protocol
+
 @interface NSEvent (KeyEquivalentMarker)
 
 // Internally marks that the event was received through performKeyEquivalent:.
@@ -163,6 +168,8 @@ static char markerKey;
 }
 
 @end
+
+#pragma mark - FlutterTextInputPlugin private interface
 
 /**
  * Private properties of FlutterTextInputPlugin.
@@ -284,6 +291,8 @@ static char markerKey;
 @property(readwrite, nonatomic) NSString* customRunLoopMode;
 
 @end
+
+#pragma mark - FlutterTextInputPlugin
 
 @implementation FlutterTextInputPlugin {
   /**


### PR DESCRIPTION
Adds marks to cleanly separate the sections of TextInputPlugin when viewing in XCode and other IDEs that recognise #pragma mark. This file is getting pretty long.

No tests since this is a cleanup with no functional changes.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
