### PR TITLE
[Impeller] dont tessellate rectangles in TextureContents

### DIFF
--- a/impeller/entity/contents/texture_contents.h
+++ b/impeller/entity/contents/texture_contents.h
@@ -77,7 +77,7 @@ class TextureContents final : public Contents {
   std::string label_;
 
   Path path_;
-  bool is_rect_ = false;
+  std::optional<Rect> rect_;
   bool stencil_enabled_ = true;
 
   std::shared_ptr<Texture> texture_;


### PR DESCRIPTION
Doesn't make a huge difference but helps reduce noise for tracking work the tessellator is doing.
