### PR TITLE
[Impeller] Make RenderTarget::CreateOffscreen utilities add a stencil by default

### DIFF
--- a/impeller/entity/contents/content_context.cc
+++ b/impeller/entity/contents/content_context.cc
@@ -306,9 +306,13 @@ std::shared_ptr<Texture> ContentContext::MakeSubpass(
   RenderTarget subpass_target;
   if (context->GetDeviceCapabilities().SupportsOffscreenMSAA() &&
       msaa_enabled) {
-    subpass_target = RenderTarget::CreateOffscreenMSAA(*context, texture_size);
+    subpass_target = RenderTarget::CreateOffscreenMSAA(
+        *context, texture_size, "Contents Offscreen MSAA",
+        RenderTarget::kDefaultColorAttachmentConfigMSAA, std::nullopt);
   } else {
-    subpass_target = RenderTarget::CreateOffscreen(*context, texture_size);
+    subpass_target = RenderTarget::CreateOffscreen(
+        *context, texture_size, "Contents Offscreen",
+        RenderTarget::kDefaultColorAttachmentConfig, std::nullopt);
   }
   auto subpass_texture = subpass_target.GetRenderTargetTexture();
   if (!subpass_texture) {

--- a/impeller/renderer/render_target.h
+++ b/impeller/renderer/render_target.h
@@ -32,31 +32,38 @@ class RenderTarget {
     StoreAction store_action;
   };
 
-  static constexpr AttachmentConfig kDefaultAttachmentConfig = {
+  static constexpr AttachmentConfig kDefaultColorAttachmentConfig = {
       .storage_mode = StorageMode::kDevicePrivate,
       .load_action = LoadAction::kClear,
       .store_action = StoreAction::kStore};
 
-  static constexpr AttachmentConfigMSAA kDefaultAttachmentConfigMSAA = {
+  static constexpr AttachmentConfigMSAA kDefaultColorAttachmentConfigMSAA = {
       .storage_mode = StorageMode::kDeviceTransient,
       .resolve_storage_mode = StorageMode::kDevicePrivate,
       .load_action = LoadAction::kClear,
       .store_action = StoreAction::kMultisampleResolve};
 
+  static constexpr AttachmentConfig kDefaultStencilAttachmentConfig = {
+      .storage_mode = StorageMode::kDeviceTransient,
+      .load_action = LoadAction::kClear,
+      .store_action = StoreAction::kDontCare};
+
   static RenderTarget CreateOffscreen(
       const Context& context,
       ISize size,
       const std::string& label = "Offscreen",
-      AttachmentConfig color_attachment_config = kDefaultAttachmentConfig,
-      std::optional<AttachmentConfig> stencil_attachment_config = std::nullopt);
+      AttachmentConfig color_attachment_config = kDefaultColorAttachmentConfig,
+      std::optional<AttachmentConfig> stencil_attachment_config =
+          kDefaultStencilAttachmentConfig);
 
   static RenderTarget CreateOffscreenMSAA(
       const Context& context,
       ISize size,
       const std::string& label = "Offscreen MSAA",
       AttachmentConfigMSAA color_attachment_config =
-          kDefaultAttachmentConfigMSAA,
-      std::optional<AttachmentConfig> stencil_attachment_config = std::nullopt);
+          kDefaultColorAttachmentConfigMSAA,
+      std::optional<AttachmentConfig> stencil_attachment_config =
+          kDefaultStencilAttachmentConfig);
 
   RenderTarget();
 


### PR DESCRIPTION
This fixes the problem noted in this comment: https://github.com/flutter/flutter/issues/120586#issuecomment-1428023566

A breakage was introduced in https://github.com/flutter/engine/pull/39537 that affects `Picture::ToImage` and `Picture::RenderToTexture`. Because the default behavior was changed to remove the stencil, these utilities end up trying to render an `EntityPass` to a `RenderTarget` with no configured stencil attachment.

This fix inverts the default behavior and explicitly removes the stencil from `ContentContext::MakeSubpass` instead.