### PR TITLE
[Impeller] Return entities from filters instead of snapshots

### DIFF
--- a/impeller/entity/contents/contents.cc
+++ b/impeller/entity/contents/contents.cc
@@ -7,6 +7,7 @@
 
 #include "fml/logging.h"
 #include "impeller/entity/contents/content_context.h"
+#include "impeller/entity/contents/texture_contents.h"
 #include "impeller/renderer/command_buffer.h"
 #include "impeller/renderer/formats.h"
 #include "impeller/renderer/render_pass.h"
@@ -29,6 +30,30 @@ ContentContextOptions OptionsFromPassAndEntity(const RenderPass& pass,
       pass.GetRenderTarget().GetStencilAttachment().has_value();
   opts.blend_mode = entity.GetBlendMode();
   return opts;
+}
+
+std::optional<Entity> Contents::EntityFromSnapshot(
+    const std::optional<Snapshot>& snapshot,
+    BlendMode blend_mode,
+    uint32_t stencil_depth) {
+  if (!snapshot.has_value()) {
+    return std::nullopt;
+  }
+
+  auto texture_rect = Rect::MakeSize(snapshot->texture->GetSize());
+
+  auto contents = TextureContents::MakeRect(texture_rect);
+  contents->SetTexture(snapshot->texture);
+  contents->SetSamplerDescriptor(snapshot->sampler_descriptor);
+  contents->SetSourceRect(texture_rect);
+  contents->SetOpacity(snapshot->opacity);
+
+  Entity entity;
+  entity.SetBlendMode(blend_mode);
+  entity.SetStencilDepth(stencil_depth);
+  entity.SetTransformation(snapshot->transform);
+  entity.SetContents(contents);
+  return entity;
 }
 
 Contents::Contents() = default;

--- a/impeller/entity/contents/contents.h
+++ b/impeller/entity/contents/contents.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "flutter/fml/macros.h"
+#include "impeller/geometry/color.h"
 #include "impeller/geometry/rect.h"
 #include "impeller/renderer/sampler_descriptor.h"
 #include "impeller/renderer/snapshot.h"
@@ -39,6 +40,12 @@ class Contents {
     Type type = Type::kNone;
     std::optional<Rect> coverage = std::nullopt;
   };
