### PR TITLE
[linux] Eliminate mirrors support

### DIFF
--- a/shell/platform/linux/fl_dart_project.cc
+++ b/shell/platform/linux/fl_dart_project.cc
@@ -6,16 +6,9 @@
 
 #include <gmodule.h>
 
-#include <string>
-#include <vector>
-
-#include "flutter/shell/platform/common/engine_switches.h"
-#include "flutter/shell/platform/linux/fl_dart_project_private.h"
-
 struct _FlDartProject {
   GObject parent_instance;
 
-  gboolean enable_mirrors;
   gchar* aot_library_path;
   gchar* assets_path;
   gchar* icu_data_path;
@@ -69,19 +62,6 @@ G_MODULE_EXPORT FlDartProject* fl_dart_project_new() {
   return self;
 }
 
-G_MODULE_EXPORT void fl_dart_project_set_enable_mirrors(
-    FlDartProject* self,
-    gboolean enable_mirrors) {
-  g_return_if_fail(FL_IS_DART_PROJECT(self));
-  self->enable_mirrors = enable_mirrors;
-}
-
-G_MODULE_EXPORT gboolean
-fl_dart_project_get_enable_mirrors(FlDartProject* self) {
-  g_return_val_if_fail(FL_IS_DART_PROJECT(self), FALSE);
-  return self->enable_mirrors;
-}
-
 G_MODULE_EXPORT const gchar* fl_dart_project_get_aot_library_path(
     FlDartProject* self) {
   g_return_val_if_fail(FL_IS_DART_PROJECT(self), nullptr);
@@ -126,16 +106,4 @@ G_MODULE_EXPORT void fl_dart_project_set_dart_entrypoint_arguments(
   g_return_if_fail(FL_IS_DART_PROJECT(self));
   g_clear_pointer(&self->dart_entrypoint_args, g_strfreev);
   self->dart_entrypoint_args = g_strdupv(argv);
-}
-
-GPtrArray* fl_dart_project_get_switches(FlDartProject* self) {
-  GPtrArray* switches = g_ptr_array_new_with_free_func(g_free);
-  std::vector<std::string> env_switches = flutter::GetSwitchesFromEnvironment();
-  for (const auto& env_switch : env_switches) {
-    g_ptr_array_add(switches, g_strdup(env_switch.c_str()));
-  }
-  if (self->enable_mirrors) {
-    g_ptr_array_add(switches, g_strdup("--dart-flags=--enable_mirrors=true"));
-  }
-  return switches;
 }

--- a/shell/platform/linux/fl_dart_project_private.h
+++ b/shell/platform/linux/fl_dart_project_private.h
@@ -11,16 +11,6 @@
 
 G_BEGIN_DECLS
 
-/**
- * fl_dart_project_get_switches:
- * @project: an #FlDartProject.
- *
- * Determines the engine switches that should be passed to the Flutter engine.
- *
- * Returns: an array of switches to pass to the Flutter engine.
- */
-GPtrArray* fl_dart_project_get_switches(FlDartProject* project);
-
 G_END_DECLS
 
 #endif  // FLUTTER_SHELL_PLATFORM_LINUX_FL_DART_PROJECT_PRIVATE_H_

--- a/shell/platform/linux/fl_dart_project_test.cc
+++ b/shell/platform/linux/fl_dart_project_test.cc
@@ -8,7 +8,6 @@
 
 #include <cstdlib>
 
-#include "flutter/shell/platform/linux/fl_dart_project_private.h"
 #include "gtest/gtest.h"
 
 TEST(FlDartProjectTest, GetPaths) {
@@ -27,15 +26,6 @@ TEST(FlDartProjectTest, GetPaths) {
       g_build_filename(dir, "data", "icudtl.dat", nullptr);
   EXPECT_STREQ(fl_dart_project_get_icu_data_path(project),
                expected_icu_data_path);
-}
-
-TEST(FlDartProjectTest, EnableMirrors) {
-  g_autoptr(FlDartProject) project = fl_dart_project_new();
-  G_GNUC_BEGIN_IGNORE_DEPRECATIONS
-  EXPECT_FALSE(fl_dart_project_get_enable_mirrors(project));
-  fl_dart_project_set_enable_mirrors(project, TRUE);
-  EXPECT_TRUE(fl_dart_project_get_enable_mirrors(project));
-  G_GNUC_END_IGNORE_DEPRECATIONS
 }
 
 TEST(FlDartProjectTest, OverrideAssetsPath) {
@@ -78,35 +68,3 @@ TEST(FlDartProjectTest, DartEntrypointArgs) {
 
   EXPECT_EQ(g_strv_length(retrieved_args), 3U);
 }
-
-TEST(FlDartProjectTest, SwitchesEmpty) {
-  g_autoptr(FlDartProject) project = fl_dart_project_new();
-
-  // Clear the main environment variable, since test order is not guaranteed.
-  unsetenv("FLUTTER_ENGINE_SWITCHES");
-
-  g_autoptr(GPtrArray) switches = fl_dart_project_get_switches(project);
-
-  EXPECT_EQ(switches->len, 0U);
-}
-
-#ifndef FLUTTER_RELEASE
-TEST(FlDartProjectTest, Switches) {
-  g_autoptr(FlDartProject) project = fl_dart_project_new();
-
-  setenv("FLUTTER_ENGINE_SWITCHES", "2", 1);
-  setenv("FLUTTER_ENGINE_SWITCH_1", "abc", 1);
-  setenv("FLUTTER_ENGINE_SWITCH_2", "foo=\"bar, baz\"", 1);
-
-  g_autoptr(GPtrArray) switches = fl_dart_project_get_switches(project);
-  EXPECT_EQ(switches->len, 2U);
-  EXPECT_STREQ(static_cast<const char*>(g_ptr_array_index(switches, 0)),
-               "--abc");
-  EXPECT_STREQ(static_cast<const char*>(g_ptr_array_index(switches, 1)),
-               "--foo=\"bar, baz\"");
-
-  unsetenv("FLUTTER_ENGINE_SWITCHES");
-  unsetenv("FLUTTER_ENGINE_SWITCH_1");
-  unsetenv("FLUTTER_ENGINE_SWITCH_2");
-}
-#endif  // !FLUTTER_RELEASE

--- a/shell/platform/linux/fl_engine.cc
+++ b/shell/platform/linux/fl_engine.cc
@@ -7,7 +7,10 @@
 #include <gmodule.h>
 
 #include <cstring>
+#include <string>
+#include <vector>
 
+#include "flutter/shell/platform/common/engine_switches.h"
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/linux/fl_binary_messenger_private.h"
 #include "flutter/shell/platform/linux/fl_dart_project_private.h"
@@ -483,8 +486,7 @@ gboolean fl_engine_start(FlEngine* self, GError** error) {
   custom_task_runners.platform_task_runner = &platform_task_runner;
   custom_task_runners.render_task_runner = &platform_task_runner;
 
-  g_autoptr(GPtrArray) command_line_args =
-      fl_dart_project_get_switches(self->project);
+  g_autoptr(GPtrArray) command_line_args = fl_engine_get_switches(self);
   // FlutterProjectArgs expects a full argv, so when processing it for flags
   // the first item is treated as the executable and ignored. Add a dummy value
   // so that all switches are used.
@@ -884,4 +886,12 @@ void fl_engine_update_accessibility_features(FlEngine* self, int32_t flags) {
 
   self->embedder_api.UpdateAccessibilityFeatures(
       self->engine, static_cast<FlutterAccessibilityFeature>(flags));
+}
+
+GPtrArray* fl_engine_get_switches(FlEngine* self) {
+  GPtrArray* switches = g_ptr_array_new_with_free_func(g_free);
+  for (const auto& env_switch : flutter::GetSwitchesFromEnvironment()) {
+    g_ptr_array_add(switches, g_strdup(env_switch.c_str()));
+  }
+  return switches;
 }

--- a/shell/platform/linux/fl_engine_private.h
+++ b/shell/platform/linux/fl_engine_private.h
@@ -336,6 +336,16 @@ gboolean fl_engine_unregister_external_texture(FlEngine* engine,
  */
 void fl_engine_update_accessibility_features(FlEngine* engine, int32_t flags);
 
+/**
+ * fl_engine_get_switches:
+ * @project: an #FlEngine.
+ *
+ * Determines the switches that should be passed to the Flutter engine.
+ *
+ * Returns: an array of switches to pass to the Flutter engine.
+ */
+GPtrArray* fl_engine_get_switches(FlEngine* engine);
+
 G_END_DECLS
 
 #endif  // FLUTTER_SHELL_PLATFORM_LINUX_FL_ENGINE_PRIVATE_H_

--- a/shell/platform/linux/fl_engine_test.cc
+++ b/shell/platform/linux/fl_engine_test.cc
@@ -412,4 +412,36 @@ TEST(FlEngineTest, Locales) {
   g_free(initial_language);
 }
 
+TEST(FlEngineTest, SwitchesEmpty) {
+  g_autoptr(FlEngine) engine = make_mock_engine();
+
+  // Clear the main environment variable, since test order is not guaranteed.
+  unsetenv("FLUTTER_ENGINE_SWITCHES");
+
+  g_autoptr(GPtrArray) switches = fl_engine_get_switches(engine);
+
+  EXPECT_EQ(switches->len, 0U);
+}
+
+#ifndef FLUTTER_RELEASE
+TEST(FlEngineTest, Switches) {
+  g_autoptr(FlEngine) engine = make_mock_engine();
+
+  setenv("FLUTTER_ENGINE_SWITCHES", "2", 1);
+  setenv("FLUTTER_ENGINE_SWITCH_1", "abc", 1);
+  setenv("FLUTTER_ENGINE_SWITCH_2", "foo=\"bar, baz\"", 1);
+
+  g_autoptr(GPtrArray) switches = fl_engine_get_switches(engine);
+  EXPECT_EQ(switches->len, 2U);
+  EXPECT_STREQ(static_cast<const char*>(g_ptr_array_index(switches, 0)),
+               "--abc");
+  EXPECT_STREQ(static_cast<const char*>(g_ptr_array_index(switches, 1)),
+               "--foo=\"bar, baz\"");
+
+  unsetenv("FLUTTER_ENGINE_SWITCHES");
+  unsetenv("FLUTTER_ENGINE_SWITCH_1");
+  unsetenv("FLUTTER_ENGINE_SWITCH_2");
+}
+#endif  // !FLUTTER_RELEASE
+
 // NOLINTEND(clang-analyzer-core.StackAddressEscape)

--- a/shell/platform/linux/public/flutter_linux/fl_dart_project.h
+++ b/shell/platform/linux/public/flutter_linux/fl_dart_project.h
@@ -36,33 +36,6 @@ G_DECLARE_FINAL_TYPE(FlDartProject, fl_dart_project, FL, DART_PROJECT, GObject)
 FlDartProject* fl_dart_project_new();
 
 /**
- * fl_dart_project_set_enable_mirrors:
- * @project: an #FlDartProject.
- * @enable_mirrors: %TRUE if the dart:mirrors library should be used.
- *
- * Sets if this Flutter project can use the dart:mirrors library.
- *
- * Deprecated: This function is temporary and will be removed in a future
- * release.
- */
-void fl_dart_project_set_enable_mirrors(FlDartProject* project,
-                                        gboolean enable_mirrors) G_DEPRECATED;
-
-/**
- * fl_dart_project_get_enable_mirrors:
- * @project: an #FlDartProject.
- *
- * Gets if this Flutter project can use the dart:mirrors library.
- *
- * Returns: %TRUE if the dart:mirrors library can be used.
- *
- * Deprecated: This function is temporary and will be removed in a future
- * release.
- */
-gboolean fl_dart_project_get_enable_mirrors(FlDartProject* project)
-    G_DEPRECATED;
-
-/**
  * fl_dart_project_get_aot_library_path:
  * @project: an #FlDartProject.
  *


### PR DESCRIPTION
Support for using dart:mirrors has been deprecated for nearly two years. this removes support for enabling mirrors from the embedder as documented in the deprecation comment. This was primarily added as a workaround for an internal tooling usecase, which no longer exists.

Issue: https://github.com/flutter/flutter/issues/120924

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
