### PR TITLE
Roll buildroot to b44849ee7d2b080fd5cc699e7fd37d79c13d012d

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -239,7 +239,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '287917d342224d34d6fbdf863aee8417a5f2e8b8',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'b44849ee7d2b080fd5cc699e7fd37d79c13d012d',
 
    # Fuchsia compatibility
    #


### PR DESCRIPTION
Changes since the last roll:
```
b44849e Update matcher contents post bump in dart sdk. (#695)
dd18826 Bump github/codeql-action from 2.2.6 to 2.2.7 (#693)
b7dd546 Bump actions/checkout from 3.3.0 to 3.4.0 (#694)
18ea6ef Bump github/codeql-action from 2.2.5 to 2.2.6 (#692)
```