### PR TITLE
Separate desktop builds to its own builder.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -261,6 +261,14 @@ targets:
       release_build: "true"
       config_name: linux_host_engine
 
+  - name: Linux linux_host_desktop_engine
+    bringup: true
+    recipe: engine_v2/engine_v2
+    timeout: 60
+    properties:
+      release_build: "true"
+      config_name: linux_host_desktop_engine
+
   - name: Linux linux_android_aot_engine
     recipe: engine_v2/engine_v2
     timeout: 60

--- a/ci/builders/linux_host_desktop_engine.json
+++ b/ci/builders/linux_host_desktop_engine.json
@@ -1,0 +1,105 @@
+{
+    "builds": [
+        {
+            "archives": [
+                {
+                    "name": "host_debug",
+                    "base_path": "out/host_debug/zip_archives/",
+                    "type": "gcs",
+                    "include_paths": [
+                        "out/host_debug/zip_archives/linux-x64-debug/linux-x64-flutter-gtk.zip"
+                    ]
+                }
+            ],
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false
+            },
+            "gn": [
+                "--runtime-mode",
+                "debug",
+                "--enable-fontconfig",
+                "--prebuilt-dart-sdk"
+            ],
+            "name": "host_debug",
+            "ninja": {
+                "config": "host_debug",
+                "targets": [
+                    "flutter/shell/platform/linux:flutter_gtk"
+                ]
+            },
+            "tests": []
+        },
+        {
+            "archives": [
+                {
+                    "name": "host_profile",
+                    "base_path": "out/host_profile/zip_archives/",
+                    "type": "gcs",
+                    "include_paths": [
+                        "out/host_profile/zip_archives/linux-x64-profile/linux-x64-flutter-gtk.zip"
+                    ]
+                }
+            ],
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false
+            },
+            "gn": [
+                "--runtime-mode",
+                "profile",
+                "--no-lto",
+                "--enable-fontconfig",
+                "--prebuilt-dart-sdk"
+            ],
+            "name": "host_profile",
+            "ninja": {
+                "config": "host_profile",
+                "targets": [
+                    "flutter/shell/platform/linux:flutter_gtk"
+                ]
+            },
+            "tests": []
+        },
+        {
+            "archives": [
+                {
+                    "name": "host_release",
+                    "base_path": "out/host_release/zip_archives/",
+                    "type": "gcs",
+                    "include_paths": [
+                        "out/host_release/zip_archives/linux-x64-release/linux-x64-flutter-gtk.zip"
+                    ]
+                }
+            ],
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false
+            },
+            "gn": [
+                "--runtime-mode",
+                "release",
+                "--enable-fontconfig",
+                "--prebuilt-dart-sdk"
+            ],
+            "name": "host_release",
+            "ninja": {
+                "config": "host_release",
+                "targets": [
+                    "flutter/shell/platform/linux:flutter_gtk"
+                ]
+            },
+            "tests": []
+        }
+    ],
+    "tests": []
+}

--- a/ci/builders/linux_host_engine.json
+++ b/ci/builders/linux_host_engine.json
@@ -77,8 +77,7 @@
                         "out/host_debug/zip_archives/linux-x64/linux-x64-embedder.zip",
                         "out/host_debug/zip_archives/linux-x64/font-subset.zip",
                         "out/host_debug/zip_archives/flutter_patched_sdk.zip",
-                        "out/host_debug/zip_archives/dart-sdk-linux-x64.zip",
-                        "out/host_debug/zip_archives/linux-x64-debug/linux-x64-flutter-gtk.zip"
+                        "out/host_debug/zip_archives/dart-sdk-linux-x64.zip"
                     ]
                 }
             ],
@@ -105,7 +104,6 @@
                     "flutter/build/archives:embedder",
                     "flutter/build/archives:flutter_patched_sdk",
                     "flutter/build/dart:copy_dart_sdk",
-                    "flutter/shell/platform/linux:flutter_gtk",
                     "flutter/tools/font-subset"
                 ]
             },
@@ -131,9 +129,7 @@
                     "name": "host_profile",
                     "base_path": "out/host_profile/zip_archives/",
                     "type": "gcs",
-                    "include_paths": [
-                        "out/host_profile/zip_archives/linux-x64-profile/linux-x64-flutter-gtk.zip"
-                    ]
+                    "include_paths": []
                 }
             ],
             "drone_dimensions": [
@@ -157,7 +153,6 @@
                     "flutter/build/dart:copy_dart_sdk",
                     "flutter/shell/testing",
                     "flutter/tools/path_ops",
-                    "flutter/shell/platform/linux:flutter_gtk",
                     "flutter:unittests"
                 ]
             },
@@ -184,8 +179,7 @@
                     "base_path": "out/host_release/zip_archives/",
                     "type": "gcs",
                     "include_paths": [
-                        "out/host_release/zip_archives/flutter_patched_sdk_product.zip",
-                        "out/host_release/zip_archives/linux-x64-release/linux-x64-flutter-gtk.zip"
+                        "out/host_release/zip_archives/flutter_patched_sdk_product.zip"
                     ]
                 }
             ],
@@ -217,7 +211,6 @@
                     "flutter/third_party/txt:txt_benchmarks",
                     "flutter/tools/path_ops",
                     "flutter/build/archives:flutter_patched_sdk",
-                    "flutter/shell/platform/linux:flutter_gtk",
                     "flutter:unittests"
                 ]
             },


### PR DESCRIPTION
Desktop artifacts are generated using the same linux host configurations causing conflicts when generating archives with different gn flags. This PR separates linux desktop builds to its own builder.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
