### PR TITLE
[impeller] disable opacity peephole due to stencil issues

### DIFF
--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -393,13 +393,10 @@ void Canvas::SaveLayer(
   auto& new_layer_pass = GetCurrentPass();
 
   // Only apply opacity peephole on default blending.
-  if (paint.blend_mode == BlendMode::kSourceOver) {
-    new_layer_pass.SetDelegate(
-        std::make_unique<OpacityPeepholePassDelegate>(paint, bounds));
-  } else {
-    new_layer_pass.SetDelegate(
-        std::make_unique<PaintPassDelegate>(paint, bounds));
-  }
+  // TODO(jonahwilliams): reland OpacityPeepholePassDelegate once stencil checks
+  // are fixed.
+  new_layer_pass.SetDelegate(
+      std::make_unique<PaintPassDelegate>(paint, bounds));
 
   if (bounds.has_value() && !backdrop_filter.has_value()) {
     // Render target switches due to a save layer can be elided. In such cases

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -309,7 +309,7 @@ EntityPass::EntityResult EntityPass::GetEntityForElement(
       // Directly render into the parent target and move on.
       if (!subpass->OnRender(renderer, root_pass_size,
                              pass_context.GetPassTarget(), position, position,
-                             pass_depth, stencil_depth_ + 1, nullptr,
+                             pass_depth, stencil_depth_, nullptr,
                              pass_context.GetRenderPass(pass_depth))) {
         return EntityPass::EntityResult::Failure();
       }

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -309,7 +309,7 @@ EntityPass::EntityResult EntityPass::GetEntityForElement(
       // Directly render into the parent target and move on.
       if (!subpass->OnRender(renderer, root_pass_size,
                              pass_context.GetPassTarget(), position, position,
-                             pass_depth, stencil_depth_, nullptr,
+                             pass_depth, stencil_depth_ + 1, nullptr,
                              pass_context.GetRenderPass(pass_depth))) {
         return EntityPass::EntityResult::Failure();
       }


### PR DESCRIPTION
This causes rendering issues on wonderous that I missed. I think we're screwing up the stencil depth checks when collapsing
