### PR TITLE
[web] Add explicit JS type test for `JsStrategy`.

### DIFF
--- a/lib/web_ui/lib/src/engine/initialization.dart
+++ b/lib/web_ui/lib/src/engine/initialization.dart
@@ -273,8 +273,18 @@ Future<void> _downloadAssetFonts() async {
 
 void _addUrlStrategyListener() {
   jsSetUrlStrategy = allowInterop((JsUrlStrategy? jsStrategy) {
-    customUrlStrategy =
-        jsStrategy == null ? null : CustomUrlStrategy.fromJs(jsStrategy);
+    if (jsStrategy == null) {
+      customUrlStrategy = null;
+    } else {
+      // Because `JSStrategy` could be anything, we check for the
+      // `addPopStateListener` property and throw if it is missing.
+      if (!hasJsProperty(jsStrategy, 'addPopStateListener')) {
+        throw StateError(
+            'Unexpected JsUrlStrategy: $jsStrategy is missing '
+            '`addPopStateListener` property');
+      }
+      customUrlStrategy = CustomUrlStrategy.fromJs(jsStrategy);
+    }
   });
   registerHotRestartListener(() {
     jsSetUrlStrategy = null;

--- a/lib/web_ui/test/window_test.dart
+++ b/lib/web_ui/test/window_test.dart
@@ -435,6 +435,7 @@ void testMain() {
     expect(() => jsSetUrlStrategy(123), throwsA(anything));
     expect(() => jsSetUrlStrategy('foo'), throwsA(anything));
     expect(() => jsSetUrlStrategy(false), throwsA(anything));
+    expect(() => jsSetUrlStrategy(<Object?>[]), throwsA(anything));
   });
 
   test('cannot set url strategy after it is initialized', () async {


### PR DESCRIPTION
Type checking is not well defined with JS interop. A safer approach is to type check JS values in JS using js_util. This CL implements such an explicit test.