### PR TITLE
[cp][Impeller] Disable impeller_unittests

### DIFF
--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -422,25 +422,27 @@ def RunCCTests(build_dir, filter, coverage, capture_core_dump):
         shuffle_flags,
         coverage=coverage
     )
+    # TODO(117122): Re-enable impeller_unittests after shader compiler errors
+    #               are addressed.
     # Impeller tests are only supported on macOS for now.
-    RunEngineExecutable(
-        build_dir,
-        'impeller_unittests',
-        filter,
-        shuffle_flags,
-        coverage=coverage,
-        extra_env={
-            # See https://developer.apple.com/documentation/metal/diagnosing_metal_programming_issues_early?language=objc
-            'MTL_SHADER_VALIDATION':
-                '1',  # Enables all shader validation tests.
-            'MTL_SHADER_VALIDATION_GLOBAL_MEMORY':
-                '1',  # Validates accesses to device and constant memory.
-            'MTL_SHADER_VALIDATION_THREADGROUP_MEMORY':
-                '1',  # Validates accesses to threadgroup memory.
-            'MTL_SHADER_VALIDATION_TEXTURE_USAGE':
-                '1',  # Validates that texture references are not nil.
-        }
-    )
+    # RunEngineExecutable(
+    #     build_dir,
+    #     'impeller_unittests',
+    #     filter,
+    #     shuffle_flags,
+    #     coverage=coverage,
+    #     extra_env={
+    #         # See https://developer.apple.com/documentation/metal/diagnosing_metal_programming_issues_early?language=objc
+    #         'MTL_SHADER_VALIDATION':
+    #             '1',  # Enables all shader validation tests.
+    #         'MTL_SHADER_VALIDATION_GLOBAL_MEMORY':
+    #             '1',  # Validates accesses to device and constant memory.
+    #         'MTL_SHADER_VALIDATION_THREADGROUP_MEMORY':
+    #             '1',  # Validates accesses to threadgroup memory.
+    #         'MTL_SHADER_VALIDATION_TEXTURE_USAGE':
+    #             '1',  # Validates that texture references are not nil.
+    #     }
+    # )
 
 
 def ParseImpellerVulkanFilter():


### PR DESCRIPTION
`impeller_unittests` are flaking on `flutter-3.7-candidate.1` cherry picks https://github.com/flutter/engine/pull/39545#issuecomment-1428607969

These tests were turned off in https://github.com/flutter/engine/pull/38307 to address this flake https://github.com/flutter/flutter/issues/114872.  Cherry-pick turning off the tests into the release branch.

Request at https://github.com/flutter/flutter/issues/120640