### PR TITLE
[Impeller] Add anonymous contents

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1115,6 +1115,8 @@ ORIGIN: ../../../flutter/impeller/display_list/display_list_vertices_geometry.cc
 ORIGIN: ../../../flutter/impeller/display_list/display_list_vertices_geometry.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/display_list/nine_patch_converter.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/display_list/nine_patch_converter.h + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/impeller/entity/contents/anonymous_contents.cc + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/impeller/entity/contents/anonymous_contents.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/entity/contents/atlas_contents.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/entity/contents/atlas_contents.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/entity/contents/clip_contents.cc + ../../../flutter/LICENSE
@@ -3648,6 +3650,8 @@ FILE: ../../../flutter/impeller/display_list/display_list_vertices_geometry.cc
 FILE: ../../../flutter/impeller/display_list/display_list_vertices_geometry.h
 FILE: ../../../flutter/impeller/display_list/nine_patch_converter.cc
 FILE: ../../../flutter/impeller/display_list/nine_patch_converter.h
+FILE: ../../../flutter/impeller/entity/contents/anonymous_contents.cc
+FILE: ../../../flutter/impeller/entity/contents/anonymous_contents.h
 FILE: ../../../flutter/impeller/entity/contents/atlas_contents.cc
 FILE: ../../../flutter/impeller/entity/contents/atlas_contents.h
 FILE: ../../../flutter/impeller/entity/contents/clip_contents.cc

