### PR TITLE
[Embedder API] Freeze parts of API for ABI stability

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,5 @@
-# This file defines an Application Binary Interface (ABI) that must maintain
+# The following files define an Application Binary Interface (ABI) that must maintain
 # both forward and backward compatibility. Changes should be heavily
 # scrutinized as mistakes are irreversible.
 /shell/platform/embedder/embedder.h @cbracken @chinmaygarde
+/shell/platform/embedder/tests/embedder_frozen.h @cbracken @chinmaygarde @loic-sharma

--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -229,6 +229,7 @@ if (enable_unittests) {
       "platform_view_embedder_unittests.cc",
       "tests/embedder_config_builder.cc",
       "tests/embedder_config_builder.h",
+      "tests/embedder_frozen.h",
       "tests/embedder_test.cc",
       "tests/embedder_test.h",
       "tests/embedder_test_backingstore_producer.cc",
@@ -312,7 +313,10 @@ if (enable_unittests) {
 
     include_dirs = [ "." ]
 
-    sources = [ "tests/embedder_unittests.cc" ]
+    sources = [
+      "tests/embedder_frozen_unittests.cc",
+      "tests/embedder_unittests.cc",
+    ]
 
     deps = [ ":embedder_unittests_library" ]
 

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -1268,6 +1268,10 @@ FlutterSemanticsNode CreateEmbedderSemanticsNode(
       transform.get(SkMatrix::kMScaleY), transform.get(SkMatrix::kMTransY),
       transform.get(SkMatrix::kMPersp0), transform.get(SkMatrix::kMPersp1),
       transform.get(SkMatrix::kMPersp2)};
+  // Do not add new members to FlutterSemanticsNode.
+  // This would break the forward compatibility of FlutterSemanticsUpdate.
+  // TODO(loicsharma): Introduce FlutterSemanticsNode2.
+  // https://github.com/flutter/flutter/issues/121176
   return {
       sizeof(FlutterSemanticsNode),
       node.id,
@@ -1305,6 +1309,10 @@ FlutterSemanticsNode CreateEmbedderSemanticsNode(
 // actions.
 FlutterSemanticsCustomAction CreateEmbedderSemanticsCustomAction(
     const flutter::CustomAccessibilityAction& action) {
+  // Do not add new members to FlutterSemanticsCustomAction.
+  // This would break the forward compatibility of FlutterSemanticsUpdate.
+  // TODO(loicsharma): Introduce FlutterSemanticsCustomAction2.
+  // https://github.com/flutter/flutter/issues/121176
   return {
       sizeof(FlutterSemanticsCustomAction),
       action.id,

--- a/shell/platform/embedder/tests/embedder_frozen.h
+++ b/shell/platform/embedder/tests/embedder_frozen.h
@@ -1,0 +1,73 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_EMBEDDER_EMBEDDER_FROZEN_H_
+#define FLUTTER_SHELL_PLATFORM_EMBEDDER_EMBEDDER_FROZEN_H_
+
+#include "flutter/shell/platform/embedder/embedder.h"
+
+// NO CHANGES ARE PERMITTED TO THE STRUCTS IN THIS FILE.
+//
+// This file contains the subset of the embedder API that is "frozen".
+// "Frozen" APIs are locked and must not be modified to guarantee
+// forward and backward ABI compatibility. The order, type, and size
+// of the struct members below must remain the same, and members must
+// not be added nor removed.
+//
+// This file serves as a "golden test" for structs in embedder.h
+// and contains a snapshot of the expected "frozen" API. Tests
+// then verify that these structs match the actual embedder API.
+
+namespace flutter {
+namespace testing {
+
+// New members must not be added to `FlutterSemanticsNode`
+// as it would break the ABI of `FlutterSemanticsUpdate`.
+// See: https://github.com/flutter/flutter/issues/121176
+typedef struct {
+  size_t struct_size;
+  int32_t id;
+  FlutterSemanticsFlag flags;
+  FlutterSemanticsAction actions;
+  int32_t text_selection_base;
+  int32_t text_selection_extent;
+  int32_t scroll_child_count;
+  int32_t scroll_index;
+  double scroll_position;
+  double scroll_extent_max;
+  double scroll_extent_min;
+  double elevation;
+  double thickness;
+  const char* label;
+  const char* hint;
+  const char* value;
+  const char* increased_value;
+  const char* decreased_value;
+  FlutterTextDirection text_direction;
+  FlutterRect rect;
+  FlutterTransformation transform;
+  size_t child_count;
+  const int32_t* children_in_traversal_order;
+  const int32_t* children_in_hit_test_order;
+  size_t custom_accessibility_actions_count;
+  const int32_t* custom_accessibility_actions;
+  FlutterPlatformViewIdentifier platform_view_id;
+  const char* tooltip;
+} FrozenFlutterSemanticsNode;
+
+// New members must not be added to `FlutterSemanticsCustomAction`
+// as it would break the ABI of `FlutterSemanticsUpdate`.
+// See: https://github.com/flutter/flutter/issues/121176
+typedef struct {
+  size_t struct_size;
+  int32_t id;
+  FlutterSemanticsAction override_action;
+  const char* label;
+  const char* hint;
+} FrozenFlutterSemanticsCustomAction;
+
+}  // namespace testing
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_PLATFORM_EMBEDDER_EMBEDDER_FROZEN_H_

--- a/shell/platform/embedder/tests/embedder_frozen_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_frozen_unittests.cc
@@ -1,0 +1,90 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/embedder/embedder.h"
+#include "flutter/shell/platform/embedder/tests/embedder_frozen.h"
+#include "flutter/testing/testing.h"
+
+namespace flutter {
+namespace testing {
+
+// Assert that both types have the same member with the same offset.
+// This prevents reordering of "frozen" embedder API struct members.
+#define ASSERT_EQ_OFFSET(type1, type2, member) \
+  ASSERT_EQ(offsetof(type1, member), offsetof(type2, member))
+
+// New members must not be added to `FlutterSemanticsNode`
+// as it would break the ABI of `FlutterSemanticsUpdate`.
+// See: https://github.com/flutter/flutter/issues/121176
+TEST(EmbedderFrozen, FlutterSemanticsNodeIsFrozen) {
+  ASSERT_EQ(sizeof(FlutterSemanticsNode), sizeof(FrozenFlutterSemanticsNode));
+
+  ASSERT_EQ_OFFSET(FlutterSemanticsNode, FrozenFlutterSemanticsNode,
+                   struct_size);
+  ASSERT_EQ_OFFSET(FlutterSemanticsNode, FrozenFlutterSemanticsNode, id);
+  ASSERT_EQ_OFFSET(FlutterSemanticsNode, FrozenFlutterSemanticsNode, flags);
+  ASSERT_EQ_OFFSET(FlutterSemanticsNode, FrozenFlutterSemanticsNode, actions);
+  ASSERT_EQ_OFFSET(FlutterSemanticsNode, FrozenFlutterSemanticsNode,
+                   text_selection_base);
+  ASSERT_EQ_OFFSET(FlutterSemanticsNode, FrozenFlutterSemanticsNode,
+                   text_selection_extent);
+  ASSERT_EQ_OFFSET(FlutterSemanticsNode, FrozenFlutterSemanticsNode,
+                   scroll_child_count);
+  ASSERT_EQ_OFFSET(FlutterSemanticsNode, FrozenFlutterSemanticsNode,
+                   scroll_index);
+  ASSERT_EQ_OFFSET(FlutterSemanticsNode, FrozenFlutterSemanticsNode,
+                   scroll_position);
+  ASSERT_EQ_OFFSET(FlutterSemanticsNode, FrozenFlutterSemanticsNode,
+                   scroll_extent_max);
+  ASSERT_EQ_OFFSET(FlutterSemanticsNode, FrozenFlutterSemanticsNode,
+                   scroll_extent_min);
+  ASSERT_EQ_OFFSET(FlutterSemanticsNode, FrozenFlutterSemanticsNode, elevation);
+  ASSERT_EQ_OFFSET(FlutterSemanticsNode, FrozenFlutterSemanticsNode, thickness);
+  ASSERT_EQ_OFFSET(FlutterSemanticsNode, FrozenFlutterSemanticsNode, label);
+  ASSERT_EQ_OFFSET(FlutterSemanticsNode, FrozenFlutterSemanticsNode, hint);
+  ASSERT_EQ_OFFSET(FlutterSemanticsNode, FrozenFlutterSemanticsNode, value);
+  ASSERT_EQ_OFFSET(FlutterSemanticsNode, FrozenFlutterSemanticsNode,
+                   increased_value);
+  ASSERT_EQ_OFFSET(FlutterSemanticsNode, FrozenFlutterSemanticsNode,
+                   decreased_value);
+  ASSERT_EQ_OFFSET(FlutterSemanticsNode, FrozenFlutterSemanticsNode,
+                   text_direction);
+  ASSERT_EQ_OFFSET(FlutterSemanticsNode, FrozenFlutterSemanticsNode, rect);
+  ASSERT_EQ_OFFSET(FlutterSemanticsNode, FrozenFlutterSemanticsNode, transform);
+  ASSERT_EQ_OFFSET(FlutterSemanticsNode, FrozenFlutterSemanticsNode,
+                   child_count);
+  ASSERT_EQ_OFFSET(FlutterSemanticsNode, FrozenFlutterSemanticsNode,
+                   children_in_traversal_order);
+  ASSERT_EQ_OFFSET(FlutterSemanticsNode, FrozenFlutterSemanticsNode,
+                   children_in_hit_test_order);
+  ASSERT_EQ_OFFSET(FlutterSemanticsNode, FrozenFlutterSemanticsNode,
+                   custom_accessibility_actions_count);
+  ASSERT_EQ_OFFSET(FlutterSemanticsNode, FrozenFlutterSemanticsNode,
+                   custom_accessibility_actions);
+  ASSERT_EQ_OFFSET(FlutterSemanticsNode, FrozenFlutterSemanticsNode,
+                   platform_view_id);
+  ASSERT_EQ_OFFSET(FlutterSemanticsNode, FrozenFlutterSemanticsNode, tooltip);
+}
+
+// New members must not be added to `FlutterSemanticsCustomAction`
+// as it would break the ABI of `FlutterSemanticsUpdate`.
+// See: https://github.com/flutter/flutter/issues/121176
+TEST(EmbedderFrozen, FlutterSemanticsCustomActionIsFrozen) {
+  ASSERT_EQ(sizeof(FlutterSemanticsCustomAction),
+            sizeof(FrozenFlutterSemanticsCustomAction));
+
+  ASSERT_EQ_OFFSET(FlutterSemanticsCustomAction,
+                   FrozenFlutterSemanticsCustomAction, struct_size);
+  ASSERT_EQ_OFFSET(FlutterSemanticsCustomAction,
+                   FrozenFlutterSemanticsCustomAction, id);
+  ASSERT_EQ_OFFSET(FlutterSemanticsCustomAction,
+                   FrozenFlutterSemanticsCustomAction, override_action);
+  ASSERT_EQ_OFFSET(FlutterSemanticsCustomAction,
+                   FrozenFlutterSemanticsCustomAction, label);
+  ASSERT_EQ_OFFSET(FlutterSemanticsCustomAction,
+                   FrozenFlutterSemanticsCustomAction, hint);
+}
+
+}  // namespace testing
+}  // namespace flutter


### PR DESCRIPTION
The embedder API defines an ABI that must maintain both forward and backward compatibility. Some parts of the embedder API - like `FlutterSemanticsNode` or `FlutterSemanticsCustomAction` - must not change to guarantee forward ABI compatibility (see https://github.com/flutter/flutter/issues/121176 and https://github.com/flutter/flutter/issues/121347). This subset of the embedder API is "frozen".

This introduces tests that detect changes to the "frozen" subset of the embedder API. These are similar to golden tests:

1. `embedder_frozen.h` contains a snapshot of the expected "frozen" API
2. `embedder_frozen_unittests.cc` verifies the actual embedder API matches the expected "frozen" API.

Part of https://github.com/flutter/flutter/issues/121176
See [go/flutter-semantics-abi](http://go/flutter-semantics-abi).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
