### PR TITLE
[macOS] Eliminate mirrors support

### DIFF
--- a/shell/platform/darwin/macos/framework/Headers/FlutterDartProject.h
+++ b/shell/platform/darwin/macos/framework/Headers/FlutterDartProject.h
@@ -30,13 +30,6 @@ FLUTTER_DARWIN_EXPORT
     NS_DESIGNATED_INITIALIZER;
 
 /**
- * If set, allows the Flutter project to use the dart:mirrors library.
- *
- * Deprecated: This function is temporary and will be removed in a future release.
- */
-@property(nonatomic) bool enableMirrors;
-
-/**
  * An NSArray of NSStrings to be passed as command line arguments to the Dart entrypoint.
  *
  * If this is not explicitly set, this will default to the contents of

--- a/shell/platform/darwin/macos/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterDartProject.mm
@@ -81,12 +81,4 @@ static NSString* const kAppBundleIdentifier = @"io.flutter.flutter.app";
   return path;
 }
 
-- (std::vector<std::string>)switches {
-  std::vector<std::string> arguments = flutter::GetSwitchesFromEnvironment();
-  if (self.enableMirrors) {
-    arguments.push_back("--dart-flags=--enable_mirrors=true");
-  }
-  return arguments;
-}
-
 @end

--- a/shell/platform/darwin/macos/framework/Source/FlutterDartProject_Internal.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterDartProject_Internal.h
@@ -26,11 +26,6 @@
 @property(nonatomic, readonly, nullable) NSString* ICUDataPath;
 
 /**
- * The command line arguments array for the engine.
- */
-@property(nonatomic, readonly) std::vector<std::string> switches;
-
-/**
  * The callback invoked by the engine in root isolate scope.
  */
 @property(nonatomic, nullable) void (*rootIsolateCreateCallback)(void* _Nullable);

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -9,6 +9,7 @@
 #include <iostream>
 #include <vector>
 
+#include "flutter/shell/platform/common/engine_switches.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterCompositor.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterDartProject_Internal.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterMenuPlugin.h"
@@ -337,7 +338,7 @@ static void OnPlatformMessage(const FlutterPlatformMessage* message, FlutterEngi
 
   // The first argument of argv is required to be the executable name.
   std::vector<const char*> argv = {[self.executableName UTF8String]};
-  std::vector<std::string> switches = _project.switches;
+  std::vector<std::string> switches = self.switches;
   std::transform(switches.begin(), switches.end(), std::back_inserter(argv),
                  [](const std::string& arg) -> const char* { return arg.c_str(); });
 
@@ -915,6 +916,10 @@ static void OnPlatformMessage(const FlutterPlatformMessage* message, FlutterEngi
 
 - (NSPasteboard*)pasteboard {
   return [NSPasteboard generalPasteboard];
+}
+
+- (std::vector<std::string>)switches {
+  return flutter::GetSwitchesFromEnvironment();
 }
 
 #pragma mark - FlutterBinaryMessenger

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
@@ -69,6 +69,24 @@ TEST_F(FlutterEngineTest, HasNonNullExecutableName) {
   latch.Wait();
 }
 
+#ifndef FLUTTER_RELEASE
+TEST_F(FlutterEngineTest, Switches) {
+  setenv("FLUTTER_ENGINE_SWITCHES", "2", 1);
+  setenv("FLUTTER_ENGINE_SWITCH_1", "abc", 1);
+  setenv("FLUTTER_ENGINE_SWITCH_2", "foo=\"bar, baz\"", 1);
+
+  FlutterEngine* engine = GetFlutterEngine();
+  std::vector<std::string> switches = engine.switches;
+  ASSERT_EQ(switches.size(), 2UL);
+  EXPECT_EQ(switches[0], "--abc");
+  EXPECT_EQ(switches[1], "--foo=\"bar, baz\"");
+
+  unsetenv("FLUTTER_ENGINE_SWITCHES");
+  unsetenv("FLUTTER_ENGINE_SWITCH_1");
+  unsetenv("FLUTTER_ENGINE_SWITCH_2");
+}
+#endif  // !FLUTTER_RELEASE
+
 TEST_F(FlutterEngineTest, MessengerSend) {
   FlutterEngine* engine = GetFlutterEngine();
   EXPECT_TRUE([engine runWithEntrypoint:@"main"]);

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h
@@ -48,6 +48,11 @@
 @property(nonatomic, readonly, nonnull) NSPasteboard* pasteboard;
 
 /**
+ * The command line arguments array for the engine.
+ */
+@property(nonatomic, readonly) std::vector<std::string> switches;
+
+/**
  * Attach a view controller to the engine as its default controller.
  *
  * Practically, since FlutterEngine can only be attached with one controller,


### PR DESCRIPTION
Support for using dart:mirrors has been deprecated for nearly two years. this removes support for enabling mirrors from the embedder as documented in the deprecation comment. This was primarily added as a workaround for an internal tooling usecase, which no longer exists.

Issue: https://github.com/flutter/flutter/issues/120924


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
