### PR TITLE
Rename FontCollection to FlutterFontCollection

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/fonts.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/fonts.dart
@@ -24,7 +24,7 @@ const String _robotoUrl =
     'https://fonts.gstatic.com/s/roboto/v20/KFOmCnqEu92Fr1Me5WZLCzYlKw.ttf';
 
 /// Manages the fonts used in the Skia-based backend.
-class SkiaFontCollection implements FontCollection {
+class SkiaFontCollection implements FlutterFontCollection {
   final Set<String> _downloadedFontFamilies = <String>{};
 
   /// Fonts that started the download process, but are not yet registered.

--- a/lib/web_ui/lib/src/engine/fonts.dart
+++ b/lib/web_ui/lib/src/engine/fonts.dart
@@ -7,7 +7,7 @@ import 'dart:typed_data';
 
 import 'assets.dart';
 
-abstract class FontCollection {
+abstract class FlutterFontCollection {
 
   /// Fonts loaded with [loadFontFromList] do not need to be registered
   /// with [registerDownloadedFonts]. Fonts are both downloaded and registered

--- a/lib/web_ui/lib/src/engine/renderer.dart
+++ b/lib/web_ui/lib/src/engine/renderer.dart
@@ -47,7 +47,7 @@ abstract class Renderer {
   }
 
   String get rendererTag;
-  FontCollection get fontCollection;
+  FlutterFontCollection get fontCollection;
 
   FutureOr<void> initialize();
   void reset(FlutterViewEmbedder embedder);

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/renderer.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/renderer.dart
@@ -155,7 +155,7 @@ class SkwasmRenderer implements Renderer {
   }
 
   @override
-  FontCollection get fontCollection => throw UnimplementedError('fontCollection not yet implemented');
+  FlutterFontCollection get fontCollection => throw UnimplementedError('fontCollection not yet implemented');
 
   @override
   FutureOr<void> initialize() {

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_stub/renderer.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_stub/renderer.dart
@@ -135,7 +135,7 @@ class SkwasmRenderer implements Renderer {
   }
 
   @override
-  FontCollection get fontCollection => throw UnimplementedError('Skwasm not implemented on this platform.');
+  FlutterFontCollection get fontCollection => throw UnimplementedError('Skwasm not implemented on this platform.');
 
   @override
   FutureOr<void> initialize() {

--- a/lib/web_ui/lib/src/engine/text/font_collection.dart
+++ b/lib/web_ui/lib/src/engine/text/font_collection.dart
@@ -20,7 +20,7 @@ import 'layout_service.dart';
 /// [downloadAssetFonts] with it to register fonts declared in the
 /// font manifest. If test fonts are enabled, then call
 /// [debugDownloadTestFonts] as well.
-class HtmlFontCollection implements FontCollection {
+class HtmlFontCollection implements FlutterFontCollection {
   FontManager? _assetFontManager;
   FontManager? _testFontManager;
 


### PR DESCRIPTION
This will avoid name conflicts with the FontCollection API that will be added to CanvasKit.
(see https://skia-review.googlesource.com/c/skia/+/657270)
