### PR TITLE
[Impeller] Uniquely label offscreen resources

### DIFF
--- a/impeller/entity/contents/content_context.cc
+++ b/impeller/entity/contents/content_context.cc
@@ -7,6 +7,7 @@
 #include <memory>
 #include <sstream>
 
+#include "impeller/base/strings.h"
 #include "impeller/entity/entity.h"
 #include "impeller/renderer/command_buffer.h"
 #include "impeller/renderer/formats.h"
@@ -308,6 +309,7 @@ bool ContentContext::IsValid() const {
 }
 
 std::shared_ptr<Texture> ContentContext::MakeSubpass(
+    const std::string& label,
     ISize texture_size,
     const SubpassCallback& subpass_callback,
     bool msaa_enabled) const {
@@ -317,11 +319,11 @@ std::shared_ptr<Texture> ContentContext::MakeSubpass(
   if (context->GetDeviceCapabilities().SupportsOffscreenMSAA() &&
       msaa_enabled) {
     subpass_target = RenderTarget::CreateOffscreenMSAA(
-        *context, texture_size, "Contents Offscreen MSAA",
+        *context, texture_size, SPrintF("%s Offscreen", label.c_str()),
         RenderTarget::kDefaultColorAttachmentConfigMSAA, std::nullopt);
   } else {
     subpass_target = RenderTarget::CreateOffscreen(
-        *context, texture_size, "Contents Offscreen",
+        *context, texture_size, SPrintF("%s Offscreen", label.c_str()),
         RenderTarget::kDefaultColorAttachmentConfig, std::nullopt);
   }
   auto subpass_texture = subpass_target.GetRenderTargetTexture();
@@ -330,7 +332,7 @@ std::shared_ptr<Texture> ContentContext::MakeSubpass(
   }
 
   auto sub_command_buffer = context->CreateCommandBuffer();
-  sub_command_buffer->SetLabel("Offscreen Contents Command Buffer");
+  sub_command_buffer->SetLabel(SPrintF("%s CommandBuffer", label.c_str()));
   if (!sub_command_buffer) {
     return nullptr;
   }
@@ -339,7 +341,7 @@ std::shared_ptr<Texture> ContentContext::MakeSubpass(
   if (!sub_renderpass) {
     return nullptr;
   }
-  sub_renderpass->SetLabel("OffscreenContentsPass");
+  sub_renderpass->SetLabel(SPrintF("%s RenderPass", label.c_str()));
 
   if (!subpass_callback(*this, *sub_renderpass)) {
     return nullptr;

--- a/impeller/entity/contents/content_context.h
+++ b/impeller/entity/contents/content_context.h
@@ -603,7 +603,8 @@ class ContentContext {
 
   /// @brief  Creates a new texture of size `texture_size` and calls
   ///         `subpass_callback` with a `RenderPass` for drawing to the texture.
-  std::shared_ptr<Texture> MakeSubpass(ISize texture_size,
+  std::shared_ptr<Texture> MakeSubpass(const std::string& label,
+                                       ISize texture_size,
                                        const SubpassCallback& subpass_callback,
                                        bool msaa_enabled = true) const;
 

--- a/impeller/entity/contents/contents.cc
+++ b/impeller/entity/contents/contents.cc
@@ -6,6 +6,7 @@
 #include <optional>
 
 #include "fml/logging.h"
+#include "impeller/base/strings.h"
 #include "impeller/entity/contents/content_context.h"
 #include "impeller/entity/contents/texture_contents.h"
 #include "impeller/renderer/command_buffer.h"
@@ -82,7 +83,7 @@ std::optional<Snapshot> Contents::RenderToSnapshot(
   }
 
   auto texture = renderer.MakeSubpass(
-      ISize::Ceil(coverage->size),
+      "Snapshot", ISize::Ceil(coverage->size),
       [&contents = *this, &entity, &coverage](const ContentContext& renderer,
                                               RenderPass& pass) -> bool {
         Entity sub_entity;

--- a/impeller/entity/contents/filters/blend_filter_contents.cc
+++ b/impeller/entity/contents/filters/blend_filter_contents.cc
@@ -150,11 +150,11 @@ static std::optional<Entity> AdvancedBlend(
     return true;
   };
 
-  auto out_texture = renderer.MakeSubpass(ISize(coverage.size), callback);
+  auto out_texture = renderer.MakeSubpass("Advanced Blend Filter",
+                                          ISize(coverage.size), callback);
   if (!out_texture) {
     return std::nullopt;
   }
-  out_texture->SetLabel("Advanced Blend Filter Texture");
 
   return Contents::EntityFromSnapshot(
       Snapshot{.texture = out_texture,
@@ -274,11 +274,11 @@ static std::optional<Entity> PipelineBlend(
     return true;
   };
 
-  auto out_texture = renderer.MakeSubpass(ISize(coverage.size), callback);
+  auto out_texture = renderer.MakeSubpass("Pipeline Blend Filter",
+                                          ISize(coverage.size), callback);
   if (!out_texture) {
     return std::nullopt;
   }
-  out_texture->SetLabel("Pipeline Blend Filter Texture");
 
   return Contents::EntityFromSnapshot(
       Snapshot{.texture = out_texture,

--- a/impeller/entity/contents/filters/border_mask_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/border_mask_blur_filter_contents.cc
@@ -122,11 +122,11 @@ std::optional<Entity> BorderMaskBlurFilterContents::RenderFilter(
     return pass.AddCommand(std::move(cmd));
   };
 
-  auto out_texture = renderer.MakeSubpass(ISize(coverage.size), callback);
+  auto out_texture = renderer.MakeSubpass("Border Mask Blur Filter",
+                                          ISize(coverage.size), callback);
   if (!out_texture) {
     return std::nullopt;
   }
-  out_texture->SetLabel("BorderMaskBlurFilter Texture");
 
   return Contents::EntityFromSnapshot(
       Snapshot{.texture = out_texture,

--- a/impeller/entity/contents/filters/color_matrix_filter_contents.cc
+++ b/impeller/entity/contents/filters/color_matrix_filter_contents.cc
@@ -97,12 +97,11 @@ std::optional<Entity> ColorMatrixFilterContents::RenderFilter(
     return pass.AddCommand(std::move(cmd));
   };
 
-  auto out_texture =
-      renderer.MakeSubpass(input_snapshot->texture->GetSize(), callback);
+  auto out_texture = renderer.MakeSubpass(
+      "Color Matrix Filter", input_snapshot->texture->GetSize(), callback);
   if (!out_texture) {
     return std::nullopt;
   }
-  out_texture->SetLabel("ColorMatrixFilter Texture");
 
   return Contents::EntityFromSnapshot(
       Snapshot{.texture = out_texture,

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -276,12 +276,12 @@ std::optional<Entity> DirectionalGaussianBlurFilterContents::RenderFilter(
   Vector2 scaled_size = pass_texture_rect.size * scale;
   ISize floored_size = ISize(scaled_size.x, scaled_size.y);
 
-  auto out_texture = renderer.MakeSubpass(floored_size, callback);
+  auto out_texture = renderer.MakeSubpass("Directional Gaussian Blur Filter",
+                                          floored_size, callback);
 
   if (!out_texture) {
     return std::nullopt;
   }
-  out_texture->SetLabel("DirectionalGaussianBlurFilter Texture");
 
   SamplerDescriptor sampler_desc;
   sampler_desc.min_filter = MinMagFilter::kLinear;

--- a/impeller/entity/contents/filters/linear_to_srgb_filter_contents.cc
+++ b/impeller/entity/contents/filters/linear_to_srgb_filter_contents.cc
@@ -74,12 +74,11 @@ std::optional<Entity> LinearToSrgbFilterContents::RenderFilter(
     return pass.AddCommand(std::move(cmd));
   };
 
-  auto out_texture =
-      renderer.MakeSubpass(input_snapshot->texture->GetSize(), callback);
+  auto out_texture = renderer.MakeSubpass(
+      "Linear to sRGB Filter", input_snapshot->texture->GetSize(), callback);
   if (!out_texture) {
     return std::nullopt;
   }
-  out_texture->SetLabel("LinearToSrgb Texture");
 
   return Contents::EntityFromSnapshot(
       Snapshot{.texture = out_texture,

--- a/impeller/entity/contents/filters/morphology_filter_contents.cc
+++ b/impeller/entity/contents/filters/morphology_filter_contents.cc
@@ -132,11 +132,11 @@ std::optional<Entity> DirectionalMorphologyFilterContents::RenderFilter(
     return pass.AddCommand(cmd);
   };
 
-  auto out_texture = renderer.MakeSubpass(ISize(coverage.size), callback);
+  auto out_texture = renderer.MakeSubpass("Directional Morphology Filter",
+                                          ISize(coverage.size), callback);
   if (!out_texture) {
     return std::nullopt;
   }
-  out_texture->SetLabel("DirectionalMorphologyFilter Texture");
 
   SamplerDescriptor sampler_desc;
   sampler_desc.min_filter = MinMagFilter::kLinear;

--- a/impeller/entity/contents/filters/srgb_to_linear_filter_contents.cc
+++ b/impeller/entity/contents/filters/srgb_to_linear_filter_contents.cc
@@ -74,12 +74,11 @@ std::optional<Entity> SrgbToLinearFilterContents::RenderFilter(
     return pass.AddCommand(std::move(cmd));
   };
 
-  auto out_texture =
-      renderer.MakeSubpass(input_snapshot->texture->GetSize(), callback);
+  auto out_texture = renderer.MakeSubpass(
+      "sRGB to Linear Filter", input_snapshot->texture->GetSize(), callback);
   if (!out_texture) {
     return std::nullopt;
   }
-  out_texture->SetLabel("SrgbToLinear Texture");
 
   return Contents::EntityFromSnapshot(
       Snapshot{.texture = out_texture,

--- a/impeller/entity/contents/filters/yuv_to_rgb_filter_contents.cc
+++ b/impeller/entity/contents/filters/yuv_to_rgb_filter_contents.cc
@@ -111,12 +111,11 @@ std::optional<Entity> YUVToRGBFilterContents::RenderFilter(
     return pass.AddCommand(std::move(cmd));
   };
 
-  auto out_texture =
-      renderer.MakeSubpass(y_input_snapshot->texture->GetSize(), callback);
+  auto out_texture = renderer.MakeSubpass(
+      "YUV to RGB Filter", y_input_snapshot->texture->GetSize(), callback);
   if (!out_texture) {
     return std::nullopt;
   }
-  out_texture->SetLabel("YUVToRGB Texture");
 
   return Contents::EntityFromSnapshot(Snapshot{.texture = out_texture},
                                       entity.GetBlendMode(),


### PR DESCRIPTION
Force a label to be provided when using the offscreen pass utility. Right now, offscreen resources created by contents/filters all get the same names. This has always been a minor headache, but a couple of days ago this caused me quite a bit of friction when xcode decided to start incorrectly showing black textures for all of the pass previews.