### PR TITLE
[canvaskit] read pixels back in Picture.toImage

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/picture.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/picture.dart
@@ -100,28 +100,7 @@ class CkPicture extends ManagedSkiaObject<SkPicture> implements ui.Picture {
   }
 
   @override
-  ui.Image toImageSync(int width, int height) {
-    SurfaceFactory.instance.baseSurface.ensureSurface();
-    if (SurfaceFactory.instance.baseSurface.usingSoftwareBackend) {
-      return toImageSyncSoftware(width, height);
-    }
-    return toImageSyncGPU(width, height);
-  }
-
-  ui.Image toImageSyncGPU(int width, int height) {
-    assert(debugCheckNotDisposed('Cannot convert picture to image.'));
-
-    final CkSurface ckSurface = SurfaceFactory.instance.baseSurface
-      .createRenderTargetSurface(ui.Size(width.toDouble(), height.toDouble()));
-    final CkCanvas ckCanvas = ckSurface.getCanvas();
-    ckCanvas.clear(const ui.Color(0x00000000));
-    ckCanvas.drawPicture(this);
-    final SkImage skImage = ckSurface.surface.makeImageSnapshot();
-    ckSurface.dispose();
-    return CkImage(skImage);
-  }
-
-  ui.Image toImageSyncSoftware(int width, int height) {
+  CkImage toImageSync(int width, int height) {
     assert(debugCheckNotDisposed('Cannot convert picture to image.'));
 
     final Surface surface = SurfaceFactory.instance.pictureToImageSurface;


### PR DESCRIPTION
This undoes the optimization made in https://github.com/flutter/engine/pull/38573, and adds a test-case that would have failed when that optimization was made. The issue is that CanvasKit loses track of which resources belong to which context that leads to WebGL errors followed by UI corruption.

Fixes https://github.com/flutter/flutter/issues/121758