### PR TITLE
[Embedder API] Lock nested structs for ABI stability

### DIFF
--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -25,12 +25,16 @@
 // - Function signatures (names, argument counts, argument order, and argument
 //   type) cannot change.
 // - The core behavior of existing functions cannot change.
+// - Instead of nesting structures by value within another structure, prefer
+//   nesting by pointer. This ensures that adding members to the nested struct
+//   does not break the ABI of the parent struct.
 // - Instead of array of structures, prefer array of pointers to structures.
 //   This ensures that array indexing does not break if members are added
 //   to the structure.
 //
 // These changes are allowed:
-// - Adding new struct members at the end of a structure.
+// - Adding new struct members at the end of a structure as long as the struct
+//   is not nested within another struct by value.
 // - Adding new enum members with a new value.
 // - Renaming a struct member as long as its type, size, and intent remain the
 //   same.

--- a/shell/platform/embedder/tests/embedder_frozen.h
+++ b/shell/platform/embedder/tests/embedder_frozen.h
@@ -22,6 +22,47 @@
 namespace flutter {
 namespace testing {
 
+// New members must not be added to `FlutterTransformation`
+// as it would break the ABI of `FlutterSemanticsNode`.
+// See: https://github.com/flutter/flutter/issues/121176
+typedef struct {
+  double scaleX;
+  double skewX;
+  double transX;
+  double skewY;
+  double scaleY;
+  double transY;
+  double pers0;
+  double pers1;
+  double pers2;
+} FrozenFlutterTransformation;
+
+// New members must not be added to `FlutterRect` as it would
+// break the ABI of `FlutterSemanticsNode` and `FlutterDamage`.
+// See: https://github.com/flutter/flutter/issues/121176
+// See: https://github.com/flutter/flutter/issues/121347
+typedef struct {
+  double left;
+  double top;
+  double right;
+  double bottom;
+} FrozenFlutterRect;
+
+// New members must not be added to `FlutterPoint` as it would
+// break the ABI of `FlutterLayer`.
+typedef struct {
+  double x;
+  double y;
+} FrozenFlutterPoint;
+
+// New members must not be added to `FlutterDamage` as it would
+// break the ABI of `FlutterPresentInfo`.
+typedef struct {
+  size_t struct_size;
+  size_t num_rects;
+  FrozenFlutterRect* damage;
+} FrozenFlutterDamage;
+
 // New members must not be added to `FlutterSemanticsNode`
 // as it would break the ABI of `FlutterSemanticsUpdate`.
 // See: https://github.com/flutter/flutter/issues/121176
@@ -45,8 +86,8 @@ typedef struct {
   const char* increased_value;
   const char* decreased_value;
   FlutterTextDirection text_direction;
-  FlutterRect rect;
-  FlutterTransformation transform;
+  FrozenFlutterRect rect;
+  FrozenFlutterTransformation transform;
   size_t child_count;
   const int32_t* children_in_traversal_order;
   const int32_t* children_in_hit_test_order;

--- a/shell/platform/embedder/tests/embedder_frozen_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_frozen_unittests.cc
@@ -14,6 +14,47 @@ namespace testing {
 #define ASSERT_EQ_OFFSET(type1, type2, member) \
   ASSERT_EQ(offsetof(type1, member), offsetof(type2, member))
 
+// New members must not be added to `FlutterTransformation`
+// as it would break the ABI of `FlutterSemanticsNode`.
+// See: https://github.com/flutter/flutter/issues/121176
+TEST(EmbedderFrozen, FlutterTransformationIsFrozen) {
+  ASSERT_EQ_OFFSET(FlutterTransformation, FrozenFlutterTransformation, scaleX);
+  ASSERT_EQ_OFFSET(FlutterTransformation, FrozenFlutterTransformation, skewX);
+  ASSERT_EQ_OFFSET(FlutterTransformation, FrozenFlutterTransformation, transX);
+  ASSERT_EQ_OFFSET(FlutterTransformation, FrozenFlutterTransformation, skewY);
+  ASSERT_EQ_OFFSET(FlutterTransformation, FrozenFlutterTransformation, scaleY);
+  ASSERT_EQ_OFFSET(FlutterTransformation, FrozenFlutterTransformation, transY);
+  ASSERT_EQ_OFFSET(FlutterTransformation, FrozenFlutterTransformation, pers0);
+  ASSERT_EQ_OFFSET(FlutterTransformation, FrozenFlutterTransformation, pers1);
+  ASSERT_EQ_OFFSET(FlutterTransformation, FrozenFlutterTransformation, pers2);
+}
+
+// New members must not be added to `FlutterRect` as it would
+// break the ABI of `FlutterSemanticsNode` and `FlutterDamage`.
+// See: https://github.com/flutter/flutter/issues/121176
+// See: https://github.com/flutter/flutter/issues/121347
+TEST(EmbedderFrozen, FlutterRectIsFrozen) {
+  ASSERT_EQ_OFFSET(FlutterRect, FrozenFlutterRect, left);
+  ASSERT_EQ_OFFSET(FlutterRect, FrozenFlutterRect, top);
+  ASSERT_EQ_OFFSET(FlutterRect, FrozenFlutterRect, right);
+  ASSERT_EQ_OFFSET(FlutterRect, FrozenFlutterRect, bottom);
+}
+
+// New members must not be added to `FlutterPoint` as it would
+// break the ABI of `FlutterLayer`.
+TEST(EmbedderFrozen, FlutterPointIsFrozen) {
+  ASSERT_EQ_OFFSET(FlutterPoint, FrozenFlutterPoint, x);
+  ASSERT_EQ_OFFSET(FlutterPoint, FrozenFlutterPoint, y);
+}
+
+// New members must not be added to `FlutterDamage` as it would
+// break the ABI of `FlutterPresentInfo`.
+TEST(EmbedderFrozen, FlutterDamageIsFrozen) {
+  ASSERT_EQ_OFFSET(FlutterDamage, FrozenFlutterDamage, struct_size);
+  ASSERT_EQ_OFFSET(FlutterDamage, FrozenFlutterDamage, num_rects);
+  ASSERT_EQ_OFFSET(FlutterDamage, FrozenFlutterDamage, damage);
+}
+
 // New members must not be added to `FlutterSemanticsNode`
 // as it would break the ABI of `FlutterSemanticsUpdate`.
 // See: https://github.com/flutter/flutter/issues/121176


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/121176
Fixes https://github.com/flutter/flutter/issues/121347

## Background

Imagine the following change:

<details>
<summary>Bad change...</summary>

```diff
typedef struct {
  /// The size of this struct. Must be sizeof(A).
  size_t struct_size;
  int one;
+ int two;
} A;

typedef struct {
  /// The size of this struct. Must be sizeof(B).
  size_t struct_size;
  A a;
  int three;
} B;
```

</details>

Adding a member to struct `A` would change the memory layout of struct `B`; this breaks ABI compatibility. The structs' `struct_size` does not protect against this ABI break. Instead, struct `B` should've nested struct `A` by pointer:

<details>
<summary>Good change...</summary>

```diff
typedef struct {
  /// The size of this struct. Must be sizeof(A).
  size_t struct_size;
  int one;
+ int two;
} A;

typedef struct {
  /// The size of this struct. Must be sizeof(B).
  size_t struct_size;
  A* a;
  int three;
} B;
```

</details>

This problem affects the following structs:

1. `FlutterTransformation` - Would break `FlutterSemanticsNode` [here](https://github.com/flutter/engine/blob/3070e61574c0d79be6d6ecc5d0c9c790bb891e0d/shell/platform/embedder/embedder.h#L1102)
2. `FlutterRect` - Would break `FlutterSemanticsNode` [here](https://github.com/flutter/engine/blob/3070e61574c0d79be6d6ecc5d0c9c790bb891e0d/shell/platform/embedder/embedder.h#L1099). Also, `FlutterDamage` is affected by the "array of structs" problem [here](https://github.com/flutter/engine/blob/3070e61574c0d79be6d6ecc5d0c9c790bb891e0d/shell/platform/embedder/embedder.h#L449)
3. `FlutterPoint` would break `FlutterLayer` [here](https://github.com/flutter/engine/blob/3070e61574c0d79be6d6ecc5d0c9c790bb891e0d/shell/platform/embedder/embedder.h#L1439)
4. `FlutterDamage` - Would break `FlutterPresentInfo` [here](https://github.com/flutter/engine/blob/3070e61574c0d79be6d6ecc5d0c9c790bb891e0d/shell/platform/embedder/embedder.h#L486)

I did not include the following nested structs as adding members to them does not seem to introduce any ABI issues:

1. `FlutterSize`
2. `FlutterUIntSize`
3. `FlutterRoundedRect`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
