### PR TITLE
[web] Fix SkParagraphBuilder tests for the chromium variant

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/text.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/text.dart
@@ -985,14 +985,7 @@ class CkParagraphBuilder implements ui.ParagraphBuilder {
   /// Builds the CkParagraph with the builder and deletes the builder.
   SkParagraph _buildSkParagraph() {
     if (canvasKitVariant == CanvasKitVariant.chromium) {
-      final String text = _paragraphBuilder.getText();
-      _paragraphBuilder.setWordsUtf16(
-        fragmentUsingIntlSegmenter(text, IntlSegmenterGranularity.word),
-      );
-      _paragraphBuilder.setGraphemeBreaksUtf16(
-        fragmentUsingIntlSegmenter(text, IntlSegmenterGranularity.grapheme),
-      );
-      _paragraphBuilder.setLineBreaksUtf16(fragmentUsingV8LineBreaker(text));
+      injectClientICU(_paragraphBuilder);
     }
     final SkParagraph result = _paragraphBuilder.build();
     _paragraphBuilder.delete();

--- a/lib/web_ui/lib/src/engine/canvaskit/text_fragmenter.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/text_fragmenter.dart
@@ -7,6 +7,27 @@ import 'dart:typed_data';
 import '../dom.dart';
 import '../text/line_breaker.dart';
 import 'canvaskit_api.dart';
+import 'renderer.dart';
+
+/// Injects required ICU data into the [builder].
+///
+/// This should only be used with the CanvasKit Chromium variant that's compiled
+/// without ICU data.
+void injectClientICU(SkParagraphBuilder builder) {
+  assert(
+    canvasKitVariant == CanvasKitVariant.chromium,
+    'This method should only be used with the CanvasKit Chromium variant.',
+  );
+
+  final String text = builder.getText();
+  builder.setWordsUtf16(
+    fragmentUsingIntlSegmenter(text, IntlSegmenterGranularity.word),
+  );
+  builder.setGraphemeBreaksUtf16(
+    fragmentUsingIntlSegmenter(text, IntlSegmenterGranularity.grapheme),
+  );
+  builder.setLineBreaksUtf16(fragmentUsingV8LineBreaker(text));
+}
 
 /// The granularity at which to segment text.
 ///

--- a/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
+++ b/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
@@ -1624,6 +1624,9 @@ void _paragraphTests() {
     builder.pushStyle(
         canvasKit.TextStyle(SkTextStyleProperties()..halfLeading = true));
     builder.pop();
+    if (canvasKitVariant == CanvasKitVariant.chromium) {
+      injectClientICU(builder);
+    }
     final SkParagraph paragraph = builder.build();
     paragraph.layout(500);
 
@@ -1738,6 +1741,10 @@ void _paragraphTests() {
       CanvasKitRenderer.instance.fontCollection.fontProvider,
     );
     builder.addText('hello');
+
+    if (canvasKitVariant == CanvasKitVariant.chromium) {
+      injectClientICU(builder);
+    }
 
     final SkParagraph paragraph = builder.build();
     paragraph.layout(500);


### PR DESCRIPTION
In tests, when we use the `SkParagraphBuilder` APIs directly (bypassing our `CkParagraphBuilder`) then we need to explicitly pass any client ICU data that it needs.