### PR TITLE
[Impeller] Give ComputeSubgroupTest unique name to avoid running tests twice

### DIFF
--- a/impeller/renderer/compute_subgroup_unittests.cc
+++ b/impeller/renderer/compute_subgroup_unittests.cc
@@ -29,10 +29,10 @@
 
 namespace impeller {
 namespace testing {
-using ComputeTest = ComputePlaygroundTest;
-INSTANTIATE_COMPUTE_SUITE(ComputeTest);
+using ComputeSubgroupTest = ComputePlaygroundTest;
+INSTANTIATE_COMPUTE_SUITE(ComputeSubgroupTest);
 
-TEST_P(ComputeTest, HeartCubicsToStrokeVertices) {
+TEST_P(ComputeSubgroupTest, HeartCubicsToStrokeVertices) {
   using CS = CubicToQuadsComputeShader;
   using QS = QuadPolylineComputeShader;
   using SS = StrokeComputeShader;
@@ -256,7 +256,7 @@ TEST_P(ComputeTest, HeartCubicsToStrokeVertices) {
   ASSERT_TRUE(OpenPlaygroundHere(callback));
 }
 
-TEST_P(ComputeTest, QuadsToPolyline) {
+TEST_P(ComputeSubgroupTest, QuadsToPolyline) {
   using QS = QuadPolylineComputeShader;
   auto context = GetContext();
   ASSERT_TRUE(context);


### PR DESCRIPTION
Currently all the `ComputeTest` tests are run twice because the macro gets called twice with the same name. I missed this when factoring the subgroup related tests into their own TU a ways back.

This also makes it easier to filter so you run only the subgroup tests or you run all tests except subgroup tests.