### PR TITLE
Update analyzer for api_conform_test

### DIFF
--- a/web_sdk/pubspec.yaml
+++ b/web_sdk/pubspec.yaml
@@ -9,6 +9,6 @@ dependencies:
   path: 1.8.2
 
 dev_dependencies:
-  analyzer: 5.7.1
+  analyzer: 5.8.0
   test: 1.22.1
   pub_semver: 2.1.3

--- a/web_sdk/test/api_conform_test.dart
+++ b/web_sdk/test/api_conform_test.dart
@@ -10,7 +10,6 @@ import 'package:analyzer/dart/analysis/features.dart';
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/analysis/utilities.dart';
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:pub_semver/pub_semver.dart';
 
 // Ignore members defined on Object.
 const Set<String> _kObjectMembers = <String>{
@@ -20,10 +19,7 @@ const Set<String> _kObjectMembers = <String>{
 };
 
 CompilationUnit _parseAndCheckDart(String path) {
-  final FeatureSet analyzerFeatures = FeatureSet.fromEnableFlags2(
-    flags: <String>['class-modifiers', 'sealed-class', 'records', 'patterns'],
-    sdkLanguageVersion: Version.parse('3.0.0-0'),
-  );
+  final FeatureSet analyzerFeatures = FeatureSet.latestLanguageVersion();
   if (!analyzerFeatures.isEnabled(Feature.non_nullable)) {
     throw Exception('non-nullable feature is disabled.');
   }


### PR DESCRIPTION
Follow-up to https://github.com/flutter/engine/pull/40328.

Just now a new analyzer version was released on pub that has the 3.0 experiments enabled by default (see also https://github.com/dart-lang/sdk/issues/51760). With that version we don't have to manually manage experiment flags in the api_conform_test.