### PR TITLE
[Windows] Revert UIA

### DIFF
--- a/shell/platform/windows/BUILD.gn
+++ b/shell/platform/windows/BUILD.gn
@@ -122,10 +122,7 @@ source_set("flutter_windows_source") {
 
   public_configs = [ ":relative_angle_headers" ]
 
-  defines = [
-    "FLUTTER_ENGINE_NO_PROTOTYPES",
-    "FLUTTER_ENGINE_USE_UIA",
-  ]
+  defines = [ "FLUTTER_ENGINE_NO_PROTOTYPES" ]
 
   public_deps = [
     "//flutter/fml:string_conversion",
@@ -229,8 +226,6 @@ executable("flutter_windows_unittests") {
       [ "//flutter/shell/platform/common:desktop_library_implementation" ]
 
   public_configs = [ "//flutter:config" ]
-
-  defines = [ "FLUTTER_ENGINE_USE_UIA" ]
 
   deps = [
     ":flutter_windows_fixtures",

--- a/shell/platform/windows/window_unittests.cc
+++ b/shell/platform/windows/window_unittests.cc
@@ -361,7 +361,7 @@ TEST(MockWindow, UnknownPointerTypeSkipsDirectManipulation) {
 }
 
 // Test that the root UIA object is queried by WM_GETOBJECT.
-TEST(MockWindow, GetObjectUia) {
+TEST(MockWindow, DISABLED_GetObjectUia) {
   MockWindow window;
   bool uia_called = false;
   ON_CALL(window, OnGetObject)


### PR DESCRIPTION
Revert building with UIA by default on Windows. Making this separate PR instead of reverting the original to hopefully keep the testing logic for ensuring it is enabled for when we are ready to re-enable, just leaving it disabled for now.

https://github.com/flutter/flutter/issues/121907

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
