### PR TITLE
Fix build output path of the shader analysis core list

### DIFF
--- a/impeller/tools/malioc.gni
+++ b/impeller/tools/malioc.gni
@@ -14,7 +14,7 @@ declare_args() {
 }
 
 if (impeller_malioc_path != "" && impeller_malioc_cores == []) {
-  core_list_file = "$root_gen_dir/mali_core_list.json"
+  core_list_file = "$root_build_dir/mali_core_list.json"
   exec_script("//build/gn_run_binary.py",
               [
                 rebase_path(impeller_malioc_path, root_build_dir),


### PR DESCRIPTION
`$root_gen_dir` isn't guaranteed to exist when GN runs this, and the script won't create it before trying to write to the file. So, this PR changes the output path to one that is guaranteed to exist.