### PR TITLE
Revert "Add support for double tap action from Apple Pencil 2"

### DIFF
--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -371,7 +371,7 @@ class PlatformDispatcher {
   //  * pointer_data.cc
   //  * pointer.dart
   //  * AndroidTouchProcessor.java
-  static const int _kPointerDataFieldCount = 36;
+  static const int _kPointerDataFieldCount = 35;
 
   static PointerDataPacket _unpackPointerDataPacket(ByteData packet) {
     const int kStride = Int64List.bytesPerElement;
@@ -417,7 +417,6 @@ class PlatformDispatcher {
         panDeltaY: packet.getFloat64(kStride * offset++, _kFakeHostEndian),
         scale: packet.getFloat64(kStride * offset++, _kFakeHostEndian),
         rotation: packet.getFloat64(kStride * offset++, _kFakeHostEndian),
-        preferredStylusAuxiliaryAction: PointerPreferredStylusAuxiliaryAction.values[packet.getInt64(kStride * offset++, _kFakeHostEndian)],
       ));
       assert(offset == (i + 1) * _kPointerDataFieldCount);
     }

--- a/lib/ui/pointer.dart
+++ b/lib/ui/pointer.dart
@@ -133,29 +133,8 @@ enum PointerSignalKind {
   /// A pointer-generated scale event (e.g. trackpad pinch).
   scale,
 
-  /// A stylus generated action (e.g. double tap on Apple Pencil 2)
-  stylusAuxiliaryAction,
-
   /// An unknown pointer signal kind.
   unknown
-}
-
-  /// The preferred action for stylus action
-enum PointerPreferredStylusAuxiliaryAction {
-  /// Ignore pointer input
-  ignore,
-
-  /// Show colour palette if available
-  showColorPalette,
-
-  /// Switch to eraser if available
-  switchEraser,
-
-  /// Switch to previous tool
-  switchPrevious,
-
-  /// unknown preferred action
-  unknown,
 }
 
 /// Information about the state of a pointer.
@@ -197,7 +176,6 @@ class PointerData {
     this.panDeltaY = 0.0,
     this.scale = 0.0,
     this.rotation = 0.0,
-    this.preferredStylusAuxiliaryAction = PointerPreferredStylusAuxiliaryAction.ignore,
   });
 
   /// Unique identifier that ties the [PointerEvent] to embedder event created it.
@@ -396,11 +374,6 @@ class PointerData {
   /// The current angle of the pan/zoom in radians, with 0.0 as the initial angle.
   final double rotation;
 
-  /// For events with signal kind of stylusAuxiliaryAction
-  ///
-  /// The current preferred action for stylusAuxiliaryAction, with ignore as the default.
-  final PointerPreferredStylusAuxiliaryAction preferredStylusAuxiliaryAction;
-
   @override
   String toString() => 'PointerData(x: $physicalX, y: $physicalY)';
 
@@ -440,8 +413,7 @@ class PointerData {
              'panDeltaX: $panDeltaX, '
              'panDeltaY: $panDeltaY, '
              'scale: $scale, '
-             'rotation: $rotation, '
-             'preferredStylusAuxiliaryAction: $preferredStylusAuxiliaryAction'
+             'rotation: $rotation'
            ')';
   }
 }