+
+  /// @brief  Create an entity that renders a given snapshot.
+  static std::optional<Entity> EntityFromSnapshot(
+      const std::optional<Snapshot>& snapshot,
+      BlendMode blend_mode = BlendMode::kSourceOver,
+      uint32_t stencil_depth = 0);
 
   virtual bool Render(const ContentContext& renderer,
                       const Entity& entity,

--- a/impeller/entity/contents/filters/blend_filter_contents.h
+++ b/impeller/entity/contents/filters/blend_filter_contents.h
@@ -11,14 +11,14 @@ namespace impeller {
 
 class BlendFilterContents : public ColorFilterContents {
  public:
-  using AdvancedBlendProc = std::function<std::optional<Snapshot>(
-      const FilterInput::Vector& inputs,
-      const ContentContext& renderer,
-      const Entity& entity,
-      const Rect& coverage,
-      std::optional<Color> foreground_color,
-      bool absorb_opacity,
-      std::optional<Scalar> alpha)>;
+  using AdvancedBlendProc =
+      std::function<std::optional<Entity>(const FilterInput::Vector& inputs,
+                                          const ContentContext& renderer,
+                                          const Entity& entity,
+                                          const Rect& coverage,
+                                          std::optional<Color> foreground_color,
+                                          bool absorb_opacity,
+                                          std::optional<Scalar> alpha)>;
 
   BlendFilterContents();
 
@@ -32,11 +32,11 @@ class BlendFilterContents : public ColorFilterContents {
 
  private:
   // |FilterContents|
-  std::optional<Snapshot> RenderFilter(const FilterInput::Vector& inputs,
-                                       const ContentContext& renderer,
-                                       const Entity& entity,
-                                       const Matrix& effect_transform,
-                                       const Rect& coverage) const override;
+  std::optional<Entity> RenderFilter(const FilterInput::Vector& inputs,
+                                     const ContentContext& renderer,
+                                     const Entity& entity,
+                                     const Matrix& effect_transform,
+                                     const Rect& coverage) const override;
 
   BlendMode blend_mode_ = BlendMode::kSourceOver;
   AdvancedBlendProc advanced_blend_proc_;

--- a/impeller/entity/contents/filters/border_mask_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/border_mask_blur_filter_contents.cc
@@ -47,7 +47,7 @@ void BorderMaskBlurFilterContents::SetBlurStyle(BlurStyle blur_style) {
   }
 }
 
-std::optional<Snapshot> BorderMaskBlurFilterContents::RenderFilter(
+std::optional<Entity> BorderMaskBlurFilterContents::RenderFilter(
     const FilterInput::Vector& inputs,
     const ContentContext& renderer,
     const Entity& entity,
@@ -126,9 +126,11 @@ std::optional<Snapshot> BorderMaskBlurFilterContents::RenderFilter(
   }
   out_texture->SetLabel("BorderMaskBlurFilter Texture");
 
-  return Snapshot{.texture = out_texture,
-                  .transform = Matrix::MakeTranslation(coverage.origin),
-                  .opacity = input_snapshot->opacity};
+  return Contents::EntityFromSnapshot(
+      Snapshot{.texture = out_texture,
+               .transform = Matrix::MakeTranslation(coverage.origin),
+               .opacity = input_snapshot->opacity},
+      entity.GetBlendMode(), entity.GetStencilDepth());
 }
 
 std::optional<Rect> BorderMaskBlurFilterContents::GetFilterCoverage(

--- a/impeller/entity/contents/filters/border_mask_blur_filter_contents.h
+++ b/impeller/entity/contents/filters/border_mask_blur_filter_contents.h
@@ -29,12 +29,11 @@ class BorderMaskBlurFilterContents final : public FilterContents {
 
  private:
   // |FilterContents|
-  std::optional<Snapshot> RenderFilter(
-      const FilterInput::Vector& input_textures,
-      const ContentContext& renderer,
-      const Entity& entity,
-      const Matrix& effect_transform,
-      const Rect& coverage) const override;
+  std::optional<Entity> RenderFilter(const FilterInput::Vector& input_textures,
+                                     const ContentContext& renderer,
+                                     const Entity& entity,
+                                     const Matrix& effect_transform,
+                                     const Rect& coverage) const override;
 
   Sigma sigma_x_;
   Sigma sigma_y_;

--- a/impeller/entity/contents/filters/color_matrix_filter_contents.cc
+++ b/impeller/entity/contents/filters/color_matrix_filter_contents.cc
@@ -23,7 +23,7 @@ void ColorMatrixFilterContents::SetMatrix(const ColorMatrix& matrix) {
   matrix_ = matrix;
 }
 
-std::optional<Snapshot> ColorMatrixFilterContents::RenderFilter(
+std::optional<Entity> ColorMatrixFilterContents::RenderFilter(
     const FilterInput::Vector& inputs,
     const ContentContext& renderer,
     const Entity& entity,
@@ -104,11 +104,12 @@ std::optional<Snapshot> ColorMatrixFilterContents::RenderFilter(
   }
   out_texture->SetLabel("ColorMatrixFilter Texture");
 
-  return Snapshot{
-      .texture = out_texture,
-      .transform = input_snapshot->transform,
-      .sampler_descriptor = input_snapshot->sampler_descriptor,
-      .opacity = GetAbsorbOpacity() ? 1.0f : input_snapshot->opacity};
+  return Contents::EntityFromSnapshot(
+      Snapshot{.texture = out_texture,
+               .transform = input_snapshot->transform,
+               .sampler_descriptor = input_snapshot->sampler_descriptor,
+               .opacity = GetAbsorbOpacity() ? 1.0f : input_snapshot->opacity},
+      entity.GetBlendMode(), entity.GetStencilDepth());
 }
 
 }  // namespace impeller

--- a/impeller/entity/contents/filters/color_matrix_filter_contents.h
+++ b/impeller/entity/contents/filters/color_matrix_filter_contents.h
@@ -24,12 +24,11 @@ class ColorMatrixFilterContents final : public ColorFilterContents {
 
  private:
   // |FilterContents|
-  std::optional<Snapshot> RenderFilter(
-      const FilterInput::Vector& input_textures,
-      const ContentContext& renderer,
-      const Entity& entity,
-      const Matrix& effect_transform,
-      const Rect& coverage) const override;
+  std::optional<Entity> RenderFilter(const FilterInput::Vector& input_textures,
+                                     const ContentContext& renderer,
+                                     const Entity& entity,
+                                     const Matrix& effect_transform,
+                                     const Rect& coverage) const override;
 
   ColorMatrix matrix_;
 

--- a/impeller/entity/contents/filters/filter_contents.h
+++ b/impeller/entity/contents/filters/filter_contents.h
@@ -107,6 +107,10 @@ class FilterContents : public Contents {
   ///         filter. Note that this is in addition to the entity's transform.
   void SetEffectTransform(Matrix effect_transform);
 
+  /// @brief  Create an Entity that renders this filter's output.
+  std::optional<Entity> GetEntity(const ContentContext& renderer,
+                                  const Entity& entity) const;
+
   // |Contents|
   bool Render(const ContentContext& renderer,
               const Entity& entity,
@@ -132,13 +136,12 @@ class FilterContents : public Contents {
       const Entity& entity,
       const Matrix& effect_transform) const;
 
-  /// @brief  Converts zero or more filter inputs into a new texture.
-  virtual std::optional<Snapshot> RenderFilter(
-      const FilterInput::Vector& inputs,
-      const ContentContext& renderer,
-      const Entity& entity,
-      const Matrix& effect_transform,
-      const Rect& coverage) const = 0;
+  /// @brief  Converts zero or more filter inputs into a render instruction.
+  virtual std::optional<Entity> RenderFilter(const FilterInput::Vector& inputs,
+                                             const ContentContext& renderer,
+                                             const Entity& entity,
+                                             const Matrix& effect_transform,
+                                             const Rect& coverage) const = 0;
 
   std::optional<Rect> GetLocalCoverage(const Entity& local_entity) const;
 

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -81,7 +81,7 @@ void DirectionalGaussianBlurFilterContents::SetSourceOverride(
   source_override_ = std::move(source_override);
 }
 
-std::optional<Snapshot> DirectionalGaussianBlurFilterContents::RenderFilter(
+std::optional<Entity> DirectionalGaussianBlurFilterContents::RenderFilter(
     const FilterInput::Vector& inputs,
     const ContentContext& renderer,
     const Entity& entity,
@@ -106,7 +106,9 @@ std::optional<Snapshot> DirectionalGaussianBlurFilterContents::RenderFilter(
   }
 
   if (blur_sigma_.sigma < kEhCloseEnough) {
-    return input_snapshot.value();  // No blur to render.
+    return Contents::EntityFromSnapshot(
+        input_snapshot.value(), entity.GetBlendMode(),
+        entity.GetStencilDepth());  // No blur to render.
   }
 
   auto radius = Radius{blur_sigma_}.radius;
@@ -120,7 +122,9 @@ std::optional<Snapshot> DirectionalGaussianBlurFilterContents::RenderFilter(
   // If the radius length is < .5, the shader will take at most 1 sample,
   // resulting in no blur.
   if (transformed_blur_radius_length < .5) {
-    return input_snapshot.value();  // No blur to render.
+    return Contents::EntityFromSnapshot(
+        input_snapshot.value(), entity.GetBlendMode(),
+        entity.GetStencilDepth());  // No blur to render.
   }
 
   // A matrix that rotates the snapshot space such that the blur direction is
@@ -283,14 +287,15 @@ std::optional<Snapshot> DirectionalGaussianBlurFilterContents::RenderFilter(
   sampler_desc.min_filter = MinMagFilter::kLinear;
   sampler_desc.mag_filter = MinMagFilter::kLinear;
 
-  return Snapshot{
-      .texture = out_texture,
-      .transform =
-          texture_rotate.Invert() *
-          Matrix::MakeTranslation(pass_texture_rect.origin) *
-          Matrix::MakeScale((1 / scale) * (scaled_size / floored_size)),
-      .sampler_descriptor = sampler_desc,
-      .opacity = input_snapshot->opacity};
+  return Contents::EntityFromSnapshot(
+      Snapshot{.texture = out_texture,
+               .transform = texture_rotate.Invert() *
+                            Matrix::MakeTranslation(pass_texture_rect.origin) *
+                            Matrix::MakeScale((1 / scale) *
+                                              (scaled_size / floored_size)),
+               .sampler_descriptor = sampler_desc,
+               .opacity = input_snapshot->opacity},
+      entity.GetBlendMode(), entity.GetStencilDepth());
 }
 
 std::optional<Rect> DirectionalGaussianBlurFilterContents::GetFilterCoverage(

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.h
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.h
@@ -37,12 +37,11 @@ class DirectionalGaussianBlurFilterContents final : public FilterContents {
 
  private:
   // |FilterContents|
-  std::optional<Snapshot> RenderFilter(
-      const FilterInput::Vector& input_textures,
-      const ContentContext& renderer,
-      const Entity& entity,
-      const Matrix& effect_transform,
-      const Rect& coverage) const override;
+  std::optional<Entity> RenderFilter(const FilterInput::Vector& input_textures,
+                                     const ContentContext& renderer,
+                                     const Entity& entity,
+                                     const Matrix& effect_transform,
+                                     const Rect& coverage) const override;
   Sigma blur_sigma_;
   Sigma secondary_blur_sigma_;
   Vector2 blur_direction_;

--- a/impeller/entity/contents/filters/linear_to_srgb_filter_contents.cc
+++ b/impeller/entity/contents/filters/linear_to_srgb_filter_contents.cc
@@ -17,7 +17,7 @@ LinearToSrgbFilterContents::LinearToSrgbFilterContents() = default;
 
 LinearToSrgbFilterContents::~LinearToSrgbFilterContents() = default;
 
-std::optional<Snapshot> LinearToSrgbFilterContents::RenderFilter(
+std::optional<Entity> LinearToSrgbFilterContents::RenderFilter(
     const FilterInput::Vector& inputs,
     const ContentContext& renderer,
     const Entity& entity,
@@ -81,11 +81,12 @@ std::optional<Snapshot> LinearToSrgbFilterContents::RenderFilter(
   }
   out_texture->SetLabel("LinearToSrgb Texture");
 
-  return Snapshot{
-      .texture = out_texture,
-      .transform = input_snapshot->transform,
-      .sampler_descriptor = input_snapshot->sampler_descriptor,
-      .opacity = GetAbsorbOpacity() ? 1.0f : input_snapshot->opacity};
+  return Contents::EntityFromSnapshot(
+      Snapshot{.texture = out_texture,
+               .transform = input_snapshot->transform,
+               .sampler_descriptor = input_snapshot->sampler_descriptor,
+               .opacity = GetAbsorbOpacity() ? 1.0f : input_snapshot->opacity},
+      entity.GetBlendMode(), entity.GetStencilDepth());
 }
 
 }  // namespace impeller

--- a/impeller/entity/contents/filters/linear_to_srgb_filter_contents.h
+++ b/impeller/entity/contents/filters/linear_to_srgb_filter_contents.h
@@ -17,12 +17,11 @@ class LinearToSrgbFilterContents final : public ColorFilterContents {
 
  private:
   // |FilterContents|
-  std::optional<Snapshot> RenderFilter(
-      const FilterInput::Vector& input_textures,
-      const ContentContext& renderer,
-      const Entity& entity,
-      const Matrix& effect_transform,
-      const Rect& coverage) const override;
+  std::optional<Entity> RenderFilter(const FilterInput::Vector& input_textures,
+                                     const ContentContext& renderer,
+                                     const Entity& entity,
+                                     const Matrix& effect_transform,
+                                     const Rect& coverage) const override;
 
   FML_DISALLOW_COPY_AND_ASSIGN(LinearToSrgbFilterContents);
 };

--- a/impeller/entity/contents/filters/local_matrix_filter_contents.cc
+++ b/impeller/entity/contents/filters/local_matrix_filter_contents.cc
@@ -19,13 +19,15 @@ Matrix LocalMatrixFilterContents::GetLocalTransform(
   return matrix_;
 }
 
-std::optional<Snapshot> LocalMatrixFilterContents::RenderFilter(
+std::optional<Entity> LocalMatrixFilterContents::RenderFilter(
     const FilterInput::Vector& inputs,
     const ContentContext& renderer,
     const Entity& entity,
     const Matrix& effect_transform,
     const Rect& coverage) const {
-  return inputs[0]->GetSnapshot(renderer, entity);
+  return Contents::EntityFromSnapshot(inputs[0]->GetSnapshot(renderer, entity),
+                                      entity.GetBlendMode(),
+                                      entity.GetStencilDepth());
 }
 
 }  // namespace impeller

--- a/impeller/entity/contents/filters/local_matrix_filter_contents.h
+++ b/impeller/entity/contents/filters/local_matrix_filter_contents.h
@@ -22,12 +22,11 @@ class LocalMatrixFilterContents final : public FilterContents {
 
  private:
   // |FilterContents|
-  std::optional<Snapshot> RenderFilter(
-      const FilterInput::Vector& input_textures,
-      const ContentContext& renderer,
-      const Entity& entity,
-      const Matrix& effect_transform,
-      const Rect& coverage) const override;
+  std::optional<Entity> RenderFilter(const FilterInput::Vector& input_textures,
+                                     const ContentContext& renderer,
+                                     const Entity& entity,
+                                     const Matrix& effect_transform,
+                                     const Rect& coverage) const override;
 
   Matrix matrix_;
 

--- a/impeller/entity/contents/filters/matrix_filter_contents.cc
+++ b/impeller/entity/contents/filters/matrix_filter_contents.cc
@@ -18,7 +18,7 @@ void MatrixFilterContents::SetSamplerDescriptor(SamplerDescriptor desc) {
   sampler_descriptor_ = std::move(desc);
 }
 
-std::optional<Snapshot> MatrixFilterContents::RenderFilter(
+std::optional<Entity> MatrixFilterContents::RenderFilter(
     const FilterInput::Vector& inputs,
     const ContentContext& renderer,
     const Entity& entity,
@@ -34,7 +34,8 @@ std::optional<Snapshot> MatrixFilterContents::RenderFilter(
                         entity.GetTransformation().Invert() *  //
                         snapshot->transform;
   snapshot->sampler_descriptor = sampler_descriptor_;
-  return snapshot;
+  return Contents::EntityFromSnapshot(snapshot, entity.GetBlendMode(),
+                                      entity.GetStencilDepth());
 }
 
 std::optional<Rect> MatrixFilterContents::GetFilterCoverage(

--- a/impeller/entity/contents/filters/matrix_filter_contents.h
+++ b/impeller/entity/contents/filters/matrix_filter_contents.h
@@ -27,12 +27,11 @@ class MatrixFilterContents final : public FilterContents {
 
  private:
   // |FilterContents|
-  std::optional<Snapshot> RenderFilter(
-      const FilterInput::Vector& input_textures,
-      const ContentContext& renderer,
-      const Entity& entity,
-      const Matrix& effect_transform,
-      const Rect& coverage) const override;
+  std::optional<Entity> RenderFilter(const FilterInput::Vector& input_textures,
+                                     const ContentContext& renderer,
+                                     const Entity& entity,
+                                     const Matrix& effect_transform,
+                                     const Rect& coverage) const override;
 
   Matrix matrix_;
   SamplerDescriptor sampler_descriptor_ = {};

--- a/impeller/entity/contents/filters/morphology_filter_contents.cc
+++ b/impeller/entity/contents/filters/morphology_filter_contents.cc
@@ -34,7 +34,7 @@ void DirectionalMorphologyFilterContents::SetMorphType(MorphType morph_type) {
   morph_type_ = morph_type;
 }
 
-std::optional<Snapshot> DirectionalMorphologyFilterContents::RenderFilter(
+std::optional<Entity> DirectionalMorphologyFilterContents::RenderFilter(
     const FilterInput::Vector& inputs,
     const ContentContext& renderer,
     const Entity& entity,
@@ -57,7 +57,9 @@ std::optional<Snapshot> DirectionalMorphologyFilterContents::RenderFilter(
   }
 
   if (radius_.radius < kEhCloseEnough) {
-    return input_snapshot.value();
+    return Contents::EntityFromSnapshot(input_snapshot.value(),
+                                        entity.GetBlendMode(),
+                                        entity.GetStencilDepth());
   }
 
   auto maybe_input_uvs = input_snapshot->GetCoverageUVs(coverage);
@@ -139,10 +141,12 @@ std::optional<Snapshot> DirectionalMorphologyFilterContents::RenderFilter(
   sampler_desc.min_filter = MinMagFilter::kLinear;
   sampler_desc.mag_filter = MinMagFilter::kLinear;
 
-  return Snapshot{.texture = out_texture,
-                  .transform = Matrix::MakeTranslation(coverage.origin),
-                  .sampler_descriptor = sampler_desc,
-                  .opacity = input_snapshot->opacity};
+  return Contents::EntityFromSnapshot(
+      Snapshot{.texture = out_texture,
+               .transform = Matrix::MakeTranslation(coverage.origin),
+               .sampler_descriptor = sampler_desc,
+               .opacity = input_snapshot->opacity},
+      entity.GetBlendMode(), entity.GetStencilDepth());
 }
 
 std::optional<Rect> DirectionalMorphologyFilterContents::GetFilterCoverage(

--- a/impeller/entity/contents/filters/morphology_filter_contents.h
+++ b/impeller/entity/contents/filters/morphology_filter_contents.h
@@ -31,12 +31,11 @@ class DirectionalMorphologyFilterContents final : public FilterContents {
 
  private:
   // |FilterContents|
-  std::optional<Snapshot> RenderFilter(
-      const FilterInput::Vector& input_textures,
-      const ContentContext& renderer,
-      const Entity& entity,
-      const Matrix& effect_transform,
-      const Rect& coverage) const override;
+  std::optional<Entity> RenderFilter(const FilterInput::Vector& input_textures,
+                                     const ContentContext& renderer,
+                                     const Entity& entity,
+                                     const Matrix& effect_transform,
+                                     const Rect& coverage) const override;
 
   Radius radius_;
   Vector2 direction_;

--- a/impeller/entity/contents/filters/srgb_to_linear_filter_contents.cc
+++ b/impeller/entity/contents/filters/srgb_to_linear_filter_contents.cc
@@ -17,7 +17,7 @@ SrgbToLinearFilterContents::SrgbToLinearFilterContents() = default;
 
 SrgbToLinearFilterContents::~SrgbToLinearFilterContents() = default;
 
-std::optional<Snapshot> SrgbToLinearFilterContents::RenderFilter(
+std::optional<Entity> SrgbToLinearFilterContents::RenderFilter(
     const FilterInput::Vector& inputs,
     const ContentContext& renderer,
     const Entity& entity,
@@ -81,11 +81,12 @@ std::optional<Snapshot> SrgbToLinearFilterContents::RenderFilter(
   }
   out_texture->SetLabel("SrgbToLinear Texture");
 
-  return Snapshot{
-      .texture = out_texture,
-      .transform = input_snapshot->transform,
-      .sampler_descriptor = input_snapshot->sampler_descriptor,
-      .opacity = GetAbsorbOpacity() ? 1.0f : input_snapshot->opacity};
+  return Contents::EntityFromSnapshot(
+      Snapshot{.texture = out_texture,
+               .transform = input_snapshot->transform,
+               .sampler_descriptor = input_snapshot->sampler_descriptor,
+               .opacity = GetAbsorbOpacity() ? 1.0f : input_snapshot->opacity},
+      entity.GetBlendMode(), entity.GetStencilDepth());
 }
 
 }  // namespace impeller

--- a/impeller/entity/contents/filters/srgb_to_linear_filter_contents.h
+++ b/impeller/entity/contents/filters/srgb_to_linear_filter_contents.h
@@ -17,12 +17,11 @@ class SrgbToLinearFilterContents final : public ColorFilterContents {
 
  private:
   // |FilterContents|
-  std::optional<Snapshot> RenderFilter(
-      const FilterInput::Vector& input_textures,
-      const ContentContext& renderer,
-      const Entity& entity,
-      const Matrix& effect_transform,
-      const Rect& coverage) const override;
+  std::optional<Entity> RenderFilter(const FilterInput::Vector& input_textures,
+                                     const ContentContext& renderer,
+                                     const Entity& entity,
+                                     const Matrix& effect_transform,
+                                     const Rect& coverage) const override;
 
   FML_DISALLOW_COPY_AND_ASSIGN(SrgbToLinearFilterContents);
 };

--- a/impeller/entity/contents/filters/yuv_to_rgb_filter_contents.cc
+++ b/impeller/entity/contents/filters/yuv_to_rgb_filter_contents.cc
@@ -36,7 +36,7 @@ void YUVToRGBFilterContents::SetYUVColorSpace(YUVColorSpace yuv_color_space) {
   yuv_color_space_ = yuv_color_space;
 }
 
-std::optional<Snapshot> YUVToRGBFilterContents::RenderFilter(
+std::optional<Entity> YUVToRGBFilterContents::RenderFilter(
     const FilterInput::Vector& inputs,
     const ContentContext& renderer,
     const Entity& entity,
@@ -118,7 +118,9 @@ std::optional<Snapshot> YUVToRGBFilterContents::RenderFilter(
   }
   out_texture->SetLabel("YUVToRGB Texture");
 
-  return Snapshot{.texture = out_texture};
+  return Contents::EntityFromSnapshot(Snapshot{.texture = out_texture},
+                                      entity.GetBlendMode(),
+                                      entity.GetStencilDepth());
 }
 
 }  // namespace impeller

--- a/impeller/entity/contents/filters/yuv_to_rgb_filter_contents.h
+++ b/impeller/entity/contents/filters/yuv_to_rgb_filter_contents.h
@@ -18,12 +18,11 @@ class YUVToRGBFilterContents final : public FilterContents {
 
  private:
   // |FilterContents|
-  std::optional<Snapshot> RenderFilter(
-      const FilterInput::Vector& input_textures,
-      const ContentContext& renderer,
-      const Entity& entity,
-      const Matrix& effect_transform,
-      const Rect& coverage) const override;
+  std::optional<Entity> RenderFilter(const FilterInput::Vector& input_textures,
+                                     const ContentContext& renderer,
+                                     const Entity& entity,
+                                     const Matrix& effect_transform,
+                                     const Rect& coverage) const override;
 
   YUVColorSpace yuv_color_space_ = YUVColorSpace::kBT601LimitedRange;
 


### PR DESCRIPTION
This is a pass collapse optimization I've been meaning to get around to.

By outputting a deferred rendering command, filters are given full control over how its results should be applied to the parent pass; whether a subpass is necessary is entirely up to the filter.

This PR is a pure refactor that shouldn't change anything about how we render. Note that thanks to our other texture passthrough optimizations, this does _not_ introduce an extra pass when filters are chained. I plan to land the actual pass removals in follow-ups.