### PR TITLE
Example of changes required to compile a Flutter iOS app extension

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -42,6 +42,7 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle) {
   // 4. Settings from the main NSBundle and default values.
 
   NSBundle* mainBundle = [NSBundle mainBundle];
+
   NSBundle* engineBundle = [NSBundle bundleForClass:[FlutterViewController class]];
 
   bool hasExplicitBundle = bundle != nil;
@@ -51,6 +52,12 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle) {
   if (bundle == nil) {
     bundle = mainBundle;
   }
+    
+    if ([[bundle.bundleURL pathExtension] isEqualToString:@"appex"]) {
+        // Peel off two directory levels - MY_APP.app/PlugIns/MY_APP_EXTENSION.appex
+        bundle = [NSBundle bundleWithURL:[[bundle.bundleURL URLByDeletingLastPathComponent] URLByDeletingLastPathComponent]];
+    }
+        
 
   auto settings = flutter::SettingsFromCommandLine(command_line);
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -52,12 +52,14 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle) {
   if (bundle == nil) {
     bundle = mainBundle;
   }
-    
-    if ([[bundle.bundleURL pathExtension] isEqualToString:@"appex"]) {
-        // Peel off two directory levels - MY_APP.app/PlugIns/MY_APP_EXTENSION.appex
-        bundle = [NSBundle bundleWithURL:[[bundle.bundleURL URLByDeletingLastPathComponent] URLByDeletingLastPathComponent]];
-    }
-        
+
+  // An app extension's defaultBundleIdentifier is within the `.appex` directory,
+  // but we want one level up in the main app bundle
+  if ([[bundle.bundleURL pathExtension] isEqualToString:@"appex"]) {
+    // Peel off two directory levels - MY_APP.app/PlugIns/MY_APP_EXTENSION.appex
+    bundle = [NSBundle bundleWithURL:[[bundle.bundleURL URLByDeletingLastPathComponent]
+                                         URLByDeletingLastPathComponent]];
+  }
 
   auto settings = flutter::SettingsFromCommandLine(command_line);
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -783,8 +783,8 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
                                     _threadHost->io_thread->GetTaskRunner()          // io
   );
 
-  _isGpuDisabled =
-      [UIApplication sharedApplication].applicationState == UIApplicationStateBackground;
+  _isGpuDisabled = false;
+      // TD [UIApplication sharedApplication].applicationState == UIApplicationStateBackground;
   // Create the shell. This is a blocking operation.
   std::unique_ptr<flutter::Shell> shell = flutter::Shell::Create(
       /*platform_data=*/std::move(platformData),
@@ -1340,12 +1340,12 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
 }
 
 - (void)addApplicationDelegate:(NSObject<FlutterPlugin>*)delegate {
-  id<UIApplicationDelegate> appDelegate = [[UIApplication sharedApplication] delegate];
+  /*id<UIApplicationDelegate> appDelegate = [[UIApplication sharedApplication] delegate];
   if ([appDelegate conformsToProtocol:@protocol(FlutterAppLifeCycleProvider)]) {
     id<FlutterAppLifeCycleProvider> lifeCycleProvider =
         (id<FlutterAppLifeCycleProvider>)appDelegate;
     [lifeCycleProvider addApplicationLifeCycleDelegate:delegate];
-  }
+  }*/
 }
 
 - (NSString*)lookupKeyForAsset:(NSString*)asset {

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -784,7 +784,7 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
   );
 
   _isGpuDisabled = false;
