### PR TITLE
[Impeller] Correct the results of 'GetRight()' and 'GetBottom()' for maximum rect

### DIFF
--- a/impeller/geometry/geometry_unittests.cc
+++ b/impeller/geometry/geometry_unittests.cc
@@ -1493,6 +1493,22 @@ TEST(GeometryTest, RectIntersection) {
     auto u = a.Intersection(b);
     ASSERT_FALSE(u.has_value());
   }
+
+  {
+    Rect a = Rect::MakeMaximum();
+    Rect b(10, 10, 300, 300);
+    auto u = a.Intersection(b);
+    ASSERT_TRUE(u);
+    ASSERT_RECT_NEAR(u.value(), b);
+  }
+
+  {
+    Rect a = Rect::MakeMaximum();
+    Rect b = Rect::MakeMaximum();
+    auto u = a.Intersection(b);
+    ASSERT_TRUE(u);
+    ASSERT_EQ(u, Rect::MakeMaximum());
+  }
 }
 
 TEST(GeometryTest, RectIntersectsWithRect) {
@@ -1518,6 +1534,18 @@ TEST(GeometryTest, RectIntersectsWithRect) {
     Rect a(0, 0, 100, 100);
     Rect b(100, 100, 100, 100);
     ASSERT_FALSE(a.IntersectsWithRect(b));
+  }
+
+  {
+    Rect a = Rect::MakeMaximum();
+    Rect b(10, 10, 100, 100);
+    ASSERT_TRUE(a.IntersectsWithRect(b));
+  }
+
+  {
+    Rect a = Rect::MakeMaximum();
+    Rect b = Rect::MakeMaximum();
+    ASSERT_TRUE(a.IntersectsWithRect(b));
   }
 }
 
@@ -1603,6 +1631,12 @@ TEST(GeometryTest, RectContainsPoint) {
     Point p(199, 199);
     ASSERT_TRUE(r.Contains(p));
   }
+
+  {
+    Rect r = Rect::MakeMaximum();
+    Point p(199, 199);
+    ASSERT_TRUE(r.Contains(p));
+  }
 }
 
 TEST(GeometryTest, RectContainsRect) {
@@ -1635,15 +1669,35 @@ TEST(GeometryTest, RectContainsRect) {
     Rect b(0, 0, 300, 300);
     ASSERT_FALSE(a.Contains(b));
   }
+  {
+    Rect a = Rect::MakeMaximum();
+    Rect b(0, 0, 300, 300);
+    ASSERT_TRUE(a.Contains(b));
+  }
 }
 
 TEST(GeometryTest, RectGetPoints) {
-  Rect r(100, 200, 300, 400);
-  auto points = r.GetPoints();
-  ASSERT_POINT_NEAR(points[0], Point(100, 200));
-  ASSERT_POINT_NEAR(points[1], Point(400, 200));
-  ASSERT_POINT_NEAR(points[2], Point(100, 600));
-  ASSERT_POINT_NEAR(points[3], Point(400, 600));
+  {
+    Rect r(100, 200, 300, 400);
+    auto points = r.GetPoints();
+    ASSERT_POINT_NEAR(points[0], Point(100, 200));
+    ASSERT_POINT_NEAR(points[1], Point(400, 200));
+    ASSERT_POINT_NEAR(points[2], Point(100, 600));
+    ASSERT_POINT_NEAR(points[3], Point(400, 600));
+  }
+
+  {
+    Rect r = Rect::MakeMaximum();
+    auto points = r.GetPoints();
+    ASSERT_EQ(points[0], Point(-std::numeric_limits<float>::infinity(),
+                               -std::numeric_limits<float>::infinity()));
+    ASSERT_EQ(points[1], Point(std::numeric_limits<float>::infinity(),
+                               -std::numeric_limits<float>::infinity()));
+    ASSERT_EQ(points[2], Point(-std::numeric_limits<float>::infinity(),
+                               std::numeric_limits<float>::infinity()));
+    ASSERT_EQ(points[3], Point(std::numeric_limits<float>::infinity(),
+                               std::numeric_limits<float>::infinity()));
+  }
 }
 
 TEST(GeometryTest, RectShift) {

--- a/impeller/geometry/rect.h
+++ b/impeller/geometry/rect.h
@@ -109,8 +109,8 @@ struct TRect {
   }
 
   constexpr bool Contains(const TPoint<Type>& p) const {
-    return p.x >= origin.x && p.x < origin.x + size.width && p.y >= origin.y &&
-           p.y < origin.y + size.height;
+    return p.x >= GetLeft() && p.x < GetRight() && p.y >= GetTop() &&
+           p.y < GetBottom();
   }
 
   constexpr bool Contains(const TRect& o) const {
@@ -124,27 +124,35 @@ struct TRect {
   constexpr bool IsMaximum() const { return *this == MakeMaximum(); }
 
   constexpr auto GetLeft() const {
+    if (IsMaximum()) {
+      return -std::numeric_limits<Type>::infinity();
+    }
     return std::min(origin.x, origin.x + size.width);
   }
 
   constexpr auto GetTop() const {
+    if (IsMaximum()) {
+      return -std::numeric_limits<Type>::infinity();
+    }
     return std::min(origin.y, origin.y + size.height);
   }
 
   constexpr auto GetRight() const {
+    if (IsMaximum()) {
+      return std::numeric_limits<Type>::infinity();
+    }
     return std::max(origin.x, origin.x + size.width);
   }
 
   constexpr auto GetBottom() const {
+    if (IsMaximum()) {
+      return std::numeric_limits<Type>::infinity();
+    }
     return std::max(origin.y, origin.y + size.height);
   }
 
   constexpr std::array<T, 4> GetLTRB() const {
-    const auto left = std::min(origin.x, origin.x + size.width);
-    const auto top = std::min(origin.y, origin.y + size.height);
-    const auto right = std::max(origin.x, origin.x + size.width);
-    const auto bottom = std::max(origin.y, origin.y + size.height);
-    return {left, top, right, bottom};
+    return {GetLeft(), GetTop(), GetRight(), GetBottom()};
   }
 
   /// @brief  Get a version of this rectangle that has a non-negative size.


### PR DESCRIPTION
fix https://github.com/flutter/flutter/issues/122486

Without this patch: if `origin.x` is `-inf` and `size.width` is `+inf`, Then `right` is `std::max(-inf, -inf + +inf)`,  which result is `-inf`. So the result of `GetLTRG()` is `[-inf, -inf, -inf, -inf]`

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
