### PR TITLE
[Linux] fix: make textures thread-safe on linux

### DIFF
--- a/shell/platform/linux/fl_texture_registrar.cc
+++ b/shell/platform/linux/fl_texture_registrar.cc
@@ -207,6 +207,18 @@ fl_texture_registrar_unregister_texture(FlTextureRegistrar* self,
                                                                   texture);
 }
 
+gboolean fl_texture_registrar_get_textures_locked(
+    FlTextureRegistrar* registrar) {
+  g_return_val_if_fail(FL_IS_TEXTURE_REGISTRAR_IMPL(registrar), FALSE);
+  FlTextureRegistrarImpl* self = FL_TEXTURE_REGISTRAR_IMPL(registrar);
+  gboolean locked = g_mutex_trylock(&self->textures_mutex);
+  if (locked) {
+    g_mutex_unlock(&self->textures_mutex);
+    return FALSE;
+  }
+  return TRUE;
+}
+
 FlTextureRegistrar* fl_texture_registrar_new(FlEngine* engine) {
   FlTextureRegistrarImpl* self = FL_TEXTURE_REGISTRAR_IMPL(
       g_object_new(fl_texture_registrar_impl_get_type(), nullptr));

--- a/shell/platform/linux/fl_texture_registrar.cc
+++ b/shell/platform/linux/fl_texture_registrar.cc
@@ -208,13 +208,6 @@ fl_texture_registrar_unregister_texture(FlTextureRegistrar* self,
                                                                   texture);
 }
 
