### PR TITLE
[Impeller] Fix the test 'Play/DisplayListTest.CanDrawBackdropFilter/Metal'

### DIFF
--- a/impeller/display_list/display_list_unittests.cc
+++ b/impeller/display_list/display_list_unittests.cc
@@ -564,7 +564,7 @@ TEST_P(DisplayListTest, CanDrawBackdropFilter) {
 
     builder.drawImage(DlImageImpeller::Make(texture), SkPoint::Make(200, 200),
                       flutter::DlImageSampling::kNearestNeighbor, true);
-    builder.saveLayer(bounds.has_value() ? &bounds.value() : nullptr, nullptr,
+    builder.SaveLayer(bounds.has_value() ? &bounds.value() : nullptr, nullptr,
                       &filter);
 
     if (draw_circle) {


### PR DESCRIPTION
fix https://github.com/flutter/flutter/issues/122064

Related PR: https://github.com/flutter/engine/pull/39762 which modified 'saveLayer' to 'SaveLayer'

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

