### PR TITLE
[macOS] Forward mouseDown/Up to view controller

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -278,6 +278,34 @@ void OnKeyboardLayoutChanged(CFNotificationCenterRef center,
   return @[ _flutterView ];
 }
 
+- (void)mouseDown:(NSEvent*)event {
+  // Work around an AppKit bug where mouseDown/mouseUp are not called on the view controller if the
+  // view is the content view of an NSPopover AND macOS's Reduced Transparency accessibility setting
+  // is enabled.
+  //
+  // This simply calls mouseDown on the next responder in the responder chain as the default
+  // implementation on NSResponder is documented to do.
+  //
+  // See: https://github.com/flutter/flutter/issues/115015
+  // See: http://www.openradar.me/FB12050037
+  // See: https://developer.apple.com/documentation/appkit/nsresponder/1524634-mousedown
+  [self.nextResponder mouseDown:event];
+}
+
+- (void)mouseUp:(NSEvent*)event {
+  // Work around an AppKit bug where mouseDown/mouseUp are not called on the view controller if the
+  // view is the content view of an NSPopover AND macOS's Reduced Transparency accessibility setting
+  // is enabled.
+  //
+  // This simply calls mouseUp on the next responder in the responder chain as the default
+  // implementation on NSResponder is documented to do.
+  //
+  // See: https://github.com/flutter/flutter/issues/115015
+  // See: http://www.openradar.me/FB12050037
+  // See: https://developer.apple.com/documentation/appkit/nsresponder/1535349-mouseup
+  [self.nextResponder mouseUp:event];
+}
+
 @end
 
 #pragma mark - FlutterViewController implementation.

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
@@ -18,6 +18,8 @@
 #include "flutter/shell/platform/embedder/test_utils/key_codes.g.h"
 #import "flutter/testing/testing.h"
 
+#pragma mark - Test Helper Classes
+
 // A wrap to convert FlutterKeyEvent to a ObjC class.
 @interface KeyEventWrapper : NSObject
 @property(nonatomic) FlutterKeyEvent* data;
@@ -36,6 +38,23 @@
 }
 @end
 
+// A FlutterViewController subclass for testing that mouseDown/mouseUp get called when
+// mouse events are sent to the associated view.
+@interface MouseEventFlutterViewController : FlutterViewController
+@property(nonatomic, assign) BOOL mouseDownCalled;
+@property(nonatomic, assign) BOOL mouseUpCalled;
+@end
+
+@implementation MouseEventFlutterViewController
+- (void)mouseDown:(NSEvent*)event {
+  self.mouseDownCalled = YES;
+}
+
+- (void)mouseUp:(NSEvent*)event {
+  self.mouseUpCalled = YES;
+}
+@end
+
 @interface FlutterViewControllerTestObjC : NSObject
 - (bool)testKeyEventsAreSentToFramework;
 - (bool)testKeyEventsArePropagatedIfNotHandled;
@@ -43,6 +62,7 @@
 - (bool)testFlagsChangedEventsArePropagatedIfNotHandled;
 - (bool)testKeyboardIsRestartedOnEngineRestart;
 - (bool)testTrackpadGesturesAreSentToFramework;
+- (bool)testMouseDownUpEventsSentToNextResponder;
 - (bool)testModifierKeysAreSynthesizedOnMouseMove;
 - (bool)testViewWillAppearCalledMultipleTimes;
 - (bool)testFlutterViewIsConfigured;
@@ -51,6 +71,8 @@
                         callback:(nullable FlutterKeyEventCallback)callback
                         userData:(nullable void*)userData;
 @end
+
+#pragma mark - Static helper functions
 
 using namespace ::flutter::testing::keycodes;
 
@@ -107,6 +129,8 @@ NSEvent* CreateMouseEvent(NSEventModifierFlags modifierFlags) {
 }
 
 }  // namespace
+
+#pragma mark - gtest tests
 
 TEST(FlutterViewController, HasViewThatHidesOtherViewsInAccessibility) {
   FlutterViewController* viewControllerMock = CreateMockViewController();
@@ -196,6 +220,10 @@ TEST(FlutterViewControllerTest, TestTrackpadGesturesAreSentToFramework) {
   ASSERT_TRUE([[FlutterViewControllerTestObjC alloc] testTrackpadGesturesAreSentToFramework]);
 }
 
+TEST(FlutterViewControllerTest, TestMouseDownUpEventsSentToNextResponder) {
+  ASSERT_TRUE([[FlutterViewControllerTestObjC alloc] testMouseDownUpEventsSentToNextResponder]);
+}
+
 TEST(FlutterViewControllerTest, TestModifierKeysAreSynthesizedOnMouseMove) {
   ASSERT_TRUE([[FlutterViewControllerTestObjC alloc] testModifierKeysAreSynthesizedOnMouseMove]);
 }
@@ -209,6 +237,8 @@ TEST(FlutterViewControllerTest, testFlutterViewIsConfigured) {
 }
 
 }  // namespace flutter::testing
