### PR TITLE
[Impeller] Fix multi-function compute

### DIFF
--- a/impeller/fixtures/BUILD.gn
+++ b/impeller/fixtures/BUILD.gn
@@ -27,13 +27,19 @@ impeller_shaders("shader_fixtures") {
     "mipmaps.frag",
     "mipmaps.vert",
     "sample.comp",
+    "stage1.comp",
+    "stage2.comp",
     "simple.vert",
     "test_texture.frag",
     "test_texture.vert",
   ]
 
   if (impeller_enable_opengles) {
-    gles_exclusions = [ "sample.comp" ]
+    gles_exclusions = [
+      "sample.comp",
+      "stage1.comp",
+      "stage2.comp",
+    ]
   }
 }
 
@@ -77,6 +83,8 @@ test_fixtures("file_fixtures") {
     "sample_with_binding.vert",
     "simple.vert.hlsl",
     "sa%m#ple.vert",
+    "stage1.comp",
+    "stage2.comp",
     "struct_def_bug.vert",
     "table_mountain_nx.png",
     "table_mountain_ny.png",

--- a/impeller/fixtures/stage1.comp
+++ b/impeller/fixtures/stage1.comp
@@ -1,0 +1,29 @@
+layout(local_size_x = 128) in;
+layout(std430) buffer;
+
+layout(binding = 0) writeonly buffer Output {
+  uint count;
+  uint elements[];
+}
+output_data;
+
+layout(binding = 1) readonly buffer Input {
+  uint count;
+  uint elements[];
+}
+input_data;
+
+void main() {
+  uint ident = gl_GlobalInvocationID.x;
+
+  if (ident >= input_data.count) {
+    return;
+  }
+
+  uint out_slot = ident * 2;
+
+  output_data.count = input_data.count * 2;
+
+  output_data.elements[out_slot] = input_data.elements[ident] * 2;
+  output_data.elements[out_slot + 1] = input_data.elements[ident] * 3;
+}

--- a/impeller/fixtures/stage2.comp
+++ b/impeller/fixtures/stage2.comp
@@ -1,0 +1,26 @@
+layout(local_size_x = 128) in;
+layout(std430) buffer;
+
+layout(binding = 0) writeonly buffer Output {
+  uint count;
+  uint elements[];
+}
+output_data;
+
+layout(binding = 1) readonly buffer Input {
+  uint count;
+  uint elements[];
+}
+input_data;
+
+void main() {
+  uint ident = gl_GlobalInvocationID.x;
+
+  if (ident >= input_data.count) {
+    return;
+  }
+
+  output_data.count = input_data.count;
+
+  output_data.elements[ident] = input_data.elements[ident] * 2;
+}

--- a/impeller/renderer/backend/metal/compute_pass_mtl.mm
+++ b/impeller/renderer/backend/metal/compute_pass_mtl.mm
@@ -241,23 +241,23 @@ bool ComputePassMTL::EncodeCommands(const std::shared_ptr<Allocator>& allocator,
         return false;
       }
     }
-  }
-  // TODO(dnfield): use feature detection to support non-uniform threadgroup
-  // sizes.
-  // https://github.com/flutter/flutter/issues/110619
+    // TODO(dnfield): use feature detection to support non-uniform threadgroup
+    // sizes.
+    // https://github.com/flutter/flutter/issues/110619
 
-  // For now, check that the sizes are uniform.
-  FML_DCHECK(grid_size == thread_group_size);
-  auto width = grid_size.width;
-  auto height = grid_size.height;
-  while (width * height >
-         static_cast<int64_t>(
-             pass_bindings.GetPipeline().maxTotalThreadsPerThreadgroup)) {
-    width /= 2;
-    height /= 2;
+    // For now, check that the sizes are uniform.
+    FML_DCHECK(grid_size == thread_group_size);
+    auto width = grid_size.width;
+    auto height = grid_size.height;
+    while (width * height >
+           static_cast<int64_t>(
+               pass_bindings.GetPipeline().maxTotalThreadsPerThreadgroup)) {
+      width /= 2;
+      height /= 2;
+    }
+    auto size = MTLSizeMake(width, height, 1);
+    [encoder dispatchThreadgroups:size threadsPerThreadgroup:size];
   }
-  auto size = MTLSizeMake(width, height, 1);
-  [encoder dispatchThreadgroups:size threadsPerThreadgroup:size];
 
   return true;
 }


### PR DESCRIPTION
Adding multiple kernels to a single compute pass was only running the last one - the call to actually dispatch the method was nested improperly and only being invoked for the final command in the buffer.

Adds a test covering this situation, including sharing data between the kernel functions and verifying the output of both.