### PR TITLE
Build iOS and macOS Obj-C with -fapplication-extension flag

### DIFF
--- a/common/config.gni
+++ b/common/config.gni
@@ -57,6 +57,7 @@ if (is_ios || is_mac) {
   flutter_cflags_objc = [
     "-Werror=overriding-method-mismatch",
     "-Werror=undeclared-selector",
+    "-fapplication-extension",
   ]
   flutter_cflags_objcc = flutter_cflags_objc
   flutter_cflags_objc_arc = flutter_cflags_objc + [ "-fobjc-arc" ]

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -44,7 +44,10 @@ source_set("flutter_framework_source_arc") {
   cflags_objc = flutter_cflags_objc_arc
   cflags_objcc = flutter_cflags_objcc_arc
 
-  defines = [ "FLUTTER_FRAMEWORK=1" ]
+  defines = [
+    "FLUTTER_FRAMEWORK=1",
+    "APPLICATION_EXTENSION_API_ONLY=1",
+  ]
   allow_circular_includes_from = [ ":flutter_framework_source" ]
   deps = [
     ":flutter_framework_source",
@@ -153,7 +156,10 @@ source_set("flutter_framework_source") {
 
   sources += _flutter_framework_headers
 
-  defines = [ "FLUTTER_FRAMEWORK=1" ]
+  defines = [
+    "FLUTTER_FRAMEWORK=1",
+    "APPLICATION_EXTENSION_API_ONLY=1",
+  ]
 
   if (shell_enable_metal) {
     sources += [

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -326,7 +326,10 @@ shared_library("create_flutter_framework_dylib") {
 
   output_name = "Flutter"
 
-  ldflags = [ "-Wl,-install_name,@rpath/Flutter.framework/Flutter" ]
+  ldflags = [
+    "-Wl,-install_name,@rpath/Flutter.framework/Flutter",
+    "-fapplication-extension",
+  ]
 
   public = _flutter_framework_headers
 

--- a/shell/platform/darwin/ios/framework/Headers/FlutterAppDelegate.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterAppDelegate.h
@@ -24,6 +24,7 @@
  * code as necessary from FlutterAppDelegate.mm.
  */
 FLUTTER_DARWIN_EXPORT
+NS_EXTENSION_UNAVAILABLE_IOS("Disallowed in app extensions")
 @interface FlutterAppDelegate
     : UIResponder <UIApplicationDelegate, FlutterPluginRegistry, FlutterAppLifeCycleProvider>
 

--- a/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
@@ -353,7 +353,8 @@ typedef enum {
  *
  * @param delegate The receiving object, such as the plugin's main class.
  */
-- (void)addApplicationDelegate:(NSObject<FlutterPlugin>*)delegate;
+- (void)addApplicationDelegate:(NSObject<FlutterPlugin>*)delegate
+    NS_EXTENSION_UNAVAILABLE_IOS("Disallowed in plugins used in app extensions");
 
 /**
  * Returns the file name for the given asset.

--- a/shell/platform/darwin/ios/framework/Headers/FlutterPluginAppLifeCycleDelegate.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterPluginAppLifeCycleDelegate.h
@@ -13,6 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Propagates `UIAppDelegate` callbacks to registered plugins.
  */
 FLUTTER_DARWIN_EXPORT
+NS_EXTENSION_UNAVAILABLE_IOS("Disallowed in plugins used in app extensions")
 @interface FlutterPluginAppLifeCycleDelegate : NSObject <UNUserNotificationCenterDelegate>
 
 /**

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -88,7 +88,6 @@ NS_INLINE NSBundle* FLTFrameworkBundle() {
                                     .URLByDeletingLastPathComponent];
     bundle = FLTFrameworkBundleInternal([FlutterDartProject defaultBundleIdentifier],
                                         appBundle.privateFrameworksURL);
-    [bundle load];
   }
 
   if (bundle == nil) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -849,7 +849,11 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
   );
 
   _isGpuDisabled =
+#if APPLICATION_EXTENSION_API_ONLY
+      NO;
+#else
       [UIApplication sharedApplication].applicationState == UIApplicationStateBackground;
+#endif
   // Create the shell. This is a blocking operation.
   std::unique_ptr<flutter::Shell> shell = flutter::Shell::Create(
       /*platform_data=*/platformData,
@@ -1433,7 +1437,7 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
   }];
 }
 
-- (void)addApplicationDelegate:(NSObject<FlutterPlugin>*)delegate {
+- (void)addApplicationDelegate:(NSObject<FlutterPlugin>*)delegate NS_EXTENSION_UNAVAILABLE_IOS("") {
   id<UIApplicationDelegate> appDelegate = [[UIApplication sharedApplication] delegate];
   if ([appDelegate conformsToProtocol:@protocol(FlutterAppLifeCycleProvider)]) {
     id<FlutterAppLifeCycleProvider> lifeCycleProvider =

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
@@ -158,6 +158,7 @@ using namespace flutter;
 }
 
 - (void)setSystemChromeEnabledSystemUIOverlays:(NSArray*)overlays {
+#if !APPLICATION_EXTENSION_API_ONLY
   // Checks if the top status bar should be visible. This platform ignores all
   // other overlays
 
@@ -175,9 +176,11 @@ using namespace flutter;
         postNotificationName:FlutterViewControllerHideHomeIndicator
                       object:nil];
   }
+#endif
 }
 
 - (void)setSystemChromeEnabledSystemUIMode:(NSString*)mode {
+#if !APPLICATION_EXTENSION_API_ONLY
   // Checks if the top status bar should be visible, reflected by edge to edge setting. This
   // platform ignores all other system ui modes.
 
@@ -195,6 +198,7 @@ using namespace flutter;
         postNotificationName:FlutterViewControllerHideHomeIndicator
                       object:nil];
   }
+#endif
 }
 
 - (void)restoreSystemChromeSystemUIOverlays {
@@ -231,9 +235,11 @@ using namespace flutter;
                       object:nil
                     userInfo:@{@(kOverlayStyleUpdateNotificationKey) : @(statusBarStyle)}];
   } else {
+#if !APPLICATION_EXTENSION_API_ONLY
     // Note: -[UIApplication setStatusBarStyle] is deprecated in iOS9
     // in favor of delegating to the view controller
     [[UIApplication sharedApplication] setStatusBarStyle:statusBarStyle];
+#endif
   }
 }
 
@@ -249,11 +255,15 @@ using namespace flutter;
   if (navigationController) {
     [navigationController popViewControllerAnimated:isAnimated];
   } else {
+#if !APPLICATION_EXTENSION_API_ONLY
     UIViewController* rootViewController =
         [UIApplication sharedApplication].keyWindow.rootViewController;
     if (engineViewController != rootViewController) {
+#endif
       [engineViewController dismissViewControllerAnimated:isAnimated completion:nil];
+#if !APPLICATION_EXTENSION_API_ONLY
     }
+#endif
   }
 }
 

