### PR TITLE
[impeller] add CompressionType enum to texture descriptor

### DIFF
--- a/impeller/renderer/backend/metal/allocator_mtl.mm
+++ b/impeller/renderer/backend/metal/allocator_mtl.mm
@@ -78,6 +78,17 @@ static ISize DeviceMaxTextureSizeSupported(id<MTLDevice> device) {
   }
 }
 
+static bool SupportsLossyTextureCompression(id<MTLDevice> device) {
+#ifdef FML_OS_IOS_SIMULATOR
+  return false;
+#else
+  if (@available(macOS 10.15, iOS 13, tvOS 13, *)) {
+    return [device supportsFamily:MTLGPUFamilyApple8];
+  }
+  return false;
+#endif
+}
+
 AllocatorMTL::AllocatorMTL(id<MTLDevice> device, std::string label)
     : device_(device), allocator_label_(std::move(label)) {
   if (!device_) {
@@ -194,6 +205,13 @@ std::shared_ptr<Texture> AllocatorMTL::OnCreateTexture(
 
   mtl_texture_desc.storageMode = ToMTLStorageMode(
       desc.storage_mode, supports_memoryless_targets_, supports_uma_);
+  if (@available(macOS 12.5, ios 15.0, *)) {
+    if (desc.compression_type == CompressionType::kLossy &&
+        SupportsLossyTextureCompression(device_)) {
+      mtl_texture_desc.compressionType = MTLTextureCompressionTypeLossy;
+    }
+  }
+
   auto texture = [device_ newTextureWithDescriptor:mtl_texture_desc];
   if (!texture) {
     return nullptr;

--- a/impeller/renderer/texture_descriptor.h
+++ b/impeller/renderer/texture_descriptor.h
@@ -13,6 +13,15 @@
 namespace impeller {
 
 //------------------------------------------------------------------------------
+/// @brief      Additional compression to apply to a texture. This value is
+///             ignored on platforms which do not support it.
+///
+///             Lossy compression is only supported on iOS 15+ on A15 chips.
+enum class CompressionType {
+  kLossless,
+  kLossy,
+};
+//------------------------------------------------------------------------------
 /// @brief      A lightweight object that describes the attributes of a texture
 ///             that can then used an allocator to create that texture.
 ///
@@ -25,6 +34,7 @@ struct TextureDescriptor {
   TextureUsageMask usage =
       static_cast<TextureUsageMask>(TextureUsage::kShaderRead);
   SampleCount sample_count = SampleCount::kCount1;
+  CompressionType compression_type = CompressionType::kLossless;
 
   constexpr size_t GetByteSizeOfBaseMipLevel() const {
     if (!IsValid()) {


### PR DESCRIPTION
Adds support for but does not use a texture compression enum for Impeller.
