### PR TITLE
[Impeller] Share stencil coverage stack between subpasses to support pass collapsing

### DIFF
--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -393,10 +393,13 @@ void Canvas::SaveLayer(
   auto& new_layer_pass = GetCurrentPass();
 
   // Only apply opacity peephole on default blending.
-  // TODO(jonahwilliams): reland OpacityPeepholePassDelegate once stencil checks
-  // are fixed.
-  new_layer_pass.SetDelegate(
-      std::make_unique<PaintPassDelegate>(paint, bounds));
+  if (paint.blend_mode == BlendMode::kSourceOver) {
+    new_layer_pass.SetDelegate(
+        std::make_unique<OpacityPeepholePassDelegate>(paint, bounds));
+  } else {
+    new_layer_pass.SetDelegate(
+        std::make_unique<PaintPassDelegate>(paint, bounds));
+  }
 
   if (bounds.has_value() && !backdrop_filter.has_value()) {
     // Render target switches due to a save layer can be elided. In such cases

--- a/impeller/entity/entity_pass.h
+++ b/impeller/entity/entity_pass.h
@@ -109,15 +109,14 @@ class EntityPass {
     static EntityResult Skip() { return {{}, kSkip}; }
   };
 
-  EntityResult GetEntityForElement(
-      const EntityPass::Element& element,
-      ContentContext& renderer,
-      InlinePassContext& pass_context,
-      ISize root_pass_size,
-      Point position,
-      uint32_t pass_depth,
-      StencilCoverageStack& stencil_coverage_stack,
-      size_t stencil_depth_floor) const;
+  EntityResult GetEntityForElement(const EntityPass::Element& element,
+                                   ContentContext& renderer,
+                                   InlinePassContext& pass_context,
+                                   ISize root_pass_size,
+                                   Point position,
+                                   uint32_t pass_depth,
+                                   StencilCoverageStack& stencil_coverage_stack,
+                                   size_t stencil_depth_floor) const;
 
   bool OnRender(ContentContext& renderer,
                 ISize root_pass_size,

--- a/impeller/entity/entity_pass.h
+++ b/impeller/entity/entity_pass.h
@@ -31,6 +31,13 @@ class EntityPass {
       const Matrix& effect_transform,
       bool is_subpass)>;
 
+  struct StencilCoverageLayer {
+    std::optional<Rect> coverage;
+    size_t stencil_depth;
+  };
+
+  using StencilCoverageStack = std::vector<StencilCoverageLayer>;
+
   EntityPass();
 
   ~EntityPass();
@@ -102,13 +109,15 @@ class EntityPass {
     static EntityResult Skip() { return {{}, kSkip}; }
   };
 
-  EntityResult GetEntityForElement(const EntityPass::Element& element,
-                                   ContentContext& renderer,
-                                   InlinePassContext& pass_context,
-                                   ISize root_pass_size,
-                                   Point position,
-                                   uint32_t pass_depth,
-                                   size_t stencil_depth_floor) const;
+  EntityResult GetEntityForElement(
+      const EntityPass::Element& element,
+      ContentContext& renderer,
+      InlinePassContext& pass_context,
+      ISize root_pass_size,
+      Point position,
+      uint32_t pass_depth,
+      StencilCoverageStack& stencil_coverage_stack,
+      size_t stencil_depth_floor) const;
 
   bool OnRender(ContentContext& renderer,
                 ISize root_pass_size,
@@ -116,6 +125,7 @@ class EntityPass {
                 Point position,
                 Point parent_position,
                 uint32_t pass_depth,
+                StencilCoverageStack& stencil_coverage_stack,
                 size_t stencil_depth_floor = 0,
                 std::shared_ptr<Contents> backdrop_filter_contents = nullptr,
                 std::optional<InlinePassContext::RenderPassResult>


### PR DESCRIPTION
Also re-enables the opacity peephole optimization by reverting https://github.com/flutter/engine/pull/40497