### PR TITLE
[Impeller] Round glyph locations per-run to fix per-glyph jitter

### DIFF
--- a/impeller/typographer/backends/skia/text_frame_skia.cc
+++ b/impeller/typographer/backends/skia/text_frame_skia.cc
@@ -75,8 +75,9 @@ TextFrame TextFrameFromTextBlob(const sk_sp<SkTextBlob>& blob, Scalar scale) {
                                  ? Glyph::Type::kBitmap
                                  : Glyph::Type::kPath;
 
-          text_run.AddGlyph(Glyph{glyphs[i], type, ToRect(glyph_bounds[i])},
-                            Point{point->x(), point->y()});
+          text_run.AddGlyph(
+              Glyph{glyphs[i], type, ToRect(glyph_bounds[i])},
+              Point{std::round(point->x()), std::round(point->y())});
         }
         break;
       }


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/121531.

Round glyph positions relative to the text run origin so that individual characters in the run will snap to the pixel grid together. Note that as the atlas changes, there may still be a subpixel/antialiasing jitter, but this should be much less apparent than the full 1 pixel jitter that this patch fixes. 

Before:

https://user-images.githubusercontent.com/919017/222868028-9cc38097-92c8-47e1-9b2b-1bcbb5d82a94.mov

After:

https://user-images.githubusercontent.com/919017/222868013-654b7598-07e7-4ae2-a985-e785747bc7af.mov

