### PR TITLE
[macOS] Remove a single accessibility root assumption

### DIFF
--- a/shell/platform/common/accessibility_bridge.h
+++ b/shell/platform/common/accessibility_bridge.h
@@ -48,13 +48,6 @@ class AccessibilityBridge
   AccessibilityBridge();
   virtual ~AccessibilityBridge();
 
-  //-----------------------------------------------------------------------------
-  /// @brief      The ID of the root node in the accessibility tree. In Flutter,
-  ///             this is always 0.
-  //  TODO(loicsharma): Remove this as it is incorrect in a multi-view world.
-  //  See: https://github.com/flutter/flutter/issues/119391
-  static constexpr int32_t kRootNodeId = 0;
-
   //------------------------------------------------------------------------------
   /// @brief      Adds a semantics node update to the pending semantics update.
   ///             Calling this method alone will NOT update the semantics tree.

--- a/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMac.mm
+++ b/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMac.mm
@@ -187,9 +187,7 @@ AccessibilityBridgeMac::MacOSEventsFromAXEvent(ui::AXEventGenerator::Event event
       if (ax_node.data().HasState(ax::mojom::State::kEditable)) {
         events.push_back({
             .name = NSAccessibilityValueChangedNotification,
-            .target = GetFlutterPlatformNodeDelegateFromID(AccessibilityBridge::kRootNodeId)
-                          .lock()
-                          ->GetNativeViewAccessible(),
+            .target = RootDelegate()->GetNativeViewAccessible(),
             .user_info = nil,
         });
       }


### PR DESCRIPTION
Today, the root accessibility semantics node is guaranteed to have ID 0. In a multi-window world, each view will have its own semantics tree, but semantic node IDs will be globally unique. In other words, the semantics tree's root will no longer be guaranteed to have ID 0. As a result, `AccessibilityBridge::kRootNodeId` is deprecated and all uses should be removed.

Part of https://github.com/flutter/flutter/issues/119391

## Manual test

<details>
<summary>Manual test...</summary>

Apply the framework patch below, run an app using your local engine, and verify the accessibility works as expected:

```diff
diff --git a/packages/flutter/lib/src/semantics/semantics.dart b/packages/flutter/lib/src/semantics/semantics.dart
index 969f822f5f..6431b3ed28 100644
--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -1650,7 +1650,7 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
     this.key,
     VoidCallback? showOnScreen,
     required SemanticsOwner owner,
-  }) : _id = 0,
+  }) : _id = 123,
        _showOnScreen = showOnScreen {
     attach(owner);
   }
@@ -1663,7 +1663,7 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
   // bits are reserved for engine generated IDs.
   static const int _maxFrameworkAccessibilityIdentifier = (1<<16) - 1;

-  static int _lastIdentifier = 0;
+  static int _lastIdentifier = 123;
   static int _generateNewId() {
     _lastIdentifier = (_lastIdentifier + 1) % _maxFrameworkAccessibilityIdentifier;
     return _lastIdentifier;
```

</details>

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
