### PR TITLE
Expose  iOS plist and AndroidManifest setting to disable partial repaint

### DIFF
--- a/common/settings.h
+++ b/common/settings.h
@@ -211,6 +211,10 @@ struct Settings {
   // Enable the Impeller renderer on supported platforms. Ignored if Impeller is
   // not supported on the platform.
   bool enable_impeller = false;
+    
+  // Disable the partical repaint on supported platforms. Ignored if partical repaint is
+  // not supported on the platform.
+  bool disable_partical_repaint = false;
 
   // Data set by platform-specific embedders for use in font initialization.
   uint32_t font_initialization_data = 0;

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -550,7 +550,8 @@ RasterStatus Rasterizer::DrawToSurfaceUnsafe(
     std::unique_ptr<FrameDamage> damage;
     // when leaf layer tracing is enabled we wish to repaint the whole frame
     // for accurate performance metrics.
-    if (frame->framebuffer_info().supports_partial_repaint &&
+    if (!delegate_.DisableParticalRepaint() &&
+        frame->framebuffer_info().supports_partial_repaint &&
         !layer_tree.is_leaf_layer_tracing_enabled()) {
       // Disable partial repaint if external_view_embedder_ SubmitFrame is
       // involved - ExternalViewEmbedder unconditionally clears the entire

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -103,6 +103,10 @@ class Rasterizer final : public SnapshotDelegate,
         const = 0;
 
     virtual const Settings& GetSettings() const = 0;
+
+    ///Whether to disable partial repaint on platform
+    virtual bool DisableParticalRepaint() const = 0;
+
   };
 
   //----------------------------------------------------------------------------

--- a/shell/common/rasterizer_unittests.cc
+++ b/shell/common/rasterizer_unittests.cc
@@ -39,6 +39,7 @@ class MockDelegate : public Rasterizer::Delegate {
                      std::shared_ptr<const fml::SyncSwitch>());
   MOCK_METHOD0(CreateSnapshotSurface, std::unique_ptr<Surface>());
   MOCK_CONST_METHOD0(GetSettings, const Settings&());
+  MOCK_CONST_METHOD0(DisableParticalRepaint, bool());
 };
 
 class MockSurface : public Surface {

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -1525,6 +1525,10 @@ fml::TimePoint Shell::GetLatestFrameTargetTime() const {
   return latest_frame_target_time_.value();
 }
 
+bool Shell::DisableParticalRepaint() const {
+  return settings_.disable_partical_repaint;
+}
+
 // |ServiceProtocol::Handler|
 fml::RefPtr<fml::TaskRunner> Shell::GetServiceProtocolHandlerTaskRunner(
     std::string_view method) const {

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -646,6 +646,10 @@ class Shell final : public PlatformView::Delegate,
 
   // |Rasterizer::Delegate|
   fml::TimePoint GetLatestFrameTargetTime() const override;
+                        
+                        
+  // |Rasterizer::Delegate|
+  bool DisableParticalRepaint() const override;
 
   // |ServiceProtocol::Handler|
   fml::RefPtr<fml::TaskRunner> GetServiceProtocolHandlerTaskRunner(

--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -452,6 +452,10 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line) {
   settings.prefetched_default_font_manager = command_line.HasOption(
       FlagForSwitch(Switch::PrefetchedDefaultFontManager));
 
+  settings.disable_partical_repaint =
+      command_line.HasOption(FlagForSwitch(Switch::DisableParticalRepaint));
+
+
   std::string all_dart_flags;
   if (command_line.GetOptionValue(FlagForSwitch(Switch::DartFlags),
                                   &all_dart_flags)) {

--- a/shell/common/switches.h
+++ b/shell/common/switches.h
@@ -266,6 +266,10 @@ DEF_SWITCH(LeakVM,
            "When the last shell shuts down, the shared VM is leaked by default "
            "(the leak_vm in VM settings is true). To clean up the leak VM, set "
            "this value to false.")
+DEF_SWITCH(DisableParticalRepaint,
+           "disable-partical-repaint",
+           "Disable the partical repaint on supported platforms"
+           "Ignored if partical repaint is not supported on the platform.")
 DEF_SWITCH(
     MsaaSamples,
     "msaa-samples",

--- a/shell/gpu/gpu_surface_metal_skia.h
+++ b/shell/gpu/gpu_surface_metal_skia.h
@@ -37,8 +37,7 @@ class SK_API_AVAILABLE_CA_METAL_LAYER GPUSurfaceMetalSkia : public Surface {
   // hack to make avoid allocating resources for the root surface when an
   // external view embedder is present.
   bool render_to_surface_ = true;
-  bool disable_partial_repaint_ = false;
-
+    
   // Accumulated damage for each framebuffer; Key is address of underlying
   // MTLTexture for each drawable
   std::map<uintptr_t, SkIRect> damage_;

--- a/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
@@ -41,6 +41,9 @@ public class FlutterLoader {
       "io.flutter.embedding.android.OldGenHeapSize";
   private static final String ENABLE_IMPELLER_META_DATA_KEY =
       "io.flutter.embedding.android.EnableImpeller";
+  private static final String DISABLE_PARTICAL_REPAINT_META_DATA_KEY =
+      "io.flutter.embedding.android.DisableParticalRepaint";
+
 
   /**
    * Set whether leave or clean up the VM after the last shell shuts down. It can be set from app's
@@ -322,6 +325,11 @@ public class FlutterLoader {
 
       final String leakVM = isLeakVM(metaData) ? "true" : "false";
       shellArgs.add("--leak-vm=" + leakVM);
+        
+    
+      if (metaData != null && metaData.getBoolean(DISABLE_PARTICAL_REPAINT_META_DATA_KEY, false)) {
+        shellArgs.add("--disable-partical-repaint");
+      }
 
       long initTimeMillis = SystemClock.uptimeMillis() - initStartTimestampMillis;
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -212,6 +212,12 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle) {
   if (enableImpeller != nil) {
     settings.enable_impeller = enableImpeller.boolValue;
   }
+    
+  // Whether to disable partial repaint.
+  NSNumber* disablePartialRepaint = [mainBundle objectForInfoDictionaryKey:@"FLTDisablePartialRepaint"];
+  if (disablePartialRepaint != nil) {
+     settings.disable_partical_repaint = disablePartialRepaint.boolValue;
+  }
 
   NSNumber* enableTraceSystrace = [mainBundle objectForInfoDictionaryKey:@"FLTTraceSystrace"];
   // Change the default only if the option is present.


### PR DESCRIPTION
expose a unified setting for iOS plist and Android Manifest to disable partial repaint
Android
`<meta-data
            android:name="io.flutter.embedding.android.DisableParticalRepaint"
            android:value="true" />`
iOS
`  <key>FLTDisablePartialRepaint</key>
  <true/>`


We find screen flickering both on ios and android platform,
try to enable application Settings to see if disabling partial repaint helps.

As existing only supports ios Settings:https://github.com/flutter/engine/pull/34328
