### PR TITLE
Reland "Make FlutterTest the default test font" (#40188)

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/fonts.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/fonts.dart
@@ -184,12 +184,15 @@ class SkiaFontCollection implements FontCollection {
       }
     }
     final List<UnregisteredFont?> completedPendingFonts = await Future.wait(pendingFonts);
-    completedPendingFonts.add(UnregisteredFont(
+    final List<UnregisteredFont> fonts = <UnregisteredFont>[
+      UnregisteredFont(
         EmbeddedTestFont.flutterTest.data.buffer,
         '<embedded>',
         EmbeddedTestFont.flutterTest.fontFamily,
-    ));
-    _unregisteredFonts.addAll(completedPendingFonts.whereType<UnregisteredFont>());
+      ),
+      ...completedPendingFonts.whereType<UnregisteredFont>(),
+    ];
+    _unregisteredFonts.addAll(fonts);
 
     // Ahem must be added to font fallbacks list regardless of where it was
     // downloaded from.

--- a/lib/web_ui/lib/src/engine/text/font_collection.dart
+++ b/lib/web_ui/lib/src/engine/text/font_collection.dart
@@ -76,13 +76,13 @@ class HtmlFontCollection implements FontCollection {
   @override
   Future<void> debugDownloadTestFonts() async {
     final FontManager fontManager = _testFontManager = FontManager();
-    for (final MapEntry<String, String> fontEntry in testFontUrls.entries) {
-      fontManager.downloadAsset(fontEntry.key, 'url(${fontEntry.value})', const <String, String>{});
-    }
     fontManager._downloadedFonts.add(createDomFontFace(
       EmbeddedTestFont.flutterTest.fontFamily,
       EmbeddedTestFont.flutterTest.data,
     ));
+    for (final MapEntry<String, String> fontEntry in testFontUrls.entries) {
+      fontManager.downloadAsset(fontEntry.key, 'url(${fontEntry.value})', const <String, String>{});
+    }
     await fontManager.downloadAllFonts();
   }
 

--- a/lib/web_ui/test/canvaskit/skia_font_collection_test.dart
+++ b/lib/web_ui/test/canvaskit/skia_font_collection_test.dart
@@ -181,5 +181,14 @@ void testMain() {
       expect(fontCollection.debugRegisteredFonts, isNotEmpty);
       expect(warnings, isEmpty);
     });
+
+    test('FlutterTest is the default test font', () async {
+      final SkiaFontCollection fontCollection = SkiaFontCollection();
+
+      await fontCollection.debugDownloadTestFonts();
+      fontCollection.registerDownloadedFonts();
+      expect(fontCollection.debugRegisteredFonts, isNotEmpty);
+      expect(fontCollection.debugRegisteredFonts!.first.family, 'FlutterTest');
+    });
   });
 }

