### PR TITLE
Update RecursiveVisitor type in const_finder

### DIFF
--- a/tools/const_finder/lib/const_finder.dart
+++ b/tools/const_finder/lib/const_finder.dart
@@ -6,7 +6,7 @@ import 'dart:collection';
 
 import 'package:kernel/kernel.dart';
 
-class _ConstVisitor extends RecursiveVisitor<void> {
+class _ConstVisitor extends RecursiveVisitor {
   _ConstVisitor(
     this.kernelFilePath,
     this.classLibraryUri,


### PR DESCRIPTION
`RecursiveVisitor` type parameter is not used by the class and it will soon be removed.