### PR TITLE
[web] Remember which variant of CanvasKit is being used

### DIFF
--- a/lib/web_ui/lib/src/engine/browser_detection.dart
+++ b/lib/web_ui/lib/src/engine/browser_detection.dart
@@ -266,3 +266,8 @@ int _detectWebGLVersion() {
   }
   return -1;
 }
+
+/// Whether the current browser supports the Chromium variant of CanvasKit.
+const bool browserSupportsCanvaskitChromium = false;
+// TODO(mdebbar): Uncomment this to enable real detection of browser support.
+// final bool browserSupportsCanvaskitChromium = domIntl.v8BreakIterator != null;

--- a/lib/web_ui/lib/src/engine/canvaskit/renderer.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/renderer.dart
@@ -28,13 +28,6 @@ import 'shader.dart';
 import 'text.dart';
 import 'vertices.dart';
 
-/// Whether we can use client-provided ICU information instead of CanvasKit's
-/// built-in ICU.
-const bool browserSupportsCanvaskitChromium = false;
-// TODO(mdebbar): Uncomment this and use it to determine which flavor of
-//  CanvasKit to download.
-// final bool browserSupportsCanvaskitChromium = domIntl.v8BreakIterator != null;
-
 enum CanvasKitVariant {
   /// The appropriate variant is chosen based on the browser.
   ///

--- a/lib/web_ui/lib/src/engine/canvaskit/text.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/text.dart
@@ -977,7 +977,7 @@ class CkParagraphBuilder implements ui.ParagraphBuilder {
 
   /// Builds the CkParagraph with the builder and deletes the builder.
   SkParagraph _buildSkParagraph() {
-    if (browserSupportsCanvaskitChromium) {
+    if (canvasKitVariant == CanvasKitVariant.chromium) {
       final String text = _paragraphBuilder.getText();
       _paragraphBuilder.setWordsUtf16(
         fragmentUsingIntlSegmenter(text, IntlSegmenterGranularity.word),


### PR DESCRIPTION
This PR splits the decision making into two variables:

1. `browserSupportsCanvasKitChromium`: This only takes effect in `auto` mode. If it's true, then we try to download the Chromium variant first, and fallback to the full variant. _**(This is currently still hardcoded to false so users don't get the Chromium variant just yet)**_

2. `canvasKitVariant`: After CanvasKit is successfully downloaded, this variable contains the variant that was downloaded. This allows us to control what CanvasKit APIs to use depending on which CanvasKit variant we are using.

Required by https://github.com/flutter/engine/pull/39984