### PR TITLE
[web] Turn on CanvasKit Chromium

### DIFF
--- a/lib/web_ui/dev/test_platform.dart
+++ b/lib/web_ui/dev/test_platform.dart
@@ -512,7 +512,10 @@ class BrowserPlatform extends PlatformPlugin {
           <meta name="assetBase" content="/">
           <script>
             window.flutterConfiguration = {
-              canvasKitBaseUrl: "/canvaskit/"
+              canvasKitBaseUrl: "/canvaskit/",
+              // TODO(eyebrowsoffire): Put the actual variant to be used.
+              // https://github.com/flutter/engine/pull/39984
+              canvasKitVariant: "full",
             };
           </script>
           $link

--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -28,10 +28,7 @@ import 'renderer.dart';
 /// Entrypoint into the CanvasKit API.
 late CanvasKit canvasKit;
 
-// TODO(mdebbar): Turn this on when CanvasKit Chromium is ready.
-// Set it to `browserSupportsCanvasKitChromium`.
-// https://github.com/flutter/flutter/issues/122329
-const bool _enableCanvasKitChromiumInAutoMode = false;
+bool get _enableCanvasKitChromiumInAutoMode => browserSupportsCanvaskitChromium;
 
 /// Sets the [CanvasKit] object on `window` so we can use `@JS()` to bind to
 /// static APIs.
@@ -2699,7 +2696,9 @@ const String _kFullCanvasKitJsFileName = 'canvaskit.js';
 const String _kChromiumCanvasKitJsFileName = 'chromium/canvaskit.js';
 
 String get _canvasKitBaseUrl => configuration.canvasKitBaseUrl;
-List<String> get _canvasKitJsFileNames {
+
+@visibleForTesting
+List<String> get canvasKitJsFileNames {
   switch (configuration.canvasKitVariant) {
     case CanvasKitVariant.auto:
       return <String>[
@@ -2713,7 +2712,7 @@ List<String> get _canvasKitJsFileNames {
   }
 }
 Iterable<String> get _canvasKitJsUrls {
-  return _canvasKitJsFileNames.map((String filename) => '$_canvasKitBaseUrl$filename');
+  return canvasKitJsFileNames.map((String filename) => '$_canvasKitBaseUrl$filename');
 }
 @visibleForTesting
 String canvasKitWasmModuleUrl(String file, String canvasKitBase) =>

--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -2698,8 +2698,8 @@ const String _kChromiumCanvasKitJsFileName = 'chromium/canvaskit.js';
 String get _canvasKitBaseUrl => configuration.canvasKitBaseUrl;
 
 @visibleForTesting
-List<String> get canvasKitJsFileNames {
-  switch (configuration.canvasKitVariant) {
+List<String> getCanvasKitJsFileNames(CanvasKitVariant variant) {
+  switch (variant) {
     case CanvasKitVariant.auto:
       return <String>[
         if (_enableCanvasKitChromiumInAutoMode) _kChromiumCanvasKitJsFileName,
@@ -2712,7 +2712,9 @@ List<String> get canvasKitJsFileNames {
   }
 }
 Iterable<String> get _canvasKitJsUrls {
-  return canvasKitJsFileNames.map((String filename) => '$_canvasKitBaseUrl$filename');
+  return getCanvasKitJsFileNames(configuration.canvasKitVariant).map(
+    (String filename) => '$_canvasKitBaseUrl$filename',
+  );
 }
 @visibleForTesting
 String canvasKitWasmModuleUrl(String file, String canvasKitBase) =>

--- a/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
+++ b/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
@@ -1835,7 +1835,7 @@ void _paragraphTests() {
     expect(surface, isNotNull);
   }, skip: isFirefox); // Intended: Headless firefox has no webgl support https://github.com/flutter/flutter/issues/109265
 
-  group('CanvasKit Chromium', () {
+  group('getCanvasKitJsFileNames', () {
     late dynamic oldV8BreakIterator = v8BreakIterator;
     setUp(() {
       oldV8BreakIterator = v8BreakIterator;
@@ -1845,28 +1845,36 @@ void _paragraphTests() {
       debugResetBrowserSupportsImageDecoder();
     });
 
-    test('is downloaded in Chromium-based browsers', () {
+    test('in Chromium-based browsers', () {
       v8BreakIterator = Object(); // Any non-null value.
       browserSupportsImageDecoder = true;
 
-      expect(canvasKitJsFileNames, <String>[
+      expect(getCanvasKitJsFileNames(CanvasKitVariant.full), <String>['canvaskit.js']);
+      expect(getCanvasKitJsFileNames(CanvasKitVariant.chromium), <String>['chromium/canvaskit.js']);
+      expect(getCanvasKitJsFileNames(CanvasKitVariant.auto), <String>[
         'chromium/canvaskit.js',
         'canvaskit.js',
       ]);
     });
 
-    test('is not downloaded in other browsers', () {
+    test('in other browsers', () {
       v8BreakIterator = null;
       browserSupportsImageDecoder = true;
-      expect(canvasKitJsFileNames, <String>['canvaskit.js']);
+      expect(getCanvasKitJsFileNames(CanvasKitVariant.full), <String>['canvaskit.js']);
+      expect(getCanvasKitJsFileNames(CanvasKitVariant.chromium), <String>['chromium/canvaskit.js']);
+      expect(getCanvasKitJsFileNames(CanvasKitVariant.auto), <String>['canvaskit.js']);
 
       v8BreakIterator = Object();
       browserSupportsImageDecoder = false;
-      expect(canvasKitJsFileNames, <String>['canvaskit.js']);
+      expect(getCanvasKitJsFileNames(CanvasKitVariant.full), <String>['canvaskit.js']);
+      expect(getCanvasKitJsFileNames(CanvasKitVariant.chromium), <String>['chromium/canvaskit.js']);
+      expect(getCanvasKitJsFileNames(CanvasKitVariant.auto), <String>['canvaskit.js']);
 
       v8BreakIterator = null;
       browserSupportsImageDecoder = false;
-      expect(canvasKitJsFileNames, <String>['canvaskit.js']);
+      expect(getCanvasKitJsFileNames(CanvasKitVariant.full), <String>['canvaskit.js']);
+      expect(getCanvasKitJsFileNames(CanvasKitVariant.chromium), <String>['chromium/canvaskit.js']);
+      expect(getCanvasKitJsFileNames(CanvasKitVariant.auto), <String>['canvaskit.js']);
     });
   });
 

--- a/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
+++ b/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
@@ -5,6 +5,7 @@
 import 'dart:math';
 import 'dart:typed_data';
 
+import 'package:js/js.dart';
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 
@@ -1834,6 +1835,41 @@ void _paragraphTests() {
     expect(surface, isNotNull);
   }, skip: isFirefox); // Intended: Headless firefox has no webgl support https://github.com/flutter/flutter/issues/109265
 
+  group('CanvasKit Chromium', () {
+    late dynamic oldV8BreakIterator = v8BreakIterator;
+    setUp(() {
+      oldV8BreakIterator = v8BreakIterator;
+    });
+    tearDown(() {
+      v8BreakIterator = oldV8BreakIterator;
+      debugResetBrowserSupportsImageDecoder();
+    });
+
+    test('is downloaded in Chromium-based browsers', () {
+      v8BreakIterator = Object(); // Any non-null value.
+      browserSupportsImageDecoder = true;
+
+      expect(canvasKitJsFileNames, <String>[
+        'chromium/canvaskit.js',
+        'canvaskit.js',
+      ]);
+    });
+
+    test('is not downloaded in other browsers', () {
+      v8BreakIterator = null;
+      browserSupportsImageDecoder = true;
+      expect(canvasKitJsFileNames, <String>['canvaskit.js']);
+
+      v8BreakIterator = Object();
+      browserSupportsImageDecoder = false;
+      expect(canvasKitJsFileNames, <String>['canvaskit.js']);
+
+      v8BreakIterator = null;
+      browserSupportsImageDecoder = false;
+      expect(canvasKitJsFileNames, <String>['canvaskit.js']);
+    });
+  });
+
   test('respects actual location of canvaskit files', () {
     expect(
       canvasKitWasmModuleUrl('canvaskit.wasm', 'https://example.com/'),
@@ -1849,3 +1885,10 @@ void _paragraphTests() {
     );
   });
 }
+
+
+@JS('window.Intl.v8BreakIterator')
+external dynamic get v8BreakIterator;
+
+@JS('window.Intl.v8BreakIterator')
+external set v8BreakIterator(dynamic x);


### PR DESCRIPTION
This is the last bit to make CanvasKit Chromium available to our users by default.

Users can always opt-out by `canvasKitVariant: "full"` to their runtime configuration similar to [this](https://docs.flutter.dev/development/platform-integration/web/renderers#runtime-configuration).
```javascript
_flutter.loader.loadEntrypoint({
  onEntrypointLoaded: async function(engineInitializer) {
    let appRunner = await engineInitializer.initializeEngine({
      canvasKitVariant: "full",
    });

    await appRunner.runApp();
  }
});
```

Closes https://github.com/flutter/flutter/issues/122329