### PR TITLE
Reland: Add testing hints (#39868)

### DIFF
--- a/testing/README.md
+++ b/testing/README.md
@@ -1,0 +1,18 @@
+# Engine Testing
+
+This directory contains the infrastructure for running tests on the engine,
+which are most often run by Flutter's continuous integration (CI) systems.
+
+The tests themselves are located in other directories, closer to the source for
+each platform, language, and variant. For instance, macOS engine unit tests
+written in objective C are located in the same directory as the source files,
+but with a `Test` suffix added (e.g. "FlutterEngineTest.mm" holds the tests for
+"FlutterEngine.mm", and they are located in the same directory).
+
+## Testing the Engine locally
+
+If you are working on the engine, you will want to be able to run tests locally.
+
+In order to learn the details of how do that, please consult the [Flutter Wiki
+page](https://github.com/flutter/flutter/wiki/Testing-the-engine) on the
+subject.

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -947,7 +947,12 @@ def run_engine_tasks_in_parallel(tasks):
 
 
 def main():
-  parser = argparse.ArgumentParser()
+  parser = argparse.ArgumentParser(
+      description='''
+In order to learn the details of running tests in the engine, please consult the
+Flutter Wiki page on the subject: https://github.com/flutter/flutter/wiki/Testing-the-engine
+'''
+  )
   all_types = [
       'engine', 'dart', 'benchmarks', 'java', 'android', 'objc', 'font-subset'
   ]

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -948,10 +948,10 @@ def run_engine_tasks_in_parallel(tasks):
 
 def main():
   parser = argparse.ArgumentParser(
-      description='''
+      description="""
 In order to learn the details of running tests in the engine, please consult the
 Flutter Wiki page on the subject: https://github.com/flutter/flutter/wiki/Testing-the-engine
-'''
+"""
   )
   all_types = [
       'engine', 'dart', 'benchmarks', 'java', 'android', 'objc', 'font-subset'


### PR DESCRIPTION
## Description

Adds some testing hints for developers so that it's easier to find the testing Wiki.

Re-landing #39868 with corrected pylint suggestion (now that the bots correctly run pylint in presubmit).