### PR TITLE
[Impeller] Build Impeller Vulkan backend on Windows

### DIFF
--- a/impeller/renderer/backend/vulkan/allocator_vk.cc
+++ b/impeller/renderer/backend/vulkan/allocator_vk.cc
@@ -252,7 +252,7 @@ class AllocatedTextureSourceVK final : public TextureSourceVK {
                                               &allocation_info      //
                                               )};
       if (result != vk::Result::eSuccess) {
-        VALIDATION_LOG << "Unable to allocation Vulkan Image: "
+        VALIDATION_LOG << "Unable to allocate Vulkan Image: "
                        << vk::to_string(result);
         return;
       }

--- a/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/impeller/renderer/backend/vulkan/context_vk.cc
@@ -51,7 +51,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL DebugUtilsMessengerCallback(
   }
 
   const auto prefix = impeller::vk::to_string(
-      impeller::vk::DebugUtilsMessageSeverityFlagBitsEXT{severity});
+      impeller::vk::DebugUtilsMessageSeverityFlagBitsEXT(severity));
   // Just so that the log doesn't say FML_DCHECK(false).
   constexpr bool kVulkanValidationFailure = false;
   FML_DCHECK(kVulkanValidationFailure)
@@ -79,6 +79,8 @@ bool HasValidationLayers() {
 
 static std::set<std::string> kRequiredDeviceExtensions = {
     VK_KHR_SWAPCHAIN_EXTENSION_NAME,
+    // Used by VMA; part of Vulkan 1.1 core.
+    VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME,
 #if FML_OS_MACOSX
     "VK_KHR_portability_subset",  // For Molten VK. No define present in header.
 #endif

--- a/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/impeller/renderer/backend/vulkan/context_vk.cc
@@ -79,8 +79,6 @@ bool HasValidationLayers() {
 
 static std::set<std::string> kRequiredDeviceExtensions = {
     VK_KHR_SWAPCHAIN_EXTENSION_NAME,
-    // Used by VMA; part of Vulkan 1.1 core.
-    VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME,
 #if FML_OS_MACOSX
     "VK_KHR_portability_subset",  // For Molten VK. No define present in header.
 #endif

--- a/impeller/renderer/compute_unittests.cc
+++ b/impeller/renderer/compute_unittests.cc
@@ -54,7 +54,7 @@ TEST_P(ComputeTest, CanCreateComputePass) {
   CS::Info info{.count = kCount};
   CS::Input0<kCount> input_0;
   CS::Input1<kCount> input_1;
-  for (uint i = 0; i < kCount; i++) {
+  for (size_t i = 0; i < kCount; i++) {
     input_0.elements[i] = Vector4(2.0 + i, 3.0 + i, 4.0 + i, 5.0 * i);
     input_1.elements[i] = Vector4(6.0, 7.0, 8.0, 9.0);
   }
@@ -139,13 +139,13 @@ TEST_P(ComputeTest, MultiStageInputAndOutput) {
 
   CS1::Input<kCount1> input_1;
   input_1.count = kCount1;
-  for (uint i = 0; i < kCount1; i++) {
+  for (size_t i = 0; i < kCount1; i++) {
     input_1.elements[i] = i;
   }
 
   CS2::Input<kCount2> input_2;
   input_2.count = kCount2;
-  for (uint i = 0; i < kCount2; i++) {
+  for (size_t i = 0; i < kCount2; i++) {
     input_2.elements[i] = i;
   }
 

--- a/impeller/tools/impeller.gni
+++ b/impeller/tools/impeller.gni
@@ -18,7 +18,7 @@ declare_args() {
   impeller_enable_opengles = is_mac || is_linux || is_win || is_android
 
   # Whether the Vulkan backend is enabled.
-  impeller_enable_vulkan = is_mac || is_linux || is_android
+  impeller_enable_vulkan = is_mac || is_linux || is_win || is_android
 
   # Whether to use a prebuilt impellerc.
   # If this is the empty string, impellerc will be built.


### PR DESCRIPTION
Fix build errors for Vulkan in Windows.

I spent some time trying to figure out why `vmaCreateImage` is failing with `ErrorFeatureNotPresent`, but didn't manage to figure it out.

1. First it fails to allocate the 1x1 placeholder texture in the Impeller Scene context:
    
```cpp
$ ../out/host_debug_unopt/impeller_unittests.exe --gtest_filter="*CanRenderColoredRect/Vulkan"
[INFO:test_timeout_listener.cc(76)] Test timeout of 120 seconds per test case will be enforced.
Note: Google Test filter = *CanRenderColoredRect/Vulkan
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from Play/AiksTest
[ RUN      ] Play/AiksTest.CanRenderColoredRect/Vulkan
UNASSIGNED-khronos-validation-createinstance-status-message(INFO / SPEC): msgNum: -671457468 - Validation Information: [ UNASSIGNED-khronos-validation-createinstance-status-message ] Object 0: handle = 0x3f26060, type = VK_OBJECT_TYPE_INSTANCE; | MessageID = 0xd7fa5f44 | Khronos Validation Layer Active:
    Settings File: Found at C:\Users\bdero\AppData\Local\LunarG\vkconfig\override\vk_layer_settings.txt specified by VkConfig application override.
    Current Enables: None.
    Current Disables: VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT.

    Objects: 1
        [0] 0x3f26060, type: 1, name: NULL
[FATAL:flutter/impeller/base/validation.cc(31)] Unable to allocation Vulkan Image: ErrorFeatureNotPresent
[ERROR:flutter/fml/backtrace.cc(108)] Caught signal SIGABRT during program execution.
Frame 0: 000000014038D1D9 fml::KillProcess
Frame 1: 000000014038D1AB fml::LogMessage::~LogMessage
Frame 2: 0000000140377F86 impeller::ValidationLog::~ValidationLog
Frame 3: 00000001426B2FE1 impeller::AllocatedTextureSourceVK::AllocatedTextureSourceVK
Frame 4: 00000001426B21A8 std::_Construct_in_place<impeller::AllocatedTextureSourceVK,const impeller::TextureDescriptor &,VmaAllocator_T *&,impeller::vk::Device &>
Frame 5: 00000001426B20B0 std::_Ref_count_obj2<impeller::AllocatedTextureSourceVK>::_Ref_count_obj2<const impeller::TextureDescriptor &,VmaAllocator_T *&,impeller::vk::Device &>
Frame 6: 00000001426B00CB std::make_shared<impeller::AllocatedTextureSourceVK,const impeller::TextureDescriptor &,VmaAllocator_T *&,impeller::vk::Device &>
Frame 7: 00000001426ADC5E impeller::AllocatorVK::OnCreateTexture
Frame 8: 000000014249937E impeller::Allocator::CreateTexture
Frame 9: 0000000142A295E1 impeller::scene::SceneContext::SceneContext
Frame 10: 000000014287E30A std::_Construct_in_place<impeller::scene::SceneContext,std::shared_ptr<impeller::Context> &>
Frame 11: 000000014287E29C std::_Ref_count_obj2<impeller::scene::SceneContext>::_Ref_count_obj2<std::shared_ptr<impeller::Context> &>
Frame 12: 0000000142867C07 std::make_shared<impeller::scene::SceneContext,std::shared_ptr<impeller::Context> &>
Frame 13: 000000014285C792 impeller::ContentContext::ContentContext
Frame 14: 0000000142831A07 std::make_unique<impeller::ContentContext,std::shared_ptr<impeller::Context> &,0>
Frame 15: 000000014283170B impeller::AiksContext::AiksContext
Frame 16: 00000001401E8926 impeller::AiksPlayground::OpenPlaygroundHere
Frame 17: 00000001401E88B5 impeller::AiksPlayground::OpenPlaygroundHere
```

2. When I comment out the Scene placeholder texture, the ImGui text atlas texture fails next for the same reason.
3. When I comment out the  texture, the GLFW window opens and I get validation failures because the texture failures.
4. Finally, if I disable all of the validation layers, we get a swapchain-related failure:
```cpp
[FATAL:flutter/impeller/base/validation.cc(31)] Could not acquire next swapchain image: ErrorOutOfDateKHR
[ERROR:flutter/fml/backtrace.cc(108)] Caught signal SIGABRT during program execution.
Frame 0: 000000014038D1D9 fml::KillProcess
Frame 1: 000000014038D1AB fml::LogMessage::~LogMessage
Frame 2: 0000000140377F86 impeller::ValidationLog::~ValidationLog
Frame 3: 0000000142729ABB impeller::SwapchainImplVK::AcquireNextDrawable
Frame 4: 000000014273A9EB impeller::SwapchainVK::AcquireNextDrawable
Frame 5: 00000001426D2B0C impeller::ContextVK::GetInstance
Frame 6: 00000001402F2142 impeller::PlaygroundImplVK::AcquireSurfaceFrame
Frame 7: 00000001402E3D5D impeller::Playground::OpenPlaygroundHere
Frame 8: 00000001401E8982 impeller::AiksPlayground::OpenPlaygroundHere
Frame 9: 00000001401E88B5 impeller::AiksPlayground::OpenPlaygroundHere
```


