### PR TITLE
[Impeller] Press `z` to toggle wireframe

### DIFF
--- a/impeller/aiks/aiks_context.cc
+++ b/impeller/aiks/aiks_context.cc
@@ -32,7 +32,7 @@ std::shared_ptr<Context> AiksContext::GetContext() const {
   return context_;
 }
 
-const ContentContext& AiksContext::GetContentContext() const {
+ContentContext& AiksContext::GetContentContext() const {
   return *content_context_;
 }
 

--- a/impeller/aiks/aiks_context.h
+++ b/impeller/aiks/aiks_context.h
@@ -26,7 +26,7 @@ class AiksContext {
 
   std::shared_ptr<Context> GetContext() const;
 
-  const ContentContext& GetContentContext() const;
+  ContentContext& GetContentContext() const;
 
   bool Render(const Picture& picture, RenderTarget& render_target);
 

--- a/impeller/aiks/aiks_playground.cc
+++ b/impeller/aiks/aiks_playground.cc
@@ -6,6 +6,8 @@
 
 #include "impeller/aiks/aiks_context.h"
 
+#include "third_party/imgui/imgui.h"
+
 namespace impeller {
 
 AiksPlayground::AiksPlayground() = default;
@@ -32,6 +34,11 @@ bool AiksPlayground::OpenPlaygroundHere(AiksPlaygroundCallback callback) {
 
   return Playground::OpenPlaygroundHere(
       [&renderer, &callback](RenderTarget& render_target) -> bool {
+        static bool wireframe = false;
+        if (ImGui::IsKeyPressed(ImGuiKey_Z)) {
+          wireframe = !wireframe;
+          renderer.GetContentContext().SetWireframe(wireframe);
+        }
         return callback(renderer, render_target);
       });
 }

--- a/impeller/entity/contents/content_context.cc
+++ b/impeller/entity/contents/content_context.cc
@@ -142,6 +142,8 @@ void ContentContextOptions::ApplyToPipelineDescriptor(
   }
 
   desc.SetPrimitiveType(primitive_type);
+
+  desc.SetPolygonMode(wireframe ? PolygonMode::kLine : PolygonMode::kFill);
 }
 
 template <typename PipelineT>
@@ -377,6 +379,10 @@ std::shared_ptr<Context> ContentContext::GetContext() const {
 
 const IDeviceCapabilities& ContentContext::GetDeviceCapabilities() const {
   return context_->GetDeviceCapabilities();
+}
+
+void ContentContext::SetWireframe(bool wireframe) {
+  wireframe_ = wireframe;
 }
 
 }  // namespace impeller

--- a/impeller/entity/contents/content_context.h
+++ b/impeller/entity/contents/content_context.h
@@ -269,13 +269,14 @@ struct ContentContextOptions {
   PrimitiveType primitive_type = PrimitiveType::kTriangle;
   std::optional<PixelFormat> color_attachment_pixel_format;
   bool has_stencil_attachment = true;
+  bool wireframe = false;
 
   struct Hash {
     constexpr std::size_t operator()(const ContentContextOptions& o) const {
       return fml::HashCombine(o.sample_count, o.blend_mode, o.stencil_compare,
                               o.stencil_operation, o.primitive_type,
                               o.color_attachment_pixel_format,
-                              o.has_stencil_attachment);
+                              o.has_stencil_attachment, o.wireframe);
     }
   };
 
@@ -289,7 +290,8 @@ struct ContentContextOptions {
              lhs.primitive_type == rhs.primitive_type &&
              lhs.color_attachment_pixel_format ==
                  rhs.color_attachment_pixel_format &&
-             lhs.has_stencil_attachment == rhs.has_stencil_attachment;
+             lhs.has_stencil_attachment == rhs.has_stencil_attachment &&
+             lhs.wireframe == rhs.wireframe;
     }
   };
 
@@ -598,6 +600,8 @@ class ContentContext {
 
   const IDeviceCapabilities& GetDeviceCapabilities() const;
 
+  void SetWireframe(bool wireframe);
+
   using SubpassCallback =
       std::function<bool(const ContentContext&, RenderPass&)>;
 
@@ -706,6 +710,10 @@ class ContentContext {
       return nullptr;
     }
 
+    if (wireframe_) {
+      opts.wireframe = true;
+    }
+
     if (auto found = container.find(opts); found != container.end()) {
       return found->second->WaitAndGet();
     }
@@ -731,6 +739,7 @@ class ContentContext {
   std::shared_ptr<Tessellator> tessellator_;
   std::shared_ptr<GlyphAtlasContext> glyph_atlas_context_;
   std::shared_ptr<scene::SceneContext> scene_context_;
+  bool wireframe_ = false;
 
   FML_DISALLOW_COPY_AND_ASSIGN(ContentContext);
 };

--- a/impeller/entity/entity_playground.cc
+++ b/impeller/entity/entity_playground.cc
@@ -6,6 +6,8 @@
 
 #include "impeller/entity/contents/content_context.h"
 
+#include "third_party/imgui/imgui.h"
+
 namespace impeller {
 
 EntityPlayground::EntityPlayground() = default;
@@ -37,6 +39,11 @@ bool EntityPlayground::OpenPlaygroundHere(EntityPlaygroundCallback callback) {
     return false;
   }
   SinglePassCallback pass_callback = [&](RenderPass& pass) -> bool {
+    static bool wireframe = false;
+    if (ImGui::IsKeyPressed(ImGuiKey_Z)) {
+      wireframe = !wireframe;
+      content_context.SetWireframe(wireframe);
+    }
     return callback(content_context, pass);
   };
   return Playground::OpenPlaygroundHere(pass_callback);


### PR DESCRIPTION
... in the Entities and Aiks playgrounds. Works on all backends.

WASD gets used for fly camera controls in Impeller Scene playgrounds, so I used `Z` to sorta match the Blender shortcut. Before I add more playground features I'm going to come up with a better way to package playground tool logic between the different kinds of playgrounds. All Entities tools should be usable in the Aiks and DL playgrounds, etc. And there needs to be a GUI that stuff like this can hook into. We shouldn't just add a million shortcuts and call it a day.

https://user-images.githubusercontent.com/919017/222307409-f4c1fcb1-b21b-4b3a-8499-c69cf02d1b80.mov



`EntityPass` is really good about not clearing attachments unnecessarily, and so uninitialized data shows up in these cases. We can add stuff to be smarter about this when "wireframe" is activated in the context, but not bothering to do so yet.

https://user-images.githubusercontent.com/919017/222309572-d9e266f8-af0d-4302-bcf3-e57fc3e7dabc.mov

