### PR TITLE
[Impeller] change default sampler descriptor to use nearest mip level and remove kNone

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -128,8 +128,7 @@ TEST_P(AiksTest, CanRenderTiledTexture) {
         Entity::TileMode::kClamp, Entity::TileMode::kRepeat,
         Entity::TileMode::kMirror, Entity::TileMode::kDecal};
     const char* mip_filter_names[] = {"None", "Nearest", "Linear"};
-    const MipFilter mip_filters[] = {MipFilter::kNone, MipFilter::kNearest,
-                                     MipFilter::kLinear};
+    const MipFilter mip_filters[] = {MipFilter::kNearest, MipFilter::kLinear};
     const char* min_mag_filter_names[] = {"Nearest", "Linear"};
     const MinMagFilter min_mag_filters[] = {MinMagFilter::kNearest,
                                             MinMagFilter::kLinear};

--- a/impeller/entity/contents/text_contents.cc
+++ b/impeller/entity/contents/text_contents.cc
@@ -114,7 +114,7 @@ static bool CommonRender(
     sampler_desc.min_filter = MinMagFilter::kLinear;
     sampler_desc.mag_filter = MinMagFilter::kLinear;
   }
-  sampler_desc.mip_filter = MipFilter::kNone;
+  sampler_desc.mip_filter = MipFilter::kNearest;
 
   typename FS::FragInfo frag_info;
   frag_info.text_color = ToVector(color.Premultiply());

