### PR TITLE
[Impeller] dont create mipmap when mipcount == 1

### DIFF
--- a/lib/ui/painting/image_decoder_impeller.cc
+++ b/lib/ui/painting/image_decoder_impeller.cc
@@ -248,7 +248,7 @@ sk_sp<DlImage> ImageDecoderImpeller::UploadTexture(
 
   texture->SetLabel(impeller::SPrintF("ui.Image(%p)", texture.get()).c_str());
 
-  {
+  if (texture_descriptor.mip_count > 1u) {
     auto command_buffer = context->CreateCommandBuffer();
     if (!command_buffer) {
       FML_DLOG(ERROR)


### PR DESCRIPTION
I can verify this with an integration test, but is that fact that we created mipmaps observable through the impeller API so I can write a simpler unittest?


Fixes https://github.com/flutter/flutter/issues/121015
