### PR TITLE
delete DL ops no longer needed after removing SkCanvasRecorder

### DIFF
--- a/display_list/display_list.h
+++ b/display_list/display_list.h
@@ -38,7 +38,7 @@
 //                       Any class implementing Dispatcher can inherit from
 //                       these utility classes to simplify its creation
 //
-// The Flutter DisplayList mechanism can be used in place of the Skia
+// The Flutter DisplayList mechanism is used in a similar manner to the Skia
 // SkPicture mechanism. The primary means of communication into and out
 // of the DisplayList is through the Dispatcher virtual class which
 // provides a nearly 1:1 translation between the records of the DisplayList
@@ -74,9 +74,6 @@ namespace flutter {
                                     \
   V(SetColor)                       \
   V(SetBlendMode)                   \
-                                    \
-  V(SetBlender)                     \
-  V(ClearBlender)                   \
                                     \
   V(SetSkPathEffect)                \
   V(SetPodPathEffect)               \
@@ -139,19 +136,15 @@ namespace flutter {
   V(DrawLines)                      \
   V(DrawPolygon)                    \
   V(DrawVertices)                   \
-  V(DrawSkVertices)                 \
                                     \
   V(DrawImage)                      \
   V(DrawImageWithAttr)              \
   V(DrawImageRect)                  \
   V(DrawImageNine)                  \
   V(DrawImageNineWithAttr)          \
-  V(DrawImageLattice)               \
   V(DrawAtlas)                      \
   V(DrawAtlasCulled)                \
                                     \
-  V(DrawSkPicture)                  \
-  V(DrawSkPictureMatrix)            \
   V(DrawDisplayList)                \
   V(DrawTextBlob)                   \
                                     \
@@ -258,9 +251,9 @@ class DisplayList : public SkRefCnt {
 
   void RenderTo(SkCanvas* canvas, SkScalar opacity = SK_Scalar1) const;
 
-  // SkPicture always includes nested bytes, but nested ops are
-  // only included if requested. The defaults used here for these
-  // accessors follow that pattern.
+  // From historical behavior, SkPicture always included nested bytes,
+  // but nested ops are only included if requested. The defaults used
+  // here for these accessors follow that pattern.
   size_t bytes(bool nested = true) const {
     return sizeof(DisplayList) + byte_count_ +
            (nested ? nested_byte_count_ : 0);

--- a/display_list/display_list_benchmarks.cc
+++ b/display_list/display_list_benchmarks.cc
@@ -13,17 +13,17 @@
 namespace flutter {
 namespace testing {
 
-SkPaint GetPaintForRun(unsigned attributes) {
-  SkPaint paint;
+DlPaint GetPaintForRun(unsigned attributes) {
+  DlPaint paint;
 
   if (attributes & kStrokedStyle_Flag && attributes & kFilledStyle_Flag) {
     // Not currently exposed by Flutter, but we can probably benchmark this in
     // the future
-    paint.setStyle(SkPaint::kStrokeAndFill_Style);
+    paint.setDrawStyle(DlDrawStyle::kStrokeAndFill);
   } else if (attributes & kStrokedStyle_Flag) {
-    paint.setStyle(SkPaint::kStroke_Style);
+    paint.setDrawStyle(DlDrawStyle::kStroke);
   } else if (attributes & kFilledStyle_Flag) {
-    paint.setStyle(SkPaint::kFill_Style);
+    paint.setDrawStyle(DlDrawStyle::kFill);
   }
 
   if (attributes & kHairlineStroke_Flag) {
@@ -76,7 +76,7 @@ void BM_DrawLine(benchmark::State& state,
                  unsigned attributes) {
   auto surface_provider = DlSurfaceProvider::Create(backend_type);
   DisplayListBuilder builder;
-  builder.setAttributesFromPaint(GetPaintForRun(attributes),
+  builder.SetAttributesFromPaint(GetPaintForRun(attributes),
                                  DisplayListOpFlags::kDrawLineFlags);
   AnnotateAttributes(attributes, state, DisplayListOpFlags::kDrawLineFlags);
 
@@ -114,7 +114,7 @@ void BM_DrawRect(benchmark::State& state,
                  unsigned attributes) {
   auto surface_provider = DlSurfaceProvider::Create(backend_type);
   DisplayListBuilder builder;
-  builder.setAttributesFromPaint(GetPaintForRun(attributes),
+  builder.SetAttributesFromPaint(GetPaintForRun(attributes),
                                  DisplayListOpFlags::kDrawRectFlags);
   AnnotateAttributes(attributes, state, DisplayListOpFlags::kDrawRectFlags);
 
@@ -163,7 +163,7 @@ void BM_DrawOval(benchmark::State& state,
                  unsigned attributes) {
   auto surface_provider = DlSurfaceProvider::Create(backend_type);
   DisplayListBuilder builder;
-  builder.setAttributesFromPaint(GetPaintForRun(attributes),
+  builder.SetAttributesFromPaint(GetPaintForRun(attributes),
                                  DisplayListOpFlags::kDrawOvalFlags);
   AnnotateAttributes(attributes, state, DisplayListOpFlags::kDrawOvalFlags);
 
@@ -209,7 +209,7 @@ void BM_DrawCircle(benchmark::State& state,
                    unsigned attributes) {
   auto surface_provider = DlSurfaceProvider::Create(backend_type);
   DisplayListBuilder builder;
-  builder.setAttributesFromPaint(GetPaintForRun(attributes),
+  builder.SetAttributesFromPaint(GetPaintForRun(attributes),
                                  DisplayListOpFlags::kDrawCircleFlags);
   AnnotateAttributes(attributes, state, DisplayListOpFlags::kDrawCircleFlags);
 
@@ -258,7 +258,7 @@ void BM_DrawRRect(benchmark::State& state,
                   SkRRect::Type type) {
   auto surface_provider = DlSurfaceProvider::Create(backend_type);
   DisplayListBuilder builder;
-  builder.setAttributesFromPaint(GetPaintForRun(attributes),
+  builder.SetAttributesFromPaint(GetPaintForRun(attributes),
                                  DisplayListOpFlags::kDrawRRectFlags);
   AnnotateAttributes(attributes, state, DisplayListOpFlags::kDrawRRectFlags);
 
@@ -339,7 +339,7 @@ void BM_DrawDRRect(benchmark::State& state,
                    SkRRect::Type type) {
   auto surface_provider = DlSurfaceProvider::Create(backend_type);
   DisplayListBuilder builder;
-  builder.setAttributesFromPaint(GetPaintForRun(attributes),
+  builder.SetAttributesFromPaint(GetPaintForRun(attributes),
                                  DisplayListOpFlags::kDrawDRRectFlags);
   AnnotateAttributes(attributes, state, DisplayListOpFlags::kDrawDRRectFlags);
 
@@ -413,7 +413,7 @@ void BM_DrawArc(benchmark::State& state,
                 unsigned attributes) {
   auto surface_provider = DlSurfaceProvider::Create(backend_type);
   DisplayListBuilder builder;
-  builder.setAttributesFromPaint(GetPaintForRun(attributes),
+  builder.SetAttributesFromPaint(GetPaintForRun(attributes),
                                  DisplayListOpFlags::kDrawArcNoCenterFlags);
   AnnotateAttributes(attributes, state,
                      DisplayListOpFlags::kDrawArcNoCenterFlags);
@@ -629,7 +629,7 @@ void BM_DrawPath(benchmark::State& state,
                  SkPath::Verb type) {
   auto surface_provider = DlSurfaceProvider::Create(backend_type);
   DisplayListBuilder builder;
-  builder.setAttributesFromPaint(GetPaintForRun(attributes),
+  builder.SetAttributesFromPaint(GetPaintForRun(attributes),
                                  DisplayListOpFlags::kDrawPathFlags);
   AnnotateAttributes(attributes, state, DisplayListOpFlags::kDrawPathFlags);
 
@@ -767,7 +767,7 @@ void BM_DrawVertices(benchmark::State& state,
                      DlVertexMode mode) {
   auto surface_provider = DlSurfaceProvider::Create(backend_type);
   DisplayListBuilder builder;
-  builder.setAttributesFromPaint(GetPaintForRun(attributes),
+  builder.SetAttributesFromPaint(GetPaintForRun(attributes),
                                  DisplayListOpFlags::kDrawVerticesFlags);
   AnnotateAttributes(attributes, state, DisplayListOpFlags::kDrawVerticesFlags);
 
@@ -866,21 +866,21 @@ void BM_DrawPoints(benchmark::State& state,
   SkPaint paint;
   switch (mode) {
     case DlCanvas::PointMode::kPoints:
-      builder.setAttributesFromPaint(
+      builder.SetAttributesFromPaint(
           GetPaintForRun(attributes),
           DisplayListOpFlags::kDrawPointsAsPointsFlags);
       AnnotateAttributes(attributes, state,
                          DisplayListOpFlags::kDrawPointsAsPointsFlags);
       break;
     case DlCanvas::PointMode::kLines:
-      builder.setAttributesFromPaint(
+      builder.SetAttributesFromPaint(
           GetPaintForRun(attributes),
           DisplayListOpFlags::kDrawPointsAsLinesFlags);
       AnnotateAttributes(attributes, state,
                          DisplayListOpFlags::kDrawPointsAsLinesFlags);
       break;
     case DlCanvas::PointMode::kPolygon:
-      builder.setAttributesFromPaint(
+      builder.SetAttributesFromPaint(
           GetPaintForRun(attributes),
           DisplayListOpFlags::kDrawPointsAsPolygonFlags);
       AnnotateAttributes(attributes, state,
@@ -933,7 +933,7 @@ void BM_DrawImage(benchmark::State& state,
                   bool upload_bitmap) {
   auto surface_provider = DlSurfaceProvider::Create(backend_type);
   DisplayListBuilder builder;
-  builder.setAttributesFromPaint(GetPaintForRun(attributes),
+  builder.SetAttributesFromPaint(GetPaintForRun(attributes),
                                  DisplayListOpFlags::kDrawImageWithPaintFlags);
   AnnotateAttributes(attributes, state,
                      DisplayListOpFlags::kDrawImageWithPaintFlags);
@@ -1016,7 +1016,7 @@ void BM_DrawImageRect(benchmark::State& state,
                       bool upload_bitmap) {
   auto surface_provider = DlSurfaceProvider::Create(backend_type);
   DisplayListBuilder builder;
-  builder.setAttributesFromPaint(
+  builder.SetAttributesFromPaint(
       GetPaintForRun(attributes),
       DisplayListOpFlags::kDrawImageRectWithPaintFlags);
   AnnotateAttributes(attributes, state,
@@ -1104,7 +1104,7 @@ void BM_DrawImageNine(benchmark::State& state,
                       bool upload_bitmap) {
   auto surface_provider = DlSurfaceProvider::Create(backend_type);
   DisplayListBuilder builder;
-  builder.setAttributesFromPaint(
+  builder.SetAttributesFromPaint(
       GetPaintForRun(attributes),
       DisplayListOpFlags::kDrawImageNineWithPaintFlags);
   AnnotateAttributes(attributes, state,
@@ -1181,7 +1181,7 @@ void BM_DrawTextBlob(benchmark::State& state,
                      unsigned attributes) {
   auto surface_provider = DlSurfaceProvider::Create(backend_type);
   DisplayListBuilder builder;
-  builder.setAttributesFromPaint(GetPaintForRun(attributes),
+  builder.SetAttributesFromPaint(GetPaintForRun(attributes),
                                  DisplayListOpFlags::kDrawTextBlobFlags);
   AnnotateAttributes(attributes, state, DisplayListOpFlags::kDrawTextBlobFlags);
 
@@ -1228,7 +1228,7 @@ void BM_DrawShadow(benchmark::State& state,
                    SkPath::Verb type) {
   auto surface_provider = DlSurfaceProvider::Create(backend_type);
   DisplayListBuilder builder;
-  builder.setAttributesFromPaint(GetPaintForRun(attributes),
+  builder.SetAttributesFromPaint(GetPaintForRun(attributes),
                                  DisplayListOpFlags::kDrawShadowFlags);
   AnnotateAttributes(attributes, state, DisplayListOpFlags::kDrawShadowFlags);
 
@@ -1292,7 +1292,7 @@ void BM_SaveLayer(benchmark::State& state,
                   size_t save_depth) {
   auto surface_provider = DlSurfaceProvider::Create(backend_type);
   DisplayListBuilder builder;
-  builder.setAttributesFromPaint(GetPaintForRun(attributes),
+  builder.SetAttributesFromPaint(GetPaintForRun(attributes),
                                  DisplayListOpFlags::kSaveLayerFlags);
   AnnotateAttributes(attributes, state, DisplayListOpFlags::kSaveLayerFlags);
 

--- a/display_list/display_list_benchmarks.h
+++ b/display_list/display_list_benchmarks.h
@@ -28,7 +28,7 @@ enum BenchmarkAttributes {
   kAntiAliasing_Flag = 1 << 3
 };
 
-SkPaint GetPaintForRun(unsigned attributes);
+DlPaint GetPaintForRun(unsigned attributes);
 
 using BackendType = DlSurfaceProvider::BackendType;
 

--- a/display_list/display_list_blend_mode.h
+++ b/display_list/display_list_blend_mode.h
@@ -5,7 +5,7 @@
 #ifndef FLUTTER_DISPLAY_LIST_DISPLAY_LIST_BLEND_MODE_H_
 #define FLUTTER_DISPLAY_LIST_DISPLAY_LIST_BLEND_MODE_H_
 
-#include "include/core/SkBlender.h"
+#include "include/core/SkBlendMode.h"
 
 namespace flutter {
 

--- a/display_list/display_list_canvas_dispatcher.cc
+++ b/display_list/display_list_canvas_dispatcher.cc
@@ -188,11 +188,6 @@ void DisplayListCanvasDispatcher::drawPoints(PointMode mode,
                                              const SkPoint pts[]) {
   canvas_->drawPoints(ToSk(mode), count, pts, paint());
 }
-void DisplayListCanvasDispatcher::drawSkVertices(
-    const sk_sp<SkVertices> vertices,
-    SkBlendMode mode) {
-  canvas_->drawVertices(vertices, mode, paint());
-}
 void DisplayListCanvasDispatcher::drawVertices(const DlVertices* vertices,
                                                DlBlendMode mode) {
   canvas_->drawVertices(vertices->skia_object(), ToSk(mode), paint());
@@ -230,22 +225,6 @@ void DisplayListCanvasDispatcher::drawImageNine(const sk_sp<DlImage> image,
   canvas_->drawImageNine(skia_image.get(), center, dst, ToSk(filter),
                          safe_paint(render_with_attributes));
 }
-void DisplayListCanvasDispatcher::drawImageLattice(
-    const sk_sp<DlImage> image,
-    const SkCanvas::Lattice& lattice,
-    const SkRect& dst,
-    DlFilterMode filter,
-    bool render_with_attributes) {
-  if (!image) {
-    return;
-  }
-  auto skia_image = image->skia_image();
-  if (!skia_image) {
-    return;
-  }
-  canvas_->drawImageLattice(skia_image.get(), lattice, dst, ToSk(filter),
-                            safe_paint(render_with_attributes));
-}
 void DisplayListCanvasDispatcher::drawAtlas(const sk_sp<DlImage> atlas,
                                             const SkRSXform xform[],
                                             const SkRect tex[],
@@ -266,18 +245,6 @@ void DisplayListCanvasDispatcher::drawAtlas(const sk_sp<DlImage> atlas,
   canvas_->drawAtlas(skia_atlas.get(), xform, tex, sk_colors, count, ToSk(mode),
                      ToSk(sampling), cullRect,
                      safe_paint(render_with_attributes));
-}
-void DisplayListCanvasDispatcher::drawPicture(const sk_sp<SkPicture> picture,
-                                              const SkMatrix* matrix,
-                                              bool render_with_attributes) {
-  const SkPaint* paint = safe_paint(render_with_attributes);
-  if (paint) {
-    // drawPicture does an implicit saveLayer if an SkPaint is supplied.
-    TRACE_EVENT0("flutter", "Canvas::saveLayer");
-    canvas_->drawPicture(picture, matrix, paint);
-  } else {
-    canvas_->drawPicture(picture, matrix, nullptr);
-  }
 }
 void DisplayListCanvasDispatcher::drawDisplayList(
     const sk_sp<DisplayList> display_list) {

--- a/display_list/display_list_canvas_dispatcher.h
+++ b/display_list/display_list_canvas_dispatcher.h
@@ -71,8 +71,6 @@ class DisplayListCanvasDispatcher : public virtual Dispatcher,
                SkScalar sweep,
                bool useCenter) override;
   void drawPoints(PointMode mode, uint32_t count, const SkPoint pts[]) override;
-  void drawSkVertices(const sk_sp<SkVertices> vertices,
-                      SkBlendMode mode) override;
   void drawVertices(const DlVertices* vertices, DlBlendMode mode) override;
   void drawImage(const sk_sp<DlImage> image,
                  const SkPoint point,
@@ -89,11 +87,6 @@ class DisplayListCanvasDispatcher : public virtual Dispatcher,
                      const SkRect& dst,
                      DlFilterMode filter,
                      bool render_with_attributes) override;
-  void drawImageLattice(const sk_sp<DlImage> image,
-                        const SkCanvas::Lattice& lattice,
-                        const SkRect& dst,
-                        DlFilterMode filter,
-                        bool render_with_attributes) override;
   void drawAtlas(const sk_sp<DlImage> atlas,
                  const SkRSXform xform[],
                  const SkRect tex[],
@@ -103,9 +96,6 @@ class DisplayListCanvasDispatcher : public virtual Dispatcher,
                  DlImageSampling sampling,
                  const SkRect* cullRect,
                  bool render_with_attributes) override;
-  void drawPicture(const sk_sp<SkPicture> picture,
-                   const SkMatrix* matrix,
-                   bool render_with_attributes) override;
   void drawDisplayList(const sk_sp<DisplayList> display_list) override;
   void drawTextBlob(const sk_sp<SkTextBlob> blob,
                     SkScalar x,

--- a/display_list/display_list_complexity_gl.cc
+++ b/display_list/display_list_complexity_gl.cc
@@ -483,34 +483,6 @@ void DisplayListGLComplexityCalculator::GLHelper::drawPoints(
   AccumulateComplexity(complexity);
 }
 
-void DisplayListGLComplexityCalculator::GLHelper::drawSkVertices(
-    const sk_sp<SkVertices> vertices,
-    SkBlendMode mode) {
-  // There is currently no way for us to get the VertexMode from the SkVertices
-  // object, but for future reference:
-  //
-  // TriangleStrip is roughly 25% more expensive than TriangleFan.
-  // TriangleFan is roughly 5% more expensive than Triangles.
-
-  // There is currently no way for us to get the vertex count from an SkVertices
-  // object, so we have to estimate it from the approximate size.
-  //
-  // Approximate size returns the sum of the sizes of the positions (SkPoint),
-  // texs (SkPoint), colors (SkColor) and indices (uint16_t) arrays multiplied
-  // by sizeof(type). As a very, very rough estimate, divide that by 20 to get
-  // an idea of the vertex count.
-  unsigned int approximate_vertex_count = vertices->approximateSize() / 20;
-
-  // For the baseline, it's hard to identify the trend. It might be O(n^1/2)
-  // For now, treat it as linear as an approximation.
-  //
-  // m = 1/1600
-  // c = 1
-  unsigned int complexity = (approximate_vertex_count + 1600) * 250 / 2;
-
-  AccumulateComplexity(complexity);
-}
-
 void DisplayListGLComplexityCalculator::GLHelper::drawVertices(
     const DlVertices* vertices,
     DlBlendMode mode) {

--- a/display_list/display_list_complexity_gl.h
+++ b/display_list/display_list_complexity_gl.h
@@ -55,7 +55,6 @@ class DisplayListGLComplexityCalculator
     void drawPoints(DlCanvas::PointMode mode,
                     uint32_t count,
                     const SkPoint points[]) override;
-    void drawSkVertices(const sk_sp<SkVertices>, SkBlendMode mode) override;
     void drawVertices(const DlVertices* vertices, DlBlendMode mode) override;
     void drawImage(const sk_sp<DlImage> image,
                    const SkPoint point,

--- a/display_list/display_list_complexity_helper.h
+++ b/display_list/display_list_complexity_helper.h
@@ -108,7 +108,6 @@ class ComplexityCalculatorHelper
   void setStrokeMiter(SkScalar limit) override {}
   void setColor(DlColor color) override {}
   void setBlendMode(DlBlendMode mode) override {}
-  void setBlender(sk_sp<SkBlender> blender) override {}
   void setColorSource(const DlColorSource* source) override {}
   void setImageFilter(const DlImageFilter* filter) override {}
   void setColorFilter(const DlColorFilter* filter) override {}
@@ -159,22 +158,6 @@ class ComplexityCalculatorHelper
               render_with_attributes, constraint);
   }
 
-  void drawImageLattice(const sk_sp<DlImage> image,
-                        const SkCanvas::Lattice& lattice,
-                        const SkRect& dst,
-                        DlFilterMode filter,
-                        bool render_with_attributes) override {
-    if (IsComplex()) {
-      return;
-    }
-    // This is not currently called from Flutter code, and this API is likely
-    // to be removed in the future. For now, just return what drawImageNine
-    // would
-    ImageRect(image->dimensions(), image->isTextureBacked(),
-              render_with_attributes,
-              SkCanvas::SrcRectConstraint::kStrict_SrcRectConstraint);
-  }
-
   void drawAtlas(const sk_sp<DlImage> atlas,
                  const SkRSXform xform[],
                  const SkRect tex[],
@@ -194,14 +177,6 @@ class ComplexityCalculatorHelper
                 render_with_attributes,
                 SkCanvas::SrcRectConstraint::kStrict_SrcRectConstraint);
     }
-  }
-
-  void drawPicture(const sk_sp<SkPicture> picture,
-                   const SkMatrix* matrix,
-                   bool render_with_attributes) override {
-    // This API shouldn't be used, but for now just take the
-    // approximateOpCount() and multiply by 50 as a placeholder.
-    AccumulateComplexity(picture->approximateOpCount() * 50);
   }
 
   // This method finalizes the complexity score calculation and returns it

--- a/display_list/display_list_complexity_metal.cc
+++ b/display_list/display_list_complexity_metal.cc
@@ -435,34 +435,6 @@ void DisplayListMetalComplexityCalculator::MetalHelper::drawPoints(
   AccumulateComplexity(complexity);
 }
 
-void DisplayListMetalComplexityCalculator::MetalHelper::drawSkVertices(
-    const sk_sp<SkVertices> vertices,
-    SkBlendMode mode) {
-  // There is currently no way for us to get the VertexMode from the SkVertices
-  // object, but for future reference:
-  //
-  // TriangleStrip is roughly 25% more expensive than TriangleFan.
-  // TriangleFan is roughly 5% more expensive than Triangles.
-
-  // There is currently no way for us to get the vertex count from an SkVertices
-  // object, so we have to estimate it from the approximate size.
-  //
-  // Approximate size returns the sum of the sizes of the positions (SkPoint),
-  // texs (SkPoint), colors (SkColor) and indices (uint16_t) arrays multiplied
-  // by sizeof(type). As a very, very rough estimate, divide that by 20 to get
-  // an idea of the vertex count.
-  unsigned int approximate_vertex_count = vertices->approximateSize() / 20;
-
-  // For the baseline, it's hard to identify the trend. It might be O(n^1/2).
-  // For now, treat it as linear as an approximation.
-  //
-  // m = 1/4000
-  // c = 1
-  unsigned int complexity = (approximate_vertex_count + 4000) * 50;
-
-  AccumulateComplexity(complexity);
-}
-
 void DisplayListMetalComplexityCalculator::MetalHelper::drawVertices(
     const DlVertices* vertices,
     DlBlendMode mode) {

--- a/display_list/display_list_complexity_metal.h
+++ b/display_list/display_list_complexity_metal.h
@@ -55,8 +55,6 @@ class DisplayListMetalComplexityCalculator
     void drawPoints(DlCanvas::PointMode mode,
                     uint32_t count,
                     const SkPoint points[]) override;
-    void drawSkVertices(const sk_sp<SkVertices> vertices,
-                        SkBlendMode mode) override;
     void drawVertices(const DlVertices* vertices, DlBlendMode mode) override;
     void drawImage(const sk_sp<DlImage> image,
                    const SkPoint point,

--- a/display_list/display_list_dispatcher.h
+++ b/display_list/display_list_dispatcher.h
@@ -58,7 +58,6 @@ class Dispatcher {
   // filter so that the color inversion happens after the ColorFilter.
   virtual void setInvertColors(bool invert) = 0;
   virtual void setBlendMode(DlBlendMode mode) = 0;
-  virtual void setBlender(sk_sp<SkBlender> blender) = 0;
   virtual void setPathEffect(const DlPathEffect* effect) = 0;
   virtual void setMaskFilter(const DlMaskFilter* filter) = 0;
   virtual void setImageFilter(const DlImageFilter* filter) = 0;
@@ -215,8 +214,6 @@ class Dispatcher {
   virtual void drawPoints(PointMode mode,
                           uint32_t count,
                           const SkPoint points[]) = 0;
-  virtual void drawSkVertices(const sk_sp<SkVertices> vertices,
-                              SkBlendMode mode) = 0;
   virtual void drawVertices(const DlVertices* vertices, DlBlendMode mode) = 0;
   virtual void drawImage(const sk_sp<DlImage> image,
                          const SkPoint point,
@@ -233,11 +230,6 @@ class Dispatcher {
                              const SkRect& dst,
                              DlFilterMode filter,
                              bool render_with_attributes) = 0;
-  virtual void drawImageLattice(const sk_sp<DlImage> image,
-                                const SkCanvas::Lattice& lattice,
-                                const SkRect& dst,
-                                DlFilterMode filter,
-                                bool render_with_attributes) = 0;
   virtual void drawAtlas(const sk_sp<DlImage> atlas,
                          const SkRSXform xform[],
                          const SkRect tex[],
@@ -247,9 +239,6 @@ class Dispatcher {
                          DlImageSampling sampling,
                          const SkRect* cull_rect,
                          bool render_with_attributes) = 0;
-  virtual void drawPicture(const sk_sp<SkPicture> picture,
-                           const SkMatrix* matrix,
-                           bool render_with_attributes) = 0;
   virtual void drawDisplayList(const sk_sp<DisplayList> display_list) = 0;
   virtual void drawTextBlob(const sk_sp<SkTextBlob> blob,
                             SkScalar x,

--- a/display_list/display_list_flags.h
+++ b/display_list/display_list_flags.h
@@ -194,17 +194,17 @@ class DisplayListAttributeFlags : DisplayListFlagsBase {
   // bool applies_stroke_attributes() const { return is_stroked(); }
 
   constexpr bool applies_shader() const { return has_any(kUsesShader_); }
-  /// The primitive honors the current SkColorFilter, including
+  /// The primitive honors the current DlColorFilter, including
   /// the related attribute InvertColors
   constexpr bool applies_color_filter() const {
     return has_any(kUsesColorFilter_);
   }
-  /// The primitive honors the SkBlendMode or SkBlender
+  /// The primitive honors the DlBlendMode
   constexpr bool applies_blend() const { return has_any(kUsesBlend_); }
   constexpr bool applies_path_effect() const {
     return has_any(kUsesPathEffect_);
   }
-  /// The primitive honors the SkMaskFilter whether set using the
+  /// The primitive honors the DlMaskFilter whether set using the
   /// filter object or using the convenience method |setMaskBlurFilter|
   constexpr bool applies_mask_filter() const {
     return has_any(kUsesMaskFilter_);
@@ -401,23 +401,11 @@ class DisplayListOpFlags : DisplayListFlags {
   static constexpr DisplayListAttributeFlags kDrawImageNineWithPaintFlags{
       kBASE_ImageFlags_  //
   };
-  static constexpr DisplayListAttributeFlags kDrawImageLatticeFlags{
-      kIgnoresPaint_  //
-  };
-  static constexpr DisplayListAttributeFlags kDrawImageLatticeWithPaintFlags{
-      kBASE_ImageFlags_  //
-  };
   static constexpr DisplayListAttributeFlags kDrawAtlasFlags{
       kIgnoresPaint_  //
   };
   static constexpr DisplayListAttributeFlags kDrawAtlasWithPaintFlags{
       kBASE_ImageFlags_  //
-  };
-  static constexpr DisplayListAttributeFlags kDrawPictureFlags{
-      kIgnoresPaint_  //
-  };
-  static constexpr DisplayListAttributeFlags kDrawPictureWithPaintFlags{
-      kSaveLayerWithPaintFlags  //
   };
   static constexpr DisplayListAttributeFlags kDrawDisplayListFlags{
       kIgnoresPaint_  //

--- a/display_list/display_list_utils.cc
+++ b/display_list/display_list_utils.cc
@@ -75,9 +75,6 @@ void SkPaintDispatchHelper::setColor(DlColor color) {
 void SkPaintDispatchHelper::setBlendMode(DlBlendMode mode) {
   paint_.setBlendMode(ToSk(mode));
 }
-void SkPaintDispatchHelper::setBlender(sk_sp<SkBlender> blender) {
-  paint_.setBlender(blender);
-}
 void SkPaintDispatchHelper::setColorSource(const DlColorSource* source) {
   paint_.setShader(source ? source->skia_object() : nullptr);
 }

--- a/display_list/display_list_utils.h
+++ b/display_list/display_list_utils.h
@@ -45,7 +45,6 @@ class IgnoreAttributeDispatchHelper : public virtual Dispatcher {
   void setStrokeMiter(float limit) override {}
   void setColor(DlColor color) override {}
   void setBlendMode(DlBlendMode mode) override {}
-  void setBlender(sk_sp<SkBlender> blender) override {}
   void setColorSource(const DlColorSource* source) override {}
   void setImageFilter(const DlImageFilter* filter) override {}
   void setColorFilter(const DlColorFilter* filter) override {}
@@ -112,8 +111,6 @@ class IgnoreDrawDispatchHelper : public virtual Dispatcher {
   void drawPoints(DlCanvas::PointMode mode,
                   uint32_t count,
                   const SkPoint points[]) override {}
-  void drawSkVertices(const sk_sp<SkVertices> vertices,
-                      SkBlendMode mode) override {}
   void drawVertices(const DlVertices* vertices, DlBlendMode mode) override {}
   void drawImage(const sk_sp<DlImage> image,
                  const SkPoint point,
@@ -130,11 +127,6 @@ class IgnoreDrawDispatchHelper : public virtual Dispatcher {
                      const SkRect& dst,
                      DlFilterMode filter,
                      bool render_with_attributes) override {}
-  void drawImageLattice(const sk_sp<DlImage> image,
-                        const SkCanvas::Lattice& lattice,
-                        const SkRect& dst,
-                        DlFilterMode filter,
-                        bool render_with_attributes) override {}
   void drawAtlas(const sk_sp<DlImage> atlas,
                  const SkRSXform xform[],
                  const SkRect tex[],
@@ -144,9 +136,6 @@ class IgnoreDrawDispatchHelper : public virtual Dispatcher {
                  DlImageSampling sampling,
                  const SkRect* cull_rect,
                  bool render_with_attributes) override {}
-  void drawPicture(const sk_sp<SkPicture> picture,
-                   const SkMatrix* matrix,
-                   bool render_with_attributes) override {}
   void drawDisplayList(const sk_sp<DisplayList> display_list) override {}
   void drawTextBlob(const sk_sp<SkTextBlob> blob,
                     SkScalar x,
@@ -182,7 +171,6 @@ class SkPaintDispatchHelper : public virtual Dispatcher {
   void setColorFilter(const DlColorFilter* filter) override;
   void setInvertColors(bool invert) override;
   void setBlendMode(DlBlendMode mode) override;
-  void setBlender(sk_sp<SkBlender> blender) override;
   void setPathEffect(const DlPathEffect* effect) override;
   void setMaskFilter(const DlMaskFilter* filter) override;
   void setImageFilter(const DlImageFilter* filter) override;

--- a/display_list/testing/dl_test_snippets.cc
+++ b/display_list/testing/dl_test_snippets.cc
@@ -122,17 +122,10 @@ std::vector<DisplayListInvocationGroup> CreateAllAttributesOps() {
             [](DisplayListBuilder& b) { b.setBlendMode(DlBlendMode::kSrcIn); }},
            {0, 8, 0, 0,
             [](DisplayListBuilder& b) { b.setBlendMode(DlBlendMode::kDstIn); }},
-           {0, 16, 0, 0,
-            [](DisplayListBuilder& b) { b.setBlender(kTestBlender1); }},
-           {0, 16, 0, 0,
-            [](DisplayListBuilder& b) { b.setBlender(kTestBlender2); }},
-           {0, 16, 0, 0,
-            [](DisplayListBuilder& b) { b.setBlender(kTestBlender3); }},
            {0, 0, 0, 0,
             [](DisplayListBuilder& b) {
               b.setBlendMode(DlBlendMode::kSrcOver);
             }},
-           {0, 0, 0, 0, [](DisplayListBuilder& b) { b.setBlender(nullptr); }},
        }},
       {"SetColorSource",
        {
@@ -819,7 +812,7 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
        }},
       {"DrawImageNine",
        {
-           // SkVanvas::drawImageNine is immediately converted to
+           // SkCanvas::drawImageNine is immediately converted to
            // drawImageLattice
            {1, 48, -1, 80,
             [](DisplayListBuilder& b) {
@@ -850,90 +843,6 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
             [](DisplayListBuilder& b) {
               b.drawImageNine(TestImage2, {10, 10, 15, 15}, {10, 10, 80, 80},
                               DlFilterMode::kNearest, false);
-            }},
-       }},
-      {"DrawImageLattice",
-       {
-           // Lattice:
-           // const int*      fXDivs;     //!< x-axis values dividing bitmap
-           // const int*      fYDivs;     //!< y-axis values dividing bitmap
-           // const RectType* fRectTypes; //!< array of fill types
-           // int             fXCount;    //!< number of x-coordinates
-           // int             fYCount;    //!< number of y-coordinates
-           // const SkIRect*  fBounds;    //!< source bounds to draw from
-           // const SkColor*  fColors;    //!< array of colors
-           // size = 64 + fXCount * 4 + fYCount * 4
-           // if fColors and fRectTypes are not null, add (fXCount + 1) *
-           // (fYCount + 1) * 5
-           {1, 88, -1, 88,
-            [](DisplayListBuilder& b) {
-              b.drawImageLattice(
-                  TestImage1,
-                  {kTestDivs1, kTestDivs1, nullptr, 3, 3, nullptr, nullptr},
-                  {10, 10, 40, 40}, DlFilterMode::kNearest, false);
-            }},
-           {1, 88, -1, 88,
-            [](DisplayListBuilder& b) {
-              b.drawImageLattice(
-                  TestImage1,
-                  {kTestDivs1, kTestDivs1, nullptr, 3, 3, nullptr, nullptr},
-                  {10, 10, 40, 45}, DlFilterMode::kNearest, false);
-            }},
-           {1, 88, -1, 88,
-            [](DisplayListBuilder& b) {
-              b.drawImageLattice(
-                  TestImage1,
-                  {kTestDivs2, kTestDivs1, nullptr, 3, 3, nullptr, nullptr},
-                  {10, 10, 40, 40}, DlFilterMode::kNearest, false);
-            }},
-           // One less yDiv does not change the allocation due to 8-byte
-           // alignment
-           {1, 88, -1, 88,
-            [](DisplayListBuilder& b) {
-              b.drawImageLattice(
-                  TestImage1,
-                  {kTestDivs1, kTestDivs1, nullptr, 3, 2, nullptr, nullptr},
-                  {10, 10, 40, 40}, DlFilterMode::kNearest, false);
-            }},
-           {1, 88, -1, 88,
-            [](DisplayListBuilder& b) {
-              b.drawImageLattice(
-                  TestImage1,
-                  {kTestDivs1, kTestDivs1, nullptr, 3, 3, nullptr, nullptr},
-                  {10, 10, 40, 40}, DlFilterMode::kLinear, false);
-            }},
-           {1, 96, -1, 96,
-            [](DisplayListBuilder& b) {
-              b.setColor(SK_ColorMAGENTA);
-              b.drawImageLattice(
-                  TestImage1,
-                  {kTestDivs1, kTestDivs1, nullptr, 3, 3, nullptr, nullptr},
-                  {10, 10, 40, 40}, DlFilterMode::kNearest, true);
-            }},
-           {1, 88, -1, 88,
-            [](DisplayListBuilder& b) {
-              b.drawImageLattice(
-                  TestImage2,
-                  {kTestDivs1, kTestDivs1, nullptr, 3, 3, nullptr, nullptr},
-                  {10, 10, 40, 40}, DlFilterMode::kNearest, false);
-            }},
-           // Supplying fBounds does not change size because the Op record
-           // always includes it
-           {1, 88, -1, 88,
-            [](DisplayListBuilder& b) {
-              b.drawImageLattice(TestImage1,
-                                 {kTestDivs1, kTestDivs1, nullptr, 3, 3,
-                                  &kTestLatticeSrcRect, nullptr},
-                                 {10, 10, 40, 40}, DlFilterMode::kNearest,
-                                 false);
-            }},
-           {1, 128, -1, 128,
-            [](DisplayListBuilder& b) {
-              b.drawImageLattice(TestImage1,
-                                 {kTestDivs3, kTestDivs3, kTestRTypes, 2, 2,
-                                  nullptr, kTestLatticeColors},
-                                 {10, 10, 40, 40}, DlFilterMode::kNearest,
-                                 false);
             }},
        }},
       {"DrawAtlas",
@@ -1011,34 +920,6 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
               b.drawAtlas(TestImage1, xforms, texs, colors, 2,
                           DlBlendMode::kSrcIn, kNearestSampling, &cull_rect,
                           false);
-            }},
-       }},
-      {"DrawPicture",
-       {
-           // cv.drawPicture cannot be compared as SkCanvas may inline it
-           {1, 16, -1, 16,
-            [](DisplayListBuilder& b) {
-              b.drawPicture(TestPicture1, nullptr, false);
-            }},
-           {1, 16, -1, 16,
-            [](DisplayListBuilder& b) {
-              b.drawPicture(TestPicture2, nullptr, false);
-            }},
-           {1, 16, -1, 16,
-            [](DisplayListBuilder& b) {
-              b.drawPicture(TestPicture1, nullptr, true);
-            }},
-           {1, 56, -1, 56,
-            [](DisplayListBuilder& b) {
-              b.drawPicture(TestPicture1, &kTestMatrix1, false);
-            }},
-           {1, 56, -1, 56,
-            [](DisplayListBuilder& b) {
-              b.drawPicture(TestPicture1, &kTestMatrix2, false);
-            }},
-           {1, 56, -1, 56,
-            [](DisplayListBuilder& b) {
-              b.drawPicture(TestPicture1, &kTestMatrix1, true);
             }},
        }},
       {"DrawDisplayList",

--- a/display_list/testing/dl_test_snippets.h
+++ b/display_list/testing/dl_test_snippets.h
@@ -8,10 +8,7 @@
 #include "flutter/display_list/display_list.h"
 #include "flutter/display_list/display_list_builder.h"
 
-#include "third_party/skia/include/core/SkPicture.h"
-#include "third_party/skia/include/core/SkPictureRecorder.h"
 #include "third_party/skia/include/core/SkSurface.h"
-#include "third_party/skia/include/effects/SkBlenders.h"
 #include "third_party/skia/include/effects/SkDashPathEffect.h"
 #include "third_party/skia/include/effects/SkGradientShader.h"
 #include "third_party/skia/include/effects/SkImageFilters.h"
@@ -93,12 +90,6 @@ static sk_sp<DlImage> MakeTestImage(int w, int h, int checker_size) {
 static auto TestImage1 = MakeTestImage(40, 40, 5);
 static auto TestImage2 = MakeTestImage(50, 50, 5);
 
-static const sk_sp<SkBlender> kTestBlender1 =
-    SkBlenders::Arithmetic(0.2, 0.2, 0.2, 0.2, false);
-static const sk_sp<SkBlender> kTestBlender2 =
-    SkBlenders::Arithmetic(0.2, 0.2, 0.2, 0.2, true);
-static const sk_sp<SkBlender> kTestBlender3 =
-    SkBlenders::Arithmetic(0.3, 0.3, 0.3, 0.3, true);
 static const DlImageColorSource kTestSource1(TestImage1,
                                              DlTileMode::kClamp,
                                              DlTileMode::kMirror,
@@ -219,40 +210,6 @@ static std::shared_ptr<const DlVertices> TestVertices2 =
                      TestPoints,
                      nullptr,
                      kColors);
-
-static constexpr int kTestDivs1[] = {10, 20, 30};
-static constexpr int kTestDivs2[] = {15, 20, 25};
-static constexpr int kTestDivs3[] = {15, 25};
-static constexpr SkCanvas::Lattice::RectType kTestRTypes[] = {
-    SkCanvas::Lattice::RectType::kDefault,
-    SkCanvas::Lattice::RectType::kTransparent,
-    SkCanvas::Lattice::RectType::kFixedColor,
-    SkCanvas::Lattice::RectType::kDefault,
-    SkCanvas::Lattice::RectType::kTransparent,
-    SkCanvas::Lattice::RectType::kFixedColor,
-    SkCanvas::Lattice::RectType::kDefault,
-    SkCanvas::Lattice::RectType::kTransparent,
-    SkCanvas::Lattice::RectType::kFixedColor,
-};
-static constexpr SkColor kTestLatticeColors[] = {
-    SK_ColorBLUE, SK_ColorGREEN, SK_ColorYELLOW,
-    SK_ColorBLUE, SK_ColorGREEN, SK_ColorYELLOW,
-    SK_ColorBLUE, SK_ColorGREEN, SK_ColorYELLOW,
-};
-static constexpr SkIRect kTestLatticeSrcRect = {1, 1, 39, 39};
-
-static sk_sp<SkPicture> MakeTestPicture(int w, int h, SkColor color) {
-  SkPictureRecorder recorder;
-  SkRTreeFactory rtree_factory;
-  SkCanvas* cv = recorder.beginRecording(kTestBounds, &rtree_factory);
-  SkPaint paint;
-  paint.setColor(color);
-  paint.setStyle(SkPaint::kFill_Style);
-  cv->drawRect(SkRect::MakeWH(w, h), paint);
-  return recorder.finishRecordingAsPicture();
-}
-static sk_sp<SkPicture> TestPicture1 = MakeTestPicture(20, 20, SK_ColorGREEN);
-static sk_sp<SkPicture> TestPicture2 = MakeTestPicture(25, 25, SK_ColorBLUE);
 
 static sk_sp<DisplayList> MakeTestDisplayList(int w, int h, SkColor color) {
   DisplayListBuilder builder;

--- a/display_list/types.h
+++ b/display_list/types.h
@@ -7,7 +7,6 @@
 
 #include "flutter/fml/macros.h"
 #include "third_party/skia/include/core/SkBitmap.h"
-#include "third_party/skia/include/core/SkBlender.h"
 #include "third_party/skia/include/core/SkBlurTypes.h"
 #include "third_party/skia/include/core/SkCanvas.h"
 #include "third_party/skia/include/core/SkColorFilter.h"

--- a/impeller/display_list/display_list_dispatcher.cc
+++ b/impeller/display_list/display_list_dispatcher.cc
@@ -589,12 +589,6 @@ void DisplayListDispatcher::setBlendMode(flutter::DlBlendMode dl_mode) {
 }
 
 // |flutter::Dispatcher|
-void DisplayListDispatcher::setBlender(sk_sp<SkBlender> blender) {
-  // Needs https://github.com/flutter/flutter/issues/95434
-  UNIMPLEMENTED;
-}
-
-// |flutter::Dispatcher|
 void DisplayListDispatcher::setPathEffect(const flutter::DlPathEffect* effect) {
   // Needs https://github.com/flutter/flutter/issues/95434
   UNIMPLEMENTED;
@@ -1121,13 +1115,6 @@ void DisplayListDispatcher::drawPoints(PointMode mode,
 }
 
 // |flutter::Dispatcher|
-void DisplayListDispatcher::drawSkVertices(const sk_sp<SkVertices> vertices,
-                                           SkBlendMode mode) {
-  // Needs https://github.com/flutter/flutter/issues/95434
-  UNIMPLEMENTED;
-}
-
-// |flutter::Dispatcher|
 void DisplayListDispatcher::drawVertices(const flutter::DlVertices* vertices,
                                          flutter::DlBlendMode dl_mode) {
   canvas_.DrawVertices(DLVerticesGeometry::MakeVertices(vertices),
@@ -1194,18 +1181,6 @@ void DisplayListDispatcher::drawImageNine(const sk_sp<flutter::DlImage> image,
 }
 
 // |flutter::Dispatcher|
-void DisplayListDispatcher::drawImageLattice(
-    const sk_sp<flutter::DlImage> image,
-    const SkCanvas::Lattice& lattice,
-    const SkRect& dst,
-    flutter::DlFilterMode filter,
-    bool render_with_attributes) {
-  // Don't implement this one since it is not exposed by flutter,
-  // Skia internally converts calls to drawImageNine into this method,
-  // which is then converted back to drawImageNine by display list.
-}
-
-// |flutter::Dispatcher|
 void DisplayListDispatcher::drawAtlas(const sk_sp<flutter::DlImage> atlas,
                                       const SkRSXform xform[],
                                       const SkRect tex[],
@@ -1219,14 +1194,6 @@ void DisplayListDispatcher::drawAtlas(const sk_sp<flutter::DlImage> atlas,
                     ToRSXForms(xform, count), ToRects(tex, count),
                     ToColors(colors, count), ToBlendMode(mode),
                     ToSamplerDescriptor(sampling), ToRect(cull_rect), paint_);
-}
-
-// |flutter::Dispatcher|
-void DisplayListDispatcher::drawPicture(const sk_sp<SkPicture> picture,
-                                        const SkMatrix* matrix,
-                                        bool render_with_attributes) {
-  // Needs https://github.com/flutter/flutter/issues/95434
-  UNIMPLEMENTED;
 }
 
 // |flutter::Dispatcher|

--- a/impeller/display_list/display_list_dispatcher.h
+++ b/impeller/display_list/display_list_dispatcher.h
@@ -59,9 +59,6 @@ class DisplayListDispatcher final : public flutter::Dispatcher {
   void setBlendMode(flutter::DlBlendMode mode) override;
 
   // |flutter::Dispatcher|
-  void setBlender(sk_sp<SkBlender> blender) override;
-
-  // |flutter::Dispatcher|
   void setPathEffect(const flutter::DlPathEffect* effect) override;
 
   // |flutter::Dispatcher|
@@ -170,10 +167,6 @@ class DisplayListDispatcher final : public flutter::Dispatcher {
                   const SkPoint points[]) override;
 
   // |flutter::Dispatcher|
-  void drawSkVertices(const sk_sp<SkVertices> vertices,
-                      SkBlendMode mode) override;
-
-  // |flutter::Dispatcher|
   void drawVertices(const flutter::DlVertices* vertices,
                     flutter::DlBlendMode dl_mode) override;
 
@@ -199,13 +192,6 @@ class DisplayListDispatcher final : public flutter::Dispatcher {
                      bool render_with_attributes) override;
 
   // |flutter::Dispatcher|
-  void drawImageLattice(const sk_sp<flutter::DlImage> image,
-                        const SkCanvas::Lattice& lattice,
-                        const SkRect& dst,
-                        flutter::DlFilterMode filter,
-                        bool render_with_attributes) override;
-
-  // |flutter::Dispatcher|
   void drawAtlas(const sk_sp<flutter::DlImage> atlas,
                  const SkRSXform xform[],
                  const SkRect tex[],
@@ -215,11 +201,6 @@ class DisplayListDispatcher final : public flutter::Dispatcher {
                  flutter::DlImageSampling sampling,
                  const SkRect* cull_rect,
                  bool render_with_attributes) override;
-
-  // |flutter::Dispatcher|
-  void drawPicture(const sk_sp<SkPicture> picture,
-                   const SkMatrix* matrix,
-                   bool render_with_attributes) override;
 
   // |flutter::Dispatcher|
   void drawDisplayList(const sk_sp<flutter::DisplayList> display_list) override;

--- a/testing/display_list_testing.cc
+++ b/testing/display_list_testing.cc
@@ -513,9 +513,6 @@ void DisplayListStreamDispatcher::setInvertColors(bool invert) {
 void DisplayListStreamDispatcher::setBlendMode(DlBlendMode mode) {
   startl() << "setBlendMode(" << mode << ");" << std::endl;
 }
-void DisplayListStreamDispatcher::setBlender(sk_sp<SkBlender> blender) {
-  startl() << "setBlender(" << blender << ");" << std::endl;
-}
 void DisplayListStreamDispatcher::setPathEffect(const DlPathEffect* effect) {
   startl() << "setPathEffect(" << effect << ");" << std::endl;
 }
@@ -769,10 +766,6 @@ void DisplayListStreamDispatcher::drawPoints(PointMode mode,
                           out_array("points", count, points)
            << ");" << std::endl;
 }
-void DisplayListStreamDispatcher::drawSkVertices(const sk_sp<SkVertices> vertices,
-                                                 SkBlendMode mode) {
-  startl() << "drawSkVertices(" << vertices << ", " << static_cast<int>(mode) << ");" << std::endl;
-}
 void DisplayListStreamDispatcher::drawVertices(const DlVertices* vertices,
                                                DlBlendMode mode) {
   startl() << "drawVertices("
@@ -820,13 +813,6 @@ void DisplayListStreamDispatcher::drawImageNine(const sk_sp<DlImage> image,
                                << "with attributes: " << render_with_attributes
            << ");" << std::endl;
 }
-void DisplayListStreamDispatcher::drawImageLattice(const sk_sp<DlImage> image,
-                                                   const SkCanvas::Lattice& lattice,
-                                                   const SkRect& dst,
-                                                   DlFilterMode filter,
-                                                   bool render_with_attributes) {
-  startl() << "drawImageLattice(blah blah);" << std::endl;
-}
 void DisplayListStreamDispatcher::drawAtlas(const sk_sp<DlImage> atlas,
                                             const SkRSXform xform[],
                                             const SkRect tex[],
@@ -842,15 +828,6 @@ void DisplayListStreamDispatcher::drawAtlas(const sk_sp<DlImage> atlas,
                    out_array("colors", count, colors) << ", "
                    << mode << ", " << sampling << ", cull: " << cull_rect << ", "
                    << "with attributes: " << render_with_attributes
-           << ");" << std::endl;
-}
-void DisplayListStreamDispatcher::drawPicture(const sk_sp<SkPicture> picture,
-                                              const SkMatrix* matrix,
-                                              bool render_with_attributes) {
-  startl() << "drawPicture("
-           << "SkPicture(ID: " << picture->uniqueID() << ", bounds: " << picture->cullRect() << ", @" << picture << "), "
-           << matrix << ", "
-           << render_with_attributes
            << ");" << std::endl;
 }
 void DisplayListStreamDispatcher::drawDisplayList(

--- a/testing/display_list_testing.h
+++ b/testing/display_list_testing.h
@@ -66,7 +66,6 @@ class DisplayListStreamDispatcher final : public Dispatcher {
   void setColorFilter(const DlColorFilter* filter) override;
   void setInvertColors(bool invert) override;
   void setBlendMode(DlBlendMode mode) override;
-  void setBlender(sk_sp<SkBlender> blender) override;
   void setPathEffect(const DlPathEffect* effect) override;
   void setMaskFilter(const DlMaskFilter* filter) override;
   void setImageFilter(const DlImageFilter* filter) override;
@@ -112,8 +111,6 @@ class DisplayListStreamDispatcher final : public Dispatcher {
   void drawPoints(PointMode mode,
                   uint32_t count,
                   const SkPoint points[]) override;
-  void drawSkVertices(const sk_sp<SkVertices> vertices,
-                      SkBlendMode mode) override;
   void drawVertices(const DlVertices* vertices, DlBlendMode mode) override;
   void drawImage(const sk_sp<DlImage> image,
                  const SkPoint point,
@@ -130,11 +127,6 @@ class DisplayListStreamDispatcher final : public Dispatcher {
                      const SkRect& dst,
                      DlFilterMode filter,
                      bool render_with_attributes) override;
-  void drawImageLattice(const sk_sp<DlImage> image,
-                        const SkCanvas::Lattice& lattice,
-                        const SkRect& dst,
-                        DlFilterMode filter,
-                        bool render_with_attributes) override;
   void drawAtlas(const sk_sp<DlImage> atlas,
                  const SkRSXform xform[],
                  const SkRect tex[],
@@ -144,9 +136,6 @@ class DisplayListStreamDispatcher final : public Dispatcher {
                  DlImageSampling sampling,
                  const SkRect* cull_rect,
                  bool render_with_attributes) override;
-  void drawPicture(const sk_sp<SkPicture> picture,
-                   const SkMatrix* matrix,
-                   bool render_with_attributes) override;
   void drawDisplayList(const sk_sp<DisplayList> display_list) override;
   void drawTextBlob(const sk_sp<SkTextBlob> blob,
                     SkScalar x,


### PR DESCRIPTION
This is pretty simple "obsolete code" fallout from removing DisplayListCanvasRecorder. Some of the DisplayList ops were only ever captured on a theoretical basis from an SkCanvas object. Since we no longer capture from SkCanvas, we can delete the methods and objects that aren't directly recordable from our own DisplayList APIs. These include:

- DLBuilder::setAttributesFromPaint(SkPaint)
- DL::setBlender (we only use the BlendMode enum, not custom blender objects)
- DL::drawPicture (no more SkPictures in the ui.Canvas/flow layers work flow)
- DL::drawSkVertices (no longer need to capture opaque SkVertices objects)
- DL::drawLattice (only ever appeared as a general form of drawImageNine)

The 1000 lines are almost all straight deletions, and maybe some comment updates to no longer discuss objects we never see. Lots of Impeller::UNIMPLEMENTED removals...