### PR TITLE
[web] consolidate network code into httpFetch

### DIFF
--- a/lib/web_ui/dev/test_platform.dart
+++ b/lib/web_ui/dev/test_platform.dart
@@ -329,7 +329,7 @@ class BrowserPlatform extends PlatformPlugin {
   Future<shelf.Response> _testPayloadGenerator(shelf.Request request) async {
     if (!request.requestedUri.path.endsWith('/long_test_payload')) {
       return shelf.Response.notFound(
-          'This request is not handled by the screenshot handler');
+          'This request is not handled by the test payload generator');
     }
 
     final int payloadLength = int.parse(request.requestedUri.queryParameters['length']!);

--- a/lib/web_ui/dev/test_platform.dart
+++ b/lib/web_ui/dev/test_platform.dart
@@ -90,6 +90,12 @@ class BrowserPlatform extends PlatformPlugin {
         // This handler goes last, after all more specific handlers failed to handle the request.
         .add(_createAbsolutePackageUrlHandler())
         .add(_screenshotHandler)
+
+        // Generates and serves a test payload of given length, split into chunks
+        // of given size. Reponds to requests to /long_test_payload.
+        .add(_testPayloadGenerator)
+
+        // If none of the handlers above handled the request, return 404.
         .add(_fileNotFoundCatcher);
 
     server.mount(cascade.handler);
@@ -318,6 +324,46 @@ class BrowserPlatform extends PlatformPlugin {
       }
       return shelf.Response.ok(fileInPackage.openRead());
     };
+  }
+
+  Future<shelf.Response> _testPayloadGenerator(shelf.Request request) async {
+    if (!request.requestedUri.path.endsWith('/long_test_payload')) {
+      return shelf.Response.notFound(
+          'This request is not handled by the screenshot handler');
+    }
+
+    final int payloadLength = int.parse(request.requestedUri.queryParameters['length']!);
+    final int chunkLength = int.parse(request.requestedUri.queryParameters['chunk']!);
+
+    final StreamController<List<int>> controller = StreamController<List<int>>();
+
+    Future<void> fillPayload() async {
+      int remainingByteCount = payloadLength;
+      int byteCounter = 0;
+      while (remainingByteCount > 0) {
+        final int currentChunkLength = min(chunkLength, remainingByteCount);
+        final List<int> chunk = List<int>.generate(
+          currentChunkLength,
+          (int i) => (byteCounter + i) & 0xFF,
+        );
+        byteCounter = (byteCounter + currentChunkLength) & 0xFF;
+        remainingByteCount -= currentChunkLength;
+        controller.add(chunk);
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+      }
+      await controller.close();
+    }
+
+    // Kick off payload filling function but don't block on it. The stream should
+    // be returned immediately, and the client should receive data in chunks.
+    unawaited(fillPayload());
+    return shelf.Response.ok(
+      controller.stream,
+      headers: <String, String>{
+        'Content-Type': 'application/octet-stream',
+        'Content-Length': '$payloadLength',
+      },
+    );
   }
 
   Future<shelf.Response> _screenshotHandler(shelf.Request request) async {

--- a/lib/web_ui/lib/src/engine/canvaskit/font_fallbacks.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/font_fallbacks.dart
@@ -488,37 +488,33 @@ class NotoDownloader {
   /// Downloads the [url] and returns it as a [ByteBuffer].
   ///
   /// Override this for testing.
-  Future<ByteBuffer> downloadAsBytes(String url, {String? debugDescription}) {
+  Future<ByteBuffer> downloadAsBytes(String url, {String? debugDescription}) async {
     if (assertionsEnabled) {
       _debugActiveDownloadCount += 1;
     }
-    final Future<ByteBuffer> result = httpFetch(url).then(
-        (DomResponse fetchResult) => fetchResult
-            .arrayBuffer()
-            .then<ByteBuffer>((dynamic x) => x as ByteBuffer));
+    final Future<ByteBuffer> data = httpFetchByteBuffer(url);
     if (assertionsEnabled) {
-      result.whenComplete(() {
+      unawaited(data.whenComplete(() {
         _debugActiveDownloadCount -= 1;
-      });
+      }));
     }
-    return result;
+    return data;
   }
 
   /// Downloads the [url] and returns is as a [String].
   ///
   /// Override this for testing.
-  Future<String> downloadAsString(String url, {String? debugDescription}) {
+  Future<String> downloadAsString(String url, {String? debugDescription}) async {
     if (assertionsEnabled) {
       _debugActiveDownloadCount += 1;
     }
-    final Future<String> result = httpFetch(url).then((DomResponse response) =>
-        response.text().then<String>((dynamic x) => x as String));
+    final Future<String> data = httpFetchText(url);
     if (assertionsEnabled) {
-      result.whenComplete(() {
+      unawaited(data.whenComplete(() {
         _debugActiveDownloadCount -= 1;
-      });
+      }));
     }
-    return result;
+    return data;
   }
 }
 

--- a/lib/web_ui/lib/src/engine/canvaskit/image.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image.dart
@@ -167,12 +167,6 @@ class ImageCodecException implements Exception {
 
 const String _kNetworkImageMessage = 'Failed to load network image.';
 
-typedef HttpRequestFactory = DomXMLHttpRequest Function();
-HttpRequestFactory httpRequestFactory = () => createDomXMLHttpRequest();
-void debugRestoreHttpRequestFactory() {
-  httpRequestFactory = () => createDomXMLHttpRequest();
-}
-
 /// Instantiates a [ui.Codec] backed by an `SkAnimatedImage` from Skia after
 /// requesting from URI.
 Future<ui.Codec> skiaInstantiateWebImageCodec(
@@ -186,49 +180,48 @@ Future<ui.Codec> skiaInstantiateWebImageCodec(
 }
 
 /// Sends a request to fetch image data.
-Future<Uint8List> fetchImage(
-    String url, WebOnlyImageCodecChunkCallback? chunkCallback) {
-  final Completer<Uint8List> completer = Completer<Uint8List>();
+Future<Uint8List> fetchImage(String url, WebOnlyImageCodecChunkCallback? chunkCallback) async {
+  try {
+    final HttpFetchResponse response = await httpFetch(url);
+    final int? contentLength = response.contentLength;
 
-  final DomXMLHttpRequest request = httpRequestFactory();
-  request.open('GET', url, true);
-  request.responseType = 'arraybuffer';
-  if (chunkCallback != null) {
-    request.addEventListener('progress', allowInterop((DomEvent event)  {
-      event = event as DomProgressEvent;
-      chunkCallback.call(event.loaded!.toInt(), event.total!.toInt());
-    }));
-  }
-
-  request.addEventListener('error', allowInterop((DomEvent event) {
-    completer.completeError(ImageCodecException('$_kNetworkImageMessage\n'
+    if (!response.hasPayload) {
+      throw ImageCodecException(
+        '$_kNetworkImageMessage\n'
         'Image URL: $url\n'
-        'Trying to load an image from another domain? Find answers at:\n'
-        'https://flutter.dev/docs/development/platform-integration/web-images'));
-  }));
-
-  request.addEventListener('load', allowInterop((DomEvent event) {
-    final int status = request.status!.toInt();
-    final bool accepted = status >= 200 && status < 300;
-    final bool fileUri = status == 0; // file:// URIs have status of 0.
-    final bool notModified = status == 304;
-    final bool unknownRedirect = status > 307 && status < 400;
-    final bool success = accepted || fileUri || notModified || unknownRedirect;
-
-    if (!success) {
-      completer.completeError(
-        ImageCodecException('$_kNetworkImageMessage\n'
-            'Image URL: $url\n'
-            'Server response code: $status'),
+        'Server response code: ${response.status}',
       );
-      return;
     }
 
-    completer.complete(Uint8List.view(request.response as ByteBuffer));
-  }));
+    if (chunkCallback != null && contentLength != null) {
+      return readChunked(response.payload, contentLength, chunkCallback);
+    } else {
+      return await response.asUint8List();
+    }
+  } on HttpFetchError catch (_) {
+    throw ImageCodecException(
+      '$_kNetworkImageMessage\n'
+      'Image URL: $url\n'
+      'Trying to load an image from another domain? Find answers at:\n'
+      'https://flutter.dev/docs/development/platform-integration/web-images',
+    );
+  }
+}
 
-  request.send();
-  return completer.future;
+/// Reads the [payload] in chunks using the browser's Streams API
+///
+/// See: https://developer.mozilla.org/en-US/docs/Web/API/Streams_API
+Future<Uint8List> readChunked(HttpFetchPayload payload, int contentLength, WebOnlyImageCodecChunkCallback chunkCallback) async {
+  final Uint8List result = Uint8List(contentLength);
+  int position = 0;
+  int cumulativeBytesLoaded = 0;
+  await payload.read<Uint8List>((Uint8List chunk) {
+    cumulativeBytesLoaded += chunk.lengthInBytes;
+    chunkCallback(cumulativeBytesLoaded, contentLength);
+    result.setAll(position, chunk);
+    position += chunk.lengthInBytes;
+  });
+  return result;
 }
 
 /// A [ui.Image] backed by an `SkImage` from Skia.

--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -463,12 +463,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
 
       case 'flutter/assets':
         final String url = utf8.decode(data!.buffer.asUint8List());
-        ui.webOnlyAssetManager.load(url).then((ByteData assetData) {
-          replyToPlatformMessage(callback, assetData);
-        }, onError: (dynamic error) {
-          printWarning('Error while trying to load an asset: $error');
-          replyToPlatformMessage(callback, null);
-        });
+        _handleFlutterAssetsMessage(url, callback);
         return;
 
       case 'flutter/platform':
@@ -611,6 +606,17 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
     // implemented. Look at [MethodChannel.invokeMethod] to see how [null] is
     // handled.
     replyToPlatformMessage(callback, null);
+  }
+
+  Future<void> _handleFlutterAssetsMessage(String url, ui.PlatformMessageResponseCallback? callback) async {
+    try {
+      final HttpFetchResponse response = await ui.webOnlyAssetManager.loadAsset(url);
+      final ByteBuffer assetData = await response.asByteBuffer();
+      replyToPlatformMessage(callback, assetData.asByteData());
+    } catch (error) {
+      printWarning('Error while trying to load an asset: $error');
+      replyToPlatformMessage(callback, null);
+    }
   }
 
   int _getHapticFeedbackDuration(String? type) {

--- a/lib/web_ui/lib/src/engine/text/font_collection.dart
+++ b/lib/web_ui/lib/src/engine/text/font_collection.dart
@@ -27,21 +27,15 @@ class HtmlFontCollection implements FontCollection {
   /// fonts declared within.
   @override
   Future<void> downloadAssetFonts(AssetManager assetManager) async {
-    ByteData byteData;
+    final HttpFetchResponse response = await assetManager.loadAsset('FontManifest.json');
 
-    try {
-      byteData = await assetManager.load('FontManifest.json');
-    } on AssetManagerException catch (e) {
-      if (e.httpStatus == 404) {
-        printWarning('Font manifest does not exist at `${e.url}` – ignoring.');
-        return;
-      } else {
-        rethrow;
-      }
+    if (!response.hasPayload) {
+      printWarning('Font manifest does not exist at `${response.url}` - ignoring.');
+      return;
     }
 
-    final List<dynamic>? fontManifest =
-        json.decode(utf8.decode(byteData.buffer.asUint8List())) as List<dynamic>?;
+    final Uint8List data = await response.asUint8List();
+    final List<dynamic>? fontManifest = json.decode(utf8.decode(data)) as List<dynamic>?;
     if (fontManifest == null) {
       throw AssertionError(
           'There was a problem trying to load FontManifest.json');

--- a/lib/web_ui/lib/src/engine/util.dart
+++ b/lib/web_ui/lib/src/engine/util.dart
@@ -563,12 +563,6 @@ String blurSigmasToCssString(double sigmaX, double sigmaY) {
   return 'blur(${(sigmaX + sigmaY) * 0.5}px)';
 }
 
-/// A typed variant of [domWindow.fetch].
-Future<DomResponse> httpFetch(String url) async {
-  final Object? result = await domWindow.fetch(url);
-  return result! as DomResponse;
-}
-
 /// Extensions to [Map] that make it easier to treat it as a JSON object. The
 /// keys are `dynamic` because when JSON is deserialized from method channels
 /// it arrives as `Map<dynamic, dynamic>`.

--- a/lib/web_ui/test/canvaskit/image_test.dart
+++ b/lib/web_ui/test/canvaskit/image_test.dart
@@ -3,9 +3,11 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
+import 'package:ui/src/engine/canvaskit/image.dart';
 import 'package:ui/ui.dart' as ui;
 
 import 'common.dart';
@@ -63,6 +65,38 @@ void testMain() {
     expect(disposedImage, image2);
 
     ui.Image.onDispose = null;
+  });
+
+  test('fetchImage fetches image in chunks', () async {
+    final List<int> cumulativeBytesLoadedInvocations = <int>[];
+    final List<int> expectedTotalBytesInvocations = <int>[];
+    final Uint8List result = await fetchImage('/long_test_payload?length=100000&chunk=1000', (int cumulativeBytesLoaded, int expectedTotalBytes) {
+      cumulativeBytesLoadedInvocations.add(cumulativeBytesLoaded);
+      expectedTotalBytesInvocations.add(expectedTotalBytes);
+    });
+
+    // Check that image payload was chunked.
+    expect(cumulativeBytesLoadedInvocations, hasLength(greaterThan(1)));
+
+    // Check that reported total byte count is the same across all invocations.
+    for (final int expectedTotalBytes in expectedTotalBytesInvocations) {
+      expect(expectedTotalBytes, 100000);
+    }
+
+    // Check that cumulative byte count grows with each invocation.
+    cumulativeBytesLoadedInvocations.reduce((int previous, int next) {
+      expect(next, greaterThan(previous));
+      return next;
+    });
+
+    // Check that the last cumulative byte count matches the total byte count.
+    expect(cumulativeBytesLoadedInvocations.last, 100000);
+
+    // Check the contents of the returned data.
+    expect(
+      result,
+      List<int>.generate(100000, (int i) => i & 0xFF),
+    );
   });
 }
 

--- a/lib/web_ui/test/engine/dom_http_fetch_test.dart
+++ b/lib/web_ui/test/engine/dom_http_fetch_test.dart
@@ -217,10 +217,13 @@ Future<void> _testNetworkErrors() async {
         expect(error.url, badUrl);
         expect(
           error.toString(),
-          'Flutter Web engine failed to complete HTTP request to fetch '
-          '"https://user:password@example.com/": TypeError: Failed to execute '
-          "'fetch' on 'Window': Request cannot be constructed from a URL "
-          'that includes credentials: https://user:password@example.com/',
+          // Browsers agree on throwing a TypeError, but they disagree on the
+          // error message. So this only checks for the common error prefix, but
+          // not the entire error message.
+          startsWith(
+            'Flutter Web engine failed to complete HTTP request to fetch '
+            '"https://user:password@example.com/": TypeError: '
+          ),
         );
       }
     }

--- a/lib/web_ui/test/engine/dom_http_fetch_test.dart
+++ b/lib/web_ui/test/engine/dom_http_fetch_test.dart
@@ -1,0 +1,230 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:typed_data';
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+import 'package:ui/src/engine.dart';
+
+import 'package:ui/ui.dart' as ui;
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+Future<void> testMain() async {
+  await ui.webOnlyInitializePlatform();
+
+  // Test successful HTTP roundtrips where the server returns a happy status
+  // code and a payload.
+  await _testSuccessfulPayloads();
+
+  // Test successful HTTP roundtrips where the server returned something other
+  // than a happy result (404 in particular is a common one).
+  await _testHttpErrorCodes();
+
+  // Test network errors that prevent the HTTP roundtrip to complete. These
+  // errors include invalid URLs, CORS issues, lost internet access, etc.
+  await _testNetworkErrors();
+
+  test('window.fetch is banned', () async {
+    expect(
+      () => domWindow.fetch('/'),
+      throwsA(isA<UnsupportedError>()),
+    );
+  });
+}
+
+Future<void> _testSuccessfulPayloads() async {
+  test('httpFetch fetches a text file', () async {
+    final HttpFetchResponse response = await httpFetch('/lib/src/engine/alarm_clock.dart');
+    expect(response.status, 200);
+    expect(response.contentLength, greaterThan(0));
+    expect(response.hasPayload, isTrue);
+    expect(response.payload, isNotNull);
+    expect(response.url, '/lib/src/engine/alarm_clock.dart');
+    expect(
+      await response.text(),
+      startsWith('''
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.'''),
+    );
+  });
+
+  test('httpFetch fetches a binary file as ByteBuffer', () async {
+    final HttpFetchResponse response = await httpFetch('/test_images/1x1.png');
+    expect(response.status, 200);
+    expect(response.contentLength, greaterThan(0));
+    expect(response.hasPayload, isTrue);
+    expect(response.payload, isNotNull);
+    expect(response.url, '/test_images/1x1.png');
+    expect(
+      (await response.asByteBuffer()).asUint8List().sublist(0, 8),
+      <int>[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A],
+    );
+  });
+
+  test('httpFetch fetches a binary file as Uint8List', () async {
+    final HttpFetchResponse response = await httpFetch('/test_images/1x1.png');
+    expect(response.status, 200);
+    expect(response.contentLength, greaterThan(0));
+    expect(response.hasPayload, isTrue);
+    expect(response.payload, isNotNull);
+    expect(response.url, '/test_images/1x1.png');
+    expect(
+      (await response.asUint8List()).sublist(0, 8),
+      <int>[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A],
+    );
+  });
+
+  test('httpFetch fetches json', () async {
+    final HttpFetchResponse response = await httpFetch('/test_images/');
+    expect(response.status, 200);
+    expect(response.contentLength, greaterThan(0));
+    expect(response.hasPayload, isTrue);
+    expect(response.payload, isNotNull);
+    expect(response.url, '/test_images/');
+    expect(
+      await response.json(),
+      isA<List<Object?>>(),
+    );
+  });
+
+  test('httpFetch reads data in chunks', () async {
+    // There is no guarantee that the server will actually serve the data in any
+    // particular chunk sizes, but breaking up the data in _some_ way does cause
+    // it to chunk it.
+    const List<List<int>> lengthAndChunks = <List<int>>[
+      <int>[0, 0],
+      <int>[10, 10],
+      <int>[1000, 100],
+      <int>[10000, 1000],
+      <int>[100000, 10000],
+    ];
+    for (final List<int> lengthAndChunk in lengthAndChunks) {
+      final int length = lengthAndChunk.first;
+      final int chunkSize = lengthAndChunk.last;
+      final String url = '/long_test_payload?length=$length&chunk=$chunkSize';
+      final HttpFetchResponse response = await httpFetch(url);
+      expect(response.status, 200);
+      expect(response.contentLength, length);
+      expect(response.hasPayload, isTrue);
+      expect(response.payload, isNotNull);
+      expect(response.url, url);
+
+      final List<int> result = <int>[];
+      await response.payload.read<Uint8List>(result.addAll);
+      expect(result, hasLength(length));
+      expect(
+        result,
+        List<int>.generate(length, (int i) => i & 0xFF),
+      );
+    }
+  });
+
+  test('httpFetchText fetches a text file', () async {
+    final String text = await httpFetchText('/lib/src/engine/alarm_clock.dart');
+    expect(
+      text,
+      startsWith('''
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.'''),
+    );
+  });
+
+  test('httpFetchByteBuffer fetches a binary file as ByteBuffer', () async {
+    final ByteBuffer response = await httpFetchByteBuffer('/test_images/1x1.png');
+    expect(
+      response.asUint8List().sublist(0, 8),
+      <int>[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A],
+    );
+  });
+
+  test('httpFetchJson fetches json', () async {
+    final Object? json = await httpFetchJson('/test_images/');
+    expect(json, isA<List<Object?>>());
+  });
+}
+
+Future<void> _testHttpErrorCodes() async {
+  test('httpFetch throws HttpFetchNoPayloadError on 404', () async {
+    final HttpFetchResponse response = await httpFetch('/file_not_found');
+    expect(response.status, 404);
+    expect(response.hasPayload, isFalse);
+    expect(response.url, '/file_not_found');
+
+    try {
+      // Attempting to read the payload when there isn't one should result in
+      // HttpFetchNoPayloadError thrown.
+      response.payload;
+      fail('Expected HttpFetchNoPayloadError');
+    } on HttpFetchNoPayloadError catch(error) {
+      expect(error.status, 404);
+      expect(error.url, '/file_not_found');
+      expect(
+        error.toString(),
+        'Flutter Web engine failed to fetch "/file_not_found". '
+        'HTTP request succeeded, but the server responded with HTTP status 404.',
+      );
+    }
+  });
+
+  test('httpFetch* functions throw HttpFetchNoPayloadError on 404', () async {
+    final List<AsyncCallback> testFunctions = <AsyncCallback>[
+      () async => httpFetchText('/file_not_found'),
+      () async => httpFetchByteBuffer('/file_not_found'),
+      () async => httpFetchJson('/file_not_found'),
+    ];
+
+    for (final AsyncCallback testFunction in testFunctions) {
+      try {
+        await testFunction();
+        fail('Expected HttpFetchNoPayloadError');
+      } on HttpFetchNoPayloadError catch(error) {
+        expect(error.status, 404);
+        expect(error.url, '/file_not_found');
+        expect(
+          error.toString(),
+          'Flutter Web engine failed to fetch "/file_not_found". '
+          'HTTP request succeeded, but the server responded with HTTP status 404.',
+        );
+      }
+    }
+  });
+}
+
+Future<void> _testNetworkErrors() async {
+  test('httpFetch* functions throw HttpFetchError on network errors', () async {
+    // Fetch throws the error this test wants on URLs with user credentials.
+    const String badUrl = 'https://user:password@example.com/';
+
+    final List<AsyncCallback> testFunctions = <AsyncCallback>[
+      () async => httpFetch(badUrl),
+      () async => httpFetchText(badUrl),
+      () async => httpFetchByteBuffer(badUrl),
+      () async => httpFetchJson(badUrl),
+    ];
+
+    for (final AsyncCallback testFunction in testFunctions) {
+      try {
+        await testFunction();
+        fail('Expected HttpFetchError');
+      } on HttpFetchError catch(error) {
+        expect(error.url, badUrl);
+        expect(
+          error.toString(),
+          'Flutter Web engine failed to complete HTTP request to fetch '
+          '"https://user:password@example.com/": TypeError: Failed to execute '
+          "'fetch' on 'Window': Request cannot be constructed from a URL "
+          'that includes credentials: https://user:password@example.com/',
+        );
+      }
+    }
+  });
+}
+
+typedef AsyncCallback = Future<void> Function();

--- a/lib/web_ui/test/text/font_loading_test.dart
+++ b/lib/web_ui/test/text/font_loading_test.dart
@@ -35,11 +35,8 @@ Future<void> testMain() async {
     test('loads Blehm font from buffer', () async {
       expect(_containsFontFamily('Blehm'), isFalse);
 
-      final DomXMLHttpRequest response = await domHttpRequest(
-          testFontUrl,
-          responseType: 'arraybuffer');
-      await ui.loadFontFromList(Uint8List.view(response.response as ByteBuffer),
-          fontFamily: 'Blehm');
+      final ByteBuffer response = await httpFetchByteBuffer(testFontUrl);
+      await ui.loadFontFromList(response.asUint8List(), fontFamily: 'Blehm');
 
       expect(_containsFontFamily('Blehm'), isTrue);
     },
@@ -59,11 +56,8 @@ Future<void> testMain() async {
 
       // Now, loads a new font using loadFontFromList. This should clear the
       // cache
-      final DomXMLHttpRequest response = await domHttpRequest(
-          testFontUrl,
-          responseType: 'arraybuffer');
-      await ui.loadFontFromList(Uint8List.view(response.response as ByteBuffer),
-          fontFamily: 'Blehm');
+      final ByteBuffer response = await httpFetchByteBuffer(testFontUrl);
+      await ui.loadFontFromList(response.asUint8List(), fontFamily: 'Blehm');
 
       // Verifies the font is loaded, and the cache is cleaned.
       expect(_containsFontFamily('Blehm'), isTrue);
@@ -84,11 +78,8 @@ Future<void> testMain() async {
             buffer.asUint8List(data.offsetInBytes, data.lengthInBytes);
         message = utf8.decode(list);
       };
-      final DomXMLHttpRequest response = await domHttpRequest(
-          testFontUrl,
-          responseType: 'arraybuffer');
-      await ui.loadFontFromList(Uint8List.view(response.response as ByteBuffer),
-          fontFamily: 'Blehm');
+      final ByteBuffer response = await httpFetchByteBuffer(testFontUrl);
+      await ui.loadFontFromList(response.asUint8List(), fontFamily: 'Blehm');
       final Completer<void> completer = Completer<void>();
       domWindow.requestAnimationFrame(allowInterop((_) { completer.complete();}) );
       await completer.future;

--- a/web_sdk/web_engine_tester/lib/golden_tester.dart
+++ b/web_sdk/web_engine_tester/lib/golden_tester.dart
@@ -13,13 +13,14 @@ import 'package:ui/src/engine/dom.dart';
 import 'package:ui/ui.dart';
 
 Future<dynamic> _callScreenshotServer(dynamic requestData) async {
-  final DomXMLHttpRequest request = await domHttpRequest(
+  // This is test code, but because the file name doesn't end with "_test.dart"
+  // the analyzer doesn't know it, so have to ignore the lint explicitly.
+  // ignore: invalid_use_of_visible_for_testing_member
+  final HttpFetchResponse response = await testOnlyHttpPost(
     'screenshot',
-    method: 'POST',
-    sendData: json.encode(requestData),
+    json.encode(requestData),
   );
-
-  return json.decode(request.responseText!);
+  return json.decode(await response.text());
 }
 
 /// How to compare pixels within the image.


### PR DESCRIPTION
Consolidate all of web engine HTTP code into a single `httpFetch` function that provides a standard way for handling errors:

- Provide `httpFetch` and a few specialize convenience functions around it for making HTTP calls.
- Provide a standard set of mock classes for mocking HTTP requests in unit tests.
- Migrate all of our code to `httpFetch` (fonts, assets, network images, 