-      // TD [UIApplication sharedApplication].applicationState == UIApplicationStateBackground;
+  // [UIApplication sharedApplication].applicationState == UIApplicationStateBackground;
   // Create the shell. This is a blocking operation.
   std::unique_ptr<flutter::Shell> shell = flutter::Shell::Create(
       /*platform_data=*/std::move(platformData),

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
@@ -164,7 +164,7 @@ using namespace flutter;
   // We opt out of view controller based status bar visibility since we want
   // to be able to modify this on the fly. The key used is
   // UIViewControllerBasedStatusBarAppearance
-  [UIApplication sharedApplication].statusBarHidden =
+  /*[UIApplication sharedApplication].statusBarHidden =
       ![overlays containsObject:@"SystemUiOverlay.top"];
   if ([overlays containsObject:@"SystemUiOverlay.bottom"]) {
     [[NSNotificationCenter defaultCenter]
@@ -174,7 +174,7 @@ using namespace flutter;
     [[NSNotificationCenter defaultCenter]
         postNotificationName:FlutterViewControllerHideHomeIndicator
                       object:nil];
-  }
+  }*/
 }
 
 - (void)setSystemChromeEnabledSystemUIMode:(NSString*)mode {
@@ -184,7 +184,7 @@ using namespace flutter;
   // We opt out of view controller based status bar visibility since we want
   // to be able to modify this on the fly. The key used is
   // UIViewControllerBasedStatusBarAppearance
-  [UIApplication sharedApplication].statusBarHidden =
+  /*[UIApplication sharedApplication].statusBarHidden =
       ![mode isEqualToString:@"SystemUiMode.edgeToEdge"];
   if ([mode isEqualToString:@"SystemUiMode.edgeToEdge"]) {
     [[NSNotificationCenter defaultCenter]
@@ -194,7 +194,7 @@ using namespace flutter;
     [[NSNotificationCenter defaultCenter]
         postNotificationName:FlutterViewControllerHideHomeIndicator
                       object:nil];
-  }
+  }*/
 }
 
 - (void)restoreSystemChromeSystemUIOverlays {
@@ -233,7 +233,7 @@ using namespace flutter;
   } else {
     // Note: -[UIApplication setStatusBarStyle] is deprecated in iOS9
     // in favor of delegating to the view controller
-    [[UIApplication sharedApplication] setStatusBarStyle:statusBarStyle];
+    //[[UIApplication sharedApplication] setStatusBarStyle:statusBarStyle];
   }
 }
 