+
+#pragma mark - FlutterViewControllerTestObjC
 
 @implementation FlutterViewControllerTestObjC
 
@@ -799,6 +829,51 @@ TEST(FlutterViewControllerTest, testFlutterViewIsConfigured) {
                                                                                  bundle:nil];
   [viewController viewWillAppear];
   [viewController viewWillAppear];
+  return true;
+}
+
+static void SwizzledNoop(id self, SEL _cmd) {}
+
+// Verify workaround an AppKit bug where mouseDown/mouseUp are not called on the view controller if
+// the view is the content view of an NSPopover AND macOS's Reduced Transparency accessibility
+// setting is enabled.
+//
+// See: https://github.com/flutter/flutter/issues/115015
+// See: http://www.openradar.me/FB12050037
+// See: https://developer.apple.com/documentation/appkit/nsresponder/1524634-mousedown
+- (bool)testMouseDownUpEventsSentToNextResponder {
+  // The root cause of the above bug is NSResponder mouseDown/mouseUp methods that don't correctly
+  // walk the responder chain calling the appropriate method on the next responder under certain
+  // conditions. Simulate this by swizzling out the default implementations and replacing them with
+  // no-ops.
+  Method mouseDown = class_getInstanceMethod([NSResponder class], @selector(mouseDown:));
+  Method mouseUp = class_getInstanceMethod([NSResponder class], @selector(mouseUp:));
+  IMP noopImp = (IMP)SwizzledNoop;
+  IMP origMouseDown = method_setImplementation(mouseDown, noopImp);
+  IMP origMouseUp = method_setImplementation(mouseUp, noopImp);
+
+  // Verify that mouseDown/mouseUp trigger mouseDown/mouseUp calls on FlutterViewController.
+  id engineMock = flutter::testing::CreateMockFlutterEngine(@"");
+  MouseEventFlutterViewController* viewController =
+      [[MouseEventFlutterViewController alloc] initWithEngine:engineMock nibName:@"" bundle:nil];
+  FlutterView* view = (FlutterView*)[viewController view];
+
+  EXPECT_FALSE(viewController.mouseDownCalled);
+  EXPECT_FALSE(viewController.mouseUpCalled);
+
+  NSEvent* mouseEvent = flutter::testing::CreateMouseEvent(0x00);
+  [view mouseDown:mouseEvent];
+  EXPECT_TRUE(viewController.mouseDownCalled);
+  EXPECT_FALSE(viewController.mouseUpCalled);
+
+  viewController.mouseDownCalled = NO;
+  [view mouseUp:mouseEvent];
+  EXPECT_FALSE(viewController.mouseDownCalled);
+  EXPECT_TRUE(viewController.mouseUpCalled);
+
+  // Restore the original NSResponder mouseDown/mouseUp implementations.
+  method_setImplementation(mouseDown, origMouseDown);
+  method_setImplementation(mouseUp, origMouseUp);
   return true;
 }
 


### PR DESCRIPTION
This works around an AppKit bug in which mouseDown/mouseUp events are not correctly forwarded up the responder chain for views nested inside an `NSPopover` if (and only if) the macOS "Reduce Transparency" accessibility setting is enabled in the System Settings.

When the above conditions are satisfied, the nested NSView receives the `mouseDown:`/`mouseUp:` call but if it delegates to the default implementation (implemented in `NSResponder`) `mouseDown:`/`mouseUp:` calls are triggered on containing views (in our case `FlutterViewWrapper`) but not triggered on the view controller and other responders in the responder chain until we an `_NSPopoverWindow` class is hit.

A minimal AppKit-only (non-Flutter) repro shows this bug repros with even a minimal `NSViewController` implementation and an unmodified `NSView`. See: https://github.com/cbracken/PopoverRepro

A radar has been filed with Apple and a copy posted to OpenRadar. See: http://www.openradar.me/FB12050037

In order to work around this bug, we override mouseDown/mouseUp in the topmost containing view of `FlutterView` (in our case, `FlutterViewWrapper`) to have the behaviour documented as the default behaviour in `NSResponder`'s `mouseDown:`/`mouseUp:` documentation. In other words, to simply forward the call to `self.nextResponder`.
See: https://developer.apple.com/documentation/appkit/nsresponder/1524634-mousedown

Because replicating the exact configuration of a `FlutterView` contained in an `NSPopover` and System Settings that have been modified to enable the "Reduce Transparency" setting is difficult and likely error-prone in infra, we instead simulate the bug by testing that even if `NSResponder`'s mouseDown/mouseUp method are swizzled to no-op, these calls are correctly forwarded to the next responder in the chain.

If, in the future Apple does fix this issue, this workaround can be removed once Flutter's minimum supported macOS SDK is at least the version that contains the fix.

Issue: https://github.com/flutter/flutter/issues/115015

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
