### PR TITLE
[Impeller] Simplify subpass branches; remove unused effect_matrix param

### DIFF
--- a/impeller/aiks/paint.cc
+++ b/impeller/aiks/paint.cc
@@ -57,13 +57,12 @@ std::shared_ptr<Contents> Paint::CreateContentsForGeometry(
 
 std::shared_ptr<Contents> Paint::WithFilters(
     std::shared_ptr<Contents> input,
-    std::optional<bool> is_solid_color,
-    const Matrix& effect_transform) const {
+    std::optional<bool> is_solid_color) const {
   bool is_solid_color_val = is_solid_color.value_or(!color_source);
   input = WithColorFilter(input);
   input = WithInvertFilter(input);
-  input = WithMaskBlur(input, is_solid_color_val, effect_transform);
-  input = WithImageFilter(input, effect_transform, /*is_subpass=*/false);
+  input = WithMaskBlur(input, is_solid_color_val, Matrix());
+  input = WithImageFilter(input, Matrix(), /*is_subpass=*/false);
   return input;
 }
 

--- a/impeller/aiks/paint.h
+++ b/impeller/aiks/paint.h
@@ -87,8 +87,7 @@ struct Paint {
   ///             original contents is returned.
   std::shared_ptr<Contents> WithFilters(
       std::shared_ptr<Contents> input,
-      std::optional<bool> is_solid_color = std::nullopt,
-      const Matrix& effect_transform = Matrix()) const;
+      std::optional<bool> is_solid_color = std::nullopt) const;
 
   /// @brief      Wrap this paint's configured filters to the given contents of
   ///             subpass target.

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -43,7 +43,7 @@ void EntityPass::SetDelegate(std::unique_ptr<EntityPassDelegate> delegate) {
 
 void EntityPass::AddEntity(Entity entity) {
   if (entity.GetBlendMode() > Entity::kLastPipelineBlendMode) {
-    blend_reads_from_pass_texture_ += 1;
+    advanced_blend_reads_from_pass_texture_ += 1;
   }
   elements_.emplace_back(std::move(entity));
 }
@@ -131,10 +131,10 @@ EntityPass* EntityPass::AddSubpass(std::unique_ptr<EntityPass> pass) {
   pass->superpass_ = this;
 
   if (pass->backdrop_filter_proc_.has_value()) {
-    filter_reads_from_pass_texture_ += 1;
+    backdrop_filter_reads_from_pass_texture_ += 1;
   }
   if (pass->blend_mode_ > Entity::kLastPipelineBlendMode) {
-    blend_reads_from_pass_texture_ += 1;
+    advanced_blend_reads_from_pass_texture_ += 1;
   }
 
   auto subpass_pointer = pass.get();
@@ -190,15 +190,16 @@ static RenderTarget CreateRenderTarget(ContentContext& renderer,
   );
 }
 
-uint32_t EntityPass::ComputeTotalReads(ContentContext& renderer) const {
+uint32_t EntityPass::GetTotalPassReads(ContentContext& renderer) const {
   return renderer.GetDeviceCapabilities().SupportsFramebufferFetch()
-             ? filter_reads_from_pass_texture_
-             : filter_reads_from_pass_texture_ + blend_reads_from_pass_texture_;
+             ? backdrop_filter_reads_from_pass_texture_
+             : backdrop_filter_reads_from_pass_texture_ +
+                   advanced_blend_reads_from_pass_texture_;
 }
 
 bool EntityPass::Render(ContentContext& renderer,
                         const RenderTarget& render_target) const {
-  if (ComputeTotalReads(renderer) > 0) {
+  if (GetTotalPassReads(renderer) > 0) {
     auto offscreen_target =
         CreateRenderTarget(renderer, render_target.GetRenderTargetSize(), true);
     if (!OnRender(renderer, offscreen_target.GetRenderTargetSize(),
@@ -329,33 +330,25 @@ EntityPass::EntityResult EntityPass::GetEntityForElement(
       if (backdrop_coverage.has_value()) {
         backdrop_coverage->origin += position;
 
-        if (subpass_coverage.has_value()) {
-          subpass_coverage = subpass_coverage->Union(backdrop_coverage.value());
-        } else {
-          subpass_coverage = backdrop_coverage;
-        }
+        subpass_coverage =
+            subpass_coverage.has_value()
+                ? subpass_coverage->Union(backdrop_coverage.value())
+                : backdrop_coverage;
       }
     }
 
-    if (subpass_coverage.has_value()) {
-      subpass_coverage =
-          subpass_coverage->Intersection(Rect::MakeSize(root_pass_size));
-    }
-
-    if (!subpass_coverage.has_value()) {
+    if (!subpass_coverage.has_value() || subpass_coverage->size.IsEmpty()) {
+      // The subpass doesn't contain anything visible, so skip it.
       return EntityPass::EntityResult::Skip();
     }
 
-    if (subpass_coverage->size.IsEmpty()) {
-      // It is not an error to have an empty subpass. But subpasses that can't
-      // create their intermediates must trip errors.
-      return EntityPass::EntityResult::Skip();
-    }
+    subpass_coverage =
+        subpass_coverage->Intersection(Rect::MakeSize(root_pass_size));
 
     auto subpass_target =
         CreateRenderTarget(renderer,                       //
                            ISize(subpass_coverage->size),  //
-                           subpass->ComputeTotalReads(renderer) > 0);
+                           subpass->GetTotalPassReads(renderer) > 0);
 
     auto subpass_texture = subpass_target.GetRenderTargetTexture();
 
@@ -418,7 +411,7 @@ bool EntityPass::OnRender(ContentContext& renderer,
 
   auto context = renderer.GetContext();
   InlinePassContext pass_context(context, render_target,
-                                 ComputeTotalReads(renderer),
+                                 GetTotalPassReads(renderer),
                                  std::move(collapsed_parent_pass));
   if (!pass_context.IsValid()) {
     return false;

--- a/impeller/entity/entity_pass.h
+++ b/impeller/entity/entity_pass.h
@@ -119,7 +119,7 @@ class EntityPass {
   BlendMode blend_mode_ = BlendMode::kSourceOver;
   bool cover_whole_screen_ = false;
 
-  /// These value are incremented whenever something is added to the pass that
+  /// These values are incremented whenever something is added to the pass that
   /// requires reading from the backdrop texture. Currently, this can happen in
   /// the following scenarios:
   ///   1. An entity with an "advanced blend" is added to the pass.
@@ -127,10 +127,10 @@ class EntityPass {
   /// These are tracked as separate values because we may ignore
   /// blend_reads_from_pass_texture_ if the device supports framebuffer based
   /// advanced blends.
-  uint32_t filter_reads_from_pass_texture_ = 0;
-  uint32_t blend_reads_from_pass_texture_ = 0;
+  uint32_t advanced_blend_reads_from_pass_texture_ = 0;
+  uint32_t backdrop_filter_reads_from_pass_texture_ = 0;
 
-  uint32_t ComputeTotalReads(ContentContext& renderer) const;
+  uint32_t GetTotalPassReads(ContentContext& renderer) const;
 
   std::optional<BackdropFilterProc> backdrop_filter_proc_ = std::nullopt;
 


### PR DESCRIPTION
Get rid of `Paint::WithFilters` `effect_matrix` parameter which should never be used.

Flatten out/simplify some branches in the subpass entity logic to make following it easier.