### PR TITLE
Always use integers to hold the size of the performance overlay cache bitmap

### DIFF
--- a/flow/instrumentation.cc
+++ b/flow/instrumentation.cc
@@ -86,11 +86,11 @@ fml::TimeDelta Stopwatch::AverageDelta() const {
 
 // Initialize the SkSurface for drawing into. Draws the base background and any
 // timing data from before the initial Visualize() call.
-void Stopwatch::InitVisualizeSurface(const SkRect& rect) const {
+void Stopwatch::InitVisualizeSurface(SkISize size) const {
   // Mark as dirty if the size has changed.
   if (visualize_cache_surface_) {
-    if (rect.width() != visualize_cache_surface_->width() ||
-        rect.height() != visualize_cache_surface_->height()) {
+    if (size.width() != visualize_cache_surface_->width() ||
+        size.height() != visualize_cache_surface_->height()) {
       cache_dirty_ = true;
     };
   }
@@ -102,15 +102,15 @@ void Stopwatch::InitVisualizeSurface(const SkRect& rect) const {
 
   // TODO(garyq): Use a GPU surface instead of a CPU surface.
   visualize_cache_surface_ =
-      SkSurface::MakeRasterN32Premul(rect.width(), rect.height());
+      SkSurface::MakeRasterN32Premul(size.width(), size.height());
 
   SkCanvas* cache_canvas = visualize_cache_surface_->getCanvas();
 
   // Establish the graph position.
   const SkScalar x = 0;
   const SkScalar y = 0;
-  const SkScalar width = rect.width();
-  const SkScalar height = rect.height();
+  const SkScalar width = size.width();
+  const SkScalar height = size.height();
 
   SkPaint paint;
   paint.setColor(0x99FFFFFF);
@@ -155,7 +155,7 @@ void Stopwatch::InitVisualizeSurface(const SkRect& rect) const {
 
 void Stopwatch::Visualize(DlCanvas* canvas, const SkRect& rect) const {
   // Initialize visualize cache if it has not yet been initialized.
-  InitVisualizeSurface(rect);
+  InitVisualizeSurface(SkISize::Make(rect.width(), rect.height()));
 
   SkCanvas* cache_canvas = visualize_cache_surface_->getCanvas();
   SkPaint paint;
@@ -163,8 +163,8 @@ void Stopwatch::Visualize(DlCanvas* canvas, const SkRect& rect) const {
   // Establish the graph position.
   const SkScalar x = 0;
   const SkScalar y = 0;
-  const SkScalar width = rect.width();
-  const SkScalar height = rect.height();
+  const SkScalar width = visualize_cache_surface_->width();
+  const SkScalar height = visualize_cache_surface_->height();
 
   // Scale the graph to show frame times up to those that are 3 times the frame
   // time.

--- a/flow/instrumentation.h
+++ b/flow/instrumentation.h
@@ -38,7 +38,7 @@ class Stopwatch {
 
   fml::TimeDelta AverageDelta() const;
 
-  void InitVisualizeSurface(const SkRect& rect) const;
+  void InitVisualizeSurface(SkISize size) const;
 
   void Visualize(DlCanvas* canvas, const SkRect& rect) const;
 


### PR DESCRIPTION
Previously this was comparing a float overlay rectangle size with an integer cache bitmap size.  This could result in mismatches if the overlay width is not an integer.
