### PR TITLE
[lint + clang tidy] add lint check for python file changes

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -229,6 +229,7 @@ targets:
       - "**.cc"
       - "**.fbs"
       - "**.frag"
+      - "**.py"
       - "**.vert"
 
   - name: Linux Android clang-tidy


### PR DESCRIPTION
Currently, clang tidy targets do not run on presubmit checks if python files are modified.

This PR triggers lint check on presubmits when python files are changed. 