### PR TITLE
Optimize search for the default bundle

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProjectTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProjectTest.mm
@@ -60,6 +60,19 @@ FLUTTER_ASSERT_ARC
   XCTAssertEqual(settings.leak_vm, NO);
 }
 
+- (void)testFLTFrameworkBundleInternalWhenBundleIsNotPresent {
+  NSBundle* found =
+      FLTFrameworkBundleInternal(@"doesNotExist", NSBundle.mainBundle.privateFrameworksURL);
+  XCTAssertNil(found);
+}
+
+- (void)testFLTFrameworkBundleInternalWhenBundleIsPresent {
+  NSString* presentBundleID = @"io.flutter.flutter";
+  NSBundle* found =
+      FLTFrameworkBundleInternal(presentBundleID, NSBundle.mainBundle.privateFrameworksURL);
+  XCTAssertNotNil(found);
+}
+
 - (void)testEnableImpellerSettingIsCorrectlyParsed {
   // The FLTEnableImpeller's value is defined in Info.plist
   NSBundle* mainBundle = [NSBundle mainBundle];

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject_Internal.h
@@ -12,6 +12,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+NSBundle* FLTFrameworkBundleInternal(NSString* bundleID, NSURL* searchURL);
+
 flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle = nil);
 
 @interface FlutterDartProject ()


### PR DESCRIPTION
`+[NSBundle bundleWithIdentifier]` is slow, and scales to the size of the app. This call during startup significantly affects the startup of `customer: chalk`. 

This implementation searches within the `privateFrameworksURL` where the default bundle is expected to be located. When tested internally, this improves startup of `customer: chalk` by 30% - see http://shortn/_WcifhO48X6.

It also falls back to `+[NSBundle bundleWithIdentifier]` so there is no functional change in behavior for customers that may be using alternate build systems.

*List which issues are fixed by this PR. You must list at least one issue.*

Fix flutter/flutter#37826

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
