### PR TITLE
[Impeller] Fix test failure for IMPELLER_ENABLE_3D

### DIFF
--- a/impeller/display_list/display_list_unittests.cc
+++ b/impeller/display_list/display_list_unittests.cc
@@ -1320,7 +1320,7 @@ TEST_P(DisplayListTest, SceneColorSource) {
 
   flutter::DlPaint paint = flutter::DlPaint().setColorSource(color_source);
 
-  builder.drawPaint(paint);
+  builder.DrawPaint(paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }


### PR DESCRIPTION
Updated for the recent rename of drawPaint in the DL builder.