### PR TITLE
[rotation_distortion]send interpolated viewport metrics to address rotation distortion

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -48,6 +48,8 @@ NSNotificationName const FlutterViewControllerShowHomeIndicator =
  * Compute the interpolated value under linear interpolation.
  */
 CGFloat FLTLinearInterpolatedValue(double progress, CGFloat from, CGFloat to, CGFloat scale) {
+  // TODO(hellohuanlin): consider non-linear interpolation to further reduce rotation distortion.
+  // See: https://github.com/flutter/flutter/issues/123248
   NSCAssert(progress >= 0 && progress <= 1, @"progress must be between 0 and 1");
   return (from * (1 - progress) + to * progress) * scale;
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -927,7 +927,7 @@ static void SendFakeTouchEvent(FlutterEngine* engine,
   // Invalidate the timer to avoid race condition when a new rotation starts before the previous
   // rotation's timer ends. The `viewWillTransitionToSize` itself is guaranteed to be called after
   // the previous rotation is complete. However, there can still be race condition because:
-  // 1. the transition duration may not be divisible by `kRotationViewportMetricsUpdateInterval`, \
+  // 1. the transition duration may not be divisible by `kRotationViewportMetricsUpdateInterval`,
   // resulting in 1 additional frame.
   // 2. there can still be rounding errors when accumulating the progress which is normalized.
   // 3. NSTimer is backed by the run loop, which is not accurate timing.

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -951,7 +951,8 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   CGFloat scale = 2;
 
   flutter::ViewportMetrics viewportMetrics;
-  FLTInterpolateViewportMetrics(viewportMetrics, /*rotationProgress=*/0, fromSize, fromPadding, toSize, toPadding, scale);
+  FLTInterpolateViewportMetrics(viewportMetrics, /*rotationProgress=*/0, fromSize, fromPadding,
+                                toSize, toPadding, scale);
 
   XCTAssertEqual(viewportMetrics.physical_width, 1000 * scale);
   XCTAssertEqual(viewportMetrics.physical_height, 500 * scale);
@@ -961,7 +962,8 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   XCTAssertEqual(viewportMetrics.physical_padding_right, 40 * scale);
 
   // 25% of rotation progress
-  FLTInterpolateViewportMetrics(viewportMetrics, /*rotationProgress=*/0.25, fromSize, fromPadding, toSize, toPadding, scale);
+  FLTInterpolateViewportMetrics(viewportMetrics, /*rotationProgress=*/0.25, fromSize, fromPadding,
+                                toSize, toPadding, scale);
 
   XCTAssertEqual(viewportMetrics.physical_width, 875 * scale);
   XCTAssertEqual(viewportMetrics.physical_height, 625 * scale);
@@ -971,7 +973,8 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   XCTAssertEqual(viewportMetrics.physical_padding_right, 50 * scale);
 
   // 50% of rotation progress
-  FLTInterpolateViewportMetrics(viewportMetrics, /*rotationProgress=*/0.5, fromSize, fromPadding, toSize, toPadding, scale);
+  FLTInterpolateViewportMetrics(viewportMetrics, /*rotationProgress=*/0.5, fromSize, fromPadding,
+                                toSize, toPadding, scale);
 
   XCTAssertEqual(viewportMetrics.physical_width, 750 * scale);
   XCTAssertEqual(viewportMetrics.physical_height, 750 * scale);
@@ -981,7 +984,8 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   XCTAssertEqual(viewportMetrics.physical_padding_right, 60 * scale);
 
   // 100% of rotation progress
-  FLTInterpolateViewportMetrics(viewportMetrics, /*rotationProgress=*/1, fromSize, fromPadding, toSize, toPadding, scale);
+  FLTInterpolateViewportMetrics(viewportMetrics, /*rotationProgress=*/1, fromSize, fromPadding,
+                                toSize, toPadding, scale);
 
   XCTAssertEqual(viewportMetrics.physical_width, 500 * scale);
   XCTAssertEqual(viewportMetrics.physical_height, 1000 * scale);
@@ -1072,7 +1076,8 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
       .andDo(^(NSInvocation* invocation) {
         frameCount += 1;
         if (frameCount == estimatedCount / 2) {
-          [viewController viewWillTransitionToSize:CGSizeZero withTransitionCoordinator:mockCoordinator];
+          [viewController viewWillTransitionToSize:CGSizeZero
+                         withTransitionCoordinator:mockCoordinator];
         }
         if (frameCount == estimatedCount * 3 / 2) {
           [expectation fulfill];
@@ -1081,7 +1086,9 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   [viewController viewWillTransitionToSize:CGSizeZero withTransitionCoordinator:mockCoordinator];
   [self waitForExpectationsWithTimeout:5.0 handler:nil];
   // Wait for additional transitionDuration to allow updateViewportMetrics calls if any.
-  XCTWaiterResult result = [XCTWaiter waitForExpectations: @[[self expectationWithDescription:@"Waiting for rotation duration"]] timeout:transitionDuration];
+  XCTWaiterResult result = [XCTWaiter
+      waitForExpectations:@[ [self expectationWithDescription:@"Waiting for rotation duration"] ]
+                  timeout:transitionDuration];
   XCTAssertEqual(result, XCTWaiterResultTimedOut);
   // Since we actually accumulate the progress delta (from 0%-100%), rather than directly
   // dividing the total transition duration by the frame interval, there can easily be

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -948,51 +948,47 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   CGSize toSize = CGSizeMake(500, 1000);
   UIEdgeInsets fromPadding = UIEdgeInsetsMake(/*top=*/10, /*left=*/20, /*bottom=*/30, /*right=*/40);
   UIEdgeInsets toPadding = UIEdgeInsetsMake(/*top=*/50, /*left=*/60, /*bottom=*/70, /*right=*/80);
+  CGFloat scale = 2;
 
   flutter::ViewportMetrics viewportMetrics;
-  FLTInterpolateViewportMetrics(viewportMetrics,
-                                /*rotationProgress=*/0, fromSize, fromPadding, toSize, toPadding);
+  FLTInterpolateViewportMetrics(viewportMetrics, /*rotationProgress=*/0, fromSize, fromPadding, toSize, toPadding, scale);
 
-  XCTAssertEqual(viewportMetrics.physical_width, 1000 * UIScreen.mainScreen.scale);
-  XCTAssertEqual(viewportMetrics.physical_height, 500 * UIScreen.mainScreen.scale);
-  XCTAssertEqual(viewportMetrics.physical_padding_top, 10 * UIScreen.mainScreen.scale);
-  XCTAssertEqual(viewportMetrics.physical_padding_left, 20 * UIScreen.mainScreen.scale);
-  XCTAssertEqual(viewportMetrics.physical_padding_bottom, 30 * UIScreen.mainScreen.scale);
-  XCTAssertEqual(viewportMetrics.physical_padding_right, 40 * UIScreen.mainScreen.scale);
+  XCTAssertEqual(viewportMetrics.physical_width, 1000 * scale);
+  XCTAssertEqual(viewportMetrics.physical_height, 500 * scale);
+  XCTAssertEqual(viewportMetrics.physical_padding_top, 10 * scale);
+  XCTAssertEqual(viewportMetrics.physical_padding_left, 20 * scale);
+  XCTAssertEqual(viewportMetrics.physical_padding_bottom, 30 * scale);
+  XCTAssertEqual(viewportMetrics.physical_padding_right, 40 * scale);
 
   // 25% of rotation progress
-  FLTInterpolateViewportMetrics(viewportMetrics,
-                                /*rotationProgress=*/0.25, fromSize, fromPadding, toSize,
-                                toPadding);
+  FLTInterpolateViewportMetrics(viewportMetrics, /*rotationProgress=*/0.25, fromSize, fromPadding, toSize, toPadding, scale);
 
-  XCTAssertEqual(viewportMetrics.physical_width, 875 * UIScreen.mainScreen.scale);
-  XCTAssertEqual(viewportMetrics.physical_height, 625 * UIScreen.mainScreen.scale);
-  XCTAssertEqual(viewportMetrics.physical_padding_top, 20 * UIScreen.mainScreen.scale);
-  XCTAssertEqual(viewportMetrics.physical_padding_left, 30 * UIScreen.mainScreen.scale);
-  XCTAssertEqual(viewportMetrics.physical_padding_bottom, 40 * UIScreen.mainScreen.scale);
-  XCTAssertEqual(viewportMetrics.physical_padding_right, 50 * UIScreen.mainScreen.scale);
+  XCTAssertEqual(viewportMetrics.physical_width, 875 * scale);
+  XCTAssertEqual(viewportMetrics.physical_height, 625 * scale);
+  XCTAssertEqual(viewportMetrics.physical_padding_top, 20 * scale);
+  XCTAssertEqual(viewportMetrics.physical_padding_left, 30 * scale);
+  XCTAssertEqual(viewportMetrics.physical_padding_bottom, 40 * scale);
+  XCTAssertEqual(viewportMetrics.physical_padding_right, 50 * scale);
 
   // 50% of rotation progress
-  FLTInterpolateViewportMetrics(viewportMetrics,
-                                /*rotationProgress=*/0.5, fromSize, fromPadding, toSize, toPadding);
+  FLTInterpolateViewportMetrics(viewportMetrics, /*rotationProgress=*/0.5, fromSize, fromPadding, toSize, toPadding, scale);
 
-  XCTAssertEqual(viewportMetrics.physical_width, 750 * UIScreen.mainScreen.scale);
-  XCTAssertEqual(viewportMetrics.physical_height, 750 * UIScreen.mainScreen.scale);
-  XCTAssertEqual(viewportMetrics.physical_padding_top, 30 * UIScreen.mainScreen.scale);
-  XCTAssertEqual(viewportMetrics.physical_padding_left, 40 * UIScreen.mainScreen.scale);
-  XCTAssertEqual(viewportMetrics.physical_padding_bottom, 50 * UIScreen.mainScreen.scale);
-  XCTAssertEqual(viewportMetrics.physical_padding_right, 60 * UIScreen.mainScreen.scale);
+  XCTAssertEqual(viewportMetrics.physical_width, 750 * scale);
+  XCTAssertEqual(viewportMetrics.physical_height, 750 * scale);
+  XCTAssertEqual(viewportMetrics.physical_padding_top, 30 * scale);
+  XCTAssertEqual(viewportMetrics.physical_padding_left, 40 * scale);
+  XCTAssertEqual(viewportMetrics.physical_padding_bottom, 50 * scale);
+  XCTAssertEqual(viewportMetrics.physical_padding_right, 60 * scale);
 
   // 100% of rotation progress
-  FLTInterpolateViewportMetrics(viewportMetrics,
-                                /*rotationProgress=*/1, fromSize, fromPadding, toSize, toPadding);
+  FLTInterpolateViewportMetrics(viewportMetrics, /*rotationProgress=*/1, fromSize, fromPadding, toSize, toPadding, scale);
 
-  XCTAssertEqual(viewportMetrics.physical_width, 500 * UIScreen.mainScreen.scale);
-  XCTAssertEqual(viewportMetrics.physical_height, 1000 * UIScreen.mainScreen.scale);
-  XCTAssertEqual(viewportMetrics.physical_padding_top, 50 * UIScreen.mainScreen.scale);
-  XCTAssertEqual(viewportMetrics.physical_padding_left, 60 * UIScreen.mainScreen.scale);
-  XCTAssertEqual(viewportMetrics.physical_padding_bottom, 70 * UIScreen.mainScreen.scale);
-  XCTAssertEqual(viewportMetrics.physical_padding_right, 80 * UIScreen.mainScreen.scale);
+  XCTAssertEqual(viewportMetrics.physical_width, 500 * scale);
+  XCTAssertEqual(viewportMetrics.physical_height, 1000 * scale);
+  XCTAssertEqual(viewportMetrics.physical_padding_top, 50 * scale);
+  XCTAssertEqual(viewportMetrics.physical_padding_left, 60 * scale);
+  XCTAssertEqual(viewportMetrics.physical_padding_bottom, 70 * scale);
+  XCTAssertEqual(viewportMetrics.physical_padding_right, 80 * scale);
 }
 
 - (void)testViewWillTransitionToSize_DoesInterpolateViewportMetricsIfNonZeroDuration {
@@ -1046,6 +1042,52 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   // Should directly update the view port metrics (when passing NO to `forRotation`).
   [viewController updateViewportMetricsIfNeeded:NO];
   OCMVerifyAll(mockEngine);
+}
+
+- (void)testViewWillTransitionToSize_RotationTimerRaceCondition {
+  // This is to verify that when a new rotation happens, the previous rotation timer must be
+  // invalidated. Since NSTimer is toll-free bridge type, which is not supported by OCMock, this
+  // test is not as straight forward - we perform the second rotation in the middle of the first
+  // rotation, and then check the frame count to determine that the interpolation of the previous
+  // rotation is not happening after the mid point.
+  FlutterEngine* mockEngine = OCMPartialMock([[FlutterEngine alloc] init]);
+  [mockEngine createShell:@"" libraryURI:@"" initialRoute:nil];
+  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:mockEngine
+                                                                                nibName:nil
+                                                                                 bundle:nil];
+  mockEngine.viewController = viewController;
+
+  id mockCoordinator = OCMProtocolMock(@protocol(UIViewControllerTransitionCoordinator));
+  NSTimeInterval transitionDuration = 0.5;
+  OCMStub([mockCoordinator transitionDuration]).andReturn(transitionDuration);
+
+  flutter::ViewportMetrics viewportMetrics;
+
+  XCTestExpectation* expectation =
+      [self expectationWithDescription:@"completed expected frame count"];
+  int estimatedCount = floor(transitionDuration / kRotationViewportMetricsUpdateInterval);
+  __block int frameCount = 0;
+  OCMStub([mockEngine updateViewportMetrics:viewportMetrics])
+      .ignoringNonObjectArgs()
+      .andDo(^(NSInvocation* invocation) {
+        frameCount += 1;
+        if (frameCount == estimatedCount / 2) {
+          [viewController viewWillTransitionToSize:CGSizeZero withTransitionCoordinator:mockCoordinator];
+        }
+        if (frameCount == estimatedCount * 3 / 2) {
+          [expectation fulfill];
+        }
+      });
+  [viewController viewWillTransitionToSize:CGSizeZero withTransitionCoordinator:mockCoordinator];
+  [self waitForExpectationsWithTimeout:5.0 handler:nil];
+  // Wait for additional transitionDuration to allow updateViewportMetrics calls if any.
+  XCTWaiterResult result = [XCTWaiter waitForExpectations: @[[self expectationWithDescription:@"Waiting for rotation duration"]] timeout:transitionDuration];
+  XCTAssertEqual(result, XCTWaiterResultTimedOut);
+  // Since we actually accumulate the progress delta (from 0%-100%), rather than directly
+  // dividing the total transition duration by the frame interval, there can easily be
+  // a rounding error. We cannot use `expectedFulfillmentCount` since it could over-fulfill once.
+  // So we check the absolute difference of at most 1 frame.
+  XCTAssert(abs(frameCount - estimatedCount * 3 / 2) <= 1);
 }
 
 - (void)testViewDidLoadDoesntInvokeEngineWhenNotTheViewController {

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h
@@ -6,6 +6,7 @@
 #define FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERVIEWCONTROLLER_INTERNAL_H_
 
 #include "flutter/fml/memory/weak_ptr.h"
+#include "flutter/lib/ui/window/viewport_metrics.h"
 
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterKeySecondaryResponder.h"
@@ -27,11 +28,20 @@ extern NSNotificationName const FlutterViewControllerHideHomeIndicator;
 FLUTTER_DARWIN_EXPORT
 extern NSNotificationName const FlutterViewControllerShowHomeIndicator;
 
+constexpr NSTimeInterval kRotationViewportMetricsUpdateInterval = 1.0 / 60;
+
 typedef NS_ENUM(NSInteger, FlutterKeyboardMode) {
   FlutterKeyboardModeHidden = 0,
   FlutterKeyboardModeDocked = 1,
   FlutterKeyboardModeFloating = 2,
 };
+
+void FLTInterpolateViewportMetrics(flutter::ViewportMetrics& viewportMetrics,
+                                   double rotationProgress,
+                                   CGSize fromSize,
+                                   UIEdgeInsets fromPadding,
+                                   CGSize toSize,
+                                   UIEdgeInsets toPadding);
 
 @interface FlutterViewController () <FlutterViewResponder>
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h
@@ -41,7 +41,8 @@ void FLTInterpolateViewportMetrics(flutter::ViewportMetrics& viewportMetrics,
                                    CGSize fromSize,
                                    UIEdgeInsets fromPadding,
                                    CGSize toSize,
-                                   UIEdgeInsets toPadding);
+                                   UIEdgeInsets toPadding,
+                                   CGFloat scale);
 
 @interface FlutterViewController () <FlutterViewResponder>
 


### PR DESCRIPTION
Send interpolated viewport metrics to make the rotation smoother. Result is pretty good, as show below.  

There are still some minor amount of distortion. There are 2 main reasons: 

1. Flutter drawing happens on the UI thread, which is not iOS main thread. The delay between issuing engine command till the drawing happens is indeterministic and could vary depending on how busy/idle the app is during the rotation. This amount of distortion is unavoidable, and unlikely solvable. 
2. We use linear interpolation for simplicity, but iOS window rotation is likely non-linear, with ease-in ease-out effect. Consider using non-linear interpolation if this becomes a problem. 

Currently we are calling framework from engine per frame. A potential performance improvement can be just sending the rotation duration to the framework, and have the framework to do the interpolation by itself. Though this will require a whole lot more refactoring on both engine and framework. 



https://user-images.githubusercontent.com/41930132/226756067-b5d99590-5565-47e3-bf37-56ca71e763b6.mp4


*List which issues are fixed by this PR. You must list at least one issue.*

Fixes https://github.com/flutter/flutter/issues/16322

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
