### PR TITLE
Adds a Linux Fuchsia FEMU config that enables CSO

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -156,6 +156,19 @@ targets:
       emulator_arch: "x64"
     timeout: 60
 
+  - name: Linux Fuchsia FEMU (cso)
+    recipe: engine/femu_test
+    bringup: true
+    properties:
+      add_recipes_cq: "true"
+      build_fuchsia: "true"
+      fuchsia_ctl_version: version:0.0.27
+      # ensure files from pre-production Fuchsia SDK tests are purged from cache
+      clobber: "true"
+      emulator_arch: "x64"
+      enable_cso: "true"
+    timeout: 60
+
   - name: Linux Fuchsia arm64 FEMU
     recipe: engine/femu_test
     bringup: true

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -160,14 +160,13 @@ targets:
     recipe: engine/femu_test
     bringup: true
     properties:
-      add_recipes_cq: "true"
       build_fuchsia: "true"
       fuchsia_ctl_version: version:0.0.27
       # ensure files from pre-production Fuchsia SDK tests are purged from cache
       clobber: "true"
       emulator_arch: "x64"
       enable_cso: "true"
-    timeout: 60
+    timeout: 90
 
   - name: Linux Fuchsia arm64 FEMU
     recipe: engine/femu_test

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -160,6 +160,7 @@ targets:
     recipe: engine/femu_test
     bringup: true
     properties:
+      add_recipes_cq: "false"
       build_fuchsia: "true"
       fuchsia_ctl_version: version:0.0.27
       # ensure files from pre-production Fuchsia SDK tests are purged from cache


### PR DESCRIPTION
This configuration exposed Fuchsia issues that were not surfaced in any other environment when it was enabled prematurely last week. This change adds a `bringup: true` builder for the new configuration. When it stabilizes, `enable_cso` will become the default, and the `bringup: true` builder can be deleted.

`enable_cso` was added here https://flutter-review.git.corp.google.com/c/recipes/+/39400.