### PR TITLE
Rename WindowPadding to ViewPadding

### DIFF
--- a/lib/ui/fixtures/ui_test.dart
+++ b/lib/ui/fixtures/ui_test.dart
@@ -534,7 +534,7 @@ void hooksTests() async {
     expectEquals(x.countryCode, y.countryCode);
   });
 
-  await test('Window padding/insets/viewPadding/systemGestureInsets', () {
+  await test('View padding/insets/viewPadding/systemGestureInsets', () {
     _callHook(
       '_updateWindowMetrics',
       20,

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -258,25 +258,25 @@ class PlatformDispatcher {
       view: _views[id],
       devicePixelRatio: devicePixelRatio,
       geometry: Rect.fromLTWH(0.0, 0.0, width, height),
-      viewPadding: WindowPadding._(
+      viewPadding: ViewPadding._(
         top: viewPaddingTop,
         right: viewPaddingRight,
         bottom: viewPaddingBottom,
         left: viewPaddingLeft,
       ),
-      viewInsets: WindowPadding._(
+      viewInsets: ViewPadding._(
         top: viewInsetTop,
         right: viewInsetRight,
         bottom: viewInsetBottom,
         left: viewInsetLeft,
       ),
-      padding: WindowPadding._(
+      padding: ViewPadding._(
         top: math.max(0.0, viewPaddingTop - viewInsetTop),
         right: math.max(0.0, viewPaddingRight - viewInsetRight),
         bottom: math.max(0.0, viewPaddingBottom - viewInsetBottom),
         left: math.max(0.0, viewPaddingLeft - viewInsetLeft),
       ),
-      systemGestureInsets: WindowPadding._(
+      systemGestureInsets: ViewPadding._(
         top: math.max(0.0, systemGestureInsetTop),
         right: math.max(0.0, systemGestureInsetRight),
         bottom: math.max(0.0, systemGestureInsetBottom),
@@ -1335,10 +1335,10 @@ class ViewConfiguration {
     this.devicePixelRatio = 1.0,
     this.geometry = Rect.zero,
     this.visible = false,
-    this.viewInsets = WindowPadding.zero,
-    this.viewPadding = WindowPadding.zero,
-    this.systemGestureInsets = WindowPadding.zero,
-    this.padding = WindowPadding.zero,
+    this.viewInsets = ViewPadding.zero,
+    this.viewPadding = ViewPadding.zero,
+    this.systemGestureInsets = ViewPadding.zero,
+    this.padding = ViewPadding.zero,
     this.gestureSettings = const GestureSettings(),
     this.displayFeatures = const <DisplayFeature>[],
   }) : assert(window == null || view == null),
@@ -1356,10 +1356,10 @@ class ViewConfiguration {
     double? devicePixelRatio,
     Rect? geometry,
     bool? visible,
-    WindowPadding? viewInsets,
-    WindowPadding? viewPadding,
-    WindowPadding? systemGestureInsets,
-    WindowPadding? padding,
+    ViewPadding? viewInsets,
+    ViewPadding? viewPadding,
+    ViewPadding? systemGestureInsets,
+    ViewPadding? padding,
     GestureSettings? gestureSettings,
     List<DisplayFeature>? displayFeatures,
   }) {
@@ -1410,53 +1410,53 @@ class ViewConfiguration {
   ///
   /// For instance, if the view doesn't overlap the
   /// [ScreenConfiguration.viewInsets] area, [viewInsets] will be
-  /// [WindowPadding.zero].
+  /// [ViewPadding.zero].
   ///
   /// The number of physical pixels on each side of this view rectangle into
   /// which the application can draw, but over which the operating system will
   /// likely place system UI, such as the keyboard or system menus, that fully
   /// obscures any content.
-  final WindowPadding viewInsets;
+  final ViewPadding viewInsets;
 
   /// The view insets, as it intersects with [ScreenConfiguration.viewPadding]
   /// for the screen it is on.
   ///
   /// For instance, if the view doesn't overlap the
   /// [ScreenConfiguration.viewPadding] area, [viewPadding] will be
-  /// [WindowPadding.zero].
+  /// [ViewPadding.zero].
   ///
   /// The number of physical pixels on each side of this screen rectangle into
   /// which the application can place a view, but which may be partially
   /// obscured by system UI (such as the system notification area), or physical
   /// intrusions in the display (e.g. overscan regions on television screens or
   /// phone sensor housings).
-  final WindowPadding viewPadding;
+  final ViewPadding viewPadding;
 
   /// The view insets, as it intersects with
   /// [ScreenConfiguration.systemGestureInsets] for the screen it is on.
   ///
   /// For instance, if the view doesn't overlap the
   /// [ScreenConfiguration.systemGestureInsets] area, [systemGestureInsets] will
-  /// be [WindowPadding.zero].
+  /// be [ViewPadding.zero].
   ///
   /// The number of physical pixels on each side of this screen rectangle into
   /// which the application can place a view, but where the operating system
   /// will consume input gestures for the sake of system navigation.
-  final WindowPadding systemGestureInsets;
+  final ViewPadding systemGestureInsets;
 
   /// The view insets, as it intersects with [ScreenConfiguration.padding] for
   /// the screen it is on.
   ///
   /// For instance, if the view doesn't overlap the
   /// [ScreenConfiguration.padding] area, [padding] will be
-  /// [WindowPadding.zero].
+  /// [ViewPadding.zero].
   ///
   /// The number of physical pixels on each side of this screen rectangle into
   /// which the application can place a view, but which may be partially
   /// obscured by system UI (such as the system notification area), or physical
   /// intrusions in the display (e.g. overscan regions on television screens or
   /// phone sensor housings).
-  final WindowPadding padding;
+  final ViewPadding padding;
 
   /// Additional configuration for touch gestures performed on this view.
   ///
@@ -1765,8 +1765,8 @@ enum AppLifecycleState {
 ///  * [MediaQuery.of], for the preferred mechanism for accessing these values.
 ///  * [Scaffold], which automatically applies the padding in material design
 ///    applications.
-class WindowPadding {
-  const WindowPadding._({ required this.left, required this.top, required this.right, required this.bottom });
+class ViewPadding {
+  const ViewPadding._({ required this.left, required this.top, required this.right, required this.bottom });
 
   /// The distance from the left edge to the first unpadded pixel, in physical pixels.
   final double left;
@@ -1780,14 +1780,20 @@ class WindowPadding {
   /// The distance from the bottom edge to the first unpadded pixel, in physical pixels.
   final double bottom;
 
-  /// A window padding that has zeros for each edge.
-  static const WindowPadding zero = WindowPadding._(left: 0.0, top: 0.0, right: 0.0, bottom: 0.0);
+  /// A view padding that has zeros for each edge.
+  static const ViewPadding zero = ViewPadding._(left: 0.0, top: 0.0, right: 0.0, bottom: 0.0);
 
   @override
   String toString() {
-    return 'WindowPadding(left: $left, top: $top, right: $right, bottom: $bottom)';
+    return 'ViewPadding(left: $left, top: $top, right: $right, bottom: $bottom)';
   }
 }
+
+/// Deprecated. Will be removed in a future version of Flutter.
+///
+/// Use [ViewPadding] instead.
+// TODO(goderbauer): deprecate this when framework has been migrated to ViewPadding.
+typedef WindowPadding = ViewPadding;
 
 /// Area of the display that may be obstructed by a hardware feature.
 ///

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -153,7 +153,7 @@ class FlutterView {
   ///  * [MediaQuery.of], a simpler mechanism for the same.
   ///  * [Scaffold], which automatically applies the view insets in material
   ///    design applications.
-  WindowPadding get viewInsets => viewConfiguration.viewInsets;
+  ViewPadding get viewInsets => viewConfiguration.viewInsets;
 
   /// The number of physical pixels on each side of the display rectangle into
   /// which the view can render, but which may be partially obscured by system
@@ -179,7 +179,7 @@ class FlutterView {
   ///  * [MediaQuery.of], a simpler mechanism for the same.
   ///  * [Scaffold], which automatically applies the padding in material design
   ///    applications.
-  WindowPadding get viewPadding => viewConfiguration.viewPadding;
+  ViewPadding get viewPadding => viewConfiguration.viewPadding;
 
   /// The number of physical pixels on each side of the display rectangle into
   /// which the view can render, but where the operating system will consume
@@ -196,7 +196,7 @@ class FlutterView {
   ///  * [WidgetsBindingObserver], for a mechanism at the widgets layer to
   ///    observe when this value changes.
   ///  * [MediaQuery.of], a simpler mechanism for the same.
-  WindowPadding get systemGestureInsets => viewConfiguration.systemGestureInsets;
+  ViewPadding get systemGestureInsets => viewConfiguration.systemGestureInsets;
 
   /// The number of physical pixels on each side of the display rectangle into
   /// which the view can render, but which may be partially obscured by system
@@ -224,7 +224,7 @@ class FlutterView {
   /// * [MediaQuery.of], a simpler mechanism for the same.
   /// * [Scaffold], which automatically applies the padding in material design
   ///   applications.
-  WindowPadding get padding => viewConfiguration.padding;
+  ViewPadding get padding => viewConfiguration.padding;
 
   /// {@macro dart.ui.ViewConfiguration.displayFeatures}
   ///

--- a/lib/web_ui/lib/platform_dispatcher.dart
+++ b/lib/web_ui/lib/platform_dispatcher.dart
@@ -202,10 +202,10 @@ class ViewConfiguration {
     this.devicePixelRatio = 1.0,
     this.geometry = Rect.zero,
     this.visible = false,
-    this.viewInsets = WindowPadding.zero,
-    this.viewPadding = WindowPadding.zero,
-    this.systemGestureInsets = WindowPadding.zero,
-    this.padding = WindowPadding.zero,
+    this.viewInsets = ViewPadding.zero,
+    this.viewPadding = ViewPadding.zero,
+    this.systemGestureInsets = ViewPadding.zero,
+    this.padding = ViewPadding.zero,
     this.gestureSettings = const GestureSettings(),
     this.displayFeatures = const <DisplayFeature>[],
   }) : assert(window == null || view == null),
@@ -222,10 +222,10 @@ class ViewConfiguration {
     double? devicePixelRatio,
     Rect? geometry,
     bool? visible,
-    WindowPadding? viewInsets,
-    WindowPadding? viewPadding,
-    WindowPadding? systemGestureInsets,
-    WindowPadding? padding,
+    ViewPadding? viewInsets,
+    ViewPadding? viewPadding,
+    ViewPadding? systemGestureInsets,
+    ViewPadding? padding,
     GestureSettings? gestureSettings,
     List<DisplayFeature>? displayFeatures,
   }) {
@@ -255,10 +255,10 @@ class ViewConfiguration {
   final double devicePixelRatio;
   final Rect geometry;
   final bool visible;
-  final WindowPadding viewInsets;
-  final WindowPadding viewPadding;
-  final WindowPadding systemGestureInsets;
-  final WindowPadding padding;
+  final ViewPadding viewInsets;
+  final ViewPadding viewPadding;
+  final ViewPadding systemGestureInsets;
+  final ViewPadding padding;
   final GestureSettings gestureSettings;
   final List<DisplayFeature> displayFeatures;
 
@@ -375,23 +375,23 @@ enum AppLifecycleState {
   detached,
 }
 
-abstract class WindowPadding {
-  const factory WindowPadding._(
+abstract class ViewPadding {
+  const factory ViewPadding._(
       {required double left,
       required double top,
       required double right,
-      required double bottom}) = engine.WindowPadding;
+      required double bottom}) = engine.ViewPadding;
 
   double get left;
   double get top;
   double get right;
   double get bottom;
 
-  static const WindowPadding zero = WindowPadding._(left: 0.0, top: 0.0, right: 0.0, bottom: 0.0);
+  static const ViewPadding zero = ViewPadding._(left: 0.0, top: 0.0, right: 0.0, bottom: 0.0);
 
   @override
   String toString() {
-    return 'WindowPadding(left: $left, top: $top, right: $right, bottom: $bottom)';
+    return 'ViewPadding(left: $left, top: $top, right: $right, bottom: $bottom)';
   }
 }
 

--- a/lib/web_ui/lib/platform_dispatcher.dart
+++ b/lib/web_ui/lib/platform_dispatcher.dart
@@ -395,6 +395,8 @@ abstract class ViewPadding {
   }
 }
 
+typedef WindowPadding = ViewPadding;
+
 class DisplayFeature {
   const DisplayFeature({
     required this.bounds,

--- a/lib/web_ui/lib/src/engine/view_embedder/dimensions_provider/custom_element_dimensions_provider.dart
+++ b/lib/web_ui/lib/src/engine/view_embedder/dimensions_provider/custom_element_dimensions_provider.dart
@@ -74,11 +74,11 @@ class CustomElementDimensionsProvider extends DimensionsProvider {
   }
 
   @override
-  WindowPadding computeKeyboardInsets(
+  ViewPadding computeKeyboardInsets(
     double physicalHeight,
     bool isEditingOnMobile,
   ) {
-    return const WindowPadding(
+    return const ViewPadding(
       top: 0,
       right: 0,
       bottom: 0,

--- a/lib/web_ui/lib/src/engine/view_embedder/dimensions_provider/dimensions_provider.dart
+++ b/lib/web_ui/lib/src/engine/view_embedder/dimensions_provider/dimensions_provider.dart
@@ -48,8 +48,8 @@ abstract class DimensionsProvider {
   /// pending DOM writes.
   ui.Size computePhysicalSize();
 
-  /// Returns the [WindowPadding] of the keyboard insets (if present).
-  WindowPadding computeKeyboardInsets(
+  /// Returns the [ViewPadding] of the keyboard insets (if present).
+  ViewPadding computeKeyboardInsets(
     double physicalHeight,
     bool isEditingOnMobile,
   );

--- a/lib/web_ui/lib/src/engine/view_embedder/dimensions_provider/full_page_dimensions_provider.dart
+++ b/lib/web_ui/lib/src/engine/view_embedder/dimensions_provider/full_page_dimensions_provider.dart
@@ -98,7 +98,7 @@ class FullPageDimensionsProvider extends DimensionsProvider {
   }
 
   @override
-  WindowPadding computeKeyboardInsets(
+  ViewPadding computeKeyboardInsets(
     double physicalHeight,
     bool isEditingOnMobile,
   ) {
@@ -118,6 +118,6 @@ class FullPageDimensionsProvider extends DimensionsProvider {
     }
     final double bottomPadding = physicalHeight - windowInnerHeight;
 
-    return WindowPadding(bottom: bottomPadding, left: 0, right: 0, top: 0);
+    return ViewPadding(bottom: bottomPadding, left: 0, right: 0, top: 0);
   }
 }

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -296,8 +296,8 @@ class EngineFlutterWindow extends ui.SingletonFlutterWindow {
   }
 
   @override
-  WindowPadding get viewInsets => _viewInsets;
-  WindowPadding _viewInsets = ui.WindowPadding.zero as WindowPadding;
+  ViewPadding get viewInsets => _viewInsets;
+  ViewPadding _viewInsets = ui.ViewPadding.zero as ViewPadding;
 
   /// Lazily populated and cleared at the end of the frame.
   ui.Size? _physicalSize;
@@ -351,9 +351,9 @@ class EngineSingletonFlutterWindow extends EngineFlutterWindow {
 final EngineSingletonFlutterWindow window =
     EngineSingletonFlutterWindow(kImplicitViewId, EnginePlatformDispatcher.instance);
 
-/// The Web implementation of [ui.WindowPadding].
-class WindowPadding implements ui.WindowPadding {
-  const WindowPadding({
+/// The Web implementation of [ui.ViewPadding].
+class ViewPadding implements ui.ViewPadding {
+  const ViewPadding({
     required this.left,
     required this.top,
     required this.right,

--- a/lib/web_ui/lib/window.dart
+++ b/lib/web_ui/lib/window.dart
@@ -11,10 +11,10 @@ abstract class FlutterView {
   double get devicePixelRatio => viewConfiguration.devicePixelRatio;
   Rect get physicalGeometry => viewConfiguration.geometry;
   Size get physicalSize => viewConfiguration.geometry.size;
-  WindowPadding get viewInsets => viewConfiguration.viewInsets;
-  WindowPadding get viewPadding => viewConfiguration.viewPadding;
-  WindowPadding get systemGestureInsets => viewConfiguration.systemGestureInsets;
-  WindowPadding get padding => viewConfiguration.padding;
+  ViewPadding get viewInsets => viewConfiguration.viewInsets;
+  ViewPadding get viewPadding => viewConfiguration.viewPadding;
+  ViewPadding get systemGestureInsets => viewConfiguration.systemGestureInsets;
+  ViewPadding get padding => viewConfiguration.padding;
   List<DisplayFeature> get displayFeatures => viewConfiguration.displayFeatures;
   void render(Scene scene) => platformDispatcher.render(scene, this);
   void updateSemantics(SemanticsUpdate update) => platformDispatcher.updateSemantics(update);

--- a/lib/web_ui/test/engine/view_embedder/dimensions_provider/custom_element_dimensions_provider_test.dart
+++ b/lib/web_ui/test/engine/view_embedder/dimensions_provider/custom_element_dimensions_provider_test.dart
@@ -79,7 +79,7 @@ void doTests() {
       final double physicalHeight =
           (domWindow.visualViewport!.height! + keyboardGap) * dpr;
 
-      final WindowPadding computed =
+      final ViewPadding computed =
           provider.computeKeyboardInsets(physicalHeight, false);
 
       expect(computed.top, 0);

--- a/lib/web_ui/test/engine/view_embedder/dimensions_provider/full_page_dimensions_provider_test.dart
+++ b/lib/web_ui/test/engine/view_embedder/dimensions_provider/full_page_dimensions_provider_test.dart
@@ -53,7 +53,7 @@ void doTests() {
           (domWindow.visualViewport!.height! + keyboardGap) * dpr;
       const double expectedBottom = keyboardGap * dpr;
 
-      final WindowPadding computed =
+      final ViewPadding computed =
           provider.computeKeyboardInsets(physicalHeight, false);
 
       expect(computed.top, 0);


### PR DESCRIPTION
`WindowPadding` is a view concept. Let's rename it to `ViewPadding` to avoid any confusion that this is related to the window concept that the multi-window support will introduce.

Part of https://github.com/flutter/flutter/issues/116929.