### PR TITLE
Add web_engine build configuration.

### DIFF
--- a/ci/builders/linux_host_engine.json
+++ b/ci/builders/linux_host_engine.json
@@ -26,47 +26,47 @@
             "tests": []
         },
         {
-          "archives": [],
-          "drone_dimensions": [
-              "device_type=none",
-              "os=Linux"
-          ],
-          "gclient_variables": {
-              "download_android_deps": false
-          },
-          "gn": [
-              "--runtime-mode",
-              "debug",
-              "--unoptimized",
-              "--prebuilt-dart-sdk",
-              "--target-dir",
-              "host_debug_impeller_vulkan"
-          ],
-          "name": "host_debug_impeller_vulkan",
-          "ninja": {
-              "config": "host_debug_impeller_vulkan",
-              "targets": [
-                  "flutter",
-                  "flutter/sky/packages"
-              ]
-          },
-          "tests": [
-            {
-                "language": "python3",
-                "name": "Host Tests for host_debug_impeller_vulkan",
-                "parameters": [
-                    "--variant",
-                    "host_debug_impeller_vulkan",
-                    "--type",
-                    "impeller-vulkan",
-                    "--engine-capture-core-dump"
-                ],
-                "script": "flutter/testing/run_tests.py",
-                "type": "local"
-            }
-        ]
-      },
-      {
+            "archives": [],
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false
+            },
+            "gn": [
+                "--runtime-mode",
+                "debug",
+                "--unoptimized",
+                "--prebuilt-dart-sdk",
+                "--target-dir",
+                "host_debug_impeller_vulkan"
+            ],
+            "name": "host_debug_impeller_vulkan",
+            "ninja": {
+                "config": "host_debug_impeller_vulkan",
+                "targets": [
+                    "flutter",
+                    "flutter/sky/packages"
+                ]
+            },
+            "tests": [
+                {
+                    "language": "python3",
+                    "name": "Host Tests for host_debug_impeller_vulkan",
+                    "parameters": [
+                        "--variant",
+                        "host_debug_impeller_vulkan",
+                        "--type",
+                        "impeller-vulkan",
+                        "--engine-capture-core-dump"
+                    ],
+                    "script": "flutter/testing/run_tests.py",
+                    "type": "local"
+                }
+            ]
+        },
+        {
             "archives": [
                 {
                     "name": "host_debug",
@@ -99,7 +99,7 @@
             "ninja": {
                 "config": "host_debug",
                 "targets": [
-		    "flutter:unittests",
+                    "flutter:unittests",
                     "flutter/build/archives:artifacts",
                     "flutter/build/archives:dart_sdk_archive",
                     "flutter/build/archives:embedder",
@@ -123,7 +123,7 @@
                     "script": "flutter/testing/run_tests.py",
                     "type": "local"
                 }
-	    ]
+            ]
         },
         {
             "archives": [
@@ -154,9 +154,9 @@
             "ninja": {
                 "config": "host_profile",
                 "targets": [
-		    "flutter/build/dart:copy_dart_sdk",
-		    "flutter/shell/testing",
-		    "flutter/tools/path_ops",
+                    "flutter/build/dart:copy_dart_sdk",
+                    "flutter/shell/testing",
+                    "flutter/tools/path_ops",
                     "flutter/shell/platform/linux:flutter_gtk",
                     "flutter:unittests"
                 ]
@@ -206,16 +206,16 @@
             "ninja": {
                 "config": "host_release",
                 "targets": [
-		    "flutter/build/dart:copy_dart_sdk",
-		    "flutter/display_list:display_list_benchmarks",
-		    "flutter/display_list:display_list_builder_benchmarks",
-		    "flutter/fml:fml_benchmarks",
-		    "flutter/impeller/geometry:geometry_benchmarks",
-		    "flutter/lib/ui:ui_benchmarks",
-		    "flutter/shell/common:shell_benchmarks",
-		    "flutter/shell/testing",
-		    "flutter/third_party/txt:txt_benchmarks",
-		    "flutter/tools/path_ops",
+                    "flutter/build/dart:copy_dart_sdk",
+                    "flutter/display_list:display_list_benchmarks",
+                    "flutter/display_list:display_list_builder_benchmarks",
+                    "flutter/fml:fml_benchmarks",
+                    "flutter/impeller/geometry:geometry_benchmarks",
+                    "flutter/lib/ui:ui_benchmarks",
+                    "flutter/shell/common:shell_benchmarks",
+                    "flutter/shell/testing",
+                    "flutter/third_party/txt:txt_benchmarks",
+                    "flutter/tools/path_ops",
                     "flutter/build/archives:flutter_patched_sdk",
                     "flutter/shell/platform/linux:flutter_gtk",
                     "flutter:unittests"
@@ -236,39 +236,6 @@
                     "type": "local"
                 }
             ]
-        },
-        {
-            "archives": [
-                {
-                    "name": "wasm_release",
-                    "base_path": "out/wasm_release/zip_archives/",
-                    "type": "gcs",
-                    "include_paths": [
-                        "out/wasm_release/zip_archives/flutter-web-sdk.zip"
-                    ]
-                }
-            ],
-            "drone_dimensions": [
-                "device_type=none",
-                "os=Linux"
-            ],
-            "gclient_variables": {
-                "download_emsdk": true,
-                "download_android_deps": false
-            },
-            "gn": [
-                "--runtime-mode",
-                "release",
-                "--web"
-            ],
-            "name": "wasm_release",
-            "ninja": {
-                "config": "wasm_release",
-                "targets": [
-                    "flutter/web_sdk:flutter_web_sdk_archive"
-                ]
-            },
-            "tests": []
         }
     ],
     "tests": []

--- a/ci/builders/linux_web_engine.json
+++ b/ci/builders/linux_web_engine.json
@@ -1,14 +1,23 @@
 {
     "builds": [
         {
-            "archives": [],
+            "archives": [
+                {
+                    "name": "wasm_release",
+                    "base_path": "out/wasm_release/zip_archives/",
+                    "type": "gcs",
+                    "include_paths": [
+                        "out/wasm_release/zip_archives/flutter-web-sdk.zip"
+                    ]
+                }
+            ],
             "drone_dimensions": [
                 "device_type=none",
                 "os=Linux"
             ],
             "gclient_variables": {
                 "download_android_deps": false,
-		"download_emsdk": true
+                "download_emsdk": true
             },
             "gn": [
                 "--build-canvaskit",
@@ -18,7 +27,9 @@
             "name": "wasm_release",
             "ninja": {
                 "config": "wasm_release",
-                "targets": []
+                "targets": [
+                    "flutter/web_sdk:flutter_web_sdk_archive"
+                ]
             },
             "generators": {
                 "pub_dirs": [
@@ -43,8 +54,7 @@
                             "check-licenses"
                         ],
                         "scripts": [
-                            "third_party/dart/tools/sdks/dart-sdk/bin/dart",
-                            "flutter/lib/web_ui/dev/felt.dart"
+                            "flutter/lib/web_ui/dev/felt"
                         ]
                     },
                     {
@@ -53,8 +63,7 @@
                             "analyze"
                         ],
                         "scripts": [
-                            "third_party/dart/tools/sdks/dart-sdk/bin/dart",
-                            "flutter/lib/web_ui/dev/felt.dart"
+                            "flutter/lib/web_ui/dev/felt"
                         ]
                     }
                 ]

--- a/ci/builders/web_engine.json
+++ b/ci/builders/web_engine.json
@@ -33,7 +33,7 @@
                             "compile_tests"
                         ],
                         "scripts": [
-                            "dart",
+                            "third_party/dart/tools/sdks/dart-sdk/bin/dart",
                             "flutter/lib/web_ui/dev/felt.dart"
                         ]
                     },
@@ -43,7 +43,7 @@
                             "check-licenses"
                         ],
                         "scripts": [
-                            "dart",
+                            "third_party/dart/tools/sdks/dart-sdk/bin/dart",
                             "flutter/lib/web_ui/dev/felt.dart"
                         ]
                     },
