### PR TITLE
Add fl_texture_get_id, so textures can be passed to Flutter

### DIFF
--- a/shell/platform/linux/fl_pixel_buffer_texture.cc
+++ b/shell/platform/linux/fl_pixel_buffer_texture.cc
@@ -10,13 +10,14 @@
 #include "flutter/shell/platform/linux/fl_pixel_buffer_texture_private.h"
 
 typedef struct {
+  int64_t id;
   GLuint texture_id;
 } FlPixelBufferTexturePrivate;
 
+static void fl_pixel_buffer_texture_iface_init(FlTextureInterface* iface);
+
 // Added here to stop the compiler from optimising this function away.
 G_MODULE_EXPORT GType fl_pixel_buffer_texture_get_type();
-
-static void fl_pixel_buffer_texture_iface_init(FlTextureInterface* iface) {}
 
 G_DEFINE_TYPE_WITH_CODE(
     FlPixelBufferTexture,
@@ -25,6 +26,29 @@ G_DEFINE_TYPE_WITH_CODE(
     G_IMPLEMENT_INTERFACE(fl_texture_get_type(),
                           fl_pixel_buffer_texture_iface_init);
     G_ADD_PRIVATE(FlPixelBufferTexture))
+
+// Implements FlTexture::set_id
+static void fl_pixel_buffer_texture_set_id(FlTexture* texture, int64_t id) {
+  FlPixelBufferTexture* self = FL_PIXEL_BUFFER_TEXTURE(texture);
+  FlPixelBufferTexturePrivate* priv =
+      reinterpret_cast<FlPixelBufferTexturePrivate*>(
+          fl_pixel_buffer_texture_get_instance_private(self));
+  priv->id = id;
+}
+
+// Implements FlTexture::set_id
+static int64_t fl_pixel_buffer_texture_get_id(FlTexture* texture) {
+  FlPixelBufferTexture* self = FL_PIXEL_BUFFER_TEXTURE(texture);
+  FlPixelBufferTexturePrivate* priv =
+      reinterpret_cast<FlPixelBufferTexturePrivate*>(
+          fl_pixel_buffer_texture_get_instance_private(self));
+  return priv->id;
+}
+
+static void fl_pixel_buffer_texture_iface_init(FlTextureInterface* iface) {
+  iface->set_id = fl_pixel_buffer_texture_set_id;
+  iface->get_id = fl_pixel_buffer_texture_get_id;
+}
 
 static void fl_pixel_buffer_texture_dispose(GObject* object) {
   FlPixelBufferTexture* self = FL_PIXEL_BUFFER_TEXTURE(object);

--- a/shell/platform/linux/fl_pixel_buffer_texture_test.cc
+++ b/shell/platform/linux/fl_pixel_buffer_texture_test.cc
@@ -68,10 +68,9 @@ static FlTestPixelBufferTexture* fl_test_pixel_buffer_texture_new() {
 
 // Test that getting the texture ID works.
 TEST(FlPixelBufferTextureTest, TextureID) {
-  // Texture ID is not assigned until the pixel buffer is copied once.
   g_autoptr(FlTexture) texture = FL_TEXTURE(fl_test_pixel_buffer_texture_new());
-  EXPECT_EQ(fl_texture_get_texture_id(texture),
-            reinterpret_cast<int64_t>(texture));
+  fl_texture_set_id(texture, 42);
+  EXPECT_EQ(fl_texture_get_id(texture), static_cast<int64_t>(42));
 }
 
 // Test that populating an OpenGL texture works.

--- a/shell/platform/linux/fl_texture.cc
+++ b/shell/platform/linux/fl_texture.cc
@@ -15,7 +15,12 @@ G_DEFINE_INTERFACE(FlTexture, fl_texture, G_TYPE_OBJECT)
 
 static void fl_texture_default_init(FlTextureInterface* self) {}
 
-int64_t fl_texture_get_texture_id(FlTexture* self) {
+void fl_texture_set_id(FlTexture* self, int64_t id) {
+  g_return_if_fail(FL_IS_TEXTURE(self));
+  FL_TEXTURE_GET_IFACE(self)->set_id(self, id);
+}
+
+G_MODULE_EXPORT int64_t fl_texture_get_id(FlTexture* self) {
   g_return_val_if_fail(FL_IS_TEXTURE(self), -1);
-  return reinterpret_cast<int64_t>(self);
+  return FL_TEXTURE_GET_IFACE(self)->get_id(self);
 }

--- a/shell/platform/linux/fl_texture_gl.cc
+++ b/shell/platform/linux/fl_texture_gl.cc
@@ -9,16 +9,42 @@
 #include <gmodule.h>
 #include <cstdio>
 
+typedef struct {
+  int64_t id;
+} FlTextureGLPrivate;
+
+static void fl_texture_gl_texture_iface_init(FlTextureInterface* iface);
+
 // Added here to stop the compiler from optimising this function away.
 G_MODULE_EXPORT GType fl_texture_gl_get_type();
-
-static void fl_texture_gl_texture_iface_init(FlTextureInterface* iface) {}
 
 G_DEFINE_TYPE_WITH_CODE(FlTextureGL,
                         fl_texture_gl,
                         G_TYPE_OBJECT,
                         G_IMPLEMENT_INTERFACE(fl_texture_get_type(),
-                                              fl_texture_gl_texture_iface_init))
+                                              fl_texture_gl_texture_iface_init);
+                        G_ADD_PRIVATE(FlTextureGL))
+
+// Implements FlTexture::set_id
+static void fl_texture_gl_set_id(FlTexture* texture, int64_t id) {
+  FlTextureGL* self = FL_TEXTURE_GL(texture);
+  FlTextureGLPrivate* priv = reinterpret_cast<FlTextureGLPrivate*>(
+      fl_texture_gl_get_instance_private(self));
+  priv->id = id;
+}
+
+// Implements FlTexture::set_id
+static int64_t fl_texture_gl_get_id(FlTexture* texture) {
+  FlTextureGL* self = FL_TEXTURE_GL(texture);
+  FlTextureGLPrivate* priv = reinterpret_cast<FlTextureGLPrivate*>(
+      fl_texture_gl_get_instance_private(self));
+  return priv->id;
+}
+
+static void fl_texture_gl_texture_iface_init(FlTextureInterface* iface) {
+  iface->set_id = fl_texture_gl_set_id;
+  iface->get_id = fl_texture_gl_get_id;
+}
 
 static void fl_texture_gl_class_init(FlTextureGLClass* klass) {}
 

--- a/shell/platform/linux/fl_texture_gl_test.cc
+++ b/shell/platform/linux/fl_texture_gl_test.cc
@@ -59,15 +59,14 @@ static FlTestTexture* fl_test_texture_new() {
 }
 
 // Test that getting the texture ID works.
-TEST(FlTextureTest, TextureID) {
-  // Texture ID is not assigned until the testure is populated.
+TEST(FlTextureGLTest, TextureID) {
   g_autoptr(FlTexture) texture = FL_TEXTURE(fl_test_texture_new());
-  EXPECT_EQ(fl_texture_get_texture_id(texture),
-            reinterpret_cast<int64_t>(texture));
+  fl_texture_set_id(texture, 42);
+  EXPECT_EQ(fl_texture_get_id(texture), static_cast<int64_t>(42));
 }
 
 // Test that populating an OpenGL texture works.
-TEST(FlTextureTest, PopulateTexture) {
+TEST(FlTextureGLTest, PopulateTexture) {
   g_autoptr(FlTextureGL) texture = FL_TEXTURE_GL(fl_test_texture_new());
   FlutterOpenGLTexture opengl_texture = {0};
   g_autoptr(GError) error = nullptr;

--- a/shell/platform/linux/fl_texture_private.h
+++ b/shell/platform/linux/fl_texture_private.h
@@ -11,14 +11,13 @@
 G_BEGIN_DECLS
 
 /**
- * fl_texture_get_texture_id:
+ * fl_texture_set_id:
  * @texture: an #FlTexture.
+ * @id: a texture ID.
  *
- * Retrieves the unique id of this texture.
- *
- * Returns: the unique id of this texture.
+ * Set the ID for a texture.
  */
-int64_t fl_texture_get_texture_id(FlTexture* texture);
+void fl_texture_set_id(FlTexture* texture, int64_t id);
 
 G_END_DECLS
 

--- a/shell/platform/linux/fl_texture_registrar_test.cc
+++ b/shell/platform/linux/fl_texture_registrar_test.cc
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_texture_registrar.h"
-#include "flutter/shell/platform/linux/fl_texture_private.h"
 #include "flutter/shell/platform/linux/fl_texture_registrar_private.h"
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_pixel_buffer_texture.h"
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_texture_gl.h"
@@ -74,10 +73,6 @@ TEST(FlTextureRegistrarTest, MockRegistrar) {
   EXPECT_TRUE(fl_texture_registrar_register_texture(
       FL_TEXTURE_REGISTRAR(registrar), texture));
   EXPECT_EQ(fl_mock_texture_registrar_get_texture(registrar), texture);
-  EXPECT_EQ(
-      fl_texture_registrar_lookup_texture(FL_TEXTURE_REGISTRAR(registrar),
-                                          fl_texture_get_texture_id(texture)),
-      texture);
   EXPECT_TRUE(fl_texture_registrar_mark_texture_frame_available(
       FL_TEXTURE_REGISTRAR(registrar), texture));
   EXPECT_TRUE(fl_mock_texture_registrar_get_frame_available(registrar));

--- a/shell/platform/linux/public/flutter_linux/fl_texture.h
+++ b/shell/platform/linux/public/flutter_linux/fl_texture.h
@@ -28,7 +28,22 @@ G_DECLARE_INTERFACE(FlTexture, fl_texture, FL, TEXTURE, GObject)
 
 struct _FlTextureInterface {
   GTypeInterface g_iface;
+
+  void (*set_id)(FlTexture* texture, int64_t id);
+
+  int64_t (*get_id)(FlTexture* texture);
 };
+
+/**
+ * fl_texture_get_id:
+ * @texture: a #FlTexture.
+ *
+ * Get the ID for this texture, which can be passed to Flutter code to refer to
+ * this texture.
+ *
+ * Returns: a texture ID.
+ */
+int64_t fl_texture_get_id(FlTexture* texture);
 
 G_END_DECLS
 

--- a/shell/platform/linux/testing/mock_engine.cc
+++ b/shell/platform/linux/testing/mock_engine.cc
@@ -505,6 +505,10 @@ FlutterEngineResult FlutterEngineMarkExternalTextureFrameAvailable(
 FlutterEngineResult FlutterEngineUnregisterExternalTexture(
     FLUTTER_API_SYMBOL(FlutterEngine) engine,
     int64_t texture_identifier) {
+  auto val = engine->textures.find(texture_identifier);
+  if (val == std::end(engine->textures)) {
+    return kInvalidArguments;
+  }
   engine->textures.erase(texture_identifier);
   return kSuccess;
 }

--- a/shell/platform/linux/testing/mock_texture_registrar.cc
+++ b/shell/platform/linux/testing/mock_texture_registrar.cc
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 #include "flutter/shell/platform/linux/testing/mock_texture_registrar.h"
-#include "flutter/shell/platform/linux/fl_texture_private.h"
 
 struct _FlMockTextureRegistrar {
   GObject parent_instance;
@@ -35,7 +34,7 @@ static FlTexture* lookup_texture(FlTextureRegistrar* registrar,
                                  int64_t texture_id) {
   FlMockTextureRegistrar* self = FL_MOCK_TEXTURE_REGISTRAR(registrar);
   if (self->texture != nullptr &&
-      fl_texture_get_texture_id(self->texture) == texture_id) {
+      fl_texture_get_id(self->texture) == texture_id) {
     return self->texture;
   }
   return nullptr;
@@ -44,8 +43,7 @@ static FlTexture* lookup_texture(FlTextureRegistrar* registrar,
 static gboolean mark_texture_frame_available(FlTextureRegistrar* registrar,
                                              FlTexture* texture) {
   FlMockTextureRegistrar* self = FL_MOCK_TEXTURE_REGISTRAR(registrar);
-  if (lookup_texture(registrar, fl_texture_get_texture_id(texture)) ==
-      nullptr) {
+  if (lookup_texture(registrar, fl_texture_get_id(texture)) == nullptr) {
     return FALSE;
   }
   self->frame_available = TRUE;


### PR DESCRIPTION
Was making use of the texture API and found there wasn't a method to get the ID as required to pass to Flutter.