### PR TITLE
Fix a flake in EmbedderTest.CompositorRenderTargetsNotRecycledWhenAvoidsCacheSet

### DIFF
--- a/shell/platform/embedder/fixtures/main.dart
+++ b/shell/platform/embedder/fixtures/main.dart
@@ -997,6 +997,26 @@ void render_targets_are_recycled() {
       builder.addPlatformView(42 + i, width: 30.0, height: 20.0);
     }
     PlatformDispatcher.instance.views.first.render(builder.build());
+    frame_count++;
+    if (frame_count == 8) {
+      signalNativeTest();
+    } else {
+      PlatformDispatcher.instance.scheduleFrame();
+    }
+  };
+  PlatformDispatcher.instance.scheduleFrame();
+}
+
+@pragma('vm:entry-point')
+void render_targets_are_in_stable_order() {
+  int frame_count = 0;
+  PlatformDispatcher.instance.onBeginFrame = (Duration duration) {
+    SceneBuilder builder = SceneBuilder();
+    for (int i = 0; i < 10; i++) {
+      builder.addPicture(Offset(0.0, 0.0), CreateGradientBox(Size(30.0, 20.0)));
+      builder.addPlatformView(42 + i, width: 30.0, height: 20.0);
+    }
+    PlatformDispatcher.instance.views.first.render(builder.build());
     PlatformDispatcher.instance.scheduleFrame();
     frame_count++;
     if (frame_count == 8) {

--- a/shell/platform/embedder/tests/embedder_gl_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_gl_unittests.cc
@@ -2977,7 +2977,7 @@ TEST_F(EmbedderTest, CompositorRenderTargetsAreInStableOrder) {
   EmbedderConfigBuilder builder(context);
   builder.SetOpenGLRendererConfig(SkISize::Make(300, 200));
   builder.SetCompositor();
-  builder.SetDartEntrypoint("render_targets_are_recycled");
+  builder.SetDartEntrypoint("render_targets_are_in_stable_order");
   builder.SetRenderTargetType(
       EmbedderTestBackingStoreProducer::RenderTargetType::kOpenGLTexture);
 
@@ -4018,7 +4018,7 @@ TEST_F(EmbedderTest, ExternalTextureGLRefreshedTooOften) {
   TestGLSurface surface(SkISize::Make(100, 100));
   auto context = surface.GetGrContext();
 
-  typedef void (*glGenTexturesProc)(uint32_t n, uint32_t * textures);
+  typedef void (*glGenTexturesProc)(uint32_t n, uint32_t* textures);
   glGenTexturesProc glGenTextures;
 
   glGenTextures = reinterpret_cast<glGenTexturesProc>(


### PR DESCRIPTION
The test assumes that the fixture app has scheduled a specific number of frames.  The fixture should stop scheduling after that point.

See https://github.com/flutter/flutter/issues/106589
