### PR TITLE
[Impeller] Add PolygonMode to render layer

### DIFF
--- a/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -409,10 +409,21 @@ struct RenderPassData {
     }
 
     //--------------------------------------------------------------------------
+    /// Determine the primitive type.
+    ///
+    // GLES doesn't support setting the fill mode, so override the primitive
+    // with GL_LINE_STRIP to somewhat emulate PolygonMode::kLine. This isn't
+    // correct; full triangle outlines won't be drawn and disconnected
+    // geometry may appear connected. However this can still be useful for
+    // wireframe debug views.
+    auto mode = pipeline.GetDescriptor().GetPolygonMode() == PolygonMode::kLine
+                    ? GL_LINE_STRIP
+                    : ToMode(pipeline.GetDescriptor().GetPrimitiveType());
+
+    //--------------------------------------------------------------------------
     /// Finally! Invoke the draw call.
     ///
-    PrimitiveType primitive_type = pipeline.GetDescriptor().GetPrimitiveType();
-    gl.DrawElements(ToMode(primitive_type),           // mode
+    gl.DrawElements(mode,                             // mode
                     command.index_count,              // count
                     ToIndexType(command.index_type),  // type
                     reinterpret_cast<const GLvoid*>(static_cast<GLsizei>(

--- a/impeller/renderer/backend/metal/formats_mtl.h
+++ b/impeller/renderer/backend/metal/formats_mtl.h
@@ -150,6 +150,16 @@ constexpr MTLPrimitiveType ToMTLPrimitiveType(PrimitiveType type) {
   return MTLPrimitiveTypePoint;
 }
 
+constexpr MTLTriangleFillMode ToMTLTriangleFillMode(PolygonMode mode) {
+  switch (mode) {
+    case PolygonMode::kFill:
+      return MTLTriangleFillModeFill;
+    case PolygonMode::kLine:
+      return MTLTriangleFillModeLines;
+  }
+  return MTLTriangleFillModeFill;
+}
+
 constexpr MTLIndexType ToMTLIndexType(IndexType type) {
   switch (type) {
     case IndexType::k16bit:

--- a/impeller/renderer/backend/metal/render_pass_mtl.mm
+++ b/impeller/renderer/backend/metal/render_pass_mtl.mm
@@ -468,6 +468,8 @@ bool RenderPassMTL::EncodeCommands(const std::shared_ptr<Allocator>& allocator,
                                        ? MTLWindingClockwise
                                        : MTLWindingCounterClockwise];
     [encoder setCullMode:ToMTLCullMode(pipeline_desc.GetCullMode())];
+    [encoder setTriangleFillMode:ToMTLTriangleFillMode(
+                                     pipeline_desc.GetPolygonMode())];
     [encoder setStencilReferenceValue:command.stencil_reference];
 
     if (!bind_stage_resources(command.vertex_bindings, ShaderStage::kVertex)) {

--- a/impeller/renderer/backend/vulkan/formats_vk.h
+++ b/impeller/renderer/backend/vulkan/formats_vk.h
@@ -336,6 +336,16 @@ constexpr vk::IndexType ToVKIndexType(IndexType index_type) {
   FML_UNREACHABLE();
 }
 
+constexpr vk::PolygonMode ToVKPolygonMode(PolygonMode mode) {
+  switch (mode) {
+    case PolygonMode::kFill:
+      return vk::PolygonMode::eFill;
+    case PolygonMode::kLine:
+      return vk::PolygonMode::eLine;
+  }
+  FML_UNREACHABLE();
+}
+
 constexpr vk::PrimitiveTopology ToVKPrimitiveTopology(PrimitiveType primitive) {
   switch (primitive) {
     case PrimitiveType::kTriangle:

--- a/impeller/renderer/backend/vulkan/pipeline_library_vk.cc
+++ b/impeller/renderer/backend/vulkan/pipeline_library_vk.cc
@@ -275,7 +275,7 @@ std::unique_ptr<PipelineCreateInfoVK> PipelineLibraryVK::CreatePipeline(
   vk::PipelineRasterizationStateCreateInfo rasterization_state;
   rasterization_state.setFrontFace(vk::FrontFace::eClockwise);
   rasterization_state.setCullMode(vk::CullModeFlagBits::eNone);
-  rasterization_state.setPolygonMode(vk::PolygonMode::eFill);
+  rasterization_state.setPolygonMode(ToVKPolygonMode(desc.GetPolygonMode()));
   // requires GPU extensions to change.
   {
     rasterization_state.setLineWidth(1.0f);

--- a/impeller/renderer/formats.h
+++ b/impeller/renderer/formats.h
@@ -215,6 +215,11 @@ enum class PrimitiveType {
   // checks. Hence, they are not supported here.
 };
 
+enum class PolygonMode {
+  kFill,
+  kLine,
+};
+
 struct DepthRange {
   Scalar z_near = 0.0;
   Scalar z_far = 1.0;

--- a/impeller/renderer/pipeline_descriptor.cc
+++ b/impeller/renderer/pipeline_descriptor.cc
@@ -41,6 +41,7 @@ std::size_t PipelineDescriptor::GetHash() const {
   fml::HashCombineSeed(seed, winding_order_);
   fml::HashCombineSeed(seed, cull_mode_);
   fml::HashCombineSeed(seed, primitive_type_);
+  fml::HashCombineSeed(seed, polygon_mode_);
   return seed;
 }
 
@@ -59,7 +60,8 @@ bool PipelineDescriptor::IsEqual(const PipelineDescriptor& other) const {
              other.back_stencil_attachment_descriptor_ &&
          winding_order_ == other.winding_order_ &&
          cull_mode_ == other.cull_mode_ &&
-         primitive_type_ == other.primitive_type_;
+         primitive_type_ == other.primitive_type_ &&
+         polygon_mode_ == other.polygon_mode_;
 }
 
 PipelineDescriptor& PipelineDescriptor::SetLabel(std::string label) {
@@ -257,6 +259,14 @@ void PipelineDescriptor::SetPrimitiveType(PrimitiveType type) {
 
 PrimitiveType PipelineDescriptor::GetPrimitiveType() const {
   return primitive_type_;
+}
+
+void PipelineDescriptor::SetPolygonMode(PolygonMode mode) {
+  polygon_mode_ = mode;
+}
+
+PolygonMode PipelineDescriptor::GetPolygonMode() const {
+  return polygon_mode_;
 }
 
 }  // namespace impeller

--- a/impeller/renderer/pipeline_descriptor.h
+++ b/impeller/renderer/pipeline_descriptor.h
@@ -125,6 +125,10 @@ class PipelineDescriptor final : public Comparable<PipelineDescriptor> {
 
   PrimitiveType GetPrimitiveType() const;
 
+  void SetPolygonMode(PolygonMode mode);
+
+  PolygonMode GetPolygonMode() const;
+
  private:
   std::string label_;
   SampleCount sample_count_ = SampleCount::kCount1;
@@ -142,6 +146,7 @@ class PipelineDescriptor final : public Comparable<PipelineDescriptor> {
   std::optional<StencilAttachmentDescriptor>
       back_stencil_attachment_descriptor_;
   PrimitiveType primitive_type_ = PrimitiveType::kTriangle;
+  PolygonMode polygon_mode_ = PolygonMode::kFill;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -54,9 +54,6 @@ TEST_P(RendererTest, CanCreateBoxPrimitive) {
   auto desc = BoxPipelineBuilder::MakeDefaultPipelineDescriptor(*context);
   ASSERT_TRUE(desc.has_value());
   desc->SetSampleCount(SampleCount::kCount4);
-  auto box_pipeline =
-      context->GetPipelineLibrary()->GetPipeline(std::move(desc)).Get();
-  ASSERT_TRUE(box_pipeline);
 
   // Vertex buffer.
   VertexBufferBuilder<VS::PerVertexData> vertex_builder;
@@ -79,9 +76,19 @@ TEST_P(RendererTest, CanCreateBoxPrimitive) {
   auto sampler = context->GetSamplerLibrary()->GetSampler({});
   ASSERT_TRUE(sampler);
   SinglePassCallback callback = [&](RenderPass& pass) {
+    ImGui::Begin("Controls", nullptr, ImGuiWindowFlags_AlwaysAutoResize);
+    static bool wireframe;
+    ImGui::Checkbox("Wireframe", &wireframe);
+    ImGui::End();
+
+    desc->SetPolygonMode(wireframe ? PolygonMode::kLine : PolygonMode::kFill);
+    auto pipeline = context->GetPipelineLibrary()->GetPipeline(desc).Get();
+
+    assert(pipeline && pipeline->IsValid());
+
     Command cmd;
     cmd.label = "Box";
-    cmd.pipeline = box_pipeline;
+    cmd.pipeline = pipeline;
 
     cmd.BindVertices(vertex_buffer);
 


### PR DESCRIPTION
Allows for good wireframe drawing. I've reached for line strips when using playgrounds to interactively debug geometry issues many times in the past. But for stroke paths, this is often insufficient for visualizing problems with joins, caps, and disconnected contours.

https://user-images.githubusercontent.com/919017/220804041-62079a6e-e8ca-40b6-a266-01b7f2201647.mov

