### PR TITLE
Add drone_dimension to target `Linux Web Framework tests`

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -335,6 +335,8 @@ targets:
         ]
       framework: "true"
       no_goma: "true"
+      drone_dimensions: >
+        ["device_type=none"]
       shard: web_tests
       subshards: >-
               ["0", "1", "2", "3", "4", "5", "6", "7_last"]


### PR DESCRIPTION
This is to force subbuilds to run on host only bots, avoiding https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20Web%20Framework%20tests/14187/overview