### PR TITLE
Make no_lto in presubmit explicit in .ci.yaml

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -24,6 +24,7 @@ platform_properties:
       ios_debug: "false"
       ios_profile: "false"
       ios_release: "false"
+      no_lto: "true"
       # CIPD flutter_internal/java/openjdk/$platform
       dependencies: >-
         [
@@ -46,6 +47,7 @@ platform_properties:
       ios_debug: "false"
       ios_profile: "false"
       ios_release: "false"
+      no_lto: "true"
       # CIPD flutter_internal/java/openjdk/$platform
       dependencies: >-
         [
@@ -68,6 +70,7 @@ platform_properties:
       ios_debug: "false"
       ios_profile: "false"
       ios_release: "false"
+      no_lto: "true"
       # CIPD flutter_internal/java/openjdk/$platform
       dependencies: >-
         [
@@ -84,6 +87,8 @@ targets:
       build_android_aot: "true"
       android_sdk_license: \n24333f8a63b6825ea9c5514f83c2829b004d1fee
       android_sdk_preview_license: \n84831b9409646a918e30573bab4c9c91346d8abd
+    postsubmit_properties:
+      no_lto: "false"
     timeout: 60
 
   - name: Linux Android Debug Engine
@@ -95,6 +100,8 @@ targets:
       build_android_vulkan: "true"
       android_sdk_license: \n24333f8a63b6825ea9c5514f83c2829b004d1fee
       android_sdk_preview_license: \n84831b9409646a918e30573bab4c9c91346d8abd
+    postsubmit_properties:
+      no_lto: "false"
     timeout: 60
 
   - name: Linux Android Emulator Tests
@@ -110,6 +117,8 @@ targets:
         ]
       upload_packages: "true"
       clobber: "true"
+    postsubmit_properties:
+      no_lto: "false"
     timeout: 60
     runIf:
       - DEPS
@@ -126,6 +135,8 @@ targets:
     properties:
       build_host: "true"
       upload_metrics: "true"
+    postsubmit_properties:
+      no_lto: "false"
     timeout: 60
 
   - name: Linux Benchmarks (no-upload)
@@ -143,6 +154,8 @@ targets:
       fuchsia_ctl_version: version:0.0.27
       # ensure files from pre-production Fuchsia SDK tests are purged from cache
       clobber: "true"
+    postsubmit_properties:
+      no_lto: "false"
     timeout: 90
 
   - name: Linux Fuchsia FEMU
@@ -155,6 +168,8 @@ targets:
       clobber: "true"
       emulator_arch: "x64"
       enable_cso: "true"
+    postsubmit_properties:
+      no_lto: "false"
     timeout: 60
 
   - name: Linux Fuchsia arm64 FEMU
@@ -167,6 +182,8 @@ targets:
       clobber: "true"
       emulator_arch: "arm64"
       enable_cso: "true"
+    postsubmit_properties:
+      no_lto: "false"
     timeout: 60
 
   - name: Linux Framework Smoke Tests
@@ -184,6 +201,8 @@ targets:
       add_recipes_cq: "true"
       build_host: "true"
       cores: "32"
+    postsubmit_properties:
+      no_lto: "false"
     timeout: 60
 
   - name: Linux Unopt
@@ -191,6 +210,8 @@ targets:
     properties:
       add_recipes_cq: "true"
       clobber: "true"
+    postsubmit_properties:
+      no_lto: "false"
     timeout: 60
 
   - name: Linux License
@@ -207,6 +228,8 @@ targets:
       cores: "32"
       lint_android: "false"
       lint_host: "true"
+    postsubmit_properties:
+      no_lto: "false"
     timeout: 60
     runIf:
       - DEPS
@@ -227,6 +250,8 @@ targets:
       cores: "32"
       lint_android: "true"
       lint_host: "false"
+    postsubmit_properties:
+      no_lto: "false"
     timeout: 60
     runIf:
       - DEPS
@@ -246,6 +271,8 @@ targets:
     properties:
       add_recipes_cq: "true"
       build_host: "true"
+    postsubmit_properties:
+      no_lto: "false"
     timeout: 90
 
   - name: Linux linux_arm_host_engine
@@ -254,6 +281,8 @@ targets:
     properties:
       release_build: "true"
       config_name: linux_arm_host_engine
+    postsubmit_properties:
+      no_lto: "false"
 
   - name: Linux linux_host_engine
     recipe: engine_v2/engine_v2
@@ -261,6 +290,8 @@ targets:
     properties:
       release_build: "true"
       config_name: linux_host_engine
+    postsubmit_properties:
+      no_lto: "false"
 
   - name: Linux linux_host_desktop_engine
     bringup: true
@@ -269,6 +300,8 @@ targets:
     properties:
       release_build: "true"
       config_name: linux_host_desktop_engine
+    postsubmit_properties:
+      no_lto: "false"
 
   - name: Linux linux_android_aot_engine
     recipe: engine_v2/engine_v2
@@ -276,6 +309,8 @@ targets:
     properties:
       release_build: "true"
       config_name: linux_android_aot_engine
+    postsubmit_properties:
+      no_lto: "false"
 
   - name: Linux linux_android_debug_engine
     recipe: engine_v2/engine_v2
@@ -283,6 +318,8 @@ targets:
     properties:
       release_build: "true"
       config_name: linux_android_debug_engine
+    postsubmit_properties:
+      no_lto: "false"
 
   - name: Linux linux_web_engine
     recipe: engine_v2/engine_v2
@@ -290,6 +327,8 @@ targets:
     properties:
       release_build: "true"
       config_name: linux_web_engine
+    postsubmit_properties:
+      no_lto: "false"
 
   - name: Linux Web Engine
     recipe: engine/web_engine
@@ -306,6 +345,8 @@ targets:
           {"dependency": "goldctl", "version": "git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603"}
         ]
       no_goma: "true"
+    postsubmit_properties:
+      no_lto: "false"
     timeout: 60
     runIf:
       - DEPS
@@ -336,6 +377,8 @@ targets:
       shard: web_tests
       subshards: >-
               ["0", "1", "2", "3", "4", "5", "6", "7_last"]
+    postsubmit_properties:
+      no_lto: "false"
     timeout: 60
     runIf:
       - DEPS
@@ -352,6 +395,8 @@ targets:
       android_sdk_license: \n24333f8a63b6825ea9c5514f83c2829b004d1fee
       android_sdk_preview_license: \n84831b9409646a918e30573bab4c9c91346d8abd
       build_android_aot: "true"
+    postsubmit_properties:
+      no_lto: "false"
     timeout: 60
 
   - name: Mac Host Engine
@@ -361,6 +406,8 @@ targets:
         {"download_emsdk": true}
       add_recipes_cq: "true"
       build_host: "true"
+    postsubmit_properties:
+      no_lto: "false"
     timeout: 75
 
   - name: Mac mac_android_aot_engine
@@ -370,6 +417,8 @@ targets:
       config_name: mac_android_aot_engine
       $flutter/osx_sdk : >-
         { "sdk_version": "14a5294e" }
+    postsubmit_properties:
+      no_lto: "false"
 
   - name: Mac mac_host_engine
     recipe: engine_v2/engine_v2
@@ -379,6 +428,8 @@ targets:
       config_name: mac_host_engine
       $flutter/osx_sdk : >-
         { "sdk_version": "14a5294e" }
+    postsubmit_properties:
+      no_lto: "false"
 
   - name: Mac Unopt
     recipe: engine/engine_unopt
@@ -388,6 +439,8 @@ targets:
         [
           "ios-16-0_14a5294e"
         ]
+    postsubmit_properties:
+      no_lto: "false"
     timeout: 75
 
   - name: Mac Host clang-tidy
@@ -397,6 +450,8 @@ targets:
       cores: "12"
       lint_host: "true"
       lint_ios: "false"
+    postsubmit_properties:
+      no_lto: "false"
     timeout: 75
     runIf:
       - DEPS
@@ -418,6 +473,8 @@ targets:
       add_recipes_cq: "true"
       lint_host: "false"
       lint_ios: "true"
+    postsubmit_properties:
+      no_lto: "false"
     timeout: 75
     runIf:
       - DEPS
@@ -439,6 +496,8 @@ targets:
       add_recipes_cq: "true"
       build_ios: "true"
       ios_debug: "true"
+    postsubmit_properties:
+      no_lto: "false"
     timeout: 60
 
   - name: Mac Web Engine
@@ -453,6 +512,8 @@ targets:
           {"dependency": "goldctl", "version": "git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603"}
         ]
       no_goma: "true"
