### PR TITLE
Make FlutterException constructor public

### DIFF
--- a/shell/platform/android/io/flutter/plugin/common/FlutterException.java
+++ b/shell/platform/android/io/flutter/plugin/common/FlutterException.java
@@ -14,7 +14,7 @@ public class FlutterException extends RuntimeException {
   public final String code;
   public final Object details;
 
-  FlutterException(String code, String message, Object details) {
+  public FlutterException(String code, String message, Object details) {
     super(message);
     if (BuildConfig.DEBUG && code == null) {
       Log.e(TAG, "Parameter code must not be null.");


### PR DESCRIPTION
The default constructor access modifier in java is package-private, which restricts access outside of this package
Change the constructor to `public` so that others may construct their own `FlutterException`

![20230223_20h48m21s_grim](https://user-images.githubusercontent.com/52340924/220911876-e89e0a6d-7d9f-4af8-828b-d4ab4b4f1b83.png)