### PR TITLE
Preserve order when regenerating GPU images

### DIFF
--- a/common/graphics/texture.cc
+++ b/common/graphics/texture.cc
@@ -14,7 +14,7 @@ Texture::Texture(int64_t id) : id_(id) {}
 
 Texture::~Texture() = default;
 
-TextureRegistry::TextureRegistry() = default;
+TextureRegistry::TextureRegistry() : image_counter_(0) {}
 
 void TextureRegistry::RegisterTexture(const std::shared_ptr<Texture>& texture) {
   if (!texture) {
@@ -26,7 +26,13 @@ void TextureRegistry::RegisterTexture(const std::shared_ptr<Texture>& texture) {
 void TextureRegistry::RegisterContextListener(
     uintptr_t id,
     std::weak_ptr<ContextListener> image) {
-  images_[id] = std::move(image);
+  size_t next_id = image_counter_.fetch_add(1);
+  auto const result = image_indices_.insert({id, next_id});
+  if (!result.second) {
+    ordered_images_.erase(result.first->second);
+    result.first->second = next_id;
+  }
+  ordered_images_[next_id] = {next_id, std::move(image)};
 }
 
 void TextureRegistry::UnregisterTexture(int64_t id) {
@@ -39,7 +45,8 @@ void TextureRegistry::UnregisterTexture(int64_t id) {
 }
 
 void TextureRegistry::UnregisterContextListener(uintptr_t id) {
-  images_.erase(id);
+  ordered_images_.erase(image_indices_[id]);
+  image_indices_.erase(id);
 }
 
 void TextureRegistry::OnGrContextCreated() {
@@ -47,11 +54,20 @@ void TextureRegistry::OnGrContextCreated() {
     it.second->OnGrContextCreated();
   }
 
-  for (const auto& [id, weak_image] : images_) {
+  // Calling OnGrContextCreated may result in a subsequent call to
+  // RegisterContextListener from the listener, which may modify the map.
+  std::vector<
+      std::pair<size_t, std::pair<uintptr_t, std::weak_ptr<ContextListener>>>>
+      ordered_images(ordered_images_.begin(), ordered_images_.end());
+
+  for (const auto& [id, pair] : ordered_images) {
+    auto index_id = pair.first;
+    auto weak_image = pair.second;
     if (auto image = weak_image.lock()) {
       image->OnGrContextCreated();
     } else {
-      images_.erase(id);
+      image_indices_.erase(index_id);
+      ordered_images_.erase(id);
     }
   }
 }
@@ -61,11 +77,14 @@ void TextureRegistry::OnGrContextDestroyed() {
     it.second->OnGrContextDestroyed();
   }
 
-  for (const auto& [id, weak_image] : images_) {
+  for (const auto& [id, pair] : ordered_images_) {
+    auto index_id = pair.first;
+    auto weak_image = pair.second;
     if (auto image = weak_image.lock()) {
       image->OnGrContextDestroyed();
     } else {
-      images_.erase(id);
+      image_indices_.erase(index_id);
+      ordered_images_.erase(id);
     }
   }
 }

--- a/common/graphics/texture.h
+++ b/common/graphics/texture.h
@@ -95,7 +95,15 @@ class TextureRegistry {
 
  private:
   std::map<int64_t, std::shared_ptr<Texture>> mapping_;
-  std::map<uintptr_t, std::weak_ptr<ContextListener>> images_;
+  std::atomic_size_t image_counter_;
+  // This map keeps track of registered context listeners by their own
+  // externally provided id. It indexes into ordered_images_.
+  std::map<uintptr_t, size_t> image_indices_;
+  // This map makes sure that iteration of images happens in insertion order
+  // (managed by image_counter_) so that images which depend on other images get
+  // re-created in the right order.
+  std::map<size_t, std::pair<uintptr_t, std::weak_ptr<ContextListener>>>
+      ordered_images_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(TextureRegistry);
 };

--- a/common/graphics/texture.h
+++ b/common/graphics/texture.h
@@ -95,15 +95,16 @@ class TextureRegistry {
 
  private:
   std::map<int64_t, std::shared_ptr<Texture>> mapping_;
-  std::atomic_size_t image_counter_;
+  size_t image_counter_;
   // This map keeps track of registered context listeners by their own
   // externally provided id. It indexes into ordered_images_.
   std::map<uintptr_t, size_t> image_indices_;
   // This map makes sure that iteration of images happens in insertion order
   // (managed by image_counter_) so that images which depend on other images get
   // re-created in the right order.
-  std::map<size_t, std::pair<uintptr_t, std::weak_ptr<ContextListener>>>
-      ordered_images_;
+  using InsertionOrderMap =
+      std::map<size_t, std::pair<uintptr_t, std::weak_ptr<ContextListener>>>;
+  InsertionOrderMap ordered_images_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(TextureRegistry);
 };

--- a/flow/texture_unittests.cc
+++ b/flow/texture_unittests.cc
@@ -20,7 +20,7 @@ struct TestContextListener : public ContextListener {
   TestContextListener(uintptr_t p_id,
                       int_closure p_create,
                       int_closure p_destroy)
-      : id(p_id), create(p_create), destroy(p_destroy) {}
+      : id(p_id), create(std::move(p_create)), destroy(std::move(p_destroy)) {}
 
   virtual ~TestContextListener() = default;
 

--- a/flow/texture_unittests.cc
+++ b/flow/texture_unittests.cc
@@ -4,11 +4,35 @@
 
 #include "flutter/common/graphics/texture.h"
 
+#include <functional>
+
 #include "flutter/flow/testing/mock_texture.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace flutter {
 namespace testing {
+
+namespace {
+using int_closure = std::function<void(int)>;
+
+struct TestContextListener : public ContextListener {
+  TestContextListener(uintptr_t p_id,
+                      int_closure p_create,
+                      int_closure p_destroy)
+      : id(p_id), create(p_create), destroy(p_destroy) {}
+
+  virtual ~TestContextListener() = default;
+
+  const uintptr_t id;
+  int_closure create;
+  int_closure destroy;
+
+  void OnGrContextCreated() override { create(id); }
+
+  void OnGrContextDestroyed() override { destroy(id); }
+};
+}  // namespace
 
 TEST(TextureRegistryTest, UnregisterTextureCallbackTriggered) {
   TextureRegistry registry;
@@ -93,6 +117,25 @@ TEST(TextureRegistryTest, ReuseSameTextureSlot) {
   ASSERT_EQ(registry.GetTexture(0), nullptr);
   ASSERT_TRUE(mock_texture1->unregistered());
   ASSERT_TRUE(mock_texture2->unregistered());
+}
+
+TEST(TextureRegistryTest, CallsOnGrContextCreatedInInsertionOrder) {
+  TextureRegistry registry;
+  std::vector<int> create_order;
+  std::vector<int> destroy_order;
+  auto create = [&](int id) { create_order.push_back(id); };
+  auto destroy = [&](int id) { destroy_order.push_back(id); };
+  auto a = std::make_shared<TestContextListener>(5, create, destroy);
+  auto b = std::make_shared<TestContextListener>(4, create, destroy);
+  auto c = std::make_shared<TestContextListener>(3, create, destroy);
+  registry.RegisterContextListener(a->id, a);
+  registry.RegisterContextListener(b->id, b);
+  registry.RegisterContextListener(c->id, c);
+  registry.OnGrContextDestroyed();
+  registry.OnGrContextCreated();
+
+  EXPECT_THAT(create_order, ::testing::ElementsAre(5, 4, 3));
+  EXPECT_THAT(destroy_order, ::testing::ElementsAre(5, 4, 3));
 }
 
 }  // namespace testing

--- a/lib/ui/painting/display_list_deferred_image_gpu_skia.cc
+++ b/lib/ui/painting/display_list_deferred_image_gpu_skia.cc
@@ -137,7 +137,6 @@ void DlDeferredImageGPUSkia::ImageWrapper::OnGrContextCreated() {
 
 void DlDeferredImageGPUSkia::ImageWrapper::OnGrContextDestroyed() {
   FML_DCHECK(raster_task_runner_->RunsTasksOnCurrentThread());
-
   DeleteTexture();
 }
 

--- a/testing/testing.gni
+++ b/testing/testing.gni
@@ -12,8 +12,7 @@ is_aot_test =
 
 # Unit tests targets are only enabled for host machines and Fuchsia right now
 declare_args() {
-  # enable_unittests = current_toolchain == host_toolchain || is_fuchsia
-  enable_unittests = true  #current_toolchain == host_toolchain || is_fuchsia
+  enable_unittests = current_toolchain == host_toolchain || is_fuchsia
 }
 
 # Creates a translation unit that defines the flutter::testing::GetFixturesPath

--- a/testing/testing.gni
+++ b/testing/testing.gni
@@ -12,7 +12,8 @@ is_aot_test =
 
 # Unit tests targets are only enabled for host machines and Fuchsia right now
 declare_args() {
-  enable_unittests = current_toolchain == host_toolchain || is_fuchsia
+  # enable_unittests = current_toolchain == host_toolchain || is_fuchsia
+  enable_unittests = true  #current_toolchain == host_toolchain || is_fuchsia
 }
 
 # Creates a translation unit that defines the flutter::testing::GetFixturesPath


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/122566

The cause of that bug is that multiple dependent `toImageSync` calls are made such that each successive image depends on the previous one.

In the current implementation, a `std::map` is causing the `OnGrContextCreated` calls to happen in sort-order based on pointer values. This patch adds another map to track the insertion order and a test to make sure that the callbacks respect insertion order.