### PR TITLE
[Impeller] mark decoded images as optimized for GPU access

### DIFF
--- a/impeller/renderer/backend/gles/blit_pass_gles.cc
+++ b/impeller/renderer/backend/gles/blit_pass_gles.cc
@@ -130,6 +130,11 @@ bool BlitPassGLES::OnCopyTextureToBufferCommand(
   return true;
 }
 
+bool BlitPassGLES::OnOptimizeForGPUAccess(std::shared_ptr<Texture> texture,
+                                          std::string label) {
+  return true;
+}
+
 // |BlitPass|
 bool BlitPassGLES::OnGenerateMipmapCommand(std::shared_ptr<Texture> texture,
                                            std::string label) {

--- a/impeller/renderer/backend/gles/blit_pass_gles.h
+++ b/impeller/renderer/backend/gles/blit_pass_gles.h
@@ -51,6 +51,10 @@ class BlitPassGLES final : public BlitPass {
                                     std::string label) override;
 
   // |BlitPass|
+  bool OnOptimizeForGPUAccess(std::shared_ptr<Texture> texture,
+                              std::string label) override;
+
+  // |BlitPass|
   bool OnGenerateMipmapCommand(std::shared_ptr<Texture> texture,
                                std::string label) override;
 

--- a/impeller/renderer/backend/metal/blit_command_mtl.h
+++ b/impeller/renderer/backend/metal/blit_command_mtl.h
@@ -50,4 +50,13 @@ struct BlitGenerateMipmapCommandMTL : public BlitGenerateMipmapCommand,
   [[nodiscard]] bool Encode(id<MTLBlitCommandEncoder> encoder) const override;
 };
 
+struct BlitOptimizeGPUAccessCommandMTL : public BlitGenerateMipmapCommand,
+                                         public BlitEncodeMTL {
+  ~BlitOptimizeGPUAccessCommandMTL() override;
+
+  std::string GetLabel() const override;
+
+  [[nodiscard]] bool Encode(id<MTLBlitCommandEncoder> encoder) const override;
+};
+
 }  // namespace impeller

