### PR TITLE
Do not end the frame in the raster cache if ScopedFrame::Raster returns kResubmit

### DIFF
--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -604,7 +604,12 @@ RasterStatus Rasterizer::DrawToSurfaceUnsafe(
       frame->Submit();
     }
 
-    compositor_context_->raster_cache().EndFrame();
+    // Do not update raster cache metrics for kResubmit because that status
+    // indicates that the frame was not actually painted.
+    if (raster_status != RasterStatus::kResubmit) {
+      compositor_context_->raster_cache().EndFrame();
+    }
+
     frame_timings_recorder.RecordRasterEnd(
         &compositor_context_->raster_cache());
     FireNextFrameCallbackIfPresent();


### PR DESCRIPTION
kResubmit (along with kSkipAndRetry) indicate that ScopedFrame::Raster did not actually paint the frame.

Fixes https://github.com/flutter/flutter/issues/121678
