### PR TITLE
add final class modifiers to fix dart roll

### DIFF
--- a/impeller/tessellator/dart/lib/tessellator.dart
+++ b/impeller/tessellator/dart/lib/tessellator.dart
@@ -145,14 +145,14 @@ final ffi.DynamicLibrary _dylib = () {
   throw UnsupportedError('Unknown platform: ${Platform.operatingSystem}');
 }();
 
-class _Vertices extends ffi.Struct {
+final class _Vertices extends ffi.Struct {
   external ffi.Pointer<ffi.Float> points;
 
   @ffi.Uint32()
   external int size;
 }
 
-class _PathBuilder extends ffi.Opaque {}
+final class _PathBuilder extends ffi.Opaque {}
 
 typedef _CreatePathBuilderType = ffi.Pointer<_PathBuilder> Function();
 typedef _create_path_builder_type = ffi.Pointer<_PathBuilder> Function();

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_canvas.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_canvas.dart
@@ -9,7 +9,7 @@ import 'dart:ffi';
 
 import 'package:ui/src/engine/skwasm/skwasm_impl.dart';
 
-class CanvasWrapper extends Opaque {}
+final class CanvasWrapper extends Opaque {}
 
 typedef CanvasHandle = Pointer<CanvasWrapper>;
 

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_memory.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_memory.dart
@@ -11,7 +11,7 @@ import 'dart:typed_data';
 
 import 'package:ui/ui.dart' as ui;
 
-class Stack extends Opaque {}
+final class Stack extends Opaque {}
 typedef StackPointer = Pointer<Stack>;
 
 /// Generic linear memory allocation

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_paint.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_paint.dart
@@ -7,7 +7,7 @@ library skwasm_impl;
 
 import 'dart:ffi';
 
-class RawPaint extends Opaque {}
+final class RawPaint extends Opaque {}
 
 typedef PaintHandle = Pointer<RawPaint>;
 

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_path.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_path.dart
@@ -9,7 +9,7 @@ import 'dart:ffi';
 
 import 'package:ui/src/engine/skwasm/skwasm_impl.dart';
 
-class RawPath extends Opaque {}
+final class RawPath extends Opaque {}
 
 typedef PathHandle = Pointer<RawPath>;
 

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_path_metrics.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_path_metrics.dart
@@ -9,9 +9,9 @@ import 'dart:ffi';
 
 import 'package:ui/src/engine/skwasm/skwasm_impl.dart';
 
-class RawContourMeasure extends Opaque {}
+final class RawContourMeasure extends Opaque {}
 
-class RawContourMeasureIter extends Opaque {}
+final class RawContourMeasureIter extends Opaque {}
 
 typedef ContourMeasureHandle = Pointer<RawContourMeasure>;
 typedef ContourMeasureIterHandle = Pointer<RawContourMeasureIter>;

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_picture.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_picture.dart
@@ -9,10 +9,10 @@ import 'dart:ffi';
 
 import 'package:ui/src/engine/skwasm/skwasm_impl.dart';
 
-class RawPictureRecorder extends Opaque {}
+final class RawPictureRecorder extends Opaque {}
 typedef PictureRecorderHandle = Pointer<RawPictureRecorder>;
 
-class RawPicture extends Opaque {}
+final class RawPicture extends Opaque {}
 typedef PictureHandle = Pointer<RawPicture>;
 
 @Native<PictureRecorderHandle Function()>(

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_surface.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_surface.dart
@@ -8,7 +8,7 @@ library skwasm_impl;
 import 'dart:ffi';
 import 'package:ui/src/engine/skwasm/skwasm_impl.dart';
 
-class RawSurface extends Opaque {}
+final class RawSurface extends Opaque {}
 typedef SurfaceHandle = Pointer<RawSurface>;
 
 @Native<SurfaceHandle Function(Pointer<Int8>)>(

--- a/shell/platform/fuchsia/dart-pkg/zircon_ffi/lib/zircon_ffi.dart
+++ b/shell/platform/fuchsia/dart-pkg/zircon_ffi/lib/zircon_ffi.dart
@@ -256,32 +256,32 @@ class ZirconFFIBindings {
           .asFunction<_dart_zircon_dart_dl_initialize>();
 }
 
-class zircon_dart_byte_array_t extends ffi.Struct {
+final class zircon_dart_byte_array_t extends ffi.Struct {
   external ffi.Pointer<ffi.Uint8> data;
 
   @ffi.Uint32()
   external int length;
 }
 
-class zircon_dart_handle_t extends ffi.Struct {
+final class zircon_dart_handle_t extends ffi.Struct {
   @ffi.Uint32()
   external int handle;
 }
 
-class zircon_dart_handle_pair_t extends ffi.Struct {
+final class zircon_dart_handle_pair_t extends ffi.Struct {
   external ffi.Pointer<zircon_dart_handle_t> left;
 
   external ffi.Pointer<zircon_dart_handle_t> right;
 }
 
-class zircon_dart_handle_list_t extends ffi.Struct {
+final class zircon_dart_handle_list_t extends ffi.Struct {
   external ffi.Pointer<ffi.Void> data;
 
   @ffi.Uint32()
   external int size;
 }
 
-class _Dart_Handle extends ffi.Opaque {}
+final class _Dart_Handle extends ffi.Opaque {}
 
 typedef _c_zircon_dart_byte_array_create = ffi.Pointer<zircon_dart_byte_array_t>
     Function(

--- a/tools/path_ops/dart/lib/path_ops.dart
+++ b/tools/path_ops/dart/lib/path_ops.dart
@@ -309,9 +309,9 @@ final ffi.DynamicLibrary _dylib = () {
   throw UnsupportedError('Unknown platform: ${Platform.operatingSystem}');
 }();
 
-class _SkPath extends ffi.Opaque {}
+final class _SkPath extends ffi.Opaque {}
 
-class _PathData extends ffi.Struct {
+final class _PathData extends ffi.Struct {
   external ffi.Pointer<ffi.Uint8> verbs;
 
   @ffi.Size()


### PR DESCRIPTION
Following the lead of https://github.com/dart-lang/sdk/commit/1755f8909264330a207a0e0e44d31f5fec9c489a, this adds the `final` class modifier to all subclasses of `Struct`, `Union`, `Opaque`, and `AbiSpecificInteger` to unblock the dart roll (https://github.com/flutter/engine/pull/40426).