### PR TITLE
Actually print out if xcrun metal fails

### DIFF
--- a/impeller/tools/build_metal_library.py
+++ b/impeller/tools/build_metal_library.py
@@ -120,7 +120,6 @@ def main():
   return 0
 
 
-
 if __name__ == '__main__':
   if sys.platform != 'darwin':
     raise Exception('This script only runs on Mac')

--- a/impeller/tools/build_metal_library.py
+++ b/impeller/tools/build_metal_library.py
@@ -113,9 +113,9 @@ def main():
 
   try:
     subprocess.check_output(command, stderr=subprocess.STDOUT, text=True)
-  except subprocess.CalledProcessError as e:
-    print(e.output)
-    return e.returncode
+  except subprocess.CalledProcessError as cpe:
+    print(cpe.output)
+    return cpe.returncode
 
   return 0
 

--- a/impeller/tools/build_metal_library.py
+++ b/impeller/tools/build_metal_library.py
@@ -111,10 +111,17 @@ def main():
 
   command += args.source
 
-  subprocess.check_output(command, stderr=subprocess.STDOUT)
+  try:
+    subprocess.check_output(command, stderr=subprocess.STDOUT, text=True)
+  except subprocess.CalledProcessError as e:
+    print(e.output)
+    return e.returncode
+
+  return 0
+
 
 
 if __name__ == '__main__':
   if sys.platform != 'darwin':
     raise Exception('This script only runs on Mac')
-  main()
+  sys.exit(main())


### PR DESCRIPTION
My previous commit was exiting with an unhelpful error that did not contain the failure output. This prints the failure output more nicely.
