### PR TITLE
drawTextBlob should not be compatible with opacity inheritance

### DIFF
--- a/display_list/display_list_builder.cc
+++ b/display_list/display_list_builder.cc
@@ -1124,7 +1124,12 @@ void DisplayListBuilder::drawTextBlob(const sk_sp<SkTextBlob> blob,
                                       SkScalar y) {
   Push<DrawTextBlobOp>(0, 1, blob, x, y);
   AccumulateOpBounds(blob->bounds().makeOffset(x, y), kDrawTextBlobFlags);
-  CheckLayerOpacityCompatibility();
+  // There is no way to query if the glyphs of a text blob overlap and
+  // there are no current guarantees from either Skia or Impeller that
+  // they will protect overlapping glyphs from the effects of overdraw
+  // so we must make the conservative assessment that this DL layer is
+  // not compatible with group opacity inheritance.
+  UpdateLayerOpacityCompatibility(false);
 }
 void DisplayListBuilder::DrawTextBlob(const sk_sp<SkTextBlob>& blob,
                                       SkScalar x,

--- a/display_list/display_list_unittests.cc
+++ b/display_list/display_list_unittests.cc
@@ -645,7 +645,7 @@ TEST(DisplayList, SingleOpsMightSupportGroupOpacityWithOrWithoutBlendMode) {
     static auto display_list = builder.Build();
     RUN_TESTS2(builder.drawDisplayList(display_list);, false);
   }
-  RUN_TESTS(builder.drawTextBlob(TestBlob1, 0, 0););
+  RUN_TESTS2(builder.drawTextBlob(TestBlob1, 0, 0);, false);
   RUN_TESTS2(builder.drawShadow(kTestPath1, SK_ColorBLACK, 1.0, false, 1.0);
              , false);
 


### PR DESCRIPTION
Technically we've never been able to trust drawTextBlob to be non-overlapping, but in practice it has nearly always been OK with inheriting opacity as most text strings don't have overlapping glyphs, and also in practice most text is drawn over a background fill so it is already involved in an incompatible DisplayList.

Recently, as we try to fix our opacity inheritance implementation code, though, some tests that draw text can have a lot of off-by-1 errors as various paths through the engine start to become capable of distributing the opacity to single-text-blob DisplayList objects, pointing out that there are real world cases where there are differences in rendering text with or without inherited opacity.

So, it is time to bite the bullet and declare that text blobs are incompatible with group opacity optimizations.