### PR TITLE
Avoid registering service extensions in flutter-release mode

### DIFF
--- a/lib/ui/dart_runtime_hooks.cc
+++ b/lib/ui/dart_runtime_hooks.cc
@@ -120,6 +120,7 @@ static void InitDartIO(Dart_Handle builtin_library,
       Dart_SetField(platform_type, ToDart("_localeClosure"), locale_closure);
   PropagateIfError(result);
 
+#if !FLUTTER_RELEASE
   // Register dart:io service extensions used for network profiling.
   Dart_Handle network_profiling_type =
       Dart_GetNonNullableType(io_lib, ToDart("_NetworkProfiling"), 0, nullptr);
@@ -127,6 +128,7 @@ static void InitDartIO(Dart_Handle builtin_library,
   result = Dart_Invoke(network_profiling_type,
                        ToDart("_registerServiceExtension"), 0, nullptr);
   PropagateIfError(result);
+#endif  // !FLUTTER_RELEASE
 }
 
 void DartRuntimeHooks::Install(bool is_ui_isolate,


### PR DESCRIPTION
Doing so is currently a NOP because `vm-service` isn't available in flutter-release (aka Dart VM product) mode.

So this makes startup time of isolates slightly faster in release mode and allows tree shaking of the relevant code in release mode.