### PR TITLE
Unregister the FlutterWindowsView on its destruction

### DIFF
--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -404,7 +404,9 @@ bool FlutterWindowsEngine::Stop() {
 
 void FlutterWindowsEngine::SetView(FlutterWindowsView* view) {
   view_ = view;
-  InitializeKeyboard();
+  if (view) {
+    InitializeKeyboard();
+  }
 }
 
 void FlutterWindowsEngine::OnVsync(intptr_t baton) {

--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -50,6 +50,9 @@ FlutterWindowsView::FlutterWindowsView(
 
 FlutterWindowsView::~FlutterWindowsView() {
   DestroyRenderSurface();
+  if (engine_) {
+    engine_->SetView(nullptr);
+  }
 }
 
 void FlutterWindowsView::SetEngine(

--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -49,10 +49,10 @@ FlutterWindowsView::FlutterWindowsView(
 }
 
 FlutterWindowsView::~FlutterWindowsView() {
-  DestroyRenderSurface();
   if (engine_) {
     engine_->SetView(nullptr);
   }
+  DestroyRenderSurface();
 }
 
 void FlutterWindowsView::SetEngine(

--- a/shell/platform/windows/flutter_windows_view_unittests.cc
+++ b/shell/platform/windows/flutter_windows_view_unittests.cc
@@ -912,5 +912,25 @@ TEST(FlutterWindowsViewTest, TooltipNodeData) {
   EXPECT_EQ(uia_tooltip, "tooltip");
 }
 
+TEST(FlutterWindowsViewTest, DestructorTest) {
+  bool destroyed = false;
+  std::unique_ptr<FlutterWindowsEngine> engine = GetTestEngine();
+
+  auto window_binding_handler =
+      std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();
+  ON_CALL(*window_binding_handler, Destruct).WillByDefault([&destroyed](){
+    EXPECT_FALSE(destroyed);
+    destroyed = true;
+  });
+
+  {
+    FlutterWindowsView view(std::move(window_binding_handler));
+    view.SetEngine(std::move(engine));
+    // Destruct view before continuing.
+  }
+
+  EXPECT_TRUE(destroyed);
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/shell/platform/windows/flutter_windows_view_unittests.cc
+++ b/shell/platform/windows/flutter_windows_view_unittests.cc
@@ -915,16 +915,22 @@ TEST(FlutterWindowsViewTest, TooltipNodeData) {
 TEST(FlutterWindowsViewTest, DestructorTest) {
   bool destroyed = false;
   std::unique_ptr<FlutterWindowsEngine> engine = GetTestEngine();
+  // Use this pointer to reference the view in the Destruct callback, which must be
+  // defined before the view is.
+  FlutterWindowsView* view_ptr = nullptr;
 
   auto window_binding_handler =
       std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();
-  ON_CALL(*window_binding_handler, Destruct).WillByDefault([&destroyed](){
+  ON_CALL(*window_binding_handler, Destruct).WillByDefault([&destroyed, &view_ptr](){
     EXPECT_FALSE(destroyed);
     destroyed = true;
+    ASSERT_NE(view_ptr, nullptr);
+    EXPECT_EQ(view_ptr->GetEngine()->view(), nullptr);
   });
 
   {
     FlutterWindowsView view(std::move(window_binding_handler));
+    view_ptr = &view;
     view.SetEngine(std::move(engine));
     // Destruct view before continuing.
   }

--- a/shell/platform/windows/flutter_windows_view_unittests.cc
+++ b/shell/platform/windows/flutter_windows_view_unittests.cc
@@ -915,18 +915,19 @@ TEST(FlutterWindowsViewTest, TooltipNodeData) {
 TEST(FlutterWindowsViewTest, DestructorTest) {
   bool destroyed = false;
   std::unique_ptr<FlutterWindowsEngine> engine = GetTestEngine();
-  // Use this pointer to reference the view in the Destruct callback, which must be
-  // defined before the view is.
+  // Use this pointer to reference the view in the Destruct callback, which must
+  // be defined before the view is.
   FlutterWindowsView* view_ptr = nullptr;
 
   auto window_binding_handler =
       std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();
-  ON_CALL(*window_binding_handler, Destruct).WillByDefault([&destroyed, &view_ptr](){
-    EXPECT_FALSE(destroyed);
-    destroyed = true;
-    ASSERT_NE(view_ptr, nullptr);
-    EXPECT_EQ(view_ptr->GetEngine()->view(), nullptr);
-  });
+  ON_CALL(*window_binding_handler, Destruct)
+      .WillByDefault([&destroyed, &view_ptr]() {
+        EXPECT_FALSE(destroyed);
+        destroyed = true;
+        ASSERT_NE(view_ptr, nullptr);
+        EXPECT_EQ(view_ptr->GetEngine()->view(), nullptr);
+      });
 
   {
     FlutterWindowsView view(std::move(window_binding_handler));

--- a/shell/platform/windows/testing/mock_window_binding_handler.cc
+++ b/shell/platform/windows/testing/mock_window_binding_handler.cc
@@ -9,7 +9,9 @@ namespace testing {
 
 MockWindowBindingHandler::MockWindowBindingHandler() : WindowBindingHandler(){};
 
-MockWindowBindingHandler::~MockWindowBindingHandler() { Destruct(); }
+MockWindowBindingHandler::~MockWindowBindingHandler() {
+  Destruct();
+}
 
 }  // namespace testing
 }  // namespace flutter

--- a/shell/platform/windows/testing/mock_window_binding_handler.cc
+++ b/shell/platform/windows/testing/mock_window_binding_handler.cc
@@ -9,7 +9,7 @@ namespace testing {
 
 MockWindowBindingHandler::MockWindowBindingHandler() : WindowBindingHandler(){};
 
-MockWindowBindingHandler::~MockWindowBindingHandler() = default;
+MockWindowBindingHandler::~MockWindowBindingHandler() { Destruct(); }
 
 }  // namespace testing
 }  // namespace flutter

--- a/shell/platform/windows/testing/mock_window_binding_handler.h
+++ b/shell/platform/windows/testing/mock_window_binding_handler.h
@@ -36,6 +36,7 @@ class MockWindowBindingHandler : public WindowBindingHandler {
   MOCK_METHOD0(SendInitialAccessibilityFeatures, void());
   MOCK_METHOD0(GetAlertDelegate, AlertPlatformNodeDelegate*());
   MOCK_METHOD0(GetAlert, ui::AXPlatformNodeWin*());
+  MOCK_METHOD0(Destruct, void());
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(MockWindowBindingHandler);


### PR DESCRIPTION
`FlutterWindowsView` owns both the `FlutterWindowsEngine` and `WindowBindingHandler` as unique pointers, so each is released upon its destruction. However, in the brief time between the release of the handler and the engine, the engine may attempt to call a method that expects the handler to exist.

Solve this by unsetting the engine's view from `FlutterWindowsView::~FlutterWindowsView`, which should complete before destructing its members. Include a unit test to verify that the view is unset by the time the handler is released.

https://github.com/flutter/flutter/issues/121189

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
