### PR TITLE
add DlCanvas(SkCanvas) vs DlCanvas(Builder) variants to DL rendertests

### DIFF
--- a/display_list/display_list_flags.h
+++ b/display_list/display_list_flags.h
@@ -222,6 +222,10 @@ class DisplayListAttributeFlags : DisplayListFlagsBase {
 
   constexpr bool is_flood() const { return has_any(kFloodsSurface_); }
 
+  constexpr bool operator==(DisplayListAttributeFlags const& other) const {
+    return flags_ == other.flags_;
+  }
+
  private:
   explicit constexpr DisplayListAttributeFlags(int flags)
       : DisplayListFlagsBase(flags),

--- a/display_list/display_list_paint.cc
+++ b/display_list/display_list_paint.cc
@@ -35,4 +35,6 @@ bool DlPaint::operator==(DlPaint const& other) const {
          Equals(maskFilter_, other.maskFilter_);
 }
 
+const DlPaint DlPaint::kDefault;
+
 }  // namespace flutter

--- a/display_list/display_list_paint.h
+++ b/display_list/display_list_paint.h
@@ -73,6 +73,8 @@ class DlPaint {
   static constexpr float kDefaultWidth = 0.0;
   static constexpr float kDefaultMiter = 4.0;
 
+  static const DlPaint kDefault;
+
   DlPaint() : DlPaint(DlColor::kBlack()) {}
   DlPaint(DlColor color);
 
@@ -214,6 +216,8 @@ class DlPaint {
     pathEffect_ = pathEffect;
     return *this;
   }
+
+  bool isDefault() const { return *this == kDefault; }
 
   bool operator==(DlPaint const& other) const;
   bool operator!=(DlPaint const& other) const { return !(*this == other); }

--- a/display_list/display_list_paint_unittests.cc
+++ b/display_list/display_list_paint_unittests.cc
@@ -27,6 +27,8 @@ TEST(DisplayListPaint, ConstructorDefaults) {
   EXPECT_EQ(paint.getColorFilter(), nullptr);
   EXPECT_EQ(paint.getImageFilter(), nullptr);
   EXPECT_EQ(paint.getMaskFilter(), nullptr);
+  EXPECT_TRUE(paint.isDefault());
+  EXPECT_EQ(paint, DlPaint::kDefault);
 
   EXPECT_EQ(DlBlendMode::kDefaultMode, DlBlendMode::kSrcOver);
   EXPECT_EQ(DlDrawStyle::kDefaultStyle, DlDrawStyle::kFill);

--- a/display_list/dl_canvas.h
+++ b/display_list/dl_canvas.h
@@ -109,7 +109,8 @@ class DlCanvas {
   virtual bool QuickReject(const SkRect& bounds) const = 0;
 
   virtual void DrawPaint(const DlPaint& paint) = 0;
-  virtual void DrawColor(DlColor color, DlBlendMode mode) = 0;
+  virtual void DrawColor(DlColor color,
+                         DlBlendMode mode = DlBlendMode::kSrcOver) = 0;
   void Clear(DlColor color) { DrawColor(color, DlBlendMode::kSrc); }
   virtual void DrawLine(const SkPoint& p0,
                         const SkPoint& p1,

--- a/display_list/testing/dl_test_snippets.cc
+++ b/display_list/testing/dl_test_snippets.cc
@@ -769,6 +769,11 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
             [](DisplayListBuilder& b) {
               b.drawImage(TestImage2, {10, 10}, kNearestSampling, false);
             }},
+           {1, 24, -1, 48,
+            [](DisplayListBuilder& b) {
+              auto dl_image = DlImage::Make(TestSkImage);
+              b.drawImage(dl_image, {10, 10}, kNearestSampling, false);
+            }},
        }},
       {"DrawImageRect",
        {
@@ -809,6 +814,12 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
               b.drawImageRect(TestImage2, {10, 10, 15, 15}, {10, 10, 80, 80},
                               kNearestSampling, false);
             }},
+           {1, 56, -1, 80,
+            [](DisplayListBuilder& b) {
+              auto dl_image = DlImage::Make(TestSkImage);
+              b.drawImageRect(dl_image, {10, 10, 15, 15}, {10, 10, 80, 80},
+                              kNearestSampling, false);
+            }},
        }},
       {"DrawImageNine",
        {
@@ -842,6 +853,12 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
            {1, 48, -1, 80,
             [](DisplayListBuilder& b) {
               b.drawImageNine(TestImage2, {10, 10, 15, 15}, {10, 10, 80, 80},
+                              DlFilterMode::kNearest, false);
+            }},
+           {1, 48, -1, 80,
+            [](DisplayListBuilder& b) {
+              auto dl_image = DlImage::Make(TestSkImage);
+              b.drawImageNine(dl_image, {10, 10, 15, 15}, {10, 10, 80, 80},
                               DlFilterMode::kNearest, false);
             }},
        }},
