### PR TITLE
[Impeller] Ignore the mask filter when saving layer

### DIFF
--- a/impeller/aiks/paint.cc
+++ b/impeller/aiks/paint.cc
@@ -69,7 +69,6 @@ std::shared_ptr<Contents> Paint::WithFilters(
 std::shared_ptr<Contents> Paint::WithFiltersForSubpassTarget(
     std::shared_ptr<Contents> input,
     const Matrix& effect_transform) const {
-  input = WithMaskBlur(input, false, effect_transform);
   input = WithImageFilter(input, effect_transform);
   input = WithColorFilter(input, /**absorb_opacity=*/true);
   return input;

--- a/impeller/display_list/display_list_unittests.cc
+++ b/impeller/display_list/display_list_unittests.cc
@@ -265,6 +265,19 @@ TEST_P(DisplayListTest, CanDrawWithMaskBlur) {
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
 
+TEST_P(DisplayListTest, IgnoreMaskFilterWhenSavingLayer) {
+  auto texture = CreateTextureForFixture("embarcadero.jpg");
+  flutter::DisplayListBuilder builder;
+  auto filter = flutter::DlBlurMaskFilter(kNormal_SkBlurStyle, 10.0f);
+  flutter::DlPaint paint;
+  paint.setMaskFilter(&filter);
+  builder.saveLayer(nullptr, &paint);
+  builder.drawImage(DlImageImpeller::Make(texture), SkPoint::Make(100, 100),
+                    flutter::DlImageSampling::kNearestNeighbor);
+  builder.restore();
+  ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
+}
+
 TEST_P(DisplayListTest, CanDrawWithBlendColorFilter) {
   auto texture = CreateTextureForFixture("embarcadero.jpg");
   flutter::DisplayListBuilder builder;


### PR DESCRIPTION
According to Skia's documentation and implementation, mask filters are ignored for saved layers. So I guess Impeller needs to be consistent with it.

https://github.com/google/skia/blob/main/include/core/SkCanvas.h#L604-L605
https://github.com/google/skia/blob/main/src/core/SkCanvas.cpp#L1114

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

