### PR TITLE
[Impeller] all vertex UBOs now named FrameInfo, all fragment ubos now named FragInfo

### DIFF
--- a/impeller/entity/contents/atlas_contents.cc
+++ b/impeller/entity/contents/atlas_contents.cc
@@ -196,9 +196,9 @@ bool AtlasTextureContents::Render(const ContentContext& renderer,
 
   auto& host_buffer = pass.GetTransientsBuffer();
 
-  VS::VertInfo vert_info;
-  vert_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                  entity.GetTransformation();
+  VS::FrameInfo frame_info;
+  frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
+                   entity.GetTransformation();
 
   FS::FragInfo frag_info;
   frag_info.texture_sampler_y_coord_scale = texture->GetYCoordScale();
@@ -208,7 +208,7 @@ bool AtlasTextureContents::Render(const ContentContext& renderer,
   cmd.pipeline = renderer.GetTexturePipeline(options);
   cmd.stencil_reference = entity.GetStencilDepth();
   cmd.BindVertices(vertex_builder.CreateVertexBuffer(host_buffer));
-  VS::BindVertInfo(cmd, host_buffer.EmplaceUniform(vert_info));
+  VS::BindFrameInfo(cmd, host_buffer.EmplaceUniform(frame_info));
   FS::BindFragInfo(cmd, host_buffer.EmplaceUniform(frag_info));
   FS::BindTextureSampler(cmd, texture,
                          renderer.GetContext()->GetSamplerLibrary()->GetSampler(
@@ -273,9 +273,9 @@ bool AtlasColorContents::Render(const ContentContext& renderer,
 
   auto& host_buffer = pass.GetTransientsBuffer();
 
-  VS::VertInfo vert_info;
-  vert_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                  entity.GetTransformation();
+  VS::FrameInfo frame_info;
+  frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
+                   entity.GetTransformation();
 
   FS::FragInfo frag_info;
   frag_info.alpha = alpha_;
@@ -285,7 +285,7 @@ bool AtlasColorContents::Render(const ContentContext& renderer,
   cmd.pipeline = renderer.GetGeometryColorPipeline(opts);
   cmd.stencil_reference = entity.GetStencilDepth();
   cmd.BindVertices(vertex_builder.CreateVertexBuffer(host_buffer));
-  VS::BindVertInfo(cmd, host_buffer.EmplaceUniform(vert_info));
+  VS::BindFrameInfo(cmd, host_buffer.EmplaceUniform(frame_info));
   FS::BindFragInfo(cmd, host_buffer.EmplaceUniform(frag_info));
   return pass.AddCommand(std::move(cmd));
 }

--- a/impeller/entity/contents/clip_contents.cc
+++ b/impeller/entity/contents/clip_contents.cc
@@ -76,7 +76,7 @@ bool ClipContents::Render(const ContentContext& renderer,
   using VS = ClipPipeline::VertexShader;
   using FS = ClipPipeline::FragmentShader;
 
-  VS::VertInfo info;
+  VS::FrameInfo info;
 
   Command cmd;
 
@@ -102,7 +102,7 @@ bool ClipContents::Render(const ContentContext& renderer,
       cmd.BindVertices(vertices);
 
       info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize());
-      VS::BindVertInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(info));
+      VS::BindFrameInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(info));
 
       options.primitive_type = PrimitiveType::kTriangleStrip;
       cmd.pipeline = renderer.GetClipPipeline(options);
@@ -130,7 +130,7 @@ bool ClipContents::Render(const ContentContext& renderer,
   cmd.BindVertices(geometry_result.vertex_buffer);
 
   info.mvp = geometry_result.transform;
-  VS::BindVertInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(info));
+  VS::BindFrameInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(info));
 
   pass.AddCommand(std::move(cmd));
   return true;
@@ -194,9 +194,9 @@ bool ClipRestoreContents::Render(const ContentContext& renderer,
   });
   cmd.BindVertices(vtx_builder.CreateVertexBuffer(pass.GetTransientsBuffer()));
 
-  VS::VertInfo info;
+  VS::FrameInfo info;
   info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize());
-  VS::BindVertInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(info));
+  VS::BindFrameInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(info));
 
   FS::FragInfo frag_info;
   // The color really doesn't matter.

--- a/impeller/entity/contents/linear_gradient_contents.cc
+++ b/impeller/entity/contents/linear_gradient_contents.cc
@@ -66,15 +66,14 @@ bool LinearGradientContents::RenderTexture(const ContentContext& renderer,
     return false;
   }
 
-  FS::GradientInfo gradient_info;
-  gradient_info.start_point = start_point_;
-  gradient_info.end_point = end_point_;
-  gradient_info.tile_mode = static_cast<Scalar>(tile_mode_);
-  gradient_info.texture_sampler_y_coord_scale =
-      gradient_texture->GetYCoordScale();
-  gradient_info.alpha = GetAlpha();
-  gradient_info.half_texel = Vector2(0.5 / gradient_texture->GetSize().width,
-                                     0.5 / gradient_texture->GetSize().height);
+  FS::FragInfo frag_info;
+  frag_info.start_point = start_point_;
+  frag_info.end_point = end_point_;
+  frag_info.tile_mode = static_cast<Scalar>(tile_mode_);
+  frag_info.texture_sampler_y_coord_scale = gradient_texture->GetYCoordScale();
+  frag_info.alpha = GetAlpha();
+  frag_info.half_texel = Vector2(0.5 / gradient_texture->GetSize().width,
+                                 0.5 / gradient_texture->GetSize().height);
 
   auto geometry_result =
       GetGeometry()->GetPositionBuffer(renderer, entity, pass);
@@ -96,8 +95,7 @@ bool LinearGradientContents::RenderTexture(const ContentContext& renderer,
   cmd.pipeline = renderer.GetLinearGradientFillPipeline(options);
 
   cmd.BindVertices(geometry_result.vertex_buffer);
-  FS::BindGradientInfo(
-      cmd, pass.GetTransientsBuffer().EmplaceUniform(gradient_info));
+  FS::BindFragInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frag_info));
   SamplerDescriptor sampler_desc;
   sampler_desc.min_filter = MinMagFilter::kLinear;
   sampler_desc.mag_filter = MinMagFilter::kLinear;
