### PR TITLE
[Windows] Remove another accessibility root ID assumption

### DIFF
--- a/shell/platform/windows/accessibility_bridge_windows.cc
+++ b/shell/platform/windows/accessibility_bridge_windows.cc
@@ -190,7 +190,12 @@ void AccessibilityBridgeWindows::SetFocus(
 
 gfx::NativeViewAccessible
 AccessibilityBridgeWindows::GetChildOfAXFragmentRoot() {
-  return view_->GetNativeViewAccessible();
+  ui::AXPlatformNodeDelegate* root_delegate = RootDelegate();
+  if (!root_delegate) {
+    return nullptr;
+  }
+
+  return root_delegate->GetNativeViewAccessible();
 }
 
 gfx::NativeViewAccessible

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -679,17 +679,12 @@ void FlutterWindowsEngine::OnPreEngineRestart() {
   }
 }
 
-gfx::NativeViewAccessible FlutterWindowsEngine::GetNativeAccessibleFromId(
-    AccessibilityNodeId id) {
+gfx::NativeViewAccessible FlutterWindowsEngine::GetNativeViewAccessible() {
   if (!accessibility_bridge_) {
     return nullptr;
   }
-  std::shared_ptr<FlutterPlatformNodeDelegate> node_delegate =
-      accessibility_bridge_->GetFlutterPlatformNodeDelegateFromID(id).lock();
-  if (!node_delegate) {
-    return nullptr;
-  }
-  return node_delegate->GetNativeViewAccessible();
+
+  return accessibility_bridge_->GetChildOfAXFragmentRoot();
 }
 
 std::string FlutterWindowsEngine::GetExecutableName() const {

--- a/shell/platform/windows/flutter_windows_engine.h
+++ b/shell/platform/windows/flutter_windows_engine.h
@@ -231,8 +231,9 @@ class FlutterWindowsEngine {
   // Returns true if the high contrast feature is enabled.
   bool high_contrast_enabled() const { return high_contrast_enabled_; }
 
-  // Returns the native accessibility node with the given id.
-  gfx::NativeViewAccessible GetNativeAccessibleFromId(AccessibilityNodeId id);
+  // Returns the native accessibility root node, or nullptr if one does not
+  // exist.
+  gfx::NativeViewAccessible GetNativeViewAccessible();
 
   // Register a root isolate create callback.
   //

--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -250,7 +250,7 @@ void FlutterWindowsView::OnUpdateSemanticsEnabled(bool enabled) {
 }
 
 gfx::NativeViewAccessible FlutterWindowsView::GetNativeViewAccessible() {
-  return engine_->GetNativeAccessibleFromId(AccessibilityBridge::kRootNodeId);
+  return engine_->GetNativeViewAccessible();
 }
 
 void FlutterWindowsView::OnCursorRectUpdated(const Rect& rect) {

--- a/shell/platform/windows/flutter_windows_view_unittests.cc
+++ b/shell/platform/windows/flutter_windows_view_unittests.cc
@@ -426,6 +426,126 @@ TEST(FlutterWindowsView, AddSemanticsNodeUpdateWithChildren) {
   }
 }
 
+// Flutter used to assume that the accessibility root had ID 0.
+// In a multi-view world, each view has its own accessibility root
+// with a globally unique node ID.
+//
+//        node1
+//          |
+//        node2
+//
+// node1 is a grouping node, node0 is a static text node.
+TEST(FlutterWindowsView, NonZeroSemanticsRoot) {
+  std::unique_ptr<FlutterWindowsEngine> engine = GetTestEngine();
+  EngineModifier modifier(engine.get());
+  modifier.embedder_api().UpdateSemanticsEnabled =
+      [](FLUTTER_API_SYMBOL(FlutterEngine) engine, bool enabled) {
+        return kSuccess;
+      };
+
+  auto window_binding_handler =
+      std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();
+  FlutterWindowsView view(std::move(window_binding_handler));
+  view.SetEngine(std::move(engine));
+
+  // Enable semantics to instantiate accessibility bridge.
+  view.OnUpdateSemanticsEnabled(true);
+
+  auto bridge = view.GetEngine()->accessibility_bridge().lock();
+  ASSERT_TRUE(bridge);
+
+  // Add root node.
+  FlutterSemanticsNode node1{sizeof(FlutterSemanticsNode), 1};
+  std::vector<int32_t> node1_children{2};
+  node1.child_count = node1_children.size();
+  node1.children_in_traversal_order = node1_children.data();
+  node1.children_in_hit_test_order = node1_children.data();
+
+  FlutterSemanticsNode node2{sizeof(FlutterSemanticsNode), 2};
+  node2.label = "prefecture";
+  node2.value = "Kyoto";
+
+  bridge->AddFlutterSemanticsNodeUpdate(&node1);
+  bridge->AddFlutterSemanticsNodeUpdate(&node2);
+  bridge->CommitUpdates();
+
+  // Look up the root windows node delegate.
+  auto root_delegate = bridge->GetFlutterPlatformNodeDelegateFromID(1).lock();
+  ASSERT_TRUE(root_delegate);
+  EXPECT_EQ(root_delegate->GetChildCount(), 1);
+
+  // Look up the child node delegate
+  auto child_delegate = bridge->GetFlutterPlatformNodeDelegateFromID(2).lock();
+  ASSERT_TRUE(child_delegate);
+  EXPECT_EQ(child_delegate->GetChildCount(), 0);
+
+  // Ensure a node with ID 0 does not exist.
+  auto fake_delegate = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
+  ASSERT_FALSE(fake_delegate);
+
+  // Get the root's native IAccessible object.
+  IAccessible* node1_accessible = root_delegate->GetNativeViewAccessible();
+  ASSERT_TRUE(node1_accessible != nullptr);
+
+  // Property lookups will be made against this node itself.
+  VARIANT varchild{};
+  varchild.vt = VT_I4;
+  varchild.lVal = CHILDID_SELF;
+
+  // Verify node type is a group.
+  VARIANT varrole{};
+  varrole.vt = VT_I4;
+  ASSERT_EQ(node1_accessible->get_accRole(varchild, &varrole), S_OK);
+  EXPECT_EQ(varrole.lVal, ROLE_SYSTEM_GROUPING);
+
+  // Verify child count.
+  long node1_child_count = 0;
+  ASSERT_EQ(node1_accessible->get_accChildCount(&node1_child_count), S_OK);
+  EXPECT_EQ(node1_child_count, 1);
+
+  {
+    // Look up first child of node1 (node0), a static text node.
+    varchild.lVal = 1;
+    IDispatch* node2_dispatch = nullptr;
+    ASSERT_EQ(node1_accessible->get_accChild(varchild, &node2_dispatch), S_OK);
+    ASSERT_TRUE(node2_dispatch != nullptr);
+    IAccessible* node2_accessible = nullptr;
+    ASSERT_EQ(node2_dispatch->QueryInterface(
+                  IID_IAccessible, reinterpret_cast<void**>(&node2_accessible)),
+              S_OK);
+    ASSERT_TRUE(node2_accessible != nullptr);
+
+    // Verify node name matches our label.
+    varchild.lVal = CHILDID_SELF;
+    BSTR bname = nullptr;
+    ASSERT_EQ(node2_accessible->get_accName(varchild, &bname), S_OK);
+    std::string name(_com_util::ConvertBSTRToString(bname));
+    EXPECT_EQ(name, "prefecture");
+
+    // Verify node value matches.
+    BSTR bvalue = nullptr;
+    ASSERT_EQ(node2_accessible->get_accValue(varchild, &bvalue), S_OK);
+    std::string value(_com_util::ConvertBSTRToString(bvalue));
+    EXPECT_EQ(value, "Kyoto");
+
+    // Verify node type is static text.
+    VARIANT varrole{};
+    varrole.vt = VT_I4;
+    ASSERT_EQ(node2_accessible->get_accRole(varchild, &varrole), S_OK);
+    EXPECT_EQ(varrole.lVal, ROLE_SYSTEM_STATICTEXT);
+
+    // Verify the parent node is the root.
+    IDispatch* parent_dispatch;
+    node2_accessible->get_accParent(&parent_dispatch);
+    IAccessible* parent_accessible;
+    ASSERT_EQ(
+        parent_dispatch->QueryInterface(
+            IID_IAccessible, reinterpret_cast<void**>(&parent_accessible)),
+        S_OK);
+    EXPECT_EQ(parent_accessible, node1_accessible);
+  }
+}
+
 // Verify the native IAccessible accHitTest method returns the correct
 // IAccessible COM object for the given coordinates.
 //


### PR DESCRIPTION
Today, the root accessibility semantics node is guaranteed to have ID 0. In a multi-window world, each view will have its own semantics tree, but semantic node IDs will be globally unique. In other words, the semantics tree's root will no longer be guaranteed to have ID 0.

This change removes another "root ID is 0" assumption from the Windows embedder that was missed in https://github.com/flutter/engine/pull/39441:

1. Remove a hardcoded ID `0` when getting the native root `IAccessible` object
2. Move logic to get the native root `IAccessible` object from `FlutterWindowsView` to `AccessibilityBridgeWindows`

Part of https://github.com/flutter/flutter/issues/119391

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
