### PR TITLE
[common] Use FML macro to prevent copy/assignment

### DIFF
--- a/shell/platform/common/alert_platform_node_delegate.h
+++ b/shell/platform/common/alert_platform_node_delegate.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_SHELL_PLATFORM_COMMON_ALERT_PLATFORM_NODE_DELEGATE_H_
 #define FLUTTER_SHELL_PLATFORM_COMMON_ALERT_PLATFORM_NODE_DELEGATE_H_
 
+#include "flutter/fml/macros.h"
 #include "flutter/third_party/accessibility/ax/ax_node_data.h"
 #include "flutter/third_party/accessibility/ax/platform/ax_platform_node_delegate_base.h"
 
@@ -19,10 +20,6 @@ class AlertPlatformNodeDelegate : public ui::AXPlatformNodeDelegateBase {
   explicit AlertPlatformNodeDelegate(
       ui::AXPlatformNodeDelegate& parent_delegate);
   ~AlertPlatformNodeDelegate();
-
-  AlertPlatformNodeDelegate(const AlertPlatformNodeDelegate& other) = delete;
-  AlertPlatformNodeDelegate operator=(const AlertPlatformNodeDelegate& other) =
-      delete;
 
   // Set the alert text of the node for which this is the delegate.
   void SetText(const std::u16string& text);
@@ -44,6 +41,8 @@ class AlertPlatformNodeDelegate : public ui::AXPlatformNodeDelegateBase {
 
   // A unique ID used to identify this node. Returned by GetUniqueId.
   ui::AXUniqueId id_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(AlertPlatformNodeDelegate);
 };
 
 }  // namespace flutter

--- a/shell/platform/darwin/common/buffer_conversions.mm
+++ b/shell/platform/darwin/common/buffer_conversions.mm
@@ -4,6 +4,7 @@
 
 #import "flutter/shell/platform/darwin/common/buffer_conversions.h"
 
+#include "flutter/fml/macros.h"
 #include "flutter/fml/platform/darwin/scoped_nsobject.h"
 
 namespace flutter {


### PR DESCRIPTION
Rather than explicitly delete the copy constructor and operator=, use the standard FML_DISALLOW_COPY_AND_ASSIGN macro used elsewhere across the codebase. Also ensure that files using this macro #include the correct FML header directly, rather than relying on a transitive include.

No test changes/additions since this patch introduces no semantic changes.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
