### PR TITLE
[Impeller] align SSBOs to 16 bytes to fix iOS shader validation issue.

### DIFF
--- a/impeller/entity/contents/gradient_generator.h
+++ b/impeller/entity/contents/gradient_generator.h
@@ -20,10 +20,6 @@ namespace impeller {
 
 class Context;
 
-/// Lower iOS version require alignment to be a multiple of 16, so the alignof
-/// operator will not give correct results for most structs.
-constexpr size_t kSSBOAlignOf = 16u;
-
 /**
  * @brief Create a host visible texture that contains the gradient defined
  * by the provided gradient data.

--- a/impeller/entity/contents/gradient_generator.h
+++ b/impeller/entity/contents/gradient_generator.h
@@ -20,6 +20,10 @@ namespace impeller {
 
 class Context;
 
+/// Lower iOS version require alignment to be a multiple of 16, so the alignof
+/// operator will not give correct results for most structs.
+constexpr size_t kSSBOAlignOf = 16u;
+
 /**
  * @brief Create a host visible texture that contains the gradient defined
  * by the provided gradient data.

--- a/impeller/entity/contents/linear_gradient_contents.cc
+++ b/impeller/entity/contents/linear_gradient_contents.cc
@@ -135,7 +135,7 @@ bool LinearGradientContents::RenderSSBO(const ContentContext& renderer,
 
   gradient_info.colors_length = colors.size();
   auto color_buffer = host_buffer.Emplace(
-      colors.data(), colors.size() * sizeof(StopData), alignof(StopData));
+      colors.data(), colors.size() * sizeof(StopData), kSSBOAlignOf);
 
   VS::FrameInfo frame_info;
   frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *

--- a/impeller/entity/contents/linear_gradient_contents.cc
+++ b/impeller/entity/contents/linear_gradient_contents.cc
@@ -134,8 +134,9 @@ bool LinearGradientContents::RenderSSBO(const ContentContext& renderer,
   auto colors = CreateGradientColors(colors_, stops_);
 
   gradient_info.colors_length = colors.size();
-  auto color_buffer = host_buffer.Emplace(
-      colors.data(), colors.size() * sizeof(StopData), kSSBOAlignOf);
+  auto color_buffer =
+      host_buffer.Emplace(colors.data(), colors.size() * sizeof(StopData),
+                          DefaultUniformAlignment());
 
   VS::FrameInfo frame_info;
   frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *

--- a/impeller/entity/contents/radial_gradient_contents.cc
+++ b/impeller/entity/contents/radial_gradient_contents.cc
@@ -70,8 +70,9 @@ bool RadialGradientContents::RenderSSBO(const ContentContext& renderer,
   auto colors = CreateGradientColors(colors_, stops_);
 
   gradient_info.colors_length = colors.size();
-  auto color_buffer = host_buffer.Emplace(
-      colors.data(), colors.size() * sizeof(StopData), kSSBOAlignOf);
+  auto color_buffer =
+      host_buffer.Emplace(colors.data(), colors.size() * sizeof(StopData),
+                          DefaultUniformAlignment());
 
   VS::FrameInfo frame_info;
   frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *

--- a/impeller/entity/contents/radial_gradient_contents.cc
+++ b/impeller/entity/contents/radial_gradient_contents.cc
@@ -71,7 +71,7 @@ bool RadialGradientContents::RenderSSBO(const ContentContext& renderer,
 
   gradient_info.colors_length = colors.size();
   auto color_buffer = host_buffer.Emplace(
-      colors.data(), colors.size() * sizeof(StopData), alignof(StopData));
+      colors.data(), colors.size() * sizeof(StopData), kSSBOAlignOf);
 
   VS::FrameInfo frame_info;
   frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *

--- a/impeller/entity/contents/sweep_gradient_contents.cc
+++ b/impeller/entity/contents/sweep_gradient_contents.cc
@@ -76,8 +76,9 @@ bool SweepGradientContents::RenderSSBO(const ContentContext& renderer,
   auto colors = CreateGradientColors(colors_, stops_);
 
   gradient_info.colors_length = colors.size();
-  auto color_buffer = host_buffer.Emplace(
-      colors.data(), colors.size() * sizeof(StopData), kSSBOAlignOf);
+  auto color_buffer =
+      host_buffer.Emplace(colors.data(), colors.size() * sizeof(StopData),
+                          DefaultUniformAlignment());
 
   VS::FrameInfo frame_info;
   frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *

--- a/impeller/entity/contents/sweep_gradient_contents.cc
+++ b/impeller/entity/contents/sweep_gradient_contents.cc
@@ -77,7 +77,7 @@ bool SweepGradientContents::RenderSSBO(const ContentContext& renderer,
 
   gradient_info.colors_length = colors.size();
   auto color_buffer = host_buffer.Emplace(
-      colors.data(), colors.size() * sizeof(StopData), alignof(StopData));
+      colors.data(), colors.size() * sizeof(StopData), kSSBOAlignOf);
 
   VS::FrameInfo frame_info;
   frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *


### PR DESCRIPTION
Fix https://github.com/flutter/flutter/issues/120817 by doing what the nice shader validation error message says