### PR TITLE
[Impeller] Load instead of restore drawing for non-MSAA passes

### DIFF
--- a/impeller/entity/inline_pass_context.cc
+++ b/impeller/entity/inline_pass_context.cc
@@ -100,7 +100,10 @@ InlinePassContext::RenderPassResult InlinePassContext::GetRenderPass(
 
   RenderPassResult result;
 
-  if (pass_count_ > 0) {
+  if (pass_count_ > 0 && pass_target_.GetRenderTarget()
+                             .GetColorAttachments()
+                             .find(0)
+                             ->second.resolve_texture) {
     result.backdrop_texture =
         pass_target_.Flip(*context_->GetResourceAllocator());
     if (!result.backdrop_texture) {
@@ -111,8 +114,12 @@ InlinePassContext::RenderPassResult InlinePassContext::GetRenderPass(
   auto color0 =
       pass_target_.GetRenderTarget().GetColorAttachments().find(0)->second;
 
-  color0.load_action =
-      pass_count_ > 0 ? LoadAction::kDontCare : LoadAction::kClear;
+  if (pass_count_ > 0) {
+    color0.load_action =
+        color0.resolve_texture ? LoadAction::kDontCare : LoadAction::kLoad;
+  } else {
+    color0.load_action = LoadAction::kClear;
+  }
 
   color0.store_action = color0.resolve_texture
                             ? StoreAction::kMultisampleResolve

--- a/impeller/entity/inline_pass_context.h
+++ b/impeller/entity/inline_pass_context.h
@@ -15,6 +15,7 @@ class InlinePassContext {
  public:
   struct RenderPassResult {
     std::shared_ptr<RenderPass> pass;
+
     std::shared_ptr<Texture> backdrop_texture;
   };
 


### PR DESCRIPTION
Fixes the `Play/AiksTest.CanRenderClippedLayers/OpenGLES` playground and removes unnecessary restore work when MSAA isn't being used.