@@ -249,11 +249,11 @@ using namespace flutter;
   if (navigationController) {
     [navigationController popViewControllerAnimated:isAnimated];
   } else {
-    UIViewController* rootViewController =
+    /*UIViewController* rootViewController =
         [UIApplication sharedApplication].keyWindow.rootViewController;
     if (engineViewController != rootViewController) {
       [engineViewController dismissViewControllerAnimated:isAnimated completion:nil];
-    }
+    }*/
   }
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm
@@ -135,7 +135,7 @@ static BOOL IsPowerOfTwo(NSUInteger x) {
 }
 
 - (void)handleDidEnterBackground:(NSNotification*)notification {
-  UIApplication* application = [UIApplication sharedApplication];
+  /*UIApplication* application = [UIApplication sharedApplication];
 #if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
   // The following keeps the Flutter session alive when the device screen locks
   // in debug mode. It allows continued use of features like hot reload and
@@ -163,11 +163,11 @@ static BOOL IsPowerOfTwo(NSUInteger x) {
     if ([delegate respondsToSelector:@selector(applicationDidEnterBackground:)]) {
       [delegate applicationDidEnterBackground:application];
     }
-  }
+  }*/
 }
 
 - (void)handleWillEnterForeground:(NSNotification*)notification {
-  UIApplication* application = [UIApplication sharedApplication];
+  /*UIApplication* application = [UIApplication sharedApplication];
 #if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
   if (_debugBackgroundTask != UIBackgroundTaskInvalid) {
     [application endBackgroundTask:_debugBackgroundTask];
@@ -181,11 +181,11 @@ static BOOL IsPowerOfTwo(NSUInteger x) {
     if ([delegate respondsToSelector:@selector(applicationWillEnterForeground:)]) {
       [delegate applicationWillEnterForeground:application];
     }
-  }
+  }*/
 }
 
 - (void)handleWillResignActive:(NSNotification*)notification {
-  UIApplication* application = [UIApplication sharedApplication];
+  /*UIApplication* application = [UIApplication sharedApplication];
   for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
     if (!delegate) {
       continue;
@@ -193,11 +193,11 @@ static BOOL IsPowerOfTwo(NSUInteger x) {
     if ([delegate respondsToSelector:@selector(applicationWillResignActive:)]) {
       [delegate applicationWillResignActive:application];
     }
-  }
+  }*/
 }
 
 - (void)handleDidBecomeActive:(NSNotification*)notification {
-  UIApplication* application = [UIApplication sharedApplication];
+  /*UIApplication* application = [UIApplication sharedApplication];
   for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
     if (!delegate) {
       continue;
@@ -205,11 +205,11 @@ static BOOL IsPowerOfTwo(NSUInteger x) {
     if ([delegate respondsToSelector:@selector(applicationDidBecomeActive:)]) {
       [delegate applicationDidBecomeActive:application];
     }
-  }
+  }*/
 }
 
 - (void)handleWillTerminate:(NSNotification*)notification {
-  UIApplication* application = [UIApplication sharedApplication];
+  /*UIApplication* application = [UIApplication sharedApplication];
   for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
     if (!delegate) {
       continue;
@@ -217,7 +217,7 @@ static BOOL IsPowerOfTwo(NSUInteger x) {
     if ([delegate respondsToSelector:@selector(applicationWillTerminate:)]) {
       [delegate applicationWillTerminate:application];
     }
-  }
+  }*/
 }
 
 #pragma GCC diagnostic push

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -779,9 +779,9 @@ static void SendFakeTouchEvent(FlutterEngine* engine,
   if ([_engine.get() viewController] == self) {
     [self onUserSettingsChanged:nil];
     [self onAccessibilityStatusChanged:nil];
-    if (UIApplication.sharedApplication.applicationState == UIApplicationStateActive) {
-      [[_engine.get() lifecycleChannel] sendMessage:@"AppLifecycleState.resumed"];
-    }
+//    if (UIApplication.sharedApplication.applicationState == UIApplicationStateActive) {
+//      [[_engine.get() lifecycleChannel] sendMessage:@"AppLifecycleState.resumed"];
+//    }
   }
   [super viewDidAppear:animated];
 }
