### PR TITLE
Use plain Uint32List objects with the fragmenter APIs.

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -1911,12 +1911,12 @@ extension SkParagraphBuilderExtension on SkParagraphBuilder {
   // into a utf16 string.
   String getText() => utf8.decode(getTextUtf8().codeUnits);
 
-  external void setWordsUtf8(SkUint32List words);
-  external void setWordsUtf16(SkUint32List words);
-  external void setGraphemeBreaksUtf8(SkUint32List graphemes);
-  external void setGraphemeBreaksUtf16(SkUint32List graphemes);
-  external void setLineBreaksUtf8(SkUint32List lineBreaks);
-  external void setLineBreaksUtf16(SkUint32List lineBreaks);
+  external void setWordsUtf8(Uint32List words);
+  external void setWordsUtf16(Uint32List words);
+  external void setGraphemeBreaksUtf8(Uint32List graphemes);
+  external void setGraphemeBreaksUtf16(Uint32List graphemes);
+  external void setLineBreaksUtf8(Uint32List lineBreaks);
+  external void setLineBreaksUtf16(Uint32List lineBreaks);
 
   external SkParagraph build();
   external void delete();

--- a/lib/web_ui/lib/src/engine/canvaskit/text_fragmenter.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/text_fragmenter.dart
@@ -43,7 +43,7 @@ final Map<IntlSegmenterGranularity, DomSegmenter> _intlSegmenters = <IntlSegment
   IntlSegmenterGranularity.word: createIntlSegmenter(granularity: 'word'),
 };
 
-SkUint32List fragmentUsingIntlSegmenter(
+Uint32List fragmentUsingIntlSegmenter(
   String text,
   IntlSegmenterGranularity granularity,
 ) {
@@ -55,10 +55,7 @@ SkUint32List fragmentUsingIntlSegmenter(
     breaks.add(iterator.current.index);
   }
   breaks.add(text.length);
-
-  final SkUint32List mallocedList = mallocUint32List(breaks.length);
-  mallocedList.toTypedArray().setAll(0, breaks);
-  return mallocedList;
+  return Uint32List.fromList(breaks);
 }
 
 // These are the soft/hard line break values expected by Skia's SkParagraph.
@@ -67,13 +64,12 @@ const int _kHardLineBreak = 1;
 
 final DomV8BreakIterator _v8LineBreaker = createV8BreakIterator();
 
-SkUint32List fragmentUsingV8LineBreaker(String text) {
+Uint32List fragmentUsingV8LineBreaker(String text) {
   final List<LineBreakFragment> fragments =
       breakLinesUsingV8BreakIterator(text, _v8LineBreaker);
 
   final int size = (fragments.length + 1) * 2;
-  final SkUint32List mallocedList = mallocUint32List(size);
-  final Uint32List typedArray = mallocedList.toTypedArray();
+  final Uint32List typedArray = Uint32List(size);
 
   typedArray[0] = 0; // start index
   typedArray[1] = _kSoftLineBreak; // break type
@@ -87,5 +83,5 @@ SkUint32List fragmentUsingV8LineBreaker(String text) {
         : _kSoftLineBreak;
   }
 
-  return mallocedList;
+  return typedArray;
 }

--- a/lib/web_ui/test/canvaskit/text_fragmenter_test.dart
+++ b/lib/web_ui/test/canvaskit/text_fragmenter_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:typed_data';
+
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
@@ -15,33 +17,25 @@ void main() {
 void testMain() {
   setUpCanvasKitTest();
 
-  late SkUint32List breaks;
-
-  tearDown(() {
-    if (browserSupportsCanvaskitChromium) {
-      free(breaks);
-    }
-  });
-
   group('$fragmentUsingIntlSegmenter', () {
     test('fragments text into words', () {
-      breaks = fragmentUsingIntlSegmenter(
+      final Uint32List breaks = fragmentUsingIntlSegmenter(
         'Hello world 你好世界',
         IntlSegmenterGranularity.word,
       );
       expect(
-        breaks.toTypedArray(),
+        breaks,
         orderedEquals(<int>[0, 5, 6, 11, 12, 14, 16]),
       );
     });
 
     test('fragments multi-line text into words', () {
-      breaks = fragmentUsingIntlSegmenter(
+      final Uint32List breaks = fragmentUsingIntlSegmenter(
         'Lorem ipsum\ndolor 你好世界 sit\namet',
         IntlSegmenterGranularity.word,
       );
       expect(
-        breaks.toTypedArray(),
+        breaks,
         orderedEquals(<int>[
           0, 5, 6, 11, 12, // "Lorem ipsum\n"
           17, 18, 20, 22, 23, 26, 27, // "dolor 你好世界 sit\n"
@@ -53,12 +47,12 @@ void testMain() {
     test('fragments text into grapheme clusters', () {
       // The smiley emoji has a length of 2.
       // The family emoji has a length of 11.
-      breaks = fragmentUsingIntlSegmenter(
+      final Uint32List breaks = fragmentUsingIntlSegmenter(
         'Lorem🙂ipsum👨‍👩‍👧‍👦',
         IntlSegmenterGranularity.grapheme,
       );
       expect(
-        breaks.toTypedArray(),
+        breaks,
         orderedEquals(<int>[
           0, 1, 2, 3, 4, 5, 7, // "Lorem🙂"
           8, 9, 10, 11, 12, 23, // "ipsum👨‍👩‍👧‍👦"
@@ -69,12 +63,12 @@ void testMain() {
     test('fragments multi-line text into grapheme clusters', () {
       // The smiley emojis have a length of 2 each.
       // The family emoji has a length of 11.
-      breaks = fragmentUsingIntlSegmenter(
+      final Uint32List breaks = fragmentUsingIntlSegmenter(
         'Lorem🙂\nipsum👨‍👩‍👧‍👦dolor\n😄',
         IntlSegmenterGranularity.grapheme,
       );
       expect(
-        breaks.toTypedArray(),
+        breaks,
         orderedEquals(<int>[
           0, 1, 2, 3, 4, 5, 7, 8, // "Lorem🙂\n"
           9, 10, 11, 12, 13, 24, // "ipsum👨‍👩‍👧‍👦"
@@ -89,11 +83,11 @@ void testMain() {
     const int kHard = 1;
 
     test('fragments text into soft and hard line breaks', () {
-      breaks = fragmentUsingV8LineBreaker(
+      final Uint32List breaks = fragmentUsingV8LineBreaker(
         'Lorem-ipsum 你好🙂\nDolor sit',
       );
       expect(
-        breaks.toTypedArray(),
+        breaks,
         orderedEquals(<int>[
           0, kSoft,
           6, kSoft, // "Lorem-"


### PR DESCRIPTION
Let CanvasKit do the malloc/copy into linear memory for us.

Doing malloc ourselves and attempting to use a view into the malloced linear memory fails on dart2wasm for the same reasons we get failures in https://github.com/flutter/flutter/issues/118334

I think this is basically equivalent perf-wise anyway, it's just changing who is doing the work (now CanvasKit does the malloc + copy instead of us).