### PR TITLE
Make SkFontMgr subclasses flexible for sk_sp

### DIFF
--- a/lib/ui/text/asset_manager_font_provider.cc
+++ b/lib/ui/text/asset_manager_font_provider.cc
@@ -97,7 +97,7 @@ void AssetManagerFontStyleSet::getStyle(int index,
   }
 }
 
-SkTypeface* AssetManagerFontStyleSet::createTypeface(int i) {
+auto AssetManagerFontStyleSet::createTypeface(int i) -> CreateTypefaceRet {
   size_t index = i;
   if (index >= assets_.size()) {
     return nullptr;
@@ -126,10 +126,11 @@ SkTypeface* AssetManagerFontStyleSet::createTypeface(int i) {
     }
   }
 
-  return SkRef(asset.typeface.get());
+  return CreateTypefaceRet(SkRef(asset.typeface.get()));
 }
 
-SkTypeface* AssetManagerFontStyleSet::matchStyle(const SkFontStyle& pattern) {
+auto AssetManagerFontStyleSet::matchStyle(const SkFontStyle& pattern)
+    -> MatchStyleRet {
   return matchStyleCSS3(pattern);
 }
 

--- a/lib/ui/text/asset_manager_font_provider.h
+++ b/lib/ui/text/asset_manager_font_provider.h
@@ -34,10 +34,14 @@ class AssetManagerFontStyleSet : public SkFontStyleSet {
   void getStyle(int index, SkFontStyle*, SkString* style) override;
 
   // |SkFontStyleSet|
-  SkTypeface* createTypeface(int index) override;
+  using CreateTypefaceRet =
+      decltype(std::declval<SkFontStyleSet>().createTypeface(0));
+  CreateTypefaceRet createTypeface(int index) override;
 
   // |SkFontStyleSet|
-  SkTypeface* matchStyle(const SkFontStyle& pattern) override;
+  using MatchStyleRet = decltype(std::declval<SkFontStyleSet>().matchStyle(
+      std::declval<SkFontStyle>()));
+  MatchStyleRet matchStyle(const SkFontStyle& pattern) override;
 
  private:
   std::shared_ptr<AssetManager> asset_manager_;

--- a/third_party/txt/src/txt/asset_font_manager.cc
+++ b/third_party/txt/src/txt/asset_font_manager.cc
@@ -40,20 +40,21 @@ void AssetFontManager::onGetFamilyName(int index, SkString* familyName) const {
   familyName->set(font_provider_->GetFamilyName(index).c_str());
 }
 
-SkFontStyleSet* AssetFontManager::onCreateStyleSet(int index) const {
+auto AssetFontManager::onCreateStyleSet(int index) const
+    -> OnCreateStyleSetRet {
   FML_DCHECK(false);
   return nullptr;
 }
 
-SkFontStyleSet* AssetFontManager::onMatchFamily(
-    const char family_name_string[]) const {
+auto AssetFontManager::onMatchFamily(const char family_name_string[]) const
+    -> OnMatchFamilyRet {
   std::string family_name(family_name_string);
-  return font_provider_->MatchFamily(family_name);
+  return OnMatchFamilyRet(font_provider_->MatchFamily(family_name));
 }
 
-SkTypeface* AssetFontManager::onMatchFamilyStyle(
-    const char familyName[],
-    const SkFontStyle& style) const {
+auto AssetFontManager::onMatchFamilyStyle(const char familyName[],
+                                          const SkFontStyle& style) const
+    -> OnMatchFamilyStyleRet {
   SkFontStyleSet* font_style_set =
       font_provider_->MatchFamily(std::string(familyName));
   if (font_style_set == nullptr)
@@ -61,12 +62,12 @@ SkTypeface* AssetFontManager::onMatchFamilyStyle(
   return font_style_set->matchStyle(style);
 }
 
-SkTypeface* AssetFontManager::onMatchFamilyStyleCharacter(
-    const char familyName[],
-    const SkFontStyle&,
-    const char* bcp47[],
-    int bcp47Count,
-    SkUnichar character) const {
+auto AssetFontManager::onMatchFamilyStyleCharacter(const char familyName[],
+                                                   const SkFontStyle&,
+                                                   const char* bcp47[],
+                                                   int bcp47Count,
+                                                   SkUnichar character) const
+    -> OnMatchFamilyStyleCharacterRet {
   return nullptr;
 }
 

--- a/third_party/txt/src/txt/asset_font_manager.h
+++ b/third_party/txt/src/txt/asset_font_manager.h
@@ -18,6 +18,7 @@
 #define TXT_ASSET_FONT_MANAGER_H_
 
 #include <memory>
+#include <utility>
 
 #include "flutter/fml/macros.h"
 #include "third_party/skia/include/core/SkFontMgr.h"
@@ -35,7 +36,10 @@ class AssetFontManager : public SkFontMgr {
 
  protected:
   // |SkFontMgr|
-  SkFontStyleSet* onMatchFamily(const char familyName[]) const override;
+  using OnMatchFamilyRet =
+      decltype((std::declval<SkFontMgr>().*
+                (&AssetFontManager::onMatchFamily))(std::declval<char[]>()));
+  OnMatchFamilyRet onMatchFamily(const char familyName[]) const override;
 
   std::unique_ptr<FontAssetProvider> font_provider_;
 
@@ -47,18 +51,33 @@ class AssetFontManager : public SkFontMgr {
   void onGetFamilyName(int index, SkString* familyName) const override;
 
   // |SkFontMgr|
-  SkFontStyleSet* onCreateStyleSet(int index) const override;
+  using OnCreateStyleSetRet = decltype((
+      std::declval<SkFontMgr>().*(&AssetFontManager::onCreateStyleSet))(0));
+  OnCreateStyleSetRet onCreateStyleSet(int index) const override;
 
   // |SkFontMgr|
-  SkTypeface* onMatchFamilyStyle(const char familyName[],
-                                 const SkFontStyle&) const override;
+  using OnMatchFamilyStyleRet = decltype((
+      std::declval<SkFontMgr>().*(&AssetFontManager::onMatchFamilyStyle))(
+      std::declval<char[]>(),
+      std::declval<SkFontStyle>()));
+  OnMatchFamilyStyleRet onMatchFamilyStyle(const char familyName[],
+                                           const SkFontStyle&) const override;
 
   // |SkFontMgr|
-  SkTypeface* onMatchFamilyStyleCharacter(const char familyName[],
-                                          const SkFontStyle&,
-                                          const char* bcp47[],
-                                          int bcp47Count,
-                                          SkUnichar character) const override;
+  using OnMatchFamilyStyleCharacterRet =
+      decltype((std::declval<SkFontMgr>().*
+                (&AssetFontManager::onMatchFamilyStyleCharacter))(
+          std::declval<char[]>(),
+          std::declval<SkFontStyle>(),
+          std::declval<const char*[]>(),
+          0,
+          0));
+  OnMatchFamilyStyleCharacterRet onMatchFamilyStyleCharacter(
+      const char familyName[],
+      const SkFontStyle&,
+      const char* bcp47[],
+      int bcp47Count,
+      SkUnichar character) const override;
 
   // |SkFontMgr|
   sk_sp<SkTypeface> onMakeFromData(sk_sp<SkData>, int ttcIndex) const override;

--- a/third_party/txt/src/txt/test_font_manager.cc
+++ b/third_party/txt/src/txt/test_font_manager.cc
@@ -27,7 +27,8 @@ TestFontManager::TestFontManager(
 
 TestFontManager::~TestFontManager() = default;
 
-SkFontStyleSet* TestFontManager::onMatchFamily(const char family_name[]) const {
+auto TestFontManager::onMatchFamily(const char family_name[]) const
+    -> OnMatchFamilyRet {
   // Find the requested name in the list, if not found, default to the first
   // font family in the test font family list.
   std::string requested_name(family_name);

--- a/third_party/txt/src/txt/test_font_manager.h
+++ b/third_party/txt/src/txt/test_font_manager.h
@@ -40,7 +40,10 @@ class TestFontManager : public AssetFontManager {
  private:
   std::vector<std::string> test_font_family_names_;
 
-  SkFontStyleSet* onMatchFamily(const char family_name[]) const override;
+  using OnMatchFamilyRet =
+      decltype((std::declval<AssetFontManager>().*
+                (&TestFontManager::onMatchFamily))(std::declval<char[]>()));
+  OnMatchFamilyRet onMatchFamily(const char family_name[]) const override;
 
   FML_DISALLOW_COPY_AND_ASSIGN(TestFontManager);
 };

--- a/third_party/txt/src/txt/typeface_font_asset_provider.cc
+++ b/third_party/txt/src/txt/typeface_font_asset_provider.cc
@@ -104,15 +104,16 @@ void TypefaceFontStyleSet::getStyle(int index,
   }
 }
 
-SkTypeface* TypefaceFontStyleSet::createTypeface(int i) {
+auto TypefaceFontStyleSet::createTypeface(int i) -> CreateTypefaceRet {
   size_t index = i;
   if (index >= typefaces_.size()) {
     return nullptr;
   }
-  return SkRef(typefaces_[index].get());
+  return CreateTypefaceRet(SkRef(typefaces_[index].get()));
 }
 
-SkTypeface* TypefaceFontStyleSet::matchStyle(const SkFontStyle& pattern) {
+auto TypefaceFontStyleSet::matchStyle(const SkFontStyle& pattern)
+    -> MatchStyleRet {
   return matchStyleCSS3(pattern);
 }
 

--- a/third_party/txt/src/txt/typeface_font_asset_provider.h
+++ b/third_party/txt/src/txt/typeface_font_asset_provider.h
@@ -42,10 +42,14 @@ class TypefaceFontStyleSet : public SkFontStyleSet {
   void getStyle(int index, SkFontStyle* style, SkString* name) override;
 
   // |SkFontStyleSet|
-  SkTypeface* createTypeface(int index) override;
+  using CreateTypefaceRet =
+      decltype(std::declval<SkFontStyleSet>().createTypeface(0));
+  CreateTypefaceRet createTypeface(int index) override;
 
   // |SkFontStyleSet|
-  SkTypeface* matchStyle(const SkFontStyle& pattern) override;
+  using MatchStyleRet = decltype(std::declval<SkFontStyleSet>().matchStyle(
+      std::declval<SkFontStyle>()));
+  MatchStyleRet matchStyle(const SkFontStyle& pattern) override;
 
  private:
   std::vector<sk_sp<SkTypeface>> typefaces_;


### PR DESCRIPTION
Skia is changing `SkFontMgr` and `SkFontStyleSet` methods to consistently return `sk_sp<SkTypeface>` and `sk_sp<SkFontStyleSet>` instead of `SkTypeface*` and `SkFontStyleSet*`. The pointers returned always needed to be `SkSafeUnref`ed but with `sk_sp` this ownership is now explicit.

Flutter subclasses both `SkFontMgr` and `SkFontStyleSet` and overrides affected methods. Normally Skia would roll out this change behind a build flag which would first be set in Flutter (to hold out the change), Skia then rolled into Flutter, then the build flag removed from Flutter (along with updating the subclasses). However, this is made quite difficult and slow because of the need to also be compatible with Flutter in other repositories at the same time. Instead, this change updates the subclasses to infer the correct return types in a way that will work both with and without the Skia change. After the Skia change is landed and rolled into Flutter the subclasses will be re-simplified to match the new method signatures.

[0] https://skia-review.googlesource.com/c/skia/+/659856
