### PR TITLE
save/restore around clipping the (potentially cached) frame canvas

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -821,6 +821,8 @@ std::shared_ptr<FlutterPlatformViewLayer> FlutterPlatformViewsController::GetLay
     return layer;
   }
   SkCanvas* overlay_canvas = frame->SkiaCanvas();
+  int restore_count = overlay_canvas->getSaveCount();
+  overlay_canvas->save();
   overlay_canvas->clipRect(rect);
   overlay_canvas->clear(SK_ColorTRANSPARENT);
   if (frame->GetDisplayListBuilder()) {
@@ -828,6 +830,7 @@ std::shared_ptr<FlutterPlatformViewLayer> FlutterPlatformViewsController::GetLay
   } else {
     slice->render_into(overlay_canvas);
   }
+  overlay_canvas->restoreToCount(restore_count);
 
   layer->did_submit_last_frame = frame->Submit();
   return layer;


### PR DESCRIPTION
This problem was introduced by https://github.com/flutter/engine/pull/37107 where a clipRect call is being executed on the raw canvas of a frame. Since these frames can be cached, that clipRect will persist to future app frames and interfere with the over-view rendering.

This problem was caught during a PR that happened to cause the test case created for https://github.com/flutter/engine/pull/39630 to use a stale frame. It looks like that issue is a race condition so it would be hard to create a specific test case that demonstrates this fix.