### PR TITLE
Change `extends Iterator` to using `implements`

### DIFF
--- a/lib/web_ui/lib/src/engine/dom.dart
+++ b/lib/web_ui/lib/src/engine/dom.dart
@@ -2053,7 +2053,7 @@ extension DomListExtension on _DomList {
       js_util.callMethod<DomNode>(this, 'item', <Object>[index.toDouble()]);
 }
 
-class _DomListIterator<T> extends Iterator<T> {
+class _DomListIterator<T> implements Iterator<T> {
   _DomListIterator(this.list);
 
   final _DomList list;
@@ -2101,7 +2101,7 @@ extension DomTouchListExtension on _DomTouchList {
       js_util.callMethod<DomTouch>(this, 'item', <Object>[index.toDouble()]);
 }
 
-class _DomTouchListIterator<T> extends Iterator<T> {
+class _DomTouchListIterator<T> implements Iterator<T> {
   _DomTouchListIterator(this.list);
 
   final _DomTouchList list;


### PR DESCRIPTION
The Dart 3.0 libraries will mark `Iterator` with the `interface` class modifier, which prevents `extends`. It will do so because the class has no implementation to inherit, and is only intended as an interface, which it is now possible to express.

This should unblock relanding https://dart-review.googlesource.com/c/sdk/+/287760
(Also working on disabling the class-modifiers experiment for Flutter `dart:` libraries, which was enabled along with the Dart SDK libraries, until the experiment can be intentionally turned back on.)