### PR TITLE
[Impeller] Source the pipeline color attachment pixel format from RenderPass textures

### DIFF
--- a/impeller/entity/contents/content_context.cc
+++ b/impeller/entity/contents/content_context.cc
@@ -28,6 +28,7 @@ void ContentContextOptions::ApplyToPipelineDescriptor(
   desc.SetSampleCount(sample_count);
 
   ColorAttachmentDescriptor color0 = *desc.GetColorAttachmentDescriptor(0u);
+  color0.format = color_attachment_pixel_format;
   color0.alpha_blend_op = BlendOperation::kAdd;
   color0.color_blend_op = BlendOperation::kAdd;
 

--- a/impeller/entity/contents/content_context.h
+++ b/impeller/entity/contents/content_context.h
@@ -195,12 +195,14 @@ struct ContentContextOptions {
   CompareFunction stencil_compare = CompareFunction::kEqual;
   StencilOperation stencil_operation = StencilOperation::kKeep;
   PrimitiveType primitive_type = PrimitiveType::kTriangle;
+  PixelFormat color_attachment_pixel_format = PixelFormat::kDefaultColor;
   bool has_stencil_attachment = true;
 
   struct Hash {
     constexpr std::size_t operator()(const ContentContextOptions& o) const {
       return fml::HashCombine(o.sample_count, o.blend_mode, o.stencil_compare,
                               o.stencil_operation, o.primitive_type,
+                              o.color_attachment_pixel_format,
                               o.has_stencil_attachment);
     }
   };
@@ -213,6 +215,8 @@ struct ContentContextOptions {
              lhs.stencil_compare == rhs.stencil_compare &&
              lhs.stencil_operation == rhs.stencil_operation &&
              lhs.primitive_type == rhs.primitive_type &&
+             lhs.color_attachment_pixel_format ==
+                 rhs.color_attachment_pixel_format &&
              lhs.has_stencil_attachment == rhs.has_stencil_attachment;
     }
   };

--- a/impeller/entity/contents/contents.cc
+++ b/impeller/entity/contents/contents.cc
@@ -16,6 +16,8 @@ namespace impeller {
 ContentContextOptions OptionsFromPass(const RenderPass& pass) {
   ContentContextOptions opts;
   opts.sample_count = pass.GetRenderTarget().GetSampleCount();
+  opts.color_attachment_pixel_format =
+      pass.GetRenderTarget().GetRenderTargetPixelFormat();
   opts.has_stencil_attachment =
       pass.GetRenderTarget().GetStencilAttachment().has_value();
   return opts;
@@ -25,6 +27,8 @@ ContentContextOptions OptionsFromPassAndEntity(const RenderPass& pass,
                                                const Entity& entity) {
   ContentContextOptions opts;
   opts.sample_count = pass.GetRenderTarget().GetSampleCount();
+  opts.color_attachment_pixel_format =
+      pass.GetRenderTarget().GetRenderTargetPixelFormat();
   opts.has_stencil_attachment =
       pass.GetRenderTarget().GetStencilAttachment().has_value();
   opts.blend_mode = entity.GetBlendMode();

--- a/impeller/renderer/render_target.cc
+++ b/impeller/renderer/render_target.cc
@@ -140,6 +140,14 @@ std::shared_ptr<Texture> RenderTarget::GetRenderTargetTexture() const {
                                        : found->second.texture;
 }
 
+PixelFormat RenderTarget::GetRenderTargetPixelFormat() const {
+  if (auto texture = GetRenderTargetTexture(); texture != nullptr) {
+    return texture->GetTextureDescriptor().format;
+  }
+
+  return PixelFormat::kUnknown;
+}
+
 RenderTarget& RenderTarget::SetColorAttachment(
     const ColorAttachment& attachment,
     size_t index) {

--- a/impeller/renderer/render_target.h
+++ b/impeller/renderer/render_target.h
@@ -72,6 +72,8 @@ class RenderTarget {
 
   std::shared_ptr<Texture> GetRenderTargetTexture() const;
 
+  PixelFormat GetRenderTargetPixelFormat() const;
+
   std::optional<ISize> GetColorAttachmentSize(size_t index) const;
 
   RenderTarget& SetColorAttachment(const ColorAttachment& attachment,


### PR DESCRIPTION
These values always match in practice today, but with the advent of wide gamut support, pipelines with different color attachment formats will need to be built. If you drag a Flutter app from a standard monitor to a wide gamut monitor, the pass textures may change formats to better support the color space.

Either way, any mismatch between a pass attachment and the pipeline layout is a bug 100% of the time, and this change just makes it so the color attachment format will always match the render pass.