@@ -1202,12 +1202,13 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 }
 
 - (CGFloat)statusBarPadding {
-  UIScreen* screen = self.view.window.screen;
-  CGRect statusFrame = [UIApplication sharedApplication].statusBarFrame;
-  CGRect viewFrame = [self.view convertRect:self.view.bounds
-                          toCoordinateSpace:screen.coordinateSpace];
-  CGRect intersection = CGRectIntersection(statusFrame, viewFrame);
-  return CGRectIsNull(intersection) ? 0.0 : intersection.size.height;
+//  UIScreen* screen = self.view.window.screen;
+//  CGRect statusFrame = [UIApplication sharedApplication].statusBarFrame;
+//  CGRect viewFrame = [self.view convertRect:self.view.bounds
+//                          toCoordinateSpace:screen.coordinateSpace];
+//  CGRect intersection = CGRectIntersection(statusFrame, viewFrame);
+//  return CGRectIsNull(intersection) ? 0.0 : intersection.size.height;
+    return 0.0;
 }
 
 - (void)viewDidLayoutSubviews {
@@ -1230,8 +1231,8 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   // There is no guarantee that UIKit will layout subviews when the application is active. Creating
   // the surface when inactive will cause GPU accesses from the background. Only wait for the first
   // frame to render when the application is actually active.
-  bool applicationIsActive =
-      [UIApplication sharedApplication].applicationState == UIApplicationStateActive;
+  bool applicationIsActive = true;
+//  [UIApplication sharedApplication].applicationState == UIApplicationStateActive;
 
   // This must run after updateViewportMetrics so that the surface creation tasks are queued after
   // the viewport metrics update tasks.
@@ -1535,7 +1536,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 }
 
 - (void)performOrientationUpdate:(UIInterfaceOrientationMask)new_preferences {
-  if (new_preferences != _orientationPreferences) {
+  /*if (new_preferences != _orientationPreferences) {
     _orientationPreferences = new_preferences;
 
     if (@available(iOS 16.0, *)) {
@@ -1584,7 +1585,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
         }
       }
     }
-  }
+  }*/
 }
 
 - (void)onHideHomeIndicatorNotification:(NSNotification*)notification {
@@ -1686,7 +1687,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 }
 
 - (CGFloat)textScaleFactor {
-  UIContentSizeCategory category = [UIApplication sharedApplication].preferredContentSizeCategory;
+    UIContentSizeCategory category = UIContentSizeCategoryMedium;// [UIApplication sharedApplication].preferredContentSizeCategory;
   // The delta is computed by approximating Apple's typography guidelines:
   // https://developer.apple.com/ios/human-interface-guidelines/visual-design/typography/
   //

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -779,9 +779,9 @@ static void SendFakeTouchEvent(FlutterEngine* engine,
   if ([_engine.get() viewController] == self) {
     [self onUserSettingsChanged:nil];
     [self onAccessibilityStatusChanged:nil];
-//    if (UIApplication.sharedApplication.applicationState == UIApplicationStateActive) {
-//      [[_engine.get() lifecycleChannel] sendMessage:@"AppLifecycleState.resumed"];
-//    }
+    /*if (UIApplication.sharedApplication.applicationState == UIApplicationStateActive) {
+      [[_engine.get() lifecycleChannel] sendMessage:@"AppLifecycleState.resumed"];
+    }*/
   }
   [super viewDidAppear:animated];
 }
@@ -1202,13 +1202,13 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 }
 
 - (CGFloat)statusBarPadding {
-//  UIScreen* screen = self.view.window.screen;
-//  CGRect statusFrame = [UIApplication sharedApplication].statusBarFrame;
-//  CGRect viewFrame = [self.view convertRect:self.view.bounds
-//                          toCoordinateSpace:screen.coordinateSpace];
-//  CGRect intersection = CGRectIntersection(statusFrame, viewFrame);
-//  return CGRectIsNull(intersection) ? 0.0 : intersection.size.height;
-    return 0.0;
+  /*UIScreen* screen = self.view.window.screen;
+  CGRect statusFrame = [UIApplication sharedApplication].statusBarFrame;
+  CGRect viewFrame = [self.view convertRect:self.view.bounds
+                          toCoordinateSpace:screen.coordinateSpace];
+  CGRect intersection = CGRectIntersection(statusFrame, viewFrame);
+  return CGRectIsNull(intersection) ? 0.0 : intersection.size.height;*/
+  return 0.0;
 }
 
 - (void)viewDidLayoutSubviews {
@@ -1232,7 +1232,8 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   // the surface when inactive will cause GPU accesses from the background. Only wait for the first
   // frame to render when the application is actually active.
   bool applicationIsActive = true;
-//  [UIApplication sharedApplication].applicationState == UIApplicationStateActive;
+  // bool applicationIsActive = [UIApplication sharedApplication].applicationState ==
+  // UIApplicationStateActive;
 
   // This must run after updateViewportMetrics so that the surface creation tasks are queued after
   // the viewport metrics update tasks.
@@ -1687,7 +1688,9 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 }
 
 - (CGFloat)textScaleFactor {
-    UIContentSizeCategory category = UIContentSizeCategoryMedium;// [UIApplication sharedApplication].preferredContentSizeCategory;
+  // UIContentSizeCategory category = [UIApplication
+  // sharedApplication].preferredContentSizeCategory;
+  UIContentSizeCategory category = UIContentSizeCategoryMedium;
   // The delta is computed by approximating Apple's typography guidelines:
   // https://developer.apple.com/ios/human-interface-guidelines/visual-design/typography/
   //


### PR DESCRIPTION
This removes any references to `[UIApplication sharedApplication]`, which does not exist in an app extension, replacing them with a default value where necessary.

This is just a rough example of what could be done to support this use case and isn't suitable for merging.