### PR TITLE
Remove special handling of gtk debug artifact.

### DIFF
--- a/ci/builders/linux_host_engine.json
+++ b/ci/builders/linux_host_engine.json
@@ -78,7 +78,7 @@
                         "out/host_debug/zip_archives/linux-x64/font-subset.zip",
                         "out/host_debug/zip_archives/flutter_patched_sdk.zip",
                         "out/host_debug/zip_archives/dart-sdk-linux-x64.zip",
-                        "out/host_debug/zip_archives/linux-x64/linux-x64-flutter-gtk.zip"
+                        "out/host_debug/zip_archives/linux-x64-debug/linux-x64-flutter-gtk.zip"
                     ]
                 }
             ],

--- a/shell/platform/linux/BUILD.gn
+++ b/shell/platform/linux/BUILD.gn
@@ -276,11 +276,7 @@ copy("publish_headers_linux") {
 }
 
 zip_bundle("flutter_gtk") {
-  prefix = "$full_target_platform_name/"
-  if (flutter_runtime_mode != "debug" ||
-      (flutter_runtime_mode == "debug" && target_cpu != "x64")) {
-    prefix = "$full_target_platform_name-$flutter_runtime_mode/"
-  }
+  prefix = "$full_target_platform_name-$flutter_runtime_mode/"
   output = "${prefix}${full_target_platform_name}-flutter-gtk.zip"
   deps = [
     ":flutter_linux_gtk",


### PR DESCRIPTION
The debug gtk artifact path was inconsistent with the release and profile paths. This PR is making the path calculation consistent.

https://github.com/flutter/flutter/pull/120658 updated the tool to use a consistent path for debug.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