@@ -53,7 +53,7 @@
                             "analyze"
                         ],
                         "scripts": [
-                            "dart",
+                            "third_party/dart/tools/sdks/dart-sdk/bin/dart",
                             "flutter/lib/web_ui/dev/felt.dart"
                         ]
                     }

--- a/ci/builders/web_engine.json
+++ b/ci/builders/web_engine.json
@@ -33,7 +33,7 @@
                             "compile_tests"
                         ],
                         "scripts": [
-                            "out/host_debug_unopt/dart-sdk/bin/dart",
+                            "dart",
                             "flutter/lib/web_ui/dev/felt.dart"
                         ]
                     },
@@ -43,7 +43,7 @@
                             "check-licenses"
                         ],
                         "scripts": [
-                            "out/host_debug_unopt/dart-sdk/bin/dart",
+                            "dart",
                             "flutter/lib/web_ui/dev/felt.dart"
                         ]
                     },
@@ -53,7 +53,7 @@
                             "analyze"
                         ],
                         "scripts": [
-                            "out/host_debug_unopt/dart-sdk/bin/dart",
+                            "dart",
                             "flutter/lib/web_ui/dev/felt.dart"
                         ]
                     }

--- a/ci/builders/web_engine.json
+++ b/ci/builders/web_engine.json
@@ -1,41 +1,65 @@
 {
-    "generators": {
-        "pub_dirs": [
-            "flutter/lib/web_ui/",
-            "flutter/web_sdk/web_engine_tester/"
-        ],
-        "tasks": [
-            {
-                "name": "compile web_tests",
-                "parameters": [
-                    "run",
-                    "compile_tests"
+    "builds": [
+        {
+            "archives": [],
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false
+            },
+            "gn": [
+                "--build-canvaskit",
+                " --web",
+                "--runtime-mode=release"
+            ],
+            "name": "wasm_release",
+            "ninja": {
+                "config": "wasm_release",
+                "targets": []
+            },
+            "generators": {
+                "pub_dirs": [
+                    "flutter/lib/web_ui/",
+                    "flutter/web_sdk/web_engine_tester/"
                 ],
-                "scripts": [
-                    "out/host_debug_unopt/dart-sdk/bin/dart",
-                    "flutter/lib/web_ui/dev/felt.dart"
+                "tasks": [
+                    {
+                        "name": "compile web_tests",
+                        "parameters": [
+                            "run",
+                            "compile_tests"
+                        ],
+                        "scripts": [
+                            "out/host_debug_unopt/dart-sdk/bin/dart",
+                            "flutter/lib/web_ui/dev/felt.dart"
+                        ]
+                    },
+                    {
+                        "name": "check licenses",
+                        "parameters": [
+                            "check-licenses"
+                        ],
+                        "scripts": [
+                            "out/host_debug_unopt/dart-sdk/bin/dart",
+                            "flutter/lib/web_ui/dev/felt.dart"
+                        ]
+                    },
+                    {
+                        "name": "web engine analysis",
+                        "parameters": [
+                            "analyze"
+                        ],
+                        "scripts": [
+                            "out/host_debug_unopt/dart-sdk/bin/dart",
+                            "flutter/lib/web_ui/dev/felt.dart"
+                        ]
+                    }
                 ]
             },
-            {
-                "name": "check licenses",
-                "parameters": [
-                    "check-licenses"
-                ],
-                "scripts": [
-                    "out/host_debug_unopt/dart-sdk/bin/dart",
-                    "flutter/lib/web_ui/dev/felt.dart"
-                ]
-            },
-            {
-                "name": "web engine analysis",
-                "parameters": [
-                    "analyze"
-                ],
-                "scripts": [
-                    "out/host_debug_unopt/dart-sdk/bin/dart",
-                    "flutter/lib/web_ui/dev/felt.dart"
-                ]
-            }
-        ]
-    }
+            "tests": []
+        }
+    ],
+    "tests": []
 }

--- a/ci/builders/web_engine.json
+++ b/ci/builders/web_engine.json
@@ -7,7 +7,8 @@
                 "os=Linux"
             ],
             "gclient_variables": {
-                "download_android_deps": false
+                "download_android_deps": false,
+		"download_emsdk": true
             },
             "gn": [
                 "--build-canvaskit",

--- a/ci/builders/web_engine.json
+++ b/ci/builders/web_engine.json
@@ -11,7 +11,7 @@
             },
             "gn": [
                 "--build-canvaskit",
-                " --web",
+                "--web",
                 "--runtime-mode=release"
             ],
             "name": "wasm_release",


### PR DESCRIPTION
Initial configuration for web engine builds using engine_v2 recipes. The implementation will be executed in multiple steps to allow to land fixes to recipes and web engine tooling along the way.

These are the expected steps:

* 1) Base build configuration - wasm build with the tests/generators running on it.
* 2) Test sub-subbuilds implementations
* 3) Tests sub-builds on multiple platforms

This PR covers i).

Bug: https://github.com/flutter/flutter/issues/119036

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
