### PR TITLE
[web] Copy canvaskit_chromium/* to canvaskit/chromium/*

### DIFF
--- a/lib/web_ui/dev/steps/compile_tests_step.dart
+++ b/lib/web_ui/dev/steps/compile_tests_step.dart
@@ -172,6 +172,7 @@ Future<void> copySkwasm() async {
 
 final io.Directory _localCanvasKitDir = io.Directory(pathlib.join(
   environment.wasmReleaseOutDir.path,
+  'flutter_web_sdk',
   'canvaskit',
 ));
 final io.File _localCanvasKitWasm = io.File(pathlib.join(

--- a/lib/web_ui/dev/steps/compile_tests_step.dart
+++ b/lib/web_ui/dev/steps/compile_tests_step.dart
@@ -172,7 +172,6 @@ Future<void> copySkwasm() async {
 
 final io.Directory _localCanvasKitDir = io.Directory(pathlib.join(
   environment.wasmReleaseOutDir.path,
-  'flutter_web_sdk',
   'canvaskit',
 ));
 final io.File _localCanvasKitWasm = io.File(pathlib.join(

--- a/third_party/canvaskit/BUILD.gn
+++ b/third_party/canvaskit/BUILD.gn
@@ -26,7 +26,13 @@ wasm_toolchain("canvaskit_chromium") {
   }
 }
 
-group("canvaskit_chromium_group") {
+copy("canvaskit_chromium_group") {
   visibility = [ "//flutter/web_sdk:*" ]
   public_deps = [ "//third_party/skia/modules/canvaskit(:canvaskit_chromium)" ]
+
+  sources = [
+    "$root_out_dir/canvaskit_chromium/canvaskit.js",
+    "$root_out_dir/canvaskit_chromium/canvaskit.wasm",
+  ]
+  outputs = [ "$root_out_dir/canvaskit/chromium/{{source_file_part}}" ]
 }

--- a/web_sdk/BUILD.gn
+++ b/web_sdk/BUILD.gn
@@ -533,6 +533,30 @@ group("flutter_ddc_modules") {
   ]
 }
 
+if (build_canvaskit) {
+  copy("canvaskit") {
+    sources = [
+      "$root_out_dir/canvaskit/canvaskit.js",
+      "$root_out_dir/canvaskit/canvaskit.wasm",
+    ]
+    outputs = [ "$root_out_dir/flutter_web_sdk/canvaskit/{{source_file_part}}" ]
+    deps = [ "//flutter/third_party/canvaskit:canvaskit_group" ]
+  }
+}
+
+if (build_canvaskit_chromium) {
+  copy("canvaskit_chromium") {
+    sources = [
+      "$root_out_dir/canvaskit_chromium/canvaskit.js",
+      "$root_out_dir/canvaskit_chromium/canvaskit.wasm",
+    ]
+    outputs = [
+      "$root_out_dir/flutter_web_sdk/canvaskit/chromium/{{source_file_part}}",
+    ]
+    deps = [ "//flutter/third_party/canvaskit:canvaskit_chromium_group" ]
+  }
+}
+
 # Archives Flutter Web SDK
 if (!is_fuchsia) {
   zip_bundle_from_file("flutter_web_sdk_archive") {
@@ -580,6 +604,15 @@ if (!is_fuchsia) {
 
     foreach(web_engine_library, web_engine_libraries) {
       sources += get_target_outputs(web_engine_library)
+    }
+
+    if (build_canvaskit) {
+      deps += [ ":canvaskit" ]
+      sources += get_target_outputs(":canvaskit")
+    }
+    if (build_canvaskit_chromium) {
+      deps += [ ":canvaskit_chromium" ]
+      sources += get_target_outputs(":canvaskit_chromium")
     }
 
     tmp_files = []

--- a/web_sdk/BUILD.gn
+++ b/web_sdk/BUILD.gn
@@ -533,30 +533,6 @@ group("flutter_ddc_modules") {
   ]
 }
 
-if (build_canvaskit) {
-  copy("canvaskit") {
-    sources = [
-      "$root_out_dir/canvaskit/canvaskit.js",
-      "$root_out_dir/canvaskit/canvaskit.wasm",
-    ]
-    outputs = [ "$root_out_dir/flutter_web_sdk/canvaskit/{{source_file_part}}" ]
-    deps = [ "//flutter/third_party/canvaskit:canvaskit_group" ]
-  }
-}
-
-if (build_canvaskit_chromium) {
-  copy("canvaskit_chromium") {
-    sources = [
-      "$root_out_dir/canvaskit_chromium/canvaskit.js",
-      "$root_out_dir/canvaskit_chromium/canvaskit.wasm",
-    ]
-    outputs = [
-      "$root_out_dir/flutter_web_sdk/canvaskit/chromium/{{source_file_part}}",
-    ]
-    deps = [ "//flutter/third_party/canvaskit:canvaskit_chromium_group" ]
-  }
-}
-
 # Archives Flutter Web SDK
 if (!is_fuchsia) {
   zip_bundle_from_file("flutter_web_sdk_archive") {
@@ -606,15 +582,6 @@ if (!is_fuchsia) {
       sources += get_target_outputs(web_engine_library)
     }
 
-    if (build_canvaskit) {
-      deps += [ ":canvaskit" ]
-      sources += get_target_outputs(":canvaskit")
-    }
-    if (build_canvaskit_chromium) {
-      deps += [ ":canvaskit_chromium" ]
-      sources += get_target_outputs(":canvaskit_chromium")
-    }
-
     tmp_files = []
     web_sdk_files =
         filter_include(sources, [ "$root_build_dir/flutter_web_sdk/**" ])
@@ -636,11 +603,11 @@ if (!is_fuchsia) {
         destination = "canvaskit/canvaskit.wasm"
       },
       {
-        source = rebase_path("$root_out_dir/canvaskit_chromium/canvaskit.js")
+        source = rebase_path("$root_out_dir/canvaskit/chromium/canvaskit.js")
         destination = "canvaskit/chromium/canvaskit.js"
       },
       {
-        source = rebase_path("$root_out_dir/canvaskit_chromium/canvaskit.wasm")
+        source = rebase_path("$root_out_dir/canvaskit/chromium/canvaskit.wasm")
         destination = "canvaskit/chromium/canvaskit.wasm"
       },
       {


### PR DESCRIPTION
This allows the flutter web server to easily find all variants of CanvasKit under one folder.