### PR TITLE
[Desktop] Use references for semantics update

### DIFF
--- a/shell/platform/common/accessibility_bridge.cc
+++ b/shell/platform/common/accessibility_bridge.cc
@@ -37,13 +37,13 @@ AccessibilityBridge::~AccessibilityBridge() {
 }
 
 void AccessibilityBridge::AddFlutterSemanticsNodeUpdate(
-    const FlutterSemanticsNode* node) {
-  pending_semantics_node_updates_[node->id] = FromFlutterSemanticsNode(node);
+    const FlutterSemanticsNode& node) {
+  pending_semantics_node_updates_[node.id] = FromFlutterSemanticsNode(node);
 }
 
 void AccessibilityBridge::AddFlutterSemanticsCustomActionUpdate(
-    const FlutterSemanticsCustomAction* action) {
-  pending_semantics_custom_action_updates_[action->id] =
+    const FlutterSemanticsCustomAction& action) {
+  pending_semantics_custom_action_updates_[action.id] =
       FromFlutterSemanticsCustomAction(action);
 }
 
@@ -578,66 +578,66 @@ void AccessibilityBridge::SetTreeData(const SemanticsNode& node,
 
 AccessibilityBridge::SemanticsNode
 AccessibilityBridge::FromFlutterSemanticsNode(
-    const FlutterSemanticsNode* flutter_node) {
+    const FlutterSemanticsNode& flutter_node) {
   SemanticsNode result;
-  result.id = flutter_node->id;
-  result.flags = flutter_node->flags;
-  result.actions = flutter_node->actions;
-  result.text_selection_base = flutter_node->text_selection_base;
-  result.text_selection_extent = flutter_node->text_selection_extent;
-  result.scroll_child_count = flutter_node->scroll_child_count;
-  result.scroll_index = flutter_node->scroll_index;
-  result.scroll_position = flutter_node->scroll_position;
-  result.scroll_extent_max = flutter_node->scroll_extent_max;
-  result.scroll_extent_min = flutter_node->scroll_extent_min;
-  result.elevation = flutter_node->elevation;
-  result.thickness = flutter_node->thickness;
-  if (flutter_node->label) {
-    result.label = std::string(flutter_node->label);
+  result.id = flutter_node.id;
+  result.flags = flutter_node.flags;
+  result.actions = flutter_node.actions;
+  result.text_selection_base = flutter_node.text_selection_base;
+  result.text_selection_extent = flutter_node.text_selection_extent;
+  result.scroll_child_count = flutter_node.scroll_child_count;
+  result.scroll_index = flutter_node.scroll_index;
+  result.scroll_position = flutter_node.scroll_position;
+  result.scroll_extent_max = flutter_node.scroll_extent_max;
+  result.scroll_extent_min = flutter_node.scroll_extent_min;
+  result.elevation = flutter_node.elevation;
+  result.thickness = flutter_node.thickness;
+  if (flutter_node.label) {
+    result.label = std::string(flutter_node.label);
   }
-  if (flutter_node->hint) {
-    result.hint = std::string(flutter_node->hint);
+  if (flutter_node.hint) {
+    result.hint = std::string(flutter_node.hint);
   }
-  if (flutter_node->value) {
-    result.value = std::string(flutter_node->value);
+  if (flutter_node.value) {
+    result.value = std::string(flutter_node.value);
   }
-  if (flutter_node->increased_value) {
-    result.increased_value = std::string(flutter_node->increased_value);
+  if (flutter_node.increased_value) {
+    result.increased_value = std::string(flutter_node.increased_value);
   }
-  if (flutter_node->decreased_value) {
-    result.decreased_value = std::string(flutter_node->decreased_value);
+  if (flutter_node.decreased_value) {
+    result.decreased_value = std::string(flutter_node.decreased_value);
   }
-  if (flutter_node->tooltip) {
-    result.tooltip = std::string(flutter_node->tooltip);
+  if (flutter_node.tooltip) {
+    result.tooltip = std::string(flutter_node.tooltip);
   }
-  result.text_direction = flutter_node->text_direction;
-  result.rect = flutter_node->rect;
-  result.transform = flutter_node->transform;
-  if (flutter_node->child_count > 0) {
+  result.text_direction = flutter_node.text_direction;
+  result.rect = flutter_node.rect;
+  result.transform = flutter_node.transform;
+  if (flutter_node.child_count > 0) {
     result.children_in_traversal_order = std::vector<int32_t>(
-        flutter_node->children_in_traversal_order,
-        flutter_node->children_in_traversal_order + flutter_node->child_count);
+        flutter_node.children_in_traversal_order,
+        flutter_node.children_in_traversal_order + flutter_node.child_count);
   }
-  if (flutter_node->custom_accessibility_actions_count > 0) {
+  if (flutter_node.custom_accessibility_actions_count > 0) {
     result.custom_accessibility_actions = std::vector<int32_t>(
-        flutter_node->custom_accessibility_actions,
-        flutter_node->custom_accessibility_actions +
-            flutter_node->custom_accessibility_actions_count);
+        flutter_node.custom_accessibility_actions,
+        flutter_node.custom_accessibility_actions +
+            flutter_node.custom_accessibility_actions_count);
   }
   return result;
 }
 
 AccessibilityBridge::SemanticsCustomAction
 AccessibilityBridge::FromFlutterSemanticsCustomAction(
-    const FlutterSemanticsCustomAction* flutter_custom_action) {
+    const FlutterSemanticsCustomAction& flutter_custom_action) {
   SemanticsCustomAction result;
-  result.id = flutter_custom_action->id;
-  result.override_action = flutter_custom_action->override_action;
-  if (flutter_custom_action->label) {
-    result.label = std::string(flutter_custom_action->label);
+  result.id = flutter_custom_action.id;
+  result.override_action = flutter_custom_action.override_action;
+  if (flutter_custom_action.label) {
+    result.label = std::string(flutter_custom_action.label);
   }
-  if (flutter_custom_action->hint) {
-    result.hint = std::string(flutter_custom_action->hint);
+  if (flutter_custom_action.hint) {
+    result.hint = std::string(flutter_custom_action.hint);
   }
   return result;
 }

--- a/shell/platform/common/accessibility_bridge.h
+++ b/shell/platform/common/accessibility_bridge.h
@@ -60,7 +60,7 @@ class AccessibilityBridge
   ///             Calling this method alone will NOT update the semantics tree.
   ///             To flush the pending updates, call the CommitUpdates().
   ///
-  /// @param[in]  node           A pointer to the semantics node update.
+  /// @param[in]  node           A reference to the semantics node update.
   void AddFlutterSemanticsNodeUpdate(const FlutterSemanticsNode& node);
 
   //------------------------------------------------------------------------------
@@ -69,7 +69,7 @@ class AccessibilityBridge
   ///             semantics tree. To flush the pending updates, call the
   ///             CommitUpdates().
   ///
-  /// @param[in]  action           A pointer to the custom semantics action
+  /// @param[in]  action           A reference to the custom semantics action
   ///                              update.
   void AddFlutterSemanticsCustomActionUpdate(
       const FlutterSemanticsCustomAction& action);

--- a/shell/platform/common/accessibility_bridge.h
+++ b/shell/platform/common/accessibility_bridge.h
@@ -61,7 +61,7 @@ class AccessibilityBridge
   ///             To flush the pending updates, call the CommitUpdates().
   ///
   /// @param[in]  node           A pointer to the semantics node update.
-  void AddFlutterSemanticsNodeUpdate(const FlutterSemanticsNode* node);
+  void AddFlutterSemanticsNodeUpdate(const FlutterSemanticsNode& node);
 
   //------------------------------------------------------------------------------
   /// @brief      Adds a custom semantics action update to the pending semantics
@@ -72,7 +72,7 @@ class AccessibilityBridge
   /// @param[in]  action           A pointer to the custom semantics action
   ///                              update.
   void AddFlutterSemanticsCustomActionUpdate(
-      const FlutterSemanticsCustomAction* action);
+      const FlutterSemanticsCustomAction& action);
 
   //------------------------------------------------------------------------------
   /// @brief      Flushes the pending updates and applies them to this
@@ -252,9 +252,9 @@ class AccessibilityBridge
                                    const SemanticsNode& node);
   void SetTreeData(const SemanticsNode& node, ui::AXTreeUpdate& tree_update);
   SemanticsNode FromFlutterSemanticsNode(
-      const FlutterSemanticsNode* flutter_node);
+      const FlutterSemanticsNode& flutter_node);
   SemanticsCustomAction FromFlutterSemanticsCustomAction(
-      const FlutterSemanticsCustomAction* flutter_custom_action);
+      const FlutterSemanticsCustomAction& flutter_custom_action);
 
   // |AXTreeObserver|
   void OnNodeWillBeDeleted(ui::AXTree* tree, ui::AXNode* node) override;

--- a/shell/platform/common/accessibility_bridge_unittests.cc
+++ b/shell/platform/common/accessibility_bridge_unittests.cc
@@ -46,9 +46,9 @@ TEST(AccessibilityBridgeTest, BasicTest) {
   FlutterSemanticsNode child1 = CreateSemanticsNode(1, "child 1");
   FlutterSemanticsNode child2 = CreateSemanticsNode(2, "child 2");
 
-  bridge->AddFlutterSemanticsNodeUpdate(&root);
-  bridge->AddFlutterSemanticsNodeUpdate(&child1);
-  bridge->AddFlutterSemanticsNodeUpdate(&child2);
+  bridge->AddFlutterSemanticsNodeUpdate(root);
+  bridge->AddFlutterSemanticsNodeUpdate(child1);
+  bridge->AddFlutterSemanticsNodeUpdate(child2);
   bridge->CommitUpdates();
 
   auto root_node = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
@@ -78,9 +78,9 @@ TEST(AccessibilityBridgeTest, AccessibilityRootId) {
   FlutterSemanticsNode child1 = CreateSemanticsNode(456, "child 1");
   FlutterSemanticsNode child2 = CreateSemanticsNode(789, "child 2");
 
-  bridge->AddFlutterSemanticsNodeUpdate(&root);
-  bridge->AddFlutterSemanticsNodeUpdate(&child1);
-  bridge->AddFlutterSemanticsNodeUpdate(&child2);
+  bridge->AddFlutterSemanticsNodeUpdate(root);
+  bridge->AddFlutterSemanticsNodeUpdate(child1);
+  bridge->AddFlutterSemanticsNodeUpdate(child2);
   bridge->CommitUpdates();
 
   auto root_node = bridge->GetFlutterPlatformNodeDelegateFromID(123).lock();
@@ -121,11 +121,11 @@ TEST(AccessibilityBridgeTest, AddOrder) {
       CreateSemanticsNode(78, "child 3", &child3_children);
   FlutterSemanticsNode child4 = CreateSemanticsNode(90, "child 4");
 
-  bridge->AddFlutterSemanticsNodeUpdate(&child3);
-  bridge->AddFlutterSemanticsNodeUpdate(&child2);
-  bridge->AddFlutterSemanticsNodeUpdate(&root);
-  bridge->AddFlutterSemanticsNodeUpdate(&child1);
-  bridge->AddFlutterSemanticsNodeUpdate(&child4);
+  bridge->AddFlutterSemanticsNodeUpdate(child3);
+  bridge->AddFlutterSemanticsNodeUpdate(child2);
+  bridge->AddFlutterSemanticsNodeUpdate(root);
+  bridge->AddFlutterSemanticsNodeUpdate(child1);
+  bridge->AddFlutterSemanticsNodeUpdate(child4);
   bridge->CommitUpdates();
 
   auto root_node = bridge->GetFlutterPlatformNodeDelegateFromID(12).lock();
@@ -165,8 +165,8 @@ TEST(AccessibilityBridgeTest, CanFireChildrenChangedCorrectly) {
   FlutterSemanticsNode root = CreateSemanticsNode(0, "root", &children);
   FlutterSemanticsNode child1 = CreateSemanticsNode(1, "child 1");
 
-  bridge->AddFlutterSemanticsNodeUpdate(&root);
-  bridge->AddFlutterSemanticsNodeUpdate(&child1);
+  bridge->AddFlutterSemanticsNodeUpdate(root);
+  bridge->AddFlutterSemanticsNodeUpdate(child1);
 
   bridge->CommitUpdates();
 
@@ -187,8 +187,8 @@ TEST(AccessibilityBridgeTest, CanFireChildrenChangedCorrectly) {
 
   FlutterSemanticsNode child2 = CreateSemanticsNode(2, "child 2");
 
-  bridge->AddFlutterSemanticsNodeUpdate(&root);
-  bridge->AddFlutterSemanticsNodeUpdate(&child2);
+  bridge->AddFlutterSemanticsNodeUpdate(root);
+  bridge->AddFlutterSemanticsNodeUpdate(child2);
   bridge->CommitUpdates();
 
   root_node = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
@@ -213,8 +213,8 @@ TEST(AccessibilityBridgeTest, CanRecreateNodeDelegates) {
   FlutterSemanticsNode root = CreateSemanticsNode(0, "root", &children);
   FlutterSemanticsNode child1 = CreateSemanticsNode(1, "child 1");
 
-  bridge->AddFlutterSemanticsNodeUpdate(&root);
-  bridge->AddFlutterSemanticsNodeUpdate(&child1);
+  bridge->AddFlutterSemanticsNodeUpdate(root);
+  bridge->AddFlutterSemanticsNodeUpdate(child1);
   bridge->CommitUpdates();
 
   auto root_node = bridge->GetFlutterPlatformNodeDelegateFromID(0);
@@ -246,7 +246,7 @@ TEST(AccessibilityBridgeTest, CanHandleSelectionChangeCorrectly) {
   root.flags = static_cast<FlutterSemanticsFlag>(
       FlutterSemanticsFlag::kFlutterSemanticsFlagIsTextField |
       FlutterSemanticsFlag::kFlutterSemanticsFlagIsFocused);
-  bridge->AddFlutterSemanticsNodeUpdate(&root);
+  bridge->AddFlutterSemanticsNodeUpdate(root);
   bridge->CommitUpdates();
 
   const ui::AXTreeData& tree = bridge->GetAXTreeData();
@@ -256,7 +256,7 @@ TEST(AccessibilityBridgeTest, CanHandleSelectionChangeCorrectly) {
   // Update the selection.
   root.text_selection_base = 0;
   root.text_selection_extent = 5;
-  bridge->AddFlutterSemanticsNodeUpdate(&root);
+  bridge->AddFlutterSemanticsNodeUpdate(root);
 
   bridge->CommitUpdates();
 
@@ -278,7 +278,7 @@ TEST(AccessibilityBridgeTest, DoesNotAssignEditableRootToSelectableText) {
   root.flags = static_cast<FlutterSemanticsFlag>(
       FlutterSemanticsFlag::kFlutterSemanticsFlagIsTextField |
       FlutterSemanticsFlag::kFlutterSemanticsFlagIsReadOnly);
-  bridge->AddFlutterSemanticsNodeUpdate(&root);
+  bridge->AddFlutterSemanticsNodeUpdate(root);
   bridge->CommitUpdates();
 
   auto root_node = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
@@ -295,7 +295,7 @@ TEST(AccessibilityBridgeTest, ToggleHasToggleButtonRole) {
       FlutterSemanticsFlag::kFlutterSemanticsFlagHasToggledState |
       FlutterSemanticsFlag::kFlutterSemanticsFlagHasEnabledState |
       FlutterSemanticsFlag::kFlutterSemanticsFlagIsEnabled);
-  bridge->AddFlutterSemanticsNodeUpdate(&root);
+  bridge->AddFlutterSemanticsNodeUpdate(root);
   bridge->CommitUpdates();
 
   auto root_node = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
@@ -311,7 +311,7 @@ TEST(AccessibilityBridgeTest, SliderHasSliderRole) {
       FlutterSemanticsFlag::kFlutterSemanticsFlagHasEnabledState |
       FlutterSemanticsFlag::kFlutterSemanticsFlagIsEnabled |
       FlutterSemanticsFlag::kFlutterSemanticsFlagIsFocusable);
-  bridge->AddFlutterSemanticsNodeUpdate(&root);
+  bridge->AddFlutterSemanticsNodeUpdate(root);
   bridge->CommitUpdates();
 
   auto root_node = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
@@ -330,7 +330,7 @@ TEST(AccessibilityBridgeTest, CanSetCheckboxChecked) {
   root.flags = static_cast<FlutterSemanticsFlag>(
       FlutterSemanticsFlag::kFlutterSemanticsFlagHasCheckedState |
       FlutterSemanticsFlag::kFlutterSemanticsFlagIsChecked);
-  bridge->AddFlutterSemanticsNodeUpdate(&root);
+  bridge->AddFlutterSemanticsNodeUpdate(root);
   bridge->CommitUpdates();
 
   auto root_node = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
@@ -351,9 +351,9 @@ TEST(AccessibilityBridgeTest, CanReparentNode) {
       CreateSemanticsNode(1, "child 1", &child1_children);
   FlutterSemanticsNode child2 = CreateSemanticsNode(2, "child 2");
 
-  bridge->AddFlutterSemanticsNodeUpdate(&root);
-  bridge->AddFlutterSemanticsNodeUpdate(&child1);
-  bridge->AddFlutterSemanticsNodeUpdate(&child2);
+  bridge->AddFlutterSemanticsNodeUpdate(root);
+  bridge->AddFlutterSemanticsNodeUpdate(child1);
+  bridge->AddFlutterSemanticsNodeUpdate(child2);
   bridge->CommitUpdates();
   bridge->accessibility_events.clear();
 
@@ -365,9 +365,9 @@ TEST(AccessibilityBridgeTest, CanReparentNode) {
   root.child_count = 2;
   root.children_in_traversal_order = new_root_children;
 
-  bridge->AddFlutterSemanticsNodeUpdate(&root);
-  bridge->AddFlutterSemanticsNodeUpdate(&child1);
-  bridge->AddFlutterSemanticsNodeUpdate(&child2);
+  bridge->AddFlutterSemanticsNodeUpdate(root);
+  bridge->AddFlutterSemanticsNodeUpdate(child1);
+  bridge->AddFlutterSemanticsNodeUpdate(child2);
   bridge->CommitUpdates();
 
   auto root_node = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
@@ -427,12 +427,12 @@ TEST(AccessibilityBridgeTest, CanReparentMultipleNodes) {
   FlutterSemanticsNode leaf2 = CreateSemanticsNode(leaf2_id, "leaf 2");
   FlutterSemanticsNode leaf3 = CreateSemanticsNode(leaf3_id, "leaf 3");
 
-  bridge->AddFlutterSemanticsNodeUpdate(&root);
-  bridge->AddFlutterSemanticsNodeUpdate(&intermediary1);
-  bridge->AddFlutterSemanticsNodeUpdate(&intermediary2);
-  bridge->AddFlutterSemanticsNodeUpdate(&leaf1);
-  bridge->AddFlutterSemanticsNodeUpdate(&leaf2);
-  bridge->AddFlutterSemanticsNodeUpdate(&leaf3);
+  bridge->AddFlutterSemanticsNodeUpdate(root);
+  bridge->AddFlutterSemanticsNodeUpdate(intermediary1);
+  bridge->AddFlutterSemanticsNodeUpdate(intermediary2);
+  bridge->AddFlutterSemanticsNodeUpdate(leaf1);
+  bridge->AddFlutterSemanticsNodeUpdate(leaf2);
+  bridge->AddFlutterSemanticsNodeUpdate(leaf3);
   bridge->CommitUpdates();
   bridge->accessibility_events.clear();
 
@@ -445,11 +445,11 @@ TEST(AccessibilityBridgeTest, CanReparentMultipleNodes) {
   intermediary2.child_count = 1;
   intermediary2.children_in_traversal_order = new_intermediary2_children;
 
-  bridge->AddFlutterSemanticsNodeUpdate(&intermediary1);
-  bridge->AddFlutterSemanticsNodeUpdate(&intermediary2);
-  bridge->AddFlutterSemanticsNodeUpdate(&leaf1);
-  bridge->AddFlutterSemanticsNodeUpdate(&leaf2);
-  bridge->AddFlutterSemanticsNodeUpdate(&leaf3);
+  bridge->AddFlutterSemanticsNodeUpdate(intermediary1);
+  bridge->AddFlutterSemanticsNodeUpdate(intermediary2);
+  bridge->AddFlutterSemanticsNodeUpdate(leaf1);
+  bridge->AddFlutterSemanticsNodeUpdate(leaf2);
+  bridge->AddFlutterSemanticsNodeUpdate(leaf3);
   bridge->CommitUpdates();
 
   auto root_node = bridge->GetFlutterPlatformNodeDelegateFromID(root_id).lock();
@@ -516,10 +516,10 @@ TEST(AccessibilityBridgeTest, CanReparentNodeWithChild) {
       CreateSemanticsNode(intermediary2_id, "intermediary 2");
   FlutterSemanticsNode leaf1 = CreateSemanticsNode(leaf1_id, "leaf 1");
 
-  bridge->AddFlutterSemanticsNodeUpdate(&root);
-  bridge->AddFlutterSemanticsNodeUpdate(&intermediary1);
-  bridge->AddFlutterSemanticsNodeUpdate(&intermediary2);
-  bridge->AddFlutterSemanticsNodeUpdate(&leaf1);
+  bridge->AddFlutterSemanticsNodeUpdate(root);
+  bridge->AddFlutterSemanticsNodeUpdate(intermediary1);
+  bridge->AddFlutterSemanticsNodeUpdate(intermediary2);
+  bridge->AddFlutterSemanticsNodeUpdate(leaf1);
   bridge->CommitUpdates();
   bridge->accessibility_events.clear();
 
@@ -532,10 +532,10 @@ TEST(AccessibilityBridgeTest, CanReparentNodeWithChild) {
   intermediary2.child_count = 1;
   intermediary2.children_in_traversal_order = new_intermediary2_children;
 
-  bridge->AddFlutterSemanticsNodeUpdate(&root);
-  bridge->AddFlutterSemanticsNodeUpdate(&intermediary1);
-  bridge->AddFlutterSemanticsNodeUpdate(&intermediary2);
-  bridge->AddFlutterSemanticsNodeUpdate(&leaf1);
+  bridge->AddFlutterSemanticsNodeUpdate(root);
+  bridge->AddFlutterSemanticsNodeUpdate(intermediary1);
+  bridge->AddFlutterSemanticsNodeUpdate(intermediary2);
+  bridge->AddFlutterSemanticsNodeUpdate(leaf1);
   bridge->CommitUpdates();
 
   auto root_node = bridge->GetFlutterPlatformNodeDelegateFromID(root_id).lock();
@@ -595,7 +595,7 @@ TEST(AccessibilityBridgeTest, LineBreakingObjectTest) {
 
   FlutterSemanticsNode root = CreateSemanticsNode(root_id, "root", {});
 
-  bridge->AddFlutterSemanticsNodeUpdate(&root);
+  bridge->AddFlutterSemanticsNodeUpdate(root);
   bridge->CommitUpdates();
 
   auto root_node = bridge->GetFlutterPlatformNodeDelegateFromID(root_id).lock();

--- a/shell/platform/common/flutter_platform_node_delegate_unittests.cc
+++ b/shell/platform/common/flutter_platform_node_delegate_unittests.cc
@@ -28,8 +28,8 @@ TEST(FlutterPlatformNodeDelegateTest, NodeDelegateHasUniqueId) {
   node1.label = "prefecture";
   node1.value = "Kyoto";
 
-  bridge->AddFlutterSemanticsNodeUpdate(&node0);
-  bridge->AddFlutterSemanticsNodeUpdate(&node1);
+  bridge->AddFlutterSemanticsNodeUpdate(node0);
+  bridge->AddFlutterSemanticsNodeUpdate(node1);
   bridge->CommitUpdates();
 
   auto node0_delegate = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
@@ -54,7 +54,7 @@ TEST(FlutterPlatformNodeDelegateTest, canPerfomActions) {
   root.tooltip = "";
   root.child_count = 0;
   root.custom_accessibility_actions_count = 0;
-  bridge->AddFlutterSemanticsNodeUpdate(&root);
+  bridge->AddFlutterSemanticsNodeUpdate(root);
 
   bridge->CommitUpdates();
 
@@ -99,7 +99,7 @@ TEST(FlutterPlatformNodeDelegateTest, canGetAXNode) {
   root.tooltip = "";
   root.child_count = 0;
   root.custom_accessibility_actions_count = 0;
-  bridge->AddFlutterSemanticsNodeUpdate(&root);
+  bridge->AddFlutterSemanticsNodeUpdate(root);
 
   bridge->CommitUpdates();
 
@@ -124,7 +124,7 @@ TEST(FlutterPlatformNodeDelegateTest, canCalculateBoundsCorrectly) {
   root.custom_accessibility_actions_count = 0;
   root.rect = {0, 0, 100, 100};  // LTRB
   root.transform = {1, 0, 0, 0, 1, 0, 0, 0, 1};
-  bridge->AddFlutterSemanticsNodeUpdate(&root);
+  bridge->AddFlutterSemanticsNodeUpdate(root);
 
   FlutterSemanticsNode child1;
   child1.id = 1;
@@ -138,7 +138,7 @@ TEST(FlutterPlatformNodeDelegateTest, canCalculateBoundsCorrectly) {
   child1.custom_accessibility_actions_count = 0;
   child1.rect = {0, 0, 50, 50};  // LTRB
   child1.transform = {0.5, 0, 0, 0, 0.5, 0, 0, 0, 1};
-  bridge->AddFlutterSemanticsNodeUpdate(&child1);
+  bridge->AddFlutterSemanticsNodeUpdate(child1);
 
   bridge->CommitUpdates();
   auto child1_node = bridge->GetFlutterPlatformNodeDelegateFromID(1).lock();
@@ -170,7 +170,7 @@ TEST(FlutterPlatformNodeDelegateTest, canCalculateOffScreenBoundsCorrectly) {
   root.custom_accessibility_actions_count = 0;
   root.rect = {0, 0, 100, 100};  // LTRB
   root.transform = {1, 0, 0, 0, 1, 0, 0, 0, 1};
-  bridge->AddFlutterSemanticsNodeUpdate(&root);
+  bridge->AddFlutterSemanticsNodeUpdate(root);
 
   FlutterSemanticsNode child1;
   child1.id = 1;
@@ -184,7 +184,7 @@ TEST(FlutterPlatformNodeDelegateTest, canCalculateOffScreenBoundsCorrectly) {
   child1.custom_accessibility_actions_count = 0;
   child1.rect = {90, 90, 100, 100};  // LTRB
   child1.transform = {2, 0, 0, 0, 2, 0, 0, 0, 1};
-  bridge->AddFlutterSemanticsNodeUpdate(&child1);
+  bridge->AddFlutterSemanticsNodeUpdate(child1);
 
   bridge->CommitUpdates();
   auto child1_node = bridge->GetFlutterPlatformNodeDelegateFromID(1).lock();
@@ -216,7 +216,7 @@ TEST(FlutterPlatformNodeDelegateTest, canUseOwnerBridge) {
   root.custom_accessibility_actions_count = 0;
   root.rect = {0, 0, 100, 100};  // LTRB
   root.transform = {1, 0, 0, 0, 1, 0, 0, 0, 1};
-  bridge->AddFlutterSemanticsNodeUpdate(&root);
+  bridge->AddFlutterSemanticsNodeUpdate(root);
 
   FlutterSemanticsNode child1;
   child1.id = 1;
@@ -230,7 +230,7 @@ TEST(FlutterPlatformNodeDelegateTest, canUseOwnerBridge) {
   child1.custom_accessibility_actions_count = 0;
   child1.rect = {0, 0, 50, 50};  // LTRB
   child1.transform = {0.5, 0, 0, 0, 0.5, 0, 0, 0, 1};
-  bridge->AddFlutterSemanticsNodeUpdate(&child1);
+  bridge->AddFlutterSemanticsNodeUpdate(child1);
 
   bridge->CommitUpdates();
   auto child1_node = bridge->GetFlutterPlatformNodeDelegateFromID(1).lock();
@@ -260,7 +260,7 @@ TEST(FlutterPlatformNodeDelegateTest, selfIsLowestPlatformAncestor) {
   root.child_count = 0;
   root.children_in_traversal_order = nullptr;
   root.custom_accessibility_actions_count = 0;
-  bridge->AddFlutterSemanticsNodeUpdate(&root);
+  bridge->AddFlutterSemanticsNodeUpdate(root);
 
   bridge->CommitUpdates();
   auto root_node = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
@@ -283,7 +283,7 @@ TEST(FlutterPlatformNodeDelegateTest, canGetFromNodeID) {
   int32_t children[] = {1};
   root.children_in_traversal_order = children;
   root.custom_accessibility_actions_count = 0;
-  bridge->AddFlutterSemanticsNodeUpdate(&root);
+  bridge->AddFlutterSemanticsNodeUpdate(root);
 
   FlutterSemanticsNode child1;
   child1.id = 1;
@@ -295,7 +295,7 @@ TEST(FlutterPlatformNodeDelegateTest, canGetFromNodeID) {
   child1.tooltip = "";
   child1.child_count = 0;
   child1.custom_accessibility_actions_count = 0;
-  bridge->AddFlutterSemanticsNodeUpdate(&child1);
+  bridge->AddFlutterSemanticsNodeUpdate(child1);
 
   bridge->CommitUpdates();
   auto root_node = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();

--- a/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacTest.mm
@@ -87,7 +87,7 @@ TEST(AccessibilityBridgeMacTest, sendsAccessibilityCreateNotificationToWindowOfF
   root.tooltip = "";
   root.child_count = 0;
   root.custom_accessibility_actions_count = 0;
-  bridge->AddFlutterSemanticsNodeUpdate(&root);
+  bridge->AddFlutterSemanticsNodeUpdate(root);
 
   bridge->CommitUpdates();
   auto platform_node_delegate = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
@@ -135,7 +135,7 @@ TEST(AccessibilityBridgeMacTest, doesNotSendAccessibilityCreateNotificationWhenH
   root.tooltip = "";
   root.child_count = 0;
   root.custom_accessibility_actions_count = 0;
-  bridge->AddFlutterSemanticsNodeUpdate(&root);
+  bridge->AddFlutterSemanticsNodeUpdate(root);
 
   bridge->CommitUpdates();
   auto platform_node_delegate = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
@@ -182,7 +182,7 @@ TEST(AccessibilityBridgeMacTest, doesNotSendAccessibilityCreateNotificationWhenN
   root.tooltip = "";
   root.child_count = 0;
   root.custom_accessibility_actions_count = 0;
-  bridge->AddFlutterSemanticsNodeUpdate(&root);
+  bridge->AddFlutterSemanticsNodeUpdate(root);
 
   bridge->CommitUpdates();
   auto platform_node_delegate = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();

--- a/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm
@@ -50,7 +50,7 @@ TEST(FlutterPlatformNodeDelegateMac, Basics) {
   root.tooltip = "";
   root.child_count = 0;
   root.custom_accessibility_actions_count = 0;
-  bridge->AddFlutterSemanticsNodeUpdate(&root);
+  bridge->AddFlutterSemanticsNodeUpdate(root);
 
   bridge->CommitUpdates();
 
@@ -88,7 +88,7 @@ TEST(FlutterPlatformNodeDelegateMac, SelectableTextHasCorrectSemantics) {
   root.tooltip = "";
   root.child_count = 0;
   root.custom_accessibility_actions_count = 0;
-  bridge->AddFlutterSemanticsNodeUpdate(&root);
+  bridge->AddFlutterSemanticsNodeUpdate(root);
 
   bridge->CommitUpdates();
 
@@ -130,7 +130,7 @@ TEST(FlutterPlatformNodeDelegateMac, SelectableTextWithoutSelectionReturnZeroRan
   root.tooltip = "";
   root.child_count = 0;
   root.custom_accessibility_actions_count = 0;
-  bridge->AddFlutterSemanticsNodeUpdate(&root);
+  bridge->AddFlutterSemanticsNodeUpdate(root);
 
   bridge->CommitUpdates();
 
@@ -172,7 +172,7 @@ TEST(FlutterPlatformNodeDelegateMac, CanPerformAction) {
   int32_t children[] = {1};
   root.children_in_traversal_order = children;
   root.custom_accessibility_actions_count = 0;
-  bridge->AddFlutterSemanticsNodeUpdate(&root);
+  bridge->AddFlutterSemanticsNodeUpdate(root);
 
   FlutterSemanticsNode child1;
   child1.id = 1;
@@ -184,7 +184,7 @@ TEST(FlutterPlatformNodeDelegateMac, CanPerformAction) {
   child1.tooltip = "";
   child1.child_count = 0;
   child1.custom_accessibility_actions_count = 0;
-  bridge->AddFlutterSemanticsNodeUpdate(&child1);
+  bridge->AddFlutterSemanticsNodeUpdate(child1);
 
   bridge->CommitUpdates();
 
@@ -251,7 +251,7 @@ TEST(FlutterPlatformNodeDelegateMac, TextFieldUsesFlutterTextField) {
   root.custom_accessibility_actions_count = 0;
   root.rect = {0, 0, 100, 100};  // LTRB
   root.transform = {1, 0, 0, 0, 1, 0, 0, 0, 1};
-  bridge->AddFlutterSemanticsNodeUpdate(&root);
+  bridge->AddFlutterSemanticsNodeUpdate(root);
 
   double rectSize = 50;
   double transformFactor = 0.5;
@@ -272,7 +272,7 @@ TEST(FlutterPlatformNodeDelegateMac, TextFieldUsesFlutterTextField) {
   child1.custom_accessibility_actions_count = 0;
   child1.rect = {0, 0, rectSize, rectSize};  // LTRB
   child1.transform = {transformFactor, 0, 0, 0, transformFactor, 0, 0, 0, 1};
-  bridge->AddFlutterSemanticsNodeUpdate(&child1);
+  bridge->AddFlutterSemanticsNodeUpdate(child1);
 
   bridge->CommitUpdates();
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -479,13 +479,11 @@ static void CommonInit(FlutterViewController* controller, FlutterEngine* engine)
     return;
   }
   for (size_t i = 0; i < update->nodes_count; i++) {
-    const FlutterSemanticsNode* node = &update->nodes[i];
-    _bridge->AddFlutterSemanticsNodeUpdate(node);
+    _bridge->AddFlutterSemanticsNodeUpdate(update->nodes[i]);
   }
 
   for (size_t i = 0; i < update->custom_actions_count; i++) {
-    const FlutterSemanticsCustomAction* action = &update->custom_actions[i];
-    _bridge->AddFlutterSemanticsCustomActionUpdate(action);
+    _bridge->AddFlutterSemanticsCustomActionUpdate(update->custom_actions[i]);
   }
 
   _bridge->CommitUpdates();

--- a/shell/platform/windows/accessibility_bridge_windows_unittests.cc
+++ b/shell/platform/windows/accessibility_bridge_windows_unittests.cc
@@ -151,11 +151,11 @@ void PopulateAXTree(std::shared_ptr<AccessibilityBridge> bridge) {
   // Add node 4: text child (with no text) of node 2.
   FlutterSemanticsNode node4{sizeof(FlutterSemanticsNode), 4};
 
-  bridge->AddFlutterSemanticsNodeUpdate(&node0);
-  bridge->AddFlutterSemanticsNodeUpdate(&node1);
-  bridge->AddFlutterSemanticsNodeUpdate(&node2);
-  bridge->AddFlutterSemanticsNodeUpdate(&node3);
-  bridge->AddFlutterSemanticsNodeUpdate(&node4);
+  bridge->AddFlutterSemanticsNodeUpdate(node0);
+  bridge->AddFlutterSemanticsNodeUpdate(node1);
+  bridge->AddFlutterSemanticsNodeUpdate(node2);
+  bridge->AddFlutterSemanticsNodeUpdate(node3);
+  bridge->AddFlutterSemanticsNodeUpdate(node4);
   bridge->CommitUpdates();
 }
 

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -332,14 +332,13 @@ bool FlutterWindowsEngine::Run(std::string_view entrypoint) {
     auto host = static_cast<FlutterWindowsEngine*>(user_data);
 
     for (size_t i = 0; i < update->nodes_count; i++) {
-      const FlutterSemanticsNode* node = &update->nodes[i];
-      host->accessibility_bridge_->AddFlutterSemanticsNodeUpdate(node);
+      host->accessibility_bridge_->AddFlutterSemanticsNodeUpdate(
+          update->nodes[i]);
     }
 
     for (size_t i = 0; i < update->custom_actions_count; i++) {
-      const FlutterSemanticsCustomAction* action = &update->custom_actions[i];
       host->accessibility_bridge_->AddFlutterSemanticsCustomActionUpdate(
-          action);
+          update->custom_actions[i]);
     }
 
     host->accessibility_bridge_->CommitUpdates();
@@ -560,9 +559,10 @@ void FlutterWindowsEngine::SendSystemLocales() {
   // Convert the locale list to the locale pointer list that must be provided.
   std::vector<const FlutterLocale*> flutter_locale_list;
   flutter_locale_list.reserve(flutter_locales.size());
-  std::transform(flutter_locales.begin(), flutter_locales.end(),
-                 std::back_inserter(flutter_locale_list),
-                 [](const auto& arg) -> const auto* { return &arg; });
+  std::transform(
+      flutter_locales.begin(), flutter_locales.end(),
+      std::back_inserter(flutter_locale_list),
+      [](const auto& arg) -> const auto* { return &arg; });
   embedder_api_.UpdateLocales(engine_, flutter_locale_list.data(),
                               flutter_locale_list.size());
 }

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -559,10 +559,9 @@ void FlutterWindowsEngine::SendSystemLocales() {
   // Convert the locale list to the locale pointer list that must be provided.
   std::vector<const FlutterLocale*> flutter_locale_list;
   flutter_locale_list.reserve(flutter_locales.size());
-  std::transform(
-      flutter_locales.begin(), flutter_locales.end(),
-      std::back_inserter(flutter_locale_list),
-      [](const auto& arg) -> const auto* { return &arg; });
+  std::transform(flutter_locales.begin(), flutter_locales.end(),
+                 std::back_inserter(flutter_locale_list),
+                 [](const auto& arg) -> const auto* { return &arg; });
   embedder_api_.UpdateLocales(engine_, flutter_locale_list.data(),
                               flutter_locale_list.size());
 }

--- a/shell/platform/windows/flutter_windows_view_unittests.cc
+++ b/shell/platform/windows/flutter_windows_view_unittests.cc
@@ -162,7 +162,7 @@ TEST(FlutterWindowsView, AddSemanticsNodeUpdate) {
   node.label = "name";
   node.value = "value";
   node.platform_view_id = -1;
-  bridge->AddFlutterSemanticsNodeUpdate(&node);
+  bridge->AddFlutterSemanticsNodeUpdate(node);
   bridge->CommitUpdates();
 
   // Look up the root windows node delegate.
@@ -275,10 +275,10 @@ TEST(FlutterWindowsView, AddSemanticsNodeUpdateWithChildren) {
   node3.label = "city";
   node3.value = "Uji";
 
-  bridge->AddFlutterSemanticsNodeUpdate(&node0);
-  bridge->AddFlutterSemanticsNodeUpdate(&node1);
-  bridge->AddFlutterSemanticsNodeUpdate(&node2);
-  bridge->AddFlutterSemanticsNodeUpdate(&node3);
+  bridge->AddFlutterSemanticsNodeUpdate(node0);
+  bridge->AddFlutterSemanticsNodeUpdate(node1);
+  bridge->AddFlutterSemanticsNodeUpdate(node2);
+  bridge->AddFlutterSemanticsNodeUpdate(node3);
   bridge->CommitUpdates();
 
   // Look up the root windows node delegate.
@@ -465,8 +465,8 @@ TEST(FlutterWindowsView, NonZeroSemanticsRoot) {
   node2.label = "prefecture";
   node2.value = "Kyoto";
 
-  bridge->AddFlutterSemanticsNodeUpdate(&node1);
-  bridge->AddFlutterSemanticsNodeUpdate(&node2);
+  bridge->AddFlutterSemanticsNodeUpdate(node1);
+  bridge->AddFlutterSemanticsNodeUpdate(node2);
   bridge->CommitUpdates();
 
   // Look up the root windows node delegate.
@@ -618,10 +618,10 @@ TEST(FlutterWindowsViewTest, AccessibilityHitTesting) {
   node3.label = "city";
   node3.value = "Uji";
 
-  bridge->AddFlutterSemanticsNodeUpdate(&node0);
-  bridge->AddFlutterSemanticsNodeUpdate(&node1);
-  bridge->AddFlutterSemanticsNodeUpdate(&node2);
-  bridge->AddFlutterSemanticsNodeUpdate(&node3);
+  bridge->AddFlutterSemanticsNodeUpdate(node0);
+  bridge->AddFlutterSemanticsNodeUpdate(node1);
+  bridge->AddFlutterSemanticsNodeUpdate(node2);
+  bridge->AddFlutterSemanticsNodeUpdate(node3);
   bridge->CommitUpdates();
 
   // Look up the root windows node delegate.
@@ -743,7 +743,7 @@ TEST(FlutterWindowsViewTest, CheckboxNativeState) {
   root.flags = static_cast<FlutterSemanticsFlag>(
       FlutterSemanticsFlag::kFlutterSemanticsFlagHasCheckedState |
       FlutterSemanticsFlag::kFlutterSemanticsFlagIsChecked);
-  bridge->AddFlutterSemanticsNodeUpdate(&root);
+  bridge->AddFlutterSemanticsNodeUpdate(root);
 
   bridge->CommitUpdates();
 
@@ -782,7 +782,7 @@ TEST(FlutterWindowsViewTest, CheckboxNativeState) {
   // Test unchecked too.
   root.flags = static_cast<FlutterSemanticsFlag>(
       FlutterSemanticsFlag::kFlutterSemanticsFlagHasCheckedState);
-  bridge->AddFlutterSemanticsNodeUpdate(&root);
+  bridge->AddFlutterSemanticsNodeUpdate(root);
   bridge->CommitUpdates();
 
   {
@@ -821,7 +821,7 @@ TEST(FlutterWindowsViewTest, CheckboxNativeState) {
   root.flags = static_cast<FlutterSemanticsFlag>(
       FlutterSemanticsFlag::kFlutterSemanticsFlagHasCheckedState |
       FlutterSemanticsFlag::kFlutterSemanticsFlagIsCheckStateMixed);
-  bridge->AddFlutterSemanticsNodeUpdate(&root);
+  bridge->AddFlutterSemanticsNodeUpdate(root);
   bridge->CommitUpdates();
 
   {
@@ -889,7 +889,7 @@ TEST(FlutterWindowsViewTest, SwitchNativeState) {
   root.flags = static_cast<FlutterSemanticsFlag>(
       FlutterSemanticsFlag::kFlutterSemanticsFlagHasToggledState |
       FlutterSemanticsFlag::kFlutterSemanticsFlagIsToggled);
-  bridge->AddFlutterSemanticsNodeUpdate(&root);
+  bridge->AddFlutterSemanticsNodeUpdate(root);
 
   bridge->CommitUpdates();
 
@@ -938,7 +938,7 @@ TEST(FlutterWindowsViewTest, SwitchNativeState) {
   // Test unpressed too.
   root.flags = static_cast<FlutterSemanticsFlag>(
       FlutterSemanticsFlag::kFlutterSemanticsFlagHasToggledState);
-  bridge->AddFlutterSemanticsNodeUpdate(&root);
+  bridge->AddFlutterSemanticsNodeUpdate(root);
   bridge->CommitUpdates();
 
   {
@@ -1006,7 +1006,7 @@ TEST(FlutterWindowsViewTest, TooltipNodeData) {
   root.custom_accessibility_actions_count = 0;
   root.flags = static_cast<FlutterSemanticsFlag>(
       FlutterSemanticsFlag::kFlutterSemanticsFlagIsTextField);
-  bridge->AddFlutterSemanticsNodeUpdate(&root);
+  bridge->AddFlutterSemanticsNodeUpdate(root);
 
   bridge->CommitUpdates();
   auto root_node = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();


### PR DESCRIPTION
This updates `AccessibilityBridge::AddFlutterSemanticsNodeUpdate` and `AccessibilityBridge::AddFlutterSemanticsCustomActionUpdate` to accept references instead of pointers as null isn't an acceptable input and these aren't out parameters.

This code is shared by both the macOS and Windows embedders but not the Linux embedder.

Part of: https://github.com/flutter/flutter/issues/121176

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
