### PR TITLE
Make the context current before accessing GL in MakeSkiaGpuImage

### DIFF
--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -328,5 +328,13 @@ if (enable_unittests) {
         deps += [ "//third_party/swiftshader" ]
       }
     }
+
+    if (shell_enable_gl) {
+      deps += [
+        "//third_party/angle:libEGL_static",
+        "//third_party/angle:libGLESv2_static",
+        "//third_party/swiftshader",
+      ]
+    }
   }
 }

--- a/shell/common/fixtures/shell_test.dart
+++ b/shell/common/fixtures/shell_test.dart
@@ -354,6 +354,9 @@ void scene_with_red_box() {
   PlatformDispatcher.instance.scheduleFrame();
 }
 
+@pragma('vm:external-name', 'NativeOnBeforeToImageSync')
+external void onBeforeToImageSync();
+
 
 @pragma('vm:entry-point')
 Future<void> toImageSync() async {
@@ -362,6 +365,7 @@ Future<void> toImageSync() async {
   canvas.drawPaint(Paint()..color = const Color(0xFFAAAAAA));
   final Picture picture = recorder.endRecording();
 
+  onBeforeToImageSync();
   final Image image = picture.toImageSync(20, 25);
   void expect(Object? a, Object? b) {
     if (a != b) {

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -293,6 +293,8 @@ std::unique_ptr<Rasterizer::GpuImageResult> Rasterizer::MakeSkiaGpuImage(
   delegate_.GetIsGpuDisabledSyncSwitch()->Execute(
       fml::SyncSwitch::Handlers()
           .SetIfTrue([&result, &image_info, &display_list] {
+            // TODO(dnfield): This isn't safe if display_list contains any GPU
+            // resources like an SkImage_gpu.
             result = MakeBitmapImage(display_list, image_info);
           })
           .SetIfFalse([&result, &image_info, &display_list,
@@ -300,6 +302,8 @@ std::unique_ptr<Rasterizer::GpuImageResult> Rasterizer::MakeSkiaGpuImage(
                        gpu_image_behavior = gpu_image_behavior_] {
             if (!surface ||
                 gpu_image_behavior == MakeGpuImageBehavior::kBitmap) {
+              // TODO(dnfield): This isn't safe if display_list contains any GPU
+              // resources like an SkImage_gpu.
               result = MakeBitmapImage(display_list, image_info);
               return;
             }

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -11,6 +11,10 @@
 #include <utility>
 #include <vector>
 
+#if SHELL_ENABLE_GL
+#include <EGL/egl.h>
+#endif  // SHELL_ENABLE_GL
+
 #include "assets/directory_asset_bundle.h"
 #include "common/graphics/persistent_cache.h"
 #include "flutter/flow/layers/backdrop_filter_layer.h"
@@ -3820,6 +3824,11 @@ TEST_F(ShellTest, PictureToImageSync) {
                   ShellTestPlatformView::BackendType::kGLBackend  //
       );
 
+  AddNativeCallback("NativeOnBeforeToImageSync",
+                    CREATE_NATIVE_ENTRY([&](auto args) {
+                      // nop
+                    }));
+
   fml::CountDownLatch latch(2);
   AddNativeCallback("NotifyNative", CREATE_NATIVE_ENTRY([&](auto args) {
                       // Teardown and set up rasterizer again.
@@ -3840,6 +3849,59 @@ TEST_F(ShellTest, PictureToImageSync) {
 
   PlatformViewNotifyDestroyed(shell.get());
   DestroyShell(std::move(shell));
+}
+
+TEST_F(ShellTest, PictureToImageSyncWithTrampledContext) {
+#if !SHELL_ENABLE_GL
+  // This test uses the GL backend.
+  GTEST_SKIP();
+#endif  // !SHELL_ENABLE_GL
+  // make it easier to trample the GL context by running on a single task
+  // runner.
+  ThreadHost thread_host("io.flutter.test." + GetCurrentTestName() + ".",
+                         ThreadHost::Type::Platform);
+  auto task_runner = thread_host.platform_thread->GetTaskRunner();
+  TaskRunners task_runners("test", task_runner, task_runner, task_runner,
+                           task_runner);
+
+  auto settings = CreateSettingsForFixture();
+  std::unique_ptr<Shell> shell =
+      CreateShell(settings,                                       //
+                  task_runners,                                   //
+                  false,                                          //
+                  nullptr,                                        //
+                  false,                                          //
+                  ShellTestPlatformView::BackendType::kGLBackend  //
+      );
+
+  AddNativeCallback(
+      "NativeOnBeforeToImageSync", CREATE_NATIVE_ENTRY([&](auto args) {
+        // Trample the GL context. If the rasterizer fails
+        // to make the right one current again, test will
+        // fail.
+        ::eglMakeCurrent(::eglGetCurrentDisplay(), NULL, NULL, NULL);
+      }));
+
+  fml::CountDownLatch latch(2);
+  AddNativeCallback("NotifyNative", CREATE_NATIVE_ENTRY([&](auto args) {
+                      // Teardown and set up rasterizer again.
+                      PlatformViewNotifyDestroyed(shell.get());
+                      PlatformViewNotifyCreated(shell.get());
+                      latch.CountDown();
+                    }));
+
+  ASSERT_NE(shell, nullptr);
+  ASSERT_TRUE(shell->IsSetup());
+  auto configuration = RunConfiguration::InferFromSettings(settings);
+  PlatformViewNotifyCreated(shell.get());
+  configuration.SetEntrypoint("toImageSync");
+  RunEngine(shell.get(), std::move(configuration));
+  PumpOneFrame(shell.get());
+
+  latch.Wait();
+
+  PlatformViewNotifyDestroyed(shell.get());
+  DestroyShell(std::move(shell), task_runners);
 }
 
 TEST_F(ShellTest, PluginUtilitiesCallbackHandleErrorHandling) {

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -3851,11 +3851,9 @@ TEST_F(ShellTest, PictureToImageSync) {
   DestroyShell(std::move(shell));
 }
 
+#if SHELL_ENABLE_GL
+// This test uses the GL backend and refers to symbols in egl.h
 TEST_F(ShellTest, PictureToImageSyncWithTrampledContext) {
-#if !SHELL_ENABLE_GL
-  // This test uses the GL backend.
-  GTEST_SKIP();
-#endif  // !SHELL_ENABLE_GL
   // make it easier to trample the GL context by running on a single task
   // runner.
   ThreadHost thread_host("io.flutter.test." + GetCurrentTestName() + ".",
@@ -3903,6 +3901,7 @@ TEST_F(ShellTest, PictureToImageSyncWithTrampledContext) {
   PlatformViewNotifyDestroyed(shell.get());
   DestroyShell(std::move(shell), task_runners);
 }
+#endif  // SHELL_ENABLE_GL
 
 TEST_F(ShellTest, PluginUtilitiesCallbackHandleErrorHandling) {
   auto settings = CreateSettingsForFixture();


### PR DESCRIPTION
The unconditional `MakeBitmapImage` is no longer necessary on Linux, with or without this context switch change. That fixes https://github.com/flutter/flutter/issues/108835
Might help https://github.com/flutter/flutter/issues/121485

Context switch fixes https://github.com/flutter/flutter/issues/120815. This was figured out by @jason-simmons - without the switch, we might be piggybacking on GDK's GL context/FBO and causing the problems seen in that bug.

I'm not quite sure what to do about the MakeBitmapImage path. It's not entirely safe, for example if you went to background on iOS and have a display_list that contains an SkImage_gpu. We have this problem elsewhere too AFAICT (e.g. in the regular `toImage` path).

~~I'm not sure how to test this. Will try to think on that a bit.~~