+    postsubmit_properties:
+      no_lto: "false"
     timeout: 60
     runIf:
       - DEPS
@@ -475,6 +536,8 @@ targets:
         [
           {"dependency": "jazzy", "version": "0.14.1"}
         ]
+    postsubmit_properties:
+      no_lto: "false"
 
   - name: Windows Android AOT Engine
     recipe: engine/engine
@@ -482,6 +545,8 @@ targets:
       build_android_aot: "true"
       android_sdk_license: \n24333f8a63b6825ea9c5514f83c2829b004d1fee
       android_sdk_preview_license: \n84831b9409646a918e30573bab4c9c91346d8abd
+    postsubmit_properties:
+      no_lto: "false"
     timeout: 60
 
   - name: Windows Host Engine
@@ -492,6 +557,8 @@ targets:
         {"download_emsdk": true}
       add_recipes_cq: "true"
       build_host: "true"
+    postsubmit_properties:
+      no_lto: "false"
 
   - name: Windows windows_android_aot_engine
     recipe: engine_v2/engine_v2
@@ -499,6 +566,8 @@ targets:
     properties:
       release_build: "true"
       config_name: windows_android_aot_engine
+    postsubmit_properties:
+      no_lto: "false"
 
   - name: Windows windows_host_engine
     recipe: engine_v2/engine_v2
