### PR TITLE
[gn + codesign] move snapshot meta data to generators

### DIFF
--- a/build/archives/BUILD.gn
+++ b/build/archives/BUILD.gn
@@ -281,17 +281,8 @@ if (host_os == "win") {
 
 # Archives Flutter Mac Artifacts
 if (is_mac) {
-  generated_file("snapshot_entitlement_config") {
-    outputs = [ "$target_gen_dir/snapshot_entitlements.txt" ]
-
-    data_keys = [ "snapshot_entitlement_file_path" ]
-
-    deps = [ "//flutter/lib/snapshot:create_macos_gen_snapshots" ]
-  }
-
   zip_bundle("archive_gen_snapshot") {
     deps = [
-      ":snapshot_entitlement_config",
       "//flutter/lib/snapshot:create_macos_gen_snapshots",
     ]
     suffix = "-$flutter_runtime_mode"
@@ -303,10 +294,6 @@ if (is_mac) {
       {
         source = "$root_out_dir/gen_snapshot_$target_cpu"
         destination = "gen_snapshot_$target_cpu"
-      },
-      {
-        source = "$target_gen_dir/snapshot_entitlements.txt"
-        destination = "entitlements.txt"
       },
     ]
   }

--- a/build/archives/BUILD.gn
+++ b/build/archives/BUILD.gn
@@ -282,9 +282,7 @@ if (host_os == "win") {
 # Archives Flutter Mac Artifacts
 if (is_mac) {
   zip_bundle("archive_gen_snapshot") {
-    deps = [
-      "//flutter/lib/snapshot:create_macos_gen_snapshots",
-    ]
+    deps = [ "//flutter/lib/snapshot:create_macos_gen_snapshots" ]
     suffix = "-$flutter_runtime_mode"
     if (flutter_runtime_mode == "debug") {
       suffix = ""

--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -290,9 +290,6 @@ if (host_os == "mac" && target_os == "mac") {
     sources = [ "${host_output_dir}/gen_snapshot" ]
     outputs = [ "${root_out_dir}/gen_snapshot_${target_cpu}" ]
     deps = [ "//third_party/dart/runtime/bin:gen_snapshot($host_toolchain)" ]
-    metadata = {
-      snapshot_entitlement_file_path = [ "gen_snapshot_{$target_cpu}" ]
-    }
   }
 }
 

--- a/sky/tools/create_macos_gen_snapshots.py
+++ b/sky/tools/create_macos_gen_snapshots.py
@@ -66,17 +66,21 @@ def main():
   if args.zip:
     zip_archive(dst)
 
+
 def embed_codesign_configuration(config_path, contents):
   with open(config_path, 'w') as f:
-     f.write('\n'.join(contents) + '\n')
+    f.write('\n'.join(contents) + '\n')
+
 
 def zip_archive(dst):
-  snapshot_filepath_with_entitlements = ['gen_snapshot_arm64', 'gen_snapshot_x64']
+  snapshot_filepath_with_entitlements = [
+      'gen_snapshot_arm64', 'gen_snapshot_x64'
+  ]
 
   embed_codesign_configuration(
-    os.path.join(dst, 'entitlements.txt'), snapshot_filepath_with_entitlements
+      os.path.join(dst, 'entitlements.txt'), snapshot_filepath_with_entitlements
   )
-  
+
   subprocess.check_call([
       'zip',
       '-r',

--- a/sky/tools/create_macos_gen_snapshots.py
+++ b/sky/tools/create_macos_gen_snapshots.py
@@ -66,8 +66,17 @@ def main():
   if args.zip:
     zip_archive(dst)
 
+def embed_codesign_configuration(config_path, contents):
+  with open(config_path, 'w') as f:
+     f.write('\n'.join(contents) + '\n')
 
 def zip_archive(dst):
+  snapshot_filepath_with_entitlements = ['gen_snapshot_arm64', 'gen_snapshot_x64']
+
+  embed_codesign_configuration(
+    os.path.join(dst, 'entitlements.txt'), snapshot_filepath_with_entitlements
+  )
+  
   subprocess.check_call([
       'zip',
       '-r',


### PR DESCRIPTION
context: https://github.com/flutter/engine/pull/36026 moved gensnapshot to generators.

This PR deletes the meta data embedding previously done through BUILD.gn files for gen snapshot, and moves the logic to the generator script.