@@ -124,16 +122,16 @@ bool LinearGradientContents::RenderSSBO(const ContentContext& renderer,
   using VS = LinearGradientSSBOFillPipeline::VertexShader;
   using FS = LinearGradientSSBOFillPipeline::FragmentShader;
 
-  FS::GradientInfo gradient_info;
-  gradient_info.start_point = start_point_;
-  gradient_info.end_point = end_point_;
-  gradient_info.tile_mode = static_cast<Scalar>(tile_mode_);
-  gradient_info.alpha = GetAlpha();
+  FS::FragInfo frag_info;
+  frag_info.start_point = start_point_;
+  frag_info.end_point = end_point_;
+  frag_info.tile_mode = static_cast<Scalar>(tile_mode_);
+  frag_info.alpha = GetAlpha();
 
   auto& host_buffer = pass.GetTransientsBuffer();
   auto colors = CreateGradientColors(colors_, stops_);
 
-  gradient_info.colors_length = colors.size();
+  frag_info.colors_length = colors.size();
   auto color_buffer =
       host_buffer.Emplace(colors.data(), colors.size() * sizeof(StopData),
                           DefaultUniformAlignment());
@@ -158,8 +156,7 @@ bool LinearGradientContents::RenderSSBO(const ContentContext& renderer,
   cmd.pipeline = renderer.GetLinearGradientSSBOFillPipeline(options);
 
   cmd.BindVertices(geometry_result.vertex_buffer);
-  FS::BindGradientInfo(
-      cmd, pass.GetTransientsBuffer().EmplaceUniform(gradient_info));
+  FS::BindFragInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frag_info));
   FS::BindColorData(cmd, color_buffer);
   VS::BindFrameInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frame_info));
 

--- a/impeller/entity/contents/radial_gradient_contents.cc
+++ b/impeller/entity/contents/radial_gradient_contents.cc
@@ -60,16 +60,16 @@ bool RadialGradientContents::RenderSSBO(const ContentContext& renderer,
   using VS = RadialGradientSSBOFillPipeline::VertexShader;
   using FS = RadialGradientSSBOFillPipeline::FragmentShader;
 
-  FS::GradientInfo gradient_info;
-  gradient_info.center = center_;
-  gradient_info.radius = radius_;
-  gradient_info.tile_mode = static_cast<Scalar>(tile_mode_);
-  gradient_info.alpha = GetAlpha();
+  FS::FragInfo frag_info;
+  frag_info.center = center_;
+  frag_info.radius = radius_;
+  frag_info.tile_mode = static_cast<Scalar>(tile_mode_);
+  frag_info.alpha = GetAlpha();
 
   auto& host_buffer = pass.GetTransientsBuffer();
   auto colors = CreateGradientColors(colors_, stops_);
 
-  gradient_info.colors_length = colors.size();
+  frag_info.colors_length = colors.size();
   auto color_buffer =
       host_buffer.Emplace(colors.data(), colors.size() * sizeof(StopData),
                           DefaultUniformAlignment());
@@ -94,8 +94,7 @@ bool RadialGradientContents::RenderSSBO(const ContentContext& renderer,
   cmd.pipeline = renderer.GetRadialGradientSSBOFillPipeline(options);
 
   cmd.BindVertices(geometry_result.vertex_buffer);
-  FS::BindGradientInfo(
-      cmd, pass.GetTransientsBuffer().EmplaceUniform(gradient_info));
+  FS::BindFragInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frag_info));
   FS::BindColorData(cmd, color_buffer);
   VS::BindFrameInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frame_info));
 
@@ -124,15 +123,14 @@ bool RadialGradientContents::RenderTexture(const ContentContext& renderer,
     return false;
   }
 
-  FS::GradientInfo gradient_info;
-  gradient_info.center = center_;
-  gradient_info.radius = radius_;
-  gradient_info.tile_mode = static_cast<Scalar>(tile_mode_);
-  gradient_info.texture_sampler_y_coord_scale =
-      gradient_texture->GetYCoordScale();
-  gradient_info.alpha = GetAlpha();
-  gradient_info.half_texel = Vector2(0.5 / gradient_texture->GetSize().width,
-                                     0.5 / gradient_texture->GetSize().height);
+  FS::FragInfo frag_info;
+  frag_info.center = center_;
+  frag_info.radius = radius_;
+  frag_info.tile_mode = static_cast<Scalar>(tile_mode_);
+  frag_info.texture_sampler_y_coord_scale = gradient_texture->GetYCoordScale();
+  frag_info.alpha = GetAlpha();
+  frag_info.half_texel = Vector2(0.5 / gradient_texture->GetSize().width,
+                                 0.5 / gradient_texture->GetSize().height);
 
   auto geometry_result =
       GetGeometry()->GetPositionBuffer(renderer, entity, pass);
@@ -154,8 +152,7 @@ bool RadialGradientContents::RenderTexture(const ContentContext& renderer,
   cmd.pipeline = renderer.GetRadialGradientFillPipeline(options);
 
   cmd.BindVertices(geometry_result.vertex_buffer);
-  FS::BindGradientInfo(
-      cmd, pass.GetTransientsBuffer().EmplaceUniform(gradient_info));
+  FS::BindFragInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frag_info));
   SamplerDescriptor sampler_desc;
   sampler_desc.min_filter = MinMagFilter::kLinear;
   sampler_desc.mag_filter = MinMagFilter::kLinear;

--- a/impeller/entity/contents/rrect_shadow_contents.cc
+++ b/impeller/entity/contents/rrect_shadow_contents.cc
@@ -86,11 +86,11 @@ bool RRectShadowContents::Render(const ContentContext& renderer,
 
   cmd.BindVertices(vtx_builder.CreateVertexBuffer(pass.GetTransientsBuffer()));
 
-  VS::VertInfo vert_info;
-  vert_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                  entity.GetTransformation() *
-                  Matrix::MakeTranslation({positive_rect.origin});
-  VS::BindVertInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(vert_info));
+  VS::FrameInfo frame_info;
+  frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
+                   entity.GetTransformation() *
+                   Matrix::MakeTranslation({positive_rect.origin});
+  VS::BindFrameInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frame_info));
 
   FS::FragInfo frag_info;
   frag_info.color = color_;

--- a/impeller/entity/contents/runtime_effect_contents.cc
+++ b/impeller/entity/contents/runtime_effect_contents.cc
@@ -148,9 +148,9 @@ bool RuntimeEffectContents::Render(const ContentContext& renderer,
   /// Vertex stage uniforms.
   ///
 
-  VS::VertInfo frame_info;
+  VS::FrameInfo frame_info;
   frame_info.mvp = geometry_result.transform;
-  VS::BindVertInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frame_info));
+  VS::BindFrameInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frame_info));
 
   //--------------------------------------------------------------------------
   /// Fragment stage uniforms.

