### PR TITLE
[Windows] Fix crash if clipboard is set to null

### DIFF
--- a/shell/platform/windows/platform_handler.cc
+++ b/shell/platform/windows/platform_handler.cc
@@ -369,6 +369,10 @@ void PlatformHandler::HandleMethodCall(
       result->Error(kClipboardError, kUnknownClipboardFormatMessage);
       return;
     }
+    if (!itr->value.IsString()) {
+      result->Error(kClipboardError, kUnknownClipboardFormatMessage);
+      return;
+    }
     SetPlainText(itr->value.GetString(), std::move(result));
   } else if (method.compare(kPlaySoundMethod) == 0) {
     // Only one string argument is expected.

--- a/shell/platform/windows/platform_handler_unittests.cc
+++ b/shell/platform/windows/platform_handler_unittests.cc
@@ -370,7 +370,8 @@ TEST_F(PlatformHandlerTest, ClipboardSetData) {
   EXPECT_EQ(result, "[null]");
 }
 
-TEST_F(PlatformHandlerTest, ClipboardSetDataNullText) {
+// Regression test for: https://github.com/flutter/flutter/issues/121976
+TEST_F(PlatformHandlerTest, ClipboardSetDataTextMustBeString) {
   use_engine_with_view();
 
   TestBinaryMessenger messenger;

--- a/shell/platform/windows/platform_handler_unittests.cc
+++ b/shell/platform/windows/platform_handler_unittests.cc
@@ -37,6 +37,8 @@ static constexpr char kClipboardHasStringsFakeContentTypeMessage[] =
     "{\"method\":\"Clipboard.hasStrings\",\"args\":\"text/madeupcontenttype\"}";
 static constexpr char kClipboardSetDataMessage[] =
     "{\"method\":\"Clipboard.setData\",\"args\":{\"text\":\"hello\"}}";
+static constexpr char kClipboardSetDataNullTextMessage[] =
+    "{\"method\":\"Clipboard.setData\",\"args\":{\"text\":null}}";
 static constexpr char kClipboardSetDataUnknownTypeMessage[] =
     "{\"method\":\"Clipboard.setData\",\"args\":{\"madeuptype\":\"hello\"}}";
 static constexpr char kSystemSoundTypeAlertMessage[] =
@@ -366,6 +368,18 @@ TEST_F(PlatformHandlerTest, ClipboardSetData) {
       SimulatePlatformMessage(&messenger, kClipboardSetDataMessage);
 
   EXPECT_EQ(result, "[null]");
+}
+
+TEST_F(PlatformHandlerTest, ClipboardSetDataNullText) {
+  use_engine_with_view();
+
+  TestBinaryMessenger messenger;
+  PlatformHandler platform_handler(&messenger, engine());
+
+  std::string result =
+      SimulatePlatformMessage(&messenger, kClipboardSetDataNullTextMessage);
+
+  EXPECT_EQ(result, "[\"Clipboard error\",\"Unknown clipboard format\",null]");
 }
 
 TEST_F(PlatformHandlerTest, ClipboardSetDataUnknownType) {


### PR DESCRIPTION
Currently, the framework allows setting the clipboard to `null`. This was an unintentional mistake from the `null` safety migration and [platforms handle this case incorrectly](https://github.com/flutter/flutter/issues/121976#issuecomment-1464721716). We will update the framework to disallow setting the clipboard's data to `null`: https://github.com/flutter/flutter/pull/122446

In the meantime, this change makes the Windows embedder resilient to unexpected clipboard messages. If your clipboard data's text is unexpected, you will now get an error instead of crashing your app.

Part of https://github.com/flutter/flutter/issues/121976
