### PR TITLE
DO NOT SUBMIT: repro for failing web test on dart 3.0

### DIFF
--- a/lib/web_ui/lib/src/engine/pointer_converter.dart
+++ b/lib/web_ui/lib/src/engine/pointer_converter.dart
@@ -242,6 +242,8 @@ class PointerDataConverter {
     final bool isDown = buttons != 0;
     if (signalKind == null ||
       signalKind == ui.PointerSignalKind.none) {
+      // The test fails when this print is removed.
+      print('if');
       switch (change) {
         case ui.PointerChange.add:
           assert(!_pointers.containsKey(device));

--- a/lib/web_ui/pubspec.yaml
+++ b/lib/web_ui/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 
 # Keep the SDK version range in sync with pubspecs under web_sdk
 environment:
-  sdk: ">=2.19.0 <3.0.0"
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   js: 0.6.4

--- a/web_sdk/web_test_utils/pubspec.yaml
+++ b/web_sdk/web_test_utils/pubspec.yaml
@@ -2,7 +2,7 @@ name: web_test_utils
 
 # Keep the SDK version range in sync with lib/web_ui/pubspec.yaml
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   collection: 1.15.0


### PR DESCRIPTION
```
cd src/flutter/lib/web_ui
dev/felt test test/engine/pointer_binding_test.dart  
```

The test passes with the `print` commented in and fail when the `print` is commented out.

The test also passes when SDK constraints are lowered to 2.19.0.