--- a/impeller/renderer/backend/gles/sampler_gles.cc
+++ b/impeller/renderer/backend/gles/sampler_gles.cc
@@ -72,10 +72,12 @@ bool SamplerGLES::ConfigureBoundTexture(const TextureGLES& texture,
   if (!target.has_value()) {
     return false;
   }
+  bool has_mips = texture.GetTextureDescriptor().mip_count > 1;
 
   const auto& desc = GetDescriptor();
-  gl.TexParameteri(target.value(), GL_TEXTURE_MIN_FILTER,
-                   ToParam(desc.min_filter, desc.mip_filter));
+  gl.TexParameteri(
+      target.value(), GL_TEXTURE_MIN_FILTER,
+      ToParam(desc.min_filter, has_mips ? desc.mip_filter : std::nullopt));
   gl.TexParameteri(target.value(), GL_TEXTURE_MAG_FILTER,
                    ToParam(desc.mag_filter));
   gl.TexParameteri(target.value(), GL_TEXTURE_WRAP_S,

--- a/impeller/renderer/backend/gles/sampler_gles.cc
+++ b/impeller/renderer/backend/gles/sampler_gles.cc
@@ -19,8 +19,18 @@ bool SamplerGLES::IsValid() const {
   return true;
 }
 
-static GLint ToParam(MinMagFilter minmag_filter, MipFilter mip_filter) {
-  switch (mip_filter) {
+static GLint ToParam(MinMagFilter minmag_filter,
+                     std::optional<MipFilter> mip_filter = std::nullopt) {
+  if (!mip_filter.has_value()) {
+    switch (minmag_filter) {
+      case MinMagFilter::kNearest:
+        return GL_NEAREST;
+      case MinMagFilter::kLinear:
+        return GL_LINEAR;
+    }
+  }
+
+  switch (mip_filter.value()) {
     case MipFilter::kNearest:
       switch (minmag_filter) {
         case MinMagFilter::kNearest:
@@ -67,7 +77,7 @@ bool SamplerGLES::ConfigureBoundTexture(const TextureGLES& texture,
   gl.TexParameteri(target.value(), GL_TEXTURE_MIN_FILTER,
                    ToParam(desc.min_filter, desc.mip_filter));
   gl.TexParameteri(target.value(), GL_TEXTURE_MAG_FILTER,
-                   ToParam(desc.mag_filter, MipFilter::kNearest));
+                   ToParam(desc.mag_filter));
   gl.TexParameteri(target.value(), GL_TEXTURE_WRAP_S,
                    ToAddressMode(desc.width_address_mode));
   gl.TexParameteri(target.value(), GL_TEXTURE_WRAP_T,

--- a/impeller/renderer/backend/gles/sampler_gles.cc
+++ b/impeller/renderer/backend/gles/sampler_gles.cc
@@ -21,13 +21,6 @@ bool SamplerGLES::IsValid() const {
 
 static GLint ToParam(MinMagFilter minmag_filter, MipFilter mip_filter) {
   switch (mip_filter) {
-    case MipFilter::kNone:
-      switch (minmag_filter) {
-        case MinMagFilter::kNearest:
-          return GL_NEAREST;
-        case MinMagFilter::kLinear:
-          return GL_LINEAR;
-      }
     case MipFilter::kNearest:
       switch (minmag_filter) {
         case MinMagFilter::kNearest:
@@ -74,7 +67,7 @@ bool SamplerGLES::ConfigureBoundTexture(const TextureGLES& texture,
   gl.TexParameteri(target.value(), GL_TEXTURE_MIN_FILTER,
                    ToParam(desc.min_filter, desc.mip_filter));
   gl.TexParameteri(target.value(), GL_TEXTURE_MAG_FILTER,
-                   ToParam(desc.mag_filter, MipFilter::kNone));
+                   ToParam(desc.mag_filter, MipFilter::kNearest));
   gl.TexParameteri(target.value(), GL_TEXTURE_WRAP_S,
                    ToAddressMode(desc.width_address_mode));
   gl.TexParameteri(target.value(), GL_TEXTURE_WRAP_T,

--- a/impeller/renderer/backend/gles/sampler_gles.cc
+++ b/impeller/renderer/backend/gles/sampler_gles.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "impeller/renderer/backend/gles/sampler_gles.h"
+#include <iostream>
 
 #include "impeller/renderer/backend/gles/formats_gles.h"
 #include "impeller/renderer/backend/gles/proc_table_gles.h"
@@ -28,6 +29,7 @@ static GLint ToParam(MinMagFilter minmag_filter,
       case MinMagFilter::kLinear:
         return GL_LINEAR;
     }
+    FML_UNREACHABLE();
   }
 
   switch (mip_filter.value()) {
@@ -72,12 +74,15 @@ bool SamplerGLES::ConfigureBoundTexture(const TextureGLES& texture,
   if (!target.has_value()) {
     return false;
   }
-  bool has_mips = texture.GetTextureDescriptor().mip_count > 1;
-
   const auto& desc = GetDescriptor();
-  gl.TexParameteri(
-      target.value(), GL_TEXTURE_MIN_FILTER,
-      ToParam(desc.min_filter, has_mips ? desc.mip_filter : std::nullopt));
+
+  std::optional<MipFilter> mip_filter = std::nullopt;
+  if (texture.GetTextureDescriptor().mip_count > 1) {
+    mip_filter = desc.mip_filter;
+  }
+
+  gl.TexParameteri(target.value(), GL_TEXTURE_MIN_FILTER,
+                   ToParam(desc.min_filter, mip_filter));
   gl.TexParameteri(target.value(), GL_TEXTURE_MAG_FILTER,
                    ToParam(desc.mag_filter));
   gl.TexParameteri(target.value(), GL_TEXTURE_WRAP_S,

--- a/impeller/renderer/backend/metal/formats_mtl.h
+++ b/impeller/renderer/backend/metal/formats_mtl.h
@@ -332,8 +332,6 @@ constexpr MTLSamplerMinMagFilter ToMTLSamplerMinMagFilter(MinMagFilter filter) {
 
 constexpr MTLSamplerMipFilter ToMTLSamplerMipFilter(MipFilter filter) {
   switch (filter) {
-    case MipFilter::kNone:
-      return MTLSamplerMipFilterNotMipmapped;
     case MipFilter::kNearest:
       return MTLSamplerMipFilterNearest;
     case MipFilter::kLinear:

--- a/impeller/renderer/backend/vulkan/formats_vk.h
+++ b/impeller/renderer/backend/vulkan/formats_vk.h
@@ -225,8 +225,6 @@ constexpr vk::SamplerMipmapMode ToVKSamplerMipmapMode(MipFilter filter) {
       return vk::SamplerMipmapMode::eNearest;
     case MipFilter::kLinear:
       return vk::SamplerMipmapMode::eLinear;
-    case MipFilter::kNone:
-      return vk::SamplerMipmapMode::eNearest;
   }
 
   FML_UNREACHABLE();

--- a/impeller/renderer/formats.h
+++ b/impeller/renderer/formats.h
@@ -247,8 +247,6 @@ enum class MinMagFilter {
 };
 
 enum class MipFilter {
-  /// Always sample from mip level 0. Other mip levels are ignored.
-  kNone,
   /// Sample from the nearest mip level.
   kNearest,
   /// Sample from the two nearest mip levels and linearly interpolate between

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -724,14 +724,14 @@ TEST_P(RendererTest, CanGenerateMipmaps) {
 
   bool first_frame = true;
   Renderer::RenderCallback callback = [&](RenderTarget& render_target) {
-    const char* mip_filter_names[] = {"None", "Nearest", "Linear"};
+    const char* mip_filter_names[] = {"Nearest", "Linear"};
     const MipFilter mip_filters[] = {MipFilter::kNearest, MipFilter::kLinear};
     const char* min_filter_names[] = {"Nearest", "Linear"};
     const MinMagFilter min_filters[] = {MinMagFilter::kNearest,
                                         MinMagFilter::kLinear};
 
     // UI state.
-    static int selected_mip_filter = 2;
+    static int selected_mip_filter = 1;
     static int selected_min_filter = 0;
     static float lod = 4.5;
 

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -725,8 +725,7 @@ TEST_P(RendererTest, CanGenerateMipmaps) {
   bool first_frame = true;
   Renderer::RenderCallback callback = [&](RenderTarget& render_target) {
     const char* mip_filter_names[] = {"None", "Nearest", "Linear"};
-    const MipFilter mip_filters[] = {MipFilter::kNone, MipFilter::kNearest,
-                                     MipFilter::kLinear};
+    const MipFilter mip_filters[] = {MipFilter::kNearest, MipFilter::kLinear};
     const char* min_filter_names[] = {"Nearest", "Linear"};
     const MinMagFilter min_filters[] = {MinMagFilter::kNearest,
                                         MinMagFilter::kLinear};

--- a/impeller/renderer/sampler_descriptor.h
+++ b/impeller/renderer/sampler_descriptor.h
@@ -18,7 +18,7 @@ class Context;
 struct SamplerDescriptor final : public Comparable<SamplerDescriptor> {
   MinMagFilter min_filter = MinMagFilter::kNearest;
   MinMagFilter mag_filter = MinMagFilter::kNearest;
-  MipFilter mip_filter = MipFilter::kNone;
+  MipFilter mip_filter = MipFilter::kNearest;
 
   SamplerAddressMode width_address_mode = SamplerAddressMode::kClampToEdge;
   SamplerAddressMode height_address_mode = SamplerAddressMode::kClampToEdge;

--- a/impeller/scene/geometry.cc
+++ b/impeller/scene/geometry.cc
@@ -246,7 +246,7 @@ void SkinnedVertexBufferGeometry::BindToCommand(
   SamplerDescriptor sampler_desc;
   sampler_desc.min_filter = MinMagFilter::kNearest;
   sampler_desc.mag_filter = MinMagFilter::kNearest;
-  sampler_desc.mip_filter = MipFilter::kNone;
+  sampler_desc.mip_filter = MipFilter::kNearest;
   sampler_desc.width_address_mode = SamplerAddressMode::kRepeat;
   sampler_desc.label = "NN Repeat";
 


### PR DESCRIPTION
By default we create mipmaps for every decoded image. Choosing the nearest mip level is the only reasonable default.