### PR TITLE
Updated the wide-gamut constant and added a unit test for it.

### DIFF
--- a/lib/ui/painting/image_decoder_impeller.cc
+++ b/lib/ui/painting/image_decoder_impeller.cc
@@ -49,7 +49,9 @@ float CalculateArea(SkPoint abc[3]) {
                       b.fX * a.fY);
 }
 
-static constexpr float kSrgbD50GamutArea = 0.084f;
+// Note: This is defined differently in Skia, in my testing this is the correct
+// area and was calculated from SkColorSpace::MakeSRGB().
+static constexpr float kSrgbGamutArea = 0.0982f;
 
 // Source:
 // https://source.chromium.org/chromium/_/skia/skia.git/+/393fb1ec80f41d8ad7d104921b6920e69749fda1:src/codec/SkAndroidCodec.cpp;l=67;drc=46572b4d445f41943059d0e377afc6d6748cd5ca;bpv=1;bpt=0
@@ -58,7 +60,8 @@ bool IsWideGamut(const SkColorSpace& color_space) {
   color_space.toXYZD50(&xyzd50);
   SkPoint rgb[3];
   LoadGamut(rgb, xyzd50);
-  return CalculateArea(rgb) > kSrgbD50GamutArea;
+  float area = CalculateArea(rgb);
+  return area > kSrgbGamutArea;
 }
 }  // namespace
 

--- a/lib/ui/painting/image_decoder_impeller.cc
+++ b/lib/ui/painting/image_decoder_impeller.cc
@@ -49,8 +49,7 @@ float CalculateArea(SkPoint abc[3]) {
                       b.fX * a.fY);
 }
 
-// Note: This is defined differently in Skia, in my testing this is the correct
-// area and was calculated from SkColorSpace::MakeSRGB().
+// Note: This was calculated from SkColorSpace::MakeSRGB().
 static constexpr float kSrgbGamutArea = 0.0982f;
 
 // Source:

--- a/lib/ui/painting/image_decoder_unittests.cc
+++ b/lib/ui/painting/image_decoder_unittests.cc
@@ -333,6 +333,28 @@ TEST_F(ImageDecoderFixtureTest, ImpellerWideGamutDisplayP3) {
 #endif  // IMPELLER_SUPPORTS_RENDERING
 }
 
+TEST_F(ImageDecoderFixtureTest, ImpellerNonWideGamut) {
+  auto data = OpenFixtureAsSkData("Horizontal.jpg");
+  auto image = SkImage::MakeFromEncoded(data);
+  ASSERT_TRUE(image != nullptr);
+  ASSERT_EQ(SkISize::Make(600, 200), image->dimensions());
+
+  ImageGeneratorRegistry registry;
+  std::shared_ptr<ImageGenerator> generator =
+      registry.CreateCompatibleGenerator(data);
+  ASSERT_TRUE(generator);
+
+  auto descriptor = fml::MakeRefCounted<ImageDescriptor>(std::move(data),
+                                                         std::move(generator));
+
+#if IMPELLER_SUPPORTS_RENDERING
+  std::shared_ptr<SkBitmap> bitmap = ImageDecoderImpeller::DecompressTexture(
+      descriptor.get(), SkISize::Make(600, 200), {600, 200},
+      /*supports_wide_gamut=*/true);
+  ASSERT_EQ(bitmap->colorType(), kRGBA_8888_SkColorType);
+#endif  // IMPELLER_SUPPORTS_RENDERING
+}
+
 TEST_F(ImageDecoderFixtureTest, ExifDataIsRespectedOnDecode) {
   auto loop = fml::ConcurrentMessageLoop::Create();
   TaskRunners runners(GetCurrentTestName(),         // label


### PR DESCRIPTION
This is the bug that was found in the wide gamut memory audit.

A skia bug was filed: https://bugs.chromium.org/p/skia/issues/detail?id=14137

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