--- a/impeller/renderer/backend/metal/blit_command_mtl.mm
+++ b/impeller/renderer/backend/metal/blit_command_mtl.mm
@@ -120,7 +120,7 @@ std::string BlitOptimizeGPUAccessCommandMTL::GetLabel() const {
 
 bool BlitOptimizeGPUAccessCommandMTL::Encode(
     id<MTLBlitCommandEncoder> encoder) const {
-  if (@available(macOS 10.15, iOS 12, tvOS 13, *)) {
+  if (@available(macOS 10.14, iOS 12, tvOS 12, *)) {
     auto texture_mtl = TextureMTL::Cast(*texture).GetMTLTexture();
     if (!texture_mtl) {
       return false;

--- a/impeller/renderer/backend/metal/blit_command_mtl.mm
+++ b/impeller/renderer/backend/metal/blit_command_mtl.mm
@@ -112,4 +112,23 @@ bool BlitGenerateMipmapCommandMTL::Encode(
   return true;
 };
 
+BlitOptimizeGPUAccessCommandMTL::~BlitOptimizeGPUAccessCommandMTL() = default;
+
+std::string BlitOptimizeGPUAccessCommandMTL::GetLabel() const {
+  return label;
+}
+
+bool BlitOptimizeGPUAccessCommandMTL::Encode(
+    id<MTLBlitCommandEncoder> encoder) const {
+  if (@available(macOS 10.15, iOS 12, tvOS 13, *)) {
+    auto texture_mtl = TextureMTL::Cast(*texture).GetMTLTexture();
+    if (!texture_mtl) {
+      return false;
+    }
+
+    [encoder optimizeContentsForGPUAccess:texture_mtl];
+  }
+  return true;
+}
+
 }  // namespace impeller

--- a/impeller/renderer/backend/metal/blit_pass_mtl.h
+++ b/impeller/renderer/backend/metal/blit_pass_mtl.h
@@ -57,6 +57,10 @@ class BlitPassMTL final : public BlitPass {
   bool OnGenerateMipmapCommand(std::shared_ptr<Texture> texture,
                                std::string label) override;
 
+  // |BlitPass|
+  bool OnOptimizeForGPUAccess(std::shared_ptr<Texture> texture,
+                              std::string label) override;
+
   FML_DISALLOW_COPY_AND_ASSIGN(BlitPassMTL);
 };
 

--- a/impeller/renderer/backend/metal/blit_pass_mtl.mm
+++ b/impeller/renderer/backend/metal/blit_pass_mtl.mm
@@ -134,4 +134,15 @@ bool BlitPassMTL::OnGenerateMipmapCommand(std::shared_ptr<Texture> texture,
   return true;
 }
 
+// |BlitPass|
+bool BlitPassMTL::OnOptimizeForGPUAccess(std::shared_ptr<Texture> texture,
+                                         std::string label) {
+  auto command = std::make_unique<BlitOptimizeGPUAccessCommandMTL>();
+  command->label = label;
+  command->texture = std::move(texture);
+
+  commands_.emplace_back(std::move(command));
+  return true;
+}
+
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/blit_pass_vk.cc
+++ b/impeller/renderer/backend/vulkan/blit_pass_vk.cc
@@ -88,6 +88,12 @@ bool BlitPassVK::OnCopyTextureToBufferCommand(
 }
 
 // |BlitPass|
+bool BlitPassVK::OnOptimizeForGPUAccess(std::shared_ptr<Texture> texture,
+                                        std::string label) {
+  return true;
+}
+
+// |BlitPass|
 bool BlitPassVK::OnGenerateMipmapCommand(std::shared_ptr<Texture> texture,
                                          std::string label) {
   auto command = std::make_unique<BlitGenerateMipmapCommandVK>();

--- a/impeller/renderer/backend/vulkan/blit_pass_vk.h
+++ b/impeller/renderer/backend/vulkan/blit_pass_vk.h
@@ -51,6 +51,9 @@ class BlitPassVK final : public BlitPass {
                                     std::string label) override;
 
   // |BlitPass|
+  bool OnOptimizeForGPUAccess(std::shared_ptr<Texture> texture,
+                              std::string label) override;
+  // |BlitPass|
   bool OnGenerateMipmapCommand(std::shared_ptr<Texture> texture,
                                std::string label) override;
 

--- a/impeller/renderer/blit_pass.cc
+++ b/impeller/renderer/blit_pass.cc
@@ -121,11 +121,6 @@ bool BlitPass::OptimizeForGPUAccess(std::shared_ptr<Texture> texture,
   return OnOptimizeForGPUAccess(std::move(texture), std::move(label));
 }
 
-bool BlitPass::OnOptimizeForGPUAccess(std::shared_ptr<Texture> texture,
-                                      std::string label) {
-  return true;
-}
-
 bool BlitPass::GenerateMipmap(std::shared_ptr<Texture> texture,
                               std::string label) {
   if (!texture) {

--- a/impeller/renderer/blit_pass.cc
+++ b/impeller/renderer/blit_pass.cc
@@ -118,7 +118,7 @@ bool BlitPass::AddCopy(std::shared_ptr<Texture> source,
 
 bool BlitPass::OptimizeForGPUAccess(std::shared_ptr<Texture> texture,
                                     std::string label) {
-  return OnOptimizeForGPUAccess(texture, label);
+  return OnOptimizeForGPUAccess(std::move(texture), std::move(label));
 }
 
 bool BlitPass::OnOptimizeForGPUAccess(std::shared_ptr<Texture> texture,

--- a/impeller/renderer/blit_pass.cc
+++ b/impeller/renderer/blit_pass.cc
@@ -116,6 +116,16 @@ bool BlitPass::AddCopy(std::shared_ptr<Texture> source,
                                       std::move(label));
 }
 
+bool BlitPass::OptimizeForGPUAccess(std::shared_ptr<Texture> texture,
+                                    std::string label) {
+  return OnOptimizeForGPUAccess(texture, label);
+}
+
+bool BlitPass::OnOptimizeForGPUAccess(std::shared_ptr<Texture> texture,
+                                      std::string label) {
+  return true;
+}
+
 bool BlitPass::GenerateMipmap(std::shared_ptr<Texture> texture,
                               std::string label) {
   if (!texture) {

--- a/impeller/renderer/blit_pass.h
+++ b/impeller/renderer/blit_pass.h
@@ -141,7 +141,7 @@ class BlitPass {
       std::string label) = 0;
 
   virtual bool OnOptimizeForGPUAccess(std::shared_ptr<Texture> texture,
-                                      std::string label);
+                                      std::string label) = 0;
 
   virtual bool OnGenerateMipmapCommand(std::shared_ptr<Texture> texture,
                                        std::string label) = 0;

--- a/impeller/renderer/blit_pass.h
+++ b/impeller/renderer/blit_pass.h
@@ -96,6 +96,19 @@ class BlitPass {
   bool GenerateMipmap(std::shared_ptr<Texture> texture, std::string label = "");
 
   //----------------------------------------------------------------------------
+  /// @brief      Optimize the provided texture for GPU access.
+  ///             This will no-op on platforms where this functionality is
+  ///             unsupported.
+  ///
+  /// @param[in]  texture  The texture to generate mipmaps for.
+  /// @param[in]  label    The optional debug label to give the command.
+  ///
+  /// @return     If the command was valid for subsequent commitment.
+  ///
+  bool OptimizeForGPUAccess(std::shared_ptr<Texture> texture,
+                            std::string label = "");
+
+  //----------------------------------------------------------------------------
   /// @brief      Encode the recorded commands to the underlying command buffer.
   ///
   /// @param      transients_allocator  The transients allocator.
@@ -126,6 +139,9 @@ class BlitPass {
       IRect source_region,
       size_t destination_offset,
       std::string label) = 0;
+
+  virtual bool OnOptimizeForGPUAccess(std::shared_ptr<Texture> texture,
+                                      std::string label);
 
   virtual bool OnGenerateMipmapCommand(std::shared_ptr<Texture> texture,
                                        std::string label) = 0;

--- a/impeller/renderer/testing/mocks.h
+++ b/impeller/renderer/testing/mocks.h
@@ -62,6 +62,9 @@ class MockBlitPass : public BlitPass {
                     size_t destination_offset,
                     std::string label));
 
+  MOCK_METHOD2(OnOptimizeForGPUAccess,
+               bool(std::shared_ptr<Texture> texture, std::string label));
+
   MOCK_METHOD2(OnGenerateMipmapCommand,
                bool(std::shared_ptr<Texture> texture, std::string label));
 };

--- a/lib/ui/painting/image_decoder_impeller.cc
+++ b/lib/ui/painting/image_decoder_impeller.cc
@@ -286,6 +286,7 @@ sk_sp<DlImage> ImageDecoderImpeller::UploadTexture(
     }
     blit_pass->SetLabel("Mipmap Blit Pass");
     blit_pass->GenerateMipmap(texture);
+    blit_pass->OptimizeForGPUAccess(texture);
 
     blit_pass->EncodeCommands(context->GetResourceAllocator());
     if (!command_buffer->SubmitCommands()) {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/122819

Apple performance tips say to do this, so lets do it.