--- a/impeller/entity/contents/solid_color_contents.cc
+++ b/impeller/entity/contents/solid_color_contents.cc
@@ -70,9 +70,9 @@ bool SolidColorContents::Render(const ContentContext& renderer,
   cmd.pipeline = renderer.GetSolidFillPipeline(options);
   cmd.BindVertices(geometry_result.vertex_buffer);
 
-  VS::VertInfo vert_info;
-  vert_info.mvp = geometry_result.transform;
-  VS::BindVertInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(vert_info));
+  VS::FrameInfo frame_info;
+  frame_info.mvp = geometry_result.transform;
+  VS::BindFrameInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frame_info));
 
   FS::FragInfo frag_info;
   frag_info.color = color_.Premultiply();

--- a/impeller/entity/contents/sweep_gradient_contents.cc
+++ b/impeller/entity/contents/sweep_gradient_contents.cc
@@ -65,17 +65,17 @@ bool SweepGradientContents::RenderSSBO(const ContentContext& renderer,
   using VS = SweepGradientSSBOFillPipeline::VertexShader;
   using FS = SweepGradientSSBOFillPipeline::FragmentShader;
 
-  FS::GradientInfo gradient_info;
-  gradient_info.center = center_;
-  gradient_info.bias = bias_;
-  gradient_info.scale = scale_;
-  gradient_info.tile_mode = static_cast<Scalar>(tile_mode_);
-  gradient_info.alpha = GetAlpha();
+  FS::FragInfo frag_info;
+  frag_info.center = center_;
+  frag_info.bias = bias_;
+  frag_info.scale = scale_;
+  frag_info.tile_mode = static_cast<Scalar>(tile_mode_);
+  frag_info.alpha = GetAlpha();
 
   auto& host_buffer = pass.GetTransientsBuffer();
   auto colors = CreateGradientColors(colors_, stops_);
 
-  gradient_info.colors_length = colors.size();
+  frag_info.colors_length = colors.size();
   auto color_buffer =
       host_buffer.Emplace(colors.data(), colors.size() * sizeof(StopData),
                           DefaultUniformAlignment());
@@ -100,8 +100,7 @@ bool SweepGradientContents::RenderSSBO(const ContentContext& renderer,
   cmd.pipeline = renderer.GetSweepGradientSSBOFillPipeline(options);
 
   cmd.BindVertices(geometry_result.vertex_buffer);
-  FS::BindGradientInfo(
-      cmd, pass.GetTransientsBuffer().EmplaceUniform(gradient_info));
+  FS::BindFragInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frag_info));
   FS::BindColorData(cmd, color_buffer);
   VS::BindFrameInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frame_info));
 
@@ -130,16 +129,15 @@ bool SweepGradientContents::RenderTexture(const ContentContext& renderer,
     return false;
   }
 
-  FS::GradientInfo gradient_info;
-  gradient_info.center = center_;
-  gradient_info.bias = bias_;
-  gradient_info.scale = scale_;
-  gradient_info.texture_sampler_y_coord_scale =
-      gradient_texture->GetYCoordScale();
-  gradient_info.tile_mode = static_cast<Scalar>(tile_mode_);
-  gradient_info.alpha = GetAlpha();
-  gradient_info.half_texel = Vector2(0.5 / gradient_texture->GetSize().width,
-                                     0.5 / gradient_texture->GetSize().height);
+  FS::FragInfo frag_info;
+  frag_info.center = center_;
+  frag_info.bias = bias_;
+  frag_info.scale = scale_;
+  frag_info.texture_sampler_y_coord_scale = gradient_texture->GetYCoordScale();
+  frag_info.tile_mode = static_cast<Scalar>(tile_mode_);
+  frag_info.alpha = GetAlpha();
+  frag_info.half_texel = Vector2(0.5 / gradient_texture->GetSize().width,
+                                 0.5 / gradient_texture->GetSize().height);
 
   auto geometry_result =
       GetGeometry()->GetPositionBuffer(renderer, entity, pass);
@@ -161,8 +159,7 @@ bool SweepGradientContents::RenderTexture(const ContentContext& renderer,
   cmd.pipeline = renderer.GetSweepGradientFillPipeline(options);
 
   cmd.BindVertices(geometry_result.vertex_buffer);
-  FS::BindGradientInfo(
-      cmd, pass.GetTransientsBuffer().EmplaceUniform(gradient_info));
+  FS::BindFragInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frag_info));
   VS::BindFrameInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frame_info));
   SamplerDescriptor sampler_desc;
   sampler_desc.min_filter = MinMagFilter::kLinear;

