### PR TITLE
[Embedder API] Introduce new update semantics callback

### DIFF
--- a/shell/platform/common/accessibility_bridge.cc
+++ b/shell/platform/common/accessibility_bridge.cc
@@ -37,10 +37,25 @@ AccessibilityBridge::~AccessibilityBridge() {
 }
 
 void AccessibilityBridge::AddFlutterSemanticsNodeUpdate(
+    const FlutterSemanticsNode2& node) {
+  pending_semantics_node_updates_[node.id] = FromFlutterSemanticsNode(node);
+}
+
+void AccessibilityBridge::AddFlutterSemanticsCustomActionUpdate(
+    const FlutterSemanticsCustomAction2& action) {
+  pending_semantics_custom_action_updates_[action.id] =
+      FromFlutterSemanticsCustomAction(action);
+}
+
+// TODO(loicsharma): Remove this as FlutterSemanticsNode is deprecated.
+// See: https://github.com/flutter/flutter/issues/121176
+void AccessibilityBridge::AddFlutterSemanticsNodeUpdate(
     const FlutterSemanticsNode& node) {
   pending_semantics_node_updates_[node.id] = FromFlutterSemanticsNode(node);
 }
 
+// TODO(loicsharma): Remove this as FlutterSemanticsNode is deprecated.
+// See: https://github.com/flutter/flutter/issues/121176
 void AccessibilityBridge::AddFlutterSemanticsCustomActionUpdate(
     const FlutterSemanticsCustomAction& action) {
   pending_semantics_custom_action_updates_[action.id] =
@@ -578,6 +593,74 @@ void AccessibilityBridge::SetTreeData(const SemanticsNode& node,
 
 AccessibilityBridge::SemanticsNode
 AccessibilityBridge::FromFlutterSemanticsNode(
+    const FlutterSemanticsNode2& flutter_node) {
+  SemanticsNode result;
+  result.id = flutter_node.id;
+  result.flags = flutter_node.flags;
+  result.actions = flutter_node.actions;
+  result.text_selection_base = flutter_node.text_selection_base;
+  result.text_selection_extent = flutter_node.text_selection_extent;
+  result.scroll_child_count = flutter_node.scroll_child_count;
+  result.scroll_index = flutter_node.scroll_index;
+  result.scroll_position = flutter_node.scroll_position;
+  result.scroll_extent_max = flutter_node.scroll_extent_max;
+  result.scroll_extent_min = flutter_node.scroll_extent_min;
+  result.elevation = flutter_node.elevation;
+  result.thickness = flutter_node.thickness;
+  if (flutter_node.label) {
+    result.label = std::string(flutter_node.label);
+  }
+  if (flutter_node.hint) {
+    result.hint = std::string(flutter_node.hint);
+  }
+  if (flutter_node.value) {
+    result.value = std::string(flutter_node.value);
+  }
+  if (flutter_node.increased_value) {
+    result.increased_value = std::string(flutter_node.increased_value);
+  }
+  if (flutter_node.decreased_value) {
+    result.decreased_value = std::string(flutter_node.decreased_value);
+  }
+  if (flutter_node.tooltip) {
+    result.tooltip = std::string(flutter_node.tooltip);
+  }
+  result.text_direction = flutter_node.text_direction;
+  result.rect = flutter_node.rect;
+  result.transform = flutter_node.transform;
+  if (flutter_node.child_count > 0) {
+    result.children_in_traversal_order = std::vector<int32_t>(
+        flutter_node.children_in_traversal_order,
+        flutter_node.children_in_traversal_order + flutter_node.child_count);
+  }
+  if (flutter_node.custom_accessibility_actions_count > 0) {
+    result.custom_accessibility_actions = std::vector<int32_t>(
+        flutter_node.custom_accessibility_actions,
+        flutter_node.custom_accessibility_actions +
+            flutter_node.custom_accessibility_actions_count);
+  }
+  return result;
+}
+
+AccessibilityBridge::SemanticsCustomAction
+AccessibilityBridge::FromFlutterSemanticsCustomAction(
+    const FlutterSemanticsCustomAction2& flutter_custom_action) {
+  SemanticsCustomAction result;
+  result.id = flutter_custom_action.id;
+  result.override_action = flutter_custom_action.override_action;
+  if (flutter_custom_action.label) {
+    result.label = std::string(flutter_custom_action.label);
+  }
+  if (flutter_custom_action.hint) {
+    result.hint = std::string(flutter_custom_action.hint);
+  }
+  return result;
+}
+
+// TODO(loicsharma): Remove this as FlutterSemanticsNode is deprecated.
+// See: https://github.com/flutter/flutter/issues/121176
+AccessibilityBridge::SemanticsNode
+AccessibilityBridge::FromFlutterSemanticsNode(
     const FlutterSemanticsNode& flutter_node) {
   SemanticsNode result;
   result.id = flutter_node.id;
@@ -627,6 +710,9 @@ AccessibilityBridge::FromFlutterSemanticsNode(
   return result;
 }
 
+// TODO(loicsharma): Remove this as FlutterSemanticsCustomAction is
+// deprecated.
+// See: https://github.com/flutter/flutter/issues/121176
 AccessibilityBridge::SemanticsCustomAction
 AccessibilityBridge::FromFlutterSemanticsCustomAction(
     const FlutterSemanticsCustomAction& flutter_custom_action) {

--- a/shell/platform/common/accessibility_bridge.h
+++ b/shell/platform/common/accessibility_bridge.h
@@ -54,6 +54,27 @@ class AccessibilityBridge
   ///             To flush the pending updates, call the CommitUpdates().
   ///
   /// @param[in]  node           A reference to the semantics node update.
+  void AddFlutterSemanticsNodeUpdate(const FlutterSemanticsNode2& node);
+
+  //------------------------------------------------------------------------------
+  /// @brief      Adds a custom semantics action update to the pending semantics
+  ///             update. Calling this method alone will NOT update the
+  ///             semantics tree. To flush the pending updates, call the
+  ///             CommitUpdates().
+  ///
+  /// @param[in]  action           A reference to the custom semantics action
+  ///                              update.
+  void AddFlutterSemanticsCustomActionUpdate(
+      const FlutterSemanticsCustomAction2& action);
+
+  //------------------------------------------------------------------------------
+  /// @brief      Adds a semantics node update to the pending semantics update.
+  ///             Calling this method alone will NOT update the semantics tree.
+  ///             To flush the pending updates, call the CommitUpdates().
+  ///
+  /// @param[in]  node           A reference to the semantics node update.
+  //  TODO(loicsharma): Remove this as FlutterSemanticsNode is deprecated.
+  //  See: https://github.com/flutter/flutter/issues/121176
   void AddFlutterSemanticsNodeUpdate(const FlutterSemanticsNode& node);
 
   //------------------------------------------------------------------------------
@@ -64,6 +85,9 @@ class AccessibilityBridge
   ///
   /// @param[in]  action           A reference to the custom semantics action
   ///                              update.
+  //  TODO(loicsharma): Remove this as FlutterSemanticsCustomAction is
+  //  deprecated.
+  //  See: https://github.com/flutter/flutter/issues/121176
   void AddFlutterSemanticsCustomActionUpdate(
       const FlutterSemanticsCustomAction& action);
 
@@ -245,7 +269,18 @@ class AccessibilityBridge
                                    const SemanticsNode& node);
   void SetTreeData(const SemanticsNode& node, ui::AXTreeUpdate& tree_update);
   SemanticsNode FromFlutterSemanticsNode(
+      const FlutterSemanticsNode2& flutter_node);
+  SemanticsCustomAction FromFlutterSemanticsCustomAction(
+      const FlutterSemanticsCustomAction2& flutter_custom_action);
+
+  // TODO(loicsharma): Remove this as FlutterSemanticsNode is deprecated.
+  // See: https://github.com/flutter/flutter/issues/121176
+  SemanticsNode FromFlutterSemanticsNode(
       const FlutterSemanticsNode& flutter_node);
+
+  // TODO(loicsharma): Remove this as FlutterSemanticsCustomAction is
+  // deprecated.
+  // See: https://github.com/flutter/flutter/issues/121176
   SemanticsCustomAction FromFlutterSemanticsCustomAction(
       const FlutterSemanticsCustomAction& flutter_custom_action);
 

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -1045,7 +1045,7 @@ typedef int64_t FlutterPlatformViewIdentifier;
 
 /// `FlutterSemanticsNode` ID used as a sentinel to signal the end of a batch of
 /// semantics node updates. This is unused if using
-/// `FlutterUpdateSemanticsCallback`.
+/// `FlutterUpdateSemanticsCallback2`.
 FLUTTER_EXPORT
 extern const int32_t kFlutterSemanticsNodeIdBatchEnd;
 
@@ -1055,6 +1055,11 @@ extern const int32_t kFlutterSemanticsNodeIdBatchEnd;
 /// (i.e., during PipelineOwner.flushSemantics), which happens after
 /// compositing. Updates are then pushed to embedders via the registered
 /// `FlutterUpdateSemanticsCallback`.
+///
+/// @deprecated     Use `FlutterSemanticsNode2` instead. In order to preserve
+///                 ABI compatibility for existing users, no new fields will be
+///                 added to this struct. New fields will continue to be added
+///                 to `FlutterSemanticsNode2`.
 typedef struct {
   /// The size of this struct. Must be sizeof(FlutterSemanticsNode).
   size_t struct_size;
@@ -1122,9 +1127,84 @@ typedef struct {
   const char* tooltip;
 } FlutterSemanticsNode;
 
+/// A node in the Flutter semantics tree.
+///
+/// The semantics tree is maintained during the semantics phase of the pipeline
+/// (i.e., during PipelineOwner.flushSemantics), which happens after
+/// compositing. Updates are then pushed to embedders via the registered
+/// `FlutterUpdateSemanticsCallback2`.
+///
+/// @see https://api.flutter.dev/flutter/semantics/SemanticsNode-class.html
+typedef struct {
+  /// The size of this struct. Must be sizeof(FlutterSemanticsNode).
+  size_t struct_size;
+  /// The unique identifier for this node.
+  int32_t id;
+  /// The set of semantics flags associated with this node.
+  FlutterSemanticsFlag flags;
+  /// The set of semantics actions applicable to this node.
+  FlutterSemanticsAction actions;
+  /// The position at which the text selection originates.
+  int32_t text_selection_base;
+  /// The position at which the text selection terminates.
+  int32_t text_selection_extent;
+  /// The total number of scrollable children that contribute to semantics.
+  int32_t scroll_child_count;
+  /// The index of the first visible semantic child of a scroll node.
+  int32_t scroll_index;
+  /// The current scrolling position in logical pixels if the node is
+  /// scrollable.
+  double scroll_position;
+  /// The maximum in-range value for `scrollPosition` if the node is scrollable.
+  double scroll_extent_max;
+  /// The minimum in-range value for `scrollPosition` if the node is scrollable.
+  double scroll_extent_min;
+  /// The elevation along the z-axis at which the rect of this semantics node is
+  /// located above its parent.
+  double elevation;
+  /// Describes how much space the semantics node takes up along the z-axis.
+  double thickness;
+  /// A textual description of the node.
+  const char* label;
+  /// A brief description of the result of performing an action on the node.
+  const char* hint;
+  /// A textual description of the current value of the node.
+  const char* value;
+  /// A value that `value` will have after a kFlutterSemanticsActionIncrease`
+  /// action has been performed.
+  const char* increased_value;
+  /// A value that `value` will have after a kFlutterSemanticsActionDecrease`
+  /// action has been performed.
+  const char* decreased_value;
+  /// The reading direction for `label`, `value`, `hint`, `increasedValue`,
+  /// `decreasedValue`, and `tooltip`.
+  FlutterTextDirection text_direction;
+  /// The bounding box for this node in its coordinate system.
+  FlutterRect rect;
+  /// The transform from this node's coordinate system to its parent's
+  /// coordinate system.
+  FlutterTransformation transform;
+  /// The number of children this node has.
+  size_t child_count;
+  /// Array of child node IDs in traversal order. Has length `child_count`.
+  const int32_t* children_in_traversal_order;
+  /// Array of child node IDs in hit test order. Has length `child_count`.
+  const int32_t* children_in_hit_test_order;
+  /// The number of custom accessibility action associated with this node.
+  size_t custom_accessibility_actions_count;
+  /// Array of `FlutterSemanticsCustomAction` IDs associated with this node.
+  /// Has length `custom_accessibility_actions_count`.
+  const int32_t* custom_accessibility_actions;
+  /// Identifier of the platform view associated with this semantics node, or
+  /// -1 if none.
+  FlutterPlatformViewIdentifier platform_view_id;
+  /// A textual tooltip attached to the node.
+  const char* tooltip;
+} FlutterSemanticsNode2;
+
 /// `FlutterSemanticsCustomAction` ID used as a sentinel to signal the end of a
 /// batch of semantics custom action updates. This is unused if using
-/// `FlutterUpdateSemanticsCallback`.
+/// `FlutterUpdateSemanticsCallback2`.
 FLUTTER_EXPORT
 extern const int32_t kFlutterSemanticsCustomActionIdBatchEnd;
 
@@ -1137,6 +1217,11 @@ extern const int32_t kFlutterSemanticsCustomActionIdBatchEnd;
 /// Action overrides are custom actions that the application developer requests
 /// to be used in place of the standard actions in the `FlutterSemanticsAction`
 /// enum.
+///
+/// @deprecated     Use `FlutterSemanticsCustomAction2` instead. In order to
+///                 preserve ABI compatility for existing users, no new fields
+///                 will be added to this struct. New fields will continue to
+///                 be added to `FlutterSemanticsCustomAction2`.
 typedef struct {
   /// The size of the struct. Must be sizeof(FlutterSemanticsCustomAction).
   size_t struct_size;
@@ -1151,7 +1236,37 @@ typedef struct {
   const char* hint;
 } FlutterSemanticsCustomAction;
 
+/// A custom semantics action, or action override.
+///
+/// Custom actions can be registered by applications in order to provide
+/// semantic actions other than the standard actions available through the
+/// `FlutterSemanticsAction` enum.
+///
+/// Action overrides are custom actions that the application developer requests
+/// to be used in place of the standard actions in the `FlutterSemanticsAction`
+/// enum.
+///
+/// @see
+/// https://api.flutter.dev/flutter/semantics/CustomSemanticsAction-class.html
+typedef struct {
+  /// The size of the struct. Must be sizeof(FlutterSemanticsCustomAction).
+  size_t struct_size;
+  /// The unique custom action or action override ID.
+  int32_t id;
+  /// For overridden standard actions, corresponds to the
+  /// `FlutterSemanticsAction` to override.
+  FlutterSemanticsAction override_action;
+  /// The user-readable name of this custom semantics action.
+  const char* label;
+  /// The hint description of this custom semantics action.
+  const char* hint;
+} FlutterSemanticsCustomAction2;
+
 /// A batch of updates to semantics nodes and custom actions.
+///
+/// @deprecated     Use `FlutterSemanticsUpdate2` instead. Adding members
+///                 to `FlutterSemanticsNode` or `FlutterSemanticsCustomAction`
+///                 breaks the ABI of this struct.
 typedef struct {
   /// The size of the struct. Must be sizeof(FlutterSemanticsUpdate).
   size_t struct_size;
@@ -1165,6 +1280,21 @@ typedef struct {
   FlutterSemanticsCustomAction* custom_actions;
 } FlutterSemanticsUpdate;
 
+/// A batch of updates to semantics nodes and custom actions.
+typedef struct {
+  /// The size of the struct. Must be sizeof(FlutterSemanticsUpdate2).
+  size_t struct_size;
+  /// The number of semantics node updates.
+  size_t node_count;
+  // Array of semantics node pointers. Has length `node_count`.
+  FlutterSemanticsNode2** nodes;
+  /// The number of semantics custom action updates.
+  size_t custom_action_count;
+  /// Array of semantics custom action pointers. Has length
+  /// `custom_action_count`.
+  FlutterSemanticsCustomAction2** custom_actions;
+} FlutterSemanticsUpdate2;
+
 typedef void (*FlutterUpdateSemanticsNodeCallback)(
     const FlutterSemanticsNode* /* semantics node */,
     void* /* user data */);
@@ -1175,6 +1305,10 @@ typedef void (*FlutterUpdateSemanticsCustomActionCallback)(
 
 typedef void (*FlutterUpdateSemanticsCallback)(
     const FlutterSemanticsUpdate* /* semantics update */,
+    void* /* user data*/);
+
+typedef void (*FlutterUpdateSemanticsCallback2)(
+    const FlutterSemanticsUpdate2* /* semantics update */,
     void* /* user data*/);
 
 typedef struct _FlutterTaskRunner* FlutterTaskRunner;
@@ -1781,9 +1915,11 @@ typedef struct {
   /// The callback will be invoked on the thread on which the `FlutterEngineRun`
   /// call is made.
   ///
-  /// @deprecated    Prefer using `update_semantics_callback` instead. If this
-  ///                calback is provided, `update_semantics_callback` must not
-  ///                be provided.
+  /// @deprecated    Use `update_semantics_callback2` instead. Only one of
+  ///                `update_semantics_node_callback`,
+  ///                `update_semantics_callback`, and
+  ///                `update_semantics_callback2` may be provided; the others
+  ///                should be set to null.
   FlutterUpdateSemanticsNodeCallback update_semantics_node_callback;
   /// The legacy callback invoked by the engine in order to give the embedder
   /// the chance to respond to updates to semantics custom actions from the Dart
@@ -1795,9 +1931,11 @@ typedef struct {
   /// The callback will be invoked on the thread on which the `FlutterEngineRun`
   /// call is made.
   ///
-  /// @deprecated    Prefer using `update_semantics_callback` instead. If this
-  ///                calback is provided, `update_semantics_callback` must not
-  ///                be provided.
+  /// @deprecated    Use `update_semantics_callback2` instead. Only one of
+  ///                `update_semantics_node_callback`,
+  ///                `update_semantics_callback`, and
+  ///                `update_semantics_callback2` may be provided; the others
+  ///                should be set to null.
   FlutterUpdateSemanticsCustomActionCallback
       update_semantics_custom_action_callback;
   /// Path to a directory used to store data that is cached across runs of a
@@ -1942,9 +2080,24 @@ typedef struct {
   /// The callback will be invoked on the thread on which the `FlutterEngineRun`
   /// call is made.
   ///
-  /// If this callback is provided, update_semantics_node_callback and
-  /// update_semantics_custom_action_callback must not be provided.
+  /// @deprecated    Use `update_semantics_callback2` instead. Only one of
+  ///                `update_semantics_node_callback`,
+  ///                `update_semantics_callback`, and
+  ///                `update_semantics_callback2` may be provided; the others
+  ///                must be set to null.
   FlutterUpdateSemanticsCallback update_semantics_callback;
+
+  /// The callback invoked by the engine in order to give the embedder the
+  /// chance to respond to updates to semantics nodes and custom actions from
+  /// the Dart application.
+  ///
+  /// The callback will be invoked on the thread on which the `FlutterEngineRun`
+  /// call is made.
+  ///
+  /// Only one of `update_semantics_node_callback`, `update_semantics_callback`,
+  /// and `update_semantics_callback2` may be provided; the others must be set
+  /// to null.
+  FlutterUpdateSemanticsCallback2 update_semantics_callback2;
 } FlutterProjectArgs;
 
 #ifndef FLUTTER_ENGINE_NO_PROTOTYPES
@@ -2286,8 +2439,8 @@ FlutterEngineResult FlutterEngineMarkExternalTextureFrameAvailable(
 /// @param[in]  engine     A running engine instance.
 /// @param[in]  enabled    When enabled, changes to the semantic contents of the
 ///                        window are sent via the
-///                        `FlutterUpdateSemanticsCallback` registered to
-///                        `update_semantics_callback` in
+///                        `FlutterUpdateSemanticsCallback2` registered to
+///                        `update_semantics_callback2` in
 ///                        `FlutterProjectArgs`.
 ///
 /// @return     The result of the call.

--- a/shell/platform/embedder/tests/embedder_a11y_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_a11y_unittests.cc
@@ -26,19 +26,66 @@ using EmbedderA11yTest = testing::EmbedderTest;
 
 constexpr static char kTooltip[] = "tooltip";
 
-TEST_F(EmbedderTest, CannotProvideNewAndLegacySemanticsCallback) {
-  EmbedderConfigBuilder builder(
-      GetEmbedderContext(EmbedderTestContextType::kSoftwareContext));
-  builder.SetSoftwareRendererConfig();
-  builder.GetProjectArgs().update_semantics_callback =
-      [](const FlutterSemanticsUpdate* update, void* user_data) {};
-  builder.GetProjectArgs().update_semantics_node_callback =
-      [](const FlutterSemanticsNode* update, void* user_data) {};
-  builder.GetProjectArgs().update_semantics_custom_action_callback =
-      [](const FlutterSemanticsCustomAction* update, void* user_data) {};
-  auto engine = builder.InitializeEngine();
-  ASSERT_FALSE(engine.is_valid());
-  engine.reset();
+TEST_F(EmbedderTest, CannotProvideMultipleSemanticsCallbacks) {
+  {
+    EmbedderConfigBuilder builder(
+        GetEmbedderContext(EmbedderTestContextType::kSoftwareContext));
+    builder.SetSoftwareRendererConfig();
+    builder.GetProjectArgs().update_semantics_callback =
+        [](const FlutterSemanticsUpdate* update, void* user_data) {};
+    builder.GetProjectArgs().update_semantics_callback2 =
+        [](const FlutterSemanticsUpdate2* update, void* user_data) {};
+    auto engine = builder.InitializeEngine();
+    ASSERT_FALSE(engine.is_valid());
+    engine.reset();
+  }
+
+  {
+    EmbedderConfigBuilder builder(
+        GetEmbedderContext(EmbedderTestContextType::kSoftwareContext));
+    builder.SetSoftwareRendererConfig();
+    builder.GetProjectArgs().update_semantics_callback2 =
+        [](const FlutterSemanticsUpdate2* update, void* user_data) {};
+    builder.GetProjectArgs().update_semantics_node_callback =
+        [](const FlutterSemanticsNode* update, void* user_data) {};
+    builder.GetProjectArgs().update_semantics_custom_action_callback =
+        [](const FlutterSemanticsCustomAction* update, void* user_data) {};
+    auto engine = builder.InitializeEngine();
+    ASSERT_FALSE(engine.is_valid());
+    engine.reset();
+  }
+
+  {
+    EmbedderConfigBuilder builder(
+        GetEmbedderContext(EmbedderTestContextType::kSoftwareContext));
+    builder.SetSoftwareRendererConfig();
+    builder.GetProjectArgs().update_semantics_callback =
+        [](const FlutterSemanticsUpdate* update, void* user_data) {};
+    builder.GetProjectArgs().update_semantics_node_callback =
+        [](const FlutterSemanticsNode* update, void* user_data) {};
+    builder.GetProjectArgs().update_semantics_custom_action_callback =
+        [](const FlutterSemanticsCustomAction* update, void* user_data) {};
+    auto engine = builder.InitializeEngine();
+    ASSERT_FALSE(engine.is_valid());
+    engine.reset();
+  }
+
+  {
+    EmbedderConfigBuilder builder(
+        GetEmbedderContext(EmbedderTestContextType::kSoftwareContext));
+    builder.SetSoftwareRendererConfig();
+    builder.GetProjectArgs().update_semantics_callback2 =
+        [](const FlutterSemanticsUpdate2* update, void* user_data) {};
+    builder.GetProjectArgs().update_semantics_callback =
+        [](const FlutterSemanticsUpdate* update, void* user_data) {};
+    builder.GetProjectArgs().update_semantics_node_callback =
+        [](const FlutterSemanticsNode* update, void* user_data) {};
+    builder.GetProjectArgs().update_semantics_custom_action_callback =
+        [](const FlutterSemanticsCustomAction* update, void* user_data) {};
+    auto engine = builder.InitializeEngine();
+    ASSERT_FALSE(engine.is_valid());
+    engine.reset();
+  }
 }
 
 TEST_F(EmbedderA11yTest, A11yTreeIsConsistent) {
@@ -53,6 +100,188 @@ TEST_F(EmbedderA11yTest, A11yTreeIsConsistent) {
 #else
   auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
 #endif
+
+  fml::AutoResetWaitableEvent signal_native_latch;
+
+  // Called by the Dart text fixture on the UI thread to signal that the C++
+  // unittest should resume.
+  context.AddNativeCallback(
+      "SignalNativeTest",
+      CREATE_NATIVE_ENTRY(([&signal_native_latch](Dart_NativeArguments) {
+        signal_native_latch.Signal();
+      })));
+
+  // Called by test fixture on UI thread to pass data back to this test.
+  NativeEntry notify_semantics_enabled_callback;
+  context.AddNativeCallback(
+      "NotifySemanticsEnabled",
+      CREATE_NATIVE_ENTRY(
+          ([&notify_semantics_enabled_callback](Dart_NativeArguments args) {
+            ASSERT_NE(notify_semantics_enabled_callback, nullptr);
+            notify_semantics_enabled_callback(args);
+          })));
+
+  NativeEntry notify_accessibility_features_callback;
+  context.AddNativeCallback(
+      "NotifyAccessibilityFeatures",
+      CREATE_NATIVE_ENTRY((
+          [&notify_accessibility_features_callback](Dart_NativeArguments args) {
+            ASSERT_NE(notify_accessibility_features_callback, nullptr);
+            notify_accessibility_features_callback(args);
+          })));
+
+  NativeEntry notify_semantics_action_callback;
+  context.AddNativeCallback(
+      "NotifySemanticsAction",
+      CREATE_NATIVE_ENTRY(
+          ([&notify_semantics_action_callback](Dart_NativeArguments args) {
+            ASSERT_NE(notify_semantics_action_callback, nullptr);
+            notify_semantics_action_callback(args);
+          })));
+
+  fml::AutoResetWaitableEvent semantics_update_latch;
+  context.SetSemanticsUpdateCallback2(
+      [&](const FlutterSemanticsUpdate2* update) {
+        ASSERT_EQ(size_t(4), update->node_count);
+        ASSERT_EQ(size_t(1), update->custom_action_count);
+
+        for (size_t i = 0; i < update->node_count; i++) {
+          const FlutterSemanticsNode2* node = update->nodes[i];
+
+          ASSERT_EQ(1.0, node->transform.scaleX);
+          ASSERT_EQ(2.0, node->transform.skewX);
+          ASSERT_EQ(3.0, node->transform.transX);
+          ASSERT_EQ(4.0, node->transform.skewY);
+          ASSERT_EQ(5.0, node->transform.scaleY);
+          ASSERT_EQ(6.0, node->transform.transY);
+          ASSERT_EQ(7.0, node->transform.pers0);
+          ASSERT_EQ(8.0, node->transform.pers1);
+          ASSERT_EQ(9.0, node->transform.pers2);
+          ASSERT_EQ(std::strncmp(kTooltip, node->tooltip, sizeof(kTooltip) - 1),
+                    0);
+
+          if (node->id == 128) {
+            ASSERT_EQ(0x3f3, node->platform_view_id);
+          } else {
+            ASSERT_NE(kFlutterSemanticsNodeIdBatchEnd, node->id);
+            ASSERT_EQ(0, node->platform_view_id);
+          }
+        }
+
+        semantics_update_latch.Signal();
+      });
+
+  EmbedderConfigBuilder builder(context);
+  builder.SetSoftwareRendererConfig();
+  builder.SetDartEntrypoint("a11y_main");
+
+  auto engine = builder.LaunchEngine();
+  ASSERT_TRUE(engine.is_valid());
+
+  // Wait for initial NotifySemanticsEnabled(false).
+  fml::AutoResetWaitableEvent notify_semantics_enabled_latch;
+  notify_semantics_enabled_callback = [&](Dart_NativeArguments args) {
+    bool enabled = true;
+    auto handle = Dart_GetNativeBooleanArgument(args, 0, &enabled);
+    ASSERT_FALSE(Dart_IsError(handle));
+    ASSERT_FALSE(enabled);
+    notify_semantics_enabled_latch.Signal();
+  };
+  notify_semantics_enabled_latch.Wait();
+
+  // Prepare to NotifyAccessibilityFeatures call
+  fml::AutoResetWaitableEvent notify_features_latch;
+  notify_accessibility_features_callback = [&](Dart_NativeArguments args) {
+    bool enabled = true;
+    auto handle = Dart_GetNativeBooleanArgument(args, 0, &enabled);
+    ASSERT_FALSE(Dart_IsError(handle));
+    ASSERT_FALSE(enabled);
+    notify_features_latch.Signal();
+  };
+
+  // Enable semantics. Wait for NotifySemanticsEnabled(true).
+  fml::AutoResetWaitableEvent notify_semantics_enabled_latch_2;
+  notify_semantics_enabled_callback = [&](Dart_NativeArguments args) {
+    bool enabled = false;
+    auto handle = Dart_GetNativeBooleanArgument(args, 0, &enabled);
+    ASSERT_FALSE(Dart_IsError(handle));
+    ASSERT_TRUE(enabled);
+    notify_semantics_enabled_latch_2.Signal();
+  };
+  auto result = FlutterEngineUpdateSemanticsEnabled(engine.get(), true);
+  ASSERT_EQ(result, FlutterEngineResult::kSuccess);
+  notify_semantics_enabled_latch_2.Wait();
+
+  // Wait for initial accessibility features (reduce_motion == false)
+  notify_features_latch.Wait();
+
+  // Set accessibility features: (reduce_motion == true)
+  fml::AutoResetWaitableEvent notify_features_latch_2;
+  notify_accessibility_features_callback = [&](Dart_NativeArguments args) {
+    bool enabled = false;
+    auto handle = Dart_GetNativeBooleanArgument(args, 0, &enabled);
+    ASSERT_FALSE(Dart_IsError(handle));
+    ASSERT_TRUE(enabled);
+    notify_features_latch_2.Signal();
+  };
+  result = FlutterEngineUpdateAccessibilityFeatures(
+      engine.get(), kFlutterAccessibilityFeatureReduceMotion);
+  ASSERT_EQ(result, FlutterEngineResult::kSuccess);
+  notify_features_latch_2.Wait();
+
+  // Wait for UpdateSemantics callback on platform (current) thread.
+  signal_native_latch.Wait();
+  fml::MessageLoop::GetCurrent().RunExpiredTasksNow();
+  semantics_update_latch.Wait();
+
+  // Dispatch a tap to semantics node 42. Wait for NotifySemanticsAction.
+  fml::AutoResetWaitableEvent notify_semantics_action_latch;
+  notify_semantics_action_callback = [&](Dart_NativeArguments args) {
+    int64_t node_id = 0;
+    Dart_GetNativeIntegerArgument(args, 0, &node_id);
+    ASSERT_EQ(42, node_id);
+
+    int64_t action_id;
+    auto handle = Dart_GetNativeIntegerArgument(args, 1, &action_id);
+    ASSERT_FALSE(Dart_IsError(handle));
+    ASSERT_EQ(static_cast<int32_t>(flutter::SemanticsAction::kTap), action_id);
+
+    Dart_Handle semantic_args = Dart_GetNativeArgument(args, 2);
+    int64_t data;
+    Dart_Handle dart_int = Dart_ListGetAt(semantic_args, 0);
+    Dart_IntegerToInt64(dart_int, &data);
+    ASSERT_EQ(2, data);
+
+    dart_int = Dart_ListGetAt(semantic_args, 1);
+    Dart_IntegerToInt64(dart_int, &data);
+    ASSERT_EQ(1, data);
+    notify_semantics_action_latch.Signal();
+  };
+  std::vector<uint8_t> bytes({2, 1});
+  result = FlutterEngineDispatchSemanticsAction(
+      engine.get(), 42, kFlutterSemanticsActionTap, &bytes[0], bytes.size());
+  ASSERT_EQ(result, FlutterEngineResult::kSuccess);
+  notify_semantics_action_latch.Wait();
+
+  // Disable semantics. Wait for NotifySemanticsEnabled(false).
+  fml::AutoResetWaitableEvent notify_semantics_enabled_latch_3;
+  notify_semantics_enabled_callback = [&](Dart_NativeArguments args) {
+    bool enabled = true;
+    Dart_GetNativeBooleanArgument(args, 0, &enabled);
+    ASSERT_FALSE(enabled);
+    notify_semantics_enabled_latch_3.Signal();
+  };
+  result = FlutterEngineUpdateSemanticsEnabled(engine.get(), false);
+  ASSERT_EQ(result, FlutterEngineResult::kSuccess);
+  notify_semantics_enabled_latch_3.Wait();
+}
+
+TEST_F(EmbedderA11yTest, A11yTreeIsConsistentUsingUnstableCallbacks) {
+#if defined(OS_FUCHSIA)
+  GTEST_SKIP() << "This test crashes on Fuchsia. https://fxbug.dev/87493 ";
+#endif  // OS_FUCHSIA
+
+  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
 
   fml::AutoResetWaitableEvent signal_native_latch;
 

--- a/shell/platform/embedder/tests/embedder_a11y_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_a11y_unittests.cc
@@ -93,13 +93,7 @@ TEST_F(EmbedderA11yTest, A11yTreeIsConsistent) {
   GTEST_SKIP() << "This test crashes on Fuchsia. https://fxbug.dev/87493 ";
 #endif  // OS_FUCHSIA
 
-#ifdef SHELL_ENABLE_GL
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
-#elif SHELL_ENABLE_METAL
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kMetalContext);
-#else
   auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
-#endif
 
   fml::AutoResetWaitableEvent signal_native_latch;
 
@@ -281,7 +275,7 @@ TEST_F(EmbedderA11yTest, A11yTreeIsConsistentUsingUnstableCallbacks) {
   GTEST_SKIP() << "This test crashes on Fuchsia. https://fxbug.dev/87493 ";
 #endif  // OS_FUCHSIA
 
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
 
   fml::AutoResetWaitableEvent signal_native_latch;
 
@@ -457,13 +451,7 @@ TEST_F(EmbedderA11yTest, A11yTreeIsConsistentUsingUnstableCallbacks) {
 }
 
 TEST_F(EmbedderA11yTest, A11yTreeIsConsistentUsingLegacyCallbacks) {
-#ifdef SHELL_ENABLE_GL
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
-#elif SHELL_ENABLE_METAL
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kMetalContext);
-#else
   auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
-#endif
 
   fml::AutoResetWaitableEvent signal_native_latch;
 

--- a/shell/platform/embedder/tests/embedder_config_builder.cc
+++ b/shell/platform/embedder/tests/embedder_config_builder.cc
@@ -247,6 +247,8 @@ void EmbedderConfigBuilder::SetIsolateCreateCallbackHook() {
 }
 
 void EmbedderConfigBuilder::SetSemanticsCallbackHooks() {
+  project_args_.update_semantics_callback2 =
+      context_.GetUpdateSemanticsCallback2Hook();
   project_args_.update_semantics_callback =
       context_.GetUpdateSemanticsCallbackHook();
   project_args_.update_semantics_node_callback =

--- a/shell/platform/embedder/tests/embedder_test_context.cc
+++ b/shell/platform/embedder/tests/embedder_test_context.cc
@@ -121,6 +121,11 @@ void EmbedderTestContext::AddNativeCallback(const char* name,
   native_resolver_->AddNativeCallback({name}, function);
 }
 
+void EmbedderTestContext::SetSemanticsUpdateCallback2(
+    SemanticsUpdateCallback2 update_semantics_callback) {
+  update_semantics_callback2_ = std::move(update_semantics_callback);
+}
+
 void EmbedderTestContext::SetSemanticsUpdateCallback(
     SemanticsUpdateCallback update_semantics_callback) {
   update_semantics_callback_ = std::move(update_semantics_callback);
@@ -152,6 +157,20 @@ void EmbedderTestContext::PlatformMessageCallback(
 void EmbedderTestContext::SetLogMessageCallback(
     const LogMessageCallback& callback) {
   log_message_callback_ = callback;
+}
+
+FlutterUpdateSemanticsCallback2
+EmbedderTestContext::GetUpdateSemanticsCallback2Hook() {
+  if (update_semantics_callback2_ == nullptr) {
+    return nullptr;
+  }
+
+  return [](const FlutterSemanticsUpdate2* update, void* user_data) {
+    auto context = reinterpret_cast<EmbedderTestContext*>(user_data);
+    if (context->update_semantics_callback2_) {
+      context->update_semantics_callback2_(update);
+    }
+  };
 }
 
 FlutterUpdateSemanticsCallback

--- a/shell/platform/embedder/tests/embedder_test_context.h
+++ b/shell/platform/embedder/tests/embedder_test_context.h
@@ -24,6 +24,8 @@
 namespace flutter {
 namespace testing {
 
+using SemanticsUpdateCallback2 =
+    std::function<void(const FlutterSemanticsUpdate2*)>;
 using SemanticsUpdateCallback =
     std::function<void(const FlutterSemanticsUpdate*)>;
 using SemanticsNodeCallback = std::function<void(const FlutterSemanticsNode*)>;
@@ -70,6 +72,8 @@ class EmbedderTestContext {
   void SetRootSurfaceTransformation(SkMatrix matrix);
 
   void AddIsolateCreateCallback(const fml::closure& closure);
+
+  void SetSemanticsUpdateCallback2(SemanticsUpdateCallback2 update_semantics);
 
   void SetSemanticsUpdateCallback(SemanticsUpdateCallback update_semantics);
 
@@ -124,6 +128,7 @@ class EmbedderTestContext {
   UniqueAOTData aot_data_;
   std::vector<fml::closure> isolate_create_callbacks_;
   std::shared_ptr<TestDartNativeResolver> native_resolver_;
+  SemanticsUpdateCallback2 update_semantics_callback2_;
   SemanticsUpdateCallback update_semantics_callback_;
   SemanticsNodeCallback update_semantics_node_callback_;
   SemanticsActionCallback update_semantics_custom_action_callback_;
@@ -135,6 +140,8 @@ class EmbedderTestContext {
   std::function<void(intptr_t)> vsync_callback_ = nullptr;
 
   static VoidCallback GetIsolateCreateCallbackHook();
+
+  FlutterUpdateSemanticsCallback2 GetUpdateSemanticsCallback2Hook();
 
   FlutterUpdateSemanticsCallback GetUpdateSemanticsCallbackHook();
 


### PR DESCRIPTION
This introduces a new update semantics embedder API that is identical to [the previous update semantics embedder API](https://github.com/flutter/engine/pull/37129), except that its ABI is stable as:

1. The callback uses array of pointers to structs instead of array of structs. This ensures that array indexing does not break if new members are added to the structs.
2. The types `FlutterSemanticsNode` and `FlutterSemanticsCustomAction` were duplicated as `FlutterSemanticsNode2` and `FlutterSemanticsCustomAction2`. This is necessary as `FlutterSemanticsUpdate` has an array of `FlutterSemanticsNode` and an array of `FlutterSemanticsCustomAction`. Adding new members to these structs would break the ABI compatibility of array indexing.

This change does not migrate embedders to this new embedder API, this will be done in subsequent changes: https://github.com/flutter/flutter/issues/121176.

Part of: https://github.com/flutter/flutter/issues/121176
See [go/flutter-semantics-abi](http://go/flutter-semantics-abi).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
