### PR TITLE
Migrate skia png codec call to public interface

### DIFF
--- a/lib/ui/painting/image_generator_apng.cc
+++ b/lib/ui/painting/image_generator_apng.cc
@@ -7,11 +7,11 @@
 #include <cstring>
 
 #include "flutter/fml/logging.h"
+#include "third_party/skia/include/codec/SkCodec.h"
 #include "third_party/skia/include/codec/SkCodecAnimation.h"
 #include "third_party/skia/include/core/SkAlphaType.h"
 #include "third_party/skia/include/core/SkColorType.h"
 #include "third_party/skia/include/core/SkStream.h"
-#include "third_party/skia/src/codec/SkPngCodec.h"
 #include "third_party/zlib/zlib.h"  // For crc32
 
 namespace flutter {
@@ -494,8 +494,8 @@ APNGImageGenerator::DemuxNextImage(const void* buffer_p,
   }
 
   SkCodec::Result header_parse_result;
-  result.codec = SkPngCodec::MakeFromStream(
-      SkMemoryStream::Make(new_png_buffer), &header_parse_result);
+  result.codec = SkCodec::MakeFromStream(SkMemoryStream::Make(new_png_buffer),
+                                         &header_parse_result);
   if (header_parse_result != SkCodec::Result::kSuccess) {
     FML_DLOG(ERROR)
         << "Failed to parse image header during APNG demux. SkCodec::Result: "


### PR DESCRIPTION
This is blocking the internal roll as the internal APIs aren't available.

Follow up from https://github.com/flutter/engine/pull/31098

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
