### PR TITLE
Match PlatformConfiguration properties to PlatformDispatcher ones

### DIFF
--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -981,8 +981,7 @@ class PlatformDispatcher {
   /// This option is used by [EditableTextState] to define its
   /// [SpellCheckConfiguration] when a default spell check service
   /// is requested.
-  bool get nativeSpellCheckServiceDefined => _nativeSpellCheckServiceDefined;
-  bool _nativeSpellCheckServiceDefined = false;
+  bool get nativeSpellCheckServiceDefined => configuration.nativeSpellCheckServiceDefined;
 
   /// Whether briefly displaying the characters as you type in obscured text
   /// fields is enabled in system settings.
@@ -991,8 +990,7 @@ class PlatformDispatcher {
   ///
   ///  * [EditableText.obscureText], which when set to true hides the text in
   ///    the text field.
-  bool get brieflyShowPassword => _brieflyShowPassword;
-  bool _brieflyShowPassword = true;
+  bool get brieflyShowPassword => configuration.brieflyShowPassword;
 
   /// The setting indicating the current brightness mode of the host platform.
   /// If the platform has no preference, [platformBrightness] defaults to
@@ -1046,16 +1044,8 @@ class PlatformDispatcher {
     final double textScaleFactor = (data['textScaleFactor']! as num).toDouble();
     final bool alwaysUse24HourFormat = data['alwaysUse24HourFormat']! as bool;
     final bool? nativeSpellCheckServiceDefined = data['nativeSpellCheckServiceDefined'] as bool?;
-    if (nativeSpellCheckServiceDefined != null) {
-      _nativeSpellCheckServiceDefined = nativeSpellCheckServiceDefined;
-    } else {
-      _nativeSpellCheckServiceDefined = false;
-    }
     // This field is optional.
     final bool? brieflyShowPassword = data['brieflyShowPassword'] as bool?;
-    if (brieflyShowPassword != null) {
-      _brieflyShowPassword = brieflyShowPassword;
-    }
     final Brightness platformBrightness =
     data['platformBrightness']! as String == 'dark' ? Brightness.dark : Brightness.light;
     final String? systemFontFamily = data['systemFontFamily'] as String?;
@@ -1072,6 +1062,8 @@ class PlatformDispatcher {
     _configuration = previousConfiguration.copyWith(
       textScaleFactor: textScaleFactor,
       alwaysUse24HourFormat: alwaysUse24HourFormat,
+      nativeSpellCheckServiceDefined: nativeSpellCheckServiceDefined ?? false,
+      brieflyShowPassword: brieflyShowPassword,
       platformBrightness: platformBrightness,
       systemFontFamily: systemFontFamily,
     );
@@ -1259,6 +1251,8 @@ class PlatformConfiguration {
     this.semanticsEnabled = false,
     this.platformBrightness = Brightness.light,
     this.textScaleFactor = 1.0,
+    this.nativeSpellCheckServiceDefined = false,
+    this.brieflyShowPassword = true,
     this.locales = const <Locale>[],
     this.defaultRouteName,
     this.systemFontFamily,
@@ -1271,6 +1265,8 @@ class PlatformConfiguration {
     bool? semanticsEnabled,
     Brightness? platformBrightness,
     double? textScaleFactor,
+    bool? nativeSpellCheckServiceDefined,
+    bool? brieflyShowPassword,
     List<Locale>? locales,
     String? defaultRouteName,
     String? systemFontFamily,
@@ -1281,6 +1277,8 @@ class PlatformConfiguration {
       semanticsEnabled: semanticsEnabled ?? this.semanticsEnabled,
       platformBrightness: platformBrightness ?? this.platformBrightness,
       textScaleFactor: textScaleFactor ?? this.textScaleFactor,
+      nativeSpellCheckServiceDefined: nativeSpellCheckServiceDefined ?? this.nativeSpellCheckServiceDefined,
+      brieflyShowPassword: brieflyShowPassword ?? this.brieflyShowPassword,
       locales: locales ?? this.locales,
       defaultRouteName: defaultRouteName ?? this.defaultRouteName,
       systemFontFamily: systemFontFamily ?? this.systemFontFamily,
@@ -1305,6 +1303,22 @@ class PlatformConfiguration {
 
   /// The system-reported text scale.
   final double textScaleFactor;
+
+  /// Whether the spell check service is supported on the current platform.
+  ///
+  /// This option is used by [EditableTextState] to define its
+  /// [SpellCheckConfiguration] when a default spell check service
+  /// is requested.
+  final bool nativeSpellCheckServiceDefined;
+
+  /// Whether briefly displaying the characters as you type in obscured text
+  /// fields is enabled in system settings.
+  ///
+  /// See also:
+  ///
+  ///  * [EditableText.obscureText], which when set to true hides the text in
+  ///    the text field.
+  final bool brieflyShowPassword;
 
   /// The full system-reported supported locales of the device.
   final List<Locale> locales;

--- a/lib/web_ui/lib/platform_dispatcher.dart
+++ b/lib/web_ui/lib/platform_dispatcher.dart
@@ -110,9 +110,9 @@ abstract class PlatformDispatcher {
 
   double get textScaleFactor => configuration.textScaleFactor;
 
-  bool get nativeSpellCheckServiceDefined => false;
+  bool get nativeSpellCheckServiceDefined => configuration.nativeSpellCheckServiceDefined;
 
-  bool get brieflyShowPassword => true;
+  bool get brieflyShowPassword => configuration.brieflyShowPassword;
 
   VoidCallback? get onTextScaleFactorChanged;
   set onTextScaleFactorChanged(VoidCallback? callback);
@@ -153,6 +153,8 @@ class PlatformConfiguration {
     this.semanticsEnabled = false,
     this.platformBrightness = Brightness.light,
     this.textScaleFactor = 1.0,
+    this.nativeSpellCheckServiceDefined = false,
+    this.brieflyShowPassword = true,
     this.locales = const <Locale>[],
     this.defaultRouteName = '/',
     this.systemFontFamily,
@@ -164,6 +166,8 @@ class PlatformConfiguration {
     bool? semanticsEnabled,
     Brightness? platformBrightness,
     double? textScaleFactor,
+    bool? nativeSpellCheckServiceDefined,
+    bool? brieflyShowPassword,
     List<Locale>? locales,
     String? defaultRouteName,
     String? systemFontFamily,
@@ -174,6 +178,8 @@ class PlatformConfiguration {
       semanticsEnabled: semanticsEnabled ?? this.semanticsEnabled,
       platformBrightness: platformBrightness ?? this.platformBrightness,
       textScaleFactor: textScaleFactor ?? this.textScaleFactor,
+      nativeSpellCheckServiceDefined: nativeSpellCheckServiceDefined ?? this.nativeSpellCheckServiceDefined,
+      brieflyShowPassword: brieflyShowPassword ?? this.brieflyShowPassword,
       locales: locales ?? this.locales,
       defaultRouteName: defaultRouteName ?? this.defaultRouteName,
       systemFontFamily: systemFontFamily ?? this.systemFontFamily,
@@ -185,6 +191,8 @@ class PlatformConfiguration {
   final bool semanticsEnabled;
   final Brightness platformBrightness;
   final double textScaleFactor;
+  final bool nativeSpellCheckServiceDefined;
+  final bool brieflyShowPassword;
   final List<Locale> locales;
   final String defaultRouteName;
   final String? systemFontFamily;

--- a/testing/dart/platform_dispatcher_test.dart
+++ b/testing/dart/platform_dispatcher_test.dart
@@ -2,13 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
 import 'dart:ui';
 
-import 'package:analyzer/dart/analysis/features.dart';
-import 'package:analyzer/dart/analysis/results.dart';
-import 'package:analyzer/dart/analysis/utilities.dart';
-import 'package:analyzer/dart/ast/ast.dart';
 import 'package:litetest/litetest.dart';
 
 void main() {
@@ -43,61 +38,5 @@ void main() {
       // ignore: deprecated_member_use
       return ViewConfiguration(view: view)..copyWith(view: view, window: view);
     });
-  });
-
-  test("PlatformDispatcher and PlatformConfiguration have matching getters", () {
-      final List<Pattern> exclusionCriteria = <Pattern>[
-        RegExp(r'^_.*'), // exclude any private members
-        RegExp(r'^on[A-Z].*'), // exclude any callbacks
-        RegExp(r'locale$'), // locale is a convenience getter for interacting with `locales` which _is_ backed by the config
-        'instance', // exclude the static instance of PlatformDispatcher
-        'configuration', // the configuration should not reference itself
-        'views', // views are backed by their own config and don't need to be referenced in the platform config
-        'initialLifecycleState', // default route is stored/retrieved from the platform, not the engine
-        'frameData', // framed data updates too often and would kick off too many config changes
-      ];
-
-      final String flutterDir = Platform.environment['FLUTTER_DIR']!;
-      final List<ClassDeclaration> classes = parseFile(
-        path: '$flutterDir/lib/ui/platform_dispatcher.dart',
-        featureSet: FeatureSet.latestLanguageVersion(),
-        throwIfDiagnostics: false,
-      ).unit.declarations.whereType<ClassDeclaration>().toList();
-      final ClassDeclaration dispatcherClass = classes.singleWhere((ClassDeclaration c) => c.name.toString() == (PlatformDispatcher).toString());
-      final ClassDeclaration configurationClass = classes.singleWhere((ClassDeclaration c) => c.name.toString() == (PlatformConfiguration).toString());
-
-      Iterable<String> getNameOfClassMember(ClassMember member) {
-        if (member is MethodDeclaration) {
-          return <String>[member.name.toString()];
-        }else if (member is FieldDeclaration) {
-          return member.fields.variables.map((VariableDeclaration variable) => variable.name.toString());
-        } else {
-          return [];
-        }
-      }
-
-      final Set<String> dispatcherMembers = dispatcherClass.members
-        .where((ClassMember member) =>
-          member is FieldDeclaration ||
-          member is MethodDeclaration && member.isGetter)
-        .expand<String>(getNameOfClassMember)
-        .where((String name) =>
-          exclusionCriteria.every((criteria) =>
-            criteria.allMatches(name).isEmpty))
-        .toSet();
-      final Set<String> configurationMembers = configurationClass.members
-        .where((ClassMember member) =>
-          member is FieldDeclaration ||
-          member is MethodDeclaration && member.isGetter)
-        .expand(getNameOfClassMember)
-        .toSet();
-
-      final Set<String> missingMembers = configurationMembers.difference(dispatcherMembers);
-      final Set<String> extraMembers = dispatcherMembers.difference(configurationMembers);
-      expect(missingMembers.isEmpty && extraMembers.isEmpty, isTrue,
-        reason:
-          'PlatformDispatcher is out of sync with PlatformConfiguration.\n'
-          '  Missing Members: $missingMembers\n'
-          '  Members not backed by PlatformConfiguration: $extraMembers');
   });
 }

--- a/testing/dart/platform_dispatcher_test.dart
+++ b/testing/dart/platform_dispatcher_test.dart
@@ -2,8 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io';
 import 'dart:ui';
 
+import 'package:analyzer/dart/analysis/features.dart';
+import 'package:analyzer/dart/analysis/results.dart';
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
 import 'package:litetest/litetest.dart';
 
 void main() {
@@ -38,5 +43,61 @@ void main() {
       // ignore: deprecated_member_use
       return ViewConfiguration(view: view)..copyWith(view: view, window: view);
     });
+  });
+
+  test("PlatformDispatcher and PlatformConfiguration have matching getters", () {
+      final List<Pattern> exclusionCriteria = <Pattern>[
+        RegExp(r'^_.*'), // exclude any private members
+        RegExp(r'^on[A-Z].*'), // exclude any callbacks
+        RegExp(r'locale$'), // locale is a convenience getter for interacting with `locales` which _is_ backed by the config
+        'instance', // exclude the static instance of PlatformDispatcher
+        'configuration', // the configuration should not reference itself
+        'views', // views are backed by their own config and don't need to be referenced in the platform config
+        'initialLifecycleState', // default route is stored/retrieved from the platform, not the engine
+        'frameData', // framed data updates too often and would kick off too many config changes
+      ];
+
+      final String flutterDir = Platform.environment['FLUTTER_DIR']!;
+      final List<ClassDeclaration> classes = parseFile(
+        path: '$flutterDir/lib/ui/platform_dispatcher.dart',
+        featureSet: FeatureSet.latestLanguageVersion(),
+        throwIfDiagnostics: false,
+      ).unit.declarations.whereType<ClassDeclaration>().toList();
+      final ClassDeclaration dispatcherClass = classes.singleWhere((ClassDeclaration c) => c.name.toString() == (PlatformDispatcher).toString());
+      final ClassDeclaration configurationClass = classes.singleWhere((ClassDeclaration c) => c.name.toString() == (PlatformConfiguration).toString());
+
+      Iterable<String> getNameOfClassMember(ClassMember member) {
+        if (member is MethodDeclaration) {
+          return <String>[member.name.toString()];
+        }else if (member is FieldDeclaration) {
+          return member.fields.variables.map((VariableDeclaration variable) => variable.name.toString());
+        } else {
+          return [];
+        }
+      }
+
+      final Set<String> dispatcherMembers = dispatcherClass.members
+        .where((ClassMember member) =>
+          member is FieldDeclaration ||
+          member is MethodDeclaration && member.isGetter)
+        .expand<String>(getNameOfClassMember)
+        .where((String name) =>
+          exclusionCriteria.every((criteria) =>
+            criteria.allMatches(name).isEmpty))
+        .toSet();
+      final Set<String> configurationMembers = configurationClass.members
+        .where((ClassMember member) =>
+          member is FieldDeclaration ||
+          member is MethodDeclaration && member.isGetter)
+        .expand(getNameOfClassMember)
+        .toSet();
+
+      final Set<String> missingMembers = configurationMembers.difference(dispatcherMembers);
+      final Set<String> extraMembers = dispatcherMembers.difference(configurationMembers);
+      expect(missingMembers.isEmpty && extraMembers.isEmpty, isTrue,
+        reason:
+          'PlatformDispatcher is out of sync with PlatformConfiguration.\n'
+          '  Missing Members: $missingMembers\n'
+          '  Members not backed by PlatformConfiguration: $extraMembers');
   });
 }


### PR DESCRIPTION
* Updated PlatformDispatcher to use PlatformConfiguration to back `nativeSpellCheckServiceDefined` and `brieflyShowPassword`
* Updated web PlatformDispatcher/Configuration to match new API

Resolves [#120840](https://github.com/flutter/flutter/issues/120840)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
