### PR TITLE
[Windows] Use the new update semantics embedder API

### DIFF
--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -327,18 +327,19 @@ bool FlutterWindowsEngine::Run(std::string_view entrypoint) {
     auto host = static_cast<FlutterWindowsEngine*>(user_data);
     host->OnPreEngineRestart();
   };
-  args.update_semantics_callback = [](const FlutterSemanticsUpdate* update,
-                                      void* user_data) {
+  args.update_semantics_callback2 = [](const FlutterSemanticsUpdate2* update,
+                                       void* user_data) {
     auto host = static_cast<FlutterWindowsEngine*>(user_data);
 
-    for (size_t i = 0; i < update->nodes_count; i++) {
-      host->accessibility_bridge_->AddFlutterSemanticsNodeUpdate(
-          update->nodes[i]);
+    for (size_t i = 0; i < update->node_count; i++) {
+      const FlutterSemanticsNode2* node = update->nodes[i];
+      host->accessibility_bridge_->AddFlutterSemanticsNodeUpdate(*node);
     }
 
-    for (size_t i = 0; i < update->custom_actions_count; i++) {
+    for (size_t i = 0; i < update->custom_action_count; i++) {
+      const FlutterSemanticsCustomAction2* action = update->custom_actions[i];
       host->accessibility_bridge_->AddFlutterSemanticsCustomActionUpdate(
-          update->custom_actions[i]);
+          *action);
     }
 
     host->accessibility_bridge_->CommitUpdates();

--- a/shell/platform/windows/flutter_windows_engine_unittests.cc
+++ b/shell/platform/windows/flutter_windows_engine_unittests.cc
@@ -60,7 +60,8 @@ TEST_F(FlutterWindowsEngineTest, RunDoesExpectedInitialization) {
         EXPECT_NE(args->custom_task_runners->thread_priority_setter, nullptr);
         EXPECT_EQ(args->custom_dart_entrypoint, nullptr);
         EXPECT_NE(args->vsync_callback, nullptr);
-        EXPECT_NE(args->update_semantics_callback, nullptr);
+        EXPECT_EQ(args->update_semantics_callback, nullptr);
+        EXPECT_NE(args->update_semantics_callback2, nullptr);
         EXPECT_EQ(args->update_semantics_node_callback, nullptr);
         EXPECT_EQ(args->update_semantics_custom_action_callback, nullptr);
 


### PR DESCRIPTION
This moves the Windows embedder to the new update semantics embedder API introduced by https://github.com/flutter/engine/pull/39807. This does not affect functionality hence why existing accessibility integration tests are unaffected.

Part of: https://github.com/flutter/flutter/issues/121176
See [go/flutter-semantics-abi](http://go/flutter-semantics-abi).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
