### PR TITLE
Revert "[lint + clang tidy] add lint check for python file changes"

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -229,7 +229,6 @@ targets:
       - "**.cc"
       - "**.fbs"
       - "**.frag"
-      - "**.py"
       - "**.vert"
 
   - name: Linux Android clang-tidy


### PR DESCRIPTION
Reverts flutter/engine#39736

The actual fix was related to glob behavior in https://github.com/flutter/cocoon/pull/2506.

We don't need `*.py` to run in both `Linux Host clang-tidy` and `Linux Android clang-tidy`, so remove the former.