### PR TITLE
Remove unused gn target.

### DIFF
--- a/build/dart/BUILD.gn
+++ b/build/dart/BUILD.gn
@@ -17,20 +17,6 @@ pool("dart_pool") {
   depth = concurrent_dart_jobs
 }
 
-if (flutter_prebuilt_dart_sdk) {
-  copy_trees("_copy_trees") {
-    sources = [
-      {
-        target = "copy_dart_sdk"
-        visibility = [ ":dart_sdk" ]
-        source = prebuilt_dart_sdk
-        dest = "$root_out_dir/dart-sdk"
-        ignore_patterns = "{}"
-      },
-    ]
-  }
-}
-
 if (build_engine_artifacts) {
   group("dart_sdk") {
     if (flutter_prebuilt_dart_sdk) {


### PR DESCRIPTION
This target is causing us to not be able to build emscripten targets without the dart prebuilts. This isn't really used anyway, so it's better to remove it.