### PR TITLE
Fix incorrect response to platform SystemSound.play

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -2917,6 +2917,7 @@ ORIGIN: ../../../flutter/shell/platform/linux/fl_pixel_buffer_texture_private.h 
 ORIGIN: ../../../flutter/shell/platform/linux/fl_pixel_buffer_texture_test.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/linux/fl_platform_plugin.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/linux/fl_platform_plugin.h + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/shell/platform/linux/fl_platform_plugin_test.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/linux/fl_plugin_registrar.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/linux/fl_plugin_registrar_private.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/linux/fl_plugin_registrar_test.cc + ../../../flutter/LICENSE
@@ -5459,6 +5460,7 @@ FILE: ../../../flutter/shell/platform/linux/fl_pixel_buffer_texture_private.h
 FILE: ../../../flutter/shell/platform/linux/fl_pixel_buffer_texture_test.cc
 FILE: ../../../flutter/shell/platform/linux/fl_platform_plugin.cc
 FILE: ../../../flutter/shell/platform/linux/fl_platform_plugin.h
+FILE: ../../../flutter/shell/platform/linux/fl_platform_plugin_test.cc
 FILE: ../../../flutter/shell/platform/linux/fl_plugin_registrar.cc
 FILE: ../../../flutter/shell/platform/linux/fl_plugin_registrar_private.h
 FILE: ../../../flutter/shell/platform/linux/fl_plugin_registrar_test.cc

--- a/shell/platform/linux/BUILD.gn
+++ b/shell/platform/linux/BUILD.gn
@@ -212,6 +212,7 @@ executable("flutter_linux_unittests") {
     "fl_method_codec_test.cc",
     "fl_method_response_test.cc",
     "fl_pixel_buffer_texture_test.cc",
+    "fl_platform_plugin_test.cc",
     "fl_plugin_registrar_test.cc",
     "fl_scrolling_manager_test.cc",
     "fl_settings_plugin_test.cc",

--- a/shell/platform/linux/fl_platform_plugin.cc
+++ b/shell/platform/linux/fl_platform_plugin.cc
@@ -160,7 +160,7 @@ static FlMethodResponse* system_sound_play(FlPlatformPlugin* self,
     g_warning("Ignoring unknown sound type %s in SystemSound.play.\n", type);
   }
 
-  return FL_METHOD_RESPONSE(fl_method_not_implemented_response_new());
+  return FL_METHOD_RESPONSE(fl_method_success_response_new(nullptr));
 }
 
 // Called when Flutter wants to quit the application.

--- a/shell/platform/linux/fl_platform_plugin_test.cc
+++ b/shell/platform/linux/fl_platform_plugin_test.cc
@@ -1,0 +1,47 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/linux/fl_platform_plugin.h"
+#include "flutter/shell/platform/linux/fl_binary_messenger_private.h"
+#include "flutter/shell/platform/linux/fl_method_codec_private.h"
+#include "flutter/shell/platform/linux/public/flutter_linux/fl_json_method_codec.h"
+#include "flutter/shell/platform/linux/public/flutter_linux/fl_method_codec.h"
+#include "flutter/shell/platform/linux/testing/fl_test.h"
+#include "flutter/shell/platform/linux/testing/mock_binary_messenger.h"
+#include "flutter/testing/testing.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+MATCHER_P(SuccessResponse, result, "") {
+  g_autoptr(FlJsonMethodCodec) codec = fl_json_method_codec_new();
+  g_autoptr(FlMethodResponse) response =
+      fl_method_codec_decode_response(FL_METHOD_CODEC(codec), arg, nullptr);
+  if (fl_value_equal(fl_method_response_get_result(response, nullptr),
+                     result)) {
+    return true;
+  }
+  *result_listener << ::testing::PrintToString(response);
+  return false;
+}
+
+TEST(FlPlatformPluginTest, PlaySound) {
+  ::testing::NiceMock<flutter::testing::MockBinaryMessenger> messenger;
+
+  g_autoptr(FlPlatformPlugin) plugin = fl_platform_plugin_new(messenger);
+  EXPECT_NE(plugin, nullptr);
+
+  g_autoptr(FlValue) args = fl_value_new_string("SystemSoundType.alert");
+  g_autoptr(FlJsonMethodCodec) codec = fl_json_method_codec_new();
+  g_autoptr(GBytes) message = fl_method_codec_encode_method_call(
+      FL_METHOD_CODEC(codec), "SystemSound.play", args, nullptr);
+
+  g_autoptr(FlValue) null = fl_value_new_null();
+  EXPECT_CALL(messenger, fl_binary_messenger_send_response(
+                             ::testing::Eq<FlBinaryMessenger*>(messenger),
+                             ::testing::_, SuccessResponse(null), ::testing::_))
+      .WillOnce(::testing::Return(true));
+
+  messenger.ReceiveMessage("flutter/platform", message);
+}


### PR DESCRIPTION
Assuming copy/paste error as original commit has it returning a not implemented error. Noticed when editing adjacent code, hadn't seen it being a problem in practice.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
