### PR TITLE
[ios] refactor platform_message_handler_ios

### DIFF
--- a/shell/platform/darwin/ios/platform_message_handler_ios.h
+++ b/shell/platform/darwin/ios/platform_message_handler_ios.h
@@ -45,7 +45,7 @@ class PlatformMessageHandlerIos : public PlatformMessageHandler {
 
  private:
   std::unordered_map<std::string, HandlerInfo> message_handlers_;
-  fml::RefPtr<fml::TaskRunner> platform_task_runner_;
+  const fml::RefPtr<fml::TaskRunner> platform_task_runner_;
   std::mutex message_handlers_mutex_;
   FML_DISALLOW_COPY_AND_ASSIGN(PlatformMessageHandlerIos);
 };

--- a/shell/platform/darwin/ios/platform_message_handler_ios.h
+++ b/shell/platform/darwin/ios/platform_message_handler_ios.h
@@ -13,7 +13,9 @@
 #include "flutter/shell/common/platform_message_handler.h"
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterBinaryMessenger.h"
 
-@protocol FlutterTaskQueue;
+@protocol FlutterTaskQueue
+- (void)dispatch:(dispatch_block_t)block;
+@end
 
 namespace flutter {
 
@@ -25,7 +27,7 @@ class PlatformMessageHandlerIos : public PlatformMessageHandler {
 
   void HandlePlatformMessage(std::unique_ptr<PlatformMessage> message) override;
 
-  bool DoesHandlePlatformMessageOnPlatformThread() const override { return false; }
+  bool DoesHandlePlatformMessageOnPlatformThread() const override;
 
   void InvokePlatformMessageResponseCallback(int response_id,
                                              std::unique_ptr<fml::Mapping> mapping) override;

--- a/shell/platform/darwin/ios/platform_message_handler_ios.h
+++ b/shell/platform/darwin/ios/platform_message_handler_ios.h
@@ -23,7 +23,7 @@ class PlatformMessageHandlerIos : public PlatformMessageHandler {
  public:
   static NSObject<FlutterTaskQueue>* MakeBackgroundTaskQueue();
 
-  PlatformMessageHandlerIos(const TaskRunners& task_runners);
+  PlatformMessageHandlerIos(fml::RefPtr<fml::TaskRunner> platform_task_runner);
 
   void HandlePlatformMessage(std::unique_ptr<PlatformMessage> message) override;
 
@@ -45,7 +45,7 @@ class PlatformMessageHandlerIos : public PlatformMessageHandler {
 
  private:
   std::unordered_map<std::string, HandlerInfo> message_handlers_;
-  TaskRunners task_runners_;
+  fml::RefPtr<fml::TaskRunner> platform_task_runner_;
   std::mutex message_handlers_mutex_;
   FML_DISALLOW_COPY_AND_ASSIGN(PlatformMessageHandlerIos);
 };

--- a/shell/platform/darwin/ios/platform_message_handler_ios.mm
+++ b/shell/platform/darwin/ios/platform_message_handler_ios.mm
@@ -40,8 +40,9 @@ NSObject<FlutterTaskQueue>* PlatformMessageHandlerIos::MakeBackgroundTaskQueue()
   return [[[FLTSerialTaskQueue alloc] init] autorelease];
 }
 
-PlatformMessageHandlerIos::PlatformMessageHandlerIos(const TaskRunners& task_runners)
-    : task_runners_(task_runners) {}
+PlatformMessageHandlerIos::PlatformMessageHandlerIos(
+    fml::RefPtr<fml::TaskRunner> platform_task_runner)
+    : platform_task_runner_(platform_task_runner) {}
 
 void PlatformMessageHandlerIos::HandlePlatformMessage(std::unique_ptr<PlatformMessage> message) {
   // This can be called from any isolate's thread.
@@ -114,7 +115,7 @@ void PlatformMessageHandlerIos::InvokePlatformMessageEmptyResponseCallback(int r
 void PlatformMessageHandlerIos::SetMessageHandler(const std::string& channel,
                                                   FlutterBinaryMessageHandler handler,
                                                   NSObject<FlutterTaskQueue>* task_queue) {
-  FML_CHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
+  FML_CHECK(platform_task_runner_->RunsTasksOnCurrentThread());
   /// TODO(gaaclarke): This should be migrated to a lockfree datastructure.
   std::lock_guard lock(message_handlers_mutex_);
   message_handlers_.erase(channel);

--- a/shell/platform/darwin/ios/platform_message_handler_ios.mm
+++ b/shell/platform/darwin/ios/platform_message_handler_ios.mm
@@ -42,7 +42,7 @@ NSObject<FlutterTaskQueue>* PlatformMessageHandlerIos::MakeBackgroundTaskQueue()
 
 PlatformMessageHandlerIos::PlatformMessageHandlerIos(
     fml::RefPtr<fml::TaskRunner> platform_task_runner)
-    : platform_task_runner_(platform_task_runner) {}
+    : platform_task_runner_(std::move(platform_task_runner)) {}
 
 void PlatformMessageHandlerIos::HandlePlatformMessage(std::unique_ptr<PlatformMessage> message) {
   // This can be called from any isolate's thread.

--- a/shell/platform/darwin/ios/platform_message_handler_ios.mm
+++ b/shell/platform/darwin/ios/platform_message_handler_ios.mm
@@ -11,10 +11,6 @@
 
 static uint64_t platform_message_counter = 1;
 
-@protocol FlutterTaskQueue
-- (void)dispatch:(dispatch_block_t)block;
-@end
-
 @interface FLTSerialTaskQueue : NSObject <FlutterTaskQueue>
 @property(nonatomic, strong) dispatch_queue_t queue;
 @end
@@ -95,6 +91,10 @@ void PlatformMessageHandlerIos::HandlePlatformMessage(std::unique_ptr<PlatformMe
       completer->CompleteEmpty();
     }
   }
+}
+
+bool PlatformMessageHandlerIos::DoesHandlePlatformMessageOnPlatformThread() const {
+  return false;
 }
 
 void PlatformMessageHandlerIos::InvokePlatformMessageResponseCallback(

--- a/shell/platform/darwin/ios/platform_message_handler_ios_test.mm
+++ b/shell/platform/darwin/ios/platform_message_handler_ios_test.mm
@@ -46,7 +46,7 @@ class MockPlatformMessageResponse : public PlatformMessageResponse {
 - (void)testCreate {
   flutter::TaskRunners task_runners("test", GetCurrentTaskRunner(), CreateNewThread("raster"),
                                     CreateNewThread("ui"), CreateNewThread("io"));
-  auto handler = std::make_unique<PlatformMessageHandlerIos>(task_runners);
+  auto handler = std::make_unique<PlatformMessageHandlerIos>(task_runners.GetPlatformTaskRunner());
   XCTAssertTrue(handler);
 }
 
@@ -57,7 +57,7 @@ class MockPlatformMessageResponse : public PlatformMessageResponse {
       "test", GetCurrentTaskRunner(), thread_host.raster_thread->GetTaskRunner(),
       thread_host.ui_thread->GetTaskRunner(), thread_host.io_thread->GetTaskRunner());
 
-  auto handler = std::make_unique<PlatformMessageHandlerIos>(task_runners);
+  auto handler = std::make_unique<PlatformMessageHandlerIos>(task_runners.GetPlatformTaskRunner());
   std::string channel = "foo";
   XCTestExpectation* didCallReply = [self expectationWithDescription:@"didCallReply"];
   handler->SetMessageHandler(
@@ -83,7 +83,7 @@ class MockPlatformMessageResponse : public PlatformMessageResponse {
       "test", GetCurrentTaskRunner(), thread_host.raster_thread->GetTaskRunner(),
       thread_host.ui_thread->GetTaskRunner(), thread_host.io_thread->GetTaskRunner());
 
-  auto handler = std::make_unique<PlatformMessageHandlerIos>(task_runners);
+  auto handler = std::make_unique<PlatformMessageHandlerIos>(task_runners.GetPlatformTaskRunner());
   std::string channel = "foo";
   XCTestExpectation* didCallMessage = [self expectationWithDescription:@"didCallMessage"];
   handler->SetMessageHandler(
@@ -111,7 +111,7 @@ class MockPlatformMessageResponse : public PlatformMessageResponse {
       "test", GetCurrentTaskRunner(), thread_host.raster_thread->GetTaskRunner(),
       thread_host.ui_thread->GetTaskRunner(), thread_host.io_thread->GetTaskRunner());
 
-  auto handler = std::make_unique<PlatformMessageHandlerIos>(task_runners);
+  auto handler = std::make_unique<PlatformMessageHandlerIos>(task_runners.GetPlatformTaskRunner());
   std::string channel = "foo";
   XCTestExpectation* didCallReply = [self expectationWithDescription:@"didCallReply"];
   NSObject<FlutterTaskQueue>* taskQueue = PlatformMessageHandlerIos::MakeBackgroundTaskQueue();

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -48,7 +48,8 @@ PlatformViewIOS::PlatformViewIOS(
       ios_context_(context),
       platform_views_controller_(platform_views_controller),
       accessibility_bridge_([this](bool enabled) { PlatformView::SetSemanticsEnabled(enabled); }),
-      platform_message_handler_(new PlatformMessageHandlerIos(task_runners)) {}
+      platform_message_handler_(
+          new PlatformMessageHandlerIos(task_runners.GetPlatformTaskRunner())) {}
 
 PlatformViewIOS::PlatformViewIOS(
     PlatformView::Delegate& delegate,


### PR DESCRIPTION
Refactor the `platform_message_handler_ios`:
1. Move @FlutterTaskQueue to header
2. Change the constructor only requires the platform task runner instead of the task_runners. Making this change so that we can use `PlatformMessageHandlerIos` while migrating to the embedder api. The embedder won't have access to the task_runners when using embedder api, but will have access to the platform task runner.
3. Minor: move impelmentation of `DoesHandlePlatformMessageOnPlatformThread` to the .mm file.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
