### PR TITLE
Remove unused flag `skia_canvaskit_enable_particles`

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -636,7 +636,6 @@ def to_gn_wasm_args(args, gn_args):
   gn_args['skia_canvaskit_enable_effects_deserialization'] = False
   gn_args['skia_canvaskit_enable_skottie'] = False
   gn_args['skia_canvaskit_include_viewer'] = False
-  gn_args['skia_canvaskit_enable_particles'] = False
   gn_args['skia_canvaskit_enable_pathops'] = True
   gn_args['skia_canvaskit_enable_rt_shader'] = True
   gn_args['skia_canvaskit_enable_matrix_helper'] = False


### PR DESCRIPTION
This flag was removed from skia in https://skia-review.googlesource.com/c/skia/+/647796