--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -485,7 +485,7 @@ void Canvas::DrawVertices(const std::shared_ptr<VerticesGeometry>& vertices,
     // the src contents should be. If neither has a value we fall back
     // to using the geometry coverage data.
     Rect src_coverage;
-    auto size = src_contents->ColorSourceSize();
+    auto size = src_contents->GetColorSourceSize();
     if (size.has_value()) {
       src_coverage = Rect::MakeXYWH(0, 0, size->width, size->height);
     } else {

--- a/impeller/aiks/paint_pass_delegate.cc
+++ b/impeller/aiks/paint_pass_delegate.cc
@@ -114,7 +114,7 @@ bool OpacityPeepholePassDelegate::CanCollapseIntoParentPass(
   }
   auto alpha = paint_.color.alpha;
   entity_pass->IterateUntilSubpass([&alpha](Entity& entity) {
-    entity.GetContents()->InheritOpacity(alpha);
+    entity.GetContents()->SetInheritedOpacity(alpha);
     return true;
   });
   return true;

--- a/impeller/entity/BUILD.gn
+++ b/impeller/entity/BUILD.gn
@@ -128,6 +128,8 @@ impeller_shaders("framebuffer_blend_entity_shaders") {
 
 impeller_component("entity") {
   sources = [
+    "contents/anonymous_contents.cc",
+    "contents/anonymous_contents.h",
     "contents/atlas_contents.cc",
     "contents/atlas_contents.h",
     "contents/clip_contents.cc",

--- a/impeller/entity/contents/anonymous_contents.cc
+++ b/impeller/entity/contents/anonymous_contents.cc
@@ -1,0 +1,34 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/entity/contents/anonymous_contents.h"
+
+#include <memory>
+
+namespace impeller {
+
+std::shared_ptr<Contents> AnonymousContents::Make(RenderProc render_proc,
+                                                  CoverageProc coverage_proc) {
+  return std::shared_ptr<Contents>(
+      new AnonymousContents(std::move(render_proc), std::move(coverage_proc)));
+}
+
+AnonymousContents::AnonymousContents(RenderProc render_proc,
+                                     CoverageProc coverage_proc)
+    : render_proc_(std::move(render_proc)),
+      coverage_proc_(std::move(coverage_proc)) {}
+
+AnonymousContents::~AnonymousContents() = default;
+
+bool AnonymousContents::Render(const ContentContext& renderer,
+                               const Entity& entity,
+                               RenderPass& pass) const {
+  return render_proc_(renderer, entity, pass);
+}
+
+std::optional<Rect> AnonymousContents::GetCoverage(const Entity& entity) const {
+  return coverage_proc_(entity);
+}
+
+}  // namespace impeller

--- a/impeller/entity/contents/anonymous_contents.h
+++ b/impeller/entity/contents/anonymous_contents.h
@@ -1,0 +1,45 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#pragma once
+
+#include <functional>
+#include <memory>
+
+#include "flutter/fml/macros.h"
+#include "impeller/entity/contents/contents.h"
+
+namespace impeller {
+
+ContentContextOptions OptionsFromPass(const RenderPass& pass);
+
+ContentContextOptions OptionsFromPassAndEntity(const RenderPass& pass,
+                                               const Entity& entity);
+
+class AnonymousContents final : public Contents {
+ public:
+  static std::shared_ptr<Contents> Make(RenderProc render_proc,
+                                        CoverageProc coverage_proc);
+
+  // |Contents|
+  ~AnonymousContents() override;
+
+  // |Contents|
+  bool Render(const ContentContext& renderer,
+              const Entity& entity,
+              RenderPass& pass) const override;
+
+  // |Contents|
+  std::optional<Rect> GetCoverage(const Entity& entity) const override;
+
+ private:
+  RenderProc render_proc_;
+  CoverageProc coverage_proc_;
+
+  AnonymousContents(RenderProc render_proc, CoverageProc coverage_proc);
+
+  FML_DISALLOW_COPY_AND_ASSIGN(AnonymousContents);
+};
+
+}  // namespace impeller

--- a/impeller/entity/contents/clip_contents.cc
+++ b/impeller/entity/contents/clip_contents.cc
@@ -74,7 +74,7 @@ bool ClipContents::CanAcceptOpacity(const Entity& entity) const {
   return true;
 }
 
-void ClipContents::InheritOpacity(Scalar opacity) {}
+void ClipContents::SetInheritedOpacity(Scalar opacity) {}
 
 bool ClipContents::Render(const ContentContext& renderer,
                           const Entity& entity,
@@ -176,7 +176,7 @@ bool ClipRestoreContents::CanAcceptOpacity(const Entity& entity) const {
   return true;
 }
 
-void ClipRestoreContents::InheritOpacity(Scalar opacity) {}
+void ClipRestoreContents::SetInheritedOpacity(Scalar opacity) {}
 
 bool ClipRestoreContents::Render(const ContentContext& renderer,
                                  const Entity& entity,

--- a/impeller/entity/contents/clip_contents.h
+++ b/impeller/entity/contents/clip_contents.h
@@ -45,7 +45,7 @@ class ClipContents final : public Contents {
   bool CanAcceptOpacity(const Entity& entity) const override;
 
   // |Contents|
-  void InheritOpacity(Scalar opacity) override;
+  void SetInheritedOpacity(Scalar opacity) override;
 
  private:
   std::unique_ptr<Geometry> geometry_;
@@ -87,7 +87,7 @@ class ClipRestoreContents final : public Contents {
   bool CanAcceptOpacity(const Entity& entity) const override;
 
   // |Contents|
-  void InheritOpacity(Scalar opacity) override;
+  void SetInheritedOpacity(Scalar opacity) override;
 
  private:
   std::optional<Rect> restore_coverage_;

--- a/impeller/entity/contents/color_source_contents.cc
+++ b/impeller/entity/contents/color_source_contents.cc
@@ -46,7 +46,7 @@ bool ColorSourceContents::CanAcceptOpacity(const Entity& entity) const {
   return true;
 }
 
-void ColorSourceContents::InheritOpacity(Scalar opacity) {
+void ColorSourceContents::SetInheritedOpacity(Scalar opacity) {
   SetAlpha(GetAlpha() * opacity);
 }
 

--- a/impeller/entity/contents/color_source_contents.h
+++ b/impeller/entity/contents/color_source_contents.h
@@ -37,7 +37,7 @@ class ColorSourceContents : public Contents {
   bool CanAcceptOpacity(const Entity& entity) const override;
 
   // | Contents|
-  void InheritOpacity(Scalar opacity) override;
+  void SetInheritedOpacity(Scalar opacity) override;
 
   Scalar GetAlpha() const;
 

--- a/impeller/entity/contents/contents.cc
+++ b/impeller/entity/contents/contents.cc
@@ -46,30 +46,6 @@ std::shared_ptr<Contents> Contents::MakeAnonymous(
                                  std::move(coverage_proc));
 }
 
-std::optional<Entity> Contents::EntityFromSnapshot(
-    const std::optional<Snapshot>& snapshot,
-    BlendMode blend_mode,
-    uint32_t stencil_depth) {
-  if (!snapshot.has_value()) {
-    return std::nullopt;
-  }
-
-  auto texture_rect = Rect::MakeSize(snapshot->texture->GetSize());
-
-  auto contents = TextureContents::MakeRect(texture_rect);
-  contents->SetTexture(snapshot->texture);
-  contents->SetSamplerDescriptor(snapshot->sampler_descriptor);
-  contents->SetSourceRect(texture_rect);
-  contents->SetOpacity(snapshot->opacity);
-
-  Entity entity;
-  entity.SetBlendMode(blend_mode);
-  entity.SetStencilDepth(stencil_depth);
-  entity.SetTransformation(snapshot->transform);
-  entity.SetContents(contents);
-  return entity;
-}
-
 Contents::Contents() = default;
 
 Contents::~Contents() = default;

--- a/impeller/entity/contents/contents.h
+++ b/impeller/entity/contents/contents.h
@@ -30,22 +30,30 @@ ContentContextOptions OptionsFromPassAndEntity(const RenderPass& pass,
 
 class Contents {
  public:
-  Contents();
-
-  virtual ~Contents();
-
   struct StencilCoverage {
-    enum class Type { kNone, kAppend, kRestore };
+    enum class Type { kNoChange, kAppend, kRestore };
 
-    Type type = Type::kNone;
+    Type type = Type::kNoChange;
     std::optional<Rect> coverage = std::nullopt;
   };
+
+  using RenderProc = std::function<bool(const ContentContext& renderer,
+                                        const Entity& entity,
+                                        RenderPass& pass)>;
+  using CoverageProc = std::function<std::optional<Rect>(const Entity& entity)>;
+
+  static std::shared_ptr<Contents> MakeAnonymous(RenderProc render_proc,
+                                                 CoverageProc coverage_proc);
 
   /// @brief  Create an entity that renders a given snapshot.
   static std::optional<Entity> EntityFromSnapshot(
       const std::optional<Snapshot>& snapshot,
       BlendMode blend_mode = BlendMode::kSourceOver,
       uint32_t stencil_depth = 0);
+
+  Contents();
+
+  virtual ~Contents();
 
   virtual bool Render(const ContentContext& renderer,
                       const Entity& entity,
@@ -77,11 +85,12 @@ class Contents {
 
   /// @brief  Return the color source's intrinsic size, if available.
   ///
-  /// For example, a gradient has a size based on its end and beginning points,
-  /// ignoring any tiling. Solid colors and runtime effects have no size.
-  std::optional<Size> ColorSourceSize() const { return color_source_size_; }
+  ///         For example, a gradient has a size based on its end and beginning
+  ///         points, ignoring any tiling. Solid colors and runtime effects have
+  ///         no size.
+  std::optional<Size> GetColorSourceSize() const;
 
-  void SetColorSourceSize(Size size) { color_source_size_ = size; }
+  void SetColorSourceSize(Size size);
 
   /// @brief Whether or not this contents can accept the opacity peephole
   ///        optimization.
@@ -94,9 +103,9 @@ class Contents {
   virtual bool CanAcceptOpacity(const Entity& entity) const;
 
   /// @brief Inherit the provided opacity.
-  virtual void InheritOpacity(Scalar opacity);
-
- protected:
+  ///
+  ///        Use of this method is invalid if CanAcceptOpacity returns false.
+  virtual void SetInheritedOpacity(Scalar opacity);
 
  private:
   std::optional<Size> color_source_size_;

--- a/impeller/entity/contents/contents.h
+++ b/impeller/entity/contents/contents.h
@@ -45,12 +45,6 @@ class Contents {
   static std::shared_ptr<Contents> MakeAnonymous(RenderProc render_proc,
                                                  CoverageProc coverage_proc);
 
-  /// @brief  Create an entity that renders a given snapshot.
-  static std::optional<Entity> EntityFromSnapshot(
-      const std::optional<Snapshot>& snapshot,
-      BlendMode blend_mode = BlendMode::kSourceOver,
-      uint32_t stencil_depth = 0);
-
   Contents();
 
   virtual ~Contents();

--- a/impeller/entity/contents/filters/blend_filter_contents.cc
+++ b/impeller/entity/contents/filters/blend_filter_contents.cc
@@ -71,16 +71,16 @@ static std::optional<Entity> AdvancedBlend(
       if (!dst_snapshot.has_value()) {
         return std::nullopt;
       }
-      return Contents::EntityFromSnapshot(dst_snapshot, entity.GetBlendMode(),
-                                          entity.GetStencilDepth());
+      return Entity::FromSnapshot(dst_snapshot, entity.GetBlendMode(),
+                                  entity.GetStencilDepth());
     }
     auto maybe_src_uvs = src_snapshot->GetCoverageUVs(coverage);
     if (!maybe_src_uvs.has_value()) {
       if (!dst_snapshot.has_value()) {
         return std::nullopt;
       }
-      return Contents::EntityFromSnapshot(dst_snapshot, entity.GetBlendMode(),
-                                          entity.GetStencilDepth());
+      return Entity::FromSnapshot(dst_snapshot, entity.GetBlendMode(),
+                                  entity.GetStencilDepth());
     }
     src_uvs = maybe_src_uvs.value();
   }
@@ -156,7 +156,7 @@ static std::optional<Entity> AdvancedBlend(
     return std::nullopt;
   }
 
-  return Contents::EntityFromSnapshot(
+  return Entity::FromSnapshot(
       Snapshot{.texture = out_texture,
                .transform = Matrix::MakeTranslation(coverage.origin),
                // Since we absorbed the transform of the inputs and used the
@@ -280,7 +280,7 @@ static std::optional<Entity> PipelineBlend(
     return std::nullopt;
   }
 
-  return Contents::EntityFromSnapshot(
+  return Entity::FromSnapshot(
       Snapshot{.texture = out_texture,
                .transform = Matrix::MakeTranslation(coverage.origin),
                // Since we absorbed the transform of the inputs and used the

--- a/impeller/entity/contents/filters/border_mask_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/border_mask_blur_filter_contents.cc
@@ -128,7 +128,7 @@ std::optional<Entity> BorderMaskBlurFilterContents::RenderFilter(
     return std::nullopt;
   }
 
-  return Contents::EntityFromSnapshot(
+  return Entity::FromSnapshot(
       Snapshot{.texture = out_texture,
                .transform = Matrix::MakeTranslation(coverage.origin),
                .opacity = input_snapshot->opacity},

--- a/impeller/entity/contents/filters/color_matrix_filter_contents.cc
+++ b/impeller/entity/contents/filters/color_matrix_filter_contents.cc
@@ -103,7 +103,7 @@ std::optional<Entity> ColorMatrixFilterContents::RenderFilter(
     return std::nullopt;
   }
 
-  return Contents::EntityFromSnapshot(
+  return Entity::FromSnapshot(
       Snapshot{.texture = out_texture,
                .transform = input_snapshot->transform,
                .sampler_descriptor = input_snapshot->sampler_descriptor,

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -106,7 +106,7 @@ std::optional<Entity> DirectionalGaussianBlurFilterContents::RenderFilter(
   }
 
   if (blur_sigma_.sigma < kEhCloseEnough) {
-    return Contents::EntityFromSnapshot(
+    return Entity::FromSnapshot(
         input_snapshot.value(), entity.GetBlendMode(),
         entity.GetStencilDepth());  // No blur to render.
   }
@@ -122,7 +122,7 @@ std::optional<Entity> DirectionalGaussianBlurFilterContents::RenderFilter(
   // If the radius length is < .5, the shader will take at most 1 sample,
   // resulting in no blur.
   if (transformed_blur_radius_length < .5) {
-    return Contents::EntityFromSnapshot(
+    return Entity::FromSnapshot(
         input_snapshot.value(), entity.GetBlendMode(),
         entity.GetStencilDepth());  // No blur to render.
   }
@@ -287,7 +287,7 @@ std::optional<Entity> DirectionalGaussianBlurFilterContents::RenderFilter(
   sampler_desc.min_filter = MinMagFilter::kLinear;
   sampler_desc.mag_filter = MinMagFilter::kLinear;
 
-  return Contents::EntityFromSnapshot(
+  return Entity::FromSnapshot(
       Snapshot{.texture = out_texture,
                .transform = texture_rotate.Invert() *
                             Matrix::MakeTranslation(pass_texture_rect.origin) *

--- a/impeller/entity/contents/filters/linear_to_srgb_filter_contents.cc
+++ b/impeller/entity/contents/filters/linear_to_srgb_filter_contents.cc
@@ -80,7 +80,7 @@ std::optional<Entity> LinearToSrgbFilterContents::RenderFilter(
     return std::nullopt;
   }
 
-  return Contents::EntityFromSnapshot(
+  return Entity::FromSnapshot(
       Snapshot{.texture = out_texture,
                .transform = input_snapshot->transform,
                .sampler_descriptor = input_snapshot->sampler_descriptor,

--- a/impeller/entity/contents/filters/local_matrix_filter_contents.cc
+++ b/impeller/entity/contents/filters/local_matrix_filter_contents.cc
@@ -25,9 +25,8 @@ std::optional<Entity> LocalMatrixFilterContents::RenderFilter(
     const Entity& entity,
     const Matrix& effect_transform,
     const Rect& coverage) const {
-  return Contents::EntityFromSnapshot(inputs[0]->GetSnapshot(renderer, entity),
-                                      entity.GetBlendMode(),
-                                      entity.GetStencilDepth());
+  return Entity::FromSnapshot(inputs[0]->GetSnapshot(renderer, entity),
+                              entity.GetBlendMode(), entity.GetStencilDepth());
 }
 
 }  // namespace impeller

--- a/impeller/entity/contents/filters/matrix_filter_contents.cc
+++ b/impeller/entity/contents/filters/matrix_filter_contents.cc
@@ -39,8 +39,8 @@ std::optional<Entity> MatrixFilterContents::RenderFilter(
                         transform.Invert() *  //
                         snapshot->transform;
   snapshot->sampler_descriptor = sampler_descriptor_;
-  return Contents::EntityFromSnapshot(snapshot, entity.GetBlendMode(),
-                                      entity.GetStencilDepth());
+  return Entity::FromSnapshot(snapshot, entity.GetBlendMode(),
+                              entity.GetStencilDepth());
 }
 
 std::optional<Rect> MatrixFilterContents::GetFilterCoverage(

--- a/impeller/entity/contents/filters/morphology_filter_contents.cc
+++ b/impeller/entity/contents/filters/morphology_filter_contents.cc
@@ -57,9 +57,8 @@ std::optional<Entity> DirectionalMorphologyFilterContents::RenderFilter(
   }
 
   if (radius_.radius < kEhCloseEnough) {
-    return Contents::EntityFromSnapshot(input_snapshot.value(),
-                                        entity.GetBlendMode(),
-                                        entity.GetStencilDepth());
+    return Entity::FromSnapshot(input_snapshot.value(), entity.GetBlendMode(),
+                                entity.GetStencilDepth());
   }
 
   auto maybe_input_uvs = input_snapshot->GetCoverageUVs(coverage);
@@ -142,7 +141,7 @@ std::optional<Entity> DirectionalMorphologyFilterContents::RenderFilter(
   sampler_desc.min_filter = MinMagFilter::kLinear;
   sampler_desc.mag_filter = MinMagFilter::kLinear;
 
-  return Contents::EntityFromSnapshot(
+  return Entity::FromSnapshot(
       Snapshot{.texture = out_texture,
                .transform = Matrix::MakeTranslation(coverage.origin),
                .sampler_descriptor = sampler_desc,

--- a/impeller/entity/contents/filters/srgb_to_linear_filter_contents.cc
+++ b/impeller/entity/contents/filters/srgb_to_linear_filter_contents.cc
@@ -80,7 +80,7 @@ std::optional<Entity> SrgbToLinearFilterContents::RenderFilter(
     return std::nullopt;
   }
 
-  return Contents::EntityFromSnapshot(
+  return Entity::FromSnapshot(
       Snapshot{.texture = out_texture,
                .transform = input_snapshot->transform,
                .sampler_descriptor = input_snapshot->sampler_descriptor,

--- a/impeller/entity/contents/filters/yuv_to_rgb_filter_contents.cc
+++ b/impeller/entity/contents/filters/yuv_to_rgb_filter_contents.cc
@@ -117,9 +117,8 @@ std::optional<Entity> YUVToRGBFilterContents::RenderFilter(
     return std::nullopt;
   }
 
-  return Contents::EntityFromSnapshot(Snapshot{.texture = out_texture},
-                                      entity.GetBlendMode(),
-                                      entity.GetStencilDepth());
+  return Entity::FromSnapshot(Snapshot{.texture = out_texture},
+                              entity.GetBlendMode(), entity.GetStencilDepth());
 }
 
 }  // namespace impeller

--- a/impeller/entity/contents/solid_color_contents.cc
+++ b/impeller/entity/contents/solid_color_contents.cc
@@ -34,7 +34,7 @@ bool SolidColorContents::CanAcceptOpacity(const Entity& entity) const {
 }
 
 // | Contents|
-void SolidColorContents::InheritOpacity(Scalar opacity) {
+void SolidColorContents::SetInheritedOpacity(Scalar opacity) {
   auto color = color_;
   color_ = color.WithAlpha(color.alpha * opacity);
 }

--- a/impeller/entity/contents/solid_color_contents.h
+++ b/impeller/entity/contents/solid_color_contents.h
@@ -39,7 +39,7 @@ class SolidColorContents final : public Contents {
   bool CanAcceptOpacity(const Entity& entity) const override;
 
   // | Contents|
-  void InheritOpacity(Scalar opacity) override;
+  void SetInheritedOpacity(Scalar opacity) override;
 
   // |Contents|
   std::optional<Rect> GetCoverage(const Entity& entity) const override;

--- a/impeller/entity/contents/text_contents.cc
+++ b/impeller/entity/contents/text_contents.cc
@@ -58,7 +58,7 @@ bool TextContents::CanAcceptOpacity(const Entity& entity) const {
   return !frame_.MaybeHasOverlapping();
 }
 
-void TextContents::InheritOpacity(Scalar opacity) {
+void TextContents::SetInheritedOpacity(Scalar opacity) {
   auto color = color_;
   color_ = color.WithAlpha(color.alpha * opacity);
 }

--- a/impeller/entity/contents/text_contents.h
+++ b/impeller/entity/contents/text_contents.h
@@ -36,7 +36,7 @@ class TextContents final : public Contents {
 
   bool CanAcceptOpacity(const Entity& entity) const override;
 
-  void InheritOpacity(Scalar opacity) override;
+  void SetInheritedOpacity(Scalar opacity) override;
 
   void SetInverseMatrix(Matrix matrix);
 

--- a/impeller/entity/contents/texture_contents.cc
+++ b/impeller/entity/contents/texture_contents.cc
@@ -61,7 +61,7 @@ bool TextureContents::CanAcceptOpacity(const Entity& entity) const {
   return true;
 }
 
-void TextureContents::InheritOpacity(Scalar opacity) {
+void TextureContents::SetInheritedOpacity(Scalar opacity) {
   opacity_ = opacity_ * opacity;
 }
 

--- a/impeller/entity/contents/texture_contents.h
+++ b/impeller/entity/contents/texture_contents.h
@@ -69,7 +69,7 @@ class TextureContents final : public Contents {
   bool CanAcceptOpacity(const Entity& entity) const override;
 
   // |Contents|
-  void InheritOpacity(Scalar opacity) override;
+  void SetInheritedOpacity(Scalar opacity) override;
 
   void SetDeferApplyingOpacity(bool defer_applying_opacity);
 

--- a/impeller/entity/entity.cc
+++ b/impeller/entity/entity.cc
@@ -76,7 +76,14 @@ BlendMode Entity::GetBlendMode() const {
   return blend_mode_;
 }
 
-bool Entity::BlendModeShouldCoverWholeScreen(BlendMode blend_mode) {
+/// @brief  Returns true if the blend mode is "destrictive", meaning that even
+///         fully transparent source colors would result in the destination
+///         getting changed.
+///
+///         This is useful for determining if EntityPass textures can be
+///         shrinkwrapped to their Entities' coverage; they can be shrinkwrapped
+///         if all of the contained Entities have non-destructive blends.
+bool Entity::IsBlendModeDestructive(BlendMode blend_mode) {
   switch (blend_mode) {
     case BlendMode::kClear:
     case BlendMode::kSource:

--- a/impeller/entity/entity.cc
+++ b/impeller/entity/entity.cc
@@ -10,11 +10,36 @@
 #include "impeller/base/validation.h"
 #include "impeller/entity/contents/content_context.h"
 #include "impeller/entity/contents/filters/filter_contents.h"
+#include "impeller/entity/contents/texture_contents.h"
 #include "impeller/entity/entity_pass.h"
 #include "impeller/geometry/vector.h"
 #include "impeller/renderer/render_pass.h"
 
 namespace impeller {
+
+std::optional<Entity> Entity::FromSnapshot(
+    const std::optional<Snapshot>& snapshot,
+    BlendMode blend_mode,
+    uint32_t stencil_depth) {
+  if (!snapshot.has_value()) {
+    return std::nullopt;
+  }
+
+  auto texture_rect = Rect::MakeSize(snapshot->texture->GetSize());
+
+  auto contents = TextureContents::MakeRect(texture_rect);
+  contents->SetTexture(snapshot->texture);
+  contents->SetSamplerDescriptor(snapshot->sampler_descriptor);
+  contents->SetSourceRect(texture_rect);
+  contents->SetOpacity(snapshot->opacity);
+
+  Entity entity;
+  entity.SetBlendMode(blend_mode);
+  entity.SetStencilDepth(stencil_depth);
+  entity.SetTransformation(snapshot->transform);
+  entity.SetContents(contents);
+  return entity;
+}
 
 Entity::Entity() = default;
 

--- a/impeller/entity/entity.h
+++ b/impeller/entity/entity.h
@@ -49,6 +49,12 @@ class Entity {
     kIntersect,
   };
 
+  /// @brief  Create an entity that can be used to render a given snapshot.
+  static std::optional<Entity> FromSnapshot(
+      const std::optional<Snapshot>& snapshot,
+      BlendMode blend_mode = BlendMode::kSourceOver,
+      uint32_t stencil_depth = 0);
+
   Entity();
 
   ~Entity();

--- a/impeller/entity/entity.h
+++ b/impeller/entity/entity.h
@@ -80,7 +80,7 @@ class Entity {
 
   bool Render(const ContentContext& renderer, RenderPass& parent_pass) const;
 
-  static bool BlendModeShouldCoverWholeScreen(BlendMode blend_mode);
+  static bool IsBlendModeDestructive(BlendMode blend_mode);
 
  private:
   Matrix transformation_;

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -457,7 +457,7 @@ bool EntityPass::OnRender(ContentContext& renderer,
         element_entity.GetStencilCoverage(stencil_stack.back().coverage);
 
     switch (stencil_coverage.type) {
-      case Contents::StencilCoverage::Type::kNone:
+      case Contents::StencilCoverage::Type::kNoChange:
         break;
       case Contents::StencilCoverage::Type::kAppend: {
         auto op = stencil_stack.back().coverage;
@@ -671,7 +671,7 @@ void EntityPass::SetStencilDepth(size_t stencil_depth) {
 
 void EntityPass::SetBlendMode(BlendMode blend_mode) {
   blend_mode_ = blend_mode;
-  cover_whole_screen_ = Entity::BlendModeShouldCoverWholeScreen(blend_mode);
+  cover_whole_screen_ = Entity::IsBlendModeDestructive(blend_mode);
 }
 
 void EntityPass::SetBackdropFilter(std::optional<BackdropFilterProc> proc) {

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -2389,7 +2389,7 @@ TEST_P(EntityTest, InheritOpacityTest) {
   texture_contents->SetOpacity(0.5);
   ASSERT_TRUE(texture_contents->CanAcceptOpacity(entity));
 
-  texture_contents->InheritOpacity(0.5);
+  texture_contents->SetInheritedOpacity(0.5);
   ASSERT_EQ(texture_contents->GetOpacity(), 0.25);
 
   // Solid color contents can accept opacity if their geometry
@@ -2401,7 +2401,7 @@ TEST_P(EntityTest, InheritOpacityTest) {
 
   ASSERT_TRUE(solid_color->CanAcceptOpacity(entity));
 
-  solid_color->InheritOpacity(0.5);
+  solid_color->SetInheritedOpacity(0.5);
   ASSERT_EQ(solid_color->GetColor().alpha, 0.25);
 
   // Color source contents can accept opacity if their geometry
@@ -2413,7 +2413,7 @@ TEST_P(EntityTest, InheritOpacityTest) {
 
   ASSERT_TRUE(tiled_texture->CanAcceptOpacity(entity));
 
-  tiled_texture->InheritOpacity(0.5);
+  tiled_texture->SetInheritedOpacity(0.5);
   ASSERT_EQ(tiled_texture->GetAlpha(), 0.25);
 
   // Text contents can accept opacity if the text frames do not
@@ -2431,7 +2431,7 @@ TEST_P(EntityTest, InheritOpacityTest) {
 
   ASSERT_TRUE(text_contents->CanAcceptOpacity(entity));
 
-  text_contents->InheritOpacity(0.5);
+  text_contents->SetInheritedOpacity(0.5);
   ASSERT_EQ(text_contents->GetColor().alpha, 0.25);
 
   // Clips and restores trivially accept opacity.


### PR DESCRIPTION
This makes it easy for filters and friends to return the subpass callbacks as deferred contents. Also did some drive by cleanup of the Contents interface.