### PR TITLE
[Impeller] Wire up a playground that can run Dart

### DIFF
--- a/ci/licenses_golden/excluded_files
+++ b/ci/licenses_golden/excluded_files
@@ -142,6 +142,7 @@
 ../../../flutter/impeller/renderer/device_buffer_unittests.cc
 ../../../flutter/impeller/renderer/host_buffer_unittests.cc
 ../../../flutter/impeller/renderer/pipeline_descriptor_unittests.cc
+../../../flutter/impeller/renderer/renderer_dart_unittests.cc
 ../../../flutter/impeller/renderer/renderer_unittests.cc
 ../../../flutter/impeller/runtime_stage/runtime_stage_unittests.cc
 ../../../flutter/impeller/scene/README.md

--- a/impeller/BUILD.gn
+++ b/impeller/BUILD.gn
@@ -92,3 +92,13 @@ impeller_component("impeller_unittests") {
     ]
   }
 }
+
+if (impeller_supports_rendering) {
+  impeller_component("impeller_dart_unittests") {
+    target_type = "executable"
+
+    testonly = true
+
+    deps = [ "renderer:renderer_dart_unittests" ]
+  }
+}

--- a/impeller/fixtures/dart_tests.dart
+++ b/impeller/fixtures/dart_tests.dart
@@ -1,0 +1,12 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui';
+
+void main() {}
+
+@pragma('vm:entry-point')
+void sayHi() {
+  print('Hi');
+}

--- a/impeller/renderer/BUILD.gn
+++ b/impeller/renderer/BUILD.gn
@@ -123,3 +123,28 @@ impeller_component("renderer_unittests") {
     "//flutter/testing:testing_lib",
   ]
 }
+
+test_fixtures("renderer_dart_fixtures") {
+  dart_main = "../fixtures/dart_tests.dart"
+
+  fixtures = [
+    "../fixtures/bay_bridge.jpg",
+    "../fixtures/boston.jpg",
+  ]
+}
+
+impeller_component("renderer_dart_unittests") {
+  testonly = true
+
+  sources = [ "renderer_dart_unittests.cc" ]
+
+  deps = [
+    ":renderer",
+    ":renderer_dart_fixtures",
+    "../fixtures:shader_fixtures",
+    "../playground:playground_test",
+    "//flutter/runtime:runtime",
+    "//flutter/testing:fixture_test",
+    "//flutter/testing:testing_lib",
+  ]
+}

--- a/impeller/renderer/renderer_dart_unittests.cc
+++ b/impeller/renderer/renderer_dart_unittests.cc
@@ -1,0 +1,87 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <memory>
+
+#include "flutter/common/settings.h"
+#include "flutter/common/task_runners.h"
+#include "flutter/lib/ui/ui_dart_state.h"
+#include "flutter/runtime/dart_isolate.h"
+#include "flutter/runtime/dart_vm_lifecycle.h"
+#include "flutter/runtime/isolate_configuration.h"
+#include "flutter/testing/dart_fixture.h"
+#include "flutter/testing/dart_isolate_runner.h"
+#include "flutter/testing/fixture_test.h"
+#include "flutter/testing/testing.h"
+#include "impeller/fixtures/box_fade.frag.h"
+#include "impeller/fixtures/box_fade.vert.h"
+#include "impeller/playground/playground_test.h"
+#include "impeller/renderer/pipeline_library.h"
+#include "impeller/renderer/render_pass.h"
+#include "impeller/renderer/sampler_library.h"
+
+#include "third_party/imgui/imgui.h"
+
+namespace impeller {
+namespace testing {
+
+class RendererDartTest : public PlaygroundTest,
+                         public flutter::testing::DartFixture {
+ public:
+  RendererDartTest()
+      : settings_(CreateSettingsForFixture()),
+        vm_ref_(flutter::DartVMRef::Create(settings_)) {
+    fml::MessageLoop::EnsureInitializedForCurrentThread();
+    current_task_runner_ = fml::MessageLoop::GetCurrent().GetTaskRunner();
+    isolate_ = CreateDartIsolate();
+    assert(isolate_);
+    assert(isolate_->get()->GetPhase() == flutter::DartIsolate::Phase::Running);
+  }
+
+  flutter::testing::AutoIsolateShutdown* GetIsolate() { return isolate_.get(); }
+
+ private:
+  std::unique_ptr<flutter::testing::AutoIsolateShutdown> CreateDartIsolate() {
+    const auto settings = CreateSettingsForFixture();
+    flutter::TaskRunners task_runners(flutter::testing::GetCurrentTestName(),
+                                      current_task_runner_,  //
+                                      current_task_runner_,  //
+                                      current_task_runner_,  //
+                                      current_task_runner_   //
+    );
+    return flutter::testing::RunDartCodeInIsolate(
+        vm_ref_, settings, task_runners, "main", {},
+        flutter::testing::GetDefaultKernelFilePath());
+  }
+
+  const flutter::Settings settings_;
+  flutter::DartVMRef vm_ref_;
+  fml::RefPtr<fml::TaskRunner> current_task_runner_;
+  std::unique_ptr<flutter::testing::AutoIsolateShutdown> isolate_;
+};
+
+INSTANTIATE_PLAYGROUND_SUITE(RendererDartTest);
+
+TEST_P(RendererDartTest, CanRunDartInPlaygroundFrame) {
+  auto isolate = GetIsolate();
+
+  SinglePassCallback callback = [&](RenderPass& pass) {
+    ImGui::Begin("Dart test", nullptr);
+    ImGui::Text(
+        "This test executes Dart code during the playground frame callback.");
+    ImGui::End();
+
+    return isolate->RunInIsolateScope([]() -> bool {
+      if (tonic::CheckAndHandleError(::Dart_Invoke(
+              Dart_RootLibrary(), tonic::ToDart("sayHi"), 0, nullptr))) {
+        return false;
+      }
+      return true;
+    });
+  };
+  OpenPlaygroundHere(callback);
+}
+
+}  // namespace testing
+}  // namespace impeller


### PR DESCRIPTION
This took a bit of tinkering, but once I figured out the fixture/dart kernel situation and got everything to happen in the right order, the minimal solution turned out to be pretty simple.