@@ -506,6 +575,8 @@ targets:
     properties:
       release_build: "true"
       config_name: windows_host_engine
+    postsubmit_properties:
+      no_lto: "false"
 
   - name: Windows windows_arm_host_engine
     recipe: engine_v2/engine_v2
@@ -513,11 +584,15 @@ targets:
     properties:
       release_build: "true"
       config_name: windows_arm_host_engine
+    postsubmit_properties:
+      no_lto: "false"
 
   - name: Windows Unopt
     recipe: engine/engine_unopt
     properties:
       add_recipes_cq: "true"
+    postsubmit_properties:
+      no_lto: "false"
     timeout: 75
 
   - name: Windows Web Engine
@@ -531,6 +606,8 @@ targets:
           {"dependency": "chrome_and_driver", "version": "version:111.0"}
         ]
       no_goma: "true"
+    postsubmit_properties:
+      no_lto: "false"
     timeout: 60
     runIf:
       - DEPS
@@ -543,6 +620,8 @@ targets:
     properties:
       build_ios: "true"
       ios_profile: "true"
+    postsubmit_properties:
+      no_lto: "false"
     timeout: 90
     runIf:
       - DEPS
@@ -554,6 +633,8 @@ targets:
     properties:
       build_ios: "true"
       ios_release: "true"
+    postsubmit_properties:
+      no_lto: "false"
     timeout: 90
     runIf:
       - DEPS


### PR DESCRIPTION
Currently --no-lto is hardcoded in presubmit builds in the ci_yaml starlark file here https://cs.opensource.google/flutter/infra/+/main:config/lib/ci_yaml/ci_yaml.star;l=398?q=lto&ss=flutter%2Finfra:config%2F.

This PR shifts setting the property into the `.ci.yaml` file. Since in general we want LTO in prod builds, and no LTO in try builds, this PR sets the `no_lto` property to `true` in the `platform_properties`, then for each configuration sets `no_lto` to `false` in their respective `postsubmit_properties`. This would be less confusing if `.ci.yaml` supported a `presubmit_properties` that could be set once-and-for-all in the `platform_properties` cc @keyonghan 