--- a/shell/platform/darwin/macos/BUILD.gn
+++ b/shell/platform/darwin/macos/BUILD.gn
@@ -133,6 +133,7 @@ source_set("flutter_framework_source") {
   defines = [
     "FLUTTER_FRAMEWORK",
     "FLUTTER_ENGINE_NO_PROTOTYPES",
+    "APPLICATION_EXTENSION_API_ONLY=1",
   ]
 
   cflags_objcc = flutter_cflags_objcc_arc
@@ -151,7 +152,10 @@ shared_library("flutter_framework_dylib") {
   visibility = [ ":*" ]
   output_name = "$_flutter_framework_name"
 
-  ldflags = [ "-Wl,-install_name,@rpath/$_flutter_framework_filename/$_framework_binary_subpath" ]
+  ldflags = [
+    "-Wl,-install_name,@rpath/$_flutter_framework_filename/$_framework_binary_subpath",
+    "-fapplication-extension",
+  ]
 
   deps = [ ":flutter_framework_source" ]
 }


### PR DESCRIPTION
First-pass on allowing engine to be built for app extensions without unsafe APIs.  This would allow the engine to be built twice, once for apps and again for app extensions.  Note the build rule tweaks are only to allow testing, this would require much more work to output two versions of the framework.

See [design doc](https://docs.google.com/document/d/1WloBrAYpqNKOhEHytTqJEHshcXxHflLUGKvULKRHbuU/edit#)

> An alternative would be to build two versions of the Flutter engines–one safe to be used in app extensions and built with with the -fapplication-extension flag and with APPLICATION_EXTENSION_API_ONLY=1 added to the defines, and the other identical to the one that exists today.  Both versions would be built and published as artifacts with the same engine infrastructure and rolled into g3.  Apps would continue to use the existing engine, and app extensions would instead link on and embed the new safe variant.  This would double the Flutter engine size in the final app bundle (at time of writing 9.1 MB in an uncompressed release app).  This alternative would be faster to implement than splitting the engines, and could be a medium-term stopgap for customers willing to sacrifice app size for extension features.
> 
> App extension unsafe code would be compiled out of the new safe framework behind conditional APPLICATION_EXTENSION_API_ONLY checks and NS_EXTENSION_UNAVAILABLE_IOS annotations.  Some APIs like the FlutterPluginAppLifeCycleDelegate would be disallowed in the new safe framework, potentially impacting what plugins or plugin features can be used in extensions.