--- a/impeller/entity/contents/texture_contents.cc
+++ b/impeller/entity/contents/texture_contents.cc
@@ -159,9 +159,9 @@ bool TextureContents::Render(const ContentContext& renderer,
 
   auto& host_buffer = pass.GetTransientsBuffer();
 
-  VS::VertInfo vert_info;
-  vert_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                  entity.GetTransformation();
+  VS::FrameInfo frame_info;
+  frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
+                   entity.GetTransformation();
 
   FS::FragInfo frag_info;
   frag_info.texture_sampler_y_coord_scale = texture_->GetYCoordScale();
@@ -180,7 +180,7 @@ bool TextureContents::Render(const ContentContext& renderer,
   cmd.pipeline = renderer.GetTexturePipeline(pipeline_options);
   cmd.stencil_reference = entity.GetStencilDepth();
   cmd.BindVertices(vertex_builder.CreateVertexBuffer(host_buffer));
-  VS::BindVertInfo(cmd, host_buffer.EmplaceUniform(vert_info));
+  VS::BindFrameInfo(cmd, host_buffer.EmplaceUniform(frame_info));
   FS::BindFragInfo(cmd, host_buffer.EmplaceUniform(frag_info));
   FS::BindTextureSampler(cmd, texture_,
                          renderer.GetContext()->GetSamplerLibrary()->GetSampler(

--- a/impeller/entity/contents/tiled_texture_contents.cc
+++ b/impeller/entity/contents/tiled_texture_contents.cc
@@ -76,12 +76,12 @@ bool TiledTextureContents::Render(const ContentContext& renderer,
   //              position_uv.vert.
   //              https://github.com/flutter/flutter/issues/118553
 
-  VS::VertInfo vert_info;
-  vert_info.mvp = geometry_result.transform;
-  vert_info.effect_transform = GetInverseMatrix();
-  vert_info.bounds_origin = geometry->GetCoverage(Matrix())->origin;
-  vert_info.texture_size = Vector2(static_cast<Scalar>(texture_size.width),
-                                   static_cast<Scalar>(texture_size.height));
+  VS::FrameInfo frame_info;
+  frame_info.mvp = geometry_result.transform;
+  frame_info.effect_transform = GetInverseMatrix();
+  frame_info.bounds_origin = geometry->GetCoverage(Matrix())->origin;
+  frame_info.texture_size = Vector2(static_cast<Scalar>(texture_size.width),
+                                    static_cast<Scalar>(texture_size.height));
 
   FS::FragInfo frag_info;
   frag_info.texture_sampler_y_coord_scale = texture_->GetYCoordScale();
@@ -102,7 +102,7 @@ bool TiledTextureContents::Render(const ContentContext& renderer,
   cmd.pipeline = renderer.GetTiledTexturePipeline(options);
 
   cmd.BindVertices(geometry_result.vertex_buffer);
-  VS::BindVertInfo(cmd, host_buffer.EmplaceUniform(vert_info));
+  VS::BindFrameInfo(cmd, host_buffer.EmplaceUniform(frame_info));
   FS::BindFragInfo(cmd, host_buffer.EmplaceUniform(frag_info));
   if (color_filter_.has_value()) {
     auto filtered_texture = CreateFilterTexture(renderer);

--- a/impeller/entity/contents/vertices_contents.cc
+++ b/impeller/entity/contents/vertices_contents.cc
@@ -101,9 +101,9 @@ bool VerticesColorContents::Render(const ContentContext& renderer,
   cmd.pipeline = renderer.GetGeometryColorPipeline(opts);
   cmd.BindVertices(geometry_result.vertex_buffer);
 
-  VS::VertInfo vert_info;
-  vert_info.mvp = geometry_result.transform;
-  VS::BindVertInfo(cmd, host_buffer.EmplaceUniform(vert_info));
+  VS::FrameInfo frame_info;
+  frame_info.mvp = geometry_result.transform;
+  VS::BindFrameInfo(cmd, host_buffer.EmplaceUniform(frame_info));
 
   FS::FragInfo frag_info;
   frag_info.alpha = alpha_;

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -808,11 +808,11 @@ TEST_P(EntityTest, BlendingModeOptions) {
       cmd.BindVertices(
           vtx_builder.CreateVertexBuffer(pass.GetTransientsBuffer()));
 
-      VS::VertInfo frame_info;
+      VS::FrameInfo frame_info;
       frame_info.mvp =
           Matrix::MakeOrthographic(pass.GetRenderTargetSize()) * world_matrix;
-      VS::BindVertInfo(cmd,
-                       pass.GetTransientsBuffer().EmplaceUniform(frame_info));
+      VS::BindFrameInfo(cmd,
+                        pass.GetTransientsBuffer().EmplaceUniform(frame_info));
 
       FS::FragInfo frag_info;
       frag_info.color = color.Premultiply();

--- a/impeller/entity/shaders/linear_gradient_fill.frag
+++ b/impeller/entity/shaders/linear_gradient_fill.frag
@@ -7,7 +7,7 @@
 
 uniform sampler2D texture_sampler;
 
-uniform GradientInfo {
+uniform FragInfo {
   vec2 start_point;
   vec2 end_point;
   float tile_mode;
@@ -15,21 +15,20 @@ uniform GradientInfo {
   float alpha;
   vec2 half_texel;
 }
-gradient_info;
+frag_info;
 
 in vec2 v_position;
 
 out vec4 frag_color;
 
 void main() {
-  float len = length(gradient_info.end_point - gradient_info.start_point);
-  float dot = dot(v_position - gradient_info.start_point,
-                  gradient_info.end_point - gradient_info.start_point);
+  float len = length(frag_info.end_point - frag_info.start_point);
+  float dot = dot(v_position - frag_info.start_point,
+                  frag_info.end_point - frag_info.start_point);
   float t = dot / (len * len);
   frag_color = IPSampleLinearWithTileMode(
-      texture_sampler, vec2(t, 0.5),
-      gradient_info.texture_sampler_y_coord_scale, gradient_info.half_texel,
-      gradient_info.tile_mode);
+      texture_sampler, vec2(t, 0.5), frag_info.texture_sampler_y_coord_scale,
+      frag_info.half_texel, frag_info.tile_mode);
   frag_color =
-      vec4(frag_color.xyz * frag_color.a, frag_color.a) * gradient_info.alpha;
+      vec4(frag_color.xyz * frag_color.a, frag_color.a) * frag_info.alpha;
 }

--- a/impeller/entity/shaders/linear_gradient_ssbo_fill.frag
+++ b/impeller/entity/shaders/linear_gradient_ssbo_fill.frag
@@ -16,33 +16,33 @@ layout(std140) readonly buffer ColorData {
 }
 color_data;
 
-uniform GradientInfo {
+uniform FragInfo {
   vec2 start_point;
   vec2 end_point;
   float alpha;
   float tile_mode;
   float colors_length;
 }
-gradient_info;
+frag_info;
 
 in vec2 v_position;
 
 out vec4 frag_color;
 
 void main() {
-  float len = length(gradient_info.end_point - gradient_info.start_point);
-  float dot = dot(v_position - gradient_info.start_point,
-                  gradient_info.end_point - gradient_info.start_point);
+  float len = length(frag_info.end_point - frag_info.start_point);
+  float dot = dot(v_position - frag_info.start_point,
+                  frag_info.end_point - frag_info.start_point);
   float t = dot / (len * len);
 
-  if ((t < 0.0 || t > 1.0) && gradient_info.tile_mode == kTileModeDecal) {
+  if ((t < 0.0 || t > 1.0) && frag_info.tile_mode == kTileModeDecal) {
     frag_color = vec4(0);
     return;
   }
-  t = IPFloatTile(t, gradient_info.tile_mode);
+  t = IPFloatTile(t, frag_info.tile_mode);
 
   vec4 result_color = vec4(0);
-  for (int i = 1; i < gradient_info.colors_length; i++) {
+  for (int i = 1; i < frag_info.colors_length; i++) {
     ColorPoint prev_point = color_data.colors[i - 1];
     ColorPoint current_point = color_data.colors[i];
     if (t >= prev_point.stop && t <= current_point.stop) {
@@ -56,6 +56,6 @@ void main() {
       break;
     }
   }
-  frag_color = vec4(result_color.xyz * result_color.a, result_color.a) *
-               gradient_info.alpha;
+  frag_color =
+      vec4(result_color.xyz * result_color.a, result_color.a) * frag_info.alpha;
 }

--- a/impeller/entity/shaders/position.vert
+++ b/impeller/entity/shaders/position.vert
@@ -5,17 +5,17 @@
 #include <impeller/transform.glsl>
 #include <impeller/types.glsl>
 
-uniform VertInfo {
+uniform FrameInfo {
   mat4 mvp;
   vec4 color;
 }
-vert_info;
+frame_info;
 
 in vec2 position;
 
 out vec4 v_color;
 
 void main() {
-  gl_Position = vert_info.mvp * vec4(position, 0.0, 1.0);
-  v_color = vert_info.color;
+  gl_Position = frame_info.mvp * vec4(position, 0.0, 1.0);
+  v_color = frame_info.color;
 }

--- a/impeller/entity/shaders/position_color.vert
+++ b/impeller/entity/shaders/position_color.vert
@@ -5,10 +5,10 @@
 #include <impeller/transform.glsl>
 #include <impeller/types.glsl>
 
-uniform VertInfo {
+uniform FrameInfo {
   mat4 mvp;
 }
-vert_info;
+frame_info;
 
 in vec2 position;
 in vec4 color;
@@ -16,6 +16,6 @@ in vec4 color;
 out vec4 v_color;
 
 void main() {
-  gl_Position = vert_info.mvp * vec4(position, 0.0, 1.0);
+  gl_Position = frame_info.mvp * vec4(position, 0.0, 1.0);
   v_color = color;
 }

--- a/impeller/entity/shaders/position_uv.vert
+++ b/impeller/entity/shaders/position_uv.vert
@@ -5,10 +5,10 @@
 #include <impeller/transform.glsl>
 #include <impeller/types.glsl>
 
-uniform VertInfo {
+uniform FrameInfo {
   mat4 mvp;
 }
-vert_info;
+frame_info;
 
 in vec2 position;
 in vec2 uv;
@@ -17,7 +17,7 @@ out vec2 v_uv;
 out vec2 v_position;
 
 void main() {
-  gl_Position = vert_info.mvp * vec4(position, 0.0, 1.0);
+  gl_Position = frame_info.mvp * vec4(position, 0.0, 1.0);
   v_uv = uv;
-  v_position = IPVec2TransformPosition(vert_info.mvp, position);
+  v_position = IPVec2TransformPosition(frame_info.mvp, position);
 }

--- a/impeller/entity/shaders/radial_gradient_fill.frag
+++ b/impeller/entity/shaders/radial_gradient_fill.frag
@@ -7,7 +7,7 @@
 
 uniform sampler2D texture_sampler;
 
-uniform GradientInfo {
+uniform FragInfo {
   vec2 center;
   float radius;
   float tile_mode;
@@ -15,19 +15,18 @@ uniform GradientInfo {
   float alpha;
   vec2 half_texel;
 }
-gradient_info;
+frag_info;
 
 in vec2 v_position;
 
 out vec4 frag_color;
 
 void main() {
-  float len = length(v_position - gradient_info.center);
-  float t = len / gradient_info.radius;
+  float len = length(v_position - frag_info.center);
+  float t = len / frag_info.radius;
   frag_color = IPSampleLinearWithTileMode(
-      texture_sampler, vec2(t, 0.5),
-      gradient_info.texture_sampler_y_coord_scale, gradient_info.half_texel,
-      gradient_info.tile_mode);
+      texture_sampler, vec2(t, 0.5), frag_info.texture_sampler_y_coord_scale,
+      frag_info.half_texel, frag_info.tile_mode);
   frag_color =
-      vec4(frag_color.xyz * frag_color.a, frag_color.a) * gradient_info.alpha;
+      vec4(frag_color.xyz * frag_color.a, frag_color.a) * frag_info.alpha;
 }

--- a/impeller/entity/shaders/radial_gradient_ssbo_fill.frag
+++ b/impeller/entity/shaders/radial_gradient_ssbo_fill.frag
@@ -16,31 +16,31 @@ layout(std140) readonly buffer ColorData {
 }
 color_data;
 
-uniform GradientInfo {
+uniform FragInfo {
   vec2 center;
   float radius;
   float tile_mode;
   float alpha;
   float colors_length;
 }
-gradient_info;
+frag_info;
 
 in vec2 v_position;
 
 out vec4 frag_color;
 
 void main() {
-  float len = length(v_position - gradient_info.center);
-  float t = len / gradient_info.radius;
+  float len = length(v_position - frag_info.center);
+  float t = len / frag_info.radius;
 
-  if ((t < 0.0 || t > 1.0) && gradient_info.tile_mode == kTileModeDecal) {
+  if ((t < 0.0 || t > 1.0) && frag_info.tile_mode == kTileModeDecal) {
     frag_color = vec4(0);
     return;
   }
-  t = IPFloatTile(t, gradient_info.tile_mode);
+  t = IPFloatTile(t, frag_info.tile_mode);
 
   vec4 result_color = vec4(0);
-  for (int i = 1; i < gradient_info.colors_length; i++) {
+  for (int i = 1; i < frag_info.colors_length; i++) {
     ColorPoint prev_point = color_data.colors[i - 1];
     ColorPoint current_point = color_data.colors[i];
     if (t >= prev_point.stop && t <= current_point.stop) {
@@ -54,6 +54,6 @@ void main() {
       break;
     }
   }
-  frag_color = vec4(result_color.xyz * result_color.a, result_color.a) *
-               gradient_info.alpha;
+  frag_color =
+      vec4(result_color.xyz * result_color.a, result_color.a) * frag_info.alpha;
 }

--- a/impeller/entity/shaders/rrect_blur.vert
+++ b/impeller/entity/shaders/rrect_blur.vert
@@ -4,17 +4,17 @@
 
 #include <impeller/types.glsl>
 
-uniform VertInfo {
+uniform FrameInfo {
   mat4 mvp;
 }
-vert_info;
+frame_info;
 
 in vec2 position;
 
 out vec2 v_position;
 
 void main() {
-  gl_Position = vert_info.mvp * vec4(position, 0.0, 1.0);
+  gl_Position = frame_info.mvp * vec4(position, 0.0, 1.0);
   // The fragment stage uses local coordinates to compute the blur.
   v_position = position;
 }

--- a/impeller/entity/shaders/runtime_effect.vert
+++ b/impeller/entity/shaders/runtime_effect.vert
@@ -4,10 +4,10 @@
 
 #include <impeller/types.glsl>
 
-uniform VertInfo {
+uniform FrameInfo {
   mat4 mvp;
 }
-vert_info;
+frame_info;
 
 in vec2 position;
 // Note: The GLES backend uses name matching for attribute locations. This name
@@ -16,6 +16,6 @@ in vec2 position;
 out vec2 _fragCoord;
 
 void main() {
-  gl_Position = vert_info.mvp * vec4(position, 0.0, 1.0);
+  gl_Position = frame_info.mvp * vec4(position, 0.0, 1.0);
   _fragCoord = position;
 }

--- a/impeller/entity/shaders/solid_fill.vert
+++ b/impeller/entity/shaders/solid_fill.vert
@@ -4,13 +4,13 @@
 
 #include <impeller/types.glsl>
 
-uniform VertInfo {
+uniform FrameInfo {
   mat4 mvp;
 }
-vert_info;
+frame_info;
 
 in vec2 position;
 
 void main() {
-  gl_Position = vert_info.mvp * vec4(position, 0.0, 1.0);
+  gl_Position = frame_info.mvp * vec4(position, 0.0, 1.0);
 }

--- a/impeller/entity/shaders/sweep_gradient_fill.frag
+++ b/impeller/entity/shaders/sweep_gradient_fill.frag
@@ -8,7 +8,7 @@
 
 uniform sampler2D texture_sampler;
 
-uniform GradientInfo {
+uniform FragInfo {
   vec2 center;
   float bias;
   float scale;
@@ -17,22 +17,20 @@ uniform GradientInfo {
   float alpha;
   vec2 half_texel;
 }
-gradient_info;
+frag_info;
 
 in vec2 v_position;
 
 out vec4 frag_color;
 
 void main() {
-  vec2 coord = v_position - gradient_info.center;
+  vec2 coord = v_position - frag_info.center;
   float angle = atan(-coord.y, -coord.x);
 
-  float t =
-      (angle * k1Over2Pi + 0.5 + gradient_info.bias) * gradient_info.scale;
+  float t = (angle * k1Over2Pi + 0.5 + frag_info.bias) * frag_info.scale;
   frag_color = IPSampleLinearWithTileMode(
-      texture_sampler, vec2(t, 0.5),
-      gradient_info.texture_sampler_y_coord_scale, gradient_info.half_texel,
-      gradient_info.tile_mode);
+      texture_sampler, vec2(t, 0.5), frag_info.texture_sampler_y_coord_scale,
+      frag_info.half_texel, frag_info.tile_mode);
   frag_color =
-      vec4(frag_color.xyz * frag_color.a, frag_color.a) * gradient_info.alpha;
+      vec4(frag_color.xyz * frag_color.a, frag_color.a) * frag_info.alpha;
 }

--- a/impeller/entity/shaders/sweep_gradient_ssbo_fill.frag
+++ b/impeller/entity/shaders/sweep_gradient_ssbo_fill.frag
@@ -17,7 +17,7 @@ layout(std140) readonly buffer ColorData {
 }
 color_data;
 
-uniform GradientInfo {
+uniform FragInfo {
   vec2 center;
   float bias;
   float scale;
@@ -25,26 +25,25 @@ uniform GradientInfo {
   float alpha;
   float colors_length;
 }
-gradient_info;
+frag_info;
 
 in vec2 v_position;
 
 out vec4 frag_color;
 
 void main() {
-  vec2 coord = v_position - gradient_info.center;
+  vec2 coord = v_position - frag_info.center;
   float angle = atan(-coord.y, -coord.x);
-  float t =
-      (angle * k1Over2Pi + 0.5 + gradient_info.bias) * gradient_info.scale;
+  float t = (angle * k1Over2Pi + 0.5 + frag_info.bias) * frag_info.scale;
 
-  if ((t < 0.0 || t > 1.0) && gradient_info.tile_mode == kTileModeDecal) {
+  if ((t < 0.0 || t > 1.0) && frag_info.tile_mode == kTileModeDecal) {
     frag_color = vec4(0);
     return;
   }
-  t = IPFloatTile(t, gradient_info.tile_mode);
+  t = IPFloatTile(t, frag_info.tile_mode);
 
   vec4 result_color = vec4(0);
-  for (int i = 1; i < gradient_info.colors_length; i++) {
+  for (int i = 1; i < frag_info.colors_length; i++) {
     ColorPoint prev_point = color_data.colors[i - 1];
     ColorPoint current_point = color_data.colors[i];
     if (t >= prev_point.stop && t <= current_point.stop) {
@@ -58,6 +57,6 @@ void main() {
       break;
     }
   }
-  frag_color = vec4(result_color.xyz * result_color.a, result_color.a) *
-               gradient_info.alpha;
+  frag_color =
+      vec4(result_color.xyz * result_color.a, result_color.a) * frag_info.alpha;
 }

--- a/impeller/entity/shaders/texture_fill.vert
+++ b/impeller/entity/shaders/texture_fill.vert
@@ -4,10 +4,10 @@
 
 #include <impeller/types.glsl>
 
-uniform VertInfo {
+uniform FrameInfo {
   mat4 mvp;
 }
-vert_info;
+frame_info;
 
 in vec2 position;
 in vec2 texture_coords;
@@ -15,6 +15,6 @@ in vec2 texture_coords;
 out vec2 v_texture_coords;
 
 void main() {
-  gl_Position = vert_info.mvp * vec4(position, 0.0, 1.0);
+  gl_Position = frame_info.mvp * vec4(position, 0.0, 1.0);
   v_texture_coords = texture_coords;
 }

--- a/impeller/entity/shaders/tiled_texture_fill.vert
+++ b/impeller/entity/shaders/tiled_texture_fill.vert
@@ -5,21 +5,21 @@
 #include <impeller/transform.glsl>
 #include <impeller/types.glsl>
 
-uniform VertInfo {
+uniform FrameInfo {
   mat4 mvp;
   mat4 effect_transform;
   vec2 bounds_origin;
   vec2 texture_size;
 }
-vert_info;
+frame_info;
 
 in vec2 position;
 
 out vec2 v_texture_coords;
 
 void main() {
-  gl_Position = vert_info.mvp * vec4(position, 0.0, 1.0);
+  gl_Position = frame_info.mvp * vec4(position, 0.0, 1.0);
   v_texture_coords = IPVec2TransformPosition(
-      vert_info.effect_transform,
-      (position - vert_info.bounds_origin) / vert_info.texture_size);
+      frame_info.effect_transform,
+      (position - frame_info.bounds_origin) / frame_info.texture_size);
 }

--- a/impeller/fixtures/array.vert
+++ b/impeller/fixtures/array.vert
@@ -2,16 +2,16 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-uniform VertInfo {
+uniform FrameInfo {
   mat4 mvp;
 }
-vert_info;
+frame_info;
 
 in vec2 position;
 
 out vec2 v_position;
 
 void main() {
-  gl_Position = vert_info.mvp * vec4(position, 0.0, 1.0);
+  gl_Position = frame_info.mvp * vec4(position, 0.0, 1.0);
   v_position = position;
 }

--- a/impeller/fixtures/inactive_uniforms.vert
+++ b/impeller/fixtures/inactive_uniforms.vert
@@ -2,16 +2,16 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-uniform VertInfo {
+uniform FrameInfo {
   mat4 mvp;
 }
-vert_info;
+frame_info;
 
 in vec2 position;
 
 out vec2 v_position;
 
 void main() {
-  gl_Position = vert_info.mvp * vec4(position, 0.0, 1.0);
+  gl_Position = frame_info.mvp * vec4(position, 0.0, 1.0);
   v_position = position;
 }

--- a/impeller/fixtures/mipmaps.vert
+++ b/impeller/fixtures/mipmaps.vert
@@ -2,10 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-uniform VertInfo {
+uniform FrameInfo {
   mat4 mvp;
 }
-vert_info;
+frame_info;
 
 in vec2 vertex_position;
 in vec2 uv;
@@ -13,6 +13,6 @@ in vec2 uv;
 out vec2 v_uv;
 
 void main() {
-  gl_Position = vert_info.mvp * vec4(vertex_position, 0.0, 1.0);
+  gl_Position = frame_info.mvp * vec4(vertex_position, 0.0, 1.0);
   v_uv = uv;
 }

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -530,11 +530,11 @@ TEST_P(RendererTest, CanBlitTextureToTexture) {
 
         cmd.BindVertices(vertex_buffer);
 
-        VS::VertInfo vert_info;
-        vert_info.mvp = Matrix::MakeOrthographic(pass->GetRenderTargetSize()) *
-                        Matrix::MakeScale(GetContentScale());
-        VS::BindVertInfo(cmd,
-                         pass->GetTransientsBuffer().EmplaceUniform(vert_info));
+        VS::FrameInfo frame_info;
+        frame_info.mvp = Matrix::MakeOrthographic(pass->GetRenderTargetSize()) *
+                         Matrix::MakeScale(GetContentScale());
+        VS::BindFrameInfo(
+            cmd, pass->GetTransientsBuffer().EmplaceUniform(frame_info));
 
         FS::FragInfo frag_info;
         frag_info.lod = 0;
@@ -654,11 +654,11 @@ TEST_P(RendererTest, CanBlitTextureToBuffer) {
 
         cmd.BindVertices(vertex_buffer);
 
-        VS::VertInfo vert_info;
-        vert_info.mvp = Matrix::MakeOrthographic(pass->GetRenderTargetSize()) *
-                        Matrix::MakeScale(GetContentScale());
-        VS::BindVertInfo(cmd,
-                         pass->GetTransientsBuffer().EmplaceUniform(vert_info));
+        VS::FrameInfo frame_info;
+        frame_info.mvp = Matrix::MakeOrthographic(pass->GetRenderTargetSize()) *
+                         Matrix::MakeScale(GetContentScale());
+        VS::BindFrameInfo(
+            cmd, pass->GetTransientsBuffer().EmplaceUniform(frame_info));
 
         FS::FragInfo frag_info;
         frag_info.lod = 0;
@@ -775,11 +775,11 @@ TEST_P(RendererTest, CanGenerateMipmaps) {
 
         cmd.BindVertices(vertex_buffer);
 
-        VS::VertInfo vert_info;
-        vert_info.mvp = Matrix::MakeOrthographic(pass->GetRenderTargetSize()) *
-                        Matrix::MakeScale(GetContentScale());
-        VS::BindVertInfo(cmd,
-                         pass->GetTransientsBuffer().EmplaceUniform(vert_info));
+        VS::FrameInfo frame_info;
+        frame_info.mvp = Matrix::MakeOrthographic(pass->GetRenderTargetSize()) *
+                         Matrix::MakeScale(GetContentScale());
+        VS::BindFrameInfo(
+            cmd, pass->GetTransientsBuffer().EmplaceUniform(frame_info));
 
         FS::FragInfo frag_info;
         frag_info.lod = lod;
@@ -846,10 +846,10 @@ TEST_P(RendererTest, TheImpeller) {
                          {Point(size.width, size.height)}});
     cmd.BindVertices(builder.CreateVertexBuffer(pass.GetTransientsBuffer()));
 
-    VS::FrameInfo vs_uniform;
-    vs_uniform.mvp = Matrix::MakeOrthographic(size);
+    VS::FrameInfo frame_info;
+    frame_info.mvp = Matrix::MakeOrthographic(size);
     VS::BindFrameInfo(cmd,
-                      pass.GetTransientsBuffer().EmplaceUniform(vs_uniform));
+                      pass.GetTransientsBuffer().EmplaceUniform(frame_info));
 
     FS::FragInfo fs_uniform;
     fs_uniform.texture_size = Point(size);
@@ -893,11 +893,11 @@ TEST_P(RendererTest, ArrayUniforms) {
                          {Point(size.width, size.height)}});
     cmd.BindVertices(builder.CreateVertexBuffer(pass.GetTransientsBuffer()));
 
-    VS::VertInfo vs_uniform;
-    vs_uniform.mvp =
+    VS::FrameInfo frame_info;
+    frame_info.mvp =
         Matrix::MakeOrthographic(size) * Matrix::MakeScale(GetContentScale());
-    VS::BindVertInfo(cmd,
-                     pass.GetTransientsBuffer().EmplaceUniform(vs_uniform));
+    VS::BindFrameInfo(cmd,
+                      pass.GetTransientsBuffer().EmplaceUniform(frame_info));
 
     auto time = GetSecondsElapsed();
     auto y_pos = [&time](float x) {
@@ -949,11 +949,11 @@ TEST_P(RendererTest, InactiveUniforms) {
                          {Point(size.width, size.height)}});
     cmd.BindVertices(builder.CreateVertexBuffer(pass.GetTransientsBuffer()));
 
-    VS::VertInfo vs_uniform;
-    vs_uniform.mvp =
+    VS::FrameInfo frame_info;
+    frame_info.mvp =
         Matrix::MakeOrthographic(size) * Matrix::MakeScale(GetContentScale());
-    VS::BindVertInfo(cmd,
-                     pass.GetTransientsBuffer().EmplaceUniform(vs_uniform));
+    VS::BindFrameInfo(cmd,
+                      pass.GetTransientsBuffer().EmplaceUniform(frame_info));
 
     FS::FragInfo fs_uniform = {.unused_color = Color::Red(),
                                .color = Color::Green()};

--- a/impeller/scene/geometry.cc
+++ b/impeller/scene/geometry.cc
@@ -168,9 +168,9 @@ void CuboidGeometry::BindToCommand(const SceneContext& scene_context,
   command.BindVertices(
       GetVertexBuffer(*scene_context.GetContext()->GetResourceAllocator()));
 
-  UnskinnedVertexShader::VertInfo info;
+  UnskinnedVertexShader::FrameInfo info;
   info.mvp = transform;
-  UnskinnedVertexShader::BindVertInfo(command, buffer.EmplaceUniform(info));
+  UnskinnedVertexShader::BindFrameInfo(command, buffer.EmplaceUniform(info));
 }
 
 //------------------------------------------------------------------------------
@@ -206,9 +206,9 @@ void UnskinnedVertexBufferGeometry::BindToCommand(
   command.BindVertices(
       GetVertexBuffer(*scene_context.GetContext()->GetResourceAllocator()));
 
-  UnskinnedVertexShader::VertInfo info;
+  UnskinnedVertexShader::FrameInfo info;
   info.mvp = transform;
-  UnskinnedVertexShader::BindVertInfo(command, buffer.EmplaceUniform(info));
+  UnskinnedVertexShader::BindFrameInfo(command, buffer.EmplaceUniform(info));
 }
 
 //------------------------------------------------------------------------------
@@ -256,12 +256,12 @@ void SkinnedVertexBufferGeometry::BindToCommand(
       scene_context.GetContext()->GetSamplerLibrary()->GetSampler(
           sampler_desc));
 
-  SkinnedVertexShader::VertInfo info;
+  SkinnedVertexShader::FrameInfo info;
   info.mvp = transform;
   info.enable_skinning = joints_texture_ ? 1 : 0;
   info.joint_texture_size =
       joints_texture_ ? joints_texture_->GetSize().width : 1;
-  SkinnedVertexShader::BindVertInfo(command, buffer.EmplaceUniform(info));
+  SkinnedVertexShader::BindFrameInfo(command, buffer.EmplaceUniform(info));
 }
 
 // |Geometry|

--- a/impeller/scene/shaders/skinned.vert
+++ b/impeller/scene/shaders/skinned.vert
@@ -2,12 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-uniform VertInfo {
+uniform FrameInfo {
   mat4 mvp;
   float enable_skinning;
   float joint_texture_size;
 }
-vert_info;
+frame_info;
 
 uniform sampler2D joints_texture;
 
@@ -31,15 +31,15 @@ const int kMatrixTexelStride = 4;
 mat4 GetJoint(float joint_index) {
   // The size of one texel in UV space. The joint texture should always be
   // square, so the answer is the same in both dimensions.
-  float texel_size_uv = 1 / vert_info.joint_texture_size;
+  float texel_size_uv = 1 / frame_info.joint_texture_size;
 
   // Each joint matrix takes up 4 pixels (16 floats), so we jump 4 pixels per
   // joint matrix.
   float matrix_start = joint_index * kMatrixTexelStride;
 
   // The texture space coordinates at the start of the matrix.
-  float x = mod(matrix_start, vert_info.joint_texture_size);
-  float y = floor(matrix_start / vert_info.joint_texture_size);
+  float x = mod(matrix_start, frame_info.joint_texture_size);
+  float y = floor(matrix_start / frame_info.joint_texture_size);
 
   // Nearest sample the middle of each the texel by adding `0.5 * texel_size_uv`
   // to both dimensions.
@@ -55,7 +55,7 @@ mat4 GetJoint(float joint_index) {
 
 void main() {
   mat4 skin_matrix;
-  if (vert_info.enable_skinning == 1) {
+  if (frame_info.enable_skinning == 1) {
     skin_matrix =
         GetJoint(joints.x) * weights.x + GetJoint(joints.y) * weights.y +
         GetJoint(joints.z) * weights.z + GetJoint(joints.w) * weights.w;
@@ -63,12 +63,12 @@ void main() {
     skin_matrix = mat4(1);  // Identity matrix.
   }
 
-  gl_Position = vert_info.mvp * skin_matrix * vec4(position, 1.0);
+  gl_Position = frame_info.mvp * skin_matrix * vec4(position, 1.0);
   v_position = gl_Position.xyz;
 
   vec3 lh_tangent = (skin_matrix * vec4(tangent.xyz * tangent.w, 0.0)).xyz;
   vec3 out_normal = (skin_matrix * vec4(normal, 0.0)).xyz;
-  v_tangent_space = mat3(vert_info.mvp) *
+  v_tangent_space = mat3(frame_info.mvp) *
                     mat3(lh_tangent, cross(out_normal, lh_tangent), out_normal);
   v_texture_coords = texture_coords;
   v_color = color;

--- a/impeller/scene/shaders/unskinned.vert
+++ b/impeller/scene/shaders/unskinned.vert
@@ -2,10 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-uniform VertInfo {
+uniform FrameInfo {
   mat4 mvp;
 }
-vert_info;
+frame_info;
 
 // This attribute layout is expected to be identical to that within
 // `impeller/scene/importer/scene.fbs`.
@@ -21,12 +21,12 @@ out vec2 v_texture_coords;
 out vec4 v_color;
 
 void main() {
-  gl_Position = vert_info.mvp * vec4(position, 1.0);
+  gl_Position = frame_info.mvp * vec4(position, 1.0);
   v_position = gl_Position.xyz;
 
   vec3 lh_tangent = tangent.xyz * tangent.w;
-  v_tangent_space =
-      mat3(vert_info.mvp) * mat3(lh_tangent, cross(normal, lh_tangent), normal);
+  v_tangent_space = mat3(frame_info.mvp) *
+                    mat3(lh_tangent, cross(normal, lh_tangent), normal);
   v_texture_coords = texture_coords;
   v_color = color;
 }


### PR DESCRIPTION
Makes all fragment shader UBOs and vertex shader UBOs consistent.
