### PR TITLE
[web][felt] Add 'archive' target + 'profile' mode

### DIFF
--- a/lib/web_ui/dev/build.dart
+++ b/lib/web_ui/dev/build.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io' show Directory;
 
 import 'package:args/command_runner.dart';
 import 'package:path/path.dart' as path;
@@ -13,12 +12,18 @@ import 'environment.dart';
 import 'pipeline.dart';
 import 'utils.dart';
 
+enum RuntimeMode {
+  profile,
+  release,
+}
+
 const Map<String, String> targetAliases = <String, String>{
   'sdk': 'flutter/web_sdk',
   'web_sdk': 'flutter/web_sdk',
   'canvaskit': 'flutter/third_party/canvaskit:canvaskit_group',
   'canvaskit_chromium': 'flutter/third_party/canvaskit:canvaskit_chromium_group',
   'skwasm': 'flutter/lib/web_ui/skwasm',
+  'archive': 'flutter/web_sdk:flutter_web_sdk_archive',
 };
 
 class BuildCommand extends Command<bool> with ArgUtils<bool> {
@@ -34,6 +39,12 @@ class BuildCommand extends Command<bool> with ArgUtils<bool> {
       help: 'Build the host build instead of the wasm build, which is '
           'currently needed for `flutter run --local-engine` to work.'
     );
+    argParser.addFlag(
+      'profile',
+      help: 'Build in profile mode instead of release mode. In this mode, the '
+          'output will be located at "out/wasm_profile".\nThis only applies to '
+          'the wasm build. The host build is always built in release mode.',
+    );
   }
 
   @override
@@ -46,15 +57,22 @@ class BuildCommand extends Command<bool> with ArgUtils<bool> {
 
   bool get host => boolArg('host');
 
+  RuntimeMode get runtimeMode =>
+      boolArg('profile') ? RuntimeMode.profile : RuntimeMode.release;
+
   List<String> get targets => argResults?.rest ?? <String>[];
 
   @override
   FutureOr<bool> run() async {
     final FilePath libPath = FilePath.fromWebUi('lib');
     final List<PipelineStep> steps = <PipelineStep>[
-      GnPipelineStep(host: host),
+      GnPipelineStep(
+        host: host,
+        runtimeMode: runtimeMode,
+      ),
       NinjaPipelineStep(
-        buildDirectory: host ? environment.hostDebugUnoptDir : environment.wasmReleaseOutDir,
+        host: host,
+        runtimeMode: runtimeMode,
         targets: targets.map((String target) => targetAliases[target] ?? target),
       ),
     ];
@@ -82,15 +100,26 @@ class BuildCommand extends Command<bool> with ArgUtils<bool> {
 class GnPipelineStep extends ProcessStep {
   GnPipelineStep({
     required this.host,
+    required this.runtimeMode,
   });
 
   final bool host;
+  final RuntimeMode runtimeMode;
 
   @override
   String get description => 'gn';
 
   @override
   bool get isSafeToInterrupt => false;
+
+  String get runtimeModeFlag {
+    switch (runtimeMode) {
+      case RuntimeMode.profile:
+        return 'profile';
+      case RuntimeMode.release:
+        return 'release';
+    }
+  }
 
   List<String> get _gnArgs {
     if (host) {
@@ -101,7 +130,7 @@ class GnPipelineStep extends ProcessStep {
     } else {
       return <String>[
         '--web',
-        '--runtime-mode=release',
+        '--runtime-mode=$runtimeModeFlag',
       ];
     }
   }
@@ -120,7 +149,11 @@ class GnPipelineStep extends ProcessStep {
 ///
 /// Can be safely interrupted.
 class NinjaPipelineStep extends ProcessStep {
-  NinjaPipelineStep({required this.buildDirectory, required this.targets});
+  NinjaPipelineStep({
+    required this.host,
+    required this.runtimeMode,
+    required this.targets,
+  });
 
   @override
   String get description => 'ninja';
@@ -128,10 +161,21 @@ class NinjaPipelineStep extends ProcessStep {
   @override
   bool get isSafeToInterrupt => true;
 
-  /// The directory to build.
-  final Directory buildDirectory;
-
+  final bool host;
   final Iterable<String> targets;
+  final RuntimeMode runtimeMode;
+
+  String get buildDirectory {
+    if (host) {
+      return environment.hostDebugUnoptDir.path;
+    }
+    switch (runtimeMode) {
+      case RuntimeMode.profile:
+        return environment.wasmProfileOutDir.path;
+      case RuntimeMode.release:
+        return environment.wasmReleaseOutDir.path;
+    }
+  }
 
   @override
   Future<ProcessManager> createProcess() {
@@ -140,7 +184,7 @@ class NinjaPipelineStep extends ProcessStep {
       'autoninja',
       <String>[
         '-C',
-        buildDirectory.path,
+        buildDirectory,
         ...targets,
       ],
     );

--- a/lib/web_ui/dev/environment.dart
+++ b/lib/web_ui/dev/environment.dart
@@ -30,6 +30,8 @@ class Environment {
         io.Directory(pathlib.join(engineSrcDir.path, 'out'));
     final io.Directory wasmReleaseOutDir =
         io.Directory(pathlib.join(outDir.path, 'wasm_release'));
+    final io.Directory wasmProfileOutDir =
+        io.Directory(pathlib.join(outDir.path, 'wasm_profile'));
     final io.Directory hostDebugUnoptDir =
         io.Directory(pathlib.join(outDir.path, 'host_debug_unopt'));
     final io.Directory dartSdkDir = dartExecutable.parent.parent;
@@ -54,6 +56,7 @@ class Environment {
       engineToolsDir: engineToolsDir,
       outDir: outDir,
       wasmReleaseOutDir: wasmReleaseOutDir,
+      wasmProfileOutDir: wasmProfileOutDir,
       hostDebugUnoptDir: hostDebugUnoptDir,
       dartSdkDir: dartSdkDir,
     );
@@ -67,6 +70,7 @@ class Environment {
     required this.engineToolsDir,
     required this.outDir,
     required this.wasmReleaseOutDir,
+    required this.wasmProfileOutDir,
     required this.hostDebugUnoptDir,
     required this.dartSdkDir,
   });
@@ -95,6 +99,9 @@ class Environment {
   ///
   /// We build CanvasKit in release mode to reduce code size.
   final io.Directory wasmReleaseOutDir;
+
+  /// The output directory for the wasm_profile build.
+  final io.Directory wasmProfileOutDir;
 
   /// The output directory for the host_debug_unopt build.
   final io.Directory hostDebugUnoptDir;


### PR DESCRIPTION
When there's a problem in CanvasKit, it's useful to have an easy way to make a profile build. Now passing `--profile` to `felt build` will build everything in profile mode including CanvasKit. The output is located at `wasm_profile` instead of the usual `wasm_release`.

While I'm at it, I also added a target for the `archive`.