### PR TITLE
Added additional uri field to routeInformationUpdated to accept entir…

### DIFF
--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -204,7 +204,7 @@ class EngineFlutterWindow extends ui.SingletonFlutterWindow {
               ).toString(),
             );
           } else {
-            path = arguments!.tryString('location')!;
+            path = arguments.tryString('location')!;
           }
           browserHistory.setRouteName(
             path,

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -191,8 +191,23 @@ class EngineFlutterWindow extends ui.SingletonFlutterWindow {
           return true;
         case 'routeInformationUpdated':
           assert(arguments != null);
+          final String? uriString = arguments!.tryString('uri');
+          final String path;
+          if (uriString != null) {
+            final Uri uri = Uri.parse(uriString);
+            // Need to remove scheme and authority.
+            path = Uri.decodeComponent(
+              Uri(
+                path: uri.path.isEmpty ? '/' : uri.path,
+                queryParameters: uri.queryParametersAll.isEmpty ? null : uri.queryParametersAll,
+                fragment: uri.fragment.isEmpty ? null : uri.fragment,
+              ).toString(),
+            );
+          } else {
+            path = arguments!.tryString('location')!;
+          }
           browserHistory.setRouteName(
-            arguments!.tryString('location'),
+            path,
             state: arguments['state'],
             replace: arguments.tryBool('replace') ?? false,
           );

--- a/lib/web_ui/test/window_test.dart
+++ b/lib/web_ui/test/window_test.dart
@@ -301,6 +301,30 @@ void testMain() {
     expect(actualState['state4']['substate2'], 'string2');
   });
 
+  test('routeInformationUpdated can handle uri',
+      () async {
+    await window.debugInitializeHistory(TestUrlStrategy.fromEntry(
+      const TestHistoryEntry('initial state', null, '/initial'),
+    ), useSingle: false);
+    expect(window.browserHistory, isA<MultiEntriesBrowserHistory>());
+
+    // routeInformationUpdated does not
+    final Completer<void> callback = Completer<void>();
+    window.sendPlatformMessage(
+      'flutter/navigation',
+      const JSONMethodCodec().encodeMethodCall(const MethodCall(
+        'routeInformationUpdated',
+        <String, dynamic>{
+          'uri': 'http://myhostname.com/baz',
+        },
+      )),
+      (_) { callback.complete(); },
+    );
+    await callback.future;
+    expect(window.browserHistory, isA<MultiEntriesBrowserHistory>());
+    expect(window.browserHistory.urlStrategy!.getPath(), '/baz');
+  });
+
   test('can replace in MultiEntriesBrowserHistory',
       () async {
     await window.debugInitializeHistory(TestUrlStrategy.fromEntry(

--- a/lib/web_ui/test/window_test.dart
+++ b/lib/web_ui/test/window_test.dart
@@ -315,14 +315,14 @@ void testMain() {
       const JSONMethodCodec().encodeMethodCall(const MethodCall(
         'routeInformationUpdated',
         <String, dynamic>{
-          'uri': 'http://myhostname.com/baz',
+          'uri': 'http://myhostname.com/baz?abc=def#fragment',
         },
       )),
       (_) { callback.complete(); },
     );
     await callback.future;
     expect(window.browserHistory, isA<MultiEntriesBrowserHistory>());
-    expect(window.browserHistory.urlStrategy!.getPath(), '/baz');
+    expect(window.browserHistory.urlStrategy!.getPath(), '/baz?abc=def#fragment');
   });
 
   test('can replace in MultiEntriesBrowserHistory',


### PR DESCRIPTION
…e uri

This unblocks https://github.com/flutter/flutter/pull/119968

Related: https://github.com/flutter/flutter/issues/100624

The goal is to make sure all the route path is passing through framework and engine in full uri format. This is useful if framework would like to handle deeplink from different domains in non-web platform.

While the feature is unrelated to web (at least there isn't a use case for web), but I migrate the routeInformationUpdated to make the API more unified.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
