### PR TITLE
Uses `int64_t` instead of `int` for the |view_id| parameter.

### DIFF
--- a/flow/embedded_views.h
+++ b/flow/embedded_views.h
@@ -420,7 +420,7 @@ class ExternalViewEmbedder {
       fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) = 0;
 
   virtual void PrerollCompositeEmbeddedView(
-      int view_id,
+      int64_t view_id,
       std::unique_ptr<EmbeddedViewParams> params) = 0;
 
   // This needs to get called after |Preroll| finishes on the layer tree.
@@ -436,7 +436,7 @@ class ExternalViewEmbedder {
   virtual std::vector<DisplayListBuilder*> GetCurrentBuilders() = 0;
 
   // Must be called on the UI thread.
-  virtual EmbedderPaintContext CompositeEmbeddedView(int view_id) = 0;
+  virtual EmbedderPaintContext CompositeEmbeddedView(int64_t view_id) = 0;
 
   // Implementers must submit the frame by calling frame.Submit().
   //

--- a/flow/testing/mock_embedder.cc
+++ b/flow/testing/mock_embedder.cc
@@ -37,7 +37,7 @@ void MockViewEmbedder::BeginFrame(
 
 // |ExternalViewEmbedder|
 void MockViewEmbedder::PrerollCompositeEmbeddedView(
-    int view_id,
+    int64_t view_id,
     std::unique_ptr<EmbeddedViewParams> params) {
   prerolled_views_.emplace_back(view_id);
 }
@@ -53,7 +53,7 @@ std::vector<DisplayListBuilder*> MockViewEmbedder::GetCurrentBuilders() {
 }
 
 // |ExternalViewEmbedder|
-EmbedderPaintContext MockViewEmbedder::CompositeEmbeddedView(int view_id) {
+EmbedderPaintContext MockViewEmbedder::CompositeEmbeddedView(int64_t view_id) {
   painted_views_.emplace_back(view_id);
   EmbedderPaintContext context = contexts_.front();
   contexts_.pop_front();

--- a/flow/testing/mock_embedder.h
+++ b/flow/testing/mock_embedder.h
@@ -34,7 +34,7 @@ class MockViewEmbedder : public ExternalViewEmbedder {
 
   // |ExternalViewEmbedder|
   void PrerollCompositeEmbeddedView(
-      int view_id,
+      int64_t view_id,
       std::unique_ptr<EmbeddedViewParams> params) override;
 
   // |ExternalViewEmbedder|
@@ -44,7 +44,7 @@ class MockViewEmbedder : public ExternalViewEmbedder {
   std::vector<DisplayListBuilder*> GetCurrentBuilders() override;
 
   // |ExternalViewEmbedder|
-  EmbedderPaintContext CompositeEmbeddedView(int view_id) override;
+  EmbedderPaintContext CompositeEmbeddedView(int64_t view_id) override;
 
   std::vector<int64_t> prerolled_views() const { return prerolled_views_; }
   std::vector<int64_t> painted_views() const { return painted_views_; }

--- a/shell/common/rasterizer_unittests.cc
+++ b/shell/common/rasterizer_unittests.cc
@@ -64,13 +64,14 @@ class MockExternalViewEmbedder : public ExternalViewEmbedder {
                     double device_pixel_ratio,
                     fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger));
   MOCK_METHOD2(PrerollCompositeEmbeddedView,
-               void(int view_id, std::unique_ptr<EmbeddedViewParams> params));
+               void(int64_t view_id,
+                    std::unique_ptr<EmbeddedViewParams> params));
   MOCK_METHOD1(PostPrerollAction,
                PostPrerollResult(
                    fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger));
   MOCK_METHOD0(GetCurrentCanvases, std::vector<SkCanvas*>());
   MOCK_METHOD0(GetCurrentBuilders, std::vector<DisplayListBuilder*>());
-  MOCK_METHOD1(CompositeEmbeddedView, EmbedderPaintContext(int view_id));
+  MOCK_METHOD1(CompositeEmbeddedView, EmbedderPaintContext(int64_t view_id));
   MOCK_METHOD2(SubmitFrame,
                void(GrDirectContext* context,
                     std::unique_ptr<SurfaceFrame> frame));

--- a/shell/common/shell_test_external_view_embedder.cc
+++ b/shell/common/shell_test_external_view_embedder.cc
@@ -52,7 +52,7 @@ void ShellTestExternalViewEmbedder::BeginFrame(
 
 // |ExternalViewEmbedder|
 void ShellTestExternalViewEmbedder::PrerollCompositeEmbeddedView(
-    int view_id,
+    int64_t view_id,
     std::unique_ptr<EmbeddedViewParams> params) {
   SkRect view_bounds = SkRect::Make(frame_size_);
   std::unique_ptr<EmbedderViewSlice> view;
@@ -100,7 +100,7 @@ void ShellTestExternalViewEmbedder::PushFilterToVisitedPlatformViews(
 }
 
 EmbedderPaintContext ShellTestExternalViewEmbedder::CompositeEmbeddedView(
-    int view_id) {
+    int64_t view_id) {
   return {slices_[view_id]->canvas(), slices_[view_id]->builder()};
 }
 

--- a/shell/common/shell_test_external_view_embedder.h
+++ b/shell/common/shell_test_external_view_embedder.h
@@ -55,7 +55,7 @@ class ShellTestExternalViewEmbedder final : public ExternalViewEmbedder {
 
   // |ExternalViewEmbedder|
   void PrerollCompositeEmbeddedView(
-      int view_id,
+      int64_t view_id,
       std::unique_ptr<EmbeddedViewParams> params) override;
 
   // |ExternalViewEmbedder|
@@ -69,7 +69,7 @@ class ShellTestExternalViewEmbedder final : public ExternalViewEmbedder {
   std::vector<DisplayListBuilder*> GetCurrentBuilders() override;
 
   // |ExternalViewEmbedder|
-  EmbedderPaintContext CompositeEmbeddedView(int view_id) override;
+  EmbedderPaintContext CompositeEmbeddedView(int64_t view_id) override;
 
   // |ExternalViewEmbedder|
   void PushVisitedPlatformView(int64_t view_id) override;

--- a/shell/platform/android/external_view_embedder/external_view_embedder.cc
+++ b/shell/platform/android/external_view_embedder/external_view_embedder.cc
@@ -22,7 +22,7 @@ AndroidExternalViewEmbedder::AndroidExternalViewEmbedder(
 
 // |ExternalViewEmbedder|
 void AndroidExternalViewEmbedder::PrerollCompositeEmbeddedView(
-    int view_id,
+    int64_t view_id,
     std::unique_ptr<EmbeddedViewParams> params) {
   TRACE_EVENT0("flutter",
                "AndroidExternalViewEmbedder::PrerollCompositeEmbeddedView");
@@ -47,7 +47,7 @@ void AndroidExternalViewEmbedder::PrerollCompositeEmbeddedView(
 
 // |ExternalViewEmbedder|
 EmbedderPaintContext AndroidExternalViewEmbedder::CompositeEmbeddedView(
-    int view_id) {
+    int64_t view_id) {
   if (slices_.count(view_id) == 1) {
     return {slices_.at(view_id)->canvas(), slices_.at(view_id)->builder()};
   }
@@ -79,7 +79,7 @@ AndroidExternalViewEmbedder::GetCurrentBuilders() {
   return builders;
 }
 
-SkRect AndroidExternalViewEmbedder::GetViewRect(int view_id) const {
+SkRect AndroidExternalViewEmbedder::GetViewRect(int64_t view_id) const {
   const EmbeddedViewParams& params = view_params_.at(view_id);
   // TODO(egarciad): The rect should be computed from the mutator stack.
   // (Clipping is missing)

--- a/shell/platform/android/external_view_embedder/external_view_embedder.h
+++ b/shell/platform/android/external_view_embedder/external_view_embedder.h
@@ -38,11 +38,11 @@ class AndroidExternalViewEmbedder final : public ExternalViewEmbedder {
 
   // |ExternalViewEmbedder|
   void PrerollCompositeEmbeddedView(
-      int view_id,
+      int64_t view_id,
       std::unique_ptr<flutter::EmbeddedViewParams> params) override;
 
   // |ExternalViewEmbedder|
-  EmbedderPaintContext CompositeEmbeddedView(int view_id) override;
+  EmbedderPaintContext CompositeEmbeddedView(int64_t view_id) override;
 
   // |ExternalViewEmbedder|
   std::vector<SkCanvas*> GetCurrentCanvases() override;
@@ -85,7 +85,7 @@ class AndroidExternalViewEmbedder final : public ExternalViewEmbedder {
 
   // Gets the rect based on the device pixel ratio of a platform view displayed
   // on the screen.
-  SkRect GetViewRect(int view_id) const;
+  SkRect GetViewRect(int64_t view_id) const;
 
  private:
   // The number of frames the rasterizer task runner will continue

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -380,7 +380,7 @@ void FlutterPlatformViewsController::PushFilterToVisitedPlatformViews(
 }
 
 void FlutterPlatformViewsController::PrerollCompositeEmbeddedView(
-    int view_id,
+    int64_t view_id,
     std::unique_ptr<EmbeddedViewParams> params) {
   // All the CATransactions should be committed by the end of the last frame,
   // so catransaction_added_ must be false.
@@ -406,7 +406,7 @@ void FlutterPlatformViewsController::PrerollCompositeEmbeddedView(
   views_to_recomposite_.insert(view_id);
 }
 
-UIView* FlutterPlatformViewsController::GetPlatformViewByID(int view_id) {
+UIView* FlutterPlatformViewsController::GetPlatformViewByID(int64_t view_id) {
   if (views_.empty()) {
     return nil;
   }
@@ -573,7 +573,7 @@ void FlutterPlatformViewsController::ApplyMutators(const MutatorsStack& mutators
   embedded_view.layer.transform = flutter::GetCATransform3DFromSkMatrix(transformMatrix);
 }
 
-void FlutterPlatformViewsController::CompositeWithParams(int view_id,
+void FlutterPlatformViewsController::CompositeWithParams(int64_t view_id,
                                                          const EmbeddedViewParams& params) {
   CGRect frame = CGRectMake(0, 0, params.sizePoints().width(), params.sizePoints().height());
   FlutterTouchInterceptingView* touchInterceptor = touch_interceptors_[view_id].get();
@@ -612,7 +612,7 @@ void FlutterPlatformViewsController::CompositeWithParams(int view_id,
   ApplyMutators(mutatorStack, touchInterceptor, rect);
 }
 
-EmbedderPaintContext FlutterPlatformViewsController::CompositeEmbeddedView(int view_id) {
+EmbedderPaintContext FlutterPlatformViewsController::CompositeEmbeddedView(int64_t view_id) {
   // Any UIKit related code has to run on main thread.
   FML_DCHECK([[NSThread currentThread] isMainThread]);
   // Do nothing if the view doesn't need to be composited.
@@ -642,7 +642,7 @@ void FlutterPlatformViewsController::Reset() {
   visited_platform_views_.clear();
 }
 
-SkRect FlutterPlatformViewsController::GetPlatformViewRect(int view_id) {
+SkRect FlutterPlatformViewsController::GetPlatformViewRect(int64_t view_id) {
   UIView* platform_view = GetPlatformViewByID(view_id);
   UIScreen* screen = [UIScreen mainScreen];
   CGRect platform_view_cgrect = [platform_view convertRect:platform_view.bounds

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -200,7 +200,7 @@ class FlutterPlatformViewsController {
   // Also reverts the composition_order_ to its original state at the beginning of the frame.
   void CancelFrame();
 
-  void PrerollCompositeEmbeddedView(int view_id,
+  void PrerollCompositeEmbeddedView(int64_t view_id,
                                     std::unique_ptr<flutter::EmbeddedViewParams> params);
 
   // Returns the `FlutterPlatformView`'s `view` object associated with the view_id.
@@ -208,7 +208,7 @@ class FlutterPlatformViewsController {
   // If the `FlutterPlatformViewsController` does not contain any `FlutterPlatformView` object or
   // a `FlutterPlatformView` object asscociated with the view_id cannot be found, the method
   // returns nil.
-  UIView* GetPlatformViewByID(int view_id);
+  UIView* GetPlatformViewByID(int64_t view_id);
 
   PostPrerollResult PostPrerollAction(
       const fml::RefPtr<fml::RasterThreadMerger>& raster_thread_merger);
@@ -220,11 +220,11 @@ class FlutterPlatformViewsController {
 
   std::vector<DisplayListBuilder*> GetCurrentBuilders();
 
-  EmbedderPaintContext CompositeEmbeddedView(int view_id);
+  EmbedderPaintContext CompositeEmbeddedView(int64_t view_id);
 
   // The rect of the platform view at index view_id. This rect has been translated into the
   // host view coordinate system. Units are device screen pixels.
-  SkRect GetPlatformViewRect(int view_id);
+  SkRect GetPlatformViewRect(int64_t view_id);
 
   // Discards all platform views instances and auxiliary resources.
   void Reset();
@@ -289,7 +289,7 @@ class FlutterPlatformViewsController {
   void ApplyMutators(const MutatorsStack& mutators_stack,
                      UIView* embedded_view,
                      const SkRect& bounding_rect);
-  void CompositeWithParams(int view_id, const EmbeddedViewParams& params);
+  void CompositeWithParams(int64_t view_id, const EmbeddedViewParams& params);
 
   // Allocates a new FlutterPlatformViewLayer if needed, draws the pixels within the rect from
   // the picture on the layer's canvas.

--- a/shell/platform/darwin/ios/ios_external_view_embedder.h
+++ b/shell/platform/darwin/ios/ios_external_view_embedder.h
@@ -39,7 +39,7 @@ class IOSExternalViewEmbedder : public ExternalViewEmbedder {
 
   // |ExternalViewEmbedder|
   void PrerollCompositeEmbeddedView(
-      int view_id,
+      int64_t view_id,
       std::unique_ptr<flutter::EmbeddedViewParams> params) override;
 
   // |ExternalViewEmbedder|
@@ -53,7 +53,7 @@ class IOSExternalViewEmbedder : public ExternalViewEmbedder {
   std::vector<DisplayListBuilder*> GetCurrentBuilders() override;
 
   // |ExternalViewEmbedder|
-  EmbedderPaintContext CompositeEmbeddedView(int view_id) override;
+  EmbedderPaintContext CompositeEmbeddedView(int64_t view_id) override;
 
   // |ExternalViewEmbedder|
   void SubmitFrame(GrDirectContext* context,

--- a/shell/platform/darwin/ios/ios_external_view_embedder.mm
+++ b/shell/platform/darwin/ios/ios_external_view_embedder.mm
@@ -42,7 +42,7 @@ void IOSExternalViewEmbedder::BeginFrame(
 
 // |ExternalViewEmbedder|
 void IOSExternalViewEmbedder::PrerollCompositeEmbeddedView(
-    int view_id,
+    int64_t view_id,
     std::unique_ptr<EmbeddedViewParams> params) {
   TRACE_EVENT0("flutter", "IOSExternalViewEmbedder::PrerollCompositeEmbeddedView");
   FML_CHECK(platform_views_controller_);
@@ -71,7 +71,7 @@ std::vector<DisplayListBuilder*> IOSExternalViewEmbedder::GetCurrentBuilders() {
 }
 
 // |ExternalViewEmbedder|
-EmbedderPaintContext IOSExternalViewEmbedder::CompositeEmbeddedView(int view_id) {
+EmbedderPaintContext IOSExternalViewEmbedder::CompositeEmbeddedView(int64_t view_id) {
   TRACE_EVENT0("flutter", "IOSExternalViewEmbedder::CompositeEmbeddedView");
   FML_CHECK(platform_views_controller_);
   return platform_views_controller_->CompositeEmbeddedView(view_id);

--- a/shell/platform/embedder/embedder_external_view_embedder.cc
+++ b/shell/platform/embedder/embedder_external_view_embedder.cc
@@ -71,7 +71,7 @@ void EmbedderExternalViewEmbedder::BeginFrame(
 
 // |ExternalViewEmbedder|
 void EmbedderExternalViewEmbedder::PrerollCompositeEmbeddedView(
-    int view_id,
+    int64_t view_id,
     std::unique_ptr<EmbeddedViewParams> params) {
   auto vid = EmbedderExternalView::ViewIdentifier(view_id);
   FML_DCHECK(pending_views_.count(vid) == 0);
@@ -119,7 +119,7 @@ EmbedderExternalViewEmbedder::GetCurrentBuilders() {
 
 // |ExternalViewEmbedder|
 EmbedderPaintContext EmbedderExternalViewEmbedder::CompositeEmbeddedView(
-    int view_id) {
+    int64_t view_id) {
   auto vid = EmbedderExternalView::ViewIdentifier(view_id);
   auto found = pending_views_.find(vid);
   if (found == pending_views_.end()) {

--- a/shell/platform/embedder/embedder_external_view_embedder.h
+++ b/shell/platform/embedder/embedder_external_view_embedder.h
@@ -87,7 +87,7 @@ class EmbedderExternalViewEmbedder final : public ExternalViewEmbedder {
 
   // |ExternalViewEmbedder|
   void PrerollCompositeEmbeddedView(
-      int view_id,
+      int64_t view_id,
       std::unique_ptr<EmbeddedViewParams> params) override;
 
   // |ExternalViewEmbedder|
@@ -97,7 +97,7 @@ class EmbedderExternalViewEmbedder final : public ExternalViewEmbedder {
   std::vector<DisplayListBuilder*> GetCurrentBuilders() override;
 
   // |ExternalViewEmbedder|
-  EmbedderPaintContext CompositeEmbeddedView(int view_id) override;
+  EmbedderPaintContext CompositeEmbeddedView(int64_t view_id) override;
 
   // |ExternalViewEmbedder|
   void SubmitFrame(GrDirectContext* context,

--- a/shell/platform/fuchsia/flutter/flatland_external_view_embedder.cc
+++ b/shell/platform/fuchsia/flutter/flatland_external_view_embedder.cc
@@ -96,7 +96,7 @@ FlatlandExternalViewEmbedder::GetCurrentBuilders() {
 }
 
 void FlatlandExternalViewEmbedder::PrerollCompositeEmbeddedView(
-    int view_id,
+    int64_t view_id,
     std::unique_ptr<flutter::EmbeddedViewParams> params) {
   zx_handle_t handle = static_cast<zx_handle_t>(view_id);
   FML_CHECK(frame_layers_.count(handle) == 0);
@@ -108,7 +108,7 @@ void FlatlandExternalViewEmbedder::PrerollCompositeEmbeddedView(
 }
 
 flutter::EmbedderPaintContext
-FlatlandExternalViewEmbedder::CompositeEmbeddedView(int view_id) {
+FlatlandExternalViewEmbedder::CompositeEmbeddedView(int64_t view_id) {
   zx_handle_t handle = static_cast<zx_handle_t>(view_id);
   auto found = frame_layers_.find(handle);
   FML_CHECK(found != frame_layers_.end());

--- a/shell/platform/fuchsia/flutter/flatland_external_view_embedder.h
+++ b/shell/platform/fuchsia/flutter/flatland_external_view_embedder.h
@@ -70,11 +70,11 @@ class FlatlandExternalViewEmbedder final
 
   // |ExternalViewEmbedder|
   void PrerollCompositeEmbeddedView(
-      int view_id,
+      int64_t view_id,
       std::unique_ptr<flutter::EmbeddedViewParams> params) override;
 
   // |ExternalViewEmbedder|
-  flutter::EmbedderPaintContext CompositeEmbeddedView(int view_id) override;
+  flutter::EmbedderPaintContext CompositeEmbeddedView(int64_t view_id) override;
 
   // |ExternalViewEmbedder|
   flutter::PostPrerollResult PostPrerollAction(

--- a/shell/platform/fuchsia/flutter/gfx_external_view_embedder.cc
+++ b/shell/platform/fuchsia/flutter/gfx_external_view_embedder.cc
@@ -170,7 +170,7 @@ GfxExternalViewEmbedder::GetCurrentBuilders() {
 }
 
 void GfxExternalViewEmbedder::PrerollCompositeEmbeddedView(
-    int view_id,
+    int64_t view_id,
     std::unique_ptr<flutter::EmbeddedViewParams> params) {
   zx_handle_t handle = static_cast<zx_handle_t>(view_id);
   FML_CHECK(frame_layers_.count(handle) == 0);
@@ -182,7 +182,7 @@ void GfxExternalViewEmbedder::PrerollCompositeEmbeddedView(
 }
 
 flutter::EmbedderPaintContext GfxExternalViewEmbedder::CompositeEmbeddedView(
-    int view_id) {
+    int64_t view_id) {
   zx_handle_t handle = static_cast<zx_handle_t>(view_id);
   auto found = frame_layers_.find(handle);
   FML_CHECK(found != frame_layers_.end());

--- a/shell/platform/fuchsia/flutter/gfx_external_view_embedder.h
+++ b/shell/platform/fuchsia/flutter/gfx_external_view_embedder.h
@@ -92,11 +92,11 @@ class GfxExternalViewEmbedder final : public flutter::ExternalViewEmbedder {
 
   // |ExternalViewEmbedder|
   void PrerollCompositeEmbeddedView(
-      int view_id,
+      int64_t view_id,
       std::unique_ptr<flutter::EmbeddedViewParams> params) override;
 
   // |ExternalViewEmbedder|
-  flutter::EmbedderPaintContext CompositeEmbeddedView(int view_id) override;
+  flutter::EmbedderPaintContext CompositeEmbeddedView(int64_t view_id) override;
 
   // |ExternalViewEmbedder|
   flutter::PostPrerollResult PostPrerollAction(

--- a/shell/platform/fuchsia/flutter/platform_view_unittest.cc
+++ b/shell/platform/fuchsia/flutter/platform_view_unittest.cc
@@ -64,9 +64,10 @@ class MockExternalViewEmbedder : public flutter::ExternalViewEmbedder {
   }
 
   void PrerollCompositeEmbeddedView(
-      int view_id,
+      int64_t view_id,
       std::unique_ptr<flutter::EmbeddedViewParams> params) override {}
-  flutter::EmbedderPaintContext CompositeEmbeddedView(int view_id) override {
+  flutter::EmbedderPaintContext CompositeEmbeddedView(
+      int64_t view_id) override {
     return {nullptr, nullptr};
   }
 };

--- a/shell/platform/fuchsia/flutter/tests/flatland_platform_view_unittest.cc
+++ b/shell/platform/fuchsia/flutter/tests/flatland_platform_view_unittest.cc
@@ -63,9 +63,10 @@ class MockExternalViewEmbedder : public flutter::ExternalViewEmbedder {
   }
 
   void PrerollCompositeEmbeddedView(
-      int view_id,
+      int64_t view_id,
       std::unique_ptr<flutter::EmbeddedViewParams> params) override {}
-  flutter::EmbedderPaintContext CompositeEmbeddedView(int view_id) override {
+  flutter::EmbedderPaintContext CompositeEmbeddedView(
+      int64_t view_id) override {
     return {nullptr, nullptr};
   }
 };

--- a/shell/testing/tester_main.cc
+++ b/shell/testing/tester_main.cc
@@ -55,7 +55,7 @@ class TesterExternalViewEmbedder : public ExternalViewEmbedder {
 
   // |ExternalViewEmbedder|
   void PrerollCompositeEmbeddedView(
-      int view_id,
+      int64_t view_id,
       std::unique_ptr<EmbeddedViewParams> params) override {}
 
   // |ExternalViewEmbedder|
@@ -65,7 +65,7 @@ class TesterExternalViewEmbedder : public ExternalViewEmbedder {
   std::vector<DisplayListBuilder*> GetCurrentBuilders() override { return {}; }
 
   // |ExternalViewEmbedder|
-  EmbedderPaintContext CompositeEmbeddedView(int view_id) override {
+  EmbedderPaintContext CompositeEmbeddedView(int64_t view_id) override {
     return {&canvas_, nullptr};
   }
 


### PR DESCRIPTION

Related issue: https://github.com/flutter/flutter/issues/120256

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
