### PR TITLE
[Windows] Mark move-only classes as such

### DIFF
--- a/shell/platform/windows/accessibility_bridge_windows.h
+++ b/shell/platform/windows/accessibility_bridge_windows.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_ACCESSIBILITY_BRIDGE_WINDOWS_H_
 #define FLUTTER_SHELL_PLATFORM_WINDOWS_ACCESSIBILITY_BRIDGE_WINDOWS_H_
 
+#include "flutter/fml/macros.h"
 #include "flutter/shell/platform/common/accessibility_bridge.h"
 #include "flutter/third_party/accessibility/ax/platform/ax_fragment_root_delegate_win.h"
 
@@ -71,6 +72,8 @@ class AccessibilityBridgeWindows : public AccessibilityBridge,
  private:
   FlutterWindowsEngine* engine_;
   FlutterWindowsView* view_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(AccessibilityBridgeWindows);
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/accessibility_bridge_windows_unittests.cc
+++ b/shell/platform/windows/accessibility_bridge_windows_unittests.cc
@@ -10,6 +10,7 @@
 
 #include <vector>
 
+#include "flutter/fml/macros.h"
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/embedder/test_utils/proc_table_replacement.h"
 #include "flutter/shell/platform/windows/flutter_platform_node_delegate_windows.h"
@@ -66,6 +67,8 @@ class AccessibilityBridgeWindowsSpy : public AccessibilityBridgeWindows {
  private:
   std::vector<MsaaEvent> dispatched_events_;
   std::vector<int32_t> focused_nodes_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(AccessibilityBridgeWindowsSpy);
 };
 
 // A FlutterWindowsEngine whose accessibility bridge is a
@@ -81,6 +84,9 @@ class FlutterWindowsEngineSpy : public FlutterWindowsEngine {
       FlutterWindowsView* view) override {
     return std::make_shared<AccessibilityBridgeWindowsSpy>(engine, view);
   }
+
+ private:
+  FML_DISALLOW_COPY_AND_ASSIGN(FlutterWindowsEngineSpy);
 };
 
 // Returns an engine instance configured with dummy project path values, and

--- a/shell/platform/windows/angle_surface_manager.h
+++ b/shell/platform/windows/angle_surface_manager.h
@@ -18,7 +18,8 @@
 #include <wrl/client.h>
 #include <memory>
 
