### PR TITLE
[Impeller] Use blit for root pass copy

### DIFF
--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -215,24 +215,39 @@ bool EntityPass::Render(ContentContext& renderer,
 
     auto command_buffer = renderer.GetContext()->CreateCommandBuffer();
     command_buffer->SetLabel("EntityPass Root Command Buffer");
-    auto render_pass = command_buffer->CreateRenderPass(render_target);
-    render_pass->SetLabel("EntityPass Root Render Pass");
 
-    {
-      auto size_rect = Rect::MakeSize(offscreen_target.GetRenderTargetSize());
-      auto contents = TextureContents::MakeRect(size_rect);
-      contents->SetTexture(offscreen_target.GetRenderTargetTexture());
-      contents->SetSourceRect(size_rect);
+    if (renderer.GetContext()
+            ->GetDeviceCapabilities()
+            .SupportsTextureToTextureBlits()) {
+      auto blit_pass = command_buffer->CreateBlitPass();
 
-      Entity entity;
-      entity.SetContents(contents);
-      entity.SetBlendMode(BlendMode::kSource);
+      blit_pass->AddCopy(offscreen_target.GetRenderTargetTexture(),
+                         render_target.GetRenderTargetTexture());
 
-      entity.Render(renderer, *render_pass);
-    }
+      if (!blit_pass->EncodeCommands(
+              renderer.GetContext()->GetResourceAllocator())) {
+        return false;
+      }
+    } else {
+      auto render_pass = command_buffer->CreateRenderPass(render_target);
+      render_pass->SetLabel("EntityPass Root Render Pass");
 
-    if (!render_pass->EncodeCommands()) {
-      return false;
+      {
+        auto size_rect = Rect::MakeSize(offscreen_target.GetRenderTargetSize());
+        auto contents = TextureContents::MakeRect(size_rect);
+        contents->SetTexture(offscreen_target.GetRenderTargetTexture());
+        contents->SetSourceRect(size_rect);
+
+        Entity entity;
+        entity.SetContents(contents);
+        entity.SetBlendMode(BlendMode::kSource);
+
+        entity.Render(renderer, *render_pass);
+      }
+
+      if (!render_pass->EncodeCommands()) {
+        return false;
+      }
     }
     if (!command_buffer->SubmitCommands()) {
       return false;

--- a/impeller/renderer/backend/metal/blit_pass_mtl.mm
+++ b/impeller/renderer/backend/metal/blit_pass_mtl.mm
@@ -80,7 +80,7 @@ bool BlitPassMTL::EncodeCommands(id<MTLBlitCommandEncoder> encoder) const {
       auto_pop_debug_marker.Release();
     }
 
-    if (command->Encode(encoder)) {
+    if (!command->Encode(encoder)) {
       return false;
     }
   }

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -514,7 +514,9 @@ TEST_P(RendererTest, CanBlitTextureToTexture) {
       // Blit `bridge` to the top left corner of the texture.
       pass->AddCopy(bridge, texture);
 
-      pass->EncodeCommands(context->GetResourceAllocator());
+      if (!pass->EncodeCommands(context->GetResourceAllocator())) {
+        return false;
+      }
     }
 
     {


### PR DESCRIPTION
Use a blit for the root pass copy when available in the backend.