### PR TITLE
[web] Put image codecs back into CanvasKit Chromium

### DIFF
--- a/third_party/canvaskit/BUILD.gn
+++ b/third_party/canvaskit/BUILD.gn
@@ -32,10 +32,14 @@ wasm_toolchain("canvaskit_chromium") {
     skia_use_client_icu = true
     skia_icu_bidi_third_party_dir = "//flutter/third_party/canvaskit/icu_bidi"
 
+    # TODO(mdebbar): Set these to false once all image decoding can be done
+    # using the browser's built-in codecs.
+    # https://github.com/flutter/flutter/issues/122331
+
     # In Chromium browsers, we can use the browser's built-in codecs.
-    skia_use_libjpeg_turbo_decode = false
-    skia_use_libpng_decode = false
-    skia_use_libwebp_decode = false
+    skia_use_libjpeg_turbo_decode = true
+    skia_use_libpng_decode = true
+    skia_use_libwebp_decode = true
   }
 }
 


### PR DESCRIPTION
Partial revert of https://github.com/flutter/engine/pull/40309

Unfortunately, we can't remove image codecs from CanvasKit at the moment because we still need them when decoding an image to a target width and height (see [here](https://github.com/flutter/engine/blob/5f7df579152edce72d1d11363fda00fa8fe4ca5f/lib/web_ui/lib/src/engine/canvaskit/image.dart#L27-L34)).