### PR TITLE
Add missing inputs declaration

### DIFF
--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -53,6 +53,7 @@ executable("flutter_shell_native_unittests") {
 }
 
 shared_library("flutter_shell_native") {
+  inputs = [ "android_exports.lst" ]
   output_name = "flutter"
   deps = [ ":flutter_shell_native_src" ]
   ldflags = [ "-Wl,--version-script=" + rebase_path("android_exports.lst") ]


### PR DESCRIPTION
  inputs = [ "android_exports.lst" ]
was missing from the flutter_shell_native rule, which meant if you edited android_exports.lst it would not notice and would not rebuild/relink.

## Pre-launch Checklist

- [x ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x ] I updated/added relevant documentation (doc comments with `///`).
- [ x] I signed the [CLA].
- [ x] All existing and new tests are passing.
