### PR TITLE
[macOS] Set textfield autofill type

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
@@ -449,6 +449,12 @@
 
   // Verify autocomplete is enabled.
   EXPECT_TRUE([plugin isAutomaticTextCompletionEnabled]);
+
+  // Verify content type is nil for unsupported content types.
+  if (@available(macOS 11.0, *)) {
+    EXPECT_EQ([plugin contentType], nil);
+  }
+
   return true;
 }
 
@@ -510,7 +516,6 @@
                                                   @"obscureText" : @YES,
                                                   @"autofill" : @{
                                                     @"uniqueIdentifier" : @"field1",
-                                                    @"hints" : @[ @"name" ],
                                                     @"editingValue" : @{@"text" : @""},
                                                   }
                                                 }
@@ -555,6 +560,11 @@
 
   // Verify autocomplete is disabled.
   EXPECT_FALSE([plugin isAutomaticTextCompletionEnabled]);
+
+  // Verify content type is password.
+  if (@available(macOS 11.0, *)) {
+    EXPECT_EQ([plugin contentType], NSTextContentTypePassword);
+  }
   return true;
 }
 
@@ -605,6 +615,86 @@
 
   // Verify autocomplete is disabled.
   EXPECT_FALSE([plugin isAutomaticTextCompletionEnabled]);
+  return true;
+}
+
+- (bool)testContentTypeWhenAutofillTypeIsUsername {
+  // Set up FlutterTextInputPlugin.
+  id engineMock = flutter::testing::CreateMockFlutterEngine(@"");
+  id binaryMessengerMock = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
+  OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
+      [engineMock binaryMessenger])
+      .andReturn(binaryMessengerMock);
+  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engineMock
+                                                                                nibName:@""
+                                                                                 bundle:nil];
+  FlutterTextInputPlugin* plugin =
+      [[FlutterTextInputPlugin alloc] initWithViewController:viewController];
+
+  // Set input client 1.
+  [plugin handleMethodCall:[FlutterMethodCall
+                               methodCallWithMethodName:@"TextInput.setClient"
+                                              arguments:@[
+                                                @(1), @{
+                                                  @"inputAction" : @"action",
+                                                  @"inputType" : @{@"name" : @"inputName"},
+                                                  @"autofill" : @{
+                                                    @"uniqueIdentifier" : @"field1",
+                                                    @"hints" : @[ @"username" ],
+                                                    @"editingValue" : @{@"text" : @""},
+                                                  }
+                                                }
+                                              ]]
+                    result:^(id){
+                    }];
+
+  // Verify autocomplete is disabled.
+  EXPECT_FALSE([plugin isAutomaticTextCompletionEnabled]);
+
+  // Verify content type is username.
+  if (@available(macOS 11.0, *)) {
+    EXPECT_EQ([plugin contentType], NSTextContentTypeUsername);
+  }
+  return true;
+}
+
+- (bool)testContentTypeWhenAutofillTypeIsOneTimeCode {
+  // Set up FlutterTextInputPlugin.
+  id engineMock = flutter::testing::CreateMockFlutterEngine(@"");
+  id binaryMessengerMock = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
+  OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
+      [engineMock binaryMessenger])
+      .andReturn(binaryMessengerMock);
+  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engineMock
+                                                                                nibName:@""
+                                                                                 bundle:nil];
+  FlutterTextInputPlugin* plugin =
+      [[FlutterTextInputPlugin alloc] initWithViewController:viewController];
+
+  // Set input client 1.
+  [plugin handleMethodCall:[FlutterMethodCall
+                               methodCallWithMethodName:@"TextInput.setClient"
+                                              arguments:@[
+                                                @(1), @{
+                                                  @"inputAction" : @"action",
+                                                  @"inputType" : @{@"name" : @"inputName"},
+                                                  @"autofill" : @{
+                                                    @"uniqueIdentifier" : @"field1",
+                                                    @"hints" : @[ @"oneTimeCode" ],
+                                                    @"editingValue" : @{@"text" : @""},
+                                                  }
+                                                }
+                                              ]]
+                    result:^(id){
+                    }];
+
+  // Verify autocomplete is disabled.
+  EXPECT_FALSE([plugin isAutomaticTextCompletionEnabled]);
+
+  // Verify content type is username.
+  if (@available(macOS 11.0, *)) {
+    EXPECT_EQ([plugin contentType], NSTextContentTypeOneTimeCode);
+  }
   return true;
 }
 


### PR DESCRIPTION
macOS supports three autofill types: username, password, and oneTimeCode. Apply these content types when the equivalent Flutter autofill hints are set.

Note that enabling autocomplete of username and password in applications will still require setting the "Autofill Credential Provider" and "Associated Domains" entitlements, and for the FlutterTextInputPlugin to be updated to use an NSSecureTextInput input type.

Issue: https://github.com/flutter/flutter/issues/120252


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
