### PR TITLE
Remove temporary flag and make FlutterTest the default font for real

### DIFF
--- a/runtime/test_font_data.cc
+++ b/runtime/test_font_data.cc
@@ -1621,19 +1621,10 @@ namespace flutter {
 std::vector<sk_sp<SkTypeface>> GetTestFontData() {
   std::vector<sk_sp<SkTypeface>> typefaces;
 #if EMBED_TEST_FONT_DATA
-  const bool defaultsToAhem =
-      std::getenv("FLUTTER_ROOT") && !std::getenv("USE_FLUTTER_TEST_FONT");
-  if (defaultsToAhem) {
-    typefaces.push_back(SkTypeface::MakeFromStream(
-        SkMemoryStream::MakeDirect(kAhemFont, kAhemFontLength)));
-    typefaces.push_back(SkTypeface::MakeFromStream(
-        SkMemoryStream::MakeDirect(kFlutterTestFont, kFlutterTestFontLength)));
-  } else {
-    typefaces.push_back(SkTypeface::MakeFromStream(
-        SkMemoryStream::MakeDirect(kFlutterTestFont, kFlutterTestFontLength)));
-    typefaces.push_back(SkTypeface::MakeFromStream(
-        SkMemoryStream::MakeDirect(kAhemFont, kAhemFontLength)));
-  }
+  typefaces.push_back(SkTypeface::MakeFromStream(
+      SkMemoryStream::MakeDirect(kFlutterTestFont, kFlutterTestFontLength)));
+  typefaces.push_back(SkTypeface::MakeFromStream(
+      SkMemoryStream::MakeDirect(kAhemFont, kAhemFontLength)));
   typefaces.push_back(SkTypeface::MakeFromStream(
       SkMemoryStream::MakeDirect(kCoughFont, kCoughFontLength)));
 #endif  // EMBED_TEST_FONT_DATA
@@ -1643,13 +1634,7 @@ std::vector<sk_sp<SkTypeface>> GetTestFontData() {
 std::vector<std::string> GetTestFontFamilyNames() {
   std::vector<std::string> names;
 #if EMBED_TEST_FONT_DATA
-  const bool defaultsToAhem =
-      std::getenv("FLUTTER_ROOT") && !std::getenv("USE_FLUTTER_TEST_FONT");
-  if (defaultsToAhem) {
-    names = {"Ahem", "FlutterTest", "Cough"};
-  } else {
-    names = {"FlutterTest", "Ahem", "Cough"};
-  }
+  names = {"FlutterTest", "Ahem", "Cough"};
 #endif  // EMBED_TEST_FONT_DATA
   return names;
 }


### PR DESCRIPTION
Remove the temporary flag for migrating the font change.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
