### PR TITLE
[Impeller] fix subpass collapse pass ending logic

### DIFF
--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -294,12 +294,14 @@ EntityPass::EntityResult EntityPass::GetEntityForElement(
       return EntityPass::EntityResult::Skip();
     }
 
-    if (subpass->delegate_->CanCollapseIntoParentPass() &&
-        !subpass->backdrop_filter_proc_.has_value()) {
+    if (!subpass->backdrop_filter_proc_.has_value() &&
+        subpass->delegate_->CanCollapseIntoParentPass()) {
       // Directly render into the parent target and move on.
+      auto render_pass_result = pass_context.GetRenderPass(pass_depth);
       if (!subpass->OnRender(renderer, root_pass_size,
                              pass_context.GetRenderTarget(), position, position,
-                             stencil_depth_floor)) {
+                             pass_depth, stencil_depth_, nullptr,
+                             render_pass_result)) {
         return EntityPass::EntityResult::Failure();
       }
       return EntityPass::EntityResult::Skip();
@@ -405,20 +407,21 @@ struct StencilLayer {
   size_t stencil_depth;
 };
 
-bool EntityPass::OnRender(
-    ContentContext& renderer,
-    ISize root_pass_size,
-    const RenderTarget& render_target,
-    Point position,
-    Point parent_position,
-    uint32_t pass_depth,
-    size_t stencil_depth_floor,
-    std::shared_ptr<Contents> backdrop_filter_contents) const {
+bool EntityPass::OnRender(ContentContext& renderer,
+                          ISize root_pass_size,
+                          const RenderTarget& render_target,
+                          Point position,
+                          Point parent_position,
+                          uint32_t pass_depth,
+                          size_t stencil_depth_floor,
+                          std::shared_ptr<Contents> backdrop_filter_contents,
+                          std::optional<InlinePassContext::RenderPassResult>
+                              collapsed_parent_pass) const {
   TRACE_EVENT0("impeller", "EntityPass::OnRender");
 
   auto context = renderer.GetContext();
-  InlinePassContext pass_context(context, render_target,
-                                 reads_from_pass_texture_);
+  InlinePassContext pass_context(
+      context, render_target, reads_from_pass_texture_, collapsed_parent_pass);
   if (!pass_context.IsValid()) {
     return false;
   }

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -297,11 +297,10 @@ EntityPass::EntityResult EntityPass::GetEntityForElement(
     if (!subpass->backdrop_filter_proc_.has_value() &&
         subpass->delegate_->CanCollapseIntoParentPass()) {
       // Directly render into the parent target and move on.
-      auto render_pass_result = pass_context.GetRenderPass(pass_depth);
       if (!subpass->OnRender(renderer, root_pass_size,
                              pass_context.GetRenderTarget(), position, position,
                              pass_depth, stencil_depth_, nullptr,
-                             render_pass_result)) {
+                             pass_context.GetRenderPass(pass_depth))) {
         return EntityPass::EntityResult::Failure();
       }
       return EntityPass::EntityResult::Skip();

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -419,8 +419,9 @@ bool EntityPass::OnRender(ContentContext& renderer,
   TRACE_EVENT0("impeller", "EntityPass::OnRender");
 
   auto context = renderer.GetContext();
-  InlinePassContext pass_context(
-      context, render_target, reads_from_pass_texture_, collapsed_parent_pass);
+  InlinePassContext pass_context(context, render_target,
+                                 reads_from_pass_texture_,
+                                 std::move(collapsed_parent_pass));
   if (!pass_context.IsValid()) {
     return false;
   }

--- a/impeller/entity/entity_pass.h
+++ b/impeller/entity/entity_pass.h
@@ -99,15 +99,16 @@ class EntityPass {
                                    uint32_t pass_depth,
                                    size_t stencil_depth_floor) const;
 
-  bool OnRender(
-      ContentContext& renderer,
-      ISize root_pass_size,
-      const RenderTarget& render_target,
-      Point position,
-      Point parent_position,
-      uint32_t pass_depth,
-      size_t stencil_depth_floor = 0,
-      std::shared_ptr<Contents> backdrop_filter_contents = nullptr) const;
+  bool OnRender(ContentContext& renderer,
+                ISize root_pass_size,
+                const RenderTarget& render_target,
+                Point position,
+                Point parent_position,
+                uint32_t pass_depth,
+                size_t stencil_depth_floor = 0,
+                std::shared_ptr<Contents> backdrop_filter_contents = nullptr,
+                std::optional<InlinePassContext::RenderPassResult>
+                    collapsed_parent_pass = std::nullopt) const;
 
   std::vector<Element> elements_;
 

--- a/impeller/entity/entity_playground.cc
+++ b/impeller/entity/entity_playground.cc
@@ -14,6 +14,22 @@ EntityPlayground::EntityPlayground() = default;
 
 EntityPlayground::~EntityPlayground() = default;
 
+bool EntityPlayground::OpenPlaygroundHere(EntityPass& entity_pass) {
+  if (!Playground::is_enabled()) {
+    return true;
+  }
+
+  ContentContext content_context(GetContext());
+  if (!content_context.IsValid()) {
+    return false;
+  }
+
+  auto callback = [&](RenderTarget& render_target) -> bool {
+    return entity_pass.Render(content_context, render_target);
+  };
+  return Playground::OpenPlaygroundHere(callback);
+}
+
 bool EntityPlayground::OpenPlaygroundHere(Entity entity) {
   if (!Playground::is_enabled()) {
     return true;

--- a/impeller/entity/entity_playground.h
+++ b/impeller/entity/entity_playground.h
@@ -7,6 +7,8 @@
 #include "flutter/fml/macros.h"
 #include "impeller/entity/contents/content_context.h"
 #include "impeller/entity/entity.h"
+#include "impeller/entity/entity_pass.h"
+
 #include "impeller/playground/playground_test.h"
 
 namespace impeller {
@@ -21,6 +23,8 @@ class EntityPlayground : public PlaygroundTest {
   ~EntityPlayground();
 
   bool OpenPlaygroundHere(Entity entity);
+
+  bool OpenPlaygroundHere(EntityPass& entity_pass);
 
   bool OpenPlaygroundHere(EntityPlaygroundCallback callback);
 

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -61,8 +61,8 @@ TEST_P(EntityTest, CanCreateEntity) {
 
 class TestPassDelegate final : public EntityPassDelegate {
  public:
-  explicit TestPassDelegate(std::optional<Rect> coverage)
-      : coverage_(coverage) {}
+  explicit TestPassDelegate(std::optional<Rect> coverage, bool collapse = false)
+      : coverage_(coverage), collapse_(collapse) {}
 
   // |EntityPassDelegate|
   ~TestPassDelegate() override = default;
@@ -74,7 +74,7 @@ class TestPassDelegate final : public EntityPassDelegate {
   bool CanElide() override { return false; }
 
   // |EntityPassDelgate|
-  bool CanCollapseIntoParentPass() override { return false; }
+  bool CanCollapseIntoParentPass() override { return collapse_; }
 
   // |EntityPassDelgate|
   std::shared_ptr<Contents> CreateContentsForSubpassTarget(
@@ -85,15 +85,19 @@ class TestPassDelegate final : public EntityPassDelegate {
 
  private:
   const std::optional<Rect> coverage_;
+  bool collapse_;
 };
 
-auto CreatePassWithRectPath(Rect rect, std::optional<Rect> bounds_hint) {
+auto CreatePassWithRectPath(Rect rect,
+                            std::optional<Rect> bounds_hint,
+                            bool collapse = false) {
   auto subpass = std::make_unique<EntityPass>();
   Entity entity;
   entity.SetContents(SolidColorContents::Make(
       PathBuilder{}.AddRect(rect).TakePath(), Color::Red()));
   subpass->AddEntity(entity);
-  subpass->SetDelegate(std::make_unique<TestPassDelegate>(bounds_hint));
+  subpass->SetDelegate(
+      std::make_unique<TestPassDelegate>(bounds_hint, collapse));
   return subpass;
 }
 
@@ -122,6 +126,27 @@ TEST_P(EntityTest, EntityPassCoverageRespectsDelegateBoundsHint) {
   auto coverage = pass.GetElementsCoverage(std::nullopt);
   ASSERT_TRUE(coverage.has_value());
   ASSERT_RECT_NEAR(coverage.value(), Rect::MakeLTRB(50, 50, 900, 900));
+}
+
+TEST_P(EntityTest, EntityPassCanMergeSubpassIntoParent) {
+  // Both a red and a blue box should appear if the pass merging has worked
+  // correctly.
+
+  EntityPass pass;
+  auto subpass = CreatePassWithRectPath(Rect::MakeLTRB(0, 0, 100, 100),
+                                        Rect::MakeLTRB(50, 50, 150, 150), true);
+  pass.AddSubpass(std::move(subpass));
+
+  Entity entity;
+  entity.SetTransformation(Matrix::MakeScale(GetContentScale()));
+  auto contents = std::make_unique<SolidColorContents>();
+  contents->SetGeometry(Geometry::MakeRect(Rect::MakeLTRB(100, 100, 200, 200)));
+  contents->SetColor(Color::Blue());
+  entity.SetContents(std::move(contents));
+
+  pass.AddEntity(entity);
+
+  ASSERT_TRUE(OpenPlaygroundHere(pass));
 }
 
 TEST_P(EntityTest, EntityPassCoverageRespectsCoverageLimit) {

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -85,7 +85,7 @@ class TestPassDelegate final : public EntityPassDelegate {
 
  private:
   const std::optional<Rect> coverage_;
-  bool collapse_;
+  const bool collapse_;
 };
 
 auto CreatePassWithRectPath(Rect rect,

--- a/impeller/entity/inline_pass_context.cc
+++ b/impeller/entity/inline_pass_context.cc
@@ -21,14 +21,14 @@ InlinePassContext::InlinePassContext(
     : context_(std::move(context)),
       render_target_(render_target),
       total_pass_reads_(pass_texture_reads),
-      collapsed_parent_pass_(collapsed_parent_pass.has_value()) {
+      is_collapsed_(collapsed_parent_pass.has_value()) {
   if (collapsed_parent_pass.has_value()) {
     pass_ = collapsed_parent_pass.value().pass;
   }
 }
 
 InlinePassContext::~InlinePassContext() {
-  if (!collapsed_parent_pass_) {
+  if (!is_collapsed_) {
     EndPass();
   }
 }

--- a/impeller/entity/inline_pass_context.cc
+++ b/impeller/entity/inline_pass_context.cc
@@ -13,15 +13,24 @@
 
 namespace impeller {
 
-InlinePassContext::InlinePassContext(std::shared_ptr<Context> context,
-                                     const RenderTarget& render_target,
-                                     uint32_t pass_texture_reads)
+InlinePassContext::InlinePassContext(
+    std::shared_ptr<Context> context,
+    const RenderTarget& render_target,
+    uint32_t pass_texture_reads,
+    std::optional<RenderPassResult> collapsed_parent_pass)
     : context_(std::move(context)),
       render_target_(render_target),
-      total_pass_reads_(pass_texture_reads) {}
+      total_pass_reads_(pass_texture_reads),
+      collapsed_parent_pass_(collapsed_parent_pass.has_value()) {
+  if (collapsed_parent_pass.has_value()) {
+    pass_ = collapsed_parent_pass.value().pass;
+  }
+}
 
 InlinePassContext::~InlinePassContext() {
-  EndPass();
+  if (!collapsed_parent_pass_) {
+    EndPass();
+  }
 }
 
 bool InlinePassContext::IsValid() const {

--- a/impeller/entity/inline_pass_context.h
+++ b/impeller/entity/inline_pass_context.h
@@ -40,7 +40,8 @@ class InlinePassContext {
   std::shared_ptr<RenderPass> pass_;
   uint32_t pass_count_ = 0;
   uint32_t total_pass_reads_ = 0;
-  bool collapsed_parent_pass_ = false;
+  // Whether this context is collapsed into a parent entity pass.
+  bool is_collapsed_ = false;
 
   FML_DISALLOW_COPY_AND_ASSIGN(InlinePassContext);
 };

--- a/impeller/entity/inline_pass_context.h
+++ b/impeller/entity/inline_pass_context.h
@@ -17,9 +17,11 @@ class InlinePassContext {
     std::shared_ptr<Texture> backdrop_texture;
   };
 
-  InlinePassContext(std::shared_ptr<Context> context,
-                    const RenderTarget& render_target,
-                    uint32_t pass_texture_reads);
+  InlinePassContext(
+      std::shared_ptr<Context> context,
+      const RenderTarget& render_target,
+      uint32_t pass_texture_reads,
+      std::optional<RenderPassResult> collapsed_parent_pass = std::nullopt);
   ~InlinePassContext();
 
   bool IsValid() const;
@@ -38,6 +40,7 @@ class InlinePassContext {
   std::shared_ptr<RenderPass> pass_;
   uint32_t pass_count_ = 0;
   uint32_t total_pass_reads_ = 0;
+  bool collapsed_parent_pass_ = false;
 
   FML_DISALLOW_COPY_AND_ASSIGN(InlinePassContext);
 };


### PR DESCRIPTION
Discovered during investigation of opacity optimizations, currently OnRender will unconditionally end the current pass - but this is incorrect if we're merged into the parent pass. Detect this case and ensure that the collapsed child gets the same render target and render pass.