--- a/runtime/test_font_data.cc
+++ b/runtime/test_font_data.cc
@@ -1622,18 +1622,18 @@ std::vector<sk_sp<SkTypeface>> GetTestFontData() {
   std::vector<sk_sp<SkTypeface>> typefaces;
 #if EMBED_TEST_FONT_DATA
   typefaces.push_back(SkTypeface::MakeFromStream(
+      SkMemoryStream::MakeDirect(kFlutterTestFont, kFlutterTestFontLength)));
+  typefaces.push_back(SkTypeface::MakeFromStream(
       SkMemoryStream::MakeDirect(kAhemFont, kAhemFontLength)));
   typefaces.push_back(SkTypeface::MakeFromStream(
       SkMemoryStream::MakeDirect(kCoughFont, kCoughFontLength)));
-  typefaces.push_back(SkTypeface::MakeFromStream(
-      SkMemoryStream::MakeDirect(kFlutterTestFont, kFlutterTestFontLength)));
 #endif  // EMBED_TEST_FONT_DATA
   return typefaces;
 }
 
 std::vector<std::string> GetTestFontFamilyNames() {
 #if EMBED_TEST_FONT_DATA
-  std::vector<std::string> names = {"Ahem", "Cough", "FlutterTest"};
+  std::vector<std::string> names = {"FlutterTest", "Ahem", "Cough"};
 #else   // EMBED_TEST_FONT_DATA
   std::vector<std::string> names;
 #endif  // EMBED_TEST_FONT_DATA

--- a/runtime/test_font_data.cc
+++ b/runtime/test_font_data.cc
@@ -1621,10 +1621,19 @@ namespace flutter {
 std::vector<sk_sp<SkTypeface>> GetTestFontData() {
   std::vector<sk_sp<SkTypeface>> typefaces;
 #if EMBED_TEST_FONT_DATA
-  typefaces.push_back(SkTypeface::MakeFromStream(
-      SkMemoryStream::MakeDirect(kFlutterTestFont, kFlutterTestFontLength)));
-  typefaces.push_back(SkTypeface::MakeFromStream(
-      SkMemoryStream::MakeDirect(kAhemFont, kAhemFontLength)));
+  const bool defaultsToAhem =
+      std::getenv("FLUTTER_ROOT") && !std::getenv("USE_FLUTTER_TEST_FONT");
+  if (defaultsToAhem) {
+    typefaces.push_back(SkTypeface::MakeFromStream(
+        SkMemoryStream::MakeDirect(kAhemFont, kAhemFontLength)));
+    typefaces.push_back(SkTypeface::MakeFromStream(
+        SkMemoryStream::MakeDirect(kFlutterTestFont, kFlutterTestFontLength)));
+  } else {
+    typefaces.push_back(SkTypeface::MakeFromStream(
+        SkMemoryStream::MakeDirect(kFlutterTestFont, kFlutterTestFontLength)));
+    typefaces.push_back(SkTypeface::MakeFromStream(
+        SkMemoryStream::MakeDirect(kAhemFont, kAhemFontLength)));
+  }
   typefaces.push_back(SkTypeface::MakeFromStream(
       SkMemoryStream::MakeDirect(kCoughFont, kCoughFontLength)));
 #endif  // EMBED_TEST_FONT_DATA
@@ -1632,12 +1641,16 @@ std::vector<sk_sp<SkTypeface>> GetTestFontData() {
 }
 
 std::vector<std::string> GetTestFontFamilyNames() {
-#if EMBED_TEST_FONT_DATA
-  std::vector<std::string> names = {"FlutterTest", "Ahem", "Cough"};
-#else   // EMBED_TEST_FONT_DATA
   std::vector<std::string> names;
+#if EMBED_TEST_FONT_DATA
+  const bool defaultsToAhem =
+      std::getenv("FLUTTER_ROOT") && !std::getenv("USE_FLUTTER_TEST_FONT");
+  if (defaultsToAhem) {
+    names = {"Ahem", "FlutterTest", "Cough"};
+  } else {
+    names = {"FlutterTest", "Ahem", "Cough"};
+  }
 #endif  // EMBED_TEST_FONT_DATA
   return names;
 }
-
 }  // namespace flutter

--- a/testing/dart/canvas_test.dart
+++ b/testing/dart/canvas_test.dart
@@ -331,6 +331,7 @@ void main() {
       builder.pushStyle(TextStyle(
         decoration: TextDecoration.underline,
         decorationColor: const Color(0xFF0000FF),
+        fontFamily: 'Ahem',
         fontSize: 10,
         color: const Color(0xFF000000),
         decorationStyle: style,

--- a/testing/dart/paragraph_builder_test.dart
+++ b/testing/dart/paragraph_builder_test.dart
@@ -7,9 +7,6 @@ import 'dart:ui';
 import 'package:litetest/litetest.dart';
 
 void main() {
-  // The actual values for font measurements will vary by platform slightly.
-  const double epsillon = 0.0001;
-
   test('Should be able to build and layout a paragraph', () {
     final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle());
     builder.addText('Hello');
@@ -40,10 +37,10 @@ void main() {
 
     final List<TextBox> boxes = paragraph.getBoxesForRange(0, 3);
     expect(boxes.length, 1);
-    expect(boxes.first.left, 0);
-    expect(boxes.first.top, closeTo(0, epsillon));
-    expect(boxes.first.right, closeTo(42, epsillon));
-    expect(boxes.first.bottom, closeTo(14, epsillon));
+    expect(boxes.first.left, 0.0);
+    expect(boxes.first.top, 0.0);
+    expect(boxes.first.right, 42.0);
+    expect(boxes.first.bottom, 14.0);
     expect(boxes.first.direction, TextDirection.ltr);
   });
 
@@ -60,13 +57,13 @@ void main() {
     final List<LineMetrics> metrics = paragraph.computeLineMetrics();
     expect(metrics.length, 1);
     expect(metrics.first.hardBreak, true);
-    expect(metrics.first.ascent, closeTo(11.200042724609375, epsillon));
-    expect(metrics.first.descent, closeTo(2.799957275390625, epsillon));
-    expect(metrics.first.unscaledAscent, closeTo(11.200042724609375, epsillon));
+    expect(metrics.first.ascent, 10.5);
+    expect(metrics.first.descent, 3.5);
+    expect(metrics.first.unscaledAscent, 10.5);
     expect(metrics.first.height, 14.0);
     expect(metrics.first.width, 70.0);
     expect(metrics.first.left, 0.0);
-    expect(metrics.first.baseline, closeTo(11.200042724609375, epsillon));
+    expect(metrics.first.baseline, 10.5);
     expect(metrics.first.lineNumber, 0);
   });
 }


### PR DESCRIPTION
Reland #40188, with an additional **temporary** flag (in the form of an env var) to opt-in.  The environment variable does not affect web. DIFF https://github.com/flutter/engine/pull/40245/commits/efe1904c5cc77a059dfcc84270a15ce1549a7677

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
