### PR TITLE
Improve Linux texture examples.

### DIFF
--- a/shell/platform/linux/public/flutter_linux/fl_pixel_buffer_texture.h
+++ b/shell/platform/linux/public/flutter_linux/fl_pixel_buffer_texture.h
@@ -27,24 +27,22 @@ G_DECLARE_DERIVABLE_TYPE(FlPixelBufferTexture,
  *
  * The following example shows how to implement an #FlPixelBufferTexture.
  * ![<!-- language="C" -->
- *   // Type definition, constructor, init, destructor and class_init are
- *   // omitted.
- *   struct _VideoPixelBufferTexture {  // extends FlPixelBufferTexture
+ *   struct _MyTexture {
  *     FlPixelBufferTexture parent_instance;
  *
  *     uint8_t *buffer;  // your pixel buffer.
  *   }
  *
- *   G_DEFINE_TYPE(VideoTexture,
- *                 video_texture,
+ *   G_DEFINE_TYPE(MyTexture,
+ *                 my_texture,
  *                 fl_pixel_buffer_texture_get_type ())
  *
  *   static gboolean
- *   video_texture_copy_pixels (FlPixelBufferTexture* texture,
- *                              const uint8_t** out_buffer,
- *                              uint32_t* width,
- *                              uint32_t* height,
- *                              GError** error) {
+ *   my_texture_copy_pixels (FlPixelBufferTexture* texture,
+ *                           const uint8_t** out_buffer,
+ *                           uint32_t* width,
+ *                           uint32_t* height,
+ *                           GError** error) {
  *     // This method is called on Render Thread. Be careful with your
  *     // cross-thread operation.
  *
@@ -72,6 +70,13 @@ G_DECLARE_DERIVABLE_TYPE(FlPixelBufferTexture,
  *       return FALSE;
  *     }
  *   }
+ *
+ *   static void my_texture_class_init(MyTextureClass* klass) {
+ *     FL_PIXEL_BUFFER_TEXTURE_CLASS(klass)->copy_pixels =
+ * my_texture_copy_pixels;
+ *   }
+ *
+ *   static void my_texture_init(MyTexture* self) {}
  * ]|
  */
 

--- a/shell/platform/linux/public/flutter_linux/fl_texture_gl.h
+++ b/shell/platform/linux/public/flutter_linux/fl_texture_gl.h
@@ -30,26 +30,24 @@ G_DECLARE_DERIVABLE_TYPE(FlTextureGL, fl_texture_gl, FL, TEXTURE_GL, GObject)
  * ![<!-- language="C" -->
  *   #include <epoxy/gl.h>
  *
- *   // Type definition, constructor, init, destructor, and class_init are
- *   // omitted.
- *   struct _VideoTextureGL { // extends FlTextureGL
+ *   struct _MyTextureGL {
  *     FlTextureGL parent_instance;
  *
  *     GLuint texture_id;
  *   };
  *
- *   G_DEFINE_TYPE(VideoTexture,
- *                 video_texture,
+ *   G_DEFINE_TYPE(MyTextureGL,
+ *                 my_texture_gl,
  *                 fl_texture_gl_get_type ())
  *
  *   static gboolean
- *   video_texture_populate (FlTextureGL *texture,
+ *   my_texture_gl_populate (FlTextureGL *texture,
  *                           uint32_t *target,
  *                           uint32_t *name,
  *                           uint32_t *width,
  *                           uint32_t *height,
  *                           GError **error) {
- *     VideoTextureGL *self = VIDEO_TEXTURE_GL (texture);
+ *     MyTextureGL *self = MY_TEXTURE_GL (texture);
  *     if (self->texture_id == 0) {
  *       glGenTextures (1, &self->texture_id);
  *       glBindTexture (GL_TEXTURE_2D, self->texture_id);
@@ -71,6 +69,12 @@ G_DECLARE_DERIVABLE_TYPE(FlTextureGL, fl_texture_gl, FL, TEXTURE_GL, GObject)
  *
  *     return TRUE;
  *   }
+ *
+ *   static void my_texture_class_init(MyTextureClass* klass) {
+ *     FL_TEXTURE_GL_CLASS(klass)->populate = my_texture_gl_populate;
+ *   }
+ *
+ *   static void my_texture_init(MyTexture* self) {}
  * ]|
  */
 


### PR DESCRIPTION
Use 'MyTexture' naming to match the Linux shell 'MyApplication'.

Show how to connect up the virtual methods.