--- a/lib/ui/window/pointer_data.h
+++ b/lib/ui/window/pointer_data.h
@@ -11,7 +11,7 @@ namespace flutter {
 
 // If this value changes, update the pointer data unpacking code in
 // platform_dispatcher.dart.
-static constexpr int kPointerDataFieldCount = 36;
+static constexpr int kPointerDataFieldCount = 35;
 static constexpr int kBytesPerField = sizeof(int64_t);
 // Must match the button constants in events.dart.
 enum PointerButtonMouse : int64_t {
@@ -63,16 +63,6 @@ struct alignas(8) PointerData {
     kScroll,
     kScrollInertiaCancel,
     kScale,
-    kStylusAuxiliaryAction,
-  };
-
-  // Must match the PreferredStylusAuxiliaryAction enum in pointer.dart.
-  enum class PreferredStylusAuxiliaryAction : int64_t {
-    kIgnore,
-    kShowColorPalette,
-    kSwitchEraser,
-    kSwitchPrevious,
-    kUnknown
   };
 
   int64_t embedder_id;
@@ -110,7 +100,6 @@ struct alignas(8) PointerData {
   double pan_delta_y;
   double scale;
   double rotation;
-  PreferredStylusAuxiliaryAction preferred_auxiliary_stylus_action;
 
   void Clear();
 };

--- a/lib/ui/window/pointer_data_packet_converter.cc
+++ b/lib/ui/window/pointer_data_packet_converter.cc
@@ -293,7 +293,6 @@ void PointerDataPacketConverter::ConvertPointerData(
     switch (pointer_data.signal_kind) {
       case PointerData::SignalKind::kScroll:
       case PointerData::SignalKind::kScrollInertiaCancel:
-      case PointerData::SignalKind::kStylusAuxiliaryAction:
       case PointerData::SignalKind::kScale: {
         // Makes sure we have an existing pointer
         auto iter = states_.find(pointer_data.device);

--- a/lib/ui/window/pointer_data_packet_converter_unittests.cc
+++ b/lib/ui/window/pointer_data_packet_converter_unittests.cc
@@ -45,8 +45,6 @@ void CreateSimulatedPointerData(PointerData& data,  // NOLINT
   data.platformData = 0;
   data.scroll_delta_x = 0.0;
   data.scroll_delta_y = 0.0;
-  data.preferred_auxiliary_stylus_action =
-      PointerData::PreferredStylusAuxiliaryAction::kIgnore;
 }
 
 void CreateSimulatedMousePointerData(PointerData& data,  // NOLINT
@@ -86,8 +84,6 @@ void CreateSimulatedMousePointerData(PointerData& data,  // NOLINT
   data.platformData = 0;
   data.scroll_delta_x = scroll_delta_x;
   data.scroll_delta_y = scroll_delta_y;
-  data.preferred_auxiliary_stylus_action =
-      PointerData::PreferredStylusAuxiliaryAction::kIgnore;
 }
 
 void CreateSimulatedTrackpadGestureData(PointerData& data,  // NOLINT
@@ -133,8 +129,6 @@ void CreateSimulatedTrackpadGestureData(PointerData& data,  // NOLINT
   data.pan_delta_y = 0.0;
   data.scale = scale;
   data.rotation = rotation;
-  data.preferred_auxiliary_stylus_action =
-      PointerData::PreferredStylusAuxiliaryAction::kIgnore;
 }
 
 void UnpackPointerPacket(std::vector<PointerData>& output,  // NOLINT

--- a/lib/web_ui/lib/pointer.dart
+++ b/lib/web_ui/lib/pointer.dart
@@ -34,24 +34,6 @@ enum PointerSignalKind {
   unknown
 }
 
-  /// The preferred action for stylus action
-enum PointerPreferredStylusAuxiliaryAction {
-  /// Ignore pointer input
-  ignore,
-
-  /// Show colour palette if available
-  showColorPalette,
-
-  /// Switch to eraser if available
-  switchEraser,
-
-  /// Switch to previous tool
-  switchPrevious,
-
-  /// unknown preferred action
-  unknown,
-}
-
 class PointerData {
   const PointerData({
     this.embedderId = 0,
@@ -89,7 +71,6 @@ class PointerData {
     this.panDeltaY = 0.0,
     this.scale = 0.0,
     this.rotation = 0.0,
-    this.preferredStylusAuxiliaryAction = PointerPreferredStylusAuxiliaryAction.ignore,
   });
   final int embedderId;
   final Duration timeStamp;
@@ -126,7 +107,6 @@ class PointerData {
   final double panDeltaY;
   final double scale;
   final double rotation;
-  final PointerPreferredStylusAuxiliaryAction preferredStylusAuxiliaryAction;
 
   @override
   String toString() => 'PointerData(x: $physicalX, y: $physicalY)';
@@ -165,8 +145,7 @@ class PointerData {
            'panDeltaX: $panDeltaX, '
            'panDeltaY: $panDeltaY, '
            'scale: $scale, '
-           'rotation: $rotation, '
-           'preferredStylusAuxiliaryAction: $preferredStylusAuxiliaryAction'
+           'rotation: $rotation'
            ')';
   }
 }

--- a/shell/common/input_events_unittests.cc
+++ b/shell/common/input_events_unittests.cc
@@ -176,8 +176,6 @@ void CreateSimulatedPointerData(PointerData& data,
   data.platformData = 0;
   data.scroll_delta_x = 0.0;
   data.scroll_delta_y = 0.0;
-  data.preferred_auxiliary_stylus_action =
-      PointerData::PreferredStylusAuxiliaryAction::kIgnore;
 }
 
 TEST_F(ShellTest, MissAtMostOneFrameForIrregularInputEvents) {

--- a/shell/platform/android/io/flutter/embedding/android/AndroidTouchProcessor.java
+++ b/shell/platform/android/io/flutter/embedding/android/AndroidTouchProcessor.java
@@ -66,7 +66,6 @@ public class AndroidTouchProcessor {
     PointerSignalKind.SCROLL,
     PointerSignalKind.SCROLL_INERTIA_CANCEL,
     PointerSignalKind.SCALE,
-    PointerSignalKind.STYLUS_AUXILIARY_ACTION,
     PointerSignalKind.UNKNOWN
   })
   public @interface PointerSignalKind {
@@ -74,28 +73,11 @@ public class AndroidTouchProcessor {
     int SCROLL = 1;
     int SCROLL_INERTIA_CANCEL = 2;
     int SCALE = 3;
-    int STYLUS_AUXILIARY_ACTION = 4;
-    int UNKNOWN = 5;
-  }
-
-  // Must match the PointerPreferredStylusAuxiliaryAction enum in pointer.dart.
-  @IntDef({
-    PointerPreferredStylusAuxiliaryAction.IGNORE,
-    PointerPreferredStylusAuxiliaryAction.SHOW_COLOR_PALETTE,
-    PointerPreferredStylusAuxiliaryAction.SWITCH_ERASER,
-    PointerPreferredStylusAuxiliaryAction.SWITCH_PREVIOUS,
-    PointerPreferredStylusAuxiliaryAction.UNKNOWN
-  })
-  public @interface PointerPreferredStylusAuxiliaryAction {
-    int IGNORE = 0;
-    int SHOW_COLOR_PALETTE = 1;
-    int SWITCH_ERASER = 2;
-    int SWITCH_PREVIOUS = 3;
     int UNKNOWN = 4;
   }
 
   // Must match the unpacking code in hooks.dart.
-  private static final int POINTER_DATA_FIELD_COUNT = 36;
+  private static final int POINTER_DATA_FIELD_COUNT = 35;
   @VisibleForTesting static final int BYTES_PER_FIELD = 8;
 
   // This value must match the value in framework's platform_view.dart.
@@ -372,8 +354,6 @@ public class AndroidTouchProcessor {
     packet.putDouble(0.0); // pan_delta_y
     packet.putDouble(1.0); // scale
     packet.putDouble(0.0); // rotation
-
-    packet.putLong(PointerPreferredStylusAuxiliaryAction.IGNORE); // preferred stylus action
 
     if (isTrackpadPan && getPointerChangeForPanZoom(pointerChange) == PointerChange.PAN_ZOOM_END) {
       ongoingPans.remove(event.getPointerId(pointerIndex));

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -56,9 +56,7 @@ typedef struct MouseState {
 // This is left a FlutterBinaryMessenger privately for now to give people a chance to notice the
 // change. Unfortunately unless you have Werror turned on, incompatible pointers as arguments are
 // just a warning.
-@interface FlutterViewController () <FlutterBinaryMessenger,
-                                     UIScrollViewDelegate,
-                                     UIPencilInteractionDelegate>
+@interface FlutterViewController () <FlutterBinaryMessenger, UIScrollViewDelegate>
 @property(nonatomic, readwrite, getter=isDisplayingFlutterUI) BOOL displayingFlutterUI;
 @property(nonatomic, assign) BOOL isHomeIndicatorHidden;
 @property(nonatomic, assign) BOOL isPresentingViewControllerAnimating;
@@ -99,7 +97,7 @@ typedef struct MouseState {
 // Trackpad rotating
 @property(nonatomic, retain)
     UIRotationGestureRecognizer* rotationGestureRecognizer API_AVAILABLE(ios(13.4));
-@property(nonatomic, retain) UIPencilInteraction* pencilInteraction API_AVAILABLE(ios(13.4));
+
 /**
  * Creates and registers plugins used by this view controller.
  */
@@ -724,10 +722,6 @@ static void SendFakeTouchEvent(FlutterEngine* engine,
   [self createTouchRateCorrectionVSyncClientIfNeeded];
 
   if (@available(iOS 13.4, *)) {
-    _pencilInteraction = [[UIPencilInteraction alloc] init];
-    _pencilInteraction.delegate = self;
-    [_flutterView addInteraction:_pencilInteraction];
-
     _hoverGestureRecognizer =
         [[UIHoverGestureRecognizer alloc] initWithTarget:self action:@selector(hoverEvent:)];
     _hoverGestureRecognizer.delegate = self;
@@ -901,8 +895,6 @@ static void SendFakeTouchEvent(FlutterEngine* engine,
   [_pinchGestureRecognizer release];
   _rotationGestureRecognizer.delegate = nil;
   [_rotationGestureRecognizer release];
-  _pencilInteraction.delegate = nil;
-  [_pencilInteraction release];
   [super dealloc];
 }
 
@@ -977,7 +969,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
     case UITouchTypeDirect:
     case UITouchTypeIndirect:
       return flutter::PointerData::DeviceKind::kTouch;
-    case UITouchTypePencil:
+    case UITouchTypeStylus:
       return flutter::PointerData::DeviceKind::kStylus;
     case UITouchTypeIndirectPointer:
       return flutter::PointerData::DeviceKind::kMouse;
@@ -1230,50 +1222,6 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   [_touchRateCorrectionVSyncClient invalidate];
   [_touchRateCorrectionVSyncClient release];
   _touchRateCorrectionVSyncClient = nil;
-}
-
-#pragma mark - Stylus Events
-
-- (void)pencilInteractionDidTap:(UIPencilInteraction*)interaction API_AVAILABLE(ios(13.4)) {
-  flutter::PointerData pointer_data = [self createAuxillaryStylusActionData];
-
-  auto packet = std::make_unique<flutter::PointerDataPacket>(1);
-  packet->SetPointerData(/*index=*/0, pointer_data);
-  [_engine.get() dispatchPointerDataPacket:std::move(packet)];
-}
-
-- (flutter::PointerData)createAuxillaryStylusActionData API_AVAILABLE(ios(13.4)) {
-  flutter::PointerData pointer_data;
-  pointer_data.Clear();
-
-  switch (UIPencilInteraction.preferredTapAction) {
-    case UIPencilPreferredActionIgnore:
-      pointer_data.preferred_auxiliary_stylus_action =
-          flutter::PointerData::PreferredStylusAuxiliaryAction::kIgnore;
-      break;
-    case UIPencilPreferredActionShowColorPalette:
-      pointer_data.preferred_auxiliary_stylus_action =
-          flutter::PointerData::PreferredStylusAuxiliaryAction::kShowColorPalette;
-      break;
-    case UIPencilPreferredActionSwitchEraser:
-      pointer_data.preferred_auxiliary_stylus_action =
-          flutter::PointerData::PreferredStylusAuxiliaryAction::kSwitchEraser;
-      break;
-    case UIPencilPreferredActionSwitchPrevious:
-      pointer_data.preferred_auxiliary_stylus_action =
-          flutter::PointerData::PreferredStylusAuxiliaryAction::kSwitchPrevious;
-      break;
-    default:
-      pointer_data.preferred_auxiliary_stylus_action =
-          flutter::PointerData::PreferredStylusAuxiliaryAction::kUnknown;
-      break;
-  }
-
-  pointer_data.time_stamp = [[NSProcessInfo processInfo] systemUptime] * kMicrosecondsPerSecond;
-  pointer_data.kind = flutter::PointerData::DeviceKind::kStylus;
-  pointer_data.signal_kind = flutter::PointerData::SignalKind::kStylusAuxiliaryAction;
-
-  return pointer_data;
 }
 
 #pragma mark - Handle view resizing

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -112,8 +112,7 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
 @property(nonatomic, copy, readonly) FlutterSendKeyEvent sendEvent;
 @end
 
-@interface FlutterViewController (Tests) <UIPencilInteractionDelegate>
-;
+@interface FlutterViewController (Tests)
 
 @property(nonatomic, assign) double targetViewInsetBottom;
 @property(nonatomic, assign) BOOL isKeyboardInOrTransitioningFromBackground;
@@ -125,7 +124,6 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
 - (void)handlePressEvent:(FlutterUIPressProxy*)press
               nextAction:(void (^)())next API_AVAILABLE(ios(13.4));
 - (void)discreteScrollEvent:(UIPanGestureRecognizer*)recognizer;
-- (flutter::PointerData)createAuxillaryStylusActionData;
 - (void)updateViewportMetrics;
 - (void)onUserSettingsChanged:(NSNotification*)notification;
 - (void)applicationWillTerminate:(NSNotification*)notification;
@@ -1477,6 +1475,11 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
 }
 
 - (void)testValidKeyUpEvent API_AVAILABLE(ios(13.4)) {
+  if (@available(iOS 13.4, *)) {
+    // noop
+  } else {
+    return;
+  }
   FlutterEnginePartialMock* mockEngine = [[FlutterEnginePartialMock alloc] init];
   mockEngine.keyEventChannel = OCMClassMock([FlutterBasicMessageChannel class]);
   OCMStub([mockEngine.keyEventChannel sendMessage:[OCMArg any] reply:[OCMArg any]])
@@ -1507,6 +1510,12 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
 }
 
 - (void)testValidKeyDownEvent API_AVAILABLE(ios(13.4)) {
+  if (@available(iOS 13.4, *)) {
+    // noop
+  } else {
+    return;
+  }
+
   FlutterEnginePartialMock* mockEngine = [[FlutterEnginePartialMock alloc] init];
   mockEngine.keyEventChannel = OCMClassMock([FlutterBasicMessageChannel class]);
   OCMStub([mockEngine.keyEventChannel sendMessage:[OCMArg any] reply:[OCMArg any]])
@@ -1538,6 +1547,11 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
 }
 
 - (void)testIgnoredKeyEvents API_AVAILABLE(ios(13.4)) {
+  if (@available(iOS 13.4, *)) {
+    // noop
+  } else {
+    return;
+  }
   id keyEventChannel = OCMClassMock([FlutterBasicMessageChannel class]);
   OCMStub([keyEventChannel sendMessage:[OCMArg any] reply:[OCMArg any]])
       .andCall(self, @selector(sendMessage:reply:));
@@ -1571,6 +1585,12 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
 }
 
 - (void)testPanGestureRecognizer API_AVAILABLE(ios(13.4)) {
+  if (@available(iOS 13.4, *)) {
+    // noop
+  } else {
+    return;
+  }
+
   FlutterViewController* vc = [[FlutterViewController alloc] initWithEngine:self.mockEngine
                                                                     nibName:nil
                                                                      bundle:nil];
@@ -1591,6 +1611,12 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
 }
 
 - (void)testMouseSupport API_AVAILABLE(ios(13.4)) {
+  if (@available(iOS 13.4, *)) {
+    // noop
+  } else {
+    return;
+  }
+
   FlutterViewController* vc = [[FlutterViewController alloc] initWithEngine:self.mockEngine
                                                                     nibName:nil
                                                                      bundle:nil];
@@ -1603,80 +1629,6 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
 
   [[[self.mockEngine verify] ignoringNonObjectArgs]
       dispatchPointerDataPacket:std::make_unique<flutter::PointerDataPacket>(0)];
-}
-
-- (void)testPencilSupport API_AVAILABLE(ios(13.4)) {
-  FlutterViewController* vc = [[FlutterViewController alloc] initWithEngine:self.mockEngine
-                                                                    nibName:nil
-                                                                     bundle:nil];
-  XCTAssertNotNil(vc);
-
-  id mockPencilInteraction = OCMClassMock([UIPencilInteraction class]);
-
-  OCMStub([mockPencilInteraction preferredTapAction])
-      .andReturn(UIPencilPreferredActionShowColorPalette);
-
-  // Check that the helper function is being called
-  FlutterViewController* viewControllerMock = OCMPartialMock(vc);
-  [viewControllerMock pencilInteractionDidTap:mockPencilInteraction];
-  OCMVerify([viewControllerMock createAuxillaryStylusActionData]);
-
-  [mockPencilInteraction stopMocking];
-}
-
-- (void)testCreateAuxillaryStylusActionData API_AVAILABLE(ios(13.4)) {
-  FlutterViewController* vc = [[FlutterViewController alloc] initWithEngine:self.mockEngine
-                                                                    nibName:nil
-                                                                     bundle:nil];
-  XCTAssertNotNil(vc);
-
-  id mockPencilInteraction = OCMClassMock([UIPencilInteraction class]);
-
-  OCMExpect([mockPencilInteraction preferredTapAction])
-      .andReturn(UIPencilPreferredActionShowColorPalette);
-
-  // Check the return value of the helper function
-  flutter::PointerData pointer_data = [vc createAuxillaryStylusActionData];
-
-  XCTAssertEqual(pointer_data.kind, flutter::PointerData::DeviceKind::kStylus);
-  XCTAssertEqual(pointer_data.signal_kind,
-                 flutter::PointerData::SignalKind::kStylusAuxiliaryAction);
-  XCTAssertEqual(pointer_data.preferred_auxiliary_stylus_action,
-                 flutter::PointerData::PreferredStylusAuxiliaryAction::kShowColorPalette);
-
-  OCMExpect([mockPencilInteraction preferredTapAction])
-      .andReturn(UIPencilPreferredActionSwitchEraser);
-
-  pointer_data = [vc createAuxillaryStylusActionData];
-
-  XCTAssertEqual(pointer_data.kind, flutter::PointerData::DeviceKind::kStylus);
-  XCTAssertEqual(pointer_data.signal_kind,
-                 flutter::PointerData::SignalKind::kStylusAuxiliaryAction);
-  XCTAssertEqual(pointer_data.preferred_auxiliary_stylus_action,
-                 flutter::PointerData::PreferredStylusAuxiliaryAction::kSwitchEraser);
-
-  OCMExpect([mockPencilInteraction preferredTapAction])
-      .andReturn(UIPencilPreferredActionSwitchPrevious);
-
-  pointer_data = [vc createAuxillaryStylusActionData];
-
-  XCTAssertEqual(pointer_data.kind, flutter::PointerData::DeviceKind::kStylus);
-  XCTAssertEqual(pointer_data.signal_kind,
-                 flutter::PointerData::SignalKind::kStylusAuxiliaryAction);
-  XCTAssertEqual(pointer_data.preferred_auxiliary_stylus_action,
-                 flutter::PointerData::PreferredStylusAuxiliaryAction::kSwitchPrevious);
-
-  OCMExpect([mockPencilInteraction preferredTapAction]).andReturn(UIPencilPreferredActionIgnore);
-
-  pointer_data = [vc createAuxillaryStylusActionData];
-
-  XCTAssertEqual(pointer_data.kind, flutter::PointerData::DeviceKind::kStylus);
-  XCTAssertEqual(pointer_data.signal_kind,
-                 flutter::PointerData::SignalKind::kStylusAuxiliaryAction);
-  XCTAssertEqual(pointer_data.preferred_auxiliary_stylus_action,
-                 flutter::PointerData::PreferredStylusAuxiliaryAction::kIgnore);
-
-  [mockPencilInteraction stopMocking];
 }
 
 - (void)testFakeEventTimeStamp {

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -2020,8 +2020,6 @@ inline flutter::PointerData::SignalKind ToPointerDataSignalKind(
       return flutter::PointerData::SignalKind::kScrollInertiaCancel;
     case kFlutterPointerSignalKindScale:
       return flutter::PointerData::SignalKind::kScale;
-    case kFlutterPointerSignalKindStylusAuxiliaryAction:
-      return flutter::PointerData::SignalKind::kStylusAuxiliaryAction;
   }
   return flutter::PointerData::SignalKind::kNone;
 }

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -889,7 +889,6 @@ typedef enum {
   kFlutterPointerSignalKindScroll,
   kFlutterPointerSignalKindScrollInertiaCancel,
   kFlutterPointerSignalKindScale,
-  kFlutterPointerSignalKindStylusAuxiliaryAction,
 } FlutterPointerSignalKind;
 
 typedef struct {


### PR DESCRIPTION
Reverts flutter/engine#39267

This change is causing the framework to fail its analysis checks because a switch over the PointerSignalKind is no longer exhaustive due to the addition of stylusAuxiliaryAction.