-guint fl_texture_registrar_get_textures_table_size(
-    FlTextureRegistrar* registrar) {
-  g_return_val_if_fail(FL_IS_TEXTURE_REGISTRAR_IMPL(registrar), 0);
-  FlTextureRegistrarImpl* self = FL_TEXTURE_REGISTRAR_IMPL(registrar);
-  return g_hash_table_size(self->textures);
-}
-
 FlTextureRegistrar* fl_texture_registrar_new(FlEngine* engine) {
   FlTextureRegistrarImpl* self = FL_TEXTURE_REGISTRAR_IMPL(
       g_object_new(fl_texture_registrar_impl_get_type(), nullptr));

--- a/shell/platform/linux/fl_texture_registrar.cc
+++ b/shell/platform/linux/fl_texture_registrar.cc
@@ -34,6 +34,9 @@ struct _FlTextureRegistrarImpl {
   // plugins.  The keys are directly stored int64s. The values are stored
   // pointer to #FlTexture.  This table is freed by the responder.
   GHashTable* textures;
+
+  // The mutex guard to make `textures` thread-safe.
+  GMutex textures_mutex;
 };
 
 static void fl_texture_registrar_impl_iface_init(
@@ -57,21 +60,27 @@ static void engine_weak_notify_cb(gpointer user_data,
   self->engine = nullptr;
 
   // Unregister any textures.
+  g_mutex_lock(&self->textures_mutex);
   g_autoptr(GHashTable) textures = self->textures;
   self->textures = g_hash_table_new_full(g_direct_hash, g_direct_equal, nullptr,
                                          g_object_unref);
   g_hash_table_remove_all(textures);
+  g_mutex_unlock(&self->textures_mutex);
+  g_mutex_clear(&self->textures_mutex);
 }
 
 static void fl_texture_registrar_impl_dispose(GObject* object) {
   FlTextureRegistrarImpl* self = FL_TEXTURE_REGISTRAR_IMPL(object);
 
+  g_mutex_lock(&self->textures_mutex);
   g_clear_pointer(&self->textures, g_hash_table_unref);
+  g_mutex_unlock(&self->textures_mutex);
 
   if (self->engine != nullptr) {
     g_object_weak_unref(G_OBJECT(self->engine), engine_weak_notify_cb, self);
     self->engine = nullptr;
   }
+  g_mutex_clear(&self->textures_mutex);
 
   G_OBJECT_CLASS(fl_texture_registrar_impl_parent_class)->dispose(object);
 }
@@ -93,8 +102,10 @@ static gboolean register_texture(FlTextureRegistrar* registrar,
     int64_t id = self->next_id++;
     if (fl_engine_register_external_texture(self->engine, id)) {
       fl_texture_set_id(texture, id);
+      g_mutex_lock(&self->textures_mutex);
       g_hash_table_insert(self->textures, GINT_TO_POINTER(id),
                           g_object_ref(texture));
+      g_mutex_unlock(&self->textures_mutex);
       return TRUE;
     } else {
       return FALSE;
@@ -108,8 +119,11 @@ static gboolean register_texture(FlTextureRegistrar* registrar,
 static FlTexture* lookup_texture(FlTextureRegistrar* registrar,
                                  int64_t texture_id) {
   FlTextureRegistrarImpl* self = FL_TEXTURE_REGISTRAR_IMPL(registrar);
-  return reinterpret_cast<FlTexture*>(
+  g_mutex_lock(&self->textures_mutex);
+  FlTexture* texture = reinterpret_cast<FlTexture*>(
       g_hash_table_lookup(self->textures, GINT_TO_POINTER(texture_id)));
+  g_mutex_unlock(&self->textures_mutex);
+  return texture;
 }
 
 static gboolean mark_texture_frame_available(FlTextureRegistrar* registrar,
@@ -135,10 +149,12 @@ static gboolean unregister_texture(FlTextureRegistrar* registrar,
   gboolean result = fl_engine_unregister_external_texture(
       self->engine, fl_texture_get_id(texture));
 
+  g_mutex_lock(&self->textures_mutex);
   if (!g_hash_table_remove(self->textures,
                            GINT_TO_POINTER(fl_texture_get_id(texture)))) {
     g_warning("Unregistering a non-existent texture %p", texture);
   }
+  g_mutex_unlock(&self->textures_mutex);
 
   return result;
 }
@@ -200,6 +216,9 @@ FlTextureRegistrar* fl_texture_registrar_new(FlEngine* engine) {
 
   self->engine = engine;
   g_object_weak_ref(G_OBJECT(engine), engine_weak_notify_cb, self);
+
+  // Initialize the mutex for textures.
+  g_mutex_init(&self->textures_mutex);
 
   return FL_TEXTURE_REGISTRAR(self);
 }

--- a/shell/platform/linux/fl_texture_registrar.cc
+++ b/shell/platform/linux/fl_texture_registrar.cc
@@ -208,16 +208,11 @@ fl_texture_registrar_unregister_texture(FlTextureRegistrar* self,
                                                                   texture);
 }
 
-gboolean fl_texture_registrar_get_textures_locked(
+guint fl_texture_registrar_get_textures_table_size(
     FlTextureRegistrar* registrar) {
-  g_return_val_if_fail(FL_IS_TEXTURE_REGISTRAR_IMPL(registrar), FALSE);
+  g_return_val_if_fail(FL_IS_TEXTURE_REGISTRAR_IMPL(registrar), 0);
   FlTextureRegistrarImpl* self = FL_TEXTURE_REGISTRAR_IMPL(registrar);
-  gboolean locked = g_mutex_trylock(&self->textures_mutex);
-  if (locked) {
-    g_mutex_unlock(&self->textures_mutex);
-    return FALSE;
-  }
-  return TRUE;
+  return g_hash_table_size(self->textures);
 }
 
 FlTextureRegistrar* fl_texture_registrar_new(FlEngine* engine) {

--- a/shell/platform/linux/fl_texture_registrar.cc
+++ b/shell/platform/linux/fl_texture_registrar.cc
@@ -66,7 +66,6 @@ static void engine_weak_notify_cb(gpointer user_data,
                                          g_object_unref);
   g_hash_table_remove_all(textures);
   g_mutex_unlock(&self->textures_mutex);
-  g_mutex_clear(&self->textures_mutex);
 }
 
 static void fl_texture_registrar_impl_dispose(GObject* object) {
@@ -171,6 +170,8 @@ static void fl_texture_registrar_impl_init(FlTextureRegistrarImpl* self) {
   self->next_id = 1;
   self->textures = g_hash_table_new_full(g_direct_hash, g_direct_equal, nullptr,
                                          g_object_unref);
+  // Initialize the mutex for textures.
+  g_mutex_init(&self->textures_mutex);
 }
 
 G_MODULE_EXPORT gboolean
@@ -228,9 +229,6 @@ FlTextureRegistrar* fl_texture_registrar_new(FlEngine* engine) {
 
   self->engine = engine;
   g_object_weak_ref(G_OBJECT(engine), engine_weak_notify_cb, self);
-
-  // Initialize the mutex for textures.
-  g_mutex_init(&self->textures_mutex);
 
   return FL_TEXTURE_REGISTRAR(self);
 }

--- a/shell/platform/linux/fl_texture_registrar_private.h
+++ b/shell/platform/linux/fl_texture_registrar_private.h
@@ -37,11 +37,12 @@ FlTexture* fl_texture_registrar_lookup_texture(FlTextureRegistrar* registrar,
  * fl_texture_registrar_get_textures_locked:
  * @registrar: an #FlTextureRegistrar.
  *
- * Checks whether the textures is locked by the mutex.
+ * Get the number of the textures registered in the registrar.
  *
- * Returns: %TRUE on locked, %FALSE otherwise.
+ * Returns: an unsigned integer number of the textures registered in the
+ * registrar.
  */
-gboolean fl_texture_registrar_get_textures_locked(
+guint fl_texture_registrar_get_textures_table_size(
     FlTextureRegistrar* registrar);
 
 G_END_DECLS

--- a/shell/platform/linux/fl_texture_registrar_private.h
+++ b/shell/platform/linux/fl_texture_registrar_private.h
@@ -33,18 +33,6 @@ FlTextureRegistrar* fl_texture_registrar_new(FlEngine* engine);
 FlTexture* fl_texture_registrar_lookup_texture(FlTextureRegistrar* registrar,
                                                int64_t texture_id);
 
-/**
- * fl_texture_registrar_get_textures_locked:
- * @registrar: an #FlTextureRegistrar.
- *
- * Get the number of the textures registered in the registrar.
- *
- * Returns: an unsigned integer number of the textures registered in the
- * registrar.
- */
-guint fl_texture_registrar_get_textures_table_size(
-    FlTextureRegistrar* registrar);
-
 G_END_DECLS
 
 #endif  // FLUTTER_SHELL_PLATFORM_LINUX_FL_TEXTURE_REGISTRAR_PRIVATE_H_

--- a/shell/platform/linux/fl_texture_registrar_private.h
+++ b/shell/platform/linux/fl_texture_registrar_private.h
@@ -33,6 +33,17 @@ FlTextureRegistrar* fl_texture_registrar_new(FlEngine* engine);
 FlTexture* fl_texture_registrar_lookup_texture(FlTextureRegistrar* registrar,
                                                int64_t texture_id);
 
+/**
+ * fl_texture_registrar_get_textures_locked:
+ * @registrar: an #FlTextureRegistrar.
+ *
+ * Checks whether the textures is locked by the mutex.
+ *
+ * Returns: %TRUE on locked, %FALSE otherwise.
+ */
+gboolean fl_texture_registrar_get_textures_locked(
+    FlTextureRegistrar* registrar);
+
 G_END_DECLS
 
 #endif  // FLUTTER_SHELL_PLATFORM_LINUX_FL_TEXTURE_REGISTRAR_PRIVATE_H_

--- a/shell/platform/linux/fl_texture_registrar_test.cc
+++ b/shell/platform/linux/fl_texture_registrar_test.cc
@@ -130,6 +130,9 @@ TEST(FlTextureRegistrarTest, RegistrarRegisterTextureInMultipleThreads) {
   for (uint64_t t = 0; t < kThreadCount; t++) {
     pthread_join(threads[t], NULL);
   };
-  EXPECT_EQ(fl_texture_registrar_get_textures_table_size(registrar),
-            kThreadCount);
+  // Check the texture named from [1, threadCount].
+  for (uint64_t t = 1; t <= kThreadCount; t++) {
+    EXPECT_TRUE(fl_texture_registrar_lookup_texture(registrar, (int64_t)t) !=
+                NULL);
+  };
 }

--- a/shell/platform/linux/fl_texture_registrar_test.cc
+++ b/shell/platform/linux/fl_texture_registrar_test.cc
@@ -104,3 +104,24 @@ TEST(FlTextureRegistrarTest, MarkTextureFrameAvailable) {
   EXPECT_TRUE(
       fl_texture_registrar_mark_texture_frame_available(registrar, texture));
 }
+
+// Test that mutex should be unlocked after calling register_texture.
+TEST(FlTextureRegistrarTest, RegistrarRegisterTextureMutex) {
+  g_autoptr(FlEngine) engine = make_mock_engine();
+  g_autoptr(FlTextureRegistrar) registrar = fl_texture_registrar_new(engine);
+  g_autoptr(FlTexture) texture = FL_TEXTURE(fl_test_registrar_texture_new());
+
+  EXPECT_FALSE(fl_texture_registrar_get_textures_locked(registrar));
+  EXPECT_TRUE(fl_texture_registrar_register_texture(registrar, texture));
+  EXPECT_FALSE(fl_texture_registrar_get_textures_locked(registrar));
+}
+
+// Test that mutex should be unlocked after calling lookup textures.
+TEST(FlTextureRegistrarTest, LookupTextureMutex) {
+  g_autoptr(FlEngine) engine = make_mock_engine();
+  g_autoptr(FlTextureRegistrar) registrar = fl_texture_registrar_new(engine);
+
+  EXPECT_FALSE(fl_texture_registrar_get_textures_locked(registrar));
+  EXPECT_EQ(fl_texture_registrar_lookup_texture(registrar, 1), nullptr);
+  EXPECT_FALSE(fl_texture_registrar_get_textures_locked(registrar));
+}


### PR DESCRIPTION
We've encountered some memory corruption when developing `RustDesk`, which is an open-source remote desktop built with Flutter, and it uses the texture API provided by Flutter to provide the remote screen to clients.

Both Windows and macOS work well, except for Linux. Sometimes random crashes will show and print **different** stack traces in these conditions:

- after registering a new texture
- preparing a RGBA data and `markAvaliable`

The runtime often complains `double free or corruption`.
One of the stack traces using lldb-10:
![image](https://user-images.githubusercontent.com/39793325/226512093-0b27e72a-ce65-4f7b-a24f-6f48df325fd3.png)

We checked the implementation of calling textures API on Linux several times, but have no luck. 

We've noticed that on Linux, textures are organized by `g_hash_table`, which is not the thread-safe hashtable and we should ensure synchronization on different threads. Also, we noticed the textures map on Windows already has the synchronization (for example https://github.com/flutter/engine/blob/2c342a8af94ee9ef19bbb222ac003c3340b9be00/shell/platform/windows/flutter_windows_texture_registrar.cc#L87-L90). So the implementation on Linux lacks this synchronization on textures management.

We add the synchronization by declaring a `GMutex`, which is a mutex provided by GTK, in this PR. It can make `g_hash_table` thread-safe in different threads(ui, raster, etc).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
