### PR TITLE
[Impeller] fix opacity inheritance test

### DIFF
--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -2425,13 +2425,6 @@ TEST_P(EntityTest, InheritOpacityTest) {
   // Clips and restores trivially accept opacity.
   ASSERT_TRUE(ClipContents().CanAcceptOpacity(entity));
   ASSERT_TRUE(ClipRestoreContents().CanAcceptOpacity(entity));
-
-  // Potentially overlapping geometry always returns false.
-  auto solid_color_2 = std::make_shared<TiledTextureContents>();
-  Path path = PathBuilder{}.MoveTo({100, 100}).LineTo({100, 200}).TakePath();
-  solid_color_2->SetGeometry(Geometry::MakeStrokePath(path, 5.0));
-
-  ASSERT_FALSE(solid_color_2->CanAcceptOpacity(entity));
 }
 
 }  // namespace testing


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/122827

We don't need to check for overlapping geometry unless its text