### PR TITLE
[Impeller] Add texture->texture blits to device capabilities

### DIFF
--- a/impeller/renderer/backend/gles/context_gles.cc
+++ b/impeller/renderer/backend/gles/context_gles.cc
@@ -76,6 +76,8 @@ ContextGLES::ContextGLES(std::unique_ptr<ProcTableGLES> gl,
             .SetHasThreadingRestrictions(true)
             .SetSupportsOffscreenMSAA(false)
             .SetSupportsSSBO(false)
+            .SetSupportsTextureToTextureBlits(
+                reactor_->GetProcTable().BlitFramebuffer.IsAvailable())
             .SetDefaultColorFormat(PixelFormat::kB8G8R8A8UNormInt)
             .SetDefaultStencilFormat(PixelFormat::kS8UInt)
             .Build();

--- a/impeller/renderer/backend/metal/context_mtl.mm
+++ b/impeller/renderer/backend/metal/context_mtl.mm
@@ -95,6 +95,7 @@ ContextMTL::ContextMTL(id<MTLDevice> device,
             .SetHasThreadingRestrictions(false)
             .SetSupportsOffscreenMSAA(true)
             .SetSupportsSSBO(true)
+            .SetSupportsTextureToTextureBlits(true)
             .SetDefaultColorFormat(PixelFormat::kB8G8R8A8UNormInt)
             .SetDefaultStencilFormat(PixelFormat::kS8UInt)
             .Build();

--- a/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/impeller/renderer/backend/vulkan/context_vk.cc
@@ -504,6 +504,7 @@ ContextVK::ContextVK(
           .SetHasThreadingRestrictions(false)
           .SetSupportsOffscreenMSAA(true)
           .SetSupportsSSBO(false)
+          .SetSupportsTextureToTextureBlits(true)
           .SetDefaultColorFormat(PixelFormat::kB8G8R8A8UNormInt)
           .SetDefaultStencilFormat(PixelFormat::kS8UInt)
           .Build();

--- a/impeller/renderer/device_capabilities.cc
+++ b/impeller/renderer/device_capabilities.cc
@@ -6,29 +6,35 @@
 
 namespace impeller {
 
-IDeviceCapabilities::IDeviceCapabilities(bool threading_restrictions,
-                                         bool offscreen_msaa,
+IDeviceCapabilities::IDeviceCapabilities(bool has_threading_restrictions,
+                                         bool supports_offscreen_msaa,
                                          bool supports_ssbo,
+                                         bool supports_texture_to_texture_blits,
                                          PixelFormat default_color_format,
                                          PixelFormat default_stencil_format)
-    : threading_restrictions_(threading_restrictions),
-      offscreen_msaa_(offscreen_msaa),
+    : has_threading_restrictions_(has_threading_restrictions),
+      supports_offscreen_msaa_(supports_offscreen_msaa),
       supports_ssbo_(supports_ssbo),
+      supports_texture_to_texture_blits_(supports_texture_to_texture_blits),
       default_color_format_(default_color_format),
       default_stencil_format_(default_stencil_format) {}
 
 IDeviceCapabilities::~IDeviceCapabilities() = default;
 
 bool IDeviceCapabilities::HasThreadingRestrictions() const {
-  return threading_restrictions_;
+  return has_threading_restrictions_;
 }
 
 bool IDeviceCapabilities::SupportsOffscreenMSAA() const {
-  return offscreen_msaa_;
+  return supports_offscreen_msaa_;
 }
 
 bool IDeviceCapabilities::SupportsSSBO() const {
   return supports_ssbo_;
+}
+
+bool IDeviceCapabilities::SupportsTextureToTextureBlits() const {
+  return supports_texture_to_texture_blits_;
 }
 
 PixelFormat IDeviceCapabilities::GetDefaultColorFormat() const {
@@ -45,19 +51,25 @@ DeviceCapabilitiesBuilder::~DeviceCapabilitiesBuilder() = default;
 
 DeviceCapabilitiesBuilder&
 DeviceCapabilitiesBuilder::SetHasThreadingRestrictions(bool value) {
-  threading_restrictions_ = value;
+  has_threading_restrictions_ = value;
   return *this;
 }
 
 DeviceCapabilitiesBuilder& DeviceCapabilitiesBuilder::SetSupportsOffscreenMSAA(
     bool value) {
-  offscreen_msaa_ = value;
+  supports_offscreen_msaa_ = value;
   return *this;
 }
 
 DeviceCapabilitiesBuilder& DeviceCapabilitiesBuilder::SetSupportsSSBO(
     bool value) {
   supports_ssbo_ = value;
+  return *this;
+}
+
+DeviceCapabilitiesBuilder&
+DeviceCapabilitiesBuilder::SetSupportsTextureToTextureBlits(bool value) {
+  supports_texture_to_texture_blits_ = value;
   return *this;
 }
 
@@ -79,9 +91,14 @@ std::unique_ptr<IDeviceCapabilities> DeviceCapabilitiesBuilder::Build() {
   FML_CHECK(default_stencil_format_.has_value())
       << "Default stencil format not set";
 
-  IDeviceCapabilities* capabilities = new IDeviceCapabilities(
-      threading_restrictions_, offscreen_msaa_, supports_ssbo_,
-      *default_color_format_, *default_stencil_format_);
+  IDeviceCapabilities* capabilities = new IDeviceCapabilities(  //
+      has_threading_restrictions_,                              //
+      supports_offscreen_msaa_,                                 //
+      supports_ssbo_,                                           //
+      supports_texture_to_texture_blits_,                       //
+      *default_color_format_,                                   //
+      *default_stencil_format_                                  //
+  );
   return std::unique_ptr<IDeviceCapabilities>(capabilities);
 }
 

--- a/impeller/renderer/device_capabilities.h
+++ b/impeller/renderer/device_capabilities.h
@@ -21,22 +21,26 @@ class IDeviceCapabilities {
 
   bool SupportsSSBO() const;
 
+  bool SupportsTextureToTextureBlits() const;
+
   PixelFormat GetDefaultColorFormat() const;
 
   PixelFormat GetDefaultStencilFormat() const;
 
  private:
-  IDeviceCapabilities(bool threading_restrictions,
-                      bool offscreen_msaa,
+  IDeviceCapabilities(bool has_threading_restrictions,
+                      bool supports_offscreen_msaa,
                       bool supports_ssbo,
+                      bool supports_texture_to_texture_blits,
                       PixelFormat default_color_format,
                       PixelFormat default_stencil_format);
 
   friend class DeviceCapabilitiesBuilder;
 
-  bool threading_restrictions_ = false;
-  bool offscreen_msaa_ = false;
+  bool has_threading_restrictions_ = false;
+  bool supports_offscreen_msaa_ = false;
   bool supports_ssbo_ = false;
+  bool supports_texture_to_texture_blits_ = false;
   PixelFormat default_color_format_;
   PixelFormat default_stencil_format_;
 
@@ -55,6 +59,8 @@ class DeviceCapabilitiesBuilder {
 
   DeviceCapabilitiesBuilder& SetSupportsSSBO(bool value);
 
+  DeviceCapabilitiesBuilder& SetSupportsTextureToTextureBlits(bool value);
+
   DeviceCapabilitiesBuilder& SetDefaultColorFormat(PixelFormat value);
 
   DeviceCapabilitiesBuilder& SetDefaultStencilFormat(PixelFormat value);
@@ -62,9 +68,10 @@ class DeviceCapabilitiesBuilder {
   std::unique_ptr<IDeviceCapabilities> Build();
 
  private:
-  bool threading_restrictions_ = false;
-  bool offscreen_msaa_ = false;
+  bool has_threading_restrictions_ = false;
+  bool supports_offscreen_msaa_ = false;
   bool supports_ssbo_ = false;
+  bool supports_texture_to_texture_blits_ = false;
   std::optional<PixelFormat> default_color_format_ = std::nullopt;
   std::optional<PixelFormat> default_stencil_format_ = std::nullopt;
 


### PR DESCRIPTION
We're not using texture->texture blits anywhere yet, but there are a couple of paths that will benefit from this in EntityPass. For the GL backend, it's GLES3 only, so we need to fallback to slower paths when it's not available.