### PR TITLE
[Impeller] Add checkbox for toggling the ColorWheel cache

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -1392,6 +1392,7 @@ TEST_P(AiksTest, ColorWheel) {
 
   auto callback = [&](AiksContext& renderer, RenderTarget& render_target) {
     // UI state.
+    static bool cache_the_wheel = true;
     static int current_blend_index = 3;
     static float dst_alpha = 1;
     static float src_alpha = 1;
@@ -1401,6 +1402,7 @@ TEST_P(AiksTest, ColorWheel) {
 
     ImGui::Begin("Controls", nullptr, ImGuiWindowFlags_AlwaysAutoResize);
     {
+      ImGui::Checkbox("Cache the wheel", &cache_the_wheel);
       ImGui::ListBox("Blending mode", &current_blend_index,
                      blend_mode_names.data(), blend_mode_names.size());
       ImGui::SliderFloat("Source alpha", &src_alpha, 0, 1);
@@ -1414,7 +1416,7 @@ TEST_P(AiksTest, ColorWheel) {
     static Point content_scale;
     Point new_content_scale = GetContentScale();
 
-    if (new_content_scale != content_scale) {
+    if (!cache_the_wheel || new_content_scale != content_scale) {
       content_scale = new_content_scale;
 
       // Render the color wheel to an image.


### PR DESCRIPTION
I added this caching because I wanted to make testing advanced blends easier, but this test happens to be useful for testing lots of draw calls.