### PR TITLE
Analyze more shaders

### DIFF
--- a/ci/licenses_golden/excluded_files
+++ b/ci/licenses_golden/excluded_files
@@ -154,6 +154,7 @@
 ../../../flutter/impeller/tessellator/tessellator_unittests.cc
 ../../../flutter/impeller/tools/build_metal_library.py
 ../../../flutter/impeller/tools/check_licenses.py
+../../../flutter/impeller/tools/malioc_cores.py
 ../../../flutter/impeller/tools/malioc_diff.py
 ../../../flutter/impeller/tools/xxd.py
 ../../../flutter/impeller/typographer/typographer_unittests.cc

--- a/impeller/entity/BUILD.gn
+++ b/impeller/entity/BUILD.gn
@@ -7,6 +7,10 @@ import("//flutter/impeller/tools/impeller.gni")
 impeller_shaders("entity_shaders") {
   name = "entity"
 
+  if (impeller_enable_vulkan) {
+    vulkan_language_version = 130
+  }
+
   shaders = [
     "shaders/blending/advanced_blend.vert",
     "shaders/blending/advanced_blend_color.frag",
@@ -69,7 +73,11 @@ impeller_shaders("modern_entity_shaders") {
   name = "modern"
 
   if (impeller_enable_opengles) {
-    gles_language_version = "460"
+    gles_language_version = 460
+  }
+
+  if (impeller_enable_vulkan) {
+    vulkan_language_version = 130
   }
 
   shaders = [
@@ -91,7 +99,11 @@ impeller_shaders("framebuffer_blend_entity_shaders") {
 
   # This version is to disable malioc checks.
   if (impeller_enable_opengles) {
-    gles_language_version = "460"
+    gles_language_version = 460
+  }
+
+  if (impeller_enable_vulkan) {
+    vulkan_language_version = 130
   }
 
   shaders = [

--- a/impeller/scene/shaders/BUILD.gn
+++ b/impeller/scene/shaders/BUILD.gn
@@ -7,6 +7,10 @@ import("//flutter/impeller/tools/impeller.gni")
 impeller_shaders("shaders") {
   name = "scene"
 
+  if (impeller_enable_vulkan) {
+    vulkan_language_version = 130
+  }
+
   shaders = [
     "skinned.vert",
     "unskinned.vert",

--- a/impeller/tools/impeller.gni
+++ b/impeller/tools/impeller.gni
@@ -394,7 +394,7 @@ template("impellerc_reflect") {
   }
 }
 
-template("impeller_shaders_metal") {
+template("_impeller_shaders_metal") {
   assert(defined(invoker.shaders), "Impeller shaders must be specified.")
   assert(defined(invoker.name), "Name of the shader library must be specified.")
 
@@ -478,7 +478,7 @@ template("blobcat_library") {
   }
 }
 
-template("impeller_shaders_gles") {
+template("_impeller_shaders_gles") {
   assert(defined(invoker.shaders), "Impeller shaders must be specified.")
   assert(defined(invoker.name), "Name of the shader library must be specified.")
   assert(defined(invoker.analyze), "Whether to analyze must be specified.")
@@ -557,9 +557,10 @@ template("impeller_shaders_gles") {
   }
 }
 
-template("impeller_shaders_vk") {
+template("_impeller_shaders_vk") {
   assert(defined(invoker.shaders), "Impeller shaders must be specified.")
   assert(defined(invoker.name), "Name of the shader library must be specified.")
+  assert(defined(invoker.analyze), "Whether to analyze must be specified.")
 
   shaders_base_name = string_join("",
                                   [
@@ -583,10 +584,23 @@ template("impeller_shaders_vk") {
     defines = [ "IMPELLER_TARGET_VULKAN" ]
   }
 
+  vk_shaders =
+      filter_include(get_target_outputs(":$impellerc_vk"), [ "*.vkspv" ])
+
+  if (invoker.analyze) {
+    analyze_lib = "analyze_$target_name"
+    malioc_analyze_shaders(analyze_lib) {
+      shaders = vk_shaders
+      if (defined(invoker.vulkan_language_version)) {
+        vulkan_language_version = invoker.vulkan_language_version
+      }
+      deps = [ ":$impellerc_vk" ]
+    }
+  }
+
   vk_lib = "genlib_$target_name"
   blobcat_library(vk_lib) {
-    shaders =
-        filter_include(get_target_outputs(":$impellerc_vk"), [ "*.vkspv" ])
+    shaders = vk_shaders
     deps = [ ":$impellerc_vk" ]
   }
 
@@ -608,12 +622,50 @@ template("impeller_shaders_vk") {
   group(target_name) {
     public_deps = [ ":$embed_vk_lib" ]
 
+    if (invoker.analyze) {
+      public_deps += [ ":$analyze_lib" ]
+    }
+
     if (!impeller_enable_metal) {
       public_deps += [ ":$reflect_vk" ]
     }
   }
 }
 
+# ------------------------------------------------------------------------------
+# @brief           A target for precompiled shaders and the associated
+#                  generated reflection library.
+#
+# @param[required] name
+#
+#    The base name for the reflected C++ library.
+#
+# @param[required] shaders
+#
+#    A list of GLSL shader files.
+#
+# @param[optional] analyze
+#
+#    Whether to analyze shaders with malioc. Defaults to false. Shaders will
+#    only be analyzed if the GN argument "impeller_malioc_path" is defined.
+#
+# @param[optional] enable_opengles
+#
+#    Whether to compile the shaders for the OpenGL ES backend. Defaults to the
+#    value of the GN argument "impeller_enable_opengles".
+#
+# @param[optional] gles_language_version
+#
+#    The GLES version required by the shaders.
+#
+# @param[optional] metal_version
+#
+#    The version of the Metal API required by the shaders.
+#
+# @param[optional] vulkan_language_version
+#
+#    The SPIR-V version required by the shaders.
+#
 template("impeller_shaders") {
   metal_version = "1.2"
   if (defined(invoker.metal_version)) {
@@ -628,7 +680,7 @@ template("impeller_shaders") {
 
   if (impeller_enable_metal) {
     mtl_shaders = "mtl_$target_name"
-    impeller_shaders_metal(mtl_shaders) {
+    _impeller_shaders_metal(mtl_shaders) {
       name = invoker.name
       shaders = invoker.shaders
       metal_version = metal_version
@@ -641,7 +693,7 @@ template("impeller_shaders") {
       analyze = false
     }
     gles_shaders = "gles_$target_name"
-    impeller_shaders_gles(gles_shaders) {
+    _impeller_shaders_gles(gles_shaders) {
       name = invoker.name
       if (defined(invoker.gles_language_version)) {
         gles_language_version = invoker.gles_language_version
@@ -656,11 +708,19 @@ template("impeller_shaders") {
   }
 
   if (impeller_enable_vulkan) {
+    analyze = true
+    if (defined(invoker.analyze) && !invoker.analyze) {
+      analyze = false
+    }
     vk_shaders = "vk_$target_name"
-    impeller_shaders_vk(vk_shaders) {
+    _impeller_shaders_vk(vk_shaders) {
       name = invoker.name
+      if (defined(invoker.vulkan_language_version)) {
+        vulkan_language_version = invoker.vulkan_language_version
+      }
       shaders = invoker.shaders
       metal_version = metal_version
+      analyze = analyze
     }
   }
 

--- a/impeller/tools/malioc.gni
+++ b/impeller/tools/malioc.gni
@@ -10,109 +10,114 @@ declare_args() {
   # Path to the Mali offline compiler tool 'malioc'.
   impeller_malioc_path = ""
 
-  impeller_malioc_cores = []
+  impeller_malioc_core_filter = [
+    "Mali-G78",
+    "Mali-T880",
+  ]
 }
 
-if (impeller_malioc_path != "" && impeller_malioc_cores == []) {
-  core_list_file = "$root_build_dir/mali_core_list.json"
-  exec_script("//build/gn_run_binary.py",
+if (impeller_malioc_path != "") {
+  _core_list_file = "$root_build_dir/mali_core_list.json"
+  exec_script("//flutter/impeller/tools/malioc_cores.py",
               [
+                "--malioc",
                 rebase_path(impeller_malioc_path, root_build_dir),
-                "--list",
-                "--format",
-                "json",
                 "--output",
-                rebase_path(core_list_file),
+                rebase_path(_core_list_file),
               ])
-  _mali_cores = read_file(core_list_file, "json")
-  foreach(mali_core, _mali_cores.cores) {
-    impeller_malioc_cores += [ mali_core.core ]
-  }
+  _impeller_malioc_cores = read_file(_core_list_file, "json")
 }
 
 template("malioc_analyze_shaders") {
-  # TODO(zra): Check that gles_language_version is in the supported set. For now
-  # assume that if it is set, it is being set to 460, which malioc does not
-  # support.
-  if (impeller_malioc_path == "" || defined(invoker.gles_language_version)) {
-    if (defined(invoker.gles_language_version) &&
-        invoker.gles_language_version != "460") {
-      print("Disabling analysis for shaders in $target_name due to gles",
-            "version explicitly set to ${invoker.gles_language_version}.")
-    }
+  if (impeller_malioc_path == "") {
     group(target_name) {
       not_needed(invoker, "*")
     }
   } else {
     target_deps = []
-    foreach(core, impeller_malioc_cores) {
-      foreach(source, invoker.shaders) {
-        shader_file_name = get_path_info(source, "name")
-        analysis_target = "${target_name}_${shader_file_name}_${core}_malioc"
-        target_deps += [ ":$analysis_target" ]
-        action(analysis_target) {
-          forward_variables_from(invoker,
-                                 "*",
-                                 [
-                                   "args",
-                                   "depfile",
-                                   "inputs",
-                                   "outputs",
-                                   "pool",
-                                   "script",
-                                 ])
+    foreach(core, _impeller_malioc_cores) {
+      foreach(filter_core, impeller_malioc_core_filter) {
+        if (core.core == filter_core) {
+          foreach(source, invoker.shaders) {
+            # Should be "gles" or "vkspv"
+            backend_ext = get_path_info(source, "extension")
+            assert(
+                backend_ext == "gles" || backend_ext == "vkspv",
+                "Shader for unsupported backend passed to malioc: {{source}}")
+            shader_file_name = get_path_info(source, "name")
+            analysis_target =
+                "${target_name}_${shader_file_name}_${core.core}_malioc"
+            if ((backend_ext == "gles" &&
+                 defined(invoker.gles_language_version) &&
+                 core.opengles_max_version < invoker.gles_language_version) ||
+                (backend_ext == "vkspv" &&
+                 defined(invoker.vulkan_language_version) &&
+                 core.vulkan_max_version < invoker.vulkan_language_version)) {
+              group(analysis_target) {
+                not_needed(invoker, "*")
+              }
+            } else {
+              target_deps += [ ":$analysis_target" ]
+              action(analysis_target) {
+                forward_variables_from(invoker,
+                                       "*",
+                                       [
+                                         "args",
+                                         "depfile",
+                                         "inputs",
+                                         "outputs",
+                                         "pool",
+                                         "script",
+                                       ])
 
-          script = "//build/gn_run_binary.py"
-          pool = "//flutter/impeller/tools:malioc_pool"
+                script = "//build/gn_run_binary.py"
+                pool = "//flutter/impeller/tools:malioc_pool"
 
-          # Should be "gles" or "vkspv"
-          backend_ext = get_path_info(source, "extension")
-          assert(backend_ext == "gles",
-                 "Shader for unsupported backend passed to malioc: {{source}}")
+                # Nest all malioc output under its own subdirectory of root_gen_dir
+                # so that it's easier to diff it against the state before any changes.
+                subdir = rebase_path(target_gen_dir, root_gen_dir)
+                output_file = "$root_gen_dir/malioc/$subdir/${shader_file_name}.${backend_ext}.${core.core}.json"
+                outputs = [ output_file ]
 
-          # Nest all malioc output under its own subdirectory of root_gen_dir
-          # so that it's easier to diff it against the state before any changes.
-          subdir = rebase_path(target_gen_dir, root_gen_dir)
-          output_file =
-              "$root_gen_dir/malioc/$subdir/${shader_file_name}.$core.json"
-          outputs = [ output_file ]
+                # Determine the kind of the shader from the file name
+                name = get_path_info(source, "name")
+                shader_kind_ext = get_path_info(name, "extension")
 
-          # Determine the kind of the shader from the file name
-          name = get_path_info(source, "name")
-          shader_kind_ext = get_path_info(name, "extension")
+                if (shader_kind_ext == "comp") {
+                  shader_kind_flag = "--compute"
+                } else if (shader_kind_ext == "frag") {
+                  shader_kind_flag = "--fragment"
+                } else if (shader_kind_ext == "geom") {
+                  shader_kind_flag = "--geometry"
+                } else if (shader_kind_ext == "tesc") {
+                  shader_kind_flag = "--tessellation_control"
+                } else if (shader_kind_ext == "tese") {
+                  shader_kind_flag = "--tessellation_evaluation"
+                } else if (shader_kind_ext == "vert") {
+                  shader_kind_flag = "--vertex"
+                } else {
+                  assert(false, "Unknown shader kind: {{source}}")
+                }
 
-          if (shader_kind_ext == "comp") {
-            shader_kind_flag = "--compute"
-          } else if (shader_kind_ext == "frag") {
-            shader_kind_flag = "--fragment"
-          } else if (shader_kind_ext == "geom") {
-            shader_kind_flag = "--geometry"
-          } else if (shader_kind_ext == "tesc") {
-            shader_kind_flag = "--tessellation_control"
-          } else if (shader_kind_ext == "tese") {
-            shader_kind_flag = "--tessellation_evaluation"
-          } else if (shader_kind_ext == "vert") {
-            shader_kind_flag = "--vertex"
-          } else {
-            assert(false, "Unknown shader kind: {{source}}")
+                args = [
+                  rebase_path(impeller_malioc_path, root_build_dir),
+                  "--format",
+                  "json",
+                  shader_kind_flag,
+                  "--core",
+                  core.core,
+                  "--output",
+                  rebase_path(output_file),
+                ]
+
+                if (backend_ext == "vkspv") {
+                  args += [ "--vulkan" ]
+                }
+
+                args += [ rebase_path(source) ]
+              }
+            }
           }
-
-          args = [
-            rebase_path(impeller_malioc_path, root_build_dir),
-            "--format",
-            "json",
-            shader_kind_flag,
-            "--core",
-            core,
-            "--output",
-            rebase_path(output_file),
-          ]
-
-          if (backend_ext == "vkspv") {
-            args += [ "--vulkan" ]
-          }
-
-          args += [ rebase_path(source) ]
         }
       }
     }

--- a/impeller/tools/malioc.json
+++ b/impeller/tools/malioc.json
@@ -1,4 +1,3415 @@
 {
+  "flutter/impeller/entity/advanced_blend.vert.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/advanced_blend.vert.vkspv",
+      "has_uniform_computation": true,
+      "type": "Vertex",
+      "variants": {
+        "Position": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 20,
+          "work_registers_used": 32
+        },
+        "Varying": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.0625,
+              0.03125,
+              0.0625,
+              0.0,
+              4.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              0.0625,
+              0.03125,
+              0.0625,
+              0.0,
+              4.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.0625,
+              0.03125,
+              0.0625,
+              0.0,
+              4.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 16,
+          "work_registers_used": 8
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/advanced_blend_color.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/advanced_blend_color.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": true,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": 62,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "arith_total",
+              "arith_fma"
+            ],
+            "longest_path_cycles": [
+              0.65625,
+              0.65625,
+              0.53125,
+              0.625,
+              0.0,
+              0.5,
+              0.5
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "shortest_path_cycles": [
+              0.359375,
+              0.328125,
+              0.359375,
+              0.25,
+              0.0,
+              0.25,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_fma"
+            ],
+            "total_cycles": [
+              0.65625,
+              0.65625,
+              0.578125,
+              0.625,
+              0.0,
+              0.5,
+              0.5
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 10,
+          "work_registers_used": 15
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/advanced_blend_colorburn.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/advanced_blend_colorburn.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": true,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": 73,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "arith_total",
+              "arith_sfu"
+            ],
+            "longest_path_cycles": [
+              0.6875,
+              0.296875,
+              0.637499988079071,
+              0.6875,
+              0.0,
+              0.5,
+              0.5
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "shortest_path_cycles": [
+              0.515625,
+              0.265625,
+              0.515625,
+              0.4375,
+              0.0,
+              0.25,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_cvt",
+              "arith_sfu"
+            ],
+            "total_cycles": [
+              0.6875,
+              0.296875,
+              0.6875,
+              0.6875,
+              0.0,
+              0.5,
+              0.5
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 8,
+          "work_registers_used": 16
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/advanced_blend_colordodge.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/advanced_blend_colordodge.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": true,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": 69,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "arith_total",
+              "arith_sfu"
+            ],
+            "longest_path_cycles": [
+              0.6875,
+              0.265625,
+              0.637499988079071,
+              0.6875,
+              0.0,
+              0.5,
+              0.5
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "shortest_path_cycles": [
+              0.515625,
+              0.234375,
+              0.515625,
+              0.4375,
+              0.0,
+              0.25,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_cvt",
+              "arith_sfu"
+            ],
+            "total_cycles": [
+              0.6875,
+              0.265625,
+              0.6875,
+              0.6875,
+              0.0,
+              0.5,
+              0.5
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 8,
+          "work_registers_used": 14
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/advanced_blend_darken.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/advanced_blend_darken.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": true,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "arith_total",
+              "arith_sfu",
+              "varying",
+              "texture"
+            ],
+            "longest_path_cycles": [
+              0.5,
+              0.171875,
+              0.390625,
+              0.5,
+              0.0,
+              0.5,
+              0.5
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "shortest_path_cycles": [
+              0.265625,
+              0.140625,
+              0.265625,
+              0.25,
+              0.0,
+              0.25,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_sfu",
+              "varying",
+              "texture"
+            ],
+            "total_cycles": [
+              0.5,
+              0.171875,
+              0.4375,
+              0.5,
+              0.0,
+              0.5,
+              0.5
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 6,
+          "work_registers_used": 11
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/advanced_blend_difference.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/advanced_blend_difference.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": true,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "arith_total",
+              "arith_sfu",
+              "varying",
+              "texture"
+            ],
+            "longest_path_cycles": [
+              0.5,
+              0.203125,
+              0.359375,
+              0.5,
+              0.0,
+              0.5,
+              0.5
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_sfu",
+              "varying"
+            ],
+            "shortest_path_cycles": [
+              0.25,
+              0.171875,
+              0.234375,
+              0.25,
+              0.0,
+              0.25,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_sfu",
+              "varying",
+              "texture"
+            ],
+            "total_cycles": [
+              0.5,
+              0.203125,
+              0.40625,
+              0.5,
+              0.0,
+              0.5,
+              0.5
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 6,
+          "work_registers_used": 11
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/advanced_blend_exclusion.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/advanced_blend_exclusion.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": true,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "arith_total",
+              "arith_sfu",
+              "varying",
+              "texture"
+            ],
+            "longest_path_cycles": [
+              0.5,
+              0.28125,
+              0.359375,
+              0.5,
+              0.0,
+              0.5,
+              0.5
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_sfu",
+              "varying"
+            ],
+            "shortest_path_cycles": [
+              0.25,
+              0.25,
+              0.234375,
+              0.25,
+              0.0,
+              0.25,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_sfu",
+              "varying",
+              "texture"
+            ],
+            "total_cycles": [
+              0.5,
+              0.28125,
+              0.40625,
+              0.5,
+              0.0,
+              0.5,
+              0.5
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 6,
+          "work_registers_used": 11
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/advanced_blend_hardlight.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/advanced_blend_hardlight.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": true,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "arith_total",
+              "arith_sfu",
+              "varying",
+              "texture"
+            ],
+            "longest_path_cycles": [
+              0.5,
+              0.46875,
+              0.421875,
+              0.5,
+              0.0,
+              0.5,
+              0.5
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_fma"
+            ],
+            "shortest_path_cycles": [
+              0.4375,
+              0.4375,
+              0.296875,
+              0.25,
+              0.0,
+              0.25,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_sfu",
+              "varying",
+              "texture"
+            ],
+            "total_cycles": [
+              0.5,
+              0.46875,
+              0.46875,
+              0.5,
+              0.0,
+              0.5,
+              0.5
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 8,
+          "work_registers_used": 15
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/advanced_blend_hue.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/advanced_blend_hue.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": true,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": 70,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "arith_total",
+              "arith_fma"
+            ],
+            "longest_path_cycles": [
+              0.762499988079071,
+              0.762499988079071,
+              0.6875,
+              0.6875,
+              0.0,
+              0.5,
+              0.5
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "shortest_path_cycles": [
+              0.5,
+              0.328125,
+              0.5,
+              0.25,
+              0.0,
+              0.25,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "total_cycles": [
+              0.78125,
+              0.762499988079071,
+              0.78125,
+              0.6875,
+              0.0,
+              0.5,
+              0.5
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 10,
+          "work_registers_used": 15
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/advanced_blend_lighten.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/advanced_blend_lighten.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": true,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "arith_total",
+              "arith_sfu",
+              "varying",
+              "texture"
+            ],
+            "longest_path_cycles": [
+              0.5,
+              0.171875,
+              0.390625,
+              0.5,
+              0.0,
+              0.5,
+              0.5
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "shortest_path_cycles": [
+              0.265625,
+              0.140625,
+              0.265625,
+              0.25,
+              0.0,
+              0.25,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_sfu",
+              "varying",
+              "texture"
+            ],
+            "total_cycles": [
+              0.5,
+              0.171875,
+              0.4375,
+              0.5,
+              0.0,
+              0.5,
+              0.5
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 6,
+          "work_registers_used": 11
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/advanced_blend_luminosity.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/advanced_blend_luminosity.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": true,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": 62,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "arith_total",
+              "arith_fma"
+            ],
+            "longest_path_cycles": [
+              0.65625,
+              0.65625,
+              0.53125,
+              0.625,
+              0.0,
+              0.5,
+              0.5
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "shortest_path_cycles": [
+              0.359375,
+              0.328125,
+              0.359375,
+              0.25,
+              0.0,
+              0.25,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_fma"
+            ],
+            "total_cycles": [
+              0.65625,
+              0.65625,
+              0.578125,
+              0.625,
+              0.0,
+              0.5,
+              0.5
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 10,
+          "work_registers_used": 15
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/advanced_blend_multiply.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/advanced_blend_multiply.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": true,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "arith_total",
+              "arith_sfu",
+              "varying",
+              "texture"
+            ],
+            "longest_path_cycles": [
+              0.5,
+              0.203125,
+              0.359375,
+              0.5,
+              0.0,
+              0.5,
+              0.5
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_sfu",
+              "varying"
+            ],
+            "shortest_path_cycles": [
+              0.25,
+              0.171875,
+              0.234375,
+              0.25,
+              0.0,
+              0.25,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_sfu",
+              "varying",
+              "texture"
+            ],
+            "total_cycles": [
+              0.5,
+              0.203125,
+              0.40625,
+              0.5,
+              0.0,
+              0.5,
+              0.5
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 6,
+          "work_registers_used": 11
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/advanced_blend_overlay.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/advanced_blend_overlay.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": true,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "arith_total",
+              "arith_sfu",
+              "varying",
+              "texture"
+            ],
+            "longest_path_cycles": [
+              0.5,
+              0.46875,
+              0.421875,
+              0.5,
+              0.0,
+              0.5,
+              0.5
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_fma"
+            ],
+            "shortest_path_cycles": [
+              0.4375,
+              0.4375,
+              0.296875,
+              0.25,
+              0.0,
+              0.25,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_sfu",
+              "varying",
+              "texture"
+            ],
+            "total_cycles": [
+              0.5,
+              0.46875,
+              0.46875,
+              0.5,
+              0.0,
+              0.5,
+              0.5
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 8,
+          "work_registers_used": 15
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/advanced_blend_saturation.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/advanced_blend_saturation.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": true,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": 70,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "arith_total",
+              "arith_fma"
+            ],
+            "longest_path_cycles": [
+              0.762499988079071,
+              0.762499988079071,
+              0.6875,
+              0.6875,
+              0.0,
+              0.5,
+              0.5
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "shortest_path_cycles": [
+              0.5,
+              0.328125,
+              0.5,
+              0.25,
+              0.0,
+              0.25,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "total_cycles": [
+              0.78125,
+              0.762499988079071,
+              0.78125,
+              0.6875,
+              0.0,
+              0.5,
+              0.5
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 10,
+          "work_registers_used": 15
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/advanced_blend_screen.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/advanced_blend_screen.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": true,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "arith_total",
+              "arith_sfu",
+              "varying",
+              "texture"
+            ],
+            "longest_path_cycles": [
+              0.5,
+              0.25,
+              0.359375,
+              0.5,
+              0.0,
+              0.5,
+              0.5
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_sfu",
+              "varying"
+            ],
+            "shortest_path_cycles": [
+              0.25,
+              0.21875,
+              0.234375,
+              0.25,
+              0.0,
+              0.25,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_sfu",
+              "varying",
+              "texture"
+            ],
+            "total_cycles": [
+              0.5,
+              0.25,
+              0.40625,
+              0.5,
+              0.0,
+              0.5,
+              0.5
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 6,
+          "work_registers_used": 11
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/advanced_blend_softlight.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/advanced_blend_softlight.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": true,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "arith_total",
+              "arith_fma"
+            ],
+            "longest_path_cycles": [
+              0.78125,
+              0.78125,
+              0.5625,
+              0.6875,
+              0.0,
+              0.5,
+              0.5
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_fma"
+            ],
+            "shortest_path_cycles": [
+              0.75,
+              0.75,
+              0.4375,
+              0.4375,
+              0.0,
+              0.25,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_fma"
+            ],
+            "total_cycles": [
+              0.78125,
+              0.78125,
+              0.609375,
+              0.6875,
+              0.0,
+              0.5,
+              0.5
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 12,
+          "work_registers_used": 25
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/blend.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/blend.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": true,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "texture"
+            ],
+            "longest_path_cycles": [
+              0.0625,
+              0.046875,
+              0.0625,
+              0.0,
+              0.0,
+              0.125,
+              0.25
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "texture"
+            ],
+            "shortest_path_cycles": [
+              0.0625,
+              0.046875,
+              0.0625,
+              0.0,
+              0.0,
+              0.125,
+              0.25
+            ],
+            "total_bound_pipelines": [
+              "texture"
+            ],
+            "total_cycles": [
+              0.0625,
+              0.046875,
+              0.0625,
+              0.0,
+              0.0,
+              0.125,
+              0.25
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 4,
+          "work_registers_used": 6
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/blend.vert.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/blend.vert.vkspv",
+      "has_uniform_computation": true,
+      "type": "Vertex",
+      "variants": {
+        "Position": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 18,
+          "work_registers_used": 32
+        },
+        "Varying": {
+          "fp16_arithmetic": null,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              3.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              3.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              3.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 14,
+          "work_registers_used": 6
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/border_mask_blur.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/border_mask_blur.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": true,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": 5,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "arith_total",
+              "arith_fma"
+            ],
+            "longest_path_cycles": [
+              0.8125,
+              0.8125,
+              0.203125,
+              0.25,
+              0.0,
+              0.25,
+              0.25
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_fma"
+            ],
+            "shortest_path_cycles": [
+              0.8125,
+              0.8125,
+              0.203125,
+              0.25,
+              0.0,
+              0.25,
+              0.25
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_fma"
+            ],
+            "total_cycles": [
+              0.8125,
+              0.8125,
+              0.203125,
+              0.25,
+              0.0,
+              0.25,
+              0.25
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 12,
+          "work_registers_used": 22
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/border_mask_blur.vert.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/border_mask_blur.vert.vkspv",
+      "has_uniform_computation": true,
+      "type": "Vertex",
+      "variants": {
+        "Position": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 20,
+          "work_registers_used": 32
+        },
+        "Varying": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.03125,
+              0.015625,
+              0.03125,
+              0.0,
+              3.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              0.03125,
+              0.015625,
+              0.03125,
+              0.0,
+              3.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.03125,
+              0.015625,
+              0.03125,
+              0.0,
+              3.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 16,
+          "work_registers_used": 7
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/color_matrix_color_filter.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/color_matrix_color_filter.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": true,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "arith_total",
+              "arith_fma",
+              "varying",
+              "texture"
+            ],
+            "longest_path_cycles": [
+              0.25,
+              0.25,
+              0.0625,
+              0.0625,
+              0.0,
+              0.25,
+              0.25
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_fma",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_cycles": [
+              0.25,
+              0.25,
+              0.0625,
+              0.0625,
+              0.0,
+              0.25,
+              0.25
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_fma",
+              "varying",
+              "texture"
+            ],
+            "total_cycles": [
+              0.25,
+              0.25,
+              0.0625,
+              0.0625,
+              0.0,
+              0.25,
+              0.25
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 14,
+          "work_registers_used": 10
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/color_matrix_color_filter.vert.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/color_matrix_color_filter.vert.vkspv",
+      "has_uniform_computation": true,
+      "type": "Vertex",
+      "variants": {
+        "Position": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 20,
+          "work_registers_used": 32
+        },
+        "Varying": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.03125,
+              0.015625,
+              0.03125,
+              0.0,
+              3.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              0.03125,
+              0.015625,
+              0.03125,
+              0.0,
+              3.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.03125,
+              0.015625,
+              0.03125,
+              0.0,
+              3.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 16,
+          "work_registers_used": 7
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/conical_gradient_fill.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/conical_gradient_fill.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": true,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": 74,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              null
+            ],
+            "longest_path_cycles": [
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt"
+            ],
+            "shortest_path_cycles": [
+              0.1875,
+              0.1875,
+              0.1875,
+              0.0625,
+              0.0,
+              0.125,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "total_cycles": [
+              0.421875,
+              0.3125,
+              0.421875,
+              0.0625,
+              0.0,
+              0.125,
+              0.25
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 20,
+          "work_registers_used": 7
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/conical_gradient_ssbo_fill.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/conical_gradient_ssbo_fill.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": true,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": 61,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              null
+            ],
+            "longest_path_cycles": [
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "shortest_path_cycles": [
+              0.171875,
+              0.140625,
+              0.171875,
+              0.0625,
+              0.0,
+              0.125,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.699999988079071,
+              0.40625,
+              0.699999988079071,
+              0.125,
+              4.0,
+              0.125,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 18,
+          "work_registers_used": 15
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/framebuffer_blend.vert.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/framebuffer_blend.vert.vkspv",
+      "has_uniform_computation": true,
+      "type": "Vertex",
+      "variants": {
+        "Position": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 20,
+          "work_registers_used": 32
+        },
+        "Varying": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.03125,
+              0.015625,
+              0.03125,
+              0.0,
+              3.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              0.03125,
+              0.015625,
+              0.03125,
+              0.0,
+              3.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.03125,
+              0.015625,
+              0.03125,
+              0.0,
+              3.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 16,
+          "work_registers_used": 7
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/framebuffer_blend_color.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/framebuffer_blend_color.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": false,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": null,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "longest_path_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "shortest_path_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "total_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 0,
+          "work_registers_used": 3
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/framebuffer_blend_colorburn.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/framebuffer_blend_colorburn.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": false,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": null,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "longest_path_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "shortest_path_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "total_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 0,
+          "work_registers_used": 3
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/framebuffer_blend_colordodge.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/framebuffer_blend_colordodge.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": false,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": null,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "longest_path_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "shortest_path_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "total_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 0,
+          "work_registers_used": 3
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/framebuffer_blend_darken.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/framebuffer_blend_darken.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": false,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": null,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "longest_path_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "shortest_path_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "total_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 0,
+          "work_registers_used": 3
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/framebuffer_blend_difference.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/framebuffer_blend_difference.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": false,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": null,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "longest_path_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "shortest_path_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "total_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 0,
+          "work_registers_used": 3
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/framebuffer_blend_exclusion.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/framebuffer_blend_exclusion.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": false,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": null,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "longest_path_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "shortest_path_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "total_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 0,
+          "work_registers_used": 3
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/framebuffer_blend_hardlight.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/framebuffer_blend_hardlight.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": false,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": null,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "longest_path_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "shortest_path_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "total_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 0,
+          "work_registers_used": 3
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/framebuffer_blend_hue.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/framebuffer_blend_hue.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": false,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": null,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "longest_path_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "shortest_path_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "total_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 0,
+          "work_registers_used": 3
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/framebuffer_blend_lighten.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/framebuffer_blend_lighten.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": false,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": null,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "longest_path_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "shortest_path_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "total_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 0,
+          "work_registers_used": 3
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/framebuffer_blend_luminosity.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/framebuffer_blend_luminosity.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": false,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": null,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "longest_path_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "shortest_path_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "total_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 0,
+          "work_registers_used": 3
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/framebuffer_blend_multiply.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/framebuffer_blend_multiply.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": false,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": null,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "longest_path_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "shortest_path_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "total_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 0,
+          "work_registers_used": 3
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/framebuffer_blend_overlay.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/framebuffer_blend_overlay.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": false,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": null,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "longest_path_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "shortest_path_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "total_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 0,
+          "work_registers_used": 3
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/framebuffer_blend_saturation.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/framebuffer_blend_saturation.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": false,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": null,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "longest_path_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "shortest_path_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "total_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 0,
+          "work_registers_used": 3
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/framebuffer_blend_screen.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/framebuffer_blend_screen.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": false,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": null,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "longest_path_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "shortest_path_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "total_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 0,
+          "work_registers_used": 3
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/framebuffer_blend_softlight.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/framebuffer_blend_softlight.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": false,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": null,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "longest_path_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "shortest_path_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "total_cycles": [
+              0.03125,
+              0.0,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 0,
+          "work_registers_used": 3
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/gaussian_blur.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/gaussian_blur.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": true,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": 47,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              null
+            ],
+            "longest_path_cycles": [
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "varying",
+              "texture"
+            ],
+            "shortest_path_cycles": [
+              0.15625,
+              0.09375,
+              0.15625,
+              0.0625,
+              0.0,
+              0.25,
+              0.25
+            ],
+            "total_bound_pipelines": [
+              "varying",
+              "texture"
+            ],
+            "total_cycles": [
+              0.265625,
+              0.265625,
+              0.25,
+              0.125,
+              0.0,
+              0.5,
+              0.5
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 14,
+          "work_registers_used": 15
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/gaussian_blur.vert.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/gaussian_blur.vert.vkspv",
+      "has_uniform_computation": true,
+      "type": "Vertex",
+      "variants": {
+        "Position": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 20,
+          "work_registers_used": 32
+        },
+        "Varying": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.0625,
+              0.03125,
+              0.0625,
+              0.0,
+              4.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              0.0625,
+              0.03125,
+              0.0625,
+              0.0,
+              4.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.0625,
+              0.03125,
+              0.0625,
+              0.0,
+              4.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 16,
+          "work_registers_used": 8
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/gaussian_blur_decal.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/gaussian_blur_decal.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": true,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": 55,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              null
+            ],
+            "longest_path_cycles": [
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "shortest_path_cycles": [
+              0.3125,
+              0.09375,
+              0.3125,
+              0.25,
+              0.0,
+              0.25,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "total_cycles": [
+              0.515625,
+              0.265625,
+              0.515625,
+              0.5,
+              0.0,
+              0.5,
+              0.5
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 12,
+          "work_registers_used": 20
+        }
+      }
+    }
+  },
   "flutter/impeller/entity/gles/advanced_blend.vert.gles": {
     "Mali-G78": {
       "core": "Mali-G78",
@@ -7111,6 +10522,2751 @@
       }
     }
   },
+  "flutter/impeller/entity/glyph_atlas.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/glyph_atlas.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": true,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "varying"
+            ],
+            "longest_path_cycles": [
+              0.0625,
+              0.03125,
+              0.0625,
+              0.0,
+              0.0,
+              0.375,
+              0.25
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "varying"
+            ],
+            "shortest_path_cycles": [
+              0.0625,
+              0.03125,
+              0.0625,
+              0.0,
+              0.0,
+              0.375,
+              0.25
+            ],
+            "total_bound_pipelines": [
+              "varying"
+            ],
+            "total_cycles": [
+              0.0625,
+              0.03125,
+              0.0625,
+              0.0,
+              0.0,
+              0.375,
+              0.25
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 6,
+          "work_registers_used": 6
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/glyph_atlas.vert.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/glyph_atlas.vert.vkspv",
+      "has_uniform_computation": true,
+      "type": "Vertex",
+      "variants": {
+        "Position": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.125,
+              0.125,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              0.125,
+              0.125,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.125,
+              0.125,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 16,
+          "work_registers_used": 32
+        },
+        "Varying": {
+          "fp16_arithmetic": null,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              4.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              4.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              4.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 16,
+          "work_registers_used": 7
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/glyph_atlas_sdf.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/glyph_atlas_sdf.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": true,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": 72,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "arith_total",
+              "arith_sfu"
+            ],
+            "longest_path_cycles": [
+              0.3125,
+              0.25,
+              0.015625,
+              0.3125,
+              0.0,
+              0.25,
+              0.25
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_sfu"
+            ],
+            "shortest_path_cycles": [
+              0.3125,
+              0.25,
+              0.015625,
+              0.3125,
+              0.0,
+              0.25,
+              0.25
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_sfu"
+            ],
+            "total_cycles": [
+              0.3125,
+              0.25,
+              0.015625,
+              0.3125,
+              0.0,
+              0.25,
+              0.25
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 6,
+          "work_registers_used": 6
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/glyph_atlas_sdf.vert.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/glyph_atlas_sdf.vert.vkspv",
+      "has_uniform_computation": true,
+      "type": "Vertex",
+      "variants": {
+        "Position": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.125,
+              0.125,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              0.125,
+              0.125,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.125,
+              0.125,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 16,
+          "work_registers_used": 32
+        },
+        "Varying": {
+          "fp16_arithmetic": null,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              3.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              3.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              3.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 16,
+          "work_registers_used": 6
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/gradient_fill.vert.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/gradient_fill.vert.vkspv",
+      "has_uniform_computation": true,
+      "type": "Vertex",
+      "variants": {
+        "Position": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 34,
+          "work_registers_used": 32
+        },
+        "Varying": {
+          "fp16_arithmetic": 0,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.125,
+              0.125,
+              0.0,
+              0.0625,
+              3.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              0.125,
+              0.125,
+              0.0,
+              0.0625,
+              3.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.125,
+              0.125,
+              0.0,
+              0.0625,
+              3.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 30,
+          "work_registers_used": 9
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/linear_gradient_fill.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/linear_gradient_fill.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": true,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "longest_path_cycles": [
+              0.265625,
+              0.21875,
+              0.265625,
+              0.0,
+              0.0,
+              0.125,
+              0.25
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "varying"
+            ],
+            "shortest_path_cycles": [
+              0.125,
+              0.125,
+              0.125,
+              0.0,
+              0.0,
+              0.125,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "total_cycles": [
+              0.3125,
+              0.25,
+              0.3125,
+              0.0,
+              0.0,
+              0.125,
+              0.25
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 14,
+          "work_registers_used": 6
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/linear_gradient_ssbo_fill.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/linear_gradient_ssbo_fill.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": true,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": 75,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              null
+            ],
+            "longest_path_cycles": [
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "varying"
+            ],
+            "shortest_path_cycles": [
+              0.109375,
+              0.078125,
+              0.109375,
+              0.0,
+              0.0,
+              0.125,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.59375,
+              0.34375,
+              0.59375,
+              0.0625,
+              4.0,
+              0.125,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 12,
+          "work_registers_used": 15
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/linear_to_srgb_filter.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/linear_to_srgb_filter.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": true,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": 20,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "arith_total",
+              "arith_sfu"
+            ],
+            "longest_path_cycles": [
+              0.4375,
+              0.296875,
+              0.359375,
+              0.4375,
+              0.0,
+              0.25,
+              0.25
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "varying",
+              "texture"
+            ],
+            "shortest_path_cycles": [
+              0.234375,
+              0.203125,
+              0.234375,
+              0.1875,
+              0.0,
+              0.25,
+              0.25
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_sfu"
+            ],
+            "total_cycles": [
+              0.4375,
+              0.328125,
+              0.359375,
+              0.4375,
+              0.0,
+              0.25,
+              0.25
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 10,
+          "work_registers_used": 12
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/linear_to_srgb_filter.vert.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/linear_to_srgb_filter.vert.vkspv",
+      "has_uniform_computation": true,
+      "type": "Vertex",
+      "variants": {
+        "Position": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 20,
+          "work_registers_used": 32
+        },
+        "Varying": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.03125,
+              0.015625,
+              0.03125,
+              0.0,
+              3.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              0.03125,
+              0.015625,
+              0.03125,
+              0.0,
+              3.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.03125,
+              0.015625,
+              0.03125,
+              0.0,
+              3.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 16,
+          "work_registers_used": 7
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/morphology_filter.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/morphology_filter.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": true,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": 54,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              null
+            ],
+            "longest_path_cycles": [
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "shortest_path_cycles": [
+              0.109375,
+              0.0,
+              0.109375,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "total_cycles": [
+              0.34375,
+              0.046875,
+              0.34375,
+              0.1875,
+              0.0,
+              0.25,
+              0.25
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 8,
+          "work_registers_used": 13
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/morphology_filter.vert.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/morphology_filter.vert.vkspv",
+      "has_uniform_computation": true,
+      "type": "Vertex",
+      "variants": {
+        "Position": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 20,
+          "work_registers_used": 32
+        },
+        "Varying": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.03125,
+              0.015625,
+              0.03125,
+              0.0,
+              3.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              0.03125,
+              0.015625,
+              0.03125,
+              0.0,
+              3.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.03125,
+              0.015625,
+              0.03125,
+              0.0,
+              3.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 16,
+          "work_registers_used": 7
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/position_color.vert.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/position_color.vert.vkspv",
+      "has_uniform_computation": true,
+      "type": "Vertex",
+      "variants": {
+        "Position": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 18,
+          "work_registers_used": 32
+        },
+        "Varying": {
+          "fp16_arithmetic": null,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              3.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              3.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              3.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 14,
+          "work_registers_used": 7
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/position_uv.vert.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/position_uv.vert.vkspv",
+      "has_uniform_computation": true,
+      "type": "Vertex",
+      "variants": {
+        "Position": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 34,
+          "work_registers_used": 32
+        },
+        "Varying": {
+          "fp16_arithmetic": 0,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.125,
+              0.125,
+              0.0,
+              0.0625,
+              4.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              0.125,
+              0.125,
+              0.0,
+              0.0625,
+              4.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.125,
+              0.125,
+              0.0,
+              0.0625,
+              4.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 30,
+          "work_registers_used": 9
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/radial_gradient_fill.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/radial_gradient_fill.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": true,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": 73,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "longest_path_cycles": [
+              0.265625,
+              0.25,
+              0.265625,
+              0.0625,
+              0.0,
+              0.125,
+              0.25
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_fma"
+            ],
+            "shortest_path_cycles": [
+              0.15625,
+              0.15625,
+              0.125,
+              0.0625,
+              0.0,
+              0.125,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "total_cycles": [
+              0.3125,
+              0.28125,
+              0.3125,
+              0.0625,
+              0.0,
+              0.125,
+              0.25
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 12,
+          "work_registers_used": 6
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/radial_gradient_ssbo_fill.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/radial_gradient_ssbo_fill.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": true,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": 59,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              null
+            ],
+            "longest_path_cycles": [
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "varying"
+            ],
+            "shortest_path_cycles": [
+              0.109375,
+              0.109375,
+              0.109375,
+              0.0625,
+              0.0,
+              0.125,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.59375,
+              0.375,
+              0.59375,
+              0.125,
+              4.0,
+              0.125,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 10,
+          "work_registers_used": 15
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/rrect_blur.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/rrect_blur.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": true,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": 37,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "arith_total",
+              "arith_fma"
+            ],
+            "longest_path_cycles": [
+              1.5499999523162842,
+              1.5499999523162842,
+              0.515625,
+              1.5,
+              0.0,
+              0.125,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_fma"
+            ],
+            "shortest_path_cycles": [
+              0.171875,
+              0.171875,
+              0.0625,
+              0.0625,
+              0.0,
+              0.125,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_fma"
+            ],
+            "total_cycles": [
+              1.6749999523162842,
+              1.6749999523162842,
+              0.5625,
+              1.5625,
+              0.0,
+              0.125,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 18,
+          "work_registers_used": 32
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/rrect_blur.vert.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/rrect_blur.vert.vkspv",
+      "has_uniform_computation": true,
+      "type": "Vertex",
+      "variants": {
+        "Position": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 18,
+          "work_registers_used": 32
+        },
+        "Varying": {
+          "fp16_arithmetic": null,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              3.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              3.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              3.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 14,
+          "work_registers_used": 6
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/runtime_effect.vert.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/runtime_effect.vert.vkspv",
+      "has_uniform_computation": true,
+      "type": "Vertex",
+      "variants": {
+        "Position": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 18,
+          "work_registers_used": 32
+        },
+        "Varying": {
+          "fp16_arithmetic": null,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              3.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              3.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              3.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 14,
+          "work_registers_used": 6
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/solid_fill.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/solid_fill.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": true,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": null,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "longest_path_cycles": [
+              0.0625,
+              0.0,
+              0.0625,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "shortest_path_cycles": [
+              0.0625,
+              0.0,
+              0.0625,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "total_cycles": [
+              0.0625,
+              0.0,
+              0.0625,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 4,
+          "work_registers_used": 5
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/solid_fill.vert.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/solid_fill.vert.vkspv",
+      "has_uniform_computation": true,
+      "type": "Vertex",
+      "variants": {
+        "Position": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 18,
+          "work_registers_used": 32
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/srgb_to_linear_filter.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/srgb_to_linear_filter.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": true,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": 20,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "arith_total",
+              "arith_sfu"
+            ],
+            "longest_path_cycles": [
+              0.4375,
+              0.28125,
+              0.390625,
+              0.4375,
+              0.0,
+              0.25,
+              0.25
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "varying",
+              "texture"
+            ],
+            "shortest_path_cycles": [
+              0.15625,
+              0.140625,
+              0.15625,
+              0.0625,
+              0.0,
+              0.25,
+              0.25
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_sfu"
+            ],
+            "total_cycles": [
+              0.4375,
+              0.328125,
+              0.390625,
+              0.4375,
+              0.0,
+              0.25,
+              0.25
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 10,
+          "work_registers_used": 9
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/srgb_to_linear_filter.vert.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/srgb_to_linear_filter.vert.vkspv",
+      "has_uniform_computation": true,
+      "type": "Vertex",
+      "variants": {
+        "Position": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 20,
+          "work_registers_used": 32
+        },
+        "Varying": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.03125,
+              0.015625,
+              0.03125,
+              0.0,
+              3.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              0.03125,
+              0.015625,
+              0.03125,
+              0.0,
+              3.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.03125,
+              0.015625,
+              0.03125,
+              0.0,
+              3.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 16,
+          "work_registers_used": 7
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/sweep_gradient_fill.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/sweep_gradient_fill.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": true,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": 18,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "arith_total",
+              "arith_fma"
+            ],
+            "longest_path_cycles": [
+              0.40625,
+              0.40625,
+              0.390625,
+              0.3125,
+              0.0,
+              0.125,
+              0.25
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_sfu"
+            ],
+            "shortest_path_cycles": [
+              0.3125,
+              0.3125,
+              0.25,
+              0.3125,
+              0.0,
+              0.125,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "total_cycles": [
+              0.453125,
+              0.4375,
+              0.453125,
+              0.3125,
+              0.0,
+              0.125,
+              0.25
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 18,
+          "work_registers_used": 16
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/sweep_gradient_ssbo_fill.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/sweep_gradient_ssbo_fill.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": true,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": 23,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              null
+            ],
+            "longest_path_cycles": [
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_sfu"
+            ],
+            "shortest_path_cycles": [
+              0.3125,
+              0.265625,
+              0.21875,
+              0.3125,
+              0.0,
+              0.125,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.71875,
+              0.546875,
+              0.71875,
+              0.375,
+              4.0,
+              0.125,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 16,
+          "work_registers_used": 20
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/texture_fill.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/texture_fill.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": true,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "varying",
+              "texture"
+            ],
+            "longest_path_cycles": [
+              0.03125,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.25,
+              0.25
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "varying",
+              "texture"
+            ],
+            "shortest_path_cycles": [
+              0.03125,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.25,
+              0.25
+            ],
+            "total_bound_pipelines": [
+              "varying",
+              "texture"
+            ],
+            "total_cycles": [
+              0.03125,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.25,
+              0.25
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 4,
+          "work_registers_used": 4
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/texture_fill.vert.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/texture_fill.vert.vkspv",
+      "has_uniform_computation": true,
+      "type": "Vertex",
+      "variants": {
+        "Position": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 20,
+          "work_registers_used": 32
+        },
+        "Varying": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.03125,
+              0.015625,
+              0.03125,
+              0.0,
+              3.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              0.03125,
+              0.015625,
+              0.03125,
+              0.0,
+              3.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.03125,
+              0.015625,
+              0.03125,
+              0.0,
+              3.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 16,
+          "work_registers_used": 7
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/tiled_texture_fill.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/tiled_texture_fill.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": true,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": 33,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "varying",
+              "texture"
+            ],
+            "longest_path_cycles": [
+              0.234375,
+              0.03125,
+              0.234375,
+              0.0625,
+              0.0,
+              0.25,
+              0.25
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "varying"
+            ],
+            "shortest_path_cycles": [
+              0.140625,
+              0.03125,
+              0.140625,
+              0.0625,
+              0.0,
+              0.25,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "varying",
+              "texture"
+            ],
+            "total_cycles": [
+              0.234375,
+              0.03125,
+              0.234375,
+              0.0625,
+              0.0,
+              0.25,
+              0.25
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 4,
+          "work_registers_used": 7
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/tiled_texture_fill.vert.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/tiled_texture_fill.vert.vkspv",
+      "has_uniform_computation": true,
+      "type": "Vertex",
+      "variants": {
+        "Position": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 28,
+          "work_registers_used": 32
+        },
+        "Varying": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.125,
+              0.125,
+              0.03125,
+              0.0625,
+              3.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              0.125,
+              0.125,
+              0.03125,
+              0.0625,
+              3.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.125,
+              0.125,
+              0.03125,
+              0.0625,
+              3.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 24,
+          "work_registers_used": 8
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/vertices.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/vertices.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": true,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "varying"
+            ],
+            "longest_path_cycles": [
+              0.03125,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.25,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "varying"
+            ],
+            "shortest_path_cycles": [
+              0.03125,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.25,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "varying"
+            ],
+            "total_cycles": [
+              0.03125,
+              0.03125,
+              0.0,
+              0.0,
+              0.0,
+              0.25,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 2,
+          "work_registers_used": 4
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/yuv_to_rgb_filter.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/yuv_to_rgb_filter.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": true,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "varying",
+              "texture"
+            ],
+            "longest_path_cycles": [
+              0.15625,
+              0.15625,
+              0.0,
+              0.0,
+              0.0,
+              0.25,
+              0.25
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "varying",
+              "texture"
+            ],
+            "shortest_path_cycles": [
+              0.15625,
+              0.15625,
+              0.0,
+              0.0,
+              0.0,
+              0.25,
+              0.25
+            ],
+            "total_bound_pipelines": [
+              "varying",
+              "texture"
+            ],
+            "total_cycles": [
+              0.15625,
+              0.15625,
+              0.0,
+              0.0,
+              0.0,
+              0.25,
+              0.25
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 12,
+          "work_registers_used": 6
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/yuv_to_rgb_filter.vert.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/yuv_to_rgb_filter.vert.vkspv",
+      "has_uniform_computation": true,
+      "type": "Vertex",
+      "variants": {
+        "Position": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.0625,
+              0.0625,
+              0.0625,
+              0.0,
+              2.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 20,
+          "work_registers_used": 32
+        },
+        "Varying": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.03125,
+              0.015625,
+              0.03125,
+              0.0,
+              3.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              0.03125,
+              0.015625,
+              0.03125,
+              0.0,
+              3.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.03125,
+              0.015625,
+              0.03125,
+              0.0,
+              3.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 16,
+          "work_registers_used": 7
+        }
+      }
+    }
+  },
   "flutter/impeller/scene/shaders/gles/skinned.vert.gles": {
     "Mali-G78": {
       "core": "Mali-G78",
@@ -7538,6 +13694,302 @@
           "thread_occupancy": 50,
           "uniform_registers_used": 7,
           "work_registers_used": 6
+        }
+      }
+    }
+  },
+  "flutter/impeller/scene/shaders/skinned.vert.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/scene/shaders/skinned.vert.vkspv",
+      "has_uniform_computation": true,
+      "type": "Vertex",
+      "variants": {
+        "Position": {
+          "fp16_arithmetic": 0,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store",
+              "texture"
+            ],
+            "longest_path_cycles": [
+              3.0625,
+              3.0625,
+              0.09375,
+              0.0,
+              4.0,
+              4.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              1.25,
+              1.25,
+              0.296875,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store",
+              "texture"
+            ],
+            "total_cycles": [
+              3.0625,
+              3.0625,
+              0.359375,
+              0.0,
+              4.0,
+              4.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 50,
+          "uniform_registers_used": 30,
+          "work_registers_used": 64
+        },
+        "Varying": {
+          "fp16_arithmetic": 0,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              3.59375,
+              3.59375,
+              0.09375,
+              0.0,
+              13.0,
+              4.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              1.78125,
+              1.78125,
+              0.296875,
+              0.0,
+              11.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              3.59375,
+              3.59375,
+              0.359375,
+              0.0,
+              13.0,
+              4.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 50,
+          "uniform_registers_used": 30,
+          "work_registers_used": 64
+        }
+      }
+    }
+  },
+  "flutter/impeller/scene/shaders/unlit.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/scene/shaders/unlit.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": true,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": 0,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "varying"
+            ],
+            "longest_path_cycles": [
+              0.25,
+              0.25,
+              0.0,
+              0.0,
+              0.0,
+              0.75,
+              0.25
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "varying"
+            ],
+            "shortest_path_cycles": [
+              0.25,
+              0.25,
+              0.0,
+              0.0,
+              0.0,
+              0.75,
+              0.25
+            ],
+            "total_bound_pipelines": [
+              "varying"
+            ],
+            "total_cycles": [
+              0.25,
+              0.25,
+              0.0,
+              0.0,
+              0.0,
+              0.75,
+              0.25
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 8,
+          "work_registers_used": 10
+        }
+      }
+    }
+  },
+  "flutter/impeller/scene/shaders/unskinned.vert.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/scene/shaders/unskinned.vert.vkspv",
+      "has_uniform_computation": true,
+      "type": "Vertex",
+      "variants": {
+        "Position": {
+          "fp16_arithmetic": 0,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.25,
+              0.25,
+              0.0,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              0.25,
+              0.25,
+              0.0,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.25,
+              0.25,
+              0.0,
+              0.0,
+              2.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 24,
+          "work_registers_used": 32
+        },
+        "Varying": {
+          "fp16_arithmetic": 0,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.75,
+              0.75,
+              0.0,
+              0.0,
+              11.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              0.75,
+              0.75,
+              0.0,
+              0.0,
+              11.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.75,
+              0.75,
+              0.0,
+              0.0,
+              11.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 24,
+          "work_registers_used": 31
         }
       }
     }

--- a/impeller/tools/malioc_cores.py
+++ b/impeller/tools/malioc_cores.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env vpython3
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+# This script parses the JSON output produced by malioc about GPU cores,
+# and outputs it in a form that can be consumed by GN
+
+
+def parse_args(argv):
+  parser = argparse.ArgumentParser(
+      description='This script sanitizes GPU core info output from malioc',
+  )
+  parser.add_argument(
+      '--malioc',
+      '-m',
+      type=str,
+      help='The path to malioc.',
+  )
+  parser.add_argument(
+      '--output',
+      '-o',
+      type=str,
+      help='The output path.',
+  )
+  return parser.parse_args(argv)
+
+
+def validate_args(args):
+  if not args.malioc or not os.path.isfile(args.malioc):
+    print('The --malioc argument must refer to the malioc binary.')
+    return False
+  return True
+
+
+def malioc_core_list(malioc):
+  malioc_cores = subprocess.check_output([malioc, '--list', '--format', 'json'])
+  cores_json = json.loads(malioc_cores)
+  cores = []
+  for core in cores_json['cores']:
+    cores.append(core['core'])
+  return cores
+
+
+def malioc_core_info(malioc, core):
+  malioc_info = subprocess.check_output([
+      malioc, '--info', '--core', core, '--format', 'json'
+  ])
+  info_json = json.loads(malioc_info)
+
+  apis = info_json['apis']
+
+  opengles_max_version = 0
+  if 'opengles' in apis:
+    opengles = apis['opengles']
+    if opengles['max_version'] is not None:
+      opengles_max_version = opengles['max_version']
+  vulkan_max_version = 0
+  if 'vulkan' in apis:
+    vulkan = apis['vulkan']
+    if vulkan['max_version'] is not None:
+      vulkan_max_version = int(vulkan['max_version'] * 100)
+
+  info = {
+      'core': core,
+      'opengles_max_version': opengles_max_version,
+      'vulkan_max_version': vulkan_max_version,
+  }
+  return info
+
+
+def main(argv):
+  args = parse_args(argv[1:])
+  if not validate_args(args):
+    return 1
+
+  infos = []
+  for core in malioc_core_list(args.malioc):
+    infos.append(malioc_core_info(args.malioc, core))
+
+  if args.output:
+    with open(args.output, 'w') as file:
+      json.dump(infos, file, sort_keys=True)
+  else:
+    print(infos)
+
+  return 0
+
+
+if __name__ == '__main__':
+  sys.exit(main(sys.argv))

--- a/impeller/tools/malioc_diff.py
+++ b/impeller/tools/malioc_diff.py
@@ -223,6 +223,8 @@ def compare_variants(befores, afters):
   return differences
 
 
+# Compares two shaders. Prints a report and returns True if there are
+# differences, and returns False otherwise.
 def compare_shaders(malioc_tree, before_shader, after_shader):
   differences = []
   for key, before_val in before_shader.items():


### PR DESCRIPTION
This PR adds analysis of shaders that are compiled to SPIR-V 1.3 for the vulkan backend. This allows analyzing shaders that use ssbos and framebuffer fetch.