### PR TITLE
[Linux] Fix duplicate calls to system font loading during startup

### DIFF
--- a/third_party/txt/src/txt/platform_linux.cc
+++ b/third_party/txt/src/txt/platform_linux.cc
@@ -4,12 +4,6 @@
 
 #include "txt/platform.h"
 
-#ifdef FLUTTER_USE_FONTCONFIG
-#include "third_party/skia/include/ports/SkFontMgr_fontconfig.h"
-#else
-#include "third_party/skia/include/ports/SkFontMgr_directory.h"
-#endif
-
 namespace txt {
 
 std::vector<std::string> GetDefaultFontFamilies() {
@@ -17,11 +11,7 @@ std::vector<std::string> GetDefaultFontFamilies() {
 }
 
 sk_sp<SkFontMgr> GetDefaultFontManager(uint32_t font_initialization_data) {
-#ifdef FLUTTER_USE_FONTCONFIG
-  return SkFontMgr_New_FontConfig(nullptr);
-#else
-  return SkFontMgr_New_Custom_Directory("/usr/share/fonts/");
-#endif
+  return SkFontMgr::RefDefault();
 }
 
 }  // namespace txt


### PR DESCRIPTION
Prior to this change, the system fonts were being loaded twice, which was affecting application startup performance on Linux.

The first call was being triggered by `Engine::SetupDefaultFontManager` while the second one happened during the first call to `SkFontMgr::RefDefault()` which is usually triggered by [`SkTypeface::MakeFromStream()`](https://github.com/google/skia/blob/0c4a277118d7fd60623e448b1a27eb34d3953e0c/src/core/SkTypeface.cpp#L216). The following stack traces show the code paths leading to these calls:

<details>
  <summary>First call to DirectorySystemFontLoader::loadSystemFonts</summary>
  
```
libflutter_linux_gtk.so!DirectorySystemFontLoader::loadSystemFonts(const DirectorySystemFontLoader * this, const SkTypeface_FreeType::Scanner & scanner, SkFontMgr_Custom::Families * families) (/home/vially/code/engine/src/third_party/skia/src/ports/SkFontMgr_custom_directory.cpp:21)
libflutter_linux_gtk.so!SkFontMgr_Custom::SkFontMgr_Custom(SkFontMgr_Custom * this, const SkFontMgr_Custom::SystemFontLoader & loader) (/home/vially/code/engine/src/third_party/skia/src/ports/SkFontMgr_custom.cpp:131)
libflutter_linux_gtk.so!sk_make_sp<SkFontMgr_Custom, DirectorySystemFontLoader>(DirectorySystemFontLoader && args) (/home/vially/code/engine/src/third_party/skia/include/core/SkRefCnt.h:372)
libflutter_linux_gtk.so!SkFontMgr_New_Custom_Directory(const char * dir) (/home/vially/code/engine/src/third_party/skia/src/ports/SkFontMgr_custom_directory.cpp:103)
libflutter_linux_gtk.so!txt::GetDefaultFontManager(uint32_t font_initialization_data) (/home/vially/code/engine/src/flutter/third_party/txt/src/txt/platform_linux.cc:23)
libflutter_linux_gtk.so!txt::FontCollection::SetupDefaultFontManager(txt::FontCollection * this, uint32_t font_initialization_data) (/home/vially/code/engine/src/flutter/third_party/txt/src/txt/font_collection.cc:48)
libflutter_linux_gtk.so!flutter::FontCollection::SetupDefaultFontManager(flutter::FontCollection * this, uint32_t font_initialization_data) (/home/vially/code/engine/src/flutter/lib/ui/text/font_collection.cc:45)
libflutter_linux_gtk.so!flutter::Engine::SetupDefaultFontManager(flutter::Engine * this) (/home/vially/code/engine/src/flutter/shell/common/engine.cc:151)
libflutter_linux_gtk.so!flutter::Shell::Setup(std::_LIBCPP_ABI_NAMESPACE::unique_ptr<flutter::PlatformView, std::_LIBCPP_ABI_NAMESPACE::default_delete<flutter::PlatformView> >, std::_LIBCPP_ABI_NAMESPACE::unique_ptr<flutter::Engine, std::_LIBCPP_ABI_NAMESPACE::default_delete<flutter::Engine> >, std::_LIBCPP_ABI_NAMESPACE::unique_ptr<flutter::Rasterizer, std::_LIBCPP_ABI_NAMESPACE::default_delete<flutter::Rasterizer> >, std::_LIBCPP_ABI_NAMESPACE::shared_ptr<flutter::ShellIOManager> const&)::$_1::operator()() const(const class {...} * this) (/home/vially/code/engine/src/flutter/shell/common/shell.cc:690)
libflutter_linux_gtk.so!std::_LIBCPP_ABI_NAMESPACE::__invoke[abi:v15000]<flutter::Shell::Setup(std::_LIBCPP_ABI_NAMESPACE::unique_ptr<flutter::PlatformView, std::_LIBCPP_ABI_NAMESPACE::default_delete<flutter::PlatformView> >, std::_LIBCPP_ABI_NAMESPACE::unique_ptr<flutter::Engine, std::_LIBCPP_ABI_NAMESPACE::default_delete<flutter::Engine> >, std::_LIBCPP_ABI_NAMESPACE::unique_ptr<flutter::Rasterizer, std::_LIBCPP_ABI_NAMESPACE::default_delete<flutter::Rasterizer> >, std::_LIBCPP_ABI_NAMESPACE::shared_ptr<flutter::ShellIOManager> const&)::$_1&>(flutter::Shell::Setup(std::_LIBCPP_ABI_NAMESPACE::unique_ptr<flutter::PlatformView, std::_LIBCPP_ABI_NAMESPACE::default_delete<flutter::PlatformView> >, std::_LIBCPP_ABI_NAMESPACE::unique_ptr<flutter::Engine, std::_LIBCPP_ABI_NAMESPACE::default_delete<flutter::Engine> >, std::_LIBCPP_ABI_NAMESPACE::unique_ptr<flutter::Rasterizer, std::_LIBCPP_ABI_NAMESPACE::default_delete<flutter::Rasterizer> >, std::_LIBCPP_ABI_NAMESPACE::shared_ptr<flutter::ShellIOManager> const&)::$_1&)(class {...} & __f) (/home/vially/code/engine/src/third_party/libcxx/include/__functional/invoke.h:403)
libflutter_linux_gtk.so!std::_LIBCPP_ABI_NAMESPACE::__invoke_void_return_wrapper<void, true>::__call<flutter::Shell::Setup(std::_LIBCPP_ABI_NAMESPACE::unique_ptr<flutter::PlatformView, std::_LIBCPP_ABI_NAMESPACE::default_delete<flutter::PlatformView> >, std::_LIBCPP_ABI_NAMESPACE::unique_ptr<flutter::Engine, std::_LIBCPP_ABI_NAMESPACE::default_delete<flutter::Engine> >, std::_LIBCPP_ABI_NAMESPACE::unique_ptr<flutter::Rasterizer, std::_LIBCPP_ABI_NAMESPACE::default_delete<flutter::Rasterizer> >, std::_LIBCPP_ABI_NAMESPACE::shared_ptr<flutter::ShellIOManager> const&)::$_1&>(flutter::Shell::Setup(std::_LIBCPP_ABI_NAMESPACE::unique_ptr<flutter::PlatformView, std::_LIBCPP_ABI_NAMESPACE::default_delete<flutter::PlatformView> >, std::_LIBCPP_ABI_NAMESPACE::unique_ptr<flutter::Engine, std::_LIBCPP_ABI_NAMESPACE::default_delete<flutter::Engine> >, std::_LIBCPP_ABI_NAMESPACE::unique_ptr<flutter::Rasterizer, std::_LIBCPP_ABI_NAMESPACE::default_delete<flutter::Rasterizer> >, std::_LIBCPP_ABI_NAMESPACE::shared_ptr<flutter::ShellIOManager> const&)::$_1&)(class {...} & __args) (/home/vially/code/engine/src/third_party/libcxx/include/__functional/invoke.h:488)
libflutter_linux_gtk.so!std::_LIBCPP_ABI_NAMESPACE::__function::__alloc_func<flutter::Shell::Setup(std::_LIBCPP_ABI_NAMESPACE::unique_ptr<flutter::PlatformView, std::_LIBCPP_ABI_NAMESPACE::default_delete<flutter::PlatformView> >, std::_LIBCPP_ABI_NAMESPACE::unique_ptr<flutter::Engine, std::_LIBCPP_ABI_NAMESPACE::default_delete<flutter::Engine> >, std::_LIBCPP_ABI_NAMESPACE::unique_ptr<flutter::Rasterizer, std::_LIBCPP_ABI_NAMESPACE::default_delete<flutter::Rasterizer> >, std::_LIBCPP_ABI_NAMESPACE::shared_ptr<flutter::ShellIOManager> const&)::$_1, std::_LIBCPP_ABI_NAMESPACE::allocator<flutter::Shell::Setup(std::_LIBCPP_ABI_NAMESPACE::unique_ptr<flutter::PlatformView, std::_LIBCPP_ABI_NAMESPACE::default_delete<flutter::PlatformView> >, std::_LIBCPP_ABI_NAMESPACE::unique_ptr<flutter::Engine, std::_LIBCPP_ABI_NAMESPACE::default_delete<flutter::Engine> >, std::_LIBCPP_ABI_NAMESPACE::unique_ptr<flutter::Rasterizer, std::_LIBCPP_ABI_NAMESPACE::default_delete<flutter::Rasterizer> >, std::_LIBCPP_ABI_NAMESPACE::shared_ptr<flutter::ShellIOManager> const&)::$_1>, void ()>::operator()[abi:v15000]()(std::_LIBCPP_ABI_NAMESPACE::__function::__alloc_func<(lambda at ../../flutter/shell/common/shell.cc:688:39), std::_LIBCPP_ABI_NAMESPACE::allocator<(lambda at ../../flutter/shell/common/shell.cc:688:39)>, void ()> * this) (/home/vially/code/engine/src/third_party/libcxx/include/__functional/function.h:185)
libflutter_linux_gtk.so!std::_LIBCPP_ABI_NAMESPACE::__function::__func<flutter::Shell::Setup(std::_LIBCPP_ABI_NAMESPACE::unique_ptr<flutter::PlatformView, std::_LIBCPP_ABI_NAMESPACE::default_delete<flutter::PlatformView> >, std::_LIBCPP_ABI_NAMESPACE::unique_ptr<flutter::Engine, std::_LIBCPP_ABI_NAMESPACE::default_delete<flutter::Engine> >, std::_LIBCPP_ABI_NAMESPACE::unique_ptr<flutter::Rasterizer, std::_LIBCPP_ABI_NAMESPACE::default_delete<flutter::Rasterizer> >, std::_LIBCPP_ABI_NAMESPACE::shared_ptr<flutter::ShellIOManager> const&)::$_1, std::_LIBCPP_ABI_NAMESPACE::allocator<flutter::Shell::Setup(std::_LIBCPP_ABI_NAMESPACE::unique_ptr<flutter::PlatformView, std::_LIBCPP_ABI_NAMESPACE::default_delete<flutter::PlatformView> >, std::_LIBCPP_ABI_NAMESPACE::unique_ptr<flutter::Engine, std::_LIBCPP_ABI_NAMESPACE::default_delete<flutter::Engine> >, std::_LIBCPP_ABI_NAMESPACE::unique_ptr<flutter::Rasterizer, std::_LIBCPP_ABI_NAMESPACE::default_delete<flutter::Rasterizer> >, std::_LIBCPP_ABI_NAMESPACE::shared_ptr<flutter::ShellIOManager> const&)::$_1>, void ()>::operator()()(std::_LIBCPP_ABI_NAMESPACE::__function::__func<(lambda at ../../flutter/shell/common/shell.cc:688:39), std::_LIBCPP_ABI_NAMESPACE::allocator<(lambda at ../../flutter/shell/common/shell.cc:688:39)>, void ()> * this) (/home/vially/code/engine/src/third_party/libcxx/include/__functional/function.h:359)
libflutter_linux_gtk.so!std::_LIBCPP_ABI_NAMESPACE::__function::__value_func<void ()>::operator()[abi:v15000]() const(const std::_LIBCPP_ABI_NAMESPACE::__function::__value_func<void ()> * this) (/home/vially/code/engine/src/third_party/libcxx/include/__functional/function.h:512)
libflutter_linux_gtk.so!std::_LIBCPP_ABI_NAMESPACE::function<void ()>::operator()() const(const std::_LIBCPP_ABI_NAMESPACE::function<void ()> * this) (/home/vially/code/engine/src/third_party/libcxx/include/__functional/function.h:1187)
libflutter_linux_gtk.so!fml::MessageLoopImpl::FlushTasks(fml::MessageLoopImpl * this, fml::FlushType type) (/home/vially/code/engine/src/flutter/fml/message_loop_impl.cc:126)
libflutter_linux_gtk.so!fml::MessageLoopImpl::RunExpiredTasksNow(fml::MessageLoopImpl * this) (/home/vially/code/engine/src/flutter/fml/message_loop_impl.cc:139)
libflutter_linux_gtk.so!fml::MessageLoopLinux::OnEventFired(fml::MessageLoopLinux * this) (/home/vially/code/engine/src/flutter/fml/platform/linux/message_loop_linux.cc:90)
libflutter_linux_gtk.so!fml::MessageLoopLinux::Run(fml::MessageLoopLinux * this) (/home/vially/code/engine/src/flutter/fml/platform/linux/message_loop_linux.cc:70)
libflutter_linux_gtk.so!fml::MessageLoopImpl::DoRun(fml::MessageLoopImpl * this) (/home/vially/code/engine/src/flutter/fml/message_loop_impl.cc:94)
```
</details>

<details>
  <summary>Second call to DirectorySystemFontLoader::loadSystemFonts</summary>
  
```
libflutter_linux_gtk.so!DirectorySystemFontLoader::loadSystemFonts(const DirectorySystemFontLoader * this, const SkTypeface_FreeType::Scanner & scanner, SkFontMgr_Custom::Families * families) (/home/vially/code/engine/src/third_party/skia/src/ports/SkFontMgr_custom_directory.cpp:21)
libflutter_linux_gtk.so!SkFontMgr_Custom::SkFontMgr_Custom(SkFontMgr_Custom * this, const SkFontMgr_Custom::SystemFontLoader & loader) (/home/vially/code/engine/src/third_party/skia/src/ports/SkFontMgr_custom.cpp:131)
libflutter_linux_gtk.so!sk_make_sp<SkFontMgr_Custom, DirectorySystemFontLoader>(DirectorySystemFontLoader && args) (/home/vially/code/engine/src/third_party/skia/include/core/SkRefCnt.h:372)
libflutter_linux_gtk.so!SkFontMgr_New_Custom_Directory(const char * dir) (/home/vially/code/engine/src/third_party/skia/src/ports/SkFontMgr_custom_directory.cpp:103)
libflutter_linux_gtk.so!SkFontMgr::Factory() (/home/vially/code/engine/src/third_party/skia/src/ports/SkFontMgr_custom_directory_factory.cpp:20)
libflutter_linux_gtk.so!SkFontMgr::RefDefault()::$_0::operator()() const(const class {...} * this) (/home/vially/code/engine/src/third_party/skia/src/core/SkFontMgr.cpp:163)
libflutter_linux_gtk.so!SkOnce::operator()<SkFontMgr::RefDefault()::$_0>(SkFontMgr::RefDefault()::$_0&&)(SkOnce * this, class {...} && fn) (/home/vially/code/engine/src/third_party/skia/include/private/base/SkOnce.h:39)
libflutter_linux_gtk.so!SkFontMgr::RefDefault() (/home/vially/code/engine/src/third_party/skia/src/core/SkFontMgr.cpp:161)
libflutter_linux_gtk.so!SkTypeface::MakeFromStream(std::_LIBCPP_ABI_NAMESPACE::unique_ptr<SkStreamAsset, std::_LIBCPP_ABI_NAMESPACE::default_delete<SkStreamAsset> > stream, int index) (/home/vially/code/engine/src/third_party/skia/src/core/SkTypeface.cpp:216)
libflutter_linux_gtk.so!flutter::AssetManagerFontStyleSet::createTypeface(flutter::AssetManagerFontStyleSet * this, int i) (/home/vially/code/engine/src/flutter/lib/ui/text/asset_manager_font_provider.cc:121)
libflutter_linux_gtk.so!flutter::AssetManagerFontStyleSet::getStyle(flutter::AssetManagerFontStyleSet * this, int index, SkFontStyle * style, SkString * name) (/home/vially/code/engine/src/flutter/lib/ui/text/asset_manager_font_provider.cc:90)
libflutter_linux_gtk.so!SkFontStyleSet::matchStyleCSS3(SkFontStyleSet * this, const SkFontStyle & pattern) (/home/vially/code/engine/src/third_party/skia/src/core/SkFontMgr.cpp:211)
libflutter_linux_gtk.so!flutter::AssetManagerFontStyleSet::matchStyle(flutter::AssetManagerFontStyleSet * this, const SkFontStyle & pattern) (/home/vially/code/engine/src/flutter/lib/ui/text/asset_manager_font_provider.cc:133)
libflutter_linux_gtk.so!skia::textlayout::FontCollection::matchTypeface(skia::textlayout::FontCollection * this, const SkString & familyName, SkFontStyle fontStyle) (/home/vially/code/engine/src/third_party/skia/modules/skparagraph/src/FontCollection.cpp:135)
libflutter_linux_gtk.so!skia::textlayout::FontCollection::findTypefaces(skia::textlayout::FontCollection * this, const std::_LIBCPP_ABI_NAMESPACE::vector<SkString, std::_LIBCPP_ABI_NAMESPACE::allocator<SkString> > & familyNames, SkFontStyle fontStyle, const std::_LIBCPP_ABI_NAMESPACE::optional<skia::textlayout::FontArguments> & fontArgs) (/home/vially/code/engine/src/third_party/skia/modules/skparagraph/src/FontCollection.cpp:94)
libflutter_linux_gtk.so!skia::textlayout::OneLineShaper::matchResolvedFonts(skia::textlayout::TextStyle const&, std::_LIBCPP_ABI_NAMESPACE::function<skia::textlayout::OneLineShaper::Resolved (sk_sp<SkTypeface>)> const&)(skia::textlayout::OneLineShaper * this, const skia::textlayout::TextStyle & textStyle, const skia::textlayout::OneLineShaper::TypefaceVisitor & visitor) (/home/vially/code/engine/src/third_party/skia/modules/skparagraph/src/OneLineShaper.cpp:417)
libflutter_linux_gtk.so!skia::textlayout::OneLineShaper::shape()::$_0::operator()(skia::textlayout::SkRange<unsigned long>, SkSpan<skia::textlayout::Block>, float&, unsigned long, unsigned char) const::{lambda(skia::textlayout::Block, skia_private::TArray<SkShaper::Feature, true>)#1}::operator()(skia::textlayout::Block, skia_private::TArray<SkShaper::Feature, true>) const(const class {...} * this, skia::textlayout::Block block, SkTArray<SkShaper::Feature> features) (/home/vially/code/engine/src/third_party/skia/modules/skparagraph/src/OneLineShaper.cpp:616)
libflutter_linux_gtk.so!std::_LIBCPP_ABI_NAMESPACE::__invoke[abi:v15000]<skia::textlayout::OneLineShaper::shape()::$_0::operator()(skia::textlayout::SkRange<unsigned long>, SkSpan<skia::textlayout::Block>, float&, unsigned long, unsigned char) const::{lambda(skia::textlayout::Block, skia_private::TArray<SkShaper::Feature, true>)#1}&, skia::textlayout::Block, skia_private::TArray<SkShaper::Feature, true> >(skia::textlayout::OneLineShaper::shape()::$_0::operator()(skia::textlayout::SkRange<unsigned long>, SkSpan<skia::textlayout::Block>, float&, unsigned long, unsigned char) const::{lambda(skia::textlayout::Block, skia_private::TArray<SkShaper::Feature, true>)#1}&, skia::textlayout::Block&&, skia_private::TArray<SkShaper::Feature, true>&&)(class {...} & __f, skia_private::TArray<SkShaper::Feature, true> && __args, skia_private::TArray<SkShaper::Feature, true> && __args) (/home/vially/code/engine/src/third_party/libcxx/include/__functional/invoke.h:403)
libflutter_linux_gtk.so!std::_LIBCPP_ABI_NAMESPACE::__invoke_void_return_wrapper<void, true>::__call<skia::textlayout::OneLineShaper::shape()::$_0::operator()(skia::textlayout::SkRange<unsigned long>, SkSpan<skia::textlayout::Block>, float&, unsigned long, unsigned char) const::{lambda(skia::textlayout::Block, skia_private::TArray<SkShaper::Feature, true>)#1}&, skia::textlayout::Block, skia_private::TArray<SkShaper::Feature, true> >(skia::textlayout::OneLineShaper::shape()::$_0::operator()(skia::textlayout::SkRange<unsigned long>, SkSpan<skia::textlayout::Block>, float&, unsigned long, unsigned char) const::{lambda(skia::textlayout::Block, skia_private::TArray<SkShaper::Feature, true>)#1}&, skia::textlayout::Block&&, skia_private::TArray<SkShaper::Feature, true>&&)(skia_private::TArray<SkShaper::Feature, true> && __args, skia_private::TArray<SkShaper::Feature, true> && __args, skia_private::TArray<SkShaper::Feature, true> && __args) (/home/vially/code/engine/src/third_party/libcxx/include/__functional/invoke.h:488)
libflutter_linux_gtk.so!std::_LIBCPP_ABI_NAMESPACE::__function::__alloc_func<skia::textlayout::OneLineShaper::shape()::$_0::operator()(skia::textlayout::SkRange<unsigned long>, SkSpan<skia::textlayout::Block>, float&, unsigned long, unsigned char) const::{lambda(skia::textlayout::Block, skia_private::TArray<SkShaper::Feature, true>)#1}, std::_LIBCPP_ABI_NAMESPACE::allocator<skia::textlayout::OneLineShaper::shape()::$_0::operator()(skia::textlayout::SkRange<unsigned long>, SkSpan<skia::textlayout::Block>, float&, unsigned long, unsigned char) const::{lambda(skia::textlayout::Block, skia_private::TArray<SkShaper::Feature, true>)#1}>, void (skia::textlayout::Block, skia_private::TArray<SkShaper::Feature, true>)>::operator()[abi:v15000](skia::textlayout::Block&&, skia_private::TArray<SkShaper::Feature, true>&&)(std::_LIBCPP_ABI_NAMESPACE::__function::__alloc_func<(lambda at ../../third_party/skia/modules/skparagraph/src/OneLineShaper.cpp:604:17), std::_LIBCPP_ABI_NAMESPACE::allocator<(lambda at ../../third_party/skia/modules/skparagraph/src/OneLineShaper.cpp:604:17)>, void (skia::textlayout::Block, skia_private::TArray<SkShaper::Feature, true>)> * this, skia_private::TArray<SkShaper::Feature, true> && __arg, skia_private::TArray<SkShaper::Feature, true> && __arg) (/home/vially/code/engine/src/third_party/libcxx/include/__functional/function.h:185)
```
</details>

The root cause here is that `GetDefaultFontManager()` does *not* set the newly initialized font manager as the [`SkFontMgr` singleton](https://github.com/google/skia/blob/0c4a277118d7fd60623e448b1a27eb34d3953e0c/src/core/SkFontMgr.cpp#L159). This means the first call to `SkFontMgr::RefDefault()` has to initialize *another* instance of the font manager. This affects both font manager implementations on Linux: custom directory and fontconfig.

This pull-request fixes that by replacing the custom `GetDefaultFontManager()` implementation on Linux with a call to `SkFontMgr::RefDefault()`. It turns out this is working as expected and it [automatically selects the correct font manager factory](https://github.com/google/skia/blob/0c4a277118d7fd60623e448b1a27eb34d3953e0c/gn/skia.gni#L173-L176) depending on the `enable-fontconfig` GN flag.

This is part of a series of pull-requests that will attempt to fix some font-loading issues related to https://github.com/flutter/flutter/issues/118911.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
