### PR TITLE
[Impeller] Improve performance / reduce memory usage of path based shadows.

### DIFF
--- a/impeller/entity/contents/solid_color_contents.cc
+++ b/impeller/entity/contents/solid_color_contents.cc
@@ -42,7 +42,7 @@ std::optional<Rect> SolidColorContents::GetCoverage(
 std::optional<Snapshot> SolidColorContents::RenderToSnapshot(
     const ContentContext& renderer,
     const Entity& entity,
-    const std::optional<SamplerDescriptor>& sampler_descriptor = std::nullopt,
+    const std::optional<SamplerDescriptor>& sampler_descriptor,
     bool msaa_enabled) const {
   auto coverage = GetCoverage(entity);
   if (!coverage.has_value()) {

--- a/impeller/entity/contents/solid_color_contents.h
+++ b/impeller/entity/contents/solid_color_contents.h
@@ -42,7 +42,7 @@ class SolidColorContents final : public Contents {
   std::optional<Snapshot> RenderToSnapshot(
       const ContentContext& renderer,
       const Entity& entity,
-      const std::optional<SamplerDescriptor>& sampler_descriptor,
+      const std::optional<SamplerDescriptor>& sampler_descriptor = std::nullopt,
       bool msaa_enabled = true) const override;
 
   // |Contents|

--- a/impeller/entity/contents/solid_color_contents.h
+++ b/impeller/entity/contents/solid_color_contents.h
@@ -39,6 +39,13 @@ class SolidColorContents final : public Contents {
   std::optional<Rect> GetCoverage(const Entity& entity) const override;
 
   // |Contents|
+  std::optional<Snapshot> RenderToSnapshot(
+      const ContentContext& renderer,
+      const Entity& entity,
+      const std::optional<SamplerDescriptor>& sampler_descriptor,
+      bool msaa_enabled = true) const override;
+
+  // |Contents|
   bool ShouldRender(const Entity& entity,
                     const std::optional<Rect>& stencil_coverage) const override;
 

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -2345,5 +2345,34 @@ TEST_P(EntityTest, RuntimeEffect) {
   ASSERT_TRUE(OpenPlaygroundHere(callback));
 }
 
+TEST_P(EntityTest, SolidColorContentsRenderSnapshot) {
+  auto callback = [&](ContentContext& context, RenderPass& pass) -> bool {
+    auto solid_contents = std::make_shared<SolidColorContents>();
+    solid_contents->SetGeometry(Geometry::MakeFillPath(
+        PathBuilder{}.AddRect(Rect::MakeLTRB(10, 10, 100, 100)).TakePath()));
+    solid_contents->SetColor(Color::Red());
+
+    Entity filter_entity;
+    filter_entity.SetContents(solid_contents);
+    auto snapshot = solid_contents->RenderToSnapshot(context, filter_entity);
+
+    if (snapshot->texture->GetSize() != ISize(1, 1)) {
+      FML_DLOG(ERROR) << "Solid Color texture size was not 1x1: "
+                      << snapshot->texture->GetSize();
+      return false;
+    }
+
+    Entity entity;
+    auto contents = TextureContents::MakeRect(Rect::MakeLTRB(0, 0, 500, 256));
+    contents->SetTexture(snapshot->texture);
+    contents->SetSourceRect(Rect::MakeSize(snapshot->texture->GetSize()));
+    entity.SetContents(contents);
+    entity.SetTransformation(Matrix::MakeScale(GetContentScale()));
+    return entity.Render(context, pass);
+  };
+
+  ASSERT_TRUE(OpenPlaygroundHere(callback));
+}
+
 }  // namespace testing
 }  // namespace impeller


### PR DESCRIPTION
We currently have fast paths for rect, rrect, and circle/oval based shadows. For all other paths, we perform 3 passes - one to render a solid color to a snapshot (at scale) and then two gaussian decal blurs. This is fairly expensive, especially if the ultimate size is large.

Rendering the solid color snapshot is wasteful, instead we could allocate a 1x1 texture with the correct color and use that. This is done by implementing RenderToSnapshot in SolidColorContents.

I did find a particularly large shadow in the new flutter gallery. Its possible this is faster because I broke something, but so far everything seems visual OK.


## Before

![image](https://user-images.githubusercontent.com/8975114/224833370-106edbe1-9817-45fc-8b10-000c44994f46.png)

## After

![image](https://user-images.githubusercontent.com/8975114/224833415-ecae4591-b7c6-4716-b0a4-60eb99aa3547.png)

