### PR TITLE
Add GN arguments that disable building host artifacts and unittests

### DIFF
--- a/common/config.gni
+++ b/common/config.gni
@@ -16,6 +16,9 @@ declare_args() {
 
   # Whether to use a prebuilt Dart SDK instead of building one.
   flutter_prebuilt_dart_sdk = false
+
+  # Whether to build host-side development artifacts.
+  flutter_build_engine_artifacts = true
 }
 
 # feature_defines_list ---------------------------------------------------------
@@ -122,5 +125,6 @@ if (flutter_prebuilt_dart_sdk) {
 # TODO: We can't build the engine artifacts for arm (32-bit) right now;
 # see https://github.com/flutter/flutter/issues/74322
 build_engine_artifacts =
-    current_toolchain == host_toolchain ||
-    (is_linux && !is_chromeos && current_cpu != "arm") || is_mac || is_win
+    flutter_build_engine_artifacts &&
+    (current_toolchain == host_toolchain ||
+     (is_linux && !is_chromeos && current_cpu != "arm") || is_mac || is_win)

--- a/tools/gn
+++ b/tools/gn
@@ -264,7 +264,9 @@ def to_gn_args(args):
   gn_args['full_dart_sdk'] = args.full_dart_sdk
 
   if args.enable_unittests:
-    gn_args['enable_unittests'] = args.enable_unittests
+    gn_args['enable_unittests'] = True
+  if args.no_enable_unittests:
+    gn_args['enable_unittests'] = False
 
   # Skia GN args.
   gn_args['skia_enable_flutter_defines'
@@ -322,6 +324,9 @@ def to_gn_args(args):
     gn_args['target_os'] = args.target_os
     gn_args['target_cpu'] = get_target_cpu(args)
     gn_args['dart_target_arch'] = gn_args['target_cpu']
+
+  if not args.build_engine_artifacts:
+    gn_args['flutter_build_engine_artifacts'] = False
 
   # We cannot cross-compile for 32 bit arm on a Windows host. We work around
   # this by leaving 'target_cpu' and 'dart_target_arch' set to 'arm' so that
@@ -660,7 +665,18 @@ def parse_args(args):
 
   parser.add_argument('--unoptimized', default=False, action='store_true')
 
-  parser.add_argument('--enable-unittests', action='store_true', default=False)
+  parser.add_argument(
+      '--enable-unittests',
+      action='store_true',
+      default=False,
+      help='Force enable building unit test binaries.'
+  )
+  parser.add_argument(
+      '--no-enable-unittests',
+      default=False,
+      action='store_true',
+      help='Force disable building unit test binaries.'
+  )
 
   parser.add_argument(
       '--runtime-mode',
@@ -753,6 +769,19 @@ def parse_args(args):
   )
   parser.add_argument(
       '--arm-float-abi', type=str, choices=['hard', 'soft', 'softfp']
+  )
+
+  parser.add_argument(
+      '--build-engine-artifacts',
+      default=True,
+      action='store_true',
+      help='Build the host-side development artifacts.'
+  )
+  parser.add_argument(
+      '--no-build-engine-artifacts',
+      dest='build_engine_artifacts',
+      action='store_false',
+      help='Do not build the host-side development artifacts.'
   )
 
   parser.add_argument('--goma', default=True, action='store_true')


### PR DESCRIPTION
This PR adds a flag that allows disabling building host engine artifacts during a host build. This is useful when it is only needed to build the desktop embedder for the host platform during a build. This will allow limiting LTO building/linking to a narrower slice of targets.

This PR also adds a flag that disables building unittests for similar reasons.