@@ -921,6 +938,15 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
                           DlBlendMode::kSrcIn, kNearestSampling, &cull_rect,
                           false);
             }},
+           {1, 48 + 32 + 8, -1, 48 + 32 + 32,
+            [](DisplayListBuilder& b) {
+              auto dl_image = DlImage::Make(TestSkImage);
+              static SkRSXform xforms[] = {{1, 0, 0, 0}, {0, 1, 0, 0}};
+              static SkRect texs[] = {{10, 10, 20, 20}, {20, 20, 30, 30}};
+              b.drawAtlas(dl_image, xforms, texs, nullptr, 2,
+                          DlBlendMode::kSrcIn, kNearestSampling, nullptr,
+                          false);
+            }},
        }},
       {"DrawDisplayList",
        {
@@ -929,6 +955,10 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
             [](DisplayListBuilder& b) { b.drawDisplayList(TestDisplayList1); }},
            {1, 16, -1, 16,
             [](DisplayListBuilder& b) { b.drawDisplayList(TestDisplayList2); }},
+           {1, 16, -1, 16,
+            [](DisplayListBuilder& b) {
+              b.drawDisplayList(MakeTestDisplayList(10, 10, SK_ColorRED));
+            }},
        }},
       {"DrawTextBlob",
        {

--- a/display_list/testing/dl_test_snippets.h
+++ b/display_list/testing/dl_test_snippets.h
@@ -89,6 +89,7 @@ static sk_sp<DlImage> MakeTestImage(int w, int h, int checker_size) {
 
 static auto TestImage1 = MakeTestImage(40, 40, 5);
 static auto TestImage2 = MakeTestImage(50, 50, 5);
+static auto TestSkImage = MakeTestImage(30, 30, 5) -> skia_image();
 
 static const DlImageColorSource kTestSource1(TestImage1,
                                              DlTileMode::kClamp,


### PR DESCRIPTION
Just a note that this PR may have a slight negative impact on the "display list builder" benchmarks as it adds a couple of new op variants to the list of DL test snippets which are used to measure the builder performance.

This PR adds new testing variants to the display_list_rendertests test suite. Previously we tested that the following graphics flows produced the same results graphically:

1. SkCanvas rendering to an SkSurface
2. ~DisplayListBuilder rendering, dispatched to an SkCanvas~ (replaced by # 6 below)
3. ~SkCanvas rendering captured into a DL~ (no longer represents an active Flutter work-flow)
4. SkPicture from # 1 and DL from ~# 2~ (now from # 6 below) that were recorded at 1x, rendered at 2x

The new rendering variations that are now added to the above are:

5. DlCanvas talking to SkCanvas rendering to an SkSurface
6. DlCanvas talking to a DLBuilder and then rendered onto SkSurface
7. ~DL produced by # 4 identical to DL produced by # 6~ (# 4 no longer produces a DL so no pair of DL's to compare)

Note that when all of the steps 1-7 were in place some bugs were discovered in `DlSkCanvasAdapter` not synchronizing all attributes and the image variants of `DLOp` not doing precise comparisons.

~This PR is a draft because now that we are testing that all of the above agree with each other, some of the comparisons may be eliminated as obsolete. In particular, # 2 (replaced by # 6) and # 3. # 4's DL replaced by # 7's DL if # 2 is eliminated.~ (All adjustments to removing the old steps and replacing them with the new steps have been implemented so this PR is moving from draft status to ready for review.)