### PR TITLE
[macOS] Mark move-only classes as such

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMac.h
+++ b/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMac.h
@@ -7,6 +7,7 @@
 
 #import <Cocoa/Cocoa.h>
 
+#include "flutter/fml/macros.h"
 #include "flutter/shell/platform/common/accessibility_bridge.h"
 
 @class FlutterEngine;
@@ -94,6 +95,8 @@ class AccessibilityBridgeMac : public AccessibilityBridge {
 
   __weak FlutterEngine* flutter_engine_;
   __weak FlutterViewController* view_controller_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(AccessibilityBridgeMac);
 };
 
 }  // namespace flutter

--- a/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMac.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMac.h
@@ -9,6 +9,7 @@
 
 #import "flutter/shell/platform/darwin/macos/framework/Headers/FlutterViewController.h"
 
+#include "flutter/fml/macros.h"
 #include "flutter/shell/platform/common/accessibility_bridge.h"
 #include "flutter/shell/platform/common/flutter_platform_node_delegate.h"
 #include "flutter/shell/platform/embedder/embedder.h"
@@ -56,6 +57,8 @@ class FlutterPlatformNodeDelegateMac : public FlutterPlatformNodeDelegate {
       const gfx::RectF& local_bounds) const;
   gfx::RectF ConvertBoundsFromScreenToGlobal(
       const gfx::RectF& window_bounds) const;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(FlutterPlatformNodeDelegateMac);
 };
 
 }  // namespace flutter

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputSemanticsObject.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputSemanticsObject.h
@@ -6,6 +6,7 @@
 
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMac.h"
 
+#include "flutter/fml/macros.h"
 #include "flutter/third_party/accessibility/ax/platform/ax_platform_node_base.h"
 
 @class FlutterTextField;
@@ -56,6 +57,8 @@ class FlutterTextPlatformNode : public ui::AXPlatformNodeBase {
   /// @brief Detaches the FlutterTextField from the FlutterView if it is not
   ///        already detached.
   void EnsureDetachedFromView();
+
+  FML_DISALLOW_COPY_AND_ASSIGN(FlutterTextPlatformNode);
 };
 
 }  // namespace flutter


### PR DESCRIPTION
Applies the FML_DISALLOW_COPY_AND_ASSIGN to non-POD types in the macOS embedder. Specifically the following three accessibility-related classes:
* FlutterPlatformNodeDelegateMac
* FlutterTextPlatformNode
* AccessibilityBridgeMac

No new tests since no semantic change. Only has the compile-time effect of preventing copying of classes intended to be move-only.


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
