### PR TITLE
[Impeller] use lossy texture compression on iOS for decode images and MSAA resolve textures.

### DIFF
--- a/impeller/renderer/render_target.cc
+++ b/impeller/renderer/render_target.cc
@@ -297,6 +297,7 @@ RenderTarget RenderTarget::CreateOffscreenMSAA(
       color_attachment_config.resolve_storage_mode;
   color0_resolve_tex_desc.format = pixel_format;
   color0_resolve_tex_desc.size = size;
+  color0_resolve_tex_desc.compression_type = CompressionType::kLossy;
   color0_resolve_tex_desc.usage =
       static_cast<uint64_t>(TextureUsage::kRenderTarget) |
       static_cast<uint64_t>(TextureUsage::kShaderRead);

--- a/lib/ui/painting/image_decoder_impeller.cc
+++ b/lib/ui/painting/image_decoder_impeller.cc
@@ -266,6 +266,7 @@ sk_sp<DlImage> ImageDecoderImpeller::UploadTextureToPrivate(
   texture_descriptor.format = pixel_format.value();
   texture_descriptor.size = {image_info.width(), image_info.height()};
   texture_descriptor.mip_count = texture_descriptor.size.MipCount();
+  texture_descriptor.compression_type = impeller::CompressionType::kLossy;
 
   auto dest_texture =
       context->GetResourceAllocator()->CreateTexture(texture_descriptor);


### PR DESCRIPTION
On iOS devices that support this (apple8+), this dramatically reduces memory usage.


Wonderous after swiping through all wonders at ToT:

![image](https://user-images.githubusercontent.com/8975114/226806557-a7df2420-2722-4fa8-9861-aa7cec9c0520.png)


Wonderous after swiping through all wonders with patch:


![image](https://user-images.githubusercontent.com/8975114/226806578-d5ac2c9b-21bc-4350-b1b3-2fa0f32330af.png)

