### PR TITLE
Fix imports for FlutterApplication

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterApplication.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterApplication.mm
@@ -8,7 +8,6 @@
 #import "flutter/shell/platform/darwin/macos/framework/Headers/FlutterAppDelegate.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterAppDelegate_Internal.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h"
-
 #include "flutter/shell/platform/embedder/embedder.h"
 
 // An NSApplication subclass that implements overrides necessary for some

--- a/shell/platform/darwin/macos/framework/Source/FlutterApplication.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterApplication.mm
@@ -5,10 +5,11 @@
 #import "flutter/shell/platform/darwin/macos/framework/Headers/FlutterApplication.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterApplication_Internal.h"
 
+#import "flutter/shell/platform/darwin/macos/framework/Headers/FlutterAppDelegate.h"
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterAppDelegate_Internal.h"
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h"
+
 #include "flutter/shell/platform/embedder/embedder.h"
-#import "shell/platform/darwin/macos/framework/Headers/FlutterAppDelegate.h"
-#import "shell/platform/darwin/macos/framework/Source/FlutterAppDelegate_Internal.h"
-#import "shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h"
 
 // An NSApplication subclass that implements overrides necessary for some
 // Flutter features, like application lifecycle handling.


### PR DESCRIPTION
## Description

In https://github.com/flutter/engine/pull/39836, There were some includes that VSCode added that didn't have the correct path, although they do compile in the engine repo, they cause problems when rolled to Google's internal repo because they don't have the correct prefix.

For future archaeologists, the setting to stop clangd from inserting headers that it doesn't really know how to insert properly is:
```json
    "clangd.arguments": [
        "--header-insertion=never"
    ],
```