-#include "window_binding_handler.h"
+#include "flutter/fml/macros.h"
+#include "flutter/shell/platform/windows/window_binding_handler.h"
 
 namespace flutter {
 
@@ -28,10 +29,6 @@ class AngleSurfaceManager {
  public:
   static std::unique_ptr<AngleSurfaceManager> Create();
   ~AngleSurfaceManager();
-
-  // Disallow copy/move.
-  AngleSurfaceManager(const AngleSurfaceManager&) = delete;
-  AngleSurfaceManager& operator=(const AngleSurfaceManager&) = delete;
 
   // Creates an EGLSurface wrapper and backing DirectX 11 SwapChain
   // associated with window, in the appropriate format for display.
@@ -125,6 +122,8 @@ class AngleSurfaceManager {
 
   // Number of active instances of AngleSurfaceManager
   static int instance_count_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(AngleSurfaceManager);
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/cursor_handler.h
+++ b/shell/platform/windows/cursor_handler.h
@@ -7,6 +7,7 @@
 
 #include <unordered_map>
 
+#include "flutter/fml/macros.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/binary_messenger.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/encodable_value.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/method_channel.h"
@@ -37,6 +38,8 @@ class CursorHandler {
 
   // The cache map for custom cursors.
   std::unordered_map<std::string, HCURSOR> custom_cursors_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(CursorHandler);
 };
 
 // Create a cursor from a rawBGRA buffer and the cursor info.

--- a/shell/platform/windows/cursor_handler_unittests.cc
+++ b/shell/platform/windows/cursor_handler_unittests.cc
@@ -6,6 +6,7 @@
 #include <memory>
 #include <vector>
 
+#include "flutter/fml/macros.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/method_result_functions.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/standard_message_codec.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/standard_method_codec.h"
@@ -53,6 +54,10 @@ void SimulateCursorMessage(TestBinaryMessenger* messenger,
 }  // namespace
 
 class CursorHandlerTest : public WindowsTest {
+ public:
+  CursorHandlerTest() = default;
+  virtual ~CursorHandlerTest() = default;
+
  protected:
   FlutterWindowsEngine* engine() { return engine_.get(); }
   FlutterWindowsView* view() { return view_.get(); }
@@ -83,6 +88,8 @@ class CursorHandlerTest : public WindowsTest {
   std::unique_ptr<FlutterWindowsEngine> engine_;
   std::unique_ptr<FlutterWindowsView> view_;
   MockWindowBindingHandler* window_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(CursorHandlerTest);
 };
 
 TEST_F(CursorHandlerTest, ActivateSystemCursor) {

--- a/shell/platform/windows/direct_manipulation_unittests.cc
+++ b/shell/platform/windows/direct_manipulation_unittests.cc
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include "flutter/shell/platform/windows/direct_manipulation.h"
-#include "flutter/shell/platform/windows/testing/mock_window_binding_handler_delegate.h"
 
+#include "flutter/fml/macros.h"
+#include "flutter/shell/platform/windows/testing/mock_window_binding_handler_delegate.h"
 #include "gtest/gtest.h"
 
 using testing::_;
@@ -16,11 +17,6 @@ class MockIDirectManipulationViewport : public IDirectManipulationViewport {
  public:
   MockIDirectManipulationViewport() {}
 
-  // Prevent copying.
-  MockIDirectManipulationViewport(MockIDirectManipulationViewport const&) =
-      delete;
-  MockIDirectManipulationViewport& operator=(
-      MockIDirectManipulationViewport const&) = delete;
   MOCK_METHOD0_WITH_CALLTYPE(STDMETHODCALLTYPE, AddRef, ULONG());
   MOCK_METHOD0_WITH_CALLTYPE(STDMETHODCALLTYPE, Release, ULONG());
   MOCK_METHOD2_WITH_CALLTYPE(STDMETHODCALLTYPE,
@@ -101,17 +97,15 @@ class MockIDirectManipulationViewport : public IDirectManipulationViewport {
       STDMETHODCALLTYPE,
       ZoomToRect,
       HRESULT(const float, const float, const float, const float, BOOL));
+
+ private:
+  FML_DISALLOW_COPY_AND_ASSIGN(MockIDirectManipulationViewport);
 };
 
 class MockIDirectManipulationContent : public IDirectManipulationContent {
  public:
   MockIDirectManipulationContent() {}
 
-  // Prevent copying.
-  MockIDirectManipulationContent(MockIDirectManipulationContent const&) =
-      delete;
-  MockIDirectManipulationContent& operator=(
-      MockIDirectManipulationContent const&) = delete;
   MOCK_METHOD0_WITH_CALLTYPE(STDMETHODCALLTYPE, AddRef, ULONG());
   MOCK_METHOD0_WITH_CALLTYPE(STDMETHODCALLTYPE, Release, ULONG());
   MOCK_METHOD2_WITH_CALLTYPE(STDMETHODCALLTYPE,
@@ -139,6 +133,9 @@ class MockIDirectManipulationContent : public IDirectManipulationContent {
   MOCK_METHOD2_WITH_CALLTYPE(STDMETHODCALLTYPE,
                              SyncContentTransform,
                              HRESULT(const float*, DWORD));
+
+ private:
+  FML_DISALLOW_COPY_AND_ASSIGN(MockIDirectManipulationContent);
 };
 
 TEST(DirectManipulationTest, TestGesture) {

--- a/shell/platform/windows/dpi_utils.cc
+++ b/shell/platform/windows/dpi_utils.cc
@@ -4,6 +4,8 @@
 
 #include "dpi_utils.h"
 
+#include "flutter/fml/macros.h"
+
 namespace flutter {
 
 namespace {
@@ -58,6 +60,8 @@ class DpiHelper {
   HMODULE shlib_module_ = nullptr;
   bool dpi_for_window_supported_ = false;
   bool dpi_for_monitor_supported_ = false;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(DpiHelper);
 };
 
 DpiHelper::DpiHelper() {

--- a/shell/platform/windows/event_watcher.h
+++ b/shell/platform/windows/event_watcher.h
@@ -9,6 +9,8 @@
 
 #include <functional>
 
+#include "flutter/fml/macros.h"
+
 namespace flutter {
 
 // A win32 `HANDLE` wrapper for use as a one-time callback.
@@ -28,8 +30,7 @@ class EventWatcher {
   HANDLE handle_;
   HANDLE handle_for_wait_;
 
-  EventWatcher(const EventWatcher&) = delete;
-  EventWatcher& operator=(const EventWatcher&) = delete;
+  FML_DISALLOW_COPY_AND_ASSIGN(EventWatcher);
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/external_texture_d3d.h
+++ b/shell/platform/windows/external_texture_d3d.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_EXTERNAL_TEXTURE_D3D_H_
 #define FLUTTER_SHELL_PLATFORM_WINDOWS_EXTERNAL_TEXTURE_D3D_H_
 
+#include "flutter/fml/macros.h"
 #include "flutter/shell/platform/windows/angle_surface_manager.h"
 #include "flutter/shell/platform/windows/external_texture.h"
 
@@ -42,6 +43,8 @@ class ExternalTextureD3d : public ExternalTexture {
   GLuint gl_texture_ = 0;
   EGLSurface egl_surface_ = EGL_NO_SURFACE;
   void* last_surface_handle_ = nullptr;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(ExternalTextureD3d);
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/external_texture_pixelbuffer.h
+++ b/shell/platform/windows/external_texture_pixelbuffer.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_EXTERNAL_TEXTURE_PIXELBUFFER_H_
 #define FLUTTER_SHELL_PLATFORM_WINDOWS_EXTERNAL_TEXTURE_PIXELBUFFER_H_
 
+#include "flutter/fml/macros.h"
 #include "flutter/shell/platform/common/public/flutter_texture_registrar.h"
 #include "flutter/shell/platform/windows/external_texture.h"
 
@@ -38,6 +39,8 @@ class ExternalTexturePixelBuffer : public ExternalTexture {
   void* const user_data_ = nullptr;
   const GlProcs& gl_;
   GLuint gl_texture_ = 0;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(ExternalTexturePixelBuffer);
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/flutter_desktop_messenger.h
+++ b/shell/platform/windows/flutter_desktop_messenger.h
@@ -8,6 +8,7 @@
 #include <atomic>
 #include <mutex>
 
+#include "flutter/fml/macros.h"
 #include "flutter/shell/platform/common/public/flutter_messenger.h"
 
 namespace flutter {
@@ -68,16 +69,15 @@ class FlutterDesktopMessenger {
   /// |FlutterDesktopMessenger| (ie |engine|).
   std::mutex& GetMutex() { return mutex_; }
 
-  FlutterDesktopMessenger(const FlutterDesktopMessenger& value) = delete;
-  FlutterDesktopMessenger& operator=(const FlutterDesktopMessenger& value) =
-      delete;
-
  private:
   // The engine that owns this state object.
   flutter::FlutterWindowsEngine* engine = nullptr;
   std::mutex mutex_;
   std::atomic<int32_t> ref_count_ = 0;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(FlutterDesktopMessenger);
 };
+
 }  // namespace flutter
 
 #endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_FLUTTER_WINDOW_STATE_H_

--- a/shell/platform/windows/flutter_platform_node_delegate_windows.h
+++ b/shell/platform/windows/flutter_platform_node_delegate_windows.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_FLUTTER_PLATFORM_NODE_DELEGATE_WINDOWS_H_
 #define FLUTTER_SHELL_PLATFORM_WINDOWS_FLUTTER_PLATFORM_NODE_DELEGATE_WINDOWS_H_
 
+#include "flutter/fml/macros.h"
 #include "flutter/shell/platform/common/flutter_platform_node_delegate.h"
 #include "flutter/shell/platform/windows/flutter_windows_view.h"
 #include "flutter/third_party/accessibility/ax/platform/ax_platform_node.h"
@@ -58,6 +59,8 @@ class FlutterPlatformNodeDelegateWindows : public FlutterPlatformNodeDelegate {
   ui::AXPlatformNode* ax_platform_node_;
   std::weak_ptr<AccessibilityBridge> bridge_;
   FlutterWindowsView* view_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(FlutterPlatformNodeDelegateWindows);
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/flutter_window.h
+++ b/shell/platform/windows/flutter_window.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 
+#include "flutter/fml/macros.h"
 #include "flutter/shell/platform/common/geometry.h"
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/windows/flutter_windows_view.h"
@@ -168,6 +169,8 @@ class FlutterWindow : public Window, public WindowBindingHandler {
 
   // The cursor rect set by Flutter.
   RECT cursor_rect_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(FlutterWindow);
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/flutter_window_unittests.cc
+++ b/shell/platform/windows/flutter_window_unittests.cc
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "flutter/fml/macros.h"
 #include "flutter/shell/platform/windows/testing/flutter_window_test.h"
 #include "flutter/shell/platform/windows/testing/mock_window_binding_handler.h"
 #include "flutter/shell/platform/windows/testing/mock_window_binding_handler_delegate.h"
@@ -27,10 +28,6 @@ class MockFlutterWindow : public FlutterWindow {
         .WillByDefault(Return(this->FlutterWindow::GetDpiScale()));
   }
   virtual ~MockFlutterWindow() {}
-
-  // Prevent copying.
-  MockFlutterWindow(MockFlutterWindow const&) = delete;
-  MockFlutterWindow& operator=(MockFlutterWindow const&) = delete;
 
   // Wrapper for GetCurrentDPI() which is a protected method.
   UINT GetDpi() { return GetCurrentDPI(); }
@@ -73,6 +70,9 @@ class MockFlutterWindow : public FlutterWindow {
                              LPARAM lParam) override {
     return kWmResultDefault;
   }
+
+ private:
+  FML_DISALLOW_COPY_AND_ASSIGN(MockFlutterWindow);
 };
 
 class MockFlutterWindowsView : public FlutterWindowsView {
@@ -83,6 +83,9 @@ class MockFlutterWindowsView : public FlutterWindowsView {
 
   MOCK_METHOD2(NotifyWinEventWrapper,
                void(ui::AXPlatformNodeWin*, ax::mojom::Event));
+
+ private:
+  FML_DISALLOW_COPY_AND_ASSIGN(MockFlutterWindowsView);
 };
 
 }  // namespace

--- a/shell/platform/windows/flutter_windows_engine.h
+++ b/shell/platform/windows/flutter_windows_engine.h
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "flutter/fml/closure.h"
+#include "flutter/fml/macros.h"
 #include "flutter/shell/platform/common/accessibility_bridge.h"
 #include "flutter/shell/platform/common/client_wrapper/binary_messenger_impl.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/basic_message_channel.h"
@@ -83,10 +84,6 @@ class FlutterWindowsEngine {
       : FlutterWindowsEngine(project, std::make_unique<WindowsRegistry>()) {}
 
   virtual ~FlutterWindowsEngine();
-
-  // Prevent copying.
-  FlutterWindowsEngine(FlutterWindowsEngine const&) = delete;
-  FlutterWindowsEngine& operator=(FlutterWindowsEngine const&) = delete;
 
   // Starts running the entrypoint function specifed in the project bundle. If
   // unspecified, defaults to main().
@@ -396,6 +393,8 @@ class FlutterWindowsEngine {
 
   // Wrapper providing Windows registry access.
   std::unique_ptr<WindowsRegistry> windows_registry_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(FlutterWindowsEngine);
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/flutter_windows_engine_unittests.cc
+++ b/shell/platform/windows/flutter_windows_engine_unittests.cc
@@ -4,6 +4,7 @@
 
 #include "flutter/shell/platform/windows/flutter_windows_engine.h"
 
+#include "flutter/fml/macros.h"
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/embedder/test_utils/proc_table_replacement.h"
 #include "flutter/shell/platform/windows/flutter_windows_view.h"
@@ -570,6 +571,9 @@ class MockFlutterWindowsView : public FlutterWindowsView {
 
   MOCK_METHOD2(NotifyWinEventWrapper,
                void(ui::AXPlatformNodeWin*, ax::mojom::Event));
+
+ private:
+  FML_DISALLOW_COPY_AND_ASSIGN(MockFlutterWindowsView);
 };
 
 TEST_F(FlutterWindowsEngineTest, AlertPlatformMessage) {

--- a/shell/platform/windows/flutter_windows_texture_registrar.h
+++ b/shell/platform/windows/flutter_windows_texture_registrar.h
@@ -10,6 +10,7 @@
 #include <unordered_map>
 
 #include "flutter/fml/closure.h"
+#include "flutter/fml/macros.h"
 #include "flutter/shell/platform/common/public/flutter_texture_registrar.h"
 #include "flutter/shell/platform/windows/external_texture.h"
 
@@ -56,6 +57,8 @@ class FlutterWindowsTextureRegistrar {
   std::mutex map_mutex_;
 
   int64_t EmplaceTexture(std::unique_ptr<ExternalTexture> texture);
+
+  FML_DISALLOW_COPY_AND_ASSIGN(FlutterWindowsTextureRegistrar);
 };
 
 };  // namespace flutter

--- a/shell/platform/windows/flutter_windows_view.h
+++ b/shell/platform/windows/flutter_windows_view.h
@@ -12,6 +12,7 @@
 #include <utility>
 #include <vector>
 
+#include "flutter/fml/macros.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/plugin_registrar.h"
 #include "flutter/shell/platform/common/geometry.h"
 #include "flutter/shell/platform/embedder/embedder.h"
@@ -372,6 +373,8 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate,
 
   // True when flutter's semantics tree is enabled.
   bool semantics_enabled_ = false;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(FlutterWindowsView);
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/keyboard_key_channel_handler.h
+++ b/shell/platform/windows/keyboard_key_channel_handler.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <string>
 
+#include "flutter/fml/macros.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/basic_message_channel.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/binary_messenger.h"
 #include "flutter/shell/platform/windows/keyboard_key_handler.h"
@@ -43,6 +44,8 @@ class KeyboardKeyChannelHandler
  private:
   // The Flutter system channel for key event messages.
   std::unique_ptr<flutter::BasicMessageChannel<rapidjson::Document>> channel_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(KeyboardKeyChannelHandler);
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/keyboard_key_embedder_handler.h
+++ b/shell/platform/windows/keyboard_key_embedder_handler.h
@@ -10,6 +10,7 @@
 #include <memory>
 #include <string>
 
+#include "flutter/fml/macros.h"
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/windows/keyboard_key_handler.h"
 
@@ -191,6 +192,8 @@ class KeyboardKeyEmbedderHandler
 
   // The plane value for the private keys defined by the GTK embedding.
   static const uint64_t windowsPlane;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(KeyboardKeyEmbedderHandler);
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/keyboard_key_handler.h
+++ b/shell/platform/windows/keyboard_key_handler.h
@@ -10,6 +10,7 @@
 #include <memory>
 #include <string>
 
+#include "flutter/fml/macros.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/basic_message_channel.h"
 #include "flutter/shell/platform/windows/keyboard_handler_base.h"
 #include "rapidjson/document.h"
@@ -121,6 +122,8 @@ class KeyboardKeyHandler : public KeyboardHandlerBase {
 
   // The sequence_id attached to the last event sent to the framework.
   uint64_t last_sequence_id_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(KeyboardKeyHandler);
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/keyboard_key_handler_unittests.cc
+++ b/shell/platform/windows/keyboard_key_handler_unittests.cc
@@ -6,6 +6,7 @@
 #include <rapidjson/document.h>
 #include <memory>
 
+#include "flutter/fml/macros.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -94,6 +95,9 @@ class MockKeyHandlerDelegate
   CallbackHandler callback_handler;
   int delegate_id;
   std::list<KeyboardHookCall>* hook_history;
+
+ private:
+  FML_DISALLOW_COPY_AND_ASSIGN(MockKeyHandlerDelegate);
 };
 
 enum KeyEventResponse {

--- a/shell/platform/windows/keyboard_manager.h
+++ b/shell/platform/windows/keyboard_manager.h
@@ -6,10 +6,13 @@
 #define FLUTTER_SHELL_PLATFORM_WINDOWS_KEYBOARD_MANAGER_H_
 
 #include <windows.h>
+
 #include <atomic>
 #include <deque>
 #include <functional>
 #include <map>
+
+#include "flutter/fml/macros.h"
 
 namespace flutter {
 
@@ -225,6 +228,8 @@ class KeyboardManager {
   // The queue of messages that have been redispatched to the system but have
   // not yet been received for a second time.
   std::deque<Win32Message> pending_redispatches_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(KeyboardManager);
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/keyboard_unittests.cc
+++ b/shell/platform/windows/keyboard_unittests.cc
@@ -115,6 +115,8 @@ class TestKeyboardManager : public KeyboardManager {
 
  private:
   bool during_redispatch_ = false;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(TestKeyboardManager);
 };
 
 // Injecting this kind of keyboard change means that a key state (the true
@@ -314,6 +316,8 @@ class MockKeyboardManagerDelegate : public KeyboardManager::WindowDelegate,
   MapVirtualKeyToChar map_vk_to_char_;
   TestKeystate key_state_;
   std::list<Win32Message> redispatched_messages_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(MockKeyboardManagerDelegate);
 };
 
 typedef struct {
@@ -353,6 +357,9 @@ class TestFlutterWindowsView : public FlutterWindowsView {
         .text = text,
     });
   }
+
+ private:
+  FML_DISALLOW_COPY_AND_ASSIGN(TestFlutterWindowsView);
 };
 
 class KeyboardTester {
@@ -515,9 +522,19 @@ class KeyboardTester {
       callback(value);
     };
   }
+
+ private:
+  FML_DISALLOW_COPY_AND_ASSIGN(KeyboardTester);
 };
 
-class KeyboardTest : public WindowsTest {};
+class KeyboardTest : public WindowsTest {
+ public:
+  KeyboardTest() = default;
+  virtual ~KeyboardTest() = default;
+
+ private:
+  FML_DISALLOW_COPY_AND_ASSIGN(KeyboardTest);
+};
 
 }  // namespace
 

--- a/shell/platform/windows/platform_handler.cc
+++ b/shell/platform/windows/platform_handler.cc
@@ -10,6 +10,7 @@
 #include <optional>
 
 #include "flutter/fml/logging.h"
+#include "flutter/fml/macros.h"
 #include "flutter/fml/platform/win/wstring_conversion.h"
 #include "flutter/shell/platform/common/json_method_codec.h"
 #include "flutter/shell/platform/windows/flutter_windows_view.h"
@@ -55,10 +56,6 @@ class ScopedGlobalMemory {
     }
   }
 
-  // Prevent copying.
-  ScopedGlobalMemory(ScopedGlobalMemory const&) = delete;
-  ScopedGlobalMemory& operator=(ScopedGlobalMemory const&) = delete;
-
   // Returns the memory pointer, which will be nullptr if allocation failed.
   void* get() { return memory_; }
 
@@ -70,6 +67,8 @@ class ScopedGlobalMemory {
 
  private:
   HGLOBAL memory_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(ScopedGlobalMemory);
 };
 
 // A scoped wrapper for GlobalLock/GlobalUnlock.
@@ -98,10 +97,6 @@ class ScopedGlobalLock {
     }
   }
 
-  // Prevent copying.
-  ScopedGlobalLock(ScopedGlobalLock const&) = delete;
-  ScopedGlobalLock& operator=(ScopedGlobalLock const&) = delete;
-
   // Returns the locked memory pointer, which will be nullptr if acquiring the
   // lock failed.
   void* get() { return locked_memory_; }
@@ -109,6 +104,8 @@ class ScopedGlobalLock {
  private:
   HGLOBAL source_;
   void* locked_memory_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(ScopedGlobalLock);
 };
 
 // A Clipboard wrapper that automatically closes the clipboard when it goes out
@@ -117,10 +114,6 @@ class ScopedClipboard : public ScopedClipboardInterface {
  public:
   ScopedClipboard();
   virtual ~ScopedClipboard();
-
-  // Prevent copying.
-  ScopedClipboard(ScopedClipboard const&) = delete;
-  ScopedClipboard& operator=(ScopedClipboard const&) = delete;
 
   int Open(HWND window) override;
 
@@ -132,6 +125,8 @@ class ScopedClipboard : public ScopedClipboardInterface {
 
  private:
   bool opened_ = false;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(ScopedClipboard);
 };
 
 ScopedClipboard::ScopedClipboard() {}

--- a/shell/platform/windows/platform_handler.h
+++ b/shell/platform/windows/platform_handler.h
@@ -12,6 +12,7 @@
 #include <optional>
 #include <variant>
 
+#include "flutter/fml/macros.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/binary_messenger.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/method_channel.h"
 #include "rapidjson/document.h"
@@ -76,6 +77,8 @@ class PlatformHandler {
   // unnecessarily. See flutter/flutter#103205.
   std::function<std::unique_ptr<ScopedClipboardInterface>()>
       scoped_clipboard_provider_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(PlatformHandler);
 };
 
 // A public interface for ScopedClipboard, so that it can be injected into

--- a/shell/platform/windows/platform_handler_unittests.cc
+++ b/shell/platform/windows/platform_handler_unittests.cc
@@ -6,6 +6,7 @@
 
 #include <memory>
 
+#include "flutter/fml/macros.h"
 #include "flutter/shell/platform/common/json_method_codec.h"
 #include "flutter/shell/platform/windows/flutter_windows_view.h"
 #include "flutter/shell/platform/windows/testing/flutter_windows_engine_builder.h"
@@ -69,15 +70,24 @@ class MockPlatformHandler : public PlatformHandler {
   MOCK_METHOD2(SystemSoundPlay,
                void(const std::string&,
                     std::unique_ptr<MethodResult<rapidjson::Document>>));
+
+ private:
+  FML_DISALLOW_COPY_AND_ASSIGN(MockPlatformHandler);
 };
 
 // A test version of the private ScopedClipboard.
 class MockScopedClipboard : public ScopedClipboardInterface {
  public:
+  MockScopedClipboard() = default;
+  virtual ~MockScopedClipboard() = default;
+
   MOCK_METHOD(int, Open, (HWND window), (override));
   MOCK_METHOD(bool, HasString, (), (override));
   MOCK_METHOD((std::variant<std::wstring, int>), GetString, (), (override));
   MOCK_METHOD(int, SetString, (const std::wstring string), (override));
+
+ private:
+  FML_DISALLOW_COPY_AND_ASSIGN(MockScopedClipboard);
 };
 
 std::string SimulatePlatformMessage(TestBinaryMessenger* messenger,
@@ -98,6 +108,10 @@ std::string SimulatePlatformMessage(TestBinaryMessenger* messenger,
 }  // namespace
 
 class PlatformHandlerTest : public WindowsTest {
+ public:
+  PlatformHandlerTest() = default;
+  virtual ~PlatformHandlerTest() = default;
+
  protected:
   FlutterWindowsEngine* engine() { return engine_.get(); }
 
@@ -120,6 +134,8 @@ class PlatformHandlerTest : public WindowsTest {
  private:
   std::unique_ptr<FlutterWindowsEngine> engine_;
   std::unique_ptr<FlutterWindowsView> view_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(PlatformHandlerTest);
 };
 
 TEST_F(PlatformHandlerTest, GetClipboardData) {

--- a/shell/platform/windows/sequential_id_generator.h
+++ b/shell/platform/windows/sequential_id_generator.h
@@ -8,6 +8,8 @@
 #include <cstdint>
 #include <unordered_map>
 
+#include "flutter/fml/macros.h"
+
 namespace flutter {
 
 // This is used to generate a series of sequential ID numbers in a way that a
@@ -52,6 +54,8 @@ class SequentialIdGenerator {
   const uint32_t min_id_;
   const uint32_t max_id_;
   uint32_t min_available_id_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(SequentialIdGenerator);
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/settings_plugin.h
+++ b/shell/platform/windows/settings_plugin.h
@@ -9,6 +9,7 @@
 
 #include <memory>
 
+#include "flutter/fml/macros.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/basic_message_channel.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/binary_messenger.h"
 #include "flutter/shell/platform/windows/event_watcher.h"
@@ -71,8 +72,7 @@ class SettingsPlugin {
 
   TaskRunner* task_runner_;
 
-  SettingsPlugin(const SettingsPlugin&) = delete;
-  SettingsPlugin& operator=(const SettingsPlugin&) = delete;
+  FML_DISALLOW_COPY_AND_ASSIGN(SettingsPlugin);
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/settings_plugin_unittests.cc
+++ b/shell/platform/windows/settings_plugin_unittests.cc
@@ -1,8 +1,10 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 #include "flutter/shell/platform/windows/settings_plugin.h"
 
+#include "flutter/fml/macros.h"
 #include "flutter/shell/platform/windows/task_runner.h"
 #include "flutter/shell/platform/windows/testing/test_binary_messenger.h"
 #include "gmock/gmock.h"
@@ -30,6 +32,9 @@ class MockSettingsPlugin : public SettingsPlugin {
 
   MOCK_METHOD0(WatchPreferredBrightnessChanged, void());
   MOCK_METHOD0(WatchTextScaleFactorChanged, void());
+
+ private:
+  FML_DISALLOW_COPY_AND_ASSIGN(MockSettingsPlugin);
 };
 
 }  // namespace

--- a/shell/platform/windows/system_utils_unittests.cc
+++ b/shell/platform/windows/system_utils_unittests.cc
@@ -5,6 +5,7 @@
 #include <cstring>
 #include <cwchar>
 
+#include "flutter/fml/macros.h"
 #include "flutter/shell/platform/windows/system_utils.h"
 #include "gtest/gtest.h"
 
@@ -13,7 +14,8 @@ namespace testing {
 
 class MockWindowsRegistry : public WindowsRegistry {
  public:
-  virtual ~MockWindowsRegistry() {}
+  MockWindowsRegistry() = default;
+  virtual ~MockWindowsRegistry() = default;
 
   virtual LSTATUS GetRegistryValue(HKEY hkey,
                                    LPCWSTR key,
@@ -37,6 +39,9 @@ class MockWindowsRegistry : public WindowsRegistry {
     }
     return ERROR_SUCCESS;
   }
+
+ private:
+  FML_DISALLOW_COPY_AND_ASSIGN(MockWindowsRegistry);
 };
 
 TEST(SystemUtils, GetPreferredLanguageInfo) {

--- a/shell/platform/windows/task_runner.h
+++ b/shell/platform/windows/task_runner.h
@@ -102,8 +102,7 @@ class TaskRunner : public TaskRunnerWindow::Delegate {
   DWORD main_thread_id_;
   std::shared_ptr<TaskRunnerWindow> task_runner_window_;
 
-  TaskRunner(const TaskRunner&) = delete;
-  TaskRunner& operator=(const TaskRunner&) = delete;
+  FML_DISALLOW_COPY_AND_ASSIGN(TaskRunner);
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/task_runner_unittests.cc
+++ b/shell/platform/windows/task_runner_unittests.cc
@@ -4,6 +4,7 @@
 
 #include "flutter/shell/platform/windows/task_runner.h"
 
+#include "flutter/fml/macros.h"
 #include "gtest/gtest.h"
 
 namespace flutter {
@@ -31,6 +32,9 @@ class MockTaskRunner : public TaskRunner {
         std::chrono::duration_cast<std::chrono::steady_clock::duration>(
             std::chrono::nanoseconds(10000)));
   }
+
+ private:
+  FML_DISALLOW_COPY_AND_ASSIGN(MockTaskRunner);
 };
 
 uint64_t MockGetCurrentTime() {

--- a/shell/platform/windows/task_runner_window.h
+++ b/shell/platform/windows/task_runner_window.h
@@ -12,6 +12,8 @@
 #include <string>
 #include <vector>
 
+#include "flutter/fml/macros.h"
+
 namespace flutter {
 
 // Hidden HWND responsible for processing flutter tasks on main thread
@@ -58,6 +60,8 @@ class TaskRunnerWindow {
   HWND window_handle_;
   std::wstring window_class_name_;
   std::vector<Delegate*> delegates_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(TaskRunnerWindow);
 };
 }  // namespace flutter
 

--- a/shell/platform/windows/testing/engine_modifier.h
+++ b/shell/platform/windows/testing/engine_modifier.h
@@ -9,6 +9,8 @@
 
 #include <chrono>
 
+#include "flutter/fml/macros.h"
+
 namespace flutter {
 
 // A test utility class providing the ability to access and alter various
@@ -66,6 +68,8 @@ class EngineModifier {
 
  private:
   FlutterWindowsEngine* engine_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(EngineModifier);
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/testing/flutter_window_test.h
+++ b/shell/platform/windows/testing/flutter_window_test.h
@@ -7,6 +7,8 @@
 
 #include "flutter/shell/platform/windows/flutter_window.h"
 
+#include "flutter/fml/macros.h"
+
 namespace flutter {
 namespace testing {
 
@@ -16,9 +18,8 @@ class FlutterWindowTest : public FlutterWindow {
   FlutterWindowTest(int width, int height);
   virtual ~FlutterWindowTest();
 
-  // Prevent copying.
-  FlutterWindowTest(FlutterWindowTest const&) = delete;
-  FlutterWindowTest& operator=(FlutterWindowTest const&) = delete;
+ private:
+  FML_DISALLOW_COPY_AND_ASSIGN(FlutterWindowTest);
 };
 
 }  // namespace testing

--- a/shell/platform/windows/testing/flutter_windows_engine_builder.cc
+++ b/shell/platform/windows/testing/flutter_windows_engine_builder.cc
@@ -4,6 +4,8 @@
 
 #include "flutter/shell/platform/windows/testing/flutter_windows_engine_builder.h"
 
+#include "flutter/fml/macros.h"
+
 namespace flutter {
 namespace testing {
 
@@ -16,10 +18,6 @@ class TestFlutterWindowsEngine : public FlutterWindowsEngine {
       : FlutterWindowsEngine(project),
         get_key_state_(std::move(get_key_state)),
         map_vk_to_scan_(std::move(map_vk_to_scan)) {}
-
-  // Prevent copying.
-  TestFlutterWindowsEngine(TestFlutterWindowsEngine const&) = delete;
-  TestFlutterWindowsEngine& operator=(TestFlutterWindowsEngine const&) = delete;
 
  protected:
   std::unique_ptr<KeyboardHandlerBase> CreateKeyboardKeyHandler(
@@ -41,6 +39,8 @@ class TestFlutterWindowsEngine : public FlutterWindowsEngine {
  private:
   KeyboardKeyEmbedderHandler::GetKeyStateHandler get_key_state_;
   KeyboardKeyEmbedderHandler::MapVirtualKeyToScanCode map_vk_to_scan_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(TestFlutterWindowsEngine);
 };
 
 FlutterWindowsEngineBuilder::FlutterWindowsEngineBuilder(

--- a/shell/platform/windows/testing/flutter_windows_engine_builder.h
+++ b/shell/platform/windows/testing/flutter_windows_engine_builder.h
@@ -7,6 +7,7 @@
 
 #include <memory>
 
+#include "flutter/fml/macros.h"
 #include "flutter/shell/platform/windows/flutter_windows_engine.h"
 #include "flutter/shell/platform/windows/keyboard_key_embedder_handler.h"
 #include "flutter/shell/platform/windows/public/flutter_windows.h"
@@ -30,11 +31,6 @@ class FlutterWindowsEngineBuilder {
 
   std::unique_ptr<FlutterWindowsEngine> Build();
 
-  // Prevent copying.
-  FlutterWindowsEngineBuilder(FlutterWindowsEngineBuilder const&) = delete;
-  FlutterWindowsEngineBuilder& operator=(FlutterWindowsEngineBuilder const&) =
-      delete;
-
  private:
   WindowsTestContext& context_;
   FlutterDesktopEngineProperties properties_ = {};
@@ -42,6 +38,8 @@ class FlutterWindowsEngineBuilder {
   std::vector<std::string> dart_entrypoint_arguments_;
   KeyboardKeyEmbedderHandler::GetKeyStateHandler get_key_state_;
   KeyboardKeyEmbedderHandler::MapVirtualKeyToScanCode map_vk_to_scan_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(FlutterWindowsEngineBuilder);
 };
 
 }  // namespace testing

--- a/shell/platform/windows/testing/mock_direct_manipulation.h
+++ b/shell/platform/windows/testing/mock_direct_manipulation.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_DIRECT_MANIPULATION_H_
 #define FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_DIRECT_MANIPULATION_H_
 
+#include "flutter/fml/macros.h"
 #include "flutter/shell/platform/windows/direct_manipulation.h"
 #include "gmock/gmock.h"
 

--- a/shell/platform/windows/testing/mock_gl_functions.h
+++ b/shell/platform/windows/testing/mock_gl_functions.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_GL_FUNCTIONS_H_
 #define FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_GL_FUNCTIONS_H_
 
+#include "flutter/fml/macros.h"
 #include "flutter/shell/platform/windows/external_texture.h"
 
 namespace flutter {
@@ -46,6 +47,8 @@ class MockGlFunctions {
 
  private:
   GlProcs gl_procs_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(MockGlFunctions);
 };
 
 }  // namespace testing

--- a/shell/platform/windows/testing/mock_text_input_manager.h
+++ b/shell/platform/windows/testing/mock_text_input_manager.h
@@ -8,6 +8,7 @@
 #include <cstring>
 #include <optional>
 
+#include "flutter/fml/macros.h"
 #include "flutter/shell/platform/windows/text_input_manager.h"
 #include "gmock/gmock.h"
 
@@ -20,13 +21,12 @@ class MockTextInputManager : public TextInputManager {
   MockTextInputManager();
   virtual ~MockTextInputManager();
 
-  // Prevent copying.
-  MockTextInputManager(MockTextInputManager const&) = delete;
-  MockTextInputManager& operator=(MockTextInputManager const&) = delete;
-
   MOCK_CONST_METHOD0(GetComposingString, std::optional<std::u16string>());
   MOCK_CONST_METHOD0(GetResultString, std::optional<std::u16string>());
   MOCK_CONST_METHOD0(GetComposingCursorPosition, long());
+
+ private:
+  FML_DISALLOW_COPY_AND_ASSIGN(MockTextInputManager);
 };
 
 }  // namespace testing

--- a/shell/platform/windows/testing/mock_window.h
+++ b/shell/platform/windows/testing/mock_window.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_WIN32_WINDOW_H_
 #define FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_WIN32_WINDOW_H_
 
+#include "flutter/fml/macros.h"
 #include "flutter/shell/platform/windows/testing/test_keyboard.h"
 #include "flutter/shell/platform/windows/window.h"
 #include "gmock/gmock.h"
@@ -19,10 +20,6 @@ class MockWindow : public Window {
   MockWindow(std::unique_ptr<WindowsProcTable> windows_proc_table,
              std::unique_ptr<TextInputManager> text_input_manager);
   virtual ~MockWindow();
-
-  // Prevent copying.
-  MockWindow(MockWindow const&) = delete;
-  MockWindow& operator=(MockWindow const&) = delete;
 
   // Wrapper for GetCurrentDPI() which is a protected method.
   UINT GetDpi();
@@ -75,6 +72,9 @@ class MockWindow : public Window {
 
  protected:
   LRESULT Win32DefWindowProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam);
+
+ private:
+  FML_DISALLOW_COPY_AND_ASSIGN(MockWindow);
 };
 
 }  // namespace testing

--- a/shell/platform/windows/testing/mock_window_binding_handler.h
+++ b/shell/platform/windows/testing/mock_window_binding_handler.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_WINDOW_BINDING_HANDLER_H_
 #define FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_WINDOW_BINDING_HANDLER_H_
 
+#include "flutter/fml/macros.h"
 #include "flutter/shell/platform/windows/window_binding_handler.h"
 #include "flutter/third_party/accessibility/ax/platform/ax_platform_node_win.h"
 #include "gmock/gmock.h"
@@ -17,10 +18,6 @@ class MockWindowBindingHandler : public WindowBindingHandler {
  public:
   MockWindowBindingHandler();
   virtual ~MockWindowBindingHandler();
-
-  // Prevent copying.
-  MockWindowBindingHandler(MockWindowBindingHandler const&) = delete;
-  MockWindowBindingHandler& operator=(MockWindowBindingHandler const&) = delete;
 
   MOCK_METHOD1(SetView, void(WindowBindingHandlerDelegate* view));
   MOCK_METHOD0(GetRenderTarget, WindowsRenderTarget());
@@ -39,6 +36,9 @@ class MockWindowBindingHandler : public WindowBindingHandler {
   MOCK_METHOD0(SendInitialAccessibilityFeatures, void());
   MOCK_METHOD0(GetAlertDelegate, AlertPlatformNodeDelegate*());
   MOCK_METHOD0(GetAlert, ui::AXPlatformNodeWin*());
+
+ private:
+  FML_DISALLOW_COPY_AND_ASSIGN(MockWindowBindingHandler);
 };
 
 }  // namespace testing

--- a/shell/platform/windows/testing/mock_window_binding_handler_delegate.h
+++ b/shell/platform/windows/testing/mock_window_binding_handler_delegate.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_WINDOW_BINDING_HANDLER_DELEGATE_H_
 #define FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_WINDOW_BINDING_HANDLER_DELEGATE_H_
 
+#include "flutter/fml/macros.h"
 #include "flutter/shell/platform/windows/window_binding_handler_delegate.h"
 #include "gmock/gmock.h"
 
@@ -14,12 +15,6 @@ namespace testing {
 class MockWindowBindingHandlerDelegate : public WindowBindingHandlerDelegate {
  public:
   MockWindowBindingHandlerDelegate() {}
-
-  // Prevent copying.
-  MockWindowBindingHandlerDelegate(MockWindowBindingHandlerDelegate const&) =
-      delete;
-  MockWindowBindingHandlerDelegate& operator=(
-      MockWindowBindingHandlerDelegate const&) = delete;
 
   MOCK_METHOD2(OnWindowSizeChanged, void(size_t, size_t));
   MOCK_METHOD0(OnWindowRepaint, void());
@@ -65,6 +60,9 @@ class MockWindowBindingHandlerDelegate : public WindowBindingHandlerDelegate {
   MOCK_METHOD1(UpdateHighContrastEnabled, void(bool enabled));
 
   MOCK_METHOD0(GetAxFragmentRootDelegate, ui::AXFragmentRootDelegateWin*());
+
+ private:
+  FML_DISALLOW_COPY_AND_ASSIGN(MockWindowBindingHandlerDelegate);
 };
 
 }  // namespace testing

--- a/shell/platform/windows/testing/mock_windows_proc_table.h
+++ b/shell/platform/windows/testing/mock_windows_proc_table.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_WINDOWS_PROC_TABLE_H_
 #define FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_WINDOWS_PROC_TABLE_H_
 
+#include "flutter/fml/macros.h"
 #include "flutter/shell/platform/windows/windows_proc_table.h"
 #include "gmock/gmock.h"
 

--- a/shell/platform/windows/testing/test_binary_messenger.h
+++ b/shell/platform/windows/testing/test_binary_messenger.h
@@ -10,6 +10,7 @@
 #include <string>
 
 #include "flutter/fml/logging.h"
+#include "flutter/fml/macros.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/binary_messenger.h"
 
 namespace flutter {
@@ -27,10 +28,6 @@ class TestBinaryMessenger : public BinaryMessenger {
       : send_handler_(std::move(send_handler)) {}
 
   virtual ~TestBinaryMessenger() = default;
-
-  // Prevent copying.
-  TestBinaryMessenger(TestBinaryMessenger const&) = delete;
-  TestBinaryMessenger& operator=(TestBinaryMessenger const&) = delete;
 
   // Simulates a message from the engine on the given channel.
   //
@@ -73,6 +70,8 @@ class TestBinaryMessenger : public BinaryMessenger {
 
   // Mapping of channel name to registered handlers.
   std::map<std::string, BinaryMessageHandler> registered_handlers_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(TestBinaryMessenger);
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/testing/test_keyboard.h
+++ b/shell/platform/windows/testing/test_keyboard.h
@@ -10,6 +10,7 @@
 #include <functional>
 #include <string>
 
+#include "flutter/fml/macros.h"
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/windows/testing/engine_modifier.h"
 #include "flutter/shell/platform/windows/testing/wm_builders.h"
@@ -99,6 +100,8 @@ class MockKeyResponseController {
                                    ResponseCallback callback) {
     callback(false);
   }
+
+  FML_DISALLOW_COPY_AND_ASSIGN(MockKeyResponseController);
 };
 
 void MockEmbedderApiForKeyboard(

--- a/shell/platform/windows/text_input_manager.cc
+++ b/shell/platform/windows/text_input_manager.cc
@@ -9,6 +9,7 @@
 #include <memory>
 
 #include "flutter/fml/logging.h"
+#include "flutter/fml/macros.h"
 
 namespace flutter {
 
@@ -27,10 +28,6 @@ class ImmContext {
     }
   }
 
-  // Prevent copying.
-  ImmContext(const ImmContext& other) = delete;
-  ImmContext& operator=(const ImmContext& other) = delete;
-
   // Returns true if a valid IMM context has been obtained.
   bool IsValid() const { return context_ != nullptr; }
 
@@ -43,6 +40,8 @@ class ImmContext {
  private:
   HWND window_handle_;
   HIMC context_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(ImmContext);
 };
 
 void TextInputManager::SetWindowHandle(HWND window_handle) {

--- a/shell/platform/windows/text_input_manager.h
+++ b/shell/platform/windows/text_input_manager.h
@@ -11,6 +11,7 @@
 #include <optional>
 #include <string>
 
+#include "flutter/fml/macros.h"
 #include "flutter/shell/platform/common/geometry.h"
 
 namespace flutter {
@@ -29,9 +30,6 @@ class TextInputManager {
  public:
   TextInputManager() noexcept = default;
   virtual ~TextInputManager() = default;
-
-  TextInputManager(const TextInputManager&) = delete;
-  TextInputManager& operator=(const TextInputManager&) = delete;
 
   // Sets the window handle with which the IME is associated.
   void SetWindowHandle(HWND window_handle);
@@ -100,6 +98,8 @@ class TextInputManager {
 
   // The system caret rect.
   Rect caret_rect_ = {{0, 0}, {0, 0}};
+
+  FML_DISALLOW_COPY_AND_ASSIGN(TextInputManager);
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/text_input_plugin.h
+++ b/shell/platform/windows/text_input_plugin.h
@@ -9,6 +9,7 @@
 #include <map>
 #include <memory>
 
+#include "flutter/fml/macros.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/binary_messenger.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/method_channel.h"
 #include "flutter/shell/platform/common/geometry.h"
@@ -107,6 +108,8 @@ class TextInputPlugin {
       0.0, 0.0, 0.0, 0.0,  //
       0.0, 0.0, 0.0, 0.0,  //
       0.0, 0.0, 0.0, 0.0};
+
+  FML_DISALLOW_COPY_AND_ASSIGN(TextInputPlugin);
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/text_input_plugin_unittest.cc
+++ b/shell/platform/windows/text_input_plugin_unittest.cc
@@ -7,6 +7,7 @@
 #include <windows.h>
 #include <memory>
 
+#include "flutter/fml/macros.h"
 #include "flutter/shell/platform/common/json_message_codec.h"
 #include "flutter/shell/platform/common/json_method_codec.h"
 #include "flutter/shell/platform/windows/testing/test_binary_messenger.h"
@@ -40,13 +41,11 @@ class MockTextInputPluginDelegate : public TextInputPluginDelegate {
   MockTextInputPluginDelegate() {}
   virtual ~MockTextInputPluginDelegate() = default;
 
-  // Prevent copying.
-  MockTextInputPluginDelegate(MockTextInputPluginDelegate const&) = delete;
-  MockTextInputPluginDelegate& operator=(MockTextInputPluginDelegate const&) =
-      delete;
-
   MOCK_METHOD1(OnCursorRectUpdated, void(const Rect&));
   MOCK_METHOD0(OnResetImeComposing, void());
+
+ private:
+  FML_DISALLOW_COPY_AND_ASSIGN(MockTextInputPluginDelegate);
 };
 
 }  // namespace

--- a/shell/platform/windows/window_proc_delegate_manager.h
+++ b/shell/platform/windows/window_proc_delegate_manager.h
@@ -10,6 +10,7 @@
 #include <map>
 #include <optional>
 
+#include "flutter/fml/macros.h"
 #include "flutter/shell/platform/windows/public/flutter_windows.h"
 
 namespace flutter {
@@ -20,11 +21,6 @@ class WindowProcDelegateManager {
  public:
   explicit WindowProcDelegateManager();
   ~WindowProcDelegateManager();
-
-  // Prevent copying.
-  WindowProcDelegateManager(WindowProcDelegateManager const&) = delete;
-  WindowProcDelegateManager& operator=(WindowProcDelegateManager const&) =
-      delete;
 
   // Adds |delegate| as a delegate to be called for |OnTopLevelWindowProc|.
   //
@@ -50,6 +46,8 @@ class WindowProcDelegateManager {
  private:
   std::map<FlutterDesktopWindowProcCallback, void*>
       top_level_window_proc_handlers_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(WindowProcDelegateManager);
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/windows_proc_table.h
+++ b/shell/platform/windows/windows_proc_table.h
@@ -5,9 +5,10 @@
 #ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_WINDOWS_PROC_TABLE_H_
 #define FLUTTER_SHELL_PLATFORM_WINDOWS_WINDOWS_PROC_TABLE_H_
 
-#include "flutter/fml/native_library.h"
-
 #include <optional>
+
+#include "flutter/fml/macros.h"
+#include "flutter/fml/native_library.h"
 
 namespace flutter {
 


### PR DESCRIPTION
Applies the FML_DISALLOW_COPY_AND_ASSIGN to non-POD types in the Windows embedder.
Also #includes fml/macros.h in a few places we were already using the macro, but missed int #include.

No new tests since no semantic change. Only has the compile-time effect of preventing copying of classes intended to be move-only.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
