### PR TITLE
Handle error more gracefully, add test for same

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -231,7 +231,6 @@ constexpr char kTextPlainFormat[] = "text/plain";
                      return;
                    }
                    NSDictionary* replyArgs = (NSDictionary*)decoded_reply;
-                   NSLog(@"dictionary: %@", replyArgs);
                    if ([replyArgs[@"response"] isEqual:@"exit"]) {
                      _terminator(sender);
                    }

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -215,9 +215,24 @@ constexpr char kTextPlainFormat[] = "text/plain";
       [_engine sendOnChannel:kFlutterPlatformChannel
                      message:[codec encodeMethodCall:methodCall]
                  binaryReply:^(NSData* _Nullable reply) {
-                   NSDictionary* replyArgs = [codec decodeEnvelope:reply];
+                   NSAssert(_terminator, @"terminator shouldn't be nil");
+                   id decoded_reply = [codec decodeEnvelope:reply];
+                   if ([decoded_reply isKindOfClass:[FlutterError class]]) {
+                     FlutterError* error = (FlutterError*)decoded_reply;
+                     NSLog(@"Method call returned error[%@]: %@ %@", [error code], [error message],
+                           [error details]);
+                     _terminator(sender);
+                     return;
+                   }
+                   if (![decoded_reply isKindOfClass:[NSDictionary class]]) {
+                     NSLog(@"Call to System.requestAppExit returned an unexpected object: %@",
+                           decoded_reply);
+                     _terminator(sender);
+                     return;
+                   }
+                   NSDictionary* replyArgs = (NSDictionary*)decoded_reply;
+                   NSLog(@"dictionary: %@", replyArgs);
                    if ([replyArgs[@"response"] isEqual:@"exit"]) {
-                     NSAssert(_terminator, @"terminator shouldn't be nil");
                      _terminator(sender);
                    }
                    if (result != nil) {


### PR DESCRIPTION
## Description

This fixes the application exit handler so that it deals more gracefully with errors returned to it from the framework.

In this case, since the framework doesn't yet have support for requesting an application exit, it was returning an error condition, which the previous code tried to convert to an NSDictionary (and failed, causing a crash).

Now it will log the error and quit as requested if an error or unrecognized object type is returned.

## Related Issues
 - https://github.com/flutter/flutter/issues/122813

## Tests
 - Added a test for the error condition.