### PR TITLE
Find the emsdk by relative path so that this works with the monorepo.

### DIFF
--- a/tools/activate_emsdk.py
+++ b/tools/activate_emsdk.py
@@ -9,7 +9,9 @@ import os
 import subprocess
 import sys
 
-EMSDK_ROOT = os.path.join('src', 'buildtools', 'emsdk')
+EMSDK_ROOT = os.path.abspath(
+    os.path.join(__file__, '..', '..', '..', 'buildtools', 'emsdk')
+)
 
 EMSDK_PATH = os.path.join(EMSDK_ROOT, 'emsdk.py')
 


### PR DESCRIPTION
This ends up basically finding the emsdk directory relative to the gclient checkout, which is different in the monorepo than it is in a engine checkout by itself. So we can find the emsdk directory relative to the script itself.