### PR TITLE
[Impeller] remove emulation of clamp, repeat, and mirror tile modes

### DIFF
--- a/impeller/compiler/shader_lib/impeller/texture.glsl
+++ b/impeller/compiler/shader_lib/impeller/texture.glsl
@@ -82,7 +82,6 @@ vec2 IPVec2Tile(vec2 coords, float x_tile_mode, float y_tile_mode) {
 /// for Decal.
 vec4 IPSampleWithTileMode(sampler2D tex,
                           vec2 coords,
-                          float y_coord_scale,
                           float x_tile_mode,
                           float y_tile_mode) {
   if (x_tile_mode == kTileModeDecal && (coords.x < 0 || coords.x >= 1) ||
@@ -90,19 +89,7 @@ vec4 IPSampleWithTileMode(sampler2D tex,
     return vec4(0);
   }
 
-  return IPSample(tex, IPVec2Tile(coords, x_tile_mode, y_tile_mode),
-                  y_coord_scale);
-}
-
-/// Sample a texture, emulating a specific tile mode.
-///
-/// This is useful for Impeller graphics backend that don't have native support
-/// for Decal.
-vec4 IPSampleWithTileMode(sampler2D tex,
-                          vec2 coords,
-                          float y_coord_scale,
-                          float tile_mode) {
-  return IPSampleWithTileMode(tex, coords, y_coord_scale, tile_mode, tile_mode);
+  return texture(tex, coords);
 }
 
 /// Sample a texture, emulating a specific tile mode.

--- a/impeller/entity/contents/tiled_texture_contents.h
+++ b/impeller/entity/contents/tiled_texture_contents.h
@@ -57,6 +57,8 @@ class TiledTextureContents final : public ColorSourceContents {
                       const Entity& entity,
                       RenderPass& pass) const;
 
+  SamplerDescriptor CreateDescriptor() const;
+
   std::shared_ptr<Texture> texture_;
   SamplerDescriptor sampler_descriptor_ = {};
   Entity::TileMode x_tile_mode_ = Entity::TileMode::kClamp;

--- a/impeller/entity/shaders/tiled_texture_fill.frag
+++ b/impeller/entity/shaders/tiled_texture_fill.frag
@@ -8,7 +8,6 @@
 uniform sampler2D texture_sampler;
 
 uniform FragInfo {
-  float texture_sampler_y_coord_scale;
   float x_tile_mode;
   float y_tile_mode;
   float alpha;
@@ -24,7 +23,6 @@ void main() {
       IPSampleWithTileMode(
           texture_sampler,                          // sampler
           v_texture_coords,                         // texture coordinates
-          frag_info.texture_sampler_y_coord_scale,  // y coordinate scale
           frag_info.x_tile_mode,                    // x tile mode
           frag_info.y_tile_mode                     // y tile mode
           ) *

--- a/impeller/entity/shaders/tiled_texture_fill.frag
+++ b/impeller/entity/shaders/tiled_texture_fill.frag
@@ -19,12 +19,10 @@ in vec2 v_texture_coords;
 out vec4 frag_color;
 
 void main() {
-  frag_color =
-      IPSampleWithTileMode(
-          texture_sampler,                          // sampler
-          v_texture_coords,                         // texture coordinates
-          frag_info.x_tile_mode,                    // x tile mode
-          frag_info.y_tile_mode                     // y tile mode
-          ) *
-      frag_info.alpha;
+  frag_color = IPSampleWithTileMode(texture_sampler,   // sampler
+                                    v_texture_coords,  // texture coordinates
+                                    frag_info.x_tile_mode,  // x tile mode
+                                    frag_info.y_tile_mode   // y tile mode
+                                    ) *
+               frag_info.alpha;
 }

--- a/impeller/entity/shaders/tiled_texture_fill.vert
+++ b/impeller/entity/shaders/tiled_texture_fill.vert
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <impeller/texture.glsl>
 #include <impeller/transform.glsl>
 #include <impeller/types.glsl>
 
@@ -10,6 +11,7 @@ uniform FrameInfo {
   mat4 effect_transform;
   vec2 bounds_origin;
   vec2 texture_size;
+  float texture_sampler_y_coord_scale;
 }
 frame_info;
 
@@ -19,7 +21,9 @@ out vec2 v_texture_coords;
 
 void main() {
   gl_Position = frame_info.mvp * vec4(position, 0.0, 1.0);
-  v_texture_coords = IPVec2TransformPosition(
-      frame_info.effect_transform,
-      (position - frame_info.bounds_origin) / frame_info.texture_size);
+  v_texture_coords = IPRemapCoords(
+      IPVec2TransformPosition(
+          frame_info.effect_transform,
+          (position - frame_info.bounds_origin) / frame_info.texture_size),
+      frame_info.texture_sampler_y_coord_scale);
 }


### PR DESCRIPTION
This makes the shaders slightly more expensive than they need to be and can be implemented entirely with the addressing mode.
